### PR TITLE
Issue 1404: Allow users to save changes to work and chapter drafts

### DIFF
--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -398,7 +398,7 @@ class WorksController < ApplicationController
             @included = 0
           end
         end
-        @work.posted = true
+        @work.posted = true if params[:post_button]
         @work.minor_version = @work.minor_version + 1
         @work.set_challenge_info
         saved = @work.save

--- a/app/views/chapters/preview_edit.html.erb
+++ b/app/views/chapters/preview_edit.html.erb
@@ -7,13 +7,14 @@
   <%= render :partial => 'hidden_fields', :locals => {:form => f} %>
 
   <p class="submit actions">
-  	<% if @chapter.posted? %>
-		<%= submit_tag t('.forms.update', :default => 'Update'), :name => 'update_button' %>
-	<% else %>
-		<%= submit_tag t('.forms.post', :default => 'Post'), :name => 'post_button' %>
-	<% end %>
-    <%= submit_tag t('.forms.edit', :default => 'Edit'), :name => 'edit_button' %>
-    <%= submit_tag t('.forms.cancel', :default => 'Cancel'), :name => 'cancel_button' %> 
+    <% if @chapter.posted? %>
+      <%= submit_tag ts('Update'), :name => 'update_button' %>
+    <% else %>
+      <%= submit_tag ts('Post'), :name => 'post_button' %>
+      <%= submit_tag ts("Save Without Posting"), :name => 'save_button' %>
+    <% end %>
+    <%= submit_tag ts('Edit'), :name => 'edit_button' %>
+    <%= submit_tag ts('Cancel'), :name => 'cancel_button' %> 
   </p>
 
 <% end %>

--- a/app/views/works/preview.html.erb
+++ b/app/views/works/preview.html.erb
@@ -34,15 +34,16 @@
   <%= render :partial => 'hidden_fields', :locals => {:form => f} %>
 
   <fieldset>
-    <legend><%= t('.post_work', :default => 'Post Work') %></legend>
+    <legend><%= ts('Post Work') %></legend>
     <p class="submit cancel edit actions">
-  	<% if @work.posted? %>
-  		<%= submit_tag t('.forms.update', :default => 'Update'), :name => 'update_button' %>
-  	<% else %>
-  		<%= submit_tag t('.forms.post', :default => 'Post'), :name => 'post_button' %>
-  	<% end %>
-      <%= submit_tag t('.forms.edit', :default => 'Edit'), :name => 'edit_button' %>
-      <%= submit_tag t('.forms.cancel', :default => 'Cancel'), :name => 'cancel_button' %> 
+      <% if @work.posted? %>
+        <%= submit_tag ts('Update'), :name => 'update_button' %>
+      <% else %>
+        <%= submit_tag ts('Post'), :name => 'post_button' %>
+        <%= submit_tag ts('Save Without Posting'), :name => 'save_button' %>
+      <% end %>
+      <%= submit_tag ts('Edit'), :name => 'edit_button' %>
+      <%= submit_tag ts('Cancel'), :name => 'cancel_button' %> 
     </p>
   </fieldset>
 


### PR DESCRIPTION
Issue 1404: Allow users to save changes to work and chapter drafts without posting them.

This still needs design and usability love at some point - the draft workflow should be clearer to users.

http://code.google.com/p/otwarchive/issues/detail?id=1404
