### PR TITLE
3806 Missing title/fandom information when sharing multi-chapter works on Twitter

### DIFF
--- a/app/views/chapters/show.html.erb
+++ b/app/views/chapters/show.html.erb
@@ -47,9 +47,3 @@
 <%= render :partial => 'comments/commentable', :locals => {:commentable => @chapter} %>
 <!-- END comment section -->
 <% end %>
-
-<% # FRONTEND NOTE: Twitter widget JavaScript included here for share/_share to ensure it is only loaded once per page %>
-<% content_for :footer_js do %>
-  <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>
-<% end %>
-

--- a/app/views/share/_share.html.erb
+++ b/app/views/share/_share.html.erb
@@ -32,4 +32,4 @@
   
 </div>
 
-<% # FRONT END NOTE: Twitter widget JavaScript is included separately in bookmarks/index, bookmarks/show, works/show, and chapters/show to ensure it is only loaded once per page %>
+<% # FRONT END NOTE: Twitter widget JavaScript is included separately in bookmarks/index, bookmarks/show, and works/_work_header_navigation to ensure it is only loaded once per page %>

--- a/app/views/works/_work_header_navigation.html.erb
+++ b/app/views/works/_work_header_navigation.html.erb
@@ -92,3 +92,8 @@
   </li>
 </ul>
 <!-- END navigation -->
+
+<% # FRONTEND NOTE: Twitter widget JavaScript included here for share/_share to ensure it is only loaded once per page %>
+<% content_for :footer_js do %>
+  <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>
+<% end %>

--- a/app/views/works/show.html.erb
+++ b/app/views/works/show.html.erb
@@ -74,8 +74,3 @@
 <!-- END comment section -->
 <% end %>
 <!-- END revealed -->
-
-<% # FRONTEND NOTE: Twitter widget JavaScript included here for share/_share to ensure it is only loaded once per page %>
-<% content_for :footer_js do %>
-  <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>
-<% end %>


### PR DESCRIPTION
http://code.google.com/p/otwarchive/issues/detail?id=3806

The Twitter JavaScript needs to be included wherever we're calling the share box, but it wasn't in chapters/show, only works/show. I moved it to works/_work_header_navigation so it will get included on both chapters and works.
