### PR TITLE
AO3-5139 Tell Hound to prefer template tokens

### DIFF
--- a/config/.rubocop.yml
+++ b/config/.rubocop.yml
@@ -10,11 +10,15 @@ Style/StringLiterals:
 # stop checking line length
 Metrics/LineLength:
   Enabled: false
-  
+
+# prefer template tokens (like %{foo}) over annotated tokens (like %s)
+Style/FormatStringToken:
+  EnforcedStyle: template
+
 # stop checking for trailing whitespace
 Style/TrailingWhitespace:
   Enabled: false
-  
+
 # stop checking for ambiguous regexp literal
 Lint/AmbiguousRegexpLiteral:
   Enabled: false


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5139

## Purpose

Suppress Hound's suggestions similar to this:

> Prefer annotated tokens (like %s) over template tokens (like %{foo}).

## Testing

None. I tried it locally using RuboCop, with/without the new setting.

```bash
rvm use 2.3.0
gem install rubocop
rubocop -c config/.rubocop.yml app/controllers/admin/admin_invitations_controller.rb
```