### PR TITLE
AO3-5094 Remove unneeded time zone hack

### DIFF
--- a/app/models/challenge_models/gift_exchange.rb
+++ b/app/models/challenge_models/gift_exchange.rb
@@ -47,9 +47,6 @@ class GiftExchange < ActiveRecord::Base
   # make sure that challenge sign-up / close / open dates aren't contradictory
   validate :validate_signup_dates
 
-  #FIXME hack because time zones are being html encoded. couldn't figure out why.
-  before_save :fix_time_zone
-
   #  When Challenges are deleted, there are two references left behind that need to be reset to nil
   before_destroy :clear_challenge_references
 

--- a/app/models/challenge_models/prompt_meme.rb
+++ b/app/models/challenge_models/prompt_meme.rb
@@ -41,9 +41,6 @@ class PromptMeme < ActiveRecord::Base
     end
   end
 
-  #FIXME hack because time zones are being html encoded. couldn't figure out why.
-  before_save :fix_time_zone
-
   #  When Challenges are deleted, there are two references left behind that need to be reset to nil
   before_destroy :clear_challenge_references
 

--- a/app/models/preference.rb
+++ b/app/models/preference.rb
@@ -20,15 +20,6 @@ class Preference < ActiveRecord::Base
      return User.current_user.try(:preference).try(:disable_work_skins)
   end
 
-  #FIXME hack because time zones are being html encoded. couldn't figure out why.
-  before_save :fix_time_zone
-  def fix_time_zone
-    return true if self.time_zone.nil?
-    return true if ActiveSupport::TimeZone[self.time_zone]
-    try = self.time_zone.gsub('&amp;', '&')
-    self.time_zone = try if ActiveSupport::TimeZone[try]
-  end
-
   def hide_hit_counts
     self.try(:hide_all_hit_counts) || self.try(:hide_private_hit_count)
   end

--- a/lib/challenge_core.rb
+++ b/lib/challenge_core.rb
@@ -33,14 +33,6 @@ module ChallengeCore
     end
   end
 
-  # HACK to avoid time zones being encoded
-  def fix_time_zone
-    return true if self.time_zone.nil?
-    return true if ActiveSupport::TimeZone[self.time_zone]
-    try = self.time_zone.gsub('&amp;', '&')
-    self.time_zone = try if ActiveSupport::TimeZone[try]
-  end
-
   # When Challenges are deleted, there are two references left behind that need to be reset to nil
   def clear_challenge_references
     collection.challenge_id = nil


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5094

## Purpose

Removes old duplicate code which was fixing an encoding issue that no longer seems to exist.

## Testing

If you set your time zone to a zone with an ampersand (on your preferences or for a challenge), it should save properly and that should be reflected when you go back to the page.

## References

Are there any other relevant issues / PRs / mailing lists discussions related to this?

## Credit

*What name do you want us to use to credit your work in the [Archive of Our Own's Release Notes](http://archiveofourown.org/admin_posts?tag=1)?*

*What pronouns do you prefer (she/her, he/him, zie/hir etc)?*

(if you do not fill this in, we will use your GitHub account name and will use "they" to avoid making assumptions about your gender)
