### PR TITLE
AO3-4615 Exposed URL breaks confirmation email layout

### DIFF
--- a/app/views/user_mailer/signup_notification.html.erb
+++ b/app/views/user_mailer/signup_notification.html.erb
@@ -1,7 +1,7 @@
 <% content_for :message do %>
   <p>Welcome to the Archive of Our Own, <%= style_bold(@user.login) %>!</p>
 
-  <p>Please <%= style_link("activate your account"), activate_url(id: @user.activation_code)) %>.</p>
+  <p>Please <%= style_link("activate your account", activate_url(id: @user.activation_code)) %>.</p>
 
   <p>Once your account is up and running, you can post your fanworks, set up email subscriptions to let you know when your favorite creators or works have updated, set preferences to customize the way the site looks and works for you, keep track of the works you've viewed on the Archive via your history, and much more.</p>
 

--- a/app/views/user_mailer/signup_notification.html.erb
+++ b/app/views/user_mailer/signup_notification.html.erb
@@ -1,7 +1,7 @@
 <% content_for :message do %>
   <p>Welcome to the Archive of Our Own, <%= style_bold(@user.login) %>!</p>
 
-  <p>Please activate your account at: <%= style_link(activate_url(:id => @user.activation_code), activate_url(:id => @user.activation_code)) %>.</p>
+  <p>Please <%= style_link("activate your account"), activate_url(id: @user.activation_code)) %>.</p>
 
   <p>Once your account is up and running, you can post your fanworks, set up email subscriptions to let you know when your favorite authors or works have updated, set preferences to customize the way the site looks and works for you, keep track of the works you've viewed on the Archive via your history, and much more.</p>
 

--- a/app/views/user_mailer/signup_notification.html.erb
+++ b/app/views/user_mailer/signup_notification.html.erb
@@ -3,7 +3,7 @@
 
   <p>Please <%= style_link("activate your account"), activate_url(id: @user.activation_code)) %>.</p>
 
-  <p>Once your account is up and running, you can post your fanworks, set up email subscriptions to let you know when your favorite authors or works have updated, set preferences to customize the way the site looks and works for you, keep track of the works you've viewed on the Archive via your history, and much more.</p>
+  <p>Once your account is up and running, you can post your fanworks, set up email subscriptions to let you know when your favorite creators or works have updated, set preferences to customize the way the site looks and works for you, keep track of the works you've viewed on the Archive via your history, and much more.</p>
 
   <p>There's lots of information and advice on how to use the Archive in our <%= style_link("FAQ", archive_faqs_url) %>. You'll find the latest news about site developments in our <%= style_link("Archive admin posts", root_url + "admin_posts") %>. If you need more help, run into a bug, or have questions or comments, please <%= support_link("get in touch with our Support team") %>, who are always happy to help out.</p>
 

--- a/app/views/user_mailer/signup_notification.text.erb
+++ b/app/views/user_mailer/signup_notification.text.erb
@@ -1,7 +1,7 @@
 <% content_for :message do %>
 Welcome to the Archive of Our Own, <%= @user.login %>!
 
-Please activate your account: <%= activate_url(id: @user.activation_code) %>.
+Please activate your account: <%= activate_url(id: @user.activation_code) %>
 
 Once your account is up and running, you can post your fanworks, set up email subscriptions to let you know when your favorite creators or works have updated, set preferences to customize the way the site looks and works for you, keep track of the works you've viewed on the Archive via your history, and much more.
 

--- a/app/views/user_mailer/signup_notification.text.erb
+++ b/app/views/user_mailer/signup_notification.text.erb
@@ -1,7 +1,7 @@
 <% content_for :message do %>
 Welcome to the Archive of Our Own, <%= @user.login %>!
 
-Please activate your account at: <%= activate_url(:id => @user.activation_code) %> .
+Please activate your account: <%= activate_url(id: @user.activation_code) %>.
 
 Once your account is up and running, you can post your fanworks, set up email subscriptions to let you know when your favorite authors or works have updated, set preferences to customize the way the site looks and works for you, keep track of the works you've viewed on the Archive via your history, and much more.
 

--- a/app/views/user_mailer/signup_notification.text.erb
+++ b/app/views/user_mailer/signup_notification.text.erb
@@ -3,7 +3,7 @@ Welcome to the Archive of Our Own, <%= @user.login %>!
 
 Please activate your account: <%= activate_url(id: @user.activation_code) %>.
 
-Once your account is up and running, you can post your fanworks, set up email subscriptions to let you know when your favorite authors or works have updated, set preferences to customize the way the site looks and works for you, keep track of the works you've viewed on the Archive via your history, and much more.
+Once your account is up and running, you can post your fanworks, set up email subscriptions to let you know when your favorite creators or works have updated, set preferences to customize the way the site looks and works for you, keep track of the works you've viewed on the Archive via your history, and much more.
 
 There's lots of information and advice on how to use the Archive in our FAQ at <%= archive_faqs_url %>. You'll find the latest news about site developments in our Archive admin posts at <%= root_url %>admin_posts. If you need more help, run into a bug, or have questions or comments, please get in touch with our Support team, who are always happy to help out: <%= root_url %>support.
 

--- a/features/other_a/invite_queue.feature
+++ b/features/other_a/invite_queue.feature
@@ -119,7 +119,7 @@ Feature: Invite queue management
     Then 1 email should be delivered
       And the email should contain "Welcome to the Archive of Our Own,"
       And the email should contain "newuser"
-      And the email should contain "Please activate your account"
+      And the email should contain "activate your account"
     
     # user activates account
     When all emails have been delivered

--- a/features/step_definitions/user_steps.rb
+++ b/features/step_definitions/user_steps.rb
@@ -201,7 +201,7 @@ Then /^I should get an activation email for "(.*?)"$/ do |login|
   step(%{1 email should be delivered})
   step(%{the email should contain "Welcome to the Archive of Our Own,"})
   step(%{the email should contain "#{login}"})
-  step(%{the email should contain "Please activate your account"})
+  step(%{the email should contain "activate your account"})
 end
 
 Then /^I should get a new user activation email$/ do


### PR DESCRIPTION
https://otwarchive.atlassian.net/browse/AO3-4615

* Change `Please activate your account at: <a href="http://archiveofourown.org/activate/HOLYKEYSMASHOFLETTERSANDNUMBERSBATMAN">http://archiveofourown.org/activate/HOLYKEYSMASHOFLETTERSANDNUMBERSBATMAN</a>.` to `Please <a href="http://archiveofourown.org/activate/HOLYKEYSMASHOFLETTERSANDNUMBERSBATMAN">activate your account</a>.`
* Change "authors" to "creators"