### PR TITLE
AO3-4629 make download menu & chapter index menu sit lower on narrow screens

### DIFF
--- a/public/stylesheets/site/2.0/08-actions.css
+++ b/public/stylesheets/site/2.0/08-actions.css
@@ -168,10 +168,6 @@ dl.stats + .landmark + .actions {
   float: none;
 }
 
-.chapter .secondary, .download .secondary {
-  top: auto;
-}
-
 .dashboard .landmark {
   clear: right;
 }

--- a/public/stylesheets/site/2.0/08-actions.css
+++ b/public/stylesheets/site/2.0/08-actions.css
@@ -72,7 +72,7 @@ p.submit, input.submit, dd.submit {
   padding: 0;
 }
 
-/*subtypes and modes 
+/*subtypes and modes
 test note: this pagination clear needs to be kept an eye on*/
 
 ol.pagination, div.pagination, ol.year {
@@ -168,10 +168,6 @@ dl.stats + .landmark + .actions {
   float: none;
 }
 
-.chapter .secondary, .download .secondary {
-  top: 3.5em;
-}
-
 .dashboard .landmark {
   clear: right;
 }
@@ -186,13 +182,13 @@ dl.stats + .landmark + .actions {
   padding: 0 0 0.15em 0;
 }
 
-.many p.actions { 
-  float: none; 
-  text-align: right; 
+.many p.actions {
+  float: none;
+  text-align: right;
 }
 
-.concise label.action { 
-  float: left; 
+.concise label.action {
+  float: left;
 }
 
 dd.any label.action {

--- a/public/stylesheets/site/2.0/08-actions.css
+++ b/public/stylesheets/site/2.0/08-actions.css
@@ -168,6 +168,10 @@ dl.stats + .landmark + .actions {
   float: none;
 }
 
+.chapter .secondary, .download .secondary {
+  top: auto;
+}
+
 .dashboard .landmark {
   clear: right;
 }


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-4629

## Purpose

the download menu and chapter index menu were positioned at the top of the page on narrow screens; by removing `.chapter .secondary, .download .secondary { top: 3.5em; }` from **08-actions.css**, they sit naturally under their parent elements on all screen sizes. (tested on wide, medium, and narrow screen sizes in chrome, firefox, and safari).

## Testing

please go to a multichapter work and make sure that the chapter index menu sits below the chapter index button on all screen/window sizes, and that the download menu sits below the download button on all screen/window sizes.