### PR TITLE
AO3-4835 Fix unreachable branch in owned_tag_sets_controller

### DIFF
--- a/app/controllers/owned_tag_sets_controller.rb
+++ b/app/controllers/owned_tag_sets_controller.rb
@@ -5,19 +5,19 @@ class OwnedTagSetsController < ApplicationController
   before_filter :users_only, :only => [ :new, :create, :nominate ]
   before_filter :moderators_only, :except => [ :index, :new, :create, :show, :show_options ]
   before_filter :owners_only, :only => [ :destroy ]
-  
+
   def load_tag_set
-    @tag_set = OwnedTagSet.find(params[:id])
+    @tag_set = OwnedTagSet.find_by_id(params[:id])
     unless @tag_set
       flash[:notice] = ts("What Tag Set did you want to look at?")
       redirect_to tag_sets_path and return
     end
   end
-  
+
   def moderators_only
     @tag_set.user_is_moderator?(current_user) || access_denied
   end
-  
+
   def owners_only
     @tag_set.user_is_owner?(current_user) || access_denied
   end

--- a/spec/controllers/owned_tag_sets_controller_spec.rb
+++ b/spec/controllers/owned_tag_sets_controller_spec.rb
@@ -104,6 +104,13 @@ describe OwnedTagSetsController do
   end
 
   describe "show" do
+    context "where tag set is not found" do
+      it "redirects and displays a notice" do
+        get :show, id: 12345
+        it_redirects_to_with_notice(tag_sets_path, "What Tag Set did you want to look at?")
+      end
+    end
+
     context "where tag set is found" do
       let(:visible) { false }
       let(:tag) { create(:character) }


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-4835

## Purpose

Previously when tag_set is not found by load_tag_set, it would raise an ActiveRecord error and return a 500. Now, it redirects to the tag set path and displays a flash notice (the previously unreachable branch).

## Testing

Navigate to /tag_sets/{some tag set id that doesn't exist} (i.e. /tag_sets/12345). It should redirect to /tag_sets and have a flash notice that says "What Tag Set did you want to look at?"

## Credit

potatoesque, she/her
