### PR TITLE
AO3-3543-change comment settings on multiple works

### DIFF
--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -745,6 +745,16 @@ public
     @errors = []
     # to avoid overwriting, we entirely trash any blank fields and also any unchecked checkboxes
     work_params = params[:work].reject {|key,value| value.blank? || value == "0"}
+    
+    # manually allow switching of anon/moderated comments
+    if work_params[:anon_commenting_enabled] == "1"
+      work_params[:anon_commenting_disabled] = "0"
+      work_params.delete(:anon_commenting_enabled)
+    end
+    if work_params[:moderated_commenting_disabled] == "1"
+      work_params[:moderated_commenting_enabled] = "0"
+      work_params.delete(:moderated_commenting_disabled)
+    end
 
     @works.each do |work|
       # now we can just update each work independently, woo!

--- a/app/views/works/edit_multiple.html.erb
+++ b/app/views/works/edit_multiple.html.erb
@@ -62,13 +62,42 @@
           </li>
         </ul>
       </dd>
-      <dt><%= ts("Comment Settings") %><%= link_to_help "anonymous-commenting" %></dt>
+      <dt><%= ts("Anonymous Commenting") %><%= link_to_help "comments-anonymous" %></dt>
       <dd>
-        <label for="work_anon_commenting_disabled">
-          <%= form.check_box :anon_commenting_disabled %>
-          <%= ts("Anonymous commenting disabled") %>
-        </label>
+        <ul>
+          <li>
+            <label for="work_anon_commenting_disabled">
+              <%= form.check_box :anon_commenting_disabled %>
+              <%= ts("Anonymous commenting disabled") %>
+            </label>
+          </li>
+          <li>
+            <label for="work_anon_commenting_enabled">
+              <%= form.check_box :anon_commenting_enabled %>
+              <%= ts("Anonymous commenting enabled") %>
+            </label>
+          </li>
+        </ul>
       </dd>
+      <dt><%= ts("Comment Moderation") %><%= link_to_help "comments-moderated" %></dt>
+      <dd>
+        <ul>
+          <li>
+            <label for="work_moderated_commenting_enabled">
+              <%= form.check_box :moderated_commenting_enabled %>
+              <%= ts("Comments moderated") %>
+            </label>
+          </li>
+          <li>
+            <label for="work_moderated_commenting_disabled">
+              <%= form.check_box :moderated_commenting_disabled %>
+              <%= ts("Comments not moderated") %>
+            </label>
+          </li>
+        </ul>
+      </dd>
+
+
     </dl>
   </fieldset>
 

--- a/app/views/works/show_multiple.html.erb
+++ b/app/views/works/show_multiple.html.erb
@@ -33,7 +33,7 @@
             <ul class="index concise">
               <% @works_by_fandom[fandom].each do |work| %>
                 <li>
-                  <label class="action" title="select <%= work.title + (work.posted? ? "" : ts(' (Draft)'))%>"><%= check_box_tag "work_ids[]", work.id %></label>
+                  <label class="action" title="select <%= work.title + (work.posted? ? "" : ts(' (Draft)'))%>"><%= check_box_tag "work_ids[]", work.id, false, id: "work_ids_#{work.id}" %></label>
                 <%= link_to work.title + (work.posted? ? "" : ts(' (Draft)')), work_path(:id => work.id) %>
 		</li>
               <% end %>

--- a/features/comments_and_kudos/comment_moderation.feature
+++ b/features/comments_and_kudos/comment_moderation.feature
@@ -22,6 +22,23 @@ Feature: Comment Moderation
       And I check "Comments moderated"
       And I post the work without preview
     Then comment moderation should be enabled on "Moderation"
+    When I am logged in as "commenter"
+      And I view the work "Moderation"
+    Then I should see "has chosen to moderate comments"
+    
+  Scenario: Turn off moderation
+    Given I am logged in as "author"
+      And I set up the draft "Moderation"
+      And I check "Comments moderated"
+      And I post the work without preview
+    Then comment moderation should be enabled on "Moderation"
+    When I edit the work "Moderation"
+      And I uncheck "Comments moderated"
+      And I post the work without preview
+    Then comment moderation should not be enabled on "Moderation"
+    When I am logged in as "commenter"
+      And I view the work "Moderation"
+    Then I should not see "has chosen to moderate comments"
     
   Scenario: Post a moderated comment
     Given the moderated work "Moderation" by "author"

--- a/features/step_definitions/comment_steps.rb
+++ b/features/step_definitions/comment_steps.rb
@@ -118,6 +118,11 @@ Then /^comment moderation should be enabled on "(.*?)"/ do |work|
   assert w.moderated_commenting_enabled?
 end
 
+Then /^comment moderation should not be enabled on "(.*?)"/ do |work|
+  w = Work.find_by_title(work)
+  assert !w.moderated_commenting_enabled?
+end
+
 Then /^the comment on "(.*?)" should be marked as unreviewed/ do |work|
   w = Work.find_by_title(work)
   assert w.comments.first.unreviewed?

