### PR TITLE
4096 Left-align mobile progress amount so large numbers work

### DIFF
--- a/public/stylesheets/site/2.0/25-role-handheld.css
+++ b/public/stylesheets/site/2.0/25-role-handheld.css
@@ -123,6 +123,11 @@ h1, h2, h3 {
   display: none;
 }
 
+.announcement .thermometer .progress .amount {
+  left: 0;
+  right: auto;
+}
+
 /*SKIN: Dash Line */
 
 /* DESCRIPTION: Horizontal dash inline*/


### PR DESCRIPTION
https://code.google.com/p/otwarchive/issues/detail?id=4096

Big progress numbers were getting cut off when they were only a small percentage of the goal (e.g. $25,000 progress of a $1,000,000 goal). This aligns the progress amount with the left edge of the thermometer so that won't happen.
