### PR TITLE
3450: More caching of admin settings.

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -73,7 +73,7 @@ protected
 
   def current_admin_session
     return @current_admin_session if defined?(@current_admin_session)
-    @current_admin_session = Rails.cache.fetch("admin_settings"){AdminSetting.first}
+    @current_admin_session = Rails.cache.fetch("admin_settings") { AdminSetting.first }
   end
 
   def current_admin

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -73,7 +73,7 @@ protected
 
   def current_admin_session
     return @current_admin_session if defined?(@current_admin_session)
-    @current_admin_session = AdminSession.find
+    @current_admin_session = Rails.cache.fetch("admin_settings"){AdminSetting.first}
   end
 
   def current_admin

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -73,7 +73,7 @@ protected
 
   def current_admin_session
     return @current_admin_session if defined?(@current_admin_session)
-    @current_admin_session = Rails.cache.fetch("admin_settings") { AdminSetting.first }
+    @current_admin_session = AdminSession.find
   end
 
   def current_admin

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -131,7 +131,7 @@ protected
       when "nomination"
         TagSetNomination.for_tag_set(OwnedTagSet.find(@last_id)).owned_by(user).first
       when "setting"
-        AdminSetting.first
+        Rails.cache.fetch("admin_settings"){AdminSetting.first}
       when "assignment", "claim", "signup"
         klass = "challenge_#{classname}".classify.constantize
         query = classname == "assignment" ? klass.by_offering_user(user) :

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -131,7 +131,7 @@ protected
       when "nomination"
         TagSetNomination.for_tag_set(OwnedTagSet.find(@last_id)).owned_by(user).first
       when "setting"
-        Rails.cache.fetch("admin_settings"){AdminSetting.first}
+        Rails.cache.fetch("admin_settings") { AdminSetting.first }
       when "assignment", "claim", "signup"
         klass = "challenge_#{classname}".classify.constantize
         query = classname == "assignment" ? klass.by_offering_user(user) :

--- a/lib/tasks/tag_tasks.rake
+++ b/lib/tasks/tag_tasks.rake
@@ -71,8 +71,9 @@ namespace :Tag do
   end
   desc "Reset filter counts from date"
   task(:unsuspend_filter_counts => :environment) do
-    if AdminSetting.first && AdminSetting.first.suspend_filter_counts_at
-      FilterTagging.update_filter_counts_since(AdminSetting.first.suspend_filter_counts_at)
+    admin_settings = Rails.cache.fetch("admin_settings") { AdminSetting.first }
+    if admin_settings && admin_settings.suspend_filter_counts_at
+      FilterTagging.update_filter_counts_since(admin_settings.suspend_filter_counts_at)
     end
   end
 end


### PR DESCRIPTION
Caching the admin settings. Cache expiration is handled in an after_save callback here: https://github.com/otwcode/otwarchive/blob/master/app/models/admin_setting.rb#L86

Resolves issue: https://code.google.com/p/otwarchive/issues/detail?id=3450