### PR TITLE
Recategorising tags shouldn't show a lying cheating error message

### DIFF
--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -210,12 +210,17 @@ class TagsController < ApplicationController
     # update everything except for the synonym,
     # so that the associations are there to move when the synonym is created
     syn_string = params[:tag].delete(:syn_string)
-    @tag.attributes = params[:tag]
+    new_tag_type = params[:tag].delete(:type)
+
     # Limiting the conditions under which you can update the tag type
-    if @tag.can_change_type? && %w(Fandom Character Relationship Freeform UnsortedTag).include?(params[:tag][:type])
-      @tag.type = params[:tag][:type]
+    if @tag.can_change_type? && %w(Fandom Character Relationship Freeform UnsortedTag).include?(new_tag_type)
+      @tag = @tag.recategorize(new_tag_type)
     end
+
+    @tag.attributes = params[:tag]
+
     @tag.syn_string = syn_string if @tag.save
+
     if @tag.errors.empty? && @tag.save
       flash[:notice] = ts('Tag was updated.')
       if params[:commit] == "Wrangle"

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -548,6 +548,13 @@ class Tag < ActiveRecord::Base
     self.unwrangled? && self.set_taggings.count == 0 && self.works.count == 0
   end
 
+  # tags having their type changed need to be reloaded to be seen as an instance of the proper subclass
+  def recategorize(new_type)
+    self.update_attribute(:type, new_type)
+    # return a new instance of the tag, with the correct class
+    Tag.find(self.id)
+  end
+
   #### FILTERING ####
   
   include WorksOwner  

--- a/app/models/unsorted_tag.rb
+++ b/app/models/unsorted_tag.rb
@@ -3,12 +3,4 @@ class UnsortedTag < Tag
   NAME = "Unsorted Tag"
   index_name Tag.index_name
 
-  # unsorted tags can have their type changed
-  # but they need to be reloaded to be seen as an instance of the proper subclass
-  def recategorize(new_type)
-    self.update_attribute(:type, new_type)
-    # return a new instance of the tag, with the correct class
-    Tag.find(self.id)
-  end
-
 end


### PR DESCRIPTION
`recategorize` is needed at Tag level, not just UnsortedTag, so the recategorised tag can be loaded as the proper subclass to which it has just been assigned.

http://code.google.com/p/otwarchive/issues/detail?id=3749
