### PR TITLE
AO3-4636 turn off tag detection

### DIFF
--- a/app/controllers/api/v1/works_controller.rb
+++ b/app/controllers/api/v1/works_controller.rb
@@ -186,7 +186,7 @@ class Api::V1::WorksController < Api::V1::BaseController
       import_multiple: "chapters",
       importing_for_others: true,
       do_not_set_current_author: true,
-      post_without_preview: work_params[:post_without_preview].nil? ? true : work_params[:post_without_preview],
+      post_without_preview: work_params[:post_without_preview].blank? ? true : work_params[:post_without_preview],
       restricted: work_params[:restricted],
       override_tags: work_params[:override_tags].nil? ? true : work_params[:override_tags],
       detect_tags: work_params[:detect_tags].nil? ? true : work_params[:detect_tags],

--- a/app/controllers/api/v1/works_controller.rb
+++ b/app/controllers/api/v1/works_controller.rb
@@ -180,31 +180,32 @@ class Api::V1::WorksController < Api::V1::BaseController
   end
 
   # Create options map for StoryParser
-  def options(archivist, params)
+  def options(archivist, work_params)
     {
       archivist: archivist,
       import_multiple: "chapters",
       importing_for_others: true,
       do_not_set_current_author: true,
-      post_without_preview: params[:post_without_preview].blank? ? true : params[:post_without_preview],
-      restricted: params[:restricted],
-      override_tags: params[:override_tags].blank? ? true : params[:override_tags],
-      collection_names: params[:collection_names],
-      title: params[:title],
-      fandom: params[:fandoms],
-      warning: params[:warnings],
-      character: params[:characters],
-      rating: params[:rating],
-      relationship: params[:relationships],
-      category: params[:categories],
-      freeform: params[:additional_tags],
-      summary: params[:summary],
-      notes: params[:notes],
-      encoding: params[:encoding],
-      external_author_name: params[:external_author_name],
-      external_author_email: params[:external_author_email],
-      external_coauthor_name: params[:external_coauthor_name],
-      external_coauthor_email: params[:external_coauthor_email]
+      post_without_preview: work_params[:post_without_preview].nil? ? true : work_params[:post_without_preview],
+      restricted: work_params[:restricted],
+      override_tags: work_params[:override_tags].nil? ? true : work_params[:override_tags],
+      detect_tags: work_params[:detect_tags].nil? ? true : work_params[:detect_tags],
+      collection_names: work_params[:collection_names],
+      title: work_params[:title],
+      fandom: work_params[:fandoms],
+      warning: work_params[:warnings],
+      character: work_params[:characters],
+      rating: work_params[:rating],
+      relationship: work_params[:relationships],
+      category: work_params[:categories],
+      freeform: work_params[:additional_tags],
+      summary: work_params[:summary],
+      notes: work_params[:notes],
+      encoding: work_params[:encoding],
+      external_author_name: work_params[:external_author_name],
+      external_author_email: work_params[:external_author_email],
+      external_coauthor_name: work_params[:external_coauthor_name],
+      external_coauthor_email: work_params[:external_coauthor_email]
     }
   end
 end

--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -1062,7 +1062,7 @@ public
       importing_for_others: params[:importing_for_others],
       restricted: params[:restricted],
       override_tags: params[:override_tags],
-      detect_tags: params[:detect_tags],
+      detect_tags: params[:detect_tags] == "true",
       fandom: params[:work][:fandom_string],
       warning: params[:work][:warning_strings],
       character: params[:work][:character_string],

--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -1062,6 +1062,7 @@ public
       importing_for_others: params[:importing_for_others],
       restricted: params[:restricted],
       override_tags: params[:override_tags],
+      detect_tags: params[:detect_tags],
       fandom: params[:work][:fandom_string],
       warning: params[:work][:warning_strings],
       character: params[:work][:character_string],

--- a/app/models/story_parser.rb
+++ b/app/models/story_parser.rb
@@ -624,7 +624,7 @@ class StoryParser
       return work_params
     end
 
-    def parse_story_from_dw(story, detect_tags = true)
+    def parse_story_from_dw(_story, detect_tags = true)
       work_params = { chapter_attributes: {} }
 
       body = @doc.css("body")
@@ -662,7 +662,7 @@ class StoryParser
       return work_params
     end
 
