### PR TITLE
3625 wrong icon when choose not to use and no warnings both selected

### DIFF
--- a/app/helpers/tags_helper.rb
+++ b/app/helpers/tags_helper.rb
@@ -299,6 +299,9 @@ module TagsHelper
     elsif warning_tags.size == 1 && warning_tags.first.name == ArchiveConfig.WARNING_DEFAULT_TAG_NAME
       # only one tag and it says choose not to warn
       "warning-choosenotto warnings"
+    elsif warning_tags.size == 2 && warning_tags.first.name == ArchiveConfig.WARNING_DEFAULT_TAG_NAME && warning_tags.second.name == ArchiveConfig.WARNING_NONE_TAG_NAME
+      # two tags and they are "choose not to warn" and "no archive warnings apply"
+      "warning-choosenotto warnings"
     else
       "warning-yes warnings"
     end


### PR DESCRIPTION
If you post a work and have selected both no warnings apply and choose not to use archive warnings, the blurb should display the orange icon that indicates you have chosen not to use the warnings. It was showing the red icon that indicates warnings are present.

http://code.google.com/p/otwarchive/issues/detail?id=3625
