### PR TITLE
Modify Issue 2807 fix with meta style that works in IE6 and 7

### DIFF
--- a/public/stylesheets/static.css
+++ b/public/stylesheets/static.css
@@ -147,14 +147,17 @@ h3.heading {
 }
 
 .meta dt {
-  font-weight: 600;
+  text-align: left;
+  min-width: 10.5em;
+  width: 25%;
   float: left;
   clear: left;
 }
 
 .meta dd {
+  width: 72.5%;
   float: left;
-  margin: 0 0 0.643em 0.375em;
+  margin: 0 0 0.643em;
 }
 
 .userstuff p {


### PR DESCRIPTION
The restyling of the meta on static pages wasn't working in IE6 or IE7. http://code.google.com/p/otwarchive/issues/detail?id=2807#c4
