### PR TITLE
Issue 2619: Add prompt to Unposted claim blurbs

### DIFF
--- a/app/views/challenge_claims/_unposted_claim_blurb.html.erb
+++ b/app/views/challenge_claims/_unposted_claim_blurb.html.erb
@@ -41,6 +41,14 @@
   
   <!--prompt tags -->
   <%= prompt_tags(prompt) %>
+
+  <!--prompt description -->
+  <% unless prompt.description.blank? %>
+    <h6 class="landmark heading"><%= ts("Summary") %></h6>
+    <blockquote class="userstuff summary" title="<%= ts("prompt") %>">
+      <%=raw sanitize_field(prompt, :description) %>
+    </blockquote>
+  <% end %>
   
   <!--actions-->
   <% if @collection.user_is_maintainer?(current_user) %>  


### PR DESCRIPTION
Resolves issue: http://code.google.com/p/otwarchive/issues/detail?id=2619

Add the prompt description to the blurbs on the "Unposted Claims" section of a Challenge.
