### PR TITLE
AO3-5286 - Use ScheduledReindexJob in cucumber tests.

### DIFF
--- a/features/admins/admin_works.feature
+++ b/features/admins/admin_works.feature
@@ -29,11 +29,11 @@ Feature: Admin Actions for Works and Bookmarks
     When I am logged in as an admin
       And I view the work "ToS Violation"
       And I follow "Hide Work"
-      And the work indexes are updated
+      And all indexing jobs have been run
     Then I should see "Item has been hidden."
       And all emails have been delivered
     When I follow "Make Work Visible"
-      And the work indexes are updated
+      And all indexing jobs have been run
     Then I should see "Item is no longer hidden."
       And logged out users should see the unhidden work "ToS Violation" by "regular_user"
       And logged in users should see the unhidden work "ToS Violation" by "regular_user"
@@ -45,7 +45,7 @@ Feature: Admin Actions for Works and Bookmarks
     When I am logged in as an admin
       And I view the work "ToS Violation"
       And I follow "Delete Work"
-      And the work indexes are updated
+      And all indexing jobs have been run
     Then I should see "Item was successfully deleted."
       And 1 email should be delivered
       And the email should contain "deleted from the Archive by a site admin"
@@ -66,12 +66,12 @@ Feature: Admin Actions for Works and Bookmarks
     When I follow "Bookmark"
       And I fill in "bookmark_notes" with "Rude comment"
       And I press "Create"
-      And the bookmark indexes are updated
+      And all indexing jobs have been run
     Then I should see "Bookmark was successfully created"
     When I am logged in as an admin
       And I am on bad_user's bookmarks page
     When I follow "Hide Bookmark"
-      And the bookmark indexes are updated
+      And all indexing jobs have been run
     Then I should see "Item has been hidden."
     When I am logged in as "regular_user" with password "password1"
       And I am on bad_user's bookmarks page

--- a/features/bookmarks/bookmark_create.feature
+++ b/features/bookmarks/bookmark_create.feature
@@ -21,7 +21,7 @@ Scenario: Create a bookmark
       And I fill in "bookmark_tag_string" with "This is a tag, and another tag,"
       And I check "bookmark_rec"
       And I press "Create"
-      And the bookmark indexes are updated
+      And all indexing jobs have been run
     Then I should see "Bookmark was successfully created"
       And I should see "My Bookmarks"
     When I am logged in as "another_bookmark_user"
@@ -37,7 +37,7 @@ Scenario: Create a bookmark
     When I edit the bookmark for "Revenge of the Sith"
       And I check "bookmark_private"
       And I press "Edit"
-      And the bookmark indexes are updated
+      And all indexing jobs have been run
     Then I should see "Bookmark was successfully updated"
     When I go to the bookmarks page
     Then I should not see "I liked this story"
@@ -84,7 +84,7 @@ Scenario: Create a bookmark
     When I view the work "Publicky"
       And I follow "Bookmark"
       And I press "Create"
-      And the bookmark indexes are updated
+      And all indexing jobs have been run
     Then I should see "Bookmark was successfully created"
     When I log out
       And I go to the bookmarks page
@@ -123,7 +123,7 @@ Scenario: bookmark added to moderated collection has flash notice only when not 
     And I follow "Bookmark"
     And I fill in "bookmark_collection_names" with "five_pillars"
     And I press "Create"
-    And the bookmark indexes are updated
+    And all indexing jobs have been run
   Then I should see "Bookmark was successfully created"
     And I should see "The collection Five Pillars is currently moderated."
   When I go to bookmarker's bookmarks page
@@ -131,7 +131,7 @@ Scenario: bookmark added to moderated collection has flash notice only when not 
   When I log out
     And I am logged in as "moderator" with password "password"
     And I approve the first item in the collection "Five Pillars"
-    And the bookmark indexes are updated
+    And all indexing jobs have been run
     And I am logged in as "bookmarker" with password "password"
     And I go to bookmarker's bookmarks page
   Then I should not see "The collection Five Pillars is currently moderated."
@@ -155,7 +155,7 @@ Scenario: bookmarks added to moderated collections appear correctly
     And I follow "Bookmark"
     And I fill in "bookmark_collection_names" with "jbs_greatest"
     And I press "Create"
-    And the bookmark indexes are updated
+    And all indexing jobs have been run
   Then I should see "Bookmark was successfully created"
     And I should see "The collection JBs Greatest is currently moderated. Your bookmark must be approved by the collection maintainers before being listed there."
     # UPDATE the bookmark and add it to a second MODERATED collection and
@@ -163,13 +163,13 @@ Scenario: bookmarks added to moderated collections appear correctly
   When I follow "Edit"
     And I fill in "bookmark_collection_names" with "jbs_greatest,beds_and_brooms"
     And I press "Update"
-    And all search indexes are updated
+    And all indexing jobs have been run
   Then I should see "Bookmark was successfully updated."
     And I should see "to the moderated collection 'Bedknobs and Broomsticks'."
   When I follow "Edit"
     And I fill in "bookmark_collection_names" with "jbs_greatest,beds_and_brooms,death_by_demographics,murder_a_la_mode"
     And I press "Update"
-    And the bookmark indexes are updated
+    And all indexing jobs have been run
   Then I should see "You have submitted your bookmark to moderated collections (Death by Demographics, Murder a la Mode)."
   When I go to bookmarker's bookmarks page
     And I should see "The Murder of Sherlock Holmes"
@@ -199,7 +199,7 @@ Scenario: bookmarks added to moderated collections appear correctly
     And I follow "Edit Bookmark"
     And I fill in "bookmark_collection_names" with "jbs_greatest,beds_and_brooms,mrs_pots"
     And I press "Edit" within "div#bookmark-form"
