### PR TITLE
3983 Escaped HTML in admin posts on home page

### DIFF
--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -27,8 +27,8 @@
     <% if @admin_posts %>
       <div class="news latest module">
         <h3 class="heading"><%= ts("News") %></h3>
-        <% @admin_posts.each do |f| %>
-          <p><%= link_to f.title, f %></p>
+        <% @admin_posts.each do |admin_post| %>
+          <p><%= link_to admin_post.title.html_safe, admin_post %></p>
         <% end %>
         <% if @admin_post_show_more %>
           <p><%= link_to h(ts('More news')) + '&#8230;'.html_safe, admin_posts_path %></p>

--- a/features/other/admin_post.feature
+++ b/features/other/admin_post.feature
@@ -147,6 +147,9 @@ Feature: Admin posts
     When I go to the admin-posts page
     Then I should see "App News & a <strong> Warning"
       And I should not see "App News &amp; a &lt;strong&gt; Warning"
+    When I go to the home page
+    Then I should see "App News & a <strong> Warning"
+      And I should not see "App News &amp; a &lt;strong&gt; Warning"
     When I am logged out as an admin
       And I go to the admin-posts page
     Then I should see "App News & a <strong> Warning"


### PR DESCRIPTION
https://code.google.com/p/otwarchive/issues/detail?id=3983

The news listing on the home page was still showing `&lt;` and all that fun stuff because it wasn't `html_safe`. I also renamed the iteration variable from `f` to `admin_post` so next time we must do something to admin_post, it'll be easier to track down.
