### PR TITLE
Fix issue 2858 with extra manage items in prompt meme sidebar

### DIFF
--- a/app/views/challenge/prompt_meme/_challenge_sidebar.html.erb
+++ b/app/views/challenge/prompt_meme/_challenge_sidebar.html.erb
@@ -19,7 +19,6 @@
   </li>
   <% if @collection.user_is_maintainer?(current_user) %>
     <li><%= link_to ts("Unposted Claims (%{count})", :count => ChallengeClaim.unposted_in_collection(@collection).count), collection_claims_path(@collection) %></li>
-    <li><%= link_to ts("Manage Items"), collection_items_path(@collection) %></li>
   <% end %>    
 
 <% end %>


### PR DESCRIPTION
"Manage Items" was appearing twice in the sidebar on prompt meme challenge collections: http://code.google.com/p/otwarchive/issues/detail?id=2858
