### PR TITLE
Fix Issue 2597 with missing hidden-by-admin icon on bookmarks

### DIFF
--- a/public/stylesheets/site/2.0/13-group-blurb.css
+++ b/public/stylesheets/site/2.0/13-group-blurb.css
@@ -196,6 +196,10 @@ li.blurb:after {
   background: url("/images/imageset.png") -125px -50px;
 }
 
+.blurb .hidden {
+  background: url("/images/imageset.png") -150px -50px;
+}
+
 .blurb .rec {
   background: url("/images/imageset.png") -100px -50px;
 }


### PR DESCRIPTION
The red lock icon wasn't showing on bookmarks that were hidden by an admin: http://code.google.com/p/otwarchive/issues/detail?id=2597

Now the icon has been defined in the stylesheet and should show up just fine.
