### PR TITLE
3899 Fix typo in div tag

### DIFF
--- a/app/views/skins/show.html.erb
+++ b/app/views/skins/show.html.erb
@@ -58,7 +58,7 @@
           <% unless @skin.headercolor.blank? %><dt>Header color</dt><dd><%= @skin.headercolor %><% end %>
           <% unless @skin.accent_color.blank? %><dt>Accent color</dt><dd><%= @skin.accent_color %><% end %>
         </dl>
-  	  </div<>
+  	  </div>
     </div>
   <% end %>
 


### PR DESCRIPTION
https://code.google.com/p/otwarchive/issues/detail?id=3899

Changed `<div<>` to the correct `<div>`
