### PR TITLE
Fix issue 2862 by adding large class to new chapters textarea

### DIFF
--- a/app/views/chapters/_chapter_form.html.erb
+++ b/app/views/chapters/_chapter_form.html.erb
@@ -82,7 +82,7 @@
 	    </p>
   
   <div class="rtf-html-field">
-    <%= f.text_area :content, :class => "mce-editor", :id => "content", :class => "observe_textlength" %>
+    <%= f.text_area :content, :class => "mce-editor", :id => "content", :class => "observe_textlength large" %>
     <%= live_validation_for_field('content', 
           :maximum_length => ArchiveConfig.CONTENT_MAX, 
           :minimum_length => ArchiveConfig.CONTENT_MIN, 


### PR DESCRIPTION
Fix issue 2862 where the textarea for adding a new chapter's text was too small: http://code.google.com/p/otwarchive/issues/detail?id=2862
