### PR TITLE
AO3-3543 Mass edit comment settings

### DIFF
--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -745,7 +745,7 @@ public
     @errors = []
     # to avoid overwriting, we entirely trash any blank fields and also any unchecked checkboxes
     work_params = params[:work].reject {|key,value| value.blank? || value == "0"}
-    
+
     # manually allow switching of anon/moderated comments
     if work_params[:anon_commenting_disabled] == "allow_anon"
       work_params[:anon_commenting_disabled] = "0"

--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -745,6 +745,16 @@ public
     @errors = []
     # to avoid overwriting, we entirely trash any blank fields and also any unchecked checkboxes
     work_params = params[:work].reject {|key,value| value.blank? || value == "0"}
+    
+    # manually allow switching of anon/moderated comments
+    if work_params[:anon_commenting_enabled] == "1"
+      work_params[:anon_commenting_disabled] = "0"
+      work_params.delete(:anon_commenting_enabled)
+    end
+    if work_params[:moderated_commenting_disabled] == "1"
+      work_params[:moderated_commenting_enabled] = "0"
+      work_params.delete(:moderated_commenting_disabled)
+    end
 
     @works.each do |work|
       # now we can just update each work independently, woo!

--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -747,13 +747,11 @@ public
     work_params = params[:work].reject {|key,value| value.blank? || value == "0"}
     
     # manually allow switching of anon/moderated comments
-    if work_params[:anon_commenting_enabled] == "1"
+    if work_params[:anon_commenting_disabled] == "allow_anon"
       work_params[:anon_commenting_disabled] = "0"
-      work_params.delete(:anon_commenting_enabled)
     end
-    if work_params[:moderated_commenting_disabled] == "1"
+    if work_params[:moderated_commenting_enabled] == "not_moderated"
       work_params[:moderated_commenting_enabled] = "0"
-      work_params.delete(:moderated_commenting_disabled)
     end
 
     @works.each do |work|

--- a/app/views/works/_standard_form.html.erb
+++ b/app/views/works/_standard_form.html.erb
@@ -286,14 +286,15 @@
         <%= f.check_box :anon_commenting_disabled %>
       </dt>
       <dd class="anonymous comments">
-        <%= f.label :anon_commenting_disabled, ts('Anonymous commenting disabled') %>
+        <%= f.label :anon_commenting_disabled, ts("Disable anonymous commenting") %>
         <%= link_to_help "comments-anonymous" %>
       </dd>
+
       <dt class="moderated comments">
         <%= f.check_box :moderated_commenting_enabled %>
       </dt>
       <dd class="moderated comments">
-        <%= f.label :moderated_commenting_enabled, ts("Comments moderated")%>
+        <%= f.label :moderated_commenting_enabled, ts("Enable comment moderation") %>
         <%= link_to_help "comments-moderated" %>
       </dd>
     </dl>

--- a/app/views/works/edit_multiple.html.erb
+++ b/app/views/works/edit_multiple.html.erb
@@ -40,11 +40,13 @@
       <dd>
         <%= form.collection_select :language_id, Language.all(:order => :short), :id, :name, {:include_blank => true} %>
       </dd>
+
       <dt><%= form.label :work_skin_id, ts("Select Work Skin") %> <%= link_to_help "work-skins" %></dt>
       <dd>
         <%= form.collection_select :work_skin_id, WorkSkin.approved_or_owned_by(current_user).order(:title), :id, :title,
             {:include_blank => true} %>
       </dd>
+
       <dt><%= ts("Visibility") %> <%= link_to_help "registered-users" %></dt>
       <dd>
         <ul>
@@ -62,42 +64,58 @@
           </li>
         </ul>
       </dd>
+
       <dt><%= ts("Anonymous Commenting") %><%= link_to_help "comments-anonymous" %></dt>
       <dd>
-        <ul>
+        <ul> 
           <li>
-            <label for="work_anon_commenting_disabled">
-              <%= form.check_box :anon_commenting_disabled %>
-              <%= ts("Anonymous commenting disabled") %>
+            <label for="work_anon_commenting_disabled_">
+              <%= form.radio_button(:anon_commenting_disabled, '') %>
+              <%= ts("Keep current anonymous comment settings") %>
             </label>
           </li>
           <li>
