### PR TITLE
AO3-5318 Fix for blank bookmarkable_type.

### DIFF
--- a/app/models/search/bookmark_query.rb
+++ b/app/models/search/bookmark_query.rb
@@ -199,7 +199,7 @@ class BookmarkQuery < Query
   end
 
   def type_filter
-    term_filter(:bookmarkable_type, options[:bookmarkable_type].gsub(" ", "")) if options[:bookmarkable_type]
+    term_filter(:bookmarkable_type, options[:bookmarkable_type].gsub(" ", "")) if options[:bookmarkable_type].present?
   end
 
   def posted_filter


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5318

## Purpose

This PR changes the check in BookmarkQuery.type_filter to check whether the bookmarkable_type is present, instead of checking whether it's non-nil. This should make bookmark search work properly again.

## Testing

See bug report.