### PR TITLE
3722 slideDown Most Recent Bookmarks on first click

### DIFF
--- a/app/views/bookmarks/_bookmark_blurb.html.erb
+++ b/app/views/bookmarks/_bookmark_blurb.html.erb
@@ -31,7 +31,7 @@
 
       	<% if bookmark_count > 1 %>
         	<% if params[:tag_id] || @most_recent_bookmarks %>
-          	<li id="recent_link_<%= "#{bookmark.bookmarkable_type.underscore}_#{bookmark.bookmarkable_id}" %>" style="display: none;" class="showme">
+          	<li id="recent_link_<%= "#{bookmark.bookmarkable_type.underscore}_#{bookmark.id}" %>" style="display: none;" class="showme">
             	<%= link_to ts("Show Most Recent Bookmarks"), 
               url_for({:controller => 'bookmarks', :action => 'fetch_recent', :id => bookmark.id }), :class => "actions", :remote => true %>
           	</li>
@@ -47,7 +47,7 @@
 	<%= render 'bookmarks/bookmark_user_module', :bookmark => bookmark %>
 
   <% # recent bookmarks will be loaded up here if requested %>
-  <div class="recent dynamic" id="recent_<%= "#{bookmark.bookmarkable_type.underscore}_#{bookmark.bookmarkable_id}" %>"></div>
+  <div class="recent dynamic" id="recent_<%= "#{bookmark.bookmarkable_type.underscore}_#{bookmark.id}" %>" style="display: none;"></div>
 
   <% if logged_in_as_admin? && bookmarkable.class == ExternalWork %>
     <%= render 'admin/admin_options', :item => bookmarkable %>

--- a/app/views/bookmarks/fetch_recent.js.erb
+++ b/app/views/bookmarks/fetch_recent.js.erb
@@ -1,8 +1,8 @@
-$j('#recent_<%= "#{@bookmark.bookmarkable_type.underscore}_#{@bookmark.bookmarkable_id}"%>').html('<%= escape_javascript(render "bookmarks", :params => {:show_recent => true}) %>');
+$j('#recent_<%= "#{@bookmark.bookmarkable_type.underscore}_#{@bookmark.id}"%>').html('<%= escape_javascript(render "bookmarks", :params => {:show_recent => true}) %>').slideDown();
 <% if @bookmark.bookmarkable.bookmarks.size > 5 %>
-  $j('#recent_<%= "#{@bookmark.bookmarkable_type.underscore}_#{@bookmark.bookmarkable_id}"%>').append('<%= escape_javascript(link_to(ts("View All"), eval(@bookmark.bookmarkable.class.to_s.underscore + "_bookmarks_path(@bookmark.bookmarkable)"), :class => "action")) %>');
-  $j('#recent_<%= "#{@bookmark.bookmarkable_type.underscore}_#{@bookmark.bookmarkable_id}"%>').append(" ");
+  $j('#recent_<%= "#{@bookmark.bookmarkable_type.underscore}_#{@bookmark.id}"%>').append('<%= escape_javascript(link_to(ts("View All"), eval(@bookmark.bookmarkable.class.to_s.underscore + "_bookmarks_path(@bookmark.bookmarkable)"), :class => "action")) %>');
+  $j('#recent_<%= "#{@bookmark.bookmarkable_type.underscore}_#{@bookmark.id}"%>').append(" ");
 <% end %>
