### PR TITLE
Making challenge_steps respect current year

### DIFF
--- a/features/step_definitions/challenge_steps.rb
+++ b/features/step_definitions/challenge_steps.rb
@@ -702,7 +702,7 @@ Then /^I should see Battle 12 descriptions$/ do
   step %{I should see "Welcome to the meme" within "#intro"}
   step %{I should see "Sign-up: Open"}
   step %{I should see "Sign-up closes:"}
-  step %{I should see "2013" within ".collection .meta"}
+  step %{I should see "#{Time.now.year}" within ".collection .meta"}
   step %{I should see "What is this thing?" within "#faq"}
   step %{I should see "It is a comment fic thing" within "#faq"}
   step %{I should see "Be nicer to people" within "#rules"}


### PR DESCRIPTION
Challenge step definitions were hard coded to look for the year "2013". I've changed it to be <code>Time.now.year</code> so we don't have to come back and fix this every year. 
