### PR TITLE
AO3-4960 Strong parameters for UserInviteRequests.

### DIFF
--- a/app/controllers/user_invite_requests_controller.rb
+++ b/app/controllers/user_invite_requests_controller.rb
@@ -31,7 +31,7 @@ class UserInviteRequestsController < ApplicationController
     if AdminSetting.request_invite_enabled?
       if logged_in?
         @user = current_user
-        @user_invite_request = @user.user_invite_requests.build(params[:user_invite_request])
+        @user_invite_request = @user.user_invite_requests.build(user_invite_request_params)
       else
         flash[:error] = "Please log in."
         redirect_to login_path
@@ -73,5 +73,11 @@ class UserInviteRequestsController < ApplicationController
     end
     flash[:notice] = ts("Requests were successfully updated.")
     redirect_to user_invite_requests_url
+  end
+
+  private
+
+  def user_invite_request_params
+    params.require(:user_invite_request).permit(:quantity, :reason)
   end
 end

--- a/app/models/user_invite_request.rb
+++ b/app/models/user_invite_request.rb
@@ -1,4 +1,6 @@
 class UserInviteRequest < ActiveRecord::Base
+  include ActiveModel::ForbiddenAttributesProtection
+
   MAX_USER_INVITE_REQUEST = ArchiveConfig.MAX_USER_INVITE_REQUEST
 
   belongs_to :user


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-4960

## Purpose

This pull request adds strong parameter protection for the UserInviteRequest class. There's a mass assignment in the `UserInviteRequestsController#create` function. I believe this code is currently disabled on the live site, but there are some tests that use it in [invite_request.feature](https://github.com/otwcode/otwarchive/blob/master/features/other_a/invite_request.feature).

## Testing

1. Log in as an admin.
2. Go to the Settings page.
3. Make sure that the "User can request invitations" checkbox is checked.
4. Update the Settings, and log out.
5. Log back in as a user.
6. Go to "My Dashboard", and click the "Invitations" button. Then click "Request Invitations."
7. Fill in the two fields and press "Send Request."
8. Log out.
9. Log in as an admin again.
10. Go to the Invitations > Manage Requests page.
11. Verify that the invitation was created, and that the number and the message are correct.

## Credit

tickinginstant, she/her