### PR TITLE
AO3-5142 Fix invalid authenticity token error in API

### DIFF
--- a/app/controllers/api/v1/base_controller.rb
+++ b/app/controllers/api/v1/base_controller.rb
@@ -4,6 +4,7 @@ module Api
   # with the new version.
   module V1
     class BaseController < ApplicationController
+      skip_before_action :verify_authenticity_token
       before_action :restrict_access
 
       private


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5142

## Purpose

Fixes the `ActionController::InvalidAuthenticityToken` that occurs when using the mass import API after the upgrade to Rails 5.

## Testing

    curl -L -X POST http://test.archiveofourown.org/api/v1/bookmarks

should return the text `HTTP Token: Access denied.`. And the temp site test site should be able to post stories to the API.
