### PR TITLE
AO3-4971 Display notice when deleting non-existent invite requests

### DIFF
--- a/app/controllers/invite_requests_controller.rb
+++ b/app/controllers/invite_requests_controller.rb
@@ -52,9 +52,13 @@ class InviteRequestsController < ApplicationController
   end
 
   def destroy
-    @invite_request = InviteRequest.find(params[:id])
-    if @invite_request.destroy
-      success_message = ts("Request for %{email} was removed from the queue.", email: @invite_request.email)
+    @invite_request = InviteRequest.find_by(params[:id])
+    if @invite_request.nil? || @invite_request.destroy
+      success_message = if @invite_request.nil?
+                          ts("Request was removed from the queue.")
+                        else
+                          ts("Request for %{email} was removed from the queue.", email: @invite_request.email)
+                        end
       respond_to do |format|
         format.html { redirect_to manage_invite_requests_path(page: params[:page]), notice: success_message }
         format.json { render json: { item_success_message: success_message }, status: :ok }

--- a/spec/controllers/invite_requests_controller_spec.rb
+++ b/spec/controllers/invite_requests_controller_spec.rb
@@ -4,7 +4,8 @@ describe InviteRequestsController do
   include LoginMacros
   include RedirectExpectationHelper
   let(:admin) { create(:admin) }
-  let(:user) { create(:user) }
+
+  before { fake_logout }
 
   describe "GET #index" do
     it "renders" do
@@ -85,7 +86,7 @@ describe InviteRequestsController do
       delete :destroy, params: { id: 0 }
       it_redirects_to_with_notice(root_path, "I'm sorry, only an admin can look at that area")
 
-      fake_login_known_user(user)
+      fake_login
       delete :destroy, params: { id: 0 }
       it_redirects_to_with_notice(root_path, "I'm sorry, only an admin can look at that area")
     end
@@ -113,11 +114,10 @@ describe InviteRequestsController do
           it_redirects_to_with_error(manage_invite_requests_path, "Request could not be removed. Please try again.")
         end
 
-        xit "redirects to manage with error when request cannot be found" do
-          # TODO: AO3-4971
+        it "redirects to manage with notice when request cannot be found" do
           invite_request.destroy
           delete :destroy, params: { id: invite_request.id }
-          # it_redirects_to_with_error(manage_invite_requests_path, "?")
+          it_redirects_to_with_notice(manage_invite_requests_path, "Request was removed from the queue.")
         end
       end
 
@@ -145,7 +145,7 @@ describe InviteRequestsController do
       get :manage
       it_redirects_to_with_notice(root_path, "I'm sorry, only an admin can look at that area")
 
-      fake_login_known_user(user)
+      fake_login
       get :manage
       it_redirects_to_with_notice(root_path, "I'm sorry, only an admin can look at that area")
     end
@@ -170,7 +170,7 @@ describe InviteRequestsController do
       post :reorder
       it_redirects_to_with_notice(root_path, "I'm sorry, only an admin can look at that area")
 
-      fake_login_known_user(user)
+      fake_login
       post :reorder
       it_redirects_to_with_notice(root_path, "I'm sorry, only an admin can look at that area")
     end


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-4971

## Purpose

Display a notice instead of an error page when admins delete non-existent invite requests.

## Testing

See issue.