### PR TITLE
Modify issue 2812 by adding JS to top Comments button

### DIFF
--- a/public/javascripts/application.js
+++ b/public/javascripts/application.js
@@ -30,7 +30,7 @@ $j(document).ready(function() {
     $j('.commas li:last-child').addClass('last');
 
     // Set things up to scroll to the top of the comments section when loading additional pages in comment pagination.
-    $j('#comments_placeholder a[data-remote]').live('click.rails', function(e){ $j.scrollTo('#comments_placeholder'); });
+    $j('#comments_placeholder a[data-remote], .actions.work .comments a').live('click.rails', function(e){ $j.scrollTo('#comments_placeholder'); });
 });
 
 function visualizeTables() {


### PR DESCRIPTION
Applies the JS for issue 2812 to the Comments link at the top of the work to resolve and issue with the comments pagination going to the top of the page in Chrome http://code.google.com/p/otwarchive/issues/detail?id=2812#c10
