### PR TITLE
3566 Text update for account purging admin setting (change days to weeks)

### DIFF
--- a/app/views/admin/settings/index.html.erb
+++ b/app/views/admin/settings/index.html.erb
@@ -19,7 +19,7 @@
     <dd><%= f.text_field :invite_from_queue_number, :size => "3" %></dd>
     <dt><%= f.label :invite_from_queue_frequency, "How often (in days) should we invite people from the queue:" %></dt>
     <dd><%= f.text_field :invite_from_queue_frequency, :size => "3" %></dd>
-    <dt><%= f.label :days_to_purge_unactivated, "How much time (in days) do you have for activating your account before we purge it:" %> </dt>
+    <dt><%= f.label :days_to_purge_unactivated, "How much time (in weeks) do you have for activating your account before we purge it:" %> </dt>
     <dd><%= f.text_field :days_to_purge_unactivated, :size => "3" %></dd>
     <dt><%= f.label :disable_filtering, "Turn off filtering on index pages" %></dt>
     <dd><%= f.check_box :disable_filtering %> </dd>


### PR DESCRIPTION
Text update to reflect the fact that units for "How much time (in days) do you have for activating your account before we purge it" Admin setting are actually weeks, not days 
http://code.google.com/p/otwarchive/issues/detail?id=3566
