### PR TITLE
Issue 2286: Empty query parameters cause errors

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -169,6 +169,11 @@ ANONYMOUS_THRESHOLD_COUNT: 10
 # SANITIZER VERSION
 SANITIZER_VERSION: 1
 
+# parameters that must be natural integers and their default values
+NONZERO_INTEGER_PARAMETERS:
+  page: 1
+  per_page: 25
+
 # These fields are query fields and are allowed to contain "less than" values
 FIELDS_ALLOWING_LESS_THAN: ["query", "words", "kudos", "hits"]
 

--- a/features/step_definitions/work_steps.rb
+++ b/features/step_definitions/work_steps.rb
@@ -185,3 +185,13 @@ Given /^I view the chaptered work(?: with ([\d]+) comments?)? "([^"]*)"(?: in (f
   visit work_url(work)
   And %{I follow "View Entire Work"} if mode == "full"
 end
+
+When /^I browse the "([^"]+)" works$/ do |tagname|
+  tag = Tag.find_by_name(tagname)
+  visit tag_works_path(tag)
+end
+
+When /^I browse the "([^"]+)" works with an empty page parameter$/ do |tagname|
+  tag = Tag.find_by_name(tagname)
+  visit tag_works_path(tag, :page => "")
+end

--- a/features/work_browse.feature
+++ b/features/work_browse.feature
@@ -1,0 +1,10 @@
+@works @browse
+Feature: browsing works from various contexts
+
+Scenario: browsing works with incorrect page params in query string
+
+  Given I am logged in as a random user
+    And a fandom exists with name: "Johnny Be Good", canonical: true
+    And I post the work "Whatever" with fandom "Johnny Be Good"
+  When I browse the "Johnny Be Good" works with an empty page parameter
+  Then I should see "1 Work found"

--- a/lib/html_cleaner.rb
+++ b/lib/html_cleaner.rb
@@ -60,6 +60,9 @@ module HtmlCleaner
   end
   
   def sanitize_value(field, value)
+    if ArchiveConfig.NONZERO_INTEGER_PARAMETERS.has_key?(field.to_s)
+      return (value.to_i > 0) ? value.to_i : ArchiveConfig.NONZERO_INTEGER_PARAMETERS[field.to_s]
+    end
     return "" if value.blank?
     value.strip!
     if field.to_s == 'title'


### PR DESCRIPTION
Sanitises page parameters for will_paginate, according to their default values for our app.

Issue 2286: Empty query parameters cause errors: http://code.google.com/p/otwarchive/issues/detail?id=2286
