### PR TITLE
AO3-5156 Fix misplaced loop end in Tag.add_filter_taggings.

### DIFF
--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -810,14 +810,14 @@ class Tag < ApplicationRecord
           end
         end
       end
+    end
 
-      # make sure that all the works and bookmarks under this tag get reindexed
-      # for filtering/searching
-      async(:reindex_taggables)
+    # make sure that all the works and bookmarks under this tag get reindexed
+    # for filtering/searching
+    async(:reindex_taggables)
 
-      tags_that_need_filter_count_reset.each do |tag_to_reset|
-        tag_to_reset.reset_filter_count
-      end
+    tags_that_need_filter_count_reset.each do |tag_to_reset|
+      tag_to_reset.reset_filter_count
     end
   end
 


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5156

## Purpose

The end of the self.works loop in Tag.add_filter_taggings was misplaced, meaning that Tag.reindex_taggables and Tag.reset_filter_count are currently called once for each work in the tag, instead of being called once after all of the filter-taggings have been modified. This meant that the time required to make a new tag canonical is quadratic in the number of works, rather than linear (as it should be).

The purpose of this pull request is to move the end of the loop to the correct place, and hopefully reduce the runtime of Tag.add_filter_taggings.

## Testing

Since this primarily affects runtime rather than functionality, there's not much to test. But it would be good to make sure that marking a tag as canonical still works as expected (i.e. the works show up in the tag).