### PR TITLE
AO3-5309 Remove bookmarkable suffix in IndexSweeper.

### DIFF
--- a/app/models/search/bookmarkable_indexer.rb
+++ b/app/models/search/bookmarkable_indexer.rb
@@ -12,6 +12,11 @@ class BookmarkableIndexer < Indexer
     BookmarkIndexer.mapping
   end
 
+  # When we fail, we don't want to just keep adding the -klass suffix.
+  def self.find_elasticsearch_ids(ids)
+    ids.map(&:to_i)
+  end
+
   def routing_info(id)
     {
       '_index' => index_name,

--- a/spec/models/async_indexer_spec.rb
+++ b/spec/models/async_indexer_spec.rb
@@ -64,9 +64,9 @@ describe AsyncIndexer do
     end
 
     it "should call the BookmarkedWorkIndexer three times with the same ID" do
-      expect(BookmarkedWorkIndexer).to receive(:new).with(["99999"])
-                                                    .exactly(3).times
-                                                    .and_call_original
+      expect(BookmarkedWorkIndexer).to receive(:new).with(["99999"]).
+        exactly(3).times.
+        and_call_original
       AsyncIndexer.index(BookmarkedWorkIndexer, [99_999], "main")
     end
 


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5309

## Purpose

This PR is intended to make the IndexSweeper's retries work properly with the three BookmarkableIndexer subclasses: BookmarkedWorkIndexer, BookmarkedSeriesIndexer, and BookmarkedExternalWorkIndexer.

Previously, each retry in IndexSweeper would append an extra suffix, resulting in incorrect failure handling. This pull request overrides BookmarkableIndexer.find_elasticsearch_ids to make sure that the suffix is stripped in indexSweeper before the ID is passed along to a BookmarkableIndexer and the suffix is re-added.

## Testing

This one is very difficult to test manually. I think you'd have to deliberately modify the code to produce an error, and then watch the failure stores. One way to consistently produce errors is to modify the line `@batch << document(object)` in Indexer.batch to read `@batch << document(object).merge("_id" => "asdf")`, since Elasticsearch doesn't like it when you try to embed the "_id" in your document.