### PR TITLE
AO3-4853 Improve cache busting for a single comment. ( Make tests and coverage more reliable )

### DIFF
--- a/app/views/comments/_single_comment.html.erb
+++ b/app/views/comments/_single_comment.html.erb
@@ -14,7 +14,7 @@
     <% elsif single_comment.hidden_by_admin? && !logged_in_as_admin? %>
       <p class="message"><%= ts("(This comment is under review by an admin and is currently unavailable.)") %></p>
     <% else %>
-      <% cache(single_comment, :expires_in => 1.week ) do %>
+      <% cache(key: "/v1/single_comment/#{single_comment.id}/#{single_comment.edited_at}/#{single_comment.updated_at}", expires_in: 1.week ) do %>
         <% # FRONT END, update this if a.user comes in %>
         <h4 class="heading byline">
           <% if !single_comment.pseud.nil? %>


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-4853

## Purpose

This should both make the tests more reliable and also make so we are less likely to have comments not appearing.

## Testing

Create a comment and ensure it is visible.
