### PR TITLE
AO3-4413 Move Bullet notices to browser console instead of footer

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -30,10 +30,12 @@ Otwarchive::Application.configure do
   config.rack_dev_mark.enable = true
   config.rack_dev_mark.theme = [:title, Rack::DevMark::Theme::GithubForkRibbon.new(position: 'left', color: 'green' , fixed: 'true' )]
 
+  # Enable Bullet gem to monitor application performance
   config.after_initialize do
     Bullet.enable = true
     Bullet.bullet_logger = true
-    Bullet.add_footer = true
+    Bullet.console = true
+    Bullet.add_footer = false
     Bullet.rails_logger = true
     Bullet.counter_cache_enable = false
   end

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -67,7 +67,7 @@ Otwarchive::Application.configure do
   config.after_initialize do
     Bullet.enable = true
     Bullet.bullet_logger = true
-    Bullet.add_footer =
+    Bullet.add_footer = false
     Bullet.console = true
     Bullet.rails_logger = true
     Bullet.counter_cache_enable = false

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -67,7 +67,8 @@ Otwarchive::Application.configure do
   config.after_initialize do
     Bullet.enable = true
     Bullet.bullet_logger = true
-    Bullet.add_footer = false
+    Bullet.add_footer =
+    Bullet.console = true
     Bullet.rails_logger = true
     Bullet.counter_cache_enable = false
   end


### PR DESCRIPTION
Resolves: https://otwarchive.atlassian.net/browse/AO3-4413

Changes the Bullet configuration so that notifications go to a browser's Console instead of being appended to the webpage's footer. 