### PR TITLE
AO3-5205: Prevent sign ups with duplicate emails in the invite queue

### DIFF
--- a/app/models/invite_request.rb
+++ b/app/models/invite_request.rb
@@ -20,7 +20,7 @@ class InviteRequest < ApplicationRecord
   def set_simplified_email
     return if email.blank?
     simplified = AdminBlacklistedEmail.canonical_email(email).split('@')
-    self.simplified_email = simplified.first.gsub(".", "") + "@#{simplified.last}"
+    self.simplified_email = simplified.first.delete(".").gsub(/\+.+$/, "") + "@#{simplified.last}"
   end
 
   # Doing this with a method so the error message makes more sense

--- a/app/models/invite_request.rb
+++ b/app/models/invite_request.rb
@@ -3,7 +3,9 @@ class InviteRequest < ApplicationRecord
   acts_as_list
   validates :email, presence: true, email_veracity: true
   validates_uniqueness_of :email, message: "is already part of our queue."
+  validate :simplified_email_uniqueness
   before_validation :compare_with_users, on: :create
+  before_validation :set_simplified_email, on: :save
 
   # Realign positions if they're incorrect
   def self.reset_order
@@ -11,6 +13,20 @@ class InviteRequest < ApplicationRecord
     unless first_request && first_request.position == 1
       requests = order(:position)
       requests.each_with_index {|request, index| request.update_attribute(:position, index + 1)}
+    end
+  end
+
+  # Borrow the blacklist cleaner but just strip out all the periods for all domains
+  def set_simplified_email
+    return if email.blank?
+    simplified = AdminBlacklistedEmail.canonical_email(email).split('@')
+    self.simplified_email = simplified.first.gsub(".", "") + "@#{simplified.last}"
+  end
+
+  # Doing this with a method so the error message makes more sense
+  def simplified_email_uniqueness
+    if InviteRequest.where(simplified_email: simplified_email).exists?
+      errors.add(:email, "is already part of our queue.")
     end
   end
 

--- a/app/models/invite_request.rb
+++ b/app/models/invite_request.rb
@@ -3,9 +3,9 @@ class InviteRequest < ApplicationRecord
   acts_as_list
   validates :email, presence: true, email_veracity: true
   validates_uniqueness_of :email, message: "is already part of our queue."
-  validate :simplified_email_uniqueness
   before_validation :compare_with_users, on: :create
-  before_validation :set_simplified_email, on: :save
+  before_validation :set_simplified_email, on: :create
+  validate :simplified_email_uniqueness, on: :create
 
   # Realign positions if they're incorrect
   def self.reset_order
@@ -25,7 +25,7 @@ class InviteRequest < ApplicationRecord
 
   # Doing this with a method so the error message makes more sense
   def simplified_email_uniqueness
-    if InviteRequest.where(simplified_email: simplified_email).where.not(id: id).exists?
+    if InviteRequest.where(simplified_email: simplified_email).exists?
       errors.add(:email, "is already part of our queue.")
     end
   end

--- a/app/models/invite_request.rb
+++ b/app/models/invite_request.rb
@@ -25,7 +25,7 @@ class InviteRequest < ApplicationRecord
 
   # Doing this with a method so the error message makes more sense
   def simplified_email_uniqueness
-    if InviteRequest.where(simplified_email: simplified_email).exists?
+    if InviteRequest.where(simplified_email: simplified_email).where.not(id: id).exists?
       errors.add(:email, "is already part of our queue.")
     end
   end

--- a/app/validators/email_veracity_validator.rb
+++ b/app/validators/email_veracity_validator.rb
@@ -5,23 +5,13 @@ class EmailVeracityValidator < ActiveModel::EachValidator
   def validate_each(record,attribute,value)
     if options[:allow_blank] && value.blank?
       result = true
+    elsif value.blank?
+      result = false
     else
       begin
         mail = Mail::Address.new(value)
         # We must check that value contains a domain and that value is an email address
-        result = mail.domain && mail.address == value
-
-        # We need to dig into treetop
-        # user@localhost is excluded
-        # treetop must respond to domain
-        # We exclude valid email values like <user@localhost.com>
-        # Hence we use m.__send__(tree).domain
-        # treetop = mail.__send__(:tree)
-
-        # A valid domain must have dot_atom_text elements size > 1
-        
-        # treetop was deprecated out of the mail gem
-        result #&&= (treetop.domain.dot_atom_text.elements.size > 1)
+        result = mail.domain && mail.domain.match('\.') && mail.address == value
       rescue Exception => e
         result = false
       end

--- a/app/validators/email_veracity_validator.rb
+++ b/app/validators/email_veracity_validator.rb
@@ -11,7 +11,7 @@ class EmailVeracityValidator < ActiveModel::EachValidator
       begin
         mail = Mail::Address.new(value)
         # We must check that value contains a domain and that value is an email address
-        result = mail.domain && mail.domain.match('\.') && mail.address == value
+        result = mail.domain&.match('\.') && mail.address == value
       rescue Exception => e
         result = false
       end

--- a/db/migrate/20171030201300_add_simplified_email_to_invite_requests.rb
+++ b/db/migrate/20171030201300_add_simplified_email_to_invite_requests.rb
@@ -1,0 +1,5 @@
+class AddSimplifiedEmailToInviteRequests < ActiveRecord::Migration[5.1]
+  def change
+    add_column :invite_requests, :simplified_email, :string, null: false, default: ''
+  end
+end

