### PR TITLE
AO3-4141 Edit Pseud form displays incorrectly limited HTML tags available for use in description

### DIFF
--- a/app/views/pseuds/_pseuds_form.html.erb
+++ b/app/views/pseuds/_pseuds_form.html.erb
@@ -15,7 +15,7 @@
   
   <dt><%= f.label :description, ts("Description") %></dt>
   <dd>
-    <p class="html-notes"><%= allowed_html_instructions %></p>
+    <p><%= allowed_html_instructions %></p>
     <%= f.text_area :description, :rows => 4, :cols => 60, :class => "observe_textlength" %>
     <%= generate_countdown_html("pseud_description", Pseud::DESCRIPTION_MAX) %>
   </dd>

--- a/app/views/pseuds/_pseuds_form.html.erb
+++ b/app/views/pseuds/_pseuds_form.html.erb
@@ -15,7 +15,7 @@
   
   <dt><%= f.label :description, ts("Description") %></dt>
   <dd>
-    <code>a href, em, strong, i, b</code>
+    <p class="html-notes"><%= allowed_html_instructions %></p>
     <%= f.text_area :description, :rows => 4, :cols => 60, :class => "observe_textlength" %>
     <%= generate_countdown_html("pseud_description", Pseud::DESCRIPTION_MAX) %>
   </dd>


### PR DESCRIPTION
Issue: https://otwarchive.atlassian.net/browse/AO3-4141

Took out the incorrect limited HTML info, added the regular "Plain text with limitd HTML" notice.
(Code was copied from the _standard_form.html.erb code.)

Looks correct on my WebDev, not sure if other (automated) tests should have been performed.