### PR TITLE
Fixes AO3-3720, pseuds not updating in autocomplete

### DIFF
--- a/app/models/pseud.rb
+++ b/app/models/pseud.rb
@@ -244,6 +244,13 @@ class Pseud < ActiveRecord::Base
   def byline
     (name != user_name) ? name + " (" + user_name + ")" : name
   end
+  
+  # get the former byline
+  def byline_was
+    past_name = name_was.blank? ? name : name_was
+    past_user_name = user.login_was.blank? ? user.login : user.login_was
+    (past_name != past_user_name) ? "#{past_name} (#{past_user_name})" : past_name
+  end
 
   # Parse a string of the "pseud.name (user.login)" format into a pseud
   def self.parse_byline(byline, options = {})
@@ -302,6 +309,10 @@ class Pseud < ActiveRecord::Base
 
   def autocomplete_value
     "#{id}#{AUTOCOMPLETE_DELIMITER}#{byline}"
+  end
+  
+  def autocomplete_value_was
+    "#{id}#{AUTOCOMPLETE_DELIMITER}#{byline_was}"
   end
 
   ## END AUTOCOMPLETE

--- a/app/models/pseud.rb
+++ b/app/models/pseud.rb
@@ -244,7 +244,7 @@ class Pseud < ActiveRecord::Base
   def byline
     (name != user_name) ? name + " (" + user_name + ")" : name
   end
-  
+
   # get the former byline
   def byline_was
     past_name = name_was.blank? ? name : name_was
@@ -310,7 +310,7 @@ class Pseud < ActiveRecord::Base
   def autocomplete_value
     "#{id}#{AUTOCOMPLETE_DELIMITER}#{byline}"
   end
-  
+
   def autocomplete_value_was
     "#{id}#{AUTOCOMPLETE_DELIMITER}#{byline_was}"
   end

--- a/app/models/pseud.rb
+++ b/app/models/pseud.rb
@@ -248,7 +248,8 @@ class Pseud < ActiveRecord::Base
   # get the former byline
   def byline_was
     past_name = name_was.blank? ? name : name_was
-    past_user_name = user.login_was.blank? ? user.login : user.login_was
+    # if we have a user and their login has changed get the old one
+    past_user_name = user.blank? ? "" : (user.login_was.blank? ? user.login : user.login_was)
     (past_name != past_user_name) ? "#{past_name} (#{past_user_name})" : past_name
   end
 

--- a/app/sweepers/pseud_sweeper.rb
+++ b/app/sweepers/pseud_sweeper.rb
@@ -6,19 +6,23 @@ class PseudSweeper < ActionController::Caching::Sweeper
   end
   
   def before_update(record)
-    if record.changed.include?(:name)
+    if record.changed.include?("name") || record.changed.include?("login")
       if record.is_a?(User)
-        record.pseuds.each {|pseud| pseud.remove_from_autocomplete}
+        record.pseuds.each {|pseud| pseud.remove_stale_from_autocomplete}
       else
-        record.remove_from_autocomplete
+        record.remove_stale_from_autocomplete
       end
     end
   end
   
   def after_update(record)
-    if record.changed.include?(:name)
+    if record.changed.include?("name") || record.changed.include?("login")
       if record.is_a?(User)
-        record.pseuds.each {|pseud| pseud.add_to_autocomplete}
+        record.pseuds.each do |pseud| 
+          # have to reload the pseud from the db otherwise it has the outdated login
+          pseud.reload
+          pseud.add_to_autocomplete
+        end
       else
         record.add_to_autocomplete
       end

--- a/app/sweepers/pseud_sweeper.rb
+++ b/app/sweepers/pseud_sweeper.rb
@@ -8,7 +8,7 @@ class PseudSweeper < ActionController::Caching::Sweeper
   def before_update(record)
     if record.changed.include?("name") || record.changed.include?("login")
       if record.is_a?(User)
-        record.pseuds.each {|pseud| pseud.remove_stale_from_autocomplete}
+        record.pseuds.each(&:remove_stale_from_autocomplete)
       else
         record.remove_stale_from_autocomplete
       end
@@ -18,7 +18,7 @@ class PseudSweeper < ActionController::Caching::Sweeper
   def after_update(record)
     if record.changed.include?("name") || record.changed.include?("login")
       if record.is_a?(User)
