### PR TITLE
Issue 3220

### DIFF
--- a/public/javascripts/jquery.tokeninput.js
+++ b/public/javascripts/jquery.tokeninput.js
@@ -446,13 +446,17 @@ $.TokenList = function (input, url_or_data, settings) {
           };
 
         // The 'delete token' button
-        $("<span>" + settings.deleteText + "</span>")
+        var delete_span_token = $("<span></span>")
             .addClass(settings.classes.tokenDelete)
             .appendTo(this_token)
             .click(function () {
                 delete_token($(this).parent());
                 return false;
             });
+				// Link with a title attribute for better accessibility
+        $("<a href=\"#\">" + settings.deleteText + "</a>")
+						.attr("title", "remove " + value)
+						.appendTo(delete_span_token)
 
         // Store data on the token
         var token_data = {"id": id, "name": value};


### PR DESCRIPTION
Issue in Google Code: http://code.google.com/p/otwarchive/issues/detail?id=3220

This change implements the short term fix described below:

"The x for deleting isn’t a link, so you can’t tab to it, ergo it doesn’t work with screen readers. The easiest thing to do would be to just add an a href=“#” around the x, but that would just be a stopgap and not totally accessible (because you could delete a tag, sure, but which tag are you deleting? and you’d have to know “x” meant “delete”).

...

To address the short-term fix, because changing the autocomplete is a big project and the short-term fix is easy to do:

To make the "remove tag" button more accessible - on top of wrapping it in an anchor tag - we could add a title attribute "remove <tag name>". That way it becomes clear what the "x" stands for and it's clearly connected to the tag (as opposed to having 20 links that just say 'delete' on one page)."
