### PR TITLE
4270 get the Archive URLs for imported works

### DIFF
--- a/app/controllers/api/v1/import_controller.rb
+++ b/app/controllers/api/v1/import_controller.rb
@@ -3,7 +3,11 @@ class Api::V1::ImportController < Api::V1::BaseController
 
   # Imports multiple works with their meta from external URLs
   # Params:
-  # +params+:: a JSON object containing the login of an archivist and an array of works
+  # +params+:: a JSON object containing the following:
+  # - archivist: username of an existing archivist
+  # - post_without_preview: false = import as drafts, true = import and post
+  # - send_claim_emails: false = don't send emails (for testing), true = send emails
+  # - array of works to import
   def create
     archivist = User.find_by_login(params[:archivist])
     external_works = params[:works]

--- a/app/controllers/api/v1/import_controller.rb
+++ b/app/controllers/api/v1/import_controller.rb
@@ -71,7 +71,7 @@ class Api::V1::ImportController < Api::V1::BaseController
         @some_success = true
         work_status = :created
         work_url = work_url(work)
-        work_messages << "Successfully created work \"" + work.title + "\""
+        work_messages << "Successfully created work \"" + work.title + "\"."
       rescue => exception
         @some_errors = true
         work_status = :unprocessable_entity

--- a/app/controllers/api/v1/works_controller.rb
+++ b/app/controllers/api/v1/works_controller.rb
@@ -1,0 +1,55 @@
+class Api::V1::WorksController < Api::V1::BaseController
+  respond_to :json
+
+  # Return the URLs of a batch of individual works. Limits the number of URLs to
+  # IMPORT_MAX_CHAPTERS so it doesn't get tied up in checking URLs for too long.
+  # Params:
+  # +original_urls+:: an array of original URLs to find on the Archive
+  def batch_urls
+    original_urls = params[:original_urls]
+    status = :bad_request
+    results = []
+    if original_urls.nil? || original_urls.blank? || original_urls.size == 0
+      results << { error: "Please provide a list of URLs to find." }
+    elsif original_urls.size >= ArchiveConfig.IMPORT_MAX_CHAPTERS
+      results << { error: "Please provide no more than #{ ArchiveConfig.IMPORT_MAX_CHAPTERS } URLs to find" }
+    else
+      status = :ok
+      original_urls.each do |original_url|
+        work_result = work_url_from_external(original_url)
+        if work_result[:work].nil?
+          results << { status: :not_found,
+                       original_url: original_url,
+                       error: work_result[:error] }
+        else
+          work = work_result[:work]
+          results << { status: :ok,
+                       original_url: original_url,
+                       work_url: work_url(work),
+                       created: work.created_at }
+        end
+      end
+    end
+    render status: status, json: results
+  end
+
+  private
+
+  def work_url_from_external(original_url)
+    work = nil
+    if original_url.blank?
+      error = "Please provide the original URL for the work."
+    else
+      work = Work.find_by_url(original_url)
+      if !work
+        error = "No work has been imported from \"" + original_url + "\"."
+      end
+    end
+    {
+      original_url: original_url,
+      work: work,
+      error: error
+    }
+  end
+
+end

--- a/app/controllers/api/v1/works_controller.rb
+++ b/app/controllers/api/v1/works_controller.rb
@@ -15,25 +15,31 @@ class Api::V1::WorksController < Api::V1::BaseController
       results << { error: "Please provide no more than #{ ArchiveConfig.IMPORT_MAX_CHAPTERS } URLs to find." }
     else
       status = :ok
-      original_urls.each do |original_url|
-        work_result = work_url_from_external(original_url)
-        if work_result[:work].nil?
-          results << { status: :not_found,
-                       original_url: original_url,
-                       error: work_result[:error] }
-        else
-          work = work_result[:work]
-          results << { status: :ok,
-                       original_url: original_url,
-                       work_url: work_url(work),
-                       created: work.created_at }
-        end
-      end
+      results = process_batch_url(original_urls)
     end
     render status: status, json: results
   end
 
   private
+
+  def process_batch_url(original_urls)
+    results = []
+    original_urls.each do |original_url|
+      work_result = work_url_from_external(original_url)
+      if work_result[:work].nil?
+        results << { status: :not_found,
+                     original_url: original_url,
+                     error: work_result[:error] }
+      else
+        work = work_result[:work]
+        results << { status: :ok,
+                     original_url: original_url,
+                     work_url: work_url(work),
+                     created: work.created_at }
+      end
+    end
+    results
+  end
 
   def work_url_from_external(original_url)
     work = nil

--- a/app/controllers/api/v1/works_controller.rb
+++ b/app/controllers/api/v1/works_controller.rb
@@ -12,7 +12,7 @@ class Api::V1::WorksController < Api::V1::BaseController
     if original_urls.nil? || original_urls.blank? || original_urls.size == 0
       results << { error: "Please provide a list of URLs to find." }
     elsif original_urls.size >= ArchiveConfig.IMPORT_MAX_CHAPTERS
-      results << { error: "Please provide no more than #{ ArchiveConfig.IMPORT_MAX_CHAPTERS } URLs to find" }
+      results << { error: "Please provide no more than #{ ArchiveConfig.IMPORT_MAX_CHAPTERS } URLs to find." }
     else
       status = :ok
       original_urls.each do |original_url|

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -447,7 +447,7 @@ Otwarchive::Application.routes.draw do
 
   namespace :api do
     namespace :v1 do
-      resources :import, only: [:create, :check], defaults: { format: :json }
+      resources :import, only: [:create], defaults: { format: :json }
       match 'works/urls', to: 'works#batch_urls', via: :post
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -442,6 +442,17 @@ Otwarchive::Application.routes.draw do
   match 'login' => 'user_sessions#new'
   match 'logout' => 'user_sessions#destroy'
 
