### PR TITLE
AO3-5234: Fix for unapproving approved works

### DIFF
--- a/app/models/moderated_work.rb
+++ b/app/models/moderated_work.rb
@@ -38,13 +38,10 @@ class ModeratedWork < ApplicationRecord
 
   def self.bulk_review(ids)
     return true unless ids.present?
-    where(id: ids).update_all("reviewed = 1")
-    admin_settings = Rails.cache.fetch("admin_settings"){ AdminSetting.first }
-    # If spam isn't hidden by default, hide it now
-    unless admin_settings.hide_spam?
-      Work.joins(:moderated_work).where("moderated_works.id IN (?)", ids).each do |work|
-        work.update_attribute(:hidden_by_admin, true)
-      end
+    where(id: ids).update_all(reviewed: true, approved: false)
+    # Ensure works are hidden and spam if they weren't already
+    Work.joins(:moderated_work).where("moderated_works.id IN (?)", ids).each do |work|
+      work.update_attributes(hidden_by_admin: true, spam: true)
     end
   end
 

--- a/app/models/moderated_work.rb
+++ b/app/models/moderated_work.rb
@@ -37,7 +37,7 @@ class ModeratedWork < ApplicationRecord
   end
 
   def self.bulk_review(ids)
-    return unless ids.present?
+    return true unless ids.present?
     where(id: ids).update_all("reviewed = 1")
     admin_settings = Rails.cache.fetch("admin_settings"){ AdminSetting.first }
     # If spam isn't hidden by default, hide it now
@@ -49,7 +49,7 @@ class ModeratedWork < ApplicationRecord
   end
 
   def self.bulk_approve(ids)
-    return unless ids.present?
+    return true unless ids.present?
     where(id: ids).update_all("approved = 1")
     Work.joins(:moderated_work).where("moderated_works.id IN (?)", ids).each do |work|
       work.mark_as_ham!

--- a/app/views/admin/spam/index.html.erb
+++ b/app/views/admin/spam/index.html.erb
@@ -3,11 +3,18 @@
 <!--/descriptions-->
 
 <!--subnav-->
+<ul class="navigation actions" role="navigation">
+  <li>
+    <%= span_if_current ts("Reviewed Works"), { show: "reviewed" } %>
+  </li>
+  <li>
+    <%= span_if_current ts("Approved Works"), { show: "approved" } %>
+  </li>
+</ul>
 <!--/subnav-->
 
 <!--main content-->
 <%= form_tag "/admin/spam/bulk_update", method: :post do %>
-  <%= submit_button nil, ts("Update Works") %>
   <table id="spam_works" summary="<%= ts("Titles, creators, and revision dates for works that have been automatically marked as spam, along with options to verify or correct their spam status.") %>">
     <caption><%= ts("Works Marked as Spam") %></caption>
     <thead>

--- a/app/views/admin/spam/index.html.erb
+++ b/app/views/admin/spam/index.html.erb
@@ -1,11 +1,14 @@
 <!--Descriptive page name, messages and instructions-->
-<h2 class="heading"><%= ts("Works Marked as Spam") %></h2>
+<h2 class="heading"><%= ts("Manage Potential Spam") %></h2>
 <!--/descriptions-->
 
 <!--subnav-->
 <ul class="navigation actions" role="navigation">
   <li>
-    <%= span_if_current ts("Reviewed Works"), { show: "reviewed" } %>
+    <%= span_if_current ts("Unreviewed Works"), admin_spam_index_path, params[:show].blank? %>
+  </li>
+  <li>
+    <%= span_if_current ts("Confirmed Spam"), { show: "reviewed" } %>
   </li>
   <li>
     <%= span_if_current ts("Approved Works"), { show: "approved" } %>
@@ -23,7 +26,7 @@
         <th scope="col"><%= ts("Creator") %></th>
         <th scope="col"><%= ts("Revised At") %></th>
         <th scope="col">
-          <%= ts("Mark Reviewed") %>
+          <%= ts("Confirm As Spam") %>
           <ul class="actions">
             <li>
               <button id="spam_all_select" type="button">


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5234

## Purpose

Allows admins to reverse approving spam works and updates some language

## Testing

When you view approved works on the spam page and mark them as spam again, that should un-approve them and change the works back to spam and hide them