### PR TITLE
Change filter_taggings table creation

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -429,7 +429,7 @@ ActiveRecord::Schema.define(:version => 20121129192353) do
   add_index "filter_counts", ["public_works_count"], :name => "index_public_works_count"
   add_index "filter_counts", ["unhidden_works_count"], :name => "index_unhidden_works_count"
 
-  create_table "filter_taggings", :id => false, :force => true do |t|
+  create_table "filter_taggings", :force => true do |t|
     t.integer  "id",                                                :null => false
     t.integer  "filter_id",       :limit => 8,                      :null => false
     t.integer  "filterable_id",   :limit => 8,                      :null => false


### PR DESCRIPTION
I'm not entirely sure what sorcery this is, just that I was getting this fun error when I tried to create a work on my local install:

```
Mysql2::Error: Field 'id' doesn't have a default value: INSERT INTO `filter_taggings` 
(`created_at`, `filter_id`, `filterable_id`, `filterable_type`, `inherited`, `updated_at`) 
VALUES ('2014-03-22 02:35:33', 992891255, 108, 'Work', 0, '2014-03-22 02:35:33')
```

And the table looked like this:

```
Field           | Type         | Null | Key | Default | Extra |
+-----------------+--------------+------+-----+---------+-------+
| id              | int(11)      | NO   |     | NULL    |       |
```

Elz had me change this line in the schema to make the error go away and turn the table into this:

```
 Field           | Type         | Null | Key | Default | Extra          |
+-----------------+--------------+------+-----+---------+----------------+
| id              | int(11)      | NO   | PRI | NULL    | auto_increment |
```

When I asked what to do with the altered file, she said check it out or pull request it, so here we are.
