### PR TITLE
AO3-5274 Create visual distinction between exclusion and inclusion checkboxes

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -551,4 +551,10 @@ module ApplicationHelper
     end
     super(*[collection_or_options, options].compact)
   end
+
+  # spans for nesting a checkbox or radio button inside its label to make custom
+  # checkbox or radio designs
+  def replacement_label(text)
+    content_tag(:span, "", class: "indicator", "aria-hidden": "true") + content_tag(:span, text)
+  end
 end # end of ApplicationHelper

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -554,7 +554,7 @@ module ApplicationHelper
 
   # spans for nesting a checkbox or radio button inside its label to make custom
   # checkbox or radio designs
-  def replacement_label(text)
+  def label_indicator_and_text(text)
     content_tag(:span, "", class: "indicator", "aria-hidden": "true") + content_tag(:span, text)
   end
 end # end of ApplicationHelper

--- a/app/views/bookmarks/_filters.html.erb
+++ b/app/views/bookmarks/_filters.html.erb
@@ -52,8 +52,8 @@
                               filter_boolean_value(filter_action, tag_type, tag.id.to_s),
                               id: "#{filter_action}_bookmark_search_#{tag_type}_ids_#{tag.id}" %>
                         <% end %>
-                        <% # If this isn't on one line, there is a space before and after the label %>
-                        <span><%= label_for_filter(tag_type, {name: tag.name, count: tag.count}) %></span>
+                        <% text = label_for_filter(tag_type, { name: tag.name, count: tag.count }) %>
+                        <%= replacement_label(text) %>
                       <% end %>
                     </li>
                   <% end %>
@@ -90,13 +90,13 @@
               <li>
                 <%= f.label :rec do %>
                   <%= f.check_box :rec %>
-                  <span><%= ts("Recs only") %></span>
+                  <%= replacement_label(ts("Recs only")) %>
                 <% end %>
               </li>
               <li>
                 <%= f.label :with_notes do %>
                   <%= f.check_box :with_notes %>
-                  <span><%= ts("Only bookmarks with notes") %></span>
+                  <%= replacement_label(ts("Only bookmarks with notes")) %>
                 <% end %>
               </li>
             </ul>

--- a/app/views/bookmarks/_filters.html.erb
+++ b/app/views/bookmarks/_filters.html.erb
@@ -53,7 +53,7 @@
                               id: "#{filter_action}_bookmark_search_#{tag_type}_ids_#{tag.id}" %>
                         <% end %>
                         <% text = label_for_filter(tag_type, { name: tag.name, count: tag.count }) %>
-                        <%= replacement_label(text) %>
+                        <%= label_indicator_and_text(text) %>
                       <% end %>
                     </li>
                   <% end %>
@@ -90,13 +90,13 @@
               <li>
                 <%= f.label :rec do %>
                   <%= f.check_box :rec %>
-                  <%= replacement_label(ts("Recs only")) %>
+                  <%= label_indicator_and_text(ts("Recs only")) %>
                 <% end %>
               </li>
               <li>
                 <%= f.label :with_notes do %>
                   <%= f.check_box :with_notes %>
-                  <%= replacement_label(ts("Only bookmarks with notes")) %>
+                  <%= label_indicator_and_text(ts("Only bookmarks with notes")) %>
                 <% end %>
               </li>
             </ul>

--- a/app/views/bookmarks/_filters.html.erb
+++ b/app/views/bookmarks/_filters.html.erb
@@ -40,19 +40,21 @@
                   <% @facets[tag_type].each do |tag| %>
                     <li>
                       <% next if filter_action == "include" && @search.options[:excluded_tag_ids]&.include?(tag.id.to_s) %>
-                      <% if (tag_type == "rating") && @facets[tag_type].length > 1 && filter_action == "include" %>
-                        <%= radio_button_tag "#{filter_action}_bookmark_search[#{tag_type}_ids][]",
-                            tag.id,
-                            filter_boolean_value(filter_action, tag_type, tag.id.to_s),
-                            id: "#{filter_action}_bookmark_search_#{tag_type}_ids_#{tag.id}" %>
-                      <% else %>
-                        <%= check_box_tag "#{filter_action}_bookmark_search[#{tag_type}_ids][]",
-                            tag.id,
-                            filter_boolean_value(filter_action, tag_type, tag.id.to_s),
-                            id: "#{filter_action}_bookmark_search_#{tag_type}_ids_#{tag.id}" %>
+                      <%= label_tag "#{filter_action}_bookmark_search_#{tag_type}_ids_#{tag.id}" do %>
+                        <% if (tag_type == "rating") && @facets[tag_type].length > 1 && filter_action == "include" %>
+                          <%= radio_button_tag "#{filter_action}_bookmark_search[#{tag_type}_ids][]",
+                              tag.id,
+                              filter_boolean_value(filter_action, tag_type, tag.id.to_s),
+                              id: "#{filter_action}_bookmark_search_#{tag_type}_ids_#{tag.id}" %>
+                        <% else %>
+                          <%= check_box_tag "#{filter_action}_bookmark_search[#{tag_type}_ids][]",
+                              tag.id,
+                              filter_boolean_value(filter_action, tag_type, tag.id.to_s),
+                              id: "#{filter_action}_bookmark_search_#{tag_type}_ids_#{tag.id}" %>
+                        <% end %>
+                        <% # If this isn't on one line, there is a space before and after the label %>
+                        <span><%= label_for_filter(tag_type, {name: tag.name, count: tag.count}) %></span>
                       <% end %>
-                      <%= label_tag "#{filter_action}_bookmark_search_#{tag_type}_ids_#{tag.id}",
-                          "#{label_for_filter(tag_type, {name: tag.name, count: tag.count})}" %>
                     </li>
                   <% end %>
                 </ul>
@@ -86,12 +88,16 @@
           <dd class="options">
             <ul>
               <li>
-                <%= f.check_box :rec %>
-                <%= f.label :rec, ts("Recs only") %>
+                <%= f.label :rec do %>
+                  <%= f.check_box :rec %>
+                  <span><%= ts("Recs only") %></span>
+                <% end %>
               </li>
               <li>
-                <%= f.check_box :with_notes %>
-                <%= f.label :with_notes, ts("Only bookmarks with notes") %>
+                <%= f.label :with_notes do %>
+                  <%= f.check_box :with_notes %>
+                  <span><%= ts("Only bookmarks with notes") %></span>
+                <% end %>
               </li>
             </ul>
           </dd>

