### PR TITLE
AO3-4692 multiple external byline

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -82,19 +82,16 @@ module ApplicationHelper
       form.send( field_type, field_name, id: field_id )
   end
 
-  # modified by Enigel Dec 13 08 to use pseud byline rather than just pseud name
-  # in order to disambiguate in the case of identical pseuds
-  # and on Feb 24 09 to sort alphabetically for great justice
-  # and show only the authors when in preview_mode, unless they're empty
+  # Byline helpers
   def byline(creation, options={})
     if creation.respond_to?(:anonymous?) && creation.anonymous?
       anon_byline = ts("Anonymous")
-      if (logged_in_as_admin? || is_author_of?(creation)) && options[:visibility] != 'public'
-        anon_byline += " [".html_safe + non_anonymous_byline(creation, options[:only_path]) + "]".html_safe
+      if (logged_in_as_admin? || is_author_of?(creation)) && options[:visibility] != "public"
+        anon_byline += " [#{non_anonymous_byline(creation, options[:only_path])}]".html_safe
       end
       return anon_byline
     end
-    non_anonymous_byline(creation, (options[:full_path] ? false : options[:only_path]))
+    non_anonymous_byline(creation, options[:only_path])
   end
 
   def non_anonymous_byline(creation, url_path = nil)
@@ -122,12 +119,12 @@ module ApplicationHelper
         end
       end
 
