### PR TITLE
AO3-3223 When saving a coauthor for a work, save for all existing chapters as well

### DIFF
--- a/app/models/creation_observer.rb
+++ b/app/models/creation_observer.rb
@@ -138,8 +138,10 @@ class CreationObserver < ActiveRecord::Observer
         if creation.is_a?(Chapter) && creation.work
           creation.work.pseuds << pseud unless creation.work.pseuds.include?(pseud)
         elsif creation.is_a?(Work)
-          if creation.chapters.first
-            creation.chapters.first.pseuds << pseud unless creation.chapters.first.pseuds.include?(pseud)
+          if creation.chapters.present?
+            creation.chapters.each { |chapter|
+              chapter.pseuds << pseud unless chapter.pseuds.include?(pseud)
+            }
           end
           creation.series.each { |series| series.pseuds << pseud unless series.pseuds.include?(pseud) }
         end

--- a/app/models/creation_observer.rb
+++ b/app/models/creation_observer.rb
@@ -138,11 +138,7 @@ class CreationObserver < ActiveRecord::Observer
         if creation.is_a?(Chapter) && creation.work
           creation.work.pseuds << pseud unless creation.work.pseuds.include?(pseud)
         elsif creation.is_a?(Work)
-          if creation.chapters.present?
-            creation.chapters.each { |chapter|
-              chapter.pseuds << pseud unless chapter.pseuds.include?(pseud)
-            }
-          end
+          creation.chapters.each { |chapter| chapter.pseuds << pseud unless chapter.pseuds.include?(pseud) }
           creation.series.each { |series| series.pseuds << pseud unless series.pseuds.include?(pseud) }
         end
       end

--- a/features/other_a/orphan_work.feature
+++ b/features/other_a/orphan_work.feature
@@ -141,14 +141,11 @@ Feature: Orphan work
     And I should see "Lovely"
 
   Scenario: Orphaning a shared work should not affect chapters created solely by the other creator
-    # Set up a shared, chaptered work where orphaneer is not listed as a
-    # creator on Chapter 2. Currently, adding an author to a chaptered work
-    # only adds them to the first chapter. If that behavior ever changes (e.g.
-    # in response to issue AO3-2971), so should this test.
 
     Given I am logged in as "keeper"
-      And I post the chaptered work "Half-Orphaned"
+      And I post the work "Half-Orphaned"
       And I add the co-author "orphaneer" to the work "Half-Orphaned"
+      And I post a chapter for the work "Half-Orphaned"
 
     # Verify that the authorship has been set up properly
     Then "orphaneer" should be a co-creator of Chapter 1 of "Half-Orphaned"

--- a/features/step_definitions/work_steps.rb
+++ b/features/step_definitions/work_steps.rb
@@ -263,6 +263,15 @@ When /^a draft chapter is added to "([^"]*)"$/ do |work_title|
   Tag.write_redis_to_database
 end
 
+# Posts a chapter for the current user
+When /^I post a chapter for the work "([^"]*)"$/ do |work_title|
+  work = Work.find_by(title: work_title)
+  visit work_url(work)
+  step %{I follow "Add Chapter"}
+  step %{I fill in "content" with "la la la la la la la la la la la"}
+  step %{I post the chapter}
+end
+
 When /^a chapter is set up for "([^"]*)"$/ do |work_title|
   work = Work.find_by(title: work_title)
   user = work.users.first

--- a/features/works/work_create.feature
+++ b/features/works/work_create.feature
@@ -27,7 +27,7 @@ Feature: Create Works
 
   Scenario: Creating a new minimally valid work and posting without preview
     Given I am logged in as "newbie"
-    When I set up the draft "All Hell Breaks Loose" 
+    When I set up the draft "All Hell Breaks Loose"
       And I fill in "content" with "Bad things happen, etc."
       And I press "Post Without Preview"
     Then I should see "Work was successfully posted."
@@ -36,7 +36,7 @@ Feature: Create Works
     Then I should see "All Hell Breaks Loose"
 
   Scenario: Creating a new minimally valid work when you have more than one pseud
-    Given I am logged in as "newbie"      
+    Given I am logged in as "newbie"
       And "newbie" creates the pseud "Pointless Pseud"
     When I set up the draft "All Hell Breaks Loose"
       And I unselect "newbie" from "work_author_attributes_ids_"
@@ -232,7 +232,7 @@ Feature: Create Works
   Then I should see "Post New Work"
     And I should see "Rich Text" within ".rtf-html-switch"
     And I should see "HTML" within ".rtf-html-switch"
-    
+
   Scenario: posting a backdated work
   Given I am logged in as "testuser" with password "testuser"
     And I post the work "This One Stays On Top"
@@ -246,7 +246,7 @@ Feature: Create Works
   Then I should see "Published:1990-01-01"
   When I go to the works page
   Then "This One Stays On Top" should appear before "Backdated"