-    def parse_story_from_deviantart(story, detect_tags = true)
+    def parse_story_from_deviantart(_story, detect_tags = true)
       work_params = { chapter_attributes: {} }
       storytext = ""
       notes = ""
@@ -708,7 +708,7 @@ class StoryParser
       notes = clean_storytext(notes)
       work_params[:notes] = notes
 
-      work_params.merge!(scan_text_for_meta(notes, detect_tags = true))
+      work_params.merge!(scan_text_for_meta(notes, detect_tags))
       work_params[:title] = title
 
       body.css("div.dev-title-container h1 a").each do |node|

--- a/app/models/story_parser.rb
+++ b/app/models/story_parser.rb
@@ -190,7 +190,8 @@ class StoryParser
 
   # Parses the text of a story, optionally from a given location.
   def parse_story(story, location, options = {})
-    work_params = parse_common(story, location, options[:encoding], options[:detect_tags])
+    detect_tags = options[:detect_tags].to_i == 0 ? false : true
+    work_params = parse_common(story, location, options[:encoding], detect_tags)
 
     # move any attributes from work to chapter if necessary
     return set_work_attributes(Work.new(work_params), location, options)
@@ -562,7 +563,7 @@ class StoryParser
 
       # Extract metadata (unless detect_tags is false)
       if location && (source = get_source_if_known(KNOWN_STORY_PARSERS, location))
-        params = eval("parse_story_from_#{source.downcase}(story)")
+        params = eval("parse_story_from_#{source.downcase}(story, detect_tags)")
         work_params.merge!(params)
       else
         work_params.merge!(parse_story_from_unknown(story, detect_tags))

--- a/app/models/story_parser.rb
+++ b/app/models/story_parser.rb
@@ -15,12 +15,12 @@ class StoryParser
                     warning_string: 'Warning',
                     relationship_string: 'Relationship|Pairing',
                     character_string: 'Character'
-                   }
+                   }.freeze
   REQUIRED_META = { title: 'Title',
                     summary: 'Summary',
                     revised_at: 'Date|Posted|Posted on|Posted at',
                     chapter_title: 'Chapter Title'
-                  }
+                  }.freeze
 
 
   # Use this for raising custom error messages
@@ -34,7 +34,7 @@ class StoryParser
   CHAPTER_ATTRIBUTES_ONLY = {}
 
   # These attributes need to be copied from the work to the chapter
-  CHAPTER_ATTRIBUTES_ALSO = { revised_at: :published_at }
+  CHAPTER_ATTRIBUTES_ALSO = { revised_at: :published_at }.freeze
 
   ### NOTE ON KNOWN SOURCES
   # These lists will stop with the first one it matches, so put more-specific matches
@@ -190,8 +190,7 @@ class StoryParser
 
   # Parses the text of a story, optionally from a given location.
   def parse_story(story, location, options = {})
-    detect_tags = options[:detect_tags].to_i == 0 ? false : true
-    work_params = parse_common(story, location, options[:encoding], detect_tags)
+    work_params = parse_common(story, location, options[:encoding], options[:detect_tags])
 
     # move any attributes from work to chapter if necessary
     return set_work_attributes(Work.new(work_params), location, options)
@@ -598,7 +597,7 @@ class StoryParser
     # Assumes that we have downloaded the story from one of those equivalents (ie, we've downloaded
     # it in format=light which is a stripped-down plaintext version.)
     #
-    def parse_story_from_lj(story, detect_tags = true)
+    def parse_story_from_lj(_story, detect_tags = true)
       work_params = { chapter_attributes: {} }
 
       # in LJ "light" format, the story contents are in the second div

--- a/app/models/story_parser.rb
+++ b/app/models/story_parser.rb
@@ -190,7 +190,7 @@ class StoryParser
 
   # Parses the text of a story, optionally from a given location.
   def parse_story(story, location, options = {})
-    work_params = parse_common(story, location, options[:encoding])
+    work_params = parse_common(story, location, options[:encoding], options[:detect_tags])
 
     # move any attributes from work to chapter if necessary
     return set_work_attributes(Work.new(work_params), location, options)
@@ -198,7 +198,7 @@ class StoryParser
 
   # parses and adds a new chapter to the end of the work
   def parse_chapter_of_work(work, chapter_content, location, options = {})
-    tmp_work_params = parse_common(chapter_content, location, options[:encoding])
+    tmp_work_params = parse_common(chapter_content, location, options[:encoding], options[:detect_tags])
     chapter = get_chapter_from_work_params(tmp_work_params)
     work.chapters << set_chapter_attributes(work, chapter, location, options)
     return work
