### PR TITLE
Issue 2580 - [X] Obsoleted by Issue 3856 [X]

### DIFF
--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -38,6 +38,7 @@ class UserSessionsController < ApplicationController
             end
           elsif user.active?
             if @user_session.being_brute_force_protected? 
+           	  LogItem.create( {:user_id => user.id, :action => ArchiveConfig.ACTION_SUSPEND, :note => "5 minutes: [" + request.remote_ip + "]"} )
            
               message = ts("Your account has been locked for 5 minutes due to too many failed login attempts.")
             else


### PR DESCRIPTION
<em> Please Remove or Close without application </em>

http://code.google.com/p/otwarchive/issues/detail?id=2580

After User attempts to login 50 times the account is blocked for 5 minutes and 
this update sends a log entry using that user and their IP address.

Note:
Using Testy account on my webdev and getting it blocked however seemed to still allow me access immediately without a 5 minute wait. This problem occurs both before and after this update.
