### PR TITLE
AO3-5074 Resurrect autocomplete feature tests for works & challenges

### DIFF
--- a/features/gift_exchanges/challenge_giftexchange_tagsets.feature
+++ b/features/gift_exchanges/challenge_giftexchange_tagsets.feature
@@ -30,14 +30,15 @@ Feature: Gift Exchange Challenge with Tag Sets
       And I should not see "Standard Challenge Tags"
       And I should not see "Angela Lansbury"
 
+  @javascript
   Scenario: Run a single-fandom exchange
 
   Given basic tags
+    And I am logged in as "mod1"
     And I have a canonical "Celebrities & Real People" fandom tag named "Hockey RPF"
     And I have a canonical "Celebrities & Real People" fandom tag named "Bandom"
     And a canonical character "Alexander Ovechkin" in fandom "Hockey RPF"
     And a canonical character "Gerard Way" in fandom "Bandom"
-    And I am logged in as "mod1"
     And I set up the tag set "HockeyExchangeTags" with the fandom tags "Hockey RPF"
   When I go to the "HockeyExchangeTags" tag set page
   Then I should see "About HockeyExchangeTags"
@@ -54,13 +55,15 @@ Feature: Gift Exchange Challenge with Tag Sets
   When I follow "Sign-up Form"
     And I check the 1st checkbox with the value "Hockey RPF"
     And I check the 2nd checkbox with the value "Hockey RPF"
-    And I fill in the 1st field with id matching "character_tagnames" with "Gerard Way"
-    # TODO: Once autocomplete testing is working again, check that it only shows characters from the right fandom
-    And I fill in the 2nd field with id matching "character_tagnames" with "Alexander Ovechkin"
+    And I enter "Gerard Way" in the "Characters" autocomplete field
+  Then I should see "No suggestions found" in the autocomplete
+  # "Gerard Way" from a different fandom cannot appear in autocomplete; let's force it anyway.
+  When I fill in the 1st field with id matching "character_tagnames" with "Gerard Way"
     And I submit
   Then I should see "Sorry! We couldn't save this challenge signup because"
     And I should see "These character tags in your request are not in the selected fandom(s), Hockey RPF: Gerard Way (Your moderator may be able to fix this.)"
     And I should not see "Sign-up was successfully created."
-  When I fill in the 1st field with id matching "character_tagnames" with "Alexander Ovechkin"
+  When I follow "remove Gerard Way"
+    And I choose "Alexander Ovechkin" from the "Characters" autocomplete
     And I submit
   Then I should see "Sign-up was successfully created."

--- a/features/step_definitions/user_steps.rb
+++ b/features/step_definitions/user_steps.rb
@@ -17,6 +17,7 @@ Given /the following activated users? exists?/ do |table|
   table.hashes.each do |hash|
     user = FactoryGirl.create(:user, hash)
     user.activate
+    user.pseuds.first.add_to_autocomplete
   end
 end
 
@@ -25,6 +26,7 @@ Given /the following activated tag wranglers? exists?/ do |table|
     user = FactoryGirl.create(:user, hash)
     user.activate
     user.tag_wrangler = '1'
+    user.pseuds.first.add_to_autocomplete
   end
 end
 

--- a/features/step_definitions/work_steps.rb
+++ b/features/step_definitions/work_steps.rb
@@ -464,9 +464,10 @@ end
 
 When /^I delete the work "([^"]*)"$/ do |work|
   work = Work.find_by(title: work)
-  visit edit_work_url(work)
+  visit edit_work_path(work)
   step %{I follow "Delete Work"}
-  click_button("Yes, Delete Work")
+  # If JavaScript is enabled, window.confirm will be used and this button will not appear
+  click_button("Yes, Delete Work") unless @javascript
   Work.tire.index.refresh
   Tag.write_redis_to_database
 end

--- a/features/works/work_create.feature
+++ b/features/works/work_create.feature
@@ -39,25 +39,26 @@ Feature: Create Works
     Given I am logged in as "newbie"
       And "newbie" creates the pseud "Pointless Pseud"
     When I set up the draft "All Hell Breaks Loose"
-      And I unselect "newbie" from "work_author_attributes_ids_"
-      And I select "Pointless Pseud" from "work_author_attributes_ids_"
+      And I unselect "newbie" from "Creator/Pseud(s)"
+      And I select "Pointless Pseud" from "Creator/Pseud(s)"
       And I press "Post Without Preview"
     Then I should see "Work was successfully posted."
     When I go to the works page
     Then I should see "All Hell Breaks Loose"
       And I should see "by Pointless Pseud"
 
