### PR TITLE
AO3-4408 New pseud button unclickable on Android

### DIFF
--- a/app/views/pseuds/index.html.erb
+++ b/app/views/pseuds/index.html.erb
@@ -4,14 +4,16 @@
 
 <!--subnav-->
 <% if current_user == @user %>
-<ul class="navigation actions" role="navigation">
-  <li><%= link_to ts('New Pseud'), new_user_pseud_path(@user) %></li>
-</ul>
+  <h3 class="landmark heading"><%= ts("Navigation") %></h3>
+  <ul class="navigation actions" role="navigation">
+    <li><%= link_to ts('New Pseud'), new_user_pseud_path(@user) %></li>
+  </ul>
 <% end %>
 <!--/subnav-->
 
 <!--main content-->
-<ul class="index group">
+<h3 class="landmark heading"><%= ts("List of Pseuds") %></h3>
+<ul class="pseud index group">
   <% @pseuds.each do |pseud| %>
     <%= render :partial => 'pseuds/pseud_blurb', :locals => {:pseud => pseud} %>
   <% end %>  


### PR DESCRIPTION
https://otwarchive.atlassian.net/browse/AO3-4408

The Manage Pseuds page was missing some landmarks, which was making the New Pseud button unclickable