### PR TITLE
AO3-4347 Remove Uncategorized Fandoms from category list in collection

### DIFF
--- a/app/controllers/fandoms_controller.rb
+++ b/app/controllers/fandoms_controller.rb
@@ -3,7 +3,7 @@ class FandomsController < ApplicationController
 
   def index
     if @collection
-      @media = Media.canonical.by_name - [Media.find_by_name(ArchiveConfig.MEDIA_NO_TAG_NAME)]
+      @media = Media.canonical.by_name - [Media.find_by_name(ArchiveConfig.MEDIA_NO_TAG_NAME)] - [Media.find_by_name(ArchiveConfig.MEDIA_UNCATEGORIZED_NAME)]
       @page_subtitle = @collection.title
       if params[:medium_id]
         @medium = Media.find_by_name(params[:medium_id])


### PR DESCRIPTION
https://otwarchive.atlassian.net/browse/AO3-4347

On a collection's Fandoms page, "Uncategorized Fandoms" was included in the select menu for browsing y category. However, the page was always empty. This removes the option from the menu.