### PR TITLE
AO3-5091: Fix 500 error on claims page caused by deleted users

### DIFF
--- a/app/models/challenge_claim.rb
+++ b/app/models/challenge_claim.rb
@@ -133,7 +133,7 @@ class ChallengeClaim < ActiveRecord::Base
   end
 
   def claiming_pseud
-    User.find_by(id: claiming_user_id).default_pseud
+    claiming_user.try(:default_pseud)
   end
 
   def requesting_pseud
@@ -141,7 +141,7 @@ class ChallengeClaim < ActiveRecord::Base
   end
 
   def claim_byline
-    User.find_by(id: claiming_user_id).default_pseud.byline
+    claiming_pseud.try(:byline) || "deleted user"
   end
 
   def request_byline

--- a/app/views/challenge_claims/_unposted_claim_blurb.html.erb
+++ b/app/views/challenge_claims/_unposted_claim_blurb.html.erb
@@ -21,7 +21,7 @@
       </span>
       <%= ts("claimed by") %>
       <span class="byline">
-        <%= claim.claiming_user.default_pseud.byline %>
+        <%= claim.claim_byline %>
       </span>
     </h5>
 

--- a/spec/models/challenge_claim_spec.rb
+++ b/spec/models/challenge_claim_spec.rb
@@ -1,0 +1,15 @@
+require 'spec_helper'
+
+describe ChallengeClaim do
+
+  describe '#claim_byline' do
+    it "should return the claiming user's default pseud byline" do
+      user = create(:user)
+      claim = ChallengeClaim.new(claiming_user_id: user.id)
+      expect(claim.claim_byline).to eq(user.default_pseud.byline)
+    end
+    it "should tell you when there's no user instead of erroring" do
+      expect(ChallengeClaim.new.claim_byline).to eq("deleted user")
+    end
+  end
+end


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5091

## Purpose

Fixes 500 error on claims page caused by deleted users

## Testing

1. Create a prompt meme challenge and add some prompts
2. Make a throwaway user account
3. Claim a prompt with the new user account
4. Delete the user account
5. Try to access the claims page as the challenge mod
6. Hopefully don't get a 500 error, and see "deleted user" on the claim description instead

## References

Are there any other relevant issues / PRs / mailing lists discussions related to this?

## Credit

*What name do you want us to use to credit your work in the [Archive of Our Own's Release Notes](http://archiveofourown.org/admin_posts?tag=1)?*

*What pronouns do you prefer (she/her, he/him, zie/hir etc)?*

(if you do not fill this in, we will use your GitHub account name and will use "they" to avoid making assumptions about your gender)