--- a/db/migrate/20171030220348_add_index_to_invite_queue_emails.rb
+++ b/db/migrate/20171030220348_add_index_to_invite_queue_emails.rb
@@ -1,0 +1,5 @@
+class AddIndexToInviteQueueEmails < ActiveRecord::Migration[5.1]
+  def change
+    add_index :invite_requests, :simplified_email, unique: true
+  end
+end

--- a/factories/invitations.rb
+++ b/factories/invitations.rb
@@ -3,7 +3,9 @@ require 'faker'
 FactoryGirl.define do
 
   factory :invite_request do
-    email
+    sequence :email do |n|
+      Faker::Internet.email(name="#{Faker::Name.first_name}_#{n}")
+    end
   end
 
   factory :invitation do

--- a/spec/models/invite_request_spec.rb
+++ b/spec/models/invite_request_spec.rb
@@ -1,24 +1,39 @@
 require 'spec_helper'
 describe InviteRequest, :ready do
   describe "Validation" do
-
     context "Invalid email" do
-
       it "invitation is not created for a blank email" do
         @invite = build(:invite_request, email: nil)
-        expect(@invite.save).to be_falsey
+        expect(@invite.valid?).to be_falsey
         expect(@invite.errors[:email]).not_to be_empty
       end
 
       BAD_EMAILS.each do |email|
-        let(:bad_email) {build(:user, email: email)}
         it "cannot be created if the email does not pass veracity check" do
-          expect(bad_email.save).to be_falsey
+          bad_email = build(:user, email: email)
+          expect(bad_email.valid?).to be_falsey
           expect(bad_email.errors[:email]).to include("should look like an email address.")
           expect(bad_email.errors[:email]).to include("does not seem to be a valid address.")
         end
       end
     end
 
+    context "Duplicate email" do
+      before :all do
+        @original_request = create(:invite_request, email: "thegodthor@gmail.com")
+      end
+
+      it "should not let you sign up again with the same email" do
+        dup_request = build(:invite_request, email: @original_request.email)
+        expect(dup_request.valid?).to be_falsey
+        expect(dup_request.errors[:email]).to include("is already part of our queue.")
+      end
+
+      it "should not allow duplicates with periods and plus signs" do
+        dup_request = build(:invite_request, email: "the.god.thor+marvel@gmail.com")
+        expect(dup_request.valid?).to be_falsey
+        expect(dup_request.errors[:email]).to include("is already part of our queue.")
+      end
+    end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -66,7 +66,7 @@ RSpec.configure do |config|
   # instead of true.
   config.use_transactional_fixtures = true
 
-  BAD_EMAILS = ['Abc.example.com','A@b@c@example.com','a\"b(c)d,e:f;g<h>i[j\k]l@example.com','just"not"right@example.com','this is"not\allowed@example.com','this\ still\"not/\/\allowed@example.com', 'nodomain']
+  BAD_EMAILS = ['Abc.example.com','A@b@c@example.com','a\"b(c)d,e:f;g<h>i[j\k]l@example.com','this is"not\allowed@example.com','this\ still\"not/\/\allowed@example.com', 'nodomain', 'foo@oops']
   INVALID_URLS = ['no_scheme.com', 'ftp://ftp.address.com','http://www.b@d!35.com','https://www.b@d!35.com','http://b@d!35.com','https://www.b@d!35.com']
   VALID_URLS = ['http://rocksalt-recs.livejournal.com/196316.html','https://rocksalt-recs.livejournal.com/196316.html']
   INACTIVE_URLS = ['https://www.iaminactive.com','http://www.iaminactive.com','https://iaminactive.com','http://iaminactive.com']

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -66,10 +66,10 @@ RSpec.configure do |config|
   # instead of true.
   config.use_transactional_fixtures = true
 
-  BAD_EMAILS = ['Abc.example.com','A@b@c@example.com','a\"b(c)d,e:f;g<h>i[j\k]l@example.com','this is"not\allowed@example.com','this\ still\"not/\/\allowed@example.com', 'nodomain', 'foo@oops']
-  INVALID_URLS = ['no_scheme.com', 'ftp://ftp.address.com','http://www.b@d!35.com','https://www.b@d!35.com','http://b@d!35.com','https://www.b@d!35.com']
-  VALID_URLS = ['http://rocksalt-recs.livejournal.com/196316.html','https://rocksalt-recs.livejournal.com/196316.html']
-  INACTIVE_URLS = ['https://www.iaminactive.com','http://www.iaminactive.com','https://iaminactive.com','http://iaminactive.com']
+  BAD_EMAILS = ['Abc.example.com', 'A@b@c@example.com', 'a\"b(c)d,e:f;g<h>i[j\k]l@example.com', 'this is"not\allowed@example.com', 'this\ still\"not/\/\allowed@example.com', 'nodomain', 'foo@oops'].freeze
+  INVALID_URLS = ['no_scheme.com', 'ftp://ftp.address.com', 'http://www.b@d!35.com', 'https://www.b@d!35.com', 'http://b@d!35.com', 'https://www.b@d!35.com'].freeze
+  VALID_URLS = ['http://rocksalt-recs.livejournal.com/196316.html', 'https://rocksalt-recs.livejournal.com/196316.html'].freeze
+  INACTIVE_URLS = ['https://www.iaminactive.com', 'http://www.iaminactive.com', 'https://iaminactive.com', 'http://iaminactive.com'].freeze
 
   # rspec-rails 3 will no longer automatically infer an example group's spec type
   # from the file location. You can explicitly opt-in to the feature using this


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5205

## Purpose

Prevents users from requesting invites multiple times for the same email address. Also fixes the validator to require a full domain.

## Testing

See issue.