### PR TITLE
AO3-4841 Migrate works model to ruby 1.9 hash syntax

### DIFF
--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -17,44 +17,44 @@ class Work < ActiveRecord::Base
 
   # creatorships can't have dependent => destroy because we email the
   # user in a before_destroy callback
-  has_many :creatorships, :as => :creation
-  has_many :pseuds, :through => :creatorships, after_remove: :expire_pseud
-  has_many :users, :through => :pseuds, :uniq => true
+  has_many :creatorships, as: :creation
+  has_many :pseuds, through: :creatorships, after_remove: :expire_pseud
+  has_many :users, through: :pseuds, uniq: true
 
-  has_many :external_creatorships, :as => :creation, :dependent => :destroy, :inverse_of => :creation
-  has_many :archivists, :through => :external_creatorships
-  has_many :external_author_names, :through => :external_creatorships, :inverse_of => :works
-  has_many :external_authors, :through => :external_author_names, :uniq => true
+  has_many :external_creatorships, as: :creation, dependent: :destroy, inverse_of: :creation
+  has_many :archivists, through: :external_creatorships
+  has_many :external_author_names, through: :external_creatorships, inverse_of: :works
+  has_many :external_authors, through: :external_author_names, uniq: true
 
   # we do NOT use dependent => destroy here because we want to destroy chapters in REVERSE order
   has_many :chapters, conditions: "work_id IS NOT NULL"
   validates_associated :chapters
 
-  has_many :serial_works, :dependent => :destroy
-  has_many :series, :through => :serial_works
+  has_many :serial_works, dependent: :destroy
+  has_many :series, through: :serial_works
 
-  has_many :related_works, :as => :parent
-  has_many :approved_related_works, :as => :parent, :class_name => "RelatedWork", :conditions => "reciprocal = 1"
-  has_many :parent_work_relationships, :class_name => "RelatedWork", :dependent => :destroy
-  has_many :children, :through => :related_works, :source => :work
-  has_many :approved_children, :through => :approved_related_works, :source => :work
+  has_many :related_works, as: :parent
+  has_many :approved_related_works, as: :parent, class_name: "RelatedWork", conditions: "reciprocal = 1"
+  has_many :parent_work_relationships, class_name: "RelatedWork", dependent: :destroy
+  has_many :children, through: :related_works, source: :work
+  has_many :approved_children, through: :approved_related_works, source: :work
 
-  has_many :gifts, :dependent => :destroy
-  accepts_nested_attributes_for :gifts, :allow_destroy => true
+  has_many :gifts, dependent: :destroy
+  accepts_nested_attributes_for :gifts, allow_destroy: true
 
-  has_many :subscriptions, :as => :subscribable, :dependent => :destroy
+  has_many :subscriptions, as: :subscribable, dependent: :destroy
 
-  has_many :challenge_assignments, :as => :creation
-  has_many :challenge_claims, :as => :creation
+  has_many :challenge_assignments, as: :creation
+  has_many :challenge_claims, as: :creation
   accepts_nested_attributes_for :challenge_claims
 
   acts_as_commentable
-  has_many :total_comments, :class_name => 'Comment', :through => :chapters
-  has_many :kudos, :as => :commentable, :dependent => :destroy
+  has_many :total_comments, class_name: 'Comment', through: :chapters
+  has_many :kudos, as: :commentable, dependent: :destroy
 
   belongs_to :language
   belongs_to :work_skin
-  validate :work_skin_allowed, :on => :save
+  validate :work_skin_allowed, on: :save
   def work_skin_allowed
     unless self.users.include?(self.work_skin.author) || (self.work_skin.public? && self.work_skin.official?)
       errors.add(:base, ts("You do not have permission to use that custom work stylesheet."))
@@ -62,8 +62,8 @@ class Work < ActiveRecord::Base
   end
 
   # statistics
-  has_many :work_links, :dependent => :destroy
-  has_one :stat_counter, :dependent => :destroy
+  has_many :work_links, dependent: :destroy
+  has_one :stat_counter, dependent: :destroy
   after_create :create_stat_counter
   def create_stat_counter
     counter = self.build_stat_counter
