### PR TITLE
3087 Verbose class needs to be on form not fieldset

### DIFF
--- a/app/views/skins/_form.html.erb
+++ b/app/views/skins/_form.html.erb
@@ -9,7 +9,7 @@
     <% else %>      
       <dd>
         <%= select_tag 'skin_type', options_for_select(Skin::TYPE_OPTIONS, @skin.type || params[:skin_type] ),
-          :onchange => 'if ($j(this).val() == "WorkSkin") {$j(".verbose").hide();} else {$j(".verbose").show();}' %>
+          :onchange => 'if ($j(this).val() == "WorkSkin") {$j("#advanced_skin_fieldset").hide();} else {$j("#advanced_skin_fieldset").show();}' %>
       </dd>
     <% end %>
   
@@ -33,7 +33,7 @@
   <p><%= f.text_area :css, :cols => 70, :class => 'large' %></p>
 </fieldset>
   
-<fieldset class="verbose<%= (@skin.type || params[:skin_type]) == 'WorkSkin' ? ' hidden' : ''%>">
+<fieldset id="advanced_skin_fieldset" class="<%= (@skin.type || params[:skin_type]) == 'WorkSkin' ? 'hidden ' : ''%>">
   <legend><%= ts('Advanced') %>
     <a href="#" class="advanced_skin_open action hidden"><%= ts('Show') %> &#8595;</a>
     <a href="#" class="advanced_skin_close action hidden"><%= ts('Hide') %> &#8593;</a>

--- a/app/views/skins/new.html.erb
+++ b/app/views/skins/new.html.erb
@@ -19,7 +19,7 @@
 <!--main content-->
 <h3 class="landmark heading"><%= ts('Create New Skin') %></h3>
 
-<%= form_for @skin, :html => {:multipart => true} do |f| %>
+<%= form_for @skin, :html => {:multipart => true, :class => "skin verbose post"} do |f| %>
   <%= render 'form', :f => f %>
 <% end %>
 <!--/content-->


### PR DESCRIPTION
https://code.google.com/p/otwarchive/issues/detail?id=3087

The advanced section of the skin form went missing because the verbose class was on a fieldset rather than the form itself. (I checked the rest of the views for "verbose" and no other forms had the problem.)
