### PR TITLE
AO3-5358 Fix intermittent test failure in pseud searches

### DIFF
--- a/spec/models/pseud_search_form_spec.rb
+++ b/spec/models/pseud_search_form_spec.rb
@@ -57,11 +57,13 @@ describe PseudSearchForm do
   end
 
   context "pseud index of bookmarkers" do
+    let(:bookmarker) { create(:pseud, name: "bookmarkermit") }
+
     it "updates when bookmarked work changes restricted status" do
       work = create(:posted_work)
       expect(work.restricted).to be_falsy
 
-      bookmark = create(:bookmark, bookmarkable_id: work.id)
+      bookmark = create(:bookmark, bookmarkable_id: work.id, pseud: bookmarker)
       run_all_indexing_jobs
       result = PseudSearchForm.new(name: bookmark.pseud.name).search_results.first
       expect(result).to eq bookmark.pseud
@@ -91,7 +93,7 @@ describe PseudSearchForm do
       serial_work = create(:serial_work, series: series)
       expect(series.restricted).to be_falsy
 
-      bookmark = create(:bookmark, bookmarkable_id: series.id, bookmarkable_type: "Series")
+      bookmark = create(:bookmark, bookmarkable_id: series.id, bookmarkable_type: "Series", pseud: bookmarker)
       run_all_indexing_jobs
       result = PseudSearchForm.new(name: bookmark.pseud.name).search_results.first
       expect(result).to eq bookmark.pseud
@@ -118,16 +120,16 @@ describe PseudSearchForm do
     end
 
     {
-      "Work" => :posted_work,
-      "Series" => :series_with_a_work,
-      "ExternalWork" => :external_work
+      Work => :posted_work,
+      Series => :series_with_a_work,
+      ExternalWork => :external_work
     }.each_pair do |type, factory|
       it "updates when bookmarked #{type} changes hidden by admin status" do
         bookmarkable = create(factory)
         expect(bookmarkable.restricted).to be_falsy
         expect(bookmarkable.hidden_by_admin).to be_falsy
 
-        bookmark = create(:bookmark, bookmarkable_id: bookmarkable.id, bookmarkable_type: type)
+        bookmark = create(:bookmark, bookmarkable_id: bookmarkable.id, bookmarkable_type: type, pseud: bookmarker)
         run_all_indexing_jobs
         result = PseudSearchForm.new(name: bookmark.pseud.name).search_results.first
         expect(result).to eq bookmark.pseud


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5358

## Purpose

Stop using randomly-generated bookmarker pseud names.

## Testing

No manual testing required. I had this run 10 times without failures on Travis by changing .travis.yml to use:

```yml
env:
  - ES=1 TEST_GROUP="rspec spec" RUN=1
  - ES=1 TEST_GROUP="rspec spec" RUN=2
  - ES=1 TEST_GROUP="rspec spec" RUN=3
  - ES=1 TEST_GROUP="rspec spec" RUN=4
  - ES=1 TEST_GROUP="rspec spec" RUN=5
  - ES=1 TEST_GROUP="rspec spec" RUN=6
  - ES=1 TEST_GROUP="rspec spec" RUN=7
  - ES=1 TEST_GROUP="rspec spec" RUN=8
  - ES=1 TEST_GROUP="rspec spec" RUN=9
  - ES=1 TEST_GROUP="rspec spec" RUN=10
```

The `RUN=X` part needs to be there, otherwise Travis smartly spawns only one job for 10 identical `env` entries.