-$j('#recent_<%= "#{@bookmark.bookmarkable_type.underscore}_#{@bookmark.bookmarkable_id}"%>').append('<%= escape_javascript(link_to("Hide Most Recent Bookmarks", {:controller => "bookmarks", :action => "hide_recent", :id => @bookmark.id }, :method => :get, :remote => true, :class => "action")) %>');
-$j('#recent_link_<%= "#{@bookmark.bookmarkable_type.underscore}_#{@bookmark.bookmarkable_id}"%>').html('<%= escape_javascript(link_to("Hide Most Recent Bookmarks", {:controller => "bookmarks", :action => "hide_recent", :id => @bookmark.id}, :method => :get, :remote => true, :class => "action")) %>');
-$j('#recent_<%= "#{@bookmark.bookmarkable_type.underscore}_#{@bookmark.bookmarkable_id}"%>').slideDown();
+$j('#recent_<%= "#{@bookmark.bookmarkable_type.underscore}_#{@bookmark.id}"%>').append('<%= escape_javascript(link_to(ts("Hide Most Recent Bookmarks"), {:controller => "bookmarks", :action => "hide_recent", :id => @bookmark.id }, :method => :get, :remote => true, :class => "action")) %>');
+$j('#recent_link_<%= "#{@bookmark.bookmarkable_type.underscore}_#{@bookmark.id}"%>').html('<%= escape_javascript(link_to(ts("Hide Most Recent Bookmarks"), {:controller => "bookmarks", :action => "hide_recent", :id => @bookmark.id}, :method => :get, :remote => true, :class => "action")) %>');
+$j('#recent_<%= "#{@bookmark.bookmarkable_type.underscore}_#{@bookmark.id}"%>').slideDown();

--- a/app/views/bookmarks/hide_recent.js.erb
+++ b/app/views/bookmarks/hide_recent.js.erb
@@ -1,3 +1,3 @@
-$j('#recent_<%= "#{@bookmark.bookmarkable_type.underscore}_#{@bookmark.bookmarkable_id}"%>').slideUp();
-$j('#recent_<%= "#{@bookmark.bookmarkable_type.underscore}_#{@bookmark.bookmarkable_id}"%>').html("");
-$j('#recent_link_<%= "#{@bookmark.bookmarkable_type.underscore}_#{@bookmark.bookmarkable_id}"%>').html('<%= escape_javascript(link_to("Show Most Recent Bookmarks", {:controller => "bookmarks", :action => "fetch_recent", :id => @bookmark.id, :params => {:fetch => true} }, :method => :get, :remote => true)) %>');
+$j('#recent_<%= "#{@bookmark.bookmarkable_type.underscore}_#{@bookmark.id}"%>').slideUp();
+$j('#recent_<%= "#{@bookmark.bookmarkable_type.underscore}_#{@bookmark.id}"%>').html("");
+$j('#recent_link_<%= "#{@bookmark.bookmarkable_type.underscore}_#{@bookmark.id}"%>').html('<%= escape_javascript(link_to(ts("Show Most Recent Bookmarks"), {:controller => "bookmarks", :action => "fetch_recent", :id => @bookmark.id, :params => {:fetch => true} }, :method => :get, :remote => true)) %>');


### PR DESCRIPTION
http://code.google.com/p/otwarchive/issues/detail?id=3722

When you select Show Most Recent Bookmarks the first time, the list of recent bookmarks just appears. When you select Hide Most Recent Bookmarks, the list slides up. When you select Show Most Recent Bookmarks a second time on the same item, the list slides down. It should always do the same thing. This makes it always slideDown.

Could also be accomplished by adding `.hide()` to `$j('#recent_<%= "#{@bookmark.bookmarkable_type.underscore}_#{@bookmark.id}"%>')` on the first line of fetch_recent.js, but since we already have `style="display: none;"` on the bookmark_blurb partial, I did that.

Changed the links to translation strings and fixed the problem of duplicate IDs by changing from `recent_<%= "#{bookmark.bookmarkable_type.underscore}_#{bookmark.bookmarkable_id}" %>` to `recent_<%= "#{bookmark.bookmarkable_type.underscore}_#{bookmark.id}" %>`, which will guarantee a unique ID even when the page contains multiple bookmarks of the same item. By happy coincidence, this stops the annoying behavior wherein the most recent bookmarks would be shown attached to the first bookmark blurb for a given item instead of the one you actually clicked the Show Most Recent Bookmarks button on.
