### PR TITLE
AO3-4796 Revert strong_parameters fix of AO3-4795

### DIFF
--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -106,12 +106,8 @@ class WorksController < ApplicationController
       end
 
       tag = @fandom || @tag
-      # This strange dance is because there is an interaction between
-      # strong_parameters and dup, without the dance
-      # options[:filter_ids] << tag.id is ignored.
-      filter_ids = options[:filter_ids] || []
-      filter_ids << tag.id
-      options[:filter_ids] = filter_ids
+      options[:filter_ids] ||= []
+      options[:filter_ids] << tag.id
     end
 
     options[:page] = params[:page]


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-4796

## Purpose

Now that we're on Rails 4 and the strong_parameters gem has been removed, we no longer need the [AO3-4795](https://otwarchive.atlassian.net/browse/AO3-4795) fix for filtering by fandom in dashboard.

## Testing

There's an automated test for this already in #2683. For manual testing, see issue.