### PR TITLE
AO3-5335 Fix dropdown ordering on error pages

### DIFF
--- a/public/500.html
+++ b/public/500.html
@@ -31,7 +31,7 @@
       <!-- BEGIN header -->
       <div id="header" class="region">
         <h1 class="heading">
-          <a href="/"><span>Archive of Our Own</span><sup> beta</sup><img alt="Archive of Our Own" class="logo" src="/images/ao3_logos/logo_42.png?1362864128" /></a> 
+          <a href="/"><span>Archive of Our Own</span><sup> beta</sup><img alt="Archive of Our Own" class="logo" src="/images/ao3_logos/logo_42.png?1362864128" /></a>
         </h1>
         <h3 class="landmark heading">Site Navigation</h3>
         <ul class="primary navigation actions" role="navigation">
@@ -65,8 +65,8 @@
             <a href="/menu/search">Search</a>
             <ul class="menu" role="menu">
               <li><a href="/works/search">Works</a></li>
-              <li><a href="/people/search">People</a></li>
               <li><a href="/bookmarks/search">Bookmarks</a></li>
+              <li><a href="/people/search">People</a></li>
               <li><a href="/tags/search">Tags</a></li>
             </ul>
           </li>
@@ -75,7 +75,8 @@
             <ul class="menu" role="menu">
               <li><a href="/about">About Us</a></li>
               <li><a href="/admin_posts">News</a></li>
-              <li><a href="/archive_faqs">FAQ</a></li>
+              <li><a href="/faq">FAQ</a></li>
+              <li><a href="/wrangling_guidelines">Wrangling Guidelines</a></li>
               <li><a href="/donate">Donate or Volunteer</a></li>
             </ul>
           </li>

--- a/public/500.html
+++ b/public/500.html
@@ -66,8 +66,8 @@
             <ul class="menu" role="menu">
               <li><a href="/works/search">Works</a></li>
               <li><a href="/bookmarks/search">Bookmarks</a></li>
-              <li><a href="/people/search">People</a></li>
               <li><a href="/tags/search">Tags</a></li>
+              <li><a href="/people/search">People</a></li>
             </ul>
           </li>
           <li class="dropdown">

--- a/public/502.html
+++ b/public/502.html
@@ -31,7 +31,7 @@
       <!-- BEGIN header -->
       <div id="header" class="region">
         <h1 class="heading">
-          <a href="/"><span>Archive of Our Own</span><sup> beta</sup><img alt="Archive of Our Own" class="logo" src="/images/ao3_logos/logo_42.png?1362864128" /></a> 
+          <a href="/"><span>Archive of Our Own</span><sup> beta</sup><img alt="Archive of Our Own" class="logo" src="/images/ao3_logos/logo_42.png?1362864128" /></a>
         </h1>
         <h3 class="landmark heading">Site Navigation</h3>
         <ul class="primary navigation actions" role="navigation">
@@ -65,8 +65,8 @@
             <a href="/menu/search">Search</a>
             <ul class="menu" role="menu">
               <li><a href="/works/search">Works</a></li>
-              <li><a href="/people/search">People</a></li>
               <li><a href="/bookmarks/search">Bookmarks</a></li>
+              <li><a href="/people/search">People</a></li>
               <li><a href="/tags/search">Tags</a></li>
             </ul>
           </li>
@@ -75,7 +75,8 @@
             <ul class="menu" role="menu">
               <li><a href="/about">About Us</a></li>
               <li><a href="/admin_posts">News</a></li>
-              <li><a href="/archive_faqs">FAQ</a></li>
+              <li><a href="/faq">FAQ</a></li>
+              <li><a href="/wrangling_guidelines">Wrangling Guidelines</a></li>
               <li><a href="/donate">Donate or Volunteer</a></li>
             </ul>
           </li>

--- a/public/502.html
+++ b/public/502.html
@@ -66,8 +66,8 @@
             <ul class="menu" role="menu">
               <li><a href="/works/search">Works</a></li>
               <li><a href="/bookmarks/search">Bookmarks</a></li>
-              <li><a href="/people/search">People</a></li>
               <li><a href="/tags/search">Tags</a></li>
+              <li><a href="/people/search">People</a></li>
             </ul>
           </li>
           <li class="dropdown">

--- a/public/503.html
+++ b/public/503.html
@@ -67,8 +67,8 @@
             <ul class="menu" role="menu">
               <li><a href="/works/search">Works</a></li>
               <li><a href="/bookmarks/search">Bookmarks</a></li>
-              <li><a href="/people/search">People</a></li>
               <li><a href="/tags/search">Tags</a></li>
+              <li><a href="/people/search">People</a></li>
             </ul>
           </li>
           <li class="dropdown">

--- a/public/503.html
+++ b/public/503.html
@@ -31,7 +31,7 @@
       <!-- BEGIN header -->
       <div id="header" class="region">
         <h1 class="heading">
-          <a href="/"><span>Archive of Our Own</span><sup> beta</sup><img alt="Archive of Our Own" class="logo" src="/images/ao3_logos/logo_42.png?1362864128" /></a> 
+          <a href="/"><span>Archive of Our Own</span><sup> beta</sup><img alt="Archive of Our Own" class="logo" src="/images/ao3_logos/logo_42.png?1362864128" /></a>
         </h1>
 
         <h3 class="landmark heading">Site Navigation</h3>
@@ -66,8 +66,8 @@
             <a href="/menu/search">Search</a>
             <ul class="menu" role="menu">
               <li><a href="/works/search">Works</a></li>
