### PR TITLE
AO3-4123 Sort admin post translations by languages' short names

### DIFF
--- a/app/views/admin_posts/_admin_post.html.erb
+++ b/app/views/admin_posts/_admin_post.html.erb
@@ -16,7 +16,8 @@
       <dt class="translations"><%= ts("Translations:") %></dt>
       <dd class="translations">
         <ul class="languages commas">
-          <% for admin_post in admin_post.translations %>
+          <% # admin_post_translations = admin_post.translations.map(&:language).sort_by(&:name) %>
+          <% for admin_post in admin_post.translations.sort_by { |translation| translation.language.short } %>
             <li><%= link_to admin_post.language.name, admin_post %></li>
           <% end %>
         </ul>

--- a/app/views/admin_posts/_admin_post.html.erb
+++ b/app/views/admin_posts/_admin_post.html.erb
@@ -1,0 +1,39 @@
+<% # expects "admin_post" %>
+<div class="header">
+  <h3 class="heading">
+    <%= link_to admin_post.title.html_safe, admin_post %>
+  </h3>
+</div>
+<h4 class="landmark heading"><%= ts("Post Header") %></h4>
+<div class="wrapper">
+  <dl class="meta">
+    <dt class="published"><%= ts("Published:") %></dt>
+    <dd class="published"><%= admin_post.created_at %></dd>
+    <% if admin_post.translated_post %>
+      <dt class="original translations"><%= ts("Original:") %></dt>
+      <dd class="original translations"><%= link_to admin_post.translated_post.title, admin_post.translated_post %></dd>
+    <% elsif !admin_post.translations.empty? %>
+      <dt class="translations"><%= ts("Translations:") %></dt>
+      <dd class="translations">
+        <ul class="languages commas">
+          <% for admin_post in admin_post.translations %>
+            <li><%= link_to admin_post.language.name, admin_post %></li>
+          <% end %>
+        </ul>
+      </dd>
+    <% end %>
+    <% if admin_post.tags.length > 0 %>
+      <dt class="tags"><%= ts("Tags:") %></dt>
+      <dd class="tags">
+        <ul class="tags commas">
+          <% for tag in admin_post.tags %>
+            <li><%= link_to tag.name, admin_posts_path(:tag => tag.id), :class => "tag" %></li>
+          <% end %>
+        </ul>
+      </dd>
+    <% end %>
+  </dl>
+</div>
+<div class="userstuff">
+  <%=raw sanitize_field(admin_post, :content) %>
+</div>

--- a/app/views/admin_posts/_admin_post.html.erb
+++ b/app/views/admin_posts/_admin_post.html.erb
@@ -16,7 +16,6 @@
       <dt class="translations"><%= ts("Translations:") %></dt>
       <dd class="translations">
         <ul class="languages commas">
-          <% # admin_post_translations = admin_post.translations.map(&:language).sort_by(&:name) %>
           <% for admin_post in admin_post.translations.sort_by { |translation| translation.language.short } %>
             <li><%= link_to admin_post.language.name, admin_post %></li>
           <% end %>

--- a/app/views/admin_posts/_admin_post.html.erb
+++ b/app/views/admin_posts/_admin_post.html.erb
@@ -16,13 +16,13 @@
       <dt class="translations"><%= ts("Translations:") %></dt>
       <dd class="translations">
         <ul class="languages commas">
-          <% for admin_post in admin_post.translations.sort_by { |translation| translation.language.short } %>
-            <li><%= link_to admin_post.language.name, admin_post %></li>
+          <% for translation in admin_post.translations %>
+            <li><%= link_to translation.language.name, admin_post %></li>
           <% end %>
         </ul>
       </dd>
     <% end %>
-    <% if admin_post.tags.length > 0 %>
+    <% if admin_post.tags.present? %>
       <dt class="tags"><%= ts("Tags:") %></dt>
       <dd class="tags">
         <ul class="tags commas">

--- a/app/views/admin_posts/_admin_post.html.erb
+++ b/app/views/admin_posts/_admin_post.html.erb
@@ -27,7 +27,7 @@
       <dd class="tags">
         <ul class="tags commas">
           <% for tag in admin_post.tags %>