-    And the bookmark indexes are updated
+    And all indexing jobs have been run
   Then I should see "Bookmark was successfully updated."
     And I should see "The collection JBs Greatest is currently moderated."
   When I go to bookmarker's bookmarks page
@@ -328,28 +328,28 @@ Scenario: Delete bookmarks of a work and a series
     And I view the work "A Mighty Duck"
     And I follow "Bookmark"
     And I press "Create"
-    And the bookmark indexes are updated
+    And all indexing jobs have been run
   Then I should see "Bookmark was successfully created."
     And I should see "Delete"
   When I follow "Delete"
     And I press "Yes, Delete Bookmark"
-    And the bookmark indexes are updated
+    And all indexing jobs have been run
   Then I should see "Bookmark was successfully deleted."
   When I view the series "The Funky Bunch"
     And I follow "Bookmark Series"
     And I press "Create"
-    And the bookmark indexes are updated
+    And all indexing jobs have been run
   Then I should see "Bookmark was successfully created."
   When I follow "Delete"
   And I press "Yes, Delete Bookmark"
-    And the bookmark indexes are updated
+    And all indexing jobs have been run
   Then I should see "Bookmark was successfully deleted."
   When I go to my bookmarks page
   Then I should see "A Mighty Duck2 the sequel"
   When I log out
     And I am logged in as "wahlly"
     And I delete the work "A Mighty Duck2 the sequel"
-    And the bookmark indexes are updated
+    And all indexing jobs have been run
   Then I should see "A Mighty Duck2 the sequel was deleted."
   When I log out
     And I am logged in as "markymark"
@@ -358,7 +358,7 @@ Scenario: Delete bookmarks of a work and a series
     And I follow "Edit"
     And I check "bookmark_private"
     And I press "Update"
-    And the bookmark indexes are updated
+    And all indexing jobs have been run
   Then I should see "Bookmark was successfully updated"
   When I follow "Delete"
     And I press "Yes, Delete Bookmark"

--- a/features/bookmarks/bookmark_external.feature
+++ b/features/bookmarks/bookmark_external.feature
@@ -42,7 +42,7 @@ Feature: Create bookmarks of external works
     Then I should see "Fandom tag is required"
     When I fill in "Fandoms" with "Popslash"
       And I press "Create"
-      And the bookmark indexes are updated
+      And all indexing jobs have been run
     Then I should see "This work isn't hosted on the Archive"
     When I go to first_bookmark_user's bookmarks page
     Then I should see "Stuck with You"
@@ -61,7 +61,7 @@ Feature: Create bookmarks of external works
     Then I should see "does not appear to be a valid URL"
     When I fill in "URL" with "http://example.org/200"
       And I press "Create"
-      And the bookmark indexes are updated
+      And all indexing jobs have been run
     Then I should see "This work isn't hosted on the Archive"
     When I go to first_bookmark_user's bookmarks page
     Then I should see "Stuck with You"

--- a/features/bookmarks/bookmark_privacy.feature
+++ b/features/bookmarks/bookmark_privacy.feature
@@ -31,7 +31,7 @@ Feature: Private bookmarks
       And I check "bookmark_rec"
       And I check "bookmark_private"
       And I press "Create"
-      And the bookmark indexes are updated
+      And all indexing jobs have been run
     Then I should see "Bookmark was successfully created"
       And I should not see the image "title" text "Restricted"
       And I should not see "Rec"
@@ -96,7 +96,7 @@ Feature: Private bookmarks
     When I am logged in as "otheruser"
       And I view the work "Public Masterpiece"
       And I rec the current work
-      And the bookmark indexes are updated
+      And all indexing jobs have been run
     When I log out
       And I go to the bookmarks page
     Then I should not see "Secret Masterpiece"

--- a/features/collections/collection_navigation.feature
+++ b/features/collections/collection_navigation.feature
@@ -25,7 +25,7 @@ Feature: Basic collection navigation
     And I fill in "Post to Collections / Challenges" with "my_collection"
     And I press "Preview"
     And I press "Post"
-    And all search indexes are updated
+    And all indexing jobs have been run
     And I follow "My Collection"
   When I follow "Profile"
   Then I should see "About My Collection (my_collection)"

--- a/features/gift_exchanges/challenge_yuletide.feature
+++ b/features/gift_exchanges/challenge_yuletide.feature
@@ -478,7 +478,7 @@ Feature: Collection
     And I should see "Anonymous"
     And 0 emails should be delivered
   When I press "Post"
-    And the work indexes are updated
+    And all indexing jobs have been run
   Then I should see "Work was successfully posted"
     And I should see "For myname"
     And I should see "Collections:"

--- a/features/importing/archivist.feature
+++ b/features/importing/archivist.feature
@@ -114,7 +114,7 @@ Feature: Archivist bulk imports
       | login | email                     |
       | ao3   | ao3testing@dreamwidth.org |
     When I import the work "http://ao3testing.dreamwidth.org/593.html"
-      And the work indexes are updated
+      And all indexing jobs have been run
     Then I should see import confirmation
       And I should see "ao3"
       And I should not see "[archived by archivist]"
@@ -127,14 +127,14 @@ Feature: Archivist bulk imports
     Given the user "creator" exists and is activated
     When I import the work "http://ao3testing.dreamwidth.org/593.html" by "creator" with email "not_creators_account_email@example.com"
       And the system processes jobs
-      And the work indexes are updated
+      And all indexing jobs have been run
     Then 1 email should be delivered to "not_creators_account_email@example.com"
     When I am logged in as "creator"
       # Use the URL because we get logged out if we follow the link in the email
       And I go to the claim page for "not_creators_account_email@example.com"
     Then I should see "Claim your works with your logged-in account."
     When I press "Add these works to my currently-logged-in account"
