### PR TITLE
AO3-4914 Test all creator's tag fields for external work bookmarks

### DIFF
--- a/features/bookmarks/bookmark_create.feature
+++ b/features/bookmarks/bookmark_create.feature
@@ -48,61 +48,6 @@ Scenario: Create a bookmark
     Then I should not see "I liked this story"
     When I go to first_bookmark_user's user page
     Then I should not see "I liked this story"
-    
-  @bookmark_fandom_error
-  Scenario: Create a bookmark on an external work (fandom error)
-    Given basic tags
-      And I am logged in as "first_bookmark_user"
-    When I go to first_bookmark_user's bookmarks page
-    Then I should not see "Stuck with You"
-    When I follow "Bookmark External Work"
-      And I fill in "bookmark_external_author" with "Sidra"
-      And I fill in "bookmark_external_title" with "Stuck with You"
-      And I fill in "bookmark_external_url" with "http://test.sidrasue.com/short.html"
-      And I press "Create"
-    Then I should see "Fandom tag is required"
-    When I fill in "bookmark_external_fandom_string" with "Popslash"
-      And I press "Create"
-    Then I should see "This work isn't hosted on the Archive"
-    When I go to first_bookmark_user's bookmarks page
-    Then I should see "Stuck with You"
-
-  @bookmark_url_error
-  Scenario: Create a bookmark on an external work (url error)
-    Given the following activated users exist
-      | login           | password   |
-      | first_bookmark_user   | password   |
-      And I am logged in as "first_bookmark_user"
-      And the default ratings exist
-    When I go to first_bookmark_user's bookmarks page
-    Then I should not see "Stuck with You"
-    When I follow "Bookmark External Work"
-      And I fill in "bookmark_external_author" with "Sidra"
-      And I fill in "bookmark_external_title" with "Stuck with You"
-      And I fill in "bookmark_external_fandom_string" with "Popslash"
-      And I press "Create"
-    Then I should see "does not appear to be a valid URL"
-    When I fill in "bookmark_external_url" with "http://test.sidrasue.com/short.html"
-      And I press "Create"
-    Then I should see "This work isn't hosted on the Archive"
-    When I go to first_bookmark_user's bookmarks page
-    Then I should see "Stuck with You"
-    
-    # edit external bookmark
-    When I follow "Edit"
-    Then I should see "Editing bookmark for Stuck with You"
-    When I fill in "Notes" with "I wish this author would join AO3"
-      And I fill in "Your tags" with "WIP"
-      And I press "Update"
-    Then I should see "Bookmark was successfully updated"
-    
-    # delete external bookmark
-    When I follow "Delete"
-    Then I should see "Are you sure you want to delete"
-      And I should see "Stuck with You"
-    When I press "Yes, Delete Bookmark"
-    Then I should see "Bookmark was successfully deleted."
-      And I should not see "Stuck with You"
       
   Scenario: Create bookmarks and recs on restricted works, check how they behave from various access points
     Given the following activated users exist

--- a/features/bookmarks/bookmark_create.feature
+++ b/features/bookmarks/bookmark_create.feature
@@ -351,27 +351,6 @@ Scenario: Delete bookmarks of a work and a series
     And I press "Yes, Delete Bookmark"
   Then I should see "Bookmark was successfully deleted."
 
-
-Scenario: Bookmark External Work link should be available to logged in users, but not logged out users
-  Given a fandom exists with name: "Testing BEW Button", canonical: true
-    And I am logged in as "markie" with password "theunicorn"
-    And I create the collection "Testing BEW Collection"
-  When I go to my bookmarks page
-  Then I should see "Bookmark External Work"
-  When I go to the bookmarks page
-  Then I should see "Bookmark External Work"
-  When I go to the bookmarks in collection "Testing BEW Collection"
-  Then I should see "Bookmark External Work"
-  When I log out
-    And I go to markie's bookmarks page
-  Then I should not see "Bookmark External Work"
-  When I go to the bookmarks page
-  Then I should not see "Bookmark External Work"
-  When I go to the bookmarks tagged "Testing BEW Button"
-  Then I should not see "Bookmark External Work"
-  When I go to the bookmarks in collection "Testing BEW Collection"
-  Then I should not see "Bookmark External Work"
-
 Scenario: Editing a bookmark's tags should expire the bookmark cache
   Given I am logged in as "some_user"
     And I post the work "Really Good Thing"

