### PR TITLE
Fix issue 2823 with unapproved works in moderated unrevealed collections

### DIFF
--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -377,12 +377,12 @@ class Work < ActiveRecord::Base
 
   def unrevealed?(user=User.current_user)
     # eventually here is where we check if it's in a challenge that hasn't been made public yet
-    !self.approved_collection_items.unrevealed.empty?
+    !self.collection_items.unrevealed.empty?
   end
 
   def anonymous?(user=User.current_user)
     # here we check if the story is in a currently-anonymous challenge
-    !self.approved_collection_items.anonymous.empty?
+    !self.collection_items.anonymous.empty?
   end
 
   ########################################################################


### PR DESCRIPTION
https://code.google.com/p/otwarchive/issues/detail?id=2823

If you post a work to a moderated, unrevealed (or anon) collection, the work is revealed until the collection moderators approve it. That defeats the purpose. This makes unrevealed/anon status not dependent on whether the work has been approved.
