### PR TITLE
AO3-5023 Confirmation popup fixes

### DIFF
--- a/app/views/admin/_admin_nav.html.erb
+++ b/app/views/admin/_admin_nav.html.erb
@@ -8,7 +8,7 @@
   </li>
   <% if current_page?(controller: 'admin_posts', action: 'edit') %>
     <li>
-      <%= link_to t('admin.admin_nav.delete', default: 'Delete Post'), @admin_post, confirm: 'Are you sure you want to delete this news post?', method: :delete %>
+      <%= link_to t('admin.admin_nav.delete', default: 'Delete Post'), @admin_post, data: { confirm: 'Are you sure you want to delete this news post?' }, method: :delete %>
     </li>
   <% end %>
   <% if current_page?(controller: 'archive_faqs', action: 'edit') && Globalize.locale.to_s == "en" %>

--- a/app/views/admin/_admin_nav.html.erb
+++ b/app/views/admin/_admin_nav.html.erb
@@ -1,30 +1,36 @@
-<h3 class="landmark heading"><%= ts('Admin Navigation') %></h3>
+<h3 class="landmark heading"><%= ts("Admin Navigation") %></h3>
 <ul class="navigation actions" role="navigation">
   <li>
-    <%= span_if_current ts('AO3 News', key: 'header'), admin_posts_path %>
+    <%= span_if_current ts("AO3 News", key: "header"), admin_posts_path %>
    </li>
   <li>
-    <%= span_if_current ts('Post AO3 News', key: 'header'), new_admin_post_path %>
+    <%= span_if_current ts("Post AO3 News", key: "header"),
+                        new_admin_post_path %>
   </li>
-  <% if current_page?(controller: 'admin_posts', action: 'edit') %>
+  <% if current_page?(controller: "admin_posts", action: "edit") %>
     <li>
-      <%= link_to t('admin.admin_nav.delete', default: 'Delete Post'), @admin_post, data: { confirm: 'Are you sure you want to delete this news post?' }, method: :delete %>
+      <%= link_to t("admin.admin_nav.delete", default: "Delete Post"),
+                  @admin_post,
+                  data: { confirm: "Are you sure you want to delete this news post?" },
+                  method: :delete %>
     </li>
   <% end %>
-  <% if current_page?(controller: 'archive_faqs', action: 'edit') && Globalize.locale.to_s == "en" %>
-    <li><%= link_to ts('Reorder Questions'), manage_archive_faq_questions_path(@archive_faq) %></li>
+  <% if current_page?(controller: "archive_faqs", action: "edit") &&
+        Globalize.locale.to_s == "en" %>
+    <li>
+      <%= link_to ts("Reorder Questions"),
+                  manage_archive_faq_questions_path(@archive_faq) %>
+    </li>
   <% end %>
 
   <li>
-    <%= span_if_current ts('Archive FAQ', key: 'header'), archive_faqs_path %>
+    <%= span_if_current ts("Archive FAQ", key: "header"), archive_faqs_path %>
   </li>
   <li>
-    <%= span_if_current ts('Known Issues', key: 'header'), known_issues_path %>
+    <%= span_if_current ts("Known Issues", key: "header"), known_issues_path %>
   </li>
   <li>
-    <%= span_if_current ts('Wrangling Guidelines', key: 'header'), wrangling_guidelines_path %>
+    <%= span_if_current ts("Wrangling Guidelines", key: "header"),
+                        wrangling_guidelines_path %>
   </li>
 </ul>
-
-
-  

--- a/app/views/admin/_admin_options.html.erb
+++ b/app/views/admin/_admin_options.html.erb
@@ -41,7 +41,9 @@
                       action: "destroy",
                       id: item,
                       creation_type: item.class },
-                    confirm: ts("Are you sure you want to delete this?"),
+                    data: {
+                            confirm: ts("Are you sure you want to delete this?")
+                          },
                     method: :delete %>
     </li>
   </ul>

--- a/app/views/admin/admin_users/confirm_delete_user_creations.html.erb
+++ b/app/views/admin/admin_users/confirm_delete_user_creations.html.erb
@@ -28,7 +28,8 @@
   <% end %>
  
   <p class="actions">
