### PR TITLE
AO3-5044 Change 'and' to 'or' in note about changing your username

### DIFF
--- a/app/views/users/change_username.html.erb
+++ b/app/views/users/change_username.html.erb
@@ -2,7 +2,7 @@
 <h2 class="heading"><%= ts("Change My User Name") %></h2>
 <%= error_messages_for :user %>
 <p class="caution">
-  <%= ts("Please use this feature with caution. For information on how changing your user name will affect your account, please check out the %{account_faq}. Note that changes to your username may take several days or longer to appear. If you are still seeing your old user name on your works, bookmarks, series, and collections after a week, please %{contact_support}.",
+  <%= ts("Please use this feature with caution. For information on how changing your user name will affect your account, please check out the %{account_faq}. Note that changes to your username may take several days or longer to appear. If you are still seeing your old user name on your works, bookmarks, series, or collections after a week, please %{contact_support}.",
   account_faq: (link_to ts("Account FAQ"), archive_faqs_path + "/your-account#namechange"),
   contact_support: (link_to ts("contact Support"), new_feedback_report_path)
   ).html_safe %>


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5044

## Purpose

Tweak wording in change username warning copy.

## Testing

See issue - this PR changes "and" to "or" only.