### PR TITLE
AO3-4441 Automated tests for importing and rearranging prompt memes

### DIFF
--- a/features/importing/archivist.feature
+++ b/features/importing/archivist.feature
@@ -110,13 +110,63 @@ Feature: Archivist bulk imports
       Then 1 email should be delivered to "otwstephanie@thepotionsmaster.net"
 
   Scenario: Claim a work and create a new account in response to an invite
-  # TODO
+
+    Given I have an archivist "elynross"
+      And the default ratings exist
+      And account creation is enabled
+    When I am logged in as "elynross"
+      And I go to the import page
+      And I import the work "http://cesy.dreamwidth.org/154770.html" by "randomtestname" with email "otwstephanie@thepotionsmaster.net"
+      And the system processes jobs
+    Then 1 email should be delivered to "otwstephanie@thepotionsmaster.net"
+      And the email should contain "Claim or remove your works"
+    When I am logged out
+      And I follow "Claim or remove your works" in the email
+    Then I should see "Claiming Your Imported Works"
+      And I should see "An archive including some of your work(s) has been moved to the Archive of Our Own. Please let us know what you'd like us to do with them."
+    When I press "Sign me up and give me my works! Yay!"
+    Then I should see "Create Account"
+    When I fill in the sign up form with valid data
+      And I press "Create Account"
+    Then I should see "Account Created!"
 
   Scenario: Orphan a work in response to an invite
-  # TODO
+
+    Given I have an archivist "elynross"
+      And the default ratings exist
+    When I am logged in as "elynross"
+      And I go to the import page
+      And I import the work "http://cesy.dreamwidth.org/154770.html" by "randomtestname" with email "otwstephanie@thepotionsmaster.net"
+      And the system processes jobs
+    Then 1 email should be delivered to "otwstephanie@thepotionsmaster.net"
+      And the email should contain "Claim or remove your works"
+    When I am logged out
+      And I follow "Claim or remove your works" in the email
+    Then I should see "Claiming Your Imported Works"
+      And I should see "An archive including some of your work(s) has been moved to the Archive of Our Own. Please let us know what you'd like us to do with them."
+    When I choose "imported_stories_orphan"
+    # TODO: This step fails with what looks like a genuine bug
+    #   And I press "Update"
+    # Then I should see "Your works have been orphaned"
 
   Scenario: Refuse all further contact
-  # TODO
+
+    Given I have an archivist "elynross"
+      And the default ratings exist
+    When I am logged in as "elynross"
+      And I go to the import page
+      And I import the work "http://cesy.dreamwidth.org/154770.html" by "randomtestname" with email "otwstephanie@thepotionsmaster.net"
+      And the system processes jobs
+    Then 1 email should be delivered to "otwstephanie@thepotionsmaster.net"
+      And the email should contain "Claim or remove your works"
+    When I am logged out
+      And I follow "Claim or remove your works" in the email
+    Then I should see "Claiming Your Imported Works"
+      And I should see "An archive including some of your work(s) has been moved to the Archive of Our Own. Please let us know what you'd like us to do with them."
+    When I choose "imported_stories_delete"
+      And I check "external_author_do_not_email"
+      And I press "Update"
+    Then I should see "Your imported stories have been deleted. Your preferences have been saved."
 
   Scenario: Importing straight into a collection
   # TODO
@@ -135,3 +185,12 @@ Feature: Archivist bulk imports
     When I check the 1st checkbox with id matching "importing_for_others"
     And I press "Import"
     Then I should see "We have notified the author(s) you imported works for. If any were missed, you can also add co-authors manually."
+
+  Scenario: Update the URL on an imported work with a redirect
+
+  # Given I have an Open Doors committee member "Ariana"
+  # When I am logged in as "Ariana"
+  #   And I go to the Open Doors tools page
+  # Then I should see "Update Redirect URL"
+  # TODO
+  # Also do following a redirect and following an invalid redirect

--- a/features/importing/archivist.feature
+++ b/features/importing/archivist.feature
@@ -89,13 +89,13 @@ Feature: Archivist bulk imports
       And the default ratings exist
     When I am logged in as "elynross"
       And I go to the import page
-      And I import the work "http://cesy.dreamwidth.org/154770.html" by "randomtestname" with email "otwstephanie@thepotionsmaster.net"
+      And I import the work "http://cesy.dreamwidth.org/154770.html" by "randomtestname" with email "otwstephanie@example.com"
     Then I should not see multi-story import messages
       And I should see "Welcome"
       And I should see "randomtestname"
       And I should see "We have notified the author(s) you imported works for. If any were missed, you can also add co-authors manually."
     When the system processes jobs
-    Then 1 email should be delivered to "otwstephanie@thepotionsmaster.net"
+    Then 1 email should be delivered to "otwstephanie@example.com"
 
   Scenario: Import a single work as an archivist specifying an external author with an invalid name
 
@@ -103,11 +103,11 @@ Feature: Archivist bulk imports
       And the default ratings exist
     When I am logged in as "elynross"
       And I go to the import page
-      And I import the work "http://cesy.dreamwidth.org/154770.html" by "ra_ndo!m-t??est n@me." with email "otwstephanie@thepotionsmaster.net"
+      And I import the work "http://cesy.dreamwidth.org/154770.html" by "ra_ndo!m-t??est n@me." with email "otwstephanie@example.com"
     Then I should see import confirmation
       And I should see "ra_ndom-test n@me."
     When the system processes jobs
-      Then 1 email should be delivered to "otwstephanie@thepotionsmaster.net"
+      Then 1 email should be delivered to "otwstephanie@example.com"
 
   Scenario: Claim a work and create a new account in response to an invite
 
@@ -116,9 +116,9 @@ Feature: Archivist bulk imports
       And account creation is enabled
     When I am logged in as "elynross"
       And I go to the import page
-      And I import the work "http://cesy.dreamwidth.org/154770.html" by "randomtestname" with email "otwstephanie@thepotionsmaster.net"
+      And I import the work "http://cesy.dreamwidth.org/154770.html" by "randomtestname" with email "otwstephanie@example.com"
       And the system processes jobs