-            <li><%= link_to tag.name, admin_posts_path(:tag => tag.id), :class => "tag" %></li>
+            <li><%= link_to tag.name, admin_posts_path(tag: tag.id), class: "tag" %></li>
           <% end %>
         </ul>
       </dd>

--- a/app/views/admin_posts/index.html.erb
+++ b/app/views/admin_posts/index.html.erb
@@ -1,4 +1,4 @@
-<div class="admin home">
+<div class="news admin home">
   <% if logged_in_as_admin? %>
     <%= render "admin_index" %>
   <% else %>

--- a/app/views/admin_posts/index.html.erb
+++ b/app/views/admin_posts/index.html.erb
@@ -15,30 +15,30 @@
       </ul>
       <!--/subnav-->
     </div>
-  <!--main content-->
-  <% @admin_posts.each do |admin_post| %>
+    <!--main content-->
+    <% @admin_posts.each do |admin_post| %>
 
-    <div class="news module group" role="article">
-    <%= render "admin_post", admin_post: admin_post %>
-    <!-- BEGIN comment section -->
-    <h3 class="landmark heading"><%= ts("Comment") %></h3>
-    <ul class="actions" role="navigation">
-      <% if admin_post.count_visible_comments > 0 %>
-        <li><%= link_to ( admin_post.count_visible_comments == 1 ? 
-                        ts("Read %{comment_count} Comment", comment_count: admin_post.count_visible_comments.to_s) : 
-                        ts("Read %{comment_count} Comments", comment_count: admin_post.count_visible_comments.to_s)),
-                        admin_post_path(id: admin_post.id, anchor: "comments", show_comments: true) %></li>
-      <% end %>
-      <li><%= link_to ts("Add Comment"), admin_post_path(id: admin_post.id, anchor: "comments", add_comment: true) %></li>
-    </ul>  
-    <!-- END comment section -->
-  </div>
-  <% end %>
-  <!--/content-->
-  <hr class="clear" />
+      <div class="news module group" role="article">
+        <%= render "admin_post", admin_post: admin_post %>
+        <!-- BEGIN comment section -->
+        <h3 class="landmark heading"><%= ts("Comment") %></h3>
+        <ul class="actions" role="navigation">
+          <% if admin_post.count_visible_comments > 0 %>
+            <li><%= link_to (admin_post.count_visible_comments == 1 ? 
+                            ts("Read %{comment_count} Comment", comment_count: admin_post.count_visible_comments.to_s) : 
+                            ts("Read %{comment_count} Comments", comment_count: admin_post.count_visible_comments.to_s)),
+                            admin_post_path(id: admin_post.id, anchor: "comments", show_comments: true) %></li>
+          <% end %>
+          <li><%= link_to ts("Add Comment"), admin_post_path(id: admin_post.id, anchor: "comments", add_comment: true) %></li>
+        </ul>
+        <!-- END comment section -->
+      </div>
+    <% end %>
+    <!--/content-->
+    <hr class="clear" />
 
-  <!--subnav-->
+    <!--subnav-->
     <%= will_paginate @admin_posts %>
-  <!--/subnav-->
+    <!--/subnav-->
   <% end %>
 </div>

--- a/app/views/admin_posts/index.html.erb
+++ b/app/views/admin_posts/index.html.erb
@@ -1,6 +1,6 @@
 <div class="admin home">
   <% if logged_in_as_admin? %>
-    <%= render :partial => "admin_index" %>
+    <%= render "admin_index" %>
   <% else %>
     <div class="primary header module">
       <!--Descriptive page name, messages and instructions-->
@@ -18,18 +18,18 @@
   <!--main content-->
   <% @admin_posts.each do |admin_post| %>
 
