### PR TITLE
Fix issue 2882 with profile page module having a shadow

### DIFF
--- a/public/stylesheets/site/2.0/17-zone-home.css
+++ b/public/stylesheets/site/2.0/17-zone-home.css
@@ -51,6 +51,10 @@ user home, collections and challenges home, tag home, admin comms home
 
 /*contexts*/
 
+.profile .primary {
+  float: none;
+}
+
 /*(no filters)*/
 
 .dashboard.collections-index .index {


### PR DESCRIPTION
Fixes issue 2882 with the shadow from the meta creeping upward behind the module on profile pages: http://code.google.com/p/otwarchive/issues/detail?id=2882
