### PR TITLE
Issues 2919 and 2952 with Condition on skins show page

### DIFF
--- a/app/views/skins/show.html.erb
+++ b/app/views/skins/show.html.erb
@@ -12,10 +12,12 @@
       <dt>Users: </dt><dd><%= @skin.preferences.count %></dd>
       <dt>Role: </dt><dd><%= @skin.role %></dd>
       <dt>Media: </dt><dd><%= @skin.get_media %></dd>
-      <dt>Condition:</dt>
-      <% if @skin.ie_condition.present? %><abbr title="internet explorer">IE</abbr><%= @skin.ie_condition %></dd><% end %>
-      <% if @skin.unusable? %><dd>parent only</dd><% end %>
-      <!--BACK END pls: else <dd>normal</dd> end-->
+      <dt>Condition: </dt>
+      <dd>
+        <% unless @skin.ie_condition.present? || @skin.unusable? %>normal<% end %>
+        <% if @skin.ie_condition.present? %><abbr title="Internet Explorer"><%= @skin.ie_condition %></abbr><% end %>
+        <% if @skin.unusable? %>parent only<% end %>
+      </dd>
     </dl>
     	<%= render :partial => "skin_top_navigation" %>
     	<p class="icon"><%= skin_preview_display(@skin) %></p>


### PR DESCRIPTION
"Condition:" displayed as empty on skins without IE or parent only conditions http://code.google.com/p/otwarchive/issues/detail?id=2919 and "IE" appeared in "Condition:" twice when an IE condition was set http://code.google.com/p/otwarchive/issues/detail?id=2952

Now a skin without conditions will be "Condition: normal," while a skin with IE conditions will be "Condition: IE6" (where "IE6" is whatever version of IE the skin creator has set).

These issues were separate in GCode, but separate branches and pull requests probably would have involved merge conflicts and/or reworking the same code twice, so this seemed much more efficient.
