### PR TITLE
AO3-5230 Fix range filters in bookmark search

### DIFF
--- a/app/models/bookmark_search.rb
+++ b/app/models/bookmark_search.rb
@@ -127,7 +127,7 @@ class BookmarkSearch < Search
         end
       end
 
-      [:bookmarkable_word_count, :date, :bookmarkable_date].each do |countable|
+      [:date, :bookmarkable_date].each do |countable|
         if search_opts[countable].present?
           key = (countable == :date) ? :created_at : countable
           filter :range, key => Search.range_to_search(search_opts[countable])
@@ -194,7 +194,7 @@ class BookmarkSearch < Search
         end
       end
 
-      [:bookmarkable_word_count, :date, :bookmarkable_date].each do |countable|
+      [:date, :bookmarkable_date].each do |countable|
         if search_opts[countable].present?
           key = (countable == :date) ? :created_at : countable
           filter :range, key => Search.range_to_search(search_opts[countable])

--- a/app/models/search/bookmark_query.rb
+++ b/app/models/search/bookmark_query.rb
@@ -31,7 +31,8 @@ class BookmarkQuery < Query
     @filters ||= (
       visibility_filters +
       bookmark_filters +
-      bookmarkable_filters
+      bookmarkable_filters +
+      range_filters
     ).flatten.compact
   end
 
@@ -163,6 +164,17 @@ class BookmarkQuery < Query
       language_filter,
       filter_id_filter
     ]
+  end
+
+  def range_filters
+    ranges = []
+    [:date, :bookmarkable_date].each do |countable|
+      if options[countable].present?
+        key = countable == :date ? :created_at : countable
+        ranges << { range: { key => Search.range_to_search(options[countable]) } }
+      end
+    end
+    ranges
   end
 
   ####################

--- a/app/models/search/bookmark_search_form.rb
+++ b/app/models/search/bookmark_search_form.rb
@@ -59,6 +59,13 @@ class BookmarkSearchForm
 
   def initialize(options={})
     @options = options
+    [:date, :bookmarkable_date].each do |countable|
+      if @options[countable].present?
+        @options[countable].gsub!("&gt;", ">")
+        @options[countable].gsub!("&lt;", "<")
+      end
+    end
+
     # If we call the form field 'notes', the parser adds html to it
     @options[:notes] = @options[:bookmark_notes]
     @searcher = BookmarkQuery.new(options.delete_if { |k, v| v.blank? })

--- a/app/views/bookmarks/search_results.html.erb
+++ b/app/views/bookmarks/search_results.html.erb
@@ -3,7 +3,7 @@
 
 <h4 class="heading">
   <%= ts("You searched for:") %>
-  <%= strip_tags @search.summary %>
+  <%= (strip_tags @search.summary).html_safe %>
 </h4>
 <!--/descriptions-->
 

--- a/features/bookmarks/bookmark_search.feature
+++ b/features/bookmarks/bookmark_search.feature
@@ -5,10 +5,10 @@ Feature: Search Bookmarks
   I have to use cucumber with elasticsearch
 
   Background:
-    Given I have bookmarks to search
-      And I am on the search bookmarks page
+    Given I am on the search bookmarks page
 
   Scenario: Search bookmarks by tag
+    Given I have bookmarks to search
     When I fill in "Tag" with "classic"
       And I press "Search bookmarks"
     Then I should see the page title "Search Bookmarks"
@@ -18,7 +18,44 @@ Feature: Search Bookmarks
     When I follow "Edit Your Search"
     Then the field labeled "Tag" should contain "classic"
 
