### PR TITLE
AO3-4343 Support emails say "sent_at" in footer

### DIFF
--- a/app/views/layouts/mailer.html.erb
+++ b/app/views/layouts/mailer.html.erb
@@ -98,7 +98,7 @@
                           <%= t 'mailer.general.footer.general.html', support_url: root_url + "support", donate_url: donate_url %>
 
                           <% if content_for?(:sent_at) %>
-                            <p><%= t 'mailer.general.footer.sent_at', sent_at: :sent_at %></p>
+                            <p><%= t 'mailer.general.footer.sent_at', sent_at: yield(:sent_at).strip %></p>
                           <% end %>
 
                           <% if content_for?(:sent_by) %>

--- a/app/views/layouts/mailer.text.erb
+++ b/app/views/layouts/mailer.text.erb
@@ -14,7 +14,7 @@ Archive of Our Own
 <%= t 'mailer.general.footer.general.text', support_url: root_url+"support", donate_url: donate_url %>
 <% if content_for?(:sent_at) %>
 
-<%= t 'mailer.general.footer.sent_at', sent_at: :sent_at %>
+<%= t 'mailer.general.footer.sent_at', sent_at: yield(:sent_at).strip %>
 
 <% end %>
 <% if content_for?(:sent_by) %>

--- a/features/other_b/support.feature
+++ b/features/other_b/support.feature
@@ -17,6 +17,7 @@ Feature: Filing a support request
     And 2 emails should be delivered
     And the email should contain "We're working hard to reply to everyone, and we'll respond to you as soon as we can."
     And the email should contain "If you have additional questions or information"
+    And the email should say what time it was sent
   When I follow "Support and Feedback"
     And I fill in "Brief summary" with "you suck"
     And I fill in "Your comment" with "blah blah blah"

--- a/features/step_definitions/email_custom_steps.rb
+++ b/features/step_definitions/email_custom_steps.rb
@@ -34,3 +34,10 @@ Then(/^"([^\"]*)" should receive (\d+) emails?$/) do |user, count|
   @user = User.find_by_login(user)
   emails("to: \"#{email_for(@user.email)}\"").size.should == count.to_i
 end
+
+Then /^the email should say what time it was sent$/ do
+  # mailer time format: 11:38PM EDT Thu 29 September 2016
+  nowish = Time.now.strftime('%I:%M%p %Z %a %d %B %Y')
+  step %{the email should contain "Sent at #{nowish}"}
+  step %{the email should not contain "sent_at"}
+end


### PR DESCRIPTION
https://otwarchive.atlassian.net/browse/AO3-4343

## Purpose

Stops displaying the words `sent_at` in the Support automated response email and instead starts displaying the date.

## Notes

This should fix it everywhere it was happening, not just the Support automated response, because the problem was the mailer layout that we use for all the user mailers. So it probably also fixes https://otwarchive.atlassian.net/browse/AO3-4657