### PR TITLE
AO3-4830 Extend tests for tag_set_nominations_controller

### DIFF
--- a/spec/controllers/tag_set_nominations_controller_spec.rb
+++ b/spec/controllers/tag_set_nominations_controller_spec.rb
@@ -19,13 +19,12 @@ describe TagSetNominationsController do
 
   let(:random_user) { FactoryGirl.create(:user) }
 
-  #TODO: Create some tag_set_nomination and tag_nomination factories?
-
   describe 'GET index' do
     context 'user is not logged in' do
       it 'redirects and returns an error message' do
         get :index, user_id: moderator.login, tag_set_id: owned_tag_set.id
-        it_redirects_to_with_error(new_user_session_path, "Sorry, you don't have permission to access the page you were trying to reach. Please log in.")
+        it_redirects_to_with_error(new_user_session_path, "Sorry, you don't have permission to access the page you " +
+            "were trying to reach. Please log in.")
       end
     end
 
@@ -39,8 +38,8 @@ describe TagSetNominationsController do
 
         context 'user_id does not match logged in user' do
           it 'redirects and returns an error message' do
-            get :index, user_id: "invalid", tag_set_id: owned_tag_set.id
-            it_redirects_to_with_error(tag_sets_path, "You can only view your own nominations, sorry.")
+            get :index, user_id: 'invalid', tag_set_id: owned_tag_set.id
+            it_redirects_to_with_error(tag_sets_path, 'You can only view your own nominations, sorry.')
           end
         end
 
@@ -50,11 +49,11 @@ describe TagSetNominationsController do
           end
 
           it 'renders the index template' do
-            expect(response).to render_template("index")
+            expect(response).to render_template('index')
           end
 
           it 'returns expected tag set nominations' do
-            expect(assigns(:tag_set_nominations)).to include(tag_set_nomination)
+            expect(assigns(:tag_set_nominations)).to eq([tag_set_nomination])
           end
         end
       end
@@ -62,55 +61,43 @@ describe TagSetNominationsController do
       context 'user_id param is falsey' do
         context 'tag set exists' do
           context 'logged in user is moderator' do
-            let(:user) { moderator.reload } # Why reload?
+            let(:user) { moderator.reload }
 
             it 'renders the index template' do
               get :index, tag_set_id: owned_tag_set.id
-              expect(response).to render_template("index")
+              expect(response).to render_template('index')
             end
 
             context 'no unreviewed tag_nominations' do
               it 'returns a flash notice about no unreviewed nominations' do
                 get :index, tag_set_id: owned_tag_set.id
-                expect(flash[:notice]).to eq("No nominations to review!")
+                expect(flash[:notice]).to eq('No nominations to review!')
               end
             end
 
             context 'unreviewed tag_nominations exist' do
-              let(:fandom_nom) { FandomNomination.create(tag_set_nomination: tag_set_nomination,
-                                                         tagname: "New Fandom", approved: false, rejected: false) }
-              let!(:unreviewed_character_nom) { CharacterNomination.create(tag_set_nomination: tag_set_nomination,
-                                                                           fandom_nomination: fandom_nom,
-                                                                           tagname: "New Character",
-                                                                           approved: false, rejected: false) }
-              let!(:unreviewed_relationship_nom) { RelationshipNomination.create(tag_set_nomination: tag_set_nomination,
-                                                                                 fandom_nomination: fandom_nom,
-                                                                                 tagname: "New Relationship",
-                                                                                 approved: false, rejected: false) }
-
               it 'does not return a flash notice about no unreviewed nominations' do
+                FandomNomination.create(tag_set_nomination: tag_set_nomination, tagname: 'New Fandom')
                 get :index, tag_set_id: owned_tag_set.id
-                expect(flash[:notice]).not_to eq("No nominations to review!")
+                expect(flash[:notice]).not_to eq('No nominations to review!')
               end
 
               context 'tag set freeform_nomination_limit is > 0' do
                 before do
-                  owned_tag_set.update_attribute(:freeform_nomination_limit, 2)
+                  owned_tag_set.update_column(:freeform_nomination_limit, 1)
                 end
 
                 context 'unreviewed freeform_nominations' do
                   context 'unreviewed freeform nominations <= 30' do
                     before do
                       add_unreviewed_freeform_nominations(30)
-                      expect(owned_tag_set.freeform_nominations.count).to eq(30)
-
                       get :index, tag_set_id: owned_tag_set.id
                     end
 
-                    it 'returns all ordered freeform nominations' do
+                    it 'returns all freeform nominations in order' do
                       expect(assigns(:nominations_count)[:freeform]).to eq(30)
                       expect(assigns(:nominations)[:freeform].count).to eq(30)
-                      expect(assigns(:nominations)[:freeform].first.tagname).to eq("New Freeform 1")
+                      expect(assigns(:nominations)[:freeform].first.tagname).to eq('New Freeform 0')
                     end
 
                     it 'does not return a flash notice about too many nominations' do
@@ -123,8 +110,6 @@ describe TagSetNominationsController do
                   context 'unreviewed freeform nominations > 30' do
                     before do
                       add_unreviewed_freeform_nominations(31)
-                      expect(owned_tag_set.freeform_nominations.count).to eq(31)
-
                       get :index, tag_set_id: owned_tag_set.id
                     end
 
@@ -141,10 +126,8 @@ describe TagSetNominationsController do
                   end
 
                   def add_unreviewed_freeform_nominations(num)
-                    num.times do
-                      FreeformNomination.create(tag_set_nomination: tag_set_nomination, tagname: "New Freeform #{num}",
-                                                approved: false, rejected: false)
-                      num -= 1
+                    num.times do |i|
+                      FreeformNomination.create(tag_set_nomination: tag_set_nomination, tagname: "New Freeform #{i}")
                     end
                   end
                 end
@@ -152,22 +135,21 @@ describe TagSetNominationsController do
                 context 'reviewed freeform_nominations' do
                   it 'does not return freeform nominations' do
                     freeform_nom = FreeformNomination.create(tag_set_nomination: tag_set_nomination,
-                                                             tagname: "New Freeform")
-                    owned_tag_set.tag_set.from_owned_tag_set = true
-                    owned_tag_set.add_tagnames("freeform", [freeform_nom.tagname])
+                                                             tagname: 'New Freeform')
+                    freeform_nom.update_column(:approved, true)
                     get :index, tag_set_id: owned_tag_set.id
 
                     expect(assigns(:nominations_count)[:freeform]).to eq(0)
-                    expect(assigns(:nominations)[:freeform]).not_to include(freeform_nom)
+                    expect(assigns(:nominations)[:freeform]).to be_empty
                   end
                 end
               end
 
               context 'tag set freeform_nomination_limit is 0' do
                 it 'does not return freeform nominations' do
-                  owned_tag_set.update_attribute(:freeform_nomination_limit, 0)
-                  FreeformNomination.create(tag_set_nomination: tag_set_nomination, tagname: "New Freeform",
-                                            approved: false, rejected: false)
+                  owned_tag_set.update_column(:freeform_nomination_limit, 0)
+                  FreeformNomination.create(tag_set_nomination: tag_set_nomination, tagname: 'New Freeform')
+
                   get :index, tag_set_id: owned_tag_set.id
                   expect(assigns(:nominations)[:freeform]).to be_nil
                 end
@@ -175,30 +157,35 @@ describe TagSetNominationsController do
 
               context 'tag set fandom_nomination_limit is > 0' do
                 before do
-                  owned_tag_set.fandom_nomination_limit = 2
-                  owned_tag_set.character_nomination_limit = 2
-                  owned_tag_set.relationship_nomination_limit = 2
-                  owned_tag_set.save(validate: false)
+                  owned_tag_set.update_column(:fandom_nomination_limit, 1)
+                  owned_tag_set.update_column(:character_nomination_limit, 1)
+                  owned_tag_set.update_column(:relationship_nomination_limit, 1)
+
+                  add_fandom_nominations(fandom_nom_num, fandom_nom_status)
+                  CharacterNomination.create(tag_set_nomination: tag_set_nomination,
+                                             fandom_nomination: FandomNomination.last, tagname: 'Unreviewed Character')
+                  RelationshipNomination.create(tag_set_nomination: tag_set_nomination,
+                                                fandom_nomination: FandomNomination.last, tagname: 'Unreviewed Relationship')
                 end
 
                 context 'unreviewed fandom nominations' do
+                  let(:fandom_nom_status) { :unreviewed }
+
+                  before do
+                    get :index, tag_set_id: owned_tag_set.id
+                  end
+
                   context 'unreviewed fandom nominations <= 30' do
-                    before do
-                      add_unreviewed_fandom_nominations(29)
-                      expect(owned_tag_set.fandom_nominations.count).to eq(30)
+                    let(:fandom_nom_num) { 30 }
 
-                      get :index, tag_set_id: owned_tag_set.id
-                    end
-
-                    it 'returns all ordered fandom nominations' do
+                    it 'returns all fandom nominations in order' do
                       expect(assigns(:nominations_count)[:fandom]).to eq(30)
                       expect(assigns(:nominations)[:fandom].count).to eq(30)
-                      expect(assigns(:nominations)[:fandom].first).to eq(fandom_nom)
+                      expect(assigns(:nominations)[:fandom].first.tagname).to eq('New Fandom 0')
                     end
 
                     it 'does not return associated character and relationship nominations' do
-                      expect(assigns(:nominations)[:cast]).not_to include(unreviewed_character_nom)
-                      expect(assigns(:nominations)[:cast]).not_to include(unreviewed_relationship_nom)
+                      expect(assigns(:nominations)[:cast]).to be_empty
                     end
 
                     it 'does not return a flash notice about too many nominations' do
@@ -209,12 +196,7 @@ describe TagSetNominationsController do
                   end
 
                   context 'unreviewed fandom nominations > 30' do
-                    before do
-                      add_unreviewed_fandom_nominations(30)
-                      expect(owned_tag_set.fandom_nominations.count).to eq(31)
-
-                      get :index, tag_set_id: owned_tag_set.id
-                    end
+                    let(:fandom_nom_num) { 31 }
 
                     it 'returns 30 fandom nominations' do
                       expect(assigns(:nominations_count)[:fandom]).to eq(31)
@@ -227,133 +209,117 @@ describe TagSetNominationsController do
                                                        "after you approve or reject some.")
                     end
                   end
-
-                  def add_unreviewed_fandom_nominations(num)
-                    num.times do
-                      FandomNomination.create(tag_set_nomination: tag_set_nomination, tagname: "New Fandom #{num}",
-                                              approved: false, rejected: false)
-                      num -= 1
-                    end
-                  end
                 end
 
                 context 'rejected fandom nominations' do
+                  let(:fandom_nom_num) { 1 }
+                  let(:fandom_nom_status) { :rejected }
+
                   before do
-                    owned_tag_set.remove_tagnames("fandom", [fandom_nom.tagname])
                     get :index, tag_set_id: owned_tag_set.id
                   end
 
                   it 'does not return fandom nominations' do
-                    expect(assigns(:nominations)[:fandom]).not_to include(fandom_nom)
+                    expect(assigns(:nominations)[:fandom]).to be_empty
                   end
 
                   it 'does not return associated character and relationship nominations' do
-                    expect(assigns(:nominations)[:cast]).not_to include(unreviewed_character_nom)
-                    expect(assigns(:nominations)[:cast]).not_to include(unreviewed_relationship_nom)
+                    expect(assigns(:nominations)[:cast]).to be_empty
                   end
                 end
 
                 context 'approved fandom nominations' do
-                  let(:reviewed_character_nom) { CharacterNomination.create(tag_set_nomination: tag_set_nomination,
-                                                                            fandom_nomination: fandom_nom,
-                                                                            tagname: "Character To Be Approved") }
-                  let(:reviewed_relationship_nom) { RelationshipNomination.create(tag_set_nomination: tag_set_nomination,
-                                                                                  fandom_nomination: fandom_nom,
-                                                                                  tagname: "Relationship To Be Approved") }
-
-                  before do
-                    owned_tag_set.tag_set.from_owned_tag_set = true
-                    owned_tag_set.add_tagnames("fandom", [fandom_nom.tagname])
-                    owned_tag_set.add_tagnames("character", [reviewed_character_nom.tagname])
-                    owned_tag_set.add_tagnames("relationship", [reviewed_relationship_nom.tagname])
-                  end
+                  let(:fandom_nom_num) { 1 }
+                  let(:fandom_nom_status) { :approved }
 
                   it 'does not return fandom nominations' do
                     get :index, tag_set_id: owned_tag_set.id
-                    expect(assigns(:nominations)[:fandom]).not_to include(fandom_nom)
+                    expect(assigns(:nominations)[:fandom]).to be_empty
                   end
 
                   it 'does not return associated reviewed character and relationship nominations' do
+                    approved_character_nom = CharacterNomination.create(tag_set_nomination: tag_set_nomination,
+                                                                        fandom_nomination: FandomNomination.last,
+                                                                        tagname: 'Approved Character')
+                    approved_character_nom.update_column(:approved, true)
+                    approved_relationship_nom = RelationshipNomination.create(tag_set_nomination: tag_set_nomination,
+                                                                              fandom_nomination: FandomNomination.last,
+                                                                              tagname: 'Approved Relationship')
+                    approved_relationship_nom.update_column(:approved, true)
                     get :index, tag_set_id: owned_tag_set.id
-                    expect(assigns(:nominations)[:cast]).not_to include(reviewed_character_nom)
-                    expect(assigns(:nominations)[:cast]).not_to include(reviewed_relationship_nom)
+
+                    expect(assigns(:nominations)[:cast]).not_to include(approved_character_nom)
+                    expect(assigns(:nominations)[:cast]).not_to include(approved_relationship_nom)
                   end
 
                   context 'character_ and relationship_nomination_limit are > 0' do
-                    before do
+                    it 'returns associated unreviewed character and relationship nominations' do
                       expect(owned_tag_set.character_nomination_limit).to be > 0
                       expect(owned_tag_set.relationship_nomination_limit).to be > 0
 
                       get :index, tag_set_id: owned_tag_set.id
-                    end
-
-                    it 'returns associated unreviewed character and relationship nominations' do
-                      expect(assigns(:nominations)[:cast]).to eq([unreviewed_character_nom, unreviewed_relationship_nom])
+                      expect(assigns(:nominations)[:cast].map(&:tagname)).to eq(['Unreviewed Character',
+                                                                                 'Unreviewed Relationship'])
                     end
                   end
 
-                  context 'character_nomination_limit is 0, relationship_nomination_limit is > 0' do
-                    before do
-                      owned_tag_set.update_attribute(:character_nomination_limit, 0)
+                  context 'either character_ or relationship_nomination_limit is > 0' do
+                    it 'returns associated unreviewed character and relationship nominations' do
+                      owned_tag_set.update_column(:character_nomination_limit, 0)
                       expect(owned_tag_set.relationship_nomination_limit).to be > 0
 
                       get :index, tag_set_id: owned_tag_set.id
-                    end
-
-                    it 'returns associated unreviewed character and relationship nominations' do
-                      expect(assigns(:nominations)[:cast]).to eq([unreviewed_character_nom, unreviewed_relationship_nom])
+                      expect(assigns(:nominations)[:cast].map(&:tagname)).to eq(['Unreviewed Character',
+                                                                                 'Unreviewed Relationship'])
                     end
                   end
 
                   context 'character_ and relationship_nomination_limit are 0' do
-                    before do
-                      owned_tag_set.update_attribute(:character_nomination_limit, 0)
-                      owned_tag_set.update_attribute(:relationship_nomination_limit, 0)
+                    it 'does not return associated character and relationship nominations' do
+                      owned_tag_set.update_column(:character_nomination_limit, 0)
+                      owned_tag_set.update_column(:relationship_nomination_limit, 0)
 
                       get :index, tag_set_id: owned_tag_set.id
-                    end
-
-                    it 'does not return associated character and relationship nominations' do
                       expect(assigns(:nominations)[:cast]).to be_nil
                     end
+                  end
+                end
+
+                def add_fandom_nominations(num, status)
+                  num.times do |i|
+                    fandom_nom = FandomNomination.create(tag_set_nomination: tag_set_nomination, tagname: "New Fandom #{i}")
+                    fandom_nom.update_column(status, true) if status != :unreviewed
                   end
                 end
               end
 
               context 'tag set fandom_nomination_limit is 0' do
-                before do
-                  owned_tag_set.update_attribute(:fandom_nomination_limit, 0)
-                end
+                let(:fandom_nom) { FandomNomination.create(tag_set_nomination: tag_set_nomination, tagname: 'New Fandom') }
 
-                it 'renders the index template' do
-                  get :index, tag_set_id: owned_tag_set.id
-                  expect(response).to render_template("index")
+                before do
+                  owned_tag_set.update_column(:fandom_nomination_limit, 0)
                 end
 
                 context 'character_ and relationship_nomination_limit are > 0' do
                   before do
-                    owned_tag_set.character_nomination_limit = 2
-                    owned_tag_set.relationship_nomination_limit = 2
-                    owned_tag_set.save(validate: false)
+                    owned_tag_set.update_column(:character_nomination_limit, 1)
+                    owned_tag_set.update_column(:relationship_nomination_limit, 1)
                   end
 
                   context 'unreviewed character and relationship nominations <= 30' do
                     before do
-                      add_unreviewed_character_nominations(29)
-                      expect(owned_tag_set.character_nominations.count).to eq(30)
-                      add_unreviewed_relationship_nominations(29)
-                      expect(owned_tag_set.relationship_nominations.count).to eq(30)
-
+                      add_unreviewed_character_nominations(30)
+                      add_unreviewed_relationship_nominations(30)
                       get :index, tag_set_id: owned_tag_set.id
                     end
 
                     it 'returns all ordered character and relationship nominations' do
                       expect(assigns(:nominations_count)[:character]).to eq(30)
                       expect(assigns(:nominations)[:character].count).to eq(30)
-                      expect(assigns(:nominations)[:character].first).to eq(unreviewed_character_nom)
+                      expect(assigns(:nominations)[:character].first.tagname).to eq('New Character 0')
                       expect(assigns(:nominations_count)[:relationship]).to eq(30)
                       expect(assigns(:nominations)[:relationship].count).to eq(30)
-                      expect(assigns(:nominations)[:relationship].first).to eq(unreviewed_relationship_nom)
+                      expect(assigns(:nominations)[:relationship].first.tagname).to eq('New Relationship 0')
                     end
 
                     it 'does not return a flash notice about too many nominations' do
@@ -365,9 +331,8 @@ describe TagSetNominationsController do
 
                   context 'unreviewed character or relationship nominations > 30' do
                     before do
-                      add_unreviewed_relationship_nominations(30)
-                      expect(owned_tag_set.relationship_nominations.count).to eq(31)
-
+                      add_unreviewed_character_nominations(1)
+                      add_unreviewed_relationship_nominations(31)
                       get :index, tag_set_id: owned_tag_set.id
                     end
 
@@ -384,27 +349,12 @@ describe TagSetNominationsController do
                                                        "after you approve or reject some.")
                     end
                   end
