### PR TITLE
AO3-4474 italicised/justified text being clipped

### DIFF
--- a/public/stylesheets/site/2.0/21-userstuff.css
+++ b/public/stylesheets/site/2.0/21-userstuff.css
@@ -146,6 +146,7 @@
 #workskin {
   font-size: 1.08em;
   margin: auto;
+  padding: 0 0.25em;
   max-width: 72em;
   overflow-x: auto;
   overflow-y: hidden;

--- a/public/stylesheets/site/2.0/22-system-messages.css
+++ b/public/stylesheets/site/2.0/22-system-messages.css
@@ -18,10 +18,6 @@ System messages use the following colours:
   float: right;
 }
 
-p.message.footnote {
-  clear: both;
-}
-
 .datetime {
   font-family: monospace;
 }

--- a/public/stylesheets/site/2.0/22-system-messages.css
+++ b/public/stylesheets/site/2.0/22-system-messages.css
@@ -18,6 +18,10 @@ System messages use the following colours:
   float: right;
 }
 
+p.message.footnote {
+  clear: both;
+}
+
 .datetime {
   font-family: monospace;
 }


### PR DESCRIPTION
https://otwarchive.atlassian.net/browse/AO3-4474

small issue, but the fix suggested in the description works like a charm... i added

`
padding: 0 0.25em;
`

to **#worskin** in **21-userstuff.css** and tested it in safari, chrome, firefox and opera. i tried resizing the window and zooming in and out to see if any misalignment issues or clipping would occur but it seemed just fine 👍 i clicked around on various documentation pages and user pages to see if the tweak caused any unexpected spacing issues, but again, everything looked ship shape. 

0.25em was more than enough space to fix the problem, since it was only clipping long letters like t and f and l. could someone else also check it out in their own browser to make sure the extra padding doesn't cause any unexpected spacing issues? 
