### PR TITLE
AO3-4863 Make error in reindex method a flash error rather than a notice

### DIFF
--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -768,7 +768,7 @@ class WorksController < ApplicationController
       RedisSearchIndexQueue.queue_works([params[:id]], priority: :high)
       flash[:notice] = ts('Work queued to be reindexed')
     else
-      flash[:notice] = ts("Sorry, you don't have permission to perform this action.")
+      flash[:error] = ts("Sorry, you don't have permission to perform this action.")
     end
     redirect_to(request.env['HTTP_REFERER'] || root_path)
   end

--- a/spec/controllers/works/miscellaneous_spec.rb
+++ b/spec/controllers/works/miscellaneous_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+require "spec_helper"
+
+describe WorksController do
+  include LoginMacros
+  include RedirectExpectationHelper
+
+  context "reindex" do
+    let(:work) { create(:work) }
+
+    context "if the user is an admin or tag wrangler" do
+      let(:user) { create(:user) }
+
+      before do
+        fake_login_admin(user)
+      end
+
+      it "should queue the work for reindex" do
+        expect(RedisSearchIndexQueue).to receive(:queue_works)
+        post :reindex, { id: work }
+      end
+      it "should redirect to the root path and display a success message" do
+        post :reindex, { id: work }
+        it_redirects_to_with_notice(root_path, "Work queued to be reindexed")
+      end
+    end
+
+    context "if the user is not an admin" do
+      it "should redirect to the root path and display an error" do
+        fake_login
+        post :reindex, { id: work }
+        it_redirects_to_with_error(root_path, "Sorry, you don't have permission to perform this action.")
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-4863

## Purpose

The error displayed by the reindex method was in a notice rather than an error flash message, so this corrects that.

## Testing

If you can trigger reindexing as an ordinary user, check that the error is displayed in a red box - however, this is covered by the automated test and looking at the code, it's probably difficult to trigger manually.