### PR TITLE
3625 warning class should be the same regardless of the order in which t...

### DIFF
--- a/app/helpers/tags_helper.rb
+++ b/app/helpers/tags_helper.rb
@@ -299,8 +299,8 @@ module TagsHelper
     elsif warning_tags.size == 1 && warning_tags.first.name == ArchiveConfig.WARNING_DEFAULT_TAG_NAME
       # only one tag and it says choose not to warn
       "warning-choosenotto warnings"
-    elsif warning_tags.size == 2 && warning_tags.first.name == ArchiveConfig.WARNING_DEFAULT_TAG_NAME && warning_tags.second.name == ArchiveConfig.WARNING_NONE_TAG_NAME
-      # two tags and they are "choose not to warn" and "no archive warnings apply"
+    elsif warning_tags.size == 2 && ((warning_tags.first.name == ArchiveConfig.WARNING_DEFAULT_TAG_NAME && warning_tags.second.name == ArchiveConfig.WARNING_NONE_TAG_NAME) || (warning_tags.first.name == ArchiveConfig.WARNING_NONE_TAG_NAME && warning_tags.second.name == ArchiveConfig.WARNING_DEFAULT_TAG_NAME))
+      # two tags and they are "choose not to warn" and "no archive warnings apply" in either order
       "warning-choosenotto warnings"
     else
       "warning-yes warnings"


### PR DESCRIPTION
...he warnings are applied

http://code.google.com/p/otwarchive/issues/detail?id=3625

Editing an existing work with "Choose Not to Warn" ticked and adding "No Archive Warnings Apply gave it the red "!" when we wanted the orange "?!" icon. I'm just guessing this was the problem, since I couldn't reproduce it on my web dev.
