### PR TITLE
AO3-3597 Fix editing work language on preview, rename admin option

### DIFF
--- a/app/views/admin/_admin_options.html.erb
+++ b/app/views/admin/_admin_options.html.erb
@@ -31,7 +31,7 @@
       </li>
     <% end %>
     <% if @work.present? %>
-      <li><%= link_to ts("Edit Tags"), edit_tags_work_path(@work) %></li>
+      <li><%= link_to ts("Edit Tags and Language"), edit_tags_work_path(@work) %></li>
     <% end %>
     <% if item.class == ExternalWork %>
       <li><%= link_to ts("Edit External Work"), edit_external_work_path(item) %></li>

--- a/app/views/works/preview_tags.html.erb
+++ b/app/views/works/preview_tags.html.erb
@@ -19,6 +19,7 @@
   <%= form.hidden_field :relationship_string, :value => "#{@work.relationship_string}" %>
   <%= form.hidden_field :character_string, :value => "#{@work.character_string}" %>
   <%= form.hidden_field :freeform_string, :value => "#{@work.freeform_string}" %>
+  <%= form.hidden_field :language_id, :value => "#{@work.language.id}" %>
 
   <fieldset>
     <legend><%= ts('Post Work') %></legend>

--- a/features/admins/admin_works.feature
+++ b/features/admins/admin_works.feature
@@ -70,7 +70,7 @@ Feature: Admin Actions for Works and Bookmarks
       And I post the work "Changes" with fandom "User-Added Fandom" with freeform "User-Added Freeform" with category "M/M"
     When I am logged in as an admin
       And I view the work "Changes"
-      And I follow "Edit Tags"
+      And I follow "Edit Tags and Language"
     When I select "Mature" from "Rating"
       And I uncheck "No Archive Warnings Apply"
       And I check "Choose Not To Use Archive Warnings"
@@ -196,7 +196,7 @@ Feature: Admin Actions for Works and Bookmarks
       And I post the work "Wrong Language"
     When I am logged in as an admin
       And I view the work "Wrong Language"
-      And I follow "Edit Tags"
+      And I follow "Edit Tags and Language"
     When I select "Deutsch" from "Choose a language"
       And I press "Post Without Preview"
     Then I should see "Deutsch"
@@ -209,7 +209,7 @@ Feature: Admin Actions for Works and Bookmarks
       And I post the work "Wrong Language"
     When I am logged in as an admin
       And I view the work "Wrong Language"
-      And I follow "Edit Tags"
+      And I follow "Edit Tags and Language"
     When I select "Deutsch" from "Choose a language"
       And I press "Preview"
       And I press "Update"

--- a/features/admins/admin_works.feature
+++ b/features/admins/admin_works.feature
@@ -189,7 +189,7 @@ Feature: Admin Actions for Works and Bookmarks
     Then I should not see "rolex"
       And I should see "I loved this!"
 
-  Scenario: Admin can edit language on works
+  Scenario: Admin can edit language on works when posting without previewing
     Given basic tags
       And basic languages
       And I am logged in as "regular_user"
@@ -201,3 +201,17 @@ Feature: Admin Actions for Works and Bookmarks
       And I press "Post Without Preview"
     Then I should see "Deutsch"
       And I should not see "English"
+
+  Scenario: Admin can edit language on works when previewing first
+    Given basic tags
+      And basic languages
+      And I am logged in as "regular_user"
+      And I post the work "Wrong Language"
+    When I am logged in as an admin
+      And I view the work "Wrong Language"
+      And I follow "Edit Tags"
+    When I select "Deutsch" from "Choose a language"
+      And I press "Preview"
+      And I press "Update"
+    Then I should see "Deutsch"
+      And I should not see "English"  


### PR DESCRIPTION
https://otwarchive.atlassian.net/browse/AO3-3597

- Admins can now edit a work's language when using Preview rather than Post Without Preview
- The button now says "Edit Tags and Language" because Language is not a tag and it was annoying me