### PR TITLE
AO3-5108 Rails BOT: Fix params issue with inbox filtering

### DIFF
--- a/app/controllers/inbox_controller.rb
+++ b/app/controllers/inbox_controller.rb
@@ -10,9 +10,8 @@ class InboxController < ApplicationController
   def show
     @inbox_total = @user.inbox_comments.with_feedback_comment.count
     @unread = @user.inbox_comments.with_feedback_comment.count_unread
-    filters = params[:filters] || {}
-    @inbox_comments = @user.inbox_comments.with_feedback_comment.find_by_filters(filters).page(params[:page])
-    @select_read, @select_replied_to, @select_date = filters[:read], filters[:replied_to], filters[:date]
+    @filters = filter_params[:filters] || {}
+    @inbox_comments = @user.inbox_comments.with_feedback_comment.find_by_filters(@filters).page(params[:page])
   end
 
   def reply
@@ -44,5 +43,12 @@ class InboxController < ApplicationController
       format.html { redirect_to request.referer || user_inbox_path(@user, page: params[:page], filters: params[:filters]), notice: success_message }
       format.json { render json: { item_success_message: success_message }, status: :ok }
     end
+  end
+
+  private
+
+  # Allow flexible params through, since we're not posting any data
+  def filter_params
+    params.permit!
   end
 end

--- a/app/views/inbox/_approve_button.html.erb
+++ b/app/views/inbox/_approve_button.html.erb
@@ -1,7 +1,7 @@
 <% # expects feedback_comment and approved_from %>
 
 <% # approve link that works with JavaScript enabled and is otherwise hidden %>
-<%= link_to(ts("Approve"), review_comment_path(feedback_comment, approved_from: approved_from.to_s, page: params[:page], filters: params[:filters]), method: :put, remote: true, class: 'hidden') %>
+<%= link_to(ts("Approve"), review_comment_path(feedback_comment, approved_from: approved_from.to_s, page: params[:page], filters: @filters), method: :put, remote: true, class: 'hidden') %>
 
 <% # unreviewed comments page link for users with JavaScript disabled %>
 <%= link_to(ts("Unreviewed Comments"), unreviewed_work_comments_path(feedback_comment.ultimate_parent), class: 'hideme') %>

--- a/app/views/inbox/_reply_button.html.erb
+++ b/app/views/inbox/_reply_button.html.erb
@@ -1,4 +1,4 @@
 <% # expects feedback_comment %>
 <% unless feedback_comment.ultimate_parent.blank? %>
-  <%= link_to ts('Reply'), reply_user_inbox_path(current_user, comment_id: feedback_comment, filters: params[:filters]), remote: true %>
+  <%= link_to ts('Reply'), reply_user_inbox_path(current_user, comment_id: feedback_comment, filters: @filters), remote: true %>
 <% end %>

--- a/app/views/inbox/show.html.erb
+++ b/app/views/inbox/show.html.erb
@@ -16,7 +16,7 @@
 
   <%= will_paginate @inbox_comments %>
 
-  <%= form_tag user_inbox_path(@user, page: params[:page], filters: params[:filters]), method: :put, id: 'inbox-form', class: 'inbox manage' do %>
+  <%= form_tag user_inbox_path(@user, page: params[:page], filters: @filters), method: :put, id: 'inbox-form', class: 'inbox manage' do %>
     <fieldset class="actions">
       <legend><%= ts("Mass Edit Options") %></legend>
 
@@ -104,15 +104,15 @@
       <dd>
         <ul>
           <li>
-            <%= radio_button_tag 'filters[read]', 'all', (@select_read != 'true' && @select_read != 'false') %>
+            <%= radio_button_tag 'filters[read]', 'all', (!%w(true false).include?(@filters[:read])) %>
             <%= label_tag 'filters_read_all', ts("Show all") %>
           </li>
           <li>
-            <%= radio_button_tag 'filters[read]', 'false', @select_read == 'false' %>
+            <%= radio_button_tag 'filters[read]', 'false', @filters[:read] == 'false' %>
             <%= label_tag 'filters_read_false', ts("Show unread") %>
           </li>
           <li>
-            <%= radio_button_tag 'filters[read]', 'true', @select_read == 'true' %>
+            <%= radio_button_tag 'filters[read]', 'true', @filters[:read] == 'true' %>
             <%= label_tag 'filters_read_true', ts("Show read") %>
           </li>
         </ul>
@@ -122,15 +122,15 @@
       <dd>
         <ul>
           <li>
