### PR TITLE
stop hound complaining unhelpfully

### DIFF
--- a/config/.rubocop.yml
+++ b/config/.rubocop.yml
@@ -7,3 +7,11 @@ Style/StringLiterals:
 # stop checking line length
 Metrics/LineLength:
   Enabled: false
+  
+# stop checking for trailing whitespace
+Style/TrailingWhitespace:
+  Enabled: false
+  
+# stop checking for ambiguous regexp literal
+Lint/AmbiguousRegexpLiteral:
+  Enabled: false


### PR DESCRIPTION
Turns off warnings for trailing whitespace and ambiguous regexp literals that actually make step definitions more readable

Signed-off-by: astolat shalott <shalott@gmail.com>