### PR TITLE
Issue 3941: remove reader-centric language from signup page

### DIFF
--- a/app/views/users/_legal.html.erb
+++ b/app/views/users/_legal.html.erb
@@ -1,7 +1,7 @@
   <!-- Age Check -->
   <p class="note">
   <%= ts('You need to be over 13 years old to become a registered member of the archive.') %>
-  <%= ts("(Sorry to our younger readers! You'll be more than welcome when the time comes.)") %></p>
+  <%= ts("(Sorry to anyone younger! You'll be more than welcome when the time comes.)") %></p>
   <p>
     <%= f.check_box :age_over_13 %>
     <%= f.label :age_over_13, "Yes, I am over 13." %>


### PR DESCRIPTION
Changing text on the account creation page to remove "reader".
http://code.google.com/p/otwarchive/issues/detail?id=3941
