### PR TITLE
AO3-5209 Fix mobile ES 0.90.7 filters

### DIFF
--- a/public/stylesheets/site/2.0/10-types-groups.css
+++ b/public/stylesheets/site/2.0/10-types-groups.css
@@ -23,7 +23,11 @@ a.tag:hover, .listbox .heading a.tag:visited:hover {
   padding-right: 0.25em;
 }
 
-.filters .tags li, .review .tags {
+/* INTERACTION: OLD FILTERS */
+/* ES UPGRADE TRANSITION: REMOVE .old-filters SELECTORS WHEN DONE */
+
+.filters .tags li, .review .tags,
+.form-filters .tags li {
   display: block;
 }
 

--- a/public/stylesheets/site/2.0/17-zone-home.css
+++ b/public/stylesheets/site/2.0/17-zone-home.css
@@ -92,7 +92,10 @@ form.inbox fieldset {
   padding-right: 0;
 }
 
-.dashboard form.filters + h4.landmark {
+/* INTERACTION: OLD FILTERS */
+/* ES UPGRADE TRANSITION: REMOVE .old-filters SELECTORS WHEN DONE */
+.dashboard form.filters + h4.landmark,
+.dashbaord form.old-filters + h4.landmark {
   clear: left;
 }
 

--- a/public/stylesheets/site/2.0/25-media-midsize.css
+++ b/public/stylesheets/site/2.0/25-media-midsize.css
@@ -76,18 +76,23 @@
 }
 
 /* 18 zone searchbrowse */
+/* INTERACTION: OLD FILTERS */
+/* ES UPGRADE TRANSITION: REMOVE .old-filters SELECTORS WHEN DONE */
 
-form.filters {
+form.filters,
+form.old-filters {
   width: auto;
   min-width: 23%;
   max-width: 24%;
 }
 
-.filters fieldset {
+.filters fieldset,
+.old-filters fieldset {
   margin-right: 0;
 }
 
-form.filters dl {
+form.filters dl,
+form.old-filters dl {
   margin-left: 0.25em;
   margin-right: 0.25em;
 }

--- a/public/stylesheets/site/2.0/26-media-narrow.css
+++ b/public/stylesheets/site/2.0/26-media-narrow.css
@@ -103,7 +103,11 @@ body .narrow-shown {
 }
 
 /* once we remove the meta class from the work form, we can remove the form .meta selectors here */
-.filtered .index, form.filters, form dd, form dt, form .meta dd, form .meta dt, form.inbox {
+/* INTERACTION: OLD FILTERS */
+/* ES UPGRADE TRANSITION: REMOVE .old-filters SELECTORS WHEN DONE */
+
+.filtered .index, form.filters, form dd, form dt, form .meta dd, form .meta dt, form.inbox,
+form.old-filters {
   width: 100%;
   max-width: 100%;
   min-width: 0;
@@ -191,18 +195,24 @@ body .narrow-shown {
 }
 
 /* 18 zone: search browse */
+/* INTERACTION: OLD FILTERS */
+/* ES UPGRADE TRANSITION: REMOVE .old-filters SELECTORS WHEN DONE */
 
-form.filters dl {
+form.filters dl,
+form.old-filters dl {
   width: auto;
 }
 
 /* Filters with JavaScript */
+/* INTERACTION: OLD FILTERS */
+/* ES UPGRADE TRANSITION: REMOVE .old-filters SELECTORS WHEN DONE */
 
 .javascript {
   background: #ddd;
 }
 
-.javascript form.filters {
+.javascript form.filters,
+.javascript form.old-filters {
   margin: 0;
   max-width: 95%;
   position: absolute;
@@ -212,7 +222,8 @@ form.filters dl {
   z-index: 400;
 }
 
-.javascript .filters fieldset {
+.javascript .filters fieldset,
+.javascript .old-filters fieldset {
   border: none;
   margin: 0;
   position: relative;
@@ -220,7 +231,8 @@ form.filters dl {
     box-shadow: none;
 }
 
-.javascript .filters p.narrow-shown {
+.javascript .filters p.narrow-shown,
+.javascript .old-filters p.narrow-shown {
   position: relative; 
 }
 
@@ -228,7 +240,8 @@ form.filters dl {
   right: 14em;
 }
 
-.filtering .filters #leave_filters {
+.filtering .filters #leave_filters,
+.filtering .old-filters #leave_filters {
   background: transparent none;
   border-bottom: none;
   position: fixed;

--- a/public/stylesheets/site/2.0/28-media-print.css
+++ b/public/stylesheets/site/2.0/28-media-print.css
@@ -22,7 +22,10 @@ html, body, #main, .works-show, dl.meta, .meta, .meta dd, .meta ul, .preface blo
   text-indent: 22pt;
 }
 
-#header, #footer, #dashboard, img, #skiplinks, .navigation, .meta dt, #feedback, .meta .stats, .blurb dt, .filters, .pagination, .flash, input, .landmark {
+/* INTERACTION: OLD FILTERS */
+/* ES UPGRADE TRANSITION: REMOVE .old-filters SELECTORS WHEN DONE */
+#header, #footer, #dashboard, img, #skiplinks, .navigation, .meta dt, #feedback, .meta .stats, .blurb dt, .filters, .pagination, .flash, input, .landmark,
+.old-filters {
   display: none;
 }
 


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5209

## Purpose

Make all of the style blocks that use .filters in selectors also use .old-filters (except in the very old IE-specific sheets, because honestly)

Because these selectors should be removed, I've broken our usual code style and put them on separate lines to make them easier to identify

## Testing

Refer to Jira

