### PR TITLE
AO3-5167 Improve performance of author checks

### DIFF
--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -1,7 +1,13 @@
 module UsersHelper
   # Can be used to check ownership of items
   def is_author_of?(item)
-    current_user.is_a?(User) ? current_user.is_author_of?(item) : false
+    if @own_bookmarks && item.is_a?(Bookmark)
+      @own_bookmarks.include?(item)
+    elsif @own_works && item.is_a?(Work)
+      @own_works.include?(item)
+    else
+      current_user.is_a?(User) && current_user.is_author_of?(item)
+    end
   end
 
   # Can be used to check if user is maintainer of any collections

--- a/app/models/collection_item.rb
+++ b/app/models/collection_item.rb
@@ -149,7 +149,7 @@ class CollectionItem < ApplicationRecord
         when "Work"
           users = item.users || [User.current_user] # if the work has no users, it is also new and being created by the current user
         when "Bookmark"
-          users = [item.user] || [User.current_user]
+          users = [item.pseud.user] || [User.current_user]
         end
 
         users.each do |user|

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -351,12 +351,12 @@
 
   # Checks authorship of any sort of object
   def is_author_of?(item)
-    if item.respond_to?(:user)
-      self == item.user
-    elsif item.respond_to?(:pseud)
-      self.pseuds.include?(item.pseud)
+    if item.respond_to?(:user_id)
+      self.id == item.user_id
+    elsif item.respond_to?(:pseud_id)
+      self.pseuds.pluck(:id).include?(item.pseud_id)
     elsif item.respond_to?(:pseuds)
-      !(self.pseuds & item.pseuds).empty?
+      !(self.pseuds.pluck(:id) & item.pseuds.pluck(:id)).empty?
     elsif item.respond_to?(:author)
       self == item.author
     else

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -351,10 +351,10 @@
 
   # Checks authorship of any sort of object
   def is_author_of?(item)
-    if item.respond_to?(:user_id)
-      self.id == item.user_id
-    elsif item.respond_to?(:pseud_id)
+    if item.respond_to?(:pseud_id)
       self.pseuds.pluck(:id).include?(item.pseud_id)
+    elsif item.respond_to?(:user_id)
+      self.id == item.user_id
     elsif item.respond_to?(:pseuds)
       !(self.pseuds.pluck(:id) & item.pseuds.pluck(:id)).empty?
     elsif item.respond_to?(:author)


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5167

## Purpose

Switches is_author_of? method to compare based on ids rather than objects, which should save on some db calls and memory. Also preloads the set of current works/bookmarks owned by the current user on index pages so that we don't have to run separate checks over and over.

## Testing

Nothing should change: appropriate footers for work and bookmark blurbs should appear if they're yours, and anonymity should be respected.