+  @javascript
   Scenario: Creating a new work with everything filled in, and we do mean everything
     Given basic tags
       And the following activated users exist
-        | login          | password    | email                 |
-        | coauthor       | something   | coauthor@example.org  |
-        | cosomeone      | something   | cosomeone@example.org |
-        | giftee         | something   | giftee@example.org    |
-        | recipient      | something   | recipient@example.org |
+        | login          | email                 |
+        | coauthor       | coauthor@example.org  |
+        | cosomeone      | cosomeone@example.org |
+        | giftee         | giftee@example.org    |
+        | recipient      | recipient@example.org |
       And I have a collection "Collection 1" with name "collection1"
       And I have a collection "Collection 2" with name "collection2"
-      And I am logged in as "thorough" with password "something"
+      And I am logged in as "thorough"
       And "thorough" creates the pseud "Pseud2"
       And "thorough" creates the pseud "Pseud3"
       And all emails have been delivered
@@ -68,18 +69,18 @@ Feature: Create Works
       And I fill in "Fandoms" with "Supernatural"
       And I fill in "Work Title" with "All Something Breaks Loose"
       And I fill in "content" with "Bad things happen, etc."
-      And I check "front-notes-options-show"
-      And I fill in "work_notes" with "This is my beginning note"
-      And I fill in "work_endnotes" with "This is my endingnote"
+      And I check "at the beginning"
+      And I fill in "Notes" with "This is my beginning note"
+      And I fill in "End Notes" with "This is my endingnote"
       And I fill in "Summary" with "Have a short summary"
       And I fill in "Characters" with "Sam Winchester, Dean Winchester,"
       And I fill in "Relationships" with "Harry/Ginny"
       And I fill in "Additional Tags" with "An extra tag"
       And I fill in "Gift this work to" with "Someone else, recipient"
-      And I check "series-options-show"
-      And I fill in "work_series_attributes_title" with "My new series"
-      And I select "Pseud2" from "work_author_attributes_ids_"
-      And I select "Pseud3" from "work_author_attributes_ids_"
+      And I check "This work is part of a series"
+      And I fill in "Or create and use a new one:" with "My new series"
+      And I select "Pseud2" from "Creator/Pseud(s)"
+      And I select "Pseud3" from "Creator/Pseud(s)"
       And I fill in "pseud_byline" with "coauthor"
       And I fill in "Post to Collections / Challenges" with "collection1, collection2"
       And I press "Preview"
@@ -131,16 +132,14 @@ Feature: Create Works
     Then I should see "Bad things happen, etc."
       And I should see "Let's write another story"
     When I follow "Edit"
-      And I check "co-authors-options-show"
+      And I check "Add co-creators?"
       And I fill in "pseud_byline" with "Does_not_exist"
       And I press "Preview"
     Then I should see "Please verify the names of your co-authors"
       And I should see "These pseuds are invalid: Does_not_exist"
     When all emails have been delivered
-      And I fill in "pseud_byline" with "cosomeone"
-    When "autocomplete tests with JavaScript" is fixed
-#      Then I should see "cosomeone" in the autocomplete
-    When I press "Preview"
+      And I choose "cosomeone" from the "pseud_byline_autocomplete" autocomplete
+      And I press "Preview"
       And I press "Update"
     Then I should see "Work was successfully updated"
       And I should see "cosomeone" within ".byline"
@@ -271,7 +270,7 @@ Feature: Create Works
     When I am logged in as "testuser" with password "testuser"
       And I go to the new work page
       And I fill in the basic work information for "All Hell Breaks Loose"
-      And I check "co-authors-options-show"
+      And I check "Add co-creators?"
       And I fill in "pseud_byline" with "Me"
       And I press "Post Without Preview"
    Then I should see "There's more than one user with the pseud Me. Please choose the one you want:"

--- a/features/works/work_delete.feature
+++ b/features/works/work_delete.feature
@@ -18,7 +18,7 @@ Feature: Delete Works
       And I am logged in as "newbie"
       And "newbie" creates the default pseud "Pointless Pseud"
     When I set up the draft "All Hell Breaks Loose" with fandom "Supernatural"
-      And I select "Pointless Pseud" from "work_author_attributes_ids_"
+      And I select "Pointless Pseud" from "Creator/Pseud(s)"
       And I press "Preview"
       And I press "Post"
     Then I should see "Work was successfully posted."
