### PR TITLE
AO3-4721 - Perform partial match by email in admin user search

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -270,7 +270,7 @@ class User < ActiveRecord::Base
       users = users.joins(:roles).where("roles.id = ?", role.id)
     end
     if query.present?
-      users = users.joins(:pseuds).where("pseuds.name LIKE ? OR email = ?", "%#{query}%", query)
+      users = users.joins(:pseuds).where("pseuds.name LIKE ? OR email LIKE ?", "%#{query}%", "%#{query}%")
     end
     users.paginate(:page => options[:page] || 1)
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,7 +8,7 @@ class User < ActiveRecord::Base
   # Authlogic gem
   acts_as_authentic do |config|
     config.transition_from_restful_authentication = true
-    if (ArchiveConfig.BCRYPT  || "true") == "true" then
+    if (ArchiveConfig.BCRYPT || "true") == "true"
       config.crypto_provider = Authlogic::CryptoProviders::BCrypt
       config.transition_from_crypto_providers = [Authlogic::CryptoProviders::Sha512, Authlogic::CryptoProviders::Sha1]
     else
@@ -17,12 +17,12 @@ class User < ActiveRecord::Base
     end
     # Use our own validations for login
     config.validate_login_field = false
-    config.validates_length_of_password_field_options = {:on => :update,
-                                                         :minimum => ArchiveConfig.PASSWORD_LENGTH_MIN,
-                                                         :if => :has_no_credentials?}
-    config.validates_length_of_password_confirmation_field_options = {:on => :update,
-                                                                      :minimum => ArchiveConfig.PASSWORD_LENGTH_MIN,
-                                                                      :if => :has_no_credentials?}
+    config.validates_length_of_password_field_options = { on: :update,
+                                                          minimum: ArchiveConfig.PASSWORD_LENGTH_MIN,
+                                                          if: :has_no_credentials? }
+    config.validates_length_of_password_confirmation_field_options = { on: :update,
+                                                                       minimum: ArchiveConfig.PASSWORD_LENGTH_MIN,
+                                                                       if: :has_no_credentials? }
   end
 
   def has_no_credentials?
@@ -33,21 +33,21 @@ class User < ActiveRecord::Base
   acts_as_authorized_user
   acts_as_authorizable
   has_many :roles_users
-  has_many :roles, :through => :roles_users
+  has_many :roles, through: :roles_users
 
   ### BETA INVITATIONS ###
-  has_many :invitations, :as => :creator
-  has_one :invitation, :as => :invitee
-  has_many :user_invite_requests, :dependent => :destroy
+  has_many :invitations, as: :creator
+  has_one :invitation, as: :invitee
+  has_many :user_invite_requests, dependent: :destroy
 
   attr_accessor :invitation_token
   attr_accessible :invitation_token
   after_create :mark_invitation_redeemed, :remove_from_queue
 
-  has_many :external_authors, :dependent => :destroy
-  has_many :external_creatorships, :foreign_key => 'archivist_id'
+  has_many :external_authors, dependent: :destroy
+  has_many :external_creatorships, foreign_key: "archivist_id"
 
-  has_many :fannish_next_of_kins, foreign_key: 'kin_id', dependent: :destroy
+  has_many :fannish_next_of_kins, foreign_key: "kin_id", dependent: :destroy
   has_one :fannish_next_of_kin, dependent: :destroy
 
   has_many :favorite_tags, dependent: :destroy
@@ -55,47 +55,47 @@ class User < ActiveRecord::Base
   # MUST be before the pseuds association, or the 'dependent' destroys the pseuds before they can be removed from kudos
   before_destroy :remove_pseud_from_kudos
 
-  has_many :pseuds, :dependent => :destroy
+  has_many :pseuds, dependent: :destroy
   validates_associated :pseuds
 
-  has_one :profile, :dependent => :destroy
+  has_one :profile, dependent: :destroy
   validates_associated :profile
 
-  has_one :preference, :dependent => :destroy
+  has_one :preference, dependent: :destroy
   validates_associated :preference
 
