### PR TITLE
AO3-4995 Redirect to path instead of record when creating bookmark

### DIFF
--- a/app/controllers/bookmarks_controller.rb
+++ b/app/controllers/bookmarks_controller.rb
@@ -135,7 +135,7 @@ class BookmarksController < ApplicationController
     if @bookmark.errors.empty?
       if @bookmarkable.save && @bookmark.save
         flash[:notice] = ts('Bookmark was successfully created. It should appear in bookmark listings within the next few minutes.')
-        redirect_to(@bookmark) and return
+        redirect_to bookmark_path(@bookmark) and return
       end
     end
     @bookmarkable.errors.full_messages.each { |msg| @bookmark.errors.add(:base, msg) }


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-4995

## Purpose

When you're on https and you make a new bookmark, you get bumped back to http. This is an attempt to change that and perhaps diagnose the cause of our "got logged out when making a bookmark" woes.

## Testing

Make a bookmark while accessing a work over https and see if you're still on https once you've been redirected to your new bookmark.

