### PR TITLE
AO3-5153: Load header login form dynamically

### DIFF
--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -29,11 +29,11 @@
   <% if logged_in? || logged_in_as_admin? %>
     <%= render 'user_sessions/greeting' %>
   <% else %>
-    <div id="login" class="dropdown">
+    <div id="login">
       <p class="user actions" role="menu">
-        <%= link_to ts('Log In', key: 'header'), login_path, id: "login-dropdown" %>
+        <%= link_to ts('Log In', key: 'header'), login_path, remote: true, id: "login-dropdown" %>
       </p>
-      <%= render 'user_sessions/login' %>
+      <div id="small_login" class="simple login"></div>
     </div>
   <% end %>
 

--- a/app/views/user_sessions/_login.html.erb
+++ b/app/views/user_sessions/_login.html.erb
@@ -1,3 +1,0 @@
-<div id="small_login" class="simple login">
-	<%= render "user_sessions/passwd_small" %>
-</div>

--- a/app/views/user_sessions/_passwd.html.erb
+++ b/app/views/user_sessions/_passwd.html.erb
@@ -5,9 +5,9 @@
     <dd><%= f.text_field :login %></dd>
     <dt><%= f.label :password, ts("Password:")  %></dt>
     <dd><%= f.password_field :password %></dd>
-    <dt><%= f.label :remember_me, ts("Remember me")  %></dt>
+    <dt><%= f.label :remember_me, ts("Remember Me")  %></dt>
   	<dd><%= f.check_box :remember_me %></dd>
   	<dt class="landmark"><%= ts("Submit") %></dt>
-    <dd class="submit actions"><%= f.submit ts("Log in"), :class => 'submit' %></dd>
+    <dd class="submit actions"><%= f.submit ts("Log In"), :class => 'submit' %></dd>
   </dl>
 <% end %>

--- a/app/views/user_sessions/new.js.erb
+++ b/app/views/user_sessions/new.js.erb
@@ -1,0 +1,11 @@
+if ($j("#small_login form").length === 0) {
+  $j("#small_login").html(
+    "<%= escape_javascript(render :partial => "user_sessions/passwd_small") %>"
+  );
+  $j("#login-dropdown").text("Close");
+  $j("#small_login").show();
+} else {
+  $j("#small_login").html("");
+  $j("#login-dropdown").text("Log In");
+  $j("#small_login").hide();
+}

--- a/features/admins/admin_invitations.feature
+++ b/features/admins/admin_invitations.feature
@@ -1,4 +1,5 @@
 @admin
+@javascript
 Feature: Admin Actions to Manage Invitations
   In order to manage user account creation
   As an an admin
@@ -58,7 +59,8 @@ Feature: Admin Actions to Manage Invitations
     When I go to account creation page
     Then I should be on invite requests page
       And I should see "To create an account, you'll need an invitation. One option is to add your name to the automatic queue below."
-      And I should see "Forgot password? Get an Invitation" within "div#small_login"
+    When I follow "Log In"
+      Then I should see "Forgot password? Get an Invitation" within "div#small_login"
 
   Scenario: Account creation enabled, invitations not required, users can request invitations, and the queue is enabled
     Given I am logged in as an admin
@@ -104,7 +106,8 @@ Feature: Admin Actions to Manage Invitations
     When I go to account creation page
     Then I should be on the home page
       And I should see "Account creation currently requires an invitation. We are unable to give out additional invitations at present, but existing invitations can still be used to create an account."
-      And I should see "Forgot password?" within "div#small_login"
+    When I follow "Log In"
+      Then I should see "Forgot password?" within "div#small_login"
       And I should not see "Get an Invitation" within "div#small_login"
 
   Scenario: Account creation enabled, invitations not required, users cannot request invitations, and the queue is enabled
@@ -224,7 +227,8 @@ Feature: Admin Actions to Manage Invitations
     When I go to account creation page
     Then I should be on the home page
       And I should see "Account creation is suspended at the moment. Please check back with us later."
