### PR TITLE
AO3-4339 Make deferred cucumbers point to new JIRA issues

### DIFF
--- a/features/collections/collection_anonymity.feature
+++ b/features/collections/collection_anonymity.feature
@@ -261,7 +261,7 @@ Feature: Collection
   # check the series
   When I follow "Another Snippet"
     And I follow "New series"
-    And "Issue 1253" is fixed
+    And "AO3-1250" is fixed
   Then I should see "Anonymous"
     # And I should not see "first_user"
   
@@ -383,7 +383,7 @@ Feature: Collection
   When I uncheck the 2nd checkbox with id matching "collection_items_\d+_unrevealed"
     And I submit
   # Issue 2243: emails don't get sent for individual reveals
-  When "Issue 2243" is fixed
+  When "AO3-2240" is fixed
     #Then 1 email should be delivered
     
   # first fic now visible, second still not

--- a/features/comments_and_kudos/kudos.feature
+++ b/features/comments_and_kudos/kudos.feature
@@ -80,7 +80,7 @@ Feature: Leave kudos
     # Then I should see "barfoo (myname3) left kudos on this work!"
     When "myname3" deletes their account
       And I view the work "Awesome Story"
-      And "issue 2198" is fixed
+      And "AO3-2195" is fixed
     # Then I should see "1 guest left kudos on this work!"
 
   Scenario: redirection when kudosing on a middle chapter, with default preferences

--- a/features/importing/work_import_lj.feature
+++ b/features/importing/work_import_lj.feature
@@ -94,7 +94,7 @@ Feature: Import Works from LJ
   Scenario: Creating a new work from an LJ story that is posted to a community
     Given basic tags
       And I am logged in as "cosomeone"
-    When "Issue 4817" is fixed
+    When "AO3-4179" is fixed
     #When I go to the import page
     #  And I fill in "urls" with "http://community.livejournal.com/rarelitslash/271960.html"
     #When I press "Import"

--- a/features/other_b/series.feature
+++ b/features/other_b/series.feature
@@ -196,14 +196,14 @@ Feature: Create and Edit Series
       And I should see "Many a Robot"
     When I view the work "WALL-E"
       Then I should see "Part 1 of the Many a Robot series" within "div#series"
-    # TODO: fix issue 3855
+    And "AO3-3847" is fixed
     #  And I should see "Part 1 of the Many a Robot series" within "dd.series"
 
   Scenario: Post Without Preview
     Given I am logged in as "whoever" with password "whatever"
       And I add the work "public" to series "be_public"
       And I follow "be_public"
-      And "Issue 2169" is fixed
+      And "AO3-2166" is fixed
   # Then I should not see the "title" text "Restricted" within "h2"
 
   Scenario: View user's series index

--- a/features/other_b/series.feature
+++ b/features/other_b/series.feature
@@ -203,8 +203,7 @@ Feature: Create and Edit Series
     Given I am logged in as "whoever" with password "whatever"
       And I add the work "public" to series "be_public"
       And I follow "be_public"
-      And "AO3-2166" is fixed
-  # Then I should not see the "title" text "Restricted" within "h2"
+    Then I should not see the image "title" text "Restricted" within "h2"
 
   Scenario: View user's series index
 

--- a/features/prompt_memes_a/challenge_promptmeme.feature
+++ b/features/prompt_memes_a/challenge_promptmeme.feature
@@ -1290,7 +1290,7 @@ Feature: Prompt Meme Challenge
   Then I should see "Draft was successfully created"
     And I should see "In response to a prompt by myname4"
     And 0 emails should be delivered
-    When "Issue 3461" is fixed
+    When "AO3-3455" is fixed
   #  And I should see "Collections:"
    # And I should see "Battle 12"
   When I view the work "Existing work"
@@ -1375,7 +1375,7 @@ Feature: Prompt Meme Challenge
     And I check "Battle 12"
     And I press "Preview"
   Then I should see "In response to a prompt by"
-    When "Issue 3461" is fixed
+    When "AO3-3455" is fixed
   #  And I should see "Collections:"
    # And I should see "Battle 12"
   When I press "Update"

--- a/features/works/chapter_edit.feature
+++ b/features/works/chapter_edit.feature
@@ -35,9 +35,9 @@ Feature: Edit chapters
     And I fill in "chapter_position" with "2"
     And I fill in "chapter_wip_length" with "100"
     And I fill in "content" with "original chapter two"
-    And "Issue 3306" is fixed
+    And "AO3-3300" is fixed
     # All the commented out bits in the following examples need to be changed
-    # back once Issue 3306 has bee fixed.
+    # back once AO3-3300 has bee fixed.
     #And I press "Preview"
   #Then I should see "This is a draft chapter in a posted work. It will be kept unless the work is deleted."
   #When I press "Post"

--- a/features/works/work_dates_edit.feature
+++ b/features/works/work_dates_edit.feature
@@ -5,7 +5,7 @@ Feature: Edit Works Dates
   I want to edit existing works
 
   Scenario: Editing dates on a work
-    When "Issue 2542" is fixed
+    When "AO3-2539" is fixed
 #    Given I have loaded the fixtures
 #      And I am logged in as "testuser" with password "testuser"
 #      And all search indexes are updated

--- a/features/works/work_edit.feature
+++ b/features/works/work_edit.feature
@@ -112,7 +112,7 @@ Feature: Edit Works
     Then I should not see "You have submitted your work to the moderated collection 'Digital Hoarders 2013'. It will not become a part of the collection until it has been approved by a moderator."
       
   Scenario: Editing a work you created today should not bump its revised-at date
-      When "Issue 2542" is fixed    
+      When "AO3-2539" is fixed    
 # Given I am logged in as "testuser" with password "testuser"
 #      And I post the work "Don't Bump Me"
 #      And I post the work "This One Stays On Top"

--- a/features/works/work_related.feature
+++ b/features/works/work_related.feature
@@ -173,7 +173,7 @@ Scenario: Editing an existing work to add an inspiration (parent work) should se
   When I press "Update"
   Then I should see "Work was successfully updated"
     And I should see "Inspired by Worldbuilding Two by inspiration"
-    And "issue 1509" is fixed
+    And "AO3-1506" is fixed
     # And 1 email should be delivered
 
 Scenario: Remixer receives comments on remix, creator of original work doesn't
@@ -274,7 +274,7 @@ Scenario: Listing external works as inspirations
   When I edit the work "Followup"
     And I check "parent-options-show"
     And I fill in "Url" with "testarchive.transformativeworks.org"
-    And "issue 1806" is fixed
+    And "AO3-1803" is fixed
     # And I press "Preview"
   # Then I should see a save error message
     # And I should see "A parent work outside the archive needs to have a title."


### PR DESCRIPTION
Resolves: https://otwarchive.atlassian.net/browse/AO3-4339

Deferred Cucumber tests (or pieces of them) refer to Google Code issue numbers, which don't correspond directly to their new JIRA issue number. I've gone through the cucumbers and replaced all the old numbers with new numbers.