### PR TITLE
3565 Tumblr share for bookmarks uses wrong id in work link

### DIFF
--- a/app/views/bookmarks/_bookmark_owner_navigation.html.erb
+++ b/app/views/bookmarks/_bookmark_owner_navigation.html.erb
@@ -11,7 +11,7 @@
       <!-- twitter, tumblr buttons go here -->
         <ul>
           <li>
-            <a href="http://www.tumblr.com/share/link?url=<%=u work_url(bookmark) %>&name=<%=u get_tumblr_embed_link_title(bookmark.bookmarkable) %>&description=<%=u get_tumblr_bookmark_embed_link(bookmark) %>" title="<%= ts('Share on Tumblr') %>" style="display:inline-block; text-indent:-9999px; overflow:hidden; width:81px; height:20px; background:url('http://platform.tumblr.com/v1/share_1.png') top left no-repeat transparent; border-bottom: none;" target="_blank">
+            <a href="http://www.tumblr.com/share/link?url=<%=u work_url(bookmark.bookmarkable) %>&name=<%=u get_tumblr_embed_link_title(bookmark.bookmarkable) %>&description=<%=u get_tumblr_bookmark_embed_link(bookmark) %>" title="<%= ts('Share on Tumblr') %>" style="display:inline-block; text-indent:-9999px; overflow:hidden; width:81px; height:20px; background:url('http://platform.tumblr.com/v1/share_1.png') top left no-repeat transparent; border-bottom: none;" target="_blank">
               <%= ts('Share on Tumblr') %>
             </a>
           </li>


### PR DESCRIPTION
When sharing a bookmark with the Tumblr share link, the work URL was using the bookmark ID, not the bookmarkable (work) ID, leading to broken links.

http://code.google.com/p/otwarchive/issues/detail?id=3565
