### PR TITLE
AO3-5078 AO3-5080 Fix two intermittent failures in orphan_series test

### DIFF
--- a/features/step_definitions/orphan_steps.rb
+++ b/features/step_definitions/orphan_steps.rb
@@ -11,11 +11,13 @@ When /^I choose to (?:keep|leave) my pseud on$/ do
 end
 
 When /^I begin orphaning the work "([^"]*)"$/ do |name|
+  step %{I wait 1 second}
   step %{I edit the work "#{name}"}
   step %{I follow "Orphan Work"}
 end
 
 When /^I begin orphaning the series "([^"]*)"$/ do |name|
+  step %{I wait 1 second}
   step %{I view the series "#{name}"}
   step %{I follow "Orphan Series"}
 end


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5078 & https://otwarchive.atlassian.net/browse/AO3-5080

## Purpose

Adds a 1-second delay to the orphaning step definitions to deal with two intermittent test failures in other_a/orphan_series.feature:

AO3-5078:

```
expected to find text "orphaneer (orphan_account)" in "Creator: orphaneer Series Begun: 2017-07-23 Series Updated: 2017-07-23 Stats: Words: 12 Works: 2 Complete: No" (RSpec::Expectations::ExpectationNotMetError)
./features/step_definitions/web_steps.rb:141:in `block (2 levels) in <top (required)>'
./features/step_definitions/web_steps.rb:14:in `block in with_scope'
./features/step_definitions/web_steps.rb:14:in `with_scope'
./features/step_definitions/web_steps.rb:140:in `/^(?:|I )should see "([^"]*)"(?: within "([^"]*)")?$/'
features/other_a/orphan_series.feature:29:in `Then I should see "orphaneer (orphan_account)" within ".series.meta"'
```

AO3-5080:

```
expected #has_no_content?("orphaneer") to return true, got false (RSpec::Expectations::ExpectationNotMetError)
  ./features/step_definitions/web_steps.rb:194:in `block (2 levels) in <top (required)>'
  ./features/step_definitions/web_steps.rb:14:in `with_scope'
  ./features/step_definitions/web_steps.rb:192:in `/^(?:|I )should not see "([^"]*)"(?: within "([^"]*)")?$/'
  features/other_a/orphan_series.feature:51:in `And I should not see "orphaneer"'
```

## Testing

No manual testing required. These fail a lot more frequently on Codeship than Travis, so restarting the group on Travis to make sure the other_a test group probably won't be too informative. (There are other failures in the other_a group, too, so if you do take that approach, be sure to check what's failing. There _is_ a possibility the wait needs to be in the scenario and not the step definition here.)
