### PR TITLE
Fix issue 2985 with invalid cursor value

### DIFF
--- a/public/stylesheets/site/2.0/02-elements.css
+++ b/public/stylesheets/site/2.0/02-elements.css
@@ -26,7 +26,7 @@ a, a:link, a:visited:hover {
   color: #111;
   text-decoration: none;
   border-bottom: 1px solid;
-  cursor: hand;
+  cursor: pointer;
 }
 
 a:visited {


### PR DESCRIPTION
In the stylesheet, the cursor on links was set to hand, which is a value that doesn't exist: http://code.google.com/p/otwarchive/issues/detail?id=2985
