### PR TITLE
AO3-5201 Add insecure to list of urls allowed to report

### DIFF
--- a/app/models/abuse_report.rb
+++ b/app/models/abuse_report.rb
@@ -34,7 +34,7 @@ class AbuseReport < ApplicationRecord
     end
   end
 
-  app_url_regex = Regexp.new('^https?:\/\/(www\.)?' +
+  app_url_regex = Regexp.new('^https?:\/\/(www\.|insecure\.)?' +
                              ArchiveConfig.APP_HOST, true)
   validates_format_of :url, with: app_url_regex,
                             message: ts('does not appear to be on this site.'),


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5201

## Purpose

Allow users to report users and works when using http://insecure.archiveofourown.org/abuse_reports

## Testing

I think this can only be tested on beta.