### PR TITLE
AO3-4108 (& AO3-4367) - Fix some problems with subscriptions and anonymous or unrevealed collections.

### DIFF
--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -416,17 +416,12 @@ class Collection < ActiveRecord::Base
   
   def reveal_collection_item_authors
     approved_collection_items.each { |collection_item| collection_item.update_attribute(:anonymous, false) }
-    send_author_reveal_notifications
   end
   
   def send_reveal_notifications
     approved_collection_items.each {|collection_item| collection_item.notify_of_reveal}
   end
   
-  def send_author_reveal_notifications
-    approved_collection_items.each {|collection_item| collection_item.notify_of_author_reveal}
-  end
-
   def self.sorted_and_filtered(sort, filters, page)
     pagination_args = {:page => page}
 

--- a/app/models/creation_observer.rb
+++ b/app/models/creation_observer.rb
@@ -11,8 +11,13 @@ class CreationObserver < ActiveRecord::Observer
   # Send notifications when a creation is posted from a draft state
   def before_update(creation)
     notify_co_authors(creation)
-    return unless !creation.is_a?(Series) && creation.valid? && creation.posted_changed? && creation.posted?
-    do_notify(creation)
+    return unless !creation.is_a?(Series) && creation.valid? && creation.posted?
+
+    if creation.posted_changed?
+      do_notify(creation)
+    else
+      notify_subscribers_on_reveal(creation)
+    end
   end
 
   # Notify recipients after save only to prevent repeat notifications from previewing
@@ -74,6 +79,31 @@ class CreationObserver < ActiveRecord::Observer
     if work && !work.unrevealed? && !work.anonymous?
       Subscription.for_work(work).each do |subscription|
         RedisMailQueue.queue_subscription(subscription, creation)
+      end
+    end
+  end
+
+  # Check whether the work's creator has just been revealed (whether because
+  # a collection has just revealed its works, or a collection has just revealed
+  # creators). If so, queue up creator subscription emails.
+  def notify_subscribers_on_reveal(work)
+    # Double-check that it's a posted work.
+    return unless work.is_a?(Work) && work.posted
+
+    # Bail out if the work or its creator is currently unrevealed.
+    return if work.in_anon_collection || work.in_unrevealed_collection
+
+    # If we've reached here, the creator of the work must be public.
+    # So now we want to check whether that's a recent thing.
+    if work.in_anon_collection_changed? || work.in_unrevealed_collection_changed?
+      # Prior to this save, the work was either anonymous or unrevealed.
+      # Either way, the author was just revealed, so we should trigger
+      # a creator subscription email.
+      Subscription.where(
+        subscribable_id: work.pseuds.pluck(:user_id),
+        subscribable_type: "User"
+      ).each do |subscription|
+        RedisMailQueue.queue_subscription(subscription, work)
       end
     end
   end

--- a/features/collections/collection_anonymity.feature
+++ b/features/collections/collection_anonymity.feature
@@ -36,9 +36,8 @@ Feature: Collection
       # not anonymous
       And the email to "third_user" should contain "first_user"
     When subscription notifications are sent
-      And "AO3-4367: author subscribers not notified when works revealed" is fixed
-    #Then "second_user" should be emailed
-    #  And the email to "second_user" should contain "first_user"
+    Then "second_user" should be emailed
+      And the email to "second_user" should contain "first_user"
     When I am logged out
     Then the work "New Snippet" should be visible to me
     When I view the collection "Hidden Treasury"
@@ -71,12 +70,11 @@ Feature: Collection
     # Then "third_user" should be emailed
     #   And the email to "third_user" should contain "first_user"
     When subscription notifications are sent
-      And "AO3-4367: author subscribers not notified when works revealed" is fixed
-    # Then "second_user" should be emailed
-    #   And 1 emails should be delivered
-    #   And the email to "second_user" should contain "first_user"
-    #   And the email to "second_user" should contain "First Snippet"
-    #   And the email to "second_user" should not contain "Second Snippet"
+    Then "second_user" should be emailed
+      And 1 emails should be delivered
+      And the email to "second_user" should contain "first_user"
+      And the email to "second_user" should contain "First Snippet"
+      And the email to "second_user" should not contain "Second Snippet"
     When I am logged out
     Then the work "First Snippet" should be visible to me
       And the work "Second Snippet" should be hidden from me
@@ -244,4 +242,64 @@ Feature: Collection
     Then the author of "Cone of Silence" should be visible to me on the work page
     When I am logged out
     Then the author of "Cone of Silence" should be hidden from me
