### PR TITLE
issue 2480 removing open id link from new account registration page

### DIFF
--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -24,12 +24,6 @@
     <%= render :partial => "openid", :locals => {:f => f} %>
   <% else %>
 
-    <% if ArchiveConfig.USE_OPENID %>
-      <p class="actions" role="navigation">
-        <%= link_to ts('Sign up using OpenID'), new_user_path(:use_openid => true, :invitation_token => @user.invitation_token) %>
-      </p>
-    <% end %>
-
     <fieldset>
       <legend><%= ts("User Details") %></legend>
       <%= render :partial => "passwd", :locals => {:f => f} %>


### PR DESCRIPTION
removing the link to open id for new accounts as a first step toward phasing out open id

http://code.google.com/p/otwarchive/issues/detail?id=2480&can=3&colspec=ID%20Roadmap%20Type%20Status%20Release%20Milestone%20Owner%20Component%20Priority%20Summary
