### PR TITLE
4018 Notes on multichaptered drafts causing errors

### DIFF
--- a/app/helpers/works_helper.rb
+++ b/app/helpers/works_helper.rb
@@ -105,9 +105,15 @@ module WorksHelper
   end
   
   def get_endnotes_link
-    current_page?(:controller => 'chapters', :action => 'show') ?
-      chapter_path(@work.last_posted_chapter.id, :anchor => 'work_endnotes') :
+    if current_page?(:controller => 'chapters', :action => 'show')
+      if @work.posted?
+        chapter_path(@work.last_posted_chapter.id, :anchor => 'work_endnotes')
+      else
+        chapter_path(@work.last_chapter.id, :anchor => 'work_endnotes')
+      end
+    else 
       "#work_endnotes"
+    end
   end
   
   def get_related_works_url

--- a/app/views/chapters/show.html.erb
+++ b/app/views/chapters/show.html.erb
@@ -9,42 +9,43 @@
 
 <!--subnav-->
 <% if logged_in_as_admin? %>
-<%= render :partial => 'admin/admin_options', :locals => {:item => @work} %>
+  <%= render :partial => 'admin/admin_options', :locals => {:item => @work} %>
 <% end %>
 <!--/subnav-->
 
 <% if !@work.unrevealed? || logged_in_as_admin? || is_author_of?(@work) || (@work.unrevealed? && can_see_work(@work, current_user)) %>
-<!-- BEGIN work -->
-<div class="work"><p class="landmark"><a name="top">&nbsp;</a></p>
-  <%= render :partial => 'works/work_header' %>
+  <!-- BEGIN work -->
+  <div class="work"><p class="landmark"><a name="top">&nbsp;</a></p>
+    <%= render :partial => 'works/work_header' %>
 
-  <div id="chapters">
-    <%= render :partial => 'chapters/chapter', :locals => { :chapter => @chapter } %>
-  </div>
+    <div id="chapters">
+      <%= render :partial => 'chapters/chapter', :locals => { :chapter => @chapter } %>
+    </div>
   
-  <% inspired_by = get_inspired_by(@work) %>
-  <% if @chapter == @work.last_posted_chapter && (!@work.endnotes.blank? || !@work.series.blank? || !inspired_by.empty?) %>
-  <!--afterword-->
-  <div class="afterword preface group" role="complementary">  
-    <% if !@work.endnotes.blank? %>
-      <%= render :partial => 'works/work_endnotes' %>
+    <% inspired_by = get_inspired_by(@work) %>
+    <% last_chapter = @work.posted? ? @work.last_posted_chapter : @work.last_chapter %>
+    <% if @chapter == last_chapter && (@work.endnotes.present? || @work.series.present? || inspired_by.present?) %>
+      <!--afterword-->
+      <div class="afterword preface group" role="complementary">  
+        <% if !@work.endnotes.blank? %>
+          <%= render :partial => 'works/work_endnotes' %>
+        <% end %>
+        <% unless @preview_mode || @work.series.blank? %>
+          <%= render :partial => 'works/work_series_links' %>
+        <% end %>
+        <% unless inspired_by.empty? %>
+          <%= render :partial => 'works/work_approved_children', :locals => {:inspired_by => inspired_by} %>
+        <% end %>
+      </div>
+      <!--/afterword-->
     <% end %>
-    <% unless @preview_mode || @work.series.blank? %>
-      <%= render :partial => 'works/work_series_links' %>
-    <% end %>
-    <% unless inspired_by.empty? %>
-      <%= render :partial => 'works/work_approved_children', :locals => {:inspired_by => inspired_by} %>
-    <% end %>
-  </div>
-  <!--/afterword-->
-  <% end %>
   
+    </div>
+    <!-- END work skin -->
   </div>
-  <!-- END work skin -->
-</div>
-<!-- END work -->
+  <!-- END work -->
 
-<!-- BEGIN comment section -->
-<%= render :partial => 'comments/commentable', :locals => {:commentable => @chapter} %>
-<!-- END comment section -->
+  <!-- BEGIN comment section -->
+  <%= render :partial => 'comments/commentable', :locals => {:commentable => @chapter} %>
+  <!-- END comment section -->
 <% end %>

