### PR TITLE
Issue 3056 restricted works error message text should include all works

### DIFF
--- a/app/views/user_sessions/new.html.erb
+++ b/app/views/user_sessions/new.html.erb
@@ -1,7 +1,7 @@
 <% if params[:restricted] %>
   <h3 class="heading"><%= ts('Sorry!') %></h3>
   <p>
-    <%= ts('This story is only available to registered users of the Archive.') %>
+    <%= ts('This work is only available to registered users of the Archive.') %>
     <%= ts('If you already have an Archive of Our Own account, log in now.') %>
     <% if @admin_settings.account_creation_enabled? %>
       <%= link_to ts("Or join us for free - it's easy."), new_user_path %>


### PR DESCRIPTION
If you're logged out and you try to view a restricted work, the error message says "this story" instead of "this work" http://code.google.com/p/otwarchive/issues/detail?id=3056