-    <%= submit_tag ts("Yes, Delete All Spammer Creations"), confirm: ts("Are you sure? Remember this will destroy ALL these objects!") %>
+    <%= submit_tag ts("Yes, Delete All Spammer Creations"),
+                   data: { confirm: ts("Are you sure? Remember this will destroy ALL these objects!") } %>
   </p>
 <% end %>
 <!--/content-->

--- a/app/views/admin/blacklisted_emails/index.html.erb
+++ b/app/views/admin/blacklisted_emails/index.html.erb
@@ -1,6 +1,6 @@
 <div class="admin">
   <!--Descriptive page name, messages and instructions-->
-  <h2 class="heading"><%= t('admin.admin_email_blacklist.index.page_heading', default: "Manage Email Blacklist") %></h2>
+  <h2 class="heading"><%= t("admin.admin_email_blacklist.index.page_heading", default: "Manage Email Blacklist") %></h2>
 
   <ul class="notes">
     <li><%= ts("Blacklisted email addresses cannot be used in guest comments.") %></li>
@@ -22,11 +22,12 @@
       </p>
     </fieldset>
   <% end %>
-  
+
   <h3 class="heading"><%= ts("Find blacklisted emails")%></h3>
 
   <!-- search form -->
-  <%= form_tag url_for(controller: "admin/blacklisted_emails", action: "index"), method: :get, class: "simple search", role: "search" do %>
+  <%= form_tag url_for(controller: "admin/blacklisted_emails", action: "index"),
+               method: :get, class: "simple search", role: "search" do %>
     <fieldset>
       <p>
         <%= label_tag "query", ts("Email to find") %>
@@ -39,12 +40,18 @@
   <!-- list of search results -->
   <% if @admin_blacklisted_emails %>
     <div class="results module">
-      <h3 class="heading"><%= t('admin.blacklist.emails_found', count: @admin_blacklisted_emails.count) %></h3>
+      <h3 class="heading">
+        <%= t("admin.blacklist.emails_found", count: @admin_blacklisted_emails.count) %>
+      </h3>
       <% if @admin_blacklisted_emails.count > 0 %>
         <ol class="emails index group">
           <% @admin_blacklisted_emails.each do |blacklisted_email| %>
           <li>
-            <%= link_to ts("Remove %{email}", email: blacklisted_email.email), blacklisted_email, method: :delete, data: { confirm: ts("Are you sure you want to remove %{email} from the blacklist?", email: blacklisted_email.email) } %>
+            <%= link_to ts("Remove %{email}", email: blacklisted_email.email),
+                        blacklisted_email,
+                        method: :delete,
+                        data: { confirm: ts("Are you sure you want to remove %{email} from the blacklist?",
+                                email: blacklisted_email.email) } %>
           </li>
           <% end %>
         </ul>

--- a/app/views/admin/blacklisted_emails/index.html.erb
+++ b/app/views/admin/blacklisted_emails/index.html.erb
@@ -44,7 +44,7 @@
         <ol class="emails index group">
           <% @admin_blacklisted_emails.each do |blacklisted_email| %>
           <li>
-            <%= link_to ts("Remove %{email}", email: blacklisted_email.email), blacklisted_email, method: :delete, confirm: ts("Are you sure you want to remove %{email} from the blacklist?", email: blacklisted_email.email) %>
+            <%= link_to ts("Remove %{email}", email: blacklisted_email.email), blacklisted_email, method: :delete, data: { confirm: ts("Are you sure you want to remove %{email} from the blacklist?", email: blacklisted_email.email) } %>
           </li>
           <% end %>
         </ul>

--- a/app/views/admin_posts/show.html.erb
+++ b/app/views/admin_posts/show.html.erb
@@ -10,7 +10,7 @@
         <h4 class="landmark heading"><%= ts("Admin Actions") %></h4>
         <ul class="management actions" role="navigation">
           <li><%= link_to ts("Edit Post"), edit_admin_post_path(@admin_post) %></li>
