### PR TITLE
AO3-4711 Improve coverage of CollectionSweeper

### DIFF
--- a/spec/sweepers/collection_sweeper_spec.rb
+++ b/spec/sweepers/collection_sweeper_spec.rb
@@ -1,0 +1,16 @@
+require 'spec_helper'
+
+describe CollectionSweeper do
+  describe 'get_collections_from_record' do
+    before(:each) do
+      @work = FactoryGirl.create(:work)
+    end
+
+    let(:sweeper) { CollectionSweeper.instance }
+    context 'for Works with no collections' do
+      it 'should return an empty array' do
+        expect(sweeper.get_collections_from_record(@work)).to be_nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [x] Have you added tests for any changed functionality?
* [x] Have you added the JIRA issue number as the *first* thing in your pull request title (eg: `AO3-1234 Fix thing`)
* [x] Have you updated the JIRA issue with the information below?

## Issue

https://otwarchive.atlassian.net/browse/AO3-4711

## Purpose

This PR adds test coverage to the case where a 'record' (in this case a Work) sent to the 'get_collections_from_record' method of the collection_sweeper.rb file doesn't have any associated Collections. It should return an empty array. Tests now ensure that it does. 

## Testing

No testing on behalf of QA is needed. Just confirm that our code coverage tools show that line # 41 in app/sweepers/collection_sweeper.rb is now covered.
