### PR TITLE
AO3-5243 Use AJAX to delete invitation requests

### DIFF
--- a/app/controllers/invite_requests_controller.rb
+++ b/app/controllers/invite_requests_controller.rb
@@ -56,7 +56,7 @@ class InviteRequestsController < ApplicationController
     if @invite_request.destroy
       success_message = ts("Request for %{email} was removed from the queue.", email: @invite_request.email)
       respond_to do |format|
-        format.html { redirect_to request.referer || manage_invite_requests_path(page: params[:page]), notice: success_message }
+        format.html { redirect_to manage_invite_requests_path(page: params[:page]), notice: success_message }
         format.json { render json: { item_success_message: success_message }, status: :ok }
       end
     else
@@ -64,7 +64,7 @@ class InviteRequestsController < ApplicationController
       respond_to do |format|
         format.html do
           flash.keep
-          redirect_to request.referer || manage_invite_requests_path(page: params[:page]), flash: { error: error_message }
+          redirect_to manage_invite_requests_path(page: params[:page]), flash: { error: error_message }
         end
         format.json { render json: { errors: error_message }, status: :unprocessable_entity }
       end

--- a/app/controllers/invite_requests_controller.rb
+++ b/app/controllers/invite_requests_controller.rb
@@ -54,11 +54,21 @@ class InviteRequestsController < ApplicationController
   def destroy
     @invite_request = InviteRequest.find(params[:id])
     if @invite_request.destroy
-      flash[:notice] = "Request was removed from the queue."
+      success_message = ts("Request for %{email} was removed from the queue.", email: @invite_request.email)
+      respond_to do |format|
+        format.html { redirect_to request.referer || manage_invite_requests_path(page: params[:page]), notice: success_message }
+        format.json { render json: { item_success_message: success_message }, status: :ok }
+      end
     else
-      flash[:error] = "Request could not be removed. Please try again."
+      error_message = ts("Request could not be removed. Please try again.")
+      respond_to do |format|
+        format.html do
+          flash.keep
+          redirect_to request.referer || manage_invite_requests_path(page: params[:page]), flash: { error: error_message }
+        end
+        format.json { render json: { errors: error_message }, status: :unprocessable_entity }
+      end
     end
-    redirect_to manage_invite_requests_path(page: params[:page])
   end
 
   def status

--- a/app/views/invite_requests/manage.html.erb
+++ b/app/views/invite_requests/manage.html.erb
@@ -23,10 +23,9 @@
           <td><%= request.position %></td>
           <td><%= request.email %></td>
           <td>
-            <%= link_to ts("Delete"),
-                        invite_request_path(request, page: params[:page]),
-                        data: { confirm: ts("Are you sure?") },
-                        method: :delete %>
+            <%= form_tag invite_request_path(request, page: params[:page]), method: "delete", class: "ajax-remove" do |f| %>
+              <%= submit_tag ts("Delete") %>
+            <% end %>
           </td>
         </tr>
       <% end %>

--- a/features/other_a/invite_queue.feature
+++ b/features/other_a/invite_queue.feature
@@ -40,8 +40,8 @@ Feature: Invite queue management
     Given an invitation request for "invitee@example.org"
       And I am logged in as an admin
     When I go to the manage invite queue page
-      And I follow "Delete"
-    Then I should see "Request was removed from the queue."
+      And I press "Delete"
+    Then I should see "Request for invitee@example.org was removed from the queue."
       And I should be on the manage invite queue page
 
   Scenario: Visitors can join the queue and check status when invitations are required and the queue is enabled

--- a/public/javascripts/application.js
+++ b/public/javascripts/application.js
@@ -539,7 +539,7 @@ $j(document).ready(function() {
 });
 
 // For simple forms that update or destroy records and remove them from a listing
