### PR TITLE
Issue 2275: admins weren't being notified of replies to admin posts

### DIFF
--- a/app/mailers/admin_mailer.rb
+++ b/app/mailers/admin_mailer.rb
@@ -39,5 +39,25 @@ class AdminMailer < ActionMailer::Base
       :subject  => "#{ArchiveConfig.APP_NAME}" + " - " + "Admin Archive Notification Sent"
     )
   end
+  
+  # Sends email to an admin when a new comment is created on an admin post
+  def comment_notification(admin_id, comment_id)
+    admin = Admin.find(admin_id)
+    @comment = Comment.find(comment_id)
+    mail(
+      :to => admin.email,
+      :subject => "[#{ArchiveConfig.APP_NAME}] Comment on " + (@comment.ultimate_parent.is_a?(Tag) ? "the tag " : "") + @comment.ultimate_parent.commentable_name
+    )
+  end
+
+  # Sends email to an admin when a comment on an admin post is edited
+  def edited_comment_notification(admin_id, comment_id)
+    admin = Admin.find(admin_id)
+    @comment = Comment.find(comment_id)
+    mail(
+      :to => admin.email,
+      :subject => "[#{ArchiveConfig.APP_NAME}] Edited comment on " + (@comment.ultimate_parent.is_a?(Tag) ? "the tag " : "") + @comment.ultimate_parent.commentable_name
+    )
+  end
 
 end

--- a/features/admin_tasks.feature
+++ b/features/admin_tasks.feature
@@ -251,3 +251,52 @@ Feature: Admin tasks
     And I follow "Read Comments"
     And "Issue 2213" is fixed
   # Then I should not see "rolex"
+
+  Scenario: make an admin post and receive comment notifications for comments posted to it
+  
+  # admin makes post
+  Given I am logged in as an admin
+    And I make an admin post
+    
+  # regular user replies to admin post
+  When I am logged out as an admin
+    And I am logged in as a random user
+    And I go to the admin-posts page
+  Given all emails have been delivered    
+  When I follow "Add Comment"
+    And I fill in "Comment" with "Excellent, my dear!"
+    And I press "Add Comment"
+  Then 1 email should be delivered to "testadmin@example.org"
+
+  # admin replies to comment of regular user
+  Given I am logged out
+    And I am logged in as an admin
+    And I go to the admin-posts page
+    And I follow "Default Admin Post"
+  Given all emails have been delivered    
+  When I follow "Read Comments (1)"
+    And I follow "Reply"
+    And I fill in "Comment" with "Thank you very much!" within ".odd"
+    And I press "Add Comment" within ".odd"
+  Then I should see "Comment created"
+  # admin gets notified of their own comment, this is not a bug unless:
+  # TODO: comments should be able to belong to an admin officially, otherwise someone can spoof being an admin by using the admin name and email
+    And 1 email should be delivered to "testadmin@example.org"
+  
+  # regular user replies to comment of admin
+  Given I am logged out as an admin
+    And I am logged in as a random user
+    And I go to the admin-posts page
+  Given all emails have been delivered    
+  When I follow "Read 2 Comments"
+    And I follow "Reply" within ".even"
+    And I fill in "Comment" with "Oh, don't grow too big a head, you." within ".even"
+    And I press "Add Comment" within ".even"
+  # admin gets the user's reply twice, this is not a bug unless TODO above is fixed
+  Then 2 emails should be delivered to "testadmin@example.org"
+  
+  # regular user edits their comment
+  Given all emails have been delivered    
+  When I follow "Edit"
+    And I press "Update"
+  Then 2 emails should be delivered to "testadmin@example.org"

--- a/features/step_definitions/admin_steps.rb
+++ b/features/step_definitions/admin_steps.rb
@@ -27,7 +27,7 @@ end
 Given /^I am logged in as an admin$/ do
   admin = Admin.find_by_login("testadmin")
   if admin.blank?
-    admin = Factory.create(:admin, :login => "testadmin", :password => "testadmin")
+    admin = Factory.create(:admin, :login => "testadmin", :password => "testadmin", :email => "testadmin@example.org")
   end
   visit admin_login_path
   fill_in "Admin user name", :with => "testadmin"
@@ -80,3 +80,10 @@ Given /^tag wrangling is on$/ do
   And "I am logged out as an admin"
 end
 
+When /^I make an admin post$/ do
+  visit new_admin_post_path
+  fill_in("Title", :with => "Default Admin Post")
+  fill_in("content", :with => "Content of the admin post.")
+  click_button("Post")
+  Then %{I should see "AdminPost was successfully created."}
+end

--- a/features/support/paths.rb
+++ b/features/support/paths.rb
@@ -77,6 +77,8 @@ module NavigationHelpers
       collection_tag_works_path(Collection.find_by_title($2), Tag.find_by_name($1))
     when /^the url for works tagged "(.*)" in collection "(.*)"$/i
       collection_tag_works_url(Collection.find_by_title($2), Tag.find_by_name($1)).sub("http://www.example.com", ArchiveConfig.APP_URL)
+    when /^the admin-posts page$/i
+      admin_posts_path
       
     # Here is an example that pulls values out of the Regexp:
     #


### PR DESCRIPTION
What's more, the user with the same id as the admin id was being notified instead. Oops!

This fixes the bare minimum (plus tests); there could be more improvements to the interaction of admins with the site, but they need to go through AD&T first.

http://code.google.com/p/otwarchive/issues/detail?id=2275
