### PR TITLE
AO3-5072 Fix redirect page

### DIFF
--- a/app/views/redirect/show.html.erb
+++ b/app/views/redirect/show.html.erb
@@ -1,11 +1,11 @@
 <h2 class="heading">Lookup Original Stories</h2>
 
 <p>
-  If you are looking for a story that might have been imported into the archive from another URL, you can enter it here and 
+  If you are looking for a story that might have been imported into the archive from another URL, you can enter it here and
   we will try and look it up.
 </p>
 
-<%= form_tag redirect_path do %>
+<%= form_tag redirect_path, method: :get do %>
 <fieldset>
 	<legend>Find story by URL</legend>
   <p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -537,7 +537,6 @@ Otwarchive::Application.routes.draw do
   resource :redirect, controller: "redirect", only: [:show] do
     member do
       get :do_redirect
-      get :show
     end
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -537,6 +537,7 @@ Otwarchive::Application.routes.draw do
   resource :redirect, controller: "redirect", only: [:show] do
     member do
       get :do_redirect
+      post :show
     end
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -537,7 +537,7 @@ Otwarchive::Application.routes.draw do
   resource :redirect, controller: "redirect", only: [:show] do
     member do
       get :do_redirect
-      post :show
+      get :show
     end
   end
 

--- a/features/importing/work_import.feature
+++ b/features/importing/work_import.feature
@@ -220,3 +220,11 @@ Feature: Import Works
     When I import "http://www.intimations.org/fanfic/idol/Huddling.html"
     Then I should see "Preview"
       And I should see "English"
+
+  Scenario: Import and check that redirects work
+    When I import "http://www.scarvesandcoffee.net/viewstory.php?sid=9570"
+      And I press "Post"
+      And I go to the redirect page
+      And I fill in "original_url" with "http://www.scarvesandcoffee.net/viewstory.php?sid=9570"
+    When I press "Go"
+    Then I should see "This is what Blaine's been thinking written in poems."

--- a/features/importing/work_import.feature
+++ b/features/importing/work_import.feature
@@ -221,10 +221,10 @@ Feature: Import Works
     Then I should see "Preview"
       And I should see "English"
 
-  Scenario: Import and check that redirects work
+  Scenario: Searching for an imported work by URL will redirect you to the work
     When I import "http://www.scarvesandcoffee.net/viewstory.php?sid=9570"
       And I press "Post"
       And I go to the redirect page
-      And I fill in "original_url" with "http://www.scarvesandcoffee.net/viewstory.php?sid=9570"
+      And I fill in "Original URL of work" with "http://www.scarvesandcoffee.net/viewstory.php?sid=9570"
       And I press "Go"
     Then I should see "This is what Blaine's been thinking written in poems."

--- a/features/importing/work_import.feature
+++ b/features/importing/work_import.feature
@@ -226,5 +226,5 @@ Feature: Import Works
       And I press "Post"
       And I go to the redirect page
       And I fill in "original_url" with "http://www.scarvesandcoffee.net/viewstory.php?sid=9570"
-    When I press "Go"
+      And I press "Go"
     Then I should see "This is what Blaine's been thinking written in poems."

--- a/features/support/paths.rb
+++ b/features/support/paths.rb
@@ -26,6 +26,8 @@ module NavigationHelpers
       bookmarks_path
     when /^the admin login page$/i
       new_admin_session_path
+    when /^the redirect page$/i
+      redirect_path
 
     # the following are examples using path_to_pickle
 


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5072

## Purpose

The form in http://archiveofourown.org/redirect did not work.

## Testing

Go to http://archiveofourown.org/redirect
Paste in a URL that has been imported from another archive using the import work function
Press submit
If a redirected work is found, it should take you to that work with a message to update the original link if possible.
If one is not found, it should stay on/return to the redirect search page but present you with this message "We could not find a work imported from that url in the Archive of Our Own, sorry! Try another url?"
However, entering both imported & non imported urls currently takes me to a blank page in Safari.
# The redirect functionality does seem to be working e.g.: http://archiveofourown.org/redirect?original_url=http://triofic.com/viewstory.php?sid=1