-            <label for="work_anon_commenting_enabled">
-              <%= form.check_box :anon_commenting_enabled %>
-              <%= ts("Anonymous commenting enabled") %>
+            <% # We use "allow_anon" as a placeholder value because the mass edit code strips 0, which is the value we actually want %>
+            <% # The controller will change it to the proper value %>
+            <label for="work_anon_commenting_disabled_allow_anon">
+              <%= form.radio_button(:anon_commenting_disabled, "allow_anon") %>
+              <%= ts("Enable anonymous comments") %>
             </label>
-          </li>
+          </li>   
+          <li>
+            <label for="work_anon_commenting_disabled_1">
+              <%= form.radio_button(:anon_commenting_disabled, "1") %>
+              <%= ts("Disable anonymous comments") %>
+            </label>
+          </li>  
         </ul>
       </dd>
+
       <dt><%= ts("Comment Moderation") %><%= link_to_help "comments-moderated" %></dt>
       <dd>
         <ul>
           <li>
-            <label for="work_moderated_commenting_enabled">
-              <%= form.check_box :moderated_commenting_enabled %>
-              <%= ts("Comments moderated") %>
+            <label for="work_moderated_commenting_enabled_">
+              <%= form.radio_button(:moderated_commenting_enabled, '') %>
+              <%= ts("Keep current comment moderation settings") %>
             </label>
           </li>
           <li>
-            <label for="work_moderated_commenting_disabled">
-              <%= form.check_box :moderated_commenting_disabled %>
-              <%= ts("Comments not moderated") %>
+            <label for="work_moderated_commenting_enabled_1">
+              <%= form.radio_button(:moderated_commenting_enabled, "1") %>
+              <%= ts("Enable comment moderation") %>
             </label>
-          </li>
+          </li>   
+          <li>
+            <% # We use "not_moderated" as a placeholder value because the mass edit code strips 0, which is the value we actually want %>
+            <% # The controller will change it to the proper value %>
+            <label for="work_moderated_commenting_enabled_not_moderated">
+              <%= form.radio_button(:moderated_commenting_enabled, "not_moderated") %>
+              <%= ts("Disable comment moderation") %>
+            </label>
+          </li>   
         </ul>
       </dd>
-
-
     </dl>
   </fieldset>
 

--- a/app/views/works/edit_multiple.html.erb
+++ b/app/views/works/edit_multiple.html.erb
@@ -62,13 +62,42 @@
           </li>
         </ul>
       </dd>
-      <dt><%= ts("Comment Settings") %><%= link_to_help "anonymous-commenting" %></dt>
+      <dt><%= ts("Anonymous Commenting") %><%= link_to_help "comments-anonymous" %></dt>
       <dd>
-        <label for="work_anon_commenting_disabled">
-          <%= form.check_box :anon_commenting_disabled %>
-          <%= ts("Anonymous commenting disabled") %>
-        </label>
+        <ul>
+          <li>
+            <label for="work_anon_commenting_disabled">
+              <%= form.check_box :anon_commenting_disabled %>
+              <%= ts("Anonymous commenting disabled") %>
+            </label>
+          </li>
+          <li>
+            <label for="work_anon_commenting_enabled">
+              <%= form.check_box :anon_commenting_enabled %>
+              <%= ts("Anonymous commenting enabled") %>
+            </label>
+          </li>
+        </ul>
       </dd>
+      <dt><%= ts("Comment Moderation") %><%= link_to_help "comments-moderated" %></dt>
+      <dd>
+        <ul>
+          <li>
+            <label for="work_moderated_commenting_enabled">
+              <%= form.check_box :moderated_commenting_enabled %>
+              <%= ts("Comments moderated") %>
+            </label>
+          </li>
+          <li>
+            <label for="work_moderated_commenting_disabled">
+              <%= form.check_box :moderated_commenting_disabled %>
+              <%= ts("Comments not moderated") %>
+            </label>
+          </li>
+        </ul>
+      </dd>
+
+
     </dl>
   </fieldset>
 

--- a/app/views/works/show_multiple.html.erb
+++ b/app/views/works/show_multiple.html.erb
@@ -33,7 +33,7 @@
             <ul class="index concise">
               <% @works_by_fandom[fandom].each do |work| %>
                 <li>
