### PR TITLE
4229 Extra li element on external works

### DIFF
--- a/app/views/external_works/show.html.erb
+++ b/app/views/external_works/show.html.erb
@@ -1,6 +1,6 @@
 <% unless @external_work.blank? %>
-  <h3 class="landmark heading">External Work</h3>
+  <h3 class="landmark heading"><%= ts('External Work') %></h3>
   <ol class="work index group">
-    <li><%= render :partial => 'external_works/blurb', :locals => {:external_work => @external_work} %></li>
+    <%= render 'external_works/blurb', external_work: @external_work %>
   </ol>
 <% end %>


### PR DESCRIPTION
https://code.google.com/p/otwarchive/issues/detail?id=4229

There's already a `<li>` in external_works/_blurb.html.erb, so we need to get rid of the one here.