### PR TITLE
AO3-3536 Show validation error message when parent Url unreachable

### DIFF
--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -1038,7 +1038,7 @@ class Work < ActiveRecord::Base
           if ew.save
             self.new_parent = {parent: ew, translation: translation}
           else
-            self.errors.add(:base, "Parent work info would not save.")
+            self.errors.add(:base, "Parent work " + ew.errors.full_messages[0])
           end
         end
       end

--- a/features/works/work_related.feature
+++ b/features/works/work_related.feature
@@ -284,13 +284,14 @@ Scenario: Listing external works as inspirations
   When I view my related works
   Then I should see "From N/A to English"
   # inactive URL should give a helpful message (AO3-1783)
+  # unreachable URL should give a more helpful message (A03-3536)
   When I edit the work "Followup"
     And I check "parent-options-show"
     And I fill in "URL" with "http://example.org/404"
     And I fill in "Title" with "Worldbuilding Two"
     And I fill in "Author" with "BNF"
     And I press "Preview"
-  Then I should see "Parent work info would not save."
+  Then I should see "Parent work Url could not be reached. If the URL is correct and the site is currently down, please try again later."
 
 Scenario: External work language
 


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-3536

## Purpose

Displays the first validation error message for a newly-associated external work when it cannot be saved.

## Testing

Edit an Archive work to add an associated external work with an unreachable URL.  Should see the error message "Parent work Url could not be reached. If the URL is correct and the site is currently down, please try again later." instead of "Parent work info would not save."
