### PR TITLE
Issue 3848: Fixed styling issue on "My Assignments"

### DIFF
--- a/public/stylesheets/site/2.0/10-types-groups.css
+++ b/public/stylesheets/site/2.0/10-types-groups.css
@@ -130,9 +130,14 @@ dl.index dd {
   background: #ededed;
 }
 
-dl.index dd p, dl.index dd .heading, dl.index ul {
-  display: inline-block;
-}
+dl.index > dd:after {
+   content: " ";
+   display: block;
+   height: 0;
+   font-size: 0;
+   clear: both;
+   visibility: hidden;
+ }
 
 dl.index dd .userstuff p {
   display: block;


### PR DESCRIPTION
![image](https://f.cloud.github.com/assets/1680226/1802868/2cfed8f8-6c0c-11e3-9fea-6a037e37316b.png)
(top: previous output; bottom: current/fixed output)

Each dd element was displaying on a new line because of an :after pseudoelement on dl.index dd. This appears to have been added for https://code.google.com/p/otwarchive/issues/detail?id=2714 many moons ago, and doesn't appear to be necessary any longer (?)

I'm very, very wary of just removing this in case there's some hidden corner of the archive with definition lists that are now suddenly all displaying on one line, though a cursory glance at pages using <dl class="index"> doesn't turn up anything broken. Maybe someone more familiar with the way the archive references CSS can verify this?

https://code.google.com/p/otwarchive/issues/detail?id=3848
