### PR TITLE
Issue 2275 - empty emails to admins

### DIFF
--- a/app/views/admin_mailer/comment_notification.html.erb
+++ b/app/views/admin_mailer/comment_notification.html.erb
@@ -1,0 +1,18 @@
+<h4>
+<% if @comment.comment_owner %>
+  <%= link_to @comment.comment_owner_name, polymorphic_url(@comment.comment_owner, :only_path => false) %>
+<% else %>
+  <%= @comment.comment_owner_name %>
+<% end %>
+<% if @comment.ultimate_parent.is_a?(Tag) %>
+  <%= ts("left the following comment on the tag") %> 
+  <%= link_to @comment.ultimate_parent.commentable_name, {:controller => :tags, :action => :show, :id => @comment.ultimate_parent, :only_path => false} %>:
+<% else %>
+  <%= ts("left the following comment on") %> 
+  <%= link_to @comment.ultimate_parent.commentable_name, polymorphic_url(@comment.ultimate_parent, :only_path => false) %>:
+<% end %>
+</h4>
+
+<p><%=raw @comment.sanitized_content %></p>
+
+<%= render :partial => 'comment_mailer/comment_notification_footer' %>

--- a/app/views/admin_mailer/edited_comment_notification.html.erb
+++ b/app/views/admin_mailer/edited_comment_notification.html.erb
@@ -1,0 +1,18 @@
+<h4>
+<% if @comment.comment_owner %>
+  <%= link_to @comment.comment_owner_name, polymorphic_url(@comment.comment_owner, :only_path => false) %>
+<% else %>
+  <%= @comment.comment_owner_name %>
+<% end %>
+<% if @comment.ultimate_parent.is_a?(Tag) %>
+  <%= ts("edited the following comment on the tag") %> 
+  <%= link_to @comment.ultimate_parent.commentable_name, {:controller => :tags, :action => :show, :id => @comment.ultimate_parent.to_param, :only_path => false} %>:
+<% else %>
+  <%= ts("edited the following comment on") %> 
+  <%= link_to @comment.ultimate_parent.commentable_name, polymorphic_url(@comment.ultimate_parent, :only_path => false) %>:
+<% end %>
+</h4>
+
+<p><%=raw @comment.sanitized_content %></p>
+
+<%= render :partial => 'comment_mailer/comment_notification_footer' %>

--- a/features/admin_tasks.feature
+++ b/features/admin_tasks.feature
@@ -262,6 +262,7 @@ Feature: Admin tasks
     And I fill in "Comment" with "Excellent, my dear!"
     And I press "Add Comment"
   Then 1 email should be delivered to "testadmin@example.org"
+    And the email should contain "Excellent"
 
   # admin replies to comment of regular user
   Given I am logged out


### PR DESCRIPTION
Ignore the commit message, the number is 2275. :sigh:

http://code.google.com/p/otwarchive/issues/detail?id=2275

Added comment notification and edited cmt notif views in admin_mailer, since that's where it was looking for them, and added a check in the cuke test.