-      And the work indexes are updated
+      And all indexing jobs have been run
     Then I should see "Author Identities for creator"
       And I should see "We have added the stories imported under not_creators_account_email@example.com to your account."
     When I go to creator's works page

--- a/features/other_a/orphan_work.feature
+++ b/features/other_a/orphan_work.feature
@@ -28,7 +28,7 @@ Feature: Orphan work
     Then I should see "Read More About The Orphaning Process"
     When I choose "Take my pseud off as well"
       And I press "Yes, I'm sure"
-      And all search indexes are updated
+      And all indexing jobs have been run
     Then I should see "Orphaning was successful."
       And I should see "Bookmarks (0)"
     When I follow "Works (0)"
@@ -134,7 +134,7 @@ Feature: Orphan work
   When I follow "Orphan Works Instead"
   Then I should see "Orphaning a work removes it from your account and re-attaches it to the specially created orphan_account."
   When I press "Yes, I'm sure"
-    And the work indexes are updated
+    And all indexing jobs have been run
   Then I should see "Orphaning was successful."
   When I go to my works page
   Then I should not see "Glorious"

--- a/features/other_a/preferences_edit.feature
+++ b/features/other_a/preferences_edit.feature
@@ -151,7 +151,7 @@ Feature: Edit preferences
   Then I should see "Stargate SG-1"
     And I should see "Stargate SG-2"
     # we are now looking at a canonical fandom tag
-  When all search indexes are updated
+  When all indexing jobs have been run
     And I follow "Stargate SG-1"
   Then I should see "This work has warnings and tags"
     And I should see "This also has warnings and tags"

--- a/features/other_a/reading.feature
+++ b/features/other_a/reading.feature
@@ -17,7 +17,7 @@ Feature: Reading count
       also updates the date
     Given I am logged in as "writer"
       And I post the work "some work"
-      And the work indexes are updated
+      And all indexing jobs have been run
       And I am logged out
     When I am logged in as "fandomer"
       And fandomer first read "some work" on "2010-05-25"
@@ -47,7 +47,7 @@ Feature: Reading count
     When I follow "Preferences"
       And I uncheck "Turn on Viewing History"
       And I press "Update"
-      And the work indexes are updated
+      And all indexing jobs have been run
     Then I should not see "My History"
     When I am on writer's works page
       And I follow "some work"

--- a/features/other_b/series.feature
+++ b/features/other_b/series.feature
@@ -87,7 +87,7 @@ Feature: Create and Edit Series
     When "AO3-3455" is fixed
       # And I should see "Part 1 of the Black Beauty series" within "dd.series"
     When I press "Update"
-      And all search indexes are updated
+      And all indexing jobs have been run
     Then I should see "Part 1 of the Black Beauty series" within "dd.series"
       And I should see "Part 2 of the Ponies series" within "dd.series"
       And I should see "Part 1 of the Black Beauty series" within "div#series"

--- a/features/other_b/subscriptions_fandoms.feature
+++ b/features/other_b/subscriptions_fandoms.feature
@@ -66,7 +66,7 @@ Feature: Subscriptions
     And I fill in "Post to Collections / Challenges" with "hidden_treasury"
     And I check "F/F"
     And I press "Post Without Preview"
-    And all search indexes are updated
+    And all indexing jobs have been run
   Then I should see "Anonymous"
     And I should see "Collections: Hidden Treasury"
   When I am logged in as "author"

--- a/features/step_definitions/bookmark_steps.rb
+++ b/features/step_definitions/bookmark_steps.rb
@@ -9,7 +9,7 @@ Given /^I have a bookmark for "([^\"]*)"$/ do |title|
   step %{I start a new bookmark for "#{title}"}
   fill_in("bookmark_tag_string", with: DEFAULT_BOOKMARK_TAGS)
     step %{I press "Create"}
-    step %{the bookmark indexes are updated}
+    step %{all indexing jobs have been run}
 end
 
 Given /^I have a bookmark of a deleted work$/ do
@@ -19,7 +19,7 @@ Given /^I have a bookmark of a deleted work$/ do
   step %{I press "Create"}
   work = Work.find_by(title: title)
   work.destroy
-  step %{the bookmark indexes are updated}
+  step %{all indexing jobs have been run}
 end
 
 Given /^I have bookmarks to search$/ do
@@ -71,7 +71,7 @@ Given /^I have bookmarks to search$/ do
                      pseud_id: pseud2.id,
                      notes: "I enjoyed this")
 
-  step %{all search indexes are updated}
+  step %{all indexing jobs have been run}
 end
 
 Given /^I have bookmarks to search by dates$/ do
@@ -85,7 +85,7 @@ Given /^I have bookmarks to search by dates$/ do
   work2 = FactoryGirl.create(:posted_work, title: "New work")
   FactoryGirl.create(:bookmark, bookmarkable_id: work2.id, notes: "New bookmark of new work")
 
