### PR TITLE
Fix issue 2809 with long collection name in filters causing scrolling

### DIFF
--- a/public/stylesheets/site/2.0/07-interactions.css
+++ b/public/stylesheets/site/2.0/07-interactions.css
@@ -210,7 +210,6 @@ form li ul.autocomplete li.input {
 
 .autocomplete li.added, .post .meta dd ul li.added {
   display: inline-block;
-  white-space: nowrap;
 }
 
 /* WIDGET: SORTABLE LIST (note: hope to merge with .sortable and .draggable etc)*/


### PR DESCRIPTION
Fixes issue 2809 where long collection names were making the filter box so wide as to cause horizontal scrolling on the Collection index http://code.google.com/p/otwarchive/issues/detail?id=2809
