### PR TITLE
AO3-4815: Ensure correct results when browsing bookmarks by user

### DIFF
--- a/app/models/search/bookmark_query.rb
+++ b/app/models/search/bookmark_query.rb
@@ -196,17 +196,8 @@ class BookmarkQuery < Query
   end
 
   def user_filter
-    return unless options[:user_ids]
-
-    options[:user_ids].flatten.uniq.map do |user_id|
-      user = User.find_by id: user_id
-      if user && user.pseuds.any?
-        user.pseuds.map { |pseud| term_filter(:pseud_id, pseud.id) }
-      else
-        term_filter(:user_id, user_id)
-      end
-    end.flatten.compact
-    # terms_filter(:user_id, options[:user_ids]) if options[:user_ids].present?
+    return unless options[:user_ids].present?
+    options[:user_ids].flatten.uniq.map { |user_id| term_filter(:user_id, user_id) }
   end
 
   def filter_id_filter

--- a/features/bookmarks/bookmark_browse.feature
+++ b/features/bookmarks/bookmark_browse.feature
@@ -1,0 +1,19 @@
+@no-txn @bookmarks @search
+Feature: Browse Bookmarks
+
+  Scenario: Bookmarks appear on both the user's bookmark page and on the bookmark page for the pseud they used create the bookmark
+
+    Given I am logged in as "ethel"
+      And I add the pseud "aka"
+      And ethel can use the new search
+      And I bookmark the work "Bookmarked with Default Pseud"
+      And I bookmark the work "Bookmarked with Other Pseud" as "aka"
+    When I go to ethel's bookmarks page
+    Then I should see "Bookmarked with Default Pseud"
+      And I should see "Bookmarked with Other Pseud"
+    When I go to the bookmarks page for user "ethel" with pseud "ethel"
+    Then I should see "Bookmarked with Default Pseud"
+      And I should not see "Bookmarked with Other Pseud"
+    When I go to the bookmarks page for user "ethel" with pseud "aka"
+    Then I should see "Bookmarked with Other Pseud"
+      And I should not see "Bookmarked with Default Pseud"

--- a/features/support/paths.rb
+++ b/features/support/paths.rb
@@ -118,6 +118,9 @@ module NavigationHelpers
       work_path(Work.find_by(title: $1)).sub("http://www.example.com", "//")
     when /^the work page with title (.*)/
       work_path(Work.find_by(title: $1)).sub("http://www.example.com", "//")
+    when /^the bookmarks page for user "(.*)" with pseud "(.*)"$/i
+      step %{the bookmark indexes are updated}
+      user_pseud_bookmarks_path(user_id: $1, pseud_id: $2)
     when /^(.*?)(?:'s)? bookmarks page$/i
       step %{the bookmark indexes are updated}
       user_bookmarks_path(user_id: $1)


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-4815

## Purpose

Updates bookmark search to use user ids for filtering on user pages, which should also fix an issue with some bookmarks not appearing on user pages.

## Testing

All of a user's bookmarks should appear on their user bookmarks page.