### PR TITLE
3264 with icons overlapping headers in some instances

### DIFF
--- a/public/stylesheets/site/2.0/17-zone-home.css
+++ b/public/stylesheets/site/2.0/17-zone-home.css
@@ -10,6 +10,7 @@ user home, collections and challenges home, tag home, admin comms home
   text-align: right;
   border-bottom: 2px solid;
   display: block;
+  margin-left: 100px;
 }
 
 .home .header .userstuff, .home .header dl.stats, .home .header .type {


### PR DESCRIPTION
http://code.google.com/p/otwarchive/issues/detail?id=3264

If your browser was exactly the wrong width and your text was exactly the wrong length, you would run into instances of the icon on some page headers overlapping the heading text. This adds a left margin the same size as the icon in order to keep that from happening.
