### PR TITLE
3266 remove checkbox background, padding, and border for IE

### DIFF
--- a/public/stylesheets/site/2.0/07-interactions.css
+++ b/public/stylesheets/site/2.0/07-interactions.css
@@ -93,12 +93,6 @@ select {
   width: 32.5%;
 }
 
-input[type="checkbox"] {
-  background: transparent;
-  border: none;
-  padding: 0;
-}
-
 input[type="radio"], input[type="checkbox"], input[type="file"], input.number, p input, p select, .heading select, li select {
   width: auto;
   margin-right: 0.375em;

--- a/public/stylesheets/site/2.0/08-actions.css
+++ b/public/stylesheets/site/2.0/08-actions.css
@@ -57,6 +57,12 @@ p.submit, input.submit, dd.submit {
   cursor: text;
 }
 
+.actions input[type="checkbox"] {
+  background: transparent;
+  border: none;
+  padding: 0;
+}
+
 /*subtypes and modes 
 test note: this pagination clear needs to be kept an eye on*/
 


### PR DESCRIPTION
Checkboxes have background colors and borders in IE 8 and 9, which we don't really want http://code.google.com/p/otwarchive/issues/detail?id=3266
