### PR TITLE
Fix issue 3057 with missing class in fandoms listbox on stats page

### DIFF
--- a/app/views/stats/index.html.erb
+++ b/app/views/stats/index.html.erb
@@ -1,4 +1,4 @@
-<h2><%= ts("Statistics") %></h2>
+<h2 class="heading"><%= ts("Statistics") %></h2>
 
 <%= render "stats/navigation" %>
 


### PR DESCRIPTION
The statistics page was hard to read in Reversi, partly due to a missing 'group' class. http://code.google.com/p/otwarchive/issues/detail?id=3057
