### PR TITLE
AO3-2312 admin post kudos

### DIFF
--- a/app/controllers/admin_posts_controller.rb
+++ b/app/controllers/admin_posts_controller.rb
@@ -33,7 +33,7 @@ class AdminPostsController < Admin::BaseController
     @previous_admin_post = admin_posts.order('created_at DESC').where('created_at < ?', @admin_post.created_at).first
     @next_admin_post = admin_posts.order('created_at ASC').where('created_at > ?', @admin_post.created_at).first
     @page_subtitle = @admin_post.title.html_safe
-    @kudos = @admin_post.kudos.with_user.includes(:user).order('created_at DESC')
+    @kudos = @admin_post.kudos.with_user.includes(:user).order("created_at DESC")
     respond_to do |format|
       format.html # show.html.erb
       format.js

--- a/app/controllers/admin_posts_controller.rb
+++ b/app/controllers/admin_posts_controller.rb
@@ -33,6 +33,7 @@ class AdminPostsController < Admin::BaseController
     @previous_admin_post = admin_posts.order('created_at DESC').where('created_at < ?', @admin_post.created_at).first
     @next_admin_post = admin_posts.order('created_at ASC').where('created_at > ?', @admin_post.created_at).first
     @page_subtitle = @admin_post.title.html_safe
+    @kudos = @admin_post.kudos.with_user.includes(:user).order('created_at DESC')
     respond_to do |format|
       format.html # show.html.erb
       format.js

--- a/app/models/admin_post.rb
+++ b/app/models/admin_post.rb
@@ -4,6 +4,7 @@ class AdminPost < ApplicationRecord
   self.per_page = 8 # option for WillPaginate
 
   acts_as_commentable
