### PR TITLE
Issue 2210

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -60,5 +60,6 @@ Otwarchive::Application.configure do
 #  end
 
   ThinkingSphinx.remote_sphinx = true
+  ThinkingSphinx.updates_enabled = false
 
 end

--- a/features/step_definitions/search.rb
+++ b/features/step_definitions/search.rb
@@ -1,5 +1,0 @@
-Given /^the (\w+) indexes are updated$/ do |model|
-  model = model.titleize.gsub(/\s/, '').constantize
-  ThinkingSphinx::Test.index *model.sphinx_index_names
-  sleep(0.5) # Wait for Sphinx to catch up
-end

--- a/features/step_definitions/search_steps.rb
+++ b/features/step_definitions/search_steps.rb
@@ -1,0 +1,17 @@
+Given /^the (\w+) indexes are updated$/ do |model|
+  model = model.titleize.gsub(/\s/, '').constantize
+  ThinkingSphinx::Test.index *model.sphinx_index_names
+  sleep(0.5) # Wait for Sphinx to catch up
+end
+
+Given /^remote sphinx is stopped$/ do
+  # set up thinking sphinx the same as in production
+  ThinkingSphinx.remote_sphinx = true
+  ThinkingSphinx.updates_enabled = false
+  # and stop it
+  ThinkingSphinx::Configuration.instance.controller.stop
+end
+
+Given /^sphinx is started again$/ do
+  ThinkingSphinx::Configuration.instance.controller.start
+end

--- a/features/work_create.feature
+++ b/features/work_create.feature
@@ -280,3 +280,21 @@ Feature: Create Works
       And I should see "Bad things happen, etc."
       And I should see "4 > 3 and 2 < 5" within "h2.title"
 
+  Scenario: Creating a new work when sphinx is down
+    Given remote sphinx is stopped
+      And basic tags
+      And I am logged in as "newbie" with password "password"
+    When I go to the new work page
+    Then I should see "Post New Work"
+      And I select "Not Rated" from "Rating"
+      And I check "No Archive Warnings Apply"
+      And I fill in "Fandoms" with "Supernatural"
+      And I fill in "Work Title" with "All Hell Breaks Loose"
+      And I fill in "content" with "Bad things happen, etc."
+    When I press "Preview"
+    Then I should see "Preview Work"
+    When I press "Post"
+    Then I should see "Work was successfully posted."
+    When I go to the works page
+    Then I should see "All Hell Breaks Loose"
+    And sphinx is started again


### PR DESCRIPTION
fix posting a work when remote sphinx is down (actually, any change to any record). http://code.google.com/p/otwarchive/issues/detail?id=2210

as we don't have deltas enabled for any of our sphinx indexes, sphinx shouldn't be updating the deltas when records are updated.
