### PR TITLE
3817 Escaped HTML on Next Chapter button on test

### DIFF
--- a/app/views/comments/_commentable.html.erb
+++ b/app/views/comments/_commentable.html.erb
@@ -10,7 +10,7 @@
       <li><%= link_to '&#8592;'.html_safe + ts('Previous Chapter'), [@work, @previous_chapter] %></li>
     <% end %>
     <% if @work && @next_chapter %>
-      <li><%= link_to (ts('Next Chapter') + ' &#8594;').html_safe, [@work, @next_chapter] %></li>
+      <li><%= link_to h(ts('Next Chapter')) + ' &#8594;'.html_safe, [@work, @next_chapter] %></li>
     <% end %>
     <% if @previous_admin_post %>
       <li><%= link_to("Previous Post", @previous_admin_post) %></li>

--- a/app/views/works/_work_header_navigation.html.erb
+++ b/app/views/works/_work_header_navigation.html.erb
@@ -18,7 +18,7 @@
     <% end %>
     
     <% if @next_chapter %>
-      <li class="chapter next"><%= link_to (ts("Next Chapter") + " &#8594;").html_safe, [@work, @next_chapter] %></li>
+      <li class="chapter next"><%= link_to h(ts("Next Chapter")) + ' &#8594;'.html_safe, [@work, @next_chapter] %></li>
     <% end %>
     
     <li class="chapter" aria-haspopup="true">


### PR DESCRIPTION
http://code.google.com/p/otwarchive/issues/detail?id=3817

The arrow on the Next Chapter button was displaying as &amp;#8594; instead of &#8594;, possibly because CopyCopter didn't like the way the translation string was written. Now it's written the same way as things that aren't broken, so maybe this fixes it. The problem was unique to the staging environment, so this is basically untested.