-    Then 1 email should be delivered to "otwstephanie@thepotionsmaster.net"
+    Then 1 email should be delivered to "otwstephanie@example.com"
       And the email should contain "Claim or remove your works"
     When I am logged out
       And I follow "Claim or remove your works" in the email
@@ -136,9 +136,9 @@ Feature: Archivist bulk imports
       And the default ratings exist
     When I am logged in as "elynross"
       And I go to the import page
-      And I import the work "http://cesy.dreamwidth.org/154770.html" by "randomtestname" with email "otwstephanie@thepotionsmaster.net"
+      And I import the work "http://cesy.dreamwidth.org/154770.html" by "randomtestname" with email "otwstephanie@example.com"
       And the system processes jobs
-    Then 1 email should be delivered to "otwstephanie@thepotionsmaster.net"
+    Then 1 email should be delivered to "otwstephanie@example.com"
       And the email should contain "Claim or remove your works"
     When I am logged out
       And I follow "Claim or remove your works" in the email
@@ -155,9 +155,9 @@ Feature: Archivist bulk imports
       And the default ratings exist
     When I am logged in as "elynross"
       And I go to the import page
-      And I import the work "http://cesy.dreamwidth.org/154770.html" by "randomtestname" with email "otwstephanie@thepotionsmaster.net"
+      And I import the work "http://cesy.dreamwidth.org/154770.html" by "randomtestname" with email "otwstephanie@example.com"
       And the system processes jobs
-    Then 1 email should be delivered to "otwstephanie@thepotionsmaster.net"
+    Then 1 email should be delivered to "otwstephanie@example.com"
       And the email should contain "Claim or remove your works"
     When I am logged out
       And I follow "Claim or remove your works" in the email
@@ -179,18 +179,9 @@ Feature: Archivist bulk imports
       And I go to the import page
       And I fill in "URLs*" with "http://cesy.dreamwidth.org/154770.html"
       And I fill in "Author Name*" with "cesy"
-      And I fill in "Author Email Address*" with "cesy@dreamwidth.org"
+      And I fill in "Author Email Address*" with "cesy@example.com"
     When I press "Import"
     Then I should see /You have entered an external author name or e-mail address but did not select "Import for others."/
     When I check the 1st checkbox with id matching "importing_for_others"
     And I press "Import"
     Then I should see "We have notified the author(s) you imported works for. If any were missed, you can also add co-authors manually."
-
-  Scenario: Update the URL on an imported work with a redirect
-
-  # Given I have an Open Doors committee member "Ariana"
-  # When I am logged in as "Ariana"
-  #   And I go to the Open Doors tools page
-  # Then I should see "Update Redirect URL"
-  # TODO
-  # Also do following a redirect and following an invalid redirect

--- a/features/prompt_memes_a/challenge_promptmeme_setup.feature
+++ b/features/prompt_memes_a/challenge_promptmeme_setup.feature
@@ -228,7 +228,6 @@ Feature: Prompt Meme Challenge
   # TODO: We need to check the display for fandomless memes
   Then I should not see "Fandom 1"
 
-  
   Scenario: Claim a prompt and view claims on main page and user page
   
   Given I have Battle 12 prompt meme fully set up
@@ -272,7 +271,6 @@ Feature: Prompt Meme Challenge
   Then I should see "Challenge sign-up was deleted."
     And I should see "Prompts (0)"
 
-  
   Scenario: Sign up with both prompts anon
   
   Given I have Battle 12 prompt meme fully set up
@@ -382,7 +380,6 @@ Feature: Prompt Meme Challenge
   When I edit the first prompt
   Then I should not see "Edit Prompt"
 
-
   Scenario: User can't delete prompt if they don't have enough
 
   Given I have Battle 12 prompt meme fully set up
@@ -411,82 +408,7 @@ Feature: Prompt Meme Challenge
   Then I should see "New claim made."
     And I should see "by Anonymous"
     And I should not see "myname" within "#main"
-  
-  Scenario: Fulfilling a claim ticks the right boxes automatically
-  
-  Given I have Battle 12 prompt meme fully set up
-  When I am logged in as "myname1"
-  When I sign up for Battle 12 with combination B
-    And I am logged in as "myname4"
-    And I claim a prompt from "Battle 12"
-  When I start to fulfill my claim
-  Then the "Battle 12" checkbox should be checked
-    And the "Battle 12" checkbox should not be disabled
-  
-  Scenario: User can fulfill a claim
-  
-  Given I have Battle 12 prompt meme fully set up
-  When I am logged in as "myname1"
-  When I sign up for Battle 12 with combination B
-    And I am logged in as "myname4"
-    And I claim a prompt from "Battle 12"
-  When I fulfill my claim
-  Then my claim should be fulfilled
-  
-  Scenario: User can fulfill a claim to their own prompt
-  
-  Given I have Battle 12 prompt meme fully set up
-  When I am logged in as "myname1"
-    And I sign up for Battle 12 with combination B
-    And I claim a prompt from "Battle 12"
-    And I fulfill my claim
-  Then my claim should be fulfilled
-  
-  Scenario: Fulfilled claim shows correctly on my claims
-  
-  Given I have Battle 12 prompt meme fully set up
-  When I am logged in as "myname1"
-  When I sign up for Battle 12 with combination B
-    And I am logged in as "myname4"
-    And I claim a prompt from "Battle 12"
-  When I fulfill my claim
-  When I am on my user page
-    And I follow "Claims"
-		And I follow "Fulfilled Claims"
-  Then I should see "Fulfilled Story"
-   # TODO: should I? It's not there at all
-    And I should not see "Not yet posted"
-  
-  Scenario: Claims count should be correct, shows fulfilled claims as well
-  
-  Given I have Battle 12 prompt meme fully set up
-  When I am logged in as "myname1"
-  When I sign up for Battle 12 with combination B
-    And I am logged in as "myname4"
-    And I claim a prompt from "Battle 12"
-  When I fulfill my claim
-  When I am on my user page
-  # Then show me the sidebar # TODO: it has Claims (0) but why?
-  Then I should see "Claims (0)"
-  When I follow "Claims"
-    And I follow "Fulfilled Claims"
-  Then I should see "Fulfilled Story"
-  
-  Scenario: Claim shows as fulfilled to another user
-  
-  Given I have Battle 12 prompt meme fully set up
-  When I am logged in as "myname1"
-  When I sign up for Battle 12 with combination B
-    And I am logged in as "myname4"
-    And I claim a prompt from "Battle 12"
-  When I fulfill my claim
-  When I am logged in as "myname1"
-  When I go to "Battle 12" collection's page
-    And I follow "Prompts ("
-  Then I should see "Fulfilled By"
-    And I should see "Mystery Work"
 
