### PR TITLE
3635 title attribute on bookmark count not displaying on hover

### DIFF
--- a/public/stylesheets/site/2.0/13-group-blurb.css
+++ b/public/stylesheets/site/2.0/13-group-blurb.css
@@ -288,6 +288,7 @@ blurbs on the manage collection items pages, mostly reseting styles inherited fr
   right: 0.25em;
   width: 60px;
   margin-top: 0.429em;
+  z-index: 1;
 }
 
 .bookmark .status span, .bookmark .status a {


### PR DESCRIPTION
The work module's header was overlapping the bookmark count, so hovering over the count was not displaying the title attribute tooltip. This changes the z-index to make it work. http://code.google.com/p/otwarchive/issues/detail?id=3635
