### PR TITLE
Fix for issue 2894 - Remove 'full text' from advanced search options	

### DIFF
--- a/app/views/works/_search_form.html.erb
+++ b/app/views/works/_search_form.html.erb
@@ -5,12 +5,12 @@
   <% @query ||= {} %>
   <% end %>
   <dl>
-  <!--<dt>
-    <label for="refine_text"><%= ts('Full text') %>: </label> <%= link_to_help "work-search-text-help" %>
+  <dt>
+    <label for="refine_text"><%= ts('Any field') %>: </label> <%= link_to_help "work-search-text-help" %>
     </dt><dd>
     <%= text_field_tag "query[text]", @query[:text], :id => 'refine_text' %>
 
-  </dd> -->
+  </dd> 
   <dt>
     <label for="refine_tag"><%= ts('Tag') %>:</label>
     </dt><dd>


### PR DESCRIPTION
I commented out the "Full text" field on the off-chance that it gets resurrected at some point in the future.
