### PR TITLE
Issue 3149: Non collection users cannot see prompts

### DIFF
--- a/app/controllers/prompts_controller.rb
+++ b/app/controllers/prompts_controller.rb
@@ -9,7 +9,6 @@ class PromptsController < ApplicationController
   before_filter :allowed_to_destroy, :only => [:destroy]
   before_filter :signup_owner_only, :only => [:edit, :update]
   before_filter :check_signup_open, :only => [:new, :create, :edit, :update]
-  #before_filter :allowed_to_see, :only => [:show]
 
   # def promptmeme_only
   #   unless @collection.challenge_type == "PromptMeme"


### PR DESCRIPTION
Resolves issue: http://code.google.com/p/otwarchive/issues/detail?id=3419

Removed the check to see if users were a part of the collection/challenge before the prompt was displayed for them.
