### PR TITLE
Fix issue 2714 with display of definition lists

### DIFF
--- a/public/stylesheets/site/2.0/10-types-groups.css
+++ b/public/stylesheets/site/2.0/10-types-groups.css
@@ -39,6 +39,8 @@ dl.index dd
         { width:auto; float:none; clear:right; margin:0 0.25em 0.643em 2.5em; padding:0.375em 0.15em 0.15em; overflow:visible; background: #e8e6ed}
 dl.index dd:after
         { content:" "; display:block; height:0; font-size:0; clear:both; visibility:hidden; }
+dl.index dd p, dl.index dd .heading, dl.index ul 
+        { display:inline-block }
 
 /*TYPES*/
 a.work  { font:100 1.143em/1.125 Georgia,serif; margin:0.5em 0; color:#900 }


### PR DESCRIPTION
Fix issue 2714, which was causing a clearfix to be applied to all of the elements inside definition lists with the class .index: http://code.google.com/p/otwarchive/issues/detail?id=2714

This actually solves a multitude of definition list problems that I thought were going to require additional issue reports and commits. It turned out to just be a matter of an errant space between an element and its :after selector, which Firefox and Opera were interpreting as *:after instead. 

We may want to investigate whether this makes the next two lines of code redundant. I took it out at first because I'd tested it in Safari, Chrome, Opera, and Firefox with it commented out and noticed no ill effects, but on second thought decided to leave the potential redundancy in and investigate another day as a separate issue.
