### PR TITLE
AO3-5279 - Deleting bookmarks causes error in BookmarkIndexer.

### DIFF
--- a/app/models/search/bookmark_indexer.rb
+++ b/app/models/search/bookmark_indexer.rb
@@ -65,13 +65,13 @@ class BookmarkIndexer < Indexer
       "_index" => index_name,
       "_type" => document_type,
       "_id" => id,
-      "routing" => parent_id(object)
+      "routing" => parent_id(id, object)
     }
   end
 
-  def parent_id(object)
+  def parent_id(id, object)
     if object.nil?
-      deleted_bookmark_info(object.id)
+      deleted_bookmark_info(id)
     else
       "#{object.bookmarkable_id}-#{object.bookmarkable_type.underscore}"
     end
@@ -89,7 +89,7 @@ class BookmarkIndexer < Indexer
       tag_ids: tags.map(&:id)
     )
 
-    unless parent_id(object).match("deleted")
+    unless parent_id(object.id, object).match("deleted")
       json_object.merge!(
         bookmarkable_join: {
           name: "bookmark",

--- a/app/models/search/bookmark_indexer.rb
+++ b/app/models/search/bookmark_indexer.rb
@@ -93,7 +93,7 @@ class BookmarkIndexer < Indexer
       json_object.merge!(
         bookmarkable_join: {
           name: "bookmark",
-          parent: parent_id(object)
+          parent: parent_id(object.id, object)
         }
       )
     end

--- a/app/models/search/indexer.rb
+++ b/app/models/search/indexer.rb
@@ -143,7 +143,7 @@ class Indexer
       body: document(object)
     }
     if respond_to?(:parent_id)
-      info.merge!(routing: parent_id(object))
+      info.merge!(routing: parent_id(object.id, object))
     end
     $new_elasticsearch.index(info)
   end


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5279

## Purpose

When the BookmarkIndexer tries to look up a bookmark that's been deleted, the object associated with the deleted ID will be nil. The parent_id function tries to call object.id if the object is nil; instead, it should take the object's ID as an argument and use that to access the information it needs.

## Testing

Try deleting a bookmark, wait a while, and then check the logs to see if there has been an error.