### PR TITLE
AO3-4480 cache the find_by_url call

### DIFF
--- a/app/models/story_parser.rb
+++ b/app/models/story_parser.rb
@@ -105,6 +105,7 @@ class StoryParser
         work.delete if work
       end
     end
+    Work.flush_find_by_url_cache
     return [works, failed_urls, errors]
   end
 

--- a/app/models/story_parser.rb
+++ b/app/models/story_parser.rb
@@ -350,6 +350,7 @@ class StoryParser
         # ack! causing the chapters to exist even if work doesn't get created!
         # chapter.save
       end
+      Work.flush_find_by_url_cache
       return work
     end
 

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -306,20 +306,39 @@ class Work < ActiveRecord::Base
   # IMPORTING
   ########################################################################
 
+  def self.find_by_url_generation_key
+    "/v1/find_by_url_generation_key"
+  end
+
+  def self.find_by_url_generation
+    Rails.cache.fetch(Work.find_by_url_generation_key, :raw => true) { rand(1..1000) } 
+  end
+
+  def self.flush_find_by_url_cache
+    Rails.cache.increment(Work.find_by_url_generation_key)
+  end
+
+  def self.find_by_url_cache_key(url)
+    url = UrlFormatter.new(url)
+    "/v1/find_by_url/#{Work.find_by_url_generation}/#{url.minimal}"
+  end
+
   # Match `url` to a work's imported_from_url field using progressively fuzzier matching:
   # 1. first exact match
   # 2. first exact match with variants of the provided url
   # 3. first match on variants of both the imported_from_url and the provided url if there is a partial match
   def self.find_by_url(url)
-    url = UrlFormatter.new(url)
-    Work.where(:imported_from_url => url.original).first ||
-      Work.where(:imported_from_url => [url.minimal, url.no_www, url.with_www, url.encoded, url.decoded]).first ||
-      Work.where("imported_from_url LIKE ?", "%#{url.minimal_no_http}%").select { |w|
-        work_url = UrlFormatter.new(w.imported_from_url)
-        ['original', 'minimal', 'no_www', 'with_www', 'encoded', 'decoded'].any? { |method|
-          work_url.send(method) == url.send(method)
-        }
-      }.first
+    Rails.cache.fetch(Work.find_by_url_cache_key(url)) do
+      url = UrlFormatter.new(url)
+      Work.where(:imported_from_url => url.original).first ||
+        Work.where(:imported_from_url => [url.minimal, url.no_www, url.with_www, url.encoded, url.decoded]).first ||
+        Work.where("imported_from_url LIKE ?", "%#{url.minimal_no_http}%").select { |w|
+          work_url = UrlFormatter.new(w.imported_from_url)
+          ['original', 'minimal', 'no_www', 'with_www', 'encoded', 'decoded'].any? { |method|
+            work_url.send(method) == url.send(method)
+          }
+        }.first
+    end
   end
 
   ########################################################################

--- a/features/importing/work_import.feature
+++ b/features/importing/work_import.feature
@@ -222,20 +222,21 @@ Feature: Import Works
       And I should see "English"
 
   Scenario: Searching for a work url should be cached
-    Then there should be no work cached for "http://www.scarvesandcoffee.net/viewstory.php?sid=9570"
+    Then there should be no work_url cached for "http://www.scarvesandcoffee.net/viewstory.php?sid=9570"
     When I import "http://www.scarvesandcoffee.net/viewstory.php?sid=9570"
     Then I should see "Preview"
     When I press "Post"
-    Then there should be no work cached for "http://www.scarvesandcoffee.net/viewstory.php?sid=9570"
-      And there should be a work cached for "http://www.scarvesandcoffee.net/viewstory.php?sid=9570"
+    Then there should be no work_url cached for "http://www.scarvesandcoffee.net/viewstory.php?sid=9570"
+    When I look for a work with url "http://www.scarvesandcoffee.net/viewstory.php?sid=9570"
+    Then there should be a work_url cached for "http://www.scarvesandcoffee.net/viewstory.php?sid=9570"
     When I import "http://www.intimations.org/fanfic/idol/Huddling.html"
     Then I should see "Preview"
     When I press "Post"
