### PR TITLE
AO3-5281 - Don't nest stat updates inside work field. [Old indexing code.]

### DIFF
--- a/app/models/indexing/index_subqueue.rb
+++ b/app/models/indexing/index_subqueue.rb
@@ -140,12 +140,10 @@ class IndexSubqueue
     @batch << { update: basics }.to_json
     @batch << {
       doc: {
-        work: {
-          hits: obj.hit_count,
-          kudos_count: obj.kudos_count,
-          bookmarks_count: obj.bookmarks_count,
-          comments_count: obj.comments_count
-        }
+        hits: obj.hit_count,
+        kudos_count: obj.kudos_count,
+        bookmarks_count: obj.bookmarks_count,
+        comments_count: obj.comments_count
       }
     }.to_json
   end


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5281

## Purpose

Fixes the StatCounter indexing code in IndexSubqueue to avoid incorrect nesting.

## Testing

See bug report.