-          <li><%= link_to t('admin.admin_nav.delete', default: 'Delete Post'), @admin_post, confirm: ts('Are you sure you want to delete this news post?'), method: :delete %></li>
+          <li><%= link_to t('admin.admin_nav.delete', default: 'Delete Post'), @admin_post, data: { confirm: ts('Are you sure you want to delete this news post?') }, method: :delete %></li>
         </ul>
       <% end %>
       <h4 class="landmark heading"><%= ts("News Post Navigation") %></h4>

--- a/app/views/admin_posts/show.html.erb
+++ b/app/views/admin_posts/show.html.erb
@@ -10,7 +10,12 @@
         <h4 class="landmark heading"><%= ts("Admin Actions") %></h4>
         <ul class="management actions" role="navigation">
           <li><%= link_to ts("Edit Post"), edit_admin_post_path(@admin_post) %></li>
-          <li><%= link_to t('admin.admin_nav.delete', default: 'Delete Post'), @admin_post, data: { confirm: ts('Are you sure you want to delete this news post?') }, method: :delete %></li>
+          <li>
+            <%= link_to t("admin.admin_nav.delete", default: "Delete Post"),
+                        @admin_post,
+                        data: { confirm: ts("Are you sure you want to delete this news post?") },
+                        method: :delete %>
+          </li>
         </ul>
       <% end %>
       <h4 class="landmark heading"><%= ts("News Post Navigation") %></h4>
@@ -33,6 +38,6 @@
   <!--/content-->
 
   <!-- BEGIN comment section -->
-  <%= render 'comments/commentable', commentable: @admin_post %>
+  <%= render "comments/commentable", commentable: @admin_post %>
   <!-- END comment section -->
 </div>

--- a/app/views/challenge_assignments/_maintainer_index.html.erb
+++ b/app/views/challenge_assignments/_maintainer_index.html.erb
@@ -32,13 +32,13 @@
   <li>
     <%= link_to ts("Default All Incomplete"),
                 default_all_collection_assignments_path(@collection),
-                confirm: ts("Are you sure? This will mark all unposted or unapproved assignments in the challenge as defaulting."),
+                data: { confirm: ts("Are you sure? This will mark all unposted or unapproved assignments in the challenge as defaulting.") },
                 role: "button" %>
   </li>
   <li>
     <%= link_to ts("Purge Assignments"),
                 confirm_purge_collection_assignments_path(@collection),
-                confirm: ts("This will delete ALL assignments so you can edit and send them over. Please do not do this unless you absolutely must!"),
+                data: { confirm: ts("This will delete ALL assignments so you can edit and send them over. Please do not do this unless you absolutely must!") },
                 role: "button" %>
   </li>
 </ul>

--- a/app/views/collections/_header.html.erb
+++ b/app/views/collections/_header.html.erb
@@ -25,7 +25,7 @@
     <% unless @collection.challenge || @collection.user_is_owner?(current_user) %>
       <% if (@participant ||= @collection.get_participants_for_user(current_user).first) %>
         <li><%= link_to ts("Leave"), collection_participant_path(@collection, @participant),
-          confirm: ts('Are you certain you want to leave this collection?'), 
+          data: { confirm: ts('Are you certain you want to leave this collection?') }, 
           method: :delete %></li>
       <% elsif logged_in? && @collection.moderated? %>
         <li><%= link_to ts("Join"), join_collection_participants_path(@collection) %></li>

--- a/app/views/invite_requests/manage.html.erb
+++ b/app/views/invite_requests/manage.html.erb
@@ -1,20 +1,20 @@
 <div class="admin">
 <!--Descriptive page name, messages and instructions-->
-  <h2 class="heading"><%= ts('Manage the Invitation Queue') %></h2>
+  <h2 class="heading"><%= ts("Manage the Invitation Queue") %></h2>
 <!--/descriptions-->
 
 <!--main content-->
   <%= form_tag reorder_invite_requests_url do %>
-    <p><%= submit_tag ts('Reorder Queue') %></p>
+    <p><%= submit_tag ts("Reorder Queue") %></p>
   <% end %>
 
