### PR TITLE
4268 mass import emails

### DIFF
--- a/app/controllers/api/v1/import_controller.rb
+++ b/app/controllers/api/v1/import_controller.rb
@@ -19,7 +19,7 @@ class Api::V1::ImportController < Api::V1::BaseController
 
       # Process the works, updating the flags
       external_works.each do |external_work|
-        works_responses << import_work(archivist, external_work)
+        works_responses << import_work(archivist, external_work.merge(params))
       end
 
       # Send claim notification emails if required

--- a/app/controllers/api/v1/import_controller.rb
+++ b/app/controllers/api/v1/import_controller.rb
@@ -22,8 +22,10 @@ class Api::V1::ImportController < Api::V1::BaseController
         works_responses << import_work(archivist, external_work)
       end
 
-      # To be added if required
-      # send_external_invites(@works)
+      # Send claim notification emails if required
+      if params[:send_claim_emails] && !@works.empty?
+        send_external_invites(@works, archivist)
+      end
 
       # set final response code and message depending on the flags
       status, messages = response_code(messages)
@@ -120,12 +122,23 @@ class Api::V1::ImportController < Api::V1::BaseController
     [status, errors]
   end
 
+  # send invitations to external authors for a given set of works
+  def send_external_invites(works, archivist)
+    external_authors = works.collect(&:external_authors).flatten.uniq
+    unless external_authors.empty?
+      external_authors.each do |external_author|
+        external_author.find_or_invite(archivist)
+      end
+    end
+  end
+
   def options(archivist, params)
     {
       archivist: archivist,
       import_multiple: "chapters",
       importing_for_others: true,
       do_not_set_current_author: true,
+      post_without_preview: params[:post_without_preview],
       restricted: params[:restricted],
       override_tags: params[:override_tags],
       collection_names: params[:collection_names],

--- a/app/controllers/api/v1/import_controller.rb
+++ b/app/controllers/api/v1/import_controller.rb
@@ -138,7 +138,7 @@ class Api::V1::ImportController < Api::V1::BaseController
       import_multiple: "chapters",
       importing_for_others: true,
       do_not_set_current_author: true,
-      post_without_preview: params[:post_without_preview],
+      post_without_preview: params[:post_without_preview].blank? ? true : params[:post_without_preview],
       restricted: params[:restricted],
       override_tags: params[:override_tags],
       collection_names: params[:collection_names],


### PR DESCRIPTION
This adds the ability to send an email with either a claim notification or an invitation (for Archive users and external authors respectively).

https://code.google.com/p/otwarchive/issues/detail?id=4268

Due to a bit of feature creep, it also fixes a bug which prevented general settings like send_claim_emails and post_without_preview were correctly passed down the chain of command.

Note: sending emails is toggled on/off by the client side so merging this won't automatically start sending emails for each import.