### PR TITLE
3628 Sub tag trees not properly nested

### DIFF
--- a/app/helpers/tags_helper.rb
+++ b/app/helpers/tags_helper.rb
@@ -200,10 +200,11 @@ module TagsHelper
     unless tag.direct_sub_tags.empty?
       sub_ul << "<ul class='tags tree index'>"
       tag.direct_sub_tags.each do |sub|
-        sub_ul << "<li>" + link_to_tag(sub) + "</li>"
+        sub_ul << "<li>" + link_to_tag(sub)
         unless sub.direct_sub_tags.empty?
-          sub_ul << "<li>" + sub_tag_tree(sub) + "</li>"
+          sub_ul << sub_tag_tree(sub)
         end
+        sub_ul << "</li>"
       end
       sub_ul << "</ul>"
     end


### PR DESCRIPTION
The markup for lists in the sub tag section of tag pages (e.g. /tags/Alternate%20Universe) was wrong. http://code.google.com/p/otwarchive/issues/detail?id=3628

Old and wrong:

```
<ul>
  <li>Thing 1</li>
  <ul>
    <li>Thing 1's Sub Thing 1</li>
  </ul>
  <li>Thing 2</li>
</ul>
```

New and not wrong:

```
<ul>
  <li>Thing 1
    <ul>
      <li>Thing 1's Sub Thing 1</li>
    </ul>
  </li>
  <li>Thing 2</li>
</ul>
```
