### PR TITLE
Issue 2908: Top link on work pages

### DIFF
--- a/app/views/comments/_commentable.html.erb
+++ b/app/views/comments/_commentable.html.erb
@@ -4,7 +4,7 @@
   <h3 class="landmark heading"><%= ts("Actions") %></h3>
   <ul class="navigation actions" role="navigation">
     <% if @work || @admin_post %>
-      <li><a href='#main'><%= '&#8593; '.html_safe + ts('Top') %></a></li>
+      <li><a href="#main"><%= '&#8593; '.html_safe + ts('Top') %></a></li>
     <% end %>
     <% if @work && @previous_chapter %>
       <li><%= link_to '&#8592;'.html_safe + ts('Previous Chapter'), [@work, @previous_chapter] %></li>


### PR DESCRIPTION
Fixes issue 2908 (Top link leading to reload in some cases) by turning link_to anchor into plain HTML link to #main
