### PR TITLE
AO3-5319 Invitation ownership

### DIFF
--- a/app/controllers/invitations_controller.rb
+++ b/app/controllers/invitations_controller.rb
@@ -5,7 +5,7 @@ class InvitationsController < ApplicationController
   before_action :admin_only, only: [:create, :destroy]
   before_action :check_user_status, only: [:index, :manage, :invite_friend, :update]
   before_action :load_invitation, only: [:show, :invite_friend, :update, :destroy]
-  before_action :check_ownership, only: [:show, :invite_friend, :update]
+  before_action :check_ownership_or_admin, only: [:show, :invite_friend, :update]
 
   def load_invitation
     @invitation = Invitation.find(params[:id] || invitation_params[:id])

--- a/app/controllers/invitations_controller.rb
+++ b/app/controllers/invitations_controller.rb
@@ -8,7 +8,7 @@ class InvitationsController < ApplicationController
   before_action :check_ownership, only: [:show, :invite_friend, :update]
 
   def load_invitation
-    @invitation = Invitation.find(params[:id])
+    @invitation = Invitation.find(params[:id] || invitation_params[:id])
     @check_ownership_of = @invitation
   end
 

--- a/app/controllers/invitations_controller.rb
+++ b/app/controllers/invitations_controller.rb
@@ -4,6 +4,13 @@ class InvitationsController < ApplicationController
   before_action :check_permission
   before_action :admin_only, only: [:create, :destroy]
   before_action :check_user_status, only: [:index, :manage, :invite_friend, :update]
+  before_action :load_invitation, only: [:show, :invite_friend, :update, :destroy]
+  before_action :check_ownership, only: [:show, :invite_friend, :update]
+
+  def load_invitation
+    @invitation = Invitation.find(params[:id])
+    @check_ownership_of = @invitation
+  end
 
   def check_permission
     @user = User.find_by(login: params[:user_id])
@@ -23,12 +30,9 @@ class InvitationsController < ApplicationController
   end
 
   def show
-    @invitation = Invitation.find(params[:id])
   end
 
   def invite_friend
-    @invitation = @user.invitations.find(invitation_params[:id])
-
     if !invitation_params[:invitee_email].blank?
       @invitation.invitee_email = invitation_params[:invitee_email]
       if @invitation.save
@@ -54,7 +58,6 @@ class InvitationsController < ApplicationController
   end
 
   def update
-    @invitation = Invitation.find(params[:id])
     @invitation.attributes = invitation_params
 
     if @invitation.invitee_email_changed? && @invitation.update_attributes(invitation_params)
@@ -71,7 +74,6 @@ class InvitationsController < ApplicationController
   end
 
   def destroy
-    @invitation = Invitation.find(params[:id])
     @user = @invitation.creator
     if @invitation.destroy
       flash[:notice] = "Invitation successfully destroyed"

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -359,6 +359,8 @@
       !(self.pseuds & item.pseuds).empty?
     elsif item.respond_to?(:author)
       self == item.author
+    elsif item.respond_to?(:creator)
+      self == item.creator
     else
       false
     end


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5319

## Purpose

Check ownership of invitations before allowing access.

Previously any user could access invitations, allowing reading private email addresses and stealing invitations. Now only the user who created the invitation or an admin may view them.

Some invitations code was also refactored to use a shared `load_invitation` method.

## Testing

How can the Archive's QA team verify that this is working as you intended? (If you have access, please copy this into the JIRA ticket for them!)

Invitations should be viewable by only the creator or an admin. Other users should receive an error, even if they attempt to access the invitation directly.

## References

Are there any other relevant issues / PRs / mailing lists discussions related to this?

Issue was initially reported to ADT by email, then discussed on Slack.

## Credit

*What name do you want us to use to credit your work in the [Archive of Our Own's Release Notes](http://archiveofourown.org/admin_posts?tag=1)?* @de3sw2aq1