### PR TITLE
Adding specs to the tests run on Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: ruby
-cache: bundler
 env:
   - TEST_GROUP="rspec spec"
   - TEST_GROUP="cucumber -f progress -r features features/importing"
@@ -36,5 +35,5 @@ notifications:
   irc:
    channels:
      - "irc.freenode.org#otw-dev"
-   on_success: change
+   on_success: always
    on_failure: always


### PR DESCRIPTION
Added the specs to the tests that we automatically run on Travis. This allows us better (visible) test coverage of the code, and lets us get rid of the autotest webdev.

Resolves issue: http://code.google.com/p/otwarchive/issues/detail?id=3702