-  <table summary="<%= ts('Lists each request/email and its current place in the queue. You can also delete each request.') %>">
-    <caption><%= ts('Manage the Invitation Queue') %></caption>
+  <table summary="<%= ts("Lists each request/email and its current place in the queue. You can also delete each request.") %>">
+    <caption><%= ts("Manage the Invitation Queue") %></caption>
     <thead>
       <tr>
-        <th scope="col"><%= ts('Queue Position') %></th>
-        <th scope="col"><%= ts('Email Address') %></th>
-        <th scope="col"><%= ts('Action') %></th>
+        <th scope="col"><%= ts("Queue Position") %></th>
+        <th scope="col"><%= ts("Email Address") %></th>
+        <th scope="col"><%= ts("Action") %></th>
       </tr>
     </thead>
     <tbody>
@@ -22,7 +22,12 @@
         <tr>
           <td><%= request.position %></td>
           <td><%= request.email %></td>
-          <td><%= link_to ts('Delete'), invite_request_path(request, page: params[:page]), data: { confirm: ts('Are you sure?') }, method: :delete %></td>
+          <td>
+            <%= link_to ts("Delete"),
+                        invite_request_path(request, page: params[:page]),
+                        data: { confirm: ts("Are you sure?") },
+                        method: :delete %>
+          </td>
         </tr>
       <% end %>
     </tbody>

--- a/app/views/invite_requests/manage.html.erb
+++ b/app/views/invite_requests/manage.html.erb
@@ -22,7 +22,7 @@
         <tr>
           <td><%= request.position %></td>
           <td><%= request.email %></td>
-          <td><%= link_to ts('Delete'), invite_request_path(request, page: params[:page]), data" { confirm: ts('Are you sure?') }, method: :delete %></td>
+          <td><%= link_to ts('Delete'), invite_request_path(request, page: params[:page]), data: { confirm: ts('Are you sure?') }, method: :delete %></td>
         </tr>
       <% end %>
     </tbody>

--- a/app/views/invite_requests/manage.html.erb
+++ b/app/views/invite_requests/manage.html.erb
@@ -22,7 +22,7 @@
         <tr>
           <td><%= request.position %></td>
           <td><%= request.email %></td>
-          <td><%= link_to ts('Delete'), invite_request_path(request, page: params[:page]), confirm: ts('Are you sure?'), method: :delete %></td>
+          <td><%= link_to ts('Delete'), invite_request_path(request, page: params[:page]), data" { confirm: ts('Are you sure?') }, method: :delete %></td>
         </tr>
       <% end %>
     </tbody>

--- a/app/views/skins/_skin_actions.html.erb
+++ b/app/views/skins/_skin_actions.html.erb
@@ -14,7 +14,7 @@
     <% if skin.editable? %>
       <li><%= span_if_current ts('Edit'), edit_skin_url(skin) %></li>
       <% unless logged_in_as_admin? %>
-        <li><%= link_to ts('Delete'), skin, confirm: ts('Are you sure?'), method: :delete %></li>
+        <li><%= link_to ts('Delete'), skin, data: { confirm: ts('Are you sure?') }, method: :delete %></li>
       <% end %>
     <% end %>
   </ul>

--- a/app/views/skins/_skin_actions.html.erb
+++ b/app/views/skins/_skin_actions.html.erb
@@ -12,9 +12,14 @@
     <% end %>
 
     <% if skin.editable? %>
-      <li><%= span_if_current ts('Edit'), edit_skin_url(skin) %></li>
+      <li><%= span_if_current ts("Edit"), edit_skin_url(skin) %></li>
       <% unless logged_in_as_admin? %>
-        <li><%= link_to ts('Delete'), skin, data: { confirm: ts('Are you sure?') }, method: :delete %></li>
+        <li>
+          <%= link_to ts("Delete"),
+                      skin,
+                      data: { confirm: ts("Are you sure?") },
+                      method: :delete %>
+        </li>
       <% end %>
     <% end %>
   </ul>

