### PR TITLE
AO3-5159 Fix broken pdf downloads by adding flag to disable javascript

### DIFF
--- a/app/controllers/downloads_controller.rb
+++ b/app/controllers/downloads_controller.rb
@@ -61,7 +61,7 @@ protected
     # convert to PDF
     # title needs to be escaped
     title = Shellwords.escape(@work.title)
-    cmd = %Q{cd "#{@work.download_dir}"; wkhtmltopdf --encoding utf-8 --title #{title} "#{@work.download_title}.html" "#{@work.download_title}.pdf"}
+    cmd = %Q{cd "#{@work.download_dir}"; wkhtmltopdf --encoding utf-8 --disable-javascript --title #{title} "#{@work.download_title}.html" "#{@work.download_title}.pdf"}
     Rails.logger.debug cmd
     `#{cmd} 2> /dev/null`
 


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5159

## Purpose

Fixes issues with some pdf downloads erroring because of a wkhtmltopdf issue.

## Testing

PDFs should generate correctly for all works.