### PR TITLE
Issue 1264: create unique index for filter_id

### DIFF
--- a/db/migrate/20120501210459_add_unique_index_filter_id_to_filter_count.rb
+++ b/db/migrate/20120501210459_add_unique_index_filter_id_to_filter_count.rb
@@ -1,0 +1,32 @@
+class AddUniqueIndexFilterIdToFilterCount < ActiveRecord::Migration
+  def self.up
+    # first get rid of duplicates!
+    invalid_filter_counts = FilterCount.group(:filter_id).having("COUNT(filter_id) > 1")
+    invalid_filter_counts.each do |ifc|
+      # identify duplicates
+      filter_counts_to_remove = FilterCount.where(:filter_id => ifc.filter_id)
+      # preserve one of them
+      filter_counts_to_remove.shift
+      # delete the others
+      filter_counts_to_remove.each {|fc| fc.destroy }
+
+      # refresh the affected filter tags to be up to date
+      Tag.where(:id => ifc.filter_id).each do |filter_tag|
+        begin
+          filter_tag.reset_filter_count
+        rescue
+          puts "Problem resetting #{filter_tag.name}"
+        end
+      end
+    end
+
+    # replace the index with a unique index, which will not allow duplicates in the future
+    remove_index :filter_counts, :filter_id
+    add_index :filter_counts, :filter_id, :unique => true
+  end
+
+  def self.down
+    remove_index :filter_counts, :filter_id
+    add_index :filter_counts, :filter_id, :unique => false
+  end
+end


### PR DESCRIPTION
Issue 1264: create unique index for filter_id, so no more duplicate filter counts can be created at database-level

I know, data munging in the migration, but it's for the good cause of
ensuring we don't have any duplicates when creating the index.

http://code.google.com/p/otwarchive/issues/detail?id=1264

Will also deal with the schema, if needed and if I figure it out - will update pull req.
