### PR TITLE
Fixed issue 2328: Remove 'As of 18 November 2010' message off the Support

### DIFF
--- a/app/views/feedbacks/new.html.erb
+++ b/app/views/feedbacks/new.html.erb
@@ -10,7 +10,10 @@
 features planned. Please do use this form to let us know about your experience of using the site - good and bad.
   If you'd like a reply, make sure you include your email address, but anonymous feedback is welcomed as well.") %></p>
 
+<p class="message"><%= ts("When reporting an issue, please remember that more info is always welcome. Let us know what error pages/messages you're seeing. Include links if applicable!") %></p>
+
 <p class="message"><%= ts("If you're looking for help, you can find answers to many common questions in our") %> <%= link_to ts("FAQ section"), archive_faqs_path %></p> 
+
 <p class="message"><%= ts("You may also want to check out our") %> <%= link_to ts("Known Issues"), known_issues_path %></p>
 
 <%= form_for(@feedback) do |f| %>


### PR DESCRIPTION
Fixed issue 2328: Remove 'As of 18 November 2010' message off the Support page
