### PR TITLE
TIME SENSITIVE: whitelist playlist additions

### DIFF
--- a/config/initializers/gem-plugin_config/sanitizer_config.rb
+++ b/config/initializers/gem-plugin_config/sanitizer_config.rb
@@ -102,6 +102,10 @@ class Sanitize
         then "google"
       when /^http:\/\/(?:www\.)?archiveofourown\.org\//
         then "archiveofourown"
+      when /^https:\/\/(?:embed\.)?spotify\.com\//
+        then "spotify"
+      when /^http:\/\/(?:www\.)?8tracks\.com\//
+        then "8tracks"
       else
         nil
       end
@@ -109,7 +113,7 @@ class Sanitize
       # if we don't know the source, sorry
       return if source.nil?           
 
-      allow_flashvars = ["ning", "vidders.net", "google", "criticalcommons", "archiveofourown"]
+      allow_flashvars = ["ning", "vidders.net", "google", "criticalcommons", "archiveofourown", "spotify", "8tracks"]
 
       # We're now certain that this is an embed from a trusted source, but we still need to run
       # it through a special Sanitize step to ensure that no unwanted elements or


### PR DESCRIPTION
Due to legal reasons, we cannot host fanmixes directly on the Archive. We can allow embedding of certain audio playlist object sources. Legal has okayed Spotify and 8tracks, both of which were given a cursory thumbs-up by ADT Chair. (Both sites use an iframe to embed.) per https://code.google.com/p/otwarchive/issues/detail?id=3294

These changes are requested by a challenge mod that goes live 2012 October 20. 
