### PR TITLE
AO3-5075 Intermittent test failure on deleting a user who co-authored a work

### DIFF
--- a/features/users/user_delete.feature
+++ b/features/users/user_delete.feature
@@ -83,6 +83,7 @@ Scenario: Delete a user who has coauthored a work
     | otheruser | password |
     And I am logged in as "testuser"
     And I coauthored the work "Shared" as "testuser" with "otheruser"
+    And I wait 1 second
   When I try to delete my account
   Then I should see "What do you want to do with your works?"
   When I choose "Remove me completely as co-author"
@@ -90,7 +91,6 @@ Scenario: Delete a user who has coauthored a work
   Then I should see "You have successfully deleted your account"
     And a user account should not exist for "testuser"
     And I should be logged out
-  # TODO - make this confirmation step better
   When I go to the works page
   Then I should see "otheruser"
     And I should not see "testuser"


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5075

## Purpose

Adds a 1-second delay between posting a work and deleting an account to prevent an intermittent failure in users/user_delete.feature

## Testing

No manual testing required, but you should restart the users group several times on Travis to make sure this scenario consistently passes. It's passed 4 times for me.

Note: https://otwarchive.atlassian.net/browse/AO3-5071 affects the same group of tests (but a different feature -- this issue is for user_delete, while AO3-5071 is for user_rename), so if you do see failures in the users test group, you'll need to check closely to see what's failing.