### PR TITLE
adjust blurb spacing on works with no summary

### DIFF
--- a/public/stylesheets/site/2.0/10-types-groups.css
+++ b/public/stylesheets/site/2.0/10-types-groups.css
@@ -56,7 +56,7 @@ li.relationships
 .icon a { border:0;}
 .mods li, dl.stats dt, dl.stats dd
         { background:none; width:auto; min-width:0; display:inline; clear:none; float:none; margin:auto;}
-dl.stats{ text-align:right; background:none; box-shadow:none; }
+dl.stats{ text-align:right; background:none; box-shadow:none; margin-top:0.675em;}
 dl.stats dd 
         { white-space:nowrap; padding-right:0.5em; }
 


### PR DESCRIPTION
On works with no summary, the edit buttons and the stats row in Archive 2.0 collide with the bottom row of tags. Adding a small margin-top to dl.stats forces a minimal space without introducing too large a visual gap.

http://code.google.com/p/otwarchive/issues/detail?id=2873
