### PR TITLE
Fix challenge_giftexchange_feature

### DIFF
--- a/features/support/paths.rb
+++ b/features/support/paths.rb
@@ -46,7 +46,7 @@ module NavigationHelpers
     when /^(.*)'s user page$/i
       user_path(:id => $1)
     when /^(.*)'s user url$/i
-      user_url(:id => $1).sub("http://www.example.com", ArchiveConfig.APP_URL)
+      user_url(:id => $1).sub("http://www.example.com", "http://#{ArchiveConfig.APP_HOST}")
     when /^(.*)'s works page$/i
       Work.tire.index.refresh
       user_works_path(:user_id => $1)
@@ -106,7 +106,7 @@ module NavigationHelpers
     when /^the "(.*)" requests page$/i                      # e.g. when I go to "Collection name" signup page
       collection_requests_path(Collection.find_by_title($1))
     when /^"(.*)" collection's url$/i                      # e.g. when I go to "Collection name" collection's url
-      collection_url(Collection.find_by_title($1)).sub("http://www.example.com", ArchiveConfig.APP_URL)
+      collection_url(Collection.find_by_title($1)).sub("http://www.example.com", "http://#{ArchiveConfig.APP_HOST}")
     when /^"(.*)" gift exchange edit page$/i
       edit_collection_gift_exchange_path(Collection.find_by_title($1))
     when /^"(.*)" collection's static page$/i
@@ -116,13 +116,13 @@ module NavigationHelpers
       tag_works_path(Tag.find_by_name($1))
     when /^the url for works tagged "(.*)"$/i
       Work.tire.index.refresh
-      tag_works_url(Tag.find_by_name($1)).sub("http://www.example.com", ArchiveConfig.APP_URL)
+      tag_works_url(Tag.find_by_name($1)).sub("http://www.example.com", "http://#{ArchiveConfig.APP_HOST}")
     when /^the works tagged "(.*)" in collection "(.*)"$/i
       Work.tire.index.refresh
       collection_tag_works_path(Collection.find_by_title($2), Tag.find_by_name($1))
     when /^the url for works tagged "(.*)" in collection "(.*)"$/i
       Work.tire.index.refresh
-      collection_tag_works_url(Collection.find_by_title($2), Tag.find_by_name($1)).sub("http://www.example.com", ArchiveConfig.APP_URL)
+      collection_tag_works_url(Collection.find_by_title($2), Tag.find_by_name($1)).sub("http://www.example.com", "http://#{ArchiveConfig.APP_HOST}")
     when /^the tag comments? page for "(.*)"$/i
       tag_comments_path(Tag.find_by_name($1))
     when /^the admin-posts page$/i


### PR DESCRIPTION
Two steps in this feature were failing with errors about the "Awesome Gift Exchange" collection URL not being found in the notification email. This should fix the problem.
