### PR TITLE
AO3-4820 Fix 500 error when creating skin with "archive" in title

### DIFF
--- a/app/controllers/skins_controller.rb
+++ b/app/controllers/skins_controller.rb
@@ -2,7 +2,6 @@ class SkinsController < ApplicationController
 
   before_filter :users_only, :only => [:new, :create, :destroy]
   before_filter :load_skin, :except => [:index, :new, :create, :unset]
-  before_filter :check_title, :only => [:create, :update]
   before_filter :check_ownership_or_admin, :only => [:edit, :update]
   before_filter :check_ownership, :only => [:destroy]
   before_filter :check_visibility, :only => [:show]
@@ -22,13 +21,6 @@ class SkinsController < ApplicationController
     unless @skin.editable?
       flash[:error] = ts("Sorry, you don't have permission to edit this skin")
       redirect_to @skin and return 
-    end
-  end
-  
-  def check_title
-    if params[:skin][:title].match(/archive/i)
-      flash[:error] = ts("You can't use the word 'archive' in your skin title, sorry! (We have to reserve it for official skins.)")
-      render (@skin ? :edit : :new) and return
     end
   end
   

--- a/app/models/skin.rb
+++ b/app/models/skin.rb
@@ -94,7 +94,7 @@ class Skin < ActiveRecord::Base
 
   validates_presence_of :title
   validates_uniqueness_of :title, :message => ts('must be unique')
-  validate :valid_title
+  validate :valid_title, :if => "User.current_user"
   def valid_title
     if title =~ /archive/i
       errors.add(:title, ts("can't use the word 'archive'. (We have to reserve it for official skins.)"))

--- a/app/models/skin.rb
+++ b/app/models/skin.rb
@@ -96,7 +96,7 @@ class Skin < ActiveRecord::Base
   validates_uniqueness_of :title, :message => ts('must be unique')
   validate :valid_title
   def valid_title
-    if self.title.match(/archive/i)
+    if title =~ /archive/i
       errors.add(:title, ts("can't use the word 'archive'. (We have to reserve it for official skins.)"))
     end
   end

--- a/app/models/skin.rb
+++ b/app/models/skin.rb
@@ -94,6 +94,12 @@ class Skin < ActiveRecord::Base
 
   validates_presence_of :title
   validates_uniqueness_of :title, :message => ts('must be unique')
+  validate :valid_title
+  def valid_title
+    if self.title.match(/archive/i)
+      errors.add(:title, ts("can't use the word 'archive'. (We have to reserve it for official skins.)"))
+    end
+  end
 
   validates_numericality_of :margin, :base_em, :allow_nil => true
   validate :valid_font

--- a/app/models/skin.rb
+++ b/app/models/skin.rb
@@ -94,6 +94,7 @@ class Skin < ActiveRecord::Base
 
   validates_presence_of :title
   validates_uniqueness_of :title, :message => ts('must be unique')
+  # We don't want this validation to run when loading site skins with the rake task
   validate :valid_title, :if => "User.current_user"
   def valid_title
     if title =~ /archive/i

--- a/features/admins/admin_skins.feature
+++ b/features/admins/admin_skins.feature
@@ -100,10 +100,10 @@ Feature: Admin manage skins
     And I should not see "#title"
   Then the cache of the skin on "public skin" should expire after I save the skin
 
-  Scenario: Admins should be able to unapprove public skins, which should also remove
-  them from preferences
+  Scenario: Admins should be able to unapprove public skins, which should also
+  remove them from preferences
   Given "skinuser" is using the approved public skin "public skin" with css "#title { text-decoration: blink;}"
-    And I unapprove the skin "public skin"
+  When I unapprove the skin "public skin"
   Then I should see "The following skins were updated: public skin"
     And I should see "public skin" within "table#unapproved_skins"
   When I am logged in as "skinuser"
@@ -111,3 +111,4 @@ Feature: Admin manage skins
   Then "Default" should be selected within "preference_skin_id"
     And I should not see "#title"
     And I should not see "text-decoration: blink;"
+

--- a/features/admins/admin_skins.feature
+++ b/features/admins/admin_skins.feature
@@ -1,0 +1,113 @@
+@skins
+Feature: Admin manage skins
+
+  Scenario: Users should not be able to see the admin skins page
+  Given I am logged in as "skinner"
+  When I go to admin's skins page
+  Then I should see "I'm sorry, only an admin can look at that area"
+
+  Scenario: Admin can cache and uncache a public skin
+  Given basic skins
+    And the approved public skin "public skin"
+    And I am logged in as an admin
+   When I follow "Approved Skins"
+    And I check "Cache"
+   Then I press "Update" 
+    And I should see "The following skins were updated: public skin"
+   When I follow "Approved Skins"
+    And I check "Uncache"
+    And I press "Update"
+   Then I should see "The following skins were updated: public skin"
+
+  Scenario: Admin can add a public skin to the chooser and then remove it
+  Given the approved public skin "public skin"
+    And the skin "public skin" is cached
+    And I am logged in as an admin
+  When I follow "Approved Skins"
+    And I check "Chooser"
+    And I press "Update"
+  Then I should see "The following skins were updated: public skin"
+  When I follow "Approved Skins"
+    And I check "Not In Chooser"
+    And I press "Update"
+  Then I should see "The following skins were updated: public skin"
+
+  Scenario: An admin can reject and unreject a skin
+  Given the unapproved public skin "public skin"
+    And I am logged in as an admin
+  When I go to admin's skins page
+    And I check "make_rejected_public_skin"
+    And I submit
+  Then I should see "The following skins were updated: public skin"
+  When I follow "Rejected Skins"
+  Then I should see "public skin"
+  When I check "make_unrejected_public_skin"
+    And I submit
+  Then I should see "The following skins were updated: public skin"
+  When I follow "Rejected Skins"
+  Then I should not see "public skin"
+
+  Scenario: An admin can feature and unfeature skin
+  Given the approved public skin "public skin"
+    And I am logged in as an admin
+  When I follow "Approved Skins"
+    And I check "Feature"
+    And I submit
+  Then I should see "The following skins were updated: public skin"
+  When I follow "Approved Skins"
+    And I check "Unfeature"
+    And I submit
+  Then I should see "The following skins were updated: public skin"
+
+  Scenario: Admins should be able to see public skins in the admin skins page
+  Given the unapproved public skin "public skin"
+    And I am logged in as an admin
+  When I go to admin's skins page
+  Then I should see "public skin" within "table#unapproved_skins"
+
+  Scenario: Admins should not be able to edit unapproved skins
+  Given the unapproved public skin "public skin"
+    And I am logged in as an admin
+  When I go to "public skin" skin page
+  Then I should not see "Edit"
+    And I should not see "Delete"
+  When I go to "public skin" edit skin page
+  Then I should see "Sorry, you don't have permission"
+
+  Scenario: Admins should be able to approve public skins
+  Given the unapproved public skin "public skin"
+    And I am logged in as an admin
+  When I go to admin's skins page
+    And I check "public skin"
+    And I submit
+  Then I should see "The following skins were updated: public skin"
+  When I follow "Approved Skins"
+  Then I should see "public skin" within "table#approved_skins"
+
+  Scenario: Admins should be able to edit but not delete public approved skins
+  Given the approved public skin "public skin" with css "#title { text-decoration: blink;}"
+    And I am logged in as an admin
+  When I go to "public skin" skin page
+  Then I should see "Edit"
+    But I should not see "Delete"
+  When I follow "Edit"
+    And I fill in "CSS" with "#greeting.logged-in { text-decoration: blink;}"
+    And I fill in "Description" with "Blinky love (admin modified)"
+    And I submit
+  Then I should see an update confirmation message
+    And I should see "(admin modified)"
+    And I should see "#greeting.logged-in"
+    And I should not see "#title"
+  Then the cache of the skin on "public skin" should expire after I save the skin
+
+  Scenario: Admins should be able to unapprove public skins, which should also remove
+  them from preferences
+  Given "skinuser" is using the approved public skin "public skin" with css "#title { text-decoration: blink;}"
+    And I unapprove the skin "public skin"
+  Then I should see "The following skins were updated: public skin"
+    And I should see "public skin" within "table#unapproved_skins"
+  When I am logged in as "skinuser"
+    And I am on skinuser's preferences page
+  Then "Default" should be selected within "preference_skin_id"
+    And I should not see "#title"
+    And I should not see "text-decoration: blink;"

