### PR TITLE
Undo changes from 2557

### DIFF
--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -26,13 +26,16 @@
       <h3 class="heading">Explore</h3>
       <ul class="meters">
         <li>
-	        <span><%= link_to ts('%{fandom_count} fandoms', :fandom_count => @fandom_count), media_path %></span><%= ' ' + ts(" to date") %>
-	      </li>
+					<span><%= link_to ts('fandoms'), media_path %></span>: 
+					<span><%= @fandom_count %></span><%= ' ' + ts(" to date") %>
+				</li>
 	      <li>
-	        <span><%= link_to ts('%{work_count} works', :work_count => @work_count), works_path %></span><%= ' ' + ts(" to date") %>
+	        <span><%= link_to ts('works'), works_path %></span>:
+	        <span><%= @work_count %></span><%= ' ' + ts(" to date") %>
 	      </li>
         <li>
-          <span><%= link_to ts('%{user_count} people', :user_count => @user_count), people_path %></span><%= ' ' + ts(" to date") %>
+	        <span><%= link_to ts('people'), people_path %></span>:
+	        <span><%= @user_count %></span><%= ' ' + ts(" to date") %>
         </li>
       </ul>    
   </div>


### PR DESCRIPTION
We wanted to rephrase some links on the home page to make it work with voice recognition software, but the way I rephrased them didn't work. This returns it to the old phrasing.

http://code.google.com/p/otwarchive/issues/detail?id=2557
