### PR TITLE
AO3-4655 Fix optional tag display on prompts

### DIFF
--- a/app/views/challenge/shared/_challenge_requests.html.erb
+++ b/app/views/challenge/shared/_challenge_requests.html.erb
@@ -23,7 +23,7 @@
 <%= will_paginate @requests %>
 
 <!--main content-->
-<ul class="index group">
+<ul class="prompt index group">
   <% @requests.each do |request| %>
     <% # here we render each prompt as a blurb %>
     <%= render "prompts/prompt_blurb", :prompt => request %>

--- a/app/views/challenge_claims/_user_index.html.erb
+++ b/app/views/challenge_claims/_user_index.html.erb
@@ -22,7 +22,7 @@
   <p class="note"><%= ts('Looking for assignments you were given for a gift exchange? Try') %> <%= link_to ts("My Assignments"), user_assignments_path(@user) %></p>
 <% end %>
 
-<ol class="index group">
+<ol class="prompt index group">
 
 	<% @claims.each do |claim| %>
 		<%= render "prompts/prompt_blurb", :prompt => claim.request_prompt, :claim => claim, :suppress_claims => !params[:posted] %>

--- a/app/views/challenge_signups/_show_offers.html.erb
+++ b/app/views/challenge_signups/_show_offers.html.erb
@@ -14,7 +14,7 @@
       <% end %>
     </h3>
 
-    <ol class="index group">
+    <ol class="prompt index group">
       <% challenge_signup.offers.each_with_index do |offer, index| %>
         <%= render "prompts/prompt_blurb", :prompt => offer, :index => index %>
       <% end %>

--- a/app/views/challenge_signups/_show_requests.html.erb
+++ b/app/views/challenge_signups/_show_requests.html.erb
@@ -14,7 +14,7 @@
       <% end %>
     </h3>
 
-    <ol class="index group">
+    <ol class="prompt index group">
       <% challenge_signup.requests.each_with_index do |request, index| %>
         <%= render "prompts/prompt_blurb", :prompt => request, :index => index %>
       <% end %>

--- a/app/views/prompts/_prompt_blurb.html.erb
+++ b/app/views/prompts/_prompt_blurb.html.erb
@@ -1,5 +1,5 @@
 <% # expects "prompt", if index is passed will use that in title if none exists, if suppress_claims is true will ignore %>
-<li class="<% if is_author_of?(prompt) %>own <% end %>prompt blurb group" role="article">
+<li class="<% if is_author_of?(prompt) %>own <% end %> blurb group" role="article">
   <div class="header module">
     <h4 class="heading">
       <% if !prompt.title.blank? %>
@@ -31,7 +31,7 @@
     <p class="datetime"><%= set_format_for_date(prompt.created_at) %></p>
   </div>
 
-  <h6 class="landmark heading"><%= ts("Tags") %></h6>  
+  <h6 class="landmark heading"><%= ts("Tags") %></h6> 
   <ul class="tags commas">
     <%= blurb_tag_block(prompt, tag_groups) %>
     <% any_types = TagSet::TAG_TYPES.select {|type| prompt.send("any_#{type}")} %>
@@ -40,8 +40,8 @@
     <% end %>
   </ul>
   <% if prompt.optional_tag_set && !prompt.optional_tag_set.tags.empty? %>
-    <h6 class="heading"><%= ts("Optional:") %></h6>
-    <ul class="tags commas">
+    <h6 class="optional heading"><%= ts("Optional Tags:") %></h6>
+    <ul class="optional tags commas">
       <%= tag_link_list(prompt.optional_tag_set.tags, link_to_works=true) %>
     </ul>
   <% end %>

--- a/app/views/prompts/show.html.erb
+++ b/app/views/prompts/show.html.erb
@@ -7,7 +7,7 @@
 <!--/subnav-->
 
 <!--main content-->
-<ul class="index group">
+<ul class="prompt index group">
   <%= render "prompts/prompt_blurb", :prompt => @prompt %>
 </ul>
 <!--/content-->

--- a/public/stylesheets/site/2.0/13-group-blurb.css
+++ b/public/stylesheets/site/2.0/13-group-blurb.css
@@ -270,11 +270,6 @@ eg collections, users, skins, instead of the 4-icon list
     word-wrap: break-word;
 }
 
-.prompt h6 {
-  float: left;
-  min-width: 65px;
-}
-
 /* mod: ITEM
 blurbs on the manage collection items pages, mostly reseting styles inherited from interactions (forms)
 */
@@ -404,6 +399,19 @@ blurbs on the manage collection items pages, mostly reseting styles inherited fr
 
 .skin .blurb .header p {
   margin-left: 65px;
+}
+
+/* mod: PROMPT */
+
+.prompt .blurb h6 {
+  display: inline-block;
+  font-family: 'Lucida Grande', 'Lucida Sans Unicode', Verdana, Helvetica, sans-serif;
+  font-size: 1em;
+  margin: 0.643em 0 0;
+}
+
+.prompt .blurb ul.optional {
+  display: inline;
 }
 
 /*END== */


### PR DESCRIPTION
https://otwarchive.atlassian.net/browse/AO3-4655

## Purpose

Fixes the alignment of the optional tags in challenge sign up prompt blurbs. (I moved the prompt class to the index that contains the prompts, not the prompts themselves, to bring it in line with the rest of the site -- we want to be able to do `.prompt .blurb` to style things, not `.prompt` and pray it's only a blurb.)