### PR TITLE
4288 4289 Filters & other bookmark navigation missing

### DIFF
--- a/app/views/bookmarks/index.html.erb
+++ b/app/views/bookmarks/index.html.erb
@@ -5,7 +5,7 @@
 <!-- /descriptions-->
 
 <!--subnav-->
-<% if current_user.is_a?(User) || @user || @tag || @collection %>
+<% if current_user.is_a?(User) || @tag || @facets.present? %>
   <ul class="navigation actions" role="navigation">
     <% if logged_in? && (@user == current_user || (@owner.blank? && @bookmarkable.blank?) || @collection) %>
       <li><%= link_to ts("Bookmark External Work"), new_external_work_path %></li>

--- a/app/views/bookmarks/index.html.erb
+++ b/app/views/bookmarks/index.html.erb
@@ -5,7 +5,7 @@
 <!-- /descriptions-->
 
 <!--subnav-->
-<% if current_user.is_a?(User) || @tag %>
+<% if @user || @tag %>
   <ul class="navigation actions" role="navigation">
     <% if logged_in? && (@user == current_user || (@owner.blank? && @bookmarkable.blank?) || @collection) %>
       <li><%= link_to ts("Bookmark External Work"), new_external_work_path %></li>

--- a/app/views/bookmarks/index.html.erb
+++ b/app/views/bookmarks/index.html.erb
@@ -5,7 +5,7 @@
 <!-- /descriptions-->
 
 <!--subnav-->
-<% if @user || @tag %>
+<% if @user || @tag || @collection %>
   <ul class="navigation actions" role="navigation">
     <% if logged_in? && (@user == current_user || (@owner.blank? && @bookmarkable.blank?) || @collection) %>
       <li><%= link_to ts("Bookmark External Work"), new_external_work_path %></li>

--- a/app/views/bookmarks/index.html.erb
+++ b/app/views/bookmarks/index.html.erb
@@ -5,7 +5,7 @@
 <!-- /descriptions-->
 
 <!--subnav-->
-<% if @user || @tag || @collection %>
+<% if current_user.is_a?(User) || @user || @tag || @collection %>
   <ul class="navigation actions" role="navigation">
     <% if logged_in? && (@user == current_user || (@owner.blank? && @bookmarkable.blank?) || @collection) %>
       <li><%= link_to ts("Bookmark External Work"), new_external_work_path %></li>


### PR DESCRIPTION
https://code.google.com/p/otwarchive/issues/detail?id=4288
https://code.google.com/p/otwarchive/issues/detail?id=4289

To make sure the Filters link always displays on a user's bookmark page, we shouldn't check if the bookmarks belong to the *current user* before getting into the navigation logic -- we just want to check if they belong to *a* user.

Also, to make sure the Filters and Bookmark External Work links appear correctly on collections' bookmark pages, we needed to check if the bookmarks are in a collection.