### PR TITLE
AO3-4716 Add bulk email search feature in admin section

### DIFF
--- a/app/controllers/admin/admin_users_controller.rb
+++ b/app/controllers/admin/admin_users_controller.rb
@@ -19,7 +19,7 @@ class Admin::AdminUsersController < ApplicationController
       if params[:download_button]
         header = [["Email", "Username"]]
         found = all_users.map { |u| [u.email, u.login] }
-        not_found = @not_found.map { |email| [email, ""]}
+        not_found = @not_found.map { |email| [email, ""] }
         send_csv_data(header + found + not_found, "bulk_user_search_#{Time.now.strftime('%Y-%m-%d-%H%M')}.csv")
         flash.now[:notice] = ts("Downloaded CSV")
       end

--- a/app/controllers/admin/admin_users_controller.rb
+++ b/app/controllers/admin/admin_users_controller.rb
@@ -4,26 +4,29 @@ class Admin::AdminUsersController < ApplicationController
   before_filter :admin_only
 
   def index
-    @roles = Role.assignable.uniq
     @role_values = @roles.map{ |role| [role.name.humanize.titlecase, role.name] }
     @role = Role.find_by_name(params[:role]) if params[:role]
     @users = User.search_by_role(@role, params[:query], inactive: params[:inactive], page: params[:page])
   end
 
   def bulk_search
-    @roles = Role.assignable.uniq
     @emails = params[:emails].split if params[:emails]
     unless @emails.nil? || @emails.blank?
       all_users, @not_found = User.search_multiple_by_email(@emails)
       @users = all_users.paginate(page: params[:page] || 1)
       if params[:download_button]
-        header = [["Email", "Username"]]
+        header = [%w(Email Username)]
         found = all_users.map { |u| [u.email, u.login] }
         not_found = @not_found.map { |email| [email, ""] }
-        send_csv_data(header + found + not_found, "bulk_user_search_#{Time.now.strftime('%Y-%m-%d-%H%M')}.csv")
+        send_csv_data(header + found + not_found, "bulk_user_search_#{Time.now.strftime("%Y-%m-%d-%H%M")}.csv")
         flash.now[:notice] = ts("Downloaded CSV")
       end
     end
+  end
+
+  before_filter :set_roles, only: [:index, :bulk_search]
+  def set_roles
+    @roles = Role.assignable.uniq
   end
 
   # GET admin/users/1
@@ -32,7 +35,7 @@ class Admin::AdminUsersController < ApplicationController
     @hide_dashboard = true
     @user = User.find_by_login(params[:id])
     unless @user
-      redirect_to :action => "index", :query => params[:query], :role => params[:role]
+      redirect_to action: "index", query: params[:query], role: params[:role]
     end
     @log_items = @user.log_items.sort_by(&:created_at).reverse
   end
@@ -41,7 +44,7 @@ class Admin::AdminUsersController < ApplicationController
   def edit
     @user = User.find_by_login(params[:id])
     unless @user
-      redirect_to :action => "index", :query => params[:query], :role => params[:role]
+      redirect_to action: "index", query: params[:query], role: params[:role]
     end
   end
 
@@ -50,43 +53,43 @@ class Admin::AdminUsersController < ApplicationController
     if params[:id]
       @user = User.find_by_login(params[:id])
       if @user.admin_update(params[:user])
-        flash[:notice] = ts('User was successfully updated.')
+        flash[:notice] = ts("User was successfully updated.")
         redirect_to(request.env["HTTP_REFERER"] || root_path)
       else
-        flash[:error] = ts('There was an error updating user %{name}', :name => params[:id])
+        flash[:error] = ts("There was an error updating user %{name}", name: params[:id])
         redirect_to(request.env["HTTP_REFERER"] || root_path)
       end
     else
       @admin_note = params[:admin_note]
       # default note for spammers
-      @admin_note = (@admin_note.blank? ? "Banned for spam" : @admin_note) if params[:admin_action] == 'spamban'
+      @admin_note = (@admin_note.blank? ? "Banned for spam" : @admin_note) if params[:admin_action] == "spamban"
       
       @user = User.find_by_login(params[:user_login])
       submitted_kin_user = User.find_by_login(params[:next_of_kin_name])
 
       # there is a next of kin username, but no email
       if params[:next_of_kin_name].present? && params[:next_of_kin_email].blank?
-        flash[:error] = ts('Fannish next of kin email is missing.')
+        flash[:error] = ts("Fannish next of kin email is missing.")
         redirect_to request.referer || root_path
 
       # there is a next of kin email, but no username
       elsif params[:next_of_kin_name].blank? && params[:next_of_kin_email].present?
-        flash[:error] = ts('Fannish next of kin user is missing.')
+        flash[:error] = ts("Fannish next of kin user is missing.")
         redirect_to request.referer || root_path
 
       # there is a next of kin username, but it is not a valid user
       elsif params[:next_of_kin_name].present? && submitted_kin_user.nil?
