### PR TITLE
Issue 820: Abuse form redirects to a faulty form after a submit with mis...

### DIFF
--- a/app/controllers/abuse_reports_controller.rb
+++ b/app/controllers/abuse_reports_controller.rb
@@ -35,14 +35,13 @@ class AbuseReportsController < ApplicationController
           if !@abuse_report.email.blank?
             UserMailer.abuse_report(@abuse_report.id).deliver
           else
-            setflash; flash[:error] = t('no_email', :default => "Sorry, we can only send you a copy of your abuse report if you enter a valid email address.")
+            setflash; flash[:error] = ts("Sorry, we can only send you a copy of your abuse report if you enter a valid email address.")
             format.html { render :action => "new" }
           end
         end
-        setflash; flash[:notice] = t('successfully_sent', :default => 'Your abuse report was sent to the Abuse team.')
+        setflash; flash[:notice] = ts("Your abuse report was sent to the Abuse team.")
         format.html { redirect_to '' }
       else
-        setflash; flash[:error] = t('failure_send', :default => 'Sorry, your abuse report could not be sent - please try again!')
         format.html { render :action => "new" }
       end
     end

--- a/app/models/abuse_report.rb
+++ b/app/models/abuse_report.rb
@@ -2,10 +2,12 @@ class AbuseReport < ActiveRecord::Base
   validates_presence_of :comment
   validates_presence_of :url
   validates :email, :email_veracity => {:allow_blank => true}
-  
+  attr_accessor :cc_me
+  validates :email, :if => :cc_me, :presence => { :message => ts("cannot be blank if requesting an emailed copy of the Abuse Report") }
   scope :by_date, order("created_at DESC")
 
   attr_protected :comment_sanitizer_version
+
   
   app_url_regex = Regexp.new('^https?:\/\/(www\.)?' + ArchiveConfig.APP_HOST, true)
   validates_format_of :url, :with => app_url_regex, :message => ts('does not appear to be on this site.')

--- a/app/views/abuse_reports/new.html.erb
+++ b/app/views/abuse_reports/new.html.erb
@@ -51,7 +51,7 @@
   		  <p class="footnote"><%= ts("Leave this blank to file an anonymous report.") %></p>
         <p>
           <%= label_tag('cc_me', ts("Email me a copy of my message (optional)")) %>:
-          <%= check_box_tag('cc_me', false) %>
+          <%= f.check_box :cc_me %>
         </p>
         <%= f.hidden_field :ip_address, :value => request.remote_ip %>
   	  </dd>		


### PR DESCRIPTION
...sing email to send a copy to [ERRORS]

Resolves issue: http://code.google.com/p/otwarchive/issues/detail?id=820 

There was a problem when asking to be CC'd a copy of the Abuse Report and not giving an email to have that copy sent to. The model now checks to make sure that an email address is provided if asking for a copy. Form cannot be submitted/a report is not generated if faulty data is entered. 
