### PR TITLE
3936 Don't count draft related works in sidebar

### DIFF
--- a/app/views/users/_sidebar.html.erb
+++ b/app/views/users/_sidebar.html.erb
@@ -54,7 +54,7 @@
     <li><%= span_if_current ts("Sign-ups (%{signup_number})", :signup_number =>@user.challenge_signups.count), user_signups_path(@user) %></li>
     <li><%= span_if_current ts("Assignments (%{assignment_number})", :assignment_number => (@user.offer_assignments.undefaulted.count + @user.pinch_hit_assignments.undefaulted.count)), user_assignments_path(@user) %></li>
     <li><%= span_if_current ts("Claims (%{claim_number})", :claim_number => (@user.request_claims.unposted.count)), user_claims_path(@user) %></li>
-    <li><%= span_if_current ts("Related Works (%{related_works_number})", :related_works_number => (@user.related_works.count + @user.parent_work_relationships.count)), user_related_works_path(@user) %></li>
+    <li><%= span_if_current ts("Related Works (%{related_works_number})", :related_works_number => (@user.related_works.posted.count + @user.parent_work_relationships.count)), user_related_works_path(@user) %></li>
   <% end %>
   <li><%= print_gifts_link(@user) %></li> 
 </ul>

--- a/features/works/work_related.feature
+++ b/features/works/work_related.feature
@@ -242,8 +242,7 @@ Scenario: Draft works should not show up on related works
     And I draft a translation
   When I am logged in as "inspiration"
     And I go to my user page
-  When "Issue 3936" is fixed
-  # Then I should not see "Related Works (1)"
+  Then I should not see "Related Works (1)"
   When I view my related works
   Then I should not see "Worldbuilding Translated"
 
@@ -367,3 +366,4 @@ Scenario: Restricted works listed as Inspiration show up [Restricted] for guests
     And the email should not contain "&lt;a href=&quot;http://archiveofourown.org/users/inspired/pseuds/inspired&quot;"
     And the email should link to misterdeejay's user url
     And the email should not contain "&lt;a href=&quot;http://archiveofourown.org/users/misterdeejay/pseuds/misterdeejay&quot;"
+  


### PR DESCRIPTION
https://code.google.com/p/otwarchive/issues/detail?id=3936

If someone posted a draft of a work that was related to yours, your side bar would show Related Works (1) even though you couldn't see the work yet. We only want it to count posted related works.