-
-                  def add_unreviewed_character_nominations(num)
-                    num.times do
-                      CharacterNomination.create(tag_set_nomination: tag_set_nomination, fandom_nomination: fandom_nom,
-                                                 tagname: "New Character #{num}", approved: false, rejected: false)
-                      num -= 1
-                    end
-                  end
-
-                  def add_unreviewed_relationship_nominations(num)
-                    num.times do
-                      RelationshipNomination.create(tag_set_nomination: tag_set_nomination, fandom_nomination: fandom_nom,
-                                                    tagname: "New Relationship #{num}", approved: false, rejected: false)
-                      num -= 1
-                    end
-                  end
                 end
 
                 context 'character_nomination_limit is 0' do
                   it 'does not return character nominations' do
-                    owned_tag_set.update_attribute(:character_nomination_limit, 0)
+                    add_unreviewed_character_nominations(1)
+                    owned_tag_set.update_column(:character_nomination_limit, 0)
                     get :index, tag_set_id: owned_tag_set.id
                     expect(assigns(:nominations)[:character]).to be_nil
                   end
@@ -412,9 +362,24 @@ describe TagSetNominationsController do
 
                 context 'relationship_nomination_limit is 0' do
                   it 'does not return relationship nominations' do
-                    owned_tag_set.update_attribute(:relationship_nomination_limit, 0)
+                    add_unreviewed_relationship_nominations(1)
+                    owned_tag_set.update_column(:relationship_nomination_limit, 0)
                     get :index, tag_set_id: owned_tag_set.id
                     expect(assigns(:nominations)[:relationship]).to be_nil
+                  end
+                end
+
+                def add_unreviewed_character_nominations(num)
+                  num.times do |i|
+                    CharacterNomination.create(tag_set_nomination: tag_set_nomination, fandom_nomination: fandom_nom,
+                                               tagname: "New Character #{i}")
+                  end
+                end
+
+                def add_unreviewed_relationship_nominations(num)
+                  num.times do |i|
+                    RelationshipNomination.create(tag_set_nomination: tag_set_nomination, fandom_nomination: fandom_nom,
+                                                  tagname: "New Relationship #{i}")
                   end
                 end
               end
@@ -437,7 +402,7 @@ describe TagSetNominationsController do
 
           it 'redirects and returns an error message' do
             get :index, tag_set_id: nil
-            it_redirects_to_with_error(tag_sets_path, "What nominations did you want to work with?")
+            it_redirects_to_with_error(tag_sets_path, 'What nominations did you want to work with?')
           end
         end
       end
@@ -448,7 +413,8 @@ describe TagSetNominationsController do
     context 'user is not logged in' do
       it 'redirects and returns an error message' do
         get :show, id: tag_set_nomination.id, tag_set_id: owned_tag_set.id
-        it_redirects_to_with_error(new_user_session_path, "Sorry, you don't have permission to access the page you were trying to reach. Please log in.")
+        it_redirects_to_with_error(new_user_session_path, "Sorry, you don't have permission to access the page you " +
+            "were trying to reach. Please log in.")
       end
     end
 
@@ -462,7 +428,7 @@ describe TagSetNominationsController do
         xcontext 'no tag set' do
           it 'redirects and returns an error message' do
             get :show, id: tag_set_nomination.id, tag_set_id: nil
-            it_redirects_to_with_error(tag_sets_path, "What tag set did you want to nominate for?")
+            it_redirects_to_with_error(tag_sets_path, 'What tag set did you want to nominate for?')
           end
         end
 
@@ -470,7 +436,7 @@ describe TagSetNominationsController do
         xcontext 'no tag set nomination' do
           it 'redirects and returns an error message' do
             get :show, id: nil, tag_set_id: owned_tag_set.id
-            it_redirects_to_with_error(user_tag_set_nominations_path(tag_nominator), "Which nominations did you want to work with?")
+            it_redirects_to_with_error(user_tag_set_nominations_path(tag_nominator), 'Which nominations did you want to work with?')
           end
         end
       end
@@ -484,29 +450,29 @@ describe TagSetNominationsController do
           it 'redirects and returns an error message' do
             get :show, id: tag_set_nomination.id, tag_set_id: owned_tag_set.id
             it_redirects_to_with_notice(tag_set_path(owned_tag_set),
-                                        "You can only see your own nominations or nominations for a set you moderate.")
+                                        'You can only see your own nominations or nominations for a set you moderate.')
           end
         end
 
         context 'user is author of nomination' do
           before do
-            fake_login_known_user(tag_nominator.reload) # Why reload?
+            fake_login_known_user(tag_nominator.reload)
           end
 
           it 'renders the show template' do
             get :show, id: tag_set_nomination.id, tag_set_id: owned_tag_set.id
-            expect(response).to render_template("show")
+            expect(response).to render_template('show')
           end
         end
 
         context 'user is moderator of tag set' do
           before do
-            fake_login_known_user(moderator.reload) # Why reload?
+            fake_login_known_user(moderator.reload)
           end
 
           it 'renders the show template' do
             get :show, id: tag_set_nomination.id, tag_set_id: owned_tag_set.id
-            expect(response).to render_template("show")
+            expect(response).to render_template('show')
           end
         end
       end
@@ -517,12 +483,24 @@ describe TagSetNominationsController do
     context 'user is not logged in' do
       it 'redirects and returns an error message' do
         get :new, tag_set_id: owned_tag_set.id
-        it_redirects_to_with_error(new_user_session_path, "Sorry, you don't have permission to access the page you were trying to reach. Please log in.")
+        it_redirects_to_with_error(new_user_session_path, "Sorry, you don't have permission to access the page you " +
+            "were trying to reach. Please log in.")
       end
     end
 
     context 'user is logged in' do
-      context 'tag set exists' do
+      context 'invalid params' do
+        # TODO: how can OwnedTagSet.find not raise an error but still return falsey?
+        xcontext 'no tag set' do
+          it 'redirects and returns an error message' do
+            fake_login_known_user(random_user)
+            get :new, tag_set_id: nil
+            it_redirects_to_with_error(tag_sets_path, 'What tag set did you want to nominate for?')
+          end
+        end
+      end
+
+      context 'valid params' do
         context 'user already has nominated tags for tag set' do
           before do
             fake_login_known_user(tag_nominator)
@@ -546,7 +524,7 @@ describe TagSetNominationsController do
 
           it 'renders the new template' do
             get :new, tag_set_id: owned_tag_set.id
-            expect(response).to render_template("new")
+            expect(response).to render_template('new')
           end
 
           it 'builds a new tag set nomination' do
@@ -557,18 +535,16 @@ describe TagSetNominationsController do
           end
 
           it 'builds new freeform nominations until freeform_nomination_limit' do
-            owned_tag_set.update_attribute(:freeform_nomination_limit, 3)
+            owned_tag_set.update_column(:freeform_nomination_limit, 3)
             get :new, tag_set_id: owned_tag_set.id
             expect(assigns(:tag_set_nomination).freeform_nominations.size).to eq(3)
           end
 
           context 'fandom_nomination_limit is > 0' do
             before do
-              owned_tag_set.fandom_nomination_limit = 2
-              owned_tag_set.character_nomination_limit = 4
-              owned_tag_set.relationship_nomination_limit = 6
-              owned_tag_set.save(validate: false)
-
+              owned_tag_set.update_column(:fandom_nomination_limit, 2)
+              owned_tag_set.update_column(:character_nomination_limit, 3)
+              owned_tag_set.update_column(:relationship_nomination_limit, 1)
               get :new, tag_set_id: owned_tag_set.id
             end
 
@@ -578,24 +554,22 @@ describe TagSetNominationsController do
 
             it 'builds new character nominations for each fandom nomination' do
               assigns(:tag_set_nomination).fandom_nominations.each do |fandom_nom|
-                expect(fandom_nom.character_nominations.size).to eq(4)
+                expect(fandom_nom.character_nominations.size).to eq(3)
               end
             end
 
             it 'builds new relationship nominations for each fandom nomination' do
               assigns(:tag_set_nomination).fandom_nominations.each do |fandom_nom|
-                expect(fandom_nom.relationship_nominations.size).to eq(6)
+                expect(fandom_nom.relationship_nominations.size).to eq(1)
               end
             end
           end
 
           context 'fandom_nomination_limit is 0' do
             before do
-              owned_tag_set.fandom_nomination_limit = 0
-              owned_tag_set.character_nomination_limit = 4
-              owned_tag_set.relationship_nomination_limit = 6
-              owned_tag_set.save(validate: false)
-
+              owned_tag_set.update_column(:fandom_nomination_limit, 0)
+              owned_tag_set.update_column(:character_nomination_limit, 2)
+              owned_tag_set.update_column(:relationship_nomination_limit, 3)
               get :new, tag_set_id: owned_tag_set.id
             end
 
@@ -604,22 +578,13 @@ describe TagSetNominationsController do
             end
 
             it 'builds new character nominations until character_nomination_limit' do
-              expect(assigns(:tag_set_nomination).character_nominations.size).to eq(4)
+              expect(assigns(:tag_set_nomination).character_nominations.size).to eq(2)
             end
 
             it 'builds new relationship nominations until relationship_nomination_limit' do
-              expect(assigns(:tag_set_nomination).relationship_nominations.size).to eq(6)
+              expect(assigns(:tag_set_nomination).relationship_nominations.size).to eq(3)
             end
           end
-        end
-      end
-
-      # TODO: how can OwnedTagSet.find not raise an error but still return falsey?
-      xcontext 'no tag set' do
-        it 'redirects and returns an error message' do
-          fake_login_known_user(random_user)
-          get :new, tag_set_id: nil
-          it_redirects_to_with_error(tag_sets_path, "What tag set did you want to nominate for?")
         end
       end
     end
@@ -629,7 +594,8 @@ describe TagSetNominationsController do
     context 'user is not logged in' do
       it 'redirects and returns an error message' do
         get :edit, id: tag_set_nomination.id, tag_set_id: owned_tag_set.id
-        it_redirects_to_with_error(new_user_session_path, "Sorry, you don't have permission to access the page you were trying to reach. Please log in.")
+        it_redirects_to_with_error(new_user_session_path, "Sorry, you don't have permission to access the page you " +
+            "were trying to reach. Please log in.")
       end
     end
 
@@ -643,7 +609,7 @@ describe TagSetNominationsController do
         xcontext 'no tag set' do
           it 'redirects and returns an error message' do
             get :edit, id: tag_set_nomination.id, tag_set_id: nil
-            it_redirects_to_with_error(tag_sets_path, "What tag set did you want to nominate for?")
+            it_redirects_to_with_error(tag_sets_path, 'What tag set did you want to nominate for?')
           end
         end
 
@@ -651,14 +617,13 @@ describe TagSetNominationsController do
         xcontext 'no tag set nomination' do
           it 'redirects and returns an error message' do
             get :edit, id: nil, tag_set_id: owned_tag_set.id
-            it_redirects_to_with_error(user_tag_set_nominations_path(tag_nominator), "Which nominations did you want to work with?")
+            it_redirects_to_with_error(user_tag_set_nominations_path(tag_nominator), 'Which nominations did you want to work with?')
           end
         end
       end
 
       context 'valid params' do
-        let!(:fandom_nom) { FandomNomination.create(tag_set_nomination: tag_set_nomination,
-                                                    tagname: "New Fandom", approved: false, rejected: false) }
+        let(:fandom_nom) { FandomNomination.create(tag_set_nomination: tag_set_nomination, tagname: 'New Fandom') }
 
         context 'user is not associated with nomination' do
           before do
@@ -668,24 +633,22 @@ describe TagSetNominationsController do
           it 'redirects and returns an error message' do
             get :edit, id: tag_set_nomination.id, tag_set_id: owned_tag_set.id
             it_redirects_to_with_notice(tag_set_path(owned_tag_set),
-                                        "You can only see your own nominations or nominations for a set you moderate.")
+                                        'You can only see your own nominations or nominations for a set you moderate.')
           end
         end
 
         context 'user is author of nomination' do
           before do
-            fake_login_known_user(tag_nominator.reload) # Why reload?
-
-            owned_tag_set.fandom_nomination_limit = 1
-            owned_tag_set.character_nomination_limit = 3
-            owned_tag_set.relationship_nomination_limit = 2
-            owned_tag_set.freeform_nomination_limit = 4
-            owned_tag_set.save(validate: false)
+            fake_login_known_user(tag_nominator.reload)
+            owned_tag_set.update_column(:fandom_nomination_limit, 1)
+            owned_tag_set.update_column(:character_nomination_limit, 3)
+            owned_tag_set.update_column(:relationship_nomination_limit, 2)
+            owned_tag_set.update_column(:freeform_nomination_limit, 4)
           end
 
           it 'renders the edit template' do
             get :edit, id: tag_set_nomination.id, tag_set_id: owned_tag_set.id
-            expect(response).to render_template("edit")
+            expect(response).to render_template('edit')
           end
 
           context 'number of tag nominations matches limits specified on tag set' do
@@ -697,17 +660,14 @@ describe TagSetNominationsController do
               get :edit, id: tag_set_nomination.id, tag_set_id: owned_tag_set.id
             end
 
-            it 'returns existing associated tag nominations' do
-              expect(assigns(:tag_set_nomination).fandom_nominations).to eq([fandom_nom])
-              expect(assigns(:tag_set_nomination).fandom_nominations[0].character_nominations.count).to eq(3)
-              expect(assigns(:tag_set_nomination).fandom_nominations[0].relationship_nominations.count).to eq(2)
-              expect(assigns(:tag_set_nomination).freeform_nominations.count).to eq(4)
-            end
-
-            it 'does not build new tag nominations' do
-              expect(assigns(:tag_set_nomination).fandom_nominations[0].character_nominations.size).to eq(3)
-              expect(assigns(:tag_set_nomination).fandom_nominations[0].relationship_nominations.size).to eq(2)
-              expect(assigns(:tag_set_nomination).freeform_nominations.size).to eq(4)
+            it 'returns only existing associated tag nominations' do
+              expect(assigns(:tag_set_nomination).fandom_nominations.map(&:tagname)).to eq(['New Fandom'])
+              expect(assigns(:tag_set_nomination).fandom_nominations[0].character_nominations.map(&:tagname)).
+                  to eq(['New Character 0', 'New Character 1', 'New Character 2'])
+              expect(assigns(:tag_set_nomination).fandom_nominations[0].relationship_nominations.map(&:tagname)).
+                  to eq(['New Relationship 0', 'New Relationship 1'])
+              expect(assigns(:tag_set_nomination).freeform_nominations.map(&:tagname)).
+                  to eq(['New Freeform 0', 'New Freeform 1', 'New Freeform 2', 'New Freeform 3'])
             end
           end
 
@@ -721,66 +681,65 @@ describe TagSetNominationsController do
             end
 
             it 'returns existing associated tag nominations' do
-              expect(assigns(:tag_set_nomination).fandom_nominations).to eq([fandom_nom])
-              expect(assigns(:tag_set_nomination).fandom_nominations[0].character_nominations.count).to eq(1)
-              expect(assigns(:tag_set_nomination).fandom_nominations[0].relationship_nominations.count).to eq(1)
-              expect(assigns(:tag_set_nomination).freeform_nominations.count).to eq(1)
+              expect(assigns(:tag_set_nomination).fandom_nominations.map(&:tagname)).to eq(['New Fandom'])
+              expect(assigns(:tag_set_nomination).fandom_nominations[0].character_nominations.map(&:tagname)).
+                  to include('New Character 0')
+              expect(assigns(:tag_set_nomination).fandom_nominations[0].relationship_nominations.map(&:tagname)).
+                  to include('New Relationship 0')
+              expect(assigns(:tag_set_nomination).freeform_nominations.map(&:tagname)).to include('New Freeform 0')
             end
 
             it 'builds new tag nominations until _nomination_limit is reached' do
+              expect(assigns(:tag_set_nomination).fandom_nominations.size).to eq(1)
               expect(assigns(:tag_set_nomination).fandom_nominations[0].character_nominations.size).to eq(3)
               expect(assigns(:tag_set_nomination).fandom_nominations[0].relationship_nominations.size).to eq(2)
               expect(assigns(:tag_set_nomination).freeform_nominations.size).to eq(4)
             end
           end
-
-          def add_character_nominations(num)
-            num.times do
-              CharacterNomination.create(tag_set_nomination: tag_set_nomination, fandom_nomination: fandom_nom,
-                                         tagname: "New Character #{num}")
-              num -= 1
-            end
-          end
-
-          def add_relationship_nominations(num)
-            num.times do
-              RelationshipNomination.create(tag_set_nomination: tag_set_nomination, fandom_nomination: fandom_nom,
-                                            tagname: "New Relationship #{num}")
-              num -= 1
-            end
-          end
-
-          def add_freeform_nominations(num)
-            num.times do
-              FreeformNomination.create(tag_set_nomination: tag_set_nomination, tagname: "New Freeform #{num}")
-              num -= 1
-            end
-          end
         end
 
         context 'user is moderator of tag set' do
-          let!(:character_nom) { CharacterNomination.create(tag_set_nomination: tag_set_nomination,
-                                                            fandom_nomination: fandom_nom, tagname: "New Character") }
-          let!(:relationship_nom) { RelationshipNomination.create(tag_set_nomination: tag_set_nomination,
-                                                                  fandom_nomination: fandom_nom,
-                                                                  tagname: "New Relationship") }
-          let!(:freeform_nom) { FreeformNomination.create(tag_set_nomination: tag_set_nomination,
-                                                          tagname: "New Freeform") }
-
           before do
-            fake_login_known_user(moderator.reload) # Why reload?
+            fake_login_known_user(moderator.reload)
+            owned_tag_set.update_column(:fandom_nomination_limit, 1)
+            add_character_nominations(1)
+            add_relationship_nominations(1)
+            add_freeform_nominations(1)
+
             get :edit, id: tag_set_nomination.id, tag_set_id: owned_tag_set.id
           end
 
           it 'renders the edit template' do
-            expect(response).to render_template("edit")
+            expect(response).to render_template('edit')
           end
 
           it 'returns associated tag nominations' do
-            expect(assigns(:tag_set_nomination).fandom_nominations).to include(fandom_nom)
-            expect(assigns(:tag_set_nomination).fandom_nominations[0].character_nominations).to include(character_nom)
-            expect(assigns(:tag_set_nomination).fandom_nominations[0].relationship_nominations).to include(relationship_nom)
-            expect(assigns(:tag_set_nomination).freeform_nominations).to include(freeform_nom)
+            expect(assigns(:tag_set_nomination).fandom_nominations.map(&:tagname)).to eq(['New Fandom'])
+            expect(assigns(:tag_set_nomination).fandom_nominations[0].character_nominations.map(&:tagname)).
+                to eq(['New Character 0'])
+            expect(assigns(:tag_set_nomination).fandom_nominations[0].relationship_nominations.map(&:tagname)).
+                to eq(['New Relationship 0'])
+            expect(assigns(:tag_set_nomination).freeform_nominations.map(&:tagname)).to eq(['New Freeform 0'])
+          end
+        end
+
+        def add_character_nominations(num)
+          num.times do |i|
+            CharacterNomination.create(tag_set_nomination: tag_set_nomination, fandom_nomination: fandom_nom,
+                                       tagname: "New Character #{i}")
+          end
+        end
+
+        def add_relationship_nominations(num)
+          num.times do |i|
+            RelationshipNomination.create(tag_set_nomination: tag_set_nomination, fandom_nomination: fandom_nom,
+                                          tagname: "New Relationship #{i}")
+          end
+        end
+
+        def add_freeform_nominations(num)
+          num.times do |i|
+            FreeformNomination.create(tag_set_nomination: tag_set_nomination, tagname: "New Freeform #{i}")
           end
         end
       end
