### PR TITLE
Equality for all forms

### DIFF
--- a/app/views/opendoors/tools/index.html.erb
+++ b/app/views/opendoors/tools/index.html.erb
@@ -24,7 +24,7 @@
   </fieldset>
 <% end %>
 
-<% form_for [:opendoors, @external_author] do |f| %>
+<%= form_for [:opendoors, @external_author] do |f| %>
   <fieldset>
     <legend>Block Email Address</legend>
     <h3><%= ts("Block Email Address") %></h3>


### PR DESCRIPTION
Issue 3698 Open Doors tool was missing an equal sign, so the form was not being created at all.

http://code.google.com/p/otwarchive/issues/detail?id=3698
