### PR TITLE
AO3-4670 Extend test suite to cover admin activating users accounts

### DIFF
--- a/app/controllers/admin/admin_users_controller.rb
+++ b/app/controllers/admin/admin_users_controller.rb
@@ -185,14 +185,6 @@ class Admin::AdminUsersController < ApplicationController
     redirect_to(admin_users_path)
   end
 
-  # DELETE admin/users/1
-  # DELETE admin/users/1.xml
-  def destroy
-    @user = User.find_by_login(params[:id])
-    @user.destroy
-    redirect_to(admin_users_url)
-  end
-
   def notify
     if params[:letter] && params[:letter].is_a?(String)
       letter = params[:letter][0,1]

--- a/features/admins/admin_manage_users.feature
+++ b/features/admins/admin_manage_users.feature
@@ -306,7 +306,7 @@ Feature: Admin Actions to manage users
    When I go to the abuse administration page for "mrparis"
     And I press "Activate User Account"
    Then I should see "User Account Activated"
-    And the user "mrparis" is activated
+    And the user "mrparis" should be activated
 
   Scenario: A admin can send an activation email for a user account
   Given the following users exist

--- a/features/admins/admin_manage_users.feature
+++ b/features/admins/admin_manage_users.feature
@@ -299,5 +299,23 @@ Feature: Admin Actions to manage users
   Then I should see "Are you sure you want to delete"
   When I press "Yes, Delete All Spammer Creations"
   Then I should see "All creations by user Spamster have been deleted."
-  
-  
+
+  Scenario: A admin can activate a user account
+  Given the user "mrparis" exists and is not activated
+    And I am logged in as an admin
+   When I go to the abuse administration page for "mrparis"
+    And I press "Activate User Account"
+   Then I should see "User Account Activated"
+    And the user "mrparis" is activated
+
+  Scenario: A admin can send an activation email for a user account
+  Given the following users exist
+        | login        | password    | email                 | activation_code |
+        | torres       | something   | torres@starfleet.org  | fake_code       |
+    And I am logged in as an admin
+    And all emails have been delivered
+   When I go to the abuse administration page for "torres"
+    And I press "Send Activation Email"
+   Then I should see "Activation email sent"
+    And 1 email should be delivered to "torres"
+

--- a/features/step_definitions/user_steps.rb
+++ b/features/step_definitions/user_steps.rb
@@ -275,7 +275,7 @@ Then /^I should get confirmation that I changed my username$/ do
   step(%{I should see "Your user name has been successfully updated."})
 end
  
-Then /^the user "([^"]*)" is activated$/ do |login|
+Then /^the user "([^"]*)" should be activated$/ do |login|
   user = User.find_by_login(login)
   assert user.active?
 end

--- a/features/step_definitions/user_steps.rb
+++ b/features/step_definitions/user_steps.rb
@@ -36,6 +36,13 @@ Given /^the user "([^\"]*)" exists and is activated$/ do |login|
   end
 end
 
+Given /^the user "([^\"]*)" exists and is not activated$/ do |login|
+  user = User.find_by_login(login)
+  if user.blank?
+    user = FactoryGirl.create(:user, {:login => login, :password => "#{DEFAULT_PASSWORD}"})
+  end
+end
+
 Given /^I am logged in as "([^\"]*)" with password "([^\"]*)"$/ do |login, password|
   step("I am logged out")
   user = User.find_by_login(login)
@@ -268,3 +275,7 @@ Then /^I should get confirmation that I changed my username$/ do
   step(%{I should see "Your user name has been successfully updated."})
 end
  
+Then /^the user "([^"]*)" is activated$/ do |login|
+  user = User.find_by_login(login)
+  assert user.active?
+end


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [x] Have you added tests for any changed functionality?
* [x] Have you added the JIRA issue number as the *first* thing in your pull request title (eg: `AO3-1234 Fix thing`)
* [x] Have you updated the JIRA issue with the information below?

## Issue

https://otwarchive.atlassian.net/browse/AO3-4670

## Purpose

This extends the test suite and removes the controller action which allowed an admin to delete a users account which was not available in the user interface.

## Testing

Nothing to test