### PR TITLE
Fixing common piwik nil error

### DIFF
--- a/vendor/plugins/piwik_analytics/lib/piwik_analytics.rb
+++ b/vendor/plugins/piwik_analytics/lib/piwik_analytics.rb
@@ -75,7 +75,7 @@ module PiwikAnalytics
 
     def self.enabled?(format)
       #raise PiwikAnalytics::PiwikAnalyticsConfigurationError if id_site.blank? || url.blank?
-      environments.include?(Rails.env) && formats.include?(format.to_sym)
+      environments.include?(Rails.env) && format.respond_to?(:to_sym) && formats.include?(format.to_sym)
     end
   end
 end


### PR DESCRIPTION
Fixing common piwik nil error. No way for testers to test this, but I thought I'd save us some error notification emails. Analytics aren't mission-critical, so we can look into why the request format sometimes comes up nil when we have more time to spare.
