### PR TITLE
3251 Redirect to the page you came from when unsubscribing

### DIFF
--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -50,7 +50,7 @@ class SubscriptionsController < ApplicationController
     respond_to do |format|
       format.html {
         flash[:notice] = ts("You have successfully unsubscribed from %{name}.", :name => @subscription.name).html_safe
-        redirect_back_or_default(@subscribable)
+        redirect_to request.referer || user_subscriptions_path(current_user)
       }
     end
   end


### PR DESCRIPTION
https://code.google.com/p/otwarchive/issues/detail?id=3251

Updates #1429.

When possible, redirect a user back to the page they were on when they clicked the Unsubscribe button. Otherwise, fall back to their subscriptions page.
