### PR TITLE
AO3-5071 Intermittent test failures when orphaning co-authored multi-chapter work

### DIFF
--- a/features/other_a/orphan_work.feature
+++ b/features/other_a/orphan_work.feature
@@ -144,15 +144,13 @@ Feature: Orphan work
 
     Given I am logged in as "keeper"
       And I post the work "Half-Orphaned"
+      And I wait 1 second
       And I add the co-author "orphaneer" to the work "Half-Orphaned"
       And I post a chapter for the work "Half-Orphaned"
-
     # Verify that the authorship has been set up properly
     Then "orphaneer" should be a co-creator of Chapter 1 of "Half-Orphaned"
       But "orphaneer" should not be a co-creator of Chapter 2 of "Half-Orphaned"
-
     When I am logged in as "orphaneer"
       And I orphan the work "Half-Orphaned"
-
     Then "orphan_account" should be a co-creator of Chapter 1 of "Half-Orphaned"
       But "orphan_account" should not be a co-creator of Chapter 2 of "Half-Orphaned"

--- a/features/other_a/reading.feature
+++ b/features/other_a/reading.feature
@@ -155,16 +155,16 @@ Feature: Reading count
     And the reading rake task is run
   When I go to fandomer's reading page
   Then I should see "multichapter work"
-  When "intermittent failure" is fixed
-    # I should see "Viewed 3 times"
+  When "AO3-5073" is fixed
+    # And I should see "Viewed 3 times"
   When I view the work "multichapter work"
     And I follow "Next Chapter"
   When I follow "Mark for Later"
   Then I should see "This work was added to your Marked for Later list."
     And I go to fandomer's reading page
   Then I should see "multichapter work"
-  When "intermittent failure" is fixed
-    # I should see "Viewed 5 times"
+  When "AO3-5073" is fixed
+    # And I should see "Viewed 5 times"
     And I should see "(Marked for Later.)"
 
   Scenario: A user can see some of their works marked for later on the homepage


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5071

## Purpose

Adds a 1 second delay to make sure the cache on the byline expires when updating the work authors.

## Testing

No manual testing is needed, but you might want to restart the other_a test group a few times to make sure the scenario consistently passes. It passed 5 times for me before submitting this. 
