### PR TITLE
3087 Update to work with the even/odd class removal

### DIFF
--- a/public/stylesheets/site/2.0/10-types-groups.css
+++ b/public/stylesheets/site/2.0/10-types-groups.css
@@ -212,7 +212,7 @@ dl.stats dd {
  padding: 0.643em 0.375em;
 }
 
-.statistics .even {
+.statistics li:nth-of-type(even) {
   background: #eee;
 }
 


### PR DESCRIPTION
https://code.google.com/p/otwarchive/issues/detail?id=3087

We merged the pull request that got rid of the even and odd classes, so the old `.even` style from sandbox should be done with pseudo classes.
