### PR TITLE
Fix issue 2994 with drafts being indistinct from posted works

### DIFF
--- a/app/views/works/show.html.erb
+++ b/app/views/works/show.html.erb
@@ -3,6 +3,11 @@
 	<li><a name="top">&nbsp;</a></li>
 	<li><a href="#work">Skip header</a></li>
 </ul>
+<% if !@work.posted? %>
+  <p class="notice">
+    <%= ts("This work is a draft and has not been posted.") %>
+  </p>
+<% end %>
 <% if @work.unrevealed? %>
   <p class="notice">
     <%= ts("This work is part of an ongoing challenge and will be revealed soon! You can find details here: ") %>


### PR DESCRIPTION
Clicking "save without posting" was leading to a view of drafted work that looks as if the draft is actually a posted work: http://code.google.com/p/otwarchive/issues/detail?id=2994

Added a banner to let users knows when they're looking at a draft work.
