### PR TITLE
AO3-2431 Update collection blurb cache key so that the changes to all_fandoms_count are visible.

### DIFF
--- a/app/sweepers/challenge_signup_sweeper.rb
+++ b/app/sweepers/challenge_signup_sweeper.rb
@@ -39,7 +39,7 @@ class ChallengeSignupSweeper < ActionController::Caching::Sweeper
         expire_fragment("collection-#{collection.id}-request-#{request.id}")
         # expire the prompt summary too - done in the model
         # and the collection blurb, for the stats
-        expire_fragment("collection-blurb-#{collection.id}-v2")
+        expire_fragment("collection-blurb-#{collection.id}-v3")
         expire_fragment("collection-profile-#{collection.id}")
       end
       # expire the signup summary, for prompt meme challenge prompts index

--- a/app/sweepers/collection_sweeper.rb
+++ b/app/sweepers/collection_sweeper.rb
@@ -48,7 +48,7 @@ class CollectionSweeper < ActionController::Caching::Sweeper
     collections.each do |collection|
       
       # expire the collection blurb and dashboard and profile
-      expire_fragment("collection-blurb-#{collection.id}-v2")
+      expire_fragment("collection-blurb-#{collection.id}-v3")
       expire_fragment("collection-profile-#{collection.id}")
 
     end

--- a/app/views/collections/_collection_blurb.html.erb
+++ b/app/views/collections/_collection_blurb.html.erb
@@ -1,7 +1,7 @@
 <!-- this partial requires collection; @challenges_count, @works_count, @bookmarks_count must be set -->
 <li class="<% if collection.user_is_owner?(current_user) %>own <% end %>collection picture blurb group" role="article">
   <% # remember to update collection_sweeper and challenge_signup_sweeper if you change this %>
-  <% cache("collection-blurb-#{collection.id}-v2") do %>
+  <% cache("collection-blurb-#{collection.id}-v3") do %>
     <div class="header module group">
       <h4 class="heading">
         <%= link_to collection.title, collection_path(collection) %>


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-2431

(The issue is discussed in the comments.)

## Purpose

My fix for inconsistent fandom counts (#2606) updates the function all_fandoms_count called by the view [collections/collection_blurb](https://github.com/otwcode/otwarchive/blob/master/app/views/collections/_collection_blurb.html.erb), but the caching on the collection blurbs means that the change won't immediately be reflected on the blurb. This pull request changes the cache version number for the collection blurbs, so that they will be regenerated with the correct fandom counts.

It also updates the collection_sweeper and the challenge_signup_sweeper, which use the collection blurb's cache key to flush the cache whenever a collection is updated.

## Testing

I'm not sure whether manual testing is needed, but if you want to test the collection_sweeper and challenge_signup_sweeper changes, I'd suggest the following steps:

1. Add a new work to a collection, and check the blurb on the Browse > Collections page to verify that the number of works has changed.
2. Add a new prompt to a prompt meme, and check that the number of prompts on the blurb has changed.