### PR TITLE
AO3-4273 Don't tell mods to contact Support re challenge tags

### DIFF
--- a/app/models/prompt.rb
+++ b/app/models/prompt.rb
@@ -154,7 +154,7 @@ class Prompt < ActiveRecord::Base
         else
           noncanonical_taglist = tag_set.send("#{tag_type}_taglist").reject {|t| t.canonical}
           unless noncanonical_taglist.empty?
-            errors.add(:base, ts("^These %{tag_type} tags in your %{prompt_type} are not canonical and cannot be used in this challenge: %{taglist}. To fix this, please contact your challenge moderator who can then log a request with Support for the tags to be made canonical if appropriate.",
+            errors.add(:base, ts("^These %{tag_type} tags in your %{prompt_type} are not canonical and cannot be used in this challenge: %{taglist}. To fix this, please ask your challenge moderator to set up a tag set for the challenge. New tags can be added to the tag set manually by the moderator or by open nominations.",
               :tag_type => tag_type,
               :prompt_type => self.class.name.downcase,
               :taglist => noncanonical_taglist.collect(&:name).join(ArchiveConfig.DELIMITER_FOR_OUTPUT)))


### PR DESCRIPTION
https://otwarchive.atlassian.net/browse/AO3-4273

## Purpose

Stop telling people to tell their challenge mods to contact Support about adding new canonical tags for challenges.

## Testing

Refer to JIRA issue
