### PR TITLE
AO3-4331 Mark works as spam or ham

### DIFF
--- a/app/controllers/admin/user_creations_controller.rb
+++ b/app/controllers/admin/user_creations_controller.rb
@@ -1,52 +1,75 @@
 class Admin::UserCreationsController < ApplicationController
 
   before_action :admin_only
+  before_action :get_creation
+  before_action :can_be_marked_as_spam, only: [:set_spam]
 
+  def get_creation
+    raise "Redshirt: Attempted to constantize invalid class initialize hide #{params[:creation_type]}" unless %w(ExternalWork Bookmark Work).include?(params[:creation_type])
+    @creation_class = params[:creation_type].constantize
+    @creation = @creation_class.find(params[:id])
+  end
+  
+  def can_be_marked_as_spam
+    unless @creation_class && @creation_class == Work
+      flash[:error] = ts("You can only mark works as spam currently.")
+      redirect_to @creation and return
+    end
+  end
+  
   # Removes an object from public view
   def hide
-    raise "Redshirt: Attempted to constantize invalid class initialize hide #{params[:creation_type]}" unless %w(ExternalWork Bookmark Work).include?(params[:creation_type])
-    creation_class = params[:creation_type].constantize
-    creation = creation_class.find(params[:id])
-    creation.hidden_by_admin = (params[:hidden] == "true")
-    creation.save(validate: false)
-    action = creation.hidden_by_admin? ? "hide" : "unhide"
-    AdminActivity.log_action(current_admin, creation, action: action)
+    @creation.hidden_by_admin = (params[:hidden] == "true")
+    @creation.save(validate: false)
+    action = @creation.hidden_by_admin? ? "hide" : "unhide"
+    AdminActivity.log_action(current_admin, @creation, action: action)
     flash[:notice] = creation.hidden_by_admin? ?
-                        ts('Item has been hidden.') :
-                        ts('Item is no longer hidden.')
-    if creation_class == Comment
-      redirect_to(creation.ultimate_parent)
-    elsif creation_class == ExternalWork || creation_class == Bookmark
+                        ts("Item has been hidden.") :
+                        ts("Item is no longer hidden.")
+    if @creation_class == Comment
+      redirect_to(@creation.ultimate_parent) 
+    elsif @creation_class == ExternalWork || @creation_class == Bookmark
       redirect_to(request.env["HTTP_REFERER"] || root_path)
     else
-      unless action  == "unhide"
+      unless action == "unhide"
         # Email users so they're aware of Abuse action
         orphan_account = User.orphan_account
-        users = creation.pseuds.map(&:user).uniq
+        users = @creation.pseuds.map(&:user).uniq
         users.each do |user|
           unless user == orphan_account
-            UserMailer.admin_hidden_work_notification(creation.id, user.id).deliver
+            UserMailer.admin_hidden_work_notification(@creation.id, user.id).deliver
           end
         end
        end
-      redirect_to(creation)
+      redirect_to(@creation)
     end
+  end  
+  
+  def set_spam
+    action = "mark as " + (params[:spam] == "true" ? "spam" : "not spam")
+    AdminActivity.log_action(current_admin, @creation, action: action, summary: @creation.inspect)    
+    if params[:spam] == "true"
+      @creation.mark_as_spam!
+      @creation.update_attribute(:hidden_by_admin, true)
+      flash[:notice] = ts("Work was marked as spam and hidden.")
+    else
+      @creation.mark_as_ham!
+      @creation.update_attribute(:hidden_by_admin, false)
+      flash[:notice] = ts("Work was marked not spam and unhidden.")
+    end
+    redirect_to(@creation)
   end
-
+  
   def destroy
-    raise "Redshirt: Attempted to constantize invalid class initialize destroy #{params[:creation_type]}" unless %w(ExternalWork Bookmark Work).include?(params[:creation_type])
-    creation_class = params[:creation_type].constantize
-    creation = creation_class.find(params[:id])
-    AdminActivity.log_action(current_admin, creation, action: 'destroy', summary: creation.inspect)
-    creation.destroy
-    flash[:notice] = ts('Item was successfully deleted.')
-    if creation_class == Comment
-      redirect_to(creation.ultimate_parent)
-    elsif creation_class == ExternalWork
+    AdminActivity.log_action(current_admin, @creation, action: "destroy", summary: @creation.inspect)
+    @creation.destroy
+    flash[:notice] = ts("Item was successfully deleted.")
+    if @creation_class == Comment 
+      redirect_to(@creation.ultimate_parent) 
+    elsif @creation_class == ExternalWork
       redirect_to bookmarks_path
     else
      redirect_to works_path
     end
   end
