### PR TITLE
Fix issue 2547 with invite emails being fanfic-centric

### DIFF
--- a/app/views/user_mailer/invitation.html.erb
+++ b/app/views/user_mailer/invitation.html.erb
@@ -12,13 +12,14 @@
 
 <p>
   The Archive of Our Own (AO3) is a free, noncommercial fanfic archive built by and for fans.
-  We are multifannish and welcome all kinds of fanfic, we run on the open-source otwarchive
-  software, and our servers are owned by the nonprofit Organization of Transformative Works,
-  which works to protect fan rights and preserve fanworks.
+  We are multifannish and welcome all kinds of fanworks, including fanfiction, fanart, and
+  fanvids. We run on the open-source otwarchive software, and our servers are owned by the
+  nonprofit Organization of Transformative Works, which works to protect fan rights and preserve
+  fanworks.
 </p>
 
 <p>
-  Also, we have a lot of spiffy features for finding the fanfic you want to read, and for
+  Also, we have a lot of spiffy features for finding the fanworks you want, and for
   posting and sharing your work with others. There are lots more coming soon! Your feedback now
   during our beta can help us build an even better archive. \o/
 </p>

--- a/features/invite_queue.feature
+++ b/features/invite_queue.feature
@@ -112,6 +112,8 @@ Feature: Invite queue management
     
     # user uses email invite
     Then the email should contain "You've been invited to join our beta!"
+      And the email should contain "fanart"
+      And the email should contain "fanvids"
     
     # user creates account, with error messages
     When I click the first link in the email


### PR DESCRIPTION
Fix issue 2547 with invitation emails being fanfic-centric: http://code.google.com/p/otwarchive/issues/detail?id=2547
