### PR TITLE
AO3-5277 Shrink "Show" button on collection Fandoms page

### DIFF
--- a/app/views/fandoms/index.html.erb
+++ b/app/views/fandoms/index.html.erb
@@ -1,19 +1,21 @@
 <!--SEARCHBROWSE Descriptive page name, messages and instructions-->
-<% if @collection %>
-  <h2 class="heading"><%= link_to(@collection.title, @collection) %> > <%= ts("Fandoms") %></h2>
-<% elsif @medium %>
-  <h2 class="heading"><%= link_to ts('Fandoms'), media_path %> > <%= @medium.name %></h2>
-<% else %>
-  <h2 class="heading"><%= link_to ts('Fandoms'), media_path %></h2>
-<% end %>
+<h2 class="heading">
+  <% if @collection %>
+    <%= link_to(@collection.title, @collection) %> > <%= ts("Fandoms") %>
+  <% elsif @medium %>
+    <%= link_to ts("Fandoms"), media_path %> > <%= @medium.name %>
+  <% else %>
+    <%= link_to ts("Fandoms"), media_path %>
+  <% end %>
+</h2>
 <p>You can search this page by pressing <kbd>ctrl F</kbd> / <kbd>cmd F</kbd> and typing in what you are looking for.</p>
 <% if @collection %>
-  <h3 class="landmark heading"><%= ts('Filters') %></h3>
+  <h3 class="landmark heading"><%= ts("Filters") %></h3>
   <%= form_tag "", method: :get, class: "filter", id: "media-filter" do %>
     <fieldset>
-      <p title="Choose media type">
-        <%= select_tag :medium_id, options_for_select(['All Media Types'] + @media.map{|m| m.name}, params[:medium_id]) %>
-        <%= submit_tag "Show" %>
+      <p title="<%=ts("Choose media type") %>">
+        <%= select_tag :medium_id, options_for_select(["All Media Types"] + @media.map{|m| m.name}, params[:medium_id]) %>
+        <%= submit_tag ts("Show") %>
       </p>
     </fieldset>
   <% end %>
@@ -22,19 +24,21 @@
 
 <!--main content-->
 <% if @fandoms_by_letter && !@fandoms_by_letter.empty? %>
-  <h3 class="landmark heading"><%= ts('Alphabet Navigation') %></h3>
+  <h3 class="landmark heading"><%= ts("Alphabet Navigation") %></h3>
   <ul class="alphabet actions" id="alphabet" role="navigation">
     <% for letter in @fandoms_by_letter.keys %>
       <li><%= link_to letter, "#letter-#{letter}" %></li>
     <% end %>
   </ul>
-  <h3 class="landmark heading"><%= ts('Alphabetised List of Fandoms') %></h3>
-  <ol class="alphabet fandom index group <%= 'collection' if @collection %>">
+  <h3 class="landmark heading"><%= ts("Alphabetised List of Fandoms") %></h3>
+  <ol class="alphabet fandom index group <%= "collection" if @collection %>">
     <% @fandoms_by_letter.each_pair do |letter, fandoms| %>
-      <li id='letter-<%= letter %>' class='letter listbox group'>
+      <li id="letter-<%= letter %>" class="letter listbox group">
         <h3 class="heading">
           <%= letter %>
-          <span class="action top" title="top"><%= link_to '&#8593;'.html_safe, "#alphabet" %></span>
+          <span class="action top" title="top">
+            <%= link_to "&#8593;".html_safe, "#alphabet" %>
+          </span>
         </h3>
         <ul class="tags index group">
           <% for fandom in fandoms %>
@@ -50,6 +54,6 @@
     <% end %>
   </ol>
 <% else %>
-  <h3 class="no_fandoms"><%= ts("No fandoms found") %></h3>
+  <h3 class="heading"><%= ts("No fandoms found") %></h3>
 <% end %>
 <!--/content-->

--- a/app/views/fandoms/index.html.erb
+++ b/app/views/fandoms/index.html.erb
@@ -8,13 +8,15 @@
 <% end %>
 <p>You can search this page by pressing <kbd>ctrl F</kbd> / <kbd>cmd F</kbd> and typing in what you are looking for.</p>
 <% if @collection %>
-  <div class="filters">
-    <h3 class="landmark heading"><%= ts('Filters') %></h3>
-    <%= form_tag '', :method => :get do %>
-      <fieldset><p title="Choose media type"><%= select_tag :medium_id, options_for_select(['All Media Types'] + @media.map{|m| m.name}, params[:medium_id]) %>
-      <%= submit_tag "Show" %></p></fieldset>
-    <% end %>
-  </div>
+  <h3 class="landmark heading"><%= ts('Filters') %></h3>
+  <%= form_tag "", method: :get, class: "filter", id: "media-filter" do %>
+    <fieldset>
+      <p title="Choose media type">
+        <%= select_tag :medium_id, options_for_select(['All Media Types'] + @media.map{|m| m.name}, params[:medium_id]) %>
+        <%= submit_tag "Show" %>
+      </p>
+    </fieldset>
+  <% end %>
 <% end %>
 <!--/descriptions-->
 


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5277

## Purpose

Changes the class name on the Fandoms page media selection form so it won't get the `.filters` styling the was making the "Show" button huge. Code- and design-wise, the form's really not what we consider a filter, but I still went with "filter" rather than "navigation" so I wouldn't feel weird not changing the heading right above it. :P 

## Testing

Refer to issue