### PR TITLE
AO3-4908 Tag set nomination tests when the fandom nomination limit is 0.

### DIFF
--- a/features/step_definitions/tag_set_steps.rb
+++ b/features/step_definitions/tag_set_steps.rb
@@ -34,14 +34,14 @@ When /^I add (.*) to the tag ?set "([^\"]*)"$/ do |tags, title|
   step %{I should see an update confirmation message}
 end
 
-When /^I set up the nominated tag ?set "([^\"]*)" with (.*) fandom noms? and (.*) character noms?$/ do |title, fandom_count, char_count|
+When /^I set up the nominated tag ?set "([^\"]*)" with (\d*) fandom noms? and (\d*) (character|relationship) noms?$/ do |title, fandom_count, nested_count, nested_type|
   unless OwnedTagSet.find_by_title("#{title}").present?
     step %{I go to the new tag set page}
-      fill_in("owned_tag_set_title", :with => title)
-      fill_in("owned_tag_set_description", :with => "Here's my tagset")
-      check("Currently taking nominations?")
-      fill_in("Fandom nomination limit", :with => fandom_count)
-      fill_in("Character nomination limit", :with => char_count)
+    fill_in("owned_tag_set_title", with: title)
+    fill_in("owned_tag_set_description", with: "Here's my tagset")
+    check("Currently taking nominations?")
+    fill_in("Fandom nomination limit", with: fandom_count)
+    fill_in("#{nested_type.titleize} nomination limit", with: nested_count)
     step %{I submit}
     step %{I should see a create confirmation message}
   end

--- a/features/tags_and_wrangling/tag_set.feature
+++ b/features/tags_and_wrangling/tag_set.feature
@@ -81,14 +81,38 @@ Feature: creating and editing tag sets
   Then I should see "Your nominations were successfully submitted"
 
   Scenario: You should be able to nominate characters when the tagset doesn't allow fandom nominations
-  Given I am logged in as "tagsetter"
+  Given a canonical character "Common Character" in fandom "Canon"
+    And I am logged in as "tagsetter"
     And I set up the nominated tag set "Nominated Tags" with 0 fandom noms and 3 character noms
   When I follow "Nominate"
-    And I fill in "Character 1" with "My Favorite Character"
-    And I fill in "Fandom?" with "My Favorite Fandom"
+    And I fill in "Character 1" with "Obscure Character"
+    And I fill in "Character 2" with "Common Character"
+    And I press "Submit"
+  Then I should see "Sorry! We couldn't save this tag set nomination"
+    And I should see "We need to know what fandom Obscure Character belongs in."
+    But I should not see "We need to know what fandom Common Character belongs in."
+  When I fill in "Fandom?" with "Canon"
     And I press "Submit"
   Then I should see "Your nominations were successfully submitted."
-    And I should see "My Favorite Character"
+    And I should see "Obscure Character"
+    And I should see "Common Character"
+
+  Scenario: You should be able to nominate relationships when the tagset doesn't allow fandom nominations
+  Given a canonical relationship "Common Pairing" in fandom "Canon"
+    And I am logged in as "tagsetter"
+    And I set up the nominated tag set "Nominated Tags" with 0 fandom noms and 3 relationship noms
+  When I follow "Nominate"
+    And I fill in "Relationship 1" with "Rare Pairing"
+    And I fill in "Relationship 2" with "Common Pairing"
+    And I press "Submit"
+  Then I should see "Sorry! We couldn't save this tag set nomination"
+    And I should see "We need to know what fandom Rare Pairing belongs in."
+    But I should not see "We need to know what fandom Common Pairing belongs in."
+  When I fill in "Fandom?" with "Canon"
+    And I press "Submit"
+  Then I should see "Your nominations were successfully submitted."
+    And I should see "Rare Pairing"
+    And I should see "Common Pairing"
 
   Scenario: You should be able to edit your nominated tag sets, but cannot delete them once they've been reviewed
   Given I am logged in as "tagsetter"
@@ -129,6 +153,22 @@ Feature: creating and editing tag sets
   Then I should see "Your nominations were successfully updated."
     And I should see "My Favorite Character"
     But I should not see "My Aforvite Character"
+
+  Scenario: You should be able to edit your nominated relationships when the tagset doesn't allow fandom nominations
+  Given I am logged in as "tagsetter"
+    And I set up the nominated tag set "Nominated Tags" with 0 fandom noms and 3 relationship noms
+  When I follow "Nominate"
+    And I fill in "Relationship 1" with "My Favorite Character & Their Best Friend"
+    And I fill in "Fandom?" with "My Favorite Fandom"
+    And I press "Submit"
+  Then I should see "Your nominations were successfully submitted."
+    And I should see "My Favorite Character & Their Best Friend"
+  When I follow "Edit"
+    And I fill in "Relationship 1" with "My Favorite Character/Their Worst Enemy"
+    And I press "Submit"
+  Then I should see "Your nominations were successfully updated."
+    And I should see "My Favorite Character/Their Worst Enemy"
+    But I should not see "Their Best Friend"
 
   Scenario: Owner of a tag set can clear all nominations
   Given I am logged in as "tagsetter"

