### PR TITLE
Removing randomization from TagSet index list.

### DIFF
--- a/app/controllers/owned_tag_sets_controller.rb
+++ b/app/controllers/owned_tag_sets_controller.rb
@@ -29,7 +29,8 @@ class OwnedTagSetsController < ApplicationController
   ### ACTIONS
 
   def index
-    if @user
+    if params[:user_id]
+      @user = User.find_by_login params[:user_id]
       @tag_sets = OwnedTagSet.owned_by(@user).visible
     elsif params[:restriction]
       @restriction = PromptRestriction.find(params[:restriction])


### PR DESCRIPTION
Removed the randomization of TagSets that appeared on the TagSet index page. 
