### PR TITLE
AO3-5295: Never count a work with one fandom as a crossover

### DIFF
--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -1576,7 +1576,7 @@ class Work < ApplicationRecord
 
   # Does this work have only one relationship tag?
   def otp
-    filters.by_type('Relationship').first_class.count == 1
+    relationships.count == 1
   end
 
   # Quick and dirty categorization of the most obvious stuff

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -1571,7 +1571,7 @@ class Work < ApplicationRecord
   # A work with multiple fandoms which are not related
   # to one another can be considered a crossover
   def crossover
-    filters.by_type('Fandom').first_class.count > 1
+    fandoms.count > 1 && filters.by_type('Fandom').first_class.count > 1
   end
 
   # Does this work have only one relationship tag?


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5295

## Purpose

Tweaks crossover index logic so that a work with one fandom is never counted as a crossover, as that's proved to be technically possible via tag wrangling.

## Testing

See issue.