### PR TITLE
3883 Include works from December 31 in stats totals for the year

### DIFF
--- a/app/controllers/stats_controller.rb
+++ b/app/controllers/stats_controller.rb
@@ -43,8 +43,9 @@ class StatsController < ApplicationController
     @years = ["All Years"] + user_works.value_of(:revised_at).map {|date| date.year.to_s}.uniq.sort
     @current_year = @years.include?(params[:year]) ? params[:year] : "All Years"
     if @current_year != "All Years"
+      next_year = @current_year.to_i + 1
       start_date = DateTime.parse("01/01/#{@current_year}")
-      end_date = DateTime.parse("31/12/#{@current_year}")
+      end_date = DateTime.parse("01/01/#{next_year}")
       work_query = work_query.where("works.revised_at >= ? AND works.revised_at <= ?", start_date, end_date)
     end
     # NOTE: eval is used here instead of send only because you can't send "bookmarks.count" -- avoid eval


### PR DESCRIPTION
https://code.google.com/p/otwarchive/issues/detail?id=3883

```
start_date = DateTime.parse("01/01/#{@current_year}")
end_date = DateTime.parse("31/12/#{@current_year}")
work_query = work_query.where("works.revised_at >= ? AND works.revised_at <= ?", start_date, end_date)
```

Basically, it wasn't getting the works from 31/12 when it was tallying kudos or what have you. Changing it to `01/01/#{next_year}` where `next_year = current_year.to_i + 1` does the trick because 31/12 is included in the range.
