### PR TITLE
Fix Issue 1205 with styling on error messages for create user page

### DIFF
--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -1,7 +1,7 @@
 <!--Descriptive page name, messages and instructions-->
 <h2 class="heading"><%= ts("Create Account") %></h2>
 <% if @user.errors.any? %>
-  <div id="errorExplanationNone">
+  <div class="error">
      <h4 class="heading"><%= ts("Oops, there's some problems with the stuff you told us.") %></h4>
      <ul>
         <% @user.errors.full_messages.each do |msg| %>


### PR DESCRIPTION
The error messages when creating a new user had old class names and thus were unstyled: http://code.google.com/p/otwarchive/issues/detail?id=1205
