### PR TITLE
Updates to Travis config for elasticsearch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ before_script:
   - cp config/newrelic.example config/newrelic.yml
   - cp config/redis-cucumber.conf.example config/redis-cucumber.conf
   - cp config/redis.travis.example config/redis.yml
+  - curl -L https://gist.githubusercontent.com/scottsds/8fda6f6fbc66d3a2315e/raw/1d4b990f7922e388d6d7563b9e5cda7c97af18a7/gistfile1.sh | bash
 notifications:
   email:
     recipients:


### PR DESCRIPTION
This patches a problem we're having with Travis-CI wanting to use the most current version of elasticsearch, which we're not prepared to use yet. 
