### PR TITLE
AO3-4643 Deleting a subscription will leave an error in resque

### DIFF
--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -90,6 +90,8 @@ class UserMailer < BulletproofMailer::Base
   
   # Sends a batched subscription notification
   def batch_subscription_notification(subscription_id, entries)
+    # Here we use find_by_id so that if the subscription is not found 
+    # then the resque job does not error and we just silently fail.
     @subscription = Subscription.find_by_id(subscription_id)
     return if @subscription.nil?
     creation_entries = JSON.parse(entries)

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -90,7 +90,8 @@ class UserMailer < BulletproofMailer::Base
   
   # Sends a batched subscription notification
   def batch_subscription_notification(subscription_id, entries)
-    @subscription = Subscription.find(subscription_id)
+    @subscription = Subscription.find_by_id(subscription_id)
+    return if @subscription.nil?
     creation_entries = JSON.parse(entries)
     @creations = []
     # look up all the creations that have generated updates for this subscription


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [x] Have you added tests for any changed functionality?
* [x] Have you added the JIRA issue number as the *first* thing in your pull request title (eg: `AO3-1234 Fix thing`)
* [x] Have you updated the JIRA issue with the information below?

## Issue

https://otwarchive.atlassian.net/browse/AO3-4643
## Purpose

This checks that we have a subscription before trying to use it to send notifications

## Testing

subscribe to a work.
update the work.
delete the subscription
After the notification would have been delivered go in to resque interface and see if you can find an error like:
Worker
ao3-app08:862 on MAILER at about 2 hours ago Retry or Remove
Class
UserMailer
Arguments
"batch_subscription_notification"
"62205766"
"[\"Chapter_18569068\"]"
Exception
ActiveRecord::RecordNotFound
Error
Couldn't find Subscription with id=62205766