### PR TITLE
BOT fix: Adds back "align right" and "justify" options

### DIFF
--- a/public/javascripts/mce_editor.js
+++ b/public/javascripts/mce_editor.js
@@ -13,7 +13,7 @@ tinyMCE.init({
 	inline_styles : false,
 
 	// Theme options - using the advanced theme for now and just limiting the buttons used - we may want to create a custom theme in future.
-	theme_advanced_buttons1 : "pasteword,|,bold,italic,underline,strikethrough,|,link,unlink,image,|,blockquote,|,hr,|,bullist,numlist,|,justifyleft,justifycenter,|,undo,redo",
+	theme_advanced_buttons1 : "pasteword,|,bold,italic,underline,strikethrough,|,link,unlink,image,|,blockquote,|,hr,|,bullist,numlist,|,justifyleft,justifycenter,justifyright,justifyfull,|,undo,redo",
 	theme_advanced_buttons2 : "",
 	theme_advanced_buttons3 : "",
 	theme_advanced_toolbar_location : "top",
@@ -96,7 +96,3 @@ function convertWord (type, content) {
     }
     return content;
 }
-
-
-
-


### PR DESCRIPTION
Adds back "align right" and "justify" options to the RTE config settings, to take issue 1248 out of BoT status.

http://code.google.com/p/otwarchive/issues/detail?id=1248
