### PR TITLE
Issue 3284: Change subject line for account activation emails

### DIFF
--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -157,7 +157,7 @@ class UserMailer < BulletproofMailer::Base
     @user = User.find(user_id)
     mail(
       :to => @user.email,
-      :subject => "[#{ArchiveConfig.APP_SHORT_NAME}] Please activate your new account"
+      :subject => "[#{ArchiveConfig.APP_SHORT_NAME}] Confirmation"
     )
   end
 


### PR DESCRIPTION
Resolves issue: https://code.google.com/p/otwarchive/issues/detail?id=3284

In an attempt to lessen the number of our emails that get marked as spam, we are changing the subject line of the email that we send out to activate a user's account. 

New subject line will read: "[AO3] Confirmation"
