### PR TITLE
Open/Close dates generated based off of todays date

### DIFF
--- a/features/step_definitions/challenge_steps.rb
+++ b/features/step_definitions/challenge_steps.rb
@@ -262,8 +262,9 @@ When /^I fill in prompt meme challenge options$/ do
 end
 
 When /^I fill in gift exchange challenge options$/ do
-  step %{I fill in "Sign-up opens" with "2010-09-20 12:40AM"}
-    step %{I fill in "Sign-up closes" with "2013-09-20 12:40AM"}
+  current_date = DateTime.current
+  fill_in("Sign-up opens", :with => "#{current_date.months_ago(2)}")
+    fill_in("Sign-up closes", :with => "#{current_date.years_since(1)}")
     select("(GMT-05:00) Eastern Time (US & Canada)", :from => "gift_exchange_time_zone")
     fill_in("Tag Sets To Use:", :with => "Standard Challenge Tags")
     fill_in("gift_exchange_request_restriction_attributes_fandom_num_required", :with => "1")


### PR DESCRIPTION
This section of the challenge features was a bit brittle. They were failing because the "future" date that we set was no longer actually in the future. 

I've made it so that Open and Close dates are now generated based off of whatever date it is that the tests run. 
