### PR TITLE
AO3-5070 Intermittent test failure when changing username 

### DIFF
--- a/features/users/user_rename.feature
+++ b/features/users/user_rename.feature
@@ -115,6 +115,7 @@ Feature:
     Given I have no users
       And I am logged in as "oldusername" with password "password"
       And I post a work "Epic story"
+      And I wait 1 second
     When I visit the change username page for oldusername
       And I fill in "New user name" with "newusername"
       And I fill in "Password" with "password"


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5070

## Purpose

Adds a 1-second delay to resolve an intermittent failure in the users/user_rename.feature scenario for changing your username updating search results. 

## Testing

No manual testing required, but you should restart the users group several times on Travis to make sure this scenario consistently passes. It's passed about 9 times for me.

Note: https://otwarchive.atlassian.net/browse/AO3-5075 affects the same group of tests (but a different feature -- this issue is for user_rename, while AO3-5075 is for user_delete), so if you _do_ see failures in the users test group, you'll need to check closely to see what's failing.
