### PR TITLE
AO3-5023 Update finders in skin and admin rake files

### DIFF
--- a/lib/tasks/admin_tasks.rake
+++ b/lib/tasks/admin_tasks.rake
@@ -18,7 +18,7 @@ namespace :admin do
   task(:purge_unvalidated_users => :environment) do
     users = User.where("activated_at IS NULL AND created_at < ?", 2.weeks.ago)
     puts users.map(&:login).join(", ")
-    # users.map(&:destroy)
+    users.map(&:destroy)
     puts "Unvalidated accounts created more than two weeks ago have been purged"
   end
 

--- a/lib/tasks/admin_tasks.rake
+++ b/lib/tasks/admin_tasks.rake
@@ -7,7 +7,7 @@ namespace :admin do
 
   desc "Resend sign-up notification emails after 24 hours"
   task(:resend_signup_emails => :environment) do
-    @users = User.find(:all, :conditions => {:activated_at => nil, :created_at => 48.hours.ago..24.hours.ago})
+    @users = User.where(activated_at: nil, created_at: 48.hours.ago..24.hours.ago)
     @users.each do |user|
       UserMailer.signup_notification(user.id).deliver
     end
@@ -16,9 +16,9 @@ namespace :admin do
 
   desc "Purge unvalidated accounts created more than 2 weeks ago"
   task(:purge_unvalidated_users => :environment) do
-    users = User.find(:all, :conditions => ["activated_at IS NULL AND created_at < ?", 2.weeks.ago])
+    users = User.where("activated_at IS NULL AND created_at < ?", 2.weeks.ago)
     puts users.map(&:login).join(", ")
-    users.map(&:destroy)
+    # users.map(&:destroy)
     puts "Unvalidated accounts created more than two weeks ago have been purged"
   end
 

--- a/lib/tasks/tag_tasks.rake
+++ b/lib/tasks/tag_tasks.rake
@@ -1,7 +1,7 @@
 namespace :Tag do
   desc "Reset common taggings - slow"
   task(reset_common: :environment) do
-    Work.find(:all).each do |w|
+    Work.find_each do |w|
       print "." if w.id.modulo(100) == 0; STDOUT.flush
       #w.update_common_tags
     end
@@ -10,7 +10,7 @@ namespace :Tag do
 
   desc "Reset tag count"
   task(reset_count: :environment) do
-    Tag.find(:all).each do |t|
+    Tag.find_each do |t|
       t.taggings_count
     end
     puts "Tag count reset."
@@ -22,14 +22,14 @@ namespace :Tag do
     tag_count = tag_scope.count
     tag_scope.each_with_index do |tag, index|
       puts "#{index} / #{tag_count}"
-      tag.taggings_count
+      tag.taggings_counts
     end
     puts "Taggings count for less-than-zero counts has been reset."
   end
 
   desc "Update relationship has_characters"
   task(update_has_characters: :environment) do
-    Relationship.all.each do |relationship|
+    Relationship.find_each do |relationship|
       relationship.update_attribute(:has_characters, true) unless relationship.characters.blank?
     end
   end
@@ -37,7 +37,7 @@ namespace :Tag do
   desc "Delete unused tags"
   task(delete_unused: :environment) do
     deleted_names = []
-    Tag.find(:all, conditions: { canonical: false, merger_id: nil, taggings_count_cache: 0 }).each do |t|
+    Tag.where(canonical: false, merger_id: nil, taggings_count_cache: 0).each do |t|
       if t.taggings.count.zero? && t.child_taggings.count.zero? && t.set_taggings.count.zero?
         deleted_names << t.name
         t.destroy
@@ -59,15 +59,18 @@ namespace :Tag do
     Tagging.find_each { |t| t.destroy if t.taggable.nil? }
     CommonTagging.find_each { |t| t.destroy if t.common_tag.nil? }
   end
+
   desc "Reset filter taggings"
   task(reset_filters: :environment) do
     FilterTagging.delete_all
     FilterTagging.build_from_taggings
   end
+
   desc "Reset filter counts"
   task(reset_filter_counts: :environment) do
     FilterCount.set_all
   end
+
   desc "Reset filter counts from date"
   task(unsuspend_filter_counts: :environment) do
     admin_settings = Rails.cache.fetch("admin_settings") { AdminSetting.first }

--- a/lib/tasks/tag_tasks.rake
+++ b/lib/tasks/tag_tasks.rake
@@ -22,7 +22,7 @@ namespace :Tag do
     tag_count = tag_scope.count
     tag_scope.each_with_index do |tag, index|
       puts "#{index} / #{tag_count}"
-      tag.taggings_counts
+      tag.taggings_count
     end
     puts "Taggings count for less-than-zero counts has been reset."
   end


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5023

Specifically this comment: https://otwarchive.atlassian.net/browse/AO3-5023?focusedCommentId=350900&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-350900

## Purpose

Updates the finders in the skin and admin rakes so we can use them. It also changes a few find alls to find_each, because all is going to load everything into memory. 

## Testing

Someone with database access will need to run the tasks for deleting unused tags, resending sign-up emails, and purging unvalidated accounts on staging. This also changes the reset common taggings, reset tag count, and update relationship has_characters tasks to the more efficient find_each, but I am not sure if we actually want or need to run those.