### PR TITLE
Issue 3210 no way to update tags on a draft without posting

### DIFF
--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -436,6 +436,9 @@ class WorksController < ApplicationController
       cancel_posting_and_redirect
     elsif params[:edit_button]
       render :edit_tags
+    elsif params[:save_button]
+    	setflash; flash[:notice] = ts('Tags were successfully updated.')
+      redirect_to(@work)
     else
       saved = true
 

--- a/app/views/works/preview_tags.html.erb
+++ b/app/views/works/preview_tags.html.erb
@@ -1,5 +1,5 @@
 <!--Descriptive page name, messages and instructions-->
-<h2 class="heading"><%=h t('.works.preview.preview_work_tags', :default => "Preview Tags") %></h2>
+<h2 class="heading"><%= ts("Preview Tags") %></h2>
 <%= error_messages_for :work %>
 <!--/descriptions-->
 
@@ -21,15 +21,16 @@
   <%= form.hidden_field :freeform_string, :value => "#{@work.freeform_string}" %>
 
   <fieldset>
-    <legend><%= t('.post_work', :default => 'Post Work') %></legend>
+    <legend><%= ts('Post Work') %></legend>
     <p class="submit cancel edit actions">
   	<% if @work.posted? %>
-  		<%= submit_tag t('.forms.update', :default => 'Update'), :name => 'update_button' %>
+  		<%= submit_tag ts('Update'), :name => 'update_button' %>
   	<% else %>
-  		<%= submit_tag t('.forms.post', :default => 'Post'), :name => 'post_button' %>
+  		<%= submit_tag ts('Post'), :name => 'post_button' %>
+  		<%= submit_tag ts('Save Without Posting'), :name => 'save_button' %>
   	<% end %>
-      <%= submit_tag t('.forms.edit', :default => 'Edit'), :name => 'edit_button' %>
-      <%= submit_tag t('.forms.cancel', :default => 'Cancel'), :name => 'cancel_button' %>
+      <%= submit_tag ts('Edit'), :name => 'edit_button' %>
+      <%= submit_tag ts('Cancel'), :name => 'cancel_button' %>
     </p>
   </fieldset>
 


### PR DESCRIPTION
http://code.google.com/p/otwarchive/issues/detail?id=3210

The preview page for edit tags didn't have a way to update tags without posting the work.
