### PR TITLE
AO3-4963 Modify new taggings_count code to handle brand new fandoms used on External Works.

### DIFF
--- a/app/models/bookmark.rb
+++ b/app/models/bookmark.rb
@@ -136,6 +136,9 @@ class Bookmark < ActiveRecord::Base
   end
 
   def tag_string=(tag_string)
+    # Make sure that we trigger the callback for our taggings.
+    self.taggings.destroy_all
+
     self.tags = []
 
     # Replace unicode full-width commas

--- a/app/models/tagging.rb
+++ b/app/models/tagging.rb
@@ -6,6 +6,10 @@ class Tagging < ActiveRecord::Base
   before_destroy :remove_filter_tagging
   before_save :add_filter_taggings
 
+  # Tell the tag that the taggings count may have been updated.
+  after_create :update_taggings_count
+  after_destroy :update_taggings_count
+
   def add_filter_taggings
     if self.tagger && self.taggable.is_a?(Work)
       self.taggable.add_filter_tagging(self.tagger)
@@ -26,5 +30,11 @@ class Tagging < ActiveRecord::Base
 
   def self.find_by_tag(taggable, tag)
     Tagging.find_by_tagger_id_and_taggable_id_and_tagger_type_and_taggable_type(tag.id, taggable.id, 'Tag', taggable.class.name)
+  end
+
+  # Tell the tag that the taggings count may have been updated, and the
+  # taggings count should be loaded into the cache if it isn't already.
+  def update_taggings_count
+    tagger.update_tag_cache unless tagger.blank? || tagger.destroyed?
   end
 end

--- a/app/models/tagging.rb
+++ b/app/models/tagging.rb
@@ -6,7 +6,7 @@ class Tagging < ActiveRecord::Base
   before_destroy :remove_filter_tagging
   before_save :add_filter_taggings
 
-  # Tell the tag that the taggings count may have been updated.
+  # When we create or destroy a tagging, it may change the taggings count.
   after_create :update_taggings_count
   after_destroy :update_taggings_count
 
@@ -32,8 +32,13 @@ class Tagging < ActiveRecord::Base
     Tagging.find_by_tagger_id_and_taggable_id_and_tagger_type_and_taggable_type(tag.id, taggable.id, 'Tag', taggable.class.name)
   end
 
-  # Tell the tag that the taggings count may have been updated, and the
-  # taggings count should be loaded into the cache if it isn't already.
+  # Most of the time, we don't need the taggings_count_cache stored in the
+  # database to be perfectly accurate. But because of the way Tag.in_use is
+  # defined and used, the difference between a value of 0 and a value of 1 is
+  # important. So we make sure to poke the taggings_count cache every time we
+  # create or destroy a tagging. If it's a large tag, it'll fall back on the
+  # cached value. If it's a small tag, it'll recompute -- and make sure that it
+  # handles the transition from 0 uses to 1 use properly.
   def update_taggings_count
     tagger.update_tag_cache unless tagger.blank? || tagger.destroyed?
   end

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -203,9 +203,7 @@ class Work < ActiveRecord::Base
     self.filters.each do |tag|
       tag.update_works_index_timestamp!
     end
-    self.tags.each do |tag|
-      tag.update_tag_cache
-    end
+
     Work.expire_work_tag_groups_id(self.id)
   end
 

--- a/features/step_definitions/tag_steps.rb
+++ b/features/step_definitions/tag_steps.rb
@@ -174,6 +174,11 @@ Given(/^the following typed tags exists$/) do |table|
   end
 end
 
+Given /^the tag "([^"]*)" does not exist$/ do |tag_name|
+  tag = Tag.find_by_name(tag_name)
+  tag.destroy if tag.present?
+end
+
 ### WHEN
 
 When /^the periodic tag count task is run$/i do

--- a/features/tags_and_wrangling/brand_new_fandoms.feature
+++ b/features/tags_and_wrangling/brand_new_fandoms.feature
@@ -2,8 +2,11 @@
 Feature: Brand new fandoms
 
   Background:
