### PR TITLE
AO3-4926 Extend tests for inbox_controller.rb

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -230,7 +230,6 @@ Otwarchive::Application.routes.draw do
     resource :inbox, controller: "inbox" do
       member do
         get :reply
-        get :cancel_reply
         post :delete
       end
     end

--- a/factories/comments.rb
+++ b/factories/comments.rb
@@ -6,7 +6,7 @@ FactoryGirl.define do
     content { Faker::Lorem.sentence(25) }
     email { Faker::Internet.email }
     commentable_type { "Work" }
-    commentable_id { FactoryGirl.create(:work).id }
+    commentable_id { create(:work).id }
     pseud
   end
 
@@ -15,7 +15,7 @@ FactoryGirl.define do
     content { Faker::Lorem.sentence(25) }
     email { Faker::Internet.email }
     commentable_type { "AdminPost" }
-    commentable_id { FactoryGirl.create(:admin_post).id }
+    commentable_id { create(:admin_post).id }
     pseud
   end
 
@@ -24,7 +24,7 @@ FactoryGirl.define do
     content { Faker::Lorem.sentence(25) }
     email { Faker::Internet.email }
     commentable_type { "Tag" }
-    commentable_id { FactoryGirl.create(:fandom).id }
+    commentable_id { create(:fandom).id }
     pseud
   end
 
@@ -33,8 +33,13 @@ FactoryGirl.define do
     content { Faker::Lorem.sentence(25) }
     email { Faker::Internet.email }
     commentable_type { "Work" }
-    commentable_id { FactoryGirl.create(:work, moderated_commenting_enabled: true).id }
+    commentable_id { create(:work, moderated_commenting_enabled: true).id }
     pseud
     unreviewed true
+  end
+
+  factory :inbox_comment do
+    user { create(:user) }
+    feedback_comment { create(:comment) }
   end
 end

--- a/features/comments_and_kudos/inbox.feature
+++ b/features/comments_and_kudos/inbox.feature
@@ -98,7 +98,7 @@ Feature: Get messages in the inbox
   Scenario: A user can reply to a comment from the home page without JavaScript
     Given I am logged in as "sewwiththeflo"
       And I post the work "Cat Thor's Bizarre Adventure"
-    When I am logged in as "unbeatablesg"
+      And I am logged in as "unbeatablesg"
       And I post the comment "dude this is super great!!" on the work "Cat Thor's Bizarre Adventure"
     When I am logged in as "sewwiththeflo"
       And I go to the homepage
@@ -118,7 +118,7 @@ Feature: Get messages in the inbox
   Scenario: A user can reply to a comment from the home page
     Given I am logged in as "sewwiththeflo"
       And I post the work "Cat Thor's Bizarre Adventure"
-    When I am logged in as "unbeatablesg"
+      And I am logged in as "unbeatablesg"
       And I post the comment "dude this is super great!!" on the work "Cat Thor's Bizarre Adventure"
     When I am logged in as "sewwiththeflo"
       And I go to the homepage

--- a/features/comments_and_kudos/inbox.feature
+++ b/features/comments_and_kudos/inbox.feature
@@ -1,4 +1,4 @@
-Feature: Get messages in the inbox 
+Feature: Get messages in the inbox
   In order to stay informed about activity concerning my works and comments
   As a user
   I'd like to get messages in my inbox
@@ -13,7 +13,7 @@ Feature: Get messages in the inbox
       And I go to my inbox page
     Then I should not see "cutman on Another Round"
       And I should not see "You should not receive this in your inbox."
-  
+
   Scenario: I should receive comments in my inbox if I haven't set my preferences to "Turn off messages to your inbox about comments."
     Given I am logged in as "boxer" with password "10987tko"
       And I post the work "The Fight"
@@ -24,7 +24,7 @@ Feature: Get messages in the inbox
       And I go to my inbox page
     Then I should see "cutman on The Fight"
       And I should see "You should receive this in your inbox."
