### PR TITLE
AO3-5033: Fix issue preventing work posting

### DIFF
--- a/app/models/chapter.rb
+++ b/app/models/chapter.rb
@@ -56,7 +56,7 @@ class Chapter < ActiveRecord::Base
   after_save :fix_positions
   def fix_positions
     # Without reloading, we were losing the work id post-Rails 5
-    if work.reload
+    if work && work.reload
       positions_changed = false
       self.position ||= 1
       chapters = work.chapters.order(:position)

--- a/app/models/chapter.rb
+++ b/app/models/chapter.rb
@@ -55,7 +55,8 @@ class Chapter < ActiveRecord::Base
 
   after_save :fix_positions
   def fix_positions
-    if work
+    # Without reloading, we were losing the work id post-Rails 5
+    if work.reload
       positions_changed = false
       self.position ||= 1
       chapters = work.chapters.order(:position)


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5033

## Purpose

Fixes issue where the chapter position fixing callback was trying to update all works on staging with a null work id (which is a separate problem) and then timing out, preventing any new works from being posted.

## Testing

First, we should check that works can be posted on staging. Next we should test chapter position updating as part of the regression, ie if you post a new chapter 3 for a work with 5 chapters, it should slot into the appropriate spot and all other chapters should have their positions updated appropriately.