### PR TITLE
AO3-4536 guest email blacklist clean

### DIFF
--- a/app/controllers/admin/blacklisted_emails_controller.rb
+++ b/app/controllers/admin/blacklisted_emails_controller.rb
@@ -1,0 +1,35 @@
+class Admin::BlacklistedEmailsController < ApplicationController
+
+  before_filter :admin_only
+
+  def index
+    @admin_blacklisted_email = AdminBlacklistedEmail.new 
+    if params[:query]
+      @admin_blacklisted_emails = AdminBlacklistedEmail.where(["email LIKE ?", '%' + params[:query] + '%'])
+      @admin_blacklisted_emails = @admin_blacklisted_emails.paginate(page: params[:page], per_page: ArchiveConfig.ITEMS_PER_PAGE)
+    end
+  end
+
+  def new
+    @admin_blacklisted_email = AdminBlacklistedEmail.new
+  end
+
+  def create
+    @admin_blacklisted_email = AdminBlacklistedEmail.new(params[:admin_blacklisted_email])
+
+    if @admin_blacklisted_email.save
+      flash[:notice] = ts("Email address #{@admin_blacklisted_email.email} added to blacklist.")
+      redirect_to admin_blacklisted_emails_url
+    else
+      render action: "index"
+    end
+  end
+
+  def destroy
+    @admin_blacklisted_email = AdminBlacklistedEmail.find(params[:id])
+    @admin_blacklisted_email.destroy
+    
+    flash[:notice] = ts("Email address #{@admin_blacklisted_email.email} removed from blacklist.")
+    redirect_to admin_blacklisted_emails_url
+  end
+end

--- a/app/models/admin_blacklisted_email.rb
+++ b/app/models/admin_blacklisted_email.rb
@@ -1,0 +1,36 @@
+class AdminBlacklistedEmail < ActiveRecord::Base
+  attr_accessible :email
+
+  before_validation :canonicalize_email
+  
+  validates :email, presence: true, uniqueness: true, email_veracity: true
+
+  def canonicalize_email
+    self.email = AdminBlacklistedEmail.canonical_email(self.email) if self.email
+  end
+  
+  # Produces a canonical version of a given email reduced to its simplest form
+  # This is what we store in the db, so that if we subsequently check a submitted email,
+  #  we only need to clean the submitted email the same way and look for it.
+  def self.canonical_email(email_to_clean)
+    canonical_email = email_to_clean.downcase
+    canonical_email.strip!
+    canonical_email.sub!('@googlemail.com','@gmail.com')
+
+    # strip periods from gmail addresses
+    if (matchdata = canonical_email.match(/(.+)\@gmail\.com/))
+      canonical_email = matchdata[1].gsub('.', '') + "@gmail.com"
+    end
+
+    # strip out anything after a +
+    canonical_email.sub!(/(\+.*)(@.*$)/, '\2')
+    
+    return canonical_email
+  end
+    
+  # Check if an email is
+  def self.is_blacklisted?(email_to_check)
+    AdminBlacklistedEmail.where(email: AdminBlacklistedEmail.canonical_email(email_to_check)).exists?
+  end
+  
+end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -12,7 +12,7 @@ class Comment < ActiveRecord::Base
   has_many :users, :through => :inbox_comments
 
   validates_presence_of :name, :unless => :pseud_id
-  validates :email, :email_veracity => {:on => :create, :unless => :pseud_id}
+  validates :email, email_veracity: {on: :create, unless: :pseud_id}, email_blacklist: {on: :create, unless: :pseud_id}
 
   validates_presence_of :content
   validates_length_of :content,

--- a/app/validators/email_blacklist_validator.rb
+++ b/app/validators/email_blacklist_validator.rb
@@ -1,0 +1,10 @@
+class EmailBlacklistValidator < ActiveModel::EachValidator
+  def validate_each(record,attribute,value)
+    if AdminBlacklistedEmail.is_blacklisted?(value)
+      record.errors[attribute] << (options[:message] || I18n.t('validators.email.blacklist'))
+      return false
+    else
+      return true
+    end
+  end
+end

--- a/app/validators/email_veracity_validator.rb
+++ b/app/validators/email_veracity_validator.rb
@@ -26,9 +26,9 @@ class EmailVeracityValidator < ActiveModel::EachValidator
     end
     unless result
       if options[:allow_blank]
-        record.errors[attribute] << (options[:message] ||  I18n.t('email_invalid', :default => 'does not seem to be a valid address. Please use a different address or leave blank.'))
+        record.errors[attribute] << (options[:message] ||  I18n.t('validators.email.veracity.allow_blank'))
       else