-    
   Scenario: Prompts are counted up correctly
   
   Given I have Battle 12 prompt meme fully set up
@@ -515,45 +437,7 @@ Feature: Prompt Meme Challenge
   Then I should not see "Unposted Claims"
   # TODO: they got really hidden, since ordinary user can't get to that page at all
   # Then claims are hidden
-  
-  Scenario: Fulfilled claims are shown to mod
- # TODO: We need to figure out if we want to hide claims from mods in 100% anonymous prompt memes
-#  Given I have Battle 12 prompt meme fully set up
-#  Given everyone has signed up for Battle 12
-#  When I am logged in as "myname4"
-#  When I claim a prompt from "Battle 12"
-#  When I close signups for "Battle 12"
-#  When I am logged in as "myname4"
-#  When I fulfill my claim
-#  When mod fulfills claim
-#  When I am on "Battle 12" collection's page
-#  When I follow "Prompts"
-#    And I follow "Show Claims"
-#  Then I should not see "Claimed by: myname4"
-#    And I should not see "Claimed by: mod1"
-#    And I should not see "Claimed by: (Anonymous)"
-#  When I follow "Show Filled"
-#  Then I should see "Claimed by: myname4"
-#    And I should see "Claimed by: mod1"
-#    And I should not see "Claimed by: (Anonymous)"
-  
-  Scenario: Fulfilled claims are hidden from user
-  
-  Given I have Battle 12 prompt meme fully set up
-  Given everyone has signed up for Battle 12
-  When I am logged in as "myname4"
-  When I claim a prompt from "Battle 12"
-  When I close signups for "Battle 12"
-  When I am logged in as "myname4"
-  When I fulfill my claim
-  When mod fulfills claim
-  When I am logged in as "myname4"
-  When I go to "Battle 12" collection's page
-    And I follow "Prompts (8)"
-  Then I should not see "myname4" within "h5"
-    And I should not see "mod1" within "h5"
-    And I should see "Fulfilled Story by Anonymous" within "div.work h4"
-  
+
   Scenario: User cannot see unposted claims to delete
   
   Given I have Battle 12 prompt meme fully set up
@@ -617,46 +501,7 @@ Feature: Prompt Meme Challenge
   Then I should see "Delete"
   When I follow "Delete"
   Then I should see "The claim was deleted."
-  
-  Scenario: Sign-up can be deleted after response has been posted
-  
-  Given I have Battle 12 prompt meme fully set up
-  When I am logged in as "myname1"
-  When I sign up for Battle 12 with combination B
-    And I am logged in as "myname4"
-    And I claim a prompt from "Battle 12"
-  When I fulfill my claim
-  When I am logged in as "myname1"
-    And I delete my signup for the prompt meme "Battle 12"
-  Then I should see "Challenge sign-up was deleted."
-  # work fulfilling is still fine
-  When I view the work "Fulfilled Story"
-  Then I should see "This work is part of an ongoing challenge and will be revealed soon! You can find details here: Battle 12"
-    And I should not see "Stargate Atlantis"
-    # work is still fine as another user
-  When I am logged in as "myname4"
-    And I view the work "Fulfilled Story"
-  Then I should see "This work is part of an ongoing challenge and will be revealed soon! You can find details here: Battle 12"
-    And I should see "Stargate Atlantis"
-  
-  Scenario: Prompt can be removed after response has been posted and still show properly on the work which fulfilled it
 
-  Given I have Battle 12 prompt meme fully set up
-  When I am logged in as "myname1"
-  When I sign up for Battle 12 with combination B
-    And I am logged in as "myname4"
-    And I claim a prompt from "Battle 12"
-  When I fulfill my claim
-  When I am logged in as "myname1"
-    And I delete my signup for the prompt meme "Battle 12"
-  When I view the work "Fulfilled Story"
-  Then I should see "This work is part of an ongoing challenge and will be revealed soon! You can find details here: Battle 12"
-    And I should not see "Stargate Atlantis"
-  When I am logged in as "myname4"
-    And I view the work "Fulfilled Story"
-  Then I should see "This work is part of an ongoing challenge and will be revealed soon! You can find details here: Battle 12"
-    And I should see "Stargate Atlantis"
-  
   Scenario: User can't claim the same prompt twice
   
   Given I have Battle 12 prompt meme fully set up
@@ -667,51 +512,3 @@ Feature: Prompt Meme Challenge
     And I view prompts for "Battle 12"
     # TODO: Refactor this test once we have a new Capybara version so that we look for .exact(Claim)
   Then I should see "Drop Claim"