-    Given I have no tags
-      And basic tags
+    # The external works form will error if we don't have basic tags, and since
+    # we're trying to create a brand new tag, we just want to double-check that
+    # it doesn't exist.
+    Given basic tags
+      And the tag "My Brand New Fandom" does not exist
 
   Scenario: Brand new fandoms should be visible on the uncategorized fandoms page.
     Given I am logged in as a random user

--- a/features/tags_and_wrangling/brand_new_fandoms.feature
+++ b/features/tags_and_wrangling/brand_new_fandoms.feature
@@ -8,14 +8,14 @@ Feature: Brand new fandoms
     Given basic tags
       And the tag "My Brand New Fandom" does not exist
 
-  Scenario: Brand new fandoms should be visible on the uncategorized fandoms page.
+  Scenario: Brand new fandoms should be visible on the Uncategorized Fandoms page.
     Given I am logged in as a random user
       And I post a work "My New Work" with fandom "My Brand New Fandom"
       And The periodic tag count task is run
     When I follow "Uncategorized Fandoms" within "#header"
     Then I should see "My Brand New Fandom"
 
-  Scenario: Fandoms used only on external works should be visible on the uncategorized fandoms page.
+  Scenario: Fandoms used only on external works should be visible on the Uncategorized Fandoms page.
     Given I am logged in as a random user
       And I set up an external work
       And I fill in "Fandoms" with "My Brand New Fandom"
@@ -23,6 +23,33 @@ Feature: Brand new fandoms
       And The periodic tag count task is run
     When I follow "Uncategorized Fandoms" within "#header"
     Then I should see "My Brand New Fandom"
+
+  Scenario: When the only work with a brand new fandom is destroyed, the fandom should not be visible on the Uncategorized Fandoms page.
+    Given I am logged in as a random user
+      And I post a work "My New Work" with fandom "My Brand New Fandom"
+      And The periodic tag count task is run
+    When I follow "Edit"
+      And I follow "Delete Work"
+      And I press "Yes"
+    Then I should see "Your work My New Work was deleted."
+    When The periodic tag count task is run
+      And I follow "Uncategorized Fandoms" within "#header"
+    Then I should not see "My Brand New Fandom"
+
+  Scenario: When the only external work with a brand new fandom is destroyed, the fandom should not be visible on the Uncategorized Fandoms page.
+    Given I am logged in as a random user
+      And I set up an external work
+      And I fill in "Title" with "External Work To Be Deleted"
+      And I fill in "Fandoms" with "My Brand New Fandom"
+      And I submit
+      And The periodic tag count task is run
+    When I am logged in as an admin
+      And I view the external work "External Work To Be Deleted"
+      And I follow "Delete External Work"
+    Then I should see "Item was successfully deleted."
+    When The periodic tag count task is run
+      And I follow "Uncategorized Fandoms" within "#header"
+    Then I should not see "My Brand New Fandom"
 
   Scenario: Brand new fandoms should be visible to wranglers.
     Given I am logged in as a tag wrangler
@@ -41,3 +68,33 @@ Feature: Brand new fandoms
     When I follow "Tag Wrangling" within "#header"
       And I follow "Fandoms by media"
     Then I should see "My Brand New Fandom"
+
+  Scenario: When the only work with a brand new fandom is destroyed, the fandom should not be visible to tag wranglers.
+    Given I am logged in as a tag wrangler
+      And I post a work "My New Work" with fandom "My Brand New Fandom"
+      And The periodic tag count task is run
+    When I follow "Edit"
+      And I follow "Delete Work"
+      And I press "Yes"
+    Then I should see "Your work My New Work was deleted."
+    When The periodic tag count task is run
+      And I follow "Tag Wrangling" within "#header"
+      And I follow "Fandoms by media"
+    Then I should not see "My Brand New Fandom"
+
+  Scenario: When the only external work with a brand new fandom is destroyed, the fandom should not be visible to tag wranglers.
+    Given I am logged in as a tag wrangler
+      And I set up an external work
+      And I fill in "Title" with "External Work To Be Deleted"
+      And I fill in "Fandoms" with "My Brand New Fandom"
+      And I submit
+      And The periodic tag count task is run
+    When I am logged in as an admin
+      And I view the external work "External Work To Be Deleted"
+      And I follow "Delete External Work"
+    Then I should see "Item was successfully deleted."
+    When The periodic tag count task is run
+      And I am logged in as a tag wrangler
+      And I follow "Tag Wrangling" within "#header"
+      And I follow "Fandoms by media"
+    Then I should not see "My Brand New Fandom"

