### PR TITLE
AO3-5045 Clear caches before each unit test

### DIFF
--- a/spec/controllers/autocomplete_controller_spec.rb
+++ b/spec/controllers/autocomplete_controller_spec.rb
@@ -1,23 +1,13 @@
-require 'spec_helper'
+require "spec_helper"
 
 describe AutocompleteController do
+  describe "tag" do
+    let!(:tag1) { create(:fandom, name: "Match") }
+    let!(:tag2) { create(:fandom, name: "Blargh") }
 
-  before do
-    # clear out the test redis db so we don't get duplicate entries
-    REDIS_GENERAL.flushdb
-  end
-
-  describe "do_tag" do
-    it "should only return matching tags" do
-      @tag = FactoryGirl.create(:fandom, name: "Match")
-      @tag2 = FactoryGirl.create(:fandom, name: "Blargh")
-
-      # we need to set this to make the controller return the JSON-encoded data we want
-      @request.env['HTTP_ACCEPT'] = "application/json"
-      get :tag, term: "Ma"
-      expect(response.body).to include("Match")
-      expect(response.body).not_to include("Blargh")
+    it "returns only matching tags" do
+      get :tag, term: "Ma", format: :json
+      expect(JSON.parse(response.body)).to eq([{ "id" => "Match", "name" => "Match" }])
     end
   end
-
 end

--- a/spec/models/cache_master_spec.rb
+++ b/spec/models/cache_master_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe CacheMaster do
- let(:cache_master) { CacheMaster.new(123456) }
+  let(:cache_master) { CacheMaster.new(123_456) }
 
   it "should have a key" do
     expect(cache_master.key).to eq("works:123456:assocs")
@@ -13,7 +13,6 @@ describe CacheMaster do
   end
 
   it "should combine multiple deleted associations" do
-    clean_the_database   
     cache_master.record('tag', 5)
     cache_master.record('tag', 6)
     cache_master.record('pseud', 7)
@@ -21,7 +20,6 @@ describe CacheMaster do
   end
 
   it "should expire caches" do
-    clean_the_database
     cache_master.record('tag', 5)
     cache_master.record('tag', 6)
     cache_master.record('pseud', 7)
@@ -36,5 +34,4 @@ describe CacheMaster do
     cache_master.expire
     expect(cache_master.get_hash).to eq({})
   end
-
 end

--- a/spec/models/index_queue_spec.rb
+++ b/spec/models/index_queue_spec.rb
@@ -1,13 +1,6 @@
 require 'spec_helper'
 
 describe IndexQueue do
-
-  before(:each) do
-    IndexQueue.all.each do |key|
-      REDIS_GENERAL.del(key)
-    end
-  end
-
   it "should build correct keys" do
     expect(IndexQueue.get_key('StatCounter', :stats)).to eq("index:stat_counter:stats")
   end
@@ -39,5 +32,4 @@ describe IndexQueue do
 
     expect(IndexQueue::REDIS.exists("index:work:main")).to be_falsey
   end
-
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -39,6 +39,7 @@ RSpec.configure do |config|
   config.before :each do
     DatabaseCleaner.start
     User.current_user = nil
+    clean_the_database
   end
 
   config.after :each do
@@ -83,7 +84,17 @@ def clean_the_database
   REDIS_RESQUE.flushall
   REDIS_ROLLOUT.flushall
   # Finally elastic search
-  Tire::Model::Search.index_prefix Time.now.to_f.to_s
+  Work.tire.index.delete
+  Work.create_elasticsearch_index
+
+  Bookmark.tire.index.delete
+  Bookmark.create_elasticsearch_index
+
+  Tag.tire.index.delete
+  Tag.create_elasticsearch_index
+
+  Pseud.tire.index.delete
+  Pseud.create_elasticsearch_index
 end
 
 def get_message_part (mail, content_type)


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5045

## Purpose

Before each unit test, clear memcached, Redis, and Elasticsearch.

Similar to #2884 / [AO3-4992](https://otwarchive.atlassian.net/browse/AO3-4992), for feature tests.

## Testing

None, automated.