### PR TITLE
AO3-4927 Extend tests for locales_controller.rb

### DIFF
--- a/factories/locales.rb
+++ b/factories/locales.rb
@@ -1,0 +1,17 @@
+require "faker"
+
+FactoryGirl.define do
+  sequence(:locale_iso) do |n|
+    "en-WAT#{n}"
+  end
+
+  sequence(:locale_name) do |n|
+    "Locale #{n}"
+  end
+
+  factory :locale do
+    language Language.default
+    iso { generate(:locale_iso) }
+    name { generate(:locale_name) }
+  end
+end

--- a/spec/controllers/locales_controller_spec.rb
+++ b/spec/controllers/locales_controller_spec.rb
@@ -1,0 +1,125 @@
+require "spec_helper"
+
+describe LocalesController do
+  include LoginMacros
+  include RedirectExpectationHelper
+  let(:user) { create(:user) }
+  let(:translation_admin) do
+    create(:user) { |u| u.translation_admin = "1" }
+  end
+
+  describe "GET #index" do
+    it "displays the default locale" do
+      get :index
+      expect(response).to render_template("index")
+      expect(assigns(:locales)).to eq([Locale.default])
+    end
+  end
+
+  describe "GET #new" do
+    context "when logged in as a translation admin" do
+      before { fake_login_known_user(translation_admin) }
+
+      it "displays the form to create a locale" do
+        get :new
+        expect(response).to render_template("new")
+        expect(assigns(:languages)).to eq(Language.default_order)
+        expect(assigns(:locale)).to be_a_new(Locale)
+      end
+    end
+  end
+
+  describe "GET #edit" do
+    context "when logged in as a translation admin" do
+      let(:locale) { create(:locale) }
+
+      before { fake_login_known_user(translation_admin) }
+
+      it "displays the form to update a locale" do
+        get :edit, id: locale.iso
+        expect(response).to render_template("edit")
+        expect(assigns(:locale)).to eq(locale)
+        expect(assigns(:languages)).to eq(Language.default_order)
+      end
+    end
+  end
+
+  describe "PUT #update" do
+    context "when logged in as a non-admin" do
+      before { fake_login_known_user(user) }
+
+      it "redirects to the user page" do
+        put :update
+        it_redirects_to user_path(user)
+      end
+    end
+
+    context "when logged in as a translation admin" do
+      let(:locale) { create(:locale) }
+
+      before { fake_login_known_user(translation_admin) }
+
+      it "updates an existing locale" do
+        params = { name: "Tiếng Việt", email_enabled: true }
+
+        put :update, id: locale.iso, locale: params
+        it_redirects_to_with_notice locales_path, "Your locale was successfully updated."
+
+        locale.reload
+        expect(locale.name).to eq(params[:name])
+        expect(locale.email_enabled).to eq(params[:email_enabled])
+      end
+
+      it "redirects to the edit form for the same locale if the new iso is not unique" do
+        put :update, id: locale.iso, locale: { iso: Locale.default.iso }
+        expect(response).to render_template("edit")
+        expect(assigns(:locale)).to eq(locale)
+        expect(assigns(:languages)).to eq(Language.default_order)
+      end
+    end
+  end
+
+  describe "POST #create" do
+    context "when logged in as a non-admin" do
+      before { fake_login_known_user(user) }
+
+      it "redirects to the user page" do
+        post :create
+        it_redirects_to user_path(user)
+      end
+    end
+
+    context "when logged in as a translation admin" do
+      before { fake_login_known_user(translation_admin) }
+
+      it "adds a new locale and redirects to list of locales" do
+        params = {
+          name: "Español", iso: "es", language_id: Language.default.id,
+          email_enabled: true, interface_enabled: false,
+        }
+
+        post :create, locale: params
+        it_redirects_to_with_notice locales_path, "Locale was successfully added."
+
+        locale = Locale.last
+        expect(locale.iso).to eq(params[:iso])
+        expect(locale.name).to eq(params[:name])
+        expect(locale.language.id).to eq(params[:language_id])
+        expect(locale.email_enabled).to eq(params[:email_enabled])
+        expect(locale.interface_enabled).to eq(params[:interface_enabled])
+      end
+
+      it "redirects to the create form if iso is missing" do
+        params = {
+          name: "Español", language_id: Language.default.id,
+          email_enabled: true, interface_enabled: false,
+        }
+
+        post :create, locale: params
+        expect(response).to render_template("new")
+        expect(assigns(:languages)).to eq(Language.default_order)
+        expect(Locale.last).to eq(Locale.default)
+      end
+    end
+  end
+end

--- a/spec/models/locale_spec.rb
+++ b/spec/models/locale_spec.rb
@@ -1,0 +1,15 @@
+require "spec_helper"
+
+describe Locale do
+  it "has a default" do
+    locale = Locale.default
+    expect(locale.iso).to eq(ArchiveConfig.DEFAULT_LOCALE_ISO)
+    expect(locale.name).to eq(ArchiveConfig.DEFAULT_LOCALE_NAME)
+    expect(locale.language).to eq(Language.default)
+  end
+
+  it "overrides to_param" do
+    locale = Locale.default
+    expect(locale.to_param).to eq(locale.iso)
+  end
+end


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-4927

## Purpose

Extend tests for locales_controller.rb.
Add a factory for locales.
Anything that remains uncovered by tests is unused and will be removed in [AO3-4942](https://otwarchive.atlassian.net/browse/AO3-4942).

## Testing

Check coverage increase. See JIRA issue.