### PR TITLE
Fix for issue 1665, new series input field was misaligned in IE7. It now 

### DIFF
--- a/public/stylesheets/ie7_overrides.css
+++ b/public/stylesheets/ie7_overrides.css
@@ -7,4 +7,5 @@ overflow:scroll;} */
 
 #main.admin_posts-index .module { float:none; } /* float issues on admin posts index */
 
-
+/* The input-field in Series Options on the New Work form is centred for no reason */
+#series-options input[type="text"] {position:absolute;}


### PR DESCRIPTION
Fix for issue 1665, new series input field was misaligned in IE7. It now left-aligns with the select field above.

google code issue: http://code.google.com/p/otwarchive/issues/detail?id=1665
