### PR TITLE
AO3-5340 Show bookmarks of deleted items.

### DIFF
--- a/app/models/bookmark.rb
+++ b/app/models/bookmark.rb
@@ -55,17 +55,39 @@ class Bookmark < ApplicationRecord
   }
 
   scope :visible_to_all, -> {
-    is_public.join_bookmarkable.
-    where("(works.posted = 1 AND works.restricted = 0 AND works.hidden_by_admin = 0) OR
-      (series.restricted = 0 AND series.hidden_by_admin = 0) OR
-      (external_works.hidden_by_admin = 0)")
+    is_public.with_bookmarkable_visible_to_all
   }
 
   scope :visible_to_registered_user, -> {
-    is_public.join_bookmarkable.
-    where("(works.posted = 1 AND works.hidden_by_admin = 0) OR
+    is_public.with_bookmarkable_visible_to_registered_user
+  }
+
+  # Scope for retrieving bookmarks with a bookmarkable visible to registered
+  # users (regardless of the bookmark's hidden_by_admin/private status).
+  scope :with_bookmarkable_visible_to_registered_user, -> {
+    join_bookmarkable.where(
+      "(works.posted = 1 AND works.hidden_by_admin = 0) OR
       (series.hidden_by_admin = 0) OR
-      (external_works.hidden_by_admin = 0)")
+      (external_works.hidden_by_admin = 0)"
+    )
+  }
+
+  # Scope for retrieving bookmarks with a bookmarkable visible to logged-out
+  # users (regardless of the bookmark's hidden_by_admin/private status).
+  scope :with_bookmarkable_visible_to_all, -> {
+    join_bookmarkable.where(
+      "(works.posted = 1 AND works.restricted = 0 AND works.hidden_by_admin = 0) OR
+      (series.restricted = 0 AND series.hidden_by_admin = 0) OR
+      (external_works.hidden_by_admin = 0)"
+    )
+  }
+
+  # Scope for retrieving bookmarks with a missing bookmarkable (regardless of
+  # the bookmark's hidden_by_admin/private status).
+  scope :with_missing_bookmarkable, -> {
+    join_bookmarkable.where(
+      "works.id IS NULL AND series.id IS NULL AND external_works.id IS NULL"
+    )
   }
 
   scope :visible_to_admin, -> { not_private }

--- a/app/models/search/bookmark_query.rb
+++ b/app/models/search/bookmark_query.rb
@@ -161,6 +161,7 @@ class BookmarkQuery < Query
 
   def bookmark_filters
     [
+      bookmarks_only_filter,
       pseud_filter,
       user_filter,
       rec_filter,
@@ -277,6 +278,13 @@ class BookmarkQuery < Query
         ]
       }.flatten
     end
+  end
+
+  # We don't want to accidentally return Bookmarkable documents when we're
+  # doing a search for Bookmarks. So we should only include documents that are
+  # marked as "bookmark" in their bookmarkable_join field.
+  def bookmarks_only_filter
+    term_filter(:bookmarkable_join, "bookmark")
   end
 
   ####################

--- a/app/models/search/pseud_indexer.rb
+++ b/app/models/search/pseud_indexer.rb
@@ -90,7 +90,8 @@ class PseudIndexer < Indexer
   # The relation containing all bookmarks that should be included in the count
   # for logged-in users (when restricted to a particular pseud).
   def general_bookmarks
-    @general_bookmarks ||= Bookmark.with_missing_bookmarkable.
+    @general_bookmarks ||=
+      Bookmark.with_missing_bookmarkable.
       or(Bookmark.with_bookmarkable_visible_to_registered_user).
       is_public
   end
@@ -98,7 +99,8 @@ class PseudIndexer < Indexer
   # The relation containing all bookmarks that should be included in the count
   # for logged-out users (when restricted to a particular pseud).
   def public_bookmarks
-    @public_bookmarks ||= Bookmark.with_missing_bookmarkable.
+    @public_bookmarks ||=
+      Bookmark.with_missing_bookmarkable.
       or(Bookmark.with_bookmarkable_visible_to_all).
       is_public
   end

--- a/app/models/search/pseud_indexer.rb
+++ b/app/models/search/pseud_indexer.rb
@@ -87,12 +87,28 @@ class PseudIndexer < Indexer
     info
   end
 
+  # The relation containing all bookmarks that should be included in the count
+  # for logged-in users (when restricted to a particular pseud).
+  def general_bookmarks
+    @general_bookmarks ||= Bookmark.with_missing_bookmarkable.
+      or(Bookmark.with_bookmarkable_visible_to_registered_user).
+      is_public
+  end
+
+  # The relation containing all bookmarks that should be included in the count
+  # for logged-out users (when restricted to a particular pseud).
+  def public_bookmarks
+    @public_bookmarks ||= Bookmark.with_missing_bookmarkable.
+      or(Bookmark.with_bookmarkable_visible_to_all).
+      is_public
+  end
+
   def general_bookmarks_count(pseud)
-    pseud.bookmarks.visible_to_registered_user.count
+    general_bookmarks.merge(pseud.bookmarks).count
   end
 
   def public_bookmarks_count(pseud)
-    pseud.bookmarks.visible_to_all.count
+    public_bookmarks.merge(pseud.bookmarks).count
   end
 
   def work_counts(pseud)

--- a/features/bookmarks/delete_bookmarkable.feature
+++ b/features/bookmarks/delete_bookmarkable.feature
@@ -64,3 +64,27 @@ Feature: Bookmarks of deleted items
       And I should see "1 Bookmark by Alice"
       And I should see "This has been deleted, sorry!"
       And I should not see "Extremely Objectionable Content"
+
+  Scenario: Deleting a restricted work with bookmarks makes the public bookmark count on all bookmarker's pseuds increase.
+    # This scenario doesn't make sense unless you can do the people search
+    # logged out. So it can't be enabled until the new search is the default.
+    When "the ES5/ES6 upgrade" is fixed
+    # Given I am logged in as "Alice"
+    #   And I post the locked work "Mayfly"
+    #   And I am logged in as "Beth"
+    #   And I bookmark the work "Mayfly"
+    # When I am logged out
+    #   And I go to the search people page
+    #   And I fill in "Name" with "Beth"
+    #   And I press "Search People"
+    # Then I should see "Beth" within "ol.pseud.group"
+    #   And I should not see "1 bookmark"
+    # When I am logged in as "Alice"
+    #   And I delete the work "Mayfly"
+    #   And all indexing jobs have been run
+    #   And I am logged out
+    #   And I go to the search people page
+    #   And I fill in "Name" with "Beth"
+    #   And I press "Search People"
+    # Then I should see "Beth" within "ol.pseud.group"
+    #   And I should see "1 bookmark"

--- a/features/bookmarks/delete_bookmarkable.feature
+++ b/features/bookmarks/delete_bookmarkable.feature
@@ -1,0 +1,66 @@
+@bookmarks @search
+Feature: Bookmarks of deleted items
+
+  Scenario: Deleting a work shouldn't make its bookmarks disappear completely.
+    Given I am logged in as "Alice"
+      And I post the work "Mayfly"
+      And I am logged in as "Beth"
+      And I bookmark the work "Mayfly" with the note "The best yet!"
+      And I am logged in as "Alice"
+      And I delete the work "Mayfly"
+      And all indexing jobs have been run
+      And I am logged in as "Charlotte"
+      And Charlotte can use the new search
+    When I go to the search people page
+      And I fill in "Name" with "Beth"
+      And I press "Search People"
+    Then I should see "Beth" within "ol.pseud.group"
+      And I should see "1 bookmark"
+    When I follow "1 bookmark"
+    Then I should see "Bookmarks (1)"
+      And I should see "1 Bookmark by Beth"
+      And I should see "This has been deleted, sorry!"
+      And I should see "The best yet!"
+      But I should not see "Mayfly"
+
+  Scenario: Deleting a series shouldn't make its bookmarks disappear completely.
+    Given I am logged in as "Alice"
+      And I post the work "Mayfly" as part of a series "Shorts"
+      And I am logged in as "Beth"
+      And I bookmark the series "Shorts"
+      And I am logged in as "Alice"
+      And I delete the series "Shorts"
+      And all indexing jobs have been run
+      And I am logged in as "Charlotte"
+      And Charlotte can use the new search
+    When I go to the search people page
+      And I fill in "Name" with "Beth"
+      And I press "Search People"
+    Then I should see "Beth" within "ol.pseud.group"
+      And I should see "1 bookmark"
+    When I follow "1 bookmark"
+    Then I should see "Bookmarks (1)"
+      And I should see "1 Bookmark by Beth"
+      And I should see "This has been deleted, sorry!"
+      But I should not see "Shorts"
+
+  Scenario: Deleting an external work shouldn't make its bookmarks disappear completely.
+    Given basic tags
+      And I am logged in as "Alice"
+      And I bookmark the external work "Extremely Objectionable Content"
+      And I am logged in as an admin
+      And I view the external work "Extremely Objectionable Content"
+      And I follow "Delete External Work"
+      And all indexing jobs have been run
+      And I am logged in as "Beth"
+      And Beth can use the new search
+    When I go to the search people page
+      And I fill in "Name" with "Alice"
+      And I press "Search People"
+    Then I should see "Alice" within "ol.pseud.group"
+      And I should see "1 bookmark"
+    When I follow "1 bookmark"
+    Then I should see "Bookmarks (1)"
+      And I should see "1 Bookmark by Alice"
+      And I should see "This has been deleted, sorry!"
+      And I should not see "Extremely Objectionable Content"

--- a/features/step_definitions/series_steps.rb
+++ b/features/step_definitions/series_steps.rb
@@ -56,6 +56,14 @@ When /^I add the work "([^\"]*)" to "(\d+)" series "([^\"]*)"$/ do |work_title, 
   end
 end
 
+When /^I delete the series "([^"]*)"$/ do |series|
+  step %{I view the series "#{series}"}
+  step %{I follow "Delete Series"}
+  step %{I press "Yes, Delete Series"}
+  step %{I should see "Series was successfully deleted."}
+  step %{all indexing jobs have been run}
+end
+
 Then /^the series "(.*)" should be deleted/ do |series|
   assert Series.where(title: series).first.nil?
 end

