### PR TITLE
4304: Move the Unsorted tags bin link down with rest of bin links

### DIFF
--- a/app/views/tag_wranglings/_wrangler_dashboard.html.erb
+++ b/app/views/tag_wranglings/_wrangler_dashboard.html.erb
@@ -15,9 +15,9 @@
       <% if @tag && @uses %>
         <% @uses.each do |key| %>
           <% if key == 'Works' || key == 'Bookmarks' %>
-            <li><%= span_if_current "#{key} (#{@counts[key]})", {:controller => key.downcase.to_sym, :action => :index, :tag_id => @tag} %></li>
+            <li><%= span_if_current "#{key} (#{@counts[key]})", { controller: key.downcase.to_sym, action: :index, tag_id: @tag } %></li>
           <% elsif key == 'External Works' %>
-            <li><%= span_if_current "#{key} (#{@counts[key]})", {:controller => :bookmarks, :action => :index, :tag_id => @tag} %></li>
+            <li><%= span_if_current "#{key} (#{@counts[key]})", { controller: :bookmarks, action: :index, tag_id: @tag } %></li>
           <% else %>
             <li><span><%= "#{key} (#{@counts[key]})" %></span></li>
           <% end %>
@@ -25,15 +25,15 @@
       <% elsif @tag && @tag.child_types %>
         <% @tag.child_types.each do |tag_type| %>
           <li>
-            <%= span_if_current tag_type.pluralize + " (#{@counts[tag_type.underscore.pluralize.to_sym]})", url_for(:show => tag_type.underscore.pluralize, :id => @tag) %>
+            <%= span_if_current tag_type.pluralize + " (#{@counts[tag_type.underscore.pluralize.to_sym]})", url_for(show: tag_type.underscore.pluralize, id: @tag) %>
           </li>
         <% end %>
       <% else %>
-        <li><%= span_if_current ts("Fandoms by media (%{count})", :count=> @counts[:fandoms]), tag_wranglings_path(:show => "fandoms") %></li>
-        <li><%= span_if_current ts("Characters by fandom (%{count})", :count=> @counts[:characters]), tag_wranglings_path(:show => "characters") %></li>
-        <li><%= span_if_current ts("Relationships by fandom (%{count})", :count=> @counts[:relationships]), tag_wranglings_path(:show => "relationships") %></li>
-        <li><%= span_if_current ts("Freeforms by fandom (%{count})", :count=> @counts[:freeforms]), tag_wranglings_path(:show => "freeforms") %></li>
-        <li><%= span_if_current(ts("Unsorted Tags (%{count})", :count => UnsortedTag.count), unsorted_tags_path) %></li>
+        <li><%= span_if_current ts("Fandoms by media (%{count})", count: @counts[:fandoms]), tag_wranglings_path(show: "fandoms") %></li>
+        <li><%= span_if_current ts("Characters by fandom (%{count})", count: @counts[:characters]), tag_wranglings_path(show: "characters") %></li>
+        <li><%= span_if_current ts("Relationships by fandom (%{count})", count: @counts[:relationships]), tag_wranglings_path(show: "relationships") %></li>
+        <li><%= span_if_current ts("Freeforms by fandom (%{count})", count: @counts[:freeforms]), tag_wranglings_path(show: "freeforms") %></li>
+        <li><%= span_if_current(ts("Unsorted Tags (%{count})", count: UnsortedTag.count), unsorted_tags_path) %></li>
       <% end %>
     </ul>
   <% end %>

--- a/app/views/tag_wranglings/_wrangler_dashboard.html.erb
+++ b/app/views/tag_wranglings/_wrangler_dashboard.html.erb
@@ -8,7 +8,6 @@
     <li><%= span_if_current(ts('Discussion'), discuss_tag_wranglings_path) %></li>
     <li><%= span_if_current(ts('Search Tags'), search_tags_path) %></li>
     <li><%= span_if_current(ts('New Tag'), new_tag_path) %></li>
-    <li><%= span_if_current(ts("Unsorted Tags (%{count})", :count => UnsortedTag.count), unsorted_tags_path) %></li>
   </ul>
 
   <% if @counts %>
@@ -34,6 +33,7 @@
         <li><%= span_if_current ts("Characters by fandom (%{count})", :count=> @counts[:characters]), tag_wranglings_path(:show => "characters") %></li>
         <li><%= span_if_current ts("Relationships by fandom (%{count})", :count=> @counts[:relationships]), tag_wranglings_path(:show => "relationships") %></li>
         <li><%= span_if_current ts("Freeforms by fandom (%{count})", :count=> @counts[:freeforms]), tag_wranglings_path(:show => "freeforms") %></li>
+        <li><%= span_if_current(ts("Unsorted Tags (%{count})", :count => UnsortedTag.count), unsorted_tags_path) %></li>
       <% end %>
     </ul>
   <% end %>


### PR DESCRIPTION
Resolves issue: https://code.google.com/p/otwarchive/issues/detail?id=4304

The 'Unsorted Tags' link calls upon 'UnsortedTag.count' which needlessly queries the database on every Wrangling page, regardless of the count information being useful or not. 

Moving the 'Unsorted Tags' link down with the rest of the bin links ensures that the database is queried only when working on actual tags. 