### PR TITLE
Fix issue 3079 adding Mac keyboard instructions to fandoms indexes

### DIFF
--- a/app/views/fandoms/index.html.erb
+++ b/app/views/fandoms/index.html.erb
@@ -6,7 +6,7 @@
 <% else %>
   <h2 class="heading"><%= link_to ts('Fandoms'), media_path %></h2>
 <% end %>
-<p>You can search this page by pressing <kbd>ctrl F</kbd> and typing in what you are looking for.</p>
+<p>You can search this page by pressing <kbd>ctrl F</kbd> / <kbd>cmd F</kbd> and typing in what you are looking for.</p>
 <% if @collection %>
 <div class="filters">
 	<h3 class="landmark heading"><%= ts('Filters') %></h3>


### PR DESCRIPTION
Issue 3079 where the instructions for searching on the fandoms index pages were specific to PCs: http://code.google.com/p/otwarchive/issues/detail?id=3079
