### PR TITLE
AO3-4652 AO3-4654 AO3-4656 Assignment email fixes

### DIFF
--- a/app/views/user_mailer/challenge_assignment_notification.html.erb
+++ b/app/views/user_mailer/challenge_assignment_notification.html.erb
@@ -21,9 +21,9 @@
     <% chars = prompt.any_character ? "Any" : styled_tag_list(tag_groups["Character"]) %>
     <% ships = prompt.any_relationship ? "Any" : styled_tag_list(tag_groups["Relationship"]) %>
     <% ratings = prompt.any_rating ? "Any" : (tag_groups["Rating"] ? get_title_string(tag_groups["Rating"]) : nil) %>
-    <% warnings = tag_groups["Warning"] ? get_title_string(tag_groups["Warning"]) : nil %>
-    <% categories = tag_groups["Category"] ? get_title_string(tag_groups["Category"]) : nil %>
-    <% atags = styled_tag_list(tag_groups["Freeform"]) %>
+    <% warnings = prompt.any_warning ? "Any" : (tag_groups["Warning"] ? get_title_string(tag_groups["Warning"]) : nil) %>
+    <% categories = prompt.any_category ? "Any" : (tag_groups["Category"] ? get_title_string(tag_groups["Category"]) : nil) %>
+    <% atags = prompt.any_freeform ? "Any" : styled_tag_list(tag_groups["Freeform"]) %>
     <% otags = prompt.optional_tag_set ? styled_tag_list(prompt.optional_tag_set.tags) : nil %>
 
     <%= styled_divider %>

--- a/app/views/user_mailer/challenge_assignment_notification.html.erb
+++ b/app/views/user_mailer/challenge_assignment_notification.html.erb
@@ -53,7 +53,7 @@
   </p>
 
   <p>
-    You can look up this assignment from <%= style_link("your archive dashboard", user_assignments_url(@assigned_user)) %>.
+    You can look up this assignment from <%= style_link("your Assignments page", user_assignments_url(@assigned_user)) %>.
   </p>
 
   <% if @collection && !@collection.assignment_notification.blank? %>

--- a/app/views/user_mailer/challenge_assignment_notification.html.erb
+++ b/app/views/user_mailer/challenge_assignment_notification.html.erb
@@ -14,38 +14,38 @@
 
     <% def styled_tag_list(tags) %>
       <% return nil if !tags || tags.empty? %>
-      <% tags.map{|tag| style_link(tag.name, tag_works_url(tag))}.to_sentence.html_safe %>
+      <% tags.map { |tag| style_link(tag.name, tag_works_url(tag)) }.to_sentence.html_safe %>
     <% end %>
 
     <% fandoms = prompt.any_fandom ? "Any" : styled_tag_list(tag_groups["Fandom"]) %>
     <% chars = prompt.any_character ? "Any" : styled_tag_list(tag_groups["Character"]) %>
     <% ships = prompt.any_relationship ? "Any" : styled_tag_list(tag_groups["Relationship"]) %>
-    <% ratings = prompt.any_rating ? "Any" : get_title_string(tag_groups["Rating"]) %>
+    <% ratings = prompt.any_rating ? "Any" : (tag_groups["Rating"] ? get_title_string(tag_groups["Rating"]) : nil) %>
     <% warnings = tag_groups["Warning"] ? get_title_string(tag_groups["Warning"]) : nil %>
     <% categories = tag_groups["Category"] ? get_title_string(tag_groups["Category"]) : nil %>
     <% atags = styled_tag_list(tag_groups["Freeform"]) %>
     <% otags = prompt.optional_tag_set ? styled_tag_list(prompt.optional_tag_set.tags) : nil %>
 
     <%= styled_divider %>
-    <%= index+1 %>. <%= style_bold(prompt.title) %>
+    <%= index + 1 %>. <%= style_bold(prompt.title) %>
 
     <p>
