### PR TITLE
AO3-4305 fix issues found on test

### DIFF
--- a/app/views/user_mailer/delete_work_notification.text.erb
+++ b/app/views/user_mailer/delete_work_notification.text.erb
@@ -1,11 +1,13 @@
 <% content_for :message do %>
 <%= t('.hello', user:  @user.default_pseud.byline) %>
+
 <%= (@work.pseuds.count > 1 && @user != User.current_user) ?
 t('.part1_other',
         title: @work.title,
-        pseud: User.current_user.default_pseud) :
+        pseud: text_pseud(User.current_user.default_pseud)) :
 t('.part1_yourself',
         title: @work.title) %>
+
 <%= t('.text.part2', support: t('.support'), url: new_feedback_report_url) %>
 
 <%= t('.part3') %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -71,14 +71,14 @@ en:
       subject: "[%{app_name}] Your work has been deleted"
       support: "contact Support"
       hello: "Dear %{user},"
-      part1_other: "Your work %{title} was deleted at the request of %{pseud}."
-      part1_yourself: "Your work %{title} was deleted at your request."
+      part1_other: "Your work \"%{title}\" was deleted at the request of %{pseud}."
+      part1_yourself: "Your work \"%{title}\" was deleted at your request."
       part2: "If you have questions, please %{support}."
       part3: "Attached is a copy of your work for your reference."
       html:
         part2: "If you have questions, please %{support}."
       text:
-        part2: "If you have questions, please %{support} %{url}."
+        part2: "If you have questions, please %{support} (%{url})."
     coauthor_notification:
       subject: "[%{app_name}] Co-creator Notification"
       edit_the_work: "Edit the work"


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-4305

## Purpose

- All text emails need their spacing fixed -- there should be a blank line between paragraphs
- The pseud doesn't show up in the text email that's delivered to the user who did not delete the work
- In the text emails, there should probably be the word "at" between "Support" and the URL, or the URL should be in parentheses or something 
- In the text emails, it would also be nice if we put quotation marks around the work title, like we do in the email for the work being deleted by an admin
