### PR TITLE
Pagination no longer hidden on side of user/works page

### DIFF
--- a/public/stylesheets/site/2.0/08-actions.css
+++ b/public/stylesheets/site/2.0/08-actions.css
@@ -27,7 +27,7 @@ p.submit, input.submit, dd.submit
 /*subtypes and modes 
 test note: this pagination clear needs to be kept an eye on*/
 ol.pagination
-        { text-align:center; clear:right; margin:0.643em auto}
+        { text-align:center; clear:both; margin:0.643em auto}
 .actions a:visited
         { color: #111; }
 .actions a:hover, .actions input:hover


### PR DESCRIPTION
The pagination on a user's works index wasn't on the right side, under the filters. Now it's not!
