### PR TITLE
Replying to comments on non-works causes errors

### DIFF
--- a/app/views/comments/_comment_form.html.erb
+++ b/app/views/comments/_comment_form.html.erb
@@ -30,7 +30,7 @@
             <p class="notice">While this work is anonymous, comments you post will also be listed anonymously.</p>
           <% end %>
         <% # When the thing that we are commenting on is a comment (read: replying to) then we use this statement. Shows in user Inbox and nested reply %>
-        <% if commentable.is_a?(Comment) && commentable.ultimate_parent.anonymous? && current_user.is_author_of?(commentable.ultimate_parent) %>
+        <% if commentable.is_a?(Comment) && commentable.ultimate_parent.is_a?(Work) && commentable.ultimate_parent.anonymous? && current_user.is_author_of?(commentable.ultimate_parent) %>
           <p class="notice">While this work is anonymous, comments you post will also be listed anonymously.</p>
         <% end %>
         <% if current_user.pseuds.count > 1 %>


### PR DESCRIPTION
The line of code here was assuming that the ultimate_parent of a comment (the thing the comment was attached to) would always be a Work. This isn't the case re: tag comments and admin posts. I added a check to ensure that the .anonymous? method is only being called if ultimate_parent is actually a Work.

Issues:
http://code.google.com/p/otwarchive/issues/detail?id=3437
http://code.google.com/p/otwarchive/issues/detail?id=3445