-      pseuds.collect { |pseud|
+      pseuds.map { |pseud|
         pseud_byline = text_only ? pseud.byline : pseud_link(pseud, only_path)
         if archivists[pseud].empty?
           pseud_byline
         else
-          archivists[pseud].collect { |ext_author|
+          archivists[pseud].map { |ext_author|
             ts("%{ext_author} [archived by %{name}]", ext_author: ext_author, name: pseud_byline)
           }.join(', ')
         end
@@ -148,7 +145,7 @@ module ApplicationHelper
       end
       anon_byline
     else
-      byline_text(creation, only_path = false, text_only = true)
+      byline_text(creation, only_path: false, text_only: true)
     end
   end
 

--- a/features/importing/archivist.feature
+++ b/features/importing/archivist.feature
@@ -29,7 +29,18 @@ Feature: Archivist bulk imports
       And the email should contain invitation warnings from "archivist" for work "Importing Test" in fandom "Lewis"
 
   Scenario: Import a work for multiple authors without accounts
+    When I go to the import page
+      And I import the work "http://ao3testing.dreamwidth.org/593.html" by "name1" with email "a@ao3.org" and by "name2" with email "b@ao3.org"
+    And I should see "Story"
+    And I should see "name1 [archived by archivist]"
+    And I should see "name2 [archived by archivist]"
 
+  Scenario: Import a work for multiple authors without accounts should send emails to all authors
+    When I go to the import page
+      And I import the work "http://ao3testing.dreamwidth.org/593.html" by "name1" with email "a@ao3.org" and by "name2" with email "b@ao3.org"
+    When the system processes jobs
+    Then 1 email should be delivered to "a@ao3.org"
+    And 1 email should be delivered to "b@ao3.org"
 
   Scenario: Import multiple works as an archivist
     When I import the works "http://ao3testing.dreamwidth.org/593.html, http://ao3testing.dreamwidth.org/325.html"

--- a/features/importing/archivist.feature
+++ b/features/importing/archivist.feature
@@ -1,95 +1,70 @@
 Feature: Archivist bulk imports
 
+  Background:
+    Given I have an archivist "archivist"
+    And the default ratings exist
+    When I am logged in as "archivist"
+
   Scenario: Non-archivist cannot import for others
-  
-  Given I am logged in as a random user
-    And the default ratings exist
-  When I go to the import page
-  Then I should not see "Import for others ONLY with permission"
-  
+    Given I am logged in as a random user
+    When I go to the import page
+    Then I should not see "Import for others ONLY with permission"
+
   Scenario: Make a user an archivist
-  
-  Given I have pre-archivist setup for "archivist"
-    And the default ratings exist
-  When I am logged in as an admin
-    And I make "archivist" an archivist
-  Then I should see "User was successfully updated"
-    
+    Given I have pre-archivist setup for "not_archivist"
+      And I am logged in as an admin
+    When I make "not_archivist" an archivist
+    Then I should see "User was successfully updated"
+
   Scenario: Archivist can see link to import for others
-  
-  Given I have an archivist "archivist"
-    And the default ratings exist
-  When I am logged in as "archivist"
-    And I go to the import page
-  Then I should see "Import for others ONLY with permission"
+    When I go to the import page
+    Then I should see "Import for others ONLY with permission"
 
   Scenario: Importing for an author without an account should have the correct byline and email
-  
-  Given I have an archivist "archivist"
-    And the default ratings exist
-  When I am logged in as "archivist"
-    And I import the work "http://rebecca2525.livejournal.com/3562.html"
-  Then I should see "We have notified the author(s) you imported works for"
-    And I should see "Importing Test"
-    And I should see "rebecca2525 [archived by archivist]"
-  When the system processes jobs
-  Then 1 email should be delivered to "rebecca2525@livejournal.com"
-    And the email should contain invitation warnings from "archivist" for work "Importing Test" in fandom "Lewis"
-      
+    When I import the work "http://rebecca2525.livejournal.com/3562.html"
+    Then I should see "We have notified the author(s) you imported works for"
+      And I should see "rebecca2525 [archived by archivist]"
+    When the system processes jobs
+    Then 1 email should be delivered to "rebecca2525@livejournal.com"
+      And the email should contain invitation warnings from "archivist" for work "Importing Test" in fandom "Lewis"
+
+  Scenario: Import a work for multiple authors without accounts
+
+
   Scenario: Import multiple works as an archivist
-  
-  Given I have an archivist "archivist"
-    And the default ratings exist
-  When I am logged in as "archivist"
-    And I import the works "http://ao3testing.dreamwidth.org/593.html, http://ao3testing.dreamwidth.org/325.html"
-  Then I should see multi-story import messages
-    And I should see "Story"
-    And I should see "Test entry"
-    And I should see "We have notified the author(s) you imported works for. If any were missed, you can also add co-authors manually."
-   
+    When I import the works "http://ao3testing.dreamwidth.org/593.html, http://ao3testing.dreamwidth.org/325.html"
+    Then I should see multi-story import messages
+      And I should see "Story"
+      And I should see "Test entry"
+      And I should see "We have notified the author(s) you imported works for. If any were missed, you can also add co-authors manually."
+
   Scenario: Importing only sends one email even if there are many works
-  
-    Given I have an archivist "archivist"
-      And the default ratings exist
-    When I am logged in as "archivist"
-      And I import the works "http://ao3testing.dreamwidth.org/593.html, http://ao3testing.dreamwidth.org/325.html"
+    When I import the works "http://ao3testing.dreamwidth.org/593.html, http://ao3testing.dreamwidth.org/325.html"
       And the system processes jobs
     Then 1 email should be delivered to "ao3testing@dreamwidth.org"
 
   Scenario: Importing for an existing Archive author should have correct byline and email
-
-  Given the following activated user exists
-    | login | email                     |
-    | ao3   | ao3testing@dreamwidth.org |
-    And I have an archivist "archivist"
-    And the default ratings exist
-  When I am logged in as "archivist"
-    And I import the work "http://ao3testing.dreamwidth.org/593.html"
-  Then I should see import confirmation
-    And I should see "ao3"
-    And I should not see "[archived by archivist]"
-    And 1 email should be delivered to "ao3testing@dreamwidth.org"
-    And the email should contain claim information
+    Given the following activated user exists
+      | login | email                     |
+      | ao3   | ao3testing@dreamwidth.org |
+    When I import the work "http://ao3testing.dreamwidth.org/593.html"
+    Then I should see import confirmation
+      And I should see "ao3"
+      And I should not see "[archived by archivist]"
+      And 1 email should be delivered to "ao3testing@dreamwidth.org"
+      And the email should contain claim information
 
   Scenario: Importing sends an email to a guessed address if it can't find the author
-
-  Given I have an archivist "archivist"
-    And the default ratings exist
-  When I am logged in as "archivist"
-    And I import the work "http://ao3testing.dreamwidth.org/593.html"
-  Then I should see import confirmation
-    And I should see "Story"
-  When the system processes jobs
+    When I import the work "http://ao3testing.dreamwidth.org/593.html"
+    Then I should see import confirmation
+      And I should see "Story"
+    When the system processes jobs
   # Importer assumes dreamwidth email for works from there
-  Then 1 email should be delivered to "ao3testing@dreamwidth.org"
-    And the email should contain invitation warnings from "archivist" for work "Story" in fandom "Testing"
+    Then 1 email should be delivered to "ao3testing@dreamwidth.org"
+      And the email should contain invitation warnings from "archivist" for work "Story" in fandom "Testing"
 
-  Scenario: Import a single work as an archivist specifying as external author
-
-    Given I have an archivist "archivist"
-      And the default ratings exist
-    When I am logged in as "archivist"
-      And I go to the import page
+  Scenario: Import a single work as an archivist specifying an external author
+    When I go to the import page
       And I import the work "http://ao3testing.dreamwidth.org/593.html" by "randomtestname" with email "random@example.com"
     Then I should not see multi-story import messages
       And I should see "Story"
@@ -99,129 +74,96 @@ Feature: Archivist bulk imports
     Then 1 email should be delivered to "random@example.com"
 
   Scenario: Import a single work as an archivist specifying an external author with an invalid name
-
-    Given I have an archivist "archivist"
-      And the default ratings exist
-    When I am logged in as "archivist"
-      And I go to the import page
-      And I import the work "http://ao3testing.dreamwidth.org/593.html" by "ra_ndo!m-t??est n@me." with email "random@example.com"
+    When I import the work "http://ao3testing.dreamwidth.org/593.html" by "ra_ndo!m-t??est n@me." with email "random@example.com"
     Then I should see import confirmation
-      And I should see "ra_ndom-test n@me."
+    And I should see "ra_ndom-test n@me."
     When the system processes jobs
-      Then 1 email should be delivered to "random@example.com"
+    Then 1 email should be delivered to "random@example.com"
 
   Scenario: Claim a work and create a new account in response to an invite
-
-    Given I have an archivist "archivist"
-      And the default ratings exist
-      And account creation is enabled
-    When I am logged in as "archivist"
-      And I go to the import page
-      And I import the work "http://ao3testing.dreamwidth.org/593.html" by "randomtestname" with email "random@example.com"
+    Given account creation is enabled
+    When I import the work "http://ao3testing.dreamwidth.org/593.html" by "randomtestname" with email "random@example.com"
       And the system processes jobs
     Then 1 email should be delivered to "random@example.com"
       And the email should contain "Claim or remove your works"
     When I am logged out
       And I follow "Claim or remove your works" in the email
     Then I should see "Claiming Your Imported Works"
-      And I should see "An archive including some of your work(s) has been moved to the Archive of Our Own."
+    And I should see "An archive including some of your work(s) has been moved to the Archive of Our Own."
     When I press "Sign me up and give me my works! Yay!"
     Then I should see "Create Account"
     When I fill in the sign up form with valid data
-      And I press "Create Account"
+    And I press "Create Account"
     Then I should see "Account Created!"
 
   Scenario: Orphan a work in response to an invite, leaving name on it
-
-    Given I have an archivist "archivist"
-      And the default ratings exist
-      And I have an orphan account
-    When I am logged in as "archivist"
-      And I go to the import page
-      And I import the work "http://ao3testing.dreamwidth.org/593.html" by "randomtestname" with email "random@example.com"
+    Given I have an orphan account
+    When I import the work "http://ao3testing.dreamwidth.org/593.html" by "randomtestname" with email "random@example.com"
       And the system processes jobs
     Then 1 email should be delivered to "random@example.com"
       And the email should contain "Claim or remove your works"
     When I am logged out
       And I follow "Claim or remove your works" in the email
     Then I should see "Claiming Your Imported Works"
-      And I should see "An archive including some of your work(s) has been moved to the Archive of Our Own."
+    And I should see "An archive including some of your work(s) has been moved to the Archive of Our Own."
     When I choose "imported_stories_orphan"
-      And I press "Update"
+    And I press "Update"
     Then I should see "Your imported stories have been orphaned. Thank you for leaving them in the archive! Your preferences have been saved."
     When I am logged in
-      And I view the work "Story"
+    And I view the work "Story"
     Then I should see "randomtestname"
-      And I should see "orphan_account"
+    And I should see "orphan_account"
 
   Scenario: Orphan a work in response to an invite, taking name off it
-
-    Given I have an archivist "archivist"
-      And the default ratings exist
-      And I have an orphan account
-    When I am logged in as "archivist"
-      And I go to the import page
-      And I import the work "http://ao3testing.dreamwidth.org/593.html" by "randomtestname" with email "random@example.com"
-      And the system processes jobs
+    Given I have an orphan account
+    When I import the work "http://ao3testing.dreamwidth.org/593.html" by "randomtestname" with email "random@example.com"
+    And the system processes jobs
     Then 1 email should be delivered to "random@example.com"
-      And the email should contain "Claim or remove your works"
+    And the email should contain "Claim or remove your works"
     When I am logged out
-      And I follow "Claim or remove your works" in the email
+    And I follow "Claim or remove your works" in the email
     Then I should see "Claiming Your Imported Works"
-      And I should see "An archive including some of your work(s) has been moved to the Archive of Our Own."
+    And I should see "An archive including some of your work(s) has been moved to the Archive of Our Own."
     When I choose "imported_stories_orphan"
-      And I check "remove_pseud"
-      And I press "Update"
+    And I check "remove_pseud"
+    And I press "Update"
     Then I should see "Your imported stories have been orphaned. Thank you for leaving them in the archive! Your preferences have been saved."
     When I am logged in
-      And I view the work "Story"
+    And I view the work "Story"
     Then I should not see "randomtestname"
-      And I should see "orphan_account"
+    And I should see "orphan_account"
 
   Scenario: Refuse all further contact
-
-    Given I have an archivist "archivist"
-      And the default ratings exist
-    When I am logged in as "archivist"
-      And I go to the import page
-      And I import the work "http://ao3testing.dreamwidth.org/593.html" by "randomtestname" with email "random@example.com"
-      And the system processes jobs
+    When I import the work "http://ao3testing.dreamwidth.org/593.html" by "randomtestname" with email "random@example.com"
+    And the system processes jobs
     Then 1 email should be delivered to "random@example.com"
-      And the email should contain "Claim or remove your works"
+    And the email should contain "Claim or remove your works"
     When I am logged out
-      And I follow "Claim or remove your works" in the email
+    And I follow "Claim or remove your works" in the email
     Then I should see "Claiming Your Imported Works"
-      And I should see "An archive including some of your work(s) has been moved to the Archive of Our Own. Please let us know what you'd like us to do with them."
+    And I should see "An archive including some of your work(s) has been moved to the Archive of Our Own. Please let us know what you'd like us to do with them."
     When I choose "imported_stories_delete"
-      And I check "external_author_do_not_email"
-      And I press "Update"
+    And I check "external_author_do_not_email"
+    And I press "Update"
     Then I should see "Your imported stories have been deleted. Your preferences have been saved."
 
   Scenario: Importing straight into a collection
-
-    Given I have an archivist "archivist"
-      And the default ratings exist
-      And I have a collection "Club"
-    When I am logged in as "archivist"
-      And I go to the import page
-      And I start to import the work "http://ao3testing.dreamwidth.org/593.html" by "randomtestname" with email "random@example.com"
+    Given I have a collection "Club"
+      And I am logged in as "archivist"
+    When I start to import the work "http://ao3testing.dreamwidth.org/593.html" by "randomtestname" with email "random@example.com"
       And I press "Import"
     Then I should see "We have notified the author(s) you imported works for. If any were missed, you can also add co-authors manually."
     When I press "Edit"
-      And I fill in "work_collection_names" with "Club"
-      And I press "Post Without Preview"
+    And I fill in "work_collection_names" with "Club"
+    And I press "Post Without Preview"
     Then I should see "Story"
-      And I should see "randomtestname"
-      And I should see "Club"
+    And I should see "randomtestname"
+    And I should see "Club"
     When the system processes jobs
     Then 1 email should be delivered to "random@example.com"
 
   Scenario: Should not be able to import for others unless the box is checked
-  
-    Given I have an archivist "archivist"
-      And the default ratings exist
-    When I am logged in as "archivist"
-      And I go to the import page
+    When I go to the import page
       And I fill in "URLs*" with "http://ao3testing.dreamwidth.org/593.html"
       And I fill in "Author Name*" with "ao3testing"
       And I fill in "Author Email Address*" with "ao3testing@example.com"
@@ -231,13 +173,12 @@ Feature: Archivist bulk imports
     And I press "Import"
     Then I should see "We have notified the author(s) you imported works for. If any were missed, you can also add co-authors manually."
 
-  Scenario: Archivist can't see Open Doors tools, OD committee can
+  Scenario: Archivist can't see Open Doors tools
+    When I go to the Open Doors tools page
+    Then I should see "Sorry, you don't have permission to access the page you were trying to reach."
 
-  Given I have an archivist "archivist"
-    And I have an Open Doors committee member "OpenDoors"
-  When I am logged in as "archivist"
-    And I go to the Open Doors tools page
-  Then I should see "Sorry, you don't have permission to access the page you were trying to reach."
-  When I am logged in as "OpenDoors"
-    And I go to the Open Doors tools page
-  Then I should see "Update Redirect URL"
+  Scenario: Open Doors committee members can see their tools
+    Given I have an Open Doors committee member "OpenDoors"
+      And I am logged in as "OpenDoors"
+    When I go to the Open Doors tools page
+    Then I should see "Update Redirect URL"

--- a/features/step_definitions/archivist_steps.rb
+++ b/features/step_definitions/archivist_steps.rb
@@ -1,15 +1,15 @@
 ### GIVEN
 
 Given /^I have an archivist "([^\"]*)"$/ do |name|
-  step(%{I have pre-archivist setup for "#{name}"})
-  step(%{I am logged in as an admin})
-    step(%{I make "#{name}" an archivist})
-    step(%{I log out})
+  user = find_or_create_user(name, "password")
+  role = Role.find_or_create_by_name("archivist")
+  user.roles = [role]
+  user.save
 end
 
 Given /^I have pre-archivist setup for "([^\"]*)"$/ do |name|
   step(%{I am logged in as "#{name}"})
-    step(%{I have loaded the "roles" fixture})
+  step(%{I have loaded the "roles" fixture})
 end
 
 Given /^I have an Open Doors committee member "([^\"]*)"$/ do |name|

--- a/features/step_definitions/archivist_steps.rb
+++ b/features/step_definitions/archivist_steps.rb
@@ -44,13 +44,18 @@ When /^I start to import the work "([^\"]*)"(?: by "([^\"]*)" with email "([^\"]
   end
 end
 
-When /^I import the work "([^\"]*)"(?: by "([^\"]*)" with email "([^\"]*)")?$/ do |url, external_author_name, external_author_email|
+When /^I import the work "([^\"]*)"(?: by "([^\"]*)" with email "([^\"]*)")(?: and by "([^\"]*)" with email "([^\"]*)")$/ do
+      |url, creator_name, creator_email, cocreator_name, cocreator_email|
   step(%{I go to the import page})
   step(%{I check "Import for others ONLY with permission"})
   step(%{I fill in "urls" with "#{url}"})
-  if external_author_name.present?
-    step(%{I fill in "external_author_name" with "#{external_author_name}"})
-    step(%{I fill in "external_author_email" with "#{external_author_email}"})
+  if creator_name.present?
+    step(%{I fill in "external_author_name" with "#{creator_name}"})
+    step(%{I fill in "external_author_email" with "#{creator_email}"})
+  end
+  if cocreator_name.present?
+    step(%{I fill in "external_coauthor_name" with "#{cocreator_name}"})
+    step(%{I fill in "external_coauthor_email" with "#{cocreator_email}"})
   end
   step(%{I check "Post without previewing"})
   step(%{I press "Import"})

--- a/features/step_definitions/archivist_steps.rb
+++ b/features/step_definitions/archivist_steps.rb
@@ -1,7 +1,7 @@
 ### GIVEN
 
 Given /^I have an archivist "([^\"]*)"$/ do |name|
-  user = find_or_create_user(name, "password")
+  user = find_or_create_new_user(name, "password")
   role = Role.find_or_create_by_name("archivist")
   user.roles = [role]
   user.save

--- a/features/step_definitions/archivist_steps.rb
+++ b/features/step_definitions/archivist_steps.rb
@@ -44,7 +44,7 @@ When /^I start to import the work "([^\"]*)"(?: by "([^\"]*)" with email "([^\"]
   end
 end
 
-When /^I import the work "([^\"]*)"(?: by "([^\"]*)" with email "([^\"]*)")(?: and by "([^\"]*)" with email "([^\"]*)")$/ do
+When /^I import the work "([^\"]*)"(?: by "([^\"]*)" with email "([^\"]*)")?(?: and by "([^\"]*)" with email "([^\"]*)")?$/ do
       |url, creator_name, creator_email, cocreator_name, cocreator_email|
   step(%{I go to the import page})
   step(%{I check "Import for others ONLY with permission"})

--- a/features/step_definitions/user_steps.rb
+++ b/features/step_definitions/user_steps.rb
@@ -45,7 +45,12 @@ end
 
 Given /^I am logged in as "([^\"]*)" with password "([^\"]*)"(?:( with preferences set to hidden warnings and additional tags))?$/ do |login, password, hidden|
   step("I am logged out")
-  find_or_create_user(login, password, hidden)
+  user = find_or_create_new_user(login, password)
+  if hidden.present?
+    user.preference.hide_warnings = true
+    user.preference.hide_freeform = true
+    user.preference.save
+  end
   visit login_path
   fill_in "User name", :with => login
   fill_in "Password", :with => password

--- a/features/step_definitions/user_steps.rb
+++ b/features/step_definitions/user_steps.rb
@@ -45,20 +45,7 @@ end
 
 Given /^I am logged in as "([^\"]*)" with password "([^\"]*)"(?:( with preferences set to hidden warnings and additional tags))?$/ do |login, password, hidden|
   step("I am logged out")
-  user = User.find_by_login(login)
-  if user.blank?
-    user = FactoryGirl.create(:user, {:login => login, :password => password})
-    user.activate
-  else
-    user.password = password
-    user.password_confirmation = password
-    user.save
-  end
-  if hidden.present?
-    user.preference.hide_warnings = true
-    user.preference.hide_freeform = true
-    user.preference.save
-  end
+  find_or_create_user(login, password, hidden)
   visit login_path
   fill_in "User name", :with => login
   fill_in "Password", :with => password
@@ -155,10 +142,10 @@ end
 
 # WHEN
 
-When /^I follow the link for "([^\"]*)" first invite$/ do |login|		
-  user = User.find_by_login(login)		
-  invite = user.invitations.first		
-  step(%{I follow "#{invite.token}"})		
+When /^I follow the link for "([^\"]*)" first invite$/ do |login|
+  user = User.find_by_login(login)
+  invite = user.invitations.first
+  step(%{I follow "#{invite.token}"})
 end
 
 When /^"([^\"]*)" creates the default pseud "([^\"]*)"$/ do |username, newpseud|

--- a/features/step_definitions/user_steps.rb
+++ b/features/step_definitions/user_steps.rb
@@ -33,7 +33,7 @@ Given /^the user "([^\"]*)" exists and is activated$/ do |login|
 end
 
 Given /^the user "([^\"]*)" exists and is not activated$/ do |login|
-  find_or_create_new_user(login, DEFAULT_PASSWORD, activated: false)
+  find_or_create_new_user(login, DEFAULT_PASSWORD, activate: false)
 end
 
 Given /^I am logged in as "([^\"]*)" with password "([^\"]*)"(?:( with preferences set to hidden warnings and additional tags))?$/ do |login, password, hidden|

--- a/features/step_definitions/user_steps.rb
+++ b/features/step_definitions/user_steps.rb
@@ -9,7 +9,7 @@ Given /^I have no users$/ do
 end
 
 Given /I have an orphan account/ do
-  user = FactoryGirl.create(:user, :login => 'orphan_account')
+  user = FactoryGirl.create(:user, login: 'orphan_account')
   user.activate
 end
 
@@ -33,7 +33,7 @@ Given /^the user "([^\"]*)" exists and is activated$/ do |login|
 end
 
 Given /^the user "([^\"]*)" exists and is not activated$/ do |login|
-  find_or_create_new_user(login, DEFAULT_PASSWORD, activated = false)
+  find_or_create_new_user(login, DEFAULT_PASSWORD, activated: false)
 end
 
 Given /^I am logged in as "([^\"]*)" with password "([^\"]*)"(?:( with preferences set to hidden warnings and additional tags))?$/ do |login, password, hidden|
@@ -52,7 +52,7 @@ Given /^I am logged in as "([^\"]*)" with password "([^\"]*)"(?:( with preferenc
   assert UserSession.find unless @javascript
 end
 
-Given /^I am logged in as "([^\"]*)"$/ do |login|
+Given /^I am logged in as "([^"]*)"$/ do |login|
   step(%{I am logged in as "#{login}" with password "#{DEFAULT_PASSWORD}"})
 end
 
@@ -70,7 +70,7 @@ Given /^I am logged in as a banned user$/ do
   step(%{I am logged in as "banned"})
 end
 
-Given /^user "([^\"]*)" is banned$/ do |login|
+Given /^user "([^"]*)" is banned$/ do |login|
   user = find_or_create_new_user(login, DEFAULT_PASSWORD)
   user.banned = true
   user.save
@@ -87,13 +87,13 @@ Given /^I log out$/ do
   step(%{I follow "Log Out"})
 end
 
-Given /^"([^\"]*)" has the pseud "([^\"]*)"$/ do |username, pseud|
+Given /^"([^"]*)" has the pseud "([^"]*)"$/ do |username, pseud|
   step (%{I am logged in as "#{username}"})
   step(%{"#{username}" creates the pseud "#{pseud}"})
   step("I am logged out")
 end
 
-Given /^"([^\"]*)" deletes their account/ do |username|
+Given /^"([^"]*)" deletes their account/ do |username|
   visit user_path(username)
   step(%{I follow "Profile"})
   step(%{I follow "Delete My Account"})
@@ -109,40 +109,40 @@ Given /^I view the people page$/ do
 end
 
 Given(/^I have coauthored a work as "(.*?)" with "(.*?)"$/) do |login, coauthor|
-  author1 = FactoryGirl.create(:pseud, :user => User.find_by_login(login))
-  author2 = FactoryGirl.create(:pseud, :user => User.find_by_login(coauthor))
+  author1 = FactoryGirl.create(:pseud, user: User.find_by_login(login))
+  author2 = FactoryGirl.create(:pseud, user: User.find_by_login(coauthor))
   FactoryGirl.create(:work, authors: [author1, author2], posted: true, title: "Shared")
 end
 
 # WHEN
 
-When /^I follow the link for "([^\"]*)" first invite$/ do |login|
+When /^I follow the link for "([^"]*)" first invite$/ do |login|
   user = User.find_by_login(login)
   invite = user.invitations.first
   step(%{I follow "#{invite.token}"})
 end
 
