### PR TITLE
3344 Recent Bookmarks does not match Recent Works on collections

### DIFF
--- a/app/views/collections/_bookmarks_module.html.erb
+++ b/app/views/collections/_bookmarks_module.html.erb
@@ -1,4 +1,4 @@
-<div class="bookmarks module group" id="collection-bookmarks">
+<div class="bookmarks listbox group" id="collection-bookmarks">
   <h3 class="heading">
     <% if collection.collection_preference.show_random || params[:show_random] %>
       <%= ts("Random bookmarks") %>  


### PR DESCRIPTION
On collections pages, the recent bookmarks div had a module class instead of a listbox class, which was making it display differently than the recent works section

http://code.google.com/p/otwarchive/issues/detail?id=3344