-  has_many :skins, :foreign_key=> 'author_id', :dependent => :nullify
-  has_many :work_skins, :foreign_key=> 'author_id', :dependent => :nullify
+  has_many :skins, foreign_key: "author_id", dependent: :nullify
+  has_many :work_skins, foreign_key: "author_id", dependent: :nullify
 
   before_create :create_default_associateds
 
   after_update :update_pseud_name
   after_update :log_change_if_login_was_edited
 
-  has_many :collection_participants, :through => :pseuds
-  has_many :collections, :through => :collection_participants
-  has_many :invited_collections, :through => :collection_participants, :source => :collection,
-      :conditions => ['collection_participants.participant_role = ?', CollectionParticipant::INVITED]
-  has_many :participated_collections, :through => :collection_participants, :source => :collection,
-      :conditions => ['collection_participants.participant_role IN (?)', [CollectionParticipant::OWNER, CollectionParticipant::MODERATOR, CollectionParticipant::MEMBER]]
-  has_many :maintained_collections, :through => :collection_participants, :source => :collection,
-      :conditions => ['collection_participants.participant_role IN (?)', [CollectionParticipant::OWNER, CollectionParticipant::MODERATOR]]
-  has_many :owned_collections, :through => :collection_participants, :source => :collection,
-          :conditions => ['collection_participants.participant_role = ?', CollectionParticipant::OWNER]
+  has_many :collection_participants, through: :pseuds
+  has_many :collections, through: :collection_participants
+  has_many :invited_collections, through: :collection_participants, source: :collection,
+           conditions: ["collection_participants.participant_role = ?", CollectionParticipant::INVITED]
+  has_many :participated_collections, through: :collection_participants, source: :collection,
+           conditions: ["collection_participants.participant_role IN (?)", [CollectionParticipant::OWNER, CollectionParticipant::MODERATOR, CollectionParticipant::MEMBER]]
+  has_many :maintained_collections, through: :collection_participants, source: :collection,
+           conditions: ["collection_participants.participant_role IN (?)", [CollectionParticipant::OWNER, CollectionParticipant::MODERATOR]]
+  has_many :owned_collections, through: :collection_participants, source: :collection,
+           conditions: ["collection_participants.participant_role = ?", CollectionParticipant::OWNER]
 
-  has_many :challenge_signups, :through => :pseuds
-  has_many :offer_assignments, :through => :pseuds
-  has_many :pinch_hit_assignments, :through => :pseuds
-  has_many :request_claims, :class_name => "ChallengeClaim", :foreign_key => 'claiming_user_id', :inverse_of => :claiming_user
+  has_many :challenge_signups, through: :pseuds
+  has_many :offer_assignments, through: :pseuds
+  has_many :pinch_hit_assignments, through: :pseuds
+  has_many :request_claims, class_name: "ChallengeClaim", foreign_key: "claiming_user_id", inverse_of: :claiming_user
   has_many :gifts, through: :pseuds, conditions: { rejected: false }
   has_many :gift_works, through: :pseuds, uniq: true
   has_many :rejected_gifts, class_name: "Gift", through: :pseuds, conditions: { rejected: true }
   has_many :rejected_gift_works, through: :pseuds, uniq: true
-  has_many :readings, :dependent => :destroy
-  has_many :bookmarks, :through => :pseuds
-  has_many :bookmark_collection_items, :through => :bookmarks, :source => :collection_items
-  has_many :comments, :through => :pseuds
-  has_many :kudos, :through => :pseuds
+  has_many :readings, dependent: :destroy
+  has_many :bookmarks, through: :pseuds
+  has_many :bookmark_collection_items, through: :bookmarks, source: :collection_items
+  has_many :comments, through: :pseuds
+  has_many :kudos, through: :pseuds
   
   # Nested associations through creatorships got weird after 3.0.x
   
@@ -154,29 +154,29 @@ class User < ActiveRecord::Base
     filters.where("filter_taggings.inherited = false")
   end
 
-  has_many :bookmark_tags, :through => :bookmarks, :source => :tags
+  has_many :bookmark_tags, through: :bookmarks, source: :tags
 
