### PR TITLE
Issue 2445 - Prompts page says freeforms instead of additional tags

### DIFF
--- a/app/views/prompts/_prompt_form_tag_options.html.erb
+++ b/app/views/prompts/_prompt_form_tag_options.html.erb
@@ -2,7 +2,7 @@
 <% form.object.build_tag_set unless form.object.tag_set %>
 <%= form.fields_for :tag_set do |tag_set_form| %>
   <% TagSet::TAG_TYPES.each do |tag_type| %>
-
+    <% tag_name = tag_type.titleize.constantize::NAME %>
     <% num_allowed = restriction.allowed(tag_type) %>
     <% num_required = restriction.required(tag_type) %>
     <% if num_allowed > 0 %>
@@ -11,11 +11,11 @@
       <% tag_field_id =  field_id(tag_set_form, "#{tag_type}_tagnames") %>
 
       <dt<%= num_required > 0 ? ' class="required"'.html_safe : '' %>>
-        <%= tag_set_form.label "#{tag_type}_tagnames".to_sym, ((num_allowed > 1) ? tag_type.pluralize : tag_type).titleize, :class => tag_type %>
+        <%= tag_set_form.label "#{tag_type}_tagnames".to_sym, ((num_allowed > 1) ? tag_name.pluralize : tag_name), :class => tag_type %>
         <%= num_required == num_allowed ? " (#{num_required})" : " (#{num_required} - #{num_allowed})" %>:
       </dt>
 
-      <dd title="<%= ts("choose #{tag_type.pluralize}") %>">
+      <dd title="<%= ts("choose #{tag_name.pluralize.downcase}") %>">
         <% # kludge required for bug in nested_attributes_for:https://rails.lighthouseapp.com/projects/8994/tickets/2646-validations-not-called-when-model-updating-using-nested-attributes %>
         <%= tag_set_form.hidden_field :updated_at, :value => Time.now %>
 
@@ -40,7 +40,7 @@
         <% if TagSet::TAGS_AS_CHECKBOXES.include?(tag_type) %>
           <% # do ratings, warnings, categories as taglists if not already specified %>
           <fieldset class="<%= ts("#{tag_type}") %> listbox">
-            <h4 class="heading"><%= ts("#{tag_type.pluralize}") %></h4>
+            <h4 class="heading"><%= ts("#{tag_name.pluralize}") %></h4>
             <%= checkbox_section tag_set_form, "#{tag_type}_tagnames", 
               (restriction.has_tags?(tag_type) ? restriction.tags(tag_type) : tag_type.classify.constantize.canonical).map {|t| t.name},
               :checked_method => "#{tag_type}_tagnames", :value_method => "to_s", :name_method => "to_s" %>
@@ -50,7 +50,7 @@
           <% # characters or relationships restricted to fandom: use an autocomplete and either do/don't include wrangled tags %>
           <% autocomplete_method = "associated_tags?fallback=false&tag_type=#{tag_type}&tag_set=#{restriction.tag_set_ids.join(',')}" %>
           <% autocomplete_method += "&include_wrangled=false" if restriction.restricted?(tag_type, "tag_set") %>
-          <div title="<%= ts("choose #{tag_type.pluralize} from your selected fandoms") %>">
+          <div title="<%= ts("choose #{tag_name.pluralize.downcase} from your selected fandoms") %>">
             <%= tag_set_form.text_field "#{tag_type}_tagnames", 
                               autocomplete_options(autocomplete_method, :autocomplete_min_chars => 0, :autocomplete_token_limit => num_allowed,
                                       :autocomplete_hint_text => ts("Please select a fandom first!"),
@@ -69,12 +69,12 @@
 
               <!-- create a scrollable checkboxes section to wrap the tags, see application_helper -->
               <fieldset class="<%= ts("#{tag_type}") %> listbox">
-                <h4 class="heading"><%= ts("#{tag_type}") %></h4>
+                <h4 class="heading"><%= ts("#{tag_name}") %></h4>
                 <%= checkbox_section tag_set_form, "#{tag_type}_tagnames", restriction.tags(tag_type).by_name_without_articles.value_of(:name),
                     :checked_method => "#{tag_type}_tagnames", :value_method => "to_s", :name_method => "to_s" %>
               </fieldset>
             <% else # we have set options but too many for tickyboxes, do autocomplete instead %>        
-              <div title="<%= ts("choose #{tag_type.pluralize} from the challenge options") %>">
+              <div title="<%= ts("choose #{tag_name.pluralize.downcase} from the challenge options") %>">
                 <%= tag_set_form.text_field "#{tag_type}_tagnames", 
                     autocomplete_options("tags_in_sets?tag_type=#{tag_type}&tag_set=#{restriction.tag_set_ids.join(',')}", :autocomplete_token_limit => num_allowed) %>
               </div>
@@ -86,7 +86,7 @@
               </p>
             <% end %>
           <% else # no specified tags so let's just go with standard autocomplete %>
-            <div title="<%= ts("choose #{tag_type.pluralize} from canonical archive tags") %>">
+            <div title="<%= ts("choose #{tag_name.pluralize.downcase} from canonical archive tags") %>">
               <%= tag_set_form.text_field "#{tag_type}_tagnames", autocomplete_options(tag_type, :autocomplete_token_limit => num_allowed) %>
             </div>
           <% end %>


### PR DESCRIPTION
Replaced the displayed tag_type with a variable based on the corresponding NAME constant to fix the Freeforms issue and enable future changes.
http://code.google.com/p/otwarchive/issues/detail?id=2445
