### PR TITLE
Issue 3171: verification needed on collection name creation to avoid commas

### DIFF
--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -144,10 +144,7 @@ class Collection < ActiveRecord::Base
     :too_long=> t('title_too_long', :default => "must be less than %{max} characters long.", :max => ArchiveConfig.TITLE_MAX)
   validate :no_reserved_strings
   def no_reserved_strings
-    errors.add(:title, ts("^Sorry, we've had to reserve the ',,' string for behind-the-scenes usage!")) if
-      title.match(/\,\,/)
-
-    errors.add(:title, ts("The ',' character cannot be in a collection Display Title.")) if
+    errors.add(:title, ts("^Sorry, the ',' character cannot be in a collection Display Title.")) if
       title.match(/\,/)
   end
 


### PR DESCRIPTION
Resolves issue: http://code.google.com/p/otwarchive/issues/detail?id=3171 (and 2506)

Added a line to the collection.rb model to check to see if a ',' appeared in the collection's Display Title. If it did, an error message is generated.
