### PR TITLE
3910 Change heading and button text on wrangling pages

### DIFF
--- a/app/views/tags/wrangle.html.erb
+++ b/app/views/tags/wrangle.html.erb
@@ -3,7 +3,7 @@
 <!--/descriptions-->
 <!--subnav-->
 <ul class="navigation actions" role="navigation">
-  <li><%= link_to ts('edit tag and parent associations'), {:controller => :tags, :action => :edit, :id => @tag} %></li>
+  <li><%= link_to ts('Edit %{current_tag_type} Tag & Associations', :current_tag_type => @tag.type.to_s), {:controller => :tags, :action => :edit, :id => @tag} %></li>
   <li><%= tag_comment_link(@tag) %></li>
 </ul>
 <!--/subnav-->
@@ -12,13 +12,13 @@
 <%
   showing_header = ""
   if params[:show] && params[:status]
-    showing_header = "Showing " + params[:status] + " " + params[:show]
+    showing_header = ts("Showing %{status} %{tag_type} Tags", :status => params[:status].to_s.capitalize, :tag_type => params[:show].to_s.titleize.singularize)
   elsif params[:show]
-    showing_header = "Showing " + params[:show]
+    showing_header = ts("Showing All %{tag_type} Tags", :tag_type => params[:show].to_s.titleize.singularize)
   end
 %>
 <% unless showing_header.blank? %>
-<h3 class="heading"><%= showing_header %></h3>
+  <h3 class="heading"><%= showing_header %></h3>
 <% end %>
 
 <% if @tag.is_a?(Fandom) && params[:show] == "relationships" %>


### PR DESCRIPTION
https://code.google.com/p/otwarchive/issues/detail?id=3910
1. The "edit tag and parent associations" link text should now say "Edit [TAG_TYPE, e.g. Fandom] Tag & Associations" to make it clearer what it does. Here, TAG_TYPE refers to the type of the tag you are currently viewing, e.g. if I am looking at the page for wrangling Supernatural character tags, it should say "Edit Fandom Tag & Associations."
2. The heading "Showing [STATUS, e.g. canonical] [TAG_TYPE, e.g. characters]" should now say "Showing [STATUS, e.g. Canonical] [TAG_TYPE, e.g. Character] Tags"
