### PR TITLE
3845 Don't print empty ul when there are no recipients, parents, or claims

### DIFF
--- a/app/views/works/_work_header_notes.html.erb
+++ b/app/views/works/_work_header_notes.html.erb
@@ -2,7 +2,7 @@
   <h3 class="heading"><%= ts("Notes:") %></h3>
 
   <% # This is awful, but we don't want the ul tag hanging around when it's empty (i.e. when there are no recipients, parent works, or claims) but we can't skip this entire section because line 25 generates the link to child works that appear under any notes. We repeat this logic on line 63 to close the ul. %>
-  <% unless @work.recipients.blank? && @work.parent_work_relationships.blank? && @work.challenge_claims.blank? %>
+  <% if @work.recipients || @work.approved_related_works.where(translation: true).exists? || @work.parent_work_relationships || @work.challenge_claims %>
     <ul class="associations">
   <% end %>
     <% # dedication %>
@@ -60,7 +60,7 @@
         </li>
       <% end %>
     <% end %>
-  <% unless @work.recipients.blank? && @work.parent_work_relationships.blank? && @work.challenge_claims.blank? %>
+  <% if @work.recipients || @work.approved_related_works.where(translation: true).exists? || @work.parent_work_relationships || @work.challenge_claims %>
     </ul>
   <% end %>
 


### PR DESCRIPTION
https://code.google.com/p/otwarchive/issues/detail?id=3845

Empty elements are bad. We don't want the associations ul around when it contains nothing. Used to be https://github.com/otwcode/otwarchive/pull/1436 until I accidentally deleted it while cleaning up my branches because it split off from another issue number.
