### PR TITLE
Fix issue 2978 with wrong text on edit multiple button

### DIFF
--- a/app/views/works/edit_multiple.html.erb
+++ b/app/views/works/edit_multiple.html.erb
@@ -65,7 +65,7 @@
     (If you leave a field blank it will remain unchanged.)
   </p>
   
-  <p class="submit actions"><%= submit_tag ts("Update All Stories"), :confirm => ts("Are you sure? Remember this will replace all existing values!") %></p>
+  <p class="submit actions"><%= submit_tag ts("Update All Works"), :confirm => ts("Are you sure? Remember this will replace all existing values!") %></p>
 
 <% end %>
 <!--/content-->


### PR DESCRIPTION
The text on the Edit Multiple Works button says "Update All Stories" instead of "Update All Works" http://code.google.com/p/otwarchive/issues/detail?id=2978