-  <div class="news module group" role="article">
+    <div class="news module group" role="article">
     <%= render "admin_post", admin_post: admin_post %>
     <!-- BEGIN comment section -->
     <h3 class="landmark heading"><%= ts("Comment") %></h3>
     <ul class="actions" role="navigation">
       <% if admin_post.count_visible_comments > 0 %>
         <li><%= link_to ( admin_post.count_visible_comments == 1 ? 
-                        ts("Read %{comment_count} Comment", :comment_count => admin_post.count_visible_comments.to_s) : 
-                        ts("Read %{comment_count} Comments", :comment_count => admin_post.count_visible_comments.to_s)),
-                        admin_post_path(:id => admin_post.id, :anchor => "comments", :show_comments => true) %></li>
+                        ts("Read %{comment_count} Comment", comment_count: admin_post.count_visible_comments.to_s) : 
+                        ts("Read %{comment_count} Comments", comment_count: admin_post.count_visible_comments.to_s)),
+                        admin_post_path(id: admin_post.id, anchor: "comments", show_comments: true) %></li>
       <% end %>
-      <li><%= link_to ts("Add Comment"), admin_post_path(:id => admin_post.id, :anchor => "comments", :add_comment => true) %></li>
+      <li><%= link_to ts("Add Comment"), admin_post_path(id: admin_post.id, anchor: "comments", add_comment: true) %></li>
     </ul>  
     <!-- END comment section -->
   </div>

--- a/app/views/admin_posts/index.html.erb
+++ b/app/views/admin_posts/index.html.erb
@@ -18,28 +18,8 @@
   <!--main content-->
   <% @admin_posts.each do |admin_post| %>
 
-  <div class="module group" role="article">
-    <div class="header">
-      <h3 class="heading">
-        <%= link_to admin_post.title.html_safe, admin_post %>
-      </h3>
-      <h4 class="heading">
-        <%= ts('Published:') %> <span class="datetime"><%= admin_post.created_at %></span> 
-        <% if logged_in_as_admin? %>
-          <span class="actions"><%= link_to ts("Edit Post"), edit_admin_post_path(@admin_post) %></span>
-        <% end %>
-      </h4>
-    </div>
-    <div class="userstuff">
-      <%=raw sanitize_field(admin_post, :content) %>
-    </div>
-    <% if admin_post.tags.length > 0 %>
-      <ul class="tags">
-        <% for tag in admin_post.tags %>
-          <li><%= link_to tag.name, admin_posts_path(:tag => tag.id), :class => "tag" %></li>
-        <% end %>
-      </ul>
-    <% end %>
+  <div class="news module group" role="article">
+    <%= render "admin_post", admin_post: admin_post %>
     <!-- BEGIN comment section -->
     <h3 class="landmark heading"><%= ts("Comment") %></h3>
     <ul class="actions" role="navigation">

--- a/app/views/admin_posts/show.html.erb
+++ b/app/views/admin_posts/show.html.erb
@@ -33,16 +33,10 @@
       <h4 class="heading">Original: <%= link_to @admin_post.translated_post.title, @admin_post.translated_post %></h4>
     <% elsif !@admin_post.translations.empty? %>
       <h4 class="heading">Translations:</h4>
-      <dl class="language index group">
+      <ul class="commas">
         <% for admin_post in @admin_post.translations %>
-          <dt>
-            <%= link_to admin_post.language.name, language_admin_posts_path(admin_post.language) %>
-          </dt>
-          <dd>
-            <%= link_to admin_post.title.html_safe, admin_post %>
-          </dd>
-        <% end %>
-      </dl>
+          <li><%= link_to admin_post.language.name, admin_post %></li>
+      <% end %>
     <% end %>
   </div>
   <div class="userstuff">

--- a/app/views/admin_posts/show.html.erb
+++ b/app/views/admin_posts/show.html.erb
@@ -27,43 +27,8 @@
     <!--/subnav-->
   </div>
   <!--main content-->
