### PR TITLE
AO3-4953 - Change Support form to require email address

### DIFF
--- a/app/models/feedback.rb
+++ b/app/models/feedback.rb
@@ -8,7 +8,7 @@ class Feedback < ActiveRecord::Base
   validates_presence_of :comment
   validates_presence_of :summary
   validates_presence_of :language
-  validates :email, email_veracity: {allow_blank: true}
+  validates :email, email_veracity: { allow_blank: false }
   validates_length_of :summary, maximum: ArchiveConfig.FEEDBACK_SUMMARY_MAX,
     too_long: ts("must be less than %{max} characters long.", max: ArchiveConfig.FEEDBACK_SUMMARY_MAX_DISPLAYED)
 
@@ -47,9 +47,7 @@ class Feedback < ActiveRecord::Base
 
   def email_and_send
     AdminMailer.feedback(id).deliver
-    if email.present?
-      UserMailer.feedback(id).deliver
-    end
+    UserMailer.feedback(id).deliver
     send_report
   end
 

--- a/app/views/feedbacks/new.html.erb
+++ b/app/views/feedbacks/new.html.erb
@@ -24,14 +24,14 @@
   <fieldset>
     <legend><%= ts("Contact Information") %></legend>
     <p class="notice" id="email-field-description">
-      <%= ts("We value anonymous feedback, but if you'd like a personal reply to your question or comment, we need your email address to contact you. Our spam filter does collect IP addresses, but we never see them.") %>
+      <%= ts("Our spam filter does collect IP addresses, but we never see them.") %>
     </p>
     <dl>
       <dt><%= f.label :username, ts("Your name (optional)") %></dt>
       <dd>
         <%= f.text_field :username %>
       </dd>
-      <dt><%= f.label :email, ts("Your email (optional)") %></dt>
+      <dt class="required"><%= f.label :email, ts("Your email (required)") %></dt>
       <dd>
         <%= f.text_field :email, size: 60, "aria-describedby" => "email-field-description" %>
       </dd>

--- a/app/views/feedbacks/new.html.erb
+++ b/app/views/feedbacks/new.html.erb
@@ -32,7 +32,7 @@
         <%= f.text_field :username %>
       </dd>
       <dt class="required"><%= f.label :email, ts("Your email (required)") %></dt>
-      <dd>
+      <dd class="required">
         <%= f.text_field :email, size: 60, "aria-describedby" => "email-field-description" %>
       </dd>
     </dl>

--- a/features/other_b/support.feature
+++ b/features/other_b/support.feature
@@ -3,7 +3,7 @@ Feature: Filing a support request
   As a confused user
   I want to file a support request
 
-  Scenario: Filing a support request
+  Scenario: Filling a support request
   
   Given I am logged in as "puzzled"
   And basic languages
@@ -21,15 +21,12 @@ Feature: Filing a support request
   When I follow "Support and Feedback"
     And I fill in "Brief summary" with "you suck"
     And I fill in "Your comment" with "blah blah blah"
-    And I fill in "Your email (required)" with ""
+    And I fill in "Your email (required)" with "test@archiveofourown.org"
     And I select "Deutsch" from "feedback_language"
     And all emails have been delivered
     And I press "Send"
-  Then I should see "Email does not seem to be a valid address."
-    And I fill in "Your email (required)" with "test@archiveofourown.org"
-    And I press "Send"
   Then I should see "Your message was sent to the Archive team - thank you!"
-    And 2 emails should be delivered
+    And 1 email should be delivered
     And the email should contain "you suck"
 
   Scenario: Not logged in, with and without email

--- a/features/other_b/support.feature
+++ b/features/other_b/support.feature
@@ -26,8 +26,7 @@ Feature: Filing a support request
     And all emails have been delivered
     And I press "Send"
   Then I should see "Your message was sent to the Archive team - thank you!"
-    And 1 email should be delivered
-    And the email should contain "you suck"
+    And 2 emails should be delivered
 
   Scenario: Not logged in, with and without email
   

--- a/features/other_b/support.feature
+++ b/features/other_b/support.feature
@@ -21,15 +21,18 @@ Feature: Filing a support request
   When I follow "Support and Feedback"
     And I fill in "Brief summary" with "you suck"
     And I fill in "Your comment" with "blah blah blah"
-    And I fill in "Your email (optional)" with ""
+    And I fill in "Your email (required)" with ""
     And I select "Deutsch" from "feedback_language"
     And all emails have been delivered
     And I press "Send"
+  Then I should see "Email does not seem to be a valid address."
+    And I fill in "Your email (required)" with "test@archiveofourown.org"
+    And I press "Send"
   Then I should see "Your message was sent to the Archive team - thank you!"
-    And 1 email should be delivered
+    And 2 emails should be delivered
     And the email should contain "you suck"
 
-  Scenario: Not logged in, with email
+  Scenario: Not logged in, with and without email
   
   When I am on the home page
     And basic languages
@@ -37,23 +40,11 @@ Feature: Filing a support request
   When I select "Deutsch" from "feedback_language"
     And I fill in "Brief summary" with "Just a brief note"
     And I fill in "Your comment" with "Men have their old boys' network, but we have the OTW. You guys rock!"
-    And I fill in "Your email (optional)" with "test@archiveofourown.org"
+    And I fill in "Your email (required)" with ""
     And all emails have been delivered
+    And I press "Send"
+  Then I should see "Email does not seem to be a valid address."
+    And I fill in "Your email (required)" with "test@archiveofourown.org"
     And I press "Send"
   Then I should see "Your message was sent to the Archive team - thank you!"
     And 2 emails should be delivered
-    
-  Scenario: Not logged in, without email
-  
-  When I am on the home page
-    And basic languages
-  When I follow "Support and Feedback"
-    And I select "Deutsch" from "feedback_language"
-    And I fill in "Brief summary" with "you suck"
-    And I fill in "Your comment" with "blah blah blah"
-    And I fill in "Your email (optional)" with ""
-    And all emails have been delivered
-    And I press "Send"
-  Then I should see "Your message was sent to the Archive team - thank you!"
-    And 1 email should be delivered
-    And the email should contain "you suck"

--- a/spec/mailers/feedback_mailer_spec.rb
+++ b/spec/mailers/feedback_mailer_spec.rb
@@ -27,30 +27,4 @@ describe AdminMailer do
      end
 
   end
-
-
-  context 'feedback without email' do
-    let(:feedback) {create(:feedback, email: nil)}
-    let(:mail) {AdminMailer.feedback(feedback.id)}
-
-    it "has the correct subject" do
-      expect(mail).to have_subject "[#{ArchiveConfig.APP_SHORT_NAME}] Support - #{feedback.summary}"
-    end
-
-    it "delivers to the correct address" do
-      expect(mail).to deliver_to ArchiveConfig.FEEDBACK_ADDRESS
-    end
-
-    it "delivers from the correct address" do
-      expect(mail).to deliver_from ArchiveConfig.RETURN_ADDRESS
-    end
-
-    it "body text contains the comment" do
-      expect(mail).to have_body_text(/#{feedback.comment}/)
-    end
-
-    it "body text contains the summary" do
-      expect(mail).to have_body_text(/#{feedback.summary}/)
-    end
-  end
 end


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-4953

## Purpose

* Makes the email field a **required** field for the Support form; and,
* removes the language in the flash notice saying that we accept anonymous feedback.

## Testing

1. Ensure that blue flash-notice on Support form says: "Our spam filter does collect IP addresses, but we never see them."
2. Email field label should now read: "Your email (required)"
3. The email field cannot be blank.
4. The email field must contain a valid email address.
