### PR TITLE
AO3-5254: Upgrade elasticsearch gem to 6.0.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -63,7 +63,7 @@ gem 'resque_mailer'
 gem 'resque-scheduler'
 #gem 'daemon-spawn', :require => 'daemon_spawn'
 gem 'tire'
-gem 'elasticsearch'
+gem 'elasticsearch', '>=6.0.0'
 gem 'aws-sdk'
 gem 'css_parser'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -180,12 +180,12 @@ GEM
     docile (1.1.5)
     domain_name (0.5.20170404)
       unf (>= 0.0.5, < 1.0.0)
-    elasticsearch (5.0.4)
-      elasticsearch-api (= 5.0.4)
-      elasticsearch-transport (= 5.0.4)
-    elasticsearch-api (5.0.4)
+    elasticsearch (6.0.0)
+      elasticsearch-api (= 6.0.0)
+      elasticsearch-transport (= 6.0.0)
+    elasticsearch-api (6.0.0)
       multi_json
-    elasticsearch-transport (5.0.4)
+    elasticsearch-transport (6.0.0)
       faraday
       multi_json
     email_spec (1.6.0)
@@ -202,7 +202,7 @@ GEM
       railties (>= 3.0.0)
     faker (1.6.6)
       i18n (~> 0.5)
-    faraday (0.12.1)
+    faraday (0.13.1)
       multipart-post (>= 1.2, < 3)
     fastimage (2.1.0)
     ffi (1.9.18)
@@ -517,7 +517,7 @@ DEPENDENCIES
   delorean
   devise
   devise-async
-  elasticsearch
+  elasticsearch (>= 6.0.0)
   email_spec (= 1.6.0)
   escape_utils (= 1.2.1)
   factory_girl (~> 4.8.0)


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5254

## Purpose

Upgrades the elasticsearch gem to match the new version.

## Testing

See general issue testing.