### PR TITLE
AO3-5269 Fix regex for getting sortable work authors

### DIFF
--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -1364,12 +1364,14 @@ class Work < ApplicationRecord
   # SORTING
   ########################################################################
 
+  SORTED_AUTHOR_REGEX = %r{^[\+\-=_\?!'"\.\/]}
+
   def sorted_authors
-    self.authors.map(&:name).join(",  ").downcase.gsub(/^[\+-=_\?!'"\.\/]/, '')
+    self.authors.map(&:name).join(",  ").downcase.gsub(SORTED_AUTHOR_REGEX, '')
   end
 
   def sorted_pseuds
-    self.pseuds.map(&:name).join(",  ").downcase.gsub(/^[\+-=_\?!'"\.\/]/, '')
+    self.pseuds.map(&:name).join(",  ").downcase.gsub(SORTED_AUTHOR_REGEX, '')
   end
 
   def sorted_title

--- a/spec/models/work_search_form_spec.rb
+++ b/spec/models/work_search_form_spec.rb
@@ -236,24 +236,23 @@ describe WorkSearchForm do
   describe "sorting results" do
     describe "by authors" do
       before do
-        %w(-zzz _yasuho 21st_wombat 007aardvark 6tasmanian_devil).each do |pseud_name|
+        %w(21st_wombat 007aardvark).each do |pseud_name|
           create(:posted_work, authors: [create(:pseud, name: pseud_name)])
         end
-        create(:posted_work, authors: %w(pseud2 pseud1).map { |n| create(:pseud, name: n) })
         update_and_refresh_indexes "work"
       end
 
       it "returns all works in the correct order of sortable pseud values" do
-        sorted_pseuds_asc = ["007aardvark", "21st_wombat", "6tasmanian_devil", "pseud2,  pseud1", "yasuho", "zzz"]
+        sorted_pseuds_asc = ["007aardvark", "21st_wombat"]
 
         work_search = WorkSearchForm.new(sort_column: "authors_to_sort_on")
-        expect(work_search.search_results.map(&:sorted_pseuds)).to eq sorted_pseuds_asc
+        expect(work_search.search_results.map(&:authors_to_sort_on)).to eq sorted_pseuds_asc
 
         work_search = WorkSearchForm.new(sort_column: "authors_to_sort_on", sort_direction: "asc")
-        expect(work_search.search_results.map(&:sorted_pseuds)).to eq sorted_pseuds_asc
+        expect(work_search.search_results.map(&:authors_to_sort_on)).to eq sorted_pseuds_asc
 
         work_search = WorkSearchForm.new(sort_column: "authors_to_sort_on", sort_direction: "desc")
-        expect(work_search.search_results.map(&:sorted_pseuds)).to eq sorted_pseuds_asc.reverse
+        expect(work_search.search_results.map(&:authors_to_sort_on)).to eq sorted_pseuds_asc.reverse
       end
     end
   end

--- a/spec/models/work_spec.rb
+++ b/spec/models/work_spec.rb
@@ -102,6 +102,26 @@ describe Work do
     end
   end
 
+  describe "authors to sort on" do
+    let(:work) { build(:work) }
+
+    it "when pseuds start with special characters" do
+      work.authors = [create(:pseud, name: "-jolyne")]
+      work.save
+      expect(work.authors_to_sort_on).to eq "jolyne"
+
+      work.authors = [create(:pseud, name: "_hermes")]
+      work.save
+      expect(work.authors_to_sort_on).to eq "hermes"
+    end
+
+    it "when there are multiple pseuds" do
+      work.authors = [create(:pseud, name: "diavolo"), create(:pseud, name: "doppio")]
+      work.save
+      expect(work.authors_to_sort_on).to eq "diavolo,  doppio"
+    end
+  end
+
   describe "work_skin_allowed" do
     context "public skin"
 

--- a/spec/models/work_spec.rb
+++ b/spec/models/work_spec.rb
@@ -102,23 +102,44 @@ describe Work do
     end
   end
 
-  describe "authors to sort on" do
+  describe "#set_author_sorting" do
     let(:work) { build(:work) }
 
-    it "when pseuds start with special characters" do
-      work.authors = [create(:pseud, name: "-jolyne")]
-      work.save
-      expect(work.authors_to_sort_on).to eq "jolyne"
+    context "when the pseuds start with special characters" do
+      it "should remove those characters" do
+        work.authors = [Pseud.new(name: "-jolyne")]
+        work.set_author_sorting
+        expect(work.authors_to_sort_on).to eq "jolyne"
 
-      work.authors = [create(:pseud, name: "_hermes")]
-      work.save
-      expect(work.authors_to_sort_on).to eq "hermes"
+        work.authors = [Pseud.new(name: "_hermes")]
+        work.set_author_sorting
+        expect(work.authors_to_sort_on).to eq "hermes"
+      end
     end
 
-    it "when there are multiple pseuds" do
-      work.authors = [create(:pseud, name: "diavolo"), create(:pseud, name: "doppio")]
-      work.save
-      expect(work.authors_to_sort_on).to eq "diavolo,  doppio"
+    context "when the pseuds start with numbers" do
+      it "should not remove numbers" do
+        work.authors = [Pseud.new(name: "007james")]
+        work.set_author_sorting
+        expect(work.authors_to_sort_on).to eq "007james"
+      end
+    end
+
+    context "when the work is anonymous" do
+      it "should set the author sorting to Anonymous" do
+        work.in_anon_collection = true
+        work.authors = [Pseud.new(name: "stealthy")]
+        work.set_author_sorting
+        expect(work.authors_to_sort_on).to eq "Anonymous"
+      end
+    end
+
+    context "when the work has multiple pseuds" do
+      it "should combine them with commas" do
+        work.authors = [Pseud.new(name: "diavolo"), Pseud.new(name: "doppio")]
+        work.set_author_sorting
+        expect(work.authors_to_sort_on).to eq "diavolo,  doppio"
+      end
     end
   end
 


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5269

## Purpose

The hyphen should be escaped, otherwise we're removing the first character if it's anything in the range from "+" to "=".

## Testing

See issue.