### PR TITLE
AO3-4403 Travis for new repos

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: ruby
+sudo: required
 env:
   - TEST_GROUP="./script/check_syntax"
   - TEST_GROUP="rspec spec"


### PR DESCRIPTION
This will mean that individual coders can set up Travis on their own fork, so they can see the Travis build and test results without needing to run them locally (taking ages) or make a pull request (clutters up the PR queue with things that aren't ready).