### PR TITLE
AO3-4344 Banned and Suspended users cannot participate in Collections

### DIFF
--- a/app/controllers/collection_participants_controller.rb
+++ b/app/controllers/collection_participants_controller.rb
@@ -109,7 +109,14 @@ class CollectionParticipantsController < ApplicationController
     end
     
     if @participants_invited.empty? && @participants_added.empty?
-      flash[:error] = ts("We couldn't find anyone new by that name to add.")
+      if pseud_results[:banned_pseuds].present?
+        flash[:error] =
+            ts("%{name} is currently banned and cannot participate in Challenges.",
+               name: pseud_results[:banned_pseuds].to_sentence
+        )
+      else
+        flash[:error] = ts("We couldn't find anyone new by that name to add.")
+      end
     else
       flash[:notice] = ""
     end

--- a/app/controllers/collection_participants_controller.rb
+++ b/app/controllers/collection_participants_controller.rb
@@ -111,7 +111,7 @@ class CollectionParticipantsController < ApplicationController
     if @participants_invited.empty? && @participants_added.empty?
       if pseud_results[:banned_pseuds].present?
         flash[:error] =
-            ts("%{name} is currently banned and cannot participate in Challenges.",
+            ts("%{name} is currently banned and cannot participate in challenges.",
                name: pseud_results[:banned_pseuds].to_sentence
         )
       else

--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -3,7 +3,7 @@ class CollectionsController < ApplicationController
   before_filter :users_only, :only => [:new, :edit, :create, :update]
   before_filter :load_collection_from_id, :only => [:show, :edit, :update, :destroy, :confirm_delete]
   before_filter :collection_owners_only, :only => [:edit, :update, :destroy, :confirm_delete]
-
+  before_filter :check_user_status, :only => [:new, :create, :edit, :update, :destroy]
   cache_sweeper :collection_sweeper
 
   def load_collection_from_id

--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -3,7 +3,7 @@ class CollectionsController < ApplicationController
   before_filter :users_only, :only => [:new, :edit, :create, :update]
   before_filter :load_collection_from_id, :only => [:show, :edit, :update, :destroy, :confirm_delete]
   before_filter :collection_owners_only, :only => [:edit, :update, :destroy, :confirm_delete]
-  before_filter :check_user_status, :only => [:new, :create, :edit, :update, :destroy]
+  before_filter :check_user_status, only: [:new, :create, :edit, :update, :destroy]
   cache_sweeper :collection_sweeper
 
   def load_collection_from_id

--- a/app/models/pseud.rb
+++ b/app/models/pseud.rb
@@ -272,7 +272,7 @@ class Pseud < ActiveRecord::Base
     bylines = list.split ","
     for byline in bylines
       pseuds = Pseud.parse_byline(byline, options)
-      banned_pseuds = pseuds.select { |pseud| pseud.user.banned? || pseud.user.suspended?}
+      banned_pseuds = pseuds.select { |pseud| pseud.user.banned? || pseud.user.suspended? }
       if banned_pseuds.present?
         pseuds = pseuds - banned_pseuds
         banned_pseuds = banned_pseuds.map(&:byline)

--- a/app/models/pseud.rb
+++ b/app/models/pseud.rb
@@ -272,7 +272,7 @@ class Pseud < ActiveRecord::Base
     bylines = list.split ","
     for byline in bylines
       pseuds = Pseud.parse_byline(byline, options)
-      banned_pseuds = pseuds.select { |pseud| pseud.user.banned? }
+      banned_pseuds = pseuds.select { |pseud| pseud.user.banned? || pseud.user.suspended?}
       if banned_pseuds.present?
         pseuds = pseuds - banned_pseuds
         banned_pseuds = banned_pseuds.map(&:byline)

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -316,7 +316,7 @@ class Work < ActiveRecord::Base
       if results[:banned_pseuds].present?
         self.errors.add(
           :base, 
-          ts("%{name} has been banned and cannot be listed as a co-creator",
+          ts("%{name} is currently banned and cannot be listed as a co-creator.",
              name: results[:banned_pseuds].to_sentence
           )
         )

--- a/features/works/work_create.feature
+++ b/features/works/work_create.feature
@@ -242,7 +242,7 @@ Feature: Create Works
     When I fill in "work_collection_names" with ""
       And I fill in "pseud_byline" with "badcoauthor"
       And I press "Preview"
-    Then I should see "badcoauthor has been banned"
+    Then I should see "badcoauthor is currently banned"
     When I fill in "pseud_byline" with "coauthor"
       And I fill in "Additional Tags" with "this is a very long tag more than one hundred characters in length how would this normally even be created"
       And I press "Preview"


### PR DESCRIPTION
Resolves: https://otwarchive.atlassian.net/browse/AO3-4344

Banned and Suspended users can no longer:

1) Be added to Collections as Participants
2) Be added to Works as Co-authors (suspended users were able to be added)

I have changed the error message to say that "{name} is currently banned and ..." This, in my opinion, covers both perm-banned and suspended users. We don't need to make that distinction to the public, and it saves lines of code having to be written. 