### PR TITLE
3812 Admin post filter labels should select associated form elements

### DIFF
--- a/app/views/admin_posts/_filters.html.erb
+++ b/app/views/admin_posts/_filters.html.erb
@@ -1,4 +1,4 @@
-<h3 class="landmark">Filters</h3>
+<h3 class="landmark"><%= ts("Filters") %></h3>
 <%= form_tag admin_posts_path, :method => :get do %>
   <p><%= label_tag :tag, ts("Tag:") %>
   <%= select_tag :tag, ('<option></option>' + options_from_collection_for_select(@tags, :id, :name, params[:tag])).html_safe %>


### PR DESCRIPTION
http://code.google.com/p/otwarchive/issues/detail?id=3812

The labels for the admin post filters didn't have the proper `for` attributes.
