### PR TITLE
Issue 2107: adding a co-author that's not a registered Archive pseud

### DIFF
--- a/app/controllers/chapters_controller.rb
+++ b/app/controllers/chapters_controller.rb
@@ -109,7 +109,7 @@ class ChaptersController < ApplicationController
     load_pseuds
 
     if !@chapter.invalid_pseuds.blank? || !@chapter.ambiguous_pseuds.blank?
-      @chapter.valid? ? (render :partial => 'choose_coauthor', :layout => 'application') : (render :new)
+      @chapter.valid? ? (render :_choose_coauthor) : (render :new)
     elsif params[:edit_button]
       render :new
     elsif params[:cancel_button]
@@ -147,7 +147,7 @@ class ChaptersController < ApplicationController
     load_pseuds
 
     if !@chapter.invalid_pseuds.blank? || !@chapter.ambiguous_pseuds.blank?
-      @chapter.valid? ? (render :partial => 'choose_coauthor', :layout => 'application') : (render :new)
+      @chapter.valid? ? (render :_choose_coauthor) : (render :new)
     elsif params[:preview_button] || params[:cancel_coauthor_button]
       @preview_mode = true
       render :preview_edit

--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -268,7 +268,7 @@ class WorksController < ApplicationController
         end
       else
         if @work.errors.empty? && (!@work.invalid_pseuds.blank? || !@work.ambiguous_pseuds.blank?)
-          render :partial => 'choose_coauthor', :layout => 'application'
+          render :_choose_coauthor
         else
           unless @work.has_required_tags?
             if @work.fandoms.blank?
@@ -393,9 +393,6 @@ class WorksController < ApplicationController
         elsif params[:update_button]
           setflash; flash[:notice] = ts('Work was successfully updated.')
         end
-
-        #bleep += "  AFTER SAVE: author attr: " + params[:work][:author_attributes][:ids].collect {|a| a}.inspect + "  @work.authors: " + @work.authors.collect {|au| au.id}.inspect + "  @work.pseuds: " + @work.pseuds.collect {|ps| ps.id}.inspect
-        #setflash; flash[:notice] = "DEBUG: in UPDATE save:  " + bleep
 
         redirect_to(@work)
       else

--- a/app/views/chapters/_choose_coauthor.html.erb
+++ b/app/views/chapters/_choose_coauthor.html.erb
@@ -1,14 +1,14 @@
-<p><%=h t('.coauthor_verify', :default => 'Please verify the names of your co-authors') %></p>
+<p><%= ts('Please verify the names of your co-authors') %></p>
 
 <%= form_for([@work, @chapter]) do |f| %>
   
-  <%= render :partial => 'pseuds/coauthor_form', :locals => {:creation => @chapter, :form => f} %>
+  <%= render 'pseuds/coauthor_form', :creation => @chapter, :form => f %>
    
-  <%= render :partial => 'hidden_fields', :locals => {:form => f} %>
+  <%= render 'hidden_fields', :form => f %>
     
   <p class="submit actions">
-    <%= submit_tag t('.forms.preview', :default => 'Preview'), :name => 'preview_button' %>
-    <%= submit_tag t('.forms.cancel', :default => 'Cancel'), :name => 'cancel_coauthor_button' %> 
+    <%= submit_tag ts('Preview'), :name => 'preview_button' %>
+    <%= submit_tag ts('Cancel'), :name => 'cancel_coauthor_button' %> 
   </p>
 
 <% end %>


### PR DESCRIPTION
Issue 2107: adding a co-author that's not a registered Archive pseud causes error 500

It was just a leftover Rails syntax change thing
(http://stackoverflow.com/questions/7322868/rails-3-vs-2-3-5-render-oddi
ties-with-partial-and-layout )

http://code.google.com/p/otwarchive/issues/detail?id=2107
