### PR TITLE
Issue 3418: Multiple collections doesnt catch moderated status

### DIFF
--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -657,6 +657,7 @@ protected
           flash[:notice] += ts(" Your work will only show up in the moderated collection you have submitted it to once it is approved by a moderator.")
         end
       end
+    end
   end
 
 public


### PR DESCRIPTION
Resolves issue: http://code.google.com/p/otwarchive/issues/detail?id=3418

Iterated through the list of collections that a work belongs to. Upon finding a collection that is moderated the extra 'flash' message is generated and we break ourselves out of the do-loop. We do this because we only want the message to show up once. 
