### PR TITLE
4290 Fix work search test failure

### DIFF
--- a/features/works/work_search.feature
+++ b/features/works/work_search.feature
@@ -59,7 +59,7 @@ Feature: Search Works
     When I am on the search works page
     When I fill in "Date" with "> 2 years ago"
       And I press "Search" within "form#new_work_search"
-    Then I should see "5 Found"
+    Then I should see "6 Found"
     When I follow "Edit Your Search"
     Then I should be on the search works page
     When I fill in "Word Count" with ">15000"


### PR DESCRIPTION
https://code.google.com/p/otwarchive/issues/detail?id=4290

It was failing on features/works/work_search.feature:62 `Then I should see "5 Found"' when we searched for works revised at: > 2 years ago because the work last revised on April 29 2013 is now (correctly) included in the results, bringing the desired total of results from 5 to 6.