-    Then there should be no work cached for "http://www.scarvesandcoffee.net/viewstory.php?sid=9570"
-      And there should be a work cached for "http://www.scarvesandcoffee.net/viewstory.php?sid=9570"
+    Then there should be no work_url cached for "http://www.scarvesandcoffee.net/viewstory.php?sid=9570"
+    Then there should be no work_url cached for "http://www.intimations.org/fanfic/idol/Huddling.html"
+    When I look for a work with url "http://www.scarvesandcoffee.net/viewstory.php?sid=9570"
+    Then there should be a work_url cached for "http://www.scarvesandcoffee.net/viewstory.php?sid=9570"
+    Then there should be no work_url cached for "http://www.intimations.org/fanfic/idol/Huddling.html"
+    When I look for a work with url "http://www.intimations.org/fanfic/idol/Huddling.html"
+    Then there should be a work_url cached for "http://www.intimations.org/fanfic/idol/Huddling.html"
 
-
-
-
-
-    

--- a/features/importing/work_import.feature
+++ b/features/importing/work_import.feature
@@ -220,3 +220,22 @@ Feature: Import Works
     When I import "http://www.intimations.org/fanfic/idol/Huddling.html"
     Then I should see "Preview"
       And I should see "English"
+
+  Scenario: Searching for a work url should be cached
+    Then there should be no work cached for "http://www.scarvesandcoffee.net/viewstory.php?sid=9570"
+    When I import "http://www.scarvesandcoffee.net/viewstory.php?sid=9570"
+    Then I should see "Preview"
+    When I press "Post"
+    Then there should be no work cached for "http://www.scarvesandcoffee.net/viewstory.php?sid=9570"
+      And there should be a work cached for "http://www.scarvesandcoffee.net/viewstory.php?sid=9570"
+    When I import "http://www.intimations.org/fanfic/idol/Huddling.html"
+    Then I should see "Preview"
+    When I press "Post"
+    Then there should be no work cached for "http://www.scarvesandcoffee.net/viewstory.php?sid=9570"
+      And there should be a work cached for "http://www.scarvesandcoffee.net/viewstory.php?sid=9570"
+
+
+
+
+
+    

--- a/features/step_definitions/work_steps.rb
+++ b/features/step_definitions/work_steps.rb
@@ -91,6 +91,10 @@ When /^I post the works "([^"]*)"$/ do |worklist|
   end
 end
 
+When /^I look for a work with url "([^"]*)"$/ do |url|
+  Work.find_by_url(url)
+end
+
 ### GIVEN
 
 Given(/^I have the Battle set loaded$/) do
@@ -523,7 +527,13 @@ Then /^the work "([^"]*)" should be deleted$/ do |work|
   assert !Work.where(title: work).exists?
 end
 
-Then /^there should be (no|a) work cached for "([^"]*)"$/ do |sense,url|
+Then /^there should be (no|a) work_url cached for "([^"]*)"$/ do |sense,url|
   work = Rails.cache.read(Work.find_by_url_cache_key(url))
-  puts work.inspect, sense
+  if sense == "no"
+    assert work.nil?
+  else
+    assert !work.nil?
+  end
 end
+
+

--- a/features/step_definitions/work_steps.rb
+++ b/features/step_definitions/work_steps.rb
@@ -522,3 +522,8 @@ end
 Then /^the work "([^"]*)" should be deleted$/ do |work|
   assert !Work.where(title: work).exists?
 end
+
+Then /^there should be (no|a) work cached for "([^"]*)"$/ do |sense,url|
+  work = Rails.cache.read(Work.find_by_url_cache_key(url))
+  puts work.inspect, sense
+end


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-4480

## Purpose

The code that is used to redirect from an old archive to an imported one is very slow and can be used to mount a denial of service against us. This code caches the results so should protect against this kind of thing.

## Testing

test.archiveofourown.org/redirect?original_url=http://www.triofic.com/viewstory.php?sid=268 should redirect to http://test.archiveofourown.org/works/1034715

Import a work from a url, test that the redirect would work as above
