### PR TITLE
Issue 3868: stop wide media from being cut off by workskin

### DIFF
--- a/public/stylesheets/site/2.0/21-userstuff.css
+++ b/public/stylesheets/site/2.0/21-userstuff.css
@@ -144,7 +144,7 @@
   font-size: 1.08em;
   margin: auto;
   max-width: 72em;
-  overflow: hidden;
+  overflow: auto;
   position: relative;
 }
 


### PR DESCRIPTION
https://code.google.com/p/otwarchive/issues/detail?id=3868

Previously there was overflow: hidden on #workskin because of an issue which has since been resolved: https://code.google.com/p/otwarchive/issues/detail?id=3272

overflow: hidden; should no longer be necessary.
