### PR TITLE
AO3-5389 Avoid clobbering sent assignments.

### DIFF
--- a/app/models/challenge_assignment.rb
+++ b/app/models/challenge_assignment.rb
@@ -331,6 +331,14 @@ class ChallengeAssignment < ApplicationRecord
 
   def self.delayed_generate(collection_id)
     collection = Collection.find(collection_id)
+
+    if collection.challenge.assignments_sent_at.present?
+      # If assignments have been sent, we don't want to delete everything and
+      # regenerate. (If the challenge moderator wants to regenerate assignments
+      # after sending assignments, they can use the Purge Assignments button.)
+      return
+    end
+
     settings = collection.challenge.potential_match_settings
 
     REDIS_GENERAL.set(progress_key(collection), 1)

--- a/app/models/potential_match.rb
+++ b/app/models/potential_match.rb
@@ -79,6 +79,14 @@ public
   def self.generate_in_background(collection_id)
     collection = Collection.find(collection_id)
 
+    if collection.challenge.assignments_sent_at.present?
+      # If assignments have been sent, we don't want to delete everything and
+      # regenerate. (If the challenge moderator wants to recalculate potential
+      # matches after sending assignments, they can use the Purge Assignments
+      # button.)
+      return
+    end
+
     # check for invalid signups
     PotentialMatch.clear_invalid_signups(collection)
     invalid_signup_ids = collection.signups.select {|s| !s.valid?}.collect(&:id)


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5389

## Purpose

If the Resque job for potential match generation/assignment generation ends up in the list of Resque failures, and failed jobs are rerun after the error has been fixed and the assignments have been sent out, then the restarted job will destroy all of the assignments that were sent out. (It will regenerate them, but because the assignment generation algorithm is randomized, this can sometimes result in different assignments. In addition, all `sent_at` values will be reset to nil, making the assignments inaccessible to gift exchange participants.)

This pull request makes it so that the two delayed jobs won't run if the challenge's `assignments_sent_at` date is set (that is, if the gift exchange moderator has pressed the "Send Assignments" button).

## Testing

Pick a collection/challenge that has already sent out assignments, and run the following line in the console:
```
PotentialMatch.generate_in_background(Collection.find_by(name: "CollectionName").id)
```
Then verify that collection participants can still see their assignments.

It would also be good to try running this line, as well, and performing a similar check:
```
ChallengeAssignment.delayed_generate(Collection.find_by(name: "CollectionName").id)
```

(Depending on your logging level, you may also be able to check the SQL statements that each command generates to verify that there are no updates, inserts, or deletes.)