### PR TITLE
Issue 3869: Add the number of invites being sent out to Invite Request Page

### DIFF
--- a/app/views/invite_requests/index.html.erb
+++ b/app/views/invite_requests/index.html.erb
@@ -1,8 +1,11 @@
 <!--Descriptive page name, messages and instructions-->
 <h2 class="heading">Request an invite</h2>
 
-<p>ts("To get a free Archive of Our Own account while we're in beta, you'll need an invitation. There are currently
-<%= InviteRequest.count %> people on the waiting list.") <% if AdminSetting.invite_from_queue_enabled? %> ts("We are sending out <%= AdminSetting.invite_from_queue_number.to_s %> invitations per day.")<% end %></p>
+<p><%= ts("To get a free Archive of Our Own account while we're in beta, you'll need an invitation. There are currently
+  %{count} people on the waiting list.", :count => InviteRequest.count) %>
+  <% if AdminSetting.invite_from_queue_enabled? %>
+    <%= ts("We are sending out %{invites} invitations per day.", :invites => AdminSetting.invite_from_queue_number) %>
+  <% end %></p>
 <!--/descriptions-->
 
 <!--main content-->

--- a/features/other/invite_queue.feature
+++ b/features/other/invite_queue.feature
@@ -36,7 +36,7 @@ Feature: Invite queue management
     When I am on the homepage
       And all emails have been delivered
       And I follow "Get an Invite"
-      And I should see "We currently send out 10 invitations per day."
+      And I should see "We are sending out 10 invitations per day."
     When I fill in "invite_request_email" with "test@archiveofourown.org"
       And I press "Add me to the list"
     Then I should see "You've been added to our queue"


### PR DESCRIPTION
Resolves issue: http://code.google.com/p/otwarchive/issues/detail?id=3869

Made the Invite Request Page show how many invites we are sending out per day. Includes a fancy test. 
