### PR TITLE
Issue 3911 wrangle to fandoms

### DIFF
--- a/app/views/tag_wranglings/index.html.erb
+++ b/app/views/tag_wranglings/index.html.erb
@@ -129,7 +129,6 @@
         <%= hidden_field_tag :sort_column, params[:sort_column] %>
         <%= hidden_field_tag :sort_direction, params[:sort_direction] %>
         <%= hidden_field_tag :page, params[:page] %>
-        <%= hidden_field_tag(:fandom_string, params[:fandom_string]) if params[:fandom_string] %>
       </div>
     <% end %>
     <!--/content-->

--- a/app/views/tags/wrangle.html.erb
+++ b/app/views/tags/wrangle.html.erb
@@ -24,7 +24,7 @@
 <% if params[:show] %>
   <ul class="actions" role="navigation">
     <li><h4 class="heading"><%= ts('Show:') %></h4></li>
-    <li><%= span_if_current ts('All'), url_for(:show: params[:show], status: nil) %></li>
+    <li><%= span_if_current ts('All'), url_for(show: params[:show], status: nil) %></li>
     <li><%= span_if_current ts('Canonical'), url_for(show: params[:show], status: 'canonical') %></li>
     <li><%= span_if_current ts('Synonymous'), url_for(show: params[:show], status: 'synonymous'), nil, ts('non-canonical tags that are synonyms') %></li>
     <li><%= span_if_current ts('Unfilterable'), url_for(show: params[:show], status: 'unfilterable'), nil, ts('non-canonical tags without synonyms') %></li>
@@ -161,7 +161,6 @@
       <%= hidden_field_tag :sort_direction, params[:sort_direction] %>
       <%= hidden_field_tag :page, params[:page] %>
       <%= hidden_field_tag :status, params[:status] %>
-      <%= hidden_field_tag(:fandom_string, params[:fandom_string]) if params[:fandom_string] %>
     </div>
 
     <p class="submit actions"><%= submit_tag ts('Wrangle') %></p>


### PR DESCRIPTION
http://code.google.com/p/otwarchive/issues/detail?id=3911

Fixes the wrangling of multiple tags at once.

Also:
- tags on the Tag Wranglings pages (aka mass bins) can now be wrangled to multiple fandoms at once, to mitigate the problem of crossover tags being put in only one of the fandoms
- more notice and error messages where needed and appropriate
- obliterates tabs and turns them into spaces
- changes hash syntax from rocket (=>) to colon (:) where I had already changed some rows
- changes " to ' around Ruby strings where possible (i.e. no interpolation in the string) (you have Ariana to thank for that ;P )

The tag wrangle action is more verbose than the tag_wranglings index: it lists the successful changes as well as the errors. This was on purpose, but can be changed if needed.