-
 end

--- a/app/controllers/admin/user_creations_controller.rb
+++ b/app/controllers/admin/user_creations_controller.rb
@@ -23,7 +23,7 @@ class Admin::UserCreationsController < ApplicationController
     @creation.save(validate: false)
     action = @creation.hidden_by_admin? ? "hide" : "unhide"
     AdminActivity.log_action(current_admin, @creation, action: action)
-    flash[:notice] = creation.hidden_by_admin? ?
+    flash[:notice] = @creation.hidden_by_admin? ?
                         ts("Item has been hidden.") :
                         ts("Item is no longer hidden.")
     if @creation_class == Comment

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -1372,15 +1372,10 @@ class Work < ApplicationRecord
   # SPAM CHECKING
   ########################################################################
 
-  def spam_checked?
-    spam_checked_at.present?
-  end
-
-  def check_for_spam
-    return unless %w(staging production).include?(Rails.env)
+  def akismet_attributes
     content = chapters_in_order.map { |c| c.content }.join
     user = users.first
-    self.spam = Akismetor.spam?(
+    {
       comment_type: 'fanwork-post',
       key: ArchiveConfig.AKISMET_KEY,
       blog: ArchiveConfig.AKISMET_NAME,
@@ -1390,7 +1385,16 @@ class Work < ApplicationRecord
       comment_author: user.login,
       comment_author_email: user.email,
       comment_content: content
-    )
+    }
+  end
+
+  def spam_checked?
+    spam_checked_at.present?
+  end
+
+  def check_for_spam
+    return unless %w(staging production).include?(Rails.env)
+    self.spam = Akismetor.spam?(akismet_attributes)
     self.spam_checked_at = Time.now
     save
   end

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -1381,7 +1381,7 @@ class Work < ApplicationRecord
     content = chapters_in_order.map { |c| c.content }.join
     user = users.first
     self.spam = Akismetor.spam?(
-      comment_type: 'Fan Fiction',
+      comment_type: 'fanwork-post',
       key: ArchiveConfig.AKISMET_KEY,
       blog: ArchiveConfig.AKISMET_NAME,
       user_ip: ip_address,
@@ -1393,6 +1393,18 @@ class Work < ApplicationRecord
     )
     self.spam_checked_at = Time.now
     save
+  end
+
+  def mark_as_spam!
+    update_attribute(:spam, true)
+    # don't submit spam reports unless in production mode
+    Rails.env.production? && Akismetor.submit_spam(akismet_attributes)
+  end
+
+  def mark_as_ham!
+    update_attribute(:spam, false)
+    # don't submit ham reports unless in production mode
+    Rails.env.production? && Akismetor.submit_ham(akismet_attributes)
   end
 
   #############################################################################

--- a/app/views/admin/_admin_options.html.erb
+++ b/app/views/admin/_admin_options.html.erb
@@ -6,6 +6,29 @@
   <% elsif item.class == Bookmark %>
     <% item_type_name = ts("Bookmark") %>
   <% else %>
+    <li><%= link_to ts('Hide'), {:controller=>"admin/user_creations", :action=>"hide", :id=>item, :creation_type => item.class, :hidden=>'true'} %></li>
+  <% end %>
+  <% if @work.present? %>
+    <li><%= link_to ts("Edit Tags"), edit_tags_work_path(@work) %></li>
+    <% if @work.spam? %>
+      <li>
+        <%= link_to ts("Mark Not Spam"), 
+                    { controller: "admin/user_creations", 
+                      action: "set_spam",
+                      id: @work.id,
+                      creation_type: @work.class,
+                      spam: 'false'} %>
+      </li>
+    <% else %>
+      <li>
+        <%= link_to ts("Mark As Spam"), 
+                    { controller: "admin/user_creations", 
+                      action: "set_spam",
+                      id: @work.id,
+                      creation_type: @work.class,
+                      spam: 'true'} %>
+      </li>
+    <% end %>    
     <% item_type_name = ts("Work") %>
   <% end %>
 

