### PR TITLE
AO3-3213 Fix tag unescaping for things like "a.k.a."

### DIFF
--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -503,7 +503,14 @@ class Tag < ActiveRecord::Base
   # Substitute characters that are particularly prone to cause trouble in urls
   def self.find_by_name(string)
     return unless string.is_a? String
-    string = string.gsub('*s*', '/').gsub('*a*', '&').gsub('*d*', '.').gsub('*q*', '?').gsub('*h*', '#')
+    string = string.gsub(
+      /\*[sadqh]\*/,
+      '*s*' => '/',
+      '*a*' => '&',
+      '*d*' => '.',
+      '*q*' => '?',
+      '*h*' => '#'
+    )
     self.where('tags.name = ?', string).first
   end
 

--- a/features/tags_and_wrangling/tag_wrangling_special.feature
+++ b/features/tags_and_wrangling/tag_wrangling_special.feature
@@ -120,4 +120,48 @@ Feature: Tag Wrangling - special cases
   When I view the tag "James T. Kirk"
     And I follow "filter works"
   Then I should see "1 Work in James T. Kirk"
-  
+
+  Scenario: Adding a noncanonical tag with "a.k.a.", and viewing works for that tag.
+
+    Given basic tags
+      And I am logged in as a random user
+
+    When I post the work "Escape Attempt" with fandom "a.k.a. Jessica Jones"
+      And I follow "a.k.a. Jessica Jones"
+
+    Then I should see "This tag belongs to the Fandom Category"
+      And I should see "a.k.a. Jessica Jones" within "h2.heading"
+      And I should see "Escape Attempt"
+
+  Scenario: Wranglers can edit a tag with "a.k.a." in the name.
+
+    Given a noncanonical fandom "a.k.a. Jessica Jones"
+      And a canonical fandom "Jessica Jones (TV)"
+
+    When I am logged in as a tag wrangler
+      And I edit the tag "a.k.a. Jessica Jones"
+    Then I should see "Edit a.k.a. Jessica Jones Tag"
+
+    When I fill in "Synonym of" with "Jessica Jones (TV)"
+      And I press "Save changes"
+    Then I should see "Tag was updated"
+
+  Scenario Outline: Tag with a, d, h, q, or s between special characters.
+
+    Given a canonical fandom "<char>a<char>d<char>h<char>q<char>s<char>"
+
+    When I am logged in as a tag wrangler
+      And I view the tag "<char>a<char>d<char>h<char>q<char>s<char>"
+    Then I should see "This tag belongs to the Fandom Category"
+      And I should see "Edit"
+
+    When I follow "Edit"
+    Then I should see "Edit <char>a<char>d<char>h<char>q<char>s<char> Tag"
+
+    Examples:
+      | char |
+      | /    |
+      | #    |
+      | .    |
+      | &    |
+      | ?    |


### PR DESCRIPTION
https://otwarchive.atlassian.net/browse/AO3-3213

Given a tag `A a.k.a. B`, the system for generating URLs turns that into `A a*d*k*d*a*d* B`. When that kind of tag name is passed to Tag.find_by_name, it first replaces all substrings `*s*` with `/`, then `*a*` with `&`, then `*d*` with `.`, etc. So when processing `A a*d*k*d*a*d* B`, it would first replace the `*a*` sequence in the middle to make `A a*d*k*d&d* B`, and then would replace the `*d*` sequence in the middle to make `A a.k*d&d* B`. So it would be incapable of looking up the tag that the user wanted.

This changes the substitution code to use a single substitution with a regex, so that it will go through the tag name from left to right, replacing each escape sequence with the appropriate character as it goes.

I also added a couple of cucumber tests.