### PR TITLE
issue 3802 Rem new features line on maintenance page

### DIFF
--- a/public/nomaintenance.html
+++ b/public/nomaintenance.html
@@ -95,7 +95,6 @@
     <div id="main" class="system error 503 maintenance">
 			<h2>Error 503</h2>
 			<h3>The archive is down for maintenance.</h3>
-			<p>We'll be back soon with new features!</p>
 			<p>If <a href="http://twitter.com/ao3_status/">@AO3_Status</a> says the site is up, but you still see this page, try <a href="http://kb.iu.edu/data/ahic.html">clearing your browser cache</a> and refreshing the page.
 			</p>
 		</div>


### PR DESCRIPTION
http://code.google.com/p/otwarchive/issues/detail?id=3802

http://test.archiveofourown.org/nomaintenance.html

The page says "We'll be back soon with new features!" which isn't always true, since we use it for more than just deploys. Let's get rid of that line.

Got rid of that line
