### PR TITLE
AO3-5305 Try to fix bookmark sorting.

### DIFF
--- a/app/models/search/bookmark_query.rb
+++ b/app/models/search/bookmark_query.rb
@@ -129,13 +129,21 @@ class BookmarkQuery < Query
   # SORTING AND AGGREGATIONS
   ####################
 
-  def sort
-    column = options[:sort_column].present? ? options[:sort_column] : 'created_at'
-    direction = options[:sort_direction].present? ? options[:sort_direction] : 'desc'
-    sort_hash = { column => { order: direction } }
+  def sort_column
+    @sort_column ||=
+      options[:sort_column].present? ? options[:sort_column] : "created_at"
+  end
 
-    if %w(created_at bookmarkable_date).include?(column)
-      sort_hash[column][:unmapped_type] = 'date'
+  def sort_direction
+    @sort_direction ||=
+      options[:sort_direction].present? ? options[:sort_direction] : "desc"
+  end
+
+  def sort
+    sort_hash = { sort_column => { order: sort_direction } }
+
+    if %w(created_at bookmarkable_date).include?(sort_column)
+      sort_hash[sort_column][:unmapped_type] = 'date'
     end
 
     sort_hash

--- a/app/models/search/query.rb
+++ b/app/models/search/query.rb
@@ -72,8 +72,18 @@ class Query
     { terms: options.merge(field => value) }
   end
 
-  def field_value_score(field)
-    { function_score: { field_value_factor: { field: field } } }
+  # Set the score equal to the value of a field. The optional value "missing"
+  # determines what score value should be used if the specified field is
+  # missing from a document.
+  def field_value_score(field, missing: 0)
+    {
+      function_score: {
+        field_value_factor: {
+          field: field,
+          missing: missing
+        }
+      }
+    }
   end
 
   def bool_value(str)

--- a/spec/models/bookmark_search_form_spec.rb
+++ b/spec/models/bookmark_search_form_spec.rb
@@ -74,7 +74,7 @@ describe BookmarkSearchForm do
       context "by Date Bookmarked" do
         it "returns bookmarkables in the correct order" do
           results = BookmarkSearchForm.new(
-            parent: tag, sort_column: "date"
+            parent: tag, sort_column: "created_at"
           ).bookmarkable_search_results
           expect(results.map(&:title)).to eq ["Two", "Three", "One"]
         end
@@ -83,7 +83,7 @@ describe BookmarkSearchForm do
           create(:bookmark, bookmarkable: work1)
           run_all_indexing_jobs
           results = BookmarkSearchForm.new(
-            parent: tag, sort_column: "date"
+            parent: tag, sort_column: "created_at"
           ).bookmarkable_search_results
           expect(results.map(&:title)).to eq ["One", "Two", "Three"]
         end


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5305

## Purpose

There's a bug in the new bookmarkable query code: it's using the wrong name for the "Date Bookmarked" sort setting. (And it's also not handling a blank value for options[:sort_column] properly.) This pull request fixes that.

## Testing

View the bookmarks for a Tag or a Collection and check the date of the first bookmarked item for each bookmarkable. They should be in decreasing order.