### PR TITLE
3310 mobi margins should match in single and multichapter works

### DIFF
--- a/app/views/downloads/show.html.erb
+++ b/app/views/downloads/show.html.erb
@@ -6,7 +6,9 @@
       <%= render 'download_chapter.html', :chapter => chapter %>
     <% end %>
   <% else %>
-    <%=raw sanitize_field(@chapters.first, :content) %>
+    <div class="userstuff">
+      <%=raw sanitize_field(@chapters.first, :content) %>
+    </div>
   <% end %>
 </div>
 


### PR DESCRIPTION
http://code.google.com/p/otwarchive/issues/detail?id=3310

Multichapter mobi files had slightly wider margins than single chapter mobi files because the single-chapter were missing some HTML.
