### PR TITLE
AO3-5274 In filters, text of selected tag not bolded on old browsers

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -555,6 +555,6 @@ module ApplicationHelper
   # spans for nesting a checkbox or radio button inside its label to make custom
   # checkbox or radio designs
   def label_indicator_and_text(text)
-    content_tag(:span, "", class: "indicator", "aria-hidden": "true") + content_tag(:span, class: "label",  text)
+    content_tag(:span, "", class: "indicator", "aria-hidden": "true") + content_tag(:span, text, class: "label")
   end
 end # end of ApplicationHelper

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -555,6 +555,6 @@ module ApplicationHelper
   # spans for nesting a checkbox or radio button inside its label to make custom
   # checkbox or radio designs
   def label_indicator_and_text(text)
-    content_tag(:span, "", class: "indicator", "aria-hidden": "true") + content_tag(:span, text)
+    content_tag(:span, "", class: "indicator", "aria-hidden": "true") + content_tag(:span, class: "label",  text)
   end
 end # end of ApplicationHelper

--- a/public/stylesheets/site/2.0/18-zone-searchbrowse.css
+++ b/public/stylesheets/site/2.0/18-zone-searchbrowse.css
@@ -187,7 +187,7 @@ form.filters {
   border-color: #aaa;
 }
 
-.filters input:checked + .indicator + span {
+.filters input:checked ~ .label {
   font-weight: 700;
 }
 


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5274

## Purpose

Changes the selector we use to bold the name of checked tags in the filters because Safari 8 and 9 don't support the one we use. This might not work.

## Testing

Use the filter checkboxes in older versions of Safari.

