### PR TITLE
AO3-5197: Avoid errors when word counting empty strings

### DIFF
--- a/lib/word_counter.rb
+++ b/lib/word_counter.rb
@@ -16,6 +16,8 @@ class WordCounter
   # -- is replaced by — (emdash) before strip so one--two will count as 2
   def count
     count = 0
+    # avoid blank? so we don't need to load Rails for tests
+    return count if @text.nil? || @text.empty?
     body = Nokogiri::HTML(@text).xpath('//body').first
     body.traverse do |node|
       if node.is_a? Nokogiri::XML::Text

--- a/spec/lib/word_counter_spec.rb
+++ b/spec/lib/word_counter_spec.rb
@@ -3,7 +3,11 @@
 require 'word_counter'
 
 describe WordCounter do
- let(:word_counter) { WordCounter.new("") }
+  let(:word_counter) { WordCounter.new("") }
+
+  it "should return zero for an empty string" do
+    expect(word_counter.count).to eq(0)
+  end
 
   it "should count plain words delimited with spaces" do
     word_counter.text = "one two three four"


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5197

## Purpose

Fixes errors when running word count on empty strings

## Testing

See issue.