### PR TITLE
AO3-5119 Rails BOT Don't send deleted sign-up email

### DIFF
--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -366,24 +366,6 @@ class UserMailer < BulletproofMailer::Base
     )
   end
 
-  def delete_signup_notification(user, challenge_signup)
-    @user = user
-    @signup = challenge_signup
-    signup_copy = generate_attachment_content_from_signup(@signup)
-    filename = @signup.collection.title.gsub(/[*:?<>|\/\\\"]/,'')
-    attachments["#{filename}.txt"] = {content: signup_copy}
-    attachments["#{filename}.html"] = {content: signup_copy}
-    I18n.with_locale(Locale.find(@user.preference.preferred_locale).iso) do
-      mail(
-        to: user.email,
-        subject: "[#{ArchiveConfig.APP_SHORT_NAME}] Your sign-up for #{@signup.collection.title} has been deleted",
-        body: ""
-      )
-    end
-    ensure
-      I18n.locale = I18n.default_locale
-  end
-
   ### OTHER NOTIFICATIONS ###
 
   # archive feedback
@@ -428,69 +410,6 @@ class UserMailer < BulletproofMailer::Base
       attachment_string += "<br/>Notes: " + chapter.notes + "<br/>\n" unless chapter.notes.blank?
       attachment_string += "<br/>End Notes: " + chapter.endnotes + "<br/>\n" unless chapter.endnotes.blank?
       attachment_string += "<br/>" + chapter.content + "<br />\n"
-    end
-    return attachment_string
-  end
-
-  def generate_attachment_content_from_signup(signup)
-    attachment_string = "Collection: #{signup.collection}<br/>\n"
-    signup.requests.each_with_index do |prompt, index|
-      attachment_string += "Request " + index+1 + ":<br />\n"
-      any_types = TagSet::TAG_TYPES.select {|type| prompt.send("any_#{type}")}
-      if any_types || (prompt.tag_set && !prompt.tag_set.tags.empty?)
-        attachment_string += "Tags: "
-        attachment_string += prompt.tag_set && !prompt.tag_set.tags.empty? ? tag_link_list(prompt.tag_set.tags, link_to_works=true) + (any_types.empty? ? "" : ", ") : ""
-        unless any_types.empty?
-          attachment_string += any_types.map {|type| content_tag(:li, ts("Any %{type}", type: type.capitalize)) }.join(", ").html_safe
-        end
-        if prompt.optional_tag_set && !prompt.optional_tag_set.tags.empty?
-          attachment_string += "<br />\nOptional: "
-          attachment_string += tag_link_list(prompt.optional_tag_set.tags, link_to_works=true)
-        end
-        attachment_string += "<br />\n"
-      end
-      unless prompt.url.blank?
-        url_label = prompt.collection.challenge.send("request_url_label")
-        attachment_string += url_label.blank? ? "URL" : url_label
-        attachment_string += ": " + link_to(prompt.url, prompt.url) + "<br />\n"
-      end
-      unless prompt.description.blank?
-        desc_label = prompt.collection.challenge.send("request_description_label")
-        attachment_string += desc_label.blank? ? ts("Details") : desc_label
-        attachment_string += ": " +  prompt.description + "<br />\n"
-      end
-      if prompt.anonymous?
-        attachment_string += "Anonymous request" + "<br />\n"
-      end
-    end
-    signup.offers.each_with_index do |offer, index|
-      attachment_string += "Offer " + index+1 + ":<br />\n"
-      any_types = TagSet::TAG_TYPES.select {|type| prompt.send("any_#{type}")}
-      if any_types || (prompt.tag_set && !prompt.tag_set.tags.empty?)
-        attachment_string += "Tags: "
-        attachment_string += prompt.tag_set && !prompt.tag_set.tags.empty? ? tag_link_list(prompt.tag_set.tags, link_to_works=true) + (any_types.empty? ? "" : ", ") : ""
-        unless any_types.empty?
-          attachment_string += any_types.map {|type| content_tag(:li, ts("Any %{type}", type: type.capitalize)) }.join(", ").html_safe
-        end
-        if prompt.optional_tag_set && !prompt.optional_tag_set.tags.empty?
-          attachment_string += "<br />\nOptional: "
-          attachment_string += tag_link_list(prompt.optional_tag_set.tags, link_to_works=true)
-        end
-        attachment_string += "<br />\n"
-      end
-      unless prompt.url.blank?
-        url_label = prompt.collection.challenge.send("request_url_label")
-        attachment_string += url_label.blank? ? "URL" : url_label
-        attachment_string += ": " + link_to(prompt.url, prompt.url) + "<br />\n"
-      end
-      unless prompt.description.blank?
-        desc_label = prompt.collection.challenge.send("request_description_label")
-        attachment_string += desc_label.blank? ? ts("Details") : desc_label
-        attachment_string += ": " +  prompt.description + "<br />\n"
-      end
-      if prompt.anonymous?
-        attachment_string += "Anonymous request" + "<br />\n"
-      end
     end
     return attachment_string
   end

--- a/app/models/challenge_signup.rb
+++ b/app/models/challenge_signup.rb
@@ -19,11 +19,6 @@ class ChallengeSignup < ApplicationRecord
 
   has_many :request_claims, class_name: "ChallengeClaim", foreign_key: 'request_signup_id'
 
-  before_destroy :before_destroy
-  def before_destroy
-    UserMailer.delete_signup_notification(user, self).deliver!
-  end
-
   before_destroy :clear_assignments_and_claims
   def clear_assignments_and_claims
     # remove this signup reference from any existing assignments


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5119

## Purpose

The Rails upgrade fixed a bug that was preventing us from sending an email when challenge sign-ups were deleted. Alas, this email had no text and no formatting, just attachments, so it's not a good email to be sending... and no one missed it, since it has been broken for years. Ergo, this removes the code for sending that email, bringing the behavior in line with what's currently on production.

(I didn't run our massive pile of challenge tests locally, so it would not surprise me if Travis fails and I need to update some tests.)

## Testing

Refer to JIRA