### PR TITLE
3237 Draft deletion date should be displayed

### DIFF
--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -292,7 +292,7 @@ class WorksController < ApplicationController
         #hack for empty chapter authors in cucumber series tests
         @chapter.pseuds = @work.pseuds if @chapter.pseuds.blank?
         if params[:preview_button] || params[:cancel_coauthor_button]
-          flash[:notice] = ts('Draft was successfully created.')
+          flash[:notice] = ts('Draft was successfully created. It will be deleted on %{deletion_date}', :deletion_date => view_context.date_in_user_time_zone(@work.created_at + 1.month))
           in_moderated_collection
           redirect_to preview_work_path(@work)
         else
@@ -356,7 +356,7 @@ class WorksController < ApplicationController
     elsif params[:preview_button] || params[:cancel_coauthor_button]
       @preview_mode = true
       if @work.has_required_tags? && @work.invalid_tags.blank?
-        flash[:notice] = ts('Draft was successfully created.')
+        flash[:notice] = ts('Draft was successfully created. It will be deleted on %{deletion_date}', :deletion_date => view_context.date_in_user_time_zone(@work.created_at + 1.month))
         in_moderated_collection
         @chapter = @work.chapters.first unless @chapter
         render :preview

--- a/app/views/works/show.html.erb
+++ b/app/views/works/show.html.erb
@@ -1,11 +1,11 @@
 <!--page description, messages-->
 <ul class="landmark skip">
 	<li><a name="top">&nbsp;</a></li>
-	<li><a href="#work">Skip header</a></li>
+	<li><a href="#work"><%= ts("Skip header") %></a></li>
 </ul>
 <% if !@work.posted? %>
   <p class="notice">
-    <%= ts("This work is a draft and has not been posted.") %>
+    <%= ts("This work is a draft and has not been posted. The draft will be deleted on") %> <%= time_in_zone(@work.created_at + 1.month) %>
   </p>
 <% end %>
 <% if @work.unrevealed? %>

--- a/features/works/work_drafts.feature
+++ b/features/works/work_drafts.feature
@@ -19,7 +19,7 @@ Feature: Work Drafts
     And I fill in "Work Title" with "Draft Dodging"
     And I fill in "content" with "Klinger lay under his porch."  
     And I press "Preview"
-  Then I should see "Draft was successfully created."
+  Then I should see "Draft was successfully created. It will be deleted on"
   When I press "Edit"
   Then I should see "Edit Work"
     And I fill in "content" with "Klinger, in Uncle Gus's Aunt Gussie dress, lay under his porch."


### PR DESCRIPTION
https://code.google.com/p/otwarchive/issues/detail?id=3237

When saving: "Draft was successfully created. It will be deleted on 2014-04-22 01:34:25 -0400"

When viewing otherwise: "This work is a draft and has not been posted. The draft will be deleted on Tue 22 Apr 2014 01:34AM EDT"
