### PR TITLE
Issue 3393: fixing 500 error on tag set search caused by search changes

### DIFF
--- a/app/views/owned_tag_sets/index.html.erb
+++ b/app/views/owned_tag_sets/index.html.erb
@@ -7,7 +7,7 @@
   <% elsif @restriction %>
     <%= ts("Tag Sets Used In This Challenge") %>
   <% elsif @query %>
-    <%= search_header @tag_sets, @query, "Tag Set" %> <%= link_to_help 'tagset-about' %>
+    <%= search_header @tag_sets, nil, "Tag Set" %> <%= link_to_help 'tagset-about' %>
   <% else %>
     <%= ts("Tag Sets") %> <%= link_to_help 'tagset-about' %> <%= ts("in the %{archive_name}", :archive_name => ArchiveConfig.APP_NAME) %>
   <% end %>


### PR DESCRIPTION
Issue 3393: fixing 500 error on tag set search caused by search changes

Tag sets don't use the actual search model, and changes elsewhere in the code made the search header method error out.

https://code.google.com/p/otwarchive/issues/detail?id=3393
