### PR TITLE
4265 - Strip out invalid characters before attempting to create a new external author

### DIFF
--- a/app/models/story_parser.rb
+++ b/app/models/story_parser.rb
@@ -296,7 +296,7 @@ class StoryParser
               # we're not allowed to import works from this address
               raise Error, "Author #{external_author_name.name} at #{external_author_name.external_author.email} does not allow importing their work to this archive."
             end
-            work.external_creatorships.build(:external_author_name => external_author_name, :archivist => (options[:archivist] || User.current_user))
+            work.external_creatorships.build(external_author_name: external_author_name, archivist: (options[:archivist] || User.current_user))
           end
         end
       end

--- a/app/models/story_parser.rb
+++ b/app/models/story_parser.rb
@@ -399,7 +399,7 @@ class StoryParser
 
     def parse_author_common(email, name)
       # strip out invalid characters (everything except alphanumeric characters, _, @ and -)
-      name.gsub!(/[^[\p{Word} \-@]]/, "")
+      name.gsub!(/[^\w[ \-@\.]]/u, "")
       external_author = ExternalAuthor.find_or_create_by_email(email)
       unless name.blank?
         external_author_name = ExternalAuthorName.where(name: name, external_author_id: external_author.id).first ||

--- a/app/models/story_parser.rb
+++ b/app/models/story_parser.rb
@@ -284,11 +284,11 @@ class StoryParser
       # handle importing works for others
       # build an external creatorship for each author
       if options[:importing_for_others]
-        external_author_names = options[:external_author_names] || parse_author(location,options[:external_author_name],options[:external_author_email])
+        external_author_names = options[:external_author_names] || parse_author(location, options[:external_author_name], options[:external_author_email])
         # convert to an array if not already one
         external_author_names = [external_author_names] if external_author_names.is_a?(ExternalAuthorName)
-        if options[:external_coauthor_name] != nil
-          external_author_names << parse_author(location,options[:external_coauthor_name],options[:external_coauthor_email])
+        if options[:external_coauthor_name].present?
+          external_author_names << parse_author(location, options[:external_coauthor_name], options[:external_coauthor_email])
         end
         external_author_names.each do |external_author_name|
           if external_author_name && external_author_name.external_author
@@ -296,7 +296,7 @@ class StoryParser
               # we're not allowed to import works from this address
               raise Error, "Author #{external_author_name.name} at #{external_author_name.external_author.email} does not allow importing their work to this archive."
             end
-            ec = work.external_creatorships.build(:external_author_name => external_author_name, :archivist => (options[:archivist] || User.current_user))
+            work.external_creatorships.build(:external_author_name => external_author_name, :archivist => (options[:archivist] || User.current_user))
           end
         end
       end
@@ -398,14 +398,16 @@ class StoryParser
     end
 
     def parse_author_common(email, name)
+      # strip out invalid characters (everything except alphanumeric characters, _, @ and -)
+      name.gsub!(/[^[\p{Word} \-@]]/, "")
       external_author = ExternalAuthor.find_or_create_by_email(email)
       unless name.blank?
-        external_author_name = ExternalAuthorName.find(:first, :conditions => {:name => name, :external_author_id => external_author.id}) ||
-                                  ExternalAuthorName.new(:name => name)
+        external_author_name = ExternalAuthorName.where(name: name, external_author_id: external_author.id).first ||
+                               ExternalAuthorName.new(name: name)
         external_author.external_author_names << external_author_name
         external_author.save
       end
-      return external_author_name || external_author.default_name
+      external_author_name || external_author.default_name
     end
 
     def get_chapter_from_work_params(work_params)

--- a/app/models/story_parser.rb
+++ b/app/models/story_parser.rb
@@ -399,7 +399,7 @@ class StoryParser
 
     def parse_author_common(email, name)
       # convert to ASCII and strip out invalid characters (everything except alphanumeric characters, _, @ and -)
