### PR TITLE
AO3-5339 Upgrade nokogiri to 1.8.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -50,7 +50,7 @@ gem 'akismetor'
 gem 'httparty'
 gem 'htmlentities'
 gem 'whenever', '~>0.6.2', :require => false
-gem 'nokogiri', '>= 1.8.1'
+gem 'nokogiri', '>= 1.8.2'
 gem 'mechanize'
 gem 'sanitize'
 # Until there is a working solution to

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -271,7 +271,7 @@ GEM
       redis (< 4.0)
     newrelic_rpm (3.18.1.330)
     nio4r (2.1.0)
-    nokogiri (1.8.1)
+    nokogiri (1.8.2)
       mini_portile2 (~> 2.3.0)
     nokogumbo (1.4.9)
       nokogiri
@@ -537,7 +537,7 @@ DEPENDENCIES
   mysql2 (= 0.3.20)
   newrelic-redis
   newrelic_rpm
-  nokogiri (>= 1.8.1)
+  nokogiri (>= 1.8.2)
   nokogumbo (= 1.4.9)
   paperclip (>= 5.2.0)
   permit_yo


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5339

## Purpose

Upgrade nokogiri to 1.8.2.

## Testing

Posting and importing works should still work. See JIRA issue.