### PR TITLE
AO3-2864 Fix Download CSV style on gift exchange signups page

### DIFF
--- a/app/views/challenge/gift_exchange/_challenge_signups.html.erb
+++ b/app/views/challenge/gift_exchange/_challenge_signups.html.erb
@@ -1,7 +1,7 @@
 <!--descriptions-->
 <h2 class="heading">
   <% if @query %>
-    <%= search_header @challenge_signups, nil, "Signup" %>
+    <%= search_header @challenge_signups, nil, "Sign-up" %>
   <% else %>
     <%= ts("Sign-ups for %{collection}", collection: @collection.title) %>
   <% end %>

--- a/app/views/challenge/gift_exchange/_challenge_signups.html.erb
+++ b/app/views/challenge/gift_exchange/_challenge_signups.html.erb
@@ -6,7 +6,7 @@
   <% end %>
 </h2>
 
-<ul class="navigation actions" role="menu">
+<ul class="navigation actions">
   <li class="search" role="search">
     <%= form_tag collection_signups_path(@collection), class: "simple search", method: :get do |form| %>
       <fieldset>
@@ -34,7 +34,7 @@
       </dt>
       <dd>
         <%= render "challenge_signups/signup_controls", challenge_signup: signup, subnav: false %>
-        <ul class="actions" role="menu">
+        <ul class="actions">
           <li>
             <%= link_to h(ts("Requests")) + ' &#8595;'.html_safe, "#", class: "requests_#{signup.id}_open" %>
             <%= link_to h(ts("Close Requests")) + ' &#8593;'.html_safe, "#", class: "requests_#{signup.id}_close" %>

--- a/app/views/challenge/gift_exchange/_challenge_signups.html.erb
+++ b/app/views/challenge/gift_exchange/_challenge_signups.html.erb
@@ -16,11 +16,11 @@
     <% end %>
   </li>
   <li>
-    <%= link_to ts("Download (CSV)"), collection_signups_path(@collection, :format => :csv) %> 
-    <%= link_to_help "csv-download"%>
+    <%= link_to ts("Download (CSV)"), collection_signups_path(@collection, format: :csv) %> 
+    <%= link_to_help "csv-download" %>
   </li>
 </ul>
-  
+
 <% if @challenge_signups.empty? %>
   <p><%= ts("No sign-ups yet!")%></p>
 <% else %>
@@ -30,29 +30,30 @@
     <% @challenge_signups.each do |signup| %>
       <dt class="participant" title="<%= ts("user name") %>">
         <%= link_to signup.pseud.name, collection_signup_path(@collection, signup) %>
-        <%= mailto_link signup.pseud.user, :subject => "[#{h(@collection.title)}] Message from Collection Maintainer" %>
+        <%= mailto_link signup.pseud.user, subject: "[#{h(@collection.title)}] Message from Collection Maintainer" %>
       </dt>
       <dd>
-        <%= render "challenge_signups/signup_controls", :challenge_signup => signup, :subnav => false %>
+        <%= render "challenge_signups/signup_controls", challenge_signup: signup, subnav: false %>
         <ul class="actions" role="menu">
           <li>
-            <%= link_to h(ts("Requests")) + ' &#8595;'.html_safe, "#", :class => "requests_#{signup.id}_open" %>
-            <%= link_to h(ts("Close Requests")) + ' &#8593;'.html_safe, "#", :class => "requests_#{signup.id}_close" %>
+            <%= link_to h(ts("Requests")) + ' &#8595;'.html_safe, "#", class: "requests_#{signup.id}_open" %>
+            <%= link_to h(ts("Close Requests")) + ' &#8593;'.html_safe, "#", class: "requests_#{signup.id}_close" %>
           </li>
           <li>
-            <%= link_to h(ts("Offers")) + ' &#8595;'.html_safe, "#", :class => "offers_#{signup.id}_open" %>
-            <%= link_to h(ts("Close Offers")) + ' &#8593;'.html_safe, "#", :class => "offers_#{signup.id}_close" %>
+            <%= link_to h(ts("Offers")) + ' &#8595;'.html_safe, "#", class: "offers_#{signup.id}_open" %>
+            <%= link_to h(ts("Close Offers")) + ' &#8593;'.html_safe, "#", class: "offers_#{signup.id}_close" %>
           </li>
         </ul>
         <div class="toggled" id="<%= "requests_#{signup.id}" %>">
-          <%= render "challenge_signups/show_requests", :challenge_signup => signup %>
+          <%= render "challenge_signups/show_requests", challenge_signup: signup %>
         </div>
         <div class="toggled" id="<%= "offers_#{signup.id}" %>">
-          <%= render "challenge_signups/show_offers", :challenge_signup => signup %>
+          <%= render "challenge_signups/show_offers", challenge_signup: signup %>
         </div>
       </dd>
     <% end %>
   </dl>
-        
+
   <%= will_paginate(@challenge_signups) %>
 <% end %>
+

--- a/app/views/challenge/gift_exchange/_challenge_signups.html.erb
+++ b/app/views/challenge/gift_exchange/_challenge_signups.html.erb
@@ -1,3 +1,4 @@
+<!--descriptions-->
 <h2 class="heading">
   <% if @query %>
     <%= search_header @challenge_signups, nil, "Signup" %>
@@ -5,7 +6,9 @@
     <%= ts("Sign-ups for %{collection}", collection: @collection.title) %>
   <% end %>
 </h2>
+<!--/descriptions-->
 
+<!--subnav-->
 <ul class="navigation actions">
   <li class="search" role="search">
     <%= form_tag collection_signups_path(@collection), class: "simple search", method: :get do |form| %>
@@ -20,7 +23,9 @@
     <%= link_to_help "csv-download" %>
   </li>
 </ul>
+<!--/subnav-->
 
+<!--main content-->
 <% if @challenge_signups.empty? %>
   <p><%= ts("No sign-ups yet!")%></p>
 <% else %>
@@ -56,4 +61,5 @@
 
   <%= will_paginate(@challenge_signups) %>
 <% end %>
+<!--/content-->
 

--- a/app/views/challenge/gift_exchange/_challenge_signups.html.erb
+++ b/app/views/challenge/gift_exchange/_challenge_signups.html.erb
@@ -15,7 +15,7 @@
       </fieldset>
     <% end %>
   </li>
-  <li class="action">
+  <li>
     <%= link_to ts("Download (CSV)"), collection_signups_path(@collection, :format => :csv) %> 
     <%= link_to_help "csv-download"%>
   </li>


### PR DESCRIPTION
https://otwarchive.atlassian.net/browse/AO3-2864

- Fix the weirdness with the Download CSV button style
- Make search results say "Sign-ups" or "Sign-up" instead of "Signups" or "Signup"
- Update syntax
- Remove `role="menu"` because it shouldn't be used the way we were using it
- Add the HTML comments we use to remind us how the page is structured