### PR TITLE
Fix Issue 2904 with mystery blurb icon in reading history

### DIFF
--- a/public/stylesheets/sandbox.css
+++ b/public/stylesheets/sandbox.css
@@ -52,7 +52,16 @@ span.delete a {
     float: left; 
 }
 
-
+/* TEMP FIX Issue 2904
+this should be revisted upon completeing the review of the reading index's XHTML */
+.history .mystery .icon {
+  position: absolute;
+  top: 0;
+  height: 55px;
+  width: 55px;
+  background-repeat: no-repeat;
+  background: url("/images/imageset.png") -110px -525px;
+}
 
 /* INTERACTIONS MODE: VERBOSE
 forms with more than three fieldsets 


### PR DESCRIPTION
Fix issue 2904 with the user icon displaying in place of the mystery work icon in the reading history page: http://code.google.com/p/otwarchive/issues/detail?id=2904

I put this in the sandbox instead of blurb because the reading index is marked with "REVIEW: IS THIS AN INDEX, LISTBOX, or MODULE?" comments before each item, and if we decide it's an index, this fix will become redundant.
