### PR TITLE
Fix issue 2903 with mass wrangling table rows

### DIFF
--- a/app/views/tag_wranglings/index.html.erb
+++ b/app/views/tag_wranglings/index.html.erb
@@ -120,9 +120,9 @@
       <tbody>
         <% for tag in @tags %>
         <tr>
-          <td title="tag">
+          <th scope="row" title="tag">
             <%= label_tag "selected_tags_#{tag.id}", "#{tag.name}" %>
-          </td>
+          </th>
           <td title="mass wrangle?"><%= check_box_tag "selected_tags[]", tag.id, nil, :id => "selected_tags_#{tag.id}" %></td>
           <td title="created"><%= l(tag.created_at.to_date) %></td>
           <% if params[:show] == 'character_relationships' %>


### PR DESCRIPTION
Fix issue 2903 on the mass wrangling pages where the table cells containing the tag were td instead of th, causing display issues in Reversi: http://code.google.com/p/otwarchive/issues/detail?id=2903
