### PR TITLE
3655 update symbols key to match categories help

### DIFF
--- a/public/help/symbols-key.html
+++ b/public/help/symbols-key.html
@@ -21,11 +21,11 @@
 				<dt><img src="/images/skins/iconsets/default/category-femslash.png" alt="Femslash" /></dt>
 				<dd>Femslash: female/female relationships</dd>
 				<dt><img src="/images/skins/iconsets/default/category-gen.png" alt="Gen" /></dt>
-				<dd>Gen: no romantic or sexual relationships</dd>
+				<dd>Gen: no romantic or sexual relationships, or relationships which are not the main focus of the work</dd>
 				<dt><img src="/images/skins/iconsets/default/category-het.png" alt="Het" /></dt>
 				<dd>Het: male/female relationships</dd>
 				<dt><img src="/images/skins/iconsets/default/category-multi.png" alt="Multi" /></dt>
-				<dd>Multi: more than one kind of the relationships listed here</dd>
+				<dd>Multi: more than one kind of the relationships listed here, or a relationship with multiple partners</dd>
 				<dt><img src="/images/skins/iconsets/default/category-other.png" alt="Other" /></dt>
 				<dd>Other relationships</dd>
 				<dt><img src="/images/skins/iconsets/default/category-slash.png" alt="Slash" /></dt>


### PR DESCRIPTION
http://code.google.com/p/otwarchive/issues/detail?id=3655

The Gen and Multi definitions in the categories help on the work posting form seem clearer and to more accurately describe how these tags are commonly used in the Archive, so the Symbols Key should match that.
