### PR TITLE
3262 with Marked for Later losing current indicator due to pagination

### DIFF
--- a/app/views/readings/index.html.erb
+++ b/app/views/readings/index.html.erb
@@ -9,7 +9,7 @@
     <%= span_if_current ts("Full History"), user_readings_path(@user), params[:show].blank? %>
   </li>
   <li>
-    <%= span_if_current ts("Marked for Later"), user_readings_path(@user, :show => 'to-read') %>
+    <%= span_if_current ts("Marked for Later"), user_readings_path(@user, :show => 'to-read'), params[:show] == "to-read" %>
   </li>
   <li>
   <%= link_to ts("Clear History"), clear_user_readings_path(current_user), :confirm => ts('Are you sure?'), :method => :post %>


### PR DESCRIPTION
http://code.google.com/p/otwarchive/issues/detail?id=3262

If your to-read list was paginated, the Marked for Later button at the top stopped looking like it was pressed down when you navigated to the second (or third or...) page.

Alternative solution: using params.merge, which is what we do in other places like bookmarks/recs.
