### PR TITLE
Issue 2971 repeated styling on chapter form in secondary navigation

### DIFF
--- a/public/stylesheets/site/2.0/07-interactions.css
+++ b/public/stylesheets/site/2.0/07-interactions.css
@@ -402,4 +402,13 @@ div.dynamic {
   width: auto;
 }
 
+/* CONTEXT: secondary */
+
+.secondary form {
+  padding: 0;
+  border: none;
+  background: transparent;
+    box-shadow: none;
+}
+
 /*END== */


### PR DESCRIPTION
http://code.google.com/p/otwarchive/issues/detail?id=2971

When viewing a chaptered work in chapter-by-chapter view, the form (select menu and go button) in the secondary menu that appears when clicking Chapter Index had a border, shadow, background, and padding applied to it, making it look bad. This removes that styling.
