### PR TITLE
Issue 2998 - Anon to comment index

### DIFF
--- a/app/views/comments/_single_comment_abbreviated.html.erb
+++ b/app/views/comments/_single_comment_abbreviated.html.erb
@@ -12,7 +12,7 @@
 	
 	<p class="datetime"><%= h(ts('Posted ')) + single_comment.created_at %>
   <% unless single_comment.edited_at.blank? %>
-  <%= ts(", Last Edited ") + l(single_comment.edited_at) %>
+  <%= h(ts(", Last Edited ")) + l(single_comment.edited_at) %>
   <% end %>
 	</p>
 </li>


### PR DESCRIPTION
Issue: http://code.google.com/p/otwarchive/issues/detail?id=2998

This brings anonymity to the ao3.org/comments page when an author leaves a top-level comment on their own work. 