-            <%= radio_button_tag 'filters[replied_to]', 'all', (@select_replied_to != 'true' && @select_replied_to != 'false') %>
+            <%= radio_button_tag 'filters[replied_to]', 'all', (!%w(true false).include?(@filters[:replied_to])) %>
             <%= label_tag 'filters_replied_to_all', ts("Show all") %>
           </li>
           <li>
-            <%= radio_button_tag 'filters[replied_to]', 'false', @select_replied_to == 'false' %>
+            <%= radio_button_tag 'filters[replied_to]', 'false', @filters[:replied_to] == 'false' %>
             <%= label_tag 'filters_replied_to_false', ts("Show without replies") %>
           </li>
           <li>
-            <%= radio_button_tag 'filters[replied_to]', 'true', @select_replied_to == 'true' %>
+            <%= radio_button_tag 'filters[replied_to]', 'true', @filters[:replied_to] == 'true' %>
             <%= label_tag 'filters_replied_to_true', ts("Show replied to") %>
           </li>
         </ul>
@@ -140,11 +140,11 @@
       <dd>
         <ul>
           <li>
-            <%= radio_button_tag 'filters[date]', 'desc', @select_date != 'asc' %>
+            <%= radio_button_tag 'filters[date]', 'desc', @filters[:date] != 'asc' %>
             <%= label_tag 'filters_date_desc', ts("Newest first") %>
           </li>
           <li>
-            <%= radio_button_tag 'filters[date]', 'asc', @select_date == 'asc' %>
+            <%= radio_button_tag 'filters[date]', 'asc', @filters[:date] == 'asc' %>
             <%= label_tag 'filters_date_asc', ts("Oldest first") %>
           </li>
         </ul>

--- a/features/comments_and_kudos/inbox.feature
+++ b/features/comments_and_kudos/inbox.feature
@@ -35,14 +35,19 @@ Feature: Get messages in the inbox
     Then I should see "cutman on Down for the Count"
       And I should see "less than 1 minute ago"
 
-  Scenario: Logged in comments in my inbox should have timestamps
+  Scenario: Comments in my inbox should be filterable
     Given I am logged in as "boxer" with password "10987tko"
       And I post the work "Down for the Count"
     When I post the comment "The fight game's complex." on the work "Down for the Count" as a guest
     When I am logged in as "boxer" with password "10987tko"
       And I go to my inbox page
+      And I choose "Show unread"
+      And I press "Filter"
     Then I should see "guest on Down for the Count"
       And I should see "less than 1 minute ago"
+    When I choose "Show read"
+      And I press "Filter"
+    Then I should not see "guest on Down for the Count"
 
   Scenario: A user can see some of their unread comments on the homepage
     Given I am logged in as "boxer" with password "10987tko"

--- a/spec/controllers/inbox_controller_spec.rb
+++ b/spec/controllers/inbox_controller_spec.rb
@@ -43,7 +43,7 @@ describe InboxController do
 
         it "renders oldest first" do
           get :show, params: { user_id: user.login, filters: { date: "asc" } }
-          expect(assigns(:select_date)).to eq("asc")
+          expect(assigns(:filters)[:date]).to eq("asc")
           expect(assigns(:inbox_comments)).to eq(inbox_comments)
           expect(assigns(:inbox_total)).to eq(3)
           expect(assigns(:unread)).to eq(3)
@@ -56,7 +56,7 @@ describe InboxController do
 
         it "renders only unread" do
           get :show, params: { user_id: user.login, filters: { read: "false" } }
-          expect(assigns(:select_read)).to eq("false")
+          expect(assigns(:filters)[:read]).to eq("false")
           expect(assigns(:inbox_comments)).to eq([unread_comment])
           expect(assigns(:inbox_total)).to eq(2)
           expect(assigns(:unread)).to eq(1)
@@ -69,7 +69,7 @@ describe InboxController do
 
         it "renders only unreplied" do
           get :show, params: { user_id: user.login, filters: { replied_to: "false" } }
-          expect(assigns(:select_replied_to)).to eq("false")
+          expect(assigns(:filters)[:replied_to]).to eq("false")
           expect(assigns(:inbox_comments)).to eq([unreplied_comment])
           expect(assigns(:inbox_total)).to eq(2)
           expect(assigns(:unread)).to eq(2)


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5108

## Purpose

Fixes strong parameter related issue causing errors on inbox filtering.

## Testing

Inboxes should be filterable again.