### PR TITLE
AO3-4316 - Improve URL matching for imported works

### DIFF
--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -288,9 +288,9 @@ class Work < ActiveRecord::Base
       Work.where(:imported_from_url => [url.minimal, url.no_www, url.with_www, url.encoded, url.decoded]).first ||
       Work.where("imported_from_url LIKE ?", "%#{url.minimal_no_http}%").select { |w|
         work_url = UrlFormatter.new(w.imported_from_url)
-        ['original', 'minimal', 'no_www', 'with_www', 'encoded', 'decoded'].map { |method|
-          work_url.send(method) == url.send(method) 
-        }.any?
+        ['original', 'minimal', 'no_www', 'with_www', 'encoded', 'decoded'].any? { |method|
+          work_url.send(method) == url.send(method)
+        }
       }.first
   end
 

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -310,12 +310,12 @@ class Work < ActiveRecord::Base
     url = UrlFormatter.new(url)
     Work.where(:imported_from_url => url.original).first ||
       Work.where(:imported_from_url => [url.minimal, url.no_www, url.with_www, url.encoded, url.decoded]).first ||
-      Work.find { |w|
+      Work.find do |w|
         work_url = UrlFormatter.new(w.imported_from_url)
         ['original', 'minimal', 'no_www', 'with_www', 'encoded', 'decoded'].map { |method|
           work_url.send(method) == url.send(method)
         }.include? true
-      }
+      end
   end
 
   ########################################################################

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -286,12 +286,12 @@ class Work < ActiveRecord::Base
     url = UrlFormatter.new(url)
     Work.where(:imported_from_url => url.original).first ||
       Work.where(:imported_from_url => [url.minimal, url.no_www, url.with_www, url.encoded, url.decoded]).first ||
-      Work.where("imported_from_url LIKE ?", "%#{url.minimal_no_http}%").select { |w|
+      Work.where("imported_from_url LIKE ?", "%#{url.minimal_no_http}%").select do |w|
         work_url = UrlFormatter.new(w.imported_from_url)
-        ['original', 'minimal', 'no_www', 'with_www', 'encoded', 'decoded'].map { |method|
+        ['original', 'minimal', 'no_www', 'with_www', 'encoded', 'decoded'].map do |method|
           work_url.send(method) == url.send(method)
-        }.include? true
-      }.first
+        end.include? true
+      end.first
   end
 
   ########################################################################

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -274,48 +274,24 @@ class Work < ActiveRecord::Base
     Resque.enqueue(Work, id, method, *args)
   end
 
-  # SECTION IN PROGRESS -- CONSIDERING MOVE OF WORK CODE INTO HERE
-
-  ########################################################################
-  # ERRORS
-  ########################################################################
-  # class Error < DuplicateError; end
-  # class Error < DraftSaveError; end
-  # class Error < PostingError; end
-
-
   ########################################################################
   # IMPORTING
   ########################################################################
-  # def self.import_from_url(url)
-  #   storyparser = StoryParser.new
-  #   if Work.find_by_imported_from_url(url)
-  #     raise DuplicateWorkError(t('already_imported', :default => "Work already imported from this url."))
-  #
-  #   work = storyparser.download_and_parse_story(url)
-  #   work.imported_from_url = url
-  #   work.expected_number_of_chapters = work.chapters.length
-  #   work.pseuds << current_user.default_pseud unless work.pseuds.include?(current_user.default_pseud)
-  #   chapters_saved = 0
-  #   work.chapters.each do |uploaded_chapter|
-  #     uploaded_chapter.pseuds << current_user.default_pseud unless uploaded_chapter.pseuds.include?(current_user.default_pseud)
-  #     uploaded_chapter.posted = true
-  #     chapters_saved += uploaded_chapter.save ? 1 : 0
-  #   end
-  #
-  #   raise DraftSaveError unless work.save && chapters_saved == work.chapters.length
-  # end
-  
+
+  # Match `url` to a work's imported_from_url field using progressively fuzzier matching:
+  # 1. first exact match
+  # 2. first exact match with variants of the provided url
+  # 3. first match on variants of both the imported_from_url and the provided url if there is a partial match
   def self.find_by_url(url)
     url = UrlFormatter.new(url)
     Work.where(:imported_from_url => url.original).first ||
       Work.where(:imported_from_url => [url.minimal, url.no_www, url.with_www, url.encoded, url.decoded]).first ||
-      Work.find do |w|
+      Work.where("imported_from_url LIKE ?", "%#{url.minimal_no_http}%").select { |w|
         work_url = UrlFormatter.new(w.imported_from_url)
         ['original', 'minimal', 'no_www', 'with_www', 'encoded', 'decoded'].map { |method|
           work_url.send(method) == url.send(method)
         }.include? true
-      end
+      }.first
   end
 
   ########################################################################

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -286,12 +286,11 @@ class Work < ActiveRecord::Base
     url = UrlFormatter.new(url)
     Work.where(:imported_from_url => url.original).first ||
       Work.where(:imported_from_url => [url.minimal, url.no_www, url.with_www, url.encoded, url.decoded]).first ||
