### PR TITLE
Fix for issue 3010, allowing https links in the Abuse Report form

### DIFF
--- a/app/models/abuse_report.rb
+++ b/app/models/abuse_report.rb
@@ -7,7 +7,7 @@ class AbuseReport < ActiveRecord::Base
 
   attr_protected :comment_sanitizer_version
   
-  app_url_regex = Regexp.new('^https?:\/\/(www.)?' + ArchiveConfig.APP_HOST, true)
+  app_url_regex = Regexp.new('^https?:\/\/(www\.)?' + ArchiveConfig.APP_HOST, true)
   validates_format_of :url, :with => app_url_regex, :message => ts('does not appear to be on this site.')
   
   # id numbers for categories on 16bugs


### PR DESCRIPTION
Fix for issue 3010, allowing https links in the Abuse Report form
