### PR TITLE
AO3-1259 Option to remove self as chapter co-creator for edit page

### DIFF
--- a/app/controllers/chapters_controller.rb
+++ b/app/controllers/chapters_controller.rb
@@ -93,7 +93,7 @@ class ChaptersController < ApplicationController
     if params["remove"] == "me"
       @chapter.pseuds = @chapter.pseuds - current_user.pseuds
       @chapter.save
-      flash[:notice] = ts("You have been removed as an author from the chapter")
+      flash[:notice] = ts("You have been removed as a creator from the chapter")
      redirect_to @work
     end
   end

--- a/app/controllers/chapters_controller.rb
+++ b/app/controllers/chapters_controller.rb
@@ -94,7 +94,7 @@ class ChaptersController < ApplicationController
       @chapter.pseuds = @chapter.pseuds - current_user.pseuds
       @chapter.save
       flash[:notice] = ts("You have been removed as a creator from the chapter")
-     redirect_to @work
+      redirect_to @work
     end
   end
 

--- a/app/models/chapter.rb
+++ b/app/models/chapter.rb
@@ -94,6 +94,13 @@ class Chapter < ActiveRecord::Base
     end
   end
 
+  after_save :expire_caches
+  def expire_caches
+    unless Rails.env.development?
+      self.touch
+    end
+  end
+
   def moderated_commenting_enabled?
     work && work.moderated_commenting_enabled?
   end

--- a/app/views/chapters/edit.html.erb
+++ b/app/views/chapters/edit.html.erb
@@ -9,7 +9,7 @@
 <!--subnav-->
 <ul class="navigation actions" role="navigation">
   <li><%= link_to ts('Delete Chapter'), [:confirm_delete, @work, @chapter], :confirm => ts('Are you sure you want to delete this chapter? This will delete all comments on the chapter as well and cannot be undone!') %></li>
-  <% if @work.pseuds.size > 1 && @chapter.pseuds.size > 1 %>
+  <% if @work.pseuds.size > 1 && @chapter.pseuds.size > 1 && current_user.is_author_of?(@chapter) %>
     <li>
       <%= link_to ts("Remove Me As Author"), {:action => "edit", :id => @chapter.id, :remove => "me"}, :confirm => ts("You will no longer be able to edit this chapter. Are you sure?") %>
     </li>

--- a/app/views/chapters/edit.html.erb
+++ b/app/views/chapters/edit.html.erb
@@ -16,7 +16,7 @@
     <li>
       <%= link_to ts("Remove Me As Chapter Co-Creator"),
                   {action: "edit", id: @chapter.id, remove: "me"},
-                  confirm: ts("You will no longer be able to edit this chapter. Are you sure?") %>
+                  confirm: ts("Are you sure you want to remove yourself as a co-creator of this chapter?") %>
     </li>
   <% end %> 
 </ul>

--- a/app/views/chapters/edit.html.erb
+++ b/app/views/chapters/edit.html.erb
@@ -11,7 +11,7 @@
   <li><%= link_to ts('Delete Chapter'), [:confirm_delete, @work, @chapter], :confirm => ts('Are you sure you want to delete this chapter? This will delete all comments on the chapter as well and cannot be undone!') %></li>
   <% if @work.pseuds.size > 1 && @chapter.pseuds.size > 1 && current_user.is_author_of?(@chapter) %>
     <li>
-      <%= link_to ts("Remove Me As Author"), {:action => "edit", :id => @chapter.id, :remove => "me"}, :confirm => ts("You will no longer be able to edit this chapter. Are you sure?") %>
+      <%= link_to ts("Remove Me As Chapter Co-Creator"), {:action => "edit", :id => @chapter.id, :remove => "me"}, :confirm => ts("You will no longer be able to edit this chapter. Are you sure?") %>
     </li>
   <% end %> 
 </ul>

