### PR TITLE
4209 Error message if you try to perform same AJAX action in two tabs

### DIFF
--- a/public/javascripts/application.js
+++ b/public/javascripts/application.js
@@ -537,6 +537,12 @@ $j(document).ready(function() {
       error: function(xhr, textStatus, errorThrown) {
         flashContainer.empty();
         flashContainer.addClass('error notice');
+        try {
+          jQuery.parseJSON(xhr.responseText);
+        } catch (e) {
+          flashContainer.append("We're sorry! Something went wrong.");
+          return;
+        }
         $j.each(jQuery.parseJSON(xhr.responseText).errors, function(index, error) {
           flashContainer.append(error + " ");
         });

--- a/public/javascripts/application.js
+++ b/public/javascripts/application.js
@@ -497,7 +497,13 @@ $j(document).ready(function() {
       error: function(xhr, textStatus, errorThrown) {
         flashContainer.empty();
         flashContainer.addClass('error notice');
-        $j.each(jQuery.parseJSON(xhr.responseText).errors, function(index, error){
+        try {
+          jQuery.parseJSON(xhr.responseText);
+        } catch (e) {
+          flashContainer.append("We're sorry! Something went wrong.");
+          return;
+        }
+        $j.each(jQuery.parseJSON(xhr.responseText).errors, function(index, error) {
           flashContainer.append(error + " ");
         });
       }
@@ -531,7 +537,7 @@ $j(document).ready(function() {
       error: function(xhr, textStatus, errorThrown) {
         flashContainer.empty();
         flashContainer.addClass('error notice');
-        $j.each(jQuery.parseJSON(xhr.responseText).errors, function(index, error){
+        $j.each(jQuery.parseJSON(xhr.responseText).errors, function(index, error) {
           flashContainer.append(error + " ");
         });
       }


### PR DESCRIPTION
https://code.google.com/p/otwarchive/issues/detail?id=4209

If you have the Testing tag favorited and open the tag's works page in two browser windows, when you use the Unfavorite Tag button in both windows, the second attempt would give an empty flash message rather than a sensible message because the form was being submitted to a URL that no longer exists. Now it will just say, "We're sorry! Something went wrong." The same should apply to trying to remove a subscription in two windows or trying to delete a history item in two windows.