### PR TITLE
AO3-5138 Prevent 500 error when admin post's translated_post_id is invalid

### DIFF
--- a/app/controllers/admin_posts_controller.rb
+++ b/app/controllers/admin_posts_controller.rb
@@ -1,6 +1,7 @@
 class AdminPostsController < ApplicationController
 
   before_action :admin_only, except: [:index, :show]
+  before_action :load_languages, except: [:show, :destroy]
 
   # GET /admin_posts
   def index
@@ -19,7 +20,6 @@ class AdminPostsController < ApplicationController
       @tags = AdminPostTag.order(:name)
     end
     @admin_posts = @admin_posts.order('created_at DESC').page(params[:page])
-    @news_languages = Language.where(id: Locale.all.map(&:language_id)).default_order
   end
 
   # GET /admin_posts/1
@@ -45,13 +45,11 @@ class AdminPostsController < ApplicationController
   # GET /admin_posts/new.xml
   def new
     @admin_post = AdminPost.new
-    @news_languages = Language.where(id: Locale.all.map(&:language_id)).default_order
   end
 
   # GET /admin_posts/1/edit
   def edit
     @admin_post = AdminPost.find(params[:id])
-    @news_languages = Language.where(id: Locale.all.map(&:language_id)).default_order
   end
 
   # POST /admin_posts
@@ -68,7 +66,6 @@ class AdminPostsController < ApplicationController
   # PUT /admin_posts/1
   def update
     @admin_post = AdminPost.find(params[:id])
-
     if @admin_post.update_attributes(admin_post_params)
       flash[:notice] = ts("Admin Post was successfully updated.")
       redirect_to(@admin_post)
@@ -82,6 +79,12 @@ class AdminPostsController < ApplicationController
     @admin_post = AdminPost.find(params[:id])
     @admin_post.destroy
     redirect_to(admin_posts_path)
+  end
+
+  protected
+
+  def load_languages
+    @news_languages = Language.where(id: Locale.all.map(&:language_id)).default_order
   end
 
   private

--- a/features/admins/admin_post_news.feature
+++ b/features/admins/admin_post_news.feature
@@ -105,6 +105,14 @@ Feature: Admin Actions to Post News
       And I am logged in as "ordinaryuser"
     Then I should see a translated admin post
 
+  Scenario: Make a translation of an admin post that doesn't exist
+    Given basic languages
+      And I am logged in as an admin
+    When I make a translation of an admin post
+    Then I should see "Sorry! We couldn't save this admin post because:"
+      And I should see "Translated post does not exist"
+      And the translation information should still be filled in
+
   Scenario: Make a translation of an admin post stop being a translation
     Given I have posted an admin post
       And basic languages

--- a/features/step_definitions/admin_steps.rb
+++ b/features/step_definitions/admin_steps.rb
@@ -311,12 +311,21 @@ end
 ### THEN
 
 When (/^I make a translation of an admin post$/) do
+  admin_post = AdminPost.find_by(title: "Default Admin Post")
+  # If post doesn't exist, assume we want to reference a non-existent post
+  admin_post_id = !admin_post.nil? ? admin_post.id : 0
   visit new_admin_post_path
   fill_in("admin_post_title", with: "Deutsch Ankuendigung")
   fill_in("content", with: "Deutsch Woerter")
   step %{I select "Deutsch" from "Choose a language"}
-  fill_in("admin_post_translated_post_id", with: AdminPost.find_by(title: "Default Admin Post").id)
+  fill_in("admin_post_translated_post_id", with: admin_post_id)
   click_button("Post")
+end
+
+Then (/^the translation information should still be filled in$/) do
+  step %{the "admin_post_title" field should contain "Deutsch Ankuendigung"}
+  step %{the "content" field should contain "Deutsch Woerter"}
+  step %{"Deutsch" should be selected within "Choose a language"}
 end
 
 Then (/^I should see a translated admin post$/) do

--- a/spec/controllers/admin_posts_controller_spec.rb
+++ b/spec/controllers/admin_posts_controller_spec.rb
@@ -1,0 +1,30 @@
+require "spec_helper"
+
+describe AdminPostsController do
+  include LoginMacros
+  include RedirectExpectationHelper
+
+  describe "POST #create" do
+    before { fake_login_admin(create(:admin)) }
+
+    let(:base_params) { { title: "AdminPost Title",
+                          content: "AdminPost content long enough to pass validation" } }
+
+    context "when admin post is valid" do
+      it "redirects to post with notice" do
+        post :create, params: { admin_post: base_params }
+        it_redirects_to_with_notice(admin_post_path(assigns[:admin_post]), "Admin Post was successfully created.")
+      end
+    end
+
+    context "when admin post is invalid" do
+      context "with invalid translated post id" do
+        it "renders the new template with error message" do
+          post :create, params: { admin_post: { translated_post_id: 0 } }.merge(base_params)
+          expect(response).to render_template(:new)
+          expect(assigns[:admin_post].errors.full_messages).to include("Translated post does not exist")
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5138

## Purpose

Makes sure admin post languages are properly loaded for all actions that need it, thereby preventing a 500 error that would occur when trying to create an admin post with an invalid translated_post_id.

I realized the specs didn't actually cover the proper scenario, but I left them in because why not.

## Testing

See JIRA
