### PR TITLE
Fixing Issue 2213 - comments marked as spam now only visible to admins. I

### DIFF
--- a/app/views/comments/_comment_thread.html.erb
+++ b/app/views/comments/_comment_thread.html.erb
@@ -1,7 +1,7 @@
 <!-- START thread -->
 <ol class="thread">
   <% for comment in comments %>
-    <% if comment.approved or logged_in? %>
+    <% if comment.approved? || logged_in_as_admin? %>
     
       <%= render :partial => 'comments/single_comment', :object => comment %>	  
       

--- a/features/admin_tasks.feature
+++ b/features/admin_tasks.feature
@@ -249,14 +249,15 @@ Feature: Admin tasks
   Then I should see "rolex"
     And I should see "Spam"
   When I follow "Spam"
-  Then I should not see "rolex"
+  Then I should see "Not Spam"
   When I follow "Hide Comments"
   # TODO: Figure out if this is a defect or not, that it shows 2 instead of 1
   # Then I should see "Read Comments (1)"
 
   # comment should no longer be there
   When I follow "Read Comments"
-  Then I should not see "rolex"
+  Then I should see "rolex"
+    And I should see "Not Spam"
   When I am logged out as an admin
     And I view the work "The One Where Neal is Awesome"
     And I follow "Read Comments"
@@ -264,8 +265,7 @@ Feature: Admin tasks
   When I am logged in as "author" with password "password"
     And I view the work "The One Where Neal is Awesome"
     And I follow "Read Comments"
-    And "Issue 2213" is fixed
-  # Then I should not see "rolex"
+    Then I should not see "rolex"
 
   Scenario: make an admin post and receive comment notifications for comments posted to it
   


### PR DESCRIPTION
Fixing Issue 2213 - comments marked as spam now only visible to admins. Includes update to relevant test.
