### PR TITLE
AO3-5163: Revert work complete-setting method to old code

### DIFF
--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -792,10 +792,13 @@ class Work < ApplicationRecord
   end
 
   after_save :update_complete_status
+  # Note: this can mark a work complete but it can also mark a complete work
+  # as incomplete if its status has changed
   def update_complete_status
     # self.chapters.posted.count ( not self.number_of_posted_chapter , here be dragons )
-    if self.chapters.posted.count == expected_number_of_chapters
-      Work.where("id = #{self.id}").update_all("complete = true")
+    self.complete = self.chapters.posted.count == expected_number_of_chapters
+    if self.complete_changed?
+      Work.where("id = #{self.id}").update_all("complete = #{self.complete}")
     end
   end
 

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -797,7 +797,7 @@ class Work < ApplicationRecord
   def update_complete_status
     # self.chapters.posted.count ( not self.number_of_posted_chapter , here be dragons )
     self.complete = self.chapters.posted.count == expected_number_of_chapters
-    if self.complete_changed?
+    if self.will_save_change_to_attribute?(:complete)
       Work.where("id = #{self.id}").update_all("complete = #{self.complete}")
     end
   end

--- a/spec/models/work_spec.rb
+++ b/spec/models/work_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe Work do
   # see lib/collectible_spec for collection-related tests
 
-  it "creates a minimally work" do
+  it "creates a minimal work" do
     expect(create(:work)).to be_valid
   end
 
@@ -204,6 +204,19 @@ describe Work do
       expect(Work.find_by_url(url)).to eq(work)
       expect(Rails.cache.read(Work.find_by_url_cache_key(url))).to eq(work)
       work.destroy
+    end
+  end
+
+  describe "#update_complete_status" do
+    it "marks a work complete when it's been completed" do
+      work = create(:posted_work, expected_number_of_chapters: 1)
+      expect(work.complete).to be_truthy
+    end
+
+    it "marks a work incomplete when it's no longer completed" do
+      work = create(:posted_work, expected_number_of_chapters: 1)
+      work.update_attributes!(expected_number_of_chapters: nil)
+      expect(work.reload.complete).to be_falsey
     end
   end
 end


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5163

## Purpose

Reverts work complete-setting method to old code to fix bug where works going from complete to incomplete didn't have their status updated.

## Testing

See issue.