--- a/features/other_b/skin.feature
+++ b/features/other_b/skin.feature
@@ -239,3 +239,10 @@ Feature: Non-public site and work skins
   Then I should see "You can only browse your own skins and approved public skins."
     And I should be on the public skins page
 
+  Scenario: A user can't use fixed positioning in a work skin
+  Given I am logged in as "skinner"
+  When I set up the skin "Work Skin" with css ".selector {position: fixed; top: 0;}"
+    And I select "Work Skin" from "Type"
+    And I submit
+  Then I should see "The position property in .selector cannot have the value fixed in Work skins, sorry!"
+

--- a/features/other_b/skin.feature
+++ b/features/other_b/skin.feature
@@ -96,7 +96,8 @@ Feature: creating and editing skins
     And I submit
   Then I should see "The following skins were updated: public skin"
 
-  Scenario: A user should be able to select one of their own non-public skins to use in their preferences
+  Scenario: A user should be able to select one of their own non-public skins to use in
+  their preferences
   Given I am logged in as "skinner"
     And I create the skin "my blinking skin" with css "#title { text-decoration: blink;}"
   When I am on skinner's preferences page
@@ -106,7 +107,8 @@ Feature: creating and editing skins
     And I should see "#title {" within "style"
     And I should see "text-decoration: blink;" within "style"
 
-  Scenario: A user should be able to select one of their own non-public skins to use in their My Skins page
+  Scenario: A user should be able to select one of their own non-public skins to use in
+  their My Skins page
   Given I am logged in as "skinner"
     And I create the skin "my blinking skin" with css "#title { text-decoration: blink;}"
   Then I should see "my blinking skin"
@@ -138,8 +140,8 @@ Feature: creating and editing skins
     And I submit
   Then I should see an update confirmation message
 
-  Scenario: Newly created public skins should not appear on the main skins page until approved and should be
-    marked as not-yet-approved
+  Scenario: Newly created public skins should not appear on the main skins page until
+  approved and should be marked as not-yet-approved
   Given I am logged in as "skinner"
     And the unapproved public skin "public skin"
   When I am on the skins page
@@ -229,7 +231,8 @@ Feature: creating and editing skins
     And I should see "#title {" within "style"
     And I should see "text-decoration: blink;" within "style"
 
-  Scenario: Admins should be able to unapprove public skins, which should also remove them from preferences
+  Scenario: Admins should be able to unapprove public skins, which should also remove
+  them from preferences
   Given "skinuser" is using the approved public skin "public skin" with css "#title { text-decoration: blink;}"
     And I unapprove the skin "public skin"
   Then I should see "The following skins were updated: public skin"
@@ -250,7 +253,8 @@ Feature: creating and editing skins
   When I follow "Write Custom CSS"
     Then I should see "CSS"
 
-  Scenario: Users should be able to create and use a wizard skin to adjust work margins, and they should be able to edit the skin while they are using it
+  Scenario: Users should be able to create and use a wizard skin to adjust work margins,
+  and they should be able to edit the skin while they are using it
   Given I am logged in as "skinner"
   When I am on the new wizard skin page
     And I fill in "Title" with "Wide margins"
@@ -282,7 +286,8 @@ Feature: creating and editing skins
   When I am on skinner's preferences page
   Then "Wide margins" should be selected within "preference_skin_id"
 
-  Scenario: Users should be able to create and use a wizard skin with multiple wizard settings
+  Scenario: Users should be able to create and use a wizard skin with multiple wizard
+  settings
   Given I am logged in as "skinner"
   When I am on the new wizard skin page
     And I fill in "Title" with "Many changes"
@@ -408,7 +413,8 @@ Feature: creating and editing skins
       And I follow "Create Work Skin"
     Then "Work Skin" should be selected within "skin_type"
 
-  Scenario: Skin type should persist and remain selectable if you encounter errors during creation
+  Scenario: Skin type should persist and remain selectable if you encounter errors
+  during creation
     Given I am logged in as "skinner"
     When I am on the skins page
       And I follow "My Work Skins"
@@ -479,7 +485,7 @@ Feature: creating and editing skins
   Then I should see "Skin was successfully created"
   Then the cache of the skin on "my blinking skin" should not expire after I save "Complex"
   Then the cache of the skin on "Complex" should expire after I save a parent skin
-  
+
   Scenario: Users should be able to create skins using @media queries
   Given I am logged in as "skinner"
     And I set up the skin "Media Query Test Skin"
@@ -500,7 +506,6 @@ Feature: creating and editing skins
     And I am on the home page
     And I follow "public skin"
    Then I should see "The skin public skin has been set. This will last for your current session."
-
     And I follow "Default"
    Then I should see "You are now using the default Archive skin again!"
 

--- a/features/other_b/skin.feature
+++ b/features/other_b/skin.feature
@@ -1,55 +1,9 @@
 @skins
-Feature: creating and editing skins
-
-  Scenario: A user's initial skin should be set to default
-  Given basic skins
-    And I am logged in as "skinner"
-  When I am on skinner's preferences page
-  Then "Default" should be selected within "preference_skin_id"
-
-  Scenario: User can set a skin for a session and then unset it
-  Given basic skins
-    And the approved public skin "public skin" with css "#title { text-decoration: blink;}"
-    And the skin "public skin" is cached
-    And the skin "public skin" is in the chooser
-  When I am logged in as "skinner"
-    And I follow "public skin"
-  Then I should see "The skin public skin has been set. This will last for your current session."
-    And the page should have the cached skin "public skin"
-  When I follow "Default"
-  Then I should see "You are now using the default Archive skin again!"
-    And the page should not have the cached skin "public skin"
-
-  Scenario: Admin can cache and uncache a public skin
-  Given basic skins
-    And the approved public skin "public skin" with css "#title { text-decoration: blink;}"
-    And I am logged in as an admin
-   When I follow "Approved Skins"
-    And I check "Cache"
-   Then I press "Update" 
-    And I should see "The following skins were updated: public skin"
-   When I follow "Approved Skins"
-    And I check "Uncache"
-    And I press "Update"
-   Then I should see "The following skins were updated: public skin"
-
-  Scenario: Admin can add a public skin to the chooser and then remove it
-  Given the approved public skin "public skin" with css "#title { text-decoration: blink;}"
-    And the skin "public skin" is cached
-    And I am logged in as an admin
-  When I follow "Approved Skins"
-    And I check "Chooser"
-    And I press "Update"
-  Then I should see "The following skins were updated: public skin"
-  When I follow "Approved Skins"
-    And I check "Not In Chooser"
-    And I press "Update"
-  Then I should see "The following skins were updated: public skin"
+Feature: Non-public site and work skins
 
   Scenario: A user should be able to create a skin with CSS
-  Given basic skins
-    And I am logged in as "skinner"
-  When I am on skin's new page
+  Given I am logged in as "skinner"
+  When I am on the new skin page
     And I fill in "Title" with "my blinking skin"
     And I fill in "CSS" with "#title { text-decoration: blink;}"
     And I submit
@@ -66,35 +20,9 @@ Feature: creating and editing skins
     And I should not see "(Not yet reviewed)"
 
   Scenario: A logged-out user should not be able to create skins.
-  When I am on skin's new page
+  Given I am logged out
+  When I go to the new skin page
     Then I should see "Sorry, you don't have permission"
