### PR TITLE
3687 remove redundant selector in listbox stylesheet

### DIFF
--- a/public/stylesheets/site/2.0/11-group-listbox.css
+++ b/public/stylesheets/site/2.0/11-group-listbox.css
@@ -27,7 +27,7 @@ http://media.transformativeworks.org/training/front_end_coding/patterns/listbox.
   padding: 0.25em;
 }
 
-.listbox .index, .dashboard .listbox .index {
+.listbox .index {
   width: auto;
   padding: 0.643em;
   float: none;


### PR DESCRIPTION
http://code.google.com/p/otwarchive/issues/detail?id=3687

While .dashboard .index does have a float and a width set, it is in 10-types-groups.css, so .listbox .index will override it even on dashboard pages.
