### PR TITLE
AO3-3733 AO3-4174 Fix orphaning shared series/works to avoid incorrectly adding orphan_account.

### DIFF
--- a/app/models/pseud.rb
+++ b/app/models/pseud.rb
@@ -326,7 +326,7 @@ class Pseud < ActiveRecord::Base
     # Should only transfer creatorship if we're a co-creator.
     if creation.pseuds.include?(self)
       creation.pseuds.delete(self)
-      creation.pseuds << pseud rescue nil
+      creation.pseuds << pseud unless creation.pseuds.include?(pseud)
     end
 
     if creation.is_a?(Work)

--- a/app/models/pseud.rb
+++ b/app/models/pseud.rb
@@ -326,7 +326,7 @@ class Pseud < ActiveRecord::Base
     # Should only transfer creatorship if we're a co-creator.
     if creation.pseuds.include?(self)
       creation.pseuds.delete(self)
-      creation.pseuds << pseud unless creation.pseuds.include?(pseud)
+      creation.pseuds << pseud unless pseud.nil? || creation.pseuds.include?(pseud)
     end
 
     if creation.is_a?(Work)

--- a/app/models/pseud.rb
+++ b/app/models/pseud.rb
@@ -323,8 +323,12 @@ class Pseud < ActiveRecord::Base
   # Options: skip_series -- if you begin by changing ownership of the series, you don't
   # want to go back up again and get stuck in a loop
   def change_ownership(creation, pseud, options={})
-    creation.pseuds.delete(self)
-    creation.pseuds << pseud rescue nil
+    # Should only transfer creatorship if we're a co-creator.
+    if creation.pseuds.include?(self)
+      creation.pseuds.delete(self)
+      creation.pseuds << pseud rescue nil
+    end
+
     if creation.is_a?(Work)
       creation.chapters.each {|chapter| self.change_ownership(chapter, pseud)}
       unless options[:skip_series]

--- a/features/other_a/orphan_series.feature
+++ b/features/other_a/orphan_series.feature
@@ -67,9 +67,6 @@ Feature: Orphan series
       And I add the work "Shared Beginnings" to the series "Shared Series"
       And I add the co-author "orphaneer" to the work "Shared Beginnings"
       And I view the series "Shared Series"
-      # And I follow "Edit Series"
-      # And I add the co-author "orphaneer"
-      # And I press "Update"
       And I add the work "Keeper's Solo" to the series "Shared Series"
 
     # Double-check to make sure that we've set up the authorships correctly.

