### PR TITLE
4209 3758 Inbox comment count wrong

### DIFF
--- a/app/controllers/inbox_controller.rb
+++ b/app/controllers/inbox_controller.rb
@@ -8,10 +8,10 @@ class InboxController < ApplicationController
   end
 
   def show
-    @inbox_total = @user.inbox_comments.count
-    @unread = @user.inbox_comments.count_unread
+    @inbox_total = @user.inbox_comments.with_feedback_comment.count
+    @unread = @user.inbox_comments.with_feedback_comment.count_unread
     filters = params[:filters] || {}
-    @inbox_comments = @user.inbox_comments.find_by_filters(filters).page(params[:page])
+    @inbox_comments = @user.inbox_comments.with_feedback_comment.find_by_filters(filters).page(params[:page])
     @select_read, @select_replied_to, @select_date = filters[:read], filters[:replied_to], filters[:date]
   end
 

--- a/app/decorators/homepage.rb
+++ b/app/decorators/homepage.rb
@@ -47,6 +47,6 @@ class Homepage
 
   def inbox_comments
     return unless logged_in?
-    @inbox_comments ||= @user.inbox_comments.for_homepage
+    @inbox_comments ||= @user.inbox_comments.with_feedback_comment.for_homepage
   end
 end

--- a/app/models/inbox_comment.rb
+++ b/app/models/inbox_comment.rb
@@ -33,15 +33,16 @@ class InboxComment < ActiveRecord::Base
 
   # Get only the comments with a feedback_comment that exists
   def self.with_feedback_comment
-    # Get an array of the ids of inbox comments that have existing feedback_comments 
+    # Get an array of the ids of inbox comments that have existing feedback_comments
     inbox_comments_with_feedback_comment = []
-    self.find_each do |inbox_comment|
-      unless inbox_comment.feedback_comment.nil? || inbox_comment.feedback_comment.is_deleted?
+    find_each do |inbox_comment|
+      unless inbox_comment.feedback_comment.nil? ||
+             inbox_comment.feedback_comment.is_deleted?
         inbox_comments_with_feedback_comment << inbox_comment
-      end    
+      end
     end
-     # Turn that array into ActiveRecord Relation objects
-    inbox_comments_with_feedback_comment.map{ |i| i.id }
-    self.where(id: inbox_comments_with_feedback_comment)
+    # Turn that array into ActiveRecord Relation objects
+    inbox_comments_with_feedback_comment.map(&:id)
+    where(id: inbox_comments_with_feedback_comment)
   end
 end

--- a/app/models/inbox_comment.rb
+++ b/app/models/inbox_comment.rb
@@ -41,8 +41,7 @@ class InboxComment < ActiveRecord::Base
         inbox_comments_with_feedback_comment << inbox_comment
       end
     end
-    # Turn that array into ActiveRecord Relation objects
-    inbox_comments_with_feedback_comment.map(&:id)
+    # Get the ActiveRecord Relation objects based on that array
     where(id: inbox_comments_with_feedback_comment)
   end
 end

--- a/app/models/inbox_comment.rb
+++ b/app/models/inbox_comment.rb
@@ -31,4 +31,17 @@ class InboxComment < ActiveRecord::Base
     self.count(:conditions => {:read => false})
   end
 
+  # Get only the comments with a feedback_comment that exists
+  def self.with_feedback_comment
+    # Get an array of the ids of inbox comments that have existing feedback_comments 
+    inbox_comments_with_feedback_comment = []
+    self.find_each do |inbox_comment|
+      unless inbox_comment.feedback_comment.nil? || inbox_comment.feedback_comment.is_deleted?
+        inbox_comments_with_feedback_comment << inbox_comment
+      end    
+    end
+     # Turn that array into ActiveRecord Relation objects
+    inbox_comments_with_feedback_comment.map{ |i| i.id }
+    self.where(id: inbox_comments_with_feedback_comment)
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -189,7 +189,7 @@ class User < ActiveRecord::Base
   end
   def unread_inbox_comments_count
     inbox_comments.with_feedback_comment.count(:all,
-                                                conditions: { read: false })
+                                               conditions: { read: false })
   end
 
   scope :alphabetical, :order => :login

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -188,7 +188,8 @@ class User < ActiveRecord::Base
     inbox_comments.find(:all, :conditions => {:read => false})
   end
   def unread_inbox_comments_count
-    inbox_comments.with_feedback_comment.count(:all, :conditions => {:read => false})
+    inbox_comments.with_feedback_comment.count(:all,
+                                                conditions: { read: false })
   end
 
   scope :alphabetical, :order => :login

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -188,7 +188,7 @@ class User < ActiveRecord::Base
     inbox_comments.find(:all, :conditions => {:read => false})
   end
   def unread_inbox_comments_count
-    inbox_comments.count(:all, :conditions => {:read => false})
+    inbox_comments.with_feedback_comment.count(:all, :conditions => {:read => false})
   end
 
   scope :alphabetical, :order => :login

--- a/app/views/inbox/show.html.erb
+++ b/app/views/inbox/show.html.erb
@@ -10,7 +10,7 @@
 <!--main content-->
 <% unless @inbox_comments.blank? %>
 
-  <%= will_paginate @inbox_comments %>
+  <% # = will_paginate @inbox_comments %>
 
   <%= form_tag user_inbox_path(@user, page: params[:page], filters: params[:filters]), method: :put, id: 'inbox-form' do %>
     <fieldset class="actions">
@@ -31,7 +31,6 @@
       <ol class="comment index group">
         <% @inbox_comments.each do |inbox_comment| %>
           <% feedback_comment = inbox_comment.feedback_comment %>
-          <% next if feedback_comment.nil? || feedback_comment.is_deleted? %>
 
           <!-- START of single comment -->
           <li class="<%= inbox_comment.read? ? 'read' : 'unread' %> comment group" role="article">
@@ -144,4 +143,4 @@
 <% end %>
 <!--/subnav-->
 
-<%= will_paginate @inbox_comments %>
+<% # = will_paginate @inbox_comments %>

--- a/app/views/inbox/show.html.erb
+++ b/app/views/inbox/show.html.erb
@@ -10,7 +10,7 @@
 <!--main content-->
 <% unless @inbox_comments.blank? %>
 
-  <% # = will_paginate @inbox_comments %>
+  <%= will_paginate @inbox_comments %>
 
   <%= form_tag user_inbox_path(@user, page: params[:page], filters: params[:filters]), method: :put, id: 'inbox-form' do %>
     <fieldset class="actions">
@@ -143,4 +143,4 @@
 <% end %>
 <!--/subnav-->
 
-<% # = will_paginate @inbox_comments %>
+<%= will_paginate @inbox_comments %>


### PR DESCRIPTION
https://code.google.com/p/otwarchive/issues/detail?id=4209
https://code.google.com/p/otwarchive/issues/detail?id=3758

If you posted a work, had someone comment on that work, deleted that work, and attempted to go to the homepage, you'd (sometimes) get a 500 error. This is because it didn't have the `<% next if feedback_comment.nil? || feedback_comment.is_deleted? %>` logic the inbox has.

However, simply using that logic could result in either (a) only two of three unread items displaying on your homepage or (b) an empty inbox section on the homepage, much like it results in the inbox count being wrong when there are non-visible unread items from deleted works/chapters.

So I have instead created a method that check the status of items' `feedback_comment` and returns the ActiveRecord Relations for *only* the items that have a `feedback_comment`, thereby resolving issue 3758 along with the 500 error on the homepage.

When this is deployed to staging, testy's homepage should stop giving a 500 error and the count of 5 unread items should drop to 0.