### PR TITLE
2757 w/ grammar fix

### DIFF
--- a/app/views/comments/_comment_form.html.erb
+++ b/app/views/comments/_comment_form.html.erb
@@ -92,7 +92,7 @@
               :maximum_length => ArchiveConfig.COMMENT_MAX,
               :tooLongMessage => ts("must be less than %{count} characters long.", :count => ArchiveConfig.COMMENT_MAX)) %>
       <p class="submit actions">
-        <%= f.submit button_name, :id => "comment_submit_for_#{commentable.id}" %>
+        <%= f.submit button_name, :id => "comment_submit_for_#{commentable.id}", 'data-disable-with' => "Please wait..." %>
         <% if controller.controller_name == 'inbox' %>
           <a name="comment_cancel" id="comment_cancel"><%= ts("Close") %></a>
         <% elsif commentable.class.name == "Comment" || !comment.new_record? %>

--- a/app/views/works/_standard_form.html.erb
+++ b/app/views/works/_standard_form.html.erb
@@ -285,7 +285,7 @@
     <legend><%= ts('Post') %></legend>
     <p class="submit cancel actions">
       <%= submit_tag ts('Preview'), :name => 'preview_button' %>
-      <%= submit_tag ts('Post without preview'), :name => 'post_button' %>
+      <%= submit_tag ts('Post without preview'), :name => 'post_button', 'data-disable-with' => "Please wait..." %>
       <%= submit_tag ts('Cancel'), :name => 'cancel_button' %>
     </p>
   </fieldset>


### PR DESCRIPTION
http://code.google.com/p/otwarchive/issues/detail?id=2757&sort=id&colspec=ID%20Roadmap%20Type%20Status%20Release%20Milestone%20Owner%20Component%20Priority%20Summary&start=400

Fixed bad grammar. Yay! This is 2757 with a 'b' at the end because I can't figure out how to push the original issue without causing a 'non-fast-forward' error.