--- a/app/views/chapters/edit.html.erb
+++ b/app/views/chapters/edit.html.erb
@@ -8,15 +8,20 @@
 
 <!--subnav-->
 <ul class="navigation actions" role="navigation">
-  <li><%= link_to ts('Delete Chapter'), [:confirm_delete, @work, @chapter], :confirm => ts('Are you sure you want to delete this chapter? This will delete all comments on the chapter as well and cannot be undone!') %></li>
+  <li>
+    <%= link_to ts('Delete Chapter'), [:confirm_delete, @work, @chapter],
+                confirm: ts('Are you sure you want to delete this chapter? This will delete all comments on the chapter as well and cannot be undone!') %>
+  </li>
   <% if @work.pseuds.size > 1 && @chapter.pseuds.size > 1 && current_user.is_author_of?(@chapter) %>
     <li>
-      <%= link_to ts("Remove Me As Chapter Co-Creator"), {:action => "edit", :id => @chapter.id, :remove => "me"}, :confirm => ts("You will no longer be able to edit this chapter. Are you sure?") %>
+      <%= link_to ts("Remove Me As Chapter Co-Creator"),
+                  {action: "edit", id: @chapter.id, remove: "me"},
+                  confirm: ts("You will no longer be able to edit this chapter. Are you sure?") %>
     </li>
   <% end %> 
 </ul>
 <!--/subnav-->
 
 <!--main content-->
-<%= render 'chapter_form', :chapter => @chapter %>
+<%= render 'chapter_form', chapter: @chapter %>
 <!--/content-->

--- a/app/views/chapters/edit.html.erb
+++ b/app/views/chapters/edit.html.erb
@@ -7,8 +7,13 @@
 <!--/descriptions-->
 
 <!--subnav-->
-<ul class="navigation actions" role="menu">
+<ul class="navigation actions" role="navigation">
   <li><%= link_to ts('Delete Chapter'), [:confirm_delete, @work, @chapter], :confirm => ts('Are you sure you want to delete this chapter? This will delete all comments on the chapter as well and cannot be undone!') %></li>
+  <% if @work.pseuds.size > 1 && @chapter.pseuds.size > 1 %>
+    <li>
+      <%= link_to ts("Remove Me As Author"), {:action => "edit", :id => @chapter.id, :remove => "me"}, :confirm => ts("You will no longer be able to edit this chapter. Are you sure?") %>
+    </li>
+  <% end %> 
 </ul>
 <!--/subnav-->
 

--- a/app/views/chapters/manage.html.erb
+++ b/app/views/chapters/manage.html.erb
@@ -37,7 +37,7 @@
               <li>
                 <%= link_to ts("Remove Me As Chapter Co-Creator"),
                             {action: "edit", id: chapter.id, remove: "me"},
-                            confirm: ts("You will no longer be able to edit this chapter. Are you sure?") %>
+                            confirm: ts("Are you sure you want to remove yourself as a co-creator of this chapter?") %>
               </li>
             <% end %> 
           <% end %>

--- a/app/views/chapters/manage.html.erb
+++ b/app/views/chapters/manage.html.erb
@@ -16,7 +16,7 @@
           <li><%= link_to ts("Edit"), [:edit, @work, chapter] %></li>
            <% if @work.chapters.count > 1 %>
              <li><%= link_to ts("Delete"), [@work, chapter], :confirm => ts("Are you sure?"), :method => :delete %></li>
-             <% if @work.pseuds.size > 1 && chapter.pseuds.size > 1 %>
+             <% if @work.pseuds.size > 1 && chapter.pseuds.size > 1 && current_user.is_author_of?(@chapter) %>
                <li><%= link_to ts("Remove Me As Author"), {:action => "edit", :id => chapter.id, :remove => "me"}, :confirm => ts("You will no longer be able to edit this chapter. Are you sure?") %></li>
              <% end %> 
           <% end %>