-
-  Scenario: An admin can reject and unreject a skin
-  Given the unapproved public skin "public skin"
-    And I am logged in as an admin
-  When I go to admin's skins page
-    And I check "make_rejected_public_skin"
-    And I submit
-  Then I should see "The following skins were updated: public skin"
-  When I follow "Rejected Skins"
-  Then I should see "public skin"
-  When I check "make_unrejected_public_skin"
-    And I submit
-  Then I should see "The following skins were updated: public skin"
-  When I follow "Rejected Skins"
-  Then I should not see "public skin"
-
-  Scenario: An admin can feature and unfeature skin
-  Given the approved public skin "public skin"
-    And I am logged in as an admin
-  When I follow "Approved Skins"
-    And I check "Feature"
-    And I submit
-  Then I should see "The following skins were updated: public skin"
-  When I follow "Approved Skins"
-    And I check "Unfeature"
-    And I submit
-  Then I should see "The following skins were updated: public skin"
 
   Scenario: A user should be able to select one of their own non-public skins to use in
   their preferences
@@ -119,18 +47,10 @@ Feature: creating and editing skins
 
   Scenario: Skin titles should be unique
   Given I am logged in as "skinner"
-  When I am on skin's new page
+  When I am on the new skin page
     And I fill in "Title" with "Default"
     And I submit
   Then I should see "must be unique"
-
-  Scenario: Only public skins should be on the main skins page
-  Given basic skins
-    And I am logged in as "skinner"
-    And I create the skin "my skin"
-  When I am on the skins page
-  Then I should not see "my skin"
-    And I should see "Default"
 
   Scenario: The user who creates a skin should be able to edit it
   Given I am logged in as "skinner"
@@ -140,184 +60,10 @@ Feature: creating and editing skins
     And I submit
   Then I should see an update confirmation message
 
-  Scenario: Newly created public skins should not appear on the main skins page until
-  approved and should be marked as not-yet-approved
-  Given I am logged in as "skinner"
-    And the unapproved public skin "public skin"
-  When I am on the skins page
-    Then I should not see "public skin"
-  When I am on skinner's skins page
-  Then I should see "public skin"
-    And I should see "(Not yet reviewed)"
-    And I should not see "(Approved)"
-
-  Scenario: Public skins should not be viewable by users until approved
-  Given the unapproved public skin "public skin"
-    And I am logged out
-  When I go to "public skin" skin page
-    Then I should see "Sorry, you don't have permission"
-  When I go to "public skin" edit skin page
-    Then I should see "Sorry, you don't have permission"
-  When I go to admin's skins page
-    Then I should see "I'm sorry, only an admin can"
-
-  Scenario: Users should not be able to see the admin skins page
-  Given I am logged in as "skinner"
-  When I go to admin's skins page
-  Then I should see "I'm sorry, only an admin can look at that area"
-
-  Scenario: Admins should be able to see public skins in the admin skins page
-  Given the unapproved public skin "public skin"
-    And I am logged in as an admin
-  When I go to admin's skins page
-  Then I should see "public skin" within "table#unapproved_skins"
-
-  Scenario: Admins should not be able to edit unapproved skins
-  Given the unapproved public skin "public skin"
-    And I am logged in as an admin
-  When I go to "public skin" skin page
-  Then I should not see "Edit"
-    And I should not see "Delete"
-  When I go to "public skin" edit skin page
-  Then I should see "Sorry, you don't have permission"
-
-  Scenario: Admins should be able to approve public skins
-  Given the unapproved public skin "public skin"
-    And I am logged in as an admin
-  When I go to admin's skins page
-    And I check "public skin"
-    And I submit
-  Then I should see "The following skins were updated: public skin"
-  When I follow "Approved Skins"
-  Then I should see "public skin" within "table#approved_skins"
-
-  Scenario: Admins should be able to edit but not delete public approved skins
-  Given the approved public skin "public skin" with css "#title { text-decoration: blink;}"
-    And I am logged in as an admin
-  When I go to "public skin" skin page
-  Then I should see "Edit"
-    But I should not see "Delete"
-  When I follow "Edit"
-    And I fill in "CSS" with "#greeting.logged-in { text-decoration: blink;}"
-    And I fill in "Description" with "Blinky love (admin modified)"
-    And I submit
-  Then I should see an update confirmation message
-    And I should see "(admin modified)"
-    And I should see "#greeting.logged-in"
-    And I should not see "#title"
-  Then the cache of the skin on "public skin" should expire after I save the skin
-
-  Scenario: Users should not be able to edit their public approved skins
-  Given the approved public skin "public skin"
-    And I am logged in as "skinner"
-    And I go to "public skin" edit skin page
-  Then I should see "Sorry, you don't have permission"
-  When I am on the skins page
-    Then I should see "public skin"
-  When I follow "Site Skins"
-  Then I should see "public skin"
-    And I should see "(Approved)"
-    And I should not see "Edit"
-
-  Scenario: Users should be able to use public approved skins created by others
-  Given the approved public skin "public skin" with css "#title { text-decoration: blink;}"
-    And I am logged in as "skinuser"
-    And I am on skinuser's preferences page
-  When I select "public skin" from "preference_skin_id"
-    And I submit
-  Then I should see "Your preferences were successfully updated."
-  When I am on skinuser's preferences page
-    And "public skin" should be selected within "preference_skin_id"
-    And I should see "#title {" within "style"
-    And I should see "text-decoration: blink;" within "style"
-
-  Scenario: Admins should be able to unapprove public skins, which should also remove
-  them from preferences
-  Given "skinuser" is using the approved public skin "public skin" with css "#title { text-decoration: blink;}"
-    And I unapprove the skin "public skin"
-  Then I should see "The following skins were updated: public skin"
-    And I should see "public skin" within "table#unapproved_skins"
-  When I am logged in as "skinuser"
-    And I am on skinuser's preferences page
-  Then "Default" should be selected within "preference_skin_id"
-    And I should not see "#title"
-    And I should not see "text-decoration: blink;"
-
-  Scenario: User should be able to toggle between the wizard and the form
-  When I am logged in
-    And I am on skin's new page
-  Then I should see "CSS" within "form#new_skin"
-  When I follow "Use Wizard"
-    Then I should see "Site Skin Wizard"
-    And I should not see "CSS" within "form"
-  When I follow "Write Custom CSS"
-    Then I should see "CSS"
-
-  Scenario: Users should be able to create and use a wizard skin to adjust work margins,
-  and they should be able to edit the skin while they are using it
-  Given I am logged in as "skinner"
-  When I am on the new wizard skin page
-    And I fill in "Title" with "Wide margins"
-    And I fill in "Description" with "Layout skin"
-    And I fill in "Work margin width" with "text"
-    And I submit
-  Then I should see a save error message
-    And I should see "Margin is not a number"
-  When I fill in "Work margin width" with "5"
-    And I submit
-  Then I should see "Skin was successfully created"
-    And I should see "Work margin width: 5%"
-  When I am on skinner's preferences page
-  Then "Default" should be selected within "preference_skin_id"
-  When I select "Wide margins" from "preference_skin_id"
-    And I submit
-  Then I should see "Your preferences were successfully updated."
-    And I should see "margin: auto 5%; max-width: 100%" within "style"
-    # Make sure that the creation/update cache keys are different:
-    And I wait 1 second
-  When I edit the skin "Wide margins" with the wizard
-    And I fill in "Work margin width" with "4.5"
-    And I submit
-  # TODO: Think about whether rounding to 4 is actually the right behaviour or not
-  Then I should see an update confirmation message
-    And I should see "Work margin width: 4%"
-    And I should not see "Work margin width: 4.5%"
-    And I should see "margin: auto 4%;" within "style"
-  When I am on skinner's preferences page
-  Then "Wide margins" should be selected within "preference_skin_id"
-
-  Scenario: Users should be able to create and use a wizard skin with multiple wizard
-  settings
-  Given I am logged in as "skinner"
-  When I am on the new wizard skin page
-    And I fill in "Title" with "Many changes"
-    And I fill in "Description" with "Layout skin"
-    And I fill in "Font" with "'Times New Roman', Garamond, serif"
-    And I fill in "Background color" with "#ccccff"
-    And I fill in "Text color" with "red"
-    And I fill in "Percent of browser font size" with "120"
-    And I fill in "Vertical gap between paragraphs" with "5"
-    And I submit
-  Then I should see "Skin was successfully created"
-    And I should see "Font: 'Times New Roman', Garamond, serif"
-    And I should see "Background color: #ccccff"
-    And I should see "Text color: red"
-    And I should see "Percent of browser font size: 120%"
-    And I should see "Vertical gap between paragraphs: 5.0em"
-  When I press "Use"
-  Then I should see "Your preferences were successfully updated."
-    And I should see "background: #ccccff;" within "style"
-    And I should see "color: red;" within "style"
-    And I should see "font-family: 'Times New Roman', Garamond, serif;" within "style"
-    And I should see "font-size: 120%;" within "style"
-    And I should see "margin: 5.0em auto;" within "style"
-  When I am on skinner's preferences page
-  Then "Many changes" should be selected within "preference_skin_id"
-
   Scenario: Users should be able to create and use a work skin
   Given I am logged in as "skinner"
     And the default ratings exist