--- a/lib/bookmarkable.rb
+++ b/lib/bookmarkable.rb
@@ -6,6 +6,7 @@ module Bookmarkable
       has_many :user_tags, through: :bookmarks, source: :tags
       after_update :update_bookmarks_index
       after_update :update_bookmarker_pseuds_index
+      after_destroy :update_bookmarker_pseuds_index
     end
   end
 

--- a/spec/models/bookmark_query_spec.rb
+++ b/spec/models/bookmark_query_spec.rb
@@ -36,19 +36,24 @@ describe BookmarkQuery do
 
   it "should not return bookmarks of hidden objects" do
     q = BookmarkQuery.new
-    expect(q.filters).to include({has_parent:{parent_type: 'bookmarkable', query:{term: { hidden_by_admin: 'false' }}}})
+    expect(q.exclusion_filters).to include({ has_parent: { parent_type: 'bookmarkable', query: { term: { hidden_by_admin: 'true' } } } })
+  end
+
+  it "should not return bookmarks of drafts" do
+    q = BookmarkQuery.new
+    expect(q.exclusion_filters).to include({ has_parent: { parent_type: 'bookmarkable', query: { term: { posted: 'false' } } } })
   end
 
   it "should not return restricted bookmarked works by default" do
     User.current_user = nil
     q = BookmarkQuery.new