@@ -207,7 +207,7 @@ class StoryParser
   def parse_chapters_into_story(location, chapter_contents, options = {})
     work = nil
     chapter_contents.each do |content|
-      work_params = parse_common(content, location, options[:encoding])
+      work_params = parse_common(content, location, options[:encoding], options[:detect_tags])
       if work.nil?
         # create the new work
         work = Work.new(work_params)

--- a/app/views/works/new_import.html.erb
+++ b/app/views/works/new_import.html.erb
@@ -104,12 +104,12 @@
                           ts("Set the following tags and/or notes on all works, overriding whatever the importer finds in the content.") %>
             <ul id="override_tags-options" class="dependent">
               <li>
-                <%= radio_button_tag "detect_tags", 1, true, id: "detect_tags_true" %>
+                <%= radio_button_tag "detect_tags", true, true, id: "detect_tags_true" %>
                 <%= label_tag "detect_tags_true",
                               ts("Use values extracted from the content for blank fields if possible") %>
               </li>
               <li>
-                <%= radio_button_tag "detect_tags", 0, false, id: "detect_tags_false"  %>
+                <%= radio_button_tag "detect_tags", false, false, id: "detect_tags_false"  %>
                 <%= label_tag "detect_tags_false",
                               ts("Do not use values extracted from the content at all; use Archive defaults for blank fields") %>
               </li>

--- a/app/views/works/new_import.html.erb
+++ b/app/views/works/new_import.html.erb
@@ -100,16 +100,17 @@
         <ul>
           <li>
             <%= check_box_tag "override_tags", 1, false, class: "toggle_formfield", id: "override_tags-options-show" %>
-            <%= label_tag "override_tags-options-show", ts("Set the following tags and/or notes on all works, overriding whatever the importer finds in the content.") %>
+            <%= label_tag "override_tags-options-show",
+                          ts("Set the following tags and/or notes on all works, overriding whatever the importer finds in the content.") %>
             <ul id="override_tags-options" class="dependent">
               <li>
-                <%= radio_button_tag "detect_tags", 1, true %>
-                <%= label_tag "detect_tags",
+                <%= radio_button_tag "detect_tags", 1, true, id: "detect_tags_true" %>
+                <%= label_tag "detect_tags_true",
                               ts("Use values extracted from the content for blank fields if possible") %>
               </li>
               <li>
-                <%= radio_button_tag "detect_tags", 0 %>
-                <%= label_tag "detect_tags",
+                <%= radio_button_tag "detect_tags", 0, false, id: "detect_tags_false"  %>
+                <%= label_tag "detect_tags_false",
                               ts("Do not use values extracted from the content at all; use Archive defaults for blank fields") %>
               </li>
             </ul>

--- a/app/views/works/new_import.html.erb
+++ b/app/views/works/new_import.html.erb
@@ -97,8 +97,24 @@
       </dd>
       <dt><%= ts("Override tags and notes") %></dt>
       <dd>
-        <%= check_box_tag "override_tags" %>
-        <%= label_tag "override_tags", ts("Set the following tags and/or notes on all works, overriding whatever the importer finds in the content.") %>
+        <ul>
+          <li>
+            <%= check_box_tag "override_tags", 1, false, class: "toggle_formfield", id: "override_tags-options-show" %>
+            <%= label_tag "override_tags-options-show", ts("Set the following tags and/or notes on all works, overriding whatever the importer finds in the content.") %>
+            <ul id="override_tags-options" class="dependent">
+              <li>
+                <%= radio_button_tag "detect_tags", 1, true %>
+                <%= label_tag "detect_tags",
+                              ts("Use values extracted from the content for blank fields if possible") %>
+              </li>
+              <li>
+                <%= radio_button_tag "detect_tags", 0 %>
+                <%= label_tag "detect_tags",
+                              ts("Do not use values extracted from the content at all; use Archive defaults for blank fields") %>
+              </li>
+            </ul>
+          </li>
+        </ul>
       </dd>
     </dl>
   </fieldset>
@@ -123,4 +139,15 @@
     </p>
   </fieldset>
 
+<% end %>
+
+<%= content_for :footer_js do %>
+  <%= javascript_tag do %>
+    $j(document).ready(function(){
+      $j(".toggle_formfield").click(function() {
+        var targetId = $j(this).attr("id").replace("-show", "");
+        toggleFormField(targetId);
+      });
+    })
+  <% end %>
 <% end %>

