### PR TITLE
AO3-4524 Repairing broken/redirecting link to OTW FAQ

### DIFF
--- a/app/views/home/about.html.erb
+++ b/app/views/home/about.html.erb
@@ -15,5 +15,5 @@ commercial exploitation and legal challenge.") %></li>
 that seeks to promote scholarship on fanworks and practices.") %></li>
     </ul>
   </p>
-  <p><%= ts("You can find out more about the OTW and its projects at its website,") %> <%= link_to ts("transformativeworks.org"), "http://transformativeworks.org" %><%= ts(", and learn about how your financial support is vital to the continuation and expansion of the OTW's work on its") %> <%= link_to ts("FAQ page"), "http://transformativeworks.org/faq-page" %>.</p>
+  <p><%= ts("You can find out more about the OTW and its projects at its website,") %> <%= link_to ts("transformativeworks.org"), "http://transformativeworks.org" %><%= ts(", and learn about how your financial support is vital to the continuation and expansion of the OTW's work on its") %> <%= link_to ts("FAQ page"), "http://transformativeworks.org/faq" %>.</p>
 </div>


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-4524

## Purpose

the link to the OTW FAQ in the AO3 "about" page was reportedly broken (though it redirected me to the correct page). the link has been changed to lead the visitor directly to the OTW FAQ page.