### PR TITLE
AO3-5016 Forbid inviting items to anon collections

### DIFF
--- a/app/controllers/collection_items_controller.rb
+++ b/app/controllers/collection_items_controller.rb
@@ -101,6 +101,8 @@ class CollectionItemsController < ApplicationController
         end
       elsif collection.closed? && !collection.user_is_maintainer?(User.current_user)
         errors << ts("%{collection_title} is closed to new submissions.", collection_title: collection.title)
+      elsif (collection.anonymous? || collection.unrevealed?) && !current_user.is_author_of?(@item)
+        errors << ts("%{collection_title}, because you don't own this item and the collection is anonymous or unrevealed.", collection_title: collection.title)
       elsif !current_user.is_author_of?(@item) && !collection.user_is_maintainer?(current_user)
         errors << ts("%{collection_title}, either you don't own this item or are not a moderator of the collection.", collection_title: collection.title)
       # add the work to a collection, and try to save it

--- a/features/collections/collection_invite.feature
+++ b/features/collections/collection_invite.feature
@@ -5,83 +5,84 @@ Feature: Collection
   As a collection maintainer
   I want to add and invite works to my collection
 
-Scenario: Invite a work to a collection where a user auto-approves inclusion
-Given I am logged in as "Scott" with password "password"
-  And I go to Scott's preferences page
-  And I check "preference_automatically_approve_collections"
-  And I press "Update"
-  And I post the work "A Death in Hong Kong" with fandom "Murder She Wrote"
-When I have the collection "scotts collection" with name "scotts_collection"
-  And I am logged in as "moderator" with password "password"
-  And I view the work "A Death in Hong Kong"
-  And I follow "Add To Collections"
-  And I fill in "collection_names" with "scotts_collection"
-  And I press "Add"
-  And I should see "Added to collection(s): scotts collection."
-  And 1 email should be delivered to "Scott"
-  And the email should contain "you have previously elected to allow"
-When I am logged in as "moderator" with password "password"
-  And I go to "scotts collection" collection's page
-  And I follow "Manage Items"
-  And I follow "Approved"
-Then I should see "A Death in Hong Kong"
+  Scenario: Invite a work to a collection where a user auto-approves inclusion
+  Given I am logged in as "Scott" with password "password"
+    And I set my preferences to automatically agree to my work being collected
+    And I post the work "A Death in Hong Kong"
+  When I have the collection "scotts collection" with name "scotts_collection"
+    And I am logged in as "moderator"
+    And I add the work "A Death in Hong Kong" to the collection "scotts collection"
+  Then I should see "Added to collection(s): scotts collection."
+    And 1 email should be delivered to "Scott"
+    And the email should contain "you have previously elected to allow"
+  When I am logged in as "moderator"
+    And I go to "scotts collection" collection's page
+    And I follow "Manage Items"
+    And I follow "Approved"
+  Then I should see "A Death in Hong Kong"
 
 
-Scenario: Invite a work to a collection where a users approves inclusion
-Given I am logged in as "Scott" with password "password"
-  And I go to Scott's preferences page
-  And I uncheck "preference_automatically_approve_collections"
-  And I press "Update"
-  And I post the work "Murder in Milan" with fandom "Murder She Wrote"
-When I have the collection "scotts collection" with name "scotts_collection"
-  And I am logged in as "moderator" with password "password"
-  And I view the work "Murder in Milan"
-  And I follow "Add To Collections"
-  And I fill in "collection_names" with "scotts_collection"
-  And I press "Add"
-  And I should see "This work has been invited to your collection (scotts collection)."
-  And 1 email should be delivered to "Scott"
-  And the email should contain "If in future you would prefer to automatically approve requests to add your"
-When I go to "scotts collection" collection's page
-  And I should see "Works (0)"
-  And I follow "Manage Items"
-  And I follow "Invited"
-  And I should see "Murder in Milan"
-  And I should see "Works listed here have been invited to this collection. Once a work's creator has approved inclusion in this collection, the work will be moved to 'Approved'."
-When I am logged in as "Scott" with password "password"
-  And I accept the invitation for my work in the collection "scotts collection"
-  And I press "Submit"
-  And I should not see "Murder in Milan"
-  And I follow "Approved"
-  And I should see "Murder in Milan"
-When I am logged in as "moderator" with password "password"
-  And I am on "scotts collection" collection's page
-  And I follow "Manage Items"
-  And I should not see "Murder in Milan"
-  And I follow "Approved"
-Then I should see "Murder in Milan"
+  Scenario: Invite a work to a collection where a user approves inclusion
+  Given I am logged in as "Scott" with password "password"
+    And I set my preferences to require my approval for my work to be collected
+    And I post the work "Murder in Milan" with fandom "Murder She Wrote"
+  When I have the collection "scotts collection" with name "scotts_collection"
+    And I am logged in as "moderator" with password "password"
+    And I add the work "Murder in Milan" to the collection "scotts collection"
+  Then I should see "This work has been invited to your collection (scotts collection)."
+    And 1 email should be delivered to "Scott"
+    And the email should contain "If in future you would prefer to automatically approve requests to add your"
+  When I go to "scotts collection" collection's page
+  Then I should see "Works (0)"
+  When I follow "Manage Items"
+    And I follow "Invited"
+  Then I should see "Murder in Milan"
+    And I should see "Works listed here have been invited to this collection. Once a work's creator has approved inclusion in this collection, the work will be moved to 'Approved'."
+  When I am logged in as "Scott" with password "password"
+    And I accept the invitation for my work in the collection "scotts collection"
+    And I press "Submit"
+  Then I should not see "Murder in Milan"
+  When I follow "Approved"
+  Then I should see "Murder in Milan"
+  When I am logged in as "moderator"
+    And I am on "scotts collection" collection's page
+    And I follow "Manage Items"
+  Then I should not see "Murder in Milan"
+  When I follow "Approved"
+  Then I should see "Murder in Milan"
 
