### PR TITLE
AO3-4360: Don't generate counts for logged-in users

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -54,9 +54,11 @@ class HomeController < ApplicationController
 
   # home page itself
   def index
-    @user_count = User.count
-    @work_count = Work.posted.count
-    @fandom_count = Fandom.canonical.count
+    unless logged_in?
+      @user_count = User.count
+      @work_count = Work.posted.count
+      @fandom_count = Fandom.canonical.count
+    end
 
     @homepage = Homepage.new(@current_user)
 


### PR DESCRIPTION
AO3-4360: Don't generate counts for logged-in users on the front-page

The partial which uses the counts gets called here: https://github.com/otwcode/otwarchive/blob/master/app/views/home/index.html.erb#L2
and is only used if the user is not logged_in?.

https://otwarchive.atlassian.net/browse/AO3-4360