### PR TITLE
AO3-5227 Remove unused advanced_search_string method

### DIFF
--- a/app/helpers/advanced_search_helper.rb
+++ b/app/helpers/advanced_search_helper.rb
@@ -1,20 +1,5 @@
 module AdvancedSearchHelper
 
-def advanced_search_string=(term_string)
-    terms = []
-    self.invalid_terms ||= []
-    term_string.split(ArchiveConfig.DELIMITER_FOR_INPUT).each do |string|
-      string.squish!
-      term = Fandom.find_or_create_by_name(string)
-      if term.valid?
-        terms << term if term.is_a?(Fandom)
-      else
-        self.invalid_terms << term
-      end
-    end
-    self.terms = terms
-  end
-
   def filter_boolean_value(filter_action, tag_type, tag_id)
     if filter_action == "include"
       @search.send("#{tag_type}_ids").present? &&


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5227

## Purpose

Removes a method that's not called anywhere in the code (thereby bringing this file's test coverage up to 100%)

## Testing

Nothing to test