### PR TITLE
AO3-4478 Fix alignment on wrangling dash in midsize and narrow layout

### DIFF
--- a/public/stylesheets/site/2.0/04-region-dashboard.css
+++ b/public/stylesheets/site/2.0/04-region-dashboard.css
@@ -21,6 +21,7 @@ http://otwcode.github.com/docs/front_end_coding/patterns/supertypes
   padding: 0 0.5625em;
   border: none;
   background: transparent;
+  vertical-align: middle;
     word-wrap: break-word;
     box-shadow: none;
 }

--- a/public/stylesheets/site/2.0/25-media-midsize.css
+++ b/public/stylesheets/site/2.0/25-media-midsize.css
@@ -29,7 +29,7 @@
   display: inline;
 }
 
-#dashboard a, #dashboard .current {
+#dashboard a, #dashboard span {
   display: inline-block;
   margin: 0.25em 0;
 }


### PR DESCRIPTION
https://otwarchive.atlassian.net/browse/AO3-4478

Drafts/Bookmarks/Private Bookmarks/External Works/Taggings Count appeared on separate lines instead of side by side. (Once I fixed that, the options in `<span>` also needed the vertical alignment adjusted, since the `<a>` options had middle alignment and the `<span>` ones did not.)