### PR TITLE
AO3-4187 Fix empty tag dropdown when filtering news posts

### DIFF
--- a/app/controllers/admin_posts_controller.rb
+++ b/app/controllers/admin_posts_controller.rb
@@ -14,7 +14,7 @@ class AdminPostsController < ApplicationController
     @admin_posts ||= AdminPost
     if params[:language_id].present? && (@language = Language.find_by(short: params[:language_id]))
       @admin_posts = @admin_posts.where(language_id: @language.id)
-      @tags = AdminPostTag.where(language_id: @language.id).order(:name)
+      @tags = AdminPostTag.joins(:admin_posts).where(admin_posts: { language_id: @language.id })
     else
       @admin_posts = @admin_posts.non_translated
       @tags = AdminPostTag.order(:name)

--- a/features/admins/admin_post_news.feature
+++ b/features/admins/admin_post_news.feature
@@ -125,33 +125,45 @@ Feature: Admin Actions to Post News
     Then I should not see a translated admin post
 
   Scenario: Log in as an admin and create an admin post with tags
-    Given I have no users
-      And the following admin exists
-      | login      | password |
-      | Elz        | secret   |
-    When I go to the admin login page
-      And I fill in "admin_login" with "Elz"
-      And I fill in "admin_password" with "secret"
-      And I press "Log in as admin"
-    Then I should see "Successfully logged in"
+    Given I am logged in as an admin
     When I follow "Admin Posts"
       And I follow "Post AO3 News"
       Then I should see "New AO3 News Post"
     When I fill in "admin_post_title" with "Good news, everyone!"
       And I fill in "content" with "I've taught the toaster to feel love."
-      And I fill in "admin_post_tag_list" with "quotes, futurama"
+      And I fill in "Tags" with "quotes, futurama"
       And I press "Post"
     Then I should see "Admin Post was successfully created."
       And I should see "toaster" within "div.admin.home"
       And I should see "futurama" within "dd.tags"
 
-  Scenario: Admin posts should show both translations and tags
+  Scenario: Admin posts can be filtered by tags and languages
     Given I have posted an admin post with tags
       And basic languages
       And I am logged in as an admin
-    When I make a translation of an admin post
+    When I make a translation of an admin post with tags
       And I am logged in as "ordinaryuser"
     Then I should see a translated admin post with tags
+
+    When I follow "News"
+    Then "futurama" should be an option within "Tag"
+      And "quotes" should be an option within "Tag"
+      And "Deutsch" should be an option within "Language"
+      And "English" should be selected within "Language"
+
+    # No tag selected
+    When I press "Go"
+    Then I should see "Content of the admin post"
+      And I should not see "Deutsch Woerter"
+      And "English" should be selected within "Language"
+
+    When I select "quotes" from "Tag"
+      And I select "Deutsch" from "Language"
+      And I press "Go"
+    Then I should not see "Content of the admin post"
+      And I should see "Deutsch Woerter"
+      And "quotes" should be selected within "Tag"
+      And "Deutsch" should be selected within "Language"
 
   Scenario: If an admin post has characters like & and < and > in the title, the escaped version will not show on the various admin post pages
     Given I am logged in as an admin

--- a/features/step_definitions/admin_steps.rb
+++ b/features/step_definitions/admin_steps.rb
@@ -251,29 +251,9 @@ When /^there are (\d+) Archive FAQs$/ do |n|
   end
 end
 
-When /^I make a(?: (\d+)(?:st|nd|rd|th)?)? Admin Post$/ do |n|
-  n ||= 1
-  visit new_admin_post_path
-  fill_in("admin_post_title", with: "Amazing News #{n}")
-  fill_in("content", with: "This is the content for the #{n} Admin Post")
-  click_button("Post")
-end
-
-When /^there are (\d+) Admin Posts$/ do |n|
-  (1..n.to_i).each do |i|
-    step %{I make a #{i} Admin Post}
-  end
-end
-
 When /^(\d+) Archive FAQs? exists?$/ do |n|
   (1..n.to_i).each do |i|
     FactoryGirl.create(:archive_faq, id: i)
-  end
-end
-
-When /^(\d+) Admin Posts? exists?$/ do |n|
-  (1..n.to_i).each do |i|
-    FactoryGirl.create(:admin_post, id: i)
   end
 end
 
@@ -310,7 +290,7 @@ end
 
 ### THEN
 
-When (/^I make a translation of an admin post$/) do
+When (/^I make a translation of an admin post( with tags)?$/) do |with_tags|
   admin_post = AdminPost.find_by(title: "Default Admin Post")
   # If post doesn't exist, assume we want to reference a non-existent post
   admin_post_id = !admin_post.nil? ? admin_post.id : 0
@@ -319,6 +299,7 @@ When (/^I make a translation of an admin post$/) do
   fill_in("content", with: "Deutsch Woerter")
   step %{I select "Deutsch" from "Choose a language"}
   fill_in("admin_post_translated_post_id", with: admin_post_id)
+  fill_in("admin_post_tag_list", with: "quotes, futurama") if with_tags
   click_button("Post")
 end
 

--- a/features/step_definitions/generic_steps.rb
+++ b/features/step_definitions/generic_steps.rb
@@ -105,6 +105,10 @@ Then /^"([^"]*)" should be selected within "([^"]*)"$/ do |value, field|
   page.has_select?(field, selected: value).should == true
 end
 
+Then /^"(.*)?" should( not)? be an option within "(.*)?"$/ do |value, negation, field|
+  expect(page.has_select?(field, with_options: [value])).to be !negation
+end
+
 Then /^I should see "([^"]*)" in the "([^"]*)" input/ do |content, labeltext|
   find_field("#{labeltext}").value.should == content
 end
@@ -145,14 +149,6 @@ Then /^the "([^"]*)" checkbox(?: within "([^"]*)")? should not be disabled$/ do 
       assert !field_disabled
     end
   end
-end
-
-Then /^I should find "([^"]*)" selected within "([^"]*)"$/ do |text, selector|
-    if page.respond_to? :should
-      page.should have_content('<option selected="selected" value="' + text + '"')
-    else
-      assert page.has_content?('<option selected="selected" value="' + text + '"')
-    end
 end
 
 Then /^I should not see the field "([^"]*)"(?: within "([^"]*)")?$/ do |id, selector|


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-4187

## Purpose

When filtering news posts, if a language is selected, the tag dropdown will have all tags across all posts of that language, instead of being empty.

## Testing

See issue.