### PR TITLE
AO3-5023: Restore missing order clause to wrangling query

### DIFF
--- a/app/controllers/tag_wranglers_controller.rb
+++ b/app/controllers/tag_wranglers_controller.rb
@@ -31,6 +31,7 @@ class TagWranglersController < ApplicationController
     @assignments = Fandom.in_use.joins(joins)
                                 .select('tags.*, users.login AS wrangler')
                                 .where(conditions)
+                                .order(:name)
                                 .paginate(page: params[:page], per_page: 50)
   end
 


### PR DESCRIPTION
AO3-5023: Restore missing order clause to wrangling query

Just got dropped in the code update