-  has_many :subscriptions, :dependent => :destroy
+  has_many :subscriptions, dependent: :destroy
   has_many :followings,
-            :class_name => 'Subscription',
-            :as => :subscribable,
-            :dependent => :destroy
+           class_name: "Subscription",
+           as: :subscribable,
+           dependent: :destroy
   has_many :subscribed_users,
-            :through => :subscriptions,
-            :source => :subscribable,
-            :source_type => 'User'
+           through: :subscriptions,
+           source: :subscribable,
+           source_type: "User"
   has_many :subscribers,
-            :through => :followings,
-            :source => :user
+           through: :followings,
+           source: :user
 
-  has_many :wrangling_assignments, :dependent => :destroy
-  has_many :fandoms, :through => :wrangling_assignments
-  has_many :wrangled_tags, :class_name => 'Tag', :as => :last_wrangler
+  has_many :wrangling_assignments, dependent: :destroy
+  has_many :fandoms, through: :wrangling_assignments
+  has_many :wrangled_tags, class_name: "Tag", as: :last_wrangler
 
-  has_many :inbox_comments, :dependent => :destroy
-  has_many :feedback_comments, :through => :inbox_comments, :conditions => {:is_deleted => false, :approved => true}, :order => 'created_at DESC'
+  has_many :inbox_comments, dependent: :destroy
+  has_many :feedback_comments, through: :inbox_comments, conditions: { is_deleted: false, approved: true }, order: "created_at DESC"
 
-  has_many :log_items, :dependent => :destroy
+  has_many :log_items, dependent: :destroy
   validates_associated :log_items
 
   after_update :expire_caches
@@ -188,7 +188,7 @@ class User < ActiveRecord::Base
   end
 
   def remove_pseud_from_kudos
-    ids = self.pseuds.collect(&:id).join(',')
+    ids = self.pseuds.collect(&:id).join(",")
     # NB: updates the kudos to remove the pseud, but the cache will not expire, and there's also issue 2198
     Kudo.update_all("pseud_id = NULL", "pseud_id IN (#{ids})") if ids.present?
   end
@@ -203,35 +203,35 @@ class User < ActiveRecord::Base
     unread_inbox_comments.with_feedback_comment.count
   end
 
-  scope :alphabetical, :order => :login
-  scope :starting_with, lambda {|letter| {:conditions => ['SUBSTR(login,1,1) = ?', letter]}}
-  scope :valid, :conditions => {:banned => false, :suspended => false}
-  scope :out_of_invites, :conditions => {:out_of_invites => true}
+  scope :alphabetical, order: :login
+  scope :starting_with, -> (letter) { { conditions: ["SUBSTR(login,1,1) = ?", letter] } }
+  scope :valid, conditions: { banned: false, suspended: false }
+  scope :out_of_invites, conditions: { out_of_invites: true }
 
   ## used in app/views/users/new.html.erb
-  validates_length_of :login, 
-    :within => ArchiveConfig.LOGIN_LENGTH_MIN..ArchiveConfig.LOGIN_LENGTH_MAX,
-    :too_short => ts("is too short (minimum is %{min_login} characters)", 
-      :min_login => ArchiveConfig.LOGIN_LENGTH_MIN),
-    :too_long => ts("is too long (maximum is %{max_login} characters)", 
-      :max_login => ArchiveConfig.LOGIN_LENGTH_MAX)
+  validates_length_of :login,
+                      within: ArchiveConfig.LOGIN_LENGTH_MIN..ArchiveConfig.LOGIN_LENGTH_MAX,
+                      too_short: ts("is too short (minimum is %{min_login} characters)",
+                                    min_login: ArchiveConfig.LOGIN_LENGTH_MIN),
+                      too_long: ts("is too long (maximum is %{max_login} characters)",
+                                   max_login: ArchiveConfig.LOGIN_LENGTH_MAX)
 
   # allow nil so can save existing users