--- a/app/views/collections/_filters.html.erb
+++ b/app/views/collections/_filters.html.erb
@@ -51,21 +51,21 @@
             <%= label_tag "collection_filters_closed_true" do %>
               <%= radio_button_tag "collection_filters[closed]", true,
                   params[:collection_filters][:closed] == "true" %>
-              <span><%= ts("Yes") %></span>
+              <%= replacement_label(ts("Yes")) %>
             <% end %>
           </li>
           <li>
             <%= label_tag "collection_filters_closed_false" do %>
               <%= radio_button_tag "collection_filters[closed]", false,
                   params[:collection_filters][:closed] == "false" %>
-              <span><%= ts("No") %></span>
+              <%= replacement_label(ts("No")) %>
             <% end %>
           </li>
           <li>
             <%= label_tag "collection_filters_closed_" do %>
               <%= radio_button_tag "collection_filters[closed]", "",
                   params[:collection_filters][:closed] == "" %>
-              <span><%= ts("Either") %></span>
+              <%= replacement_label(ts("Either")) %>
             <% end %>
           </li>
         </ul>
@@ -77,21 +77,21 @@
             <%= label_tag "collection_filters_moderated_true" do %>
               <%= radio_button_tag "collection_filters[moderated]", true,
                   params[:collection_filters][:moderated] == "true" %>
-              <span><%= ts("Yes") %></span>
+              <%= replacement_label(ts("Yes")) %>
             <% end %>
           </li>
           <li>
             <%= label_tag "collection_filters_moderated_false" do %>
               <%= radio_button_tag "collection_filters[moderated]", false,
                   params[:collection_filters][:moderated] == "false" %>
-              <span><%= ts("No") %></span>
+              <%= replacement_label(ts("No")) %>
             <% end %>
           </li>
           <li>
             <%= label_tag "collection_filters_moderated_" do %>
               <%= radio_button_tag "collection_filters[moderated]", "",
                   params[:collection_filters][:moderated] == "" %>
-              <span><%= ts("Either") %></span>
+              <%= replacement_label(ts("Either")) %>
             <% end %>
           </li>
         </ul>
@@ -105,16 +105,16 @@
                   "gift_exchange",
                   params[:collection_filters][:challenge_type] == "gift_exchange"
               %>
-              <span><%= ts("Gift Exchange Challenge") %></span>
+              <%= replacement_label(ts("Gift Exchange Challenge")) %>
             <% end %>
           </li>
           <li>
             <%= label_tag "collection_filters_challenge_type_prompt_meme" do %>
               <%= radio_button_tag "collection_filters[challenge_type]",
                   "prompt_meme",
-                  params[:collection_filters][:challenge_type] == "prompt_meme" 
+                  params[:collection_filters][:challenge_type] == "prompt_meme"
               %>
-              <span><%= ts("Prompt Meme Challenge") %></span>
+              <%= replacement_label(ts("Prompt Meme Challenge")) %>
             <% end %>
           </li>
           <li>
@@ -123,14 +123,14 @@
                   "no_challenge",
                   params[:collection_filters][:challenge_type] == "no_challenge"
               %>
-              <span><%= ts("No Challenge") %></span>
+              <%= replacement_label(ts("No Challenge")) %>
             <% end %>
           </li>
           <li>
             <%= label_tag "collection_filters_challenge_type_" do %>
               <%= radio_button_tag "collection_filters[challenge_type]", "",
                   params[:collection_filters][:challenge_type] == "" %>
-              <span><%= ts("Any") %></span>
+              <%= replacement_label(ts("Any")) %>
             <% end %>
           </li>
         </ul>

--- a/app/views/collections/_filters.html.erb
+++ b/app/views/collections/_filters.html.erb
@@ -48,19 +48,25 @@
       <dd>
         <ul>
           <li>
-            <%= radio_button_tag "collection_filters[closed]", true,
-                params[:collection_filters][:closed] == "true" %>
-            <%= label_tag "collection_filters_closed_true", ts("Yes") %>
+            <%= label_tag "collection_filters_closed_true" do %>
+              <%= radio_button_tag "collection_filters[closed]", true,
+                  params[:collection_filters][:closed] == "true" %>
+              <span><%= ts("Yes") %></span>
+            <% end %>
           </li>
           <li>
-            <%= radio_button_tag "collection_filters[closed]", false,
-                params[:collection_filters][:closed] == "false" %>
-            <%= label_tag "collection_filters_closed_false", ts("No") %>
+            <%= label_tag "collection_filters_closed_false" do %>
+              <%= radio_button_tag "collection_filters[closed]", false,
+                  params[:collection_filters][:closed] == "false" %>
+              <span><%= ts("No") %></span>
+            <% end %>
           </li>
           <li>
-            <%= radio_button_tag "collection_filters[closed]", "",
-                params[:collection_filters][:closed] == "" %>
-            <%= label_tag "collection_filters_closed_", ts("Either") %>
+            <%= label_tag "collection_filters_closed_" do %>
+              <%= radio_button_tag "collection_filters[closed]", "",
+                  params[:collection_filters][:closed] == "" %>
+              <span><%= ts("Either") %></span>
+            <% end %>
           </li>
         </ul>
       </dd>
@@ -68,18 +74,25 @@
       <dd>
         <ul>
           <li>
-            <%= radio_button_tag "collection_filters[moderated]", true,
-                params[:collection_filters][:moderated] == "true" %>
-            <%= label_tag "collection_filters_moderated_true", ts("Yes") %>
+            <%= label_tag "collection_filters_moderated_true" do %>
+              <%= radio_button_tag "collection_filters[moderated]", true,
+                  params[:collection_filters][:moderated] == "true" %>
+              <span><%= ts("Yes") %></span>
+            <% end %>
           </li>
           <li>
-            <%= radio_button_tag "collection_filters[moderated]", false,
-                params[:collection_filters][:moderated] == "false" %>
-            <%= label_tag "collection_filters_moderated_false", ts("No") %>
+            <%= label_tag "collection_filters_moderated_false" do %>
+              <%= radio_button_tag "collection_filters[moderated]", false,
+                  params[:collection_filters][:moderated] == "false" %>
+              <span><%= ts("No") %></span>
+            <% end %>
           </li>
           <li>
