### PR TITLE
AO3-5044 Update warning about changing username

### DIFF
--- a/app/views/users/change_username.html.erb
+++ b/app/views/users/change_username.html.erb
@@ -3,8 +3,8 @@
 <%= error_messages_for :user %>
 <p class="caution">
   <%= ts("Please use this feature with caution. For information on how changing your user name will affect your account, please check out the %{account_faq}. Note that changes to your username may take several days or longer to appear. If you are still seeing your old user name on your works, bookmarks, series, and collections after a week, please %{contact_support}.",
-  account_faq: (link_to ts('Account FAQ'), archive_faqs_path + "/your-account#namechange"),
-  contact_support: (link_to ts('contact Support'), new_feedback_report_path)
+  account_faq: (link_to ts("Account FAQ"), archive_faqs_path + "/your-account#namechange"),
+  contact_support: (link_to ts("contact Support"), new_feedback_report_path)
   ).html_safe %>
 </p>
 <p class="note">

--- a/app/views/users/change_username.html.erb
+++ b/app/views/users/change_username.html.erb
@@ -2,7 +2,10 @@
 <h2 class="heading"><%= ts("Change My User Name") %></h2>
 <%= error_messages_for :user %>
 <p class="caution">
-  <%= ts("Please use this feature with caution. We will not redirect your old user name to your new one. Bookmarks and external links to your user page and your pseud pages under the old name will no longer work and the old name may be used by someone else unless all you are changing is capitalization.") %>
+  <%= ts("Please use this feature with caution. For information on how changing your user name will affect your account, please check out the %{account_faq}. Note that changes to your username may take several days or longer to appear. If you are still seeing your old user name on your works, bookmarks, series, and collections after a week, please %{contact_support}.",
+  account_faq: (link_to ts('Account FAQ'), archive_faqs_path + "/your-account#namechange"),
+  contact_support: (link_to ts('contact Support'), new_feedback_report_path)
+  ).html_safe %>
 </p>
 <p class="note">
   <%= ts("If that is not what you want, you can <a href=\"#{new_user_pseud_path(@user)}\">create a new Pseud</a> instead.").html_safe %>


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5044

## Purpose

Update the warning note shown when changing username. 

## Testing

Visit `/users/testy/change_username` (replace `testy`) and check that the warning note copy matches what's in the issue. Check that the links are correct.