### PR TITLE
AO3-4964 - Change wording on Diversity Statement

### DIFF
--- a/app/views/home/diversity_statement.html.erb
+++ b/app/views/home/diversity_statement.html.erb
@@ -7,7 +7,7 @@
 
   <p><%= ts("We,") %> <%= link_to ts("the Archive team"), admin_posts_path %><%= ts(", know that we won't get everything right on the first try, and we won't be able to make everyone equally happy. But we strive to find a good balance, and we promise to respectfully consider your feedback and to take it seriously.") %></p>
 
-  <p><%= ts("You are free to express your creativity within the") %> <%= link_to ts("few restrictions"), tos_path %> <%= ts("needed to keep the service viable for other users. With servers in the United States, we need to follow U.S. laws, but the Archive strives to protect your rights to free expression and privacy; you can read about the details in our") %> <%= link_to ts("Terms of Service"), tos_path %>.</p>
+  <p><%= ts("You are free to express your creativity within the") %> <%= link_to ts("few restrictions"), tos_path %> <%= ts("needed to keep the service viable for other users. The Archive strives to protect your rights to free expression and privacy; you can read about the details in our") %> <%= link_to ts("Terms of Service"), tos_path %>.</p>
 
   <p><%= ts("We know that there are") %> <%= link_to ts("some essential parts"), "/admin_posts/295" %> <%= ts("that are still missing to make the Archive truly panfandom: the ability to host fanworks other than text, an interface in languages other than English, and more ways for you to connect with each other, to name just a few. But with your support, we'll get there.") %></p>
 


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-4964

## Purpose

This Pull request updates the language used on the Archive's Diversity page. 

## Testing

Ensure that the Diversity statement reads in part as:

"You are free to express your creativity within the few restrictions needed to keep the service viable for other users. The Archive strives to protect your rights to free expression and privacy; you can read about the details in our Terms of Service."

## References

None.