### PR TITLE
3332 with skin status message hidden under preview image

### DIFF
--- a/public/stylesheets/site/2.0/13-group-blurb.css
+++ b/public/stylesheets/site/2.0/13-group-blurb.css
@@ -51,6 +51,10 @@ li.blurb:after {
   margin: 0.375em 5.25em 0 65px;
 }
 
+.blurb .header p {
+  margin-left: 65px;
+}
+
 .blurb .header img {
   position: relative;
   margin: 0;


### PR DESCRIPTION
When a skin is submitted for public use, a status message displays in the skin blurb. However, part of the message was covered by the preview image/icon.

http://code.google.com/p/otwarchive/issues/detail?id=3332
