### PR TITLE
AO3-5176: Add more indexes to tag nominations

### DIFF
--- a/db/migrate/20170919143944_add_indexes_to_nominations.rb
+++ b/db/migrate/20170919143944_add_indexes_to_nominations.rb
@@ -1,0 +1,7 @@
+class AddIndexesToNominations < ActiveRecord::Migration[5.1]
+  def change
+    add_index :tag_nominations, [:type, :fandom_nomination_id]
+    add_index :tag_nominations, [:type, :synonym]
+    add_index :tag_nominations, [:type, :tagname]
+  end
+end


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5176

## Purpose

Add more indexes to tag nominations table for slow queries

## Testing

Things should not blow up and should ideally run a bit faster