### PR TITLE
Issue 3742 - Always show the Chapter title as a link.

### DIFF
--- a/app/views/chapters/_chapter.html.erb
+++ b/app/views/chapters/_chapter.html.erb
@@ -13,7 +13,7 @@
 
   <div class="chapter<%= ' preface' unless @preview_mode %> group" role="complementary">
     <h3 class="title">
-      <% if !current_page?(:controller => 'chapters', :action => 'show') %><%= link_to chapter.chapter_header, [chapter.work, chapter] %><% else %><%= chapter.chapter_header %><% end %><% unless chapter.title.blank? %>: <%= chapter.title.html_safe %><% end %>
+      <%= link_to chapter.chapter_header, [chapter.work, chapter] %><% unless chapter.title.blank? %>: <%= chapter.title.html_safe %><% end %>
     </h3>
 
     <!-- only display byline if different from the main byline -->


### PR DESCRIPTION
Fixes https://code.google.com/p/otwarchive/issues/detail?id=3742

I'm removing the conditional in the template, so the chapter title _always_ displays as a link, when viewing the entire work or just that chapter. If we want to hide the link when just viewing a single chapter (since it doesn't go anywhere), we should probably do that in the front-end (via JavaScript or even CSS to make it stand out less), rather than trying to refresh the template from the cache when the user changes view mode. :)
