### PR TITLE
Fix issue 2789 with #main div closing too early on collections form

### DIFF
--- a/app/views/collections/_form.html.erb
+++ b/app/views/collections/_form.html.erb
@@ -138,4 +138,3 @@
  <%= submit_fieldset collection_form %>
 
 <% end %>
-</div>


### PR DESCRIPTION
Fix issue 2789 with the #main div closing too early: http://code.google.com/p/otwarchive/issues/detail?id=2789

Fixed by removing stray closing div on new collections form.
