### PR TITLE
AO3-4686 Sort potential matches by quality in autocomplete

### DIFF
--- a/app/controllers/autocomplete_controller.rb
+++ b/app/controllers/autocomplete_controller.rb
@@ -167,8 +167,8 @@ class AutocompleteController < ApplicationController
     signup_id = params[:signup_id] 
     signup = ChallengeSignup.find(signup_id)
     pmatches = return_requests ? 
-      signup.offer_potential_matches.map {|pm| pm.request_signup.pseud.byline} :
-      signup.request_potential_matches.map {|pm| pm.offer_signup.pseud.byline}
+      signup.offer_potential_matches.sort.reverse.map {|pm| pm.request_signup.pseud.byline} :
+      signup.request_potential_matches.sort.reverse.map {|pm| pm.offer_signup.pseud.byline}
     pmatches.select! {|pm| pm.match(/#{search_param}/)} if search_param.present?
     render_output(pmatches)
   end


### PR DESCRIPTION
# Pull Request Checklist
- [X ] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
- [x] Have you read through the [contributor guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
- [ ] Have you added tests for any changed functionality?
- [x] Have you added the JIRA issue number as the _first_ thing in your pull request title (eg: `AO3-1234 Fix thing`)
- [x] Have you updated the JIRA issue with the information below?
## Issue

https://otwarchive.atlassian.net/browse/AO3-4686
## Purpose

Changes autocomplete results for potential matches to be sorted by quality. 
## Testing

Go to potential matching page and go to either No Recipients or No Givers tab
Click in the empty text field and wait for the potential matches to pop up
Look at the signups of the first and last potential matches and compare to the person being matched

Match quality is ranked by:
number of prompts that match
highest number of tags that match among the prompts
So you should expect to see the first potential match (at least for someone with a lot of options) be a person who has two prompts that match, or at least more tags that match.
## Credit

astolat, she/her
