### PR TITLE
AO3-5374 Divide bookmark search form into field sets

### DIFF
--- a/app/views/bookmarks/_search_form.html.erb
+++ b/app/views/bookmarks/_search_form.html.erb
@@ -19,7 +19,7 @@
       <%= f.text_field :other_tag_names, autocomplete_options("tag") %>
     </dd>
     <dt>
-      <%= f.label :bookmarkable_type, ts("Work type") %>
+      <%= f.label :bookmarkable_type, ts("Item type") %>
       <%= link_to_help "bookmark-search-type-help" %>
     </dt>
     <dd>

--- a/app/views/bookmarks/_search_form.html.erb
+++ b/app/views/bookmarks/_search_form.html.erb
@@ -19,7 +19,7 @@
       <%= f.text_field :other_tag_names, autocomplete_options("tag") %>
     </dd>
     <dt>
-      <%= f.label :bookmarkable_type, ts("Item type") %>
+      <%= f.label :bookmarkable_type, ts("Type") %>
       <%= link_to_help "bookmark-search-type-help" %>
     </dt>
     <dd>

--- a/app/views/bookmarks/_search_form.html.erb
+++ b/app/views/bookmarks/_search_form.html.erb
@@ -1,6 +1,8 @@
-<%= form_for @search, as: :bookmark_search, url: search_bookmarks_path, html: { class: "search", method: :get } do |f| %>
+<%= form_for @search, as: :bookmark_search, url: search_bookmarks_path,
+    html: { class: "search", method: :get } do |f| %>
 <fieldset>
-  <legend>Search bookmarks</legend>
+  <legend><%= ts("Bookmarked Item") %></legend>
+  <h3 class="landmark heading"><%= ts("Bookmarked Item") %></h3>
   <dl>
     <dt>
       <%= f.label :bookmarkable_query, ts('Any field on work') %>
@@ -10,27 +12,6 @@
       <%= f.text_field :bookmarkable_query %>
     </dd>
     <dt>
-      <%= f.label :bookmark_query, ts('Any field on bookmark') %>
-      <%= link_to_help "bookmark-search-text-help" %>
-    </dt>
-    <dd>
-      <%= f.text_field :bookmark_query %>
-    </dd>
-    <dt>
-      <%= f.label :bookmarker, ts('Bookmarker') %>
-      <%= link_to_help "bookmark-search-text-help" %>
-    </dt>
-    <dd>
-      <%= f.text_field :bookmarker %>
-    </dd>
-    <dt>
-      <%= f.label :bookmark_notes, ts("Notes") %>
-      <%= link_to_help "bookmark-search-text-help" %>
-    </dt>
-    <dd>
-      <%= f.text_field :bookmark_notes %>
-    </dd>
-    <dt>
       <%= f.label :other_tag_names, ts("Work tags") %>
       <%= link_to_help "bookmark-search-tag-help" %>
     </dt>
@@ -38,39 +19,12 @@
       <%= f.text_field :other_tag_names, autocomplete_options("tag") %>
     </dd>
     <dt>
-      <%= f.label :other_bookmark_tag_names, ts("Bookmarker's tags") %>
-      <%= link_to_help "bookmark-search-tag-help" %>
-    </dt>
-    <dd>
-      <%= f.text_field :other_bookmark_tag_names, autocomplete_options("tag") %>
-    </dd>
-    <dt>
-      <%= f.label :rec, ts("Rec") %>
-      <%= link_to_help "bookmark-search-rec-help" %>
-    </dt>
-    <dd>
-      <%= f.check_box :rec  %>
-    </dd>
-    <dt>
-      <%= f.label :with_notes, ts("With notes") %>
-      <%= link_to_help "bookmark-search-notes-help" %>
-    </dt>
-    <dd>
-      <%= f.check_box :with_notes  %>
-    </dd>
-    <dt>
-      <%= f.label :bookmarkable_type, ts("Type") %>
+      <%= f.label :bookmarkable_type, ts("Work type") %>
       <%= link_to_help "bookmark-search-type-help" %>
     </dt>
     <dd>
-      <%= f.select :bookmarkable_type, options_for_select(["",  "Work", "Series", "External Work"]) %>
-    </dd>
-    <dt>
-      <%= f.label :date, ts('Date bookmarked') %>
-      <%= link_to_help "bookmark-search-date-bookmarked-help" %>
-    </dt>
-    <dd>
-      <%= f.text_field :date %>
+      <%= f.select :bookmarkable_type,
+                   options_for_select(["", "Work", "Series", "External Work"]) %>
     </dd>
     <dt>
       <%= f.label :bookmarkable_date, ts('Date updated') %>
