### PR TITLE
3508 whitelist Soundcloud and 3509 unwhitelist 4shared

### DIFF
--- a/config/initializers/gem-plugin_config/sanitizer_config.rb
+++ b/config/initializers/gem-plugin_config/sanitizer_config.rb
@@ -92,8 +92,6 @@ class Sanitize
         then "viddler"
       when /^http:\/\/(?:www\.)?metacafe\.com\//
         then "metacafe"
-      when /^http:\/\/(?:www\.)?4shared\.net\//
-          then "4shared"
       when /^http:\/\/(?:www\.)?vidders\.net\//
         then "vidders.net"
       when /^http:\/\/(?:www\.)?criticalcommons\.org\//
@@ -108,6 +106,8 @@ class Sanitize
         then "spotify"
       when /^http:\/\/(?:www\.)?8tracks\.com\//
         then "8tracks"
+      when /^https:\/\/(?:w\.)?soundcloud\.com\//
+        then "soundcloud"
       else
         nil
       end
@@ -115,7 +115,7 @@ class Sanitize
       # if we don't know the source, sorry
       return if source.nil?           
 
-      allow_flashvars = ["ning", "vidders.net", "google", "criticalcommons", "archiveofourown", "podfic", "spotify", "8tracks"]
+      allow_flashvars = ["ning", "vidders.net", "google", "criticalcommons", "archiveofourown", "podfic", "spotify", "8tracks", "soundcloud"]
 
       # We're now certain that this is an embed from a trusted source, but we still need to run
       # it through a special Sanitize step to ensure that no unwanted elements or


### PR DESCRIPTION
Whitelist Soundcloud http://code.google.com/p/otwarchive/issues/detail?id=3508

Remove 4shared from whitelist http://code.google.com/p/otwarchive/issues/detail?id=3509

Note that this only whitelists HTML5 embeds from Soundcloud. Flash embeds from that site use allowscriptaccess, which we do not allow.
