### PR TITLE
AO3-4828 Adds warning_strings param

### DIFF
--- a/app/controllers/external_works_controller.rb
+++ b/app/controllers/external_works_controller.rb
@@ -58,7 +58,7 @@ class ExternalWorksController < ApplicationController
   def work_params
     params.require(:work).permit(
       :rating_string, :fandom_string, :relationship_string, :character_string,
-      :freeform_string, category_string: []
+      :freeform_string, category_string: [], warning_strings: []
     )
   end
 end

--- a/features/admins/admin_works.feature
+++ b/features/admins/admin_works.feature
@@ -32,7 +32,7 @@ Feature: Admin Actions for Works and Bookmarks
     Then I should see "Item has been hidden."
       And all emails have been delivered
     When I follow "Make Work Visible"
-    Then I should see "Item is no longer hidden."      
+    Then I should see "Item is no longer hidden."
       And logged out users should see the unhidden work "ToS Violation" by "regular_user"
       And logged in users should see the unhidden work "ToS Violation" by "regular_user"
       And 0 emails should be delivered
@@ -52,8 +52,8 @@ Feature: Admin Actions for Works and Bookmarks
     Then I should not see "ToS Violation"
     When I am logged in
       And I am on regular_users's works page
-    Then I should not see "ToS Violation"  
-      
+    Then I should not see "ToS Violation"
+
   Scenario: Can hide bookmarks
     Given basic tags
       And I am logged in as "regular_user" with password "password1"
@@ -70,7 +70,7 @@ Feature: Admin Actions for Works and Bookmarks
     Then I should see "Item has been hidden."
     When I am logged in as "regular_user" with password "password1"
       And I am on bad_user's bookmarks page
-    Then I should not see "Rude comment" 
+    Then I should not see "Rude comment"
 
   Scenario: Can edit tags on works
     Given basic tags
@@ -120,6 +120,7 @@ Feature: Admin Actions for Works and Bookmarks
       And I fill in "Title" with "Admin-Added Title"
       And I fill in "Creator's Summary" with "Admin-added summary"
       And I select "Mature" from "Rating"
+      And I check "No Archive Warnings Apply"
       And I fill in "Fandoms" with "Admin-Added Fandom"
       And I fill in "Relationships" with "Admin-Added Relationship"
       And I fill in "Characters" with "Admin-Added Character"
@@ -130,10 +131,11 @@ Feature: Admin Actions for Works and Bookmarks
       And I should see "Admin-Added Title"
       And I should see "Admin-added summary"
       And I should see "Mature"
+      And I should see "No Archive Warnings"
       And I should see "Admin-Added Fandom"
       And I should see "Admin-Added Character"
       And I should see "Admin-Added Freeform"
-      And I should see "M/M"      
+      And I should see "M/M"
 
   Scenario: Can delete external works
     Given basic tags
@@ -143,7 +145,7 @@ Feature: Admin Actions for Works and Bookmarks
       And I view the external work "External Changes"
       And I follow "Delete External Work"
     Then I should see "Item was successfully deleted."
-  
+
   Scenario: Can mark a comment as spam
     Given I have no works or comments
       And the following activated users exist
@@ -231,4 +233,4 @@ Feature: Admin Actions for Works and Bookmarks
     Then I should see "Preview Tags and Language"
     When I press "Update"
     Then I should see "Deutsch"
-      And I should not see "English"  
+      And I should not see "English"


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [x] Have you added tests for any changed functionality?
* [x] Have you added the JIRA issue number as the *first* thing in your pull request title (eg: `AO3-1234 Fix thing`)
* [x] Have you updated the JIRA issue with the information below?

## Issue

https://otwarchive.atlassian.net/browse/AO3-4828

## Purpose

Adds a missing warning_strings param to ExternalWork as well as a cucumber test for this in the future.

## Testing

1. Log in as admin
2. Find a bookmark of an external work – http://test.ao3.org/external_works is giving a 500 error, but you can likely find one on http://test.ao3.org/bookmarks or http://test.ao3.org/users/testy/bookmarks
3. Follow the "Edit External Work" link
4. Change as much or as little information in the form as you want
5. Press "Update External Work"

## References

None

## Credit

Littlelines - David Stump

*What pronouns do you prefer (she/her, he/him, zie/hir etc)?*

he/him