-        flash[:error] = ts('Fannish next of kin user is invalid.')
+        flash[:error] = ts("Fannish next of kin user is invalid.")
         redirect_to request.referer || root_path
 
       # there is an admin action selected, but no note entered
       elsif params[:admin_action].present? && @admin_note.blank?
-        flash[:error] = ts('You must include notes in order to perform this action.')
+        flash[:error] = ts("You must include notes in order to perform this action.")
         redirect_to request.referer || root_path
 
       # there is no length entered for the suspension
-      elsif params[:admin_action] == 'suspend' && params[:suspend_days].blank?
-        flash[:error] = ts('Please enter the number of days for which the user should be suspended.')
+      elsif params[:admin_action] == "suspend" && params[:suspend_days].blank?
+        flash[:error] = ts("Please enter the number of days for which the user should be suspended.")
         redirect_to request.referer || root_path
 
       # we made it through without any errors, so let's do some stuff
@@ -98,73 +101,73 @@ class Admin::AdminUsersController < ApplicationController
           @user.fannish_next_of_kin = FannishNextOfKin.new(user_id: params[:user_login],
                                                            kin_id: submitted_kin_user.id,
                                                            kin_email: params[:next_of_kin_email])
-          success_message << ts('Fannish next of kin added.')
+          success_message << ts("Fannish next of kin added.")
         end
 
         # update the next of kin user if the field is present and changed
         if params[:next_of_kin_name].present? && !(submitted_kin_user.id == @user.fannish_next_of_kin.kin_id)
           @user.fannish_next_of_kin.kin_id = submitted_kin_user.id
           @user.fannish_next_of_kin.save
-          success_message << ts('Fannish next of kin user updated.')
+          success_message << ts("Fannish next of kin user updated.")
         end
 
         # update the next of kin email is the field is present and changed
         if params[:next_of_kin_email].present? && !(params[:next_of_kin_email] == @user.fannish_next_of_kin.kin_email)
           @user.fannish_next_of_kin.kin_email = params[:next_of_kin_email]
           @user.fannish_next_of_kin.save
-          success_message << ts('Fannish next of kin email updated.')
+          success_message << ts("Fannish next of kin email updated.")
         end
 
         # delete the next of kin if the fields are blank and changed
         if params[:next_of_kin_user].blank? && params[:next_of_kin_email].blank? && @user.fannish_next_of_kin
           @user.fannish_next_of_kin.destroy
-          success_message << ts('Fannish next of kin removed.')
+          success_message << ts("Fannish next of kin removed.")
         end
 
         # create warning
-        if params[:admin_action] == 'warn'
+        if params[:admin_action] == "warn"
           @user.create_log_item(action: ArchiveConfig.ACTION_WARN, note: @admin_note, admin_id: current_admin.id)
-          success_message << ts('Warning was recorded.')
+          success_message << ts("Warning was recorded.")
         end
 
         # create suspension
-        if params[:admin_action] == 'suspend'
+        if params[:admin_action] == "suspend"
           @user.suspended = true
           @suspension_days = params[:suspend_days].to_i
           @user.suspended_until = @suspension_days.days.from_now
           @user.create_log_item(action: ArchiveConfig.ACTION_SUSPEND, note: @admin_note, admin_id: current_admin.id, enddate: @user.suspended_until)
-          success_message << ts('User has been temporarily suspended.')
+          success_message << ts("User has been temporarily suspended.")
         end
 
         # create ban
-        if params[:admin_action] == 'ban' || params[:admin_action] == 'spamban'
+        if params[:admin_action] == "ban" || params[:admin_action] == "spamban"
           @user.banned = true
           @user.create_log_item(action: ArchiveConfig.ACTION_BAN, note: @admin_note, admin_id: current_admin.id)
-          success_message << ts('User has been permanently suspended.')
+          success_message << ts("User has been permanently suspended.")
         end
 
         # unsuspended suspended user
-        if params[:admin_action] == 'unsuspend' && @user.suspended?
+        if params[:admin_action] == "unsuspend" && @user.suspended?
           @user.suspended = false
           @user.suspended_until = nil
           if !@user.suspended && @user.suspended_until.blank?
             @user.create_log_item(action: ArchiveConfig.ACTION_UNSUSPEND, note: @admin_note, admin_id: current_admin.id)
-            success_message << ts('Suspension has been lifted.')
+            success_message << ts("Suspension has been lifted.")
           end
         end
 
         # unban banned user
-        if params[:admin_action] == 'unban' && @user.banned?
+        if params[:admin_action] == "unban" && @user.banned?
           @user.banned = false
           if !@user.banned?
             @user.create_log_item(action: ArchiveConfig.ACTION_UNSUSPEND, note: @admin_note, admin_id: current_admin.id)
-            success_message << ts('Suspension has been lifted.')
+            success_message << ts("Suspension has been lifted.")
           end
         end
 
         @user.save
         flash[:notice] = success_message
-        if params[:admin_action] == 'spamban'
+        if params[:admin_action] == "spamban"
           redirect_to confirm_delete_user_creations_admin_user_path(@user)
         else
           redirect_to request.referer || root_path
