### PR TITLE
3820 Drafts pagination needs arrows instead of angle quotation marks

### DIFF
--- a/app/views/works/drafts.html.erb
+++ b/app/views/works/drafts.html.erb
@@ -5,7 +5,7 @@
   <%= ts("Unposted drafts are only saved for a month from the day they are first created, and then deleted from the Archive.") %>
 </p>
 
-<%= paginated_section @works, {:previous_label => 'Previous', :next_label => 'Next'} do %>
+<%= paginated_section @works, {:previous_label => '&#8592;'.html_safe + ts('Previous'), :next_label => h(ts('Next')) + ' &#8594;'.html_safe} do %>
   <ul class="work index group">
     <% for work in @works %>
       <%= render 'work_blurb', :work => work %>


### PR DESCRIPTION
https://code.google.com/p/otwarchive/issues/detail?id=3820

Using the same format as Next/Previous chapter code so it shouldn’t interfere with CopyCopter once it’s on staging
