### PR TITLE
4096 Mobile style tweaks for admin banner and its thermometer

### DIFF
--- a/public/stylesheets/site/2.0/25-role-handheld.css
+++ b/public/stylesheets/site/2.0/25-role-handheld.css
@@ -104,6 +104,25 @@ h1, h2, h3 {
   width: auto;
 }
 
+/* system: messages */
+
+.announcement .userstuff {
+  margin: 1%;
+}
+
+.announcement p.submit {
+  bottom: -0.5em;
+  right: 1%;
+}
+
+.announcement .thermometer-content {
+  width: 80%;
+}
+
+.announcement .thermometer .amount {
+  display: none;
+}
+
 /*SKIN: Dash Line */
 
 /* DESCRIPTION: Horizontal dash inline*/


### PR DESCRIPTION
https://code.google.com/p/otwarchive/issues/detail?id=4096
- Hide the numbers on the thermometer, since they're already in the text and tend to get cut off when added to the thermometer
- Make the thermometer a bit wider
- Reduce the margins on the banner
