### PR TITLE
Issue: 3269 - 404 on password changes on unactivated accounts

### DIFF
--- a/app/controllers/passwords_controller.rb
+++ b/app/controllers/passwords_controller.rb
@@ -12,7 +12,7 @@ class PasswordsController < ApplicationController
       setflash; flash[:notice] = ts("We couldn't find an account with that email address or username. Please try again?")
       render :action => "new"
     elsif !@user.active?
-      setflash; flash[:error] = ts("Your account has not been activated. Please check your email (including your spam folder) for the activation link or <a href=\"#{new_feedback_report_url}\">contact support</a>.".html_safe)
+      setflash; flash[:error] = ts("Your account has not been activated. Please check your email (including your spam folder) for the activation link or <a href=\"#{new_feedback_report_url}\">contact Support</a>.".html_safe)
       render :action => "new"
     else
       @user.reset_user_password


### PR DESCRIPTION
Resolves issue: http://code.google.com/p/otwarchive/issues/detail?id=3269

Added a check in the passwords controller to make sure a user's account has been activated before allowing any password changes. On attempted password change, the user is reminded that their account is not active and instructions are given about how to go about activating their account. 
