### PR TITLE
Issue 3096 hide referrers and download counts

### DIFF
--- a/app/views/stats/index.html.erb
+++ b/app/views/stats/index.html.erb
@@ -81,10 +81,11 @@
                   <dt><%= ts("Kudos") %></dt><dd><%= work.kudos.count %></dd>
                   <dt><%= ts("Comments") %></dt><dd><%= work.comments.count %></dd>
                   <dt><%= ts("Bookmarks") %></dt><dd><%= work.bookmarks.count %></dd>
-                  <% # dt ts("Newest Link") /dt dd %>
+                  <% # dt ts("Newest Link") /dt %>
+                    <% # dd %>
                     <% # work.work_links.last.try(:url) || ts("none yet") %> 
                     <% # ( link_to ts("see all"), work_links_path(:work_id => work.id) /a ) %>
-                  </dd>
+                  <% # /dd %>
                 </dl>
               </dd>
             </dl>


### PR DESCRIPTION
Referrers and download counts weren't working, so we needed to hide them from the stats page: http://code.google.com/p/otwarchive/issues/detail?id=3096

Bonus note! There's a closing anchor tag in the referrers on Line 87 that we don't seem to need: (<%= link_to ts("see all"), work_links_path(:work_id => work.id) %></a>)
