### PR TITLE
Fix issue 2802 by removing user name from deleted comment placeholder

### DIFF
--- a/app/views/comments/_single_comment.html.erb
+++ b/app/views/comments/_single_comment.html.erb
@@ -9,7 +9,7 @@
   <% else %>
     <% if single_comment.is_deleted %>
       <p>
-        (<%= ts("previous comment by %{name} deleted", :name => get_commenter_pseud_or_name(single_comment)) %>)
+        (<%= ts("Previous comment deleted.") %>)
       </p>
     <% elsif single_comment.hidden_by_admin? && !logged_in_as_admin? %>
       <p class="message">(<%= ts("This comment is under review by an admin and is currently unavailable.") %>)</p>

--- a/features/comments_delete.feature
+++ b/features/comments_delete.feature
@@ -1,0 +1,50 @@
+@comments
+Feature: Delete a comment
+  In order to remove a comment from public view
+  As a user
+  I want to be able to delete a comment I added
+  As an author
+  I want to be able to delete a comment a reader added to my work
+  
+  Scenario: User deletes a comment they added to a work
+    When I am logged in as "author"
+      And I post the work "Awesome story"
+    When I am logged in as "commenter"
+      And I post the comment "Fail comment" on the work "Awesome story"
+      And I delete the comment
+    Then I should see "Comment deleted."
+    
+  Scenario: User deletes a comment they added to a work and which is the parent of another comment
+    When I am logged in as "author"
+      And I post the work "Awesome story"
+    When I am logged in as "commenter1"
+      And I post the comment "Fail comment" on the work "Awesome story"
+      And I reply to a comment with "I didn't mean that"
+      And I delete the comment
+    Then I should see "Comment deleted."
+      And I should see "(Previous comment deleted.)"
+      And I should see "I didn't mean that"
+      
+  Scenario: Author deletes a comment another user added to their work
+    When I am logged in as "author"
+      And I post the work "Awesome story"
+    When I am logged in as "commenter"
+      And I post the comment "Fail comment" on the work "Awesome story"
+    When I am logged in as "author"
+      And I view the work "Awesome story" with comments
+      And I delete the comment
+    Then I should see "Comment deleted."
+    
+  Scenario: Author deletes a parent comment that another user added to their work
+    When I am logged in as "author"
+      And I post the work "Awesome story"
+    When I am logged in as "commenter"
+      And I post the comment "Fail comment" on the work "Awesome story"
+      And I reply to a comment with "I didn't mean that"
+    When I am logged in as "author"
+      And I view the work "Awesome story" with comments
+      And I delete the comment
+    Then I should see "Comment deleted."
+      And I should see "(Previous comment deleted.)"
+      And I should see "I didn't mean that"
+  

--- a/features/step_definitions/comment_steps.rb
+++ b/features/step_definitions/comment_steps.rb
@@ -102,6 +102,11 @@ Morbi vitae lacus vitae magna volutpat pharetra rhoncus eget nisi. Proin vehicul
   end
 end
 
+When /^I delete the comment$/ do
+  When %{I follow "Delete" within ".odd"}
+    And %{I follow "Yes, delete!"}
+end
+
 Then /^I should see the reply to comment form$/ do
   Then %{I should see "Comment as" within ".odd"}
 end

--- a/features/step_definitions/work_steps.rb
+++ b/features/step_definitions/work_steps.rb
@@ -86,6 +86,11 @@ When /^I view the work "([^\"]*)"(?: in (full|chapter-by-chapter) mode)?$/ do |w
   When %{I follow "View chapter by chapter"} if mode == "chapter-by-chapter"
 end
 
+When /^I view the work "([^\"]*)" with comments$/ do |work|
+  work = Work.find_by_title!(work)
+  visit work_url(work, :anchor => "comments", :show_comments => true)
+end
+
 When /^I edit the work "([^\"]*)"$/ do |work|
   work = Work.find_by_title!(work)
   visit edit_work_url(work)


### PR DESCRIPTION
Fix for issue 2802 http://code.google.com/p/otwarchive/issues/detail?id=2802 

This removes the name of the user who posted the deleted comment from the deleted comment placeholder. It also includes a comments_delete.feature.
