### PR TITLE
Error 500 on opendoors tool

### DIFF
--- a/app/controllers/redirect_controller.rb
+++ b/app/controllers/redirect_controller.rb
@@ -34,7 +34,7 @@ class RedirectController < ApplicationController
     redirect_to redirect_path
   end 
   
-  def index
+  def show
     if !@original_url.blank?
       redirect_to :action => :do_redirect, :original_url => @original_url and return
     end

--- a/app/views/opendoors/tools/index.html.erb
+++ b/app/views/opendoors/tools/index.html.erb
@@ -1,7 +1,7 @@
 <% unless @imported_from_url.blank? %>
   <p class="important">
     <%= ts('Test redirect: ') %>
-    <%= link_to @imported_from_url, redirects_path(:original_url => @imported_from_url) %>
+    <%= link_to @imported_from_url, redirect_path(:original_url => @imported_from_url) %>
   </p>
 <% end %>
 


### PR DESCRIPTION
The action index was replaced with show in most places, except the actual action definition in the controller :)

Also, there was a call to the old path, with an extra s.

http://code.google.com/p/otwarchive/issues/detail?id=3063
