### PR TITLE
Fix issue 2723 with link focus on keyboard navigation

### DIFF
--- a/public/stylesheets/site/2.0/02-elements.css
+++ b/public/stylesheets/site/2.0/02-elements.css
@@ -13,6 +13,8 @@ a:hover { color: #999}
 a:active, a:focus
         { outline:1px dotted}
 a img   { border: 0}
+a:focus img
+        { outline:1px dotted}
 
 h1, h2, h3, h4, h5, h6, .heading	
         { font-family: Georgia, serif; font-weight: 400}

--- a/public/stylesheets/site/2.0/03-region-header.css
+++ b/public/stylesheets/site/2.0/03-region-header.css
@@ -26,6 +26,8 @@ notice that CSS3 declarations sit on their own line and always come last*/
 #header h1 a, #header fieldset, #header form, #header p
         { background:none; color:#900; font-size:100%; border:0; padding:0; margin: 0;
           box-shadow:none }
+#header h1 a:focus img
+        { outline:none } 
 #greeting .icon 
         { float:right; padding:0; margin:0 0 -0.429em 0; border-bottom:5px solid #900}
 #greeting 

--- a/public/stylesheets/site/2.0/06-region-footer.css
+++ b/public/stylesheets/site/2.0/06-region-footer.css
@@ -7,7 +7,7 @@ http://media.transformativeworks.org/training/front_end_coding/patterns/supertyp
 #footer a   
         { background:transparent; color: #fff; border: 0; font-weight: 400; margin: auto; padding: 0
           box-shadow:none; }
-#footer a:hover
+#footer a:hover, #footer a:focus
         { background:#500;
           box-shadow:none }
 #footer p.beta
@@ -17,7 +17,7 @@ http://media.transformativeworks.org/training/front_end_coding/patterns/supertyp
           box-shadow: inset 2px 2px 2px #111;}
 #footer .secondary a 
         {  color: #900;} 
-#footer .secondary a:hover {
+#footer .secondary a:hover, #footer .secondary a:focus {
 background: transparent;
 }
 /*END== */

--- a/public/stylesheets/site/2.0/08-actions.css
+++ b/public/stylesheets/site/2.0/08-actions.css
@@ -30,7 +30,7 @@ ol.pagination
         { text-align:center; clear:right; margin:0.643em auto}
 .actions a:visited
         { color: #111; }
-.actions a:hover, .actions input:hover
+.actions a:hover, .actions input:hover, .actions a:focus, .actions input:focus
         { color:#900; border-top:1px solid #999; border-left:1px solid #999; 
           box-shadow:inset 2px 2px 2px #bbb  }
 .actions a:active, .current,a.current, .current a:visited


### PR DESCRIPTION
Fix issue 2723 with link focus when navigating with the tab key: http://code.google.com/p/otwarchive/issues/detail?id=2723

It was hard to see the dotted outline on inputs and button-style links, particularly those in the header, so now :focus gives the same depressed look as :hover.

Issue 2723 also mentions Reversi, so this fix might be incomplete. Do public skins get fixed this way or through admin? I'm pretty sure it's admin, but I might be wrong.
