### PR TITLE
AO3-1654 Make "n more comments in this thread" a link.

### DIFF
--- a/app/views/comments/_comment_thread.html.erb
+++ b/app/views/comments/_comment_thread.html.erb
@@ -9,7 +9,7 @@
       <% if child_comments && child_comments.count > 0 %>
         <!-- cut off the recursion when we get too deep, but not if there's just one last measly comment left -->
         <% if depth >= ArchiveConfig.COMMENT_THREAD_MAX_DEPTH && child_comments.count > 1 %>
-          <li class="comment"><p>(<%= link_to ts("%{count} more comments in this thread", :count => comment.children_count), comment_url(comment) %>)</p></li>
+          <li class="comment"><p>(<%= link_to ts("%{count} more comments in this thread", count: comment.children_count), comment_url(comment) %>)</p></li>
         <% else %>
           <li>
             <%= render 'comments/comment_thread', comments: child_comments, depth: depth+1 %>

--- a/app/views/comments/_comment_thread.html.erb
+++ b/app/views/comments/_comment_thread.html.erb
@@ -9,7 +9,7 @@
       <% if child_comments && child_comments.count > 0 %>
         <!-- cut off the recursion when we get too deep, but not if there's just one last measly comment left -->
         <% if depth >= ArchiveConfig.COMMENT_THREAD_MAX_DEPTH && child_comments.count > 1 %>
-          <li class="comment"><p>(<%= ts("%{count} more comments in this thread", :count => comment.children_count) %>)</p></li>
+          <li class="comment"><p>(<%= link_to ts("%{count} more comments in this thread", :count => comment.children_count), comment_url(comment) %>)</p></li>
         <% else %>
           <li>
             <%= render 'comments/comment_thread', comments: child_comments, depth: depth+1 %>

--- a/features/comments_and_kudos/comments_delete.feature
+++ b/features/comments_and_kudos/comments_delete.feature
@@ -50,8 +50,7 @@ Feature: Delete a comment
 
   Scenario: Deleting higher-level comments in a deep comment thread should still allow readers to access the deeper comments.
 
-    Given I am logged in as "author"
-      And I post the work "Testing"
+    Given the work "Testing"
       And I am logged in as "commenter"
 
     When I post a deeply nested comment thread on "Testing"

--- a/features/comments_and_kudos/comments_delete.feature
+++ b/features/comments_and_kudos/comments_delete.feature
@@ -47,4 +47,23 @@ Feature: Delete a comment
     Then I should see "Comment deleted."
       And I should see "(Previous comment deleted.)"
       And I should see "I didn't mean that"
-  
+
+  Scenario: Deleting higher-level comments in a deep comment thread should still allow readers to access the deeper comments.
+
+    Given I am logged in as "author"
+      And I post the work "Testing"
+      And I am logged in as "commenter"
+
+    When I post a deeply nested comment thread on "Testing"
+      And I view the work "Testing" with comments
+    Then I should see "(2 more comments in this thread)"
+      And I should not see the deeply nested comments
+
+    When I delete all visible comments on "Testing"
+      And I view the work "Testing" with comments
+    Then I should see "(Previous comment deleted.)"
+      And I should see "(2 more comments in this thread)"
+      And I should not see the deeply nested comments
+
+    When I follow "2 more comments in this thread"
+    Then I should see the deeply nested comments


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [x] Have you added tests for any changed functionality?
* [x] Have you added the JIRA issue number as the *first* thing in your pull request title (eg: `AO3-1234 Fix thing`)
* [x] Have you updated the JIRA issue with the information below?

## Issue

https://otwarchive.atlassian.net/browse/AO3-1654

## Purpose

When a work has a comment thread that is very deeply nested, the thread doesn't display the most deeply-nested comments when you view the work -- instead, it displays the text `(%{count} more comments in this thread)`, and you can click on the `Thread` link for the parent comment to view the hidden comments. When all comments visible on the work's comments page are deleted, however, there are no `Thread` links to click on, so the deeply nested comments become inaccessible to anyone without a direct link.

As suggested in the bug report, this pull request makes the `%{count} more comments in this thread` text a link, making the nested comments accessible again.

## Testing

The bug report has some steps that can be used for testing.

One thing to keep in mind for trying to force the page to hide some deeply nested comments: if a comment has only one direct child, no matter how deep that comment is, the comment display code won't hide it. It'll only hide a comment's descendants if the comment's depth is more than 5, **and** the comment has more than one **direct** reply. (The QA testers probably already know this, but I had trouble with this when I tried to set up my own tests, so I figured I'd mention it just in case.)