### PR TITLE
AO3-4272 Allow HTML in afterword list of anonymous remixes

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -85,7 +85,7 @@ module ApplicationHelper
   # Byline helpers
   def byline(creation, options={})
     if creation.respond_to?(:anonymous?) && creation.anonymous?
-      anon_byline = ts("Anonymous")
+      anon_byline = ts("Anonymous").html_safe
       if (logged_in_as_admin? || is_author_of?(creation)) && options[:visibility] != "public"
         anon_byline += " [#{non_anonymous_byline(creation, options[:only_path])}]".html_safe
       end

--- a/features/support/paths.rb
+++ b/features/support/paths.rb
@@ -57,6 +57,8 @@ module NavigationHelpers
       manage_invite_requests_path
     when /my pseuds page/
       user_pseuds_path(User.current_user)
+    when /my "(.*)" pseud page/
+      user_pseud_path(user_id: User.current_user, id: $1)
     when /my user page/
       user_path(User.current_user)
     when /my preferences page/
@@ -101,6 +103,8 @@ module NavigationHelpers
       skins_path(:skin_type => "WorkSkin")
     when /^(.*?)(?:'s)? user page$/i
       user_path(id: $1)
+    when /^(.*?)(?:'s)? "(.*)" pseud page$/i
+      user_pseud_path(user_id: $1, id: $2)
     when /^(.*?)(?:'s)? user url$/i
       user_url(id: $1).sub("http://www.example.com", "http://#{ArchiveConfig.APP_HOST}")
     when /^(.*?)(?:'s)? works page$/i

--- a/features/works/work_related.feature
+++ b/features/works/work_related.feature
@@ -343,7 +343,32 @@ Scenario: Restricted works listed as Inspiration show up [Restricted] for guests
     And I view the work "Followup"
   Then I should see "Inspired by [Restricted Work] by inspiration"
 
-  Scenario: When a user is notified that a co-authored work has been inspired by a work they posted, the e-mail should link to each author's URL instead of showing escaped HTML
+Scenario: Anonymous works listed as inspiration should have links to the authors,
+  but only for the authors themselves and admins
+  Given I have related works setup
+    And I have the anonymous collection "Muppets Anonymous"
+    And a related work has been posted and approved
+
+  When I am logged in as "remixer"
+    And I add the work "Followup" to the collection "Muppets Anonymous"
+    And I view the work "Worldbuilding"
+  Then I should see "Works inspired by this one: Followup by Anonymous [remixer]"
+  When I follow "remixer" within ".afterword .children"
+  Then I should be on my "remixer" pseud page
+
+  When I am logged in as an admin
+    And I view the work "Worldbuilding"
+  Then I should see "Works inspired by this one: Followup by Anonymous [remixer]"
+  When I follow "remixer" within ".afterword .children"
+  Then I should be on remixer's "remixer" pseud page
+
+  When I am logged out
+    And I view the work "Worldbuilding"
+  Then I should see "Works inspired by this one: Followup by Anonymous"
+    And I should not see "remixer" within ".afterword .children"
+
+Scenario: When a user is notified that a co-authored work has been inspired by a work they posted,
+  the e-mail should link to each author's URL instead of showing escaped HTML
   Given I have related works setup
     And I am logged in as "inspiration"
     And I post the work "Seed of an Idea"


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-4272

## Purpose

Allow HTML in afterword list of anonymous remixes, so links to authors (available to authors themselves and admins) do not get escaped.

This is @astirya's fix (#2364) + tests.

## Testing

https://otwarchive.atlassian.net/browse/AO3-4272
https://otwarchive.atlassian.net/browse/AO3-4948