-  <div role="article" class="news group">
-    <div class="header">
-      <h3 class="heading"><%= @admin_post.title.html_safe %></h3>
-    </div>
-    <h4 class="landmark heading"><%= ts("Post Header") %></h4>
-    <div class="wrapper">
-      <dl class="meta">
-        <dt class="published"><%= ts("Published:") %></dt>
-        <dd class="published"><%= @admin_post.created_at %></dd>
-        <% if @admin_post.translated_post %>
-          <dt class="original translations"><%= ts("Original:") %></dt>
-          <dd class="original translations"><%= link_to @admin_post.translated_post.title, @admin_post.translated_post %></dd>
-        <% elsif !@admin_post.translations.empty? %>
-          <dt class="translations"><%= ts("Translations:") %></dt>
-          <dd class="translations">
-            <ul class="languages commas">
-              <% for admin_post in @admin_post.translations %>
-                <li><%= link_to admin_post.language.name, admin_post %></li>
-              <% end %>
-            </ul>
-          </dd>
-        <% end %>
-        <% if @admin_post.tags.length > 0 %>
-          <dt class="tags"><%= ts("Tags:") %></dt>
-          <dd class="tags">
-            <ul class="tags commas">
-              <% for tag in @admin_post.tags %>
-                <li><%= link_to tag.name, admin_posts_path(:tag => tag.id), :class => "tag" %></li>
-              <% end %>
-            </ul>
-          </dd>
-        <% end %>
-      </dl>
-    </div>
-    <div class="userstuff">
-      <%=raw sanitize_field(@admin_post, :content) %>
-    </div>
+  <div role="article" class="news module group">
+    <%= render "admin_post", admin_post: @admin_post %>
   </div>
   <!--/content-->
 

--- a/app/views/admin_posts/show.html.erb
+++ b/app/views/admin_posts/show.html.erb
@@ -5,54 +5,69 @@
     <div class="icon"></div>
     <!--/descriptions-->
     <!--subnav-->
-    <ul class="navigation actions" role="navigation">
-      <% if @previous_admin_post %>
-        <li><%= link_to("Previous Post", @previous_admin_post) %></li>
+    <div class="navigation actions module">
+      <% if logged_in_as_admin? %>
+        <h4 class="landmark heading"><%= ts("Admin Actions") %></h4>
+        <ul class="management actions" role="navigation">
+          <li><%= link_to ts("Edit Post"), edit_admin_post_path(@admin_post) %></li>
+          <li><%= link_to t('admin.admin_nav.delete', default: 'Delete Post'), @admin_post, confirm: 'Are you sure you want to delete this news post?', method: :delete %></li>
+        </ul>
       <% end %>
-      <% if @next_admin_post %>
-        <li><%= link_to("Next Post", @next_admin_post) %></li>
-      <% end %>
-      <li><%= link_to_rss admin_posts_path(:rss) %></li>
-    </ul>
+      <h4 class="landmark heading"><%= ts("News Post Navigation") %></h4>
+      <ul class="actions" role="navigation">
+        <% if @previous_admin_post %>
+          <li><%= link_to("Previous Post", @previous_admin_post) %></li>
+        <% end %>
+        <% if @next_admin_post %>
+          <li><%= link_to("Next Post", @next_admin_post) %></li>
+        <% end %>
+        <li><%= link_to_rss admin_posts_path(:rss) %></li>
+      </ul>
+    </div>
     <!--/subnav-->
   </div>
-<!--main content-->
-<div role="article" class="group">
-  <div class="header">
-    <h3 class="heading">
-      <%= @admin_post.title.html_safe %>
-    </h3>
-      <h4 class="heading">
-        Published: <%= @admin_post.created_at %>
-        <% if logged_in_as_admin? %>
-            <%= link_to ts("Edit Post"), edit_admin_post_path(@admin_post), class: 'action' %>
-            <%= link_to t('admin.admin_nav.delete', default: 'Delete Post'), @admin_post, confirm: 'Are you sure you want to delete this news post?', method: :delete, class: 'action' %>
+  <!--main content-->
+  <div role="article" class="news group">
+    <div class="header">
+      <h3 class="heading"><%= @admin_post.title.html_safe %></h3>
+    </div>
+    <h4 class="landmark heading"><%= ts("Post Header") %></h4>
+    <div class="wrapper">
+      <dl class="meta">
+        <dt class="published"><%= ts("Published:") %></dt>
+        <dd class="published"><%= @admin_post.created_at %></dd>
+        <% if @admin_post.translated_post %>
+          <dt class="original translations"><%= ts("Original:") %></dt>
+          <dd class="original translations"><%= link_to @admin_post.translated_post.title, @admin_post.translated_post %></dd>
+        <% elsif !@admin_post.translations.empty? %>
+          <dt class="translations"><%= ts("Translations:") %></dt>
+          <dd class="translations">
+            <ul class="languages commas">
+              <% for admin_post in @admin_post.translations %>
+                <li><%= link_to admin_post.language.name, admin_post %></li>
+              <% end %>
+            </ul>
+          </dd>
         <% end %>