-        record.pseuds.each do |pseud| 
+        record.pseuds.each do |pseud|
           # have to reload the pseud from the db otherwise it has the outdated login
           pseud.reload
           pseud.add_to_autocomplete

--- a/config/.rubocop.yml
+++ b/config/.rubocop.yml
@@ -11,3 +11,7 @@ Metrics/LineLength:
 # stop checking for trailing whitespace
 Style/TrailingWhitespace:
   Enabled: false
+  
+# stop checking for ambiguous regexp literal
+Lint/AmbiguousRegexpLiteral:
+  Enabled: false

--- a/config/.rubocop.yml
+++ b/config/.rubocop.yml
@@ -7,3 +7,7 @@ Style/StringLiterals:
 # stop checking line length
 Metrics/LineLength:
   Enabled: false
+  
+# stop checking for trailing whitespace
+Style/TrailingWhitespace:
+  Enabled: false

--- a/features/other_a/autocomplete.feature
+++ b/features/other_a/autocomplete.feature
@@ -50,3 +50,40 @@ Scenario: Collection autocomplete shows Collection Title and Name
     And I fill in "collection_names" with "Issue"
   Then I should see "jb_fletcher" in the autocomplete
     And I should see "robert_stack" in the autocomplete
+
+Scenario: Pseuds should be added and removed from autocomplete as they are changed
+  Given I have flushed Redis
+    And I am logged in as "new_user"
+  Then the pseud autocomplete should contain "new_user"
+  When I add the pseud "extra"
+  Then the pseud autocomplete should contain "extra (new_user)"
+  When I change the pseud "extra" to "funny"
+    And I go to my pseuds page
+  Then I should not see "extra"
+    And I should see "funny"
+    And the pseud autocomplete should not contain "extra (new_user)"
+    And the pseud autocomplete should contain "funny (new_user)"
+  When I delete the pseud "funny"
+  Then the pseud autocomplete should not contain "funny (different_user)"
+    And the pseud autocomplete should contain "different_user"
+    
+Scenario: Pseuds should be added and removed from autocomplete as usernames change
+  Given I have flushed Redis
+    And I am logged in as "new_user"
+    And I add the pseud "funny"
+  When I change my username to "different_user"
+  Then the pseud autocomplete should not contain "funny (new_user)"
+    And the pseud autocomplete should not contain "new_user"
+    And the pseud autocomplete should contain "different_user"
+    And the pseud autocomplete should contain "funny (different_user)"
+  When I change my username to "funny"
+  Then the pseud autocomplete should not contain "funny (different_user)"
+    And the pseud autocomplete should contain "funny"
+    And the pseud autocomplete should contain "different_user (funny)"
+  When I try to delete my account as funny
+  Then a user account should not exist for "funny"
+    And the pseud autocomplete should not contain "funny"
+    And the pseud autocomplete should not contain "different_user (funny)"
+    
+    
+  

--- a/features/other_a/autocomplete.feature
+++ b/features/other_a/autocomplete.feature
@@ -1,55 +1,58 @@
-@wip
 Feature: Display autocomplete for tags
   In order to facilitate posting
   I should be getting autocompletes for my tags
 
-Scenario: Only matching canonical tags should appear in autocomplete, and searching for the same data twice should produce same results
-	Given I am logged in
-		And a set of tags for testing autocomplete
-   	And I go to the new work page
-  Then the tag autocomplete fields should list only matching canonical tags
+  Scenario: Autocomplete tests should be added when javascript testing is enabled
+  When "AO3-4369: Javascript enabled for automated tests" is fixed
+  # uncomment all the below tests which currently DO NOT WORK
   
