### PR TITLE
AO3-3704 Users can add coauthor work skins to works

### DIFF
--- a/app/helpers/works_helper.rb
+++ b/app/helpers/works_helper.rb
@@ -184,5 +184,7 @@ module WorksHelper
     work.challenge_claims.present?
   end
 
-
+  def all_coauthor_skins
+    WorkSkin.approved_or_owned_by_any(@allpseuds.map(&:user)).order(:title)
+  end
 end

--- a/app/models/skin.rb
+++ b/app/models/skin.rb
@@ -154,10 +154,14 @@ class Skin < ApplicationRecord
 
   def self.approved_or_owned_by(user = User.current_user)
     if user.nil?
-      where(public: true, official: true)
+      approved_skins
     else
-      where("(public = 1 AND official = 1) OR author_id = ?", user.id)
+      approved_or_owned_by_any([user])
     end
+  end
+
+  def self.approved_or_owned_by_any(users)
+    where("(public = 1 AND official = 1) OR author_id in (?)", users.map(&:id))
   end
 
   def self.usable

--- a/app/views/works/_standard_form.html.erb
+++ b/app/views/works/_standard_form.html.erb
@@ -241,9 +241,7 @@
           <%= link_to_help "work-skins" %>
         </dt>
         <dd class="skin">
-          <%= f.collection_select :work_skin_id, WorkSkin.approved_or_owned_by(current_user).order(:title),
-                :id,
-                :title,
+          <%= f.collection_select :work_skin_id, all_coauthor_skins, :id, :title,
                 { :selected => (@work.work_skin ? @work.work_skin.id.to_s : nil), include_blank: true } %>
           <p class="actions" role="navigation">
             <%= link_to ts("Public Work Skins"), skins_path(:skin_type => "WorkSkin") %>

--- a/factories/skins.rb
+++ b/factories/skins.rb
@@ -9,6 +9,7 @@ FactoryGirl.define do
 
     factory :public_work_skin do
       public true
+      official true
     end
   end
 end

--- a/features/step_definitions/user_steps.rb
+++ b/features/step_definitions/user_steps.rb
@@ -21,6 +21,14 @@ Given /the following activated users? exists?/ do |table|
   end
 end
 
+Given /the following activated users with private work skins/ do |table|
+  table.hashes.each do |hash|
+    user = FactoryGirl.create(:user, hash)
+    user.activate
+    FactoryGirl.create(:private_work_skin, author: user, title: "#{user.login.titleize}'s Work Skin")
+  end
+end
+
 Given /the following activated tag wranglers? exists?/ do |table|
   table.hashes.each do |hash|
     user = FactoryGirl.create(:user, hash)

--- a/features/works/work_edit.feature
+++ b/features/works/work_edit.feature
@@ -144,6 +144,22 @@ Feature: Edit Works
     Then I should see "ex_friend" within ".byline"
       And I should not see "coolperson" within ".byline"
 
+  Scenario: User applies a coauthor's work skin to their work
+    Given the following activated users with private work skins
+        | login       |
+        | lead_author |
+        | coauthor    |
+        | random_user |
+      And I coauthored the work "Shared" as "lead_author" with "coauthor"
+      And I am logged in as "lead_author"
+    When I edit the work "Shared"
+    Then I should see "Lead Author's Work Skin" within "#work_work_skin_id"
+      And I should see "Coauthor's Work Skin" within "#work_work_skin_id"
+      And I should not see "Random User's Work Skin" within "#work_work_skin_id"
+    When I select "Coauthor's Work Skin" from "Select Work Skin"
+      And I press "Post Without Preview"
+    Then I should see "Work was successfully updated"
+
   Scenario: A work cannot be edited to remove its fandom
     Given basic tags
       And I am logged in as a random user

--- a/features/works/work_edit_multiple.feature
+++ b/features/works/work_edit_multiple.feature
@@ -138,3 +138,16 @@ Feature: Edit Multiple Works
     Then I should not see "coauthor" within ".byline"
     When I view the work "Shared Work 2"
     Then I should not see "coauthor" within ".byline"
+
+  Scenario: User applies a private work skin to multiple coauthored works
+    Given the following activated users with private work skins
+      | login       |
+      | lead_author |
+      | coauthor    |
+      And I am logged in as "lead_author"
+      And I edit multiple works coauthored as "lead_author" with "coauthor"
+    Then I should see "Lead Author's Work Skin" within "#work_work_skin_id"
+      And I should not see "Coauthor's Work Skin" within "#work_work_skin_id"
+    When I select "Lead Author's Work Skin" from "Select Work Skin"
+      And I press "Update All Works"
+    Then I should see "Your edits were put through"

--- a/spec/helpers/works_helper_spec.rb
+++ b/spec/helpers/works_helper_spec.rb
@@ -39,4 +39,47 @@ describe WorksHelper do
 
   end
 
+  describe '#all_coauthor_skins' do
+    before do
+      @allpseuds = Array.new(5) { |i| FactoryGirl.create(:pseud, name: "Pseud-#{i}") }
+    end
+
+    context 'no public work skins or private work skins' do
+      it 'returns an empty array' do
+        expect(helper.all_coauthor_skins).to be_empty
+      end
+    end
+
+    context 'public work skins exist' do
+      before do
+        FactoryGirl.create(:public_work_skin, title: 'Z Public Skin')
+        FactoryGirl.create(:public_work_skin, title: 'B Public Skin')
+      end
+
+      context 'no private work skins' do
+        it 'returns public work skins, ordered by title' do
+          expect(helper.all_coauthor_skins.pluck(:title)).to eq(['B Public Skin', 'Z Public Skin'])
+        end
+      end
+
+      context 'private work skins exist' do
+        before do
+          FactoryGirl.create(:private_work_skin, title: 'A Private Skin', author: @allpseuds[3].user)
+          FactoryGirl.create(:private_work_skin, title: 'M Private Skin', author: @allpseuds[0].user)
+          FactoryGirl.create(:private_work_skin, title: 'Unowned Private Skin')
+        end
+
+        it 'returns public work skins and skins belonging to allpseuds, ordered by title' do
+          expect(helper.all_coauthor_skins.pluck(:title)).to eq(['A Private Skin',
+                                                                 'B Public Skin',
+                                                                 'M Private Skin',
+                                                                 'Z Public Skin'])
+        end
+
+        it 'does not return unassociated private work skins' do
+          expect(helper.all_coauthor_skins.pluck(:title)).not_to include(['Unowned Private Skin'])
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-3704

## Purpose

Users can now add coauthors' work skins to works from the Edit Work page. Users still won't be able to add coauthors' work skins from the Edit Multiple Works page.

## Testing

1. Create a work with a work skin
2. Add a co-author
3. Post work
4. Have co-author edit work

If bugfix is working, co-author should be able to edit work without original author's work skin getting stripped. They should also be able to add or remove their coauthor's work skin at any time.
