### PR TITLE
AO3-4937 Update nokogiri and associated gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -44,7 +44,7 @@ gem 'akismetor'
 gem 'httparty'
 gem 'htmlentities'
 gem 'whenever', '~>0.6.2', :require => false
-gem 'nokogiri', '>=1.6.6.2'
+gem 'nokogiri', '>= 1.7.1'
 gem 'mechanize'
 gem 'sanitize'
 gem 'rest-client', '~> 1.8.0', :require => 'rest_client'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -108,6 +108,7 @@ GEM
       tins (>= 1.6.0, < 2)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
+    crass (1.0.2)
     css_parser (1.3.7)
       addressable
     cucumber (2.3.2)
@@ -197,10 +198,10 @@ GEM
     mail (2.5.4)
       mime-types (~> 1.16)
       treetop (~> 1.4.8)
-    mechanize (2.7.4)
+    mechanize (2.7.5)
       domain_name (~> 0.5, >= 0.5.1)
       http-cookie (~> 1.0)
-      mime-types (>= 1.17.2, < 3)
+      mime-types (>= 1.17.2)
       net-http-digest_auth (~> 1.1, >= 1.1.1)
       net-http-persistent (~> 2.5, >= 2.5.2)
       nokogiri (~> 1.6)
@@ -217,7 +218,7 @@ GEM
     multi_xml (0.5.5)
     multipart-post (2.0.0)
     mysql2 (0.3.20)
-    net-http-digest_auth (1.4)
+    net-http-digest_auth (1.4.1)
     net-http-persistent (2.9.4)
     net-scp (1.1.1)
       net-ssh (>= 2.6.5)
@@ -231,9 +232,10 @@ GEM
       newrelic_rpm (~> 3.11)
       redis (< 4.0)
     newrelic_rpm (3.14.1.311)
-    nokogiri (1.6.8)
+    nokogiri (1.7.1)
       mini_portile2 (~> 2.1.0)
-      pkg-config (~> 1.1.7)
+    nokogumbo (1.4.10)
+      nokogiri
     ntlm-http (0.1.1)
     orm_adapter (0.5.0)
     paperclip (4.3.6)
@@ -252,7 +254,6 @@ GEM
     pickle (0.5.1)
       cucumber (>= 0.8)
       rake
-    pkg-config (1.1.7)
     poltergeist (1.11.0)
       capybara (~> 2.1)
       cliver (~> 0.3.1)
@@ -348,8 +349,10 @@ GEM
     rvm-capistrano (1.3.3)
       capistrano (>= 2.0.0)
     safe_yaml (1.0.4)
-    sanitize (2.0.4)
-      nokogiri (~> 1.6.0)
+    sanitize (4.4.0)
+      crass (~> 1.0.2)
+      nokogiri (>= 1.4.4)
+      nokogumbo (~> 1.4.1)
     selenium-webdriver (3.2.2)
       childprocess (~> 0.5)
       rubyzip (~> 1.0)
@@ -489,7 +492,7 @@ DEPENDENCIES
   mysql2 (= 0.3.20)
   newrelic-redis
   newrelic_rpm
-  nokogiri (>= 1.6.6.2)
+  nokogiri (>= 1.7.1)
   paperclip
   permit_yo
   phraseapp-in-context-editor-ruby (>= 1.0.6)
@@ -533,4 +536,4 @@ RUBY VERSION
    ruby 2.2.5p319
 
 BUNDLED WITH
-   1.13.6
+   1.14.6


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-4937

## Purpose

Update nokogiri and associated gems

## Testing

Check that imports still work as well as expected