### PR TITLE
Update issue 3151 with invisible labels on bookmark fields

### DIFF
--- a/app/views/bookmarks/_bookmark_form.html.erb
+++ b/app/views/bookmarks/_bookmark_form.html.erb
@@ -38,13 +38,6 @@
       <% end %>
       <%= ts(" save a bookmark!") %>
     </h4>
-    <p class="footnote">(
-      <% if bookmarkable.class != ExternalWork %>
-        <%= ts("The author's summary and tags are added automatically.") %> 
-      <% end %>
-      <%= allowed_html_instructions(show_list=false) %>)
-    </p>
-
 
       <% # What we're bookmarking %>
       <% if bookmarkable.class == ExternalWork && bookmarkable.new_record? %>
@@ -64,7 +57,10 @@
         <dl>
           <dt><%= f.label :notes, ts("Notes") %></dt>
           <dd>
-            <%= allowed_html_instructions %>
+            <p class="footnote">
+              <% if bookmarkable.class != ExternalWork %><%= ts("The author's summary and tags are added automatically.") %><% end %>
+              <%= allowed_html_instructions(show_list=false) %>
+            </p>
             <%= f.text_area :notes, :rows => 4, :class => "observe_textlength" %>
             <%= generate_countdown_html("bookmark_notes", ArchiveConfig.NOTES_MAX) %>
           </dd>

--- a/public/stylesheets/site/2.0/07-interactions.css
+++ b/public/stylesheets/site/2.0/07-interactions.css
@@ -383,6 +383,10 @@ div.dynamic {
     box-shadow: none;
 }
 
+.toggled .bookmark form p.footnote {
+  padding-bottom: 0.643em;
+}
+
 /*INTERACTION: LOGIN SIGNUP*/
 
 /*INTERACTION: POST (work, chapter, comment, news, feedback, challenge etc) */


### PR DESCRIPTION
Fix confusing styling that resulted from making the labels on the new bookmark form visible: http://code.google.com/p/otwarchive/issues/detail?id=3151#c5
