### PR TITLE
Fix issue 3184 with tag icon showing under a wrangler's transparent icon

### DIFF
--- a/public/stylesheets/site/2.0/17-zone-home.css
+++ b/public/stylesheets/site/2.0/17-zone-home.css
@@ -45,6 +45,10 @@ user home, collections and challenges home, tag home, admin comms home
   background: url("/images/imageset.png") 0px -275px;
 }
 
+.wrangler .primary .icon {
+  background: none;
+}
+
 /*contexts*/
 
 .profile .primary {


### PR DESCRIPTION
On a wrangler's page, the red t icon was showing beneath the wrangler's icon: http://code.google.com/p/otwarchive/issues/detail?id=3184
