### PR TITLE
Fix Issue 2984 changing cursor on filter headings

### DIFF
--- a/public/stylesheets/site/2.0/18-zone-searchbrowse.css
+++ b/public/stylesheets/site/2.0/18-zone-searchbrowse.css
@@ -76,6 +76,10 @@ form.filters dl {
   padding: 0;
 }
 
+form.filters dt span {
+  cursor: pointer;
+}
+
 .filters dd {
   width: 100%;
 }


### PR DESCRIPTION
The arrow icons and heading text on filters were displaying the default cursors, making it difficult to know they were clickable items that would expand the list: http://code.google.com/p/otwarchive/issues/detail?id=2984
