### PR TITLE
AO3-5081 Fix intermittent failure in works/work_create

### DIFF
--- a/features/other_a/orphan_work.feature
+++ b/features/other_a/orphan_work.feature
@@ -144,7 +144,6 @@ Feature: Orphan work
 
     Given I am logged in as "keeper"
       And I post the work "Half-Orphaned"
-      And I wait 1 second
       And I add the co-author "orphaneer" to the work "Half-Orphaned"
       And I post a chapter for the work "Half-Orphaned"
     # Verify that the authorship has been set up properly

--- a/features/step_definitions/work_steps.rb
+++ b/features/step_definitions/work_steps.rb
@@ -494,7 +494,9 @@ When /^the statistics_tasks rake task is run$/ do
   StatCounter.hits_to_database
   StatCounter.stats_to_database
 end
+
 When /^I add the co-author "([^"]*)" to the work "([^"]*)"$/ do |coauthor, work|
+  step %{I wait 1 second}
   step %{I edit the work "#{work}"}
   step %{I add the co-author "#{coauthor}"}
   step %{I post the work without preview}


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5081

## Purpose

Adds a 1-second delay to the step for editing an existing work to add a co-author. Without this delay, the cache didn't have time to update, so we'd get intermittent test failures in a works/work_create (and probably a few other places I haven't noticed yet). 

The step is only used 5 times in our features, so this won't amount to a significant delay.

## Testing

No manual testing needed, but we should keep an eye on Codeship the next several times it runs to see if this helped.