### PR TITLE
AO3-5169: Improve auth error handling for kudos

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -22,7 +22,18 @@ class ApplicationController < ActionController::Base
   end
 
   def display_auth_error
-    redirect_to '/auth_error'
+    respond_to do |format|
+      format.html do
+        redirect_to auth_error_path
+      end
+      format.js do
+        render json: {
+          errors: {
+            auth_error: "Your current session has expired and we can't authenticate your request. Try logging in again, refreshing the page, or <a href='http://kb.iu.edu/data/ahic.html'>clearing your cache</a> if you continue to experience problems.".html_safe
+          }
+        }, status: :unprocessable_entity
+      end
+    end
   end
 
   def transform_sanitized_hash_to_ac_params(key, value)

--- a/public/javascripts/application.js
+++ b/public/javascripts/application.js
@@ -454,18 +454,18 @@ $j(document).ready(function() {
         var msg = 'Sorry, we were unable to save your kudos';
         var data = $j.parseJSON(jqXHR.responseText);
 
-        if (data.errors && (data.errors.pseud_id || data.errors.ip_address)) {
-          msg = "You have already left kudos here. :)";
+        if (data.errors) {
+          if (data.errors.pseud_id || data.errors.ip_address) {
+            msg = "You have already left kudos here. :)";
+          } else if (data.errors.cannot_be_author) {
+            msg = "You can't leave kudos on your own work.";
+          } else if (data.errors.guest_on_restricted) {
+            msg = "You can't leave guest kudos on a restricted work.";
+          } else if (data.errors.auth_error) {
+            msg = data.errors.auth_error;
+          }
         }
-
-        if (data.errors && data.errors.cannot_be_author) {
-          msg = "You can't leave kudos on your own work.";
-        }
-        if (data.errors && data.errors.guest_on_restricted) {
-          msg = "You can't leave guest kudos on a restricted work.";
-        }
-
-        $j('#kudos_message').addClass('comment_error').text(msg);
+        $j('#kudos_message').addClass('comment_error').html(msg);
       },
       success: function(data) {
         $j('#kudos_message').addClass('notice').text('Thank you for leaving kudos!');


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5169

## Purpose

Displays auth error message when attempting to submit kudos instead of doing nothing and only having a console error.

## Testing

See issue.