### PR TITLE
AO3-4769 Removing a TODO in tests

### DIFF
--- a/features/comments_and_kudos/add_comment.feature
+++ b/features/comments_and_kudos/add_comment.feature
@@ -95,8 +95,8 @@ Scenario: Comment threading, comment editing
     And I press "Update"
   Then I should see "Comment was successfully updated"
     #TODO Someone should figure out why this fails intermittently on Travis. Caching? The success message is there but the old comment text lingers.
-    #And I should see "Actually, I meant something different"
-    #And I should not see "Mistaken comment"
+    And I should see "Actually, I meant something different"
+    And I should not see "Mistaken comment"
     And I should see Last Edited in the right timezone
   When I am logged in as "commenter3"
     And I view the work "The One Where Neal is Awesome"
@@ -106,8 +106,8 @@ Scenario: Comment threading, comment editing
     And I press "Comment" within ".thread .even"
   Then I should see "Comment created!"
     # TODO Someone should figure out why this fails intermittently on Travis. Caching? The success message is there but the old comment text lingers.
-    # And I should not see "Mistaken comment"
-    # And I should see "Actually, I meant something different" within "ol.thread li ol.thread li ol.thread li ol.thread"
+    And I should not see "Mistaken comment"
+    And I should see "Actually, I meant something different" within "ol.thread li ol.thread li ol.thread li ol.thread"
     And I should see "I loved it, too." within "ol.thread"
     And I should see "Thank you." within "ol.thread li ol.thread li ol.thread"
     And I should see "This should be nested" within "ol.thread li ol.thread li ol.thread"


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-4769

## Purpose

Removes a TODO and tests more stuff. I've had this running on Travis for quite a while with no failures, so presume the previous flakiness was fixed.

## Testing

None required

## Credit

Cesy, she