-            <%= radio_button_tag "collection_filters[moderated]", "", params[:collection_filters][:moderated] == "" %>
-            <%= label_tag "collection_filters_moderated_", ts("Either") %>
+            <%= label_tag "collection_filters_moderated_" do %>
+              <%= radio_button_tag "collection_filters[moderated]", "",
+                  params[:collection_filters][:moderated] == "" %>
+              <span><%= ts("Either") %></span>
+            <% end %>
           </li>
         </ul>
       </dd>
@@ -87,32 +100,38 @@
       <dd>
         <ul>
           <li>
-            <%= radio_button_tag "collection_filters[challenge_type]",
-                "gift_exchange",
-                params[:collection_filters][:challenge_type] == "gift_exchange"
-            %>
-            <%= label_tag "collection_filters_challenge_type_gift_exchange",
-                ts("Gift Exchange Challenge") %>
-          </li>    
-          <li>
-            <%= radio_button_tag "collection_filters[challenge_type]",
-                "prompt_meme",
-                params[:collection_filters][:challenge_type] == "prompt_meme" %>
-            <%= label_tag "collection_filters_challenge_type_prompt_meme",
-                ts("Prompt Meme Challenge") %>
+            <%= label_tag "collection_filters_challenge_type_gift_exchange" do %>
+              <%= radio_button_tag "collection_filters[challenge_type]",
+                  "gift_exchange",
+                  params[:collection_filters][:challenge_type] == "gift_exchange"
+              %>
+              <span><%= ts("Gift Exchange Challenge") %></span>
+            <% end %>
           </li>
           <li>
-            <%= radio_button_tag "collection_filters[challenge_type]",
-                "no_challenge",
-                params[:collection_filters][:challenge_type] == "no_challenge"
-            %>
-            <%= label_tag "collection_filters_challenge_type_no_challenge",
-                ts("No Challenge") %>
+            <%= label_tag "collection_filters_challenge_type_prompt_meme" do %>
+              <%= radio_button_tag "collection_filters[challenge_type]",
+                  "prompt_meme",
+                  params[:collection_filters][:challenge_type] == "prompt_meme" 
+              %>
+              <span><%= ts("Prompt Meme Challenge") %></span>
+            <% end %>
           </li>
           <li>
-            <%= radio_button_tag "collection_filters[challenge_type]", "",
-                params[:collection_filters][:challenge_type] == "" %>
-            <%= label_tag "collection_filters_challenge_type_", ts("Any") %>
+            <%= label_tag "collection_filters_challenge_type_no_challenge" do %>
+              <%= radio_button_tag "collection_filters[challenge_type]",
+                  "no_challenge",
+                  params[:collection_filters][:challenge_type] == "no_challenge"
+              %>
+              <span><%= ts("No Challenge") %></span>
+            <% end %>
+          </li>
+          <li>
+            <%= label_tag "collection_filters_challenge_type_" do %>
+              <%= radio_button_tag "collection_filters[challenge_type]", "",
+                  params[:collection_filters][:challenge_type] == "" %>
+              <span><%= ts("Any") %></span>
+            <% end %>
           </li>
         </ul>
       </dd>

--- a/app/views/collections/_filters.html.erb
+++ b/app/views/collections/_filters.html.erb
@@ -51,21 +51,21 @@
             <%= label_tag "collection_filters_closed_true" do %>
               <%= radio_button_tag "collection_filters[closed]", true,
                   params[:collection_filters][:closed] == "true" %>
-              <%= replacement_label(ts("Yes")) %>
+              <%= label_indicator_and_text(ts("Yes")) %>
             <% end %>
           </li>
           <li>
             <%= label_tag "collection_filters_closed_false" do %>
               <%= radio_button_tag "collection_filters[closed]", false,
                   params[:collection_filters][:closed] == "false" %>
-              <%= replacement_label(ts("No")) %>
+              <%= label_indicator_and_text(ts("No")) %>
             <% end %>
           </li>
           <li>
             <%= label_tag "collection_filters_closed_" do %>
               <%= radio_button_tag "collection_filters[closed]", "",
                   params[:collection_filters][:closed] == "" %>
-              <%= replacement_label(ts("Either")) %>
+              <%= label_indicator_and_text(ts("Either")) %>
             <% end %>
           </li>
         </ul>
@@ -77,21 +77,21 @@
             <%= label_tag "collection_filters_moderated_true" do %>
               <%= radio_button_tag "collection_filters[moderated]", true,
                   params[:collection_filters][:moderated] == "true" %>
-              <%= replacement_label(ts("Yes")) %>
+              <%= label_indicator_and_text(ts("Yes")) %>
             <% end %>
           </li>
           <li>
             <%= label_tag "collection_filters_moderated_false" do %>
               <%= radio_button_tag "collection_filters[moderated]", false,
                   params[:collection_filters][:moderated] == "false" %>
-              <%= replacement_label(ts("No")) %>
+              <%= label_indicator_and_text(ts("No")) %>
             <% end %>
           </li>
           <li>
             <%= label_tag "collection_filters_moderated_" do %>
               <%= radio_button_tag "collection_filters[moderated]", "",
                   params[:collection_filters][:moderated] == "" %>
-              <%= replacement_label(ts("Either")) %>
+              <%= label_indicator_and_text(ts("Either")) %>
             <% end %>
           </li>
         </ul>
@@ -105,7 +105,7 @@
                   "gift_exchange",
                   params[:collection_filters][:challenge_type] == "gift_exchange"
               %>
-              <%= replacement_label(ts("Gift Exchange Challenge")) %>
+              <%= label_indicator_and_text(ts("Gift Exchange Challenge")) %>
             <% end %>
           </li>
           <li>
@@ -114,7 +114,7 @@
                   "prompt_meme",
                   params[:collection_filters][:challenge_type] == "prompt_meme"
               %>
-              <%= replacement_label(ts("Prompt Meme Challenge")) %>
+              <%= label_indicator_and_text(ts("Prompt Meme Challenge")) %>
             <% end %>
           </li>
           <li>
@@ -123,14 +123,14 @@
                   "no_challenge",
                   params[:collection_filters][:challenge_type] == "no_challenge"
               %>
-              <%= replacement_label(ts("No Challenge")) %>
+              <%= label_indicator_and_text(ts("No Challenge")) %>
             <% end %>
           </li>
           <li>
             <%= label_tag "collection_filters_challenge_type_" do %>
               <%= radio_button_tag "collection_filters[challenge_type]", "",
                   params[:collection_filters][:challenge_type] == "" %>
