### PR TITLE
4194 Batch load relationships in tag sets

### DIFF
--- a/app/controllers/owned_tag_sets_controller.rb
+++ b/app/controllers/owned_tag_sets_controller.rb
@@ -185,7 +185,7 @@ class OwnedTagSetsController < ApplicationController
   
   def do_batch_load
     if params[:batch_associations]
-      failed = @tag_set.load_batch_associations!(params[:batch_associations], :do_relationships => (params[:batch_do_relationship] ? true : false))
+      failed = @tag_set.load_batch_associations!(params[:batch_associations], :do_relationships => (params[:batch_do_relationships] ? true : false))
       if failed.empty?
         flash[:notice] = ts("Tags and associations loaded!")
         redirect_to tag_set_path(@tag_set) and return      


### PR DESCRIPTION
https://code.google.com/p/otwarchive/issues/detail?id=4194

Basically, it was always treating tags as a Character and never as a Relationship because the ticky box is named `batch_do_relationships`, but it was looking for `batch_do_relationship` without the s.
