### PR TITLE
BOT fix: Issue 2772 - kudos from static pages

### DIFF
--- a/app/views/kudos/show.html.erb
+++ b/app/views/kudos/show.html.erb
@@ -1,4 +1,5 @@
-<h3 class="heading"><%= ts("Kudos on") %>  <%= link_to @kudo.commentable.work.title.html_safe, @referrer %></h3>
+<h3 class="heading">
+  <%= ts("Kudos on") %> <%= link_to @kudo.commentable.title, @referrer %>
+</h3>
 
 <%= render "kudos/kudos", :kudos => @kudo.commentable.kudos.with_pseud.order("created_at DESC"), :guest_kudos_count => @kudo.commentable.guest_kudos_count, :commentable => @kudo.commentable %>
-


### PR DESCRIPTION
Showing the kudos was erring because it was using a method from when kudos belonged to chapters rather than works.

http://code.google.com/p/otwarchive/issues/detail?id=2772
