### PR TITLE
3743 Approved canonical tag nominations not appearing in tag set

### DIFF
--- a/app/controllers/tag_set_nominations_controller.rb
+++ b/app/controllers/tag_set_nominations_controller.rb
@@ -1,4 +1,6 @@
 class TagSetNominationsController < ApplicationController
+  cache_sweeper :tag_set_sweeper
+  
   before_filter :users_only
   before_filter :load_tag_set, :except => [ :index ]
   before_filter :load_nomination, :only => [:show, :edit, :update, :destroy]


### PR DESCRIPTION
http://code.google.com/p/otwarchive/issues/detail?id=3743

If you approved a someone's nomination of a canonical tag in a tag set, it didn't appear until you edited the tag set. Now it does.

This is Enigel's idea; I just put it in and checked if it worked.