-        record.errors[attribute] << (options[:message] || I18n.t('email_invalid', :default => 'does not seem to be a valid address.'))
+        record.errors[attribute] << (options[:message] || I18n.t('validators.email.veracity.no_blank'))
       end
     end
   end

--- a/app/views/admin/_header.html.erb
+++ b/app/views/admin/_header.html.erb
@@ -20,6 +20,7 @@
       <li><%= span_if_current ts('Wrangling Guidelines', key: 'header'), wrangling_guidelines_path %></li>
     </ul>
   </li>
+  <li><%= link_to ts('Blacklist', key: 'header'), admin_blacklisted_emails_path %></li>
   <li><%= link_to ts('Settings', key: 'header'), admin_settings_path %></li>
   <li><%= link_to ts('Banners', key: 'header'), admin_banners_path %></li>
   <li class="dropdown">

--- a/app/views/admin/blacklisted_emails/index.html.erb
+++ b/app/views/admin/blacklisted_emails/index.html.erb
@@ -1,57 +1,56 @@
 <div class="admin">
   <!--Descriptive page name, messages and instructions-->
   <h2 class="heading"><%= t('admin.admin_email_blacklist.index.page_heading', default: "Manage Email Blacklist") %></h2>
-  
-  <p> <%= ts("Blacklisted email addresses cannot be used in guest comments. They will not affect users who share the same email address or prevent invitations from being sent or used by those email addresses. All emails are stored in a single canonical format and common variants of the same address are not allowed (for instance, foo+whatever@bar.com will not be allowed if foo@bar.com is blacklisted).") %></p>
+
+  <ul class="notes">
+    <li><%= ts("Blacklisted email addresses cannot be used in guest comments.") %></li>
+    <li><%= ts("They will not affect users who share the same email address or prevent invitations from being sent to or used by those email addresses.") %></li>
+    <li><%= ts("All emails are stored in a single canonical format and common variants of the same address are not allowed (for instance, foo+whatever@bar.com will not be allowed if foo@bar.com is blacklisted).") %></li>
+  </ul>
   <!--/descriptions-->
 
   <!--main content-->
-  <h3 class="heading"><%= ts("Add email address to blacklist")%></h3>
-  
-  <%= form_for(@admin_blacklisted_email) do |f| %>
+  <h3 class="heading"><%= ts("Add email address to blacklist") %></h3>
+
+  <%= form_for(@admin_blacklisted_email, html: { class: "simple post" }) do |f| %>
     <%= error_messages_for @admin_blacklisted_email %>
     <fieldset>
       <p>
-        <%= f.label :email, ts("Email") %>
+        <%= f.label :email, ts("Email to add") %>
         <%= f.text_field :email %>
-        <span class="submit actions">
-          <%= f.submit ts("Add To Blacklist") %>
-        </span>
+        <%= f.submit ts("Add To Blacklist") %>
       </p>
     </fieldset>
   <% end %>
   
   <h3 class="heading"><%= ts("Find blacklisted emails")%></h3>
-    
+
   <!-- search form -->
-  <%= form_tag url_for(controller: "admin/blacklisted_emails", action: "index"), method: :get, class: "search", role: "search" do %>
+  <%= form_tag url_for(controller: "admin/blacklisted_emails", action: "index"), method: :get, class: "simple search", role: "search" do %>
     <fieldset>
       <p>
-        <%= label_tag "query", ts("Find Email") %>
+        <%= label_tag "query", ts("Email to find") %>
         <%= text_field_tag "query", params[:query] %>
-        <span class="submit actions">
-          <%= submit_tag ts("Find") %>
-        </span>
+        <%= submit_tag ts("Search Blacklist") %>
       </p>
     </fieldset>
   <% end %>
 
   <!-- list of search results -->
-  <div id="search results">
-    <% if @admin_blacklisted_emails %>
+  <% if @admin_blacklisted_emails %>
+    <div class="results module">
       <h3 class="heading"><%= t('admin.blacklist.emails_found', count: @admin_blacklisted_emails.count) %></h3>
       <% if @admin_blacklisted_emails.count > 0 %>
-        <ul class="index group">
+        <ol class="emails index group">
           <% @admin_blacklisted_emails.each do |blacklisted_email| %>
           <li>
-            [<%= link_to "Remove", blacklisted_email, class: "actions", method: :delete %>]
-            <%= blacklisted_email.email %>
+            <%= link_to ts("Remove %{email}", email: blacklisted_email.email), blacklisted_email, method: :delete, confirm: ts("Are you sure you want to remove %{email} from the blacklist?", email: blacklisted_email.email) %>
           </li>
           <% end %>
         </ul>
         <%= will_paginate @admin_blacklisted_emails %>
       <% end %>
