### PR TITLE
Fix issue 2724 with pseud list in sidebar skipped in keyboard navigating

### DIFF
--- a/app/views/users/_sidebar.html.erb
+++ b/app/views/users/_sidebar.html.erb
@@ -5,12 +5,12 @@
   <% if @user.pseuds.size > 1 %>
     <li class="pseud" aria-haspopup="true">
       <% pseud_link_text = ((current_page?(@user) ? ts("Pseuds") : (@author ? @author.name : @user.login)) + ' &#8595;').html_safe %>
-      <a class="pseud_switcher_open open" title="Pseuds"><%= pseud_link_text %></a>
-      <a class="pseud_switcher_close close" title="Pseuds"><%= pseud_link_text %></a>
+      <a class="pseud_switcher_open open" title="Pseuds" href="#"><%= pseud_link_text %></a>
+      <a class="pseud_switcher_close close" title="Pseuds" href="#"><%= pseud_link_text %></a>
       <ul id="pseud_switcher" class="toggled secondary">
           <%= print_pseud_selector(@user.pseuds) %>
         <li><%= span_if_current ts("All Pseuds (%{pseud_number})", :pseud_number => @user.pseuds.count), user_pseuds_path(@user) %></li>
-        <li><a class="pseud_switcher_close close action" style='cursor: pointer;' title="Close Pseud Switcher">X</a></li>
+        <li><a class="pseud_switcher_close close action" style='cursor: pointer;' title="Close Pseud Switcher" href="#">X</a></li>
       </ul>
     </li>
 	<% end %>


### PR DESCRIPTION
If you're using a keyboard to navigate the site, the pseud list in the side bar and the icon in the header were skipped: http://code.google.com/p/otwarchive/issues/detail?id=2724

This fixes the pseud list issue but not the icon.