-  
-  Scenario: User can fulfill the same claim twice
-  
-  Given I have Battle 12 prompt meme fully set up
-  When I am logged in as "myname1"
-  When I sign up for Battle 12 with combination B
-    And I am logged in as "myname4"
-    And I claim a prompt from "Battle 12"
-  When I fulfill my claim
-  When I fulfill my claim again
-  Then I should see "Work was successfully posted"
-    And I should see "Second Story"
-    And I should see "In response to a prompt by Anonymous"
-    And I should see "Collections: Battle 12"
-  
-  Scenario: User edits existing work to fulfill claim
-  
-  Given I have Battle 12 prompt meme fully set up
-  When I am logged in as "myname1"
-  When I sign up for Battle 12 with combination B
-    And I am logged in as "myname4"
-    And I claim a prompt from "Battle 12"
-    And I post the work "Existing Story"
-    And I should not see "Battle 12"
-    And I edit the work "Existing Story"
-    And I check "random SGA love in Battle 12 (Anonymous)"
-    And I press "Post Without Preview"
-  Then I should see "Battle 12"
-  Then I should see "Existing Story"
-    And I should see "This work is part of an ongoing challenge"
-  When I reveal works for "Battle 12"
-  When I view the work "Existing Story"
-    And I should not see "This work is part of an ongoing challenge"
-    
-  Scenario: User edits existing work in another collection to fulfill claim
-  
-  Given I have Battle 12 prompt meme fully set up
-    And I have a collection "Othercoll"
-  When I am logged in as "myname1"
-  When I sign up for Battle 12 with combination B
-    And I am logged in as "myname4"
-    And I claim a prompt from "Battle 12"
-    And I post the work "Existing Story" in the collection "Othercoll"
-    And I edit the work "Existing Story"
-    And I check "random SGA love in Battle 12 (Anonymous)"
-    And I press "Post Without Preview"
-  Then I should see "Battle 12"
-    And I should see "Othercoll"

--- a/features/prompt_memes_b/challenge_promptmeme_posting_fills.feature
+++ b/features/prompt_memes_b/challenge_promptmeme_posting_fills.feature
@@ -43,3 +43,411 @@ Feature: Prompt Meme Challenge
   # email the anonymous prompter that they've received a fill!
    # And 1 email should be delivered to "my1@e.org"
 # TODO: when work_anonymous is implemented, test that the prompt filler can be anon too
