### PR TITLE
Issue 3670: fix cache error on tag page

### DIFF
--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -75,7 +75,7 @@ class TagsController < ApplicationController
       (@tag.child_types - %w(SubTag)).each do |child_type|
         tags = @tag.send(child_type.underscore.pluralize).order('taggings_count DESC').limit(ArchiveConfig.TAG_LIST_LIMIT + 1)
         unless tags.blank?
-          children[child_type] = tags.uniq
+          children[child_type] = tags.to_a.uniq
         end
       end
       children


### PR DESCRIPTION
Issue 3670: fix cache error on tag page by ensuring results to be cached are in array format.

https://code.google.com/p/otwarchive/issues/detail?id=3670
