### PR TITLE
Issue 2825

### DIFF
--- a/app/views/bookmarks/_bookmark_user_module.html.erb
+++ b/app/views/bookmarks/_bookmark_user_module.html.erb
@@ -19,6 +19,7 @@
     </ul>
   <% end %>
 
+  <% # When the user views their own bookmark blurb, they are warned about seeing their bookmark in a modded collection %>
   <% unless bookmark.collections.blank? %>
       <% bookmark.collections.each do |modded| %>
         <% if modded.moderated? %>


### PR DESCRIPTION
Resolves issue: http://code.google.com/p/otwarchive/issues/detail?id=2825

View now check to see if a collection that the bookmark belongs to is moderated. If it is, there is a notice letting users know that their bookmark will not show up in the collection until the collection maintainers accept it. 
