### PR TITLE
3273 Extra commas when tags are hidden at preference level

### DIFF
--- a/app/views/tags/show_hidden.js.erb
+++ b/app/views/tags/show_hidden.js.erb
@@ -7,6 +7,6 @@ else
   open_tags = "<li class=\"#{@display_category}\">"
   closing_tags = "</li>"
 end
-tag_list = @display_tags.map {|tag| open_tags + link_to_tag(tag) + (tag == last_tag ? " " : ArchiveConfig.DELIMITER_FOR_OUTPUT) + closing_tags } 
+tag_list = @display_tags.map {|tag| open_tags + link_to_tag(tag) + closing_tags } 
 %>
 $j("#<%= "#{@display_creation.class.to_s.underscore}_#{@display_creation.id}_category_#{@display_category}" %>").replaceWith("<%= escape_javascript(tag_list.join(" ").html_safe) %>");


### PR DESCRIPTION
Removes the extra comma from warning and additional tags when a user has set their preferences to hide warning and/or additional tags by default.

http://code.google.com/p/otwarchive/issues/detail?id=3273
