### PR TITLE
AO3-5299 Rescue unparseable absolute date filters

### DIFF
--- a/spec/models/work_query_spec.rb
+++ b/spec/models/work_query_spec.rb
@@ -150,19 +150,35 @@ describe WorkQuery do
     expect(q.generated_query[:sort]).to eq({'comments_count' => { order: 'desc'}})
   end
 
-  it "should rescue absurd dates" do
+  it "rescues absurd relative dates" do
     q = WorkQuery.new(revised_at: "> 700000000 days")
     filter = q.range_filters.first
     date = filter.dig(:range, :revised_at, :lt)
     expect(date.year).to eq(1000.years.ago.year)
   end
 
-  it "should rescue absurd date ranges" do
+  it "rescues absurd relative date ranges" do
     q = WorkQuery.new(revised_at: "700000000-700000001 days ago")
     filter = q.range_filters.first
     start_date = filter.dig(:range, :revised_at, :gte)
     end_date = filter.dig(:range, :revised_at, :lte)
     expect(start_date.year).to eq(1000.years.ago.year)
     expect(end_date.year).to eq(1000.years.ago.year)
+  end
+
+  it "discards unparseable absolute date ranges" do
+    q = WorkQuery.new(date_from: "2017-12-32")
+    expect(q.date_range_filter).to be_nil
+    q = WorkQuery.new(date_to: "many moons ago")
+    expect(q.date_range_filter).to be_nil
+  end
+
+  it "clamps absolute date ranges so the year is between 0-9999" do
+    q = WorkQuery.new(date_from: "2017-12-31")
+    expect(q.date_range_filter.dig(:range, :revised_at, :gte)).to eq(Date.new(2017, 12, 31))
+
+    q = WorkQuery.new(date_from: "-2000-12-26", date_to: "20000-11-27")
+    expect(q.date_range_filter.dig(:range, :revised_at, :gte)).to eq(Date.new(0, 12, 26))
+    expect(q.date_range_filter.dig(:range, :revised_at, :lte)).to eq(Date.new(9999, 11, 27))
   end
 end


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5299

## Purpose

For the "Date Updated" filter, the front-end sends date strings that may be unparseable for Ruby (e.g. 2017-12-32) or Elasticsearch (10000-12-31). Avoid 500s in these cases.

## Testing

See JIRA.