### PR TITLE
Fix issue 2666 with items overflowing scrolling listboxes in IE7

### DIFF
--- a/public/stylesheets/site/2.0/31-role-ie7.css
+++ b/public/stylesheets/site/2.0/31-role-ie7.css
@@ -20,6 +20,12 @@ ul#skiplinks, .landmark, .landmark a, .index .heading.landmark {
   margin-bottom: 0.643em;
 }
 
+/* scrolling listbox list item containment */
+
+.listbox .many ul {
+  position: relative;
+}
+
 /*font fallbacks for icons*/
 
 span.replied. span.unreviewed, .actions a, .action, .symbol {


### PR DESCRIPTION
In IE7, list items that were supposed to be contained inside a scrolling listbox (such as on the tag set edit page) were escaping: http://code.google.com/p/otwarchive/issues/detail?id=2666
