### PR TITLE
AO3-4707 Add some specs for related works

### DIFF
--- a/factories/related_works.rb
+++ b/factories/related_works.rb
@@ -1,0 +1,21 @@
+require 'faker'
+
+FactoryGirl.define do
+  factory :related_work do
+    parent_type "Work"
+    parent_id { FactoryGirl.create(:work).id }
+    work_id { FactoryGirl.create(:work).id }
+  end
+
+  factory :related_work_known_parent do
+    parent_creator { FactoryGirl.create(:user) }
+    parent_work { FactoryGirl.create(:work, authors: [parent_creator.default_pseud]) }
+    parent_work { FactoryGirl.create(:related_work, work_id: parent_work.id) }
+  end
+
+  factory :related_work_known_child do
+    child_creator { FactoryGirl.create(:user) }
+    child_work { FactoryGirl.create(:work, authors: [child_creator.default_pseud]) }
+    related_work { FactoryGirl.create(:related_work, work_id: child_work.id) }
+  end
+end

--- a/factories/related_works.rb
+++ b/factories/related_works.rb
@@ -6,16 +6,4 @@ FactoryGirl.define do
     parent_id { FactoryGirl.create(:work).id }
     work_id { FactoryGirl.create(:work).id }
   end
-
-  factory :related_work_known_parent do
-    parent_creator { FactoryGirl.create(:user) }
-    parent_work { FactoryGirl.create(:work, authors: [parent_creator.default_pseud]) }
-    parent_work { FactoryGirl.create(:related_work, work_id: parent_work.id) }
-  end
-
-  factory :related_work_known_child do
-    child_creator { FactoryGirl.create(:user) }
-    child_work { FactoryGirl.create(:work, authors: [child_creator.default_pseud]) }
-    related_work { FactoryGirl.create(:related_work, work_id: child_work.id) }
-  end
 end

--- a/spec/controllers/related_works_controller_spec.rb
+++ b/spec/controllers/related_works_controller_spec.rb
@@ -2,6 +2,10 @@ require 'spec_helper'
 
 describe RelatedWorksController do
   include LoginMacros
+  let(:child_creator) { FactoryGirl.create(:user) }
+  let(:child_work) { FactoryGirl.create(:work, authors: [child_creator.default_pseud]) }
+  let(:parent_creator) { FactoryGirl.create(:user) }
+  let(:parent_work) { FactoryGirl.create(:work, authors: [parent_creator.default_pseud]) }
 
   describe "GET #index" do
     context "for a blank user" do
@@ -36,11 +40,9 @@ describe RelatedWorksController do
   describe "PUT #update" do
     context "by the creator of the child work" do
       before(:each) do
-        child_creator = FactoryGirl.create(:user)
-        child_work = FactoryGirl.create(:work, authors: [child_creator.default_pseud])
-        related_work = FactoryGirl.create(:related_work, work_id: child_work.id)
+        @related_work = FactoryGirl.create(:related_work, work_id: child_work.id)
         fake_login_known_user(child_creator)
-        put :update, id: related_work
+        put :update, id: @related_work
       end
 
       it "sets a flash message" do
@@ -54,9 +56,9 @@ describe RelatedWorksController do
 
     context "by a user who is not the creator of either work" do
       before(:each) do
-        related_work = FactoryGirl.create(:related_work)
+        @related_work = FactoryGirl.create(:related_work)
         fake_login
-        put :update, id: related_work
+        put :update, id: @related_work
       end
 
       it "sets a flash message" do
@@ -70,8 +72,6 @@ describe RelatedWorksController do
 
     context "by the creator of the parent work" do
       before(:each) do
-        parent_creator = FactoryGirl.create(:user)
-        parent_work = FactoryGirl.create(:work, authors: [parent_creator.default_pseud])
         @related_work = FactoryGirl.create(:related_work, parent_id: parent_work.id, reciprocal: true)
         fake_login_known_user(parent_creator)
       end
@@ -110,11 +110,9 @@ describe RelatedWorksController do
   describe "DELETE #destroy" do
     context "by the creator of the parent work" do
       before(:each) do
-        parent_creator = FactoryGirl.create(:user)
-        parent_work = FactoryGirl.create(:work, authors: [parent_creator.default_pseud])
-        related_work = FactoryGirl.create(:related_work, parent_id: parent_work.id, reciprocal: true)
+        @related_work = FactoryGirl.create(:related_work, parent_id: parent_work.id, reciprocal: true)
         fake_login_known_user(parent_creator)