-      </h4>
-    <% if @admin_post.translated_post %>
-      <h4 class="heading">Original: <%= link_to @admin_post.translated_post.title, @admin_post.translated_post %></h4>
-    <% elsif !@admin_post.translations.empty? %>
-      <h4 class="heading">Translations:</h4>
-      <ul class="commas">
-        <% for admin_post in @admin_post.translations %>
-          <li><%= link_to admin_post.language.name, admin_post %></li>
-      <% end %>
-    <% end %>
-  </div>
-  <div class="userstuff">
+        <% if @admin_post.tags.length > 0 %>
+          <dt class="tags"><%= ts("Tags:") %></dt>
+          <dd class="tags">
+            <ul class="tags commas">
+              <% for tag in @admin_post.tags %>
+                <li><%= link_to tag.name, admin_posts_path(:tag => tag.id), :class => "tag" %></li>
+              <% end %>
+            </ul>
+          </dd>
+        <% end %>
+      </dl>
+    </div>
+    <div class="userstuff">
       <%=raw sanitize_field(@admin_post, :content) %>
+    </div>
   </div>
-  <% if @admin_post.tags.length > 0 %>
-  <ul class="tags">
-    <% for tag in @admin_post.tags %>
-      <li><%= link_to tag.name, admin_posts_path(:tag => tag.id), :class => "tag" %></li>
-    <% end %>
-  </ul>
-  <% end %>
-</div>
-<!--/content-->
+  <!--/content-->
 
-<!-- BEGIN comment section -->
-<%= render :partial => 'comments/commentable', :locals => {:commentable => @admin_post} %>
-<!-- END comment section -->
+  <!-- BEGIN comment section -->
+  <%= render :partial => 'comments/commentable', :locals => {:commentable => @admin_post} %>
+  <!-- END comment section -->
 </div>

--- a/app/views/admin_posts/show.html.erb
+++ b/app/views/admin_posts/show.html.erb
@@ -1,4 +1,4 @@
-<div class="admin home">
+<div class="news admin home">
   <div class="primary header module">
     <!--Descriptive page name, messages and instructions-->
     <h2 class="heading"><%= link_to ts("AO3 News"), admin_posts_path %></h2>

--- a/app/views/admin_posts/show.html.erb
+++ b/app/views/admin_posts/show.html.erb
@@ -10,7 +10,7 @@
         <h4 class="landmark heading"><%= ts("Admin Actions") %></h4>
         <ul class="management actions" role="navigation">
           <li><%= link_to ts("Edit Post"), edit_admin_post_path(@admin_post) %></li>
-          <li><%= link_to t('admin.admin_nav.delete', default: 'Delete Post'), @admin_post, confirm: 'Are you sure you want to delete this news post?', method: :delete %></li>
+          <li><%= link_to t('admin.admin_nav.delete', default: 'Delete Post'), @admin_post, confirm: ts('Are you sure you want to delete this news post?'), method: :delete %></li>
         </ul>
       <% end %>
       <h4 class="landmark heading"><%= ts("News Post Navigation") %></h4>
@@ -33,6 +33,6 @@
   <!--/content-->
 
   <!-- BEGIN comment section -->
-  <%= render :partial => 'comments/commentable', :locals => {:commentable => @admin_post} %>
+  <%= render 'comments/commentable', commentable: @admin_post %>
   <!-- END comment section -->
 </div>

--- a/features/admins/admin_post_news.feature
+++ b/features/admins/admin_post_news.feature
@@ -137,6 +137,14 @@ Feature: Admin Actions to Post News
       And I should see "toaster" within "div.admin.home"
       And I should see "futurama" within "dd.tags"
 
+  Scenario: Admin posts should show both translations and tags
+    Given I have posted an admin post with tags
+      And basic languages
+      And I am logged in as an admin
+    When I make a translation of an admin post
+      And I am logged in as "ordinaryuser"
+    Then I should see a translated admin post with tags
+
   Scenario: If an admin post has characters like & and < and > in the title, the escaped version will not show on the various admin post pages
     Given I am logged in as an admin
     When I follow "Admin Posts"

