### PR TITLE
3469 with time zone cached in comments timestamp

### DIFF
--- a/app/views/comments/_single_comment.html.erb
+++ b/app/views/comments/_single_comment.html.erb
@@ -44,15 +44,15 @@
           <% end %>
         </div>
         <blockquote class="userstuff"><%=raw sanitize_field(single_comment, :content) %></blockquote>
-        <p class="datetime">
-          <%= ts("Posted") %> <%= time_in_zone(single_comment.created_at) %>
-        </p>
-        <% unless single_comment.edited_at.blank? %>
-          <p class="datetime edited">
-            <%= ts("Last Edited") %> <%= time_in_zone(single_comment.edited_at) %>
-          </p>
-        <% end %>
       <% end %><!-- end caching -->
+      <p class="datetime">
+        <%= ts("Posted") %> <%= time_in_zone(single_comment.created_at) %>
+      </p>
+      <% unless single_comment.edited_at.blank? %>
+        <p class="datetime edited">
+          <%= ts("Last Edited") %> <%= time_in_zone(single_comment.edited_at) %>
+        </p>
+      <% end %>
       <h5 class="landmark heading"><%= ts("Comment Actions") %></h5>
 
       <ul class="navigation actions" role="menu" id="navigation_for_comment_<%= single_comment.id %>">


### PR DESCRIPTION
http://code.google.com/p/otwarchive/issues/detail?id=3469

Users should see the timestamp on comments in the time zone they have set in user preferences.
