### PR TITLE
AO3-5020 Remember work search sort direction field value

### DIFF
--- a/app/models/work_search.rb
+++ b/app/models/work_search.rb
@@ -220,7 +220,7 @@ class WorkSearch < Search
       options[:sort_column] = 'revised_at'
     end
 
-    options[:sort_direction] ||= sort_direction(options[:sort_column]).downcase
+    options[:sort_direction] ||= default_sort_direction(options[:sort_column]).downcase
     options[:sort_direction] = "desc" unless options[:sort_direction] == "asc"
   end
 
@@ -363,7 +363,7 @@ class WorkSearch < Search
     Hash[SORT_OPTIONS.collect {|v| [ v[1], v[0] ]}][sort_column]
   end
 
-  def sort_direction(sort_column)
+  def default_sort_direction(sort_column)
     if %w(authors_to_sort_on title_to_sort_on).include?(sort_column)
       'asc'
     else

--- a/app/views/works/_search_form.html.erb
+++ b/app/views/works/_search_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_for @search, :url => search_works_path, :html => {:method => :get, :class => 'verbose search'} do |f| %>
+<%= form_for @search, url: search_works_path, html: {method: :get, class: 'verbose search'} do |f| %>
   <fieldset>
     <legend><%= ts('Work Info') %></legend>
     <h3 class="landmark heading"><%= ts('Work Info') %></h3>
@@ -171,8 +171,8 @@
         <%= f.label :sort_direction, ts("Sort direction") %>
       </dt>
       <dd>
-        <%= select_tag "work_search[sort_direction]",
-          '<option value="asc">Ascending</option><option value="desc">Descending</option>'.html_safe,
+        <%= f.select :sort_direction,
+          options_for_select([["Ascending", "asc"], ["Descending", "desc"]], @search.sort_direction),
           {:include_blank => true } %>
       </dd>
     </dl>

--- a/features/search/works_info.feature
+++ b/features/search/works_info.feature
@@ -84,7 +84,7 @@ Feature: Search works by work info
     When I follow "Edit Your Search"
     Then the field labeled "Title" should contain "work"
       And "Title" should be selected within "Sort by"
-    When I select "Ascending" from "Sort direction" 
+    When I select "Ascending" from "Sort direction"
       And I press "Search" within "#new_work_search"
     Then I should see "You searched for: Title: work sort by: title ascending"
       And I should see "3 Found"
@@ -94,5 +94,4 @@ Feature: Search works by work info
     When I follow "Edit Your Search"
     Then the field labeled "Title" should contain "work"
       And "Title" should be selected within "Sort by"
-    When "AO3-5020" is fixed
-      # And "Ascending" should be selected within "Sort direction"
+      And "Ascending" should be selected within "Sort direction"

--- a/features/search/works_stats.feature
+++ b/features/search/works_stats.feature
@@ -67,24 +67,20 @@ Feature: Search works by stats
     When I follow "Edit Your Search"
     Then the field labeled "Kudos" should contain "<2"
       And "Kudos" should be selected within "Sort by"
-    When "AO3-5020" is fixed
-      # And "Ascending" should be selected within "Sort direction"
+      And "Ascending" should be selected within "Sort direction"
     When I check "Complete"
       And I press "Search" within "#new_work_search"
-    When "AO3-5020" is fixed
-    # Then I should see "You searched for: Complete kudos count: <2 sort by: kudos ascending"
+    Then I should see "You searched for: Complete kudos count: <2 sort by: kudos ascending"
       And I should see "4 Found"
       And I should see "second work"
       And I should see "third work"
       And I should see "fourth"
       And I should see "Fulfilled Story-thing"
-    When "AO3-5020" is fixed
-      # And the 4th result should contain "Kudos: 1"
+      And the 4th result should contain "Kudos: 1"
     When I follow "Edit Your Search"
     Then the field labeled "Kudos" should contain "<2"
       And the "Complete" checkbox should be checked
-    When "AO3-5020" is fixed
-      # And "Ascending" should be selected within "Sort direction"
+      And "Ascending" should be selected within "Sort direction"
 
   Scenario: Search by exact number of comments
     Given a set of works with comments for searching
@@ -125,8 +121,7 @@ Feature: Search works by stats
     When I follow "Edit Your Search"
     Then the field labeled "Comments" should contain "> 0"
       And "Comments" should be selected within "Sort by"
-    When "AO3-5020" is fixed
-      # And "Ascending" should be selected within "Sort direction"
+      And "Ascending" should be selected within "Sort direction"
 
   Scenario: Search by < a number of comments and sort in descending order by
   comments
@@ -147,8 +142,7 @@ Feature: Search works by stats
     When I follow "Edit Your Search"
     Then the field labeled "Comments" should contain "<20"
       And "Comments" should be selected within "Sort by"
-    When "AO3-5020" is fixed
-      # And "Descending" should be selected within "Sort direction"
+      And "Descending" should be selected within "Sort direction"
 
   Scenario: Search by > a number of comments and sort in ascending order by
   title using the header search
@@ -163,8 +157,7 @@ Feature: Search works by stats
     When I follow "Edit Your Search"
     Then the field labeled "Comments" should contain "> 2"
       And "Title" should be selected within "Sort by"
-    When "AO3-5020" is fixed
-      # And "Ascending" should be selected within "Sort direction"
+      And "Ascending" should be selected within "Sort direction"
 
   Scenario: Search by exact number of bookmarks
     Given a set of works with bookmarks for searching
@@ -203,8 +196,7 @@ Feature: Search works by stats
     When I follow "Edit Your Search"
     Then the field labeled "Bookmarks" should contain ">1"
       And "Bookmarks" should be selected within "Sort by"
-    When "AO3-5020" is fixed
-      # And "Ascending" should be selected within "Sort direction"
+      And "Ascending" should be selected within "Sort direction"
 
   Scenario: Search by < a number of bookmarks and sort in descending order by
   bookmarks
@@ -225,8 +217,7 @@ Feature: Search works by stats
     When I follow "Edit Your Search"
     Then the field labeled "Bookmarks" should contain "< 20"
       And "Bookmarks" should be selected within "Sort by"
-    When "AO3-5020" is fixed
-      # And "Descending" should be selected within "Sort direction"
+      And "Descending" should be selected within "Sort direction"
 
   Scenario: Search by > a number of bookmarks and sort in ascending order by
   title using the header search
@@ -240,5 +231,4 @@ Feature: Search works by stats
     When I follow "Edit Your Search"
     Then the field labeled "Bookmarks" should contain "> 2"
       And "Title" should be selected within "Sort by"
-    When "AO3-5020" is fixed
-      # And "Ascending" should be selected within "Sort direction"
+      And "Ascending" should be selected within "Sort direction"


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5020

## Purpose

When editing search, previously selected sort direction value should persist.

## Testing

1. Go to the work search
2. Select a sort direction from the "Sort direction" dropdown, and any other parameters as needed.
3. Execute the search.
4. Edit Your Search.
5. See if your selected sort direction has persisted on the form

## References

https://otwarchive.atlassian.net/browse/AO3-5017 introduced an automated test for this issue. It was previously commented out, but this pull request enables it.