### PR TITLE
AO3-5377 Use whitelist, not blacklist, for indexing fields

### DIFF
--- a/app/models/search/bookmark_indexer.rb
+++ b/app/models/search/bookmark_indexer.rb
@@ -81,6 +81,11 @@ class BookmarkIndexer < Indexer
     tags = object.tags
     json_object = object.as_json(
       root: false,
+      only: [
+        :id, :created_at, :bookmarkable_type, :bookmarkable_id, :user_id, 
+        :notes, :private, :updated_at, :hidden_by_admin, :pseud_id, :rec, 
+        :delta, :notes_sanitizer_version
+      ],
       except: [:notes_sanitizer_version, :delta],
       methods: [:bookmarker, :collection_ids, :with_notes, :bookmarkable_date]
     ).merge(

--- a/app/models/search/bookmark_indexer.rb
+++ b/app/models/search/bookmark_indexer.rb
@@ -82,9 +82,8 @@ class BookmarkIndexer < Indexer
     json_object = object.as_json(
       root: false,
       only: [
-        :id, :created_at, :bookmarkable_type, :bookmarkable_id, :user_id, 
-        :notes, :private, :updated_at, :hidden_by_admin, :pseud_id, :rec, 
-        :delta, :notes_sanitizer_version
+        :id, :created_at, :bookmarkable_type, :bookmarkable_id, :user_id,
+        :notes, :private, :updated_at, :hidden_by_admin, :pseud_id, :rec
       ],
       except: [:notes_sanitizer_version, :delta],
       methods: [:bookmarker, :collection_ids, :with_notes, :bookmarkable_date]

--- a/app/models/search/bookmark_indexer.rb
+++ b/app/models/search/bookmark_indexer.rb
@@ -85,7 +85,6 @@ class BookmarkIndexer < Indexer
         :id, :created_at, :bookmarkable_type, :bookmarkable_id, :user_id,
         :notes, :private, :updated_at, :hidden_by_admin, :pseud_id, :rec
       ],
-      except: [:notes_sanitizer_version, :delta],
       methods: [:bookmarker, :collection_ids, :with_notes, :bookmarkable_date]
     ).merge(
       user_id: object.pseud&.user_id,

--- a/app/models/search/work_indexer.rb
+++ b/app/models/search/work_indexer.rb
@@ -45,6 +45,17 @@ class WorkIndexer < Indexer
   def document(object)
     object.as_json(
       root: false,
+      only: [
+        :id, :expected_number_of_chapters, :created_at, :updated_at, 
+        :major_version, :minor_version, :posted, :language_id, :restricted, 
+        :title, :summary, :notes, :word_count, :hidden_by_admin, :delta, 
+        :revised_at, :authors_to_sort_on, :title_to_sort_on, :backdate, 
+        :endnotes, :imported_from_url, :hit_count_old, :last_visitor_old, 
+        :complete, :summary_sanitizer_version, :notes_sanitizer_version, 
+        :endnotes_sanitizer_version, :work_skin_id, :in_anon_collection, 
+        :in_unrevealed_collection, :anon_commenting_disabled, :ip_address, 
+        :spam, :spam_checked_at, :moderated_commenting_enabled
+      ],
       except: [
         :delta, :summary_sanitizer_version, :notes_sanitizer_version,
         :endnotes_sanitizer_version, :hit_count_old, :last_visitor_old,

--- a/app/models/search/work_indexer.rb
+++ b/app/models/search/work_indexer.rb
@@ -46,15 +46,12 @@ class WorkIndexer < Indexer
     object.as_json(
       root: false,
       only: [
-        :id, :expected_number_of_chapters, :created_at, :updated_at, 
-        :major_version, :minor_version, :posted, :language_id, :restricted, 
-        :title, :summary, :notes, :word_count, :hidden_by_admin, :delta, 
-        :revised_at, :authors_to_sort_on, :title_to_sort_on, :backdate, 
-        :endnotes, :imported_from_url, :hit_count_old, :last_visitor_old, 
-        :complete, :summary_sanitizer_version, :notes_sanitizer_version, 
-        :endnotes_sanitizer_version, :work_skin_id, :in_anon_collection, 
-        :in_unrevealed_collection, :anon_commenting_disabled, :ip_address, 
-        :spam, :spam_checked_at, :moderated_commenting_enabled
+        :id, :expected_number_of_chapters, :created_at, :updated_at,
+        :major_version, :minor_version, :posted, :language_id, :restricted,
+        :title, :summary, :notes, :word_count, :hidden_by_admin, :revised_at,
+        :authors_to_sort_on, :title_to_sort_on, :backdate, :endnotes,
+        :imported_from_url, :complete, :work_skin_id, :in_anon_collection,
+        :in_unrevealed_collection,
       ],
       except: [
         :delta, :summary_sanitizer_version, :notes_sanitizer_version,

--- a/app/models/search/work_indexer.rb
+++ b/app/models/search/work_indexer.rb
@@ -53,11 +53,6 @@ class WorkIndexer < Indexer
         :imported_from_url, :complete, :work_skin_id, :in_anon_collection,
         :in_unrevealed_collection,
       ],
-      except: [
-        :delta, :summary_sanitizer_version, :notes_sanitizer_version,
-        :endnotes_sanitizer_version, :hit_count_old, :last_visitor_old,
-        :anon_commenting_disabled, :ip_address, :spam, :spam_checked_at,
-        :moderated_commenting_disabled],
       methods: [
         :rating_ids,
         :warning_ids,


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5377

## Purpose

For bookmarks and works, we previously indexed all fields except [names of fields]. This had the potential to go very wrong, so now we index only [names of fields].

I did `names = Model.columns.map(&:name)`, `names.map &:to_sym`, and then pasted the output, so there wouldn't be too much room for human error in terms of typos in field names. I also did it in three separate commits to make it easier (possibly) to see what was removed from the whole list.

## Testing

Refer to Jira