### PR TITLE
AO3-5058 Simplify archivist error message when no email or author specified

### DIFF
--- a/app/models/story_parser.rb
+++ b/app/models/story_parser.rb
@@ -218,7 +218,7 @@ class StoryParser
     if location.present? && ext_author_name.blank? && ext_author_email.blank?
       source = get_source_if_known(KNOWN_AUTHOR_PARSERS, location)
       if source.nil?
-        raise Error, "No external author name or email specified, and unable to generate email based on source location"
+        raise Error, "No external author name or email specified"
       else
         send("parse_author_from_#{source.downcase}", location)
       end

--- a/features/importing/archivist.feature
+++ b/features/importing/archivist.feature
@@ -41,7 +41,7 @@ Feature: Archivist bulk imports
     When I start importing "http://import-site-with-tags" with a mock website as an archivist
       And I check "Import for others ONLY with permission"
       And I press "Import"
-    Then I should see "We couldn't successfully import that work, sorry: No external author name or email specified, and unable to generate email based on source location"
+    Then I should see "We couldn't successfully import that work, sorry: No external author name or email specified"
 
   Scenario: Importing for an author without an account should have the correct byline and email
     When I import the work "http://rebecca2525.livejournal.com/3562.html"


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5058

## Purpose

This simplifies an error message that was too verbose as discovered when testing on Test.

## Testing

Same as previously for this ticket.
