### PR TITLE
3627 Showing hidden additional tags should not alphabetize them

### DIFF
--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -123,7 +123,7 @@ class TagsController < ApplicationController
         end
       else
         if %w(warnings freeforms).include?(params[:tag_type])
-          @display_tags = @display_creation.send(params[:tag_type]).sort
+          @display_tags = @display_creation.send(params[:tag_type])
         end
       end
       @display_category = @display_tags.first.class.name.downcase.pluralize


### PR DESCRIPTION
https://code.google.com/p/otwarchive/issues/detail?id=3627

If you set the preference to hide additional tags, you'd get an alphabetized list of the tags when choosing to display them. We want to keep them in the order they were entered.

Note that this causes the delimiter to appear in the wrong place (e.g. "Community: ff_exchange, Non-Graphic Violence, Injury Hurt/Comfort, First Time," -- the comma that is after First Time should be after Injury), but [pull request 1235](https://github.com/otwcode/otwarchive/pull/1235/files) for [Issue 3273 Extra comma when 'Hide additional tags/warnings' enabled](https://code.google.com/p/otwarchive/issues/detail?id=3273) removes the delimiter altogether, so it didn't seem like a good use of time to futz with it here. (Related: Probably a good idea to merge that first.)
