### PR TITLE
Issues 2959 and 2614: Series edit bugs

### DIFF
--- a/app/controllers/series_controller.rb
+++ b/app/controllers/series_controller.rb
@@ -119,6 +119,10 @@ class SeriesController < ApplicationController
       flash[:notice] = ts('Series was successfully updated.')
       redirect_to(@series)
     else
+      @pseuds = current_user.pseuds
+      @coauthors = @series.pseuds.select{ |p| p.user.id != current_user.id}
+      to_select = @series.pseuds.blank? ? [current_user.default_pseud] : @series.pseuds
+      @selected_pseuds = to_select.collect {|pseud| pseud.id.to_i }
       render :action => "edit"
     end
   end

--- a/app/views/pseuds/_byline.html.erb
+++ b/app/views/pseuds/_byline.html.erb
@@ -30,8 +30,7 @@
 </dt>
 <dd class="byline coauthors">
   <%= check_box_tag "co-authors-options-show", "1", nil, :class => "toggle_formfield" %>
-
-<fieldset id="co-authors-options" title="Add Co Authors">
-<%= text_field :pseud, :byline, autocomplete_options("pseud", :size => 50) %>
-</fieldset>
+  <fieldset id="co-authors-options" title="Add Co Authors">
+    <%= text_field :pseud, :byline, autocomplete_options("pseud", :size => 50) %>
+  </fieldset>
 </dd>

--- a/app/views/series/edit.html.erb
+++ b/app/views/series/edit.html.erb
@@ -76,3 +76,15 @@
 <% end %>
 </div>
 <!--/content-->
+
+<%= content_for :footer_js do %>
+  <%= javascript_tag do %>
+    $j(document).ready(function(){
+      $j(".toggle_formfield").click(function() {
+        var targetId = $j(this).attr("id").replace("-show", "");
+        toggleFormField(targetId);
+      });
+    })
+  <% end %>
+<% end %>
+


### PR DESCRIPTION
Issue 2959: fixing 500 error when series is invalid and live validation doesn't catch it. Also issue 2614: coauthor field on series form was broken.

Note: the toggling js should really not be on the individual views. Somebody needs to move those back to the .js file.

http://code.google.com/p/otwarchive/issues/detail?id=2959
http://code.google.com/p/otwarchive/issues/detail?id=2614
