### PR TITLE
AO3-4394 Reduce n+1 queries when loading /tags/TagName/works pages.

### DIFF
--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -1067,8 +1067,7 @@ class WorksController < ApplicationController
 
   def fields_for_work_index
     [
-      :tags, :external_creatorships, :series, :language,
-      collections: [:collection_items],
+      :tags, :external_creatorships, :series, :language, :approved_collections,
       pseuds: [:user]
     ]
   end

--- a/app/helpers/works_helper.rb
+++ b/app/helpers/works_helper.rb
@@ -43,7 +43,7 @@ module WorksHelper
 
   def recipients_link(work)
     # join doesn't maintain html_safe, so mark the join safe
-    work.gifts.not_rejected.includes(:pseud).map { |gift| link_to(h(gift.recipient), gift.pseud ? user_gifts_path(gift.pseud.user) : gifts_path(recipient: gift.recipient_name)) }.join(", ").html_safe
+    work.gifts.not_rejected.includes(pseud: [:user]).map { |gift| link_to(h(gift.recipient), gift.pseud ? user_gifts_path(gift.pseud.user) : gifts_path(recipient: gift.recipient_name)) }.join(", ").html_safe
   end
 
   # select the default warning if this is a new work

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -175,32 +175,26 @@ class Collection < ApplicationRecord
   scope :by_title, -> { order(:title) }
 
   scope :approved, -> {
-    includes(:collection_items)
-      .where(
-        collection_items: {
-          user_approval_status: CollectionItem::APPROVED,
-          collection_approval_status: CollectionItem::APPROVED
-        }
-      )
-      .references(:collection_items)
+    where(
+      collection_items: {
+        user_approval_status: CollectionItem::APPROVED,
+        collection_approval_status: CollectionItem::APPROVED
+      }
+    ).references(:collection_items)
   }
   scope :user_approved, -> {
-    includes(:collection_items)
-      .where(
-        collection_items: {
-          user_approval_status: CollectionItem::APPROVED
-        }
-      )
-      .references(:collection_items)
+    where(
+      collection_items: {
+        user_approval_status: CollectionItem::APPROVED
+      }
+    ).references(:collection_items)
   }
   scope :rejected, -> {
-    includes(:collection_items)
-      .where(
-        collection_items: {
-          user_approval_status: CollectionItem::REJECTED
-        }
-      )
-      .references(:collection_items)
+    where(
+      collection_items: {
+        user_approval_status: CollectionItem::REJECTED
+      }
+    ).references(:collection_items)
   }
 
 


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-4394

## Purpose

The purpose of this pull request is to modify the work search code so that it can pre-load data using includes. I did this by adding an `includes()` function to the SearchResult class, with syntax mimicking the `includes()` syntax for relations, so that it's easy to specify which fields you want to be included when you load your search results. I then updated the works controller to make sure that the includes were consistent.

(In order to add `:approved_collections` to the includes to further reduce the n+1 queries, I also had to fix a bug with the definition of Collection.approved. I also fixed an n+1 query in the `recipients_link` helper, since I had a work with multiple recipients that kept showing up and causing problems.)

## Testing

I tested this by visiting various works pages and examining log/bullet.log -- I assume that a similar technique can be used in production.