### PR TITLE
AO3-4875 Claim external authors by id as well as email

### DIFF
--- a/app/models/external_author.rb
+++ b/app/models/external_author.rb
@@ -135,7 +135,7 @@ class ExternalAuthor < ActiveRecord::Base
 
   def find_or_invite(archivist = nil)
     if self.email
-      matching_user = User.find_by_email(self.email)
+      matching_user = User.find_by_email(self.email) || User.find_by_id(self.user_id)
       if matching_user
         self.claim!(matching_user)
       else

--- a/app/models/external_author.rb
+++ b/app/models/external_author.rb
@@ -141,12 +141,11 @@ class ExternalAuthor < ActiveRecord::Base
       else
         # invite person at the email address unless they don't want invites
         unless self.do_not_email
-          @invitation = Invitation.new(:invitee_email => self.email, :external_author => self, :creator => User.current_user)
+          @invitation = Invitation.new(invitee_email: self.email, external_author: self, creator: User.current_user)
           @invitation.save
         end
       end
     end
-    # eventually we may want to try finding authors by pseud?
   end
 
 end

--- a/spec/models/external_author_spec.rb
+++ b/spec/models/external_author_spec.rb
@@ -1,0 +1,49 @@
+require 'spec_helper'
+require 'support/login_macros'
+
+describe ExternalAuthor, type: :model do
+  include LoginMacros
+
+  describe "find_or_invite" do
+    let(:unclaimed_user) { create(:user) }
+    let(:claimed_user) { create(:user) }
+    let(:unclaimed_ext_author) { create(:external_author, is_claimed: false) }
+    let(:unclaimed_user_author) { create(:external_author, email: unclaimed_user.email, is_claimed: false) }
+    let(:claimed_ext_author) { create(:external_author, user_id: claimed_user.id, is_claimed: true) }
+    let(:archivist) { create_archivist }
+
+    context "a user with a matching email exists" do
+      subject { unclaimed_user_author }
+
+      it "should automatically be claimed by the user" do
+        subject.find_or_invite(archivist)
+        expect(subject.claimed?).to eq(true)
+        expect(subject.user_id).to eq(unclaimed_user.id)
+      end
+    end
+
+    context "a claimed external user with a matching email exists" do
+      subject { claimed_ext_author }
+
+      it "should automatically be claimed by the corresponding user" do
+        expect(subject).to receive(:claim!).with(claimed_user)
+        subject.find_or_invite(archivist)
+      end
+
+      it "should not send an invitation email" do
+        expect(Invitation).to_not receive(:new)
+        subject.find_or_invite(archivist)
+      end
+    end
+
+    context "no external author or user with a matching email exists" do
+      subject { unclaimed_ext_author }
+
+      it "should generate an invite for the email address" do
+        expect(Invitation).to receive(:new).and_call_original
+        subject.find_or_invite(archivist)
+      end
+    end
+
+  end
+end

--- a/spec/models/external_author_spec.rb
+++ b/spec/models/external_author_spec.rb
@@ -15,7 +15,7 @@ describe ExternalAuthor, type: :model do
     context "a user with a matching email exists" do
       subject { unclaimed_user_author }
 
-      it "should automatically be claimed by the user" do
+      it "is automatically claimed by the user" do
         subject.find_or_invite(archivist)
         expect(subject.claimed?).to eq(true)
         expect(subject.user_id).to eq(unclaimed_user.id)
@@ -25,12 +25,12 @@ describe ExternalAuthor, type: :model do
     context "a claimed external user with a matching email exists" do
       subject { claimed_ext_author }
 
-      it "should automatically be claimed by the corresponding user" do
+      it "is automatically claimed by the corresponding user" do
         expect(subject).to receive(:claim!).with(claimed_user)
         subject.find_or_invite(archivist)
       end
 
-      it "should not send an invitation email" do
+      it "does NOT generate an invitation email" do
         expect(Invitation).to_not receive(:new)
         subject.find_or_invite(archivist)
       end
@@ -39,7 +39,7 @@ describe ExternalAuthor, type: :model do
     context "no external author or user with a matching email exists" do
       subject { unclaimed_ext_author }
 
-      it "should generate an invite for the email address" do
+      it "generates an invitation email" do
         expect(Invitation).to receive(:new).and_call_original
         subject.find_or_invite(archivist)
       end


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-4875

## Purpose

If a work is imported from an external site, and external author is created with the author's email from that site. A claim email is sent to the email address; the user can then claim this external author identity to associate it with their AO3 account.

Currently, if the email address is the same on the external author and the user, future imports will be automatically transferred to the user. But if the emails are different, the works remain in a weird limbo with a broken byline that only mentions the archivist.

This code now checks if the external author is already claimed by a user and transfers the works even if the email addresses don't match.

## Testing

1. As an archivist, import a work with an email address that doesn't match an existing Archive user.
2. This will send an invitation email to the email address. Use this to claim the work imported in step 1 as an existing Archive user with a different email address.
3. Import another work with the same email address as in step 1. Previously, this work would have triggered an invitation to claim email and appeared with the archivist's name in the byline. Now, it should appear with the Archive user's name only.