-  step %{all search indexes are updated}
+  step %{all indexing jobs have been run}
 end
 
 When /^I bookmark the work "([^\"]*)"(?: as "([^"]*)")?(?: with the note "([^"]*)")?$/ do |title, pseud, note|
@@ -93,7 +93,7 @@ When /^I bookmark the work "([^\"]*)"(?: as "([^"]*)")?(?: with the note "([^"]*
   select(pseud, from: "bookmark_pseud_id") unless pseud.nil?
   fill_in("bookmark_notes", with: note) unless note.nil?
   click_button("Create")
-  step %{the bookmark indexes are updated}
+  step %{all indexing jobs have been run}
 end
 
 When /^I start a new bookmark for "([^\"]*)"$/ do |title|
@@ -139,7 +139,7 @@ When /^I rec the current work$/ do
   click_link("Bookmark")
   check("bookmark_rec")
   click_button("Create")
-  step %{the bookmark indexes are updated}
+  step %{all indexing jobs have been run}
 end
 
 When(/^I attempt to create a bookmark of "([^"]*)" with a pseud that is not mine$/) do |work|

--- a/features/step_definitions/challenge_steps.rb
+++ b/features/step_definitions/challenge_steps.rb
@@ -179,7 +179,7 @@ When /^I reveal the authors of the "([^\"]*)" challenge$/ do |title|
     step %{I follow "Collection Settings"}
     step %{I uncheck "This collection is anonymous"}
     step %{I press "Update"}
-    step %{the work indexes are updated}
+    step %{all indexing jobs have been run}
 end
 
 # Notification messages

--- a/features/step_definitions/fixtures_steps.rb
+++ b/features/step_definitions/fixtures_steps.rb
@@ -3,7 +3,7 @@ Given /^I have loaded the fixtures$/ do
   fixtures_folder = File.join(Rails.root, 'features', 'fixtures')
   fixtures = Dir[File.join(fixtures_folder, '*.yml')].map {|f| File.basename(f, '.yml') }
   ActiveRecord::FixtureSet.create_fixtures(fixtures_folder, fixtures)
-  step %{all search indexes are updated}
+  step %{all search indexes are completely regenerated}
 end
 
 Given /^I have loaded the "([^\"]*)" fixture$/ do |fixture|

--- a/features/step_definitions/search_steps.rb
+++ b/features/step_definitions/search_steps.rb
@@ -1,30 +1,48 @@
 require "cucumber/rspec/doubles"
 
-Given /^the (\w+) indexes are updated$/ do |klass|
+Given /^the (\w+) indexes are completely regenerated$/ do |klass|
   es_update(klass)
+
   # ES UPGRADE TRANSITION #
   # Remove unless block
-  unless !elasticsearch_enabled?($elasticsearch)
+  unless $rollout.active?(:stop_old_indexing)
     tire_update(klass)
   end
 end
 
-
-Given /^all search indexes are updated$/ do
+Given /^all search indexes are completely regenerated$/ do
   ['work', 'bookmark', 'pseud', 'tag'].each do |klass|
-    step %{the #{klass} indexes are updated}
+    step %{the #{klass} indexes are completely regenerated}
   end
 end
 
-Given /^the (\w+) indexes are reindexed$/ do |model|
+Given /^the (\w+) indexes are refreshed$/ do |model|
   # ES UPGRADE TRANSITION #
   # Change $new_elasticsearch to $elasticsearch
   $new_elasticsearch.indices.refresh index: "ao3_test_#{model}s"
+
+  # ES UPGRADE TRANSITION #
+  # Remove unless block
+  unless $rollout.active?(:stop_old_indexing)
+    klass = model.capitalize.constantize
+    klass.tire.index.refresh
+  end
 end
 
-Given /^all search indexes are reindexed$/ do
+Given /^all search indexes are refreshed$/ do
   ['work', 'bookmark', 'pseud', 'tag'].each do |model|
-    step %{the #{model} indexes are reindexed}
+    step %{the #{model} indexes are refreshed}
+  end
+end
+
+Given /^the (\w+) indexing job has been run$/ do |reindex_type|
+  ScheduledReindexJob.perform(reindex_type)
+  step %{all search indexes are refreshed}
+end
+
+Given /^all indexing jobs have been run$/ do
+  %w(main background stats).each do |reindex_type|
+    step %{the #{reindex_type} indexing job has been run}
   end
 end
 

--- a/features/step_definitions/series_steps.rb
+++ b/features/step_definitions/series_steps.rb
@@ -44,7 +44,7 @@ When /^I add the work "([^\"]*)" to "(\d+)" series "([^\"]*)"$/ do |work_title, 
     visit preview_work_url(work)
     click_button("Post")
     step "I should see \"Work was successfully posted.\""
-    step %{the work indexes are updated}
+    step %{all indexing jobs have been run}
     Tag.write_redis_to_database
   end
 

--- a/features/step_definitions/tag_steps.rb
+++ b/features/step_definitions/tag_steps.rb
@@ -10,7 +10,7 @@ Given /^basic tags$/ do
   step %{the basic warnings exist}
   Fandom.where(name: "No Fandom", canonical: true).first_or_create
   step %{the basic categories exist}
-  step %{the tag indexes are updated}
+  step %{all indexing jobs have been run}
 end
 
 Given /^the default ratings exist$/ do

--- a/features/step_definitions/work_search_steps.rb
+++ b/features/step_definitions/work_search_steps.rb
@@ -36,7 +36,7 @@ Given /^a set of alternate universe works for searching$/ do
   # syn (AU)
   FactoryGirl.create(:posted_work, character_string: "AU Character")
 
-  step %{the work indexes are updated}
+  step %{all indexing jobs have been run}
 end
 
 Given /^a set of Steve Rogers works for searching$/ do
@@ -71,7 +71,7 @@ Given /^a set of Steve Rogers works for searching$/ do
   FactoryGirl.create(:posted_work,
                      summary: "Bucky thinks about his pal Steve Rogers.")
 
-  step %{the work indexes are updated}
+  step %{all indexing jobs have been run}
 end
 
 Given /^a set of Kirk\/Spock works for searching$/ do
@@ -93,7 +93,7 @@ Given /^a set of Kirk\/Spock works for searching$/ do
                      relationship_string: "Spirk",
                      category_string: "F/M")
 
-  step %{the work indexes are updated}
+  step %{all indexing jobs have been run}
 end
 
 Given /^a set of Spock\/Uhura works for searching$/ do
@@ -114,7 +114,7 @@ Given /^a set of Spock\/Uhura works for searching$/ do
                        relationship_string: relationship)
   end
 
-  step %{the work indexes are updated}
+  step %{all indexing jobs have been run}
 end
 
 Given /^a set of works with various categories for searching$/ do
@@ -128,7 +128,7 @@ Given /^a set of works with various categories for searching$/ do
   # Create one work using multiple categories
   FactoryGirl.create(:posted_work, category_string: "M/M, F/F")
 
-  step %{the work indexes are updated}
+  step %{all indexing jobs have been run}
 end
 
 Given /^a set of works with comments for searching$/ do
@@ -146,7 +146,7 @@ Given /^a set of works with comments for searching$/ do
   step %{the work "Work 7" with 10 comments setup}
 
   step %{the statistics_tasks rake task is run}
-  step %{the work indexes are updated}
+  step %{all indexing jobs have been run}
 end
 
 Given /^a set of Star Trek works for searching$/ do
@@ -183,7 +183,7 @@ Given /^a set of Star Trek works for searching$/ do
                      fandom_string: "Battlestar Galactica (2003)",
                      freeform_string: "Star Trek Fusion")
 
-  step %{the work indexes are updated}
+  step %{all indexing jobs have been run}
 end
 
 Given /^a set of works with bookmarks for searching$/ do
@@ -209,7 +209,7 @@ Given /^a set of works with bookmarks for searching$/ do
     ActionController::Base.new.expire_fragment("#{work.cache_key}/stats")
   end
 
-  step %{the work indexes are updated}
+  step %{all indexing jobs have been run}
 end
 
 Given /^a set of works with various ratings for searching$/ do
@@ -229,7 +229,7 @@ Given /^a set of works with various ratings for searching$/ do
                      rating_string: ArchiveConfig.RATING_DEFAULT_TAG_NAME,
                      summary: "Nothing explicit here.")
 
-  step %{the work indexes are updated}
+  step %{all indexing jobs have been run}
 end
 
 Given /^a set of works with various warnings for searching$/ do
@@ -253,7 +253,7 @@ Given /^a set of works with various warnings for searching$/ do
                      warning_string: "#{ArchiveConfig.WARNING_DEFAULT_TAG_NAME},
                                      #{ArchiveConfig.WARNING_NONE_TAG_NAME}")
 
-  step %{the work indexes are updated}
+  step %{all indexing jobs have been run}
 end
 
 Given /^a set of works with various access levels for searching$/ do
@@ -271,7 +271,7 @@ Given /^a set of works with various access levels for searching$/ do
                      hidden_by_admin: true,
                      title: "Work Hidden by Admin")
 
-  step %{the work indexes are updated}
+  step %{all indexing jobs have been run}
 end
 
 ### WHEN

--- a/features/step_definitions/work_steps.rb
+++ b/features/step_definitions/work_steps.rb
@@ -72,7 +72,7 @@ When /^I post (?:a|the) work "([^"]*)"(?: with fandom "([^"]*)")?(?: with charac
     step %{I set up the draft "#{title}" with fandom "#{fandom}" with character "#{character}" with second character "#{character2}" with freeform "#{freeform}" with second freeform "#{freeform2}" with category "#{category}" in collection "#{collection}" as a gift to "#{recipient}" as part of a series "#{series}" with relationship "#{relationship}" using the pseud "#{pseud}"}
     click_button("Post Without Preview")
   end
-  step %{the work indexes are updated}
+  step %{all indexing jobs have been run}
   Tag.write_redis_to_database
 end
 
@@ -101,7 +101,7 @@ Given(/^I have the Battle set loaded$/) do
   step %{I reveal the "Battle 12" challenge}
   step %{I am logged in as "myname4"}
   step %{the statistics_tasks rake task is run}
-  step %{the work indexes are updated}
+  step %{all indexing jobs have been run}
 end
 
 Given /^I have no works or comments$/ do
@@ -259,7 +259,7 @@ When /^I post the chaptered work "([^"]*)"$/ do |title|
   fill_in("content", with: "Another Chapter.")
   click_button("Preview")
   step %{I press "Post"}
