### PR TITLE
AO3-4138 make reading history more linguistically accessible

### DIFF
--- a/app/views/readings/_reading_blurb.html.erb
+++ b/app/views/readings/_reading_blurb.html.erb
@@ -12,11 +12,11 @@
 
       <% if reading.work.nil? %>
 
-        <%= ts('(Deleted work, last viewed %{date})', :date => set_format_for_date(reading.last_viewed)) %>
+        <%= ts('(Deleted work, last visited %{date})', :date => set_format_for_date(reading.last_viewed)) %>
 
       <% else %>
 
-        <span><%= ts('Last viewed:') %></span> <%= set_format_for_date(reading.last_viewed) %>
+        <span><%= ts('Last visited:') %></span> <%= set_format_for_date(reading.last_viewed) %>
 
         <% if reading.major_version_read != reading.work.major_version %>
           <%= ts('(Update available.)') %>
@@ -27,9 +27,9 @@
         <% end %>
 
         <% if reading.view_count == 1 %>
-          <%= ts('Viewed once') %>
+          <%= ts('Visited once') %>
         <% else %>
-          <%= ts('Viewed %{count} times', :count => reading.view_count) %>
+          <%= ts('Visited %{count} times', :count => reading.view_count) %>
         <% end %>
 
         <% if reading.toread? %>

--- a/app/views/readings/_reading_blurb.html.erb
+++ b/app/views/readings/_reading_blurb.html.erb
@@ -12,7 +12,7 @@
 
       <% if reading.work.nil? %>
 
-        <%= ts('(Deleted work, last visited %{date})', :date => set_format_for_date(reading.last_viewed)) %>
+        <%= ts('(Deleted work, last visited %{date})', date: set_format_for_date(reading.last_viewed)) %>
 
       <% else %>
 

--- a/app/views/readings/_reading_blurb.html.erb
+++ b/app/views/readings/_reading_blurb.html.erb
@@ -3,7 +3,7 @@
 
   <% unless reading.work.nil? %>
 
-    <%= render 'works/work_module', :work => reading.work %>
+    <%= render 'works/work_module', work: reading.work %>
 
   <% end %>
 
@@ -29,7 +29,7 @@
         <% if reading.view_count == 1 %>
           <%= ts('Visited once') %>
         <% else %>
-          <%= ts('Visited %{count} times', :count => reading.view_count) %>
+          <%= ts('Visited %{count} times', count: reading.view_count) %>
         <% end %>
 
         <% if reading.toread? %>

--- a/features/other_a/reading.feature
+++ b/features/other_a/reading.feature
@@ -11,7 +11,7 @@ Feature: Reading count
     And I should not see "History" within "div#dashboard"
   When I go to second_reader's reading page
     Then I should see "History" within "div#dashboard"
-    
+
   Scenario: Read a work several times, counts show on reading history
       increment the count whenever you reread a story
       also updates the date
@@ -22,14 +22,14 @@ Feature: Reading count
       And fandomer first read "some work" on "2010-05-25"
     When I go to fandomer's reading page
     Then I should see "some work"
-      And I should see "Viewed once"
-      And I should see "Last viewed: 25 May 2010"
+      And I should see "Visited once"
+      And I should see "Last visited: 25 May 2010"
     When I am on writer's works page
       And I follow "some work"
     When the reading rake task is run
       And I go to fandomer's reading page
-    Then I should see "Viewed 2 times"
-      And I should see "Last viewed: less than 1 minute ago"
+    Then I should see "Visited 2 times"
+      And I should see "Last visited: less than 1 minute ago"
 
   Scenario: disable reading history
     then re-enable and check counts update again
@@ -41,8 +41,8 @@ Feature: Reading count
       And fandomer first read "some work" on "2010-05-25"
     When I go to fandomer's reading page
     Then I should see "some work"
-      And I should see "Viewed once"
-      And I should see "Last viewed: 25 May 2010"    
+      And I should see "Visited once"
+      And I should see "Last visited: 25 May 2010"
     When I follow "Preferences"
       And I uncheck "Turn on Viewing History"
       And I press "Update"
@@ -59,14 +59,14 @@ Feature: Reading count
       And I press "Update"
     Then I should see "Your preferences were successfully updated."
     When I go to fandomer's reading page
-    Then I should see "Viewed once"
-      And I should see "Last viewed: 25 May 2010"
+    Then I should see "Visited once"
+      And I should see "Last visited: 25 May 2010"
     When I am on writer's works page
       And I follow "some work"
     When the reading rake task is run
       And I go to fandomer's reading page
-    Then I should see "Viewed 2 times"
-      And I should see "Last viewed: less than 1 minute ago"
+    Then I should see "Visited 2 times"
+      And I should see "Last visited: less than 1 minute ago"
 
   Scenario: Clear entire reading history
 
@@ -142,21 +142,21 @@ Feature: Reading count
   When the reading rake task is run
     And I go to fandomer's reading page
   Then I should see "multichapter work"
-    And I should see "Viewed once"
+    And I should see "Visited once"
   When I press "Delete from History"
   Then I should see "Work successfully deleted from your history."
   When I view the work "multichapter work"
     And the reading rake task is run
   When I go to fandomer's reading page
   Then I should see "multichapter work"
-    And I should see "Viewed once"
+    And I should see "Visited once"
   When I view the work "multichapter work"
     And I follow "Next Chapter"
     And the reading rake task is run
   When I go to fandomer's reading page
   Then I should see "multichapter work"
   When "AO3-5073" is fixed
-    # And I should see "Viewed 3 times"
+    # And I should see "Visited 3 times"
   When I view the work "multichapter work"
     And I follow "Next Chapter"
   When I follow "Mark for Later"
@@ -164,7 +164,7 @@ Feature: Reading count
     And I go to fandomer's reading page
   Then I should see "multichapter work"
   When "AO3-5073" is fixed
-    # And I should see "Viewed 5 times"
+    # And I should see "Visited 5 times"
     And I should see "(Marked for Later.)"
 
   Scenario: A user can see some of their works marked for later on the homepage


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-4138

## Purpose

in reading history, changes "last viewed: (date)" and "viewed: (number)" to "last visited" and "visited"

## Testing

please go to your reading history and confirm that the text bar under each work in your history now says "last visited: (date)" and "visited: (number)"

## References

the initial pr was closed; sorry about that