### PR TITLE
AO3-5096 Fix an old FIXME by removing a duplicate method

### DIFF
--- a/app/models/external_work.rb
+++ b/app/models/external_work.rb
@@ -68,10 +68,8 @@ class ExternalWork < ActiveRecord::Base
   def visible?(user=User.current_user)
     self.hidden_by_admin? ? user.kind_of?(Admin) : true
   end
-  # FIXME - duplicate of above but called in different ways in different places
-  def visible(user=User.current_user)
-    self.hidden_by_admin? ? user.kind_of?(Admin) : true
-  end
+
+  alias_method :visible, :visible?
 
   #######################################################################
   # TAGGING


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5096

## Purpose

Removes duplicate method in the external work model and uses alias_method instead

## Testing

No behavior should change. Bookmarks of external works should still be appropriately visible.