--- a/app/views/admin/_admin_options.html.erb
+++ b/app/views/admin/_admin_options.html.erb
@@ -36,7 +36,7 @@
       </li>
       <% if @work.spam? %>
         <li>
-          <%= link_to ts("Mark Not Spam"), 
+          <%= link_to ts("Mark Not Spam"),
                       { controller: "admin/user_creations",
                         action: "set_spam",
                         id: @work.id,
@@ -45,8 +45,8 @@
         </li>
       <% else %>
         <li>
-          <%= link_to ts("Mark As Spam"), 
-                      { controller: "admin/user_creations", 
+          <%= link_to ts("Mark As Spam"),
+                      { controller: "admin/user_creations",
                         action: "set_spam",
                         id: @work.id,
                         creation_type: @work.class,

--- a/app/views/admin/_admin_options.html.erb
+++ b/app/views/admin/_admin_options.html.erb
@@ -6,29 +6,6 @@
   <% elsif item.class == Bookmark %>
     <% item_type_name = ts("Bookmark") %>
   <% else %>
-    <li><%= link_to ts('Hide'), {:controller=>"admin/user_creations", :action=>"hide", :id=>item, :creation_type => item.class, :hidden=>'true'} %></li>
-  <% end %>
-  <% if @work.present? %>
-    <li><%= link_to ts("Edit Tags"), edit_tags_work_path(@work) %></li>
-    <% if @work.spam? %>
-      <li>
-        <%= link_to ts("Mark Not Spam"), 
-                    { controller: "admin/user_creations", 
-                      action: "set_spam",
-                      id: @work.id,
-                      creation_type: @work.class,
-                      spam: 'false'} %>
-      </li>
-    <% else %>
-      <li>
-        <%= link_to ts("Mark As Spam"), 
-                    { controller: "admin/user_creations", 
-                      action: "set_spam",
-                      id: @work.id,
-                      creation_type: @work.class,
-                      spam: 'true'} %>
-      </li>
-    <% end %>    
     <% item_type_name = ts("Work") %>
   <% end %>
 
@@ -54,10 +31,33 @@
       </li>
     <% end %>
     <% if @work.present? %>
-      <li><%= link_to ts("Edit Tags and Language"), edit_tags_work_path(@work) %></li>
+      <li>
+        <%= link_to ts("Edit Tags and Language"), edit_tags_work_path(@work) %>
+      </li>
+      <% if @work.spam? %>
+        <li>
+          <%= link_to ts("Mark Not Spam"), 
+                      { controller: "admin/user_creations",
+                        action: "set_spam",
+                        id: @work.id,
+                        creation_type: @work.class,
+                        spam: "false" } %>
+        </li>
+      <% else %>
+        <li>
+          <%= link_to ts("Mark As Spam"), 
+                      { controller: "admin/user_creations", 
+                        action: "set_spam",
+                        id: @work.id,
+                        creation_type: @work.class,
+                        spam: "true" } %>
+        </li>
+      <% end %>
     <% end %>
     <% if item.class == ExternalWork %>
-      <li><%= link_to ts("Edit External Work"), edit_external_work_path(item) %></li>
+      <li>
+        <%= link_to ts("Edit External Work"), edit_external_work_path(item) %>
+      </li>
     <% end %>
     <li><%= link_to ts("Delete %{item}", item: item_type_name),
                     { controller: "admin/user_creations",

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -148,7 +148,7 @@ Otwarchive::Application.routes.draw do
     resources :user_creations, only: [:destroy] do
       member do
         get :hide
-        get :set_spam
+        put :set_spam
       end
     end
     resources :users, controller: 'admin_users' do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -148,6 +148,7 @@ Otwarchive::Application.routes.draw do
     resources :user_creations, only: [:destroy] do
       member do
         get :hide
+        get :set_spam
       end
     end
     resources :users, controller: 'admin_users' do

--- a/features/admins/admin_works.feature
+++ b/features/admins/admin_works.feature
@@ -212,7 +212,7 @@ Feature: Admin Actions for Works and Bookmarks
     When I follow "Comments (1)"
     Then I should not see "rolex"
       And I should see "I loved this!"
-
+      
   Scenario: Admin can edit language on works when posting without previewing
     Given basic tags
       And basic languages
@@ -241,3 +241,25 @@ Feature: Admin Actions for Works and Bookmarks
     When I press "Update"
     Then I should see "Deutsch"
       And I should not see "English"
+
+  Scenario: can mark a work as spam
+  Given the work "Spammity Spam"
+    And I am logged in as an admin
+    And I view the work "Spammity Spam"
+  Then I should see "Mark As Spam"
+  When I follow "Mark As Spam"
+  Then I should see "marked as spam and hidden"
+    And I should see "Mark Not Spam"
+    And the work "Spammity Spam" should be marked as spam
+    And the work "Spammity Spam" should be hidden
+
+  Scenario: can mark a spam work as not-spam
+  Given the spam work "Spammity Spam"
+    And I am logged in as an admin
+    And I view the work "Spammity Spam"
+  Then I should see "Mark Not Spam"
+  When I follow "Mark Not Spam"
+  Then I should see "marked not spam and unhidden"
+    And I should see "Mark As Spam"
+    And the work "Spammity Spam" should not be marked as spam
+    And the work "Spammity Spam" should not be hidden

--- a/features/step_definitions/admin_steps.rb
+++ b/features/step_definitions/admin_steps.rb
@@ -356,6 +356,20 @@ Then (/^I should not see a translated admin post$/) do
   step %{I should not see "Translations: Deutsch"}
 end
 
+Then /^the work "([^\"]*)" should be hidden$/ do |work|
+  w = Work.find_by_title(work)
+  user = w.pseuds.first.user.login
+  step %{logged out users should not see the hidden work "#{work}" by "#{user}"}
+  step %{logged in users should not see the hidden work "#{work}" by "#{user}"}
+end
+
+Then /^the work "([^\"]*)" should not be hidden$/ do |work|
+  w = Work.find_by_title(work)
+  user = w.pseuds.first.user.login
+  step %{logged out users should see the unhidden work "#{work}" by "#{user}"}
+  step %{logged in users should see the unhidden work "#{work}" by "#{user}"}
+end
+
 Then /^logged out users should not see the hidden work "([^\"]*)" by "([^\"]*)"?/ do |work, user|
   step %{I am logged out}
   step %{I should not see the hidden work "#{work}" by "#{user}"}
@@ -457,4 +471,14 @@ Then(/^I should be able to comment with the address "([^"]*)"$/) do |email|
   step %{I post the comment "I loved this" on the work "New Work" as a guest with email "#{email}"}
   step %{I should not see "has been blocked at the owner's request"}
   step %{I should see "Comment created!"}
+end
+
+Then /^the work "([^\"]*)" should be marked as spam/ do |work|
+  w = Work.find_by_title(work)
+  assert w.spam?
+end
+
+Then /^the work "([^\"]*)" should not be marked as spam/ do |work|
+  w = Work.find_by_title(work)
+  assert !w.spam?
 end

--- a/features/step_definitions/work_steps.rb
+++ b/features/step_definitions/work_steps.rb
@@ -208,6 +208,14 @@ Given /^there is a work "([^"]*)" in an unrevealed collection "([^"]*)"$/ do |wo
   step %{I am logged out}
 end
 
+Given /^the spam work "([^\"]*)"$/ do |work|
+  step %{I have a work "#{work}"}
+  step %{I am logged out}
+  w = Work.find_by_title(work)
+  w.update_attribute(:spam, true)
+  w.update_attribute(:hidden_by_admin, true)
+end
+
 ### WHEN
 
 When /^I view the ([\d]+)(?:st|nd|rd|th) chapter$/ do |chapter_no|


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-4331

## Purpose

Adds button to works in admin view to mark them as spam or ham, so Akismet can learn. After this is merged, [AO3-4330](https://otwarchive.atlassian.net/browse/AO3-4330) will also report works to Akismet as spam when they are batch-deleted.

## Testing

Refer to JIRA

## References

Update of #2163 

## Credit

This is primarily Naomi's code and she should be credited.