### PR TITLE
Fixing warnings in tests for accented tags as per Rebecca's suggestion

### DIFF
--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -91,7 +91,7 @@ class Tag < ActiveRecord::Base
     if !self.new_record? && self.name_changed?
       # ordinary wranglers can change case and accents but not punctuation or the actual letters in the name
       # admins can change tags with no restriction
-      unless User.current_user.is_a?(Admin) || (self.name.downcase == self.name_was.downcase) || (self.name.mb_chars.normalize(:kd).gsub(/[^\x00-\x7F]/n,'').downcase.to_s == self.name_was.mb_chars.normalize(:kd).gsub(/[^\x00-\x7F]/n,'').downcase.to_s)
+      unless User.current_user.is_a?(Admin) || (self.name.downcase == self.name_was.downcase) || (self.name.mb_chars.normalize(:kd).gsub(/[^\x00-\x7F]/u,'').downcase.to_s == self.name_was.mb_chars.normalize(:kd).gsub(/[^\x00-\x7F]/u,'').downcase.to_s)
         self.errors.add(:name, "can only be changed by an admin.")
       end
     end


### PR DESCRIPTION
Issue 1551, this sorts out the unicode warnings.
