### PR TITLE
Edits to the TOS and TOS FAQ to clarify policy on original works, two sma

### DIFF
--- a/app/views/archive_faqs/index.html.erb
+++ b/app/views/archive_faqs/index.html.erb
@@ -8,6 +8,7 @@
   <!--main content-->
   <div class="admin userstuff">
     <p>Some commonly asked questions about the Archive are answered here. 
+    Questions and answers about our Terms of Service can be found in the <%= link_to "TOS FAQ", tos_faq_path %>. 
     You may also like to check out our <%= link_to "Known Issues", known_issues_path %>. 
     If you need more help, please submit a <%= link_to "support request", feedbacks_path %>.</p>
 

--- a/app/views/home/_tos.html.erb
+++ b/app/views/home/_tos.html.erb
@@ -260,11 +260,11 @@
       </p>
       <h5><a name="IV.A.">A. Procedures</a></h5>
       <ol style="list-style-type:decimal;">
-        <li>1. Submitting a complaint
+        <li>Submitting a complaint
           <p>Complaints may be submitted to our abuse team. Except in the case of <a href="#IV.D.">copyright complaints</a>, a complainant may submit a complaint via <%= link_to 'the web form', new_abuse_report_path %>, which does not require identifying information. Depending on the nature of the complaint, however, anonymity may hinder our ability to verify the complaint or affect the credibility of the complaint. In order for the abuse team to follow up on any allegation, the exact location (<acronym title="Uniform Resource Locator">URL</acronym>) and nature of the alleged violation must be supplied in the original complaint. Repeated unverified abuse complaints from the same source may be subject to summary rejection.
           </p>
         </li>
-        <li>2. Treatment and investigation of complaints
+        <li>Treatment and investigation of complaints
           <p>Only people who need to know about a complaint will be informed about it. The details of any individual complaint are confidential and must be used only in resolving that complaint.
           </p>
           <p>The subject of a complaint may also be among those who need to know about it. Only information provided in the complaint will be passed on. The complainant has complete control over what information is submitted to Abuse, and can submit the complaint anonymously. (Legal names and other information sufficient to identify a person in the physical world will never be disclosed as part of a standard abuse complaint. For further clarification, please refer to <a href="http://transformativeworks.org/privacy">our privacy policy</a>.)
@@ -286,11 +286,11 @@
           <p>If the complainant requests notification of the resolution of the complaint and provides contact information, we will notify him or her.
           </p>
         </li>
-        <li>3. Submitting an appeal
+        <li>Submitting an appeal
           <p>The complainant or the original poster may appeal a decision to the abuse team as a whole. During the appeal, the original decision will remain in effect. We will attempt to resolve appeals as speedily as possible, but please remember that we are all volunteers. The abuse team's decisions are final unless overturned by the Board at the Board's sole discretion. There is no right of appeal to the Board. The abuse team, however, may consult with the Board or with committee members authorized by the Board if the abuse team decides that consultation would help resolve an issue.
           </p>
         </li>
-        <li>4. Account statuses
+        <li>Account statuses
           <p>"Account status" refers to the existence of warnings on an account and whether that account has been suspended, temporarily or permanently (<%= link_to 'refer to the ToS FAQ', tos_faq_path(:anchor => 'account_status') %>).
           </p>
           <p>The abuse team may issue warnings when it determines that a violation of the <acronym title="Terms of Service">ToS</acronym> was minor or unintentional. More serious, intentional, or repeated violations of the <acronym title="Terms of Service">ToS</acronym> will trigger suspensions. A suspension will generally be for a period of time, such as a month. The abuse team may also permanently suspend users when it determines that permanent suspension is justified. Permanent suspensions for violations other than spam or threatening the technical integrity of the site require a majority vote of the abuse team. The abuse team's discretion will be informed by the nature of the violation and the response of the user, including the user's decision to voluntarily remove the content that violates the <acronym title="Terms of Service">ToS</acronym>.
