### PR TITLE
AO3 5067: Don't eat paragraphs on edit for RTE fields

### DIFF
--- a/config/initializers/monkeypatches/textarea_convert_html_to_newlines.rb
+++ b/config/initializers/monkeypatches/textarea_convert_html_to_newlines.rb
@@ -39,7 +39,7 @@ module ActionView
           end
 
           content = options.delete("value") { value_before_type_cast(object) }
-          content = strip_html_breaks(content)
+          content = strip_html_breaks(content, options['name'])
 
           content_tag("textarea", content, options)
         end


### PR DESCRIPTION
AO3 5067: Don't eat paragraphs on edit for RTE fields

Simple case of an argument being left out when this part of the code was re-written.