### PR TITLE
A03-5042 Add only_path:false to byline calls in download partials

### DIFF
--- a/app/views/downloads/_download_afterword.html.erb
+++ b/app/views/downloads/_download_afterword.html.erb
@@ -11,8 +11,8 @@
       <dl>
         <dt><%= ts('Works inspired by this one') %></dt>
         <dd>
-          <%= @work.approved_related_works.where(:translation => false).map{|rw| 
-"#{link_to(rw.work.title.html_safe, work_url(rw.work))} #{ts('by')} #{byline(rw.work)}"}.join(", 
+          <%= @work.approved_related_works.where(:translation => false).map{|rw|
+"#{link_to(rw.work.title.html_safe, work_url(rw.work))} #{ts('by')} #{byline(rw.work, only_path: false)}"}.join(",
 ").html_safe %>
         </dd>
       </dl>

--- a/app/views/downloads/_download_chapter.html.erb
+++ b/app/views/downloads/_download_chapter.html.erb
@@ -5,7 +5,7 @@
     <% unless @mobi %><h2 class="heading"><%= @chapter.chapter_title.html_safe %></h2><% end %>
     <% if (!@chapter.pseuds.blank? && (@chapter.pseuds != @work.pseuds) && (!@work.anonymous?)) %>
       <%# only display byline if different from the main byline %>
-      <p class="byline"><%= ts('Chapter by') %> <%= byline(@chapter) %></p>
+      <p class="byline"><%= ts('Chapter by') %> <%= byline(@chapter, only_path: false) %></p>
     <% end %>
 
     <% unless @chapter.summary.blank? %>

--- a/app/views/downloads/_download_preface.html.erb
+++ b/app/views/downloads/_download_preface.html.erb
@@ -61,7 +61,7 @@ hide_freeform?(@work)) %>
         <% parent_work_list = @work.parent_work_relationships.reject{ |wr| wr.parent.nil? } %>
         <%= parent_work_list.map{ |rw| "#{link_to(rw.parent.title,
                url_for(action: :show, controller: rw.parent_type.underscore.pluralize, id: rw.parent_id,
-                       only_path: false)) } #{ts('by')} #{byline(rw.parent)}" }.join(", ").html_safe %>
+                       only_path: false)) } #{ts('by')} #{byline(rw.parent, only_path: false)}" }.join(", ").html_safe %>
       </dd>
     </dl>
   <% end %>


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5042

## Purpose

This changes three more byline instances in chapter partials to use `only_path: false`, in order to make absolute rather than relative links.

## Testing

STR for chapter bylines are in the issue. I believe they would be similar for the other instances, except you'd need related works and a parent work.