### PR TITLE
Issue 2730: fix for 500 error when editing signups

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -429,13 +429,13 @@ module ApplicationHelper
       end
     
     checkboxes = choices.map do |choice|      
-      is_checked = !options[:checked_method] || already_checked.empty? ? false : already_checked.include?(choice.name)
       display_name = case
         when options[:name_helper_method]
           eval("#{options[:name_helper_method]}(choice)")
         else
           choice.send(options[:name_method]).html_safe
         end
+      is_checked = !options[:checked_method] || already_checked.empty? ? false : already_checked.include?(display_name)
       value = choice.send(options[:value_method])
       checkbox_id = "#{base_id}_#{name_to_id(value)}"
       checkbox = check_box_tag(field_name, value, is_checked, opts.merge({:id => checkbox_id}))


### PR DESCRIPTION
Issue 2730: fix for 500 error when editing signups with categories, ratings or warnings

http://code.google.com/p/otwarchive/issues/detail?id=2730
