### PR TITLE
2863 with abbreviated comments showing wrong time zone

### DIFF
--- a/app/views/comments/_single_comment_abbreviated.html.erb
+++ b/app/views/comments/_single_comment_abbreviated.html.erb
@@ -20,8 +20,8 @@
     <% else %>
       <span class="visitor icon"><!-- visitor icon holder --></span>
     <% end %>
-	</div>
-	<blockquote class="userstuff"><%=raw sanitize_field(single_comment, :content) %></blockquote>
+  </div>
+  <blockquote class="userstuff"><%=raw sanitize_field(single_comment, :content) %></blockquote>
   <% unless single_comment.edited_at.blank? %>
     <p class="edited datetime">
       <%= ts('Last Edited') %> <%= time_in_zone(single_comment.edited_at) %>


### PR DESCRIPTION
http://code.google.com/p/otwarchive/issues/detail?id=2863

The comments on ao3.org/comments were showing the server's time zone, not the user's. This also fixes the 500 error on that page.
