### PR TITLE
AO3-4905 Removed check for recently reset password in change email sc…

### DIFF
--- a/app/views/users/change_email.html.erb
+++ b/app/views/users/change_email.html.erb
@@ -19,10 +19,8 @@
     <dt><%= label_tag :email_confirmation, ts("Confirm New Email") %></dt>
     <dd><%= email_field_tag :email_confirmation %></dd>
 
-    <% unless @user.recently_reset? %>
-      <dt><%= label_tag :password_check, ts("Password") %></dt>
-      <dd><%= password_field_tag :password_check%></dd>
-    <% end %>
+    <dt><%= label_tag :password_check, ts("Password") %></dt>
+    <dd><%= password_field_tag :password_check%></dd>
 
     <dt class="landmark"><%= label_tag :submit, ts("Submit") %></dt>
     <dd class="submit actions">

--- a/app/views/users/change_email.html.erb
+++ b/app/views/users/change_email.html.erb
@@ -20,7 +20,10 @@
     <dd><%= email_field_tag :email_confirmation %></dd>
 
     <dt><%= label_tag :password_check, ts("Password") %></dt>
-    <dd><%= password_field_tag :password_check%></dd>
+    <%= password_field_tag :password_check, nil, "aria-describedby" => "password-field-description" %>
+    <p class="footnote" id="password-field-description">
+      <%= ts("This must be your current password, not a reset password that was emailed to you.") %>
+    </p>
 
     <dt class="landmark"><%= label_tag :submit, ts("Submit") %></dt>
     <dd class="submit actions">

--- a/app/views/users/change_email.html.erb
+++ b/app/views/users/change_email.html.erb
@@ -20,10 +20,12 @@
     <dd><%= email_field_tag :email_confirmation %></dd>
 
     <dt><%= label_tag :password_check, ts("Password") %></dt>
-    <%= password_field_tag :password_check, nil, "aria-describedby" => "password-field-description" %>
-    <p class="footnote" id="password-field-description">
-      <%= ts("This must be your current password, not a reset password that was emailed to you.") %>
-    </p>
+    <dd>
+      <%= password_field_tag :password_check, nil, "aria-describedby" => "password-field-description" %>
+      <p class="footnote" id="password-field-description">
+        <%= ts("This must be your current password, not a reset password that was emailed to you.") %>
+      </p>
+    </dd>
 
     <dt class="landmark"><%= label_tag :submit, ts("Submit") %></dt>
     <dd class="submit actions">

--- a/features/other_a/profile_edit.feature
+++ b/features/other_a/profile_edit.feature
@@ -12,46 +12,46 @@ Background:
   And I want to edit my profile
 
 
-Scenario: Edit profile - add details
+Scenario: Add details
 
   When I fill in the details of my profile
     Then I should see "Your profile has been successfully updated"
 	And 0 emails should be delivered
 
-Scenario: Edit profile - change details
+Scenario: Change details
 
   When I change the details in my profile
     Then I should see "Your profile has been successfully updated"
 	And 0 emails should be delivered
 
-Scenario:	Edit profile - remove details
+Scenario: Remove details
 
   When I remove details from my profile
     Then I should see "Your profile has been successfully updated"
     And 0 emails should be delivered
 
-Scenario: Edit profile - changing email address requires reauthenticating
+Scenario: Changing email address requires reauthenticating
 
   When I follow "Change Email"
-  And I fill in "New Email" with "blah"
-  And I fill in "Confirm New Email" with "blah"
+  And I fill in "New Email" with "blah@a.com"
+  And I fill in "Confirm New Email" with "blah@a.com"
   And I press "Change Email"
     Then I should see "You must enter your password"
     And 0 emails should be delivered
 
-Scenario: Edit profile - changing email address - entering an invalid email address
+Scenario: Changing email address - entering an invalid email address
 
   When I enter an invalid email
 	Then I should see "Email does not seem to be a valid address"
 	And 0 emails should be delivered
 
-Scenario: Edit profile - changing email address - entering an incorrect password
+Scenario: Changing email address - entering an incorrect password
 
   When I enter an incorrect password
     Then I should see "Your password was incorrect"
 	And 0 emails should be delivered
 
-Scenario: Edit profile - Changing email address and viewing
+Scenario: Changing email address and viewing
 
   When I change my email
     Then I should see "Your email has been successfully updated"
@@ -62,10 +62,9 @@ Scenario: Edit profile - Changing email address and viewing
 	When I change my preferences to display my email address
 	  Then I should see "My email address: valid2@archiveofourown.org"
 
-Scenario: Edit profile - Changing email address after requesting temporary password
+Scenario: Changing email address after requesting temporary password
 
   When I am logged out
-    And I am on the home page
     And I follow "Forgot password?"
     And I fill in "reset_password_for" with "editname"
     And I press "Reset Password"
@@ -82,7 +81,7 @@ Scenario: Edit profile - Changing email address after requesting temporary passw
   When I change my preferences to display my email address
   Then I should see "My email address: valid2@archiveofourown.org"
 
-Scenario: Edit profile - Changing email address after requesting temporary password by entering temporary password
+Scenario: Changing email address after requesting temporary password by entering temporary password
 
   When I am logged out
     And I am on the home page
@@ -94,21 +93,21 @@ Scenario: Edit profile - Changing email address after requesting temporary passw
     And I am logged in as "editname"
     And I want to edit my profile
     And I enter a temporary password for user editname
- Then I should see "Your password was incorrect"
-	And 0 emails should be delivered
+  Then I should see "Your password was incorrect"
+    And 0 emails should be delivered
 
