### PR TITLE
3636 Account creation confirmation page should say wait 24 hours

### DIFF
--- a/app/views/users/confirmation.html.erb
+++ b/app/views/users/confirmation.html.erb
@@ -16,5 +16,5 @@
 			<%= ts("You must verify your account within 14 days, or your registration will expire.") %>
 		</p>
 		<p>
-			<%= link_to ts('.back_to_archive', :default => 'Return to archive front page'), root_path %>
+			<%= link_to ts('Return to archive front page'), root_path %>
 		</p>


### PR DESCRIPTION
https://code.google.com/p/otwarchive/issues/detail?id=3636

Was https://github.com/otwcode/otwarchive/pull/1438.

The following copy changes:
<i>In just a few minutes, you should receive an email at the address you gave us.</i> -> <b>Within 24 hours</b>, you should receive an email at the address you gave us.

<i>If you don't hear from us within 2 hours, and you don't find our email in your spam filter, please drop us a line...</i> -> If you don't hear from us within <b>24</b> hours, and you don't find our email in your spam filter, please drop us a line
