### PR TITLE
CSS: A2.0 Skin Addendum for Tag Guidelines

### DIFF
--- a/public/stylesheets/site/2.0/16-zone-system.css
+++ b/public/stylesheets/site/2.0/16-zone-system.css
@@ -121,12 +121,12 @@ admin role is only admin facing, and changes normal views in role-admin.css*/
 /* ZONE: SYSTEM: FAQS: TAG GUIDELINES */
 
 .faq .userstuff .notice, .faq .userstuff .caution, .faq .userstuff .example { 
-margin: 0.643em 3.958em; 
-padding: 0.643em;
+  margin: 0.643em 3.958em; 
+  padding: 0.643em;
 } 
 
 .faq .userstuff .example {
-border: 1px solid #c2d2df;
+  border: 1px solid #c2d2df;
 }
 
 /*END== */


### PR DESCRIPTION
re: https://code.google.com/p/otwarchive/issues/detail?id=3467

This adds three classes to the 16-zone-system.css in their own new zone to allow for content formatting on the Tag Guidelines pages.

NB: The code has been tested in a closed location but not on a webdav. My system is having issues acknowledging changes to CSS. Again.
