### PR TITLE
3594 Add JS to prevent double submission of support form

### DIFF
--- a/app/views/feedbacks/new.html.erb
+++ b/app/views/feedbacks/new.html.erb
@@ -61,7 +61,7 @@
     <legend><%= ts('Send Your Feedback') %></legend>
     <%= f.hidden_field :user_agent, :value => request.env["HTTP_USER_AGENT"] %>
     <%= f.hidden_field :ip_address, :value => request.remote_ip %>
-    <p class="submit actions"><%= f.submit ts("Send"), :disable_with => "Please wait..." %></p>
+    <p class="submit actions"><%= f.submit ts("Send"), :disable_with => ts("Please wait...") %></p>
   </fieldset>
   
 <% end %>


### PR DESCRIPTION
When you click the button to send a support ticket, it now turns into "Please wait..." so you can't submit it multiple times. http://code.google.com/p/otwarchive/issues/detail?id=3594
