### PR TITLE
Fix Issue 2759 by adding columns to fandoms list on static pages

### DIFF
--- a/app/views/static/fandoms/index.html.erb
+++ b/app/views/static/fandoms/index.html.erb
@@ -12,19 +12,21 @@
 
   <!--main content-->
   <% if @fandoms_by_letter && !@fandoms_by_letter.empty? %>
-    <ul class="alphabet">
+    <h3 class="landmark heading"><%= ts('Alphabet Navigation') %></h3>
+    <ul class="alphabet navigation actions" id="alphabet" role="navigation">
       <% for letter in @fandoms_by_letter.keys %>
         <li><%= link_to letter, "#letter-#{letter}" %></li>
       <% end %>
     </ul>
-    <ul class="letters shadowed <%= 'collection' if @collection %>">
+    <h3 class="landmark heading"><%= ts('Alphabetized List of Fandoms') %></h3>
+    <ol class="alphabet fandom index group <%= 'collection' if @collection %>">
       <% @fandoms_by_letter.each_pair do |letter, fandoms| %>
-        <li id='letter-<%= letter %>' class='letter'>
-          <h3 class="shadowed">
+        <li id='letter-<%= letter %>' class='letter listbox group'>
+          <h3 class="heading">
             <%= letter %>
-            <span class="top"><%= link_to "top", "#main" %></span>
+            <span class="action top"><%= link_to "top", "#main" %></span>
           </h3>
-          <ul class="fandom index">
+          <ul class="tags index group">
             <% for fandom in fandoms %>
             <li class='<%= cycle('odd', 'even', :name => "letter-#{letter}") %>'>
               <%= link_to(fandom.name, static_collection_fandom_path(@collection, fandom)) %>
@@ -36,9 +38,9 @@
           </ul>
         </li>
       <% end %>
-    </ul>
+    </ol>
   <% else %>
-    <h3 class="heading"><%= ts("No fandoms found") %></h3>
+    <h3 class="no_fandoms"><%= ts("No fandoms found") %></h3>
   <% end %>
   <!--/content-->
 </div>

--- a/public/stylesheets/static.css
+++ b/public/stylesheets/static.css
@@ -18,7 +18,7 @@ a, a:link, #header ul ul li a:link{color:#900;}
 
 #main {padding:0 2.5em;}
 h3,h4,h5,h6,p {line-height:1; margin:0.375em 0;}
-ul {margin:0 0.15em; text-indent:0; padding:0 }
+ul, ol {list-style: none; margin:0 0.15em; text-indent:0; padding:0 }
 li {margin: 0.643em 0;}
 
 ul li, .blurb li,.navigation>*,.stats>*,.meta ul li {list-style: none;display: inline;}
@@ -26,6 +26,6 @@ blockquote.summary {background:#eee; padding:0.25em; border:1px solid #ddd}
 li.blurb {margin:auto; border-top:1px solid #ccc;}
 .blurb dl.stats { background: #eee; font-size: 0.8575em; text-align: right; padding: 0 0.375em 0.375em; margin: 1.286em auto 0; }
 
-.letter h3 {background: #ddd;}
+h3.heading {background: #ddd; padding: 0.25em;}
 .letter ul.index li {width: 45%; float: left; clear: none; margin-right: 1.5em;}
 .letter ul.index:after {content: " "; display: block; height: 0; font-size: 0; clear: both; visibility: hidden;}


### PR DESCRIPTION
Fix issue 2759 by making dividing the alphabetical fandoms list into two columns on static pages: http://code.google.com/p/otwarchive/issues/detail?id=2759

Note: I'm pretty sure the XHTML for the static pages is from design 1.0. Do we want the XHTML updated to correspond with the new design?
