### PR TITLE
Set comment ip addresses more securely and universally

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -163,6 +163,7 @@ class CommentsController < ApplicationController
       redirect_back_or_default(root_path)
     else
       @comment = Comment.new(params[:comment])
+      @comment.ip_address = request.remote_ip
       @comment.user_agent = request.env['HTTP_USER_AGENT']
       @comment.commentable = Comment.commentable_object(@commentable)
       @controller_name = params[:controller_name]

--- a/app/views/comments/_comment_form.html.erb
+++ b/app/views/comments/_comment_form.html.erb
@@ -78,7 +78,6 @@
           <dd>
             <%= f.text_field :email, :id => "comment_email_for_#{commentable.id}" %>
             <%= live_validation_for_field("comment_email_for_#{commentable.id}", :failureMessage => ts('Please enter your email address.')) %>
-            <%= f.hidden_field :ip_address, :value => "#{request.remote_ip}", :id => "comment_ip_address_for_#{commentable.id}" %>
           </dd>
         </dl>
 


### PR DESCRIPTION
Set IP address data for all comments and do it more securely in the controller instead of the view.

(No issue yet, will discuss.)