### PR TITLE
AO3-4662 - Remove the /api/v1/import route

### DIFF
--- a/app/controllers/api/v1/import_controller.rb
+++ b/app/controllers/api/v1/import_controller.rb
@@ -1,4 +1,0 @@
-class Api::V1::ImportController < Api::V1::BaseController
-  respond_to :json
-
-end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -464,7 +464,6 @@ Otwarchive::Application.routes.draw do
       resources :bookmarks, only: [:create], defaults: { format: :json }
       resources :works, only: [:create], defaults: { format: :json }
       match 'bookmarks/import', to: 'bookmarks#create', via: :post
-      match 'import', to: 'works#create', via: :post
       match 'works/import', to: 'works#create', via: :post
       match 'works/urls', to: 'works#batch_urls', via: :post
     end

--- a/spec/api/api_authorization_spec.rb
+++ b/spec/api/api_authorization_spec.rb
@@ -4,7 +4,7 @@ require 'api/api_helper'
 
 describe "API Authorization" do
   include ApiHelper
-  end_points = %w(api/v1/import api/v1/works api/v1/bookmarks)
+  end_points = %w(api/v1/works api/v1/bookmarks)
 
   describe "API POST with invalid request" do
     it "should return 401 Unauthorized if no token is supplied" do

--- a/spec/api/api_works_spec.rb
+++ b/spec/api/api_works_spec.rb
@@ -98,7 +98,7 @@ describe "API WorksController - Create" do
       before(:all) do
         mock_external
         user = create(:user)
-        post "/api/v1/import",
+        post "/api/v1/works",
              { archivist: user.login,
                works: [{ id: "123",
                          title: api_fields[:title],
@@ -165,7 +165,7 @@ describe "API WorksController - Create" do
       before(:all) do
         mock_external
         user = create(:user)
-        post "/api/v1/import",
+        post "/api/v1/works",
              { archivist: user.login,
                works: [{ external_author_name: "bar",
                          external_author_email: "bar@foo.com",
@@ -221,7 +221,7 @@ describe "API WorksController - Create" do
       before(:all) do
         mock_external
         user = create(:user)
-        post "/api/v1/import",
+        post "/api/v1/works",
              { archivist: user.login,
                works: [{ external_author_name: "bar",
                          external_author_email: "bar@foo.com",

--- a/spec/api/api_works_spec.rb
+++ b/spec/api/api_works_spec.rb
@@ -22,15 +22,8 @@ describe "API WorksController - Create" do
       WebMock.reset!
     end
 
-    it "should support the deprecated /import end-point" do
-      post "/api/v1/import",
-           { archivist: @user.login,
-             works: [{ external_author_name: "bar",
-                       external_author_email: "bar@foo.com",
-                       chapter_urls: ["http://foo"] }]
-           }.to_json,
-           valid_headers
-      assert_equal 200, response.status
+    it "should not support the deprecated /import end-point", type: :routing do
+      expect(post: "/api/v1/import").not_to be_routable
     end
 
     it "should return 200 OK when all stories are created" do

--- a/spec/models/cache_master_spec.rb
+++ b/spec/models/cache_master_spec.rb
@@ -1,10 +1,10 @@
 require 'spec_helper'
 
 describe CacheMaster do
- let(:cache_master) { CacheMaster.new(42) }
+ let(:cache_master) { CacheMaster.new(123456) }
 
   it "should have a key" do
-    expect(cache_master.key).to eq("works:42:assocs")
+    expect(cache_master.key).to eq("works:123456:assocs")
   end
 
   it "should record deleted associations" do


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-4662

## Purpose

Removes an old API controller which is no longer used for automated imports.

## Testing

If the automated tests pass, this is working.

