### PR TITLE
AO3-5225: Fix sidebar counts and scope by user id if a user is present

### DIFF
--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -72,7 +72,7 @@ module UsersHelper
     # ES UPGRADE TRANSITION #
     # Remove conditional and call to BookmarkSearch
     if use_new_search?
-      total = BookmarkSearchForm.count_for_pseuds(user.pseuds)
+      total = BookmarkSearchForm.count_for_user(user)
     else
       total = BookmarkSearch.count_for_pseuds(user.pseuds)
     end

--- a/app/models/search/query.rb
+++ b/app/models/search/query.rb
@@ -22,6 +22,14 @@ class Query
     QueryResult.new(klass, response, options.slice(:page, :per_page))
   end
 
+  # Perform a count query based on the given options
+  def count
+    $new_elasticsearch.count(
+      index: index_name,
+      body: { query: generated_query[:query] }
+    )['count']
+  end
+
   # Sort by relevance by default, override in subclasses as necessary
   def sort
     { "_score" => { order: "desc" }}

--- a/features/users/user_dashboard.feature
+++ b/features/users/user_dashboard.feature
@@ -65,6 +65,7 @@ Feature: User dashboard
     And I go to meatloaf's user page
   Then I should see "Newest Work"
     And I should not see "Oldest Work"
+    And I should see "Works (6)" within "#dashboard"
   When I follow "Works (6)" within "#user-works"
   Then I should see "6 Works by meatloaf"
     And I should see "Oldest Work"
@@ -102,6 +103,7 @@ Feature: User dashboard
     And I go to meatloaf's user page
   Then I should see "Work Six" within "#user-bookmarks"
     And I should not see "Work One" within "#user-bookmarks"
+    And I should see "Bookmarks (6)" within "#dashboard"
   When I follow "Bookmarks (6)" within "#user-bookmarks"
   Then I should see "6 Bookmarks by meatloaf"
     And I should see "Work One"
@@ -118,6 +120,7 @@ Feature: User dashboard
     And I follow "gravy" within ".pseud .expandable li"
   Then I should see "Recent works"
     And I should see "Pseud's Work 1"
+    And I should see "Works (1)" within "#dashboard"
     And I should not see "Works (" within "#user-works"
     And I should not see "Oldest Work" within "#user-works"
   Then I should see "Recent series"
@@ -125,6 +128,7 @@ Feature: User dashboard
     And I should not see "Oldest Series"
   Then I should see "Recent bookmarks"
     And I should see "Work 5" within "#user-bookmarks"
+    And I should see "Bookmarks (1)" within "#dashboard"
 
   Scenario: You can follow a fandom link from a user's dashboard and then use the filters to sort within that fandom.
   Given a media exists with name: "TV Shows", canonical: true


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5225

## Purpose

Fixes sidebar counts and uses user ids where available instead of pseud ids. Also simplifies things a bit since we already have default visibility logic in the query classes.

## Testing

Sidebar counts should be correct when logged in or out for both works and bookmarks, on user pages and on pseud pages.