-              <%= replacement_label(ts("Any")) %>
+              <%= label_indicator_and_text(ts("Any")) %>
             <% end %>
           </li>
         </ul>

--- a/app/views/works/_collection_filters.html.erb
+++ b/app/views/works/_collection_filters.html.erb
@@ -30,7 +30,7 @@
                     @search.collection_ids.present? && @search.collection_ids.include?(collection.id.to_s), 
                     id: "work_search_collection_ids_#{collection.id}" %>
                   <% text = "#{collection.name} (#{collection.count})" %>
-                  <%= replacement_label(text) %>
+                  <%= label_indicator_and_text(text) %>
                 <% end %>
               </li>
             <% end %>

--- a/app/views/works/_collection_filters.html.erb
+++ b/app/views/works/_collection_filters.html.erb
@@ -9,7 +9,7 @@
   <%= field_set_tag (ts('Filter results:') + link_to_help("filters")).html_safe do %>
     <dl class="filters" role="menu">
       <dt class="landmark"><%= ts("Submit") %></dt>
-      <dd class="submit actions"><%= f.submit ts('Sort and Filter') %></dd>
+      <dd class="submit actions"><%= f.submit ts("Sort and Filter") %></dd>
       <dt>
         <%= f.label :sort_column, ts("Sort by") %>
       </dt>
@@ -24,19 +24,20 @@
           <ul>              
             <% @facets['collections'].each do |collection| %>
               <li>
-                <%= check_box_tag "work_search[collection_ids][]", 
-                  collection.id,
-                  @search.collection_ids.present? && @search.collection_ids.include?(collection.id.to_s), 
-                  :id => "work_search_collection_ids_#{collection.id}" %>
-                <%= label_tag "work_search_collection_ids_#{collection.id}", 
-                  "#{collection.name} (#{collection.count})" %>
+                <%= label_tag "work_search_collection_ids_#{collection.id}" do %> 
+                  <%= check_box_tag "work_search[collection_ids][]", 
+                    collection.id,
+                    @search.collection_ids.present? && @search.collection_ids.include?(collection.id.to_s), 
+                    id: "work_search_collection_ids_#{collection.id}" %>
+                  <span><%= "#{collection.name} (#{collection.count})" %></span>
+                <% end %>
               </li>
             <% end %>
           </ul>
         </dd>
       <% end %>
       <dt class="landmark"><%= ts("Submit") %></dt>
-      <dd class="submit actions"><%= f.submit ts('Sort and Filter') %></dd>
+      <dd class="submit actions"><%= f.submit ts("Sort and Filter") %></dd>
     </dl>
     <div>
       <%= hidden_field_tag("user_id", @user.login) if @user %>

--- a/app/views/works/_collection_filters.html.erb
+++ b/app/views/works/_collection_filters.html.erb
@@ -29,7 +29,8 @@
                     collection.id,
                     @search.collection_ids.present? && @search.collection_ids.include?(collection.id.to_s), 
                     id: "work_search_collection_ids_#{collection.id}" %>
-                  <span><%= "#{collection.name} (#{collection.count})" %></span>
+                  <% text = "#{collection.name} (#{collection.count})" %>
+                  <%= replacement_label(text) %>
                 <% end %>
               </li>
             <% end %>

--- a/app/views/works/_filters.html.erb
+++ b/app/views/works/_filters.html.erb
@@ -96,7 +96,7 @@
                 <% end %>
               </li>
               <li>
-                <%= f.label :crossover, ts("Only crossovers"), value: "T" do %>
+                <%= f.label :crossover, value: "T" do %>
                   <%= f.radio_button :crossover, "T" %>
                   <%= label_indicator_and_text(ts("Show only crossovers")) %>
                 <% end %>
@@ -130,18 +130,18 @@
           <dd id="work_words" class="expandable">
             <dl class="range">
               <dt><%= f.label :words_from, ts("From") %></dt>
-              <dd><%= f.text_field :words_from %>
+              <dd><%= f.text_field :words_from %></dd>
               <dt><%= f.label :words_to, ts("To") %></dt>
-              <dd><%= f.text_field :words_to %>
+              <dd><%= f.text_field :words_to %></dd>
             </dl>
           </dd>
           <dt id="toggle_work_dates" class="filter-toggle dates"><%= ts("Date Updated") %></dt>
           <dd id="work_dates" class="expandable">
             <dl class="range">
               <dt><%= f.label :date_from, ts("From") %></dt>
-              <dd><%= f.text_field :date_from, class: "datepicker" %>
+              <dd><%= f.text_field :date_from, class: "datepicker" %></dd>
               <dt><%= f.label :date_to, ts("To") %></dt>
-              <dd><%= f.text_field :date_to, class: "datepicker" %>
+              <dd><%= f.text_field :date_to, class: "datepicker" %></dd>
             </dl>
           </dd>
 

--- a/app/views/works/_filters.html.erb
+++ b/app/views/works/_filters.html.erb
@@ -52,8 +52,8 @@
                             filter_boolean_value(filter_action, tag_type, tag.id.to_s),
                             id: "#{filter_action}_work_search_#{tag_type}_ids_#{tag.id}" %>
                         <% end %>
-                        <% # If this isn't on one line, there is a space before and after the label %>
-                        <span><%= label_for_filter(tag_type, {name: tag.name, count: tag.count}) %></span>
+                        <% text = label_for_filter(tag_type, { name: tag.name, count: tag.count }) %>
+                        <%= replacement_label(text) %>
                       <% end %>
                     </li>
                   <% end %>
@@ -86,19 +86,19 @@
               <li>
                 <%= f.label :crossover, value: "" do %>
                   <%= f.radio_button :crossover, "" %>
-                  <span><%= ts("Include crossovers") %></span>
+                  <%= replacement_label(ts("Include crossovers")) %>
                 <% end %>
               </li>
               <li>
                 <%= f.label :crossover, value: "F" do %>
                   <%= f.radio_button :crossover, "F" %>
-                  <span><%= ts("Exclude crossovers") %></span>
+                  <%= replacement_label(ts("Exclude crossovers")) %>
                 <% end %>
               </li>
               <li>
                 <%= f.label :crossover, ts("Only crossovers"), value: "T" do %>
                   <%= f.radio_button :crossover, "T" %>
