### PR TITLE
Fixes broken references in Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,8 +29,7 @@ gem 'rest-client', :require => 'rest_client'
 gem 'resque', '>=1.14.0'
 gem 'resque_mailer'
 gem 'thinking-sphinx',
-  :git     => 'git://github.com/freelancing-god/thinking-sphinx.git',
-  :branch  => 'rails3',
+  :git     => 'git://github.com/pat/thinking-sphinx.git',
   :require => 'thinking_sphinx'
 #gem 'daemon-spawn', :require => 'daemon_spawn'
 gem 'aws-s3', :require => 'aws/s3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,21 +8,21 @@ GIT
       ya2yaml (~> 0.26)
 
 GIT
-  remote: git://github.com/freelancing-god/thinking-sphinx.git
-  revision: 506db5cb1b11d4c09d3d6fcccb87a40b1b839ba0
-  branch: rails3
-  specs:
-    thinking-sphinx (2.0.0)
-      activerecord (>= 3.0.2)
-      riddle (>= 1.2.1)
-
-GIT
   remote: git://github.com/odorcicd/authlogic.git
   revision: a087ad0cba3c165ba22fcf176c28b6f7517931e8
   branch: rails3
   specs:
     authlogic (2.1.3)
       activesupport
+
+GIT
+  remote: git://github.com/pat/thinking-sphinx.git
+  revision: 0d5b51e7f2a6fb207a65e7542833be82d1916ce4
+  specs:
+    thinking-sphinx (2.0.13)
+      activerecord (>= 3.0.3)
+      builder (>= 2.1.2)
+      riddle (>= 1.5.3)
 
 GEM
   remote: http://rubygems.org/
@@ -194,7 +194,7 @@ GEM
     resque_mailer (1.0.1)
     rest-client (1.6.1)
       mime-types (>= 1.16)
-    riddle (1.2.1)
+    riddle (1.5.3)
     rspec (2.5.0)
       rspec-core (~> 2.5.0)
       rspec-expectations (~> 2.5.0)


### PR DESCRIPTION
The thinking-sphinx owner's repo url changed, so this commit fixes the reference to the repository in the Gemfile.

I was only able to make the archive to work locally with the version 2.0.13, so I also changed the version here. I understand since this is a change in the gem that messes with the search, may be a little dangerous to merge this in production, but I'm making the pull request mostly for future reference for anyone who may have the same problem.
