### PR TITLE
AO3-4795 filtering by fandom in dashboard is broken

### DIFF
--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -102,8 +102,12 @@ class WorksController < ApplicationController
       end
 
       tag = @fandom || @tag
-      options[:filter_ids] ||= []
-      options[:filter_ids] << tag.id
+      # This strange dance is because there is an interaction between
+      # strong_parameters and dup, with out the dance 
+      # options[:filter_ids] << tag.id is ignored.
+      filter_ids = options[:filter_ids] || []
+      filter_ids << tag.id
+      options[:filter_ids] = filter_ids
     end
 
     options[:page] = params[:page]

--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -103,7 +103,7 @@ class WorksController < ApplicationController
 
       tag = @fandom || @tag
       # This strange dance is because there is an interaction between
-      # strong_parameters and dup, with out the dance 
+      # strong_parameters and dup, without the dance 
       # options[:filter_ids] << tag.id is ignored.
       filter_ids = options[:filter_ids] || []
       filter_ids << tag.id

--- a/features/users/user_dashboard.feature
+++ b/features/users/user_dashboard.feature
@@ -124,3 +124,18 @@ Feature: User dashboard
     And I should not see "Oldest Series"
   Then I should see "Recent bookmarks"
     And I should see "Work 5" within "#user-bookmarks"
+
+  Scenario: Sorting within user or collection filtered results removes fandom filter
+  Given a media exists with name: "TV Shows", canonical: true
+    And a fandom exists with name: "Star Trek", canonical: true
+    And a fandom exists with name: "Star Trek: Discovery", canonical: true
+  When I am logged in as "meatloaf"
+    And I post the work "Excellent" with fandom "Star Trek"
+    And I post the work "Even more Excellent" with fandom "Star Trek"
+    And I post the work "Exciting" with fandom "Star Trek: Discovery"
+  When I go to meatloaf's user page
+  When I follow "Star Trek"
+  Then I should see "2 Works by meatloaf in Star Trek"
+  When I press "Sort and Filter"
+  Then I should see "2 Works by meatloaf in Star Trek"
+

--- a/features/users/user_dashboard.feature
+++ b/features/users/user_dashboard.feature
@@ -125,16 +125,16 @@ Feature: User dashboard
   Then I should see "Recent bookmarks"
     And I should see "Work 5" within "#user-bookmarks"
 
-  Scenario: Sorting within user or collection filtered results removes fandom filter
+  Scenario: You can follow a fandom link from a user's dashboard and then use the filters to sort within that fandom.
   Given a media exists with name: "TV Shows", canonical: true
     And a fandom exists with name: "Star Trek", canonical: true
     And a fandom exists with name: "Star Trek: Discovery", canonical: true
-  When I am logged in as "meatloaf"
+    And I am logged in as "meatloaf"
     And I post the work "Excellent" with fandom "Star Trek"
     And I post the work "Even more Excellent" with fandom "Star Trek"
     And I post the work "Exciting" with fandom "Star Trek: Discovery"
   When I go to meatloaf's user page
-  When I follow "Star Trek"
+    And I follow "Star Trek"
   Then I should see "2 Works by meatloaf in Star Trek"
   When I press "Sort and Filter"
   Then I should see "2 Works by meatloaf in Star Trek"


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-4795

## Purpose

Fix the filtering in a user dashboard ( and hopefully in a collection )

## Testing

When viewing filtered results for a user or collection, and then sorting, the filter is removed.
Example:
Go to a user's dashboard and click on one of their fandoms. This shows you the filtered list of the works they have created in that fandom. The title of the page will for example be "1-3 works by ariana_paris in Testing".
In the right-hand Sort and filter bar, select a sort order (for example, "word count"), then click on the Sort and filter button.
Instead of getting the same 3 works, sorted by word count, you see the list of all the user's works sorted by word count. The Fandom filtering is gone.