### PR TITLE
4294 4295 Fandom tag indented on prompts, external works

### DIFF
--- a/app/views/external_works/_blurb.html.erb
+++ b/app/views/external_works/_blurb.html.erb
@@ -15,7 +15,7 @@
       &nbsp;
     </h5>
     
-    <p class="caution notice"><%= ts("This work isn't hosted on the Archive so this blurb might not be complete or accurate.") %></p>
+    <p class="notice"><%= ts("This work isn't hosted on the Archive so this blurb might not be complete or accurate.") %></p>
 
     <%= get_symbols_for(external_work) %>
     <p class="datetime"><%= set_format_for_date(external_work.created_at) %></p>

--- a/app/views/external_works/_blurb.html.erb
+++ b/app/views/external_works/_blurb.html.erb
@@ -9,13 +9,13 @@
       <%= byline(external_work) %>
     </h4>
 
-    <h5 class="heading">
+    <h5 class="fandoms heading">
       <span class="landmark"><%= ts('Fandom') %>:</span>
       <%= external_work.fandom_tags.collect{|tag| link_to_tag_works(tag) }.join(', ').html_safe %>
       &nbsp;
     </h5>
     
-    <p class="notice"><%= ts("This work isn't hosted on the Archive so this blurb might not be complete or accurate.") %></p>
+    <p class="caution notice"><%= ts("This work isn't hosted on the Archive so this blurb might not be complete or accurate.") %></p>
 
     <%= get_symbols_for(external_work) %>
     <p class="datetime"><%= set_format_for_date(external_work.created_at) %></p>

--- a/app/views/prompts/_prompt_blurb.html.erb
+++ b/app/views/prompts/_prompt_blurb.html.erb
@@ -20,7 +20,7 @@
     <% tag_groups = prompt.tag_groups %>
 
     <% # eventually we should let mod specify topmost tag type to display -- ie chars and rels for single-fandom meme, freeforms for single-relationship meme  %>
-    <h5 class="heading">
+    <h5 class="fandoms heading">
       <span class="landmark"><%= ts('Fandom') %>:</span>
       <%= tag_groups['Fandom'].collect{|tag| link_to_tag_works(tag) }.join(', ').html_safe if tag_groups['Fandom'] %>
       &nbsp;


### PR DESCRIPTION
https://code.google.com/p/otwarchive/issues/detail?id=4294
https://code.google.com/p/otwarchive/issues/detail?id=4295

The fandom tags were slightly indented because a class name was missing.