### PR TITLE
AO3-4692 - Preserve external authors when one author is claimed

### DIFF
--- a/app/models/external_author.rb
+++ b/app/models/external_author.rb
@@ -69,7 +69,7 @@ class ExternalAuthor < ActiveRecord::Base
           # ()archivist might already be removed if another coauthor already claimed), then add user as owner
           archivist = external_creatorship.archivist
           pseud_to_add = claiming_user.pseuds.select {|pseud| pseud.name == external_author_name.name}.first || claiming_user.default_pseud
-          if other_external_creators.empty? || !other_external_creators.map {|e| e.archivist}.include?(archivist)
+          if other_external_creators.empty? || !other_external_creators.map(&:archivist).include?(archivist)
             work.change_ownership(archivist, claiming_user, pseud_to_add)
           else
             work.add_creator(claiming_user, pseud_to_add)

--- a/app/models/external_author.rb
+++ b/app/models/external_author.rb
@@ -61,12 +61,19 @@ class ExternalAuthor < ActiveRecord::Base
     external_author_names.each do |external_author_name|
       external_author_name.external_work_creatorships.each do |external_creatorship|
         work = external_creatorship.creation
+        other_external_creators = work.external_creatorships - [external_creatorship]
+
         # if previously claimed, don't do it again
         unless work.users.include?(claiming_user)
-          # remove archivist as owner if still on the work -- might not be if another coauthor already claimed, add user as owner
+          # remove archivist as owner if still on the work and there are no other external authors associated with it
+          # ()archivist might already be removed if another coauthor already claimed), then add user as owner
           archivist = external_creatorship.archivist
           pseud_to_add = claiming_user.pseuds.select {|pseud| pseud.name == external_author_name.name}.first || claiming_user.default_pseud
-          work.change_ownership(archivist, claiming_user, pseud_to_add)
+          if other_external_creators.empty? || !other_external_creators.map {|e| e.archivist}.include?(archivist)
+            work.change_ownership(archivist, claiming_user, pseud_to_add)
+          else
+            work.add_creator(claiming_user, pseud_to_add)
+          end
           claimed_works << work.id
         end
       end

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -368,16 +368,20 @@ class Work < ActiveRecord::Base
     end
   end
 
-  # Transfer ownership of the work from one user to another
-  def change_ownership(old_user, new_user, new_pseud=nil)
-    raise "No new user provided, cannot change ownership" unless new_user
-    new_pseud = new_user.default_pseud if new_pseud.nil?
+  def add_creator(creator_to_add, new_pseud = nil)
+    new_pseud = creator_to_add.default_pseud if new_pseud.nil?
     self.pseuds << new_pseud
     self.chapters.each do |chapter|
       chapter.pseuds << new_pseud
       chapter.save
     end
     save
+  end
+
+  # Transfer ownership of the work from one user to another
+  def change_ownership(old_user, new_user, new_pseud = nil)
+    raise "No new user provided, cannot change ownership" unless new_user
+    self.add_creator(new_user, new_pseud)
     self.remove_author(old_user) if old_user && users.include?(old_user)
   end
 

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -381,8 +381,8 @@ class Work < ActiveRecord::Base
   # Transfer ownership of the work from one user to another
   def change_ownership(old_user, new_user, new_pseud = nil)
     raise "No new user provided, cannot change ownership" unless new_user
-    self.add_creator(new_user, new_pseud)
-    self.remove_author(old_user) if old_user && users.include?(old_user)
+    add_creator(new_user, new_pseud)
+    remove_author(old_user) if old_user && users.include?(old_user)
   end
 
   def set_challenge_info

--- a/features/importing/archivist.feature
+++ b/features/importing/archivist.feature
@@ -28,12 +28,12 @@ Feature: Archivist bulk imports
     Then 1 email should be delivered to "rebecca2525@livejournal.com"
       And the email should contain invitation warnings from "archivist" for work "Importing Test" in fandom "Lewis"
 
-  Scenario: Import a work for multiple authors without accounts
+  Scenario: Import a work for multiple authors without accounts should display all in the byline
     When I go to the import page
       And I import the work "http://ao3testing.dreamwidth.org/593.html" by "name1" with email "a@ao3.org" and by "name2" with email "b@ao3.org"
-    And I should see "Story"
-    And I should see "name1 [archived by archivist]"
-    And I should see "name2 [archived by archivist]"
+    Then I should see "Story"
+      And I should see "name1 [archived by archivist]"
+      And I should see "name2 [archived by archivist]"
 
   Scenario: Import a work for multiple authors without accounts should send emails to all authors
     When I go to the import page
@@ -41,6 +41,26 @@ Feature: Archivist bulk imports
     When the system processes jobs
     Then 1 email should be delivered to "a@ao3.org"
     And 1 email should be delivered to "b@ao3.org"
+
+  Scenario: Import a work for multiple authors with and without accounts should display all in the byline
+    Given the following activated users exist
+      | login | email |
+      | user1 | a@ao3.org |
+    When I go to the import page
+      And I import the work "http://ao3testing.dreamwidth.org/593.html" by "name1" with email "a@ao3.org" and by "name2" with email "b@ao3.org"
+    Then I should see "Story"
+      And I should see "user1"
+      And I should see "name2 [archived by archivist]"
+
+  Scenario: Import a work for multiple authors with and without accounts should send emails to all authors
+    Given the following activated users exist
+      | login | email |
+      | user1 | a@ao3.org |
+    When I go to the import page
+      And I import the work "http://ao3testing.dreamwidth.org/593.html" by "name1" with email "a@ao3.org" and by "name2" with email "b@ao3.org"
+    When the system processes jobs
+      Then 1 email should be delivered to "a@ao3.org"
+      And 1 email should be delivered to "b@ao3.org"
 
   Scenario: Import multiple works as an archivist
     When I import the works "http://ao3testing.dreamwidth.org/593.html, http://ao3testing.dreamwidth.org/325.html"

--- a/features/step_definitions/archivist_steps.rb
+++ b/features/step_definitions/archivist_steps.rb
@@ -44,7 +44,7 @@ When /^I start to import the work "([^\"]*)"(?: by "([^\"]*)" with email "([^\"]
   end
 end
 
-When /^I import the work "([^\"]*)"(?: by "([^\"]*)" with email "([^\"]*)")?(?: and by "([^\"]*)" with email "([^\"]*)")?$/ do
+When /^I import the work "(.*?)"(?: by "(.*?)" with email "(.*?)")?(?: and by "(.*?)" with email "(.*?)")?$/ do
       |url, creator_name, creator_email, cocreator_name, cocreator_email|
   step(%{I go to the import page})
   step(%{I check "Import for others ONLY with permission"})


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-4692

## Purpose

Initial testing on my fix for AO3-4692 revealed that claiming a work (including automatic claiming when one author on an imported work already has an AO3 account) removes all other external authors from a work. This pull request fixes that issue.

## Testing

See the issue for testing notes.

Note: this is currently broken on Test.