### PR TITLE
AO3-5262: Move query cleaning out of the works controller

### DIFF
--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -23,59 +23,7 @@ class WorksController < ApplicationController
 
   # we want to extract the countable params from work_search and move them into their fields
   def clean_work_search_params
-    # https://aaronlasseigne.com/2014/07/20/know-ruby-clone-and-dup/
-    # While nearly identical, clone does one more thing than dup.
-    # In clone, the frozen state of the object is also copied.
-    # In dup, it'll always be thawed.
-
-    clean_params = work_search_params&.dup
-    clean_params[:query] = clean_params[:query].dup unless clean_params[:query].nil?
-    clean_params[:sort_column] = clean_params[:sort_column].dup unless clean_params[:sort_column].nil?
-    clean_params[:sort_direction] = clean_params[:sort_direction].dup unless clean_params[:sort_direction].nil?
-
-    if clean_params.present? && clean_params[:query].present?
-      # swap in gt/lt for ease of matching; swap them back out for safety at the end
-      clean_params[:query].gsub!('&gt;', '>')
-      clean_params[:query].gsub!('&lt;', '<')
-
-      # extract countable params
-      %w(word kudo comment bookmark hit).each do |term|
-        next unless clean_params[:query].gsub!(/#{term}s?\s*(?:\_?count)?\s*:?\s*((?:<|>|=|:)\s*\d+(?:\-\d+)?)/i, '')
-        # pluralize, add _count, convert to symbol
-        term = term.pluralize unless term == 'word'
-        term += '_count' unless term == 'hits'
-        term = term.to_sym
-
-        value = Regexp.last_match(1).gsub(/^(\:|\=)/, '') # get rid of : and =
-        # don't overwrite if submitting from advanced search?
-        clean_params[term] = value unless clean_params[term].present?
-      end
-
-      # get sort-by
-      if clean_params[:query].gsub!(/sort(?:ed)?\s*(?:by)?\s*:?\s*(<|>|=|:)\s*(\w+)\s*(ascending|descending)?/i, '')
-        sortdir = Regexp.last_match(3) || Regexp.last_match(1)
-        sortby = Regexp.last_match(2).gsub(/\s*_?count/, '').singularize # turn word_count or word count or words into just "word" eg
-
-        _, sort_column = WorkSearch::SORT_OPTIONS.find { |opt, _| opt =~ /#{sortby}/i }
-        clean_params[:sort_column] = sort_column unless sort_column.nil?
-        clean_params[:sort_direction] = sort_direction(sortdir)
-      end
-
-      # put categories into quotes
-      qr = Regexp.new('(?:"|\')?')
-      %w(m/m f/f f/m m/f).each do |cat|
-        cr = Regexp.new("#{qr}#{cat}#{qr}")
-        clean_params[:query].gsub!(cr, "\"#{cat}\"")
-      end
-
-      # swap out gt/lt
-      clean_params[:query].gsub!('>', '&gt;')
-      clean_params[:query].gsub!('<', '&lt;')
-
-      # get rid of empty queries
-      clean_params[:query] = nil if clean_params[:query] =~ /^\s*$/
-    end
-    clean_params
+    QueryCleaner.new(work_search_params || {}).clean
   end
 
   def search
@@ -1070,14 +1018,6 @@ class WorksController < ApplicationController
       end
 
       render page_name
-    end
-  end
-
-  def sort_direction(sortdir)
-    if sortdir == '>' || sortdir == 'ascending'
-      'asc'
-    elsif sortdir == '<' || sortdir == 'descending'
-      'desc'
     end
   end
 

--- a/app/models/search/query_cleaner.rb
+++ b/app/models/search/query_cleaner.rb
@@ -1,0 +1,100 @@
+# This is currently being tested without loading most of Rails
+# so beware of changes that rely on other classes or Rails methods
+class QueryCleaner
+
+  attr_reader :params
+
+  SORT_OPTIONS = [
+    ['Author', 'authors_to_sort_on'],
+    ['Title', 'title_to_sort_on'],
+    ['Date Posted', 'created_at'],
+    ['Date Updated', 'revised_at'],
+    ['Word Count', 'word_count'],
+    ['Hits', 'hits'],
+    ['Kudos', 'kudos_count'],
+    ['Comments', 'comments_count'],
+    ['Bookmarks', 'bookmarks_count']
+  ].freeze
+
+  def initialize(params = {})
+    @params = params.dup
+  end
+
+  def clean
+    return params if params[:query].nil? || params[:query].empty?
+    unescape_angle_brackets
+    extract_countables
+    set_sorting
+    add_quotes_to_categories
+    escape_angle_brackets
+    clean_up_query
+
+    params
+  end
+
+  def unescape_angle_brackets
+    params[:query] = params[:query].gsub('&gt;', '>').gsub('&lt;', '<')
+  end
+
+  def escape_angle_brackets
+    params[:query] = params[:query].gsub('>', '&gt;').gsub('<', '&lt;')
+  end
+
+  # extract countable params
+  def extract_countables
+    %w(word kudo comment bookmark hit).each do |term|
+      count_regex = /#{term}s?\s*(?:\_?count)?\s*:?\s*((?:<|>|=|:)\s*\d+(?:\-\d+)?)/i
+      m = params[:query].match(count_regex)
+      next if m.nil?
+      params[:query] = params[:query].gsub(count_regex, '')
+      # pluralize, add _count, convert to symbol
+      term = term.pluralize unless term == 'word'
+      term += '_count' unless term == 'hits'
+      term = term.to_sym
+
+      value = m[1].gsub(/^(\:|\=)/, '').strip # get rid of : and =
+      # don't overwrite if submitting from advanced search?
+      params[term] = value if params[term].nil? || params[term].empty?
+    end
+  end
+
+  # get sort-by
+  def set_sorting
+    sort_regex = /sort(?:ed)?\s*(?:by)?\s*:?\s*(<|>|=|:)\s*(\w+)\s*(ascending|descending)?/i
+    return unless m = params[:query].match(sort_regex)
+    params[:query] = params[:query].gsub(sort_regex, '')
+    sortdir = m[3] || m[1]
+    # turn word_count or word count or words into just "word" eg
+    sortby = m[2].gsub(/\s*_?count/, '').singularize
+
+    sort_column = SORT_OPTIONS.find { |opt, _| opt =~ /#{sortby}/i }&.last
+    params[:sort_column] = sort_column unless sort_column.nil?
+    params[:sort_direction] = sort_direction(sortdir)
+  end
+
+  def sort_direction(sortdir)
+    if sortdir == '>' || sortdir == 'ascending'
+      'asc'
+    elsif sortdir == '<' || sortdir == 'descending'
+      'desc'
+    end
+  end
+
+  # put categories into quotes
+  def add_quotes_to_categories
+    qr = Regexp.new('(?:"|\')?')
+    %w(m/m f/f f/m m/f).each do |cat|
+      cr = Regexp.new("#{qr}#{cat}#{qr}", Regexp::IGNORECASE)
+      params[:query] = params[:query].gsub(cr, "\"#{cat}\"")
+    end
+  end
+
+  # If we've stripped out everything in the query, null it out
+  def clean_up_query
+    if params[:query] =~ /^\s*$/
+      params[:query] = nil
+    else
+      params[:query] = params[:query].strip
+    end
+  end
+end

--- a/app/models/search/query_cleaner.rb
+++ b/app/models/search/query_cleaner.rb
@@ -32,6 +32,8 @@ class QueryCleaner
     params
   end
 
+  private
+
   def unescape_angle_brackets
     params[:query] = params[:query].gsub('&gt;', '>').gsub('&lt;', '<')
   end
@@ -81,11 +83,12 @@ class QueryCleaner
   end
 
   # put categories into quotes
+  # don't match if the letters are part of larger words (ie, "Tom/Mark")
   def add_quotes_to_categories
     qr = Regexp.new('(?:"|\')?')
     %w(m/m f/f f/m m/f).each do |cat|
-      cr = Regexp.new("#{qr}#{cat}#{qr}", Regexp::IGNORECASE)
-      params[:query] = params[:query].gsub(cr, "\"#{cat}\"")
+      cr = Regexp.new("(\\A|\\s)#{qr}#{cat}#{qr}(\\z|\\s)", Regexp::IGNORECASE)
+      params[:query] = params[:query].gsub(cr, " \"#{cat}\" ")
     end
   end
 

--- a/app/models/work_search.rb
+++ b/app/models/work_search.rb
@@ -418,20 +418,8 @@ class WorkSearch < Search
   #
   #############################################################################
 
-  SORT_OPTIONS = [
-    ['Author', 'authors_to_sort_on'],
-    ['Title', 'title_to_sort_on'],
-    ['Date Posted', 'created_at'],
-    ['Date Updated', 'revised_at'],
-    ['Word Count', 'word_count'],
-    ['Hits', 'hits'],
-    ['Kudos', 'kudos_count'],
-    ['Comments', 'comments_count'],
-    ['Bookmarks', 'bookmarks_count']
-  ]
-
   def sort_options
-    SORT_OPTIONS
+    QueryCleaner::SORT_OPTIONS
   end
 
   def sort_values
@@ -440,7 +428,7 @@ class WorkSearch < Search
 
   # extract the pretty name
   def name_for_sort_column(sort_column)
-    Hash[SORT_OPTIONS.collect {|v| [ v[1], v[0] ]}][sort_column]
+    Hash[sort_options.collect {|v| [ v[1], v[0] ]}][sort_column]
   end
 
   def default_sort_direction(sort_column)

--- a/spec/controllers/works/default_rails_actions_spec.rb
+++ b/spec/controllers/works/default_rails_actions_spec.rb
@@ -145,7 +145,7 @@ describe WorksController do
     context "when the query contains categories" do
       it "surrounds categories in quotes" do
         [
-          { query: "M/F sort by: comments", expected: "M/F " },
+          { query: "M/F sort by: comments", expected: "\"m/f\"" },
           { query: "f/f Scully/Reyes", expected: "\"f/f\" Scully/Reyes" },
         ].each do |settings|
           call_with_params(query: settings[:query])
@@ -153,10 +153,10 @@ describe WorksController do
         end
       end
 
-      it "surrounds categories in quotes even when it shouldn't (AO3-3576)" do
+      it "does not surround categories in quotes when it shouldn't" do
         query = "sam/frodo sort by: word"
         call_with_params(query: query)
-        expect(controller.params[:work_search][:query]).to eq("sa\"m/f\"rodo ")
+        expect(controller.params[:work_search][:query]).to eq("sam/frodo")
       end
     end
   end

--- a/spec/models/query_cleaner_spec.rb
+++ b/spec/models/query_cleaner_spec.rb
@@ -44,6 +44,11 @@ describe QueryCleaner do
       expect(cleaner.clean[:query]).to eq("Buffy \"f/f\"")
     end
 
+    it "should not ID category tags that are part of larger words" do
+      cleaner = QueryCleaner.new(query: "Jim/Frank")
+      expect(cleaner.clean[:query]).to eq("Jim/Frank")
+    end
+
     it "should extract sorting options from a query" do
       cleaner = QueryCleaner.new(query: "sort by: hits ascending")
       clean_params = cleaner.clean

--- a/spec/models/query_cleaner_spec.rb
+++ b/spec/models/query_cleaner_spec.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+require 'active_support/inflector'
+require File.expand_path('../../app/models/search/query_cleaner', File.dirname(__FILE__))
+
+describe QueryCleaner do
+  describe "#clean" do
+    it "should return a hash" do
+      q = { query: "hello world" }
+      cleaner = QueryCleaner.new(q)
+      expect(cleaner.clean).to eq(q)
+    end
+
+    it "should not error if there is no query" do
+      cleaner = QueryCleaner.new({})
+      expect(cleaner.clean).to eq({})
+    end
+
+    it "should extract word count from a query" do
+      ["words=100", "wordcount:100", "word_count = 100"].each do |query|
+        cleaner = QueryCleaner.new(query: query)
+        clean_params = cleaner.clean
+        expect(clean_params[:query]).to eq(nil)
+        expect(clean_params[:word_count]).to eq("100")
+      end
+    end
+
+    it "should extract hits from a query" do
+      cleaner = QueryCleaner.new(query: "hit count > 50")
+      clean_params = cleaner.clean
+      expect(clean_params[:query]).to eq(nil)
+      expect(clean_params[:hits]).to eq("> 50")
+    end
+
+    it "should extract comment count from a query" do
+      cleaner = QueryCleaner.new(query: "pumpkins comments<10")
+      clean_params = cleaner.clean
+      expect(clean_params[:query]).to eq("pumpkins")
+      expect(clean_params[:comments_count]).to eq("<10")
+    end
+
+    it "should put quotes around category tags" do
+      cleaner = QueryCleaner.new(query: "Buffy F/F")
+      expect(cleaner.clean[:query]).to eq("Buffy \"f/f\"")
+    end
+
+    it "should extract sorting options from a query" do
+      cleaner = QueryCleaner.new(query: "sort by: hits ascending")
+      clean_params = cleaner.clean
+      expect(clean_params[:query]).to eq(nil)
+      expect(clean_params[:sort_column]).to eq("hits")
+      expect(clean_params[:sort_direction]).to eq("asc")
+    end
+
+    it "should extract word count sorting from a query" do
+      cleaner = QueryCleaner.new(query: "sort:<words")
+      clean_params = cleaner.clean
+      expect(clean_params[:query]).to eq(nil)
+      expect(clean_params[:sort_column]).to eq("word_count")
+      expect(clean_params[:sort_direction]).to eq("desc")
+    end
+
+    it "should extract author sorting from a query" do
+      cleaner = QueryCleaner.new(query: "sorted by:>author")
+      clean_params = cleaner.clean
+      expect(clean_params[:query]).to eq(nil)
+      expect(clean_params[:sort_column]).to eq("authors_to_sort_on")
+      expect(clean_params[:sort_direction]).to eq("asc")
+    end
+  end
+end


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5262
https://otwarchive.atlassian.net/browse/AO3-3576

## Purpose

Extracts the query cleanup code from the works controller into a separate class. Also ended up fixing the weird category-escaping-overreach bug.

## Testing

Behavior should be the same, other than the category tag escaping, which should now be case-insensitive, but should only match when the letters are not part of larger words.