### PR TITLE
3655 Fix further inconsistencies in help text

### DIFF
--- a/public/help/categories-help.html
+++ b/public/help/categories-help.html
@@ -1,4 +1,4 @@
-<h4>Categories Tags</h4>
+<h4>Category Tags</h4>
 
 <p>(For more information, see the <a href="http://archiveofourown.org/archive_faqs/10">Tags on the Archive FAQ</a>.)</p>
 
@@ -6,16 +6,16 @@
   
   <dl>
     <dt>F/F</dt>
-    <dd>Female/Female</dd>
+    <dd>Female/Female relationships</dd>
     <dt>F/M</dt>
-    <dd>Female/Male</dd>
+    <dd>Female/Male relationships</dd>
     <dt>Gen</dt>
-    <dd>General: no relationship, or containing relationships which are not the main focus of the work</dd>
+    <dd>General: no romantic or sexual relationships, or relationships which are not the main focus of the work</dd>
     <dt>M/M</dt>
-    <dd>Male/Male</dd>
+    <dd>Male/Male relationships</dd>
     <dt>Multi</dt>
-    <dd>Any combination of relationships, multiple partners</dd>
+    <dd>More than one kind of relationship, or a relationship with multiple partners</dd>
     <dt>Other</dt>
-    <dd>Other</dd>
+    <dd>Other relationships</dd>
   </dl>
   

--- a/public/help/symbols-key.html
+++ b/public/help/symbols-key.html
@@ -4,13 +4,13 @@
 		<dd><h4>Content rating</h4>
 			<dl>
 				<dt><img src="/images/skins/iconsets/default/rating-general-audience.png" alt="G" /></dt>
-				<dd>General audiences</dd>
+				<dd>General Audiences</dd>
 				<dt><img src="/images/skins/iconsets/default/rating-teen.png" alt="T" /></dt>
-				<dd>Teen</dd>
+				<dd>Teen And Up Audiences</dd>
 				<dt><img src="/images/skins/iconsets/default/rating-mature.png" alt="M" /></dt>
 				<dd>Mature</dd>
 				<dt><img src="/images/skins/iconsets/default/rating-explicit.png" alt="E" /></dt>
-				<dd>Explicit, only suitable for adults</dd>
+				<dd>Explicit: only suitable for adults</dd>
 				<dt><img src="/images/skins/iconsets/default/rating-notrated.png" alt="blank square" /></dt>
 				<dd>The work was not given any rating</dd>
 			</dl>
@@ -18,18 +18,18 @@
 		<dt><img src="/images/key-square-2.png" alt="Second Square" /></dt>
 		<dd><h4>Relationships, pairings, orientations</h4>
 			<dl>
-				<dt><img src="/images/skins/iconsets/default/category-femslash.png" alt="Femslash" /></dt>
-				<dd>Femslash: female/female relationships</dd>
+				<dt><img src="/images/skins/iconsets/default/category-femslash.png" alt="F/F" /></dt>
+				<dd>F/F: female/female relationships</dd>
 				<dt><img src="/images/skins/iconsets/default/category-gen.png" alt="Gen" /></dt>
 				<dd>Gen: no romantic or sexual relationships, or relationships which are not the main focus of the work</dd>
-				<dt><img src="/images/skins/iconsets/default/category-het.png" alt="Het" /></dt>
-				<dd>Het: male/female relationships</dd>
+				<dt><img src="/images/skins/iconsets/default/category-het.png" alt="F/M" /></dt>
+				<dd>F/M: female/male relationships</dd>
 				<dt><img src="/images/skins/iconsets/default/category-multi.png" alt="Multi" /></dt>
-				<dd>Multi: more than one kind of the relationships listed here, or a relationship with multiple partners</dd>
+				<dd>Multi: more than one kind of relationship, or a relationship with multiple partners</dd>
 				<dt><img src="/images/skins/iconsets/default/category-other.png" alt="Other" /></dt>
 				<dd>Other relationships</dd>
-				<dt><img src="/images/skins/iconsets/default/category-slash.png" alt="Slash" /></dt>
-				<dd>Slash: male/male relationships</dd>
+				<dt><img src="/images/skins/iconsets/default/category-slash.png" alt="M/M" /></dt>
+				<dd>M/M: male/male relationships</dd>
 				<dt><img src="/images/skins/iconsets/default/category-none.png" alt="blank square" /></dt>
 				<dd>The work was not put in any categories</dd>
 			</dl>


### PR DESCRIPTION
https://code.google.com/p/otwarchive/issues/detail?id=3655

in categories-help.html...

Was: Categories Tags
Is: Category Tags
Why: English

Was: Female/Female
Is: Female/Female relationships
Why: Because symbols-key.html used "relationships" and it sounded nicer

Was: Female/Male
Is: Female/Male relationships
Why: Because symbols-key.html used "relationships" and it sounded nicer

Was: General: no relationship, or containing relationships which are not the main focus of the work
Is: General: no romantic or sexual relationships, or relationships which are not the main focus of the work
Why: Because the symbols-key.html version was clearer about whether a Gen work can contain, say, friendships or parent-child relationships or...

Was: Any combination of relationships, multiple partners
Is: More than one kind of relationship, or a relationship with multiple partners
Why: To match symbols-key.html, but both versions were edited to get rid of the kinda unnecessarily awkward phrasing of "of the relationships listed here"

Was: Other
Is: Other relationships
Why: Because symbols-key.html used "relationships" and it sounded nicer

in symbols-key.html...
Was: General audiences
Is: General Audiences
Why: We capitalize all the words of our rating tags in most places they're displayed (e.g. filters, post new form, in the title text when you hover over the rating icon)

Was: Teen
Is: Teen And Up Audiences
Why: Because it's the full name of the tag

Was: Explicit, only suitable for adults
Is: Explicit: only suitable for adults
Why: Because we use colons instead of commas in the category section, and the document should have some internal consistency

Was: alt="Femslash"
Is: alt="F/F"
Why: Because the title text when you hover over the category icon and the span text that serves as our fallback both say "F/F"

Was: Femslash: female/female relationships
Is: F/F: female/female relationships
Why: We don't generally refer to F/F as "Femslash" in user-facing text, likely because it's kind of Western-media-fandom-centric (and not even always at that; "altfic" was the word in some Western media fandoms)

Was: alt="Het"
Is: alt="F/M"
Why: Because the title text when you hover over the category icon and the span text that serves as our fallback both say "F/M"

Was: Het: male/female relationships
Is: F/M: female/male relationships
Why: We don't generally refer to F/M as "Het" in user-facing text, and the second half needed to be switched because F stands for female and the M stands for male, not the other way around ;)

Was: Multi: more than one kind of the relationships listed here, or a relationship with multiple partners
Is: Multi: more than one kind of relationship, or a relationship with multiple partners
Why: Kinda unnecessarily awkward phrasing of "of the relationships listed here"

Was: alt="Slash"
Is: alt="M/M"
Why: Because the title text when you hover over the category icon and the span text that serves as our fallback both say "M/M"

Was: Slash: male/male relationships
Is: M/M: male/male relationships
Why: We don't generally refer to M/M as "Slash" in user-facing text, likely because it's kind of Western-media-fandom-centric
