### PR TITLE
Issue 3110 wordcount

### DIFF
--- a/app/models/chapter.rb
+++ b/app/models/chapter.rb
@@ -190,9 +190,11 @@ class Chapter < ActiveRecord::Base
         end
       end
       self.word_count = count
+    else
+      self.word_count
     end
   end
-    
+
   # Return the name to link comments to for this object
   def commentable_name
     self.work.title

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -187,11 +187,10 @@ class Work < ActiveRecord::Base
   ########################################################################
   before_save :validate_authors, :clean_and_validate_title, :validate_published_at, :ensure_revised_at
 
-  before_save :set_word_count, :post_first_chapter
+  before_save :post_first_chapter, :set_word_count
 
   after_save :save_chapters, :save_parents
 
-  # before_save :validate_tags # Enigel's feeble attempt
   before_save :check_for_invalid_tags
   before_update :validate_tags
   after_update :adjust_series_restriction
@@ -467,6 +466,7 @@ class Work < ActiveRecord::Base
   def post_first_chapter
     if self.posted_changed?
       self.chapters.first.posted = self.posted
+      self.chapters.first.save
     end
   end
 


### PR DESCRIPTION
In the work model: post_first_chapter needs to happen before set_word_count, and changing the chapter's posted state needs to be saved.

In the chapter model: set_word_count was returning nil if the chapter wasn't a new_record or the content hadn't changed - needed because of the first change, or it moves the nil problem to the PwP workflow :)

http://code.google.com/p/otwarchive/issues/detail?id=3110
