### PR TITLE
3333 making filters keyboard accessible

### DIFF
--- a/app/views/bookmarks/_filters.html.erb
+++ b/app/views/bookmarks/_filters.html.erb
@@ -18,14 +18,14 @@
         <dt>
           <% tag_label = tag_type == 'tag' ? "Bookmarker's Tags" : tag_type.capitalize %>
           <noscript><%= tag_label %></noscript>
-          <span class="tag_category_<%= tag_type %>_open hidden">
+          <a class="tag_category_<%= tag_type %>_open hidden" href="#">
             <%= image_tag 'arrow-right.gif', :alt => "" %>
             <%= tag_label %>
-          </span>
-          <span class="tag_category_<%= tag_type %>_close hidden">
+          </a>
+          <a class="tag_category_<%= tag_type %>_close hidden" href="#">
             <%= image_tag 'arrow-down.gif', :alt => "" %>
             <%= tag_label %>
-          </span>
+          </a>
         </dt>
         <dd id="tag_category_<%= tag_type %>" class="tags toggled">
           <ul>              

--- a/app/views/works/_filters.html.erb
+++ b/app/views/works/_filters.html.erb
@@ -19,14 +19,14 @@
       <% %w(rating warning category fandom character relationship freeform).each do |tag_type| %>
         <dt>
           <noscript><%= tag_type.capitalize %></noscript>
-          <span class="tag_category_<%= tag_type %>_open hidden">
+          <a class="tag_category_<%= tag_type %>_open hidden" href="#">
             <%= image_tag 'arrow-right.gif', :alt => "" %>
             <%= tag_type.capitalize %>
-          </span>
-          <span class="tag_category_<%= tag_type %>_close hidden">
+          </a>
+          <a class="tag_category_<%= tag_type %>_close hidden" href="#">
             <%= image_tag 'arrow-down.gif', :alt => "" %>
             <%= tag_type.capitalize %>
-          </span>
+          </a>
         </dt>
         <dd id="tag_category_<%= tag_type %>" class="tags toggled">
           <ul>              

--- a/public/stylesheets/site/2.0/18-zone-searchbrowse.css
+++ b/public/stylesheets/site/2.0/18-zone-searchbrowse.css
@@ -76,8 +76,16 @@ form.filters dl {
   padding: 0;
 }
 
-form.filters dt span {
-  cursor: pointer;
+.filters dt a {
+  border: none;
+}
+
+.filters dt a:hover {
+  color: #111;
+}
+
+.filters dt a:focus img {
+  outline: none;
 }
 
 .filters dd, .filters dt, .filters .submit input {


### PR DESCRIPTION
The filters weren't accessible via Tab key in Firefox, Safari, or Chrome. http://code.google.com/p/otwarchive/issues/detail?id=3333
