### PR TITLE
3967 Change ARIA roles on autocomplete

### DIFF
--- a/public/javascripts/jquery.tokeninput.js
+++ b/public/javascripts/jquery.tokeninput.js
@@ -310,7 +310,7 @@ $.TokenList = function (input, url_or_data, settings) {
     var first_dropdown_item = null;
 
     // The list to store the token items in
-    var token_list = $("<ul role=\"listbox\" aria-activedescendant=\"ui-active-menuitem\"/>")
+    var token_list = $("<ul />") // was role=\"listbox\" aria-activedescendant=\"ui-active-menuitem\"
         .addClass(settings.classes.tokenList)
         .click(function (event) {
             var li = $(event.target).closest("li");
@@ -345,7 +345,7 @@ $.TokenList = function (input, url_or_data, settings) {
     }
 
     // The token holding the input box
-    var input_token = $("<li role=\"menuitem\" />")
+    var input_token = $("<li />") // was role=\"menuitem\"
         .addClass(settings.classes.inputToken)
         .appendTo(token_list)
         .append(input_box);
@@ -707,7 +707,7 @@ $.TokenList = function (input, url_or_data, settings) {
                 .hide();
 
             $.each(results, function(index, value) {
-                var this_li = $("<li role=\"menuitem\">" + highlight_term(escapeHTML(value.name), query) + "</li>")
+                var this_li = $("<li role=\"option\">" + highlight_term(escapeHTML(value.name), query) + "</li>") // was role=\"menuitem\"
                                   .appendTo(dropdown_ul);
 
                 if(index % 2) {


### PR DESCRIPTION
http://code.google.com/p/otwarchive/issues/detail?id=3967

The ARIA roles on the autocomplete were confusing JAWS. It was set up like this:

```
<ul role="listbox"> container for the whole autocomplete thing
  <li role="menuitem"> first tag previously added with the autocomplete
  <li role="menuitem"> second tag previously added with the autocomplete
  <li role="menuitem"> container for the input to add tags and its children
    <input role="combobox"> input for typing tag names
      <div> containing the list of suggested tags
        <ul role="listbox">
          <li role="menuitem"> first suggested tag
          <li role="menuitem"> second suggested tag
```

`<input role="combobox">` and the second `<ul role="listbox">` were right (the [combobox spec](http://www.w3.org/TR/wai-aria/roles#combobox) has an example of an autocomplete), but the listbox's children are now `role="option"` to comply with the [listbox spec](http://www.w3.org/TR/wai-aria/roles#listbox), which says children of listbox should be option (menuitem is for menu's children).

The first listbox role is what was reportedly causing problems, so that and the menuitem roles have been removed. I'm not actually sure how that's going to affect removing tags with JAWS, but before we can worry about that, we need to get _adding_ tags working.