--- a/features/other_a/orphan_series.feature
+++ b/features/other_a/orphan_series.feature
@@ -1,0 +1,85 @@
+@series
+Feature: Orphan series
+  As an author
+  I want to orphan a series full of works
+
+  Background:
+    Given I have an orphan account
+      And I am logged in as "orphaneer"
+
+  Scenario: Orphaning a series (remove pseud) should remove all references to the user from the series
+
+    Given I add the work "Work to be Rued" to the series "My Biggest Mistakes"
+      And I add the work "Regrettable Work" to the series "My Biggest Mistakes"
+
+    When I orphan and take my pseud off the series "My Biggest Mistakes"
+      And I am logged out
+      And I view the series "My Biggest Mistakes"
+
+    Then I should not see "orphaneer"
+
+  Scenario: Orphaning a series (leave pseud) should change the authorship to the correct pseudonym of orphan_account
+
+    Given I add the work "Work to be Rued" to the series "My Biggest Mistakes"
+      And I add the work "Regrettable Work" to the series "My Biggest Mistakes"
+
+    When I orphan and leave my pseud on the series "My Biggest Mistakes"
+      And I view the series "My Biggest Mistakes"
+
+    Then I should see "orphaneer (orphan_account)" within ".series.meta"
+      And I should not see "Edit"
+
+  Scenario: Orphaning a series should remove it from the user's series page
+
+    Given I add the work "Work to be Rued" to the series "My Biggest Mistakes"
+      And I add the work "Regrettable Work" to the series "My Biggest Mistakes"
+
+    When I orphan and take my pseud off the series "My Biggest Mistakes"
+      And I am on orphaneer's series page
+
+    Then I should not see "My Biggest Mistakes"
+
+  Scenario: Orphaning a work in a series with only one work should cause the series to be orphaned
+
+    Given I add the work "Work to be Rued" to the series "My Biggest Mistakes"
+
+    When I orphan the work "Work to be Rued"
+      And I am logged out
+      And I view the series "My Biggest Mistakes"
+
+    Then I should see "orphan_account"
+      And I should not see "orphaneer"
+
+  Scenario: Orphaning one but not all of the works in a series should make the series co-created by orphan_account
+
+    Given I add the work "Work to be Rued" to the series "My Biggest Mistakes"
+      And I add the work "Work to be Kept" to the series "My Biggest Mistakes"
+
+    When I orphan the work "Work to be Rued"
+
+    Then "orphaneer" should be a co-creator of the series "My Biggest Mistakes"
+      And "orphan_account" should be a co-creator of the series "My Biggest Mistakes"
+
+  Scenario: When a user orphans a shared series, it should not change the byline for works that they didn't co-create
+
+    # Set up a shared series where orphaneer is not listed as a creator on the second work
+    Given I am logged in as "keeper"
+      And I add the work "Shared Beginnings" to the series "Shared Series"
+      And I add the co-author "orphaneer" to the work "Shared Beginnings"
+      And I view the series "Shared Series"
+      # And I follow "Edit Series"
+      # And I add the co-author "orphaneer"
+      # And I press "Update"
+      And I add the work "Keeper's Solo" to the series "Shared Series"
+
+    # Double-check to make sure that we've set up the authorships correctly.
+    Then "orphaneer" should be a co-creator of the series "Shared Series"
+      And "orphaneer" should be a co-creator of the work "Shared Beginnings"
+      But "orphaneer" should not be a co-creator of the work "Keeper's Solo"
+
+    When I am logged in as "orphaneer"
+      And I orphan the series "Shared Series"
+
+    Then "orphan_account" should be a co-creator of the series "Shared Series"
+      And "orphan_account" should be a co-creator of the work "Shared Beginnings"
+      But "orphan_account" should not be a co-creator of the work "Keeper's Solo"

--- a/features/other_a/orphan_series.feature
+++ b/features/other_a/orphan_series.feature
@@ -66,7 +66,6 @@ Feature: Orphan series
     Given I am logged in as "keeper"
       And I add the work "Shared Beginnings" to the series "Shared Series"
       And I add the co-author "orphaneer" to the work "Shared Beginnings"
-      And I view the series "Shared Series"
       And I add the work "Keeper's Solo" to the series "Shared Series"
 
     # Double-check to make sure that we've set up the authorships correctly.

--- a/features/other_a/orphan_work.feature
+++ b/features/other_a/orphan_work.feature
@@ -139,3 +139,23 @@ Feature: Orphan work
   Then I should not see "Glorious"
     And I should not see "Excellent"
     And I should see "Lovely"
+
+  Scenario: Orphaning a shared work should not affect chapters created solely by the other creator
+    # Set up a shared, chaptered work where orphaneer is not listed as a
+    # creator on Chapter 2. Currently, adding an author to a chaptered work
+    # only adds them to the first chapter. If that behavior ever changes (e.g.
+    # in response to issue AO3-2971), so should this test.
+
+    Given I am logged in as "keeper"
+      And I post the chaptered work "Half-Orphaned"
+      And I add the co-author "orphaneer" to the work "Half-Orphaned"
+
+    # Verify that the authorship has been set up properly
+    Then "orphaneer" should be a co-creator of Chapter 1 of "Half-Orphaned"
+      But "orphaneer" should not be a co-creator of Chapter 2 of "Half-Orphaned"
+
+    When I am logged in as "orphaneer"
+      And I orphan the work "Half-Orphaned"
+
+    Then "orphan_account" should be a co-creator of Chapter 1 of "Half-Orphaned"
+      But "orphan_account" should not be a co-creator of Chapter 2 of "Half-Orphaned"

