### PR TITLE
4008 Links in login block squished

### DIFF
--- a/app/views/user_sessions/_passwd_small.html.erb
+++ b/app/views/user_sessions/_passwd_small.html.erb
@@ -10,16 +10,17 @@
     <label for="user_session_remember_me" class="action"><%= check_box_tag "user_session[remember_me]", 1, false, :id => 'user_session_remember_me' %><%= ts('Remember Me') %></label>
     <%= f.submit ts("Log In") %>
   </p>    
-  <ul class="footnote actions">
-  	<li><%= link_to ts("Forgot password?"), new_password_path %></li>
-  	<% if @admin_settings.account_creation_enabled? %>
-      <li>
-        <%= link_to ts("Sign Up"), new_user_path %>
-      </li>
-    <% elsif @admin_settings.invite_from_queue_enabled? %>
-      <li>
-        <%= link_to ts('Get Invite'), invite_requests_path %>
-      </li>
-    <% end %>
-  </ul>
 <% end %>
+
+<ul class="footnote actions">
+  <li><%= link_to ts("Forgot password?"), new_password_path %></li>
+  <% if @admin_settings.account_creation_enabled? %>
+    <li>
+      <%= link_to ts("Sign Up"), new_user_path %>
+    </li>
+  <% elsif @admin_settings.invite_from_queue_enabled? %>
+    <li>
+      <%= link_to ts('Get Invite'), invite_requests_path %>
+    </li>
+  <% end %>
+</ul>

--- a/public/stylesheets/site/2.0/03-region-header.css
+++ b/public/stylesheets/site/2.0/03-region-header.css
@@ -214,11 +214,16 @@ notice that CSS3 declarations sit are indented twice (four spaces) and always co
 }
 
 #small_login .footnote {
+  float: left;
   font-size: 0.857em;
   padding: 0.375em 0;
 }
 
-#header .dropdown .login .footnote a {
+#small_login .footnote li {
+  padding: 0 0.25em;
+}
+
+.dropdown #small_login .footnote a {
   background: transparent;
   border-bottom: 1px solid;
 }


### PR DESCRIPTION
https://code.google.com/p/otwarchive/issues/detail?id=4008

The "Forgot password?" and "Get Invite" (or "Sign Up", when invitations are disabled) links in the log in form in the header didn't have a space between them. I've unsquished them, and also moved them out of the form element, since they had no business being there.
