### PR TITLE
Issue 4078: Tag cache key consistency

### DIFF
--- a/lib/works_owner.rb
+++ b/lib/works_owner.rb
@@ -45,7 +45,8 @@ module WorksOwner
   private
   
   def redis_works_index_key
-    "#{self.class.to_s.downcase}_#{self.id}_windex"
+    klass = self.is_a?(Tag) ? 'tag' : self.class.to_s.underscore
+    "#{klass}_#{self.id}_windex"
   end
   
 end


### PR DESCRIPTION
Issue 4078: Tag cache key consistency

Calling "self.class" on different kinds of tags in different places was leading to failures in cache invalidation.
