### PR TITLE
Issue 2290: small css fix for view most recent bookmarks

### DIFF
--- a/public/stylesheets/site-chrome.css
+++ b/public/stylesheets/site-chrome.css
@@ -161,6 +161,7 @@ NAVIGATION, ACTIONS (BUTTONS)*/
                  { position:static; display: inline; height: 25px; width: 25px; border:none; }
  .blurb ul.required-tags li  span.text { display:none }
  .blurb ul.required-tags li span{ display:block; background-repeat:no-repeat; height: 25px; width: 25px; }
+ .blurb ul.recent-bookmarks li { display: block; }
  .blurb .category, .blurb .iswip, .blurb .external-work
                  { position: absolute; left: 28px; }
  .blurb .category         { top: 0; }


### PR DESCRIPTION
Small css fix provided by Branch for stray bits of grey border hanging out in the "view most recent bookmarks" section of bookmarks.

http://code.google.com/p/otwarchive/issues/detail?id=2290
