### PR TITLE
3463 with item added mail not sent if work belongs to a series

### DIFF
--- a/app/mailers/collection_mailer.rb
+++ b/app/mailers/collection_mailer.rb
@@ -4,6 +4,7 @@ class CollectionMailer < ActionMailer::Base
   helper :application
   helper :tags
   helper :works
+  helper :series
 
   layout 'mailer'
   default :from => ArchiveConfig.RETURN_ADDRESS


### PR DESCRIPTION
When a new work is added to a collection and both (a) a collection email has been provided and (b) "Send a message to the collection email when a work is added" is selected, a notification should be sent to that email address. It was erroring if the work was part of a series.

http://code.google.com/p/otwarchive/issues/detail?id=3463
