### PR TITLE
AO3-4483 Mass importer can't import works with the wrong encoding

### DIFF
--- a/app/models/story_parser.rb
+++ b/app/models/story_parser.rb
@@ -532,8 +532,9 @@ class StoryParser
     def parse_common(story, location = nil, encoding = nil)
       work_params = { title: "UPLOADED WORK", chapter_attributes: { content: "" } }
 
-      # Encode as HTML - the dummy tag forces plain text documents to preserve line breaks and not be a big blob
-      # Rescue errors as it complains about things the sanitizer will fix later
+      # Encode as HTML - the dummy "foo" tag will be stripped out by the sanitizer but forces Nokogiri to
+      # preserve line breaks in plain text documents
+      # Rescue all errors as Nokogiri complains about things the sanitizer will fix later
       @doc = Nokogiri::HTML.parse(story.prepend("<foo/>"), nil, encoding) rescue ""
 
       # Try to convert all relative links to absolute

--- a/app/models/story_parser.rb
+++ b/app/models/story_parser.rb
@@ -532,9 +532,9 @@ class StoryParser
     def parse_common(story, location = nil, encoding = nil)
       work_params = {title: "UPLOADED WORK", chapter_attributes: { content: "" }}
 
-      # Encode as HTML - the dummy <i> is to force plain text documents to be parsed as HTML with line
-      # breaks rather than one big blob
-      @doc = Nokogiri::HTML.parse(story.prepend("<i/>"), nil, encoding) rescue ""
+      # Encode as HTML - the dummy tag forces plain text documents to preserve line breaks and not be a big blob
+      # Rescue errors as it complains about things the sanitizer will fix later
+      @doc = Nokogiri::HTML.parse(story.prepend("<foo/>"), nil, encoding) rescue ""
 
       # Try to convert all relative links to absolute
       base = @doc.at_css('base') ? @doc.css('base')[0]['href'] : location.split('?').first
@@ -569,13 +569,8 @@ class StoryParser
       storyhead = @doc.css("head").inner_html if @doc.css("head")
 
       # Story content - Look for progressively less specific containers or grab everything
-      storytext =
-        if @doc.errors.empty?
-          element = @doc.at_css('.chapter-content') || @doc.at_css('body') || @doc.at_css('html') || @doc || story
-          element.inner_html
-        else
-          story
-        end
+      element = @doc.at_css('.chapter-content') || @doc.at_css('body') || @doc.at_css('html') || @doc
+      storytext = element ? element.inner_html : story
 
       meta = {}
       meta.merge!(scan_text_for_meta(storyhead)) unless storyhead.blank?

--- a/app/models/story_parser.rb
+++ b/app/models/story_parser.rb
@@ -530,7 +530,7 @@ class StoryParser
     # form results) and returns the final sanitized hash.
     #
     def parse_common(story, location = nil, encoding = nil)
-      work_params = {title: "UPLOADED WORK", chapter_attributes: { content: "" }}
+      work_params = { title: "UPLOADED WORK", chapter_attributes: { content: "" } }
 
       # Encode as HTML - the dummy tag forces plain text documents to preserve line breaks and not be a big blob
       # Rescue errors as it complains about things the sanitizer will fix later
@@ -564,7 +564,7 @@ class StoryParser
     # our fallback: parse a story from an unknown source, so we have no special
     # rules.
     def parse_story_from_unknown(story)
-      work_params = {:chapter_attributes => {}}
+      work_params = { chapter_attributes: {} }
 
       storyhead = @doc.css("head").inner_html if @doc.css("head")
 

--- a/spec/api/api_spec.rb
+++ b/spec/api/api_spec.rb
@@ -51,6 +51,11 @@ stubbed response", headers: {})
               body: "stubbed response",
               headers: {})
 
+  WebMock.stub_request(:any, /no-content/).
+    to_return(status: 200,
+              body: "",
+              headers: {})
+
   WebMock.stub_request(:any, /bar/).
     to_return(status: 404, headers: {})
 
@@ -121,6 +126,18 @@ stubbed response", headers: {})
            { archivist: @user.login }.to_json,
            valid_headers
       assert_equal 400, response.status
+    end
+
+    it "should return a helpful message if the external work contains no text" do
+      post "/api/v1/import",
+           { archivist: @user.login,
+             works: [{ external_author_name: "bar",
+                       external_author_email: "bar@foo.com",
+                       chapter_urls: ["http://no-content"] }]
+           }.to_json,
+           valid_headers
+      parsed_body = JSON.parse(response.body)
+      expect(parsed_body["works"].first["messages"].first).to start_with("\"We couldn't")
     end
 
     describe "should use API metadata for these fields:" do
@@ -285,6 +302,7 @@ stubbed response", headers: {})
         expect(@work.external_author_names.first.name).to eq(api_fields[:external_author_name])
       end
     end
+
   end
 
   WebMock.allow_net_connect!

--- a/spec/api/api_spec.rb
+++ b/spec/api/api_spec.rb
@@ -302,7 +302,6 @@ stubbed response", headers: {})
         expect(@work.external_author_names.first.name).to eq(api_fields[:external_author_name])
       end
     end
-
   end
 
   WebMock.allow_net_connect!

--- a/spec/models/story_parser_spec.rb
+++ b/spec/models/story_parser_spec.rb
@@ -149,7 +149,7 @@ describe StoryParser do
       }.each_pair do |input, output|
         location, href = input
         story_in = '<html><body><p>here is <a href="' + href + '">a link</a>.</p></body></html>'
-        story_out = 'here is <a href="' + output + '">a link</a>.'
+        story_out = '<p>here is <a href="' + output + '">a link</a>.</p>'
         results = @sp.parse_common(story_in, location)
         expect(results[:chapter_attributes][:content]).to include(story_out)
       end


### PR DESCRIPTION
When you try to get it to import a plain text file with the wrong encoding, the API returns a spurious Rails routes error which breaks anything on the client side that tries to parse it as Json.

This needs to be tested through the API as that is the only thing affected by the issue this fixes.