### PR TITLE
AO3-5376 Add complete field to series and work bookmarkables

### DIFF
--- a/app/models/series.rb
+++ b/app/models/series.rb
@@ -227,7 +227,8 @@ class Series < ApplicationRecord
   def bookmarkable_json
     as_json(
       root: false,
-      only: [:title, :summary, :hidden_by_admin, :restricted, :created_at],
+      only: [:title, :summary, :hidden_by_admin, :restricted, :created_at,
+        :complete],
       methods: [:revised_at, :posted, :tag, :filter_ids, :rating_ids,
         :warning_ids, :category_ids, :fandom_ids, :character_ids,
         :relationship_ids, :freeform_ids, :pseud_ids, :creators, :language_id,

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -1512,7 +1512,7 @@ class Work < ApplicationRecord
     as_json(
       root: false,
       only: [:title, :summary, :hidden_by_admin, :restricted, :posted,
-        :created_at, :revised_at, :language_id, :word_count],
+        :created_at, :revised_at, :language_id, :word_count, :complete],
       methods: [:tag, :filter_ids, :rating_ids, :warning_ids, :category_ids,
         :fandom_ids, :character_ids, :relationship_ids, :freeform_ids,
         :pseud_ids, :creators, :collection_ids, :work_types]

--- a/features/bookmarks/bookmark_search.feature
+++ b/features/bookmarks/bookmark_search.feature
@@ -199,3 +199,27 @@ Feature: Search Bookmarks
       And I should see "Skies Grown Darker"
     When I follow "Edit Your Search"
     Then the field labeled "Bookmarker" should contain "testuser"
+
+  @new-search
+  Scenario: Search for bookmarks by the bookmarkable item's completion status
+    Given I have bookmarks of various completion statuses to search
+    When I fill in "Any field on work" with "complete: true"
+      And I press "Search bookmarks"
+    Then I should see "You searched for: complete: true"
+      And I should see "2 Found"
+      And I should see "Finished Work"
+      And I should see "Complete Series"
+      And I should not see "Incomplete Work"
+      And I should not see "Incomplete Series"
+      And I should not see "External Work"
+    When I follow "Edit Your Search"
+    Then the field labeled "Any field on work" should contain "complete: true"
+    When I fill in "Any field on work" with "complete: false"
+      And I press "Search bookmarks"
+    Then I should see "You searched for: complete: false"
+      And I should see "2 Found"
+      And I should see "Incomplete Work"
+      And I should see "Incomplete Series"
+      And I should not see "Finished Work"
+      And I should not see "Complete Series"
+      And I should not see "External Work"

--- a/features/step_definitions/bookmark_steps.rb
+++ b/features/step_definitions/bookmark_steps.rb
@@ -102,6 +102,24 @@ Given /^I have bookmarks to search by dates$/ do
   step %{all indexing jobs have been run}
 end
 
+Given /^I have bookmarks of various completion statuses to search$/ do
+  complete_work = FactoryGirl.create(:posted_work, title: "Finished Work")
+  incomplete_work = FactoryGirl.create(:posted_work, title: "Incomplete Work", complete: false, expected_number_of_chapters: 2)
+
+  complete_series = FactoryGirl.create(:series_with_a_work, title: "Complete Series", complete: true)
+  incomplete_series = FactoryGirl.create(:series_with_a_work, title: "Incomplete Series", complete: false)
+
+  external_work = FactoryGirl.create(:external_work, title: "External Work")
+
+  FactoryGirl.create(:bookmark, bookmarkable_id: complete_work.id)
+  FactoryGirl.create(:bookmark, bookmarkable_id: incomplete_work.id)
+  FactoryGirl.create(:bookmark, bookmarkable_id: complete_series.id, bookmarkable_type: "Series")
+  FactoryGirl.create(:bookmark, bookmarkable_id: incomplete_series.id, bookmarkable_type: "Series")
+  FactoryGirl.create(:bookmark, bookmarkable_id: external_work.id, bookmarkable_type: "ExternalWork")
+
+  step %{all indexing jobs have been run}
+end
+
 When /^I bookmark the work "(.*?)"(?: as "(.*?)")?(?: with the note "(.*?)")?(?: with the tags "(.*?)")?$/ do |title, pseud, note, tags|
   step %{I start a new bookmark for "#{title}"}
   select(pseud, from: "bookmark_pseud_id") unless pseud.nil?


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5376

## Purpose

Index series and work bookmarkable documents on whether or not they are complete so it is once again possible to search for `complete: true` on bookmarked items.

## Testing

Refer to Jira