--- a/features/tags_and_wrangling/tag_set.feature
+++ b/features/tags_and_wrangling/tag_set.feature
@@ -80,6 +80,16 @@ Feature: creating and editing tag sets
     And I submit
   Then I should see "Your nominations were successfully submitted"
 
+  Scenario: You should be able to nominate characters when the tagset doesn't allow fandom nominations
+  Given I am logged in as "tagsetter"
+    And I set up the nominated tag set "Nominated Tags" with 0 fandom noms and 3 character noms
+  When I follow "Nominate"
+    And I fill in "Character 1" with "My Favorite Character"
+    And I fill in "Fandom?" with "My Favorite Fandom"
+    And I press "Submit"
+  Then I should see "Your nominations were successfully submitted."
+    And I should see "My Favorite Character"
+
   Scenario: You should be able to edit your nominated tag sets, but cannot delete them once they've been reviewed
   Given I am logged in as "tagsetter"
     And I set up the nominated tag set "Mayfly" with 3 fandom noms and 3 character noms
@@ -103,6 +113,22 @@ Feature: creating and editing tag sets
   Then I should see "Partially Reviewed (unreviewed nominations may be edited)"
   When I follow "Edit"
   Then I should not see the field "tag_set_nomination_fandom_nominations_attributes_0_tagname" within "div#main"
+
+  Scenario: You should be able to edit your nominated characters when the tagset doesn't allow fandom nominations
+  Given I am logged in as "tagsetter"
+    And I set up the nominated tag set "Nominated Tags" with 0 fandom noms and 3 character noms
+  When I follow "Nominate"
+    And I fill in "Character 1" with "My Aforvite Character"
+    And I fill in "Fandom?" with "My Favorite Fandom"
+    And I press "Submit"
+  Then I should see "Your nominations were successfully submitted."
+    And I should see "My Aforvite Character"
+  When I follow "Edit"
+    And I fill in "Character 1" with "My Favorite Character"
+    And I press "Submit"
+  Then I should see "Your nominations were successfully updated."
+    And I should see "My Favorite Character"
+    But I should not see "My Aforvite Character"
 
   Scenario: Owner of a tag set can clear all nominations
   Given I am logged in as "tagsetter"

--- a/spec/controllers/tag_set_nominations_controller_spec.rb
+++ b/spec/controllers/tag_set_nominations_controller_spec.rb
@@ -810,7 +810,7 @@ describe TagSetNominationsController do
                        parent_tagname: "Fandom B"
                      }
                    }
-                }
+                 }
 
             owned_tag_set.reload
           end
@@ -1033,7 +1033,7 @@ describe TagSetNominationsController do
                          parent_tagname: "Fandom D"
                        }
                      }
-                  }
+                   }
 
               owned_tag_set.reload
               tag_set_nom.reload

--- a/spec/controllers/tag_set_nominations_controller_spec.rb
+++ b/spec/controllers/tag_set_nominations_controller_spec.rb
@@ -782,7 +782,74 @@ describe TagSetNominationsController do
           fake_login_known_user(random_user)
         end
 
-        context 'tag set nomination saves successfully' do
+        context "success when fandom_nomination_limit is 0" do
+          let(:owned_tag_set) do
+            create(:owned_tag_set,
+                   fandom_nomination_limit: 0,
+                   character_nomination_limit: 1,
+                   relationship_nomination_limit: 1)
+          end
+
+          let(:new_nomination) { owned_tag_set.tag_set_nominations.first }
+
+          before do
+            post :create,
+                 tag_set_id: owned_tag_set.id,
+                 tag_set_nomination: {
+                   pseud_id: random_user.default_pseud.id,
+                   owned_tag_set_id: owned_tag_set.id,
+                   character_nominations_attributes: {
+                     "0": {
+                       tagname: "Character A",
+                       parent_tagname: "Fandom A"
+                     }
+                   },
+                   relationship_nominations_attributes: {
+                     "0": {
+                       tagname: "Characters B & C",
+                       parent_tagname: "Fandom B"
+                     }
+                   }
+                }
+
+            owned_tag_set.reload
+          end
+
+          it "creates the new tag set nomination" do
+            expect(owned_tag_set.tag_set_nominations.count).to eq 1
+            expect(new_nomination).not_to eq nil
+            expect(new_nomination.pseud).to eq random_user.default_pseud
+            expect(new_nomination.owned_tag_set).to eq owned_tag_set
+          end
+
+          it "creates the character and relationship nominations" do
+            expect(owned_tag_set.character_nominations.count).to eq 1
+            expect(new_nomination.character_nominations.count).to eq 1
+            character_nom = new_nomination.character_nominations.first
+            expect(character_nom.tagname).to eq "Character A"
+            expect(character_nom.parent_tagname).to eq "Fandom A"
+
+            expect(owned_tag_set.relationship_nominations.count).to eq 1
+            expect(new_nomination.relationship_nominations.count).to eq 1
+            relationship_nom = new_nomination.relationship_nominations.first
+            expect(relationship_nom.tagname).to eq "Characters B & C"
+            expect(relationship_nom.parent_tagname).to eq "Fandom B"
+          end
+
+          it "does not create a fandom nomination" do
+            expect(owned_tag_set.fandom_nominations.count).to eq 0
+            expect(new_nomination.fandom_nominations.count).to eq 0
+          end
+
+          it "redirects and returns a success message" do
+            it_redirects_to_with_notice(
+              tag_set_nomination_path(owned_tag_set, new_nomination),
+              "Your nominations were successfully submitted."
+            )
+          end
+        end
+
+        context "success when fandom_nomination_limit > 0" do
           before do
             owned_tag_set.update_column(:character_nomination_limit, 1)
             post :create,
