### PR TITLE
3682 Don't include h3 for profile title when no profile title set

### DIFF
--- a/app/views/profile/show.html.erb
+++ b/app/views/profile/show.html.erb
@@ -9,8 +9,8 @@
     <dl class="meta">
       <dt class="pseuds"><%= link_to ts("My pseuds:"), user_pseuds_path(@user) %></dt>
       <dd class="pseuds"><%= print_pseud_list(@user.pseuds) %></dd>
-	    <dt><%= ts("I joined on:") %></dt>
-		  <dd><%= ts("%{date}", :date => l(@user.created_at.to_date)) %></dd>
+      <dt><%= ts("I joined on:") %></dt>
+      <dd><%= ts("%{date}", :date => l(@user.created_at.to_date)) %></dd>
       <% if @user.profile.location? %>
         <dt class="location"><%=h ts("I live in:") %></dt>
         <dd><%=h @user.profile.location %></dd>


### PR DESCRIPTION
http://code.google.com/p/otwarchive/issues/detail?id=3682

If the user has a profile title set, continue to show it in an h3. If they do not have a profile title set, do not show the h3.

Also some indenting fixes and a translation string added.
