### PR TITLE
AO3-4692 - Remove archivist when all authors have been claimed

### DIFF
--- a/app/models/external_author.rb
+++ b/app/models/external_author.rb
@@ -66,12 +66,14 @@ class ExternalAuthor < ActiveRecord::Base
 
         # if previously claimed by this user, don't do it again
         unless work.users.include?(claiming_user)
-          # Add this user as a creator and remove archivist as creator if there are no other external authors associated with it
-          archivist = external_creatorship.archivist
+          # Get the pseud to associate with the work
           pseud_to_add = claiming_user.pseuds.select {|pseud| pseud.name == external_author_name.name}.first || claiming_user.default_pseud
 
-          if other_unclaimed_creators.empty? || other_unclaimed_creators.map(&:archivist).exclude?(archivist)
-            work.change_ownership(archivist, claiming_user, pseud_to_add)
+          # If there are no other unclaimed authors, or if none of the other unclaimed authors have the same archivist,
+          # remove this user's archivist from the work creators, else just add the claiming user
+          claiming_user_archivist = external_creatorship.archivist
+          if other_unclaimed_creators.map(&:archivist).exclude?(claiming_user_archivist)
+            work.change_ownership(claiming_user_archivist, claiming_user, pseud_to_add)
           else
             work.add_creator(claiming_user, pseud_to_add)
           end

--- a/app/models/external_author.rb
+++ b/app/models/external_author.rb
@@ -62,14 +62,15 @@ class ExternalAuthor < ActiveRecord::Base
       external_author_name.external_work_creatorships.each do |external_creatorship|
         work = external_creatorship.creation
         other_external_creators = work.external_creatorships - [external_creatorship]
+        other_unclaimed_creators = other_external_creators.reject(&:claimed?)
 
-        # if previously claimed, don't do it again
+        # if previously claimed by this user, don't do it again
         unless work.users.include?(claiming_user)
-          # remove archivist as owner if still on the work and there are no other external authors associated with it
-          # ()archivist might already be removed if another coauthor already claimed), then add user as owner
+          # Add this user as a creator and remove archivist as creator if there are no other external authors associated with it
           archivist = external_creatorship.archivist
           pseud_to_add = claiming_user.pseuds.select {|pseud| pseud.name == external_author_name.name}.first || claiming_user.default_pseud
-          if other_external_creators.empty? || !other_external_creators.map(&:archivist).include?(archivist)
+
+          if other_unclaimed_creators.empty? || other_unclaimed_creators.map(&:archivist).exclude?(archivist)
             work.change_ownership(archivist, claiming_user, pseud_to_add)
           else
             work.add_creator(claiming_user, pseud_to_add)

--- a/features/importing/archivist.feature
+++ b/features/importing/archivist.feature
@@ -62,6 +62,18 @@ Feature: Archivist bulk imports
       Then 1 email should be delivered to "a@ao3.org"
       And 1 email should be delivered to "b@ao3.org"
 
+  Scenario: Import a work for multiple authors with accounts should not display the archivist
+    Given the following activated users exist
+      | login | email |
+      | user1 | a@ao3.org |
+      | user2 | b@ao3.org |
+    When I go to the import page
+    And I import the work "http://ao3testing.dreamwidth.org/593.html" by "name1" with email "a@ao3.org" and by "name2" with email "b@ao3.org"
+    Then I should see "Story"
+      And I should see "user1"
+      And I should see "user2"
+      But I should not see "archivist" within ".byline"
+
   Scenario: Import multiple works as an archivist
     When I import the works "http://ao3testing.dreamwidth.org/593.html, http://ao3testing.dreamwidth.org/325.html"
     Then I should see multi-story import messages


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-4692

## Purpose

If all the external authors on a work have claimed their accounts, the archivist account that created them is lingering pointlessly. This removes it at that point.
