### PR TITLE
AO3-4375 Update tips and tricks page

### DIFF
--- a/app/views/home/first_login_help.html.erb
+++ b/app/views/home/first_login_help.html.erb
@@ -44,12 +44,12 @@
   <h3 class="heading" id="edit_profile">
     <%= ts('Editing Your Profile, Password, and Preferences') %>
   </h3>
-  <p><%= ts('To add your info, go to %{homepage}, select the 
+  <p><%= ts('To add your info, go to %{dashboard}, select the 
   "%{profile}" tab, and select "%{edit_profile}" from the range of 
   options at the end of the page. Here, you can enter some basic personal 
   information. It\'s also where to go to change your password. Refer to the 
   %{profile_faq} for more information.',
-  homepage: (link_to ts('your home page'), user_path(current_user)),
+  dashboard: (link_to ts('your Dashboard'), user_path(current_user)),
   profile: (link_to ts('Profile'), user_profile_path(current_user)),
   edit_profile: (link_to ts('Edit My Profile'), edit_user_path(current_user)), 
   profile_faq: (link_to ts('Profile FAQ'), archive_faqs_path + '/profile')
@@ -179,7 +179,7 @@
   or on top of the page in mobile devices. You can clear your history, or delete 
   individual entries if you don\'t want these entries to show up in your 
   history. You can also add works to the "Marked for Later" list in your 
-  history. For more information on History, please visit %{history_faq}.',
+  history. For more information on History, please visit the %{history_faq}.',
   dashboard: (link_to ts('your Dashboard'), user_path(current_user)),
   history: (link_to ts('History'), user_readings_path(current_user)),
   history_faq: (link_to ts('History and Mark for Later FAQ'), 
@@ -193,7 +193,7 @@
   by selecting the "Subscribe" link at the top or bottom of a work, or at the 
   top or bottom of a collection or series page, or the user\'s profile page. You 
   can check your subscriptions from %{dashboard} by selecting the 
-  "Subscriptions" link. For more information on Subscriptions, please visit 
+  "Subscriptions" link. For more information on Subscriptions, please visit the 
   %{subscription_faq}.',
   dashboard: (link_to ts('your Dashboard'), user_path(current_user)),
   subscription_faq: (link_to ts('Subscriptions and Feeds FAQ'), 

--- a/app/views/home/first_login_help.html.erb
+++ b/app/views/home/first_login_help.html.erb
@@ -1,16 +1,9 @@
+<% # Expects current_user %>
 <div class="userstuff">
   <h2 class="heading">
     <%= ts('Welcome to the %{app_name}!', app_name: ArchiveConfig.APP_NAME) %>
   </h2>
-
   <p><%= ts('Here are some tips to help you get started.') %></p>
-  <% if current_user %>
-    <%= form_tag end_first_login_user_path(current_user), method: :post, remote: true do %>
-      <p class="submit actions">
-        <%= submit_tag ts('Dismiss this message permanently') %>
-      </p>
-    <% end %>
-  <% end %>
 
   <h3 class="landmark heading"><%= ts('Table of Contents') %></h3>
   <ul id="toc" class="toc" role="directory">

--- a/app/views/home/first_login_help.html.erb
+++ b/app/views/home/first_login_help.html.erb
@@ -94,8 +94,10 @@
   %{search_tutorial}.',
   fandoms: (link_to ts('Fandoms'), menu_fandoms_path),
   all_fandoms: (link_to ts('All Fandoms'), media_path),
-  movies: (link_to ts('Movies'), 
-                   medium_fandoms_path(Media.find_by_name('Movies'))),
+  movies: Media.find_by_name('Movies') ? (link_to ts('Movies'), 
+                                         medium_fandoms_path(
+                                           Media.find_by_name('Movies'))) :
+                                         ts('Movies'),
   search: (link_to ts('search feature'), search_works_path),
   search_faq: (link_to ts('Search and Browse FAQ'), 
                        archive_faqs_path + '/search-and-browse'),

--- a/app/views/home/first_login_help.html.erb
+++ b/app/views/home/first_login_help.html.erb
@@ -1,49 +1,238 @@
 <div class="userstuff">
-<!-- Note: anticipates that current_user is set -->
-<h2 class="heading">Welcome to the Archive of Our Own!</h2>
-<p>Here are some tips to help you get started.</p>
-<% if current_user %>
-  <%= form_tag end_first_login_user_path(current_user), :method => :post, :remote => true do %>
-    <p class="submit actions"><%= submit_tag ts("Dismiss this message permanently") %></p>
+  <h2 class="heading">
+    <%= ts('Welcome to the %{app_name}!', app_name: ArchiveConfig.APP_NAME) %>
+  </h2>
+
+  <p><%= ts('Here are some tips to help you get started.') %></p>
+  <% if current_user %>
+    <%= form_tag end_first_login_user_path(current_user), method: :post, remote: true do %>
+      <p class="submit actions">
+        <%= submit_tag ts('Dismiss this message permanently') %>
+      </p>
+    <% end %>
   <% end %>
-<% end %>
 
-<h3 class="landmark heading">Table Of Contents</h3>
-<ul id="toc" class="toc" role="navigation">
-  <li><a href="#logging_in">Logging In</a></li>
-  <li><a href="#pseuds">Pseuds</a></li>
-  <li><a href="#posting">Posting Works</a></li>
-  <li><a href="#bookmarking">Bookmarking Works</a></li>
-  <li><a href="#warnings">Warnings</a></li>
-  <li><a href="#tags">Tags</a></li>
-  <li><a href="#edit_profile">Editing Your Profile, Password, and Preferences</a></li>
-  <li><a href="#support">Support and Feedback</a></li>
-</ul>
+  <h3 class="landmark heading"><%= ts('Table of Contents') %></h3>
+  <ul id="toc" class="toc" role="directory">
+    <li><%= link_to ts('Logging In and Logging Out'), '#logging_in' %></li>
+    <li>
+      <%= link_to ts('Editing Your Profile, Password, and Preferences'),
+                  '#edit_profile' %>
+    </li>
+    <li><%= link_to ts('Pseuds'), '#pseuds' %></li>
+    <li><%= link_to ts('Posting Works'), '#posting' %></li>
+    <li><%= link_to ts('Browsing'), '#browsing' %></li>
+    <li><%= link_to ts('Tags'), '#tags' %></li>
+    <li><%= link_to ts('Warnings'), '#warnings' %></li>
+    <li><%= link_to ts('Bookmarking Works'), '#bookmarking' %></li>
+    <li><%= link_to ts('Preferences'), '#preferences' %></li>
+    <li>
+      <%= link_to ts('Additional Browsing Information'), '#additional' %>
+      <ul>
+        <li><%= link_to ts('History and Mark for Later'), '#history' %></li>
+        <li><%= link_to ts('Subscriptions'), '#subscriptions' %></li>
+      </ul>
+    </li>
+    <li><%= link_to ts('Terms of Service'), '#legal_stuff' %></li>
+    <li><%= link_to ts('Support and Feedback'), '#support' %></li>
+  </ul>
 
-<h3 id="logging_in">Logging In</h3>
-<p>To log in, locate and fill in the log in link (located at the top of the screen for those using a visual browser, and as indicated by your screenreader if you're using one). If you're on the <%= link_to "main page", root_path %>, then there'll be a log in area at the very top of the page; there's a log in link there everywhere else on the Archive as well. If you forget your password, then select <%= link_to "forgot your password", new_password_path %>.</p>
+  <h3 class="heading" id="logging_in">
+    <%= ts('Logging In and Logging Out') %>
+  </h3>
+  <p><%= ts('To log in, locate the login link and fill in your Username and 
+  Password. The link will be located at the top right of the screen and as 
+  indicated by your screenreader if you\'re using one. If you forget your 
+  password, then select "%{forgot_password}". To log out, select "Log Out" on 
+  the top right corner in the default browser skin.',
+  forgot_password: (link_to ts('forgot your password'), new_password_path)
+  ).html_safe %></p>
 
-<h3 id="pseuds">Pseuds</h3>
-<p>While you were making your profile all nice and pretty, you may have noticed our "pseuds" page. Pseuds are basically pen names. If you've written Buffyfic under the name "spikefan92", but you switched to calling yourself "Ariana" when you discovered <acronym title="Stargate: Atlantis">SGA</acronym>, you can use the pseuds function to post each fic under the appropriate name&#8212;but still manage them using the same account. You can <%= link_to "manage your pseuds", user_pseuds_path(current_user) %> through your profile page. </p>
+  <h3 class="heading" id="edit_profile">
+    <%= ts('Editing Your Profile, Password, and Preferences') %>
+  </h3>
+  <p><%= ts('To add your info, go to %{homepage}, select the 
+  "%{profile}" tab, and select "%{edit_profile}" from the range of 
+  options at the end of the page. Here, you can enter some basic personal 
+  information. It\'s also where to go to change your password. Refer to the 
+  %{profile_faq} for more information.',
+  homepage: (link_to ts('your home page'), user_path(current_user)),
+  profile: (link_to ts('Profile'), user_profile_path(current_user)),
+  edit_profile: (link_to ts('Edit My Profile'), edit_user_path(current_user)), 
+  profile_faq: (link_to ts('Profile FAQ'), archive_faqs_path + '/profile')
+  ).html_safe %></p>
 
-<h3 id="posting">Posting Works</h3>
-<p>To post a new work, just use the <%= link_to "Post New", new_work_path %> link conveniently located near the start of every page. You can either copy and paste in your work's <acronym title="Hyper Text Markup Language">HTML</acronym>, use our Rich Text editor, or upload your story from an existing <acronym title="Uniform Resource Location, web address">URL</acronym>. Right now, that last feature is confirmed to work for <acronym title="Live Journal">LJ</acronym>, but you may get erratic results from other places. (We'd love to hear about how well other places worked for you, or didn't&#8212;you can <%= link_to "send us feedback", new_feedback_report_path %>.)</p>
+  <h3 class="heading" id="pseuds">
+    <%= ts('Pseuds') %>
+  </h3>
+  <p><%= ts('Pseuds are like pen names linked to your account. You can use 
+  different pseuds to post your works under the appropriate name while still 
+  managing them through the same account. You can %{manage_pseuds} through 
+  your profile page. For more information, please visit the 
+  %{pseuds_faq}.',
+  manage_pseuds: (link_to ts('manage your pseuds'), 
+                          user_pseuds_path(current_user)),
+  pseuds_faq: (link_to ts('Pseuds FAQ'), archive_faqs_path + '/pseuds'),
+  ).html_safe %></p>
 
-<h3 id="warnings">Warnings</h3>
-<p>The archive defines four "primary" Archive-specific warnings: "Graphic Depictions Of Violence", "Major Character Death", "Rape/Non-Con", and "Underage". You also have the option of choosing not to warn, or of choosing not to use Archive warnings&#8212;for example, if you'd like to warn for violence but don't want to spoil a character death. If you'd like to warn for something not on the core warnings list, please feel free to use the story's tags! Remember, "No Archive Warnings Apply" does only refer to primary warnings.</p>
+  <h3 class="heading" id="posting">
+    <%= ts('Posting Works') %>
+  </h3>
+  <p><%= ts('To open the Post New Work page, just select the %{post} link 
+  from the menu of the Post tab located at the top right of the page in the 
+  default browser skin. Visit the %{posting_faq} or check out our 
+  %{post_tutorial} for more information.',
+  post: (link_to ts('Post New'), new_work_path),
+  posting_faq: (link_to ts('Posting and Editing FAQ'), 
+                        archive_faqs_path + '/posting-and-editing'),
+  post_tutorial: (link_to ts('Tutorial: Posting a Work on AO3'), 
+                          archive_faqs_path + '/tutorial-posting-a-work-on-ao3')
+  ).html_safe %></p>
 
-<h3 id="tags">Tags</h3>
-<p>All tags on the archive&#8212;including those for fandoms, relationships, and characters&#8212;start out user-created. Feel free to label your stories with whatever you want! Behind the scenes, our incredible tag wrangling team will hook the tags up with their synonyms, so that people can find your fic whether you call it "<acronym>AMTDI</acronym>", "Aliens Made Them Do It", or "sex pollen". Read this <%= link_to "admin post explaining tags", url_for(:controller => :admin_posts, :action => :show, :id => 11) %> to learn more.</p>
+  <h3 class="heading" id="browsing">
+    <%= ts('Browsing') %>
+  </h3>
+  <p><%= ts('You can start browsing works by going to the "%{fandoms}" tab at 
+  the top of any Archive page in the default skin and selecting either 
+  "%{all_fandoms}" or one of the subsets such as "%{movies}". Alternatively, you 
+  can use the %{search} to look for specific fandoms, works, or users. You can 
+  use the "Sort and Filter" form to narrow down the results in any fandom page. 
+  For more instructions, please visit %{search_faq} and the 
+  %{search_tutorial}.',
+  fandoms: (link_to ts('Fandoms'), menu_fandoms_path),
+  all_fandoms: (link_to ts('All Fandoms'), media_path),
+  movies: (link_to ts('Movies'), 
+                   medium_fandoms_path(Media.find_by_name('Movies'))),
+  search: (link_to ts('search feature'), search_works_path),
+  search_faq: (link_to ts('Search and Browse FAQ'), 
+                       archive_faqs_path + '/search-and-browse'),
+  search_tutorial: (link_to ts('Searching and browsing tutorial'), 
+                            admin_posts_path + '/259'),
+  ).html_safe %></p>
 
-<h3 id="bookmarking">Bookmarking Works</h3>
-<p>To bookmark a work, select the "bookmark this story" link at the start of its metadata while you're reading it. You can also bookmark stories not archived here by selecting "My Bookmarks" in your Dashboard.</p>
+  <h3 class="heading" id="tags">
+    <%= ts('Tags') %>
+  </h3>
+  <p><%= ts('All tags on the Archive—including those for fandoms, relationships, 
+  and characters—start out user-created. You can always use the existing tags by 
+  selecting from the autocomplete list. If you cannot find the tags you want to 
+  use, feel free to create new tags for your works. Behind the scenes, our tag 
+  wrangling team will match the tags up with their synonyms, so that people can 
+  find your work whether you tag it "<abbr>AMTDI</abbr>", "Aliens Made Them Do 
+  It", or "Sex Pollen". Refer to the %{tags_faq} to learn more.',
+  tags_faq: (link_to ts('Tags FAQ'), archive_faqs_path + '/tags')
+  ).html_safe %></p>
 
-<h3 id="edit_profile">Editing Your Profile, Password, and Preferences</h3>
-<p>To add your info, go to <%= link_to "your home page", user_path(current_user) %>, select the "<%= link_to "Profile", user_profile_path(current_user) %>" tab, and select "<%= link_to "Edit My Profile", edit_user_path(current_user) %>" from the range of options at the end of the page. Here, you can enter some basic personal information. It's also where to go to change your password.</p>
+  <h3 class="heading" id="warnings">
+    <%= ts('Warnings') %>
+  </h3>
+  <p><%= ts('The Archive defines four "primary" %{warnings_tos}: "Graphic 
+  Depictions Of Violence", "Major Character Death", "Rape/Non-Con", and 
+  "Underage". When posting a work, you have the option to explicitly select 
+  warnings for this content, deny the presence of such content ("No Archive 
+  Warnings Apply"), or choose not to apply warnings regardless of whether or not 
+  these warnings are applicable ("Creator Chose Not To Use Archive Warnings"). 
+  Remember, "No Archive Warnings Apply" only refers to the listed primary 
+  warnings.',
+  warnings_tos: (link_to ts('Archive-specific warnings'), tos_path + '#IV.K.3')
+  ).html_safe %></p>
+  <p><%= ts('When browsing the Archive, warnings will be displayed in the blurb 
+  of each work. Official warning tags are displayed in bold. A four square grid 
+  in the top left corner of each work\'s blurb indicates the work\'s rating, 
+  completion status, pairing category, and any Archive warnings that apply to 
+  it. Refer to the %{symbols_key} for more information.',
+  symbols_key: (link_to ts('Symbols Key Chart'), '/help/symbols-key.html')
+  ).html_safe %></p>
 
-<p>"<%= link_to 'Set My Preferences', user_preferences_path(current_user) %>" is located next to "Edit My Profile", and is pretty self-explanatory. The Preferences area controls both the Archive's behavior (such as whether your viewing history is saved) and the Archive's appearance. The Archive's appearance controls will get more and more sophisticated as we get closer and closer to <acronym title="Archive of Our Own">AO3</acronym>'s first full release; i.e. if you really hate the font(s) we use, you will be able to change them soon. You can also access your preferences from your Dashboard.</p>
+  <h3 class="heading" id="bookmarking">
+    <%= ts('Bookmarking Works') %>
+  </h3>
+  <p><%= ts('You can bookmark works on the Archive as well as works hosted on 
+  other sites. You can choose to make your bookmarks public or private. You can 
+  also mark a public bookmark as a rec (recommendation). Additionally, you can 
+  add notes and tags to the bookmark, and/or add it to a collection. For more 
+  instructions on managing your Bookmarks, please visit the %{bookmarks_faq}.',
+  bookmarks_faq: (link_to ts('Bookmarks FAQ'), archive_faqs_path + '/bookmarks') 
+  ).html_safe %></p>
 
-<h3 id="support">Support and Feedback</h3>
-<p>As you use the archive, never forget that we're still in beta and that we love, love, love feedback. Please send us some, at our <%= link_to "handy-dandy feedback page", new_feedback_report_path %>, as often as you like.</p>
-<p>If there's anything more you want to know, then please visit our <%= link_to "FAQ", archive_faqs_path %> or contact our <%= link_to "support team", new_feedback_report_path %>.</p>
+  <h3 class="heading" id="preferences">
+    <%= ts('Preferences') %></h3>
+  <p><%= ts('"%{set_preferences}" is located next to the "%{edit_profile}" 
+  button, and allows you to adjust certain settings to personalize your 
+  experience on the site. The Preferences area controls both the Archive\'s 
+  behavior (such as whether your history is saved) and the Archive\'s 
+  appearance. Go to the %{preferences_faq} for more details.',
+  set_preferences: (link_to ts('Set My Preferences'),     
+                            user_preferences_path(current_user)),
+  edit_profile: (link_to ts('Edit My Profile'), edit_user_path(current_user)),
+  preferences_faq: (link_to ts('Preferences FAQ'),
+                            archive_faqs_path + '/preferences') 
+  ).html_safe %></p>
+  <p><%= ts('For more information on how to customize the skins and interface of 
+  the Archive, refer to the %{skins_faq} and %{tutorial_list}.',
+  skins_faq: (link_to ts('Skins and Archive Interface FAQ'), 
+                      archive_faqs_path + '/skins-and-archive-interface'),
+  tutorial_list: (link_to ts('List of Tutorials'), 
+                          archive_faqs_path + '/tutorials')
+  ).html_safe %></p>
+
+  <h3 class="heading" id="additional">
+    <%= ts('Additional Browsing Information') %>
+  </h3>
+  <h4 class="heading" id="history">
+    <%= ts('History and Mark for Later') %></h4>
+  <p><%= ts('You can access and manage your history by going to %{dashboard} and 
+  selecting the "%{history}" link in the side menu in the default browser skin 
+  or on top of the page in mobile devices. You can clear your history, or delete 
+  individual entries if you don\'t want these entries to show up in your 
+  history. You can also add works to the "Marked for Later" list in your 
+  history. For more information on History, please visit %{history_faq}.',
+  dashboard: (link_to ts('your Dashboard'), user_path(current_user)),
+  history: (link_to ts('History'), user_readings_path(current_user)),
+  history_faq: (link_to ts('History and Mark for Later FAQ'), 
+                        archive_faqs_path + '/History-and-mark-for-later')
+  ).html_safe %></p>
+
+  <h4 class="heading" id="subscriptions">
+    <%= ts('Subscriptions') %>
+  </h4>
+  <p><%= ts('You can subscribe to a work, collection, series of works, or user 
+  by selecting the "Subscribe" link at the top or bottom of a work, or at the 
+  top or bottom of a collection or series page, or the user\'s profile page. You 
+  can check your subscriptions from %{dashboard} by selecting the 
+  "Subscriptions" link. For more information on Subscriptions, please visit 
+  %{subscription_faq}.',
+  dashboard: (link_to ts('your Dashboard'), user_path(current_user)),
+  subscription_faq: (link_to ts('Subscriptions and Feeds FAQ'), 
+                             archive_faqs_path + '/subscriptions-and-feeds')
+  ).html_safe %></p>
+
+  <h3 class="heading" id="legal_stuff">
+    <%= ts('Terms of Service') %>
+  </h3>
+  <p><%= ts('You can keep up to date with the policies and procedures for the 
+  site listed in the current %{tos}, and find explanations for some of the more 
+  common questions in the %{tos_faq}. If you still have questions about a 
+  specific work, please %{contact_abuse}. If you have general policy questions, 
+  you can either contact Abuse or %{contact_support}.',
+  tos: (link_to ts('Terms of Service'), tos_path),
+  tos_faq:(link_to ts('Terms of Service FAQ'), tos_faq_path),
+  contact_abuse: (link_to ts('contact Abuse'), new_abuse_report_path),
+  contact_support: (link_to ts('contact Support'), new_feedback_report_path)
+  ).html_safe %></p>
+
+  <h3 class="heading" id="support">
+    <%= ts('Support and Feedback') %>
+  </h3>
+  <p><%= ts('Some frequently asked questions about the Archive are answered in 
+  the broader %{faq}. You may also like to check out our %{known_issues}. If you 
+  need more help, please %{contact_support}. If you want to know more about some 
+  user-created tools that work with the Archive, please visit the 
+  %{tools_faq}.',
+  faq: (link_to ts('Archive FAQ'), archive_faqs_path),
+  known_issues: (link_to ts('Known Issues'), known_issues_path),
+  contact_support: (link_to ts('contact Support'), new_feedback_report_path),
+  tools_faq: (link_to ts('Unofficial Browser Tools FAQ'), 
+                      archive_faqs_path + '/unofficial-browser-tools')
+  ).html_safe %></p>
 </div>

--- a/features/other_a/banner_login.feature
+++ b/features/other_a/banner_login.feature
@@ -14,26 +14,6 @@ Feature: First login help banner
   When I follow "Learn some tips and tricks"
   Then I should see the first login popup
   
-  Scenario: Turn off first login help banner from the popup
-
-  Given I am logged in as "newname"
-  When I am on newname's user page
-  When I follow "Learn some tips and tricks"
-  When I press "Dismiss this message permanently"
-  Then I should not see the first login banner
-  
-  Scenario: Banner stays off after logout and login if turned off from popup
-  
-  Given I am logged in as "newname"
-  When I am on newname's user page
-  When I follow "Learn some tips and tricks"
-  When I press "Dismiss this message permanently"
-  When I am logged out
-    And I am logged in as "newname" with password "password"
-  Then I should not see the first login banner
-  When I am on newname's user page
-  Then I should not see the first login banner
-  
   Scenario: Turn off first login help banner directly
 
   Given I am logged in as "newname2"

--- a/features/step_definitions/banner_steps.rb
+++ b/features/step_definitions/banner_steps.rb
@@ -137,7 +137,7 @@ end
 
 Then /^I should see the first login popup$/ do
   step %{I should see "Here are some tips to help you get started."}
-    step %{I should see "To log in, locate and fill in the log in link"}
+    step %{I should see "To log in, locate the login link"}
 end
 
 Then /^I should see the banner with minor edits$/ do


### PR DESCRIPTION
https://otwarchive.atlassian.net/browse/AO3-4375

## Purpose

Updates the Tips & Tricks first login help banner to: https://docs.google.com/document/d/1qIIM4GUFJl7Su8h21oBgUMVR6tn0PbCZw7hLfOYWUtI

Also removes the dismiss button that was in the popup, 'cause that was weird and ugly and not worth making less ugly given it already exists on the banner.