-  validates_length_of :password, 
-    :within => ArchiveConfig.PASSWORD_LENGTH_MIN..ArchiveConfig.PASSWORD_LENGTH_MAX,
-    :allow_nil => true,
-    :too_short => ts("is too short (minimum is %{min_pwd} characters)", 
-      :min_pwd => ArchiveConfig.PASSWORD_LENGTH_MIN),
-    :too_long => ts("is too long (maximum is %{max_pwd} characters)", 
-      :max_pwd => ArchiveConfig.PASSWORD_LENGTH_MAX)
+  validates_length_of :password,
+                      within: ArchiveConfig.PASSWORD_LENGTH_MIN..ArchiveConfig.PASSWORD_LENGTH_MAX,
+                      allow_nil: true,
+                      too_short: ts("is too short (minimum is %{min_pwd} characters)",
+                                    min_pwd: ArchiveConfig.PASSWORD_LENGTH_MIN),
+                      too_long: ts("is too long (maximum is %{max_pwd} characters)",
+                                   max_pwd: ArchiveConfig.PASSWORD_LENGTH_MAX)
 
   validates_format_of :login,
-    :message => ts("must begin and end with a letter or number; it may also contain underscores but no other characters."),
-    :with => /\A[A-Za-z0-9]\w*[A-Za-z0-9]\Z/
+                      message: ts("must begin and end with a letter or number; it may also contain underscores but no other characters."),
+                      with: /\A[A-Za-z0-9]\w*[A-Za-z0-9]\Z/
   # done by authlogic
-  validates_uniqueness_of :login, case_sensitive: false, message: ts('has already been taken')
+  validates_uniqueness_of :login, case_sensitive: false, message: ts("has already been taken")
 
-  validates :email, :email_veracity => true
+  validates :email, email_veracity: true
 
   # Virtual attribute for age check and terms of service
   attr_accessor :age_over_13
@@ -239,14 +239,14 @@ class User < ActiveRecord::Base
   attr_accessible :age_over_13, :terms_of_service
 
   validates_acceptance_of :terms_of_service,
-                         :allow_nil => false,
-                         :message => ts('Sorry, you need to accept the Terms of Service in order to sign up.'),
-                         :if => :first_save?
+                          allow_nil: false,
+                          message: ts("Sorry, you need to accept the Terms of Service in order to sign up."),
+                          if: :first_save?
 
-  validates_acceptance_of  :age_over_13,
-                          :allow_nil => false,
-                          :message => ts('Sorry, you have to be over 13!'),
-                          :if => :first_save?
+  validates_acceptance_of :age_over_13,
+                          allow_nil: false,
+                          message: ts("Sorry, you have to be over 13!"),
+                          if: :first_save?
 
   def to_param
     login
@@ -262,7 +262,7 @@ class User < ActiveRecord::Base
   # Options: inactive, page
   def self.search_by_role(role, query, options = {})
     return if role.blank? && query.blank?
-    users = User.select('DISTINCT users.*').order(:login)
+    users = User.select("DISTINCT users.*").order(:login)
     if options[:inactive]
       users = users.where("activated_at IS NULL")
     end
@@ -280,9 +280,9 @@ class User < ActiveRecord::Base
     !activated_at.nil?
   end
 
-  def generate_password(length=8)
-    chars = 'abcdefghjkmnpqrstuvwxyzABCDEFGHJKLMNOPQRSTUVWXYZ23456789'
-    password = ''
+  def generate_password(length = 8)
+    chars = "abcdefghjkmnpqrstuvwxyzABCDEFGHJKLMNOPQRSTUVWXYZ23456789"
+    password = ""
     length.downto(1) { |i| password << chars[rand(chars.length - 1)] }
     password
   end
@@ -301,7 +301,7 @@ class User < ActiveRecord::Base
   end
 
   def create_default_associateds
-    self.pseuds << Pseud.new(:name => self.login, :is_default => true)
+    self.pseuds << Pseud.new(name: self.login, is_default: true)
     self.profile = Profile.new
     self.preference = Preference.new
   end
@@ -326,7 +326,7 @@ class User < ActiveRecord::Base
 
   def unposted_works
     return @unposted_works if @unposted_works
-    @unposted_works = works.where(posted: false).order('works.created_at DESC')
+    @unposted_works = works.where(posted: false).order("works.created_at DESC")
   end
 
   # removes ALL unposted works
