### PR TITLE
AO3-3597 Only include language field on tag preview page for admins

### DIFF
--- a/app/views/works/edit_tags.html.erb
+++ b/app/views/works/edit_tags.html.erb
@@ -1,6 +1,10 @@
 <!--Descriptive page name, messages and instructions-->
 <h2 class="heading">
-  <%= ts('Edit Work Tags for %{title}', title: @work.title).html_safe %>
+  <% if logged_in_as_admin? %>
+    <%= ts('Edit Work Tags and Language for %{title}', title: @work.title).html_safe %>
+  <% else %>
+    <%= ts('Edit Work Tags for %{title}', title: @work.title).html_safe %>
+  <% end %>
 </h2>
 
 <%= error_messages_for :work %>

--- a/app/views/works/edit_tags.html.erb
+++ b/app/views/works/edit_tags.html.erb
@@ -6,7 +6,7 @@
 <%= error_messages_for :work %>
 <!--/descriptions-->
 
-<!--main content-->	
+<!--main content-->
 <%= form_for(@work, html: { id: "work-form", class: "verbose work post" }, url: { action: "update_tags" }) do |f| %> 
   <p class="required notice">* <%= ts('Required information') %></p>
 

--- a/app/views/works/preview_tags.html.erb
+++ b/app/views/works/preview_tags.html.erb
@@ -19,7 +19,9 @@
   <%= form.hidden_field :relationship_string, :value => "#{@work.relationship_string}" %>
   <%= form.hidden_field :character_string, :value => "#{@work.character_string}" %>
   <%= form.hidden_field :freeform_string, :value => "#{@work.freeform_string}" %>
-  <%= form.hidden_field :language_id, :value => "#{@work.language.id}" %>
+  <% if logged_in_as_admin? %>
+    <%= form.hidden_field :language_id, :value => "#{@work.language.id}" %>
+  <% end %>
 
   <fieldset>
     <legend><%= ts('Post Work') %></legend>

--- a/app/views/works/preview_tags.html.erb
+++ b/app/views/works/preview_tags.html.erb
@@ -32,12 +32,12 @@
   <fieldset>
     <legend><%= ts('Post Work') %></legend>
     <p class="submit cancel edit actions">
-    <% if @work.posted? %>
-      <%= submit_tag ts('Update'), name: 'update_button' %>
-    <% else %>
-      <%= submit_tag ts('Post'), name: 'post_button' %>
-      <%= submit_tag ts('Save Without Posting'), name: 'save_button' %>
-    <% end %>
+      <% if @work.posted? %>
+        <%= submit_tag ts('Update'), name: 'update_button' %>
+      <% else %>
+        <%= submit_tag ts('Post'), name: 'post_button' %>
+        <%= submit_tag ts('Save Without Posting'), name: 'save_button' %>
+      <% end %>
       <%= submit_tag ts('Edit'), name: 'edit_button' %>
       <%= submit_tag ts('Cancel'), name: 'cancel_button' %>
     </p>

--- a/app/views/works/preview_tags.html.erb
+++ b/app/views/works/preview_tags.html.erb
@@ -6,34 +6,34 @@
 <!--main content-->
 <div id="previewpane">
   <div class="draft work">
-    <%= render :partial => 'works/meta', :locals => {:work => @work} %>
+    <%= render 'works/meta' work: @work %>
   </div>
 </div>
 <!--/content-->
 
