### PR TITLE
Issue 4224: keep page number after deleting

### DIFF
--- a/app/controllers/invite_requests_controller.rb
+++ b/app/controllers/invite_requests_controller.rb
@@ -1,14 +1,12 @@
 class InviteRequestsController < ApplicationController
-  before_filter :admin_only, :only => [:manage, :reorder, :destroy]
-  
+  before_filter :admin_only, only: [:manage, :reorder, :destroy]
+
   # GET /invite_requests
-  # GET /invite_requests.xml
   def index
     @invite_request = InviteRequest.new
   end
 
   # GET /invite_requests/1
-  # GET /invite_requests/1.xml
   def show
     @invite_request = InviteRequest.find_by_email(params[:email])
     unless (request.xml_http_request?) || @invite_request
@@ -22,21 +20,20 @@ class InviteRequestsController < ApplicationController
   end
 
   # POST /invite_requests
-  # POST /invite_requests.xml
   def create
     @invite_request = InviteRequest.new(params[:invite_request])
     if @invite_request.save
       flash[:notice] = "You've been added to our queue! Yay! We estimate that you'll receive an invitation around #{@invite_request.proposed_fill_date}. We strongly recommend that you add do-not-reply@archiveofourown.org to your address book to prevent the invitation email from getting blocked as spam by your email provider."
       redirect_to invite_requests_path
     else
-      render :action => :index
+      render action: :index
     end
   end
-  
+
   def manage
     @invite_requests = InviteRequest.order(:position).page(params[:page])
   end
-  
+
   def reorder
     if InviteRequest.reset_order
       flash[:notice] = "The queue has been successfully updated."
@@ -45,7 +42,7 @@ class InviteRequestsController < ApplicationController
     end
     redirect_to manage_invite_requests_url
   end
-  
+
   def destroy
     @invite_request = InviteRequest.find(params[:id])
     if @invite_request.destroy
@@ -53,6 +50,6 @@ class InviteRequestsController < ApplicationController
     else
       flash[:error] = "Request could not be removed. Please try again."
     end
-    redirect_to manage_invite_requests_url
+    redirect_to manage_invite_requests_url(page: params[:page])
   end
 end

--- a/app/views/invite_requests/manage.html.erb
+++ b/app/views/invite_requests/manage.html.erb
@@ -1,36 +1,35 @@
 <div class="admin">
 <!--Descriptive page name, messages and instructions-->
-<h2 class="heading"><%= ts("Manage the Invite Queue") %></h2>
+  <h2 class="heading"><%= ts('Manage the Invite Queue') %></h2>
 <!--/descriptions-->
-
 
 <!--main content-->
   <%= form_tag reorder_invite_requests_url do %>
     <p><%= submit_tag ts('Reorder Queue') %></p>
   <% end %>
 
-<table summary="<%= ts('Lists each request/email and its current place in the queue. You can also delete each request.') %>">
-  <caption><%= ts('Manage the Invite Queue') %></caption>
-  <thead>
-	  <tr>
-	    <th scope="col"><%= ts('Queue Position') %></th>
-	    <th scope="col"><%= ts('Email Address') %></th>
-	    <th scope="col"><%= ts('Action') %></th>
-	  </tr>
-	</thead>
-	<tbody>
-    <% for request in @invite_requests %>
+  <table summary="<%= ts('Lists each request/email and its current place in the queue. You can also delete each request.') %>">
+    <caption><%= ts('Manage the Invite Queue') %></caption>
+    <thead>
       <tr>
-        <td><%= request.position %></td>
-        <td><%= request.email %></td>
-        <td><%= link_to ts('Delete'), request, :confirm => ts('Are you sure?'), :method => :delete %></td>
+        <th scope="col"><%= ts('Queue Position') %></th>
+        <th scope="col"><%= ts('Email Address') %></th>
+        <th scope="col"><%= ts('Action') %></th>
       </tr>
-    <% end %>
-  </tbody>
-</table>
+    </thead>
+    <tbody>
+      <% @invite_requests.each do |request| %>
+        <tr>
+          <td><%= request.position %></td>
+          <td><%= request.email %></td>
+          <td><%= link_to ts('Delete'), invite_request_path(request, page: params[:page]), confirm: ts('Are you sure?'), method: :delete %></td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
 <!--/content-->
 
 <!--subnav-->
-<%= will_paginate @invite_requests %>
+  <%= will_paginate @invite_requests %>
 <!--/subnav-->
 </div>


### PR DESCRIPTION
* The link to delete an invite request now keeps and sends the current page number to the controller
* The controller redirects to that page instead of defaulting to the first page.
* The tiniest bit of cleanup/refactoring (`each` instead of `for`, colon instead of rocket, etc.)

https://code.google.com/p/otwarchive/issues/detail?id=4224
