### PR TITLE
AO3-4320 Add Tag FAQs link to Tagging Help and Fandom Help text

### DIFF
--- a/public/help/fandom-help.html
+++ b/public/help/fandom-help.html
@@ -4,3 +4,4 @@
 
 <p>The name(s) of the fandom(s) to which your work belongs. Full names, rather than abbreviations, are preferred. You may list multiple fandoms, separated by commas (for example, if your work is a crossover).</p>
 
+<p>For more information regarding Tags, including how to add tags not currently on the Archive, please read our <a href="http://archiveofourown.org/faq/tags">Tags FAQ</a>.</p>

--- a/public/help/fandom-help.html
+++ b/public/help/fandom-help.html
@@ -1,7 +1,5 @@
 <h4>Fandom Tags</h4>
 
-<p>(For more information, see the <a href="http://archiveofourown.org/archive_faqs/10">Tags on the Archive FAQ</a>.)</p>
-
 <p>The name(s) of the fandom(s) to which your work belongs. Full names, rather than abbreviations, are preferred. You may list multiple fandoms, separated by commas (for example, if your work is a crossover).</p>
 
 <p>For more information regarding Tags, including how to add tags not currently on the Archive, please read our <a href="http://archiveofourown.org/faq/tags">Tags FAQ</a>.</p>

--- a/public/help/tagging-help.html
+++ b/public/help/tagging-help.html
@@ -18,3 +18,5 @@
   Any other tags you want to give your work (for example, "Angst", "Crossover", or "Tentacles"). You may also use this field to warn for things not covered by the Archive Warnings. Please do not enter fandom, relationship, or character names in this field. Multiple tags should be separated by commas.
   </dd>
 </dl>
+
+<p>For more information regarding Tags, including how to add tags not currently on the Archive, please read our <a href="http://archiveofourown.org/faq/tags">Tags FAQ</a>.</p>


### PR DESCRIPTION
Resolves: https://otwarchive.atlassian.net/browse/AO3-4320

Added links to the Tag FAQs on both fandom-help.html and tagging-help.html
Removed the old (and now redundant) link to FAQs from fandom-help.html

(Basically just a text change, and both pages looked okay to me on my webdev.)