### PR TITLE
3271 Remove blank line so share would look better on LJ/DW.

### DIFF
--- a/app/helpers/works_helper.rb
+++ b/app/helpers/works_helper.rb
@@ -160,15 +160,15 @@ module WorksHelper
     summary_text = add_label_for_embed(ts("Summary: "), sanitize_field(work, :summary))
     
     if work.series.count != 0
-      [chapters_text, fandom_text, rating_text, warning_text, relationship_text, char_text, tags_text, series_text, summary_text].compact.join("\n")
+      [chapters_text, fandom_text, rating_text, warning_text, relationship_text, char_text, tags_text, series_text, summary_text].compact.join("")
     else
-      [chapters_text, fandom_text, rating_text, warning_text, relationship_text, char_text, tags_text, summary_text].compact.join("\n")
+      [chapters_text, fandom_text, rating_text, warning_text, relationship_text, char_text, tags_text, summary_text].compact.join("")
     end   
   end
   
   # combine title, word count, creator, and meta to make copy and paste share code for a work
   def get_embed_link(work)
-    [get_embed_link_title(work) + tag("br"), get_embed_link_meta(work)].compact.join("\n")
+    [get_embed_link_title(work) + tag("br"), get_embed_link_meta(work)].compact.join("")
   end
 
   # get bookmark information for share code
@@ -184,7 +184,7 @@ module WorksHelper
     if bookmark.bookmarkable.is_a?(Work)
       work_embed = get_embed_link(bookmark.bookmarkable)
       bookmark_meta = get_embed_link_bookmark_meta(bookmark)
-      [work_embed, bookmark_meta].compact.join("\n")
+      [work_embed, bookmark_meta].compact.join("")
     end
   end
   
@@ -204,7 +204,7 @@ module WorksHelper
     if bookmark.bookmarkable.is_a?(Work)
       work_meta = get_embed_link_meta(bookmark.bookmarkable)
       bookmark_meta = get_embed_link_bookmark_meta(bookmark)
-      [work_meta, bookmark_meta].compact.join("\n")
+      [work_meta, bookmark_meta].compact.join("")
     end
   end
   


### PR DESCRIPTION
Went from compact.join("\n") to compact.join("") for share code for users who have LJ or DW set to auto format.