@@ -194,7 +197,7 @@ class Admin::AdminUsersController < ApplicationController
   def destroy_user_creations
     creations = @user.works + @user.bookmarks + @user.collections + @user.comments
     creations.each do |creation|
-      AdminActivity.log_action(current_admin, creation, action: 'destroy spam', summary: creation.inspect)
+      AdminActivity.log_action(current_admin, creation, action: "destroy spam", summary: creation.inspect)
       creation.mark_as_spam! if creation.respond_to?(:mark_as_spam!)
       creation.destroy
     end
@@ -206,7 +209,7 @@ class Admin::AdminUsersController < ApplicationController
     if params[:letter] && params[:letter].is_a?(String)
       letter = params[:letter][0,1]
     else
-      letter = '0'
+      letter = "0"
     end
     @all_users = User.alphabetical.starting_with(letter)
     @roles = Role.assignable.uniq
@@ -228,12 +231,12 @@ class Admin::AdminUsersController < ApplicationController
 
     if @users.nil? || @users.length == 0
       flash[:error] = ts("Who did you want to notify?")
-      redirect_to :action => :notify and return
+      redirect_to action: :notify and return
     end
 
     unless params[:subject] && !params[:subject].blank?
       flash[:error] = ts("Please enter a subject.")
-      redirect_to :action => :notify and return
+      redirect_to action: :notify and return
     else
       @subject = params[:subject]
     end
@@ -241,7 +244,7 @@ class Admin::AdminUsersController < ApplicationController
     # We need to use content because otherwise html will be stripped
     unless params[:content] && !params[:content].blank?
       flash[:error] = ts("What message did you want to send?")
-      redirect_to :action => :notify and return
+      redirect_to action: :notify and return
     else
       @message = params[:content]
     end
@@ -252,8 +255,8 @@ class Admin::AdminUsersController < ApplicationController
 
     AdminMailer.archive_notification(current_admin.login, @users.map(&:id), @subject, @message).deliver
 
-    flash[:notice] = ts("Notification sent to %{count} user(s).", :count => @users.size)
-    redirect_to :action => :notify
+    flash[:notice] = ts("Notification sent to %{count} user(s).", count: @users.size)
+    redirect_to action: :notify
   end
 
   def troubleshoot
@@ -263,8 +266,8 @@ class Admin::AdminUsersController < ApplicationController
     @user.set_user_work_dates
     @user.reindex_user_bookmarks
     @user.create_log_item(options = { action: ArchiveConfig.ACTION_TROUBLESHOOT, admin_id: current_admin.id })
-    flash[:notice] = ts('User account troubleshooting complete.')
-    redirect_to(request.env['HTTP_REFERER'] || root_path) && return
+    flash[:notice] = ts("User account troubleshooting complete.")
+    redirect_to(request.env["HTTP_REFERER"] || root_path) && return
   end
 
 
@@ -272,12 +275,12 @@ class Admin::AdminUsersController < ApplicationController
     @user = User.find_by_login(params[:id])
     @user.activate
     if @user.active?
-      @user.create_log_item( options = {:action => ArchiveConfig.ACTION_ACTIVATE, :note => 'Manually Activated', :admin_id => current_admin.id})
-      flash[:notice] = t('activated', :default => "User Account Activated")
-      redirect_to :action => :show
+      @user.create_log_item( options = { action: ArchiveConfig.ACTION_ACTIVATE, note: "Manually Activated", admin_id: current_admin.id })
+      flash[:notice] = ts("User Account Activated")
+      redirect_to action: :show
     else
-      flash[:error] = t('activation_failed', :default => "Attempt to activate account failed.")
-      redirect_to :action => :show
+      flash[:error] = ts("Attempt to activate account failed.")
+      redirect_to action: :show
     end
   end
 
@@ -285,8 +288,8 @@ class Admin::AdminUsersController < ApplicationController
     @user = User.find_by_login(params[:id])
     # send synchronously to avoid getting caught in mail queue
     UserMailer.signup_notification(@user.id).deliver! 
-    flash[:notice] = t('activation_sent', :default => "Activation email sent")
-    redirect_to :action => :show
+    flash[:notice] = ts("Activation email sent")
+    redirect_to action: :show
   end
 
 end

--- a/app/controllers/challenge_signups_controller.rb
+++ b/app/controllers/challenge_signups_controller.rb
@@ -309,13 +309,14 @@ protected
     csv_array = []
     csv_array << header
     @collection.prompts.where(type: "Request").each do |request|
-      if request.anonymous?
-        row = ["(Anonymous)", "", ""]
-      else
-        row = [request.challenge_signup.pseud.name,
-               request.challenge_signup.pseud.user.email,
-               collection_signup_url(@collection, request.challenge_signup)]
-      end
+      row =
+        if request.anonymous?
+          ["(Anonymous)", "", ""]
+        else
+          [request.challenge_signup.pseud.name,
+           request.challenge_signup.pseud.user.email,
+           collection_signup_url(@collection, request.challenge_signup)]
+        end
       csv_array << (row + request_to_array("request", request))
     end
 

