### PR TITLE
AO3-4826 Tumblr share code produces wrong link text

### DIFF
--- a/app/views/share/_share.html.erb
+++ b/app/views/share/_share.html.erb
@@ -18,7 +18,7 @@
       
     <% # Tumblr share %>
     <li>
-      <a href="http://www.tumblr.com/share/link?url=<%=u shareable.is_a?(Bookmark) ? work_url(bookmark.bookmarkable) : work_url(@work) %>&name=<%=u shareable.is_a?(Bookmark) ? get_tumblr_embed_link_title(bookmark.bookmarkable) : get_tumblr_embed_link_title(@work) %>&description=<%=u shareable.is_a?(Bookmark) ? get_tumblr_bookmark_embed_link(bookmark) : get_embed_link_meta(@work) %>" title="<%= ts('Share on Tumblr') %>" style="display:inline-block; text-indent:-9999px; overflow:hidden; width:81px; height:20px; background:url('//platform.tumblr.com/v1/share_1.png') top left no-repeat transparent; border-bottom: none;" target="_blank">
+      <a href="http://www.tumblr.com/share/link?url=<%=u shareable.is_a?(Bookmark) ? work_url(bookmark.bookmarkable) : work_url(@work) %>&title=<%=u shareable.is_a?(Bookmark) ? get_tumblr_embed_link_title(bookmark.bookmarkable) : get_tumblr_embed_link_title(@work) %>&caption=<%=u shareable.is_a?(Bookmark) ? get_tumblr_bookmark_embed_link(bookmark) : get_embed_link_meta(@work) %>" title="<%= ts('Share on Tumblr') %>" style="display:inline-block; text-indent:-9999px; overflow:hidden; width:81px; height:20px; background:url('//platform.tumblr.com/v1/share_1.png') top left no-repeat transparent; border-bottom: none;" target="_blank">
         <%= ts('Share on Tumblr') %>
       </a>
     </li>

--- a/app/views/share/_share.html.erb
+++ b/app/views/share/_share.html.erb
@@ -18,7 +18,7 @@
       
     <% # Tumblr share %>
     <li>
-      <a href="http://www.tumblr.com/share/link?url=<%=u shareable.is_a?(Bookmark) ? work_url(bookmark.bookmarkable) : work_url(@work) %>&title=<%=u shareable.is_a?(Bookmark) ? get_tumblr_embed_link_title(bookmark.bookmarkable) : get_tumblr_embed_link_title(@work) %>&caption=<%=u shareable.is_a?(Bookmark) ? get_tumblr_bookmark_embed_link(bookmark) : get_embed_link_meta(@work) %>" title="<%= ts('Share on Tumblr') %>" style="display:inline-block; text-indent:-9999px; overflow:hidden; width:81px; height:20px; background:url('//platform.tumblr.com/v1/share_1.png') top left no-repeat transparent; border-bottom: none;" target="_blank">
+      <a href="http://tumblr.com/widgets/share/tool?canonicalUrl=<%=u shareable.is_a?(Bookmark) ? work_url(bookmark.bookmarkable) : work_url(@work) %>&title=<%=u shareable.is_a?(Bookmark) ? get_tumblr_embed_link_title(bookmark.bookmarkable) : get_tumblr_embed_link_title(@work) %>&caption=<%=u shareable.is_a?(Bookmark) ? get_tumblr_bookmark_embed_link(bookmark) : get_embed_link_meta(@work) %>" title="<%= ts('Share on Tumblr') %>" style="display:inline-block; text-indent:-9999px; overflow:hidden; width:81px; height:20px; background:url('//platform.tumblr.com/v1/share_1.png') top left no-repeat transparent; border-bottom: none;" target="_blank">
         <%= ts('Share on Tumblr') %>
       </a>
     </li>


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-4826

## Purpose

From JIRA:
>We're using an old version of the Tumblr share code – the parameters in the URL are no longer correct.
>
> * Our Tumblr share link code: https://github.com/otwcode/otwarchive/blob/master/app/views/share/_share.html.erb#L21
> * Tumblr share documentation: https://www.tumblr.com/docs/en/share_button
>
>For the link, you'll want to change the start to "http://tumblr.com/widgets/share/tool" and the "url" parameter to "canonicalUrl," "name" to "title," and "description" to "caption"

## Testing

Refer to JIRA issue
