### PR TITLE
AO3-5364 Turn collection bookmark counts into bookmarked item counts for new search.

### DIFF
--- a/app/controllers/bookmarks_controller.rb
+++ b/app/controllers/bookmarks_controller.rb
@@ -44,7 +44,7 @@ class BookmarksController < ApplicationController
     options = params[:bookmark_search].present? ? bookmark_search_params : {}
     options.merge!(page: params[:page]) if params[:page].present?
     options[:show_private] = false
-    options[:show_restricted] = current_user.present?
+    options[:show_restricted] = logged_in? || logged_in_as_admin?
     # ES UPGRADE TRANSITION #
     # Remove conditional and call to BookmarkSearch
     if use_new_search?
@@ -69,7 +69,7 @@ class BookmarksController < ApplicationController
     else
       base_options = {
         show_private: (@user.present? && @user == current_user),
-        show_restricted: current_user.present?,
+        show_restricted: logged_in? || logged_in_as_admin?,
         page: params[:page]
       }
 

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -343,8 +343,8 @@ class Collection < ApplicationRecord
     # Note that "approved_by_collection" forces the bookmarks to be approved
     # both by the collection AND by the user.
     bookmarks = Bookmark.is_public.joins(:collection_items).
-      merge(CollectionItem.approved_by_collection).
-      where(collection_items: { collection_id: children.ids + [id] })
+                merge(CollectionItem.approved_by_collection).
+                where(collection_items: { collection_id: children.ids + [id] })
 
     logged_in = User.current_user.present?
 

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -335,6 +335,29 @@ class Collection < ApplicationRecord
     count
   end
 
+  # Return the count of all bookmarkable items (works, series, external works)
+  # that are in this collection (or any of its children) and visible to
+  # the current user. Excludes bookmarks of deleted works/series.
+  def all_bookmarked_items_count
+    # The set of all bookmarks in this collection and its children.
+    # Note that "approved_by_collection" forces the bookmarks to be approved
+    # both by the collection AND by the user.
+    bookmarks = Bookmark.is_public.joins(:collection_items).
+      merge(CollectionItem.approved_by_collection).
+      where(collection_items: { collection_id: children.ids + [id] })
+
+    logged_in = User.current_user.present?
+
+    [
+      logged_in ? Work.visible_to_registered_user : Work.visible_to_all,
+      logged_in ? Series.visible_to_registered_user : Series.visible_to_all,
+      ExternalWork.visible_to_all
+    ].map do |relation|
+      relation.joins(:bookmarks).merge(bookmarks).distinct.
+        count("bookmarks.bookmarkable_id")
+    end.sum
+  end
+
   def all_fandoms
     # We want filterable fandoms, but not inherited metatags:
     Fandom.for_collections([self] + children).

--- a/app/sweepers/challenge_signup_sweeper.rb
+++ b/app/sweepers/challenge_signup_sweeper.rb
@@ -39,8 +39,7 @@ class ChallengeSignupSweeper < ActionController::Caching::Sweeper
         ActionController::Base.new.expire_fragment("collection-#{collection.id}-request-#{request.id}")
         # expire the prompt summary too - done in the model
         # and the collection blurb, for the stats
-        ActionController::Base.new.expire_fragment("collection-blurb-#{collection.id}-v3")
-        ActionController::Base.new.expire_fragment("collection-profile-#{collection.id}")
+        CollectionSweeper.expire_collection_blurb_and_profile(collection)
       end
       # expire the signup summary, for prompt meme challenge prompts index
       ActionController::Base.new.expire_fragment("collection-#{collection.id}-signup-#{record.id}")

--- a/app/sweepers/collection_sweeper.rb
+++ b/app/sweepers/collection_sweeper.rb
@@ -54,6 +54,9 @@ class CollectionSweeper < ActionController::Caching::Sweeper
   def self.expire_collection_blurb_and_profile(collection)
     # Expire all versions of the blurb: whether the new search is enabled or
     # not, and whether the user is logged in or not.
+    # TODO: After the ES6 upgrade, re-evaluate whether it's necessary to keep
+    # the new-search/old-search distinction for enabling/disabling filtering
+    # (and probably change the name if it is kept).
     %w[old-search new-search].product(%w[logged-in logged-out]).each do |pair|
       search, logged_in = pair
       cache_key = "collection-blurb-#{search}-#{logged_in}-#{collection.id}-v3"

--- a/app/views/collections/_collection_blurb.html.erb
+++ b/app/views/collections/_collection_blurb.html.erb
@@ -1,7 +1,9 @@
 <!-- this partial requires collection; @challenges_count, @works_count, @bookmarks_count must be set -->
 <li class="<% if collection.user_is_owner?(current_user) %>own <% end %>collection picture blurb group" role="article">
