### PR TITLE
Fix issue 2993 with broken line break tag in gift notification

### DIFF
--- a/app/views/user_mailer/recipient_notification.html.erb
+++ b/app/views/user_mailer/recipient_notification.html.erb
@@ -8,7 +8,7 @@
 <p>
   <%= link_to @work.title.html_safe, work_url(@work) %> <%= "(#{@work.word_count} words)" %><br />
   by <%= @work.anonymous? ? "an anonymous giver" : @work.pseuds.collect(&:byline).join(", ") %><br />
-  <%= "Fandom: " + @work.fandom_string unless @work.fandom_string.blank? %></br />
+  <%= "Fandom: " + @work.fandom_string unless @work.fandom_string.blank? %><br />
   <% unless @work.summary.blank? %>
     Summary: 
     <blockquote>


### PR DESCRIPTION
The gift notification e-mails were either failing to display the line break between fandom and summary or displaying a /> because the br / was coded as /br /: http://code.google.com/p/otwarchive/issues/detail?id=2993
