### PR TITLE
3630 Outline overlaps autocomplete suggestions when wrangling on Opera

### DIFF
--- a/public/stylesheets/site/2.0/11-group-listbox.css
+++ b/public/stylesheets/site/2.0/11-group-listbox.css
@@ -7,10 +7,9 @@ http://media.transformativeworks.org/training/front_end_coding/patterns/listbox.
   background: #ddd;
   border: 2px solid #ccc;
   padding: 0;
-  outline: 1px solid #fff;
   margin: 0.643em auto;
   overflow: hidden;
-    box-shadow: none;
+    box-shadow: 0 0 0 1px #fff;
 }
 
 .listbox .heading {


### PR DESCRIPTION
We were using `outline` on listboxes to make them pretty, but Opera's rendering engine makes the outline overlap autocomplete suggestions on the tag edit pages. This changes from `outline` to `box-shadow`. http://code.google.com/p/otwarchive/issues/detail?id=3630
