### PR TITLE
Issues 1883 and 2847: robots.txt: disallow indexing downloads and search results

### DIFF
--- a/public/robots.public.txt
+++ b/public/robots.public.txt
@@ -8,6 +8,7 @@ User-agent:	*
 Disallow:	/works? # cruel but efficient
 Disallow: /autocomplete/
 Disallow: /downloads/
+Disallow: /external_works/
 # disallow indexing of search results
 Disallow: /bookmarks/search?
 Disallow: /people/search?
@@ -17,6 +18,7 @@ Disallow: /works/search?
 User-agent:	Googlebot
 Disallow: /autocomplete/
 Disallow: /downloads/
+Disallow: /external_works/
 # Googlebot is smart and knows pattern matching
 Disallow: /works/*?
 Disallow: /*search?


### PR DESCRIPTION
Issues 1883 and 2847: robots.txt: disallow indexing downloads and search results

http://code.google.com/p/otwarchive/issues/detail?id=1883
http://code.google.com/p/otwarchive/issues/detail?id=2847

ETA:
http://code.google.com/p/otwarchive/issues/detail?id=2949
while I was at it.
