### PR TITLE
AO3-4614 Fix light font on Android

### DIFF
--- a/public/stylesheets/site/2.0/02-elements.css
+++ b/public/stylesheets/site/2.0/02-elements.css
@@ -115,7 +115,7 @@ hr {
 }
 
 blockquote, pre {
-  font: 100 1em 'Lucida Grande', 'Lucida Sans Unicode', Verdana, Helvetica, sans-serif;
+  font: 1em 'Lucida Grande', 'Lucida Sans Unicode', Verdana, Helvetica, sans-serif;
   margin: 0.643em;
 }
 

--- a/public/stylesheets/site/2.0/21-userstuff.css
+++ b/public/stylesheets/site/2.0/21-userstuff.css
@@ -10,6 +10,11 @@
   line-height: 1.5;
 }
 
+/* AO3-4614 temporary workaround for Android bug */
+blockquote.userstuff p {
+  font-weight: normal;
+}
+
 /*lists */
 
 .userstuff dl {

--- a/public/stylesheets/site/2.0/21-userstuff.css
+++ b/public/stylesheets/site/2.0/21-userstuff.css
@@ -10,11 +10,6 @@
   line-height: 1.5;
 }
 
-/* AO3-4614 temporary workaround for Android bug */
-blockquote.userstuff p {
-  font-weight: normal;
-}
-
 /*lists */
 
 .userstuff dl {


### PR DESCRIPTION
https://otwarchive.atlassian.net/browse/AO3-4614

Some Android users were seeing a very light font on work summaries and various other place. Turns out there was a good reason for that: we were setting the font weight on blockquotes to 100, aka the thinnest possible.

Why this problem was only happening for some people, and only started now given this code was four and a half years old, I don't know. But it shouldn't happen for them now.