@@ -95,27 +95,27 @@ class Work < ActiveRecord::Base
   ########################################################################
   validates_presence_of :title
   validates_length_of :title,
-    :minimum => ArchiveConfig.TITLE_MIN,
-    :too_short=> ts("must be at least %{min} characters long.", :min => ArchiveConfig.TITLE_MIN)
+    minimum: ArchiveConfig.TITLE_MIN,
+    too_short: ts("must be at least %{min} characters long.", min: ArchiveConfig.TITLE_MIN)
 
   validates_length_of :title,
-    :maximum => ArchiveConfig.TITLE_MAX,
-    :too_long=> ts("must be less than %{max} characters long.", :max => ArchiveConfig.TITLE_MAX)
+    maximum: ArchiveConfig.TITLE_MAX,
+    too_long: ts("must be less than %{max} characters long.", max: ArchiveConfig.TITLE_MAX)
 
   validates_length_of :summary,
-    :allow_blank => true,
-    :maximum => ArchiveConfig.SUMMARY_MAX,
-    :too_long => ts("must be less than %{max} characters long.", :max => ArchiveConfig.SUMMARY_MAX)
+    allow_blank: true,
+    maximum: ArchiveConfig.SUMMARY_MAX,
+    too_long: ts("must be less than %{max} characters long.", max: ArchiveConfig.SUMMARY_MAX)
 
   validates_length_of :notes,
-    :allow_blank => true,
-    :maximum => ArchiveConfig.NOTES_MAX,
-    :too_long => ts("must be less than %{max} characters long.", :max => ArchiveConfig.NOTES_MAX)
+    allow_blank: true,
+    maximum: ArchiveConfig.NOTES_MAX,
+    too_long: ts("must be less than %{max} characters long.", max: ArchiveConfig.NOTES_MAX)
 
   validates_length_of :endnotes,
-    :allow_blank => true,
-    :maximum => ArchiveConfig.NOTES_MAX,
-    :too_long => ts("must be less than %{max} characters long.", :max => ArchiveConfig.NOTES_MAX)
+    allow_blank: true,
+    maximum: ArchiveConfig.NOTES_MAX,
+    too_long: ts("must be less than %{max} characters long.", max: ArchiveConfig.NOTES_MAX)
 
   # Checks that work has at least one author
   def validate_authors
@@ -123,7 +123,7 @@ class Work < ActiveRecord::Base
       errors.add(:base, ts("Work must have at least one author."))
       return false
     elsif !self.invalid_pseuds.blank?
-      errors.add(:base, ts("These pseuds are invalid: %{pseuds}", :pseuds => self.invalid_pseuds.inspect))
+      errors.add(:base, ts("These pseuds are invalid: %{pseuds}", pseuds: self.invalid_pseuds.inspect))
     end
   end
 
@@ -144,7 +144,7 @@ class Work < ActiveRecord::Base
     unless self.title.blank?
       self.title = self.title.strip
       if self.title.length < ArchiveConfig.TITLE_MIN
-        errors.add(:base, ts("Title must be at least %{min} characters long without leading spaces.", :min => ArchiveConfig.TITLE_MIN))
+        errors.add(:base, ts("Title must be at least %{min} characters long without leading spaces.", min: ArchiveConfig.TITLE_MIN))
         return false
       else
         self.title_to_sort_on = self.sorted_title
@@ -210,7 +210,7 @@ class Work < ActiveRecord::Base
   end
 
   def self.work_blurb_tag_cache(id)
-    Rails.cache.fetch(Work.work_blurb_tag_cache_key(id), :raw => true) { rand(1..1000) }
+    Rails.cache.fetch(Work.work_blurb_tag_cache_key(id), raw: true) { rand(1..1000) }
   end
 
   def self.expire_work_tag_groups_id(id)
