### PR TITLE
AO3-4350 Homepage off-center

### DIFF
--- a/public/stylesheets/site/2.0/16-zone-system.css
+++ b/public/stylesheets/site/2.0/16-zone-system.css
@@ -161,6 +161,10 @@ SUBSECTIONS:
   font: normal 0.857em 'Monaco', 'Consolas', Courier, monospace;
 }
 
+.splash .news blockquote {
+  float: left;
+}
+
 .splash .jump {
   text-align: right; 
 }
@@ -184,7 +188,8 @@ SUBSECTIONS:
 /* module: twitter */
 
 .tweets iframe {
-  width: 100% !important;
+  display: block !important;
+  margin: 0 auto;
 }
 
 /* mod: logged-in */
@@ -201,7 +206,7 @@ SUBSECTIONS:
 
 /* misc */
 
-.splash .module .module, .splash .dynamic {
+.splash .module .module, .splash .dynamic, .splash .news blockquote {
   margin: 0;
   width: 100%;
 }

--- a/public/stylesheets/site/2.0/26-media-narrow.css
+++ b/public/stylesheets/site/2.0/26-media-narrow.css
@@ -140,7 +140,7 @@ body .narrow-shown {
   padding: 0;
 }
 
-.splash div.module, .logged-in .splash > .module {
+.splash div.module, .logged-in .splash .module {
   margin: auto 1%;
   width: 98%;
 }

--- a/public/stylesheets/site/2.0/26-media-narrow.css
+++ b/public/stylesheets/site/2.0/26-media-narrow.css
@@ -140,7 +140,8 @@ body .narrow-shown {
   padding: 0;
 }
 
-.splash div.module, .logged-in .splash .module {
+.splash div.module, .logged-in .splash > .module {
+  margin: auto 1%;
   width: 98%;
 }
 

--- a/public/stylesheets/site/2.0/26-media-narrow.css
+++ b/public/stylesheets/site/2.0/26-media-narrow.css
@@ -140,8 +140,9 @@ body .narrow-shown {
   padding: 0;
 }
 
-.splash div.module, .logged-in .splash .module {
-  margin: auto 1%;
+.splash div.module, .logged-in .splash > .module {
+  margin-left: 1%;
+  margin-right: 1%;
   width: 98%;
 }
 


### PR DESCRIPTION
https://otwarchive.atlassian.net/browse/AO3-4350

Please forgive the low-priority pull request; this issue was making it very hard to do the BOT-SPR for #2304 (which this is branched from)

* Makes it so all the modules on the logged-out homepage are centered on narrow screens
* Centers the tweets within the tweet area logged in and out on all the screen sizes, praise the lord
* Centers the title/date/comments on the logged-in homepage news items on narrow screens