### PR TITLE
Autocomplete gains a class method

### DIFF
--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -119,16 +119,16 @@ class Collection < ActiveRecord::Base
     end
   end
 
-  validates_presence_of :name, :message => t('collection.no_name', :default => "Please enter a name for your collection.")
-  validates_uniqueness_of :name, :case_sensitive => false, :message => t('collection.duplicate_name', :default => 'Sorry, that name is already taken. Try again, please!')
+  validates_presence_of :name, :message => ts("Please enter a name for your collection.")
+  validates_uniqueness_of :name, :case_sensitive => false, :message => ts('Sorry, that name is already taken. Try again, please!')
   validates_length_of :name,
     :minimum => ArchiveConfig.TITLE_MIN,
-    :too_short=> t('title_too_short', :default => "must be at least %{min} characters long.", :min => ArchiveConfig.TITLE_MIN)
+    :too_short=> ts("must be at least %{min} characters long.", :min => ArchiveConfig.TITLE_MIN)
   validates_length_of :name,
     :maximum => ArchiveConfig.TITLE_MAX,
-    :too_long=> t('title_too_long', :default => "must be less than %{max} characters long.", :max => ArchiveConfig.TITLE_MAX)
+    :too_long=> ts("must be less than %{max} characters long.", :max => ArchiveConfig.TITLE_MAX)
   validates_format_of :name,
-    :message => t('collection.name_invalid', :default => 'must begin and end with a letter or number; it may also contain underscores but no other characters.'),
+    :message => ts('must begin and end with a letter or number; it may also contain underscores but no other characters.'),
     :with => /\A[A-Za-z0-9]\w*[A-Za-z0-9]\Z/
   validates_length_of :icon_alt_text, :allow_blank => true, :maximum => ArchiveConfig.ICON_ALT_MAX,
     :too_long => ts("must be less than %{max} characters long.", :max => ArchiveConfig.ICON_ALT_MAX)
@@ -137,13 +137,13 @@ class Collection < ActiveRecord::Base
 
   validates :email, :email_veracity => {:allow_blank => true}
 
-  validates_presence_of :title, :message => t('collection.no_title', :default => "Please enter a title to be displayed for your collection.")
+  validates_presence_of :title, :message => ts("Please enter a title to be displayed for your collection.")
   validates_length_of :title,
     :minimum => ArchiveConfig.TITLE_MIN,
-    :too_short=> t('title_too_short', :default => "must be at least %{min} characters long.", :min => ArchiveConfig.TITLE_MIN)
+    :too_short=> ts("must be at least %{min} characters long.", :min => ArchiveConfig.TITLE_MIN)
   validates_length_of :title,
     :maximum => ArchiveConfig.TITLE_MAX,
-    :too_long=> t('title_too_long', :default => "must be less than %{max} characters long.", :max => ArchiveConfig.TITLE_MAX)
+    :too_long=> ts("must be less than %{max} characters long.", :max => ArchiveConfig.TITLE_MAX)
   validate :no_reserved_strings
   def no_reserved_strings
     errors.add(:title, ts("^Sorry, we've had to reserve the ',,' string for behind-the-scenes usage!")) if
@@ -153,10 +153,10 @@ class Collection < ActiveRecord::Base
   validates_length_of :description,
     :allow_blank => true,
     :maximum => ArchiveConfig.SUMMARY_MAX,
-    :too_long => t('summary_too_long', :default => "must be less than %{max} characters long.", :max => ArchiveConfig.SUMMARY_MAX)
+    :too_long => ts("must be less than %{max} characters long.", :max => ArchiveConfig.SUMMARY_MAX)
 
-  validates_format_of :header_image_url, :allow_blank => true, :with => URI::regexp(%w(http https)), :message => t('collection.url_invalid', :default => "Not a valid URL.")
-  validates_format_of :header_image_url, :allow_blank => true, :with => /\.(png|gif|jpg)$/, :message => t('collection.image_invalid', :default => "Only gif, jpg, png files allowed.")
+  validates_format_of :header_image_url, :allow_blank => true, :with => URI::regexp(%w(http https)), :message => ts("Not a valid URL.")
+  validates_format_of :header_image_url, :allow_blank => true, :with => /\.(png|gif|jpg)$/, :message => ts("Only gif, jpg, png files allowed.")
 
   scope :top_level, where(:parent_id => nil)
   scope :closed, joins(:collection_preference).where("collection_preferences.closed = ?", true)
@@ -212,8 +212,13 @@ class Collection < ActiveRecord::Base
   ## AUTOCOMPLETE
   # set up autocomplete and override some methods
   include AutocompleteSource
+
   def autocomplete_search_string
     "#{name} #{title}"
+  end
+
+  def autocomplete_search_string_was
+    "#{name_was} #{title_was}"
   end
 
   def autocomplete_prefixes

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -406,7 +406,16 @@ class Tag < ActiveRecord::Base
       end
     end
   end
-    
+  
+  def remove_stale_from_autocomplete
+    super
+    if self.is_a?(Character) || self.is_a?(Relationship)
+      parents.each do |parent|
+        $redis.zrem("autocomplete_fandom_#{parent.name.downcase}_#{type.downcase}", autocomplete_value_was) if parent.is_a?(Fandom)
+      end
+    end
+  end
+
   def self.parse_autocomplete_value(current_autocomplete_value)
     current_autocomplete_value.split(AUTOCOMPLETE_DELIMITER, 2)
   end

--- a/app/sweepers/collection_sweeper.rb
+++ b/app/sweepers/collection_sweeper.rb
@@ -5,14 +5,11 @@ class CollectionSweeper < ActionController::Caching::Sweeper
     record.add_to_autocomplete if record.is_a?(Collection)
   end
 
