### PR TITLE
AO3-5294 Fix cache key calculation for admins.

### DIFF
--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -113,7 +113,7 @@ class WorksController < ApplicationController
            (params[:page].blank? || params[:page].to_i <= ArchiveConfig.PAGES_TO_CACHE)
           # the subtag is for eg collections/COLL/tags/TAG
           subtag = @tag.present? && @tag != @owner ? @tag : nil
-          user = current_user.present? ? 'logged_in' : 'logged_out'
+          user = logged_in? || logged_in_as_admin? ? 'logged_in' : 'logged_out'
           @works = Rails.cache.fetch("#{@owner.works_index_cache_key(subtag)}_#{user}_page#{params[:page]}", expires_in: 20.minutes) do
             results = @search.search_results
             # calling this here to avoid frozen object errors


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5294

## Purpose

Within a controller, current_user always contains either a User item, or nil. (Note that this behaves differently from User.current_user, which can contain an Admin item, a User item, or nil.) So when an admin is logged in, current_user is nil.

Currently, the WorksController calculates the cache key by *only* checking current_user, so the cache key for admins is the same as the cache key for logged-out users. As a result, if an admin views a Works page before a logged-out user, the logged-out user may be able to see restricted works from the cache. And if a logged-out user views a Works page before an admin, the admin may not be able to see restricted works on that page.

## Testing

See the bug report for some testing steps.