### PR TITLE
AO3-3958 Test unescaped HTML in title field when editing work/series

### DIFF
--- a/features/other_b/series.feature
+++ b/features/other_b/series.feature
@@ -218,3 +218,11 @@ Feature: Create and Edit Series
     Then I should see "Part 2 of the Ponies series" within "dd.series"
     When "AO3-3455" is fixed
     # And I should see "Part 1 of the Black Beauty series" within "dd.series"
+
+  Scenario: When editing a series, the title field should not escape HTML
+    Given I am logged in as "whoever"
+      And I post the work "whatever" as part of a series "What a title! :< :& :>"
+      And I go to whoever's series page
+      And I follow "What a title! :< :& :>"
+      And I follow "Edit Series"
+    Then I should see "What a title! :< :& :>" in the "Series Title" input

--- a/features/works/work_edit.feature
+++ b/features/works/work_edit.feature
@@ -161,3 +161,10 @@ Feature: Edit Works
       And I press "Cancel"
     When I view the work "Work 1"
       Then I should see "Fandom: testing"
+
+  Scenario: When editing a work, the title field should not escape HTML
+    Given I have a work "What a title! :< :& :>"
+      And I go to the works page
+      And I follow "What a title! :< :& :>"
+      And I follow "Edit"
+    Then I should see "What a title! :< :& :>" in the "Work Title" input


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-3958

## Purpose

AO3-3958 was already fixed at some point, I'm just adding tests.

## Testing

See issue.