### PR TITLE
Basic attempt at caching a tag's children query

### DIFF
--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -70,6 +70,10 @@ class TagsController < ApplicationController
       end
       @bookmarks = @tag.bookmarks.visible.paginate(:page => params[:page])
     end
+    # cache the children, since it's a possibly massive query; expired in common_tagging_sweeper and tag_sweeper
+    @tag_children = Rails.cache.fetch "views/tags/#{@tag.id}/children" do
+      @tag.children.uniq.compact.sort.group_by(&:type)
+    end
   end
 
   def feed

--- a/app/sweepers/common_tagging_sweeper.rb
+++ b/app/sweepers/common_tagging_sweeper.rb
@@ -1,0 +1,14 @@
+class CommonTaggingSweeper < ActionController::Caching::Sweeper
+  observe CommonTagging
+  
+  # upon creation of a common_tagging, the filterable has gained a child, so expire its children cache
+  def after_create(common_tagging)
+    expire_fragment("views/tags/#{common_tagging.filterable_id}/children")
+  end
+  
+  # upon destruction of a common_tagging, the filterable has lost a child, so expire its children cache
+  def before_destroy(common_tagging)
+    expire_fragment("views/tags/#{common_tagging.filterable_id}/children")
+  end
+
+end

--- a/app/sweepers/tag_sweeper.rb
+++ b/app/sweepers/tag_sweeper.rb
@@ -17,6 +17,13 @@ class TagSweeper < ActionController::Caching::Sweeper
         tag.remove_from_autocomplete
       end
     end
+    # if type has changed, expire the tag's parents' children cache (it stores the children's type)
+    if tag.type_changed?
+      tag.parents.each do |parent_tag|
+        expire_fragment("views/tags/#{parent_tag.id}/children")
+      end
+    end
+
     update_tag_nominations(tag)
   end
 

--- a/app/views/tags/show.html.erb
+++ b/app/views/tags/show.html.erb
@@ -11,7 +11,7 @@
       	<li><%= tag_comment_link(@tag) %></li>
       <% end %>
     </ul>
-</div>
+  </div>
 
   <%= error_messages_for :tag %>
   <!--/descriptions-->
@@ -76,15 +76,15 @@
   </div>
   <% end %>
 
-  <% unless @tag.children.blank? %>
+  <% unless @tag_children.blank? %>
   <div class="child listbox group">
-  <h3 class="heading"><%= ts('Child tags (more specific)') %>:</h3>
-  <% @tag.children.uniq.compact.sort.group_by(&:type).each do |type, tags| %>
-    <div class="<%= type.to_s.pluralize.downcase %> listbox">
-      <h4 class="heading"><%= type.to_s.pluralize %>:</h4>
-    <ul class="tags commas index group"><%= tag_link_list(tags) %></ul>
-  </div>
-  <% end %>
+    <h3 class="heading"><%= ts('Child tags (more specific)') %>:</h3>
+    <% @tag_children.each do |type, tags| %>
+      <div class="<%= type.to_s.pluralize.downcase %> listbox">
+        <h4 class="heading"><%= type.to_s.pluralize %>:</h4>
+        <ul class="tags commas index group"><%= tag_link_list(tags) %></ul>
+      </div>
+    <% end %>
   </div>
   <% end %>
 


### PR DESCRIPTION
Basic attempt at caching a tag's children query and, more importantly, expiring it.

Please review and help me improve it if needed. :)

http://code.google.com/p/otwarchive/issues/detail?id=3202

(Some fandoms are enormously prolific with their children, which causes the "show ALL the things" tag show page to lag enormously. We want to cache as much as possible, but also expire the cache when things change.)
