### PR TITLE
AO3-4997 Resurrect autocomplete feature tests for tag wrangling

### DIFF
--- a/features/step_definitions/autocomplete_steps.rb
+++ b/features/step_definitions/autocomplete_steps.rb
@@ -25,13 +25,6 @@ Then /^I should not see "([^\"]+)" in the autocomplete$/ do |string|
   expect(find("input + .autocomplete", visible: true)).to have_no_content(string)
 end
 
-# this is needed for values like 'Allo 'Allo that can't be handled right
-# by Nokogiri in the typical find
-# note: this might only work for the first autocomplete in a page D:
-Then /^the autocomplete value should be set to "([^"]*)"$/ do |string|
-  string == page.find("input.autocomplete")['value']
-end
-
 # Define all values to be entered here depending on the fieldname
 When /^I enter text in the "([^\"]+)" autocomplete field$/ do |fieldname|
   text = case fieldname

--- a/features/step_definitions/tag_steps.rb
+++ b/features/step_definitions/tag_steps.rb
@@ -202,7 +202,7 @@ end
 
 When /^I edit the tag "([^\"]*)"$/ do |tag|
   tag = Tag.find_by_name!(tag)
-  visit tag_url(tag)
+  visit tag_path(tag)
   within(".header") do
     click_link("Edit")
   end
@@ -210,7 +210,7 @@ end
 
 When /^I view the tag "([^\"]*)"$/ do |tag|
   tag = Tag.find_by_name!(tag)
-  visit tag_url(tag)
+  visit tag_path(tag)
 end
 
 When /^I create the fandom "([^\"]*)" with id (\d+)$/ do |name, id|

--- a/features/tags_and_wrangling/tag_wrangling.feature
+++ b/features/tags_and_wrangling/tag_wrangling.feature
@@ -198,26 +198,28 @@ Feature: Tag wrangling
      When I view the work "Indexing Issues"
      Then I should see "Reindex Work"
 
-  Scenario: Issue 1701: Sign up for a fandom from the edit fandom page, then from editing a child tag of a fandom
-    
+  @javascript
+  Scenario: AO3-1698 Sign up for a fandom from the edit fandom page,
+    then from editing a child tag of a fandom
+
     Given a canonical fandom "'Allo 'Allo"
       And a canonical fandom "From Eroica with Love"
       And a canonical fandom "Cabin Pressure"
       And a noncanonical relationship "Dorian/Martin"
-    
+
     # I want to sign up from the edit page of an unassigned fandom
     When I am logged in as a tag wrangler
       And I edit the tag "'Allo 'Allo"
     Then I should see "Sign Up"
     When I follow "Sign Up"
     Then I should see "Assign fandoms to yourself"
-      And the autocomplete value should be set to "'Allo 'Allo"
+      And I should see "'Allo 'Allo" in the "tag_fandom_string" input
     When I press "Assign"
     Then I should see "Wranglers were successfully assigned"
     When I edit the tag "'Allo 'Allo"
     Then I should not see "Sign Up"
       And I should see the tag wrangler listed as an editor of the tag
-    
+
     # I want to sign up from the edit page of a relationship that belongs to two unassigned fandoms
     When I edit the tag "Dorian/Martin"
     Then I should not see "Sign Up"
@@ -225,10 +227,9 @@ Feature: Tag wrangling
       And I press "Save changes"
     Then I should see "Tag was updated"
     When I follow "Sign Up"
-    When "autocomplete tests with JavaScript" is fixed
-#      Then I should see "Cabin Pressure" in the autocomplete
-#      And I should see "From Eroica with Love" in the autocomplete
-    When I press "Assign"
+      And I choose "Cabin Pressure" from the "Enter as many fandoms as you like." autocomplete
+      And I choose "From Eroica with Love" from the "Enter as many fandoms as you like." autocomplete
+      And I press "Assign"
     Then I should see "Wranglers were successfully assigned"
     When I edit the tag "From Eroica with Love"
     Then I should not see "Sign Up"
@@ -239,27 +240,22 @@ Feature: Tag wrangling
 
   Scenario: A user can not see the reindex button on a tag page
 
-    Given the following typed tags exists
-        | name              | type         | canonical |
-        | Cowboy Bebop      | Fandom       | true      |
+    Given a canonical fandom "Cowboy Bebop"
       And I am logged in as a random user
     When I view the tag "Cowboy Bebop"
     Then I should not see "Reindex Tag"
 
   Scenario: A tag wrangler can not see the reindex button on a tag page
 
-    Given the following typed tags exists
-        | name              | type         | canonical |
-        | Cowboy Bebop      | Fandom       | true      |
+    Given a canonical fandom "Cowboy Bebop"
       And the tag wrangler "lain" with password "lainnial" is wrangler of "Cowboy Bebop"
     When I view the tag "Cowboy Bebop"
     Then I should not see "Reindex Tag"
 
-  Scenario: An admin can see the reindex button on a tag page and will recieve the correct message when pressed.
+  Scenario: An admin can see the reindex button on a tag page
+    and will receive the correct message when pressed.
 
-    Given the following typed tags exists
-        | name              | type         | canonical |
-        | Cowboy Bebop      | Fandom       | true      |
+    Given a canonical fandom "Cowboy Bebop"
       And I am logged in as an admin
     When I view the tag "Cowboy Bebop"
     Then I follow "Reindex Tag"

--- a/features/tags_and_wrangling/tag_wrangling_characters.feature
+++ b/features/tags_and_wrangling/tag_wrangling_characters.feature
@@ -90,10 +90,8 @@ Scenario: character wrangling - syns, mergers, characters, autocompletes
     And I enter "First" in the "Synonym of" autocomplete field
   Then I should see "First Doctor" in the autocomplete
     But I should not see "The First Doctor" in the autocomplete
-  When I fill in "Synonym of" with "First Doctor"
-    And I enter "Doc" in the "Fandoms" autocomplete field
-  Then I should see "Doctor Who" in the autocomplete
-  When I fill in "Fandoms" with "Doctor Who"
+  When I choose "First Doctor" from the "Synonym of" autocomplete
+    And I choose "Doctor Who" from the "Fandoms" autocomplete
     And I press "Save changes"
   Then I should see "Tag was updated"
 
@@ -122,9 +120,7 @@ Scenario: character wrangling - syns, mergers, characters, autocompletes
     And I check "Canonical"
     And I choose "Character"
     And I press "Create Tag"
-    And I enter "First " in the "SubTags" autocomplete field
-  Then I should see "First Doctor" in the autocomplete
-  When I fill in "SubTags" with "First Doctor"
+    And I choose "First Doctor" from the "SubTags" autocomplete
     And I press "Save changes"
   Then I should see "Tag was updated"
   When I follow "First Doctor"

