### PR TITLE
Issue 2711: fixing broken subcollection index pages

### DIFF
--- a/app/views/challenge/gift_exchange/_challenge_navigation_user.html.erb
+++ b/app/views/challenge/gift_exchange/_challenge_navigation_user.html.erb
@@ -1,1 +1,1 @@
-<%= render "challenge/shared/challenge_navigation_user", :collection => (@collection || collection) %>
+<%= render "challenge/shared/challenge_navigation_user", :collection => (collection ||= @collection) %>

--- a/app/views/challenge/prompt_meme/_challenge_navigation_user.html.erb
+++ b/app/views/challenge/prompt_meme/_challenge_navigation_user.html.erb
@@ -1,1 +1,1 @@
-<%= render "challenge/shared/challenge_navigation_user", :collection => (@collection || collection) %>
+<%= render "challenge/shared/challenge_navigation_user", :collection => (collection ||= @collection) %>

--- a/app/views/challenge/shared/_challenge_navigation_user.html.erb
+++ b/app/views/challenge/shared/_challenge_navigation_user.html.erb
@@ -1,6 +1,6 @@
 <!-- added to the navigation controls for the collection. enclose items in list elements. @collection is defined here but @challenge may not be.  -->
 <% collection ||= @collection %>
-<% if collection.challenge.signup_open %>
+<% if collection.challenge && collection.challenge.signup_open %>
   <% if logged_in? %>
     <% if (@challenge_signup = ChallengeSignup.in_collection(collection).by_user(current_user).first) %>
       <li><%= link_to ts("Edit Signup"), edit_collection_signup_path(collection, @challenge_signup) %></li>


### PR DESCRIPTION
Issue 2711: fixing broken subcollection index pages.

We shouldn't override the local variable with @collection, because this is a case where they're two different collections.

http://code.google.com/p/otwarchive/issues/detail?id=2711