@@ -79,14 +33,81 @@
     <dd>
       <%= f.text_field :bookmarkable_date %>
     </dd>
-    <dt>
-      <%= f.label :sort_column, ts("Sort by") %>
-    </dt>
-    <dd>
-      <%= f.select :sort_column, options_for_select(@search.sort_options, @search.sort_column), { :include_blank => "Best Match" } %>
-    </dd>
-    <dt class="landmark">Submit</dt>
-    <dd class="submit actions"><%= f.submit ts('Search bookmarks') %></dd>
-</dl>
+  </dl>
 </fieldset>
+
+  <fieldset>
+    <legend><%= ts("Bookmark") %></legend>
+    <h3 class="landmark heading"><%= ts("Bookmark") %></h3>
+    <dl>
+      <dt>
+        <%= f.label :bookmark_query, ts('Any field on bookmark') %>
+        <%= link_to_help "bookmark-search-text-help" %>
+      </dt>
+      <dd>
+        <%= f.text_field :bookmark_query %>
+      </dd>
+      <dt>
+        <%= f.label :other_bookmark_tag_names, ts("Bookmarker's tags") %>
+        <%= link_to_help "bookmark-search-tag-help" %>
+      </dt>
+      <dd>
+        <%= f.text_field :other_bookmark_tag_names, autocomplete_options("tag") %>
+      </dd>
+      <dt>
+        <%= f.label :bookmarker, ts('Bookmarker') %>
+        <%= link_to_help "bookmark-search-text-help" %>
+      </dt>
+      <dd>
+        <%= f.text_field :bookmarker %>
+      </dd>
+      <dt>
+        <%= f.label :bookmark_notes, ts("Notes") %>
+        <%= link_to_help "bookmark-search-text-help" %>
+      </dt>
+      <dd>
+        <%= f.text_field :bookmark_notes %>
+      </dd>
+      <dt>
+        <%= ts("Bookmark type") %>
+      </dt>
+      <dd>
+        <ul>
+          <li>
+            <%= f.check_box :rec  %>
+            <%= f.label :rec, ts("Rec") %>
+            <%= link_to_help "bookmark-search-rec-help" %>
+          </li>
+          <li>
+            <%= f.check_box :with_notes  %>
+            <%= f.label :with_notes, ts("With notes") %>
+            <%= link_to_help "bookmark-search-notes-help" %>
+          </li>
+        </ul>
+      </dd>
+      <dt>
+        <%= f.label :date, ts('Date bookmarked') %>
+        <%= link_to_help "bookmark-search-date-bookmarked-help" %>
+      </dt>
+      <dd>
+        <%= f.text_field :date %>
+      </dd>
+    </dl>
+  </fieldset>
+
+  <fieldset>
+    <legend><%= ts("Search") %></legend>
+    <h3 class="landmark heading"><%= ts("Search") %></h3>
+    <dl>
+      <dt>
+        <%= f.label :sort_column, ts("Sort by") %>
+      </dt>
+      <dd>
+        <%= f.select :sort_column,
+                     options_for_select(@search.sort_options, @search.sort_column),
+                     { :include_blank => ts("Best Match") } %>
+      </dd>
+    </dl>
+    <p class="submit"><%= f.submit ts("Search Bookmarks") %></p>
+  </fieldset>
 <% end %>

--- a/app/views/bookmarks/_search_form_old.html.erb
+++ b/app/views/bookmarks/_search_form_old.html.erb
@@ -72,7 +72,7 @@
       <%= f.select :sort_column, options_for_select(@search.sort_options, @search.sort_column), { :include_blank => "Best Match" } %>
     </dd>
     <dt class="landmark">Submit</dt>
-    <dd class="submit actions"><%= f.submit ts('Search Bookmarks') %></dd>
+    <dd class="submit actions"><%= f.submit ts('Search bookmarks') %></dd>
 </dl>
 </fieldset>
 <% end %>

--- a/app/views/bookmarks/_search_form_old.html.erb
+++ b/app/views/bookmarks/_search_form_old.html.erb
@@ -72,7 +72,7 @@
       <%= f.select :sort_column, options_for_select(@search.sort_options, @search.sort_column), { :include_blank => "Best Match" } %>
     </dd>
     <dt class="landmark">Submit</dt>