-    <% end %>
-  </div>
+    </div>
+  <% end %>
   <!--/content-->
 </div>

--- a/app/views/admin/blacklisted_emails/index.html.erb
+++ b/app/views/admin/blacklisted_emails/index.html.erb
@@ -1,0 +1,57 @@
+<div class="admin">
+  <!--Descriptive page name, messages and instructions-->
+  <h2 class="heading"><%= t('admin.admin_email_blacklist.index.page_heading', default: "Manage Email Blacklist") %></h2>
+  
+  <p> <%= ts("Blacklisted email addresses cannot be used in guest comments. They will not affect users who share the same email address or prevent invitations from being sent or used by those email addresses. All emails are stored in a single canonical format and common variants of the same address are not allowed (for instance, foo+whatever@bar.com will not be allowed if foo@bar.com is blacklisted).") %></p>
+  <!--/descriptions-->
+
+  <!--main content-->
+  <h3 class="heading"><%= ts("Add email address to blacklist")%></h3>
+  
+  <%= form_for(@admin_blacklisted_email) do |f| %>
+    <%= error_messages_for @admin_blacklisted_email %>
+    <fieldset>
+      <p>
+        <%= f.label :email, ts("Email") %>
+        <%= f.text_field :email %>
+        <span class="submit actions">
+          <%= f.submit ts("Add To Blacklist") %>
+        </span>
+      </p>
+    </fieldset>
+  <% end %>
+  
+  <h3 class="heading"><%= ts("Find blacklisted emails")%></h3>
+    
+  <!-- search form -->
+  <%= form_tag url_for(controller: "admin/blacklisted_emails", action: "index"), method: :get, class: "search", role: "search" do %>
+    <fieldset>
+      <p>
+        <%= label_tag "query", ts("Find Email") %>
+        <%= text_field_tag "query", params[:query] %>
+        <span class="submit actions">
+          <%= submit_tag ts("Find") %>
+        </span>
+      </p>
+    </fieldset>
+  <% end %>
+
+  <!-- list of search results -->
+  <div id="search results">
+    <% if @admin_blacklisted_emails %>
+      <h3 class="heading"><%= t('admin.blacklist.emails_found', count: @admin_blacklisted_emails.count) %></h3>
+      <% if @admin_blacklisted_emails.count > 0 %>
+        <ul class="index group">
+          <% @admin_blacklisted_emails.each do |blacklisted_email| %>
+          <li>
+            [<%= link_to "Remove", blacklisted_email, class: "actions", method: :delete %>]
+            <%= blacklisted_email.email %>
+          </li>
+          <% end %>
+        </ul>
+        <%= will_paginate @admin_blacklisted_emails %>
+      <% end %>
+    <% end %>
+  </div>
+  <!--/content-->
+</div>

