### PR TITLE
Issue 3201 combining checkbox and tag name columns for wrangling

### DIFF
--- a/app/views/tag_wranglings/index.html.erb
+++ b/app/views/tag_wranglings/index.html.erb
@@ -117,8 +117,8 @@
         <% for tag in @tags %>
         <tr>
           <th scope="row" title="<%= ts("tag") %>">
-            <%= label_tag "selected_tags_#{tag.id}", "#{tag.name}" %>
           	<%= check_box_tag "selected_tags[]", tag.id, nil, :id => "selected_tags_#{tag.id}" %>
+          	<%= label_tag "selected_tags_#{tag.id}", "#{tag.name}" %>
           </th>
           <td title="<%= ts("created") %>"><%= l(tag.created_at.to_date) %></td>
           <% if params[:show] == 'character_relationships' %>


### PR DESCRIPTION
http://code.google.com/p/otwarchive/issues/detail?id=3201

The ticky boxes and all/none buttons for selecting tags to mass wrangle should be in the same column as the name of the tag. Instead, they were a separate column, taking up valuable space.
