### PR TITLE
AO3-4232 "If you accept cookies from our site" note floats oddly on wide screens

### DIFF
--- a/public/stylesheets/site/2.0/22-system-messages.css
+++ b/public/stylesheets/site/2.0/22-system-messages.css
@@ -18,6 +18,10 @@ System messages use the following colours:
   float: right;
 }
 
+p.message.footnote {
+  clear: both;
+}
+
 .datetime {
   font-family: monospace;
 }

--- a/public/stylesheets/site/2.0/22-system-messages.css
+++ b/public/stylesheets/site/2.0/22-system-messages.css
@@ -18,7 +18,7 @@ System messages use the following colours:
   float: right;
 }
 
-p.message.footnote {
+.message.footnote {
   clear: both;
 }
 


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-4232

## Purpose

makes the "if you accept cookies from our site and you choose proceed..." note sit beneath the proceed and go back buttons on all screen sizes.

## Testing

didn't seem to cause alignment issues when clicking around on other pages, but it'd be nice if the reviewer could double check 👌

tried to make the selector as specific as possible

## Credit

*What name do you want us to use to credit your work in the [Archive of Our Own's Release Notes](http://archiveofourown.org/admin_posts?tag=1)?*

cosette is fine!

*What pronouns do you prefer (she/her, he/him, zie/hir etc)?*

she/her is fine