@@ -282,8 +282,8 @@ class Work < ActiveRecord::Base
 
   def self.purge_old_drafts
     draft_ids = Work.where('works.posted = ? AND works.created_at < ?', false, 1.month.ago).value_of(:id)
-    Chapter.where(:work_id => draft_ids).order("position DESC").map(&:destroy)
-    Work.where(:id => draft_ids).map(&:destroy)
+    Chapter.where(work_id: draft_ids).order("position DESC").map(&:destroy)
+    Work.where(id: draft_ids).map(&:destroy)
     draft_ids.size
   end
 
@@ -312,8 +312,8 @@ class Work < ActiveRecord::Base
   # 3. first match on variants of both the imported_from_url and the provided url if there is a partial match
   def self.find_by_url(url)
     url = UrlFormatter.new(url)
-    Work.where(:imported_from_url => url.original).first ||
-      Work.where(:imported_from_url => [url.minimal, url.no_www, url.with_www, url.encoded, url.decoded]).first ||
+    Work.where(imported_from_url: url.original).first ||
+      Work.where(imported_from_url: [url.minimal, url.no_www, url.with_www, url.encoded, url.decoded]).first ||
       Work.where("imported_from_url LIKE ?", "%#{url.minimal_no_http}%").select { |w|
         work_url = UrlFormatter.new(w.imported_from_url)
         ['original', 'minimal', 'no_www', 'with_www', 'encoded', 'decoded'].any? { |method|
@@ -337,7 +337,7 @@ class Work < ActiveRecord::Base
     end
     self.authors << Pseud.find(attributes[:ambiguous_pseuds]) if attributes[:ambiguous_pseuds]
     if !attributes[:byline].blank?
-      results = Pseud.parse_bylines(attributes[:byline], :keep_ambiguous => true)
+      results = Pseud.parse_bylines(attributes[:byline], keep_ambiguous: true)
       self.authors << results[:pseuds]
       self.invalid_pseuds = results[:invalid_pseuds]
       self.ambiguous_pseuds = results[:ambiguous_pseuds]
@@ -389,7 +389,7 @@ class Work < ActiveRecord::Base
     # if this is fulfilling a challenge, add the collection and recipient
     challenge_assignments.each do |assignment|
       add_to_collection(assignment.collection)
-      self.gifts << Gift.new(:pseud => assignment.requesting_pseud) unless (assignment.requesting_pseud.blank? || recipients && recipients.include?(assignment.request_byline))
+      self.gifts << Gift.new(pseud: assignment.requesting_pseud) unless (assignment.requesting_pseud.blank? || recipients && recipients.include?(assignment.request_byline))
     end
   end
 
@@ -397,7 +397,7 @@ class Work < ActiveRecord::Base
     # if this is fulfilling a challenge claim, add the collection and recipient
     challenge_claims.each do |assignment|
       add_to_collection(claim.collection)
-      self.gifts << Gift.new(:pseud => claim.requesting_pseud) unless (recipients && recipients.include?(claim.request_byline))
+      self.gifts << Gift.new(pseud: claim.requesting_pseud) unless (recipients && recipients.include?(claim.request_byline))
     end
     save
   end
@@ -523,7 +523,7 @@ class Work < ActiveRecord::Base
   # provide an interface to increment major version number
   # resets minor_version to 0
   def update_major_version
-    self.update_attributes({:major_version => self.major_version+1, :minor_version => 0})
+    self.update_attributes({major_version: self.major_version+1, minor_version: 0})
   end
 
   # provide an interface to increment minor version number
@@ -532,7 +532,7 @@ class Work < ActiveRecord::Base
   end
 
   def set_revised_at(date=nil)
-    date ||= self.chapters.where(:posted => true).maximum('published_at') || 
+    date ||= self.chapters.where(posted: true).maximum('published_at') || 
         self.revised_at || self.created_at
     date = date.instance_of?(Date) ? DateTime::jd(date.jd, 12, 0, 0) : date
     self.revised_at = date
@@ -619,7 +619,7 @@ class Work < ActiveRecord::Base
 
   # Save chapter data when the work is updated
   def save_chapters
-    self.chapters.first.save(:validate => false)
+    self.chapters.first.save(validate: false)
   end
 
   # If the work is posted, the first chapter should be posted too
@@ -684,7 +684,7 @@ class Work < ActiveRecord::Base
     chapters = self.chapters.order('position ASC')
     # only posted chapters unless author
     unless User.current_user && (User.current_user.is_a?(Admin) || User.current_user.is_author_of?(self))
-      chapters = chapters.where(:posted => true)
+      chapters = chapters.where(posted: true)
     end
     # when doing navigation pass false as contents are not needed
     chapters = chapters.select('published_at, id, work_id, title, position, posted') unless include_content
@@ -750,7 +750,7 @@ class Work < ActiveRecord::Base
     if self.new_record?
       self.word_count = self.chapters.first.set_word_count
     else
-      self.word_count = Chapter.select("SUM(word_count) AS work_word_count").where(:work_id => self.id, :posted => true).first.work_word_count
+      self.word_count = Chapter.select("SUM(word_count) AS work_word_count").where(work_id: self.id, posted: true).first.work_word_count
     end
   end
 
@@ -839,7 +839,7 @@ class Work < ActiveRecord::Base
     if filter
       if !self.filters.include?(filter)
         if meta
-          self.filter_taggings.create(:filter_id => filter.id, :inherited => true)
+          self.filter_taggings.create(filter_id: filter.id, inherited: true)
         else
           self.filters << filter
         end
@@ -911,8 +911,8 @@ class Work < ActiveRecord::Base
   # Gets all comments for all chapters in the work
   def find_all_comments
     Comment.where(
-      :parent_type => 'Chapter',
-      :parent_id => self.chapters.value_of(:id)
+      parent_type: 'Chapter',
+      parent_id: self.chapters.value_of(:id)
     )
   end
 
@@ -927,8 +927,8 @@ class Work < ActiveRecord::Base
   # returns the top-level comments for all chapters in the work
   def comments
     Comment.where(
-      :commentable_type => 'Chapter',
-      :commentable_id => self.chapters.value_of(:id)
+      commentable_type: 'Chapter',
+      commentable_id: self.chapters.value_of(:id)
     )
   end
 
@@ -967,7 +967,7 @@ class Work < ActiveRecord::Base
       if attributes[:url].include?(ArchiveConfig.APP_HOST)
         if attributes[:url].match(/\/works\/(\d+)/)
           begin
-            self.new_parent = {:parent => Work.find($1), :translation => attributes[:translation]}
+            self.new_parent = {parent: Work.find($1), translation: attributes[:translation]}
           rescue
             self.errors.add(:base, "The work you listed as an inspiration does not seem to exist.")
           end
@@ -987,11 +987,11 @@ class Work < ActiveRecord::Base
         translation = attributes.delete(:translation)
         ew = ExternalWork.find_by_url(attributes[:url])
         if ew && (ew.title == attributes[:title]) && (ew.author == attributes[:author])
-          self.new_parent = {:parent => ew, :translation => translation}
+          self.new_parent = {parent: ew, translation: translation}
         else
           ew = ExternalWork.new(attributes)
           if ew.save
-            self.new_parent = {:parent => ew, :translation => translation}
+            self.new_parent = {parent: ew, translation: translation}
           else
             self.errors.add(:base, "Parent work info would not save.")
           end
@@ -1004,7 +1004,7 @@ class Work < ActiveRecord::Base
   def save_parents
     if self.new_parent and !(self.parents.include?(self.new_parent))
       unless self.new_parent.blank? || self.new_parent[:parent].blank?
-        relationship = self.new_parent[:parent].related_works.build :work_id => self.id, :translation => self.new_parent[:translation]
+        relationship = self.new_parent[:parent].related_works.build work_id: self.id, translation: self.new_parent[:translation]
         if relationship.save
           self.new_parent = nil
         end
@@ -1014,7 +1014,7 @@ class Work < ActiveRecord::Base
 
   protected
 
-  # a string for use in :joins => clause to add ownership lookup
+  # a string for use in joins: clause to add ownership lookup
   OWNERSHIP_JOIN = "INNER JOIN creatorships ON (creatorships.creation_id = works.id AND creatorships.creation_type = 'Work')
                     INNER JOIN pseuds ON creatorships.pseud_id = pseuds.id
                     INNER JOIN users ON pseuds.user_id = users.id"
@@ -1023,11 +1023,11 @@ class Work < ActiveRecord::Base
                   INNER JOIN tags ON common_taggings.common_tag_id = tags.id"
 
 
-  VISIBLE_TO_ALL_CONDITIONS = {:posted => true, :restricted => false, :hidden_by_admin => false}
+  VISIBLE_TO_ALL_CONDITIONS = {posted: true, restricted: false, hidden_by_admin: false}
 
-  VISIBLE_TO_USER_CONDITIONS = {:posted => true, :hidden_by_admin => false}
+  VISIBLE_TO_USER_CONDITIONS = {posted: true, hidden_by_admin: false}
 
-  VISIBLE_TO_ADMIN_CONDITIONS = {:posted => true}
+  VISIBLE_TO_ADMIN_CONDITIONS = {posted: true}
 
 
 
@@ -1057,13 +1057,13 @@ class Work < ActiveRecord::Base
 
   scope :recent, lambda { |*args| where("revised_at > ?", (args.first || 4.weeks.ago.to_date)) }
   scope :within_date_range, lambda { |*args| where("revised_at BETWEEN ? AND ?", (args.first || 4.weeks.ago), (args.last || Time.now)) }
-  scope :posted, where(:posted => true)
-  scope :unposted, where(:posted => false)
+  scope :posted, where(posted: true)
+  scope :unposted, where(posted: false)
   scope :not_spam, where(spam: false)
-  scope :restricted , where(:restricted => true)
-  scope :unrestricted, where(:restricted => false)
-  scope :hidden, where(:hidden_by_admin => true)
-  scope :unhidden, where(:hidden_by_admin => false)
+  scope :restricted , where(restricted: true)
+  scope :unrestricted, where(restricted: false)
+  scope :hidden, where(hidden_by_admin: true)
+  scope :unhidden, where(hidden_by_admin: false)
   scope :visible_to_all, posted.unrestricted.unhidden
   scope :visible_to_registered_user, posted.unhidden
   scope :visible_to_admin, posted
@@ -1072,9 +1072,9 @@ class Work < ActiveRecord::Base
 
   scope :giftworks_for_recipient_name, lambda { |name| select("DISTINCT works.*").joins(:gifts).where("recipient_name = ?", name).where("gifts.rejected = FALSE") }
 
-  scope :non_anon, where(:in_anon_collection => false)
-  scope :unrevealed, where(:in_unrevealed_collection => true)
-  scope :revealed, where(:in_unrevealed_collection => false)
+  scope :non_anon, where(in_anon_collection: false)
+  scope :unrevealed, where(in_unrevealed_collection: true)
+  scope :revealed, where(in_unrevealed_collection: false)
   scope :latest, visible_to_all.
                  revealed.
                  order("revised_at DESC").
@@ -1093,7 +1093,7 @@ class Work < ActiveRecord::Base
     when 'User'
       select("DISTINCT works.*").
       posted.
-      joins({:pseuds => :user}).
+      joins({pseuds: :user}).
       where("works.hidden_by_admin = false OR users.id = ?", user.id)
     else
       visible_to_all
@@ -1108,14 +1108,14 @@ class Work < ActiveRecord::Base
   scope :with_filter, lambda { |tag|
     select("DISTINCT works.*").
     joins(:filter_taggings).
-    where({:filter_taggings => {:filter_id => tag.id}})
+    where({filter_taggings: {filter_id: tag.id}})
   }
 
   # Note: this version will work only on canonical tags (filters)
   scope :with_all_filter_ids, lambda {|tag_ids_to_find|
     select("DISTINCT works.*").
     joins(:filter_taggings).
-    where({:filter_taggings => {:filter_id => tag_ids_to_find}}).
+    where({filter_taggings: {filter_id: tag_ids_to_find}}).
     group("works.id").
     having("count(DISTINCT filter_taggings.filter_id) = #{tag_ids_to_find.size}")
   }
@@ -1123,7 +1123,7 @@ class Work < ActiveRecord::Base
   scope :with_any_filter_ids, lambda {|tag_ids_to_find|
     select("DISTINCT works.*").
     joins(:filter_taggings).
-    where({:filter_taggings => {:filter_id => tag_ids_to_find}})
+    where({filter_taggings: {filter_id: tag_ids_to_find}})
   }
 
   scope :with_all_tag_ids, lambda {|tag_ids_to_find|
@@ -1153,7 +1153,7 @@ class Work < ActiveRecord::Base
     group("tags.name").
     order("tags.type, tags.name ASC")
 
-  scope :owned_by, lambda {|user| select("DISTINCT works.*").joins({:pseuds => :user}).where('users.id = ?', user.id)}
+  scope :owned_by, lambda {|user| select("DISTINCT works.*").joins({pseuds: :user}).where('users.id = ?', user.id)}
   scope :written_by_id, lambda {|pseud_ids|
     select("DISTINCT works.*").
     joins(:pseuds).
@@ -1195,7 +1195,7 @@ class Work < ActiveRecord::Base
   # find all the works that do not have a tag in the given category (i.e. no fandom, no characters etc.)
   def self.no_tags(tag_category, options = {})
     tags = tag_category.tags
-    with_scope :find => options do
+    with_scope find: options do
       find(:all).collect {|w| w if (w.tags & tags).empty? }.compact.uniq
     end
   end
@@ -1225,7 +1225,7 @@ class Work < ActiveRecord::Base
     end
 
     if %w(Pseud User).include?(owner.class.to_s)
-      works = works.where(:in_anon_collection => false)
+      works = works.where(in_anon_collection: false)
     end
     unless owner.is_a?(Collection)
       works = works.revealed
@@ -1236,18 +1236,18 @@ class Work < ActiveRecord::Base
 
     works = works.posted
     works = works.order("revised_at DESC")
-    works = works.paginate(:page => options[:page], :per_page => ArchiveConfig.ITEMS_PER_PAGE)
+    works = works.paginate(page: options[:page], per_page: ArchiveConfig.ITEMS_PER_PAGE)
   end
 
   def self.collected_without_filters(user, options)
     works = Work.written_by_id([user.id])
     works = works.join(:collection_items)
     unless User.current_user == user
-      works = works.where(:in_anon_collection => false)
+      works = works.where(in_anon_collection: false)
       works = works.posted
     end
     works = works.order("revised_at DESC")
-    works = works.paginate(:page => options[:page], :per_page => ArchiveConfig.ITEMS_PER_PAGE)
+    works = works.paginate(page: options[:page], per_page: ArchiveConfig.ITEMS_PER_PAGE)
   end
 
   ########################################################################
@@ -1309,11 +1309,11 @@ class Work < ActiveRecord::Base
   #############################################################################
 
   mapping do
-    indexes :authors_to_sort_on,  :index    => :not_analyzed
-    indexes :title_to_sort_on,    :index    => :not_analyzed
-    indexes :title,               :boost => 20
-    indexes :creator,             :boost => 15
-    indexes :revised_at,          :type  => 'date'
+    indexes :authors_to_sort_on,  index: :not_analyzed
+    indexes :title_to_sort_on,    index: :not_analyzed
+    indexes :title,               boost: 20
+    indexes :creator,             boost: 15
+    indexes :revised_at,          type: 'date'
   end
 
   def to_indexed_json


### PR DESCRIPTION

## Issue

https://otwarchive.atlassian.net/browse/AO3-4841

## Purpose

Moves the works controller and works model to ruby 1.9 hash syntax

## Testing

No manual testing required.