-Scenario: For fandom-specific autocomplete, if a fandom is entered then only characters/relationships within the fandom should appear in autocomplete
-	Given I am logged in
-		And a set of tags for testing autocomplete
- 		And I go to the new work page
- 	Then the fandom-specific tag autocomplete fields should list only fandom-specific canonical tags
-
-Scenario: Bookmark archive work form autocomplete should work
-  Given I am logged in
-    And a set of tags for testing autocomplete
-  When I start a new bookmark
-    And I enter text in the "Your Tags" autocomplete field
-  Then I should only see matching canonical tags in the autocomplete
-
-Scenario: Bookmark external work form autocomplete should work
-  Given I am logged in
-    And a set of tags for testing autocomplete
-    And an external work    
-  When I go to the new external work page
-  Then the tag autocomplete fields should list only matching canonical tags
-    And the fandom-specific tag autocomplete fields should list only fandom-specific canonical tags
-    And the external url autocomplete field should list the urls of existing external works
-
-Scenario: Pseud and collection autocompletes should work
-  Given I am logged in
-	  And a set of collections for testing autocomplete
-  	And a set of users for testing autocomplete
-   	And I go to the new work page
-  Then the coauthor autocomplete field should list matching users
-    And the gift recipient autocomplete field should list matching users
-    And the collection item autocomplete field should list matching collections
-
-Scenario: Collection autocomplete shows Collection Title and Name
-  Given I have the collection "Issue" with name "jb_fletcher"
-    And I have the collection "Issue" with name "robert_stack"
-    And I am logged in as "Scott" with password "password"
-    And I post the work "All The Nice Things"
-    And I view the work "All The Nice Things"
-    And I follow "Add To Collections"
-    And I fill in "collection_names" with "Issue"
-  Then I should see "jb_fletcher" in the autocomplete
-    And I should see "robert_stack" in the autocomplete
+# Scenario: Only matching canonical tags should appear in autocomplete, and searching for the same data twice should produce same results
+#   Given I am logged in
+#     And a set of tags for testing autocomplete
+#      And I go to the new work page
+#   Then the tag autocomplete fields should list only matching canonical tags
+#
+# Scenario: For fandom-specific autocomplete, if a fandom is entered then only characters/relationships within the fandom should appear in autocomplete
+#   Given I am logged in
+#     And a set of tags for testing autocomplete
+#      And I go to the new work page
+#    Then the fandom-specific tag autocomplete fields should list only fandom-specific canonical tags
+#
+# Scenario: Bookmark archive work form autocomplete should work
+#   Given I am logged in
+#     And a set of tags for testing autocomplete
+#   When I start a new bookmark
+#     And I enter text in the "Your Tags" autocomplete field
+#   Then I should only see matching canonical tags in the autocomplete
+#
+# Scenario: Bookmark external work form autocomplete should work
+#   Given I am logged in
+#     And a set of tags for testing autocomplete
+#     And an external work
+#   When I go to the new external work page
+#   Then the tag autocomplete fields should list only matching canonical tags
+#     And the fandom-specific tag autocomplete fields should list only fandom-specific canonical tags
+#     And the external url autocomplete field should list the urls of existing external works
+#
+# Scenario: Pseud and collection autocompletes should work
+#   Given I am logged in
+#     And a set of collections for testing autocomplete
+#     And a set of users for testing autocomplete
+#      And I go to the new work page
+#   Then the coauthor autocomplete field should list matching users
+#     And the gift recipient autocomplete field should list matching users
+#     And the collection item autocomplete field should list matching collections
+#
+# Scenario: Collection autocomplete shows Collection Title and Name
+#   Given I have the collection "Issue" with name "jb_fletcher"
+#     And I have the collection "Issue" with name "robert_stack"
+#     And I am logged in as "Scott" with password "password"
+#     And I post the work "All The Nice Things"
+#     And I view the work "All The Nice Things"
+#     And I follow "Add To Collections"
+#     And I fill in "collection_names" with "Issue"
+#   Then I should see "jb_fletcher" in the autocomplete
+#     And I should see "robert_stack" in the autocomplete
 
 Scenario: Pseuds should be added and removed from autocomplete as they are changed
   Given I have flushed Redis
@@ -64,8 +67,8 @@ Scenario: Pseuds should be added and removed from autocomplete as they are chang
     And the pseud autocomplete should not contain "extra (new_user)"
     And the pseud autocomplete should contain "funny (new_user)"
   When I delete the pseud "funny"
-  Then the pseud autocomplete should not contain "funny (different_user)"
-    And the pseud autocomplete should contain "different_user"
+  Then the pseud autocomplete should not contain "funny (new_user)"
+    And the pseud autocomplete should contain "new_user"
     
 Scenario: Pseuds should be added and removed from autocomplete as usernames change
   Given I have flushed Redis