-<%= form_for(@work, :url => {:action => :update_tags}) do |form| %>
-  <%= form.hidden_field :rating_string, :value => "#{@work.rating_string}" %>
-  <%= form.hidden_field :warning_string, :value => "#{@work.warning_string}" %>
-  <%= form.hidden_field :category_string, :value => "#{@work.category_string}" %>
-  <%= form.hidden_field :fandom_string, :value => "#{@work.fandom_string}" %>
-  <%= form.hidden_field :relationship_string, :value => "#{@work.relationship_string}" %>
-  <%= form.hidden_field :character_string, :value => "#{@work.character_string}" %>
-  <%= form.hidden_field :freeform_string, :value => "#{@work.freeform_string}" %>
+<%= form_for(@work, url: { action: :update_tags }) do |form| %>
+  <%= form.hidden_field :rating_string, value: "#{@work.rating_string}" %>
+  <%= form.hidden_field :warning_string, value: "#{@work.warning_string}" %>
+  <%= form.hidden_field :category_string, value: "#{@work.category_string}" %>
+  <%= form.hidden_field :fandom_string, value: "#{@work.fandom_string}" %>
+  <%= form.hidden_field :relationship_string, value: "#{@work.relationship_string}" %>
+  <%= form.hidden_field :character_string, value: "#{@work.character_string}" %>
+  <%= form.hidden_field :freeform_string, value: "#{@work.freeform_string}" %>
   <% if logged_in_as_admin? %>
-    <%= form.hidden_field :language_id, :value => "#{@work.language.id}" %>
+    <%= form.hidden_field :language_id, value: "#{@work.language.id}" %>
   <% end %>
 
   <fieldset>
     <legend><%= ts('Post Work') %></legend>
     <p class="submit cancel edit actions">
-  	<% if @work.posted? %>
-  		<%= submit_tag ts('Update'), :name => 'update_button' %>
-  	<% else %>
-  		<%= submit_tag ts('Post'), :name => 'post_button' %>
-  		<%= submit_tag ts('Save Without Posting'), :name => 'save_button' %>
-  	<% end %>
-      <%= submit_tag ts('Edit'), :name => 'edit_button' %>
-      <%= submit_tag ts('Cancel'), :name => 'cancel_button' %>
+    <% if @work.posted? %>
+      <%= submit_tag ts('Update'), name: 'update_button' %>
+    <% else %>
+      <%= submit_tag ts('Post'), name: 'post_button' %>
+      <%= submit_tag ts('Save Without Posting'), name: 'save_button' %>
+    <% end %>
+      <%= submit_tag ts('Edit'), name: 'edit_button' %>
+      <%= submit_tag ts('Cancel'), name: 'cancel_button' %>
     </p>
   </fieldset>
 

--- a/app/views/works/preview_tags.html.erb
+++ b/app/views/works/preview_tags.html.erb
@@ -1,12 +1,18 @@
 <!--Descriptive page name, messages and instructions-->
-<h2 class="heading"><%= ts("Preview Tags") %></h2>
+<h2 class="heading">
+  <% if logged_in_as_admin? %>
+    <%= ts("Preview Tags and Language") %>
+  <% else %>
+    <%= ts("Preview Tags") %>
+  <% end %>
+</h2>
 <%= error_messages_for :work %>
 <!--/descriptions-->
 
 <!--main content-->
 <div id="previewpane">
   <div class="draft work">
-    <%= render 'works/meta' work: @work %>
+    <%= render 'works/meta', work: @work %>
   </div>
 </div>
 <!--/content-->

--- a/features/admins/admin_works.feature
+++ b/features/admins/admin_works.feature
@@ -197,6 +197,7 @@ Feature: Admin Actions for Works and Bookmarks
     When I am logged in as an admin
       And I view the work "Wrong Language"
       And I follow "Edit Tags and Language"
+    Then I should see "Edit Work Tags and Language for "
     When I select "Deutsch" from "Choose a language"
       And I press "Post Without Preview"
     Then I should see "Deutsch"
@@ -212,6 +213,7 @@ Feature: Admin Actions for Works and Bookmarks
       And I follow "Edit Tags and Language"
     When I select "Deutsch" from "Choose a language"
       And I press "Preview"
-      And I press "Update"
+    Then I should see "Preview Tags and Language"
+    When I press "Update"
     Then I should see "Deutsch"
       And I should not see "English"  


### PR DESCRIPTION
https://otwarchive.atlassian.net/browse/AO3-3597

* Only includes the invisible language field on the preview page for admins
* Updates a few page headings to say tags and language when you're an admin