### PR TITLE
AO3-3583 Type field on bookmark search loses info on editing search

### DIFF
--- a/app/views/bookmarks/_search_form.html.erb
+++ b/app/views/bookmarks/_search_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_for @search, :url => search_bookmarks_path, :html => {:class => 'search', :method => :get} do |f| %>
+<%= form_for @search, url: search_bookmarks_path, html: { class: "search", method: :get } do |f| %>
 <fieldset>
   <legend>Search bookmarks</legend>
   <dl>
@@ -49,7 +49,7 @@
       <%= link_to_help "bookmark-search-type-help" %>
     </dt>
     <dd>
-      <%= f.select :bookmarkable_type, options_for_select(["",  "Work", "Series", "External Work"]) %>
+      <%= f.select :bookmarkable_type, options_for_select(["",  "Work", "Series", "External Work"], @search.bookmarkable_type) %>
     </dd>
     <dt>
       <%= f.label :date, ts('Date Bookmarked') %>

--- a/app/views/bookmarks/_search_form.html.erb
+++ b/app/views/bookmarks/_search_form.html.erb
@@ -1,80 +1,83 @@
 <%= form_for @search, url: search_bookmarks_path, html: { class: "search", method: :get } do |f| %>
-<fieldset>
-  <legend>Search bookmarks</legend>
-  <dl>
-    <dt>
-      <%= f.label :query, ts('Any field') %>
-      <%= link_to_help "bookmark-search-text-help" %>
-    </dt>
-    <dd>
-      <%= f.text_field :query %>
-    </dd>
-    <dt>
-      <%= f.label :bookmarker, ts('Bookmarker') %>
-      <%= link_to_help "bookmark-search-text-help" %>
-    </dt>
-    <dd>
-      <%= f.text_field :bookmarker %>
-    </dd>
-    <dt>
-      <%= f.label :notes, ts("Notes") %>
-      <%= link_to_help "bookmark-search-text-help" %>
-    </dt>
-    <dd>
-      <%= f.text_field :notes %>
-    </dd>
-    <dt>
-      <%= f.label :tag, ts("Tag") %>
-      <%= link_to_help "bookmark-search-tag-help" %>
-    </dt>
-    <dd>
-      <%= f.text_field :tag %>
-    </dd>
-    <dt>
-      <%= f.label :rec, ts("Rec") %>
-      <%= link_to_help "bookmark-search-rec-help" %>
-    </dt>
-    <dd>    
-      <%= f.check_box :rec  %>
-    </dd>
-    <dt>
-      <%= f.label :with_notes, ts("With Notes") %>
-      <%= link_to_help "bookmark-search-notes-help" %>
-    </dt>
-    <dd>
-      <%= f.check_box :with_notes  %>
-    </dd>
-    <dt>
-      <%= f.label :bookmarkable_type, ts("Type") %>
-      <%= link_to_help "bookmark-search-type-help" %>
-    </dt>
-    <dd>
-      <%= f.select :bookmarkable_type, options_for_select(["",  "Work", "Series", "External Work"], @search.bookmarkable_type) %>
-    </dd>
-    <dt>
-      <%= f.label :date, ts('Date Bookmarked') %>
-      <%= link_to_help "bookmark-search-date-bookmarked-help" %>
-    </dt>
-    <dd>
-      <%= f.text_field :date %>
-    </dd>
-    <dt>
-      <%= f.label :bookmarkable_date, ts('Date Updated') %>
-      <%= link_to_help "bookmark-search-date-updated-help" %>
-    </dt>
-    <dd>
-      <%= f.text_field :bookmarkable_date %>
-    </dd> 
-    <dt>
-      <%= f.label :sort_column, ts("Sort by") %>
-    </dt>
-    <dd>
-      <%= f.select :sort_column, options_for_select(@search.sort_options, @search.sort_column), { :include_blank => "Best Match" } %>
-    </dd>
+  <fieldset>
+    <legend><%= ts("Search bookmarks") %></legend>
+    <dl>
+      <dt>
+        <%= f.label :query, ts("Any field") %>
+        <%= link_to_help "bookmark-search-text-help" %>
+      </dt>
+      <dd>
+        <%= f.text_field :query %>
+      </dd>
+      <dt>
+        <%= f.label :bookmarker, ts("Bookmarker") %>
+        <%= link_to_help "bookmark-search-text-help" %>
+      </dt>
+      <dd>
+        <%= f.text_field :bookmarker %>
+      </dd>
+      <dt>
+        <%= f.label :notes, ts("Notes") %>
+        <%= link_to_help "bookmark-search-text-help" %>
+      </dt>
+      <dd>
+        <%= f.text_field :notes %>
+      </dd>
+      <dt>
+        <%= f.label :tag, ts("Tag") %>
+        <%= link_to_help "bookmark-search-tag-help" %>
+      </dt>
+      <dd>
+        <%= f.text_field :tag %>
+      </dd>
+      <dt>
+        <%= f.label :rec, ts("Rec") %>
+        <%= link_to_help "bookmark-search-rec-help" %>
+      </dt>
+      <dd>
+        <%= f.check_box :rec %>
+      </dd>
+      <dt>
+        <%= f.label :with_notes, ts("With notes") %>
+        <%= link_to_help "bookmark-search-notes-help" %>
+      </dt>
+      <dd>
+        <%= f.check_box :with_notes %>
+      </dd>
+      <dt>
+        <%= f.label :bookmarkable_type, ts("Type") %>
+        <%= link_to_help "bookmark-search-type-help" %>
+      </dt>
+      <dd>
+        <%= f.select :bookmarkable_type, options_for_select(
+                                          ["",  "Work", "Series", "External Work"],
+                                          @search.bookmarkable_type) %>
+      </dd>
+      <dt>
+        <%= f.label :date, ts("Date bookmarked") %>
+        <%= link_to_help "bookmark-search-date-bookmarked-help" %>
+      </dt>
+      <dd>
+        <%= f.text_field :date %>
+      </dd>
+      <dt>
+        <%= f.label :bookmarkable_date, ts("Date updated") %>
+        <%= link_to_help "bookmark-search-date-updated-help" %>
+      </dt>
+      <dd>
+        <%= f.text_field :bookmarkable_date %>
+      </dd> 
+      <dt>
+        <%= f.label :sort_column, ts("Sort by") %>
+      </dt>
+      <dd>
+        <%= f.select :sort_column, options_for_select(@search.sort_options,
+                                                      @search.sort_column),
+                                  { include_blank: "Best Match" } %>
+      </dd>
  
