### PR TITLE
AO3-5190 Abuse and support form language on error

### DIFF
--- a/app/controllers/feedbacks_controller.rb
+++ b/app/controllers/feedbacks_controller.rb
@@ -14,8 +14,6 @@ class FeedbacksController < ApplicationController
 
   def create
     @feedback = Feedback.new(feedback_params)
-    language_name = Language.find_by(id: @feedback.language).name
-    @feedback.language = language_name
     @feedback.rollout = @feedback.rollout_string
     @feedback.user_agent = request.env["HTTP_USER_AGENT"]
     @feedback.ip_address = request.remote_ip

--- a/app/views/abuse_reports/new.html.erb
+++ b/app/views/abuse_reports/new.html.erb
@@ -48,7 +48,7 @@
         <%= f.label :language, ts("Select language (required)") %>
       </dt>
       <dd class="required">
-        <%= f.collection_select(:language, @abuse_languages, :name, :name, { selected: Language.default.name }) %>
+        <%= f.collection_select(:language, @abuse_languages, :name, :name, { selected: @abuse_report.language || Language.default.name }) %>
       </dd>
       <dt class="required">
         <%= f.label :summary, ts("Brief summary of Terms of Service Violation (required)") %>

--- a/app/views/feedbacks/new.html.erb
+++ b/app/views/feedbacks/new.html.erb
@@ -45,7 +45,7 @@
         <%= f.label :language, ts("Select language (required)") %>
       </dt>
       <dd class="required">
-        <%= f.collection_select(:language, @support_languages, :id, :name, { selected: Language.default.id }) %>
+        <%= f.collection_select(:language, @support_languages, :name, :name, { selected: @feedback.language || Language.default.name }) %>
       </dd>
       <dt class="required">
         <%= f.label :summary, ts("Brief summary (required)") %>

--- a/features/other_a/abuse_report.feature
+++ b/features/other_a/abuse_report.feature
@@ -56,7 +56,7 @@ Feature: Filing an abuse report
     And I select "Deutsch" from "abuse_report_language"
     And I press "Submit"
     And I should see "Email does not seem to be a valid address."
-    And the field labeled "abuse_report_language" should contain "Deutsch"
+    And "Deutsch" should be selected within "Select language (required)"
   Then I fill in "Your email" with "valid@archiveofourown.org"
     And I press "Submit"
     And I should see "Your abuse report was sent to the Abuse team."

--- a/features/other_a/abuse_report.feature
+++ b/features/other_a/abuse_report.feature
@@ -53,10 +53,11 @@ Feature: Filing an abuse report
     And I fill in "Your comment (required)" with "This is wrong"
     And I fill in "Link to the page you are reporting" with "http://www.archiveofourown.org/works"
     And I fill in "Your email (required)" with ""
+    And I select "Deutsch" from "abuse_report_language"
     And I press "Submit"
     And I should see "Email does not seem to be a valid address."
+    And the field labeled "abuse_report_language" should contain "Deutsch"
   Then I fill in "Your email" with "valid@archiveofourown.org"
     And I press "Submit"
     And I should see "Your abuse report was sent to the Abuse team."
     And 2 email should be delivered
-

--- a/features/other_b/support.feature
+++ b/features/other_b/support.feature
@@ -40,20 +40,8 @@ Feature: Filing a support request
     And all emails have been delivered
     And I press "Send"
   Then I should see "Email does not seem to be a valid address."
+    And "Deutsch" should be selected within "Select language (required)"
     And I fill in "Your email (required)" with "test@archiveofourown.org"
     And I press "Send"
   Then I should see "Your message was sent to the Archive team - thank you!"
     And 2 emails should be delivered
-
-  Scenario: Invalid form submission
-
-  When I am on the home page
-    And basic languages
-    And I follow "Support and Feedback"
-  When I select "Deutsch" from "feedback_language"
-    And I fill in "Brief summary" with "Just a brief note"
-    And I fill in "Your comment" with "Men have their old boys' network, but we have the OTW. You guys rock!"
-    And I fill in "Your email (required)" with "a"
-    And I press "Send"
-  Then I should see "Sorry, your message could not be saved"
-    And the field labeled "feedback_language" should contain "Deutsch"

--- a/features/other_b/support.feature
+++ b/features/other_b/support.feature
@@ -44,3 +44,16 @@ Feature: Filing a support request
     And I press "Send"
   Then I should see "Your message was sent to the Archive team - thank you!"
     And 2 emails should be delivered
+
+  Scenario: Invalid form submission
+
+  When I am on the home page
+    And basic languages
+    And I follow "Support and Feedback"
+  When I select "Deutsch" from "feedback_language"
+    And I fill in "Brief summary" with "Just a brief note"
+    And I fill in "Your comment" with "Men have their old boys' network, but we have the OTW. You guys rock!"
+    And I fill in "Your email (required)" with "a"
+    And I press "Send"
+  Then I should see "Sorry, your message could not be saved"
+    And the field labeled "feedback_language" should contain "Deutsch"


### PR DESCRIPTION
This PR replaces https://github.com/otwcode/otwarchive/pull/3120, which got really complicated because of merge conflicts.

## Issue

https://otwarchive.atlassian.net/browse/AO3-5190

## Purpose

When submitting an abuse or support form with an error (such as an invalid email address), chosen language should persist.

## Testing

Follow the "Report Abuse" or "Technical Support and Feedback" link in the footer
Select a language other than English
Fill in required information, but in the URL field, enter a URL that will make the form error (e.g. enter http://test.ao3.org) or make another mistake such as entering an invalid email address
Submit

Includes two Cucumber tests