### PR TITLE
AO3-4942 Remove unused locales code

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -287,32 +287,6 @@ public
     @menu_media = Media.by_name - [Media.find_by_name(ArchiveConfig.MEDIA_NO_TAG_NAME), uncategorized] + [uncategorized]
   end
 
-  ### GLOBALIZATION ###
-
-#  before_filter :load_locales
-#  before_filter :set_preferred_locale
-
-#  I18n.backend = I18nDB::Backend::DBBased.new
-#  I18n.record_missing_keys = false # if you want to record missing translations
-  protected
-
-  def load_locales
-    @loaded_locales ||= Locale.order(:iso)
-  end
-
-  # Sets the locale
-  def set_preferred_locale
-    # Loading the current locale
-    if session[:locale] && @loaded_locales.detect { |loc| loc.iso == session[:locale]}
-      set_locale session[:locale].to_sym
-    else
-      set_locale Locale.find_main_cached.iso.to_sym
-    end
-    @current_locale = Locale.find_by_iso(I18n.locale.to_s)
-  end
-
-  ### -- END GLOBALIZATION -- ###
-
   public
 
   #### -- AUTHORIZATION -- ####

--- a/app/controllers/locales_controller.rb
+++ b/app/controllers/locales_controller.rb
@@ -5,19 +5,8 @@ class LocalesController < ApplicationController
     logged_in_as_admin? || permit?("translation_admin") || access_denied
   end
 
-  def set
-    if params[:locale_id]
-      session[:locale] = params[:locale_id]
-    end
-    redirect_to(request.env["HTTP_REFERER"] || root_path)
-  end
-
   def index
     @locales = Locale.all(:order => :iso)
-  end
-
-  def show
-    @locale = Locale.find_by_iso(params[:id])
   end
 
   def new

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -443,11 +443,7 @@ Otwarchive::Application.routes.draw do
     resources :works
     resources :admin_posts
   end
-  resources :locales do
-    collection do
-      get :set
-    end
-  end
+  resources :locales, except: :destroy
 
   #### SESSIONS ####
 


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-4942

## Purpose

- Remove unused locales code in locales_controller and application_controller.
- Disable unused routes in locales_controller.

## Testing

- Check that coverage for the locales_controller is now at 100%.
- Check that we can still create/edit locales.

## References

Tests for this controller were added in https://otwarchive.atlassian.net/browse/AO3-4927.