### PR TITLE
3745 Use FAQ section titles as page titles

### DIFF
--- a/app/controllers/archive_faqs_controller.rb
+++ b/app/controllers/archive_faqs_controller.rb
@@ -17,6 +17,7 @@ class ArchiveFaqsController < ApplicationController
   # GET /archive_faqs/1.xml
   def show
     @archive_faq = ArchiveFaq.find(params[:id])
+    @page_subtitle = @archive_faq.title + ts(" FAQ")
 
     respond_to do |format|
       format.html # show.html.erb


### PR DESCRIPTION
http://code.google.com/p/otwarchive/issues/detail?id=3745

The page title said Show Archive Faq | Archive of Our Own no matter which FAQ section you were in. Now it uses Name of Section FAQ | Archive of Our Own
