### PR TITLE
Restore timezone settings

### DIFF
--- a/app/views/preferences/index.html.erb
+++ b/app/views/preferences/index.html.erb
@@ -17,60 +17,58 @@
 <!--main content-->
 <%= form_for(@preference, :url => { :action => "update", :user_id => @user }) do |f| %>
 <fieldset>
-	<legend><%= ts("Privacy") %></legend>
-	<h4 class="heading"><%= ts("Privacy") %> <%= link_to_help "privacy-preferences" %></h4>
+  <legend><%= ts("Privacy") %></legend>
+  <h4 class="heading"><%= ts("Privacy") %> <%= link_to_help "privacy-preferences" %></h4>
   <ul>
-  	<li>
-   	  <%= f.check_box :email_visible %>
-   	  <%= f.label :email_visible, ts("Show my email address to other people.") %>
-   	</li>
-
-  	<li>
-    	  <%= f.check_box :date_of_birth_visible %>
-    	  <%= f.label :date_of_birth_visible, ts("Show my date of birth to other people.") %>
-  	</li>
-
-  	<li>
-   	  <%= f.check_box :minimize_search_engines %>
-   	  <%= f.label :minimize_search_engines, ts("Hide my work from search engines when possible.") %>
-   	</li>
-   	
-  	<li>
-   	  <%= f.check_box :disable_share_links %>
-   	  <%= f.label :disable_share_links, ts("Hide the share buttons on my work.") %>
-   	</li>
-   	
-   	
-  </ul>
-  </fieldset>
-  <fieldset>
-	<legend><%= ts("Display") %></legend><h4 class="heading"><%= ts("Display") %> <%= link_to_help "display-preferences" %></h4>
-  <ul>
-  	<li>
-    	  <%= f.check_box :adult %>
-    	  <%= f.label :adult, ts("Show me adult content without checking.") %>
-  	</li>
-
-  	<li>
-    	  <%= f.check_box :view_full_works %>
-    	  <%= f.label :view_full_works, ts("Show the whole work by default.") %>
-  	</li>
-
-  	<li>
-    	  <%= f.check_box :hide_warnings %>
-    	  <%= f.label :hide_warnings, ts("Hide warnings (you can still choose to show them).")  %>
-  	</li>
-
-  	<li>
-  	  <%= f.check_box :hide_freeform %>
-  	  <%= f.label :hide_freeform, ts("Hide additional tags (you can still choose to show them).")  %>
-	  </li>
+    <li>
+      <%= f.check_box :email_visible %>
+      <%= f.label :email_visible, ts("Show my email address to other people.") %>
+    </li>
 
     <li>
-    	<%= f.check_box :disable_work_skins %>
-    	<%= f.label :disable_work_skins, ts("Hide other people's work skins.")  %> <%= link_to_help "skins-basics" %>
+      <%= f.check_box :date_of_birth_visible %>
+      <%= f.label :date_of_birth_visible, ts("Show my date of birth to other people.") %>
     </li>
-</ul>
+
+    <li>
+      <%= f.check_box :minimize_search_engines %>
+      <%= f.label :minimize_search_engines, ts("Hide my work from search engines when possible.") %>
+    </li>
+
+    <li>
+      <%= f.check_box :disable_share_links %>
+      <%= f.label :disable_share_links, ts("Hide the share buttons on my work.") %>
+    </li>
+  </ul>
+</fieldset>
+<fieldset>
+  <legend><%= ts("Display") %></legend><h4 class="heading"><%= ts("Display") %> <%= link_to_help "display-preferences" %></h4>
+  <ul>
+    <li>
+      <%= f.check_box :adult %>
+      <%= f.label :adult, ts("Show me adult content without checking.") %>
+    </li>
+
+    <li>
+      <%= f.check_box :view_full_works %>
+      <%= f.label :view_full_works, ts("Show the whole work by default.") %>
+    </li>
+
+    <li>
+      <%= f.check_box :hide_warnings %>
+      <%= f.label :hide_warnings, ts("Hide warnings (you can still choose to show them).")  %>
+    </li>
+
+    <li>
+      <%= f.check_box :hide_freeform %>
+      <%= f.label :hide_freeform, ts("Hide additional tags (you can still choose to show them).")  %>
+    </li>
+
+    <li>
+      <%= f.check_box :disable_work_skins %>
+      <%= f.label :disable_work_skins, ts("Hide other people's work skins.")  %> <%= link_to_help "skins-basics" %>
+    </li>
+  </ul>
 
   <fieldset>
     <dl>
@@ -79,12 +77,18 @@
         <span class="navigation actions"><%= link_to ts('Public skins'), skins_path %></span>
         <%= f.select :skin_id, @available_skins.collect{|s| [s.title, s.id]} %>
       </dd>
+
+      <dt><%= f.label :time_zone, ts("Your time zone: ")%></dt>
+      <dd><%= f.time_zone_select :time_zone, nil, :default => Time.zone.name %></dd>
+      
+      <dt><%= f.label :work_title_format, ts("Browser page title format")  %> <%= link_to_help "work_title_format" %>:</dt>
+      <dd><%= f.text_field :work_title_format %></dd>
     </dl>
   </fieldset>
 </fieldset>
 
 <fieldset>
-	<legend><%= ts("Statistics") %></legend> 
+  <legend><%= ts("Statistics") %></legend> 
 
   <h4 class="heading"><%= ts("Statistics") %> <%= link_to_help "statistics-preferences" %></h4>
   <ul>


### PR DESCRIPTION
Reinstated the timezone and page title format that went missing as a result of 2707 being merged.

Um, also fixed some tabs in the file - apologies for messy diff.

http://code.google.com/p/otwarchive/issues/detail?id=3774
