### PR TITLE
AO3-4374 Spiffy up account creation confirmation page

### DIFF
--- a/app/views/users/confirmation.html.erb
+++ b/app/views/users/confirmation.html.erb
@@ -10,7 +10,8 @@
     <%= ts("If you don't hear from us within 24 hours, and you don't find our email in your spam filter, please <a href='%{support_path}'>drop us a line at Support</a>.", support_path: new_feedback_report_path).html_safe %>
   </p>
   <p>
-    <%= ts("<strong>Important!</strong> You must verify your account within %{days_before_purge} days, or your registration will expire.", days_before_purge: ArchiveConfig.DAYS_TO_PURGE_UNACTIVATED).html_safe %>
+    <% # We do days_to_purge_unactivated * 7 because it's actually weeks %>
+    <%= ts("<strong>Important!</strong> You must verify your account within %{days_before_purge} days, or your registration will expire.", days_before_purge: AdminSetting.first.days_to_purge_unactivated? ? (AdminSetting.first.days_to_purge_unactivated * 7) : ArchiveConfig.DAYS_TO_PURGE_UNACTIVATED).html_safe %>
   </p>
   <p>
     <%= link_to ts('Return to Archive front page'), root_path %>

--- a/app/views/users/confirmation.html.erb
+++ b/app/views/users/confirmation.html.erb
@@ -1,20 +1,19 @@
+<!--Descriptive page name, messages and instructions-->
 <h2 class="heading"><%= ts("Account Created!") %></h2>
-<!-- Boilerplate text for account creation confirmation -->
-<p>
-  <%= ts("Within 24 hours, you should receive an email at the address you gave us.") %>
-  <%= ts("This will have the URL you need to go to in order to verify your account and complete the account creation process.") %>
-  <%= ts("You might want to add") %>
-  <strong><%=h ArchiveConfig.RETURN_ADDRESS %></strong>
-  <%= ts("to your address book to make sure you get the mail.") %>
-</p>
-<p>
-  <%= ts("If you don't hear from us within 24 hours, and you don't find our email in your spam filter, please drop us a line at") %>
-  <%= "Support (http://archiveofourown.org/support)" %>.
-</p>
-<p>
-  <strong><%= ts("Important!") %></strong>
-  <%= ts("You must verify your account within 14 days, or your registration will expire.") %>
-</p>
-<p>
-  <%= link_to ts('Return to archive front page'), root_path %>
-</p>
+<!--/descriptions-->
+<!--main content-->
+<div class="userstuff">
+  <p>
+    <%= ts("Within 24 hours, you should receive an email at the address you gave us. This will have the URL you need to go to in order to verify your account and complete the account creation process. You might want to add <strong>%{return_address}</strong> to your address book to make sure you get the mail.", return_address: ArchiveConfig.RETURN_ADDRESS).html_safe %>
+  </p>
+  <p>
+    <%= ts("If you don't hear from us within 24 hours, and you don't find our email in your spam filter, please <a href='%{support_path}'>drop us a line at Support</a>.", support_path: new_feedback_report_path).html_safe %>
+  </p>
+  <p>
+    <%= ts("<strong>Important!</strong> You must verify your account within %{days_before_purge} days, or your registration will expire.", days_before_purge: ArchiveConfig.DAYS_TO_PURGE_UNACTIVATED).html_safe %>
+  </p>
+  <p>
+    <%= link_to ts('Return to Archive front page'), root_path %>
+  </p>
+</div>
+<!--/content-->

--- a/app/views/users/confirmation.html.erb
+++ b/app/views/users/confirmation.html.erb
@@ -1,20 +1,20 @@
-		<h2 class="heading"><%= ts("Account Created!") %></h2>
+<h2 class="heading"><%= ts("Account Created!") %></h2>
 <!-- Boilerplate text for account creation confirmation -->
