### PR TITLE
Fix issue 2846 with Rules button for collections displaying as en, Rules

### DIFF
--- a/app/views/collection_profile/_navigation.html.erb
+++ b/app/views/collection_profile/_navigation.html.erb
@@ -8,7 +8,7 @@
 	<li><a href="#faq"><%= ts("FAQ") %></a></li>
 	<% end %>
 	<% if show_collection_section(@collection, "rules") && section != "rules" %>
-	<li><a href="#rules"><%= t("Rules") %></a></li>
+	<li><a href="#rules"><%= ts("Rules") %></a></li>
 	<% end %>
 </ul>
 <% end %>


### PR DESCRIPTION
The Rules button on collection profiles was display as "en, Rules" instead of just "Rules," and this change puts it back to plain ol' "Rules": http://code.google.com/p/otwarchive/issues/detail?id=2846