--- a/features/bookmarks/bookmark_external.feature
+++ b/features/bookmarks/bookmark_external.feature
@@ -1,0 +1,60 @@
+@bookmarks
+Feature: Create bookmarks of external works
+  In order to have an archive full of bookmarks
+  As a humble user
+  I want to bookmark some works
+
+  @bookmark_fandom_error
+  Scenario: Create a bookmark on an external work (fandom error)
+    Given basic tags
+      And I am logged in as "first_bookmark_user"
+    When I go to first_bookmark_user's bookmarks page
+    Then I should not see "Stuck with You"
+    When I follow "Bookmark External Work"
+      And I fill in "bookmark_external_author" with "Sidra"
+      And I fill in "bookmark_external_title" with "Stuck with You"
+      And I fill in "bookmark_external_url" with "http://test.sidrasue.com/short.html"
+      And I press "Create"
+    Then I should see "Fandom tag is required"
+    When I fill in "bookmark_external_fandom_string" with "Popslash"
+      And I press "Create"
+    Then I should see "This work isn't hosted on the Archive"
+    When I go to first_bookmark_user's bookmarks page
+    Then I should see "Stuck with You"
+
+  @bookmark_url_error
+  Scenario: Create a bookmark on an external work (url error)
+    Given the following activated users exist
+      | login           | password   |
+      | first_bookmark_user   | password   |
+      And I am logged in as "first_bookmark_user"
+      And the default ratings exist
+    When I go to first_bookmark_user's bookmarks page
+    Then I should not see "Stuck with You"
+    When I follow "Bookmark External Work"
+      And I fill in "bookmark_external_author" with "Sidra"
+      And I fill in "bookmark_external_title" with "Stuck with You"
+      And I fill in "bookmark_external_fandom_string" with "Popslash"
+      And I press "Create"
+    Then I should see "does not appear to be a valid URL"
+    When I fill in "bookmark_external_url" with "http://test.sidrasue.com/short.html"
+      And I press "Create"
+    Then I should see "This work isn't hosted on the Archive"
+    When I go to first_bookmark_user's bookmarks page
+    Then I should see "Stuck with You"
+    
+    # edit external bookmark
+    When I follow "Edit"
+    Then I should see "Editing bookmark for Stuck with You"
+    When I fill in "Notes" with "I wish this author would join AO3"
+      And I fill in "Your tags" with "WIP"
+      And I press "Update"
+    Then I should see "Bookmark was successfully updated"
+    
+    # delete external bookmark
+    When I follow "Delete"
+    Then I should see "Are you sure you want to delete"
+      And I should see "Stuck with You"
+    When I press "Yes, Delete Bookmark"
+    Then I should see "Bookmark was successfully deleted."
+      And I should not see "Stuck with You"

--- a/features/bookmarks/bookmark_external.feature
+++ b/features/bookmarks/bookmark_external.feature
@@ -58,3 +58,23 @@ Feature: Create bookmarks of external works
     When I press "Yes, Delete Bookmark"
     Then I should see "Bookmark was successfully deleted."
       And I should not see "Stuck with You"
+
+  Scenario: Bookmark External Work link should be available to logged in users, but not logged out users
+    Given a fandom exists with name: "Testing BEW Button", canonical: true
+      And I am logged in as "markie" with password "theunicorn"
+      And I create the collection "Testing BEW Collection"
+    When I go to my bookmarks page
+    Then I should see "Bookmark External Work"
+    When I go to the bookmarks page
+    Then I should see "Bookmark External Work"
+    When I go to the bookmarks in collection "Testing BEW Collection"
+    Then I should see "Bookmark External Work"
+    When I log out
+      And I go to markie's bookmarks page
+    Then I should not see "Bookmark External Work"
+    When I go to the bookmarks page
+    Then I should not see "Bookmark External Work"
+    When I go to the bookmarks tagged "Testing BEW Button"
+    Then I should not see "Bookmark External Work"
+    When I go to the bookmarks in collection "Testing BEW Collection"
+    Then I should not see "Bookmark External Work"

