### PR TITLE
AO3-5337 Update factories to make non-canonical tags by default

### DIFF
--- a/factories/tags.rb
+++ b/factories/tags.rb
@@ -19,7 +19,7 @@ FactoryGirl.define do
   end
 
   factory :tag_set do
-    tags { [create(:fandom)] }
+    tags { [create(:canonical_fandom)] }
   end
 
   factory :owned_tag_set do
@@ -61,7 +61,6 @@ FactoryGirl.define do
   end
 
   factory :tag do
-    canonical true
     name { generate(:tag_name) }
   end
 
@@ -70,27 +69,38 @@ FactoryGirl.define do
   end
 
   factory :fandom do
-    canonical true
     sequence(:name) { |n| "The #{n} Fandom" }
+
+    factory :canonical_fandom do
+      canonical true
+    end
   end
 
   factory :character do
-    canonical true
     sequence(:name) { |n| "Character #{n}" }
+
+    factory :canonical_character do
+      canonical true
+    end
   end
 
   factory :relationship do
-    canonical true
     sequence(:name) { |n| "Jane#{n}/John#{n}" }
+
+    factory :canonical_relationship do
+      canonical true
+    end
   end
 
   factory :freeform do
-    canonical true
     sequence(:name) { |n| "Freeform #{n}" }
+
+    factory :canonical_freeform do
+      canonical true
+    end
   end
 
   factory :banned do |f|
-    f.canonical true
     f.sequence(:name) { |n| "Banned #{n}" }
   end
 end

--- a/features/tags_and_wrangling/tag_wrangling_more.feature
+++ b/features/tags_and_wrangling/tag_wrangling_more.feature
@@ -106,22 +106,20 @@ Feature: Tag wrangling: assigning wranglers, using the filters on the Wranglers 
     Then I should see "Sign Up"
 
   Scenario: Updating multiple tags works.
-    Given the following typed tags exists
-        | name                                   | type         |
-        | Cowboy Bebop                           | Fandom       |
-        | Spike Spiegel is a sweetie             | Freeform     |
-        | Jet Black is a sweetie                 | Freeform     |
+    Given a canonical fandom "Cowboy Bebop"
+      And a noncanonical freeform "Spike Spiegel is a sweetie"
+      And a noncanonical freeform "Jet Black is a sweetie"
       And I am logged in as a random user
       And I post the work "Brain Scratch" with fandom "Cowboy Bebop" with freeform "Spike Spiegel is a sweetie"
       And I post the work "Asteroid Blues" with fandom "Cowboy Bebop" with freeform "Jet Black is a sweetie"
-     When the tag wrangler "lain" with password "lainnial" is wrangler of "Cowboy Bebop"
-       And I follow "Tag Wrangling"
-       And I follow "2"
-       And I fill in "fandom_string" with "Cowboy Bebop"
-       And I check the mass wrangling option for "Spike Spiegel is a sweetie"
-       And I check the mass wrangling option for "Jet Black is a sweetie"
-       And I press "Wrangle"
-     Then I should see "The following tags were successfully wrangled to Cowboy Bebop: Spike Spiegel is a sweetie, Jet Black is a sweetie"
+    When the tag wrangler "lain" with password "lainnial" is wrangler of "Cowboy Bebop"
+      And I follow "Tag Wrangling"
+      And I follow "2"
+      And I fill in "Wrangle to Fandom(s)" with "Cowboy Bebop"
+      And I check the mass wrangling option for "Spike Spiegel is a sweetie"
+      And I check the mass wrangling option for "Jet Black is a sweetie"
+      And I press "Wrangle"
+    Then I should see "The following tags were successfully wrangled to Cowboy Bebop: Spike Spiegel is a sweetie, Jet Black is a sweetie"
 
   Scenario: Updating multiple tags works and set them as canonical
     Given the following typed tags exists

--- a/spec/controllers/autocomplete_controller_spec.rb
+++ b/spec/controllers/autocomplete_controller_spec.rb
@@ -2,8 +2,8 @@ require "spec_helper"
 
 describe AutocompleteController do
   describe "tag" do
-    let!(:tag1) { create(:fandom, name: "Match") }
-    let!(:tag2) { create(:fandom, name: "Blargh") }
+    let!(:tag1) { create(:canonical_fandom, name: "Match") }
+    let!(:tag2) { create(:canonical_fandom, name: "Blargh") }
 
     it "returns only matching tags" do
       get :tag, params: { term: "Ma", format: :json }