+  <% logged_in = (logged_in_as_admin? || logged_in?) ? "logged-in" : "logged-out" %>
+  <% old_search = @admin_settings.disable_filtering? || !use_new_search? %>
   <% # remember to update collection_sweeper and challenge_signup_sweeper if you change this %>
-  <% cache("collection-blurb-#{collection.id}-v3", skip_digest: true) do %>
+  <% cache("collection-blurb-#{old_search ? "old-search" : "new-search"}-#{logged_in}-#{collection.id}-v3", skip_digest: true) do %>
     <div class="header module group">
       <h4 class="heading">
         <%= link_to collection.title, collection_path(collection) %>
@@ -52,8 +54,9 @@
       <% end %>
       <dt><%= ts("Works:") %></dt>
       <dd><%= link_to(@works_count, collection_works_path(collection)) %></dd>
-      <% if (@bookmarks_count = collection.all_approved_bookmarks_count) > 0 %>
-        <dt><%= ts("Bookmarks:") %></dt>
+      <% @bookmarks_count = old_search ? collection.all_approved_bookmarks_count : collection.all_bookmarked_items_count %>
+      <% if @bookmarks_count > 0 %>
+        <dt><%= ts(old_search ? "Bookmarks:" : "Bookmarked Items:") %></dt>
         <dd><%= link_to(@bookmarks_count, collection_bookmarks_path(collection)) %></dd>
       <% end %>
     </dl>

--- a/app/views/collections/_sidebar.html.erb
+++ b/app/views/collections/_sidebar.html.erb
@@ -28,7 +28,11 @@
 
     <li><%= span_if_current ts("Works (%{count})", key: 'dashboard', :count => @collection.all_approved_works_count), collection_works_path(@collection) %></li>
 
-    <li><%= span_if_current ts("Bookmarks (%{count})", key: 'dashboard', :count => @collection.all_approved_bookmarks_count), collection_bookmarks_path(@collection) %></li>
+    <% if @admin_settings.disable_filtering? || !use_new_search? %>
+      <li><%= span_if_current ts("Bookmarks (%{count})", key: 'dashboard', :count => @collection.all_approved_bookmarks_count), collection_bookmarks_path(@collection) %></li>
+    <% else %>
+      <li><%= span_if_current ts("Bookmarked Items (%{count})", key: 'dashboard', :count => @collection.all_bookmarked_items_count), collection_bookmarks_path(@collection) %></li>
+    <% end %>
 
     <li>
       <% if controller.controller_name == 'collections' && controller.action_name == 'show' %>

--- a/features/collections/collectible_closed_collection.feature
+++ b/features/collections/collectible_closed_collection.feature
@@ -16,6 +16,7 @@ Feature: Collectible items in closed collections
     Then I should see "Works (0)"
       And I should not see "Blabla"
 
+  @old-search
   Scenario: Add my bookmark to a closed collection
     Given I have a bookmark for "Tundra penguins"
     When I add my bookmark to the collection "Various_Penguins"
@@ -24,3 +25,13 @@ Feature: Collectible items in closed collections
     Then I should see "Bookmarks (0)"
       And I should not see "Tundra penguins"
 
+  # This is the same as the test above, but with the sidebar text updated to
+  # reflect the new bookmarked item listings.
+  @new-search
+  Scenario: Add my bookmark to a closed collection
+    Given I have a bookmark for "Tundra penguins"
+    When I add my bookmark to the collection "Various_Penguins"
+    Then I should see "is closed"
+    When I go to "Various Penguins" collection's page
+    Then I should see "Bookmarked Items (0)"
+      And I should not see "Tundra penguins"

--- a/features/collections/collectible_moderated_collection.feature
+++ b/features/collections/collectible_moderated_collection.feature
@@ -26,12 +26,24 @@ Feature: Collectible items in moderated collections
     When I press "Update"
     Then I should see "the moderated collection 'Various Penguins'"
 
+  @old-search
   Scenario: Add my bookmark to a moderated collection
     Given I have a bookmark for "Tundra penguins"
     When I add my bookmark to the collection "Various_Penguins"
     Then I should see "until it has been approved by a moderator."
     When I go to "Various Penguins" collection's page
     Then I should see "Bookmarks (0)"
+      And I should not see "Tundra penguins"
+
+  # This is the same as the test above, but with the sidebar text updated to
+  # reflect the new bookmarked item listings.
+  @new-search
+  Scenario: Add my bookmark to a moderated collection
+    Given I have a bookmark for "Tundra penguins"
+    When I add my bookmark to the collection "Various_Penguins"
+    Then I should see "until it has been approved by a moderator."
+    When I go to "Various Penguins" collection's page
+    Then I should see "Bookmarked Items (0)"
       And I should not see "Tundra penguins"
 
   Scenario: Bookmarks of deleted items are included on a moderated collection's