-  When I am on skin's new page
+  When I am on the new skin page
     And I select "Work Skin" from "skin_type"
     And I fill in "Title" with "Awesome Work Skin"
     And I fill in "Description" with "Great work skin"
@@ -350,37 +96,23 @@ Feature: creating and editing skins
     And I log out
   Then I should be on the login page
 
-  Scenario: Users should be able to adjust their wizard skin by adding custom CSS
-  Given I am logged in as "skinner"
-    And I create and use a skin to make the header pink
-    # Make sure that the creation/update cache keys are different:
-    And I wait 1 second
-  When I edit my pink header skin to have a purple logo
-  Then I should see an update confirmation message
-    And I should see a pink header
-    And I should see a purple logo
-
-  Scenario: Change the accent color
-  Given I am logged in as "skinner"
-  When I create and use a skin to change the accent color
-  Then I should see a different accent color
-
-  Scenario: Create a complex replacement skin
+  Scenario: Create a complex replacement skin using Archive skin components
   Given I have loaded site skins
     And I am logged in as "skinner"
-    And I set up the skin "Complex"
-    And I select "replace archive skin entirely" from "skin_role"
-    And I check "add_site_parents"
+  When I set up the skin "Complex"
+    And I select "replace archive skin entirely" from "What it does:"
+    And I check "Load Archive Skin Components"
     And I submit
   Then I should see a create confirmation message
-  When I check "add_site_parents"
+    And I should see "We've added all the archive skin components as parents. You probably want to remove some of them now!"
+  When I check "Load Archive Skin Components"
     And I submit
   Then I should see errors
 
   Scenario: Vendor-prefixed properties should be allowed
     Given basic skins
       And I am logged in as "skinner"
-    When I am on skin's new page
+    When I am on the new skin page
       And I fill in "Title" with "skin with prefixed property"
       And I fill in "CSS" with ".myclass { -moz-box-sizing: border-box; -webkit-transition: opacity 2s; }"
       And I submit
@@ -390,7 +122,7 @@ Feature: creating and editing skins
   Scenario: #workskin selector prefixing
     Given basic skins
       And I am logged in as "skinner"
-    When I am on skin's new page
+    When I am on the new skin page
       And I select "Work Skin" from "skin_type"
       And I fill in "Title" with "#worksin prefixing"
       And I fill in "CSS" with "#workskin, #workskin a, #workskin:hover, #workskin *, .prefixme, .prefixme:hover, * .prefixme { color: red; }"
@@ -433,8 +165,7 @@ Feature: creating and editing skins
   Scenario: View toggle buttons on skins (Issue 3197)
   Given basic skins
     And I am logged in as "skinner"
-    When I am on skinner's preferences page
-    When I follow "Skins"
+  When I am on skinner's skins page
   Then I should see "My Site Skins"
     And I should see "My Work Skins"
     And I should see "Public Site Skins"
@@ -444,47 +175,24 @@ Feature: creating and editing skins
   Given basic skins
     And I am logged in as "skinner"
     And I am on skinner's skins page
-    And I follow "My Work Skins"
+  When I follow "My Work Skins"
   Then I should see "My Work Skins"
     When I follow "My Site Skins"
   Then I should see "My Site Skins"
 
-  Scenario: Toggle between public site skins and public work skins
-  Given I am logged in as "skinner"
-    And I am on skinner's skins page
-    And I follow "Public Work Skins"
-  Then I should see "Public Work Skins"
-    When I follow "Public Site Skins"
-  Then I should see "Public Site Skins"
-
-  Scenario: Reverting to default skin when a custom skin is selected
-  Given the approved public skin "public skin" with css "#title { text-decoration: blink;}"
-    And I am logged in as "skinner"
-    And I am on skinner's preferences page
-    And I select "public skin" from "preference_skin_id"
-    And I submit
-  When I am on skinner's preferences page
-    Then "public skin" should be selected within "preference_skin_id"
-  When I go to skinner's skins page
-    And I press "Revert to Default Skin"
-  When I am on skinner's preferences page
-    Then "Default" should be selected within "preference_skin_id"
-
   Scenario: The cache should be flushed with a parent and not when unrelated
   Given I have loaded site skins
     And I am logged in as "skinner"
-    And I set up the skin "Complex"
-    And I select "replace archive skin entirely" from "skin_role"
-    And I check "add_site_parents"
+  When I set up the skin "Complex"
+    And I select "replace archive skin entirely" from "What it does:"
+    And I check "Load Archive Skin Components"
     And I submit
   Then I should see a create confirmation message
-  When I am on skin's new page
-    And I fill in "Title" with "my blinking skin"
-    And I fill in "CSS" with "#title { text-decoration: blink;}"
+  When I set up the skin "Title" with css "#title { text-decoration: blink;}"
     And I submit
   Then I should see "Skin was successfully created"
-  Then the cache of the skin on "my blinking skin" should not expire after I save "Complex"
-  Then the cache of the skin on "Complex" should expire after I save a parent skin
+    And the cache of the skin on "my blinking skin" should not expire after I save "Complex"
+    And the cache of the skin on "Complex" should expire after I save a parent skin
 
   Scenario: Users should be able to create skins using @media queries
   Given I am logged in as "skinner"
@@ -497,15 +205,37 @@ Feature: creating and editing skins
   When I press "Use"
   Then the page should have a skin with the media query "only screen and (max-width: 42em), only screen and (max-width: 62em)"
 
-  Scenario: A user should be able to choose a temporary skin
-  Given basic skins
-    And the approved public skin "public skin" with css "#title { text-decoration: blink;}"
-    And the skin "public skin" is cached
-    And the skin "public skin" is in the chooser
+  Scenario: A user should be able to delete a skin
+  Given I am logged in as "skinner"
+    And I create the skin "Ugly Skin"
+  When I go to "Ugly Skin" skin page
+    And I follow "Delete"
+  Then I should see "The skin was deleted."
+    And I should be on skinner's skins page
+
+  Scenario: A user's skin should be reset to the default if they delete the skin they
+  are using
+  Given I am logged in as "skinner"
+    And I create the skin "Ugly Skin"
+    And I change my skin to "Ugly Skin"
+  When I go to skinner's skins page
+    And I follow "Delete"
+  Then I should see "The skin was deleted."
+  When I go to skinner's preferences page
+  Then "Default" should be selected within "preference_skin_id"
+
+  Scenario: A user can't make a skin with "Archive" in the title
+  Given I am logged in as "skinner"
+    And I set up the skin "My Archive Skin" with some css
+  When "AO3-4820" is fixed
+    # And I press "Submit"
+  # Then I should see "You can't use the word 'archive' in your skin title, sorry! (We have to reserve it for official skins.)"
+    # And I should be on the new skin page
+
+  Scenario: A user can't look at another user's skins
+  Given the user "scully" exists and is activated
     And I am logged in as "skinner"
