### PR TITLE
3917 Error if external author info present & import for others unchecked

### DIFF
--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -517,6 +517,12 @@ class WorksController < ApplicationController
       flash.now[:error] = ts("Did you want to enter a URL?")
       render :new_import and return
     end
+    
+    # is external author information entered when import for others is not checked?
+    if (params[:external_author_name] || params[:external_author_email]) && !params[:importing_for_others]
+      flash.now[:error] = ts("You have entered an external author name or e-mail address but did not select \"Import for others.\" Please select the \"Import for others\" option or remove the external author information to continue.")
+      render :new_import and return
+    end
 
     # is this an archivist importing?
     if params[:importing_for_others] && !current_user.archivist

--- a/features/importing/archivist.feature
+++ b/features/importing/archivist.feature
@@ -99,3 +99,17 @@ Feature: Archivist bulk imports
 
   Scenario: Importing straight into a collection
   # TODO
+  
+  Scenario: Should not be able to import for others unless the box is checked
+  
+    Given I have an archivist "elynross"
+    When I am logged in as "elynross"
+      And I go to the import page
+      And I fill in "URLs*" with "http://cesy.dreamwidth.org/154770.html"
+      And I fill in "Author Name*" with "cesy"
+      And I fill in "Author Email Address*" with "cesy@dreamwidth.org"
+    When I press "Import"
+    Then I should see /You have entered an external author name or e-mail address but did not select "Import for others."/
+    When I check the 1st checkbox with id matching "importing_for_others"
+    And I press "Import"
+    Then I should see "We have notified the author(s) you imported works for. If any were missed, you can also add co-authors manually."


### PR DESCRIPTION
https://code.google.com/p/otwarchive/issues/detail?id=3917

If you enter external author information and don't select 'Import for others ONLY with permission,' the work imports as yours. Let's give an error that says, 'You have entered an external author name or e-mail address but did not select "Import for others." Please select the "Import for others" option or remove the external author information to continue.'
