### PR TITLE
AO3-4688 Test gift exchange deletion

### DIFF
--- a/features/gift_exchanges/challenge_giftexchange.feature
+++ b/features/gift_exchanges/challenge_giftexchange.feature
@@ -277,24 +277,17 @@ Feature: Gift Exchange Challenge
       And the email should link to myname1's user url
       And the email html body should link to the works tagged "Stargate Atlantis"
 
-  Scenario: User signs up for two gift exchanges at once #'
-    Given I am logged in as "mod1"
-      And I have created the gift exchange "Awesome Gift Exchange"
-      And I open signups for "Awesome Gift Exchange"
-      And everyone has signed up for the gift exchange "Awesome Gift Exchange"
-      And I have generated matches for "Awesome Gift Exchange"
-      And I have sent assignments for "Awesome Gift Exchange"
-    Given I have created the gift exchange "Second Challenge" with name "testcoll2"
-      And I open signups for "Second Challenge"
-      And everyone has signed up for the gift exchange "Second Challenge"
-      And I have generated matches for "Second Challenge"
-      And I have sent assignments for "Second Challenge"
+  Scenario: User signs up for two gift exchanges at once and can use the Fulfill
+  link to fulfill one assignment at a time
+    Given everyone has their assignments for "Awesome Gift Exchange"
+      And everyone has their assignments for "Second Challenge"
     When I am logged in as "myname1"
       And I start to fulfill my assignment
-      # This is in fact a bug - only one of them should be checked
-      # TODO: Uncomment when the intermittent bug has been fixed
-    #Then the "Awesome Gift Exchange (myname3)" checkbox should be checked
-    #  And the "Second Challenge (myname3)" checkbox should be checked
+      And "AO3-4571" is fixed
+    # "I start to fulfill" will use the first Fulfill option on the page
+    # which will be for the oldest assignment
+    # Then the "Awesome Gift Exchange (myname3)" checkbox should be checked
+    #   And the "Second Challenge (myname3)" checkbox should not be checked
 
   Scenario: User has more than one pseud on signup form
     Given "myname1" has the pseud "othername"
@@ -319,11 +312,7 @@ Feature: Gift Exchange Challenge
 
   Scenario: Mod can see everyone's assignments, includind users' emails
     Given I am logged in as "mod1"
-      And I have created the gift exchange "Awesome Gift Exchange"
-      And I open signups for "Awesome Gift Exchange"
-      And everyone has signed up for the gift exchange "Awesome Gift Exchange"
-      And I have generated matches for "Awesome Gift Exchange"
-      And I have sent assignments for "Awesome Gift Exchange"
+      And everyone has their assignments for "Awesome Gift Exchange"
     When I go to the "Awesome Gift Exchange" assignments page
       Then I should see "Assignments for Awesome"
     When I follow "Open"
@@ -332,12 +321,7 @@ Feature: Gift Exchange Challenge
       And I should see the image "alt" text "email myname1"
 
   Scenario: User can see their assignment, but no email links
-    Given I am logged in as "mod1"
-      And I have created the gift exchange "Awesome Gift Exchange"
-      And I open signups for "Awesome Gift Exchange"
-      And everyone has signed up for the gift exchange "Awesome Gift Exchange"
-      And I have generated matches for "Awesome Gift Exchange"
-      And I have sent assignments for "Awesome Gift Exchange"
+    Given everyone has their assignments for "Awesome Gift Exchange"
     When I am logged in as "myname1"
       And I go to my user page
       And I follow "Assignments"
@@ -350,12 +334,7 @@ Feature: Gift Exchange Challenge
 
   Scenario: User fulfills their assignment and it shows on their assigments page as fulfilled
 
-    Given I am logged in as "mod1"
-      And I have created the gift exchange "Awesome Gift Exchange"
-      And I open signups for "Awesome Gift Exchange"
-      And everyone has signed up for the gift exchange "Awesome Gift Exchange"
-      And I have generated matches for "Awesome Gift Exchange"
-      And I have sent assignments for "Awesome Gift Exchange"
+    Given everyone has their assignments for "Awesome Gift Exchange"
     When I am logged in as "myname1"
       And I fulfill my assignment
     When I go to my user page

--- a/features/gift_exchanges/challenge_giftexchange.feature
+++ b/features/gift_exchanges/challenge_giftexchange.feature
@@ -498,3 +498,45 @@ Feature: Gift Exchange Challenge
         And the email should not contain "Rating:"
         And the email should not contain "Warnings:"
         And the email should not contain "Optional Tags:"
