### PR TITLE
4258 Stop error on edit tag sets page

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -397,8 +397,7 @@ module ApplicationHelper
     toggle_hide = content_tag(:a, ts("Collapse Checkboxes"),
                                   style: "display: none;",
                                   class: "toggle #{checkboxes_id}_hide",
-                                  href: "##{checkboxes_id}")
-                             + "\n".html_safe
+                                  href: "##{checkboxes_id}") + "\n".html_safe
 
     css_class = checkbox_section_css_class(checkboxes_size)
 


### PR DESCRIPTION
https://code.google.com/p/otwarchive/issues/detail?id=4258

The error was: 
```
Error message
ActionView::Template::Error: undefined method `+@' for "\n":ActiveSupport::SafeBuffer

Stack trace (show Rails)
…eases/20150301093335/app/helpers/
application_helper.rb: 401:in `checkbox_section_toggle'
…eases/20150301093335/app/helpers/
application_helper.rb: 493:in `checkbox_section'
…le/ruby/1.9.1/gems/journey-1.0.4/lib/journey/
router.rb:  68:in `block in call'
…le/ruby/1.9.1/gems/journey-1.0.4/lib/journey/
router.rb:  56:in `each'
…le/ruby/1.9.1/gems/journey-1.0.4/lib/journey/
router.rb:  56:in `call'
```