### PR TITLE
Issue 2794 with inline paragraphs in challenge signups

### DIFF
--- a/public/stylesheets/site/2.0/10-types-groups.css
+++ b/public/stylesheets/site/2.0/10-types-groups.css
@@ -138,6 +138,10 @@ dl.index dd p, dl.index dd .heading, dl.index ul {
   display: inline-block;
 }
 
+dl.index dd .userstuff p {
+  display: block;
+}
+
 /*TYPES*/
 
 a.rss span {
@@ -202,10 +206,6 @@ dl.stats {
 dl.stats dd {
   white-space: nowrap;
   padding-right: 0.5em;
-}
-
-.series.module, .children.module {
-
 }
 
 /*END== */


### PR DESCRIPTION
Fixes issue 2794 with paragraphs displaying side-by-side in challenge sign-ups: http://code.google.com/p/otwarchive/issues/detail?id=2794

(Also deleted an empty block left over from my issue 2887 related changes. Let me know if you want me to undo and give it a separate issue/pull request, though.)
