### PR TITLE
Fix issue 2899 with length of chapter title field on new work form

### DIFF
--- a/app/views/works/_standard_form.html.erb
+++ b/app/views/works/_standard_form.html.erb
@@ -183,7 +183,7 @@
             <dt><%= ts('Chapter 1 of') %></dt>
             <dd><%= f.text_field :wip_length, :class => "number" %></dd>
             <dt><%= ts('Chapter Title:') %></dt>
-            <dd><%= c.text_field :title, :class => "number", :value => @chapter.title %></dd>
+            <dd><%= c.text_field :title, :value => @chapter.title %></dd>
           </dl>
         </fieldset>
       </dd>


### PR DESCRIPTION
Fix issue 2899 where the chapter title input field was only displaying 4 characters on the post new form: http://code.google.com/p/otwarchive/issues/detail?id=2899
