### PR TITLE
AO3-5327 Reindex bookmarker pseuds when bookmarkables change hidden by admin status

### DIFF
--- a/app/models/external_work.rb
+++ b/app/models/external_work.rb
@@ -71,6 +71,13 @@ class ExternalWork < ApplicationRecord
 
   alias_method :visible, :visible?
 
+  # Visibility has changed, which means we need to reindex
+  # the external work's bookmarker pseuds, to update their bookmark counts.
+  def should_reindex_pseuds?
+    pertinent_attributes = %w[id hidden_by_admin]
+    destroyed? || (saved_changes.keys & pertinent_attributes).present?
+  end
+
   #######################################################################
   # TAGGING
   # External works are taggable objects.

--- a/app/models/series.rb
+++ b/app/models/series.rb
@@ -138,7 +138,7 @@ class Series < ApplicationRecord
   # Visibility has changed, which means we need to reindex
   # the series' bookmarker pseuds, to update their bookmark counts.
   def should_reindex_pseuds?
-    pertinent_attributes = %w[id restricted]
+    pertinent_attributes = %w[id restricted hidden_by_admin]
     destroyed? || (saved_changes.keys & pertinent_attributes).present?
   end
 

--- a/factories/series.rb
+++ b/factories/series.rb
@@ -1,12 +1,17 @@
-require 'faker'
+require "faker"
 
 FactoryGirl.define do
-
   sequence(:series_title) do |n|
     "Awesome Series #{n}"
   end
 
   factory :series do
-    title {generate(:series_title)}
+    title { generate(:series_title) }
+
+    factory :series_with_a_work do
+      after(:build) do |series|
+        series.works = [create(:posted_work)]
+      end
+    end
   end
 end


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5327

## Purpose

When a work or a series or an external work becomes hidden by admin, we need to reindex its bookmarkers so they get the correct public/general bookmark counts.

## Testing

See JIRA issue.

## References

Similar to #3236.