### PR TITLE
Fix issue 3187 with profile link in stats navigation

### DIFF
--- a/app/views/stats/_navigation.html.erb
+++ b/app/views/stats/_navigation.html.erb
@@ -1,5 +1,4 @@
 <ul role="navigation" class="navigation actions">
   <li><%= span_if_current ts("Stats"), user_stats_path(@user) %></li>
-  <li><%= link_to ts("Profile"), user_profile_path(@user) %></li>
   <li><%= link_to ts("Edit Works"), show_multiple_user_works_path(@user) %></li>
 </ul>


### PR DESCRIPTION
Remove profile link from stats navigation: http://code.google.com/p/otwarchive/issues/detail?id=3187
