### PR TITLE
AO3-5202 Fix MIME type for MOBI downloads

### DIFF
--- a/app/controllers/downloads_controller.rb
+++ b/app/controllers/downloads_controller.rb
@@ -98,7 +98,7 @@ protected
       flash[:error] = ts('We were not able to render this work. Please try another format')
       redirect_back_or_default work_path(@work) and return
     end
-    send_file_sync("mobi", "aapplication/x-mobipocket-ebook")
+    send_file_sync("mobi", "application/x-mobipocket-ebook")
   end
 
   def download_epub


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5202

## Purpose

Fix a minor typo.

## Testing

MOBI downloads should work on Kindle devices.