### PR TITLE
3590 Autocomplete options displaying horizontally

### DIFF
--- a/public/stylesheets/site/2.0/07-interactions.css
+++ b/public/stylesheets/site/2.0/07-interactions.css
@@ -190,7 +190,7 @@ p.character_counter {
   margin: 0.25em auto auto;
 }
 
-.autocomplete input, div.dropdown ul li {
+.autocomplete input, .autocomplete .dropdown ul li {
   display: block;
   margin: 0.25em 0 0;
   min-width: 10em;


### PR DESCRIPTION
On the dynamic form for saving bookmarks, the autocomplete options were displaying horizontally. We want them to be vertical, like everywhere else.

http://code.google.com/p/otwarchive/issues/detail?id=3590
