### PR TITLE
Issue 3114 alerting visitors to delay when commenting/kudosing

### DIFF
--- a/app/views/comments/_commentable.html.erb
+++ b/app/views/comments/_commentable.html.erb
@@ -50,6 +50,10 @@
         <li id="show_comments_link"><%= show_hide_comments_link(commentable) %></li>
     <% end %>
   </ul>
+  
+        <% unless logged_in? %>
+        <p class="caution"><%= ts("Your comment or kudos may take up to 20 minutes to appear on the page.") %></p>
+      <% end %>
 
   <h3 class="landmark heading"><a name="comments"><%= ts("Comments") %></a></h3>
 


### PR DESCRIPTION
If we turn on caching and can't get it to expire when visitors leave a comment/kudos, we need to let them know it'll be a while before their comment/kudos shows up: http://code.google.com/p/otwarchive/issues/detail?id=3114

Only merge if necessary
