### PR TITLE
3378 inbox filter options misaligned

### DIFF
--- a/app/views/inbox/show.html.erb
+++ b/app/views/inbox/show.html.erb
@@ -94,7 +94,6 @@
             <%= radio_button_tag 'filters[read]', 'false', @select_read == 'false' %>
             <%= label_tag 'filters_read_false', ts("Show unread") %>
           </li>
-          </li>
           <li>
             <%= radio_button_tag 'filters[read]', 'true', @select_read == 'true' %>
             <%= label_tag 'filters_read_true', ts("Show read") %>


### PR DESCRIPTION
http://code.google.com/p/otwarchive/issues/detail?id=3378

I could've done this with CSS -- form dd + dd was causing the radio buttons to be misaligned because, AFAIR, it was a tweak for the post new form -- but instead I changed the markup so it would have the same structure as work/bookmark filters.
