### PR TITLE
AO3-5130 Rails BOT: Fix co-creator notification for chapter

### DIFF
--- a/features/works/chapter_edit.feature
+++ b/features/works/chapter_edit.feature
@@ -312,6 +312,9 @@ Feature: Edit chapters
     When I add the co-author "amy"
       And I post the chapter
     Then I should see "amy, karma"
+      And 1 email should be delivered to "amy"
+      And the email should contain "You have been listed as a co-creator on the following work"
+      And the email should not contain "translation missing"
 
 
   Scenario: You should be able to edit a chapter to add a co-creator who is

--- a/lib/creatable.rb
+++ b/lib/creatable.rb
@@ -30,12 +30,12 @@ module Creatable
   # Notify new co-authors that they've been added to a creation
   def notify_co_authors
     this_creation = self
-    creation = self.work if self.is_a?(Chapter)
+    creation = self.is_a?(Chapter) ? self.work : self
     if self && !self.authors.blank? && User.current_user.is_a?(User)
       new_authors = (self.authors - (self.pseuds + User.current_user.pseuds)).uniq
       unless new_authors.blank?
         for pseud in new_authors
-          UserMailer.coauthor_notification(pseud.user.id, self.id, self.class.name).deliver
+          UserMailer.coauthor_notification(pseud.user.id, creation.id, creation.class.name).deliver
         end
       end
     end


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5130

## Purpose

The Rails 5.0 upgrade introduced co-creator notification, however the email template doesn't handle chapters. If the creatable is a chapter, we'll use the parent work in the notification instead.

## Testing

See issue. In a local environment I have trouble sending actual emails, so I log them to check the contents:

```ruby
# deliver! to send it now!
mail = UserMailer.coauthor_notification(pseud.user.id, creation.id, creation.class.name).deliver!
Rails.logger.info mail.body.parts.find { |p| p.content_type.match /html/ }.body.raw_source
```