### PR TITLE
Issue 2284: Error 500 on saving bookmarks with excess of commas in the ta

### DIFF
--- a/app/models/bookmark.rb
+++ b/app/models/bookmark.rb
@@ -117,11 +117,13 @@ class Bookmark < ActiveRecord::Base
     self.tags = []
     tag_string.split(ArchiveConfig.DELIMITER_FOR_INPUT).each do |string|
       string.squish!
-      tag = Tag.find_by_name(string)
-      if tag
-        self.tags << tag
-      else
-        self.tags << Freeform.create(:name => string)
+      if !string.blank?
+        tag = Tag.find_by_name(string)
+        if tag
+          self.tags << tag
+        else
+          self.tags << Freeform.create(:name => string) 
+        end
       end
     end
     return self.tags

--- a/features/bookmark_create.feature
+++ b/features/bookmark_create.feature
@@ -215,3 +215,11 @@ Feature: Create bookmarks
       But I should see "Public Masterpiece"
       And I should see "Publicky"
 
+Scenario: extra commas in bookmark form (Issue 2284)
+
+  Given I am logged in as "bookmarkuser" with password "password"
+    And I post the work "Some Work"
+  When I follow "Bookmark"
+    And I fill in "Your Tags" with "Good tag, ,, also good tag, "
+    And I press "Create"
+  Then I should see "created"


### PR DESCRIPTION
Issue 2284: Error 500 on saving bookmarks with excess of commas in the tags

Added check for blank string before trying to find or create the tag.

http://code.google.com/p/otwarchive/issues/detail?id=2284
