### PR TITLE
Issue 2271: Logging out from your own skins page results in error

### DIFF
--- a/app/controllers/skins_controller.rb
+++ b/app/controllers/skins_controller.rb
@@ -14,7 +14,7 @@ class SkinsController < ApplicationController
       @preference = current_user.preference
     end
     if params[:user_id] && @user = User.find_by_login(params[:user_id])
-      redirect_to new_session_path and return unless logged_in?
+      redirect_to new_user_session_path and return unless logged_in?
       if (@user != current_user)
         flash[:error] = "You can only browse your own skins and approved public skins." 
         redirect_to skins_path and return

--- a/features/skin.feature
+++ b/features/skin.feature
@@ -289,3 +289,9 @@ Feature: creating and editing skins
     And I should not see "Hide Creator's Style"
     And I should see "Show Creator's Style"
 
+  Scenario: Log out from my skins page (Issue 2271)
+  
+  Given I am logged in as "skinner" with password "password"
+  When I follow "My Skins"
+    And I follow "Log out"
+  Then I should be on the login page

--- a/features/support/paths.rb
+++ b/features/support/paths.rb
@@ -27,6 +27,8 @@ module NavigationHelpers
 
     # Add more mappings here.
 
+    when /^the login page$/i
+      new_user_session_path
     when /^(.*)'s user page$/i
       user_path(:id => $1)
     when /^(.*)'s user url$/i


### PR DESCRIPTION
Logging out from one's own skins page redirects to login page.

http://code.google.com/p/otwarchive/issues/detail?id=2271
