### PR TITLE
3788 remove unused selector from blurb style sheet

### DIFF
--- a/public/stylesheets/site/2.0/13-group-blurb.css
+++ b/public/stylesheets/site/2.0/13-group-blurb.css
@@ -13,7 +13,7 @@ by overriding the rules in the marked off section.
 Perhaps we can make a wizard for this specific task.
 */
 
-.blurb ul li, .blurb dd ul li, .blurb ul.type {
+.blurb ul li, .blurb dd ul li {
   display: inline;
 }
 


### PR DESCRIPTION
http://code.google.com/p/otwarchive/issues/detail?id=3788

.blurb ul.type isn't used, so we can take it out
