### PR TITLE
AO3-5331 Try to fix handling of non-existent tag names in work search and bookmark listings.

### DIFF
--- a/app/models/search/query.rb
+++ b/app/models/search/query.rb
@@ -72,6 +72,14 @@ class Query
     { terms: options.merge(field => value) }
   end
 
+  # A filter used to match all words in a particular field, most frequently
+  # used for matching non-existent tags. The match query doesn't allow
+  # negation/or/and/wildcards, so it should only be used on fields where the
+  # users are expected to enter, e.g. canonical tags.
+  def match_filter(field, value, options = {})
+    { match: { field => { query: value, operator: "and" }.merge(options) } }
+  end
+
   # Set the score equal to the value of a field. The optional value "missing"
   # determines what score value should be used if the specified field is
   # missing from a document.

--- a/app/models/search/taggable_query.rb
+++ b/app/models/search/taggable_query.rb
@@ -10,8 +10,8 @@ module TaggableQuery
         @filter_ids += ids.is_a?(Array) ? ids : [ids]
       end
     end
-    @filter_ids += named_tags
-    @filter_ids.uniq
+    @filter_ids += parsed_included_tags[:ids]
+    @filter_ids = @filter_ids.uniq
   end
 
   def exclusion_ids
@@ -19,21 +19,65 @@ module TaggableQuery
     return if options[:excluded_tag_names].blank? && options[:excluded_tag_ids].blank?
 
     ids = options[:excluded_tag_ids] || []
-    names = options[:excluded_tag_names]&.split(",")
-    ids += Tag.where(name: names).pluck(:id) if names
+    ids += parsed_excluded_tags[:ids]
     ids += Tag.where(id: ids).pluck(:merger_id)
     @exclusion_ids = ids.uniq.compact
   end
 
-  # Get the ids for tags passed in by name
-  def named_tags
-    names = []
-    %w(fandom character relationship freeform other_tag).each do |tag_type|
-      tag_names_key = "#{tag_type}_names".to_sym
-      if options[tag_names_key].present?
-        names += options[tag_names_key].split(",")
-      end
-    end
-    Tag.where(name: names).pluck(:id)
+  # Returns a list of tag names that should be included in all results. Only
+  # returns the ones that aren't in the database, because the ones that are in
+  # the database will be covered by the filter_ids function.
+  def included_tag_names
+    parsed_included_tags[:missing]
+  end
+
+  # Returns parse_named_tags of all of the fields used to include tag names.
+  def parsed_included_tags
+    @parsed_included_tags ||= parse_named_tags(
+      %i[fandom_names character_names relationship_names freeform_names
+         other_tag_names]
+    )
+  end
+
+  # Returns a list of tag names that should be excluded from all results. Only
+  # returns the ones that aren't in the database, because the ones that are in
+  # the database will be covered by the exclusion_ids function.
+  def excluded_tag_names
+    parsed_excluded_tags[:missing]
+  end
+
+  # Returns parse_named_tags of all of the fields used to exclude tag names.
+  def parsed_excluded_tags
+    @parsed_excluded_tags ||= parse_named_tags(%i[excluded_tag_names])
+  end
+
+  # Uses the database to look up all of the tag names listed in the passed-in
+  # fields. Returns a hash with the following format:
+  #   {
+  #     ids: [1, 2, 3],
+  #     missing: ["missing tag name", "other missing"]
+  #   }
+  def parse_named_tags(fields)
+    names = all_tag_names(fields)
+    found = if names.present?
+              Tag.where(name: names).pluck(:id, :name)
+            else
+              []
+            end
+
+    {
+      ids: found.map(&:first),
+      missing: (names - found.map(&:second)).uniq
+    }
+  end
+
+  # Parse the options for each of the passed-in fields, treating each one as a
+  # comma-separated list of tags. Returns the list of all tags, with blank and
+  # duplicate tags removed.
+  def all_tag_names(fields)
+    fields.flat_map do |field|
+      next if options[field].blank?
+      options[field].split(",").map(&:squish)
+    end.reject(&:blank?).uniq
   end
 end

--- a/app/models/search/work_search_form.rb
+++ b/app/models/search/work_search_form.rb
@@ -118,16 +118,8 @@ class WorkSearchForm
     if @options[:creators].present?
       summary << "Author/Artist: #{@options[:creators]}"
     end
