### PR TITLE
Fix issue 2755 by creating a large class for textareas

### DIFF
--- a/app/views/skins/_form.html.erb
+++ b/app/views/skins/_form.html.erb
@@ -30,7 +30,7 @@
 <fieldset>
   <legend>CSS</legend>
   <h3 class="heading"><%= f.label :css, ts('CSS') %> <%= link_to_help "skins-creating" %></h3>
-    <p><%= f.text_area :css, :cols => 70 %></p>        
+    <p><%= f.text_area :css, :cols => 70, :class => "large" %></p>        
 </fieldset>
   
 <fieldset class="verbose<%= (@skin.type || params[:skin_type]) == 'WorkSkin' ? ' hidden' : ''%>">

--- a/app/views/works/_standard_form.html.erb
+++ b/app/views/works/_standard_form.html.erb
@@ -275,7 +275,7 @@
           <% use_tinymce %>
           <div class="rtf-html-field">
             <h4 class="landmark heading"><%= ts('Work Text *') %></h4>
-            <%= c.text_area :content, :value => @chapter.content, :class => "mce-editor observe_textlength", :id => "content" %>
+            <%= c.text_area :content, :value => @chapter.content, :class => "mce-editor observe_textlength large", :id => "content" %>
             <%= live_validation_for_field('content',
               :maximum_length => ArchiveConfig.CONTENT_MAX, :minimum_length => ArchiveConfig.CONTENT_MIN,
               :tooLongMessage => ts('We salute your ambition! But sadly the content must be less than %{max} characters long. (Maybe you want to create a multi-chaptered work?)', :max => ArchiveConfig.CONTENT_MAX.to_s),

--- a/public/stylesheets/site/2.0/07-interactions.css
+++ b/public/stylesheets/site/2.0/07-interactions.css
@@ -33,6 +33,7 @@ input,textarea
         { font-size:100%; width:100%; border:1px solid #bbb;
           box-shadow: inset 0 1px 2px #ccc }
 textarea{ min-height:12em}
+textarea.large { height: 36em; }
 input:focus, select:focus, textarea:focus
         { background:#f3efec }
 input[type="radio"] + label, input[type="checkbox"] + label
@@ -149,7 +150,7 @@ div.dynamic
 .post .required .warnings
         { font-weight:normal; color:#2a2a2a}
 .post .text textarea
-        { height: 36em; clear:right}
+        { clear:right}
 
 /* CONTEXT: dashboard*/
 .dashboard fieldset 


### PR DESCRIPTION
Fix issue 2755 by creating a .large class with a height of 36em and adding it to the work text and CSS textareas: http://code.google.com/p/otwarchive/issues/detail?id=2755
