### PR TITLE
AO3-4956 Fix capitalization for flash error in opendoors/tools_controller

### DIFF
--- a/app/controllers/opendoors/tools_controller.rb
+++ b/app/controllers/opendoors/tools_controller.rb
@@ -19,7 +19,7 @@ class Opendoors::ToolsController < ApplicationController
       @work = Work.find_by_id(work_id)
     end
     unless @work
-      flash[:error] = ts("We couldn't find that work on the archive. Have you put in the full url?")
+      flash[:error] = ts("We couldn't find that work on the Archive. Have you put in the full URL?")
       redirect_to :action => :index and return
     end
 

--- a/spec/controllers/opendoors/tools_controller_spec.rb
+++ b/spec/controllers/opendoors/tools_controller_spec.rb
@@ -52,17 +52,17 @@ describe Opendoors::ToolsController do
 
       it "redirects to tools if work URL is missing" do
         post :url_update
-        it_redirects_to_with_error(opendoors_tools_path, "We couldn't find that work on the archive. Have you put in the full url?")
+        it_redirects_to_with_error(opendoors_tools_path, "We couldn't find that work on the Archive. Have you put in the full URL?")
       end
 
       it "redirects to tools if work URL is invalid" do
         post :url_update, work_url: "/faq"
-        it_redirects_to_with_error(opendoors_tools_path, "We couldn't find that work on the archive. Have you put in the full url?")
+        it_redirects_to_with_error(opendoors_tools_path, "We couldn't find that work on the Archive. Have you put in the full URL?")
       end
 
       it "redirects to tools if work ID is not found" do
         post :url_update, work_url: "/works/7331278/"
-        it_redirects_to_with_error(opendoors_tools_path, "We couldn't find that work on the archive. Have you put in the full url?")
+        it_redirects_to_with_error(opendoors_tools_path, "We couldn't find that work on the Archive. Have you put in the full URL?")
       end
 
       context "with a valid work ID" do


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-4956?focusedCommentId=348917&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-348917

## Purpose

"archive" to "Archive", "url" to "URL".

## Testing

Check flash error. See issue.