### PR TITLE
2718 use relative protocol url for Twitter javascript

### DIFF
--- a/app/views/works/_work_header_navigation.html.erb
+++ b/app/views/works/_work_header_navigation.html.erb
@@ -83,7 +83,7 @@
           <li>
             <a href="http://twitter.com/share" class="twitter-share-button" data-size="large" data-via="ao3org" data-text="<%= tweet_text(@work) %>" data-url="<%= work_url(@work) %>">Tweet</a>
             <% content_for :footer_js do %>
-              <script type="text/javascript" src="http://platform.twitter.com/widgets.js"></script>
+              <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>
             <% end %>
           </li>
           <li>


### PR DESCRIPTION
http://code.google.com/p/otwarchive/issues/detail?id=2718

When someone is looking at the Archive with https, the Twitter JavaScript should also have https
