### PR TITLE
AO3-1744 Show error when wrangling tags into a non-canonical fandom.

### DIFF
--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -230,7 +230,7 @@ class TagsController < ApplicationController
 
     @tag.attributes = params[:tag]
 
-    @tag.syn_string = syn_string if @tag.save
+    @tag.syn_string = syn_string if @tag.errors.empty? && @tag.save
 
     if @tag.errors.empty? && @tag.save
       # check if a resetting of the taggings_count was requsted

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -990,9 +990,9 @@ class Tag < ActiveRecord::Base
     names.each do |name|
       parent = Tag.find_by_name(name)
       if parent && parent.canonical?
-        self.add_association(parent)
+        add_association(parent)
       else
-        self.errors.add(:base, "Cannot add association: '#{name}' tag " +
+        errors.add(:base, "Cannot add association: '#{name}' tag " +
           (parent ? "is not canonical." : "does not exist."))
       end
     end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -989,7 +989,12 @@ class Tag < ActiveRecord::Base
     names = tag_string.split(',').map(&:squish)
     names.each do |name|
       parent = Tag.find_by_name(name)
-      self.add_association(parent) if parent && parent.canonical?
+      if parent && parent.canonical?
+        self.add_association(parent)
+      else
+        self.errors.add(:base, "Cannot add association: '#{name}' tag " +
+          (parent ? "is not canonical." : "does not exist."))
+      end
     end
   end
 

--- a/features/tags_and_wrangling/tag_wrangling.feature
+++ b/features/tags_and_wrangling/tag_wrangling.feature
@@ -146,8 +146,9 @@ Feature: Tag wrangling
     # trying to assign a non-canonical fandom to a character
     When I fill in "Fandoms" with "Stargate Atlantis"
       And I press "Save changes"
-    Then I should see "Tag was updated"
-      And I should not see "Stargate Atlantis"
+    Then I should see "Cannot add association"
+      And I should see "'Stargate Atlantis' tag is not canonical"
+      And I should not see "Stargate Atlantis" within "form"
       
     # making a fandom tag canonical, then assigning it to a character
     When I view the tag "Stargate Atlantis"


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-1744
## Purpose

Currently, when you try to add a non-canonical fandom to a character or relationship tag, it will fail silently -- the non-canonical fandom won't be added as a parent (correctly), but the flash message says that the tag has been updated, and doesn't notify the wrangler that the fandom wasn't added. This pull request adds an error message when trying to add an association to a non-canonical tag, and updates the existing non-canonical fandom test to check for that error message.
## Testing

The bug report has steps for reproducing the problem.
