### PR TITLE
Issue 2183 with empty ul on blurb for moderated challenges

### DIFF
--- a/app/views/challenge/shared/_challenge_navigation_user.html.erb
+++ b/app/views/challenge/shared/_challenge_navigation_user.html.erb
@@ -12,6 +12,16 @@
       </li>
     <% elsif (!collection.moderated? || collection.user_is_posting_participant?(current_user)) %>
       <li><%= link_to ts("Sign Up"), new_collection_signup_path(collection) %></li>
+    <% elsif !collection.user_is_owner?(current_user) && collection.moderated? %>
+      <% if (@participant ||= collection.get_participants_for_user(current_user).first) %>  
+        <li><%= link_to ts("Leave"), collection_participant_path(collection, @participant), 
+          :confirm => ts('Are you certain you want to leave this collection?'), 
+          :method => :delete %></li>
+      <% elsif collection.moderated? %>
+        <li><%= link_to ts("Join"), join_collection_participants_path(collection) %></li>
+      <% end %>
     <% end %>
   <% end %>
+<% elsif logged_in? && collection.challenge && collection.moderated? && !collection.challenge.signup_open %>
+  <li><%= link_to ts("Join"), join_collection_participants_path(collection) %></li>
 <% end %>

--- a/app/views/collections/_header.html.erb
+++ b/app/views/collections/_header.html.erb
@@ -19,7 +19,7 @@
   	  <%= render "challenge/#{challenge_class_name(@collection)}/challenge_navigation_user" %>
   	<% end %>
 
-    <% unless @collection.user_is_owner?(current_user) %>
+    <% unless @collection.challenge || @collection.user_is_owner?(current_user) %>
       <% if (@participant ||= @collection.get_participants_for_user(current_user).first) %>  
         <li><%= link_to ts("Leave"), collection_participant_path(@collection, @participant), 
           :confirm => ts('Are you certain you want to leave this collection?'), 


### PR DESCRIPTION
If you view the collections index and see a open, moderated challenge of which you are not a member, maintainer, or owner, you can view the source and see there is an empty ul navigation element in the blurb which would normally contain buttons for Sign Up/Edit Sign Up/Cancel Sign Up: http://code.google.com/p/otwarchive/issues/detail?id=2183

I went with the suggestion of adding a Join button, but I could change it so no ul displays at all.
