### PR TITLE
AO3-4839 Add dividers to series navigation on works

### DIFF
--- a/app/helpers/series_helper.rb
+++ b/app/helpers/series_helper.rb
@@ -17,22 +17,39 @@ module SeriesHelper
                                          collect{ |sw| sw.work }
       visible_position = serial_works.index(work) || serial_works.length
       unless !visible_position
+        # Span used at end of previous_link and beginning of next_link to prevent extra
+        # whitespace around main_link if next or previous link is missing. It also allows
+        # us to use CSS to insert a decorative divider
+        divider_span = content_tag(:span, " ", class: "divider")
+        # This is empty if there is no previous work, otherwise it is:
+        # <a href class="previous">←Previous Work</a><span class="divider"> </span>
         previous_link = if visible_position > 0
-                          link_to(ts("&larr; Previous Work").html_safe,
-                                  serial_works[visible_position - 1])
+                          link_to(ts("&#8592; Previous Work").html_safe,
+                                  serial_works[visible_position - 1],
+                                  class: "previous") +
+                          divider_span
                         else
                           "".html_safe
                         end
-        main_link = ts(" Part %{position} of the %{series_title} series ",
-                       position: (visible_position + 1).to_s,
-                       series_title: link_to(serial.title, serial)).html_safe
+        # This part is always included
+        # <span class="title">Part # of the <a href>TITLE</a> series</a></span>
+        main_link = content_tag(:span,
+                                ts("Part %{position} of the %{series_title} series",
+                                  position: (visible_position + 1).to_s,
+                                  series_title: link_to(serial.title, serial)).html_safe,
+                                class: "title")
+        # This is empty if there is no next work, otherwise it is:
+        # <span class="divider"> </span><a href class="next">Next Work →</a>
         next_link = if (visible_position < serial_works.size - 1)
-                      link_to(ts("Next Work &rarr;").html_safe,
-                              serial_works[visible_position + 1])
+                      divider_span +
+                      link_to(ts("Next Work &#8594;").html_safe,
+                              serial_works[visible_position + 1],
+                              class: "next")
                     else
                       "".html_safe
                     end
-        previous_link + main_link + next_link
+        # put the parts together and wrap them in <span class="series">
+        content_tag(:span, previous_link + main_link + next_link, class: "series")
       end
     end
   end

--- a/app/helpers/series_helper.rb
+++ b/app/helpers/series_helper.rb
@@ -41,7 +41,7 @@ module SeriesHelper
                                 class: "title")
         # This is empty if there is no next work, otherwise it is
         # <span class="divider"> </span><a href class="next">Next Work</a>
-        # wwith a right-pointing arrow after "Work"
+        # with a right-pointing arrow after "Work"
         next_link = if visible_position < serial_works.size - 1
                       divider_span + link_to(ts("Next Work &#8594;").html_safe,
                                              serial_works[visible_position + 1],

--- a/app/helpers/series_helper.rb
+++ b/app/helpers/series_helper.rb
@@ -10,21 +10,22 @@ module SeriesHelper
     series = work.series.select { |s| s.visible?(current_user) }
     series.map do |serial|
       serial_works = serial.serial_works.
-                            find(:all,
+                           find(:all,
                                  include: :work,
                                  conditions: ['works.posted = ?', true],
                                  order: :position).
                            select { |sw| sw.work.visible(current_user) }.
-                           collect(&:work)
+                           map(&:work)
       visible_position = serial_works.index(work) || serial_works.length
       unless !visible_position
         # Span used at end of previous_link and beginning of next_link to prevent extra
         # whitespace around main_link if next or previous link is missing. It also allows
         # us to use CSS to insert a decorative divider
         divider_span = content_tag(:span, " ", class: "divider")
-        # This is empty if there is no previous work, otherwise it is:
-        # <a href class="previous"><- Previous Work</a><span class="divider"> </span>
-        previous_link = if visible_position.positive?
+        # This is empty if there is no previous work, otherwise it is
+        # <a href class="previous">Previous Work</a><span class="divider"> </span>
+        # with a left-pointing arrow before "Previous"
+        previous_link = if visible_position > 0
                           link_to(ts("&#8592; Previous Work").html_safe,
                                   serial_works[visible_position - 1],
                                   class: "previous") + divider_span
@@ -38,8 +39,9 @@ module SeriesHelper
                                    position: (visible_position + 1).to_s,
                                    series_title: link_to(serial.title, serial)).html_safe,
                                 class: "title")
