### PR TITLE
Issue_3158: Increase icon alt txt from 50 to 250 characters

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -81,7 +81,7 @@ LOGNOTE_MAX: 1250
 FEEDBACK_SUMMARY_MAX: 100
 INFO_MAX: 100000
 FAQ_MAX: 200000
-ICON_ALT_MAX: 50
+ICON_ALT_MAX: 250
 ICON_COMMENT_MAX: 50
 
 # max number of tags of each type allowed in challenge prompts (requests/offers)


### PR DESCRIPTION
Resolves Issue_3158: http://code.google.com/p/otwarchive/issues/detail?id=3158

Increased character max limit to 250 from 50. 
