### PR TITLE
Issue 3744 - Fixes capitlization of uses of Tos and Faq to TOS and FAQ

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -12,6 +12,9 @@ class ApplicationController < ActionController::Base
   helper_method :current_admin
   helper_method :logged_in?
   helper_method :logged_in_as_admin?
+  
+  # Title helpers
+  helper_method :process_title
 
   # clear out the flash-being-set
   before_filter :clear_flash_cookie
@@ -77,6 +80,15 @@ protected
   
   def guest?
     !(logged_in? || logged_in_as_admin?)
+  end
+  
+  def process_title(string)
+  	string = string.humanize.titleize
+  
+  	string = string.sub("Faq", "FAQ")
+  	string = string.sub("Tos", "TOS")
+  	
+  	return string
   end
 
 public

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -22,8 +22,8 @@
         <% if defined?(@page_subtitle) %>
           <%= @page_subtitle %>
         <% else %>
-          <%= controller.action_name=="index" ? "" : controller.action_name.humanize.titleize %>
-          <%= controller.action_name=="index" ? controller.controller_name.humanize.titleize : controller.controller_name.singularize.humanize.titleize %>
+          <%= controller.action_name=="index" ? "" : process_title(controller.action_name) %>
+          <%= controller.action_name=="index" ? process_title(controller.controller_name) : process_title(controller.controller_name.singularize) %>
         <% end %>
         |
         <%= ArchiveConfig.APP_NAME  %>


### PR DESCRIPTION
http://code.google.com/p/otwarchive/issues/detail?id=3744

Simple, but effective.

Shouldn't effect work titles, should effect future pages created.
Can't make edge case guarantees, for example - if AO3 decided it would be a great idea to include a new search feature called "Fruc-Tose  Searcher" (Fructose would be fine) then it will make it "Fruc-TOSe Searcher" but seriously the odds of running into these is just too small to be of concern.