--- a/features/admins/admin_post_news.feature
+++ b/features/admins/admin_post_news.feature
@@ -135,7 +135,7 @@ Feature: Admin Actions to Post News
       And I press "Post"
     Then I should see "Admin Post was successfully created."
       And I should see "toaster" within "div.admin.home"
-      And I should see "futurama" within ".tags"
+      And I should see "futurama" within "dd.tags"
 
   Scenario: If an admin post has characters like & and < and > in the title, the escaped version will not show on the various admin post pages
     Given I am logged in as an admin

--- a/features/step_definitions/admin_steps.rb
+++ b/features/step_definitions/admin_steps.rb
@@ -1,17 +1,17 @@
 default_settings = {
-  :invite_from_queue_enabled => ArchiveConfig.INVITE_FROM_QUEUE_ENABLED,
-  :invite_from_queue_number => ArchiveConfig.INVITE_FROM_QUEUE_NUMBER,
-  :invite_from_queue_frequency => ArchiveConfig.INVITE_FROM_QUEUE_FREQUENCY,
-  :account_creation_enabled => true,
-  :creation_requires_invite => true,
-  :request_invite_enabled => true,
-  :days_to_purge_unactivated => ArchiveConfig.DAYS_TO_PURGE_UNACTIVATED
+  invite_from_queue_enabled: ArchiveConfig.INVITE_FROM_QUEUE_ENABLED,
+  invite_from_queue_number: ArchiveConfig.INVITE_FROM_QUEUE_NUMBER,
+  invite_from_queue_frequency: ArchiveConfig.INVITE_FROM_QUEUE_FREQUENCY,
+  account_creation_enabled: true,
+  creation_requires_invite: true,
+  request_invite_enabled: true,
+  days_to_purge_unactivated: ArchiveConfig.DAYS_TO_PURGE_UNACTIVATED
 }
 
 def update_settings(settings)
   admin_settings = AdminSetting.first_or_create
   admin_settings.update_attributes(settings)
-  admin_settings.save(:validate => false)
+  admin_settings.save(validate: false)
 end
 
 ### GIVEN
@@ -19,7 +19,7 @@ end
 Given /^I have an AdminSetting$/ do
   unless AdminSetting.first
     settings = AdminSetting.new(default_settings)
-    settings.save(:validate => false)
+    settings.save(validate: false)
   end
 end
 
@@ -42,11 +42,11 @@ Given /^I am logged in as an admin$/ do
   step("I am logged out")
   admin = Admin.find_by_login("testadmin")
   if admin.blank?
-    admin = FactoryGirl.create(:admin, :login => "testadmin", :password => "testadmin", :email => "testadmin@example.org")
+    admin = FactoryGirl.create(:admin, login: "testadmin", password: "testadmin", email: "testadmin@example.org")
   end
   visit admin_login_path
-  fill_in "Admin user name", :with => "testadmin"
-  fill_in "Admin password", :with => "testadmin"
+  fill_in "Admin user name", with: "testadmin"
+  fill_in "Admin password", with: "testadmin"
   click_button "Log in as admin"
   step("I should see \"Successfully logged in\"")
 end
@@ -172,8 +172,8 @@ end
 
 When /^I make an admin post$/ do
   visit new_admin_post_path
-  fill_in("admin_post_title", :with => "Default Admin Post")
-  fill_in("content", :with => "Content of the admin post.")
+  fill_in("admin_post_title", with: "Default Admin Post")
+  fill_in("content", with: "Content of the admin post.")
   click_button("Post")
 end
 
@@ -187,10 +187,10 @@ end
 When /^I make a(?: (\d+)(?:st|nd|rd|th)?)? FAQ post$/ do |n|
   n ||= 1
   visit new_archive_faq_path
-  fill_in("Question*", :with => "Number #{n} Question.")
-  fill_in("Answer*", :with => "Number #{n} posted FAQ, this is.")
-  fill_in("Category name*", :with => "Number #{n} FAQ")
-  fill_in("Anchor name*", :with => "Number#{n}anchor")
+  fill_in("Question*", with: "Number #{n} Question.")
+  fill_in("Answer*", with: "Number #{n} posted FAQ, this is.")
+  fill_in("Category name*", with: "Number #{n} FAQ")
+  fill_in("Anchor name*", with: "Number#{n}anchor")
   click_button("Post")
 end
 