-  step %{the work indexes are updated}
+  step %{all indexing jobs have been run}
   Tag.write_redis_to_database
 end
 
@@ -276,7 +276,7 @@ end
 When /^a chapter is added to "([^"]*)"$/ do |work_title|
   step %{a draft chapter is added to "#{work_title}"}
   click_button("Post")
-  step %{the work indexes are updated}
+  step %{all indexing jobs have been run}
   Tag.write_redis_to_database
 end
 
@@ -284,14 +284,14 @@ When /^a chapter with the co-author "([^\"]*)" is added to "([^\"]*)"$/ do |coau
   step %{a chapter is set up for "#{work_title}"}
   step %{I add the co-author "#{coauthor}"}
   click_button("Post")
-  step %{the work indexes are updated}
+  step %{all indexing jobs have been run}
   Tag.write_redis_to_database
 end
 
 When /^a draft chapter is added to "([^"]*)"$/ do |work_title|
   step %{a chapter is set up for "#{work_title}"}
   step %{I press "Preview"}
-  step %{the work indexes are updated}
+  step %{all indexing jobs have been run}
 
   Tag.write_redis_to_database
 end
@@ -317,7 +317,7 @@ end
 # meant to be used in conjunction with above step
 When /^I post the(?: draft)? chapter$/ do
   click_button("Post")
-  step %{the work indexes are updated}
+  step %{all indexing jobs have been run}
 
   Tag.write_redis_to_database
 end
