### PR TITLE
AO3-5280 Add co-creator names to co-creator emails

### DIFF
--- a/app/views/user_mailer/coauthor_notification.html.erb
+++ b/app/views/user_mailer/coauthor_notification.html.erb
@@ -4,7 +4,13 @@
   <p><%= t ".part1_#{creation_type}" %></p>
 
   <p>
-    <i><b><%= style_link(@creation.title, (@creation.class == Series ? series_url(@creation) : work_url(@creation))) %></b></i>
+    <i><b><%= style_link(@creation.title, (@creation.class == Series ? series_url(@creation) : work_url(@creation))) %></b></i> by <%= @creation.pseuds.map{ |p| style_pseud_link(p) }.to_sentence.html_safe %>
+  </p>
+
+  <p>
+    <%= t(".html.creation",
+    creation_link: "<i><b>#{style_link(@creation.title, (@creation.class == Series ? series_url(@creation) : work_url(@creation)))}</b></i>", 
+    pseud_links: @creation.pseuds.map{ |p| style_pseud_link(p) }.to_sentence.html_safe).html_safe %>
   </p>
 
   <p><%= t(".html.part2_#{creation_type}", edit: style_link(t(".edit_the_#{creation_type}"), (@creation.class == Series ? edit_series_url(@creation) : edit_work_url(@creation)))).html_safe %></p>

--- a/app/views/user_mailer/coauthor_notification.html.erb
+++ b/app/views/user_mailer/coauthor_notification.html.erb
@@ -4,12 +4,8 @@
   <p><%= t ".part1_#{creation_type}" %></p>
 
   <p>
-    <i><b><%= style_link(@creation.title, (@creation.class == Series ? series_url(@creation) : work_url(@creation))) %></b></i> by <%= @creation.pseuds.map{ |p| style_pseud_link(p) }.to_sentence.html_safe %>
-  </p>
-
-  <p>
     <%= t(".html.creation",
-    creation_link: "<i><b>#{style_link(@creation.title, (@creation.class == Series ? series_url(@creation) : work_url(@creation)))}</b></i>", 
+    creation_link: "<i><b>#{style_link(@creation.title, (@creation.class == Series ? series_url(@creation) : work_url(@creation)))}</b></i>".html_safe, 
     pseud_links: @creation.pseuds.map{ |p| style_pseud_link(p) }.to_sentence.html_safe).html_safe %>
   </p>
 

--- a/app/views/user_mailer/coauthor_notification.text.erb
+++ b/app/views/user_mailer/coauthor_notification.text.erb
@@ -3,8 +3,9 @@
 
 <%= t ".part1_#{creation_type}" %>
 
-<%= @creation.title %>
-(<%= @creation.class == Series ? series_url(@creation) : work_url(@creation) %>)
+<%= t ".text.creation", title: @creation.title, 
+  url: @creation.class == Series ? series_url(@creation) : work_url(@creation),
+  pseuds: @creation.pseuds.map{ |p| p.byline }.to_sentence %>
 
 <%= t ".text.part2_#{creation_type}",  url: @creation.class == Series ? edit_series_url(@creation) : edit_work_url(@creation) %>
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -187,9 +187,11 @@ en:
       part1_work: "You have been listed as a co-creator on the following work:"
       part1_series: "You have been listed as a co-creator on the following series:"
       html:
+        creation: "%{creation_link} by %{pseud_links}"
         part2_work: "%{edit} to remove yourself as creator if you've been added in error or don't want to be listed as a creator."
         part2_series: "%{edit} to remove yourself as creator if you've been added in error or don't want to be listed as a creator."
       text:
+        creation: "%{title} (%{url}) by %{pseuds}"
         part2_work: "Edit the work to remove yourself as creator if you've been added in error or don't want to be listed as a creator: %{url}"
         part2_series: "Edit the series to remove yourself as creator if you've been added in error or don't want to be listed as a creator: %{url}"
     change_email:

--- a/features/works/work_create.feature
+++ b/features/works/work_create.feature
@@ -338,16 +338,3 @@ Feature: Create Works
     When I follow "Next Chapter →"
     Then I should see "Chapter 2"
       And I should see "author, coauthor" within ".byline"
-
-  Scenario: Adding a co-creator to a work should notify the co-creator
-
-    Given the user "karma" exists and is activated
-      And the user "amy" exists and is activated
-    When I am logged in as "karma"
-      And I post the work "Forever Friends"
-      And I add the co-author "amy" to the work "Forever Friends"
-    Then 1 email should be delivered to "amy"
-      And the email should contain "You have been listed as a co-creator on the following work"
-      And the email should contain "Forever Friends"
-      And the email should contain "amy, karma"
-      And the email should not contain "translation missing"

--- a/features/works/work_create.feature
+++ b/features/works/work_create.feature
@@ -338,3 +338,16 @@ Feature: Create Works
     When I follow "Next Chapter →"
     Then I should see "Chapter 2"
       And I should see "author, coauthor" within ".byline"
+
+  Scenario: Adding a co-creator to a work should notify the co-creator
+
+    Given the user "karma" exists and is activated
+      And the user "amy" exists and is activated
+    When I am logged in as "karma"
+      And I post the work "Forever Friends"
+      And I add the co-author "amy" to the work "Forever Friends"
+    Then 1 email should be delivered to "amy"
+      And the email should contain "You have been listed as a co-creator on the following work"
+      And the email should contain "Forever Friends"
+      And the email should contain "amy, karma"
+      And the email should not contain "translation missing"


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5260

## Purpose

What it says on the tin 

## Testing

Add a co-creator to a work and a series and check the resultant notif emails for names