### PR TITLE
Fix issue 2833 with Bookmarked? search help causing 404

### DIFF
--- a/public/help/work-search-bookmark-help.html
+++ b/public/help/work-search-bookmark-help.html
@@ -1,0 +1,3 @@
+<h4>Work Search Bookmark</h4>
+
+<p>Select "Bookmarked" to limit the search to works that other users have bookmarked.</p>


### PR DESCRIPTION
On the search page, clicking the help link next for the Bookmarked? field gives a 404: http://code.google.com/p/otwarchive/issues/detail?id=2833

Adds a help page for this field that reads, 'Select "Bookmarked" to limit the search to works that other users have bookmarked.' I'm 99.9% sure this is correct, although playing with it on beta gave me works that didn't appear to be bookmarked. Do the results perhaps include private bookmarks? And, if so, should the help text or known issues page mention that so we don't get lots of bug reports?
