### PR TITLE
Issue 3856 - Fixes the brute force attack vulnerability in user authentication

### DIFF
--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -45,9 +45,7 @@ class UserSessionsController < ApplicationController
 			flash[:notice] = ts("Successfully logged in.")
 			@current_user = @user_session.record
 			redirect_back_or_default(@current_user) and return
-		  end
-
-		  if !user.suspended
+		  elsif !user.suspended
 			if user.recently_reset? && params[:user_session][:password] == user.activation_code
 			  if user.updated_at > 1.week.ago
 				# we sent out a generated password and they're using it
@@ -73,15 +71,14 @@ class UserSessionsController < ApplicationController
 			  message = ts("You'll need to activate your account before you can log in. Please check your email or contact support.")
 			end
 		  end
-		  
+		else
+		  message = ts("The password or user name you entered doesn't match our records. Please try again or click the 'forgot password' link below.")
 		end
     flash.now[:error] = message
-	@user_session = UserSession.new(params[:user_session])
-	if @user_session.save
-	  return
+    #@user_session = UserSession.new(params[:user_session])
+	if !@user_session.save
+	  render :action => 'new'
 	end
-	render :action => 'new'
-	
 	end
   end
 


### PR DESCRIPTION
Fixes <a href="http://code.google.com/p/otwarchive/issues/detail?id=3856">Issue 3856</a> and <a href="http://code.google.com/p/otwarchive/issues/detail?can=2&q=2580">Issue 2580</a>

<em>Replaces pull request for 2580</em>

Correctly suspends user's accounts on repeated failures (50 times) for 5 minutes, displays the time until suspension upon attempted logins. This fix only applies to the User's authentication sequence. 

Also contains (and relies on) the code from 2580 where a log message is produced when the user has their account suspended. This code is pre-init-safe and should properly continue any suspensions in progress until their natural termination of 5 minutes.
