### PR TITLE
AO3-5164: Ensure admin settings are loaded for invites js request

### DIFF
--- a/app/controllers/invite_requests_controller.rb
+++ b/app/controllers/invite_requests_controller.rb
@@ -8,6 +8,7 @@ class InviteRequestsController < ApplicationController
 
   # GET /invite_requests/1
   def show
+    fetch_admin_settings # we normally skip this for js requests
     @invite_request = InviteRequest.find_by(email: params[:email])
     unless (request.xml_http_request?) || @invite_request
       flash[:error] = "You can search for the email address you signed up with below. If you can't find it, your invitation may have already been emailed to that address; please check your email Spam folder as your spam filters may have placed it there."


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5164

## Purpose

Fixes broken lookup form for invites when javascript is enabled.

## Testing

Go to /invite_requests, add an email, and then look it up - the lookup should work and return the appropriate message.