### PR TITLE
AO3-3686 Keep prompts when deleting a pseud.

### DIFF
--- a/features/other_a/pseud_delete.feature
+++ b/features/other_a/pseud_delete.feature
@@ -27,7 +27,61 @@ Feature: Delete pseud.
     And I follow "testymctesty"
   Then I should see "fourth"
     And I should not see "fifth work"
-              
-     
-    
-      
+
+  Scenario: Deleting a pseud shouldn't break gift exchange signups.
+
+    Given I am logged in as "moderator"
+      And I set up the collection "Exchange1"
+      And I select "Gift Exchange" from "challenge_type"
+      And I press "Submit"
+      And I check "Sign-up open?"
+      And I press "Submit"
+      And I am logged in as "test"
+      And I add the pseud "testpseud"
+
+    When I start signing up for "Exchange1"
+      And I select "testpseud" from "challenge_signup_pseud_id"
+      And I fill in "Description:" with "Antidisestablishmentarianism."
+      And I press "Submit"
+    Then I should see "Sign-up was successfully created."
+
+    When I view the collection "Exchange1"
+      And I follow "My Sign-up"
+    Then I should see "Antidisestablishmentarianism."
+
+    When I am on test's pseuds page
+      And I follow "Delete"
+    Then I should see "The pseud was successfully deleted."
+
+    When I view the collection "Exchange1"
+      And I follow "My Sign-up"
+    Then I should see "Antidisestablishmentarianism."
+
+  Scenario: Deleting a pseud shouldn't break prompt meme signups.
+
+    Given I am logged in as "moderator"
+      And I set up the collection "PromptsGalore"
+      And I select "Prompt Meme" from "challenge_type"
+      And I press "Submit"
+      And I press "Submit"
+      And I am logged in as "test"
+      And I add the pseud "testpseud"
+
+    When I start signing up for "PromptsGalore"
+      And I select "testpseud" from "challenge_signup_pseud_id"
+      And I fill in "Description:" with "Antidisestablishmentarianism."
+      And I press "Submit"
+    Then I should see "Sign-up was successfully created."
+
+    When I view the collection "PromptsGalore"
+      And I follow "My Prompts"
+    Then I should see "Antidisestablishmentarianism."
+
+    When I am on test's pseuds page
+      And I follow "Delete"
+    Then I should see "The pseud was successfully deleted."
+
+    When I view the collection "PromptsGalore"
+      And I follow "My Prompts"
+    Then I should see "Antidisestablishmentarianism."
+


### PR DESCRIPTION
https://otwarchive.atlassian.net/browse/AO3-3686

When deleting a pseud, the pseud's challenge signups and challenge assignments are transferred to the user's default pseud, but the existing code doesn't update the `pseud_id` associated with any of the pseud's prompts. The pseud has a `:dependent => :destroy` relationship with any prompts that belong to the pseud, so when `pseud.destroy` is called, the prompts (but not the signups associated with those prompts) are deleted. This results in blank, invalid signups.

This pull request modifies the pseud deletion code to update each prompt's `pseud_id`, and keep the prompts from being destroyed. I also wrote some cucumber tests to check whether the prompts stuck around after the pseud was deleted.

(As a side note: Prompts aren't indexed by `pseud_id`. But prompts always have the same `pseud_id` as the signup they're associated with, thanks to a `before_save` hook, and challenge signups _are_ indexed by `pseud_id`. So I used a join with the `challenge_signups` table to try to make the update to `prompts.pseud_id` more efficient.)
