### PR TITLE
AO3-4896 remove delete chapter button from work/chapter view

### DIFF
--- a/app/views/chapters/_chapter_management.html.erb
+++ b/app/views/chapters/_chapter_management.html.erb
@@ -7,9 +7,5 @@
       <% end %>
     </li>
   <% end %>
-
   <li><%= link_to ts('Edit Chapter'), [:edit, work, chapter] %></li>
-  <% if work.chapters.count > 1 %>
-    <li><%= link_to ts('Delete Chapter'), [:confirm_delete, work, chapter], data: {confirm: ts('Are you sure you want to delete this chapter? This will delete all comments on the chapter as well and cannot be undone!')} %></li>
-  <% end %>
 </ul>


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-4896

## Purpose

removes the "delete chapter" button that displays in the work/chapter view when a work has more than one chapter. to avoid accidental deletion, chapter deletion should only be accessible from the edit chapter or edit work view

## Testing

please view one of your multi-chaptered works and ensure that there is no "delete chapter" button beside the "edit chapter" button above the chapter title