### PR TITLE
3377 with bookmark index not taking up full width of page on mobile

### DIFF
--- a/public/stylesheets/site/2.0/25-role-handheld.css
+++ b/public/stylesheets/site/2.0/25-role-handheld.css
@@ -71,7 +71,7 @@ h1 a img {
   padding: 0;
 }
 
-#dashboard, #main.dashboard .index, .dashboard form.filters, #main .filters, .works-index .index, .collections-index .index, #inner form dd, #inner form dt {
+#dashboard, #main.dashboard .index, .dashboard form.filters, #main .filters, .works-index .index, .collections-index .index, .bookmarks-index .index, #inner form dd, #inner form dt {
   width: 100%;
   max-width: 100%;
   min-width: 0;


### PR DESCRIPTION
http://code.google.com/p/otwarchive/issues/detail?id=3377

Bookmark blurbs were only taking up 75% of the page on mobile.
