### PR TITLE
AO3-5289: Fix timezone feature failure

### DIFF
--- a/features/gift_exchanges/challenge_giftexchange.feature
+++ b/features/gift_exchanges/challenge_giftexchange.feature
@@ -52,11 +52,10 @@ Feature: Gift Exchange Challenge
     Given I am logged in as "mod1"
       And I have created the gift exchange "My Gift Exchange"
       And I am on "My Gift Exchange" gift exchange edit page
-    # Port Moresby does not do Daylight Saving Time - do not change this timezone or the test breaks at the end of DST
-    When I select "(GMT+10:00) Port Moresby" from "gift_exchange_time_zone"
+    When I select "(GMT-08:00) Pacific Time (US & Canada)" from "gift_exchange_time_zone"
     And I submit
       Then I should see "Challenge was successfully updated"
-      Then I should see "PGT"
+      Then I should see the correct time zone for "Pacific Time (US & Canada)"
 
   Scenario: Add a co-mod
     Given the following activated users exist

--- a/features/step_definitions/generic_steps.rb
+++ b/features/step_definitions/generic_steps.rb
@@ -242,3 +242,8 @@ end
 When /^I want to search for exactly one term$/ do
   Capybara.exact = true
 end
+
+When /^I should see the correct time zone for "(.*)"$/ do |zone|
+  Time.zone = zone
+  page.body.should =~ /#{Regexp.escape(Time.zone.now.zone)}/
+end


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5289

## Purpose

Fixes failing timezone test caused by CI operating system upgrades (https://unix.stackexchange.com/questions/359684/why-is-timezone-displayed-as-a-number)

## Testing

Only affects automated tests.