### PR TITLE
Fix issue 3148 adding kbd tags to share instructions

### DIFF
--- a/app/views/works/_work_header_navigation.html.erb
+++ b/app/views/works/_work_header_navigation.html.erb
@@ -75,7 +75,7 @@
   <li class="share">
     <%= link_to_ibox ts("Share"), :for => "#share" %>
     <div id="share" style="display: none;">
-      <p><%= ts("Copy and paste to link back to this work: (CTRL/CMD-A will select all)") -%></p>
+      <p><%= ts("Copy and paste the following code to link back to this work (") %><kbd><%= ts("ctrl A")%></kbd><%= ts(" / ") %><kbd><%= ts("cmd A")%></kbd><%= ts(" will select all), or use the Tweet link to share the work on Twitter.") %></p>
       <p><textarea rows="4" cols="50"><%= get_embed_link(@work) %></textarea></p>
       <% if @work.users.all? {|u| u.preference.disable_share_links?} %>
         <p><%= ts("The author has chosen to disable share buttons.") %></p>


### PR DESCRIPTION
The directions for sharing a work tell visitors to input something on their keyboards, but the input was not in kbd tags http://code.google.com/p/otwarchive/issues/detail?id=3148

Also added a mention of the Tweet link, since it's easy to overlook. The input instructions have been lowercased to match the instructions on the media index.
