### PR TITLE
Set type for private in bookmark mapping to fix query problem

### DIFF
--- a/app/models/bookmark.rb
+++ b/app/models/bookmark.rb
@@ -157,7 +157,7 @@ class Bookmark < ActiveRecord::Base
 
   mapping do
     indexes :notes
-    indexes :private
+    indexes :private, :type => 'boolean'
     indexes :bookmarkable_type
     indexes :bookmarkable_id
     indexes :created_at,          :type  => 'date'


### PR DESCRIPTION
Set type for private in bookmark mapping to fix query problem
