### PR TITLE
Fix Issue 2532 adding main ARIA landmark to home page

### DIFF
--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,7 +1,7 @@
 <%= render :partial => 'layouts/header' %>
 <div id="inner" class="wrapper">
   
-  <div id="main" class="system">
+  <div id="main" class="system region" role="main">
   <%= flash_div :error, :caution, :notice %>
   
   <div class="intro module">


### PR DESCRIPTION
The main page body on the home page was missing a main ARIA landmark: http://code.google.com/p/otwarchive/issues/detail?id=2532
