### PR TITLE
AO3-3380 Handle when a work becomes anonymous after queuing subscriptions, but before sending subscriptions.

### DIFF
--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -101,6 +101,14 @@ class UserMailer < BulletproofMailer::Base
       next if (creation.is_a?(Chapter) && !creation.work.try(:posted))
       next if creation.pseuds.any? {|p| p.user == User.orphan_account} # no notifications for orphan works
       # TODO: allow subscriptions to orphan_account to receive notifications
+
+      # If the subscription notification is for a user subscription, we don't
+      # want to send updates about works that have recently become anonymous.
+      if @subscription.subscribable_type == 'User'
+        next if creation.is_a?(Work) && creation.anonymous?
+        next if creation.is_a?(Chapter) && creation.work.anonymous?
+      end
+
       @creations << creation
     end
     

--- a/features/collections/collection_anonymity.feature
+++ b/features/collections/collection_anonymity.feature
@@ -303,3 +303,20 @@ Feature: Collection
 
     Then "eager_fan" should not be emailed
 
+  Scenario: Creating a new work then immediately editing to add it to an
+    anonymous collection should not trigger a subscriber email.
+
+    Given I have the anonymous collection "Anon Forever"
+      And the following activated users exist
+        | login      | password | email              |
+        | mysterious | password | mysterious@foo.com |
+        | subscriber | password | subscriber@foo.com |
+      And "subscriber" subscribes to author "mysterious"
+      And all emails have been delivered
+
+    When I am logged in as "mysterious"
+      And I post the work "Anonymous Gift"
+      And I add the work "Anonymous Gift" to the collection "Anon Forever"
+      And subscription notifications are sent
+
+    Then 0 emails should be delivered


### PR DESCRIPTION
# Pull Request Checklist
- [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
- [x] Have you read through the [contributor guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
- [x] Have you added tests for any changed functionality?
- [x] Have you added the JIRA issue number as the _first_ thing in your pull request title (eg: `AO3-1234 Fix thing`)
- [x] Have you updated the JIRA issue with the information below?

_(Is there anything I need to update the JIRA issue with?)_
## Issue

https://otwarchive.atlassian.net/browse/AO3-3380
## Purpose

Before queuing up a subscription notification, the CreationObserver checks whether the work in question is anonymous (to make sure that subscription notifications won't inadvertently reveal anonymous authors). However, those checks only work if you post directly to an anonymous collection, so that the work has always been anonymous. It doesn't cover cases where someone accidentally forgets to add the collection when they first post the work, and then immediately adds it to the correct collection before batch subscription emails are sent.

This pull request adds an extra check to the UserMailer, to ensure that the work didn't suddenly become anonymous between the time the subscription notification was queued, and the time the subscription email is being sent out.
## Testing

The bug report has steps that can be used for testing this change.
## Credit

tickinginstant, she/her
