### PR TITLE
gcode 2873: add margin-top on .blurb stats

### DIFF
--- a/public/stylesheets/site/2.0/10-types-groups.css
+++ b/public/stylesheets/site/2.0/10-types-groups.css
@@ -195,6 +195,7 @@ li.relationships {
 dl.stats {
   text-align: right;
   background: none;
+  margin-top: 0.643em;
     box-shadow: none;
 }
 


### PR DESCRIPTION
On works with no summary, the edit buttons and the stats row in Archive 2.0 collide with the bottom row of tags. Adding a small margin-top to dl.stats forces a minimal space without introducing too large a visual gap.

Okay, I think I've got git re-set on my end so that it will behave.

NB: @shalott - vim did something with the eof that I do not recognize at all. (I am seriously looking at a knife at the moment.)
