### PR TITLE
Issue 2859: Maintainer ability to edit signups in a PromptMeme

### DIFF
--- a/app/controllers/challenge_signups_controller.rb
+++ b/app/controllers/challenge_signups_controller.rb
@@ -35,7 +35,7 @@ class ChallengeSignupsController < ApplicationController
   end
 
   def signup_owner_only
-    not_signup_owner and return unless (@challenge_signup.pseud.user == current_user || (@collection.challenge_type == "GiftExchange" && !@challenge.signup_open && @collection.user_is_owner?(current_user)))
+    not_signup_owner and return unless (@challenge_signup.pseud.user == current_user || (@collection.challenge_type == "GiftExchange" && !@challenge.signup_open && @collection.user_is_owner?(current_user)) || @collection.challenge_type == "PromptMeme" && @collection.user_is_maintainer?(current_user))
   end
 
   def maintainer_or_signup_owner_only

--- a/app/controllers/prompts_controller.rb
+++ b/app/controllers/prompts_controller.rb
@@ -53,7 +53,7 @@ class PromptsController < ApplicationController
   end
 
   def signup_owner_only
-    not_signup_owner and return unless (@challenge_signup.pseud.user == current_user || (@collection.challenge_type == "GiftExchange" && !@challenge.signup_open && @collection.user_is_owner?(current_user)))
+    not_signup_owner and return unless (@challenge_signup.pseud.user == current_user || (@collection.challenge_type == "GiftExchange" && !@challenge.signup_open && @collection.user_is_owner?(current_user)) || @collection.challenge_type == "PromptMeme" && @collection.user_is_maintainer?(current_user))
   end
 
   def maintainer_or_signup_owner_only


### PR DESCRIPTION
Resolves issue: http://code.google.com/p/otwarchive/issues/detail?id=2859

Added an option to allow editing of a prompt if the user is a maintainer of the collection. This change brings PromptMeme's inline with the other types of Challenges. 