-    And I am on the home page
-    And I follow "public skin"
-   Then I should see "The skin public skin has been set. This will last for your current session."
-    And I follow "Default"
-   Then I should see "You are now using the default Archive skin again!"
+  When I go to scully's skins page
+  Then I should see "You can only browse your own skins and approved public skins."
+    And I should be on the public skins page
 

--- a/features/other_b/skin.feature
+++ b/features/other_b/skin.feature
@@ -188,7 +188,9 @@ Feature: Non-public site and work skins
     And I check "Load Archive Skin Components"
     And I submit
   Then I should see a create confirmation message
-  When I set up the skin "Title" with css "#title { text-decoration: blink;}"
+   When I am on the new skin page
+    And I fill in "Title" with "my blinking skin"
+    And I fill in "CSS" with "#title { text-decoration: blink;}"
     And I submit
   Then I should see "Skin was successfully created"
     And the cache of the skin on "my blinking skin" should not expire after I save "Complex"

--- a/features/other_b/skin.feature
+++ b/features/other_b/skin.feature
@@ -229,10 +229,8 @@ Feature: Non-public site and work skins
   Scenario: A user can't make a skin with "Archive" in the title
   Given I am logged in as "skinner"
     And I set up the skin "My Archive Skin" with some css
-  When "AO3-4820" is fixed
-    # And I press "Submit"
-  # Then I should see "You can't use the word 'archive' in your skin title, sorry! (We have to reserve it for official skins.)"
-    # And I should be on the new skin page
+  When I press "Submit"
+  Then I should see "Title can't use the word 'archive'. (We have to reserve it for official skins.)"
 
   Scenario: A user can't look at another user's skins
   Given the user "scully" exists and is activated

--- a/features/other_b/skin_public.feature
+++ b/features/other_b/skin_public.feature
@@ -83,9 +83,9 @@ Feature: Public skins
   Given I am logged in as "skinner"
     And I am on skinner's skins page
   When I follow "Public Work Skins"
-  Then I should see "Public Work Skins"
-    When I follow "Public Site Skins"
-  Then I should see "Public Site Skins"
+  Then I should see "Public Work Skins" within "h2"
+  When I follow "Public Site Skins"
+  Then I should see "Public Site Skins" within "h2"
 
   Scenario: Reverting to default skin when a custom skin is selected
   Given the approved public skin "public skin" with css "#title { text-decoration: blink;}"
@@ -109,8 +109,8 @@ Feature: Public skins
   Then I should see "Cached skin"
     And I should not see "Uncached skin"
 
-  Scenario: A user can preview a cached public site skin, and it will take the user to
-  the works page for a canonical tag with between 10 and 20 works
+  Scenario: A user can preview a cached public site skin, and it will take the 
+  user to the works page for a canonical tag with between 10 and 20 works
   Given the approved public skin "Usable Skin"
     And the skin "Usable Skin" is cached
     And the canonical fandom "Dallas" with 2 works
@@ -124,4 +124,4 @@ Feature: Public skins
     And I should see "Go back or click any link to remove the skin"
     And I should see "Tip: You can preview any archive page you want by tacking on '?site_skin=[skin_id]' like you can see in the url above."
   When I follow "Return To Skin To Use"
-  Then I should be on the "Usable Skin" page
+  Then I should be on "Usable Skin" skin page

--- a/features/other_b/skin_public.feature
+++ b/features/other_b/skin_public.feature
@@ -26,59 +26,6 @@ Feature: Public skins
   When I set the skin "Uncached Public Skin" for this session
   Then I should see "Sorry, but only certain skins can be used this way (for performance reasons). Please drop a support request if you'd like Uncached Public Skin to be added!"
 
-  Scenario: Admin can cache and uncache a public skin
-  Given basic skins
-    And the approved public skin "public skin"
-    And I am logged in as an admin
-   When I follow "Approved Skins"
-    And I check "Cache"
-   Then I press "Update" 
-    And I should see "The following skins were updated: public skin"
-   When I follow "Approved Skins"
-    And I check "Uncache"
-    And I press "Update"
-   Then I should see "The following skins were updated: public skin"
-
-  Scenario: Admin can add a public skin to the chooser and then remove it
-  Given the approved public skin "public skin"
-    And the skin "public skin" is cached
-    And I am logged in as an admin
-  When I follow "Approved Skins"
-    And I check "Chooser"
-    And I press "Update"
-  Then I should see "The following skins were updated: public skin"
-  When I follow "Approved Skins"
-    And I check "Not In Chooser"
-    And I press "Update"
-  Then I should see "The following skins were updated: public skin"
-
-  Scenario: An admin can reject and unreject a skin
-  Given the unapproved public skin "public skin"
-    And I am logged in as an admin
-  When I go to admin's skins page
-    And I check "make_rejected_public_skin"
-    And I submit
-  Then I should see "The following skins were updated: public skin"
-  When I follow "Rejected Skins"
-  Then I should see "public skin"
-  When I check "make_unrejected_public_skin"
-    And I submit
-  Then I should see "The following skins were updated: public skin"
-  When I follow "Rejected Skins"
-  Then I should not see "public skin"
-
-  Scenario: An admin can feature and unfeature skin
-  Given the approved public skin "public skin"
-    And I am logged in as an admin
-  When I follow "Approved Skins"
-    And I check "Feature"
-    And I submit
-  Then I should see "The following skins were updated: public skin"
-  When I follow "Approved Skins"
-    And I check "Unfeature"
-    And I submit
-  Then I should see "The following skins were updated: public skin"
-
   Scenario: Only public skins should be on the main skins page
   Given basic skins
     And I am logged in as "skinner"
@@ -108,59 +55,13 @@ Feature: Public skins
   When I go to admin's skins page
     Then I should see "I'm sorry, only an admin can"
 
-  Scenario: Users should not be able to see the admin skins page
-  Given I am logged in as "skinner"
-  When I go to admin's skins page
-  Then I should see "I'm sorry, only an admin can look at that area"
-
-  Scenario: Admins should be able to see public skins in the admin skins page
-  Given the unapproved public skin "public skin"
-    And I am logged in as an admin
-  When I go to admin's skins page
-  Then I should see "public skin" within "table#unapproved_skins"
-
-  Scenario: Admins should not be able to edit unapproved skins
-  Given the unapproved public skin "public skin"
-    And I am logged in as an admin
-  When I go to "public skin" skin page
-  Then I should not see "Edit"
-    And I should not see "Delete"
-  When I go to "public skin" edit skin page
-  Then I should see "Sorry, you don't have permission"
-
-  Scenario: Admins should be able to approve public skins
-  Given the unapproved public skin "public skin"
-    And I am logged in as an admin
-  When I go to admin's skins page
-    And I check "public skin"
-    And I submit
-  Then I should see "The following skins were updated: public skin"
-  When I follow "Approved Skins"
-  Then I should see "public skin" within "table#approved_skins"
-
-  Scenario: Admins should be able to edit but not delete public approved skins
-  Given the approved public skin "public skin" with css "#title { text-decoration: blink;}"
-    And I am logged in as an admin
-  When I go to "public skin" skin page
-  Then I should see "Edit"
-    But I should not see "Delete"
-  When I follow "Edit"
-    And I fill in "CSS" with "#greeting.logged-in { text-decoration: blink;}"
-    And I fill in "Description" with "Blinky love (admin modified)"
-    And I submit
-  Then I should see an update confirmation message
-    And I should see "(admin modified)"
-    And I should see "#greeting.logged-in"
-    And I should not see "#title"
-  Then the cache of the skin on "public skin" should expire after I save the skin
-
   Scenario: Users should not be able to edit their public approved skins
   Given the approved public skin "public skin"
     And I am logged in as "skinner"
-    And I go to "public skin" edit skin page
+  When I go to "public skin" edit skin page
   Then I should see "Sorry, you don't have permission"
   When I am on the skins page
-    Then I should see "public skin"
+  Then I should see "public skin"
   When I follow "Site Skins"
   Then I should see "public skin"
     And I should see "(Approved)"
