### PR TITLE
Fix Issue 2840 with link color of visited fandom tags on profiles

### DIFF
--- a/public/stylesheets/site/2.0/10-types-groups.css
+++ b/public/stylesheets/site/2.0/10-types-groups.css
@@ -5,7 +5,7 @@ http://media.transformativeworks.org/training/front_end_coding/patterns/supertyp
 /*TYPE: TAGS */
 a.tag, .tags a
         { color: #111; line-height:1.5; text-decoration:none; padding: 0 0.125em; border-bottom:1px dotted}
-a.tag:hover	
+a.tag:hover, .listbox .heading a.tag:visited:hover	
         { background: #900; color: #fff }
 .tags li{ display:inline}
 .filters .tags li, .review .tags


### PR DESCRIPTION
Fix issue 2840 by setting the text color on :visited:hover tags in listbox headings to white: http://code.google.com/p/otwarchive/issues/detail?id=2840
