### PR TITLE
AO3-4548 Ensuring that translated questions keep to themselves

### DIFF
--- a/app/controllers/archive_faqs_controller.rb
+++ b/app/controllers/archive_faqs_controller.rb
@@ -25,7 +25,7 @@ class ArchiveFaqsController < ApplicationController
     else
       @archive_faq.questions.each do |question|
         question.translations.each do |translation|
-          if translation.is_translated == "1"
+          if translation.is_translated == "1" && params[:language_id].to_s == translation.locale.to_s
             @questions << question
           end
         end

--- a/app/helpers/language_helper.rb
+++ b/app/helpers/language_helper.rb
@@ -15,7 +15,7 @@ module LanguageHelper
     questions = []
     all_questions.each do |question|
       question.translations.each do |translation|
-        if translation.is_translated == "1"
+        if translation.is_translated == "1" && params[:language_id].to_s == translation.locale.to_s
           questions << question
         end
       end


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-4548 

## Purpose

Resolves a BoT problem where if you created a translation of a question in one language (i.e. German), it would cause the original English version of the question to show up in all the other non-English languages even though you had not checked the ticky to make the question show up. 

## Testing

Ensure that when you check a question as translated in one language (i.e. German) that it doesn't show up in any other language.