-When /^"([^\"]*)" creates the default pseud "([^\"]*)"$/ do |username, newpseud|
+When /^"([^\"]*)" creates the default pseud "([^"]*)"$/ do |username, newpseud|
   visit new_user_pseud_path(username)
-  fill_in "Name", :with => newpseud
+  fill_in "Name", with: newpseud
   check("pseud_is_default")
   click_button "Create"
 end
 
 When /^I fill in "([^\"]*)"'s temporary password$/ do |login|
   user = User.find_by_login(login)
-  fill_in "Password", :with => user.activation_code
+  fill_in "Password", with: user.activation_code
 end
 
-When /^"([^\"]*)" creates the pseud "([^\"]*)"$/ do |username, newpseud|
+When /^"([^\"]*)" creates the pseud "([^"]*)"$/ do |username, newpseud|
   visit new_user_pseud_path(username)
-  fill_in "Name", :with => newpseud
+  fill_in "Name", with: newpseud
   click_button "Create"
 end
 
-When /^I create the pseud "([^\"]*)"$/ do |newpseud|
+When /^I create the pseud "([^"]*)"$/ do |newpseud|
   visit new_user_pseud_path(User.current_user)
-  fill_in "Name", :with => newpseud
+  fill_in "Name", with: newpseud
   click_button "Create"
 end
 
