### PR TITLE
Fix Issue 2695 with comment textarea resizing on edit with error

### DIFF
--- a/public/stylesheets/site/2.0/22-system-messages.css
+++ b/public/stylesheets/site/2.0/22-system-messages.css
@@ -70,10 +70,6 @@ ul.notes li, .error ul li {
 }
 
 span.error {
-  display: inline-block;
-}
-
-.comment span.error {
   display: block;
 }
 


### PR DESCRIPTION
When you attempt to edit an existing comment in a way that puts you over the character limit, the textarea shrinks when you click Update, and it becomes difficult to edit your comment down to the proper length: http://code.google.com/p/otwarchive/issues/detail?id=2695

Now the textarea should stay the proper size.