-Scenario: Inviting a work to an anonymous collection should not make it anonymous
-Given the work "Don't Hide Me"
-  And I have the anonymous collection "anonstuff"
-  And I am logged in as the owner of "anonstuff"
-When I view the work "Don't Hide Me"
-  And I follow "Add To Collections"
-  And I fill in "collection_names" with "anonstuff"
-  And I press "Add"
-Then I should see "This work has been invited to your collection"
-When I view the work "Don't Hide Me"
-Then I should not see "Anonymous"
+  Scenario: Invite another's work to a anonymous collection should not be allowed.
+  Given I am logged in
+    And I set my preferences to automatically agree to my work being collected
+    And I post the work "A Death in Hong Kong"
+  When I have the hidden collection "anon collection" with name "anon_collection"
+    And I am logged in as "moderator"
+    And I add the work "A Death in Hong Kong" to the collection "anon collection"
+  Then I should see "because you don't own this item and the collection is anonymous or unrevealed"
+    And 0 emails should be delivered
+  When I view the approved collection items page for "anon collection"
+  Then I should not see "A Death in Hong Kong"
 
-Scenario: Inviting a work to a hidden collection should not make it unrevealed
-Given the work "Don't Hide Me"
-  And I have the hidden collection "hiddenstuff"
-  And I am logged in as the owner of "hiddenstuff"
-When I view the work "Don't Hide Me"
-  And I follow "Add To Collections"
-  And I fill in "collection_names" with "hiddenstuff"
-  And I press "Add"
-Then I should see "This work has been invited to your collection"
-When I am logged out
-  And I view the work "Don't Hide Me"
-Then I should not see "This work is part of an ongoing challenge and will be revealed soon!"
+  Scenario: Invite another's work to a hidden collection should not be allowed.
+  Given I am logged in
+    And I set my preferences to automatically agree to my work being collected
+    And I post the work "A Death in Hong Kong"
+  When I have the hidden collection "hidden collection" with name "hidden_collection"
+    And I am logged in as "moderator"
+    And I add the work "A Death in Hong Kong" to the collection "hidden collection"
+  Then I should see "because you don't own this item and the collection is anonymous or unrevealed"
+    And 0 emails should be delivered
+  When I view the approved collection items page for "hidden collection"
+  Then I should not see "A Death in Hong Kong"
+
+  Scenario: Invite another's work to a hidden anonymous collection should not be allowed.
+  Given I am logged in
+    And I set my preferences to automatically agree to my work being collected
+    And I post the work "A Death in Hong Kong"
+  When I have the hidden anonymous collection "anon hidden collection" with name "anon_hidden_collection"
+    And I am logged in as "moderator"
+    And I add the work "A Death in Hong Kong" to the collection "anon hidden collection"
+  Then I should see "because you don't own this item and the collection is anonymous or unrevealed"
+    And 0 emails should be delivered
+  When I view the approved collection items page for "anon hidden collection"
+  Then I should not see "A Death in Hong Kong"

