### PR TITLE
Issue 2211 reloaded

### DIFF
--- a/app/helpers/tags_helper.rb
+++ b/app/helpers/tags_helper.rb
@@ -13,6 +13,18 @@ module TagsHelper
     end
   end
 
+  def tag_works_links_list(tags)
+    tags = tags.uniq.compact
+    if !tags.blank? && tags.respond_to?(:collect)
+      last_tag = tags.pop
+      tag_list = tags.collect{|tag| "<li>" + link_to_tag_works(tag) + ", </li>"}.join
+      tag_list += content_tag(:li, link_to_tag_works(last_tag))
+      tag_list.html_safe
+    else
+      ""
+    end
+  end
+  
   def description(tag)
     tag.name + " (" + tag.class.name + ")"
   end
@@ -54,6 +66,10 @@ module TagsHelper
     link_to_tag_with_text(tag, tag.is_a?(Warning) ? warning_display_name(tag.name) : tag.name, options)
   end
 
+  def link_to_tag_works(tag, options = {})
+    link_to_tag_works_with_text(tag, tag.is_a?(Warning) ? warning_display_name(tag.name) : tag.name, options)
+  end
+  
   def link_to_tag_with_text(tag, link_text, options = {})
     link_to_with_tag_class(@collection ?
     {:controller => :tags, :action => :show, :id => tag, :collection_id => @collection} :
@@ -66,8 +82,7 @@ module TagsHelper
   end
 
   def link_to_tag_works_with_text(tag, link_text, options = {})
-    link_to_with_tag_class(@collection ?
-    {:controller => :works, :action => :index, :tag_id => tag, :collection_id => @collection, :only_path => false} :
+    link_to_with_tag_class(@collection ? collection_tag_works_url(@collection, tag) :
     {:controller => :works, :action => :index, :tag_id => tag}, link_text, options)
   end
 

--- a/app/views/challenge/gift_exchange/_challenge_requests_signups_summary.html.erb
+++ b/app/views/challenge/gift_exchange/_challenge_requests_signups_summary.html.erb
@@ -55,13 +55,13 @@
           <td>
             <% any_types = TagSet::TAG_TYPES.select {|type| prompt && prompt.send("any_#{type}")} %>
             <%= !prompt || !prompt.tag_set ? "" : 
-                  content_tag(:ul, tag_link_list(prompt.tag_set.tags) + 
+                  content_tag(:ul, tag_works_links_list(prompt.tag_set.tags) + 
                                     any_types.map {|type| content_tag(:li, h(ts("Any %{type}", :type => type.capitalize))) }.join("\n").html_safe) %>
           </td>
           <% if eval("show_#{prompt_type}_optional_tags") %>
             <td>
               <% if prompt && prompt.optional_tag_set && !prompt.optional_tag_set.tags.empty? %>
-                <%= content_tag(:ul, tag_link_list(prompt.optional_tag_set.tags)) %>
+                <%= content_tag(:ul, tag_works_links_list(prompt.optional_tag_set.tags)) %>
               <% end %>
             </td>
           <% end %>

--- a/app/views/challenge/gift_exchange/_challenge_signups.html.erb
+++ b/app/views/challenge/gift_exchange/_challenge_signups.html.erb
@@ -76,13 +76,13 @@
           <td>
             <% any_types = TagSet::TAG_TYPES.select {|type| prompt && prompt.send("any_#{type}")} %>
             <%= !prompt || !prompt.tag_set ? "" : 
-                  content_tag(:ul, tag_link_list(prompt.tag_set.tags) + 
+                  content_tag(:ul, tag_works_links_list(prompt.tag_set.tags) + 
                                     any_types.map {|type| content_tag(:li, h(ts("Any %{type}", :type => type.capitalize))) }.join("\n").html_safe) %>
           </td>
           <% if eval("show_#{prompt_type}_optional_tags") %>
             <td>
               <% if prompt && prompt.optional_tag_set && !prompt.optional_tag_set.tags.empty? %>
-                <%= content_tag(:ul, tag_link_list(prompt.optional_tag_set.tags)) %>
+                <%= content_tag(:ul, tag_works_links_list(prompt.optional_tag_set.tags)) %>
               <% end %>
             </td>
           <% end %>

--- a/app/views/challenge_requests/index.html.erb
+++ b/app/views/challenge_requests/index.html.erb
@@ -35,13 +35,13 @@
           <td>
             <% any_types = TagSet::TAG_TYPES.select {|type| prompt && prompt.send("any_#{type}")} %>
             <%= !prompt || !prompt.tag_set ? "" : 
-                  content_tag(:ul, tag_link_list(prompt.tag_set.tags) + 
+                  content_tag(:ul, tag_works_links_list(prompt.tag_set.tags) + 
                                     any_types.map {|type| content_tag(:li, h(ts("Any %{type}", :type => type.capitalize))) }.join("\n").html_safe) %>
           </td>
           <% if @challenge.request_restriction.optional_tags_allowed %>
             <td>
               <% if prompt && prompt.optional_tag_set && !prompt.optional_tag_set.tags.empty? %>
-                <%= content_tag(:ul, tag_link_list(prompt.optional_tag_set.tags)) %>
+                <%= content_tag(:ul, tag_works_links_list(prompt.optional_tag_set.tags)) %>
               <% end %>
             </td>
           <% end %>

--- a/app/views/challenge_signups/_show_prompt.html.erb
+++ b/app/views/challenge_signups/_show_prompt.html.erb
@@ -6,15 +6,15 @@
       <dt>Tags:</dt>
       <dd>
         <ul class="tags">
-          <%= prompt.tag_set && !prompt.tag_set.tags.empty? ? tag_link_list(prompt.tag_set.tags) + (any_types.empty? ? "" : ", ") : "" %>
+          <%= prompt.tag_set && !prompt.tag_set.tags.empty? ? tag_works_links_list(prompt.tag_set.tags) + (any_types.empty? ? "" : ", ") : "" %>
           <% unless any_types.empty? %>
-            <%= any_types.map {|type| content_tag(:li, h(ts("Any %{type}", :type => type.capitalize))) }.join(", ").html_safe %>
+            <%= any_types.map {|type| content_tag(:li, ts("Any %{type}", :type => type.capitalize)) }.join(", ").html_safe %>
           <% end %>
         </ul>
         <% if prompt.optional_tag_set && !prompt.optional_tag_set.tags.empty? %>
           <p>Optional:</p>
           <ul class="tags">
-            <%= tag_link_list(prompt.optional_tag_set.tags) %>
+            <%= tag_works_links_list(prompt.optional_tag_set.tags) %>
           </ul>
         <% end %>
       </dd>

--- a/features/challenge_giftexchange.feature
+++ b/features/challenge_giftexchange.feature
@@ -7,12 +7,12 @@ Feature: Gift Exchange Challenge
   Scenario: Create a gift exchange, sign up for it
 
   Given the following activated users exist
-    | login          | password    |
-    | mod1           | something   |
-    | myname1        | something   |
-    | myname2        | something   |
-    | myname3        | something   |
-    | myname4        | something   |
+    | login          | password    | email      |
+    | mod1           | something   | mod@e.org  |
+    | myname1        | something   | my1@e.org  |
+    | myname2        | something   | my2@e.org  |
+    | myname3        | something   | my3@e.org  |
+    | myname4        | something   | my4@e.org  |
     And I have no tags
     And I create the fandom "Stargate Atlantis" with id 27
     And I create the fandom "Stargate SG-1" with id 28
@@ -64,6 +64,7 @@ Feature: Gift Exchange Challenge
     And I fill in "gift_exchange_offer_restriction_attributes_fandom_num_required" with "1"
     And I fill in "gift_exchange_offer_restriction_attributes_fandom_num_allowed" with "1"
     And I fill in "gift_exchange_offer_restriction_attributes_freeform_num_allowed" with "2"
+    And I select "1" from "gift_exchange_potential_match_settings_attributes_num_required_fandoms"
     And I check "Signup open?"
     And I press "Submit"
     And "issue 1859" is fixed
@@ -198,5 +199,19 @@ Feature: Gift Exchange Challenge
     And I wait 3 seconds
   When I reload the page
   Then I should see "Main Assignments"
-  When I follow "Send Assignments"
+  When all emails have been delivered
+    And I follow "Send Assignments"
   Then I should see "Assignments are now being sent out"
+  Given the system processes jobs
+    And I wait 3 seconds
+  When I reload the page
+  Then I should not see "Assignments are now being sent out"
+  # 4 users and the mod should get emails :)
+    And 1 email should be delivered to "mod@e.org"
+    And 1 email should be delivered to "my1@e.org"
+    And 1 email should be delivered to "my2@e.org"
+    And 1 email should be delivered to "my3@e.org"
+    And 1 email should be delivered to "my4@e.org"
+    And the email should link to "My Gift Exchanger" collection's url
+      And the email should link to myname1's user url
+      And the email should link to the works tagged "Stargate Atlantis" in collection "My Gift Exchanger"

--- a/features/support/paths.rb
+++ b/features/support/paths.rb
@@ -29,6 +29,8 @@ module NavigationHelpers
 
     when /^(.*)'s user page$/i
       user_path(:id => $1)
+    when /^(.*)'s user url$/i
+      user_url(:id => $1).sub("http://www.example.com", ArchiveConfig.APP_URL)
     when /^(.*)'s works page$/i
       user_works_path(:user_id => $1)
     when /^the "(.*)" work page/
@@ -63,9 +65,15 @@ module NavigationHelpers
       edit_skin_path(Skin.find_by_title($1))
     when /^"(.*)" collection's page$/i                      # e.g. when I go to "Collection name" collection's page
       collection_path(Collection.find_by_title($1))
+    when /^"(.*)" collection's url$/i                      # e.g. when I go to "Collection name" collection's url
+      collection_url(Collection.find_by_title($1)).sub("http://www.example.com", ArchiveConfig.APP_URL)
     when /^"(.*)" collection's static page$/i
       static_collection_path(Collection.find_by_title($1))
-
+    when /^the works tagged "(.*)" in collection "(.*)"$/i
+      collection_tag_works_path(Collection.find_by_title($2), Tag.find_by_name($1))
+    when /^the url for works tagged "(.*)" in collection "(.*)"$/i
+      collection_tag_works_url(Collection.find_by_title($2), Tag.find_by_name($1)).sub("http://www.example.com", ArchiveConfig.APP_URL)
+      
     # Here is an example that pulls values out of the Regexp:
     #
     #   when /^(.*)'s profile page$/i


### PR DESCRIPTION
Modifies the links to use for lists of tags in the context of signups for a collection: lists of links to the works with that tag in the collection, which I assume was always the intended use but was defective.

Gcode issues:
http://code.google.com/p/otwarchive/issues/detail?id=2211
http://code.google.com/p/otwarchive/issues/detail?id=2220