-Scenario: Edit profile -  Changing email address -- can't be the same as another user's
+Scenario: Changing email address -- can't be the same as another user's
 
   When I enter a duplicate email
 	Then I should see "Email has already been taken"
 	And 0 emails should be delivered
 
-Scenario: Edit profile - date of birth - under age
+Scenario: Date of birth - under age
 
   When I enter a birthdate that shows I am under age
     Then I should see "You must be over 13"
 
-Scenario: Edit profile - entering date of birth and displaying
+Scenario: Entering date of birth and displaying
 
   When I fill in my date of birth
     Then I should see "Your profile has been successfully updated"
@@ -116,17 +115,17 @@ Scenario: Edit profile - entering date of birth and displaying
     Then I should see "My birthday: 1980-11-30"
 	  And 0 emails should be delivered
 
-Scenario: Edit profile - change password - mistake in typing old password
+Scenario: Change password - mistake in typing old password
 
   When I make a mistake typing my old password
     Then I should see "Your old password was incorrect"
 
-Scenario: Edit profile - change password - mistake in typing new password confirmation
+Scenario: Change password - mistake in typing new password confirmation
 
   When I make a typing mistake confirming my new password
     Then I should see "Password confirmation doesn't match confirmation"
 
-Scenario: Edit profile - change password
+Scenario: Change password
 
   When I change my password
     Then I should see "Your password has been changed"

--- a/features/other_a/profile_edit.feature
+++ b/features/other_a/profile_edit.feature
@@ -62,6 +62,41 @@ Scenario: Edit profile - Changing email address and viewing
 	When I change my preferences to display my email address
 	  Then I should see "My email address: valid2@archiveofourown.org"
 
+Scenario: Edit profile - Changing email address after requesting temporary password
+
+  When I am logged out
+    And I am on the home page
+    And I follow "Forgot password?"
+    And I fill in "reset_password_for" with "editname"
+    And I press "Reset Password"
+  Then 1 email should be delivered to "bar@ao3.org"
+  When all emails have been delivered
+    And I am logged in as "editname"
+    And I want to edit my profile
+    And I change my email
+  Then I should see "Your email has been successfully updated"
+    And 1 email should be delivered to "bar@ao3.org"
+    And the email should contain "the email associated with your account has been changed to"
+    And the email should contain "valid2@archiveofourown.org"
+    And the email should not contain "translation missing"
+  When I change my preferences to display my email address
+  Then I should see "My email address: valid2@archiveofourown.org"
+
+Scenario: Edit profile - Changing email address after requesting temporary password by entering temporary password
+
+  When I am logged out
+    And I am on the home page
+    And I follow "Forgot password?"
+    And I fill in "reset_password_for" with "editname"
+    And I press "Reset Password"
+  Then 1 email should be delivered to "bar@ao3.org"
+  When all emails have been delivered
+    And I am logged in as "editname"
+    And I want to edit my profile
+    And I enter a temporary password for user editname
+ Then I should see "Your password was incorrect"
+	And 0 emails should be delivered
+
 Scenario: Edit profile -  Changing email address -- can't be the same as another user's
 
   When I enter a duplicate email

--- a/features/step_definitions/profile_steps.rb
+++ b/features/step_definitions/profile_steps.rb
@@ -50,7 +50,7 @@ When /^I change my email$/ do
   click_link("Change Email")
   fill_in("new_email", with: "valid2@archiveofourown.org")
   fill_in("email_confirmation", with: "valid2@archiveofourown.org")
-  fill_in("password_check", "password")
+  fill_in("password_check", with: "password")
   click_button("Change Email")
 end
 

--- a/features/step_definitions/profile_steps.rb
+++ b/features/step_definitions/profile_steps.rb
@@ -37,12 +37,20 @@ When /^I enter an incorrect password$/ do
   click_button("Change Email")
 end
 
-
-When /^I change my email$/ do
+When /^I enter a temporary password for user (.*)$/ do |login|
   click_link("Change Email")
   fill_in("new_email", with: "valid2@archiveofourown.org")
   fill_in("email_confirmation", with: "valid2@archiveofourown.org")
-  fill_in("password_check", with: "password")
+  user = User.find_by(login: login)
+  fill_in("password_check", with: user.activation_code)
+  click_button("Change Email")
+end
+
+When /^I change my email$/ do |password|
+  click_link("Change Email")
+  fill_in("new_email", with: "valid2@archiveofourown.org")
+  fill_in("email_confirmation", with: "valid2@archiveofourown.org")
+  fill_in("password_check", "password")
   click_button("Change Email")
 end
 

--- a/features/step_definitions/profile_steps.rb
+++ b/features/step_definitions/profile_steps.rb
@@ -46,7 +46,7 @@ When /^I enter a temporary password for user (.*)$/ do |login|
   click_button("Change Email")
 end
 
-When /^I change my email$/ do |password|
+When /^I change my email$/ do
   click_link("Change Email")
   fill_in("new_email", with: "valid2@archiveofourown.org")
   fill_in("email_confirmation", with: "valid2@archiveofourown.org")


### PR DESCRIPTION
…reen

## Issue

https://otwarchive.atlassian.net/browse/AO3-4905

## Purpose

This removes the check from email_change screen whether the user has recently requested a temporary password. This should not matter in this screen.

This could actually be used maliciously as well.

## Testing

Request temporary password. You could still login with normal password and change emails.

## Credit

Tal Hayon.
Please use he.