@@ -225,17 +225,17 @@ def get_series_name(age, classname, name)
   end
 end
   
-Then /^I should see the (most recent|oldest) (work|series) for (pseud|user) "([^\"]*)"/ do |age, type, classname, name|
+Then /^I should see the (most recent|oldest) (work|series) for (pseud|user) "([^"]*)"/ do |age, type, classname, name|
   title = (type == "work" ? get_work_name(age, classname, name) : get_series_name(age, classname, name))
   step %{I should see "#{title}"}
 end
 
-Then /^I should not see the (most recent|oldest) (work|series) for (pseud|user) "([^\"]*)"/ do |age, type, classname, name|
+Then /^I should not see the (most recent|oldest) (work|series) for (pseud|user) "([^"]*)"/ do |age, type, classname, name|
   title = (type == "work" ? get_work_name(age, classname, name) : get_series_name(age, classname, name))
   step %{I should not see "#{title}"}
 end
 
-When /^I change my username to "([^\"]*)"/ do |new_name|
+When /^I change my username to "([^"]*)"/ do |new_name|
   visit change_username_user_path(User.current_user)
   fill_in("New user name", with: new_name)
   fill_in("Password", with: "password")

--- a/features/support/user.rb
+++ b/features/support/user.rb
@@ -1,5 +1,5 @@
 module UserHelpers
