### PR TITLE
Fix issue 2837 with delete series confirmation message

### DIFF
--- a/app/views/works/_standard_form.html.erb
+++ b/app/views/works/_standard_form.html.erb
@@ -160,7 +160,7 @@
                 <ul class="navigation actions" role="navigation">
                   <li><%= link_to serial.series.title, serial.series %></li>
                   <li><%= link_to ts('Remove'), serial_work_path(serial), :method => :delete %></li>
-                  <li><%= link_to ts('Delete'), serial.series, :confirm => ts('Are you sure?'), :method => :delete %></li>
+                  <li><%= link_to ts('Delete'), serial.series, :confirm => ts('Delete series from all works?'), :method => :delete %></li>
                 </ul>
               </dd>
             <% end %>


### PR DESCRIPTION
Fixes issue 2837 with an unclear confirmation message when deleting a series from a work: http://code.google.com/p/otwarchive/issues/detail?id=2837
