### PR TITLE
Issue 2927: Broken title text for ?! image when no warnings are checked ...

### DIFF
--- a/app/helpers/tags_helper.rb
+++ b/app/helpers/tags_helper.rb
@@ -241,7 +241,7 @@ module TagsHelper
   def get_title_string(tags, category_name = "")
     if tags && tags.size > 0
       tags.collect(&:name).join(", ")
-    elsif tags.blank?
+    elsif tags.blank? && category_name.blank?
      "Choose Not To Use Archive Warnings"
     else
       category_name.blank? ? "" : "No" + " " + category_name


### PR DESCRIPTION
...in a challenge request

Resolves issue: https://code.google.com/p/otwarchive/issues/detail?id=2927

If the warnings are blank (user unchecked all the warning options in a challenge request form) then we set the default text back to "Choose Not To Use Archive Warnings".
