### PR TITLE
Hopefully fixes #4191 in a good way

### DIFF
--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -370,7 +370,7 @@ class Work < ActiveRecord::Base
     # if this is fulfilling a challenge, add the collection and recipient
     challenge_assignments.each do |assignment|
       add_to_collection(assignment.collection)
-      self.gifts << Gift.new(:pseud => assignment.requesting_pseud) unless (recipients && recipients.include?(assignment.requesting_pseud.byline))
+      self.gifts << Gift.new(:pseud => assignment.requesting_pseud) unless (assignment.requesting_pseud.blank? || recipients && recipients.include?(assignment.request_byline))
     end
   end
 


### PR DESCRIPTION
- Deleted recipient account meant that `requesting_pseud` was nil; we already have a `request_byline` method, so we're going to use that instead
- However, a gift can't have a nil pseud, so we're not going to create a new gift through this path anyway
  https://code.google.com/p/otwarchive/issues/detail?id=4191
