### PR TITLE
Add persistence_token for users

### DIFF
--- a/features/fixtures/users.yml
+++ b/features/fixtures/users.yml
@@ -3,16 +3,16 @@ testuser:
   login: testuser
   email: test@example.com
   activated_at: 2009-12-12 21:08:07 +00:00
-  persistence_token: foo
+  persistence_token: foo1
 testuser2:
   id: 2
   login: testuser2
   email: test2@example.com
   activated_at: 2009-12-12 21:08:07 +00:00
-  persistence_token: foo
+  persistence_token: foo2
 sad_user_with_no_pseuds:
   id: 3
   login: sad_user_with_no_pseuds
   email: test3@example.com
   activated_at: 2009-12-12 21:08:07 +00:00
-  persistence_token: foo
+  persistence_token: foo3


### PR DESCRIPTION
Attempting to run fixture-loading tests locally gives this error:

`Mysql2::Error: Field 'persistence_token' doesn't have a default value: INSERT INTO `users` (`id`, `login`, `email`, `activated_at`, `created_at`, `updated_at`) VALUES (1, 'testuser', 'test@example.com', '2009-12-12 21:08:07', '2014-08-22 05:36:52', '2014-08-22 05:36:52') (ActiveRecord::StatementInvalid)
./features/step_definitions/fixtures_steps.rb:5:in `/^I have loaded the fixtures$/'`

This adds a persistence_token so the tests will run. (This finishes what https://github.com/otwcode/otwarchive/pull/1574 started.)
