### PR TITLE
AO3-4834 Fix unreachable branch in owned_tag_sets_controller

### DIFF
--- a/app/controllers/owned_tag_sets_controller.rb
+++ b/app/controllers/owned_tag_sets_controller.rb
@@ -44,15 +44,15 @@ class OwnedTagSetsController < ApplicationController
         @query = params[:query]
         @tag_sets = @tag_sets.where("title LIKE ?", '%' + params[:query] + '%')
       else
-        # show a random selection 
+        # show a random selection
         @tag_sets = @tag_sets.order("created_at DESC")
       end
     end
     @tag_sets = @tag_sets.paginate(:per_page => (params[:per_page] || ArchiveConfig.ITEMS_PER_PAGE), :page => (params[:page] || 1))
   end
-  
+
   def show_options
-    @restriction = PromptRestriction.find(params[:restriction])
+    @restriction = PromptRestriction.find_by_id(params[:restriction])
     unless @restriction
       flash[:error] = ts("Which Tag Set did you want to look at?")
       redirect_to tag_sets_path and return

--- a/spec/controllers/owned_tag_sets_controller_spec.rb
+++ b/spec/controllers/owned_tag_sets_controller_spec.rb
@@ -70,6 +70,13 @@ describe OwnedTagSetsController do
         get :show_options, params
       end
 
+      context "where the restriction isn't found" do
+        it "displays an error and redirects" do
+          get :show_options
+          it_redirects_to_with_error(tag_sets_path, "Which Tag Set did you want to look at?")
+        end
+      end
+
       context "where tag_type isn't specified" do
         it "then sets the correct tags with the type fandom" do
           expect(assigns(:tag_sets)).to include(*fandom_tag_sets)


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-4834 

## Purpose

Fixing an unreachable branch in owned_tag_sets_controller. If the restriction isn't found with the show_options action, redirect to the tag sets path and display a flash error.

## Testing

Navigate to /tag_sets/show_options. It should redirect back to /tag_sets with a flash error saying, "Which Tag Set did you want to look at?"

## Credit

potatoesque, she/her
