### PR TITLE
3210 BOT-C fix rewording buttons

### DIFF
--- a/app/views/works/edit_tags.html.erb
+++ b/app/views/works/edit_tags.html.erb
@@ -1,22 +1,23 @@
 <!--Descriptive page name, messages and instructions-->
 <h2 class="heading"><%= ts('Edit Work Tags for ') + @work.title.html_safe %></h2>
-<p class="navigation actions"><%= link_to t('.back_to_work', :default => 'Return to work'), @work %></p>
+
 <%= error_messages_for :work %>
 <!--/descriptions-->
 
 <div id="work-form" class="edit work post">
 <%= form_for(@work, :html => {:name => "storyForm"}, :url => { :action => "update_tags" }) do |f| %> 
+<p class="required notice"><%= ts('* Required information') %></p>
 
 <!--main content-->					
 <%= render :partial => 'work_form_tags', :locals => {:include_blank => false} %>
 <!--/content--> 
 
   <fieldset>
-    <legend><%= 'Post Work' %></legend>
+    <legend><%= ts('Post Work') %></legend>
     <p class="submit cancel actions">
-      <%= submit_tag t('.forms.preview', :default => 'Preview'), :name => 'preview_button' %>
-      <%= submit_tag t('.forms.update', :default => 'Update'), :name => 'update_button' %>
-      <%= submit_tag t('.forms.cancel', :default => 'Cancel'), :name => 'cancel_button' %>
+      <%= submit_tag ts('Preview'), :name => 'preview_button' %>
+      <%= submit_tag ts('Post without Preview'), :name => 'update_button' %>
+      <%= submit_tag ts('Cancel'), :name => 'cancel_button' %>
     </p> 
   </fieldset>
 <% end %> <!-- end of form_for -->


### PR DESCRIPTION
Edit Tags button should say "Post without Preview" instead of "Update" to avoid confusion on drafts. Also removed Return to Work button because, hey, why should Edit Tags have it when plain Edit Work doesn't.

http://code.google.com/p/otwarchive/issues/detail?id=3210