@@ -177,18 +78,6 @@ Feature: Public skins
     And "public skin" should be selected within "preference_skin_id"
     And I should see "#title {" within "style"
     And I should see "text-decoration: blink;" within "style"
-
-  Scenario: Admins should be able to unapprove public skins, which should also remove
-  them from preferences
-  Given "skinuser" is using the approved public skin "public skin" with css "#title { text-decoration: blink;}"
-    And I unapprove the skin "public skin"
-  Then I should see "The following skins were updated: public skin"
-    And I should see "public skin" within "table#unapproved_skins"
-  When I am logged in as "skinuser"
-    And I am on skinuser's preferences page
-  Then "Default" should be selected within "preference_skin_id"
-    And I should not see "#title"
-    And I should not see "text-decoration: blink;"
 
   Scenario: Toggle between public site skins and public work skins
   Given I am logged in as "skinner"

--- a/features/other_b/skin_public.feature
+++ b/features/other_b/skin_public.feature
@@ -1,0 +1,238 @@
+@skins
+Feature: Public skins
+
+  Scenario: A user's initial skin should be set to default
+  Given basic skins
+    And I am logged in as "skinner"
+  When I am on skinner's preferences page
+  Then "Default" should be selected within "preference_skin_id"
+
+  Scenario: User can set a skin for a session and then unset it
+  Given basic skins
+    And the approved public skin "public skin" with css "#title { text-decoration: blink;}"
+    And the skin "public skin" is cached
+    And the skin "public skin" is in the chooser
+  When I am logged in as "skinner"
+    And I follow "public skin"
+  Then I should see "The skin public skin has been set. This will last for your current session."
+    And the page should have the cached skin "public skin"
+  When I follow "Default"
+  Then I should see "You are now using the default Archive skin again!"
+    And the page should not have the cached skin "public skin"
+
+  Scenario: A user can't set an uncached public skin for a session
+  Given the approved public skin "Uncached Public Skin"
+    And I am logged in as "skinner"
+  When I set the skin "Uncached Public Skin" for this session
+  Then I should see "Sorry, but only certain skins can be used this way (for performance reasons). Please drop a support request if you'd like Uncached Public Skin to be added!"
+
+  Scenario: Admin can cache and uncache a public skin
+  Given basic skins
+    And the approved public skin "public skin"
+    And I am logged in as an admin
+   When I follow "Approved Skins"
+    And I check "Cache"
+   Then I press "Update" 
+    And I should see "The following skins were updated: public skin"
+   When I follow "Approved Skins"
+    And I check "Uncache"
+    And I press "Update"
+   Then I should see "The following skins were updated: public skin"
+
+  Scenario: Admin can add a public skin to the chooser and then remove it
+  Given the approved public skin "public skin"
+    And the skin "public skin" is cached
+    And I am logged in as an admin
+  When I follow "Approved Skins"
+    And I check "Chooser"
+    And I press "Update"
+  Then I should see "The following skins were updated: public skin"
+  When I follow "Approved Skins"
+    And I check "Not In Chooser"
+    And I press "Update"
+  Then I should see "The following skins were updated: public skin"
+
+  Scenario: An admin can reject and unreject a skin
+  Given the unapproved public skin "public skin"
+    And I am logged in as an admin
+  When I go to admin's skins page
+    And I check "make_rejected_public_skin"
+    And I submit
+  Then I should see "The following skins were updated: public skin"
+  When I follow "Rejected Skins"
+  Then I should see "public skin"
+  When I check "make_unrejected_public_skin"
+    And I submit
+  Then I should see "The following skins were updated: public skin"
+  When I follow "Rejected Skins"
+  Then I should not see "public skin"
+
+  Scenario: An admin can feature and unfeature skin
+  Given the approved public skin "public skin"
+    And I am logged in as an admin
+  When I follow "Approved Skins"
+    And I check "Feature"
+    And I submit
+  Then I should see "The following skins were updated: public skin"
+  When I follow "Approved Skins"
+    And I check "Unfeature"
+    And I submit
+  Then I should see "The following skins were updated: public skin"
+
+  Scenario: Only public skins should be on the main skins page
+  Given basic skins
+    And I am logged in as "skinner"
+    And I create the skin "my skin"
+  When I am on the skins page
+  Then I should not see "my skin"
+    And I should see "Default"
+
+  Scenario: Newly created public skins should not appear on the main skins page until
+  approved and should be marked as not-yet-approved
+  Given I am logged in as "skinner"
+    And the unapproved public skin "public skin"
+  When I am on the skins page
+    Then I should not see "public skin"
+  When I am on skinner's skins page
+  Then I should see "public skin"
+    And I should see "(Not yet reviewed)"
+    And I should not see "(Approved)"
+
+  Scenario: Public skins should not be viewable by users until approved
+  Given the unapproved public skin "public skin"
+    And I am logged out
+  When I go to "public skin" skin page
+    Then I should see "Sorry, you don't have permission"
+  When I go to "public skin" edit skin page
+    Then I should see "Sorry, you don't have permission"
+  When I go to admin's skins page
+    Then I should see "I'm sorry, only an admin can"
+
+  Scenario: Users should not be able to see the admin skins page
+  Given I am logged in as "skinner"
+  When I go to admin's skins page
+  Then I should see "I'm sorry, only an admin can look at that area"
+
+  Scenario: Admins should be able to see public skins in the admin skins page
+  Given the unapproved public skin "public skin"
+    And I am logged in as an admin
+  When I go to admin's skins page
+  Then I should see "public skin" within "table#unapproved_skins"
+
+  Scenario: Admins should not be able to edit unapproved skins
+  Given the unapproved public skin "public skin"
+    And I am logged in as an admin
+  When I go to "public skin" skin page
+  Then I should not see "Edit"
+    And I should not see "Delete"
+  When I go to "public skin" edit skin page
+  Then I should see "Sorry, you don't have permission"
+
+  Scenario: Admins should be able to approve public skins
+  Given the unapproved public skin "public skin"
+    And I am logged in as an admin
+  When I go to admin's skins page
+    And I check "public skin"
+    And I submit
+  Then I should see "The following skins were updated: public skin"
+  When I follow "Approved Skins"
+  Then I should see "public skin" within "table#approved_skins"
+
+  Scenario: Admins should be able to edit but not delete public approved skins
+  Given the approved public skin "public skin" with css "#title { text-decoration: blink;}"
+    And I am logged in as an admin
+  When I go to "public skin" skin page
+  Then I should see "Edit"
+    But I should not see "Delete"
+  When I follow "Edit"
+    And I fill in "CSS" with "#greeting.logged-in { text-decoration: blink;}"
+    And I fill in "Description" with "Blinky love (admin modified)"
+    And I submit
+  Then I should see an update confirmation message
+    And I should see "(admin modified)"
+    And I should see "#greeting.logged-in"
+    And I should not see "#title"
+  Then the cache of the skin on "public skin" should expire after I save the skin
+
+  Scenario: Users should not be able to edit their public approved skins
+  Given the approved public skin "public skin"
+    And I am logged in as "skinner"
+    And I go to "public skin" edit skin page
+  Then I should see "Sorry, you don't have permission"
+  When I am on the skins page
+    Then I should see "public skin"
+  When I follow "Site Skins"
+  Then I should see "public skin"
+    And I should see "(Approved)"
+    And I should not see "Edit"
+
+  Scenario: Users should be able to use public approved skins created by others
+  Given the approved public skin "public skin" with css "#title { text-decoration: blink;}"
+    And I am logged in as "skinuser"
+    And I am on skinuser's preferences page
+  When I select "public skin" from "preference_skin_id"
+    And I submit
+  Then I should see "Your preferences were successfully updated."
+  When I am on skinuser's preferences page
+    And "public skin" should be selected within "preference_skin_id"
+    And I should see "#title {" within "style"
+    And I should see "text-decoration: blink;" within "style"
+
+  Scenario: Admins should be able to unapprove public skins, which should also remove
+  them from preferences
+  Given "skinuser" is using the approved public skin "public skin" with css "#title { text-decoration: blink;}"
+    And I unapprove the skin "public skin"
+  Then I should see "The following skins were updated: public skin"
+    And I should see "public skin" within "table#unapproved_skins"
+  When I am logged in as "skinuser"
+    And I am on skinuser's preferences page
+  Then "Default" should be selected within "preference_skin_id"
+    And I should not see "#title"
+    And I should not see "text-decoration: blink;"
+
+  Scenario: Toggle between public site skins and public work skins
+  Given I am logged in as "skinner"
+    And I am on skinner's skins page
+  When I follow "Public Work Skins"
+  Then I should see "Public Work Skins"
+    When I follow "Public Site Skins"
+  Then I should see "Public Site Skins"
+
+  Scenario: Reverting to default skin when a custom skin is selected
+  Given the approved public skin "public skin" with css "#title { text-decoration: blink;}"
+    And I am logged in as "skinner"
+    And I am on skinner's preferences page
+    And I select "public skin" from "preference_skin_id"
+    And I submit
+  When I am on skinner's preferences page
+    Then "public skin" should be selected within "preference_skin_id"
+  When I go to skinner's skins page
+    And I press "Revert to Default Skin"
+  When I am on skinner's preferences page
+    Then "Default" should be selected within "preference_skin_id"
+
+  Scenario: A logged out user only sees cached skins on the public skins page
+  Given the approved public skin "Uncached skin"
+    And the approved public skin "Cached skin"
+    And the skin "Cached skin" is cached
+    And I am logged out
+  When I go to the public skins page
+  Then I should see "Cached skin"
+    And I should not see "Uncached skin"
+
+  Scenario: A user can preview a cached public site skin, and it will take the user to
+  the works page for a canonical tag with between 10 and 20 works
+  Given the approved public skin "Usable Skin"
+    And the skin "Usable Skin" is cached
+    And the canonical fandom "Dallas" with 2 works
+    And the canonical fandom "Major Crimes" with 11 works
+    And the canonical fandom "Rizzoli and Isles" with 21 works
+    And I am logged in as "skinner"
+  When I go to the public skins page
+    And I follow "Preview"
+  Then I should be on the works tagged "Major Crimes"
+    And I should see "You are previewing the skin Usable Skin. This is a randomly chosen page."
+    And I should see "Go back or click any link to remove the skin"
+    And I should see "Tip: You can preview any archive page you want by tacking on '?site_skin=[skin_id]' like you can see in the url above."
+  When I follow "Return To Skin To Use"
+  Then I should be on the "Usable Skin" page

