### PR TITLE
AO3-5264: Set operator for bookmark search

### DIFF
--- a/app/models/search/bookmark_query.rb
+++ b/app/models/search/bookmark_query.rb
@@ -77,7 +77,7 @@ class BookmarkQuery < Query
   end
 
   def general_query
-    { query_string: { query: query_term } }
+    { query_string: { query: query_term, default_operator: "AND" } }
   end
 
   def parent_query
@@ -86,7 +86,8 @@ class BookmarkQuery < Query
         parent_type: "bookmarkable",
         query: {
           query_string: {
-            query: query_term
+            query: query_term,
+            default_operator: "AND"
           }
         }
       }

--- a/spec/models/bookmark_query_spec.rb
+++ b/spec/models/bookmark_query_spec.rb
@@ -5,7 +5,7 @@ describe BookmarkQuery do
   it "should allow you to perform a simple search" do
     q = BookmarkQuery.new(query: "unicorns")
     search_body = q.generated_query
-    expect(search_body[:query][:bool][:should]).to include({:query_string => { :query => "unicorns" }})
+    expect(search_body[:query][:bool][:should]).to include({ query_string: { query: "unicorns", default_operator: "AND" }})
   end
 
   it "should not return private bookmarks by default" do


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5264

## Purpose

Fixes bookmark search to use 'AND' as the default operator, to match other search behavior.

## Testing

Bookmark searches for multiple words/terms should return results that match all of them, not any one of them.