### PR TITLE
I don't understand how it used to work

### DIFF
--- a/app/models/tagset_models/owned_tag_set.rb
+++ b/app/models/tagset_models/owned_tag_set.rb
@@ -58,7 +58,7 @@ class OwnedTagSet < ActiveRecord::Base
 
   after_update :cleanup_outdated_associations
   def cleanup_outdated_associations
-    tag_ids = SetTagging.where(:tag_set_id => self.tag_set.id)[:tag_id]
+    tag_ids = SetTagging.where(:tag_set_id => self.tag_set.id).collect(&:tag_id)
     TagSetAssociation.where(:owned_tag_set_id => self.id).where("tag_id NOT IN (?) OR parent_tag_id NOT IN (?)", tag_ids, tag_ids).delete_all
   end
 


### PR DESCRIPTION
It did use to work, right?

Anyway, neither a scope nor a plain array liked [:tag_id], and since tag_ids were what we wanted to collect anyway, that's what we're doing now.

http://code.google.com/p/otwarchive/issues/detail?id=3673
