### PR TITLE
Issue 2622:  in prompt meme fill notes, link to prompt goes to sign up f...

### DIFF
--- a/app/views/works/_work_header_notes.html.erb
+++ b/app/views/works/_work_header_notes.html.erb
@@ -24,9 +24,9 @@
     <% unless claim.request_prompt.nil? %>
       <p>In response to a prompt by:
         <% if claim.request_prompt.anonymous? %>
-          <%= link_to(ts("Anonymous"), collection_prompt_path(claim.collection, claim.request_prompt)) %>
+          <%= ts("Anonymous in the ", link_to(claim.collection.name, collection_path(claim.collection))) %>
         <% else %>
-          <%= link_to(claim.request_signup.pseud.byline, collection_prompt_path(claim.collection, claim.request_prompt)) %>
+          <%= link_to(claim.request_signup.pseud.byline, user_pseud_path(claim.request_signup.user, claim.request_signup.pseud)) %> <%= ts(" in the ") %> <%= link_to(claim.collection.name, collection_path(claim.collection)) %>
         <% end %>
       </p>
     <% end %>


### PR DESCRIPTION
...orm not prompt

Resolves issue: https://code.google.com/p/otwarchive/issues/detail?id=2622

New note lists the user that the work was created for (and links to them) and lists the challenge in which the prompt was generated (and links to it).
