### PR TITLE
Single column fandom index for handhelds

### DIFF
--- a/public/stylesheets/site/2.0/25-role-handheld.css
+++ b/public/stylesheets/site/2.0/25-role-handheld.css
@@ -12,4 +12,4 @@ h1,h2,h3{word-break:break-all}
 .blurb dl.tags dt, .blurb dl.tags dd, dl.meta dt, dl.meta dd, .alphabet .listbox li, .media .listbox {width:auto; float:none}
 .blurb dl.tags dd, dl.meta dd {margin-left:1em}
 
-
+.alphabet .listbox li {display:block}


### PR DESCRIPTION
Additional change related to Issue 2583: alphabetical listboxes (i.e. fandom index) should display one full-width column when viewed on iPhone.
