### PR TITLE
Issue 3102: Related works reveal anonymous unrevealed works

### DIFF
--- a/app/views/related_works/index.html.erb
+++ b/app/views/related_works/index.html.erb
@@ -113,8 +113,10 @@
     <% @remixes_by_user.each do |related_work| %>
       <% unless related_work.translation? %>
         <% if related_work.parent && related_work.work %>
-          <dt class="parent">            
-            <% if related_work.work.unrevealed? || related_work.work.anonymous? %>
+          <dt class="parent">
+            <% if related_work.parent.is_a?(ExternalWork) %>
+               <%= link_to related_work.parent.title, related_work.parent %> by <%= byline(related_work.parent) %>
+            <% elsif related_work.parent.unrevealed? || related_work.parent.anonymous? %>
               <%= ts("A work in an unrevealed or anonymous challenge") %>
             <% else %>
               <%= link_to related_work.parent.title, related_work.parent %> by <%= byline(related_work.parent) %>
@@ -122,7 +124,11 @@
           </dt>
  		      <dd class="child">
  		        <%= ts("inspired") %>
-            <%= link_to related_work.work.title, related_work.work %>
+            <% if related_work.work.unrevealed? || related_work.work.anonymous? %>
+              <%= ts("A work in an unrevealed or anonymous challenge") %>
+            <% else %>
+              <%= link_to related_work.work.title, related_work.work %>
+            <% end %>
             <% if current_user == @user %>
             <span class="actions" role="button"><%= link_to "Remove", {:controller => :related_works, :action => :destroy, :id => related_work.id},  :confirm => ts('Are you sure?'), :method => :delete %></span>
             <% end %>


### PR DESCRIPTION
Resolves issue: http://code.google.com/p/otwarchive/issues/detail?id=3012

Changed the logic in the code to make it grab the correct work and check to see if it is unrevealed or anonymous. 

I also had the code check to see if the INSPIRING work is unrevealed or anonymous. It would be a weird situation indeed where an author was inspired by an unrevealed work, but why not lock this down tight so there aren't any accidental reveals.
