### PR TITLE
AO3-4827 Count the contents of all chapters when creating a work

### DIFF
--- a/app/models/chapter.rb
+++ b/app/models/chapter.rb
@@ -190,7 +190,7 @@ class Chapter < ActiveRecord::Base
 
   # Set the value of word_count to reflect the length of the text in the chapter content
   def set_word_count
-    if self.new_record? || self.content_changed?
+    if self.new_record? || self.content_changed? || self.word_count.nil?
       counter = WordCounter.new(self.content)
       self.word_count = counter.count
     else

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -748,9 +748,13 @@ class Work < ActiveRecord::Base
   # Set the value of word_count to reflect the length of the chapter content
   # Called before_save
   def set_word_count
-    self.word_count = 0
-    chapters.each do |chapter|
-      self.word_count += chapter.set_word_count
+    if self.new_record?
+      self.word_count = 0
+      chapters.each do |chapter|
+        self.word_count += chapter.set_word_count
+      end
+    else
+      self.word_count = Chapter.select("SUM(word_count) AS work_word_count").where(:work_id => self.id, :posted => true).first.work_word_count
     end
   end
 

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -748,7 +748,10 @@ class Work < ActiveRecord::Base
   # Set the value of word_count to reflect the length of the chapter content
   def set_word_count
     if self.new_record?
-      self.word_count = self.chapters.first.set_word_count
+      self.word_count = 0
+      chapters.each do |chapter|
+        self.word_count += chapter.set_word_count
+      end
     else
       self.word_count = Chapter.select("SUM(word_count) AS work_word_count").where(:work_id => self.id, :posted => true).first.work_word_count
     end

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -746,14 +746,11 @@ class Work < ActiveRecord::Base
   end
 
   # Set the value of word_count to reflect the length of the chapter content
+  # Called before_save
   def set_word_count
-    if self.new_record?
-      self.word_count = 0
-      chapters.each do |chapter|
-        self.word_count += chapter.set_word_count
-      end
-    else
-      self.word_count = Chapter.select("SUM(word_count) AS work_word_count").where(:work_id => self.id, :posted => true).first.work_word_count
+    self.word_count = 0
+    chapters.each do |chapter|
+      self.word_count += chapter.set_word_count
     end
   end
 

--- a/features/importing/work_import.feature
+++ b/features/importing/work_import.feature
@@ -147,6 +147,14 @@ Feature: Import Works
       Then I should see "1. Chapter 1 (2000-01-10)"
       Then I should see "2. Importing Test Part 2 (2000-01-22)"
 
+  Scenario: Imported multichapter work should have the correct word count
+    Given I import the urls with mock websites as chapters without preview
+      """
+      http://import-site-without-tags
+      http://second-import-site-without-tags
+      """
+    Then I should see "Words:5"
+
 #  Scenario: Import works for others and have them automatically notified
 
   @work_import_special_characters_auto_utf

--- a/features/importing/work_import.feature
+++ b/features/importing/work_import.feature
@@ -166,7 +166,7 @@ Feature: Import Works
       And I follow "1"
       And I fill in "content" with "some extra content that is longer than before"
       And I press "Post Without Preview"
-    Then I should see "Words:12"
+    Then I should see "Words:11"
 
 #  Scenario: Import works for others and have them automatically notified
 