-                  <span><%= ts("Show only crossovers") %></span>
+                  <%= replacement_label(ts("Show only crossovers")) %>
                 <% end %>
               </li>
             </ul>
@@ -109,19 +109,19 @@
               <li>
                 <%= f.label :complete, value: "" do %>
                   <%= f.radio_button :complete, "" %>
-                  <span><%= ts("Both complete and incomplete") %></span>
+                  <%= replacement_label(ts("Both complete and incomplete")) %>
                 <% end %>
               </li>
               <li>
                 <%= f.label :complete, value: "T" do %>
                   <%= f.radio_button :complete, "T" %>
-                  <span><%= ts("Only complete works") %></span>
+                  <%= replacement_label(ts("Only complete works")) %>
                 <% end %>
               </li>
               <li>
                 <%= f.label :complete, value: "F" do %>
                   <%= f.radio_button :complete, "F" %>
-                  <span><%= ts("Only incomplete works") %></span>
+                  <%= replacement_label(ts("Only incomplete works")) %>
                 <% end %>
               </li>
             </ul>

--- a/app/views/works/_filters.html.erb
+++ b/app/views/works/_filters.html.erb
@@ -53,7 +53,7 @@
                             id: "#{filter_action}_work_search_#{tag_type}_ids_#{tag.id}" %>
                         <% end %>
                         <% text = label_for_filter(tag_type, { name: tag.name, count: tag.count }) %>
-                        <%= replacement_label(text) %>
+                        <%= label_indicator_and_text(text) %>
                       <% end %>
                     </li>
                   <% end %>
@@ -86,19 +86,19 @@
               <li>
                 <%= f.label :crossover, value: "" do %>
                   <%= f.radio_button :crossover, "" %>
-                  <%= replacement_label(ts("Include crossovers")) %>
+                  <%= label_indicator_and_text(ts("Include crossovers")) %>
                 <% end %>
               </li>
               <li>
                 <%= f.label :crossover, value: "F" do %>
                   <%= f.radio_button :crossover, "F" %>
-                  <%= replacement_label(ts("Exclude crossovers")) %>
+                  <%= label_indicator_and_text(ts("Exclude crossovers")) %>
                 <% end %>
               </li>
               <li>
                 <%= f.label :crossover, ts("Only crossovers"), value: "T" do %>
                   <%= f.radio_button :crossover, "T" %>
-                  <%= replacement_label(ts("Show only crossovers")) %>
+                  <%= label_indicator_and_text(ts("Show only crossovers")) %>
                 <% end %>
               </li>
             </ul>
@@ -109,19 +109,19 @@
               <li>
                 <%= f.label :complete, value: "" do %>
                   <%= f.radio_button :complete, "" %>
-                  <%= replacement_label(ts("Both complete and incomplete")) %>
+                  <%= label_indicator_and_text(ts("Both complete and incomplete")) %>
                 <% end %>
               </li>
               <li>
                 <%= f.label :complete, value: "T" do %>
                   <%= f.radio_button :complete, "T" %>
-                  <%= replacement_label(ts("Only complete works")) %>
+                  <%= label_indicator_and_text(ts("Only complete works")) %>
                 <% end %>
               </li>
               <li>
                 <%= f.label :complete, value: "F" do %>
                   <%= f.radio_button :complete, "F" %>
-                  <%= replacement_label(ts("Only incomplete works")) %>
+                  <%= label_indicator_and_text(ts("Only incomplete works")) %>
                 <% end %>
               </li>
             </ul>

--- a/app/views/works/_filters.html.erb
+++ b/app/views/works/_filters.html.erb
@@ -40,19 +40,21 @@
                   <% @facets[tag_type].each do |tag| %>
                     <li>
                       <% next if filter_action == "include" && @search.options[:excluded_tag_ids]&.include?(tag.id.to_s) %>
-                      <% if (tag_type == "rating") && @facets[tag_type].length > 1 && filter_action == "include" %>
-                        <%= radio_button_tag "#{filter_action}_work_search[#{tag_type}_ids][]",
-                          tag.id,
-                          filter_boolean_value(filter_action, tag_type, tag.id.to_s),
-                          id: "#{filter_action}_work_search_#{tag_type}_ids_#{tag.id}" %>
-                      <% else %>
-                        <%= check_box_tag "#{filter_action}_work_search[#{tag_type}_ids][]",
-                          tag.id,
-                          filter_boolean_value(filter_action, tag_type, tag.id.to_s),
-                          id: "#{filter_action}_work_search_#{tag_type}_ids_#{tag.id}" %>
+                      <%= label_tag "#{filter_action}_work_search_#{tag_type}_ids_#{tag.id}" do %>
+                        <% if (tag_type == "rating") && @facets[tag_type].length > 1 && filter_action == "include" %>
+                          <%= radio_button_tag "#{filter_action}_work_search[#{tag_type}_ids][]",
+                            tag.id,
+                            filter_boolean_value(filter_action, tag_type, tag.id.to_s),
+                            id: "#{filter_action}_work_search_#{tag_type}_ids_#{tag.id}" %>
+                        <% else %>
+                          <%= check_box_tag "#{filter_action}_work_search[#{tag_type}_ids][]",
+                            tag.id,
+                            filter_boolean_value(filter_action, tag_type, tag.id.to_s),
+                            id: "#{filter_action}_work_search_#{tag_type}_ids_#{tag.id}" %>
+                        <% end %>
+                        <% # If this isn't on one line, there is a space before and after the label %>
+                        <span><%= label_for_filter(tag_type, {name: tag.name, count: tag.count}) %></span>
                       <% end %>
-                      <%= label_tag "#{filter_action}_work_search_#{tag_type}_ids_#{tag.id}",
-                        "#{label_for_filter(tag_type, {name: tag.name, count: tag.count})}" %>
                     </li>
                   <% end %>
                 </ul>
@@ -82,16 +84,22 @@
           <dd id="work_crossover" class="expandable">
             <ul>
               <li>
-                <%= f.radio_button :crossover, "" %>
-                <%= f.label :crossover, ts("Include crossovers"), value: "" %>
+                <%= f.label :crossover, value: "" do %>
+                  <%= f.radio_button :crossover, "" %>
+                  <span><%= ts("Include crossovers") %></span>
+                <% end %>
               </li>
               <li>
