### PR TITLE
AO3-4816 Forbidden attribute protection for collection profile model

### DIFF
--- a/app/models/collection_profile.rb
+++ b/app/models/collection_profile.rb
@@ -1,28 +1,25 @@
 class CollectionProfile < ActiveRecord::Base
+  include ActiveModel::ForbiddenAttributesProtection
   belongs_to :collection
 
-  attr_protected :intro_sanitizer_version
-  attr_protected :faq_sanitizer_version
-  attr_protected :rules_sanitizer_version
-  
-  validates_length_of :intro, 
-    :allow_blank => true,
-    :maximum => ArchiveConfig.INFO_MAX, :too_long => ts("must be less than %{max} letters long.", :max => ArchiveConfig.INFO_MAX)
+  validates_length_of :intro,
+    allow_blank: true,
+    maximum: ArchiveConfig.INFO_MAX, too_long: ts("must be less than %{max} letters long.", max: ArchiveConfig.INFO_MAX)
 
-  validates_length_of :faq, 
-    :allow_blank => true,
-    :maximum => ArchiveConfig.INFO_MAX, :too_long => ts("must be less than %{max} letters long.", :max => ArchiveConfig.INFO_MAX)
+  validates_length_of :faq,
+    allow_blank: true,
+    maximum: ArchiveConfig.INFO_MAX, too_long: ts("must be less than %{max} letters long.", max: ArchiveConfig.INFO_MAX)
 
-  validates_length_of :rules, 
-    :allow_blank => true,
-    :maximum => ArchiveConfig.INFO_MAX, :too_long => ts("must be less than %{max} letters long.", :max => ArchiveConfig.INFO_MAX)
+  validates_length_of :rules,
+    allow_blank: true,
+    maximum: ArchiveConfig.INFO_MAX, too_long: ts("must be less than %{max} letters long.", max: ArchiveConfig.INFO_MAX)
 
-  validates_length_of :assignment_notification, 
-    :allow_blank => true,
-    :maximum => ArchiveConfig.SUMMARY_MAX, :too_long => ts("must be less than %{max} letters long.", :max => ArchiveConfig.SUMMARY_MAX)
+  validates_length_of :assignment_notification,
+    allow_blank: true,
+    maximum: ArchiveConfig.SUMMARY_MAX, too_long: ts("must be less than %{max} letters long.", max: ArchiveConfig.SUMMARY_MAX)
 
-  validates_length_of :gift_notification, 
-    :allow_blank => true,
-    :maximum => ArchiveConfig.SUMMARY_MAX, :too_long => ts("must be less than %{max} letters long.", :max => ArchiveConfig.SUMMARY_MAX)
+  validates_length_of :gift_notification,
+    allow_blank: true,
+    maximum: ArchiveConfig.SUMMARY_MAX, too_long: ts("must be less than %{max} letters long.", max: ArchiveConfig.SUMMARY_MAX)
 
 end


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-4816

## Purpose

Adds forbidden attribute protection to collection profile now that the collections controller has been deployed.

## Testing

74% automated test coverage, but since a test found this, I'd say as long as the failing test (cucumber features/admins/users/admin_abuse_users.feature:106) passes, it's all right and doesn't need manual testing.