### PR TITLE
Issue 2642:  Landing pages on challenge creation not consistent

### DIFF
--- a/app/controllers/challenge/prompt_meme_controller.rb
+++ b/app/controllers/challenge/prompt_meme_controller.rb
@@ -45,7 +45,7 @@ class Challenge::PromptMemeController < ChallengesController
       if initializing_tag_sets?
         flash[:notice] += ts(' The tag list is being initialized. Please wait a short while and then check your challenge settings to customize the results.')
       end
-      redirect_to @collection
+      redirect_to collection_profile_path(@collection)
     else
       render :action => :new
     end


### PR DESCRIPTION
Resolves issue: http://code.google.com/p/otwarchive/issues/detail?id=2642

On Prompt Meme creation, redirect to the collection's profile page. This makes the creation of Prompt Memes and Gift Exchanges consistent. 
