### PR TITLE
AO3-5023 Fix disabling form buttons on submission

### DIFF
--- a/app/views/chapters/_chapter_form.html.erb
+++ b/app/views/chapters/_chapter_form.html.erb
@@ -74,7 +74,7 @@
           <li><%= submit_tag ts("Save Without Posting"), name: "save_button" %></li>
         <% end %>
         <li><%= submit_tag ts("Preview"), name: "preview_button" %></li>
-        <li><%= submit_tag ts("Post Without Preview"), name: "post_without_preview_button", disable_with: ts("Please wait...") %></li>
+        <li><%= submit_tag ts("Post Without Preview"), name: "post_without_preview_button", data: { disable_with: ts("Please wait...") } %></li>
         <li><%= submit_tag ts("Cancel"), name: "cancel_button" %></li>
       </ul>
     </fieldset>

--- a/app/views/chapters/preview.html.erb
+++ b/app/views/chapters/preview.html.erb
@@ -25,7 +25,7 @@
       <% if @chapter.posted? %>
         <li><%= submit_tag ts('Update'), :name => 'update_button' %></li>
       <% else %>
-        <li><%= submit_tag ts('Post'), :name => 'post_button', :disable_with =>  ts("Please wait...") %></li>
+        <li><%= submit_tag ts('Post'), :name => 'post_button', data: {disable_with: ts("Please wait...") } %></li>
         <li><%= submit_tag ts("Save Without Posting"), :name => 'save_button' %></li>
       <% end %>
       <li><%= submit_tag ts('Edit'), :name => 'edit_button' %></li>

--- a/app/views/chapters/preview.html.erb
+++ b/app/views/chapters/preview.html.erb
@@ -35,8 +35,8 @@
         </li>
       <% end %>
       <li><%= submit_tag ts("Edit"), name: "edit_button" %></li>
-      <li><%= submit_tag ts("Cancel"), name: "cancel_button" %></li> 
+      <li><%= submit_tag ts("Cancel"), name: "cancel_button" %></li>
     </ul>
   </fieldset>
-  
+
 <% end %>

--- a/app/views/chapters/preview.html.erb
+++ b/app/views/chapters/preview.html.erb
@@ -25,7 +25,7 @@
       <% if @chapter.posted? %>
         <li><%= submit_tag ts('Update'), :name => 'update_button' %></li>
       <% else %>
-        <li><%= submit_tag ts('Post'), :name => 'post_button', data: {disable_with: ts("Please wait...") } %></li>
+        <li><%= submit_tag ts('Post'), :name => 'post_button', data: { disable_with: ts("Please wait...") } %></li>
         <li><%= submit_tag ts("Save Without Posting"), :name => 'save_button' %></li>
       <% end %>
       <li><%= submit_tag ts('Edit'), :name => 'edit_button' %></li>

--- a/app/views/chapters/preview.html.erb
+++ b/app/views/chapters/preview.html.erb
@@ -5,7 +5,7 @@
 
 <% if @work.work_skin && !Preference.disable_work_skin?(params[:style]) %>
   <% cache("#{@work.work_skin.id}-#{@work.work_skin.updated_at}-work-skin", skip_digest: true) do %>
-    <%= render "skins/skin_style_block", :skin => @work.work_skin %>
+    <%= render "skins/skin_style_block", skin: @work.work_skin %>
   <% end %><!-- end cache for work skin -->
 <% end %>
 
@@ -17,19 +17,25 @@
 
 <%= form_for([@work, @chapter]) do |f| %>
 
-  <%= render 'hidden_fields', :form => f %>
+  <%= render "hidden_fields", form: f %>
 
   <fieldset>
     <legend><%= ts("Post Chapter") %></legend>
     <ul class="actions">
       <% if @chapter.posted? %>
-        <li><%= submit_tag ts('Update'), :name => 'update_button' %></li>
+        <li><%= submit_tag ts("Update"), name: "update_button" %></li>
       <% else %>
-        <li><%= submit_tag ts('Post'), :name => 'post_button', data: { disable_with: ts("Please wait...") } %></li>
-        <li><%= submit_tag ts("Save Without Posting"), :name => 'save_button' %></li>
+        <li>
+          <%= submit_tag ts("Post"),
+                         name: "post_button",
+                         data: { disable_with: ts("Please wait...") } %>
+        </li>
+        <li>
+          <%= submit_tag ts("Save Without Posting"), name: "save_button" %>
+        </li>
       <% end %>
-      <li><%= submit_tag ts('Edit'), :name => 'edit_button' %></li>
-      <li><%= submit_tag ts('Cancel'), :name => 'cancel_button' %></li> 
+      <li><%= submit_tag ts("Edit"), name: "edit_button" %></li>
+      <li><%= submit_tag ts("Cancel"), name: "cancel_button" %></li> 
     </ul>
   </fieldset>
   

