### PR TITLE
Issue 1754: Use of non-canonical tags leads to confusing error message

### DIFF
--- a/app/models/prompt.rb
+++ b/app/models/prompt.rb
@@ -135,7 +135,7 @@ class Prompt < ActiveRecord::Base
         else
           noncanonical_taglist = tag_set.send("#{tag_type}_taglist").reject {|t| t.canonical}
           unless noncanonical_taglist.empty?
-            errors.add(:base, ts("^These %{tag_type} tags in your %{prompt_type} are not canonical and can't be used unless the moderator requests them to be added: %{taglist}. Please contact support to resolve this issue.",
+            errors.add(:base, ts("^These %{tag_type} tags in your %{prompt_type} are not canonical and can't be used unless the moderator requests them to be added: %{taglist}. Please contact Support to resolve this issue.",
               :tag_type => tag_type,
               :prompt_type => self.class.name.downcase,
               :taglist => noncanonical_taglist.collect(&:name).join(ArchiveConfig.DELIMITER_FOR_OUTPUT)))


### PR DESCRIPTION
Resolves issue: http://code.google.com/p/otwarchive/issues/detail?id=1754

Added additional text to direct the user to contact support to get their non-canonical tag situation fixed. 

I also added a ^ to the beginning of the error message output so that it would remove the "Requests base" text that was being appended to the error message when displayed to the user. 

OLD: "Requests base These character tags in your request ..."
NEW: "These character tags in your request  ..."