-                <%= f.radio_button :crossover, "F" %>
-                <%= f.label :crossover, ts("Exclude crossovers"), value: "F" %>
+                <%= f.label :crossover, value: "F" do %>
+                  <%= f.radio_button :crossover, "F" %>
+                  <span><%= ts("Exclude crossovers") %></span>
+                <% end %>
               </li>
               <li>
-                <%= f.radio_button :crossover, "T" %>
-                <%= f.label :crossover, ts("Show only crossovers"), value: "T" %>
+                <%= f.label :crossover, ts("Only crossovers"), value: "T" do %>
+                  <%= f.radio_button :crossover, "T" %>
+                  <span><%= ts("Show only crossovers") %></span>
+                <% end %>
               </li>
             </ul>
           </dd>
@@ -99,16 +107,22 @@
           <dd id="work_complete" class="expandable">
             <ul>
               <li>
-                <%= f.radio_button :complete, "" %>
-                <%= f.label :complete, ts("Both complete and incomplete"), value: "" %>
+                <%= f.label :complete, value: "" do %>
+                  <%= f.radio_button :complete, "" %>
+                  <span><%= ts("Both complete and incomplete") %></span>
+                <% end %>
               </li>
               <li>
-                <%= f.radio_button :complete, "T" %>
-                <%= f.label :complete, ts("Only complete works"), value: "T" %>
+                <%= f.label :complete, value: "T" do %>
+                  <%= f.radio_button :complete, "T" %>
+                  <span><%= ts("Only complete works") %></span>
+                <% end %>
               </li>
               <li>
-                <%= f.radio_button :complete, "F" %>
-                <%= f.label :complete, ts("Only incomplete works"), value: "F" %>
+                <%= f.label :complete, value: "F" do %>
+                  <%= f.radio_button :complete, "F" %>
+                  <span><%= ts("Only incomplete works") %></span>
+                <% end %>
               </li>
             </ul>
           </dd>

