### PR TITLE
AO3-5105: Use count over length for large tag data

### DIFF
--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -69,7 +69,7 @@ class Tag < ApplicationRecord
   def taggings_count
     cache_read = Rails.cache.read(taggings_count_cache_key)
     return cache_read unless cache_read.nil?
-    real_value = taggings.length
+    real_value = taggings.count
     self.taggings_count = real_value
     real_value
   end
@@ -81,7 +81,7 @@ class Tag < ApplicationRecord
 
   def update_counts_cache(id)
     tag = Tag.find(id)
-    tag.taggings_count = tag.taggings.length
+    tag.taggings_count = tag.taggings.count
   end
 
   acts_as_commentable


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5105

## Purpose

Replace length with count for large tag queries. On staging, the cache must be empty, because this code is running synchronously and it's slow for warning/rating tags even with the smaller amount of data there.

## Testing

In the short term, posting on staging should be faster. 