--- a/features/step_definitions/work_steps.rb
+++ b/features/step_definitions/work_steps.rb
@@ -249,6 +249,29 @@ When /^the draft "([^\"]*)" in collection "([^\"]*)"$/ do |title, collection|
   click_button("Preview")
 end
 
+When /^I set the fandom to "([^\"]*)"$/ do |fandom|
+  fill_in("Fandoms", :with => fandom)
+end
+
+When /^I select "([^\"]*)" for editing$/ do |title|
+  id = Work.find_by_title(title).id
+  check("work_ids_#{id}")
+end  
+
+When /^I edit the multiple works "([^\"]*)" and "([^\"]*)"/ do |title1, title2|
+  # check if the works have been posted yet
+  if !(Work.where(title: title1).exists?)
+    step %{I post the work "#{title1}"}
+  end
+  if !(Work.where(title: title2).exists?)
+    step %{I post the work "#{title2}"}
+  end
+  step %{I go to my edit multiple works page}
+  step %{I select "#{title1}" for editing}
+  step %{I select "#{title2}" for editing}
+  step %{I press "Edit"}
+end
+
 When /^I set up the draft "([^\"]*)"$/ do |title|
   step "basic tags"
   visit new_work_url

--- a/features/support/paths.rb
+++ b/features/support/paths.rb
@@ -93,6 +93,8 @@ module NavigationHelpers
     when /my works page/
       Work.tire.index.refresh
       user_works_path(User.current_user)
+    when /my edit multiple works page/
+      show_multiple_user_works_path(User.current_user)
     when /my subscriptions page/
       user_subscriptions_path(User.current_user)   
     when /my stats page/

--- a/features/works/work_edit_multiple.feature
+++ b/features/works/work_edit_multiple.feature
@@ -1,0 +1,79 @@
+@works @tags
+Feature: Edit Multiple Works
+  In order to change settings on my works more easily
+  As an author
+  I want to edit multiple works at once
+  
+  Scenario: I can edit multiple works at once
+  Given I am logged in as "author"
+    And I post the work "Glorious" with fandom "SGA"
+    And I post the work "Excellent" with fandom "Star Trek"
+    And I go to my works page
+  When I follow "Edit Works"
+  Then I should see "Edit Multiple Works"
+    And I should see "All"
+    And I should see "None"
+  When I select "Glorious" for editing
+    And I select "Excellent" for editing
+    And I press "Edit"
+  Then I should see "Your edits will be applied to all of the following works"
+    And I should see "Glorious"
+    And I should see "Excellent"
+  When I set the fandom to "Random"
+   And I press "Update All Works"
+  Then I should see "Your edits were put through"
+    And I should see "Random"
+    And I should not see "SGA"
+    And I should not see "Star Trek"
+  When I view the work "Glorious"
+  Then I should see "Random"
+    And I should not see "SGA"
+  When I view the work "Excellent"
+  Then I should see "Random"
+    And I should not see "Star Trek"
+    
+  Scenario: I can disable anon commenting on multiple works at once
+  Given I am logged in as "author"
+    And I edit the multiple works "Glorious" and "Excellent"
+  When I check "Anonymous commenting disabled"
+    And I press "Update All Works"
+    And I am logged out
+    And I view the work "Glorious"
+  Then I should see "doesn't allow non-Archive users to comment"
+  When I view the work "Excellent"    
+  Then I should see "doesn't allow non-Archive users to comment"
+
+  Scenario: I can enable moderated commenting on multiple works at once
+  Given I am logged in as "author"
+    And I edit the multiple works "Glorious" and "Excellent"
+    And I check "Comments moderated"
+    And I press "Update All Works"
+  When I am logged in as "commenter"
+    And I view the work "Glorious"
+  Then I should see "has chosen to moderate comments"
+  When I view the work "Excellent"
+  Then I should see "has chosen to moderate comments"
+
+  Scenario: I can enable anon commenting on multiple works at once
+  Given I am logged in as "author"
+    And I edit the multiple works "Glorious" and "Excellent"
+    And I check "Anonymous commenting disabled"
+    And I press "Update All Works"
+    And I edit the multiple works "Glorious" and "Excellent"
+    And I check "Anonymous commenting enabled"
+    And I press "Update All Works"
+  When I am logged out
+    And I view the work "Glorious"
+  Then I should not see "doesn't allow non-Archive users to comment"
+  
+  Scenario: I can disable moderated commenting on multiple works at once
+  Given I am logged in as "author"
+    And I edit the multiple works "Glorious" and "Excellent"
+    And I check "Comments moderated"
+    And I press "Update All Works"
+    And I edit the multiple works "Glorious" and "Excellent"
+    And I check "Comments not moderated"
+    And I press "Update All Works"
+  When I am logged out
+    And I view the work "Glorious"
+  Then I should not see "has chosen to moderate comments"


### PR DESCRIPTION
Allow turning comment moderation on and off for multiple works via the edit multiple works interface. Also allows re-enabling anon commenting through this interface.

Also adds a basic test for the edit multiple page, editing two works to overwrite their fandom tags. 

Signed-off-by: shalott <shalott@gmail.com>