### PR TITLE
Issue 2249: Clarifying errors on Prompt Memes

### DIFF
--- a/app/models/prompt.rb
+++ b/app/models/prompt.rb
@@ -118,13 +118,13 @@ class Prompt < ActiveRecord::Base
               ts("none") :
               "(#{tag_count}) -- " + taglist.collect(&:name).join(ArchiveConfig.DELIMITER_FOR_OUTPUT)
           if allowed == 0
-            errors.add(:base, ts("Your #{prompt_type} cannot include any #{tag_type} tags, but you have included %{taglist}.",
+            errors.add(:base, ts("^#{prompt_type}: Your #{prompt_type} cannot include any #{tag_type} tags, but you have included %{taglist}.",
               :taglist => taglist_string))
           elsif required == allowed
-            errors.add(:base, ts("Your #{prompt_type} must include exactly %{required} #{tag_type} tags, but you have included #{tag_count} #{tag_type} tags in your current #{prompt_type}.",
+            errors.add(:base, ts("^#{prompt_type}: Your #{prompt_type} must include exactly %{required} #{tag_type} tags, but you have included #{tag_count} #{tag_type} tags in your current #{prompt_type}.",
               :required => required))
           else
-            errors.add(:base, ts("Your #{prompt_type} must include between %{required} and %{allowed} #{tag_type} tags, but you have included #{tag_count} #{tag_type} tags in your current #{prompt_type}.",
+            errors.add(:base, ts("^#{prompt_type}: Your #{prompt_type} must include between %{required} and %{allowed} #{tag_type} tags, but you have included #{tag_count} #{tag_type} tags in your current #{prompt_type}.",
               :required => required, :allowed => allowed))
           end
         end

--- a/app/views/challenge_signups/_signup_form.html.erb
+++ b/app/views/challenge_signups/_signup_form.html.erb
@@ -23,7 +23,6 @@
 
 
 <%= form_for([@collection, @challenge_signup], :url => (@challenge_signup.new_record? ? collection_signups_path(@collection) : collection_signup_path(@collection))) do |signup_form| %>
-<<<<<<< HEAD
   <p class="required notice"><%= ts('* Required information') %></p>
   <% unless @challenge_signup.errors.empty? %>
     <div class="error">

--- a/features/gift_exchanges/challenge_yuletide.feature
+++ b/features/gift_exchanges/challenge_yuletide.feature
@@ -136,13 +136,13 @@ Feature: Collection
     And I press "Submit"
   Then I should see a save error message
     # errors for the empty request
-    And I should see "Request: your Request must include exactly 1 fandom tags, but you have included 0 fandom tags in your current Request"
+    And I should see "Request: Your Request must include exactly 1 fandom tags, but you have included 0 fandom tags in your current Request"
     # errors for the not-quite-filled offer
-    And I should see "Offer: your Offer must include between 2 and 3 character tags, but you have included 1 character tags in your current Offer"
+    And I should see "Offer: Your Offer must include between 2 and 3 character tags, but you have included 1 character tags in your current Offer"
     And I should see a not-in-fandom error message
     # errors for the empty offer
-    And I should see "Offer: your Offer must include exactly 1 fandom tags, but you have included 0 fandom tags in your current Offer"
-    And I should see "Offer: your Offer must include between 2 and 3 character tags, but you have included 0 character tags in your current Offer"
+    And I should see "Offer: Your Offer must include exactly 1 fandom tags, but you have included 0 fandom tags in your current Offer"
+    And I should see "Offer: Your Offer must include between 2 and 3 character tags, but you have included 0 character tags in your current Offer"
   # Over-fill the remaining missing fields and duplicate fandoms
   When I fill in "challenge_signup_requests_attributes_0_tag_set_attributes_character_tagnames" with "John Sheppard, Teyla Emmagan, Obscure person"
     And I check the 2nd checkbox with the value "Tiny fandom"
@@ -153,11 +153,11 @@ Feature: Collection
     And I fill in "challenge_signup_offers_attributes_1_tag_set_attributes_character_tagnames" with "Obscure person, John Sheppard, Teyla Emmagan, Foo The Wonder Goat"
     And I press "Submit"
   Then I should see a save error message
-    And I should see "Request: your Request must include between 0 and 2 character tags, but you have included 3 character tags in your current Request"
+    And I should see "Request: Your Request must include between 0 and 2 character tags, but you have included 3 character tags in your current Request"
     And I should see a not-in-fandom error message for "Obscure person" in "Stargate Atlantis"
-    And I should see "Request: your Request must include exactly 1 fandom tags, but you have included 2 fandom tags in your current Request"
+    And I should see "Request: Your Request must include exactly 1 fandom tags, but you have included 2 fandom tags in your current Request"
     And I should see a not-in-fandom error message for "Obscure person, John Sheppard" in "Care Bears"
-    And I should see "Offer: your Offer must include between 2 and 3 character tags, but you have included 4 character tags in your current Offer"
+    And I should see "Offer: Your Offer must include between 2 and 3 character tags, but you have included 4 character tags in your current Offer"
     And I should see a not-in-fandom error message for "Obscure person, John Sheppard, Teyla Emmagan, Foo The Wonder Goat" in "Care Bears"
     And I should see "You have submitted more than one offer with the same fandom tags. This challenge requires them all to be unique."
   

--- a/features/prompt_memes/challenge_promptmeme.feature
+++ b/features/prompt_memes/challenge_promptmeme.feature
@@ -112,7 +112,7 @@ Feature: Prompt Meme Challenge
   Given I have Battle 12 prompt meme fully set up
     And I am logged in as "myname1"
   When I sign up for "Battle 12" with missing prompts
-  Then I should see "Request: your Request must include exactly 1 fandom tags, but you have included 0 fandom tags in your current Request"
+  Then I should see "Request: Your Request must include exactly 1 fandom tags, but you have included 0 fandom tags in your current Request"
   When I fill in the missing prompt
   Then I should see "Sign-up was successfully created"
   


### PR DESCRIPTION
Resolves issue: http://code.google.com/p/otwarchive/issues/detail?id=2249

Error messages now appear above the Prompt that they are referencing. There is a generic error message at the top of the page to let users know they need to look through their submission.