--- a/features/step_definitions/preferences_steps.rb
+++ b/features/step_definitions/preferences_steps.rb
@@ -108,4 +108,14 @@ When /^I set my preferences to hide freeform by browser$/ do
   step %{I should see "Your preferences were successfully updated"}
 end
 
+When /^I set my preferences to automatically agree to my work being collected$/ do
+  user = User.current_user
+  user.preference.automatically_approve_collections = true
+  user.preference.save
+end
 
+When /^I set my preferences to require my approval for my work to be collected$/ do
+  user = User.current_user
+  user.preference.automatically_approve_collections = false
+  user.preference.save
+end


### PR DESCRIPTION
Forbid adding works belonging to others to unrevealed/hidden or
anonymous collections directly. Remove tests that assumed collection
moderators could do invite or add works to such collections.

Due to the removal of Carriage Returns at the end of lines please review by adding ?w=1 to the URL as per https://github.com/blog/967-github-secrets 

# Pull Request Checklist

* [X] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [X] Have you read through the [contributor guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [X] Have you added tests for any changed functionality?
* [X] Have you added the JIRA issue number as the *first* thing in your pull request title (eg: `AO3-1234 Fix thing`)
* [X] Have you updated the JIRA issue with the information below?

## Issue

https://otwarchive.atlassian.net/browse/AO3-5016

## Purpose

What does this PR do?
This PR prevents moderators of collections from directly inviting or adding items to collections that are hidden or unrevealed. Item authors will still be able to add items to such collections. 

## Testing

How can the Archive's QA team verify that this is working as you intended?

As User A, make an anonymous and/or unrevealed collection: 
1. Log in as User A
2. Browse > Collections > New Collection
3. Fill out required information
4. Check either "This collection is unrevealed" or "This collection is anonymous" (or both!)
5. Press "Submit"
6. Log out
As User B, agree to your work automatically being included in collections:
7. Log in as User B
8. Hi, User B! > My Preferences
9. Check "Automatically agree to your work being collected by others in the Archive."
10. Press "Update"
As User B, post a work (if you don't already have one):
11. Post > New Work
12. Fill in required information
13. Press "Post Without Preview"
As User A, invite User B's work to your anonymous or unrevealed collection
14. Go to User B's work
15. Press "Add To Collections" at the bottom of the work
16. Enter the name of your anonymous or unrevealed collection
17. Press "Add"

Verify:
That the attempt to add to the collection is rejected with a flash message containing "because you don't own this item and the collection is anonymous or unrevealed."

## References

Are there any other relevant issues / PRs / mailing lists discussions related to this?
https://otwarchive.atlassian.net/browse/AO3-5028 can be viewed as relevant.

## Credit

*What name do you want us to use to credit your work in the [Archive of Our Own's Release Notes](http://archiveofourown.org/admin_posts?tag=1)?*
dense lancer
*What pronouns do you prefer (she/her, he/him, zie/hir etc)?*
he/him
