### PR TITLE
AO3-4123 Sort admin post translations by languages' short names

### DIFF
--- a/app/views/admin_posts/_admin_post.html.erb
+++ b/app/views/admin_posts/_admin_post.html.erb
@@ -16,7 +16,7 @@
       <dt class="translations"><%= ts("Translations:") %></dt>
       <dd class="translations">
         <ul class="languages commas">
-          <% for translation in admin_post.translations %>
+          <% for translation in admin_post.translations.sort_by { |translation| translation.language.short } %>
             <li><%= link_to translation.language.name, translation %></li>
           <% end %>
         </ul>


### PR DESCRIPTION
https://otwarchive.atlassian.net/browse/AO3-4123

Per a discussion with Translation chair Priscilla, this sorts the translations by the language's short name, so the order should match the order of languages in the "Language" filter menu at the top of the news post index

Longterm, Translation would prefer to be able to set a name for sorting, the same way Tag Wranglers do with fandoms