### PR TITLE
Fix for the not-reproducible cases when recent_date is nil in set_revise...

### DIFF
--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -413,7 +413,7 @@ class Work < ActiveRecord::Base
       # do is update with current time
       if recent_date == Date.today && self.revised_at && self.revised_at.to_date == Date.today
         return self.revised_at
-      elsif recent_date == Date.today && self.revised_at && self.revised_at.to_date != Date.today
+      elsif recent_date == Date.today && self.revised_at && self.revised_at.to_date != Date.today || recent_date.nil?
         self.revised_at = Time.now
       else
         self.revised_at = DateTime::jd(recent_date.jd, 12, 0, 0)


### PR DESCRIPTION
Fix for the not-reproducible cases when recent_date is nil in set_revised_at, which causes errors 500

http://code.google.com/p/otwarchive/issues/detail?id=2942

Hotfix: checking for nil and using Time.now, as we already do when we can't figure out another date.
