### PR TITLE
AO3-5147 Can't load site skins via rake task due to a period in the path

### DIFF
--- a/app/models/skin.rb
+++ b/app/models/skin.rb
@@ -271,7 +271,7 @@ class Skin < ApplicationRecord
 
   def get_css
     if filename
-      File.read(Rails.public_path.join("." + filename))
+      File.read(Rails.public_path.join(filename))
     else
       css
     end


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5147

## Purpose

Removes a period that seemed to be making bundle exec rake skins:load_site_skins fail with:

Errno::ENOENT: No such file or directory @ rb_sysopen - /home/ao3app/app/releases/20170903111536/public/.stylesheets/site/2.0/01-core.css


## Testing

Make sure the task runs and that you can change your site skin.