@@ -338,7 +338,7 @@ class User < ActiveRecord::Base
 
   # Retrieve the current default pseud
   def default_pseud
-    self.pseuds.where(:is_default => true).first
+    self.pseuds.where(is_default: true).first
   end
 
   # Checks authorship of any sort of object
@@ -373,7 +373,7 @@ class User < ActiveRecord::Base
       success = set_roles(attributes[:roles])
       if success && attributes[:email]
         self.email = attributes[:email]
-        success = self.save(:validate => false)
+        success = self.save(validate: false)
       end
       success
     end
@@ -403,7 +403,7 @@ class User < ActiveRecord::Base
 
   # Set translator role for this user and log change
   def translation_admin=(should_be_translation_admin)
-    set_role('translation_admin', should_be_translation_admin == '1')
+    set_role("translation_admin", should_be_translation_admin == "1")
   end
 
   # Is this user an authorized tag wrangler?
@@ -417,7 +417,7 @@ class User < ActiveRecord::Base
 
   # Set tag wrangler role for this user and log change
   def tag_wrangler=(should_be_tag_wrangler)
-    set_role('tag_wrangler', should_be_tag_wrangler == '1')
+    set_role("tag_wrangler", should_be_tag_wrangler == "1")
   end
 
   # Is this user an authorized archivist?
@@ -431,12 +431,12 @@ class User < ActiveRecord::Base
 
   # Set archivist role for this user and log change
   def archivist=(should_be_archivist)
-    set_role('archivist', should_be_archivist == '1')
+    set_role("archivist", should_be_archivist == "1")
   end
 
   # Creates log item tracking changes to user
   def create_log_item(options = {})
-    options.reverse_merge! :note => 'System Generated', :user_id => self.id
+    options.reverse_merge! note: "System Generated", user_id: self.id
     LogItem.create(options)
   end
 
@@ -450,7 +450,7 @@ class User < ActiveRecord::Base
   # Returns array of works where the user is the sole author
   def sole_authored_works
     @sole_authored_works = []
-    works.find(:all, :conditions => 'posted = 1').each do |w|
+    works.find(:all, conditions: "posted = 1").each do |w|
       if self.is_sole_author_of?(w)
         @sole_authored_works << w
       end
@@ -461,7 +461,7 @@ class User < ActiveRecord::Base
   # Returns array of the user's co-authored works
   def coauthored_works
     @coauthored_works = []
-    works.find(:all, :conditions => 'posted = 1').each do |w|
+    works.find(:all, conditions: "posted = 1").each do |w|
       unless self.is_sole_author_of?(w)
         @coauthored_works << w
       end
@@ -557,6 +557,6 @@ class User < ActiveRecord::Base
   end
 
    def log_change_if_login_was_edited
-     create_log_item( options = {:action => ArchiveConfig.ACTION_RENAME, :note => "Old Username: #{login_was}; New Username: #{login}"}) if login_changed?
+     create_log_item(options = { action: ArchiveConfig.ACTION_RENAME, note: "Old Username: #{login_was}; New Username: #{login}" }) if login_changed?
    end
 end

--- a/features/admins/users/admin_find_users.feature
+++ b/features/admins/users/admin_find_users.feature
@@ -1,0 +1,36 @@
+Feature: Admin Find Users page
+
+  Background:
+    Given I have loaded the "roles" fixture
+      And the following activated users exist
+        | login | email     |
+        | userA | a@ao3.org |
+        | userB | b@bo3.org |
+      And the user "userB" exists and has the role "archivist"
+      And I am logged in as an admin
+
+  Scenario: The default page for the Admin section should be the Find Users page
+    Then I should see "Find Users"
+
+  Scenario: It should perform a partial match on name
+    When I fill in "query" with "user"
+      And I submit
+    Then I should see "userA"
+      And I should see "userB"
+
+  Scenario: It should perform a partial match by email
+    When I fill in "query" with "bo3"
+      And I submit
+    Then I should see "userB"
+      But I should not see "userA"
+
+  Scenario: It should perform an exact match by role
+    When I select "Archivist" from "role"
+      And I submit
+    Then I should see "userB"
+      But I should not see "userA"
+
+  Scenario: It should display an appropriate message if no users are found
+    When I fill in "query" with "co3"
+      And I submit
+    Then I should see "0 users found"

