### PR TITLE
Revised: adjust blurb spacing on works with no summary 

### DIFF
--- a/public/stylesheets/site/2.0/10-types-groups.css
+++ b/public/stylesheets/site/2.0/10-types-groups.css
@@ -215,6 +215,7 @@ li.relationships {
 dl.stats {
   text-align: right;
   background: none;
+  margin-top: .643em;
     box-shadow: none;
 }
 


### PR DESCRIPTION
See also pull 451. 

On works with no summary, the edit buttons and the stats row in Archive 2.0 collide with the bottom row of tags. Adding a small margin-top to dl.stats forces a minimal space without introducing too large a visual gap.

http://code.google.com/p/otwarchive/issues/detail?id=2873

Margin value decreased to align with site style.

(Does @ work, @sarken ?)
