### PR TITLE
Issue 2254 - importing fails when source contains the NUL character

### DIFF
--- a/app/models/story_parser.rb
+++ b/app/models/story_parser.rb
@@ -401,6 +401,9 @@ class StoryParser
         story = eval("download_from_#{source.downcase}(location)")
       end
 
+      # clean up any erroneously included string terminator (Issue 785)
+      story = story.gsub("\000", "")
+      
       #story = fix_bad_characters(story)
       # ^ This eats ALL special characters. I don't think we need it at all
       # so I'm taking it out. If we want it back, it should be the last

--- a/features/cassette_library/cucumber_tags/work_import_nul_character.yml
+++ b/features/cassette_library/cucumber_tags/work_import_nul_character.yml
@@ -1,0 +1,38 @@
+--- 
+- !ruby/struct:VCR::HTTPInteraction 
+  request: !ruby/struct:VCR::Request 
+    method: :get
+    uri: http://www.the-archive.net:80/viewstory.php?sid=1910
+    body: 
+    headers: 
+  response: !ruby/struct:VCR::Response 
+    status: !ruby/struct:VCR::ResponseStatus 
+      code: 200
+      message: OK
+    headers: 
+      date: 
+      - Mon, 28 Mar 2011 23:09:18 GMT
+      server: 
+      - Apache/2.0.63 (Unix) mod_ssl/2.0.63 OpenSSL/0.9.8e-fips-rhel5 mod_auth_passthrough/2.1 mod_bwlimited/1.4 FrontPage/5.0.2.2635
+      x-powered-by: 
+      - PHP/5.2.9
+      cache-control: 
+      - no-cache, must-revalidate, max_age=0, post-check=0, pre-check=0
+      pragma: 
+      - no-cache
+      expires: 
+      - "0"
+      set-cookie: 
+      - PHPSESSID=b034cdf4bd9a694f3fced0a678395b5c; path=/
+      transfer-encoding: 
+      - chunked
+      content-type: 
+      - text/html
+    body: "<html>\n\
+      <head>\n\n<title>I'm Batman</title>\n\
+      </head>\n\n\
+      <body vlink='#545454'>\0\n\
+      <p>When I get out of here</p>\n\n\
+      </body>\n\
+      </html>\n"
+    http_version: "1.1"

--- a/features/support/vcr.rb
+++ b/features/support/vcr.rb
@@ -23,6 +23,7 @@ VCR.cucumber_tags do |t|
   t.tags '@work_import_special_characters_man_latin', :record => :all
   t.tags '@work_import_special_characters_man_cp', :record => :all
   t.tags '@work_import_special_characters_man_utf'
+  t.tags '@work_import_nul_character'
 
   t.tags '@import_da'
   t.tags '@import_da_fic'

--- a/features/work_import.feature
+++ b/features/work_import.feature
@@ -143,3 +143,12 @@ Feature: Import Works
       And I should see "Das Maß aller Dinge" within "h2.title"
       And I should see "Ä Ö Ü é è È É ü ö ä ß ñ"
 
+  @work_import_nul_character
+  Scenario: Import a work with the illegal 00 character (string terminator)
+    Given basic tags
+      And I am logged in as a random user
+    When I go to the import page
+      And I fill in "urls" with "http://www.the-archive.net/viewstory.php?sid=1910"
+    When I press "Import"
+    Then I should see "Preview Work"
+      And I should see "When I get out of here"


### PR DESCRIPTION
http://code.google.com/p/otwarchive/issues/detail?id=2254

A word of warning: vcr "recorded" the source as binary, because of the NUL character, thus the generated "cassette" was useless for our purposes. I edited it manually and the test failed, and then applied the fix and the test passed. If you run vcr in recording mode again, it will overwrite the cassette and the test will fail.

The error only seems to happen when the NUL appears right after the <body> tag, which is a very specific case, but, alas, the whole of the-archive.net suffers from it.
