### PR TITLE
3293 footer escaping outer wrapper

### DIFF
--- a/public/stylesheets/site/2.0/06-region-footer.css
+++ b/public/stylesheets/site/2.0/06-region-footer.css
@@ -4,8 +4,8 @@ http://media.transformativeworks.org/training/front_end_coding/patterns/supertyp
 
 #footer {
   background: #900 url("/images/skins/textures/tiles/red-ao3.png");
-  clear: both;
   border-top: 2px solid;
+  float: left;
   font-size: 0.75em;
   position: relative;
   padding: 0;


### PR DESCRIPTION
The #footer div was escaping from the #outer div, which was visible in skins like Simply Twilling. http://code.google.com/p/otwarchive/issues/detail?id=3293#c25
