### PR TITLE
Issue 3367: tag search form should retain data when you search

### DIFF
--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -37,6 +37,7 @@ class TagsController < ApplicationController
   def search
     if params[:query].present?
       options = params[:query].dup
+      @query = options
       options.merge!(:page => params[:page] || 1)
       @tags = Tag.search(options)
     end


### PR DESCRIPTION
Issue 3367: tag search form should retain data when you search

http://code.google.com/p/otwarchive/issues/detail?id=3367
