### PR TITLE
AO3-3468 Change authors_to_sort_on from a column to a method

### DIFF
--- a/app/models/pseud.rb
+++ b/app/models/pseud.rb
@@ -73,6 +73,7 @@ class Pseud < ApplicationRecord
 
   after_update :check_default_pseud
   after_update :expire_caches
+  after_update :reindex_works
 
   scope :on_works, lambda {|owned_works|
     select("DISTINCT pseuds.*").
@@ -138,13 +139,6 @@ class Pseud < ApplicationRecord
 
   def self.not_orphaned
     where("user_id != ?", User.orphan_account)
-  end
-
-  def update_author_sorting
-    works.each do |work|
-      work.set_author_sorting
-      work.save!
-    end
   end
 
   # Enigel Dec 12 08: added sort method
@@ -497,4 +491,15 @@ class Pseud < ApplicationRecord
     end
   end
 
+  def should_reindex_works?
+    pertinent_attributes = %w[id name]
+    destroyed? || (saved_changes.keys & pertinent_attributes).present?
+  end
+
+  # If the pseud gets renamed, anything with the old name needs to be reindexed.
+  def reindex_works
+    return unless should_reindex_works?
+    IndexQueue.enqueue_ids(Work, works.pluck(:id), :main)
+    IndexQueue.enqueue_ids(Bookmark, bookmarks.pluck(:id), :main)
+  end
 end

--- a/app/models/search/work_indexer.rb
+++ b/app/models/search/work_indexer.rb
@@ -49,11 +49,12 @@ class WorkIndexer < Indexer
         :id, :expected_number_of_chapters, :created_at, :updated_at,
         :major_version, :minor_version, :posted, :language_id, :restricted,
         :title, :summary, :notes, :word_count, :hidden_by_admin, :revised_at,
-        :authors_to_sort_on, :title_to_sort_on, :backdate, :endnotes,
+        :title_to_sort_on, :backdate, :endnotes,
         :imported_from_url, :complete, :work_skin_id, :in_anon_collection,
         :in_unrevealed_collection,
       ],
       methods: [
+        :authors_to_sort_on,
         :rating_ids,
         :warning_ids,
         :category_ids,

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -558,7 +558,6 @@
     if login.downcase == login_before_last_save.downcase
       old_pseud.name = login
       old_pseud.save!
-      old_pseud.update_author_sorting
       reindex_user_pseuds
     else
       new_pseud = pseuds.where(name: login).first
@@ -568,7 +567,6 @@
         # change the old pseud to match
         old_pseud.name = login
         old_pseud.save!(validate: false)
-        old_pseud.update_author_sorting
         reindex_user_pseuds
       else
         # shouldn't be able to get here, but just in case

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -132,18 +132,6 @@ class Work < ApplicationRecord
     end
   end
 
-  # ES UPGRADE TRANSITION #
-  # Drop unused database column authors_to_sort_on
-  def authors_to_sort_on
-    if self.anonymous?
-      "Anonymous"
-    elsif self.authors.present?
-      self.sorted_authors
-    else
-      self.sorted_pseuds
-    end
-  end
-
   # Makes sure the title has no leading spaces
   validate :clean_and_validate_title
 
@@ -1374,12 +1362,15 @@ class Work < ApplicationRecord
 
   SORTED_AUTHOR_REGEX = %r{^[\+\-=_\?!'"\.\/]}
 
-  def sorted_authors
-    self.authors.map(&:name).join(",  ").downcase.gsub(SORTED_AUTHOR_REGEX, '')
-  end
-
-  def sorted_pseuds
-    self.pseuds.map(&:name).join(",  ").downcase.gsub(SORTED_AUTHOR_REGEX, '')
+  # TODO drop unused database column authors_to_sort_on
+  def authors_to_sort_on
+    if self.anonymous?
+      "Anonymous"
+    elsif self.authors.present?
+      self.authors.map(&:name).join(",  ").downcase.gsub(SORTED_AUTHOR_REGEX, '')
+    else
+      self.pseuds.map(&:name).join(",  ").downcase.gsub(SORTED_AUTHOR_REGEX, '')
+    end
   end
 
   def sorted_title

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -132,14 +132,15 @@ class Work < ApplicationRecord
     end
   end
 
-  # Set the authors_to_sort_on value, which should be anon for anon works
-  def set_author_sorting
+  # ES UPGRADE TRANSITION #
+  # Drop unused database column authors_to_sort_on
+  def authors_to_sort_on
     if self.anonymous?
-      self.authors_to_sort_on = "Anonymous"
+      "Anonymous"
     elsif self.authors.present?
-      self.authors_to_sort_on = self.sorted_authors
+      self.sorted_authors
     else
-      self.authors_to_sort_on = self.sorted_pseuds
+      self.sorted_pseuds
     end
   end
 
@@ -191,9 +192,8 @@ class Work < ApplicationRecord
 
   after_save :save_chapters, :save_parents, :save_new_recipients
 
-  before_create :set_anon_unrevealed, :set_author_sorting
+  before_create :set_anon_unrevealed
   after_create :notify_after_creation
-  before_update :set_author_sorting
 
   before_save :check_for_invalid_tags
   before_update :validate_tags, :notify_before_update
@@ -1164,8 +1164,6 @@ class Work < ApplicationRecord
 
   scope :id_only, -> { select("works.id") }
 
-  scope :ordered_by_author_desc, -> { order("authors_to_sort_on DESC") }
-  scope :ordered_by_author_asc, -> { order("authors_to_sort_on ASC") }
   scope :ordered_by_title_desc, -> { order("title_to_sort_on DESC") }
   scope :ordered_by_title_asc, -> { order("title_to_sort_on ASC") }
   scope :ordered_by_word_count_desc, -> { order("word_count DESC") }

--- a/spec/models/work_search_form_spec.rb
+++ b/spec/models/work_search_form_spec.rb
@@ -239,7 +239,7 @@ describe WorkSearchForm do
         %w(21st_wombat 007aardvark).each do |pseud_name|
           create(:posted_work, authors: [create(:pseud, name: pseud_name)])
         end
-        update_and_refresh_indexes "work"
+        run_all_indexing_jobs
       end
 
       it "returns all works in the correct order of sortable pseud values" do
@@ -253,6 +253,29 @@ describe WorkSearchForm do
 
         work_search = WorkSearchForm.new(sort_column: "authors_to_sort_on", sort_direction: "desc")
         expect(work_search.search_results.map(&:authors_to_sort_on)).to eq sorted_pseuds_asc.reverse
+      end
+    end
+
+    describe "by authors who changes username" do
+      let!(:user_1) { create(:user, login: "cioelle") }
+      let!(:user_2) { create(:user, login: "ruth") }
+
+      before do
+        create(:posted_work, authors: [user_1.default_pseud])
+        create(:posted_work, authors: [user_2.default_pseud])
+        run_all_indexing_jobs
+      end
+
+      it "returns all works in the correct order of sortable pseud values" do
+        work_search = WorkSearchForm.new(sort_column: "authors_to_sort_on")
+        expect(work_search.search_results.map(&:authors_to_sort_on)).to eq ["cioelle", "ruth"]
+
+        user_1.login = "yabalchoath"
+        user_1.save!
+        run_all_indexing_jobs
+
+        work_search = WorkSearchForm.new(sort_column: "authors_to_sort_on")
+        expect(work_search.search_results.map(&:authors_to_sort_on)).to eq ["ruth", "yabalchoath"]
       end
     end
   end

--- a/spec/models/work_spec.rb
+++ b/spec/models/work_spec.rb
@@ -153,17 +153,15 @@ describe Work do
     end
   end
 
-  describe "#set_author_sorting" do
+  describe "#authors_to_sort_on" do
     let(:work) { build(:work) }
 
     context "when the pseuds start with special characters" do
       it "should remove those characters" do
         work.authors = [Pseud.new(name: "-jolyne")]
-        work.set_author_sorting
         expect(work.authors_to_sort_on).to eq "jolyne"
 
         work.authors = [Pseud.new(name: "_hermes")]
-        work.set_author_sorting
         expect(work.authors_to_sort_on).to eq "hermes"
       end
     end
@@ -171,7 +169,6 @@ describe Work do
     context "when the pseuds start with numbers" do
       it "should not remove numbers" do
         work.authors = [Pseud.new(name: "007james")]
-        work.set_author_sorting
         expect(work.authors_to_sort_on).to eq "007james"
       end
     end
@@ -180,7 +177,6 @@ describe Work do
       it "should set the author sorting to Anonymous" do
         work.in_anon_collection = true
         work.authors = [Pseud.new(name: "stealthy")]
-        work.set_author_sorting
         expect(work.authors_to_sort_on).to eq "Anonymous"
       end
     end
@@ -188,7 +184,6 @@ describe Work do
     context "when the work has multiple pseuds" do
       it "should combine them with commas" do
         work.authors = [Pseud.new(name: "diavolo"), Pseud.new(name: "doppio")]
-        work.set_author_sorting
         expect(work.authors_to_sort_on).to eq "diavolo,  doppio"
       end
     end


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-3468

## Purpose

When a work's author changes their username:

- authors_to_sort_on is a column: the work needs to be resaved, then reindexed, and we're doing so synchronously.
- authors_to_sort_on is a method: its value is up-to-date when called, the work doesn't need to be resaved, just reindexed, and we can use the asynchronous indexing queues.

We can drop the database column authors_to_sort_on whenever.

Also add a hook so when a pseud gets renamed, its works and bookmarks get reindexed.

## Testing

See issue.