### PR TITLE
3621 Remove individual deleted work from history

### DIFF
--- a/app/views/readings/_reading_blurb.html.erb
+++ b/app/views/readings/_reading_blurb.html.erb
@@ -27,7 +27,7 @@
         <% end %>
 
         <% if reading.view_count == 1 %>
-          <%= ts('Viewed once')%>
+          <%= ts('Viewed once') %>
         <% else %>
           <%= ts('Viewed %{count} times', :count => reading.view_count) %>
         <% end %>


### PR DESCRIPTION
https://code.google.com/p/otwarchive/issues/detail?id=3621

There was no way to delete a work placeholder from your history. Now there is. No tests included because it's not possible to delete history items without JavaScript at the moment.
