### PR TITLE
3348 redux challenge settings update covered in IE 9

### DIFF
--- a/app/views/challenge/gift_exchange/_challenge_navigation_maintainer.html.erb
+++ b/app/views/challenge/gift_exchange/_challenge_navigation_maintainer.html.erb
@@ -1,5 +1,5 @@
 <% if @collection.challenge.user_allowed_to_see_signups?(current_user) %>
-  <li role="navigation"><%= link_to ts("Signups"), collection_signups_path(@collection) %></li>
+  <li role="navigation"><%= link_to ts("Sign-ups"), collection_signups_path(@collection) %></li>
 <% end %>
 <% if @collection.user_is_owner?(current_user) %>
   <li role="navigation"><%= link_to ts("Challenge Settings"), edit_collection_gift_exchange_path(@collection) %></li>

--- a/app/views/challenge/gift_exchange/_challenge_sidebar.html.erb
+++ b/app/views/challenge/gift_exchange/_challenge_sidebar.html.erb
@@ -1,14 +1,14 @@
 <% if logged_in? %>
-<h4 class="landmark heading">Gift Exchange</h4>
+<h4 class="landmark heading"><%= ts("Gift Exchange") %></h4>
   <ul class="navigation actions">
   <!-- added automatically to the collection sidebar for challenges. 
         all items should be enclosed in <li> </li> and linked with span_if_current! 
         @collection is defined, @challenge may not be. -->
   <!-- signup form or link -->
   <% if (@challenge_signup = ChallengeSignup.in_collection(@collection).by_user(current_user).first) %>
-    <li><%= span_if_current ts("Your Signup"), collection_signup_path(@collection, @challenge_signup) %></li>
+    <li><%= span_if_current ts("Your Sign-up"), collection_signup_path(@collection, @challenge_signup) %></li>
   <% elsif @collection.challenge.user_allowed_to_sign_up?(current_user) || @collection.user_is_posting_participant?(current_user) %>
-    <li><%= span_if_current ts("Signup Form"), new_collection_signup_path(@collection) %></li>
+    <li><%= span_if_current ts("Sign-up Form"), new_collection_signup_path(@collection) %></li>
   <% end %>
 
   <!-- assignment link -->
@@ -23,11 +23,11 @@
 
   <% if @collection.challenge.user_allowed_to_see_signups?(current_user) %>
     <li>
-      <%= span_if_current ts("Signups (%{count})", :count => @collection.signups.count), collection_signups_path(@collection) %>
+      <%= span_if_current ts("Sign-ups (%{count})", :count => @collection.signups.count), collection_signups_path(@collection) %>
     </li>
   <% end %>
   <li>
-    <%= span_if_current ts("Signup Summary"), summary_collection_signups_path(@collection) %>
+    <%= span_if_current ts("Sign-up Summary"), summary_collection_signups_path(@collection) %>
   </li>
   <% if @collection.challenge.user_allowed_to_see_requests_summary?(current_user) %>
     <li>

--- a/app/views/challenge/gift_exchange/_challenge_signups.html.erb
+++ b/app/views/challenge/gift_exchange/_challenge_signups.html.erb
@@ -1,4 +1,4 @@
-<h2 class="heading"><%= ts("Signups for %{collection}", :collection => @collection.title) %></h2>
+<h2 class="heading"><%= ts("Sign-ups for %{collection}", :collection => @collection.title) %></h2>
   
 <ul class="navigation" role="menu">
   <li class="action">
@@ -8,7 +8,7 @@
 </ul>
   
 <% if @challenge_signups.empty? %>
-  <p><%= ts("No signups yet!")%></p>
+  <p><%= ts("No sign-ups yet!")%></p>
 <% else %>
   <%= will_paginate(@challenge_signups) %>
 

--- a/app/views/challenge/gift_exchange/_gift_exchange_form.html.erb
+++ b/app/views/challenge/gift_exchange/_gift_exchange_form.html.erb
@@ -1,10 +1,10 @@
-<h2 class="heading"><%= ts("Setting Up The %{title} Gift Exchange", :title => @collection.title) %></h2>
+<h2 class="heading"><%= ts("Setting Up the %{title} Gift Exchange", :title => @collection.title) %></h2>
 
 <h3 class="landmark heading"><%= ts('Notes') %></h3>
 <ul class="notes">
