### PR TITLE
Fixing issue 2806: syntax error causing problems after activation.

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -249,7 +249,7 @@ class UsersController < ApplicationController
       @user = User.find_by_activation_code(params[:id])
       if @user
         if @user.active?
-          flash[:error].now = ts("Your account has already been activated.")
+          flash.now[:error] = ts("Your account has already been activated.")
           redirect_to @user and return
         end
         @user.activate && UserMailer.activation(@user.id).deliver


### PR DESCRIPTION
Fixing issue 2806: syntax error causing problems after activation.

http://code.google.com/p/otwarchive/issues/detail?id=2806
