### PR TITLE
3747: Pass in ID instead of User and Work Objects

### DIFF
--- a/app/controllers/admin/user_creations_controller.rb
+++ b/app/controllers/admin/user_creations_controller.rb
@@ -23,7 +23,7 @@ class Admin::UserCreationsController < ApplicationController
       users = creation.pseuds.map(&:user).uniq
       users.each do |user|
         unless user == orphan_account
-          UserMailer.admin_hidden_work_notification(creation, user).deliver
+          UserMailer.admin_hidden_work_notification(creation.id, user.id).deliver
         end
       end
      redirect_to(creation)

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -294,12 +294,12 @@ class UserMailer < BulletproofMailer::Base
   end
 
   # Sends email to authors when a creation is hidden by an Admin
-  def admin_hidden_work_notification(creation, user)
-    @user = user
-    @work = creation
+  def admin_hidden_work_notification(creation_id, user_id)
+    @user = User.find_by_id(user_id)
+    @work = Work.find_by_id(creation_id)
 
     mail(
-        to: user.email,
+        to: @user.email,
         subject: "[#{ArchiveConfig.APP_SHORT_NAME}] Your work has been hidden by the Abuse Team"
     )
   end


### PR DESCRIPTION
Resolves Bot-DB: https://code.google.com/p/otwarchive/issues/detail?id=3747

