### PR TITLE
Issue 3287 - adding extra text to activation emails

### DIFF
--- a/app/views/user_mailer/signup_notification.html.erb
+++ b/app/views/user_mailer/signup_notification.html.erb
@@ -1,3 +1,9 @@
-<%=h 'Welcome to the Archive of Our Own,' %> <%=h @user.login %>!
+<p><%=h 'Welcome to the Archive of Our Own,' %> <%=h @user.login %>!</p>
 
-<%=h 'Please activate your account at:' %> <%= link_to activate_url(:id => @user.activation_code), activate_url(:id => @user.activation_code) %> 
+<p><%=h 'Please activate your account at:' %> <%= link_to activate_url(:id => @user.activation_code), activate_url(:id => @user.activation_code) %> </p>
+
+<p>Once your account is up and running, you can post your fanworks, set up email subscriptions to let you know when your favorite authors or works have updated, set preferences to customize the way the site looks and works for you, keep track of the works you've viewed on the Archive via your history, and much more.</p>
+
+<p>There's lots of information and advice on how to use the Archive in our FAQ: <a href="http://archiveofourown.org/archive_faqs">http://archiveofourown.org/archive_faqs</a>. You'll find the latest news about site developments in our Archive admin posts: <a href="http://archiveofourown.org/admin_posts">http://archiveofourown.org/admin_posts</a>. If you need more help, run into a bug, or have questions or comments, please get in touch with our Support team, who are always happy to help out. </p>
+
+<p>We hope you enjoy using the Archive.</p>


### PR DESCRIPTION
As per issue 3287 - adding extra text to activation emails to help make them less spam-ish.

http://code.google.com/p/otwarchive/issues/detail?id=3287
