### PR TITLE
AO3-5273: Fix child queries for bookmark filter data

### DIFF
--- a/app/models/search/bookmarkable_query.rb
+++ b/app/models/search/bookmarkable_query.rb
@@ -1,4 +1,6 @@
 class BookmarkableQuery < Query
+  attr_accessor :bookmark_query
+
   def klass
     'Bookmarkable'
   end
@@ -15,17 +17,23 @@ class BookmarkableQuery < Query
   # Elasticsearch doesn't let you do parent aggregations directly
   def self.filters_for_bookmarks(bookmark_query)
     query = BookmarkableQuery.new(per_page: 0)
-    query.add_bookmark_filters(bookmark_query)
+    query.bookmark_query = bookmark_query
+    query.add_bookmark_filters
     query.aggregation_results
   end
 
   # Take the existing bookmark filters and flip them around
   # Simple term filters should now be child filters so they apply to the bookmarks
   # Parent filters should now be regular filters on the work/series
-  def add_bookmark_filters(bookmark_query)
-    add_flipped_filters(bookmark_query)
-    add_flipped_exclusion_filters(bookmark_query)
-    add_flipped_query(bookmark_query)
+  def add_bookmark_filters
+    add_flipped_filters
+    add_flipped_exclusion_filters
+    add_flipped_query
+    add_child_filters
+  end
+
+  def child_filters
+    @child_filters ||= { include: [], exclude: [] }
   end
 
   # Do a regular search and return only the aggregations
@@ -46,41 +54,39 @@ class BookmarkableQuery < Query
 
   private
 
-  def add_flipped_filters(bookmark_query)
-    if bookmark_query.filters.present?
-      @filters ||= []
-      bookmark_query.filters.each do |filter|
-        @filters << flipped_filter(filter)
-      end
-    end
+  def add_flipped_filters
+    return unless bookmark_query&.filters.present?
+    @filters ||= []
+    @filters += bookmark_query.filters.map { |filter| flipped_filter(filter) }.compact
   end
 
-  def add_flipped_exclusion_filters(bookmark_query)
-    if bookmark_query.exclusion_filters.present?
-      @exclusion_filters ||= []
-      bookmark_query.exclusion_filters.each do |filter|
-        @exclusion_filters << flipped_filter(filter)
-      end
-    end
+  def add_flipped_exclusion_filters
+    return unless bookmark_query&.exclusion_filters.present?
+    @exclusion_filters ||= []
+    @exclusion_filters += bookmark_query.exclusion_filters.map { |filter| flipped_filter(filter, type: :exclusion) }.compact
   end
 
-  def add_flipped_query(bookmark_query)
-    shoulds = bookmark_query.should_query
+  def add_flipped_query
+    shoulds = bookmark_query&.should_query
     if shoulds.present?
       @should_queries = shoulds.map { |q| flipped_query(q) }
     end
   end
 
-  def flipped_filter(filter)
+  # Because a work or a series can have many bookmarks, we need to combine
+  # the child queries into one bool query so that we don't, eg, leak private bookmark data
+  def flipped_filter(filter, options = {})
     if filter.key?(:term) || filter.key?(:terms)
-      { has_child: { type: "bookmark", query: filter } }
+      key = options[:type] == :exclusion ? :exclude : :include
+      child_filters[key] << filter
+      return nil
     elsif filter.key?(:has_parent)
       filter[:has_parent][:query]
     end
   end
 
   def flipped_query(q)
-    if q.key?(:query_string)
+    if q.key?(:query_string) || q.key?(:simple_query_string)
       q
     elsif q.key?(:has_parent)
       child_query = q[:has_parent]&.merge(type: "bookmark")
@@ -89,4 +95,21 @@ class BookmarkableQuery < Query
     end
   end
 
+  # Combine include and exclude child filters into one query so they apply to the same bookmarks
+  def add_child_filters
+    bool = {}
+    bool[:must] = child_filters[:include] if child_filters[:include].present?
+    bool[:must_not] = child_filters[:exclude] if child_filters[:exclude].present?
+    unless bool.empty?
+      has_child_query = {
+        has_child: {
+          type: 'bookmark',
+          query: {
+            bool: bool
+          }
+        }
+      }
+      @filters << has_child_query
+    end
+  end
 end

--- a/spec/models/bookmarkable_query_spec.rb
+++ b/spec/models/bookmarkable_query_spec.rb
@@ -1,0 +1,26 @@
+require 'spec_helper'
+
+describe BookmarkableQuery do
+  describe "#add_bookmark_filters" do
+    it "should take a default has_parent query and flip it around" do
+      bookmark_query = BookmarkQuery.new
+      q = BookmarkableQuery.new
+      q.bookmark_query = bookmark_query
+      q.add_bookmark_filters
+      filters = q.generated_query.dig(:query, :bool, :filter, :bool, :must)
+      expect(filters).to include(term: { restricted: "false" })
+    end
+
+    it "should take bookmark filters and combine them into one child query" do
+      bookmark_query = BookmarkQuery.new(user_ids: [5], excluded_tag_ids: [666])
+      q = BookmarkableQuery.new
+      q.bookmark_query = bookmark_query
+      q.add_bookmark_filters
+      filters = q.generated_query.dig(:query, :bool, :filter, :bool, :must)
+      child_filter = filters.detect { |f| f.key?(:has_child) }
+      expect(child_filter.dig(:has_child, :query, :bool, :must)).to include(term: { private: "false" })
+      expect(child_filter.dig(:has_child, :query, :bool, :must)).to include(term: { user_id: 5 })
+      expect(child_filter.dig(:has_child, :query, :bool, :must_not)).to include(term: { tag_ids: 666 })      
+    end
+  end
+end


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5273

## Purpose

Fixes an issue where private bookmarks were being counted in filters if the work/series had other public bookmarks.

Because works/series/external works can have multiple bookmarks, the child filters have to be combined into one query of their own or else incorrect results may be returned. 

## Testing

See issue.