### PR TITLE
Issues 3665 and 3671: fix for phantom data in work form

### DIFF
--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -25,7 +25,8 @@ class Work < ActiveRecord::Base
   has_many :external_author_names, :through => :external_creatorships, :inverse_of => :works
   has_many :external_authors, :through => :external_author_names, :uniq => true
 
-  has_many :chapters # we do NOT use dependent => destroy here because we want to destroy chapters in REVERSE order
+  # we do NOT use dependent => destroy here because we want to destroy chapters in REVERSE order
+  has_many :chapters, conditions: "work_id IS NOT NULL"
   validates_associated :chapters
 
   has_many :serial_works, :dependent => :destroy
@@ -622,7 +623,11 @@ class Work < ActiveRecord::Base
 
   # Gets the current first chapter
   def first_chapter
-    self.chapters.order('position ASC').first || self.chapters.first
+    if self.new_record?
+      self.chapters.first || self.chapters.build
+    else
+      self.chapters.order('position ASC').first
+    end
   end
 
   # Gets the current last chapter


### PR DESCRIPTION
Issues 3665 and 3671: fix for phantom data in work form due to Rails association bug. Works are now told explicitly not to pull in chapters with null foreign keys.

Rails bug (not getting fixed until Rails 4): https://github.com/rails/rails/issues/5215

https://code.google.com/p/otwarchive/issues/detail?id=3665
https://code.google.com/p/otwarchive/issues/detail?id=3671
