### PR TITLE
AO3-3359 Add search button to top of advanced search form

### DIFF
--- a/app/views/works/_search_form.html.erb
+++ b/app/views/works/_search_form.html.erb
@@ -2,6 +2,7 @@
   <fieldset>
     <legend><%= ts('Work Info') %></legend>
     <h3 class="landmark heading"><%= ts('Work Info') %></h3>
+    <p class="submit"><%= f.submit ts('Search') %></p>
     <dl>
       <dt>
         <%= f.label :query, ts('Any Field') %>
@@ -9,19 +10,19 @@
       </dt>
       <dd>
         <%= f.text_field :query %>
-      </dd>      
+      </dd>
       <dt>
         <%= f.label :title, ts('Title') %>
       </dt>
       <dd>
         <%= f.text_field :title %>
-      </dd>      
+      </dd>
       <dt>
         <%= f.label :creator, ts('Author/Artist') %>
       </dt>
       <dd>
         <%= f.text_field :creator %>
-      </dd>  
+      </dd>
       <dt>
         <%= f.label :revised_at, ts('Date') %>
         <%= link_to_help "work-search-date-help" %>
@@ -57,7 +58,7 @@
       </dd>
     </dl>
   </fieldset>
-  
+
   <fieldset>
     <legend><%= ts('Work Tags') %> <%= link_to_help "work-search-tags-help" %></legend>
     <h3 class="landmark heading"><%= ts('Work Tags') %></h3>
@@ -90,7 +91,7 @@
             </li>
           <% end %>
         </ul>
-      </dd>      
+      </dd>
       <dt>
         <%= ts('Categories') %>
       </dt>
@@ -103,19 +104,19 @@
             </li>
           <% end %>
         </ul>
-      </dd>    
+      </dd>
       <dt>
         <%= f.label :character_names, ts('Characters') %>
       </dt>
       <dd>
         <%= f.text_field :character_names, autocomplete_options("character") %>
-      </dd>      
+      </dd>
       <dt>
         <%= f.label :relationship_names, ts('Relationships') %>
       </dt>
       <dd>
         <%= f.text_field :relationship_names, autocomplete_options("relationship") %>
-      </dd>      
+      </dd>
       <dt>
         <%= f.label :freeform_names, ts('Additional Tags') %>
       </dt>
@@ -124,7 +125,7 @@
       </dd>
     </dl>
   </fieldset>
-  
+
   <fieldset>
     <legend><%= ts('Work Stats') %> <%= link_to_help "work-search-numerical-help" %></legend>
     <h3 class="landmark heading"><%= ts('Work Stats') %></h3>
@@ -155,7 +156,7 @@
       </dd>
     </dl>
   </fieldset>
-  
+
   <fieldset>
     <legend><%= ts('Search') %></legend>
     <h3 class="landmark heading"><%= ts('Search') %></h3>
@@ -170,12 +171,12 @@
         <%= f.label :sort_direction, ts("Sort direction") %>
       </dt>
       <dd>
-        <%= select_tag "work_search[sort_direction]", 
+        <%= select_tag "work_search[sort_direction]",
           '<option value="asc">Ascending</option><option value="desc">Descending</option>'.html_safe,
-          {:include_blank => true } %> 
+          {:include_blank => true } %>
       </dd>
     </dl>
     <p class="submit"><%= f.submit ts('Search') %></p>
   </fieldset>
-  
+
 <% end %>

--- a/app/views/works/_search_form.html.erb
+++ b/app/views/works/_search_form.html.erb
@@ -2,6 +2,7 @@
   <fieldset>
     <legend><%= ts('Work Info') %></legend>
     <h3 class="landmark heading"><%= ts('Work Info') %></h3>
+    <p class="submit"><%= f.submit ts('Search') %></p>
     <dl>
       <dt>
         <%= f.label :query, ts('Any Field') %>

--- a/app/views/works/_search_form.html.erb
+++ b/app/views/works/_search_form.html.erb
@@ -2,7 +2,6 @@
   <fieldset>
     <legend><%= ts('Work Info') %></legend>
     <h3 class="landmark heading"><%= ts('Work Info') %></h3>
-    <p class="submit"><%= f.submit ts('Search') %></p>
     <dl>
       <dt>
         <%= f.label :query, ts('Any Field') %>

