### PR TITLE
AO3-5303 People search bookmark count should respect bookmarkable privacy

### DIFF
--- a/app/decorators/pseud_decorator.rb
+++ b/app/decorators/pseud_decorator.rb
@@ -16,10 +16,11 @@ class PseudDecorator < SimpleDelegator
     work_counts
     bookmark_counts
     work_key = User.current_user.present? ? :general_works_count : :public_works_count
+    bookmark_key = User.current_user.present? ? :general_bookmarks_count : :public_bookmarks_count
     pseuds.map do |pseud|
       data = {
         user_login: users[user_id].login,
-        public_bookmarks_count: bookmark_counts[id],
+        bookmark_key => bookmark_counts[id],
         work_key => work_counts[id]
       }
       new_with_data(pseud, data)
@@ -42,7 +43,7 @@ class PseudDecorator < SimpleDelegator
   end
 
   def bookmarks_count
-    data[:public_bookmarks_count]
+    User.current_user.present? ? data[:general_bookmarks_count] : data[:public_bookmarks_count]
   end
 
   def byline

--- a/app/models/search/pseud_indexer.rb
+++ b/app/models/search/pseud_indexer.rb
@@ -75,7 +75,7 @@ class PseudIndexer < Indexer
   end
 
   def public_bookmarks_count(pseud)
-    pseud.bookmarks.where(private: false, hidden_by_admin: false).count
+    pseud.bookmarks.visible_to_all.count
   end
 
   def work_counts(pseud)

--- a/app/models/search/pseud_indexer.rb
+++ b/app/models/search/pseud_indexer.rb
@@ -49,6 +49,7 @@ class PseudIndexer < Indexer
     {
       sortable_name: pseud.name.downcase,
       fandoms: fandoms(pseud),
+      general_bookmarks_count: general_bookmarks_count(pseud),
       public_bookmarks_count: public_bookmarks_count(pseud),
       general_works_count: work_counts.values.sum,
       public_works_count: work_counts[false] || 0
@@ -72,6 +73,10 @@ class PseudIndexer < Indexer
                           name: tags.first.name,
                           count: tags.length }
                          }
+  end
+
+  def general_bookmarks_count(pseud)
+    pseud.bookmarks.visible_to_registered_user.count
   end
 
   def public_bookmarks_count(pseud)

--- a/spec/models/pseud_decorator_spec.rb
+++ b/spec/models/pseud_decorator_spec.rb
@@ -15,6 +15,7 @@ describe PseudDecorator do
         "collection_ids"=>[1],
         "sortable_name"=>@pseud.name.downcase,
         "fandoms"=>[{"id"=>13, "name"=>"Stargate SG-1", "count"=>7}],
+        "general_bookmarks_count"=>7,
         "public_bookmarks_count"=>5,
         "general_works_count"=>10,
         "public_works_count"=>7
@@ -52,8 +53,12 @@ describe PseudDecorator do
     end
 
     describe "#bookmarks_count" do
-      it "returns the public bookmarks count" do
+      it "returns the public count if there's no current user" do
         expect(@decorator.bookmarks_count).to eq(5)
+      end
+      it "returns the general count if there is a current user" do
+        User.current_user = User.new
+        expect(@decorator.bookmarks_count).to eq(7)
       end
     end
 


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5303

## Purpose

Currently, people search results are telling _everyone_, logged in or out, how many public bookmarks a user has of _both_ public and restricted items (works, series, external works). This makes it so logged out users see a total that only includes public bookmarks of public items, while logged in users continue to see a total that includes public bookmarks of both public and restricted items.

## Testing

Refer to Jira

## References

Builds off #3223 -- you could honestly just merge this and close that, as long as you update both issues.
