### PR TITLE
AO3 3468 Fix issue with 'Uncategorized Fandoms' Tag

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -155,10 +155,12 @@ class UsersController < ApplicationController
 
       @user.activation_code = Digest::SHA1.hexdigest( Time.now.to_s.split(//).sort_by {rand}.join )
 
-      if @user.save
-        notify_and_show_confirmation_screen
-      else
-        render :action => "new"
+      @user.transaction do
+        if @user.save
+          notify_and_show_confirmation_screen
+        else
+          render :action => "new"
+        end
       end
     end
   end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -155,12 +155,10 @@ class UsersController < ApplicationController
 
       @user.activation_code = Digest::SHA1.hexdigest( Time.now.to_s.split(//).sort_by {rand}.join )
 
-      @user.transaction do
-        if @user.save
-          notify_and_show_confirmation_screen
-        else
-          render :action => "new"
-        end
+      if @user.save
+        notify_and_show_confirmation_screen
+      else
+        render :action => "new"
       end
     end
   end

--- a/app/models/media.rb
+++ b/app/models/media.rb
@@ -13,7 +13,7 @@ class Media < Tag
   # The media tag for unwrangled fandoms
   def self.uncategorized
     Rails.cache.fetch("/MEDIA_UNCATEGORIZED_TAG/v1", expires_in: 1.day) do
-      Tag.find(ArchiveConfig.MEDIA_UNCATEGORIZED_ID||(Rails.env == "test" ? self.find_or_create_by_name(ArchiveConfig.MEDIA_UNCATEGORIZED_NAME).id : 9971))
+      Tag.find(ArchiveConfig.MEDIA_UNCATEGORIZED_ID || (Rails.env == "test" ? self.find_or_create_by_name(ArchiveConfig.MEDIA_UNCATEGORIZED_NAME).id : 9971))
     end 
   end
 

--- a/app/models/media.rb
+++ b/app/models/media.rb
@@ -12,8 +12,11 @@ class Media < Tag
   
   # The media tag for unwrangled fandoms
   def self.uncategorized
+    if Rails.env == "test"
+     return self.find_or_create_by_name(ArchiveConfig.MEDIA_UNCATEGORIZED_NAME)
+    end
     Rails.cache.fetch("/MEDIA_UNCATEGORIZED_TAG/v1", expires_in: 1.day) do
-      Tag.find(ArchiveConfig.MEDIA_UNCATEGORIZED_ID || (Rails.env == "test" ? self.find_or_create_by_name(ArchiveConfig.MEDIA_UNCATEGORIZED_NAME).id : 9971))
+      Tag.find(ArchiveConfig.MEDIA_UNCATEGORIZED_ID || 9971)
     end 
   end
 

--- a/app/models/media.rb
+++ b/app/models/media.rb
@@ -12,9 +12,11 @@ class Media < Tag
   
   # The media tag for unwrangled fandoms
   def self.uncategorized
-    self.find_or_create_by_name(ArchiveConfig.MEDIA_UNCATEGORIZED_NAME)
+    Rails.cache.fetch("/MEDIA_UNCATEGORIZED_TAG/v1", expires_in: 1.day) do
+      Tag.find(ArchiveConfig.MEDIA_UNCATEGORIZED_ID||(Rails.env == "test" ? self.find_or_create_by_name(ArchiveConfig.MEDIA_UNCATEGORIZED_NAME).id : 9971))
+    end 
   end
-  
+
   def add_association(tag) 
     tag.parents << self unless tag.parents.include?(self)
   end


### PR DESCRIPTION
The special case for the test suite is because in the first instance the tag will have to be created. I could move this to the application initialisation  if people wanted ?