### PR TITLE
3379 Overflowing text in forms and pre tags

### DIFF
--- a/public/stylesheets/site/2.0/02-elements.css
+++ b/public/stylesheets/site/2.0/02-elements.css
@@ -134,7 +134,7 @@ kbd, tt, code, var, pre, samp {
 }
 
 pre {
-  white-space: pre;
+  white-space: pre-wrap;
 }
 
 strong, b {

--- a/public/stylesheets/site/2.0/07-interactions.css
+++ b/public/stylesheets/site/2.0/07-interactions.css
@@ -15,10 +15,9 @@ form {
   clear: right;
 }
 
-form > fieldset {
-  width: 98%;
-  padding: 0.643em 1%;
-  margin: 0.643em 0;
+/* wrap long text in Opera, Safari, and Chrome */
+fieldset {
+  min-width: 0;
 }
 
 /*Guideline: Forms are written by lots of people, and, this is beta, change a LOT. 

--- a/public/stylesheets/site/2.0/17-zone-home.css
+++ b/public/stylesheets/site/2.0/17-zone-home.css
@@ -72,8 +72,10 @@ user home, collections and challenges home, tag home, admin comms home
 
 /*(with filters)*/
 
+/* wrap long text in Firefox (applied to inbox only to avoid weirdness on all forms in IE) */
 #inbox-form {
   float: left;
+  overflow-x: auto;
   width: 75%;
 }
 


### PR DESCRIPTION
https://code.google.com/p/otwarchive/issues/detail?id=3379

Text inside pre tags wouldn't wrap in Firefox despite the word-wrap on the parent element, so now we're traded pre white-space for pre-wrap. Text inside inbox comments wasn't wrapping in Chrome or Safari, so we've overridden the webkit-specific default min-width of content with 0. Text inside inbox comments wasn't wrapping in Firefox no matter what, so now we just make the form scroll horizontally to keep the filters accessible.
