### PR TITLE
4092 Fix restricted character error message for tag nominations

### DIFF
--- a/app/models/tagset_models/tag_nomination.rb
+++ b/app/models/tagset_models/tag_nomination.rb
@@ -11,7 +11,7 @@ class TagNomination < ActiveRecord::Base
   validates_format_of :tagname,
     :if => "!tagname.blank?",
     :with => /\A[^,*<>^{}=`\\%]+\z/,
-    :message => ts("^Tag nominations cannot include the following restricted characters: , &#94; * < > { } = ` \\ %").html_safe
+    :message => ts("^Tag nominations cannot include the following restricted characters: , &#94; * < > { } = ` \\ %")
 
   validate :type_validity
   def type_validity


### PR DESCRIPTION
https://code.google.com/p/otwarchive/issues/detail?id=4092

The `^` was causing the error message to get cut off, so now it's replaced with `&#94;` The phrasing change is so all of these errors will have close to the same wording.
