### PR TITLE
AO3-5069 Prevent new works with series from 500ing when there are validation errors

### DIFF
--- a/app/helpers/works_helper.rb
+++ b/app/helpers/works_helper.rb
@@ -73,6 +73,13 @@ module WorksHelper
     end
   end
 
+  # Passes value of fields for series back to form when an error occurs on posting
+  def work_series_value(field)
+    if params[:work] && params[:work][:series_attributes]
+      params[:work][:series_attributes][field]
+    end
+  end
+
   def language_link(work)
     if work.respond_to?(:language) && work.language
       link_to work.language.name, work.language

--- a/app/views/works/_standard_form.html.erb
+++ b/app/views/works/_standard_form.html.erb
@@ -169,14 +169,14 @@
             <%= fields_for "work[series_attributes]" do |s| %>
               <dt><%= s.label "id", ts("Choose one of your existing series:") %></dt>
               <dd>
-                <%= s.collection_select(:id, @series, :id, :title, { :prompt => true }) %>
+                <%= s.collection_select(:id, @series, :id, :title, { selected: work_series_value(:id), prompt: true }) %>
               </dd>
 
               <dt><%= s.label :title, ts("Or create and use a new one:") %></dt>
-              <dd><%= s.text_field :title %></dd>
+              <dd><%= s.text_field :title, value: work_series_value(:title) %></dd>
             <% end %>
 
-            <% unless @serial_works.blank? %>
+            <% unless @serial_works.blank? || @work.new_record? %>
               <dt><%= ts("Current Series") %></dt>
               <% for serial in @serial_works %>
                 <dd>

--- a/features/works/work_create.feature
+++ b/features/works/work_create.feature
@@ -199,8 +199,6 @@ Feature: Create Works
 
   Scenario: Creating a new work in a new series with some invalid things should return to the new work page with an error message and series information still filled in
     Given basic tags
-      And the following activated users exist
-        | login          | password    | email                   |
       And I am logged in as "thorough" with password "something"
     When I set up the draft "Bad Draft"
       And I fill in "Fandoms" with "Invalid12./"
@@ -217,9 +215,7 @@ Feature: Create Works
       And I should not see "Remove Work From Series"
 
   Scenario: Creating a new work in an existing series with some invalid things should return to the new work page with an error message and series information still filled in
-    Given basic tags
-      And the following activated users exist
-        | login          | password    | email                   |
+    Given basic tags              |
       And I am logged in as "thorough" with password "something"
       And I post the work "Work one" as part of a series "My existing series"
     When I set up the draft "Bad Draft"

--- a/features/works/work_create.feature
+++ b/features/works/work_create.feature
@@ -215,7 +215,7 @@ Feature: Create Works
       And I should not see "Remove Work From Series"
 
   Scenario: Creating a new work in an existing series with some invalid things should return to the new work page with an error message and series information still filled in
-    Given basic tags              |
+    Given basic tags
       And I am logged in as "thorough" with password "something"
       And I post the work "Work one" as part of a series "My existing series"
     When I set up the draft "Bad Draft"

--- a/features/works/work_create.feature
+++ b/features/works/work_create.feature
@@ -197,27 +197,47 @@ Feature: Create Works
       And I should see "Chapter"
       And I should see "1/?"
 
-  Scenario: Creating a new work in a series with some invalid things should not 500
+  Scenario: Creating a new work in a new series with some invalid things should return to the new work page with an error message and series information still filled in
     Given basic tags
       And the following activated users exist
         | login          | password    | email                   |
         | coauthor       | something   | coauthor@example.org |
         | badcoauthor    | something   | badcoauthor@example.org |
       And I am logged in as "thorough" with password "something"
-      And user "badcoauthor" is banned
     When I set up the draft "Bad Draft"
       And I fill in "Fandoms" with "Invalid12./"
       And I fill in "Work Title" with "/"
       And I fill in "content" with "T"
-      And I check "chapters-options-show"
-      And I fill in "work_wip_length" with "text"
-      And I fill in "work_collection_names" with "collection1, collection2"
-      And I check "series-options-show"
-      And I fill in "work_series_attributes_title" with "My new series"
+      And I check "This work has multiple chapters"
+      And I fill in "Post to Collections / Challenges" with "collection1, collection2"
+      And I check "This work is part of a series"
+      And I fill in "Or create and use a new one:" with "My new series"
       And I press "Preview"
     Then I should see "Sorry! We couldn't save this work because:"
       And I should see a collection not found message for "collection1"