--- a/app/views/chapters/manage.html.erb
+++ b/app/views/chapters/manage.html.erb
@@ -1,33 +1,57 @@
-<!--REVIEW: this is very different, including classes, to most of the front end. Can it be regularised? Can it be generalised?-->
-<div id="manage-chapters">
+<!--Descriptive page name, messages and instructions-->
+<h2 class="heading"><%= ts('Manage Chapters') %></h2>
+<!--/descriptions-->
 
-  <h4 class="heading"><%= ts("Delete/reorder chapters") %></h4>
+<!--subnav-->
+<!--/subnav-->
+
+<!--main content-->
+<div id="manage-chapters">
 
   <p id="drag" class="showme"><%= ts("Drag chapters to change their order.") %><p>
   <noscript><p><%= ts("Enter new chapter numbers.") %><p></noscript>
-  <%= form_tag url_for(:action => 'update_positions') do %>
+
+  <%= form_tag url_for(action: 'update_positions') do %>
+
   <ul id="sortable_chapter_list" class="sortable">
     <% for chapter in @chapters %>
-      <li id="chapter_<%= chapter.id %>" class='chapter-position-list'>
-        <%= text_field_tag 'chapters[]', nil, :size => 3, :maxlength => 3, :class => 'number chapter-position-field', :id => 'chapters_' + chapter.position.to_s %>
-        <span id='position-for-<%= chapter.id %>'><%= chapter.position %></span>. 
+      <li id="chapter_<%= chapter.id %>" class="chapter-position-list">
+
+        <%= text_field_tag 'chapters[]', nil,
+                                        size: 3,
+                                        maxlength: 3,
+                                        class: "number chapter-position-field",
+                                        id: "chapters_" + chapter.position.to_s %>
+        <span id="position-for-<%= chapter.id %>"><%= chapter.position %></span>.
         <%= chapter.chapter_title.html_safe %>
-        <ul class='chapter-control actions' role="menu">
+
+        <ul class="chapter-control actions">
           <li><%= link_to ts("Edit"), [:edit, @work, chapter] %></li>
-           <% if @work.chapters.count > 1 %>
-             <li><%= link_to ts("Delete"), [@work, chapter], :confirm => ts("Are you sure?"), :method => :delete %></li>
-             <% if @work.pseuds.size > 1 && chapter.pseuds.size > 1 && current_user.is_author_of?(chapter) %>
-               <li><%= link_to ts("Remove Me As Chapter Co-Creator"), {:action => "edit", :id => chapter.id, :remove => "me"}, :confirm => ts("You will no longer be able to edit this chapter. Are you sure?") %></li>
-             <% end %> 
+          <% if @work.chapters.count > 1 %>
+            <li>
+              <%= link_to ts("Delete"), [@work, chapter],
+                                        confirm: ts("Are you sure?"),
+                                        method: :delete %>
+            </li>
+            <% if @work.pseuds.size > 1 && chapter.pseuds.size > 1 && current_user.is_author_of?(chapter) %>
+              <li>
+                <%= link_to ts("Remove Me As Chapter Co-Creator"),
+                            {action: "edit", id: chapter.id, remove: "me"},
+                            confirm: ts("You will no longer be able to edit this chapter. Are you sure?") %>
+              </li>
+            <% end %> 
           <% end %>
         </ul>
+
       </li>
-    <% end %>    
+    <% end %>
   </ul>
+
   <p class="submit actions">
     <%= submit_tag ts("Update Positions") %>
     <%= link_to ts("Back"), url_for(@work) %>
   </p>
+
   <% end %>
 </div>
 
@@ -49,3 +73,4 @@
       })
   <% end %>
 <% end %>
+<!--/content-->

--- a/app/views/chapters/manage.html.erb
+++ b/app/views/chapters/manage.html.erb
@@ -16,7 +16,7 @@
           <li><%= link_to ts("Edit"), [:edit, @work, chapter] %></li>
            <% if @work.chapters.count > 1 %>
              <li><%= link_to ts("Delete"), [@work, chapter], :confirm => ts("Are you sure?"), :method => :delete %></li>
