### PR TITLE
AO3-4793 Add strong parameters to models where we don't think we are doing mass assignment ( low coverage )

### DIFF
--- a/app/models/errors.rb
+++ b/app/models/errors.rb
@@ -1,0 +1,3 @@
+class Errors < ActiveRecord::Base
+  include ActiveModel::ForbiddenAttributesProtection
+end

--- a/app/models/menu.rb
+++ b/app/models/menu.rb
@@ -1,0 +1,3 @@
+class Menu < ActiveRecord::Base
+  include ActiveModel::ForbiddenAttributesProtection
+end

--- a/app/models/opendoors/tools.rb
+++ b/app/models/opendoors/tools.rb
@@ -1,0 +1,3 @@
+class Opendoors::Tools < ActiveRecord::Base
+  include ActiveModel::ForbiddenAttributesProtection
+end

--- a/app/models/redirect.rb
+++ b/app/models/redirect.rb
@@ -1,0 +1,3 @@
+class Redirect < ActiveRecord::Base
+  include ActiveModel::ForbiddenAttributesProtection
+end

--- a/app/models/serial_work.rb
+++ b/app/models/serial_work.rb
@@ -1,4 +1,6 @@
 class SerialWork < ActiveRecord::Base
+  include ActiveModel::ForbiddenAttributesProtection
+
   belongs_to :series, :touch => true
   belongs_to :work, :touch => true
   validates_uniqueness_of :work_id, :scope => [:series_id]


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-4793

## Purpose
The idea here is that both brakeman and ourselves do not think we are doing mass assignment in a number of controllers, It seem sensible to confirm this by turning on the use of strong parameters in the controllers. This way we will not get less surprises in the move to rails 4.

## Testing

No Manual testing