-      name = name.to_ascii.gsub!(/[^\w[ \-@\.]]/u, "")
+      name = name.to_ascii.gsub(/[^\w[ \-@\.]]/u, "")
       external_author = ExternalAuthor.find_or_create_by_email(email)
       unless name.blank?
         external_author_name = ExternalAuthorName.where(name: name, external_author_id: external_author.id).first ||

--- a/app/models/story_parser.rb
+++ b/app/models/story_parser.rb
@@ -398,8 +398,8 @@ class StoryParser
     end
 
     def parse_author_common(email, name)
-      # strip out invalid characters (everything except alphanumeric characters, _, @ and -)
-      name.gsub!(/[^\w[ \-@\.]]/u, "")
+      # convert to ASCII and strip out invalid characters (everything except alphanumeric characters, _, @ and -)
+      name = name.to_ascii.gsub!(/[^\w[ \-@\.]]/u, "")
       external_author = ExternalAuthor.find_or_create_by_email(email)
       unless name.blank?
         external_author_name = ExternalAuthorName.where(name: name, external_author_id: external_author.id).first ||

--- a/features/importing/archivist.feature
+++ b/features/importing/archivist.feature
@@ -93,9 +93,9 @@ Feature: Archivist bulk imports
     Given I have an archivist "elynross"
     When I am logged in as "elynross"
     And I go to the import page
-    And I import the work "http://cesy.dreamwidth.org/154770.html" by "rando!m-t??estname" with email "otwstephanie@thepotionsmaster.net"
+    And I import the work "http://cesy.dreamwidth.org/154770.html" by "ra_ndo!m-t??est n@me." with email "otwstephanie@thepotionsmaster.net"
     Then I should see import confirmation
-    And I should see "random-testname"
+    And I should see "ra_ndom-test n@me."
     When the system processes jobs
     Then 1 email should be delivered to "otwstephanie@thepotionsmaster.net"
 

--- a/features/importing/archivist.feature
+++ b/features/importing/archivist.feature
@@ -83,10 +83,21 @@ Feature: Archivist bulk imports
       And I import the work "http://cesy.dreamwidth.org/154770.html" by "randomtestname" with email "otwstephanie@thepotionsmaster.net"
     Then I should not see multi-story import messages
       And I should see "Welcome"
+      And I should see "randomtestname"
       And I should see "We have notified the author(s) you imported works for. If any were missed, you can also add co-authors manually."
     When the system processes jobs
     Then 1 email should be delivered to "otwstephanie@thepotionsmaster.net"
 
+  Scenario: Import a single work as an archivist specifying an external author with an invalid name
+
+    Given I have an archivist "elynross"
+    When I am logged in as "elynross"
+    And I go to the import page
+    And I import the work "http://cesy.dreamwidth.org/154770.html" by "rando!m-t??estname" with email "otwstephanie@thepotionsmaster.net"
+    Then I should see import confirmation
+    And I should see "random-testname"
+    When the system processes jobs
+    Then 1 email should be delivered to "otwstephanie@thepotionsmaster.net"
 
   Scenario: Claim a work and create a new account in response to an invite
   # TODO

--- a/features/step_definitions/archivist_steps.rb
+++ b/features/step_definitions/archivist_steps.rb
@@ -21,7 +21,7 @@ When /^I make "([^\"]*)" an archivist$/ do |name|
     step(%{I press "Update"})
 end
 
-When /^I import the work "([^\"]*)"(?: by "([^\"]*)" with email "([^\"]*)")?$/ do |url,external_author_name,external_author_email|
+When /^I import the work "([^\"]*)"(?: by "([^\"]*)" with email "([^\"]*)")?$/ do |url, external_author_name, external_author_email|
   step(%{I go to the import page})
   step(%{I check "Import for others ONLY with permission"})
   step(%{I fill in "urls" with "#{url}"})


### PR DESCRIPTION
When importing external works as an archivist, either through the mass importer or the form, if you set the external author's name to something invalid, the external author is quietly dropped. This strips out the invalid characters that prevent the external author name from being created and associated with the work.

https://code.google.com/p/otwarchive/issues/detail?id=4265