-// e.g. delete from history, mark as read
+// e.g. delete from history, mark as read, delete invitation request
 // <form> needs ajax-remove class
 // controller needs item_success_message
 $j(document).ready(function() {
@@ -548,8 +548,12 @@ $j(document).ready(function() {
 
     var form = $j(this);
     var formAction = form.attr('action');
-    var formParent = form.closest('li.group');
-    var parentContainer = formParent.closest('div');
+    // The record we're removing is probably in a list, but might be in a table
+    if (form.closest('li.group').length !== 0) {
+      formParent = form.closest('li.group');
+    } else { formParent = form.closest('tr'); };
+    // The admin div does not hold a flash container
+    var parentContainer = formParent.closest('div:not(.admin)');
     var flashContainer = parentContainer.find('.flash');
 
     $j.ajax({

--- a/spec/controllers/invite_requests_controller_spec.rb
+++ b/spec/controllers/invite_requests_controller_spec.rb
@@ -134,7 +134,7 @@ describe InviteRequestsController do
           allow_any_instance_of(InviteRequest).to receive(:destroy) { false }
           delete :destroy, params: { id: invite_request.id, format: :json }
           parsed_body = JSON.parse(response.body, symbolize_names: true)
-          expect(parsed_body[:item_error_message]).to eq("Request could not be removed. Please try again.")
+          expect(parsed_body[:errors]).to eq("Request could not be removed. Please try again.")
         end
       end
     end

--- a/spec/controllers/invite_requests_controller_spec.rb
+++ b/spec/controllers/invite_requests_controller_spec.rb
@@ -95,28 +95,47 @@ describe InviteRequestsController do
 
       before { fake_login_admin(admin) }
 
-      it "redirects to manage with notice" do
-        delete :destroy, params: { id: invite_request.id }
-        it_redirects_to_with_notice(manage_invite_requests_path, "Request was removed from the queue.")
+      context "when format is HTML" do
+        it "redirects to manage with notice" do
+          delete :destroy, params: { id: invite_request.id }
+          it_redirects_to_with_notice(manage_invite_requests_path, "Request for #{invite_request.email} was removed from the queue.")
+        end
+
+        it "redirects to manage at a specified page" do
+          page = 45_789
+          delete :destroy, params: { id: invite_request.id, page: page }
+          it_redirects_to_with_notice(manage_invite_requests_path(page: page), "Request for #{invite_request.email} was removed from the queue.")
+        end
+
+        it "redirects to manage with error when deletion fails" do
+          allow_any_instance_of(InviteRequest).to receive(:destroy) { false }
+          delete :destroy, params: { id: invite_request.id }
+          it_redirects_to_with_error(manage_invite_requests_path, "Request could not be removed. Please try again.")
+        end
+
+        xit "redirects to manage with error when request cannot be found" do
+          # TODO: AO3-4971
+          invite_request.destroy
+          delete :destroy, params: { id: invite_request.id }
+          # it_redirects_to_with_error(manage_invite_requests_path, "?")
+        end
       end
 
-      it "redirects to manage at a specified page" do
-        page = 45_789
-        delete :destroy, params: { id: invite_request.id, page: page }
-        it_redirects_to_with_notice(manage_invite_requests_path(page: page), "Request was removed from the queue.")
-      end
+      context "when format is JSON" do
+        it "deletes request and responds with success status and message" do
+          delete :destroy, params: { id: invite_request.id, format: :json }
+          parsed_body = JSON.parse(response.body, symbolize_names: true)
+          expect(parsed_body[:item_success_message]).to eq("Request for #{invite_request.email} was removed from the queue.")
+          expect(response).to have_http_status(:success)
+          expect { invite_request.reload }.to raise_error ActiveRecord::RecordNotFound
+        end
 
-      it "redirects to manage with error when deletion fails" do
-        allow_any_instance_of(InviteRequest).to receive(:destroy) { false }
-        delete :destroy, params: { id: invite_request.id }
-        it_redirects_to_with_error(manage_invite_requests_path, "Request could not be removed. Please try again.")
-      end
-
-      xit "redirects to manage with error when request cannot be found" do
-        # TODO: AO3-4971
-        invite_request.destroy
-        delete :destroy, params: { id: invite_request.id }
-        # it_redirects_to_with_error(manage_invite_requests_path, "?")
+        it "fails with an error" do
+          allow_any_instance_of(InviteRequest).to receive(:destroy) { false }
+          delete :destroy, params: { id: invite_request.id, format: :json }
+          parsed_body = JSON.parse(response.body, symbolize_names: true)
+          expect(parsed_body[:item_error_message]).to eq("Request could not be removed. Please try again.")
+        end
       end
     end
   end


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5243

## Purpose

Uses JavaScript to make it so the page doesn't reload after the deletion of a given invitation request.

## Testing

Refer to JIRA
