### PR TITLE
AO3-5363 Split "Any field" and "Tag" fields on bookmark search

### DIFF
--- a/app/controllers/bookmarks_controller.rb
+++ b/app/controllers/bookmarks_controller.rb
@@ -370,10 +370,16 @@ class BookmarksController < ApplicationController
 
   def bookmark_search_params
     params.require(:bookmark_search).permit(
+      # ES UPGRADE TRANSITION #
+      # Remove fields for only BookmarkSearch: query, tag
       :query,
+      :bookmark_query,
+      :bookmarkable_query,
       :bookmarker,
       :bookmark_notes,
       :tag,
+      :bookmark_tag,
+      :bookmarkable_tag,
       :rec,
       :with_notes,
       :bookmarkable_type,

--- a/app/controllers/bookmarks_controller.rb
+++ b/app/controllers/bookmarks_controller.rb
@@ -378,8 +378,6 @@ class BookmarksController < ApplicationController
       :bookmarker,
       :bookmark_notes,
       :tag,
-      :bookmark_tag,
-      :bookmarkable_tag,
       :rec,
       :with_notes,
       :bookmarkable_type,

--- a/app/models/search/bookmark_query.rb
+++ b/app/models/search/bookmark_query.rb
@@ -102,7 +102,6 @@ class BookmarkQuery < Query
     query_text = (options[:bookmark_query] || "").dup
     query_text << split_query_text_words(:bookmarker, options[:bookmarker])
     query_text << split_query_text_words(:notes, options[:notes])
-    query_text << split_query_text_phrases(:tag, options[:bookmark_tag])
     escape_slashes(query_text.strip)
   end
 

--- a/app/models/search/bookmark_query.rb
+++ b/app/models/search/bookmark_query.rb
@@ -33,10 +33,11 @@ class BookmarkQuery < Query
     QueryResult.new(klass, response, options.slice(:page, :per_page))
   end
 
-  # Currently, we only have one query:
+  # Combine the query on the bookmark with the query on the bookmarkable.
   def queries
     @queries ||= [
-      query
+      bookmark_query_or_filter,
+      parent_bookmarkable_query_or_filter
     ].flatten.compact
   end
 
@@ -81,49 +82,28 @@ class BookmarkQuery < Query
   # QUERIES
   ####################
 
-  # Instead of doing a standard query, which would only match bookmark fields
-  # we'll make this a should query that will try to match either the bookmark
-  # or its parent
-  # TODO This isn't right, since it requires all of the fields to be on one or
-  # the other (and, in particular, can't handle tags on the parent with a
-  # specified bookmarker on the child).
-  def query
-    if query_term.present?
-      @query ||= make_bool(should: [general_query, parent_query])
-    end
+  def bookmark_query_or_filter
+    return nil if bookmark_query_text.blank?
+    { query_string: { query: bookmark_query_text, default_operator: "AND" } }
   end
 
-  def general_query
-    { query_string: { query: query_term, default_operator: "AND" } }
-  end
-
-  def parent_query
+  def parent_bookmarkable_query_or_filter
+    return nil if bookmarkable_query.bookmarkable_query_or_filter.blank?
     {
       has_parent: {
         parent_type: "bookmarkable",
         score: true, # include the score from the bookmarkable
-        query: {
-          query_string: {
-            query: query_term,
-            default_operator: "AND"
-          }
-        }
+        query: bookmarkable_query.bookmarkable_query_or_filter
       }
     }
   end
 
-  def query_term
-    input = (options[:q] || options[:query] || "").dup
-    generate_search_text(input)
-  end
-
-  def generate_search_text(query = '')
-    search_text = query
-    [:bookmarker, :notes].each do |field|
-      search_text << split_query_text_words(field, options[field])
-    end
-    search_text << split_query_text_phrases(:tag, options[:tag])
-    escape_slashes(search_text.strip)
+  def bookmark_query_text
+    query_text = (options[:bookmark_query] || "").dup
+    query_text << split_query_text_words(:bookmarker, options[:bookmarker])
+    query_text << split_query_text_words(:notes, options[:notes])
+    query_text << split_query_text_phrases(:tag, options[:bookmark_tag])
+    escape_slashes(query_text.strip)
   end
 
   ####################

--- a/app/models/search/bookmark_search_form.rb
+++ b/app/models/search/bookmark_search_form.rb
@@ -5,7 +5,8 @@ class BookmarkSearchForm
   include ActiveModel::Validations
 
   ATTRIBUTES = [
-    :query,
+    :bookmark_query,
+    :bookmarkable_query,
     :rec,
     :bookmark_notes,
     :with_notes,
@@ -17,7 +18,8 @@ class BookmarkSearchForm
     :bookmarkable_pseud_names,
     :bookmarkable_pseud_ids,
     :bookmarkable_type,
-    :tag,
+    :bookmark_tag,
+    :bookmarkable_tag,
     :excluded_tag_names,
     :excluded_bookmark_tag_names,
     :excluded_tag_ids,
@@ -81,10 +83,21 @@ class BookmarkSearchForm
     false
   end
 
+  # This is used by SearchHelper.search_header.
+  def query
+    queries = []
+    %w[bookmarkable_query bookmark_query].each do |key|
+      queries << options[key] if options[key].present?
+    end
+    queries.join(', ')
+  end
+
   def summary
     summary = []
-    if options[:query].present?
-      summary << options[:query]
+    %w[bookmarkable_query bookmark_query].each do |key|
+      if options[key].present?
+        summary << options[key]
+      end
     end
     if options[:bookmarker].present?
       summary << "Bookmarker: #{options[:bookmarker]}"
@@ -93,8 +106,10 @@ class BookmarkSearchForm
       summary << "Notes: #{options[:notes]}"
     end
     tags = []
-    if options[:tag].present?
-      tags << options[:tag]
+    %w[bookmarkable_tag bookmark_tag].each do |key|
+      if options[key].present?
+        tags << options[key]
+      end
     end
     all_tag_ids = []
     [:filter_ids, :fandom_ids, :rating_ids, :category_ids, :warning_ids, :character_ids, :relationship_ids, :freeform_ids].each do |tag_ids|

--- a/app/models/search/bookmark_search_form.rb
+++ b/app/models/search/bookmark_search_form.rb
@@ -18,8 +18,6 @@ class BookmarkSearchForm
     :bookmarkable_pseud_names,
     :bookmarkable_pseud_ids,
     :bookmarkable_type,
-    :bookmark_tag,
-    :bookmarkable_tag,
     :excluded_tag_names,
     :excluded_bookmark_tag_names,
     :excluded_tag_ids,
@@ -106,7 +104,7 @@ class BookmarkSearchForm
       summary << "Notes: #{options[:notes]}"
     end
     tags = []
-    %w[bookmarkable_tag bookmark_tag].each do |key|
+    %w[other_tag_names other_bookmark_tag_names].each do |key|
       if options[key].present?
         tags << options[key]
       end

--- a/app/models/search/bookmarkable_query.rb
+++ b/app/models/search/bookmarkable_query.rb
@@ -88,7 +88,6 @@ class BookmarkableQuery < Query
 
   def bookmarkable_query_text
     query_text = (options[:bookmarkable_query] || "").dup
-    query_text << split_query_text_phrases(:tag, options[:bookmarkable_tag])
     escape_slashes(query_text.strip)
   end
 

--- a/app/views/bookmarks/_filters.html.erb
+++ b/app/views/bookmarks/_filters.html.erb
@@ -86,20 +86,19 @@
       <dd class="more group">
         <dl>
           <dt class="search">
-            <%= f.label :query, ts("Search within results") %>
+            <%= f.label :bookmarkable_query, ts("Search within results") %>
             <%= link_to_help "bookmark-search-text-help" %>
           </dt>
           <dd class="search">
-            <%= f.text_field :query %>
+            <%= f.text_field :bookmarkable_query %>
           </dd>
 
-          <% # TODO: UPDATE WHEN NEW BOOKMARK CODE COMES IN %>
           <dt class="bookmarker search">
-            <%= f.label :query, ts("Search bookmarker's tags and notes") %>
+            <%= f.label :bookmark_query, ts("Search bookmarker's tags and notes") %>
             <%= link_to_help "bookmark-search-text-help" %>
           </dt>
           <dd class="bookmarker search">
-            <%= f.text_field :query %>
+            <%= f.text_field :bookmark_query %>
           </dd>
 
           <dt class="options"><%= ts("Bookmark types") %></dt>

--- a/app/views/bookmarks/_search_form.html.erb
+++ b/app/views/bookmarks/_search_form.html.erb
@@ -35,14 +35,14 @@
       <%= link_to_help "bookmark-search-tag-help" %>
     </dt>
     <dd>
-      <%= f.text_field :other_tag_names %>
+      <%= f.text_field :other_tag_names, autocomplete_options("tag") %>
     </dd>
     <dt>
       <%= f.label :other_bookmark_tag_names, ts("Bookmarker's tags") %>
       <%= link_to_help "bookmark-search-tag-help" %>
     </dt>
     <dd>
-      <%= f.text_field :other_bookmark_tag_names %>
+      <%= f.text_field :other_bookmark_tag_names, autocomplete_options("tag") %>
     </dd>
     <dt>
       <%= f.label :rec, ts("Rec") %>

--- a/app/views/bookmarks/_search_form.html.erb
+++ b/app/views/bookmarks/_search_form.html.erb
@@ -3,14 +3,14 @@
   <legend>Search bookmarks</legend>
   <dl>
     <dt>
-      <%= f.label :bookmarkable_query, ts('Any field on Bookmarked Item') %>
+      <%= f.label :bookmarkable_query, ts('Any field on bookmarked item') %>
       <%= link_to_help "bookmark-search-text-help" %>
     </dt>
     <dd>
       <%= f.text_field :bookmarkable_query %>
     </dd>
     <dt>
-      <%= f.label :bookmark_query, ts('Any field on Bookmark') %>
+      <%= f.label :bookmark_query, ts('Any field on bookmark') %>
       <%= link_to_help "bookmark-search-text-help" %>
     </dt>
     <dd>
@@ -31,14 +31,14 @@
       <%= f.text_field :bookmark_notes %>
     </dd>
     <dt>
-      <%= f.label :bookmarkable_tag, ts("Bookmarked Item's Tags") %>
+      <%= f.label :bookmarkable_tag, ts("Bookmarked item's tags") %>
       <%= link_to_help "bookmark-search-tag-help" %>
     </dt>
     <dd>
       <%= f.text_field :bookmarkable_tag %>
     </dd>
     <dt>
-      <%= f.label :bookmark_tag, ts("Bookmark's Tags") %>
+      <%= f.label :bookmark_tag, ts("Bookmarker's tags") %>
       <%= link_to_help "bookmark-search-tag-help" %>
     </dt>
     <dd>
@@ -52,7 +52,7 @@
       <%= f.check_box :rec  %>
     </dd>
     <dt>
-      <%= f.label :with_notes, ts("With Notes") %>
+      <%= f.label :with_notes, ts("With notes") %>
       <%= link_to_help "bookmark-search-notes-help" %>
     </dt>
     <dd>
@@ -66,14 +66,14 @@
       <%= f.select :bookmarkable_type, options_for_select(["",  "Work", "Series", "External Work"]) %>
     </dd>
     <dt>
-      <%= f.label :date, ts('Date Bookmarked') %>
+      <%= f.label :date, ts('Date bookmarked') %>
       <%= link_to_help "bookmark-search-date-bookmarked-help" %>
     </dt>
     <dd>
       <%= f.text_field :date %>
     </dd>
     <dt>
-      <%= f.label :bookmarkable_date, ts('Date Updated') %>
+      <%= f.label :bookmarkable_date, ts('Date updated') %>
       <%= link_to_help "bookmark-search-date-updated-help" %>
     </dt>
     <dd>

--- a/app/views/bookmarks/_search_form.html.erb
+++ b/app/views/bookmarks/_search_form.html.erb
@@ -31,18 +31,18 @@
       <%= f.text_field :bookmark_notes %>
     </dd>
     <dt>
-      <%= f.label :bookmarkable_tag, ts("Bookmarked item's tags") %>
+      <%= f.label :other_tag_names, ts("Bookmarked item's tags") %>
       <%= link_to_help "bookmark-search-tag-help" %>
     </dt>
     <dd>
-      <%= f.text_field :bookmarkable_tag %>
+      <%= f.text_field :other_tag_names %>
     </dd>
     <dt>
-      <%= f.label :bookmark_tag, ts("Bookmarker's tags") %>
+      <%= f.label :other_bookmark_tag_names, ts("Bookmarker's tags") %>
       <%= link_to_help "bookmark-search-tag-help" %>
     </dt>
     <dd>
-      <%= f.text_field :bookmark_tag %>
+      <%= f.text_field :other_bookmark_tag_names %>
     </dd>
     <dt>
       <%= f.label :rec, ts("Rec") %>

--- a/app/views/bookmarks/_search_form_old.html.erb
+++ b/app/views/bookmarks/_search_form_old.html.erb
@@ -1,20 +1,13 @@
-<%= form_for @search, as: :bookmark_search, url: search_bookmarks_path, html: { class: "search", method: :get } do |f| %>
+<%= form_for @search, as: :bookmark_search, :url => search_bookmarks_path, :html => {:class => 'search', :method => :get} do |f| %>
 <fieldset>
   <legend>Search bookmarks</legend>
   <dl>
     <dt>
-      <%= f.label :bookmarkable_query, ts('Any field on Bookmarked Item') %>
+      <%= f.label :query, ts('Any field') %>
       <%= link_to_help "bookmark-search-text-help" %>
     </dt>
     <dd>
-      <%= f.text_field :bookmarkable_query %>
-    </dd>
-    <dt>
-      <%= f.label :bookmark_query, ts('Any field on Bookmark') %>
-      <%= link_to_help "bookmark-search-text-help" %>
-    </dt>
-    <dd>
-      <%= f.text_field :bookmark_query %>
+      <%= f.text_field :query %>
     </dd>
     <dt>
       <%= f.label :bookmarker, ts('Bookmarker') %>
@@ -31,18 +24,11 @@
       <%= f.text_field :bookmark_notes %>
     </dd>
     <dt>
-      <%= f.label :bookmarkable_tag, ts("Bookmarked Item's Tags") %>
+      <%= f.label :tag, ts("Tag") %>
       <%= link_to_help "bookmark-search-tag-help" %>
     </dt>
     <dd>
-      <%= f.text_field :bookmarkable_tag %>
-    </dd>
-    <dt>
-      <%= f.label :bookmark_tag, ts("Bookmark's Tags") %>
-      <%= link_to_help "bookmark-search-tag-help" %>
-    </dt>
-    <dd>
-      <%= f.text_field :bookmark_tag %>
+      <%= f.text_field :tag %>
     </dd>
     <dt>
       <%= f.label :rec, ts("Rec") %>

--- a/app/views/bookmarks/_search_form_old.html.erb
+++ b/app/views/bookmarks/_search_form_old.html.erb
@@ -38,7 +38,7 @@
       <%= f.check_box :rec  %>
     </dd>
     <dt>
-      <%= f.label :with_notes, ts("With Notes") %>
+      <%= f.label :with_notes, ts("With notes") %>
       <%= link_to_help "bookmark-search-notes-help" %>
     </dt>
     <dd>
@@ -52,14 +52,14 @@
       <%= f.select :bookmarkable_type, options_for_select(["",  "Work", "Series", "External Work"]) %>
     </dd>
     <dt>
-      <%= f.label :date, ts('Date Bookmarked') %>
+      <%= f.label :date, ts('Date bookmarked') %>
       <%= link_to_help "bookmark-search-date-bookmarked-help" %>
     </dt>
     <dd>
       <%= f.text_field :date %>
     </dd>
     <dt>
-      <%= f.label :bookmarkable_date, ts('Date Updated') %>
+      <%= f.label :bookmarkable_date, ts('Date updated') %>
       <%= link_to_help "bookmark-search-date-updated-help" %>
     </dt>
     <dd>

--- a/app/views/bookmarks/search.html.erb
+++ b/app/views/bookmarks/search.html.erb
@@ -8,5 +8,10 @@
 <!--/subnav-->
 
 <!--main content-->
-<%= render :partial => 'bookmarks/search_form' %>
+<% # ES UPGRADE TRANSITION # %>
+<% if use_new_search? %>
+  <%= render "bookmarks/search_form" %>
+<% else %>
+  <%= render "bookmarks/search_form_old" %>
+<% end %>
 <!--/content-->

--- a/features/bookmarks/bookmark_search.feature
+++ b/features/bookmarks/bookmark_search.feature
@@ -7,6 +7,7 @@ Feature: Search Bookmarks
   Background:
     Given I am on the search bookmarks page
 
+  @old-search
   Scenario: Search bookmarks by tag
     Given I have bookmarks to search
     When I fill in "Tag" with "classic"
@@ -17,6 +18,40 @@ Feature: Search Bookmarks
       And I should see "third work"
     When I follow "Edit Your Search"
     Then the field labeled "Tag" should contain "classic"
+
+  @new-search
+  Scenario: Search bookmarks by tag
+    Given I have bookmarks to search
+
+    # Only on bookmarks
+    When I fill in "Bookmark's Tags" with "rare"
+      And I press "Search bookmarks"
+    Then I should see the page title "Search Bookmarks"
+      And I should see "You searched for: Tags: rare"
+      And I should see "1 Found"
+      And I should see "second work"
+    When I follow "Edit Your Search"
+    Then the field labeled "Bookmark's Tags" should contain "rare"
+
+    # Only on bookmarkables
+    When I am on the search bookmarks page
+      And I fill in "Bookmarked Item's Tags" with "rare"
+      And I press "Search bookmarks"
+    Then I should see the page title "Search Bookmarks"
+      And I should see "You searched for: Tags: rare"
+      And I should see "1 Found"
+      And I should see "First work"
+    When I follow "Edit Your Search"
+    Then the field labeled "Bookmarked Item's Tags" should contain "rare"
+
+    # On bookmarks and bookmarkables, results should match both
+    When I am on the search bookmarks page
+      And I fill in "Bookmark's Tags" with "rare"
+      And I fill in "Bookmarked Item's Tags" with "rare"
+      And I press "Search bookmarks"
+    Then I should see the page title "Search Bookmarks"
+      And I should see "You searched for: Tags: rare"
+      And I should see "No results found."
 
   Scenario: Search bookmarks by date bookmarked
     Given I have bookmarks to search by dates
@@ -65,6 +100,7 @@ Feature: Search Bookmarks
     When I follow "Edit Your Search"
     Then the "Rec" checkbox should be checked
 
+  @old-search
   Scenario: Search bookmarks by any field
     Given I have bookmarks to search
     When I fill in "Any field" with "Hobbits"
@@ -74,6 +110,43 @@ Feature: Search Bookmarks
       And I should see "No results found."
     When I follow "Edit Your Search"
     Then the field labeled "Any field" should contain "Hobbits"
+
+  @new-search
+  Scenario: Search bookmarks by any field
+    Given I have bookmarks to search by any field
+
+    # Only on bookmarks
+    When I fill in "Any field on Bookmark" with "more please"
+      And I press "Search bookmarks"
+    Then I should see the page title "Bookmarks Matching 'more please'"
+      And I should see "You searched for: more please"
+      And I should see "2 Found"
+      And I should see "Hurt and that's it"
+      And I should see "Fluff"
+    When I follow "Edit Your Search"
+    Then the field labeled "Any field on Bookmark" should contain "more please"
+
+    # Only on bookmarkables
+    When I am on the search bookmarks page
+      And I fill in "Any field on Bookmarked Item" with "hurt"
+      And I press "Search bookmarks"
+    Then I should see the page title "Bookmarks Matching 'hurt'"
+      And I should see "You searched for: hurt"
+      And I should see "2 Found"
+      And I should see "Comfort"
+      And I should see "Hurt and that's it"
+    When I follow "Edit Your Search"
+    Then the field labeled "Any field on Bookmarked Item" should contain "hurt"
+
+    # On bookmarks and bookmarkables, results should match both
+    When I am on the search bookmarks page
+      And I fill in "Any field on Bookmark" with "more please"
+      And I fill in "Any field on Bookmarked Item" with "hurt"
+      And I press "Search bookmarks"
+    Then I should see the page title "Bookmarks Matching 'hurt, more please'"
+      And I should see "You searched for: hurt, more please"
+      And I should see "1 Found"
+      And I should see "Hurt and that's it"
 
   Scenario: Search bookmarks by type
     Given I have bookmarks to search

--- a/features/bookmarks/bookmark_search.feature
+++ b/features/bookmarks/bookmark_search.feature
@@ -24,30 +24,30 @@ Feature: Search Bookmarks
     Given I have bookmarks to search
 
     # Only on bookmarks
-    When I fill in "Bookmark's Tags" with "rare"
+    When I fill in "Bookmarker's tags" with "rare"
       And I press "Search bookmarks"
     Then I should see the page title "Search Bookmarks"
       And I should see "You searched for: Tags: rare"
       And I should see "1 Found"
       And I should see "second work"
     When I follow "Edit Your Search"
-    Then the field labeled "Bookmark's Tags" should contain "rare"
+    Then the field labeled "Bookmarker's tags" should contain "rare"
 
     # Only on bookmarkables
     When I am on the search bookmarks page
-      And I fill in "Bookmarked Item's Tags" with "rare"
+      And I fill in "Bookmarked item's tags" with "rare"
       And I press "Search bookmarks"
     Then I should see the page title "Search Bookmarks"
       And I should see "You searched for: Tags: rare"
       And I should see "1 Found"
       And I should see "First work"
     When I follow "Edit Your Search"
-    Then the field labeled "Bookmarked Item's Tags" should contain "rare"
+    Then the field labeled "Bookmarked item's tags" should contain "rare"
 
     # On bookmarks and bookmarkables, results should match both
     When I am on the search bookmarks page
-      And I fill in "Bookmark's Tags" with "rare"
-      And I fill in "Bookmarked Item's Tags" with "rare"
+      And I fill in "Bookmarker's tags" with "rare"
+      And I fill in "Bookmarked item's tags" with "rare"
       And I press "Search bookmarks"
     Then I should see the page title "Search Bookmarks"
       And I should see "You searched for: Tags: rare"
@@ -55,16 +55,16 @@ Feature: Search Bookmarks
 
   Scenario: Search bookmarks by date bookmarked
     Given I have bookmarks to search by dates
-    When I fill in "Date Bookmarked" with "> 900 days ago"
+    When I fill in "Date bookmarked" with "> 900 days ago"
       And I press "Search bookmarks"
     Then I should see the page title "Search Bookmarks"
       And I should see "You searched for: Date bookmarked: > 900 days ago"
       And I should see "1 Found"
       And I should see "Old bookmark of old work"
     When I follow "Edit Your Search"
-    Then the field labeled "Date Bookmarked" should contain "> 900 days ago"
+    Then the field labeled "Date bookmarked" should contain "> 900 days ago"
 
-    When I fill in "Date Bookmarked" with "< 900 days ago"
+    When I fill in "Date bookmarked" with "< 900 days ago"
       And I press "Search bookmarks"
     Then I should see "You searched for: Date bookmarked: < 900 days ago"
       And I should see "2 Found"
@@ -73,7 +73,7 @@ Feature: Search Bookmarks
 
   Scenario: Search bookmarks by date updated
     Given I have bookmarks to search by dates
-    When I fill in "Date Updated" with "> 900 days ago"
+    When I fill in "Date updated" with "> 900 days ago"
       And I press "Search bookmarks"
     Then I should see the page title "Search Bookmarks"
       And I should see "You searched for: Date updated: > 900 days ago"
@@ -81,9 +81,9 @@ Feature: Search Bookmarks
       And I should see "Old bookmark of old work"
       And I should see "New bookmark of old work"
     When I follow "Edit Your Search"
-    Then the field labeled "Date Updated" should contain "> 900 days ago"
+    Then the field labeled "Date updated" should contain "> 900 days ago"
 
-    When I fill in "Date Updated" with "< 900 days ago"
+    When I fill in "Date updated" with "< 900 days ago"
       And I press "Search bookmarks"
     Then I should see "You searched for: Date updated: < 900 days ago"
       And I should see "1 Found"
@@ -116,7 +116,7 @@ Feature: Search Bookmarks
     Given I have bookmarks to search by any field
 
     # Only on bookmarks
-    When I fill in "Any field on Bookmark" with "more please"
+    When I fill in "Any field on bookmark" with "more please"
       And I press "Search bookmarks"
     Then I should see the page title "Bookmarks Matching 'more please'"
       And I should see "You searched for: more please"
@@ -124,11 +124,11 @@ Feature: Search Bookmarks
       And I should see "Hurt and that's it"
       And I should see "Fluff"
     When I follow "Edit Your Search"
-    Then the field labeled "Any field on Bookmark" should contain "more please"
+    Then the field labeled "Any field on bookmark" should contain "more please"
 
     # Only on bookmarkables
     When I am on the search bookmarks page
-      And I fill in "Any field on Bookmarked Item" with "hurt"
+      And I fill in "Any field on bookmarked item" with "hurt"
       And I press "Search bookmarks"
     Then I should see the page title "Bookmarks Matching 'hurt'"
       And I should see "You searched for: hurt"
@@ -136,12 +136,12 @@ Feature: Search Bookmarks
       And I should see "Comfort"
       And I should see "Hurt and that's it"
     When I follow "Edit Your Search"
-    Then the field labeled "Any field on Bookmarked Item" should contain "hurt"
+    Then the field labeled "Any field on bookmarked item" should contain "hurt"
 
     # On bookmarks and bookmarkables, results should match both
     When I am on the search bookmarks page
-      And I fill in "Any field on Bookmark" with "more please"
-      And I fill in "Any field on Bookmarked Item" with "hurt"
+      And I fill in "Any field on bookmark" with "more please"
+      And I fill in "Any field on bookmarked item" with "hurt"
       And I press "Search bookmarks"
     Then I should see the page title "Bookmarks Matching 'hurt, more please'"
       And I should see "You searched for: hurt, more please"
@@ -163,7 +163,7 @@ Feature: Search Bookmarks
   Scenario: Search for bookmarks with notes, and then edit search to narrow
   results by the note content
     Given I have bookmarks to search
-    When I check "With Notes"
+    When I check "With notes"
       And I press "Search bookmarks"
     Then I should see the page title "Search Bookmarks"
       And I should see "You searched for: With Notes"
@@ -171,7 +171,7 @@ Feature: Search Bookmarks
       And I should see "fifth"
       And I should see "Skies Grown Darker"
     When I follow "Edit Your Search"
-    Then the "With Notes" checkbox should be checked
+    Then the "With notes" checkbox should be checked
     When I fill in "Notes" with "broken heart"
       And I press "Search bookmarks"
     Then I should see the page title "Search Bookmarks"
@@ -181,7 +181,7 @@ Feature: Search Bookmarks
       # And I should see "fifth"
     When I follow "Edit Your Search"
     Then the field labeled "Notes" should contain "broken heart"
-      And the "With Notes" checkbox should be checked
+      And the "With notes" checkbox should be checked
 
   Scenario: If testuser has the pseud tester_pseud, searching for bookmarks by
   the bookmarker testuser returns all of tester_pseud's bookmarks

--- a/features/search/filters.feature
+++ b/features/search/filters.feature
@@ -154,6 +154,27 @@ Feature: Filters
       And I should not see "Roonal Woozlib and the Ferrets of Nimh"
 
   @javascript
+  Scenario: Filter a user's bookmarks by "Search within results" and "Search bookmarker's tags and notes"
+    Given I am logged in as "recengine"
+      And recengine can use the new search
+      And I bookmark the work "Bilbo Does the Thing" with the tags "hobbit"
+      And I bookmark the work "A Hobbit's Meandering" with the tags "bilbo"
+
+    When I go to my bookmarks page
+      And I fill in "Search within results" with "bilbo"
+      And I press "Sort and Filter"
+    Then I should see "1 Bookmark found by recengine"
+      And I should see "Bilbo Does the Thing"
+      And I should not see "A Hobbit's Meandering"
+
+    When I go to my bookmarks page
+      And I fill in "Search bookmarker's tags and notes" with "bilbo"
+      And I press "Sort and Filter"
+    Then I should see "1 Bookmark found by recengine"
+      And I should see "A Hobbit's Meandering"
+      And I should not see "Bilbo Does the Thing"
+
+  @javascript
   Scenario: Filter a user's bookmarks by bookmarker's tags
     Given I am logged in as "recengine"
       And recengine can use the new search

--- a/features/step_definitions/bookmark_steps.rb
+++ b/features/step_definitions/bookmark_steps.rb
@@ -30,18 +30,19 @@ Given /^I have bookmarks to search$/ do
   pseud1 = FactoryGirl.create(:pseud, name: "testy", user_id: user1.id)
   pseud2 = FactoryGirl.create(:pseud, name: "tester_pseud", user_id: user1.id)
 
+  # set up a tag
+  freeform1 = FactoryGirl.create(:freeform, name: "classic")
+  freeform2 = FactoryGirl.create(:freeform, name: "rare")
+
   # set up some works
-  work1 = FactoryGirl.create(:work, title: "First work", posted: true)
-  work2 = FactoryGirl.create(:work, title: "second work", posted: true)
-  work3 = FactoryGirl.create(:work, title: "third work", posted: true)
-  work4 = FactoryGirl.create(:work, title: "fourth", posted: true)
-  work5 = FactoryGirl.create(:work, title: "fifth", posted: true)
+  work1 = FactoryGirl.create(:posted_work, title: "First work", freeform_string: freeform2.name)
+  work2 = FactoryGirl.create(:posted_work, title: "second work")
+  work3 = FactoryGirl.create(:posted_work, title: "third work")
+  work4 = FactoryGirl.create(:posted_work, title: "fourth")
+  work5 = FactoryGirl.create(:posted_work, title: "fifth")
 
   # set up an external work
   external1 = FactoryGirl.create(:external_work, title: "Skies Grown Darker")
-
-  # set up a tag
-  freeform1 = FactoryGirl.create(:freeform, name: "classic")
 
   # set up the bookmarks
   FactoryGirl.create(:bookmark,
@@ -51,7 +52,8 @@ Given /^I have bookmarks to search$/ do
 
   FactoryGirl.create(:bookmark,
                      bookmarkable_id: work2.id,
-                     pseud_id: user1.default_pseud.id)
+                     pseud_id: user1.default_pseud.id,
+                     tag_string: freeform2.name)
 
   FactoryGirl.create(:bookmark,
                      bookmarkable_id: work3.id,
@@ -70,6 +72,18 @@ Given /^I have bookmarks to search$/ do
                      bookmarkable_type: "ExternalWork",
                      pseud_id: pseud2.id,
                      notes: "I enjoyed this")
+
+  step %{all indexing jobs have been run}
+end
+
+Given /^I have bookmarks to search by any field$/ do
+  work1 = FactoryGirl.create(:posted_work, title: "Comfort", freeform_string: "hurt a little comfort but only so much")
+  work2 = FactoryGirl.create(:posted_work, title: "Hurt and that's it")
+  work3 = FactoryGirl.create(:posted_work, title: "Fluff")
+
+  FactoryGirl.create(:bookmark, bookmarkable_id: work1.id, notes: "whatever")
+  FactoryGirl.create(:bookmark, bookmarkable_id: work2.id, tag_string: "more please")
+  FactoryGirl.create(:bookmark, bookmarkable_id: work3.id, notes: "more please")
 
   step %{all indexing jobs have been run}
 end

--- a/spec/models/bookmark_query_spec.rb
+++ b/spec/models/bookmark_query_spec.rb
@@ -3,22 +3,15 @@ require 'spec_helper'
 describe BookmarkQuery do
 
   it "should allow you to perform a simple search" do
-    q = BookmarkQuery.new(query: "unicorns")
+    q = BookmarkQuery.new(bookmarkable_query: "space", bookmark_query: "unicorns")
     search_body = q.generated_query
     query = { query_string: { query: "unicorns", default_operator: "AND" } }
+    expect(search_body[:query][:bool][:must]).to include(query)
     expect(search_body[:query][:bool][:must]).to include(
-      bool: {
-        should: [
-          query,
-          {
-            has_parent: {
-              parent_type: "bookmarkable",
-              query: query,
-              score: true
-            }
-          }
-        ],
-        minimum_should_match: 1
+      has_parent: {
+        parent_type: "bookmarkable",
+        query: { query_string: { query: "space", default_operator: "AND" } },
+        score: true
       }
     )
   end
@@ -140,35 +133,4 @@ describe BookmarkQuery do
     q = BookmarkQuery.new(language_id: 1)
     expect(q.filters).to include({has_parent:{parent_type: 'bookmarkable', query:{term: {language_id: 1}}}})
   end
-
-#   it "should allow you to filter by count ranges" do
-#     q = WorkQuery.new(word_count: ">1000")
-#     expect(q.filters).to include({range: { word_count: { gt: 1000 } } })
-#   end
-
-#   it "should sort by date by default" do
-#     q = WorkQuery.new
-#     expect(q.generated_query[:sort]).to eq({'revised_at' => { order: 'desc'}})
-#   end
-
-#   it "should allow you to sort by creator name" do
-#     q = WorkQuery.new(sort_column: 'authors_to_sort_on', sort_direction: 'asc')
-#     expect(q.generated_query[:sort]).to eq({'authors_to_sort_on' => { order: 'asc'}})
-#   end
-
-#   it "should allow you to sort by title" do
-#     q = WorkQuery.new(sort_column: 'title_to_sort_on')
-#     expect(q.generated_query[:sort]).to eq({'title_to_sort_on' => { order: 'desc'}})
-#   end
-
-#   it "should allow you to sort by kudos" do
-#     q = WorkQuery.new(sort_column: 'kudos_count')
-#     expect(q.generated_query[:sort]).to eq({'kudos_count' => { order: 'desc'}})
-#   end
-
-#   it "should allow you to sort by comments" do
-#     q = WorkQuery.new(sort_column: 'comments_count')
-#     expect(q.generated_query[:sort]).to eq({'comments_count' => { order: 'desc'}})
-#   end
-
 end


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5363
https://otwarchive.atlassian.net/browse/AO3-5355

## Purpose

The ES6 bookmark search form now has new fields, which correspond to new fields on bookmark filters in [AO3-5355](https://otwarchive.atlassian.net/browse/AO3-5355):

- Any field on bookmarked item (form) = Search within results (filters)
- Any field on bookmark (form) = Search bookmarker's tags and notes (filters)
- Bookmarked item's tags (form) = Other work tags to include (filters)
- Bookmarker's tags (form) = Other bookmarker's tags to include (filters)

## Testing

See JIRA issue.