--- a/features/step_definitions/series_steps.rb
+++ b/features/step_definitions/series_steps.rb
@@ -2,6 +2,15 @@ When /^I view the series "([^\"]*)"$/ do |series|
   visit series_url(Series.find_by_title!(series))
 end
 
+When /^I add the series "([^\"]*)"$/ do |series_title|
+  check("series-options-show")  
+  if Series.find_by_title(series_title)
+    step %{I select "#{series_title}" from "work_series_attributes_id"}
+  else
+    fill_in("work_series_attributes_title", :with => series_title)
+  end
+end
+
 When /^I add the work "([^\"]*)" to series "([^\"]*)"(?: as "([^"]*)")?$/ do |work_title, series_title, pseud|
   work = Work.find_by_title(work_title)
   if work.blank?
@@ -22,13 +31,14 @@ When /^I add the work "([^\"]*)" to series "([^\"]*)"(?: as "([^"]*)")?$/ do |wo
     select(pseud, :from => "work_author_attributes_ids_")
   end
   
-  check("series-options-show")  
-  if Series.find_by_title(series_title)
-    step %{I select "#{series_title}" from "work_series_attributes_id"}
-  else
-    fill_in("work_series_attributes_title", :with => series_title)
-  end
+  step %{I add the series "#{series_title}"}
   click_button("Post Without Preview")
+end
+
+When /^I add the draft "([^\"]*)" to series "([^\"]*)"$/ do |work_title, series_title|
+  step %{I edit the work "#{work_title}"}
+  step %{I add the series "#{series_title}"}
+  click_button("Save Without Posting")
 end
 
 When /^I add the work "([^\"]*)" to "(\d+)" series "([^\"]*)"$/ do |work_title, count, series_title|

--- a/features/step_definitions/work_steps.rb
+++ b/features/step_definitions/work_steps.rb
@@ -109,6 +109,11 @@ When /^I post the chaptered work "([^\"]*)"$/ do |title|
   Work.tire.index.refresh
 end
 
+When /^I post the chaptered draft "([^\"]*)"$/ do |title|
+  step %{the draft "#{title}"}
+  step %{a draft chapter is added to "#{title}"}
+end
+
 When /^I post the work "([^\"]*)" in the collection "([^\"]*)"$/ do |title, collection|
   work = Work.find_by_title(title)
   if work.blank?

--- a/features/works/work_drafts.feature
+++ b/features/works/work_drafts.feature
@@ -118,3 +118,23 @@ Feature: Work Drafts
       When I edit the draft "Walking Into Mordor"
         And I press "Preview"
       Then I should see "Draft was successfully created. It will be automatically deleted on"
+
+    Scenario: A chaptered draft should be able to have beginning and end notes, and it should display them.
+      Given I am logged in as "composer"
+        And I post the chaptered draft "Epic in Progress"
+      When I edit the draft "Epic in Progress"
+        And I add the beginning notes "Some beginning notes."
+        And I add the end notes "Some end notes."
+        And I press "Save Without Posting"
+      Then I should see "Some beginning notes."
+        And I should see "See the end of the work for more notes."
+      When I follow "more notes"
+      Then I should see "Some end notes."
+
+      Scenario: If a chaptered draft belongs to a series, the series should be listed on the draft
+        Given I am logged in as "two_can_sam"
+          And I post the chaptered draft "Cereal Serial"
+        When I add the draft "Cereal Serial" to series "Aisle 5"
+          And I follow "Next Chapter"
+        Then I should see "Series this work belongs to:"
+          And I should see "Aisle 5"


### PR DESCRIPTION
https://code.google.com/p/otwarchive/issues/detail?id=4018

If a chaptered draft had notes, you'd get the error, "Called id for nil, which would mistakenly be 4 -- if you really wanted the id of nil, use object_id." This was on line `<% endnotes_link = link_to (@work.notes.blank? ? ts("notes") : ts("more notes")), get_endnotes_link %>` due to the `get_endnotes_link` method:

```
  def get_endnotes_link
    current_page?(:controller => 'chapters', :action => 'show') ?
      chapter_path(@work.last_posted_chapter.id, :anchor => 'work_endnotes') :
      "#work_endnotes"
  end
```
