### PR TITLE
Fix issue 2931 with empty approved children info appearing on preview

### DIFF
--- a/app/views/works/preview.html.erb
+++ b/app/views/works/preview.html.erb
@@ -16,14 +16,23 @@
         <div class="userstuff"><%=raw sanitize_field(@chapter, :content) %></div>
     <% end %>
     </div>
-    <% unless @work.endnotes.blank? %>
-      <div class="preface group"><div class="end notes">
-          <h3 class="heading"><%=h t('.notes', :default => "Notes:") %></h3>
-          <blockquote class="userstuff"><%=raw sanitize_field(@work, :endnotes) %></blockquote>
-       </div></div>
-
+    
+    <% if !@work.endnotes.blank? || !@work.series.blank? || !@work.approved_children.blank? %>
+    <!--afterword-->
+    <div class="afterword preface group" role="complementary">
+      <% unless @work.endnotes.blank? %>
+        <%= render :partial => 'works/work_endnotes' %>
+      <% end %>
+      <% unless @work.series.blank? %>
+        <%= render :partial => 'works/work_series_links' %>
+      <% end %>
+      <% unless @work.approved_children.blank? %>
+        <%= render :partial => 'works/work_approved_children' %>
+      <% end %>
+    </div>
+    <!--/afterword-->
     <% end %>
-  	<%= render :partial => 'works/work_approved_children' %>
+
   </div>
 </div>
 


### PR DESCRIPTION
Issue 2931: http://code.google.com/p/otwarchive/issues/detail?id=2931

The "Works inspired by this one" header was showing up on preview when the work didn't have any approved children. Now it only shows up when the work has 'em. (Series and end notes should also appear in preview unless blank.)
