### PR TITLE
Fix issue 2693 with pagination clears

### DIFF
--- a/public/stylesheets/site/2.0/08-actions.css
+++ b/public/stylesheets/site/2.0/08-actions.css
@@ -62,8 +62,6 @@ dl.stats + h6 + .actions, li.news .actions
         { clear: none}
 .actions a.symbol, .action a 
         { border:0; background:none;padding:0 0 0.15em 0}
-.works-index ol.pagination
-        { clear: both; }
 
 /*END== */
         

--- a/public/stylesheets/site/2.0/18-zone-searchbrowse.css
+++ b/public/stylesheets/site/2.0/18-zone-searchbrowse.css
@@ -6,6 +6,8 @@ Arguably filter and search could be styled in interactions but I've put them her
 /* INDEX PAGES (with filters)*/ 
 .works-index .index, .collections-index .index 
         { width:75%; float:left}
+.works-index ol.pagination
+        { clear: both; }        
 .media-index .listbox
         { min-height:17.5em;}
 /* INTERACTION: SEARCH */


### PR DESCRIPTION
Fix issue 2693 with pagination and white space on top of tag wrangling pages, which also affects user bookmarks and series indexes: http://code.google.com/p/otwarchive/issues/detail?id=2693

Reverts to lim's original clear: right for ol.pagination and adds new .works-index ol.pagination clear:both from Branch's support request "ol.pagination still screwed up." Thanks, Branch!
