### PR TITLE
AO3-4644 ensure comments are delivered.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -274,7 +274,7 @@ GEM
       redis (>= 3.0.0)
       resque (>= 1.20.0, < 1.25)
       rufus-scheduler (~> 2.0)
-    resque_mailer (2.2.4)
+    resque_mailer (2.3.1)
       actionmailer (>= 3.0)
     rest-client (1.8.0)
       http-cookie (>= 1.0.2, < 2.0)

--- a/app/mailers/README
+++ b/app/mailers/README
@@ -1,11 +1,13 @@
 All mailers include Resque::Mailer
 
-This uses the resque_mailer gem to send email asyncronously by default when using deliver (puts it into a background job)
+This uses the resque_mailer gem to send email asyncronously by default when
+using deliver (puts it into a background job)
 
-Jobs are persisted to queues as JSON objects. Because of this all jobs must only accept arguments that can be JSON encoded.
+Jobs are persisted to queues as JSON objects.
 
-This is why most methods pass object IDs instead of passing around the objects.
+The latest version of resque_mailer supports this for active record structures
+this is recomended as it gets round the horrible message which is 
+create_after and the resque job running before the data is commited.
 
-While this is less convenient than passing the object, it gives you a slight advantage: your jobs will be run against the most recent version of an object because they need to pull from the DB or cache. If your jobs were run against objects, they could potentially be operating on a stale record with out-of-date information.
-
-The only exception to this are methods which are called with deliver! (instead of deliver). These methods are not put into a queue, but are instead run immediately (synchronously). Only do this if the state of the current object is important, and the up-to-date record cannot be used. Although it's better to pass the information that may change as a string, and refactor the method to send asynchronously.
+Additionally if the thing passed is deleted before the email is sent
+the data in the email would have been correct.

--- a/app/mailers/comment_mailer.rb
+++ b/app/mailers/comment_mailer.rb
@@ -6,9 +6,8 @@ class CommentMailer < ActionMailer::Base
   default from: "Archive of Our Own " + "<#{ArchiveConfig.RETURN_ADDRESS}>"
 
   # Sends email to an owner of the top-level commentable when a new comment is created
