### PR TITLE
Fix issue 2761 with spacing between paragraphs and kudos button

### DIFF
--- a/public/stylesheets/static.css
+++ b/public/stylesheets/static.css
@@ -1,7 +1,7 @@
 ul#skiplinks, .landmark , .landmark a
 { border: 0; font-size: 0; line-height: 0; height: 0; margin: 0; clear:both; color:transparent; opacity:0; }
 .clear {clear:both;}
-body {padding:0; margin:0; font-size:0.875em}
+body {padding:0; margin:0; font: 100%/1.125 'Lucida Grande','Lucida Sans Unicode','GNU Unifont',Verdana,Helvetica,sans-serif;}
 a{color:#900;}
 a:visited {color:#555;}
 a:hover {color:#ddd;}
@@ -11,21 +11,23 @@ a:hover {color:#ddd;}
 #header a, #header a:link {color:#fff}
 a, a:link, #header ul ul li a:link{color:#900;}
 
-#header ul.navigation ul {position:absolute; margin-left:-999em; background: #fff; font-size:0.75em}
+#header ul.navigation ul {position:absolute; margin-left:-999em; background: #fff; font-size:0.5625em}
 #header ul.navigation:hover ul{position:absolute; margin:0 0 0 19.5em}
 #header ul ul li a{color:#900;;padding:0.5em; border:1px solid #555; display:block}
 #header ul ul li a:hover {background:#ddd; color:#000;}
 
-#main {padding:0 2.5em;}
+#main {padding:0 2.5em; font-size: 0.875em;}
 h3,h4,h5,h6,p {line-height:1; margin:0.375em 0;}
 ul, ol {list-style: none; margin:0 0.15em; text-indent:0; padding:0 }
 li {margin: 0.643em 0;}
 
 ul li, .blurb li,.navigation>*,.stats>*,.meta ul li {list-style: none;display: inline;}
-blockquote.summary {background:#eee; padding:0.25em; border:1px solid #ddd}
+blockquote.summary, p.message {background:#eee; padding:0.25em; border:1px solid #ddd}
 li.blurb {margin:auto; border-top:1px solid #ccc;}
 .blurb dl.stats { background: #eee; font-size: 0.8575em; text-align: right; padding: 0 0.375em 0.375em; margin: 1.286em auto 0; }
 
 h3.heading {background: #ddd; padding: 0.25em;}
 .letter ul.index li {width: 45%; float: left; clear: none; margin-right: 1.5em;}
 .letter ul.index:after {content: " "; display: block; height: 0; font-size: 0; clear: both; visibility: hidden;}
+
+.userstuff p {line-height: 1.5; margin: 1.286em auto;}


### PR DESCRIPTION
Issue 2761 states that the kudos button overwhelmed the line about commenting on static pages: http://code.google.com/p/otwarchive/issues/detail?id=2761

This fix changes the formatting of the 'please comment' message so the kudos button does not overpower it so much. It also separates the message from the story text by increasing the top and bottom margins and the line height on the story text (which, incidentally, makes the story text easier to read). 

As a bonus, the font of the static pages now matches the font on the rest of the archive, which makes the text appear larger and easier to read.
