### PR TITLE
AO3-4597 No vertical space separating rows of buttons

### DIFF
--- a/public/stylesheets/site/2.0/03-region-header.css
+++ b/public/stylesheets/site/2.0/03-region-header.css
@@ -280,6 +280,7 @@ notice that CSS3 declarations sit are indented twice (four spaces) and always co
  
 #header #search .button {
   height: auto;
+  margin: 0;
 }
  
 /*CONTEXT: collections*/

--- a/public/stylesheets/site/2.0/08-actions.css
+++ b/public/stylesheets/site/2.0/08-actions.css
@@ -15,6 +15,11 @@ ul.actions, p.actions, li.actions, span.actions, fieldset.actions, dd.actions {
   text-align: center;
 }
 
+ul.actions {
+  padding-bottom: 0;
+  padding-top: 0;
+}
+
 .actions a, .actions a:link, .action, .action:link, .actions input, input[type="submit"], button, .current, .actions label {
   background: #eee;
   color: #444;
@@ -134,7 +139,7 @@ ul#skiplinks, .landmark, .landmark a, .index .heading.landmark {
   z-index: 99;
   border: 2px solid #bbb;
   margin: auto;
-  padding: 0.375em;
+  padding: 0 0.375em;
   overflow: hidden;
   right: 2.5em;
     box-shadow: 2px 2px 5px #bbb;


### PR DESCRIPTION
https://otwarchive.atlassian.net/browse/AO3-4597

Changes addressing the header misalignment, chapter edit button misalignment, and whitespace in secondary menus that occurred when implementing the button spacing.