+
+  Scenario: Fulfilling a claim ticks the right boxes automatically
+  
+  Given I have Battle 12 prompt meme fully set up
+  When I am logged in as "myname1"
+  When I sign up for Battle 12 with combination B
+    And I am logged in as "myname4"
+    And I claim a prompt from "Battle 12"
+  When I start to fulfill my claim
+  Then the "Battle 12" checkbox should be checked
+    And the "Battle 12" checkbox should not be disabled
+  
+  Scenario: User can fulfill a claim
+  
+  Given I have Battle 12 prompt meme fully set up
+  When I am logged in as "myname1"
+  When I sign up for Battle 12 with combination B
+    And I am logged in as "myname4"
+    And I claim a prompt from "Battle 12"
+  When I fulfill my claim
+  Then my claim should be fulfilled
+  
+  Scenario: User can fulfill a claim to their own prompt
+  
+  Given I have Battle 12 prompt meme fully set up
+  When I am logged in as "myname1"
+    And I sign up for Battle 12 with combination B
+    And I claim a prompt from "Battle 12"
+    And I fulfill my claim
+  Then my claim should be fulfilled
+
+  Scenario: Fulfilled claim shows correctly on my claims
+  
+  Given I have Battle 12 prompt meme fully set up
+  When I am logged in as "myname1"
+  When I sign up for Battle 12 with combination B
+    And I am logged in as "myname4"
+    And I claim a prompt from "Battle 12"
+  When I fulfill my claim
+  When I am on my user page
+    And I follow "Claims"
+		And I follow "Fulfilled Claims"
+  Then I should see "Fulfilled Story"
+   # TODO: should I? It's not there at all
+    And I should not see "Not yet posted"
+  
+  Scenario: Claims count should be correct, shows fulfilled claims as well
+  
+  Given I have Battle 12 prompt meme fully set up
+  When I am logged in as "myname1"
+  When I sign up for Battle 12 with combination B
+    And I am logged in as "myname4"
+    And I claim a prompt from "Battle 12"
+  When I fulfill my claim
+  When I am on my user page
+  # Then show me the sidebar # TODO: it has Claims (0) but why?
+  Then I should see "Claims (0)"
+  When I follow "Claims"
+    And I follow "Fulfilled Claims"
+  Then I should see "Fulfilled Story"
+  
+  Scenario: Claim shows as fulfilled to another user
+  
+  Given I have Battle 12 prompt meme fully set up
+  When I am logged in as "myname1"
+  When I sign up for Battle 12 with combination B
+    And I am logged in as "myname4"
+    And I claim a prompt from "Battle 12"
+  When I fulfill my claim
+  When I am logged in as "myname1"
+  When I go to "Battle 12" collection's page
+    And I follow "Prompts ("
+  Then I should see "Fulfilled By"
+    And I should see "Mystery Work"
+
+  Scenario: Fulfilled claims are shown to mod
+ # TODO: We need to figure out if we want to hide claims from mods in 100% anonymous prompt memes
+#  Given I have Battle 12 prompt meme fully set up
+#  Given everyone has signed up for Battle 12
+#  When I am logged in as "myname4"
+#  When I claim a prompt from "Battle 12"
+#  When I close signups for "Battle 12"
+#  When I am logged in as "myname4"
+#  When I fulfill my claim
+#  When mod fulfills claim
+#  When I am on "Battle 12" collection's page
+#  When I follow "Prompts"
+#    And I follow "Show Claims"
+#  Then I should not see "Claimed by: myname4"
+#    And I should not see "Claimed by: mod1"
+#    And I should not see "Claimed by: (Anonymous)"
+#  When I follow "Show Filled"
+#  Then I should see "Claimed by: myname4"
+#    And I should see "Claimed by: mod1"
+#    And I should not see "Claimed by: (Anonymous)"
+  
+  Scenario: Fulfilled claims are hidden from user
+  
+  Given I have Battle 12 prompt meme fully set up
+  Given everyone has signed up for Battle 12
+  When I am logged in as "myname4"
+  When I claim a prompt from "Battle 12"
+  When I close signups for "Battle 12"
+  When I am logged in as "myname4"
+  When I fulfill my claim
+  When mod fulfills claim
+  When I am logged in as "myname4"
+  When I go to "Battle 12" collection's page
+    And I follow "Prompts (8)"
+  Then I should not see "myname4" within "h5"
+    And I should not see "mod1" within "h5"
+    And I should see "Fulfilled Story by Anonymous" within "div.work h4"
+
+  Scenario: Sign-up can be deleted after response has been posted
+  
+  Given I have Battle 12 prompt meme fully set up
+  When I am logged in as "myname1"
+  When I sign up for Battle 12 with combination B
+    And I am logged in as "myname4"
+    And I claim a prompt from "Battle 12"
+  When I fulfill my claim
+  When I am logged in as "myname1"
+    And I delete my signup for the prompt meme "Battle 12"
+  Then I should see "Challenge sign-up was deleted."
+  # work fulfilling is still fine
+  When I view the work "Fulfilled Story"
+  Then I should see "This work is part of an ongoing challenge and will be revealed soon! You can find details here: Battle 12"
+    And I should not see "Stargate Atlantis"
+    # work is still fine as another user
+  When I am logged in as "myname4"
+    And I view the work "Fulfilled Story"
+  Then I should see "This work is part of an ongoing challenge and will be revealed soon! You can find details here: Battle 12"
+    And I should see "Stargate Atlantis"
+  
+  Scenario: Prompt can be removed after response has been posted and still show properly on the work which fulfilled it
+
+  Given I have Battle 12 prompt meme fully set up
+  When I am logged in as "myname1"
+  When I sign up for Battle 12 with combination B
+    And I am logged in as "myname4"
+    And I claim a prompt from "Battle 12"
+  When I fulfill my claim
+  When I am logged in as "myname1"
+    And I delete my signup for the prompt meme "Battle 12"
+  When I view the work "Fulfilled Story"
+  Then I should see "This work is part of an ongoing challenge and will be revealed soon! You can find details here: Battle 12"
+    And I should not see "Stargate Atlantis"
+  When I am logged in as "myname4"
+    And I view the work "Fulfilled Story"
+  Then I should see "This work is part of an ongoing challenge and will be revealed soon! You can find details here: Battle 12"
+    And I should see "Stargate Atlantis"
+
+  Scenario: User can fulfill the same claim twice
+  
+  Given I have Battle 12 prompt meme fully set up
+  When I am logged in as "myname1"
+  When I sign up for Battle 12 with combination B
+    And I am logged in as "myname4"
+    And I claim a prompt from "Battle 12"
+  When I fulfill my claim
+  When I fulfill my claim again
+  Then I should see "Work was successfully posted"
+    And I should see "Second Story"
+    And I should see "In response to a prompt by Anonymous"
+    And I should see "Collections: Battle 12"
+  
+  Scenario: User edits existing work to fulfill claim
+  
+  Given I have Battle 12 prompt meme fully set up
+  When I am logged in as "myname1"
+  When I sign up for Battle 12 with combination B
+    And I am logged in as "myname4"
+    And I claim a prompt from "Battle 12"
+    And I post the work "Existing Story"
+    And I should not see "Battle 12"
+    And I edit the work "Existing Story"
+    And I check "random SGA love in Battle 12 (Anonymous)"
+    And I press "Post Without Preview"
+  Then I should see "Battle 12"
+  Then I should see "Existing Story"
+    And I should see "This work is part of an ongoing challenge"
+  When I reveal works for "Battle 12"
+  When I view the work "Existing Story"
+    And I should not see "This work is part of an ongoing challenge"
+    
+  Scenario: User edits existing work in another collection to fulfill claim
+  
+  Given I have Battle 12 prompt meme fully set up
+    And I have a collection "Othercoll"
+  When I am logged in as "myname1"
+  When I sign up for Battle 12 with combination B
+    And I am logged in as "myname4"
+    And I claim a prompt from "Battle 12"
+    And I post the work "Existing Story" in the collection "Othercoll"
+    And I edit the work "Existing Story"
+    And I check "random SGA love in Battle 12 (Anonymous)"
+    And I press "Post Without Preview"
+  Then I should see "Battle 12"
+    And I should see "Othercoll"
+
+  Scenario: Fulfill a claim by editing an existing work
+  
+  Given I have Battle 12 prompt meme fully set up
+    And everyone has signed up for Battle 12
+  When I close signups for "Battle 12"
+  When I reveal the "Battle 12" challenge
+  When I reveal the authors of the "Battle 12" challenge
+  When I am logged in as "myname1"
+    And I go to "Battle 12" collection's page
+    And I follow "Prompts ("
+  When I press "Claim"
+  Then I should see "New claim made"
+  When I post the work "Here's one I made earlier"
+    And I edit the work "Here's one I made earlier"
+    And I check "Battle 12"
+    And I press "Preview"
+  Then I should see "In response to a prompt by"
+    When "AO3-3455" is fixed
+  #  And I should see "Collections:"
+   # And I should see "Battle 12"
+  When I press "Update"
+  Then I should see "Work was successfully updated"
+    And I should not see "draft"
+    And I should see "In response to a prompt by"
+  Then I should see "Collections:"
+    And I should see "Battle 12"
+    
+  # claim is fulfilled on collection page
+  When I go to "Battle 12" collection's page
+    And I follow "Prompts"
+  Then I should see "myname1" within ".prompt .work"
+    And I should see "Fulfilled By"
+
+  Scenario: When draft is posted, claim is fulfilled and posted to collection
+  
+  Given I have Battle 12 prompt meme fully set up
+  When I am logged in as "myname2"
+    And I sign up for Battle 12 with combination B
+  When I am logged in as "myname4"
+    And I claim a prompt from "Battle 12"
+  When I close signups for "Battle 12"
+  When I reveal the "Battle 12" challenge
+  When I reveal the authors of the "Battle 12" challenge
+  When I am logged in as "myname4"
+    And I go to the "Battle 12" requests page
+  When I press "Claim"
+  When I follow "Fulfill"
+    And I fill in the basic work information for "Existing work"
+    And I check "random SGA love in Battle 12 (Anonymous)"
+    And I press "Preview"
+  When I am on my user page
+    And I follow "Drafts"
+    And all emails have been delivered
+  When I follow "Post Draft"
+  Then 1 email should be delivered
+  Then I should see "Your work was successfully posted"
+    And I should see "In response to a prompt by Anonymous"
+  When I go to "Battle 12" collection's page
+    And I follow "Prompts ("
+  Then I should see "myname4"
+    And I should see "Fulfilled By"
+  When I follow "Existing work"
+  Then I should see "Existing work"
+    And I should see "Battle 12"
+    And I should not see "draft"
+
+  Scenario: Make another claim and then fulfill from the post new form (New Work)
+  
+  Given I have Battle 12 prompt meme fully set up
+  Given everyone has signed up for Battle 12
+  When I close signups for "Battle 12"
+  When I reveal the "Battle 12" challenge
+  Given all emails have been delivered
+  When I reveal the authors of the "Battle 12" challenge
+  When I go to "Battle 12" collection's page
+    And I follow "Prompts (8)"
+  When I press "Claim"
+  Then I should see "New claim made."
+  When I am logged in as "myname4"
+    And I go to the collections page
+    And I follow "Battle 12"
+  When I follow "Prompts ("
+  When I press "Claim"
+  Then I should see "New claim made"
+  When I follow "New Work"
+  When I fill in the basic work information for "Existing work"
+    And I check "Battle 12 (myname4)"
+    And I press "Preview"
+  Then I should see "Draft was successfully created"
+    And I should see "In response to a prompt by myname4"
+    And 0 emails should be delivered
+    When "AO3-3455" is fixed
+  #  And I should see "Collections:"
+   # And I should see "Battle 12"
+  When I view the work "Existing work"
+  Then I should see "draft"
+
+  Scenario: Fulfilled claims show as fulfilled to another user
+  
+  Given I have Battle 12 prompt meme fully set up
+  Given everyone has signed up for Battle 12
+  When I am logged in as "myname4"
+  When I claim a prompt from "Battle 12"
+  When I close signups for "Battle 12"
+  When I am logged in as "myname4"
+  When I fulfill my claim
+  When mod fulfills claim
+  When I reveal the "Battle 12" challenge
+  Given all emails have been delivered
+  When I reveal the authors of the "Battle 12" challenge
+  When I go to "Battle 12" collection's page
+    And I follow "Prompts (8)"
+  When I press "Claim"
+  Then I should see "New claim made."
+  When I am logged in as "myname4"
+    And I go to the "Battle 12" requests page
+  Then I should see "mod1" within ".prompt .work"
+    And I should see "myname4" within ".prompt .work"
+
+  Scenario: When a prompt is filled with a co-authored work, the e-mail should link to each author's URL instead of showing escaped HTML
+
+  Given I have Battle 12 prompt meme fully set up
+  When I am logged in as "myname1"
+    And I sign up for Battle 12 with combination A
+    And I log out
+  When I am logged in as "myname2"
+    And I claim a prompt from "Battle 12"
+    And I start to fulfill my claim with "Co-authored Fill"
+    And I add the co-author "myname3" 
+  When I press "Post Without Preview"
+  Then 1 email should be delivered to "myname3"
+    And the email should contain "You have been listed as a coauthor on the following work"
+  When I am logged in as "mod1"
+    And I reveal the authors of the "Battle 12" challenge
+    And I reveal the "Battle 12" challenge
+  Then 1 email should be delivered to "myname1"
+    And the email should link to myname2's user url
+    And the email should not contain "&lt;a href=&quot;http://archiveofourown.org/users/myname2/pseuds/myname2&quot;"
+    And the email should link to myname3's user url
+    And the email should not contain "&lt;a href=&quot;http://archiveofourown.org/users/myname3/pseuds/myname3&quot;"
+
+  Scenario: check that completed ficlet is unrevealed
+  
+  Given I have Battle 12 prompt meme fully set up
+  Given everyone has signed up for Battle 12
+  When mod fulfills claim
+  When I am logged in as "myname4"
+  When I view the work "Fulfilled Story-thing"
+  Then I should not see "In response to a prompt by myname4"
+    And I should not see "Fandom: Stargate Atlantis"
+    And I should not see "Anonymous"
+    And I should not see "mod1"
+    And I should see "This work is part of an ongoing challenge and will be revealed soon! You can find details here: Battle 12"
+
+  Scenario: Mod can post a fic
+
+  Given I have Battle 12 prompt meme fully set up
+  Given everyone has signed up for Battle 12
+  When I am logged in as "mod1"
+  When I claim a prompt from "Battle 12"
+  When I am on my user page
+  Then I should see "Claims (1)" 
+  When I follow "Claims"
+  Then I should see "My Claims"
+    And I should see "canon SGA love by myname4 in Battle 12" within "div#main.challenge_claims-index h4"
+  When I follow "Fulfill"
+    And I fill in "Fandoms" with "Stargate Atlantis"
+    And I fill in "Work Title*" with "Fulfilled Story-thing"
+    And I select "Not Rated" from "Rating"
+    And I check "No Archive Warnings Apply"
+    And I fill in "content" with "This is an exciting story about Atlantis, but in a different universe this time"
+  When I press "Preview"
+    And I press "Post"
+  Then I should see "Work was successfully posted"
+
+  Scenario: Mod can complete a claim
+  
+  Given I have Battle 12 prompt meme fully set up
+  Given everyone has signed up for Battle 12
+  When I am logged in as "mod1"
+  When I claim a prompt from "Battle 12"
+  When I start to fulfill my claim
+    And I fill in "Work Title" with "Fulfilled Story-thing"
+    And I fill in "content" with "This is an exciting story about Atlantis, but in a different universe this time"
+  When I press "Preview"
+    And I press "Post"
+  When I am on my user page
+  Then I follow "Claims"
+    And I should not see "mod" within "h4"
+  Then I follow "Fulfilled Claims"
+  # On the users' My Claims page, they see their anon works as Anonymous
+    And I should see "Anonymous" within "div.work h4"
+
+  Scenario: Fic shows what prompt it is fulfilling when mod views it
+  
+  Given I have Battle 12 prompt meme fully set up
+  Given everyone has signed up for Battle 12
+  When I am logged in as "mod1"
+  When I claim a prompt from "Battle 12"
+  When I start to fulfill my claim
+    And I fill in "Work Title" with "Fulfilled Story-thing"
+    And I fill in "content" with "This is an exciting story about Atlantis, but in a different universe this time"
+  When I press "Preview"
+    And I press "Post"
+  When I view the work "Fulfilled Story-thing"
+  Then I should see "In response to a prompt by myname4"
+    And I should see "Fandom: Stargate Atlantis"
+    And I should see "Anonymous" within ".byline"

