### PR TITLE
AO3-4877 Fix gift exchange sign-ups CSV downloads

### DIFF
--- a/app/controllers/challenge_signups_controller.rb
+++ b/app/controllers/challenge_signups_controller.rb
@@ -293,7 +293,7 @@ protected
           row += request_to_array(type, signup.send(type.pluralize)[i])
         end
       end
-      csv << row
+      csv_array << row
     end
 
     csv_array

--- a/factories/challenges.rb
+++ b/factories/challenges.rb
@@ -24,5 +24,22 @@ FactoryGirl.define do
       potential_match.request_signup_id = FactoryGirl.create(:challenge_signup, collection_id: potential_match.collection_id)
     end
   end  
-  
+
+  factory :gift_exchange do
+    after(:build) do |ge|
+      ge.offer_restriction_id = create(:prompt_restriction).id
+      ge.request_restriction_id = create(:prompt_restriction).id
+      ge.prompt_restriction_id = create(:prompt_restriction).id
+    end
+  end
+
+  factory :offer
+  factory :request
+
+  factory :prompt_meme do
+    after(:build) do |pm|
+      pm.request_restriction_id = create(:prompt_restriction).id
+      pm.prompt_restriction_id = create(:prompt_restriction).id
+    end
+  end
 end

--- a/factories/tags.rb
+++ b/factories/tags.rb
@@ -13,6 +13,10 @@ FactoryGirl.define do
     association :filterable, factory: :fandom
   end
 
+  factory :tag_set do
+    tags { [create(:fandom)] }
+  end
+
   factory :owned_tag_set do
     title { generate(:tag_title) }
     nominated true

--- a/spec/controllers/challenge_signups_controller_spec.rb
+++ b/spec/controllers/challenge_signups_controller_spec.rb
@@ -1,0 +1,61 @@
+require 'spec_helper'
+
+describe ChallengeSignupsController, type: :controller do
+
+  let(:tag_set1) { create(:tag_set) }
+  let(:signup) { create(:challenge_signup) }
+
+
+  describe "gift_exchange_to_csv" do
+    let(:tag_set2) { create(:tag_set) }
+    let(:gift_exchange) { create(:gift_exchange) }
+    let(:collection) { create(:collection,
+                              challenge: gift_exchange,
+                              challenge_type: "GiftExchange",
+                              signups: [signup]) }
+
+    before do
+      signup.offers = [create(:offer,
+                              collection_id: collection.id,
+                              challenge_signup_id: signup.id,
+                              tag_set: tag_set1)]
+      signup.requests = [create(:request,
+                                collection_id: collection.id,
+                                challenge_signup_id: signup.id,
+                                tag_set: tag_set2)]
+    end
+
+    it "generates a CSV with all the challenge information" do
+      controller.instance_variable_set(:@challenge, collection.challenge)
+      controller.instance_variable_set(:@collection, collection)
+      expect(controller.send(:gift_exchange_to_csv))
+        .to eq([["Pseud", "Email", "Sign-up URL", "Request 1 Tags", "Request 1 Description", "Offer 1 Tags", "Offer 1 Description"],
+                [signup.pseud.name, signup.pseud.user.email, collection_signup_url(collection, signup),
+                 signup.requests.first.tag_set.tags.first.name, "", signup.offers.first.tag_set.tags.first.name, ""]])
+    end
+  end
+
+  describe "prompt_meme_to_csv" do
+    let(:prompt_meme) { create(:prompt_meme) }
+    let(:collection) { create(:collection,
+                              challenge: prompt_meme,
+                              challenge_type: "PromptMeme",
+                              signups: [signup]) }
+
+    before do
+      signup.requests = [create(:request,
+                                collection_id: collection.id,
+                                challenge_signup_id: signup.id,
+                                tag_set: tag_set1)]
+    end
+
+    it "generates a CSV with all the challenge information" do
+      controller.instance_variable_set(:@challenge, collection.challenge)
+      controller.instance_variable_set(:@collection, collection)
+      expect(controller.send(:prompt_meme_to_csv))
+        .to eq([["Pseud", "Email", "Sign-up URL", "Tags", "Description"],
+                [signup.pseud.name, signup.pseud.user.email, collection_signup_url(collection, signup),
+                 signup.requests.first.tag_set.tags.first.name, ""]])
+    end
+  end
+end

--- a/spec/controllers/challenge_signups_controller_spec.rb
+++ b/spec/controllers/challenge_signups_controller_spec.rb
@@ -5,7 +5,6 @@ describe ChallengeSignupsController, type: :controller do
   let(:tag_set1) { create(:tag_set) }
   let(:signup) { create(:challenge_signup) }
 
-
   describe "gift_exchange_to_csv" do
     let(:tag_set2) { create(:tag_set) }
     let(:gift_exchange) { create(:gift_exchange) }

--- a/spec/controllers/owned_tag_sets_controller_spec.rb
+++ b/spec/controllers/owned_tag_sets_controller_spec.rb
@@ -81,8 +81,8 @@ describe OwnedTagSetsController do
         it "then sets the correct tags with the type fandom" do
           expect(assigns(:tag_sets)).to include(*fandom_tag_sets)
           expect(assigns(:tag_sets)).to include(character_tag_set)
-          expect(assigns(:tag_set_ids)).to include(*fandom_tag_sets.map(&:id))
-          expect(assigns(:tag_set_ids)).to include character_tag_set.id
+          expect(assigns(:tag_set_ids)).to include(*fandom_tag_sets.map(&:tag_set_id))
+          expect(assigns(:tag_set_ids)).to include character_tag_set.tag_set_id
           expect(assigns(:tag_type)).to eq "fandom"
           fandom_tag_sets.each do |tag_set|
             expect(assigns(:tags)).to include(*tag_set.tags)
@@ -98,8 +98,8 @@ describe OwnedTagSetsController do
         it "sets the correct tags with the type character" do
           expect(assigns(:tag_sets)).to include(*fandom_tag_sets)
           expect(assigns(:tag_sets)).to include(character_tag_set)
-          expect(assigns(:tag_set_ids)).to include(*fandom_tag_sets.map(&:id))
-          expect(assigns(:tag_set_ids)).to include character_tag_set.id
+          expect(assigns(:tag_set_ids)).to include(*fandom_tag_sets.map(&:tag_set_id))
+          expect(assigns(:tag_set_ids)).to include character_tag_set.tag_set_id
           expect(assigns(:tag_type)).to eq "character"
           fandom_tag_sets.each do |tag_set|
             expect(assigns(:tags)).to_not include(*tag_set.tags)


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-4877

## Purpose

This fixes the bug introduced in release 0.9.180 which prevents gift exchange sign-ups from being downloaded as a CSV file.

## Testing

Try to download the CSV for a gift exchange. This was consistently broken but should now work.
