### PR TITLE
AO3-4840 Skin wizard should change bottom border on Reindex Work button

### DIFF
--- a/lib/skin_wizard.rb
+++ b/lib/skin_wizard.rb
@@ -45,6 +45,10 @@ module SkinWizard
         #dashboard.own {
           border-color: #{color};
         }
+
+        .actions .reindex a {
+          border-bottom-color: #{color};
+        }
       "
     else
       ""


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-4840

## Purpose

Changing the header color from red in the skin wizard should also change the red border on the Reindex Work button.

Sorry for the low-priority pull request, but I was already in the file for #2721