### PR TITLE
3719 Make text in meta line up with tags in meta

### DIFF
--- a/public/stylesheets/site/2.0/12-group-meta.css
+++ b/public/stylesheets/site/2.0/12-group-meta.css
@@ -35,6 +35,10 @@ dl.meta {
   float: left;
 }
 
+.meta .stats dl, .meta .stats dl dt:first-child, .meta dd ul li:first-child {
+  padding-left: 0;
+}
+
 .meta p {
   display: block;
   margin-top: 0;


### PR DESCRIPTION
https://code.google.com/p/otwarchive/issues/detail?id=3719

Might as well fix the thing where tags were indented farther than text (e.g. language) on the work meta
