### PR TITLE
AO3-4939 Improve reliability of timestamp-related tests for tag comments

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -104,7 +104,7 @@ gem 'audited-activerecord', '~> 3.0'
 # For controlling application behavour dynamically
 gem 'rollout'
 
-#  Place the New Relic gem as low in the list as possible, allowing the 
+#  Place the New Relic gem as low in the list as possible, allowing the
 #  frameworks above it to be instrumented when the gem initializes.
 gem 'newrelic_rpm'
 gem 'newrelic-redis'
@@ -127,13 +127,15 @@ group :test do
   gem 'poltergeist'
   gem 'capybara-screenshot'
   gem 'cucumber-rails', '~> 1.4.3', require: false
-  gem 'gherkin' 
+  gem 'gherkin'
   gem 'launchy'    # So you can do Then show me the page
   gem 'delorean'
   gem 'faker', '~> 1.6.3'
   # Record and replay data from external URLs
   gem 'vcr', '~> 3.0', '>= 3.0.1'
   gem 'webmock', '~> 1.24.2'
+  gem 'timecop'
+  gem 'cucumber-timecop', :require => false
   # Code coverage
   gem 'simplecov', '~> 0.12.0'
   gem 'coveralls', '~> 0.8.12'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -127,6 +127,10 @@ GEM
       mime-types (>= 1.16, < 4)
       nokogiri (~> 1.5)
       railties (>= 3, < 5)
+    cucumber-timecop (0.0.6)
+      chronic
+      cucumber
+      timecop
     cucumber-wire (0.0.1)
     dalli (2.7.6)
     database_cleaner (1.2.0)
@@ -388,6 +392,7 @@ GEM
     thor (0.19.1)
     thread_safe (0.3.5)
     tilt (1.4.1)
+    timecop (0.8.1)
     timeliness (0.3.8)
     tins (1.12.0)
     tire (0.6.2)
@@ -467,6 +472,7 @@ DEPENDENCIES
   css_parser
   cucumber (~> 2.3.2)
   cucumber-rails (~> 1.4.3)
+  cucumber-timecop
   dalli
   database_cleaner (= 1.2.0)
   delorean
@@ -519,6 +525,7 @@ DEPENDENCIES
   strong_parameters!
   test-unit (~> 3.0)
   test_after_commit
+  timecop
   timeliness
   tire
   transaction_retry

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -7,6 +7,7 @@
 # This file has been edited by hand :(
 require 'simplecov'
 require 'coveralls'
+require 'cucumber/timecop'
 require 'capybara/poltergeist'
 SimpleCov.command_name "features-" + (ENV['TEST_RUN'] || 'local')
 Coveralls.wear_merged!('rails') unless ENV['TEST_LOCAL']

--- a/features/tags_and_wrangling/tag_comment.feature
+++ b/features/tags_and_wrangling/tag_comment.feature
@@ -10,12 +10,14 @@ I'd like to comment on a tag'
         | login     |
         | dizmo     |
       And a fandom exists with name: "Stargate Atlantis", canonical: true
+      And it is currently Mon Mar 27 22:00:00 UTC 2017
     When I am logged in as "dizmo"
     When I view the tag "Stargate Atlantis"
     Then I should see "0 comments"
     When I post the comment "Shouldn't this be a metatag with Stargate?" on the tag "Stargate Atlantis" via web
     Then I should see "Shouldn't this be a metatag with Stargate?"
       And the comment's posted date should be nowish
+      And I jump in our Delorean and return to the present
 
   Scenario: Edit a comment on a tag
 
@@ -23,6 +25,7 @@ I'd like to comment on a tag'
         | login     |
         | dizmo     |
       And a fandom exists with name: "Stargate Atlantis", canonical: true
+      And it is currently Mon Mar 27 22:00:00 UTC 2017
     When I am logged in as "dizmo"
     When I post the comment "Shouldn't this be a metatag with Stargate?" on the tag "Stargate Atlantis"
     When I follow "Edit"
@@ -31,10 +34,10 @@ I'd like to comment on a tag'
     When I fill in "Comment" with "Yep, we should have a Stargate franchise metatag."
       And I press "Update"
     Then I should see "Comment was successfully updated."
-    When "the weird issue with tag comments not updating" is fixed
-      #And I should see "Yep, we should have a Stargate franchise metatag."
-      #And I should not see "Shouldn't this be a metatag with Stargate?"
-      #And I should see Last Edited nowish
+    When I should see "Yep, we should have a Stargate franchise metatag."
+      And I should not see "Shouldn't this be a metatag with Stargate?"
+      And I should see Last Edited nowish
+      And I jump in our Delorean and return to the present
 
   Scenario: Multiple comments on a tag increment correctly
 
@@ -228,7 +231,7 @@ I'd like to comment on a tag'
     Then I should see "Comment created"
     # all it checks is that the pagination links aren't broken
     When I follow "Next" within ".pagination"
-    Then I should see "And now things should not break!" 
+    Then I should see "And now things should not break!"
 
   Scenario: Comments pagination for a tag with slashes and periods in the name
 

--- a/features/tags_and_wrangling/tag_comment.feature
+++ b/features/tags_and_wrangling/tag_comment.feature
@@ -34,10 +34,10 @@ I'd like to comment on a tag'
     When I fill in "Comment" with "Yep, we should have a Stargate franchise metatag."
       And I press "Update"
     Then I should see "Comment was successfully updated."
-    When I should see "Yep, we should have a Stargate franchise metatag."
+      And I should see "Yep, we should have a Stargate franchise metatag."
       And I should not see "Shouldn't this be a metatag with Stargate?"
       And I should see Last Edited nowish
-      And I jump in our Delorean and return to the present
+    When I jump in our Delorean and return to the present
 
   Scenario: Multiple comments on a tag increment correctly
 


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-4939

## Purpose

Improve the reliability of the tests 

## Testing

No manual testing required