### PR TITLE
Fixed typo causing problem

### DIFF
--- a/app/views/stats/index.html.erb
+++ b/app/views/stats/index.html.erb
@@ -19,7 +19,7 @@
 <div class="wrapper">
   <dl class="work meta group" role="complementary">
     <% [:author_subscriptions, :kudos, :comments, :bookmarks, :subscriptions, :word_count].each do |stat| %>
-      <dt><%= (stat.to_s.titeize == "Comments") ? ts("Comment Threads") : stat.to_s.titleize%></dt>
+      <dt><%= (stat.to_s.titleize == "Comments") ? ts("Comment Threads") : stat.to_s.titleize%></dt>
       <dd><%= @totals[stat] %></dd>
     <% end %>
     <% unless @user.preference.hide_hit_counts %>


### PR DESCRIPTION
The issue: http://code.google.com/p/otwarchive/issues/detail?id=3192

The code that got committed had a misspelled variable name that caused a problem (obviously). This fixes that. So sorry!
