### PR TITLE
AO3-5145 Fix potential nil errors on posting prompt fills

### DIFF
--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -865,6 +865,10 @@ class WorksController < ApplicationController
 
     @chapter = @work.first_chapter
 
+    if params[:claim_id]
+      @posting_claim = ChallengeClaim.find_by(id: params[:claim_id])
+    end
+
     # If we're in preview mode, we want to pick up any changes that have been made to the first chapter
     if params[:work] && work_params[:chapter_attributes]
       @chapter.attributes = work_params[:chapter_attributes]

--- a/app/models/challenge_claim.rb
+++ b/app/models/challenge_claim.rb
@@ -153,7 +153,7 @@ class ChallengeClaim < ApplicationRecord
   end
 
   def prompt_description
-    request_prompt.try(:description) || ""
+    request_prompt&.description || ""
   end
 
 end

--- a/app/models/challenge_claim.rb
+++ b/app/models/challenge_claim.rb
@@ -152,4 +152,8 @@ class ChallengeClaim < ApplicationRecord
     (self.claiming_user == current_user) || self.collection.user_is_maintainer?(current_user)
   end
 
+  def prompt_description
+    request_prompt.try(:description) || ""
+  end
+
 end

--- a/app/views/works/_notes_form.html.erb
+++ b/app/views/works/_notes_form.html.erb
@@ -14,9 +14,8 @@
       </span>
       <fieldset id="front-notes-options" class="start">
         <legend><%= f.label :notes, ts("Notes") %></legend>
-        <% if !params[:claim_id].blank? %>
-        <% posting_claim = ChallengeClaim.find(params[:claim_id]) %>
-          <%= f.text_area :notes, :class => "observe_textlength", :value => "<strong>Prompt:</strong> " << posting_claim.request_prompt.description %>
+        <% if @posting_claim && @posting_claim.prompt_description.present? %>
+          <%= f.text_area :notes, :class => "observe_textlength", :value => "<strong>Prompt:</strong> #{@posting_claim.prompt_description}" %>
           <%= generate_countdown_html("#{type}_notes", ArchiveConfig.NOTES_MAX) %>
         <% else %>
           <%= f.text_area :notes, :class => "observe_textlength" %>


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5145

## Purpose

Fixes nil error when fulfilling a claim for a prompt with no description.

(Bonus round: don't make database calls from the view when avoidable)

## Testing

See issue