### PR TITLE
Fix issue 2905 with chapter text escaping draft box

### DIFF
--- a/app/views/chapters/preview_edit.html.erb
+++ b/app/views/chapters/preview_edit.html.erb
@@ -1,5 +1,13 @@
+<% if @work.work_skin && !Preference.disable_work_skin?(params[:style]) %>
+  <% cache("#{@work.work_skin.id}-#{@work.work_skin.updated_at}-work-skin") do %>
+    <%= render "skins/skin_style_block", :skin => @work.work_skin %>
+  <% end %><!-- end cache for work skin -->
+<% end %>
+
 <div id="chapters">
-<%= render :partial => 'chapters/chapter', :locals => { :chapter => @chapter } %>
+  <div id="workskin">
+    <%= render :partial => 'chapters/chapter', :locals => { :chapter => @chapter } %>
+  </div>
 </div>
 
 <%= form_for([@work, @chapter]) do |f| %>


### PR DESCRIPTION
http://code.google.com/p/otwarchive/issues/detail?id=2905

The issue was reported as the chapter content escaping the grey draft box in the chapters update view (which is controlled by chapters/preview_edit.html.erb), which seemed like a CSS error, but the problem turned out to be that work skins weren't included in the chapters update view (they are in the chapters preview view, which is controlled by chapters/preview.html.erb). So, now the chapters update view includes the work skin, which also solves the problem with the chapter text floating outside the draft box.
