### PR TITLE
AO3-5305 Fix new-search feature tests for Codeship

### DIFF
--- a/features/support/hooks.rb
+++ b/features/support/hooks.rb
@@ -20,3 +20,9 @@ Before do
 
   step %{all search indexes are completely regenerated}
 end
+
+# ES UPGRADE TRANSITION #
+# Remove hook
+Before '@new-search' do
+  $rollout.activate :use_new_search
+end


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5305

## Purpose

The new UI is only enabled if ES 0.90 is not running. This is not a problem for the Travis build where there's only one active ES version per job, and new/old-search-only tests are disabled accordingly.

In the Codeship build, both ES versions are always active, which means the new UI is not available. We need to enable it specifically for the tests tagged new-search.

## Testing

Codeship should pass.