### PR TITLE
Issue 3296: New Subcollection button leads to Error 500

### DIFF
--- a/app/views/collections/_collection_form_delete.html.erb
+++ b/app/views/collections/_collection_form_delete.html.erb
@@ -1,5 +1,5 @@
 <ul class="navigation actions" role="menu">
-  <% if @collection.user_is_owner?(current_user) && !@collection.id.nil? %>
+  <% if @collection.user_is_owner?(current_user) %>
     <li><%= link_to ts("Delete Collection"), collection_path(@collection),
                     :confirm => ts('Are you certain you want to delete this collection? All collection settings will be lost. (Works will not be deleted.)'),
                     :method => :delete %></li>

--- a/app/views/collections/_form.html.erb
+++ b/app/views/collections/_form.html.erb
@@ -166,6 +166,7 @@
  </fieldset>
 
  <%= submit_fieldset collection_form %>
+  <% unless @collection.new_record? %>
   <%= render "collections/collection_form_delete" %>
-
+  <% end %>
 <% end %>


### PR DESCRIPTION
Resolves issue: http://code.google.com/p/otwarchive/issues/detail?id=3296

When adding a new subcollection from the collection page, it was causing an internal routing error because it was trying to add the 'Delete' a collection button to a collection that did not yet exist. I made it check to see if whatever it was trying to delete existed, first. That make sense? Either way, this seems to work. 
