### PR TITLE
Issue 3142 increase font size of kbd tt code var and pre text

### DIFF
--- a/public/stylesheets/site/2.0/02-elements.css
+++ b/public/stylesheets/site/2.0/02-elements.css
@@ -129,7 +129,7 @@ blockquote p:last-child {
 }
 
 kbd, tt, code, var, pre {
-  font: normal 0.75em 'Monaco', 'Consolas', Courier, monospace;
+  font: normal 0.857em 'Monaco', 'Consolas', Courier, monospace;
   margin: auto;
 }
 


### PR DESCRIPTION
Fix issue 3142 where the font size of certain items did not match the rest of the site: http://code.google.com/p/otwarchive/issues/detail?id=3142

The fix here is actually a compromise -- I bumped it up from 0.75em to 0.857em (for users with a default font size of 16px, this is an increase from 11px to 12px). Making the font the same size made it too difficult to tell the kbd/code/etc text from the surrounding text, especially in instances where the first and last characters were punctuation (which happens a lot with code or when telling people to input a search term).