--- a/features/importing/work_import.feature
+++ b/features/importing/work_import.feature
@@ -1,4 +1,4 @@
-@works
+@import
 Feature: Import Works
   In order to have an archive full of works
   As an author
@@ -9,23 +9,23 @@ Feature: Import Works
   Then I should see "Please log in"
 
   Scenario: Creating a new minimally valid work
-    When I set up importing
+    When I set up importing with a mock website
     Then I should see "Import New Work"
-    When I fill in "urls" with "http://cesy.dreamwidth.org"
+    When I fill in "urls" with "http://import-site-without-tags"
       And I press "Import"
     Then I should see "Preview"
-      And I should see "Welcome"
-      And I should not see "A work has already been imported from http://cesy.dreamwidth.org"
+      And I should see "Untitled Imported Work"
+      And I should not see "A work has already been imported from http://import-site-without-tags"
       And I should see "No Fandom"
       And I should see "Chose Not To"
       And I should see "Not Rated"
     When I press "Post"
     Then I should see "Work was successfully posted."
     When I go to the works page
-    Then I should see "Recent Entries"
+    Then I should see "Untitled Imported Work"
 
-  Scenario: Creating a new work with provided tags
-    When I start importing "http://astolat.dreamwidth.org/220479.html"
+  Scenario: With override disabled and tag detection enabled, tags should be detected
+    When I start importing "http://import-site-with-tags" with a mock website
       And I select "Explicit" from "Rating"
       And I check "No Archive Warnings Apply"
       And I fill in "Fandoms" with "Idol RPF"
@@ -36,18 +36,79 @@ Feature: Import Works
       And I fill in "Notes at the beginning" with "This is a <i>note</i>"
     When I press "Import"
     Then I should see "Preview"
-      And I should see "Extra Credit"
+      And I should see "Detected Title"
       And I should see "Explicit"
-      And I should see "No Archive Warnings Apply"
-      And I should see "Idol RPF"
-      And I should see "M/M"
-      And I should see "Adam/Kris"
-      And I should see "Adam Lambert"
-      And I should see "Kris Allen"
-      And I should see "kinkmeme"
-      And I should see "This is a note"
+      And I should see "Archive Warning: Underage"
+      And I should see "Fandom: Detected Fandom"
+      And I should see "Category: M/M"
+      And I should see "Relationship: Detected 1/Detected 2"
+      And I should see "Characters: Detected 1Detected 2"
+      And I should see "Additional Tags: Detected tag 1Detected tag 2"
+      And I should see "Notes: This is a content note."
     When I press "Post"
     Then I should see "Work was successfully posted."
+
+  Scenario: With override and tag detection enabled, provided tags should be used when tags are entered
+    When I start importing "http://import-site-with-tags" with a mock website
+      And I check "override_tags"
+      And I choose "detect_tags_true"
+      And I select "Mature" from "Rating"
+      And I check "No Archive Warnings Apply"
+      And I fill in "Fandoms" with "Idol RPF"
+      And I check "F/M"
+      And I fill in "Relationships" with "Adam/Kris"
+      And I fill in "Characters" with "Adam Lambert, Kris Allen"
+      And I fill in "Additional Tags" with "kinkmeme"
+      And I fill in "Notes at the beginning" with "This is a <i>note</i>"
+    When I press "Import"
+      Then I should see "Preview"
+      And I should see "Detected Title"
+      And I should see "Rating: Mature"
+      And I should see "Archive Warning: No Archive Warnings"
+      And I should see "Fandom: Idol RPF"
+      And I should see "Category: F/M"
+      And I should see "Relationship: Adam/Kris"
+      And I should see "Characters: Adam LambertKris Allen"
+      And I should see "Additional Tags: kinkmeme"
+      And I should see "Notes: This is a note"
+    When I press "Post"
+    Then I should see "Work was successfully posted."
+
+  Scenario: With override and tag detection enabled, both provided and detected tags should be used when not all tags are entered
+    When I start importing "http://import-site-with-tags" with a mock website
+    And I check "override_tags"
+    And I choose "detect_tags_true"
+    And I select "Mature" from "Rating"
+    And I check "No Archive Warnings Apply"
+    And I fill in "Characters" with "Adam Lambert, Kris Allen"
+    And I fill in "Additional Tags" with "kinkmeme"
+    And I fill in "Notes at the beginning" with "This is a <i>note</i>"
+    When I press "Import"
+    Then I should see "Preview"
+    And I should see "Detected Title"
+    And I should see "Rating: Mature"
+    And I should see "Archive Warning: No Archive Warnings"
+    And I should see "Fandom: Detected Fandom"
+    And I should see "Relationship: Detected 1/Detected 2"
+    And I should see "Characters: Adam LambertKris Allen"
+    And I should see "Additional Tags: kinkmeme"
+    And I should see "Notes: This is a note"
+    And I should not see "Category: M/M"
+    When I press "Post"
+    Then I should see "Work was successfully posted."
+
+  Scenario: Default tags should be used when no tags are entered, and override is enabled and tag detection is disabled
+    When I start importing "http://import-site-with-tags" with a mock website
+      And I check "override_tags"
+      And I choose "detect_tags_false"
+    When I press "Import"
+      Then I should see "Detected Title"
+      And I should see "Rating: Not Rated"
+      And I should see "Archive Warning: Creator Chose Not To Use Archive Warnings"
+      And I should see "Fandom: No Fandom"
+      And I should not see "Relationship:"
+      And I should not see "Additional Tags:"
+      And I should not see "Relationship: Detected 1/Detected 2"
 
   Scenario: Importing multiple works with backdating
     When I import the urls
