### PR TITLE
Modify fix for issue 2547 by removing 'fanfic archive'

### DIFF
--- a/app/views/user_mailer/invitation.html.erb
+++ b/app/views/user_mailer/invitation.html.erb
@@ -11,11 +11,10 @@
 </p>
 
 <p>
-  The Archive of Our Own (AO3) is a free, noncommercial fanfic archive built by and for fans.
-  We are multifannish and welcome all kinds of fanworks, including fanfiction, fanart, and
-  fanvids. We run on the open-source otwarchive software, and our servers are owned by the
-  nonprofit Organization of Transformative Works, which works to protect fan rights and preserve
-  fanworks.
+  The Archive of Our Own (AO3) is a free, noncommercial archive built by and for fans. We are
+  multifannish and welcome all kinds of fanworks, including fanfiction, fanart, and fanvids. We
+  run on the open-source otwarchive software, and our servers are owned by the nonprofit
+  Organization of Transformative Works, which works to protect fan rights and preserve fanworks.
 </p>
 
 <p>


### PR DESCRIPTION
Modify fix for issue 2547 invitation mailers by removing the word fanfic per comments 8 and 9: http://code.google.com/p/otwarchive/issues/detail?id=2547