-              <li><a href="/people/search">People</a></li>
               <li><a href="/bookmarks/search">Bookmarks</a></li>
+              <li><a href="/people/search">People</a></li>
               <li><a href="/tags/search">Tags</a></li>
             </ul>
           </li>
@@ -76,7 +76,8 @@
             <ul class="menu" role="menu">
               <li><a href="/about">About Us</a></li>
               <li><a href="/admin_posts">News</a></li>
-              <li><a href="/archive_faqs">FAQ</a></li>
+              <li><a href="/faq">FAQ</a></li>
+              <li><a href="/wrangling_guidelines">Wrangling Guidelines</a></li>
               <li><a href="/donate">Donate or Volunteer</a></li>
             </ul>
           </li>

--- a/public/507.html
+++ b/public/507.html
@@ -67,8 +67,8 @@
             <ul class="menu" role="menu">
               <li><a href="/works/search">Works</a></li>
               <li><a href="/bookmarks/search">Bookmarks</a></li>
-              <li><a href="/people/search">People</a></li>
               <li><a href="/tags/search">Tags</a></li>
+              <li><a href="/people/search">People</a></li>
             </ul>
           </li>
           <li class="dropdown">

--- a/public/507.html
+++ b/public/507.html
@@ -31,7 +31,7 @@
       <!-- BEGIN header -->
       <div id="header" class="region">
         <h1 class="heading">
-          <a href="/"><span>Archive of Our Own</span><sup> beta</sup><img alt="Archive of Our Own" class="logo" src="/images/ao3_logos/logo_42.png?1362864128" /></a> 
+          <a href="/"><span>Archive of Our Own</span><sup> beta</sup><img alt="Archive of Our Own" class="logo" src="/images/ao3_logos/logo_42.png?1362864128" /></a>
         </h1>
 
         <h3 class="landmark heading">Site Navigation</h3>
@@ -66,8 +66,8 @@
             <a href="/menu/search">Search</a>
             <ul class="menu" role="menu">
               <li><a href="/works/search">Works</a></li>
-              <li><a href="/people/search">People</a></li>
               <li><a href="/bookmarks/search">Bookmarks</a></li>
+              <li><a href="/people/search">People</a></li>
               <li><a href="/tags/search">Tags</a></li>
             </ul>
           </li>
@@ -76,7 +76,8 @@
             <ul class="menu" role="menu">
               <li><a href="/about">About Us</a></li>
               <li><a href="/admin_posts">News</a></li>
-              <li><a href="/archive_faqs">FAQ</a></li>
+              <li><a href="/faq">FAQ</a></li>
+              <li><a href="/wrangling_guidelines">Wrangling Guidelines</a></li>
               <li><a href="/donate">Donate or Volunteer</a></li>
             </ul>
           </li>

--- a/public/nomaintenance.html
+++ b/public/nomaintenance.html
@@ -31,7 +31,7 @@
       <!-- BEGIN header -->
       <div id="header" class="region">
         <h1 class="heading">
-          <a href="/"><span>Archive of Our Own</span><sup> beta</sup><img alt="Archive of Our Own" class="logo" src="/images/ao3_logos/logo_42.png?1362864128" /></a> 
+          <a href="/"><span>Archive of Our Own</span><sup> beta</sup><img alt="Archive of Our Own" class="logo" src="/images/ao3_logos/logo_42.png?1362864128" /></a>
         </h1>
         <h3 class="landmark heading">Site Navigation</h3>
         <ul class="primary navigation actions" role="navigation">
@@ -65,9 +65,9 @@
             <a href="/menu/search">Search</a>
             <ul class="menu" role="menu">
               <li><a href="/works/search">Works</a></li>
-              <li><a href="/people/search">People</a></li>
               <li><a href="/bookmarks/search">Bookmarks</a></li>
               <li><a href="/tags/search">Tags</a></li>
+              <li><a href="/people/search">People</a></li>
             </ul>
           </li>
           <li class="dropdown">
@@ -75,7 +75,8 @@
             <ul class="menu" role="menu">
               <li><a href="/about">About Us</a></li>
               <li><a href="/admin_posts">News</a></li>
-              <li><a href="/archive_faqs">FAQ</a></li>
+              <li><a href="/faq">FAQ</a></li>
+              <li><a href="/wrangling_guidelines">Wrangling Guidelines</a></li>
               <li><a href="/donate">Donate or Volunteer</a></li>
             </ul>
           </li>


### PR DESCRIPTION
- "Search" dropdown now has Bookmarks and People in the correct order
- "FAQ" in the "About" dropdown now links to the correct FAQ page
- "About" dropdown now contains Wrangling Guidelines link

# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [x] Have you added tests for any changed functionality?
* [x] Have you added the JIRA issue number as the *first* thing in your pull request title (eg: `AO3-1234 Fix thing`)
* [x] Have you updated the JIRA issue with the information below?

(Not sure how to request access for your JIRA board.)

## Issue

https://otwarchive.atlassian.net/browse/AO3-5335

## Purpose

Updates the 500.html public-facing page with the correct links/ordering for dropdown menus.

## Testing

Visit the Archive with a standard public-facing page (such as the index) and compare the Search and About dropdown menus on the navigation bar with these changes.

## References

None.

## Credit

*What name do you want us to use to credit your work in the [Archive of Our Own's Release Notes](http://archiveofourown.org/admin_posts?tag=1)?*

*What pronouns do you prefer (she/her, he/him, zie/hir etc)?*

digitalAlchemist, he/him