-      And I should see "My new series"
+      And the field labeled "Or create and use a new one:" should contain "My new series"
+      And I should not see "Remove Work From Series"
+
+  Scenario: Creating a new work in an existing series with some invalid things should return to the new work page with an error message and series information still filled in
+    Given basic tags
+      And the following activated users exist
+        | login          | password    | email                   |
+        | coauthor       | something   | coauthor@example.org |
+        | badcoauthor    | something   | badcoauthor@example.org |
+      And I am logged in as "thorough" with password "something"
+      And I post the work "Work one" as part of a series "My existing series"
+    When I set up the draft "Bad Draft"
+      And I fill in "Fandoms" with "Invalid12./"
+      And I fill in "Work Title" with "/"
+      And I fill in "content" with "T"
+      And I check "This work has multiple chapters"
+      And I fill in "Post to Collections / Challenges" with "collection1, collection2"
+      And I check "This work is part of a series"
+      And I select "My existing series" from "Choose one of your existing series:"
+      And I press "Preview"
+    Then I should see "Sorry! We couldn't save this work because:"
+      And I should see a collection not found message for "collection1"
+      And "My existing series" should be selected within "Choose one of your existing series:"
       And I should not see "Remove Work From Series"
 
   Scenario: test for integer title and multiple fandoms

--- a/features/works/work_create.feature
+++ b/features/works/work_create.feature
@@ -201,8 +201,6 @@ Feature: Create Works
     Given basic tags
       And the following activated users exist
         | login          | password    | email                   |
-        | coauthor       | something   | coauthor@example.org |
-        | badcoauthor    | something   | badcoauthor@example.org |
       And I am logged in as "thorough" with password "something"
     When I set up the draft "Bad Draft"
       And I fill in "Fandoms" with "Invalid12./"
@@ -222,8 +220,6 @@ Feature: Create Works
     Given basic tags
       And the following activated users exist
         | login          | password    | email                   |
-        | coauthor       | something   | coauthor@example.org |
-        | badcoauthor    | something   | badcoauthor@example.org |
       And I am logged in as "thorough" with password "something"
       And I post the work "Work one" as part of a series "My existing series"
     When I set up the draft "Bad Draft"

--- a/features/works/work_create.feature
+++ b/features/works/work_create.feature
@@ -197,6 +197,29 @@ Feature: Create Works
       And I should see "Chapter"
       And I should see "1/?"
 
+  Scenario: Creating a new work in a series with some invalid things should not 500
+    Given basic tags
+      And the following activated users exist
+        | login          | password    | email                   |
+        | coauthor       | something   | coauthor@example.org |
+        | badcoauthor    | something   | badcoauthor@example.org |
+      And I am logged in as "thorough" with password "something"
+      And user "badcoauthor" is banned
+    When I set up the draft "Bad Draft"
+      And I fill in "Fandoms" with "Invalid12./"
+      And I fill in "Work Title" with "/"
+      And I fill in "content" with "T"
+      And I check "chapters-options-show"
+      And I fill in "work_wip_length" with "text"
+      And I fill in "work_collection_names" with "collection1, collection2"
+      And I check "series-options-show"
+      And I fill in "work_series_attributes_title" with "My new series"
+      And I press "Preview"
+    Then I should see "Sorry! We couldn't save this work because:"
+      And I should see a collection not found message for "collection1"
+      And I should see "My new series"
+      And I should not see "Remove Work From Series"
+
   Scenario: test for integer title and multiple fandoms
     Given I am logged in
     When I set up the draft "02138"


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5069

## Purpose

Prevent 500 error when posting/previewing a new work in a series when other validation errors exist.
## Testing

1. Log in
2. Post > New Work
3. Fill in all required information EXCEPT a warning
4. Check "This work is part of a series"
5. Choose an existing series or fill in a name for a new one
6. Preview or Post Without Preview

You should see the edit form with a flash warning, the information you filled out in steps 4 and 5 should be persisted, and there should be no link to remove the work from the series. When you get rid of the warning the work should post as normal and be in the series.

Adding/removing existing works from series should work as before.

## Credit

cresenne, she/her
