### PR TITLE
3467 FAQ caution, notice, and example styles

### DIFF
--- a/public/stylesheets/site/2.0/16-zone-system.css
+++ b/public/stylesheets/site/2.0/16-zone-system.css
@@ -132,10 +132,13 @@ admin role is only admin facing, and changes normal views in role-admin.css*/
   margin: 0.643em;
 }
 
-/*6. ZONE: SYSTEM: ERROR PAGES*/
+/* 6. ZONE: SYSTEM: FAQS */
 
-.error .tweet_list {
-  padding: 0.5em;
+.faq .userstuff .notice, .faq .userstuff .caution, .faq .example { 
+  margin: 0.643em 3.858em; 
+  padding: 0.643em;
+} 
+
+.faq .example {
+  border: 1px solid #c2d2df;
 }
-		
-/*END== */


### PR DESCRIPTION
https://code.google.com/p/otwarchive/issues/detail?id=3467

Styles for the FAQ pages, specifically requested by wranglers for wrangling guidelines. Rebase of pull request #1049, with a tweak to the .example selector (there's no flash notice with an "example" class -- actually, fun fact, there is nothing else on the archive with that class -- so we don't have to use a .userstuff class).

(The .tweet_list style that got clobbered is from the old Twitter widget and just didn't get removed. Sob, I miss you, old Twitter widget.)
