### PR TITLE
3975 - Remove obsolete functions initSelect and hideFormFields from login page

### DIFF
--- a/app/views/layouts/session.html.erb
+++ b/app/views/layouts/session.html.erb
@@ -19,7 +19,7 @@
     </title>
     <%= render :partial => 'layouts/includes' %>
   </head>
-  <body onload="hideFormFields(); initSelect('languages_menu')">
+  <body>
     <%= render :partial => 'layouts/header' %>
     <!-- BEGIN main -->
     <div id="main" class="<%= controller.controller_name + '-' + controller.action_name %> system session region">


### PR DESCRIPTION
https://code.google.com/p/otwarchive/issues/detail?id=3975

These were not being used anymore, one of them was causing a JavaScript error when you log in, and sarken said they could go :)
