### PR TITLE
3973 Make Nimbus the default font for PDFs

### DIFF
--- a/app/views/layouts/barebones.html.erb
+++ b/app/views/layouts/barebones.html.erb
@@ -12,8 +12,8 @@
     .meta dl.tags { border: 1px solid;  padding: 1em; }
     .meta dd { margin: -1em 0 0 10em; }
     .meta .endnote-link { font-size: .8em; }
-    #chapters  { padding: 1em; }
-    .userstuff  { padding: 1em; }
+    #chapters  { font-family: "Nimbus Roman No9 L", "Times New Roman", serif; padding: 1em; }
+    .userstuff  { font-family: "Nimbus Roman No9 L", "Times New Roman", serif; padding: 1em; }
   </style>
 </head>
 <body>


### PR DESCRIPTION
http://code.google.com/p/otwarchive/issues/detail?id=3973

When we took out `font-family: serif;` to fix the issue with HTML downloads displaying in Batang (a Korean font) in Internet Explorer 9, our server started using a sans serif for PDFs. This made PDF people unhappy. Now we're going to make HTML people who have Nimbus Roman No9 L installed or a serif other than Times New Roman as their browser default unhappy instead.
