### PR TITLE
AO3-4499 - Set imported date to the date of the last chapter

### DIFF
--- a/app/models/story_parser.rb
+++ b/app/models/story_parser.rb
@@ -271,6 +271,7 @@ class StoryParser
       @options = options
       work.imported_from_url = location
       work.expected_number_of_chapters = work.chapters.length
+      work.revised_at = work.chapters.last.published_at
 
       # set authors for the works
       pseuds = []

--- a/features/importing/work_import_dw.feature
+++ b/features/importing/work_import_dw.feature
@@ -140,6 +140,7 @@ Feature: Import Works from DW
         | login          | password    |
         | cosomeone      | something   |
       And I am logged in as "cosomeone" with password "something"
+      And I set my time zone to "UTC"
     When I go to the import page
       And I fill in "urls" with
          """

--- a/features/importing/work_import_lj.feature
+++ b/features/importing/work_import_lj.feature
@@ -133,6 +133,7 @@ Feature: Import Works from LJ
   Scenario: Creating a new multichapter work from an LJ story
     Given basic tags
       And I am logged in as "cosomeone"
+      And I set my time zone to "UTC"
     When I go to the import page
       And I fill in "urls" with
          """

--- a/features/step_definitions/preferences_steps.rb
+++ b/features/step_definitions/preferences_steps.rb
@@ -75,3 +75,9 @@ When /^I set my preferences to turn off viewing history$/ do
   user.preference.history_enabled = false
   user.preference.save
 end
+
+When /^I set my time zone to "([^"]*)"$/ do |time_zone|
+  user = User.current_user
+  user.preference.time_zone = time_zone
+  user.preference.save
+end


### PR DESCRIPTION
https://otwarchive.atlassian.net/browse/AO3-4499

Given two chapter with different dates in their content, the date of the last chapter to be imported should become the revision date of the entire work.