### PR TITLE
AO3-4621 Fetch Icons via https

### DIFF
--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -38,9 +38,9 @@ module UsersHelper
   # Determine which icon to show on user pages
   def standard_icon(user = nil, pseud = nil)
     if pseud && pseud.icon
-      pseud.icon.url(:standard).gsub(/^http:/, "https")
+      pseud.icon.url(:standard).gsub(/^http:/, "https:")
     elsif user && user.default_pseud && user.default_pseud.icon
-      user.default_pseud.icon.url(:standard).gsub(/^http:/, "https")
+      user.default_pseud.icon.url(:standard).gsub(/^http:/, "https:")
     else
       '/images/skins/iconsets/default/icon_user.png'
     end

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -38,9 +38,9 @@ module UsersHelper
   # Determine which icon to show on user pages
   def standard_icon(user = nil, pseud = nil)
     if pseud && pseud.icon
-      pseud.icon.url(:standard)
+      pseud.icon.url(:standard).gsub(/^http:/, "https")
     elsif user && user.default_pseud && user.default_pseud.icon
-      user.default_pseud.icon.url(:standard)
+      user.default_pseud.icon.url(:standard).gsub(/^http:/, "https")
     else
       '/images/skins/iconsets/default/icon_user.png'
     end

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -7,6 +7,7 @@ class Collection < ActiveRecord::Base
   url: "/system/:class/:attachment/:id/:style/:basename.:extension",
   path: %w(staging production).include?(Rails.env) ? ":class/:attachment/:id/:style.:extension" : ":rails_root/public:url",
   storage: %w(staging production).include?(Rails.env) ? :s3 : :filesystem,
+  s3_protocol: "https",
   s3_credentials: "#{Rails.root}/config/s3.yml",
   bucket: %w(staging production).include?(Rails.env) ? YAML.load_file("#{Rails.root}/config/s3.yml")['bucket'] : "",
   default_url: "/images/skins/iconsets/default/icon_collection.png"

--- a/app/models/pseud.rb
+++ b/app/models/pseud.rb
@@ -10,6 +10,7 @@ class Pseud < ActiveRecord::Base
     styles: { standard: "100x100>" },
     path: %w(staging production).include?(Rails.env) ? ":attachment/:id/:style.:extension" : ":rails_root/public:url",
     storage: %w(staging production).include?(Rails.env) ? :s3 : :filesystem,
+    s3_protocol: "https",
     s3_credentials: "#{Rails.root}/config/s3.yml",
     bucket: %w(staging production).include?(Rails.env) ? YAML.load_file("#{Rails.root}/config/s3.yml")['bucket'] : "",
     default_url: "/images/skins/iconsets/default/icon_user.png"

--- a/app/models/skin.rb
+++ b/app/models/skin.rb
@@ -48,6 +48,7 @@ class Skin < ActiveRecord::Base
                     url: "/system/:class/:attachment/:id/:style/:basename.:extension",
                     path: %w(staging production).include?(Rails.env) ? ":class/:attachment/:id/:style.:extension" : ":rails_root/public:url",
                     storage: %w(staging production).include?(Rails.env) ? :s3 : :filesystem,
+                    s3_protocol: "https",
                     s3_credentials: "#{Rails.root}/config/s3.yml",
                     bucket: %w(staging production).include?(Rails.env) ? YAML.load_file("#{Rails.root}/config/s3.yml")['bucket'] : "",
                     default_url: "/images/skins/iconsets/default/icon_skins.png"


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-4621

## Purpose

Current icons should be served by https, rather than http ( amazon icons ). New icons should be saved in the database as https...

## Testing

Check the page source