@@ -203,8 +203,8 @@ end
 When /^I make a(?: (\d+)(?:st|nd|rd|th)?)? Admin Post$/ do |n|
   n ||= 1
   visit new_admin_post_path
-  fill_in("admin_post_title", :with => "Amazing News #{n}")
-  fill_in("content", :with => "This is the content for the #{n} Admin Post")
+  fill_in("admin_post_title", with: "Amazing News #{n}")
+  fill_in("content", with: "This is the content for the #{n} Admin Post")
   click_button("Post")
 end
 
@@ -254,10 +254,10 @@ end
 
 When (/^I make a translation of an admin post$/) do
   visit new_admin_post_path
-  fill_in("admin_post_title", :with => "Deutsch Ankuendigung")
-  fill_in("content", :with => "Deutsch Woerter")
+  fill_in("admin_post_title", with: "Deutsch Ankuendigung")
+  fill_in("content", with: "Deutsch Woerter")
   step(%{I select "Deutsch" from "Choose a language"})
-  fill_in("admin_post_translated_post_id", :with => AdminPost.find_by_title("Default Admin Post").id)
+  fill_in("admin_post_translated_post_id", with: AdminPost.find_by_title("Default Admin Post").id)
   click_button("Post")
 end
 

--- a/features/step_definitions/admin_steps.rb
+++ b/features/step_definitions/admin_steps.rb
@@ -264,9 +264,9 @@ end
 Then (/^I should see a translated admin post$/) do
   step(%{I go to the admin-posts page})
   step(%{I should see "Default Admin Post"})
-  step(%{I should not see "Deutsch" within "dd.translations"})
-  step(%{I follow "Default Admin Post"})
   step(%{I should see "Translations: Deutsch"})
+  step(%{I follow "Default Admin Post"})
+  step(%{I should see "Deutsch" within "dd.translations"})
   step(%{I follow "Deutsch"})
   step(%{I should see "Deutsch Woerter"})
 end

--- a/features/step_definitions/admin_steps.rb
+++ b/features/step_definitions/admin_steps.rb
@@ -264,10 +264,10 @@ end
 Then (/^I should see a translated admin post$/) do
   step(%{I go to the admin-posts page})
   step(%{I should see "Default Admin Post"})
-    step(%{I should not see "Deutsch Ankuendigung"})
+  step(%{I should not see "Deutsch" within "dd.translations"})
   step(%{I follow "Default Admin Post"})
-  step(%{I should see "Translations: Deutsch Deutsch Ankuendigung"})
-  step(%{I follow "Deutsch Ankuendigung"})
+  step(%{I should see "Translations: Deutsch"})
+  step(%{I follow "Deutsch"})
   step(%{I should see "Deutsch Woerter"})
 end
 
@@ -276,7 +276,7 @@ Then (/^I should not see a translated admin post$/) do
   step(%{I should see "Default Admin Post"})
   step(%{I should see "Deutsch Ankuendigung"})
   step(%{I follow "Default Admin Post"})
-  step(%{I should not see "Translations: Deutsch Deutsch Ankuendigung"})
+  step(%{I should not see "Translations: Deutsch"})
 end
 
 Then /^logged out users should not see the hidden work "([^\"]*)" by "([^\"]*)"?/ do |work, user|

--- a/features/step_definitions/admin_steps.rb
+++ b/features/step_definitions/admin_steps.rb
@@ -161,6 +161,15 @@ Given /^I have posted an admin post without paragraphs$/ do
   step("I am logged out as an admin")
 end
 
+Given /^I have posted an admin post with tags$/ do
+  step("I am logged in as an admin")
+  visit new_admin_post_path
+  fill_in("admin_post_title", with: "Default Admin Post")
+  fill_in("content", with: "Content of the admin post.")
+  fill_in("admin_post_tag_list", with: "quotes, futurama")
+  click_button("Post")
+end
+
 ### WHEN
 
 When /^I turn off guest downloading$/ do
