### PR TITLE
3353 with author actions and stats overlapping

### DIFF
--- a/public/stylesheets/site/2.0/13-group-blurb.css
+++ b/public/stylesheets/site/2.0/13-group-blurb.css
@@ -222,7 +222,7 @@ li.blurb:after {
 }
 
 .blurb.own dl.stats {
-  padding-left: 12.15em;
+  padding-left: 19.15em;
 }
 
 /*modification: PICTURE 


### PR DESCRIPTION
The stats line didn't allow for enough room for the Add Chapter button on your own work blurbs so the stats and the buttons were overlapping: http://code.google.com/p/otwarchive/issues/detail?id=3353
