### PR TITLE
AO3-4479 Adding retries to Travis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ script:
   - RAILS_ENV=test bundle exec rake db:create:all --trace
   - RAILS_ENV=test bundle exec rake db:schema:load --trace
   - RAILS_ENV=test bundle exec rake db:migrate --trace
-  - bundle exec $TEST_GROUP
+  - travis_retry bundle exec $TEST_GROUP
 before_script:
   - bash script/travis_configure.sh
   - bash script/travis_elasticsearch_upgrade.sh


### PR DESCRIPTION
https://otwarchive.atlassian.net/browse/AO3-4479

Add travis_retry feature. This will retry any test that fails 3 times before giving final failure. This means it'll take slightly longer to get notified in the event of a genuine failure, as well as taking longer to execute when a shutdown happens and it has to retry, but seems to work for eliminating the bogus failures due to shutdown. The perfect solution would be for Travis to reply to my comment on the issue about the shutdowns, but this will reduce our pain.