### PR TITLE
Log scale tagging

### DIFF
--- a/app/helpers/tags_helper.rb
+++ b/app/helpers/tags_helper.rb
@@ -22,21 +22,30 @@ module TagsHelper
 
   # Adds the appropriate css classes for the tag index page
   def tag_cloud(tags, classes)
-    max, min = 0.0, 0.0
+    max, min = -1.0/0, 1.0/0
     tags.each { |t|
+      next if t.count.to_i == 0 # 0s make log scales sad
       max = Math.log(t.count.to_i) if Math.log(t.count.to_i) > max
       min = Math.log(t.count.to_i) if Math.log(t.count.to_i) < min
     }
 
     divisor = ((max - min) / classes.size)
-
     tags.each { |t|
-      class_idx = ((Math.log(t.count.to_i) - min) / divisor).floor
-      # handle upper edge case to prevent OOB access
-      if class_idx >= classes.size
-        class_idx = classes.size - 1
-      end    
-      yield t, classes[class_idx]
+      if divisor.infinite?
+        # all counts were 0
+        yield t, classes[0]
+      else
+        class_idx = ((Math.log(t.count.to_i) - min) / divisor)
+        # handle lower edge case to prevent OOB access
+        if class_idx.nan?
+          class_idx = 0.0
+        end
+        # handle upper edge case to prevent OOB access
+        if class_idx >= classes.size
+          class_idx = classes.size - 1
+        end
+        yield t, classes[class_idx.floor]
+      end
     }
   end
 


### PR DESCRIPTION
This is the same commit as before except this time I tested it in the vagrant image and I think it looks considerably better than what is currently live. See for yourself.

![screenshot from 2014-12-13 03 27 09](https://cloud.githubusercontent.com/assets/79513/5423553/77880a6a-8278-11e4-8146-d6a167fd4f7c.png)

There is an actual distribution of sizes and not just one or two giant tags in the most popular tab.

One note: the instructions on the wiki don't mention a few things you have to do. I'll list them here in case someone else hits it later. You have to run "Tag.add_missing_filter_taggings" followed by "FilterTagging.update_filter_counts_since('1970-01-01')"  (obviously after running the datbase migrations) for the tag ui to work from a fresh vagrant image. Took me a while to figure that out.
