### PR TITLE
AO3-5225 Fix include_private? when pseud_ids are specified.

### DIFF
--- a/app/models/search/bookmark_query.rb
+++ b/app/models/search/bookmark_query.rb
@@ -277,7 +277,8 @@ class BookmarkQuery < Query
     # Use fetch instead of || here to make sure that we don't accidentally
     # override a deliberate choice not to show private bookmarks.
     options.fetch(:show_private,
-                  User.current_user && user_ids.include?(User.current_user.id))
+                  User.current_user.is_a?(User) &&
+                  user_ids.include?(User.current_user.id))
   end
 
   def include_restricted?
@@ -292,7 +293,7 @@ class BookmarkQuery < Query
       user_ids += options[:user_ids].map(&:to_i)
     end
     if options[:pseud_ids].present?
-      user_ids += Pseud.where(id: options[:pseud_id]).pluck(:user_id)
+      user_ids += Pseud.where(id: options[:pseud_ids]).pluck(:user_id)
     end
     user_ids
   end


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5225

## Purpose

The bookmark count in the sidebar of pseud pages is broken, because the `BookmarkQuery.user_ids` function checks for the existence of `options[:pseud_ids]`, then uses `options[:pseud_id]` instead. This pull request fixes the typo (and fixes another issue that I noticed, where an admin could potentially be mistaken for the user with the same ID).

## Testing

Log in as someone with multiple pseuds and at least one private bookmark, and check whether the private bookmark is included in the sidebar count for the pseud with the bookmark.