### PR TITLE
Fix issue 2732 with width of items in sortable lists

### DIFF
--- a/public/stylesheets/site/2.0/07-interactions.css
+++ b/public/stylesheets/site/2.0/07-interactions.css
@@ -94,6 +94,10 @@ form li ul.autocomplete li.input
 .ui-sortable li:hover 
         { background: #ddd; border: 2px solid #999; cursor:move;
           box-shadow:1px 1px 3px #bbb }
+.ui-sortable input
+        { width: auto; }
+.ui-sortable .heading
+        { display: inline-block; }
 .ui-draggable form
         { cursor: move; box-shadow: 0 0 3px #555 }
 


### PR DESCRIPTION
Fixes issue 2732 by setting the width of inputs in sortable lists to auto and headings to display as inline-block: http://code.google.com/p/otwarchive/issues/detail?id=2732
