### PR TITLE
AO3-5085 Remove unused method locales_menu in application_helper

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -220,17 +220,6 @@ module ApplicationHelper
     }.join.html_safe
   end
 
-  # For setting the current locale
-  def locales_menu    
-    result = "<form action=\"" + url_for(action: 'set', controller: 'locales') + "\">\n" 
-    result << "<div><select id=\"accessible_menu\" name=\"locale_id\" >\n"
-    result << options_from_collection_for_select(@loaded_locales, :iso, :name, @current_locale.iso)
-    result << "</select></div>"
-    result << "<noscript><p><input type=\"submit\" name=\"commit\" value=\"Go\" /></p></noscript>"
-    result << "</form>"
-    return result
-  end
-
   # Generates sorting links for index pages, with column names and directions
   def sort_link(title, column=nil, options = {})
     condition = options[:unless] if options.has_key?(:unless)


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5085

## Purpose

Remove unused method locales_menu in application_helper, which should have been removed along with locales_controller#set, as part of [AO3-4942](https://otwarchive.atlassian.net/browse/AO3-4942).

## Testing

Check that we can see the locale list and create/edit locales normally.