### PR TITLE
AO3-5086 Update Spotify subdomain for embeds

### DIFF
--- a/config/initializers/gem-plugin_config/sanitizer_config.rb
+++ b/config/initializers/gem-plugin_config/sanitizer_config.rb
@@ -106,7 +106,7 @@ class Sanitize
         then "archiveofourown"
       when /^podfic\.com\//
         then "podfic"
-      when /^(embed\.)?spotify\.com\//
+      when /^(open\.)?spotify\.com\//
         then "spotify"
       when /^8tracks\.com\//
         then "8tracks"

--- a/spec/lib/html_cleaner_spec.rb
+++ b/spec/lib/html_cleaner_spec.rb
@@ -207,7 +207,7 @@ describe HtmlCleaner do
 
       %w{youtube.com youtube-nocookie.com vimeo.com player.vimeo.com static.ning.com ning.com dailymotion.com
          metacafe.com vidders.net criticalcommons.org google.com archiveofourown.org podfic.com archive.org
-         embed.spotify.com spotify.com 8tracks.com w.soundcloud.com soundcloud.com viddertube.com}.each do |source|
+         open.spotify.com spotify.com 8tracks.com w.soundcloud.com soundcloud.com viddertube.com}.each do |source|
 
         it "should allow embeds from #{source}" do
           html = '<iframe width="560" height="315" src="//' + source + '/embed/123" frameborder="0"></iframe>'


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5086

## Purpose

Allow embeds from the open subdomain for Spotify. According to the issue, we no longer need to support the old embed subdomain. 

## Testing

See issue