### PR TITLE
AO3-4532 Allowing for the use of Diacritics and special characters in Support Form

### DIFF
--- a/app/models/feedback_reporters/feedback_reporter.rb
+++ b/app/models/feedback_reporters/feedback_reporter.rb
@@ -1,5 +1,6 @@
 class FeedbackReporter
   include HtmlCleaner
+  require 'url_formatter'
 
   attr_accessor :title, 
     :description,
@@ -23,8 +24,11 @@ class FeedbackReporter
   end
 
   def send_report!
+    # We're sending the XML data via a URL to our Support ticket service. The URL needs to be Percent-encoded so that
+    # everything shows up correctly on the other end. (https://en.wikipedia.org/wiki/Percent-encoding)
+    encoded_xml = CGI.escape(xml.to_str)
     HTTParty.post("#{ArchiveConfig.BUGS_SITE}",
-      body: "&xml=#{xml}"
+      body: "&xml=#{encoded_xml}"
     )
   end
 

--- a/app/views/feedbacks/report.xml.erb
+++ b/app/views/feedbacks/report.xml.erb
@@ -2,7 +2,7 @@
   <row no="1">
     <fl val="Contact Name"><%= cdata_section(@report.username.present? ? @report.username : "Anonymous user") %></fl>
     <fl val="Email"><%= cdata_section(@report.email.present? ? @report.email : "do-not-reply@archiveofourown.org") %></fl>
-    <fl val="Subject"><%= cdata_section(@report.title.present? ? "[#{ArchiveConfig.APP_SHORT_NAME}] Support - #{@report.title.html_safe}": "[#{ArchiveConfig.APP_SHORT_NAME}] Support - No Title") %></fl>
+    <fl val="Subject"><%= cdata_section(@report.title.present? ? "[#{ArchiveConfig.APP_SHORT_NAME}] Support - #{@report.title.html_safe}" : "[#{ArchiveConfig.APP_SHORT_NAME}] Support - No Title") %></fl>
     <fl val="Description"><%= cdata_section(@report.description.present? ? @report.description.html_safe : "No description submitted.") %></fl>
     <fl val="Language"><%= cdata_section(@report.language.present? ? @report.language : "English") %></fl>
     <fl val="Archive Version"><%= cdata_section(@report.site_revision.present? ? @report.site_revision : "Unknown site revision") %></fl>


### PR DESCRIPTION
Resolves problems with: https://otwarchive.atlassian.net/browse/AO3-4532

Encode the URL sent to the Support Ticket site so that it is percent-encoded.

*  https://en.wikipedia.org/wiki/Percent-encoding#Percent-encoding_reserved_characters