### PR TITLE
Fixed mixed-up rating icons for Issue 2843

### DIFF
--- a/public/stylesheets/site/2.0/13-group-blurb.css
+++ b/public/stylesheets/site/2.0/13-group-blurb.css
@@ -125,11 +125,11 @@ li.blurb:after {
 /*icon image replacement*/
 
 .blurb .rating-general-audience {
-  background: url("/images/imageset.png") -75px -25px;
+  background: url("/images/imageset.png") -50px -25px;
 }
 
 .blurb .rating-explicit {
-  background: url("/images/imageset.png") -50px -25px;
+  background: url("/images/imageset.png") -25px -25px;
 }
 
 .blurb .rating-mature {


### PR DESCRIPTION
As I noted in the comments of pull request 445 for issue 2843, I got some of the ratings icons mixed up in the sprites conversion. This fixes that.

Issue: http://code.google.com/p/otwarchive/issues/detail?id=2843
Note: https://github.com/otwcode/otwarchive/pull/445