--- a/app/controllers/challenge_signups_controller.rb
+++ b/app/controllers/challenge_signups_controller.rb
@@ -2,6 +2,7 @@
 require 'csv'
 
 class ChallengeSignupsController < ApplicationController
+  include ExportsHelper
 
   before_filter :users_only, :except => [:summary, :display_summary, :requests_summary]
   before_filter :load_collection, :except => [:index]
@@ -95,7 +96,7 @@ class ChallengeSignupsController < ApplicationController
     end
 
     # using respond_to in order to provide Excel output
-    # see below for export_csv method
+    # see ExportsHelper for export_csv method
     respond_to do |format|
       format.html {
           if @challenge.user_allowed_to_see_signups?(current_user)
@@ -114,7 +115,9 @@ class ChallengeSignupsController < ApplicationController
       format.csv {
         if (@collection.gift_exchange? && @challenge.user_allowed_to_see_signups?(current_user)) || 
         (@collection.prompt_meme? && @collection.user_is_maintainer?(current_user))
-          export_csv
+          csv_data = self.send("#{@challenge.class.name.underscore}_to_csv")
+          filename = "#{@collection.name}_signups_#{Time.now.strftime('%Y-%m-%d-%H%M')}.csv"
+          send_csv_data(csv_data, filename)
         else
           flash[:error] = ts("You aren't allowed to see the CSV summary.")
           redirect_to collection_path(@collection) rescue redirect_to '/' and return
@@ -266,7 +269,7 @@ protected
   def gift_exchange_to_csv
     header = ["Pseud", "Email", "Sign-up URL"]
 
-    ["request", "offer"].each do |type|
+    %w(request offer).each do |type|
       @challenge.send("#{type.pluralize}_num_allowed").times do |i|
         header << "#{type.capitalize} #{i+1} Tags"
         header << "#{type.capitalize} #{i+1} Optional Tags" if
@@ -278,23 +281,22 @@ protected
       end
     end
 
-    csv_data = CSV.generate(:col_sep => "\t", :encoding => "utf-8") do |csv|
-      csv << header
+    csv_array = []
+    csv_array << header
       
-      @collection.signups.each do |signup|
-        row = [signup.pseud.name, signup.pseud.user.email,
-               collection_signup_url(@collection, signup)]
+    @collection.signups.each do |signup|
+      row = [signup.pseud.name, signup.pseud.user.email,
+             collection_signup_url(@collection, signup)]
 
-        ["request", "offer"].each do |type|
-          @challenge.send("#{type.pluralize}_num_allowed").times do |i|
-            row += request_to_array(type, signup.send(type.pluralize)[i])
-          end
+      %w(request offer).each do |type|
+        @challenge.send("#{type.pluralize}_num_allowed").times do |i|
+          row += request_to_array(type, signup.send(type.pluralize)[i])
         end
-        csv << row
       end
+      csv << row
     end
 
-    return csv_data
+    csv_array
   end
 
   
@@ -304,36 +306,19 @@ protected
     header << "Description" if @challenge.request_restriction.description_allowed
     header << "URL" if @challenge.request_restriction.url_allowed
 
-    csv_data = CSV.generate(:col_sep => "\t", :encoding => "utf-8") do |csv|
-      csv << header
-      @collection.prompts.where(:type => 'Request').each do |request|
-        if request.anonymous?
-          row = ["(Anonymous)", "", ""]
-        else
-          row = [request.challenge_signup.pseud.name,
-                 request.challenge_signup.pseud.user.email,
-                 collection_signup_url(@collection, request.challenge_signup)]
-        end
-
-        csv << (row + request_to_array("request", request))
+    csv_array = []
+    csv_array << header
+    @collection.prompts.where(type: "Request").each do |request|
+      if request.anonymous?
+        row = ["(Anonymous)", "", ""]
+      else
+        row = [request.challenge_signup.pseud.name,
+               request.challenge_signup.pseud.user.email,
+               collection_signup_url(@collection, request.challenge_signup)]
       end
+      csv_array << (row + request_to_array("request", request))
     end
 
-    return csv_data
+    csv_array
   end
-
-  
-  # Tab-separated CSV with utf-16le encoding (unicode) and byte order
-  # mark. This seems to be the only variant Excel can get
-  # automatically into proper table format. OpenOffice handles it
-  # well, too.
-  def export_csv
-    csv_data = self.send("#{@challenge.class.name.underscore}_to_csv")
-    filename = "#{@collection.name}_signups_#{Time.now.strftime('%Y-%m-%d-%H%M')}.csv"
-
-    byte_order_mark = "\uFEFF"
-    csv_data = (byte_order_mark + csv_data).encode("utf-16le", "utf-8", :invalid => :replace, :undef => :replace, :replace => "")
-    send_data(csv_data, :filename => filename, :type => :csv)
-  end
-  
 end

--- a/app/helpers/exports_helper.rb
+++ b/app/helpers/exports_helper.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ExportsHelper
 
   def send_csv_data(content_array, filename)
@@ -9,7 +10,7 @@ module ExportsHelper
   # automatically into proper table format. OpenOffice handles it
   # well, too.
   def export_csv(content_array)
-    csv_data = content_array.map {|x| x.to_csv(col_sep: "\t", encoding: "utf-8")}.join
+    csv_data = content_array.map { |x| x.to_csv(col_sep: "\t", encoding: "utf-8") }.join
     byte_order_mark = "\uFEFF"
     (byte_order_mark + csv_data).encode("utf-16le", "utf-8", invalid: :replace, undef: :replace, replace: "")
   end

--- a/app/helpers/exports_helper.rb
+++ b/app/helpers/exports_helper.rb
@@ -1,0 +1,16 @@
+module ExportsHelper
+
+  def send_csv_data(content_array, filename)
+    send_data(export_csv(content_array), filename: filename, type: :csv)
+  end
+
+  # Tab-separated CSV with utf-16le encoding (unicode) and byte order
+  # mark. This seems to be the only variant Excel can get
+  # automatically into proper table format. OpenOffice handles it
+  # well, too.
+  def export_csv(content_array)
+    csv_data = content_array.map {|x| x.to_csv(col_sep: "\t", encoding: "utf-8")}.join
+    byte_order_mark = "\uFEFF"
+    (byte_order_mark + csv_data).encode("utf-16le", "utf-8", invalid: :replace, undef: :replace, replace: "")
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -272,7 +272,14 @@ class User < ActiveRecord::Base
     if query.present?
       users = users.joins(:pseuds).where("pseuds.name LIKE ? OR email LIKE ?", "%#{query}%", "%#{query}%")
     end
-    users.paginate(:page => options[:page] || 1)
+    users.paginate(page: options[:page] || 1)
+  end
+
+  def self.search_multiple_by_email(emails = [])
+    users = User.where(email: emails)
+    found_emails = users.map(&:email)
+    not_found = emails - found_emails
+    [users, not_found]
   end
 
   ### AUTHENTICATION AND PASSWORDS

--- a/app/views/admin/_header.html.erb
+++ b/app/views/admin/_header.html.erb
@@ -1,6 +1,12 @@
 <h3 class="landmark heading"><%= ts("Admin Navigation", key: "header") %></h3>
 <ul class="admin primary navigation actions" role="navigation">
-  <li><%= link_to ts("Manage Users", key: "header"), admin_users_path %></li>
+  <li class="dropdown">
+    <%= link_to ts("Manage Users", key: "header"), admin_users_path %>
+    <ul class="menu" role="menu">
+      <li><%= link_to ts("Find Users", key: "header"), admin_users_path %></li>
+      <li><%= link_to ts("Bulk Email Search", key: "header"), bulk_search_admin_users_path %></li>
+    </ul>
+  </li>
   <li><%= link_to ts("Notifications", key: "header"), notify_admin_users_path %></li>
   <li class="dropdown">
     <%= link_to ts("Invitations", key: "header"), admin_invitations_path %>

--- a/app/views/admin/admin_users/_user_table.html.erb
+++ b/app/views/admin/admin_users/_user_table.html.erb
@@ -1,0 +1,33 @@
+<h3 class="heading"><%= ts("#{pluralize(@users.total_entries, 'user')} found") %></h3>
+<% if @users.size > 0 %>
+  <div class="wrapper">
+    <table id="admin_users_table" summary="<%= ts("Users matching your search criteria, as well as options for updating the user's roles and viewing more information.") %>">
+      <caption><%= ts("List of Users") %></caption>
+      <colgroup>
+        <col class="name"/>
+        <col span="6"/>
+      </colgroup>
+      <thead>
+      <tr>
+        <th scope="col"><%= ts("Username") %></th>
+        <th scope="col"><%= ts("Email") %></th>
+        <% for role in @roles %>
+          <th scope="col"><%= role.name.try(:titleize) %></th>
+        <% end %>
+        <th scope="col"><%= ts("Fannish Next of Kin") %></th>
+        <th scope="col"><%= ts("Update") %></th>
+        <th scope="col"><%= ts("Details") %></th>
+      </tr>
+      </thead>
+      <tbody>
+      <% @users.each do |user| %>
+        <tr id="user_<%= user.id %>">
+          <%= render "user_form", user: user %>
+        </tr>
+      <% end %>
+      </tbody>
+    </table>
+  </div>
+  <%= will_paginate @users %>
+<% end %>
+<!--/content-->

--- a/app/views/admin/admin_users/bulk_search.html.erb
+++ b/app/views/admin/admin_users/bulk_search.html.erb
@@ -4,8 +4,8 @@
   <!--/descriptions-->
 
   <!--main content-->
-  <div class="notice">
-    <p><%= ts("Please enter a list of email addresses to search below. This form will search for <strong>exact</strong> matches.").html_safe %></p>
+  <div>
+    <p class="notice"><%= ts("Please enter a list of email addresses to search below. This form will search for <strong>exact</strong> matches.").html_safe %></p>
   </div>
 
   <%= form_tag url_for(controller: "admin/admin_users", action: :bulk_search, method: :post), class: "search", role: "search" do %>

--- a/app/views/admin/admin_users/bulk_search.html.erb
+++ b/app/views/admin/admin_users/bulk_search.html.erb
@@ -1,0 +1,45 @@
+<div class="admin">
+  <!--Descriptive page name, messages and instructions-->
+  <h2 class="heading"><%= ts("Bulk Email Search") %></h2>
+  <!--/descriptions-->
+
+  <!--main content-->
+  <div class="notice">
+    <p><%= ts("Please enter a list of email addresses to search below. This form will search for <strong>exact</strong> matches.").html_safe %></p>
+  </div>
+
+  <%= form_tag url_for(controller: "admin/admin_users", action: :bulk_search, method: :post), class: "search", role: "search" do %>
+    <fieldset>
+      <legend><%= ts("Email addresses") %></legend>
+      <dl>
+        <dt class="required"><%= label_tag "emails", ts("Email addresses *") %></dt>
+        <dd class="required"><%= text_area_tag "emails", @emails ? @emails.join("\n") : "", rows: 10, cols: 70, "aria-describedby" => "url-field-description" %>
+          <p class="footnote" id="url-field-description">
+            <%= ts("Emails to find; <strong>one URL per line.</strong>").html_safe %>
+          </p>
+        </dd>
+      </dl>
+    </fieldset>
+
+    <fieldset>
+      <legend><%= ts("Find") %></legend>
+      <p class="submit actions">
+        <%= submit_tag ts("Download CSV"), name: "download_button" %>
+        <%= submit_tag ts("Find") %>
+      </p>
+    </fieldset>
+  <% end %>
+
+  <% if @not_found || @users %>
+    <p><%= ts("#{@emails.size} emails searched. #{@emails.size - @not_found.size} found. #{@not_found.size} not found.") %></p>
+
+    <% unless @not_found.empty? %>
+      <h3 class="heading"><%= ts("Not found") %></h3>
+      <p><%= @not_found.join(",") %></p>
+    <% end %>
+
+    <% if @users %>
+      <%= render "user_table", users: @users %>
+    <% end %>
+  <% end %>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -153,6 +153,8 @@ Otwarchive::Application.routes.draw do
       end
       collection do
         get :notify
+        get :bulk_search
+        post :bulk_search
         post :send_notification
         post :update_user
       end

--- a/features/admins/users/admin_find_users.feature
+++ b/features/admins/users/admin_find_users.feature
@@ -3,34 +3,82 @@ Feature: Admin Find Users page
   Background:
     Given I have loaded the "roles" fixture
       And the following activated users exist
-        | login | email     |
-        | userA | a@ao3.org |
-        | userB | b@bo3.org |
+        | login  | email      |
+        | userA  | a@ao3.org  |
+        | userB  | b@bo3.org  |
+        | userCB | cb@bo3.org |
       And the user "userB" exists and has the role "archivist"
       And I am logged in as an admin
 
   Scenario: The default page for the Admin section should be the Find Users page
     Then I should see "Find Users"
 
-  Scenario: It should perform a partial match on name
+  Scenario: The Find Users page should perform a partial match on name
     When I fill in "query" with "user"
       And I submit
     Then I should see "userA"
       And I should see "userB"
+      And I should see "userCB"
 
-  Scenario: It should perform a partial match by email
+  Scenario: The Find Users page should perform a partial match by email
     When I fill in "query" with "bo3"
       And I submit
     Then I should see "userB"
+      And I should see "userCB"
       But I should not see "userA"
 
-  Scenario: It should perform an exact match by role
+  Scenario: The Find Users page should perform an exact match by role
     When I select "Archivist" from "role"
       And I submit
     Then I should see "userB"
       But I should not see "userA"
+      And I should not see "userCB"
 
-  Scenario: It should display an appropriate message if no users are found
+  Scenario: The Find Users should display an appropriate message if no users are found
     When I fill in "query" with "co3"
       And I submit
     Then I should see "0 users found"
+
+  # Bulk email search
+  Scenario: The Bulk Email Search page should find all existing matching users
+    When I go to the Bulk Email Search page
+      And I fill in "Email addresses *" with
+      """
+        b@bo3.org
+        a@ao3.org
+      """
+      And I press "Find"
+    Then I should see "userB"
+      And I should see "userA"
+      But I should not see "userCB"
+
+  Scenario: The Bulk Email Search page should list emails found and not found
+    When I go to the Bulk Email Search page
+      And I fill in "Email addresses *" with
+      """
+        b@bo3.org
+        a@ao3.org
+        c@co3.org
+      """
+      And I press "Find"
+    Then I should see "2 found"
+      And I should see "1 not found"
+
+  Scenario: The Bulk Email Search page should find an exact match
+    When I go to the Bulk Email Search page
+      And I fill in "Email addresses *" with "b@bo3.org"
+      And I press "Find"
+    Then I should see "userB"
+      But I should not see "userA"
+      And I should not see "userCB"
+
+   Scenario: Admins can download a CSV of found emails
+     When I go to the Bulk Email Search page
+      And I fill in "Email addresses *" with
+      """
+        b@bo3.org
+        a@ao3.org
+        c@co3.org
+      """
+      And I press "Download CSV"
+     Then I should download a csv file with 4 rows and the header row "Email Username"

--- a/features/admins/users/admin_manage_users.feature
+++ b/features/admins/users/admin_manage_users.feature
@@ -2,7 +2,7 @@
 Feature: Admin Actions to manage users
   In order to manage user accounts
   As an an admin
-  I want to be able to look up and edit individual users
+  I want to be able to edit individual users
 
   Scenario: Admin can update a user's email address and roles
     Given the following activated user exists

--- a/features/gift_exchanges/challenge_giftexchange.feature
+++ b/features/gift_exchanges/challenge_giftexchange.feature
@@ -407,14 +407,13 @@ Feature: Gift Exchange Challenge
     Then I should see "myname1"
       And I should see "Fulfilled Story"
 
-
   Scenario: Download signups CSV
     Given I am logged in as "mod1"
     And I have created the gift exchange "My Gift Exchange"
 
     When I go to the "My Gift Exchange" signups page
     And I follow "Download (CSV)"
-    Then I should get a file with ending and type csv
+    Then I should download a csv file with the header row "Pseud Email Sign-up URL Request 1 Tags Request 1 Description Offer 1 Tags Offer 1 Description"
 
   Scenario: View a signup summary with no tags
     Given the following activated users exist

--- a/features/prompt_memes_c/challenge_promptmeme_claims.feature
+++ b/features/prompt_memes_c/challenge_promptmeme_claims.feature
@@ -387,7 +387,7 @@ Feature: Prompt Meme Challenge
     And I create Battle 12 promptmeme
   When I go to the "Battle 12" signups page
     And I follow "Download (CSV)"
-  Then I should get a file with ending and type csv
+  Then I should download a csv file with the header row "Pseud Email Sign-up URL Tags Description"
 
   Scenario: Can't download prompt CSV from requests page
   # it's aimed at users, not mods

--- a/features/step_definitions/web_steps.rb
+++ b/features/step_definitions/web_steps.rb
@@ -296,7 +296,7 @@ end
 Then /^I should download a ([^"]*) file with(?: (\d+) rows and)? the header row "(.*?)"$/ do |type, rows, header|
   page.response_headers['Content-Disposition'].should =~ /attachment; filename=.*?\.#{type}/i
   page.response_headers['Content-Type'].should =~ /\/#{type}/i
-  body_without_bom = page.body.encode("UTF-8").gsub!("\xEF\xBB\xBF", "")
+  body_without_bom = page.body.encode("UTF-8").delete!("\xEF\xBB\xBF")
   csv = CSV.parse(body_without_bom, col_sep: "\t") # array of arrays
   expect(csv.first.join(" ")).to eq(header)
   expect(csv.size).to eq(rows.to_i) if rows

--- a/features/step_definitions/web_steps.rb
+++ b/features/step_definitions/web_steps.rb
@@ -293,9 +293,13 @@ Then /^(?:|I )should have the following query string:$/ do |expected_pairs|
   end
 end
 
-Then /^I should get a file with ending and type ([^\"]*)$/ do |type|
-  page.response_headers['Content-Disposition'].should =~ Regexp.new("filename=.*?\.#{type}")
-  page.response_headers['Content-Type'].should =~ Regexp.new("/#{type}")
+Then /^I should download a ([^"]*) file with(?: (\d+) rows and)? the header row "(.*?)"$/ do |type, rows, header|
+  page.response_headers['Content-Disposition'].should =~ /attachment; filename=.*?\.#{type}/i
+  page.response_headers['Content-Type'].should =~ /\/#{type}/i
+  body_without_bom = page.body.encode("UTF-8").gsub!("\xEF\xBB\xBF", "")
+  csv = CSV.parse(body_without_bom, col_sep: "\t") # array of arrays
+  expect(csv.first.join(" ")).to eq(header)
+  expect(csv.size).to == rows.to_i if rows
 end
 
 Then /^show me the page$/ do

--- a/features/step_definitions/web_steps.rb
+++ b/features/step_definitions/web_steps.rb
@@ -299,7 +299,7 @@ Then /^I should download a ([^"]*) file with(?: (\d+) rows and)? the header row 
   body_without_bom = page.body.encode("UTF-8").gsub!("\xEF\xBB\xBF", "")
   csv = CSV.parse(body_without_bom, col_sep: "\t") # array of arrays
   expect(csv.first.join(" ")).to eq(header)
-  expect(csv.size).to == rows.to_i if rows
+  expect(csv.size).to eq(rows.to_i) if rows
 end
 
 Then /^show me the page$/ do

--- a/features/support/paths.rb
+++ b/features/support/paths.rb
@@ -207,20 +207,20 @@ module NavigationHelpers
       fandom_path($1)
 
     # Admin Pages
-      when /^the admin-posts page$/i
-        admin_posts_path
-      when /^the admin-settings page$/i
-        admin_settings_path
-      when /^the admin-notices page$/i
-        notify_admin_users_path
-      when /^the admin-blacklist page$/i
-        admin_blacklisted_emails_path
-      when /^the manage users page$/
-        admin_users_path
-      when /^the bulk email search page$/i
-        bulk_search_admin_users_path
-      when /^the abuse administration page for "(.*)"$/i
-        admin_user_path(User.find_by_login($1))
+    when /^the admin-posts page$/i
+      admin_posts_path
+    when /^the admin-settings page$/i
+      admin_settings_path
+    when /^the admin-notices page$/i
+      notify_admin_users_path
+    when /^the admin-blacklist page$/i
+      admin_blacklisted_emails_path
+    when /^the manage users page$/
+      admin_users_path
+    when /^the bulk email search page$/i
+      bulk_search_admin_users_path
+    when /^the abuse administration page for "(.*)"$/i
+      admin_user_path(User.find_by_login($1))
 
     # Here is an example that pulls values out of the Regexp:
     #

--- a/features/support/paths.rb
+++ b/features/support/paths.rb
@@ -171,14 +171,6 @@ module NavigationHelpers
       collection_tag_works_url(Collection.find_by_title($2), Tag.find_by_name($1)).sub("http://www.example.com", "http://#{ArchiveConfig.APP_HOST}")
     when /^the tag comments? page for "(.*)"$/i
       tag_comments_path(Tag.find_by_name($1))
-    when /^the admin-posts page$/i
-      admin_posts_path
-    when /^the admin-settings page$/i
-      admin_settings_path
-    when /^the admin-notices page$/i
-      notify_admin_users_path
-    when /^the admin-blacklist page$/i
-      admin_blacklisted_emails_path
     when /^the FAQ reorder page$/i
       manage_archive_faqs_path
     when /^the Wrangling Guidelines reorder page$/i
@@ -197,10 +189,6 @@ module NavigationHelpers
       edit_tag_set_path(OwnedTagSet.find_by_title($1))
     when /^the "(.*)" tag ?set page$/i
       tag_set_path(OwnedTagSet.find_by_title($1))
-    when /^the manage users page$/
-      admin_users_path
-    when /^the abuse administration page for "(.*)"$/i
-      admin_user_path(User.find_by_login($1))
     when /^the Open Doors tools page$/i
       opendoors_tools_path
     when /^the Open Doors external authors page$/i
@@ -217,6 +205,22 @@ module NavigationHelpers
       tag_wranglings_path
     when /^the "(.*)" fandom relationship page$/i
       fandom_path($1)
+
+    # Admin Pages
+      when /^the admin-posts page$/i
+        admin_posts_path
+      when /^the admin-settings page$/i
+        admin_settings_path
+      when /^the admin-notices page$/i
+        notify_admin_users_path
+      when /^the admin-blacklist page$/i
+        admin_blacklisted_emails_path
+      when /^the manage users page$/
+        admin_users_path
+      when /^the bulk email search page$/i
+        bulk_search_admin_users_path
+      when /^the abuse administration page for "(.*)"$/i
+        admin_user_path(User.find_by_login($1))
 
     # Here is an example that pulls values out of the Regexp:
     #

--- a/spec/helpers/exports_helper_spec.rb
+++ b/spec/helpers/exports_helper_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # encoding: utf-8
 require 'spec_helper'
 

--- a/spec/helpers/exports_helper_spec.rb
+++ b/spec/helpers/exports_helper_spec.rb
@@ -1,0 +1,27 @@
+# encoding: utf-8
+require 'spec_helper'
+
+describe ExportsHelper do
+
+  context "tab-delimited file generation" do
+    header = ["Column 1", "Column 2", "Column 3"]
+
+    before do
+      array = [
+        header,
+        ["Thing 1", "Thing 2", "Thing 3"],
+        ["Foo 1", "Foo 2", "Foo 3"]
+      ]
+      result = export_csv(array)
+      text_without_bom = result.encode("UTF-8").sub!(/^\xEF\xBB\xBF/u, '')
+      @csv_array = CSV.parse(text_without_bom, col_sep: "\t")
+    end
+
+    it "should be a TSV file with the expected number of rows" do
+      expect(@csv_array.size).to eq(3)
+    end
+    it "should contain the right fields" do
+      expect(@csv_array.first).to eq(header)
+    end
+  end
+end


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-4716

## Purpose

Open Doors need to know if authors in external archives they are processing already have Archive accounts. This feature adds a new Bulk Email Search form in the Admin section which allows you to paste in a list of emails and then view which ones are associated with Archive users, and download the results as a CSV file.

## Testing

The **Bulk Email Search** feature is a new entry in Admin section > **Manage Users**. When you paste a list of line-break separated email addresses into the form and press **Find**, you should see:
- a plain comma-separated list of email addresses that weren't found
- a paginated table of user accounts for all the email addresses on the list that were found (this is the same table that appears when doing a normal search by user or email)
- if you press **Download CSV** instead of **Find**, you will get all of the above and your browser should download an Excel-friendly CSV file containing all the original addresses with their AO3 logins if they have one, or a blank cell in the Login column if they don't

The CSV code had to be moved out of the ChallengeSignupsController, so it is worth checking that prompt meme and gift exchange CSVs can still be downloaded (existing challenges would be enough to test this)
