### PR TITLE
Issue 3192: change label from 'comments' to 'comment threads' on stats p...

### DIFF
--- a/app/views/stats/index.html.erb
+++ b/app/views/stats/index.html.erb
@@ -82,7 +82,7 @@
                   <% end %>
                   <% # dt ts("Downloads") /dt dd work.downloads /dd %>
                   <dt><%= ts("Kudos") %></dt><dd><%= work.kudos.count %></dd>
-                  <dt><%= ts("Comments") %></dt><dd><%= work.comments.count %></dd>
+                  <dt><%= ts("Comment Threads") %></dt><dd><%= work.comments.count %></dd>
                   <dt><%= ts("Bookmarks") %></dt><dd><%= work.bookmarks.count %></dd>
                   <% # dt ts("Newest Link") /dt %>
                     <% # dd %>


### PR DESCRIPTION
...age

Resolves issue: http://code.google.com/p/otwarchive/issues/detail?id=3192

Changed label from 'Comments' to 'Comment Thread'. The issue is that the comment count is showing only 'Top-Level' comments, and not replies or replies to replies. This label change clarifies what is meant to be represented on the stats page. 
