### PR TITLE
AO3-4493 Make long unsubscribe text wrap

### DIFF
--- a/public/stylesheets/site/2.0/03-region-header.css
+++ b/public/stylesheets/site/2.0/03-region-header.css
@@ -1,4 +1,4 @@
-/*==REGION: HEADER is #1 of the 4 regions shown on every page 
+/*==REGION: HEADER is #1 of the 4 regions shown on every page
 http://otwcode.github.com/docs/front_end_coding/patterns/supertypes
 notice that CSS3 declarations sit are indented twice (four spaces) and always come last*/
 
@@ -45,7 +45,7 @@ notice that CSS3 declarations sit are indented twice (four spaces) and always co
   background: #ddd;
 }
 
-#header .current { 
+#header .current {
   background: #ccc;
 }
 
@@ -256,7 +256,7 @@ notice that CSS3 declarations sit are indented twice (four spaces) and always co
   padding: 0.75em 0.5em 0.5em;
 }
 
-/* search */ 
+/* search */
 
 #header .search {
   float: right;
@@ -277,12 +277,11 @@ notice that CSS3 declarations sit are indented twice (four spaces) and always co
 #header #search .text {
   margin: 0.2857em 0.429em;
 }
- 
+
 #header #search .button {
-  height: auto;
   margin: 0;
 }
- 
+
 /*CONTEXT: collections*/
 
 #header h2 {

--- a/public/stylesheets/site/2.0/08-actions.css
+++ b/public/stylesheets/site/2.0/08-actions.css
@@ -55,7 +55,8 @@ label.action {
 }
 
 input[type="submit"] {
-  height: 1.929em;
+  height: auto;
+  white-space: normal;
 }
 
 p.submit, input.submit, dd.submit {
@@ -72,7 +73,7 @@ p.submit, input.submit, dd.submit {
   padding: 0;
 }
 
-/*subtypes and modes 
+/*subtypes and modes
 test note: this pagination clear needs to be kept an eye on*/
 
 ol.pagination, div.pagination, ol.year {
@@ -186,13 +187,13 @@ dl.stats + .landmark + .actions {
   padding: 0 0 0.15em 0;
 }
 
-.many p.actions { 
-  float: none; 
-  text-align: right; 
+.many p.actions {
+  float: none;
+  text-align: right;
 }
 
-.concise label.action { 
-  float: left; 
+.concise label.action {
+  float: left;
 }
 
 dd.any label.action {

--- a/public/stylesheets/site/2.0/18-zone-searchbrowse.css
+++ b/public/stylesheets/site/2.0/18-zone-searchbrowse.css
@@ -107,12 +107,6 @@ form.filters dl {
   padding-right: 0;
 }
 
-.filters .submit input {
-  height: 100%;
-  min-height: 1.286em;
-  white-space: normal;
-}
-
 form.filters dl dl {
   margin: 0;
   padding: 0;


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-4493

## Purpose

makes long unsubscribe text wrap inside button. 

for the text inside the unsubscribe buttons to wrap, the height must be set to auto and white-space must be set to normal... but if input[type="submit"] had been set to a height of 1.929em with a specific purpose in mind, we can also target only the buttons in the subscribe section with a selector like 

.subscription input[type="submit"]

that being said, i didn't notice any immediate changes in button heights when testing the change on other pages, but i'll continue to test different pages and check for possible height issues.