### PR TITLE
3261 adding Mark as read button to blurbs on the to-read page of History

### DIFF
--- a/app/views/readings/_reading_blurb.html.erb
+++ b/app/views/readings/_reading_blurb.html.erb
@@ -28,6 +28,9 @@
   
       <ul class="navigation actions" role="menu">
         <li><%= link_to ts("Delete"), user_reading_path(current_user, reading), :confirm => ts('Are you sure?'), :method => :delete %></li>
+        <% if params[:show] == "to-read" %>
+          <li><%= markasread_link(work) %></li>
+        <% end %>
       </ul>
     </div>
 


### PR DESCRIPTION
Previously, you had to go to the work itself to remove it from your to-read items. This puts the Mark as read button on the to-read page: http://code.google.com/p/otwarchive/issues/detail?id=3261
