### PR TITLE
AO3-4619 - Add Github documentation and templates

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,6 +1,6 @@
 # We do not use GitHub for issues!
 
-Please do not create issues here. OTW volunteers create agreed issues in our 
+Please do not create issues here. OTW volunteers create approved issues in our 
 [JIRA issue tracker](https://otwarchive.atlassian.net) - please see below if you want to report a bug.
 
 ## To get help or report a bug

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,18 @@
+# We do not use Github for issues!
+
+Please do not create issues here.
+
+## To get help
+
+If you need help using [Archive of Our Own](http://archiveofourown.org), please [contact its Support team](http://archiveofourown.org/support)
+
+## To suggest a new feature
+
+[AO3 Support](http://archiveofourown.org/support) also track feature requests.
+
+## To find existing coding issues to work on
+
+We only accept code contributions on issues we have already prioritized.
+
+If you are looking for an issue to work on, please check our [JIRA issue tracker](https://otwarchive.atlassian.net).
+

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,14 +1,16 @@
-# We do not use Github for issues!
+# We do not use GitHub for issues!
 
-Please do not create issues here.
+Please do not create issues here. OTW volunteers create agreed issues in our 
+[JIRA issue tracker](https://otwarchive.atlassian.net) - please see below if you want to report a bug.
 
-## To get help
+## To get help or report a bug
 
-If you need help using [Archive of Our Own](http://archiveofourown.org), please [contact its Support team](http://archiveofourown.org/support)
+If you need help using [Archive of Our Own](http://archiveofourown.org) or want to report an issue
+you have found, please [contact its Support team](http://archiveofourown.org/support).
 
 ## To suggest a new feature
 
-[AO3 Support](http://archiveofourown.org/support) also track feature requests.
+[The AO3 Support team](http://archiveofourown.org/support) also track feature requests.
 
 ## To find existing coding issues to work on
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -24,8 +24,8 @@ Are there any other relevant issues / PRs / mailing lists discussions related to
 
 ## Credit
 
-What name do you want us to use to credit your work in the [Archive of Our Own's Release Notes](http://archiveofourown.org/admin_posts?tag=1)?
+*What name do you want us to use to credit your work in the [Archive of Our Own's Release Notes](http://archiveofourown.org/admin_posts?tag=1)?*
 
-What pronouns do you prefer (she/her, he/him, zie/hir etc)?
+*What pronouns do you prefer (she/her, he/him, zie/hir etc)?*
 
 (if you do not fill this in, we will use your GitHub account name and will use "they" to avoid making assumptions about your gender)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,33 @@
+# Pull Request Checklist
+
+* [ ] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
+* [ ] Have you read through the [contributor guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
+* [ ] Have you added tests for any changed functionality?
+* [ ] Have you added the JIRA issue number as the *first* thing in your pull request title (eg: `AO3-1234 Fix thing`)
+* [ ] Have you updated the JIRA issue with the information below?
+
+# Helpful things
+
+## Fixes
+
+Fixes https://otwarchive.atlassian.net/browse/AO3-**XXXX** (please fill in issue number and remove this comment)
+
+## Purpose
+
+What does this PR do?
+
+## Testing
+
+How can the Archive's QA team verify that this is work as you intended? (If you have access, please copy this into the JIRA ticket for them!)
+
+## References
+
+Are there any other relevant issues / PRs / mailing lists discussions related to this?
+
+## Credit
+
+What name do you want us to use to credit your work in the [Archive of Our Own's Release Notes](http://archiveofourown.org/admin_posts?tag=1)?
+
+What pronouns do you prefer (she/her, he/him, zie/hir etc)?
+
+(if you do not fill this in, we will use your Github account name and will use "they" to avoid making assumptions about your gender)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,11 +6,9 @@
 * [ ] Have you added the JIRA issue number as the *first* thing in your pull request title (eg: `AO3-1234 Fix thing`)
 * [ ] Have you updated the JIRA issue with the information below?
 
-# Helpful things
+## Issue
 
-## Fixes
-
-Fixes https://otwarchive.atlassian.net/browse/AO3-**XXXX** (please fill in issue number and remove this comment)
+https://otwarchive.atlassian.net/browse/AO3-**XXXX** (please fill in issue number and remove this comment)
 
 ## Purpose
 
@@ -18,7 +16,7 @@ What does this PR do?
 
 ## Testing
 
-How can the Archive's QA team verify that this is work as you intended? (If you have access, please copy this into the JIRA ticket for them!)
+How can the Archive's QA team verify that this is working as you intended? (If you have access, please copy this into the JIRA ticket for them!)
 
 ## References
 
@@ -30,4 +28,4 @@ What name do you want us to use to credit your work in the [Archive of Our Own's
 
 What pronouns do you prefer (she/her, he/him, zie/hir etc)?
 
-(if you do not fill this in, we will use your Github account name and will use "they" to avoid making assumptions about your gender)
+(if you do not fill this in, we will use your GitHub account name and will use "they" to avoid making assumptions about your gender)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,51 @@
+# Contributing to Archive of Our Own
+
+## Contributing code
+
+### Pick an issue to work on
+
+You will find our [list of approved issues on JIRA](https://otwarchive.atlassian.net/projects/AO3/issues).
+
+We regret that we cannot accept pull requests for issues we haven't already logged, with the exception of documentation 
+or spelling corrections. 
+
+### Resolve the issue
+
+Consult our [Developer Documentation](https://github.com/otwcode/otwarchive/wiki) on how to set up a local development 
+environment so you can work on the Archive code.
+
+### Submit your pull request
+
+Please read the checklist on [our pull request template](https://github.com/otwcode/otwarchive/blob/master/.github/PULL_REQUEST_TEMPLATE.md)
+on the steps you need to perform to make we can accept your pull request.
+
+### Action comments on your pull request
+
+When we review your pull request, we will make comments on Github. Please make sure you read these carefully and apply
+their suggestions!
+
+Due to our workload, it may take several weeks before an approved pull request is merged, so be patient - we will get to it!
+
+### Testing and fixing bugs
+
+Once your pull request is merged, it will be deployed to our internal Staging server and our manual QA team will check it.
+We may ask you to make further changes and submit a new pull request if we find any problems that will affect our users'
+ability to benefit from your changes. 
+
+### Release
+
+Once we have checked that all is well, your contribution will be deployed to [Archive of Our Own](http://archiveofourown.org) and you will be credited
+in the [AO3 release notes](http://archiveofourown.org/admin_posts?tag=1)! Make sure you tell us your preferred name and pronoun
+in the pull request.
+
+## Volunteering for the OTW
+
+If you would like to donate more of your time and expertise in a multi-national, inclusive, fandom-oriented development team, you might
+ enjoy becoming an official OTW volunteer. We are always looking for coders and testers! 
+
+[Read more about volunteering with the OTW](http://transformativeworks.org/how-you-can-help/volunteer) 
+
+## Questions?
+
+[Drop us an email](mailto:otw-coders@transformativeworks.org) if you have any questions. 
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,11 +17,11 @@ environment so you can work on the Archive code.
 ### Submit your pull request
 
 Please read the checklist on [our pull request template](https://github.com/otwcode/otwarchive/blob/master/.github/PULL_REQUEST_TEMPLATE.md)
-on the steps you need to perform to make we can accept your pull request.
+for the steps you need to perform to make sure we can accept your pull request.
 
 ### Action comments on your pull request
 
-When we review your pull request, we will make comments on Github. Please make sure you read these carefully and apply
+When we review your pull request, we will make comments on GitHub. Please make sure you read these carefully and apply
 their suggestions!
 
 Due to our workload, it may take several weeks before an approved pull request is merged, so be patient - we will get to it!
@@ -35,13 +35,13 @@ ability to benefit from your changes.
 ### Release
 
 Once we have checked that all is well, your contribution will be deployed to [Archive of Our Own](http://archiveofourown.org) and you will be credited
-in the [AO3 release notes](http://archiveofourown.org/admin_posts?tag=1)! Make sure you tell us your preferred name and pronoun
+in the [AO3 Release Notes](http://archiveofourown.org/admin_posts?tag=1)! Make sure you tell us your preferred name and pronoun
 in the pull request.
 
 ## Volunteering for the OTW
 
 If you would like to donate more of your time and expertise in a multi-national, inclusive, fandom-oriented development team, you might
- enjoy becoming an official OTW volunteer. We are always looking for coders and testers! 
+ enjoy becoming an official OTW volunteer.
 
 [Read more about volunteering with the OTW](http://transformativeworks.org/how-you-can-help/volunteer) 
 

--- a/README.md
+++ b/README.md
@@ -1,38 +1,32 @@
 OTW-Archive [![Build Status](https://travis-ci.org/otwcode/otwarchive.png)](https://travis-ci.org/otwcode/otwarchive) [![Codeship Status](https://www.codeship.io/projects/1f7468f0-7e15-0131-c059-7a8d26daf885/status?branch=master)](https://www.codeship.io/projects/14476)
 =========
+The OTW-Archive software is an open-source web application intended for hosting archives of fanworks, including fanfic, fanart, and fan vids. 
 
-The OTW-Archive software is an open-source web application intended for hosting archives
-of fanworks, including fanfic, fanart, and fan vids. 
-
-Its development is sponsored by
-the [Organization for Transformative Works](http://transformativeworks.org), a nonprofit
-organization by and for fans.
+Its development is sponsored and managed by the [Organization for Transformative Works](http://transformativeworks.org), a nonprofit organization by and for fans.
 
 Release Status
 ---------
+Development of the OTW-Archive software is an ongoing labor of love. You can see it in action on the [Archive of Our Own](http://archiveofourown.org), aka AO3, a multifandom archive also run by the OTW.
 
-The OTW-Archive software is still in beta and has not yet been formally released, but you
-can see it in action on the [Archive of Our Own](http://archiveofourown.org), aka AO3, a
-multifandom archive also run by the OTW.
-
-Our ultimate goal is to release OTW-Archive in a form that can be installed and used by
-any fan archivist interested in creating and maintaining a fanwork archive.
-
-You can get more information about
-our broad development plan at the [OTW-Archive Roadmap](http://transformativeworks.org/projects/archive).
+You can find more information about the [history and future of the AO3 project on the OTW website](http://transformativeworks.org/projects/archive).
 
 How to Contribute
 ----------
+We welcome pull requests for bugs described in our issue tracker. Please see our [Contributing Guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md) for further information!
 
-You can also submit a pull request; we'll get back to you as soon as we can!
+* [Bug Tracker](https://otwarchive.atlassian.net/projects/AO3/issues)
+* [Developer Documentation](https://github.com/otwcode/otwarchive/wiki)
+* [Commit Policy](https://github.com/otwcode/otwarchive/wiki/Commit-policy)
 
-Please see our [Contributing Guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)
-
-* Bug Tracking: https://otwarchive.atlassian.net/projects/AO3/issues
-* Developer Documentation: https://github.com/otwcode/otwarchive/wiki
-* Beta Website: http://archiveofourown.org
-
-License
+License and Acknowledgments
 ----------
+The Archive code is licensed under [GPL](http://www.gnu.org/licenses/gpl-2.0.html) by the [Organization for Transformative Works](http://transformativeworks.org).
 
-Code is licensed under [GPL](http://www.gnu.org/licenses/gpl-2.0.html) by the [Organization for Transformative Works](http://transformativeworks.org).
+We benefit from software and services that are free to use for Open Source projects, including:
+
+* [RubyMine IDE](https://www.jetbrains.com/ruby/) by JetBrains
+* [Travis CI](https://travis-ci.org/)
+* [Codeship](http://codeship.com/)
+* [Hound](https://houndci.com/) by [thoughtbot](https://thoughtbot.com/)
+
+Thank you kindly!

--- a/README.md
+++ b/README.md
@@ -24,15 +24,7 @@ our broad development plan at the [OTW-Archive Roadmap](http://transformativewor
 How to Contribute
 ----------
 
-Volunteers are always welcome both for coding and testing! 
-
-[Read more about volunteering with the OTW](http://transformativeworks.org/how-you-can-help/volunteer) or [drop us an email](mailto:otw-coders@transformativeworks.org) if you have any questions. 
-
-You can also submit a pull request; we'll get back to you as soon as we can!
-
-* Bug Tracking: https://otwarchive.atlassian.net/projects/AO3/issues
-* Developer Documentation: https://github.com/otwcode/otwarchive/wiki
-* Beta Website: http://archiveofourown.org
+Please see our [Contributing Guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)
 
 License
 ----------

--- a/README.md
+++ b/README.md
@@ -24,7 +24,13 @@ our broad development plan at the [OTW-Archive Roadmap](http://transformativewor
 How to Contribute
 ----------
 
+You can also submit a pull request; we'll get back to you as soon as we can!
+
 Please see our [Contributing Guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)
+
+* Bug Tracking: https://otwarchive.atlassian.net/projects/AO3/issues
+* Developer Documentation: https://github.com/otwcode/otwarchive/wiki
+* Beta Website: http://archiveofourown.org
 
 License
 ----------


### PR DESCRIPTION
## Fixes

Fixes https://otwarchive.atlassian.net/browse/AO3-4619

## Purpose

Add templates to discourage issues and standardise pull requests, and CONTRIBUTING document so our Github repo looks like other Open Source repos.

## Testing

See notes on [AO3-4619](https://otwarchive.atlassian.net/browse/AO3-4619)

## References

Discussed briefly in chat.

## Credit

What name do you want us to use to credit your work in the [Archive of Our Own's Release Notes](http://archiveofourown.org/admin_posts?tag=1)?

Ariana

What pronouns do you prefer (she/her, he/him, zie/hir etc)?

she/her