### PR TITLE
AO3-5265: Switch tag name search back to a query string

### DIFF
--- a/app/models/search/tag_query.rb
+++ b/app/models/search/tag_query.rb
@@ -38,9 +38,13 @@ class TagQuery < Query
 
   def name_query
     return unless options[:name]
-
-    name = escape_reserved_characters(options[:name])
-    { match_phrase: { name: name } } if options[:name]
+    {
+      simple_query_string: {
+        query: escape_reserved_characters(options[:name]),
+        fields: ["name"],
+        default_operator: "and"
+      }
+    }
   end
 
 end


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5265

## Purpose

Change the query type for tag names in tag search to allow people to do partial matching

## Testing

Partial searches with asterisks should return results