### PR TITLE
AO3-4439: making abuse report in user mailer translatable i18n

### DIFF
--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -385,7 +385,7 @@ class UserMailer < BulletproofMailer::Base
     @comment = abuse_report.comment
     mail(
       to: abuse_report.email,
-      subject: "[#{ArchiveConfig.APP_SHORT_NAME}] Your Abuse Report"
+      subject: "#{t 'user_mailer.abuse_report.subject', app_name: ArchiveConfig.APP_SHORT_NAME}"
     )
   end
 

--- a/app/views/user_mailer/abuse_report.html.erb
+++ b/app/views/user_mailer/abuse_report.html.erb
@@ -1,13 +1,11 @@
 <% content_for :message do %>
-  <p>
-    The following abuse report has been sent to the Abuse team:
-  </p>
+  <p><%= t 'user_mailer.abuse_report.para1' %></p>
   
   <p>
-    <%= style_bold("URL of the page the abuse is on:") %> <%= style_link(@url, @url) %>
+    <%= style_bold(t 'user_mailer.abuse_report.url_para') %> <%= style_link(@url, @url) %>
   </p>
   
-  <%= style_bold("Description of the abuse:") %>
+  <%= style_bold(t 'user_mailer.abuse_report.description_para') %>
   <%= style_quote(@comment) %>
 
 <% end %>

--- a/app/views/user_mailer/abuse_report.text.erb
+++ b/app/views/user_mailer/abuse_report.text.erb
@@ -1,9 +1,9 @@
 <% content_for :message do %>
-The following abuse report has been sent to the Abuse team:
+<%= t 'user_mailer.abuse_report.para1' %>
   
-URL of the page the abuse is on: <%= @url %>
+<%= t 'user_mailer.abuse_report.url_para' %> <%= @url %>
   
-Description of the abuse:
+<%= t 'user_mailer.abuse_report.description_para' %>
 <%= text_divider %>
 
 <%= to_plain_text(@comment) %><% end %>

--- a/config/locales/en-US.yml
+++ b/config/locales/en-US.yml
@@ -260,3 +260,8 @@
       txt: "Hi %{login}\nWe just wanted to let you know that you have %{total} new
         invitation(s),\nwhich can be used to create new accounts at the archive. You
         can invite a\nfriend at %{invitation_page}.\nCheers, \n%{archive_name}"
+    abuse_report:
+      subject: "[%{app_name}] Your Abuse Report"
+      para1: "The following abuse report has been sent to the Abuse team:"
+      url_para: "URL of the page the abuse is on:"
+      description_para: "Description of the abuse:"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -42,3 +42,8 @@ en:
           friend at %{invitation_page}.
           Cheers, 
           %{archive_name}
+    abuse_report:
+      subject: "[%{app_name}] Your Abuse Report"
+      para1: "The following abuse report has been sent to the Abuse team:"
+      url_para: "URL of the page the abuse is on:"
+      description_para: "Description of the abuse:"


### PR DESCRIPTION
The confirmation mail after you send an abuse report should look the same after this, but new strings should appear in PhraseApp.

https://otwarchive.atlassian.net/browse/AO3-4417
https://otwarchive.atlassian.net/browse/AO3-4439