--- a/app/views/invite_requests/index.html.erb
+++ b/app/views/invite_requests/index.html.erb
@@ -2,9 +2,9 @@
 <h2 class="heading"><%= ts("Request an Invitation") %></h2>
 
 <p><%= ts("To get a free Archive of Our Own account while we're in beta, you'll need an invitation. There are currently
-  %{count} people on the waiting list.", :count => InviteRequest.count) %>
+  %{count} people on the waiting list.", count: InviteRequest.count) %>
   <% if AdminSetting.invite_from_queue_enabled? %>
-    <%= ts("We are sending out %{invites} invitations per day.", :invites => AdminSetting.invite_from_queue_number) %>
+    <%= ts("We are sending out %{invites} invitations per day.", invites: AdminSetting.invite_from_queue_number) %>
   <% end %></p>
 <!--/descriptions-->
 
@@ -12,8 +12,7 @@
 <% if @admin_settings.invite_from_queue_enabled? %>
   <h3 class="heading"><%= ts("Add yourself to the list") %></h3>
 
-  <!--BACK END, please move this class "simple" into the form and lose this div-->
-  <%= form_for(@invite_request, :html => {:class => "simple"}) do |f| %>
+  <%= form_for(@invite_request, html: {class: "simple"}) do |f| %>
     <%= error_messages_for @invite_request %>
     <fieldset>
       <p>
@@ -29,7 +28,7 @@
 
 <h3 class="heading"><%= ts("Wondering how long you'll have to wait?") %></h3>
 
-<%= form_tag url_for(:action => :show), {:remote => true, :method => :get, :class => "simple"} do %>
+<%= form_tag url_for(action: :show), {remote: true, method: :get, class: "simple"} do %>
 <fieldset>
   <p>
     <%= label_tag :email %>

--- a/config/locales/en-US.yml
+++ b/config/locales/en-US.yml
@@ -3,6 +3,12 @@
 # Use this as the base for the locale file of your language.
 
 "en-US":
+  admin:
+    blacklist:
+      emails_found: 
+        one: "one email found"
+        other: "%{count} emails found"
+  
   date:
     formats:
       default: "%Y-%m-%d"
@@ -269,3 +275,11 @@
       para1: "The following abuse report has been sent to the Abuse team:"
       url_para: "URL of the page the abuse is on:"
       description_para: "Description of the abuse:"
+  
+  validators:
+    email:
+      blacklist: "has been blocked at the owner's request. That means it can't be used in guest comments. Please check the address to make sure it's yours to use and contact AO3 Support if you have any questions."
+      veracity:
+        allow_blank: "does not seem to be a valid address. Please use a different address or leave blank."
+        no_blank: "does not seem to be a valid address."
+        

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,6 +1,12 @@
 # Sample localization file for English. Add more files in this directory for other locales.
 # See http://github.com/svenfuchs/rails-i18n/tree/master/rails%2Flocale for starting points.
 en:
+  admin:
+    blacklist:
+      emails_found: 
+        one: "one email found"
+        other: "%{count} emails found"
+  
   mailer:
     general: 
       footer: 
@@ -52,3 +58,11 @@ en:
       para1: "The following abuse report has been sent to the Abuse team:"
       url_para: "URL of the page the abuse is on:"
       description_para: "Description of the abuse:"
+
+  validators:
+    email:
+      blacklist: "has been blocked at the owner's request. That means it can't be used in guest comments. Please check the address to make sure it's yours to use and contact AO3 Support if you have any questions."
+      veracity:
+        allow_blank: "does not seem to be a valid address. Please use a different address or leave blank."
+        no_blank: "does not seem to be a valid address."  
+        

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -132,6 +132,7 @@ Otwarchive::Application.routes.draw do
         get :confirm_delete
       end
     end
+    resources :blacklisted_emails, only: [:index, :new, :create, :destroy]
     resources :settings
     resources :skins do
       collection do

--- a/db/migrate/20160331005706_create_admin_blacklisted_emails.rb
+++ b/db/migrate/20160331005706_create_admin_blacklisted_emails.rb
@@ -1,0 +1,11 @@
+class CreateAdminBlacklistedEmails < ActiveRecord::Migration
+  def change
+    create_table :admin_blacklisted_emails do |t|
+      t.string :email
+
+      t.timestamps
+    end
+
+    add_index :admin_blacklisted_emails, :email, unique: true
+  end
+end

--- a/factories/admin_blacklisted_email.rb
+++ b/factories/admin_blacklisted_email.rb
@@ -1,0 +1,7 @@
+require 'faker'
+
+FactoryGirl.define do
+  factory :admin_blacklisted_email do
+    email
+  end
+end

--- a/features/admins/admin_email_blacklist.feature
+++ b/features/admins/admin_email_blacklist.feature
@@ -1,0 +1,61 @@
+@admin
+Feature: Admin email blacklist
+  In order to prevent the use of certain email addresses in guest comments
+  As an an admin
+  I want to be able to manage a blacklist of email addresses
+  
+Scenario: Add email address to blacklist
+  Given I am logged in as an admin
+  Then I should see "Blacklist"
+  When I follow "Blacklist"
+  Then I should see "Find blacklisted emails"
+    And I should see "Add email address to blacklist"
+    And I should see "Email"
+  When I fill in "Email" with "foo@bar.com"
+    And I press "Add To Blacklist"
+  Then I should see "Email address foo@bar.com added to blacklist"
+    And the address "foo@bar.com" should be in the blacklist
+
+Scenario: Remove email address from blacklist
+  Given I am logged in as an admin
+    And I have blacklisted the address "foo@bar.com"
+  When I follow "Blacklist"
+    And I fill in "Find Email" with "bar"
+    And I press "Find"
+  Then I should see "email found"
+    And I should see "foo@bar.com"
+  When I follow "Remove"
+  Then I should see "Email address foo@bar.com removed from blacklist"
+    And the address "foo@bar.com" should not be in the blacklist
+    
+Scenario: Blacklisted email addresses should not be usable in guest comments
+  Given I am logged in as an admin
+    And I have blacklisted the address "foo@bar.com"
+    And I am logged in as "author"
+    And I post the work "New Work"
+  When I post the comment "I loved this" on the work "New Work" as a guest with email "foo@bar.com"
+  Then I should see "has been blocked at the owner's request"
+    And I should not see "Comments (1)"
+  When I fill in "Email" with "someone@bar.com"
+    And I press "Comment"
+  Then I should see "Comments (1)"
+
+Scenario: Variants of blacklisted email addresses should not be usable
+  Given I am logged in as an admin
+  When I have blacklisted the address "foo.bar+gloop@googlemail.com"
+  Then the address "foobar@gmail.com" should be in the blacklist
+  When I am logged out
+  Then I should not be able to comment with the address "foobar@gmail.com"
+    And I should not be able to comment with the address "foobar+baz@gmail.com"
+    And I should not be able to comment with the address "foo.bar@gmail.com"
+    And I should be able to comment with the address "whee@gmail.com"
+
+Scenario: Blacklisting a user's email should not affect their ability to post comments
+  Given the user "author" exists and is activated
+    And I am logged in as an admin
+    And I have blacklisted the address for user "author"
+  When I am logged in as "author"
+    And I post the work "New Work"
+    And I post a comment "here's a great comment"
+  Then I should see "Comment created!"
+  

--- a/features/admins/admin_email_blacklist.feature
+++ b/features/admins/admin_email_blacklist.feature
@@ -20,8 +20,8 @@ Scenario: Remove email address from blacklist
   Given I am logged in as an admin
     And I have blacklisted the address "foo@bar.com"
   When I follow "Blacklist"
-    And I fill in "Find Email" with "bar"
-    And I press "Find"
+    And I fill in "Email to find" with "bar"
+    And I press "Search Blacklist"
   Then I should see "email found"
     And I should see "foo@bar.com"
   When I follow "Remove"
@@ -58,4 +58,3 @@ Scenario: Blacklisting a user's email should not affect their ability to post co
     And I post the work "New Work"
     And I post a comment "here's a great comment"
   Then I should see "Comment created!"
-  

--- a/features/step_definitions/admin_steps.rb
+++ b/features/step_definitions/admin_steps.rb
@@ -359,3 +359,44 @@ When(/^the user "(.*?)" is unbanned in the background/) do |user|
   u = User.find_by_login(user)
   u.update_attribute(:banned, false)
 end
+
+Given(/^I have blacklisted the address "([^"]*)"$/) do |email|
+  visit admin_blacklisted_emails_url
+  fill_in("Email", with: email)
+  click_button("Add To Blacklist")
+end
+
+Given(/^I have blacklisted the address for user "([^"]*)"$/) do |user|
+  visit admin_blacklisted_emails_url
+  u = User.find_by_login(user)
+  fill_in("Email", with: u.email)
+  click_button("Add To Blacklist")
+end
+
+Then(/^the address "([^"]*)" should be in the blacklist$/) do |email|
+  visit admin_blacklisted_emails_url
+  fill_in("Find Email", with: email)
+  click_button("Find")
+  assert page.should have_content(email)
+end
+
+Then(/^the address "([^"]*)" should not be in the blacklist$/) do |email|
+  visit admin_blacklisted_emails_url
+  fill_in("Find Email", with: email)
+  click_button("Find")
+  step %{I should see "0 emails found"}
+end
+
+Then(/^I should not be able to comment with the address "([^"]*)"$/) do |email|
+  step %{the work "New Work"}
+  step %{I post the comment "I loved this" on the work "New Work" as a guest with email "#{email}"}
+  step %{I should see "has been blocked at the owner's request"}
+  step %{I should not see "Comment created!"}
+end
+
+Then(/^I should be able to comment with the address "([^"]*)"$/) do |email|
+  step %{the work "New Work"}
+  step %{I post the comment "I loved this" on the work "New Work" as a guest with email "#{email}"}
+  step %{I should not see "has been blocked at the owner's request"}
+  step %{I should see "Comment created!"}
+end

