### PR TITLE
Adding ADT approved text

### DIFF
--- a/app/models/prompt.rb
+++ b/app/models/prompt.rb
@@ -154,7 +154,7 @@ class Prompt < ActiveRecord::Base
         else
           noncanonical_taglist = tag_set.send("#{tag_type}_taglist").reject {|t| t.canonical}
           unless noncanonical_taglist.empty?
-            errors.add(:base, ts("^These %{tag_type} tags in your %{prompt_type} are not canonical and can't be used unless the moderator requests them to be added: %{taglist}. Please contact your challenge moderator.",
+            errors.add(:base, ts("^These %{tag_type} tags in your %{prompt_type} are not canonical and cannot be used in this challenge: %{taglist}. To fix this, please contact your challenge moderator who can then log a request with Support for the tags to be made canonical if appropriate.",
               :tag_type => tag_type,
               :prompt_type => self.class.name.downcase,
               :taglist => noncanonical_taglist.collect(&:name).join(ArchiveConfig.DELIMITER_FOR_OUTPUT)))


### PR DESCRIPTION
Updating text for issue: http://code.google.com/p/otwarchive/issues/detail?id=1754

Now reads: "These fandom tags in your request are not canonical and can't be used unless the moderator requests them to be added: $tag_name. Please contact your challenge moderator."
