### PR TITLE
Fix issue 2807 with work meta on static pages

### DIFF
--- a/public/stylesheets/static.css
+++ b/public/stylesheets/static.css
@@ -141,6 +141,22 @@ h3.heading {
   visibility: hidden;
 }
 
+.meta, .meta .tags {
+  float: left;
+  width: 100%;
+}
+
+.meta dt {
+  font-weight: 600;
+  float: left;
+  clear: left;
+}
+
+.meta dd {
+  float: left;
+  margin: 0 0 0.643em 0.375em;
+}
+
 .userstuff p {
   line-height: 1.5;
   margin: 1.286em auto;


### PR DESCRIPTION
On static pages, the work meta was hard to read: http://code.google.com/p/otwarchive/issues/detail?id=2807

This puts the tags on the same line as their labels and bolds the labels.
