### PR TITLE
4263 Series and external work fandom name slightly indented

### DIFF
--- a/app/views/external_works/_work_module.html.erb
+++ b/app/views/external_works/_work_module.html.erb
@@ -14,11 +14,12 @@
 
   <h5 class="fandoms heading">
     <span class="landmark"><%= ts('Fandom') %>:</span>
-    <%= external_work.fandom_tags.collect{|tag| link_to_tag_works(tag) }.join(', ').html_safe %>
-    &nbsp;
+    <%= external_work.fandom_tags.collect{ |tag| link_to_tag_works(tag) }.join(', ').html_safe %>
   </h5>
-    
-  <p class="notice"><%= ts("This work isn't hosted on the Archive so this blurb might not be complete or accurate.") %></p>
+
+  <p class="notice">
+    <%= ts("This work isn't hosted on the Archive so this blurb might not be complete or accurate.") %>
+  </p>
 
   <%= get_symbols_for(external_work) %>
   <p class="datetime"><%= set_format_for_date(external_work.created_at) %></p>
@@ -45,7 +46,7 @@
     <dd><%= link_to_bookmarkable_bookmarks(external_work) %></dd>
   <% end %>
 
-  <% if external_work.related_works.count > 0 %>	
+  <% if external_work.related_works.count > 0 %>
     <dt><%= ts("Related Works:") %></dt>
     <dd><%= link_to external_work.related_works.count.to_s, external_work %></dd>
   <% end %>

--- a/app/views/external_works/_work_module.html.erb
+++ b/app/views/external_works/_work_module.html.erb
@@ -2,7 +2,7 @@
 <div class="header module">
 
   <h4 class="heading">
-    <% # so bookmarks go to the external work's page and not directly to the external link %>
+    <% # so bookmarks go to the external work page, not directly to the external link %>
     <% if external_work ||= @bookmarkable %>
       <%= link_to bookmarkable.title, bookmarkable %>
     <% else %>
@@ -14,11 +14,13 @@
 
   <h5 class="fandoms heading">
     <span class="landmark"><%= ts('Fandom') %>:</span>
-    <%= external_work.fandom_tags.collect{ |tag| link_to_tag_works(tag) }.join(', ').html_safe %>
+    <%= external_work.fandom_tags.collect{ |tag| link_to_tag_works(tag) }.
+                                  join(', ').html_safe %>
   </h5>
 
   <p class="notice">