+
+  Scenario: A mod can delete a gift exchange and all the assignments and
+  sign-ups will be deleted with it, but the collection will remain
+    Given everyone has their assignments for "Bad Gift Exchange"
+      And I am logged in as "mod1"
+    When I delete the challenge "Bad Gift Exchange"
+    Then I should see "Challenge settings were deleted."
+      And I should not see the gift exchange dashboard for "Bad Gift Exchange"
+      And no one should have an assignment for "Bad Gift Exchange"
+      And no one should be signed up for "Bad Gift Exchange"
+    When I am on the collections page
+    Then I should see "Bad Gift Exchange"
+
+  Scenario: A user can still access their Sign-ups page after a gift exchange 
+  they were signed up for has been deleted
+    Given I am logged in as "mod1"
+      And I have created the gift exchange "Bad Gift Exchange"
+      And I open signups for "Bad Gift Exchange"
+      And everyone has signed up for the gift exchange "Bad Gift Exchange"
+      And the challenge "Bad Gift Exchange" is deleted
+    When I am logged in as "myname1"
+      And I go to my signups page
+    Then I should see "Challenge Sign-ups"
+      And I should not see "Bad Gift Exchange"
+
+  Scenario: A user can still access their Assignments page after a gift exchange
+  they had an unfulfilled assignment in has been deleted
+    Given everyone has their assignments for "Bad Gift Exchange"
+      And the challenge "Bad Gift Exchange" is deleted
+    When I am logged in as "myname1"
+      And I go to my assignments page
+    Then I should see "My Assignments"
+      And I should not see "Bad Gift Exchange"
+
+  Scenario: A user can still access their Assignments page after a gift exchange 
+  they had a fulfilled assignment in has been deleted
+    Given an assignment has been fulfilled in a gift exchange
+      And the challenge "Awesome Gift Exchange" is deleted
+    When I am logged in as "myname1"
+      And I go to my assignments page
+    Then I should see "My Assignments"
+      And I should not see "Awesome Gift Exchange"

--- a/features/step_definitions/challege_gift_exchange_steps.rb
+++ b/features/step_definitions/challege_gift_exchange_steps.rb
@@ -100,8 +100,8 @@ end
 
 Given /^the gift exchange "([^\"]*)" is ready for signups$/ do |title|
   step %{I am logged in as "mod1"}
-  step %{I have created the gift exchange "Awesome Gift Exchange"}
-  step %{I open signups for "Awesome Gift Exchange"}
+  step %{I have created the gift exchange "#{title}"}
+  step %{I open signups for "#{title}"}
 end
 
 ## Signing up
@@ -281,10 +281,7 @@ Given /^I have sent assignments for "([^\"]*)"$/ do |challengename|
 end
 
 Given /^everyone has their assignments for "([^\"]*)"$/ do |challenge_title|
-  step %{I am logged in as "mod1"}
-  step %{I have created the gift exchange "#{challenge_title}"}
-  step %{I open signups for "#{challenge_title}"}
-  step %{everyone has signed up for the gift exchange "#{challenge_title}"}
+  step %{the gift exchange "#{challenge_title}" is ready for matching}
   step %{I have generated matches for "#{challenge_title}"}
   step %{I have sent assignments for "#{challenge_title}"}
 end
@@ -310,12 +307,7 @@ When /^I fulfill my assignment$/ do
 end
 
 When /^an assignment has been fulfilled in a gift exchange$/ do
-  step %{I am logged in as "mod1"}
-  step %{I have created the gift exchange "Awesome Gift Exchange"}
-  step %{I open signups for "Awesome Gift Exchange"}
-  step %{everyone has signed up for the gift exchange "Awesome Gift Exchange"}
-  step %{I have generated matches for "Awesome Gift Exchange"}
-  step %{I have sent assignments for "Awesome Gift Exchange"}
+  step %{everyone has their assignments for "Awesome Gift Exchange"}
   step %{I am logged in as "myname1"}
   step %{I fulfill my assignment}
 end

--- a/features/step_definitions/challege_gift_exchange_steps.rb
+++ b/features/step_definitions/challege_gift_exchange_steps.rb
@@ -280,6 +280,15 @@ Given /^I have sent assignments for "([^\"]*)"$/ do |challengename|
   step %{I should not see "Assignments are now being sent out"}
 end
 
+Given /^everyone has their assignments for "([^\"]*)"$/ do |challenge_title|
+  step %{I am logged in as "mod1"}
+  step %{I have created the gift exchange "#{challenge_title}"}
+  step %{I open signups for "#{challenge_title}"}
+  step %{everyone has signed up for the gift exchange "#{challenge_title}"}
+  step %{I have generated matches for "#{challenge_title}"}
+  step %{I have sent assignments for "#{challenge_title}"}
+end
+
 ### Fulfilling assignments
 
 When /^I start to fulfill my assignment$/ do
