### PR TITLE
AO3-4616 Add delays for the skin tests.

### DIFF
--- a/features/other_b/skin.feature
+++ b/features/other_b/skin.feature
@@ -212,6 +212,8 @@ Feature: creating and editing skins
     And I submit
   Then I should see "Your preferences were successfully updated."
     And I should see "margin: auto 5%; max-width: 100%" within "style"
+    # Make sure that the creation/update cache keys are different:
+    And I wait 1 second
   When I edit the skin "Wide margins" with the wizard
     And I fill in "Work margin width" with "4.5"
     And I submit
@@ -289,6 +291,8 @@ Feature: creating and editing skins
   Scenario: Users should be able to adjust their wizard skin by adding custom CSS
   Given I am logged in as "skinner"
     And I create and use a skin to make the header pink
+    # Make sure that the creation/update cache keys are different:
+    And I wait 1 second
   When I edit my pink header skin to have a purple logo
   Then I should see an update confirmation message
     And I should see a pink header


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [x] Have you added tests for any changed functionality?
* [x] Have you added the JIRA issue number as the *first* thing in your pull request title (eg: `AO3-1234 Fix thing`)
* [x] Have you updated the JIRA issue with the information below?

## Issue

https://otwarchive.atlassian.net/browse/AO3-4616

## Purpose

The updated_at field only has resolution down to the second, not the millisecond, so if two updates to the same skin are performed within the same second, the cache key used to access the cached version of the data won't change between updates. But in order to ensure that caching always has the most recent version of the data, the cache key has to change whenever the underlying data changes.

This pull request adds a small delay to two of the automated skins tests, in an attempt to ensure that the cache key has changed when the data changes. This is a stopgap measure that will hopefully stop the intermittent Travis skin test failures until the larger caching problem is handled (likely by updating Rails).

## Testing

This is an update to the automated tests, so I don't think it really requires any manual QA. (Aside from possibly making Travis CI run the other_b tests over and over again to check whether this fixes the problem.)

## Credit

tickinginstant, she/her