--- a/features/importing/work_import.feature
+++ b/features/importing/work_import.feature
@@ -155,6 +155,19 @@ Feature: Import Works
       """
     Then I should see "Words:5"
 
+  Scenario: Editing an imported multichapter work should have the correct word count
+    Given I import the urls with mock websites as chapters without preview
+      """
+      http://import-site-without-tags
+      http://second-import-site-without-tags
+      """
+    Then I should see "Words:5"
+    When I follow "Edit"
+      And I follow "1"
+      And I fill in "content" with "some extra content that is longer than before"
+      And I press "Post Without Preview"
+    Then I should see "Words:12"
+
 #  Scenario: Import works for others and have them automatically notified
 
   @work_import_special_characters_auto_utf

--- a/features/step_definitions/work_import_steps.rb
+++ b/features/step_definitions/work_import_steps.rb
@@ -35,6 +35,11 @@ stubbed response", headers: {})
               body: "stubbed response",
               headers: {})
 
+  WebMock.stub_request(:any, /second-import-site-without-tags/).
+    to_return(status: 200,
+              body: "second stubbed response",
+              headers: {})
+
   WebMock.stub_request(:any, /no-content/).
     to_return(status: 200,
               body: "",
@@ -69,8 +74,14 @@ When /^I import the urls$/ do |urls|
   step %{I press "Import"}
 end
 
-When /^I import the urls with mock websites$/ do |urls|
+When /^I import the urls with mock websites( as chapters)?( without preview)?$/ do |chapters, no_preview, urls|
   step %{I set up importing with a mock website}
   step %{I fill in "urls" with "#{urls}"}
+  if chapters
+    step %{I choose "import_multiple_chapters"}
+  end
+  if no_preview
+    step %{I check "post_without_preview"}
+  end
   step %{I press "Import"}
 end

--- a/features/works/work_edit.feature
+++ b/features/works/work_edit.feature
@@ -36,6 +36,7 @@ Feature: Edit Works
     When I press "Update"
     Then I should see "Work was successfully updated."
       And I should see "Additional Tags: new tag"
+      And I should see "Words:3"
     When all search indexes are updated
       And I go to testuser's works page
     Then I should see "First work"
@@ -51,6 +52,7 @@ Feature: Edit Works
     Then I should see "Chapter was successfully posted."
       And I should not see "first chapter content"
       And I should see "second chapter content"
+      And I should see "Words:6"
     When I edit the work "First work"
     Then I should not see "chapter content"
     When I follow "1"
@@ -61,6 +63,7 @@ Feature: Edit Works
     Then I should see "Chapter was successfully updated."
       And I should see "first chapter new content"
       And I should not see "second chapter content"
+      And I should see "Words:7"
     When I edit the work "First Work"
       And I follow "2"
       And I fill in "content" with "second chapter new content"
@@ -111,21 +114,6 @@ Feature: Edit Works
       And I should see "Work was successfully updated"
     Then I should not see "You have submitted your work to the moderated collection 'Digital Hoarders 2013'. It will not become a part of the collection until it has been approved by a moderator."
       
-  Scenario: Editing a work you created today should not bump its revised-at date
-      When "AO3-2539" is fixed    
-# Given I am logged in as "testuser" with password "testuser"
-#      And I post the work "Don't Bump Me"
-#      And I post the work "This One Stays On Top"
-#      And I edit the work "Don't Bump Me"
-#      And I press "Post Without Preview"
-#    When I go to the works page
-#    Then "This One Stays On Top" should appear before "Don't Bump Me"
-#    When I edit the work "Don't Bump Me"
-#      And I press "Preview"
-#      And I press "Update"
-#      And I go to the works page
-#    Then "This One Stays On Top" should appear before "Don't Bump Me"
-
   Scenario: Previewing edits to a posted work should not refer to the work as a draft
     Given I am logged in as "editor"
       And I post the work "Load of Typos"

--- a/lib/work_chapter_count_caching.rb
+++ b/lib/work_chapter_count_caching.rb
@@ -9,7 +9,11 @@ module WorkChapterCountCaching
   end
 
   def invalidate_work_chapter_count(work)
-    Rails.cache.delete(key_for_chapter_total_counting(work))
-    Rails.cache.delete(key_for_chapter_posted_counting(work))
+    # Caching is not configured on development environments
+    # Trying to delete a non-existent cache made chapter deletion fail
+    unless Rails.env == "development"
+      Rails.cache.delete(key_for_chapter_total_counting(work))
+      Rails.cache.delete(key_for_chapter_posted_counting(work))
+    end
   end
 end


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-4827

## Purpose

We recently noticed that multi chapter imports had a word count that only included the first chapter when imported without preview. Any action that resaves the work after initial posting corrects the word count, but this isn't something Open Doors want to have to do for automated imports. This pull request fixes that situation by adding up all the word counts for all the chapters on a work when it is first posted.

## Testing

See the Jira ticket