### PR TITLE
3466 Org name wrong in invitation email HIGH PRIORITY EMBARRASSING

### DIFF
--- a/app/views/user_mailer/invitation.html.erb
+++ b/app/views/user_mailer/invitation.html.erb
@@ -14,7 +14,7 @@
   The Archive of Our Own (AO3) is a free, noncommercial archive built by and for fans. We are
   multifannish and welcome all kinds of fanworks, including fanfiction, fanart, fanvids, and
   podfic. We run on the open-source otwarchive software, and our servers are owned by the
-  nonprofit Organization of Transformative Works, which works to protect fan rights and
+  nonprofit Organization for Transformative Works, which works to protect fan rights and
   preserve fanworks.
 </p>
 


### PR DESCRIPTION
http://code.google.com/p/otwarchive/issues/detail?id=3466

We are not the Organization _of_ Transformative Works, but rather _for_ them. /o\
