### PR TITLE
AO3-5326 Reindex bookmarker pseuds when bookmarkables change restricted status

### DIFF
--- a/app/models/series.rb
+++ b/app/models/series.rb
@@ -135,6 +135,13 @@ class Series < ApplicationRecord
     end
   end
 
+  # Visibility has changed, which means we need to reindex
+  # the series' bookmarker pseuds, to update their bookmark counts.
+  def should_reindex_pseuds?
+    pertinent_attributes = %w[id restricted]
+    destroyed? || (saved_changes.keys & pertinent_attributes).present?
+  end
+
   # Change the positions of the serial works in the series
   def reorder(positions)
     SortableList.new(self.serial_works.in_order).reorder_list(positions)

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -268,6 +268,9 @@ class Work < ApplicationRecord
     IndexQueue.enqueue_ids(Pseud, pseud_ids, :background)
   end
 
+  # Visibility has changed, which means we need to reindex
+  # the work's pseuds, to update their work counts, as well as
+  # the work's bookmarker pseuds, to update their bookmark counts.
   def should_reindex_pseuds?
     pertinent_attributes = %w(id posted restricted in_anon_collection
                               in_unrevealed_collection hidden_by_admin)

--- a/lib/bookmarkable.rb
+++ b/lib/bookmarkable.rb
@@ -5,6 +5,7 @@ module Bookmarkable
       has_many :bookmarks, as: :bookmarkable
       has_many :user_tags, through: :bookmarks, source: :tags
       after_update :update_bookmarks_index
+      after_update :update_bookmarker_pseuds_index
     end
   end
 
@@ -18,4 +19,12 @@ module Bookmarkable
     RedisSearchIndexQueue.queue_bookmarks(self.bookmarks.pluck :id)
   end
 
+  def update_bookmarker_pseuds_index
+    # ES UPGRADE TRANSITION #
+    # Remove new indexing check
+    return unless $rollout.active?(:start_new_indexing)
+    return unless respond_to?(:should_reindex_pseuds?)
+    return unless should_reindex_pseuds?
+    IndexQueue.enqueue_ids(Pseud, bookmarks.pluck(:pseud_id), :background)
+  end
 end

--- a/spec/models/index_queue_spec.rb
+++ b/spec/models/index_queue_spec.rb
@@ -41,7 +41,6 @@ describe IndexQueue do
   describe "#run" do
     it "should call the work indexer" do
       work = create(:work)
-      IndexQueue.enqueue(work, :main) # because test env doesn't enqueue
       expect(WorkIndexer).to receive(:new).with(
         array_including(work.id.to_s)
       ).and_call_original
@@ -50,7 +49,6 @@ describe IndexQueue do
 
     it "should call the bookmark indexer" do
       bookmark = create(:bookmark)
-      IndexQueue.enqueue(bookmark, :main) # because test env doesn't enqueue
       expect(BookmarkIndexer).to receive(:new).with(
         array_including(bookmark.id.to_s)
       ).and_call_original
@@ -59,7 +57,6 @@ describe IndexQueue do
 
     it "should call the tag indexer" do
       tag = create(:freeform)
-      IndexQueue.enqueue(tag, :main) # because test env doesn't enqueue
       expect(TagIndexer).to receive(:new).with(
         array_including(tag.id.to_s)
       ).and_call_original
@@ -68,7 +65,6 @@ describe IndexQueue do
 
     it "should call the pseud indexer" do
       pseud = create(:user).default_pseud
-      IndexQueue.enqueue(pseud, :main) # because test env doesn't enqueue
       expect(PseudIndexer).to receive(:new).with(
         array_including(pseud.id.to_s)
       ).and_call_original

--- a/spec/models/pseud_search_form_spec.rb
+++ b/spec/models/pseud_search_form_spec.rb
@@ -1,10 +1,9 @@
 require "spec_helper"
 
 describe PseudSearchForm do
-  let(:fandom_kp) { create(:fandom) }
-  let(:fandom_mlaatr) { create(:fandom) }
-
   context "searching pseuds in a fandom" do
+    let(:fandom_kp) { create(:fandom) }
+    let(:fandom_mlaatr) { create(:fandom) }
     let!(:work_1) { create(:posted_work, fandoms: [fandom_kp]) }
     let!(:work_2) { create(:posted_work, fandoms: [fandom_kp], restricted: true) }
     let!(:work_3) { create(:posted_work, fandoms: [fandom_mlaatr]) }