-      <% if fandoms then %><%= style_bold("Fandom:") %> <%= fandoms %><br><% end %>      
-      <% if chars then %><%= style_bold("Characters:") %> <%= chars %><br><% end %>
-      <% if ships then %><%= style_bold("Relationships:") %> <%= ships %><br><% end %>
-      <% if ratings then %><%= style_bold("Rating:") %> <%= ratings %><br><% end %>
-      <% if warnings then %><%= style_bold("Warnings:") %> <%= warnings %><br><% end %>
-      <% if categories then %><%= style_bold("Category:") %> <%= categories %><br><% end %>
-      <% if atags then %><%= style_bold("Additional Tags:") %> <%= atags %><br><% end %>
-      <% if otags then %><%= style_bold("Optional Tags:") %> <%= otags %><br><% end %>
-      <% if prompt.url && !prompt.url.blank? then %><%= style_bold("Prompt URL:") %> <%= style_link(prompt.url, prompt.url) %><br><% end %>
+      <% if fandoms %><%= style_bold("Fandom:") %> <%= fandoms %><br><% end %>
+      <% if chars %><%= style_bold("Characters:") %> <%= chars %><br><% end %>
+      <% if ships %><%= style_bold("Relationships:") %> <%= ships %><br><% end %>
+      <% if ratings %><%= style_bold("Rating:") %> <%= ratings %><br><% end %>
+      <% if warnings %><%= style_bold("Warnings:") %> <%= warnings %><br><% end %>
+      <% if categories %><%= style_bold("Category:") %> <%= categories %><br><% end %>
+      <% if atags %><%= style_bold("Additional Tags:") %> <%= atags %><br><% end %>
+      <% if otags %><%= style_bold("Optional Tags:") %> <%= otags %><br><% end %>
+      <% if prompt.url && !prompt.url.blank? %><%= style_bold("Prompt URL:") %> <%= style_link(prompt.url, prompt.url) %><br><% end %>
       <% if prompt.description && !prompt.description.blank? %>
         <%= style_bold("Description:") %>
         <%= style_quote(prompt.description) %>
       <% end %>
     </p>
   <% end %>
-  
+
   <%= styled_divider %>
 
   <p>

--- a/app/views/user_mailer/challenge_assignment_notification.text.erb
+++ b/app/views/user_mailer/challenge_assignment_notification.text.erb
@@ -14,9 +14,9 @@ Prompts:
 <% chars = prompt.any_character ? "Any" : tag_list(tag_groups["Character"]) %>
 <% ships = prompt.any_relationship ? "Any" : tag_list(tag_groups["Relationship"]) %>
 <% ratings = prompt.any_rating ? "Any" : (tag_groups["Rating"] ? get_title_string(tag_groups["Rating"]) : nil) %>
-<% warnings = tag_groups["Warning"] ? get_title_string(tag_groups["Warning"]) : nil %>
-<% categories = tag_groups["Category"] ? get_title_string(tag_groups["Category"]) : nil %>
-<% atags = tag_list(tag_groups["Freeform"]) %>
+<% warnings = prompt.any_warning ? "Any" : (tag_groups["Warning"] ? get_title_string(tag_groups["Warning"]) : nil) %>
+<% categories = prompt.any_category ? "Any" : (tag_groups["Category"] ? get_title_string(tag_groups["Category"]) : nil) %>
+<% atags = prompt.any_freeform ? "Any" : tag_list(tag_groups["Freeform"]) %>
 <% otags = prompt.optional_tag_set ? tag_list(prompt.optional_tag_set.tags) : nil %>
 <%= text_divider %>
 

--- a/app/views/user_mailer/challenge_assignment_notification.text.erb
+++ b/app/views/user_mailer/challenge_assignment_notification.text.erb
@@ -8,21 +8,21 @@ Prompts:
 <% tag_groups = prompt.tag_groups %>
 <% def tag_list(tags) %>
 <%  return nil if !tags || tags.empty? %>
-<%  tags.map{|tag| tag.name}.to_sentence.html_safe %>
+<%  tags.map { |tag| tag.name }.to_sentence.html_safe %>
 <% end %>
 <% fandoms = prompt.any_fandom ? "Any" : tag_list(tag_groups["Fandom"]) %>
 <% chars = prompt.any_character ? "Any" : tag_list(tag_groups["Character"]) %>
 <% ships = prompt.any_relationship ? "Any" : tag_list(tag_groups["Relationship"]) %>
