### PR TITLE
AO3 5008: Tweak subscription validation

### DIFF
--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -1,7 +1,7 @@
 class Subscription < ActiveRecord::Base
   include ActiveModel::ForbiddenAttributesProtection
 
-  VALID_SUBSCRIBABLES = %w(Work User Series)
+  VALID_SUBSCRIBABLES = %w(Work User Series).freeze
 
   belongs_to :user
   belongs_to :subscribable, polymorphic: true
@@ -12,7 +12,7 @@ class Subscription < ActiveRecord::Base
   # Without the condition, you get a 500 error instead of a validation error
   # if there's an invalid subscribable type
   validates :subscribable, presence: true,
-    if: Proc.new { |s| VALID_SUBSCRIBABLES.include?(s.subscribable_type) }
+                           if: proc { |s| VALID_SUBSCRIBABLES.include?(s.subscribable_type) }
   
   # Get the subscriptions associated with this work
   # currently: users subscribed to work, users subscribed to creator of work

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -1,10 +1,18 @@
 class Subscription < ActiveRecord::Base
   include ActiveModel::ForbiddenAttributesProtection
 
+  VALID_SUBSCRIBABLES = %w(Work User Series)
+
   belongs_to :user
   belongs_to :subscribable, polymorphic: true
-  
-  validates_presence_of :user, :subscribable
+
+  validates_presence_of :user
+
+  validates :subscribable_type, inclusion: { in: VALID_SUBSCRIBABLES }
+  # Without the condition, you get a 500 error instead of a validation error
+  # if there's an invalid subscribable type
+  validates :subscribable, presence: true,
+    if: Proc.new { |s| VALID_SUBSCRIBABLES.include?(s.subscribable_type) }
   
   # Get the subscriptions associated with this work
   # currently: users subscribed to work, users subscribed to creator of work

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -67,14 +67,25 @@ describe Subscription do
     end
   end
 
-  context "when subscribable_type is not a valid type" do
+  context "when subscribable is not a valid object to subscribe to" do
+    before do
+      subscription.subscribable_id = 1
+      subscription.subscribable_type = "Pseud"
+    end
+
+    it "should not save" do
+      expect { subscription.save }.to be_falsey
+    end
+  end
+
+  context "when subscribable_type is not a real model name" do
     before do
       subscription.subscribable_id = 1
       subscription.subscribable_type = "Серия"
     end
 
-    it "should raise error" do
-      expect { subscription.save }.to raise_error NameError
+    it "should not save" do
+      expect { subscription.save }.to be_falsey
     end
   end
 end

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -62,7 +62,7 @@ describe Subscription do
       work.destroy
     end
 
-    it "should not save" do
+    it "should be invalid" do
       expect(subscription.valid?).to be_falsey
     end
   end
@@ -73,7 +73,7 @@ describe Subscription do
       subscription.subscribable_type = "Pseud"
     end
 
-    it "should not save" do
+    it "should be invalid" do
       expect(subscription.valid?).to be_falsey
     end
   end
@@ -84,7 +84,7 @@ describe Subscription do
       subscription.subscribable_type = "Серия"
     end
 
-    it "should not save" do
+    it "should be invalid" do
       expect(subscription.valid?).to be_falsey
     end
   end

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -63,7 +63,7 @@ describe Subscription do
     end
 
     it "should not save" do
-      expect(subscription.save).to be_falsey
+      expect(subscription.valid?).to be_falsey
     end
   end
 
@@ -74,7 +74,7 @@ describe Subscription do
     end
 
     it "should not save" do
-      expect { subscription.save }.to be_falsey
+      expect(subscription.valid?).to be_falsey
     end
   end
 
@@ -85,7 +85,7 @@ describe Subscription do
     end
 
     it "should not save" do
-      expect { subscription.save }.to be_falsey
+      expect(subscription.valid?).to be_falsey
     end
   end
 end


### PR DESCRIPTION
AO3 5008: Tweak subscription validation to prevent subscriptions to nonsubscribable models.

First, explicitly validate the types of objects you're allowed to subscribe to. Then add a condition to the subscribable validation so that you don't get a 500 error if subscribable_type is not a real model name, allowing failures to have a consistent format.