--- a/features/tags_and_wrangling/tag_wrangling_characters.feature
+++ b/features/tags_and_wrangling/tag_wrangling_characters.feature
@@ -2,6 +2,7 @@
 
 Feature: Tag Wrangling - Characters
 
+@javascript
 Scenario: character wrangling - syns, mergers, characters, autocompletes
 
   Given the following activated tag wrangler exists
@@ -11,27 +12,27 @@ Scenario: character wrangling - syns, mergers, characters, autocompletes
     And a fandom exists with name: "Doctor Who", canonical: true
     And a relationship exists with name: "First Doctor/TARDIS", canonical: true
     And I am logged in as "Enigel" with password "wrangulate!"
-    And I follow "Tag Wrangling"
-    
+
   # create a new canonical character from tag wrangling interface
+  When I follow "Tag Wrangling"
     And I follow "New Tag"
     And I fill in "Name" with "The First Doctor"
     And I choose "Character"
-    And I check "tag_canonical"
+    And I check "Canonical"
     And I press "Create Tag"
   Then I should see "Tag was successfully created"
-    And the "tag_canonical" checkbox should be checked
-    And the "tag_canonical" checkbox should not be disabled
-  
+    And the "Canonical" checkbox should be checked
+    And the "Canonical" checkbox should not be disabled
+
   # create a new non-canonical character from tag wrangling interface
   When I follow "New Tag"
     And I fill in "Name" with "The Doctor (1st)"
     And I choose "Character"
     And I press "Create Tag"
   Then I should see "Tag was successfully created"
-    And the "tag_canonical" checkbox should not be checked
-    And the "tag_canonical" checkbox should not be disabled
-    
+    And the "Canonical" checkbox should not be checked
+    And the "Canonical" checkbox should not be disabled
+
   # check those two created properly
   When I am on the search tags page
     And the tag indexes are updated
@@ -43,35 +44,36 @@ Scenario: character wrangling - syns, mergers, characters, autocompletes
   Then I should see "The First Doctor"
     And I should see "The Doctor (1st)"
     And I should not see "The Doctor (1st)" within "span.canonical"
-  
+
   # assigning an existing merger to a non-canonical character
   When I edit the tag "The Doctor (1st)"
     And I fill in "Synonym of" with "The First Doctor"
     And I press "Save changes"
   Then I should see "Tag was updated"
-  When I follow "The First Doctor"
+  When I follow "Edit The First Doctor"
   Then I should not see "Make tag non-canonical and unhook all associations"
- Given I am logged in as an admin
+
+  Given I am logged in as an admin
   When I edit the tag "The Doctor (1st)"
     And I fill in "Synonym of" with "The First Doctor"
     And I press "Save changes"
   Then I should see "Tag was updated"
-  When I follow "The First Doctor"
+  When I follow "Edit The First Doctor"
   Then I should see "Make tag non-canonical and unhook all associations"
     And I should see "The Doctor (1st)"
-    And the "tag_canonical" checkbox should be checked
-    And the "tag_canonical" checkbox should be disabled
-    
+    And the "Canonical" checkbox should be checked
+    And the "Canonical" checkbox should be disabled
+
   # creating a new canonical character by renaming
   When I fill in "Synonym of" with "First Doctor"
     And I press "Save changes"
   Then I should see "Tag was updated"
     And I should not see "Synonyms"
   When I follow "Edit First Doctor"
-  
+
   # creating non-canonical characters from work posting
   When I am logged in as "Enigel" with password "wrangulate!"
-  When I go to the new work page
+    And I go to the new work page
     And I select "Not Rated" from "Rating"
     And I check "No Archive Warnings Apply"
     And I fill in "Fandoms" with "Doctor Who"
@@ -81,32 +83,25 @@ Scenario: character wrangling - syns, mergers, characters, autocompletes
     And I press "Preview"
     And I press "Post"
   Then I should see "Work was successfully posted."
-  
+
   # editing non-canonical character in order to syn it to existing canonical merger
   When I follow "1st Doctor"
     And I follow "Edit"
-    And I fill in "Synonym of" with "First"
-  When "autocomplete tests with JavaScript" is fixed
-#    Then I should see "First Doctor" in the autocomplete
-#    But I should not see "The First Doctor" in the autocomplete
+    And I enter "First" in the "Synonym of" autocomplete field
+  Then I should see "First Doctor" in the autocomplete
+    But I should not see "The First Doctor" in the autocomplete
   When I fill in "Synonym of" with "First Doctor"
-    And I fill in "Fandoms" with "Doc"
-    
-    # don't we want this to pull the fandom as well? if it doesn't already, I think we should add it
-  When "autocomplete tests with JavaScript" is fixed
-#    Then I should see "Doctor Who" in the autocomplete
+    And I enter "Doc" in the "Fandoms" autocomplete field
+  Then I should see "Doctor Who" in the autocomplete
   When I fill in "Fandoms" with "Doctor Who"
     And I press "Save changes"
   Then I should see "Tag was updated"
-  
+
   # adding a non-canonical synonym to a canonical, fandom should be copied
-  When I follow "First Doctor"
+  When I follow "Edit First Doctor"
   Then I should see "Doctor Who"
-    And the "tag_canonical" checkbox should be disabled
-  When I fill in "tag_merger_string" with "One"
-  When "autocomplete tests with JavaScript" is fixed
-#    Then I should see "One" in the autocomplete
-  When I fill in "tag_merger_string" with "One"
+    And the "Canonical" checkbox should be disabled
+  When I choose "One" from the "tag_merger_string_autocomplete" autocomplete
     And I fill in "Relationships" with "First Doctor/TARDIS"
     And I press "Save changes"
   Then I should see "Tag was updated"
@@ -115,21 +110,20 @@ Scenario: character wrangling - syns, mergers, characters, autocompletes
   When I follow "One"
   Then I should see "Doctor Who"
     But I should not see "First Doctor/TARDIS" within ".tags"
-  
+
   # metatags and subtags, transference thereof to a new canonical
-  When I follow "First Doctor"
+  When I follow "Edit First Doctor"
     And I fill in "MetaTags" with "The Doctor (DW)"
     And I press "Save changes"
   Then I should see "Tag was updated"
     But I should not see "The Doctor (DW)"
   When I follow "New Tag"
     And I fill in "Name" with "The Doctor (DW)"
-    And I check "tag_canonical"
+    And I check "Canonical"
     And I choose "Character"
     And I press "Create Tag"
-    And I fill in "SubTags" with "First "
-  When "autocomplete tests with JavaScript" is fixed
-#    Then I should see "First Doctor" in the autocomplete
+    And I enter "First " in the "SubTags" autocomplete field
+  Then I should see "First Doctor" in the autocomplete
   When I fill in "SubTags" with "First Doctor"
     And I press "Save changes"
   Then I should see "Tag was updated"
