### PR TITLE
turning off x-sendfile.

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -13,7 +13,7 @@ Otwarchive::Application.configure do
   # config.action_dispatch.x_sendfile_header = "X-Sendfile"
 
   # For nginx:
-  config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect'
+  # config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect'
 
   # If you have no front-end server that supports something like X-Sendfile,
   # just comment this out and Rails will serve the files


### PR DESCRIPTION
I prefer this to the alternative of configuring nginx with an internal redirect
to a hard-coded filesystem path.

typical rails apps use x-sendfile because you don't want to block your
application with the time it takes to download big files. but our downloads
aren't all that big (except for pdfs they are typically no bigger than the
show pages) and all our downloads go through nginx anyway except the first one.

my guess is the time spent sending the file is minor compared with the time
spent actually creating it so we save little by passing it off to nginx after
it's created instead of sending it directly.

it keeps the unicorn busy a bit longer (until the file is completely downloaded
by the browser), but we aren't in danger of the normal denial of service
problem because we partition our unicorns.
