### PR TITLE
3798 Filtered pagination on news fails if no language set

### DIFF
--- a/app/views/admin_posts/_filters.html.erb
+++ b/app/views/admin_posts/_filters.html.erb
@@ -3,6 +3,6 @@
   <p><%= label_tag :tag, ts("Tag:") %>
   <%= select_tag :tag, ('<option></option>' + options_from_collection_for_select(@tags, :id, :name, params[:tag])).html_safe %>
   <%= label_tag :language_id, ts("Language:") %>
-  <%= select_tag :language_id, (options_from_collection_for_select(Language.default_order, :short, :name, params[:language_id] || Language.default.short)).html_safe %>
+  <%= select_tag :language_id, options_from_collection_for_select(Language.default_order, :short, :name, params[:language_id] || Language.default.short) %>
   <%= submit_tag ts('Go') %></p>
 <% end %>


### PR DESCRIPTION
https://code.google.com/p/otwarchive/issues/detail?id=3798

If you filtered the news posts (admin_posts) by tag and did not select a language, when you attempted to navigate to the second page of results using the pagination links, you would get a 500 error. This is because the URL produced by the pagination expects language parameters: `http://test.ao3.org/languages//admin_posts?commit=Go&page=4&tag=13&utf8=✓` -- note the `//` where the short name for a language should be, e.g. `/en/`.

This pull request makes it so the language filter will be set to the Archive's default language unless the user selects a different language to filter by. We can do this because news posts are filtered to the Archive's default language automatically, so we're not depriving the user of the ability to see all news posts regardless of language.
