### PR TITLE
Clarification of ToS FAQ question: minimal ratings

### DIFF
--- a/app/views/home/tos_faq.html.erb
+++ b/app/views/home/tos_faq.html.erb
@@ -210,7 +210,7 @@
 			</p>
 			<h5 id="why_minimal">The ratings/warnings policy is really minimal.  Why is this?
 			</h5>
-			<p>We believe that appropriate ratings and warnings are often in the eye of the beholder.  Users who feel that a fanwork lacks an appropriate rating/warning are encouraged to try to resolve the issue with the creator. Users may also add tags of their own to a fanwork, which other users can consult for more information.
+			<p>We believe that appropriate ratings and warnings are often in the eye of the beholder.  Users who feel that a fanwork lacks an appropriate rating/warning are encouraged to try to resolve the issue with the creator. Users may also add tags of their own to on-site bookmarks of a fanwork, which other users can consult for more information. When those tags are present, you can click on the "Bookmarks" link at the top of the work to see them.
 			</p>
 			<h5 id="ratings_vs_warnings">What's the difference between ratings and warnings?
 			</h5>


### PR DESCRIPTION
As per email discussion with Rebecca Tushnet of Content Policy, additional clarification of a sentence under "The ratings/warnings policy is really minimal.  Why is this?" is provided, as well as the addition of a follow-up sentence. 

(Edit submitted through github as per https://123.writeboard.com/3fcf70d279f7b0655)

Sam J. Support, Wrangling, Troublemaking.
