### PR TITLE
AO3-3543 Moderated comments tweaks

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -201,7 +201,7 @@ class CommentsController < ApplicationController
             cookies[:comment_email] = @comment.email[0..100]
           end
           if @comment.unreviewed?
-            flash[:comment_notice] = ts("Your comment was received! It will appear publicly after the author has approved it.")
+            flash[:comment_notice] = ts("Your comment was received! It will appear publicly after the work creator has approved it.")
           else
             flash[:comment_notice] = ts('Comment created!')
           end

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -14,7 +14,7 @@ class CommentsController < ApplicationController
   before_filter :check_permission_to_edit, :only => [:edit, :update ]
   before_filter :check_permission_to_delete, :only => [:delete_comment, :destroy]
   before_filter :check_anonymous_comment_preference, :only => [:new, :create, :add_comment_reply]
-  before_filter :check_permission_to_review, :only => [:unreviewed]
+  before_filter :check_permission_to_review, :only => [:unreviewed, :show]
 
   cache_sweeper :comment_sweeper
 
@@ -38,7 +38,7 @@ class CommentsController < ApplicationController
 
   # Check to see if the ultimate_parent is a Work, and if so, if it's restricted
   def check_if_restricted
-    parent =  find_parent
+    parent = find_parent
     if parent.respond_to?(:restricted) && parent.restricted? && ! (logged_in? || logged_in_as_admin?)
       redirect_to login_path(:restricted_commenting => true) and return
     end
@@ -46,7 +46,7 @@ class CommentsController < ApplicationController
 
   # Check to see if the ultimate_parent is a Work, and if so, if it allows anon comments
   def check_anonymous_comment_preference
-    parent =  find_parent
+    parent = find_parent
     if parent.respond_to?(:anon_commenting_disabled) && parent.anon_commenting_disabled && !logged_in?
       flash[:error] = ts("Sorry, this work doesn't allow non-Archive users to comment.")
       redirect_to work_path(parent)
@@ -57,7 +57,11 @@ class CommentsController < ApplicationController
     parent = find_parent
     unless logged_in_as_admin? || current_user_owns?(parent)
       flash[:error] = ts("Sorry, you don't have permission to see that.")
-      redirect_to login_path and return
+      if logged_in?
+        redirect_to root_path and return
+      else
+        redirect_to login_path and return
+      end
     end
   end
 

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -14,7 +14,8 @@ class CommentsController < ApplicationController
   before_filter :check_permission_to_edit, :only => [:edit, :update ]
   before_filter :check_permission_to_delete, :only => [:delete_comment, :destroy]
   before_filter :check_anonymous_comment_preference, :only => [:new, :create, :add_comment_reply]
-  before_filter :check_permission_to_review, :only => [:unreviewed, :show]
+  before_filter :check_permission_to_review, :only => [:unreviewed]
+  before_filter :check_permission_to_access_single_unreviewed, only: [:show]
 
   cache_sweeper :comment_sweeper
 
@@ -61,6 +62,20 @@ class CommentsController < ApplicationController
         redirect_to root_path and return
       else
         redirect_to login_path and return
+      end
+    end
+  end
+
+  def check_permission_to_access_single_unreviewed
+    if @comment.unreviewed?
+      parent = find_parent
+      unless logged_in_as_admin? || current_user_owns?(parent) || current_user_owns?(@comment)
+        flash[:error] = ts("Sorry, you don't have permission to see that.")
+        if logged_in?
+          redirect_to root_path and return
+        else
+          redirect_to login_path and return
+        end
       end
     end
   end

--- a/app/helpers/comments_helper.rb
+++ b/app/helpers/comments_helper.rb
@@ -291,11 +291,37 @@ module CommentsHelper
 
   end
 
-  # determine if the creator of the commentable item is anonymous and if the person leaving the comment is the owner
-  def ultimate_parent_is_anonymous_work_owned_by_commenter(commentable)
-    commentable.is_a?(Work) && current_user.is_author_of?(commentable) && commentable.anonymous? ||
-    commentable.is_a?(Chapter) && current_user.is_author_of?(commentable) && commentable.work.anonymous? ||
-    commentable.is_a?(Comment) && commentable.ultimate_parent.is_a?(Work) && commentable.ultimate_parent.anonymous? && current_user.is_author_of?(commentable.ultimate_parent)
+  # find the parent of the commentable
+  def find_parent(commentable)
+    if commentable.is_a?(Comment)
+      commentable.ultimate_parent
+    elsif commentable.respond_to?(:work)
+      commentable.work
+    else
+      commentable
+    end
+  end
+
+  # if parent commentable is a work, determine if current user created it
+  def current_user_is_work_creator(commentable)
+    if logged_in?
+      parent = find_parent(commentable)
+      parent.is_a?(Work) && current_user.is_author_of?(parent)
+    end
+  end
+
+  # if parent commentable is an anonymous work, determine if current user created it
+  def current_user_is_anonymous_creator(commentable)
+    if logged_in?
+      parent = find_parent(commentable)
+      parent.respond_to?(:work) && parent.anonymous? && current_user.is_author_of?(parent)
+    end
+  end
+
+  # determine if the parent has its comments set to moderated
+  def comments_are_moderated(commentable)
+    parent = find_parent(commentable)
+    parent.respond_to?(:moderated_commenting_enabled) && parent.moderated_commenting_enabled?
   end
 
 end

