### PR TITLE
AO3-5274 Revert "In filters, text of selected tag not bolded on old browsers"

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -555,6 +555,6 @@ module ApplicationHelper
   # spans for nesting a checkbox or radio button inside its label to make custom
   # checkbox or radio designs
   def label_indicator_and_text(text)
-    content_tag(:span, "", class: "indicator", "aria-hidden": "true") + content_tag(:span, text, class: "label")
+    content_tag(:span, "", class: "indicator", "aria-hidden": "true") + content_tag(:span, text)
   end
 end # end of ApplicationHelper

--- a/public/stylesheets/site/2.0/18-zone-searchbrowse.css
+++ b/public/stylesheets/site/2.0/18-zone-searchbrowse.css
@@ -193,7 +193,7 @@ form.filters {
   border-color: #aaa;
 }
 
-.filters input:checked ~ .label {
+.filters input:checked + .indicator + span {
   font-weight: 700;
 }
 


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5274

## Purpose

Reverts changes to the selector we use to bold the name of checked tags in the filters because it's even more broken in Safari 9 now.

## Testing

Use the filter checkboxes in older versions of Safari. Nothing should inexplicably disappear.
