### PR TITLE
AO3-5160: Add auth error page

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,8 @@
 PROFILER_SESSIONS_FILE = 'used_tags.txt'
 
 class ApplicationController < ActionController::Base
+  protect_from_forgery with: :exception, prepend: true
+  rescue_from ActionController::InvalidAuthenticityToken, with: :display_auth_error
 
   helper :all # include all helpers, all the time
 
@@ -17,6 +19,10 @@ class ApplicationController < ActionController::Base
     sanitize_params(params.to_unsafe_h).each do |key, value|
       params[key] = transform_sanitized_hash_to_ac_params(key, value)
     end
+  end
+
+  def display_auth_error
+    redirect_to '/auth_error'
   end
 
   def transform_sanitized_hash_to_ac_params(key, value)
@@ -467,9 +473,5 @@ public
                       :set_media,
                       :store_location,
                       if: proc { %w(js json).include?(request.format) }
-
-  #### -- AUTHORIZATION -- ####
-
-  protect_from_forgery with: :exception, prepend: true
 
 end

--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -8,5 +8,8 @@ class ErrorsController < ApplicationController
       end
     end
   end
+
+  def auth_error
+  end
   
 end

--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -1,17 +1,8 @@
 class UserSessionsController < ApplicationController
 
-  # I hope this isn't catching unwanted exceptions; it's hard to locate
-  # where exactly the exception is thrown in case of no cookies. --rebecca
-  rescue_from ActionController::InvalidAuthenticityToken, with: :show_auth_error
-
   layout "session"
   before_action :admin_logout_required
   skip_before_action :store_location
-
-
-  def show_auth_error
-    redirect_to "/auth_error.html"
-  end
 
   def new
   end

--- a/app/views/errors/auth_error.html.erb
+++ b/app/views/errors/auth_error.html.erb
@@ -1,2 +1,2 @@
 <h2 class="heading">Session Expired</h2>
-<p>Your current session has expired and we can't authenticate your request. Try logging in again, refreshing the page, or clearing your cache if you continue to experience problems.</p>
+<p>Your current session has expired and we can't authenticate your request. Try logging in again, refreshing the page, or <a href="http://kb.iu.edu/data/ahic.html">clearing your cache</a> if you continue to experience problems.</p>

--- a/app/views/errors/auth_error.html.erb
+++ b/app/views/errors/auth_error.html.erb
@@ -1,0 +1,2 @@
+<h2 class="heading">Session Expired</h2>
+<p>Your current session has expired and we can't authenticate your request. Try logging in again, refreshing the page, or clearing your cache if you continue to experience problems.</p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,6 +15,7 @@ Otwarchive::Application.routes.draw do
   get '/404', to: 'errors#404'
   get '/422', to: 'errors#422'
   get '/500', to: 'errors#500'
+  get '/auth_error', to: 'errors#auth_error'
 
   #### DOWNLOADS ####
 


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5160

## Purpose

Adds a new error page to handle Invalid Authenticity Token errors, to give users some context for the problem they're running into.

## Testing

See issue.