### PR TITLE
AO3-5280 - Make the scheduled reindexing job index ExternalWorks and Series.

### DIFF
--- a/app/models/external_work.rb
+++ b/app/models/external_work.rb
@@ -128,7 +128,6 @@ class ExternalWork < ApplicationRecord
         :relationship_ids, :freeform_ids, :creators, :revised_at
       ]
     ).merge(
-      id: "external_work-#{id}",
       bookmarkable_type: "ExternalWork",
       bookmarkable_join: "bookmarkable"
     )

--- a/app/models/indexing/index_subqueue.rb
+++ b/app/models/indexing/index_subqueue.rb
@@ -35,19 +35,12 @@ class IndexSubqueue
   end
 
   def run
-    # Do this before the old indexing  to make sure that we know which IDs to
-    # pass to the indexer. (Delete this comment after the upgrade is complete.)
-    if $rollout.active?(:start_new_indexing)
-      AsyncIndexer.index(klass, ids, label)
-    end
-    unless $rollout.active?(:stop_old_indexing)
-      build_batch
-      @response = perform_batch_update
-      if @response.code == 200
-        respond_to_success
-      else
-        respond_to_failure
-      end
+    build_batch
+    @response = perform_batch_update
+    if @response.code == 200
+      respond_to_success
+    else
+      respond_to_failure
     end
   end
 

--- a/app/models/indexing/scheduled_reindex_job.rb
+++ b/app/models/indexing/scheduled_reindex_job.rb
@@ -3,7 +3,7 @@ class ScheduledReindexJob
   def self.perform(reindex_type)
     classes = case reindex_type
               when 'main'
-                %w(Pseud Tag Work Bookmark)
+                %w(Pseud Tag Work Bookmark Series ExternalWork)
               when 'background'
                 %w(Work Bookmark)
               when 'stats'

--- a/app/models/series.rb
+++ b/app/models/series.rb
@@ -226,7 +226,6 @@ class Series < ApplicationRecord
         :relationship_ids, :freeform_ids, :pseud_ids, :creators, :language_id,
         :word_count, :work_types]
     ).merge(
-      id: "series-#{id}",
       anonymous: anonymous?,
       unrevealed: unrevealed?,
       bookmarkable_type: 'Series',

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -1507,7 +1507,6 @@ class Work < ApplicationRecord
         :fandom_ids, :character_ids, :relationship_ids, :freeform_ids,
         :pseud_ids, :creators, :collection_ids, :work_types]
     ).merge(
-      id: "work-#{id}",
       anonymous: anonymous?,
       unrevealed: unrevealed?,
       bookmarkable_type: 'Work',

--- a/spec/models/index_queue_spec.rb
+++ b/spec/models/index_queue_spec.rb
@@ -27,7 +27,12 @@ describe IndexQueue do
   it "should create subqueues when run" do
     iq = IndexQueue.new("index:work:main")
     iq.add_id(1)
-    expect(IndexSubqueue).to receive(:create_and_enqueue)
+
+    # Once the upgrade is complete, this check can be deleted.
+    expect(IndexSubqueue).to receive(:create_and_enqueue).exactly(
+      $rollout.active?(:stop_old_indexing) ? 0 : 1
+    ).times
+
     iq.run
 
     expect(IndexQueue::REDIS.exists("index:work:main")).to be_falsey


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5280

## Purpose

This pull request does three things to try to fix the indexing of ExternalWorks and Series:
1. Add Series and ExternalWork to the list of classes indexed by ScheduledReindexJob.
2. Refactor the logic of IndexQueue and IndexSubqueue so that IndexSubqueue won't handle ExternalWorks or Series (since it would cause IndexSubqueue.klass to fail with an error).
3. Remove the unnecessary `id: "external_work-#{id}"` field (and similar) from bookmarkable_json, since it apparently causes ES to error when re-indexing a document. (Credit to WendyBeth for figuring out this issue and the fix in #3122.)

## Testing

Testing instructions are in the bug report.