### PR TITLE
Fix issue 2751 with sortable list actions escaping the list item

### DIFF
--- a/public/stylesheets/site/2.0/07-interactions.css
+++ b/public/stylesheets/site/2.0/07-interactions.css
@@ -90,14 +90,17 @@ form li ul.autocomplete li.input
 
 /* WIDGET: SORTABLE LIST (note: hope to merge with .sortable and .draggable etc)*/
 .ui-sortable li 
-        { border: 2px solid transparent; box-shadow:1px 1px 3px transparent}
+        { border: 2px solid transparent; float: left; width: 100%; clear: right;
+          box-shadow:1px 1px 3px transparent }
 .ui-sortable li:hover 
         { background: #ddd; border: 2px solid #999; cursor:move;
           box-shadow:1px 1px 3px #bbb }
 .ui-sortable input
-        { width: auto; }
+        { margin: 0.429em 0 0.25em 0.25em; width: auto; }
 .ui-sortable .heading
         { display: inline-block; }
+.ui-sortable ul.actions li 
+        { float: none; }
 .ui-draggable form
         { cursor: move; box-shadow: 0 0 3px #555 }
 


### PR DESCRIPTION
Fix Issue 2751, where the actions on chapter reordering weren't staying inside the list item to which they belonged: http://code.google.com/p/otwarchive/issues/detail?id=2751

This also applies to any future ul.actions that appear inside sortable lists.
