### PR TITLE
Abuse edit works

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -173,7 +173,7 @@ public
 
   # Prevents admin from logging in as users
   def admin_logout_required
-    if logged_in_as_admin?  && !ta
+    if logged_in_as_admin?
       setflash; flash[:notice] = 'Please log out of your admin account first!'
       redirect_to root_path
     end


### PR DESCRIPTION
Resolves issue: http://code.google.com/p/otwarchive/issues/detail?id=3458

Removed the check on :edit_tags and :update_tags which was explicitly keeping admins out. 

Added :edit_tags and :update_tags to be excepted from the 'check_ownership' method but INSTEAD had those two tags checked with the 'check_ownership_or_admin' method.
