### PR TITLE
3686 Extra padding on fandom tags in work blurbs when in a listbox

### DIFF
--- a/public/stylesheets/site/2.0/11-group-listbox.css
+++ b/public/stylesheets/site/2.0/11-group-listbox.css
@@ -24,7 +24,6 @@ http://media.transformativeworks.org/training/front_end_coding/patterns/listbox.
 .listbox > .heading, .listbox .heading a:visited {
   margin: 0;
   color: #222;
-  margin-top: 0;
   padding: 0.25em;
 }
 


### PR DESCRIPTION
http://code.google.com/p/otwarchive/issues/detail?id=3686

We were trying to put padding around the listbox heading (that is, where it says "Recent works") but didn't get specific enough in the CSS, so it was affecting all things with that class.

With bonus removal of `margin-top: 0`, since `margin: 0` includes the top margin.
