### PR TITLE
4251 Sortable name for favorite tags

### DIFF
--- a/app/decorators/homepage.rb
+++ b/app/decorators/homepage.rb
@@ -20,10 +20,10 @@ class Homepage
   def favorite_tags
     return unless logged_in?
     if Rails.env.development?
-      @favorite_tags ||= @user.favorite_tags.to_a.sort_by { |favorite_tag| favorite_tag.tag.name.downcase }
+      @favorite_tags ||= @user.favorite_tags.to_a.sort_by { |favorite_tag| favorite_tag.tag.sortable_name.downcase }
     else
       @favorite_tags ||= Rails.cache.fetch("home/index/#{@user.id}/home_favorite_tags") do
-        @user.favorite_tags.to_a.sort_by { |favorite_tag| favorite_tag.tag.name.downcase }
+        @user.favorite_tags.to_a.sort_by { |favorite_tag| favorite_tag.tag.sortable_name.downcase }
       end
     end
   end

--- a/lib/tasks/after_tasks.rake
+++ b/lib/tasks/after_tasks.rake
@@ -406,6 +406,19 @@ namespace :After do
     end
   end
 
+  desc "Set initial values for sortable tag names for tags that aren't fandoms"
+  task(:more_sortable_tag_names => :environment) do
+  
+    [Category, Character, Freeform, Relationship, Warning].each do |klass|
+      puts "Adding sortable names for #{klass.to_s.downcase.pluralize}"
+      klass.by_name.find(:all, :conditions => "canonical = 1").each do |tag|
+        tag.set_sortable_name
+        puts tag.sortable_name
+        tag.save
+      end
+    end
+  end
+
 end # this is the end that you have to put new tasks above
 
 ##################


### PR DESCRIPTION
https://code.google.com/p/otwarchive/issues/detail?id=4251

Will make it so favorite tags are alphabetized by sortable name, e.g. "The Fandom" will be under F. Includes rake task to add sortable_name to tags that are lacking.