-      Work.where("imported_from_url LIKE ?", "%#{url.minimal_no_http}%").select do |w|
+      Work.where("imported_from_url LIKE ?", "%#{url.minimal_no_http}%").select { |w|
         work_url = UrlFormatter.new(w.imported_from_url)
-        ['original', 'minimal', 'no_www', 'with_www', 'encoded', 'decoded'].map do |method|
-          work_url.send(method) == url.send(method)
-        end.include? true
-      end.first
+        ['original', 'minimal', 'no_www', 'with_www', 'encoded', 'decoded'].map { |method|
+          work_url.send(method) == url.send(method) }.any?
+      }.first
   end
 
   ########################################################################

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -289,7 +289,8 @@ class Work < ActiveRecord::Base
       Work.where("imported_from_url LIKE ?", "%#{url.minimal_no_http}%").select { |w|
         work_url = UrlFormatter.new(w.imported_from_url)
         ['original', 'minimal', 'no_www', 'with_www', 'encoded', 'decoded'].map { |method|
-          work_url.send(method) == url.send(method) }.any?
+          work_url.send(method) == url.send(method) 
+        }.any?
       }.first
   end
 

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -310,7 +310,12 @@ class Work < ActiveRecord::Base
     url = UrlFormatter.new(url)
     Work.where(:imported_from_url => url.original).first ||
       Work.where(:imported_from_url => [url.minimal, url.no_www, url.with_www, url.encoded, url.decoded]).first ||
-      Work.where("imported_from_url LIKE ? OR imported_from_url LIKE ?", "%#{url.encoded}%", "%#{url.decoded}%").first
+      Work.find { |w|
+        work_url = UrlFormatter.new(w.imported_from_url)
+        ['original', 'minimal', 'no_www', 'with_www', 'encoded', 'decoded'].map { |method|
+          work_url.send(method) == url.send(method)
+        }.include? true
+      }
   end
 
   ########################################################################

