### PR TITLE
AO3-4884 Fix exposed HTML in invitation email

### DIFF
--- a/app/views/user_mailer/invitation.html.erb
+++ b/app/views/user_mailer/invitation.html.erb
@@ -20,10 +20,10 @@
   </p>
 
   <p>
-    <%= t ".html.part3", invitation_link: style_link(signup_url(:invitation_token => @invitation.token), signup_url(:invitation_token => @invitation.token)) %>
+    <%= t(".html.part3", invitation_link: style_link(signup_url(:invitation_token => @invitation.token), signup_url(:invitation_token => @invitation.token))).html_safe %>
   </p>
 
   <p>
-    <%= t ".html.faq_link", faq_link: style_link(t(".html.faq_link_text"), archive_faqs_url) %>
+    <%= t(".html.faq_link", faq_link: style_link(t(".html.faq_link_text"), archive_faqs_url)).html_safe %>
   </p>
 <% end %>


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-4884

## Purpose

Our links were showing their HTML. Now they won't.
