### PR TITLE
Fix issue 2670 with double commas in collection blurbs

### DIFF
--- a/app/views/collections/_collection_blurb.html.erb
+++ b/app/views/collections/_collection_blurb.html.erb
@@ -17,7 +17,7 @@
 	    <% if collection.all_moderators.length > 0%>
 			  <h6 class="landmark heading">Mods</h6>
 			  <ul title="moderated by" class="mods commas">
-			    <%= collection.all_moderators.map {|mod| content_tag(:li, link_to(mod.byline, mod.user))}.join(", ").html_safe %>
+			    <%= collection.all_moderators.map {|mod| content_tag(:li, link_to(mod.byline, mod.user))}.join("\n").html_safe %>
 			  </ul>
 	    <% end %>
 		</div>


### PR DESCRIPTION
Fix issue 2670 with double commas separating multiple maintainers in collection blurbs: http://code.google.com/p/otwarchive/issues/detail?id=2670

I removed the hard coded comma, since we are moving toward commas inserted by CSS.
