### PR TITLE
AO3-4549 - Stop page title creation from causing a 500 error when fandom is empty

### DIFF
--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -210,19 +210,18 @@ class WorksController < ApplicationController
   def show
     @tag_groups = @work.tag_groups
     if @work.unrevealed?
-      @page_title = ts('Mystery Work')
+      @page_title = ts("Mystery Work")
     else
-      page_title_inner = ''
-      page_creator = ''
-      if @work.anonymous?
-        page_creator = ts('Anonymous')
-      else
-        page_creator = @work.pseuds.collect(&:byline).sort.join(', ')
-      end
-      page_title_inner = if @tag_groups['Fandom'].size > 3
-                           ts('Multifandom')
+      page_creator = if @work.anonymous?
+                       ts("Anonymous")
+                     else
+                       @work.pseuds.map(&:byline).sort.join(", ")
+                     end
+      fandoms = @tag_groups["Fandom"]
+      page_title_inner = if fandoms.size > 3
+                           ts("Multifandom")
                          else
-                           @tag_groups['Fandom'][0].name
+                           fandoms.empty? ? ts("No fandom specified") : fandoms[0].name
                          end
       @page_title = get_page_title(page_title_inner, page_creator, @work.title)
     end

--- a/spec/controllers/works_controller_spec.rb
+++ b/spec/controllers/works_controller_spec.rb
@@ -195,19 +195,28 @@ describe WorksController do
 
   describe "create" do
     before do
-      @user = FactoryGirl.create(:user)
+      @user = create(:user)
       fake_login_known_user(@user)
     end
 
     it "should not allow a user to submit only a pseud that is not theirs" do
-      @user2 = FactoryGirl.create(:user)
-      work_attributes = FactoryGirl.attributes_for(:work)
+      @user2 = create(:user)
+      work_attributes = attributes_for(:work)
       work_attributes[:author_attributes] = { ids: [@user2.pseuds.first.id] }
       expect {
         post :create, { work: work_attributes }
       }.to_not change(Work, :count)
       expect(response).to render_template("new")
       expect(flash[:error]).to eq "You're not allowed to use that pseud."
+    end
+  end
+
+  describe "show" do
+    it "shouldn't error when a work has no fandoms" do
+      work = create(:work, fandoms: [], posted: true)
+      fake_login
+      get :show, id: work.id
+      expect(assigns(:page_title)).to include "No fandom specified"
     end
   end
 


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-4549

## Purpose

It is possible to edit an existing work and save it without a fandom (see [AO3-4808](https://otwarchive.atlassian.net/browse/AO3-4808)). When this happens and the work's cached blurb expires, trying to view the work results in a 500 error because the code that generates the page title assumes there is always a fandom. 

## Testing

1. edit an existing work to remove the fandom
2. get someone with database admin rights to kill the Rails cache
3. check that the work is still accessible, does not have a fandom in the blurb and that the page title says "No fandom specified" where it would normally have the fandom.

## References

The underlying cause of works being saved without a fandom will be addressed in [AO3-4808](https://otwarchive.atlassian.net/browse/AO3-4808). 