### PR TITLE
AO3-4940 Fix incorrect test in tag_set_nominations_controller_spec.rb

### DIFF
--- a/spec/controllers/tag_set_nominations_controller_spec.rb
+++ b/spec/controllers/tag_set_nominations_controller_spec.rb
@@ -1365,7 +1365,7 @@ describe TagSetNominationsController do
                             'character_change_New Character 2': '',
                             'relationship_change_New Relationship': '',
                             'fandom_change_New Fandom': '',
-                            'freeform_change_New Fandom': '' } }
+                            'freeform_change_New Freeform': '' } }
 
       before do
         fake_login_known_user(moderator.reload)
@@ -1386,9 +1386,9 @@ describe TagSetNominationsController do
                   'character_reject_New Character 2': 1,
                   'relationship_approve_New Relationship': 1,
                   'fandom_approve_New Fandom': 1,
-                  'freeform_reject_New Fandom': 1)
-          it_redirects_to(tag_set_nominations_path(owned_tag_set))
-          expect(flash[:notice]).to include('Still some nominations left to review!')
+                  'freeform_reject_New Freeform': 1)
+          it_redirects_to(tag_set_path(owned_tag_set))
+          expect(flash[:notice]).to include('All nominations reviewed, yay!')
         end
       end
 


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-4940

## Purpose

Fixed a single test in tag_set_nominations_controller_spec.rb in order to cover TagSetNominationsController:271-272, as originally intended.

## Testing

Code change is only in spec file so this won't change any functionality for the user.

## References

Code error was originally introduced as part of this merged PR: https://github.com/otwcode/otwarchive/pull/2728/files.

## Credit

*What name do you want us to use to credit your work in the [Archive of Our Own's Release Notes](http://archiveofourown.org/admin_posts?tag=1)?* cyrilcee

*What pronouns do you prefer (she/her, he/him, zie/hir etc)?* she/her
