### PR TITLE
Fixing issue 2385: remove share area from ff.net imports

### DIFF
--- a/app/models/story_parser.rb
+++ b/app/models/story_parser.rb
@@ -746,7 +746,14 @@ class StoryParser
     # Parses a story from fanfiction.net
     def parse_story_from_ffnet(story)
       work_params = {:chapter_attributes => {}}
-      storytext = clean_storytext((@doc/"#storytext").inner_html)
+      # storytext = clean_storytext((@doc/"#storytext").inner_html)
+      storytext = (@doc/"#storytext")
+      #remove share area
+      divs = storytext.css("div div.a2a_kit")
+      if !divs[0].nil?
+        divs[0].remove
+      end
+      storytext = clean_storytext(storytext.inner_html)
 
       work_params[:notes] = ((@doc/"#storytext")/"p").first.try(:inner_html)
 


### PR DESCRIPTION
Fix for issue 2385: http://code.google.com/p/otwarchive/issues/detail?id=2385

Imports from ff.net should not include share links.
