### PR TITLE
Issue 2184, adding date to fields allowed to contain <

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -181,7 +181,7 @@ NONZERO_INTEGER_PARAMETERS:
   per_page: 25
 
 # These fields are query fields and are allowed to contain "less than" values
-FIELDS_ALLOWING_LESS_THAN: ["query", "words", "kudos", "hits"]
+FIELDS_ALLOWING_LESS_THAN: ["query", "words", "kudos", "hits", "date"]
 
 
 # Only the following fields are allowed to have HTML. In all others,


### PR DESCRIPTION
allows less than to be used in the date field for advanced searches

http://code.google.com/p/otwarchive/issues/detail?id=2184&q=Difficulty%3DEasy&colspec=ID%20Roadmap%20Type%20Status%20Release%20Milestone%20Owner%20Component%20Priority%20Summary
