### PR TITLE
AO3-5361 Link text and alignment changes for bookmarks

### DIFF
--- a/app/views/bookmarks/_bookmarkable_blurb.html.erb
+++ b/app/views/bookmarks/_bookmarkable_blurb.html.erb
@@ -50,7 +50,7 @@
 
   <ul class="actions" role="navigation">
     <li id="recent_link_<%= bookmarkable.id %>" class="showme">
-      <%= link_to ts("View All"),
+      <%= link_to ts("All Bookmarks"),
                   polymorphic_path([bookmarkable, Bookmark]),
                   class: "actions" %>
     </li>

--- a/public/stylesheets/site/2.0/13-group-blurb.css
+++ b/public/stylesheets/site/2.0/13-group-blurb.css
@@ -368,10 +368,14 @@ blurbs on the manage collection items pages, mostly reseting styles inherited fr
 }
 
 .bookmark .short .status {
-	left: 30px;
+	left: 0;
 	margin-top: 0;
 	top: 0;
 	width: 25px;
+}
+
+.bookmark .short .header h5 {
+  margin-left: 35px;
 }
 
 .bookmark .dynamic {


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5361

## Purpose

On a tag's bookmark page, change the link text from "View All" to "All Bookmarks." On that page and on an item's bookmark page, moves icon and "Bookmarked by" info a smidge to the left.

## Testing

Refer to Jira


