### PR TITLE
AO3-3546 change abuse form

### DIFF
--- a/app/mailers/admin_mailer.rb
+++ b/app/mailers/admin_mailer.rb
@@ -9,9 +9,14 @@ class AdminMailer < ActionMailer::Base
     abuse_report = AbuseReport.find(abuse_report_id)
     @email = abuse_report.email
     @url = abuse_report.url
-    meta = abuse_report.metadata
-    @author = meta["author"]
-    @title = meta["title"]
+    if abuse_report.metadata.nil?
+      @has_metadata = false
+    else
+      meta = abuse_report.metadata
+      @author = meta["author"]
+      @title = meta["title"]
+      @has_metadata = true
+    end
     @comment = abuse_report.comment
     mail(
       to: ArchiveConfig.ABUSE_ADDRESS,

--- a/app/mailers/admin_mailer.rb
+++ b/app/mailers/admin_mailer.rb
@@ -9,7 +9,9 @@ class AdminMailer < ActionMailer::Base
     abuse_report = AbuseReport.find(abuse_report_id)
     @email = abuse_report.email
     @url = abuse_report.url
-    @message = abuse_report.metadata
+    meta = abuse_report.metadata
+    @author = meta["author"]
+    @title = meta["title"]
     @comment = abuse_report.comment
     mail(
       to: ArchiveConfig.ABUSE_ADDRESS,

--- a/app/mailers/admin_mailer.rb
+++ b/app/mailers/admin_mailer.rb
@@ -9,6 +9,7 @@ class AdminMailer < ActionMailer::Base
     abuse_report = AbuseReport.find(abuse_report_id)
     @email = abuse_report.email
     @url = abuse_report.url
+    @message = abuse_report.metadata
     @comment = abuse_report.comment
     mail(
       to: ArchiveConfig.ABUSE_ADDRESS,

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -382,7 +382,9 @@ class UserMailer < BulletproofMailer::Base
     abuse_report = AbuseReport.find(abuse_report_id)
     @email = abuse_report.email
     @url = abuse_report.url
-    @message = abuse_report.metadata
+    meta = abuse_report.metadata
+    @author = meta["author"]
+    @title = meta["title"]
     @comment = abuse_report.comment
     mail(
       to: abuse_report.email,

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -382,6 +382,7 @@ class UserMailer < BulletproofMailer::Base
     abuse_report = AbuseReport.find(abuse_report_id)
     @email = abuse_report.email
     @url = abuse_report.url
+    @message = abuse_report.metadata
     @comment = abuse_report.comment
     mail(
       to: abuse_report.email,

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -382,9 +382,14 @@ class UserMailer < BulletproofMailer::Base
     abuse_report = AbuseReport.find(abuse_report_id)
     @email = abuse_report.email
     @url = abuse_report.url
-    meta = abuse_report.metadata
-    @author = meta["author"]
-    @title = meta["title"]
+    if abuse_report.metadata.nil?
+      @has_metadata = false
+    else
+      meta = abuse_report.metadata
+      @author = meta["author"]
+      @title = meta["title"]
+      @has_metadata = true
+    end
     @comment = abuse_report.comment
     mail(
       to: abuse_report.email,

--- a/app/models/abuse_report.rb
+++ b/app/models/abuse_report.rb
@@ -1,4 +1,6 @@
 class AbuseReport < ActiveRecord::Base
+  serialize :metadata, JSON
+
   validates_presence_of :comment
   validates_presence_of :url
   validates :email, :email_veracity => {:allow_blank => true}
@@ -29,7 +31,7 @@ class AbuseReport < ActiveRecord::Base
     id = url.match('(?<=works/)[0-9]+')[0]
     w = Work.find_by_id id
     if w
-      self.metadata = { author: w.authors_to_sort_on, title: w.title }
+      self.metadata =  { author: w.authors_to_sort_on, title: w.title } 
     end
   end
 

--- a/app/models/abuse_report.rb
+++ b/app/models/abuse_report.rb
@@ -29,10 +29,12 @@ class AbuseReport < ActiveRecord::Base
   before_save :get_work_info
   def get_work_info
     if url.include? "works"
-      work_id = match('(?<=works/)[0-9]+')[0]
-      w = Work.find_by_id work_id
-      if w
-        self.metadata =  { author: w.authors_to_sort_on, title: w.title } 
+      work_id = url.match('(?<=works/)[0-9]+')
+      if work_id
+        w = Work.find_by_id work_id[0]
+        if w
+          self.metadata =  { author: w.authors_to_sort_on, title: w.title } 
+        end
       end
     end
   end

--- a/app/models/abuse_report.rb
+++ b/app/models/abuse_report.rb
@@ -24,6 +24,15 @@ class AbuseReport < ActiveRecord::Base
     end
   end
 
+  before_save :get_work_info
+  def get_work_info
+    id = url.match('(?<=works/)[0-9]+')[0]
+    w = Work.find_by_id id
+    if w
+      self.metadata = { author: w.authors_to_sort_on, title: w.title }
+    end
+  end
+
   def email_copy?
    cc_me == "1"
   end

--- a/app/models/abuse_report.rb
+++ b/app/models/abuse_report.rb
@@ -33,14 +33,14 @@ class AbuseReport < ActiveRecord::Base
       if work_id
         w = Work.find_by_id work_id[0]
         if w
-          self.metadata =  { author: w.authors_to_sort_on, title: w.title } 
+          self.metadata = { author: w.authors_to_sort_on, title: w.title }
         end
       end
     end
   end
 
   def email_copy?
-   cc_me == "1"
+    cc_me == "1"
   end
 
   app_url_regex = Regexp.new('^https?:\/\/(www\.)?' + ArchiveConfig.APP_HOST, true)

--- a/app/models/abuse_report.rb
+++ b/app/models/abuse_report.rb
@@ -28,10 +28,12 @@ class AbuseReport < ActiveRecord::Base
 
   before_save :get_work_info
   def get_work_info
-    id = url.match('(?<=works/)[0-9]+')[0]
-    w = Work.find_by_id id
-    if w
-      self.metadata =  { author: w.authors_to_sort_on, title: w.title } 
+    if url.include? "works"
+      work_id = match('(?<=works/)[0-9]+')[0]
+      w = Work.find_by_id work_id
+      if w
+        self.metadata =  { author: w.authors_to_sort_on, title: w.title } 
+      end
     end
   end
 

--- a/app/views/admin_mailer/abuse_report.html.erb
+++ b/app/views/admin_mailer/abuse_report.html.erb
@@ -4,6 +4,9 @@
   
   Email of the person who reported the abuse, if given: <%= style_email(@email, @email) %><br>
   URL of the page the abuse is on: <%= style_link(@url, @url) %><br>
+  
+  Title of the work: <%= @title.html_safe %><br/>
+  Author(s) of the work: <%= @author.html_safe %><br/> 
   Description of the abuse:
   
   <%= style_quote(@comment) %>

--- a/app/views/admin_mailer/abuse_report.html.erb
+++ b/app/views/admin_mailer/abuse_report.html.erb
@@ -5,8 +5,10 @@
   Email of the person who reported the abuse, if given: <%= style_email(@email, @email) %><br>
   URL of the page the abuse is on: <%= style_link(@url, @url) %><br>
   
-  Title of the work: <%= @title.html_safe %><br/>
-  Author(s) of the work: <%= @author.html_safe %><br/> 
+  <% if @has_metadata %>
+    Title of the work: <%= @title.html_safe %><br/> 
+    Author(s) of the work: <%= @author.html_safe %><br/> 
+  <% end %>
   Description of the abuse:
   
   <%= style_quote(@comment) %>

--- a/app/views/admin_mailer/abuse_report.html.erb
+++ b/app/views/admin_mailer/abuse_report.html.erb
@@ -7,7 +7,7 @@
   
   <% if @has_metadata %>
     Title of the work: <%= @title.html_safe %><br/> 
-    Author(s) of the work: <%= @author.html_safe %><br/> 
+    Creator(s) of the work: <%= @author.html_safe %><br/> 
   <% end %>
   Description of the abuse:
   

--- a/app/views/admin_mailer/abuse_report.text.erb
+++ b/app/views/admin_mailer/abuse_report.text.erb
@@ -5,6 +5,9 @@ Email of the person who reported the abuse, if given: <%= @email %>
 
 URL of the page the abuse is on: <%= @url %>
 
+Title of the work: <%= @title %>
+Author(s) of the work: <%= @author %>
+
 Description of the abuse:
   
 "<%= to_plain_text(@comment) %>"

--- a/app/views/admin_mailer/abuse_report.text.erb
+++ b/app/views/admin_mailer/abuse_report.text.erb
@@ -5,9 +5,10 @@ Email of the person who reported the abuse, if given: <%= @email %>
 
 URL of the page the abuse is on: <%= @url %>
 
-Title of the work: <%= @title %>
-Author(s) of the work: <%= @author %>
-
+<% if @has_metadata %>
+  Title of the work: <%= @title %>
+  Author(s) of the work: <%= @author %>
+<% end %>
 Description of the abuse:
   
 "<%= to_plain_text(@comment) %>"

--- a/app/views/admin_mailer/abuse_report.text.erb
+++ b/app/views/admin_mailer/abuse_report.text.erb
@@ -7,7 +7,7 @@ URL of the page the abuse is on: <%= @url %>
 
 <% if @has_metadata %>
   Title of the work: <%= @title %>
-  Author(s) of the work: <%= @author %>
+  Creator(s) of the work: <%= @author %>
 <% end %>
 Description of the abuse:
   

--- a/app/views/user_mailer/abuse_report.html.erb
+++ b/app/views/user_mailer/abuse_report.html.erb
@@ -5,8 +5,10 @@
   
   <p>
     <%= style_bold("URL of the page the abuse is on:") %> <%= style_link(@url, @url) %><br/>
-    <%= style_bold("Title of the work:") %> <%= @title.html_safe %><br/>
-    <%= style_bold("Author(s) of the work:") %> <%= @author.html_safe %><br/>
+    <% if @has_metadata %>
+      <%= style_bold("Title of the work:") %> <%= @title.html_safe %><br/>
+      <%= style_bold("Author(s) of the work:") %> <%= @author.html_safe %><br/>
+    <% end %>
   </p>
   
   <%= style_bold("Description of the abuse:") %>

--- a/app/views/user_mailer/abuse_report.html.erb
+++ b/app/views/user_mailer/abuse_report.html.erb
@@ -4,7 +4,9 @@
   </p>
   
   <p>
-    <%= style_bold("URL of the page the abuse is on:") %> <%= style_link(@url, @url) %>
+    <%= style_bold("URL of the page the abuse is on:") %> <%= style_link(@url, @url) %><br/>
+    <%= style_bold("Title of the work:") %> <%= @title.html_safe %><br/>
+    <%= style_bold("Author(s) of the work:") %> <%= @author.html_safe %><br/>
   </p>
   
   <%= style_bold("Description of the abuse:") %>

--- a/app/views/user_mailer/abuse_report.html.erb
+++ b/app/views/user_mailer/abuse_report.html.erb
@@ -7,7 +7,7 @@
     <%= style_bold("URL of the page the abuse is on:") %> <%= style_link(@url, @url) %><br/>
     <% if @has_metadata %>
       <%= style_bold("Title of the work:") %> <%= @title.html_safe %><br/>
-      <%= style_bold("Author(s) of the work:") %> <%= @author.html_safe %><br/>
+      <%= style_bold("Creator(s) of the work:") %> <%= @author.html_safe %><br/>
     <% end %>
   </p>
   

--- a/app/views/user_mailer/abuse_report.text.erb
+++ b/app/views/user_mailer/abuse_report.text.erb
@@ -5,7 +5,7 @@ URL of the page the abuse is on: <%= @url %>
 
 <% if @has_metadata %>
   Title of the work: <%= @title %>
-  Author(s) of the work: <%= @author %>
+  Creator(s) of the work: <%= @author %>
 <% end %>
   
 Description of the abuse:

--- a/app/views/user_mailer/abuse_report.text.erb
+++ b/app/views/user_mailer/abuse_report.text.erb
@@ -2,6 +2,8 @@
 The following abuse report has been sent to the Abuse team:
   
 URL of the page the abuse is on: <%= @url %>
+Title of the work: <%= @title %>
+Author(s) of the work: <%= @author %>
   
 Description of the abuse:
 <%= text_divider %>

--- a/app/views/user_mailer/abuse_report.text.erb
+++ b/app/views/user_mailer/abuse_report.text.erb
@@ -2,8 +2,11 @@
 The following abuse report has been sent to the Abuse team:
   
 URL of the page the abuse is on: <%= @url %>
-Title of the work: <%= @title %>
-Author(s) of the work: <%= @author %>
+
+<% if @has_metadata %>
+  Title of the work: <%= @title %>
+  Author(s) of the work: <%= @author %>
+<% end %>
   
 Description of the abuse:
 <%= text_divider %>

--- a/db/migrate/20150907163906_add_metadata_to_abuse_reports.rb
+++ b/db/migrate/20150907163906_add_metadata_to_abuse_reports.rb
@@ -1,0 +1,5 @@
+class AddMetadataToAbuseReports < ActiveRecord::Migration
+  def change
+    add_column :abuse_reports, :metadata, :text
+  end
+end

--- a/spec/mailers/abuse_mailer_spec.rb
+++ b/spec/mailers/abuse_mailer_spec.rb
@@ -16,14 +16,6 @@ describe AdminMailer do
       expect(mail).to deliver_from("Archive of Our Own <#{ArchiveConfig.RETURN_ADDRESS}>")
     end
    
-    it "body text contains the title of the reported work" do
-      expect(mail).to have_body_text(/#{report.metadata["title"]}/)
-    end
-
-    it "body text contains the author of the reported work" do
-      expect(mail).to have_body_text(/#{report.metadata["author"]}/)
-    end
-    
     it "body text contains the comment" do
       expect(mail).to have_body_text(/#{report.comment}/)
     end
@@ -56,14 +48,6 @@ describe AdminMailer do
 
     it "delivers from the correct address" do
       expect(mail).to deliver_from("Archive of Our Own <#{ArchiveConfig.RETURN_ADDRESS}>")
-    end
-
-    it "body text contains the title of the reported work" do
-      expect(mail).to have_body_text(/#{report.metadata["title"]}/)
-    end
-
-    it "body text contains the author of the reported work" do
-      expect(mail).to have_body_text(/#{report.metadata["author"]}/)
     end
 
     it "body text contains the comment" do
@@ -100,6 +84,32 @@ describe AdminMailer do
      expect(mail).to deliver_from("Archive of Our Own <#{ArchiveConfig.RETURN_ADDRESS}>")
    end
 
+   it "body text contains the comment" do
+     expect(mail).to have_body_text(/#{report.comment}/)
+   end
+   
+   it "has the url of the page with abuse" do
+     expect(mail.html_part).to have_body_text(report.url)
+   end
+  end
+
+  
+  context "abuse_reports contains creator and title if reporting a work" do
+   let(:report) {create(:abuse_report, url: "http://archiveofourown.org/works/3753052?view_full_work=true")}
+   let(:mail) {AdminMailer.abuse_report(report.id)}
+
+   it "has the correct subject" do
+     expect(mail).to have_subject "[#{ArchiveConfig.APP_SHORT_NAME}] Admin Abuse Report"
+   end
+
+   it "delivers to the correct address" do
+     expect(mail).to deliver_to ArchiveConfig.ABUSE_ADDRESS
+   end
+
+   it "delivers from the correct address" do
+     expect(mail).to deliver_from("Archive of Our Own <#{ArchiveConfig.RETURN_ADDRESS}>")
+   end
+
    it "body text contains the title of the reported work" do
      expect(mail).to have_body_text(/#{report.metadata["title"]}/)
    end
@@ -116,6 +126,5 @@ describe AdminMailer do
      expect(mail.html_part).to have_body_text(report.url)
    end
   end
-
 
 end

--- a/spec/mailers/abuse_mailer_spec.rb
+++ b/spec/mailers/abuse_mailer_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
 describe AdminMailer do
   context "abuse_reports with email" do
-    let(:report) { create(:abuse_report) }
-    let(:mail) { AdminMailer.abuse_report(report.id) }
+    let(:report) {create(:abuse_report)}
+    let(:mail) {AdminMailer.abuse_report(report.id)}
 
     it "has the correct subject" do
       expect(mail).to have_subject "[#{ArchiveConfig.APP_SHORT_NAME}] Admin Abuse Report"
@@ -31,8 +31,8 @@ describe AdminMailer do
   end
 
   context "abuse_reports without email" do
-    let(:report) { create(:abuse_report) }
-    let(:mail) { AdminMailer.abuse_report(report.id) }
+    let(:report) {create(:abuse_report)}
+    let(:mail) {AdminMailer.abuse_report(report.id)}
 
     it "has the correct subject" do
       expect(mail).to have_subject "[#{ArchiveConfig.APP_SHORT_NAME}] Admin Abuse Report"
@@ -61,9 +61,9 @@ describe AdminMailer do
   end
 
   context "abuse_reports sends copy if cc_me is checked" do
-    let(:report) { create(:abuse_report, email: "cc_me@email.com", cc_me: "1") }
-    let(:mail) { AdminMailer.abuse_report(report.id) }
-    let(:mail2) { UserMailer.abuse_report(report.id) }
+    let(:report) {create(:abuse_report, email: "cc_me@email.com", cc_me: "1")}
+    let(:mail) {AdminMailer.abuse_report(report.id)}
+    let(:mail2) {UserMailer.abuse_report(report.id)}
 
     it "has the correct subject" do
       puts report.email_copy?
@@ -94,9 +94,9 @@ describe AdminMailer do
   end
 
   context "abuse_reports contains creator and title if reporting a work" do
-    let(:work) { create(:work) }
-    let(:report) { create(:abuse_report, url: work_url(work.url)) }
-    let(:mail) { AdminMailer.abuse_report(report.id) }
+    let(:work) {create(:work)}
+    let(:report) {create(:abuse_report, url: work_url(work))}
+    let(:mail) {AdminMailer.abuse_report(report.id)}
 
     it "has the correct subject" do
       expect(mail).to have_subject "[#{ArchiveConfig.APP_SHORT_NAME}] Admin Abuse Report"

--- a/spec/mailers/abuse_mailer_spec.rb
+++ b/spec/mailers/abuse_mailer_spec.rb
@@ -95,7 +95,8 @@ describe AdminMailer do
 
   
   context "abuse_reports contains creator and title if reporting a work" do
-   let(:report) {create(:abuse_report, url: "http://archiveofourown.org/works/3753052?view_full_work=true")}
+   let(:work) {create(:work)}
+   let(:report) {create(:abuse_report, url: work.url)}
    let(:mail) {AdminMailer.abuse_report(report.id)}
 
    it "has the correct subject" do
@@ -105,7 +106,6 @@ describe AdminMailer do
    it "delivers to the correct address" do
      expect(mail).to deliver_to ArchiveConfig.ABUSE_ADDRESS
    end
-
    it "delivers from the correct address" do
      expect(mail).to deliver_from("Archive of Our Own <#{ArchiveConfig.RETURN_ADDRESS}>")
    end

--- a/spec/mailers/abuse_mailer_spec.rb
+++ b/spec/mailers/abuse_mailer_spec.rb
@@ -96,7 +96,7 @@ describe AdminMailer do
   
   context "abuse_reports contains creator and title if reporting a work" do
    let(:work) {create(:work)}
-   let(:report) {create(:abuse_report, url: work.url)}
+   let(:report) {create(:abuse_report, url: work_url(work.url)}
    let(:mail) {AdminMailer.abuse_report(report.id)}
 
    it "has the correct subject" do

--- a/spec/mailers/abuse_mailer_spec.rb
+++ b/spec/mailers/abuse_mailer_spec.rb
@@ -96,7 +96,7 @@ describe AdminMailer do
   
   context "abuse_reports contains creator and title if reporting a work" do
    let(:work) {create(:work)}
-   let(:report) {create(:abuse_report, url: work_url(work.url)}
+   let(:report) {create(:abuse_report, url: work_url(work.url))}
    let(:mail) {AdminMailer.abuse_report(report.id)}
 
    it "has the correct subject" do

--- a/spec/mailers/abuse_mailer_spec.rb
+++ b/spec/mailers/abuse_mailer_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
 describe AdminMailer do
   context "abuse_reports with email" do
-    let(:report) {create(:abuse_report)}
-    let(:mail) {AdminMailer.abuse_report(report.id)}
+    let(:report) { create(:abuse_report) }
+    let(:mail) { AdminMailer.abuse_report(report.id) }
 
     it "has the correct subject" do
       expect(mail).to have_subject "[#{ArchiveConfig.APP_SHORT_NAME}] Admin Abuse Report"
@@ -31,8 +31,8 @@ describe AdminMailer do
   end
 
   context "abuse_reports without email" do
-    let(:report) {create(:abuse_report)}
-    let(:mail) {AdminMailer.abuse_report(report.id)}
+    let(:report) { create(:abuse_report) }
+    let(:mail) { AdminMailer.abuse_report(report.id) }
 
     it "has the correct subject" do
       expect(mail).to have_subject "[#{ArchiveConfig.APP_SHORT_NAME}] Admin Abuse Report"
@@ -61,70 +61,71 @@ describe AdminMailer do
   end
 
   context "abuse_reports sends copy if cc_me is checked" do
-   let(:report) {create(:abuse_report, email: "cc_me@email.com", cc_me: "1")}
-   let(:mail) {AdminMailer.abuse_report(report.id)}
-   let(:mail2) {UserMailer.abuse_report(report.id)}
+    let(:report) { create(:abuse_report, email: "cc_me@email.com", cc_me: "1") }
+    let(:mail) { AdminMailer.abuse_report(report.id) }
+    let(:mail2) { UserMailer.abuse_report(report.id) }
 
+    it "has the correct subject" do
+      puts report.email_copy?
+      puts report.cc_me
+      expect(mail).to have_subject "[#{ArchiveConfig.APP_SHORT_NAME}] Admin Abuse Report"
+    end
 
-   it "has the correct subject" do
-     puts report.email_copy?
-     puts report.cc_me
-     expect(mail).to have_subject "[#{ArchiveConfig.APP_SHORT_NAME}] Admin Abuse Report"
-   end
+    it "delivers to the correct address" do
+      expect(mail).to deliver_to ArchiveConfig.ABUSE_ADDRESS
+    end
 
-   it "delivers to the correct address" do
-     expect(mail).to deliver_to ArchiveConfig.ABUSE_ADDRESS
-   end
+    it "ccs the user who filed the report" do
+      expect(mail2).to deliver_to("cc_me@email.com")
+    end
 
-   it "ccs the user who filed the report" do
-     expect(mail2).to deliver_to("cc_me@email.com")
-   end
+    it "delivers from the correct address" do
+      expect(mail).to deliver_from("Archive of Our Own <#{ArchiveConfig.RETURN_ADDRESS}>")
+    end
 
-   it "delivers from the correct address" do
-     expect(mail).to deliver_from("Archive of Our Own <#{ArchiveConfig.RETURN_ADDRESS}>")
-   end
+    it "body text contains the comment" do
+      expect(mail).to have_body_text(/#{report.comment}/)
+    end
 
-   it "body text contains the comment" do
-     expect(mail).to have_body_text(/#{report.comment}/)
-   end
-   
-   it "has the url of the page with abuse" do
-     expect(mail.html_part).to have_body_text(report.url)
-   end
+    it "has the url of the page with abuse" do
+      expect(mail.html_part).to have_body_text(report.url)
+    end
+
   end
 
-  
   context "abuse_reports contains creator and title if reporting a work" do
-   let(:work) {create(:work)}
-   let(:report) {create(:abuse_report, url: work_url(work.url))}
-   let(:mail) {AdminMailer.abuse_report(report.id)}
+    let(:work) { create(:work) }
+    let(:report) { create(:abuse_report, url: work_url(work.url)) }
+    let(:mail) { AdminMailer.abuse_report(report.id) }
 
-   it "has the correct subject" do
-     expect(mail).to have_subject "[#{ArchiveConfig.APP_SHORT_NAME}] Admin Abuse Report"
-   end
+    it "has the correct subject" do
+      expect(mail).to have_subject "[#{ArchiveConfig.APP_SHORT_NAME}] Admin Abuse Report"
+    end
 
-   it "delivers to the correct address" do
-     expect(mail).to deliver_to ArchiveConfig.ABUSE_ADDRESS
-   end
-   it "delivers from the correct address" do
-     expect(mail).to deliver_from("Archive of Our Own <#{ArchiveConfig.RETURN_ADDRESS}>")
-   end
+    it "delivers to the correct address" do
+      expect(mail).to deliver_to ArchiveConfig.ABUSE_ADDRESS
+    end
 
-   it "body text contains the title of the reported work" do
-     expect(mail).to have_body_text(/#{report.metadata["title"]}/)
-   end
+    it "delivers from the correct address" do
+      expect(mail).to deliver_from("Archive of Our Own <#{ArchiveConfig.RETURN_ADDRESS}>")
+    end
 
-   it "body text contains the author of the reported work" do
-     expect(mail).to have_body_text(/#{report.metadata["author"]}/)
-   end
+    it "body text contains the title of the reported work" do
+      expect(mail).to have_body_text(/#{report.metadata["title"]}/)
+    end
 
-   it "body text contains the comment" do
-     expect(mail).to have_body_text(/#{report.comment}/)
-   end
+    it "body text contains the author of the reported work" do
+      expect(mail).to have_body_text(/#{report.metadata["author"]}/)
+    end
+
+    it "body text contains the comment" do
+      expect(mail).to have_body_text(/#{report.comment}/)
+    end
    
-   it "has the url of the page with abuse" do
-     expect(mail.html_part).to have_body_text(report.url)
-   end
+    it "has the url of the page with abuse" do
+      expect(mail.html_part).to have_body_text(report.url)
+    end
+
   end
 
 end

--- a/spec/mailers/abuse_mailer_spec.rb
+++ b/spec/mailers/abuse_mailer_spec.rb
@@ -15,7 +15,15 @@ describe AdminMailer do
     it "delivers from the correct address" do
       expect(mail).to deliver_from("Archive of Our Own <#{ArchiveConfig.RETURN_ADDRESS}>")
     end
+   
+    it "body text contains the title of the reported work" do
+      expect(mail).to have_body_text(/#{report.metadata["title"]}/)
+    end
 
+    it "body text contains the author of the reported work" do
+      expect(mail).to have_body_text(/#{report.metadata["author"]}/)
+    end
+    
     it "body text contains the comment" do
       expect(mail).to have_body_text(/#{report.comment}/)
     end
@@ -48,6 +56,14 @@ describe AdminMailer do
 
     it "delivers from the correct address" do
       expect(mail).to deliver_from("Archive of Our Own <#{ArchiveConfig.RETURN_ADDRESS}>")
+    end
+
+    it "body text contains the title of the reported work" do
+      expect(mail).to have_body_text(/#{report.metadata["title"]}/)
+    end
+
+    it "body text contains the author of the reported work" do
+      expect(mail).to have_body_text(/#{report.metadata["author"]}/)
     end
 
     it "body text contains the comment" do
@@ -84,10 +100,18 @@ describe AdminMailer do
      expect(mail).to deliver_from("Archive of Our Own <#{ArchiveConfig.RETURN_ADDRESS}>")
    end
 
+   it "body text contains the title of the reported work" do
+     expect(mail).to have_body_text(/#{report.metadata["title"]}/)
+   end
+
+   it "body text contains the author of the reported work" do
+     expect(mail).to have_body_text(/#{report.metadata["author"]}/)
+   end
+
    it "body text contains the comment" do
      expect(mail).to have_body_text(/#{report.comment}/)
    end
-
+   
    it "has the url of the page with abuse" do
      expect(mail.html_part).to have_body_text(report.url)
    end


### PR DESCRIPTION
* Modified AbuseReport model to include a metadata attribute which contains the title and the author of the work, when a work is reported
* Modified the AdminMailer and UserMailer to pull the author and title from the metadata and pass it to the AbuseReport mail views
* Modified abuse mailer spec to check for correct metadata
* Added migration required to add the metadata field to the AbuseReport ActiveRecord
