### PR TITLE
AO3-4890 Flash red error when loading nonexistent tag

### DIFF
--- a/app/controllers/owned_tag_sets_controller.rb
+++ b/app/controllers/owned_tag_sets_controller.rb
@@ -9,7 +9,7 @@ class OwnedTagSetsController < ApplicationController
   def load_tag_set
     @tag_set = OwnedTagSet.find_by_id(params[:id])
     unless @tag_set
-      flash[:notice] = ts("What Tag Set did you want to look at?")
+      flash[:error] = ts("What Tag Set did you want to look at?")
       redirect_to tag_sets_path and return
     end
   end

--- a/spec/controllers/owned_tag_sets_controller_spec.rb
+++ b/spec/controllers/owned_tag_sets_controller_spec.rb
@@ -112,9 +112,9 @@ describe OwnedTagSetsController do
 
   describe "show" do
     context "where tag set is not found" do
-      it "redirects and displays a notice" do
+      it "redirects and displays an error" do
         get :show, id: 12345
-        it_redirects_to_with_notice(tag_sets_path, "What Tag Set did you want to look at?")
+        it_redirects_to_with_error(tag_sets_path, "What Tag Set did you want to look at?")
       end
     end
 


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-4890

## Purpose

When uses tries to navigate to /tag_sets/{some tag set id that doesn't exist}, message "What Tag Set did you want to look at?" is shown on red background to implicate an error has occurred, not just an informational message.

## Testing

Navigate to /tag_set/12345 (or use any other nonexistant tag set id).