### PR TITLE
4251 Include ratings in sortable_name task

### DIFF
--- a/lib/tasks/after_tasks.rake
+++ b/lib/tasks/after_tasks.rake
@@ -409,9 +409,9 @@ namespace :After do
   desc "Set initial values for sortable tag names for tags that aren't fandoms"
   task(:more_sortable_tag_names => :environment) do
   
-    [Category, Character, Freeform, Relationship, Warning].each do |klass|
+    [Category, Character, Freeform, Rating, Relationship, Warning].each do |klass|
       puts "Adding sortable names for #{klass.to_s.downcase.pluralize}"
-      klass.by_name.find(:all, :conditions => "canonical = 1").each do |tag|
+      klass.by_name.find_each(:conditions => "canonical = 1 AND sortable_name = ''") do |tag|
         tag.set_sortable_name
         puts tag.sortable_name
         tag.save


### PR DESCRIPTION
https://code.google.com/p/otwarchive/issues/detail?id=4251

Improve the rake task a bit: including ratings (oops), use find_each, and only set sortable_name for canonical tags that have a blank sortable name.