@@ -791,7 +750,8 @@ describe TagSetNominationsController do
     context 'user is not logged in' do
       it 'redirects and returns an error message' do
         post :create, tag_set_id: owned_tag_set.id
-        it_redirects_to_with_error(new_user_session_path, "Sorry, you don't have permission to access the page you were trying to reach. Please log in.")
+        it_redirects_to_with_error(new_user_session_path, "Sorry, you don't have permission to access the page you " +
+            "were trying to reach. Please log in.")
       end
     end
 
@@ -805,7 +765,7 @@ describe TagSetNominationsController do
         xcontext 'no tag set' do
           it 'redirects and returns an error message' do
             post :create, tag_set_id: nil
-            it_redirects_to_with_error(tag_sets_path, "What tag set did you want to nominate for?")
+            it_redirects_to_with_error(tag_sets_path, 'What tag set did you want to nominate for?')
           end
         end
 
@@ -819,12 +779,12 @@ describe TagSetNominationsController do
 
       context 'valid params' do
         before do
-          fake_login_known_user(random_user.reload) # Why reload?
+          fake_login_known_user(random_user)
         end
 
         context 'tag set nomination saves successfully' do
           before do
-            owned_tag_set.update_attribute(:character_nomination_limit, 1)
+            owned_tag_set.update_column(:character_nomination_limit, 1)
             post :create,
                  tag_set_id: owned_tag_set.id,
                  tag_set_nomination: { pseud_id: random_user.default_pseud.id,
@@ -833,12 +793,10 @@ describe TagSetNominationsController do
 
           context 'all tag nominations are canonical' do
             let(:nomination_attributes) {
-              { fandom_nominations_attributes: {
-                  "0": { tagname: "New Fandom",
-                         character_nominations_attributes: {
-                             "0": { tagname: "New Character",
-                                    from_fandom_nomination: true } } } }
-              }
+              { fandom_nominations_attributes: { '0': { tagname: 'New Fandom',
+                                                        character_nominations_attributes: {
+                                                            '0': { tagname: 'New Character',
+                                                                   from_fandom_nomination: true } } } } }
             }
 
             it 'creates a new tag set nomination' do
@@ -850,16 +808,16 @@ describe TagSetNominationsController do
 
             it 'creates associated tag nominations' do
               new_fandom_nomination = FandomNomination.last
-              expect(assigns(:tag_set_nomination).fandom_nominations.count).to eq(1)
-              expect(assigns(:tag_set_nomination).fandom_nominations[0]).to eq(new_fandom_nomination)
-              expect(new_fandom_nomination.tagname).to eq("New Fandom")
-              expect(new_fandom_nomination.character_nominations.count).to eq(1)
-              expect(new_fandom_nomination.character_nominations[0].tagname).to eq("New Character")
+              new_character_nomination = CharacterNomination.last
+              expect(assigns(:tag_set_nomination).fandom_nominations).to eq([new_fandom_nomination])
+              expect(new_fandom_nomination.tagname).to eq('New Fandom')
+              expect(new_fandom_nomination.character_nominations).to eq([new_character_nomination])
+              expect(new_character_nomination.tagname).to eq('New Character')
             end
 
-            it 'returns a flash message and redirects to tag set nomination page' do
+            it 'redirects and returns a success message' do
               it_redirects_to_with_notice(tag_set_nomination_path(owned_tag_set, TagSetNomination.last),
-                                          "Your nominations were successfully submitted.")
+                                          'Your nominations were successfully submitted.')
             end
           end
 
@@ -868,73 +826,67 @@ describe TagSetNominationsController do
             # [:tag_set_nomination][:character_nominations_attributes][:from_fandom_nomination] param, but I don't
             # think the resulting params can actually be triggered by the UI
             # If so, how do I trigger the state where a new CharacterNom or RelationshipNom is created
-            # with parented: false && parent_tagname: "", without failing CastNomination#known_fandom validation?
+            # with parented: false && parent_tagname: '', without failing CastNomination#known_fandom validation?
             context 'noncanonical character nominations are created' do
               let(:nomination_attributes) {
-                { character_nominations_attributes: {
-                    "0": { tagname: "New Character",
-                           parent_tagname: "",
-                           from_fandom_nomination: true } }
-                }
+                { character_nominations_attributes: { '0': { tagname: 'New Character',
+                                                             parent_tagname: '',
+                                                             from_fandom_nomination: true } } }
               }
 
-              it 'returns a flash message about noncanonical tags' do
-                expect(flash[:notice]).to eq("Your nominations were successfully submitted." +
-                                                 " Please consider editing to add fandoms to any of your non-canonical tags!")
+              it 'returns a success message with info about noncanonical tags' do
+                expect(flash[:notice]).to eq('Your nominations were successfully submitted. Please consider editing ' +
+                                                 'to add fandoms to any of your non-canonical tags!')
               end
             end
 
             context 'noncanonical relationship nominations are created' do
               let(:nomination_attributes) {
-                { relationship_nominations_attributes: {
-                    "0": { tagname: "New Relationship",
-                           parent_tagname: "",
-                           from_fandom_nomination: true } }
-                }
+                { relationship_nominations_attributes: { '0': { tagname: 'New Relationship',
+                                                                parent_tagname: '',
+                                                                from_fandom_nomination: true } } }
               }
 
-              it 'returns a flash message about noncanonical tags' do
-                expect(flash[:notice]).to eq("Your nominations were successfully submitted." +
-                                                 " Please consider editing to add fandoms to any of your non-canonical tags!")
+              it 'returns a success message with info about noncanonical tags' do
+                expect(flash[:notice]).to eq('Your nominations were successfully submitted. Please consider editing ' +
+                                                 'to add fandoms to any of your non-canonical tags!')
               end
             end
           end
         end
 
         context 'tag set nomination save fails' do
-          let!(:old_tag_set_nom_count) { owned_tag_set.tag_set_nominations.count }
-
           before do
-            owned_tag_set.nominated = false
-            owned_tag_set.fandom_nomination_limit = 1
-            owned_tag_set.character_nomination_limit = 2
-            owned_tag_set.relationship_nomination_limit = 3
-            owned_tag_set.freeform_nomination_limit = 1
-            owned_tag_set.save(validate: false)
+            owned_tag_set.update_column(:nominated, false)
+          end
 
-            post :create,
-                 tag_set_id: owned_tag_set.id,
-                 tag_set_nomination: { pseud_id: random_user.default_pseud.id,
-                                       owned_tag_set_id: owned_tag_set.id }
+          it 'renders the new template' do
+            post :create, tag_set_id: owned_tag_set.id, tag_set_nomination: { pseud_id: random_user.default_pseud.id,
+                                                                              owned_tag_set_id: owned_tag_set.id }
+            expect(response).to render_template('new')
           end
 
           it 'builds a new tag set nomination' do
-            new_tag_set_nom_count = owned_tag_set.tag_set_nominations.count
-            expect(old_tag_set_nom_count).to eq(new_tag_set_nom_count)
+            expect { post :create, tag_set_id: owned_tag_set.id, tag_set_nomination: { pseud_id: random_user.default_pseud.id,
+                                                                                       owned_tag_set_id: owned_tag_set.id } }.
+                not_to change { owned_tag_set.tag_set_nominations.count }
             expect(assigns(:tag_set_nomination).new_record?).to be_truthy
             expect(assigns(:tag_set_nomination).pseud).to eq(random_user.default_pseud)
             expect(assigns(:tag_set_nomination).owned_tag_set).to eq(owned_tag_set)
           end
 
           it 'builds new tag nominations until limits' do
+            owned_tag_set.update_column(:fandom_nomination_limit, 1)
+            owned_tag_set.update_column(:character_nomination_limit, 2)
+            owned_tag_set.update_column(:relationship_nomination_limit, 3)
+            owned_tag_set.update_column(:freeform_nomination_limit, 1)
+            post :create, tag_set_id: owned_tag_set.id, tag_set_nomination: { pseud_id: random_user.default_pseud.id,
+                                                                              owned_tag_set_id: owned_tag_set.id }
+
             expect(assigns(:tag_set_nomination).fandom_nominations.size).to eq(1)
             expect(assigns(:tag_set_nomination).fandom_nominations[0].character_nominations.size).to eq(2)
             expect(assigns(:tag_set_nomination).fandom_nominations[0].relationship_nominations.size).to eq(3)
             expect(assigns(:tag_set_nomination).freeform_nominations.size).to eq(1)
-          end
-
-          it 'renders the new template' do
-            expect(response).to render_template("new")
           end
         end
       end
@@ -945,7 +897,8 @@ describe TagSetNominationsController do
     context 'user is not logged in' do
       it 'redirects and returns an error message' do
         put :update, tag_set_id: owned_tag_set.id, id: tag_set_nomination.id
-        it_redirects_to_with_error(new_user_session_path, "Sorry, you don't have permission to access the page you were trying to reach. Please log in.")
+        it_redirects_to_with_error(new_user_session_path, "Sorry, you don't have permission to access the page you " +
+            "were trying to reach. Please log in.")
       end
     end
 
@@ -959,7 +912,7 @@ describe TagSetNominationsController do
         xcontext 'no tag set' do
           it 'redirects and returns an error message' do
             put :update, tag_set_id: nil, id: tag_set_nomination.id, tag_set_nomination: {}
-            it_redirects_to_with_error(tag_sets_path, "What tag set did you want to nominate for?")
+            it_redirects_to_with_error(tag_sets_path, 'What tag set did you want to nominate for?')
           end
         end
 
@@ -975,12 +928,14 @@ describe TagSetNominationsController do
         xcontext 'no tag set nomination' do
           it 'redirects and returns an error message' do
             put :update, id: nil, tag_set_id: owned_tag_set.id, tag_set_nomination: {}
-            it_redirects_to_with_error(user_tag_set_nominations_path(tag_nominator), "Which nominations did you want to work with?")
+            it_redirects_to_with_error(user_tag_set_nominations_path(tag_nominator), 'Which nominations did you want to work with?')
           end
         end
       end
 
       context 'valid params' do
+        let(:fandom_nom) { FandomNomination.create(tag_set_nomination: tag_set_nomination, tagname: 'New Fandom') }
+
         context 'user is not associated with nomination' do
           before do
             fake_login_known_user(random_user)
@@ -989,44 +944,47 @@ describe TagSetNominationsController do
           it 'redirects and returns an error message' do
             put :update, id: tag_set_nomination.id, tag_set_id: owned_tag_set.id, tag_set_nomination: {}
             it_redirects_to_with_notice(tag_set_path(owned_tag_set),
-                                        "You can only see your own nominations or nominations for a set you moderate.")
+                                        'You can only see your own nominations or nominations for a set you moderate.')
           end
         end
 
         context 'user is author of nomination' do
           before do
-            fake_login_known_user(tag_nominator.reload) # Why reload?
+            fake_login_known_user(tag_nominator.reload)
           end
 
           context 'tag set nomination saves successfully' do
+            let!(:character_nom) { CharacterNomination.create(tag_set_nomination: tag_set_nomination,
+                                                              fandom_nomination: fandom_nom, tagname: 'New Character') }
+
             before do
-              owned_tag_set.update_attribute(:character_nomination_limit, 1)
+              owned_tag_set.update_column(:character_nomination_limit, 1)
               put :update,
                   tag_set_id: owned_tag_set.id,
                   id: tag_set_nomination.id,
                   tag_set_nomination: { pseud_id: tag_nominator_pseud.id,
                                         owned_tag_set_id: owned_tag_set.id }.merge(nomination_attributes)
-              tag_set_nomination.reload
             end
 
             context 'all tag nominations are canonical' do
               let(:nomination_attributes) {
-                { fandom_nominations_attributes: {
-                    "0": { tagname: "Renamed Fandom",
-                           character_nominations_attributes: {
-                               "0": { tagname: "Renamed Character",
-                                      from_fandom_nomination: true } } } }
+                { fandom_nominations_attributes: { '0': { tagname: 'Renamed Fandom',
+                                                          id: fandom_nom.id,
+                                                          character_nominations_attributes: {
+                                                              '0': { tagname: 'Renamed Character',
+                                                                     id: character_nom.id,
+                                                                     from_fandom_nomination: true } } } }
                 }
               }
 
               it 'updates the tag set nomination and associated tag nominations' do
-                expect(tag_set_nomination.fandom_nominations[0].tagname).to eq("Renamed Fandom")
-                expect(tag_set_nomination.fandom_nominations[0].character_nominations[0].tagname).to eq("Renamed Character")
+                expect(fandom_nom.reload.tagname).to eq('Renamed Fandom')
+                expect(character_nom.reload.tagname).to eq('Renamed Character')
               end
 
-              it 'returns a flash message and redirects to tag set nomination page' do
+              it 'redirects and returns a success message' do
                 it_redirects_to_with_notice(tag_set_nomination_path(owned_tag_set, tag_set_nomination),
-                                            "Your nominations were successfully updated.")
+                                            'Your nominations were successfully updated.')
               end
             end
 
