### PR TITLE
Removing an incorrectly rendered calculation

### DIFF
--- a/app/views/collection_profile/show.html.erb
+++ b/app/views/collection_profile/show.html.erb
@@ -20,7 +20,7 @@
         <dd><%= @collection.email %></dd>
       <% end %>
       <% if @collection.challenge.present? %>
-        <%= tag_sets_counted = tag_set_count(@collection) %>
+        <% tag_sets_counted = tag_set_count(@collection) %>
         <% if tag_sets_counted.present? %>
           <dt><%= tag_sets_counted > 1 ?  ts("Tag sets: ") : ts("Tag set: ") %></dt>
           <dd>


### PR DESCRIPTION
Resolving BoT-DB: http://code.google.com/p/otwarchive/issues/detail?id=3404

I was calculating a variable but used <%= %> which was rendering my result in the view, an unintended consequence. 
