### PR TITLE
4034 Tooltip wording change when nominations are closed

### DIFF
--- a/app/helpers/tag_sets_helper.rb
+++ b/app/helpers/tag_sets_helper.rb
@@ -44,6 +44,9 @@ module TagSetsHelper
   end
   
   def nomination_status(nomination=nil)
+    symbol = "?!"
+    status = "unreviewed"
+    tooltip = ts('This nomination has not been reviewed yet.')
     if nomination
       if nomination.approved
         symbol = "&#10004;"
@@ -57,10 +60,6 @@ module TagSetsHelper
         symbol = "?!"
         status = "unreviewed"
         tooltip = ts('This nomination has not been reviewed yet and can still be changed.')
-      else
-        symbol = "?!"
-        status = "unreviewed"
-        tooltip = ts('This nomination has not been reviewed yet.')
       end
     end
 


### PR DESCRIPTION
https://code.google.com/p/otwarchive/issues/detail?id=4034

When nominations are closed, the tooltip shouldn't say nominations can be edited.
