### PR TITLE
AO3-5023 Fix logged in user claiming imported works

### DIFF
--- a/app/controllers/downloads_controller.rb
+++ b/app/controllers/downloads_controller.rb
@@ -205,10 +205,8 @@ protected
     render_xhtml(afterword, "afterword")
 
     # write the OEBPS navigation files
-    File.open("#{epubdir}/OEBPS/toc.ncx", 'w') {|f| f.write(render_to_string(file: "#{Rails.root}/app/views/epub/toc.ncx"))}
-    File.open("#{epubdir}/OEBPS/content.opf", 'w') {|f| f.write(render_to_string(file: "#{Rails.root}/app/views/epub/content.opf"))}
-
-
+    File.open("#{epubdir}/OEBPS/toc.ncx", 'w') { |f| f.write(render_to_string(file: "#{Rails.root}/app/views/epub/toc.ncx", layout: false)) }
+    File.open("#{epubdir}/OEBPS/content.opf", 'w') { |f| f.write(render_to_string(file: "#{Rails.root}/app/views/epub/content.opf", layout: false)) }
   end
 
   def render_xhtml(html, filename)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -47,7 +47,7 @@ Otwarchive::Application.routes.draw do
 
   get 'signup/:invitation_token' => 'users#new', as: 'signup'
   get 'claim/:invitation_token' => 'external_authors#claim', as: 'claim'
-  get 'complete_claim/:invitation_token' => 'external_authors#complete_claim', as: 'complete_claim'
+  post 'complete_claim/:invitation_token' => 'external_authors#complete_claim', as: 'complete_claim'
 
   #### TAGS ####
 

--- a/features/importing/archivist.feature
+++ b/features/importing/archivist.feature
@@ -205,8 +205,8 @@ Feature: Archivist bulk imports
       And I check "Do not email me in the future when works are imported with this email address."
       And I press "Update"
     Then I should see "Your imported stories have been deleted. Your preferences have been saved."
-    When no emails have been sent
-    When I am logged in as "archivist"
+    When the email queue is clear
+      And I am logged in as "archivist"
       And I import the work "http://ao3testing.dreamwidth.org/325.html" by "randomtestname" with email "random@example.com"
       And the system processes jobs
      Then 0 emails should be delivered to "random@example.com"

--- a/features/step_definitions/email_custom_steps.rb
+++ b/features/step_definitions/email_custom_steps.rb
@@ -1,4 +1,4 @@
-Given /^(?:a clear email queue|no emails have been sent)$/ do
+Given /^(?:a clear email queue|no emails have been sent|the email queue is clear)$/ do
   reset_mailer
 end
 

--- a/features/support/paths.rb
+++ b/features/support/paths.rb
@@ -205,6 +205,8 @@ module NavigationHelpers
       opendoors_tools_path
     when /^the Open Doors external authors page$/i
       opendoors_external_authors_path
+    when /^the claim page for "(.*)"$/i
+      claim_path(:invitation_token => Invitation.find_by(invitee_email: $1).token)
     when /^the languages page$/i
       languages_path
     when /^the wranglers page$/i

--- a/features/support/paths.rb
+++ b/features/support/paths.rb
@@ -206,7 +206,7 @@ module NavigationHelpers
     when /^the Open Doors external authors page$/i
       opendoors_external_authors_path
     when /^the claim page for "(.*)"$/i
-      claim_path(:invitation_token => Invitation.find_by(invitee_email: $1).token)
+      claim_path(invitation_token: Invitation.find_by(invitee_email: $1).token)
     when /^the languages page$/i
       languages_path
     when /^the wranglers page$/i


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5023

Comment: https://otwarchive.atlassian.net/browse/AO3-5023?focusedCommentId=351011&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-351011

## Purpose

Fixes a routing error that was preventing users from claiming imported works. There's a little bit of test tidying, too, because I was trying to track down several OD-related bugs, and I needed to understand what we were testing in some of these. :P Alas, this was the only one I could fix. 

## Testing

You'll need a user with two email addresses: one they use for their AO3 account and one they don't. An archivist will need to import a work and list the non-AO3 email addresses in the external author information. While logged in, the user should follow the claim link in the email and choose "Add these works to my currently-logged-in account." The works should be added to their account.

