### PR TITLE
AO3-4232 "If you accept cookies from our site" note floats oddly on wide screens (PR2)

### DIFF
--- a/public/stylesheets/site/2.0/22-system-messages.css
+++ b/public/stylesheets/site/2.0/22-system-messages.css
@@ -1,4 +1,4 @@
-/* ==SYSTEM MESSAGES 
+/* ==SYSTEM MESSAGES
 System messages use the following colours:
 * notice => blue: success, messages, additional information, no action needed, can proceed
 * caution => yellow: user may wish to change their mind, action optional, can proceed
@@ -73,11 +73,17 @@ span.error {
   display: block;
 }
 
-/* ADMIN ANNOUNCEMENT BANNERS 
+/* contexts */
+
+.actions + .footnote {
+ clear: both;
+}
+
+/* ADMIN ANNOUNCEMENT BANNERS
 Set by an admin, these banners appear on every page until the user dismisses them or the admin deletes it
 default (no additional class) => blue like other notice messages
 event => red gradient with white text for fundraising, celebrations, other happy Org events
-alert => yellow-orange to alert users of problems or planned downtime 
+alert => yellow-orange to alert users of problems or planned downtime
 */
 
 .announcement {
@@ -99,7 +105,7 @@ alert => yellow-orange to alert users of problems or planned downtime
 }
 
 .announcement p.submit {
-  bottom: -0.25em; 
+  bottom: -0.25em;
   margin: 0;
   padding: 0;
   position: absolute;
@@ -110,7 +116,7 @@ alert => yellow-orange to alert users of problems or planned downtime
   background: #fff none;
   border: 1px solid #bbb;
   font-size: 0.875em;
-  padding: 0.25em 0.5em; 
+  padding: 0.25em 0.5em;
     border-radius: 2em;
 }
 
@@ -193,7 +199,7 @@ progress indicator colors are set in application.js */
   right: 0;
 }
 
-/* SYMBOLS (mostly help button, arguably an action but hey ho); 
+/* SYMBOLS (mostly help button, arguably an action but hey ho);
 IN REVIEW: this block is very old (2008), a bit wonky and has an unexpected effect on blurb that needs detangling so it might change a lot*/
 
 span.symbol {


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-4232

## Purpose

makes the "if you accept cookies from our site and you choose proceed..." note sit beneath the proceed and go back buttons on all screen sizes.

(second pull request; first one couldn't be altered) 😞