@@ -62,26 +123,6 @@ Feature: Import Works
     When I follow "Huddling"
     Then I should see "Preview"
       And I should see "2010-01-11"
-
-  Scenario: Tags should be detected when override is not enabled
-    When I start importing "http://rebecca2525.dreamwidth.org/3506.html"
-    When I press "Import"
-      Then I should see "Relationship: Lewis/Hathaway"
-
-  Scenario: Provided tags should be used when tags are entered, and override and tag detection are enabled
-    When I start importing "http://rebecca2525.dreamwidth.org/3506.html"
-      And I check "override_tags"
-      And I choose "detect_tags_true"
-      And I fill in "Relationships" with "Adam/Kris"
-    When I press "Import"
-      Then I should see "Relationship: Adam/Kris"
-
-  Scenario: Default tags should be used when no tags are entered, and override is enabled and tag detection is disabled
-    When I start importing "http://rebecca2525.dreamwidth.org/3506.html"
-      And I check "override_tags"
-      And I choose "detect_tags_false"
-    When I press "Import"
-      Then I should not see "Relationship: Lewis/Hathaway"
 
   Scenario: Importing a new multichapter work with backdating should have correct chapter index dates
     Given basic tags

--- a/features/importing/work_import.feature
+++ b/features/importing/work_import.feature
@@ -73,7 +73,6 @@ Feature: Import Works
       And I check "override_tags"
       And I choose "detect_tags_true"
       And I fill in "Relationships" with "Adam/Kris"
-      Then show me the page
     When I press "Import"
       Then I should see "Relationship: Adam/Kris"
 

--- a/features/importing/work_import.feature
+++ b/features/importing/work_import.feature
@@ -24,7 +24,7 @@ Feature: Import Works
     When I go to the works page
     Then I should see "Recent Entries"
 
-  Scenario: Creating a new work with tags
+  Scenario: Creating a new work with provided tags
     When I start importing "http://astolat.dreamwidth.org/220479.html"
       And I select "Explicit" from "Rating"
       And I check "No Archive Warnings Apply"
@@ -62,6 +62,27 @@ Feature: Import Works
     When I follow "Huddling"
     Then I should see "Preview"
       And I should see "2010-01-11"
+
+  Scenario: Tags should be detected when override is not enabled
+    When I start importing "http://rebecca2525.dreamwidth.org/3506.html"
+    When I press "Import"
+      Then I should see "Relationship: Lewis/Hathaway"
+
+  Scenario: Provided tags should be used when tags are entered, and override and tag detection are enabled
+    When I start importing "http://rebecca2525.dreamwidth.org/3506.html"
+      And I check "override_tags"
+      And I choose "detect_tags_true"
+      And I fill in "Relationships" with "Adam/Kris"
+      Then show me the page
+    When I press "Import"
+      Then I should see "Relationship: Adam/Kris"
+
+  Scenario: Default tags should be used when no tags are entered, and override is enabled and tag detection is disabled
+    When I start importing "http://rebecca2525.dreamwidth.org/3506.html"
+      And I check "override_tags"
+      And I choose "detect_tags_false"
+    When I press "Import"
+      Then I should not see "Relationship: Lewis/Hathaway"
 
   Scenario: Importing a new multichapter work with backdating should have correct chapter index dates
     Given basic tags

