### PR TITLE
AO3-4958 Strong parameters for Kudos.

### DIFF
--- a/app/controllers/kudos_controller.rb
+++ b/app/controllers/kudos_controller.rb
@@ -11,7 +11,7 @@ class KudosController < ApplicationController
   end
 
   def create
-    @kudo = Kudo.new(params[:kudo])
+    @kudo = Kudo.new(kudo_params)
     if current_user.present?
       @kudo.pseud = current_user.default_pseud
     else
@@ -56,5 +56,11 @@ class KudosController < ApplicationController
         end
       end
     end
+  end
+
+  private
+
+  def kudo_params
+    params.require(:kudo).permit(:commentable_id, :commentable_type)
   end
 end

--- a/app/models/kudo.rb
+++ b/app/models/kudo.rb
@@ -1,4 +1,6 @@
 class Kudo < ActiveRecord::Base
+  include ActiveModel::ForbiddenAttributesProtection
+
   belongs_to :pseud
   belongs_to :commentable, :polymorphic => true
 


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-4958

## Purpose

This pull request adds strong parameter protection for the Kudos class. There's a mass assignment in the `KudosController#create` function, so this pull request whitelists the two fields used in the new_kudo form.

## Testing

1. Try to add a kudo to a work when logged out, with Javascript enabled.
2. Try to add a kudo to a work when logged in, with Javascript enabled.
3. Try to add a kudo to a work when logged in, with Javascript disabled.
4. Try to add a kudo to a work when logged out, with Javascript disabled.

In each case, the kudo(s) should appear on the correct work.

## Credit

tickinginstant, she/her