### PR TITLE
Issue 4234: Fix for broken indexing

### DIFF
--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -1272,8 +1272,10 @@ class Work < ActiveRecord::Base
   end
 
   def to_indexed_json
-    to_json(methods:
-      [ :rating_ids,
+    to_json(
+      except: [:spam, :spam_checked_at],
+      methods: [
+        :rating_ids,
         :warning_ids,
         :category_ids,
         :fandom_ids,


### PR DESCRIPTION
Issue 4234: Fix for broken indexing. Spam fields were causing errors due to incorrect mapping.

https://code.google.com/p/otwarchive/issues/detail?id=4234