--- a/features/step_definitions/.rubocop.yml
+++ b/features/step_definitions/.rubocop.yml
@@ -1,0 +1,5 @@
+inherit_from:
+  - ../../.rubocop.yml
+  
+Lint/AmbiguousRegexpLiteral:
+  Enabled: false

--- a/features/step_definitions/.rubocop.yml
+++ b/features/step_definitions/.rubocop.yml
@@ -1,5 +1,0 @@
-inherit_from:
-  - ../../.rubocop.yml
-  
-Lint/AmbiguousRegexpLiteral:
-  Enabled: false

--- a/features/step_definitions/autocomplete_steps.rb
+++ b/features/step_definitions/autocomplete_steps.rb
@@ -222,11 +222,11 @@ Then /^the tag autocomplete fields should have the entered values$/ do
 end
 
 Then(/^the pseud autocomplete should contain "([^\"]*)"$/) do |pseud|
-  results = Pseud.autocomplete_lookup(search_param: pseud, autocomplete_prefix: "autocomplete_pseud").map {|res| Pseud.fullname_from_autocomplete(res)}
+  results = Pseud.autocomplete_lookup(search_param: pseud, autocomplete_prefix: "autocomplete_pseud").map { |res| Pseud.fullname_from_autocomplete(res) }
   assert results.include?(pseud)
 end
 
 Then(/^the pseud autocomplete should not contain "([^\"]*)"$/) do |pseud|
-  results = Pseud.autocomplete_lookup(search_param: pseud, autocomplete_prefix: "autocomplete_pseud").map {|res| Pseud.fullname_from_autocomplete(res)}
+  results = Pseud.autocomplete_lookup(search_param: pseud, autocomplete_prefix: "autocomplete_pseud").map { |res| Pseud.fullname_from_autocomplete(res) }
   assert !results.include?(pseud)
 end

--- a/features/step_definitions/autocomplete_steps.rb
+++ b/features/step_definitions/autocomplete_steps.rb
@@ -220,3 +220,13 @@ Then /^the tag autocomplete fields should have the entered values$/ do
     step %{I should see "Lex Luthor" in the autocomplete}
     step %{I should see "Dean Winchester" in the autocomplete}
 end
+
+Then(/^the pseud autocomplete should contain "([^\"]*)"$/) do |pseud|
+  results = Pseud.autocomplete_lookup(search_param: pseud, autocomplete_prefix: "autocomplete_pseud").map {|res| Pseud.fullname_from_autocomplete(res)}
+  assert results.include?(pseud)
+end
+
+Then(/^the pseud autocomplete should not contain "([^\"]*)"$/) do |pseud|
+  results = Pseud.autocomplete_lookup(search_param: pseud, autocomplete_prefix: "autocomplete_pseud").map {|res| Pseud.fullname_from_autocomplete(res)}
+  assert !results.include?(pseud)
+end

--- a/features/step_definitions/pseud_steps.rb
+++ b/features/step_definitions/pseud_steps.rb
@@ -6,7 +6,7 @@ end
   
 When /^I edit the pseud "([^\"]*)"/ do |pseud| 
   p = Pseud.where(name: pseud, user_id: User.current_user.id).first
-  visit edit_user_pseud_path(User.current_user, pseud)
+  visit edit_user_pseud_path(User.current_user, p)
 end
 
 When /^I add the pseud "([^\"]*)"/ do |pseud| 

--- a/features/step_definitions/pseud_steps.rb
+++ b/features/step_definitions/pseud_steps.rb
@@ -1,0 +1,21 @@
+When /^I change the pseud "([^\"]*)" to "([^\"]*)"/ do |old_pseud, new_pseud|
+  step %{I edit the pseud "#{old_pseud}"}
+  fill_in("Name", with: new_pseud)
+  click_button("Update")
+end
+  
+When /^I edit the pseud "([^\"]*)"/ do |pseud| 
+  p = Pseud.where(name: pseud, user_id: User.current_user.id).first
+  visit edit_user_pseud_path(User.current_user, pseud)
+end
+
+When /^I add the pseud "([^\"]*)"/ do |pseud| 
+  visit new_user_pseud_path(User.current_user)
+  fill_in("Name", with: pseud)
+  click_button("Create")
+end
+
+When(/^I delete the pseud "([^\"]*)"$/) do |pseud|
+  visit user_pseuds_path(User.current_user)
+  click_link("delete_#{pseud}")
+end

