### PR TITLE
AO3-4475 Fix TODOs in comment test

### DIFF
--- a/features/comments_and_kudos/add_comment.feature
+++ b/features/comments_and_kudos/add_comment.feature
@@ -42,8 +42,7 @@ Scenario: Comment editing
   Then I should see "Comment was successfully updated"
     And I should see "Actually, I meant something different"
     And I should not see "Mistaken comment"
-    And I should see "EST" within ".comment .posted"
-    And I should see "Last Edited"
+    And I should see Last Edited in the right timezone
 
 Scenario: Comment threading, comment editing
 
@@ -83,8 +82,7 @@ Scenario: Comment threading, comment editing
     #TODO Someone should figure out why this fails intermittently on Travis. Caching? The success message is there but the old comment text lingers.
     #And I should see "Actually, I meant something different"
     #And I should not see "Mistaken comment"
-    And I should see "EST" within ".comment .posted"
-    And I should see "Last Edited"
+    And I should see Last Edited in the right timezone
   When I am logged in as "commenter3"
     And I view the work "The One Where Neal is Awesome"
     And I follow "Comments (5)"

--- a/features/comments_and_kudos/add_comment.feature
+++ b/features/comments_and_kudos/add_comment.feature
@@ -5,6 +5,7 @@ Feature: Comment on work
   I'd like to comment on a work
 
 Scenario: Comment links from downloads and static pages
+
   When I am logged in as "author"
     And I post the work "Generic Work"
   When I am logged in as "commenter"
@@ -12,6 +13,7 @@ Scenario: Comment links from downloads and static pages
   Then I should see the comment form
 
 Scenario: When logged in I can comment on a work
+
   Given I have no works or comments
   When I am logged in as "author"
     And I post the work "The One Where Neal is Awesome"
@@ -27,8 +29,24 @@ Scenario: When logged in I can comment on a work
     And I follow "Entire Work"
     And I follow "Comments (1)"
   Then I should see "commenter on Chapter 1" within "h4.heading.byline"
-    
+
+Scenario: Comment editing
+
+  When I am logged in as "author"
+    And I post the work "The One Where Neal is Awesome"
+  When I am logged in as "commenter"
+    And I post the comment "Mistaken comment" on the work "The One Where Neal is Awesome"
+    And I follow "Edit"
+  And I fill in "Comment" with "Actually, I meant something different"
+    And I press "Update"
+  Then I should see "Comment was successfully updated"
+    And I should see "Actually, I meant something different"
+    And I should not see "Mistaken comment"
+    And I should see "EST" within ".comment .posted"
+    And I should see "Last Edited"
+
 Scenario: Comment threading, comment editing
+
   When I am logged in as "author"
     And I post the work "The One Where Neal is Awesome"
   When I am logged in as "commenter"
@@ -65,8 +83,8 @@ Scenario: Comment threading, comment editing
     #TODO Someone should figure out why this fails intermittently on Travis. Caching? The success message is there but the old comment text lingers.
     #And I should see "Actually, I meant something different"
     #And I should not see "Mistaken comment"
-    #And I should see "Posted"
-    #And I should see "Last Edited"
+    And I should see "EST" within ".comment .posted"
+    And I should see "Last Edited"
   When I am logged in as "commenter3"
     And I view the work "The One Where Neal is Awesome"
     And I follow "Comments (5)"
@@ -83,7 +101,8 @@ Scenario: Comment threading, comment editing
     And I should not see "This should be nested" within ".thread .thread .thread .thread"
     And I should see "I loved this" within "ol.thread"
 
-  Scenario: Try to post an invalid comment '
+  Scenario: Try to post an invalid comment
+
     When I am logged in as "author"
       And I post the work "Generic Work"
     When I am logged in as "commenter"

--- a/features/comments_and_kudos/comments_pagination.feature
+++ b/features/comments_and_kudos/comments_pagination.feature
@@ -9,5 +9,27 @@ Scenario: One-chapter work with many comments
   When I follow "Next" within ".pagination"
   Then I should see "1" within ".pagination"
 
-# TODO
-# Scenario: Multi-chapter work with many comments per chapter
+Scenario: Multi-chapter work with many comments per chapter
+
+  Given the chaptered work with 6 chapters with 50 comments "Epic WIP"
+  When I view the work "Epic WIP"
+  Then I should see "Comments (50)"
+  When I follow "Comments"
+  Then I should see "2" within ".pagination"
+    And I should not see "3" within ".pagination"
+  When I follow "Next" within ".pagination"
+  Then I should see "1" within ".pagination"
+  # All those comments were on the first chapter. Now put some more on
+  When I am logged in
+    And I view the work "Epic WIP"
+    And I view the 3rd chapter
+    And I post a comment "The third chapter is especially good."
+    And I post a comment "I loved the cliffhanger in chapter 3"
+  Then I should see "Comments (2)"
+  # Going to the work shows first chapter and only those comments
+  When I view the work "Epic WIP"
+  Then I should see "Comments (50)"
+  # Entire work shows all comments
+  When I follow "Entire Work"
+  Then I should see "Comments (52)"
+    And I should see "3" within ".pagination"

--- a/features/comments_and_kudos/comments_pagination.feature
+++ b/features/comments_and_kudos/comments_pagination.feature
@@ -32,4 +32,5 @@ Scenario: Multi-chapter work with many comments per chapter
   # Entire work shows all comments
   When I follow "Entire Work"
   Then I should see "Comments (52)"
-    And I should see "3" within ".pagination"
+  When I follow "Comments (52)"
+  Then I should see "3" within ".pagination"

--- a/features/step_definitions/comment_steps.rb
+++ b/features/step_definitions/comment_steps.rb
@@ -35,6 +35,12 @@ Then /^I should see the reply to comment form$/ do
   step %{I should see "Comment as" within ".odd"}
 end
 
+Then /^I should see Last Edited in the right timezone$/ do
+  zone = Time.current.in_time_zone(Time.zone).zone
+  step %{I should see "#{zone}" within ".comment .posted"}
+  step %{I should see "Last Edited"}
+end
+
 # WHEN
 
 When /^I set up the comment "([^"]*)" on the work "([^"]*)"$/ do |comment_text, work|

--- a/features/step_definitions/work_steps.rb
+++ b/features/step_definitions/work_steps.rb
@@ -97,9 +97,12 @@ Given /^the chaptered work(?: with ([\d]+) chapters)?(?: with ([\d]+) comments?)
   end
   step %{I am logged out}
   n_comments ||= 0
+  work = Work.find_by_title!(title)
   n_comments.to_i.times do |i|
     step %{I am logged in as a random user}
-    step %{I post the comment "Bla bla" on the work "#{title}"}
+    visit work_url(work)
+    fill_in("comment[content]", :with => "Bla bla")
+    click_button("Comment")
     step %{I am logged out}
   end
 end

--- a/features/step_definitions/work_steps.rb
+++ b/features/step_definitions/work_steps.rb
@@ -101,7 +101,7 @@ Given /^the chaptered work(?: with ([\d]+) chapters)?(?: with ([\d]+) comments?)
   n_comments.to_i.times do |i|
     step %{I am logged in as a random user}
     visit work_url(work)
-    fill_in("comment[content]", :with => "Bla bla")
+    fill_in("comment[content]", with: "Bla bla")
     click_button("Comment")
     step %{I am logged out}
   end


### PR DESCRIPTION
https://otwarchive.atlassian.net/browse/AO3-4475

Our automated test for comment pagination, threading and editing has some TODOs. Fix them.

The last test here is a pretty slow one, given that it needs a lot of comments, so I've also done my best to speed it up.