### PR TITLE
AO3-5363 Rename "bookmarked item" search fields to use "work"

### DIFF
--- a/app/views/bookmarks/_search_form.html.erb
+++ b/app/views/bookmarks/_search_form.html.erb
@@ -3,7 +3,7 @@
   <legend>Search bookmarks</legend>
   <dl>
     <dt>
-      <%= f.label :bookmarkable_query, ts('Any field on bookmarked item') %>
+      <%= f.label :bookmarkable_query, ts('Any field on work') %>
       <%= link_to_help "bookmark-search-text-help" %>
     </dt>
     <dd>
@@ -31,7 +31,7 @@
       <%= f.text_field :bookmark_notes %>
     </dd>
     <dt>
-      <%= f.label :other_tag_names, ts("Bookmarked item's tags") %>
+      <%= f.label :other_tag_names, ts("Work tags") %>
       <%= link_to_help "bookmark-search-tag-help" %>
     </dt>
     <dd>

--- a/features/bookmarks/bookmark_search.feature
+++ b/features/bookmarks/bookmark_search.feature
@@ -35,19 +35,19 @@ Feature: Search Bookmarks
 
     # Only on bookmarkables
     When I am on the search bookmarks page
-      And I fill in "Bookmarked item's tags" with "rare"
+      And I fill in "Work tags" with "rare"
       And I press "Search bookmarks"
     Then I should see the page title "Search Bookmarks"
       And I should see "You searched for: Tags: rare"
       And I should see "1 Found"
       And I should see "First work"
     When I follow "Edit Your Search"
-    Then the field labeled "Bookmarked item's tags" should contain "rare"
+    Then the field labeled "Work tags" should contain "rare"
 
     # On bookmarks and bookmarkables, results should match both
     When I am on the search bookmarks page
       And I fill in "Bookmarker's tags" with "rare"
-      And I fill in "Bookmarked item's tags" with "rare"
+      And I fill in "Work tags" with "rare"
       And I press "Search bookmarks"
     Then I should see the page title "Search Bookmarks"
       And I should see "You searched for: Tags: rare"
@@ -128,7 +128,7 @@ Feature: Search Bookmarks
 
     # Only on bookmarkables
     When I am on the search bookmarks page
-      And I fill in "Any field on bookmarked item" with "hurt"
+      And I fill in "Any field on work" with "hurt"
       And I press "Search bookmarks"
     Then I should see the page title "Bookmarks Matching 'hurt'"
       And I should see "You searched for: hurt"
@@ -136,12 +136,12 @@ Feature: Search Bookmarks
       And I should see "Comfort"
       And I should see "Hurt and that's it"
     When I follow "Edit Your Search"
-    Then the field labeled "Any field on bookmarked item" should contain "hurt"
+    Then the field labeled "Any field on work" should contain "hurt"
 
     # On bookmarks and bookmarkables, results should match both
     When I am on the search bookmarks page
       And I fill in "Any field on bookmark" with "more please"
-      And I fill in "Any field on bookmarked item" with "hurt"
+      And I fill in "Any field on work" with "hurt"
       And I press "Search bookmarks"
     Then I should see the page title "Bookmarks Matching 'hurt, more please'"
       And I should see "You searched for: hurt, more please"

--- a/script/gem_security.sh
+++ b/script/gem_security.sh
@@ -1,7 +1,11 @@
 #!/bin/sh
 TMP=/tmp/audit.$$
 bundle-audit update
-bundle-audit check --ignore "" > $TMP
+# TODO update gems, remove ignore checks:
+# loofah 2.0.3 to >= 2.2.1
+# rails-html-sanitizer 1.0.3 to >= 1.0.4
+# sanitize 4.5.0 to >= 4.6.3
+bundle-audit check --ignore CVE-2018-8048 CVE-2018-3741 CVE-2018-3740 > $TMP
 if [ "`cat $TMP |wc -l`" != "1" ]; then
    cat $TMP
    echo "Please either update gem or if that is not possible update ignore list in"


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5363

## Purpose

Rename "Any field on bookmarked item" to "Any field on work" and "Bookmarked item's tags" to "Work tags" to match the filters.

## Testing

Labels should have the correct text, renamed fields should still work.