--- a/features/step_definitions/admin_steps.rb
+++ b/features/step_definitions/admin_steps.rb
@@ -369,21 +369,21 @@ end
 Given(/^I have blacklisted the address for user "([^"]*)"$/) do |user|
   visit admin_blacklisted_emails_url
   u = User.find_by_login(user)
-  fill_in("Email", with: u.email)
+  fill_in("admin_blacklisted_email_email", with: u.email)
   click_button("Add To Blacklist")
 end
 
 Then(/^the address "([^"]*)" should be in the blacklist$/) do |email|
   visit admin_blacklisted_emails_url
-  fill_in("Find Email", with: email)
-  click_button("Find")
+  fill_in("Email to find", with: email)
+  click_button("Search Blacklist")
   assert page.should have_content(email)
 end
 
 Then(/^the address "([^"]*)" should not be in the blacklist$/) do |email|
   visit admin_blacklisted_emails_url
-  fill_in("Find Email", with: email)
-  click_button("Find")
+  fill_in("Email to find", with: email)
+  click_button("Search Blacklist")
   step %{I should see "0 emails found"}
 end
 

--- a/features/step_definitions/comment_steps.rb
+++ b/features/step_definitions/comment_steps.rb
@@ -54,11 +54,11 @@ When /^I post the comment "([^"]*)" on the work "([^"]*)"$/ do |comment_text, wo
   click_button("Comment")
 end
 
-When /^I post the comment "([^"]*)" on the work "([^"]*)" as a guest$/ do |comment_text, work|
+When /^I post the comment "([^"]*)" on the work "([^"]*)" as a guest(?: with email "([^"]*)")?$/ do |comment_text, work, email|
   step "I am logged out"
   step "I set up the comment \"#{comment_text}\" on the work \"#{work}\""
   fill_in("Name", :with => "guest")
-  fill_in("Email", :with => "guest@foo.com")
+  fill_in("Email", :with => (email || "guest@foo.com"))
   click_button "Comment"
 end
 

--- a/features/step_definitions/comment_steps.rb
+++ b/features/step_definitions/comment_steps.rb
@@ -46,7 +46,7 @@ end
 When /^I set up the comment "([^"]*)" on the work "([^"]*)"$/ do |comment_text, work|
   work = Work.find_by_title!(work)
   visit work_url(work)
-  fill_in("comment[content]", :with => comment_text)
+  fill_in("comment[content]", with: comment_text)
 end
 
 When /^I post the comment "([^"]*)" on the work "([^"]*)"$/ do |comment_text, work|
@@ -57,20 +57,20 @@ end
 When /^I post the comment "([^"]*)" on the work "([^"]*)" as a guest(?: with email "([^"]*)")?$/ do |comment_text, work, email|
   step "I am logged out"
   step "I set up the comment \"#{comment_text}\" on the work \"#{work}\""
-  fill_in("Name", :with => "guest")
-  fill_in("Email", :with => (email || "guest@foo.com"))
+  fill_in("Name", with: "guest")
+  fill_in("Email", with: (email || "guest@foo.com"))
   click_button "Comment"
 end
 
 When /^I edit a comment$/ do
   step %{I follow "Edit"}
-  fill_in("comment[content]", :with => "Edited comment")
+  fill_in("comment[content]", with: "Edited comment")
   click_button "Update"
 end
 
 # this step assumes we are on a page with a comment form
 When /^I post a comment "([^"]*)"$/ do |comment_text|
