### PR TITLE
AO3-4407 Only mention user invites on homepage to logged out visitors when user invites are turned on

### DIFF
--- a/app/views/home/_intro_module.html.erb
+++ b/app/views/home/_intro_module.html.erb
@@ -1,26 +1,26 @@
 <div class="intro module">
-  <h2 class="heading"><%= ts('A fan-created, fan-run, non-profit, non-commercial archive for transformative fanworks, like fanfiction, fanart, fan videos, and podfic') %></h2>
-  <p class="stats"><%= ts('more than %{fandom_count} fandoms | %{user_count} users | %{work_count} works', fandom_count: content_tag(:span, @fandom_count, class: 'count'), user_count: content_tag(:span, @user_count, class: 'count'), work_count: content_tag(:span, @work_count, class: 'count')).html_safe %></p>
-  <p class="parent"><%= ts('The Archive of Our Own is a project of the') %> <%= link_to ts('Organization for Transformative Works'), 'http://transformativeworks.org' %>.</p>
+  <h2 class="heading"><%= ts("A fan-created, fan-run, non-profit, non-commercial archive for transformative fanworks, like fanfiction, fanart, fan videos, and podfic") %></h2>
+  <p class="stats"><%= ts("more than %{fandom_count} fandoms | %{user_count} users | %{work_count} works", fandom_count: content_tag(:span, @fandom_count, class: "count"), user_count: content_tag(:span, @user_count, class: "count"), work_count: content_tag(:span, @work_count, class: "count")).html_safe %></p>
+  <p class="parent"><%= ts("The Archive of Our Own is a project of the") %> <%= link_to ts("Organization for Transformative Works"), "http://transformativeworks.org" %>.</p>
 
   <div class="account module">
-    <h4 class="heading"><%= ts('With an %{short_name} account, you can:', short_name: ArchiveConfig.APP_SHORT_NAME) %></h4>
+    <h4 class="heading"><%= ts("With an %{short_name} account, you can:", short_name: ArchiveConfig.APP_SHORT_NAME) %></h4>
     <ul>
-      <li><%= ts('Share your own fanworks') %></li>
-      <li><%= ts('Get notified when your favorite works, series, or users update') %></li>
-      <li><%= ts('Participate in challenges') %></li>
-      <li><%= ts('Keep track of works you\'ve visited and works you want to check out later') %></li>
+      <li><%= ts("Share your own fanworks") %></li>
+      <li><%= ts("Get notified when your favorite works, series, or users update") %></li>
+      <li><%= ts("Participate in challenges") %></li>
+      <li><%= ts("Keep track of works you've visited and works you want to check out later") %></li>
     </ul>
 
 
     <% if @admin_settings.invite_from_queue_enabled? && @admin_settings.creation_requires_invite? && @admin_settings.request_invite_enabled? %>
-      <p><%= ts('While the site is in beta, you can join by getting an invitation from another user or from our automated invite queue. All fans and fanworks are welcome!') %></p>
-      <p class="actions"><%= link_to ts('Get Invited!'), invite_requests_path %></p>
+      <p><%= ts("While the site is in beta, you can join by getting an invitation from another user or from our automated invite queue. All fans and fanworks are welcome!") %></p>
+      <p class="actions"><%= link_to ts("Get Invited!"), invite_requests_path %></p>
     <% elsif @admin_settings.invite_from_queue_enabled? && @admin_settings.creation_requires_invite? %>
-      <p><%= ts('While the site is in beta, you can join by getting an invitation from our automated invite queue. All fans and fanworks are welcome!') %></p>
-      <p class="actions"><%= link_to ts('Get Invited!'), invite_requests_path %></p>
+      <p><%= ts("While the site is in beta, you can join by getting an invitation from our automated invite queue. All fans and fanworks are welcome!") %></p>
+      <p class="actions"><%= link_to ts("Get Invited!"), invite_requests_path %></p>
     <% elsif @admin_settings.account_creation_enabled? && !@admin_settings.creation_requires_invite? %>
