### PR TITLE
AO3-5023 Fix broken links for wrangling in a fandom

### DIFF
--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -304,7 +304,7 @@ class TagsController < ApplicationController
       elsif params[:status] == 'unwrangled'
         @tags = @tag.same_work_tags.unwrangled.by_type(params[:show].singularize.camelize).order(sort).paginate(page: params[:page], per_page: ArchiveConfig.ITEMS_PER_PAGE)
       else
-        @tags = @tag.send(params[:show]).find(:all, order: sort).paginate(page: params[:page], per_page: ArchiveConfig.ITEMS_PER_PAGE)
+        @tags = @tag.send(params[:show]).order(sort).paginate(page: params[:page], per_page: ArchiveConfig.ITEMS_PER_PAGE)
       end
     end
   end

--- a/features/support/paths.rb
+++ b/features/support/paths.rb
@@ -211,6 +211,8 @@ module NavigationHelpers
       languages_path
     when /^the wranglers page$/i
       tag_wranglers_path
+    when /^my wrangling page$/i
+      tag_wrangler_path(User.current_user)
     when /^the unassigned fandoms page $/i
       unassigned_fandoms_path
     when /^the "(.*)" tag page$/i

--- a/features/tags_and_wrangling/tag_wrangling.feature
+++ b/features/tags_and_wrangling/tag_wrangling.feature
@@ -191,6 +191,41 @@ Feature: Tag wrangling
     Then I should see "Tag was updated"
       And I should see "Stargate Atlantis"
 
+    # check sidebar links and pages for wrangling within a fandom
+    When I am on my wrangling page
+      And I follow "Stargate SG-1"
+    Then I should see "Wrangle Tags for Stargate SG-1"
+    When I follow "Characters (3)"
+    Then I should see "Wrangle Tags for Stargate SG-1"
+      And I should see "Showing All Character Tags"
+      And I should see "Daniel Jackson"
+      And I should see "Jack O'Neil"
+      And I should see "Jack O'Neill"
+    When I follow "Canonical"
+    Then I should see "Showing Canonical Character Tags"
+      And I should see "Daniel Jackson"
+      And I should see "Jack O'Neill"
+      # This would fail because "Jack O'Neil" is in "Jack O'Neill"
+      # But I should not see "Jack O'Neil"
+    When I follow "Synonymous"
+    Then I should see "Showing Synonymous Character Tags"
+      And I should see "Jack O'Neil"
+      # It will be in a td in the tbody, whereas "Jack O'Neil" is in a th
+      But I should not see "Jack O'Neill" within "tbody th"
+      And I should not see "Daniel Jackson"
+    When I follow "Relationships (0)"
+    Then I should see "Wrangle Tags for Stargate SG-1"
+      And I should see "Showing All Relationship Tags"
+    When I follow "Freeforms (0)"
+    Then I should see "Wrangle Tags for Stargate SG-1"
+      And I should see "Showing All Freeform Tags"
+    When I follow "SubTags (0)"
+    Then I should see "Wrangle Tags for Stargate SG-1"
+      And I should see "Showing All Sub Tag Tags"
+    When I follow "Mergers (0)"
+    Then I should see "Wrangle Tags for Stargate SG-1"
+      And I should see "Showing All Merger Tags"
+
   Scenario: Wrangler has option to reindex a work
 
     Given the work "Indexing Issues"


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5023

This comment: https://otwarchive.atlassian.net/browse/AO3-5023?focusedCommentId=351205&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-351205

## Purpose

When logged in as a wrangler, the Characters/Relationships/Freeforms/SubTags/Mergers links on pages like http://test.archiveofourown.org/tags/MASH%20(TV)/wrangle give a 404, which was actually disguising a 500.

## Testing

Refer to JIRA