### PR TITLE
AO3-5023 Update cache key version number for hashed tag data due to Rails 4.2 error

### DIFF
--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -238,7 +238,7 @@ class Work < ActiveRecord::Base
   end
 
   def self.tag_groups_key_id(id)
-    "/v2/work_tag_groups/#{id}"
+    "/v3/work_tag_groups/#{id}"
   end
 
   def tag_groups_key


### PR DESCRIPTION
Update cache key version number for hashed tag data due to Rails 4.2 error