### PR TITLE
Fix issue with pagination clear on dashboard bookmark pages

### DIFF
--- a/public/stylesheets/site/2.0/17-zone-home.css
+++ b/public/stylesheets/site/2.0/17-zone-home.css
@@ -61,6 +61,10 @@ user home, collections and challenges home, tag home, admin comms home
   width: 100%;
 }
 
+#dynamic-bookmark + h4.landmark {
+  clear: both;
+}
+
 /*(with filters)*/
 
 #inbox-form {


### PR DESCRIPTION
Fix issue with the pagination not clearing on bookmark index pages that have a dashboard (i.e., user and collection bookmark indexes): http://code.google.com/p/otwarchive/issues/detail?id=2877

Although this is in the zone-home file, it does get applied to the site-wide bookmark index as well. I could add a .dashboard class in front of it to stop that, but since it does no damage, I'm inclined to leave it as-is.
