### PR TITLE
Issue 2960 restructuring series edit form

### DIFF
--- a/app/views/series/edit.html.erb
+++ b/app/views/series/edit.html.erb
@@ -16,41 +16,59 @@
 
 <!--main content-->
 
-<div id="work-form" class="edit series post">
+<div id="work-form" class="simple post series">
 <%= form_for(@series) do |f| %>
   <%= error_messages_for @series %>
-  <p class="notice required"><%= ts("* Required information") %></p>
+  <p class="required notice"><%= ts("* Required information") %></p>
   <fieldset>
+    <legend><%= ts('Meta') %></legend>
     <dl>
-      <dt><%= f.label :title, ts("Series Title*"), :class => "required" %></dt>
-      <dd><%= f.text_field :title%></dd>
-      <%= render :partial => 'pseuds/byline', :locals => {:form => f, :type => 'series'} %>
-    </dl>
-  </fieldset>
-  <fieldset>
-    <dl>
-      <dt><%= f.label :summary, ts("Series Description") %><dt>
-      <dd>
+      <dt class="title">
+        <%= f.label :title, ts("Series Title*"), :class => "required" %>
+      </dt>
+      <dd class="title">
+        <%= f.text_field :title, :class => "observe_textlength text" %>
+        <%= live_validation_for_field('series_title',
+              :maximum_length => ArchiveConfig.TITLE_MAX, :minimum_length => ArchiveConfig.TITLE_MIN,
+              :failureMessage => ts("We need a title! (At least %{min_length} characters long, please.)", :min_length => ArchiveConfig.TITLE_MIN.to_s))
+        %>
+        <%= generate_countdown_html("series_title", ArchiveConfig.TITLE_MAX) %>
+      </dd>
+      
+      <!-- Add coauthors-->
+      <%= render 'pseuds/byline', :form => f, :type => 'series' %>
+      
+      <dt class="summary">
+        <%= f.label :summary, ts("Series Description", :max => ArchiveConfig.SUMMARY_MAX.to_s) %>
+      </dt>
+      <dd class="summary">
         <%= allowed_html_instructions %>
         <%= f.text_area :summary, :class => "observe_textlength" %>
-      </dd>
-      <dd class="validation">
+        <%= live_validation_for_field('series_summary', :presence => false, :maximum_length => ArchiveConfig.SUMMARY_MAX) %>
         <%= generate_countdown_html("series_summary", ArchiveConfig.SUMMARY_MAX) %>
       </dd>
-      <dt><%= f.label :notes, ts("Series Notes") %><dt>
+      
+      <dt>
+        <%= f.label :notes, ts("Series Notes") %>
+      </dt>
       <dd>
         <%= allowed_html_instructions %>
         <%= f.text_area :notes, :class => "observe_textlength" %>
-      </dd>
-      <dd class="validation">
+        <%= live_validation_for_field('series_notes', :presence => false, :maximum_length => ArchiveConfig.NOTES_MAX) %>
         <%= generate_countdown_html("series_notes", ArchiveConfig.NOTES_MAX) %>
       </dd>
-      <dt><%= f.label :complete, ts("Is this series complete?") %><dt>
-      <dd><%= f.check_box :complete %></dd>
+      <dt>
+        <%= f.check_box :complete %>
+      </dt>
+      <dd>
+        <%= f.label :complete, ts("This series is complete") %>
+      </dd>
     </dl>
   </fieldset>
-  <fieldset>
-    <p class="submit navigation">
+  
+  <fieldset class="create">
+    <legend><%= ts('Post') %></legend>
+    <p class="submit cancel actions">
       <%= f.submit ts("Update") %>
       <%= link_to ts("Cancel"), series_path %>
     </p>


### PR DESCRIPTION
Fix issue 2960 with the series edit form: http://code.google.com/p/otwarchive/issues/detail?id=2960

Reported issues: 
1. no legends
2. no landmarks 
3. the form labels in the second fieldset have double underlines
4. the Cancel option is a plain text link
5. the character counter is centered under the corresponding input
6. the text fields with character counters do not have Live Validation

Changes in this commit: 
1. The legend is included, but you'll have to view the source (per our style, forms with three of fewer fieldsets do not display legends) -- the line you are looking for is <legend>Meta</legend>.
2. The landmark is not included, as it was an experiment on the works form.
3. Form labels now have only one line beneath them.
4. The Cancel option is style as a button.
5. The character counter is now right-aligned.
6. If you go over the character limit, the red Live Validation text will appear.

Additionally:
1. The form is now two fieldsets (grey boxes) instead of three. I did this for two reasons. One, because it corresponds with how the information is displayed. The information provided for Series Title, Author/Pseuds, Co-authors, Add co-authors?, Series Description, Series Notes, and This series is complete, all displays as one group on the series page (the meta box above the stories). Two, because it corresponds with the way forms are laid out elsewhere on the site. The forms for collections and works both put title, authors/owners, summary/description, and notes in a single fieldset.
2. The checkbox now appears to the right of the label 'This series is complete' rather than appearing to the left of the label 'Is this series complete?' It might seem visually counterintuitive, but it tends to work better for assistive technology, and we use this layout in many forms. 

Known issues:
1. Ticking the Add co-authors? box does nothing. See Issue 2614.
2. When viewing the form for a series that has a co-author, the 'Current Co-authors:' label has a colon, unlike all the other labels. This will be fixed when the forms are all properly standardized.