-        
+
   Scenario: Users must set something as a warning and Author Chose Not To Use Archive Warnings should not be added automatically
     Given basic tags
       And I am logged in
@@ -282,7 +282,7 @@ Feature: Create Works
    Then I should see "Work was successfully posted. It should appear in work listings within the next few minutes."
       And I should see "Me (myself), testuser"
 
-  Scenario: Users can't set a publication date that is in the future, e.g. set 
+  Scenario: Users can't set a publication date that is in the future, e.g. set
   the date to April 30 when it is April 26
     Given I am logged in
       And it is currently Wed Apr 26 22:00:00 UTC 2017
@@ -292,3 +292,17 @@ Feature: Create Works
       And I press "Post Without Preview"
     Then I should see "Publication date can't be in the future."
     When I jump in our Delorean and return to the present
+
+  Scenario: Adding a coauthor to a work adds the coauthor to all existing chapters.
+    Given the following activated users exists
+    | login             | password   | email                     |
+    | author            | password   | author@example.com        |
+    | coauthor          | password   | coauthor@example.com      |
+
+    Given I am logged in as "author"
+    And I post the chaptered work "Chaptered Work"
+      And I add the co-author "coauthor" to the work "Chaptered Work"
+      Then I should see "author, coauthor" within ".byline"
+    When I follow "Next Chapter →"
+      Then I should see "Chapter 2"
+      And I should see "author, coauthor" within ".byline"

--- a/features/works/work_create.feature
+++ b/features/works/work_create.feature
@@ -294,15 +294,13 @@ Feature: Create Works
     When I jump in our Delorean and return to the present
 
   Scenario: Adding a coauthor to a work adds the coauthor to all existing chapters.
-    Given the following activated users exists
-    | login             | password   | email                     |
-    | author            | password   | author@example.com        |
-    | coauthor          | password   | coauthor@example.com      |
+    Given the user "author" exists and is activated
+      And the user "coauthor" exists and is activated
 
-    Given I am logged in as "author"
-    And I post the chaptered work "Chaptered Work"
+    When I am logged in as "author"
+      And I post the chaptered work "Chaptered Work"
       And I add the co-author "coauthor" to the work "Chaptered Work"
-      Then I should see "author, coauthor" within ".byline"
+    Then I should see "author, coauthor" within ".byline"
     When I follow "Next Chapter →"
-      Then I should see "Chapter 2"
+    Then I should see "Chapter 2"
       And I should see "author, coauthor" within ".byline"

--- a/spec/controllers/works/default_rails_actions_spec.rb
+++ b/spec/controllers/works/default_rails_actions_spec.rb
@@ -356,20 +356,20 @@ describe WorksController do
 
     context "where the coauthor is being updated" do
       let(:new_coauthor) { create(:user) }
-      let(:params) {
+      let(:params) do
         {
           work: { title: "New title" },
           pseud: { byline: new_coauthor.login },
           id: update_work.id
         }
-      }
+      end
       it "should update coauthors for each chapter when the work is updated" do
         put :update, params
         updated_work = Work.find(update_work.id)
         expect(updated_work.pseuds).to include new_coauthor.default_pseud
-        updated_work.chapters.each { |c|
+        updated_work.chapters.each do |c|
           expect(c.pseuds).to include new_coauthor.default_pseud
-        }
+        end
       end
     end
   end

--- a/spec/controllers/works/default_rails_actions_spec.rb
+++ b/spec/controllers/works/default_rails_actions_spec.rb
@@ -353,6 +353,25 @@ describe WorksController do
       expect(response).to render_template :edit
       allow_any_instance_of(Work).to receive(:save).and_call_original
     end
+
+    context "where the coauthor is being updated" do
+      let(:new_coauthor) { create(:user) }
+      let(:params) {
+        {
+          work: { title: "New title" },
+          pseud: { byline: new_coauthor.login },
+          id: update_work.id
+        }
+      }
+      it "should update coauthors for each chapter when the work is updated" do
+        put :update, params
+        updated_work = Work.find(update_work.id)
+        expect(updated_work.pseuds).to include new_coauthor.default_pseud
+        updated_work.chapters.each { |c|
+          expect(c.pseuds).to include new_coauthor.default_pseud
+        }
+      end
+    end
   end
 
   describe "collected" do


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-3223 

## Purpose

The current behavior is that when a coauthor is saved for a multichapter work, they are only saved as a coauthor for the first chapter. This change makes it so that they are saved as a coauthor for every chapter of the work. However, it does not change it so that each new chapter contains all the work's coauthors; they will only have the user who saved that chapter as an author, and all other coauthors have to be added manually.

## Testing

* Create a multichapter work with one user.
* Add a second user as a coauthor for the entire work.
* As the second user, select "Edit Chapter" for any chapter except for the first--there should be no error banner, and the user should be able to edit that chapter as normal.

## References

https://otwarchive.atlassian.net/browse/AO3-2971 (duplicate)

## Credit

potatoesque, she/her
