### PR TITLE
AO3-5042 Use _url for absolute links in bylines and download afterword

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -149,7 +149,7 @@ module ApplicationHelper
     if only_path
       link_to(pseud.byline, user_pseud_path(pseud.user, pseud), rel: "author")
     else
-      link_to(pseud.byline, user_pseud_path(pseud.user, pseud, only_path: false), rel: "author")
+      link_to(pseud.byline, user_pseud_url(pseud.user, pseud), rel: "author")
     end
   end
 

--- a/app/views/downloads/_download_afterword.html.erb
+++ b/app/views/downloads/_download_afterword.html.erb
@@ -20,4 +20,4 @@
   </div>
 <% end %>
 
-<p class="message"><%= ts("Please") %> <%= link_to ts("drop by the archive and comment"), new_work_comment_path(@work, :only_path => false) %> <%= ts("to let the author know if you enjoyed their work!") %></p>
+<p class="message"><%= ts("Please") %> <%= link_to ts("drop by the archive and comment"), new_work_comment_url(@work) %> <%= ts("to let the author know if you enjoyed their work!") %></p>


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5042

## Purpose

This changes byline and comment links in download files to use absolute, rather than relative URLs.

## Testing

STR are in the issue, but I found these simpler ones:

1. Log in
2. Post > New Work
3. Fill in required information
4. Post Without Preview
5. Download > HTML
6. Open the downloaded file

Expected: the byline link in the preface and the "drop by the archive and comment" link in the afterword should be absolute.
Actual: those links are relative, so they have hrefs of `file://...` and are broken when viewing the downloaded file locally.