### PR TITLE
AO3-4748 Give date on unposted prompt meme claims proper margin

### DIFF
--- a/public/stylesheets/site/2.0/13-group-blurb.css
+++ b/public/stylesheets/site/2.0/13-group-blurb.css
@@ -226,6 +226,7 @@ li.blurb:after, .blurb .blurb:after {
 }
 
 .claim .datetime {
+  margin-left: 65px;
   position: static;
 }
 


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-4748

## Purpose

On the Unposted Claims page prompt meme mods can see, stops the date a prompt was claimed from being partly hidden under the icon. (We don't usually use `px` for margins, but because we're dealing with an image here, we do. You can check line 49 of this file to see that `65px` is the same margin the headings above the claimed date have.)

## Testing

Refer to JIRA