-    
+
   Scenario: Logged in comments in my inbox should have timestamps
     Given I am logged in as "boxer" with password "10987tko"
       And I post the work "Down for the Count"
@@ -34,7 +34,7 @@ Feature: Get messages in the inbox
       And I go to my inbox page
     Then I should see "cutman on Down for the Count"
       And I should see "less than 1 minute ago"
-      
+
   Scenario: Logged in comments in my inbox should have timestamps
     Given I am logged in as "boxer" with password "10987tko"
       And I post the work "Down for the Count"
@@ -75,7 +75,7 @@ Feature: Get messages in the inbox
       And I should not see "The latest unread items from your inbox."
       And I should not see "cutman on the Gladiators of Old"
       And I should not see "I can still make you cry, you know."
-  
+
   Scenario: A user can mark an unread comment read on the homepage
     Given I am logged in as "boxer" with password "10987tko"
       And I post the work "Special Coverage"
@@ -94,3 +94,44 @@ Feature: Get messages in the inbox
       And I should not see "The latest unread items from your inbox."
       And I should not see "cutman on Special Coverage"
       And I should not see "Is there anything we can do to make the fight go longer?"
+
+  Scenario: A user can reply to a comment from the home page without JavaScript
+    Given I am logged in as "sewwiththeflo"
+      And I post the work "Cat Thor's Bizarre Adventure"
+    When I am logged in as "unbeatablesg"
+      And I post the comment "dude this is super great!!" on the work "Cat Thor's Bizarre Adventure"
+    When I am logged in as "sewwiththeflo"
+      And I go to the homepage
+    Then I should see "unbeatablesg on Cat Thor's Bizarre Adventure"
+      And I should see "dude this is super great!!"
+      And I should see a link "Reply"
+    When I reply to a comment with "Thank you! Please go to bed."
+      And I go to the homepage
+    Then I should not see "Unread messages"
+      And I should not see "dude this is super great!!"
+    When I am logged in as "unbeatablesg"
+      And I go to the homepage
+    Then I should see "sewwiththeflo on Cat Thor's Bizarre Adventure"
+      And I should see "Thank you! Please go to bed."
+
+  @javascript
+  Scenario: A user can reply to a comment from the home page
+    Given I am logged in as "sewwiththeflo"
+      And I post the work "Cat Thor's Bizarre Adventure"
+    When I am logged in as "unbeatablesg"
+      And I post the comment "dude this is super great!!" on the work "Cat Thor's Bizarre Adventure"
+    When I am logged in as "sewwiththeflo"
+      And I go to the homepage
+    Then I should see "unbeatablesg on Cat Thor's Bizarre Adventure"
+      And I should see "dude this is super great!!"
+      And I should see a link "Reply"
+    When I follow "Reply" within ".latest.messages.module"
+      And I fill in "Comment" with "Thank you! Please go to bed." within "#reply-to-comment"
+      And I press "Comment" within "#reply-to-comment"
+    Then I should be on the homepage
+      And I should not see "Unread messages"
+      And I should not see "dude this is super great!!"
+    When I am logged in as "unbeatablesg"
+      And I go to the homepage
+    Then I should see "sewwiththeflo on Cat Thor's Bizarre Adventure"
+      And I should see "Thank you! Please go to bed."

