### PR TITLE
AO3-4340 Allow sensible values for transform and clip CSS properties

### DIFF
--- a/lib/css_cleaner.rb
+++ b/lib/css_cleaner.rb
@@ -11,12 +11,12 @@ module CssCleaner
   NUMBER_WITH_UNIT_REGEX = Regexp.new("#{NUMBER_REGEX}\s*#{UNITS_REGEX}?\s*,?\s*")
   PAREN_NUMBER_REGEX = Regexp.new('\(\s*' + NUMBER_WITH_UNIT_REGEX.to_s + '+\s*\)')
   PREFIX_REGEX = Regexp.new('moz|ms|o|webkit')
-  
+
   FUNCTION_NAME_REGEX = Regexp.new('scalex?y?|translatex?y?|skewx?y?|rotatex?y?|matrix', Regexp::IGNORECASE)
   TRANSFORM_FUNCTION_REGEX = Regexp.new("#{FUNCTION_NAME_REGEX}#{PAREN_NUMBER_REGEX}")
 
   SHAPE_NAME_REGEX = Regexp.new('rect', Regexp::IGNORECASE)
-  SHAPE_FUNCTION_REGEX =  Regexp.new("#{SHAPE_NAME_REGEX}#{PAREN_NUMBER_REGEX}")
+  SHAPE_FUNCTION_REGEX = Regexp.new("#{SHAPE_NAME_REGEX}#{PAREN_NUMBER_REGEX}")
 
   RGBA_REGEX = Regexp.new('rgba?' + PAREN_NUMBER_REGEX.to_s, Regexp::IGNORECASE)
   COLOR_REGEX = Regexp.new('#[0-9a-f]{3,6}|' + ALPHA_REGEX.to_s + '|' + RGBA_REGEX.to_s)
@@ -82,12 +82,12 @@ module CssCleaner
     end
     return clean_css
   end