--- a/features/bookmarks/bookmark_external.feature
+++ b/features/bookmarks/bookmark_external.feature
@@ -29,39 +29,36 @@ Feature: Create bookmarks of external works
       And I should see "Character 4"
 
   @bookmark_fandom_error
-  Scenario: Create a bookmark on an external work (fandom error)
+  Scenario: A user must enter a fandom to create a bookmark on an external work
     Given basic tags
       And I am logged in as "first_bookmark_user"
     When I go to first_bookmark_user's bookmarks page
     Then I should not see "Stuck with You"
     When I follow "Bookmark External Work"
-      And I fill in "bookmark_external_author" with "Sidra"
-      And I fill in "bookmark_external_title" with "Stuck with You"
-      And I fill in "bookmark_external_url" with "http://test.sidrasue.com/short.html"
+      And I fill in "Creator" with "Sidra"
+      And I fill in "Title" with "Stuck with You"
+      And I fill in "URL" with "http://test.sidrasue.com/short.html"
       And I press "Create"
     Then I should see "Fandom tag is required"
-    When I fill in "bookmark_external_fandom_string" with "Popslash"
+    When I fill in "Fandoms" with "Popslash"
       And I press "Create"
     Then I should see "This work isn't hosted on the Archive"
     When I go to first_bookmark_user's bookmarks page
     Then I should see "Stuck with You"
 
   @bookmark_url_error
-  Scenario: Create a bookmark on an external work (url error)
-    Given the following activated users exist
-      | login           | password   |
-      | first_bookmark_user   | password   |
-      And I am logged in as "first_bookmark_user"
+  Scenario: A user must enter a valid URL to create a bookmark on an external work
+    Given I am logged in as "first_bookmark_user"
       And the default ratings exist
     When I go to first_bookmark_user's bookmarks page
     Then I should not see "Stuck with You"
     When I follow "Bookmark External Work"
-      And I fill in "bookmark_external_author" with "Sidra"
-      And I fill in "bookmark_external_title" with "Stuck with You"
-      And I fill in "bookmark_external_fandom_string" with "Popslash"
+      And I fill in "Creator" with "Sidra"
+      And I fill in "Title" with "Stuck with You"
+      And I fill in "Fandoms" with "Popslash"
       And I press "Create"
     Then I should see "does not appear to be a valid URL"
-    When I fill in "bookmark_external_url" with "http://test.sidrasue.com/short.html"
+    When I fill in "URL" with "http://test.sidrasue.com/short.html"
       And I press "Create"
     Then I should see "This work isn't hosted on the Archive"
     When I go to first_bookmark_user's bookmarks page

--- a/features/bookmarks/bookmark_external.feature
+++ b/features/bookmarks/bookmark_external.feature
@@ -4,6 +4,30 @@ Feature: Create bookmarks of external works
   As a humble user
   I want to bookmark some works
 
+  @bookmark_external_work
+  Scenario: A user can bookmark an external work using all the Creator's Tags fields (fandoms, rating, category, relationships, character)
+    Given basic tags
+      And I am logged in as "bookmarker"
+      And I am on the new external work page
+    When I fill in "URL" with "https://ao3testing.dreamwidth.org/856.html"
+      And I fill in "Creator" with "ao3testing"
+      And I fill in "Title" with "Some External Work"
+      And I fill in "Fandoms" with "Test Fandom"
+      And I select "General Audiences" from "Rating"
+      And I check "M/M"
+      And I fill in "Relationships" with "Character 1/Character 2"
+      And I fill in "Characters" with "Character 3, Character 4"
+      And I press "Create"
+    Then I should see "Bookmark was successfully created."
+      And I should see "Some External Work"
+      And I should see "ao3testing"
+      And I should see "Test Fandom"
+      And I should see "General Audiences"
+      And I should see "M/M"
+      And I should see "Character 1/Character 2"
+      And I should see "Character 3"
+      And I should see "Character 4"
+
   @bookmark_fandom_error
   Scenario: Create a bookmark on an external work (fandom error)
     Given basic tags

