### PR TITLE
4228 Fix HTML on adult content warning page

### DIFF
--- a/app/views/works/_adult.html.erb
+++ b/app/views/works/_adult.html.erb
@@ -22,4 +22,6 @@
 
 <div class="clear"></div>
 
-<%= render 'works/work_blurb', :work => @work %>
+<ol class="works index group">
+  <%= render 'works/work_blurb', work: @work %>
+</ol>

--- a/app/views/works/_adult.html.erb
+++ b/app/views/works/_adult.html.erb
@@ -22,6 +22,6 @@
 
 <div class="clear"></div>
 
-<ol class="works index group">
+<ol class="work index group">
   <%= render 'works/work_blurb', work: @work %>
 </ol>


### PR DESCRIPTION
https://code.google.com/p/otwarchive/issues/detail?id=4228

Makes sure the `<li>` containing the blurb is inside an `<ol>`. (I chose `<ol>` because that's what we use on external_works/show.html.erb. Precedent, baby.)