-  
+
   def is_legal_property(property)
     ArchiveConfig.SUPPORTED_CSS_PROPERTIES.include?(property) || 
       property.match(/-(#{PREFIX_REGEX})-(#{ArchiveConfig.SUPPORTED_CSS_PROPERTIES.join('|')})/)
   end
-  
+
   def is_legal_shorthand_property(property)
     property.match(/#{ArchiveConfig.SUPPORTED_CSS_SHORTHAND_PROPERTIES.join('|')}/)
   end
@@ -234,6 +234,6 @@ module CssCleaner
       return ""
     end
   end
-  
+
 
 end

--- a/lib/css_cleaner.rb
+++ b/lib/css_cleaner.rb
@@ -12,8 +12,11 @@ module CssCleaner
   PAREN_NUMBER_REGEX = Regexp.new('\(\s*' + NUMBER_WITH_UNIT_REGEX.to_s + '+\s*\)')
   PREFIX_REGEX = Regexp.new('moz|ms|o|webkit')
   
-  FUNCTION_NAME_REGEX = Regexp.new('scalex?y?|translatex?y?|skewx?y?|rotate|matrix', Regexp::IGNORECASE)
+  FUNCTION_NAME_REGEX = Regexp.new('scalex?y?|translatex?y?|skewx?y?|rotatex?y?|matrix', Regexp::IGNORECASE)
   TRANSFORM_FUNCTION_REGEX = Regexp.new("#{FUNCTION_NAME_REGEX}#{PAREN_NUMBER_REGEX}")
+
+  SHAPE_NAME_REGEX = Regexp.new('rect', Regexp::IGNORECASE)
+  SHAPE_FUNCTION_REGEX =  Regexp.new("#{SHAPE_NAME_REGEX}#{PAREN_NUMBER_REGEX}")
 
   RGBA_REGEX = Regexp.new('rgba?' + PAREN_NUMBER_REGEX.to_s, Regexp::IGNORECASE)
   COLOR_REGEX = Regexp.new('#[0-9a-f]{3,6}|' + ALPHA_REGEX.to_s + '|' + RGBA_REGEX.to_s)
@@ -27,7 +30,7 @@ module CssCleaner
   URL_REGEX = Regexp.new(URI_REGEX.to_s + '|"' + URI_REGEX.to_s + '"|\'' + URI_REGEX.to_s + '\'')
   URL_FUNCTION_REGEX = Regexp.new('url\(\s*' + URL_REGEX.to_s + '\s*\)')
 
-  VALUE_REGEX = Regexp.new("#{TRANSFORM_FUNCTION_REGEX}|#{URL_FUNCTION_REGEX}|#{COLOR_STOP_FUNCTION_REGEX}|#{COLOR_REGEX}|#{NUMBER_WITH_UNIT_REGEX}|#{ALPHA_REGEX}")
+  VALUE_REGEX = Regexp.new("#{TRANSFORM_FUNCTION_REGEX}|#{URL_FUNCTION_REGEX}|#{COLOR_STOP_FUNCTION_REGEX}|#{COLOR_REGEX}|#{NUMBER_WITH_UNIT_REGEX}|#{ALPHA_REGEX}|#{SHAPE_FUNCTION_REGEX}")
 
 
   # For use in ActiveRecord models

--- a/spec/models/skin_spec.rb
+++ b/spec/models/skin_spec.rb
@@ -72,13 +72,14 @@ describe Skin do
           color:rgba(254,254,254,1)
         }",
 
-      "should allow through gradients, scale, skew, translate, rotate" =>
+      "should allow through gradients, clip, scale, skew, translate, rotate" =>
         "#main ul.sorting {
         background:-moz-linear-gradient(bottom, rgba(120,120,120,1) 5%, rgba(94,94,94,1) 50%, rgba(108,108,108,1) 55%, rgba(137,137,137,1) 100%) ;
         }
         ul.sorting  a:hover {
         background:-webkit-linear-gradient(bottom, rgba(71,71,71,1) 5%, rgba(59,59,59,1) 50%, rgba(74,74,74,1) 55%, rgba(91,91,91,1) 100%) !important;
         }
+        #main .clip {clip: rect(1em, 2em, 3em, 4em);}
         #main li.blurb:nth-child(2n), #main.works-show .meta, .thread .thread li.comment:nth-child(3n+1) {-moz-transform: rotate(-0.5deg);}
         #main .foo {-moz-transform:rotate(120deg); -moz-transform:skewx(25deg) translatex(150px);}
         #menu {
@@ -87,7 +88,9 @@ describe Skin do
                     	-webkit-border-radius:2px;
                     	-webkit-transition:text-shadow .7s ease-out, background .7s ease-out;
                     	-webkit-transform: scale(2.1) rotate(-90deg)
-        }",
+        }
+        #main .rotatvert {transform: rotatey(180deg);}
+        .rotatehoriz {transform: rotatex(50deg)}",
 
         "should allow multiple valid values for a single property" =>
         "#outer .actions a:hover,symbol .question:hover,.actions input:hover,#outer input[type=\"submit\"]:hover,button:hover,.actions label:hover

--- a/spec/models/skin_spec.rb
+++ b/spec/models/skin_spec.rb
@@ -89,7 +89,7 @@ describe Skin do
                     	-webkit-transition:text-shadow .7s ease-out, background .7s ease-out;
                     	-webkit-transform: scale(2.1) rotate(-90deg)
         }
-        #main .rotatvert {transform: rotatey(180deg);}
+        #main .rotatevert {transform: rotatey(180deg);}
         .rotatehoriz {transform: rotatex(50deg)}",
 
         "should allow multiple valid values for a single property" =>


### PR DESCRIPTION
https://otwarchive.atlassian.net/browse/AO3-4340

Basically, we allow the `clip` property in skins, but don't currently allow the only useful value for it: `rect(top, right, bottom, left)`. We also allow the `transform` property, and the `rotate()` transformation, but not `rotatex(angle)` or `rotatey(angle)`, despite allowing `scalex()` and `scaley()` for the same property. Twas all very odd.

Obviously, this is a Very Important pull request.