### PR TITLE
4069 Restricted characters error message for tag set title

### DIFF
--- a/app/models/tagset_models/owned_tag_set.rb
+++ b/app/models/tagset_models/owned_tag_set.rb
@@ -44,7 +44,7 @@ class OwnedTagSet < ActiveRecord::Base
     :too_long=> ts("must be less than %{max} characters long.", :max => ArchiveConfig.TITLE_MAX)
   validates_format_of :title,
     :with => /\A[^,*<>^{}=`\\%]+\z/,
-    :message => '^The title of a tag set cannot include the following restricted characters: , &#94; * < > { } = ` \\ %'.html_safe
+    :message => '^The title of a tag set cannot include the following restricted characters: , &#94; * < > { } = ` \\ %'
 
   validates_length_of :description,
     :allow_blank => true,


### PR DESCRIPTION
https://code.google.com/p/otwarchive/issues/detail?id=4069

The `^` was causing the error message to get cut off, so now it's replaced with `&#94;` The phrasing change is so all of these errors will have close to the same wording.
