### PR TITLE
AO3-5023 Get arrays of readings and admin posts for homepage

### DIFF
--- a/app/decorators/homepage.rb
+++ b/app/decorators/homepage.rb
@@ -25,7 +25,7 @@ class Homepage
       @admin_posts = AdminPost.non_translated.for_homepage.all
     else
       @admin_posts = Rails.cache.fetch("home/index/home_admin_posts", expires_in: 20.minutes) do
-        AdminPost.non_translated.for_homepage
+        AdminPost.non_translated.for_homepage.to_a
       end
     end
   end
@@ -52,7 +52,8 @@ class Homepage
       @readings ||= Rails.cache.fetch("home/index/#{@user.id}/home_marked_for_later") do
         @user.readings.order("RAND()").
           limit(ArchiveConfig.NUMBER_OF_ITEMS_VISIBLE_ON_HOMEPAGE).
-          where(toread: true)
+          where(toread: true).
+          to_a
       end
     end
   end


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5023

Specifically this comment: https://otwarchive.atlassian.net/browse/AO3-5023?focusedCommentId=350618&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-350618

## Purpose

When you are logged in and have more than three Marked for Later items, you see different items under "Is it later already?" each time you reload the homepage. This is because caching is broken -- we need an array, not ActiveRecord objects. See the discussion here: https://github.com/otwcode/otwarchive/pull/2917#discussion_r116371412 

## Testing

Log in and add more than three items to your Marked for Later list. Go to homepage make sure "Is it later already?" shows three random works from your marked for later, and the works _do not_ change until your marked for later is updated.