### PR TITLE
3771 Tag Sets without visible tag lists are hidden

### DIFF
--- a/app/controllers/owned_tag_sets_controller.rb
+++ b/app/controllers/owned_tag_sets_controller.rb
@@ -31,15 +31,15 @@ class OwnedTagSetsController < ApplicationController
   def index
     if params[:user_id]
       @user = User.find_by_login params[:user_id]
-      @tag_sets = OwnedTagSet.owned_by(@user).visible
+      @tag_sets = OwnedTagSet.owned_by(@user)
     elsif params[:restriction]
       @restriction = PromptRestriction.find(params[:restriction])
-      @tag_sets = OwnedTagSet.visible.in_prompt_restriction(@restriction)
+      @tag_sets = OwnedTagSet.in_prompt_restriction(@restriction)
       if @tag_sets.count == 1
         redirect_to tag_set_path(@tag_sets.first, :tag_type => (params[:tag_type] || "fandom")) and return
       end
     else
-      @tag_sets = OwnedTagSet.visible
+      @tag_sets = OwnedTagSet
       if params[:query]
         @query = params[:query]
         @tag_sets = @tag_sets.where("title LIKE ?", '%' + params[:query] + '%')

--- a/features/step_definitions/tag_set_steps.rb
+++ b/features/step_definitions/tag_set_steps.rb
@@ -5,12 +5,17 @@ When /^I follow the add new tag ?set link$/ do
 end
 
 # This takes strings like:
+# ...with a visible tag list
 # ...with the fandom tags "x, y, z" and the character tags "a, b, c"
-When /^I set up the tag ?set "([^\"]*)" with (.*)$/ do |title, tags|
+# ...with an invisible tag list and the freeform tags "m, n, o"
+When /^I set up the tag ?set "([^\"]*)" with(?: (?:an? )(visible|invisible) tag list and)? (.*)$/ do |title, visibility, tags|
   unless OwnedTagSet.find_by_title("#{title}").present?
     step %{I go to the new tag set page}
       fill_in("owned_tag_set_title", :with => title)
       fill_in("owned_tag_set_description", :with => "Here's my tagset")
+      visibility ||= "invisible"
+      check("owned_tag_set_visible") if visibility == "visible"
+      uncheck("owned_tag_set_visible") if visibility == "invisible"
       tags.scan(/the (\w+) tags "([^\"]*)"/).each do |type, tags|
         fill_in("owned_tag_set_tag_set_attributes_#{type}_tagnames_to_add", :with => tags)
       end
@@ -129,4 +134,9 @@ When /^I should see the tags with Unicode characters/ do
   tags.each do |tag|
     step %{I should see "#{tag}"}
   end
+end
+
+When /^I view the tag set "([^\"]*)"/ do |tagset|
+  tagset = OwnedTagSet.find_by_title!(tagset)
+  visit tag_set_path(tagset)
 end

--- a/features/tags_and_wrangling/tag_set.feature
+++ b/features/tags_and_wrangling/tag_set.feature
@@ -26,7 +26,34 @@ Feature: creating and editing tag sets
   Then I should see an update confirmation message
     And I should see "wheee"
     
-  Scenario: If a set is not visible, only a moderator should be able to see the tags in the set
+  Scenario: If a tag set does not have a visible tag list, only a moderator should be able to see the tags in the set, but everyone should be able to see the tag set
+  Given I am logged in as "tagsetter"
+    And I set up the tag set "Tag Set with Non-visible Tag List" with an invisible tag list and the fandom tags "Dallas, Knots Landing, Models Inc"
+  Then I should see "Dallas"
+    And I should see "Knots Landing"
+    And I should see "Models Inc"
+  When I go to the tagsets page
+  Then I should see "Tag Set with Non-visible Tag List"
+  When I log out
+    And I go to the tagsets page
+  Then I should see "Tag Set with Non-visible Tag List"
+  When I follow "Tag Set with Non-visible Tag List"
+  Then I should not see "Dallas"
+    And I should not see "Knots Landing"
+    And I should not see "Models Inc"
+    And I should see "The moderators have chosen not to make the tags in this set visible to the public (possibly while nominations are underway)."
+    
+  Scenario: If a tag set has a visible tag list, everyone should be able to see the tags in the set
+  Given I am logged in as "tagsetter"
+    And I set up the tag set "Tag Set with Visible Tag List" with a visible tag list and the fandom tags "Dallas, Knots Landing, Models Inc"
+  Then I should see "Dallas"
+    And I should see "Knots Landing"
+    And I should see "Models Inc"
+  When I log out
+    And I view the tag set "Tag Set with Visible Tag List"
+  Then I should see "Dallas"
+    And I should see "Knots Landing"
+    And I should see "Models Inc"
 
   Scenario: A moderator should be able to manually set up associations between tags in their set on the main tag set edit page
 


### PR DESCRIPTION
If you didn't select "Visible tag list?" on a tag set, your tag _set_ wasn't showing up anywhere (index, search) because of some confusion in the controller. The controller was using `visible` as if it referred to the visibility of the tag set itself, but it actually refers to the "Visible tag list?" setting and therefore the visibility of the tags within a given tag set.

https://code.google.com/p/otwarchive/issues/detail?id=3771
