### PR TITLE
AO3-5117: Fix bug in collection creation when no pseud was selected

### DIFF
--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -100,7 +100,7 @@ class CollectionsController < ApplicationController
 
     # add the owner
     owner_attributes = []
-    (params[:owner_pseuds] || [current_user.default_pseud]).each do |pseud_id|
+    (params[:owner_pseuds] || [current_user.default_pseud_id]).each do |pseud_id|
       pseud = Pseud.find(pseud_id)
       owner_attributes << {pseud: pseud, participant_role: CollectionParticipant::OWNER} if pseud
     end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -345,6 +345,10 @@
     self.pseuds.where(is_default: true).first
   end
 
+  def default_pseud_id
+    pseuds.where(is_default: true).pluck(:id).first
+  end
+
   # Checks authorship of any sort of object
   def is_author_of?(item)
     if item.respond_to?(:user)

--- a/app/views/collections/_form.html.erb
+++ b/app/views/collections/_form.html.erb
@@ -10,7 +10,7 @@
           <%= label_tag "owner_pseuds[]", ts("Owner pseud(s)") %>
         </dt>
         <dd>
-          <%= select_tag "owner_pseuds[]", options_from_collection_for_select(current_user.pseuds, :id, :name, current_user.default_pseud), multiple: true %>
+          <%= select_tag "owner_pseuds[]", options_from_collection_for_select(current_user.pseuds, :id, :name, current_user.default_pseud_id), multiple: true %>
         </dd>
       <% else %>
         <p><%= hidden_field_tag "owner_pseuds[]", [current_user.default_pseud.id] %></p>


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5117

## Purpose

Fixes both a small and large bug with collection creation.

## Testing

If a user with multiple pseuds tries to create a new collection, their default pseud should be automatically selected on the form. If they're feeling contrary and still unselect all of the pseuds, then the collection should still be created without erroring using the default pseud.