-                  <label class="action" title="select <%= work.title + (work.posted? ? "" : ts(' (Draft)'))%>"><%= check_box_tag "work_ids[]", work.id %></label>
+                  <label class="action" title="select <%= work.title + (work.posted? ? "" : ts(' (Draft)'))%>"><%= check_box_tag "work_ids[]", work.id, false, id: "work_ids_#{work.id}" %></label>
                 <%= link_to work.title + (work.posted? ? "" : ts(' (Draft)')), work_path(:id => work.id) %>
 		</li>
               <% end %>

--- a/features/comments_and_kudos/comment_moderation.feature
+++ b/features/comments_and_kudos/comment_moderation.feature
@@ -22,6 +22,23 @@ Feature: Comment Moderation
       And I check "Comments moderated"
       And I post the work without preview
     Then comment moderation should be enabled on "Moderation"
+    When I am logged in as "commenter"
+      And I view the work "Moderation"
+    Then I should see "has chosen to moderate comments"
+    
+  Scenario: Turn off moderation
+    Given I am logged in as "author"
+      And I set up the draft "Moderation"
+      And I check "Comments moderated"
+      And I post the work without preview
+    Then comment moderation should be enabled on "Moderation"
+    When I edit the work "Moderation"
+      And I uncheck "Comments moderated"
+      And I post the work without preview
+    Then comment moderation should not be enabled on "Moderation"
+    When I am logged in as "commenter"
+      And I view the work "Moderation"
+    Then I should not see "has chosen to moderate comments"
     
   Scenario: Post a moderated comment
     Given the moderated work "Moderation" by "author"

--- a/features/comments_and_kudos/comment_moderation.feature
+++ b/features/comments_and_kudos/comment_moderation.feature
@@ -8,7 +8,7 @@ Feature: Comment Moderation
   Scenario: Turn off comments from anonymous users who can still leave kudos
     Given I am logged in as "author"
       And I set up the draft "No Anons"
-      And I check "Anonymous commenting disabled"
+      And I check "Disable anonymous commenting"
       And I post the work without preview
       And I am logged out
     When I view the work "No Anons"
@@ -19,7 +19,7 @@ Feature: Comment Moderation
   Scenario: Turn on moderation
     Given I am logged in as "author"
       And I set up the draft "Moderation"
-      And I check "Comments moderated"
+      And I check "Enable comment moderation"
       And I post the work without preview
     Then comment moderation should be enabled on "Moderation"
     When I am logged in as "commenter"
@@ -29,11 +29,11 @@ Feature: Comment Moderation
   Scenario: Turn off moderation
     Given I am logged in as "author"
       And I set up the draft "Moderation"
-      And I check "Comments moderated"
+      And I check "Enable comment moderation"
       And I post the work without preview
     Then comment moderation should be enabled on "Moderation"
     When I edit the work "Moderation"
-      And I uncheck "Comments moderated"
+      And I uncheck "Enable comment moderation"
       And I post the work without preview
     Then comment moderation should not be enabled on "Moderation"
     When I am logged in as "commenter"

--- a/features/step_definitions/comment_steps.rb
+++ b/features/step_definitions/comment_steps.rb
@@ -109,7 +109,7 @@ end
 Given(/^the moderated work "(.*?)" by "(.*?)"$/) do |work, user|
   step %{I am logged in as "#{user}"}
   step %{I set up the draft "#{work}"}
-  step %{I check "Comments moderated"}
+  check("work_moderated_commenting_enabled")
   step %{I post the work without preview}
 end
 

--- a/features/step_definitions/comment_steps.rb
+++ b/features/step_definitions/comment_steps.rb
@@ -118,6 +118,11 @@ Then /^comment moderation should be enabled on "(.*?)"/ do |work|
   assert w.moderated_commenting_enabled?
 end
 
+Then /^comment moderation should not be enabled on "(.*?)"/ do |work|
+  w = Work.find_by_title(work)
+  assert !w.moderated_commenting_enabled?
+end
+
 Then /^the comment on "(.*?)" should be marked as unreviewed/ do |work|
   w = Work.find_by_title(work)
   assert w.comments.first.unreviewed?

--- a/features/step_definitions/work_steps.rb
+++ b/features/step_definitions/work_steps.rb
@@ -250,20 +250,20 @@ When /^the draft "([^\"]*)" in collection "([^\"]*)"$/ do |title, collection|
 end
 
 When /^I set the fandom to "([^\"]*)"$/ do |fandom|
