### PR TITLE
4144 Add blank option to Is this a translation of another post?

### DIFF
--- a/app/views/admin_posts/_admin_post_form.html.erb
+++ b/app/views/admin_posts/_admin_post_form.html.erb
@@ -50,7 +50,7 @@
           <%= f.label :translated_post_id, ts("Is this a translation of another post?") %>
         </dt>
         <dd>
-          <%= f.collection_select(:translated_post_id, @translatable_posts, :id, :title, {:prompt => true}) %>
+          <%= f.collection_select(:translated_post_id, @translatable_posts, :id, :title, {:include_blank => true}) %>
         </dd>
       </dl>
     </fieldset>

--- a/features/admins/admin_post_news.feature
+++ b/features/admins/admin_post_news.feature
@@ -81,6 +81,17 @@ Feature: Admin Actions to Post News
     When I make a translation of an admin post
       And I am logged in as "ordinaryuser"
     Then I should see a translated admin post
+    
+  Scenario: Make a translation of an admin post stop being a translation
+    Given I have posted an admin post
+      And basic languages
+      And I am logged in as an admin
+      And I make a translation of an admin post
+    When I follow "Edit Post"
+      And I select "" from "Is this a translation of another post?"
+      And I press "Post"
+    When I am logged in as "ordinaryuser"
+    Then I should not see a translated admin post
 
   Scenario: Log in as an admin and create an admin post with tags
     Given I have no users

--- a/features/step_definitions/admin_steps.rb
+++ b/features/step_definitions/admin_steps.rb
@@ -218,3 +218,11 @@ Then (/^I should see a translated admin post$/) do
   step(%{I follow "Deutsch Ankuendigung"})
   step(%{I should see "Deutsch Woerter"})
 end
+
+Then (/^I should not see a translated admin post$/) do
+  step(%{I go to the admin-posts page})
+  step(%{I should see "Default Admin Post"})
+  step(%{I should see "Deutsch Ankuendigung"})
+  step(%{I follow "Default Admin Post"})
+  step(%{I should not see "Translations: Deutsch Deutsch Ankuendigung"})
+end


### PR DESCRIPTION
https://code.google.com/p/otwarchive/issues/detail?id=4144

For admin posts, if you accidentally selected a post in "Is this a translation of another post?", you couldn't remove it. This was bad because it meant news posts could disappear from the front page. Now there's a blank option so you can undo your whoopsie.
