### PR TITLE
AO3-4635 Potential Match generation test for no tags, unconstrained matching.

### DIFF
--- a/features/gift_exchanges/potential_matches.feature
+++ b/features/gift_exchanges/potential_matches.feature
@@ -64,6 +64,34 @@ Feature:
         | test3 | test1   |
         | test3 | test2   |
 
+  Scenario: Unconstrained exchange with no tags.
+
+    Given I create the gift exchange "no_tags3" with the following options
+        | value      | minimum | maximum | match |
+        | prompts    | 1       | 1       | 1     |
+      And the user "test1" signs up for "no_tags3" with the following prompts
+        | type    |
+        | request |
+        | offer   |
+      And the user "test2" signs up for "no_tags3" with the following prompts
+        | type    |
+        | request |
+        | offer   |
+      And the user "test3" signs up for "no_tags3" with the following prompts
+        | type    |
+        | request |
+        | offer   |
+
+    When potential matches are generated for "no_tags3"
+    Then the potential matches for "no_tags3" should be
+        | offer | request |
+        | test1 | test2   |
+        | test1 | test3   |
+        | test2 | test1   |
+        | test2 | test3   |
+        | test3 | test1   |
+        | test3 | test2   |
+
   Scenario: Constrained exchange with no matches.
 
     Given I create the gift exchange "constrained3" with the following options


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [x] Have you added tests for any changed functionality?
* [x] Have you added the JIRA issue number as the *first* thing in your pull request title (eg: `AO3-1234 Fix thing`)
* [x] Have you updated the JIRA issue with the information below?

## Issue

https://otwarchive.atlassian.net/browse/AO3-4635

## Purpose

This adds a new automated test for the new potential match generation code, verifying that the correct set of potential matches is generated when signups have no tags, and matching is unconstrained.

## Testing

It's a new automated test, so as long as it passes, I don't know that testing is necessary.