### PR TITLE
Consolidate fix for issue 2971 with existing code

### DIFF
--- a/public/stylesheets/site/2.0/07-interactions.css
+++ b/public/stylesheets/site/2.0/07-interactions.css
@@ -371,7 +371,7 @@ div.dynamic {
     box-shadow: 1px 2px 5px;
 }
 
-.dynamic form fieldset, .toggled form fieldset, .toggled form dl, .secondary .toggled form {
+.dynamic form fieldset, .toggled form fieldset, .toggled form dl, .secondary .toggled form, .secondary form {
   border: none;
   background: transparent;
   margin: 0;
@@ -400,15 +400,6 @@ div.dynamic {
 
 .dashboard .filters dt {
   width: auto;
-}
-
-/* CONTEXT: secondary */
-
-.secondary form {
-  padding: 0;
-  border: none;
-  background: transparent;
-    box-shadow: none;
 }
 
 /*END== */


### PR DESCRIPTION
Issue 2971 with unwanted styles on chapter index secondary navigation: http://code.google.com/p/otwarchive/issues/detail?id=2971

 I should have fixed this by adding .secondary form to an existing block that applied the same style, but totally didn't notice that the block existed. My bad. 

(This pullreq is the very definition of non-urgent, so don't worry if it doesn't make it into the same deploy as the original fix.)
