### PR TITLE
Fix issue 2851 with font size in textarea

### DIFF
--- a/public/stylesheets/site/2.0/07-interactions.css
+++ b/public/stylesheets/site/2.0/07-interactions.css
@@ -30,7 +30,7 @@ legend, input[type="hidden"]
         { height:0; width:0; font-size:0; opacity:0; padding:0; margin:0}
 label   { cursor: pointer; margin-right:0.375em; }
 input,textarea   
-        { font-size:100%; width:100%; border:1px solid #bbb;
+        { font: 100% 'Lucida Grande', 'Lucida Sans Unicode', 'GNU Unifont', Verdana, Helvetica, sans-serif; width:100%; border:1px solid #bbb;
           box-shadow: inset 0 1px 2px #ccc }
 textarea{ min-height:12em}
 textarea.large { height: 36em; }


### PR DESCRIPTION
Fix issue 2851 with small font in the comment text area on Firefox: http://code.google.com/p/otwarchive/issues/detail?id=2851
