### PR TITLE
AO3-5324 Re-allow hiding of series by admin

### DIFF
--- a/app/controllers/admin/user_creations_controller.rb
+++ b/app/controllers/admin/user_creations_controller.rb
@@ -31,17 +31,6 @@ class Admin::UserCreationsController < ApplicationController
     elsif @creation_class == ExternalWork || @creation_class == Bookmark
       redirect_to(request.env["HTTP_REFERER"] || root_path)
     else
-      unless action == "unhide" || @creation_class != Work
-        # Email users so they're aware of Abuse action
-        # Emails for works are handled in the work class
-        orphan_account = User.orphan_account
-        users = @creation.pseuds.map(&:user).uniq
-        users.each do |user|
-          unless user == orphan_account
-            UserMailer.admin_hidden_work_notification(@creation.id, user.id).deliver
-          end
-        end
-      end
       redirect_to(@creation)
     end
   end  

--- a/app/controllers/admin/user_creations_controller.rb
+++ b/app/controllers/admin/user_creations_controller.rb
@@ -5,7 +5,7 @@ class Admin::UserCreationsController < ApplicationController
   before_action :can_be_marked_as_spam, only: [:set_spam]
 
   def get_creation
-    raise "Redshirt: Attempted to constantize invalid class initialize #{params[:creation_type]}" unless %w(ExternalWork Bookmark Work).include?(params[:creation_type])
+    raise "Redshirt: Attempted to constantize invalid class initialize #{params[:creation_type]}" unless %w(Bookmark ExternalWork Series Work).include?(params[:creation_type])
     @creation_class = params[:creation_type].constantize
     @creation = @creation_class.find(params[:id])
   end

--- a/app/controllers/admin/user_creations_controller.rb
+++ b/app/controllers/admin/user_creations_controller.rb
@@ -31,7 +31,7 @@ class Admin::UserCreationsController < ApplicationController
     elsif @creation_class == ExternalWork || @creation_class == Bookmark
       redirect_to(request.env["HTTP_REFERER"] || root_path)
     else
-      unless action == "unhide" || @creation_class == Work
+      unless action == "unhide" || @creation_class != Work
         # Email users so they're aware of Abuse action
         # Emails for works are handled in the work class
         orphan_account = User.orphan_account

--- a/app/views/admin/_admin_options.html.erb
+++ b/app/views/admin/_admin_options.html.erb
@@ -1,10 +1,12 @@
 <!-- BEGIN admin options -->
 <div class="admin">
 
-  <% if item.class == ExternalWork %>
-    <% item_type_name = ts("External Work") %>
-  <% elsif item.class == Bookmark %>
+  <% if item.class == Bookmark %>
     <% item_type_name = ts("Bookmark") %>
+  <% elsif item.class == ExternalWork %>
+    <% item_type_name = ts("External Work") %>
+  <% elsif item.class == Series %>
+    <% item_type_name = ts("Series") %>
   <% else %>
     <% item_type_name = ts("Work") %>
   <% end %>

--- a/app/views/series/show.html.erb
+++ b/app/views/series/show.html.erb
@@ -4,6 +4,11 @@
 	<% if @series.restricted %>
 		<%= image_tag("lockblue.png", :size => "15x15", :alt => "(Restricted)", :title => "Restricted", skip_pipeline: true) %>
 	<% end %>
+  <% if series.hidden_by_admin %>
+    <%= image_tag("lockred.png", size: "15x15", alt: ts("(Hidden by Admin)"),
+                  title: ts("Hidden by Administrator"),
+                  skip_pipeline: true) %>
+  <% end %>
 </h2>
 <!--/descriptions-->
 
@@ -70,13 +75,13 @@
 
 <% if logged_in_as_admin? %>
 <!-- BEGIN admin options -->
-  <%= render :partial => 'admin/admin_options', :locals => {:item => @series} %>
+  <%= render "admin/admin_options", item: @series %>
 <% end %>
 
 <h3 class="landmark heading"><%= ts("Listing Series") %></h3>
 <ul class="series work index group">
   <% for serial in @serial_works %>
-    <%= render :partial => 'works/work_blurb', :locals => {:work => serial.work} %>
+    <%= render "works/work_blurb", work: serial.work %>
   <% end %>
 </ul>
 <!--/content-->

--- a/app/views/series/show.html.erb
+++ b/app/views/series/show.html.erb
@@ -4,7 +4,7 @@
 	<% if @series.restricted %>
 		<%= image_tag("lockblue.png", :size => "15x15", :alt => "(Restricted)", :title => "Restricted", skip_pipeline: true) %>
 	<% end %>
