### PR TITLE
AO3-4678 Tests for destroying wrangling guidelines and assignments

### DIFF
--- a/features/step_definitions/tag_steps.rb
+++ b/features/step_definitions/tag_steps.rb
@@ -227,10 +227,15 @@ When /^I make a(?: (\d+)(?:st|nd|rd|th)?)? Wrangling Guideline$/ do |n|
   click_button("Post")
 end
 
-When /^(\d+) Wrangling Guidelines? exists?$/ do |n|	
+When /^(\d+) Wrangling Guidelines? exists?$/ do |n|
   (1..n.to_i).each do |i|
     FactoryGirl.create(:wrangling_guideline, id: i)
   end
+end
+
+When /^I uncheck the Tag Wrangler checkbox for "([^\"]*)"$/ do |username|
+  user_id = User.find_by_login(username).id
+  uncheck("user_roles_#{user_id}")
 end
 
 ### THEN
@@ -249,4 +254,23 @@ Then /^I should not see the tag search result "([^\"]*)"(?: within "([^"]*)")?$/
     with_scope(selector) do
       page.has_no_text?(result)
     end
+end
+
+Then /^"([^\"]*)" should not be a tag wrangler$/ do |username|
+  user = User.find_by_login(username)
+  user.tag_wrangler.should be_falsey
+end
+
+Then /^"([^\"]*)" should be assigned to the wrangler "([^\"]*)"$/ do |fandom, username|
+  user = User.find_by_login(username)
+  fandom = Fandom.find_by_name(fandom)
+  assignment = WranglingAssignment.find(:first, :conditions => { :user_id => user.id, :fandom_id => fandom.id })
+  assignment.should_not be_nil
+end
+
+Then /^"([^\"]*)" should not be assigned to the wrangler "([^\"]*)"$/ do |fandom, username|
+  user = User.find_by_login(username)
+  fandom = Fandom.find_by_name(fandom)
+  assignment = WranglingAssignment.find(:first, :conditions => { :user_id => user.id, :fandom_id => fandom.id })
+  assignment.should be_nil
 end

--- a/features/support/paths.rb
+++ b/features/support/paths.rb
@@ -197,6 +197,10 @@ module NavigationHelpers
       opendoors_tools_path
     when /^the languages page$/i
       languages_path
+    when /^the wranglers page$/i
+      tag_wranglers_path
+    when /^the unassigned fandoms page $/i
+      unassigned_fandoms_path
       
     # Here is an example that pulls values out of the Regexp:
     #

--- a/features/tags_and_wrangling/tag_wrangling_admin.feature
+++ b/features/tags_and_wrangling/tag_wrangling_admin.feature
@@ -15,3 +15,24 @@ Feature: Tag wrangling
     Then I should see "Tag was updated"
       And I should see "Amélie"
       And I should not see "Amelie"
+
+  Scenario: Admin can remove a user's wrangling privileges from the manage users page (this will leave assignments intact)
+
+    Given the tag wrangler "tangler" with password "wr@ngl3r" is wrangler of "Testing"
+    When I am logged in as an admin
+      And I am on the manage users page
+    When I fill in "Name or email" with "tangler"
+      And I press "Find"
+    Then I should see "tangler" within "#admin_users_table"
+    When I uncheck the Tag Wrangler checkbox for "tangler"
+      And I press "Update"
+    Then "tangler" should not be a tag wrangler
+      And "Testing" should be assigned to the wrangler "tangler"
+
+  Scenario: Admin can remove a user's wrangling assignments
+
+    Given the tag wrangler "tangler" with password "wr@ngl3r" is wrangler of "Testing"
+    When I am logged in as an admin
+      And I am on the wranglers page
+      And I follow "x"
+    Then "Testing" should not be assigned to the wrangler "tangler"

--- a/features/tags_and_wrangling/tag_wrangling_more.feature
+++ b/features/tags_and_wrangling/tag_wrangling_more.feature
@@ -81,3 +81,22 @@ Feature: Tag wrangling: assigning wranglers, using the filters on the Wranglers 
     Then "dizmo" should be selected within "wrangler_id"
       And I should see "Ghost Soup"
       And I should see "first fandom"
+
+  Scenario: Wrangler can remove self from a fandom
+
+    Given the tag wrangler "tangler" with password "wr@ngl3r" is wrangler of "Testing"
+      And I am logged in as "tangler" with password "wr@ngl3r"
+    When I am on the wranglers page
+      And I follow "x"
+    Then "Testing" should not be assigned to the wrangler "tangler"
+
+  Scenario: Wrangler can remove another wrangler from a fandom
+
+    Given the tag wrangler "tangler" with password "wr@ngl3r" is wrangler of "Testing"
+      And the following activated tag wrangler exists
+      | login          |
+      | wranglerette   |
+      And I am logged in as "wranglerette"
+    When I am on the wranglers page
+      And I follow "x"
+    Then "Testing" should not be assigned to the wrangler "tangler"

--- a/features/tags_and_wrangling/wrangling_guidelines.feature
+++ b/features/tags_and_wrangling/wrangling_guidelines.feature
@@ -41,3 +41,11 @@ Feature: Wrangling Guidelines
   Then I should see "1. The 2 Wrangling Guideline"
     And I should see "2. The 3 Wrangling Guideline"
     And I should see "3. The 1 Wrangling Guideline"
+
+  Scenario: Delete Wrangling Guideline
+  
+  Given I am logged in as an admin
+    And 1 Wrangling Guideline exists
+  When I go to the Wrangling Guidelines page
+    And I follow "Delete"
+  Then I should not see


### PR DESCRIPTION
https://otwarchive.atlassian.net/browse/AO3-4678

## Purpose

Automated tests for
* admin removing a wrangler's wrangling permission (which leaves their assignments intact)
* admin removing an assignment from a wrangler (tag_wraglers # destroy)
* tag wrangler removing their own assignment (tag_wranglers # destroy)
* tag wrangler removing another wrangler's assignment (tag_wranglers # destroy)
* admin deleting a wrangling guideline (wrangling_guidelines # destroy)

Some of these use JavaScript, so if they fail in Travis, I'll comment them out :| They do work locally.