+  Scenario: Search bookmarks by date bookmarked
+    Given I have bookmarks to search by dates
+    When I fill in "Date Bookmarked" with "> 900 days ago"
+      And I press "Search bookmarks"
+    Then I should see the page title "Search Bookmarks"
+      And I should see "You searched for: Date bookmarked: > 900 days ago"
+      And I should see "1 Found"
+      And I should see "Old bookmark of old work"
+    When I follow "Edit Your Search"
+    Then the field labeled "Date Bookmarked" should contain "> 900 days ago"
+
+    When I fill in "Date Bookmarked" with "< 900 days ago"
+      And I press "Search bookmarks"
+    Then I should see "You searched for: Date bookmarked: < 900 days ago"
+      And I should see "2 Found"
+      And I should see "New bookmark of old work"
+      And I should see "New bookmark of new work"
+
+  Scenario: Search bookmarks by date updated
+    Given I have bookmarks to search by dates
+    When I fill in "Date Updated" with "> 900 days ago"
+      And I press "Search bookmarks"
+    Then I should see the page title "Search Bookmarks"
+      And I should see "You searched for: Date updated: > 900 days ago"
+      And I should see "2 Found"
+      And I should see "Old bookmark of old work"
+      And I should see "New bookmark of old work"
+    When I follow "Edit Your Search"
+    Then the field labeled "Date Updated" should contain "> 900 days ago"
+
+    When I fill in "Date Updated" with "< 900 days ago"
+      And I press "Search bookmarks"
+    Then I should see "You searched for: Date updated: < 900 days ago"
+      And I should see "1 Found"
+      And I should see "New bookmark of new work"
+
   Scenario: Search bookmarks for recs
+    Given I have bookmarks to search
     When I check "Rec"
       And I press "Search bookmarks"
     Then I should see the page title "Search Bookmarks"
@@ -29,6 +66,7 @@ Feature: Search Bookmarks
     Then the "Rec" checkbox should be checked
 
   Scenario: Search bookmarks by any field
+    Given I have bookmarks to search
     When I fill in "Any field" with "Hobbits"
       And I press "Search bookmarks"
     Then I should see the page title "Bookmarks Matching 'Hobbits'"
@@ -38,6 +76,7 @@ Feature: Search Bookmarks
     Then the field labeled "Any field" should contain "Hobbits"
 
   Scenario: Search bookmarks by type
+    Given I have bookmarks to search
     When I select "External Work" from "Type"
       And I press "Search bookmarks"
     Then I should see the page title "Search Bookmarks"
@@ -50,6 +89,7 @@ Feature: Search Bookmarks
 
   Scenario: Search for bookmarks with notes, and then edit search to narrow
   results by the note content
+    Given I have bookmarks to search
     When I check "With Notes"
       And I press "Search bookmarks"
     Then I should see the page title "Search Bookmarks"
@@ -72,6 +112,7 @@ Feature: Search Bookmarks
 
   Scenario: If testuser has the pseud tester_pseud, searching for bookmarks by
   the bookmarker testuser returns all of tester_pseud's bookmarks
+    Given I have bookmarks to search
     When I fill in "Bookmarker" with "testuser"
       And I press "Search bookmarks"
     Then I should see the page title "Search Bookmarks"

--- a/features/step_definitions/bookmark_steps.rb
+++ b/features/step_definitions/bookmark_steps.rb
@@ -74,6 +74,20 @@ Given /^I have bookmarks to search$/ do
   step %{all search indexes are updated}
 end
 
+Given /^I have bookmarks to search by dates$/ do
+  work1 = nil
+  Timecop.freeze(901.days.ago) do
+    work1 = FactoryGirl.create(:posted_work, title: "Old work")
+    FactoryGirl.create(:bookmark, bookmarkable_id: work1.id, notes: "Old bookmark of old work")
+  end
+  FactoryGirl.create(:bookmark, bookmarkable_id: work1.id, notes: "New bookmark of old work")
+
+  work2 = FactoryGirl.create(:posted_work, title: "New work")
+  FactoryGirl.create(:bookmark, bookmarkable_id: work2.id, notes: "New bookmark of new work")
+
+  step %{all search indexes are updated}
+end
+
 When /^I bookmark the work "([^\"]*)"(?: as "([^"]*)")?(?: with the note "([^"]*)")?$/ do |title, pseud, note|
   step %{I start a new bookmark for "#{title}"}
   select(pseud, from: "bookmark_pseud_id") unless pseud.nil?


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5230

## Purpose

- Parse date updated and date bookmarked filters
- Unescape < and > characters
- Avoid re-escaping < and > characters in search summary
- Remove unused references to "bookmarkable_word_count"

## Testing

See issue.