### PR TITLE
AO3-4858 Tag wrangling pages should allow sorting by taggings_count_cache

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -415,7 +415,7 @@ public
     if model.to_s.downcase == 'work'
       allowed = ['author', 'title', 'date', 'created_at', 'word_count', 'hit_count']
     elsif model.to_s.downcase == 'tag'
-      allowed = ['name', 'created_at', 'suggested_fandoms', 'taggings_count']
+      allowed = ['name', 'created_at', 'suggested_fandoms', 'taggings_count_cache']
     elsif model.to_s.downcase == 'collection'
       allowed = ['collections.title', 'collections.created_at']
     elsif model.to_s.downcase == 'prompt'

--- a/app/controllers/tag_wranglings_controller.rb
+++ b/app/controllers/tag_wranglings_controller.rb
@@ -18,7 +18,7 @@ class TagWranglingsController < ApplicationController
       params[:sort_column] = 'created_at' if !valid_sort_column(params[:sort_column], 'tag')
       params[:sort_direction] = 'ASC' if !valid_sort_direction(params[:sort_direction])
       sort = params[:sort_column] + " " + params[:sort_direction]
-      sort = sort + ", name ASC" if sort.include?('taggings_count')
+      sort = sort + ", name ASC" if sort.include?('taggings_count_cache')
       if params[:show] == "fandoms"
         @media_names = Media.by_name.value_of(:name)
         @page_subtitle = ts("fandoms")

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -293,7 +293,7 @@ class TagsController < ApplicationController
       params[:sort_direction] = 'ASC' unless valid_sort_direction(params[:sort_direction])
       sort = params[:sort_column] + ' ' + params[:sort_direction]
       # add a secondary sorting key when the main one is not discerning enough
-      if sort.include?('suggested') || sort.include?('taggings_count')
+      if sort.include?('suggested') || sort.include?('taggings_count_cache')
         sort += ', name ASC'
       end
       # this makes sure params[:status] is safe

--- a/app/views/tag_wranglings/index.html.erb
+++ b/app/views/tag_wranglings/index.html.erb
@@ -89,7 +89,7 @@
                   </ul>
                 </th>
                 <th scope="col" title="<%= ts('sort by') %>">
-                  <%= sort_link ts('Taggings'), :taggings_count_cache, {desc_default: true} %>
+                  <%= sort_link ts('Taggings'), :taggings_count_cache, { desc_default: true } %>
                 </th>
                 <th scope="col"><%= ts('Manage') %></th>
               </tr>
@@ -120,7 +120,7 @@
                     <% end %>
                   </td>
 
-                  <td title="<%= ts('taggings') %>"><%= tag.taggings_count %></td>
+                  <td title="<%= ts('taggings') %>"><%= tag.taggings_count_cache %></td>
 
                   <td>
                     <ul class="actions" role="navigation">

--- a/app/views/tag_wranglings/index.html.erb
+++ b/app/views/tag_wranglings/index.html.erb
@@ -120,7 +120,7 @@
                     <% end %>
                   </td>
 
-                  <td title="<%= ts('taggings') %>"><%= tag.taggings_count_cache %></td>
+                  <td title="<%= ts('taggings') %>"><%= tag.taggings_count %></td>
 
                   <td>
                     <ul class="actions" role="navigation">


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-4858

## Purpose

When attempting to sort the tags on a tag_wranglings page (e.g. test.ao3.org/tag_wranglings?show=relationships), the _initial_ click on the "Taggings" sort link would appear to tags in descending order by the number of taggings, giving you a URL like test.ao3.org/tag_wranglings?show=relationships&sort_column=taggings_count_cache&sort_direction=DESC 

However, the "Taggings" heading would _not_ take on the grey, pressed-button style that indicates it was currently selected, and clicking the heading a second time would _not_ sort the tags in _ascending_ order. 

This updates the logic around sorting tags to use `taggings_count_cache` instead of `taggings_count`

## Testing

Make sure the "Taggings" heading on pages like test.ao3.org/tag_wranglings?show=relationships toggles between sorting tags in descending and ascending order. Make sure it also takes on the pressed-button style that "Created" initially has.