-    <%= ts("This work isn't hosted on the Archive so this blurb might not be complete or accurate.") %>
+    <%= ts("This work isn't hosted on the Archive so this blurb might not be complete 
+           or accurate.") %>
   </p>
 
   <%= get_symbols_for(external_work) %>
@@ -31,7 +33,7 @@
   <%= blurb_tag_block(external_work) %>
 </ul>
 
-<!--summary-->	
+<!--summary-->
 <% unless external_work.summary.blank? %>
   <h6 class="landmark heading"><%= ts("Summary") %></h6>
   <blockquote class="userstuff summary">

--- a/app/views/external_works/_work_module.html.erb
+++ b/app/views/external_works/_work_module.html.erb
@@ -12,7 +12,7 @@
     <%= byline(external_work) %>
   </h4>
 
-  <h5 class="heading">
+  <h5 class="fandoms heading">
     <span class="landmark"><%= ts('Fandom') %>:</span>
     <%= external_work.fandom_tags.collect{|tag| link_to_tag_works(tag) }.join(', ').html_safe %>
     &nbsp;

--- a/app/views/series/_series_module.html.erb
+++ b/app/views/series/_series_module.html.erb
@@ -7,15 +7,19 @@
     <%= ts('by') %>
     <%= byline(series) %>
     <% if series.restricted %>
-      <%= image_tag("lockblue.png", size: "15x15", alt: ts("(Restricted)"), title: ts("Restricted")) %>
+      <%= image_tag("lockblue.png", size: "15x15", alt: ts("(Restricted)"),
+                                    title: ts("Restricted")) %>
     <% end %>
     <% if series.hidden_by_admin %>
-      <%= image_tag("lockred.png", size: "15x15", alt: ts("(Hidden by Admin)"), title: ts("Hidden by Administrator")) %>
+      <%= image_tag("lockred.png", size: "15x15", alt: ts("(Hidden by Admin)"),
+                                   title: ts("Hidden by Administrator")) %>
     <% end %>
   </h4>
   <h5 class="fandoms heading">
     <span class="landmark"><%= ts('Fandom') %>:</span>
-    <%= series.work_tags.select{ |tag| tag.type == "Fandom" }.sort.collect{ |tag| link_to_tag_works(tag) }.join(', ').html_safe %>
+    <%= series.work_tags.select{ |tag| tag.type == "Fandom" }.
+                         sort.collect{ |tag| link_to_tag_works(tag) }.
+                         join(', ').html_safe %>
   </h5>
   <%= get_symbols_for(series) %>
   <p class="datetime"><%= set_format_for_date(series.revised_at) %></p>

--- a/app/views/series/_series_module.html.erb
+++ b/app/views/series/_series_module.html.erb
@@ -7,15 +7,15 @@
     <%= ts('by') %>
     <%= byline(series) %>
     <% if series.restricted %>
-      <%= image_tag("lockblue.png", :size => "15x15", :alt => "(Restricted)", :title => "Restricted") %>
+      <%= image_tag("lockblue.png", size: "15x15", alt: ts("(Restricted)"), title: ts("Restricted")) %>
     <% end %>
     <% if series.hidden_by_admin %>
-      <%= image_tag("lockred.png", :size => "15x15", :alt => "(Hidden by Admin)", :title => "Hidden by Administrator") %>
+      <%= image_tag("lockred.png", size: "15x15", alt: ts("(Hidden by Admin)"), title: ts("Hidden by Administrator")) %>
     <% end %>
-	</h4>
+  </h4>
   <h5 class="fandoms heading">
     <span class="landmark"><%= ts('Fandom') %>:</span>
-    <%= series.work_tags.select{|tag| tag.type == "Fandom"}.sort.collect{|tag| link_to_tag_works(tag) }.join(', ').html_safe %>
+    <%= series.work_tags.select{ |tag| tag.type == "Fandom" }.sort.collect{ |tag| link_to_tag_works(tag) }.join(', ').html_safe %>
   </h5>
   <%= get_symbols_for(series) %>
   <p class="datetime"><%= set_format_for_date(series.revised_at) %></p>
@@ -29,7 +29,9 @@
 <!--summary-->
 <% unless series.summary.blank? %>
   <h6 class="landmark heading"><%= ts("Summary") %></h6>
-  <blockquote class="userstuff summary"><%=raw strip_images(sanitize_field(series, :summary)) %></blockquote>
+  <blockquote class="userstuff summary">
+    <%=raw strip_images(sanitize_field(series, :summary)) %>
+  </blockquote>
 <% end %>
 <!--stats-->
 <dl class="stats">
@@ -38,7 +40,7 @@
   <dt><%= ts('Works:') %></dt> 
   <dd><%= series.visible_work_count %></dd>
   <% if (bookmark_count = series.bookmarks.is_public.count) > 0 %>
-  	<dt><%= ts('Bookmarks:') %></dt>
+    <dt><%= ts('Bookmarks:') %></dt>
     <dd><%= link_to_bookmarkable_bookmarks(series, bookmark_count.to_s) %></dd>
   <% end %>
 </dl>

--- a/app/views/series/_series_module.html.erb
+++ b/app/views/series/_series_module.html.erb
@@ -13,7 +13,7 @@
       <%= image_tag("lockred.png", :size => "15x15", :alt => "(Hidden by Admin)", :title => "Hidden by Administrator") %>
     <% end %>
 	</h4>
-  <h5 class="heading">
+  <h5 class="fandoms heading">
     <span class="landmark"><%= ts('Fandom') %>:</span>
     <%= series.work_tags.select{|tag| tag.type == "Fandom"}.sort.collect{|tag| link_to_tag_works(tag) }.join(', ').html_safe %>
   </h5>


### PR DESCRIPTION
https://code.google.com/p/otwarchive/issues/detail?id=4263

The fandom tags didn't have the fandoms class, so the CSS was not being properly applied.