### PR TITLE
AO3-4956 Extend tests for opendoors/tools_controller.rb and change from 404 to flash error

### DIFF
--- a/app/controllers/opendoors/tools_controller.rb
+++ b/app/controllers/opendoors/tools_controller.rb
@@ -16,7 +16,7 @@ class Opendoors::ToolsController < ApplicationController
     # extract the work id and find the work
     if params[:work_url] && params[:work_url].match(/works\/([0-9]+)\/?$/)
       work_id = $1
-      @work = Work.find(work_id)
+      @work = Work.find_by_id(work_id)
     end
     unless @work
       flash[:error] = ts("We couldn't find that work on the archive. Have you put in the full url?")

--- a/factories/users.rb
+++ b/factories/users.rb
@@ -12,6 +12,9 @@ FactoryGirl.define do
     "testadmin#{n}"
   end
 
+  factory :role do
+  end
+
   factory :user do
     login {generate(:login)}
     password "password"
@@ -29,6 +32,10 @@ FactoryGirl.define do
     factory :invited_user do
       login {generate(:login)}
       invitation_token nil
+    end
+
+    factory :opendoors_user do
+      roles { [create(:role, name: "opendoors")] }
     end
   end
 end

--- a/features/importing/archivist.feature
+++ b/features/importing/archivist.feature
@@ -220,11 +220,18 @@ Feature: Archivist bulk imports
     When I go to the Open Doors tools page
     Then I should see "Sorry, you don't have permission to access the page you were trying to reach."
 
-  Scenario: Open Doors committee members can see their tools
-    Given I have an Open Doors committee member "OpenDoors"
+  Scenario: Open Doors committee members can update the redirect URL of a work
+    Given the work "My Immortal"
+      And I have an Open Doors committee member "OpenDoors"
       And I am logged in as "OpenDoors"
     When I go to the Open Doors tools page
     Then I should see "Update Redirect URL"
+    When I fill in "imported_from_url" with "http://example.com/my-immortal"
+      And I fill in "work_url" with the path to the "My Immortal" work page
+      And I submit with the 2nd button
+    Then I should see "Updated imported-from url for My Immortal to http://example.com/my-immortal"
+    When I follow "http://example.com/my-immortal"
+    Then I should be on the "My Immortal" work page
 
   Scenario: Open Doors committee members can block an email address from having imports
     Given I have an Open Doors committee member "OpenDoors"

--- a/features/step_definitions/archivist_steps.rb
+++ b/features/step_definitions/archivist_steps.rb
@@ -31,6 +31,10 @@ When /^I make "([^\"]*)" an Open Doors committee member$/ do |name|
   @user.roles = [@role]
 end
 
+When /^(?:|I )fill in "([^"]*)" with the path to (.+)$/ do |field, page_name|
+  fill_in(field, with: path_to(page_name))
+end
+
 When /^I start to import the work "([^\"]*)"(?: by "([^\"]*)" with email "([^\"]*)")?$/ do |url, external_author_name, external_author_email|
   step(%{I go to the import page})
   step(%{I check "Import for others ONLY with permission"})

--- a/spec/controllers/opendoors/tools_controller_spec.rb
+++ b/spec/controllers/opendoors/tools_controller_spec.rb
@@ -8,12 +8,11 @@ describe Opendoors::ToolsController do
   let(:opendoors_user) { create(:opendoors_user) }
 
   describe "GET #index" do
-    it "denies access if not logged in" do
+    it "denies access if not logged in with Open Doors privileges" do
+      fake_logout
       get :index
       it_redirects_to_with_error(new_user_session_path, "Sorry, you don't have permission to access the page you were trying to reach. Please log in.")
-    end
 
-    it "denies access if logged in without Open Doors privileges" do
       fake_login_known_user(user)
       get :index
       it_redirects_to_with_error(user_path(user), "Sorry, you don't have permission to access the page you were trying to reach.")
@@ -38,18 +37,17 @@ describe Opendoors::ToolsController do
   end
 
   describe "POST #url_update" do
-    it "denies access if not logged in" do
+    it "denies access if not logged in with Open Doors privileges" do
+      fake_logout
       post :url_update
       it_redirects_to_with_error(new_user_session_path, "Sorry, you don't have permission to access the page you were trying to reach. Please log in.")
-    end
 
-    it "denies access if logged in but not Open Doors" do
       fake_login_known_user(user)
       post :url_update
       it_redirects_to_with_error(user_path(user), "Sorry, you don't have permission to access the page you were trying to reach.")
     end
 
-    context "when logged in as Open Doors" do
+    context "when logged in with Open Doors privileges" do
       before { fake_login_known_user(opendoors_user) }
 
       it "redirects to tools if work URL is missing" do

