### PR TITLE
Fix for optional tag sets vanishing on edit

### DIFF
--- a/app/views/prompts/_prompt_form.html.erb
+++ b/app/views/prompts/_prompt_form.html.erb
@@ -68,7 +68,7 @@
             <%= optional_tag_set_form.label :tagnames, ts("Optional Tags: ") %> <%= link_to_help("challenge-optional-tags-user")%>
           </dt>
           <dd>
-            <%= optional_tag_set_form.text_field :tagnames, autocomplete_options("tag?type=all") %>
+            <%= optional_tag_set_form.text_field :tagnames, autocomplete_options("tag?type=all", :value => form.object.optional_tag_set.tagnames) %>
           </dd>
         <% end %>
       <% end %>

--- a/features/challenges/challenge_giftexchange.feature
+++ b/features/challenges/challenge_giftexchange.feature
@@ -80,6 +80,24 @@ Feature: Gift Exchange Challenge
   When I sign up for "Awesome Gift Exchange" with combination A
   Then I should see "Sign-up was successfully created"
   
+  
+  Scenario: Optional tags should be saved when editing a signup (gcode issue #2729)
+  Given I am logged in as "mod1"
+    And I have created the gift exchange "Awesome Gift Exchange"
+    And I edit settings for "Awesome Gift Exchange" challenge
+    And I check "Optional Tags?"
+    And I submit
+  When I am logged in as "myname1"
+    And I sign up for "Awesome Gift Exchange" with combination A
+    And I follow "Edit Sign-up"
+    fill_in("Optional Tags:", :with => "M/M, Mature")
+    And I submit
+  Then I should see "Mature"
+  When I follow "Edit Sign-up"
+  Then I should see "Mature"
+  When I submit
+  Then I should see "Mature"
+  
   Scenario: Sign-ups can be seen in the dashboard
   Given I am logged in as "mod1"
     And I have created the gift exchange "Awesome Gift Exchange"


### PR DESCRIPTION
Fix for issue 2729: optional tag sets vanished on edit. As you can see, MASSIVE amounts of code. :P Test added to the challenge feature, ran clean
https://code.google.com/p/otwarchive/issues/detail?id=2729 

Signed-off-by: shalott shalott@gmail.com