-  <% if series.hidden_by_admin %>
+  <% if @series.hidden_by_admin %>
     <%= image_tag("lockred.png", size: "15x15", alt: ts("(Hidden by Admin)"),
                   title: ts("Hidden by Administrator"),
                   skip_pipeline: true) %>

--- a/features/admins/admin_works.feature
+++ b/features/admins/admin_works.feature
@@ -1,7 +1,7 @@
 @admin
-Feature: Admin Actions for Works and Bookmarks
+Feature: Admin Actions for Works, Comments, Series, Bookmarks
   As an admin
-  I should be able to perform special actions on works
+  I should be able to perform special actions
 
   Scenario: Can reindex works
     Given I am logged in as "regular_user"
@@ -263,3 +263,60 @@ Feature: Admin Actions for Works and Bookmarks
     And I should see "Mark As Spam"
     And the work "Spammity Spam" should not be marked as spam
     And the work "Spammity Spam" should not be hidden
+
+  Scenario: Admin can hide a series (e.g. if the series description or notes contain a TOS Violation)
+    Given I am logged in as "tosser"
+      And I add the work "Legit Work" to series "Violation"
+    When I am logged in as an admin
+      And I view the series "Violation"
+      And I press "Hide Series"
+    Then I should see "Item has been hidden."
+      And I should see the image "title" text "Hidden by Administrator"
+      And I should see "Make Series Visible"
+    When I am logged out
+      And I go to tosser's series page
+    Then I should see "Series (0)"
+      And I should not see "Violation"
+    When I view the series "Violation"
+    Then I should see "Sorry, you don't have permission to access the page you were trying to reach."
+    When I am logged in as "other_user"
+      And I go to tosser's series page
+    Then I should see "Series (0)"
+      And I should not see "Violation"
+    When I view the series "Violation"
+    Then I should see "Sorry, you don't have permission to access the page you were trying to reach."
+    When I am logged in as "tosser"
+      And I go to tosser's series page
+    Then I should see "Series (0)"
+      And I should not see "Violation"
+    When I view the series "Violation"
+    Then I should see the image "title" text "Hidden by Administrator"
+
+  Scenario: Admin can un-hide a series
+    Given I am logged in as "tosser"
+      And I add the work "Legit Work" to series "Violation"
+      And I am logged in as an admin
+      And I view the series "Violation"
+      And I press "Hide Series"
+    When I press "Make Series Visible"
+    Then I should see "Item is no longer hidden."
+      And I should not see the image "title" text "Hidden by Administrator"
+      And I should see "Hide Series"
+    When I am logged out
+      And I go to tosser's series page
+    Then I should see "Series (1)"
+      And I should see "Violation"
+    When I view the series "Violation"
+    Then I should see "Violation"
+    When I am logged in as "other_user"
+      And I go to tosser's series page
+    Then I should see "Series (1)"
+      And I should see "Violation"
+    When I view the series "Violation"
+    Then I should see "Violation"
+    When I am logged in as "tosser"
+      And I go to tosser's series page
+    Then I should see "Series (1)"
+      And I should see "Violation"
+    When I view the series "Violation"
+    Then I should see "Violation"

--- a/features/admins/admin_works.feature
+++ b/features/admins/admin_works.feature
@@ -269,7 +269,7 @@ Feature: Admin Actions for Works, Comments, Series, Bookmarks
       And I add the work "Legit Work" to series "Violation"
     When I am logged in as an admin
       And I view the series "Violation"
-      And I press "Hide Series"
+      And I follow "Hide Series"
     Then I should see "Item has been hidden."
       And I should see the image "title" text "Hidden by Administrator"
       And I should see "Make Series Visible"
@@ -297,8 +297,8 @@ Feature: Admin Actions for Works, Comments, Series, Bookmarks
       And I add the work "Legit Work" to series "Violation"
       And I am logged in as an admin
       And I view the series "Violation"
-      And I press "Hide Series"
-    When I press "Make Series Visible"
+      And I follow "Hide Series"
+    When I follow "Make Series Visible"
     Then I should see "Item is no longer hidden."
       And I should not see the image "title" text "Hidden by Administrator"
       And I should see "Hide Series"


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5324

## Purpose

- Adds Series to the whitelist to prevent the 500 error that was stopping us from hiding them
- Makes it so the button to hide a series correctly says Hide Series (instead of Hide Work)
- Add a red lock to the series show page to make it clearer to the admin and the series owners that the series has been hidden

## Testing

Log in as an admin, press the "Hide Series" button on a series, and confirm that a success message and a red lock icon appear. Use the "Make Series Visible" icon and confirm that a success message appears and the red lock icon goes away.