### PR TITLE
Putting back the accidentally swapped complete / not complete symbols get

### DIFF
--- a/app/helpers/tags_helper.rb
+++ b/app/helpers/tags_helper.rb
@@ -255,9 +255,9 @@ module TagsHelper
 
     if [Work, Series].include?(item.class)
       if item.complete?
-        symbol_block << get_symbol_link( "complete-no iswip", "#{item.class.to_s} in Progress" )
-      else
         symbol_block << get_symbol_link( "complete-yes iswip" , "Complete #{item.class.to_s}")
+      else
+        symbol_block << get_symbol_link( "complete-no iswip", "#{item.class.to_s} in Progress" )
       end
     elsif item.class == ExternalWork
       symbol_block << get_symbol_link('external-work', "External Work")


### PR DESCRIPTION
Putting back the accidentally swapped complete / not complete symbols getters

http://code.google.com/p/otwarchive/issues/detail?id=2531
