### PR TITLE
AO3-5199: Don't generate extra html files

### DIFF
--- a/app/controllers/downloads_controller.rb
+++ b/app/controllers/downloads_controller.rb
@@ -28,7 +28,6 @@ class DownloadsController < ApplicationController
 
     FileUtils.mkdir_p @work.download_dir
     @chapters = @work.chapters.order('position ASC').where(posted: true)
-    create_work_html
 
     respond_to do |format|
       format.html do


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5199

## Purpose

Skips generating unneeded html files that fill up disk space

## Testing

Make sure mobi and epub generation still works