--- a/features/tags_and_wrangling/brand_new_fandoms.feature
+++ b/features/tags_and_wrangling/brand_new_fandoms.feature
@@ -11,7 +11,7 @@ Feature: Brand new fandoms
   Scenario: Brand new fandoms should be visible on the Uncategorized Fandoms page.
     Given I am logged in as a random user
       And I post a work "My New Work" with fandom "My Brand New Fandom"
-      And The periodic tag count task is run
+      And the periodic tag count task is run
     When I follow "Uncategorized Fandoms" within "#header"
     Then I should see "My Brand New Fandom"
 
@@ -20,19 +20,19 @@ Feature: Brand new fandoms
       And I set up an external work
       And I fill in "Fandoms" with "My Brand New Fandom"
       And I submit
-      And The periodic tag count task is run
+      And the periodic tag count task is run
     When I follow "Uncategorized Fandoms" within "#header"
     Then I should see "My Brand New Fandom"
 
   Scenario: When the only work with a brand new fandom is destroyed, the fandom should not be visible on the Uncategorized Fandoms page.
     Given I am logged in as a random user
       And I post a work "My New Work" with fandom "My Brand New Fandom"
-      And The periodic tag count task is run
+      And the periodic tag count task is run
     When I follow "Edit"
       And I follow "Delete Work"
       And I press "Yes"
     Then I should see "Your work My New Work was deleted."
-    When The periodic tag count task is run
+    When the periodic tag count task is run
       And I follow "Uncategorized Fandoms" within "#header"
     Then I should not see "My Brand New Fandom"
 
@@ -42,19 +42,19 @@ Feature: Brand new fandoms
       And I fill in "Title" with "External Work To Be Deleted"
       And I fill in "Fandoms" with "My Brand New Fandom"
       And I submit
-      And The periodic tag count task is run
+      And the periodic tag count task is run
     When I am logged in as an admin
       And I view the external work "External Work To Be Deleted"
       And I follow "Delete External Work"
     Then I should see "Item was successfully deleted."
-    When The periodic tag count task is run
+    When the periodic tag count task is run
       And I follow "Uncategorized Fandoms" within "#header"
     Then I should not see "My Brand New Fandom"
 
   Scenario: Brand new fandoms should be visible to wranglers.
     Given I am logged in as a tag wrangler
       And I post a work "My New Work" with fandom "My Brand New Fandom"
-      And The periodic tag count task is run
+      And the periodic tag count task is run
     When I follow "Tag Wrangling" within "#header"
       And I follow "Fandoms by media"
     Then I should see "My Brand New Fandom"
@@ -64,7 +64,7 @@ Feature: Brand new fandoms
       And I set up an external work
       And I fill in "Fandoms" with "My Brand New Fandom"
       And I submit
-      And The periodic tag count task is run
+      And the periodic tag count task is run
     When I follow "Tag Wrangling" within "#header"
       And I follow "Fandoms by media"
     Then I should see "My Brand New Fandom"
@@ -72,12 +72,12 @@ Feature: Brand new fandoms
   Scenario: When the only work with a brand new fandom is destroyed, the fandom should not be visible to tag wranglers.
     Given I am logged in as a tag wrangler
       And I post a work "My New Work" with fandom "My Brand New Fandom"
-      And The periodic tag count task is run
+      And the periodic tag count task is run
     When I follow "Edit"
       And I follow "Delete Work"
       And I press "Yes"
     Then I should see "Your work My New Work was deleted."
-    When The periodic tag count task is run
+    When the periodic tag count task is run
       And I follow "Tag Wrangling" within "#header"
       And I follow "Fandoms by media"
     Then I should not see "My Brand New Fandom"
@@ -88,12 +88,12 @@ Feature: Brand new fandoms
       And I fill in "Title" with "External Work To Be Deleted"
       And I fill in "Fandoms" with "My Brand New Fandom"
       And I submit
