### PR TITLE
Issue 3863: Fix for search 500 errors

### DIFF
--- a/app/models/work_search.rb
+++ b/app/models/work_search.rb
@@ -206,7 +206,7 @@ class WorkSearch < Search
   
   # Search within text fields: general, titles, creator names, and partial tag names
   def generate_search_text
-    search_text = self.query.present? ? self.query.dup : ""
+    search_text = self.query.present? ? escape_reserved_characters(self.query.dup) : ""
     [:title, :creator, :tag].each do |field|
       if self.options[field].present?
         self.options[field].split(" ").each do |word|
@@ -235,6 +235,7 @@ class WorkSearch < Search
   end
   
   def escape_reserved_characters(word)
+    word.gsub!('/', '\\/')
     word.gsub!('!', '\\!')
     word.gsub!('+', '\\+')
     word.gsub!('-', '\\-')


### PR DESCRIPTION
Issue 3863: Fix for search 500 errors

Add slash to escaped characters list and actually escape the search query

https://code.google.com/p/otwarchive/issues/detail?id=3863
