### PR TITLE
Fixing issue 2731: tag set and challenge form tag problem

### DIFF
--- a/app/views/prompts/_prompt_form_tag_options.html.erb
+++ b/app/views/prompts/_prompt_form_tag_options.html.erb
@@ -42,7 +42,7 @@
           <fieldset class="<%= ts("#{tag_type}") %> listbox">
             <h4 class="heading"><%= ts("#{tag_type.pluralize}") %></h4>
             <%= checkbox_section tag_set_form, "#{tag_type}_tagnames", 
-              (restriction.has_tags?(tag_type) ? restriction.tags(tag_type) : tag_type.classify.constantize.all).map {|t| t.name},
+              (restriction.has_tags?(tag_type) ? restriction.tags(tag_type) : tag_type.classify.constantize.canonical).map {|t| t.name},
               :checked_method => "#{tag_type}_tagnames", :value_method => "to_s", :name_method => "to_s" %>
           </fieldset>
     


### PR DESCRIPTION
Fixing issue 2731: don't display noncanonical ratings/warnings/categories on tag set and challenge forms.

http://code.google.com/p/otwarchive/issues/detail?id=2731
