### PR TITLE
AO3-5249 Add basic search of invitation queue

### DIFF
--- a/app/controllers/invite_requests_controller.rb
+++ b/app/controllers/invite_requests_controller.rb
@@ -66,7 +66,7 @@ class InviteRequestsController < ApplicationController
                           ts("Request for %{email} was removed from the queue.", email: @invite_request.email)
                         end
       respond_to do |format|
-        format.html { redirect_to manage_invite_requests_path(page: params[:page]), notice: success_message }
+        format.html { redirect_to manage_invite_requests_path(page: params[:page], query: params[:query]), notice: success_message }
         format.json { render json: { item_success_message: success_message }, status: :ok }
       end
     else
@@ -74,7 +74,7 @@ class InviteRequestsController < ApplicationController
       respond_to do |format|
         format.html do
           flash.keep
-          redirect_to manage_invite_requests_path(page: params[:page]), flash: { error: error_message }
+          redirect_to manage_invite_requests_path(page: params[:page], query: params[:query]), flash: { error: error_message }
         end
         format.json { render json: { errors: error_message }, status: :unprocessable_entity }
       end

--- a/app/controllers/invite_requests_controller.rb
+++ b/app/controllers/invite_requests_controller.rb
@@ -40,6 +40,12 @@ class InviteRequestsController < ApplicationController
 
   def manage
     @invite_requests = InviteRequest.order(:position).page(params[:page])
+    if params[:query].present?
+      @invite_requests = InviteRequest.where("simplified_email LIKE ?",
+                                             "%#{params[:query]}%")
+                                      .order(:position)
+                                      .page(params[:page])
+    end
   end
 
   def reorder
@@ -83,7 +89,7 @@ class InviteRequestsController < ApplicationController
 
   def invite_request_params
     params.require(:invite_request).permit(
-      :email
+      :email, :query
     )
   end
 end

--- a/app/views/invite_requests/manage.html.erb
+++ b/app/views/invite_requests/manage.html.erb
@@ -3,11 +3,27 @@
   <h2 class="heading"><%= ts("Manage the Invitation Queue") %></h2>
 <!--/descriptions-->
 
-<!--main content-->
-  <%= form_tag reorder_invite_requests_url do %>
-    <p><%= submit_tag ts("Reorder Queue") %></p>
-  <% end %>
+<!--subnav-->
+  <ul class="navigation actions" role="navigation">
+    <li>
+      <%= form_tag reorder_invite_requests_url do %>
+        <p><%= submit_tag ts("Reorder Queue") %></p>
+      <% end %>
+    </li>
+    <li class="search" role="search">
+      <%= form_tag manage_invite_requests_path, method: :get,
+          id: "invite-request-search", class: "simple search" do %>
+        <fieldset>
+          <%= text_field_tag :query, params[:query],
+              title: ts("Find invitation requests from") %>
+          <%= submit_tag ts("Search Queue") %>
+        </fieldset>
+      <% end %>
+    </li>
+  </ul>
+<!--/subnav-->
 
+<!--main content-->
   <table summary="<%= ts("Lists each request/email and its current place in the queue. You can also delete each request.") %>">
     <caption><%= ts("Manage the Invitation Queue") %></caption>
     <thead>

--- a/app/views/invite_requests/manage.html.erb
+++ b/app/views/invite_requests/manage.html.erb
@@ -39,7 +39,7 @@
           <td><%= request.position %></td>
           <td><%= request.email %></td>
           <td>
-            <%= form_tag invite_request_path(request, page: params[:page]), method: "delete", class: "ajax-remove" do |f| %>
+            <%= form_tag invite_request_path(request, page: params[:page], query: params[:query]), method: "delete", class: "ajax-remove" do |f| %>
               <%= submit_tag ts("Delete") %>
             <% end %>
           </td>

--- a/features/admins/admin_invitations.feature
+++ b/features/admins/admin_invitations.feature
@@ -351,8 +351,7 @@ Feature: Admin Actions to Manage Invitations
      And I press "Update Invitation"
    Then I should see "oldman@ds9.com" in the "invitation_invitee_email" input
 
-  Search: An admin can search the invitation queue, and search parameters are
-  kept even if deleting without JavaScript
+  Search: An admin can search the invitation queue, and search parameters are kept even if deleting without JavaScript
     Given I am logged in as an admin
       And an invitation request for "streamtv@example.com"
       And an invitation request for "livetv@example.com"

--- a/features/admins/admin_invitations.feature
+++ b/features/admins/admin_invitations.feature
@@ -350,3 +350,19 @@ Feature: Admin Actions to Manage Invitations
    When I fill in "invitation_invitee_email" with "oldman@ds9.com"
      And I press "Update Invitation"
    Then I should see "oldman@ds9.com" in the "invitation_invitee_email" input
+
+  Search: An admin can search the invitation queue
+    Given I am logged in as an admin
+      And an invitation request for "streamtv@example.com"
+      And an invitation request for "livetv@example.com"
+      And an invitation request for "clearstream@example.com"
+      And an invitation request for "stre.a.mer@example.com"
+      And an invitation request for "dreamer@example.com"
+    When I am on the manage invite queue page
+      And I fill in "#query" with "stream"
+      And I press "Search Queue"
+    Then I should see "streamtv@example.com"
+      And I should see "clearstream@example.com"
+      And I should see "stre.a.mer@example.com"
+      But I should not see "livetv@example.com"
+      And I should not see "dreamer@example.com"

--- a/features/admins/admin_invitations.feature
+++ b/features/admins/admin_invitations.feature
@@ -351,7 +351,8 @@ Feature: Admin Actions to Manage Invitations
      And I press "Update Invitation"
    Then I should see "oldman@ds9.com" in the "invitation_invitee_email" input
 
-  Search: An admin can search the invitation queue
+  Search: An admin can search the invitation queue, and search parameters are
+  kept even if deleting without JavaScript
     Given I am logged in as an admin
       And an invitation request for "streamtv@example.com"
       And an invitation request for "livetv@example.com"
@@ -366,3 +367,6 @@ Feature: Admin Actions to Manage Invitations
       And I should see "stre.a.mer@example.com"
       But I should not see "livetv@example.com"
       And I should not see "dreamer@example.com"
+    When I follow "Delete"
+    Then I should not see "dreamer@example.com"
+      And I should not see "livetv@example.com"


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5249

## Purpose

Lets admins do basic searches of email addresses in the invitations queue. Uses the simplified search column so they can find addresses like li.ves.tre.amt.v without worrying about punctuation.

## Testing

Put addresses in the queue! Search for them!