### PR TITLE
3446 Correct JS error related to moving of timepicker script

### DIFF
--- a/app/views/challenge/shared/_challenge_form_schedule.html.erb
+++ b/app/views/challenge/shared/_challenge_form_schedule.html.erb
@@ -35,3 +35,16 @@
     <% end %>
   </dl>
 </fieldset>
+
+<%= content_for :footer_js do %>
+  <script src="/javascripts/jquery-ui-timepicker-addon.js" type="text/javascript"></script>  
+  <%= javascript_tag do %>
+      $j('.timepicker').datetimepicker({
+        ampm: true,
+        dateFormat: 'yy-mm-dd',
+        timeFormat: 'hh:mmTT',
+        hourGrid: 5,
+        minuteGrid: 10
+      });
+  <% end %>
+<% end %> 

--- a/app/views/layouts/_includes.html.erb
+++ b/app/views/layouts/_includes.html.erb
@@ -39,7 +39,6 @@ if (typeof jQuery == 'undefined')
 <%= javascript_include_tag 'jquery.tokeninput.js' %>
 <%= javascript_include_tag 'jquery.purr.js' %>
 <%= javascript_include_tag 'best_in_place.js' %>
-<%= javascript_include_tag "jquery-ui-timepicker-addon.js" %>
 <%= javascript_include_tag "ibox/ibox" %>
 <%= javascript_include_tag "jquery.cookie" %>
 

--- a/public/javascripts/application.js
+++ b/public/javascripts/application.js
@@ -198,18 +198,6 @@ jQuery(function($){
   });
 });
 
-// Timepicker
-jQuery(function($) {
-  $('.timepicker').datetimepicker({
-    ampm: true,
-    dateFormat: 'yy-mm-dd',
-    timeFormat: 'hh:mmTT',
-    hourGrid: 5,
-    minuteGrid: 10
-  });
-});
-
-
 // Set up open and close toggles for a given object
 // Typical setup (this will leave the toggled item open for users without javascript but hide the controls from them):
 // <a class="foo_open hidden">Open Foo</a>


### PR DESCRIPTION
There was some timpicker-related JavaScript hanging around in application.js that was causing an error and preventing the rest of our JS from loading. That JS is basically just settings for the timepicker, so I relocated it to the page where we use the timepicker (and thus those settings). 

http://code.google.com/p/otwarchive/issues/detail?id=3446