-  def find_or_create_new_user(login, password, activate = true)
+  def find_or_create_new_user(login, password, activate: true)
     user = User.find_by_login(login)
     if user.blank?
       user = FactoryGirl.create(:user, login: login, password: password)

--- a/features/support/user.rb
+++ b/features/support/user.rb
@@ -1,5 +1,5 @@
 module UserHelpers
-  def find_or_create_user(login, password)
+  def find_or_create_user(login, password, hidden)
     user = User.find_by_login(login)
     if user.blank?
       user = FactoryGirl.create(:user, { login: login, password: password })
@@ -8,6 +8,11 @@ module UserHelpers
       user.password = password
       user.password_confirmation = password
       user.save
+    end
+    if hidden.present?
+      user.preference.hide_warnings = true
+      user.preference.hide_freeform = true
+      user.preference.save
     end
     user
   end

--- a/features/support/user.rb
+++ b/features/support/user.rb
@@ -1,9 +1,9 @@
 module UserHelpers
-  def find_or_create_new_user(login, password)
+  def find_or_create_new_user(login, password, activate = true)
     user = User.find_by_login(login)
     if user.blank?
-      user = FactoryGirl.create(:user, { login: login, password: password })
-      user.activate
+      user = FactoryGirl.create(:user, login: login, password: password)
+      user.activate if activate
     else
       user.password = password
       user.password_confirmation = password

