### PR TITLE
AO3-5019 Fix text overlap in related works section on downloads

### DIFF
--- a/app/views/downloads/_download_preface.html.erb
+++ b/app/views/downloads/_download_preface.html.erb
@@ -54,16 +54,17 @@ hide_freeform?(@work)) %>
     <% end %>
   <% end %>
 
-  <% unless @work.parents.blank? %>
-    <dl>
-      <dt><%= ts('This work was inspired by') %></dt>
-      <dd>
-        <% parent_work_list = @work.parent_work_relationships.reject{ |wr| wr.parent.nil? } %>
-        <%= parent_work_list.map{ |rw| "#{link_to(rw.parent.title,
-               url_for(action: :show, controller: rw.parent_type.underscore.pluralize, id: rw.parent_id,
-                       only_path: false)) } #{ts('by')} #{byline(rw.parent, only_path: false)}" }.join(", ").html_safe %>
-      </dd>
-    </dl>
+  <% related_works = @work.parent_work_relationships.reject{ |wr| !wr.parent } %>
+  <% if related_works.length > 0 %>
+    <ul>
+    <% related_works.each do |work| %>
+      <li>
+        <%= ts(work.translation ? 'A translation of' : 'Inspired by') %>
+        <%= link_to work.parent.title.html_safe, work_url(work.parent) %>
+        <%= ts("by") %> <%= byline(work.parent) %>.
+      </li>
+    <% end %>
+    </ul>
   <% end %>
 
 </div>

--- a/app/views/downloads/_download_preface.html.erb
+++ b/app/views/downloads/_download_preface.html.erb
@@ -63,7 +63,7 @@ hide_freeform?(@work)) %>
           "A translation of %{work_link} by %{author_link}" :
           "Inspired by %{work_link} by %{author_link}"
         %>
-        <% work_link = link_to work.parent.title.html_safe, work_url(work.parent) %>
+        <% work_link = link_to work.parent.title.html_safe, url_for(work.parent) %>
         <% author_link = byline(work.parent, visibility: 'public', only_path: false) %>
 
         <%= ts(relation_text, work_link: work_link, author_link: author_link).html_safe %>

--- a/app/views/downloads/_download_preface.html.erb
+++ b/app/views/downloads/_download_preface.html.erb
@@ -61,7 +61,7 @@ hide_freeform?(@work)) %>
       <li>
         <%= ts(work.translation ? 'A translation of' : 'Inspired by') %>
         <%= link_to work.parent.title.html_safe, work_url(work.parent) %>
-        <%= ts("by") %> <%= byline(work.parent) %>.
+        <%= ts("by") %> <%= byline(work.parent, only_path: false) %>.
       </li>
     <% end %>
     </ul>

--- a/app/views/downloads/_download_preface.html.erb
+++ b/app/views/downloads/_download_preface.html.erb
@@ -59,9 +59,14 @@ hide_freeform?(@work)) %>
     <ul>
     <% related_works.each do |work| %>
       <li>
-        <%= ts(work.translation ? 'A translation of' : 'Inspired by') %>
-        <%= link_to work.parent.title.html_safe, work_url(work.parent) %>
-        <%= ts("by") %> <%= byline(work.parent, only_path: false) %>.
+        <% relation_text = work.translation ?
+          "A translation of %{work_link} by %{author_link}" :
+          "Inspired by %{work_link} by %{author_link}"
+        %>
+        <% work_link = link_to work.parent.title.html_safe, work_url(work.parent) %>
+        <% author_link = byline(work.parent, visibility: 'public', only_path: false) %>
+
+        <%= ts(relation_text, work_link: work_link, author_link: author_link).html_safe %>
       </li>
     <% end %>
     </ul>


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5019

## Purpose

Fix overlapping text in related works section on downloads.

## Testing

See issue.  The new related works section should look like this:
![image](https://user-images.githubusercontent.com/1171203/32968625-d52bc7dc-cb96-11e7-9667-06b13188f1b0.png)
