### PR TITLE
AO3-5331 Don't exclude mergers when excluding non-canonical tags.

### DIFF
--- a/app/models/search/taggable_query.rb
+++ b/app/models/search/taggable_query.rb
@@ -20,7 +20,6 @@ module TaggableQuery
 
     ids = options[:excluded_tag_ids] || []
     ids += parsed_excluded_tags[:ids]
-    ids += Tag.where(id: ids).pluck(:merger_id)
     @exclusion_ids = ids.uniq.compact
   end
 

--- a/spec/models/bookmark_search_form_exclusion_filters_spec.rb
+++ b/spec/models/bookmark_search_form_exclusion_filters_spec.rb
@@ -85,8 +85,9 @@ describe BookmarkSearchForm do
         expect(search.search_results).not_to include(excluded_bookmark)
       end
 
-      it "should exclude bookmarks for works tagged with a canonical tag given that tag's synonym" do
-        excluded_work.update(freeform_string: "Exclude Work Tag")
+      it "should only exclude bookmarks for works tagged with a synonym (not the merger) when given that synonym as a tag to exclude" do
+        included_work.update(freeform_string: "Exclude Work Tag")
+        excluded_work.update(freeform_string: "Tagged Work Exclusion")
         update_and_refresh_indexes("bookmark")
 
         options = {

--- a/spec/models/work_search_form_exclusion_filters_spec.rb
+++ b/spec/models/work_search_form_exclusion_filters_spec.rb
@@ -48,8 +48,10 @@ describe WorkSearchForm do
         expect(search.search_results).not_to include(excluded_work)
       end
 
-      it "should exclude works tagged with a canonical tag given that tag's synonym" do
-        excluded_work.update(freeform_string: "Exclude Me")
+      it "should only exclude works tagged with a synonym (not its merger) when given that synonym as a tag to exclude" do
+        included_work.update(freeform_string: "Exclude Me")
+        excluded_work.update(freeform_string: "Excluded")
+
         update_and_refresh_indexes("work")
 
         options = {


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5331

## Purpose

Excluding non-canonical tags currently excludes those tags' mergers as well, making the behavior of exclusion filters asymmetric with the behavior of inclusion filters. This PR removes the mergers from the list of tags to be excluded.

## Testing

1. Find a non-canonical tag with a merger.
2. Go to the merger's works listing.
3. Type the non-canonical tag into the "Other tags to exclude" field.
4. Press the "Sort and Filter" button.
5. Make sure that the only works excluded are those tagged with the synonym.