### PR TITLE
AO3-5218 - Add successful_reindex callback.

### DIFF
--- a/app/models/search/async_indexer.rb
+++ b/app/models/search/async_indexer.rb
@@ -11,7 +11,7 @@ class AsyncIndexer
     indexer = name.split(":").first.constantize
     ids = REDIS.smembers(name)
     batch = indexer.new(ids).index_documents
-    IndexSweeper.new(batch, indexer).process_batch_failures
+    IndexSweeper.new(batch, indexer).process_batch
     REDIS.del(name)
   end
 

--- a/app/models/search/indexer.rb
+++ b/app/models/search/indexer.rb
@@ -108,6 +108,14 @@ class Indexer
     (INDEXERS_FOR_CLASS[name] || []).map(&:constantize)
   end
 
+  # Should be called after a batch update, with the IDs that were successfully
+  # updated. Calls successful_reindex on the indexable class.
+  def self.handle_success(ids)
+    if indexables.respond_to?(:successful_reindex)
+      indexables.successful_reindex(ids)
+    end
+  end
+
   ####################
   # INSTANCE METHODS
   ####################


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5218

## Purpose

Adds a callback to successful_reindex to the IndexSweeper, so that when the Works index is updated in Elasticsearch, the cache will be busted for each of the work's pseuds, collections, and filters.

I also renamed "process_batch_failures" to "process_batch," because it's processing successes in addition to failures now.

## Testing

This one's a bit hard to test since it's a caching issue, but hopefully there should be less of a delay before Works start showing up on various index pages.