### PR TITLE
Issue 3724: Typo in backdate help text

### DIFF
--- a/public/help/backdating-help.html
+++ b/public/help/backdating-help.html
@@ -10,7 +10,7 @@
 </p>
 
 <p>
-    Any subsequent chapters you add will havethat date pre-set on the form, though you
+    Any subsequent chapters you add will have that date pre-set on the form, though you
     will still have the option of overriding that date. This means that if you don't know
     or care exactly when each chapter was originally published, you can still backdate your work conveniently.
 </p>


### PR DESCRIPTION
Resolves issue: http://code.google.com/p/otwarchive/issues/detail?id=3724

Fixed a typo
