### PR TITLE
3808 Change wording on mergers and add links

### DIFF
--- a/app/views/tags/show.html.erb
+++ b/app/views/tags/show.html.erb
@@ -55,7 +55,7 @@
   <% if @tag.merger %>
   <div class="merger module">
     <h3 class="heading"><%= ts("Mergers") %></h3>
-    <p><%= ts("%{tag_name} has been merged into %{tag_merger} for filtering. Works and bookmarks tagged with %{tag_name} will show up in %{tag_merger}'s filter.", :tag_name => @tag.name, :tag_merger => @tag.merger.name) %></p>
+    <p><%= ts("%{tag_name} has been made a synonym of %{tag_synonym_link}. Works and bookmarks tagged with %{tag_name} will show up in %{tag_synonym}'s filter.", :tag_name => @tag.name, :tag_synonym_link => (link_to_tag @tag.merger), :tag_synonym => @tag.merger.name).html_safe %></p>
   </div>
   <% end %>
 


### PR DESCRIPTION
https://code.google.com/p/otwarchive/issues/detail?id=3808

> If possible, the sentences could be changed to:
> 
> [tag-name] has been made a synonym of [linked canonical tag-name].
> Works and bookmarks tagged with [tag-name] will show up in [canonical tag-name]'s filters.
> 
> with [linked canonical tag-name] linking to the canonical tag in question?
