### PR TITLE
AO3-5110 Rails BOT: Don't try to autoload observers that no longer exist

### DIFF
--- a/app/models/collection_item.rb
+++ b/app/models/collection_item.rb
@@ -188,7 +188,8 @@ class CollectionItem < ApplicationRecord
   after_update :notify_of_status_change
   def notify_of_status_change
     if saved_change_to_unrevealed?
-      # making sure that creation_observer.rb has not already notified the user
+      # making sure notify_recipients in the work model has not already notified 
+      # the user
       if !work.new_recipients.blank?
         notify_of_reveal
       end

--- a/config/application.rb
+++ b/config/application.rb
@@ -39,10 +39,6 @@ module Otwarchive
     I18n.config.available_locales = [:en, :ar, :ca, 'zh-CN', :cs, :nl, :fi, :fr, :de, :he, :hu, :id,
       :it, :ja, :ko, :lt, :pl, 'pt-BR', :ru, :es, :sv, :tr]
 
-    # Activate observers that should always be running.
-    # config.active_record.observers = :cacher, :garbage_collector, :forum_observer
-    config.active_record.observers = :comment_observer, :work_observer, :creation_observer, :collection_preference_observer, :kudo_observer, :response_observer
-
     # Set Time.zone default to the specified zone and make Active Record auto-convert to this zone.
     # Run "rake -D time" for a list of tasks for finding time zone names. Default is UTC.
     # config.time_zone = 'Central Time (US & Canada)'


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5110

## Purpose

In Rails 5.0 (#2958), we moved some code out of observers and into the models they actually pertain to, but our application.rb config was still trying to autoload these observers.

## Testing

None beyond the regression test