@@ -138,7 +132,7 @@ Scenario: character wrangling - syns, mergers, characters, autocompletes
   When I follow "New Tag"
     And I fill in "Name" with "John Smith"
     And I choose "Character"
-    And I check "tag_canonical"
+    And I check "Canonical"
     And I press "Create Tag"
     And I fill in "MetaTags" with "First Doctor"
     And I press "Save changes"
@@ -154,14 +148,14 @@ Scenario: character wrangling - syns, mergers, characters, autocompletes
     And I should not see "1st Doctor"
     And I should not see "One"
     And I should not see "The Doctor (DW)"
-  When I follow "First Doctor (DW)"
+  When I follow "Edit First Doctor (DW)"
   Then I should see "John Smith"
     And I should see "First Doctor" within "div#child_Merger_associations_to_remove_checkboxes"
     And I should see "The Doctor (1st)"
     And I should see "1st Doctor"
     And I should see "One" within "div#child_Merger_associations_to_remove_checkboxes"
     And I should see "The Doctor (DW)"
-    
+
   # trying to syn a non-canonical to another non-canonical
   When I follow "New Tag"
     And I fill in "Name" with "Eleventh Doctor"
@@ -179,4 +173,3 @@ Scenario: character wrangling - syns, mergers, characters, autocompletes
   When I fill in "Synonym of" with "Doctor Who"
     And I press "Save changes"
   Then I should see "Doctor Who is a fandom. Synonyms must belong to the same category."
-

--- a/features/tags_and_wrangling/tag_wrangling_fandoms.feature
+++ b/features/tags_and_wrangling/tag_wrangling_fandoms.feature
@@ -2,6 +2,7 @@
 
 Feature: Tag Wrangling - Fandoms
 
+@javascript
 Scenario: fandoms wrangling - syns, mergers, autocompletes, metatags
 
   Given the following activated tag wrangler exists
@@ -11,37 +12,37 @@ Scenario: fandoms wrangling - syns, mergers, autocompletes, metatags
     And a media exists with name: "TV Shows", canonical: true
     And a character exists with name: "Neal Caffrey", canonical: true
     And I am logged in as "Enigel" with password "wrangulate!"
-    And I follow "Tag Wrangling"
-    
+
   # create a new canonical fandom from tag wrangling interface
+  When I follow "Tag Wrangling"
     And I follow "New Tag"
     And I fill in "Name" with "Stargate SG-1"
     And I choose "Fandom"
-    And I check "tag_canonical"
+    And I check "Canonical"
     And I press "Create Tag"
   Then I should see "Tag was successfully created"
-    And the "tag_canonical" checkbox should be checked
-    And the "tag_canonical" checkbox should not be disabled
-  
+    And the "Canonical" checkbox should be checked
+    And the "Canonical" checkbox should not be disabled
+
   # create a new non-canonical fandom from tag wrangling interface
   When I follow "New Tag"
     And I fill in "Name" with "SGA"
     And I choose "Fandom"
     And I press "Create Tag"
   Then I should see "Tag was successfully created"
-    And the "tag_canonical" checkbox should not be checked
-    And the "tag_canonical" checkbox should not be disabled
-    
+    And the "Canonical" checkbox should not be checked
+    And the "Canonical" checkbox should not be disabled
+
   # creating a new canonical fandom by synning
   When I fill in "Synonym of" with "Stargate Atlantis"
     And I press "Save changes"
   Then I should see "Tag was updated"
     And I should not see "Synonyms"
-  When I follow "Stargate Atlantis"
+  When I follow "Edit Stargate Atlantis"
     And I should see "SGA"
-    And the "tag_canonical" checkbox should be checked
-    And the "tag_canonical" checkbox should be disabled
-  
+  Then the "Canonical" checkbox should be checked
+    And the "Canonical" checkbox should be disabled
+
   # creating non-canonical fandoms from work posting
   When I go to the new work page
     And I select "Not Rated" from "Rating"
@@ -52,39 +53,36 @@ Scenario: fandoms wrangling - syns, mergers, autocompletes, metatags
     And I press "Preview"
     And I press "Post"
   Then I should see "Work was successfully posted."
-  
+
   # editing non-canonical fandom in order to syn it to existing canonical merger
   When I follow "SG1"
     And I follow "Edit"
-    And I fill in "Synonym of" with "Stargate"
-  When "autocomplete tests with JavaScript" is fixed
-#    Then I should see "Stargate Atlantis" in the autocomplete
-#    And I should see "Stargate SG-1" in the autocomplete
+    And I enter "Stargate" in the "Synonym of" autocomplete field
+  Then I should see "Stargate Atlantis" in the autocomplete
+    And I should see "Stargate SG-1" in the autocomplete
   When I fill in "Synonym of" with "Stargate SG-1"
-    And I fill in "tag_media_string" with "TV"
-  When "autocomplete tests with JavaScript" is fixed
-#    And I should see "TV Shows" int the autocomplete
-    And I fill in "tag_media_string" with "TV Shows"
+  When I enter "TV" in the "tag_media_string_autocomplete" autocomplete field
+    Then I should see "TV Shows" in the autocomplete
+  When I choose "TV Shows" from the "tag_media_string_autocomplete" autocomplete
     And I press "Save changes"
   Then I should see "Tag was updated"
-  
+
   # adding a non-canonical synonym to a canonical, fandom should be copied
-  When I follow "Stargate SG-1"
+  When I follow "Edit Stargate SG-1"
   Then I should see "TV Shows"
-    And I should see "SG-1"
-    And the "tag_canonical" checkbox should be disabled
-  When I fill in "tag_merger_string" with "Stargate"
-  When "autocomplete tests with JavaScript" is fixed
-#    Then I should see "Stargates SG-1" in the autocomplete
-#      And I should see "the whole Stargate franchise" in the autocomplete
-#      And I should not see "Stargate SG-1" in the autocomplete
-  When I fill in "tag_merger_string" with "Stargates SG-1"
+    And I should see "SG1"
+    And the "Canonical" checkbox should be disabled
+  When I enter "Stargate" in the "tag_merger_string_autocomplete" autocomplete field
+  Then I should see "Stargates SG-1" in the autocomplete
+    And I should see "the whole Stargate franchise" in the autocomplete
+    And I should not see "Stargate SG-1" in the autocomplete
+  When I choose "Stargates SG-1" from the "tag_merger_string_autocomplete" autocomplete
     And I press "Save changes"
   Then I should see "Tag was updated"
     And I should see "Stargates SG-1"
   When I follow "Stargates SG-1"
   Then I should see "TV Shows"
-  
+
   # metatags and subtags, transference thereof to a new canonical
   When I edit the tag "Stargate Atlantis"
     And I fill in "MetaTags" with "Stargate Franchise"
