### PR TITLE
AO3-4477 Fix homepage inbox reply form being cut off

### DIFF
--- a/public/stylesheets/site/2.0/16-zone-system.css
+++ b/public/stylesheets/site/2.0/16-zone-system.css
@@ -21,7 +21,6 @@ SUBSECTIONS:
 .splash {
   margin: auto;
   max-width: 78em;
-  overflow: hidden;
 }
 
 .splash .module h3 {


### PR DESCRIPTION
https://otwarchive.atlassian.net/browse/AO3-4477

`overflow: hidden` is a relic of homepages gone by and is causing the reply form on the inbox to get cut off in some circumstances. It should go bye-bye.