### PR TITLE
Fix issue 2970 adding navigation to search pages

### DIFF
--- a/app/views/bookmarks/search.html.erb
+++ b/app/views/bookmarks/search.html.erb
@@ -2,7 +2,11 @@
 <h2 class="heading"><%= ts("Bookmark Search: Beta") %></h2>
 
 <ul class="navigation actions" role="navigation">
-	<li><%= link_to(ts("Advanced search"), search_index_path(:query => @query)) %></li></ul>
+  <li><%= span_if_current ts("Work Search"), search_index_path(:query => @query) %></li>
+  <li><%= span_if_current ts("Tag Search"), search_tags_path %></li>
+  <li><%= span_if_current ts("Bookmark Search"), search_bookmarks_path %></li>
+  <li><%= span_if_current ts("People Search"), search_people_path %></li>
+</ul>
 
 <%= render :partial => 'bookmarks/search_form' %>
 

--- a/app/views/people/search.html.erb
+++ b/app/views/people/search.html.erb
@@ -1,9 +1,12 @@
 <!--SEARCHBROWSE-->
-<h2 class="heading">People Search: Alpha</h2>
+<h2 class="heading"><%= ts("People Search: Alpha") %></h2>
 
-<ul class="navigation actions" role="navigation"><li>
-  <%= link_to(ts("Advanced search"), search_index_path(:query => @query)) %>
-</li></ul>
+<ul class="navigation actions" role="navigation">
+  <li><%= span_if_current ts("Work Search"), search_index_path(:query => @query) %></li>
+  <li><%= span_if_current ts("Tag Search"), search_tags_path %></li>
+  <li><%= span_if_current ts("Bookmark Search"), search_bookmarks_path %></li>
+  <li><%= span_if_current ts("People Search"), search_people_path %></li>
+</ul>
 
 <%= render :partial => 'people/search_form' %>
 

--- a/app/views/search/index.html.erb
+++ b/app/views/search/index.html.erb
@@ -1,13 +1,11 @@
-<h2 class="heading">Work Search: Beta</h2>
+<h2 class="heading"><%= ts("Work Search: Beta") %></h2>
+
+<ul class="navigation actions" role="navigation">
+  <li><%= span_if_current ts("Work Search"), search_index_path %></li>
+  <li><%= span_if_current ts("Tag Search"), search_tags_path %></li>
+  <li><%= span_if_current ts("Bookmark Search"), search_bookmarks_path %></li>
+  <li><%= span_if_current ts("People Search"), search_people_path %></li>
+</ul>
 
   <%= render :partial => 'works/search_form' %> 
 
-<h2 class="heading"><%= link_to t("tag_search", :default => "Tag Search: Beta"), search_tags_path %></h2>
-
-
-
-<h2 class="heading"><%= link_to t("bookmark_search", :default => "Bookmark Search: Beta"), search_bookmarks_path %></h2>
-
-
-
-<h2 class="heading"><%= link_to t("people_search", :default => "People Search: Alpha"), search_people_path %></h2>

--- a/app/views/tags/search.html.erb
+++ b/app/views/tags/search.html.erb
@@ -1,4 +1,11 @@
-<h2 class="heading"><%= ts('Tag Search: Beta') %></h2>
+<h2 class="heading"><%= ts("Tag Search: Beta") %></h2>
+
+<ul class="navigation actions" role="navigation">
+  <li><%= span_if_current ts("Work Search"), search_index_path %></li>
+  <li><%= span_if_current ts("Tag Search"), search_tags_path %></li>
+  <li><%= span_if_current ts("Bookmark Search"), search_bookmarks_path %></li>
+  <li><%= span_if_current ts("People Search"), search_people_path %></li>
+</ul>
 
 <%= render :partial => 'tags/search_form' %>
 


### PR DESCRIPTION
Fix issue 2970 by adding navigation actions (buttons) to take you from one type of search page to another: http://code.google.com/p/otwarchive/issues/detail?id=2970
