### PR TITLE
AO3-4716 Correct id on bulk email search footnote

### DIFF
--- a/app/views/admin/admin_users/bulk_search.html.erb
+++ b/app/views/admin/admin_users/bulk_search.html.erb
@@ -13,8 +13,8 @@
       <legend><%= ts("Email addresses") %></legend>
       <dl>
         <dt class="required"><%= label_tag "emails", ts("Email addresses *") %></dt>
-        <dd class="required"><%= text_area_tag "emails", @emails ? @emails.join("\n") : "", rows: 10, cols: 70, "aria-describedby" => "url-field-description" %>
-          <p class="footnote" id="url-field-description">
+        <dd class="required"><%= text_area_tag "emails", @emails ? @emails.join("\n") : "", rows: 10, cols: 70, "aria-describedby" => "email-field-description" %>
+          <p class="footnote" id="email-field-description">
             <%= ts("Emails to find; <strong>one URL per line.</strong>").html_safe %>
           </p>
         </dd>


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-4716

## Purpose

This addresses the copy-pasted `url-field-description` which should have been changed to `email-field-description` just for the sake of coherence.

## Testing

Check the ids in the HTML - they will be used by screenreaders that use the `aria-describedby` attribute.