### PR TITLE
AO3-5213 Index authors on works correctly for sorting

### DIFF
--- a/app/models/search/work_indexer.rb
+++ b/app/models/search/work_indexer.rb
@@ -20,7 +20,7 @@ class WorkIndexer < Indexer
             analyzer: "simple"
           },
           authors_to_sort_on: {
-            type: "text"
+            type: "keyword"
           },
           title_to_sort_on: {
             type: "keyword"


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5213

## Purpose

Fixes the indexing type for the authors_to_sort_on field for works so that it can be used for sorting.

## Testing

When works are reindexed, you should be able to sort by author without getting an error.