### PR TITLE
Issue 3660: Link in ToS must go to DoS

### DIFF
--- a/app/views/home/_tos.html.erb
+++ b/app/views/home/_tos.html.erb
@@ -119,7 +119,7 @@
           </p>
         </li>
         <li>
-          <p>to create an account if you are a resident or national of any country to which the U.S. has prohibited transactions by mandating a trade embargo, as detailed further by <a href="http://www.ustreas.gov/offices/enforcement/ofac/programs/">the State Department</a>; or
+          <p>to create an account if you are a resident or national of any country to which the U.S. has prohibited transactions by mandating a trade embargo, as detailed further by <a href="http://www.pmddtc.state.gov/embargoed_countries/">the State Department</a>; or
           </p>
         </li>
         <li>


### PR DESCRIPTION
Resolves issue: http://code.google.com/p/otwarchive/issues/detail?id=3660

Pointed the link to the Department of State instead of Treasury. 
