### PR TITLE
Issue 2889 stylesheet links do not meet XHTML standards

### DIFF
--- a/app/models/skin.rb
+++ b/app/models/skin.rb
@@ -384,7 +384,7 @@ class Skin < ActiveRecord::Base
   end
     
   def stylesheet_link(file, media)
-    '<link rel="stylesheet" type="text/css" media="' + media + '" href="' + file + '">'
+    '<link rel="stylesheet" type="text/css" media="' + media + '" href="' + file + '" />'
   end
   
   def self.naturalized(string)


### PR DESCRIPTION
The stylesheet link tags were not self-closing: http://code.google.com/p/otwarchive/issues/detail?id=2889
