### PR TITLE
Issue 2812 fix.

### DIFF
--- a/public/javascripts/application.js
+++ b/public/javascripts/application.js
@@ -28,6 +28,9 @@ $j(document).ready(function() {
         $j(this).attr("data-method", "delete").attr("data-confirm", "Are you sure? This CANNOT BE UNDONE!");
     });
     $j('.commas li:last-child').addClass('last');
+
+    // Set things up to scroll to the top of the comments section when loading additional pages in comment pagination.
+    $j('#comments_placeholder a[data-remote]').live('click.rails', function(e){ $j.scrollTo('#comments_placeholder'); });
 });
 
 function visualizeTables() {


### PR DESCRIPTION
Add a jQuery call to scroll to the top of the comments section when a user clicks on a new page of comments.  A couple of notes: 1) this won't work if JS is turned off (users will go to top-of page, could be fixed with an anchor), 2) the scroll and load happen in parallel, so most of the time you'll scroll to the top before the new content loads, no easy way to fix that (though it is fixable through more complex means).