-      And I should see "Forgot password? Get an Invitation" within "div#small_login"
+    When I follow "Log In"
+      Then I should see "Forgot password? Get an Invitation" within "div#small_login"
 
   Scenario: Account creation disabled, invitations not required, users cannot request invitations, and the queue is disabled
     Given I am logged in as an admin

--- a/features/admins/authenticate_admins.feature
+++ b/features/admins/authenticate_admins.feature
@@ -1,4 +1,5 @@
 @admin
+@javascript
 Feature: Authenticate Admin Users
 
   Scenario: admin cannot log in as an ordinary user - it is a different type of account
@@ -6,6 +7,7 @@ Feature: Authenticate Admin Users
       | login       | password |
       | Zooey       | secret   |
   When I go to the home page
+      And I follow "Log In"
       And I fill in "user_session_login" with "Zooey"
       And I fill in "user_session_password" with "secret"
       And I press "Log In"

--- a/features/other_a/invite_queue.feature
+++ b/features/other_a/invite_queue.feature
@@ -1,4 +1,5 @@
 @admin
+@javascript
 Feature: Invite queue management
 
   Background:
@@ -31,6 +32,7 @@ Feature: Invite queue management
       And I press "Update"
     When I am logged out as an admin
       And I am on the homepage
+      And I follow "Log In"
     Then I should see "Get an Invitation"
     When I follow "Get an Invitation"
     Then I should see "Request an Invitation"
@@ -52,6 +54,7 @@ Feature: Invite queue management
       And the invitation queue is enabled
     When I am on the homepage
       And all emails have been delivered
+      And I follow "Log In"
       And I follow "Get an Invitation"
     Then I should see "We are sending out 10 invitations per day."
     When I fill in "invite_request_email" with "test@archiveofourown.org"
@@ -60,8 +63,7 @@ Feature: Invite queue management
 
     # check your place in the queue - invalid address
     When I check how long "testttt@archiveofourown.org" will have to wait in the invite request queue
-    Then I should see "You can search for the email address you signed up with below."
-      And I should see "If you can't find it, your invitation may have already been emailed to that address; please check your email Spam folder as your spam filters may have placed it there."
+    Then I should see "Sorry, we can't find the email address you entered"
       And I should not see "You are currently number"
 
     # check your place in the queue - correct address
@@ -92,18 +94,19 @@ Feature: Invite queue management
       And the invite_from_queue_at is yesterday
     When I am on the homepage
       And all emails have been delivered
+      And I follow "Log In"
       And I follow "Get an Invitation"
     When I fill in "invite_request_email" with "test@archiveofourown.org"
       And I press "Add me to the list"
       And the check_queue rake task is run
     Then 1 email should be delivered to test@archiveofourown.org
     When I check how long "test@archiveofourown.org" will have to wait in the invite request queue
-    Then I should see "You can search for the email address you signed up with below."
-      And I should see "If you can't find it, your invitation may have already been emailed to that address;"
+    Then I should see "Sorry, we can't find the email address you entered"
 
     # invite can be used
     When I am logged in as an admin
       And I follow "Invitations"
+      And I follow "Invite New Users"
       And I fill in "track_invitation_invitee_email" with "test@archiveofourown.org"
       And I press "Go"
     Then I should see "Sender queue"
@@ -146,6 +149,7 @@ Feature: Invite queue management
       | login | password    | email            |
       | fred  | yabadabadoo | fred@bedrock.com |
     When I am on the homepage
+      And I follow "Log In"
       And I follow "Get an Invitation"
       And I fill in "invite_request_email" with "fred@bedrock.com"
       And I press "Add me to the list"

--- a/features/users/authenticate_users.feature
+++ b/features/users/authenticate_users.feature
@@ -1,5 +1,6 @@
 @users
 @admin
+@javascript
 Feature: User Authentication
 
   Scenario: Forgot password
@@ -9,6 +10,7 @@ Feature: User Authentication
       | sam      | secret   |
       And all emails have been delivered
     When I am on the home page
+      And I follow "Log In"
       And I fill in "User name" with "sam"
       And I fill in "Password" with "test"
       And I press "Log In"
@@ -25,6 +27,7 @@ Feature: User Authentication
 
     # old password should still work
     When I am on the homepage
