### PR TITLE
AO3-5140 Fix Date search regex matches whitespace

### DIFF
--- a/app/models/search.rb
+++ b/app/models/search.rb
@@ -24,7 +24,7 @@ class Search < ApplicationRecord
     option.gsub!("&gt;", ">")
     option.gsub!("&lt;", "<")
     option.downcase!
-    match = option.match(/^([<>]*)\s*([\d -]+)\s*(year|week|month|day|hour)s?(\s*ago)?s*$/)
+    match = option.match(/^([<>]*)\s*([\d -]+)\s*(year|week|month|day|hour)s?(\s*ago)?\s*$/)
     range = {}
     if match
       range = time_range(match[1], match[2], match[3])


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5140

## Purpose

The regex on line 27 of app/models/search.rb matched any amount of the letter s instead of whitespace.

## Testing

Refer to Jira issue.
