### PR TITLE
AO3-5144 Add parent thread link for comments

### DIFF
--- a/app/views/comments/_comment_actions.html.erb
+++ b/app/views/comments/_comment_actions.html.erb
@@ -6,6 +6,11 @@
   <% end %>
   <% unless comment.unreviewed? %>
     <li><%= link_to ts("Thread"), comment %></li>
+    <% if comment.depth > 0 %>
+    <li>
+      <%= link_to ts("Parent Thread"), comment_url(id: comment.thread) %>
+    </li>
+    <% end %>
   <% end %>
   <% if is_author_of?(comment) && comment.count_all_comments == 0 %>
     <li id="edit_comment_link_<%= comment.id %>">

--- a/app/views/comments/_comment_actions.html.erb
+++ b/app/views/comments/_comment_actions.html.erb
@@ -7,9 +7,9 @@
   <% unless comment.unreviewed? %>
     <li><%= link_to ts("Thread"), comment %></li>
     <% if comment.depth > 0 %>
-    <li>
-      <%= link_to ts("Parent Thread"), comment_url(id: comment.thread) %>
-    </li>
+      <li>
+        <%= link_to ts("Parent Thread"), comment_path(id: comment.thread) %>
+      </li>
     <% end %>
   <% end %>
   <% if is_author_of?(comment) && comment.count_all_comments == 0 %>


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5144

## Purpose

Adds a 'parent thread' link to comments.

## Testing

Reply to comments, see that the link appears and takes you to the right place.