### PR TITLE
Modify fix for issue 2183 by adding missing Join buttons on blurbs

### DIFF
--- a/app/views/collections/_collection_blurb.html.erb
+++ b/app/views/collections/_collection_blurb.html.erb
@@ -59,7 +59,7 @@
   
   <% end %><!-- end cache -->  
   
-  <% if collection.user_is_owner?(current_user) || (collection.challenge && collection.challenge.signup_open && logged_in?) %>
+  <% if collection.user_is_owner?(current_user) || (collection.challenge && collection.challenge.signup_open && logged_in?) || (collection.moderated? && logged_in?) %>
     <h6 class="landmark heading"><%= ts("User Actions") %></h6>
 	  <ul class="navigation actions" role="menu">
       <% if collection.user_is_owner?(current_user) %>
@@ -67,6 +67,9 @@
       <% end %>
       <% if collection.challenge && collection.challenge.signup_open && logged_in? %>
         <%= render "challenge/#{challenge_class_name(collection)}/challenge_navigation_user", :collection => collection %>
+      <% end %>
+      <% if !collection.user_is_owner?(current_user) && collection.moderated? && !(collection.challenge && collection.challenge.signup_open) %>
+      	<li><%= link_to ts("Join"), join_collection_participants_path(collection) %></li>
       <% end %>
     </ul>
   <% end %>


### PR DESCRIPTION
http://code.google.com/p/otwarchive/issues/detail?id=2183

The Join button was missing on blurbs for the following types of collections:
- Open, Moderated, Sign-ups Open
- Closed, Moderated, Sign-ups Closed
- Open, Moderated
- Closed, Moderated
