### PR TITLE
Issue 1086: Collections show work counts including locked works even whe...

### DIFF
--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -266,19 +266,12 @@ class Collection < ActiveRecord::Base
   end
 
   def all_approved_works_count
-    if !User.current_user.nil? && User.current_user.active?
+    if !User.current_user.nil?
       count = self.approved_works.count
       self.children.each {|child| count += child.approved_works.count}
       count
     else
-      count = 0
-      # Count the items in the collection
-      all_approved_works.each do |collection_item|
-        work = Work.find_by_id(collection_item.id)
-        if !work.restricted?
-          count = count + 1
-        end
-      end
+      count = all_approved_works.where(:restricted => false).count
       count
     end
   end


### PR DESCRIPTION
...n user is not logged in

Resolves issue: http://code.google.com/p/otwarchive/issues/detail?id=1086

Collection model all_approved_works_count checks to see if a user is logged in or not, and if not, returns only the number of works in a collection (and subcollections) that are non-restricted. 