@@ -1038,27 +996,27 @@ describe TagSetNominationsController do
               # with parented: false && parent_tagname: "", without failing CastNomination#known_fandom validation?
               let(:nomination_attributes) {
                 { character_nominations_attributes: {
-                    "0": { tagname: "Renamed Character",
-                           parent_tagname: "",
+                    '0': { tagname: 'Renamed Character',
+                           parent_tagname: '',
+                           id: character_nom.id,
                            from_fandom_nomination: true } }
                 }
               }
 
-              it 'returns a flash message about noncanonical tags' do
-                expect(flash[:notice]).to eq("Your nominations were successfully updated." +
-                                                 " Please consider editing to add fandoms to any of your non-canonical tags!")
+              it 'returns a success message with info about noncanonical tags' do
+                expect(flash[:notice]).to eq('Your nominations were successfully updated. Please consider editing ' +
+                                                 'to add fandoms to any of your non-canonical tags!')
               end
             end
           end
 
           context 'tag set nomination save fails' do
             before do
-              owned_tag_set.nominated = false
-              owned_tag_set.fandom_nomination_limit = 1
-              owned_tag_set.character_nomination_limit = 2
-              owned_tag_set.relationship_nomination_limit = 3
-              owned_tag_set.freeform_nomination_limit = 1
-              owned_tag_set.save(validate: false)
+              owned_tag_set.update_column(:nominated, false)
+              owned_tag_set.update_column(:fandom_nomination_limit, 1)
+              owned_tag_set.update_column(:character_nomination_limit, 2)
+              owned_tag_set.update_column(:relationship_nomination_limit, 3)
+              owned_tag_set.update_column(:freeform_nomination_limit, 1)
 
               put :update,
                   tag_set_id: owned_tag_set.id,
@@ -1075,36 +1033,40 @@ describe TagSetNominationsController do
             end
 
             it 'renders the edit template' do
-              expect(response).to render_template("edit")
+              expect(response).to render_template('edit')
             end
           end
         end
 
         context 'user is moderator of tag set' do
+          let!(:character_nom) { CharacterNomination.create(tag_set_nomination: tag_set_nomination,
+                                                            fandom_nomination: fandom_nom, tagname: 'New Character') }
+
           before do
-            fake_login_known_user(moderator.reload) # Why reload?
-            owned_tag_set.update_attribute(:character_nomination_limit, 1)
+            fake_login_known_user(moderator.reload)
+            owned_tag_set.update_column(:character_nomination_limit, 1)
             put :update,
                 tag_set_id: owned_tag_set.id,
                 id: tag_set_nomination.id,
                 tag_set_nomination: { pseud_id: mod_pseud.id,
                                       owned_tag_set_id: owned_tag_set.id,
                                       fandom_nominations_attributes: {
-                                          "0": { tagname: "Renamed Fandom",
+                                          '0': { tagname: 'Renamed Fandom',
+                                                 id: fandom_nom.id,
                                                  character_nominations_attributes: {
-                                                     "0": { tagname: "Renamed Character",
+                                                     '0': { tagname: 'Renamed Character',
+                                                            id: character_nom.id,
                                                             from_fandom_nomination: true } } } } }
-            tag_set_nomination.reload
           end
 
           it 'updates the tag set nomination and associated tag nominations' do
-            expect(tag_set_nomination.fandom_nominations[0].tagname).to eq("Renamed Fandom")
-            expect(tag_set_nomination.fandom_nominations[0].character_nominations[0].tagname).to eq("Renamed Character")
+            expect(fandom_nom.reload.tagname).to eq('Renamed Fandom')
+            expect(character_nom.reload.tagname).to eq('Renamed Character')
           end
 
-          it 'returns a flash message and redirects to tag set nomination page' do
+          it 'redirects and returns a success message' do
             it_redirects_to_with_notice(tag_set_nomination_path(owned_tag_set, tag_set_nomination),
-                                        "Your nominations were successfully updated.")
+                                        'Your nominations were successfully updated.')
           end
         end
       end
@@ -1115,7 +1077,8 @@ describe TagSetNominationsController do
     context 'user is not logged in' do
       it 'redirects and returns an error message' do
         delete :destroy, id: tag_set_nomination.id, tag_set_id: owned_tag_set.id
-        it_redirects_to_with_error(new_user_session_path, "Sorry, you don't have permission to access the page you were trying to reach. Please log in.")
+        it_redirects_to_with_error(new_user_session_path, "Sorry, you don't have permission to access the page you " +
+            "were trying to reach. Please log in.")
       end
     end
 
@@ -1129,7 +1092,7 @@ describe TagSetNominationsController do
         xcontext 'no tag set' do
           it 'redirects and returns an error message' do
             delete :destroy, id: tag_set_nomination.id, tag_set_id: nil
-            it_redirects_to_with_error(tag_sets_path, "What tag set did you want to nominate for?")
+            it_redirects_to_with_error(tag_sets_path, 'What tag set did you want to nominate for?')
           end
         end
 
@@ -1137,20 +1100,23 @@ describe TagSetNominationsController do
         xcontext 'no tag set nomination' do
           it 'redirects and returns an error message' do
             delete :destroy, id: nil, tag_set_id: owned_tag_set.id
-            it_redirects_to_with_error(user_tag_set_nominations_path(tag_nominator), "Which nominations did you want to work with?")
+            it_redirects_to_with_error(user_tag_set_nominations_path(tag_nominator), 'Which nominations did you want to work with?')
           end
         end
       end
 
       context 'valid params' do
+        before do
+          allow(TagSetNomination).to receive(:find) { tag_set_nomination }
+        end
+
         context 'user is not moderator of tag set' do
           before do
-            fake_login_known_user(tag_nominator.reload) # Why reload?
+            fake_login_known_user(tag_nominator.reload)
           end
 
-          context 'at least one tag nominations associated with tag_set_nomination is reviewed' do
+          context 'at least one tag nomination associated with tag_set_nomination is reviewed' do
             before do
-              allow(TagSetNomination).to receive(:find) { tag_set_nomination } # hmm, is this the best way?
               allow(tag_set_nomination).to receive(:unreviewed?) { false }
             end
 
@@ -1162,13 +1128,12 @@ describe TagSetNominationsController do
             it 'redirects and returns an error message' do
               delete :destroy, id: tag_set_nomination.id, tag_set_id: owned_tag_set.id
               it_redirects_to_with_error(tag_set_nomination_path(owned_tag_set, tag_set_nomination),
-                                         "You cannot delete nominations after some of them have been reviewed, sorry!")
+                                         'You cannot delete nominations after some of them have been reviewed, sorry!')
             end
           end
 
           context 'all tag nominations associated with tag_set_nomination are unreviewed' do
             before do
-              allow(TagSetNomination).to receive(:find) { tag_set_nomination } # hmm, is this the best way?
               allow(tag_set_nomination).to receive(:unreviewed?) { true }
             end
 
@@ -1179,16 +1144,15 @@ describe TagSetNominationsController do
 
             it 'redirects and returns a success message' do
               delete :destroy, id: tag_set_nomination.id, tag_set_id: owned_tag_set.id
-              it_redirects_to_with_notice(tag_set_path(owned_tag_set), "Your nominations were deleted.")
+              it_redirects_to_with_notice(tag_set_path(owned_tag_set), 'Your nominations were deleted.')
             end
           end
         end
 
         context 'user is moderator of tag set' do
           before do
-            allow(TagSetNomination).to receive(:find) { tag_set_nomination } # hmm, is this the best way?
             allow(tag_set_nomination).to receive(:unreviewed?) { false }
-            fake_login_known_user(moderator.reload) # Why reload?
+            fake_login_known_user(moderator.reload)
           end
 
           it 'deletes the tag set nomination' do
@@ -1198,7 +1162,7 @@ describe TagSetNominationsController do
 
           it 'redirects and returns a success message' do
             delete :destroy, id: tag_set_nomination.id, tag_set_id: owned_tag_set.id
-            it_redirects_to_with_notice(tag_set_path(owned_tag_set), "Your nominations were deleted.")
+            it_redirects_to_with_notice(tag_set_path(owned_tag_set), 'Your nominations were deleted.')
           end
         end
       end
@@ -1209,7 +1173,8 @@ describe TagSetNominationsController do
     context 'user is not logged in' do
       it 'redirects and returns an error message' do
         get :confirm_destroy_multiple, tag_set_id: owned_tag_set.id
-        it_redirects_to_with_error(new_user_session_path, "Sorry, you don't have permission to access the page you were trying to reach. Please log in.")
+        it_redirects_to_with_error(new_user_session_path, "Sorry, you don't have permission to access the page you " +
+            "were trying to reach. Please log in.")
       end
     end
 
@@ -1218,18 +1183,20 @@ describe TagSetNominationsController do
         fake_login_known_user(random_user)
       end
 
-      context 'tag set exists' do
-        it 'renders the confirm_destroy_multiple template' do
-          get :confirm_destroy_multiple, tag_set_id: owned_tag_set.id
-          expect(response).to render_template("confirm_destroy_multiple")
+      context 'invalid params' do
+        # TODO: how can OwnedTagSet.find not raise an error but still return falsey?
+        xcontext 'no tag set' do
+          it 'redirects and returns an error message' do
+            get :confirm_destroy_multiple, tag_set_id: nil
+            it_redirects_to_with_error(tag_sets_path, 'What tag set did you want to nominate for?')
+          end
         end
       end
 
-      # TODO: how can OwnedTagSet.find not raise an error but still return falsey?
-      xcontext 'no tag set' do
-        it 'redirects and returns an error message' do
-          get :confirm_destroy_multiple, tag_set_id: nil
-          it_redirects_to_with_error(tag_sets_path, "What tag set did you want to nominate for?")
+      context 'valid params' do
+        it 'renders the confirm_destroy_multiple template' do
+          get :confirm_destroy_multiple, tag_set_id: owned_tag_set.id
+          expect(response).to render_template('confirm_destroy_multiple')
         end
       end
     end
@@ -1244,7 +1211,8 @@ describe TagSetNominationsController do
     context 'user is not logged in' do
       it 'redirects and returns an error message' do
         delete :destroy_multiple, tag_set_id: owned_tag_set.id
-        it_redirects_to_with_error(new_user_session_path, "Sorry, you don't have permission to access the page you were trying to reach. Please log in.")
+        it_redirects_to_with_error(new_user_session_path, "Sorry, you don't have permission to access the page you " +
+            "were trying to reach. Please log in.")
       end
     end
 
@@ -1259,7 +1227,7 @@ describe TagSetNominationsController do
       end
 
       it 'redirects and returns a success message' do
-        it_redirects_to_with_notice(tag_set_path(owned_tag_set), "All nominations for this Tag Set have been cleared.")
+        it_redirects_to_with_notice(tag_set_path(owned_tag_set), 'All nominations for this Tag Set have been cleared.')
       end
     end
 
@@ -1283,28 +1251,28 @@ describe TagSetNominationsController do
     context 'user is not logged in' do
       it 'redirects and returns an error message' do
         put :update_multiple, tag_set_id: owned_tag_set.id
-        it_redirects_to_with_error(new_user_session_path, "Sorry, you don't have permission to access the page you were trying to reach. Please log in.")
+        it_redirects_to_with_error(new_user_session_path, "Sorry, you don't have permission to access the page you " +
+            "were trying to reach. Please log in.")
       end
     end
 
     context 'logged in user is moderator of tag set' do
-      let(:fandom_nom) { FandomNomination.create(tag_set_nomination: tag_set_nomination, tagname: "New Fandom") }
+      let(:fandom_nom) { FandomNomination.create(tag_set_nomination: tag_set_nomination, tagname: 'New Fandom') }
       let!(:character_nom1) { CharacterNomination.create(tag_set_nomination: tag_set_nomination,
                                                          fandom_nomination: fandom_nom,
-                                                         tagname: "New Character 1") }
+                                                         tagname: 'New Character 1') }
       let!(:character_nom2) { CharacterNomination.create(tag_set_nomination: tag_set_nomination,
                                                          fandom_nomination: fandom_nom,
-                                                         tagname: "New Character 2") }
+                                                         tagname: 'New Character 2') }
       let!(:relationship_nom) { RelationshipNomination.create(tag_set_nomination: tag_set_nomination,
                                                               fandom_nomination: fandom_nom,
-                                                              tagname: "New Relationship",
-                                                              approved: false, rejected: false) }
-      let!(:freeform_nom) { FreeformNomination.create(tag_set_nomination: tag_set_nomination, tagname: "New Freeform") }
-      let(:base_params) { { "character_change_New Character 1": "",
-                              "character_change_New Character 2": "",
-                              "relationship_change_New Relationship": "",
-                              "fandom_change_New Fandom": "",
-                              "freeform_change_New Fandom": "" } }
+                                                              tagname: 'New Relationship') }
+      let!(:freeform_nom) { FreeformNomination.create(tag_set_nomination: tag_set_nomination, tagname: 'New Freeform') }
+      let(:base_params) { { 'character_change_New Character 1': '',
+                            'character_change_New Character 2': '',
+                            'relationship_change_New Relationship': '',
+                            'fandom_change_New Fandom': '',
+                            'freeform_change_New Fandom': '' } }
 
       before do
         fake_login_known_user(moderator.reload)
@@ -1314,27 +1282,27 @@ describe TagSetNominationsController do
         it 'redirects and returns a flash message' do
           put :update_multiple, { tag_set_id: owned_tag_set.id }.merge(base_params)
           it_redirects_to(tag_set_nominations_path(owned_tag_set))
-          expect(flash[:notice]).to include("Still some nominations left to review!")
+          expect(flash[:notice]).to include('Still some nominations left to review!')
         end
       end
 
       context 'all tag nominations have an associated _approve, _reject, _change, or _synonym param value' do
         it 'redirects and returns a flash message' do
-          put :update_multiple, { tag_set_id: owned_tag_set.id }.
-              merge(base_params).merge({ "character_approve_New Character 1": 1,
-                                           "character_reject_New Character 2": 1,
-                                           "relationship_approve_New Relationship": 1,
-                                           "fandom_approve_New Fandom": 1,
-                                           "freeform_reject_New Fandom": 1 })
+          put :update_multiple, { tag_set_id: owned_tag_set.id }.merge(base_params).
+              merge({ 'character_approve_New Character 1': 1,
+                      'character_reject_New Character 2': 1,
+                      'relationship_approve_New Relationship': 1,
+                      'fandom_approve_New Fandom': 1,
+                      'freeform_reject_New Fandom': 1 })
           it_redirects_to(tag_set_nominations_path(owned_tag_set))
-          expect(flash[:notice]).to include("Still some nominations left to review!")
+          expect(flash[:notice]).to include('Still some nominations left to review!')
         end
       end
 
       context 'tag nomination _reject param has a value' do
         before do
-          put :update_multiple, { tag_set_id: owned_tag_set.id }.
-              merge(base_params).merge({ "relationship_reject_New Relationship": 1 })
+          put :update_multiple, { tag_set_id: owned_tag_set.id }.merge(base_params).
+              merge({ 'relationship_reject_New Relationship': 1 })
         end
 
         it 'updates tag_nomination.rejected to true' do
@@ -1342,16 +1310,15 @@ describe TagSetNominationsController do
         end
 
         it 'returns a success message' do
-          expect(flash[:notice]).to include("Successfully rejected: New Relationship")
+          expect(flash[:notice]).to include('Successfully rejected: New Relationship')
         end
       end
 
       context 'tag nomination _approve param has a value' do
         context 'approving the tag nomination is successful' do
           before do
-            put :update_multiple, { tag_set_id: owned_tag_set.id }.
-                merge(base_params).merge({ "fandom_approve_New Fandom": 1,
-                                             "character_approve_New Character 2": 1 })
+            put :update_multiple, { tag_set_id: owned_tag_set.id }.merge(base_params).
+                merge({ 'fandom_approve_New Fandom': 1, 'character_approve_New Character 2': 1 })
           end
 
           it 'updates tag_nomination.approved to true' do
@@ -1360,8 +1327,8 @@ describe TagSetNominationsController do
           end
 
           it 'returns a success message' do
-            expect(flash[:notice]).to include("Successfully added to set: New Fandom")
-            expect(flash[:notice]).to include("Successfully added to set: New Character 2")
+            expect(flash[:notice]).to include('Successfully added to set: New Fandom')
+            expect(flash[:notice]).to include('Successfully added to set: New Character 2')
           end
         end
 
@@ -1369,13 +1336,13 @@ describe TagSetNominationsController do
           before do
             allow(OwnedTagSet).to receive(:find).with("#{owned_tag_set.id}") { owned_tag_set }
             allow(owned_tag_set).to receive(:add_tagnames).with('fandom', ['New Fandom']) { false }
-            put :update_multiple, { tag_set_id: owned_tag_set.id }.
-                merge(base_params).merge({ "fandom_approve_New Fandom": 1,
-                                             "character_approve_New Character 2": 1 })
+            put :update_multiple, { tag_set_id: owned_tag_set.id }.merge(base_params).
+                merge({ 'fandom_approve_New Fandom': 1, 'character_approve_New Character 2': 1 })
           end
 
           it 'renders the index template and returns an error message' do
-            expect(flash[:error]).to eq("Oh no! We ran into a problem partway through saving your updates -- please check over your tag set closely!")
+            expect(flash[:error]).to eq('Oh no! We ran into a problem partway through saving your updates -- please ' +
+                                            'check over your tag set closely!')
             expect(response).to render_template('index')
           end
         end
@@ -1386,10 +1353,10 @@ describe TagSetNominationsController do
           end
 
           context 'name change is successful' do
-            it 'changes tagname of the other tags to their synonyms' do
+            it 'calls TagNomination.change_tagname! with old and new tagnames' do
               allow(TagNomination).to receive(:change_tagname!)
-              put :update_multiple, { tag_set_id: owned_tag_set.id }.
-                  merge(base_params).merge({ "character_approve_New Character 2": 1 })
+              put :update_multiple, { tag_set_id: owned_tag_set.id }.merge(base_params).
+                  merge({ 'character_approve_New Character 2': 1 })
               expect(TagNomination).to have_received(:change_tagname!).with(owned_tag_set, 'New Character 1', 'New Character 2')
             end
           end
@@ -1397,9 +1364,11 @@ describe TagSetNominationsController do
           context 'name change fails' do
             it 'renders the index template and returns an error message' do
               allow(TagNomination).to receive(:change_tagname!) { false }
-              put :update_multiple, { tag_set_id: owned_tag_set.id }.
-                  merge(base_params).merge({ "character_approve_New Character 2": 1 })
-              expect(flash[:error]).to eq("Oh no! We ran into a problem partway through saving your updates, changing New Character 1 to New Character 2 -- please check over your tag set closely!")
+              put :update_multiple, { tag_set_id: owned_tag_set.id }.merge(base_params).
+                  merge({ 'character_approve_New Character 2': 1 })
+              expect(flash[:error]).to eq('Oh no! We ran into a problem partway through saving your updates, ' +
+                                              'changing New Character 1 to New Character 2 -- please check over ' +
+                                              'your tag set closely!')
               expect(response).to render_template('index')
             end
           end
@@ -1408,9 +1377,8 @@ describe TagSetNominationsController do
 
       context 'tag nomination _approve and _reject params have a value' do
         before do
-          put :update_multiple, { tag_set_id: owned_tag_set.id }.
-              merge(base_params).merge({ "relationship_approve_New Relationship": 1,
-                                           "relationship_reject_New Relationship": 2 })
+          put :update_multiple, { tag_set_id: owned_tag_set.id }.merge(base_params).
+              merge({ 'relationship_approve_New Relationship': 1, 'relationship_reject_New Relationship': 2 })
         end
 
         it 'renders the index template' do
@@ -1418,15 +1386,16 @@ describe TagSetNominationsController do
         end
 
         it 'returns expected errors' do
-          expect(assigns(:errors)).to include("You have both approved and rejected the following relationship tags: " + "New Relationship")
+          expect(assigns(:errors)).to include('You have both approved and rejected the following relationship tags: ' +
+                                                  'New Relationship')
         end
       end
 
       context 'tag nomination _change param is not empty' do
         context '_change param = current tag nomination tagname' do
           it 'does not update the tag nomination' do
-            put :update_multiple, { tag_set_id: owned_tag_set.id }.
-                merge(base_params).merge({ "freeform_change_New Freeform": 'New Freeform' })
+            put :update_multiple, { tag_set_id: owned_tag_set.id }.merge(base_params).
+                merge({ 'freeform_change_New Freeform': 'New Freeform' })
             expect(freeform_nom.reload.approved).to be_falsey
           end
         end
@@ -1435,7 +1404,7 @@ describe TagSetNominationsController do
           context 'new name is invalid' do
             before do
               put :update_multiple, { tag_set_id: owned_tag_set.id }.
-                  merge(base_params).merge({ "freeform_change_New Freeform": "N*w Fr**f*rm" })
+                  merge(base_params).merge({ 'freeform_change_New Freeform': 'N*w Fr**f*rm' })
             end
 
             it 'renders the index template' do
@@ -1443,14 +1412,14 @@ describe TagSetNominationsController do
             end
 
             it 'returns expected errors' do
-              expect(assigns(:errors).first).to start_with("Invalid name change for New Freeform to N*w Fr**f*rm: ")
+              expect(assigns(:errors).first).to start_with('Invalid name change for New Freeform to N*w Fr**f*rm: ')
             end
           end
 
           context 'no tag nomination associated with name' do
             before do
-              put :update_multiple, { tag_set_id: owned_tag_set.id }.
-                  merge(base_params).merge({ "freeform_change_A Freeform Masquerade": "Different Freeform" })
+              put :update_multiple, { tag_set_id: owned_tag_set.id }.merge(base_params).
+                  merge({ 'freeform_change_A Freeform Masquerade': 'Different Freeform' })
             end
 
             it 'renders the index template' do
@@ -1466,12 +1435,13 @@ describe TagSetNominationsController do
             context 'name change is successful' do
               before do
                 allow(TagNomination).to receive(:change_tagname!).and_call_original
-                put :update_multiple, { tag_set_id: owned_tag_set.id }.
-                    merge(base_params).merge({ "freeform_change_New Freeform": 'Different Freeform' })
+                put :update_multiple, { tag_set_id: owned_tag_set.id }.merge(base_params).
+                    merge({ 'freeform_change_New Freeform': 'Different Freeform' })
               end
 
-              it 'calls TagNomination#change_tagname! with _change param value' do
-                expect(TagNomination).to have_received(:change_tagname!).with(owned_tag_set, 'New Freeform', 'Different Freeform')
+              it 'calls TagNomination.change_tagname! with _change param value' do
+                expect(TagNomination).to have_received(:change_tagname!).with(owned_tag_set, 'New Freeform',
+                                                                              'Different Freeform')
               end
 
               it 'updates tag_nomination.approved to true' do
@@ -1479,17 +1449,25 @@ describe TagSetNominationsController do
               end
 
               it 'returns a success message' do
-                expect(flash[:notice]).to include("Successfully added to set: Different Freeform")
+                expect(flash[:notice]).to include('Successfully added to set: Different Freeform')
               end
             end
 
             context 'name change is not successful' do
-              it 'renders the index template and returns an error message' do
+              before do
                 allow(TagNomination).to receive(:change_tagname!) { false }
-                put :update_multiple, { tag_set_id: owned_tag_set.id }.
-                    merge(base_params).merge({ "freeform_change_New Freeform": 'Different Freeform' })
-                expect(flash[:error]).to eq("Oh no! We ran into a problem partway through saving your updates, changing New Freeform to Different Freeform -- please check over your tag set closely!")
+                put :update_multiple, { tag_set_id: owned_tag_set.id }.merge(base_params).
+                    merge({ 'freeform_change_New Freeform': 'Different Freeform' })
+              end
+
+              it 'renders the index template' do
                 expect(response).to render_template('index')
+              end
+
+              it 'returns an error message' do
+                expect(flash[:error]).to eq('Oh no! We ran into a problem partway through saving your updates, ' +
+                                                'changing New Freeform to Different Freeform -- please check over ' +
+                                                'your tag set closely!')
               end
             end
           end
@@ -1500,7 +1478,7 @@ describe TagSetNominationsController do
         context '_synonym param = current tag nomination tagname' do
           it 'does not update the tag nomination' do
             put :update_multiple, { tag_set_id: owned_tag_set.id }.
-                merge(base_params).merge({ "freeform_synonym_New Freeform": 'New Freeform' })
+                merge(base_params).merge({ 'freeform_synonym_New Freeform': 'New Freeform' })
             expect(freeform_nom.reload.approved).to be_falsey
           end
         end
@@ -1508,8 +1486,8 @@ describe TagSetNominationsController do
         context '_synonym param is different from current tag nomination tagname' do
           context 'new name is invalid' do
             before do
-              put :update_multiple, { tag_set_id: owned_tag_set.id }.
-                  merge(base_params).merge({ "freeform_synonym_New Freeform": "N*w Fr**f*rm" })
+              put :update_multiple, { tag_set_id: owned_tag_set.id }.merge(base_params).
+                  merge({ 'freeform_synonym_New Freeform': 'N*w Fr**f*rm' })
             end
 
             it 'renders the index template' do
@@ -1517,14 +1495,14 @@ describe TagSetNominationsController do
             end
 
             it 'returns expected errors' do
-              expect(assigns(:errors).first).to start_with("Invalid name change for New Freeform to N*w Fr**f*rm: ")
+              expect(assigns(:errors).first).to start_with('Invalid name change for New Freeform to N*w Fr**f*rm: ')
             end
           end
 
           context 'no tag nomination associated with name' do
             before do
