### PR TITLE
AO3-5291 Prevent Browse > Bookmarks page from showing restricted bookmarks to logged-out users.

### DIFF
--- a/app/models/search/bookmark_query.rb
+++ b/app/models/search/bookmark_query.rb
@@ -274,13 +274,16 @@ class BookmarkQuery < Query
   end
 
   def include_private?
-    options[:show_private] ||
-      User.current_user && user_ids.include?(User.current_user.id)
+    # Use fetch instead of || here to make sure that we don't accidentally
+    # override a deliberate choice not to show private bookmarks.
+    options.fetch(:show_private,
+                  User.current_user && user_ids.include?(User.current_user.id))
   end
 
   def include_restricted?
-    options[:show_restricted] ||
-      User.current_user.present?
+    # Use fetch instead of || here to make sure that we don't accidentally
+    # override a deliberate choice not to show restricted bookmarks.
+    options.fetch(:show_restricted, User.current_user.present?)
   end
 
   def user_ids


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5291

## Purpose

The Browse > Bookmarks page can sometimes show restricted works as a result of caching.

When viewing the Browse > Bookmarks page with caching enabled, the BookmarksController sets :show_restricted to false. However, the definition of include_restricted? in the BookmarkQuery class will override the explicit :show_restricted value for logged-in users and logged-in admins. So the BookmarksController will put bookmarks of restricted works in the cache -- a cache that's shared with logged-out users.

This pull request fixes the definition of include_restricted? in the BookmarkQuery class so that if someone sets :show_restricted to false, the value won't be overridden.

(I don't think there's a way to have private bookmarks pop up on the Browse > Bookmarks page, but I also changed include_private? just in case this sort of issue comes up again in the future.)

## Testing

1. Add a bookmark of a restricted work.
2. Before logging out, view the Browse > Bookmarks page.
3. Verify that the bookmark doesn't appear.
4. Log out, and view the Browse > Bookmarks page again.
5. Verify that the bookmark doesn't appear.