### PR TITLE
Issue 2168 making add another prompt work without javascript

### DIFF
--- a/app/views/challenge_signups/_promptmeme_signup_form.html.erb
+++ b/app/views/challenge_signups/_promptmeme_signup_form.html.erb
@@ -131,7 +131,7 @@
       <% end %>
     <% end %>
     <% if @challenge.send("requests_num_allowed") > @challenge.send("requests_num_required") %>
-      <p class="navigation">
+      <p class="navigation showme" style="display: none;">
         <%= link_to_add_section(
              ts("Add another prompt? (Up to %{allowed} allowed.)", :allowed => @challenge.send("requests_num_allowed")), 
              signup_form, prompt_type.to_sym, "prompts/prompt_form", {:is_offer => false, :required => false, :edit_record => false}) 

--- a/app/views/challenge_signups/_signup_form.html.erb
+++ b/app/views/challenge_signups/_signup_form.html.erb
@@ -81,7 +81,7 @@ So if anyone can think of a better design for this, that would be awesome
     <% end %>
     
     <% if @challenge.send("#{prompt_type}_num_allowed") > @challenge.send("#{prompt_type}_num_required") %>
-      <p class="navigation">
+      <p class="navigation showme" style="display: none;">
         <%= link_to_add_section(
              ts("Add another %{type}? (Up to %{allowed} allowed.)", :type => prompt_type.singularize, :allowed => @challenge.send("#{prompt_type}_num_allowed")), 
              signup_form, prompt_type.to_sym, "prompts/prompt_form", {:is_offer => (prompt_type == "offers"), :required => false, :edit_record => false}) 


### PR DESCRIPTION
Issue 2168 making add another prompt work without javascript - hide the button you can't use

This doesn't quite do everything Zebra asked for, but it makes it better than it was.