--- a/app/views/users/change_username.html.erb
+++ b/app/views/users/change_username.html.erb
@@ -32,7 +32,7 @@
     <dd><%= password_field_tag :password %></dd>
     <dt class="landmark"><%= ts("Submit") %></dt>
     <dd class="submit actions">
-      <%= submit_tag ts("Change User Name"), confirm: ts("Are you sure you want to change your user name?") %>
+      <%= submit_tag ts("Change User Name"), data: { confirm: ts("Are you sure you want to change your user name?") } %>
     </dd>
   </dl>
 <% end %>

--- a/app/views/users/change_username.html.erb
+++ b/app/views/users/change_username.html.erb
@@ -1,5 +1,5 @@
 <!--Descriptive page name, messages and instructions-->
-<h2 class="heading"><%= ts('Change My User Name') %></h2>
+<h2 class="heading"><%= ts("Change My User Name") %></h2>
 <%= error_messages_for :user %>
 <p class="caution">
   <%= ts("Please use this feature with caution. We will not redirect your old user name to your new one. Bookmarks and external links to your user page and your pseud pages under the old name will no longer work and the old name may be used by someone else unless all you are changing is capitalization.") %>
@@ -10,7 +10,7 @@
 <!--/descriptions-->
 
 <!--subnav-->
-<%= render 'edit_header_navigation' %>
+<%= render "edit_header_navigation" %>
 <!--/subnav-->
 
 <!--main content-->
@@ -21,7 +21,7 @@
     <dd><p class="important informational"><%= @user.login %></p></dd>
     <dt><%= label_tag :new_login, ts("New user name") %></dt>
     <dd>
-      <%= text_field_tag :new_login, @new_login, autocomplete: 'off', "aria-describedby" => "new-login-field-description" %>
+      <%= text_field_tag :new_login, @new_login, autocomplete: "off", "aria-describedby" => "new-login-field-description" %>
       <p class="footnote" id="new-login-field-description">
         <%= ts("%{minimum} to %{maximum} characters (A-Z, a-z, _, 0-9 only), no spaces, cannot begin or end with underscore (_)",
                minimum: ArchiveConfig.LOGIN_LENGTH_MIN,
@@ -42,9 +42,9 @@
     <%= ts("If you've forgotten your password, we can send you a temporary one.") %>
   </p>
   <%= form_tag passwords_path do %>
-    <%= hidden_field_tag 'login', @user.login %>
+    <%= hidden_field_tag "login", @user.login %>
     <p class="footnote">
-      <%= submit_tag ts('Reset My Password') %>
+      <%= submit_tag ts("Reset My Password") %>
     </p>
   <% end %>
 <% end %>

--- a/app/views/works/_standard_form.html.erb
+++ b/app/views/works/_standard_form.html.erb
@@ -142,7 +142,7 @@
                       </li>
                       <li>
                         <%= link_to ts("Remove"), related_work,
-                                confirm: ts("Are you sure you want to delete the connection to this work?"),
+                                data: { confirm: ts("Are you sure you want to delete the connection to this work?") },
                                 method: :delete %>
                       </li>
                     </ul>


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5023, specifically https://otwarchive.atlassian.net/browse/AO3-5023?focusedCommentId=350327&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-350327

## Purpose

Restores the confirmation popup message in a variety of places:

- Deleting works, bookmarks, or external works as an admin should have a confirmation popup
- Deleting news posts as an admin, both while on the post's edit page and the post itself, should have a confirmation popup
- As an admin, choosing the "Spammer: ban and delete all creations" option for a user and pressing "Submit" on the confirmation page for deleting creations should have a confirmation popup
- Deleting an invite request as an admin should have a confirmation popup
- As an admin, following the remove link after searching for a blacklisted email should have a confirmation popup
- Defaulting all incomplete assignments or purging all assignments as a challenge mod should have a confirmation popup
- Using the "Leave" button to leave a collection you are a member of should have a confirmation popup
- Deleting a skin should have a confirmation popup
- Changing your username should have a confirmation popup when you submit the form
- Removing a parent work from the work edit page should have a confirmation popup

Also some style fixes relating to spacing and quotation marks.

## Testing

Check that the behavior described above/in the JIRA comment happens