@@ -404,7 +404,7 @@ When /^the work "([^"]*)" was created (\d+) days ago$/ do |title, number|
   step "the draft \"#{title}\""
   work = Work.find_by(title: title)
   work.update_attribute(:created_at, number.to_i.days.ago)
-  step %{the work indexes are updated}
+  step %{all indexing jobs have been run}
 
   Tag.write_redis_to_database
 end
@@ -417,7 +417,7 @@ When /^I post the locked work "([^"]*)"$/ do |title|
   end
   visit preview_work_url(work)
   click_button("Post")
-  step %{the work indexes are updated}
+  step %{all indexing jobs have been run}
 
   Tag.write_redis_to_database
 end
@@ -475,14 +475,14 @@ end
 When /^I browse the "([^"]+)" works$/ do |tagname|
   tag = Tag.find_by_name(tagname)
   visit tag_works_path(tag)
-  step %{the work indexes are updated}
+  step %{all indexing jobs have been run}
 
   Tag.write_redis_to_database
 end
 When /^I browse the "([^"]+)" works with an empty page parameter$/ do |tagname|
   tag = Tag.find_by_name(tagname)
   visit tag_works_path(tag, page: "")
-  step %{the work indexes are updated}
+  step %{all indexing jobs have been run}
 
   Tag.write_redis_to_database
 end
@@ -493,31 +493,31 @@ When /^I delete the work "([^"]*)"$/ do |work|
   step %{I follow "Delete Work"}
   # If JavaScript is enabled, window.confirm will be used and this button will not appear
   click_button("Yes, Delete Work") unless @javascript
-  step %{the work indexes are updated}
+  step %{all indexing jobs have been run}
 
   Tag.write_redis_to_database
 end
 When /^I preview the work$/ do
   click_button("Preview")
-  step %{the work indexes are updated}
+  step %{all indexing jobs have been run}
 
   Tag.write_redis_to_database
 end
 When /^I update the work$/ do
   click_button("Update")
-  step %{the work indexes are updated}
+  step %{all indexing jobs have been run}
 
   Tag.write_redis_to_database
 end
 When /^I post the work without preview$/ do
   click_button "Post Without Preview"
-  step %{the work indexes are updated}
+  step %{all indexing jobs have been run}
 
   Tag.write_redis_to_database
 end
 When /^I post the work$/ do
   click_button "Post"
-  step %{the work indexes are updated}
+  step %{all indexing jobs have been run}
 end
 When /^the statistics_tasks rake task is run$/ do
   StatCounter.hits_to_database
@@ -585,7 +585,7 @@ end
 
 When /^the statistics for the work "([^"]*)" are updated$/ do |title|
   step %{the statistics_tasks rake task is run}
-  step %{all search indexes are updated}
+  step %{all indexing jobs have been run}
   work = Work.find_by(title: title)
   # Touch the work to actually expire the cache
   work.touch

--- a/features/support/hooks.rb
+++ b/features/support/hooks.rb
@@ -9,8 +9,6 @@ Before do
   REDIS_ROLLOUT.flushall
   REDIS_AUTOCOMPLETE.flushall
 
-  step %{all search indexes are updated}
-
   # ES UPGRADE TRANSITION #
   # Remove rollout activation & unless block
   $rollout.activate :start_new_indexing
@@ -19,4 +17,6 @@ Before do
     $rollout.activate :stop_old_indexing
     $rollout.activate :use_new_search
   end
+
+  step %{all search indexes are completely regenerated}
 end

--- a/features/support/paths.rb
+++ b/features/support/paths.rb
@@ -11,16 +11,16 @@ module NavigationHelpers
     when /the home\s?page/
       '/'
     when /^the search bookmarks page$/i
-      step %{the bookmark indexes are updated}
+      step %{all indexing jobs have been run}
       search_bookmarks_path
     when /^the search tags page$/i
-      step %{the tag indexes are updated}
+      step %{all indexing jobs have been run}
       search_tags_path
     when /^the search works page$/i
-      step %{the work indexes are updated}
+      step %{all indexing jobs have been run}
       search_works_path
     when /^the search people page$/i
-      step %{the pseud indexes are updated}
+      step %{all indexing jobs have been run}
       search_people_path
     when /^the bookmarks page$/i
       bookmarks_path
@@ -66,10 +66,10 @@ module NavigationHelpers
     when /my preferences page/
       user_preferences_path(User.current_user)
     when /my bookmarks page/
-      step %{the bookmark indexes are updated}
+      step %{all indexing jobs have been run}
       user_bookmarks_path(User.current_user)
     when /my works page/
-      step %{the work indexes are updated}
+      step %{all indexing jobs have been run}
       user_works_path(User.current_user)
     when /my drafts page/
       drafts_user_works_path(User.current_user)
