### PR TITLE
Issue 3995: And X more kudos message should be correctly pluralized

### DIFF
--- a/app/views/kudos/_kudos.html.erb
+++ b/app/views/kudos/_kudos.html.erb
@@ -12,7 +12,7 @@
               to_sentence(:last_word_connector => ', ').
               html_safe + ', ' %>
           <%= link_to work_kudos_path(commentable), :id => "kudos_summary" do %>
-            collapsed_count = kudos.length - ArchiveConfig.MAX_KUDOS_TO_SHOW
+           <% collapsed_count = kudos.length - ArchiveConfig.MAX_KUDOS_TO_SHOW %>
             <% if collapsed_count == 1 %>
               <%= ts(' and 1 more user') %>
             <% else %>


### PR DESCRIPTION
Resolves issue: https://code.google.com/p/otwarchive/issues/detail?id=3995

Checks to see how many remaining Kudos there are. If there is only 1, it says "user" otherwise it says "users". 
