### PR TITLE
AO3-5265 Change tag search back to querystring and ensure exact results are near top

### DIFF
--- a/app/models/search/indexer.rb
+++ b/app/models/search/indexer.rb
@@ -44,7 +44,7 @@ class Indexer
           index: {
             number_of_shards: 5,
           }
-        },
+        }.merge(settings),
         mappings: mapping,
       }
     )
@@ -61,14 +61,24 @@ class Indexer
 
   def self.mapping
     {
-      document_type => {
+      document_type: {
         properties: {
-          #add properties in subclasses
+          # add properties in subclasses
         }
       }
     }
   end
 
+  def self.settings
+    {
+      analyzer: {
+        custom_analyzer: {
+          # add properties in subclasses
+        }
+      }
+    }
+  end
+  
   def self.index_all(options={})
     unless options[:skip_delete]
       delete_index

--- a/app/models/search/indexer.rb
+++ b/app/models/search/indexer.rb
@@ -36,13 +36,13 @@ class Indexer
     end
   end
 
-  def self.create_index
+  def self.create_index(shards = 5)
     $new_elasticsearch.indices.create(
       index: index_name,
       body: {
         settings: {
           index: {
-            number_of_shards: 5,
+            number_of_shards: shards,
           }
         }.merge(settings),
         mappings: mapping,

--- a/app/models/search/query.rb
+++ b/app/models/search/query.rb
@@ -53,10 +53,14 @@ class Query
   # Don't include empty conditions, since those will affect results
   def filtered_query
     filtered_query = {}
-    filtered_query[:filter] = filter_bool if filter_bool.present?
-    filtered_query[:must] = query_bool if query_bool.present?
-    if should_query.present?
-      filtered_query[:should] = should_query
+    filter = filter_bool
+    query = query_bool
+    should = should_query
+    
+    filtered_query[:filter] = filter if filter.present?
+    filtered_query[:must] = query if query.present?
+    if should.present?
+      filtered_query[:should] = should
       filtered_query[:minimum_should_match] = 1
     end
     filtered_query
@@ -74,7 +78,8 @@ class Query
 
   # Boolean query
   def query_bool
-    queries if !queries.blank?
+    q = queries
+    q unless q.blank?
   end
 
   # Should queries (used primarily for bookmarks)
@@ -127,13 +132,13 @@ class Query
 
   # Only escape if it isn't already escaped
   def escape_slashes(word)
-    word = word.gsub(/([^\\])\//) { |s| $1 + '\\/' }
+    word.gsub(/([^\\])\//) { |s| $1 + '\\/' }
   end
 
   def escape_reserved_characters(word)
     word = escape_slashes(word)
     word.gsub!('!', '\\!')
-    word.gsub!('+', '\\+')
+    word.gsub!('+', '\\\\+')
     word.gsub!('-', '\\-')
     word.gsub!('?', '\\?')
     word.gsub!("~", '\\~')

--- a/app/models/search/tag_indexer.rb
+++ b/app/models/search/tag_indexer.rb
@@ -10,10 +10,39 @@ class TagIndexer < Indexer
         properties: {
           name: {
             type: "text",
-            analyzer: "simple"
+            analyzer: "tag_name_analyzer",
+            fields: {
+              exact: {
+                type:     "text",
+                analyzer: "exact_tag_analyzer"
+              }
+            }
           },
           tag_type: {
             type: "keyword"
+          }
+        }
+      }
+    }
+  end
+
+  def self.settings
+    {
+      analysis: {
+        analyzer: {
+          tag_name_analyzer: {
+            type: "custom",
+            tokenizer: "standard",
+            filter: [
+              "lowercase"
+            ]
+          },
+          exact_tag_analyzer: {
+            type: "custom",
+            tokenizer: "keyword",
+            filter: [
+              "lowercase"
+            ]
           }
         }
       }

--- a/app/models/search/tag_query.rb
+++ b/app/models/search/tag_query.rb
@@ -39,12 +39,11 @@ class TagQuery < Query
   def name_query
     return unless options[:name]
     {
-      simple_query_string: {
+      query_string: {
         query: escape_reserved_characters(options[:name]),
-        fields: ["name"],
+        fields: ["name.exact^2", "name"],
         default_operator: "and"
       }
     }
   end
-
 end

--- a/spec/models/search/tag_query_spec.rb
+++ b/spec/models/search/tag_query_spec.rb
@@ -1,0 +1,45 @@
+require 'spec_helper'
+
+describe TagQuery, type: :model do
+
+  it "should do something" do
+    tag_query = TagQuery.new
+    tag_query.name_query.should be_nil
+  end
+
+    # Note that the simple query string syntax only supports * at the end of a term; putting one at the start or in the middle of a search term does not work.
+  it "searches for an exact match by default" do
+    # abc should not match abcd
+  end
+  
+  it "performs a wildcard search at the end of a term" do
+    # abc* should match abcde
+  end
+  
+  it "does NOT perform a wildcard search in the midd of a term" do
+    # ab*d should not match abcd
+  end
+  
+  it "does NOT perform a wildcard search at the beginning of a term" do
+    # *bcd should not match abcd
+  end
+  
+  it "should treat plus (+) as a literal character" do
+    # abc+ should match abc+
+    # abc+ should NOT match abcccc
+  end
+  
+  it "should treat minus (-) as a literal character" do
+    # ab-cd should match ab-cd
+    # ab -cd should match ab -cd
+    # ab -cd should NOT match ab (excluding cd)
+  end
+  
+  it "should ignore slashes without quotes" do
+    # a/b should match a b
+  end
+  
+  it "should match slashes when they're quoted" do
+    # 'a/b' should match a/b
+  end
+end

--- a/spec/models/search/tag_query_spec.rb
+++ b/spec/models/search/tag_query_spec.rb
@@ -14,7 +14,8 @@ describe TagQuery, type: :model do
       free_abapos: create(:freeform, name: "ab'c d"),
       rel_slash: create(:relationship, name: "ab/cd"),
       rel_space: create(:relationship, name: "ab cd"),
-      rel_quotes: create(:relationship, name: "ab \"cd\" ef")
+      rel_quotes: create(:relationship, name: "ab \"cd\" ef"),
+      rel_unicode: create(:relationship, name: "Dave ♦ Sawbuck")
     }
     update_and_refresh_indexes('tag', 1)
     tags
@@ -132,9 +133,21 @@ describe TagQuery, type: :model do
     results.should include(tags[:fan_yuri])
   end
 
-  it "matches tags without canonical punctuation ('yuri' on ice matches 'Yuri!!! On Ice')" do
+  it "matches tags without canonical punctuation ('yuri on ice' matches 'Yuri!!! On Ice')" do
     tag_query = TagQuery.new(name: "yuri on ice")
     results = tag_query.search_results
     results.should include(tags[:fan_yuri])
+  end
+
+  it "matches unicode tags with unicode character ('Dave ♦ Sawbuck' matches 'Dave ♦ Sawbuck')" do
+    tag_query = TagQuery.new(name: "dave ♦ sawbuck")
+    results = tag_query.search_results
+    results.should include(tags[:rel_unicode])
+  end
+
+  it "matches unicode tags without unicode character ('dave sawbuck' matches 'Dave ♦ Sawbuck')" do
+    tag_query = TagQuery.new(name: "dave sawbuck")
+    results = tag_query.search_results
+    results.should include(tags[:rel_unicode])
   end
 end

--- a/spec/models/search/tag_query_spec.rb
+++ b/spec/models/search/tag_query_spec.rb
@@ -3,127 +3,138 @@ require 'spec_helper'
 describe TagQuery, type: :model do
   let!(:tags) do
     tags = {
-      character: create(:character, name: "abc"),
-      character2: create(:character, name: "abc -d"),
-      character3: create(:character, name: "abc d"),
-      fandom: create(:fandom, name: "abcd"),
-      fandom2: create(:fandom, name: "abc-d"),
-      fandom3: create(:fandom, name: "Yuri!!! On Ice"),
-      freeform: create(:freeform, name: "abc+"),
-      freeform2: create(:freeform, name: "abccc"),
-      freeform3: create(:freeform, name: "ab'c d"),
-      relationship: create(:relationship, name: "ab/cd"),
-      relationship2: create(:relationship, name: "ab cd"),
-      relationship3: create(:relationship, name: "ab \"cd\" ef")
+      char_abc: create(:character, name: "abc"),
+      char_abc_d_minus: create(:character, name: "abc -d"),
+      char_abc_d: create(:character, name: "abc d"),
+      fan_abcd: create(:fandom, name: "abcd"),
+      fan_abc_d_minus: create(:fandom, name: "abc-d"),
+      fan_yuri: create(:fandom, name: "Yuri!!! On Ice"),
+      free_abcplus: create(:freeform, name: "abc+"),
+      free_abccc: create(:freeform, name: "abccc"),
+      free_abapos: create(:freeform, name: "ab'c d"),
+      rel_slash: create(:relationship, name: "ab/cd"),
+      rel_space: create(:relationship, name: "ab cd"),
+      rel_quotes: create(:relationship, name: "ab \"cd\" ef")
     }
-    update_and_refresh_indexes('tag')
+    update_and_refresh_indexes('tag', 1)
     tags
   end
 
   it "performs a case-insensitive search ('AbC' matches 'abc')" do
     tag_query = TagQuery.new(name: "AbC")
     results = tag_query.search_results
-    results.should include(tags[:character])
+    results.first.should eq(tags[:char_abc])
+    results.should include(tags[:free_abcplus])
   end
 
-  it "performs a query string search ('ab or cd' matches 'ab cd')" do
+  it "performs a query string search ('ab OR cd' matches 'ab cd', 'ab/cd' and 'ab “cd” ef')" do
     tag_query = TagQuery.new(name: "ab OR cd")
     results = tag_query.search_results
-    results.first.should be_in([tags[:relationship], tags[:relationship2]])
+    results.first.should eq(tags[:rel_slash])
+    results.should include(tags[:rel_space])
+    results.should include(tags[:rel_quotes])
+  end
+
+  it "performs an exact match with quotes ('xgh OR “abc d”' matches 'abc d')" do
+    tag_query = TagQuery.new(name: 'xgh OR "abc d"')
+    results = tag_query.search_results
+    results.first.should eq(tags[:char_abc_d])
+    results.should include(tags[:char_abc_d])
   end
   
-  it "lists closest matches at the top of the results ('abc' result lists 'abc' or 'abc+' first)" do
+  it "lists closest matches at the top of the results ('abc' result lists 'abc' first)" do
     tag_query = TagQuery.new(name: "abc")
     results = tag_query.search_results
-    results.first.should be_in([tags[:character], tags[:freeform]])
-    results.should include(tags[:character2])
-    results.should include(tags[:character3])
-    results.should include(tags[:fandom2])
+    results.first.should eq(tags[:char_abc])
+    results.should include(tags[:char_abc_d])
+    results.should include(tags[:free_abcplus])
+    results.should include(tags[:fan_abc_d_minus])
   end
   
   it "matches every token in any order ('d abc' matches 'abc d' and 'abc-d', but not 'abc' or 'abc+')" do
     tag_query = TagQuery.new(name: "d abc")
     results = tag_query.search_results
-    results.should include(tags[:character3])
-    results.should include(tags[:fandom2])
-    results.should_not include(tags[:freeform])
-    results.should_not include(tags[:character])
+    results.should include(tags[:char_abc_d])
+    results.should include(tags[:fan_abc_d_minus])
+    results.should_not include(tags[:free_abcplus])
+    results.should_not include(tags[:char_abc])
   end
 
   it "matches tokens with double quotes ('ab \"cd\" ef' matches 'ab \"cd\" ef')" do
     tag_query = TagQuery.new(name: "ab \"cd\" ef")
     results = tag_query.search_results
-    results.should include(tags[:relationship3])
+    results.should include(tags[:rel_quotes])
   end
 
   it "matches tokens with single quotes ('ab'c d' matches 'ab'c d')" do
     tag_query = TagQuery.new(name: "ab'c d")
     results = tag_query.search_results
-    results.should include(tags[:freeform3])
+    results.should include(tags[:free_abapos])
   end
   
   it "performs a wildcard search at the end of a term ('abc*' matches 'abcd' and 'abcde')" do
     tag_query = TagQuery.new(name: "abc*")
     results = tag_query.search_results
-    results.should include(tags[:character])
-    results.should include(tags[:fandom])
-    results.should include(tags[:freeform2])
+    results.should include(tags[:char_abc])
+    results.should include(tags[:fan_abcd])
+    results.should include(tags[:free_abccc])
     results.should_not include(tags[:relationship])
   end
   
   it "performs a wildcard search in the middle of a term ('a*d' matches 'abcd')" do
     tag_query = TagQuery.new(name: "a*d")
     results = tag_query.search_results
-    results.should include(tags[:fandom])
+    results.should include(tags[:fan_abcd])
   end
   
   it "performs a wildcard search at the beginning of a term ('*cd' matches 'abcd')" do
     tag_query = TagQuery.new(name: "*cd")
     results = tag_query.search_results
-    results.should include(tags[:fandom])
+    results.should include(tags[:fan_abcd])
   end
   
   it "preserves plus (+) character ('abc+' matches 'abc+' and 'abc', but not 'abccc')" do
     tag_query = TagQuery.new(name: "abc+")
     results = tag_query.search_results
-    results.should include(tags[:freeform])
-    results.should include(tags[:character])
-    results.should_not include(tags[:freeform2])
+    results.should include(tags[:free_abcplus])
+    results.should include(tags[:char_abc])
+    results.should_not include(tags[:free_abccc])
   end
   
   it "preserves minus (-) character ('abc-d' matches 'abc-d', 'abc -d', 'abc d' but not 'abc' or 'abcd')" do
     tag_query = TagQuery.new(name: "abc-d")
     results = tag_query.search_results
-    results.should include(tags[:fandom2])
-    results.should include(tags[:character3])
-    results.should_not include(tags[:fandom])
-    results.should_not include(tags[:character])
+    results.should include(tags[:fan_abc_d_minus])
+    results.should include(tags[:char_abc_d_minus])
+    results.should_not include(tags[:fan_abcd])
+    results.should_not include(tags[:char_abc])
   end
 
   it "preserves minus (-) preceded by a space ('abc -d' matches 'abc -d', 'abc d' and 'abc-d', but not 'abc')" do
     tag_query = TagQuery.new(name: "abc -d")
     results = tag_query.search_results
-    results.first.should be_in([tags[:character2], tags[:character3]])
-    results.should include(tags[:fandom2])
-    results.should_not include(tags[:character])
+    results.first.should eq(tags[:char_abc_d_minus])
+    results.should include(tags[:char_abc_d])
+    results.should include(tags[:fan_abc_d_minus])
+    results.should_not include(tags[:char_abc])
   end
   
   it "preserves slashes without quotes ('ab/cd' should match 'ab/cd' and 'ab cd')" do
     tag_query = TagQuery.new(name: "ab/cd")
     results = tag_query.search_results
-    results.should include(tags[:relationship])
-    results.should include(tags[:relationship2])
+    results.should include(tags[:rel_slash])
+    results.should include(tags[:rel_space])
   end
   
-  it "matches tags with canonical punctuation ('yuri!!!' on ice matches 'Yuri!!! On Ice'" do
+  it "matches tags with canonical punctuation ('yuri!!!' on ice matches 'Yuri!!! On Ice')" do
     tag_query = TagQuery.new(name: "yuri!!! on ice")
     results = tag_query.search_results
-    results.should include(tags[:fandom3])
+    results.should include(tags[:fan_yuri])
   end
 
-  it "matches tags without canonical punctuation ('yuri' on ice matches 'Yuri!!! On Ice'" do
+  it "matches tags without canonical punctuation ('yuri' on ice matches 'Yuri!!! On Ice')" do
     tag_query = TagQuery.new(name: "yuri on ice")
     results = tag_query.search_results
-    results.should include(tags[:fandom3])
+    results.should include(tags[:fan_yuri])
   end
 end

--- a/spec/models/search/tag_query_spec.rb
+++ b/spec/models/search/tag_query_spec.rb
@@ -11,73 +11,88 @@ describe TagQuery, type: :model do
       fandom3: create(:fandom, name: "Yuri!!! On Ice"),
       freeform: create(:freeform, name: "abc+"),
       freeform2: create(:freeform, name: "abccc"),
+      freeform3: create(:freeform, name: "ab'c d"),
       relationship: create(:relationship, name: "ab/cd"),
       relationship2: create(:relationship, name: "ab cd"),
+      relationship3: create(:relationship, name: "ab \"cd\" ef")
     }
     update_and_refresh_indexes('tag')
     tags
   end
 
-  it "performs a case-insensitive search (AbC matches abc)" do
-    tag_query = TagQuery.new({ name: "AbC" })
+  it "performs a case-insensitive search ('AbC' matches 'abc')" do
+    tag_query = TagQuery.new(name: "AbC")
     results = tag_query.search_results
     results.should include(tags[:character])
   end
 
-  it "performs a query string search (ab or cd matches ab cd)" do
-    tag_query = TagQuery.new({ name: "ab OR cd" })
+  it "performs a query string search ('ab or cd' matches 'ab cd')" do
+    tag_query = TagQuery.new(name: "ab OR cd")
     results = tag_query.search_results
     results.first.should be_in([tags[:relationship], tags[:relationship2]])
   end
   
-  it "lists exact matches (without punctuation) at the top of the results (abc result lists abc or abc+ first)" do
-    tag_query = TagQuery.new({ name: "abc" })
+  it "lists closest matches at the top of the results ('abc' result lists 'abc' or 'abc+' first)" do
+    tag_query = TagQuery.new(name: "abc")
     results = tag_query.search_results
-    results.first.should be_in([tags[:character], tags[:freeform]]) # abc+ is the same as abc for the indexer
+    results.first.should be_in([tags[:character], tags[:freeform]])
     results.should include(tags[:character2])
     results.should include(tags[:character3])
     results.should include(tags[:fandom2])
   end
   
-  it "matches every token (d abc matches abc d and abc-d, but not abc or abc+)" do
-    tag_query = TagQuery.new({ name: "d abc" })
+  it "matches every token in any order ('d abc' matches 'abc d' and 'abc-d', but not 'abc' or 'abc+')" do
+    tag_query = TagQuery.new(name: "d abc")
     results = tag_query.search_results
     results.should include(tags[:character3])
     results.should include(tags[:fandom2])
     results.should_not include(tags[:freeform])
     results.should_not include(tags[:character])
   end
-  
-  it "performs a wildcard search at the end of a term (abc* matches abcd and abcde)" do
-    tag_query = TagQuery.new({ name: "abc*" })
+
+  it "matches tokens with double quotes ('ab \"cd\" ef' matches 'ab \"cd\" ef')" do
+    tag_query = TagQuery.new(name: "ab \"cd\" ef")
     results = tag_query.search_results
+    results.should include(tags[:relationship3])
+  end
+
+  it "matches tokens with single quotes ('ab'c d' matches 'ab'c d')" do
+    tag_query = TagQuery.new(name: "ab'c d")
+    results = tag_query.search_results
+    results.should include(tags[:freeform3])
+  end
+  
+  it "performs a wildcard search at the end of a term ('abc*' matches 'abcd' and 'abcde')" do
+    tag_query = TagQuery.new(name: "abc*")
+    results = tag_query.search_results
+    results.should include(tags[:character])
     results.should include(tags[:fandom])
     results.should include(tags[:freeform2])
     results.should_not include(tags[:relationship])
   end
   
-  it "performs a wildcard search in the middle of a term (a*d matches abcd)" do
-    tag_query = TagQuery.new({ name: "a*d" })
+  it "performs a wildcard search in the middle of a term ('a*d' matches 'abcd')" do
+    tag_query = TagQuery.new(name: "a*d")
     results = tag_query.search_results
     results.should include(tags[:fandom])
   end
   
-  it "performs a wildcard search at the beginning of a term (*cd matches abcd)" do
-    tag_query = TagQuery.new({ name: "*cd" })
+  it "performs a wildcard search at the beginning of a term ('*cd' matches 'abcd')" do
+    tag_query = TagQuery.new(name: "*cd")
     results = tag_query.search_results
     results.should include(tags[:fandom])
   end
   
-  it "preserves plus (+) character (abc+ matches abc+ and abc, but not abccc)" do
-    tag_query = TagQuery.new({ name: "abc+" })
+  it "preserves plus (+) character ('abc+' matches 'abc+' and 'abc', but not 'abccc')" do
+    tag_query = TagQuery.new(name: "abc+")
     results = tag_query.search_results
     results.should include(tags[:freeform])
     results.should include(tags[:character])
     results.should_not include(tags[:freeform2])
   end
   
-  it "preserves minus (-) character (abc-d matches abc-d, abc -d, abc d but not abc or abcd)" do
-    tag_query = TagQuery.new({ name: "abc-d" })
+  it "preserves minus (-) character ('abc-d' matches 'abc-d', 'abc -d', 'abc d' but not 'abc' or 'abcd')" do
+    tag_query = TagQuery.new(name: "abc-d")
     results = tag_query.search_results
     results.should include(tags[:fandom2])
     results.should include(tags[:character3])
@@ -85,30 +100,29 @@ describe TagQuery, type: :model do
     results.should_not include(tags[:character])
   end
 
-  it "preserves minus (-) preceded by a space (abc -d matches abc -d, abc d and abc-d, but not abc)" do
-    tag_query = TagQuery.new({ name: "abc -d" })
+  it "preserves minus (-) preceded by a space ('abc -d' matches 'abc -d', 'abc d' and 'abc-d', but not 'abc')" do
+    tag_query = TagQuery.new(name: "abc -d")
     results = tag_query.search_results
-    results.first.should eq(tags[:character2])
+    results.first.should be_in([tags[:character2], tags[:character3]])
     results.should include(tags[:fandom2])
-    results.should include(tags[:character3])
     results.should_not include(tags[:character])
   end
   
-  it "preserves slashes without quotes (ab/cd should match ab/cd and ab cd)" do
-    tag_query = TagQuery.new({ name: "ab/cd" })
+  it "preserves slashes without quotes ('ab/cd' should match 'ab/cd' and 'ab cd')" do
+    tag_query = TagQuery.new(name: "ab/cd")
     results = tag_query.search_results
     results.should include(tags[:relationship])
     results.should include(tags[:relationship2])
   end
   
-  it "matches tags with canonical punctuation (yuri!!! on ice matches Yuri!!! On Ice" do
-    tag_query = TagQuery.new({ name: "yuri!!! on ice" })
+  it "matches tags with canonical punctuation ('yuri!!!' on ice matches 'Yuri!!! On Ice'" do
+    tag_query = TagQuery.new(name: "yuri!!! on ice")
     results = tag_query.search_results
     results.should include(tags[:fandom3])
   end
 
-  it "matches tags without canonical punctuation (yuri on ice matches Yuri!!! On Ice" do
-    tag_query = TagQuery.new({ name: "yuri on ice" })
+  it "matches tags without canonical punctuation ('yuri' on ice matches 'Yuri!!! On Ice'" do
+    tag_query = TagQuery.new(name: "yuri on ice")
     results = tag_query.search_results
     results.should include(tags[:fandom3])
   end

--- a/spec/models/search/tag_query_spec.rb
+++ b/spec/models/search/tag_query_spec.rb
@@ -1,45 +1,115 @@
 require 'spec_helper'
 
 describe TagQuery, type: :model do
-
-  it "should do something" do
-    tag_query = TagQuery.new
-    tag_query.name_query.should be_nil
+  let!(:tags) do
+    tags = {
+      character: create(:character, name: "abc"),
+      character2: create(:character, name: "abc -d"),
+      character3: create(:character, name: "abc d"),
+      fandom: create(:fandom, name: "abcd"),
+      fandom2: create(:fandom, name: "abc-d"),
+      fandom3: create(:fandom, name: "Yuri!!! On Ice"),
+      freeform: create(:freeform, name: "abc+"),
+      freeform2: create(:freeform, name: "abccc"),
+      relationship: create(:relationship, name: "ab/cd"),
+      relationship2: create(:relationship, name: "ab cd"),
+    }
+    update_and_refresh_indexes('tag')
+    tags
   end
 
-    # Note that the simple query string syntax only supports * at the end of a term; putting one at the start or in the middle of a search term does not work.
-  it "searches for an exact match by default" do
-    # abc should not match abcd
+  it "performs a case-insensitive search (AbC matches abc)" do
+    tag_query = TagQuery.new({ name: "AbC" })
+    results = tag_query.search_results
+    results.should include(tags[:character])
+  end
+
+  it "performs a query string search (ab or cd matches ab cd)" do
+    tag_query = TagQuery.new({ name: "ab OR cd" })
+    results = tag_query.search_results
+    results.first.should be_in([tags[:relationship], tags[:relationship2]])
   end
   
-  it "performs a wildcard search at the end of a term" do
-    # abc* should match abcde
+  it "lists exact matches (without punctuation) at the top of the results (abc result lists abc or abc+ first)" do
+    tag_query = TagQuery.new({ name: "abc" })
+    results = tag_query.search_results
+    results.first.should be_in([tags[:character], tags[:freeform]]) # abc+ is the same as abc for the indexer
+    results.should include(tags[:character2])
+    results.should include(tags[:character3])
+    results.should include(tags[:fandom2])
   end
   
-  it "does NOT perform a wildcard search in the midd of a term" do
-    # ab*d should not match abcd
+  it "matches every token (d abc matches abc d and abc-d, but not abc or abc+)" do
+    tag_query = TagQuery.new({ name: "d abc" })
+    results = tag_query.search_results
+    results.should include(tags[:character3])
+    results.should include(tags[:fandom2])
+    results.should_not include(tags[:freeform])
+    results.should_not include(tags[:character])
   end
   
-  it "does NOT perform a wildcard search at the beginning of a term" do
-    # *bcd should not match abcd
+  it "performs a wildcard search at the end of a term (abc* matches abcd and abcde)" do
+    tag_query = TagQuery.new({ name: "abc*" })
+    results = tag_query.search_results
+    results.should include(tags[:fandom])
+    results.should include(tags[:freeform2])
+    results.should_not include(tags[:relationship])
   end
   
-  it "should treat plus (+) as a literal character" do
-    # abc+ should match abc+
-    # abc+ should NOT match abcccc
+  it "performs a wildcard search in the middle of a term (a*d matches abcd)" do
+    tag_query = TagQuery.new({ name: "a*d" })
+    results = tag_query.search_results
+    results.should include(tags[:fandom])
   end
   
-  it "should treat minus (-) as a literal character" do
-    # ab-cd should match ab-cd
-    # ab -cd should match ab -cd
-    # ab -cd should NOT match ab (excluding cd)
+  it "performs a wildcard search at the beginning of a term (*cd matches abcd)" do
+    tag_query = TagQuery.new({ name: "*cd" })
+    results = tag_query.search_results
+    results.should include(tags[:fandom])
   end
   
-  it "should ignore slashes without quotes" do
-    # a/b should match a b
+  it "preserves plus (+) character (abc+ matches abc+ and abc, but not abccc)" do
+    tag_query = TagQuery.new({ name: "abc+" })
+    results = tag_query.search_results
+    results.should include(tags[:freeform])
+    results.should include(tags[:character])
+    results.should_not include(tags[:freeform2])
   end
   
-  it "should match slashes when they're quoted" do
-    # 'a/b' should match a/b
+  it "preserves minus (-) character (abc-d matches abc-d, abc -d, abc d but not abc or abcd)" do
+    tag_query = TagQuery.new({ name: "abc-d" })
+    results = tag_query.search_results
+    results.should include(tags[:fandom2])
+    results.should include(tags[:character3])
+    results.should_not include(tags[:fandom])
+    results.should_not include(tags[:character])
+  end
+
+  it "preserves minus (-) preceded by a space (abc -d matches abc -d, abc d and abc-d, but not abc)" do
+    tag_query = TagQuery.new({ name: "abc -d" })
+    results = tag_query.search_results
+    results.first.should eq(tags[:character2])
+    results.should include(tags[:fandom2])
+    results.should include(tags[:character3])
+    results.should_not include(tags[:character])
+  end
+  
+  it "preserves slashes without quotes (ab/cd should match ab/cd and ab cd)" do
+    tag_query = TagQuery.new({ name: "ab/cd" })
+    results = tag_query.search_results
+    results.should include(tags[:relationship])
+    results.should include(tags[:relationship2])
+  end
+  
+  it "matches tags with canonical punctuation (yuri!!! on ice matches Yuri!!! On Ice" do
+    tag_query = TagQuery.new({ name: "yuri!!! on ice" })
+    results = tag_query.search_results
+    results.should include(tags[:fandom3])
+  end
+
+  it "matches tags without canonical punctuation (yuri on ice matches Yuri!!! On Ice" do
+    tag_query = TagQuery.new({ name: "yuri on ice" })
+    results = tag_query.search_results
+    results.should include(tags[:fandom3])
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -133,7 +133,7 @@ end
 
 # ES UPGRADE TRANSITION #
 # Replace all instances of $new_elasticsearch with $elasticsearch
-def update_and_refresh_indexes(klass_name)
+def update_and_refresh_indexes(klass_name, shards = 5)
   # ES UPGRADE TRANSITION #
   # Remove block
   if elasticsearch_enabled?($elasticsearch)
@@ -148,7 +148,7 @@ def update_and_refresh_indexes(klass_name)
   indexer_class = "#{klass_name.capitalize.constantize}Indexer".constantize
 
   indexer_class.delete_index
-  indexer_class.create_index
+  indexer_class.create_index(shards)
 
   if klass_name == 'bookmark'
     bookmark_indexers = {


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5265

## Purpose

This PR amends the tag search and query code such that the following examples are true:

* performs a case-insensitive search (AbC matches abc)
* performs a query string search (ab or cd matches ab cd)
* lists exact matches (without punctuation) at the top of the results (abc result lists abc or abc+ first)
* matches every token (d abc matches abc d and abc-d, but not abc or abc+)
* performs a wildcard search at the end of a term (abc* matches abcd and abcde)
* performs a wildcard search in the middle of a term (a*d matches abcd)
* performs a wildcard search at the beginning of a term (*cd matches abcd)
* preserves plus (+) character (abc+ matches abc+ and abc, but not abccc)
* preserves minus (-) character (abc-d matches abc-d, abc -d, abc d but not abc or abcd)
* preserves minus (-) preceded by a space (abc -d matches abc -d, abc d and abc-d, but not abc)
* preserves slashes without quotes (ab/cd should match ab/cd and ab cd)
* matches tags with canonical punctuation (yuri!!! on ice matches Yuri!!! On Ice)
* matches tags without canonical punctuation (yuri on ice matches Yuri!!! On Ice)

## Testing

See above and on Jira ticket.