### PR TITLE
AO3-4992 Clear Redis before each feature test

### DIFF
--- a/app/models/redis_mail_queue.rb
+++ b/app/models/redis_mail_queue.rb
@@ -74,7 +74,7 @@ class RedisMailQueue
   def self.clear_queue(notification_type)
     redis = redis_for_type(notification_type)
     keys = redis.keys("#{notification_type}_*")
-    redis.del(*keys)
+    redis.del(*keys) unless keys.empty?
     redis.del("notification_#{notification_type}")
   end
 

--- a/features/other_a/autocomplete.feature
+++ b/features/other_a/autocomplete.feature
@@ -1,4 +1,3 @@
-@autocomplete
 Feature: Display autocomplete for tags
   In order to facilitate posting
   I should be getting autocompletes for my tags

--- a/features/step_definitions/autocomplete_steps.rb
+++ b/features/step_definitions/autocomplete_steps.rb
@@ -1,7 +1,3 @@
-Before("@autocomplete") do
-  step %{I have flushed Redis}
-end
-
 Given /^a set of tags for testing autocomplete$/ do
   step %{basic tags}
   step %{a canonical fandom "Supernatural"}

--- a/features/step_definitions/work_search_steps.rb
+++ b/features/step_definitions/work_search_steps.rb
@@ -26,10 +26,6 @@ When /^I search for works by mod$/ do
       step %{I press "Search"}
 end
 
-When /^I have flushed Redis$/ do
-  REDIS_GENERAL.flushdb
-end
-
 ### THEN
 
 Then /^I should see appropriate results for that complex term$/ do

--- a/features/step_definitions/work_steps.rb
+++ b/features/step_definitions/work_steps.rb
@@ -100,7 +100,6 @@ Given(/^I have the Battle set loaded$/) do
   step %{mod fulfills claim}
   step %{I reveal the "Battle 12" challenge}
   step %{I am logged in as "myname4"}
-  step %{I have flushed Redis}
   step %{the statistics_tasks rake task is run}
   step %{the work indexes are updated}
 end

--- a/features/support/hooks.rb
+++ b/features/support/hooks.rb
@@ -1,7 +1,7 @@
 Before do
+  # Reset Elasticsearch
   Work.tire.index.delete
   Work.create_elasticsearch_index
-  Work.tire.index.refresh
 
   Bookmark.tire.index.delete
   Bookmark.create_elasticsearch_index
@@ -13,5 +13,12 @@ Before do
   Pseud.tire.index.delete
   Pseud.create_elasticsearch_index
 
+  # Clear Memcached
   Rails.cache.clear
+
+  # Clear Redis
+  REDIS_GENERAL.flushall
+  REDIS_KUDOS.flushall
+  REDIS_RESQUE.flushall
+  REDIS_ROLLOUT.flushall
 end


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-4992

## Purpose

- Remove autocomplete-test-only-hook to clear Redis
- When clearing the mail queue, skip the DEL command if there are no keys, otherwise we get an error ("wrong number of arguments").

## Testing

Just automated tests.

There's a code change in the mail queue, I'm not sure how we'd test that manually. I did run into the error because of a test though:

https://github.com/otwcode/otwarchive/blob/6e196e01b43255bfec5da5dcefed0f4dda218c3b/features/comments_and_kudos/kudos.feature#L110