-              put :update_multiple, { tag_set_id: owned_tag_set.id }.
-                  merge(base_params).merge({ "freeform_synonym_A Freeform Masquerade": "Different Freeform" })
+              put :update_multiple, { tag_set_id: owned_tag_set.id }.merge(base_params).
+                  merge({ 'freeform_synonym_A Freeform Masquerade': 'Different Freeform' })
             end
 
             it 'renders the index template' do
@@ -1539,8 +1517,8 @@ describe TagSetNominationsController do
           context 'new name is valid' do
             before do
               freeform_nom.update_column(:synonym, 'Different Freeform')
-              put :update_multiple, { tag_set_id: owned_tag_set.id }.
-                  merge(base_params).merge({ "freeform_synonym_New Freeform": 'Different Freeform' })
+              put :update_multiple, { tag_set_id: owned_tag_set.id }.merge(base_params).
+                  merge({ 'freeform_synonym_New Freeform': 'Different Freeform' })
             end
 
             it 'updates tag_nomination.approved to true' do
@@ -1548,7 +1526,7 @@ describe TagSetNominationsController do
             end
 
             it 'returns a success message' do
-              expect(flash[:notice]).to include("Successfully added to set: Different Freeform")
+              expect(flash[:notice]).to include('Successfully added to set: Different Freeform')
             end
           end
         end

--- a/spec/controllers/tag_set_nominations_controller_spec.rb
+++ b/spec/controllers/tag_set_nominations_controller_spec.rb
@@ -1,0 +1,48 @@
+require 'spec_helper'
+
+describe TagSetNominationsController do
+  describe 'GET index' do
+
+  end
+
+  describe 'GET show' do
+
+  end
+
+  describe 'POST create' do
+
+  end
+
+  describe 'PUT update' do
+
+  end
+
+  describe 'DELETE destroy' do
+
+  end
+
+  describe 'PUT edit' do
+
+  end
+
+  describe 'GET confirm_destroy_multiple' do
+
+  end
+
+  describe 'DELETE destroy_multiple' do
+
+  end
+
+  describe 'PUT update_multiple' do
+
+  end
+
+  describe 'check_pseud_ownership'
+  describe 'load_tag_set'
+  describe 'load_nomination'
+  describe 'set_limit'
+  describe 'build_nominations'
+  describe 'request_noncanonical_info'
+  describe 'base_nom_query'
+  describe 'setup_for_review'
+end

--- a/spec/controllers/tag_set_nominations_controller_spec.rb
+++ b/spec/controllers/tag_set_nominations_controller_spec.rb
@@ -4,17 +4,445 @@ describe TagSetNominationsController do
   include LoginMacros
   include RedirectExpectationHelper
 
-  let(:tag_setter) { FactoryGirl.create(:user) }
-  let(:tag_setter_pseud) { FactoryGirl.create(:pseud, user_id: tag_setter.id) }
+  let(:tag_set_nomination) { FactoryGirl.create(:tag_set_nomination) }
+  let(:owned_tag_set) { tag_set_nomination.owned_tag_set }
+
+  let(:tag_nominator) { tag_nominator_pseud.user }
+  let(:tag_nominator_pseud) { tag_set_nomination.pseud }
+  let(:moderator) { mod_pseud.user }
+  let(:mod_pseud) { FactoryGirl.create(:pseud) }
 
   describe 'GET index' do
+    before do
+      owned_tag_set.add_moderator(mod_pseud)
+      owned_tag_set.save!
+      moderator.reload
+    end
 
+    context 'user is not logged in' do
+      it 'redirects and shows an error message' do
+        get :index, user_id: moderator.login, tag_set_id: owned_tag_set.id
+        it_redirects_to_with_error(new_user_session_path, "Sorry, you don't have permission to access the page you were trying to reach. Please log in.")
+      end
+    end
+
+    context 'user is logged in' do
+      before do
+        fake_login_known_user(user)
+      end
+
+      context 'user_id param is truthy' do
+        let(:user) { tag_nominator }
+
+        context 'user_id does not match logged in user' do
+          it 'redirects and shows an error message' do
+            get :index, user_id: "invalid", tag_set_id: owned_tag_set.id
+            it_redirects_to_with_error(tag_sets_path, "You can only view your own nominations, sorry.")
+          end
+        end
+
+        context 'user_id matches logged in user' do
+          before do
+            get :index, user_id: tag_nominator.login, tag_set_id: owned_tag_set.id
+          end
+
+          it 'renders the index template' do
+            expect(response).to render_template("index")
+          end
+
+          it 'returns expected tag set nominations' do
+            expect(assigns(:tag_set_nominations)).to include(tag_set_nomination)
+          end
+        end
+      end
+
+      context 'user_id param is falsey' do
+        context 'tag set is found' do
+          context 'logged in user is moderator' do
+            let(:user) { moderator }
+
+            it 'renders the index template' do
+              get :index, tag_set_id: owned_tag_set.id
+              expect(response).to render_template("index")
+            end
+
+            context 'no unreviewed tag_nominations' do
+              it 'returns a flash notice about no unreviewed nominations' do
+                get :index, tag_set_id: owned_tag_set.id
+                expect(flash[:notice]).to eq("No nominations to review!")
+              end
+            end
+
+            context 'unreviewed tag_nominations exist' do
+              let(:fandom_nom) { FandomNomination.create(tag_set_nomination: tag_set_nomination,
+                                                         tagname: "New Fandom", approved: false, rejected: false) }
+              let!(:unreviewed_character_nom) { CharacterNomination.create(tag_set_nomination: tag_set_nomination,
+                                                                           fandom_nomination: fandom_nom,
+                                                                           tagname: "New Character",
+                                                                           approved: false, rejected: false) }
+              let!(:unreviewed_relationship_nom) { RelationshipNomination.create(tag_set_nomination: tag_set_nomination,
+                                                                                 fandom_nomination: fandom_nom,
+                                                                                 tagname: "New Relationship",
+                                                                                 approved: false, rejected: false) }
+
+              it 'does not return a flash notice about no unreviewed nominations' do
+                get :index, tag_set_id: owned_tag_set.id
+                expect(flash[:notice]).not_to eq("No nominations to review!")
+              end
+
+              context 'tag set freeform_nomination_limit is > 0' do
+                before do
+                  owned_tag_set.update_attribute(:freeform_nomination_limit, 2)
+                end
+
+                context 'unreviewed freeform_nominations' do
+                  context 'unreviewed freeform nominations <= 30' do
+                    before do
+                      add_unreviewed_freeform_nominations(30)
+                      expect(owned_tag_set.freeform_nominations.count).to eq(30)
+
+                      get :index, tag_set_id: owned_tag_set.id
+                    end
+
+                    it 'returns all ordered freeform nominations' do
+                      expect(assigns(:nominations_count)[:freeform]).to eq(30)
+                      expect(assigns(:nominations)[:freeform].count).to eq(30)
+                      expect(assigns(:nominations)[:freeform].first.tagname).to eq("New Freeform 1")
+                    end
+
+                    it 'does not return a flash notice about too many nominations' do
+                      expect(flash[:notice]).not_to eq("There are too many nominations to show at once, so here's a " +
+                                                           "randomized selection! Additional nominations will appear " +
+                                                           "after you approve or reject some.")
+                    end
+                  end
+
+                  context 'unreviewed freeform nominations > 30' do
+                    before do
+                      add_unreviewed_freeform_nominations(31)
+                      expect(owned_tag_set.freeform_nominations.count).to eq(31)
+
+                      get :index, tag_set_id: owned_tag_set.id
+                    end
+
+                    it 'returns 30 freeform nominations' do
+                      expect(assigns(:nominations_count)[:freeform]).to eq(31)
+                      expect(assigns(:nominations)[:freeform].count).to eq(30)
+                    end
+
+                    it 'returns a flash notice about too many nominations' do
+                      expect(flash[:notice]).to eq("There are too many nominations to show at once, so here's a " +
+                                                       "randomized selection! Additional nominations will appear " +
+                                                       "after you approve or reject some.")
+                    end
+                  end
+
+                  def add_unreviewed_freeform_nominations(num)
+                    num.times do
+                      FreeformNomination.create(tag_set_nomination: tag_set_nomination, tagname: "New Freeform #{num}",
+                                                approved: false, rejected: false)
+                      num -= 1
+                    end
+                  end
+                end
+
+                context 'reviewed freeform_nominations' do
+                  it 'does not return freeform nominations' do
+                    freeform_nom = FreeformNomination.create(tag_set_nomination: tag_set_nomination,
+                                                             tagname: "New Freeform")
+                    owned_tag_set.tag_set.from_owned_tag_set = true
+                    owned_tag_set.add_tagnames("freeform", [freeform_nom.tagname])
+                    get :index, tag_set_id: owned_tag_set.id
+
+                    expect(assigns(:nominations_count)[:freeform]).to eq(0)
+                    expect(assigns(:nominations)[:freeform]).not_to include(freeform_nom)
+                  end
+                end
+              end
+
+              context 'tag set freeform_nomination_limit is 0' do
+                it 'does not return freeform nominations' do
+                  owned_tag_set.update_attribute(:freeform_nomination_limit, 0)
+                  FreeformNomination.create(tag_set_nomination: tag_set_nomination, tagname: "New Freeform",
+                                            approved: false, rejected: false)
+                  get :index, tag_set_id: owned_tag_set.id
+                  expect(assigns(:nominations)[:freeform]).to be_nil
+                end
+              end
+
+              context 'tag set fandom_nomination_limit is > 0' do
+                before do
+                  owned_tag_set.fandom_nomination_limit = 2
+                  owned_tag_set.character_nomination_limit = 2
+                  owned_tag_set.relationship_nomination_limit = 2
+                  owned_tag_set.save(validate: false)
+                end
+
+                context 'unreviewed fandom nominations' do
+                  context 'unreviewed fandom nominations <= 30' do
+                    before do
+                      add_unreviewed_fandom_nominations(29)
+                      expect(owned_tag_set.fandom_nominations.count).to eq(30)
+
+                      get :index, tag_set_id: owned_tag_set.id
+                    end
+
+                    it 'returns all ordered fandom nominations' do
+                      expect(assigns(:nominations_count)[:fandom]).to eq(30)
+                      expect(assigns(:nominations)[:fandom].count).to eq(30)
+                      expect(assigns(:nominations)[:fandom].first).to eq(fandom_nom)
+                    end
+
+                    it 'does not return associated character and relationship nominations' do
+                      expect(assigns(:nominations)[:cast]).not_to include(unreviewed_character_nom)
+                      expect(assigns(:nominations)[:cast]).not_to include(unreviewed_relationship_nom)
+                    end
+
+                    it 'does not return a flash notice about too many nominations' do
+                      expect(flash[:notice]).not_to eq("There are too many nominations to show at once, so here's a " +
+                                                           "randomized selection! Additional nominations will appear " +
+                                                           "after you approve or reject some.")
+                    end
+                  end
+
+                  context 'unreviewed fandom nominations > 30' do
+                    before do
+                      add_unreviewed_fandom_nominations(30)
+                      expect(owned_tag_set.fandom_nominations.count).to eq(31)
+
+                      get :index, tag_set_id: owned_tag_set.id
+                    end
+
+                    it 'returns 30 fandom nominations' do
+                      expect(assigns(:nominations_count)[:fandom]).to eq(31)
+                      expect(assigns(:nominations)[:fandom].count).to eq(30)
+                    end
+
+                    it 'returns a flash notice about too many nominations' do
+                      expect(flash[:notice]).to eq("There are too many nominations to show at once, so here's a " +
+                                                       "randomized selection! Additional nominations will appear " +
+                                                       "after you approve or reject some.")
+                    end
+                  end
+
+                  def add_unreviewed_fandom_nominations(num)
+                    num.times do
+                      FandomNomination.create(tag_set_nomination: tag_set_nomination, tagname: "New Fandom #{num}",
+                                              approved: false, rejected: false)
+                      num -= 1
+                    end
+                  end
+                end
+
+                context 'rejected fandom nominations' do
+                  before do
+                    owned_tag_set.remove_tagnames("fandom", [fandom_nom.tagname])
+                    get :index, tag_set_id: owned_tag_set.id
+                  end
+
+                  it 'does not return fandom nominations' do
+                    expect(assigns(:nominations)[:fandom]).not_to include(fandom_nom)
+                  end
+
+                  it 'does not return associated character and relationship nominations' do
+                    expect(assigns(:nominations)[:cast]).not_to include(unreviewed_character_nom)
+                    expect(assigns(:nominations)[:cast]).not_to include(unreviewed_relationship_nom)
+                  end
+                end
+
+                context 'approved fandom nominations' do
+                  let(:reviewed_character_nom) { CharacterNomination.create(tag_set_nomination: tag_set_nomination,
+                                                                            fandom_nomination: fandom_nom,
+                                                                            tagname: "Character To Be Approved") }
+                  let(:reviewed_relationship_nom) { RelationshipNomination.create(tag_set_nomination: tag_set_nomination,
+                                                                                  fandom_nomination: fandom_nom,
+                                                                                  tagname: "Relationship To Be Approved") }
+
+                  before do
+                    owned_tag_set.tag_set.from_owned_tag_set = true
+                    owned_tag_set.add_tagnames("fandom", [fandom_nom.tagname])
+                    owned_tag_set.add_tagnames("character", [reviewed_character_nom.tagname])
+                    owned_tag_set.add_tagnames("relationship", [reviewed_relationship_nom.tagname])
+                  end
+
+                  it 'does not return fandom nominations' do
+                    get :index, tag_set_id: owned_tag_set.id
+                    expect(assigns(:nominations)[:fandom]).not_to include(fandom_nom)
+                  end
+
+                  it 'does not return associated reviewed character and relationship nominations' do
+                    get :index, tag_set_id: owned_tag_set.id
+                    expect(assigns(:nominations)[:cast]).not_to include(reviewed_character_nom)
+                    expect(assigns(:nominations)[:cast]).not_to include(reviewed_relationship_nom)
+                  end
+
+                  context 'character_ and relationship_nomination_limit are > 0' do
+                    before do
+                      expect(owned_tag_set.character_nomination_limit).to be > 0
+                      expect(owned_tag_set.relationship_nomination_limit).to be > 0
+
+                      get :index, tag_set_id: owned_tag_set.id
+                    end
+
+                    it 'returns associated unreviewed character and relationship nominations' do
+                      expect(assigns(:nominations)[:cast]).to eq([unreviewed_character_nom, unreviewed_relationship_nom])
+                    end
+                  end
+
+                  context 'character_nomination_limit is 0, relationship_nomination_limit is > 0' do
+                    before do
+                      owned_tag_set.update_attribute(:character_nomination_limit, 0)
+                      expect(owned_tag_set.relationship_nomination_limit).to be > 0
+
+                      get :index, tag_set_id: owned_tag_set.id
+                    end
+
+                    it 'returns associated unreviewed character and relationship nominations' do
+                      expect(assigns(:nominations)[:cast]).to eq([unreviewed_character_nom, unreviewed_relationship_nom])
+                    end
+                  end
+
+                  context 'character_ and relationship_nomination_limit are 0' do
+                    before do
+                      owned_tag_set.update_attribute(:character_nomination_limit, 0)
+                      owned_tag_set.update_attribute(:relationship_nomination_limit, 0)
+
+                      get :index, tag_set_id: owned_tag_set.id
+                    end
+
+                    it 'does not return associated character and relationship nominations' do
+                      expect(assigns(:nominations)[:cast]).to be_nil
+                    end
+                  end
+                end
+              end
+
+              context 'tag set fandom_nomination_limit is 0' do
+                before do
+                  owned_tag_set.update_attribute(:fandom_nomination_limit, 0)
+                end
+
+                it 'renders the index template' do
+                  get :index, tag_set_id: owned_tag_set.id
+                  expect(response).to render_template("index")
+                end
+
+                context 'character_ and relationship_nomination_limit are > 0' do
+                  before do
+                    owned_tag_set.character_nomination_limit = 2
+                    owned_tag_set.relationship_nomination_limit = 2
+                    owned_tag_set.save(validate: false)
+                  end
+
+                  context 'unreviewed character and relationship nominations <= 30' do
+                    before do
+                      add_unreviewed_character_nominations(29)
+                      expect(owned_tag_set.character_nominations.count).to eq(30)
+                      add_unreviewed_relationship_nominations(29)
+                      expect(owned_tag_set.relationship_nominations.count).to eq(30)
+
+                      get :index, tag_set_id: owned_tag_set.id
+                    end
+
+                    it 'returns all ordered character and relationship nominations' do
+                      expect(assigns(:nominations_count)[:character]).to eq(30)
+                      expect(assigns(:nominations)[:character].count).to eq(30)
+                      expect(assigns(:nominations)[:character].first).to eq(unreviewed_character_nom)
+                      expect(assigns(:nominations_count)[:relationship]).to eq(30)
+                      expect(assigns(:nominations)[:relationship].count).to eq(30)
+                      expect(assigns(:nominations)[:relationship].first).to eq(unreviewed_relationship_nom)
+                    end
+
+                    it 'does not return a flash notice about too many nominations' do
+                      expect(flash[:notice]).not_to eq("There are too many nominations to show at once, so here's a " +
+                                                           "randomized selection! Additional nominations will appear " +
+                                                           "after you approve or reject some.")
+                    end
+                  end
+
+                  context 'unreviewed character or relationship nominations > 30' do
+                    before do
+                      add_unreviewed_relationship_nominations(30)
+                      expect(owned_tag_set.relationship_nominations.count).to eq(31)
+
+                      get :index, tag_set_id: owned_tag_set.id
+                    end
+
+                    it 'returns 30 character and relationship nominations' do
+                      expect(assigns(:nominations_count)[:character]).to eq(1)
+                      expect(assigns(:nominations)[:character].count).to eq(1)
+                      expect(assigns(:nominations_count)[:relationship]).to eq(31)
+                      expect(assigns(:nominations)[:relationship].count).to eq(30)
+                    end
+
+                    it 'returns a flash notice about too many nominations' do
+                      expect(flash[:notice]).to eq("There are too many nominations to show at once, so here's a " +
+                                                       "randomized selection! Additional nominations will appear " +
+                                                       "after you approve or reject some.")
+                    end
+                  end
+
+                  def add_unreviewed_character_nominations(num)
+                    num.times do
+                      CharacterNomination.create(tag_set_nomination: tag_set_nomination, fandom_nomination: fandom_nom,
+                                                 tagname: "New Character #{num}", approved: false, rejected: false)
+                      num -= 1
+                    end
+                  end
+
+                  def add_unreviewed_relationship_nominations(num)
+                    num.times do
+                      RelationshipNomination.create(tag_set_nomination: tag_set_nomination, fandom_nomination: fandom_nom,
+                                                    tagname: "New Relationship #{num}", approved: false, rejected: false)
+                      num -= 1
+                    end
+                  end
+                end
+
+                context 'character_nomination_limit is 0' do
+                  it 'does not return character nominations' do
+                    owned_tag_set.update_attribute(:character_nomination_limit, 0)
+                    get :index, tag_set_id: owned_tag_set.id
+                    expect(assigns(:nominations)[:character]).to be_nil
+                  end
+                end
+
+                context 'relationship_nomination_limit is 0' do
+                  it 'does not return relationship nominations' do
+                    owned_tag_set.update_attribute(:relationship_nomination_limit, 0)
+                    get :index, tag_set_id: owned_tag_set.id
+                    expect(assigns(:nominations)[:relationship]).to be_nil
+                  end
+                end
+              end
+            end
+          end
+
+          context 'logged in user is not moderator' do
+            let(:user) { FactoryGirl.create(:user) }
+
+            it 'redirects and shows an error message' do
+              get :index, tag_set_id: owned_tag_set.id
+              it_redirects_to_with_error(tag_sets_path, "You can't see those nominations, sorry.")
+            end
+          end
+        end
+
+        # is testing this even possible?
+        # how can OwnedTagSet.find not raise an error but still return falsey?
+        xcontext 'tag set is not found' do
+          let(:user) { FactoryGirl.create(:user) }
+
+          it 'redirects and shows an error message' do
+            get :index, tag_set_id: nil
+            it_redirects_to_with_error(tag_sets_path, "What nominations did you want to work with?")
+          end
+        end
+      end
+    end
   end
 
   describe 'GET show' do