+    And I follow "Log In"
     And I fill in "User name" with "sam"
     And I fill in "Password" with "secret"
     And I press "Log In"
@@ -32,6 +35,7 @@ Feature: User Authentication
 
     # password from email should also work
     When I am logged out
+    And I follow "Log In"
     And I fill in "User name" with "sam"
     And I fill in "sam"'s temporary password
     And I press "Log In"
@@ -47,6 +51,7 @@ Feature: User Authentication
     # old password should no longer work
     When I am logged out
     When I am on the homepage
+    And I follow "Log In"
     And I fill in "User name" with "sam"
     And I fill in "Password" with "secret"
     And I press "Log In"
@@ -55,6 +60,7 @@ Feature: User Authentication
     # generated password should no longer work
     When I am logged out
     When I am on the homepage
+    And I follow "Log In"
     And I fill in "User name" with "sam"
     And I fill in "sam"'s temporary password
     And I press "Log In"
@@ -63,6 +69,7 @@ Feature: User Authentication
     # new password should work
     When I am logged out
     When I am on the homepage
+    And I follow "Log In"
     And I fill in "User name" with "sam"
     And I fill in "Password" with "newpass"
     And I press "Log In"
@@ -71,6 +78,7 @@ Feature: User Authentication
   Scenario: invalid user
     Given I have loaded the fixtures
     When I am on the home page
+    And I follow "Log In"
     And I follow "Forgot password?"
     When I fill in "reset_password_for" with "testuser"
       And I press "Reset Password"
@@ -78,7 +86,9 @@ Feature: User Authentication
       And 1 email should be delivered
 
     # password from email should work
-    When I fill in "User name" with "testuser"
+    When I am on the home page
+    And I follow "Log In"
+    And I fill in "User name" with "testuser"
     And I fill in "testuser"'s temporary password
     And I press "Log In"
     Then I should see "Hi, testuser"
@@ -93,6 +103,7 @@ Feature: User Authentication
     # new password should work
     When I am logged out
     When I am on the homepage
+    And I follow "Log In"
     And I fill in "User name" with "testuser"
     And I fill in "Password" with "newpas"
     And I press "Log In"
@@ -105,6 +116,7 @@ Feature: User Authentication
       | sam      | secret   |
       And all emails have been delivered
     When I am on the home page
+      And I follow "Log In"
       And I fill in "User name" with "sammy"
       And I fill in "Password" with "test"
       And I press "Log In"
@@ -117,6 +129,7 @@ Feature: User Authentication
       | sam      | secret   |
       And all emails have been delivered
     When I am on the home page
+      And I follow "Log In"
       And I fill in "User name" with "sam"
       And I fill in "Password" with "tester"
       And I press "Log In"

--- a/public/stylesheets/site/2.0/03-region-header.css
+++ b/public/stylesheets/site/2.0/03-region-header.css
@@ -223,9 +223,12 @@ notice that CSS3 declarations sit are indented twice (four spaces) and always co
   padding: 0 0.25em;
 }
 
-.dropdown #small_login .footnote a {
-  background: transparent;
+#small_login .footnote a {
   border-bottom: 1px solid;
+}
+
+#small_login .footnote a:hover, #small_login .footnote a:focus {
+  background: transparent;
 }
 
 /* primary navigation */

--- a/spec/requests/comments_spec.rb
+++ b/spec/requests/comments_spec.rb
@@ -99,12 +99,10 @@ describe "Comments" do
     before do
       @user = create(:user)
       visit login_path
-      within("div#small_login") do
-        fill_in "User name:",with: "#{@user.login}" ,  exact: true
-        fill_in "Password", with: "password"
-        check "Remember Me"
-        click_button "Log In"
-      end
+      fill_in "User name:", with: "#{@user.login}"
+      fill_in "Password", with: "password"
+      check "Remember Me"
+      click_button "Log In"
     end
 
     it_behaves_like "on unrestricted works" do


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5153

## Purpose

Loads header login form with javascript to avoid form caching issues

## Testing

Form should load when you click the link and go away when you click 'Close' and take you to the full-page login form when you don't have js enabled.