+  has_many :kudos, as: :commentable, dependent: :destroy
   enum comment_permissions: {
     enable_all: 0,
     disable_anon: 1,
@@ -69,6 +70,18 @@ class AdminPost < ApplicationRecord
   def translated_post_must_exist
     if translated_post_id.present? && AdminPost.find_by(id: translated_post_id).nil?
       errors.add(:translated_post_id, 'does not exist')
+    end
+  end
+  
+  def guest_kudos_count
+    Rails.cache.fetch "admin_posts/#{id}/guest_kudos_count-v2" do
+      kudos.by_guest.count
+    end
+  end
+
+  def all_kudos_count
+    Rails.cache.fetch "admin_posts/#{id}/kudos_count-v2" do
+      kudos.count
     end
   end
 

--- a/app/models/admin_post.rb
+++ b/app/models/admin_post.rb
@@ -4,7 +4,7 @@ class AdminPost < ApplicationRecord
   self.per_page = 8 # option for WillPaginate
 
   acts_as_commentable
-  has_many :kudos, as: :commentable, dependent: :destroy
+  has_many :kudos, as: :commentable, inverse_of: :commentable, dependent: :destroy
   enum comment_permissions: {
     enable_all: 0,
     disable_anon: 1,

--- a/app/models/kudo.rb
+++ b/app/models/kudo.rb
@@ -40,11 +40,13 @@ class Kudo < ApplicationRecord
   after_destroy :update_work_stats
   after_create :after_create, :update_work_stats
   def after_create
-    users = self.commentable.pseuds.map(&:user).uniq
+    if self.commentable.respond_to?(:pseuds)
+      users = self.commentable.pseuds.map(&:user).uniq 
 
-    users.each do |user|
-      if notify_user_by_email?(user)
-        RedisMailQueue.queue_kudo(user, self)
+      users.each do |user|
+        if notify_user_by_email?(user)
+          RedisMailQueue.queue_kudo(user, self)
+        end
       end
     end
   end

--- a/app/models/kudo.rb
+++ b/app/models/kudo.rb
@@ -2,7 +2,7 @@ class Kudo < ApplicationRecord
   include ActiveModel::ForbiddenAttributesProtection
   include Responder
 
-  VALID_COMMENTABLE_TYPES = %w[Work].freeze
+  VALID_COMMENTABLE_TYPES = %w[Work AdminPost].freeze
 
   belongs_to :user
   belongs_to :commentable, polymorphic: true
@@ -56,6 +56,13 @@ class Kudo < ApplicationRecord
       Rails.cache.delete("works/#{commentable_id}/kudos_count-v2")
       # If it's a guest kudo, also expire the work's cached guest kudos count.
       Rails.cache.delete("works/#{commentable_id}/guest_kudos_count-v2") if user_id.nil?
+    end
+
+    if commentable_type == "AdminPost"
+      # Expire the admin post's cached total kudos count.
+      Rails.cache.delete("admin_posts/#{commentable_id}/kudos_count-v2")
+      # If it's a guest kudo, also expire the admin post's cached guest kudos count.
+      Rails.cache.delete("admin_posts/#{commentable_id}/guest_kudos_count-v2") if user_id.nil?
     end
 
     # Expire the cached kudos section under the work.

--- a/app/models/kudo.rb
+++ b/app/models/kudo.rb
@@ -40,14 +40,12 @@ class Kudo < ApplicationRecord
   after_destroy :update_work_stats
   after_create :after_create, :update_work_stats
   def after_create
-    if self.commentable.respond_to?(:pseuds)
-      users = self.commentable.pseuds.map(&:user).uniq 
+    return unless self.commentable.respond_to?(:pseuds)
+    
+    users = self.commentable.pseuds.map(&:user).uniq 
 
-      users.each do |user|
-        if notify_user_by_email?(user)
-          RedisMailQueue.queue_kudo(user, self)
-        end
-      end
+    users.each do |user|
+      RedisMailQueue.queue_kudo(user, self) if notify_user_by_email?(user)
     end
   end
 

--- a/app/views/comments/_commentable.html.erb
+++ b/app/views/comments/_commentable.html.erb
@@ -27,12 +27,13 @@
     <% if @admin_post %>
       <li><%= link_to ts('Back to AO3 News Index'), admin_posts_path %></li>
     <% end %>
-
-    <% if @work && !is_author_of?(@work) %>
+    
+    <% kudos_target = @work || @admin_post %>
+    <% if kudos_target && !is_author_of?(kudos_target) %>
       <li>
         <%= form_for(:kudo, url: kudos_path, html: { method: 'post', id: 'new_kudo' }) do |kudo_form| %>
-          <%= kudo_form.hidden_field :commentable_id, :value => @work.id %>
-          <%= kudo_form.hidden_field :commentable_type, :value => 'Work' %>
+          <%= kudo_form.hidden_field :commentable_id, :value => kudos_target.id %>
+          <%= kudo_form.hidden_field :commentable_type, :value => @admin_post ? 'AdminPost' : 'Work' %>
           <%= kudo_form.submit ts("Kudos ♥"), :id => 'kudo_submit' %>
         <% end %>
       </li>
@@ -66,8 +67,8 @@
   <div id="kudos_message"></div>
   <%= flash_div :kudos_error, :kudos_notice %>
 
-  <% if @work && (@chapter.blank? || @chapter.posted?) %>
-    <%= render "kudos/kudos", :kudos => @kudos, :guest_kudos_count => @work.guest_kudos_count, :commentable => @work %>
+  <% if kudos_target && (@chapter.blank? || @chapter.posted?) %>
+    <%= render "kudos/kudos", :kudos => @kudos, :guest_kudos_count => kudos_target.guest_kudos_count, :commentable => kudos_target %>
   <% end %>
 
 

--- a/app/views/kudos/_kudos.html.erb
+++ b/app/views/kudos/_kudos.html.erb
@@ -14,7 +14,7 @@
           <% end %>
           <%= ts(pluralize(guest_kudos_count, "guest")) %>
         <% end %>
-        <%= ts(" left kudos on this work!") %>
+        <%= ts(" left kudos on this #{commentable.is_a?(AdminPost) ? "post" : "work"}!") %>
       </p>
     <% end %>
   <% end %>

--- a/features/comments_and_kudos/kudos.feature
+++ b/features/comments_and_kudos/kudos.feature
@@ -167,3 +167,57 @@ Feature: Kudos
       And the email should contain "Meh Story"
       And the email should not contain "0 guests"
       And the email should not contain "translation missing"
+
+  Scenario: Leave kudos on an admin post when logged in
+
+    Given I have posted an admin post
+      And I am logged in as "happyuser"
+      And I go to the admin-posts page
+      And I follow "Default Admin Post"
+      And all emails have been delivered
+      And I press "Kudos ♥"
+    Then I should see "Thank you for leaving kudos!"
+      And I should see "happyuser left kudos on this post!"
+    When I press "Kudos ♥"
+    Then I should see "You have already left kudos here. :)"
+    When kudos are sent
+    Then 0 emails should be delivered
+
+  Scenario: Leave kudos on an admin post when logged out
+
+    Given I have posted an admin post
+      And I go to the admin-posts page
+      And I follow "Default Admin Post"
+      And I press "Kudos ♥"
+    Then I should see "Thank you for leaving kudos!"
+      And I should see "1 guest left kudos on this post!"
+    When I press "Kudos ♥"
+    Then I should see "You have already left kudos here. :)"
+    When kudos are sent
+    Then 0 emails should be delivered
+
+  @javascript
+  Scenario: Leave kudos on an admin post via JS when logged in
+
+    Given I have posted an admin post
+      And I am logged in as "happyuser"
+      And I go to the admin-posts page
+      And I follow "Default Admin Post"
+      And all emails have been delivered
+      And I press "Kudos ♥"
+    Then I should see "Thank you for leaving kudos!"
+      And I should see "happyuser left kudos on this post!"
+    When I press "Kudos ♥"
+    Then I should see "You have already left kudos here. :)"
+
+  @javascript
+  Scenario: Leave kudos on an admin post via JS when logged out
+  
+    Given I have posted an admin post
+      And I go to the admin-posts page
+      And I follow "Default Admin Post"
+      And I press "Kudos ♥"
+    Then I should see "Thank you for leaving kudos!"
+      And I should see "1 guest left kudos on this post!"
+    When I press "Kudos ♥"
+    Then I should see "You have already left kudos here. :)"

--- a/features/step_definitions/admin_steps.rb
+++ b/features/step_definitions/admin_steps.rb
@@ -101,6 +101,7 @@ end
 Given /^I have posted an admin post$/ do
   step(%{I am logged in as a "communications" admin})
   step("I make an admin post")
+  step("I am on the homepage")
   step("I log out")
 end
 


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-2312

## Purpose

Lets guests and users leave kudos on admin posts.

## Testing

- While logged in as a user, try to leave kudos on an admin post from that post's page. Check that the success flash message appears and your kudos is listed.
- Try it as a guest.
- Try to leave kudos multiple times. Check that the "you already left kudos" error message appears.
- Try the above steps with JS off.  

Note: I found that a kudo left while logged in as a admin counts as having been left by a guest. I assume that is expected as admins are not users. Let me know in review if that's not what's desired.