### PR TITLE
AO3-5355 Add new fields to bookmark filters

### DIFF
--- a/app/views/bookmarks/_filters.html.erb
+++ b/app/views/bookmarks/_filters.html.erb
@@ -62,9 +62,16 @@
             <% end %>
             <% field_name = filter_action == "include" ? "other_tag_names" : "excluded_tag_names" %>
             <dt class="autocomplete search">
-              <%= f.label field_name, ts("Other tags to %{filter_action}", filter_action: filter_action) %>
+              <%= f.label field_name, ts("Other work tags to %{filter_action}", filter_action: filter_action) %>
             </dt>
             <dd class="autocomplete search">
+              <%= f.text_field field_name, autocomplete_options("tag") %>
+            </dd>
+            <% # TODO: UPDATE WHEN NEW BOOKMARK CODE COMES IN %>
+            <dt class="bookmarker autocomplete search">
+              <%= f.label field_name, ts("Other bookmarker's tags to %{filter_action}", filter_action: filter_action) %>
+            </dt>
+            <dd class="bookmarker autocomplete search">
               <%= f.text_field field_name, autocomplete_options("tag") %>
             </dd>
           </dl>
@@ -84,7 +91,16 @@
             <%= f.text_field :query %>
           </dd>
 
-          <dt class="options"><%= ts("Options") %></dt>
+          <% # TODO: UPDATE WHEN NEW BOOKMARK CODE COMES IN %>
+          <dt class="bookmarker search">
+            <%= f.label :query, ts("Search bookmarker's tags and notes") %>
+            <%= link_to_help "bookmark-search-text-help" %>
+          </dt>
+          <dd class="bookmarker search">
+            <%= f.text_field :query %>
+          </dd>
+
+          <dt class="options"><%= ts("Bookmark types") %></dt>
           <dd class="options">
             <ul>
               <li>

--- a/public/help/bookmark-search-bookmarker-tags-notes-help.html
+++ b/public/help/bookmark-search-bookmarker-tags-notes-help.html
@@ -1,0 +1,2 @@
+<h4>Bookmark Search: Bookmarker's Tags and Notes</h4>
+

--- a/public/stylesheets/site/2.0/18-zone-searchbrowse.css
+++ b/public/stylesheets/site/2.0/18-zone-searchbrowse.css
@@ -140,7 +140,13 @@ form.filters {
   padding: 0.25em 0;
 }
 
-.filters .more dd.search, .filters .range dd {
+.filters .group dt.bookmarker {
+  border-top: 1px solid #f3efec;
+  margin-top: 0.643em;
+  padding-top: 0.643em;
+}
+
+.filters .more dd.search, .filters .more dt.search, .filters .range dd {
   margin-top: 0;
 }
 
@@ -158,7 +164,7 @@ form.filters {
 
 .filters [type="checkbox"], .filters [type="radio"] {
   border: 0; 
-  clip: rect(0 0 0 0); 
+  clip: rect(0 0 0 0);
   height: 1px;
   margin: -1px; 
   overflow: hidden; 


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5355

## Purpose

The filters should now have fields for:
- Other work tags to include
- Other bookmarker's tags to include
- Other work tags to exclude
- Other bookmarker's tags to exclude
- Search bookmarker's tags and notes (note: this is named "Search within bookmarker's tags and notes" in the mockup")

This fields won't do anything yet. The "Search bookmarker's tags and notes" will have a help pop-up, but it is currently empty.

## Testing

Refer to Jira
