### PR TITLE
AO3-5302 Only count bookmarks of visible items for people search

### DIFF
--- a/app/models/search/pseud_indexer.rb
+++ b/app/models/search/pseud_indexer.rb
@@ -75,7 +75,7 @@ class PseudIndexer < Indexer
   end
 
   def public_bookmarks_count(pseud)
-    pseud.bookmarks.where(private: false, hidden_by_admin: false).count
+    pseud.bookmarks.visible_to_all.count
   end
 
   def work_counts(pseud)


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5302

## Purpose

Previously, if a user had bookmarked an item (work, series, external work) was hidden by an admin, the bookmark total in the people search results would include that work. This uses the [visible_to_all scope](https://github.com/otwcode/otwarchive/blob/c39b474a079243c52a956511b64a72d0ba956f80/app/models/bookmark.rb#L57) to fix that.

## Testing

Refer to Jira