### PR TITLE
AO3-5353 Reindex series when canonical tag becomes syn

### DIFF
--- a/app/models/indexing/scheduled_reindex_job.rb
+++ b/app/models/indexing/scheduled_reindex_job.rb
@@ -5,7 +5,7 @@ class ScheduledReindexJob
               when 'main'
                 %w(Pseud Tag Work Bookmark Series ExternalWork)
               when 'background'
-                %w(Work Bookmark Pseud)
+                %w(Work Bookmark Pseud Series)
               when 'stats'
                 %w(StatCounter)
               end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -687,9 +687,11 @@ class Tag < ApplicationRecord
   # a way of finding their ids to reindex them. :)
   def reindex_taggables
     work_ids = all_filtered_work_ids
+    series_ids = all_filtered_series_ids
     bookmark_ids = all_bookmark_ids
     yield if block_given?
     reindex_all_works(work_ids)
+    reindex_all_series(series_ids)
     reindex_all_bookmarks(bookmark_ids)
     reindex_pseuds if type == "Fandom"
   end
@@ -722,6 +724,25 @@ class Tag < ApplicationRecord
     # add in the direct works for any noncanonical tags
     (self.filter_taggings.where(filterable_type: "Work").pluck(:filterable_id) +
       self.works.pluck(:id)).uniq
+  end
+
+  # Reindex all series (series_ids argument works as above)
+  def reindex_all_series(series_ids = [])
+    return unless $rollout.active?(:start_new_indexing)
+    if series_ids.empty?
+      series_ids = all_filtered_series_ids
+    end
+    IndexQueue.enqueue_ids(Series, series_ids, :background)
+  end
+
+  # Series get their filters through works, so we need to find the works with this tag's
+  # filters, and then use the serial_works table to find the ids of any series with the
+  # tag's filters
+  def all_filtered_series_ids
+    SerialWork.select(:id, :series_id).
+               joins("JOIN filter_taggings ON filter_taggings.filterable_id = serial_works.work_id").
+               where("filter_taggings.filter_id = ? AND filter_taggings.filterable_type = 'Work'", id).
+               pluck(:series_id).uniq
   end
 
   # Reindex all bookmarks (bookmark_ids argument works as above)

--- a/features/other_b/bookmark_indexing.feature
+++ b/features/other_b/bookmark_indexing.feature
@@ -37,3 +37,25 @@ Feature: Bookmark Indexing
       And I press "Sort and Filter"
     Then the 1st bookmark result should contain "Telling Stories"
       And the 2nd bookmark result should contain "Unrelated Story"
+
+  @new-search
+  Scenario: Synning a canonical tag used on a bookmarked series should move the 
+  bookmark to the new canonical's bookmark listings; de-synning should remove it
+    Given I am logged in as "author"
+      And a canonical fandom "Veronica Mars"
+      And a canonical fandom "Veronica Mars (TV)"
+      And I post the work "The Story Telling: Beginnings" with fandom "Veronica Mars" as part of a series "Telling Stories"
+      And I am logged in as "bookmarker"
+      And I bookmark the series "Telling Stories"
+    When I go to the bookmarks tagged "Veronica Mars"
+    Then the 1st bookmark result should contain "Telling Stories"
+    When I am logged in as a tag wrangler
+      And I syn the tag "Veronica Mars" to "Veronica Mars (TV)"
+      And I go to the bookmarks tagged "Veronica Mars (TV)"
+    Then the 1st bookmark result should contain "Telling Stories"
+    When I de-syn the tag "Veronica Mars" from "Veronica Mars (TV)"
+      And the tag "Veronica Mars" is canonized
+      And I go to the bookmarks tagged "Veronica Mars (TV)"
+    Then I should not see "Telling Stories"
+    When I go to the bookmarks tagged "Veronica Mars"
+    Then the 1st bookmark result should contain "Telling Stories"

--- a/features/step_definitions/tag_steps.rb
+++ b/features/step_definitions/tag_steps.rb
@@ -310,6 +310,12 @@ When /^the tag "([^\"]*)" is decanonized$/ do |tag|
   tag.save
 end
 
+When /^the tag "([^"]*)" is canonized$/ do |tag|
+  tag = Tag.find_by!(name: tag)
+  tag.canonical = true
+  tag.save
+end
+
 When /^I make a(?: (\d+)(?:st|nd|rd|th)?)? Wrangling Guideline$/ do |n|
   n ||= 1
   visit new_wrangling_guideline_path
@@ -328,6 +334,21 @@ When /^I flush the wrangling sidebar caches$/ do
   [Fandom, Character, Relationship, Freeform].each do |klass|
     Rails.cache.delete("/wrangler/counts/sidebar/#{klass}")
   end
+end
+
+When /^I syn the tag "([^"]*)" to "([^"]*)"$/ do |tag, syn|
+  tag = Tag.find_by(name: tag)
+  visit edit_tag_path(tag)
+  fill_in("Synonym of", with: syn)
+  click_button("Save changes")
+end
+
+When /^I de-syn the tag "([^"]*)" from "([^"]*)"$/ do |syn, tag|
+  tag = Tag.find_by(name: tag)
+  syn_id = Tag.find_by(name: syn).id
+  visit edit_tag_path(tag)
+  check("child_Merger_associations_to_remove_#{syn_id}")
+  click_button("Save changes")
 end
 
 ### THEN


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5353

## Purpose

Reindex series when canonical tag becomes syn, ensuring that bookmarks of the series will show up on the new canonical tag's bookmark listings.

## Testing

Refer to Jira