--- a/features/importing/work_import_dw.feature
+++ b/features/importing/work_import_dw.feature
@@ -76,8 +76,6 @@ Feature: Import Works from DW
   @import_dw_tables_no_backdate
   Scenario: Creating a new work from an DW story without backdating it
     Given basic tags
-      And a category exists with name: "Gen", canonical: true
-      And a category exists with name: "F/M", canonical: true
       And the following activated user exists
         | login          | password    |
         | cosomeone      | something   |

--- a/features/importing/work_import_lj.feature
+++ b/features/importing/work_import_lj.feature
@@ -69,8 +69,6 @@ Feature: Import Works from LJ
   @import_lj_no_backdate
   Scenario: Creating a new work from an LJ story without backdating it
     Given basic tags
-      And a category exists with name: "Gen", canonical: true
-      And a category exists with name: "F/M", canonical: true
       And I am logged in as a random user
     When I go to the import page
       And I fill in "urls" with "http://rebecca2525.livejournal.com/3562.html"

--- a/features/other_b/subscriptions_fandoms.feature
+++ b/features/other_b/subscriptions_fandoms.feature
@@ -6,7 +6,7 @@ Feature: Subscriptions
   Scenario: Subscribe to a test fandom when there are no works in it
 
   When I am logged in as "author"
-    And I post a work "My Work Title" with category "M/F"
+    And I post a work "My Work Title" with category "F/M"
   When I am logged in as "reader"
     And I view the "F/F" works index
   Then I should see "RSS Feed"

--- a/features/step_definitions/tag_steps.rb
+++ b/features/step_definitions/tag_steps.rb
@@ -20,7 +20,7 @@ Given /^basic tags$/ do
   Category.find_or_create_by_name_and_canonical("Other", true)
   Category.find_or_create_by_name_and_canonical("F/F", true)
   Category.find_or_create_by_name_and_canonical("Multi", true)
-  Category.find_or_create_by_name_and_canonical("M/F", true)
+  Category.find_or_create_by_name_and_canonical("F/M", true)
   Category.find_or_create_by_name_and_canonical("M/M", true)
 end
 

--- a/features/step_definitions/tag_steps.rb
+++ b/features/step_definitions/tag_steps.rb
@@ -17,6 +17,7 @@ Given /^basic tags$/ do
   Warning.find_or_create_by_name_and_canonical("No Archive Warnings Apply", true)
   Warning.find_or_create_by_name_and_canonical("Choose Not To Use Archive Warnings", true)
   Fandom.find_or_create_by_name_and_canonical("No Fandom", true)
+  Category.find_or_create_by_name_and_canonical("Gen", true)
   Category.find_or_create_by_name_and_canonical("Other", true)
   Category.find_or_create_by_name_and_canonical("F/F", true)
   Category.find_or_create_by_name_and_canonical("Multi", true)