-             <% if @work.pseuds.size > 1 && chapter.pseuds.size > 1 && current_user.is_author_of?(@chapter) %>
+             <% if @work.pseuds.size > 1 && chapter.pseuds.size > 1 && current_user.is_author_of?(chapter) %>
                <li><%= link_to ts("Remove Me As Author"), {:action => "edit", :id => chapter.id, :remove => "me"}, :confirm => ts("You will no longer be able to edit this chapter. Are you sure?") %></li>
              <% end %> 
           <% end %>

--- a/app/views/chapters/manage.html.erb
+++ b/app/views/chapters/manage.html.erb
@@ -17,7 +17,7 @@
            <% if @work.chapters.count > 1 %>
              <li><%= link_to ts("Delete"), [@work, chapter], :confirm => ts("Are you sure?"), :method => :delete %></li>
              <% if @work.pseuds.size > 1 && chapter.pseuds.size > 1 && current_user.is_author_of?(chapter) %>
-               <li><%= link_to ts("Remove Me As Author"), {:action => "edit", :id => chapter.id, :remove => "me"}, :confirm => ts("You will no longer be able to edit this chapter. Are you sure?") %></li>
+               <li><%= link_to ts("Remove Me As Chapter Co-Creator"), {:action => "edit", :id => chapter.id, :remove => "me"}, :confirm => ts("You will no longer be able to edit this chapter. Are you sure?") %></li>
              <% end %> 
           <% end %>
         </ul>

--- a/app/views/pseuds/_byline.html.erb
+++ b/app/views/pseuds/_byline.html.erb
@@ -1,36 +1,58 @@
-<!-- Co-Author stuff -->
-
 <dt class="byline<%= @pseuds.size > 1 ? "" : " hidden" %>">
-  <%= label_tag "#{type}_author_attributes_ids_", ts("Author / Pseud(s)") %>
+  <%= label_tag "#{type}_author_attributes_ids_", ts("Creator/Pseud(s)") %>
 </dt>
 <dd class="byline<%= @pseuds.size > 1 ? "" : " hidden" %>">
   <%= select_tag "#{type}[author_attributes][ids][]",
-      options_from_collection_for_select(@pseuds, :id, :name, @selected_pseuds), :multiple => true %>
+      options_from_collection_for_select(@pseuds, :id, :name, @selected_pseuds), multiple: true %>
 </dd>
 
-<% unless @coauthors.blank? %>
-  <select name="<%= type %>[author_attributes][coauthors][]" multiple="multiple" class="hidden">
-    <%= options_from_collection_for_select(@coauthors, :id, :name, @selected_pseuds) %>
-  </select>
-<% end %>
-
 <% if @coauthors.size > 0 %>
-  <dt class="byline"><%= ts("Current Co-authors:") %> </dt>
-    <dd class="byline">
-      <ul>
+  <dt class="byline">
+    <%= type == "chapter" ? ts("Work co-creators") : ts("Current co-creators") %>
+  </dt>
+  <dd class="byline">
+    <ul>
+      <% for author in @coauthors %>
+        <li><%= author.byline %></li>
+      <% end %>
+    </ul>
+  </dd>
+
+  <% if type == "chapter" %>
+    <dt>
+      <%= ts("Chapter co-creators") %>
+    </dt>
+    <dd class="listbox">
+      <h4 class="heading"><%= ts('Co-creators') %></h4>
+      <ul class="many options index">
         <% for author in @coauthors %>
