### PR TITLE
Fix issue 3047 with font size increasing in iPod/iPhone landscape mode

### DIFF
--- a/public/stylesheets/site/2.0/25-role-handheld.css
+++ b/public/stylesheets/site/2.0/25-role-handheld.css
@@ -2,6 +2,10 @@
 linearise content, suppress large images, suppress custom fonts and other large downloads
 pasted in the Slim Shaded look temporarily to try to fix for iphone--needs test*/
 
+html {
+  -webkit-text-size-adjust: none;
+}
+
 #outer {
   font-size: 12px;
 }


### PR DESCRIPTION
Fix issue 3047 where rotating your iPod or iPhone into landscape mode would adjust the size of the font in Safari: http://code.google.com/p/otwarchive/issues/detail?id=3047
