### PR TITLE
Issue 3100: works in multiple fandoms get various totals inflated

### DIFF
--- a/app/controllers/stats_controller.rb
+++ b/app/controllers/stats_controller.rb
@@ -59,7 +59,7 @@ class StatsController < ApplicationController
     
     # group by fandom or flat view
     if params[:flat_view]
-      @works = {ts("All Fandoms") => works}
+      @works = {ts("All Fandoms") => works.uniq}
     else
       @works = works.group_by(&:fandom)
     end
@@ -69,7 +69,7 @@ class StatsController < ApplicationController
     (sort_options - ["date"]).each do |value|
       # see explanation above about the eval here
       # the inject is used to collect the sum in the "result" variable as we iterate over all the works
-      @totals[value.split(".")[0].to_sym] = works.inject(0) {|result, work| result + (eval("work.#{value}") || 0)} # sum the works
+      @totals[value.split(".")[0].to_sym] = works.uniq.inject(0) {|result, work| result + (eval("work.#{value}") || 0)} # sum the works
     end
     @totals[:author_subscriptions] = Subscription.where(:subscribable_id => @user.id, :subscribable_type => 'User').count
 
@@ -83,7 +83,7 @@ class StatsController < ApplicationController
       
     # Add Rows and Values 
     # see explanation above about the eval here
-    @chart_data.add_rows(works[0..4].map {|w| [w.title, eval("w.#{chart_col}")]})
+    @chart_data.add_rows(works.uniq[0..4].map {|w| [w.title, eval("w.#{chart_col}")]})
 
     # image version of bar chart
     # opts from here: http://code.google.com/apis/chart/image/docs/gallery/bar_charts.html

--- a/app/views/stats/index.html.erb
+++ b/app/views/stats/index.html.erb
@@ -66,7 +66,7 @@
             <dl>
               <dt>
                 <%= link_to work.title, work_path(:id => work.id) %> 
-                <% if params[:flat_view] %><span class="fandom">(<%= work.fandom %>)</span><% end %>
+                <% if params[:flat_view] %><span class="fandom">(<%= work.fandom_string %>)</span><% end %>
                 <span class="wordcount">(<%= ts("%{wordcount} words", :wordcount => work.word_count) %>)</span>
               </dt>
               <dd>


### PR DESCRIPTION
In most of these places, works is already an array, so using uniq on it
shouldn't affect performance too much, versus having buggy stats.

Haven't addressed display opinions, or the fandom synonyms, only things that were definitely bugs regarding inflated totals and multifandom works showing up multiple times in the flat view list and in the chart.

http://code.google.com/p/otwarchive/issues/detail?id=3100