--- a/app/helpers/comments_helper.rb
+++ b/app/helpers/comments_helper.rb
@@ -291,4 +291,11 @@ module CommentsHelper
 
   end
 
+  # determine if the creator of the commentable item is anonymous and if the person leaving the comment is the owner
+  def ultimate_parent_is_anonymous_work_owned_by_commenter(commentable)
+    commentable.is_a?(Work) && current_user.is_author_of?(commentable) && commentable.anonymous? ||
+    commentable.is_a?(Chapter) && current_user.is_author_of?(commentable) && commentable.work.anonymous? ||
+    commentable.is_a?(Comment) && commentable.ultimate_parent.is_a?(Work) && commentable.ultimate_parent.anonymous? && current_user.is_author_of?(commentable.ultimate_parent)
+  end
+
 end

--- a/app/views/comment_mailer/_comment_notification_footer.erb
+++ b/app/views/comment_mailer/_comment_notification_footer.erb
@@ -5,6 +5,10 @@
   <% end %>
 </p>
 
+<% if @comment.unreviewed? %>
+  <p>Comments on this work are moderated and will not appear until approved by the work creator.</p>
+<% end %>
+
 <% if @comment.ultimate_parent.is_a?(Tag) %>
 
   <%= style_link("Read all comments on " + @comment.ultimate_parent.name, 

--- a/app/views/comment_mailer/_comment_notification_footer.text.erb
+++ b/app/views/comment_mailer/_comment_notification_footer.text.erb
@@ -1,6 +1,7 @@
 <%= text_divider %>
 Posted: <%= @comment.created_at %><% unless @comment.edited_at.blank? %>
 Last edited: <%= @comment.edited_at %><% end %>
+
 <% if @comment.unreviewed? %>
 Comments on this work are moderated and will not appear until approved by the work creator.
 <% end %>

--- a/app/views/comment_mailer/_comment_notification_footer.text.erb
+++ b/app/views/comment_mailer/_comment_notification_footer.text.erb
@@ -1,6 +1,9 @@
 <%= text_divider %>
 Posted: <%= @comment.created_at %><% unless @comment.edited_at.blank? %>
 Last edited: <%= @comment.edited_at %><% end %>
+<% if @comment.unreviewed? %>
+Comments on this work are moderated and will not appear until approved by the work creator.
+<% end %>
 <% if @comment.ultimate_parent.is_a?(Tag) %>
 Read all comments on <%= @comment.ultimate_parent.name %>: <%= url_for(:controller => :comments, :action => :index, :tag_id => @comment.ultimate_parent, :only_path => false) %><% unless @noreply %>
 Reply to this comment: <%= url_for(:controller => :comments, :action => :index, :tag_id => @comment.ultimate_parent, :only_path => false, :add_comment_reply_id => @comment.id, :anchor => "comment_#{@comment.id}") %><% end %>

--- a/app/views/comments/_comment_form.html.erb
+++ b/app/views/comments/_comment_form.html.erb
@@ -26,8 +26,14 @@
         <%= hidden_field_tag :page, params[:page] %>
       <% end %>
 
+      <% if comments_are_moderated(commentable) && !current_user_is_work_creator(commentable) %>
+        <p class="notice">
+          <%= ts("This work's creator has chosen to moderate comments on the work. Your comment will not appear until it has been by approved by the creator.") %>
+        </p>
+      <% end %>
+
       <% if logged_in? %>
-        <% if ultimate_parent_is_anonymous_work_owned_by_commenter(commentable) %>
+        <% if current_user_is_anonymous_creator(commentable) %>
           <p class="notice">
            <%= ts("While this work is anonymous, comments you post will also be listed anonymously.") %>
           </p>

--- a/app/views/comments/_comment_form.html.erb
+++ b/app/views/comments/_comment_form.html.erb
@@ -11,28 +11,34 @@
       <% if commentable.is_a?(Tag) %>
         <%= hidden_field_tag :tag_id, commentable.name %>
       <% end %>
+
       <% if params[:view_full_work] %>
         <%= hidden_field_tag :view_full_work, params[:view_full_work] %>
       <% end %>
+
       <% if controller.controller_name == "inbox" && params[:filters] %>
         <%= hidden_field_tag "filters[read]", params[:filters][:read] %>
         <%= hidden_field_tag "filters[replied_to]", params[:filters][:replied_to] %>
         <%= hidden_field_tag "filters[date]", params[:filters][:date] %>
       <% end %>
+
       <% if params[:page] %>
         <%= hidden_field_tag :page, params[:page] %>
       <% end %>
+
       <% if logged_in? %>
-          <% # The following two notices show on the top-level comment box on either a: Work (full view) or Chapter by Chapter page %>
-          <% if commentable.is_a?(Work) && current_user.is_author_of?(commentable) && commentable.anonymous? %>
-            <p class="notice">While this work is anonymous, comments you post will also be listed anonymously.</p>
-          <% elsif commentable.is_a?(Chapter) && current_user.is_author_of?(commentable) && commentable.work.anonymous? %>
-            <p class="notice">While this work is anonymous, comments you post will also be listed anonymously.</p>
-          <% end %>
+        <% # The following two notices show on the top-level comment box on either a: Work (full view) or Chapter by Chapter page %>
+        <% if commentable.is_a?(Work) && current_user.is_author_of?(commentable) && commentable.anonymous? %>
+          <p class="notice">While this work is anonymous, comments you post will also be listed anonymously.</p>
+        <% elsif commentable.is_a?(Chapter) && current_user.is_author_of?(commentable) && commentable.work.anonymous? %>
+          <p class="notice">While this work is anonymous, comments you post will also be listed anonymously.</p>
+        <% end %>
+
         <% # When the thing that we are commenting on is a comment (read: replying to) then we use this statement. Shows in user Inbox and nested reply %>
         <% if commentable.is_a?(Comment) && commentable.ultimate_parent.is_a?(Work) && commentable.ultimate_parent.anonymous? && current_user.is_author_of?(commentable.ultimate_parent) %>
           <p class="notice">While this work is anonymous, comments you post will also be listed anonymously.</p>
         <% end %>
+
         <% if current_user.pseuds.count > 1 %>
           <h4 class="heading"><%= ts("Comment as") %> <%= f.collection_select :pseud_id, current_user.pseuds, :id, :name, {:selected => (comment.pseud ? comment.pseud.id.to_s : current_user.default_pseud.id.to_s)}, :id => "comment_pseud_id_for_#{commentable.id}", :title => ts("Choose Name") %>
             <% if controller.controller_name == "inbox" %>
@@ -89,11 +95,10 @@
               $j(name_id).val($j.cookie('comment_name'));
             }
             if (!$j(email_id).val()) {
-              $j(email_id).val($j.cookie('comment_email'));              
+              $j(email_id).val($j.cookie('comment_email'));
             }
           <% end %>
         <% end %>
