### PR TITLE
3350 comment actions redirecting to top of comments section

### DIFF
--- a/public/javascripts/application.js
+++ b/public/javascripts/application.js
@@ -30,7 +30,7 @@ $j(document).ready(function() {
     $j('.commas li:last-child').addClass('last');
 
     // Set things up to scroll to the top of the comments section when loading additional pages in comment pagination.
-    $j('#comments_placeholder a[data-remote], .actions.work .comments a').live('click.rails', function(e){ $j.scrollTo('#comments_placeholder'); });
+    $j('#comments_placeholder .pagination a[data-remote], .actions.work .comments a').live('click.rails', function(e){ $j.scrollTo('#comments_placeholder'); });
 });
 
 function visualizeTables() {


### PR DESCRIPTION
If you chose edit, reply, or delete on a comment, it would scroll up to the top of the comments section because the scrolling jQuery was applied to all a elements in the comment section with a data-remote attribute. This makes it so the scrolling only applies to the pagination. http://code.google.com/p/otwarchive/issues/detail?id=3350
