### PR TITLE
3655 Alphabetize symbols key categories

### DIFF
--- a/public/help/symbols-key.html
+++ b/public/help/symbols-key.html
@@ -20,16 +20,16 @@
 			<dl>
 				<dt><img src="/images/skins/iconsets/default/category-femslash.png" alt="F/F" /></dt>
 				<dd>F/F: female/female relationships</dd>
-				<dt><img src="/images/skins/iconsets/default/category-gen.png" alt="Gen" /></dt>
-				<dd>Gen: no romantic or sexual relationships, or relationships which are not the main focus of the work</dd>
 				<dt><img src="/images/skins/iconsets/default/category-het.png" alt="F/M" /></dt>
 				<dd>F/M: female/male relationships</dd>
+				<dt><img src="/images/skins/iconsets/default/category-gen.png" alt="Gen" /></dt>
+				<dd>Gen: no romantic or sexual relationships, or relationships which are not the main focus of the work</dd>
+				<dt><img src="/images/skins/iconsets/default/category-slash.png" alt="M/M" /></dt>
+				<dd>M/M: male/male relationships</dd>
 				<dt><img src="/images/skins/iconsets/default/category-multi.png" alt="Multi" /></dt>
 				<dd>Multi: more than one kind of relationship, or a relationship with multiple partners</dd>
 				<dt><img src="/images/skins/iconsets/default/category-other.png" alt="Other" /></dt>
 				<dd>Other relationships</dd>
-				<dt><img src="/images/skins/iconsets/default/category-slash.png" alt="M/M" /></dt>
-				<dd>M/M: male/male relationships</dd>
 				<dt><img src="/images/skins/iconsets/default/category-none.png" alt="blank square" /></dt>
 				<dd>The work was not put in any categories</dd>
 			</dl>


### PR DESCRIPTION
http://code.google.com/p/otwarchive/issues/detail?id=3655

List was originally in alphabetical order, but by a different set of words:
- Femslash
- Gen
- Het
- Multi
- Other
- Slash
- [None] -- last because it's not actually a tag category

Now it should be in alphabetical order by the words actually written there:
- F/F
- F/M
- Gen
- M/M
- Multi
- Other
- [None] -- last because it's not actually a tag category