--- a/features/other_b/skin_wizard.feature
+++ b/features/other_b/skin_wizard.feature
@@ -6,16 +6,18 @@ Feature: Skin wizard
     And I am on the new skin page
   Then I should see "CSS" within "form#new_skin"
   When I follow "Use Wizard"
-    Then I should see "Site Skin Wizard"
+  Then I should be on the new wizard skin page
+    And I should see "Site Skin Wizard"
     And I should not see "CSS" within "form"
   When I follow "Write Custom CSS"
-    Then I should see "CSS"
+  Then I should be on the new skin page
+    And I should see "CSS"
 
   Scenario: Users should be able to create and use a wizard skin to adjust work margins,
   and they should be able to edit the skin while they are using it
   Given I am logged in as "skinner"
-  When I am on the new wizard skin page
-    And I fill in "Title" with "Wide margins"
+    And I am on the new wizard skin page
+  When I fill in "Title" with "Wide margins"
     And I fill in "Description" with "Layout skin"
     And I fill in "Work margin width" with "text"
     And I submit
@@ -26,8 +28,7 @@ Feature: Skin wizard
   Then I should see "Skin was successfully created"
     And I should see "Work margin width: 5%"
   When I am on skinner's preferences page
-  Then "Default" should be selected within "preference_skin_id"
-  When I select "Wide margins" from "preference_skin_id"
+    And I select "Wide margins" from "preference_skin_id"
     And I submit
   Then I should see "Your preferences were successfully updated."
     And I should see "margin: auto 5%; max-width: 100%" within "style"
@@ -47,8 +48,8 @@ Feature: Skin wizard
   Scenario: Users should be able to create and use a wizard skin with multiple wizard
   settings
   Given I am logged in as "skinner"
-  When I am on the new wizard skin page
-    And I fill in "Title" with "Many changes"
+    And I am on the new wizard skin page
+  When I fill in "Title" with "Many changes"
     And I fill in "Description" with "Layout skin"
     And I fill in "Font" with "'Times New Roman', Garamond, serif"
     And I fill in "Background color" with "#ccccff"

--- a/features/other_b/skin_wizard.feature
+++ b/features/other_b/skin_wizard.feature
@@ -6,11 +6,10 @@ Feature: Skin wizard
     And I am on the new skin page
   Then I should see "CSS" within "form#new_skin"
   When I follow "Use Wizard"
-  Then I should be on the new wizard skin page
-    And I should see "Site Skin Wizard"
+  Then I should see "Site Skin Wizard"
     And I should not see "CSS" within "form"
   When I follow "Write Custom CSS"
-  Then I should be on the new skin page
+  Then I should see "Create New Skin"
     And I should see "CSS"
 
   Scenario: Users should be able to create and use a wizard skin to adjust work margins,

--- a/features/other_b/skin_wizard.feature
+++ b/features/other_b/skin_wizard.feature
@@ -1,0 +1,88 @@
+@skins
+Feature: Skin wizard
+
+  Scenario: User should be able to toggle between the wizard and the form
+  When I am logged in
+    And I am on the new skin page
+  Then I should see "CSS" within "form#new_skin"
+  When I follow "Use Wizard"
+    Then I should see "Site Skin Wizard"
+    And I should not see "CSS" within "form"
+  When I follow "Write Custom CSS"
+    Then I should see "CSS"
+
+  Scenario: Users should be able to create and use a wizard skin to adjust work margins,
+  and they should be able to edit the skin while they are using it
+  Given I am logged in as "skinner"
+  When I am on the new wizard skin page
+    And I fill in "Title" with "Wide margins"
+    And I fill in "Description" with "Layout skin"
+    And I fill in "Work margin width" with "text"
+    And I submit
+  Then I should see a save error message
+    And I should see "Margin is not a number"
+  When I fill in "Work margin width" with "5"
+    And I submit
+  Then I should see "Skin was successfully created"
+    And I should see "Work margin width: 5%"
+  When I am on skinner's preferences page
+  Then "Default" should be selected within "preference_skin_id"
+  When I select "Wide margins" from "preference_skin_id"
+    And I submit
+  Then I should see "Your preferences were successfully updated."
+    And I should see "margin: auto 5%; max-width: 100%" within "style"
+    # Make sure that the creation/update cache keys are different:
+    And I wait 1 second
+  When I edit the skin "Wide margins" with the wizard
+    And I fill in "Work margin width" with "4.5"
+    And I submit
+  # TODO: Think about whether rounding to 4 is actually the right behaviour or not
+  Then I should see an update confirmation message
+    And I should see "Work margin width: 4%"
+    And I should not see "Work margin width: 4.5%"
+    And I should see "margin: auto 4%;" within "style"
+  When I am on skinner's preferences page
+  Then "Wide margins" should be selected within "preference_skin_id"
+
+  Scenario: Users should be able to create and use a wizard skin with multiple wizard
+  settings
+  Given I am logged in as "skinner"
+  When I am on the new wizard skin page
+    And I fill in "Title" with "Many changes"
+    And I fill in "Description" with "Layout skin"
+    And I fill in "Font" with "'Times New Roman', Garamond, serif"
+    And I fill in "Background color" with "#ccccff"
+    And I fill in "Text color" with "red"
+    And I fill in "Percent of browser font size" with "120"
+    And I fill in "Vertical gap between paragraphs" with "5"
+    And I submit
+  Then I should see "Skin was successfully created"
+    And I should see "Font: 'Times New Roman', Garamond, serif"
+    And I should see "Background color: #ccccff"
+    And I should see "Text color: red"
+    And I should see "Percent of browser font size: 120%"
+    And I should see "Vertical gap between paragraphs: 5.0em"
+  When I press "Use"
+  Then I should see "Your preferences were successfully updated."
+    And I should see "background: #ccccff;" within "style"
+    And I should see "color: red;" within "style"
+    And I should see "font-family: 'Times New Roman', Garamond, serif;" within "style"
+    And I should see "font-size: 120%;" within "style"
+    And I should see "margin: 5.0em auto;" within "style"
+  When I am on skinner's preferences page
+  Then "Many changes" should be selected within "preference_skin_id"
+
+  Scenario: Users should be able to adjust their wizard skin by adding custom CSS
+  Given I am logged in as "skinner"
+    And I create and use a skin to make the header pink
+    # Make sure that the creation/update cache keys are different:
+    And I wait 1 second
+  When I edit my pink header skin to have a purple logo
+  Then I should see an update confirmation message
+    And I should see a pink header
+    And I should see a purple logo
+
+  Scenario: Change the accent color
+  Given I am logged in as "skinner"
+  When I create and use a skin to change the accent color
+  Then I should see a different accent color

