### PR TITLE
AO3-4771 Tests for the collection_participants_controller.

### DIFF
--- a/app/controllers/collection_participants_controller.rb
+++ b/app/controllers/collection_participants_controller.rb
@@ -53,8 +53,11 @@ class CollectionParticipantsController < ApplicationController
     end
     participants = CollectionParticipant.in_collection(@collection).for_user(current_user) unless current_user.nil?
     if participants.empty?
-      @participant = CollectionParticipant.new(collection: @collection, pseud: current_user.default_pseud,
-                        participant_role: CollectionParticipant::NONE)
+      @participant = CollectionParticipant.new(
+        collection: @collection,
+        pseud: current_user.default_pseud,
+        participant_role: CollectionParticipant::NONE
+      )
       @participant.save
       flash[:notice] = t('applied_to_join_collection', :default => "You have applied to join %{collection}.", :collection => @collection.title)
     else

--- a/app/controllers/collection_participants_controller.rb
+++ b/app/controllers/collection_participants_controller.rb
@@ -44,8 +44,6 @@ class CollectionParticipantsController < ApplicationController
     !@participant.is_owner? || (@collection.owners != [@participant.pseud]) || owners_required
   end
 
-
-
   ## ACTIONS
 
   def join
@@ -55,8 +53,8 @@ class CollectionParticipantsController < ApplicationController
     end
     participants = CollectionParticipant.in_collection(@collection).for_user(current_user) unless current_user.nil?
     if participants.empty?
-      @participant = CollectionParticipant.new(:collection => @collection, :pseud => current_user.default_pseud,
-                        :participant_role => CollectionParticipant::NONE)
+      @participant = CollectionParticipant.new(collection: @collection, pseud: current_user.default_pseud,
+                        participant_role: CollectionParticipant::NONE)
       @participant.save
       flash[:notice] = t('applied_to_join_collection', :default => "You have applied to join %{collection}.", :collection => @collection.title)
     else

--- a/app/controllers/collection_participants_controller.rb
+++ b/app/controllers/collection_participants_controller.rb
@@ -22,10 +22,10 @@ class CollectionParticipantsController < ApplicationController
 
   def load_participant_and_collection
     if params[:collection_participant]
-      @participant = CollectionParticipant.where(id: params[:collection_participant][:id]).first
+      @participant = CollectionParticipant.find_by_id(params[:collection_participant][:id])
       @new_role = params[:collection_participant][:participant_role]
     else
-      @participant = CollectionParticipant.where(id: params[:id]).first
+      @participant = CollectionParticipant.find_by_id(params[:id])
     end
 
     no_participant and return unless @participant

--- a/app/controllers/collection_participants_controller.rb
+++ b/app/controllers/collection_participants_controller.rb
@@ -14,27 +14,28 @@ class CollectionParticipantsController < ApplicationController
     redirect_to collection_participants_path(@collection)
     false
   end
-  
+
   def no_participant
     flash[:error] = t('no_participant', :default => "Which participant did you want to work with?")
     redirect_to root_path
   end
-  
+
   def load_participant_and_collection
     if params[:collection_participant]
-      @participant = CollectionParticipant.find(params[:collection_participant][:id])
+      @participant = CollectionParticipant.where(id: params[:collection_participant][:id]).first
       @new_role = params[:collection_participant][:participant_role]
     else
-      @participant = CollectionParticipant.find(params[:id])
+      @participant = CollectionParticipant.where(id: params[:id]).first
     end
+
     no_participant and return unless @participant
     @collection = @participant.collection
-  end    
+  end
 
   def allowed_to_promote
     @participant.user_allowed_to_promote?(current_user, @new_role) || not_allowed(@collection)
   end
-  
+
   def allowed_to_destroy
     @participant.user_allowed_to_destroy?(current_user) || not_allowed(@collection)
   end
@@ -42,9 +43,9 @@ class CollectionParticipantsController < ApplicationController
   def has_other_owners
     !@participant.is_owner? || (@collection.owners != [@participant.pseud]) || owners_required
   end
-  
-  
-  
+
+
+
   ## ACTIONS
 
   def join
@@ -54,29 +55,29 @@ class CollectionParticipantsController < ApplicationController
     end
     participants = CollectionParticipant.in_collection(@collection).for_user(current_user) unless current_user.nil?
     if participants.empty?