--- a/app/views/feedbacks/new.html.erb
+++ b/app/views/feedbacks/new.html.erb
@@ -75,7 +75,7 @@
     <%= f.hidden_field :user_agent, value: request.env["HTTP_USER_AGENT"] %>
     <%= f.hidden_field :ip_address, value: request.remote_ip %>
     <p class="submit actions">
-      <%= f.submit ts("Send"), disable_with: ts("Please wait...") %>
+      <%= f.submit ts("Send"), data: { disable_with: ts("Please wait...") } %>
     </p>
   </fieldset>
 

--- a/app/views/feedbacks/new.html.erb
+++ b/app/views/feedbacks/new.html.erb
@@ -1,7 +1,7 @@
 <!--Descriptive page name, messages and instructions-->
 <%= error_messages_for :feedback %>
 
-<h2 class="heading"><%= ts('Support and Feedback') %></h2>
+<h2 class="heading"><%= ts("Support and Feedback") %></h2>
 <!--/descriptions-->
 
 <!--subnav-->
@@ -17,7 +17,7 @@
 <!--main content-->
 <h3 class="heading"><%= ts("We love to hear from our users! Tell us about your experience - good, bad, or broken - using our site!") %></h3>
 <div class="userstuff">
-  <p><%= ts('We\'re still in our beta phase of development, so there are lots of bugs to be fixed and new features to be considered. For live updates on Archive performance, please check out our Twitter feed: <a href="http://twitter.com/ao3_status">@AO3_status</a>. Please use this form to let us know about your experience while using the site - good and bad! This form is for questions about the Archive and the OTW. Questions for creators should be left on their works. If you have technical issues with this page, please use <a href="http://www.transformativeworks.org/contact_us/contact-archive-support/">the back-up form</a>.').html_safe %></p>
+  <p><%= ts("We're still in our beta phase of development, so there are lots of bugs to be fixed and new features to be considered. For live updates on Archive performance, please check out our Twitter feed: <a href=\"http://twitter.com/ao3_status\">@AO3_status</a>. Please use this form to let us know about your experience while using the site - good and bad! This form is for questions about the Archive and the OTW. Questions for creators should be left on their works. If you have technical issues with this page, please use <a href=\"http://www.transformativeworks.org/contact_us/contact-archive-support/\">the back-up form</a>.").html_safe %></p>
   <p><%= ts("<strong>We can answer Support inquiries in %{list}.</strong> Please allow for up to one week delay for responses in any language other than English and español.", list: @support_languages.map(&:name).to_sentence).html_safe %></p>
 </div>
 <%= form_for(@feedback, html: { class: "post feedback" }) do |f| %>
@@ -39,7 +39,7 @@
   </fieldset>
 
   <fieldset>
-    <legend><%= ts('Describe Your Feedback') %></legend>
+    <legend><%= ts("Describe Your Feedback") %></legend>
     <dl>
       <dt class="required">
         <%= f.label :language, ts("Select language (required)") %>
@@ -53,7 +53,7 @@
       <dd class="required">
         <%= f.text_field :summary, size: 60, class: "observe_textlength" %>
         <%= generate_countdown_html("feedback_summary", ArchiveConfig.FEEDBACK_SUMMARY_MAX_DISPLAYED) %>