-  <li>The more options you allow here, the more complicated your signup form will be.</li>
-  <li>If you keep to one request and one offer, automated matching will be easier! A single request can include multiple fandoms. Unless you want to do fairly complicated requests, you probably don't need more than one request/offer.</li>
-  <li>You only need to set the "Allowed" number if you want more allowed than required. </li>
+  <li><%= ts("The more options you allow here, the more complicated your sign-up form will be.") %></li>
+  <li><%= ts("If you keep to one request and one offer, automated matching will be easier! A single request can include multiple fandoms. Unless you want to do fairly complicated requests, you probably don't need more than one request/offer.") %></li>
+  <li><%= ts('You only need to set the "Allowed" number if you want more allowed than required.') %></li>
 </ul>
 
 <!-- /descriptions-->
@@ -12,22 +12,22 @@
 <!--/subnav-->
 
 <!--main content-->
-<h3 class="landmark heading">Gift Exchange Settings</h3>
+<h3 class="landmark heading"><%= ts("Gift Exchange Settings") %></h3>
 <%= form_for([@collection, @challenge], :url => collection_gift_exchange_path(@collection), :html => {:class => "verbose create challenge"}) do |f| %>
   <%= error_messages_for @challenge %>
   <%= render "challenge/shared/challenge_form_schedule", :f => f %>
 
   <fieldset>
-  	<legend>Requests and Offers</legend>
-  	<h3 class="landmark heading">Requests and Offers</h3>
+  	<legend><%= ts("Requests and Offers") %></legend>
+  	<h3 class="landmark heading"><%= ts("Requests and Offers") %></h3>
     <dl>
-      <dt><%= f.label :requests_summary_visible, ts("Requests visible?") %>: <%= link_to_help "challenge-requests-summary" %></dt>
+      <dt><%= f.label :requests_summary_visible, ts("Requests visible?") %> <%= link_to_help "challenge-requests-summary" %></dt>
       <dd><%= f.check_box :requests_summary_visible %></dd>
 
-      <dt><%= f.label :requests_num_required, ts("Number of requests per signup") %>:</dt>
+      <dt><%= f.label :requests_num_required, ts("Number of requests per sign-up:") %></dt>
       <%= required_and_allowed(f, "requests", false) %>
 
-      <dt><%= f.label :offers_num_required, ts("Number of offers per signup") %>:</dt>
+      <dt><%= f.label :offers_num_required, ts("Number of offers per sign-up:") %></dt>
       <%= required_and_allowed(f, "offers", false) %>
     </dl>
   </fieldset>

--- a/app/views/challenge/prompt_meme/_challenge_navigation_maintainer.html.erb
+++ b/app/views/challenge/prompt_meme/_challenge_navigation_maintainer.html.erb
@@ -1,5 +1,5 @@
 <% if @collection.challenge.user_allowed_to_see_signups?(current_user) %>
-  <li role="navigation"><%= link_to ts("Signups"), collection_signups_path(@collection) %></li>
+  <li role="navigation"><%= link_to ts("Sign-ups"), collection_signups_path(@collection) %></li>
 <% end %>
 <% if @collection.user_is_owner?(current_user) %>
   <li role="navigation"><%= link_to ts("Challenge Settings"), edit_collection_prompt_meme_path(@collection) %></li>

--- a/app/views/challenge/prompt_meme/_challenge_sidebar.html.erb
+++ b/app/views/challenge/prompt_meme/_challenge_sidebar.html.erb
@@ -1,4 +1,4 @@
-<h4 class="landmark heading">Prompt Meme</h4>
+<h4 class="landmark heading"><%= ts("Prompt Meme") %></h4>
 <ul class="navigation actions">
   <% # added automatically to the collection sidebar for challenges. 
     #  all items should be enclosed in <li> </li> and linked with span_if_current! 

--- a/app/views/challenge/prompt_meme/_challenge_signups.html.erb
+++ b/app/views/challenge/prompt_meme/_challenge_signups.html.erb
@@ -1,4 +1,4 @@
-<h2 class="heading"><%= ts("Signups for %{collection}", :collection => @collection.title) %></h2>
+<h2 class="heading"><%= ts("Sign-ups for %{collection}", :collection => @collection.title) %></h2>
   
 <% @challenge ||= @collection.challenge -%>
 <ul class="navigation actions" role="menu">

