### PR TITLE
From https://docs.newrelic.com/docs/releases/ruby

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -73,7 +73,7 @@ gem 'coveralls', require: false
 
 #  Place the New Relic gem as low in the list as possible, allowing the 
 #  frameworks above it to be instrumented when the gem initializes.
-gem 'newrelic_rpm', "3.7.2.192"
+gem 'newrelic_rpm', "3.8.0.218"
 gem 'newrelic-redis'
 
 # For URL mangling

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -158,7 +158,7 @@ GEM
     newrelic-redis (1.4.0)
       newrelic_rpm (~> 3.0)
       redis (< 4.0)
-    newrelic_rpm (3.7.2.192)
+    newrelic_rpm (3.8.0.218)
     nokogiri (1.6.0)
       mini_portile (~> 0.5.0)
     nokogiri (1.6.0-x86-mingw32)
@@ -342,7 +342,7 @@ DEPENDENCIES
   memcache-client
   mysql2
   newrelic-redis
-  newrelic_rpm (= 3.7.2.192)
+  newrelic_rpm (= 3.8.0.218)
   nokogiri (>= 1.4.2)
   paperclip
   permit_yo


### PR DESCRIPTION
Ruby VM measurements

The Ruby agent now records more detailed information about the performance and behavior of the Ruby VM, mainly focused around Ruby's garbage collector. This information is exposed on the new 'Ruby VM' tab in the UI. For details about what is recorded, see:

http://docs.newrelic.com/docs/ruby/ruby-vm-stats

Separate in-transaction GC timings for web and background processes

Previously, an application with GC instrumentation enabled, and both web and background processes reporting in to it would show an overly inflated GC band on the application overview graph, because data from both web and non-web transactions would be included. This has been fixed, and GC time during web and non-web transactions is now tracked separately.