@@ -33,14 +33,15 @@ Feature: Delete Works
     When I go to newbie's user page
     Then I should not see "All Hell Breaks Loose"
 
+  @javascript
   Scenario: Deleting a work with everything filled in, and we do mean everything
     Given basic tags
       And the following activated users exist
-        | login          | password    | email                 |
-        | coauthor       | something   | coauthor@example.org  |
-        | cosomeone      | something   | cosomeone@example.org |
-        | giftee         | something   | giftee@example.org    |
-        | recipient      | something   | recipient@example.org |
+        | login          | email                 |
+        | coauthor       | coauthor@example.org  |
+        | cosomeone      | cosomeone@example.org |
+        | giftee         | giftee@example.org    |
+        | recipient      | recipient@example.org |
       And I have a collection "Collection 1" with name "collection1"
       And I have a collection "Collection 2" with name "collection2"
       And I am logged in as "thorough"
@@ -54,19 +55,19 @@ Feature: Delete Works
       And I fill in "Fandoms" with "Supernatural"
       And I fill in "Work Title" with "All Something Breaks Loose"
       And I fill in "content" with "Bad things happen, etc."
-      And I check "front-notes-options-show"
-      And I fill in "work_notes" with "This is my beginning note"
-      And I fill in "work_endnotes" with "This is my endingnote"
+      And I check "at the beginning"
+      And I fill in "Notes" with "This is my beginning note"
+      And I fill in "End Notes" with "This is my endingnote"
       And I fill in "Summary" with "Have a short summary"
       And I fill in "Characters" with "Sam Winchester, Dean Winchester,"
       And I fill in "Relationships" with "Harry/Ginny"
       And I fill in "Gift this work to" with "Someone else, recipient"
-      And I check "series-options-show"
-      And I fill in "work_series_attributes_title" with "My new series"
-      And I select "Pseud2" from "work_author_attributes_ids_"
-      And I select "Pseud3" from "work_author_attributes_ids_"
+      And I check "This work is part of a series"
+      And I fill in "Or create and use a new one:" with "My new series"
+      And I select "Pseud2" from "Creator/Pseud(s)"
+      And I select "Pseud3" from "Creator/Pseud(s)"
       And I fill in "pseud_byline" with "coauthor"
-      And I fill in "work_collection_names" with "collection1, collection2"
+      And I fill in "Post to Collections / Challenges" with "collection1, collection2"
       And I press "Preview"
     Then I should see "Preview"
     When I press "Post"
@@ -116,16 +117,14 @@ Feature: Delete Works
     Then I should see "Bad things happen, etc."
       And I should see "Let's write another story"
     When I follow "Edit"
-      And I check "co-authors-options-show"
+      And I check "Add co-creators?"
       And I fill in "pseud_byline" with "Does_not_exist"
       And I press "Preview"
     Then I should see "Please verify the names of your co-authors"
       And I should see "These pseuds are invalid: Does_not_exist"
     When all emails have been delivered
-      And I fill in "pseud_byline" with "cosomeone"
-    When "autocomplete tests with JavaScript" is fixed
-#      Then I should see "cosomeone" in the autocomplete
-    When I press "Preview"
+      And I choose "cosomeone" from the "pseud_byline_autocomplete" autocomplete
+      And I press "Preview"
       And I press "Update"
     Then I should see "Work was successfully updated"
       And I should see "cosomeone" within ".byline"
@@ -140,7 +139,7 @@ Feature: Delete Works
       And I press "Update"
     Then I should see "Work was successfully updated"
       And I should see "For giftee"
-    When I am logged in as "someone_else" with password "something"
+    When I am logged in as "someone_else"
       And I view the work "All Something Breaks Loose"
       And I press "Kudos"
     Then I should see "someone_else left kudos on this work!"
@@ -150,7 +149,7 @@ Feature: Delete Works
     Then I should see "Bookmark was successfully created"
     When I go to the bookmarks page
     Then I should see "All Something Breaks Loose"
-    When I am logged in as "thorough" with password "something"
+    When I am logged in as "thorough"
       And I go to giftee's user page
     Then I should see "Gifts (1)"
     When I delete the work "All Something Breaks Loose"


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5074

## Purpose

Enable pending autocomplete feature tests for works & challenges.

Log in before setting up tags in the single-fandom exchange scenario. If we're logged in, touching a tag will set its last wrangler, which runs the tag's after_update hook, which updates Redis for the tag's
fandom-specific autocomplete searches.

Add default pseuds to autocomplete in some user creation steps, similar to features/support/user.rb.

## Testing

None, automated.