### PR TITLE
Using the renamed airbrake gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -93,5 +93,5 @@ group :production do
   # Use unicorn as the web server
   gem 'unicorn', :require => false
   gem "memcache-client"
-  gem "hoptoad_notifier", "~> 2.3"
+  gem 'airbrake'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -62,6 +62,9 @@ GEM
       activemodel (= 3.0.4)
       activesupport (= 3.0.4)
     activesupport (3.0.4)
+    airbrake (3.0.4)
+      activesupport
+      builder
     archive-tar-minitar (0.5.2)
     arel (2.0.9)
     aws-s3 (0.6.2)
@@ -117,9 +120,6 @@ GEM
     gherkin (2.3.3)
       json (~> 1.4.6)
     highline (1.6.2)
-    hoptoad_notifier (2.4.7)
-      activesupport
-      builder
     htmlentities (4.2.1)
     i18n (0.5.0)
     jquery-rails (0.2.7)
@@ -264,6 +264,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  airbrake
   authlogic!
   aws-s3
   best_in_place
@@ -278,7 +279,6 @@ DEPENDENCIES
   factory_girl
   fakeweb
   fastimage
-  hoptoad_notifier (~> 2.3)
   htmlentities
   jquery-rails (>= 0.2.6)
   launchy

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -1,5 +1,5 @@
 require './config/boot'
-require 'hoptoad_notifier/capistrano'
+require 'airbrake/capistrano'
 
 # takes care of the bundle install tasks
 require 'bundler/capistrano'

--- a/config/initializers/archive_config/archive_config.rb
+++ b/config/initializers/archive_config/archive_config.rb
@@ -11,7 +11,7 @@ end
 # has to be run after ArchiveConfig loaded
 # and only for production
 if Rails.env == 'production'
-  HoptoadNotifier.configure do |config|
+  Airbrake.configure do |config|
     config.api_key = ArchiveConfig.HOPTOAD_KEY
     config.params_filters << ["email", "crypted_password", "salt"]
   end

--- a/config/initializers/monkeypatches/show_exceptions.rb
+++ b/config/initializers/monkeypatches/show_exceptions.rb
@@ -8,12 +8,12 @@ module ActionDispatch
       def render_exception_with_template(env, exception)
         body = ErrorsController.action(rescue_responses[exception.class.name]).call(env)
         log_error(exception)
-        notify_hoptoad(exception)
+        notify_airbrake(exception)
         body
       rescue
         render_exception_without_template(env, exception)
       end
-      
+
       alias_method_chain :render_exception, :template if Rails.env == "production"
   end
 end


### PR DESCRIPTION
Using the renamed airbrake gem (see http://robots.thoughtbot.com/post/9414766498/airbrake-gem-available)

http://code.google.com/p/otwarchive/issues/detail?id=2604

(Attn of @ambtus & @elzj)
