### PR TITLE
Fix issue 2786 to give wranglers their tag trees back

### DIFF
--- a/app/helpers/tags_helper.rb
+++ b/app/helpers/tags_helper.rb
@@ -169,7 +169,7 @@ module TagsHelper
         end
       end
     end
-    content_tag(:ul, meta_ul)
+    content_tag(:ul, meta_ul, :class => 'tags tree index')
   end
 
   # Returns a nested list of sub tags

--- a/public/stylesheets/site/2.0/19-zone-tags.css
+++ b/public/stylesheets/site/2.0/19-zone-tags.css
@@ -4,7 +4,7 @@ individual tags are shown in many contexts across the site and are styled in typ
 tags also have various states in roles-states.css (arguably a nomination is an embyronic tag)/
 
 /*TAGS SHOW */
-ul.tree { display: block }
+ul.tree, ul.tree li { display: block }
 .tag_wranglers-index #tag_wranglers 
         { width:75%; float:left}
         


### PR DESCRIPTION
Fixes issue 2786 where the sub tag lists were displaying inline and the meta tag lists were not nested: code.google.com/p/otwarchive/issues/detail?id=2786 

This resolves the issue by adding display: block to the list items for ul.tree and by adding the tag, tree, and index classes to the previously class-less meta tags ul.