-      <p class="actions"><%= link_to ts('Create an Account!'), new_user_path %></p>
+      <p class="actions"><%= link_to ts("Create an Account!"), new_user_path %></p>
     <% end %>
   </div>
 </div>

--- a/app/views/home/_intro_module.html.erb
+++ b/app/views/home/_intro_module.html.erb
@@ -12,8 +12,12 @@
       <li><%= ts('Keep track of works you\'ve visited and works you want to check out later') %></li>
     </ul>
 
-    <% if @admin_settings.invite_from_queue_enabled? && @admin_settings.creation_requires_invite? %>
+
+    <% if @admin_settings.invite_from_queue_enabled? && @admin_settings.creation_requires_invite? && @admin_settings.request_invite_enabled? %>
       <p><%= ts('While the site is in beta, you can join by getting an invitation from another user or from our automated invite queue. All fans and fanworks are welcome!') %></p>
+      <p class="actions"><%= link_to ts('Get Invited!'), invite_requests_path %></p>
+    <% elsif @admin_settings.invite_from_queue_enabled? && @admin_settings.creation_requires_invite? %>
+      <p><%= ts('While the site is in beta, you can join by getting an invitation from our automated invite queue. All fans and fanworks are welcome!') %></p>
       <p class="actions"><%= link_to ts('Get Invited!'), invite_requests_path %></p>
     <% elsif @admin_settings.account_creation_enabled? && !@admin_settings.creation_requires_invite? %>
       <p class="actions"><%= link_to ts('Create an Account!'), new_user_path %></p>

--- a/features/admins/admin_invitations.feature
+++ b/features/admins/admin_invitations.feature
@@ -79,7 +79,7 @@ Feature: Admin Actions to Manage Invitations
       And I go to the admin-settings page
       And I uncheck "Account creation enabled"
       And I check "Account creation requires invitation"
-      And I uncheck "Users can request invitations"
+      And I check "Users can request invitations"
       And I check "Invite from queue enabled (People can add themselves to the queue and invitations are sent out automatically)"
       And I press "Update"
       And I am logged out as an admin

--- a/features/admins/admin_invitations.feature
+++ b/features/admins/admin_invitations.feature
@@ -53,7 +53,7 @@ Feature: Admin Actions to Manage Invitations
       And I am logged out as an admin
     When I go to the home page
     Then I should see "Get Invited!"
-      And I should see "While the site is in beta, you can join by getting an invitation from another user or from our automated invite queue. All fans and fanworks are welcome!"
+      And I should see "While the site is in beta, you can join by getting an invitation from our automated invite queue. All fans and fanworks are welcome!"
       And I should not see "Create an Account!"
     When I go to account creation page
     Then I should be on invite requests page
@@ -160,7 +160,7 @@ Feature: Admin Actions to Manage Invitations
       And I am logged out as an admin
     When I go to the home page
     Then I should see "Get Invited!"
-      And I should see "While the site is in beta, you can join by getting an invitation from another user or from our automated invite queue. All fans and fanworks are welcome!"
+      And I should see "While the site is in beta, you can join by getting an invitation from our automated invite queue. All fans and fanworks are welcome!"
       And I should not see "Create an Account!"
 
   Scenario: Account creation enabled, invitations not required, users cannot request invitations, and the queue is disabled


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-4407

## Purpose

on the homepage, logged out users were encouraged to ask friends for invites even when user invite requests were turned off in the admin panel. with this, the homepage only shows logged out users "you can join by getting an invitation from another user" when user invite requests are turned on

## Testing

please make sure that when user invite requests are turned off, the homepage does not show logged out users "you can join by getting an invitation from another user"

and please make sure that when user invite requests are turned on, the homepage does show logged out users "you can join by getting an invitation from another user"

for good measure, please also check that when account creation is enabled, neither the invite queue nor the user invite is mentioned on the homepage