### PR TITLE
Issue 3452: Taking favicon out of sharing code, since it doesn't work on Tumblr

### DIFF
--- a/app/helpers/works_helper.rb
+++ b/app/helpers/works_helper.rb
@@ -137,8 +137,7 @@ module WorksHelper
     if work.anonymous?
       profile_link = ts("Anonymous")
     else
-      profile_link = work.pseuds.map {|pseud| link_to(image_tag(root_url + "favicon.ico", :alt => "favicon", :border => "0"), user_profile_url(pseud.user)) +
-                                    link_to(content_tag(:strong, pseud.name), user_url(pseud.user))}.join(', ').html_safe
+      profile_link = work.pseuds.map {|pseud| link_to(content_tag(:strong, pseud.name), user_url(pseud.user))}.join(', ').html_safe
     end
 
     chapters_text = ts("Chapters: ") + work.chapter_total_display


### PR DESCRIPTION
Issue 3452: Taking favicon out of sharing code, since it doesn't work on Tumblr

http://code.google.com/p/otwarchive/issues/detail?id=3452
