### PR TITLE
AO3-4579 Challenge signup/creation email address warning

### DIFF
--- a/app/views/challenge_signups/_signup_form.html.erb
+++ b/app/views/challenge_signups/_signup_form.html.erb
@@ -21,9 +21,9 @@
   </noscript>
 <% end %>
 
-
-<%= form_for([@collection, @challenge_signup], :url => (@challenge_signup.new_record? ? collection_signups_path(@collection) : collection_signup_path(@collection, @challenge_signup))) do |signup_form| %>
-  <p class="required notice"><%= ts('* Required information') %></p>
+<%= form_for([@collection, @challenge_signup], :url => (@challenge_signup.new_record? ? collection_signups_path(@collection) : collection_signup_path(@collection))) do |signup_form| %>
+  <p class="notes"><%= ts("Challenge maintainers may have access to the email address associated with your AO3 account for the purpose of communicating with you about the challenge.") %></p>
+  <p class="required notice"><%= ts("* Required information") %></p>
   <% unless @challenge_signup.errors.empty? %>
     <div class="error">
       <h4 class="heading"><%= ts("There were some problems with this submission. Please correct the mistakes below.") %></h4>

--- a/app/views/collections/_form.html.erb
+++ b/app/views/collections/_form.html.erb
@@ -60,7 +60,7 @@
           <%= ts("JPG, GIF, PNG") %>
         </p>
       </dd>
-      
+
       <dt><%= ts("Icon") %></dt>
       <dd>
         <ul class="notes">
@@ -163,6 +163,13 @@
         <% type = @collection.challenge ? @collection.challenge.class.name : @challenge_type %>
         <dd>
           <%= select_tag :challenge_type, options_for_select(Collection::CHALLENGE_TYPE_OPTIONS, type) %>
+        </dd>
+        <dt><strong><%= ts("Notice to challenge creators") %></strong></dt>
+        <dd>
+          <ul class="notes">
+            <li><%= ts("As a challenge owner, you may have access to challenge participants' email addresses.") %></li>
+            <li><%= ts("Use of those email addresses for any purpose other than running the challenge will lead to the termination of your account.") %></li>
+          </ul>
         </dd>
       </dl>
     </fieldset>


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-4579

## Purpose

informs users signing up for challenges that the creator of the challenge may have access to their email address and warns challenge creators about using email addresses for anything other than running the challenge. 

i think (?) javascript would have been necessary to dynamically add a mandatory tick box to the page when someone chooses to make their collection a challenge, and to remove the tick box if/when they unselect a challenge. in which case there would have to be a noscript workaround for that too. or if you have the mandatory tick box there all the time regardless of whether or not the user is making their collection a challenge, then people might get annoyed if they ignore that part of the form and then hit submit and receive an error for not ticking a box they didn't think was relevant to them... so i thought it'd be simpler and would require less code to just add a note in the appropriate area. but if a mandatory tick box is a more solid solution i can work on that on instead

## Testing

please make sure that on challenge signup pages there's a blue warning above the "required information" note that warns the user about their email address possibly being made available

and also that in the challenge creation page there's a blue note warning the challenge creator that use of email addresses for anything other than running the challenge will lead to termination of their account