### PR TITLE
AO3-4337 Update gCode link to JIRA link for Wrangling Tools page

### DIFF
--- a/app/views/tag_wranglings/index.html.erb
+++ b/app/views/tag_wranglings/index.html.erb
@@ -12,7 +12,7 @@
       <li><a href="http://wiki.transformativeworks.org/mediawiki/Category:Tag_Wrangling_Committee">Tag Wrangling Committee</a> - Full collection of wiki links &amp; policies</li>
       <li><a href="http://wiki.transformativeworks.org/mediawiki/Category:Tag_Wrangler_Training">Tag Wrangling Training</a> - New wranglers, start here!</li>
       <li><a href="http://wiki.transformativeworks.org/mediawiki/Tag_Wrangling_FAQ">Tag Wrangling FAQ</a> - Please check here before emailing Staff</li>
-      <li><a href="http://code.google.com/p/otwarchive/issues/list?can=2&q=roadmap=TagWrangling">Tag Wrangling gCode</a> - Known bugs</li>
+      <li><a href="https://otwarchive.atlassian.net/issues/?jql=project%20%3D%20AO3%20AND%20component%20%3D%20%22Tag%20Wrangling%22%20AND%20status%20%3D%20%22To%20Do%22">Tag Wrangling Issue Tracker</a> - Known bugs</li>
       <li><a href="https://secure.transformativeworks.org/mailman/private/tagwranglers/">Tag Wrangler Mailing List Archives</a> (For more information please see <a href="http://wiki.transformativeworks.org/mediawiki/Tag_Wrangler_Mailing_List">Tag Wrangler Mailing List</a>)</li>
       <li><a href="https://fanarchive.campfirenow.com/">Campfire Chat</a> (For more information please see <a href="http://wiki.transformativeworks.org/mediawiki/How_to_Use_Campfire_-_An_Interactive_Tutorial">Chat Instructions</a>)</li>
       <li><a href="http://wiki.transformativeworks.org/mediawiki/Fandoms_in_need_of_Cowranglers">Fandoms in need of Cowranglers and fandoms up for grabs</a></li>


### PR DESCRIPTION
https://otwarchive.atlassian.net/browse/AO3-4337?jql=issuetype%20%3D%20Improvement

Updates the Wrangling Tools page for wranglers to lin to the new JIRA issue tracker, instead of the old gCode one.