### PR TITLE
AO3-5304 Filter restricted works in people search by fandoms

### DIFF
--- a/app/decorators/pseud_decorator.rb
+++ b/app/decorators/pseud_decorator.rb
@@ -108,6 +108,7 @@ class PseudDecorator < SimpleDelegator
   end
 
   def fandom_stats(id)
-    data[:fandoms]&.detect { |fandom| fandom['id'].to_s == id.to_s }
+    key = User.current_user.present? ? "id" : "id_for_public"
+    data[:fandoms]&.detect { |fandom| fandom[key].to_s == id.to_s }
   end
 end

--- a/app/models/search/pseud_indexer.rb
+++ b/app/models/search/pseud_indexer.rb
@@ -65,14 +65,26 @@ class PseudIndexer < Indexer
   # Produces an array of hashes with the format
   # [{id: 1, name: "Star Trek", count: 5}]
   def tag_info(pseud, tag_type)
-    pseud.direct_filters.where(works: countable_works_conditions).
-                         by_type(tag_type).
-                         group_by(&:id).
-                         map{ |id, tags| {
-                          id: id,
-                          name: tags.first.name,
-                          count: tags.length }
-                         }
+    info = []
+    info += pseud.direct_filters.where(works: countable_works_conditions)
+                 .by_type(tag_type).group_by(&:id)
+                 .map do |id, tags|
+                   {
+                     id: id,
+                     name: tags.first.name,
+                     count: tags.length
+                   }
+                 end
+    info += pseud.direct_filters.where(works: countable_works_conditions.merge(restricted: false))
+                 .by_type(tag_type).group_by(&:id)
+                 .map do |id, tags|
+                   {
+                     id_for_public: id,
+                     name: tags.first.name,
+                     count: tags.length
+                   }
+                 end
+    info
   end
 
   def general_bookmarks_count(pseud)

--- a/app/models/search/pseud_query.rb
+++ b/app/models/search/pseud_query.rb
@@ -29,9 +29,10 @@ class PseudQuery < Query
   end
 
   def fandom_filter
+    key = User.current_user.present? ? "fandoms.id" : "fandoms.id_for_public"
     if options[:fandom_ids]
       options[:fandom_ids].map do |fandom_id|
-        { term: { "fandoms.id" => fandom_id } }
+        { term: { key => fandom_id } }
       end
     end
   end

--- a/spec/models/pseud_decorator_spec.rb
+++ b/spec/models/pseud_decorator_spec.rb
@@ -14,7 +14,10 @@ describe PseudDecorator do
         "byline"=>@pseud.byline,
         "collection_ids"=>[1],
         "sortable_name"=>@pseud.name.downcase,
-        "fandoms"=>[{"id"=>13, "name"=>"Stargate SG-1", "count"=>7}],
+        "fandoms" => [
+          { "id" => 13, "name" => "Stargate SG-1", "count" => 7 },
+          { "id_for_public" => 13, "name" => "Stargate SG-1", "count" => 2 }
+        ],
         "general_bookmarks_count"=>7,
         "public_bookmarks_count"=>5,
         "general_works_count"=>10,
@@ -111,8 +114,18 @@ describe PseudDecorator do
     end
 
     describe "#fandom_link" do
-      it "is an html link to the pseud works page with the fandom id" do
+      it "is an html link to the pseud works page with the fandom id, showing the public count" do
+        expect(@decorator.fandom_link(13)).to eq("<a href='/users/#{@pseud.user.to_param}/pseuds/#{@pseud.to_param}/works?fandom_id=13'>2 works in Stargate SG-1</a>")
+      end
+      it "is an html link to the pseud works page with the fandom id, showing the general count if there is a current user" do
+        User.current_user = User.new
         expect(@decorator.fandom_link(13)).to eq("<a href='/users/#{@pseud.user.to_param}/pseuds/#{@pseud.to_param}/works?fandom_id=13'>7 works in Stargate SG-1</a>")
+      end
+      it "returns nil if there are no public works" do
+        data = @search_results.first.dup
+        data["_source"]["fandoms"] = [{ "id" => 13, "name" => "Stargate SG-1", "count" => 7 }]
+        dec = PseudDecorator.decorate_from_search([@pseud], [data]).first
+        expect(dec.fandom_link(13)).to be_nil
       end
     end
 

--- a/spec/models/pseud_search_form_spec.rb
+++ b/spec/models/pseud_search_form_spec.rb
@@ -1,0 +1,57 @@
+require "spec_helper"
+
+describe PseudSearchForm do
+  let(:fandom_kp) { create(:fandom) }
+  let(:fandom_mlaatr) { create(:fandom) }
+
+  context "searching pseuds in a fandom" do
+    let!(:work_1) { create(:posted_work, fandoms: [fandom_kp]) }
+    let!(:work_2) { create(:posted_work, fandoms: [fandom_kp], restricted: true) }
+    let!(:work_3) { create(:posted_work, fandoms: [fandom_mlaatr]) }
+    let!(:work_4) { create(:posted_work, fandoms: [fandom_mlaatr], restricted: true) }
+
+    before { update_and_refresh_indexes "pseud" }
+
+    it "returns all pseuds writing in the fandom when logged in" do
+      User.current_user = User.new
+      results = PseudSearchForm.new(fandom: fandom_kp.name).search_results
+      expect(results).to include work_1.pseuds.first
+      expect(results).to include work_2.pseuds.first
+      expect(results).not_to include work_3.pseuds.first
+      expect(results).not_to include work_4.pseuds.first
+    end
+
+    it "returns pseuds writing public works in the fandom" do
+      results = PseudSearchForm.new(fandom: fandom_kp.name).search_results
+      expect(results).to include work_1.pseuds.first
+      expect(results).not_to include work_2.pseuds.first
+      expect(results).not_to include work_3.pseuds.first
+      expect(results).not_to include work_4.pseuds.first
+    end
+  end
+
+  context "searching pseuds in multiple fandoms" do
+    let(:user) { create(:user) }
+
+    let!(:work_1) { create(:posted_work, fandoms: [fandom_kp, fandom_mlaatr]) }
+    let!(:work_2) { create(:posted_work, fandoms: [fandom_kp], authors: [user.default_pseud]) }
+    let!(:work_3) { create(:posted_work, fandoms: [fandom_mlaatr], authors: [user.default_pseud], restricted: true) }
+
+    before { update_and_refresh_indexes "pseud" }
+
+    it "returns all pseuds writing in all fandoms" do
+      User.current_user = User.new
+      results = PseudSearchForm.new(fandom: "#{fandom_kp.name},#{fandom_mlaatr.name}").search_results
+      expect(results).to include work_1.pseuds.first
+      expect(results).to include user.default_pseud
+    end
+
+    it "returns pseuds writing public works in all fandoms" do
+      results = PseudSearchForm.new(fandom: "#{fandom_kp.name},#{fandom_mlaatr.name}").search_results
+      expect(results).to include work_1.pseuds.first
+      # This author posts in both fandoms, but their only work for fandom_mlaatr is restricted.
+      # To logged out users, this author does not post in both specified fandoms.
+      expect(results).not_to include user.default_pseud
+    end
+  end
+end


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5304

## Purpose

For logged out users:

- If a pseud has works in the specified fandom, but all of them are restricted, do not include the pseud in search results.
- Do not include the restricted works in the fandom-specific total.

## Testing

See JIRA issue.