### PR TITLE
AO3-5292 - Ensure people search is updated when works are posted, and cover more types of work editing.

### DIFF
--- a/app/models/bookmark.rb
+++ b/app/models/bookmark.rb
@@ -111,7 +111,7 @@ class Bookmark < ApplicationRecord
   def update_pseud_index
     return unless $rollout.active?(:start_new_indexing)
     return unless destroyed? || saved_change_to_id? || saved_change_to_private?
-    AsyncIndexer.index(PseudIndexer, [pseud_id], :background)
+    IndexQueue.enqueue_id(Pseud, pseud_id, :background)
   end
 
   def visible?(current_user=User.current_user)

--- a/app/models/creatorship.rb
+++ b/app/models/creatorship.rb
@@ -3,6 +3,8 @@ class Creatorship < ApplicationRecord
   belongs_to :creation, polymorphic: true, touch: true
 
   before_destroy :expire_caches
+  after_create :update_pseud_index
+  after_destroy :update_pseud_index
 
   validate :unique_index
 
@@ -37,4 +39,9 @@ class Creatorship < ApplicationRecord
     end
   end
 
+  def update_pseud_index
+    return unless creation_type == 'Work'
+    return unless creation.respond_to?(:reindex_changed_pseud)
+    creation.reindex_changed_pseud(pseud_id)
+  end
 end

--- a/app/models/filter_tagging.rb
+++ b/app/models/filter_tagging.rb
@@ -10,6 +10,13 @@ class FilterTagging < ApplicationRecord
   validates_presence_of :filter, :filterable
 
   before_destroy :expire_caches
+  after_create :update_pseud_index
+  after_destroy :update_pseud_index
+
+  def update_pseud_index
+    return unless filter.is_a?(Fandom) && filterable.is_a?(Work)
+    IndexQueue.enqueue_ids(Pseud, filterable.pseud_ids, :background)
+  end
 
   def self.find(*args)
     raise "id is not guaranteed to be unique. please install composite_primary_keys gem and set the primary key to id,filter_id"

--- a/app/models/indexing/index_queue.rb
+++ b/app/models/indexing/index_queue.rb
@@ -25,6 +25,11 @@ class IndexQueue
     queue = self.new(key).add_id(id)
   end
 
+  def self.enqueue_ids(klass, ids, label)
+    key = get_key(klass, label)
+    queue = self.new(key).add_ids(ids)
+  end
+
   ####################
   # INSTANCE METHODS
   ####################
@@ -38,6 +43,10 @@ class IndexQueue
 
   def add_id(id)
     REDIS.sadd(name, id)
+  end
+
+  def add_ids(ids)
+    REDIS.sadd(name, ids) unless ids.blank?
   end
 
   def run

--- a/app/models/indexing/index_queue.rb
+++ b/app/models/indexing/index_queue.rb
@@ -22,12 +22,12 @@ class IndexQueue
 
   def self.enqueue_id(klass, id, label)
     key = get_key(klass, label)
-    queue = self.new(key).add_id(id)
+    new(key).add_id(id)
   end
 
   def self.enqueue_ids(klass, ids, label)
     key = get_key(klass, label)
-    queue = self.new(key).add_ids(ids)
+    new(key).add_ids(ids)
   end
 
   ####################

--- a/app/models/indexing/scheduled_reindex_job.rb
+++ b/app/models/indexing/scheduled_reindex_job.rb
@@ -5,7 +5,7 @@ class ScheduledReindexJob
               when 'main'
                 %w(Pseud Tag Work Bookmark Series ExternalWork)
               when 'background'
-                %w(Work Bookmark)
+                %w(Work Bookmark Pseud)
               when 'stats'
                 %w(StatCounter)
               end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -701,7 +701,7 @@ class Tag < ApplicationRecord
                 joins("JOIN filter_taggings ON filter_taggings.filterable_id = creatorships.creation_id").
                 where("filter_taggings.filter_id = ? AND filter_taggings.filterable_type = 'Work' AND creatorships.creation_type = 'Work'", id).
                 find_in_batches do |batch|
-      AsyncIndexer.index(PseudIndexer, batch.map(&:pseud_id).uniq, :background)
+      IndexQueue.enqueue_ids(Pseud, batch.map(&:pseud_id), :background)
     end
   end
 

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -270,7 +270,7 @@ class Work < ApplicationRecord
 
   def should_reindex_pseuds?
     pertinent_attributes = %w(id posted restricted in_anon_collection
-      in_unrevealed_collection hidden_by_admin)
+                              in_unrevealed_collection hidden_by_admin)
     destroyed? || (saved_changes.keys & pertinent_attributes).present?
   end
 

--- a/features/search/people_search.feature
+++ b/features/search/people_search.feature
@@ -2,12 +2,10 @@ Feature: Search pseuds
   As a user
   I want to use search to find other users
 
-  Background:
-    Given I have loaded the fixtures
-    And I am logged in as "testuser"
-    And testuser can use the new search
-
   Scenario: Search by name