-    let!(:tag_set_nomination) { FactoryGirl.create(:tag_set_nomination, pseud_id: tag_setter_pseud.id) }
-    let(:owned_tag_set) { tag_set_nomination.owned_tag_set}
-
     context 'user is not logged in' do
       it 'redirects and shows an error message' do
         get :show, id: tag_set_nomination.id, tag_set_id: owned_tag_set.id
@@ -25,7 +453,7 @@ describe TagSetNominationsController do
     context 'user is logged in' do
       context 'invalid params' do
         before do
-          fake_login_known_user(tag_setter)
+          fake_login_known_user(tag_nominator)
         end
 
         # is testing this even possible?
@@ -42,23 +470,20 @@ describe TagSetNominationsController do
         xcontext 'no tag set nomination' do
           it 'redirects and shows an error message' do
             get :show, id: nil, tag_set_id: owned_tag_set.id
-            it_redirects_to_with_error(user_tag_set_nominations_path(tag_setter), "Which nominations did you want to work with?")
+            it_redirects_to_with_error(user_tag_set_nominations_path(tag_nominator), "Which nominations did you want to work with?")
           end
         end
       end
 
       context 'valid params' do
         context 'logged in user is not author of nomination' do
-          let(:moderator) { FactoryGirl.create(:user) }
-          let(:mod_pseud) { FactoryGirl.create(:pseud, user_id: moderator.id) }
-
           before do
             owned_tag_set.add_moderator(mod_pseud)
             owned_tag_set.save!
             moderator.reload
           end
 
-          context 'user is not moderator of tag set' do
+          context 'user is also not moderator of tag set' do
             before do
               random_user = FactoryGirl.create(:user)
               fake_login_known_user(random_user)
@@ -67,7 +492,7 @@ describe TagSetNominationsController do
             it 'redirects and shows an error message' do
               get :show, id: tag_set_nomination.id, tag_set_id: owned_tag_set.id
               it_redirects_to_with_notice(tag_set_path(owned_tag_set),
-                                         "You can only see your own nominations or nominations for a set you moderate.")
+                                          "You can only see your own nominations or nominations for a set you moderate.")
             end
           end
 
@@ -85,12 +510,12 @@ describe TagSetNominationsController do
 
         context 'logged in user is author of nomination' do
           before do
-            fake_login_known_user(tag_setter)
+            fake_login_known_user(tag_nominator)
           end
 
           context 'user is not moderator of tag set' do
             it 'renders the show template' do
-              tag_setter.reload # Whywhywhywhy
+              tag_nominator.reload # Whywhywhywhy
 
               get :show, id: tag_set_nomination.id, tag_set_id: owned_tag_set.id
               expect(response).to render_template("show")
@@ -99,9 +524,9 @@ describe TagSetNominationsController do
 
           context 'user is also moderator of tag set' do
             before do
-              owned_tag_set.add_moderator(tag_setter_pseud)
+              owned_tag_set.add_moderator(tag_nominator_pseud)
               owned_tag_set.save!
-              tag_setter.reload
+              tag_nominator.reload
             end
 
             it 'renders the show template' do
@@ -112,6 +537,14 @@ describe TagSetNominationsController do
         end
       end
     end
+  end
+
+  describe 'GET new' do
+
+  end
+
+  describe 'GET edit' do
+
   end
 
   describe 'POST create' do
@@ -126,10 +559,6 @@ describe TagSetNominationsController do
 
   end
 
-  describe 'PUT edit' do
-
-  end
-
   describe 'GET confirm_destroy_multiple' do
 
   end
@@ -141,13 +570,4 @@ describe TagSetNominationsController do
   describe 'PUT update_multiple' do
 
   end
-
-  describe 'check_pseud_ownership'
-  describe 'load_tag_set'
-  describe 'load_nomination'
-  describe 'set_limit'
-  describe 'build_nominations'
-  describe 'request_noncanonical_info'
-  describe 'base_nom_query'
-  describe 'setup_for_review'
 end

--- a/spec/controllers/tag_set_nominations_controller_spec.rb
+++ b/spec/controllers/tag_set_nominations_controller_spec.rb
@@ -21,7 +21,7 @@ describe TagSetNominationsController do
 
   describe 'GET index' do
     context 'user is not logged in' do
-      it 'redirects and shows an error message' do
+      it 'redirects and returns an error message' do
         get :index, user_id: moderator.login, tag_set_id: owned_tag_set.id
         it_redirects_to_with_error(new_user_session_path, "Sorry, you don't have permission to access the page you were trying to reach. Please log in.")
       end
@@ -36,7 +36,7 @@ describe TagSetNominationsController do
         let(:user) { tag_nominator }
 
         context 'user_id does not match logged in user' do
-          it 'redirects and shows an error message' do
+          it 'redirects and returns an error message' do
             get :index, user_id: "invalid", tag_set_id: owned_tag_set.id
             it_redirects_to_with_error(tag_sets_path, "You can only view your own nominations, sorry.")
           end
@@ -422,7 +422,7 @@ describe TagSetNominationsController do
           context 'logged in user is not moderator' do
             let(:user) { random_user }
 
-            it 'redirects and shows an error message' do
+            it 'redirects and returns an error message' do
               get :index, tag_set_id: owned_tag_set.id
               it_redirects_to_with_error(tag_sets_path, "You can't see those nominations, sorry.")
             end
@@ -433,7 +433,7 @@ describe TagSetNominationsController do
         xcontext 'no tag set' do
           let(:user) { random_user }
 
-          it 'redirects and shows an error message' do
+          it 'redirects and returns an error message' do
             get :index, tag_set_id: nil
             it_redirects_to_with_error(tag_sets_path, "What nominations did you want to work with?")
           end
@@ -444,7 +444,7 @@ describe TagSetNominationsController do
 
   describe 'GET show' do
     context 'user is not logged in' do
-      it 'redirects and shows an error message' do
+      it 'redirects and returns an error message' do
         get :show, id: tag_set_nomination.id, tag_set_id: owned_tag_set.id
         it_redirects_to_with_error(new_user_session_path, "Sorry, you don't have permission to access the page you were trying to reach. Please log in.")
       end
@@ -458,7 +458,7 @@ describe TagSetNominationsController do
 
         # TODO: how can OwnedTagSet.find not raise an error but still return falsey?
         xcontext 'no tag set' do
-          it 'redirects and shows an error message' do
+          it 'redirects and returns an error message' do
             get :show, id: tag_set_nomination.id, tag_set_id: nil
             it_redirects_to_with_error(tag_sets_path, "What tag set did you want to nominate for?")
           end
@@ -466,7 +466,7 @@ describe TagSetNominationsController do
 
         # TODO: how can TagSetNomination.find not raise an error but still return falsey?
         xcontext 'no tag set nomination' do
-          it 'redirects and shows an error message' do
+          it 'redirects and returns an error message' do
             get :show, id: nil, tag_set_id: owned_tag_set.id
             it_redirects_to_with_error(user_tag_set_nominations_path(tag_nominator), "Which nominations did you want to work with?")
           end
@@ -479,7 +479,7 @@ describe TagSetNominationsController do
             fake_login_known_user(random_user)
           end
 
-          it 'redirects and shows an error message' do
+          it 'redirects and returns an error message' do
             get :show, id: tag_set_nomination.id, tag_set_id: owned_tag_set.id
             it_redirects_to_with_notice(tag_set_path(owned_tag_set),
                                         "You can only see your own nominations or nominations for a set you moderate.")
@@ -513,7 +513,7 @@ describe TagSetNominationsController do
 
   describe 'GET new' do
     context 'user is not logged in' do
-      it 'redirects and shows an error message' do
+      it 'redirects and returns an error message' do
         get :new, tag_set_id: owned_tag_set.id
         it_redirects_to_with_error(new_user_session_path, "Sorry, you don't have permission to access the page you were trying to reach. Please log in.")
       end
@@ -614,7 +614,7 @@ describe TagSetNominationsController do
 
       # TODO: how can OwnedTagSet.find not raise an error but still return falsey?
       xcontext 'no tag set' do
-        it 'redirects and shows an error message' do
+        it 'redirects and returns an error message' do
           fake_login_known_user(random_user)
           get :new, tag_set_id: nil
           it_redirects_to_with_error(tag_sets_path, "What tag set did you want to nominate for?")
@@ -625,7 +625,7 @@ describe TagSetNominationsController do
 
   describe 'GET edit' do
     context 'user is not logged in' do
-      it 'redirects and shows an error message' do
+      it 'redirects and returns an error message' do
         get :edit, id: tag_set_nomination.id, tag_set_id: owned_tag_set.id
         it_redirects_to_with_error(new_user_session_path, "Sorry, you don't have permission to access the page you were trying to reach. Please log in.")
       end
@@ -639,7 +639,7 @@ describe TagSetNominationsController do
 
         # TODO: how can OwnedTagSet.find not raise an error but still return falsey?
         xcontext 'no tag set' do
-          it 'redirects and shows an error message' do
+          it 'redirects and returns an error message' do
             get :edit, id: tag_set_nomination.id, tag_set_id: nil
             it_redirects_to_with_error(tag_sets_path, "What tag set did you want to nominate for?")
           end
@@ -647,7 +647,7 @@ describe TagSetNominationsController do
 
         # TODO: how can TagSetNomination.find not raise an error but still return falsey?
         xcontext 'no tag set nomination' do
-          it 'redirects and shows an error message' do
+          it 'redirects and returns an error message' do
             get :edit, id: nil, tag_set_id: owned_tag_set.id
             it_redirects_to_with_error(user_tag_set_nominations_path(tag_nominator), "Which nominations did you want to work with?")
           end
@@ -663,7 +663,7 @@ describe TagSetNominationsController do
             fake_login_known_user(random_user)
           end
 
-          it 'redirects and shows an error message' do
+          it 'redirects and returns an error message' do
             get :edit, id: tag_set_nomination.id, tag_set_id: owned_tag_set.id
             it_redirects_to_with_notice(tag_set_path(owned_tag_set),
                                         "You can only see your own nominations or nominations for a set you moderate.")
@@ -787,7 +787,7 @@ describe TagSetNominationsController do
 
   describe 'POST create' do
     context 'user is not logged in' do
-      it 'redirects and shows an error message' do
+      it 'redirects and returns an error message' do
         post :create, tag_set_id: owned_tag_set.id
         it_redirects_to_with_error(new_user_session_path, "Sorry, you don't have permission to access the page you were trying to reach. Please log in.")
       end
@@ -801,14 +801,14 @@ describe TagSetNominationsController do
 
         # TODO: how can OwnedTagSet.find not raise an error but still return falsey?
         xcontext 'no tag set' do
-          it 'redirects and shows an error message' do
+          it 'redirects and returns an error message' do
             post :create, tag_set_id: nil
             it_redirects_to_with_error(tag_sets_path, "What tag set did you want to nominate for?")
           end
         end
 
         context 'pseud_id param does not match user' do
-          it 'redirects and shows an error message' do
+          it 'redirects and returns an error message' do
             post :create, tag_set_id: owned_tag_set.id, tag_set_nomination: { pseud_id: tag_nominator.default_pseud.id }
             it_redirects_to_with_error(root_path, "You can't nominate tags with that pseud.")
           end
@@ -941,7 +941,7 @@ describe TagSetNominationsController do
 
   describe 'PUT update' do
     context 'user is not logged in' do
-      it 'redirects and shows an error message' do
+      it 'redirects and returns an error message' do
         put :update, tag_set_id: owned_tag_set.id, id: tag_set_nomination.id
         it_redirects_to_with_error(new_user_session_path, "Sorry, you don't have permission to access the page you were trying to reach. Please log in.")
       end
@@ -955,14 +955,14 @@ describe TagSetNominationsController do
 
         # TODO: how can OwnedTagSet.find not raise an error but still return falsey?
         xcontext 'no tag set' do
-          it 'redirects and shows an error message' do
+          it 'redirects and returns an error message' do
             put :update, tag_set_id: nil, id: tag_set_nomination.id, tag_set_nomination: {}
             it_redirects_to_with_error(tag_sets_path, "What tag set did you want to nominate for?")
           end
         end
 
         context 'pseud_id param does not match user' do
-          it 'redirects and shows an error message' do
+          it 'redirects and returns an error message' do
             put :update, tag_set_id: owned_tag_set.id, id: tag_set_nomination.id,
                 tag_set_nomination: { pseud_id: random_user.default_pseud.id }
             it_redirects_to_with_error(root_path, "You can't nominate tags with that pseud.")
@@ -971,7 +971,7 @@ describe TagSetNominationsController do
 
         # TODO: how can TagSetNomination.find not raise an error but still return falsey?
         xcontext 'no tag set nomination' do
-          it 'redirects and shows an error message' do
+          it 'redirects and returns an error message' do
             put :update, id: nil, tag_set_id: owned_tag_set.id, tag_set_nomination: {}
             it_redirects_to_with_error(user_tag_set_nominations_path(tag_nominator), "Which nominations did you want to work with?")
           end
@@ -984,7 +984,7 @@ describe TagSetNominationsController do
             fake_login_known_user(random_user)
           end
 
-          it 'redirects and shows an error message' do
+          it 'redirects and returns an error message' do
             put :update, id: tag_set_nomination.id, tag_set_id: owned_tag_set.id, tag_set_nomination: {}
             it_redirects_to_with_notice(tag_set_path(owned_tag_set),
                                         "You can only see your own nominations or nominations for a set you moderate.")
@@ -1110,7 +1110,97 @@ describe TagSetNominationsController do
   end
 
   describe 'DELETE destroy' do
+    context 'user is not logged in' do
+      it 'redirects and returns an error message' do
+        delete :destroy, id: tag_set_nomination.id, tag_set_id: owned_tag_set.id
+        it_redirects_to_with_error(new_user_session_path, "Sorry, you don't have permission to access the page you were trying to reach. Please log in.")
+      end
+    end
 
+    context 'user is logged in' do
+      context 'invalid params' do
+        before do
+          fake_login_known_user(tag_nominator)
+        end
+
+        # TODO: how can OwnedTagSet.find not raise an error but still return falsey?
+        xcontext 'no tag set' do
+          it 'redirects and returns an error message' do
+            delete :destroy, id: tag_set_nomination.id, tag_set_id: nil
+            it_redirects_to_with_error(tag_sets_path, "What tag set did you want to nominate for?")
+          end
+        end
+
+        # TODO: how can TagSetNomination.find not raise an error but still return falsey?
+        xcontext 'no tag set nomination' do
+          it 'redirects and returns an error message' do
+            delete :destroy, id: nil, tag_set_id: owned_tag_set.id
+            it_redirects_to_with_error(user_tag_set_nominations_path(tag_nominator), "Which nominations did you want to work with?")
+          end
+        end
+      end
+
+      context 'valid params' do
+        context 'user is not moderator of tag set' do
+          before do
+            fake_login_known_user(tag_nominator.reload) # Why reload?
+          end
+
+          context 'at least one tag nominations associated with tag_set_nomination is reviewed' do
+            before do
+              allow(TagSetNomination).to receive(:find) { tag_set_nomination } # hmm, is this the best way?
+              allow(tag_set_nomination).to receive(:unreviewed?) { false }
+            end
+
+            it 'does not delete the tag set nomination' do
+              delete :destroy, id: tag_set_nomination.id, tag_set_id: owned_tag_set.id
+              expect(tag_set_nomination.reload).to eq(tag_set_nomination)
+            end
+
+            it 'redirects and returns an error message' do
+              delete :destroy, id: tag_set_nomination.id, tag_set_id: owned_tag_set.id
+              it_redirects_to_with_error(tag_set_nomination_path(owned_tag_set, tag_set_nomination),
+                                         "You cannot delete nominations after some of them have been reviewed, sorry!")
+            end
+          end
+
+          context 'all tag nominations associated with tag_set_nomination are unreviewed' do
+            before do
+              allow(TagSetNomination).to receive(:find) { tag_set_nomination } # hmm, is this the best way?
+              allow(tag_set_nomination).to receive(:unreviewed?) { true }
+            end
+
+            it 'deletes the tag set nomination' do
+              expect { delete :destroy, id: tag_set_nomination.id, tag_set_id: owned_tag_set.id }.
+                  to change { TagSetNomination.count }.by(-1)
+            end
+
+            it 'redirects and returns a success message' do
+              delete :destroy, id: tag_set_nomination.id, tag_set_id: owned_tag_set.id
+              it_redirects_to_with_notice(tag_set_path(owned_tag_set), "Your nominations were deleted.")
+            end
+          end
+        end
+
+        context 'user is moderator of tag set' do
+          before do
+            allow(TagSetNomination).to receive(:find) { tag_set_nomination } # hmm, is this the best way?
+            allow(tag_set_nomination).to receive(:unreviewed?) { false }
+            fake_login_known_user(moderator.reload) # Why reload?
+          end
+
+          it 'deletes the tag set nomination' do
+            expect { delete :destroy, id: tag_set_nomination.id, tag_set_id: owned_tag_set.id }.
+                to change { TagSetNomination.count }.by(-1)
+          end
+
+          it 'redirects and returns a success message' do
+            delete :destroy, id: tag_set_nomination.id, tag_set_id: owned_tag_set.id
+            it_redirects_to_with_notice(tag_set_path(owned_tag_set), "Your nominations were deleted.")
+          end
+        end
+      end
+    end
   end
 
   describe 'GET confirm_destroy_multiple' do

--- a/spec/controllers/tag_set_nominations_controller_spec.rb
+++ b/spec/controllers/tag_set_nominations_controller_spec.rb
@@ -7,15 +7,15 @@ describe TagSetNominationsController do
   let(:tag_set_nomination) { FactoryGirl.create(:tag_set_nomination) }
   let(:owned_tag_set) { tag_set_nomination.owned_tag_set }
 
-  let(:tag_nominator) { tag_nominator_pseud.user }
   let(:tag_nominator_pseud) { tag_set_nomination.pseud }
-  let(:moderator) { mod_pseud.user }
+  let(:tag_nominator) { tag_nominator_pseud.user }
   let(:mod_pseud) {
     FactoryGirl.create(:pseud).tap do |pseud|
       owned_tag_set.add_moderator(pseud)
       owned_tag_set.save!
     end
   }
+  let(:moderator) { mod_pseud.user }
 
   let(:random_user) { FactoryGirl.create(:user) }
 
@@ -23,8 +23,8 @@ describe TagSetNominationsController do
     context 'user is not logged in' do
       it 'redirects and returns an error message' do
         get :index, user_id: moderator.login, tag_set_id: owned_tag_set.id
