### PR TITLE
Issue 2150: errors when synning tags

### DIFF
--- a/app/helpers/tags_helper.rb
+++ b/app/helpers/tags_helper.rb
@@ -161,8 +161,8 @@ module TagsHelper
     if tag
       span = tag.canonical? ? "<span class='canonical'>" : "<span>"
       span += tag.type + ": " + link_to_tag(tag) + " (#{tag.taggings_count})</span>"
+      span.html_safe
     end
-    span.html_safe
   end
 
   def tag_comment_link(tag)

--- a/app/models/common_tagging.rb
+++ b/app/models/common_tagging.rb
@@ -18,7 +18,7 @@ class CommonTagging < ActiveRecord::Base
   def inherit_parents
     if common_tag.is_a?(Relationship) && filterable.is_a?(Character)
       filterable.fandoms.each do |fandom|
-        common_tag.parents << fandom unless common_tag.parents.include?(fandom)
+        common_tag.add_association(fandom)
       end
     end
   end

--- a/app/models/fandom.rb
+++ b/app/models/fandom.rb
@@ -41,7 +41,7 @@ class Fandom < Tag
     end
   end
   
-  # Types of tags to which a character tag can belong via common taggings or meta taggings
+  # Types of tags to which a fandom tag can belong via common taggings or meta taggings
   def parent_types
     ['Media', 'MetaTag']
   end

--- a/app/models/freeform.rb
+++ b/app/models/freeform.rb
@@ -2,7 +2,7 @@ class Freeform < Tag
 
   NAME = ArchiveConfig.FREEFORM_CATEGORY_NAME
 
-  # Types of tags to which a character tag can belong via common taggings or meta taggings
+  # Types of tags to which a freeform tag can belong via common taggings or meta taggings
   def parent_types
     ['Fandom', 'MetaTag']
   end

--- a/app/models/relationship.rb
+++ b/app/models/relationship.rb
@@ -2,7 +2,7 @@ class Relationship < Tag
 
   NAME = ArchiveConfig.RELATIONSHIP_CATEGORY_NAME
   
-  # Types of tags to which a character tag can belong via common taggings or meta taggings
+  # Types of tags to which a relationship tag can belong via common taggings or meta taggings
   def parent_types
     ['Fandom', 'Character', 'MetaTag']
   end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -532,9 +532,17 @@ class Tag < ActiveRecord::Base
   # Add a common tagging association
   # Offloading most of the logic to the inherited tag models
   def add_association(tag)
-    self.parents << tag unless self.parents.include?(tag)
+    self.parents << tag unless self.has_parent?(tag)
   end
 
+  def has_parent?(tag)
+    self.common_taggings.where(:filterable_id => tag.id).count > 0
+  end
+  
+  def has_child?(tag)
+    self.child_taggings.where(:common_tag_id => tag.id).count > 0
+  end
+  
   # Determine how two tags are related and divorce them from each other
   def remove_association(tag)
     if tag.class == self.class


### PR DESCRIPTION
self.parents isn't always up to date when checking if a tag already has another tag as parent; checking for common_taggings instead.

There were also erroneous code comments, and an occasionally unassigned variable in tags_helper.

http://code.google.com/p/otwarchive/issues/detail?id=2150

Note 1: I didn't change _all_ checks for self.parents.include, only those directly related to this bug.

Note 2: This issue is not properly tested in cucumber - the test was passing even when the live code was failing.
