### PR TITLE
AO3-5369 work previous/next chapter navigation to anchor on main content

### DIFF
--- a/app/views/comments/_commentable.html.erb
+++ b/app/views/comments/_commentable.html.erb
@@ -9,11 +9,11 @@
     <% end %>
 
     <% if @work && @previous_chapter %>
-      <li><%= link_to '&#8592;'.html_safe + ts('Previous Chapter'), [@work, @previous_chapter] %></li>
+      <li><%= link_to '&#8592;'.html_safe + ts('Previous Chapter'), [@work, @previous_chapter, :anchor => "workskin"] %></li>
     <% end %>
 
     <% if @work && @next_chapter %>
-      <li><%= link_to h(ts('Next Chapter')) + ' &#8594;'.html_safe, [@work, @next_chapter] %></li>
+      <li><%= link_to h(ts('Next Chapter')) + ' &#8594;'.html_safe, [@work, @next_chapter, :anchor => "workskin"] %></li>
     <% end %>
 
     <% if @previous_admin_post %>

--- a/app/views/works/_work_header_navigation.html.erb
+++ b/app/views/works/_work_header_navigation.html.erb
@@ -17,11 +17,11 @@
     <li class="chapter entire"><%= link_to ts("Entire Work"), work_path(@work, :view_full_work => 'true') %></li>
 
     <% if @previous_chapter %>
-      <li class="chapter previous"><%= link_to '&#8592; '.html_safe + ts("Previous Chapter"), [@work, @previous_chapter] %></li>
+      <li class="chapter previous"><%= link_to '&#8592; '.html_safe + ts("Previous Chapter"), [@work, @previous_chapter, :anchor => "workskin"] %></li>
     <% end %>
 
     <% if @next_chapter %>
-      <li class="chapter next"><%= link_to h(ts("Next Chapter")) + ' &#8594;'.html_safe, [@work, @next_chapter] %></li>
+      <li class="chapter next"><%= link_to h(ts("Next Chapter")) + ' &#8594;'.html_safe, [@work, @next_chapter, :anchor => "workskin"] %></li>
     <% end %>
 
     <li class="chapter" aria-haspopup="true">
@@ -56,7 +56,7 @@
     </li>
 
     <% unless current_user.is_author_of?(@work) || current_user.try(:preference).try(:history_enabled) == false %>
-    <li class="mark"> 
+    <li class="mark">
       <% if marked_for_later?(@work) %>
         <%= mark_as_read_link(@work) %>
       <% else %>
@@ -68,7 +68,7 @@
 
   <li class="comments" id="show_comments_link_top">
     <% # If in single chapter view, show comments for the chapter; otherwise, show the comments for the entire work %>
-    <% @previous_chapter || @next_chapter ? commentable = @chapter : commentable = @work %> 
+    <% @previous_chapter || @next_chapter ? commentable = @chapter : commentable = @work %>
     <% if commentable.count_visible_comments > 0 %>
       <%= show_hide_comments_link(commentable) %>
     <% else %>
@@ -82,7 +82,7 @@
       <%= link_to ts("Unreviewed Comments") + " (" + @work.find_all_comments.unreviewed_only.count.to_s + ")" , unreviewed_work_comments_path(@work) %>
     </li>
   <% end %>
-  
+
   <% # allow user to disable style on work if it has been customized %>
   <% if @work.work_skin %>
     <li class="style">
@@ -102,7 +102,7 @@
       <%= render 'share/share', :shareable => @work %>
     </li>
   <% end %>
-  
+
   <% if current_user && @subscription %>
     <li class="subscribe">
       <%= render 'subscriptions/form', :subscription => @subscription %>


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [ ] Have you added tests for any changed functionality? (see testing - automated)
* [x] Have you added the JIRA issue number as the *first* thing in your pull request title (eg: `AO3-1234 Fix thing`)
* [x] Have you updated the JIRA issue with the information below?

## Issue

https://otwarchive.atlassian.net/browse/AO3-5369

## Purpose

Work previous/next chapter navigations to anchor on main content

## Testing

manual: pick multichapter work, verify that the previous/next chapter buttons in header navigation section and comment section skip past header/meta sections and start on main content (div id = workskin)  

automated: wasnt sure if there were any to add. asserting on anchor tag seems discouraged in capybara, and the existing examples (rspec) seemed more relevant had the anchor been passed by controller

## References

~~Are there any other relevant issues / PRs / mailing lists discussions related to this?~~

## Credit

~~*What name do you want us to use to credit your work in the [Archive of Our Own's Release Notes](http://archiveofourown.org/admin_posts?tag=1)?*~~

~~*What pronouns do you prefer (she/her, he/him, zie/hir etc)?*~~

(if you do not fill this in, we will use your GitHub account name and will use "they" to avoid making assumptions about your gender)  :ok_hand: 