-    <dt class="landmark">Submit</dt>
-    <dd class="submit actions"><%= f.submit ts('Search bookmarks') %></dd>
-</dl>
-</fieldset>
+      <dt class="landmark"><%= ts("Submit") %></dt>
+      <dd class="submit actions"><%= f.submit ts("Search bookmarks") %></dd>
+    </dl>
+  </fieldset>
 <% end %>
-

--- a/features/bookmarks/bookmark_search.feature
+++ b/features/bookmarks/bookmark_search.feature
@@ -46,8 +46,7 @@ Feature: Search Bookmarks
       And I should see "1 Found"
       And I should see "Skies Grown Darker"
     When I follow "Edit Your Search"
-    When "AO3-3583" is fixed
-    # Then "External Work" should be selected within "Type"
+    Then "External Work" should be selected within "Type"
 
   Scenario: Search for bookmarks with notes, and then edit search to narrow
   results by the note content

--- a/features/bookmarks/bookmark_search.feature
+++ b/features/bookmarks/bookmark_search.feature
@@ -50,15 +50,15 @@ Feature: Search Bookmarks
 
   Scenario: Search for bookmarks with notes, and then edit search to narrow
   results by the note content
-    When I check "With Notes"
+    When I check "With notes"
       And I press "Search bookmarks"
     Then I should see the page title "Search Bookmarks"
-      And I should see "You searched for: With Notes"
+      And I should see "You searched for: With notes"
       And I should see "2 Found"
       And I should see "fifth"
       And I should see "Skies Grown Darker"
     When I follow "Edit Your Search"
-    Then the "With Notes" checkbox should be checked
+    Then the "With notes" checkbox should be checked
     When I fill in "Notes" with "broken heart"
       And I press "Search bookmarks"
     Then I should see the page title "Search Bookmarks"
@@ -68,7 +68,7 @@ Feature: Search Bookmarks
       # And I should see "fifth"
     When I follow "Edit Your Search"
     Then the field labeled "Notes" should contain "broken heart"
-      And the "With Notes" checkbox should be checked
+      And the "With notes" checkbox should be checked
 
   Scenario: If testuser has the pseud tester_pseud, searching for bookmarks by
   the bookmarker testuser does not return any of tester_pseud's bookmarks

--- a/features/bookmarks/bookmark_search.feature
+++ b/features/bookmarks/bookmark_search.feature
@@ -1,22 +1,102 @@
 @no-txn @bookmarks @search
 Feature: Search Bookmarks
-  In order to test search
+  In order to find works I might consider good
   As a humble coder
   I have to use cucumber with elasticsearch
 
-  Scenario: Search bookmarks
+  Background:
     Given I have loaded the fixtures
-    When I am on the search bookmarks page
+      And I am on the search bookmarks page
       And all search indexes are updated
-    When I fill in "bookmark_search_tag" with "classic"
+
+  Scenario: Search bookmarks by tag
+    When I fill in "Tag" with "classic"
       And I press "Search bookmarks"
-    Then I should see "1 Found"
-    When I am on the search bookmarks page
-      And I check "Rec"
+    Then I should see the page title "Search Bookmarks"
+      And I should see "You searched for: Tags: classic"
+      And I should see "1 Found"
+      And I should see "third work"
+    When I follow "Edit Your Search"
+    Then the field labeled "Tag" should contain "classic"
+
+  Scenario: Search bookmarks for recs
+    When I check "Rec"
       And I press "Search bookmarks"
