### PR TITLE
AO3-5229: Simple fix for ancient date errors

### DIFF
--- a/app/models/search.rb
+++ b/app/models/search.rb
@@ -82,8 +82,12 @@ class Search < ApplicationRecord
   end
 
   # helper method to create times from two strings
+  # Elasticsearch gets grumpy with negative years, so the simple fix
+  # is just to go back a thousand years
+  # TODO: rework date query formats if Homer ever starts posting his stuff to AO3
   def self.time_from_string(amount, period)
-    amount.to_i.send(period).ago
+    date = amount.to_i.send(period).ago
+    date.year < 0 ? 1000.years.ago : date
   end
 
   # Generate a range based on one number

--- a/app/models/search.rb
+++ b/app/models/search.rb
@@ -87,7 +87,7 @@ class Search < ApplicationRecord
   # TODO: rework date query formats if Homer ever starts posting his stuff to AO3
   def self.time_from_string(amount, period)
     date = amount.to_i.send(period).ago
-    date.year < 0 ? 1000.years.ago : date
+    date.year.negative? ? out_of_range_date : date
   end
 
   # Generate a range based on one number
@@ -112,7 +112,14 @@ class Search < ApplicationRecord
     else
       raise "unknown period: " + period
     end
+    a, a2 = [a, a2].map do |date|
+      date.year.negative? ? out_of_range_date : date
+    end
     { gte: a, lte: a2 }
+  end
+
+  def self.out_of_range_date
+    1000.years.ago
   end
 
   # Only escape if it isn't already escaped

--- a/spec/models/work_query_spec.rb
+++ b/spec/models/work_query_spec.rb
@@ -156,4 +156,13 @@ describe WorkQuery do
     date = filter.dig(:range, :revised_at, :lt)
     expect(date.year).to eq(1000.years.ago.year)
   end
+
+  it "should rescue absurd date ranges" do
+    q = WorkQuery.new(revised_at: "700000000-700000001 days ago")
+    filter = q.range_filters.first
+    start_date = filter.dig(:range, :revised_at, :gte)
+    end_date = filter.dig(:range, :revised_at, :lte)
+    expect(start_date.year).to eq(1000.years.ago.year)
+    expect(end_date.year).to eq(1000.years.ago.year)
+  end
 end

--- a/spec/models/work_query_spec.rb
+++ b/spec/models/work_query_spec.rb
@@ -150,4 +150,10 @@ describe WorkQuery do
     expect(q.generated_query[:sort]).to eq({'comments_count' => { order: 'desc'}})
   end
 
+  it "should rescue absurd dates" do
+    q = WorkQuery.new(revised_at: "> 700000000 days")
+    filter = q.range_filters.first
+    date = filter.dig(:range, :revised_at, :lt)
+    expect(date.year).to eq(1000.years.ago.year)
+  end
 end


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5229

## Purpose

Fix error encountered when a user enters a very large date in date search. Since we're really just concerned with things posted by contemporaneous people, a simple fix should suffice for now.

## Testing

Entering a large value in date search should no longer error.