### PR TITLE
Issue 3189 making 'Expand full list' button for user fandoms keyboard navigable

### DIFF
--- a/app/views/users/_contents.html.erb
+++ b/app/views/users/_contents.html.erb
@@ -29,8 +29,8 @@
             <%= link_to ts("Expand full list"), url_for(:expand_fandoms => true) %>
           <% end %>
         </noscript>
-        <a class="fandom_full_list_open hidden"><%= ts("Expand full list") %></a>
-        <a class="fandom_full_list_close hidden"><%= ts("Hide full list") %></a>
+        <a class="fandom_full_list_open hidden" href="#"><%= ts("Expand full list") %></a>
+        <a class="fandom_full_list_close hidden" href="#"><%= ts("Hide full list") %></a>
       </p>
     <% end %>
   </div>


### PR DESCRIPTION
On user dashboards, the 'expand full list' button for showing all of a user's fandoms would be skipped when trying to navigate with a keyboard: http://code.google.com/p/otwarchive/issues/detail?id=3189
