### PR TITLE
AO3-4380: Improve speed of inbox comment query

### DIFF
--- a/app/models/inbox_comment.rb
+++ b/app/models/inbox_comment.rb
@@ -33,15 +33,7 @@ class InboxComment < ActiveRecord::Base
 
   # Get only the comments with a feedback_comment that exists
   def self.with_feedback_comment
-    # Get an array of the ids of inbox comments that have existing feedback_comments
-    inbox_comments_with_feedback_comment = []
-    find_each do |inbox_comment|
-      unless inbox_comment.feedback_comment.nil? ||
-             inbox_comment.feedback_comment.is_deleted?
-        inbox_comments_with_feedback_comment << inbox_comment
-      end
-    end
-    # Get the ActiveRecord Relation objects based on that array
-    where(id: inbox_comments_with_feedback_comment)
+    joins("LEFT JOIN comments ON comments.id = inbox_comments.feedback_comment_id").
+    where("comments.id IS NOT NULL AND comments.is_deleted = 0")
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -185,14 +185,13 @@ class User < ActiveRecord::Base
   end
 
   def read_inbox_comments
-    inbox_comments.find(:all, :conditions => {:read => true})
+    inbox_comments.where(read: true)
   end
   def unread_inbox_comments
-    inbox_comments.find(:all, :conditions => {:read => false})
+    inbox_comments.where(read: false)
   end
   def unread_inbox_comments_count
-    inbox_comments.with_feedback_comment.count(:all,
-                                               conditions: { read: false })
+    unread_inbox_comments.with_feedback_comment.count
   end
 
   scope :alphabetical, :order => :login


### PR DESCRIPTION
Use a single query to determine which inbox comments have comments attached to them rather than looping through the comments, which is non-performant for users with large inboxes.

https://otwarchive.atlassian.net/browse/AO3-4380