### PR TITLE
Issue 4212 akismet

### DIFF
--- a/app/views/admin_mailer/send_spam_alert.html.erb
+++ b/app/views/admin_mailer/send_spam_alert.html.erb
@@ -3,7 +3,7 @@
   <p>The following accounts have a suspicious level of traffic:</p>
   <% @spam.each_pair do |user_id, info| %>
     <% user = User.find(user_id) %>
-    User <%= style_link(user.login, root_url + user_works_path(user).gsub(/^\//, '')) %> has a score of 
+    User <%= style_link(user.login, root_url + user_works_path(user)) %> has a score of 
     <%= info["score"] %>
     <ul>
     <% Work.where(id: info["work_ids"]).each do |work| %>

--- a/app/views/admin_mailer/send_spam_alert.html.erb
+++ b/app/views/admin_mailer/send_spam_alert.html.erb
@@ -3,7 +3,7 @@
   <p>The following accounts have a suspicious level of traffic:</p>
   <% @spam.each_pair do |user_id, info| %>
     <% user = User.find(user_id) %>
-    User <%= style_link(user.login, root_url + user_works_path(user)) %> has a score of 
+    User <%= style_link(user.login, root_url + user_works_path(user).gsub(/^\//, '')) %> has a score of 
     <%= info["score"] %>
     <ul>
     <% Work.where(id: info["work_ids"]).each do |work| %>

--- a/app/views/admin_mailer/send_spam_alert.text.erb
+++ b/app/views/admin_mailer/send_spam_alert.text.erb
@@ -7,8 +7,7 @@
     User <%= user.login %> (<%= root_url + user_works_path(user) %>) has a score of <%= info["score"] %>
 
     <% Work.where(id: info["work_ids"]).each do |work| %>
-      * <%= work.title %> (<%= work_url(work) %>) 
-      <% if work.spam? %>(<%= ts('Flagged as spam') %>)<% end %>
+      * <%= work.title %> (<%= work_url(work) %>) <% if work.spam? %>(<%= ts('Flagged as spam') %>)<% end %>
     <% end %>
 
   <% end %>

--- a/app/views/admin_mailer/send_spam_alert.text.erb
+++ b/app/views/admin_mailer/send_spam_alert.text.erb
@@ -4,7 +4,7 @@
 
   <% @spam.each_pair do |user_id, info| %>
     <% user = User.find(user_id) %>
-    User <%= user.login %> (<%= root_url + user_works_path(user).gsub(/^\//, '') %>) has a score of <%= info["score"] %>
+    User <%= user.login %> (<%= root_url + user_works_path(user) %>) has a score of <%= info["score"] %>
 
     <% Work.where(id: info["work_ids"]).each do |work| %>
       * <%= work.title %> (<%= work_url(work) %>) 

--- a/app/views/admin_mailer/send_spam_alert.text.erb
+++ b/app/views/admin_mailer/send_spam_alert.text.erb
@@ -1,6 +1,7 @@
 <% content_for :message do %>
 
   The following accounts have a suspicious level of traffic:
+
   <% @spam.each_pair do |user_id, info| %>
     <% user = User.find(user_id) %>
     User <%= user.login %> (<%= root_url + user_works_path(user).gsub(/^\//, '') %>) has a score of <%= info["score"] %>
@@ -9,6 +10,6 @@
       * <%= work.title %> (<%= work_url(work) %>) 
       <% if work.spam? %>(<%= ts('Flagged as spam') %>)<% end %>
     <% end %>
-  <% end %>
 
+  <% end %>
 <% end %>

--- a/app/views/admin_mailer/send_spam_alert.text.erb
+++ b/app/views/admin_mailer/send_spam_alert.text.erb
@@ -3,7 +3,7 @@
   The following accounts have a suspicious level of traffic:
   <% @spam.each_pair do |user_id, info| %>
     <% user = User.find(user_id) %>
-    User <%= user.login %> ( <%= root_url + user_works_path(user) %> ) has a score of <%= info["score"] %>
+    User <%= user.login %> (<%= root_url + user_works_path(user).gsub(/^\//, '') %>) has a score of <%= info["score"] %>
 
     <% Work.where(id: info["work_ids"]).each do |work| %>
       * <%= work.title %> (<%= work_url(work) %>) 


### PR DESCRIPTION

The URL for the user is incorrect. In the emails, it's http://test.archiveofourown.org//users/sarken/works -- note the two / instead of one. However, it _does_ work, so it's not the end of the world.

The plain text version of the email could benefit from a blank line between "The following accounts have a suspicious level of traffic:" and "User sarken ( http://test.archiveofourown.org//users/sarken/works ) has a score of 2" but I'd need to see an email with multiple users and multiple works before I could tell you if that blank line needs to be before or after <% @spam.each_pair do |user_id, info| %> on line 4.

Also in the plain text email, there are spaces between the URL and the parentheses for the user, e.g. ( http://test.archiveofourown.org//users/sarken/works ), but not for the work, e.g. (http://test.archiveofourown.org/works/1059182). I think we should get rid of the spaces for user, since our other emails don't generally use them.