-        it_redirects_to_with_error(new_user_session_path, "Sorry, you don't have permission to access the page you " +
-            "were trying to reach. Please log in.")
+        it_redirects_to_with_error(new_user_session_path, "Sorry, you don't have permission to access the page you " \
+          "were trying to reach. Please log in.")
       end
     end
 
@@ -101,9 +101,9 @@ describe TagSetNominationsController do
                     end
 
                     it 'does not return a flash notice about too many nominations' do
-                      expect(flash[:notice]).not_to eq("There are too many nominations to show at once, so here's a " +
-                                                           "randomized selection! Additional nominations will appear " +
-                                                           "after you approve or reject some.")
+                      expect(flash[:notice]).not_to eq("There are too many nominations to show at once, so here's a " \
+                                                         "randomized selection! Additional nominations will appear " \
+                                                         "after you approve or reject some.")
                     end
                   end
 
@@ -119,9 +119,9 @@ describe TagSetNominationsController do
                     end
 
                     it 'returns a flash notice about too many nominations' do
-                      expect(flash[:notice]).to eq("There are too many nominations to show at once, so here's a " +
-                                                       "randomized selection! Additional nominations will appear " +
-                                                       "after you approve or reject some.")
+                      expect(flash[:notice]).to eq("There are too many nominations to show at once, so here's a " \
+                                                     "randomized selection! Additional nominations will appear " \
+                                                     "after you approve or reject some.")
                     end
                   end
 
@@ -189,9 +189,9 @@ describe TagSetNominationsController do
                     end
 
                     it 'does not return a flash notice about too many nominations' do
-                      expect(flash[:notice]).not_to eq("There are too many nominations to show at once, so here's a " +
-                                                           "randomized selection! Additional nominations will appear " +
-                                                           "after you approve or reject some.")
+                      expect(flash[:notice]).not_to eq("There are too many nominations to show at once, so here's a " \
+                                                         "randomized selection! Additional nominations will appear " \
+                                                         "after you approve or reject some.")
                     end
                   end
 
@@ -204,9 +204,9 @@ describe TagSetNominationsController do
                     end
 
                     it 'returns a flash notice about too many nominations' do
-                      expect(flash[:notice]).to eq("There are too many nominations to show at once, so here's a " +
-                                                       "randomized selection! Additional nominations will appear " +
-                                                       "after you approve or reject some.")
+                      expect(flash[:notice]).to eq("There are too many nominations to show at once, so here's a " \
+                                                     "randomized selection! Additional nominations will appear " \
+                                                     "after you approve or reject some.")
                     end
                   end
                 end
@@ -323,9 +323,9 @@ describe TagSetNominationsController do
                     end
 
                     it 'does not return a flash notice about too many nominations' do
-                      expect(flash[:notice]).not_to eq("There are too many nominations to show at once, so here's a " +
-                                                           "randomized selection! Additional nominations will appear " +
-                                                           "after you approve or reject some.")
+                      expect(flash[:notice]).not_to eq("There are too many nominations to show at once, so here's a " \
+                                                         "randomized selection! Additional nominations will appear " \
+                                                         "after you approve or reject some.")
                     end
                   end
 
@@ -344,9 +344,9 @@ describe TagSetNominationsController do
                     end
 
                     it 'returns a flash notice about too many nominations' do
-                      expect(flash[:notice]).to eq("There are too many nominations to show at once, so here's a " +
-                                                       "randomized selection! Additional nominations will appear " +
-                                                       "after you approve or reject some.")
+                      expect(flash[:notice]).to eq("There are too many nominations to show at once, so here's a " \
+                                                     "randomized selection! Additional nominations will appear " \
+                                                     "after you approve or reject some.")
                     end
                   end
                 end
@@ -413,8 +413,8 @@ describe TagSetNominationsController do
     context 'user is not logged in' do
       it 'redirects and returns an error message' do
         get :show, id: tag_set_nomination.id, tag_set_id: owned_tag_set.id
-        it_redirects_to_with_error(new_user_session_path, "Sorry, you don't have permission to access the page you " +
-            "were trying to reach. Please log in.")
+        it_redirects_to_with_error(new_user_session_path, "Sorry, you don't have permission to access the page you " \
+          "were trying to reach. Please log in.")
       end
     end
 
@@ -483,8 +483,8 @@ describe TagSetNominationsController do
     context 'user is not logged in' do
       it 'redirects and returns an error message' do
         get :new, tag_set_id: owned_tag_set.id
-        it_redirects_to_with_error(new_user_session_path, "Sorry, you don't have permission to access the page you " +
-            "were trying to reach. Please log in.")
+        it_redirects_to_with_error(new_user_session_path, "Sorry, you don't have permission to access the page you " \
+          "were trying to reach. Please log in.")
       end
     end
 
@@ -594,8 +594,8 @@ describe TagSetNominationsController do
     context 'user is not logged in' do
       it 'redirects and returns an error message' do
         get :edit, id: tag_set_nomination.id, tag_set_id: owned_tag_set.id
-        it_redirects_to_with_error(new_user_session_path, "Sorry, you don't have permission to access the page you " +
-            "were trying to reach. Please log in.")
+        it_redirects_to_with_error(new_user_session_path, "Sorry, you don't have permission to access the page you " \
+          "were trying to reach. Please log in.")
       end
     end
 
@@ -663,11 +663,11 @@ describe TagSetNominationsController do
             it 'returns only existing associated tag nominations' do
               expect(assigns(:tag_set_nomination).fandom_nominations.map(&:tagname)).to eq(['New Fandom'])
               expect(assigns(:tag_set_nomination).fandom_nominations[0].character_nominations.map(&:tagname)).
-                  to eq(['New Character 0', 'New Character 1', 'New Character 2'])
+                to eq(['New Character 0', 'New Character 1', 'New Character 2'])
               expect(assigns(:tag_set_nomination).fandom_nominations[0].relationship_nominations.map(&:tagname)).
-                  to eq(['New Relationship 0', 'New Relationship 1'])
+                to eq(['New Relationship 0', 'New Relationship 1'])
               expect(assigns(:tag_set_nomination).freeform_nominations.map(&:tagname)).
-                  to eq(['New Freeform 0', 'New Freeform 1', 'New Freeform 2', 'New Freeform 3'])
+                to eq(['New Freeform 0', 'New Freeform 1', 'New Freeform 2', 'New Freeform 3'])
             end
           end
 
@@ -683,9 +683,9 @@ describe TagSetNominationsController do
             it 'returns existing associated tag nominations' do
               expect(assigns(:tag_set_nomination).fandom_nominations.map(&:tagname)).to eq(['New Fandom'])
               expect(assigns(:tag_set_nomination).fandom_nominations[0].character_nominations.map(&:tagname)).
-                  to include('New Character 0')
+                to include('New Character 0')
               expect(assigns(:tag_set_nomination).fandom_nominations[0].relationship_nominations.map(&:tagname)).
-                  to include('New Relationship 0')
+                to include('New Relationship 0')
               expect(assigns(:tag_set_nomination).freeform_nominations.map(&:tagname)).to include('New Freeform 0')
             end
 
@@ -716,9 +716,9 @@ describe TagSetNominationsController do
           it 'returns associated tag nominations' do
             expect(assigns(:tag_set_nomination).fandom_nominations.map(&:tagname)).to eq(['New Fandom'])
             expect(assigns(:tag_set_nomination).fandom_nominations[0].character_nominations.map(&:tagname)).
-                to eq(['New Character 0'])
+              to eq(['New Character 0'])
             expect(assigns(:tag_set_nomination).fandom_nominations[0].relationship_nominations.map(&:tagname)).
-                to eq(['New Relationship 0'])
+              to eq(['New Relationship 0'])
             expect(assigns(:tag_set_nomination).freeform_nominations.map(&:tagname)).to eq(['New Freeform 0'])
           end
         end
@@ -750,8 +750,8 @@ describe TagSetNominationsController do
     context 'user is not logged in' do
       it 'redirects and returns an error message' do
         post :create, tag_set_id: owned_tag_set.id
-        it_redirects_to_with_error(new_user_session_path, "Sorry, you don't have permission to access the page you " +
-            "were trying to reach. Please log in.")
+        it_redirects_to_with_error(new_user_session_path, "Sorry, you don't have permission to access the page you " \
+          "were trying to reach. Please log in.")
       end
     end
 
@@ -788,70 +788,35 @@ describe TagSetNominationsController do
             post :create,
                  tag_set_id: owned_tag_set.id,
                  tag_set_nomination: { pseud_id: random_user.default_pseud.id,
-                                       owned_tag_set_id: owned_tag_set.id }.merge(nomination_attributes)
+                                       owned_tag_set_id: owned_tag_set.id,
+                                       fandom_nominations_attributes: {
+                                         '0': { tagname: 'New Fandom',
+                                                character_nominations_attributes: {
+                                                  '0': { tagname: 'New Character',
+                                                         from_fandom_nomination: true }
+                                                } }
+                                       } }
           end
 
-          context 'all tag nominations are canonical' do
-            let(:nomination_attributes) {
-              { fandom_nominations_attributes: { '0': { tagname: 'New Fandom',
-                                                        character_nominations_attributes: {
-                                                            '0': { tagname: 'New Character',
-                                                                   from_fandom_nomination: true } } } } }
-            }
-
-            it 'creates a new tag set nomination' do
-              new_tag_set_nomination = TagSetNomination.last
-              expect(assigns(:tag_set_nomination)).to eq(new_tag_set_nomination)
-              expect(new_tag_set_nomination.pseud).to eq(random_user.default_pseud)
-              expect(new_tag_set_nomination.owned_tag_set).to eq(owned_tag_set)
-            end
-
-            it 'creates associated tag nominations' do
-              new_fandom_nomination = FandomNomination.last
-              new_character_nomination = CharacterNomination.last
-              expect(assigns(:tag_set_nomination).fandom_nominations).to eq([new_fandom_nomination])
-              expect(new_fandom_nomination.tagname).to eq('New Fandom')
-              expect(new_fandom_nomination.character_nominations).to eq([new_character_nomination])
-              expect(new_character_nomination.tagname).to eq('New Character')
-            end
-
-            it 'redirects and returns a success message' do
-              it_redirects_to_with_notice(tag_set_nomination_path(owned_tag_set, TagSetNomination.last),
-                                          'Your nominations were successfully submitted.')
-            end
+          it 'creates a new tag set nomination' do
+            new_tag_set_nomination = TagSetNomination.last
+            expect(assigns(:tag_set_nomination)).to eq(new_tag_set_nomination)
+            expect(new_tag_set_nomination.pseud).to eq(random_user.default_pseud)
+            expect(new_tag_set_nomination.owned_tag_set).to eq(owned_tag_set)
           end
 
-          context 'at least one character or relationship nomination is noncanonical' do
-            # TODO: I can force test #request_nancanonical_info for these 2 tests by adding the
-            # [:tag_set_nomination][:character_nominations_attributes][:from_fandom_nomination] param, but I don't
-            # think the resulting params can actually be triggered by the UI
-            # If so, how do I trigger the state where a new CharacterNom or RelationshipNom is created
-            # with parented: false && parent_tagname: '', without failing CastNomination#known_fandom validation?
-            context 'noncanonical character nominations are created' do
-              let(:nomination_attributes) {
-                { character_nominations_attributes: { '0': { tagname: 'New Character',
-                                                             parent_tagname: '',
-                                                             from_fandom_nomination: true } } }
-              }
+          it 'creates associated tag nominations' do
+            new_fandom_nomination = FandomNomination.last
+            new_character_nomination = CharacterNomination.last
+            expect(assigns(:tag_set_nomination).fandom_nominations).to eq([new_fandom_nomination])
+            expect(new_fandom_nomination.tagname).to eq('New Fandom')
+            expect(new_fandom_nomination.character_nominations).to eq([new_character_nomination])
+            expect(new_character_nomination.tagname).to eq('New Character')
+          end
 
-              it 'returns a success message with info about noncanonical tags' do
-                expect(flash[:notice]).to eq('Your nominations were successfully submitted. Please consider editing ' +
-                                                 'to add fandoms to any of your non-canonical tags!')
-              end
-            end
-
-            context 'noncanonical relationship nominations are created' do
-              let(:nomination_attributes) {
-                { relationship_nominations_attributes: { '0': { tagname: 'New Relationship',
-                                                                parent_tagname: '',
-                                                                from_fandom_nomination: true } } }
-              }
-
-              it 'returns a success message with info about noncanonical tags' do
-                expect(flash[:notice]).to eq('Your nominations were successfully submitted. Please consider editing ' +
-                                                 'to add fandoms to any of your non-canonical tags!')
-              end
-            end
+          it 'redirects and returns a success message' do
+            it_redirects_to_with_notice(tag_set_nomination_path(owned_tag_set, TagSetNomination.last),
+                                        'Your nominations were successfully submitted.')
           end
         end
 
@@ -869,7 +834,7 @@ describe TagSetNominationsController do
           it 'builds a new tag set nomination' do
             expect { post :create, tag_set_id: owned_tag_set.id, tag_set_nomination: { pseud_id: random_user.default_pseud.id,
                                                                                        owned_tag_set_id: owned_tag_set.id } }.
-                not_to change { owned_tag_set.tag_set_nominations.count }
+              not_to change { owned_tag_set.tag_set_nominations.count }
             expect(assigns(:tag_set_nomination).new_record?).to be_truthy
             expect(assigns(:tag_set_nomination).pseud).to eq(random_user.default_pseud)
             expect(assigns(:tag_set_nomination).owned_tag_set).to eq(owned_tag_set)
@@ -897,8 +862,8 @@ describe TagSetNominationsController do
     context 'user is not logged in' do
       it 'redirects and returns an error message' do
         put :update, tag_set_id: owned_tag_set.id, id: tag_set_nomination.id
-        it_redirects_to_with_error(new_user_session_path, "Sorry, you don't have permission to access the page you " +
-            "were trying to reach. Please log in.")
+        it_redirects_to_with_error(new_user_session_path, "Sorry, you don't have permission to access the page you " \
+          "were trying to reach. Please log in.")
       end
     end
 
@@ -963,50 +928,26 @@ describe TagSetNominationsController do
                   tag_set_id: owned_tag_set.id,
                   id: tag_set_nomination.id,
                   tag_set_nomination: { pseud_id: tag_nominator_pseud.id,
-                                        owned_tag_set_id: owned_tag_set.id }.merge(nomination_attributes)
+                                        owned_tag_set_id: owned_tag_set.id,
+                                        fandom_nominations_attributes: {
+                                          '0': { tagname: 'Renamed Fandom',
+                                                 id: fandom_nom.id,
+                                                 character_nominations_attributes: {
+                                                   '0': { tagname: 'Renamed Character',
+                                                          id: character_nom.id,
+                                                          from_fandom_nomination: true }
+                                                 } }
+                                        } }
             end
 
-            context 'all tag nominations are canonical' do
-              let(:nomination_attributes) {
-                { fandom_nominations_attributes: { '0': { tagname: 'Renamed Fandom',
-                                                          id: fandom_nom.id,
-                                                          character_nominations_attributes: {
-                                                              '0': { tagname: 'Renamed Character',
-                                                                     id: character_nom.id,
-                                                                     from_fandom_nomination: true } } } }
-                }
-              }
-
-              it 'updates the tag set nomination and associated tag nominations' do
-                expect(fandom_nom.reload.tagname).to eq('Renamed Fandom')
-                expect(character_nom.reload.tagname).to eq('Renamed Character')
-              end
-
-              it 'redirects and returns a success message' do
-                it_redirects_to_with_notice(tag_set_nomination_path(owned_tag_set, tag_set_nomination),
-                                            'Your nominations were successfully updated.')
-              end
+            it 'updates the tag set nomination and associated tag nominations' do
+              expect(fandom_nom.reload.tagname).to eq('Renamed Fandom')
+              expect(character_nom.reload.tagname).to eq('Renamed Character')
             end
 
-            context 'at least one character or relationship nomination is noncanonical' do
-              # TODO: I can force test #request_nancanonical_info for these 2 tests by adding the
-              # [:tag_set_nomination][:character_nominations_attributes][:from_fandom_nomination] param, but I don't
-              # think the resulting params can actually be triggered by the UI
-              # If so, how do I trigger the state where a new CharacterNom or RelationshipNom is created
-              # with parented: false && parent_tagname: "", without failing CastNomination#known_fandom validation?
-              let(:nomination_attributes) {
-                { character_nominations_attributes: {
-                    '0': { tagname: 'Renamed Character',
-                           parent_tagname: '',
-                           id: character_nom.id,
-                           from_fandom_nomination: true } }
-                }
-              }
-
-              it 'returns a success message with info about noncanonical tags' do
-                expect(flash[:notice]).to eq('Your nominations were successfully updated. Please consider editing ' +
-                                                 'to add fandoms to any of your non-canonical tags!')
-              end
+            it 'redirects and returns a success message' do
+              it_redirects_to_with_notice(tag_set_nomination_path(owned_tag_set, tag_set_nomination),
+                                          'Your nominations were successfully updated.')
             end
           end
 
@@ -1051,12 +992,14 @@ describe TagSetNominationsController do
                 tag_set_nomination: { pseud_id: mod_pseud.id,
                                       owned_tag_set_id: owned_tag_set.id,
                                       fandom_nominations_attributes: {
-                                          '0': { tagname: 'Renamed Fandom',
-                                                 id: fandom_nom.id,
-                                                 character_nominations_attributes: {
-                                                     '0': { tagname: 'Renamed Character',
-                                                            id: character_nom.id,
-                                                            from_fandom_nomination: true } } } } }
+                                        '0': { tagname: 'Renamed Fandom',
+                                               id: fandom_nom.id,
+                                               character_nominations_attributes: {
+                                                 '0': { tagname: 'Renamed Character',
+                                                        id: character_nom.id,
+                                                        from_fandom_nomination: true }
+                                               } }
+                                      } }
           end
 
           it 'updates the tag set nomination and associated tag nominations' do
@@ -1077,8 +1020,8 @@ describe TagSetNominationsController do
     context 'user is not logged in' do
       it 'redirects and returns an error message' do
         delete :destroy, id: tag_set_nomination.id, tag_set_id: owned_tag_set.id
-        it_redirects_to_with_error(new_user_session_path, "Sorry, you don't have permission to access the page you " +
-            "were trying to reach. Please log in.")
+        it_redirects_to_with_error(new_user_session_path, "Sorry, you don't have permission to access the page you " \
+          "were trying to reach. Please log in.")
       end
     end
 
@@ -1139,7 +1082,7 @@ describe TagSetNominationsController do
 
             it 'deletes the tag set nomination' do
               expect { delete :destroy, id: tag_set_nomination.id, tag_set_id: owned_tag_set.id }.
-                  to change { TagSetNomination.count }.by(-1)
+                to change { TagSetNomination.count }.by(-1)
             end
 
             it 'redirects and returns a success message' do
@@ -1157,7 +1100,7 @@ describe TagSetNominationsController do
 
           it 'deletes the tag set nomination' do
             expect { delete :destroy, id: tag_set_nomination.id, tag_set_id: owned_tag_set.id }.
-                to change { TagSetNomination.count }.by(-1)
+              to change { TagSetNomination.count }.by(-1)
           end
 
           it 'redirects and returns a success message' do