-          <li><%= author.byline %></li>
+          <li>
+            <% # You should only be able to add co-creators %>
+            <% author_is_coauthor = @chapter.new_record? ? false :
+                                    @selected_pseuds.include?(author.id) %>
+            <%= label_tag "chapter_author_attributes_coauthors_#{author.id}",
+                          author.id, class: "action" do %>
+              <%= check_box_tag "chapter[author_attributes][coauthors][]",
+                                author.id,
+                                author_is_coauthor,
+                                disabled: author_is_coauthor,
+                                id: "chapter_author_attributes_coauthors_#{author.id}" %>
+              <%= author.name %>
+            <% end %>
+          </li>
         <% end %>
       </ul>
     </dd>
+  <% end %>
 <% end %>
 
+
 <dt class="byline coauthors">
- <%= label_tag "co-authors-options-show", ts('Add co-authors?') %> 
+ <%= label_tag "co-authors-options-show", ts('Add co-creators?') %> 
 </dt>
 <dd class="byline coauthors">
-  <%= check_box_tag "co-authors-options-show", "1", nil, :class => "toggle_formfield" %>
-  <fieldset id="co-authors-options" title="Add Co Authors">
-    <%= text_field :pseud, :byline, autocomplete_options("pseud", :size => 50) %>
+  <%= check_box_tag "co-authors-options-show", "1", nil, class: "toggle_formfield" %>
+  <fieldset id="co-authors-options" title="<%= ts('Add co-creators') %>">
+    <%= text_field :pseud, :byline, autocomplete_options("pseud", size: 50) %>
   </fieldset>
 </dd>

--- a/features/step_definitions/autocomplete_steps.rb
+++ b/features/step_definitions/autocomplete_steps.rb
@@ -174,8 +174,8 @@ Given /^a set of users for testing autocomplete$/ do
 end
 
 Then /^the coauthor autocomplete field should list matching users$/ do
-  check("Add co-authors?")
-  fill_in("pseud_byline", :with => "coa")
+  check("co-authors-options-show")
+  fill_in("pseud_byline", with: "coa")
   step %{I should see "coauthor" in the autocomplete}
   step %{I should not see "giftee" in the autocomplete}
 end

--- a/features/step_definitions/work_steps.rb
+++ b/features/step_definitions/work_steps.rb
@@ -514,10 +514,10 @@ Then /^the work "([^\"]*)" should be deleted$/ do |work|
   assert !Work.where(title: work).exists?
 end
 
-Then /^the Remove Me As Author option should be on the ([\d]+)(?:st|nd|rd|th) chapter$/ do |chapter_number|
-  step %{I should see "Remove Me As Author" within "ul#sortable_chapter_list > li:nth-of-type(#{chapter_number})"}
+Then /^the Remove Me As Chapter Co-Creator option should be on the ([\d]+)(?:st|nd|rd|th) chapter$/ do |chapter_number|
+  step %{I should see "Remove Me As Chapter Co-Creator" within "ul#sortable_chapter_list > li:nth-of-type(#{chapter_number})"}
 end
 
-Then /^the Remove Me As Author option should not be on the ([\d]+)(?:st|nd|rd|th) chapter$/ do |chapter_number|
-  step %{I should not see "Remove Me As Author" within "ul#sortable_chapter_list > li:nth-of-type(#{chapter_number})"}
+Then /^the Remove Me As Chapter Co-Creator option should not be on the ([\d]+)(?:st|nd|rd|th) chapter$/ do |chapter_number|
+  step %{I should not see "Remove Me As Chapter Co-Creator" within "ul#sortable_chapter_list > li:nth-of-type(#{chapter_number})"}
 end

--- a/features/step_definitions/work_steps.rb
+++ b/features/step_definitions/work_steps.rb
@@ -216,19 +216,30 @@ When /^a chapter is added to "([^\"]*)"$/ do |work_title|
   Work.tire.index.refresh
 end
 
+When /^a chapter with the co-author "([^\"]*)" is added to "([^\"]*)"$/ do |coauthor, work_title|
+  step %{a new chapter for "#{work_title}" is started}
+  step %{I add the co-author "#{coauthor}"}
+  click_button("Post")
+  Work.tire.index.refresh
+end
+
 When /^a draft chapter is added to "([^\"]*)"$/ do |work_title|
