### PR TITLE
Issue 3735: misbehaving tag sets

### DIFF
--- a/app/controllers/owned_tag_sets_controller.rb
+++ b/app/controllers/owned_tag_sets_controller.rb
@@ -155,7 +155,7 @@ class OwnedTagSetsController < ApplicationController
   end
   
   def update
-    if @tag_set.update_attributes(params[:owned_tag_set])
+    if @tag_set.update_attributes(params[:owned_tag_set]) && @tag_set.tag_set.save
       setflash; flash[:notice] = ts("Tag set was successfully updated.")
       redirect_to tag_set_path(@tag_set)
     else

--- a/app/models/tagset_models/owned_tag_set.rb
+++ b/app/models/tagset_models/owned_tag_set.rb
@@ -72,7 +72,7 @@ class OwnedTagSet < ActiveRecord::Base
   
   def add_tagnames(tag_type, tagnames_to_add)
     self.tag_set.send("#{tag_type}_tagnames_to_add=", tagnames_to_add)
-    return false unless self.save
+    return false unless self.tag_set.save && self.save
 
     # update the nominations -- approve any where an approved tag was either a synonym or the tag itself
     TagNomination.for_tag_set(self).where(:type => "#{tag_type.classify}Nomination").where("tagname IN (?)", tagnames_to_add).update_all(:approved => true, :rejected => false)


### PR DESCRIPTION
I tried `autosave: true` on the `belongs_to :tag_set` association, no results. I tried `autosave: true` on the `has_one :owned_tag_set association`, same lack of results.

So I just settled for explicitly saving the parent tag_set when we were updating things from the owned_tag_set side.

http://code.google.com/p/otwarchive/issues/detail?id=3735
