### PR TITLE
Issue 3065 - Rephrased text on Work Search

### DIFF
--- a/public/help/work-search-text-help.html
+++ b/public/help/work-search-text-help.html
@@ -5,9 +5,18 @@
 <p>The characters ":" and "@" have special meanings. Leave them out of your search or you will get unexpected results.</p>
 
 <dl>
-<dt>*: any characters </dt><dd><em>book*</em> will find <em>book</em> and <em>books</em> and <em>booking</em>.</dd>
-<dt>space: a space acts like AND </dt><dd><em>Harry Potter</em> will find <em>Harry Potter</em> and <em>Harry James Potter</em> but not <em>Harry</em>.</dd>
-<dt>|: OR (not exclusive) </dt><dd><em>Harry | Potter</em> will find <em>Harry</em>, <em>Harry Potter</em>, and <em>Potter</em>.</dd>
-<dt>": words in exact sequence </dt><dd><em>"Harry Lockhart"</em> will find <em>"Harry Lockhart"</em> but not <em>Harry Potter/Gilderoy Lockhart</em>.</dd>
-<dt>-: NOT </dt><dd><em>Harry -Lockhart</em> will find <em>Harry Potter</em> but not <em>Harry Lockhart</em> or <em>Gilderoy Lockhart/Harry Potter</em>.</dd>
+  <dt>*: any characters </dt>
+  <dd><em>book*</em> will find <em>book</em> and <em>books</em> and <em>booking</em>.</dd>
+  
+  <dt>space: a space acts like AND </dt>
+  <dd><em>Harry Potter</em> will find <em>Harry Potter</em> and <em>Harry James Potter</em> but not <em>Harry</em>.</dd>
+  
+  <dt>|: OR (not exclusive) </dt>
+  <dd><em>Harry | Potter</em> will find <em>Harry</em>, <em>Harry Potter</em>, and <em>Potter</em>.</dd>
+  
+  <dt>": words in exact sequence </dt>
+  <dd><em>"Harry Lockhart"</em> will find <em>"Harry Lockhart"</em> but not <em>Harry Potter/Gilderoy Lockhart</em>.</dd>
+  
+  <dt>-: NOT </dt>
+  <dd><em>Harry -Lockhart</em> will find <em>Harry Potter</em> but not <em>Harry Lockhart</em> or <em>Gilderoy Lockhart/Harry Potter</em>.</dd>
 </dl>


### PR DESCRIPTION
Amended wording on Works Search help text to make it less specific to the search page and clearer as to what is being searched.
