### PR TITLE
Fix for logfile spec failure

### DIFF
--- a/spec/lib/logfile_reader_spec.rb
+++ b/spec/lib/logfile_reader_spec.rb
@@ -57,8 +57,8 @@ describe LogfileReader do
     it "gets the correct logfiles with no start date" do
       results = self.class.logfiles_to_read
       results.size.should == 2
-      results.first.should == LogfileReader::LOGFILE_DIR + "default.log.1"
-      results.second.should == LogfileReader::LOGFILE_DIR + "default.log.2"
+      results.should include(LogfileReader::LOGFILE_DIR + "default.log.1")
+      results.should include(LogfileReader::LOGFILE_DIR + "default.log.2")
     end
     
     it "gets the correct logfiles given a start date" do


### PR DESCRIPTION
Changed spec to test for the inclusion of both filenames rather than depending on them being in a particular order
