### PR TITLE
Fix for issue 1807

### DIFF
--- a/app/models/creation_observer.rb
+++ b/app/models/creation_observer.rb
@@ -15,6 +15,13 @@ class CreationObserver < ActiveRecord::Observer
     do_notify(creation)
   end
 
+  # Send notifications if a creation has been edited and its recipients list has changed
+  def after_update(creation)
+    if creation.is_a?(Work)
+      notify_recipients(creation)
+    end
+  end
+  
   # send the appropriate notifications
   def do_notify(creation)
     if creation.is_a?(Work)
@@ -44,8 +51,8 @@ class CreationObserver < ActiveRecord::Observer
 
   # notify recipients that they have gotten a story!
   def notify_recipients(work)
-    if !work.recipients.blank? && !work.unrevealed?
-      recipient_pseuds = Pseud.parse_bylines(work.recipients, :assume_matching_login => true)[:pseuds]
+    if !work.new_recipients.blank? && !work.unrevealed?
+      recipient_pseuds = Pseud.parse_bylines(work.new_recipients, :assume_matching_login => true)[:pseuds]
       recipient_pseuds.each do |pseud|
         UserMailer.recipient_notification(pseud.user.id, work.id).deliver
       end

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -100,6 +100,7 @@ class Work < ActiveRecord::Base
   attr_accessor :ambiguous_pseuds
   attr_accessor :new_parent, :url_for_parent
   attr_accessor :should_reset_filters
+  attr_accessor :new_recipients
 
   ########################################################################
   # VALIDATION
@@ -328,13 +329,21 @@ class Work < ActiveRecord::Base
         new_gifts << Gift.new(:recipient => name.strip)
       end
     end
+    set_new_recipients(new_gifts)
     self.gifts = new_gifts
   end
 
   def recipients
     self.gifts.collect(&:recipient).join(",")
   end
-
+  
+  def set_new_recipients(gifts)
+    current_gifts = self.gifts.collect(&:recipient)
+    new_gifts = gifts.collect(&:recipient)
+    diff = new_gifts - current_gifts
+    self.new_recipients = diff.join(",")
+  end
+  
   ########################################################################
   # VISIBILITY
   ########################################################################

--- a/spec/models/work_spec.rb
+++ b/spec/models/work_spec.rb
@@ -31,5 +31,44 @@ describe Work do
     end
     
   end
+  
+  describe "new recipients virtual attribute" do
+    
+    before(:each) do
+      @author = Factory.create(:user)
+      @recipient1 = Factory.create(:user)
+      @recipient2 = Factory.create(:user)
+      @recipient3 = Factory.create(:user)
+      
+      @fandom1 = Factory.create(:fandom)
+      @chapter1 = Factory.create(:chapter)
+      
+      @work = Work.new(:title => "Title")
+      @work.fandoms << @fandom1
+      @work.authors = [@author.pseuds.first]
+      @work.recipients = @recipient1.pseuds.first.name + "," + @recipient2.pseuds.first.name
+      @work.chapters << @chapter1
+    end
+    
+    it "should be the same as recipients when they are first added" do
+      @work.new_recipients.should eq(@work.recipients)
+    end
+    
+    it "should only contain the new recipients when more are added" do
+      @work.recipients += "," + @recipient3.pseuds.first.name
+      @work.new_recipients.should eq(@recipient3.pseuds.first.name)
+    end
+    
+    it "should only contain the new recipient if replacing the previous recipient" do
+      @work.recipients = @recipient3.pseuds.first.name
+      @work.new_recipients.should eq(@recipient3.pseuds.first.name)
+    end
+    
+    it "should be empty if one or more of the original recipients are removed" do
+      @work.recipients = @recipient2.pseuds.first.name
+      @work.new_recipients.should be_empty
+    end
+    
+  end 
     
 end


### PR DESCRIPTION
Apologies for crappy variable naming. I blame Enigel who claimed to rock at naming things and then drew a blank when I asked for help. :P If one of you lovely people can think of something more meaningful then I will be more than happy to update the code where necessary. :)

_models/creation_observer.rb_
- after_update method added which fixes the initial problem of edited works not sending out gift notification emails. Also modified notify_recipients to use the new virtual atttribute new_recipients...

_models/work.rb_ 
- added a new virtual attribute new_recipients which stores changes to the recipients list. I hope the spec tests explain how this is supposed to be work, but that's assuming my test descriptions were clear, which they might not be.

_spec/models/work_spec.rb_ 
- added tests for the new_recipients virtual attribute.
