### PR TITLE
AO3-5284 - Fix searching tags by type. [Old indexing code.]

### DIFF
--- a/app/models/tag_search.rb
+++ b/app/models/tag_search.rb
@@ -8,8 +8,18 @@ class TagSearch < Search
       query do
         boolean do
           must { string query_string, default_operator: "AND" } if query_string.present?
-          must { term '_type', options[:type].downcase } if options[:type].present?
           must { term :canonical, 'T' } if options[:canonical].present?
+
+          if options[:type].present?
+            # To support the tags indexed prior to IndexSubqueue, we want to
+            # find the type either in the tag_type field or the _type field:
+            should { term '_type', options[:type].downcase }
+            should { term :tag_type, options[:type].downcase }
+
+            # The tire gem doesn't natively support :minimum_should_match,
+            # but elasticsearch 0.90 does, so we hack it in.
+            @value[:minimum_should_match] = 1
+          end
         end
       end
     end


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5284

## Purpose

The purpose of this pull request is to modify the fields that are indexed for Tags to ensure that it's possible to search by type. Currently, the tags on the archive can be divided into three categories:

1. **Tags manually indexed with reindex_document, or indexed before the IndexSubqueue code was written.** These tags have their _type set to, e.g. "fandom" or "character," and since the search code currently only checks the _type field, these are the only tags that will be returned in the search.

2. **Tags indexed with the IndexSubqueue code.** These tags have their _type set to "tag" (meaning they won't be returned by the current search code) and the JSON documents that are sent to ES contain no fields relating to their type. In order to be searched by type, all of these tags would have to be reindexed.

3. **Tags indexed both ways.** They show up in the search results twice. One of the results should probably be deleted.

It's very difficult to delete tags when their _type is set to "fandom" or "character" because as soon as a tag is deleted, the type association disappears, and so the delayed IndexSubqueue code has no idea what to use as the _type to delete the tag from the index. So I've chosen to modify the code so that all newly-reindexed tags have the _type "tag," regardless of the method of indexing, and store the tag type (e.g. "Fandom" or "Character") in a field of the JSON called tag_type (modeled after the new indexing code).

This pull request also sets up the tag search so that it will return results with the proper type value in *either* the _type field or the tag_type field. That way, even if no reindexing is performed, all tags indexed the old way will still appear. But newly created/modified tags will start to show up in the search, and search will work for all tags if a full reindexing is performed. (Though there may still be duplicates unless all entries are deleted before the reindexing happens.)

## Testing

See bug report for testing steps.