### PR TITLE
AO3-5240 Revert timezone in gift exchange test to Papua New Guinea again

### DIFF
--- a/features/gift_exchanges/challenge_giftexchange.feature
+++ b/features/gift_exchanges/challenge_giftexchange.feature
@@ -52,10 +52,11 @@ Feature: Gift Exchange Challenge
     Given I am logged in as "mod1"
       And I have created the gift exchange "My Gift Exchange"
       And I am on "My Gift Exchange" gift exchange edit page
-    When I select "(GMT-08:00) Pacific Time (US & Canada)" from "gift_exchange_time_zone"
-      And I submit
-    Then I should see "Challenge was successfully updated"
-    Then I should see "PDT"
+    # Port Moresby does not do Daylight Saving Time - do not change this timezone or the test breaks at the end of DST
+    When I select "(GMT+10:00) Port Moresby" from "gift_exchange_time_zone"
+    And I submit
+      Then I should see "Challenge was successfully updated"
+      Then I should see "PGT"
 
   Scenario: Add a co-mod
     Given the following activated users exist


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5240

## Purpose

Reverts a test broken in the Rails 4 upgrade due to a change of timezone.

## Testing

Automated test only.

## References

https://otwarchive.atlassian.net/browse/AO3-4132 (original fix)