### PR TITLE
AO3-4641 Make it more likely new works will clear the Tag cache

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -108,6 +108,7 @@ gem 'dalli'
 gem 'kgio', '2.10.0'
 
 group :test do
+  gem "test_after_commit"
   gem 'rspec', '~> 3.4'
   gem 'rspec-rails', '~> 3.4.2'
   gem 'pickle'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -341,6 +341,8 @@ GEM
     stringex (2.0.3)
     test-unit (3.1.8)
       power_assert
+    test_after_commit (1.1.0)
+      activerecord (>= 3.2)
     thor (0.19.1)
     tilt (1.4.1)
     timeliness (0.3.8)
@@ -462,6 +464,7 @@ DEPENDENCIES
   shoulda
   simplecov (~> 0.11.2)
   test-unit (~> 3.0)
+  test_after_commit
   timeliness
   tire
   transaction_retry

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -154,7 +154,7 @@ class Tag < ActiveRecord::Base
     end
   end
 
-  after_save :queue_flush_work_cache
+  after_commit :queue_flush_work_cache
   def queue_flush_work_cache
     async(:flush_work_cache)
   end


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [x] Have you added tests for any changed functionality?
* [x] Have you added the JIRA issue number as the *first* thing in your pull request title (eg: `AO3-1234 Fix thing`)
* [x] Have you updated the JIRA issue with the information below?

## Issue

https://otwarchive.atlassian.net/browse/AO3-4641

## Purpose

Right now we have a number of failed jobs becuase the async job is running before the data is saved in mysql

## Testing

I am afraid this one can't be tested as fixing anything as the failure will only occur when we have fast resque workers and test does not have that.
