### PR TITLE
AO3-4895 Set RuboCop's Ruby version for Hound

### DIFF
--- a/config/.rubocop.yml
+++ b/config/.rubocop.yml
@@ -1,5 +1,8 @@
 # options available at https://github.com/bbatsov/rubocop/blob/master/config/default.yml
 
+AllCops:
+  TargetRubyVersion: 2.2
+
 # stop checking quotation marks
 Style/StringLiterals:
   Enabled: false


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-4895

## Purpose

Stop Hound from commenting about Ruby 2.3 features.

## Testing

As long as automated tests pass.