-		<p>
-			<%= ts("Within 24 hours, you should receive an email at the address you gave us.") %>
-			<%= ts("This will have the URL you need to go to in order to verify your account and complete the account creation process.") %>
-			<%= ts("You might want to add") %>
-			<strong><%=h ArchiveConfig.RETURN_ADDRESS %></strong> 
-			<%= ts("to your address book to make sure you get the mail.") %>
-		</p>
-		<p>
-			<%= ts("If you don't hear from us within 24 hours, and you don't find our email in your spam filter, please drop us a line at") %>
-			<%= "Support (http://archiveofourown.org/support)" %>.
-		</p>
-		<p>
-			<strong><%= ts("Important!") %></strong>
-			<%= ts("You must verify your account within 14 days, or your registration will expire.") %>
-		</p>
-		<p>
-			<%= link_to ts('Return to archive front page'), root_path %>
-		</p>
+<p>
+  <%= ts("Within 24 hours, you should receive an email at the address you gave us.") %>
+  <%= ts("This will have the URL you need to go to in order to verify your account and complete the account creation process.") %>
+  <%= ts("You might want to add") %>
+  <strong><%=h ArchiveConfig.RETURN_ADDRESS %></strong>
+  <%= ts("to your address book to make sure you get the mail.") %>
+</p>
+<p>
+  <%= ts("If you don't hear from us within 24 hours, and you don't find our email in your spam filter, please drop us a line at") %>
+  <%= "Support (http://archiveofourown.org/support)" %>.
+</p>
+<p>
+  <strong><%= ts("Important!") %></strong>
+  <%= ts("You must verify your account within 14 days, or your registration will expire.") %>
+</p>
+<p>
+  <%= link_to ts('Return to archive front page'), root_path %>
+</p>

--- a/features/other_a/invite_request.feature
+++ b/features/other_a/invite_request.feature
@@ -84,7 +84,7 @@ Feature: Invite requests
         | user_password_confirmation  | password1 |
       And I press "Create Account"
     Then I should see "Within 24 hours, you should receive an email at the address you gave us."
-      And I should see "You must verify your account within 14 days"
+      And I should see how long I have to activate my account
       And I should see "If you don't hear from us within 24 hours"
 
   Scenario: When not logged in, there is a Create an Account button

--- a/features/step_definitions/invite_steps.rb
+++ b/features/step_definitions/invite_steps.rb
@@ -125,3 +125,10 @@ When /^I check how long "(.*?)" will have to wait in the invite request queue$/ 
   fill_in("email", :with => "#{email}")
   click_button("Look me up")
 end
+
+### Then
+
+Then /^I should see how long I have to activate my account$/ do
+  days_to_activate = AdminSetting.first.days_to_purge_unactivated? ? (AdminSetting.first.days_to_purge_unactivated? * 7) : ArchiveConfig.DAYS_TO_PURGE_UNACTIVATED
+  step %{I should see "You must verify your account within #{days_to_activate} days"}
+end

--- a/features/step_definitions/invite_steps.rb
+++ b/features/step_definitions/invite_steps.rb
@@ -129,6 +129,6 @@ end
 ### Then
 
 Then /^I should see how long I have to activate my account$/ do
-  days_to_activate = AdminSetting.first.days_to_purge_unactivated? ? (AdminSetting.first.days_to_purge_unactivated? * 7) : ArchiveConfig.DAYS_TO_PURGE_UNACTIVATED
+  days_to_activate = AdminSetting.first.days_to_purge_unactivated? ? (AdminSetting.first.days_to_purge_unactivated * 7) : ArchiveConfig.DAYS_TO_PURGE_UNACTIVATED
   step %{I should see "You must verify your account within #{days_to_activate} days"}
 end


### PR DESCRIPTION
https://otwarchive.atlassian.net/browse/AO3-4374

After you create an account, the page that you see -- http://archiveofourown.org/users -- has a sentence that says: "If you don't hear from us within 24 hours, and you don't find our email in your spam filter, please drop us a line at Support (http://archiveofourown.org/support)."

That should be a hyperlink, not a typed out URL.

It also has a link that says: "Return to archive front page"

That should be "Archive."

BONUS ROUND: Instead of hard coding in the number of days after which an unactivated account will be purged, now we use the value in the admin settings (times 7 because that field is for weeks even though it's named days /o\) and, if that's blank, the config file. \o/

SUPER BONUS ROUND: Wrapped the page content in `<div class="userstuff">` like we do for all our text-y pages so there'll be some space between the darn paragraphs.