### PR TITLE
AO3-4849 Fix opendoors contact url, replace Admin with admin

### DIFF
--- a/app/controllers/user_invite_requests_controller.rb
+++ b/app/controllers/user_invite_requests_controller.rb
@@ -43,7 +43,7 @@ class UserInviteRequestsController < ApplicationController
         render :action => "new"
       end
     else
-      flash[:error] = ts("Sorry, new invitations are temporarily unavailable. If you are the mod of a challenge currently being run on the Archive, please <a href=\"#{new_feedback_report_url}\">contact Support</a>. If you are the maintainer of an at-risk archive, please contact <a href=\"http://opendoors.transformativeworks.org/contact/open doors\">Open Doors</a>".html_safe)
+      flash[:error] = ts("Sorry, new invitations are temporarily unavailable. If you are the mod of a challenge currently being run on the Archive, please <a href=\"#{new_feedback_report_url}\">contact Support</a>. If you are the maintainer of an at-risk archive, please contact <a href=\"http://opendoors.transformativeworks.org/contact-open-doors/\">Open Doors</a>".html_safe)
       redirect_to root_path
     end
   end

--- a/app/helpers/mailer_helper.rb
+++ b/app/helpers/mailer_helper.rb
@@ -41,7 +41,7 @@ module MailerHelper
   end
 
   def opendoors_link(text)
-    style_link(text, "http://opendoors.transformativeworks.org/contact/open%20doors")
+    style_link(text, "http://opendoors.transformativeworks.org/contact-open-doors/")
   end
   
   def styled_divider

--- a/app/views/user_mailer/admin_deleted_work_notification.text.erb
+++ b/app/views/user_mailer/admin_deleted_work_notification.text.erb
@@ -3,7 +3,7 @@
 
 <%= t('.text.part1', title: @work.title) %>
 
-<%= t('.text.part2', opendoors_link: 'http://opendoors.transformativeworks.org/contact/open%20doors') %>
+<%= t('.text.part2', opendoors_link: 'http://opendoors.transformativeworks.org/contact-open-doors/') %>
 
 <%= t('.text.part3', abuse_link: new_abuse_report_url) %>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -54,7 +54,7 @@ en:
           Cheers, 
           %{archive_name}
     admin_deleted_work_notification:
-      subject: "[%{app_name}] Your work has been deleted by an Admin"
+      subject: "[%{app_name}] Your work has been deleted by an admin"
       hello: "Dear %{user},"
       opendoors: "contact Open Doors"
       abuse_committee: "contact our Abuse Committee"


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-4306
https://otwarchive.atlassian.net/browse/AO3-4849

## Purpose

Change the subject line of the email to have a lower case a in admin.
Replace the old opendoors contact page with the new one.

## Testing

Check the email
