### PR TITLE
FIX: Issues 2186 2587 3066 3073 3161 HTML escaping in titles

### DIFF
--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -150,6 +150,11 @@ class Collection < ActiveRecord::Base
       title.match(/\,\,/)
   end
 
+  # return title.html_safe to overcome escaping done by sanitiser
+  def title
+    read_attribute(:title).html_safe
+  end
+
   validates_length_of :description,
     :allow_blank => true,
     :maximum => ArchiveConfig.SUMMARY_MAX,

--- a/app/models/series.rb
+++ b/app/models/series.rb
@@ -24,6 +24,11 @@ class Series < ActiveRecord::Base
     :maximum => ArchiveConfig.TITLE_MAX, 
     :too_long=> t('title_too_long', :default => "must be less than %{max} letters long.", :max => ArchiveConfig.TITLE_MAX)
     
+  # return title.html_safe to overcome escaping done by sanitiser
+  def title
+    read_attribute(:title).html_safe
+  end
+
   validates_length_of :summary, 
     :allow_blank => true, 
     :maximum => ArchiveConfig.SUMMARY_MAX, 

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -104,6 +104,11 @@ class Work < ActiveRecord::Base
   attr_accessor :should_reset_filters
   attr_accessor :new_recipients
 
+  # return title.html_safe to overcome escaping done by sanitiser
+  def title
+    read_attribute(:title).html_safe
+  end
+
   ########################################################################
   # VALIDATION
   ########################################################################


### PR DESCRIPTION
Overloaded 'title' for work, series, collection, in response to &amp; / &lt; / &gt; issues.

https://code.google.com/p/otwarchive/issues/detail?id=2186
https://code.google.com/p/otwarchive/issues/detail?id=2587
https://code.google.com/p/otwarchive/issues/detail?id=3066
https://code.google.com/p/otwarchive/issues/detail?id=3073
https://code.google.com/p/otwarchive/issues/detail?id=3161