@@ -1173,8 +1116,8 @@ describe TagSetNominationsController do
     context 'user is not logged in' do
       it 'redirects and returns an error message' do
         get :confirm_destroy_multiple, tag_set_id: owned_tag_set.id
-        it_redirects_to_with_error(new_user_session_path, "Sorry, you don't have permission to access the page you " +
-            "were trying to reach. Please log in.")
+        it_redirects_to_with_error(new_user_session_path, "Sorry, you don't have permission to access the page you " \
+          "were trying to reach. Please log in.")
       end
     end
 
@@ -1204,15 +1147,15 @@ describe TagSetNominationsController do
 
   describe 'DELETE destroy_multiple' do
     before do
-      allow(OwnedTagSet).to receive(:find).with("#{owned_tag_set.id}") { owned_tag_set }
+      allow(OwnedTagSet).to receive(:find).with(owned_tag_set.id.to_s) { owned_tag_set }
       allow(owned_tag_set).to receive(:clear_nominations!)
     end
 
     context 'user is not logged in' do
       it 'redirects and returns an error message' do
         delete :destroy_multiple, tag_set_id: owned_tag_set.id
-        it_redirects_to_with_error(new_user_session_path, "Sorry, you don't have permission to access the page you " +
-            "were trying to reach. Please log in.")
+        it_redirects_to_with_error(new_user_session_path, "Sorry, you don't have permission to access the page you " \
+          "were trying to reach. Please log in.")
       end
     end
 
@@ -1251,8 +1194,8 @@ describe TagSetNominationsController do
     context 'user is not logged in' do
       it 'redirects and returns an error message' do
         put :update_multiple, tag_set_id: owned_tag_set.id
-        it_redirects_to_with_error(new_user_session_path, "Sorry, you don't have permission to access the page you " +
-            "were trying to reach. Please log in.")
+        it_redirects_to_with_error(new_user_session_path, "Sorry, you don't have permission to access the page you " \
+          "were trying to reach. Please log in.")
       end
     end
 
@@ -1289,11 +1232,11 @@ describe TagSetNominationsController do
       context 'all tag nominations have an associated _approve, _reject, _change, or _synonym param value' do
         it 'redirects and returns a flash message' do
           put :update_multiple, { tag_set_id: owned_tag_set.id }.merge(base_params).
-              merge({ 'character_approve_New Character 1': 1,
-                      'character_reject_New Character 2': 1,
-                      'relationship_approve_New Relationship': 1,
-                      'fandom_approve_New Fandom': 1,
-                      'freeform_reject_New Fandom': 1 })
+            merge('character_approve_New Character 1': 1,
+                  'character_reject_New Character 2': 1,
+                  'relationship_approve_New Relationship': 1,
+                  'fandom_approve_New Fandom': 1,
+                  'freeform_reject_New Fandom': 1)
           it_redirects_to(tag_set_nominations_path(owned_tag_set))
           expect(flash[:notice]).to include('Still some nominations left to review!')
         end
@@ -1302,7 +1245,7 @@ describe TagSetNominationsController do
       context 'tag nomination _reject param has a value' do
         before do
           put :update_multiple, { tag_set_id: owned_tag_set.id }.merge(base_params).
-              merge({ 'relationship_reject_New Relationship': 1 })
+            merge('relationship_reject_New Relationship': 1)
         end
 
         it 'updates tag_nomination.rejected to true' do
@@ -1318,7 +1261,7 @@ describe TagSetNominationsController do
         context 'approving the tag nomination is successful' do
           before do
             put :update_multiple, { tag_set_id: owned_tag_set.id }.merge(base_params).
-                merge({ 'fandom_approve_New Fandom': 1, 'character_approve_New Character 2': 1 })
+              merge('fandom_approve_New Fandom': 1, 'character_approve_New Character 2': 1)
           end
 
           it 'updates tag_nomination.approved to true' do
@@ -1334,15 +1277,15 @@ describe TagSetNominationsController do
 
         context 'approving the tag nomination fails' do
           before do
-            allow(OwnedTagSet).to receive(:find).with("#{owned_tag_set.id}") { owned_tag_set }
+            allow(OwnedTagSet).to receive(:find).with(owned_tag_set.id.to_s) { owned_tag_set }
             allow(owned_tag_set).to receive(:add_tagnames).with('fandom', ['New Fandom']) { false }
             put :update_multiple, { tag_set_id: owned_tag_set.id }.merge(base_params).
-                merge({ 'fandom_approve_New Fandom': 1, 'character_approve_New Character 2': 1 })
+              merge('fandom_approve_New Fandom': 1, 'character_approve_New Character 2': 1)
           end
 
           it 'renders the index template and returns an error message' do
-            expect(flash[:error]).to eq('Oh no! We ran into a problem partway through saving your updates -- please ' +
-                                            'check over your tag set closely!')
+            expect(flash[:error]).to eq('Oh no! We ran into a problem partway through saving your updates -- please ' \
+                                          'check over your tag set closely!')
             expect(response).to render_template('index')
           end
         end
@@ -1356,7 +1299,7 @@ describe TagSetNominationsController do
             it 'calls TagNomination.change_tagname! with old and new tagnames' do
               allow(TagNomination).to receive(:change_tagname!)
               put :update_multiple, { tag_set_id: owned_tag_set.id }.merge(base_params).
-                  merge({ 'character_approve_New Character 2': 1 })
+                merge('character_approve_New Character 2': 1)
               expect(TagNomination).to have_received(:change_tagname!).with(owned_tag_set, 'New Character 1', 'New Character 2')
             end
           end
@@ -1365,10 +1308,10 @@ describe TagSetNominationsController do
             it 'renders the index template and returns an error message' do
               allow(TagNomination).to receive(:change_tagname!) { false }
               put :update_multiple, { tag_set_id: owned_tag_set.id }.merge(base_params).
-                  merge({ 'character_approve_New Character 2': 1 })
-              expect(flash[:error]).to eq('Oh no! We ran into a problem partway through saving your updates, ' +
-                                              'changing New Character 1 to New Character 2 -- please check over ' +
-                                              'your tag set closely!')
+                merge('character_approve_New Character 2': 1)
+              expect(flash[:error]).to eq('Oh no! We ran into a problem partway through saving your updates, ' \
+                                            'changing New Character 1 to New Character 2 -- please check over ' \
+                                            'your tag set closely!')
               expect(response).to render_template('index')
             end
           end
@@ -1378,7 +1321,7 @@ describe TagSetNominationsController do
       context 'tag nomination _approve and _reject params have a value' do
         before do
           put :update_multiple, { tag_set_id: owned_tag_set.id }.merge(base_params).
-              merge({ 'relationship_approve_New Relationship': 1, 'relationship_reject_New Relationship': 2 })
+            merge('relationship_approve_New Relationship': 1, 'relationship_reject_New Relationship': 2)
         end
 
         it 'renders the index template' do
@@ -1386,8 +1329,8 @@ describe TagSetNominationsController do
         end
 
         it 'returns expected errors' do
-          expect(assigns(:errors)).to include('You have both approved and rejected the following relationship tags: ' +
-                                                  'New Relationship')
+          expect(assigns(:errors)).to include('You have both approved and rejected the following relationship tags: ' \
+                                                'New Relationship')
         end
       end
 
@@ -1395,7 +1338,7 @@ describe TagSetNominationsController do
         context '_change param = current tag nomination tagname' do
           it 'does not update the tag nomination' do
             put :update_multiple, { tag_set_id: owned_tag_set.id }.merge(base_params).
-                merge({ 'freeform_change_New Freeform': 'New Freeform' })
+              merge('freeform_change_New Freeform': 'New Freeform')
             expect(freeform_nom.reload.approved).to be_falsey
           end
         end
@@ -1404,7 +1347,7 @@ describe TagSetNominationsController do
           context 'new name is invalid' do
             before do
               put :update_multiple, { tag_set_id: owned_tag_set.id }.
-                  merge(base_params).merge({ 'freeform_change_New Freeform': 'N*w Fr**f*rm' })
+                merge(base_params).merge('freeform_change_New Freeform': 'N*w Fr**f*rm')
             end
 
             it 'renders the index template' do
@@ -1419,7 +1362,7 @@ describe TagSetNominationsController do
           context 'no tag nomination associated with name' do
             before do
               put :update_multiple, { tag_set_id: owned_tag_set.id }.merge(base_params).
-                  merge({ 'freeform_change_A Freeform Masquerade': 'Different Freeform' })
+                merge('freeform_change_A Freeform Masquerade': 'Different Freeform')
             end
 
             it 'renders the index template' do
@@ -1436,7 +1379,7 @@ describe TagSetNominationsController do
               before do
                 allow(TagNomination).to receive(:change_tagname!).and_call_original
                 put :update_multiple, { tag_set_id: owned_tag_set.id }.merge(base_params).
-                    merge({ 'freeform_change_New Freeform': 'Different Freeform' })
+                  merge('freeform_change_New Freeform': 'Different Freeform')
               end
 
               it 'calls TagNomination.change_tagname! with _change param value' do
@@ -1457,7 +1400,7 @@ describe TagSetNominationsController do
               before do
                 allow(TagNomination).to receive(:change_tagname!) { false }
                 put :update_multiple, { tag_set_id: owned_tag_set.id }.merge(base_params).
-                    merge({ 'freeform_change_New Freeform': 'Different Freeform' })
+                  merge('freeform_change_New Freeform': 'Different Freeform')
               end
 
               it 'renders the index template' do
@@ -1465,9 +1408,9 @@ describe TagSetNominationsController do
               end
 
               it 'returns an error message' do
-                expect(flash[:error]).to eq('Oh no! We ran into a problem partway through saving your updates, ' +
-                                                'changing New Freeform to Different Freeform -- please check over ' +
-                                                'your tag set closely!')
+                expect(flash[:error]).to eq('Oh no! We ran into a problem partway through saving your updates, ' \
+                                              'changing New Freeform to Different Freeform -- please check over ' \
+                                              'your tag set closely!')
               end
             end
           end
@@ -1477,8 +1420,8 @@ describe TagSetNominationsController do
       context 'tag nomination _synonym param is not empty' do
         context '_synonym param = current tag nomination tagname' do
           it 'does not update the tag nomination' do
-            put :update_multiple, { tag_set_id: owned_tag_set.id }.
-                merge(base_params).merge({ 'freeform_synonym_New Freeform': 'New Freeform' })
+            put :update_multiple, { tag_set_id: owned_tag_set.id }.merge(base_params).
+              merge('freeform_synonym_New Freeform': 'New Freeform')
             expect(freeform_nom.reload.approved).to be_falsey
           end
         end
@@ -1487,7 +1430,7 @@ describe TagSetNominationsController do
           context 'new name is invalid' do
             before do
               put :update_multiple, { tag_set_id: owned_tag_set.id }.merge(base_params).
-                  merge({ 'freeform_synonym_New Freeform': 'N*w Fr**f*rm' })
+                merge('freeform_synonym_New Freeform': 'N*w Fr**f*rm')
             end
 
             it 'renders the index template' do
@@ -1502,7 +1445,7 @@ describe TagSetNominationsController do
           context 'no tag nomination associated with name' do
             before do
               put :update_multiple, { tag_set_id: owned_tag_set.id }.merge(base_params).
-                  merge({ 'freeform_synonym_A Freeform Masquerade': 'Different Freeform' })
+                merge('freeform_synonym_A Freeform Masquerade': 'Different Freeform')
             end
 
             it 'renders the index template' do
@@ -1518,7 +1461,7 @@ describe TagSetNominationsController do
             before do
               freeform_nom.update_column(:synonym, 'Different Freeform')
               put :update_multiple, { tag_set_id: owned_tag_set.id }.merge(base_params).
-                  merge({ 'freeform_synonym_New Freeform': 'Different Freeform' })
+                merge('freeform_synonym_New Freeform': 'Different Freeform')
             end
 
             it 'updates tag_nomination.approved to true' do

--- a/spec/controllers/tag_set_nominations_controller_spec.rb
+++ b/spec/controllers/tag_set_nominations_controller_spec.rb
@@ -1204,7 +1204,33 @@ describe TagSetNominationsController do
   end
 
   describe 'GET confirm_destroy_multiple' do
+    context 'user is not logged in' do
+      it 'redirects and returns an error message' do
+        get :confirm_destroy_multiple, tag_set_id: owned_tag_set.id
+        it_redirects_to_with_error(new_user_session_path, "Sorry, you don't have permission to access the page you were trying to reach. Please log in.")
+      end
+    end
 
+    context 'user is logged in' do
+      before do
+        fake_login_known_user(random_user)
+      end
+
+      context 'tag set exists' do
+        it 'renders the confirm_destroy_multiple template' do
+          get :confirm_destroy_multiple, tag_set_id: owned_tag_set.id
+          expect(response).to render_template("confirm_destroy_multiple")
+        end
+      end
+
+      # TODO: how can OwnedTagSet.find not raise an error but still return falsey?
+      xcontext 'no tag set' do
+        it 'redirects and returns an error message' do
+          get :confirm_destroy_multiple, tag_set_id: nil
+          it_redirects_to_with_error(tag_sets_path, "What tag set did you want to nominate for?")
+        end
+      end
+    end
   end
 
   describe 'DELETE destroy_multiple' do

--- a/spec/controllers/tag_set_nominations_controller_spec.rb
+++ b/spec/controllers/tag_set_nominations_controller_spec.rb
@@ -1,12 +1,117 @@
 require 'spec_helper'
 
 describe TagSetNominationsController do
+  include LoginMacros
+  include RedirectExpectationHelper
+
+  let(:tag_setter) { FactoryGirl.create(:user) }
+  let(:tag_setter_pseud) { FactoryGirl.create(:pseud, user_id: tag_setter.id) }
+
   describe 'GET index' do
 
   end
 
   describe 'GET show' do
+    let!(:tag_set_nomination) { FactoryGirl.create(:tag_set_nomination, pseud_id: tag_setter_pseud.id) }
+    let(:owned_tag_set) { tag_set_nomination.owned_tag_set}
 
+    context 'user is not logged in' do
+      it 'redirects and shows an error message' do
+        get :show, id: tag_set_nomination.id, tag_set_id: owned_tag_set.id
+        it_redirects_to_with_error(new_user_session_path, "Sorry, you don't have permission to access the page you were trying to reach. Please log in.")
+      end
+    end
+
+    context 'user is logged in' do
+      context 'invalid params' do
+        before do
+          fake_login_known_user(tag_setter)
+        end
+
+        # is testing this even possible?
+        # how can OwnedTagSet.find not raise an error but still return falsey?
+        xcontext 'no tag set' do
+          it 'redirects and shows an error message' do
+            get :show, id: tag_set_nomination.id, tag_set_id: nil
+            it_redirects_to_with_error(tag_sets_path, "What tag set did you want to nominate for?")
+          end
+        end
+
+        # is testing this even possible?
+        # how can TagSetNomination.find not raise an error but still return falsey?
+        xcontext 'no tag set nomination' do
+          it 'redirects and shows an error message' do
+            get :show, id: nil, tag_set_id: owned_tag_set.id
+            it_redirects_to_with_error(user_tag_set_nominations_path(tag_setter), "Which nominations did you want to work with?")
+          end
+        end
+      end
+
+      context 'valid params' do
+        context 'logged in user is not author of nomination' do
+          let(:moderator) { FactoryGirl.create(:user) }
+          let(:mod_pseud) { FactoryGirl.create(:pseud, user_id: moderator.id) }
+
+          before do
+            owned_tag_set.add_moderator(mod_pseud)
+            owned_tag_set.save!
+            moderator.reload
+          end
+
+          context 'user is not moderator of tag set' do
+            before do
+              random_user = FactoryGirl.create(:user)
+              fake_login_known_user(random_user)
+            end
+
+            it 'redirects and shows an error message' do
+              get :show, id: tag_set_nomination.id, tag_set_id: owned_tag_set.id
+              it_redirects_to_with_notice(tag_set_path(owned_tag_set),
+                                         "You can only see your own nominations or nominations for a set you moderate.")
+            end
+          end
+
+          context 'user is moderator of tag set' do
+            before do
+              fake_login_known_user(moderator)
+            end
+
+            it 'renders the show template' do
+              get :show, id: tag_set_nomination.id, tag_set_id: owned_tag_set.id
+              expect(response).to render_template("show")
+            end
+          end
+        end
+
+        context 'logged in user is author of nomination' do
+          before do
+            fake_login_known_user(tag_setter)
+          end
+
+          context 'user is not moderator of tag set' do
+            it 'renders the show template' do
+              tag_setter.reload # Whywhywhywhy
+
+              get :show, id: tag_set_nomination.id, tag_set_id: owned_tag_set.id
+              expect(response).to render_template("show")
+            end
+          end
+
+          context 'user is also moderator of tag set' do
+            before do
+              owned_tag_set.add_moderator(tag_setter_pseud)
+              owned_tag_set.save!
+              tag_setter.reload
+            end
+
+            it 'renders the show template' do
+              get :show, id: tag_set_nomination.id, tag_set_id: owned_tag_set.id
+              expect(response).to render_template("show")
+            end
+          end
+        end
+      end
+    end
   end
 
   describe 'POST create' do


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-4830

## Purpose

This is my first code change to the otwarchive repository, so I'm hoping someone can help set me straight on any otw style guidelines or best practices that I've disregarded!

This is to increase code coverage of tag_set_nominations_controller.rb. Code coverage in coveralls will increase from [68.34%](https://coveralls.io/builds/9916720/source?filename=app%2Fcontrollers%2Ftag_set_nominations_controller.rb) to [96.98%](https://coveralls.io/builds/9900548/source?filename=app%2Fcontrollers%2Ftag_set_nominations_controller.rb). \o/

Previously, tag_set_nominations_controller.rb was covered primarily with Cucumber tests. This code change will add additional unit test coverage.

Other open TODO items I'd like some help with:
There were 3 error handling paths in the controller that I wasn't sure how to set up to test:
1. In TagSetNominationsController.load_tag_set:22 - Is it possible to test the case where OwnedTagSet.find returns a falsey value, but doesn't raise an ActiveRecord error?
2. In TagSetNominationsController.load_nomination:30 - Is it possible to test the case where TagSetNomination.find returns a falsey value, but doesn't raise an ActiveRecord error?
3. In TagSetNominationsController#index:82 - Is it possible to test the case where OwnedTagSet.find returns a falsey value, but doesn't raise an ActiveRecord error?

~~I also wasn't sure what params would trigger the flash notice in TagSetNominationsController.request_noncanonical_info. I did set up some specs to test this (line 825 and 992), but I'd have preferred to use params that could actually be triggered by a real user through the UI. If someone knows better params to use here to test this code path, that would be very great.~~ Addressing this in [AO3-4856](https://otwarchive.atlassian.net/browse/AO3-4856).

## Testing

Use Coveralls to confirm that the coverage percentage has increased:
1. Go to https://coveralls.io/github/otwcode/otwarchive?branch=master 
2. In the "Search" field near the "Source Files on Master" heading, enter the name of the controller: tag_set_nominations_controller.rb
3. Note the number in the "Coverage" column of the table

## Credit

*What name do you want us to use to credit your work in the [Archive of Our Own's Release Notes](http://archiveofourown.org/admin_posts?tag=1)?*
cyrilcee

*What pronouns do you prefer (she/her, he/him, zie/hir etc)?*
she/her
