### PR TITLE
3622 user-created tables do not need font color set

### DIFF
--- a/public/stylesheets/site/2.0/21-userstuff.css
+++ b/public/stylesheets/site/2.0/21-userstuff.css
@@ -113,7 +113,6 @@
 
 .userstuff table, .userstuff td, .userstuff col, .userstuff tr, .userstuff thead, .userstuff tfoot, .userstuff tbody, .userstuff th, .userstuff thead td, .userstuff th a, .userstuff th a:link {
   background: transparent;
-  color: #222;
   border: none;
 }
 


### PR DESCRIPTION
http://code.google.com/p/otwarchive/issues/detail?id=3622

Weirdly, we were setting a `color: #222` for tables in `userstuff`. That's not even our normal font color, and setting it like this was causing problems with site skins.
