### PR TITLE
Issue 3198: Order of [Fulfill] and [Default] on Assignment page

### DIFF
--- a/app/views/challenge_assignments/_assignment_blurb.html.erb
+++ b/app/views/challenge_assignments/_assignment_blurb.html.erb
@@ -55,7 +55,7 @@
     <ul class="navigation actions" role="menu">
       <% if @user && @user == current_user %>        
         <li><%= link_to ts("Fulfill"), new_collection_work_path(assignment.collection, :assignment_id => assignment.id) %></li>
-	<li role="button">
+        <li role="button">
           <%= link_to "Default", default_user_assignment_path(@user, assignment), 
               :confirm => "Are you sure? This will mark you as having defaulted and notify the collection maintainer! It cannot be undone." %>
         </li>


### PR DESCRIPTION
Resolves issue: http://code.google.com/p/otwarchive/issues/detail?id=3198

Changed the order of the [Fulfill] and [Default] buttons.