-    tags = []
-    if @options[:tag].present?
-      tags << @options[:tag]
-    end
-    all_tag_ids = []
-    [:filter_ids, :fandom_ids, :rating_ids, :category_ids, :warning_ids, :character_ids, :relationship_ids, :freeform_ids].each do |tag_ids|
-      if @options[tag_ids].present?
-        all_tag_ids += @options[tag_ids]
-      end
-    end
+    tags = @searcher.included_tag_names
+    all_tag_ids = @searcher.filter_ids
     unless all_tag_ids.empty?
       tags << Tag.where(id: all_tag_ids).pluck(:name).join(", ")
     end

--- a/features/search/filters.feature
+++ b/features/search/filters.feature
@@ -73,6 +73,26 @@ Feature: Filters
       And I should not see "Roonal Woozlib and the Ferrets of Nimh"
 
   @javascript
+  Scenario: Filter through a user's works with non-existent tags
+    Given the tag "legend korra" does not exist
+
+    When I go to meatloaf's works page
+      And I fill in "Other tags to include" with "legend korra"
+      And I press "Sort and Filter"
+    Then I should see "1 Work by meatloaf"
+      And I should see "Bilbo Does the Thing"
+      And I should not see "A Hobbit's Meandering"
+      And I should not see "Roonal Woozlib and the Ferrets of Nimh"
+
+    When I go to meatloaf's works page
+      And I fill in "Other tags to exclude" with "legend korra"
+      And I press "Sort and Filter"
+    Then I should see "2 Works by meatloaf"
+      And I should not see "Bilbo Does the Thing"
+      And I should see "A Hobbit's Meandering"
+      And I should see "Roonal Woozlib and the Ferrets of Nimh"
+
+  @javascript
   Scenario: You can filter through a user's bookmarks using inclusion filters
     Given I am logged in as "recengine"
       And recengine can use the new search
@@ -195,6 +215,43 @@ Feature: Filters
       And I should not see "Bilbo Does the Thing"
       And I should not see "A Hobbit's Meandering"
       And I should see "Roonal Woozlib and the Ferrets of Nimh"
+
+  @javascript
+  Scenario: Filter a user's bookmarks by non-existent tags
+    Given the tag "legend korra" does not exist
+      And the tag "fun crossover" does not exist
+      And I am logged in as "recengine"
+      And recengine can use the new search
+      And I bookmark the work "A Hobbit's Meandering" with the tags "fun"
+      And I bookmark the work "Bilbo Does the Thing" with the tags "fun little crossover"
+
+    When I go to my bookmarks page
+      And I fill in "Other work tags to include" with "legend korra"
+      And I press "Sort and Filter"
+    Then I should see "1 Bookmark by recengine"
+      And I should not see "A Hobbit's Meandering"
+      And I should see "Bilbo Does the Thing"
+
+    When I go to my bookmarks page
+      And I fill in "Other work tags to exclude" with "legend korra"
+      And I press "Sort and Filter"
+    Then I should see "1 Bookmark by recengine"
+      And I should see "A Hobbit's Meandering"
+      And I should not see "Bilbo Does the Thing"
+
+    When I go to my bookmarks page
+      And I fill in "Other bookmarker's tags to include" with "fun crossover"
+      And I press "Sort and Filter"
+    Then I should see "1 Bookmark by recengine"
+      And I should not see "A Hobbit's Meandering"
+      And I should see "Bilbo Does the Thing"
+
+    When I go to my bookmarks page
+      And I fill in "Other bookmarker's tags to exclude" with "fun crossover"
+      And I press "Sort and Filter"
+    Then I should see "1 Bookmark by recengine"
+      And I should see "A Hobbit's Meandering"
+      And I should not see "Bilbo Does the Thing"
 
   @javascript @old-search
   Scenario: The filter counts should match the actual returned count


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5331

## Purpose

When non-existent tag names are entered into various fields, the search behavior is wrong:

1. When entered into the tag fields on the work search form, or the "Other tags to include" field on work listings, all non-existent tag names are concatenated and searched for in quotes (forcing all of the tag names to appear in order with no gaps).
2. When entered into any of the fields "Other work tags to include," "Other work tags to exclude," "Other bookmarker's tags to include," or "Other bookmarker's tags to exclude," on bookmark listings, or "Other tags to exclude" on work listings, non-existent tags disappear without a trace. They don't constrain the query at all.

This PR refactors the code for handling named tags. Given a list of named tags, it finds all tags in the database matching those names, and keeps **both** the IDs of the tags found, and the names of the tags that weren't found. It keeps track of both lists, making it possible to add `match` filters that check the `tag` field for a text match.

I switched over to using `match` instead of `query_string` because (a) the way that the query was generated before meant that tags could not take advantage of `query_string`'s features, (b) using `match` means that we're not required to escape characters like `/`, and (c) in my tests, `match` is marginally faster than `query_string`.

## Testing

The bug report and its comments have several details about how to reproduce the issue.