### PR TITLE
Issue 2966 - Dimensions hint is now a bullet point

### DIFF
--- a/app/views/pseuds/_pseuds_form.html.erb
+++ b/app/views/pseuds/_pseuds_form.html.erb
@@ -25,8 +25,9 @@
     <% unless @pseud.new_record? %>
       <li><%= icon_display(@user, @pseud) %> <%= ts("This is your icon.") %></li>
     <% end %>
-    <li><%= ts("You can have one icon for each pseud.") %></li>
-    <li><%= ts("Icons can be in png, jpeg or gif format, and should be sized 100x100 pixels for best results.") %></li>
+    <li><%= ts("You can have one icon for each pseud") %></li>
+    <li><%= ts("Icons can be in png, jpeg or gif form") %></li> 
+    <li><%= ts("Icons should be sized 100x100 pixels for best results") %></li> 
   </ul>
   <% if @pseud.icon_file_name %>
     <%= f.check_box :delete_icon, {:checked => false} %>


### PR DESCRIPTION
As per testing party consensus, the new hint now has its own bullet point rather than being tagged on the end of the format hint.
