### PR TITLE
The old ao3-front01 and ao3-front02 have been repurposed to be

### DIFF
--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -15,6 +15,8 @@ server "ao3-app05.ao3.org",  :app
 server "ao3-app06.ao3.org",  :app
 server "ao3-app07.ao3.org",  :app
 server "ao3-app08.ao3.org",  :app , :workers , :schedulers
+server "ao3-app09.ao3.org",  :app , :workers , :schedulers
+server "ao3-app10.ao3.org",  :app , :workers , :schedulers
 server "ao3-app98.ao3.org",  :app , :workers , :schedulers
 server "ao3-app99.ao3.org",  :app , :workers , :schedulers
 server "ao3-front01.ao3.org", :web


### PR DESCRIPTION
resque workers ao3-app09 and ao3-app10. While it might mean we are
a bit heavy on the workers it will mean that the wrangulator will
fly. Additionally we don't record newrelic stats for resque workers
so we don't have to pay for resque workers, also we have a power budget
for the rack and we are under it so lets keep the machines for a bit
so we get some last work out of them for a year or so.