### PR TITLE
AO3-4644 Fixed lost comment emails

### DIFF
--- a/app/mailers/comment_mailer.rb
+++ b/app/mailers/comment_mailer.rb
@@ -37,8 +37,9 @@ class CommentMailer < ActionMailer::Base
   # Sends email to commenter when a reply is posted to their comment
   # This may be a non-user of the archive
   def comment_reply_notification(your_comment_id, comment_id)
-    @your_comment = Comment.find(your_comment_id)
-    @comment = Comment.find(comment_id)
+    @your_comment = Comment.find_by_id(your_comment_id)
+    @comment = Comment.find_by_id(comment_id)
+    return if @comment.nil? || @your_comment.nil?
     mail(
       to: @your_comment.comment_owner_email,
       subject: "[#{ArchiveConfig.APP_SHORT_NAME}] Reply to your comment on " + (@comment.ultimate_parent.is_a?(Tag) ? "the tag " : "") + @comment.ultimate_parent.commentable_name.gsub("&gt;", ">").gsub("&lt;", "<")

--- a/app/mailers/comment_mailer.rb
+++ b/app/mailers/comment_mailer.rb
@@ -37,6 +37,8 @@ class CommentMailer < ActionMailer::Base
   # Sends email to commenter when a reply is posted to their comment
   # This may be a non-user of the archive
   def comment_reply_notification(your_comment_id, comment_id)
+    # Here we use find_by_id so that we can silently fail if either the comment
+    # or the parent commet has been deleted.
     @your_comment = Comment.find_by_id(your_comment_id)
     @comment = Comment.find_by_id(comment_id)
     return if @comment.nil? || @your_comment.nil?

--- a/app/models/comment_observer.rb
+++ b/app/models/comment_observer.rb
@@ -1,8 +1,15 @@
 class CommentObserver < ActiveRecord::Observer
 
+  # A wrapper to call both methods
+  def after_commit(comment)
+    # for rails4 change to return unless transaction_any_action?([:create])
+    send_user(comment) if transaction_include_action?(:create)
+    send_create(comment) if transaction_include_action?(:update)
+  end
+
   # Add new comments to the inbox of the person to whom they're directed
   # Send that user a notification email
-  def after_commit(comment)
+  def send_create(comment)
     # We are using after commit rather than after_save
     # The following should fire only on a new record.
     # for rails4 change to return unless transaction_any_action?([:create])
@@ -51,7 +58,7 @@ class CommentObserver < ActiveRecord::Observer
 
   end
 
-  def after_commit(comment)
+  def send_update(comment)
     # We are using after commit rather than after_update
     # The following should fire only on an update to a record.
     # for rails4 change to return unless transaction_any_action?([:update])

--- a/app/models/comment_observer.rb
+++ b/app/models/comment_observer.rb
@@ -2,7 +2,11 @@ class CommentObserver < ActiveRecord::Observer
 
   # Add new comments to the inbox of the person to whom they're directed
   # Send that user a notification email
-  def after_create(comment)
+  def after_commit(comment)
+    # We are using after commit rather than after_save
+    # The following should fire only on a new record.
+    # for rails4 change to return unless transaction_any_action?([:create])
+    return unless transaction_include_action?(:create)
     comment.reload
     # eventually we will set the locale to the user's stored language of choice
     #Locale.set ArchiveConfig.SUPPORTED_LOCALES[ArchiveConfig.DEFAULT_LOCALE]
@@ -47,7 +51,11 @@ class CommentObserver < ActiveRecord::Observer
 
   end
 
-  def after_update(comment)
+  def after_commit(comment)
+    # We are using after commit rather than after_update
+    # The following should fire only on an update to a record.
+    # for rails4 change to return unless transaction_any_action?([:update])
+    return unless transaction_include_action?(:update)
     users = []
     admins = []
 


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [x] Have you added tests for any changed functionality?
* [x] Have you added the JIRA issue number as the *first* thing in your pull request title (eg: `AO3-1234 Fix thing`)
* [x] Have you updated the JIRA issue with the information below?

## Issue

https://otwarchive.atlassian.net/browse/AO3-4644

## Purpose

Reduce the number of errors in resque so we can see any real problems

## Testing

I suspect this needs the resque queues to be full to allow either the original comment or the parent to be deleted. We could simulate it by stopping the workers.

An example error looks like:

Worker
ao3-app03:12932 on MAILER at about 2 hours ago Retry or Remove
Class
 CommentMailer
Arguments
"comment_reply_notification"
77000005
77033890
Exception
ActiveRecord::RecordNotFound
Error
Couldn't find Comment with id=77033890
