### PR TITLE
AO3-5111: Fix attribute_changed deprecation message

### DIFF
--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -6,7 +6,7 @@ class ApplicationRecord < ActiveRecord::Base
 
   def update_sanitizer_version
     ArchiveConfig.FIELDS_ALLOWING_HTML.each do |field|
-      if self.respond_to?("#{field}_changed?") && self.send("#{field}_changed?")
+      if self.will_save_change_to_attribute?(field)
         self.send("#{field}_sanitizer_version=", ArchiveConfig.SANITIZER_VERSION)
       end
     end


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5111

## Purpose

Updates syntax in before save hook to remove deprecation warning.

## Testing

The sanitizer version should still set properly, but there's no way to test that since we don't actually use it. Tests should run without a zillion deprecation warnings now.