### PR TITLE
Fix issue 2983 with links opening in new window

### DIFF
--- a/app/views/tags/wrangle.html.erb
+++ b/app/views/tags/wrangle.html.erb
@@ -128,9 +128,9 @@
                 </label>
               </li>
             <% end %>
-            <li><%= link_to 'edit', {:controller => :tags, :action => :edit, :id => tag}, :target => "_blank" %></li>
-            <li><%= link_to 'wrangle', {:controller => :tags, :action => :wrangle, :id => tag}, :target => "_blank" %></li>
-            <li><%= link_to 'works', {:controller => :works, :action => :index, :tag_id => tag}, :target => "_blank" %></li>
+            <li><%= link_to 'edit', {:controller => :tags, :action => :edit, :id => tag} %></li>
+            <li><%= link_to 'wrangle', {:controller => :tags, :action => :wrangle, :id => tag} %></li>
+            <li><%= link_to 'works', {:controller => :works, :action => :index, :tag_id => tag} %></li>
           </ul>
         </td>
       </tr>


### PR DESCRIPTION
The links to edit, wrangle, and works on the wrangle/show? tag pages were opening in a new window: http://code.google.com/p/otwarchive/issues/detail?id=2983
