### PR TITLE
AO3-4718 Fix permission checks for comments on tags.

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -6,10 +6,10 @@ class CommentsController < ApplicationController
                                               :cancel_comment_reply, :cancel_comment_edit,
                                               :delete_comment, :cancel_comment_delete, :unreviewed, :review_all ]
   before_filter :check_user_status, :only => [:new, :create, :edit, :update, :destroy]
-  before_filter :load_comment, only: [:show, :edit, :update, :delete_comment, :destroy, :approve, :reject]
+  before_filter :load_comment, only: [:show, :edit, :update, :delete_comment, :destroy, :cancel_comment_edit, :cancel_comment_delete, :review, :approve, :reject]
   before_filter :check_visibility, :only => [:show]
   before_filter :check_if_restricted
-  before_filter :check_tag_wrangler_access, :only => [:index, :show]
+  before_filter :check_tag_wrangler_access
   before_filter :check_pseud_ownership, :only => [:create, :update]
   before_filter :check_ownership, :only => [:edit, :update]
   before_filter :check_permission_to_edit, :only => [:edit, :update ]
@@ -111,7 +111,7 @@ class CommentsController < ApplicationController
   end
 
   def check_tag_wrangler_access
-    if @commentable.is_a?(Tag) || (@comment && @comment.commentable.is_a?(Tag))
+    if @commentable.is_a?(Tag) || (@comment && @comment.parent.is_a?(Tag))
       logged_in_as_admin? || permit?("tag_wrangler") || access_denied
     end
   end
@@ -323,7 +323,6 @@ class CommentsController < ApplicationController
   end
 
   def review
-    @comment = Comment.find(params[:id])
     if @comment && current_user_owns?(@comment.ultimate_parent) && @comment.unreviewed?
       @comment.toggle!(:unreviewed)
       # mark associated inbox comments as read
@@ -453,7 +452,6 @@ class CommentsController < ApplicationController
   end
 
   def cancel_comment_edit
-    @comment = Comment.find(params[:id])
     respond_to do |format|
       format.html { redirect_to_comment(@comment) }
       format.js
@@ -473,7 +471,6 @@ class CommentsController < ApplicationController
   end
 
   def cancel_comment_delete
-    @comment = Comment.find(params[:id])
     respond_to do |format|
       format.html do
         options = {}

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -3,7 +3,7 @@ class CommentsController < ApplicationController
   before_filter :load_commentable, :only => [ :index, :new, :create, :edit, :update,
                                               :show_comments, :hide_comments, :add_comment,
                                               :cancel_comment, :add_comment_reply,
-                                              :cancel_comment_reply, :cancel_comment_edit,
+                                              :cancel_comment_reply,
                                               :delete_comment, :cancel_comment_delete, :unreviewed, :review_all ]
   before_filter :check_user_status, :only => [:new, :create, :edit, :update, :destroy]
   before_filter :load_comment, only: [:show, :edit, :update, :delete_comment, :destroy, :cancel_comment_edit, :cancel_comment_delete, :review, :approve, :reject]
@@ -11,7 +11,7 @@ class CommentsController < ApplicationController
   before_filter :check_if_restricted
   before_filter :check_tag_wrangler_access
   before_filter :check_pseud_ownership, :only => [:create, :update]
-  before_filter :check_ownership, :only => [:edit, :update]
+  before_filter :check_ownership, only: [:edit, :update, :cancel_comment_edit]
   before_filter :check_permission_to_edit, :only => [:edit, :update ]
   before_filter :check_permission_to_delete, :only => [:delete_comment, :destroy]
   before_filter :check_anonymous_comment_preference, :only => [:new, :create, :add_comment_reply]

--- a/features/step_definitions/comment_steps.rb
+++ b/features/step_definitions/comment_steps.rb
@@ -130,6 +130,10 @@ When /^I delete the comment$/ do
   step %{I follow "Yes, delete!"}
 end
 
+When /^I view the latest comment$/ do
+  visit comment_path(Comment.last)
+end
+
 Given(/^the moderated work "([^\"]*?)" by "([^\"]*?)"$/) do |work, user|
   step %{I am logged in as "#{user}"}
   step %{I set up the draft "#{work}"}

--- a/features/tags_and_wrangling/tag_comment.feature
+++ b/features/tags_and_wrangling/tag_comment.feature
@@ -242,3 +242,26 @@ I'd like to comment on a tag'
     # all it checks is that the pagination links aren't broken
     When I follow "Next" within ".pagination"
     Then I should see "And now things should not break!"
+
+  Scenario: Comments on a tag should not be visible to non-wranglers.
+
+    Given a canonical fandom "World Domination"
+      And I am logged in as a tag wrangler
+      And I post the comment "Top-secret plans." on the tag "World Domination"
+      And I am logged out
+
+    When I view the latest comment
+
+    Then I should not see "Top-secret plans."
+
+  Scenario: Comments replying to a comment on a tag should not be visible to non-wranglers.
+
+    Given a canonical fandom "World Domination"
+      And I am logged in as a tag wrangler
+      And I post the comment "Anyone have a plan?" on the tag "World Domination"
+      And I reply to a comment with "Top-secret plans."
+      And I am logged out
+
+    When I view the latest comment
+
+    Then I should not see "Top-secret plans."


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-4718

## Purpose

There are two closely related issues with the way that the `check_tag_wrangler_access` filter applies to comments on tags. This pull request attempts to address them.

## Testing

I wrote some instructions on the issue for replicating this problem, as well as some other instructions for manual QA in the contributor chat.

## References

This is a rewrite of #2612, since I realized while trying to merge that the issue was a little larger than I thought, and I wanted to add more tests (and get rid of one of the existing tests, which was inelegantly written).

## Credit

tickinginstant, she/her