### PR TITLE
Update Issue 3151 with invisible labels on bookmark fields

### DIFF
--- a/app/views/bookmarks/_bookmark_form.html.erb
+++ b/app/views/bookmarks/_bookmark_form.html.erb
@@ -67,9 +67,9 @@
 
           <dt><%= f.label :tag_string, ts("Your Tags") %></dt>
           <dd title="your tags">
-            <p class="footnote">
-              <% if bookmarkable.class != ExternalWork %><%= ts("The author's tags are added automatically.") %><% end %>
-            </p>
+            <% if bookmarkable.class != ExternalWork %>
+              <p class="footnote"><%= ts("The author's tags are added automatically.") %></p>
+            <% end %>
             <%= f.text_field :tag_string, autocomplete_options('tag?type=all', :size => (in_page ? 60 : 80)) %>
             <p class="character_counter">
               <%= ts("Comma separated, %{max} characters per tag", :max => ArchiveConfig.TAG_MAX) %>


### PR DESCRIPTION
Moved "Author's tags are added automatically" from the notes section to the Your Tags section for sense-making reasons. http://code.google.com/p/otwarchive/issues/detail?id=3151
