### PR TITLE
4286: Only display languages with associated locales in admin post dropdown

### DIFF
--- a/app/controllers/admin_posts_controller.rb
+++ b/app/controllers/admin_posts_controller.rb
@@ -19,6 +19,7 @@ class AdminPostsController < ApplicationController
       @tags = AdminPostTag.order(:name)
     end
     @admin_posts = @admin_posts.order('created_at DESC').page(params[:page])
+    @news_languages = Language.where(id: Locale.all.map(&:language_id)).default_order
   end
 
   # GET /admin_posts/1

--- a/app/views/admin_posts/_filters.html.erb
+++ b/app/views/admin_posts/_filters.html.erb
@@ -3,6 +3,6 @@
   <p><%= label_tag :tag, ts("Tag:") %>
   <%= select_tag :tag, ('<option></option>' + options_from_collection_for_select(@tags, :id, :name, params[:tag])).html_safe %>
   <%= label_tag :language_id, ts("Language:") %>
-  <%= select_tag :language_id, options_from_collection_for_select(Language.default_order, :short, :name, params[:language_id] || Language.default.short) %>
+  <%= select_tag :language_id, options_from_collection_for_select(@news_languages, :short, :name, params[:language_id] || Language.default.short) %>
   <%= submit_tag ts('Go') %></p>
 <% end %>


### PR DESCRIPTION
Resolves issue: https://code.google.com/p/otwarchive/issues/detail?id=4286

Simply carried over the code changes in #1874 to also be used in the index listing of the Admin Posts. 