### PR TITLE
AO3-4402 Fixing one of the warnings in our specs for user_mailer database cleanup

### DIFF
--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -86,16 +86,16 @@ describe UserMailer do
 
     # before(:all) doesn't get cleaned up by database cleaner
     after(:all) do
-      @author.destroy
-      @archivist.destroy
-      @external_author.destroy
-      @external_author_name.destroy
+      @author.destroy if @author
+      @archivist.destroy if @archivist
+      @external_author.destroy if @external_author
+      @external_author_name.destroy if @external_author_name
 
-      @invitation.destroy
-      @fandom1.destroy
+      @invitation.destroy if @invitation
+      @fandom1.destroy if @fandom1
 
-      @work.destroy
-      @work2.destroy
+      @work.destroy if @work
+      @work2.destroy if @work2
     end
 
     let(:email) { UserMailer.invitation_to_claim(@invitation.id, @archivist.login).deliver }


### PR DESCRIPTION
Will make Travis a little quieter/happier. Currently it gives a warning: 
```
An error occurred in an `after(:context)` hook.
  NoMethodError: undefined method `destroy' for nil:NilClass
  occurred at /home/travis/build/otwcode/otwarchive/spec/mailers/user_mailer_spec.rb:89:in `block (3 levels) in <top (required)>'
```
which will stop happening after this change.