### PR TITLE
Fix issue 2963 with unclickable navigation on mobile dashboard pages

### DIFF
--- a/public/stylesheets/site/2.0/25-role-handheld.css
+++ b/public/stylesheets/site/2.0/25-role-handheld.css
@@ -148,3 +148,7 @@ dl.stats + h6 + .actions {
   clear: none;
   float: left;
 }
+
+.dashboard .landmark {
+  clear: both;
+}


### PR DESCRIPTION
http://code.google.com/p/otwarchive/issues/detail?id=2963

On the iPhone, navigation items appearing above ordered lists on dashboard pages (such as any user's works index or your own collection index) were unclickable because the ordered lists were overlapping them. Changing the clear on .dashboard .landmark for the handheld stylesheet fixes that.