--- a/spec/controllers/opendoors/tools_controller_spec.rb
+++ b/spec/controllers/opendoors/tools_controller_spec.rb
@@ -1,0 +1,109 @@
+require "spec_helper"
+
+describe Opendoors::ToolsController do
+  include LoginMacros
+  include RedirectExpectationHelper
+
+  let(:user) { create(:user) }
+  let(:opendoors_user) { create(:opendoors_user) }
+
+  describe "GET #index" do
+    it "denies access if not logged in" do
+      get :index
+      it_redirects_to_with_error(new_user_session_path, "Sorry, you don't have permission to access the page you were trying to reach. Please log in.")
+    end
+
+    it "denies access if logged in without Open Doors privileges" do
+      fake_login_known_user(user)
+      get :index
+      it_redirects_to_with_error(user_path(user), "Sorry, you don't have permission to access the page you were trying to reach.")
+    end
+
+    context "when logged in with Open Doors privileges" do
+      before { fake_login_known_user(opendoors_user) }
+
+      it "shows the tools page" do
+        get :index
+        expect(response).to render_template("index")
+        expect(assigns(:external_author)).to be_a_new(ExternalAuthor)
+        expect(assigns(:imported_from_url)).to be_nil
+      end
+
+      it "optionally recognizes the imported-from URL" do
+        url = "http://example.com"
+        get :index, imported_from_url: url
+        expect(assigns(:imported_from_url)).to eq(url)
+      end
+    end
+  end
+
+  describe "POST #url_update" do
+    it "denies access if not logged in" do
+      post :url_update
+      it_redirects_to_with_error(new_user_session_path, "Sorry, you don't have permission to access the page you were trying to reach. Please log in.")
+    end
+
+    it "denies access if logged in but not Open Doors" do
+      fake_login_known_user(user)
+      post :url_update
+      it_redirects_to_with_error(user_path(user), "Sorry, you don't have permission to access the page you were trying to reach.")
+    end
+
+    context "when logged in as Open Doors" do
+      before { fake_login_known_user(opendoors_user) }
+
+      it "redirects to tools if work URL is missing" do
+        post :url_update
+        it_redirects_to_with_error(opendoors_tools_path, "We couldn't find that work on the archive. Have you put in the full url?")
+      end
+
+      it "redirects to tools if work URL is invalid" do
+        post :url_update, work_url: "/faq"
+        it_redirects_to_with_error(opendoors_tools_path, "We couldn't find that work on the archive. Have you put in the full url?")
+      end
+
+      it "redirects to tools if work ID is not found" do
+        post :url_update, work_url: "/works/7331278/"
+        it_redirects_to_with_error(opendoors_tools_path, "We couldn't find that work on the archive. Have you put in the full url?")
+      end
+
+      context "with a valid work ID" do
+        let(:work) { create(:work) }
+        let(:work_with_imported_from_url) { create(:work, imported_from_url: "http://example.org/my-immortal") }
+
+        it "redirects to tools if imported-from URL is missing" do
+          post :url_update, work_url: "/works/#{work.id}/"
+          it_redirects_to_with_error(opendoors_tools_path, "The imported-from url you are trying to set doesn't seem valid.")
+        end
+
+        it "redirects to tools if imported-from URL is invalid" do
+          post :url_update, work_url: "/works/#{work.id}/", imported_from_url: " "
+          it_redirects_to_with_error(opendoors_tools_path, "The imported-from url you are trying to set doesn't seem valid.")
+        end
+
+        it "redirects to tools if imported-from URL is already used in another work" do
+          url = work_with_imported_from_url.imported_from_url
+          post :url_update, work_url: "/works/#{work.id}/", imported_from_url: url
+          it_redirects_to_with_error(opendoors_tools_path(imported_from_url: url), "There is already a work imported from the url #{url}.")
+        end
+
+        it "updates work if imported-from URL is valid" do
+          url = "https://example.com/share/?url=https://example.com/dead-archive"
+          post :url_update, work_url: "http://example.org/works/#{work.id}/", imported_from_url: url
+          it_redirects_to_with_notice(opendoors_tools_path(imported_from_url: url), "Updated imported-from url for #{work.title} to #{url}")
+          work.reload
+          expect(work.imported_from_url).to eq(url)
+        end
+
+        it "updates work if imported-from URL has non-ASCII characters" do
+          url = "https://example.com/work/resurrección"
+          post :url_update, work_url: "http://example.org/works/#{work.id}/", imported_from_url: url
+          encoded_url = URI.encode(url)
+          it_redirects_to_with_notice(opendoors_tools_path(imported_from_url: encoded_url), "Updated imported-from url for #{work.title} to #{encoded_url}")
+          work.reload
+          expect(work.imported_from_url).to eq(encoded_url)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-4956

## Purpose

- Display an error message instead of raising 404 when a work ID cannot be found.
- Add controller spec for opendoors/tools_controller.rb.
- Add a scenario for updating a work's imported from URL.

## Testing

See https://otwarchive.atlassian.net/browse/AO3-4956.