@@ -93,30 +91,24 @@ Scenario: fandoms wrangling - syns, mergers, autocompletes, metatags
     But I should not see "Stargate Franchise" within ".tags"
   When I follow "New Tag"
     And I fill in "Name" with "Stargate Franchise"
-    And I check "tag_canonical"
+    And I check "Canonical"
     And I choose "Fandom"
     And I press "Create Tag"
     And I fill in "tag_media_string" with "TV Shows"
-    And I fill in "SubTags" with "Stargate Atlantis"
-  When "autocomplete tests with JavaScript" is fixed
-#    Then I should see "Stargate Atlantis" in the autocomplete
-  When I fill in "SubTags" with "Stargate Atlantis"
+    And I choose "Stargate Atlantis" from the "Add SubTags" autocomplete
     And I press "Save changes"
   Then I should see "Tag was updated"
     And I should see "TV Shows"
-    And the "tag_canonical" checkbox should be checked
+    And the "Canonical" checkbox should be checked
   When I follow "Stargate Atlantis"
   Then I should see "Stargate Franchise" within "div#parent_MetaTag_associations_to_remove_checkboxes"
   When I edit the tag "Stargate SG-1"
-    And I fill in "MetaTags" with "Stargate Franchise"
-  When "autocomplete tests with JavaScript" is fixed
-#    And I should see "Stargate Franchise" in the autocomplete
-    And I fill in "MetaTags" with "Stargate Franchise"
+    And I choose "Stargate Franchise" from the "Add MetaTags" autocomplete
     And I press "Save changes"
   Then I should see "Tag was updated"
   When I follow "New Tag"
     And I fill in "Name" with "Stargate SG-1: Ark of Truth"
-    And I check "tag_canonical"
+    And I check "Canonical"
     And I choose "Fandom"
     And I press "Create Tag"
     And I fill in "MetaTags" with "Stargate SG-1"
@@ -131,12 +123,12 @@ Scenario: fandoms wrangling - syns, mergers, autocompletes, metatags
     And I should not see "Stargates SG-1"
     And I should not see "SG1"
     And I should not see "Stargate Franchise"
-  When I follow "Stargate SG-1: Greatest Show in the Universe"
+  When I follow "Edit Stargate SG-1: Greatest Show in the Universe"
   Then I should see "Stargate SG-1: Ark of Truth"
     And I should see "Stargates SG-1"
     And I should see "SG1"
     And I should see "Stargate Franchise"
-    
+
   # trying to syn a non-canonical to another non-canonical
   When I follow "New Tag"
     And I fill in "Name" with "White Collar"
@@ -154,22 +146,22 @@ Scenario: fandoms wrangling - syns, mergers, autocompletes, metatags
   When I fill in "Synonym of" with "Neal Caffrey"
     And I press "Save changes"
   Then I should see "Neal Caffrey is a character. Synonyms must belong to the same category."
-  
-  Scenario: Checking the media pages
-  
+
+Scenario: Checking the media pages
+
   Given basic tags
     And tag wrangling is on
     And a media exists with name: "TV Shows", canonical: true
     And a media exists with name: "Video Games", canonical: true
     And a media exists with name: "Books", canonical: true
-    And a fandom exists with name: "Stargate", canonical: true
-    And a fandom exists with name: "Lord of the Rings", canonical: true
-    And a fandom exists with name: "Final Fantasy", canonical: true
-    And a fandom exists with name: "Yuletide RPF", canonical: true
-    And a fandom exists with name: "A weird thing", canonical: true
-    And a fandom exists with name: "Be another thing", canonical: true
-    And a fandom exists with name: "Be a second B fandom", canonical: true
-    And a fandom exists with name: "Can sort alphabetically", canonical: true
+    And a canonical fandom "Stargate"
+    And a canonical fandom "Lord of the Rings"
+    And a canonical fandom "Final Fantasy"
+    And a canonical fandom "Yuletide RPF"
+    And a canonical fandom "A weird thing"
+    And a canonical fandom "Be another thing"
+    And a canonical fandom "Be a second B fandom"
+    And a canonical fandom "Can sort alphabetically"
     And the following activated tag wrangler exists
     | login  | password    |
     | Enigel | wrangulate! |
@@ -186,7 +178,9 @@ Scenario: fandoms wrangling - syns, mergers, autocompletes, metatags
     And I fill in "tag_media_string" with "Video Games"
     And I press "Save changes"
   Then I should see "Tag was updated"
-  When I post the work "Test" with fandom "Yuletide RPF"
+
+  Given I post the work "Test" with fandom "Yuletide RPF"
+    And I post the work "Test Ring" with fandom "Lord of the Rings"
   When I go to the fandoms page
   Then I should see "Fandoms" within "h2"
     And I should see "Books" within "div#main .media"
@@ -194,15 +188,21 @@ Scenario: fandoms wrangling - syns, mergers, autocompletes, metatags
     And I should see "Video Games" within "div#main .media"
     And I should see "Uncategorized Fandoms" within "div#main .media"
     And I should see "Yuletide RPF" within "div#main .media"
+
+  # Tags will show up if there's at least a work
   When I follow "Books"
   Then I should see "Fandoms > Books"
-    # TODO: figure out why this is broken
-    # And I should not see "No fandoms found"
-    # And I should see "Lord of the Rings"
-    And I should see "No fandoms found"
-    And I should not see "Lord of the Rings"
+    And I should not see "No fandoms found"
+    And I should see "Lord of the Rings"
     And I should not see "Stargate"
     And I should not see "Yuletide RPF"
+
+  # Tags will not show up if there are no works
+  When I go to the fandoms page
+    And I follow "Video Games"
+  Then I should see "No fandoms found"
+    And I should not see "Final Fantasy"
+
   When I go to the media page
   Then I should see "Fandoms" within "h2"
   When I follow "Uncategorized Fandoms"
@@ -210,4 +210,3 @@ Scenario: fandoms wrangling - syns, mergers, autocompletes, metatags
     And I should see "A weird thing" within "#letter-W .tags"
     And I should see "Be a second B fandom" within "#letter-B .tags"
     And I should see "Be another thing" within "#letter-B .tags"
-

--- a/features/tags_and_wrangling/tag_wrangling_fandoms.feature
+++ b/features/tags_and_wrangling/tag_wrangling_fandoms.feature
@@ -60,10 +60,8 @@ Scenario: fandoms wrangling - syns, mergers, autocompletes, metatags
     And I enter "Stargate" in the "Synonym of" autocomplete field
   Then I should see "Stargate Atlantis" in the autocomplete
     And I should see "Stargate SG-1" in the autocomplete
-  When I fill in "Synonym of" with "Stargate SG-1"
-  When I enter "TV" in the "tag_media_string_autocomplete" autocomplete field
-    Then I should see "TV Shows" in the autocomplete
-  When I choose "TV Shows" from the "tag_media_string_autocomplete" autocomplete
+  When I choose "Stargate SG-1" from the "Synonym of" autocomplete
+    And I choose "TV Shows" from the "tag_media_string_autocomplete" autocomplete
     And I press "Save changes"
   Then I should see "Tag was updated"
 