+  step %{a new chapter for "#{work_title}" is started}
+  step %{I press "Preview"}
+  Work.tire.index.refresh
+end
+
+When /^a new chapter for "([^\"]*)" is started$/ do |work_title|
   work = Work.find_by_title(work_title)
   user = work.users.first
   step %{I am logged in as "#{user.login}"}
   visit work_url(work)
   step %{I follow "Add Chapter"}
   step %{I fill in "content" with "la la la la la la la la la la la"}
-  step %{I press "Preview"}
-  Work.tire.index.refresh
 end
 
 # meant to be used in conjunction with above step
-When /^I post the draft chapter$/ do
+When /^I post the(?: draft)? chapter$/ do
   click_button("Post")
   Work.tire.index.refresh
 end
@@ -425,7 +436,7 @@ end
 
 When /^I add the co-author "([^\"]*)"$/ do |coauthor|
   step %{the user "#{coauthor}" exists and is activated}
-  check("Add co-authors?")
+  check("co-authors-options-show")
   fill_in("pseud_byline", with: "#{coauthor}")
 end
 

--- a/features/step_definitions/work_steps.rb
+++ b/features/step_definitions/work_steps.rb
@@ -513,3 +513,11 @@ end
 Then /^the work "([^\"]*)" should be deleted$/ do |work|
   assert !Work.where(title: work).exists?
 end
+
+Then /^the Remove Me As Author option should be on the ([\d]+)(?:st|nd|rd|th) chapter$/ do |chapter_number|
+  step %{I should see "Remove Me As Author" within "ul#sortable_chapter_list > li:nth-of-type(#{chapter_number})"}
+end
+
+Then /^the Remove Me As Author option should not be on the ([\d]+)(?:st|nd|rd|th) chapter$/ do |chapter_number|
+  step %{I should not see "Remove Me As Author" within "ul#sortable_chapter_list > li:nth-of-type(#{chapter_number})"}
+end

--- a/features/works/chapter_edit.feature
+++ b/features/works/chapter_edit.feature
@@ -202,7 +202,7 @@ Feature: Edit chapters
   When I press "Post"
     Then I should see "Chapter was successfully posted."
     And I should not see "This chapter is a draft and hasn't been posted yet!"
-  
+
 
   Scenario: Create a work and add a draft chapter, edit the draft chapter, and save changes to the draft chapter without previewing or posting
   Given basic tags
@@ -228,7 +228,7 @@ Feature: Edit chapters
   Then I should see "Chapter was successfully updated."
     And I should see "This chapter is a draft and hasn't been posted yet!"
     And I should see "Like the ability to save easily."
-    
+
 
   Scenario: Chapter drafts aren't updates; posted chapter drafts are
     Given I am logged in as "testuser" with password "testuser"
@@ -251,7 +251,7 @@ Feature: Edit chapters
     When I follow "Edit Chapter"
       And I press "Post Without Preview"
       Then I should see Updated today
-      
+
 
   Scenario: Posting a new chapter without previewing should set the work's updated date to now
 
@@ -278,3 +278,83 @@ Feature: Edit chapters
       And I press "Post Without Preview"
       And I go to the works page
     Then "First work" should appear before "A Whole New Work"