--- a/features/step_definitions/comment_steps.rb
+++ b/features/step_definitions/comment_steps.rb
@@ -45,7 +45,7 @@ end
 
 When /^I set up the comment "([^"]*)" on the work "([^"]*)"$/ do |comment_text, work|
   work = Work.find_by_title!(work)
-  visit work_url(work)
+  visit work_path(work)
   fill_in("comment[content]", with: comment_text)
 end
 

--- a/spec/controllers/inbox_controller_spec.rb
+++ b/spec/controllers/inbox_controller_spec.rb
@@ -1,0 +1,192 @@
+require "spec_helper"
+
+describe InboxController do
+  include LoginMacros
+  include RedirectExpectationHelper
+  let(:user) { create(:user) }
+
+  describe "GET #show" do
+    it "redirects to user page when not logged in" do
+      get :show, user_id: user.login
+      it_redirects_to user_path(user)
+    end
+
+    it "redirects to user page when logged in as another user" do
+      fake_login_known_user(create(:user))
+      get :show, user_id: user.login
+      it_redirects_to user_path(user)
+    end
+
+    context "when logged in as the same user" do
+      before { fake_login_known_user(user) }
+
+      it "renders the user inbox" do
+        get :show, user_id: user.login
+        expect(response).to render_template("show")
+        expect(assigns(:inbox_total)).to eq(0)
+        expect(assigns(:unread)).to eq(0)
+      end
+
+      context "with unread comments" do
+        let!(:inbox_comments) do
+          Array.new(3) do |i|
+            create(:inbox_comment, user: user, created_at: Time.now + i.days)
+          end
+        end
+
+        it "renders non-zero unread count" do
+          get :show, user_id: user.login
+          expect(assigns(:inbox_comments)).to eq(inbox_comments.reverse)
+          expect(assigns(:inbox_total)).to eq(3)
+          expect(assigns(:unread)).to eq(3)
+        end
+
+        it "renders oldest first" do
+          get :show, user_id: user.login, filters: { date: "asc" }
+          expect(assigns(:select_date)).to eq("asc")
+          expect(assigns(:inbox_comments)).to eq(inbox_comments)
+          expect(assigns(:inbox_total)).to eq(3)
+          expect(assigns(:unread)).to eq(3)
+        end
+      end
+
+      context "with 1 read and 1 unread" do
+        let!(:read_comment) { create(:inbox_comment, user: user, read: true) }
+        let!(:unread_comment) { create(:inbox_comment, user: user) }
+
+        it "renders only unread" do
+          get :show, user_id: user.login, filters: { read: "false" }
+          expect(assigns(:select_read)).to eq("false")
+          expect(assigns(:inbox_comments)).to eq([unread_comment])
+          expect(assigns(:inbox_total)).to eq(2)
+          expect(assigns(:unread)).to eq(1)
+        end
+      end
+
+      context "with 1 replied and 1 unreplied" do
+        let!(:replied_comment) { create(:inbox_comment, user: user, replied_to: true) }
+        let!(:unreplied_comment) { create(:inbox_comment, user: user) }
+
+        it "renders only unreplied" do
+          get :show, user_id: user.login, filters: { replied_to: "false" }
+          expect(assigns(:select_replied_to)).to eq("false")
+          expect(assigns(:inbox_comments)).to eq([unreplied_comment])
+          expect(assigns(:inbox_total)).to eq(2)
+          expect(assigns(:unread)).to eq(2)
+        end
+      end
+
+      context "with a deleted comment" do
+        let(:inbox_comment) { create(:inbox_comment, user: user) }
+
+        it "excludes deleted comments" do
+          inbox_comment.feedback_comment.destroy
+          get :show, user_id: user.login
+          expect(assigns(:inbox_total)).to eq(0)
+          expect(assigns(:unread)).to eq(0)
+        end
+      end
+    end
+  end
+
+  describe "GET #reply" do
+    let(:inbox_comment) { create(:inbox_comment) }
+    let(:feedback_comment) { inbox_comment.feedback_comment }
+
+    before { fake_login_known_user(inbox_comment.user) }
+
+    it "renders the HTML form" do
+      get :reply, user_id: inbox_comment.user.login, comment_id: feedback_comment.id
+      path_params = {
+        add_comment_reply_id: feedback_comment.id,
+        anchor: "comment_" + feedback_comment.id.to_s
+      }
+      it_redirects_to comment_path(feedback_comment, path_params)
+      expect(assigns(:commentable)).to eq(feedback_comment)
+      expect(assigns(:comment)).to be_a_new(Comment)
+    end
+
+    it "renders the JS form" do
+      get :reply, user_id: inbox_comment.user.login, comment_id: feedback_comment.id, format: "js"
+      expect(response).to render_template("reply")
+      expect(assigns(:commentable)).to eq(feedback_comment)
+      expect(assigns(:comment)).to be_a_new(Comment)
+    end
+  end
+
+  describe "PUT #update" do
+    before { fake_login_known_user(user) }
+
+    context "with no comments selected" do
+      it "redirects to inbox with caution" do
+        put :update, user_id: user.login, read: "yeah"
+        it_redirects_to_with_caution user_inbox_path(user), "Please select something first"
+        # A notice also appears!
+        expect(flash[:notice]).to eq("Inbox successfully updated.")
+      end
+
+      it "redirects to the previously viewed page if HTTP_REFERER is set" do
+        @request.env['HTTP_REFERER'] = root_path
+        put :update, user_id: user.login, read: "yeah"
+        it_redirects_to_with_caution root_path, "Please select something first"
+      end
+    end
+
+    context "with unread comments" do
+      let!(:inbox_comment_1) { create(:inbox_comment, user: user) }
+      let!(:inbox_comment_2) { create(:inbox_comment, user: user) }
+
+      it "marks all as read" do
+        put :update, user_id: user.login, inbox_comments: [inbox_comment_1.id, inbox_comment_2.id], read: "yeah"
+        it_redirects_to_with_notice user_inbox_path(user), "Inbox successfully updated."
+
+        inbox_comment_1.reload
+        expect(inbox_comment_1.read).to be_truthy
+        inbox_comment_2.reload
+        expect(inbox_comment_2.read).to be_truthy
+      end
+
+      it "marks one as read" do
+        put :update, user_id: user.login, inbox_comments: [inbox_comment_1.id], read: "yeah"
+        it_redirects_to_with_notice user_inbox_path(user), "Inbox successfully updated."
+
+        inbox_comment_1.reload
+        expect(inbox_comment_1.read).to be_truthy
+        inbox_comment_2.reload
+        expect(inbox_comment_2.read).to be_falsy
+      end
+
+      it "deletes one" do
+        put :update, user_id: user.login, inbox_comments: [inbox_comment_1.id], delete: "yeah"
+        it_redirects_to_with_notice user_inbox_path(user), "Inbox successfully updated."
+
+        expect(InboxComment.find_by_id(inbox_comment_1.id)).to be_nil
+        inbox_comment_2.reload
+        expect(inbox_comment_2.read).to be_falsy
+      end
+    end
+
+    context "with a read comment" do
+      let!(:inbox_comment) { create(:inbox_comment, user: user, read: true) }
+
+      it "marks as unread" do
+        put :update, user_id: user.login, inbox_comments: [inbox_comment.id], unread: "yeah"
+        it_redirects_to_with_notice user_inbox_path(user), "Inbox successfully updated."
+
+        inbox_comment.reload
+        expect(inbox_comment.read).to be_falsy
+      end
+
+      it "marks as unread and returns a JSON response" do
+        put :update, user_id: user.login, inbox_comments: [inbox_comment.id], unread: "yeah", format: "json"
+
+        inbox_comment.reload
+        expect(inbox_comment.read).to be_falsy
+
+        parsed_body = JSON.parse(response.body, symbolize_names: true)
+        expect(parsed_body[:item_success_message]).to eq("Inbox successfully updated.")
+        expect(response).to have_http_status(:success)
+      end
+    end
+  end
+end

--- a/spec/support/redirect_expectation_helper.rb
+++ b/spec/support/redirect_expectation_helper.rb
@@ -5,6 +5,11 @@ module RedirectExpectationHelper
     expect(flash[:notice]).to eq notice
   end
 
+  def it_redirects_to_with_caution(path, caution)
+    it_redirects_to(path)
+    expect(flash[:caution]).to eq caution
+  end
+
   def it_redirects_to_with_error(path, error)
     it_redirects_to(path)
     expect(flash[:error]).to eq error


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-4926

## Purpose

- Add specs for the controller.
- Add cukes for replying to inbox comments from the home page, both with and without JavaScript.
- Remove the route cancel_reply which has no action.

## Testing

- Check that coverage for the controller is now at 100%.