### PR TITLE
AO3-4736 Bugfix for user can't remove coauthors from Edit Multiple Wo…

### DIFF
--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -1067,6 +1067,7 @@ class WorksController < ApplicationController
       :backdate, :language_id, :work_skin_id, :restricted, :anon_commenting_disabled,
       :moderated_commenting_enabled, :title, :pseuds_to_add, :collections_to_add,
       :unrestricted,
+      pseuds_to_remove: [],
       challenge_assignment_ids: [],
       challenge_claim_ids: [],
       category_string: [],

--- a/features/step_definitions/user_steps.rb
+++ b/features/step_definitions/user_steps.rb
@@ -114,10 +114,11 @@ Given /^I view the people page$/ do
   visit people_path
 end
 
-Given(/^I have coauthored a work as "(.*?)" with "(.*?)"$/) do |login, coauthor|
+Given(/^I coauthored the work "(.*?)" as "(.*?)" with "(.*?)"$/) do |title, login, coauthor|
+  step %{basic tags}
   author1 = User.find_by(login: login).default_pseud
   author2 = User.find_by(login: coauthor).default_pseud
-  FactoryGirl.create(:work, authors: [author1, author2], posted: true, title: "Shared")
+  FactoryGirl.create(:work, authors: [author1, author2], posted: true, title: title)
 end
 
 # WHEN

--- a/features/step_definitions/work_steps.rb
+++ b/features/step_definitions/work_steps.rb
@@ -344,6 +344,15 @@ When /^I edit multiple works with different anonymous commenting settings$/ do
   step %{I press "Edit"}
 end
 
+When /^I edit multiple works coauthored as "(.*)" with "(.*)"$/ do |author, coauthor|
+  step %{I coauthored the work "Shared Work 1" as "#{author}" with "#{coauthor}"}
+  step %{I coauthored the work "Shared Work 2" as "#{author}" with "#{coauthor}"}
+  step %{I go to my edit multiple works page}
+  step %{I select "Shared Work 1" for editing}
+  step %{I select "Shared Work 2" for editing}
+  step %{I press "Edit"}
+end
+
 When /^the purge_old_drafts rake task is run$/ do
   Work.purge_old_drafts
 end

--- a/features/users/user_delete.feature
+++ b/features/users/user_delete.feature
@@ -82,7 +82,7 @@ Scenario: Delete a user who has coauthored a work
     | login     | password |
     | otheruser | password |
     And I am logged in as "testuser"
-    And I have coauthored a work as "testuser" with "otheruser"
+    And I coauthored the work "Shared" as "testuser" with "otheruser"
   When I try to delete my account
   Then I should see "What do you want to do with your works?"
   When I choose "Remove me completely as co-author"

--- a/features/works/work_edit.feature
+++ b/features/works/work_edit.feature
@@ -129,12 +129,11 @@ Feature: Edit Works
       And I should see "coauthor, leadauthor" within ".byline"
 
   Scenario: You can remove yourself as coauthor from a work
-    Given basic tags
-      And the following activated users exist
+    Given the following activated users exist
         | login          |
         | coolperson     |
         | ex_friend      |
-      And I have coauthored a work as "coolperson" with "ex_friend"
+      And I coauthored the work "Shared" as "coolperson" with "ex_friend"
       And I am logged in as "coolperson"
     When I view the work "Shared"
     Then I should see "coolperson, ex_friend" within ".byline"

--- a/features/works/work_edit_multiple.feature
+++ b/features/works/work_edit_multiple.feature
@@ -123,3 +123,18 @@ Feature: Edit Multiple Works
   Then I should see "doesn't allow non-Archive users to comment"
   When I view the work "Work with Anonymous Commenting Enabled"
   Then I should not see "doesn't allow non-Archive users to comment"
+
+  Scenario: User can remove coauthors from multiple works at once
+    Given the following activated users exists
+      | login     |
+      | author    |
+      | coauthor  |
+      And I am logged in as "author"
+      And I edit multiple works coauthored as "author" with "coauthor"
+    When I check "coauthor" within "#work_pseuds_to_remove_checkboxes"
+      And I press "Update All Works"
+    Then I should see "Your edits were put through"
+    When I view the work "Shared Work 1"
+    Then I should not see "coauthor" within ".byline"
+    When I view the work "Shared Work 2"
+    Then I should not see "coauthor" within ".byline"


### PR DESCRIPTION
…rks page

## Issue

https://otwarchive.atlassian.net/browse/AO3-4736 (in comments)

## Purpose

Fixes bug where user can't remove coauthors from works from the Edit Multiple Works page. Only an issue on staging and in dev, not production.

## Testing

Steps to Reproduce Bug:

1. Coauthor a work
2. Go to Dashboard
3. Click on "Edit Works" button
4. Check box next to coauthored work & click "Edit" button
5. Scroll down to "Current Authors", and check box next to coauthor's pseud
6. Click "Update All Works"
7. BUG: Coauthor was not removed (click on work to confirm)

If this bugfix works, coauthor should be removed in Step 7.
