### PR TITLE
Fix issue 2133 with pseud works index displaying user instead of pseud

### DIFF
--- a/app/views/works/index.html.erb
+++ b/app/views/works/index.html.erb
@@ -4,7 +4,7 @@
   <% if @collection %>
    <%= ts("in %{collection_title}", :collection_title => link_to(@collection.title, @collection)).html_safe %>
   <% elsif @user %>
-    <%= ts("by %{author_name}", :author_name => @author.name) %>
+    <%= @author ? ts("by %{author_name}", :author_name => @author.name) : ts("by %{user_name}", :user_name => @user.login) %>
   <% elsif @tag %>
     <%= ts("in %{tag_name}", :tag_name => @tag.name) %>
 <% end %>


### PR DESCRIPTION
Works index for a pseud should say "Works found by $pseud", not $user: http://code.google.com/p/otwarchive/issues/detail?id=2133