--- a/public/stylesheets/sandbox.css
+++ b/public/stylesheets/sandbox.css
@@ -1,22 +1,29 @@
-/*==SANDBOX: All temporary, development, and unreviewed css lives here. 
-Rules will be incorporated into the main cascade by Front End before deploy. 
-If you've just coded up a new feature and put in some layout, put that layout here, 
-with a comment, and the Front End Santa will make your wishes come true. 
-Or if you've put in a fix and you've not yet read the Front End Docs? 
+/*==SANDBOX: All temporary, development, and unreviewed css lives here.
+Rules will be incorporated into the main cascade by Front End before deploy.
+If you've just coded up a new feature and put in some layout, put that layout here,
+with a comment, and the Front End Santa will make your wishes come true.
+Or if you've put in a fix and you've not yet read the Front End Docs?
 Put your fix in here.
 Examples:
 
-/*Fix for issue 996 
+/*Fix for issue 996
 .bookmark .header {float:left;}
 
-/*Draft layout for views/shiny/new by astolat. 
+/*Draft layout for views/shiny/new by astolat.
 It has to be purple, see wiki, ADT meeting 25
-.shiny-happy-people table {display:table-cell; 
+.shiny-happy-people table {display:table-cell;
 background:purple; color:#555;}
 
 /*Some helpful notes
 0.875em/1.286 line height = 14px with 18px leading
 0.643em  = 9px, so {margin: 0.643em auto;} gives you a single blank line between block elements */
+
+/* Possible solution for AO3-3359
+add <p class="submit"><%= f.submit ts('Search') %></p>
+to line 5 of app/views/works/_search_form.html.erb
+then add #new_work_search fieldset:first-of-type .submit {padding-top: 0;}
+to public/stylesheets/site/2.0/08-actions.css
+*/
 
 /* Issue 3243 needs nested ul to be indented in external_authors/claim
 */

--- a/public/stylesheets/sandbox.css
+++ b/public/stylesheets/sandbox.css
@@ -18,12 +18,11 @@ background:purple; color:#555;}
 0.875em/1.286 line height = 14px with 18px leading
 0.643em  = 9px, so {margin: 0.643em auto;} gives you a single blank line between block elements */
 
-/* Possible solution for AO3-3359
-add <p class="submit"><%= f.submit ts('Search') %></p>
-to line 5 of app/views/works/_search_form.html.erb
-then add #new_work_search fieldset:first-of-type .submit {padding-top: 0;}
-to public/stylesheets/site/2.0/08-actions.css
-*/
+/* styling for AO3-3359 to remove top padding from the new button
+and preserve the balance/symmetry of the page */
+#new_work_search fieldset:first-of-type .submit {
+  padding-top: 0;
+}
 
 /* Issue 3243 needs nested ul to be indented in external_authors/claim
 */

--- a/public/stylesheets/site/2.0/08-actions.css
+++ b/public/stylesheets/site/2.0/08-actions.css
@@ -148,10 +148,6 @@ ul#skiplinks, .landmark, .landmark a, .index .heading.landmark {
 
 /* CONTEXTS */
 
-#new_work_search fieldset:first-of-type .submit {
-  padding-top: 0;
-}
-
 .heading .actions, .heading .action, .heading span.actions {
   height: auto;
   font: 100 75%/1.286 'Lucida Grande', 'Lucida Sans Unicode', 'Arial Unicode MS', 'GNU Unifont',sans-serif;

--- a/public/stylesheets/site/2.0/08-actions.css
+++ b/public/stylesheets/site/2.0/08-actions.css
@@ -72,7 +72,7 @@ p.submit, input.submit, dd.submit {
   padding: 0;
 }
 
-/*subtypes and modes 
+/*subtypes and modes
 test note: this pagination clear needs to be kept an eye on*/
 
 ol.pagination, div.pagination, ol.year {
@@ -148,6 +148,10 @@ ul#skiplinks, .landmark, .landmark a, .index .heading.landmark {
 
 /* CONTEXTS */
 
+#new_work_search fieldset:first-of-type .submit {
+  padding-top: 0;
+}
+
 .heading .actions, .heading .action, .heading span.actions {
   height: auto;
   font: 100 75%/1.286 'Lucida Grande', 'Lucida Sans Unicode', 'Arial Unicode MS', 'GNU Unifont',sans-serif;
@@ -186,13 +190,13 @@ dl.stats + .landmark + .actions {
   padding: 0 0 0.15em 0;
 }
 
-.many p.actions { 
-  float: none; 
-  text-align: right; 
+.many p.actions {
+  float: none;
+  text-align: right;
 }
 
-.concise label.action { 
-  float: left; 
+.concise label.action {
+  float: left;
 }
 
 dd.any label.action {


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-3359

## Purpose

adds a search button to the top of the advanced search form, and removes top padding from the new button to preserve the balance/symmetry of the page. (tried to make sure the selector would only target that one submit button, since this styling isn't necessary for any other buttons i don't think...)

## Testing

the changes shouldn't affect any other forms (or submit buttons) on the site.