--- a/lib/url_formatter.rb
+++ b/lib/url_formatter.rb
@@ -26,6 +26,10 @@ class UrlFormatter
       return input.gsub(/(\?|#).*$/, '') << querystring.to_s
     end
   end
+
+  def minimal_no_http
+    minimal.gsub(/https?:\/\/www\./, "")
+  end
   
   def no_www
     minimal.gsub(/http:\/\/www\./, "http://")

--- a/spec/models/story_parser_spec.rb
+++ b/spec/models/story_parser_spec.rb
@@ -100,8 +100,8 @@ describe StoryParser do
 
   describe "check_for_previous_import" do
     let(:location_with_www) { "http://www.testme.org/welcome_to_test_vale.html" }
-    let(:location_no_www)   { "http://testme.org/welcome_to_test_vale.html" }
-    let(:location_partial_match)   { "http://testme.org/welcome_to_test_vale/12345" }
+    let(:location_no_www) { "http://testme.org/welcome_to_test_vale.html" }
+    let(:location_partial_match) { "http://testme.org/welcome_to_test_vale/12345" }
 
     it "should recognise previously imported www. works" do
       @work = FactoryGirl.create(:work, imported_from_url: location_with_www)
@@ -118,7 +118,7 @@ describe StoryParser do
     it "should not perform a partial match on work import locations" do
       @work = create(:work, imported_from_url: location_partial_match)
 
-      expect { @sp.check_for_previous_import("http://testme.org/welcome_to_test_vale/123")}.to_not raise_exception
+      expect { @sp.check_for_previous_import("http://testme.org/welcome_to_test_vale/123") }.to_not raise_exception
     end
   end
 

--- a/spec/models/story_parser_spec.rb
+++ b/spec/models/story_parser_spec.rb
@@ -101,6 +101,7 @@ describe StoryParser do
   describe "check_for_previous_import" do
     let(:location_with_www) { "http://www.testme.org/welcome_to_test_vale.html" }
     let(:location_no_www)   { "http://testme.org/welcome_to_test_vale.html" }
+    let(:location_partial_match)   { "http://testme.org/welcome_to_test_vale/12345" }
 
     it "should recognise previously imported www. works" do
       @work = FactoryGirl.create(:work, imported_from_url: location_with_www)
@@ -112,6 +113,12 @@ describe StoryParser do
       @work = FactoryGirl.create(:work, imported_from_url: location_no_www)
 
       expect { @sp.check_for_previous_import(location_with_www) }.to raise_exception
+    end
+
+    it "should not perform a partial match on work import locations" do
+      @work = create(:work, imported_from_url: location_partial_match)
+
+      expect { @sp.check_for_previous_import("http://testme.org/welcome_to_test_vale/123")}.to_not raise_exception
     end
   end
 

--- a/spec/models/work_spec.rb
+++ b/spec/models/work_spec.rb
@@ -167,5 +167,36 @@ describe Work do
 
   end
 
+  describe "#find_by_url" do
+
+    it "should find imported works with various URL formats" do
+      [
+        'http://foo.com/bar.html', 'http://foo.com/bar', 'http://lj-site.com/bar/foo?color=blue'
+      ].each do |url|
+        work = create(:work, imported_from_url: url)
+        expect(Work.find_by_url(url)).to eq(work)
+        work.destroy
+      end
+    end
+
+    it "should not mix up imported works with similar URLs or significant query parameters" do
+      {
+        'http://foo.com/12345' => 'http://foo.com/123',
+        'http://efiction-site.com/viewstory.php?sid=123' => 'http://efiction-site.com/viewstory.php?sid=456'
+      }.each do |import_url, find_url|
+        work = create(:work, imported_from_url: import_url)
+        expect(Work.find_by_url(find_url)).to_not eq(work)
+        work.destroy
+      end
+    end
+
+    it "should find works imported with irrelevant query parameters" do
+      work = create(:work, imported_from_url: 'http://lj-site.com/thing1?style=mine')
+      expect(Work.find_by_url('http://lj-site.com/thing1?style=other')).to eq(work)
+      work.destroy
+    end
+
+  end
+
 
 end

--- a/spec/models/work_spec.rb
+++ b/spec/models/work_spec.rb
@@ -164,7 +164,10 @@ describe Work do
   describe "#find_by_url" do
     it "should find imported works with various URL formats" do
       [
-        'http://foo.com/bar.html', 'http://foo.com/bar', 'http://lj-site.com/bar/foo?color=blue'
+        'http://foo.com/bar.html',
+        'http://foo.com/bar',
+        'http://lj-site.com/bar/foo?color=blue',
+        'http://www.foo.com/bar'
       ].each do |url|
         work = create(:work, imported_from_url: url)
         expect(Work.find_by_url(url)).to eq(work)
@@ -175,7 +178,8 @@ describe Work do
     it "should not mix up imported works with similar URLs or significant query parameters" do
       {
         'http://foo.com/12345' => 'http://foo.com/123',
-        'http://efiction-site.com/viewstory.php?sid=123' => 'http://efiction-site.com/viewstory.php?sid=456'
+        'http://efiction-site.com/viewstory.php?sid=123' => 'http://efiction-site.com/viewstory.php?sid=456',
+        'http://www.foo.com/i-am-something' => 'http://foo.com/i-am-something/else'
       }.each do |import_url, find_url|
         work = create(:work, imported_from_url: import_url)
         expect(Work.find_by_url(find_url)).to_not eq(work)

--- a/spec/models/work_spec.rb
+++ b/spec/models/work_spec.rb
@@ -108,17 +108,11 @@ describe Work do
       let(:work_author) {@skin_author}
       let(:work){build(:custom_work_skin, authors: [work_author.pseuds.first], work_skin_id: @private_skin.id)}
       it "can be used by the work skin author" do
-        puts work_author.login
-        puts work_author.pseuds.first.name
         expect(work.save).to be_truthy
       end
 
       let(:work){build(:custom_work_skin, authors: [@second_author.pseuds.first], work_skin_id: @private_skin.id)}
       xit "cannot be used by another user" do
-        puts @skin_author.login
-        puts @skin_author.pseuds.first.name
-        puts @second_author.login
-        puts @second_author.pseuds.first.name
         expect(work.save).to be_falsey
          expect(work.errors[:base]).to include("You do not have permission to use that custom work stylesheet.")
       end
@@ -168,7 +162,6 @@ describe Work do
   end
 
   describe "#find_by_url" do
-
     it "should find imported works with various URL formats" do
       [
         'http://foo.com/bar.html', 'http://foo.com/bar', 'http://lj-site.com/bar/foo?color=blue'
@@ -195,8 +188,5 @@ describe Work do
       expect(Work.find_by_url('http://lj-site.com/thing1?style=other')).to eq(work)
       work.destroy
     end
-
   end
-
-
 end


### PR DESCRIPTION
https://code.google.com/p/otwarchive/issues/detail?id=4325

Instead of doing a partial match as a last resort, the #find_by_url code now does exact matches based on various URL combinations. This should allow it to find URLs with insignificant query parameters (e.g. LiveJournal's ?style=mine), significant query parameters that we know about (e.g. eFiction's sid parameter) and URLs ending with consecutive numbers (like the temporary site I did for HASA before realising the bug existed).

Test cases have been added for all these scenarios.