### PR TITLE
2012-07-10 is now more than 2 years ago

### DIFF
--- a/features/works/work_search.feature
+++ b/features/works/work_search.feature
@@ -59,7 +59,7 @@ Feature: Search Works
     When I am on the search works page
     When I fill in "Date" with "> 2 years ago"
       And I press "Search" within "form#new_work_search"
-    Then I should see "4 Found"
+    Then I should see "5 Found"
     When I follow "Edit Your Search"
     Then I should be on the search works page
     When I fill in "Word Count" with ">15000"


### PR DESCRIPTION
```
    When I am on the search works page
    When I fill in "Date" with "> 2 years ago"
      And I press "Search" within "form#new_work_search"
    Then I should see "4 Found"
```

That test was failing because there are now five works with a revised_at date of more than 2 years ago. (third work's revised_at date is 2012-07-10, so it just had a birthday.)
