### PR TITLE
Changing the archivist step for checking the email body

### DIFF
--- a/features/step_definitions/archivist_steps.rb
+++ b/features/step_definitions/archivist_steps.rb
@@ -48,9 +48,11 @@ Then /^I should see import confirmation$/ do
 end
 
 Then /^the email should contain invitation warnings from "([^\"]*)" for work "([^\"]*)" in fandom "([^\"]*)"$/ do |name, work, fandom|
-  Then %{the email should contain "Hello from the Archive of Our Own!"}
-  Then %{the email should contain "A fanfic archive including your works has been backed up to the AO3 by #{name}"}
-  Then %{the email should contain "your works will not be publicly readable"}
+  Then %{the email should contain "has recently been imported by"}
+  Then %{the email should contain "Open Doors"}
+  Then %{the email should contain "we believe that the following fanworks belong to you"}
+  Then %{the email should contain "the archivist #{name} has decided to move"}
+  Then %{the email should contain "your works will only be readable by logged-in users"}
   Then %{the email should contain "Claim or remove your works"}
   Then %{the email should contain "#{work}"}
   Then %{the email should contain "#{fandom}"}


### PR DESCRIPTION
The email body was changed, but the cuke wasn't - this brings the cuke in line with the code.
