### PR TITLE
Fix issue 2713 with inconsistently defined footer link styles

### DIFF
--- a/public/stylesheets/site/2.0/06-region-footer.css
+++ b/public/stylesheets/site/2.0/06-region-footer.css
@@ -4,7 +4,7 @@ http://media.transformativeworks.org/training/front_end_coding/patterns/supertyp
 #footer { background:#900 url("/images/skins/textures/tiles/red-ao3.png"); clear:both; border-top:2px solid; position:relative; min-height:150px }
 #footer ul
         { border:0; clear: both; color: #fff; font-size: 0.75em; margin: 1.5em 0; padding: 1em; text-align: center; float:none }
-#footer ul.navigation a   
+#footer a   
         { background:transparent; color: #fff; border: 0; font-weight: 400; margin: auto; padding: 0
           box-shadow:none; }
 #footer a:hover
@@ -15,6 +15,9 @@ http://media.transformativeworks.org/training/front_end_coding/patterns/supertyp
 #footer .secondary 
         { margin: auto; right: auto;
           box-shadow: inset 2px 2px 2px #111;}
-#footer .secondary li a 
-        {  color: #900;}       
+#footer .secondary a 
+        {  color: #900;} 
+#footer .secondary a:hover {
+background: transparent;
+}
 /*END== */


### PR DESCRIPTION
Fix issue 2713 where the :hover style defined for footer links was not actually being applied to the links: http://code.google.com/p/otwarchive/issues/detail?id=2713

I went with the option of making #footer ul.navigation a into #footer a in case we ever add links to the footer that are not contained within the navigation list. I also added #footer .secondary a:hover { background: transparent; } so the secondary links, which are red, would remain readable on hover.
