### PR TITLE
AO3-4468 Fixing TODOs on admin news post tests

### DIFF
--- a/features/admins/admin_post_news.feature
+++ b/features/admins/admin_post_news.feature
@@ -35,7 +35,9 @@ Feature: Admin Actions to Post News
       And I fill in "Comment" with "Thank you very much!" within ".odd"
       And I press "Comment" within ".odd"
     Then I should see "Comment created"
-    # Someone can spoof being an admin by using the admin name and a different email, but their name will not be linked and their icon will not match
+    # Someone can spoof being an admin by using the admin name and a different email, but their icon will not match
+    # We want to improve this so that the name is linked and the spoof is more obvious
+    When "Issue AO3-3685" is fixed
     # notification to the admin list for admin post
       And 1 email should be delivered to "admin@example.org"
     # reply to the user

--- a/features/admins/admin_post_news.feature
+++ b/features/admins/admin_post_news.feature
@@ -35,7 +35,7 @@ Feature: Admin Actions to Post News
       And I fill in "Comment" with "Thank you very much!" within ".odd"
       And I press "Comment" within ".odd"
     Then I should see "Comment created"
-    # TODO: comments should be able to belong to an admin officially, otherwise someone can spoof being an admin by using the admin name and email
+    # Someone can spoof being an admin by using the admin name and a different email, but their name will not be linked and their icon will not match
     # notification to the admin list for admin post
       And 1 email should be delivered to "admin@example.org"
     # reply to the user


### PR DESCRIPTION
https://otwarchive.atlassian.net/browse/AO3-4468

The automated tests for admins posting news posts and commenting on them had a TODO - fix it by adding a clearer comment. The test for this is already expanded in a separate pull req.