### PR TITLE
making filter_tagging have a composite index

### DIFF
--- a/app/models/filter_tagging.rb
+++ b/app/models/filter_tagging.rb
@@ -4,16 +4,23 @@
 class FilterTagging < ActiveRecord::Base
   belongs_to :filter, :class_name => 'Tag'
   belongs_to :filterable, :polymorphic => true
-  
+
   validates_presence_of :filter, :filterable
-  
+
+  def self.find(*args)
+    raise "id is not guaranteed to be unique. please install composite_primary_keys gem and set the primary key to id,filter_id"
+  end
+  def self.find_by_id(id)
+    raise "id is not guaranteed to be unique. please install composite_primary_keys gem and set the primary key to id,filter_id"
+  end
+
   # Is this a valid filter tagging that should actually exist?
   def should_exist?
     return false unless self.filter && self.filter.canonical?
     tags = [self.filter] + self.filter.mergers + self.filter.meta_tags
     !(self.filterable.tags & tags).empty?
-  end 
-  
+  end
+
   # Remove all invalid filter taggings
   def self.remove_invalid
     i = self.count
@@ -21,42 +28,42 @@ class FilterTagging < ActiveRecord::Base
       begin
         puts "Checking #{i}"
         unless filter_tagging.should_exist?
-          filter_tagging.destroy       
+          filter_tagging.destroy
         end
         i = i - 1
       rescue
-        "Problem with filter tagging #{filter_tagging.id}"
+        "Problem with filter tagging id:#{filter_tagging.id} filter_id:#{filter_tagging.filter_id}"
       end
     end
-  end  
-  
+  end
+
   # Build all filter taggings from current taggings data
   def self.build_from_taggings
     Tagging.find(:all, :conditions => {:taggable_type => 'Work'}).each do |tagging|
       print "." if tagging.id.modulo(10) == 0; STDOUT.flush
       if tagging.tagger && tagging.taggable
         tag = tagging.tagger.canonical? ? tagging.tagger : tagging.tagger.merger
-        if tag && tag.canonical? 
+        if tag && tag.canonical?
           tag.filter_taggings.create!(:filterable => tagging.taggable)
         end
       end
-    end 
+    end
   end
-  
+
   def self.update_filter_counts_since(date)
     if date
-      filters = FilterTagging.find(:all, :include => :filter, :conditions => ["created_at > ?", date]).collect(&:filter).compact.uniq
+      filters = FilterTagging.includes(:filter).where("created_at > ?", date).collect(&:filter).compact.uniq
       count = filters.length
       filters.each_with_index do |filter, i|
-        begin 
+        begin
           filter.reset_filter_count
           puts "Updating filter #{i + 1} of #{count} - #{filter.name}"
         rescue
-          puts "Did not update filter #{i + 1} of #{count} - #{filter.name}"         
+          puts "Did not update filter #{i + 1} of #{count} - #{filter.name}"
         end
       end
     else
       raise "date not set for filter count suspension! very bad!"
     end
-  end  
+  end
 end

--- a/db/migrate/20120131225520_filter_tagging_primary_key.rb
+++ b/db/migrate/20120131225520_filter_tagging_primary_key.rb
@@ -1,0 +1,11 @@
+class FilterTaggingPrimaryKey < ActiveRecord::Migration
+  def self.up
+     execute "ALTER TABLE `filter_taggings` DROP INDEX `primary`, ADD PRIMARY KEY (`id`,`filter_id`);"
+#     execute "ALTER TABLE `filter_taggings` PARTITION BY KEY(`filter_id`) PARTITIONS 16;"
+  end
+
+  def self.down
+#     execute "ALTER TABLE `filter_taggings` REMOVE PARTITIONING;"
+     execute "ALTER TABLE `filter_taggings` DROP INDEX `primary`, ADD PRIMARY KEY (`id`);"
+  end
+end


### PR DESCRIPTION
from james:
around 22% improvement can be made by making the primary key include filter_id,
additionally partitioning that table on filter_id helps the query by around 32%.
I would recommend letting the system bed down for a week or so before we do the partitioning

my thoughts:

As far as I can tell, the only problem with not having id be the primary key all by itself (which is what rails expects) is that it might not be unique, and rails is expecting it to be. Because the id field is auto_increment and the primary key is identified with id first, we won't end up with two FilterTagging records with the same id except with a direct sql insert. 

If we did have duplicate FilterTagging ids, this would only be a problem if we were trying to access and manipulate individual FilterTagging records which were found by id. We don't currently do so. Just in case we decide to do so in the future, I've modified the find statements for FilterTagging to trigger an exception and a reminder to install the composite_primary_keys gem. I didn't install the gem because I think it adds too much complexity and is overkill for our situation. Besides, I couldn't get it to work :)
