### PR TITLE
Increase Capybara timeout for CI servers

### DIFF
--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -39,7 +39,7 @@ ActionController::Base.allow_rescue = false
 Capybara.configure do |config|
   config.match = :prefer_exact
   config.ignore_hidden_elements = false
-  config.default_wait_time = 10
+  config.default_wait_time = 15
 end
 
 


### PR DESCRIPTION
Travis CI and Codeship both run the same set of tests, but both intermittently fail at various point in our testing code. The same tests always pass locally. The most likely explanation is that our views take longer to render on the busy CI servers than they do locally, so the "Then I should see..." steps time out before the page has actually been updated. 

Following advice from Codeship, I've added a 15 second timeout to Capybara in the hopes that it will help.
