### PR TITLE
Issue 2249: Clarifying errors on Prompt Memes

### DIFF
--- a/app/models/prompt.rb
+++ b/app/models/prompt.rb
@@ -118,13 +118,13 @@ class Prompt < ActiveRecord::Base
               ts("none") :
               "(#{tag_count}) -- " + taglist.collect(&:name).join(ArchiveConfig.DELIMITER_FOR_OUTPUT)
           if allowed == 0
-            errors.add(:base, ts("^#{prompt_type}: your #{prompt_type} cannot include any #{tag_type} tags, but you have included %{taglist}.",
+            errors.add(:base, ts("Your #{prompt_type} cannot include any #{tag_type} tags, but you have included %{taglist}.",
               :taglist => taglist_string))
           elsif required == allowed
-            errors.add(:base, ts("^#{prompt_type}: your #{prompt_type} must include exactly %{required} #{tag_type} tags, but you have included #{tag_count} #{tag_type} tags in your current #{prompt_type}.",
+            errors.add(:base, ts("Your #{prompt_type} must include exactly %{required} #{tag_type} tags, but you have included #{tag_count} #{tag_type} tags in your current #{prompt_type}.",
               :required => required))
           else
-            errors.add(:base, ts("^#{prompt_type}: your #{prompt_type} must include between %{required} and %{allowed} #{tag_type} tags, but you have included #{tag_count} #{tag_type} tags in your current #{prompt_type}.",
+            errors.add(:base, ts("Your #{prompt_type} must include between %{required} and %{allowed} #{tag_type} tags, but you have included #{tag_count} #{tag_type} tags in your current #{prompt_type}.",
               :required => required, :allowed => allowed))
           end
         end

--- a/app/views/challenge_signups/_signup_form.html.erb
+++ b/app/views/challenge_signups/_signup_form.html.erb
@@ -23,7 +23,11 @@
 
 
 <%= form_for([@collection, @challenge_signup], :url => (@challenge_signup.new_record? ? collection_signups_path(@collection) : collection_signup_path(@collection))) do |signup_form| %>
-  <%= error_messages_for @challenge_signup %>
+  <% unless @challenge_signup.errors.empty? %>
+    <div class="error">
+      <h4 class="heading"><%= ts("There were some problems with this submission. Please correct the mistakes below.") %></h4>
+    </div>
+  <% end %>
 
   <%= render "signup_form_general_information", :form => signup_form %>
 
@@ -39,6 +43,7 @@
     </blockquote>
     
   <% @challenge_signup.send("#{prompt_type}").each_with_index do |prompt, index| %>
+      <%= error_messages_for prompt %>
     <%= signup_form.fields_for prompt_type.to_sym, prompt do |prompt_form| %>
       <%= render "prompts/prompt_form", :form => prompt_form, :index => index, :required => (index < @challenge.required(prompt_type)) %>
     <% end %>


### PR DESCRIPTION
Resolves issue: http://code.google.com/p/otwarchive/issues/detail?id=2249

Error messages now appear above the Prompt that they are referencing. There is a generic error message at the top of the page to let users know they need to look through their submission. 
