### PR TITLE
AO3-5235 Block requesting invitations when the queue is disabled

### DIFF
--- a/app/controllers/invite_requests_controller.rb
+++ b/app/controllers/invite_requests_controller.rb
@@ -22,6 +22,13 @@ class InviteRequestsController < ApplicationController
 
   # POST /invite_requests
   def create
+    unless @admin_settings.invite_from_queue_enabled?
+      flash[:error] = ts("<strong>New invitation requests are currently closed.</strong> For more information, please check the %{news}.",
+                         news: view_context.link_to("\"Invitations\" tag on AO3 News", admin_posts_path(tag_id: 143))).html_safe
+      redirect_to invite_requests_path
+      return
+    end
+
     @invite_request = InviteRequest.new(invite_request_params)
     if @invite_request.save
       flash[:notice] = "You've been added to our queue! Yay! We estimate that you'll receive an invitation around #{@invite_request.proposed_fill_date}. We strongly recommend that you add do-not-reply@archiveofourown.org to your address book to prevent the invitation email from getting blocked as spam by your email provider."

--- a/spec/controllers/invite_requests_controller_spec.rb
+++ b/spec/controllers/invite_requests_controller_spec.rb
@@ -65,6 +65,19 @@ describe InviteRequestsController do
       invite_request = InviteRequest.find_by_email(email)
       it_redirects_to_with_notice(invite_requests_path, "You've been added to our queue! Yay! We estimate that you'll receive an invitation around #{invite_request.proposed_fill_date}. We strongly recommend that you add do-not-reply@archiveofourown.org to your address book to prevent the invitation email from getting blocked as spam by your email provider.")
     end
+
+    context "invite queue is disabled" do
+      before do
+        AdminSetting.first.update_attribute(:invite_from_queue_enabled, false)
+      end
+
+      it "redirects to index with error" do
+        post :create, params: { invite_request: { email: generate(:email) } }
+        it_redirects_to(invite_requests_path)
+        expect(flash[:error]).to include("New invitation requests are currently closed.")
+        expect(assigns(:admin_settings).invite_from_queue_enabled?).to be_falsey
+      end
+    end
   end
 
   describe "DELETE #destroy" do


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5235

## Purpose

When the queue is disabled, users can still request invitations, even if those don't get sent out. Users should not be able to.

## Testing

See JIRA issue.