--- a/features/support/user.rb
+++ b/features/support/user.rb
@@ -1,5 +1,5 @@
 module UserHelpers
-  def find_or_create_user(login, password, hidden)
+  def find_or_create_new_user(login, password)
     user = User.find_by_login(login)
     if user.blank?
       user = FactoryGirl.create(:user, { login: login, password: password })
@@ -8,11 +8,6 @@ module UserHelpers
       user.password = password
       user.password_confirmation = password
       user.save
-    end
-    if hidden.present?
-      user.preference.hide_warnings = true
-      user.preference.hide_freeform = true
-      user.preference.save
     end
     user
   end

--- a/features/support/user.rb
+++ b/features/support/user.rb
@@ -1,0 +1,16 @@
+module UserHelpers
+  def find_or_create_user(login, password)
+    user = User.find_by_login(login)
+    if user.blank?
+      user = FactoryGirl.create(:user, { login: login, password: password })
+      user.activate
+    else
+      user.password = password
+      user.password_confirmation = password
+      user.save
+    end
+    user
+  end
+end
+
+World(UserHelpers)


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-4692
## Purpose

Fixes a bug which caused only one external author created by an archivist to be displayed on imported works.
## Testing

This also removes duplication in the byline code.
- check that existing stories have the same byline they normally have (including Anonymous)
- check that importing a work as an archivist with an author and co-author who do not have accounts on the Archive displays both authors in the format `name1 [archived by archivist], name2 [archived by archivist]`
