### PR TITLE
AO3-5251: Add spam-specific hidden work email

### DIFF
--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -366,6 +366,16 @@ class UserMailer < BulletproofMailer::Base
     )
   end
 
+  def admin_spam_work_notification(creation_id, user_id)
+    @user = User.find_by(id: user_id)
+    @work = Work.find_by(id: creation_id)
+
+    mail(
+        to: @user.email,
+        subject: "[#{ArchiveConfig.APP_SHORT_NAME}] Your work was hidden as spam"
+    )
+  end
+
   ### OTHER NOTIFICATIONS ###
 
   # archive feedback

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -1422,7 +1422,11 @@ class Work < ApplicationRecord
   def notify_of_hiding
     return unless hidden_by_admin? && saved_change_to_hidden_by_admin?
     users.each do |user|
-      UserMailer.admin_hidden_work_notification(id, user.id).deliver
+      if spam?
+        UserMailer.admin_spam_work_notification(id, user.id).deliver
+      else
+        UserMailer.admin_hidden_work_notification(id, user.id).deliver
+      end
     end
   end
 

--- a/app/views/admin/settings/index.html.erb
+++ b/app/views/admin/settings/index.html.erb
@@ -28,15 +28,12 @@
     
       <dt><%= f.label :days_to_purge_unactivated, ts("How many weeks you have to activate your account before we purge it") %></dt>
       <dd><%= f.text_field :days_to_purge_unactivated, :size => "3" %></dd>
-
-      <dt><%= f.check_box :hide_spam %></dt>
-      <dd><%= f.label :hide_spam, ts("Automatically hide spam works") %></dd>
     </dl>
   </fieldset>
   
   <fieldset>
-    <legend><%= ts("Performance") %></legend>
-    <h3 class="landmark heading"><%= ts("Performance") %></h3>
+    <legend><%= ts("Performance and Misc") %></legend>
+    <h3 class="landmark heading"><%= ts("Performance and Misc") %></h3>
     <dl>
         
       <dt><%= f.check_box :disable_filtering %></dt>
@@ -59,6 +56,9 @@
     
       <dt><%= f.label :cache_expiration, ts("How often (in minutes) should we refresh caching") %></dt>
       <dd><%= f.text_field :cache_expiration, :size => "3" %></dd>
+
+      <dt><%= f.check_box :hide_spam %></dt>
+      <dd><%= f.label :hide_spam, ts("Automatically hide spam works") %></dd>
     </dl>
   </fieldset>
   

--- a/app/views/user_mailer/admin_spam_work_notification.html.erb
+++ b/app/views/user_mailer/admin_spam_work_notification.html.erb
@@ -1,0 +1,12 @@
+<% content_for :message do %>
+  <p>Dear <%= @user.default_pseud.byline %>,</p>
+
+  <p>Your work <i><%= style_link(@work.title.html_safe, work_url(@work)) %></i> has been flagged by our automated system as spam and hidden until it can be reviewed by our Abuse team. While the work is hidden it can only be accessed by you and AO3 site admins.</p>
+
+  <p>If we determine that your work is not spam, we'll unhide it. Other users will then be able to access and leave feedback on it as usual. Please note that we do not screen works for other kinds of violations at this time. If your work is reported to us for a different reason in the future, that will be investigated separately.</p>
+
+  <p>If you have any questions, please <%= abuse_link("contact our Abuse Team") %>.</p>
+
+  <p>Sincerely,</p>
+  <p><%= style_bold("AO3 Abuse") %></p>
+<% end %>

--- a/app/views/user_mailer/admin_spam_work_notification.text.erb
+++ b/app/views/user_mailer/admin_spam_work_notification.text.erb
@@ -1,0 +1,12 @@
+<% content_for :message do %>
+  Dear <%= @user.default_pseud.byline %>,
+
+  Your work "<%= @work.title.html_safe %>" (<%= work_url(@work) %>) has been flagged by our automated system as spam and hidden until it can be reviewed by our Abuse team. While the work is hidden it can only be accessed by you and AO3 site admins.
+
+  If we determine that your work is not spam, we'll unhide it. Other users will then be able to access and leave feedback on it as usual. Please note that we do not screen works for other kinds of violations at this time. If your work is reported to us for a different reason in the future, that will be investigated separately.
+
+  If you have any questions, please contact our Abuse Team (<%= new_abuse_report_url %>).
+
+  Sincerely,
+  AO3 Abuse
+<% end %>

--- a/spec/models/work_spec.rb
+++ b/spec/models/work_spec.rb
@@ -229,17 +229,20 @@ describe Work do
       before do
         @admin_setting.update_attribute(:hide_spam, true)
       end
-      it "automatically hides spam works" do
-        @work.update_attributes!(spam: true)
+      it "automatically hides spam works and sends an email" do
+        expect { @work.update_attributes!(spam: true) }.
+          to change { ActionMailer::Base.deliveries.count }.by(1)
         expect(@work.reload.hidden_by_admin).to be_truthy
+        expect(ActionMailer::Base.deliveries.last.subject).to eq("[AO3] Your work was hidden as spam")
       end
     end
     context "when the admin setting is disabled" do
       before do
         @admin_setting.update_attribute(:hide_spam, false)
       end
-      it "does not automatically hide spam works" do
-        @work.update_attributes!(spam: true)
+      it "does not automatically hide spam works and does not send an email" do
+        expect { @work.update_attributes!(spam: true) }.
+          not_to change { ActionMailer::Base.deliveries.count }
         expect(@work.reload.hidden_by_admin).to be_falsey
       end
     end


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5251

## Purpose

Adds a more specific email that goes out when a work is hidden as spam.

## Testing

Mark a work as spam and determine that the correct email arrives.