### PR TITLE
AO3-5142 Add test to check that API works with forgery protection on

### DIFF
--- a/spec/api/api_authorization_spec.rb
+++ b/spec/api/api_authorization_spec.rb
@@ -7,6 +7,15 @@ describe "API Authorization" do
   end_points = %w(/api/v1/works /api/v1/bookmarks)
 
   describe "API POST with invalid request" do
+    it "should return 401 Unauthorized if no token is supplied and forgery protection is enabled" do
+      ActionController::Base.allow_forgery_protection = true
+      end_points.each do |url|
+        post url
+        assert_equal 401, response.status
+      end
+      ActionController::Base.allow_forgery_protection = false
+    end
+
     it "should return 401 Unauthorized if no token is supplied" do
       end_points.each do |url|
         post url


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5142

## Purpose

Adds a test which temporarily turns on the forgery protection and verifies that the API still responds correctly (since AO3-5142 caused the API to return a 422 that resulted in a 404 on the remote site)

## Testing

This is just one automated test.
