### PR TITLE
AO3-4492 Add missing landmarks to user gifts page

### DIFF
--- a/app/views/gifts/index.html.erb
+++ b/app/views/gifts/index.html.erb
@@ -11,6 +11,7 @@
 
 <!--subnavigation, sorting and actions-->
 <% if @user && @user == current_user %>
+  <h3 class="landmark heading"><%= ts("Navigation") %></h3>
   <ul class="navigation actions" role="navigation">
     <li>
       <%= span_if_current ts("Accepted Gifts"), user_gifts_path(@user), !(params[:refused]) %>
@@ -29,6 +30,7 @@
 <% end %>
 
 <!--main content-->
+<h3 class="heading landmark"><%= ts("List of Gifts") %></h3>
 <ul class="gift work index group">
   <% for work in @works %>
     <%= render 'gifts/gift_blurb', work: work, gift: work %>


### PR DESCRIPTION
https://otwarchive.atlassian.net/browse/AO3-4492

Our landmarks, which also act as clears (sob) were missing from the gifts page, which was causing display issues with the Accepted and Refused options on mobile