--- a/features/tags_and_wrangling/tag_wrangling_freeforms.feature
+++ b/features/tags_and_wrangling/tag_wrangling_freeforms.feature
@@ -56,12 +56,8 @@ Scenario: freeforms wrangling - syns, mergers, autocompletes, metatags
   # editing non-canonical freeform in order to syn it to existing canonical merger
   When I follow "Pirate AU"
     And I follow "Edit"
-    And I enter "Alternate Universe " in the "Synonym of" autocomplete field
-  Then I should see "Alternate Universe Pirates" in the autocomplete
-  When I fill in "Synonym of" with "Alternate Universe Pirates"
-    And I enter "No" in the "tag_fandom_string_autocomplete" autocomplete field
-  Then I should see "No Fandom" in the autocomplete
-  When I choose "No Fandom" from the "tag_fandom_string_autocomplete" autocomplete
+    And I choose "Alternate Universe Pirates" from the "Synonym of" autocomplete
+    And I choose "No Fandom" from the "tag_fandom_string_autocomplete" autocomplete
     And I press "Save changes"
   Then I should see "Tag was updated"
 
@@ -70,8 +66,6 @@ Scenario: freeforms wrangling - syns, mergers, autocompletes, metatags
   Then I should see "No Fandom"
     And I should see "Pirate AU"
     And the "Canonical" checkbox should be disabled
-  When I enter "Arrr" in the "tag_merger_string_autocomplete" autocomplete field
-  Then I should see "Arrr-verse" in the autocomplete
   When I choose "Arrr-verse" from the "tag_merger_string_autocomplete" autocomplete
     And I press "Save changes"
   Then I should see "Tag was updated"
@@ -99,9 +93,7 @@ Scenario: freeforms wrangling - syns, mergers, autocompletes, metatags
   When I follow "Alternate Universe Pirates"
   Then I should see "Alternate Universe" within "div#parent_MetaTag_associations_to_remove_checkboxes"
   When I edit the tag "Alternate Universe Space Pirates"
-    And I enter "Alternate Universe P" in the "MetaTags" autocomplete field
-  Then I should see "Alternate Universe Pirates" in the autocomplete
-  When I fill in "MetaTags" with "Alternate Universe Pirates"
+    And I choose "Alternate Universe Pirates" from the "MetaTags" autocomplete
     And I press "Save changes"
   Then I should see "Tag was updated"
   When I follow "Alternate Universe Pirates"

--- a/features/tags_and_wrangling/tag_wrangling_freeforms.feature
+++ b/features/tags_and_wrangling/tag_wrangling_freeforms.feature
@@ -2,6 +2,7 @@
 
 Feature: Tag Wrangling - Freeforms
 
+@javascript
 Scenario: freeforms wrangling - syns, mergers, autocompletes, metatags
 
   Given the following activated tag wrangler exists
@@ -10,36 +11,36 @@ Scenario: freeforms wrangling - syns, mergers, autocompletes, metatags
     And basic tags
     And I am logged in as "Enigel" with password "wrangulate!"
     And I follow "Tag Wrangling"
-    
+
   # create a new canonical freeform from tag wrangling interface
-    And I follow "New Tag"
+  When I follow "New Tag"
     And I fill in "Name" with "Alternate Universe Pirates"
     And I choose "Freeform"
-    And I check "tag_canonical"
+    And I check "Canonical"
     And I press "Create Tag"
   Then I should see "Tag was successfully created"
-    And the "tag_canonical" checkbox should be checked
-    And the "tag_canonical" checkbox should not be disabled
-  
+    And the "Canonical" checkbox should be checked
+    And the "Canonical" checkbox should not be disabled
+
   # create a new non-canonical freeform from tag wrangling interface
   When I follow "New Tag"
     And I fill in "Name" with "Pirates! in Spaaaaace! AU"
     And I choose "Freeform"
     And I press "Create Tag"
   Then I should see "Tag was successfully created"
-    And the "tag_canonical" checkbox should not be checked
-    And the "tag_canonical" checkbox should not be disabled
-    
+    And the "Canonical" checkbox should not be checked
+    And the "Canonical" checkbox should not be disabled
+
   # creating a new canonical freeform by synning
   When I fill in "Synonym of" with "Alternate Universe Space Pirates"
     And I press "Save changes"
   Then I should see "Tag was updated"
     And I should not see "Synonyms"
-  When I follow "Alternate Universe Space Pirates"
+  When I follow "Edit Alternate Universe Space Pirates"
     And I should see "Pirates! in Spaaaaace! AU"
-    And the "tag_canonical" checkbox should be checked
-    And the "tag_canonical" checkbox should be disabled
-  
+    And the "Canonical" checkbox should be checked
+    And the "Canonical" checkbox should be disabled
+
   # creating non-canonical freeforms from work posting
   When I go to the new work page
     And I select "Not Rated" from "Rating"
@@ -51,62 +52,55 @@ Scenario: freeforms wrangling - syns, mergers, autocompletes, metatags
     And I press "Preview"
     And I press "Post"
   Then I should see "Work was successfully posted."
-  
+
   # editing non-canonical freeform in order to syn it to existing canonical merger
   When I follow "Pirate AU"
     And I follow "Edit"
-    And I fill in "Synonym of" with "Alternate Universe "
-  When "autocomplete tests with JavaScript" is fixed
-#    Then I should see "Alternate Universe Pirates" in the autocomplete
+    And I enter "Alternate Universe " in the "Synonym of" autocomplete field
+  Then I should see "Alternate Universe Pirates" in the autocomplete
   When I fill in "Synonym of" with "Alternate Universe Pirates"
-    And I fill in "Fandoms" with "No"
-  When "autocomplete tests with JavaScript" is fixed
-#    And I should see "No Fandom" in the autocomplete
-  When I fill in "Fandoms" with "No Fandom"
+    And I enter "No" in the "tag_fandom_string_autocomplete" autocomplete field
+  Then I should see "No Fandom" in the autocomplete
+  When I choose "No Fandom" from the "tag_fandom_string_autocomplete" autocomplete
     And I press "Save changes"
   Then I should see "Tag was updated"
-  
+
   # adding a non-canonical synonym to a canonical, fandom should be copied
-  When I follow "Alternate Universe Pirates"
+  When I follow "Edit Alternate Universe Pirates"
   Then I should see "No Fandom"
     And I should see "Pirate AU"
