### PR TITLE
3274 Standardize email subject formatting for admin notifs, support, and...

### DIFF
--- a/app/mailers/admin_mailer.rb
+++ b/app/mailers/admin_mailer.rb
@@ -12,7 +12,7 @@ class AdminMailer < ActionMailer::Base
     @comment = abuse_report.comment
     mail(
       :to => ArchiveConfig.ABUSE_ADDRESS,
-      :subject  => "#{ArchiveConfig.APP_SHORT_NAME}" + " - " + "Admin Abuse Report"
+      :subject  => "[#{ArchiveConfig.APP_SHORT_NAME}] Admin Abuse Report"
     )
   end
 
@@ -23,7 +23,7 @@ class AdminMailer < ActionMailer::Base
     mail(
       :from => feedback.email.blank? ? ArchiveConfig.RETURN_ADDRESS : feedback.email,
       :to => ArchiveConfig.FEEDBACK_ADDRESS,
-      :subject => "#{ArchiveConfig.APP_SHORT_NAME}" + ": Support - " + feedback.summary,
+      :subject => "[#{ArchiveConfig.APP_SHORT_NAME}] Support - " + feedback.summary,
     )
   end
 
@@ -38,7 +38,7 @@ class AdminMailer < ActionMailer::Base
     end
     mail(
       :to => ArchiveConfig.WEBMASTER_ADDRESS,
-      :subject  => "#{ArchiveConfig.APP_SHORT_NAME}" + " - " + "Admin Archive Notification Sent"
+      :subject  => "[#{ArchiveConfig.APP_SHORT_NAME}] Admin Archive Notification Sent"
     )
   end
   

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -321,7 +321,7 @@ class UserMailer < BulletproofMailer::Base
     @comment = feedback.comment
     mail(
       :to => feedback.email,
-      :subject => "#{ArchiveConfig.APP_SHORT_NAME}: Support - #{strip_html_breaks_simple(feedback.summary)}"
+      :subject => "[#{ArchiveConfig.APP_SHORT_NAME}] Support - #{strip_html_breaks_simple(feedback.summary)}"
     )
   end
 
@@ -332,7 +332,7 @@ class UserMailer < BulletproofMailer::Base
     @comment = abuse_report.comment
     mail(
         :to => abuse_report.email,
-        :subject  => "#{ArchiveConfig.APP_SHORT_NAME}" + " - " + "Your Abuse Report"
+        :subject  => "[#{ArchiveConfig.APP_SHORT_NAME}] Your Abuse Report"
     )
   end
 


### PR DESCRIPTION
... abuse

We've been using [AO3], but these were still AO3:

http://code.google.com/p/otwarchive/issues/detail?id=3274#c34