-        delete :destroy, id: related_work
+        delete :destroy, id: @related_work
       end
 
       it "sets a flash message" do
@@ -128,9 +126,9 @@ describe RelatedWorksController do
 
     context "by a user who is not the creator of either work" do
       before(:each) do
-        related_work = FactoryGirl.create(:related_work)
+        @related_work = FactoryGirl.create(:related_work)
         fake_login
-        delete :destroy, id: related_work
+        delete :destroy, id: @related_work
       end
 
       it "sets a flash message" do
@@ -144,8 +142,6 @@ describe RelatedWorksController do
 
     context "by the creator of the child work" do
       before(:each) do
-        child_creator = FactoryGirl.create(:user)
-        child_work = FactoryGirl.create(:work, authors: [child_creator.default_pseud])
         @related_work = FactoryGirl.create(:related_work, work_id: child_work.id)
         fake_login_known_user(child_creator)
       end

--- a/spec/controllers/related_works_controller_spec.rb
+++ b/spec/controllers/related_works_controller_spec.rb
@@ -151,9 +151,9 @@ describe RelatedWorksController do
       end
 
       it "deletes the related work" do
-        expect{
+        expect {
           delete :destroy, id: @related_work
-        }.to change(RelatedWork,:count).by(-1)
+        }.to change(RelatedWork, :count).by(-1)
       end
 
       xit "redirects the requester" do
@@ -163,4 +163,3 @@ describe RelatedWorksController do
     end
   end
 end
-

--- a/spec/controllers/related_works_controller_spec.rb
+++ b/spec/controllers/related_works_controller_spec.rb
@@ -1,0 +1,33 @@
+require 'spec_helper'
+
+describe RelatedWorksController do
+  describe "GET #index" do
+    context "for a blank user" do
+      before(:each) do
+        get :index, user_id: ""
+      end
+
+      it "sets a flash message" do
+        expect(flash[:error]).to eq("Whose related works were you looking for?")
+      end
+
+      it "redirects the requester" do
+        expect(response).to have_http_status(:redirect)
+      end
+    end
+
+    context "for a nonexistent user" do
+      before(:each) do
+        get :index, user_id: "user"
+      end
+
+      it "sets a flash message" do
+        expect(flash[:error]).to eq("Sorry, we couldn't find that user")
+      end
+
+      it "redirects the requester" do
+        expect(response).to have_http_status(:redirect)
+      end
+    end
+  end
+end

--- a/spec/controllers/related_works_controller_spec.rb
+++ b/spec/controllers/related_works_controller_spec.rb
@@ -156,9 +156,9 @@ describe RelatedWorksController do
         }.to change(RelatedWork, :count).by(-1)
       end
 
-      xit "redirects the requester" do
+      it "redirects the requester" do
         delete :destroy, id: @related_work
-        expect(response).to redirect_to user_related_works_path(@current_user)
+        expect(response).to have_http_status(:redirect)
       end
     end
   end

--- a/spec/controllers/related_works_controller_spec.rb
+++ b/spec/controllers/related_works_controller_spec.rb
@@ -156,7 +156,7 @@ describe RelatedWorksController do
         }.to change(RelatedWork,:count).by(-1)
       end
 
-      it "redirects the requester" do
+      xit "redirects the requester" do
         delete :destroy, id: @related_work
         expect(response).to redirect_to user_related_works_path(@current_user)
       end

--- a/spec/controllers/related_works_controller_spec.rb
+++ b/spec/controllers/related_works_controller_spec.rb
@@ -1,6 +1,8 @@
 require 'spec_helper'
 
 describe RelatedWorksController do
+  include LoginMacros
+
   describe "GET #index" do
     context "for a blank user" do
       before(:each) do
@@ -30,4 +32,135 @@ describe RelatedWorksController do
       end
     end
   end
