### PR TITLE
AO3-4651 Abuse reports should only accept 5 reports per work

### DIFF
--- a/app/models/abuse_report.rb
+++ b/app/models/abuse_report.rb
@@ -65,7 +65,7 @@ class AbuseReport < ActiveRecord::Base
       existing_reports_total = AbuseReport.where('created_at > ? AND
                                                  url LIKE ?',
                                                  1.month.ago,
-                                                 '%#{work_params_only}%').count
+                                                 "%#{work_params_only}%").count
       if existing_reports_total >= ArchiveConfig.ABUSE_REPORTS_PER_WORK_MAX
         errors[:base] << ts('URL has already been reported. To make sure the
                             Abuse Team can handle reports quickly and

--- a/spec/models/abuse_report_spec.rb
+++ b/spec/models/abuse_report_spec.rb
@@ -73,5 +73,16 @@ describe AbuseReport do
     end
   end
 
+  context "overreported work" do
+    let(:overreported_work) { build(:abuse_report,
+                              url: "http://archiveofourown.org/works/1234") }
+    it "cannot be reported again" do
+      max_reports = ArchiveConfig.ABUSE_REPORTS_PER_WORK_MAX
+      max_reports.times { create(:abuse_report,
+                          url: "http://archiveofourown.org/works/1234") }
+      expect(overreported_work.save).to be_falsey
+      expect(overreported_work.errors[:base]).not_to be_empty
+    end
+  end
 
 end

--- a/spec/models/abuse_report_spec.rb
+++ b/spec/models/abuse_report_spec.rb
@@ -108,4 +108,18 @@ describe AbuseReport do
       expect(common_report_variant.errors[:base]).not_to be_empty
     end
   end
+
+  context "for a URL that is not a work" do
+    page_url = "http://archiveofourown.org/tags/Testing/works"
+
+    let(:common_report) { build(:abuse_report, url: page_url) }
+    it "can be submitted an unrestriced number of times" do
+      ArchiveConfig.ABUSE_REPORTS_PER_WORK_MAX.times do
+        create(:abuse_report, url: page_url)
+      end
+      expect(common_report.save).to be_truthy
+      expect(common_report.errors[:base]).to be_empty
+    end
+  end
+
 end

--- a/spec/models/abuse_report_spec.rb
+++ b/spec/models/abuse_report_spec.rb
@@ -74,12 +74,16 @@ describe AbuseReport do
   end
 
   context "overreported work" do
-    let(:overreported_work) { build(:abuse_report,
-                              url: "http://archiveofourown.org/works/1234") }
+    let(:overreported_work) do
+      build(:abuse_report,
+            url: "http://archiveofourown.org/works/1234")
+    end
     it "cannot be reported again" do
       max_reports = ArchiveConfig.ABUSE_REPORTS_PER_WORK_MAX
-      max_reports.times { create(:abuse_report,
-                          url: "http://archiveofourown.org/works/1234") }
+      max_reports.times do
+        create(:abuse_report,
+               url: "http://archiveofourown.org/works/1234")
+      end
       expect(overreported_work.save).to be_falsey
       expect(overreported_work.errors[:base]).not_to be_empty
     end

--- a/spec/models/abuse_report_spec.rb
+++ b/spec/models/abuse_report_spec.rb
@@ -73,20 +73,19 @@ describe AbuseReport do
     end
   end
 
-  context "overreported work" do
-    let(:overreported_work) do
-      build(:abuse_report,
-            url: "http://archiveofourown.org/works/1234")
-    end
+  context "when work is overreported" do
+    work_url = "http://archiveofourown.org/works/1234"
+
+    let(:overreported_work) { build(:abuse_report, url: work_url) }
+
     it "cannot be reported again" do
-      max_reports = ArchiveConfig.ABUSE_REPORTS_PER_WORK_MAX
-      max_reports.times do
-        create(:abuse_report,
-               url: "http://archiveofourown.org/works/1234")
+      ArchiveConfig.ABUSE_REPORTS_PER_WORK_MAX.times do
+        create(:abuse_report, url: work_url)
       end
       expect(overreported_work.save).to be_falsey
       expect(overreported_work.errors[:base]).not_to be_empty
     end
+
   end
 
 end


### PR DESCRIPTION
https://otwarchive.atlassian.net/browse/AO3-4651

## Purpose

The check to make sure a work hadn't been reported to Abuse more than 5 times was broken. This fixes it and adds a test.

It's currently hot fixed on production.

## Testing

Attempt to report a work to Abuse 6 times. The 6th time should fail.