--- a/features/step_definitions/pseud_steps.rb
+++ b/features/step_definitions/pseud_steps.rb
@@ -3,7 +3,7 @@ When /^I change the pseud "([^\"]*)" to "([^\"]*)"/ do |old_pseud, new_pseud|
   fill_in("Name", with: new_pseud)
   click_button("Update")
 end
-  
+
 When /^I edit the pseud "([^\"]*)"/ do |pseud| 
   p = Pseud.where(name: pseud, user_id: User.current_user.id).first
   visit edit_user_pseud_path(User.current_user, p)

--- a/features/step_definitions/user_steps.rb
+++ b/features/step_definitions/user_steps.rb
@@ -256,6 +256,14 @@ Then /^I should not see the (most recent|oldest) (work|series) for (pseud|user) 
   step %{I should not see "#{title}"}
 end
 
+When /^I change my username to "([^\"]*)"/ do |new_name|
+  visit change_username_user_path(User.current_user)
+  fill_in("New user name", with: new_name)
+  fill_in("Password", with: "password")
+  click_button("Change User Name")
+  step %{I should get confirmation that I changed my username}
+end
+
 Then /^I should get confirmation that I changed my username$/ do
   step(%{I should see "Your user name has been successfully updated."})
 end

--- a/features/step_definitions/user_steps.rb
+++ b/features/step_definitions/user_steps.rb
@@ -256,7 +256,7 @@ Then /^I should not see the (most recent|oldest) (work|series) for (pseud|user) 
   step %{I should not see "#{title}"}
 end
 
-When /^I change my username to "([^\"]*)"/ do |new_name|
+When (/^I change my username to "([^\"]*)"/) do |new_name|
   visit change_username_user_path(User.current_user)
   fill_in("New user name", with: new_name)
   fill_in("Password", with: "password")

--- a/features/step_definitions/user_steps.rb
+++ b/features/step_definitions/user_steps.rb
@@ -267,3 +267,4 @@ end
 Then /^I should get confirmation that I changed my username$/ do
   step(%{I should see "Your user name has been successfully updated."})
 end
+ 

--- a/features/step_definitions/user_steps.rb
+++ b/features/step_definitions/user_steps.rb
@@ -256,7 +256,7 @@ Then /^I should not see the (most recent|oldest) (work|series) for (pseud|user) 
   step %{I should not see "#{title}"}
 end
 
-When (/^I change my username to "([^\"]*)"/) do |new_name|
+When(/^I change my username to "([^\"]*)"/) do |new_name|
   visit change_username_user_path(User.current_user)
   fill_in("New user name", with: new_name)
   fill_in("Password", with: "password")

--- a/features/step_definitions/user_steps.rb
+++ b/features/step_definitions/user_steps.rb
@@ -256,7 +256,7 @@ Then /^I should not see the (most recent|oldest) (work|series) for (pseud|user) 
   step %{I should not see "#{title}"}
 end
 
-When /^I change my username to "([^\"]*)"/h do |new_name|
+When /^I change my username to "([^\"]*)"/ do |new_name|
   visit change_username_user_path(User.current_user)
   fill_in("New user name", with: new_name)
   fill_in("Password", with: "password")

--- a/features/step_definitions/user_steps.rb
+++ b/features/step_definitions/user_steps.rb
@@ -256,7 +256,7 @@ Then /^I should not see the (most recent|oldest) (work|series) for (pseud|user) 
   step %{I should not see "#{title}"}
 end
 
-When(/^I change my username to "([^\"]*)"/) do |new_name|
+When /^I change my username to "([^\"]*)"/h do |new_name|
   visit change_username_user_path(User.current_user)
   fill_in("New user name", with: new_name)
   fill_in("Password", with: "password")


### PR DESCRIPTION
A fix for AO3-3720 and also AO3-3621 which was caused by the same issue. 

The issue was (1) the removal/addition wasn't being triggered at all because the condition check was looking for :name instead of "name" etc, and (2) the removal wasn't using the correct stale values for pseud/username, and (3) for username changes, the correct current value had to be reloaded from the database before adding.

With shiny tests, yay. 

Signed-off-by: astolat shalott <shalott@gmail.com>