--- a/public/stylesheets/site/2.0/18-zone-searchbrowse.css
+++ b/public/stylesheets/site/2.0/18-zone-searchbrowse.css
@@ -176,11 +176,14 @@ form.filters {
 }
 
 .filters .indicator:before {
-  background: linear-gradient(#fff 2%, #ddd 95%, #bbb 100%);
+  background: #eee;
   color: #aaa;  
-  border: 0.125em solid;
+  border: 1px solid;
   margin-right: 0.25em;
   text-align: center;
+    background-image: -moz-linear-gradient(top, #fff 2%, #ddd 95%, #bbb 100%);
+    background-image: -webkit-linear-gradient(top, #fff 2%, #ddd 95%, #bbb 100%);
+    background-image: linear-gradient(#fff 2%, #ddd 95%, #bbb 100%);
 }
 
 .filters input:focus + .indicator + span {
@@ -189,7 +192,6 @@ form.filters {
 
 .filters input:checked + .indicator:before {
   border-color: #aaa;
-  font-weight: 500;
 }
 
 .filters input:checked + .indicator + span {
@@ -203,8 +205,11 @@ form.filters {
 }
 
 .filters [type="checkbox"]:checked + .indicator:before {
-  color: #006d00;
-  background: linear-gradient(#fff 2%, #c3d8c3 95%, #a7baa7 100%);
+  background: #deffde;
+  color: #008000;
+    background-image: -moz-linear-gradient(top, #fff 2%, #d1f0d1 95%, #b3ccb3 100%);
+    background-image: -webkit-linear-gradient(top, #fff 2%, #d1f0d1 95%, #b3ccb3 100%);
+    background-image: linear-gradient(#fff 2%, #d1f0d1 95%, #b3ccb3 100%);
 }
 
 .filters [type="radio"] + .indicator:before {
@@ -217,9 +222,13 @@ form.filters {
 }
 
 .filters [type="radio"]:checked + .indicator:before {
-  background: radial-gradient(ellipse at center, rgba(0, 0, 0, 0.8) 0%, rgba(0, 0, 0, 0.8) 11%, rgba(0, 0, 0, 0) 23%),
-              linear-gradient(to bottom, #bbb 0%, #ddd 5%, #fff 100%);
-  color: #aaa;
+  background: #fff;
+    background-image: -moz-radial-gradient(center, ellipse cover, rgba(0, 0, 0, 0.8) 0%, rgba(0, 0, 0, 0.8) 11%, rgba(0, 0, 0, 0) 23%),
+                      -moz-linear-gradient(top, #bbb 0%, #ddd 5%, #fff 100%);
+    background-image: -webkit-radial-gradient(center, ellipse cover, rgba(0, 0, 0, 0.8) 0%, rgba(0, 0, 0, 0.8) 11%, rgba(0, 0, 0, 0) 23%),
+                      -webkit-linear-gradient(top, #bbb 0%, #ddd 5%, #fff 100%);
+    background-image: radial-gradient(ellipse at center, rgba(0, 0, 0, 0.8) 0%, rgba(0, 0, 0, 0.8) 11%, rgba(0, 0, 0, 0) 23%),
+                      linear-gradient(to bottom, #bbb 0%, #ddd 5%, #fff 100%);
 }
 
 .filters .exclude [type="checkbox"] + .indicator:before {
@@ -227,8 +236,11 @@ form.filters {
 }
 
 .filters .exclude [type="checkbox"]:checked + .indicator:before {
+  background: #fedede;
   color: #f00;
-  background: linear-gradient(#fff 2%, #EFCECE 95%, #E0C0C0 100%);
+    background-image: -moz-linear-gradient(top, #fff 2%, #efd1d1 95%, #d8bebe 100%);
+    background-image: -webkit-linear-gradient(top, #fff 2%, #efd1d1 95%, #d8bebe 100%);
+    background-image: linear-gradient(#fff 2%, #efd1d1 95%, #d8bebe 100%);
 }
 
 /* INTERACTION: OLD FILTERS */

--- a/public/stylesheets/site/2.0/18-zone-searchbrowse.css
+++ b/public/stylesheets/site/2.0/18-zone-searchbrowse.css
@@ -178,6 +178,7 @@ form.filters {
 .filters .indicator:before {
   background: #eee;
   color: #aaa;  
+  display: inline-block;
   border: 1px solid;
   margin-right: 0.25em;
   text-align: center;
@@ -216,7 +217,6 @@ form.filters {
   content: "";
   width: 1em;
   height: 1em;
-  display: inline-block;
   vertical-align: -0.125em;
     border-radius: 1em;
 }

--- a/public/stylesheets/site/2.0/18-zone-searchbrowse.css
+++ b/public/stylesheets/site/2.0/18-zone-searchbrowse.css
@@ -156,14 +156,6 @@ form.filters {
   margin-top: 1.286em; /* heading top margin minus sort bottom margin */
 }
 
-.filters dl legend {
-  width: auto;
-  height: auto;
-  opacity: 1.0;
-  display: inline;
-  font-size: 1em;
-}
-
 .filters [type="checkbox"], .filters [type="radio"] {
   border: 0; 
   clip: rect(0 0 0 0); 

--- a/public/stylesheets/site/2.0/18-zone-searchbrowse.css
+++ b/public/stylesheets/site/2.0/18-zone-searchbrowse.css
@@ -156,6 +156,14 @@ form.filters {
   margin-top: 1.286em; /* heading top margin minus sort bottom margin */
 }
 
+.filters dl legend {
+  width: auto;
+  height: auto;
+  opacity: 1.0;
+  display: inline;
+  font-size: 1em;
+}
+
 .filters [type="radio"], .filters [type="checkbox"] {
   border: 0; 
   clip: rect(0 0 0 0); 
@@ -167,7 +175,7 @@ form.filters {
   width: 1px;
 }
 
-.filters input[type="radio"] + span:before, .filters input[type="checkbox"] + span:before {
+.filters input[type="radio"] + .indicator:before, .filters input[type="checkbox"] + .indicator:before {
   background: linear-gradient(#fff 2%, #ddd 95%, #bbb 100%);
   color: #aaa;  
   border: 0.125em solid;
@@ -175,16 +183,16 @@ form.filters {
   text-align: center;
 }
 
-.filters input:checked + span:before {
+.filters input:checked + .indicator:before {
   border-color: #aaa;
   font-weight: 500;
 }
 
-.filters input:checked + span {
+.filters input:checked + .indicator + span {
   font-weight: 700;
 }
 
-.filters [type="radio"] + span:before {
+.filters [type="radio"] + .indicator:before {
   content: "";
   width: 1em;
   height: 1em;
@@ -193,28 +201,28 @@ form.filters {
     border-radius: 1em;
 }
 
-.filters [type="radio"]:checked + span:before {
+.filters [type="radio"]:checked + .indicator:before {
   background: radial-gradient(ellipse at center, rgba(0, 0, 0, 0.8) 0%, rgba(0, 0, 0, 0.8) 11%, rgba(0, 0, 0, 0) 23%),
               linear-gradient(to bottom, #bbb 0%, #ddd 5%, #fff 100%);
   color: #aaa;
 }
 
-.filters [type="checkbox"] + span:before {
+.filters [type="checkbox"] + .indicator:before {
   content: " \2713";
   padding: 0 0.25em;
     border-radius: 0.25em;
 }
 
-.filters [type="checkbox"]:checked + span:before {
+.filters [type="checkbox"]:checked + .indicator:before {
   color: #006d00;
   background: linear-gradient(#fff 2%, #c3d8c3 95%, #a7baa7 100%);
 }
 
-.filters .exclude [type="checkbox"] + span:before {
+.filters .exclude [type="checkbox"] + .indicator:before {
   content: " \2715";
 }
 
-.filters .exclude [type="checkbox"]:checked + span:before {
+.filters .exclude [type="checkbox"]:checked + .indicator:before {
   color: red;
   background: linear-gradient(#fff 2%, #EFCECE 95%, #E0C0C0 100%);
 }

--- a/public/stylesheets/site/2.0/18-zone-searchbrowse.css
+++ b/public/stylesheets/site/2.0/18-zone-searchbrowse.css
@@ -168,7 +168,6 @@ form.filters {
 }
 
 .filters input[type="radio"] + span:before, .filters input[type="checkbox"] + span:before {
-  /* background: linear-gradient(to bottom, #ffffff 0%, #f1f1f1 50%, #e1e1e1 51%, #f6f6f6 100%); */
   background: linear-gradient(#fff 2%, #ddd 95%, #bbb 100%);
   color: #aaa;  
   border: 0.125em solid;
@@ -195,7 +194,9 @@ form.filters {
 }
 
 .filters [type="radio"]:checked + span:before {
-  background: radial-gradient(ellipse at center, #aaa 0%, #ddd 29%, #fff 61%);
+  background: radial-gradient(ellipse at center, rgba(0, 0, 0, 0.8) 0%, rgba(0, 0, 0, 0.8) 11%, rgba(0, 0, 0, 0) 23%),
+              linear-gradient(to bottom, #bbb 0%, #ddd 5%, #fff 100%);
+  color: #aaa;
 }
 
 .filters [type="checkbox"] + span:before {
@@ -206,7 +207,6 @@ form.filters {
 
 .filters [type="checkbox"]:checked + span:before {
   color: #006d00;
-  /* background: linear-gradient(to bottom, #ffffff 0%, #e5efe5 50%, #c5dfc7 51%, #eaf4ea 100%); */
   background: linear-gradient(#fff 2%, #c3d8c3 95%, #a7baa7 100%);
 }
 
@@ -216,7 +216,6 @@ form.filters {
 
 .filters .exclude [type="checkbox"]:checked + span:before {
   color: red;
-  /* background: linear-gradient(to bottom, #ffffff 0%, #f9eaeb 50%, #f1d5d5 51%, #faf0ee 100%); */
   background: linear-gradient(#fff 2%, #EFCECE 95%, #E0C0C0 100%);
 }
 

--- a/public/stylesheets/site/2.0/18-zone-searchbrowse.css
+++ b/public/stylesheets/site/2.0/18-zone-searchbrowse.css
@@ -156,6 +156,63 @@ form.filters {
   margin-top: 1.286em; /* heading top margin minus sort bottom margin */
 }
 
+.filters [type="radio"], .filters [type="checkbox"] {
+  border: 0; 
+  clip: rect(0 0 0 0); 
+  height: 1px;
+  margin: -1px; 
+  overflow: hidden; 
+  padding: 0; 
+  position: absolute; 
+  width: 1px;
+}
+
+.filters input[type="radio"] + span:before, .filters input[type="checkbox"] + span:before {
+  background: linear-gradient(to bottom, #ffffff 0%, #f1f1f1 50%, #e1e1e1 51%, #f6f6f6 100%);
+  color: #aaa;  
+  border: 0.125em solid;
+  margin-right: 0.25em;
+  text-align: center;
+}
+
+.filters input:checked + span:before {
+  border-color: #aaa;
+  font-weight: 500;
+}
+
+.filters input:checked + span {
+  font-weight: 700;
+}
+
+.filters [type="radio"] + span:before {
+  content: "";
+  width: 1em;
+  height: 1em;
+  display: inline-block;
+  vertical-align: -0.125em;
+    border-radius: 1em;
+}
+
+.filters [type="checkbox"] + span:before {
+  content: " \2713";
+  padding: 0 0.25em;
+    border-radius: 0.25em;
+}
+
+.filters input:checked + span:before {
+  color: #006d00;
+  background: linear-gradient(to bottom, #ffffff 0%, #e5efe5 50%, #c5dfc7 51%, #eaf4ea 100%);
+}
+
+.filters .exclude [type="checkbox"] + span:before {
+  content: " \2715";
+}
+
+.filters .exclude [type="checkbox"]:checked + span:before {
+  color: red;
+  background: linear-gradient(to bottom, #ffffff 0%, #f9eaeb 50%, #f1d5d5 51%, #faf0ee 100%);
+}
+
 /* INTERACTION: OLD FILTERS */
 /* ES UPGRADE TRANSITION: REMOVE WHEN DONE */
 

--- a/public/stylesheets/site/2.0/18-zone-searchbrowse.css
+++ b/public/stylesheets/site/2.0/18-zone-searchbrowse.css
@@ -168,7 +168,8 @@ form.filters {
 }
 
 .filters input[type="radio"] + span:before, .filters input[type="checkbox"] + span:before {
-  background: linear-gradient(to bottom, #ffffff 0%, #f1f1f1 50%, #e1e1e1 51%, #f6f6f6 100%);
+  /* background: linear-gradient(to bottom, #ffffff 0%, #f1f1f1 50%, #e1e1e1 51%, #f6f6f6 100%); */
+  background: linear-gradient(#fff 2%, #ddd 95%, #bbb 100%);
   color: #aaa;  
   border: 0.125em solid;
   margin-right: 0.25em;
@@ -193,15 +194,20 @@ form.filters {
     border-radius: 1em;
 }
 
+.filters [type="radio"]:checked + span:before {
+  background: radial-gradient(ellipse at center, #aaa 0%, #ddd 29%, #fff 61%);
+}
+
 .filters [type="checkbox"] + span:before {
   content: " \2713";
   padding: 0 0.25em;
     border-radius: 0.25em;
 }
 
-.filters input:checked + span:before {
+.filters [type="checkbox"]:checked + span:before {
   color: #006d00;
-  background: linear-gradient(to bottom, #ffffff 0%, #e5efe5 50%, #c5dfc7 51%, #eaf4ea 100%);
+  /* background: linear-gradient(to bottom, #ffffff 0%, #e5efe5 50%, #c5dfc7 51%, #eaf4ea 100%); */
+  background: linear-gradient(#fff 2%, #c3d8c3 95%, #a7baa7 100%);
 }
 
 .filters .exclude [type="checkbox"] + span:before {
@@ -210,7 +216,8 @@ form.filters {
 
 .filters .exclude [type="checkbox"]:checked + span:before {
   color: red;
-  background: linear-gradient(to bottom, #ffffff 0%, #f9eaeb 50%, #f1d5d5 51%, #faf0ee 100%);
+  /* background: linear-gradient(to bottom, #ffffff 0%, #f9eaeb 50%, #f1d5d5 51%, #faf0ee 100%); */
+  background: linear-gradient(#fff 2%, #EFCECE 95%, #E0C0C0 100%);
 }
 
 /* INTERACTION: OLD FILTERS */

--- a/public/stylesheets/site/2.0/18-zone-searchbrowse.css
+++ b/public/stylesheets/site/2.0/18-zone-searchbrowse.css
@@ -164,7 +164,7 @@ form.filters {
   font-size: 1em;
 }
 
-.filters [type="radio"], .filters [type="checkbox"] {
+.filters [type="checkbox"], .filters [type="radio"] {
   border: 0; 
   clip: rect(0 0 0 0); 
   height: 1px;
@@ -175,12 +175,16 @@ form.filters {
   width: 1px;
 }
 
-.filters input[type="radio"] + .indicator:before, .filters input[type="checkbox"] + .indicator:before {
+.filters .indicator:before {
   background: linear-gradient(#fff 2%, #ddd 95%, #bbb 100%);
   color: #aaa;  
   border: 0.125em solid;
   margin-right: 0.25em;
   text-align: center;
+}
+
+.filters input:focus + .indicator + span {
+  outline: 1px dotted;
 }
 
 .filters input:checked + .indicator:before {
@@ -190,6 +194,17 @@ form.filters {
 
 .filters input:checked + .indicator + span {
   font-weight: 700;
+}
+
+.filters [type="checkbox"] + .indicator:before {
+  content: " \2713";
+  padding: 0 0.25em;
+    border-radius: 0.25em;
+}
+
+.filters [type="checkbox"]:checked + .indicator:before {
+  color: #006d00;
+  background: linear-gradient(#fff 2%, #c3d8c3 95%, #a7baa7 100%);
 }
 
 .filters [type="radio"] + .indicator:before {
@@ -207,23 +222,12 @@ form.filters {
   color: #aaa;
 }
 
-.filters [type="checkbox"] + .indicator:before {
-  content: " \2713";
-  padding: 0 0.25em;
-    border-radius: 0.25em;
-}
-
-.filters [type="checkbox"]:checked + .indicator:before {
-  color: #006d00;
-  background: linear-gradient(#fff 2%, #c3d8c3 95%, #a7baa7 100%);
-}
-
 .filters .exclude [type="checkbox"] + .indicator:before {
   content: " \2715";
 }
 
 .filters .exclude [type="checkbox"]:checked + .indicator:before {
-  color: red;
+  color: #f00;
   background: linear-gradient(#fff 2%, #EFCECE 95%, #E0C0C0 100%);
 }
 


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5274

## Purpose

Uses [this technique](https://www.sitepoint.com/replacing-radio-buttons-without-replacing-radio-buttons/) to update the styling of the input elements on our filters with the specific goal of making it easier to tell if the selected item is selected for inclusion or exclusion as you scroll down the page.

## Testing

Refer to JIRA
