### PR TITLE
AO3-4222 Fix links to news post tag and capitalization of spam

### DIFF
--- a/app/controllers/invite_requests_controller.rb
+++ b/app/controllers/invite_requests_controller.rb
@@ -11,7 +11,7 @@ class InviteRequestsController < ApplicationController
     fetch_admin_settings # we normally skip this for js requests
     @invite_request = InviteRequest.find_by(email: params[:email])
     unless (request.xml_http_request?) || @invite_request
-      flash[:error] = "You can search for the email address you signed up with below. If you can't find it, your invitation may have already been emailed to that address; please check your email Spam folder as your spam filters may have placed it there."
+      flash[:error] = "You can search for the email address you signed up with below. If you can't find it, your invitation may have already been emailed to that address; please check your email spam folder as your spam filters may have placed it there."
       redirect_to status_invite_requests_path and return
     end
     respond_to do |format|
@@ -24,7 +24,7 @@ class InviteRequestsController < ApplicationController
   def create
     unless @admin_settings.invite_from_queue_enabled?
       flash[:error] = ts("<strong>New invitation requests are currently closed.</strong> For more information, please check the %{news}.",
-                         news: view_context.link_to("\"Invitations\" tag on AO3 News", admin_posts_path(tag_id: 143))).html_safe
+                         news: view_context.link_to("\"Invitations\" tag on AO3 News", admin_posts_path(tag: 143))).html_safe
       redirect_to invite_requests_path
       return
     end

--- a/app/views/home/_intro_module.html.erb
+++ b/app/views/home/_intro_module.html.erb
@@ -12,7 +12,7 @@
                the %{news} for more information, or if you have already requested 
                an invitation, you can %{status}.",
                news: link_to("\"Invitations\" tag on AO3 News",
-                     admin_posts_path(tag_id: 143)),
+                     admin_posts_path(tag: 143)),
                status: link_to("check your position on the waiting list",
                        status_invite_requests_path)
             ).html_safe %>

--- a/app/views/invite_requests/_index_closed.html.erb
+++ b/app/views/invite_requests/_index_closed.html.erb
@@ -7,7 +7,7 @@
   <%= ts("<strong>New invitation requests are currently closed.</strong> For     
         more information, please check the %{news}.",
       news: link_to("\"Invitations\" tag on AO3 News",
-                    admin_posts_path(tag_id: 143))
+                    admin_posts_path(tag: 143))
       ).html_safe %>
 </p>
 <p>

--- a/features/other_a/invite_queue.feature
+++ b/features/other_a/invite_queue.feature
@@ -61,7 +61,7 @@ Feature: Invite queue management
     # check your place in the queue - invalid address
     When I check how long "testttt@archiveofourown.org" will have to wait in the invite request queue
     Then I should see "Invitation Request Status"
-      And I should see "If you can't find it, your invitation may have already been emailed to that address; please check your email Spam folder as your spam filters may have placed it there."
+      And I should see "If you can't find it, your invitation may have already been emailed to that address; please check your email spam folder as your spam filters may have placed it there."
       And I should not see "You are currently number"
 
     # check your place in the queue - correct address

--- a/spec/controllers/invite_requests_controller_spec.rb
+++ b/spec/controllers/invite_requests_controller_spec.rb
@@ -17,7 +17,7 @@ describe InviteRequestsController do
   describe "GET #show" do
     context "given invalid emails" do
       it "redirects to index with error" do
-        message = "You can search for the email address you signed up with below. If you can't find it, your invitation may have already been emailed to that address; please check your email Spam folder as your spam filters may have placed it there."
+        message = "You can search for the email address you signed up with below. If you can't find it, your invitation may have already been emailed to that address; please check your email spam folder as your spam filters may have placed it there."
         get :show, params: { id: 0 }
         it_redirects_to_with_error(status_invite_requests_path, message)
         expect(assigns(:invite_request)).to be_nil


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-4222

## Purpose

Fix links to news posts tagged "invitations" added in AO3-4222 and AO3-5235. Fix capitalization of "spam" in an error message to make it match the capitalization we use elsewhere.

## Testing

Refer to JIRA