### PR TITLE
AO3-5368 update wording of work status for page filter and search page

### DIFF
--- a/app/views/works/_filters.html.erb
+++ b/app/views/works/_filters.html.erb
@@ -109,19 +109,19 @@
               <li>
                 <%= f.label :complete, value: "" do %>
                   <%= f.radio_button :complete, "" %>
-                  <%= label_indicator_and_text(ts("Both complete and incomplete")) %>
+                  <%= label_indicator_and_text(ts("All works")) %>
                 <% end %>
               </li>
               <li>
                 <%= f.label :complete, value: "T" do %>
                   <%= f.radio_button :complete, "T" %>
-                  <%= label_indicator_and_text(ts("Only complete works")) %>
+                  <%= label_indicator_and_text(ts("Complete works only")) %>
                 <% end %>
               </li>
               <li>
                 <%= f.label :complete, value: "F" do %>
                   <%= f.radio_button :complete, "F" %>
-                  <%= label_indicator_and_text(ts("Only incomplete works")) %>
+                  <%= label_indicator_and_text(ts("Works in progress only")) %>
                 <% end %>
               </li>
             </ul>

--- a/app/views/works/_search_form.html.erb
+++ b/app/views/works/_search_form.html.erb
@@ -36,15 +36,15 @@
           <ul>
             <li>
               <%= f.radio_button :complete, "" %>
-              <%= f.label :complete, ts("Both complete and incomplete"), value: "" %>
+              <%= f.label :complete, ts("All works"), value: "" %>
             </li>
             <li>
               <%= f.radio_button :complete, "T" %>
-              <%= f.label :complete, ts("Only complete works"), value: "T" %>
+              <%= f.label :complete, ts("Complete works only"), value: "T" %>
             </li>
             <li>
               <%= f.radio_button :complete, "F" %>
-              <%= f.label :complete, ts("Only incomplete works"), value: "F" %>
+              <%= f.label :complete, ts("Works in progress only"), value: "F" %>
             </li>
           </ul>
         </dd>

--- a/features/search/works_stats.feature
+++ b/features/search/works_stats.feature
@@ -84,7 +84,7 @@ Feature: Search works by stats
       And "Ascending" should be selected within "Sort direction"
 
   # This is basically the same scenario as above, but the new search has
-  # changed the "Complete" checkbox into a "Only complete works" radio button,
+  # changed the "Complete" checkbox into a "Complete works only" radio button,
   # and work status is no longer included in the search summary (AO3-5329).
   # So we need a slightly different scenario.
   @new-search
@@ -130,7 +130,7 @@ Feature: Search works by stats
     Then the field labeled "Kudos" should contain "<2"
       And "Kudos" should be selected within "Sort by"
       And "Ascending" should be selected within "Sort direction"
-    When I choose "Only complete works"
+    When I choose "Complete works only"
       And I press "Search" within "#new_work_search"
     When "AO3-5329" is fixed
     # Then I should see "You searched for: Complete kudos count: <2 sort by: kudos ascending"
@@ -142,7 +142,7 @@ Feature: Search works by stats
       And the 4th result should contain "Kudos: 1"
     When I follow "Edit Your Search"
     Then the field labeled "Kudos" should contain "<2"
-      And the "Only complete works" checkbox should be checked
+      And the "Complete works only" checkbox should be checked
       And "Ascending" should be selected within "Sort direction"
 
   Scenario: Search by exact number of comments


### PR DESCRIPTION
# Pull Request Checklist

* [ ] Have you added tests for any changed functionality?
* [x] Have you updated the JIRA issue with the information below?

## Issue

https://otwarchive.atlassian.net/browse/AO3-5368

## Purpose

Updates wording of "Status" portion of Works search/filter to match usual wording

## Testing

[assuming new search is enabled] verify descriptions "All works", "Complete works only", and "Works in progress only" for:
- (Work Search) Search > Works > Status
- (Work Filter) Browse > Tags > Select AnyTag? > Filters > Status

~~helloworld PRs continue~~