### PR TITLE
Issue 2337: chapter title help popup has misleading text

### DIFF
--- a/app/views/chapters/_chapter_form.html.erb
+++ b/app/views/chapters/_chapter_form.html.erb
@@ -6,7 +6,7 @@
 	<dl>
 		<dt><%= f.label :title, t('.form_title', :default => 'Chapter title') %></dt>
 		<dd><p><%= f.text_field :title, :class => "storyinputfield", :live => true %>
-    <%= link_to_help "story-title" %></p>
+    <%= link_to_help "chapter-title" %></p>
     <%= generate_countdown_html("chapter_title", ArchiveConfig.TITLE_MAX) %>
     </dd>
 	

--- a/features/chapter_edit.feature
+++ b/features/chapter_edit.feature
@@ -169,3 +169,21 @@ Feature: Edit chapters
     Then I should not see "Draft"
     And I should not see "draft"
 
+  Scenario: view chapter title info pop up
+    
+  Given the following activated user exists
+    | login         | password   |
+    | epicauthor    | password   |
+    And basic tags
+  When I am logged in as "epicauthor"
+    And I go to epicauthor's user page
+    And I follow "Post New"
+    And I select "Not Rated" from "Rating"
+    And I check "No Archive Warnings Apply"
+    And I fill in "Fandoms" with "New Fandom"
+    And I fill in "Work Title" with "New Epic Work"
+    And I fill in "Work text" with "Well, maybe not so epic."
+    And I press "Post"
+    And I follow "Add Chapter"
+    And I follow "Chapter title"
+  Then I should see "You can add a chapter title"

--- a/public/help/chapter-title.html
+++ b/public/help/chapter-title.html
@@ -1,0 +1,3 @@
+<h4>Chapter Title</h4>
+
+<p>You can add a chapter title, but it's not required.</p>


### PR DESCRIPTION
Issue 2337: chapter title help popup has misleading text

http://code.google.com/p/otwarchive/issues/detail?id=2337

-added info popup for chapter title so info box would no longer contain the information on work titles
-added test for chapter title popup
