### PR TITLE
4266 Only allow a URL to be reported to Abuse 5 times per month

### DIFF
--- a/app/models/abuse_report.rb
+++ b/app/models/abuse_report.rb
@@ -53,13 +53,14 @@ class AbuseReport < ActiveRecord::Base
   end
 
   # if the URL being reported belongs to a work
-  # then make sure it isn't reported more than ABUSE_REPORTS_PER_WORK_MAX times
+  # make sure it isn't reported more than ABUSE_REPORTS_PER_WORK_MAX times in a month
   def work_is_not_over_reported
     if url.match(/works\/\d+/)
+      # use "works/123" instead of just the id to avoid confusion with chapter ids
       work_params_only = url.match(/works\/\d+/).to_s
       existing_reports_total = AbuseReport.where("created_at > ? AND
                                                  url LIKE ?",
-                                                 1.week.ago,
+                                                 1.month.ago,
                                                  "%#{work_params_only}%").
                                            count
       if existing_reports_total >= ArchiveConfig.ABUSE_REPORTS_PER_WORK_MAX + 1

--- a/app/models/abuse_report.rb
+++ b/app/models/abuse_report.rb
@@ -12,7 +12,7 @@ class AbuseReport < ActiveRecord::Base
 
   # if the URL ends like "works/123", add a / at the end
   # if the URL contains "works/123?", remove the parameters and add a /
-  # work_is_not_over_reported uses the / so "works/1234" isn't a match for "works/123"
+  # work_is_not_over_reported uses the / so "/works/1234" isn't a match for "/works/123"
   before_validation :clean_work_url, on: :create
   def clean_work_url
     if url.match(/(works\/\d+)$/)
@@ -66,12 +66,12 @@ class AbuseReport < ActiveRecord::Base
     reporter.send_report!
   end
 
-  # if the URL clearly belongs to a work (i.e. contains "works/123")
+  # if the URL clearly belongs to a work (i.e. contains "/works/123")
   # make sure it isn't reported more than ABUSE_REPORTS_PER_WORK_MAX times per month
   def work_is_not_over_reported
-    if url.match(/works\/\d+/)
-      # use "works/123/" instead of just the id to avoid confusion with chapter ids
-      work_params_only = url.match(/works\/\d+\//).to_s
+    if url.match(/\/works\/\d+/)
+      # use "/works/123/" instead of just the id to avoid confusion with chapter ids
+      work_params_only = url.match(/\/works)\/\d+\//).to_s
       existing_reports_total = AbuseReport.where("created_at > ? AND
                                                  url LIKE ?",
                                                  1.month.ago,

--- a/app/models/abuse_report.rb
+++ b/app/models/abuse_report.rb
@@ -70,7 +70,7 @@ class AbuseReport < ActiveRecord::Base
   # make sure it isn't reported more than ABUSE_REPORTS_PER_WORK_MAX times per month
   def work_is_not_over_reported
     if url.match(/\/works\/\d+/)
-      # use "/works/123/" instead of just the id to avoid confusion with chapter ids
+      # use "/works/123/" to avoid matching chapter or external work ids
       work_params_only = url.match(/\/works\/\d+\//).to_s
       existing_reports_total = AbuseReport.where("created_at > ? AND
                                                  url LIKE ?",

--- a/app/models/abuse_report.rb
+++ b/app/models/abuse_report.rb
@@ -20,7 +20,7 @@ class AbuseReport < ActiveRecord::Base
     elsif url.match(/(works\/\d+\?)/)
       self.url = url.split("?").first + "/"
     else
-      self.url
+      url
     end
   end
 

--- a/app/models/abuse_report.rb
+++ b/app/models/abuse_report.rb
@@ -71,7 +71,7 @@ class AbuseReport < ActiveRecord::Base
   def work_is_not_over_reported
     if url.match(/\/works\/\d+/)
       # use "/works/123/" instead of just the id to avoid confusion with chapter ids
-      work_params_only = url.match(/\/works)\/\d+\//).to_s
+      work_params_only = url.match(/\/works\/\d+\//).to_s
       existing_reports_total = AbuseReport.where("created_at > ? AND
                                                  url LIKE ?",
                                                  1.month.ago,

--- a/config/config.yml
+++ b/config/config.yml
@@ -115,6 +115,9 @@ IMPORT_MAX_WORKS: 25
 IMPORT_MAX_CHAPTERS: 200
 IMPORT_MAX_WORKS_BY_ARCHIVIST: 200
 
+# max number of abuse reports to accept for a given work URL
+ABUSE_REPORTS_PER_WORK_MAX: 5
+
 # number of items in various displays
 ITEMS_PER_PAGE: 25
 # must be less than ITEMS_PER_PAGE above

--- a/lib/tasks/after_tasks.rake
+++ b/lib/tasks/after_tasks.rake
@@ -421,7 +421,6 @@ namespace :After do
 
   desc "Set initial values for sortable tag names for tags that aren't fandoms"
   task(:more_sortable_tag_names => :environment) do
-  
     [Category, Character, Freeform, Rating, Relationship, Warning].each do |klass|
       puts "Adding sortable names for #{klass.to_s.downcase.pluralize}"
       klass.by_name.find_each(:conditions => "canonical = 1 AND sortable_name = ''") do |tag|
@@ -429,6 +428,15 @@ namespace :After do
         puts tag.sortable_name
         tag.save
       end
+    end
+  end
+
+  desc "Clean up work URLs for abuse reports from the last month"
+  task(:clean_abuse_report_work_urls => :environment) do
+    AbuseReport.where("created_at > ?", 1.month.ago).each do |report|
+      report.clean_work_url
+      puts report.url
+      report.save
     end
   end
 

--- a/lib/tasks/after_tasks.rake
+++ b/lib/tasks/after_tasks.rake
@@ -361,6 +361,19 @@ namespace :After do
 #   end
 # end
 
+# desc "Set initial values for sortable tag names for tags that aren't fandoms"
+# task(:more_sortable_tag_names => :environment) do
+#  
+#   [Category, Character, Freeform, Rating, Relationship, Warning].each do |klass|
+#     puts "Adding sortable names for #{klass.to_s.downcase.pluralize}"
+#     klass.by_name.find_each(:conditions => "canonical = 1 AND sortable_name = ''") do |tag|
+#       tag.set_sortable_name
+#       puts tag.sortable_name
+#       tag.save
+#     end
+#   end
+# end
+
   #### Add your new tasks here
   
 

--- a/lib/tasks/after_tasks.rake
+++ b/lib/tasks/after_tasks.rake
@@ -361,19 +361,6 @@ namespace :After do
 #   end
 # end
 
-# desc "Set initial values for sortable tag names for tags that aren't fandoms"
-# task(:more_sortable_tag_names => :environment) do
-#  
-#   [Category, Character, Freeform, Rating, Relationship, Warning].each do |klass|
-#     puts "Adding sortable names for #{klass.to_s.downcase.pluralize}"
-#     klass.by_name.find_each(:conditions => "canonical = 1 AND sortable_name = ''") do |tag|
-#       tag.set_sortable_name
-#       puts tag.sortable_name
-#       tag.save
-#     end
-#   end
-# end
-
   #### Add your new tasks here
   
 


### PR DESCRIPTION
https://code.google.com/p/otwarchive/issues/detail?id=4266

What this does is clean up the URL a bit for reported works and then check and make sure the last month hasn't already seen 5 or more reports containing "/works/123/" (where "123" is the id of the work being reported). The cleanup of the URLs is to make sure that, even if "works/1234" has reached the maximum, "works/123" can still be reported.