### PR TITLE
Made delivery of some emails synchronous to keep them out of mail queue

### DIFF
--- a/app/controllers/admin/admin_users_controller.rb
+++ b/app/controllers/admin/admin_users_controller.rb
@@ -211,7 +211,8 @@ class Admin::AdminUsersController < ApplicationController
 
   def send_activation
     @user = User.find_by_login(params[:id])
-    UserMailer.signup_notification(@user.id).deliver
+    # send synchronously to avoid getting caught in mail queue
+    UserMailer.signup_notification(@user.id).deliver! 
     flash[:notice] = t('activation_sent', :default => "Activation email sent")
     redirect_to :action => :show
   end

--- a/app/models/challenge_signup_observer.rb
+++ b/app/models/challenge_signup_observer.rb
@@ -2,7 +2,8 @@ class ChallengeSignupObserver < ActiveRecord::Observer
 
   # Email a copy of the deleted signup to the user, to cover accidental deletions or modly deletions
   def before_destroy(challenge_signup)
-		UserMailer.delete_signup_notification(user, challenge_signup).deliver!
+    # must be synchronous because signup is being destroyed
+		UserMailer.delete_signup_notification(user, challenge_signup).deliver! 
   end
 
 end

--- a/app/models/invitation.rb
+++ b/app/models/invitation.rb
@@ -62,9 +62,10 @@ class Invitation < ActiveRecord::Base
       begin
         if self.external_author
           archivist = self.external_author.external_creatorships.collect(&:archivist).collect(&:login).uniq.join(", ")
-          UserMailer.invitation_to_claim(self, archivist).deliver!
+          UserMailer.invitation_to_claim(self, archivist).deliver
         else
-          UserMailer.invitation(self).deliver!
+          # send invitations actively sent by a user synchronously to avoid delays
+          UserMailer.invitation(self).deliver! 
         end
         self.sent_at = Time.now
       rescue Exception => exception

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -209,7 +209,8 @@ class User < ActiveRecord::Base
   def reset_user_password
     temp_password = generate_password(20)
     User.update_all("activation_code = '#{temp_password}', recently_reset = 1, updated_at = '#{Time.now}'", "id = #{self.id}")
-    UserMailer.reset_password(self.id, temp_password).deliver
+    # send synchronously to prevent getting caught in backed-up mail queue
+    UserMailer.reset_password(self.id, temp_password).deliver! 
   end
 
   def activate

--- a/app/models/work_observer.rb
+++ b/app/models/work_observer.rb
@@ -7,7 +7,7 @@ class WorkObserver < ActiveRecord::Observer
 	  #  unless users.blank?
 	  #    for user in users
 	  #      unless user.preference.edit_emails_off? || user == orphan_account
-	  #        UserMailer.edit_work_notification(user, work).deliver!
+	  #        UserMailer.edit_work_notification(user, work).deliver! 
 	  #      end
 	  #    end
 	  #  end
@@ -21,7 +21,8 @@ class WorkObserver < ActiveRecord::Observer
 	    unless users.blank?
 	      for user in users
 					unless user == orphan_account
-						UserMailer.delete_work_notification(user, work).deliver!
+					  # this has to use the synchronous version because the work is going to be destroyed
+						UserMailer.delete_work_notification(user, work).deliver! 
 					end
 	      end
 	    end

--- a/lib/tasks/after_tasks.rake
+++ b/lib/tasks/after_tasks.rake
@@ -279,7 +279,7 @@ namespace :After do
 #  task(:invite_external_authors => :environment) do
 #    Invitation.where("sent_at is NULL").where("external_author_id IS NOT NULL").each do |invite|
 #      archivist = invite.external_author.external_creatorships.collect(&:archivist).collect(&:login).uniq.join(", ")
-#      UserMailer.invitation_to_claim(invite, archivist).deliver!
+#      UserMailer.invitation_to_claim(invite, archivist).deliver
 #      invite.sent_at = Time.now
 #      invite.save
 #    end


### PR DESCRIPTION
made synchronous: password reset, activation email (both user- and admin-generated), and invitation emails sent by individual users. Also improved commenting on all other deliver! calls.

See http://code.google.com/p/otwarchive/issues/detail?id=2914

Signed-off-by: shalott shalott@gmail.com
