### PR TITLE
Fix issue 2900 by adding icon class to tag wrangler icon paragraph

### DIFF
--- a/app/views/tag_wranglers/show.html.erb
+++ b/app/views/tag_wranglers/show.html.erb
@@ -2,7 +2,7 @@
 <div class="primary header module">
 <!--Descriptive page name, messages and instructions-->
 <h2 class="heading"><%= @wrangler.login %>'s Wrangling Page</h2>
-	<p><%= icon_display(@wrangler) %></p>
+	<p class="icon"><%= icon_display(@wrangler) %></p>
 	<!--/descriptions-->
 </div>
 <!--subnav-->


### PR DESCRIPTION
Fix issue 2900 where the containing paragraph for icon on tag_wrangler/show was not actually containing the icon due to a missing class: http://code.google.com/p/otwarchive/issues/detail?id=2900
