### PR TITLE
Fix issue 2790 with alphabetical pagination for people index

### DIFF
--- a/app/helpers/alphabet_helper.rb
+++ b/app/helpers/alphabet_helper.rb
@@ -60,7 +60,7 @@ module AlphabetHelper
       unless character.char == active_letter
         block << " " + link
       else
-        block << ' <span class="current">' + link + '</span>'
+        block << ' <span class="current">' + character.char + '</span>'
       end
     end
 

--- a/app/views/people/index.html.erb
+++ b/app/views/people/index.html.erb
@@ -5,7 +5,7 @@
 <p class="navigation actions" role="navigation"><%= link_to "People Search (Alpha)", search_people_path %></p> 
 <!--subnav-->
 
- <div title="alphabetical pagination actions"><%= alpha_paginated_section @pseuds_alphabet %></div>
+ <div class="alphabetical pagination navigation actions" role="navigation"><%= alpha_paginated_section @pseuds_alphabet %></div>
   <%= paginated_section @authors do %>
   <!--/subnav-->
  
@@ -19,12 +19,13 @@
   <!--/content-->
   
 <!--subnav-->
-<div class="alphabetical pagination navigation" role="navigation">
+<div class="alphabetical pagination navigation actions" role="navigation">
   <h3 class="landmark heading">Next Page Navigation</h3>
 <%= alpha_paginated_section @pseuds_alphabet %>
+</div>
 
 <% else %>
-  <div class="pagination" role="navigation">
+  <div class="alphabetical pagination navigation actions" role="navigation">
   <% for character in @navigation %>
     <a href="<%= person_path(character) %>"><%= character.char %></a>
   <% end %>

--- a/app/views/people/show.html.erb
+++ b/app/views/people/show.html.erb
@@ -8,7 +8,7 @@
   <li><%= link_to t('.people.Reccers', :default => "Reccers"), person_path(@character, :show => "reccers") %></li>
 </ul>
 
-<div title="alphabetical pagination actions">
+<div class="alphabetical pagination actions">
   <h5 class="landmark heading">By Letter</h5>
   <%= people_paginated_section(@what) %></div> 
 <%= paginated_section @people do %>

--- a/public/stylesheets/site/2.0/08-actions.css
+++ b/public/stylesheets/site/2.0/08-actions.css
@@ -26,7 +26,7 @@ p.submit, input.submit, dd.submit
         { cursor: text }
 /*subtypes and modes 
 test note: this pagination clear needs to be kept an eye on*/
-ol.pagination
+ol.pagination, div.pagination
         { text-align:center; clear:right; margin:0.643em auto}
 .actions a:visited
         { color: #111; }

--- a/public/stylesheets/site/2.0/18-zone-searchbrowse.css
+++ b/public/stylesheets/site/2.0/18-zone-searchbrowse.css
@@ -6,7 +6,7 @@ Arguably filter and search could be styled in interactions but I've put them her
 /* INDEX PAGES (with filters)*/ 
 .works-index .index, .collections-index .index 
         { width:75%; float:left}
-.works-index ol.pagination, .index + h4.landmark
+.works-index ol.pagination, .people-index ol + div.pagination, .index + h4.landmark
         { clear: both; }        
 .media-index .listbox
         { min-height:17.5em;}


### PR DESCRIPTION
Fix issue 2790 with a missing closing div and missing classes on people pages' alphabetical pagination: http://code.google.com/p/otwarchive/issues/detail?id=2790

This kind of snowballed. The title-instead-of-class issue in people/index also appeared in people/show, and once the classes were added, the CSS and the alphabet helper both needed to be tweaked so the newly-styled alphabetical pagination displayed properly.
