### PR TITLE
issue 2263: add link to subscribe on user profile page

### DIFF
--- a/app/controllers/profile_controller.rb
+++ b/app/controllers/profile_controller.rb
@@ -9,6 +9,12 @@ class ProfileController < ApplicationController
       Profile.create(:user_id => @user.id)
       @user.reload
     end
+    #code the same as the stuff in users_controller
+    if current_user.respond_to?(:subscriptions)
+      @subscription = current_user.subscriptions.where(:subscribable_id => @user.id,
+                                                       :subscribable_type => 'User').first ||
+                      current_user.subscriptions.build
+    end
   end
   
 end

--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -21,7 +21,7 @@ class SubscriptionsController < ApplicationController
 
     respond_to do |format|
       if @subscription.save
-        format.html { redirect_to(@subscription.subscribable, :notice => "You are now following #{@subscription.name}. 
+        format.html { redirect_to(:back, :notice => "You are now following #{@subscription.name}. 
         If you'd like to stop receiving email updates, you can return to this page and click 'Unsubscribe'.") }
       else
         format.html { render :action => "new" }
@@ -37,7 +37,7 @@ class SubscriptionsController < ApplicationController
     @subscription.destroy
 
     respond_to do |format|
-      format.html { redirect_to(@subscribable, :notice => "You have successfully unsubscribed from #{@subscription.name}.") }
+      format.html { redirect_to(:back, :notice => "You have successfully unsubscribed from #{@subscription.name}.") }
     end
   end
 end

--- a/features/subscriptions.feature
+++ b/features/subscriptions.feature
@@ -51,4 +51,15 @@ Feature: Subscriptions
     And I post the work "Awesome Story 2: The Sequel"
   Then 0 emails should be delivered
     
-   
+  Scenario: subscribe button on profile page
+  
+  When I am logged in as "myname2" with password "something"
+    And I go to myname1's profile page
+    And I press "Subscribe"
+  Then I should see "You are now following myname1"
+    And I should see "About myname1"
+    And I should not see "Fandoms"
+  When I follow "Unsubscribe"
+  Then I should see "successfully unsubscribed"
+    And I should see "About myname1"
+    And I should not see "Fandoms"

--- a/features/support/paths.rb
+++ b/features/support/paths.rb
@@ -51,6 +51,8 @@ module NavigationHelpers
       user_preferences_path(:user_id => $1)
     when /^the subscriptions page for "(.*)"$/i
       user_subscriptions_path(:user_id => $1)
+    when /^(.*)'s profile page$/i
+      user_profile_path(:user_id => $1)
     when /my user page/
       user_path(User.current_user)
     when /my preferences page/
@@ -59,6 +61,8 @@ module NavigationHelpers
       user_bookmarks_path(User.current_user)
     when /my subscriptions page/
       user_subscriptions_path(User.current_user)      
+    when /my profile page/
+      user_profile_path(User.current_user)
     when /the import page/
       new_work_path(:import => 'true')
     when /the work-skins page/


### PR DESCRIPTION
issue 2263: add link to subscribe on user profile page

-added logic in the profile controller so that subscribe button would appear on user profile page
-changed redirect in subscriptions controller to point to :back, not to user page, so that subscribing from a profile page returns you to the profile page and not the user page
-added test to confirm that those two things function as expected
