### PR TITLE
3335 with bookmark information escaping blurb

### DIFF
--- a/app/views/bookmarks/_bookmark_blurb.html.erb
+++ b/app/views/bookmarks/_bookmark_blurb.html.erb
@@ -22,7 +22,7 @@
 		<% end %>
 
     <!--navigation and actions-->
-    <% if logged_in? && (bookmark_count > 1 || !is_author_of?(bookmark)) %>
+    <% if (bookmark_count > 1 && (params[:tag_id] || @most_recent_bookmarks)) || (logged_in? && !is_author_of?(bookmark)) %>
     	<ul class="navigation actions" role="navigation">
       	<% # let the user reading this bookmark save a copy for themselves %>
       	<% if logged_in? && !is_author_of?(bookmark) %>


### PR DESCRIPTION
Because of an empty ul, the bookmark information was escaping the bookmark blurb on dashboard pages with filters when viewed by an admin.

http://code.google.com/p/otwarchive/issues/detail?id=3335
