### PR TITLE
fixing overeager replacement of ampersand entities during sanitising

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -204,6 +204,8 @@ FIELDS_ALLOWING_LESS_THAN: ["query", "words", "kudos", "hits"]
 FIELDS_ALLOWING_HTML: ["about_me", "banner_text", "comment", "content", "description", "endnotes", "faq", "intro", "note", "notes",
   "rules", "signup_instructions_general", "signup_instructions_offers", "signup_instructions_requests", "summary"]
 
+FIELDS_ALLOWING_HTML_ENTITIES: ["title"]
+
 FIELDS_ALLOWING_VIDEO_EMBEDS: ["content"]
 
 FIELDS_ALLOWING_CSS: ["content", "endnotes", "notes"]

--- a/lib/html_cleaner.rb
+++ b/lib/html_cleaner.rb
@@ -88,9 +88,9 @@ module HtmlCleaner
       # clean out all tags
       value = Sanitize.clean(fix_bad_characters(value))
     end
-    # FIXME
-    # for now, just put ampersands back the way they were
-    value.gsub!(/&amp;/, '&')
+
+    # Plain text fields can't contain &amp; entities:
+    value.gsub!(/&amp;/, '&') unless (ArchiveConfig.FIELDS_ALLOWING_HTML_ENTITIES + ArchiveConfig.FIELDS_ALLOWING_HTML).include?(field.to_s)
     value
   end
 


### PR DESCRIPTION
Fixes http://code.google.com/p/otwarchive/issues/detail?id=2245

Would be great if this could go into the next deploy with the other epub fix as that one already has an after task for trashing all our epubs.