-  fill_in("comment[content]", :with => comment_text)
+  fill_in("comment[content]", with: comment_text)
   click_button("Comment")
 end
 
@@ -79,7 +79,7 @@ When /^I reply to a comment with "([^"]*)"$/ do |comment_text|
   step %{I follow "Reply"}
   step %{I should see the reply to comment form}
   with_scope(".odd") do
-    fill_in("comment[content]", :with => comment_text)
+    fill_in("comment[content]", with: comment_text)
     click_button("Comment")
   end
 end
@@ -98,7 +98,7 @@ end
 
 When /^I compose an invalid comment(?: within "([^"]*)")?$/ do |selector|
   with_scope(selector) do
-    fill_in("Comment", :with => %/Sed mollis sapien ac massa pulvinar facilisis. Nulla rhoncus neque nisi. Integer sit amet nulla vel orci hendrerit aliquam. Proin vehicula bibendum vulputate. Nullam porttitor, arcu eu mollis accumsan, turpis justo ornare tellus, ac congue lectus purus ut risus. Phasellus feugiat, orci id tempor elementum, sapien nulla dignissim sapien, dictum eleifend nisl erat vitae urna. Cras imperdiet bibendum porttitor. Suspendisse vitae tellus nibh, vel facilisis magna. Quisque nec massa augue. Pellentesque in ipsum lacus. Aenean mauris leo, viverra sit amet fringilla sit amet, volutpat eu risus. Etiam scelerisque, nibh a condimentum eleifend, augue ipsum blandit tortor, lacinia pharetra ante felis eget lorem. Proin tristique dictum placerat. Aenean commodo imperdiet massa et auctor. Phasellus eleifend posuere varius.
+    fill_in("Comment", with: %/Sed mollis sapien ac massa pulvinar facilisis. Nulla rhoncus neque nisi. Integer sit amet nulla vel orci hendrerit aliquam. Proin vehicula bibendum vulputate. Nullam porttitor, arcu eu mollis accumsan, turpis justo ornare tellus, ac congue lectus purus ut risus. Phasellus feugiat, orci id tempor elementum, sapien nulla dignissim sapien, dictum eleifend nisl erat vitae urna. Cras imperdiet bibendum porttitor. Suspendisse vitae tellus nibh, vel facilisis magna. Quisque nec massa augue. Pellentesque in ipsum lacus. Aenean mauris leo, viverra sit amet fringilla sit amet, volutpat eu risus. Etiam scelerisque, nibh a condimentum eleifend, augue ipsum blandit tortor, lacinia pharetra ante felis eget lorem. Proin tristique dictum placerat. Aenean commodo imperdiet massa et auctor. Phasellus eleifend posuere varius.
 Sed bibendum nisl vel ligula rhoncus at laoreet lorem lacinia. Vivamus est est, euismod vel pretium in, aliquam ac turpis. Integer ac leo sem, vel egestas lacus. Duis id nibh magna, vel adipiscing erat. Aliquam arcu velit, laoreet eget laoreet eget, semper id augue. Nullam volutpat pretium turpis vitae molestie. Ut id nisi eget nibh blandit blandit malesuada et sem. Fusce at accumsan erat. Sed sed adipiscing tortor. Proin vitae eros eget neque dignissim ullamcorper. Vestibulum eleifend nisl sed erat molestie suscipit. Fusce rutrum dignissim diam vel ultricies. Proin nec consequat velit. Aliquam eu nulla urna. Morbi ac orci nisl.
 Vivamus vitae felis erat, a hendrerit nisi. Nullam et nunc sed est laoreet tempus non at nibh. Pellentesque tincidunt, diam eu vestibulum pretium, diam metus volutpat risus, ut mollis augue dolor quis ligula. Fusce in placerat leo. Nullam quis orci dui. Donec ultrices quam ut metus blandit cursus. Quisque lobortis elit sit amet libero mollis quis egestas ipsum faucibus. Curabitur sit amet sollicitudin metus. Vivamus sit amet justo eget felis dictum scelerisque in eu mauris. Vestibulum in diam ligula, et convallis ante. Praesent risus magna, adipiscing in vehicula eu, interdum eu arcu. Duis in nisl libero, nec posuere massa. Vestibulum pretium fermentum dui et dignissim. Mauris at diam sed purus faucibus tristique. Maecenas non orci et augue dignissim tempor. Sed vestibulum condimentum faucibus.
 Morbi nec ullamcorper dolor. In luctus vulputate arcu et egestas. Nullam at pretium enim. Nulla congue tincidunt dignissim. Fusce malesuada odio nec turpis sagittis et accumsan tellus iaculis. Mauris eu libero non diam pretium feugiat quis in mauris. Vestibulum ut facilisis massa. Cras est metus, pulvinar eget ullamcorper in, eleifend id est. Ut ac bibendum elit. Vestibulum quis eros sem. Duis elementum congue lorem, nec semper justo adipiscing vitae. Nam eget velit est, nec varius leo. Quisque aliquet aliquet elit, eu elementum enim lacinia aliquam. Suspendisse laoreet convallis interdum. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. In quis velit massa. Nullam lectus risus, condimentum ac fringilla eu, pretium sed metus.

--- a/features/step_definitions/work_steps.rb
+++ b/features/step_definitions/work_steps.rb
@@ -146,8 +146,10 @@ Given /^the chaptered work with comments setup$/ do
 end
 
 Given /^the work "([^\"]*)"$/ do |work|
-  step %{I have a work "#{work}"}
-  step %{I am logged out}
+  unless Work.where(title: work).exists?
+    step %{I have a work "#{work}"}
+    step %{I am logged out}
+  end
 end
 
 ### WHEN

--- a/features/support/factories.rb
+++ b/features/support/factories.rb
@@ -29,6 +29,10 @@ FactoryGirl.define do
     f.sequence(:email) { |n| "foo#{n}@archiveofourown.org" }
   end
 
+  factory :admin_blacklisted_email do |f|
+    f.sequence(:email) {|n| "foo#{n}@ao3.org"}
+  end
+
   factory :admin_post do |f|
     f.sequence(:title) { |n| "Amazing News #{n}"}
     f.sequence(:content) {|n| "This is the content for the #{n} Admin Post"}

--- a/features/support/paths.rb
+++ b/features/support/paths.rb
@@ -169,6 +169,8 @@ module NavigationHelpers
       admin_settings_path      
     when /^the admin-notices page$/i
       notify_admin_users_path
+    when /^the admin-blacklist page$/i
+      admin_blacklisted_emails_path
     when /^the FAQ reorder page$/i
       manage_archive_faqs_path
     when /^the Wrangling Guidelines reorder page$/i

--- a/public/stylesheets/site/2.0/07-interactions.css
+++ b/public/stylesheets/site/2.0/07-interactions.css
@@ -558,6 +558,10 @@ form.simple span.actions {
   float: none;
 }
 
+.simple input[type="submit"] {
+  margin: 0;
+}
+
 /* WIDGET: TOGGLED FORMS (SHOW/HIDE bookmark and collection - hidden with jS) */
 
 .toggled form dd, .dynamic form dd {

--- a/spec/models/admin_blacklisted_email_spec.rb
+++ b/spec/models/admin_blacklisted_email_spec.rb
@@ -1,0 +1,58 @@
+require 'spec_helper'
+
+describe AdminBlacklistedEmail, :ready do
+
+  it "can be created" do
+    expect(create(:admin_blacklisted_email)).to be_valid
+  end
+
+  context "invalid" do
+    let(:blacklisted_without_email) {build(:admin_blacklisted_email, email: nil)}
+    it 'is invalid without an email' do
+      expect(blacklisted_without_email.save).to be_falsey
+      expect(blacklisted_without_email.errors[:email]).not_to be_empty
+    end
+  end
+
+  context "uniqueness" do
+    let(:existing_email) {create(:admin_blacklisted_email, email: "foobar@gmail.com")}
+
+    it "is invalid if email is not unique" do
+      expect(build(:admin_blacklisted_email, email: existing_email.email)).to be_invalid
+    end
+  end
+    
+  context "blacklisted emails" do
+    before(:each) do
+      @existing_email = FactoryGirl.create(:admin_blacklisted_email, email: "foobar@gmail.com")
+      @existing_email2 = FactoryGirl.create(:admin_blacklisted_email, email: "foo@bar.com")
+    end
+    
+    it "match themselves" do
+      expect(AdminBlacklistedEmail.is_blacklisted?("foobar@gmail.com"))
+      expect(AdminBlacklistedEmail.is_blacklisted?("foo@bar.com"))
+    end
+    
+    it "match variants" do
+      expect(AdminBlacklistedEmail.is_blacklisted?("FOO@bar.com")).to be_truthy
+      expect(AdminBlacklistedEmail.is_blacklisted?("foo+baz@bar.com")).to be_truthy
+      expect(AdminBlacklistedEmail.is_blacklisted?("FOO@BAR.COM")).to be_truthy
+      expect(AdminBlacklistedEmail.is_blacklisted?("FOOBAR@gmail.com")).to be_truthy
+      expect(AdminBlacklistedEmail.is_blacklisted?("foobar+baz+bat@gmail.com")).to be_truthy
+      expect(AdminBlacklistedEmail.is_blacklisted?("foo.bar@gmail.com")).to be_truthy
+      expect(AdminBlacklistedEmail.is_blacklisted?("f.o.o.bar@gmail.com")).to be_truthy
+      expect(AdminBlacklistedEmail.is_blacklisted?("foobar@googlemail.com")).to be_truthy
+      expect(AdminBlacklistedEmail.is_blacklisted?("foobar@GOOGLEMAIL.com")).to be_truthy
+      expect(AdminBlacklistedEmail.is_blacklisted?("fo.ob.ar@googlemail.com")).to be_truthy
+      expect(AdminBlacklistedEmail.is_blacklisted?("foobar+baz@googlemail.com")).to be_truthy
+      expect(AdminBlacklistedEmail.is_blacklisted?("FOOBAR@googlemail.com")).to be_truthy      
+    end
+    
+    it "do not match other emails" do
+      expect(AdminBlacklistedEmail.is_blacklisted?("something_else@bar.com")).to be_falsey
+      expect(AdminBlacklistedEmail.is_blacklisted?("foo@gmail.com")).to be_falsey
+      expect(AdminBlacklistedEmail.is_blacklisted?("something_else@gmail.com")).to be_falsey
+      expect(AdminBlacklistedEmail.is_blacklisted?("foo.f.o.o@gmail.com")).to be_falsey
+    end
+  end
+end


### PR DESCRIPTION
 https://otwarchive.atlassian.net/browse/AO3-4536

Allows blacklisting of emails so they can't be used to post guest/anonymous comments.

See https://github.com/otwcode/otwarchive/pull/2410 for discussion and review comments