@@ -332,4 +341,29 @@ When /^I have set up matching for "([^\"]*)" with no required matching$/ do |cha
   step %{I have created the gift exchange "Awesome Gift Exchange"}
   step %{I open signups for "Awesome Gift Exchange"}
   step %{everyone has signed up for the gift exchange "Awesome Gift Exchange"}
+end
+
+### Deleting a gift exchange
+
+Then /^I should not see the gift exchange dashboard for "([^\"]*)"$/ do |challenge_title|
+  collection = Collection.find_by_title(challenge_title)
+  visit collection_path(collection)
+  step %{I should not see "Gift Exchange" within "#dashboard"}
+  step %{I should not see "Sign-up Form" within "#dashboard"}
+  step %{I should not see "My Sign-up" within "#dashboard"}
+  step %{I should not see "Sign-ups" within "#dashboard"}
+  step %{I should not see "Challenge Settings" within "#dashboard"}
+  step %{I should not see "Sign-up Summary" within "#dashboard"}
+  step %{I should not see "Requests Summary" within "#dashboard"}
+  step %{I should not see "Matching" within "#dashboard"}
+  step %{I should not see "Assignments" within "#dashboard"}
+  step %{I should not see "Challenge Settings" within "#dashboard"}
+end
+
+Then /^no one should have an assignment for "([^\"]*)"$/ do |challenge_title|
+  collection = Collection.find_by_title(challenge_title)
+  User.all.each do |user|
+    user.offer_assignments.in_collection(collection).should be_empty
+    user.pinch_hit_assignments.in_collection(collection).should be_empty
+  end
 end

--- a/features/step_definitions/challenge_steps.rb
+++ b/features/step_definitions/challenge_steps.rb
@@ -241,3 +241,25 @@ Then /^the notification message to "([^\"]*)" should escape the ampersand$/ do |
   email.html_part.body.should =~ /The first thing &amp; the second thing./
   email.html_part.body.should_not =~ /The first thing & the second thing./
 end
+
+# Delete challenge
+
+Given /^the challenge "([^\"]*)" is deleted$/ do |challenge_title|
+  collection = Collection.find_by_title(challenge_title)
+  user_id = collection.all_owners.first.user_id
+  mod_login = User.find_by_id(user_id).login
+  step %{I am logged in as "#{mod_login}"}
+  step %{I delete the challenge "#{challenge_title}"}
+end
+
+When /^I delete the challenge "([^\"]*)"$/ do |challenge_title|
+  step %{I edit settings for "#{challenge_title}" challenge}
+  step %{I follow "Delete Challenge"}
+end
+
+Then /^no one should be signed up for "([^\"]*)"$/ do |challenge_title|
+  collection = Collection.find_by_title(challenge_title)
+  User.all.each do |user|
+    user.challenge_signups.in_collection(collection).should be_empty
+  end
+end

--- a/features/step_definitions/challenge_steps.rb
+++ b/features/step_definitions/challenge_steps.rb
@@ -246,10 +246,7 @@ end
 
 Given /^the challenge "([^\"]*)" is deleted$/ do |challenge_title|
   collection = Collection.find_by_title(challenge_title)
-  user_id = collection.all_owners.first.user_id
-  mod_login = User.find_by_id(user_id).login
-  step %{I am logged in as "#{mod_login}"}
-  step %{I delete the challenge "#{challenge_title}"}
+  collection.challenge.destroy
 end
 
 When /^I delete the challenge "([^\"]*)"$/ do |challenge_title|

--- a/features/support/paths.rb
+++ b/features/support/paths.rb
@@ -81,6 +81,8 @@ module NavigationHelpers
       user_invitations_path(User.current_user)
     when /my gifts page/
       user_gifts_path(User.current_user)
+    when /my assignments page/
+      user_assignments_path(User.current_user)
     when /^(.*)'s gifts page/
       user_gifts_path(user_id: $1)
     when /the import page/


### PR DESCRIPTION
https://otwarchive.atlassian.net/browse/AO3-4688

## Purpose

Tests that sign-ups and assignments are deleted when a gift exchange is deleted, and also ensures that the sign-up and assignment pages of exchange participants are still accessible after the exchange is deleted. 

These tests show https://otwarchive.atlassian.net/browse/AO3-3994 ("Deleting the gift exchange from a collection causes the Signups pages of participants to give Error 500") is fixed.

Commit 57fcbba contains the new tests; commit e381210 contains a bit of refactoring so we're not repeating ourselves so much when we just want to assume an exchange's assignments have been sent. Commit 86dc39a lets us delete a challenge without the going through the interface, since going to the settings page and clicking the button is already tested in its own scenario.

## Testing

No manual testing required.