### PR TITLE
AO3-4410 Making git on vagrant easier to use

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .DS_Store
 .bundle
 .idea
+stdout
 # /
 /*.tmproj
 /sphinx


### PR DESCRIPTION
Will only affect coders using vagrant or other machines with settings that dump things in stdout under normal use.