### PR TITLE
3235 with display of warnings on external works edit page

### DIFF
--- a/app/views/external_works/edit.html.erb
+++ b/app/views/external_works/edit.html.erb
@@ -1,4 +1,4 @@
-<div id="work-form" class="create external bookmark">
+<div id="work-form" class="post external bookmark">
   <%= form_for(@external_work) do |f| %>
     <fieldset>
       <legend>Work Preface</legend>


### PR DESCRIPTION
On the admin edit page for external works, the warnings were listed side by side, so you had to think a minute to determine which checkbox went with which warning. This changes the form's create class to post, which gives it the proper one-warning-per-line styling. 

http://code.google.com/p/otwarchive/issues/detail?id=3235
