### PR TITLE
Issue 2661: Fixes for clearing tag set nominations

### DIFF
--- a/app/views/owned_tag_sets/_navigation.html.erb
+++ b/app/views/owned_tag_sets/_navigation.html.erb
@@ -12,16 +12,14 @@
       <% end %>
     <% end %>
     <% if @tag_set.user_is_owner?(current_user) %>
-      <li><%= link_to ts("Clear Nominations"), confirm_destroy_multiple_tag_set_nominations_path(@tag_set),
-        :confirm => ts("Are you certain you want to clear nominations for this Tag Set? (This will NOT affect the tags already in your set, but it will clear the history of rejected tags and users will be able to nominate again.)"),
-        :method => :post %></li>
+      <li><%= link_to ts("Clear Nominations"), confirm_destroy_multiple_tag_set_nominations_path(@tag_set) %></li>
       <li><%= span_if_current ts("Batch Load"), batch_load_tag_set_path(@tag_set) %></li>
       <li><%= span_if_current ts("Edit"), edit_tag_set_path(@tag_set) %></li>
       <li role="button"><%= link_to ts("Delete"), confirm_delete_tag_set_path(@tag_set),
         :confirm => ts('Are you certain you want to delete this Tag Set? This will delete all nominations and tag set associations as well!') %></li>
     <% end %>
     <% unless current_page?(tag_set_path(@tag_set)) %>
-      <li><%= link_to ts("Back To %{title}", :title => @tag_set.title), tag_set_path(@tag_set) %></li>  
+      <li><%= link_to ts("Back To %{title}", :title => @tag_set.title), tag_set_path(@tag_set) %></li>
     <% end %>
     <li><%= link_to ts("All Tag Sets"), tag_sets_path %></li>
   </ul>

--- a/app/views/tag_set_nominations/confirm_destroy_multiple.html.erb
+++ b/app/views/tag_set_nominations/confirm_destroy_multiple.html.erb
@@ -2,7 +2,7 @@
 <h2 class="heading"><%= ts("Clear all Tag Set Nominations?") %></h2>
 
 <!--main content-->
-<%= form_for(@tag_set, :url => destroy_multiple_tag_set_nominations_path(@tag_set), :html => {:class => "simple destroy"}, method: :post) do |f| %>
+<%= form_for(@tag_set, :url => destroy_multiple_tag_set_nominations_path(@tag_set), :html => {:class => "simple destroy"}, method: :delete) do |f| %>
   <p><%= ts("Are you certain you want to clear all Tag Set Nominations?") %></p>
   <p>
     <%= f.submit ts("Yes, Clear Tag Set Nominations") %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -84,7 +84,7 @@ Otwarchive::Application.routes.draw do
     resources :nominations, :controller => 'tag_set_nominations' do
       collection do
         put  :update_multiple
-        post :destroy_multiple
+        delete :destroy_multiple
         get  :confirm_destroy_multiple
       end
       member do


### PR DESCRIPTION
Issue 2661: Fixes for clearing tag set nominations

(Fix for BOT issue: the behavior with and without javascript is now the same. The usual no-js method wouldn't work because the urls have a different format, and this is a bit safer anyway.)

https://code.google.com/p/otwarchive/issues/detail?id=2661
