### PR TITLE
Fix issue 2956 by adding podfic to front page and invite emails

### DIFF
--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -7,7 +7,7 @@
   <div class="intro module">
   <h2 class="heading"><%= ts('hi!') %></h2>
   <p><%= ts('Welcome to the Archive of Our Own!') %></p>
-  <p><%= ts("We're a fan-created, fan-run, non-profit, non-commercial archive for transformative fanworks, like fanfiction, fanart, and fanvids.") %></p>
+  <p><%= ts("We're a fan-created, fan-run, non-profit, non-commercial archive for transformative fanworks, like fanfiction, fanart, fanvids, and podfic.") %></p>
   <p><%= ts('While the site is in beta, you can get an invitation from another user or from our automated invite queue. All fans and fanworks are welcome!') %></p>
     <% if logged_in? %>
       <p id="signup" class="navigation actions" role="navigation"><%= link_to ts('Invite a friend'), user_invitations_path(current_user) %></p> 

--- a/app/views/user_mailer/invitation.html.erb
+++ b/app/views/user_mailer/invitation.html.erb
@@ -12,9 +12,10 @@
 
 <p>
   The Archive of Our Own (AO3) is a free, noncommercial archive built by and for fans. We are
-  multifannish and welcome all kinds of fanworks, including fanfiction, fanart, and fanvids. We
-  run on the open-source otwarchive software, and our servers are owned by the nonprofit
-  Organization of Transformative Works, which works to protect fan rights and preserve fanworks.
+  multifannish and welcome all kinds of fanworks, including fanfiction, fanart, fanvids, and
+  podfic. We run on the open-source otwarchive software, and our servers are owned by the
+  nonprofit Organization of Transformative Works, which works to protect fan rights and
+  preserve fanworks.
 </p>
 
 <p>

--- a/features/invite_queue.feature
+++ b/features/invite_queue.feature
@@ -113,7 +113,7 @@ Feature: Invite queue management
     # user uses email invite
     Then the email should contain "You've been invited to join our beta!"
       And the email should contain "fanart"
-      And the email should contain "fanvids"
+      And the email should contain "podfic"
     
     # user creates account, with error messages
     When I click the first link in the email


### PR DESCRIPTION
http://code.google.com/p/otwarchive/issues/detail?id=2956

Podfic is now explicitly listed on our front page and in our invitation emails.