-<% ratings = prompt.any_rating ? "Any" : get_title_string(tag_groups["Rating"]) %>
+<% ratings = prompt.any_rating ? "Any" : (tag_groups["Rating"] ? get_title_string(tag_groups["Rating"]) : nil) %>
 <% warnings = tag_groups["Warning"] ? get_title_string(tag_groups["Warning"]) : nil %>
 <% categories = tag_groups["Category"] ? get_title_string(tag_groups["Category"]) : nil %>
 <% atags = tag_list(tag_groups["Freeform"]) %>
 <% otags = prompt.optional_tag_set ? tag_list(prompt.optional_tag_set.tags) : nil %>
 <%= text_divider %>
 
-<%= index+1 %>. <%= prompt.title %>
+<%= index + 1 %>. <%= prompt.title %>
 
-<% if fandoms then %>Fandom: <%= fandoms %><% end %><% if chars %>
+<% if fandoms %>Fandom: <%= fandoms %><% end %><% if chars %>
 Characters: <%= chars %><% end %><% if ships %>
 Relationships: <%= ships %><% end %><% if ratings %>
 Rating: <%= ratings %><% end %><% if warnings %>

--- a/app/views/user_mailer/challenge_assignment_notification.text.erb
+++ b/app/views/user_mailer/challenge_assignment_notification.text.erb
@@ -38,7 +38,7 @@ Description:
 
 This assignment is due at: <%= to_plain_text(time_in_zone(@collection.challenge.assignments_due_at, (@collection.challenge.time_zone || Time.zone.name), @assigned_user)).gsub(/\n\s*/, "") %>.
 
-You can look up this assignment from your archive dashboard at <%= user_assignments_url(@assigned_user) %>.
+You can look up this assignment from your Assignments page at <%= user_assignments_url(@assigned_user) %>.
 <% if @collection && !@collection.assignment_notification.blank? %>
 
 

--- a/features/gift_exchanges/challenge_giftexchange.feature
+++ b/features/gift_exchanges/challenge_giftexchange.feature
@@ -266,6 +266,20 @@ Feature: Gift Exchange Challenge
       And the email should link to myname1's user url
       And the email html body should link to the works tagged "Stargate Atlantis"
 
+  Scenario: Assignment emails contain only the relevant tags
+    Given the gift exchange "Awesome Gift Exchange" is ready for matching
+      And I have generated matches for "Awesome Gift Exchange"
+    When I have sent assignments for "Awesome Gift Exchange"
+    Then 1 email should be delivered to "myname4"
+      And the email should contain "Fandom:"
+      And the email should contain "Additional Tags:"
+      And the email should not contain "Character:"
+      And the email should not contain "Relationships:"
+      And the email should not contain "Rating:"
+      And the email should not contain "Warnings:"
+      And the email should not contain "Category:"
+      And the email should not contain "Optional Tags:"
+
   Scenario: User signs up for two gift exchanges at once #'
     Given I am logged in as "mod1"
       And I have created the gift exchange "Awesome Gift Exchange"

--- a/features/gift_exchanges/challenge_giftexchange.feature
+++ b/features/gift_exchanges/challenge_giftexchange.feature
@@ -266,20 +266,6 @@ Feature: Gift Exchange Challenge
       And the email should link to myname1's user url
       And the email html body should link to the works tagged "Stargate Atlantis"
 
-  Scenario: Assignment emails contain only the relevant tags
-    Given the gift exchange "Awesome Gift Exchange" is ready for matching
-      And I have generated matches for "Awesome Gift Exchange"
-    When I have sent assignments for "Awesome Gift Exchange"
-    Then 1 email should be delivered to "myname4"
-      And the email should contain "Fandom:"
-      And the email should contain "Additional Tags:"
-      And the email should not contain "Character:"
-      And the email should not contain "Relationships:"
-      And the email should not contain "Rating:"
-      And the email should not contain "Warnings:"
-      And the email should not contain "Category:"
-      And the email should not contain "Optional Tags:"
-
   Scenario: User signs up for two gift exchanges at once #'
     Given I am logged in as "mod1"
       And I have created the gift exchange "Awesome Gift Exchange"
@@ -371,9 +357,9 @@ Feature: Gift Exchange Challenge
       And I follow "Complete"
     Then I should see "myname1"
       And I should see "Fulfilled Story"
-      
+
   Scenario: Refused story should still fulfill the assignment
-  
+
     Given an assignment has been fulfilled in a gift exchange
       And I reveal works for "Awesome Gift Exchange"
       And I refuse my gift story "Fulfilled Story"
