### PR TITLE
Issue 2474: Allowed prompts for a prompt meme must be greater than zero

### DIFF
--- a/app/models/challenge/prompt_meme.rb
+++ b/app/models/challenge/prompt_meme.rb
@@ -25,7 +25,7 @@ class PromptMeme < ActiveRecord::Base
   PROMPT_TYPES.each do |type|
     %w(required allowed).each do |setting|
       prompt_limit_field = "#{type}_num_#{setting}"
-      validates_numericality_of prompt_limit_field, :only_integer => true, :less_than_or_equal_to => ArchiveConfig.PROMPT_MEME_PROMPTS_MAX, :greater_than_or_equal_to => 0
+      validates_numericality_of prompt_limit_field, :only_integer => true, :less_than_or_equal_to => ArchiveConfig.PROMPT_MEME_PROMPTS_MAX, :greater_than_or_equal_to => 1
     end
   end
 


### PR DESCRIPTION
Resolves issue: http://code.google.com/p/otwarchive/issues/detail?id=2476

Changed Prompt_meme model to check that allowed prompts is => 1