@@ -269,6 +278,16 @@ Then (/^I should see a translated admin post$/) do
   step(%{I should see "Deutsch" within "dd.translations"})
   step(%{I follow "Deutsch"})
   step(%{I should see "Deutsch Woerter"})
+end
+
+Then (/^I should see a translated admin post with tags$/) do
+  step(%{I go to the admin-posts page})
+  step(%{I should see "Default Admin Post"})
+  step(%{I should see "Tags: quotes futurama"})
+  step(%{I should see "Translations: Deutsch"})
+  step(%{I follow "Default Admin Post"})
+  step(%{I should see "Deutsch" within "dd.translations"})
+  step(%{I should see "futurama" within "dd.tags"})
 end
 
 Then (/^I should not see a translated admin post$/) do

--- a/public/stylesheets/site/2.0/12-group-meta.css
+++ b/public/stylesheets/site/2.0/12-group-meta.css
@@ -73,12 +73,12 @@ dl.meta {
 .news .meta dt, .news .meta dd, .news .meta ul {
   display: inline;
   float: none;
-  line-height: 2;
 }
 
 .news .meta dd:after {
   content: " ";
   display: block;
+  margin-bottom: 0.643em;
 }
 
 /* TODO the post new work form needs its classes changed so these overrides are no longer needed */

--- a/public/stylesheets/site/2.0/12-group-meta.css
+++ b/public/stylesheets/site/2.0/12-group-meta.css
@@ -73,7 +73,7 @@ dl.meta {
 .news .meta dt, .news .meta dd, .news .meta ul {
   display: inline;
   float: none;
-  margin-left: 0; /* to avoid problems in narrow width */
+  margin-left: 0;
 }
 
 .news .meta dd:after {

--- a/public/stylesheets/site/2.0/12-group-meta.css
+++ b/public/stylesheets/site/2.0/12-group-meta.css
@@ -73,6 +73,7 @@ dl.meta {
 .news .meta dt, .news .meta dd, .news .meta ul {
   display: inline;
   float: none;
+  margin-left: 0; /* to avoid problems in narrow width */
 }
 
 .news .meta dd:after {

--- a/public/stylesheets/site/2.0/12-group-meta.css
+++ b/public/stylesheets/site/2.0/12-group-meta.css
@@ -78,7 +78,7 @@ dl.meta {
 .news .meta dd:after {
   content: " ";
   display: block;
-  margin-bottom: 0.643em;
+  height: 0.643em;
 }
 
 /* TODO the post new work form needs its classes changed so these overrides are no longer needed */

--- a/public/stylesheets/site/2.0/12-group-meta.css
+++ b/public/stylesheets/site/2.0/12-group-meta.css
@@ -54,13 +54,34 @@ dl.meta {
   margin: 0;
 }
 
-/*CONTEXTS */
+/* CONTEXTS */
 
 .dashboard .meta .clear {
   clear: none;
   clear: right;
 }
 
+.news .wrapper {
+    box-shadow: none;
+}
+
+.news dl.meta {
+  border: none;
+  padding: 0;
+}
+
+.news .meta dt, .news .meta dd, .news .meta ul {
+  display: inline;
+  float: none;
+  line-height: 2;
+}
+
+.news .meta dd:after {
+  content: " ";
+  display: block;
+}
+
+/* TODO the post new work form needs its classes changed so these overrides are no longer needed */
 .post .meta dd ul li {
   display: block;
 }


### PR DESCRIPTION
https://otwarchive.atlassian.net/browse/AO3-4123

This should go after #2411 -- the relevant commits here are https://github.com/otwcode/otwarchive/pull/2412/commits/a7c11a328b24e5df2c9813a0bdae21d05f930d98 and https://github.com/otwcode/otwarchive/pull/2412/commits/689b4769fcd74c5ecf5bad4bd9837b46ae192e57 and https://github.com/otwcode/otwarchive/pull/2412/commits/7f6ac63b8e9837aba2e189ddd2ac8983f897c47c

Per a discussion with Translation chair Priscilla, this sorts the translations by the language's short name, so the order should match the order of languages in the "Language" filter menu at the top of the news post index

Longterm, Translation would prefer to be able to set a name for sorting, the same way Tag Wranglers do with fandoms