### PR TITLE
Issue 3900: Add Marked for Later to Clear History warning message

### DIFF
--- a/app/views/readings/index.html.erb
+++ b/app/views/readings/index.html.erb
@@ -12,7 +12,7 @@
     <%= span_if_current ts("Marked for Later"), user_readings_path(@user, :show => 'to-read') %>
   </li>
   <li>
-  <%= link_to ts("Clear History"), clear_user_readings_path(current_user), :confirm => ts('Are you sure?'), :method => :post %>
+  <%= link_to ts("Clear History"), clear_user_readings_path(current_user), :confirm => ts('Are you sure you want to clear your History and Marked for Later lists? This cannot be undone!'), :method => :post %>
   </li>
 </ul>
 <% end %>


### PR DESCRIPTION
Clear History confirmation popup didn't mention that it also clears Marked for Later, and should be more emphatic that it can't be undone. http://code.google.com/p/otwarchive/issues/detail?id=3900