+
+
+  Scenario: Posting a new chapter with a co-creator does not add them to previous or
+  subsequent chapters
+
+    Given I am logged in as "karma" with password "the1nonly"
+      And I post the work "Summer Friends"
+    When a new chapter for "Summer Friends" is started
+    Then I should not see "Chapter co-creators"
+    When I add the co-author "sabrina"
+      And I post the chapter
+    Then I should see "karma, sabrina"
+    When I follow "Previous Chapter"
+    Then I should see "Chapter by karma"
+    When a new chapter for "Summer Friends" is started
+    Then I should see "Chapter co-creators"
+      And the "sabrina" checkbox should not be checked
+    When I post the chapter
+    Then I should see "Chapter by karma"
+
+
+  Scenario: You should be able to edit a chapter to add a co-creator who is not already
+  on the work
+
+    Given I am logged in as "karma" with password "the1nonly"
+      And I post the work "Forever Friends"
+      And a chapter is added to "Forever Friends"
+    When I view the work "Forever Friends"
+      And I view the 2nd chapter
+      And I follow "Edit Chapter"
+    Then I should not see "Chapter co-creators"
+    When I add the co-author "amy"
+      And I post the chapter
+    Then I should see "amy, karma"
+
+
+  Scenario: You should be able to edit a chapter to add a co-creator who is already on
+  the work
+
+    Given I am logged in as "karma" with password "the1noly"
+      And I post the work "Past Friends"
+      And a chapter with the co-author "sabrina" is added to "Past Friends"
+      And a chapter is added to "Past Friends"
+   When I view the work "Past Friends"
+      And I view the 3rd chapter
+    Then I should see "Chapter by karma"
+    When I follow "Edit Chapter"
+    Then I should see "Chapter co-creators"
+      And the "sabrina" checkbox should not be checked
+    When I check "sabrina"
+      And I post the chapter
+    Then I should not see "Chapter by karma"
+
+
+  Scenario: Editing a chapter with a co-creator should not give you the ability to
+  remove them as a co-creator
+
+    Given I am logged in as "karma" with password "the1noly"
+      And I post the work "Camp Friends"
+      And a chapter with the co-author "sabrina" is added to "Camp Friends"
+    When I follow "Edit Chapter"
+    Then I should see "Chapter co-creators"
+      And the "sabrina" checkbox should be checked
+      And the "sabrina" checkbox should be disabled
+
+
+  Scenario: Editing a chapter even if you are not a co-creator
+
+    Given I am logged in as "originalposter"
+      And I post the work "OP's Work"
+      And a chapter with the co-author "opsfriend" is added to "OP's Work"
+    When I am logged in as "opsfriend"
+      And I view the work "OP's Work"
+    Then I should see "Chapter 1"
+      And I should see "Chapter by originalposter"
+    When I follow "Edit Chapter"
+      And I fill in "content" with "opsfriend was here"
+      And I post the chapter
+    Then I should see "opsfriend was here"
+      And I should see "Chapter by originalposter"

--- a/features/works/chapter_edit.feature
+++ b/features/works/chapter_edit.feature
@@ -384,9 +384,31 @@ Feature: Edit chapters
       And a chapter with the co-author "opsfriend" is added to "OP's Work"
     When I am logged in as "opsfriend"
       And I view the work "OP's Work"
+      And I follow "Edit"
       And I follow "Manage Chapters"
     When I follow "Remove Me As Author"
     Then I should see "You have been removed as an author from the chapter"
       And I should see "Chapter 1"
     When I view the 2nd chapter
     Then I should see "Chapter by originalposter"
+
+
+  Scenario: The option to remove yourself as a co-creator should only be included for
+  chapters you are a co-creator of
+
+    Given I am logged in as "originalposter"
+      And I post the work "OP's Work"
+      And a chapter with the co-author "opsfriend" is added to "OP's Work"
+    When I am logged in as "opsfriend"
+      And I view the work "OP's Work"
+      And I follow "Edit"
+      And I follow "Manage Chapters"
+    Then the Remove Me As Author option should not be on the 1st chapter
+      And the Remove Me As Author option should be on the 2nd chapter
+    When I view the work "OP's Work"
+      And I follow "Edit Chapter"
+    Then I should not see "Remove Me As Author"
+    When I view the work "OP's Work"
+      And I view the 2nd chapter
+      And I follow "Edit Chapter"
+    Then I should see "Remove Me As Author"

