### PR TITLE
Added changes to keep state of tickbox on preview

### DIFF
--- a/app/views/works/_hidden_fields.html.erb
+++ b/app/views/works/_hidden_fields.html.erb
@@ -34,6 +34,7 @@
 <%= form.hidden_field :backdate, :value => "#{@work.backdate}" %>
 <%= form.hidden_field :expected_number_of_chapters, :value => "#{@work.expected_number_of_chapters}" %>
 <%= form.hidden_field :restricted, :value => "#{@work.restricted}" %>
+<%= form.hidden_field :anon_commenting_disabled, :value => "#{@work.anon_commenting_disabled}" %>
 <%= form.hidden_field :revised_at, :value => "#{@work.revised_at}" %>
 <%= form.hidden_field :language_id, :value => "#{@work.language_id}" %>
 <%= form.hidden_field :work_skin_id, :value => "#{@work.work_skin_id}" %>


### PR DESCRIPTION
Added <code>:anon_commenting_disabled</code> to the _hidden_fields.html.erb file so that the state of the check-box is preserved during Preview>>Edit workflow.