@@ -359,7 +359,7 @@
       <p>Writing <acronym>RPF</acronym> (real-person fiction) never constitutes harassment in and of itself. However, content that advocates specific, real harmful actions towards real people is not allowed. This includes, but is not limited to, death threats and requests for readers to harass specific people. If you find content that you believe contains harassing or threatening material, please <%= link_to 'contact the abuse team', new_abuse_report_path %>.
       </p>
       <h5><a name="IV.H.">H. Illegal and inappropriate content</a></h5>
-      <p>The Archive of Our Own is a place for fanworks. Content may not be uploaded to <acronym title="Organization for Transformative Works">OTW</acronym>'s servers if it contains or links to child pornography (images of real children); warez, cracks, hacks or other executable files and their associated utilities; trade secrets, restricted technologies, or classified information; or if it consists entirely of actual instruction manuals, technical data, recipes, or other non-fanwork content, including non-fanwork creative work. Uploading such content is a violation of the <acronym title="Terms of Service">ToS</acronym>.
+      <p>The Archive of Our Own is a place for fanworks. Content may not be uploaded to <acronym title="Organization for Transformative Works">OTW</acronym>'s servers if it contains or links to child pornography (images of real children); warez, cracks, hacks or other executable files and their associated utilities; trade secrets, restricted technologies, or classified information; or if it consists entirely of actual instruction manuals, technical data, recipes, or other non-fanwork content, including non-fanwork creative work (<%= link_to 'refer to the ToS FAQ', tos_faq_path(:anchor => 'original_fiction') %>). Uploading such content is a violation of the <acronym title="Terms of Service">ToS</acronym>.
       </p>
       <p>We may determine that we need to remove content to resolve a threatened or pending lawsuit. If so, we will remove the content. Unless it otherwise violates the <acronym title="Terms of Service">ToS</acronym>, removal for this reason will not lead to a suspension.
       </p>
@@ -591,7 +591,7 @@
               </p>
             </li>
             <li>
-              <p>These ToS are written assuming a single maintainer. If there are multiple active maintainers of a collection, they must all agree before the OTW will bring the collection into Open Doors. If some but not all of the maintainers later wish to part from the OTW, those who wish to do so can continue to work with the collection on the OTW servers, while the OTW will follow provisions iv. and v. for any maintainers who wish to move the collection elsewhere. The OTW will retransfer domain names only to maintainers who were registered owners of the domain names at issue. For active collections, maintainers can use whatever dispute resolution procedure they work out between themselves, provided that they otherwise comply with OTW policies.
+              <p>These ToS are written assuming a single maintainer. If there are multiple active maintainers of a collection, they must all agree before the OTW will bring the collection into Open Doors. If some but not all of the maintainers later wish to part from the OTW, those who wish to do so can continue to work with the collection on the OTW servers, while the OTW will follow provisions d. and e. for any maintainers who wish to move the collection elsewhere. The OTW will retransfer domain names only to maintainers who were registered owners of the domain names at issue. For active collections, maintainers can use whatever dispute resolution procedure they work out between themselves, provided that they otherwise comply with OTW policies.
               </p>
             </li>
           </ol>

--- a/app/views/home/tos_faq.html.erb
+++ b/app/views/home/tos_faq.html.erb
@@ -324,18 +324,25 @@
       </p>
 			<h5 id="original_fiction">Can I archive original fiction?
 			</h5>
-			<p>No.  Although some users may want a place for all their creative work, our current vision of the Archive is of a place dedicated to fanworks in particular.  The archive was designed to serve the <a href="http://transformativeworks.org/about/">mission</a> of the Organization for Transformative Works (<acronym title="Organization for Transformative Works">OTW</acronym>), which was "established by fans to serve the interests of fans by providing access to and preserving the history of fanworks and fan culture in its myriad forms."
+			<p>Yes and no. Although some users may want a place for all their creative work, our current vision of the Archive is of a place dedicated to fanworks in particular. The archive was designed to serve the <a href="http://transformativeworks.org/about/">mission</a> of the Organization for Transformative Works (<acronym title="Organization for Transformative Works">OTW</acronym>), which was "established by fans to serve the interests of fans by providing access to and preserving the history of fanworks and fan culture in its myriad forms."
 			</p>