-        
       <% end %>
 
       <p>

--- a/app/views/comments/_comment_form.html.erb
+++ b/app/views/comments/_comment_form.html.erb
@@ -27,16 +27,10 @@
       <% end %>
 
       <% if logged_in? %>
-        <% # The following two notices show on the top-level comment box on either a: Work (full view) or Chapter by Chapter page %>
-        <% if commentable.is_a?(Work) && current_user.is_author_of?(commentable) && commentable.anonymous? %>
-          <p class="notice">While this work is anonymous, comments you post will also be listed anonymously.</p>
-        <% elsif commentable.is_a?(Chapter) && current_user.is_author_of?(commentable) && commentable.work.anonymous? %>
-          <p class="notice">While this work is anonymous, comments you post will also be listed anonymously.</p>
-        <% end %>
-
-        <% # When the thing that we are commenting on is a comment (read: replying to) then we use this statement. Shows in user Inbox and nested reply %>
-        <% if commentable.is_a?(Comment) && commentable.ultimate_parent.is_a?(Work) && commentable.ultimate_parent.anonymous? && current_user.is_author_of?(commentable.ultimate_parent) %>
-          <p class="notice">While this work is anonymous, comments you post will also be listed anonymously.</p>
+        <% if ultimate_parent_is_anonymous_work_owned_by_commenter(commentable) %>
+          <p class="notice">
+           <%= ts("While this work is anonymous, comments you post will also be listed anonymously.") %>
+          </p>
         <% end %>
 
         <% if current_user.pseuds.count > 1 %>