-  def before_update(record)
-    if record.is_a?(Collection) && (record.changed.include?(:name) || record.changed.include?(:title))
-      record.remove_from_autocomplete
-    end
-  end
-
   def after_update(record)
-    if record.is_a?(Collection) && (record.changed.include?(:name) || record.changed.include?(:title))
+    if record.is_a?(Collection) && (record.name_changed? || record.title_changed?)
+      Rails.logger.debug "Removing renamed collection from autocomplete: #{record.autocomplete_search_string_was}"
+      record.remove_stale_from_autocomplete
+      Rails.logger.debug "Adding renamed collection to autocomplete: #{record.autocomplete_search_string}"
       record.add_to_autocomplete
     end
   end

--- a/lib/autocomplete_source.rb
+++ b/lib/autocomplete_source.rb
@@ -19,9 +19,17 @@ module AutocompleteSource
   def autocomplete_search_string
     "#{name}"
   end
+
+  def autocomplete_search_string_was
+    "#{name_was}"
+  end
   
   def autocomplete_value
     "#{id}#{AUTOCOMPLETE_DELIMITER}#{name}" + (self.respond_to?(:title) ? "#{AUTOCOMPLETE_DELIMITER}#{title}" : "")
+  end
+
+  def autocomplete_value_was
+    "#{id}#{AUTOCOMPLETE_DELIMITER}#{name_was}" + (self.respond_to?(:title) ? "#{AUTOCOMPLETE_DELIMITER}#{title_was}" : "")
   end
   
   def autocomplete_score
@@ -46,24 +54,14 @@ module AutocompleteSource
       end
     end
   end
-  
-  def remove_from_autocomplete    
-    self.class.autocomplete_pieces(autocomplete_search_string).each do |word_piece|
-      autocomplete_prefixes.each do |prefix|
-        # we leave the word pieces in the completion set so we don't accidentally trash
-        # parts of other completions -- doing a weekly reload for cleanup is good enough
-        if (self.class.is_complete_word?(word_piece))
-          word = self.class.get_word(word_piece)
-          phrases = $redis.zrevrangebyscore(self.class.autocomplete_score_key(prefix, word), 'inf', 0)
-          if phrases.count == 1 && phrases.first == autocomplete_value
-            # there's only one phrase for this word and we're removing it, remove the completed word from the completion set
-            $redis.zrem(self.class.autocomplete_completion_key(prefix), word_piece)
-          end
-          # remove the phrase we're deleting from the score set
-          $redis.zrem(self.class.autocomplete_score_key(prefix, word_piece), autocomplete_value)
-        end
-      end
-    end
+
+  def remove_from_autocomplete
+    self.class.remove_from_autocomplete(self.autocomplete_search_string, self.autocomplete_prefixes, self.autocomplete_value)
+  end
+
+  def remove_stale_from_autocomplete
+    Rails.logger.debug "Removing stale from autocomplete: #{autocomplete_search_string_was}"
+    self.class.remove_from_autocomplete(self.autocomplete_search_string_was, self.autocomplete_prefixes, self.autocomplete_value_was)
   end
   
   module ClassMethods
@@ -75,7 +73,7 @@ module AutocompleteSource
     
     # takes either an array or string of search terms (typically extra values passed in through live params, like fandom)
     # and returns an array of stripped and lowercase words for actual searching or use in keys
-    def get_search_terms(search_term)      
+    def get_search_terms(search_term)
       terms = search_term.is_a?(Array) ? search_term.map {|term| term.split(',')}.flatten : (search_term.blank? ? [] : search_term.split(','))
       terms.map {|term| term.strip.downcase}
     end
@@ -214,8 +212,8 @@ module AutocompleteSource
     end
       
     def autocomplete_phrase_split(string)
-        # split into words
-        string.downcase.split(/(?:\s+|\&|\/)/) # split on spaces, slash, ampersand
+      # split into words
+      string.downcase.split(/(?:\s+|\&|\/)/) # split on spaces, slash, ampersand
     end
     
     def autocomplete_pieces(string)
@@ -262,7 +260,26 @@ module AutocompleteSource
       
       results
     end
-                
+  
+    # generic method to remove pieces for given search string and value from the given autocomplete prefixes
+    def remove_from_autocomplete(search_string, prefixes, value)
+      autocomplete_pieces(search_string).each do |word_piece|
+        prefixes.each do |prefix|
+          # we leave the word pieces in the completion set so we don't accidentally trash
+          # parts of other completions -- doing a weekly reload for cleanup is good enough
+          if is_complete_word?(word_piece)
+            word = get_word(word_piece)
+            phrases = $redis.zrevrangebyscore(autocomplete_score_key(prefix, word), 'inf', 0)
+            if phrases.count == 1 && phrases.first == value
+              # there's only one phrase for this word and we're removing it, remove the completed word from the completion set
+              $redis.zrem(autocomplete_completion_key(prefix), word_piece)
+            end
+            # remove the phrase we're deleting from the score set
+            $redis.zrem(autocomplete_score_key(prefix, word_piece), value)
+          end
+        end
+      end
+    end
   end
   
   def self.included(base)


### PR DESCRIPTION
Autocomplete gains a class method to remove any given string / values / prefixes from the results.

Using it to remove old records that have had the autocomplete relevant fields changed, in the sweeper.

Collections (name & title) and tags (name).

http://code.google.com/p/otwarchive/issues/detail?id=2893
http://code.google.com/p/otwarchive/issues/detail?id=2849
