### PR TITLE
Fix issue 2722 with filters displaying next to inbox on handheld

### DIFF
--- a/public/stylesheets/site/2.0/25-role-handheld.css
+++ b/public/stylesheets/site/2.0/25-role-handheld.css
@@ -48,6 +48,13 @@ h1,h2,h3{word-break:break-all}
 
 dl.stats + h6 + .actions
        { margin: auto }
+       
+/*zone: home*/
+#inbox-form {
+clear: both;
+float: none; 
+width: auto;
+}
 
 /*SKIN: Dash Line */
 /* DESCRIPTION: Horizontal dash inline*/


### PR DESCRIPTION
Fixes issue 2722, wherein the filters were still displaying next to (and sometimes overlapping) the main content when viewing your inbox on a mobile device: http://code.google.com/p/otwarchive/issues/detail?id=2722
