### PR TITLE
Issue 3700 kudos from deleted account

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -59,6 +59,8 @@ class User < ActiveRecord::Base
   has_many :external_authors, :dependent => :destroy
   has_many :external_creatorships, :foreign_key => 'archivist_id'
 
+  before_destroy :remove_pseud_from_kudos # MUST be before the pseuds association, or the 'dependent' destroys the pseuds before they can be removed from kudos
+
   has_many :pseuds, :dependent => :destroy
   validates_associated :pseuds
 
@@ -184,8 +186,6 @@ class User < ActiveRecord::Base
 
   has_many :log_items, :dependent => :destroy
   validates_associated :log_items
-
-  before_destroy :remove_pseud_from_kudos
 
   def remove_pseud_from_kudos
     ids = self.pseuds.collect(&:id).join(',')


### PR DESCRIPTION
http://code.google.com/p/otwarchive/issues/detail?id=3700

Rails is tricksy, precious.

"Sometimes the code needs that the callbacks execute in a specific order. For example, a before_destroy callback (log_children in this case) should be executed before the children get destroyed by the +dependent: destroy+ option." and

http://apidock.com/rails/ActiveRecord/Callbacks/before_destroy#43-Where-you-declare-before-destroy-matters
