### PR TITLE
AO3-5201 Move codeship to mysql 5.7

### DIFF
--- a/config/database.codeship.yml
+++ b/config/database.codeship.yml
@@ -3,16 +3,16 @@ development:
   host: localhost
   encoding: utf8
   pool: 10
+  port: 3307
   username: <%= ENV['MYSQL_USER'] %>
   password: <%= ENV['MYSQL_PASSWORD'] %>
   database: development<%= ENV['TEST_ENV_NUMBER'] %>
-  socket: /var/run/mysqld/mysqld.sock
 test:
   adapter: mysql2
   host: localhost
   encoding: utf8
   pool: 10
+  port: 3307
   username: <%= ENV['MYSQL_USER'] %>
   password: <%= ENV['MYSQL_PASSWORD'] %>
   database: test<%= ENV['TEST_ENV_NUMBER'] %>
-  socket: /var/run/mysqld/mysqld.sock

--- a/script/prepare_codeship.sh
+++ b/script/prepare_codeship.sh
@@ -7,6 +7,7 @@
 #
 export RAILS_ENV=test
 bundle install
+\curl -sSL https://raw.githubusercontent.com/codeship/scripts/master/packages/mysql-5.7.sh | bash -s
 cp config/database.codeship.yml config/database.yml
 cp config/newrelic.example config/newrelic.yml
 cp config/redis-cucumber.conf.example config/redis-cucumber.conf


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5021

## Purpose

Get codeship using mysql 5.7 which I think will be needed for the rails 4.0 change.

I am going to apply this to my copy of the 4.0 branch and see if it passes on codeship ( https://app.codeship.com/projects/14479/builds/25132225 )

## Testing

No manual testing required