--- a/features/step_definitions/archivist_steps.rb
+++ b/features/step_definitions/archivist_steps.rb
@@ -1,10 +1,7 @@
 ### GIVEN
 
 Given /^I have an archivist "([^\"]*)"$/ do |name|
-  user = find_or_create_new_user(name, "password")
-  role = Role.find_or_create_by_name("archivist")
-  user.roles = [role]
-  user.save
+  step(%{the user "#{name}" exists and has the role "archivist"})
 end
 
 Given /^I have pre-archivist setup for "([^\"]*)"$/ do |name|

--- a/features/step_definitions/user_steps.rb
+++ b/features/step_definitions/user_steps.rb
@@ -28,11 +28,11 @@ Given /the following activated tag wranglers? exists?/ do |table|
   end
 end
 
-Given /^the user "([^\"]*)" exists and is activated$/ do |login|
+Given /^the user "([^"]*)" exists and is activated$/ do |login|
   find_or_create_new_user(login, DEFAULT_PASSWORD)
 end
 
-Given /^the user "([^\"]*)" exists and is not activated$/ do |login|
+Given /^the user "([^"]*)" exists and is not activated$/ do |login|
   find_or_create_new_user(login, DEFAULT_PASSWORD, activate: false)
 end
 
@@ -43,7 +43,7 @@ Given /^the user "([^"]*)" exists and has the role "([^"]*)"/ do |login, role|
   user.save
 end
 
-Given /^I am logged in as "([^\"]*)" with password "([^\"]*)"(?:( with preferences set to hidden warnings and additional tags))?$/ do |login, password, hidden|
+Given /^I am logged in as "([^"]*)" with password "([^"]*)"(?:( with preferences set to hidden warnings and additional tags))?$/ do |login, password, hidden|
   step("I am logged out")
   user = find_or_create_new_user(login, password)
   if hidden.present?
@@ -136,12 +136,12 @@ When /^"([^\"]*)" creates the default pseud "([^"]*)"$/ do |username, newpseud|
   click_button "Create"
 end
 
-When /^I fill in "([^\"]*)"'s temporary password$/ do |login|
+When /^I fill in "([^"]*)"'s temporary password$/ do |login|
   user = User.find_by_login(login)
   fill_in "Password", with: user.activation_code
 end
 
-When /^"([^\"]*)" creates the pseud "([^"]*)"$/ do |username, newpseud|
+When /^"([^"]*)" creates the pseud "([^"]*)"$/ do |username, newpseud|
   visit new_user_pseud_path(username)
   fill_in "Name", with: newpseud
   click_button "Create"

--- a/features/step_definitions/user_steps.rb
+++ b/features/step_definitions/user_steps.rb
@@ -36,6 +36,13 @@ Given /^the user "([^\"]*)" exists and is not activated$/ do |login|
   find_or_create_new_user(login, DEFAULT_PASSWORD, activate: false)
 end
 
+Given /^the user "([^"]*)" exists and has the role "([^"]*)"/ do |login, role|
+  user = find_or_create_new_user(login, DEFAULT_PASSWORD)
+  role = Role.find_or_create_by_name(role)
+  user.roles = [role]
+  user.save
+end
+
 Given /^I am logged in as "([^\"]*)" with password "([^\"]*)"(?:( with preferences set to hidden warnings and additional tags))?$/ do |login, password, hidden|
   step("I am logged out")
   user = find_or_create_new_user(login, password)


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-4721

## Purpose

Enabled admins to search for users by a partial email address.

## Testing

Log in as an admin, go to the Find Users page and search for, for example, "gmail". Currently, this will only return users whose pseud includes "gmail". Now, it will also return users who email address includes "gmail".

## Reviewing
This includes style changes. Review commit aa0e949 for the actual functionality changes