### PR TITLE
3859 Works don't have noindex meta when noindex preference is set

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -10,7 +10,7 @@
     <meta name="distribution" content="GLOBAL" />
     <meta name="classification" content="transformative works" />
     <meta name="author" content="Organization for Transformative Works" />
-    <% if @user && @user.try(:preference).try(:minimize_search_engines?) %>
+    <% if @user && @user.try(:preference).try(:minimize_search_engines?) || @work && @work.users.all? {|u| u.try(:preference).try(:minimize_search_engines?)} %>
       <meta name="robots" content="noindex" />
       <meta name="googlebot" content="noindex" />
     <% end %>


### PR DESCRIPTION
https://code.google.com/p/otwarchive/issues/detail?id=3859

We were correctly inserting this into the page `<head>` on user pages, but not on works themselves:

```
      <meta name="robots" content="noindex" />
      <meta name="googlebot" content="noindex" />
```

Now it will be inserted on works if all authors have the "Hide my work from search engines when possible" preference set. (I went with all authors because that's what we use for the "Hide the share buttons on my work" preference.)
