### PR TITLE
AO3-5125 Map Open Doors temp site URLs to original site URLs

### DIFF
--- a/lib/tasks/opendoors.rake
+++ b/lib/tasks/opendoors.rake
@@ -1,0 +1,25 @@
+namespace :opendoors do
+  desc "Update urls for hexfiles import"
+  task(:url_update_hexfiles => :environment) do
+    c = Collection.find_by(name: "thehexfiles")
+    c.works.find_each do |work|
+      if work.imported_from_url.match /astele.co.uk\/hex\/Chapter\/Details\/(\d+)/
+        work.imported_from_url = "http://www.thehexfiles.net/viewstory.php?sid=#{$1}"
+        puts work.imported_from_url
+        work.save
+      end        
+    end
+  end
+
+  desc "Update urls for hpfandom import"
+  task(:url_update_hpfandom => :environment) do
+    c = Collection.find_by(name: "hpfandom")
+    c.works.find_each do |work|
+      if work.imported_from_url.match /astele.co.uk\/hpfandom\/Chapter\/Details\/(\d+)/
+        work.imported_from_url = "http://www.hpfandom.net/eff/viewstory.php?sid=#{$1}"
+        puts work.imported_from_url
+        work.save
+      end
+    end
+  end
+end

--- a/lib/tasks/opendoors.rake
+++ b/lib/tasks/opendoors.rake
@@ -1,22 +1,13 @@
 namespace :opendoors do
-  desc "Update urls for hexfiles import"
-  task(:url_update_hexfiles => :environment) do
-    c = Collection.find_by(name: "thehexfiles")
-    c.works.find_each do |work|
-      if work.imported_from_url.match /astele.co.uk\/hex\/Chapter\/Details\/(\d+)/
-        work.imported_from_url = "http://www.thehexfiles.net/viewstory.php?sid=#{$1}"
-        puts work.imported_from_url
-        work.save
-      end        
-    end
-  end
-
-  desc "Update urls for hpfandom import"
-  task(:url_update_hpfandom => :environment) do
-    c = Collection.find_by(name: "hpfandom")
-    c.works.find_each do |work|
-      if work.imported_from_url.match /astele.co.uk\/hpfandom\/Chapter\/Details\/(\d+)/
-        work.imported_from_url = "http://www.hpfandom.net/eff/viewstory.php?sid=#{$1}"
+  desc "Map import urls based on spreadsheet data"
+  task(:import_url_mapping => :environment) do
+    puts "Where is the Open Doors CSV located?"
+    loc = gets.chomp
+    CSV.foreach(loc, headers: true) do |row|
+      row["AO3 URL"].match(/works\/(\d+)/)
+      work = Work.find($1)
+      if work.imported_from_url == row["URL Imported From"]
+        work.imported_from_url = row["Original URL"]
         puts work.imported_from_url
         work.save
       end

--- a/lib/tasks/opendoors.rake
+++ b/lib/tasks/opendoors.rake
@@ -4,12 +4,15 @@ namespace :opendoors do
     puts "Where is the Open Doors CSV located?"
     loc = gets.chomp
     CSV.foreach(loc, headers: true) do |row|
-      row["AO3 URL"].match(/works\/(\d+)/)
-      work = Work.find($1)
-      if work.imported_from_url == row["URL Imported From"]
-        work.imported_from_url = row["Original URL"]
-        puts work.imported_from_url
-        work.save
+      begin
+        work = Work.where(imported_from_url: row["URL Imported From"]).first
+        if work
+          work.imported_from_url = row["Original URL"]
+          puts work.imported_from_url
+          work.save!
+        end
+      rescue
+        puts "Could not update work from #{row["Original URL"]}"
       end
     end
   end


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5125

## Purpose

Adds a task to map Open Doors imports to their original urls via csv files

## Testing

Will work with Ariana to test this - I believe you'll be able to see the updated import urls on the admin backend