--- a/app/views/comments/unreviewed.html.erb
+++ b/app/views/comments/unreviewed.html.erb
@@ -1,5 +1,5 @@
 <!--Descriptive page name, messages and instructions-->
-<h2 class="heading"><%= ts("Unreviewed Comments On ") %><%= link_to(@commentable.commentable_name, @commentable) %></h2> 
+<h2 class="heading"><%= ts("Unreviewed Comments on") %> <%= link_to(@commentable.commentable_name, @commentable) %></h2> 
 <!--/descriptions-->
 
 <!--main content-->
@@ -10,7 +10,7 @@
   <% end %>
   <%= will_paginate @comments %>
 <% else %>
-  <p class="message"><%= ts("No unreviewed comments.")%></p>
+  <p class="notice"><%= ts("No unreviewed comments.")%></p>
 <% end %>
 <!--main content-->
 

--- a/app/views/comments/unreviewed.html.erb
+++ b/app/views/comments/unreviewed.html.erb
@@ -10,7 +10,7 @@
   <% end %>
   <%= will_paginate @comments %>
 <% else %>
-  <p class="notice"><%= ts("No unreviewed comments.")%></p>
+  <p class="notice"><%= ts("No unreviewed comments.") %></p>
 <% end %>
 <!--main content-->
 

--- a/features/comments_and_kudos/comment_moderation.feature
+++ b/features/comments_and_kudos/comment_moderation.feature
@@ -27,7 +27,7 @@ Feature: Comment Moderation
     Given the moderated work "Moderation" by "author"
     When I am logged in as "commenter"
       And I post the comment "Fail comment" on the work "Moderation"
-    Then I should see "Your comment was received! It will appear publicly after the work creator approved it."
+    Then I should see "Your comment was received! It will appear publicly after the work creator has approved it."
       And the comment on "Moderation" should be marked as unreviewed
       And I should not see "Comments (1)"
       And I should not see "Unreviewed Comments (1)"
@@ -43,7 +43,7 @@ Feature: Comment Moderation
     Given the moderated work "Moderation" by "author"
     When I am logged in as "author"
       And I post the comment "Fail comment" on the work "Moderation"
-    Then I should not see "It will appear publicly after the work creator approved it"
+    Then I should not see "It will appear publicly after the work creator has approved it."
       And the comment on "Moderation" should not be marked as unreviewed
       And I should see "Comment created"
       And I should not see "Unreviewed Comments (1)"

--- a/features/comments_and_kudos/comment_moderation.feature
+++ b/features/comments_and_kudos/comment_moderation.feature
@@ -27,7 +27,7 @@ Feature: Comment Moderation
     Given the moderated work "Moderation" by "author"
     When I am logged in as "commenter"
       And I post the comment "Fail comment" on the work "Moderation"
-    Then I should see "Your comment was received! It will appear publicly after the author has approved it."
+    Then I should see "Your comment was received! It will appear publicly after the work creator approved it."
       And the comment on "Moderation" should be marked as unreviewed
       And I should not see "Comments (1)"
       And I should not see "Unreviewed Comments (1)"
@@ -43,7 +43,7 @@ Feature: Comment Moderation
     Given the moderated work "Moderation" by "author"
     When I am logged in as "author"
       And I post the comment "Fail comment" on the work "Moderation"
-    Then I should not see "It will appear publicly after the author has approved it"
+    Then I should not see "It will appear publicly after the work creator approved it"
       And the comment on "Moderation" should not be marked as unreviewed
       And I should see "Comment created"
       And I should not see "Unreviewed Comments (1)"


### PR DESCRIPTION
https://otwarchive.atlassian.net/browse/AO3-3543

1. If comments are moderated and you are not the work creator, the comment form will now have a message: "This work's creator has chosen to moderate comments on the work. Your comment will not appear until it has been by approved by the creator."

2. The emails will now say "Comments on this work are moderated and will not appear until approved by the work creator." This might need some fiddling, appearance-wise, because I couldn't test it on dev.

3. If anyone other than the work creator or an admin attempts to access the unreviewed comment page, they will be redirected to the log in page (if not logged in) or to the homepage (if logged in) with a message: "Sorry, you don't have permission to see that."

4. If anyone other than the work creator, an admin, or the comment creator attempts to access the moderated comment directly (e.g. via a URL like http://ao3.org/comments/###), they will be redirected to the log in page (if not logged in) or to the homepage (if logged in) with a message: "Sorry, you don't have permission to see that."

5. The flash message upon posting a moderated comment will now say "Your comment was received! It will appear publicly after the work creator has approved it." (It previously said "author.")

The code for displaying the "While this work is anonymous, comments you post will also be listed anonymously" message also got a bit of a rewrite in the process. 