### PR TITLE
AO3-4966 Render co-author dialog when ambiguous or invalid pseuds are present

### DIFF
--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -304,7 +304,7 @@ class WorksController < ApplicationController
 
       if @work.errors.empty?
         if @work.invalid_pseuds.present? || @work.ambiguous_pseuds.present?
-          render :_choose_coauthor && return
+          render :_choose_coauthor and return
         else
           @work.posted = @chapter.posted = true if params[:post_button]
           @work.set_revised_at_by_chapter(@chapter)

--- a/spec/controllers/works/default_rails_actions_spec.rb
+++ b/spec/controllers/works/default_rails_actions_spec.rb
@@ -196,7 +196,7 @@ describe WorksController do
       fake_login_known_user(@user)
     end
 
-    it "should not allow a user to submit only a pseud that is not theirs" do
+    it "doesn't allow a user to submit only a pseud that is not theirs" do
       @user2 = create(:user)
       work_attributes = attributes_for(:work)
       work_attributes[:author_attributes] = { ids: [@user2.pseuds.first.id] }
@@ -205,6 +205,22 @@ describe WorksController do
       }.to_not change(Work, :count)
       expect(response).to render_template("new")
       expect(flash[:error]).to eq "You're not allowed to use that pseud."
+    end
+
+    it "renders the co-author view if a work has invalid pseuds" do
+      allow_any_instance_of(Work).to receive(:invalid_pseuds).and_return(@user.pseuds.first)
+      work_attributes = attributes_for(:work)
+      post :create, work: work_attributes
+      expect(response).to render_template("_choose_coauthor")
+      allow_any_instance_of(Work).to receive(:invalid_pseuds).and_call_original
+    end
+
+    it "renders the co-author view if a work has ambiguous pseuds" do
+      allow_any_instance_of(Work).to receive(:ambiguous_pseuds).and_return(@user.pseuds.first)
+      work_attributes = attributes_for(:work)
+      post :create, work: work_attributes
+      expect(response).to render_template("_choose_coauthor")
+      allow_any_instance_of(Work).to receive(:ambiguous_pseuds).and_call_original
     end
   end
 


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-4966

## Purpose

As part of the fix for the 500 error when no fandoms are present, I refactored the create method in the WorksController and introduced an `&& return` (in line with previous refactoring in the controller) which should have been an `and return` and caused a 500 error when it was hit.

## Testing

Try to add a co-author with multiple pseuds to a new work (see Jira for more specific steps)