### PR TITLE
AO3-4847 Allow admins to see ip address of commenter

### DIFF
--- a/app/views/comments/_single_comment.html.erb
+++ b/app/views/comments/_single_comment.html.erb
@@ -60,7 +60,7 @@
       <% end %><!-- end caching -->
 
       <% if logged_in_as_admin? %>
-        <p class="comment ip"><%= ts("IP Address: %{ip_address}", ip_address: single_comment.ip_address.blank? ? "No address recorded" : single_comment.ip_address) %></p>
+        <p class="ip"><%= ts("IP Address: %{ip_address}", ip_address: single_comment.ip_address.blank? ? "No address recorded" : single_comment.ip_address) %></p>
       <% end %>
       <%= render "comments/comment_actions", comment: single_comment %>
     <% end %>

--- a/app/views/comments/_single_comment.html.erb
+++ b/app/views/comments/_single_comment.html.erb
@@ -60,7 +60,9 @@
       <% end %><!-- end caching -->
 
       <%= render "comments/comment_actions", comment: single_comment %>
-
+      <% if logged_in_as_admin?  %>
+          <p><%= ts("IP Address: %{ip_address}", ip_address: single_comment.ip_address.blank? ? "None recorded" : single_comment.ip_address) %> </p>
+      <% end %>
     <% end %>
   <% end %>
 </li>

--- a/app/views/comments/_single_comment.html.erb
+++ b/app/views/comments/_single_comment.html.erb
@@ -59,10 +59,10 @@
         <% end %>
       <% end %><!-- end caching -->
 
-      <%= render "comments/comment_actions", comment: single_comment %>
-      <% if logged_in_as_admin?  %>
-          <p><%= ts("IP Address: %{ip_address}", ip_address: single_comment.ip_address.blank? ? "None recorded" : single_comment.ip_address) %> </p>
+      <% if logged_in_as_admin? %>
+        <p class="comment ip"><%= ts("IP Address: %{ip_address}", ip_address: single_comment.ip_address.blank? ? "No address recorded" : single_comment.ip_address) %></p>
       <% end %>
+      <%= render "comments/comment_actions", comment: single_comment %>
     <% end %>
   <% end %>
 </li>

--- a/app/views/comments/_single_comment_abbreviated.html.erb
+++ b/app/views/comments/_single_comment_abbreviated.html.erb
@@ -33,6 +33,6 @@
     </p>
   <% end %>
   <% if logged_in_as_admin? %>
-    <p class="comment ip"><%= ts("IP Address: %{ip_address}", ip_address: single_comment.ip_address.blank? ? "No address recorded" : single_comment.ip_address) %></p>
+    <p class="ip"><%= ts("IP Address: %{ip_address}", ip_address: single_comment.ip_address.blank? ? "No address recorded" : single_comment.ip_address) %></p>
   <% end %>
 </li>

--- a/app/views/comments/_single_comment_abbreviated.html.erb
+++ b/app/views/comments/_single_comment_abbreviated.html.erb
@@ -32,4 +32,7 @@
       <%= ts('Last Edited') %> <%= time_in_zone(single_comment.edited_at) %>
     </p>
   <% end %>
+  <% if logged_in_as_admin? %>
+    <p class="comment ip"><%= ts("IP Address: %{ip_address}", ip_address: single_comment.ip_address.blank? ? "No address recorded" : single_comment.ip_address) %></p>
+  <% end %>
 </li>

--- a/features/comments_and_kudos/add_comment.feature
+++ b/features/comments_and_kudos/add_comment.feature
@@ -1,5 +1,5 @@
 @comments
-Feature: Comment on work 
+Feature: Comment on work
   In order to give feedback
   As a reader
   I'd like to comment on a work
@@ -20,8 +20,8 @@ Scenario: When logged in I can comment on a work
   When I am logged in as "commenter"
     And I view the work "The One Where Neal is Awesome"
     And I fill in "Comment" with "I loved this!"
-    And I press "Comment" 
-  Then I should see "Comment created!" 
+    And I press "Comment"
+  Then I should see "Comment created!"
     And I should see "I loved this!" within ".odd"
     And I should not see "on Chapter 1" within ".odd"
   When I am logged in as "author"
@@ -29,7 +29,26 @@ Scenario: When logged in I can comment on a work
     And I follow "Entire Work"
     And I follow "Comments (1)"
   Then I should see "commenter on Chapter 1" within "h4.heading.byline"
-  
+
+  Scenario: IP address of the commenter are displayed only to an admin
+
+  Given I have no works or comments
+  When I am logged in as "author"
+    And I post the work "The One Where Neal is Awesome"
+  When I am logged in as "commenter"
+    And I view the work "The One Where Neal is Awesome"
+    And I fill in "Comment" with "I loved this!"
+    And I press "Comment"
+  Then I should see "Comment created!"
+    And I should not see "IP Address"
+  When I am logged in as "author"
+    And I view the work "The One Where Neal is Awesome"
+  Then I should not see "IP Address"
+  When I am logged in as an admin
+    And I view the work "The One Where Neal is Awesome"
+  Then I should see "IP Address"
+
+
 Scenario: I cannot comment with a pseud that I don't own
 
   Given the work "Random Work"
@@ -138,7 +157,7 @@ Scenario: Comment threading, comment editing
       And I press "Update"
     Then I should see "must be less than"
       And I should see "Sed mollis sapien ac massa pulvinar facilisis"
-      
+
 Scenario: Don't receive comment notifications of your own comments by default
 
   When I am logged in as "author"
@@ -147,7 +166,7 @@ Scenario: Don't receive comment notifications of your own comments by default
     And I post the comment "Something" on the work "Generic Work"
   Then "author" should be emailed
     And "commenter" should not be emailed
-    
+
 Scenario: Set preference and receive comment notifications of your own comments
 
   When I am logged in as "author"

--- a/public/stylesheets/site/2.0/24-role-admin.css
+++ b/public/stylesheets/site/2.0/24-role-admin.css
@@ -9,10 +9,6 @@ This shows the archive when logged in as admin, and overrides with admin styles,
   background: #066;
 }
 
-#footer .beta {
-  display: none;
-}
-
 #header .admin {
   background: #066;
   border-top: 1px solid #fff;
@@ -45,6 +41,11 @@ div.admin + h3.landmark {
 
 .admin .abuse.comment .userstuff {
   margin: 0.643em;
+}
+
+.comment .ip {
+  margin: 1.929em 0.643em 0.643em;
+  text-align: right;
 }
 
 /* TABLES AND LISTS */


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-4847

## Purpose

Allows admins to see a commenter's IP address

## Testing

Ensure that a guest, an author and the commentator can't see the ip address.
Ensure that an admin can see the ip address.
