### PR TITLE
Fixes #4190: draft work shells left behind

### DIFF
--- a/app/models/serial_work.rb
+++ b/app/models/serial_work.rb
@@ -3,23 +3,22 @@ class SerialWork < ActiveRecord::Base
   belongs_to :work, :touch => true
   validates_uniqueness_of :work_id, :scope => [:series_id]
   acts_as_list :scope => :series
-  
+
   after_create :adjust_series_visibility
   after_destroy :adjust_series_visibility
   after_destroy :delete_empty_series
-  
+
   scope :in_order, {:order => :position}
-  
-	# If you add or remove a work from a series, make sure restricted? is still accurate
+
+  # If you add or remove a work from a series, make sure restricted? is still accurate
   def adjust_series_visibility
-    self.series.adjust_restricted
+    self.series.adjust_restricted unless self.series.blank?
   end
-  
+
   # If you delete a work from a series and it was the last one, delete the series too
   def delete_empty_series
-    if self.series.serial_works.blank?
+    if self.series.present? && self.series.serial_works.blank?
       self.series.destroy
     end
   end
-  
 end

--- a/lib/tasks/work_tasks.rake
+++ b/lib/tasks/work_tasks.rake
@@ -1,8 +1,8 @@
 namespace :work do
-  desc "Purge drafts created more than a week ago"
+  desc "Purge drafts created more than a month ago"
   task(:purge_old_drafts => :environment) do
-     count = Work.purge_old_drafts
-     puts "Unposted works (#{count}) created more than one month ago have been purged"
+    count = Work.purge_old_drafts
+    puts "Unposted works (#{count}) created more than one month ago have been purged"
   end
 
   desc "create missing hit counters"
@@ -10,7 +10,7 @@ namespace :work do
     Work.find_each do |work|
       counter = work.stat_counter
       unless counter
-        counter = StatCounter.create(:work=>work, :hit_count => 1)
+        counter = StatCounter.create(:work => work, :hit_count => 1)
       end
     end
   end


### PR DESCRIPTION
- Adds `series.blank?` checks to prevent bothering nil with things nil can't do
- Fixes description of task ("month" not "week") and weird spacing

https://code.google.com/p/otwarchive/issues/detail?id=4190

(Hotfixed on the server that runs the task.)
