### PR TITLE
AO3-4358 Sign-up Form / Prompt Form link missing in modded collections

### DIFF
--- a/features/gift_exchanges/challenge_giftexchange.feature
+++ b/features/gift_exchanges/challenge_giftexchange.feature
@@ -70,6 +70,7 @@ Feature: Gift Exchange Challenge
       And I press "Submit"
     Then I should see "New members invited: comod"
 
+
   Scenario: Sign up for a gift exchange
     Given the gift exchange "Awesome Gift Exchange" is ready for signups
       And I am logged in as "myname1"
@@ -378,6 +379,26 @@ Feature: Gift Exchange Challenge
       And I follow "Sign-up Summary"
     Then I should not see "Summary does not appear until at least"
       And I should see "Tags were not used in this Challenge, so there is no summary to display here."
+
+  Scenario: Sign-up Form link shows up in sidebar of moderated collections
+    Given I am logged in as "mod1"
+      And I have created the gift exchange "Cabbot Cove"
+      And I open signups for "Cabbot Cove"
+    When  I am logged in as "Scott" with password "password"
+      And I go to "Cabbot Cove" collection's page
+      And I should see "Unmoderated"
+      And I should see "Sign-up Form"
+    Then  I am logged in as "mod1"
+      And I go to "Cabbot Cove" collection's page
+      And I follow "Collection Settings"
+      And I check "This collection is moderated"
+      And I press "Update"
+    Then I am logged in as "Scott" with password "password"
+      And I go to "Cabbot Cove" collection's page
+      And I should see "Moderated"
+      And I should see "Sign-up Form"
+
+
 
   Scenario: Tagsets show up in Challenge metadata
     Given I am logged in as "mod1"

--- a/lib/challenge_core.rb
+++ b/lib/challenge_core.rb
@@ -72,8 +72,7 @@ module ChallengeCore
   end
 
   def user_allowed_to_sign_up?(user)
-    self.collection.user_is_maintainer?(user) || 
-      (self.signup_open && (!self.collection.moderated? || self.collection.user_is_posting_participant?(user)))
+    self.collection.user_is_maintainer?(user) || self.signup_open
   end
   
   def user_allowed_to_see_prompt?(user, prompt)


### PR DESCRIPTION
Resolves issue: https://otwarchive.atlassian.net/browse/AO3-4358

The 'Sign-up Form' and 'Prompt Form' links were missing in both Gift Exchanges and Prompt Memes (respectively) when a collection was moderated. This PR:

* Removed the check from the code that looked to see if a collection was moderated (and if it was, if that user was already a posting participant). 
* Added a new Cucumber test to catch regression on this functionality in the future