-  def comment_notification(user_id, comment_id)
-    user = User.find(user_id)
-    @comment = Comment.find(comment_id)
+  def comment_notification(user, comment)
+    @comment = comment
     @owner = user
     I18n.with_locale(Locale.find(user.preference.preferred_locale).iso) do
       mail(
@@ -21,9 +20,8 @@ class CommentMailer < ActionMailer::Base
   end
 
   # Sends email to an owner of the top-level commentable when a comment is edited
-  def edited_comment_notification(user_id, comment_id)
-    user = User.find(user_id)
-    @comment = Comment.find(comment_id)
+  def edited_comment_notification(user, comment)
+    @comment = comment
     I18n.with_locale(Locale.find(user.preference.preferred_locale).iso) do
       mail(
         to: user.email,
@@ -36,9 +34,9 @@ class CommentMailer < ActionMailer::Base
 
   # Sends email to commenter when a reply is posted to their comment
   # This may be a non-user of the archive
-  def comment_reply_notification(your_comment_id, comment_id)
-    @your_comment = Comment.find(your_comment_id)
-    @comment = Comment.find(comment_id)
+  def comment_reply_notification(your_comment, comment)
+    @your_comment = your_comment
+    @comment = comment
     mail(
       to: @your_comment.comment_owner_email,
       subject: "[#{ArchiveConfig.APP_SHORT_NAME}] Reply to your comment on " + (@comment.ultimate_parent.is_a?(Tag) ? "the tag " : "") + @comment.ultimate_parent.commentable_name.gsub("&gt;", ">").gsub("&lt;", "<")
@@ -49,9 +47,9 @@ class CommentMailer < ActionMailer::Base
 
   # Sends email to commenter when a reply to their comment is edited
   # This may be a non-user of the archive
-  def edited_comment_reply_notification(your_comment_id, edited_comment_id)
-    @your_comment = Comment.find(your_comment_id)
-    @comment = Comment.find(edited_comment_id)
+  def edited_comment_reply_notification(your_comment, edited_comment)
+    @your_comment = your_comment
+    @comment = edited_comment
     mail(
       to: @your_comment.comment_owner_email,
       subject: "[#{ArchiveConfig.APP_SHORT_NAME}] Edited reply to your comment on " + (@comment.ultimate_parent.is_a?(Tag) ? "the tag " : "") + @comment.ultimate_parent.commentable_name.gsub("&gt;", ">").gsub("&lt;", "<")
@@ -61,8 +59,8 @@ class CommentMailer < ActionMailer::Base
   end
 
   # Sends email to the poster of a comment
-  def comment_sent_notification(comment_id)
-    @comment = Comment.find(comment_id)
+  def comment_sent_notification(comment)
+    @comment = comment
     @noreply = true # don't give reply link to your own comment
     mail(
       to: @comment.comment_owner_email,

--- a/app/models/comment_observer.rb
+++ b/app/models/comment_observer.rb
@@ -14,7 +14,7 @@ class CommentObserver < ActiveRecord::Observer
       users << comment.comment_owner
     end
     if notify_user_by_email?(comment.comment_owner) && notify_user_of_own_comments?(comment.comment_owner)
-      CommentMailer.comment_sent_notification(comment.id).deliver
+      CommentMailer.comment_sent_notification(comment).deliver
     end
 
     # Reply to owner of parent comment if this is a reply comment
@@ -36,7 +36,7 @@ class CommentObserver < ActiveRecord::Observer
       users.each do |user|
         unless user == comment.comment_owner && !notify_user_of_own_comments?(user)
           if notify_user_by_email?(user) || comment.ultimate_parent.is_a?(Tag)
-            CommentMailer.comment_notification(user.id, comment.id).deliver
+            CommentMailer.comment_notification(user, comment).deliver
           end
           if notify_user_by_inbox?(user)
             add_feedback_to_inbox(user, comment)
@@ -73,7 +73,7 @@ class CommentObserver < ActiveRecord::Observer
         users << comment.comment_owner
       end
       if notify_user_by_email?(comment.comment_owner) && notify_user_of_own_comments?(comment.comment_owner)
-        CommentMailer.comment_sent_notification(comment.id).deliver
+        CommentMailer.comment_sent_notification(comment).deliver
       end
 
       # send notification to the owner(s) of the ultimate parent, who can be users or admins
@@ -90,7 +90,7 @@ class CommentObserver < ActiveRecord::Observer
         users.each do |user|
           unless user == comment.comment_owner && !notify_user_of_own_comments?(user)
             if notify_user_by_email?(user) || comment.ultimate_parent.is_a?(Tag)
-              CommentMailer.edited_comment_notification(user.id, comment.id).deliver
+              CommentMailer.edited_comment_notification(user, comment).deliver
             end
             if notify_user_by_inbox?(user)
               update_feedback_in_inbox(user, comment)
@@ -120,9 +120,9 @@ class CommentObserver < ActiveRecord::Observer
         if (have_different_owner?(comment, parent_comment)) 
           if !parent_comment_owner || notify_user_by_email?(parent_comment_owner) || comment.ultimate_parent.is_a?(Tag)
             if comment.edited_at_changed?
-              CommentMailer.edited_comment_reply_notification(parent_comment.id, comment.id).deliver
+              CommentMailer.edited_comment_reply_notification(parent_comment, comment).deliver
             else
-              CommentMailer.comment_reply_notification(parent_comment.id, comment.id).deliver
+              CommentMailer.comment_reply_notification(parent_comment, comment).deliver
             end
           end
           if parent_comment_owner && notify_user_by_inbox?(parent_comment_owner)

--- a/config/initializers/resque_mailer.rb
+++ b/config/initializers/resque_mailer.rb
@@ -1,0 +1,5 @@
+# There's also Active Record serializer which allows you to pass 
+# AR models directly as arguments. To use it just do:
+
+Resque::Mailer.argument_serializer = Resque::Mailer::Serializers::ActiveRecordSerializer
+

--- a/config/initializers/resque_mailer.rb
+++ b/config/initializers/resque_mailer.rb
@@ -1,5 +1,5 @@
+# frozen_string_literal: true
 # There's also Active Record serializer which allows you to pass 
 # AR models directly as arguments. To use it just do:
 
 Resque::Mailer.argument_serializer = Resque::Mailer::Serializers::ActiveRecordSerializer
-

--- a/spec/mailers/comment_mailer_spec.rb
+++ b/spec/mailers/comment_mailer_spec.rb
@@ -7,7 +7,7 @@ describe CommentMailer do
       @comment = FactoryGirl.create(:comment)
     end
 
-    let(:email) { CommentMailer.comment_sent_notification(@comment.id).deliver }
+    let(:email) { CommentMailer.comment_sent_notification(@comment).deliver }
 
     it "should have a valid from line" do
       text = "From: Archive of Our Own <#{ArchiveConfig.RETURN_ADDRESS}>"


### PR DESCRIPTION
# Pull Request Checklist
- [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
- [x] Have you read through the [contributor guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
- [x] Have you added tests for any changed functionality?
- [x] Have you added the JIRA issue number as the _first_ thing in your pull request title (eg: `AO3-1234 Fix thing`)
- [x] Have you updated the JIRA issue with the information below?
## Issue

https://otwarchive.atlassian.net/browse/AO3-4644
## Purpose

Reduce the number of errors in resque so we can see any real problems
## Testing

I suspect this needs the resque queues to be full to allow either the original comment or the parent to be deleted. We could simulate it by stopping the workers.

An example error looks like:

Worker
ao3-app03:12932 on MAILER at about 2 hours ago Retry or Remove
Class
 CommentMailer
Arguments
"comment_reply_notification"
77000005
77033890
Exception
ActiveRecord::RecordNotFound
Error
Couldn't find Comment with id=77033890
