### PR TITLE
Issue 1187: Gift notification email links to the gift's general work url...

### DIFF
--- a/app/views/user_mailer/recipient_notification.html.erb
+++ b/app/views/user_mailer/recipient_notification.html.erb
@@ -1,13 +1,17 @@
 <p><%= ts("Hello, %{name}!", :name => @user.login) %></p>
 
 <p>
-<%= ts("A gift story has been posted for you ") %>
-<%= @collection ? "in the #{@collection.title} collection " : "" %>at the Archive of Our Own!
+<%= ts("A gift story has been posted for you") %> <%= @collection ? " in the #{@collection.title} collection " : "" %>at the Archive of Our Own!
 </p>
 
 <p>
-  <%= link_to @work.title.html_safe, work_url(@work) %> <%= "(#{@work.word_count} words)" %><br />
-  by <%= @work.anonymous? ? "an anonymous giver" : @work.pseuds.collect(&:byline).join(", ") %><br />
+  <% if @collection.nil? %>
+    <%= link_to @work.title.html_safe, work_url(@work) %> <%= "(#{@work.word_count} words)" %><br />
+    by <%= @work.anonymous? ? "an anonymous giver" : @work.pseuds.collect(&:byline).join(", ") %><br />
+  <% else %>
+    <%= link_to @work.title.html_safe, collection_work_url(@collection, @work) %><%= "(#{@work.word_count} words)" %><br />
+    by <%= @work.anonymous? ? "an anonymous giver" : @work.pseuds.collect(&:byline).join(", ") %><br />
+  <% end %>
   <%= "Fandom: " + @work.fandom_string unless @work.fandom_string.blank? %><br />
   <% unless @work.summary.blank? %>
     Summary: 
@@ -23,5 +27,5 @@
 
 <p>
   Please note: if you don't want to receive emails like this one, you can set your preferences 
-  at the archive not to receive notification of gift stories.
+  at the Archive not to receive notification of gift stories.
 </p>


### PR DESCRIPTION
..., rather than the collection work url

Resolves issue: https://code.google.com/p/otwarchive/issues/detail?id=1187

For works that are given as Gifts and are a part of a collection, the link in the generated email will link to the work inside it's collection (/collection/work/id). Otherwise the link in the email will just link directly to the work (/works/id)

I also made some minor cosmetic changes to this file so the email would be more pretty. I'm all about the pretty things.
