### PR TITLE
2776 Advanced shouldn't be open if no media is set

### DIFF
--- a/app/helpers/skins_helper.rb
+++ b/app/helpers/skins_helper.rb
@@ -48,7 +48,7 @@ module SkinsHelper
   def show_advanced_skin?(skin)
     !skin.new_record? && 
       (skin.role != Skin::DEFAULT_ROLE ||
-        skin.media != Skin::DEFAULT_MEDIA ||
+        (skin.media.present? && skin.media != Skin::DEFAULT_MEDIA) ||
         skin.ie_condition.present? ||
         skin.unusable? ||
         !skin.skin_parents.empty?)


### PR DESCRIPTION
By default, there are no media checkboxes selected, so the Advanced section should not be open when that is the case.

https://code.google.com/p/otwarchive/issues/detail?id=2776
