### PR TITLE
4174 Bold h4 in userstuff

### DIFF
--- a/public/stylesheets/site/2.0/21-userstuff.css
+++ b/public/stylesheets/site/2.0/21-userstuff.css
@@ -86,6 +86,10 @@
   border-bottom: 0.25em double #333;
 }
 
+.userstuff h4 {
+  font-weight: 700;
+}
+
 .userstuff h5 {
   font-weight: 600;
   font-size: 1em;


### PR DESCRIPTION
https://code.google.com/p/otwarchive/issues/detail?id=4174

Make `h4` in `.userstuff` (e.g. works, FAQs) bold, since it otherwise blends in with the rest of the text too much
