### PR TITLE
Issue 3434

### DIFF
--- a/app/views/comments/_comment_form.html.erb
+++ b/app/views/comments/_comment_form.html.erb
@@ -36,9 +36,7 @@
         <% if current_user.pseuds.count > 1 %>
           <h4 class="heading"><%= ts("Comment as") %> <%= f.collection_select :pseud_id, current_user.pseuds, :id, :name, {:selected => (comment.pseud ? comment.pseud.id.to_s : current_user.default_pseud.id.to_s)}, :id => "comment_pseud_id_for_#{commentable.id}", :title => ts("Choose Name") %>
             <% if controller.controller_name == "inbox" %>
-              <% if commentable.ultimate_parent.is_a?(Work) && commentable.pseud.nil? && commentable.ultimate_parent.anonymous? %>
-                <span><%= ts("to") %> <%= get_commenter_pseud_or_name(commentable) %> <%= ts("on") %> <%= commentable_description_link(commentable) %></span>
-              <% elsif commentable.ultimate_parent.is_a?(Work) && commentable.pseud.user.is_author_of?(commentable.ultimate_parent) && commentable.ultimate_parent.anonymous? %>
+              <% if commentable.ultimate_parent.is_a?(Work) && commentable.pseud.present? && commentable.pseud.user.is_author_of?(commentable.ultimate_parent) && commentable.ultimate_parent.anonymous? %>
                 <span><%= ts("to") %> <%= "Anonymous Creator" %> <%= ts("on") %> <%= commentable_description_link(commentable) %></span>
               <% else %>
                 <span><%= ts("to") %> <%= get_commenter_pseud_or_name(commentable) %> <%= ts("on") %> <%= commentable_description_link(commentable) %></span>
@@ -50,7 +48,7 @@
           <h4 class="heading"><%= ts("Comment as") %> <span class="byline"><%= current_user.default_pseud.name %></span>
             <%= f.hidden_field :pseud_id, :value => "#{current_user.default_pseud.id}", :id => "comment_pseud_id_for_#{commentable.id}" %>
             <% if controller.controller_name == "inbox" %>
-              <% if commentable.ultimate_parent.is_a?(Work) && commentable.pseud.user.is_author_of?(commentable.ultimate_parent) && commentable.ultimate_parent.anonymous? %>
+              <% if commentable.ultimate_parent.is_a?(Work) && commentable.pseud.present? && commentable.pseud.user.is_author_of?(commentable.ultimate_parent) && commentable.ultimate_parent.anonymous? %>
                 <span><%= ts("to") %> <%= "Anonymous Creator" %> <%= ts("on") %> <%= commentable_description_link(commentable) %></span>
               <% else %>
                 <span><%= ts("to") %> <%= get_commenter_pseud_or_name(commentable) %> <%= ts("on") %> <%= commentable_description_link(commentable) %></span>


### PR DESCRIPTION
Resolves issue: http://code.google.com/p/otwarchive/issues/detail?id=3434

The part of the code that handled comments from the inbox didn't take into consideration that a user might be replying to comments from a non-archive user. This checks to make sure the user being replied to is an archive user, and if not grabs whatever name they used to comment with.
