### PR TITLE
3912 Remove Add new tags field from wrangling pages

### DIFF
--- a/app/views/tags/wrangle.html.erb
+++ b/app/views/tags/wrangle.html.erb
@@ -25,23 +25,6 @@
   <p><%= link_to ts('Wrangle Relationships to Characters'), tag_wranglings_path(:show => 'character_relationships', :fandom_string => @tag.name) %></p>
 <% end %>
 
-<% if params[:show] && params[:show] !~ /suggested/ %>
-  <fieldset>
-    <h3 class="heading"><%= ts('Add new') %> <%= params[:show] %></h3>
-    <%= form_for @tag, :as => :tag, :url => { :action => "update", :id => @tag}, :html => { :method => :put } do |f| %>
-      <div title="<%= ts('add new') %>">
-        <%= f.text_field "#{params[:show].singularize}_string", autocomplete_options("tag?type=#{params[:show].singularize}") %>
-        <%= hidden_field_tag :show, params[:show] %>
-        <%= hidden_field_tag :sort_column, params[:sort_column] %>
-        <%= hidden_field_tag :sort_direction, params[:sort_direction] %>
-        <%= hidden_field_tag :page, params[:page] %>
-        <%= hidden_field_tag :status, params[:status] %>
-        <span class="submit actions"><%= f.submit ts('Wrangle') %></span>
-      </div>
-    <% end %>
-  </fieldset>
-<% end %>
-
 <% if params[:show] %>
   <ul class="actions" role="navigation">
     <li><h4 class="heading"><%= ts('Show:') %></h4></li>


### PR DESCRIPTION
https://code.google.com/p/otwarchive/issues/detail?id=3912

The wrangling pages have a field that lets wranglers add new tags of the type being viewed (e.g. new character tags if they're wrangling a character tag) to the fandom. According to the wranglers, this field is mostly superfluous and not useful -- it only allows canonical tags to be added, and duplicates a function available on the tag edit page for the fandom.

This removes that field.
