### PR TITLE
AO3-5243 Use correct finder when destroying invite requests

### DIFF
--- a/app/controllers/invite_requests_controller.rb
+++ b/app/controllers/invite_requests_controller.rb
@@ -52,7 +52,7 @@ class InviteRequestsController < ApplicationController
   end
 
   def destroy
-    @invite_request = InviteRequest.find_by(params[:id])
+    @invite_request = InviteRequest.find_by(id: params[:id])
     if @invite_request.nil? || @invite_request.destroy
       success_message = if @invite_request.nil?
                           ts("Request was removed from the queue.")


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5243

## Purpose

Makes sure we're finding the proper invite request to delete

## Testing

Try deleting and invite request and make sure the right one gets deleted
