### PR TITLE
AO3-2864 Challenge signup search

### DIFF
--- a/app/controllers/challenge_signups_controller.rb
+++ b/app/controllers/challenge_signups_controller.rb
@@ -89,7 +89,7 @@ class ChallengeSignupsController < ApplicationController
               @query = params[:query]
               @challenge_signups = @challenge_signups.where("pseuds.name LIKE ?", '%' + params[:query] + '%')
             end
-            @challenge_signups = @challenge_signups.order("pseuds.name").paginate(:page => params[:page], :per_page => ArchiveConfig.ITEMS_PER_PAGE)          
+            @challenge_signups = @challenge_signups.order("pseuds.name").paginate(page: params[:page], per_page: ArchiveConfig.ITEMS_PER_PAGE)          
           elsif params[:user_id] && (@user = User.find_by_login(params[:user_id]))
             @challenge_signups = @collection.signups.by_user(current_user)
           else

--- a/app/controllers/challenge_signups_controller.rb
+++ b/app/controllers/challenge_signups_controller.rb
@@ -84,7 +84,12 @@ class ChallengeSignupsController < ApplicationController
     respond_to do |format|
       format.html {
           if @challenge.user_allowed_to_see_signups?(current_user)
-            @challenge_signups = @collection.signups.joins(:pseud).order("pseuds.name").paginate(:page => params[:page], :per_page => ArchiveConfig.ITEMS_PER_PAGE)
+            @challenge_signups = @collection.signups.joins(:pseud)
+            if params[:query]
+              @query = params[:query]
+              @challenge_signups = @challenge_signups.where("pseuds.name LIKE ?", '%' + params[:query] + '%')
+            end
+            @challenge_signups = @challenge_signups.order("pseuds.name").paginate(:page => params[:page], :per_page => ArchiveConfig.ITEMS_PER_PAGE)          
           elsif params[:user_id] && (@user = User.find_by_login(params[:user_id]))
             @challenge_signups = @collection.signups.by_user(current_user)
           else

--- a/app/views/challenge/gift_exchange/_challenge_signups.html.erb
+++ b/app/views/challenge/gift_exchange/_challenge_signups.html.erb
@@ -1,6 +1,20 @@
-<h2 class="heading"><%= ts("Sign-ups for %{collection}", :collection => @collection.title) %></h2>
-  
+<h2 class="heading">
+  <% if @query %>
+    <%= search_header @challenge_signups, nil, "Signup" %>
+  <% else %>
+    <%= ts("Sign-ups for %{collection}", collection: @collection.title) %>
+  <% end %>
+</h2>
+
 <ul class="navigation actions" role="menu">
+  <li class="search" role="search">
+    <%= form_tag collection_signups_path(@collection), class: "simple search", method: :get do |form| %>
+      <fieldset>
+        <%= text_field_tag "query", @query, title: "search" %>
+        <%= submit_tag ts("Search By Pseud") %>
+      </fieldset>
+    <% end %>
+  </li>
   <li class="action">
     <%= link_to ts("Download (CSV)"), collection_signups_path(@collection, :format => :csv) %> 
     <%= link_to_help "csv-download"%>

--- a/app/views/challenge/prompt_meme/_challenge_signups.html.erb
+++ b/app/views/challenge/prompt_meme/_challenge_signups.html.erb
@@ -8,5 +8,4 @@
   </li>
   <li><%= link_to ts("Manage Prompts"), collection_requests_path(@collection) %></li>
   <li><%= link_to ts("Manage Claims"), collection_claims_path(@collection) %></li>
-
-
+</ul>

--- a/features/gift_exchanges/challenge_giftexchange.feature
+++ b/features/gift_exchanges/challenge_giftexchange.feature
@@ -114,17 +114,28 @@ Feature: Gift Exchange Challenge
     Then I should not see "Sign-ups" within "#dashboard"
   
   Scenario: Mod can view signups
-    Given the gift exchange "Awesome Gift Exchange" is ready for signups
-      And everyone has signed up for the gift exchange "Awesome Gift Exchange"
-    When I am logged in as "mod1"
-      And I go to "Awesome Gift Exchange" collection's page
-      And I follow "Sign-ups"
-    Then I should see "myname4" within "#main"
-      And I should see "myname3" within "#main"
-      And I should see "myname2" within "#main"
-      And I should see "myname1" within "#main"
-      And I should see "Something else weird"
-      And I should see "Alternate Universe - Historical"
+   Given the gift exchange "Awesome Gift Exchange" is ready for signups
+     And everyone has signed up for the gift exchange "Awesome Gift Exchange"
+   When I am logged in as "mod1"
+     And I go to "Awesome Gift Exchange" collection's page
+     And I follow "Sign-ups"
+   Then I should see "myname4" within "#main"
+     And I should see "myname3" within "#main"
+     And I should see "myname2" within "#main"
+     And I should see "myname1" within "#main"
+     And I should see "Something else weird"
+     And I should see "Alternate Universe - Historical"
+
+   Scenario: Mod can search signups by pseud
+   Given the gift exchange "Awesome Gift Exchange" is ready for signups
+     And everyone has signed up for the gift exchange "Awesome Gift Exchange"
+   When I am logged in as "mod1"
+     And I go to "Awesome Gift Exchange" collection's page
+     And I follow "Sign-ups"
+     And I fill in "query" with "3"
+     And I press "Search By Pseud"
+   Then I should see "myname3" within "#main"
+     And I should not see "myname4" within "#main"
 
   Scenario: Cannot generate matches while signup is open
     Given the gift exchange "Awesome Gift Exchange" is ready for signups


### PR DESCRIPTION
RELEASE NOTES: Challenge moderators can now search the signups for their challenge by pseud instead of having to manually find them in the alphabetic list, which can be very long for a large challenge.

https://code.google.com/p/otwarchive/issues/detail?id=2867
https://otwarchive.atlassian.net/browse/AO3-2864

Signups for a large gift exchange should now be searchable by pseud. Has tests.

Also fixes a tiny unclosed ul tag on the prompt meme signup.

Signed-off-by: shalott <shalott@gmail.com>