--- a/features/cassette_library/cucumber_tags/bookmark_external_work.yml
+++ b/features/cassette_library/cucumber_tags/bookmark_external_work.yml
@@ -1,0 +1,112 @@
+---
+http_interactions:
+- request:
+    method: head
+    uri: http://ao3testing.dreamwidth.org/593.html
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 13 Mar 2017 21:16:27 GMT
+      Content-Type:
+      - text/html; charset=utf-8
+      Content-Length:
+      - '16431'
+      Connection:
+      - keep-alive
+      Server:
+      - Apache/2.4.7 (Ubuntu) mod_apreq2-20090110/2.8.0 mod_perl/2.0.8 Perl/v5.18.2
+      Set-Cookie:
+      - ljuniq=NfoiiaI1ZBkTM2n%3A1489439786; domain=.dreamwidth.org; path=/; expires=Fri,
+        12-May-2017 21:16:26 GMT
+      Cache-Control:
+      - private, proxy-revalidate
+      Vary:
+      - Accept-Encoding
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 13 Mar 2017 21:16:27 GMT
+- request:
+    method: post
+    uri: https://collector.newrelic.com/agent_listener/14//get_redirect_host?marshal_format=json
+    body:
+      encoding: UTF-8
+      string: "[]"
+    headers:
+      Content-Encoding:
+      - identity
+      Host:
+      - collector.newrelic.com
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - NewRelic-RubyAgent/3.14.1.311 (ruby 2.2.5 x86_64-darwin15) zlib/1.2.8
+      Content-Type:
+      - application/octet-stream
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/plain
+      Content-Length:
+      - '133'
+    body:
+      encoding: UTF-8
+      string: '{"exception":{"message":"Invalid license key, please contact support@newrelic.com","error_type":"NewRelic::Agent::LicenseException"}}'
+    http_version: 
+  recorded_at: Mon, 13 Mar 2017 21:23:03 GMT
+- request:
+    method: head
+    uri: http://ao3testing.dreamwidth.org/856.html
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 13 Mar 2017 21:23:06 GMT
+      Content-Type:
+      - text/html; charset=utf-8
+      Content-Length:
+      - '16677'
+      Connection:
+      - keep-alive
+      Server:
+      - Apache/2.4.7 (Ubuntu) mod_apreq2-20090110/2.8.0 mod_perl/2.0.8 Perl/v5.18.2
+      Set-Cookie:
+      - ljuniq=mr33x0s3jFfySv4%3A1489440186; domain=.dreamwidth.org; path=/; expires=Fri,
+        12-May-2017 21:23:06 GMT
+      Cache-Control:
+      - private, proxy-revalidate
+      Vary:
+      - Accept-Encoding
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 13 Mar 2017 21:23:06 GMT
+recorded_with: VCR 3.0.1

--- a/features/support/paths.rb
+++ b/features/support/paths.rb
@@ -213,6 +213,8 @@ module NavigationHelpers
       tag_wranglings_path
     when /^the "(.*)" fandom relationship page$/i
       fandom_path($1)
+    when /^the new external work page$/i
+      new_external_work_path
 
     # Admin Pages
     when /^the admin-posts page$/i

--- a/features/support/vcr.rb
+++ b/features/support/vcr.rb
@@ -17,6 +17,7 @@ end
 
 VCR.cucumber_tags do |t|
   t.tags '@archivist_import'
+  t.tags '@bookmark_external_work'
   t.tags '@bookmark_fandom_error'
   t.tags '@bookmark_url_error'
 


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-4914

## Purpose

Test all creator's tag fields for external work bookmarks, plus minor tidying (fix scenario description, use label name, put in separate file) of existing external bookmark tests

## Testing

No manual testing
