### PR TITLE
3761 Caution class for draft page warning

### DIFF
--- a/app/views/works/drafts.html.erb
+++ b/app/views/works/drafts.html.erb
@@ -1,15 +1,14 @@
 <h2 class="heading"><%= ts("Unposted Drafts") %></h2>
 
-<p>
+<p class="caution notice">
   <strong><%= ts("Please note:") %></strong>
   <%= ts("Unposted drafts are only saved for a month from the day they are first created, and then deleted from the Archive.") %>
 </p>
 
-<!--BACK END, can we just remove this laquo etc-->
-<%= paginated_section @works, {:previous_label => '&laquo; Previous', :next_label => 'Next &raquo;'} do %>
+<%= paginated_section @works, {:previous_label => 'Previous', :next_label => 'Next'} do %>
   <ul class="work index group">
-     <% for work in @works %>
-        <%= render 'work_blurb', :work => work %>
-     <% end %>
-   </ul>
+    <% for work in @works %>
+      <%= render 'work_blurb', :work => work %>
+    <% end %>
+  </ul>
 <% end %>


### PR DESCRIPTION
http://code.google.com/p/otwarchive/issues/detail?id=3761

Make the little note about drafts being ephemeral yellow so it's harder to miss. Also take out the &laquo; and &raquo; from the Previous/Next links per the note that's been there for ages.
