### PR TITLE
AO3-5131 Skip uniqueness validation for deleted comments

### DIFF
--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -23,7 +23,11 @@ class Comment < ApplicationRecord
     errors.add(:base, ts("This comment looks like spam to our system, sorry! Please try again, or create an account to comment.")) unless check_for_spam?
   end
 
-  validates :content, uniqueness: {scope: [:commentable_id, :commentable_type, :name, :email, :pseud_id], message: ts("^This comment has already been left on this work. (It may not appear right away for performance reasons.)")}
+  validates :content, uniqueness: {
+    scope: [:commentable_id, :commentable_type, :name, :email, :pseud_id],
+    unless: :is_deleted?,
+    message: ts("^This comment has already been left on this work. (It may not appear right away for performance reasons.)")
+  }
 
   scope :recent, lambda { |*args|  where("created_at > ?", (args.first || 1.week.ago.to_date)) }
   scope :limited, lambda {|limit| {limit: limit.kind_of?(Fixnum) ? limit : 5} }

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -1,0 +1,24 @@
+require 'spec_helper'
+
+describe Comment do
+
+  context "with an existing comment from the same user" do
+    before(:all) do
+      @first_comment = create(:comment)
+      attributes = %w(pseud_id commentable_id commentable_type content name email)
+      @second_comment = Comment.new(
+        @first_comment.attributes.slice(*attributes)
+      )
+    end
+
+    it "should be invalid if exactly duplicated" do
+      expect(@second_comment.valid?).to eq(false)
+      expect(@second_comment.errors.keys).to include(:content)
+    end
+
+    it "should not be invalid if in the process of being deleted" do
+      @second_comment.is_deleted = true
+      expect(@second_comment.valid?).to eq(true)
+    end
+  end
+end


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5131

## Purpose

Prevents the uniqueness validation on comments from blocking deletion

## Testing

Testing notes in ticket