### PR TITLE
AO3-5311 Add user's rollout info to support tickets

### DIFF
--- a/app/controllers/feedbacks_controller.rb
+++ b/app/controllers/feedbacks_controller.rb
@@ -16,6 +16,9 @@ class FeedbacksController < ApplicationController
     @feedback = Feedback.new(feedback_params)
     language_name = Language.find_by(id: @feedback.language).name
     @feedback.language = language_name
+    @feedback.rollout = @feedback.rollout_string
+    @feedback.user_agent = request.env["HTTP_USER_AGENT"]
+    @feedback.ip_address = request.remote_ip
     if @feedback.save
       @feedback.email_and_send
       flash[:notice] = t("successfully_sent",
@@ -36,8 +39,7 @@ class FeedbacksController < ApplicationController
 
   def feedback_params
     params.require(:feedback).permit(
-      :comment, :email, :summary, :user_agent,
-      :ip_address, :username, :language, :rollout
+      :comment, :email, :summary, :username, :language
     )
   end
 

--- a/app/controllers/feedbacks_controller.rb
+++ b/app/controllers/feedbacks_controller.rb
@@ -37,7 +37,7 @@ class FeedbacksController < ApplicationController
   def feedback_params
     params.require(:feedback).permit(
       :comment, :email, :summary, :user_agent,
-      :ip_address, :username, :language
+      :ip_address, :username, :language, :rollout
     )
   end
 

--- a/app/mailers/admin_mailer.rb
+++ b/app/mailers/admin_mailer.rb
@@ -37,18 +37,11 @@ class AdminMailer < ActionMailer::Base
   end
 
   def feedback(feedback_id)
-    feedback = Feedback.find(feedback_id)
-    @summary = feedback.summary
-    @comment = feedback.comment
-    @username = feedback.username if feedback.username.present?
-    @email = feedback.email if feedback.email.present?
-    @language = feedback.language
-    @rollout = feedback.rollout if feedback.rollout.present?
-    @user_agent = feedback.user_agent if feedback.user_agent.present?
+    @feedback = Feedback.find(feedback_id)
     mail(
-      from: feedback.email.blank? ? ArchiveConfig.RETURN_ADDRESS : feedback.email,
+      from: @feedback.email.blank? ? ArchiveConfig.RETURN_ADDRESS : @feedback.email,
       to: ArchiveConfig.FEEDBACK_ADDRESS,
-      subject: "[#{ArchiveConfig.APP_SHORT_NAME}] Support - #{strip_html_breaks_simple(feedback.summary)}"
+      subject: "[#{ArchiveConfig.APP_SHORT_NAME}] Support - #{strip_html_breaks_simple(@feedback.summary)}"
     )
   end
   

--- a/app/mailers/admin_mailer.rb
+++ b/app/mailers/admin_mailer.rb
@@ -41,10 +41,10 @@ class AdminMailer < ActionMailer::Base
     @summary = feedback.summary
     @comment = feedback.comment
     @username = feedback.username if feedback.username.present?
-    @email = if feedback.email.present?
-               feedback.email
-             end
+    @email = feedback.email if feedback.email.present?
     @language = feedback.language
+    @rollout = feedback.rollout if feedback.rollout.present?
+    @user_agent = feedback.user_agent if feedback.user_agent.present?
     mail(
       from: feedback.email.blank? ? ArchiveConfig.RETURN_ADDRESS : feedback.email,
       to: ArchiveConfig.FEEDBACK_ADDRESS,

--- a/app/models/feedback.rb
+++ b/app/models/feedback.rb
@@ -55,7 +55,7 @@ class Feedback < ApplicationRecord
     string = ""
     # ES UPGRADE TRANSITION #
     # Remove ES version logic, but leave this method for future rollout use
-    string << if use_new_search?
+    string << if Feedback.use_new_search?
                 "ES 6.0"
               else
                 "ES 0.90"

--- a/app/models/feedback.rb
+++ b/app/models/feedback.rb
@@ -55,12 +55,11 @@ class Feedback < ApplicationRecord
     string = ""
     # ES UPGRADE TRANSITION #
     # Remove ES version logic, but leave this method for future rollout use
-    if $rollout.active?(:use_new_search) || User.current_user.present? && $rollout.active?(:use_new_search, User.current_user)
-      string << "ES 6.0"
-    else
-      string << "ES 0.90"
-    end
-    string
+    string << if $rollout.active?(:use_new_search) || User.current_user.present? && $rollout.active?(:use_new_search, User.current_user)
+                "ES 6.0"
+              else
+                "ES 0.90"
+              end
   end
 
   def send_report

--- a/app/models/feedback.rb
+++ b/app/models/feedback.rb
@@ -51,6 +51,18 @@ class Feedback < ApplicationRecord
     send_report
   end
 
+  def rollout_string
+    string = ""
+    # ES UPGRADE TRANSITION #
+    # Remove ES version logic, but leave this method for future rollout use
+    if $rollout.active?(:use_new_search) || User.current_user.present? && $rollout.active?(:use_new_search, User.current_user)
+      string << "ES 6.0"
+    else
+      string << "ES 0.90"
+    end
+    string
+  end
+
   def send_report
     return unless %w(staging production).include?(Rails.env)
     reporter = SupportReporter.new(
@@ -60,7 +72,8 @@ class Feedback < ApplicationRecord
       email: email,
       username: username,
       user_agent: user_agent,
-      site_revision: ArchiveConfig.REVISION.to_s
+      site_revision: ArchiveConfig.REVISION.to_s,
+      rollout: rollout
     )
     reporter.send_report!
   end

--- a/app/models/feedback.rb
+++ b/app/models/feedback.rb
@@ -55,7 +55,7 @@ class Feedback < ApplicationRecord
     string = ""
     # ES UPGRADE TRANSITION #
     # Remove ES version logic, but leave this method for future rollout use
-    string << if $rollout.active?(:use_new_search) || User.current_user.present? && $rollout.active?(:use_new_search, User.current_user)
+    string << if use_new_search?
                 "ES 6.0"
               else
                 "ES 0.90"

--- a/app/models/feedback_reporters/support_reporter.rb
+++ b/app/models/feedback_reporters/support_reporter.rb
@@ -1,6 +1,6 @@
 class SupportReporter < FeedbackReporter
   PROJECT_PATH = "authtoken=#{ArchiveConfig.SUPPORT_AUTH}&portal=ao3support&department=Support"
-  attr_accessor :user_agent, :site_revision
+  attr_accessor :user_agent, :site_revision, :rollout
 
   def template
     "feedbacks/report"

--- a/app/views/admin_mailer/feedback.html.erb
+++ b/app/views/admin_mailer/feedback.html.erb
@@ -20,8 +20,8 @@
 
 
   Feedback:
-  <p><b><%= (raw @feedback.summary) %></b></p>
-  <p><%= (raw @feedback.comment) %></p>
+  <b><%= (raw @feedback.summary) %></b>
+  <%= (raw @feedback.comment) %>
 
 <% end %>
 

--- a/app/views/admin_mailer/feedback.html.erb
+++ b/app/views/admin_mailer/feedback.html.erb
@@ -11,6 +11,12 @@
       Archive revision: (rev. <%= ArchiveConfig.REVISION %>)
     </p>
   <% end %>
+  <% unless @rollout.blank? %>
+    <p>Rollout: <%= raw @rollout %><p>
+  <% end %>
+  <% unless @user_agent.blank? %>
+    <p>User agent: <%= raw @user_agent %></p>
+  <% end %>
 
 
   Feedback:

--- a/app/views/admin_mailer/feedback.html.erb
+++ b/app/views/admin_mailer/feedback.html.erb
@@ -1,27 +1,27 @@
 <% content_for :message do %>
 
   <p><%= style_bold("Here's some user feedback on the Archive!") %></p>
-  <p>Username: <%= @username.present? ? (raw @username) : "Anonymous user" %></p>
-  <% unless @email.blank? %>
-    <p>Email address: <%= raw @email %></p>
+  <p>Username: <%= @feedback.username.present? ? (raw @feedback.username) : "Anonymous user" %></p>
+  <% unless @feedback.email.blank? %>
+    <p>Email address: <%= raw @feedback.email %></p>
   <% end %>
-  <p>Language: <%= @language %></p>
+  <p>Language: <%= @feedback.language %></p>
   <% unless ArchiveConfig.REVISION.blank? %>
     <p>
       Archive revision: (rev. <%= ArchiveConfig.REVISION %>)
     </p>
   <% end %>
-  <% unless @rollout.blank? %>
-    <p>Rollout: <%= raw @rollout %><p>
+  <% unless @feedback.rollout.blank? %>
+    <p>Rollout: <%= raw @feedback.rollout %><p>
   <% end %>
-  <% unless @user_agent.blank? %>
-    <p>User agent: <%= raw @user_agent %></p>
+  <% unless @feedback.user_agent.blank? %>
+    <p>User agent: <%= raw @feedback.user_agent %></p>
   <% end %>
 
 
   Feedback:
-  <p><b><%= (raw @summary) %></b></p>
-  <p><%= (raw @comment) %></p>
+  <p><b><%= (raw @feedback.summary) %></b></p>
+  <p><%= (raw @feedback.comment) %></p>
 
 <% end %>
 

--- a/app/views/admin_mailer/feedback.text.erb
+++ b/app/views/admin_mailer/feedback.text.erb
@@ -1,25 +1,25 @@
 <% content_for :message do %>
 Here's some user feedback on the Archive!
-  Username: <%= @username.present? ? (raw @username) : "Anonymous user" %>
-  <% unless @email.blank? %>
-    Email address: <%= raw @email %>
+  Username: <%= @feedback.username.present? ? (raw @feedback.username) : "Anonymous user" %>
+  <% unless @feedback.email.blank? %>
+    Email address: <%= raw @feedback.email %>
   <% end %>
-    Language: <%= @language %>
+    Language: <%= @feedback.language %>
   <% unless ArchiveConfig.REVISION.blank? %>
     Archive revision: (rev. <%= ArchiveConfig.REVISION %>)
   <% end %>
-  <% unless @rollout.blank? %>
-    Rollout: <%= raw @rollout %>
+  <% unless @feedback.rollout.blank? %>
+    Rollout: <%= raw @feedback.rollout %>
   <% end %>
-  <% unless @user_agent.blank? %>
-    User agent: <%= raw @user_agent %>
+  <% unless @feedback.user_agent.blank? %>
+    User agent: <%= raw @feedback.user_agent %>
   <% end %>
 
 Feedback: 
 <%= text_divider %>
 
-* <%= to_plain_text(raw @summary) %> *
-<%= to_plain_text(raw @comment) %>
+* <%= to_plain_text(raw @feedback.summary) %> *
+<%= to_plain_text(raw @feedback.comment) %>
 <% end %>
 
 <% content_for :sent_at do %><%= Time.now.to_s(:time_for_mailers) %><% end %>

--- a/app/views/admin_mailer/feedback.text.erb
+++ b/app/views/admin_mailer/feedback.text.erb
@@ -8,6 +8,12 @@ Here's some user feedback on the Archive!
   <% unless ArchiveConfig.REVISION.blank? %>
     Archive revision: (rev. <%= ArchiveConfig.REVISION %>)
   <% end %>
+  <% unless @rollout.blank? %>
+    Rollout: <%= raw @rollout %>
+  <% end %>
+  <% unless @user_agent.blank? %>
+    User agent: <%= raw @user_agent %>
+  <% end %>
 
 Feedback: 
 <%= text_divider %>

--- a/app/views/feedbacks/new.html.erb
+++ b/app/views/feedbacks/new.html.erb
@@ -72,9 +72,6 @@
 
   <fieldset>
     <legend><%= ts("Send Your Feedback") %></legend>
-    <%= f.hidden_field :user_agent, value: request.env["HTTP_USER_AGENT"] %>
-    <%= f.hidden_field :ip_address, value: request.remote_ip %>
-    <%= f.hidden_field :rollout, value: @feedback.rollout_string %>
     <p class="submit actions">
       <%= f.submit ts("Send"), data: { disable_with: ts("Please wait...") } %>
     </p>

--- a/app/views/feedbacks/new.html.erb
+++ b/app/views/feedbacks/new.html.erb
@@ -74,6 +74,7 @@
     <legend><%= ts("Send Your Feedback") %></legend>
     <%= f.hidden_field :user_agent, value: request.env["HTTP_USER_AGENT"] %>
     <%= f.hidden_field :ip_address, value: request.remote_ip %>
+    <%= f.hidden_field :rollout, value: @feedback.rollout_string %>
     <p class="submit actions">
       <%= f.submit ts("Send"), data: { disable_with: ts("Please wait...") } %>
     </p>

--- a/app/views/feedbacks/report.xml.erb
+++ b/app/views/feedbacks/report.xml.erb
@@ -7,5 +7,6 @@
     <fl val="Language"><%= cdata_section(@report.language.present? ? @report.language : "English") %></fl>
     <fl val="Archive Version"><%= cdata_section(@report.site_revision.present? ? @report.site_revision : "Unknown site revision") %></fl>
     <fl val="User Agent"><%= cdata_section(@report.user_agent.present? ? @report.user_agent : "Unknown user agent") %></fl>
+    <fl val="Rollout"><%= cdata_section(@report.rollout.present? ? @report.rollout : "Unknown") %></fl>
   </row>
 </requests>

--- a/db/migrate/20180108220405_add_rollout_to_feedbacks.rb
+++ b/db/migrate/20180108220405_add_rollout_to_feedbacks.rb
@@ -1,0 +1,5 @@
+class AddRolloutToFeedbacks < ActiveRecord::Migration[5.1]
+  def change
+    add_column :feedbacks, :rollout, :string
+  end
+end


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5311

## Purpose

Adds a method for passing rollout information to Support (it's kind of unnecessarily complex because we might use rollout for two features, even though we do not currently). Uses said method to pass Elasticsearch version info to both the ticket tracker and mailing list.

## Testing

Refer to Jira.