--- a/features/works/chapter_edit.feature
+++ b/features/works/chapter_edit.feature
@@ -358,3 +358,35 @@ Feature: Edit chapters
       And I post the chapter
     Then I should see "opsfriend was here"
       And I should see "Chapter by originalposter"
+
+
+  Scenario: Removing yourself as a co-creator from the chapter edit page
+
+    Given I am logged in as "originalposter"
+      And I post the work "OP's Work"
+      And a chapter with the co-author "opsfriend" is added to "OP's Work"
+    When I am logged in as "opsfriend"
+      And I view the work "OP's Work"
+      And I view the 2nd chapter
+      And I follow "Edit Chapter"
+    When I follow "Remove Me As Author"
+    Then I should see "You have been removed as an author from the chapter"
+      And I should see "Chapter 1"
+    When I view the 2nd chapter
+    Then I should see "Chapter 2"
+      And I should see "Chapter by originalposter"
+
+
+  Scenario: Removing yourself as a co-creator from the chapter manage page
+
+    Given I am logged in as "originalposter"
+      And I post the work "OP's Work"
+      And a chapter with the co-author "opsfriend" is added to "OP's Work"
+    When I am logged in as "opsfriend"
+      And I view the work "OP's Work"
+      And I follow "Manage Chapters"
+    When I follow "Remove Me As Author"
+    Then I should see "You have been removed as an author from the chapter"
+      And I should see "Chapter 1"
+    When I view the 2nd chapter
+    Then I should see "Chapter by originalposter"

--- a/features/works/chapter_edit.feature
+++ b/features/works/chapter_edit.feature
@@ -369,8 +369,8 @@ Feature: Edit chapters
       And I view the work "OP's Work"
       And I view the 2nd chapter
       And I follow "Edit Chapter"
-    When I follow "Remove Me As Author"
-    Then I should see "You have been removed as an author from the chapter"
+    When I follow "Remove Me As Chapter Co-Creator"
+    Then I should see "You have been removed as a creator from the chapter"
       And I should see "Chapter 1"
     When I view the 2nd chapter
     Then I should see "Chapter 2"
@@ -386,8 +386,8 @@ Feature: Edit chapters
       And I view the work "OP's Work"
       And I follow "Edit"
       And I follow "Manage Chapters"
-    When I follow "Remove Me As Author"
-    Then I should see "You have been removed as an author from the chapter"
+    When I follow "Remove Me As Chapter Co-Creator"
+    Then I should see "You have been removed as a creator from the chapter"
       And I should see "Chapter 1"
     When I view the 2nd chapter
     Then I should see "Chapter by originalposter"
@@ -403,12 +403,12 @@ Feature: Edit chapters
       And I view the work "OP's Work"
       And I follow "Edit"
       And I follow "Manage Chapters"
-    Then the Remove Me As Author option should not be on the 1st chapter
-      And the Remove Me As Author option should be on the 2nd chapter
+    Then the Remove Me As Chapter Co-Creator option should not be on the 1st chapter
+      And the Remove Me As Chapter Co-Creator option should be on the 2nd chapter
     When I view the work "OP's Work"
       And I follow "Edit Chapter"
-    Then I should not see "Remove Me As Author"
+    Then I should not see "Remove Me As Chapter Co-Creator"
     When I view the work "OP's Work"
       And I view the 2nd chapter
       And I follow "Edit Chapter"
-    Then I should see "Remove Me As Author"
+    Then I should see "Remove Me As Chapter Co-Creator"


### PR DESCRIPTION
https://otwarchive.atlassian.net/browse/AO3-1259

You could already remove yourself as a chapter co-creator, but it was hidden on the Manage Chapters page. Now it will be on the Edit page for an individual chapter. It will only show up if you are a co-creator of that particular chapter. It also now says "Chapter Co-Creator" instead of just "Author" because clarity is our friend.

I had to merge in the changes from #2515 so I could use the test steps I wrote for that... and so I could avoid merge conflicts with the tests.