### PR TITLE
Issue 3180: Ability to disable user invitation request form

### DIFF
--- a/app/controllers/user_invite_requests_controller.rb
+++ b/app/controllers/user_invite_requests_controller.rb
@@ -10,35 +10,40 @@ class UserInviteRequestsController < ApplicationController
   # GET /user_invite_requests/new
   # GET /user_invite_requests/new.xml
   def new
-    setflash; flash[:error] = "Sorry, new invitations are not currently available. If you're a challenge mod or are looking to preserve works from another site, please contact Support."
-    redirect_to root_path
-    # if logged_in? 
-    #   @user = current_user
-    #   @user_invite_request = @user.user_invite_requests.build
-    # else
-    #   setflash; flash[:error] = "Please log in."
-    #   redirect_to login_path
-    # end
+    if AdminSetting.request_invite_enabled?
+     if logged_in?
+       @user = current_user
+       @user_invite_request = @user.user_invite_requests.build
+     else
+       setflash; flash[:error] = ts("Please log in.")
+       redirect_to login_path
+     end
+    else
+      setflash; flash[:error] = ts("Sorry, new invitations are temporarily unavailable. If you are the mod of a challenge currently being run on the Archive, please <a href=\"#{new_feedback_report_url}\">contact Support</a>. If you are the maintainer of an at-risk archive, please contact <a href=\"http://opendoors.transformativeworks.org/contact/open doors\">Open Doors</a>".html_safe)
+      redirect_to root_path
+    end
   end
-
   # POST /user_invite_requests
   # POST /user_invite_requests.xml
   def create
-    setflash; flash[:error] = "Sorry, new invitations are not currently available. If you're a challenge mod or are looking to preserve works from another site, please contact Support."
-    redirect_to root_path
-    # if logged_in? 
-    #   @user = current_user
-    #   @user_invite_request = @user.user_invite_requests.build(params[:user_invite_request])
-    # else
-    #   setflash; flash[:error] = "Please log in."
-    #   redirect_to login_path
-    # end
-    # if @user_invite_request.save
-    #   setflash; flash[:notice] = 'Request was successfully created.'
-    #   redirect_to(@user)
-    # else
-    #   render :action => "new"
-    # end
+    if AdminSetting.request_invite_enabled?
+      if logged_in?
+         @user = current_user
+         @user_invite_request = @user.user_invite_requests.build(params[:user_invite_request])
+       else
+         setflash; flash[:error] = "Please log in."
+         redirect_to login_path
+       end
+       if @user_invite_request.save
+         setflash; flash[:notice] = 'Request was successfully created.'
+         redirect_to(@user)
+      else
+        render :action => "new"
+      end
+    else
+      setflash; flash[:error] = ts("Sorry, new invitations are temporarily unavailable. If you are the mod of a challenge currently being run on the Archive, please <a href=\"#{new_feedback_report_url}\">contact Support</a>. If you are the maintainer of an at-risk archive, please contact <a href=\"http://opendoors.transformativeworks.org/contact/open doors\">Open Doors</a>".html_safe)
+      redirect_to root_path
+    end
   end
 
   # PUT /user_invite_requests/1
@@ -51,7 +56,7 @@ class UserInviteRequestsController < ApplicationController
         request.save!
       end
     end
-    setflash; flash[:notice] = 'Requests were successfully updated.'
+    setflash; flash[:notice] = ts("Requests were successfully updated.")
     redirect_to user_invite_requests_url
   end
 end

--- a/app/models/admin_setting.rb
+++ b/app/models/admin_setting.rb
@@ -14,6 +14,9 @@ class AdminSetting < ActiveRecord::Base
   def self.invite_from_queue_enabled?
     self.first ? self.first.invite_from_queue_enabled? : ArchiveConfig.INVITE_FROM_QUEUE_ENABLED
   end
+  def self.request_invite_enabled?
+    self.first ? self.first.request_invite_enabled? : false
+  end
   def self.invite_from_queue_at
     self.first.invite_from_queue_at
   end

--- a/app/views/admin/settings/index.html.erb
+++ b/app/views/admin/settings/index.html.erb
@@ -9,6 +9,8 @@
     <dt><%= f.label :account_creation_enabled, "Account Creation Enabled (Can people create accounts without an invitation?)" %>
 </dt>
     <dd><%= f.check_box :account_creation_enabled %> </dd>
+    <dt><%= f.label :request_invite_enabled, "Users can request invitations?" %></dt>
+    <dd><%= f.check_box :request_invite_enabled %></dd>
     <dt><%= f.label :invite_from_queue_enabled, "Invite from Queue Enabled
 (Can people add themselves to the queue and are invitations sent out automatically?)" %>
 </dt>

--- a/db/migrate/20121102002223_add_request_invite_enabled_field.rb
+++ b/db/migrate/20121102002223_add_request_invite_enabled_field.rb
@@ -1,0 +1,9 @@
+class AddRequestInviteEnabledField < ActiveRecord::Migration
+  def self.up
+    add_column :admin_settings, :request_invite_enabled, :boolean, :null => false, :default => false
+  end
+
+  def self.down
+    remove_column :admin_settings, :request_invite_enabled
+  end
+end


### PR DESCRIPTION
Resolves issue: http://code.google.com/p/otwarchive/issues/detail?id=3180

Added the 'request_invite_enabled' column to the admin_settings table. Defaults to false. If set to true, users will be allowed to request invites, otherwise they are given a meaningful message and send back to the main Archive homepage. 
