### PR TITLE
3555 Remove serif font style from epub

### DIFF
--- a/app/views/layouts/barebones.html.erb
+++ b/app/views/layouts/barebones.html.erb
@@ -7,13 +7,13 @@
     p.message { text-align: center; }
     .meta h1 { font-size: 1.5em; text-align: center; }
     .meta h2 { font-size: 1.25em; text-align: center; }
-    .meta h2 {page-break-before: always;}
+    .meta h2 { page-break-before: always;}
     .meta .byline { text-align: center; }
-    .meta dl.tags {border: 1px solid;  padding: 1em; }
+    .meta dl.tags { border: 1px solid;  padding: 1em; }
     .meta dd { margin: -1em 0 0 10em; }
     .meta .endnote-link { font-size: .8em; }
-    #chapters  {font-family: serif; padding: 1em; }
-    .userstuff  {font-family: serif; padding: 1em; }
+    #chapters  { padding: 1em; }
+    .userstuff  { padding: 1em; }
   </style>
 </head>
 <body>


### PR DESCRIPTION
Kobo doesn't like that we specify a serif font in our epub files. http://code.google.com/p/otwarchive/issues/detail?id=3555
