### PR TITLE
AO3-4860 Adds strong parameters to Gift Exchange

### DIFF
--- a/app/controllers/challenge/gift_exchange_controller.rb
+++ b/app/controllers/challenge/gift_exchange_controller.rb
@@ -112,7 +112,7 @@ class Challenge::GiftExchangeController < ChallengesController
         :num_required_ratings, :num_required_warnings, :include_optional_fandoms,
         :include_optional_characters, :include_optional_relationships,
         :include_optional_freeforms, :include_optional_categories, :include_optional_ratings,
-        :include_optional_warnings, :max_tags_matched
+        :include_optional_warnings
       ]
     )
   end

--- a/app/controllers/challenge/gift_exchange_controller.rb
+++ b/app/controllers/challenge/gift_exchange_controller.rb
@@ -1,5 +1,5 @@
 class Challenge::GiftExchangeController < ChallengesController
-  
+
   before_filter :users_only
   before_filter :load_collection
   before_filter :load_challenge, :except => [:new, :create]
@@ -34,11 +34,11 @@ class Challenge::GiftExchangeController < ChallengesController
   end
 
   def create
-    @challenge = GiftExchange.new(params[:gift_exchange])
+    @challenge = GiftExchange.new(gift_exchange_params)
     if @challenge.save
       @collection.challenge = @challenge
       @collection.save
-      flash[:notice] = ts('Challenge was successfully created.')      
+      flash[:notice] = ts('Challenge was successfully created.')
       redirect_to collection_profile_path(@collection)
     else
       render :action => :new
@@ -46,12 +46,12 @@ class Challenge::GiftExchangeController < ChallengesController
   end
 
   def update
-    if @challenge.update_attributes(params[:gift_exchange])
+    if @challenge.update_attributes(gift_exchange_params)
       flash[:notice] = ts('Challenge was successfully updated.')
-      
+
       # expire the cache on the signup form
       expire_fragment(:controller => 'challenge_signups', :action => 'new')
-      
+
       # see if we initialized the tag set
       redirect_to collection_profile_path(@collection)
     else
@@ -64,10 +64,60 @@ class Challenge::GiftExchangeController < ChallengesController
     flash[:notice] = 'Challenge settings were deleted.'
     redirect_to @collection
   end
-  
+
   private
+
+  def gift_exchange_params
+    params.require(:gift_exchange).permit(
+      :signup_open, :time_zone, :signups_open_at_string, :signups_close_at_string,
+      :assignments_due_at_string, :requests_summary_visible, :requests_num_required,
+      :requests_num_allowed, :offers_num_required, :offers_num_allowed,
+      :signup_instructions_general, :signup_instructions_requests,
+      :signup_instructions_offers, :request_url_label, :offer_url_label,
+      :offer_description_label, :request_description_label,
+      request_restriction_attributes: [
+        :id, :optional_tags_allowed, :title_required, :title_allowed, :description_required,
+        :description_allowed, :url_required, :url_allowed, :fandom_num_required,
+        :fandom_num_allowed, :allow_any_fandom, :require_unique_fandom,
+        :character_num_required, :character_num_allowed, :allow_any_character,
+        :require_unique_character, :relationship_num_required, :relationship_num_allowed,
+        :allow_any_relationship, :require_unique_relationship, :rating_num_required,
+        :rating_num_allowed, :allow_any_rating, :require_unique_rating,
+        :category_num_required, :category_num_allowed, :allow_any_category,
+        :require_unique_category, :freeform_num_required, :freeform_num_allowed,
+        :allow_any_freeform, :require_unique_freeform, :warning_num_required,
+        :warning_num_allowed, :allow_any_warning, :require_unique_warning
+      ],
+      offer_restriction_attributes: [
+        :id, :optional_tags_allowed, :title_required, :title_allowed,
+        :description_required, :description_allowed, :url_required, :url_allowed,
+        :fandom_num_required, :fandom_num_allowed, :allow_any_fandom,
+        :require_unique_fandom, :character_num_required, :character_num_allowed,
+        :allow_any_character, :require_unique_character, :relationship_num_required,
+        :relationship_num_allowed, :allow_any_relationship, :require_unique_relationship,
+        :rating_num_required, :rating_num_allowed, :rating_num_required, :allow_any_rating, :require_unique_rating,
+        :category_num_required, :category_num_allowed, :allow_any_category,
+        :require_unique_category, :freeform_num_required, :freeform_num_allowed,
+        :allow_any_freeform, :require_unique_freeform, :warning_num_required,
+        :warning_num_allowed, :allow_any_warning, :require_unique_warning,
+        :tag_sets_to_add, :character_restrict_to_fandom,
+        :character_restrict_to_tag_set, :relationship_restrict_to_fandom,
+        :relationship_restrict_to_tag_set,
+        tag_sets_to_remove: []
+      ],
+      potential_match_settings_attributes: [
+        :id, :num_required_prompts, :num_required_fandoms, :num_required_characters,
+        :num_required_relationships, :num_required_freeforms, :num_required_categories,
+        :num_required_ratings, :num_required_warnings, :include_optional_fandoms,
+        :include_optional_characters, :include_optional_relationships,
+        :include_optional_freeforms, :include_optional_categories, :include_optional_ratings,
+        :include_optional_warnings, :max_tags_matched
+      ]
+    )
+  end
+
   def initializing_tag_sets?
