### PR TITLE
Issue 2599: notes character counter not working: they had lost the class 

### DIFF
--- a/app/views/works/_notes_form.html.erb
+++ b/app/views/works/_notes_form.html.erb
@@ -2,27 +2,27 @@
 <dd class="notes">
   <ul>
     <li class="start">
-      <%= check_box_tag "front-notes-options-show", "1", !@work.notes.blank?, :class => "toggle_formfield" %>
+      <%= check_box_tag "front-notes-options-show", "1", !f.object.notes.blank?, :class => "toggle_formfield" %>
       <%= label_tag 'front-notes-options-show', ts("at the beginning") %>
       <span class="warning<%= f.object.notes.blank? ? ' hidden' : '' %>">
         <%= ts("Warning: Unchecking this box will delete the existing beginning note.") %>
       </span>
       <fieldset id="front-notes-options" class="start">
-        <legend><%= f.label :notes, "Notes" %></legend>
-        <%= f.text_area :notes %>
+        <legend><%= f.label :notes, ts("Notes") %></legend>
+        <%= f.text_area :notes, :class => "observe_textlength" %>
         <%= generate_countdown_html("#{type}_notes", ArchiveConfig.NOTES_MAX) %>
       </fieldset>
     </li>
 
     <li class="end">
-      <%= check_box_tag "end-notes-options-show", "1", !@work.endnotes.blank?, :class => "toggle_formfield" %>
+      <%= check_box_tag "end-notes-options-show", "1", !f.object.endnotes.blank?, :class => "toggle_formfield" %>
       <%= label_tag 'end-notes-options-show', ts("at the end") %>
       <span class="warning<%= f.object.endnotes.blank? ? ' hidden' : '' %>">
         <%= ts("Warning: Unchecking this box will delete the existing end note.") %>
       </span>
       <fieldset id="end-notes-options" class="end">
-	      <legend><%= f.label :notes, "Notes" %></legend>
-	      <%= f.text_area :endnotes %>
+        <legend><%= f.label :endnotes, ts("End Notes") %></legend>
+        <%= f.text_area :endnotes, :class => "observe_textlength" %>
         <%= generate_countdown_html("#{type}_endnotes", ArchiveConfig.NOTES_MAX) %>
       </fieldset>
     </li>


### PR DESCRIPTION
Issue 2599: notes character counter not working: they had lost the class that declares a textarea as a countable field.

More importantly, DRYing up work and chapter notes had kept check for @work.notes instead of the form's object in two places.

http://code.google.com/p/otwarchive/issues/detail?id=2599