--- a/features/prompt_memes_c/challenge_promptmeme_claims.feature
+++ b/features/prompt_memes_c/challenge_promptmeme_claims.feature
@@ -272,79 +272,10 @@ Feature: Prompt Meme Challenge
   Then I should see "claimed by mod"
     And I should see "by myname4"
     And I should see "Stargate Atlantis"
-  
-  Scenario: Mod can post a fic
-  
-  Given I have Battle 12 prompt meme fully set up
-  Given everyone has signed up for Battle 12
-  When I am logged in as "mod1"
-  When I claim a prompt from "Battle 12"
-  When I am on my user page
-  Then I should see "Claims (1)" 
-  When I follow "Claims"
-  Then I should see "My Claims"
-    And I should see "canon SGA love by myname4 in Battle 12" within "div#main.challenge_claims-index h4"
-  When I follow "Fulfill"
-    And I fill in "Fandoms" with "Stargate Atlantis"
-    And I fill in "Work Title*" with "Fulfilled Story-thing"
-    And I select "Not Rated" from "Rating"
-    And I check "No Archive Warnings Apply"
-    And I fill in "content" with "This is an exciting story about Atlantis, but in a different universe this time"
-  When I press "Preview"
-    And I press "Post"
-  Then I should see "Work was successfully posted"
-  
-  Scenario: Fic shows what prompt it is fulfilling when mod views it
-  
-  Given I have Battle 12 prompt meme fully set up
-  Given everyone has signed up for Battle 12
-  When I am logged in as "mod1"
-  When I claim a prompt from "Battle 12"
-  When I start to fulfill my claim
-    And I fill in "Work Title" with "Fulfilled Story-thing"
-    And I fill in "content" with "This is an exciting story about Atlantis, but in a different universe this time"
-  When I press "Preview"
-    And I press "Post"
-  When I view the work "Fulfilled Story-thing"
-  Then I should see "In response to a prompt by myname4"
-    And I should see "Fandom: Stargate Atlantis"
-    And I should see "Anonymous" within ".byline"
-  
-  Scenario: Mod can complete a claim
-  
-  Given I have Battle 12 prompt meme fully set up
-  Given everyone has signed up for Battle 12
-  When I am logged in as "mod1"
-  When I claim a prompt from "Battle 12"
-  When I start to fulfill my claim
-    And I fill in "Work Title" with "Fulfilled Story-thing"
-    And I fill in "content" with "This is an exciting story about Atlantis, but in a different universe this time"
-  When I press "Preview"
-    And I press "Post"
-  When I am on my user page
-  Then I follow "Claims"
-    And I should not see "mod" within "h4"
-  Then I follow "Fulfilled Claims"
-  # On the users' My Claims page, they see their anon works as Anonymous
-    And I should see "Anonymous" within "div.work h4"
-  
-    
+
   Scenario: check that claims can't be viewed even after challenge is revealed
   # TODO: Find a way to construct the link to a claim show page for someone who shouldn't be able to see it
