### PR TITLE
AO3-5155: Skip default before_actions for non-html requests

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -466,7 +466,7 @@ public
                       :set_redirects,
                       :set_media,
                       :store_location,
-                      unless: proc {|c| request.format == 'html' }
+                      unless: proc { %w(js json).include?(request.format) }
 
   #### -- AUTHORIZATION -- ####
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -460,6 +460,14 @@ public
     !param.blank? && ['asc', 'desc'].include?(param.to_s.downcase)
   end
 
+  # Don't get unnecessary data for json requests
+  skip_before_action  :fetch_admin_settings,
+                      :load_admin_banner,
+                      :set_redirects,
+                      :set_media,
+                      :store_location,
+                      unless: proc {|c| request.format == 'html' }
+
   #### -- AUTHORIZATION -- ####
 
   protect_from_forgery with: :exception, prepend: true

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -466,7 +466,7 @@ public
                       :set_redirects,
                       :set_media,
                       :store_location,
-                      unless: proc { %w(js json).include?(request.format) }
+                      if: proc { %w(js json).include?(request.format) }
 
   #### -- AUTHORIZATION -- ####
 


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5155
## Purpose

Skips loading page-related data for non-html requests that don't need it.

## Testing

See issue.