--- a/spec/controllers/tags_controller_spec.rb
+++ b/spec/controllers/tags_controller_spec.rb
@@ -177,6 +177,10 @@ describe TagsController do
         # The tag now has the original class, we can reload the original record without error.
         unsorted_tag.reload
       end
+    end
+
+    context "when updating a canonical tag" do
+      let(:tag) { create(:canonical_freeform) }
 
       it "wrangles" do
         expect(tag.canonical?).to be_truthy

--- a/spec/controllers/works/default_rails_actions_spec.rb
+++ b/spec/controllers/works/default_rails_actions_spec.rb
@@ -219,7 +219,7 @@ describe WorksController do
 
   describe "index" do
     before do
-      @fandom = create(:fandom)
+      @fandom = create(:canonical_fandom)
       @work = create(:work, posted: true, fandom_string: @fandom.name)
     end
 
@@ -272,7 +272,7 @@ describe WorksController do
 
       context "with an owner tag" do
         before do
-          @fandom2 = FactoryGirl.create(:fandom)
+          @fandom2 = FactoryGirl.create(:canonical_fandom)
           @work2 = FactoryGirl.create(:work, posted: true, fandom_string: @fandom2.name)
 
           update_and_refresh_indexes('work')
@@ -360,8 +360,8 @@ describe WorksController do
   end
 
   describe "collected" do
-    let(:collected_fandom) { create(:fandom) }
-    let(:collected_fandom2) { create(:fandom) }
+    let(:collected_fandom) { create(:canonical_fandom) }
+    let(:collected_fandom2) { create(:canonical_fandom) }
     let(:collection) { create(:collection) }
     let(:collected_user) { create(:user) }
 

--- a/spec/models/pseud_search_form_spec.rb
+++ b/spec/models/pseud_search_form_spec.rb
@@ -2,8 +2,8 @@ require "spec_helper"
 
 describe PseudSearchForm do
   context "searching pseuds in a fandom" do
-    let(:fandom_kp) { create(:fandom) }
-    let(:fandom_mlaatr) { create(:fandom) }
+    let(:fandom_kp) { create(:canonical_fandom) }
+    let(:fandom_mlaatr) { create(:canonical_fandom) }
     let!(:work_1) { create(:posted_work, fandoms: [fandom_kp]) }
     let!(:work_2) { create(:posted_work, fandoms: [fandom_kp], restricted: true) }
     let!(:work_3) { create(:posted_work, fandoms: [fandom_mlaatr]) }
@@ -30,8 +30,8 @@ describe PseudSearchForm do
   end
 
   context "searching pseuds in multiple fandoms" do
-    let(:fandom_kp) { create(:fandom) }
-    let(:fandom_mlaatr) { create(:fandom) }
+    let(:fandom_kp) { create(:canonical_fandom) }
+    let(:fandom_mlaatr) { create(:canonical_fandom) }
     let(:user) { create(:user) }
 
     let!(:work_1) { create(:posted_work, fandoms: [fandom_kp, fandom_mlaatr]) }

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -458,9 +458,9 @@ describe Tag do
   describe "multiple tags of the same type" do
     before do
       # set up three tags of the same type
-      @canonical_tag = FactoryGirl.create(:fandom)
+      @canonical_tag = FactoryGirl.create(:canonical_fandom)
       @syn_tag = FactoryGirl.create(:fandom)
-      @sub_tag = FactoryGirl.create(:fandom)
+      @sub_tag = FactoryGirl.create(:canonical_fandom)
     end
 
     it "should let you make a tag the synonym of a canonical one" do

--- a/spec/models/work_search_form_exclusion_filters_spec.rb
+++ b/spec/models/work_search_form_exclusion_filters_spec.rb
@@ -65,15 +65,15 @@ describe WorkSearchForm do
 
     describe "meta tagging" do
       let!(:grand_parent_tag) do
-        FactoryGirl.create(:tag, type: "Character", name: "Sam")
+        create(:canonical_character, name: "Sam")
       end
 
       let!(:parent_tag) do
-        FactoryGirl.create(:tag, type: "Character", name: "Sam Winchester")
+        create(:canonical_character, name: "Sam Winchester")
       end
 
       let!(:child_tag) do
-        FactoryGirl.create(:tag, type: "Character", name: "Endverse Sam Winchester")
+        create(:canonical_character, name: "Endverse Sam Winchester")
       end
 
       let!(:grand_parent_parent_meta_tagging) do


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5337

## Purpose

Tags when first created are not canonical until wranglers make them. Tests should reflect that: only make canonical tags when we have to (for autocomplete, search indexing, etc.)

## Testing

None, automated.