### PR TITLE
Issue 1533: tag comment visibility

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -22,7 +22,7 @@ class CommentsController < ApplicationController
   end
 
   def check_tag_wrangler_access
-    if @commentable.is_a?(Tag)
+    if @commentable.is_a?(Tag) || (@comment && @comment.commentable.is_a?(Tag))
       logged_in_as_admin? || permit?("tag_wrangler") || access_denied
     end
   end


### PR DESCRIPTION
Issue 1533: tag comments should only be visible to authorized users even with direct url.

http://code.google.com/p/otwarchive/issues/detail?id=1533