@@ -31,6 +30,8 @@ describe PseudSearchForm do
   end
 
   context "searching pseuds in multiple fandoms" do
+    let(:fandom_kp) { create(:fandom) }
+    let(:fandom_mlaatr) { create(:fandom) }
     let(:user) { create(:user) }
 
     let!(:work_1) { create(:posted_work, fandoms: [fandom_kp, fandom_mlaatr]) }
@@ -52,6 +53,68 @@ describe PseudSearchForm do
       # This author posts in both fandoms, but their only work for fandom_mlaatr is restricted.
       # To logged out users, this author does not post in both specified fandoms.
       expect(results).not_to include user.default_pseud
+    end
+  end
+
+  context "pseud index of bookmarkers" do
+    it "updates when bookmarked work changes restricted status" do
+      work = create(:posted_work)
+      expect(work.restricted).to be_falsy
+
+      bookmark = create(:bookmark, bookmarkable_id: work.id)
+      run_all_indexing_jobs
+      result = PseudSearchForm.new(name: bookmark.pseud.name).search_results.first
+      expect(result).to eq bookmark.pseud
+
+      # Bookmark of public work is counted for logged in and logged out searches
+      User.current_user = User.new
+      expect(result.bookmarks_count).to eq 1
+      User.current_user = nil
+      expect(result.bookmarks_count).to eq 1
+
+      # Work becomes restricted
+      work.update_attribute(:restricted, true)
+      expect(work.restricted).to be_truthy
+      run_all_indexing_jobs
+      result = PseudSearchForm.new(name: bookmark.pseud.name).search_results.first
+      expect(result).to eq bookmark.pseud
+
+      # Bookmark of restricted work is only counted for logged in searches
+      User.current_user = User.new
+      expect(result.bookmarks_count).to eq 1
+      User.current_user = nil
+      expect(result.bookmarks_count).to eq 0
+    end
+
+    it "updates when bookmarked series changes restricted status" do
+      series = create(:series)
+      serial_work = create(:serial_work, series: series)
+      expect(series.restricted).to be_falsy
+
+      bookmark = create(:bookmark, bookmarkable_id: series.id, bookmarkable_type: "Series")
+      run_all_indexing_jobs
+      result = PseudSearchForm.new(name: bookmark.pseud.name).search_results.first
+      expect(result).to eq bookmark.pseud
+
+      # Bookmark of public series is counted for logged in and logged out searches
+      User.current_user = User.new
+      expect(result.bookmarks_count).to eq 1
+      User.current_user = nil
+      expect(result.bookmarks_count).to eq 1
+
+      # Series becomes restricted
+      serial_work.work.update_attribute(:restricted, true)
+      series.reload
+      expect(series.restricted).to be_truthy
+      run_all_indexing_jobs
+      result = PseudSearchForm.new(name: bookmark.pseud.name).search_results.first
+      expect(result).to eq bookmark.pseud
+
+      # Bookmark of restricted series is only counted for logged in searches
+      User.current_user = User.new
+      expect(result.bookmarks_count).to eq 1
+      User.current_user = nil
+      expect(result.bookmarks_count).to eq 0
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -172,6 +172,14 @@ def refresh_index_without_updating(klass_name)
   $new_elasticsearch.indices.refresh(index: "ao3_test_#{klass_name}s")
 end
 
+def run_all_indexing_jobs
+  %w[main background stats].each do |reindex_type|
+    ScheduledReindexJob.perform reindex_type
+  end
+  # Specs are too fast! Wait for ES...
+  sleep 1
+end
+
 def delete_index(index)
   # ES UPGRADE TRANSITION #
   # Remove block

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -176,8 +176,9 @@ def run_all_indexing_jobs
   %w[main background stats].each do |reindex_type|
     ScheduledReindexJob.perform reindex_type
   end
-  # Specs are too fast! Wait for ES...
-  sleep 1
+  %w[work bookmark pseud tag].each do |index|
+    refresh_index_without_updating index
+  end
 end
 
 def delete_index(index)


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5326

## Purpose

When a work or a series becomes (un)restricted, we need to reindex its bookmarkers so they get the correct public/general bookmark counts.

External works can't be restricted, so they're fine.

## Testing

See JIRA issue.

## References

The new specs run the indexing jobs (instead of totally refreshing ES), similar to the feature tests in #3206.