### PR TITLE
AO3-4523 Fix collapse/expand fandoms link on dashboard

### DIFF
--- a/public/stylesheets/site/2.0/09-roles-states.css
+++ b/public/stylesheets/site/2.0/09-roles-states.css
@@ -42,7 +42,7 @@ span.unread, .replied, span.claimed, .actions span.defaulted {
   font-weight: 700;
 }
 
-.hidden, body .hidden, .actions .hidden {
+.hidden, body .hidden, .actions .hidden, .actions a.hidden {
   display: none;
 }
 


### PR DESCRIPTION
https://otwarchive.atlassian.net/browse/AO3-4523

Both the Expand and Collapse options were showing on the fandoms list. We only want the one that applies to show.