--- a/features/collections/collectible_open_collection.feature
+++ b/features/collections/collectible_open_collection.feature
@@ -24,12 +24,24 @@ Feature: Collectible items
     Then I should see "Works (1)"
       And I should see "Blabla"
 
+  @old-search
   Scenario: Add my bookmark to a collection
     Given I have a bookmark for "Tundra penguins"
     When I add my bookmark to the collection "Various_Penguins"
     Then I should see "Added"
     When I go to "Various Penguins" collection's page
     Then I should see "Bookmarks (1)" within "#dashboard"
+      And I should see "Tundra penguins"
+
+  # This is the same as the test above, but with the sidebar text updated to
+  # reflect the new bookmarked item listings.
+  @new-search
+  Scenario: Add my bookmark to a collection
+    Given I have a bookmark for "Tundra penguins"
+    When I add my bookmark to the collection "Various_Penguins"
+    Then I should see "Added"
+    When I go to "Various Penguins" collection's page
+    Then I should see "Bookmarked Items (1)" within "#dashboard"
       And I should see "Tundra penguins"
 
   Scenario: Bookmarks of deleted items are included on the collection's Manage

--- a/features/collections/collection_navigation.feature
+++ b/features/collections/collection_navigation.feature
@@ -38,9 +38,10 @@ Feature: Basic collection navigation
   When I follow "Works (1)"
   Then I should see "Work for my collection by mod"
     And I should see "1 Work in My Collection"
-  When I follow "Bookmarks (0)"
-  # Depending on whether the new search is enabled, I may see "0 Bookmarks" or
-  # "0 Bookmarked Items" so for simplicity, we look for "0 Bookmark":
+  # Depending on whether the new search is enabled, I may see "Bookmarks" or
+  # "Bookmarked Items," both in the sidebar link and at the top of the
+  # bookmark page. So in both cases, we look for "Bookmark":
+  When I follow "Bookmark" within "#dashboard"
   Then I should see "0 Bookmark"
   When I follow "Random Items"
   Then I should see "Work for my collection by mod"

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -72,4 +72,44 @@ describe Collection do
       end # moderated_status loop
     end # challenges type loop
   end
+
+  describe "all_bookmarked_items_count" do
+    let(:collection) { create(:collection) }
+
+    it "does not include bookmarks of deleted works" do
+      work = create(:posted_work)
+      create(:bookmark, collections: [collection], bookmarkable: work)
+      expect do
+        work.destroy
+      end.to change { collection.all_bookmarked_items_count }.from(1).to(0)
+    end
+
+    it "does not include multiple bookmarks of the same work" do
+      work = create(:posted_work)
+      create(:bookmark, collections: [collection], bookmarkable: work)
+      create(:bookmark, collections: [collection], bookmarkable: work)
+      expect(collection.all_bookmarked_items_count).to eq 1
+    end
+
+    it "doesn't include private bookmarks" do
+      create(:bookmark, collections: [collection], private: true)
+      expect(collection.all_bookmarked_items_count).to eq 0
+    end
+
+    it "includes bookmarks of restricted works only when logged-in" do
+      work = create(:posted_work, restricted: true)
+      create(:bookmark, collections: [collection], bookmarkable: work)
+      expect do
+        User.current_user = User.new
+      end.to change { collection.all_bookmarked_items_count }.from(0).to(1)
+    end
+
+    it "counts bookmarks of all types" do
+      %i[posted_work series_with_a_work external_work].each do |factory|
+        item = create(factory)
+        create(:bookmark, collections: [collection], bookmarkable: item)
+      end
+      expect(collection.all_bookmarked_items_count).to eq 3
+    end
+  end
 end


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5364

## Purpose

This PR makes the bookmark counts in the sidebar of collections into *bookmarked item* counts, instead. It also changes the count in blurbs on the Browse > Collections page to match the sidebar counts, as well. (Since that blurb is cached, this necessitated some changes to the cache key to account for the difference in count and label when logged in/logged out or using new search/old search. Which in turn required some changes to the sweepers.)

I also noticed while testing that bookmark search and bookmark listings don't show bookmarks of restricted works to admins, so I fixed that to make sure that the numbers are consistent even when logged in as admin.

## Testing

1. While logged in as an admin, check the bookmark count in the collection's sidebar to make sure it matches the number in the header of the collection's /bookmarks page. Also check the number in the collection's blurb on a /collections listing (perhaps on a parent collection's "Subcollections" page).
2. While logged in as a regular user, check the same three numbers.
3. While logged out, check the same three numbers.