-    And the "tag_canonical" checkbox should be disabled
-  When I fill in "tag_merger_string" with "Arrr"
-  When "autocomplete tests with JavaScript" is fixed
-#    Then I should see "Arrr-verse" in the autocomplete
-  When I fill in "tag_merger_string" with "Arrr-verse"
+    And the "Canonical" checkbox should be disabled
+  When I enter "Arrr" in the "tag_merger_string_autocomplete" autocomplete field
+  Then I should see "Arrr-verse" in the autocomplete
+  When I choose "Arrr-verse" from the "tag_merger_string_autocomplete" autocomplete
     And I press "Save changes"
   Then I should see "Tag was updated"
     And I should see "Arrr-verse"
   When I follow "Arrr-verse"
   Then I should see "No Fandom"
-  
+
   # metatags and subtags, transference thereof to a new canonical
-  When I follow "Alternate Universe Pirates"
+  When I follow "Edit Alternate Universe Pirates"
     And I fill in "MetaTags" with "Alternate Universe"
     And I press "Save changes"
   Then I should see "Tag was updated"
     But I should not see "Alternate Universe" within "dd.tags"
   When I follow "New Tag"
     And I fill in "Name" with "Alternate Universe"
-    And I check "tag_canonical"
+    And I check "Canonical"
     And I choose "Freeform"
     And I press "Create Tag"
     And I fill in "Fandoms" with "No Fandom"
-    And I fill in "SubTags" with "Alternate Universe P"
-  When "autocomplete tests with JavaScript" is fixed
-#    Then I should see "Alternate Universe Pirates" in the autocomplete
-  When I fill in "SubTags" with "Alternate Universe Pirates"
+    And I choose "Alternate Universe Pirates" from the "SubTags" autocomplete
     And I press "Save changes"
   Then I should see "Tag was updated"
     And I should see "No Fandom"
-    And the "tag_canonical" checkbox should be checked
+    And the "Canonical" checkbox should be checked
   When I follow "Alternate Universe Pirates"
   Then I should see "Alternate Universe" within "div#parent_MetaTag_associations_to_remove_checkboxes"
   When I edit the tag "Alternate Universe Space Pirates"
-    And I fill in "MetaTags" with "Alternate Universe P"
-  When "autocomplete tests with JavaScript" is fixed
-#    And I should see "Alternate Universe Pirates" in the autocomplete
+    And I enter "Alternate Universe P" in the "MetaTags" autocomplete field
+  Then I should see "Alternate Universe Pirates" in the autocomplete
   When I fill in "MetaTags" with "Alternate Universe Pirates"
     And I press "Save changes"
   Then I should see "Tag was updated"
@@ -118,7 +112,7 @@ Scenario: freeforms wrangling - syns, mergers, autocompletes, metatags
     And I should not see "Alternate Universe Space Pirates"
     And I should not see "Pirate AU"
     And I should not see "Arrr-verse"
-  When I follow "Alternate Universe Pirrrates"
+  When I follow "Edit Alternate Universe Pirrrates"
   Then I should see "Alternate Universe Space Pirates"
     And I should see "Pirate AU"
     And I should see "Arrr-verse"
@@ -141,4 +135,3 @@ Scenario: freeforms wrangling - syns, mergers, autocompletes, metatags
   When I fill in "Synonym of" with "No Fandom"
     And I press "Save changes"
   Then I should see "No Fandom is a fandom. Synonyms must belong to the same category."
-

--- a/features/tags_and_wrangling/tag_wrangling_relationships.feature
+++ b/features/tags_and_wrangling/tag_wrangling_relationships.feature
@@ -2,39 +2,40 @@
 
 Feature: Tag Wrangling - Relationships
 
+@javascript
 Scenario: relationship wrangling - syns, mergers, characters, autocompletes
 
   Given the following activated tag wrangler exists
     | login  | password    |
     | Enigel | wrangulate! |
     And basic tags
-    And a fandom exists with name: "Torchwood", canonical: true
-    And a character exists with name: "Hoban Washburne", canonical: true
-    And a character exists with name: "Zoe Washburne", canonical: true
-    And a character exists with name: "Jack Harkness", canonical: true
-    And a character exists with name: "Ianto Jones", canonical: true
+    And a canonical fandom "Torchwood"
+    And a canonical character "Hoban Washburne"
+    And a canonical character "Zoe Washburne"
+    And a canonical character "Jack Harkness"
+    And a canonical character "Ianto Jones"
     And I am logged in as an admin
     And I follow "Tag Wrangling"
-    
+
   # create a new canonical relationship from tag wrangling interface
-    And I follow "New Tag"
+  When I follow "New Tag"
     And I fill in "Name" with "Jack Harkness/Ianto Jones"
     And I choose "Relationship"
-    And I check "tag_canonical"
+    And I check "Canonical"
     And I press "Create Tag"
   Then I should see "Tag was successfully created"
-    And the "tag_canonical" checkbox should be checked
-    And the "tag_canonical" checkbox should not be disabled
-  
+    And the "Canonical" checkbox should be checked
+    And the "Canonical" checkbox should not be disabled
+
   # create a new non-canonical relationship from tag wrangling interface
   When I follow "New Tag"
     And I fill in "Name" with "Wash/Zoe"
     And I choose "Relationship"
     And I press "Create Tag"
   Then I should see "Tag was successfully created"
-    And the "tag_canonical" checkbox should not be checked
-    And the "tag_canonical" checkbox should not be disabled
-  
+    And the "Canonical" checkbox should not be checked
+    And the "Canonical" checkbox should not be disabled
+
   # assigning characters AND a new merger to a non-canonical relationship
   When I fill in "Characters" with "Hoban Washburne, Zoe Washburne"
     And I fill in "Synonym of" with "Hoban Washburne/Zoe Washburne"
@@ -42,27 +43,27 @@ Scenario: relationship wrangling - syns, mergers, characters, autocompletes
   Then I should see "Tag was updated"
     And I should see "Hoban Washburne" within "div#parent_Character_associations_to_remove_checkboxes"
     And I should see "Zoe Washburne" within "div#parent_Character_associations_to_remove_checkboxes"
-  When I follow "Hoban Washburne/Zoe Washburne"
+  When I follow "Edit Hoban Washburne/Zoe Washburne"
   Then I should see "Hoban Washburne" within "div#parent_Character_associations_to_remove_checkboxes"
     And I should see "Zoe Washburne" within "div#parent_Character_associations_to_remove_checkboxes"
     And I should see "Wash/Zoe"
-    And the "tag_canonical" checkbox should be checked
-    And the "tag_canonical" checkbox should be disabled
-    
+    And the "Canonical" checkbox should be checked
+    And the "Canonical" checkbox should be disabled
+
   # creating a new canonical relationship by renaming
   When I fill in "Synonym of" with "Hoban 'Wash' Washburne/Zoe Washburne"
     And I press "Save changes"
   Then I should see "Tag was updated"
     And I should not see "Synonyms"
