### PR TITLE
AO3-4310 Translate invite request decline email

### DIFF
--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -158,7 +158,7 @@ class UserMailer < BulletproofMailer::Base
     I18n.with_locale(Locale.find(@user.preference.preferred_locale).iso) do
       mail(
         to: @user.email,
-        subject: "#{t 'user_mailer.invite_request_declined.subject', app_name: ArchiveConfig.APP_SHORT_NAME}"
+        subject: t('user_mailer.invite_request_declined.subject', app_name: ArchiveConfig.APP_SHORT_NAME)
       )
     end
     ensure

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -158,7 +158,7 @@ class UserMailer < BulletproofMailer::Base
     I18n.with_locale(Locale.find(@user.preference.preferred_locale).iso) do
       mail(
         to: @user.email,
-        subject: "[#{ArchiveConfig.APP_SHORT_NAME}] Additional Invite Code Request Declined"
+        subject: "#{t 'user_mailer.invite_request_declined.subject', app_name: ArchiveConfig.APP_SHORT_NAME}"
       )
     end
     ensure

--- a/app/views/user_mailer/invite_request_declined.html.erb
+++ b/app/views/user_mailer/invite_request_declined.html.erb
@@ -1,11 +1,11 @@
 <% content_for :message do %>
-  <p><%= ts("Dear #{style_bold(@user.login)}, ").html_safe%></p>
+  <p><%= t('.greeting', user: style_bold(@user.login)).html_safe %></p>
 
-  <p><%= ts("We regret to inform you that your request for #{@total} new ") %><%= @total == 1 ? ts("invitation") : ts("invitations") %><%= ts(" cannot be fulfilled at this time.") %> </p>
-  <p><%= ts("Your request was: ") %></p>
+  <p><%= t('.main', count: @total) %></p>
+  <p><%= t('.reason') %></p>
   <p><%= style_quote(@reason) %></p>
 
-  <p>Regards,</p>
+  <p><%= t('.signoff') %></p>
   <p><%= style_link(ArchiveConfig.APP_SHORT_NAME, root_url) %></p>
 <% end %>
 

--- a/app/views/user_mailer/invite_request_declined.text.erb
+++ b/app/views/user_mailer/invite_request_declined.text.erb
@@ -4,6 +4,6 @@
 <%= t('.reason') %>
 <%= to_plain_text(raw @reason) %>
 
-<%= t '.signoff' %>
+<%= t('.signoff') %>
 <%= ArchiveConfig.APP_SHORT_NAME %>
 <% end %>

--- a/app/views/user_mailer/invite_request_declined.text.erb
+++ b/app/views/user_mailer/invite_request_declined.text.erb
@@ -1,9 +1,9 @@
 <% content_for :message do %>
-<%= ts("Dear #{@user.login}, ")%>
-<%= ts("We regret to inform you that your request for #{@total} new ") %><%= @total == 1 ? ts("invitation") : ts("invitations") %><%= ts(" cannot be fulfilled at this time.") %>
-<%= ts("Your request was: ") %>
+<%= t('.greeting', user: @user.login) %>
+<%= t('.main', count: @total) %>
+<%= t('.reason') %>
 <%= to_plain_text(raw @reason) %>
 
-Regards,
-AO3
+<%= t '.signoff' %>
+<%= ArchiveConfig.APP_SHORT_NAME %>
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -309,6 +309,14 @@ en:
         part13: "Best,"
         part14: "The Open Doors team"
         part15: "Organization for Transformative Works"
+    invite_request_declined:
+      subject: "[%{app_name}] Additional Invite Code Request Declined"
+      greeting: "Dear %{user},"
+      reason: "Your request was:"
+      signoff: "Regards,"
+      main:
+        one: "We regret to inform you that your request for a new invitation cannot be fulfilled at this time."
+        other: "We regret to inform you that your request for %{count} new invitations cannot be fulfilled at this time."
 
   validators:
     email:

--- a/spec/miscellaneous/mailers/user_mailer_spec.rb
+++ b/spec/miscellaneous/mailers/user_mailer_spec.rb
@@ -311,4 +311,53 @@ describe UserMailer, type: :mailer do
       end
     end
   end
+
+  describe "invite request declined" do
+
+    before(:each) do
+      @user = FactoryGirl.create(:user)
+      @total = 2
+      @reason = "You smell"
+    end
+
+    let(:email) { UserMailer.invite_request_declined(@user.id, @total, @reason).deliver }
+
+    # Test the headers
+    it 'has a valid from line' do
+      text = "Archive of Our Own <#{ArchiveConfig.RETURN_ADDRESS}>"
+      expect(email.header['From'].to_s).to eq(text)
+    end
+
+    it 'has the correct subject line' do
+      text = "[#{ArchiveConfig.APP_SHORT_NAME}] Additional Invite Code Request Declined"
+      expect(email.subject).to eq(text)
+    end
+
+    # Test both body contents
+    it_behaves_like "multipart email"
+
+    describe 'HTML version' do
+      it 'has text contents' do
+        expect(get_message_part(email, /html/)).to include("We regret to inform you")
+      end
+      
+      it 'does not have missing translations' do
+        expect(get_message_part(email, /html/)).not_to include("translation missing")
+      end
+      
+      it 'does not have exposed HTML' do
+        expect(get_message_part(email, /html/)).not_to include("&lt;")
+      end
+    end
+
+    describe 'text version' do
+      it 'says the right thing' do
+        expect(get_message_part(email, /plain/)).to include("We regret to inform you")
+      end
+      
+      it 'does not have missing translations' do
+        expect(get_message_part(email, /plain/)).not_to include("translation missing")
+      end
+    end
+  end
 end

--- a/spec/miscellaneous/mailers/user_mailer_spec.rb
+++ b/spec/miscellaneous/mailers/user_mailer_spec.rb
@@ -337,7 +337,7 @@ describe UserMailer, type: :mailer do
 
     describe 'HTML version' do
       it 'has text contents' do
-        expect(get_message_part(email, /html/)).to include("We regret to inform you")
+        expect(get_message_part(email, /html/)).to include("We regret to inform you that your request for 2 new invitations cannot be fulfilled at this time")
       end
       
       it 'does not have missing translations' do
@@ -351,7 +351,7 @@ describe UserMailer, type: :mailer do
 
     describe 'text version' do
       it 'says the right thing' do
-        expect(get_message_part(email, /plain/)).to include("We regret to inform you")
+        expect(get_message_part(email, /plain/)).to include("We regret to inform you that your request for 2 new invitations cannot be fulfilled at this time")
       end
       
       it 'does not have missing translations' do

--- a/spec/miscellaneous/mailers/user_mailer_spec.rb
+++ b/spec/miscellaneous/mailers/user_mailer_spec.rb
@@ -313,7 +313,6 @@ describe UserMailer, type: :mailer do
   end
 
   describe "invite request declined" do
-
     before(:each) do
       @user = FactoryGirl.create(:user)
       @total = 2


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-4310

## Purpose

Makes the invite request declined email translatable

## Testing

Request an invite, get an admin to decline it, get an email notification, it shows in English with no errors.

## Credit

Cesy, she/her
