### PR TITLE
Issue 2270: Trying to use an already redeemed invitation gives error 500

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -26,7 +26,7 @@ class UsersController < ApplicationController
       if !invitation
         flash[:error] = ts("There was an error with your invitation token, please contact support")
         redirect_to new_feedback_report_path and return
-      elsif invitation.redeemed_at && @invitation.invitee
+      elsif invitation.redeemed_at && invitation.invitee
         flash[:error] = ts("This invitation has already been used to create an account, sorry!")
         redirect_to root_path and return
       end

--- a/features/invite_use.feature
+++ b/features/invite_use.feature
@@ -1,0 +1,16 @@
+Feature: invitations
+In order to join the archive
+As an unregistered user
+I want to use an invitation to create an account
+
+  Scenario: user attempts to use an invitation
+  
+  Given I am a visitor
+  When I use an invitation to sign up
+  Then I should see "Create Account"
+  
+  Scenario: user attempts to use an already redeemed invitation
+  
+  Given I am a visitor
+  When I use an already used invitation to sign up
+  Then I should see "This invitation has already been used to create an account"

--- a/features/step_definitions/invite_steps.rb
+++ b/features/step_definitions/invite_steps.rb
@@ -1,0 +1,29 @@
+Given /^an invitation(?: for "([^\"]+)") exists$/ do |invitee_email|
+  invite = Invitation.new
+  invite.invitee_email = (invitee_email ? invitee_email : "default@example.org")
+  invite.save
+end
+
+def invite(attributes = {})
+  @invite ||= Invitation.new
+  @invite.invitee_email = "default@example.org"
+  @invite.save  
+  @invite
+end
+
+When /^I use an invitation to sign up$/ do
+  visit signup_path(invite.token)
+end
+
+When /^I use an already used invitation to sign up$/ do
+  steps %Q{
+    Given the following activated user exists
+      | login    | password |
+      | invited  | password |
+  }
+  user = User.find_by_login("invited")
+  invite.redeemed_at = Time.now
+  invite.mark_as_redeemed(user)
+  invite.save
+  visit signup_path(invite.token)
+end

--- a/features/step_definitions/user_steps.rb
+++ b/features/step_definitions/user_steps.rb
@@ -86,3 +86,7 @@ Given /^"([^\"]*)" deletes their account/ do |username|
   Given %{I follow "Profile"}
   Given %{I follow "Delete My Account"}
 end
+
+Given /^I am a visitor$/ do
+  Given %{I am logged out}
+end


### PR DESCRIPTION
http://code.google.com/p/otwarchive/issues/detail?id=2270

The actual fix was one character - writing the tests has been the real fun.

Feel free to suggest improvements to the tests. I know the "visitor" step doubles the "I am logged out" step, but it reads better to me from the POV of the actor in the scenario - the unregistered user. "I am logged out" implies I was logged in, "visitor" defines someone who doesn't have a login yet.
