### PR TITLE
AO3-5134 Work byline not updated when using Edit Works to remove co-creator

### DIFF
--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -253,7 +253,7 @@ class Work < ApplicationRecord
 
     Work.expire_work_tag_groups_id(self.id)
 
-    unless self.destroyed?
+    if persisted?
       self.touch
     end
   end

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -253,7 +253,9 @@ class Work < ApplicationRecord
 
     Work.expire_work_tag_groups_id(self.id)
 
-    self.touch
+    unless self.destroyed?
+      self.touch
+    end
   end
 
   def self.work_blurb_tag_cache_key(id)

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -252,6 +252,8 @@ class Work < ApplicationRecord
     Work.flush_find_by_url_cache unless imported_from_url.blank?
 
     Work.expire_work_tag_groups_id(self.id)
+
+    self.touch
   end
 
   def self.work_blurb_tag_cache_key(id)

--- a/features/bookmarks/bookmark_privacy.feature
+++ b/features/bookmarks/bookmark_privacy.feature
@@ -108,8 +108,7 @@ Feature: Private bookmarks
     Then I should not see "Secret Masterpiece"
       And I should see "Public Masterpiece"
       And I should not see "Bookmarks: 2"
-      # CACHING (perform_caching: true)
-      # And I should see "Bookmarks: 1"
+      And I should see "Bookmarks: 1"
     When I view the work "Public Masterpiece"
     Then I should not see "Bookmarks:2"
       And I should see "Bookmarks:1"
@@ -126,5 +125,5 @@ Feature: Private bookmarks
       And I should not see "bookmarker"
       And I should see "otheruser"
       # bookmark counter
-      And I should see "0" within ".count"
+      And I should see "1" within ".count"
       And I should not see "2" within ".count"


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5134

## Purpose

This fixes work caching issue where the author byline is not updated if you remove a co-author. Turns out the work cache_key is not updated if expire_caches is called so I added it. This seems to have solved an issue in private bookmarks where the count was not updated correctly.

I'd appreciate input on the change if possible.

## Testing

Steps are described in bug report.

## Credit

Tal Hayon

Please use he.
