### PR TITLE
Modify fix for issue 2751 by applying to FAQs and series

### DIFF
--- a/app/views/archive_faqs/_archive_faq_order.html.erb
+++ b/app/views/archive_faqs/_archive_faq_order.html.erb
@@ -3,7 +3,7 @@
   <ul id="sortable_archive_faq_list">
     <% for archive_faq in @archive_faqs %>
       <li id="archive_faq_<%= archive_faq.id %>" class="archive_faq-position-list">
-        <%= text_field_tag "archive_faqs[]", nil, :size => 3, :maxlength => 3, :id => "archive_faqs_#{archive_faq.id}" %>
+        <%= text_field_tag "archive_faqs[]", nil, :size => 3, :maxlength => 3, :id => "archive_faqs_#{archive_faq.id}", :class => "number" %>
         <span id='position-for-<%= archive_faq.id %>'><%= archive_faq.position %></span>. 
         <h3 class="heading"><%=h archive_faq.title %></h3>
       </li>

--- a/app/views/series/_series_order.html.erb
+++ b/app/views/series/_series_order.html.erb
@@ -3,7 +3,7 @@
   <ul id="sortable_series_list">
     <% @serial_works.each_with_index do |serial, i| %>
       <li id="serial_<%= serial.id %>" class="serial-position-list">
-        <%= text_field_tag 'serial_works[]', nil, :size => 3, :maxlength => 3, :class => 'serial-position-field', :id => "serial_#{i}" %>
+        <%= text_field_tag 'serial_works[]', nil, :size => 3, :maxlength => 3, :class => 'number serial-position-field', :id => "serial_#{i}" %>
         <span id='position-for-<%= serial.id %>'><%= serial.position %></span>.
         <h3 class="heading"><%=serial.work.title.html_safe + (serial.work.posted? ? "" : " (DRAFT)") %></h3>
       </li>


### PR DESCRIPTION
This applies the modified fix for issue 2751 to the the admin reorder FAQ page and to the reorder series page: http://code.google.com/p/otwarchive/issues/detail?id=2751

This adds the number class onto the other sortable lists, correcting what I broke by removing width: auto in pull request 459: https://github.com/otwcode/otwarchive/pull/459
