### PR TITLE
AO3-4989 Returning to referer if deleting bookmark

### DIFF
--- a/app/controllers/bookmarks_controller.rb
+++ b/app/controllers/bookmarks_controller.rb
@@ -213,7 +213,12 @@ class BookmarksController < ApplicationController
   def destroy
     @bookmark.destroy
     flash[:notice] = ts("Bookmark was successfully deleted.")
-    redirect_to user_bookmarks_path(current_user)
+
+    if request.referer&.match(/confirm_delete|edit/)
+      redirect_to(user_bookmarks_path(current_user))
+    else
+      redirect_to(request.referer || user_bookmarks_path(current_user))
+    end
   end
 
   # Used on index page to show 4 most recent bookmarks (after bookmark being currently viewed) via RJS

--- a/app/controllers/bookmarks_controller.rb
+++ b/app/controllers/bookmarks_controller.rb
@@ -214,7 +214,7 @@ class BookmarksController < ApplicationController
     @bookmark.destroy
     flash[:notice] = ts("Bookmark was successfully deleted.")
 
-    if request.referer&.match(/confirm_delete|edit/)
+    if request.referer&.match(/confirm_delete|edit|#{bookmarks_path(@bookmark.id)}/)
       redirect_to(user_bookmarks_path(current_user))
     else
       redirect_to(request.referer || user_bookmarks_path(current_user))


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-4989

## Purpose

This makes it so you return to referer if you delete a bookmark unless you came from a page specifically editing or deleting it. I saw the pattern used in the comment controller but I'm not sure it it's the best way of implementing this.

## Testing

Delete bookmark from all possible places. If page still exists (user bookmarks second page, recent bookmarks, etc.) then you should still be at that page.

## Credit

Tal Hayon

Please use he.