-  fill_in("Fandoms", :with => fandom)
+  fill_in("Fandoms", with: fandom)
 end
 
 When /^I select "([^\"]*)" for editing$/ do |title|
   id = Work.find_by_title(title).id
   check("work_ids_#{id}")
-end  
+end
 
 When /^I edit the multiple works "([^\"]*)" and "([^\"]*)"/ do |title1, title2|
   # check if the works have been posted yet
-  if !(Work.where(title: title1).exists?)
+  unless (Work.where(title: title1).exists?)
     step %{I post the work "#{title1}"}
   end
-  if !(Work.where(title: title2).exists?)
+  unless (Work.where(title: title2).exists?)
     step %{I post the work "#{title2}"}
   end
   step %{I go to my edit multiple works page}
@@ -273,7 +273,7 @@ When /^I edit the multiple works "([^\"]*)" and "([^\"]*)"/ do |title1, title2|
 end
 
 When /^I edit multiple works with different comment moderation settings$/ do
-  step %{I set up the draft "Work with Comment Moderation Enabled"} 
+  step %{I set up the draft "Work with Comment Moderation Enabled"}
   check("work_moderated_commenting_enabled")
   step %{I post the work without preview}
   step %{I post the work "Work with Comment Moderation Disabled"}
@@ -284,7 +284,7 @@ When /^I edit multiple works with different comment moderation settings$/ do
 end
 
 When /^I edit multiple works with different anonymous commenting settings$/ do
-  step %{I set up the draft "Work with Anonymous Commenting Disabled"} 
+  step %{I set up the draft "Work with Anonymous Commenting Disabled"}
   check("work_anon_commenting_disabled")
   step %{I post the work without preview}
   step %{I post the work "Work with Anonymous Commenting Enabled"}

--- a/features/step_definitions/work_steps.rb
+++ b/features/step_definitions/work_steps.rb
@@ -260,10 +260,10 @@ end
 
 When /^I edit the multiple works "([^\"]*)" and "([^\"]*)"/ do |title1, title2|
   # check if the works have been posted yet
-  unless (Work.where(title: title1).exists?)
+  unless Work.where(title: title1).exists?
     step %{I post the work "#{title1}"}
   end
-  unless (Work.where(title: title2).exists?)
+  unless Work.where(title: title2).exists?
     step %{I post the work "#{title2}"}
   end
   step %{I go to my edit multiple works page}

--- a/features/step_definitions/work_steps.rb
+++ b/features/step_definitions/work_steps.rb
@@ -249,6 +249,29 @@ When /^the draft "([^\"]*)" in collection "([^\"]*)"$/ do |title, collection|
   click_button("Preview")
 end
 
+When /^I set the fandom to "([^\"]*)"$/ do |fandom|
+  fill_in("Fandoms", :with => fandom)
+end
+
+When /^I select "([^\"]*)" for editing$/ do |title|
+  id = Work.find_by_title(title).id
+  check("work_ids_#{id}")
+end  
+
+When /^I edit the multiple works "([^\"]*)" and "([^\"]*)"/ do |title1, title2|
+  # check if the works have been posted yet
+  if !(Work.where(title: title1).exists?)
+    step %{I post the work "#{title1}"}
+  end
+  if !(Work.where(title: title2).exists?)
+    step %{I post the work "#{title2}"}
+  end
+  step %{I go to my edit multiple works page}
+  step %{I select "#{title1}" for editing}
+  step %{I select "#{title2}" for editing}
+  step %{I press "Edit"}
+end
+
 When /^I set up the draft "([^\"]*)"$/ do |title|
   step "basic tags"
   visit new_work_url

--- a/features/step_definitions/work_steps.rb
+++ b/features/step_definitions/work_steps.rb
@@ -272,6 +272,28 @@ When /^I edit the multiple works "([^\"]*)" and "([^\"]*)"/ do |title1, title2|
   step %{I press "Edit"}
 end
 
