### PR TITLE
AO3-5066 Fix error where users can preview any chapter

### DIFF
--- a/app/controllers/chapters_controller.rb
+++ b/app/controllers/chapters_controller.rb
@@ -3,7 +3,7 @@ class ChaptersController < ApplicationController
   before_filter :users_only, except: [ :index, :show, :destroy, :confirm_delete ]
   before_filter :load_work, except: [:index, :auto_complete_for_pseud_name, :update_positions]
   # only authors of a work should be able to edit its chapters
-  before_filter :check_ownership, only: [ :new, :create, :edit, :update, :manage, :destroy, :confirm_delete ]
+  before_filter :check_ownership, only: [ :new, :create, :edit, :update, :manage, :preview, :destroy, :confirm_delete ]
   before_filter :set_instance_variables, only: [ :new, :create, :edit, :update, :preview, :post, :confirm_delete ]
   before_filter :check_visibility, only: [ :show]
   before_filter :check_user_status, only: [:new, :create, :edit, :update]

--- a/spec/controllers/chapters_controller_spec.rb
+++ b/spec/controllers/chapters_controller_spec.rb
@@ -815,7 +815,6 @@ describe ChaptersController do
       end
 
       it "errors and redirects to work" do
-        pending "non-work owner should not be able to access preview"
         get :preview, work_id: work.id, id: work.chapters.first.id
         it_redirects_to_with_error(work_path(work), "Sorry, you don't have permission to access the page you were trying to reach.")
       end


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5066

## Purpose

Fixes issue where users could preview chapters of works they did not own.

## Testing

1. Log in
2. Post > New Work
3. Fill in required information
4. Press Post Without Preview
5. Follow Add Chapter
6. Fill in required information
7. Press Preview to create a draft
8. Copy the chapter's preview URL from your browser bar -- it will look like http://test.archiveofourown.org/works/###/chapters/###/preview
9. Log out
10. Log in as some other user
11. Paste the chapter's preview URL into your browser and press enter to go there

You should be redirected to the work the chapter belongs to with a message saying, "Sorry, you don't have permission to access the page you were trying to reach."

## Credit

cresenne, she/her
