### PR TITLE
issue 2304: collection name should have info popup

### DIFF
--- a/app/views/collections/_form.html.erb
+++ b/app/views/collections/_form.html.erb
@@ -24,7 +24,7 @@
     </dd>
   <% end %>
 
-    <dt><%= collection_form.label :name, ts("Collection Name* (letters, numbers, underscores)") %>:</dt>
+    <dt><%= collection_form.label :name, ts("Collection Name* (letters, numbers, underscores)") %>:<%= link_to_help "collection-name" %></dt>
     <dd><%= collection_form.text_field :name %></dd>
 
 

--- a/features/collection_create.feature
+++ b/features/collection_create.feature
@@ -89,6 +89,28 @@ Feature: Collection
     And I press "Preview"
   Then I should see "Preview Work"
     And I should see "My SubCollection" within ".collections"
-    
 
+  Scenario: clicking the help popup for moderated collection
+    
+  Given the following activated users exist
+    | login          | password    |
+    | myname1        | something   |
+    | myname2        | something   |
+    And I am logged in as "myname1" with password "something"
+  When I go to the collections page
+  When I follow "New Collection"
+    And I follow "Moderated collection"
+  Then I should see "By default, collections are not moderated"
+
+  Scenario: clicking the help popup for collection name
+
+  Given the following activated users exist
+    | login          | password    |
+    | myname1        | something   |
+    | myname2        | something   |
+    And I am logged in as "myname1" with password "something"
+  When I go to the collections page
+  When I follow "New Collection"
+    And I follow "Collection name"
+  Then I should see "The name of the collection can be"
   

--- a/public/help/collection-name.html
+++ b/public/help/collection-name.html
@@ -1,0 +1,6 @@
+<h4>Collection Name</h4>
+
+<p>
+  The name of the collection can be changed at a later point, but that will break links to the collection.  
+</p>
+  


### PR DESCRIPTION
issue 2304: collection name should have info popup

-added info popup to collection name field in signup form
-added test for collection name info popup
-and, as long as i was right there, added a test for the "is this collection moderated?" info box
