### PR TITLE
AO3-2431 Make collection fandom count skip metatags

### DIFF
--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -309,15 +309,14 @@ class Collection < ActiveRecord::Base
   end
 
   def all_fandoms
-    Fandom.for_collections([self] + self.children).select("DISTINCT tags.*")
+    # We want filterable fandoms, but not inherited metatags:
+    Fandom.for_collections([self] + self.children).
+      where('filter_taggings.inherited = 0').uniq
   end
 
   def all_fandoms_count
-    # this is the only way to get this to be done with an actual efficient count query instead of
-    # actually loading the tags and then counting, because count on AR queries isn't respecting
-    # the selects :P
-    # see: https://rails.lighthouseapp.com/projects/8994/tickets/1334-count-calculations-should-respect-scoped-selects
-    Fandom.select("count(distinct tags.id) as count").for_collections([self] + self.children).first.count
+    # Rails now handles .uniq.count correctly, so we can make this simpler:
+    all_fandoms.count
   end
 
   def maintainers

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -310,7 +310,7 @@ class Collection < ActiveRecord::Base
 
   def all_fandoms
     # We want filterable fandoms, but not inherited metatags:
-    Fandom.for_collections([self] + self.children).
+    Fandom.for_collections([self] + children).
       where('filter_taggings.inherited = 0').uniq
   end
 

--- a/features/collections/collection_navigation.feature
+++ b/features/collections/collection_navigation.feature
@@ -88,3 +88,17 @@ Feature: Basic collection navigation
       And I press "Show"
     Then I should not see "High School Musical"
       And I should see "Steven's Universe"
+
+  Scenario: A collection's fandom count shouldn't include inherited metatags.
+    Given I have the collection "MCU Party"
+      And a canonical fandom "The Avengers"
+      And a canonical fandom "MCU"
+      And "MCU" is a metatag of the fandom "The Avengers"
+      And I am logged in as "mcu_fan"
+      And I post the work "Ensemble Piece" with fandom "The Avengers" in the collection "MCU Party"
+
+    When I go to the collections page
+    Then I should see "Fandoms: 1"
+
+    When I go to "MCU Party" collection's page
+    Then I should see "Fandoms (1)"

--- a/features/step_definitions/tag_steps.rb
+++ b/features/step_definitions/tag_steps.rb
@@ -80,6 +80,13 @@ Given /^a synonym "([^\"]*)" of the tag "([^\"]*)"$/ do |synonym, merger|
   synonym.save
 end
 
+Given /^"([^\"]*)" is a metatag of the fandom "([^\"]*)"$/ do |metatag, fandom|
+  fandom = Fandom.find_or_create_by_name(fandom)
+  metatag = Fandom.find_or_create_by_name(metatag)
+  fandom.meta_tags << metatag
+  fandom.save
+end
+
 Given /^I am logged in as a tag wrangler$/ do
   step "I am logged out"
   username = "wrangler"


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-2431
## Purpose

The fandom counts for collections are a little inconsistent. The fandom count in the sidebar includes all metatags for all fandoms used on works in the collection; the list of fandoms doesn't. This pull request changes the fandom count in the sidebar (and the fandom count in the collection's blurb) to skip inherited taggings, to make it match the query used to generate the list of fandoms.
## Testing

The example given in the bug report no longer works, but there are very detailed steps on how to reproduce this issue in the bug report's comments.