-  When I follow "Hoban 'Wash' Washburne/Zoe Washburne"
+  When I follow "Edit Hoban 'Wash' Washburne/Zoe Washburne"
   Then I should see "Make tag non-canonical and unhook all associations"
     And I should see "Wash/Zoe"
     And I should see "Hoban Washburne/Zoe Washburne"
     And I should see "Hoban Washburne" within "div#parent_Character_associations_to_remove_checkboxes"
     And I should see "Zoe Washburne" within "div#parent_Character_associations_to_remove_checkboxes"
-    And the "tag_canonical" checkbox should be checked
-    And the "tag_canonical" checkbox should be disabled
-  
+    And the "Canonical" checkbox should be checked
+    And the "Canonical" checkbox should be disabled
+
   # creating non-canonical relationships from work posting
   When I am logged in as "Enigel" with password "wrangulate!"
    And I go to the new work page
@@ -75,36 +76,28 @@ Scenario: relationship wrangling - syns, mergers, characters, autocompletes
     And I press "Preview"
     And I press "Post"
   Then I should see "Work was successfully posted."
-  
+
   # editing non-canonical relationship in order to syn it to existing canonical merger AND add characters
   When I follow "Jack/Ianto"
     And I follow "Edit"
-    And I fill in "Synonym of" with "Jack H"
-  When "autocomplete tests with JavaScript" is fixed
-#    Then I should see "Jack Harkness/Ianto Jones" in the autocomplete
+    And I enter "Jack H" in the "Synonym of" autocomplete field
+  Then I should see "Jack Harkness/Ianto Jones" in the autocomplete
   When I fill in "Synonym of" with "Jack Harkness/Ianto Jones"
-    And I fill in "Characters" with "Jack H"
-  When "autocomplete tests with JavaScript" is fixed
-#    And I should see "Jack Harkness" in the autocomplete
-    And I fill in "Characters" with "Jack Harkness, Ianto Jones"
-    And I fill in "Fandoms" with "Tor"
-  When "autocomplete tests with JavaScript" is fixed
-#    And I should see "Torchwood" in the autocomplete
-    And I fill in "Fandoms" with "Torchwood"
+    And I enter "Jack H" in the "Characters" autocomplete field
+  Then I should see "Jack Harkness" in the autocomplete
+  When I fill in "Characters" with "Jack Harkness, Ianto Jones"
+    And I choose "Torchwood" from the "Fandoms" autocomplete
     And I press "Save changes"
   Then I should see "Tag was updated"
-  
+
   # adding a non-canonical synonym to a canonical, fandom should be copied
-  When I follow "Jack Harkness/Ianto Jones"
+  When I follow "Edit Jack Harkness/Ianto Jones"
   Then I should see "Jack Harkness" within "div#parent_Character_associations_to_remove_checkboxes"
     And I should see "Ianto Jones" within "div#parent_Character_associations_to_remove_checkboxes"
     And I should see "Torchwood"
     And I should see "Jack/Ianto"
-    And the "tag_canonical" checkbox should be disabled
-  When "autocomplete tests with JavaScript" is fixed
-#    When I fill in "tag_merger_string" with "Jant"
-#    Then I should see "Janto" in the autocomplete
-  When I fill in "tag_merger_string" with "Janto"
+    And the "Canonical" checkbox should be disabled
+    And I choose "Janto" from the "tag_merger_string_autocomplete" autocomplete
     And I press "Save changes"
   Then I should see "Tag was updated"
     And I should see "Janto"
@@ -112,22 +105,19 @@ Scenario: relationship wrangling - syns, mergers, characters, autocompletes
   Then I should see "Torchwood"
     But I should not see "Jack Harkness" within ".tags"
     And I should not see "Ianto Jones" within ".tags"
-  
+
   # metatags and subtags, transference thereof to a new canonical
-  When I follow "Jack Harkness/Ianto Jones"
+  When I follow "Edit Jack Harkness/Ianto Jones"
     And I fill in "MetaTags" with "Jack Harkness/Male Character"
     And I press "Save changes"
   Then I should see "Tag was updated"
     But I should not see "Jack Harkness/Male Character"
   When I follow "New Tag"
     And I fill in "Name" with "Jack Harkness/Male Character"
-    And I check "tag_canonical"
+    And I check "Canonical"
     And I choose "Relationship"
     And I press "Create Tag"
-    And I fill in "SubTags" with "Jack Harkness"
-  When "autocomplete tests with JavaScript" is fixed
-#    Then I should see "Jack Harkness/Ianto Jones" in the autocomplete
-  When I fill in "SubTags" with "Jack Harkness/Ianto Jones"
+    And I choose "Jack Harkness/Ianto Jones" from the "SubTags" autocomplete
     And I press "Save changes"
   Then I should see "Tag was updated"
   When I follow "Jack Harkness/Ianto Jones"
@@ -135,7 +125,7 @@ Scenario: relationship wrangling - syns, mergers, characters, autocompletes
   When I follow "New Tag"
     And I fill in "Name" with "Jack Harkness/Robot Ianto Jones"
     And I choose "Relationship"
-    And I check "tag_canonical"
+    And I check "Canonical"
     And I press "Create Tag"
     And I fill in "MetaTags" with "Jack Harkness/Ianto Jones"
     And I press "Save changes"
@@ -150,13 +140,13 @@ Scenario: relationship wrangling - syns, mergers, characters, autocompletes
     And I should not see "Jack Harkness/Male Character"
     And I should not see "Janto"
     And I should not see "Jack/Ianto"
-  When I follow "Captain Jack Harkness/Ianto Jones"
+  When I follow "Edit Captain Jack Harkness/Ianto Jones"
   Then I should see "Jack Harkness/Robot Ianto Jones"
     And I should see "Jack Harkness/Male Character"
     And I should see "Janto"
     And I should see "Jack/Ianto"
     And I should see "Jack Harkness/Ianto Jones" within "div#child_Merger_associations_to_remove_checkboxes"
-    
+
   # trying to syn a non-canonical to another non-canonical
   When I follow "New Tag"
     And I fill in "Name" with "James Norrington/Jack Sparrow"
@@ -174,33 +164,33 @@ Scenario: relationship wrangling - syns, mergers, characters, autocompletes
   When I fill in "Synonym of" with "Torchwood"
     And I press "Save changes"
   Then I should see "Torchwood is a fandom. Synonyms must belong to the same category."
-  
-  Scenario: Issue 962, non-canonical merger pairings
-  
+
+Scenario: AO3-959 Non-canonical merger pairings
+
   Given the following activated tag wrangler exists
     | login  | password    |
     | Enigel | wrangulate! |
     And basic tags
