### PR TITLE
AO3-5247 Use _url helper in spam alert email

### DIFF
--- a/app/views/admin_mailer/send_spam_alert.html.erb
+++ b/app/views/admin_mailer/send_spam_alert.html.erb
@@ -3,7 +3,7 @@
   <p>The following accounts have a suspicious level of traffic:</p>
   <% @spam.each_pair do |user_id, info| %>
     <% user = User.find(user_id) %>
-    User <%= style_link(user.login, root_url + user_works_path(user)) %> has a score of 
+    User <%= style_link(user.login, user_works_url(user)) %> has a score of 
     <%= info["score"] %>
     <ul>
     <% Work.where(id: info["work_ids"]).each do |work| %>

--- a/app/views/admin_mailer/send_spam_alert.text.erb
+++ b/app/views/admin_mailer/send_spam_alert.text.erb
@@ -4,7 +4,7 @@
 
   <% @spam.each_pair do |user_id, info| %>
     <% user = User.find(user_id) %>
-    User <%= user.login %> (<%= root_url + user_works_path(user) %>) has a score of <%= info["score"] %>
+    User <%= user.login %> (<%= user_works_url(user) %>) has a score of <%= info["score"] %>
 
     <% Work.where(id: info["work_ids"]).each do |work| %>
       * <%= work.title %> (<%= work_url(work) %>) <% if work.spam? %>(<%= ts('Flagged as spam') %>)<% end %>

--- a/app/views/user_mailer/invite_request_declined.html.erb
+++ b/app/views/user_mailer/invite_request_declined.html.erb
@@ -6,7 +6,7 @@
   <p><%= style_quote(@reason) %></p>
 
   <p>Regards,</p>
-  <p><%= style_link(ArchiveConfig.APP_SHORT_NAME, root_path) %></p>
+  <p><%= style_link(ArchiveConfig.APP_SHORT_NAME, root_url) %></p>
 <% end %>
 
 


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5247

## Purpose

Resque was loaded with errors like: 
```
undefined method `user_works_path' for #<#<Class:0x000000088772a8>:0x00000008874c88> Did you mean? user_works_url
```

This applies the helpful suggestion to the spam alert email _and_ the invite_request_decline email, which our our only two instances of `_path` helpers in mailers.

## Testing

Refer to JIRA.