-        <%= live_validation_for_field('feedback_summary',
+        <%= live_validation_for_field("feedback_summary",
               failureMessage: ts("Please enter a brief summary of your message")) %>
       </dd>
       <dt class="required">
@@ -61,7 +61,7 @@
       </dt>
       <dd class="required">
         <%= f.text_area :comment, cols: 60, "aria-describedby" => "comment-field-description" %>
-        <%= live_validation_for_field('feedback_comment',
+        <%= live_validation_for_field("feedback_comment",
               failureMessage: ts("Please enter your feedback")) %>
         <p class="footnote" id="comment-field-description">
           <%= ts("Please be as specific as possible, including error messages and/or links") %>
@@ -71,7 +71,7 @@
   </fieldset>
 
   <fieldset>
-    <legend><%= ts('Send Your Feedback') %></legend>
+    <legend><%= ts("Send Your Feedback") %></legend>
     <%= f.hidden_field :user_agent, value: request.env["HTTP_USER_AGENT"] %>
     <%= f.hidden_field :ip_address, value: request.remote_ip %>
     <p class="submit actions">

--- a/app/views/works/_standard_form.html.erb
+++ b/app/views/works/_standard_form.html.erb
@@ -339,7 +339,7 @@
       </li>
       <li>
         <%= submit_tag ts("Post Without Preview"), name: "post_button",
-              disable_with: ts("Please wait...") %>
+              data: { disable_with: ts("Please wait...") } %>
       </li>
       <li>
         <%= submit_tag ts("Cancel"), name: "cancel_button" %>

--- a/app/views/works/preview.html.erb
+++ b/app/views/works/preview.html.erb
@@ -49,7 +49,7 @@
       <% if @work.posted? %>
         <li><%= submit_tag ts('Update'), :name => 'update_button' %></li>
       <% else %>
-        <li><%= submit_tag ts('Post'), :name => 'post_button', :disable_with => ts("Please wait...") %></li>
+        <li><%= submit_tag ts('Post'), :name => 'post_button', data: { disable_with: ts("Please wait...") } %></li>
         <li><%= submit_tag ts('Save Without Posting'), :name => 'save_button' %></li>
       <% end %>
       <li><%= submit_tag ts('Edit'), :name => 'edit_button' %></li>

--- a/app/views/works/preview.html.erb
+++ b/app/views/works/preview.html.erb
@@ -6,29 +6,29 @@
 <!--main content-->
 <div id="previewpane">
   <div class="draft work">
-    <%= render :partial => 'works/work_header' %>
+    <%= render "works/work_header" %>
     <div id="chapters">
     <% if @chapters %>
       <% @chapters.each do |chapter| %>
-        <%= render :partial => 'chapters/chapter', :locals => {:chapter => chapter} %>
+        <%= render "chapters/chapter", chapter: chapter %>
       <% end %>
     <% else %>
-        <div class="userstuff"><%=raw sanitize_field(@chapter, :content) %></div>
+      <div class="userstuff"><%=raw sanitize_field(@chapter, :content) %></div>
     <% end %>
     </div>
-    
+
     <% inspired_by = get_inspired_by(@work) %>
     <% if !@work.endnotes.blank? || !@work.series.blank? || !inspired_by.empty? %>
     <!--afterword-->
     <div class="afterword preface group" role="complementary">
       <% unless @work.endnotes.blank? %>
-        <%= render :partial => 'works/work_endnotes' %>
+        <%= render "works/work_endnotes" %>
       <% end %>
       <% unless @work.series.blank? %>
-        <%= render :partial => 'works/work_series_links' %>
+        <%= render "works/work_series_links" %>
       <% end %>
       <% unless inspired_by.empty? %>
-        <%= render :partial => 'works/work_approved_children', :locals => {:inspired_by => inspired_by} %>
+        <%= render "works/work_approved_children", inspired_by: inspired_by %>
       <% end %>
     </div>
     <!--/afterword-->
@@ -41,19 +41,25 @@
 
 <%= form_for(@work) do |f| %>
 
-  <%= render :partial => 'hidden_fields', :locals => {:form => f} %>
+  <%= render "hidden_fields", form: f %>
 
   <fieldset>
-    <legend><%= ts('Post Work') %></legend>
+    <legend><%= ts("Post Work") %></legend>
     <ul class="actions">
       <% if @work.posted? %>
-        <li><%= submit_tag ts('Update'), :name => 'update_button' %></li>
+        <li><%= submit_tag ts("Update"), name: "update_button" %></li>
       <% else %>
-        <li><%= submit_tag ts('Post'), :name => 'post_button', data: { disable_with: ts("Please wait...") } %></li>
-        <li><%= submit_tag ts('Save Without Posting'), :name => 'save_button' %></li>
+        <li>
+          <%= submit_tag ts("Post"),
+                         name: "post_button",
+                         data: { disable_with: ts("Please wait...") } %>
+        </li>
+        <li>
+          <%= submit_tag ts("Save Without Posting"), name: "save_button" %>
+        </li>
       <% end %>
-      <li><%= submit_tag ts('Edit'), :name => 'edit_button' %></li>
-      <li><%= submit_tag ts('Cancel'), :name => 'cancel_button' %></li> 
+      <li><%= submit_tag ts("Edit"), name: "edit_button" %></li>
+      <li><%= submit_tag ts("Cancel"), name: "cancel_button" %></li>
     </ul>
   </fieldset>
 


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5023 

Specifically: https://otwarchive.atlassian.net/browse/AO3-5023?focusedCommentId=350329&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-350329

## Purpose

Restores the following behavior:

- Post Without Preview should get disabled with "Please wait..." on new chapter form
- Post should get disabled with "Please wait..." on chapter preview page
- Send should get disabled with "Please wait..." on support form
- Post Without Preview should get disabled with "Please wait..." on new work form
- Post should get disabled with "Please wait..." on work preview page

Also has style fixes concerning hash rockets, quotation marks, and line length.

## Testing

Check that the behavior described above/in the JIRA comment happens
