### PR TITLE
Temporary added step to the collection_anonymity cuke

### DIFF
--- a/features/collection_anonymity.feature
+++ b/features/collection_anonymity.feature
@@ -36,6 +36,8 @@ Feature: Collection
   Given all emails have been delivered
   When I follow "Hidden Treasury"
     And I follow "Post To Collection"
+    # TODO: remove this step when issue 3236 is fixed, collection name should be pre-filled
+    And I fill in "Post to Collections / Challenges" with "hidden_treasury"
     And I fill in "Fandoms" with "No Fandom"
     And I fill in "Work Title" with "New Snippet"
     And I fill in "content" with "This is a new snippet written for this hidden challenge"
@@ -50,6 +52,8 @@ Feature: Collection
   # Post to collection with preview
   When I follow "Hidden Treasury"
     And I follow "Post To Collection"
+    # TODO: remove this step when issue 3236 is fixed, collection name should be pre-filled
+    And I fill in "Post to Collections / Challenges" with "hidden_treasury"
     And I fill in "Fandoms" with "No Fandom"
     And I fill in "Work Title" with "Another Snippet"
     And I fill in "content" with "This is another new snippet written for this hidden challenge"
@@ -183,6 +187,8 @@ Feature: Collection
   When I am logged in as "first_user"
     And I go to "Anonymous Hugs" collection's page
     And I follow "Post To Collection"
+    # TODO: remove this step when issue 3236 is fixed, collection name should be pre-filled
+    And I fill in "Post to Collections / Challenges" with "anonyhugs"
     And I fill in "Fandoms" with "No Fandom"
     And I fill in "Work Title" with "New Snippet"
     And I fill in "content" with "This is a new snippet written for this hidden challenge"
@@ -198,6 +204,8 @@ Feature: Collection
   When I am logged in as "first_user"
     And I go to "Anonymous Hugs" collection's page
     And I follow "Post To Collection"
+    # TODO: remove this step when issue 3236 is fixed, collection name should be pre-filled
+    And I fill in "Post to Collections / Challenges" with "anonyhugs"
     And I fill in "Fandoms" with "No Fandom"
     And I fill in "Work Title" with "Another Snippet"
     And I fill in "content" with "This is another new snippet written for this hidden challenge"
@@ -324,6 +332,8 @@ Feature: Collection
   Given all emails have been delivered
   When I go to "Hidden Treasury" collection's page
     And I follow "Post To Collection"
+    # TODO: remove this step when issue 3236 is fixed
+    And I fill in "Post to Collections / Challenges" with "hidden_treasury"
     And I fill in "Fandoms" with "No Fandom"
     And I fill in "Work Title" with "New Snippet"
     And I fill in "content" with "This is a new snippet written for this hidden challenge"
@@ -340,6 +350,8 @@ Feature: Collection
   # post to collection for day 2
   When I follow "Hidden Treasury"
     And I follow "Post To Collection"
+    # TODO: remove this step when issue 3236 is fixed, collection name should be pre-filled
+    And I fill in "Post to Collections / Challenges" with "hidden_treasury"
     And I fill in "Fandoms" with "No Fandom"
     And I fill in "Work Title" with "New Snippet 2"
     And I fill in "content" with "This is a new snippet written for this hidden challenge"


### PR DESCRIPTION
The cuke was failing because of a different issue (gcode 3236). Added a step to ensure the collection name is present on the post work form, which proves that this one at least is not a code bug.
