### PR TITLE
Fix Issue 2689 with commas after all items in a comma list

### DIFF
--- a/public/javascripts/application.js
+++ b/public/javascripts/application.js
@@ -27,6 +27,7 @@ $j(document).ready(function() {
         this.href = this.href.replace(/\/confirm_delete$/, "");
         $j(this).attr("data-method", "delete").attr("data-confirm", "Are you sure? This CANNOT BE UNDONE!");
     });
+    $j('.commas li:last-child').addClass('last');
 });
 
 function visualizeTables() {

--- a/public/stylesheets/site/2.0/28-role-ie8_or_lower.css
+++ b/public/stylesheets/site/2.0/28-role-ie8_or_lower.css
@@ -169,6 +169,12 @@ input, select, option, textarea, legend, label, .actions a {
   display: none;
 }
 
+/* commas */
+
+.commas li.last:after {
+  content: none;
+}
+
 /*DIAGNOSIS*/
 
 /* WIDGET: IBOX (called by help links)*/


### PR DESCRIPTION
IE8 doesn't understand :last-child, so it was displaying commas even after the last and/or only item in a list with the commas class: http://code.google.com/p/otwarchive/issues/detail?id=2689

Now we add the class "last" to the final item in a list with the commas class, set .commas li.last:after { content: none; } in the IE8 and lower stylesheet, and no more comma where it shouldn't be!