-      And The periodic tag count task is run
+      And the periodic tag count task is run
     When I am logged in as an admin
       And I view the external work "External Work To Be Deleted"
       And I follow "Delete External Work"
     Then I should see "Item was successfully deleted."
-    When The periodic tag count task is run
+    When the periodic tag count task is run
       And I am logged in as a tag wrangler
       And I follow "Tag Wrangling" within "#header"
       And I follow "Fandoms by media"

--- a/features/tags_and_wrangling/brand_new_fandoms.feature
+++ b/features/tags_and_wrangling/brand_new_fandoms.feature
@@ -1,0 +1,40 @@
+@user @tag_wrangling
+Feature: Brand new fandoms
+
+  Background:
+    Given I have no tags
+      And basic tags
+
+  Scenario: Brand new fandoms should be visible on the uncategorized fandoms page.
+    Given I am logged in as a random user
+      And I post a work "My New Work" with fandom "My Brand New Fandom"
+      And The periodic tag count task is run
+    When I follow "Uncategorized Fandoms" within "#header"
+    Then I should see "My Brand New Fandom"
+
+  Scenario: Fandoms used only on external works should be visible on the uncategorized fandoms page.
+    Given I am logged in as a random user
+      And I set up an external work
+      And I fill in "Fandoms" with "My Brand New Fandom"
+      And I submit
+      And The periodic tag count task is run
+    When I follow "Uncategorized Fandoms" within "#header"
+    Then I should see "My Brand New Fandom"
+
+  Scenario: Brand new fandoms should be visible to wranglers.
+    Given I am logged in as a tag wrangler
+      And I post a work "My New Work" with fandom "My Brand New Fandom"
+      And The periodic tag count task is run
+    When I follow "Tag Wrangling" within "#header"
+      And I follow "Fandoms by media"
+    Then I should see "My Brand New Fandom"
+
+  Scenario: Fandoms used only on external works should be visible to wranglers.
+    Given I am logged in as a tag wrangler
+      And I set up an external work
+      And I fill in "Fandoms" with "My Brand New Fandom"
+      And I submit
+      And The periodic tag count task is run
+    When I follow "Tag Wrangling" within "#header"
+      And I follow "Fandoms by media"
+    Then I should see "My Brand New Fandom"

--- a/features/tags_and_wrangling/tag_wrangling.feature
+++ b/features/tags_and_wrangling/tag_wrangling.feature
@@ -263,15 +263,3 @@ Feature: Tag wrangling
     When I view the tag "Cowboy Bebop"
     Then I follow "Reindex Tag"
       And I should see "Tag sent to be reindexed"
-
-  Scenario: Fandoms used only on external works should be visible to wranglers.
-    Given I have no tags
-      And basic tags
-      And I am logged in as a tag wrangler
-      And I set up an external work
-      And I fill in "Fandoms" with "My Brand New Fandom"
-      And I submit
-      And The periodic tag count task is run
-    When I follow "Tag Wrangling" within "#header"
-      And I follow "Fandoms by media"
-    Then I should see "My Brand New Fandom"

--- a/features/tags_and_wrangling/tag_wrangling.feature
+++ b/features/tags_and_wrangling/tag_wrangling.feature
@@ -263,3 +263,15 @@ Feature: Tag wrangling
     When I view the tag "Cowboy Bebop"
     Then I follow "Reindex Tag"
       And I should see "Tag sent to be reindexed"
+
+  Scenario: Fandoms used only on external works should be visible to wranglers.
+    Given I have no tags
+      And basic tags
+      And I am logged in as a tag wrangler
+      And I set up an external work
+      And I fill in "Fandoms" with "My Brand New Fandom"
+      And I submit
+      And The periodic tag count task is run
+    When I follow "Tag Wrangling" within "#header"
+      And I follow "Fandoms by media"
+    Then I should see "My Brand New Fandom"


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-4963

## Purpose

This pull request moves the call to `Tag.update_tag_cache` from the Work's `expire_caches` function into a new callback in the Tagging class, which is triggered whenever a Tagging is created or destroyed. This ensures that the `taggings_count` will behave the same regardless of whether the new tag is used on a Work or an ExternalWork (or a Bookmark).

## Testing

There are steps for replicating the bug in the JIRA issue.

## Credit

tickinginstant, she/her