-    # uuughly :P but check params to see if we're initializing 
+    # uuughly :P but check params to see if we're initializing
     !params[:gift_exchange][:offer_restriction_attributes].keys.
       select { |k| k =~ /init_(less|greater)/ }.
       select { |k| params[:gift_exchange][:offer_restriction_attributes][k] == '1' }.

--- a/app/controllers/challenge/gift_exchange_controller.rb
+++ b/app/controllers/challenge/gift_exchange_controller.rb
@@ -74,7 +74,8 @@ class Challenge::GiftExchangeController < ChallengesController
       :requests_num_allowed, :offers_num_required, :offers_num_allowed,
       :signup_instructions_general, :signup_instructions_requests,
       :signup_instructions_offers, :request_url_label, :offer_url_label,
-      :offer_description_label, :request_description_label,
+      :offer_description_label, :request_description_label, :works_reveal_at_string,
+      :authors_reveal_at_string,
       request_restriction_attributes: [
         :id, :optional_tags_allowed, :title_required, :title_allowed, :description_required,
         :description_allowed, :url_required, :url_allowed, :fandom_num_required,

--- a/app/controllers/challenge/gift_exchange_controller.rb
+++ b/app/controllers/challenge/gift_exchange_controller.rb
@@ -10,8 +10,8 @@ class Challenge::GiftExchangeController < ChallengesController
 
   # we use this to make the times get set in the moderator's specified timezone
   def set_time_zone
-    if params[:gift_exchange] && params[:gift_exchange][:time_zone]
-      Time.zone = params[:gift_exchange][:time_zone]
+    if gift_exchange_params && gift_exchange_params[:time_zone]
+      Time.zone = gift_exchange_params[:time_zone]
     elsif @challenge && @challenge.time_zone
       Time.zone = @challenge.time_zone
     end
@@ -119,7 +119,7 @@ class Challenge::GiftExchangeController < ChallengesController
 
   def initializing_tag_sets?
     # uuughly :P but check params to see if we're initializing
-    !params[:gift_exchange][:offer_restriction_attributes].keys.
+    !gift_exchange_params[:offer_restriction_attributes].keys.
       select { |k| k =~ /init_(less|greater)/ }.
       select { |k| params[:gift_exchange][:offer_restriction_attributes][k] == '1' }.
       empty?

--- a/app/controllers/challenge/gift_exchange_controller.rb
+++ b/app/controllers/challenge/gift_exchange_controller.rb
@@ -119,7 +119,7 @@ class Challenge::GiftExchangeController < ChallengesController
 
   def initializing_tag_sets?
     # uuughly :P but check params to see if we're initializing
-    !gift_exchange_params[:offer_restriction_attributes].keys.
+    !params[:gift_exchange][:offer_restriction_attributes].keys.
       select { |k| k =~ /init_(less|greater)/ }.
       select { |k| params[:gift_exchange][:offer_restriction_attributes][k] == '1' }.
       empty?

--- a/app/controllers/challenge/gift_exchange_controller.rb
+++ b/app/controllers/challenge/gift_exchange_controller.rb
@@ -10,7 +10,7 @@ class Challenge::GiftExchangeController < ChallengesController
 
   # we use this to make the times get set in the moderator's specified timezone
   def set_time_zone
-    if gift_exchange_params && gift_exchange_params[:time_zone]
+    if params[:gift_exchange] && gift_exchange_params[:time_zone]
       Time.zone = gift_exchange_params[:time_zone]
     elsif @challenge && @challenge.time_zone
       Time.zone = @challenge.time_zone

--- a/app/models/challenge_models/gift_exchange.rb
+++ b/app/models/challenge_models/gift_exchange.rb
@@ -1,21 +1,22 @@
 class GiftExchange < ActiveRecord::Base
-  PROMPT_TYPES = %w(requests offers)  
+  PROMPT_TYPES = %w(requests offers)
+  include ActiveModel::ForbiddenAttributesProtection
   include ChallengeCore
-  
+
   override_datetime_setters
-  
+
   belongs_to :collection
-  has_one :collection, :as => :challenge 
+  has_one :collection, :as => :challenge
 
   attr_protected :signup_instructions_general_sanitizer_version
   attr_protected :signup_instructions_requests_sanitizer_version
   attr_protected :signup_instructions_offers_sanitizer_version
 
-  # limits the kind of prompts users can submit 
-  belongs_to :prompt_restriction, :class_name => "PromptRestriction", :dependent => :destroy  
+  # limits the kind of prompts users can submit
+  belongs_to :prompt_restriction, :class_name => "PromptRestriction", :dependent => :destroy
   accepts_nested_attributes_for :prompt_restriction
 
-  belongs_to :request_restriction, :class_name => "PromptRestriction", :dependent => :destroy  
+  belongs_to :request_restriction, :class_name => "PromptRestriction", :dependent => :destroy
   accepts_nested_attributes_for :request_restriction
 
   belongs_to :offer_restriction, :class_name => "PromptRestriction", :dependent => :destroy
@@ -24,7 +25,7 @@ class GiftExchange < ActiveRecord::Base
   belongs_to :potential_match_settings, :dependent => :destroy
   accepts_nested_attributes_for :potential_match_settings
 
-  validates_length_of :signup_instructions_general, :signup_instructions_requests, :signup_instructions_offers, { 
+  validates_length_of :signup_instructions_general, :signup_instructions_requests, :signup_instructions_offers, {
     :allow_blank => true,
     :maximum => ArchiveConfig.INFO_MAX, :too_long => ts("must be less than %{max} letters long.", :max => ArchiveConfig.INFO_MAX)
   }
@@ -55,26 +56,26 @@ class GiftExchange < ActiveRecord::Base
 
   #  When Challenges are deleted, there are two references left behind that need to be reset to nil
   before_destroy :clear_challenge_references
-  
+
   after_save :copy_tag_set_from_offer_to_request
   def copy_tag_set_from_offer_to_request
     if self.offer_restriction
       self.request_restriction.set_owned_tag_sets(self.offer_restriction.owned_tag_sets)
 
-      # copy the tag-set-based restriction settings 
+      # copy the tag-set-based restriction settings
       self.request_restriction.character_restrict_to_fandom = self.offer_restriction.character_restrict_to_fandom
-      self.request_restriction.relationship_restrict_to_fandom = self.offer_restriction.relationship_restrict_to_fandom      
+      self.request_restriction.relationship_restrict_to_fandom = self.offer_restriction.relationship_restrict_to_fandom
       self.request_restriction.character_restrict_to_tag_set = self.offer_restriction.character_restrict_to_tag_set
-      self.request_restriction.relationship_restrict_to_tag_set = self.offer_restriction.relationship_restrict_to_tag_set      
+      self.request_restriction.relationship_restrict_to_tag_set = self.offer_restriction.relationship_restrict_to_tag_set
       self.request_restriction.save
     end
   end
-  
+
   # override core
   def allow_name_change?
     false
   end
-  
+
   def topmost_tag_type
     self.request_restriction.topmost_tag_type
   end
@@ -82,7 +83,7 @@ class GiftExchange < ActiveRecord::Base
   def user_allowed_to_see_requests_summary?(user)
     self.collection.user_is_maintainer?(user) || self.requests_summary_visible?
   end
-  
+
   def user_allowed_to_see_prompt?(user, prompt)
     self.collection.user_is_maintainer?(user) || prompt.pseud.user == user
   end


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [x] Have you added tests for any changed functionality?
* [x] Have you added the JIRA issue number as the *first* thing in your pull request title (eg: `AO3-1234 Fix thing`)
* [x] Have you updated the JIRA issue with the information below?

## Issue

https://otwarchive.atlassian.net/browse/AO3-4860

## Purpose

This PR adds basic strong parameters to the GiftExchangeController and ForbiddenAttributes protection to the model. Based on a previous review, I left non-CRUD action params alone instead of using the new strong param method. If desired, I can update those `param[:gift_exchange]` references to use the new `gift_exchange_params` method quicky.

## Testing

1. Log in
2. Browse > Collections > New Collection
3. Fill in required information and choose "Gift Exchange" for "Type of challenge, if any"
4. Submit
5. Fill in form with whatever combination of settings you like
6. Submit
7. Choose "Challenge Settings" from side bar
8. Edit form with whatever combination of settings you like
9. Update

## References

No outside references

## Credit

*What name do you want us to use to credit your work in the [Archive of Our Own's Release Notes](http://archiveofourown.org/admin_posts?tag=1)?*

Littlelines - David Stump

*What pronouns do you prefer (she/her, he/him, zie/hir etc)?*

(he/him)