### PR TITLE
2299 Add opens new window message to TOS link

### DIFF
--- a/app/views/users/_legal.html.erb
+++ b/app/views/users/_legal.html.erb
@@ -9,7 +9,7 @@
   <!-- Terms of Service -->
   <p>
      <%= ts("And - really important - we need you to agree to our") %> 
-     <%= link_to "Terms of Service", tos_path, :target => '_blank' %>:
+     <%= link_to "Terms of Service (opens new window)", tos_path, :target => '_blank' %>:
   </p>
   <fieldset name="<%= tos_field_name %>"id="tos-partial">
     <%= render(:partial => 'home/tos') %>


### PR DESCRIPTION
To met accessibility guidelines, it's nice to tell people when you're making a link open in a new window. http://code.google.com/p/otwarchive/issues/detail?id=2299#c16