+
+  #### API ####
+
+  namespace :api do
+    namespace :v1 do
+      resources :import, only: [:create, :check], defaults: { format: :json }
+      match 'works/urls', to: 'works#batch_urls', via: :post
+    end
+  end
+
+
   #### MISC ####
 
   resources :comments do
@@ -519,12 +530,6 @@ Otwarchive::Application.routes.draw do
     end
   end
 
-  # API end points
-  namespace :api do
-    namespace :v1 do
-      resources :import, only: [:create], defaults: { format: :json }
-    end
-  end
 
   match 'search' => 'works#search'
   match 'support' => 'feedbacks#create', :as => 'feedbacks', :via => [:post]

--- a/spec/api/api_spec.rb
+++ b/spec/api/api_spec.rb
@@ -111,7 +111,7 @@ describe "API WorksController" do
       parsed_body = JSON.parse(response.body)
       expect(parsed_body.first["status"]).to eq "ok"
       expect(parsed_body.first["work_url"]).to eq work_url(work)
-      expect(parsed_body.first["created_at"]).to eq work.created_at
+      expect(parsed_body.first["created"]).to eq work.created_at
     end
 
     it "should return an error for a work that wasn't imported" do

--- a/spec/api/api_spec.rb
+++ b/spec/api/api_spec.rb
@@ -93,8 +93,11 @@ describe "API ImportController" do
 end
 
 describe "API WorksController" do
+  before do
+    @work = FactoryGirl.create(:work, posted: true, imported_from_url: "foo")
+  end
+
   describe "valid work URL request" do
-    work = FactoryGirl.create(:work, posted: true, imported_from_url: "foo")
     it "should return 200 OK" do
       post "/api/v1/works/urls",
            { original_urls: %w(bar foo)
@@ -110,8 +113,8 @@ describe "API WorksController" do
            valid_headers
       parsed_body = JSON.parse(response.body)
       expect(parsed_body.first["status"]).to eq "ok"
-      expect(parsed_body.first["work_url"]).to eq work_url(work)
-      expect(parsed_body.first["created"]).to eq work.created_at
+      expect(parsed_body.first["work_url"]).to eq work_url(@work)
+      expect(parsed_body.first["created"]).to eq @work.created_at.as_json
     end
 
     it "should return an error for a work that wasn't imported" do

--- a/spec/api/api_spec.rb
+++ b/spec/api/api_spec.rb
@@ -111,6 +111,7 @@ describe "API WorksController" do
       parsed_body = JSON.parse(response.body)
       expect(parsed_body.first["status"]).to eq "ok"
       expect(parsed_body.first["work_url"]).to eq work_url(work)
+      expect(parsed_body.first["created_at"]).to eq work.created_at
     end
 
     it "should return an error for a work that wasn't imported" do

--- a/spec/api/api_spec.rb
+++ b/spec/api/api_spec.rb
@@ -1,6 +1,16 @@
 require 'spec_helper'
 require 'webmock'
 
+# set up a valid token and some headers
+def valid_headers
+  api = ApiKey.first_or_create!(name: "Test", access_token: "testabc")
+  {
+    "HTTP_AUTHORIZATION" => ActionController::HttpAuthentication::Token.encode_credentials(api.access_token),
+    "HTTP_ACCEPT" => "application/json",
+    "CONTENT_TYPE" => "application/json"
+  }
+end
+
 describe "API ImportController" do
   # Let the test get at external sites, but stub out anything containing "foo"
   WebMock.allow_net_connect!
@@ -8,16 +18,6 @@ describe "API ImportController" do
     to_return(status: 200, body: "stubbed response", headers: {})
   WebMock.stub_request(:any, /bar/).
     to_return(status: 404, headers: {})
-
-  # set up a valid token and some headers
-  def valid_headers
-    api = ApiKey.first_or_create!(name: "Test", access_token: "testabc")
-    {
-      "HTTP_AUTHORIZATION" => ActionController::HttpAuthentication::Token.encode_credentials(api.access_token),
-      "HTTP_ACCEPT" => "application/json",
-      "CONTENT_TYPE" => "application/json"
-    }
-  end
 
   describe "API import with invalid request" do
     it "should return 401 Unauthorized if no token is supplied" do
@@ -90,4 +90,37 @@ describe "API ImportController" do
   end
 
   WebMock.allow_net_connect!
+end
+
+describe "API WorksController" do
+  describe "valid work URL request" do
+    work = FactoryGirl.create(:work, posted: true, imported_from_url: "foo")
+    it "should return 200 OK" do
+      post "/api/v1/works/urls",
+           { original_urls: %w(bar foo)
+           }.to_json,
+           valid_headers
+      assert_equal 200, response.status
+    end
+
+    it "should return the work URL for an imported work" do
+      post "/api/v1/works/urls",
+           { original_urls: %w(foo)
+           }.to_json,
+           valid_headers
+      parsed_body = JSON.parse(response.body)
+      expect(parsed_body.first["status"]).to eq "ok"
+      expect(parsed_body.first["work_url"]).to eq work_url(work)
+    end
+
+    it "should return an error for a work that wasn't imported" do
+      post "/api/v1/works/urls",
+           { original_urls: %w(bar)
+           }.to_json,
+           valid_headers
+      parsed_body = JSON.parse(response.body)
+      expect(parsed_body.first["status"]).to eq("not_found")
+      expect(parsed_body.first).to include("error")
+    end
+  end
 end


### PR DESCRIPTION
https://code.google.com/p/otwarchive/issues/detail?id=4270

This creates an end point which takes an array of external urls and for each one, returns either an error indicating it hasn't been found, or the work's URL and creation date on the Archive.