-      @participant = CollectionParticipant.new(:collection => @collection, :pseud => current_user.default_pseud, 
+      @participant = CollectionParticipant.new(:collection => @collection, :pseud => current_user.default_pseud,
                         :participant_role => CollectionParticipant::NONE)
       @participant.save
       flash[:notice] = t('applied_to_join_collection', :default => "You have applied to join %{collection}.", :collection => @collection.title)
     else
       participants.each do |participant|
         if participant.is_invited?
-          participant approve_membership!
+          participant.approve_membership!
           flash[:notice] = t('collection_participants.accepted_invite', :default => "You are now a member of %{collection}.", :collection => @collection.title)
           redirect_to(request.env["HTTP_REFERER"] || root_path) and return
         end
       end
-      
+
       flash[:notice] = t('collection_participants.no_invitation', :default => "You have already joined (or applied to) this collection.")
     end
-    
+
     redirect_to(request.env["HTTP_REFERER"] || root_path)
-  end 
-    
+  end
+
   def index
     @collection_participants = @collection.collection_participants.reject {|p| p.pseud.nil?}.sort_by {|participant| participant.pseud.name.downcase }
   end
-  
+
   def update
     if @participant.update_attributes(params[:collection_participant])
       flash[:notice] = t('collection_participants.update_success', :default => "Updated %{participant}.", :participant => @participant.pseud.name)
@@ -85,8 +86,8 @@ class CollectionParticipantsController < ApplicationController
     end
     redirect_to collection_participants_path(@collection)
   end
-  
-  def destroy    
+
+  def destroy
     @participant.destroy
     flash[:notice] = t('collection_participants.destroy', :default => "Removed %{participant} from collection.", :participant => @participant.pseud.name)
     redirect_to(request.env["HTTP_REFERER"] || root_path)
@@ -100,14 +101,14 @@ class CollectionParticipantsController < ApplicationController
       if @collection.participants.include?(pseud)
         participant = CollectionParticipant.find(:first, :conditions => {:collection_id => @collection.id, :pseud_id => pseud.id})
         if participant && participant.is_none?
-          @participants_added << participant if participant.approve_membership! 
+          @participants_added << participant if participant.approve_membership!
         end
       else
         participant = CollectionParticipant.new(:collection => @collection, :pseud => pseud, :participant_role => CollectionParticipant::MEMBER)
         @participants_invited << participant if participant.save
       end
     end
-    
+
     if @participants_invited.empty? && @participants_added.empty?
       if pseud_results[:banned_pseuds].present?
         flash[:error] =
@@ -120,7 +121,7 @@ class CollectionParticipantsController < ApplicationController
     else
       flash[:notice] = ""
     end
-    
+
     unless @participants_invited.empty?
       @participants_invited = @participants_invited.sort_by {|participant| participant.pseud.name.downcase }
       flash[:notice] += ts("New members invited: ") +  @participants_invited.collect(&:pseud).collect(&:byline).join(', ')
@@ -130,7 +131,7 @@ class CollectionParticipantsController < ApplicationController
       @participants_added = @participants_added.sort_by {|participant| participant.pseud.name.downcase }
       flash[:notice] += ts("Members added: ") +  @participants_added.collect(&:pseud).collect(&:byline).join(', ')
     end
-    
+
     redirect_to collection_participants_path(@collection)
   end
 

--- a/spec/controllers/admin/api_controller_spec.rb
+++ b/spec/controllers/admin/api_controller_spec.rb
@@ -3,16 +3,7 @@ require 'spec_helper'
 
 describe Admin::ApiController do
   include LoginMacros
-
-  def it_redirects_to_homepage
-    expect(response).to have_http_status(:redirect)
-    expect(response).to redirect_to root_path
-  end
-
-  def it_redirects_to_admin_api_index
-    expect(response).to have_http_status(:redirect)
-    expect(response).to redirect_to admin_api_index_path
-  end
+  include RedirectExpectationHelper
 
   describe "GET #index" do
     let(:params) { nil }
@@ -20,7 +11,7 @@ describe Admin::ApiController do
     context "where there is no user or admin logged in" do
       it "redirects to the homepage" do
         get :index, params
-        it_redirects_to_homepage
+        it_redirects_to root_path
       end
     end
 
@@ -33,7 +24,7 @@ describe Admin::ApiController do
 
       it "redirects to the homepage" do
         get :index, params
-        it_redirects_to_homepage
+        it_redirects_to root_path
       end
     end
 
@@ -85,7 +76,7 @@ describe Admin::ApiController do
 
       it "redirects to the homepage" do
         get :show
-        it_redirects_to_admin_api_index
+        it_redirects_to admin_api_index_path
       end
     end
   end
@@ -122,7 +113,7 @@ describe Admin::ApiController do
         it "redirects to the homepage and notifies of the success" do
           post :create, params
           expect(ApiKey.where(name: api_key_name)).to_not be_empty
-          it_redirects_to_admin_api_index
+          it_redirects_to admin_api_index_path
           expect(flash[:notice]).to include("New token successfully created")
         end
       end
@@ -156,7 +147,7 @@ describe Admin::ApiController do
 
         it "redirects to index" do
           post :create, params
-          it_redirects_to_admin_api_index
+          it_redirects_to admin_api_index_path
         end
       end
     end
@@ -214,7 +205,7 @@ describe Admin::ApiController do
             expect(ApiKey.where(name: new_name)).to be_empty
             post :update, params
             expect(ApiKey.where(name: new_name)).to_not be_empty
-            it_redirects_to_admin_api_index
+            it_redirects_to admin_api_index_path
             expect(flash[:notice]).to include("Access token was successfully updated")
           end
         end
@@ -246,7 +237,7 @@ describe Admin::ApiController do
 
         it "redirects to index" do
           post :update, id: api_key_id, cancel_button: "Cancel"
-          it_redirects_to_admin_api_index
+          it_redirects_to admin_api_index_path
         end
       end
     end

--- a/spec/controllers/collection_participants_controller_spec.rb
+++ b/spec/controllers/collection_participants_controller_spec.rb
@@ -1,0 +1,468 @@
+# frozen_string_literal: true
+require "spec_helper"
+
+describe CollectionParticipantsController do
+  include LoginMacros
+
+  def it_redirects_to_with_notice(path, notice)
+    it_redirects_to(path)
+    expect(flash[:notice]).to eq notice
+  end
+
+  def it_redirects_to_with_error(path, error)
+    it_redirects_to(path)
+    expect(flash[:error]).to eq error
+  end
+
+  def it_redirects_to(path)
+    expect(response).to have_http_status :redirect
+    expect(response).to redirect_to path
+  end
+
+  describe "join" do
+    context "where user isn't logged in" do
+      it "redirects to new user session" do
+        get :join
+        it_redirects_to new_user_session_path
+      end
+    end
+
+    context "where the user is logged in" do
+      let(:user) { FactoryGirl.create(:user) }
+
+      before do
+        fake_login_known_user(user)
+      end
+
+      context "where there is no collection" do
+        it "redirects to index and displays an error" do
+          get :join, { collection_id: nil }
+          it_redirects_to_with_error(root_path, "Which collection did you want to join?")
+        end
+
+        context "where the HTTP_REFERER is set" do
+          before do
+            request.env["HTTP_REFERER"] = collections_path
+          end
+
+          it "navigates back to the previously viewed page" do
+            get :join
+            it_redirects_to_with_error(collections_path, "Which collection did you want to join?")
+          end
+        end
+      end
+
+      context "where there is a collection" do
+        let (:collection) { FactoryGirl.create(:collection) }
+        let (:current_role) { CollectionParticipant::NONE }
+
+        context "where the user is already a participant" do
+          let! (:participant) {
+            FactoryGirl.create(
+              :collection_participant,
+              collection: collection,
+              pseud: user.default_pseud,
+              participant_role: current_role
+            )
+          }
+
+          context "where the user has been invited" do
+            let (:current_role) { CollectionParticipant::INVITED }
+
+            it "approves the participant and redirects to the index" do
+              get :join, { collection_id: collection.name }
+              expect(CollectionParticipant.find(participant.id).participant_role).to eq CollectionParticipant::MEMBER
+              it_redirects_to_with_notice(root_path, "You are now a member of #{collection.title}.")
+            end
+          end
+
+          context "where the user is not currently invited" do
+            it "redirects to the index and displays a notice that the user has already joined or applied" do
+              get :join, { collection_id: collection.name }
+              it_redirects_to_with_notice(root_path, "You have already joined (or applied to) this collection.")
+            end
+          end
+        end
+
+        context "where user isn't a participant yet" do
+          it "creates a participant for the user, redirects to index and notifies them that they have applied" do
+            get :join, { collection_id: collection.name }
+            participant = CollectionParticipant.find_by_pseud_id(user.default_pseud.id)
+            expect(participant).to be_present
+            expect(participant.participant_role).to eq CollectionParticipant::NONE
+            it_redirects_to_with_notice(root_path, "You have applied to join #{collection.title}.")
+          end
+        end
+      end
+    end
+  end
+
+  describe "index" do
+    let (:collection) { FactoryGirl.create(:collection) }
+    let (:current_role) { CollectionParticipant::NONE }
+    let (:user) { FactoryGirl.create(:user) }
+
+    context "user is not logged in" do
+      it "redirects to the index and displays an access denied message" do
+        get :index, { collection_id: collection.name }
+        it_redirects_to_with_error(new_user_session_path, "Sorry, you don't have permission to access the page you were trying to reach. Please log in.")
+      end
+    end
+
+    context "user is logged in" do
+      let! (:participant) {
+        FactoryGirl.create(
+          :collection_participant,
+          collection: collection,
+          pseud: user.default_pseud,
+          participant_role: current_role
+        )
+      }
+      let (:params) { { collection_id: collection.name } }
+
+      before do
+        fake_login_known_user(user)
+      end
+
+      context "where the user is not a maintainer" do
+        it "redirects to the index" do
+          get :index, params
+          it_redirects_to_with_error(user_path(user), "Sorry, you don't have permission to access the page you were trying to reach.")
+        end
+      end
+
+      context "where the user is a maintainer" do
+        render_views
+        let (:current_role) { CollectionParticipant::MODERATOR }
+
+        context "where the collection has several participants" do
+          let! (:users) {
+            3.times.map do
+              user = FactoryGirl.create(:user)
+              FactoryGirl.create(
+                :collection_participant,
+                collection: collection,
+                pseud: user.default_pseud
+              )
+              user
+            end
+          }
+
+          it "displays the participants in the correct order" do
+            get :index, params
+            expect(response).to have_http_status(:success)
+            users.each do |user|
+              expect(response.body).to include user.default_pseud.name
+            end
+          end
+        end
+      end
+    end
+  end
+
+  describe "update" do
+    let (:user) { FactoryGirl.create(:user) }
+    let (:collection) { FactoryGirl.create(:collection) }
+    let (:user_role) { CollectionParticipant::NONE }
+    let! (:user_participant) {
+      FactoryGirl.create(
+        :collection_participant,
+        pseud: user.default_pseud,
+        collection: collection,
+        participant_role: user_role
+      )
+    }
+    let (:id_to_update) { nil }
+    let (:params) {
+      {
+        collection_participant: {
+          participant_role:  CollectionParticipant::MEMBER,
+          id: id_to_update
+        }
+      }
+    }
+
+    before do
+      fake_login_known_user(user)
+    end
+
+    context "where there is no participant" do
+      it "displays an error and redirects to the index" do
+        put :update, params
+        expect(response).to have_http_status :redirect
+        expect(response).to redirect_to root_path
+        expect(flash[:error]).to eq "Which participant did you want to work with?"
+      end
+    end
+
+    context "where there is a participant" do
+      let (:participant) {
+        FactoryGirl.create(
+          :collection_participant,
+          collection: user_participant.collection,
+          participant_role: CollectionParticipant::NONE
+        )
+      }
+      let (:id_to_update) { participant.id }
+      context "where the user is not a collection maintainer" do
+        it "redirects to the collection page and displays an error" do
+          put :update, params
+          expect(flash[:error]).to eq "Sorry, you're not allowed to do that."
+          expect(response).to have_http_status :redirect
+          expect(response).to redirect_to collection_path(collection)
+        end
+      end
+
+      context "where the user is a collection maintainer" do
+        let (:user_role) { CollectionParticipant::MODERATOR }
+        context "where the participant is updated successfully" do
+          it "successfully updates and redirects to collection participants" do
+            put :update, params
+            expect(flash[:notice]).to eq "Updated #{participant.pseud.name}."
+            expect(response).to have_http_status :redirect
+            expect(response).to redirect_to collection_participants_path(collection)
+            expect(CollectionParticipant.find_by_pseud_id(participant.pseud_id).participant_role).to eq CollectionParticipant::MEMBER
+          end
+        end
+
+        context "where the participant is not updated successfully" do
+          before do
+            allow_any_instance_of(CollectionParticipant).to receive(:update_attributes).and_return(false)
+          end
+
+          it "displays an error notice and and redirects to collection participants" do
+            put :update, params
+            expect(flash[:error]).to eq "Couldn't update #{participant.pseud.name}."
+            expect(response).to have_http_status :redirect
+            expect(response).to redirect_to collection_participants_path(collection)
+          end
+        end
+      end
+    end
+  end
+
+  describe "destroy" do
+    let (:user) { FactoryGirl.create(:user) }
+    let (:pseud_name) { user.default_pseud.name }
+    let (:collection) { FactoryGirl.create(:collection) }
+    let (:user_participant_role) { CollectionParticipant::MEMBER }
+    let! (:user_participant) {
+      FactoryGirl.create(
+        :collection_participant,
+        pseud: user.default_pseud,
+        collection: collection,
+        participant_role: user_participant_role
+      )
+    }
+    let (:params) {
+      { id: user_participant.id }
+    }
+
+    before do
+      fake_login_known_user(user)
+    end
+
+    context "where there is no participant found" do
+      let (:params) { { id: nil } }
+
+      it "displays an error and redirects to the index" do
+        delete :destroy, params
+        it_redirects_to_with_error(root_path, "Which participant did you want to work with?")
+      end
+    end
+
+    context "where there is a participant found" do
+      context "where user is not a maintainer" do
+        context "where the user is destroying their own participant" do
+          it "destroys the participant successfully and redirects to index" do
+            delete :destroy, params
+            it_redirects_to_with_notice(root_path, "Removed #{pseud_name} from collection.")
+            expect(CollectionParticipant.find_by_pseud_id(user.default_pseud.id)).to_not be_present
+          end
+        end
+
+        context "where the user is trying to destroy another participant" do
+          let (:other_participant) {
+            FactoryGirl.create(
+              :collection_participant,
+              collection: collection,
+              participant_role: CollectionParticipant::MEMBER
+            )
+          }
+          let (:pseud_name) { other_participant.pseud.name }
+          let (:params) {
+            { id: other_participant.id }
+          }
+
+          it "doesn't allow the destroy and redirects to the collection page" do
+            delete :destroy, params
+            it_redirects_to collection_path(collection)
+            expect(flash[:error]).to eq "Sorry, you're not allowed to do that."
+            expect(CollectionParticipant.find(other_participant)).to be_present
+          end
+        end
+      end
+
+      context "where user is a maintainer" do
+        let (:user_participant_role) { CollectionParticipant::MODERATOR }
+        let (:collection) { FactoryGirl.create(:collection) }
+        let (:other_participant) {
+          FactoryGirl.create(
+            :collection_participant,
+            collection: collection,
+            participant_role: CollectionParticipant::MEMBER
+          )
+        }
+        let (:pseud_name) { other_participant.pseud.name }
+        let (:params) {
+          { id: other_participant.id }
+        }
+
+        context "where participant to be destroyed is not an owner" do
+          it "destroys the participant successfully and redirects to index" do
+            delete :destroy, params
+            it_redirects_to_with_notice(root_path, "Removed #{pseud_name} from collection.")
+            expect(CollectionParticipant.find_by_pseud_id(other_participant.pseud_id)).to_not be_present
+          end
+        end
+
+        context "where participant to be destroyed is an owner" do
+          let (:delete_participant_id) { CollectionParticipant.find_by_pseud_id(collection.owners.first.id) }
+          let (:params) {
+            { id: delete_participant_id }
+          }
+
+          context "where there are no other owners" do
+            it "displays an error and redirects to the collection participants path" do
+              delete :destroy, params
+              it_redirects_to_with_error(collection_participants_path(collection), "You can't remove the only owner!")
+              expect(CollectionParticipant.find(delete_participant_id)).to be_present
+            end
+          end
+
+          context "where there are other owners" do
+            let! (:pseud_name) { CollectionParticipant.find(delete_participant_id).pseud.name }
+            let! (:other_owner) {
+              FactoryGirl.create(
+                :collection_participant,
+                collection: collection,
+                participant_role: CollectionParticipant::OWNER
+              )
+            }
+
+            it "destroys the participant successfully and redirects to index" do
+              delete :destroy, params
+              it_redirects_to_with_notice(root_path, "Removed #{pseud_name} from collection.")
+              expect(CollectionParticipant.where(id: delete_participant_id)).to be_empty
+            end
+          end
+        end
+      end
+    end
+  end
+
+  describe "add" do
+    let (:user) { FactoryGirl.create(:user) }
+    let (:collection) { FactoryGirl.create(:collection) }
+    let (:participants_to_invite) { "" }
+    let! (:params) {
+      {
+        collection_id: collection.name,
+        participants_to_invite: participants_to_invite
+      }
+    }
+    let (:user_participant_role) { CollectionParticipant::MEMBER }
+    let! (:user_participant) {
+      FactoryGirl.create(
+        :collection_participant,
+        pseud: user.default_pseud,
+        collection: collection,
+        participant_role: user_participant_role
+      )
+    }
+
+    before do
+      fake_login_known_user(user)
+    end
+
+    context "where the user is not a maintainer" do
+      it "redirects and shows an error message" do
+        get :add, params
+        it_redirects_to_with_error(user_path(user), "Sorry, you don't have permission to access the page you were trying to reach.")
+      end
+    end
+
+    context "where the user is a maintainer" do
+      let (:user_participant_role) { CollectionParticipant:: MODERATOR }
+      let (:banned) { false }
+      let (:users) { 3.times.map { FactoryGirl.create(:user, banned: banned) } }
+      let (:participants_to_invite) {
+        users.map(&:default_pseud).map(&:byline).map(&:to_s).join(",")
+      }
+
+      context "where users to be added have already applied to the collection" do
+        let! (:participants) {
+          users.each do |user|
+            FactoryGirl.create(
+              :collection_participant,
+              collection: collection,
+              pseud: user.default_pseud,
+              participant_role: CollectionParticipant::NONE
+            )
+          end
+        }
+
+        it "approves those users, redirects to the collection participants page and displays a notification" do
+          get :add, params
+          it_redirects_to collection_participants_path(collection)
+          expect(flash[:notice]).to include "Members added:"
+          users.each do |user|
+            expect(flash[:notice]).to include user.default_pseud.byline
+            participant = CollectionParticipant.find_by_pseud_id(user.default_pseud.id)
+            expect(participant.participant_role).to eq CollectionParticipant::MEMBER
+          end
+        end
+      end
+
+      context "where the users to be added haven't yet applied to the collection" do
+        it "creates new participants with the member role and redirects" do
+          get :add, params
+          it_redirects_to collection_participants_path(collection)
+          expect(flash[:notice]).to include "New members invited:"
+          users.each do |user|
+            expect(flash[:notice]).to include user.default_pseud.byline
+            participant = CollectionParticipant.find_by_pseud_id(user.default_pseud.id)
+            expect(participant.participant_role).to eq CollectionParticipant::MEMBER
+          end
+        end
+      end
+
+      context "where users to be added are banned users" do
+        let (:banned) { true }
+
+        it "doesn't approve the member, displays an error and redirects" do
+          get :add, params
+          it_redirects_to_with_error(collection_participants_path(collection), "#{users.last.default_pseud.name} is currently banned and cannot participate in challenges.")
+          users.each do |user|
+            expect(CollectionParticipant.where(pseud_id: user.default_pseud.id)).to be_empty
+          end
+        end
+      end
+
+      context "where users to be added can't be found" do
+        let! (:pseud_ids) { users.map(&:default_pseud).map(&:id) }
+        it "displays an error and redirects" do
+          users.each do |user|
+              user.default_pseud.destroy
+          end
+
+          get :add, params
+          it_redirects_to_with_error(collection_participants_path(collection), "We couldn't find anyone new by that name to add.")
+          pseud_ids.each do |pseud_id|
+            expect(CollectionParticipant.where(pseud_id: pseud_id)).to be_empty
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/controllers/collection_participants_controller_spec.rb
+++ b/spec/controllers/collection_participants_controller_spec.rb
@@ -3,21 +3,7 @@ require "spec_helper"
 
 describe CollectionParticipantsController do
   include LoginMacros
-
-  def it_redirects_to_with_notice(path, notice)
-    it_redirects_to(path)
-    expect(flash[:notice]).to eq notice
-  end
-
-  def it_redirects_to_with_error(path, error)
-    it_redirects_to(path)
-    expect(flash[:error]).to eq error
-  end
-
-  def it_redirects_to(path)
-    expect(response).to have_http_status :redirect
-    expect(response).to redirect_to path
-  end
+  include RedirectExpectationHelper
 
   describe "join" do
     context "where user isn't logged in" do
@@ -148,7 +134,7 @@ describe CollectionParticipantsController do
             end
           end
 
-          it "displays the participants in the correct order" do
+          it "displays the participants" do
             get :index, params
             expect(response).to have_http_status(:success)
             users.each do |user|
@@ -189,9 +175,7 @@ describe CollectionParticipantsController do
     context "where there is no participant" do
       it "displays an error and redirects to the index" do
         put :update, params
-        expect(response).to have_http_status :redirect
-        expect(response).to redirect_to root_path
-        expect(flash[:error]).to eq "Which participant did you want to work with?"
+        it_redirects_to_with_error(root_path, "Which participant did you want to work with?")
       end
     end
 
@@ -207,9 +191,7 @@ describe CollectionParticipantsController do
       context "where the user is not a collection maintainer" do
         it "redirects to the collection page and displays an error" do
           put :update, params
-          expect(flash[:error]).to eq "Sorry, you're not allowed to do that."
-          expect(response).to have_http_status :redirect
-          expect(response).to redirect_to collection_path(collection)
+          it_redirects_to_with_error(collection_path(collection), "Sorry, you're not allowed to do that.")
         end
       end
 
@@ -218,10 +200,8 @@ describe CollectionParticipantsController do
         context "where the participant is updated successfully" do
           it "successfully updates and redirects to collection participants" do
             put :update, params
+            it_redirects_to_with_notice(collection_participants_path(collection), "Updated #{participant.pseud.name}.")
             expect(flash[:notice]).to eq "Updated #{participant.pseud.name}."
-            expect(response).to have_http_status :redirect
-            expect(response).to redirect_to collection_participants_path(collection)
-            expect(CollectionParticipant.find_by_pseud_id(participant.pseud_id).participant_role).to eq CollectionParticipant::MEMBER
           end
         end
 
@@ -232,9 +212,7 @@ describe CollectionParticipantsController do
 
           it "displays an error notice and and redirects to collection participants" do
             put :update, params
-            expect(flash[:error]).to eq "Couldn't update #{participant.pseud.name}."
-            expect(response).to have_http_status :redirect
-            expect(response).to redirect_to collection_participants_path(collection)
+            it_redirects_to_with_error(collection_participants_path(collection), "Couldn't update #{participant.pseud.name}.")
           end
         end
       end

--- a/spec/controllers/collection_participants_controller_spec.rb
+++ b/spec/controllers/collection_participants_controller_spec.rb
@@ -53,21 +53,21 @@ describe CollectionParticipantsController do
       end
 
       context "where there is a collection" do
-        let (:collection) { FactoryGirl.create(:collection) }
-        let (:current_role) { CollectionParticipant::NONE }
+        let(:collection) { FactoryGirl.create(:collection) }
+        let(:current_role) { CollectionParticipant::NONE }
 
         context "where the user is already a participant" do
-          let! (:participant) {
+          let!(:participant) do
             FactoryGirl.create(
               :collection_participant,
               collection: collection,
               pseud: user.default_pseud,
               participant_role: current_role
             )
-          }
+          end
 
           context "where the user has been invited" do
-            let (:current_role) { CollectionParticipant::INVITED }
+            let(:current_role) { CollectionParticipant::INVITED }
 
             it "approves the participant and redirects to the index" do
               get :join, { collection_id: collection.name }
@@ -98,9 +98,9 @@ describe CollectionParticipantsController do
   end
 
   describe "index" do
-    let (:collection) { FactoryGirl.create(:collection) }
-    let (:current_role) { CollectionParticipant::NONE }
-    let (:user) { FactoryGirl.create(:user) }
+    let(:collection) { FactoryGirl.create(:collection) }
+    let(:current_role) { CollectionParticipant::NONE }
+    let(:user) { FactoryGirl.create(:user) }
 
     context "user is not logged in" do
       it "redirects to the index and displays an access denied message" do
@@ -110,15 +110,15 @@ describe CollectionParticipantsController do
     end
 
     context "user is logged in" do
-      let! (:participant) {
+      let!(:participant) do
         FactoryGirl.create(
           :collection_participant,
           collection: collection,
           pseud: user.default_pseud,
           participant_role: current_role
         )
-      }
-      let (:params) { { collection_id: collection.name } }
+      end
+      let(:params) { { collection_id: collection.name } }
 
       before do
         fake_login_known_user(user)
@@ -133,10 +133,10 @@ describe CollectionParticipantsController do
 
       context "where the user is a maintainer" do
         render_views
-        let (:current_role) { CollectionParticipant::MODERATOR }
+        let(:current_role) { CollectionParticipant::MODERATOR }
 
         context "where the collection has several participants" do
-          let! (:users) {
+          let!(:users) do
             3.times.map do
               user = FactoryGirl.create(:user)
               FactoryGirl.create(
@@ -146,7 +146,7 @@ describe CollectionParticipantsController do
               )
               user
             end
-          }
+          end
 
           it "displays the participants in the correct order" do
             get :index, params
@@ -161,26 +161,26 @@ describe CollectionParticipantsController do
   end
 
   describe "update" do
-    let (:user) { FactoryGirl.create(:user) }
-    let (:collection) { FactoryGirl.create(:collection) }
-    let (:user_role) { CollectionParticipant::NONE }
-    let! (:user_participant) {
+    let(:user) { FactoryGirl.create(:user) }
+    let(:collection) { FactoryGirl.create(:collection) }
+    let(:user_role) { CollectionParticipant::NONE }
+    let!(:user_participant) do
       FactoryGirl.create(
         :collection_participant,
         pseud: user.default_pseud,
         collection: collection,
         participant_role: user_role
       )
-    }
-    let (:id_to_update) { nil }
-    let (:params) {
+    end
+    let(:id_to_update) { nil }
+    let(:params) do
       {
         collection_participant: {
           participant_role:  CollectionParticipant::MEMBER,
           id: id_to_update
         }
       }
-    }
+    end
 
     before do
       fake_login_known_user(user)
@@ -196,14 +196,14 @@ describe CollectionParticipantsController do
     end
 
     context "where there is a participant" do
-      let (:participant) {
+      let(:participant) {
         FactoryGirl.create(
           :collection_participant,
           collection: user_participant.collection,
           participant_role: CollectionParticipant::NONE
         )
       }
-      let (:id_to_update) { participant.id }
+      let(:id_to_update) { participant.id }
       context "where the user is not a collection maintainer" do
         it "redirects to the collection page and displays an error" do
           put :update, params
@@ -214,7 +214,7 @@ describe CollectionParticipantsController do
       end
 
       context "where the user is a collection maintainer" do
-        let (:user_role) { CollectionParticipant::MODERATOR }
+        let(:user_role) { CollectionParticipant::MODERATOR }
         context "where the participant is updated successfully" do
           it "successfully updates and redirects to collection participants" do
             put :update, params
@@ -242,28 +242,28 @@ describe CollectionParticipantsController do
   end
 
   describe "destroy" do
-    let (:user) { FactoryGirl.create(:user) }
-    let (:pseud_name) { user.default_pseud.name }
-    let (:collection) { FactoryGirl.create(:collection) }
-    let (:user_participant_role) { CollectionParticipant::MEMBER }
-    let! (:user_participant) {
+    let(:user) { FactoryGirl.create(:user) }
+    let(:pseud_name) { user.default_pseud.name }
+    let(:collection) { FactoryGirl.create(:collection) }
+    let(:user_participant_role) { CollectionParticipant::MEMBER }
+    let!(:user_participant) do
       FactoryGirl.create(
         :collection_participant,
         pseud: user.default_pseud,
         collection: collection,
         participant_role: user_participant_role
       )
-    }
-    let (:params) {
+    end
+    let(:params) do
       { id: user_participant.id }
-    }
+    end
 
     before do
       fake_login_known_user(user)
     end
 
     context "where there is no participant found" do
-      let (:params) { { id: nil } }
+      let(:params) { { id: nil } }
 
       it "displays an error and redirects to the index" do
         delete :destroy, params
@@ -282,17 +282,15 @@ describe CollectionParticipantsController do
         end
 
         context "where the user is trying to destroy another participant" do
-          let (:other_participant) {
+          let(:other_participant) do
             FactoryGirl.create(
               :collection_participant,
               collection: collection,
               participant_role: CollectionParticipant::MEMBER
             )
-          }
-          let (:pseud_name) { other_participant.pseud.name }
-          let (:params) {
-            { id: other_participant.id }
-          }
+          end
+          let(:pseud_name) { other_participant.pseud.name }
+          let(:params) { { id: other_participant.id } }
 
           it "doesn't allow the destroy and redirects to the collection page" do
             delete :destroy, params
@@ -304,19 +302,19 @@ describe CollectionParticipantsController do
       end
 
       context "where user is a maintainer" do
-        let (:user_participant_role) { CollectionParticipant::MODERATOR }
-        let (:collection) { FactoryGirl.create(:collection) }
-        let (:other_participant) {
+        let(:user_participant_role) { CollectionParticipant::MODERATOR }
+        let(:collection) { FactoryGirl.create(:collection) }
+        let(:other_participant) do
           FactoryGirl.create(
             :collection_participant,
             collection: collection,
             participant_role: CollectionParticipant::MEMBER
           )
-        }
-        let (:pseud_name) { other_participant.pseud.name }
-        let (:params) {
+        end
+        let(:pseud_name) { other_participant.pseud.name }
+        let(:params) do
           { id: other_participant.id }
-        }
+        end
 
         context "where participant to be destroyed is not an owner" do
           it "destroys the participant successfully and redirects to index" do
@@ -327,8 +325,8 @@ describe CollectionParticipantsController do
         end
 
         context "where participant to be destroyed is an owner" do
-          let (:delete_participant_id) { CollectionParticipant.find_by_pseud_id(collection.owners.first.id) }
-          let (:params) {
+          let(:delete_participant_id) { CollectionParticipant.find_by_pseud_id(collection.owners.first.id) }
+          let(:params) {
             { id: delete_participant_id }
           }
 
@@ -341,14 +339,14 @@ describe CollectionParticipantsController do
           end
 
           context "where there are other owners" do
-            let! (:pseud_name) { CollectionParticipant.find(delete_participant_id).pseud.name }
-            let! (:other_owner) {
+            let!(:pseud_name) { CollectionParticipant.find(delete_participant_id).pseud.name }
+            let!(:other_owner) do
               FactoryGirl.create(
                 :collection_participant,
                 collection: collection,
                 participant_role: CollectionParticipant::OWNER
               )
-            }
+            end
 
             it "destroys the participant successfully and redirects to index" do
               delete :destroy, params
@@ -362,24 +360,24 @@ describe CollectionParticipantsController do
   end
 
   describe "add" do
-    let (:user) { FactoryGirl.create(:user) }
-    let (:collection) { FactoryGirl.create(:collection) }
-    let (:participants_to_invite) { "" }
-    let! (:params) {
+    let(:user) { FactoryGirl.create(:user) }
+    let(:collection) { FactoryGirl.create(:collection) }
+    let(:participants_to_invite) { "" }
+    let!(:params) do
       {
         collection_id: collection.name,
         participants_to_invite: participants_to_invite
       }
-    }
-    let (:user_participant_role) { CollectionParticipant::MEMBER }
-    let! (:user_participant) {
+    end
+    let(:user_participant_role) { CollectionParticipant::MEMBER }
+    let!(:user_participant) do
       FactoryGirl.create(
         :collection_participant,
         pseud: user.default_pseud,
         collection: collection,
         participant_role: user_participant_role
       )
-    }
+    end
 
     before do
       fake_login_known_user(user)
@@ -393,15 +391,15 @@ describe CollectionParticipantsController do
     end
 
     context "where the user is a maintainer" do
-      let (:user_participant_role) { CollectionParticipant:: MODERATOR }
-      let (:banned) { false }
-      let (:users) { 3.times.map { FactoryGirl.create(:user, banned: banned) } }
-      let (:participants_to_invite) {
+      let(:user_participant_role) { CollectionParticipant:: MODERATOR }
+      let(:banned) { false }
+      let(:users) { Array.new(3) { FactoryGirl.create(:user, banned: banned) } }
+      let(:participants_to_invite) do
         users.map(&:default_pseud).map(&:byline).map(&:to_s).join(",")
-      }
+      end
 
       context "where users to be added have already applied to the collection" do
-        let! (:participants) {
+        let!(:participants) do
           users.each do |user|
             FactoryGirl.create(
               :collection_participant,
@@ -410,7 +408,7 @@ describe CollectionParticipantsController do
               participant_role: CollectionParticipant::NONE
             )
           end
-        }
+        end
 
         it "approves those users, redirects to the collection participants page and displays a notification" do
           get :add, params
@@ -438,7 +436,7 @@ describe CollectionParticipantsController do
       end
 
       context "where users to be added are banned users" do
-        let (:banned) { true }
+        let(:banned) { true }
 
         it "doesn't approve the member, displays an error and redirects" do
           get :add, params
@@ -450,10 +448,10 @@ describe CollectionParticipantsController do
       end
 
       context "where users to be added can't be found" do
-        let! (:pseud_ids) { users.map(&:default_pseud).map(&:id) }
+        let!(:pseud_ids) { users.map(&:default_pseud).map(&:id) }
         it "displays an error and redirects" do
           users.each do |user|
-              user.default_pseud.destroy
+            user.default_pseud.destroy
           end
 
           get :add, params

--- a/spec/controllers/collection_participants_controller_spec.rb
+++ b/spec/controllers/collection_participants_controller_spec.rb
@@ -36,7 +36,7 @@ describe CollectionParticipantsController do
 
       context "where there is no collection" do
         it "redirects to index and displays an error" do
-          get :join, { collection_id: nil }
+          get :join, collection_id: nil
           it_redirects_to_with_error(root_path, "Which collection did you want to join?")
         end
 
@@ -70,7 +70,7 @@ describe CollectionParticipantsController do
             let(:current_role) { CollectionParticipant::INVITED }
 
             it "approves the participant and redirects to the index" do
-              get :join, { collection_id: collection.name }
+              get :join, collection_id: collection.name
               expect(CollectionParticipant.find(participant.id).participant_role).to eq CollectionParticipant::MEMBER
               it_redirects_to_with_notice(root_path, "You are now a member of #{collection.title}.")
             end
@@ -78,7 +78,7 @@ describe CollectionParticipantsController do
 
           context "where the user is not currently invited" do
             it "redirects to the index and displays a notice that the user has already joined or applied" do
-              get :join, { collection_id: collection.name }
+              get :join, collection_id: collection.name
               it_redirects_to_with_notice(root_path, "You have already joined (or applied to) this collection.")
             end
           end
@@ -86,7 +86,7 @@ describe CollectionParticipantsController do
 
         context "where user isn't a participant yet" do
           it "creates a participant for the user, redirects to index and notifies them that they have applied" do
-            get :join, { collection_id: collection.name }
+            get :join, collection_id: collection.name
             participant = CollectionParticipant.find_by_pseud_id(user.default_pseud.id)
             expect(participant).to be_present
             expect(participant.participant_role).to eq CollectionParticipant::NONE
@@ -104,7 +104,7 @@ describe CollectionParticipantsController do
 
     context "user is not logged in" do
       it "redirects to the index and displays an access denied message" do
-        get :index, { collection_id: collection.name }
+        get :index, collection_id: collection.name
         it_redirects_to_with_error(new_user_session_path, "Sorry, you don't have permission to access the page you were trying to reach. Please log in.")
       end
     end
@@ -137,7 +137,7 @@ describe CollectionParticipantsController do
 
         context "where the collection has several participants" do
           let!(:users) do
-            3.times.map do
+            Array.new(3) do
               user = FactoryGirl.create(:user)
               FactoryGirl.create(
                 :collection_participant,
@@ -196,13 +196,13 @@ describe CollectionParticipantsController do
     end
 
     context "where there is a participant" do
-      let(:participant) {
+      let(:participant) do
         FactoryGirl.create(
           :collection_participant,
           collection: user_participant.collection,
           participant_role: CollectionParticipant::NONE
         )
-      }
+      end
       let(:id_to_update) { participant.id }
       context "where the user is not a collection maintainer" do
         it "redirects to the collection page and displays an error" do
@@ -326,9 +326,7 @@ describe CollectionParticipantsController do
 
         context "where participant to be destroyed is an owner" do
           let(:delete_participant_id) { CollectionParticipant.find_by_pseud_id(collection.owners.first.id) }
-          let(:params) {
-            { id: delete_participant_id }
-          }
+          let(:params) { { id: delete_participant_id } }
 
           context "where there are no other owners" do
             it "displays an error and redirects to the collection participants path" do

--- a/spec/controllers/collection_participants_controller_spec.rb
+++ b/spec/controllers/collection_participants_controller_spec.rb
@@ -201,7 +201,6 @@ describe CollectionParticipantsController do
           it "successfully updates and redirects to collection participants" do
             put :update, params
             it_redirects_to_with_notice(collection_participants_path(collection), "Updated #{participant.pseud.name}.")
-            expect(flash[:notice]).to eq "Updated #{participant.pseud.name}."
           end
         end
 
@@ -273,7 +272,7 @@ describe CollectionParticipantsController do
           it "doesn't allow the destroy and redirects to the collection page" do
             delete :destroy, params
             it_redirects_to collection_path(collection)
-            expect(flash[:error]).to eq "Sorry, you're not allowed to do that."
+            it_redirects_to_with_error(collection_path(collection), "Sorry, you're not allowed to do that.")
             expect(CollectionParticipant.find(other_participant)).to be_present
           end
         end

--- a/spec/controllers/works_controller_spec.rb
+++ b/spec/controllers/works_controller_spec.rb
@@ -2,11 +2,7 @@ require 'spec_helper'
 
 describe WorksController do
   include LoginMacros
-
-  def it_redirects_to_user_login
-    expect(response).to have_http_status(:redirect)
-    expect(response).to redirect_to new_user_session_path
-  end
+  include RedirectExpectationHelper
 
   describe "before_filter #clean_work_search_params" do
     let(:params) { nil }
@@ -19,7 +15,7 @@ describe WorksController do
     context "when no work search parameters are given" do
       it "redirects to the login screen when no user is logged in" do
         get :clean_work_search_params, params
-        it_redirects_to_user_login
+        it_redirects_to new_user_session_path
       end
 
       it "returns a nil" do
@@ -183,7 +179,7 @@ describe WorksController do
   describe "new" do
     it "should not return the form for anyone not logged in" do
       get :new
-      it_redirects_to_user_login
+      it_redirects_to new_user_session_path
     end
 
     it "should render the form if logged in" do

--- a/spec/support/redirect_expectation_helper.rb
+++ b/spec/support/redirect_expectation_helper.rb
@@ -1,0 +1,17 @@
+module RedirectExpectationHelper
+
+  def it_redirects_to_with_notice(path, notice)
+    it_redirects_to(path)
+    expect(flash[:notice]).to eq notice
+  end
+
+  def it_redirects_to_with_error(path, error)
+    it_redirects_to(path)
+    expect(flash[:error]).to eq error
+  end
+
+  def it_redirects_to(path)
+    expect(response).to have_http_status :redirect
+    expect(response).to redirect_to path
+  end
+end

--- a/spec/support/redirect_expectation_helper.rb
+++ b/spec/support/redirect_expectation_helper.rb
@@ -1,5 +1,5 @@
+# frozen_string_literal: true
 module RedirectExpectationHelper
-
   def it_redirects_to_with_notice(path, notice)
     it_redirects_to(path)
     expect(flash[:notice]).to eq notice


### PR DESCRIPTION
Notes:
* The collection lookup in load_participant_and_collection using collection.find raises an ActiveRecord error if the collection isn't found; since there is a case handling this I assumed it wasn't the desired behavior, so I changed it to .where(id: the_id).first which will return nil if the collection isn't found. Then the handling works as expected.
* The participant.approve_membership! did not previously appear to work as written.

## Issue

https://otwarchive.atlassian.net/browse/AO3-4771

## Purpose

Rspec tests for the collection_participants_controller with small tweaks to the controller so functionality works as expected.

## Testing

There are two minor changes: 
* When updating participants, when changing a participant from invited to member, it should now work
* When a participant is deleted between when the edit page is opened and the edit is attempted, there will be a redirect to the archive index with a message that says "Which participant did you want to work with?"

## Credit

potatoesque, she/her