-    <dd class="submit actions"><%= f.submit ts('Search bookmarks') %></dd>
+    <dd class="submit actions"><%= f.submit ts('Search Bookmarks') %></dd>
 </dl>
 </fieldset>
 <% end %>

--- a/features/bookmarks/bookmark_search.feature
+++ b/features/bookmarks/bookmark_search.feature
@@ -183,7 +183,7 @@ Feature: Search Bookmarks
     When "AO3-3583" is fixed
     # Then "External Work" should be selected within "Type"
     When I select "Series" from "Type"
-      And I press "Search bookmarks"
+      And I press "Search Bookmarks"
     Then I should see "You searched for: Type: Series"
       And I should see "2 Found"
 
@@ -234,7 +234,7 @@ Feature: Search Bookmarks
   Scenario: Search for bookmarks by the bookmarkable item's completion status
     Given I have bookmarks of various completion statuses to search
     When I fill in "Any field on work" with "complete: true"
-      And I press "Search bookmarks"
+      And I press "Search Bookmarks"
     Then I should see "You searched for: complete: true"
       And I should see "2 Found"
       And I should see "Finished Work"
@@ -245,7 +245,7 @@ Feature: Search Bookmarks
     When I follow "Edit Your Search"
     Then the field labeled "Any field on work" should contain "complete: true"
     When I fill in "Any field on work" with "complete: false"
-      And I press "Search bookmarks"
+      And I press "Search Bookmarks"
     Then I should see "You searched for: complete: false"
       And I should see "2 Found"
       And I should see "Incomplete Work"

--- a/features/bookmarks/bookmark_search.feature
+++ b/features/bookmarks/bookmark_search.feature
@@ -11,7 +11,7 @@ Feature: Search Bookmarks
   Scenario: Search bookmarks by tag
     Given I have bookmarks to search
     When I fill in "Tag" with "classic"
-      And I press "Search bookmarks"
+      And I press "Search Bookmarks"
     Then I should see the page title "Search Bookmarks"
       And I should see "You searched for: Tags: classic"
       And I should see "1 Found"
@@ -25,7 +25,7 @@ Feature: Search Bookmarks
 
     # Only on bookmarks
     When I fill in "Bookmarker's tags" with "rare"
-      And I press "Search bookmarks"
+      And I press "Search Bookmarks"
     Then I should see the page title "Search Bookmarks"
       And I should see "You searched for: Tags: rare"
       And I should see "1 Found"
@@ -36,7 +36,7 @@ Feature: Search Bookmarks
     # Only on bookmarkables
     When I am on the search bookmarks page
       And I fill in "Work tags" with "rare"
-      And I press "Search bookmarks"
+      And I press "Search Bookmarks"
     Then I should see the page title "Search Bookmarks"
       And I should see "You searched for: Tags: rare"
       And I should see "1 Found"
@@ -45,10 +45,10 @@ Feature: Search Bookmarks
     Then the field labeled "Work tags" should contain "rare"
 
     # On bookmarks and bookmarkables, results should match both
-    When I am on the search bookmarks page
+    When I am on the search Bookmarks page
       And I fill in "Bookmarker's tags" with "rare"
       And I fill in "Work tags" with "rare"
-      And I press "Search bookmarks"
+      And I press "Search Bookmarks"
     Then I should see the page title "Search Bookmarks"
       And I should see "You searched for: Tags: rare"
       And I should see "No results found."
@@ -56,7 +56,7 @@ Feature: Search Bookmarks
   Scenario: Search bookmarks by date bookmarked
     Given I have bookmarks to search by dates
     When I fill in "Date bookmarked" with "> 900 days ago"
-      And I press "Search bookmarks"
+      And I press "Search Bookmarks"
     Then I should see the page title "Search Bookmarks"
       And I should see "You searched for: Date bookmarked: > 900 days ago"
       And I should see "1 Found"
@@ -65,7 +65,7 @@ Feature: Search Bookmarks
     Then the field labeled "Date bookmarked" should contain "> 900 days ago"
 
     When I fill in "Date bookmarked" with "< 900 days ago"
-      And I press "Search bookmarks"
+      And I press "Search Bookmarks"
     Then I should see "You searched for: Date bookmarked: < 900 days ago"
       And I should see "2 Found"
       And I should see "New bookmark of old work"
@@ -74,7 +74,7 @@ Feature: Search Bookmarks
   Scenario: Search bookmarks by date updated
     Given I have bookmarks to search by dates
     When I fill in "Date updated" with "> 900 days ago"
