### PR TITLE
3471 Editing bookmark tags should update the bookmark blurb

### DIFF
--- a/app/models/tagging.rb
+++ b/app/models/tagging.rb
@@ -1,6 +1,6 @@
 class Tagging < ActiveRecord::Base
-  belongs_to :tagger, :polymorphic => true, :counter_cache => true
-  belongs_to :taggable, :polymorphic => true
+  belongs_to :tagger, polymorphic: true, counter_cache: true
+  belongs_to :taggable, polymorphic: true, touch: true
 
   validates_presence_of :tagger, :taggable
   before_destroy :remove_filter_tagging

--- a/features/bookmarks/bookmark_create.feature
+++ b/features/bookmarks/bookmark_create.feature
@@ -380,5 +380,18 @@ Scenario: Bookmark External Work link should be available to logged in users, bu
   Then I should not see "Bookmark External Work"
   When I go to the bookmarks in collection "Testing BEW Collection"
   Then I should not see "Bookmark External Work"
-
   
+Scenario: Editing a bookmark's tags should update the bookmark blurb
+  Given I am logged in as "some_user"
+    And I post the work "Really Good Thing"
+  When I am logged in as "bookmarker"
+    And I view the work "Really Good Thing"
+    And I follow "Bookmark"
+    And I fill in "bookmark_notes" with "I liked this story"
+    And I fill in "bookmark_tag_string" with "Tag 1, Tag 2"
+  When I press "Create"
+  Then I should see "Bookmark was successfully created"
+  When I follow "Edit"
+    And I fill in "bookmark_tag_string" with "New Tag"
+  When I press "Update"
+  Then I should see "New Tag"


### PR DESCRIPTION
https://code.google.com/p/otwarchive/issues/detail?id=3471

(The test should fail in the first commit, showing the bookmark blurb not updating when the tags are edited. The test should pass in the second commit, showing the bookmark blurb updating in light of the code change.)