--- a/features/step_definitions/work_import_steps.rb
+++ b/features/step_definitions/work_import_steps.rb
@@ -1,21 +1,76 @@
-Given /^I set up importing$/ do
+require 'webmock/cucumber'
+
+def content_fields
+  {
+    title: "Detected Title", summary: "Detected summary", fandoms: "Detected Fandom", warnings: "Underage",
+    characters: "Detected 1, Detected 2", rating: "Explicit", relationships: "Detected 1/Detected 2",
+    categories: "F/F", freeform: "Detected tag 1, Detected tag 2", external_author_name: "Detected Author",
+    external_author_email: "detected@foo.com", notes: "This is a <i>content note</i>.",
+    date: "2002-01-12", chapter_title: "Detected chapter title"
+  }
+end
+
+# Let the test get at external sites, but stub out anything containing certain keywords
+def mock_external
+  WebMock.allow_net_connect!
+  WebMock.stub_request(:any, /import-site-with-tags/).
+    to_return(status: 200,
+              body:
+                "Title: #{content_fields[:title]}
+Summary:  #{content_fields[:summary]}
+Date: #{content_fields[:date]}
+Fandom:  #{content_fields[:fandoms]}
+Rating: #{content_fields[:rating]}
+Warnings:  #{content_fields[:warnings]}
+Characters:  #{content_fields[:characters]}
+Pairings:  #{content_fields[:relationships]}
+Category:  #{content_fields[:categories]}
+Tags:  #{content_fields[:freeform]}
+Author's notes:  #{content_fields[:notes]}
+
+stubbed response", headers: {})
+
+  WebMock.stub_request(:any, /import-site-without-tags/).
+    to_return(status: 200,
+              body: "stubbed response",
+              headers: {})
+
+  WebMock.stub_request(:any, /no-content/).
+    to_return(status: 200,
+              body: "",
+              headers: {})
+
+  WebMock.stub_request(:any, /bar/).
+    to_return(status: 404, headers: {})
+end
+
+Given /^I set up importing( with a mock website)?$/ do |mock|
+  unless mock.blank?
+    mock_external
+  end
   step %{basic tags}
   step %{I am logged in as a random user}
   step %{I go to the import page}
 end
 
-When /^I start importing "(.*)"$/ do |url|
-  step %{I set up importing}
+When /^I start importing "(.*)"( with a mock website)?$/ do |url, mock|
+  step %{I set up importing#{mock}}
   step %{I fill in "urls" with "#{url}"}
 end
 
-When /^I import "(.*)"$/ do |url|
-  step %{I start importing "#{url}"}
+When /^I import "(.*)"( with a mock website)?$/ do |url, mock|
+  step %{I start importing "#{url}"#{mock}}
   step %{I press "Import"}
 end
   
 When /^I import the urls$/ do |urls|
   step %{I set up importing}
+  step %{I fill in "urls" with "#{urls}"}
+  step %{I press "Import"}
+end
+
+When /^I import the urls with mock websites$/ do |urls|
+  step %{I set up importing with a mock website}
   step %{I fill in "urls" with "#{urls}"}
   step %{I press "Import"}
 end

--- a/features/support/webmock.rb
+++ b/features/support/webmock.rb
@@ -1,0 +1,5 @@
+require 'webmock/cucumber'
+
+After("@import") do
+  WebMock.reset!
+end

--- a/features/works/work_create.feature
+++ b/features/works/work_create.feature
@@ -49,8 +49,6 @@ Feature: Create Works
 
   Scenario: Creating a new work with everything filled in, and we do mean everything
     Given basic tags
-      And a category exists with name: "Gen", canonical: true
-      And a category exists with name: "F/M", canonical: true
       And the following activated users exist
         | login          | password    | email                 |
         | coauthor       | something   | coauthor@example.org  |

--- a/features/works/work_delete.feature
+++ b/features/works/work_delete.feature
@@ -34,8 +34,6 @@ Feature: Delete Works
 
   Scenario: Deleting a work with everything filled in, and we do mean everything
     Given basic tags
-      And a category exists with name: "Gen", canonical: true
-      And a category exists with name: "F/M", canonical: true
       And the following activated users exist
         | login          | password    | email                 |
         | coauthor       | something   | coauthor@example.org  |

--- a/public/javascripts/application.js
+++ b/public/javascripts/application.js
@@ -301,7 +301,8 @@ function toggleFormField(element_id) {
 // Hides expandable form field options if Javascript is enabled
 function hideFormFields() {
     if ($j('#work-form') != null) {
-        var toHide = ['#co-authors-options', '#front-notes-options', '#end-notes-options', '#chapters-options', '#parent-options', '#series-options', '#backdate-options'];
+        var toHide = ['#co-authors-options', '#front-notes-options', '#end-notes-options', '#chapters-options',
+          '#parent-options', '#series-options', '#backdate-options', '#override_tags-options'];
         $j.each(toHide, function(index, name) {
             if ($j(name)) {
                 if (!($j(name + '-show').is(':checked'))) { $j(name).addClass('hidden'); }

--- a/public/stylesheets/site/2.0/07-interactions.css
+++ b/public/stylesheets/site/2.0/07-interactions.css
@@ -157,6 +157,11 @@ form dd p.informational {
 
 /*END FORM RULES*/
 
+/* WIDGET: DEPENDENT OPTIONS */
+.toggle_formfield ~ ul.dependent {
+  margin-left: 2.625em;
+}
+
 /* WIDGET: CHARACTER COUNTER (todo: ARIA live region POLITE)*/
 
 p.character_counter {

--- a/spec/api/api_helper.rb
+++ b/spec/api/api_helper.rb
@@ -15,19 +15,21 @@ module ApiHelper
   # Values in API fake content
   def content_fields
     {
-      title: "Foo Title", summary: "Foo summary", fandoms: "Foo Fandom", warnings: "Underage",
-      characters: "foo 1, foo 2", rating: "Explicit", relationships: "foo 1/foo 2",
-      categories: "F/F", freeform: "foo tag 1, foo tag 2", external_author_name: "bar",
-      external_author_email: "bar@foo.com", notes: "This is a <i>content note</i>."
+      title: "Detected Title", summary: "Detected summary", fandoms: "Detected Fandom", warnings: "Underage",
+      characters: "Detected 1, Detected 2", rating: "Explicit", relationships: "Detected 1/Detected 2",
+      categories: "F/F", freeform: "Detected tag 1, Detected tag 2", external_author_name: "Detected Author",
+      external_author_email: "detected@foo.com", notes: "This is a <i>content note</i>.",
+      date: "2002-01-12", chapter_title: "Detected chapter title"
     }
   end
 
   def api_fields
     {
-      title: "Bar Title", summary: "Bar summary", fandoms: "Bar Fandom", warnings: "Rape/Non-Con",
-      characters: "bar 1, bar 2", rating: "General", relationships: "bar 1/bar 2",
-      categories: "M/M", freeform: "bar tag 1, bar tag 2", external_author_name: "bar",
-      external_author_email: "bar@foo.com", notes: "This is an <i>API note</i>."
+      title: "API Title", summary: "API summary", fandoms: "API Fandom", warnings: "Rape/Non-Con",
+      characters: "API 1, API 2", rating: "General", relationships: "bar 1/bar 2",
+      categories: "M/M", freeform: "API tag 1, API tag 2", external_author_name: "API Author",
+      external_author_email: "api@foo.com", notes: "This is an <i>API note</i>.",
+      date: "2002-01-12", chapter_title: "API chapter title (TBD)"
     }
   end
 
@@ -39,6 +41,7 @@ module ApiHelper
                 body:
                   "Title: #{content_fields[:title]}
 Summary:  #{content_fields[:summary]}
+Date: #{content_fields[:date]}
 Fandom:  #{content_fields[:fandoms]}
 Rating: #{content_fields[:rating]}
 Warnings:  #{content_fields[:warnings]}
@@ -47,6 +50,7 @@ Pairings:  #{content_fields[:relationships]}
 Category:  #{content_fields[:categories]}
 Tags:  #{content_fields[:freeform]}
 Author's notes:  #{content_fields[:notes]}
+Chapter title:  #{content_fields[:chapter_title]}
 
 stubbed response", headers: {})
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -34,34 +34,25 @@ RSpec.configure do |config|
   config.mock_with :rspec
   #config.raise_errors_for_deprecations!
   config.include FactoryGirl::Syntax::Methods
-  config.include(EmailSpec::Helpers)
-  config.include(EmailSpec::Matchers)
-  config.before(:suite) do
-    DatabaseCleaner.strategy = :transaction
-    DatabaseCleaner.clean
-  end
-
-  config.before(:each) do
-    DatabaseCleaner.start
-  end
-
-  config.after(:each) do
-    DatabaseCleaner.clean
-  end
-
+  config.include EmailSpec::Helpers
+  config.include EmailSpec::Matchers
   config.include Capybara::DSL
 
-  config.before(:suite) do
+  config.before :suite do
     DatabaseCleaner.strategy = :transaction
     DatabaseCleaner.clean
   end
 
-  config.before(:each) do
+  config.before :each do
     DatabaseCleaner.start
   end
 
-  config.after(:each) do
+  config.after :each do
     DatabaseCleaner.clean
+  end
+
+  config.after :suite do
+    DatabaseCleaner.clean_with :truncation
   end
 
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-4636
## Purpose

Currently, the importer always detects tags in the content of the stories it imports and adds those tags to the imported work. This sometimes leads to rubbish tags (e.g.: "Warnings: fluffy bunnies") and in some cases where it detects text that isn't a valid tag, breaks the import. The `Override...` checkbox on the import form (and its API equivalent) only allows you to override tags if you provide some other content, but not to ignore detected tags completely.

This PR adds a `detect_tags` option in addition to the existing `override_tags`, to prevent all tags from being detected at all when some tags are overridden.
## Testing

See Jira for testing notes
