### PR TITLE
AO3-4993 Refactor url caching testing to use rspec rather than cucumber.

### DIFF
--- a/features/importing/work_import.feature
+++ b/features/importing/work_import.feature
@@ -220,23 +220,3 @@ Feature: Import Works
     When I import "http://www.intimations.org/fanfic/idol/Huddling.html"
     Then I should see "Preview"
       And I should see "English"
-
-  Scenario: Searching for a work url should be cached
-    Then there is no cached work_url for "http://www.scarvesandcoffee.net/viewstory.php?sid=9570"
-    When I import "http://www.scarvesandcoffee.net/viewstory.php?sid=9570"
-    Then I should see "Preview"
-    When I press "Post"
-    Then there is no cached work_url for "http://www.scarvesandcoffee.net/viewstory.php?sid=9570"
-    When I look for a work with url "http://www.scarvesandcoffee.net/viewstory.php?sid=9570"
-    Then there is a cached work_url for "http://www.scarvesandcoffee.net/viewstory.php?sid=9570"
-    When I import "http://www.intimations.org/fanfic/idol/Huddling.html"
-    Then I should see "Preview"
-    When I press "Post"
-    Then there is no cached work_url for "http://www.scarvesandcoffee.net/viewstory.php?sid=9570"
-    Then there is no cached work_url for "http://www.intimations.org/fanfic/idol/Huddling.html"
-    When I look for a work with url "http://www.scarvesandcoffee.net/viewstory.php?sid=9570"
-    Then there is a cached work_url for "http://www.scarvesandcoffee.net/viewstory.php?sid=9570"
-    Then there is no cached work_url for "http://www.intimations.org/fanfic/idol/Huddling.html"
-    When I look for a work with url "http://www.intimations.org/fanfic/idol/Huddling.html"
-    Then there is a cached work_url for "http://www.intimations.org/fanfic/idol/Huddling.html"
-

--- a/features/step_definitions/work_steps.rb
+++ b/features/step_definitions/work_steps.rb
@@ -91,10 +91,6 @@ When /^I post the works "([^"]*)"$/ do |worklist|
   end
 end
 
-When /^I look for a work with url "([^"]*)"$/ do |url|
-  Work.find_by_url(url)
-end
-
 ### GIVEN
 
 Given(/^I have the Battle set loaded$/) do
@@ -537,13 +533,4 @@ end
 
 Then /^the work "([^"]*)" should be deleted$/ do |work|
   assert !Work.where(title: work).exists?
-end
-
-Then /^there is (no|a) cached work_url for "([^"]*)"$/ do |sense, url|
-  work = Rails.cache.read(Work.find_by_url_cache_key(url))
-  if sense == "no"
-    assert work.nil?
-  else
-    assert !work.nil?
-  end
 end

--- a/spec/models/work_spec.rb
+++ b/spec/models/work_spec.rb
@@ -186,7 +186,7 @@ describe Work do
 
     it "should find works imported with irrelevant query parameters" do
       work = create(:work, imported_from_url: "http://lj-site.com/thing1?style=mine")
-      expect(Work.find_by_url("http://lj-site.com/thing1?style=other").to eq(work)
+      expect(Work.find_by_url("http://lj-site.com/thing1?style=other")).to eq(work)
       work.destroy
     end
 

--- a/spec/models/work_spec.rb
+++ b/spec/models/work_spec.rb
@@ -185,9 +185,8 @@ describe Work do
     end
 
     it "should find works imported with irrelevant query parameters" do
-      url = "http://lj-site.com/thing1?style=mine"
-      work = create(:work, imported_from_url: url)
-      expect(Work.find_by_url(url)).to eq(work)
+      work = create(:work, imported_from_url: "http://lj-site.com/thing1?style=mine")
+      expect(Work.find_by_url("http://lj-site.com/thing1?style=other").to eq(work)
       work.destroy
     end
 

--- a/spec/models/work_spec.rb
+++ b/spec/models/work_spec.rb
@@ -187,6 +187,13 @@ describe Work do
     it "should find works imported with irrelevant query parameters" do
       url = "http://lj-site.com/thing1?style=mine"
       work = create(:work, imported_from_url: url)
+      expect(Work.find_by_url(url)).to eq(work)
+      work.destroy
+    end
+
+    it "gets the work from cache when searching for an imported work by URL" do
+      url = "http://lj-site.com/thing2"
+      work = create(:work, imported_from_url: url)
       expect(Rails.cache.read(Work.find_by_url_cache_key(url))).to be_nil
       expect(Work.find_by_url(url)).to eq(work)
       expect(Rails.cache.read(Work.find_by_url_cache_key(url))).to eq(work)

--- a/spec/models/work_spec.rb
+++ b/spec/models/work_spec.rb
@@ -152,7 +152,7 @@ describe Work do
     end
 
     it "recipients should be unique" do
-      @work.recipients = @recipient2.pseuds.first.name + "," + @recipient2.pseuds.first.name 
+      @work.recipients = @recipient2.pseuds.first.name + "," + @recipient2.pseuds.first.name
       expect(@work.new_recipients).to eq(@recipient2.pseuds.first.name)
     end
 
@@ -185,8 +185,11 @@ describe Work do
     end
 
     it "should find works imported with irrelevant query parameters" do
-      work = create(:work, imported_from_url: 'http://lj-site.com/thing1?style=mine')
-      expect(Work.find_by_url('http://lj-site.com/thing1?style=other')).to eq(work)
+      url = "http://lj-site.com/thing1?style=mine"
+      work = create(:work, imported_from_url: url)
+      expect(Rails.cache.read(Work.find_by_url_cache_key(url))).to be_nil
+      expect(Work.find_by_url(url)).to eq(work)
+      expect(Rails.cache.read(Work.find_by_url_cache_key(url))).to eq(work)
       work.destroy
     end
   end


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-4993

## Purpose

Move tests from cucumber to rspec

## Testing

No manual testing required.