-			<p>Because our long-term plans include hosting fanworks of all kinds, not just fan fiction, we concluded that it was better to draw a line between fanworks and non-fanworks and only host the former, in order to avoid becoming a general repository for all sorts of creative works.  There remains significant debate on this topic, however, and we intend to revisit it after the archive has been open for some time.  We welcome feedback from Archive users at <a href="http://transformativeworks.org/contact/content%20policy">Content Policy</a>.
-			</p>
-			<p><em>Exception</em>: Some Open Doors projects may contain both fanworks and non-fanworks.  Once we accept an Open Doors project for preservation, all its components will be hosted on the archive.
-			</p>
-			<h5 id="defining_fanworks">How will you draw the line between fanworks and non-fanworks?
+			<p>
+      Because our long-term plans include hosting fanworks of all kinds, not just fan fiction, we concluded that it was better to draw a line between fanworks and non-fanworks and only host the former, in order to avoid becoming a general repository for all sorts of creative works. In addition, we will enforce the noncommercialization policy strictly, including a ban on works posted to promote the sale of the author's other works, even if those are not hosted on the site.
+      </p>
+      <p>
+      However, there are a number of varieties of works produced by fans that do not fit comfortably into a narrow definition of fanfiction, fanart, vids, or other types of fanworks.  Some of these do fall within our mission.  In particular, original fiction that is part of an Open Doors project is allowed, as are types of original fiction and quasi-original fiction produced within a fandom context.  Examples include such things as anthropomorfic, original fiction that is produced as part of a fandom challenge, exchange, or charity event, and genres such as Original Slash and Original BL.
+      </p>
+      <p>
+      At such time as we are able to host art and vids, we anticipate similar policies will apply to those mediums: Art and vids will be considered fannish even in cases where they do not directly depict characters and elements from or use footage from an existing media source if they were created in a fandom context for a fandom audience.  This may include such things as fanart that is intended to be for a particular canon but which does not contain readily identifiable canon characters or elements, art and vids produced as part of a fandom challenge, exchange, or charity event, illustrations of fanfiction, and vids that comment on a particular canon without using any clips from it (e.g., fan-produced videos set in a particular universe).  
+      </p>
+      <p>
+      In general, when there is doubt as to whether a particular work counts as a fanwork, we will trust the judgment of the work's creator.
+      </p>
+      <h5 id="defining_fanworks">How will you draw the line between fanworks and non-fanworks?
 			</h5>
-			<p>The presumption is that a work is a fanwork, but if it's clear from context&#8212;tags, author's notes, etc.&#8212;that it's not, it may be removed for violating the Content Policy.  Please note that alternate universes/alternate realities or fanworks set in the distant past/future of a particular canon are still fanworks.
+			<p>The presumption is that a work is a fanwork, but if it's clear from context&mdash;tags, author's notes, etc.&mdash;that it's not, it may be removed for violating the Content Policy. Please note that alternate universes/alternate realities or fanworks set in the distant past/future of a particular canon are still fanworks. Original works that are not based on a specific media source (canon) may also count as fanworks so long as they are fannish in nature. Please see "Can I archive original fiction?" above for more detail.
 			</p>
-			<h4 id="tags_and_warnings">
-				Tags and Warnings
+			<h4 id="tags_and_warnings">Tags and Warnings
 			</h4>
 			<p id="tags">This is the list of archive tags that authors will be able to choose from when posting a story.
 			</p>


### PR DESCRIPTION
Edits to the TOS and TOS FAQ to clarify policy on original works, two small numbering fixes, also added a link to the TOS FAQ from the Archive FAQ

http://code.google.com/p/otwarchive/issues/detail?id=2351