--- a/app/views/challenge/prompt_meme/_prompt_meme_form.html.erb
+++ b/app/views/challenge/prompt_meme/_prompt_meme_form.html.erb
@@ -1,11 +1,11 @@
-<h2 class="heading"><%= ts("Setting Up The %{title} Prompt Meme", :title => @collection.title) -%></h2>
+<h2 class="heading"><%= ts("Setting Up the %{title} Prompt Meme", :title => @collection.title) -%></h2>
 
 <h3 class="landmark heading"><%= ts("Notes") %></h3>
 <ul class="notes">
-  <li>The more options you allow here, the more complicated your signup form will be.</li>
-  <li>If you set the "Required" value higher than the corresponding "Allowed" value, we will 
+  <li><%= ts("The more options you allow here, the more complicated your sign-up form will be.") %></li>
+  <li><%= ts('If you set the "Required" value higher than the corresponding "Allowed" value, we will 
     automatically assume that you want the allowed value to be the same as the required value. You only need to manually
-    set the "Allowed" number if you want more allowed than required. </li>
+    set the "Allowed" number if you want more allowed than required.') %></li>
 </ul>
 
 <!-- /descriptions-->
@@ -13,21 +13,21 @@
 <!--/subnav-->
 
 <!--main content-->
-<h3 class="landmark heading">Prompt Meme Settings</h3>
+<h3 class="landmark heading"><%= ts("Prompt Meme Settings") %></h3>
 
-<%= form_for([@collection, @challenge], :url => collection_prompt_meme_path(@collection)) do |f| %>
+<%= form_for([@collection, @challenge], :url => collection_prompt_meme_path(@collection), :html => {:class => "verbose create challenge"}) do |f| %>
   <%= error_messages_for @challenge %>
   <%= render "challenge/shared/challenge_form_schedule", :f => f %>
 
   <fieldset>
-    <legend>Prompts</legend>
-    <h3 class="heading">Prompts</h3>
+    <legend><%= ts("Prompts") %></legend>
+    <h3 class="landmark heading"><%= ts("Prompts") %></h3>
     <dl>
       <dt><%= f.label :anonymous, ts("Prompts anonymous by default?") %></dt>
       <dd><%= f.check_box :anonymous %>
       <p class="note">(Participants can override)</p>
       </dd>
-      <dt><%= f.label :requests_num_required, ts("Number of prompts per signup") %>:</dt>
+      <dt><%= f.label :requests_num_required, ts("Number of prompts per sign-up:") %></dt>
       <%= required_and_allowed(f, "requests", false) %>
 
     </dl>
@@ -47,4 +47,3 @@
 <!--subnav-->
 <%= render "challenge/shared/challenge_form_delete" %>
 <!--/subnav-->
-

--- a/app/views/challenge/shared/_challenge_form_delete.html.erb
+++ b/app/views/challenge/shared/_challenge_form_delete.html.erb
@@ -4,5 +4,5 @@
       :confirm => ts('Are you certain you want to delete the challenge from this collection? All signups, assignments, and settings will be lost. (Works will remain in the collection.)'),
       :method => :delete %></li>
   <% end %>
-  <li><%= link_to 'Back', collection_path(@collection) %></li>
+  <li><%= link_to ts('Back'), collection_path(@collection) %></li>
 </ul>

--- a/app/views/challenge/shared/_challenge_form_instructions.html.erb
+++ b/app/views/challenge/shared/_challenge_form_instructions.html.erb
@@ -1,11 +1,11 @@
 <fieldset>
-  <legend><%= ts("Signup Instructions") %></legend>
-  <h3 class="heading"><%= ts("Signup Instructions") %></h3>
+  <legend><%= ts("Sign-up Instructions") %></legend>
+  <h3 class="landmark heading"><%= ts("Sign-up Instructions") %></h3>
   <p class="note">
     <%= ts("Explain to your members how you want them to sign up.") %> <%= allowed_html_instructions %>
   </p>
   <dl>
-    <dt><%= f.label :signup_instructions_general, ts("General Signup Instructions: ") %></dt>
+    <dt><%= f.label :signup_instructions_general, ts("General Sign-up Instructions:") %></dt>
     <dd>
       <%= f.text_area :signup_instructions_general, :id => field_id(f, "signup_instructions_general").to_sym, :rows => 6, :cols => 60, :class => "observe_textlength" %>
       <%= live_validation_for_field(field_id(f, "signup_instructions_general").to_sym, :presence => false, :maximum_length => ArchiveConfig.INFO_MAX) -%>
@@ -22,22 +22,23 @@
     <% end %>
   </dl>
 
-  <h4 class="heading">Change the labels</h4>
-  <p>You can change these form fields to something more useful for your own challenge.</p>
+  <h4 class="heading"><%= ts("Change the Labels") %></h4>
+  <p><%= ts("You can change these form fields to something more useful for your own challenge.") %></p>
   <dl>
     <% f.object.class::PROMPT_TYPES.each do |prompt_types| %>
       <% prompt_type = prompt_types.singularize %>
-      <dt>
-      <%= ts("In #{prompt_types.capitalize} change") %></dt>
+      <dt><%= ts("In #{prompt_types.capitalize} change:") %></dt>
       <dd>
         <fieldset>
-          <dt><%= f.label "#{prompt_type}_url_label".to_sym, ts("\"Prompt URL\" to") %>:</dt>
-      <dd><%= f.text_field "#{prompt_type}_url_label".to_sym %></dd>
+          <dl>
+            <dt><%= f.label "#{prompt_type}_url_label".to_sym, ts("\"Prompt URL\" to:") %></dt>
+            <dd><%= f.text_field "#{prompt_type}_url_label".to_sym %></dd>
 
-      <dt><%= f.label "#{prompt_type}_description_label".to_sym, ts("\"Description\" to") %>:</dt>
-      <dd><%= f.text_field "#{prompt_type}_description_label".to_sym %></dd>
-    </fieldset>
-    </dd>
+            <dt><%= f.label "#{prompt_type}_description_label".to_sym, ts("\"Description\" to:") %></dt>
+            <dd><%= f.text_field "#{prompt_type}_description_label".to_sym %></dd>
+          </dl>
+        </fieldset>
+      </dd>
     <% end %>
   </dl>
 </fieldset>

--- a/app/views/challenge/shared/_challenge_form_schedule.html.erb
+++ b/app/views/challenge/shared/_challenge_form_schedule.html.erb
@@ -1,36 +1,36 @@
 <fieldset>
-  <legend>Schedule</legend>
-  <h3 class="heading">Schedule</h3>
+  <legend><%= ts("Schedule") %></legend>
+  <h3 class="landmark heading"><%= ts("Schedule") %></h3>
   <ul class="notes">
     <li>
-      Collection maintainers can sign up while signup is closed. Nobody else will 
-      see the signup links until you mark your collection open. In this way you can go through the steps and make sure your signup form looks just as you want before you launch.
+      <%= ts("Collection maintainers can sign up while sign-up is closed. Nobody else will 
+      see the sign-up links until you mark your collection open. In this way you can go through the steps and make sure your sign-up form looks just as you want before you launch.") %>
     </li>
-    <li>Dates don't do anything right now; you need to manually open and close signup.</li>
+    <li><%= ts("Dates don't do anything right now; you need to manually open and close sign-up.") %></li>
   </ul>
   <dl>
-    <dt><%= f.label :signup_open, ts("Signup open?") %></dt>
+    <dt><%= f.label :signup_open, ts("Sign-up open?") %></dt>
     <dd class="datetime"><%= f.check_box :signup_open %></dd>
     
-    <dt><%= f.label :time_zone, ts("Time zone")%>:</dt>
+    <dt><%= f.label :time_zone, ts("Time zone:") %></dt>
     <dd class="datetime"><%= f.time_zone_select :time_zone, nil, :default => Time.zone.name %></dd>
       
-    <dt><%= f.label :signups_open_at_string, ts("Signup opens")%>:</dt>
+    <dt><%= f.label :signups_open_at_string, ts("Sign-up opens:")%></dt>
     <dd class="datetime"><%= f.text_field :signups_open_at_string, :class => 'timepicker' %></dd>
 
-    <dt><%= f.label :signups_close_at_string, ts("Signup closes")%>:</dt>
+    <dt><%= f.label :signups_close_at_string, ts("Sign-up closes:")%></dt>
     <dd class="datetime"><%= f.text_field :signups_close_at_string, :class => 'timepicker' %></dd>
 
-    <dt><%= f.label :assignments_due_at_string, ts("Assignments due")%>:</dt>
+    <dt><%= f.label :assignments_due_at_string, ts("Assignments due:")%></dt>
     <dd class="datetime"><%= f.text_field :assignments_due_at_string, :class => 'timepicker' %></dd>
 
     <% if @collection.unrevealed? %>
-      <dt><%= f.label :works_reveal_at_string, ts("Works revealed")%>:</dt>
+      <dt><%= f.label :works_reveal_at_string, ts("Works revealed:")%></dt>
       <dd class="datetime"><%= f.text_field :works_reveal_at_string, :class => 'timepicker' %></dd>
     <% end %>
 
     <% if @collection.anonymous? %>
-      <dt><%= f.label :authors_reveal_at_string, ts("Authors revealed")%>:</dt>
+      <dt><%= f.label :authors_reveal_at_string, ts("Authors revealed:")%></dt>
       <dd class="datetime"><%= f.text_field :authors_reveal_at_string , :class => 'timepicker' %></dd>
     <% end %>
   </dl>

--- a/app/views/challenge/shared/_challenge_meta.html.erb
+++ b/app/views/challenge/shared/_challenge_meta.html.erb
@@ -2,58 +2,58 @@
 <% challenge = @collection.challenge %>
 <% zone = (challenge.time_zone || Time.zone.name) %>
 <% if challenge.signup_open %>
-  <dt><%= ts("Signup")%>:</dt>
+  <dt><%= ts("Sign-up:")%></dt>
   <dd><strong><%= link_to ts("Open"), new_collection_signup_path(@collection) %></strong></dd>
 
-  <dt><%= ts("Signup closes")%>:</dt>
+  <dt><%= ts("Sign-up closes:")%></dt>
   <dd class="datetime"><%= time_in_zone(challenge.signups_close_at, zone) %></dd>
 
 <% elsif Time.now < (challenge.signups_open_at || 1.day.ago) %>
 
-  <dt><%= ts("Signup opens")%>:</dt>
+  <dt><%= ts("Sign-up opens:")%></dt>
   <dd class="datetime"><%= time_in_zone(challenge.signups_open_at, zone) %></dd>
 
-  <dt><%= ts("Signup closes")%>:</dt>
+  <dt><%= ts("Sign-up closes:")%></dt>
   <dd class="datetime"><%= time_in_zone(challenge.signups_close_at, zone) %></dd>
 
 <% elsif Time.now < (challenge.signups_close_at || 1.day.ago) %>
-  <dt><%= ts("Signup")%>:</dt>
+  <dt><%= ts("Sign-up:")%></dt>
   <dd><strong><%= ts("Closed")%></strong> 
     <span class="datetime">(on <%= time_in_zone(challenge.signups_close_at, zone) %>)</span></dd>
 <% end %>
 
-<dt><%= ts("Assignments due")%>:</dt>
+<dt><%= ts("Assignments due:")%></dt>
 <dd class="datetime"><%= time_in_zone(challenge.assignments_due_at, zone) %></dd>
 
 <% if @collection.unrevealed? %>
-  <dt><%= ts("Works revealed")%>:</dt>
+  <dt><%= ts("Works revealed:")%></dt>
   <dd class="datetime"><%= time_in_zone(challenge.works_reveal_at, zone) %></dd>
 <% end %>
 
 <% if @collection.anonymous? %>
-  <dt><%= ts("Authors revealed")%>:</dt>
+  <dt><%= ts("Authors revealed:")%></dt>
   <dd class="datetime"><%= time_in_zone(challenge.authors_reveal_at, zone) %></dd>
 <% end %>
 
-<dt><%= ts("Signed up") %>:</dt>
+<dt><%= ts("Signed up:") %></dt>
 <dd>
   <%= signup_count = @collection.signups.count %>
   <% if signup_count < 6 %>
-    <%= ts("Too few signups to display names") %>
+    <%= ts("Too few sign-ups to display names") %>
   <% else %>  
     <% num_to_show = 20 # arbitrary number for how many names to list %>
     <ul>
       <% @collection.signups.includes(:pseud => :user).collect(&:pseud).compact.each_with_index do |pseud, index| %>
         <% if index == num_to_show %>
           </ul>
-          <h5 id="show_signups" style="display:none" class="showme">(See all...)</h5>
+          <h5 id="show_signups" style="display:none" class="showme"><%= ts("(See all...)") %></h5>
           <ul id="more_signups" class="hideme">
         <% end %>
         <li><%= "#{pseud.byline}" + (index != (num_to_show-1) && index != (signup_count-1) ? "," : "") %></li>
       <% end %>
     </ul>
     <% if signup_count > num_to_show %>
-      <h5 style="display:none" id="hide_signups">(See fewer...)</h5>
+      <h5 style="display:none" id="hide_signups"><%= ts("(See fewer...)") %></h5>
       <%= content_for :footer_js do %>
         <%= javascript_tag do %>
           $j(document).ready(function(){

--- a/app/views/challenge/shared/_challenge_navigation_user.html.erb
+++ b/app/views/challenge/shared/_challenge_navigation_user.html.erb
@@ -3,11 +3,11 @@
 <% if collection.challenge && collection.challenge.signup_open %>
   <% if logged_in? %>
     <% if (@challenge_signup = ChallengeSignup.in_collection(collection).by_user(current_user).first) %>
-      <li><%= link_to ts("Edit Signup"), edit_collection_signup_path(collection, @challenge_signup) %></li>
+      <li><%= link_to ts("Edit Sign-up"), edit_collection_signup_path(collection, @challenge_signup) %></li>
       <li>
-        <%= link_to ts("Cancel Signup"),
+        <%= link_to ts("Cancel Sign-up"),
           collection_signup_path(collection, @challenge_signup),
-          :confirm => ts("Are you sure you want to cancel your signup? All signup information will be lost."),
+          :confirm => ts("Are you sure you want to cancel your sign-up? All sign-up information will be lost."),
           :method => :delete %>
       </li>
 

--- a/app/views/challenge/shared/_challenge_signups.html.erb
+++ b/app/views/challenge/shared/_challenge_signups.html.erb
@@ -3,7 +3,7 @@
   # It should not be user-facing for most challenges
 %>
 
-<h2 class="heading"><%= ts("Signups for %{collection}", :collection => @collection.title) %></h2>  
+<h2 class="heading"><%= ts("Sign-ups for %{collection}", :collection => @collection.title) %></h2>  
 <% @challenge ||= @collection.challenge %>
 
 <ul class="navigation actions" role="menu">

--- a/app/views/challenge_signups/_signup_form.html.erb
+++ b/app/views/challenge_signups/_signup_form.html.erb
@@ -1,4 +1,4 @@
-<h2 class="heading"><%= ts("Sign Up For %{title}", :title => @collection.title) %></h2>
+<h2 class="heading"><%= ts("Sign Up for %{title}", :title => @collection.title) %></h2>
 
 <!-- descriptions-->
 <!-- /descriptions-->

--- a/app/views/challenge_signups/_signup_form_general_information.html.erb
+++ b/app/views/challenge_signups/_signup_form_general_information.html.erb
@@ -1,4 +1,4 @@
-<h3 class="heading">Sign up as
+<h3 class="heading"><%= ts("Sign up as") %>
   <% if (form.object.new_record? || @challenge.allow_name_change?) && current_user.pseuds.size > 1 %>
     <%= form.select :pseud_id, options_from_collection_for_select(current_user.pseuds, :id, :name, current_user.default_pseud.id) %>
   <% else %>

--- a/app/views/challenge_signups/index.html.erb
+++ b/app/views/challenge_signups/index.html.erb
@@ -7,7 +7,7 @@
 <% elsif @user %>
   <!-- view in user dashboard -->
 
-  <h2 class="heading"><%= ts("Challenge Signups for %{user}", :user => @user.login) %></h2>
+  <h2 class="heading"><%= ts("Challenge Sign-ups for %{user}", :user => @user.login) %></h2>
 
   <dl class="signup index group">
     <% @challenge_signups.each do |challenge_signup| %>

--- a/app/views/challenge_signups/show.html.erb
+++ b/app/views/challenge_signups/show.html.erb
@@ -1,6 +1,6 @@
 <div id="collection-page" class="collection challenge home">
   <!--main content-->
-  <h2 class="heading"><%= ts("Signup for %{person}", :person => @challenge_signup.pseud.byline) %></h2>
+  <h2 class="heading"><%= ts("Sign-up for %{person}", :person => @challenge_signup.pseud.byline) %></h2>
   <!--subnav-->
   <%= render "signup_controls", :challenge_signup => @challenge_signup %>
   <!--/subnav-->

--- a/app/views/potential_match_settings/_potential_match_settings_form.html.erb
+++ b/app/views/potential_match_settings/_potential_match_settings_form.html.erb
@@ -5,22 +5,22 @@
 <%= challenge_form.fields_for(:potential_match_settings) do |match_settings_form| %>
 
   <fieldset id="match_settings">
-    <legend>Minimum Number To Match</legend>
-    <h3 class="heading">Minimum Number To Match</h3>
+    <legend><%= ts("Minimum Number To Match") %></legend>
+    <h3 class="landmark heading"><%= ts("Minimum Number To Match") %></h3>
     <p class="note">
-      This means the <em>minimum</em> level of matching needed for an offer to match a request.
-      Any matches above the minimum required number will be used to rank the quality of potential matches.
+      <%= ts("This means the") %> <em><%= ts("minimum") %></em> <%= ts("level of matching needed for an offer to match a request.
+      Any matches above the minimum required number will be used to rank the quality of potential matches.") %>
     </p>
 
     <p class="note">
-     If you change these
-      settings <em>after</em> you generate potential matches,
-      you will need to <em>regenerate potential matches</em> before your changes show.
+     <%= ts("If you change these
+      settings") %> <em><%= ts("after") %></em> <%= ts("you generate potential matches,
+      you will need to") %> <em><%= ts("regenerate potential matches") %></em> <%= ts("before your changes show.") %>
     </p>
 
     <dl>
       <dt>
-        <%= match_settings_form.label(:num_required_prompts, ts("Requests: ")) %>
+        <%= match_settings_form.label(:num_required_prompts, ts("Requests:")) %>
       </dt>
       <dd><%= match_settings_form.select(:num_required_prompts, PotentialMatchSettings::REQUIRED_MATCH_OPTIONS.select {|k,v| k != "0"}, :selected => potential_match_settings.num_required_prompts) %></dd>
 

--- a/app/views/prompt_restrictions/_prompt_restriction_form.html.erb
+++ b/app/views/prompt_restrictions/_prompt_restriction_form.html.erb
@@ -14,24 +14,24 @@ is verbose-->
 
     <% if is_offer %>
       <!-- skip the notes -->
-    	<legend>Offer Settings</legend>
-    	<h3 class-"landmark">Offer Settings</h3>
+    	<legend><%= ts("Offer Settings") %></legend>
+    	<h3 class="landmark"><%= ts("Offer Settings") %></h3>
     	<p class="note">
-    	  These settings determine what each separate offer can contain. Note these can be entirely different from the request settings!
+    	  <%= ts("These settings determine what each separate offer can contain. Note these can be entirely different from the request settings!") %>
     	</p>
     <% else %>
-    	<legend>Request Settings</legend>
-    	<h3 class-"landmark">Request Settings</h3>
+    	<legend><%= ts("Request Settings") %></legend>
+    	<h3 class="landmark"><%= ts("Request Settings") %></h3>
     	<p class="note">
-    	  These settings determine what each separate request can contain, and in particular how many different tags of each kind.
-    	  <% unless type == "prompt_meme" %>If you plan to use automated matching, keep in mind it will be slower the more tags you allow people to request.<% end %>
+    	  <%= ts("These settings determine what each separate request can contain, and in particular how many different tags of each kind.") %>
+    	  <% unless type == "prompt_meme" %><%= ts("If you plan to use automated matching, keep in mind it will be slower the more tags you allow people to request.") %><% end %>
     	</p>
     	<% unless type == "prompt_meme" %><p class="note">
-    	  Checking "Allow Any?" allows users to select "Any" for that field; this means they will match <em>anything</em> put in that field. This option is safer for offers than requests!
+    	  <%= ts('Checking "Allow Any?" allows users to select "Any" for that field; this means they will match') %> <em><%= ts("anything") %></em> <%= ts("put in that field. This option is safer for offers than requests!") %>
     	</p><% end %>
     	<p class="note">
-    	  If you allow three prompts and specify that fandom "must be unique", the user will have to choose completely different fandoms
-    	  for all three prompts&#8212;no overlap allowed. Please explain this in your signup instructions!
+    	  <%= ts('If you allow three prompts and specify that fandom "must be unique", the user will have to choose completely different fandoms
+    	  for all three prompts -- no overlap allowed. Please explain this in your signup instructions!') %>
     	</p> 
     <% end %>
     <dl>
@@ -46,25 +46,25 @@ is verbose-->
   <% if show_tag_options %>
     <fieldset>
       <legend><%= ts("Tag Options") %></legend>
-      <h3 class-"landmark"><%= ts("Tag Options") %> <%= link_to_help("prompt-restriction-tag-set" + (type == "gift_exchange" ? "" : "-promptmeme")) %> </h3>
+      <h3 class="landmark"><%= ts("Tag Options") %> <%= link_to_help("prompt-restriction-tag-set" + (type == "gift_exchange" ? "" : "-promptmeme")) %> </h3>
       <p class="note">
-     <%= link_to(ts("Tag sets"), tag_sets_path) %> show what tags can be used in
-        your challenge. You can make your own or use any public tag set. Beware: owners can change the contents of their public tag set without warning.
+     <%= link_to(ts("Tag sets"), tag_sets_path) %> <%= ts("show what tags can be used in
+        your challenge. You can make your own or use any public tag set. Beware: owners can change the contents of their public tag set without warning.") %>
       </p> 
       <dl>
         <% unless restriction.owned_tag_sets.empty? %>
           <dt><%= prompt_restriction_form.label :tag_sets_to_remove, ts("Current Tag Sets:") %></dt>
           <dd>
             <fieldset class="listbox">
-              <h4 class="heading">Check to remove</h4>
-            <%= checkbox_section(prompt_restriction_form, :tag_sets_to_remove, restriction.owned_tag_sets, :name_method => "title") %>
-          </fieldset>
+              <h4 class="heading"><%= ts("Check to remove") %></h4>
+              <%= checkbox_section(prompt_restriction_form, :tag_sets_to_remove, restriction.owned_tag_sets, :name_method => "title") %>
+            </fieldset>
           </dd>
         <% end %>
-        <dt><%= prompt_restriction_form.label :tag_sets_to_add, ts("Tag Sets To Use: ") %></dt>
-        <dd title="tag sets to use"><%= prompt_restriction_form.text_field :tag_sets_to_add, autocomplete_options("owned_tag_sets") %></dd>
+        <dt><%= prompt_restriction_form.label :tag_sets_to_add, ts("Tag Sets To Use:") %></dt>
+        <dd title="<%= ts('tag sets to use') %>"><%= prompt_restriction_form.text_field :tag_sets_to_add, autocomplete_options("owned_tag_sets") %></dd>
         <% TagSet::TAG_TYPES_RESTRICTED_TO_FANDOM.each do |tag_type| %>
-          <dt><%= ts("#{tag_type.classify} Settings") %> <%= link_to_help("prompt-restriction-character-and-relationship") %></dt>
+          <dt><%= ts("#{tag_type.classify} Settings:") %> <%= link_to_help("prompt-restriction-character-and-relationship") %></dt>
           <dd>
             <ul>
               <li>

--- a/app/views/users/_sidebar.html.erb
+++ b/app/views/users/_sidebar.html.erb
@@ -52,7 +52,7 @@
 <h4 class="landmark heading"><%= ts("Switch")%></h4>
 <ul class="navigation actions">
   <% if @user == current_user %>
-    <li><%= span_if_current ts("Signups (%{signup_number})", :signup_number =>@user.challenge_signups.count), user_signups_path(@user) %></li>
+    <li><%= span_if_current ts("Sign-ups (%{signup_number})", :signup_number =>@user.challenge_signups.count), user_signups_path(@user) %></li>
     <li><%= span_if_current ts("Assignments (%{assignment_number})", :assignment_number => (@user.offer_assignments.undefaulted.count + @user.pinch_hit_assignments.undefaulted.count)), user_assignments_path(@user) %></li>
     <li><%= span_if_current ts("Claims (%{claim_number})", :claim_number => (@user.request_claims.unposted.count)), user_claims_path(@user) %></li>
     <li><%= span_if_current ts("Related Works (%{related_works_number})", :related_works_number => (@user.related_works.count + @user.parent_work_relationships.count)), user_related_works_path(@user) %></li>


### PR DESCRIPTION
There was some broken HTML that IE 9 choked on, causing the challenge settings form to repeat and hide the update button: https://code.google.com/p/otwarchive/issues/detail?id=3348

This also adds about a bajillion translation strings to all the challenge views, moves the colons inside the strings so we don't have weird spacing issues, adds the verbose class to the prompt meme form to make it match the gift exchange form, changes some h3 and h4s to landmarks instead of visible headings (they were meant as alternatives to legends, which some screen readers don't like, and thus only repeat visible information), and changes various instances of "signup" to "sign-up" so screen readers don't mangle it so badly.