--- a/features/step_definitions/skin_steps.rb
+++ b/features/step_definitions/skin_steps.rb
@@ -12,9 +12,8 @@ Given /^I set up the skin "([^"]*)"$/ do |skin_name|
   fill_in("CSS", :with => "#title { text-decoration: blink;}")
 end
 
-Given /^I set up the skin "([^"]*)" with css$/ do |skin_name, css|
-  step "I set up the skin \"#{skin_name}\""
-  fill_in("CSS", :with => css)
+Given /^I set up the skin "([^"]*)" with some css$/ do |skin_name|
+  step %{I set up the skin "#{skin_name}" with css "#{DEFAULT_CSS}"}
 end
 
 Given /^I set up the skin "([^"]*)" with css "([^"]*)"$/ do |skin_name, css|
@@ -27,7 +26,7 @@ Given /^I create the skin "([^"]*)" with css "([^"]*)"$/ do |skin_name, css|
   step %{I submit}
 end
 
-Given /^I create the skin "([^"]*)" with css$/ do |skin_name, css|
+Given /^I create the skin "([^"]*)" with some css$/ do |skin_name, css|
   step "I set up the skin \"#{skin_name}\" with css \"#{css}\""
   step %{I submit}
 end
@@ -57,7 +56,7 @@ end
 Given /^I approve the skin "([^"]*)"$/ do |skin_name|
   step "I am logged in as an admin"
   visit admin_skins_url
-  check("make_official_#{skin_name.gsub(/\s/, '_')}")
+  check("make_official_#{skin_name.downcase.gsub(/\s/, '_')}")
   step %{I submit}
 end
 
@@ -65,7 +64,7 @@ Given /^I unapprove the skin "([^"]*)"$/ do |skin_name|
   step "I am logged in as an admin"
   visit admin_skins_url
   step "I follow \"Approved Skins\""
-  check("make_unofficial_#{skin_name.gsub(/\s/, '_')}")
+  check("make_unofficial_#{skin_name.downcase.gsub(/\s/, '_')}")
   step %{I submit}
 end
 
@@ -144,6 +143,16 @@ When /^the skin "([^\"]*)" is cached$/ do |skin_name|
   skin.cached = true
   skin.save
   skin.cache!
+end
+
+When /^I preview the skin "([^\"]*)"$/ do |skin_name|
+  skin = Skin.find_by_title(skin_name)
+  visit preview_skin_path(skin)
+end
+
+When /^I set the skin "([^\"]*)" for this session$/ do |skin_name|
+  skin = Skin.find_by_title(skin_name)
+  visit set_skin_path(skin)
 end
 
 ### THEN

--- a/features/step_definitions/skin_steps.rb
+++ b/features/step_definitions/skin_steps.rb
@@ -13,7 +13,7 @@ Given /^I set up the skin "([^"]*)"$/ do |skin_name|
 end
 
 Given /^I set up the skin "([^"]*)" with some css$/ do |skin_name|
-  step %{I set up the skin "#{skin_name}" with css "#{DEFAULT_CSS}"}
+  step %{I set up the skin "#{skin_name}" with css #{DEFAULT_CSS}}
 end
 
 Given /^I set up the skin "([^"]*)" with css "([^"]*)"$/ do |skin_name, css|

--- a/features/step_definitions/tag_steps.rb
+++ b/features/step_definitions/tag_steps.rb
@@ -128,7 +128,7 @@ end
 Given /^the canonical fandom "([^\"]*)" with (\d+) works$/ do |tag_name, number_of_works|
   tag = FactoryGirl.create(:fandom, name: tag_name, canonical: true)
   number_of_works.to_i.times do |i|
-    FactoryGirl.create(:work, fandom_string: tag_name)
+    FactoryGirl.create(:work, posted: true, fandom_string: tag_name)
   end
 end
 

--- a/features/step_definitions/tag_steps.rb
+++ b/features/step_definitions/tag_steps.rb
@@ -125,9 +125,9 @@ Given /^a tag "([^\"]*)" with(?: (\d+))? comments$/ do |tagname, n_comments|
   end
 end
 
-Given /^the canonical fandom "([^\"]*)" with (\d+) works$/ do |tag_name, number_of_works|
-  tag = FactoryGirl.create(:fandom, name: tag_name, canonical: true)
-  number_of_works.to_i.times do |i|
+Given /^the canonical fandom "([^"]*)" with (\d+) works$/ do |tag_name, number_of_works|
+  FactoryGirl.create(:fandom, name: tag_name, canonical: true)
+  number_of_works.to_i.times do
     FactoryGirl.create(:work, posted: true, fandom_string: tag_name)
   end
 end

--- a/features/step_definitions/tag_steps.rb
+++ b/features/step_definitions/tag_steps.rb
@@ -125,6 +125,13 @@ Given /^a tag "([^\"]*)" with(?: (\d+))? comments$/ do |tagname, n_comments|
   end
 end
 
+Given /^the canonical fandom "([^\"]*)" with (\d+) works$/ do |tag_name, number_of_works|
+  tag = FactoryGirl.create(:fandom, name: tag_name, canonical: true)
+  number_of_works.to_i.times do |i|
+    FactoryGirl.create(:work, fandom_string: tag_name)
+  end
+end
+
 Given /^a period-containing tag "([^\"]*)" with(?: (\d+))? comments$/ do |tagname, n_comments|
   tag = Fandom.find_or_create_by_name(tagname)
   step %{I am logged out}

--- a/features/support/paths.rb
+++ b/features/support/paths.rb
@@ -93,6 +93,8 @@ module NavigationHelpers
       user_gifts_path(user_id: $1)
     when /the import page/
       new_work_path(:import => 'true')
+    when /the public skins page/
+      skins_path
     when /the work-skins page/
       skins_path(:skin_type => "WorkSkin")
     when /^(.*?)(?:'s)? user page$/i
@@ -128,9 +130,11 @@ module NavigationHelpers
     when /^(.*?)(?:'s)? profile page$/i
       user_profile_path(user_id: $1)
     when /^(.*)'s skins page/
-      skins_path(user_id: $1)
+      user_skins_path(user_id: $1)
     when /^"(.*)" skin page/
       skin_path(Skin.find_by_title($1))
+    when /^the new skin page/
+      new_skin_path
     when /^the new wizard skin page/
       new_skin_path(wizard: true)
     when /^"(.*)" edit skin page/


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-4820

## Purpose

Moves the validation of skin titles to the model, thereby preventing a 500 error that was happening when you should've just been getting an error message.

## Testing

Refer to JIRA.

## References

Pull request #2704 is also in here because I needed to update one of the tests it adds. Relevant commits for the linked issue:
- 5631123 
- 75ed7ad
- addc997
- fa0b922