### PR TITLE
AO3-4808 Display an error if fandom is removed when editing tags

### DIFF
--- a/features/works/work_edit.feature
+++ b/features/works/work_edit.feature
@@ -153,3 +153,12 @@ Feature: Edit Works
       And I fill in "Fandoms" with ""
       And I press "Post Without Preview"
     Then I should see "Sorry! We couldn't save this work because:Please add all required tags. Fandom is missing."
+
+  Scenario: User can cancel editing a work
+    Given I am logged in as a random user
+      And I post the work "Work 1" with fandom "testing"
+      And I edit the work "Work 1"
+      And I fill in "Fandoms" with ""
+      And I press "Cancel"
+    When I view the work "Work 1"
+      Then I should see "Fandom: testing"

--- a/features/works/work_edit_tags.feature
+++ b/features/works/work_edit_tags.feature
@@ -64,3 +64,22 @@ Feature: Edit tags on a work
   When I view the work "Some Work"
     And I follow "Edit Tags"
   Then I should not see "Choose a language"
+
+  Scenario: A work's tags cannot be edited to remove its fandom
+  Given I am logged in as a random user
+    And I post the work "Work 1" with fandom "testing"
+    And I view the work "Work 1"
+    And I follow "Edit Tags"
+  When I fill in "Fandoms" with ""
+    And I press "Post Without Preview"
+    Then I should see "Sorry! We couldn't save this work because:Please add all required tags. Fandom is missing."
+
+  Scenario: User can cancel editing a work's tags
+  Given I am logged in as a random user
+    And I post the work "Work 1" with fandom "testing"
+    And I view the work "Work 1"
+    And I follow "Edit Tags"
+    And I fill in "Fandoms" with ""
+    And I press "Cancel"
+  When I view the work "Work 1"
+    Then I should see "Fandom: testing"


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-4808

## Purpose

Fixes the Broken on Test issue where no message appears when using Edit Tags to remove the fandom.

## Testing

See Jira.