-    expect(q.filters).to include({has_parent:{parent_type: 'bookmarkable', query:{term: {restricted: 'false'}}}})
+    expect(q.exclusion_filters).to include({ has_parent: { parent_type: 'bookmarkable', query: { term: { restricted: 'true' } } } })
   end
 
   it "should only return restricted bookmarked works when a user is logged in" do
     User.current_user = User.new
     q = BookmarkQuery.new
-    expect(q.filters).not_to include({has_parent:{parent_type: 'bookmarkable', query:{term: {restricted: 'false'}}}})
+    expect(q.exclusion_filters).not_to include({ has_parent: { parent_type: 'bookmarkable', query: { term: { restricted: 'true' } } } })
   end
 
   it "should allow you to filter for recs" do

--- a/spec/models/bookmark_query_spec.rb
+++ b/spec/models/bookmark_query_spec.rb
@@ -36,24 +36,24 @@ describe BookmarkQuery do
 
   it "should not return bookmarks of hidden objects" do
     q = BookmarkQuery.new
-    expect(q.exclusion_filters).to include({ has_parent: { parent_type: 'bookmarkable', query: { term: { hidden_by_admin: 'true' } } } })
+    expect(q.exclusion_filters).to include(has_parent: { parent_type: 'bookmarkable', query: { term: { hidden_by_admin: 'true' } } })
   end
 
   it "should not return bookmarks of drafts" do
     q = BookmarkQuery.new
