### PR TITLE
Modify fix for Issue 2751 by clearing list items in IE7

### DIFF
--- a/public/stylesheets/site/2.0/07-interactions.css
+++ b/public/stylesheets/site/2.0/07-interactions.css
@@ -90,7 +90,7 @@ form li ul.autocomplete li.input
 
 /* WIDGET: SORTABLE LIST (note: hope to merge with .sortable and .draggable etc)*/
 .ui-sortable li 
-        { border: 2px solid transparent; float: left; width: 100%; clear: right;
+        { border: 2px solid transparent; float: left; width: 100%; clear: both;
           box-shadow:1px 1px 3px transparent }
 .ui-sortable li:hover 
         { background: #ddd; border: 2px solid #999; cursor:move;

--- a/public/stylesheets/site/2.0/31-role-ie7.css
+++ b/public/stylesheets/site/2.0/31-role-ie7.css
@@ -17,4 +17,4 @@ span.replied. span.unreviewed, .actions a, .action, .symbol
 /*hL clearfixes
 test note: these were put in last minute so might need redoing
 http://www.stuffandnonsense.co.uk/archives/clearing_floats_without_structural_markup_in_ie7.html*/
-.group {zoom:1;}
+.group, .ui-sortable {zoom:1;}


### PR DESCRIPTION
Modifies the fix for Issue 2751 so the chapter list doesn't scroll horizontally in IE7: http://code.google.com/p/otwarchive/issues/detail?id=2751