+When /^I edit multiple works with different comment moderation settings$/ do
+  step %{I set up the draft "Work with Comment Moderation Enabled"} 
+  check("work_moderated_commenting_enabled")
+  step %{I post the work without preview}
+  step %{I post the work "Work with Comment Moderation Disabled"}
+  step %{I go to my edit multiple works page}
+  step %{I select "Work with Comment Moderation Enabled" for editing}
+  step %{I select "Work with Comment Moderation Disabled" for editing}
+  step %{I press "Edit"}
+end
+
+When /^I edit multiple works with different anonymous commenting settings$/ do
+  step %{I set up the draft "Work with Anonymous Commenting Disabled"} 
+  check("work_anon_commenting_disabled")
+  step %{I post the work without preview}
+  step %{I post the work "Work with Anonymous Commenting Enabled"}
+  step %{I go to my edit multiple works page}
+  step %{I select "Work with Anonymous Commenting Disabled" for editing}
+  step %{I select "Work with Anonymous Commenting Enabled" for editing}
+  step %{I press "Edit"}
+end
+
 When /^I set up the draft "([^\"]*)"$/ do |title|
   step "basic tags"
   visit new_work_url

--- a/features/support/paths.rb
+++ b/features/support/paths.rb
@@ -93,6 +93,8 @@ module NavigationHelpers
     when /my works page/
       Work.tire.index.refresh
       user_works_path(User.current_user)
+    when /my edit multiple works page/
+      show_multiple_user_works_path(User.current_user)
     when /my subscriptions page/
       user_subscriptions_path(User.current_user)   
     when /my stats page/

--- a/features/works/work_edit_multiple.feature
+++ b/features/works/work_edit_multiple.feature
@@ -1,0 +1,79 @@
+@works @tags
+Feature: Edit Multiple Works
+  In order to change settings on my works more easily
+  As an author
+  I want to edit multiple works at once
+  
+  Scenario: I can edit multiple works at once
+  Given I am logged in as "author"
+    And I post the work "Glorious" with fandom "SGA"
+    And I post the work "Excellent" with fandom "Star Trek"
+    And I go to my works page
+  When I follow "Edit Works"
+  Then I should see "Edit Multiple Works"
+    And I should see "All"
+    And I should see "None"
+  When I select "Glorious" for editing
+    And I select "Excellent" for editing
+    And I press "Edit"
+  Then I should see "Your edits will be applied to all of the following works"
+    And I should see "Glorious"
+    And I should see "Excellent"
+  When I set the fandom to "Random"
+   And I press "Update All Works"
+  Then I should see "Your edits were put through"
+    And I should see "Random"
+    And I should not see "SGA"
+    And I should not see "Star Trek"
+  When I view the work "Glorious"
+  Then I should see "Random"
+    And I should not see "SGA"
+  When I view the work "Excellent"
+  Then I should see "Random"
+    And I should not see "Star Trek"
+    
+  Scenario: I can disable anon commenting on multiple works at once
+  Given I am logged in as "author"
+    And I edit the multiple works "Glorious" and "Excellent"
+  When I check "Anonymous commenting disabled"
+    And I press "Update All Works"
+    And I am logged out
+    And I view the work "Glorious"
+  Then I should see "doesn't allow non-Archive users to comment"
+  When I view the work "Excellent"    
+  Then I should see "doesn't allow non-Archive users to comment"
+
+  Scenario: I can enable moderated commenting on multiple works at once
+  Given I am logged in as "author"
+    And I edit the multiple works "Glorious" and "Excellent"
+    And I check "Comments moderated"
+    And I press "Update All Works"
+  When I am logged in as "commenter"
+    And I view the work "Glorious"
+  Then I should see "has chosen to moderate comments"
+  When I view the work "Excellent"
+  Then I should see "has chosen to moderate comments"
+
+  Scenario: I can enable anon commenting on multiple works at once
+  Given I am logged in as "author"
+    And I edit the multiple works "Glorious" and "Excellent"
+    And I check "Anonymous commenting disabled"
+    And I press "Update All Works"
+    And I edit the multiple works "Glorious" and "Excellent"
+    And I check "Anonymous commenting enabled"
+    And I press "Update All Works"
+  When I am logged out
+    And I view the work "Glorious"
+  Then I should not see "doesn't allow non-Archive users to comment"
+  
+  Scenario: I can disable moderated commenting on multiple works at once
+  Given I am logged in as "author"
+    And I edit the multiple works "Glorious" and "Excellent"
+    And I check "Comments moderated"
+    And I press "Update All Works"
+    And I edit the multiple works "Glorious" and "Excellent"
+    And I check "Comments not moderated"
+    And I press "Update All Works"
+  When I am logged out
+    And I view the work "Glorious"
+  Then I should not see "has chosen to moderate comments"

