### PR TITLE
Fix Issue 2987 with typo in password reset email

### DIFF
--- a/app/views/user_mailer/reset_password.html.erb
+++ b/app/views/user_mailer/reset_password.html.erb
@@ -2,6 +2,6 @@
 
 <%= @password %>
 
-<p><%= ts("After you log in using this generated password you will be asked change your password to something you can remember.") %> <%= ts("If you do not use this generated password within a week, it will expire, and you will have to request a new one.") %></p>
+<p><%= ts("After you log in using this generated password you will be asked to change your password to something you can remember.") %> <%= ts("If you do not use this generated password within a week, it will expire, and you will have to request a new one.") %></p>
 
 <p><%= ts("If you did not request this password reset, you may ignore this email and your previous password will continue to work.") %>


### PR DESCRIPTION
The password reset email was missing a "to": http://code.google.com/p/otwarchive/issues/detail?id=2987
