### PR TITLE
Fix issue 2932 with download menu in Opera with JS off

### DIFF
--- a/public/stylesheets/site/2.0/08-actions.css
+++ b/public/stylesheets/site/2.0/08-actions.css
@@ -141,8 +141,8 @@ dl.stats + h6 + .actions, li.news .actions {
   float: none;
 }
 
-.chapter .secondary {
-  top: 2.5em;
+.chapter .secondary, .download .secondary {
+  top: 3.5em;
 }
 
 .dashboard .landmark {


### PR DESCRIPTION
When browsing a work in Opera with Javascript turned off, the download menu was obscuring some buttons: http://code.google.com/p/otwarchive/issues/detail?id=2932

Now it's not.