--- a/features/works/work_edit_multiple.feature
+++ b/features/works/work_edit_multiple.feature
@@ -35,7 +35,7 @@ Feature: Edit Multiple Works
   Scenario: I can disable anon commenting on multiple works at once
   Given I am logged in as "author"
     And I edit the multiple works "Glorious" and "Excellent"
-  When I check "Anonymous commenting disabled"
+  When I choose "Disable anonymous comments"
     And I press "Update All Works"
     And I am logged out
     And I view the work "Glorious"
@@ -43,10 +43,10 @@ Feature: Edit Multiple Works
   When I view the work "Excellent"    
   Then I should see "doesn't allow non-Archive users to comment"
 
-  Scenario: I can enable moderated commenting on multiple works at once
+  Scenario: I can enable comment moderation on multiple works at once
   Given I am logged in as "author"
     And I edit the multiple works "Glorious" and "Excellent"
-    And I check "Comments moderated"
+    And I choose "Enable comment moderation"
     And I press "Update All Works"
   When I am logged in as "commenter"
     And I view the work "Glorious"
@@ -57,23 +57,47 @@ Feature: Edit Multiple Works
   Scenario: I can enable anon commenting on multiple works at once
   Given I am logged in as "author"
     And I edit the multiple works "Glorious" and "Excellent"
-    And I check "Anonymous commenting disabled"
+    And I choose "Disable anonymous comments"
     And I press "Update All Works"
     And I edit the multiple works "Glorious" and "Excellent"
-    And I check "Anonymous commenting enabled"
+    And I choose "Enable anonymous comments"
     And I press "Update All Works"
   When I am logged out
     And I view the work "Glorious"
   Then I should not see "doesn't allow non-Archive users to comment"
   
-  Scenario: I can disable moderated commenting on multiple works at once
+  Scenario: I can disable comment moderation on multiple works at once
   Given I am logged in as "author"
     And I edit the multiple works "Glorious" and "Excellent"
-    And I check "Comments moderated"
+    And I choose "Enable comment moderation"
     And I press "Update All Works"
     And I edit the multiple works "Glorious" and "Excellent"
-    And I check "Comments not moderated"
+    And I choose "Disable comment moderation"
     And I press "Update All Works"
   When I am logged out
     And I view the work "Glorious"
   Then I should not see "has chosen to moderate comments"
+
+  Scenario: I can keep different comment moderation settings on different works when I edit them at once
+  Given I am logged in as "author"
+    And I edit multiple works with different comment moderation settings
+  When I set the fandom to "Random"
+    And I choose "Keep current comment moderation settings"
+    And I press "Update All Works"
+  When I am logged out
+    And I view the work "Work with Comment Moderation Enabled"
+  Then I should see "has chosen to moderate comments"
+  When I view the work "Work with Comment Moderation Disabled"
+  Then I should not see "has chosen to moderate comments"
+
+  Scenario: I can keep different anonymous commenting settings on different works when I edit them at once
+  Given I am logged in as "author"
+    And I edit multiple works with different anonymous commenting settings
+  When I set the fandom to "Random"
+    And I choose "Keep current anonymous comment settings"
+    And I press "Update All Works"
+  When I am logged out
+    And I view the work "Work with Anonymous Commenting Disabled"
+  Then I should see "doesn't allow non-Archive users to comment"
+  When I view the work "Work with Anonymous Commenting Enabled"
+  Then I should not see "doesn't allow non-Archive users to comment"


### PR DESCRIPTION
https://otwarchive.atlassian.net/browse/AO3-3543

1. After some discussion with Docs and Support, change phrasing on standard work form commenting options to "Disable anonymous commenting" and "Enable comment moderation."

2. Make it possible to select from three radio options for anonymous and moderated comments when mass editing works: 

Anonymous Commenting: 
  Keep current anonymous comment settings
  Enable anonymous comments
  Disable anonymous comments

Comment Moderation:  
  Keep current comment moderation settings
  Enable comment moderation
  Disable comment moderation