### PR TITLE
AO3-5370 Fix vanishing filter label text in Safari 9

### DIFF
--- a/public/stylesheets/site/2.0/18-zone-searchbrowse.css
+++ b/public/stylesheets/site/2.0/18-zone-searchbrowse.css
@@ -163,7 +163,7 @@ form.filters {
 }
 
 /* AO3-5370: Normally you'd use absolute positioning here, but we
-needed relative positioning and a left ofset to fix a bug in Safari 9 */
+needed relative positioning and a left offset to fix a bug in Safari 9 */
 .filters [type="checkbox"], .filters [type="radio"] {
   border: 0; 
   clip: rect(0 0 0 0);

--- a/public/stylesheets/site/2.0/18-zone-searchbrowse.css
+++ b/public/stylesheets/site/2.0/18-zone-searchbrowse.css
@@ -162,14 +162,17 @@ form.filters {
   margin-top: 1.286em; /* heading top margin minus sort bottom margin */
 }
 
+/* AO3-5370: Normally you'd use absolute positioning here, but we
+needed relative positioning and a left ofset to fix a bug in Safari 9 */
 .filters [type="checkbox"], .filters [type="radio"] {
   border: 0; 
   clip: rect(0 0 0 0);
   height: 1px;
+  left: -2em;
   margin: -1px; 
   overflow: hidden; 
   padding: 0; 
-  position: absolute; 
+  position: relative; 
   width: 1px;
 }
 


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5370

## Purpose

Fixes an issue where the labels in the filters would disappear in Safari 9 when you expanded the next filter section.

## Testing

Try to use the filters in Safari 9, and then try to use them in other browsers to make sure I didn't break anything new.