### PR TITLE
AO3-4628 Incompatible character encodings: ASCII-8BIT and UTF-8

### DIFF
--- a/app/models/story_parser.rb
+++ b/app/models/story_parser.rb
@@ -440,7 +440,7 @@ class StoryParser
         story = eval("download_from_#{source.downcase}(location)")
       end
 
-      return story.force_encoding("UTF-8")
+      return story
     end
 
     # canonicalize the url for downloading from lj or clones
@@ -943,7 +943,7 @@ class StoryParser
     # works conservatively -- doesn't split on
     # spaces and truncates instead.
     def clean_tags(tags)
-      tags = Sanitize.clean(tags) # no html allowed in tags
+      tags = Sanitize.clean(tags.force_encoding("UTF-8")) # no html allowed in tags
       if tags.match(/,/)
         tagslist = tags.split(/,/)
       else

--- a/app/models/story_parser.rb
+++ b/app/models/story_parser.rb
@@ -440,7 +440,7 @@ class StoryParser
         story = eval("download_from_#{source.downcase}(location)")
       end
 
-      return story
+      return story.force_encoding("UTF-8")
     end
 
     # canonicalize the url for downloading from lj or clones

--- a/spec/models/story_parser_spec.rb
+++ b/spec/models/story_parser_spec.rb
@@ -210,7 +210,6 @@ describe StoryParser do
       to_return(status: 200,
                 body: body.force_encoding("Windows-1252"),
                 headers: {})
-
   end
 
   describe "Import" do
@@ -227,8 +226,7 @@ describe StoryParser do
       urls = %w(http://ascii-8bit http://utf-8 http://win-1252)
       urls.each do |url|
         expect {
-          @sp.download_and_parse_story(url, { pseuds: [@user.default_pseud],
-                                              do_not_set_current_author: false })
+          @sp.download_and_parse_story(url, pseuds: [@user.default_pseud], do_not_set_current_author: false)
         }.to_not raise_exception
       end
     end


### PR DESCRIPTION
https://otwarchive.atlassian.net/browse/AO3-4628

This fixes a problem which occurs when importing a work (both manually or automatically) whose metadata contains non-ASCII characters. When these tags reach the Sanitise gem without specifying an encoding, it bombs out because it expects pure ASCII or UTF-8, but gets something it thinks is ASCII but actually contains Unicode characters.

I also add tests which reproduce the problem if you remove the UTF-8 encoding on the string passed to Sanitise.

This is a blocker for the ongoing Ink Stained Fingers import that is just waiting for the works with this problem to be imported.