-    And a fandom exists with name: "Testing", canonical: true
-    And a relationship exists with name: "Testing McTestypants/Testing McTestySkirt", canonical: true
-    And a relationship exists with name: "Testypants/Testyskirt", canonical: false
+    And a canonical fandom "Testing"
+    And a canonical relationship "Testing McTestypants/Testing McTestySkirt"
+    And a noncanonical relationship "Testypants/Testyskirt"
     And I am logged in as "Enigel" with password "wrangulate!"
     And I follow "Tag Wrangling"
-    
+
   When I edit the tag "Testing McTestypants/Testing McTestySkirt"
     And I fill in "Fandoms" with "Testing"
     And I press "Save changes"
   Then I should see "Tag was updated"
-  
+
   When I edit the tag "Testypants/Testyskirt"
     And I fill in "Synonym of" with "Testing McTestypants/Testing McTestySkirt"
     And I press "Save changes"
   Then I should see "Tag was updated"
-  
+
   When I edit the tag "Testing McTestypants/Testing McTestySkirt"
     # I'm not sure how the line below was ever passing? The checkbox is disabled, and from what I can gather from
     # some wranglers, it is expected behavior.
-    # And I uncheck "tag_canonical"
+    # And I uncheck "Canonical"
     And I press "Save changes"
   Then I should see "Tag was updated"
 
@@ -210,7 +200,7 @@ Scenario: relationship wrangling - syns, mergers, characters, autocompletes
     And I press "Preview"
     And I press "Update"
   Then I should see "Work was successfully updated"
-  
+
   When I go to Enigel's works page
   Then I should see "Testypants/Testyskirt"
      And I should see "Testing McTestypants/Testing McTestySkirt"
@@ -221,22 +211,22 @@ Scenario: relationship wrangling - syns, mergers, characters, autocompletes
   Then I should see "Testypants/Testyskirt"
     And I should not see "Testing McTestypants/Testing McTestySkirt"
 
-  Scenario: Issue 2150: creating a new merger to a non-can tag while adding characters which belong to a fandom
-  
+Scenario: AO3-2147 Creating a new merger to a non-can tag while adding characters which belong to a fandom
+
   Given the following activated tag wrangler exists
     | login  | password    |
-    | Enigel | wrangulate |
+    | Enigel | wrangulate  |
     And the following activated user exists
     | login  | password    |
     | writer | password    |
     And basic tags
-    And a fandom exists with name: "Up with Testing", canonical: true
-    And a fandom exists with name: "Coding", canonical: true
-    And a character exists with name: "Testing McTestypants", canonical: true
-    And a character exists with name: "Testing McTestySkirt", canonical: true
-    
+    And a canonical fandom "Up with Testing"
+    And a canonical fandom "Coding"
+    And a canonical character "Testing McTestypants"
+    And a canonical character "Testing McTestySkirt"
+
   # create a relationship from posting a work as a regular user, just in case
-   Given I am logged in as "writer" with password "password"
+  Given I am logged in as "writer" with password "password"
     And I follow "New Work"
     And I fill in "Fandoms" with "Up with Testing"
     And I fill in "Work Title" with "whatever"
@@ -245,7 +235,7 @@ Scenario: relationship wrangling - syns, mergers, characters, autocompletes
     And I press "Preview"
     And I press "Post"
     And I log out
-  
+
   # wrangle the tags to be as close of those that have errored on beta and test
   When I am logged in as "Enigel" with password "wrangulate"
     And I edit the tag "Coding"
@@ -253,17 +243,17 @@ Scenario: relationship wrangling - syns, mergers, characters, autocompletes
     And I press "Save changes"
   Then I should see "Tag was updated"
     And I should see "Up with Testing"
-    
+
   When I edit the tag "Testing McTestypants"
     And I fill in "Fandoms" with "Up with Testing, Coding"
     And I press "Save changes"
   Then I should see "Tag was updated"
-  
+
   When I edit the tag "Testing McTestySkirt"
     And I fill in "Fandoms" with "Up with Testing, Coding"
     And I press "Save changes"
   Then I should see "Tag was updated"
-  
+
   When I edit the tag "Testypants/Testyskirt"
     And I fill in "Synonym of" with "Testing McTestypants/Testing McTestySkirt"
     And I fill in "Characters" with "Testing McTestypants, Testing McTestySkirt"
@@ -279,9 +269,9 @@ Scenario: relationship wrangling - syns, mergers, characters, autocompletes
     And I should see "Up with Testing" within "div#parent_Fandom_associations_to_remove_checkboxes"
     And I should see "Coding" within "div#parent_Fandom_associations_to_remove_checkboxes"
     And I should see "Testypants/Testyskirt"
-    And the "tag_canonical" checkbox should be checked
-    And the "tag_canonical" checkbox should be disabled
-  
+    And the "Canonical" checkbox should be checked
+    And the "Canonical" checkbox should be disabled
+
   When I edit the tag "Testing McTestypants/Testing McTestySkirt"
     And I fill in "Synonym of" with "Dame Tester/Sir Tester"
     And I press "Save changes"

--- a/features/tags_and_wrangling/tag_wrangling_relationships.feature
+++ b/features/tags_and_wrangling/tag_wrangling_relationships.feature
@@ -80,12 +80,9 @@ Scenario: relationship wrangling - syns, mergers, characters, autocompletes
   # editing non-canonical relationship in order to syn it to existing canonical merger AND add characters
   When I follow "Jack/Ianto"
     And I follow "Edit"
-    And I enter "Jack H" in the "Synonym of" autocomplete field
-  Then I should see "Jack Harkness/Ianto Jones" in the autocomplete
-  When I fill in "Synonym of" with "Jack Harkness/Ianto Jones"
-    And I enter "Jack H" in the "Characters" autocomplete field
-  Then I should see "Jack Harkness" in the autocomplete
-  When I fill in "Characters" with "Jack Harkness, Ianto Jones"
+    And I choose "Jack Harkness/Ianto Jones" from the "Synonym of" autocomplete
+    And I choose "Jack Harkness" from the "Characters" autocomplete
+    And I choose "Ianto Jones" from the "Characters" autocomplete
     And I choose "Torchwood" from the "Fandoms" autocomplete
     And I press "Save changes"
   Then I should see "Tag was updated"


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-4997

## Purpose

Enable pending autocomplete feature tests for tag wrangling.

Some "follow tag name link" actions become ambiguous when JavaScript is enabled because we have delete buttons with title containing tag names, so we need to switch to "Edit (tag name)".

On the tag edit page, we can refer to certain fields by their labels only when they don't already have any values pre-filled. If they do, their input fields will be preceded by a section of checkboxes to toggle existing values, and we have to refer to them by IDs. Example: "Add Fandoms" vs "tag_fandom_string_autocomplete".

Clean-up:

- Refer to the "Canonical" checkbox by its label
- Prefer the step "Given a (non)canonical (tag type)" over alternatives
- Fix a TODO in the media pages test

## Testing

Automated.