### PR TITLE
Fix issue 2865 with missing class on tag_index's Most Poplar nav action

### DIFF
--- a/app/views/tags/index.html.erb
+++ b/app/views/tags/index.html.erb
@@ -5,13 +5,7 @@
   <ul role="navigation" class="navigation actions" role="navigation">
     <li class="search"><%= render 'tags/search_form' %></li>
     <% if logged_in? %><li><%= link_to ts("Tag Sets"), tag_sets_path %></li><% end %>
-    <li>
-      <% if params[:show] == "random" %>
-        <%= link_to ts('Most Popular'), tags_path %>
-      <% else %>
-        <%= span_if_current ts('Most Popular'), tags_path %>
-      <% end %>
-    </li>
+    <li><%= span_if_current(ts('Most Popular'), tags_path, params[:show].blank?) %></li>
     <li><%= span_if_current ts('Random'), tags_path(:show => "random") %></li>
   </ul>
 <% end %>


### PR DESCRIPTION
Fixes issue 2865 by adding a .current span to the Most Popular navigation action on the tags index: http://code.google.com/p/otwarchive/issues/detail?id=2865

I feel like there might be a shorter, more direct way to accomplish this -- something that will apply the span just on archiveofourown.org/tags, not archiveofourown.org/tags?show=random -- but I'm not sure what.
