### PR TITLE
Fix for issue AO3-3947, with cucumber scenarios to test

### DIFF
--- a/app/models/creation_observer.rb
+++ b/app/models/creation_observer.rb
@@ -54,15 +54,15 @@ class CreationObserver < ActiveRecord::Observer
   def notify_recipients(work)
     if work.posted && !work.new_recipients.blank? && !work.unrevealed?
       recipient_pseuds = Pseud.parse_bylines(work.new_recipients, :assume_matching_login => true)[:pseuds]
-      recipient_pseuds.collect(&:user_id).uniq.each do |userid|
-        if work.collections.empty?
+      # check user prefs to see which recipients want to get gift notifications
+      # (since each user has only one preference item, this removes duplicates)
+      recip_ids = Preference.where(user_id: recipient_pseuds.collect(&:user_id),
+                                   recipient_emails_off: false).pluck(:user_id)
+      recip_ids.each do |userid|
+        if work.collections.empty? || work.collections.first.nil?
           UserMailer.recipient_notification(userid, work.id).deliver
         else
-          if work.collections.first.nil?
-            UserMailer.recipient_notification(userid, work.id).deliver
-          else
-            UserMailer.recipient_notification(userid, work.id, work.collections.first.id).deliver
-          end
+          UserMailer.recipient_notification(userid, work.id, work.collections.first.id).deliver
         end
       end
     end

--- a/app/models/creation_observer.rb
+++ b/app/models/creation_observer.rb
@@ -56,7 +56,7 @@ class CreationObserver < ActiveRecord::Observer
       recipient_pseuds = Pseud.parse_bylines(work.new_recipients, :assume_matching_login => true)[:pseuds]
       # check user prefs to see which recipients want to get gift notifications
       # (since each user has only one preference item, this removes duplicates)
-      recip_ids = Preference.where(user_id: recipient_pseuds.collect(&:user_id),
+      recip_ids = Preference.where(user_id: recipient_pseuds.map(&:user_id),
                                    recipient_emails_off: false).pluck(:user_id)
       recip_ids.each do |userid|
         if work.collections.empty? || work.collections.first.nil?

--- a/features/other_a/gift.feature
+++ b/features/other_a/gift.feature
@@ -269,3 +269,34 @@ Feature: Create Gifts
       And the gift for "giftee1" should still exist on "GiftStory1"
     When I have removed the recipients
     Then the gift for "giftee1" should still exist on "GiftStory1"
+
+  Scenario: Opt to disable notifications, then receive a gift (with no collection)
+ 
+    Given I am logged in as "giftee1" with password "something"
+      And I set my preferences to turn off notification emails for gifts
+    When I am logged in as "gifter" with password "something"
+      And I post the work "QuietGift" as a gift for "giftee1, giftee2"
+    Then 0 emails should be delivered to "giftee1@foo.com"
+      And "giftee2@foo.com" should be notified by email about their gift "QuietGift" 
+ 
+  Scenario: Opt to disable notifications, then receive a gift posted to a non-hidden collection
+ 
+    Given I am logged in as "giftee1" with password "something"
+      And I set my preferences to turn off notification emails for gifts
+      And I have the collection "Open Skies"
+    When I am logged in as "gifter" with password "something"
+      And I post the work "QuietGift" in the collection "Open Skies" as a gift for "giftee1, giftee2"
+    Then 0 emails should be delivered to "giftee1@foo.com"
+      And "giftee2@foo.com" should be notified by email about their gift "QuietGift" 
+ 
+  Scenario: Opt to disable notifications, then receive a gift posted to a hidden collection and later revealed
+ 
+    Given I am logged in as "giftee1" with password "something"
+      And I set my preferences to turn off notification emails for gifts
+      And I have the hidden collection "Hidden Treasures"
+    When I am logged in as "gifter" with password "something"
+      And I post the work "QuietGift" in the collection "Hidden Treasures" as a gift for "giftee1, giftee2"
+      And I reveal works for "Hidden Treasures"
+    Then 0 emails should be delivered to "giftee1@foo.com"
+      And "giftee2@foo.com" should be notified by email about their gift "QuietGift" 
+  

--- a/features/step_definitions/preferences_steps.rb
+++ b/features/step_definitions/preferences_steps.rb
@@ -16,6 +16,12 @@ When /^I set my preferences to turn off notification emails for kudos$/ do
   user.preference.save
 end
 
+When /^I set my preferences to turn off notification emails for gifts$/ do
+  user = User.current_user
+  user.preference.recipient_emails_off = true
+  user.preference.save
+end
+
 When /^I set my preferences to hide warnings$/ do
   user = User.current_user
   user.preference.hide_warnings = true


### PR DESCRIPTION
https://otwarchive.atlassian.net/browse/AO3-3947

I added a check to CreationObserver so that it won't trigger the UserMailer's recipient_notification if the user has gift notifications turned off in their preferences. I also created three cucumber scenarios to test recipient notifications (corresponding to the three laid out in the description of issue AO3-3947).

(I hope this is okay! I tried to follow the guidelines in the wiki, but I've never tried to contribute code to an open-source project before.)