### PR TITLE
Issue 3092: Pages with work blurbs do not validate

### DIFF
--- a/app/views/works/_work_blurb.html.erb
+++ b/app/views/works/_work_blurb.html.erb
@@ -33,7 +33,7 @@
         <% if work.hidden_by_admin %><%= image_tag("lockred.png", :size => "15x15", :alt => "(Hidden by Admin)", :title => "Hidden by Administrator") %><% end %>
       </h4>
 
-  	  <h5 class="fandom heading" title="fandoms">
+  	  <h5 class="fandoms heading" title="fandom">
         <% fandoms = tag_groups['Fandom'] %>
         <%= fandoms.collect{|tag| link_to_tag_works(tag) }.join(', ').html_safe if fandoms %>
   		  &nbsp;


### PR DESCRIPTION
Fixed duplicate 'class' attribute in _work_blurb.html.erb file. Dropped errors from 35 to 10 here:

http://validator.w3.org/check?uri=http%3A%2F%2Fscott.archiveofourown.org%2Fworks&charset=%28detect+automatically%29&doctype=Inline&group=0&user-agent=W3C_Validator%2F1.3

Hopefully resolves: http://code.google.com/p/otwarchive/issues/detail?id=3092
