### PR TITLE
4209 Marked for Later updating, Favorite Tag decanonizing

### DIFF
--- a/app/models/favorite_tag.rb
+++ b/app/models/favorite_tag.rb
@@ -32,7 +32,7 @@ class FavoriteTag < ActiveRecord::Base
 
   def expire_cached_home_favorite_tags
     unless Rails.env.development?
-      Rails.cache.delete("home/index/#{User.current_user.id}/home_favorite_tags")
+      Rails.cache.delete("home/index/#{user_id}/home_favorite_tags")
     end
   end
 end

--- a/app/models/reading.rb
+++ b/app/models/reading.rb
@@ -2,7 +2,7 @@ class Reading < ActiveRecord::Base
   belongs_to :user
   belongs_to :work
 
-  after_save :expire_cached_home_marked_for_later, if: :toread?
+  after_save :expire_cached_home_marked_for_later, if: :toread_changed?
   after_destroy :expire_cached_home_marked_for_later, if: :toread?
 
   # called from show in work controller


### PR DESCRIPTION
https://code.google.com/p/otwarchive/issues/detail?id=4209

If you marked a work for later and then accessed it again (but didn't mark it as read), the list on the homepage would still regenerate when the reading rake task ran. This should only regenerate the list when you change a work's marked for later status.

This also fixes it so tags that are decanonized will be correctly removed from favorite tags lists.