### PR TITLE
Monkeypatching rails to always accept at least HTML.

### DIFF
--- a/config/initializers/monkeypatches/accept_header.rb
+++ b/config/initializers/monkeypatches/accept_header.rb
@@ -1,0 +1,24 @@
+# https://rails.lighthouseapp.com/projects/8994/tickets/6022-content-negotiation-fails-for-some-headers-regression#ticket-6022-13
+# https://rails.lighthouseapp.com/projects/8994/tickets/5833
+# specific reason: user agent "Mozilla/4.0 (PSP (PlayStation Portable); 2.00)" sets http accept header to "*/*;q=0.01" and rails gives it a 500
+
+module ActionDispatch
+  module Http
+    module MimeNegotiation
+
+      # Patched to always accept at least HTML
+      def accepts
+        @env["action_dispatch.request.accepts"] ||= begin
+          header = @env['HTTP_ACCEPT'].to_s.strip
+
+          if header.empty?
+            [content_mime_type]
+          else
+            Mime::Type.parse(header) << Mime::HTML
+          end
+        end
+      end
+
+    end
+  end
+end

--- a/features/accept_header.feature
+++ b/features/accept_header.feature
@@ -1,0 +1,10 @@
+Feature: Browsing from a non-standard user agent
+As a Playstation user
+In order to browse the AO3
+I want to be able to browse from my PSP
+
+Scenario: user agent requests a weird header
+
+  Given I use a PSP browser
+  When I make a request for "/works"
+  Then the response should be "200"

--- a/features/step_definitions/request_header_steps.rb
+++ b/features/step_definitions/request_header_steps.rb
@@ -1,0 +1,14 @@
+World(Rack::Test::Methods)
+# thanks to these guys: http://www.anthonyeden.com/2010/11/testing-rest-apis-with-cucumber-and-rack-test/
+
+Given /^I use a PSP browser$/ do
+  header 'Accept', '*/*;q=0.01'
+end
+
+Given /^I make a request for "([^\"]*)"$/ do |path|
+  get path
+end
+
+Then /^the response should be "([^\"]*)"$/ do |status|
+  last_response.status.should == status.to_i
+end


### PR DESCRIPTION
Fixes http://code.google.com/p/otwarchive/issues/detail?id=2268

See https://rails.lighthouseapp.com/projects/8994/tickets/6022-content-negotiation-fails-for-some-headers-regression#ticket-6022-13 for details and the source of the monkeypatch.

Includes cuke.
