### PR TITLE
AO3-5234: Add links, fix false errors on spam page

### DIFF
--- a/app/models/moderated_work.rb
+++ b/app/models/moderated_work.rb
@@ -37,7 +37,7 @@ class ModeratedWork < ApplicationRecord
   end
 
   def self.bulk_review(ids)
-    return unless ids.present?
+    return true unless ids.present?
     where(id: ids).update_all("reviewed = 1")
     admin_settings = Rails.cache.fetch("admin_settings"){ AdminSetting.first }
     # If spam isn't hidden by default, hide it now
@@ -49,7 +49,7 @@ class ModeratedWork < ApplicationRecord
   end
 
   def self.bulk_approve(ids)
-    return unless ids.present?
+    return true unless ids.present?
     where(id: ids).update_all("approved = 1")
     Work.joins(:moderated_work).where("moderated_works.id IN (?)", ids).each do |work|
       work.mark_as_ham!

--- a/app/views/admin/spam/index.html.erb
+++ b/app/views/admin/spam/index.html.erb
@@ -3,11 +3,18 @@
 <!--/descriptions-->
 
 <!--subnav-->
+<ul class="navigation actions" role="navigation">
+  <li>
+    <%= span_if_current ts("Reviewed Works"), { show: "reviewed" } %>
+  </li>
+  <li>
+    <%= span_if_current ts("Approved Works"), { show: "approved" } %>
+  </li>
+</ul>
 <!--/subnav-->
 
 <!--main content-->
 <%= form_tag "/admin/spam/bulk_update", method: :post do %>
-  <%= submit_button nil, ts("Update Works") %>
   <table id="spam_works" summary="<%= ts("Titles, creators, and revision dates for works that have been automatically marked as spam, along with options to verify or correct their spam status.") %>">
     <caption><%= ts("Works Marked as Spam") %></caption>
     <thead>


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5234

## Purpose

Adds a subnav with links to view already-reviewed works on the admin spam page. Also tweaks method return values to prevent misleading error messages when changes have actually gone through.

## Testing

Should be able to view reviewed/approved works and should not get an error when changes have saved.