### PR TITLE
AO3-2439 Stop converting > to &gt; in skins

### DIFF
--- a/lib/css_cleaner.rb
+++ b/lib/css_cleaner.rb
@@ -52,7 +52,8 @@ module CssCleaner
             errors.add(:base, ts("We don't allow the @font-face feature."))
             next
           end
-          sel = selector.gsub(/\n/, '').strip
+          # remove whitespace and convert &gt; entities back to the > direct child selector
+          sel = selector.gsub(/\n/, '').gsub('&gt;', '>').strip
           (prefix.blank? || sel.start_with?(prefix)) ? sel : "#{prefix} #{sel}"
         end
         clean_declarations = ""


### PR DESCRIPTION
https://otwarchive.atlassian.net/browse/AO3-2439

Was https://code.google.com/p/otwarchive/issues/detail?id=2442

When a user attempted to use a CSS selector like `.listbox > .heading`, it would get converted to `.listbox &gt; .heading`, which didn't work. This makes it so the `&gt;` in the selector gets converted back to a `>`. This may or may not be a terrible idea.