### PR TITLE
AO3-5183 Index preferences on skin_id

### DIFF
--- a/db/migrate/20170922234741_add_index_to_preferences.rb
+++ b/db/migrate/20170922234741_add_index_to_preferences.rb
@@ -1,0 +1,5 @@
+class AddIndexToPreferences < ActiveRecord::Migration[5.1]
+  def change
+    add_index :preferences, :skin_id
+  end
+end


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5183

## Purpose

Adds an index to the preferences table in hopes that it will speed up the approved skins page enough for us to access it again.

## Testing

Can't really be tested