### PR TITLE
issue 2283.

### DIFF
--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -33,7 +33,7 @@ module UsersHelper
   
   def standard_icon_display(user, pseud=nil)
     pseud ||= user.default_pseud
-    image_tag(standard_icon(user, pseud), :alt => (pseud.icon_file_name ? pseud.icon_alt_text : "Archive of Our Own default icon: the AO3 logo in grey, on a white background"), :class => "icon")
+    image_tag(standard_icon(user, pseud), :alt => (pseud.try(:icon_file_name) ? pseud.icon_alt_text : "Archive of Our Own default icon: the AO3 logo in grey, on a white background"), :class => "icon")
   end
   
   def icon_display(user, pseud=nil)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -199,10 +199,9 @@ class User < ActiveRecord::Base
     password
   end
 
+  # use update_all to force the update even if the user is invalid
   def reset_user_password
-    self.activation_code = generate_password(20)
-    self.recently_reset = true
-    self.save
+    User.update_all("activation_code = '#{generate_password(20)}', recently_reset = 1", "id = #{self.id}")
   end
 
   def activate

--- a/features/authenticate_users.feature
+++ b/features/authenticate_users.feature
@@ -65,6 +65,36 @@ Feature: User Authentication
     And I press "Log in"
     Then I should see "Hi, sam!"
 
+  Scenario: invalid user
+    Given I have loaded the "users" fixture
+    When I am on the home page
+    And I follow "forgot password?"
+    When I fill in "login" with "testuser"
+      And I press "Reset password"
+    Then I should see "Check your email"
+      And 1 email should be delivered
+
+    # password from email should work
+    When I fill in "User name" with "testuser"
+    And I fill in "testuser"'s temporary password
+    And I press "Log in"
+    Then I should see "Hi, testuser!"
+    And I should see "Change My Password"
+
+    # and I should be able to change the password
+    When I fill in "New Password" with "newpas"
+    And I fill in "Confirm New Password" with "newpas"
+    And I press "Change Password"
+    Then I should see "Your password has been changed"
+
+    # new password should work
+    When I am logged out
+    When I am on the homepage
+    And I fill in "User name" with "testuser"
+    And I fill in "Password" with "newpas"
+    And I press "Log in"
+    Then I should see "Hi, testuser!"
+
   Scenario: Wrong username
     Given I have no users
       And the following activated user exists


### PR DESCRIPTION
issue 2283. update the user object during a password reset even if the user is otherwise invalid.

http://code.google.com/p/otwarchive/issues/detail?id=2283
