### PR TITLE
3751 correct languages in which we offer support

### DIFF
--- a/app/views/feedbacks/new.html.erb
+++ b/app/views/feedbacks/new.html.erb
@@ -3,60 +3,61 @@
 <h2 class="heading"><%= ts('Support and Feedback') %></h2>
 
 <h4 class="landmark heading"><%= ts("Reference Links") %></h4>
-  <ul class="navigation actions" role="navigation">
-    <li><%= link_to ts("FAQ Index"), archive_faqs_path %></li>
-    <li><%= link_to ts("Tutorials"), admin_posts_path(:tag => 5) %></li>
-    <li><%= link_to ts("Release Notes"), admin_posts_path(:tag => 1) %></li>	
-    <li><%= link_to ts("Known Issues"), known_issues_path %></li>
-  </ul>
+<ul class="navigation actions" role="navigation">
+  <li><%= link_to ts("FAQ Index"), archive_faqs_path %></li>
+  <li><%= link_to ts("Tutorials"), admin_posts_path(:tag => 5) %></li>
+  <li><%= link_to ts("Release Notes"), admin_posts_path(:tag => 1) %></li>	
+  <li><%= link_to ts("Known Issues"), known_issues_path %></li>
+</ul>
 
 <h3 class="heading"><%= ts("We love to hear from our users! Tell us about your experience - good, bad, or broken - using our site!") %></h3>
 
 <p><%= ts("We're still in our beta phase of development, so there are ") %><a href="http://code.google.com/p/otwarchive/issues/list"><%= ts("lots of bugs to be fixed") %></a><%= ts(" and ") %><a href="https://trello.com/board/feature-requests/4f0cd935f97f91cf29246288"><%= ts("new features to be considered") %></a><%= ts(". For live updates on Archive performance, please check out our Twitter feed: ") %><a href="http://twitter.com/ao3_status">@AO3_status</a><%= ts(". Please use this form to let us know about your experience while using the site - good and bad! This form is for questions about the Archive and the OTW. Questions for authors should be left on their works. If you have technical issues with this page, please use ") %><a href="http://transformativeworks.org/contact/archive%20support"><%= ts("the back-up form.") %></a></p>
 
-<p><%= ts("We can answer Support inquiries in Deutsch, English, español, français, Polski, português brasileiro, Türkçe, and 中文. You can just write your question or feedback in one of the listed languages and we'll sort it out! Please allow for up to one week delay for responses in any language other than English and español.") %></p>
+<p><%= ts("We can answer Support inquiries in Deutsch, English, español, français, Kiswahili, and português brasileiro. You can just write your question or feedback in one of the listed languages and we'll sort it out! Please allow for up to one week delay for responses in any language other than English and español.") %></p>
 
 <%= form_for(@feedback, :html => {:class => "post feedback"}) do |f| %>
   <fieldset>
-  <legend><%= ts("Contact Information") %></legend>
-    <p class="notice"><%= ts("We value anonymous feedback, but if you'd like a personal reply to your question or comment, we need your email address to contact you. Our spam filter does collect IP addresses, but we never see them.") %></p>
-    <dl>
-      <dt><%= f.label :email, ts("Your email (optional)") %>:</dt>
-      <dd><%= f.text_field :email, :size => 60 %></dd>
-    </dl>
+    <legend><%= ts("Contact Information") %></legend>
+      <p class="notice"><%= ts("We value anonymous feedback, but if you'd like a personal reply to your question or comment, we need your email address to contact you. Our spam filter does collect IP addresses, but we never see them.") %></p>
+      <dl>
+        <dt><%= f.label :email, ts("Your email (optional)") %>:</dt>
+        <dd><%= f.text_field :email, :size => 60 %></dd>
+      </dl>
   </fieldset>
   
   <fieldset>
-  <legend><%= ts('Describe Your Feedback') %></legend>
-  <dl>
-    <dt class="required"><%= f.label :category, ts("What is your feedback about") %>:</dt>
-    <dd>
-      <%= f.select("category", [ 
+    <legend><%= ts('Describe Your Feedback') %></legend>
+    <dl>
+      <dt class="required"><%= f.label :category, ts("What is your feedback about") %>:</dt>
+      <dd>
+        <%= f.select("category", [ 
             [Feedback::BUGS_BUG_NAME, Feedback::BUGS_BUG], 
             [Feedback::BUGS_FEEDBACK_NAME, Feedback::BUGS_FEEDBACK],  
             [Feedback::BUGS_MISC_NAME, Feedback::BUGS_MISC], 
             [Feedback::BUGS_ASSISTANCE_NAME, Feedback::BUGS_ASSISTANCE], 
             [Feedback::BUGS_LANG_NAME, Feedback::BUGS_LANG], 
             [Feedback::BUGS_TAGS_NAME, Feedback::BUGS_TAGS] ], 
-         :selected => Feedback::BUGS_MISC) %>
-     </dd>
-     <dt class="required"><%= f.label :summary, "Brief summary (required)" %>: </dt>
-     <dd>
-       <%= f.text_field :summary, :size => 60, :class => "observe_textlength" %>
-       <%= generate_countdown_html("feedback_summary", ArchiveConfig.FEEDBACK_SUMMARY_MAX) %>
-       <p>
-       <%= live_validation_for_field('feedback_summary', :failureMessage => ts("Please enter a brief summary of your message")) %>
-       </p>
-     </dd>
-     <dt class="required"><%= f.label :comment, ts("Your comment (required)") %>:
-     </dt>
-     <dd>
-       <%= f.text_area :comment, :cols => 60 %>
-       <p class="footnote"><%= ts("Please be as specific as possible, including error messages and/or links") %></p>
-       <p><%= live_validation_for_field('feedback_comment', :failureMessage => ts("Please enter your feedback")) %></p>
-     </dd>
-   </dl>
+          :selected => Feedback::BUGS_MISC) %>
+      </dd>
+      <dt class="required"><%= f.label :summary, "Brief summary (required)" %>: </dt>
+      <dd>
+        <%= f.text_field :summary, :size => 60, :class => "observe_textlength" %>
+        <%= generate_countdown_html("feedback_summary", ArchiveConfig.FEEDBACK_SUMMARY_MAX) %>
+        <p>
+          <%= live_validation_for_field('feedback_summary', :failureMessage => ts("Please enter a brief summary of your message")) %>
+        </p>
+      </dd>
+      <dt class="required"><%= f.label :comment, ts("Your comment (required)") %>:
+      </dt>
+      <dd>
+        <%= f.text_area :comment, :cols => 60 %>
+        <p class="footnote"><%= ts("Please be as specific as possible, including error messages and/or links") %></p>
+        <p><%= live_validation_for_field('feedback_comment', :failureMessage => ts("Please enter your feedback")) %></p>
+      </dd>
+    </dl>
   </fieldset>
+  
   <fieldset>
     <legend><%= ts('Send Your Feedback') %></legend>
     <%= f.hidden_field :user_agent, :value => request.env["HTTP_USER_AGENT"] %>


### PR DESCRIPTION
http://code.google.com/p/otwarchive/issues/detail?id=3751

hele:    sarken, for when you get back, the list should be: Deutsch, English, español, français, Kiswahili, português brasileiro.

Lots of tabbing corrections, line 17 is the language change.