+    Given I have loaded the fixtures
+      And I am logged in as "testuser"
+      And testuser can use the new search
     When I go to the search people page
       And I fill in "Name" with "testuser"
       And I press "Search People"
@@ -18,8 +16,100 @@ Feature: Search pseuds
       And I should not see "sad user"
 
   Scenario: Search by fandom
+    Given I have loaded the fixtures
+      And I am logged in as "testuser"
+      And testuser can use the new search
     When I go to the search people page
       And I fill in "Fandom" with "Ghost Soup"
       And I press "Search People"
     Then I should see "testuser2"
       And I should not see "testy"
+
+  Scenario: Search by fandom updates when a work is posted.
+    Given a canonical fandom "Ghost Soup"
+      And I am logged in as "testuser"
+      And testuser can use the new search
+    When I post a work "Drabble Collection" with fandom "Ghost Soup"
+      And all indexing jobs have been run
+      And I go to the search people page
+      And I fill in "Fandom" with "Ghost Soup"
+      And I press "Search People"
+    Then I should see "testuser" within "ol.pseud.group"
+
+  Scenario: Search by fandom updates when a fandom is added to a work.
+    Given a canonical fandom "Ghost Soup"
+      And I am logged in as "testuser"
+      And I post the work "Drabble Collection" with fandom "MCU"
+      And all indexing jobs have been run
+      And testuser can use the new search
+    When I edit the work "Drabble Collection"
+      And I fill in "Fandom" with "MCU, Ghost Soup"
+      And I press "Post Without Preview"
+      And all indexing jobs have been run
+      And I go to the search people page
+      And I fill in "Fandom" with "Ghost Soup"
+      And I press "Search People"
+    Then I should see "testuser" within "ol.pseud.group"
+
+  Scenario: Search by fandom updates when a fandom is removed from a work.
+    Given a canonical fandom "Ghost Soup"
+      And I am logged in as "testuser"
+      And I post the work "Drabble Collection" with fandom "MCU, Ghost Soup"
+      And all indexing jobs have been run
+      And testuser can use the new search
+    When I edit the work "Drabble Collection"
+      And I fill in "Fandom" with "MCU"
+      And I press "Post Without Preview"
+      And all indexing jobs have been run
+      And I go to the search people page
+      And I fill in "Fandom" with "Ghost Soup"
+      And I press "Search People"
+    Then I should not see "testuser" within "ol.pseud.group"
+
+  Scenario: Search by fandom updates when an author is added to a work.
+    Given a canonical fandom "Ghost Soup"
+      And I am logged in as "testuser"
+      And I post the work "Drabble Collection" with fandom "Ghost Soup"
+      And all indexing jobs have been run
+      And testuser can use the new search
+    When I edit the work "Drabble Collection"
+      And I add the co-author "alice"
+      And I press "Post Without Preview"
+      And all indexing jobs have been run
+      And I go to the search people page
+      And I fill in "Fandom" with "Ghost Soup"
+      And I press "Search People"
+    Then I should see "testuser" within "ol.pseud.group"
+      And I should see "alice" within "ol.pseud.group"
+
+  Scenario: Search by fandom updates when an author is removed from a work.
+    Given a canonical fandom "Ghost Soup"
+      And I am logged in as "testuser"
+      And I set up a draft "Drabble Collection" with fandom "Ghost Soup"
+      And I add the co-author "alice"
+      And I press "Post Without Preview"
+      And all indexing jobs have been run
+      And testuser can use the new search
+    When I edit the work "Drabble Collection"
+      And I follow "Remove Me As Author"
+      And all indexing jobs have been run
+      And I go to the search people page
+      And I fill in "Fandom" with "Ghost Soup"
+      And I press "Search People"
+    Then I should see "alice" within "ol.pseud.group"
+      But I should not see "testuser" within "ol.pseud.group"
+
+  Scenario: Search by fandom updates when a work is orphaned.
+    Given a canonical fandom "Ghost Soup"
+      And I have an orphan account
+      And I am logged in as "testuser"
+      And I post the work "Drabble Collection" with fandom "Ghost Soup"
+      And all indexing jobs have been run
+      And testuser can use the new search
+    When I orphan the work "Drabble Collection"
+      And all indexing jobs have been run
+      And I go to the search people page
+      And I fill in "Fandom" with "Ghost Soup"
+      And I press "Search People"
+    Then I should see "orphan_account" within "ol.pseud.group"
+      But I should not see "testuser" within "ol.pseud.group"


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5292

## Purpose

This pull request fixes the issue with `[pseuds.pluck(:id)]` in Work.update_pseud_index, and adds several more callbacks to ensure that the pseud indexes are updated whenever an author is added or removed, and whenever a filterable fandom is added or removed.

In order to avoid the duplicate work that might occur when more than one callback is triggered at a time (e.g. when someone simultaneously adds a co-author and a fandom, or simultaneously posts the work while adding a co-author), I also switched over to using IndexQueue for all of the pseud reindexing. That way, since the IndexQueue stores all of the IDs to be indexed as a REDIS set, any duplicate calls should be ignored.

## Testing

See the bug report for details.