### PR TITLE
Issue 3593: Add Chapter number and Additional Tag info to mailers

### DIFF
--- a/app/views/user_mailer/batch_subscription_notification.html.erb
+++ b/app/views/user_mailer/batch_subscription_notification.html.erb
@@ -9,7 +9,7 @@
     <% if creation.is_a?(Work) %>
       <%= this_work.backdate ? "backdated" : "new" %> work:
     <% else %>
-      new chapter of <i><b><%= work_link %></b></i>:
+      new chapter of <i><b><%= work_link %></b></i> (<%= this_work.word_count %> words):
     <% end %>
 
     <p>
@@ -25,30 +25,37 @@
       <% end %>
     </p>
 
+    <% if creation.summary.present? && creation.is_a?(Chapter) %>
+      <%= style_bold("Chapter Summary:") %> <%= style_quote(raw strip_tags(sanitize_field(creation, :summary))) %>
+    <% end %>
+
     <% unless @seen[this_work.id] %>
       <p>
         <%= style_bold("Chapters:") %> <%= this_work.chapter_total_display %>
         <br><%= style_bold("Fandom:") %> <%= this_work.fandoms.map{|f| style_link(f.name, fandom_url(f))}.to_sentence.html_safe %>
-        <% if this_work.character_string && !this_work.character_string.blank? %>
-          <br><%= style_bold("Characters:") %> <%= this_work.character_string %>
-        <% end %>
+        <br><%= style_bold("Rating:") %> <%= this_work.rating_string %>
+        <br><%= style_bold("Warnings:") %> <%= this_work.warning_string %>
         <% if this_work.relationship_string && !this_work.relationship_string.blank? %>
           <br><%= style_bold("Relationships:") %> <%= this_work.relationship_string %>
+        <% end %>
+        <% if this_work.character_string && !this_work.character_string.blank? %>
+          <br><%= style_bold("Characters:") %> <%= this_work.character_string %>
         <% end %>
         <% if this_work.freeform_string && !this_work.freeform_string.blank? %>
           <br><%= style_bold("Additional Tags:") %> <%= this_work.freeform_string %>
         <% end %>
-        <br><%= style_bold("Rating:") %> <%= this_work.rating_string %>
-        <br><%= style_bold("Warnings:") %> <%= this_work.warning_string %>
+        <% if this_work.series.count > 0 %>
+          <br><%= style_bold("Series:") %> <%= series_list_for_feeds(this_work).html_safe %>
+        <% end %>
       </p>
 
       <% @seen[this_work.id] = true %>
     <% end %>
 
-    <% if creation.summary && !creation.summary.blank? %>
+    <% if creation.summary.present? %>
       <p>
-        <%= style_bold((creation.is_a?(Chapter) ? "Chapter " : "") + "Summary:") %>
-        <%= style_quote(raw strip_tags(sanitize_field(creation, :summary))) %>
+        <%= style_bold("Summary:") %>
+        <%= creation.is_a?(Work) ? style_quote(raw strip_tags(sanitize_field(creation, :summary))) : style_quote(raw strip_tags(sanitize_field(creation.work, :summary))) %>
       </p>
     <% end %>
 

--- a/app/views/user_mailer/batch_subscription_notification.text.erb
+++ b/app/views/user_mailer/batch_subscription_notification.text.erb
@@ -2,22 +2,28 @@
 <% @seen = {} %>
 <% @creations.each_with_index do |creation, index| %>
 <% this_work = creation.respond_to?(:work) ? creation.work : creation %>
-<%= this_work.pseuds.map{|p| p.byline}.to_sentence.html_safe %> posted a <% if creation.is_a?(Work) then %><%= this_work.backdate ? "backdated" : "new" %> work:<% else %>new chapter of <%= this_work.title %>:<% end %> <%= creation.is_a?(Work) ? work_url(this_work) : work_chapter_url(this_work, creation) %>
+<%= this_work.pseuds.map{|p| p.byline}.to_sentence.html_safe %> posted a <% if creation.is_a?(Work) then %><%= this_work.backdate ? "backdated" : "new" %> work:<% else %>new chapter of <%= this_work.title %> (<%= this_work.word_count %> words):<% end %> <%= creation.is_a?(Work) ? work_url(this_work) : work_chapter_url(this_work, creation) %>
  
 <%= creation.is_a?(Work) ? this_work.title.html_safe : @subscription.chapter_name(creation) %> (<%= creation.word_count%> words)<% unless @seen[this_work.id] %>
 by <%= this_work.pseuds.map{|p| text_pseud(p)}.to_sentence.html_safe %>
 
-Chapter: <%= this_work.chapter_total_display %>
-Fandom: <%= this_work.fandoms.map{|f| f.name}.to_sentence.html_safe %>
-<% if this_work.character_string && !this_work.character_string.blank? then %>Characters: <%= this_work.character_string %><% end %>
-<% if this_work.relationship_string && !this_work.relationship_string.blank? then %>Relationships: <%= this_work.relationship_string %><% end %>
-<% if this_work.freeform_string && !this_work.freeform_string.blank? %>Additional Tags: <%= this_work.freeform_string %><% end %>
-Rating: <%= this_work.rating_string %>
-Warnings: <%= this_work.warning_string %><% @seen[this_work.id] = true %><% end %>
+<% if !creation.summary.blank? && creation.is_a?(Chapter) %>
+Chapter Summary: <%= raw to_plain_text(sanitize_field(creation, :summary)) %>
+<% end %>
 
-<% if creation.summary && !creation.summary.blank? %>
-<% if creation.is_a?(Chapter) then %>Chapter <% end %>Summary: 
-    <%= raw to_plain_text(sanitize_field(creation, :summary)) %><% end %><% if (index < @creations.length-1) %>
+Chapters: <%= this_work.chapter_total_display %>
+Fandom: <%= this_work.fandoms.map{|f| f.name}.to_sentence.html_safe %>
+Rating: <%= this_work.rating_string %>
+Warnings: <%= this_work.warning_string %>
+<% if this_work.relationship_string && !this_work.relationship_string.blank? then %>Relationships: <%= this_work.relationship_string %><% end %>
+<% if this_work.character_string && !this_work.character_string.blank? then %>Characters: <%= this_work.character_string %><% end %>
+<% if this_work.freeform_string && !this_work.freeform_string.blank? %>Additional Tags: <%= this_work.freeform_string %><% end %>
+<% if this_work.series.count > 0 %>Series: <%=raw to_plain_text(series_list_for_feeds(this_work)) %><% end %>
+<% @seen[this_work.id] = true %><% end %>
+
+<% if creation.summary.present? %>
+Summary:
+    <%= raw creation.is_a?(Work) ? to_plain_text(sanitize_field(creation, :summary)) : to_plain_text(sanitize_field(creation.work, :summary)) %><% end %><% if (index < @creations.length-1) %>
 
 <%= text_divider %>
 


### PR DESCRIPTION
Resolves issue: http://code.google.com/p/otwarchive/issues/detail?id=3593

Added the 'Chapter' count and 'Additional Tags' information back to subscription notification emails. 
