### PR TITLE
Fixing broken tag_search test

### DIFF
--- a/features/tag_search.feature
+++ b/features/tag_search.feature
@@ -6,15 +6,16 @@ Feature: Search Tags
 
   Scenario: Search tags
     Given I have no tags
-      And a fandom exists with name: "first fandom"
+      And a fandom exists with name: "first fandom", canonical: false
       And a character exists with name: "first last", canonical: true
-      And a relationship exists with name: "first last/someone else"
+      And a relationship exists with name: "first last/someone else", canonical: false
       And the tag indexes are updated
     When I am on the search tags page
       And I fill in "tag_search" with "first"
       And I press "Search tags"
     Then I should see "3 Found"
       And I should see "Fandom: first fandom (0)"
+      And I should not see "Fandom: first fandom (0)" within ".canonical"
       And I should see "Character: first last (0)" within ".canonical"
       And I should see "Relationship: first last/someone else (0)"
     When I am on the search tags page


### PR DESCRIPTION
Fixing broken tag_search test

The test could do with refactoring generally, but this solves the autotest problem for now - it appears to be a problem in the test, possibly affected by the new rspec tests, rather than an actual code bug.
