### PR TITLE
Resolving double email issue

### DIFF
--- a/app/models/collection_item.rb
+++ b/app/models/collection_item.rb
@@ -141,7 +141,10 @@ class CollectionItem < ActiveRecord::Base
   after_update :notify_of_status_change
   def notify_of_status_change
     if unrevealed_changed?
-      notify_of_reveal
+      # making sure that creation_observer.rb has not already notified the user
+      if !work.new_recipients.blank?
+        notify_of_reveal
+      end
     end
     if anonymous_changed?
       notify_of_author_reveal


### PR DESCRIPTION
Resolves double emails in this issue: http://code.google.com/p/otwarchive/issues/detail?id=1187

Checks to make sure that the recipient of the email has not already been notified about their gift work.
