### PR TITLE
Fix issue 2746 with position of inbox pagination

### DIFF
--- a/app/views/inbox/show.html.erb
+++ b/app/views/inbox/show.html.erb
@@ -71,8 +71,6 @@
     <!-- coming soon <%= submit_tag ts("mass reply") %> -->
   <% end %> <!-- end of inbox form -->
 
-  <%= will_paginate @inbox_comments %>
-
   <!-- we can't open comment forms inside the inbox form, which is why this is down here -->
   <!-- this div will contain the reply-to-comment form -->
   <div id="reply-to-comment" class="dynamic hidden"></div> 
@@ -128,3 +126,5 @@
   <% end %>
 <% end %>
 <!--/subnav-->
+
+<%= will_paginate @inbox_comments %>

--- a/public/stylesheets/site/2.0/17-zone-home.css
+++ b/public/stylesheets/site/2.0/17-zone-home.css
@@ -64,6 +64,10 @@ user home, collections and challenges home, tag home, admin comms home
   width: 75%;
 }
 
+.dashboard form.filters + h4.landmark {
+  clear: left;
+}
+
 /*HISTORY note:listbox? generalise this irregular structure*/
 
 .readings-index h3 {


### PR DESCRIPTION
Fix issue 2746 with the bottom pagination on inbox pages appearing above the filters: http://code.google.com/p/otwarchive/issues/detail?id=2746
