### PR TITLE
Update admins.yml and users.yml to work when seeding

### DIFF
--- a/test/fixtures/admins.yml
+++ b/test/fixtures/admins.yml
@@ -7,3 +7,4 @@ admin_00001:
   id: 1
   login: testadmin
   email: user1@example.com
+  persistence_token: foo

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -15,6 +15,7 @@ user_00025:
   out_of_invites: true
   email: mjsunbound@gmail.com
   banned: false
+  persistence_token: foo
 user_00014: 
   salt: 9a5dd70dd81851f215947e1bd1ec3f37e2ecec6b
   created_at: 2008-12-07 19:54:32 Z
@@ -31,6 +32,7 @@ user_00014:
   out_of_invites: true
   email: Uriel@example.com
   banned: false
+  persistence_token: foo
 user_00003: 
   salt: 7e3041ebc2fc05a40c60028e2c4901a81035d3cd
   created_at: 2008-11-09 01:26:02 Z
@@ -47,6 +49,7 @@ user_00003:
   out_of_invites: true
   email: user3@example.com
   banned: false
+  persistence_token: foo
 user_00004: 
   salt: 7e3041ebc2fc05a40c60028e2c4901a81035d3cd
   created_at: 2008-11-09 01:26:02 Z
@@ -63,6 +66,7 @@ user_00004:
   out_of_invites: true
   email: user4@example.com
   banned: false
+  persistence_token: foo
 user_00015: 
   salt: 787e39d8cc37646fb25274a444a48abbafeebd7a
   created_at: 2009-07-17 22:44:23 Z
@@ -79,6 +83,7 @@ user_00015:
   out_of_invites: true
   email: sarkymoocow@example.com
   banned: false
+  persistence_token: foo
 user_00026: 
   salt: 631dcaa51dd023f4cdcdf2747a6322fc2e108ceb
   created_at: 2009-12-12 21:08:12 Z
@@ -95,6 +100,7 @@ user_00026:
   out_of_invites: true
   email: dawn@ccaonline.com
   banned: false
+  persistence_token: foo
 user_00027: 
   salt: 5a432a7543be536b62f1f51fee2255d0483c3b9d
   created_at: 2009-12-12 21:09:13 Z
@@ -111,6 +117,7 @@ user_00027:
   out_of_invites: true
   email: attempt-unique@yahoo.com
   banned: false
+  persistence_token: foo
 user_00016: 
   salt: 47bfebbcd173627903284aced46fc6efea0c9eb4
   created_at: 2009-07-17 23:18:52 Z
@@ -127,6 +134,7 @@ user_00016:
   out_of_invites: true
   email: cal@example.com
   banned: false
+  persistence_token: foo
 user_00005: 
   salt: 343452076355fe7bf635ee217a55e6e98acf8d41
   created_at: 2008-12-05 13:55:27 Z
@@ -143,6 +151,7 @@ user_00005:
   out_of_invites: true
   email: ash@example.com
   banned: false
+  persistence_token: foo
 user_00006: 
   salt: 97bf16bc68d47f5d5cccca85770c82f52c23e58d
   created_at: 2008-12-05 13:55:28 Z
@@ -159,6 +168,7 @@ user_00006:
   out_of_invites: true
   email: 
   banned: false
+  persistence_token: foo
 user_00017: 
   salt: 97730ef8bcd524fd18e4b9237fc05130a177c413
   created_at: 2009-07-18 09:55:25 Z
@@ -175,6 +185,7 @@ user_00017:
   out_of_invites: true
   email: reccer@example.com
   banned: false
+  persistence_token: foo
 user_00028: 
   salt: 4231509879a346f8f3c88294be33d28567a3649f
   created_at: 2009-12-12 21:10:24 Z
@@ -191,6 +202,7 @@ user_00028:
   out_of_invites: true
   email: boo@moog.com
   banned: false
+  persistence_token: foo
 user_00029: 
   salt: 73c1309f8eafb8a949355857d46f682a36854cc3
   created_at: 2009-12-12 21:13:55 Z
@@ -207,6 +219,7 @@ user_00029:
   out_of_invites: true
   email: marina@nbtsc.org
   banned: false
+  persistence_token: foo
 user_00007: 
   salt: 2239939fc04c4d2a0d2b5ceedfc1727c3e527b63
   created_at: 2008-12-05 14:07:24 Z
@@ -223,6 +236,7 @@ user_00007:
   out_of_invites: true
   email: boccaccio@example.org
   banned: false
+  persistence_token: foo
 user_00030: 
   salt: 3979aea39223e3479cf5d29af9a388ea2d13f25f
   created_at: 2009-12-12 21:58:12 Z
@@ -239,6 +253,7 @@ user_00030:
   out_of_invites: true
   email: elmiller00@gmail.com
   banned: false
+  persistence_token: foo
 user_00031: 
   salt: 570b4a55a931c7a1c5be1f5608ee825a88b51e37
   created_at: 2009-12-12 22:39:41 Z
@@ -255,6 +270,7 @@ user_00031:
   out_of_invites: true
   email: savyln7@gmail.com
   banned: false
+  persistence_token: foo
 user_00019: 
   salt: 
   created_at: 2009-09-16 23:37:53 Z