-    expect(q.exclusion_filters).to include({ has_parent: { parent_type: 'bookmarkable', query: { term: { posted: 'false' } } } })
+    expect(q.exclusion_filters).to include(has_parent: { parent_type: 'bookmarkable', query: { term: { posted: 'false' } } })
   end
 
   it "should not return restricted bookmarked works by default" do
     User.current_user = nil
     q = BookmarkQuery.new
-    expect(q.exclusion_filters).to include({ has_parent: { parent_type: 'bookmarkable', query: { term: { restricted: 'true' } } } })
+    expect(q.exclusion_filters).to include(has_parent: { parent_type: 'bookmarkable', query: { term: { restricted: 'true' } } })
   end
 
   it "should only return restricted bookmarked works when a user is logged in" do
     User.current_user = User.new
     q = BookmarkQuery.new
-    expect(q.exclusion_filters).not_to include({ has_parent: { parent_type: 'bookmarkable', query: { term: { restricted: 'true' } } } })
+    expect(q.exclusion_filters).not_to include(has_parent: { parent_type: 'bookmarkable', query: { term: { restricted: 'true' } } })
   end
 
   it "should allow you to filter for recs" do

--- a/spec/models/bookmarkable_query_spec.rb
+++ b/spec/models/bookmarkable_query_spec.rb
@@ -7,8 +7,10 @@ describe BookmarkableQuery do
       q = BookmarkableQuery.new
       q.bookmark_query = bookmark_query
       q.add_bookmark_filters
-      filters = q.generated_query.dig(:query, :bool, :filter, :bool, :must)
-      expect(filters).to include(term: { restricted: "false" })
+      excluded = q.generated_query.dig(:query, :bool, :filter, :bool, :must_not)
+      expect(excluded).to include(term: { restricted: "true" })
+      expect(excluded).to include(term: { hidden_by_admin: "true" })
+      expect(excluded).to include(term: { posted: "false" })
     end
 
     it "should take bookmark filters and combine them into one child query" do


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5340

## Purpose

The purpose of this pull request is to make sure that bookmarks of deleted items (works, series, or external works) don't completely disappear. In order to accomplish this, I made the following changes:

1. Modify the bookmarkable visibility filters in BookmarkQuery so that instead of requiring the bookmarkable be unhidden, unrestricted, and posted, it requires *not* having a hidden, restricted, or unposted bookmarkable. A non-existent bookmarkable can't have hidden_by_admin set to false, but it won't have hidden_by_admin set to true, so this reversal results in bookmarks of deleted works being included in searches. (This is inspired by Elz's plans several months ago.)

2. Modify the bookmark counts in the pseud search to include bookmarks of deleted works. In order to accomplish this, I slightly refactored the visible_to_all and visible_to_restricted_user scopes in the Bookmark class. This made it possible to construct a Bookmark relation that included bookmarks with a visible bookmarkable *or* with a missing bookmarkable.

3. Add a call to update_bookmarker_pseuds_index when a bookmarkable is destroyed.

## Testing

The bug report has steps for reproducing the bug.