### PR TITLE
4162 Fix restricted characters error message for tag creation

### DIFF
--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -96,7 +96,7 @@ class Tag < ActiveRecord::Base
     :message => "of tag is too long -- try using less than #{ArchiveConfig.TAG_MAX} characters or using commas to separate your tags."
   validates_format_of :name,
     :with => /\A[^,*<>^{}=`\\%]+\z/,
-    :message => 'of a tag can not include the following restricted characters: , ^ * < > { } = ` \\ %'
+    :message => 'of a tag cannot include the following restricted characters: , &#94; * < > { } = ` \\ %'
 
   validates_presence_of :sortable_name
     


### PR DESCRIPTION
https://code.google.com/p/otwarchive/issues/detail?id=4162

The `^` was causing the error message to get cut off, so now it's replaced with `&#94;` The phrasing change is so all of these errors will have close to the same wording.
