### PR TITLE
Issue 3423: generate 404 instead of 500 for bookmarks of nonexistent tags

### DIFF
--- a/app/controllers/bookmarks_controller.rb
+++ b/app/controllers/bookmarks_controller.rb
@@ -181,6 +181,9 @@ class BookmarksController < ApplicationController
     end
     if params[:tag_id]
       @tag = Tag.find_by_name(params[:tag_id])
+      unless @tag && @tag.is_a?(Tag)
+        raise ActiveRecord::RecordNotFound, "Couldn't find tag named '#{params[:tag_id]}'"
+      end
       unless @tag.canonical?
         if @tag.merger.present?
           redirect_to tag_bookmarks_path(@tag.merger) and return


### PR DESCRIPTION
Issue 3423: generate 404 instead of 500 for bookmarks of nonexistent tags

Code is the same as the works controller.

http://code.google.com/p/otwarchive/issues/detail?id=3423
