### PR TITLE
AO3-5023 Bump paperclip version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -66,7 +66,7 @@ gem 'aws-sdk'
 gem 'css_parser'
 
 gem 'cocaine'
-gem 'paperclip', '4.3.6'
+gem 'paperclip', '>= 5.1.0'
 
 # for looking up image dimensions quickly
 gem 'fastimage'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -221,7 +221,7 @@ GEM
       webrobots (>= 0.0.9, < 0.2)
     method_source (0.8.2)
     mime-types (2.99.3)
-    mimemagic (0.3.0)
+    mimemagic (0.3.2)
     mini_portile2 (2.2.0)
     minitest (5.10.2)
     mono_logger (1.1.0)
@@ -250,12 +250,12 @@ GEM
       nokogiri
     ntlm-http (0.1.1)
     orm_adapter (0.5.0)
-    paperclip (4.3.6)
-      activemodel (>= 3.2.0)
-      activesupport (>= 3.2.0)
+    paperclip (5.1.0)
+      activemodel (>= 4.2.0)
+      activesupport (>= 4.2.0)
       cocaine (~> 0.5.5)
       mime-types
-      mimemagic (= 0.3.0)
+      mimemagic (~> 0.3.0)
     permit_yo (2.1.3)
     phraseapp-in-context-editor-ruby (1.2.1)
       i18n (>= 0.6)
@@ -515,7 +515,7 @@ DEPENDENCIES
   newrelic_rpm
   nokogiri (>= 1.7.1)
   nokogumbo (= 1.4.9)
-  paperclip (= 4.3.6)
+  paperclip (>= 5.1.0)
   permit_yo
   phraseapp-in-context-editor-ruby (>= 1.0.6)
   pickle
@@ -558,4 +558,4 @@ RUBY VERSION
    ruby 2.2.5p319
 
 BUNDLED WITH
-   1.14.6
+   1.15.1

--- a/config/s3.example
+++ b/config/s3.example
@@ -1,3 +1,4 @@
 bucket: mybucket
 access_key_id: myaccesskey
 secret_access_key: mysecret
+s3_region: us-east-1


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5023

## Purpose

Bump the version of paperclip so we can use version 2 of the Amazon api

## Testing

This isn't something that i can test at all in a dev environment I think....

"However, I think I have hit a bug! I get a 500 error when trying to either create a pseud with an icon or edit a pseud to have an icon." so test file uploads, icons, collections etc 