--- a/features/step_definitions/orphan_steps.rb
+++ b/features/step_definitions/orphan_steps.rb
@@ -1,0 +1,54 @@
+When /^I choose to take my pseud off$/ do
+  step %{I choose "Take my pseud off as well"}
+  step %{I press "Yes, I'm sure"}
+  step %{I should see "Orphaning was successful."}
+end
+
+When /^I choose to (?:keep|leave) my pseud on$/ do
+  step %{I choose "Leave a copy of my pseud on"}
+  step %{I press "Yes, I'm sure"}
+  step %{I should see "Orphaning was successful."}
+end
+
+When /^I begin orphaning the work "([^"]*)"$/ do |name|
+  step %{I edit the work "#{name}"}
+  step %{I follow "Orphan Work"}
+end
+
+When /^I begin orphaning the series "([^"]*)"$/ do |name|
+  step %{I view the series "#{name}"}
+  step %{I follow "Orphan Series"}
+end
+
+When /^I orphan(?:| and take my pseud off) the (work|series) "([^"]*)"$/ do |type, name|
+  step %{I begin orphaning the #{type} "#{name}"}
+  step %{I choose to take my pseud off}
+end
+
+When /^I orphan and (?:keep|leave) my pseud on the (work|series) "([^"]*)"$/ do |type, name|
+  step %{I begin orphaning the #{type} "#{name}"}
+  step %{I choose to keep my pseud on}
+end
+
+Then /^"([^"]*)" (should|should not) be (?:a|the) (?:|co-)creator (?:of|on) the work "([^"]*)"$/ do |user, should_or_should_not, work|
+  step %{I view the work "#{work}"}
+  step %{I #{should_or_should_not} see "#{user}" within ".byline"}
+end
+
+Then /^"([^"]*)" (should|should not) be (?:a|the) (?:|co-)creator (?:of|on) Chapter (\d+) of "([^"]*)"$/ do |user, should_or_should_not, chapter, work|
+  step %{I view the work "#{work}"}
+  step %{I view the #{chapter}th chapter}
+
+  if page.has_css? ".chapter .byline"
+    # the chapter has different co-authors from the full work
+    step %{I #{should_or_should_not} see "#{user}" within ".chapter .byline"}
+  else
+    # the chapter's co-authors are the same as the full work's
+    step %{I #{should_or_should_not} see "#{user}" within ".byline"}
+  end
+end
+
+Then /^"([^"]*)" (should|should not) be (?:a|the) (?:|co-)creator (?:of|on) the series "([^"]*)"$/ do |user, should_or_should_not, series|
+  step %{I view the series "#{series}"}
+  step %{I #{should_or_should_not} see "#{user}" within ".series.meta"}
+end


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-3733
https://otwarchive.atlassian.net/browse/AO3-4174
## Purpose

Currently, the orphaning code contains checks in `Creatorship.orphan` to avoid transferring ownership of works the user doesn't own to orphan_account. However, when orphaning a series that the user is a co-creator for, `Pseud.change_ownership` will be recursively called on all works in the series, without checking whether the user is a co-creator of those works. This results in orphan_account being added as a co-creator on all works in the series, regardless of whether the orphaning user was a co-creator before.

The same problem occurs when orphaning a work: `Pseud.change_ownership` is recursively called on all chapters in the work, meaning that orphan_account will be added as a co-creator on all chapters (even on chapters that aren't co-created by the orphaning user).

This pull request adds a check to `Pseud.change_ownership` to ensure that it won't transfer ownership of items the user doesn't own. It also adds one test for each of the two issues it resolves, as well as several tests for orphaning series (since there were no tests before, and I wanted to make sure that the functionality didn't change).
## Testing

The two bug reports contain steps that can be used for QA testing.