@@ -918,7 +985,90 @@ describe TagSetNominationsController do
             fake_login_known_user(tag_nominator.reload)
           end
 
-          context 'tag set nomination saves successfully' do
+          context "success when fandom_nomination_limit is 0" do
+            let(:owned_tag_set) do
+              create(:owned_tag_set,
+                     fandom_nomination_limit: 0,
+                     character_nomination_limit: 1,
+                     relationship_nomination_limit: 1)
+            end
+
+            let(:tag_set_nom) do
+              TagSetNomination.create(owned_tag_set: owned_tag_set,
+                                      pseud: random_user.default_pseud)
+            end
+
+            let(:character_nom) do
+              CharacterNomination.create(tag_set_nomination: tag_set_nom,
+                                         tagname: "Character A",
+                                         parent_tagname: "Fandom A")
+            end
+
+            let(:relationship_nom) do
+              RelationshipNomination.create(tag_set_nomination: tag_set_nom,
+                                            tagname: "Characters B & C",
+                                            parent_tagname: "Fandom B")
+            end
+
+            before do
+              fake_login_known_user(tag_set_nom.pseud.user)
+
+              post :update,
+                   tag_set_id: owned_tag_set.id,
+                   id: tag_set_nom.id,
+                   tag_set_nomination: {
+                     pseud_id: tag_set_nom.pseud.id,
+                     owned_tag_set_id: owned_tag_set.id,
+                     character_nominations_attributes: {
+                       "0": {
+                         id: character_nom.id,
+                         tagname: "Character D",
+                         parent_tagname: "Fandom C"
+                       }
+                     },
+                     relationship_nominations_attributes: {
+                       "0": {
+                         id: relationship_nom.id,
+                         tagname: "Characters E & F",
+                         parent_tagname: "Fandom D"
+                       }
+                     }
+                  }
+
+              owned_tag_set.reload
+              tag_set_nom.reload
+              character_nom.reload
+              relationship_nom.reload
+            end
+
+            it "does not create new nominations" do
+              expect(owned_tag_set.tag_set_nominations.count).to eq 1
+              expect(owned_tag_set.fandom_nominations.count).to eq 0
+              expect(owned_tag_set.character_nominations.count).to eq 1
+              expect(owned_tag_set.relationship_nominations.count).to eq 1
+
+              expect(tag_set_nom.fandom_nominations.count).to eq 0
+              expect(tag_set_nom.character_nominations.count).to eq 1
+              expect(tag_set_nom.relationship_nominations.count).to eq 1
+            end
+
+            it "modifies the character and relationship nominations" do
+              expect(character_nom.tagname).to eq "Character D"
+              expect(character_nom.parent_tagname).to eq "Fandom C"
+
+              expect(relationship_nom.tagname).to eq "Characters E & F"
+              expect(relationship_nom.parent_tagname).to eq "Fandom D"
+            end
+
+            it "redirects and returns a success message" do
+              it_redirects_to_with_notice(
+                tag_set_nomination_path(owned_tag_set, tag_set_nom),
+                "Your nominations were successfully updated."
+              )
+            end
+          end
+
+          context "success when fandom_nomination_limit > 0" do
             let!(:character_nom) { CharacterNomination.create(tag_set_nomination: tag_set_nomination,
                                                               fandom_nomination: fandom_nom, tagname: 'New Character') }
 


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-4908

## Purpose

This adds four new cucumber tests and a few new RSpec tests to handle the case of nominating characters & relationships (and editing character & relationship nominations) when the fandom nomination limit is set to 0.

## Testing

I don't think manual testing is required -- as long as this passes automated tests, it's doing what it's supposed to.

## Credit

tickinginstant, she/her