### PR TITLE
AO3-5023 Allow resque tasks to start

### DIFF
--- a/lib/tasks/resque.rake
+++ b/lib/tasks/resque.rake
@@ -5,7 +5,6 @@ require 'resque/scheduler/tasks'
 namespace :resque do
   task :setup do
     require 'resque'
-    require 'resque_scheduler'
     require 'resque/scheduler'
 
     # you probably already have this somewhere


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5023

## Purpose

Currently neither the resque workers or the scheduler starts

## Testing

Test things that require the resque workers/ Look at the resque interface on test and see that there are workers running