### PR TITLE
Issue 2472: quick fix to guarantee we expire all existing prompt caches.

### DIFF
--- a/app/views/challenge/prompt_meme/_challenge_requests.html.erb
+++ b/app/views/challenge/prompt_meme/_challenge_requests.html.erb
@@ -111,7 +111,7 @@
         <% end %>
       <% end %>
       
-      <% cache("collection-#{@collection.id}-prompt-#{prompt.id}") do %>
+      <% cache(prompt) do %>
       <!-- show tags, description, url for all allowed requests and offers: using a lot of evals here to DRY up the code since it's so repetitive -->
           <% TagSet::TAG_TYPES.each do |type| %>
             <% if eval("@show_request_#{type}_tags") %>


### PR DESCRIPTION
Issue 2472: quick fix to guarantee we expire all existing prompt caches. The sweeper won't do that unless the existing signups are all updated via controller action.
