### PR TITLE
Issue 3525 - Sort works by date on stats page when hit counts are disabled

### DIFF
--- a/app/controllers/stats_controller.rb
+++ b/app/controllers/stats_controller.rb
@@ -28,7 +28,7 @@ class StatsController < ApplicationController
     sort_options = ""
     @sort = ""
     if current_user.preference.hide_hit_counts
-      sort_options = %w(kudos.count comments.count bookmarks.count subscriptions.count word_count)
+      sort_options = %w(date kudos.count comments.count bookmarks.count subscriptions.count word_count)
       @sort = sort_options.include?(params[:sort_column]) ? params[:sort_column] : "kudos.count"
     else
       sort_options = %w(hits date kudos.count comments.count bookmarks.count subscriptions.count word_count)
@@ -76,6 +76,8 @@ class StatsController < ApplicationController
     # graph top 5 works
     @chart_data = GoogleVisualr::DataTable.new    
     @chart_data.new_column('string', 'Title')
+
+    # TODO: If current_user.preference_hide_hit_counts is true, we probably shouldn't graph hits here
     chart_col = @sort == "date" ? "hits" : @sort
     chart_col_title = chart_col.split(".")[0].titleize == "Comments" ? ts("Comment Threads") : chart_col.split(".")[0].titleize
     chart_title = @sort == "date" ? ts("Most Recent") : ts("Top Five By #{chart_col_title}")


### PR DESCRIPTION
https://code.google.com/p/otwarchive/issues/detail?id=3525

Allow the user to sort by date when clicking the date sort option button on the Stats page.

Note that the visualization still shows the top 5 most recent works graphed against the number of hits when sorting by date. This is probably not the correct behavior when the user turned off hits in their preferences. However I'm not sure if it's part of this bug (or what to display instead).
