### PR TITLE
AO3-4708 No padding around drafted works in yellow container

### DIFF
--- a/public/stylesheets/site/2.0/09-roles-states.css
+++ b/public/stylesheets/site/2.0/09-roles-states.css
@@ -10,7 +10,11 @@ http://otwcode.github.com/docs/front_end_coding/patterns/modifiers
 .draft {
   border: 2px dashed #aaa;
   padding: 0.643em;
-    border-radius: 0.5em;
+  border-radius: 0.5em;
+}
+
+works-drafts .module {
+  padding: 0.4em;
 }
 
 /*(these states spoof the ".navigation .current" style)*/


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-4708

## Purpose

adds some padding to the drafts container. this addition fixes it but i'm not sure i placed it in the right stylesheet... i did some searching but i couldn't quite figure out where this selector should be 😞