-    Then I should see "First work"
-    When I am on the search bookmarks page
-      And I fill in "bookmark_search_query" with "Hobbits"
+    Then I should see the page title "Search Bookmarks"
+      And I should see "You searched for: Rec"
+      And I should see "1 Found"
+      And I should see "First work"
+    When I follow "Edit Your Search"
+    Then the "Rec" checkbox should be checked
+
+  Scenario: Search bookmarks by any field
+    When I fill in "Any field" with "Hobbits"
       And I press "Search bookmarks"
-    Then I should see "Bookmarks Matching 'Hobbits'"
+    Then I should see the page title "Bookmarks Matching 'Hobbits'"
+      And I should see "You searched for: Hobbits"
+      And I should see "No results found."
+    When I follow "Edit Your Search"
+    Then the field labeled "Any field" should contain "Hobbits"
+
+  Scenario: Search bookmarks by type
+    When I select "External Work" from "Type"
+      And I press "Search bookmarks"
+    Then I should see the page title "Search Bookmarks"
+      And I should see "You searched for: Type: External Work"
+      And I should see "1 Found"
+      And I should see "Skies Grown Darker"
+    When I follow "Edit Your Search"
+    When "AO3-3583" is fixed
+    # Then "External Work" should be selected within "Type"
+
+  Scenario: Search for bookmarks with notes, and then edit search to narrow
+  results by the note content
+    When I check "With Notes"
+      And I press "Search bookmarks"
+    Then I should see the page title "Search Bookmarks"
+      And I should see "You searched for: With Notes"
+      And I should see "2 Found"
+      And I should see "fifth"
+      And I should see "Skies Grown Darker"
+    When I follow "Edit Your Search"
+    Then the "With Notes" checkbox should be checked
+    When I fill in "Notes" with "broken heart"
+      And I press "Search bookmarks"
+    Then I should see the page title "Search Bookmarks"
+      And I should see "You searched for: Notes: broken heart, With Notes"
+    When "AO3-3943" is fixed
+      # And I should see "1 Found"
+      # And I should see "fifth"
+    When I follow "Edit Your Search"
+    Then the field labeled "Notes" should contain "broken heart"
+      And the "With Notes" checkbox should be checked
+
+  Scenario: If testuser has the pseud tester_pseud, searching for bookmarks by
+  the bookmarker testuser does not return any of tester_pseud's bookmarks
+    When I fill in "Bookmarker" with "testuser"
+      And I press "Search bookmarks"
+    Then I should see the page title "Search Bookmarks"
+      And I should see "You searched for: Bookmarker: testuser"
+      And I should see "3 Found"
+      And I should see "First work"
+      And I should see "second work"
+      And I should see "third work"
+      And I should not see "tester_pseud"
+      And I should not see "fifth"
+      And I should not see "Skies Grown Darker"
+    When I follow "Edit Your Search"
+    Then the field labeled "Bookmarker" should contain "testuser"
+
+  Scenario: If testuser has the pseud tester_pseud, searching for bookmarks by
+  the bookmarker tester_pseud does not return any of testusers's bookmarks
+    When I fill in "Bookmarker" with "tester_pseud"
+      And I press "Search bookmarks"
+    Then I should see the page title "Search Bookmarks"
+      And I should see "You searched for: Bookmarker: tester_pseud"
+      And I should see "2 Found"
+      And I should see "fifth"
+      And I should see "Skies Grown Darker"
+      And I should not see "First work"
+      And I should not see "second work"
+      And I should not see "third work"
 

--- a/features/fixtures/bookmarks.yml
+++ b/features/fixtures/bookmarks.yml
@@ -24,3 +24,10 @@ bookmark5:
   pseud_id: 3
   bookmarkable_id: 5
   bookmarkable_type: Work
+  notes: "Left me with a broken heart"
+bookmark6:
+  id: 6
+  pseud_id: 3
+  bookmarkable_id: 2
+  bookmarkable_type: ExternalWork
+  notes: "I enjoyed this"

--- a/features/fixtures/external_works.yml
+++ b/features/fixtures/external_works.yml
@@ -1,4 +1,5 @@
 first_ext:
+  id: 1
   created_at: 2009-07-17 23:33:05 +00:00
   title: Just a fancy word for compromise
   author: Zooey Glass
@@ -8,6 +9,7 @@ first_ext:
   summary: You've got to read between the years; you've got to write between the lines.
   hidden_by_admin: false
 second_ext:
+  id: 2
   created_at: 2009-07-18 09:38:18 +00:00
   title: Skies Grown Darker
   author: parenthetical


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-3583

## Purpose

If you choose a bookmark type to search for and then edit your search after viewing the results, the type field should stay filled in.

Contains the tests from #2907. Relevant commits are: 
* 8e547c9
* 8e43b83
* f31b31c

## Testing

See issue