### PR TITLE
AO3-5278: Fix pseud search error when logged out

### DIFF
--- a/app/decorators/pseud_decorator.rb
+++ b/app/decorators/pseud_decorator.rb
@@ -37,7 +37,8 @@ class PseudDecorator < SimpleDelegator
   end
 
   def works_count
-    User.current_user.present? ? data[:general_works_count] : data[:public_works_count]
+    count = User.current_user.present? ? data[:general_works_count] : data[:public_works_count]
+    count || 0
   end
 
   def bookmarks_count

--- a/app/models/search/pseud_indexer.rb
+++ b/app/models/search/pseud_indexer.rb
@@ -51,7 +51,7 @@ class PseudIndexer < Indexer
       fandoms: fandoms(pseud),
       public_bookmarks_count: public_bookmarks_count(pseud),
       general_works_count: work_counts.values.sum,
-      public_works_count: work_counts[false]
+      public_works_count: work_counts[false] || 0
     }
   end
 

--- a/spec/models/pseud_decorator_spec.rb
+++ b/spec/models/pseud_decorator_spec.rb
@@ -43,6 +43,12 @@ describe PseudDecorator do
         User.current_user = User.new
         expect(@decorator.works_count).to eq(10)
       end
+      it "should return 0 if a count is nil" do
+        data = @search_results.first.dup
+        data["_source"]["public_works_count"] = nil
+        dec = PseudDecorator.decorate_from_search([@pseud], [data]).first
+        expect(dec.works_count).to eq(0)
+      end
     end
 
     describe "#bookmarks_count" do


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5278

## Purpose

Fixes 500 error when searching people, which happened because values were set to nil for users with no public works.

## Testing

See issue.