### PR TITLE
AO3-5030 Add test for importing input with string terminators for Nokogiri

### DIFF
--- a/app/models/story_parser.rb
+++ b/app/models/story_parser.rb
@@ -912,7 +912,7 @@ class StoryParser
         raise Error, "We couldn't download anything from #{location}. Please make sure that the URL is correct and complete, and try again."
       end
 
-      # clean up any erroneously included string terminator (Issue 785)
+      # clean up any erroneously included string terminator (AO3-2251)
       story.gsub!("\000", "")
 
       story

--- a/features/support/vcr.rb
+++ b/features/support/vcr.rb
@@ -26,7 +26,6 @@ VCR.cucumber_tags do |t|
   t.tags '@work_import_special_characters_man_latin', :record => :all
   t.tags '@work_import_special_characters_man_cp', :record => :all
   t.tags '@work_import_special_characters_man_utf'
-  t.tags '@work_import_nul_character'
 
   # need to run this every time for the devart features, because the recorded responses run into an encoding error I don't have time to investigate
   t.tags '@import_da_title_link', :record => :all

--- a/spec/models/story_parser_spec.rb
+++ b/spec/models/story_parser_spec.rb
@@ -211,6 +211,10 @@ describe StoryParser do
       to_return(status: 200,
                 body: body.force_encoding("Windows-1252"),
                 headers: {})
+
+    WebMock.stub_request(:any, /non-sgml-character-number-3/).
+      to_return(status: 200,
+                body: "<body>\0When I get out of here</body>")
   end
 
   describe "Import" do
@@ -230,6 +234,11 @@ describe StoryParser do
           @sp.download_and_parse_story(url, pseuds: [@user.default_pseud], do_not_set_current_author: false)
         }.to_not raise_exception
       end
+    end
+
+    it "ignores string terminators (AO3-2251)" do
+      story = @sp.download_and_parse_story("http://non-sgml-character-number-3", pseuds: [@user.default_pseud])
+      expect(story.chapters[0].content).to include("When I get out of here")
     end
   end
 end


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5030

## Purpose

Add test for [AO3-2251](https://otwarchive.atlassian.net/browse/AO3-2251).

The original test, relying on an external site, was added in #67 and removed in #1536.

The cassette for this test (features/cassette_library/cucumber_tags/work_import_nul_character.yml) is still in the repository. I'm not removing it here because it might end up committed back (like some of the cassettes removed in [AO3-4968](https://otwarchive.atlassian.net/browse/AO3-4968) got added back in the Rails 4.0 upgrade). I'll remove it as part of [AO3-4488](https://otwarchive.atlassian.net/browse/AO3-4488), where I plan to delete all cassettes and .gitignore them permanently.

## Testing

Automated.