### PR TITLE
4152 Allow users to set multiple categories on external works

### DIFF
--- a/app/views/bookmarks/_external_work_fields.html.erb
+++ b/app/views/bookmarks/_external_work_fields.html.erb
@@ -65,10 +65,17 @@
       <%= ew.collection_select(:rating_string, Rating.canonical.by_name, :name, :name, {:selected => ArchiveConfig.RATING_DEFAULT_TAG_NAME}) %>
     </dd>
     <dt>
-      <%= ew.label :category_string, Category::NAME %> <%= link_to_help "categories-help" %>
+      <%= Category::NAME %> <%= link_to_help "categories-help" %>
     </dt>
     <dd>
-      <%= ew.collection_select(:category_string, Category.canonical.by_name.sort, :name, :name, {:include_blank => true}) %>
+      <ul>
+        <% for tag in Category.canonical.by_name.sort %>
+          <li>               
+            <%= check_box_tag "bookmark[external][category_string][]", tag.name, false, id: "bookmark_external_category_string_#{tag.id}" %>
+            <%= label_tag "bookmark_external_category_string_#{tag.id}", tag.name %>
+          </li>
+        <% end %> 
+      </ul>
     </dd>
     <dt>
       <%= ew.label :relationship_string, Relationship::NAME.pluralize %> <%= link_to_help "relationships-help" %>


### PR DESCRIPTION
https://code.google.com/p/otwarchive/issues/detail?id=4152

Use checkboxes instead of a select so users can set multiple categories on external works.
