### PR TITLE
AO3-5275 Centralize Elasticsearch prefix

### DIFF
--- a/app/models/bookmark.rb
+++ b/app/models/bookmark.rb
@@ -162,7 +162,7 @@ class Bookmark < ApplicationRecord
   # Remove conditional and Tire reference
   def self.index_name
     if use_new_search?
-      "ao3_#{Rails.env}_bookmarks"
+      "#{ArchiveConfig.ELASTICSEARCH_PREFIX}_#{Rails.env}_bookmarks"
     else
       tire.index.name
     end

--- a/app/models/pseud.rb
+++ b/app/models/pseud.rb
@@ -130,7 +130,7 @@ class Pseud < ApplicationRecord
   # Remove conditional and Tire reference
   def self.index_name
     if use_new_search?
-      "ao3_#{Rails.env}_pseuds"
+      "#{ArchiveConfig.ELASTICSEARCH_PREFIX}_#{Rails.env}_pseuds"
     else
       tire.index.name
     end

--- a/app/models/search/bookmarkable_indexer.rb
+++ b/app/models/search/bookmarkable_indexer.rb
@@ -1,7 +1,7 @@
 class BookmarkableIndexer < Indexer
 
   def self.index_name
-    "ao3_#{Rails.env}_bookmarks"
+    "#{ArchiveConfig.ELASTICSEARCH_PREFIX}_#{Rails.env}_bookmarks"
   end
 
   def self.document_type

--- a/app/models/search/indexer.rb
+++ b/app/models/search/indexer.rb
@@ -104,7 +104,7 @@ class Indexer
   end
 
   def self.index_name
-    "ao3_#{Rails.env}_#{klass.underscore.pluralize}"
+    "#{ArchiveConfig.ELASTICSEARCH_PREFIX}_#{Rails.env}_#{klass.underscore.pluralize}"
   end
 
   def self.document_type

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -29,7 +29,7 @@ class Tag < ApplicationRecord
   # Remove conditional and Tire reference
   def self.index_name
     if use_new_search?
-      "ao3_#{Rails.env}_works"
+      "#{ArchiveConfig.ELASTICSEARCH_PREFIX}_#{Rails.env}_works"
     else
       tire.index.name
     end

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -281,7 +281,7 @@ class Work < ApplicationRecord
   # Remove conditional and Tire reference
   def self.index_name
     if use_new_search?
-      "ao3_#{Rails.env}_works"
+      "#{ArchiveConfig.ELASTICSEARCH_PREFIX}_#{Rails.env}_works"
     else
       tire.index.name
     end

--- a/config/config.yml
+++ b/config/config.yml
@@ -367,6 +367,13 @@ ACTION_NEW_EMAIL: 9
 ACTION_TROUBLESHOOT: 10
 
 
+# Elasticsearch index prefix
+# If you're using webdev or another shared environment, change this to include
+# your username (e.g. ao3_testy) to ensure all users have separate search
+# indexes
+ELASTICSEARCH_PREFIX: 'ao3'
+
+
 ##### For dumping the seed database and NOT clearing emails on stage
 
 # users who have webdavs or asked to be added


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5275

## Purpose

Makes it easier to modify the Elasticsearch index prefix if you're working on webdev or another shared environment.

