### PR TITLE
Fixing issue 2911: subscriptions to deleted objects

### DIFF
--- a/app/models/series.rb
+++ b/app/models/series.rb
@@ -12,7 +12,9 @@ class Series < ActiveRecord::Base
   has_many :creatorships, :as => :creation
   has_many :pseuds, :through => :creatorships
   has_many :users, :through => :pseuds, :uniq => true
-  
+
+  has_many :subscriptions, :as => :subscribable, :dependent => :destroy
+   
   validates_presence_of :title
   validates_length_of :title, 
     :minimum => ArchiveConfig.TITLE_MIN, 

--- a/features/support/factories.rb
+++ b/features/support/factories.rb
@@ -101,6 +101,12 @@ Factory.define :external_work do |f|
   end
 end
 
+Factory.define :subscription do |f|
+  f.association :user
+  f.subscribable_type "Series"
+  f.subscribable_id { Factory.create(:series).id }
+end
+
 # Factory.define :collection_participant do |f|
 #   f.association :pseud
 #   f.association :collection

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -1,0 +1,57 @@
+require 'spec_helper'
+
+describe Subscription do
+  let(:subscription) { Factory.build(:subscription) }
+
+  context "to a work" do
+    before(:each) do
+      subscription.subscribable = Factory.create(:work)
+      subscription.save!
+    end
+
+    describe "when the work is destroyed" do
+      before(:each) do
+        subscription.subscribable.destroy
+      end
+
+      it "should be destroyed" do
+        expect { subscription.reload }.should raise_error
+      end
+    end
+  end
+
+  context "to a series" do
+    before(:each) do
+      subscription.subscribable = Factory.create(:series)
+      subscription.save!
+    end
+
+    describe "when the series is destroyed" do
+      before(:each) do
+        subscription.subscribable.destroy
+      end
+
+      it "should be destroyed" do
+        expect { subscription.reload }.should raise_error
+      end
+    end
+  end
+
+  context "to a user" do
+    before(:each) do
+      subscription.subscribable = Factory.create(:user)
+      subscription.save!
+    end
+
+    describe "when the user is destroyed" do
+      before(:each) do
+        subscription.subscribable.destroy
+      end
+
+      it "should be destroyed" do
+        expect { subscription.reload }.should raise_error
+      end
+    end
+  end
+
+end


### PR DESCRIPTION
Fixing issue 2911: subscriptions should be removed when their subscribables are. Added test.

http://code.google.com/p/otwarchive/issues/detail?id=2911