@@ -271,6 +287,7 @@ user_00019:
   out_of_invites: true
   email: zooey.glass04@gmail.com
   banned: false
+  persistence_token: foo
 user_00008: 
   salt: 6e2ee018720464deaa10520d4b3f059710eb2b8d
   created_at: 2008-12-06 22:53:08 Z
@@ -287,6 +304,7 @@ user_00008:
   out_of_invites: true
   email: chaucer@example.com
   banned: false
+  persistence_token: foo
 user_00020: 
   salt: 67363e5f3b3debc2a528aeead8c182e2e4398dab
   created_at: 2009-12-12 21:06:59 Z
@@ -303,6 +321,7 @@ user_00020:
   out_of_invites: true
   email: hh-ook@gmail.com
   banned: false
+  persistence_token: foo
 user_00021: 
   salt: 56e1aeae2f94163b784b694f4d22f6452241d543
   created_at: 2009-12-12 21:07:09 Z
@@ -319,6 +338,7 @@ user_00021:
   out_of_invites: true
   email: sdfsdf@gmail.com
   banned: false
+  persistence_token: foo
 user_00010: 
   salt: efff6c5d4da98884f33dfe1b858163bf8b6832b3
   created_at: 2008-12-06 23:03:31 Z
@@ -335,6 +355,7 @@ user_00010:
   out_of_invites: true
   email: Sam@example.com
   banned: false
+  persistence_token: foo
 user_00009: 
   salt: b09cbc4962f7a925a704704d687548e2040856d4
   created_at: 2008-12-06 22:58:44 Z
@@ -351,6 +372,7 @@ user_00009:
   out_of_invites: true
   email: Dean@example.com
   banned: false
+  persistence_token: foo
 user_00032: 
   salt: 143ff69e26d306a5cb0016e6d5feda3213027138
   created_at: 2009-12-12 23:45:44 Z
@@ -367,6 +389,7 @@ user_00032:
   out_of_invites: true
   email: enigel@gmail.com
   banned: false
+  persistence_token: foo
 user_00033: 
   salt: feef278f6c8d201c0cb4c37253833f60f2090f8e
   created_at: 2009-12-17 11:37:58 Z
@@ -383,6 +406,7 @@ user_00033:
   out_of_invites: true
   email: liminimail@googlemail.com
   banned: false
+  persistence_token: foo
 user_00011: 
   salt: 21f8f1eb19a6dd5b649b451bb4386841506a387d
   created_at: 2008-12-06 23:05:24 Z
@@ -399,6 +423,7 @@ user_00011:
   out_of_invites: true
   email: Ellen@example.com
   banned: false
+  persistence_token: foo
 user_00022: 
   salt: fef057870a00a1d4cd6d67e1441ce762a451d7cb
   created_at: 2009-12-12 21:07:24 Z
@@ -415,6 +440,7 @@ user_00022:
   out_of_invites: true
   email: jenn.calaelen@googlemail.com
   banned: false
+  persistence_token: foo
 user_00023: 
   salt: b510f1f2ac546e9b85d0d17dec60f590992715ca
   created_at: 2009-12-12 21:07:37 Z
@@ -431,6 +457,7 @@ user_00023:
   out_of_invites: true
   email: llwyden@trickster.org
   banned: false
+  persistence_token: foo
 user_00012: 
   salt: c5e416e746f06c3c68b542ed3223d89ce9be52cf
   created_at: 2008-12-06 23:13:19 Z
@@ -447,6 +474,7 @@ user_00012:
   out_of_invites: true
   email: zooey@example.com
   banned: false
+  persistence_token: foo
 user_00001: 
   salt: 7e3041ebc2fc05a40c60028e2c4901a81035d3cd
   created_at: 2008-11-09 01:26:02 Z
@@ -463,6 +491,7 @@ user_00001:
   out_of_invites: true
   email: user1@example.com
   banned: false
+  persistence_token: foo
 user_00002: 
   salt: 7e3041ebc2fc05a40c60028e2c4901a81035d3cd
   created_at: 2008-11-09 01:26:02 Z
@@ -479,6 +508,7 @@ user_00002:
   out_of_invites: true
   email: user2@example.com
   banned: false
+  persistence_token: foo
 user_00013: 
   salt: 5860eac2a470dbee25aa5a4ba8a4e6b841c38c37
   created_at: 2008-12-06 23:29:42 Z
@@ -495,6 +525,7 @@ user_00013:
   out_of_invites: true
   email: Jessica@example.com
   banned: false
+  persistence_token: foo
 user_00024: 
   salt: 943292d06d1761ac3c7e8585a5b728db1f82a930
   created_at: 2009-12-12 21:07:42 Z
@@ -511,3 +542,4 @@ user_00024:
   out_of_invites: true
   email: aaa@bbb.com
   banned: false
+  persistence_token: foo


### PR DESCRIPTION
When you run bundle exec rake db:otwseed, you get "Field 'persistence_token' doesn't have a default value" errors for the admins and users tables. This adds a placeholder value of foo for persistence_token to stop that from happening.

This'll also take care of a bunch of tests that fail due to the same problem.
