### PR TITLE
Fix issue 2879 with two New Pseud buttons

### DIFF
--- a/app/views/pseuds/index.html.erb
+++ b/app/views/pseuds/index.html.erb
@@ -18,10 +18,4 @@
 </ul>
 <!--/content-->
 
-<!--subnav-->
-<% if current_user == @user %>
-<ul class="navigation actions" role="navigation">
-  <li><%= link_to ts('New Pseud'), new_user_pseud_path(@user) %></li>
-</ul>
-<% end %>
-<!--/subnav-->
+


### PR DESCRIPTION
The second New Pseud button on a user's pseud index was floating up to the top of the page in Chrome: http://code.google.com/p/otwarchive/issues/detail?id=2879

This could have been fixed by adding a landmark, which would force the button to clear, but I removed the lower navigation actions instead, since other user index pages (e.g. user's skins index, user's collections index, user's bookmarks index) only have navigation at the top.