+
+  describe "PUT #update" do
+    context "by the creator of the child work" do
+      before(:each) do
+        child_creator = FactoryGirl.create(:user)
+        child_work = FactoryGirl.create(:work, authors: [child_creator.default_pseud])
+        related_work = FactoryGirl.create(:related_work, work_id: child_work.id)
+        fake_login_known_user(child_creator)
+        put :update, id: related_work
+      end
+
+      it "sets a flash message" do
+        expect(flash[:error]).to eq("Sorry, but you don't have permission to do that. Try removing the link from your own work.")
+      end
+
+      it "redirects the requester" do
+        expect(response).to have_http_status(:redirect)
+      end
+    end
+
+    context "by a user who is not the creator of either work" do
+      before(:each) do
+        related_work = FactoryGirl.create(:related_work)
+        fake_login
+        put :update, id: related_work
+      end
+
+      it "sets a flash message" do
+        expect(flash[:error]).to eq("Sorry, but you don't have permission to do that.")
+      end
+
+      it "redirects the requester" do
+        expect(response).to have_http_status(:redirect)
+      end
+    end
+
+    context "by the creator of the parent work" do
+      before(:each) do
+        parent_creator = FactoryGirl.create(:user)
+        parent_work = FactoryGirl.create(:work, authors: [parent_creator.default_pseud])
+        @related_work = FactoryGirl.create(:related_work, parent_id: parent_work.id, reciprocal: true)
+        fake_login_known_user(parent_creator)
+      end
+
+      context "with valid parameters" do
+        before(:each) do
+          put :update, id: @related_work
+        end
+
+        it "updates the related work attributes" do
+          @related_work.reload
+          expect(@related_work.reciprocal?).to be false
+        end
+
+        it "sets a flash message" do
+          expect(flash[:notice]).to eq("Link was successfully removed")
+        end
+
+        it "redirects to the parent work" do
+          expect(response).to redirect_to @related_work.parent
+        end
+      end
+
+      context "with invalid parameters" do
+        xit "sets a flash message" do
+          expect(flash[:notice]).to eq("Sorry, something went wrong.")
+        end
+
+        xit "redirects to the related work" do
+          expect(response).to redirect_to @related_work
+        end
+      end
+    end
+  end
+
+  describe "DELETE #destroy" do
+    context "by the creator of the parent work" do
+      before(:each) do
+        parent_creator = FactoryGirl.create(:user)
+        parent_work = FactoryGirl.create(:work, authors: [parent_creator.default_pseud])
+        related_work = FactoryGirl.create(:related_work, parent_id: parent_work.id, reciprocal: true)
+        fake_login_known_user(parent_creator)
+        delete :destroy, id: related_work
+      end
+
+      it "sets a flash message" do
+        expect(flash[:error]).to eq("Sorry, but you don't have permission to do that. You can only approve or remove the link from your own work.")
+      end
+
+      it "redirects the requester" do
+        expect(response).to have_http_status(:redirect)
+      end
+    end
+
+    context "by a user who is not the creator of either work" do
+      before(:each) do
+        related_work = FactoryGirl.create(:related_work)
+        fake_login
+        delete :destroy, id: related_work
+      end
+
+      it "sets a flash message" do
+        expect(flash[:error]).to eq("Sorry, but you don't have permission to do that.")
+      end
+
+      it "redirects the requester" do
+        expect(response).to have_http_status(:redirect)
+      end
+    end
+
+    context "by the creator of the child work" do
+      before(:each) do
+        child_creator = FactoryGirl.create(:user)
+        child_work = FactoryGirl.create(:work, authors: [child_creator.default_pseud])
+        @related_work = FactoryGirl.create(:related_work, work_id: child_work.id)
+        fake_login_known_user(child_creator)
+      end
+
+      it "deletes the related work" do
+        expect{
+          delete :destroy, id: @related_work
+        }.to change(RelatedWork,:count).by(-1)
+      end
+
+      it "redirects the requester" do
+        delete :destroy, id: @related_work
+        expect(response).to redirect_to user_related_works_path(@current_user)
+      end
+    end
+  end
 end
+


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-4707

## Purpose

Increases coverage of the related works controller. The redirect code `redirect_back_or_default(some_path)` is really old, so the best I could do for now is just check that it _does_ redirect, but not to where. It's better than nothing? (I'm going to update the last redirect in the fix for https://otwarchive.atlassian.net/browse/AO3-2151 and the new code will have the same behavior, but be properly testable. I could update the other redirects, too, if people want.)

There are two pending bits I couldn't figure out, but I left them because maybe someone can finish them off.