### PR TITLE
Fix issue 2821 with hidden help for filters

### DIFF
--- a/public/stylesheets/site/2.0/18-zone-searchbrowse.css
+++ b/public/stylesheets/site/2.0/18-zone-searchbrowse.css
@@ -67,6 +67,17 @@ form.filters {
   float: right;
 }
 
+form.filters legend {
+  height: auto;
+  width: auto;
+  font-size: 100%;
+  background: #fff;
+  border: 2px solid #ddd;
+  padding: 0.5em;
+    box-shadow: 1px 2px 3px #999;
+    opacity: 1;
+}
+
 .filters .tags {
   display: block;
 }


### PR DESCRIPTION
The filters form has a help link in its legend, but the legend was hidden and thus help was only accessible to keyboard users, which was weird: http://code.google.com/p/otwarchive/issues/detail?id=2821
