### PR TITLE
Issue 2276: Search results in error if results contain nil values

### DIFF
--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -11,22 +11,23 @@ class PeopleController < ApplicationController
         errors, @people = Query.search_with_sphinx(Pseud, @query, page)
         flash.now[:error] = errors.join(" ") unless errors.blank?
       rescue Riddle::ConnectionError
-        flash.now[:error] = t('errors.search_engine_down', :default => "The search engine seems to be down at the moment, sorry!")
+        flash.now[:error] = ts("The search engine seems to be down at the moment, sorry!")
       end
-      @rec_counts = Pseud.rec_counts_for_pseuds(@people)
-      @work_counts = Pseud.work_counts_for_pseuds(@people)
+      # @people could contain nils from sphinx
+      @rec_counts = Pseud.rec_counts_for_pseuds(@people.compact)
+      @work_counts = Pseud.work_counts_for_pseuds(@people.compact)
     end
-  end  
+  end
 
-    
+
   def index
     if @collection
       @pseuds_alphabet = @collection.participants.find(:all, :select => 'name')
       @pseuds_alphabet = @pseuds_alphabet.collect {|pseud| pseud.name.scan(/./mu)[0].upcase}.uniq.sort
-      if params[:letter] && params[:letter].is_a?(String)		
-        letter = params[:letter][0,1]		
-      else		
-	letter = @pseuds_alphabet[0]		
+      if params[:letter] && params[:letter].is_a?(String)
+        letter = params[:letter][0,1]
+      else
+  letter = @pseuds_alphabet[0]
       end
       @authors = @collection.participants.alphabetical.starting_with(letter).paginate(:per_page => (params[:per_page] || ArchiveConfig.ITEMS_PER_PAGE), :page => (params[:page] || 1))
       @rec_counts = Pseud.rec_counts_for_pseuds(@authors)
@@ -34,9 +35,9 @@ class PeopleController < ApplicationController
     else
       @navigation = People.all
     end
-    
-  end 
- 
+
+  end
+
   def show
     @navigation = People.all
     @character = People.find(params[:id])

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -35,7 +35,7 @@ class TagsController < ApplicationController
         errors, @tags = Query.search_with_sphinx(Tag, @query, page)
         flash.now[:error] = errors.join(" ") unless errors.blank?
       rescue Riddle::ConnectionError
-        flash.now[:error] = t('errors.search_engine_down', :default => "The search engine seems to be down at the moment, sorry!")
+        flash.now[:error] = ts("The search engine seems to be down at the moment, sorry!")
       end
     end
   end

--- a/app/views/bookmarks/search.html.erb
+++ b/app/views/bookmarks/search.html.erb
@@ -1,7 +1,7 @@
 <h2>Bookmark Search: Beta</h2>
 
 <ul class="navigation" role="navigation"><li>
-  <%= link_to(t('.refine_search', :default => "Advanced search"), search_index_path(:query => @query)) %>
+  <%= link_to(ts("Advanced search"), search_index_path(:query => @query)) %>
 </li></ul>
 
 <%= render :partial => 'bookmarks/search_form' %>
@@ -11,7 +11,9 @@
   <h3 class="landmark">Bookmarks List</h3>
   <ol class="bookmark index">
     <% for bookmark in @bookmarks %>
-      <%= render :partial => 'bookmark', :locals => {:bookmark => bookmark} %>
+      <% unless bookmark.nil? %>
+        <%= render :partial => 'bookmark', :locals => {:bookmark => bookmark} %>
+      <% end %>
     <% end %>
   </ol>
   <%= will_paginate @bookmarks %>

--- a/app/views/people/search.html.erb
+++ b/app/views/people/search.html.erb
@@ -1,7 +1,7 @@
 <h2>People Search: Alpha</h2>
 
 <ul class="navigation" role="navigation"><li>
-  <%= link_to(t('.refine_search', :default => "Advanced search"), search_index_path(:query => @query)) %>
+  <%= link_to(ts("Advanced search"), search_index_path(:query => @query)) %>
 </li></ul>
 
 <%= render :partial => 'people/search_form' %>
@@ -11,7 +11,9 @@
   <h3 class="landmark">People List</h3>
   <ol class="pseud index">
     <% for person in @people %>
-      <%= render :partial => 'people/author_blurb', :locals => {:author => person} %>
+      <% unless person.nil? %>
+        <%= render :partial => 'people/author_blurb', :locals => {:author => person} %>
+      <% end %>
     <% end %>
   </ol>
   <%= will_paginate @tags %>

--- a/app/views/tags/search.html.erb
+++ b/app/views/tags/search.html.erb
@@ -7,7 +7,9 @@
   <h3 class="landmark">Tags List</h3>
   <ol class="tag index">
     <% for tag in @tags %>
-      <li><%= tag_search_result(tag) %></li>
+      <% unless tag.nil? %>
+        <li><%= tag_search_result(tag) %></li>
+      <% end %>
     <% end %>
   </ol>
   <%= will_paginate @tags %>

--- a/features/people_search.feature
+++ b/features/people_search.feature
@@ -1,4 +1,4 @@
-@no-txn
+@no-txn @search
 Feature: Search People
   In order to test search
   As a humble coder

--- a/features/tag_wrangling_characters.feature
+++ b/features/tag_wrangling_characters.feature
@@ -1,4 +1,4 @@
-@no-txn @tags @users @tag_wrangling
+@no-txn @tags @users @tag_wrangling @search
 
 Feature: Tag Wrangling - Characters
 

--- a/features/work_drafts.feature
+++ b/features/work_drafts.feature
@@ -1,4 +1,4 @@
-@works
+@works @search
 @no-txn
 Feature: Work Drafts
 

--- a/features/work_lock.feature
+++ b/features/work_lock.feature
@@ -1,4 +1,4 @@
-@works
+@works @search
 @no-txn
 
 Feature: Locking works to archive users only


### PR DESCRIPTION
Checking for nil everywhere we iterate through and display search results, or compacting the values for the cases where the search results structure could be turned into an array.

Have considered the retry_stale option on sphinx, but it seemed like an unnecessary performance load since we reindex often enough anyway. Nil results could still sneak in, and we'd rather didn't give errors to the user if it can be avoided.

http://code.google.com/p/otwarchive/issues/detail?id=2276
