### PR TITLE
Punctuation in work-search-date-help.html

### DIFF
--- a/public/help/work-search-date-help.html
+++ b/public/help/work-search-date-help.html
@@ -24,4 +24,4 @@
 	</ul>
 </p>
 
-<p>Note that the "ago" is optional</p>
+<p>Note that the "ago" is optional.</p>


### PR DESCRIPTION
The help pages seem to use complete sentences, so I'm adding this period to make this help file more consistent with that style.