-      And I press "Search bookmarks"
+      And I press "Search Bookmarks"
     Then I should see the page title "Search Bookmarks"
       And I should see "You searched for: Date updated: > 900 days ago"
       And I should see "2 Found"
@@ -84,7 +84,7 @@ Feature: Search Bookmarks
     Then the field labeled "Date updated" should contain "> 900 days ago"
 
     When I fill in "Date updated" with "< 900 days ago"
-      And I press "Search bookmarks"
+      And I press "Search Bookmarks"
     Then I should see "You searched for: Date updated: < 900 days ago"
       And I should see "1 Found"
       And I should see "New bookmark of new work"
@@ -92,7 +92,7 @@ Feature: Search Bookmarks
   Scenario: Search bookmarks for recs
     Given I have bookmarks to search
     When I check "Rec"
-      And I press "Search bookmarks"
+      And I press "Search Bookmarks"
     Then I should see the page title "Search Bookmarks"
       And I should see "You searched for: Rec"
       And I should see "1 Found"
@@ -104,7 +104,7 @@ Feature: Search Bookmarks
   Scenario: Search bookmarks by any field
     Given I have bookmarks to search
     When I fill in "Any field" with "Hobbits"
-      And I press "Search bookmarks"
+      And I press "Search Bookmarks"
     Then I should see the page title "Bookmarks Matching 'Hobbits'"
       And I should see "You searched for: Hobbits"
       And I should see "No results found."
@@ -117,7 +117,7 @@ Feature: Search Bookmarks
 
     # Only on bookmarks
     When I fill in "Any field on bookmark" with "more please"
-      And I press "Search bookmarks"
+      And I press "Search Bookmarks"
     Then I should see the page title "Bookmarks Matching 'more please'"
       And I should see "You searched for: more please"
       And I should see "2 Found"
@@ -129,7 +129,7 @@ Feature: Search Bookmarks
     # Only on bookmarkables
     When I am on the search bookmarks page
       And I fill in "Any field on work" with "hurt"
-      And I press "Search bookmarks"
+      And I press "Search Bookmarks"
     Then I should see the page title "Bookmarks Matching 'hurt'"
       And I should see "You searched for: hurt"
       And I should see "2 Found"
@@ -142,7 +142,7 @@ Feature: Search Bookmarks
     When I am on the search bookmarks page
       And I fill in "Any field on bookmark" with "more please"
       And I fill in "Any field on work" with "hurt"
-      And I press "Search bookmarks"
+      And I press "Search Bookmarks"
     Then I should see the page title "Bookmarks Matching 'hurt, more please'"
       And I should see "You searched for: hurt, more please"
       And I should see "1 Found"
@@ -151,7 +151,7 @@ Feature: Search Bookmarks
   Scenario: Search bookmarks by type
     Given I have bookmarks to search
     When I select "External Work" from "Type"
-      And I press "Search bookmarks"
+      And I press "Search Bookmarks"
     Then I should see the page title "Search Bookmarks"
       And I should see "You searched for: Type: External Work"
       And I should see "1 Found"
@@ -164,7 +164,7 @@ Feature: Search Bookmarks
   results by the note content
     Given I have bookmarks to search
     When I check "With notes"
-      And I press "Search bookmarks"
+      And I press "Search Bookmarks"
     Then I should see the page title "Search Bookmarks"
       And I should see "You searched for: With Notes"
       And I should see "2 Found"
@@ -173,7 +173,7 @@ Feature: Search Bookmarks
     When I follow "Edit Your Search"
     Then the "With notes" checkbox should be checked
     When I fill in "Notes" with "broken heart"
-      And I press "Search bookmarks"
+      And I press "Search Bookmarks"
     Then I should see the page title "Search Bookmarks"
       And I should see "You searched for: Notes: broken heart, With Notes"
     When "AO3-3943" is fixed
@@ -187,7 +187,7 @@ Feature: Search Bookmarks
   the bookmarker testuser returns all of tester_pseud's bookmarks
     Given I have bookmarks to search
     When I fill in "Bookmarker" with "testuser"
-      And I press "Search bookmarks"
+      And I press "Search Bookmarks"
     Then I should see the page title "Search Bookmarks"
       And I should see "You searched for: Bookmarker: testuser"
       And I should see "6 Found"


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5374

## Purpose

Divides the bookmark search form up to be a bit less overwhelming. Refer to issue for screenshot.

## Testing

All fields on the new bookmark search form should still work.