@@ -112,17 +112,17 @@ module NavigationHelpers
     when /^(.*?)(?:'s)? user url$/i
       user_url(id: $1).sub("http://www.example.com", "http://#{ArchiveConfig.APP_HOST}")
     when /^(.*?)(?:'s)? works page$/i
-      step %{the work indexes are updated}
+      step %{all indexing jobs have been run}
       user_works_path(user_id: $1)
     when /^the "(.*)" work page/
       work_path(Work.find_by(title: $1)).sub("http://www.example.com", "//")
     when /^the work page with title (.*)/
       work_path(Work.find_by(title: $1)).sub("http://www.example.com", "//")
     when /^the bookmarks page for user "(.*)" with pseud "(.*)"$/i
-      step %{the bookmark indexes are updated}
+      step %{all indexing jobs have been run}
       user_pseud_bookmarks_path(user_id: $1, pseud_id: $2)
     when /^(.*?)(?:'s)? bookmarks page$/i
-      step %{the bookmark indexes are updated}
+      step %{all indexing jobs have been run}
       user_bookmarks_path(user_id: $1)
     when /^(.*?)(?:'s)? pseuds page$/i
       user_pseuds_path(user_id: $1)
@@ -175,22 +175,22 @@ module NavigationHelpers
     when /^"(.*)" gift exchange matching page$/i
       collection_potential_matches_path(Collection.find_by(title: $1))
     when /^the works tagged "(.*)"$/i
-      step %{the work indexes are updated}
+      step %{all indexing jobs have been run}
       tag_works_path(Tag.find_by_name($1))
     when /^the bookmarks tagged "(.*)"$/i
-      step %{the bookmark indexes are updated}
+      step %{all indexing jobs have been run}
       tag_bookmarks_path(Tag.find_by_name($1))
     when /^the url for works tagged "(.*)"$/i
-      step %{the work indexes are updated}
+      step %{all indexing jobs have been run}
       tag_works_url(Tag.find_by_name($1)).sub("http://www.example.com", "http://#{ArchiveConfig.APP_HOST}")
     when /^the bookmarks in collection "(.*)"$/i
-      step %{the bookmark indexes are updated}
+      step %{all indexing jobs have been run}
       collection_bookmarks_path(Collection.find_by(title: $1))
     when /^the works tagged "(.*)" in collection "(.*)"$/i
-      step %{the work indexes are updated}
+      step %{all indexing jobs have been run}
       collection_tag_works_path(Collection.find_by(title: $2), Tag.find_by_name($1))
     when /^the url for works tagged "(.*)" in collection "(.*)"$/i
-      step %{the work indexes are updated}
+      step %{all indexing jobs have been run}
       collection_tag_works_url(Collection.find_by(title: $2), Tag.find_by_name($1)).sub("http://www.example.com", "http://#{ArchiveConfig.APP_HOST}")
     when /^the tag comments? page for "(.*)"$/i
       tag_comments_path(Tag.find_by_name($1))

--- a/features/tags_and_wrangling/tag_search.feature
+++ b/features/tags_and_wrangling/tag_search.feature
@@ -9,7 +9,7 @@ Feature: Search Tags
       And a fandom exists with name: "first fandom", canonical: false
       And a character exists with name: "first last", canonical: true
       And a relationship exists with name: "first last/someone else", canonical: false
-      And the tag indexes are updated
+      And all indexing jobs have been run
     When I am on the search tags page
       And I fill in "tag_search" with "first"
       And I press "Search tags"
@@ -42,7 +42,7 @@ Feature: Search Tags
     Scenario: Search for fandom with slash in name
       Given I have no tags
         And a fandom exists with name: "first/fandom", canonical: false
-        And the tag indexes are updated
+        And all indexing jobs have been run
       When I am on the search tags page
         And I fill in "tag_search" with "first"
         And I press "Search tags"
@@ -52,7 +52,7 @@ Feature: Search Tags
     Scenario: Search for fandom with period in name
       Given I have no tags
         And a fandom exists with name: "first.fandom", canonical: false
-        And the tag indexes are updated
+        And all indexing jobs have been run
       When I am on the search tags page
         And I fill in "tag_search" with "first.fandom"
         And I press "Search tags"

--- a/features/tags_and_wrangling/tag_wrangling_characters.feature
+++ b/features/tags_and_wrangling/tag_wrangling_characters.feature
@@ -35,7 +35,7 @@ Scenario: character wrangling - syns, mergers, characters, autocompletes
 
   # check those two created properly
   When I am on the search tags page
-    And the tag indexes are updated
+    And all indexing jobs have been run
     And I fill in "tag_search" with "Doctor"
     And I press "Search tags"
     # This part of the code is a hot mess. Capybara is returning the first instance of .canonical which contains

--- a/features/tags_and_wrangling/tag_wrangling_relationships.feature
+++ b/features/tags_and_wrangling/tag_wrangling_relationships.feature
@@ -198,7 +198,7 @@ Scenario: AO3-959 Non-canonical merger pairings
     And I press "Update"
   Then I should see "Work was successfully updated"
 
-  When the work indexes are updated
+  When all indexing jobs have been run
     And I go to Enigel's works page
   Then I should see "Testypants/Testyskirt"
      And I should see "Testing McTestypants/Testing McTestySkirt"

--- a/features/tags_and_wrangling/tag_wrangling_special.feature
+++ b/features/tags_and_wrangling/tag_wrangling_special.feature
@@ -113,7 +113,7 @@ Feature: Tag Wrangling - special cases
     And I press "Preview"
     And I press "Update"
   Then I should see "Work was successfully updated"
-    And all search indexes are updated
+    And all indexing jobs have been run
   When I view the tag "Evan ?"
     And I follow "filter works"
   Then I should see "1 Work in Evan ?"

--- a/features/users/user_dashboard.feature
+++ b/features/users/user_dashboard.feature
@@ -61,7 +61,7 @@ Feature: User dashboard
     And I should see "Work 5"
     And I should not see "Works (5)" within "#user-works"
   When I post the work "Newest Work"
-    And the work indexes are updated
+    And all indexing jobs have been run
     And I go to meatloaf's user page
   Then I should see "Newest Work"
     And I should not see "Oldest Work"

--- a/features/users/user_rename.feature
+++ b/features/users/user_rename.feature
@@ -120,7 +120,7 @@ Feature:
       And I fill in "New user name" with "newusername"
       And I fill in "Password" with "password"
       And I press "Change User Name"
-      And the work indexes are updated
+      And all indexing jobs have been run
     Then I should get confirmation that I changed my username
     When I am on the the works page
     Then I should see "newusername"

--- a/features/works/chapter_edit.feature
+++ b/features/works/chapter_edit.feature
@@ -98,7 +98,7 @@ Feature: Edit chapters
 
   # view chapters in the right order
   When I am logged out
-    And the work indexes are updated
+    And all indexing jobs have been run
     And I go to epicauthor's works page
     And I follow "New Epic Work"
     And I follow "Entire Work"

--- a/features/works/work_browse.feature
+++ b/features/works/work_browse.feature
@@ -6,6 +6,5 @@ Scenario: browsing works with incorrect page params in query string
   Given I am logged in as a random user
     And a fandom exists with name: "Johnny Be Good", canonical: true
     And I post the work "Whatever" with fandom "Johnny Be Good"
-    And the work indexes are updated
   When I browse the "Johnny Be Good" works with an empty page parameter
   Then I should see "1 Work"

--- a/features/works/work_dates_edit.feature
+++ b/features/works/work_dates_edit.feature
@@ -8,7 +8,7 @@ Feature: Edit Works Dates
     When "AO3-2539" is fixed
 #    Given I have loaded the fixtures
 #      And I am logged in as "testuser" with password "testuser"
-#      And all search indexes are updated
+#      And all indexing jobs have been run
 #    When I am on testuser's works page
 #    Then I should not see "less than 1 minute ago"
 #      And I should see "29 Apr 2012"

--- a/features/works/work_delete.feature
+++ b/features/works/work_delete.feature
@@ -153,7 +153,7 @@ Feature: Delete Works
       And I go to giftee's user page
     Then I should see "Gifts (1)"
     When I delete the work "All Something Breaks Loose"
-      And all search indexes are updated
+      And all indexing jobs have been run
     Then I should see "Your work All Something Breaks Loose was deleted."
     When I go to giftee's user page
     Then I should see "Gifts (0)"
@@ -163,7 +163,7 @@ Feature: Delete Works
     When I go to thorough's user page
     Then I should not see "All Something Breaks Loose"
     # This is correct behaviour - bookmark details are preserved even though the work is gone
-    Then all search indexes are updated
+    Then all indexing jobs have been run
     Then I go to the bookmarks page
     Then I should not see "All Something Breaks Loose"
     When I go to someone_else's bookmarks page

--- a/features/works/work_drafts.feature
+++ b/features/works/work_drafts.feature
@@ -57,7 +57,7 @@ Feature: Work Drafts
   Scenario: Drafts cannot be found by search
   Given I am logged in as "drafter" with password "something"
     And the draft "draft to post"
-  Given the work indexes are updated
+  Given all indexing jobs have been run
   When I fill in "site_search" with "draft"
     And I press "Search"
   Then I should see "No results found"

--- a/features/works/work_edit.feature
+++ b/features/works/work_edit.feature
@@ -10,7 +10,7 @@ Feature: Edit Works
     When I view the work "First work"
     Then I should not see "Edit"
     Given I am logged in as "testuser" with password "testuser"
-      And all search indexes are updated
+      And all indexing jobs have been run
     # This isn't my work
     When I view the work "fourth"
     Then I should not see "Edit"  
@@ -37,7 +37,7 @@ Feature: Edit Works
     Then I should see "Work was successfully updated."
       And I should see "Additional Tags: new tag"
       And I should see "Words:3"
-    When all search indexes are updated
+    When all indexing jobs have been run
       And I go to testuser's works page
     Then I should see "First work"
       And I should see "first fandom"

--- a/features/works/work_edit_multiple.feature
+++ b/features/works/work_edit_multiple.feature
@@ -21,7 +21,7 @@ Feature: Edit Multiple Works
     And I should not see "Lovely"
   When I press "Yes, Delete Works"
   Then I should see "Your works Glorious, Excellent were deleted."
-  When the work indexes are updated
+  When all indexing jobs have been run
     And I go to my works page
   Then I should not see "Glorious"
     And I should not see "Excellent"

--- a/features/works/work_lock.feature
+++ b/features/works/work_lock.feature
@@ -26,7 +26,7 @@ Scenario: Posting locked work
     When I go to the works tagged "Supernatural"
     Then I should see "Awesomeness" within "h4"
     And I should see the image "alt" text "(Restricted)" within "h4"
-    When the work indexes are updated
+    When all indexing jobs have been run
       And I fill in "site_search" with "Awesomeness"
       And I press "Search"
     Then I should see "1 Found"
@@ -52,7 +52,7 @@ Scenario: Posting locked work
 Scenario: Editing posted work
     Given I am logged in as "fandomer" with password "password"
       And I post the work "Sad generic work"
-      And the work indexes are updated
+      And all indexing jobs have been run
     When I am logged out
       And I go to fandomer's works page
     Then I should see "Sad generic work"

--- a/lib/searchable.rb
+++ b/lib/searchable.rb
@@ -15,9 +15,6 @@ module Searchable
   end
 
   def enqueue_to_index
-    if Rails.env.test?
-      reindex_document and return
-    end
     IndexQueue.enqueue(self, :main)
   end
 


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5286

## Purpose

This PR modifies the Searchable module so that it no longer automatically calls reindex_document in the test environment, and changes the cucumber tests to use the new "all indexing jobs have been run" step, which uses the ScheduledReindexJob object to more closely match the indexing behavior outside of the test environment.

## Testing

This basically only changes tests (plus a single line of code that only runs in the test environment), so no manual testing should be required.

## References

There are 11 automated test failures, as a result of [AO3-5281](https://otwarchive.atlassian.net/browse/AO3-5281) and [AO3-5284](https://otwarchive.atlassian.net/browse/AO3-5284). These can be fixed by merging in #3203 and #3205. I left them separate so that it's easier to see which changes belong to which pull request, but I can merge them if that would be preferable.