### PR TITLE
MERGE ME PLS Changing the user dashboard test

### DIFF
--- a/features/users/user_dashboard.feature
+++ b/features/users/user_dashboard.feature
@@ -119,6 +119,7 @@ Feature: User dashboard
   Then I should see "Recent series"
     And I should see "Newest Series" within "#user-series"
     And I should not find "Oldest Series" within "#user-series"
+    And I should see "Series (6)" within "#user-series"
   When I follow "Series (6)" within "#user-series"
   Then I should see "meatloaf's Series"
     And I should see "Oldest Series"


### PR DESCRIPTION
This changes the step in the user dashboard test from "And I should not see "Oldest Series"" to "And I should not find "Oldest Series"". The step was failing intermittently on Travis (but not locally), and this change is either going to [a] fix it, [b] produce a better error that lets me see why it's failing, or [c] change absolutely nothing. Unfortunately, I don't know which of those is true, since I've run this thing about a dozen times and haven't been able to make it fail.
