### PR TITLE
4165 - Fix spurious error message when importing for oneself while having archivist privileges

### DIFF
--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -526,7 +526,7 @@ class WorksController < ApplicationController
     end
     
     # is external author information entered when import for others is not checked?
-    if (!params[:external_author_name].blank? || !params[:external_author_email].blank?) && !params[:importing_for_others]
+    if (params[:external_author_name].present? || params[:external_author_email].present?) && !params[:importing_for_others]
       flash.now[:error] = ts("You have entered an external author name or e-mail address but did not select \"Import for others.\" Please select the \"Import for others\" option or remove the external author information to continue.")
       render :new_import and return
     end


### PR DESCRIPTION
Importing for yourself without entering an external author and email, with "Import for others" unticked resulted in the error message that should appear when the option is unticked and one of those fields is filled in.

https://code.google.com/p/otwarchive/issues/detail?id=4165

The code was originally checking for the presence of the external author and email fields, which are always present, rather than checking whether they were blank.
