### PR TITLE
3750 Expire cache on work modules

### DIFF
--- a/app/views/works/_work_module.html.erb
+++ b/app/views/works/_work_module.html.erb
@@ -24,7 +24,7 @@
       <%= byline(work) %>
 
 <% #### CACHE show/hide #### %>
-<% cache("#{work.cache_key}-#{hide_warnings?(work) ? 'nowarn' : 'showwarn'}-#{hide_freeform?(work)  ? 'nofreeform' : 'showfreeform'}-v2") do %>
+<% cache("#{work.cache_key}-#{hide_warnings?(work) ? 'nowarn' : 'showwarn'}-#{hide_freeform?(work)  ? 'nofreeform' : 'showfreeform'}-v3") do %>
 
       <% tag_groups = work.tags.group_by { |t| t.type.to_s } %>
   


### PR DESCRIPTION
http://code.google.com/p/otwarchive/issues/detail?id=3750

Blurbs for works and bookmarks (which use the work module) were still showing "Author Chose Not To Use Archive Warnings" due to caching.