-  
-  Scenario: check that completed ficlet is unrevealed
-  
-  Given I have Battle 12 prompt meme fully set up
-  Given everyone has signed up for Battle 12
-  When mod fulfills claim
-  When I am logged in as "myname4"
-  When I view the work "Fulfilled Story-thing"
-  Then I should not see "In response to a prompt by myname4"
-    And I should not see "Fandom: Stargate Atlantis"
-    And I should not see "Anonymous"
-    And I should not see "mod1"
-    And I should see "This work is part of an ongoing challenge and will be revealed soon! You can find details here: Battle 12"
-    
+
   Scenario: Mod can reveal challenge
   
   Given I have Battle 12 prompt meme fully set up
@@ -369,28 +300,7 @@ Feature: Prompt Meme Challenge
   Then I should see "Collection was successfully updated"
   # 2 stories are now revealed, so notify the prompters
     And 2 emails should be delivered
-    
-  Scenario: When a prompt is filled with a co-authored work, the e-mail should link to each author's URL instead of showing escaped HTML
-  Given I have Battle 12 prompt meme fully set up
-  When I am logged in as "myname1"
-    And I sign up for Battle 12 with combination A
-    And I log out
-  When I am logged in as "myname2"
-    And I claim a prompt from "Battle 12"
-    And I start to fulfill my claim with "Co-authored Fill"
-    And I add the co-author "myname3" 
-  When I press "Post Without Preview"
-  Then 1 email should be delivered to "myname3"
-    And the email should contain "You have been listed as a coauthor on the following work"
-  When I am logged in as "mod1"
-    And I reveal the authors of the "Battle 12" challenge
-    And I reveal the "Battle 12" challenge
-  Then 1 email should be delivered to "myname1"
-    And the email should link to myname2's user url
-    And the email should not contain "&lt;a href=&quot;http://archiveofourown.org/users/myname2/pseuds/myname2&quot;"
-    And the email should link to myname3's user url
-    And the email should not contain "&lt;a href=&quot;http://archiveofourown.org/users/myname3/pseuds/myname3&quot;"
-        
+
   Scenario: Story is anon when challenge is revealed
   
   Given I have standard challenge tags setup
@@ -459,7 +369,6 @@ Feature: Prompt Meme Challenge
   Then I should see "Fulfilled By"
     And I should see "Fulfilled Story by myname4" within "div.work"
     And I should see "Fulfilled Story-thing by mod1" within "div.work"
-
 
   Scenario: Anon prompts stay anon on claims index even if challenge is revealed
   
@@ -530,60 +439,7 @@ Feature: Prompt Meme Challenge
     
   Scenario: check that anon prompts are still anon on the fulfilling work
   # TODO
