### PR TITLE
Fix issue 2810 with missing icon on skins show pages

### DIFF
--- a/public/stylesheets/site/2.0/17-zone-home.css
+++ b/public/stylesheets/site/2.0/17-zone-home.css
@@ -19,7 +19,7 @@ user home, collections and challenges home, tag home, admin comms home
 .collection .primary .icon
         { background: url("/images/skins/iconsets/default/icon_collection.png")}
 .skins .primary .icon
-        { background: url("/images/skins/iconsets/default/icon_skins.jpeg")}
+        { background: url("/images/skins/iconsets/default/icon_skins.png")}
 .admin .primary .icon
         { background: url("/images/skins/iconsets/default/icon_admin.jpeg")}
 .tag .primary .icon, .tagset .primary .icon


### PR DESCRIPTION
Fix issue 2810 where no icon was appearing on the skins show pages because the background URL had the wrong file extension: http://code.google.com/p/otwarchive/issues/detail?id=2810
