### PR TITLE
AO3-5023 Make ePub toc.ncx and content.opf stop using site layout

### DIFF
--- a/app/controllers/downloads_controller.rb
+++ b/app/controllers/downloads_controller.rb
@@ -205,10 +205,8 @@ protected
     render_xhtml(afterword, "afterword")
 
     # write the OEBPS navigation files
-    File.open("#{epubdir}/OEBPS/toc.ncx", 'w') {|f| f.write(render_to_string(file: "#{Rails.root}/app/views/epub/toc.ncx"))}
-    File.open("#{epubdir}/OEBPS/content.opf", 'w') {|f| f.write(render_to_string(file: "#{Rails.root}/app/views/epub/content.opf"))}
-
-
+    File.open("#{epubdir}/OEBPS/toc.ncx", 'w') { |f| f.write(render_to_string(file: "#{Rails.root}/app/views/epub/toc.ncx", layout: false)) }
+    File.open("#{epubdir}/OEBPS/content.opf", 'w') { |f| f.write(render_to_string(file: "#{Rails.root}/app/views/epub/content.opf", layout: false)) }
   end
 
   def render_xhtml(html, filename)


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5023

Specifically the issue described in this comment: https://otwarchive.atlassian.net/browse/AO3-5023?focusedCommentId=350617&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-350617

## Purpose

This makes sure we don't include the site layout when making the files for our ePub.

## Testing

Make sure you can download _and open_ an ePub on multiple devices/platforms/programs.

## References

Sarken [19:35] 
Jumping over here to talk about the problem with ePub files on staging. Claire gave us a useful error message (`Line 192: XML declaration allowed only at the start of the document`), so I'm investigating, and I'm already finding interesting things.

[19:37] 
So an ePub is a container, basically, with a bunch of files inside it. I can find XML declarations on line 192 of not one but _two_ files inside a broken ePub: content.opf and toc.ncx. I haven't looked at content.opf in detail yet, but I see a huuuuge difference between the toc.ncx files from staging and production.

[19:37] 
This is what a working toc.ncx file looks like:

[19:37] 
 ```
<?xml version="1.0" encoding="UTF-8"?>
<ncx xmlns="http://www.daisy.org/z3986/2005/ncx/" version="2005-1">
  <head>
    <meta name="dtb:uid" content=""/>
    <meta name="dtb:depth" content="1"/>
    <meta name="dtb:totalPageCount" content="0"/>
    <meta name="dtb:maxPageNumber" content="0"/>
  </head>
  <docTitle>
    <text>The Taste of Her Cherry Chapstick</text>
  </docTitle>
  <navMap>
    <navPoint id="preface" playOrder="0">
      <navLabel>
        <text>Preface</text>
      </navLabel>
      <content src="preface.xhtml"/>
    </navPoint>
      <navPoint id="chapter1" playOrder="1">
        <navLabel>
          <text>The Taste of Her Cherry Chapstick</text>
        </navLabel>
        <content src="chapter1_1.xhtml"/>
      </navPoint>
    <navPoint id="afterword" playOrder="2">
      <navLabel>
        <text>Afterword</text>
      </navLabel>
      <content src="afterword.xhtml"/>
    </navPoint>
  </navMap>
</ncx>
```

[19:39] 
Whereas the _broken_ toc.ncx file from staging is _not_ just a nicely formatted XML document. It also includes the site layout, which it 100% should not

Sarken [19:40] 
A quick look at content.opf shows me the same issue.

[19:43] 
So it seems like something is using application.html.erb as the template when it shouldn't be, and we need to tell it to stop.