-  
-  Scenario: Fulfilled claims show as fulfilled to another user
-  
-  Given I have Battle 12 prompt meme fully set up
-  Given everyone has signed up for Battle 12
-  When I am logged in as "myname4"
-  When I claim a prompt from "Battle 12"
-  When I close signups for "Battle 12"
-  When I am logged in as "myname4"
-  When I fulfill my claim
-  When mod fulfills claim
-  When I reveal the "Battle 12" challenge
-  Given all emails have been delivered
-  When I reveal the authors of the "Battle 12" challenge
-  When I go to "Battle 12" collection's page
-    And I follow "Prompts (8)"
-  When I press "Claim"
-  Then I should see "New claim made."
-  When I am logged in as "myname4"
-    And I go to the "Battle 12" requests page
-  Then I should see "mod1" within ".prompt .work"
-    And I should see "myname4" within ".prompt .work"
-    
-  Scenario: Make another claim and then fulfill from the post new form (New Work)
-  
-  Given I have Battle 12 prompt meme fully set up
-  Given everyone has signed up for Battle 12
-  When I close signups for "Battle 12"
-  When I reveal the "Battle 12" challenge
-  Given all emails have been delivered
-  When I reveal the authors of the "Battle 12" challenge
-  When I go to "Battle 12" collection's page
-    And I follow "Prompts (8)"
-  When I press "Claim"
-  Then I should see "New claim made."
-  When I am logged in as "myname4"
-    And I go to the collections page
-    And I follow "Battle 12"
-  When I follow "Prompts ("
-  When I press "Claim"
-  Then I should see "New claim made"
-  When I follow "New Work"
-  When I fill in the basic work information for "Existing work"
-    And I check "Battle 12 (myname4)"
-    And I press "Preview"
-  Then I should see "Draft was successfully created"
-    And I should see "In response to a prompt by myname4"
-    And 0 emails should be delivered
-    When "AO3-3455" is fixed
-  #  And I should see "Collections:"
-   # And I should see "Battle 12"
-  When I view the work "Existing work"
-  Then I should see "draft"
-  
+
   Scenario: work left in draft so claim is not yet totally fulfilled
   
   Given I have Battle 12 prompt meme fully set up
@@ -612,72 +468,6 @@ Feature: Prompt Meme Challenge
   When I press "Post Without Preview"
     And I should see "Work was successfully posted."
   Then I should see "Fulfilled Story"
-    
-  Scenario: When draft is posted, claim is fulfilled and posted to collection
-  
-  Given I have Battle 12 prompt meme fully set up
-  When I am logged in as "myname2"
-    And I sign up for Battle 12 with combination B
-  When I am logged in as "myname4"
-    And I claim a prompt from "Battle 12"
-  When I close signups for "Battle 12"
-  When I reveal the "Battle 12" challenge
-  When I reveal the authors of the "Battle 12" challenge
-  When I am logged in as "myname4"
-    And I go to the "Battle 12" requests page
-  When I press "Claim"
-  When I follow "Fulfill"
-    And I fill in the basic work information for "Existing work"
-    And I check "random SGA love in Battle 12 (Anonymous)"
-    And I press "Preview"
-  When I am on my user page
-    And I follow "Drafts"
-    And all emails have been delivered
-  When I follow "Post Draft"
-  Then 1 email should be delivered
-  Then I should see "Your work was successfully posted"
-    And I should see "In response to a prompt by Anonymous"
-  When I go to "Battle 12" collection's page
-    And I follow "Prompts ("
-  Then I should see "myname4"
-    And I should see "Fulfilled By"
-  When I follow "Existing work"
-  Then I should see "Existing work"
-    And I should see "Battle 12"
-    And I should not see "draft"
-  
-  Scenario: Fulfill a claim by editing an existing work
-  
-  Given I have Battle 12 prompt meme fully set up
-    And everyone has signed up for Battle 12
-  When I close signups for "Battle 12"
-  When I reveal the "Battle 12" challenge
-  When I reveal the authors of the "Battle 12" challenge
-  When I am logged in as "myname1"
-    And I go to "Battle 12" collection's page
-    And I follow "Prompts ("
-  When I press "Claim"
-  Then I should see "New claim made"
-  When I post the work "Here's one I made earlier"
-    And I edit the work "Here's one I made earlier"
-    And I check "Battle 12"
-    And I press "Preview"
-  Then I should see "In response to a prompt by"
-    When "AO3-3455" is fixed
-  #  And I should see "Collections:"
-   # And I should see "Battle 12"
-  When I press "Update"
-  Then I should see "Work was successfully updated"
-    And I should not see "draft"
-    And I should see "In response to a prompt by"
-  Then I should see "Collections:"
-    And I should see "Battle 12"
-    
-  # claim is fulfilled on collection page
-  When I go to "Battle 12" collection's page
-    And I follow "Prompts"
-  Then I should see "myname1" within ".prompt .work"
-    And I should see "Fulfilled By"
 
   Scenario: Download prompt CSV from signups page
   
@@ -696,7 +486,6 @@ Feature: Prompt Meme Challenge
     And I am logged in as "mod1"
   When I go to the "Battle 12" requests page
   Then I should not see "Download (CSV)"
-
 
   Scenario: Validation error doesn't cause semi-anon ticky to lose state (Issue 2617)
   Given I set up an anon promptmeme "Scotts Prompt" with name "scotts_prompt"

--- a/features/step_definitions/invite_steps.rb
+++ b/features/step_definitions/invite_steps.rb
@@ -26,7 +26,7 @@ end
 Given /^account creation is enabled$/ do
   steps %Q{
     Given the following admin settings are configured:
-    | account_creation_enabled | 0 |
+    | account_creation_enabled | 1 |
   }
 end
 


### PR DESCRIPTION
https://otwarchive.atlassian.net/browse/AO3-4441

Improve the automated tests for importing, which currently don't cover several key features. Adds tests for getting a claim email when someone imports your work, responding to that email to claim your work, responding to orphan, and responding to delete and ask not to be contacted again.

It appears that responding to claim is not working entirely smoothly, needs further investigation later. In rough testing on Staging, I managed to get an error 500 by clicking the claim link, then logging out. The test fails when you try to claim, with error 500 about login not existing.

Also rearrange the prompt meme tests that keep failing on Travis so they're of more equal size and logically arranged. Plenty more to optimise there, but keeping them sensibly sized will reduce failures.