### PR TITLE
Comment out the revert filter taggings migration to stop failures

### DIFF
--- a/db/migrate/20130707160814_revert_filter_taggings_primary_key.rb
+++ b/db/migrate/20130707160814_revert_filter_taggings_primary_key.rb
@@ -1,15 +1,15 @@
 class RevertFilterTaggingsPrimaryKey < ActiveRecord::Migration
   def self.up
     # We want to handle this differently for staging/production due to the size of the table
-    if Rails.env.development?
-      execute "ALTER TABLE `filter_taggings` DROP INDEX `primary`, ADD PRIMARY KEY (`id`);"
-    end
+    # if Rails.env.development?
+     # execute "ALTER TABLE `filter_taggings` DROP INDEX `primary`, ADD PRIMARY KEY (`id`);"
+    # end
   end
 
   def self.down
-    if Rails.env.development?
-      execute "ALTER TABLE `filter_taggings` DROP INDEX `primary`, ADD PRIMARY KEY (`id`,`filter_id`);"
-    end
+    # if Rails.env.development?
+     # execute "ALTER TABLE `filter_taggings` DROP INDEX `primary`, ADD PRIMARY KEY (`id`,`filter_id`);"
+    # end
   end
 end
 


### PR DESCRIPTION
If you set up otwarchive and run the migrations for the first time, they currently fail on the revert_filter_taggings migration. 

```
==  RevertFilterTaggingsPrimaryKey: migrating =================================
-- execute("ALTER TABLE `filter_taggings` DROP INDEX `primary`, ADD PRIMARY KEY (`id`);")
rake aborted!
An error has occurred, all later migrations canceled:

Mysql2::Error: Can't DROP 'primary'; check that column/key exists: ALTER TABLE `filter_taggings` DROP INDEX `primary`, ADD PRIMARY KEY (`id`);/Users/sarken/otwarchive/db/migrate/20130707160814_revert_filter_taggings_primary_key.rb:5:in `up'
Tasks: TOP => db:migrate
```

revert_filter_taggings was there to undo [filter_tagging_primary_key](https://github.com/otwcode/otwarchive/blob/master/db/migrate/20120131225520_filter_tagging_primary_key.rb), but filter_tagging_primary_key is already commented out, so there's nothing to drop.
