### PR TITLE
Issue 3456: Co-author confused by deletion email

### DIFF
--- a/app/views/user_mailer/delete_work_notification.html.erb
+++ b/app/views/user_mailer/delete_work_notification.html.erb
@@ -1,3 +1,4 @@
-<p><%=h "Your story" %> <cite><%=h @work.title.html_safe %></cite> <%=h "was deleted at your request." %></p>
-<p><%=h "If you have questions, please contact" %> <%= "Support (http://archiveofourown.org/support)" %>.</p>
-<p><%=h "Attached is a copy of your work for your reference." %></p>
+<p><%= ts("Dear ") %><%= @user.default_pseud.byline %><%= ts(":") %></p>
+<p><%= ts("Your work") %> <cite><%= @work.title.html_safe %></cite> <%= ts("was deleted at ") %> <%= (@work.pseuds.count > 1 && @user != User.current_user) ? ts("the request of ") + User.current_user.default_pseud.byline + ts(".") : ts("your request.") %> </p>
+<p><%= ts("If you have questions, please contact") %> <%= ts("Support (http://archiveofourown.org/support)") %>.</p>
+<p><%= ts("Attached is a copy of your work for your reference.") %></p>


### PR DESCRIPTION
Resolves issue: http://code.google.com/p/otwarchive/issues/detail?id=3456

Added some logic to the view to properly express to the user who requested the work to be deleted when there are more than one authors on a work.

Also changed the file over to the new translation method and replaced 'story' with 'work'.
