### PR TITLE
AO3-4453 Let dashboard pseud menu wrap

### DIFF
--- a/public/javascripts/application.js
+++ b/public/javascripts/application.js
@@ -389,7 +389,18 @@ function setupAccordion() {
     if (expander.attr('href') == '#') {
       e.preventDefault();
     }
-    expander.toggleClass("expanded").toggleClass("collapsed").next().toggle();
+    // We need to treat the pseud menu differently so it will be properly responsive
+    // The other accordions need to be converted to a similar system
+    // Otherwise we run into bugs if one @media uses inline display and another uses block
+    if (expander.attr('title') == 'Pseud Switcher') {
+      if (expander.hasClass('expanded')) {
+        expander.toggleClass("expanded").toggleClass("collapsed").next().removeAttr('style');
+      } else {
+        expander.toggleClass("expanded").toggleClass("collapsed").next().hide();
+      }
+    } else {
+      expander.toggleClass("expanded").toggleClass("collapsed").next().toggle();
+    }
   });
 }
 

--- a/public/stylesheets/site/2.0/25-media-midsize.css
+++ b/public/stylesheets/site/2.0/25-media-midsize.css
@@ -25,26 +25,23 @@
   text-align: left;
 }
 
-#dashboard li, #dashboard a, #dashboard .current {
-  display: inline-block;
+#dashboard li {
+  display: inline;
 }
 
-#dashboard li {
-  margin: 0.125em 0;
-  position: relative;
+#dashboard a, #dashboard .current {
+  display: inline-block;
+  margin: 0.25em 0;
 }
 
 #dashboard .secondary {
   background: #eee;
-  float: right;
-  padding: 0 0.5em;
-    border-radius: 0.25em;
-    box-shadow: inset 2px 2px 5px #bbb,
-    inset 0 0 1px #bbb;
+  padding: 0.375em 0 0.625em;
+    box-shadow: inset 2px 2px 5px #bbb;
 }
 
-#dashboard .secondary li {
-  margin: 0;
+#dashboard .secondary a {
+  margin: 0.125em 0;
 }
 
 #dashboard .landmark {


### PR DESCRIPTION
https://otwarchive.atlassian.net/browse/AO3-4453

To make it so the list of pseuds can wrap across lines, we need to change how the list items display, and we need to adjust the JavaScript so instead of using jQuery's `toggle()` to apply a `style` attribute of `display: inline;` or `display: block;` directly to the pseud menu, it will use whatever display style is in the CSS for the window's current width.