### PR TITLE
Issue2487 open challenges list

### DIFF
--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -163,10 +163,10 @@ class Collection < ActiveRecord::Base
 
   # we need to add other challenge types to this join in future
   scope :ge_signups_open, joins("INNER JOIN gift_exchanges on gift_exchanges.id = challenge_id").
-                       where("gift_exchanges.signup_open = 1 && gift_exchanges.signups_close_at > ?", Time.now).
+                       where("gift_exchanges.signup_open = 1 && gift_exchanges.signups_close_at > ? && gift_exchanges.signups_open_at < ?", Time.now, Time.now).
                        order("gift_exchanges.signups_close_at")
   scope :pm_signups_open, joins("INNER JOIN prompt_memes on prompt_memes.id = challenge_id").
-                       where("prompt_memes.signup_open = 1 || (prompt_memes.signups_close_at > ? && prompt_memes.signups_open_at < ?)", Time.now).
+                       where("prompt_memes.signup_open = 1 || (prompt_memes.signups_close_at > ? && prompt_memes.signups_open_at < ?)", Time.now, Time.now).
                        order("prompt_memes.signups_close_at")
 
   scope :with_name_like, lambda {|name|

--- a/app/views/challenge/gift_exchange/_gift_exchange_form.html.erb
+++ b/app/views/challenge/gift_exchange/_gift_exchange_form.html.erb
@@ -28,7 +28,7 @@
       see the sign up form links.
     </p>
     <p class="notes">
-      Currently the dates are provided <strong>only for information</strong>. You will need to manually open and close signup.
+      These dates are for information, and also affect the listing of open challenges. You will still need to manually open and close signup.
       If your collection is set to unrevealed/anonymous, you can set dates for those as well.
     </p>
     <dl>

--- a/app/views/challenge/prompt_meme/_prompt_meme_form.html.erb
+++ b/app/views/challenge/prompt_meme/_prompt_meme_form.html.erb
@@ -27,7 +27,7 @@
       see the sign up form links.
     </p>
     <p class="notes">
-      Currently the dates are provided <strong>only for information</strong>. You will need to manually open and close signup.
+      These dates are for information, and also affect the listing of open challenges. You will still need to manually open and close prompting (signup).
       If your collection is set to unrevealed/anonymous, you can set dates for those as well.
     </p>
     <dl>

--- a/features/challenge_promptmeme.feature
+++ b/features/challenge_promptmeme.feature
@@ -33,6 +33,26 @@ Feature: Prompt Meme Challenge
   When I view open challenges
   Then I should see "Battle 12"
   
+  Scenario: Past challenge is not in list of open challenges
+  
+  Given I am logged in as "mod1"
+    And I have standard challenge tags setup
+  When I set up Battle 12 promptmeme collection
+    And I fill in past challenge options
+    And I am logged in as "myname1"
+  When I view open challenges
+  Then I should not see "Battle 12"
+  
+  Scenario: Future challenge is not in list of open challenges
+  
+  Given I am logged in as "mod1"
+    And I have standard challenge tags setup
+  When I set up Battle 12 promptmeme collection
+    And I fill in future challenge options
+    And I am logged in as "myname1"
+  When I view open challenges
+  Then I should not see "Battle 12"
+  
   Scenario: Can edit settings for a prompt meme
   
   Given I have Battle 12 prompt meme fully set up

--- a/features/step_definitions/challenge_steps.rb
+++ b/features/step_definitions/challenge_steps.rb
@@ -192,6 +192,24 @@ When /^I fill in Battle 12 challenge options$/ do
     And %{I press "Update"}
 end
 
+When /^I fill in future challenge options$/ do
+  When "I fill in prompt meme challenge options"
+    And %{I select "2015" from "prompt_meme_signups_open_at_1i"}
+    And %{I select "2016" from "prompt_meme_signups_close_at_1i"}
+    And %{I fill in "prompt_meme_requests_num_allowed" with "3"}
+    And %{I uncheck "Signup open?"}
+    And %{I press "Update"}
+end
+
+When /^I fill in past challenge options$/ do
+  When "I fill in prompt meme challenge options"
+    And %{I select "2010" from "prompt_meme_signups_open_at_1i"}
+    And %{I select "2010" from "prompt_meme_signups_close_at_1i"}
+    And %{I fill in "prompt_meme_requests_num_allowed" with "3"}
+    And %{I uncheck "Signup open?"}
+    And %{I press "Update"}
+end
+
 When /^I fill in unlimited prompt challenge options$/ do
   When "I fill in prompt meme challenge options"
     And %{I check "prompt_meme_request_restriction_attributes_character_restrict_to_fandom"}


### PR DESCRIPTION
http://code.google.com/p/otwarchive/issues/detail?id=2487

Some of the problems I can see are either that challenge owners have temporarily opened signups again for a gift exchange to fix an issue, or forgotten to leave signups closed. It should also respect if signup hasn't opened yet. Also added clarification when setting the dates.
