### PR TITLE
AO3-5109 Rails BOT: Don't auto disable submit buttons after they're pressed

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -60,6 +60,8 @@ module Otwarchive
 
     config.action_mailer.default_url_options = { host: "archiveofourown.org" }
 
+    config.action_view.automatically_disable_submit_tag = false
+
     # Configure sensitive parameters which will be filtered from the log file.
     config.filter_parameters += [:content, :password, :terms_of_service_non_production]
 


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5109

## Purpose

As a result of the Rails upgrade, all submit buttons were getting disabled after they were pressed, which caused problems like not being able to preview a work after correcting a validation error resulting from a missing title. 

## Testing

Refer to JIRA

## References

https://stackoverflow.com/a/44025628
http://edgeguides.rubyonrails.org/configuring.html#configuring-action-view