-  
+
+  Scenario: A work is in two anonymous collections, and one is revealed
+    Given I have the anonymous collection "Permanent Mice"
+      And I have the anonymous collection "Temporary Mice"
+      And I am logged in as "a_nonny_mouse"
+      And I post the work "Cheesy Goodness"
+      And I add the work "Cheesy Goodness" to the collection "Permanent Mice"
+      And I add the work "Cheesy Goodness" to the collection "Temporary Mice"
+      And "eager_fan" subscribes to author "a_nonny_mouse"
+
+    When I am logged in as "moderator"
+      And I reveal authors for "Temporary Mice"
+      And subscription notifications are sent
+
+    Then "eager_fan" should not be emailed
+
+  Scenario: A work is in two unrevealed collections, and one is revealed
+    Given I have the hidden collection "Super-Secret"
+      And I have the hidden collection "Secret for Now"
+      And I am logged in as "classified"
+      And I post the work "Top-Secret Goodness"
+      And I add the work "Top-Secret Goodness" to the collection "Super-Secret"
+      And I add the work "Top-Secret Goodness" to the collection "Secret for Now"
+      And "eager_fan" subscribes to author "classified"
+
+    When I am logged in as "moderator"
+      And I reveal works for "Secret for Now"
+      And subscription notifications are sent
+
+    Then "eager_fan" should not be emailed
+
+  Scenario: A work is in one anonymous and one hidden collection, and the anonymous collection is revealed
+    Given I have the hidden collection "Triple-Secret"
+      And I have the anonymous collection "Cheese Enthusiasts"
+      And I am logged in as "classified"
+      And I post the work "Half and Half"
+      And I add the work "Half and Half" to the collection "Triple-Secret"
+      And I add the work "Half and Half" to the collection "Cheese Enthusiasts"
+      And "eager_fan" subscribes to author "classified"
+
+    When I am logged in as "moderator"
+      And I reveal authors for "Cheese Enthusiasts"
+      And subscription notifications are sent
+
+    Then "eager_fan" should not be emailed
+
+  Scenario: A work is in one anonymous and one hidden collection, and the hidden collection is revealed
+    Given I have the hidden collection "Hidden Dreams"
+      And I have the anonymous collection "Anons Anonymous"
+      And I am logged in as "classified"
+      And I post the work "Half and Half"
+      And I add the work "Half and Half" to the collection "Hidden Dreams"
+      And I add the work "Half and Half" to the collection "Anons Anonymous"
+      And "eager_fan" subscribes to author "classified"
+
+    When I am logged in as "moderator"
+      And I reveal works for "Hidden Dreams"
+      And subscription notifications are sent
+
+    Then "eager_fan" should not be emailed
+


### PR DESCRIPTION
https://otwarchive.atlassian.net/browse/AO3-4108
https://otwarchive.atlassian.net/browse/AO3-4367

Attempts to fix AO3-4108 (and AO3-4367) by removing the code for author reveals from the CollectionItem and Collection objects, and rewriting a similar system within CreationObserver's before_update function.

The bug AO3-4108, where works in two anon collections send out author subscription emails when only one collection does author reveals, meant that CollectionItem's notify_of_author_reveal needed to be able to check whether the item was in another anonymous collection (i.e. whether it would still be anonymous after the author reveal). In other words, when queuing up author subscription emails, it would be really nice to access the *new* value of item.in_anon_collection (the value that takes into account the newly-de-anonymized collection). Unfortunately, item.in_anon_collection doesn't seem to be updated before notify_of_author_reveal is called, and I didn't want to duplicate work by calculating the value twice.

I eventually decided to try to move the logic for author reveal emails to CreationObserver's before_update function, where the other half of the creator subscriber code lives. (And it gets called just before the work's value of in_anon_collection is saved, so it's guaranteed to be up-to-date.) Instead of relying on a call from Collection, it checks whether the work's creator is currently visible, and then uses in_anon_collection_changed? and in_revealed_collection_changed? to tell whether the author is newly revealed (and thus whether emails should be sent out).

As a happy accident, the code that I wrote also seems to fix AO3-4367 (the bug where author reveals aren't sent out for a collection that goes straight from unrevealed to revealed, with no anon period).

I wrote up four new cucumber tests, for four scenarios:

1. A work is in two anonymous collections and one is revealed.
2. A work is in two hidden collections and one is revealed.
3. A work is in two collections, one hidden and one anonymous, and the anonymous collection is revealed.
4. A work is in two collections, one hidden and one anonymous, and the hidden collection is revealed.

In each of these scenarios, no author subscription emails should be sent. The original code actually passes two of these tests, because AO3-4367 means that author subscriptions aren't sent out in scenarios 2 and 4. But since my code seems to fix AO3-4367, I figured it would be good to add some tests to make sure that I wasn't missing any weird edge cases.

I also uncommented the two existing tests for AO3-4367.