### PR TITLE
4235 Fix 503 page title

### DIFF
--- a/public/503.html
+++ b/public/503.html
@@ -11,7 +11,7 @@
 		<meta name="classification" content="transformative works" />
 		<meta name="author" content="Organization for Transformative Works" />
 		<title>
-                 Exceeded maximum allowed downloads per minute.
+      Page responding too slowly.
 		</title>
     <link rel="stylesheet" type="text/css" media="screen" href="/stylesheets/skins/skin_873_archive_2_0/1_site_screen_.css">
     <link rel="stylesheet" type="text/css" media="only screen and (max-width: 480px), handheld" href="/stylesheets/skins/skin_873_archive_2_0/4_site_maxwidth.handheld_.css">


### PR DESCRIPTION
https://code.google.com/p/otwarchive/issues/detail?id=4235

The page title that appears in the browser bar should correspond with the error message, which says the Archive was responding to slowly. Instead, the page title said, "Exceeded maximum allowed downloads per minute."