### PR TITLE
AO3-5099 Add option for exact string match for admin user search

### DIFF
--- a/app/controllers/admin/admin_users_controller.rb
+++ b/app/controllers/admin/admin_users_controller.rb
@@ -6,7 +6,9 @@ class Admin::AdminUsersController < ApplicationController
   def index
     @role_values = @roles.map{ |role| [role.name.humanize.titlecase, role.name] }
     @role = Role.find_by(name: params[:role]) if params[:role]
-    @users = User.search_by_role(@role, params[:query], inactive: params[:inactive], page: params[:page])
+    @users = User.search_by_role(@role,
+                                 params[:query],
+                                 inactive: params[:inactive], exact: params[:exact], page: params[:page])
   end
 
   def bulk_search

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -267,11 +267,11 @@
       users = users.joins(:roles).where("roles.id = ?", role.id)
     end
     if query.present?
-      if (options[:exact])
-        users = users.joins(:pseuds).where("pseuds.name = ? OR email = ?", "#{query}", "#{query}")
-      else
-        users = users.joins(:pseuds).where("pseuds.name LIKE ? OR email LIKE ?", "%#{query}%", "%#{query}%")
-      end
+      users = if options[:exact]
+                users.joins(:pseuds).where("pseuds.name = ? OR email = ?", query.to_s, query.to_s)
+              else
+                users.joins(:pseuds).where("pseuds.name LIKE ? OR email LIKE ?", "%#{query}%", "%#{query}%")
+              end
     end
     users.paginate(page: options[:page] || 1)
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -267,7 +267,11 @@
       users = users.joins(:roles).where("roles.id = ?", role.id)
     end
     if query.present?
-      users = users.joins(:pseuds).where("pseuds.name LIKE ? OR email LIKE ?", "%#{query}%", "%#{query}%")
+      if (options[:exact])
+        users = users.joins(:pseuds).where("pseuds.name = ? OR email = ?", "#{query}", "#{query}")
+      else
+        users = users.joins(:pseuds).where("pseuds.name LIKE ? OR email LIKE ?", "%#{query}%", "%#{query}%")
+      end
     end
     users.paginate(page: options[:page] || 1)
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -272,6 +272,16 @@
     users.paginate(page: options[:page] || 1)
   end
 
+  def self.filter_by_name_or_email(users, query, exact)
+    if exact
+      users.joins(:pseuds).where("pseuds.name = ? OR email = ?", query.to_s, query.to_s)
+    else
+      users.joins(:pseuds).where("pseuds.name LIKE ? OR email LIKE ?", "%#{query}%", "%#{query}%")
+    end
+  end
+
+  private_class_method :filter_by_name_or_email
+
   def self.search_multiple_by_email(emails = [])
     users = User.where(email: emails)
     found_emails = users.map(&:email)
@@ -395,14 +405,6 @@
       self.roles = Role.find(role_list)
     else
       self.roles = []
-    end
-  end
-
-  def self.filter_by_name_or_email(users, query, exact)
-    if exact
-      users.joins(:pseuds).where("pseuds.name = ? OR email = ?", query.to_s, query.to_s)
-    else
-      users.joins(:pseuds).where("pseuds.name LIKE ? OR email LIKE ?", "%#{query}%", "%#{query}%")
     end
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -267,11 +267,7 @@
       users = users.joins(:roles).where("roles.id = ?", role.id)
     end
     if query.present?
-      users = if options[:exact]
-                users.joins(:pseuds).where("pseuds.name = ? OR email = ?", query.to_s, query.to_s)
-              else
-                users.joins(:pseuds).where("pseuds.name LIKE ? OR email LIKE ?", "%#{query}%", "%#{query}%")
-              end
+      users = filter_by_name_or_email(users, query, options[:exact])
     end
     users.paginate(page: options[:page] || 1)
   end
@@ -399,6 +395,14 @@
       self.roles = Role.find(role_list)
     else
       self.roles = []
+    end
+  end
+
+  def self.filter_by_name_or_email(users, query, exact)
+    if exact
+      users.joins(:pseuds).where("pseuds.name = ? OR email = ?", query.to_s, query.to_s)
+    else
+      users.joins(:pseuds).where("pseuds.name LIKE ? OR email LIKE ?", "%#{query}%", "%#{query}%")
     end
   end
 

--- a/app/views/admin/admin_users/index.html.erb
+++ b/app/views/admin/admin_users/index.html.erb
@@ -16,6 +16,11 @@
         <%= check_box_tag "inactive", "1", params[:inactive].present? %>
         <%= label_tag "inactive", ts("Not yet activated") %>
       </dd>
+      <dt><%= label_tag "settings", ts("Search Settings") %></dt>
+      <dd>
+        <%= check_box_tag "exact", "1", params[:exact].present? %>
+        <%= label_tag "exact", ts("Exact match only") %>
+      </dd>
     </dl>
     <p class="submit"><%= submit_tag ts("Find") %></p>
   <% end %>

--- a/features/admins/users/admin_find_users.feature
+++ b/features/admins/users/admin_find_users.feature
@@ -20,12 +20,32 @@ Feature: Admin Find Users page
       And I should see "userB"
       And I should see "userCB"
 
+  Scenario: The Find Users page should perform a exact match on name if exact is checked
+    When I check "exact"
+      And I fill in "query" with "user"
+      And I submit
+    Then I should see "0 users found"
+    When I fill in "query" with "userA"
+      And I submit
+    Then the field labeled "user_email" should contain "a@ao3.org"
+      But I should not see "UserB"
+
   Scenario: The Find Users page should perform a partial match by email
     When I fill in "query" with "bo3"
       And I submit
     Then I should see "userB"
       And I should see "userCB"
       But I should not see "userA"
+
+  Scenario: The Find Users page should perform a exact match on email if exact is checked
+    When I check "exact"
+      And I fill in "query" with "not_email"
+      And I submit
+    Then I should see "0 users found"
+    When I fill in "query" with "a@ao3.org"
+      And I submit
+    Then I should see "userA"
+      But I should not see "UserB"
 
   Scenario: The Find Users page should perform an exact match by role
     When I select "Archivist" from "role"


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5099

## Purpose

Adds an option for exact string matching in admin user search.

## Testing

Search for user names with exact matching checked.

I've also added feature tests for email and user names when exact is checked.

## Credit

Tal Hayon

Please use he.