-        # This is empty if there is no next work, otherwise it is:
-        # <span class="divider"> </span><a href class="next">Next Work -></a>
+        # This is empty if there is no next work, otherwise it is
+        # <span class="divider"> </span><a href class="next">Next Work</a>
+        # wwith a right-pointing arrow after "Work"
         next_link = if visible_position < serial_works.size - 1
                       divider_span + link_to(ts("Next Work &#8594;").html_safe,
                                              serial_works[visible_position + 1],

--- a/app/helpers/series_helper.rb
+++ b/app/helpers/series_helper.rb
@@ -33,7 +33,7 @@ module SeriesHelper
                           "".html_safe
                         end
         # This part is always included
-        # <span class="title">Part # of the <a href>TITLE</a> series</a></span>
+        # <span class="title">Part # of the <a href>TITLE</a> series</span>
         main_link = content_tag(:span,
                                 ts("Part %{position} of the %{series_title} series",
                                    position: (visible_position + 1).to_s,

--- a/app/helpers/series_helper.rb
+++ b/app/helpers/series_helper.rb
@@ -33,7 +33,7 @@ module SeriesHelper
                           "".html_safe
                         end
         # This part is always included
-        # <span class="title">Part # of the <a href>TITLE</a> series</span>
+        # <span class="position">Part # of the <a href>TITLE</a> series</span>
         main_link = content_tag(:span,
                                 ts("Part %{position} of the %{series_title} series",
                                    position: (visible_position + 1).to_s,

--- a/app/helpers/series_helper.rb
+++ b/app/helpers/series_helper.rb
@@ -11,11 +11,11 @@ module SeriesHelper
     series.map do |serial|
       serial_works = serial.serial_works.
                            find(:all,
-                                 include: :work,
-                                 conditions: ['works.posted = ?', true],
-                                 order: :position).
+                                include: :work,
+                                conditions: ['works.posted = ?', true],
+                                order: :position).
                            select { |sw| sw.work.visible(current_user) }.
-                           map(&:work)
+                     map(&:work)
       visible_position = serial_works.index(work) || serial_works.length
       unless !visible_position
         # Span used at end of previous_link and beginning of next_link to prevent extra

--- a/app/helpers/series_helper.rb
+++ b/app/helpers/series_helper.rb
@@ -7,14 +7,31 @@ module SeriesHelper
 
   # this should only show prev and next works visible to the current user
   def series_data_for_work(work)
-    series = work.series.select{|s| s.visible?(current_user)}
+    series = work.series.select{ |s| s.visible?(current_user) }
     series.map do |serial|
-      serial_works = serial.serial_works.find(:all, :include => :work, :conditions => ['works.posted = ?', true], :order => :position).select{|sw| sw.work.visible(current_user)}.collect{|sw| sw.work}
+      serial_works = serial.serial_works.find(:all,
+                                              include: :work,
+                                              conditions: ['works.posted = ?', true],
+                                              order: :position).
+                                         select{ |sw| sw.work.visible(current_user) }.
+                                         collect{ |sw| sw.work }
       visible_position = serial_works.index(work) || serial_works.length
       unless !visible_position
-        previous_link = visible_position > 0 ? link_to(ts("&larr; Previous Work").html_safe, serial_works[visible_position - 1]) : "".html_safe
-        main_link = ts(" Part %{position} of the %{series_title} series ", position: (visible_position + 1).to_s, series_title: link_to(serial.title, serial)).html_safe
-        next_link = (visible_position < serial_works.size-1) ? link_to(ts("Next Work &rarr;").html_safe, serial_works[visible_position + 1]) : "".html_safe
+        previous_link = if visible_position > 0
+                          link_to(ts("&larr; Previous Work").html_safe,
+                                  serial_works[visible_position - 1])
+                        else
+                          "".html_safe
+                        end
+        main_link = ts(" Part %{position} of the %{series_title} series ",
+                       position: (visible_position + 1).to_s,
+                       series_title: link_to(serial.title, serial)).html_safe
+        next_link = if (visible_position < serial_works.size - 1)
+                      link_to(ts("Next Work &rarr;").html_safe,
+                              serial_works[visible_position + 1])
+                    else
+                      "".html_safe
+                    end
         previous_link + main_link + next_link
       end
     end

--- a/app/helpers/series_helper.rb
+++ b/app/helpers/series_helper.rb
@@ -38,7 +38,7 @@ module SeriesHelper
                                 ts("Part %{position} of the %{series_title} series",
                                    position: (visible_position + 1).to_s,
                                    series_title: link_to(serial.title, serial)).html_safe,
-                                class: "title")
+                                class: "position")
         # This is empty if there is no next work, otherwise it is
         # <span class="divider"> </span><a href class="next">Next Work</a>
         # with a right-pointing arrow after "Work"

--- a/lib/skin_wizard.rb
+++ b/lib/skin_wizard.rb
@@ -173,6 +173,7 @@ module SkinWizard
         .post .required .warnings,
         dd.required,
         .required .autocomplete,
+        span.series .divider,
         .userstuff h2 {
           color: #{color};
         }

--- a/public/stylesheets/site/2.0/10-types-groups.css
+++ b/public/stylesheets/site/2.0/10-types-groups.css
@@ -185,7 +185,7 @@ span.series .previous + .divider:before {
   content: "\0020\25CF";
 }
 
-span.series .title + .divider:after {
+span.series .position + .divider:after {
   content: "\25CF\0020";
 }
 

--- a/public/stylesheets/site/2.0/10-types-groups.css
+++ b/public/stylesheets/site/2.0/10-types-groups.css
@@ -175,6 +175,20 @@ li.relationships a {
   float: none;
 }
 
+/* circle dividers for series navigation on works */
+
+span.series .divider {
+  color: #777;
+}
+
+span.series .previous + .divider:before {
+  content: "\0020\25CF";
+}
+
+span.series .title + .divider:after {
+  content: "\25CF\0020";
+}
+
 p.kudos {
   background: url("/images/imageset.png") no-repeat -110px -580px;
   padding: 0.5em 0.5em 0.5em 60px;


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-4839

## Purpose

Adds a little circle to the series navigation on works so it's easier to read; refer to issue for example. It's not exactly BOT, but it's BOT-Concern-ish and we want it in this deploy.

## Testing

Refer to issue.
