### PR TITLE
minor tweak that removes double call to pry

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -95,10 +95,9 @@ group :test do
   gem "vcr", "~> 2.5.0"
   gem 'delorean'
   gem 'faker'
-  gem 'pry'
 end
 
-group :development do
+group :test, :development do
   gem 'pry'
 end
 


### PR DESCRIPTION
does absolutely nothing except get rid of the warning about two versions of pry installed
