### PR TITLE
AO3-4785 fix test where user's profile wasn't being destroyed properly

### DIFF
--- a/spec/controllers/profile_controller_spec.rb
+++ b/spec/controllers/profile_controller_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe ProfileController do
   describe 'show' do
     it 'should be an error for a non existent user' do
-      get :show, user: 999_999_999_999
+      get :show, user_id: 999_999_999_999
 
       expect(response).to redirect_to(root_path)
       expect(flash[:error]).to eq "Sorry, there's no user by that name."
@@ -12,7 +12,8 @@ describe ProfileController do
     it 'should create a new profile if one does not exist' do
       @user = FactoryGirl.create(:user)
       @user.profile.destroy
-      get :show, user: @user.id
+      @user.reload
+      get :show, user_id: @user
       expect(@user.profile).to be
     end
   end


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-4785

## Purpose

Fix tests for profile_controller to get 100% coverage.

## Testing

run `bundle exec rspec spec/controllers/profile_controller_spec.rb`

## Credit

cresenne, she/her