@@ -382,7 +368,7 @@ Feature: Gift Exchange Challenge
       And I follow "Complete"
     Then I should see "myname1"
       And I should see "Fulfilled Story"
-  
+
 
   Scenario: Download signups CSV
     Given I am logged in as "mod1"
@@ -452,3 +438,52 @@ Feature: Gift Exchange Challenge
     When I am logged in as "myname2"
       And I delete my signup for the gift exchange "Awesome Gift Exchange"
     Then I should see "Challenge sign-up was deleted."
+
+  Scenario: Assignment emails should contain all the information in the request
+  # Note: tag names are lowercased for the test so we could borrow the potential
+  # match steps, and due to the HTML, each tag must be looked for separate from
+  # its label or other tags of its type
+    Given I create the gift exchange "EmailTest" with the following options
+        | value      | minimum | maximum | match |
+        | prompts    | 1       | 1       | 1     |
+        | fandoms    | 1       | 1       | 0     |
+        | characters | 1       | 1       | 0     |
+        | freeforms  | 0       | 2       | 0     |
+        | ratings    | 0       | 1       | 0     |
+        | categories | 0       | 1       | 0     |
+      And the user "badgirlsdoitwell" signs up for "EmailTest" with the following prompts
+        | type    | characters | fandoms  | freeforms | ratings | categories |
+        | request | any        | the show | fic, art  | mature  |            |
+        | offer   | villain    | the show | fic       |         |            |
+      And the user "sweetiepie" signs up for "EmailTest" with the following prompts
+        | type    | characters | fandoms  | freeforms | ratings | categories |
+        | request | protag     | the book |           |         | any        |
+        | offer   | protag     | the book | fic       |         |            |
+      When I have generated matches for "EmailTest"
+        And I have sent assignments for "EmailTest"
+      Then 1 email should be delivered to "sweetiepie"
+        And the email should contain "Fandom:"
+        And the email should contain "the show"
+        And the email should contain "Additional Tags:"
+        And the email should contain "fic"
+        And the email should contain "art"
+        And the email should contain "Characters:"
+        And the email should contain "Any"
+        And the email should contain "Rating:"
+        And the email should contain "mature"
+        And the email should not contain "Relationships:"
+        And the email should not contain "Warnings:"
+        And the email should not contain "Category:"
+        And the email should not contain "Optional Tags:"
+      Then 1 email should be delivered to "badgirlsdoitwell"
+        And the email should contain "Fandom:"
+        And the email should contain "the book"
+        And the email should contain "Characters:"
+        And the email should contain "protag"
+        And the email should contain "Category:"
+        And the email should contain "Any"
+        And the email should not contain "Additional Tags:"
+        And the email should not contain "Relationships:"
+        And the email should not contain "Rating:"
+        And the email should not contain "Warnings:"
+        And the email should not contain "Optional Tags:"

--- a/features/step_definitions/challenge_steps.rb
+++ b/features/step_definitions/challenge_steps.rb
@@ -121,8 +121,11 @@ end
 ### WHEN other
 
 When /^I close signups for "([^\"]*)"$/ do |title|
-  step %{I am logged in as "mod1"}
-  visit collection_path(Collection.find_by_title(title))
+  collection = Collection.find_by_title(title)
+  user_id = collection.all_owners.first.user_id
+  mod_login = User.find_by_id(user_id).login
+  step %{I am logged in as "#{mod_login}"}
+  visit collection_path(collection)
   step %{I follow "Challenge Settings"}
     step %{I uncheck "Sign-up open?"}
     step %{I press "Update"}


### PR DESCRIPTION
https://otwarchive.atlassian.net/browse/AO3-4652
https://otwarchive.atlassian.net/browse/AO3-4654
https://otwarchive.atlassian.net/browse/AO3-4656

## Purpose

AO3-4652: When you receive an assignment email in a gift exchange, it says "Rating: Choose Not To Use Archive Warnings" if (a) your recipient did not select a rating or (b) the challenge does not use rating tags. This makes it so "Rating:" is only included if the recipient specifies.

AO3-4654: All of the fields the requester explicitly set to "Any" should be listed in the email, like they are on the sign-up you can access by going through your dashboard.

AO3-4656: The link to your Assignments page should say "Assignments page" rather than "archive dashboard."

## Testing

Refer to JIRA.