### PR TITLE
model_name is not a String

### DIFF
--- a/app/models/work_skin.rb
+++ b/app/models/work_skin.rb
@@ -22,14 +22,8 @@ class WorkSkin < Skin
   end
 
   def self.model_name
-    name = "skin"
-    name.instance_eval do
-      def plural;   pluralize;   end
-      def singular; singularize; end
-      def human;    singularize; end # for Rails 3.0.0+
-      def i18n_key; singularize; end # for Rails 3.0.3+
-    end
-    return name
+    # re-use the model_name of the superclass (Skin)
+    self.superclass.model_name
   end
 
   def self.basic_formatting


### PR DESCRIPTION
The weird errors were from Rails not knowing how to generate routes. We were trying to feed it "skin" as the model_name for WorkSkin, but model_name is not a String, it's an ActiveModel::Name.

http://code.google.com/p/otwarchive/issues/detail?id=3679
http://code.google.com/p/otwarchive/issues/detail?id=3680
