### PR TITLE
2299: added target: blank

### DIFF
--- a/app/views/users/_legal.html.erb
+++ b/app/views/users/_legal.html.erb
@@ -9,7 +9,7 @@
   <!-- Terms of Service -->
   <p>
      <%= ts("And - really important - we need you to agree to our") %> 
-     <%= link_to "Terms of Service", tos_path %>:
+     <%= link_to "Terms of Service", tos_path, :target => '_blank' %>:
   </p>
   <fieldset name="<%= tos_field_name %>"id="tos-partial">
     <%= render(:partial => 'home/tos') %>


### PR DESCRIPTION
http://code.google.com/p/otwarchive/issues/detail?id=2299&colspec=ID%20Roadmap%20Type%20Status%20Release%20Milestone%20Owner%20Component%20Priority%20Summary&start=400

^issue here

Added small :target => '_blank'. Mildly puzzled as to why a link is there when ToS is provided in whole directly under it, but hey, at least the link's fixed now. Yay?
