### PR TITLE
Fix for redis errors - reconnect after forking.

### DIFF
--- a/config/initializers/gem-plugin_config/resque.rb
+++ b/config/initializers/gem-plugin_config/resque.rb
@@ -7,3 +7,7 @@ Resque.redis = redis_config[rails_env]
 
 # in-process performing of jobs (for testing) doesn't require a redis server
 Resque.inline = ENV['RAILS_ENV'] == "test"
+
+Resque.after_fork do 
+  Resque.redis.client.reconnect
+end


### PR DESCRIPTION
Fix for redis errors - reconnect after forking.

"Tried to use a connection from a child process without reconnecting. You need to reconnect to Redis after forking."
