### PR TITLE
Issue 3081 External Works on tag edit page should link to bookmarks

### DIFF
--- a/app/views/tag_wranglings/_wrangler_dashboard.html.erb
+++ b/app/views/tag_wranglings/_wrangler_dashboard.html.erb
@@ -17,6 +17,8 @@
         <% for key in @uses %>
           <% if key == 'Works' || key == 'Bookmarks' %>
           <li><%= span_if_current "#{key} (#{@counts[key]})", {:controller => key.downcase.to_sym, :action => :index, :tag_id => @tag} %></li>
+          <% elsif key == 'External Works' %>
+          <li><%= span_if_current "#{key} (#{@counts[key]})", {:controller => :bookmarks, :action => :index, :tag_id => @tag} %></li>
           <% else %>
           <li><span><%= "#{key} (#{@counts[key]})" %></span></li>
           <% end %>


### PR DESCRIPTION
Tag wranglers wanted the External Works link on the dashboard/left side of the tag edit page to link to bookmarks: http://code.google.com/p/otwarchive/issues/detail?id=3081
