### PR TITLE
3266 make disabled styling more specific to avoid affecting pagination

### DIFF
--- a/public/stylesheets/site/2.0/08-actions.css
+++ b/public/stylesheets/site/2.0/08-actions.css
@@ -84,7 +84,7 @@ ol.pagination, div.pagination, ol.year {
     box-shadow: inset 1px 1px 3px #333;
 }
 
-.actions .disabled {
+.actions label.disabled {
   background: #ccc;
 }
 


### PR DESCRIPTION
I added .actions .disabled to the stylesheet to style the labels on the Manage Collection Items page, but the class wasn't specific enough and affected other things. 

http://code.google.com/p/otwarchive/issues/detail?id=3266
