### PR TITLE
AO3-5327 Fix the test that hides a series being bookmarked

### DIFF
--- a/spec/models/pseud_search_form_spec.rb
+++ b/spec/models/pseud_search_form_spec.rb
@@ -138,8 +138,10 @@ describe PseudSearchForm do
         User.current_user = nil
         expect(result.bookmarks_count).to eq 1
 
+        # This reload is here because the following update_attribute fails otherwise
+        # I don't know why :(
+        bookmarkable.reload
         bookmarkable.update_attribute(:hidden_by_admin, true)
-        expect(bookmarkable.hidden_by_admin).to be_truthy
         run_all_indexing_jobs
         result = PseudSearchForm.new(name: bookmark.pseud.name).search_results.first
         expect(result).to eq bookmark.pseud

--- a/spec/models/pseud_search_form_spec.rb
+++ b/spec/models/pseud_search_form_spec.rb
@@ -138,8 +138,10 @@ describe PseudSearchForm do
         User.current_user = nil
         expect(result.bookmarks_count).to eq 1
 
-        # This reload is here because the following update_attribute fails otherwise
-        # I don't know why :(
+        # When a series and its work are first created, the series loads
+        # an empty collection of bookmarks, which stays unupdated when we pluck
+        # the bookmark IDs to reindex bookmarker pseuds, so no pseuds get reindexed.
+        # We need to reload the series.
         bookmarkable.reload
         bookmarkable.update_attribute(:hidden_by_admin, true)
         run_all_indexing_jobs


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5327

## Purpose

~Without the reload call, update_attribute fails, with bookmarkable.errors containing an error with no messages. I don't know why this happens. Years from now, if you figure this out, please let me know.~

When a series and its work are first created, the series loads an empty collection of bookmarks, which stays unupdated when we pluck the bookmark IDs to reindex bookmarker pseuds, so no pseuds get reindexed. We need to reload the series.

## Testing

See JIRA issue.

## References

The test was introduced in #3238.