### PR TITLE
Updating deleted work mailers

### DIFF
--- a/app/helpers/mailer_helper.rb
+++ b/app/helpers/mailer_helper.rb
@@ -35,6 +35,14 @@ module MailerHelper
   def support_link(text)
     style_link(text, root_url + "support")
   end
+
+  def abuse_link(text)
+    style_link(text, root_url + "abuse_reports/new")
+  end
+
+  def opendoors_link(text)
+    style_link(text, "http://opendoors.transformativeworks.org/contact/open%20doors")
+  end
   
   def styled_divider
     ("<div style=\"line-height:0.5em;\">" +

--- a/app/views/user_mailer/admin_deleted_work_notification.html.erb
+++ b/app/views/user_mailer/admin_deleted_work_notification.html.erb
@@ -3,9 +3,9 @@
   
   <p>Your work <i><%= style_bold(@work.title.html_safe) %></i> was deleted from the Archive by a site admin.</p>
   
-  <p>If your work was part of an import project managed by our Open Doors team, please <%= style_link("contact Open Doors", "http://opendoors.transformativeworks.org/contact/open%20doors") %> with any further questions.
+  <p>If your work was part of an import project managed by our Open Doors team, please <%= opendoors_link("contact Open Doors") %> with any further questions.</p>
  
-   <p>If it's possible your work violated the Archive's Terms of Service, please <%= style_link("contact our Abuse Committee", "#{root_url}abuse_reports/new") %>.</p>
+  <p>If it's possible your work violated the Archive's Terms of Service, please <%= abuse_link("contact our Abuse Committee") %>.</p>
   
   <p>Attached is a copy of your work for your reference.</p>
 <% end %>

--- a/app/views/user_mailer/admin_deleted_work_notification.text.erb
+++ b/app/views/user_mailer/admin_deleted_work_notification.text.erb
@@ -3,9 +3,9 @@ Dear <%= @user.default_pseud.byline %>,
 
 Your work "<%= @work.title.html_safe %>" was deleted from the Archive by a site admin.
 
-If your work was part of an import project managed by our Open Doors team, please <%= link_to("contact Open Doors", "http://opendoors.transformativeworks.org/contact/open%20doors") %> with any further questions.
+If your work was part of an import project managed by our Open Doors team, please contact Open Doors (<%= "http://opendoors.transformativeworks.org/contact/open%20doors" %>) with any further questions.
 
-If it's possible your work violated the Archive's Terms of Service, please <%= link_to("contact our Abuse Committee", "#{root_url}abuse_reports/new") %>.
+If it's possible your work violated the Archive's Terms of Service, please contact our Abuse Committee (<%= root_url + "abuse_reports/new" %>).
 
 Attached is a copy of your work for your reference.
 <% end %>


### PR DESCRIPTION
Resolves BoT-C: http://code.google.com/p/otwarchive/issues/detail?id=3807

Updating the admin deleted work mailers to correctly show links to Abuse and Support forms in the text version of the mailer. 

Also added a couple of new helper methods to easily make the Abuse and Support links in the HTML versions of the mailers. 
