### PR TITLE
AO3-5393 Update Code Climate exclusions

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,2 +1,9 @@
 exclude_paths:
+- "bin/"
+- "config/"
+- "db/"
+- "factories/"
+- "features/"
 - "script/"
+- "spec/"
+- "test/"

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -9,7 +9,7 @@ require 'simplecov'
 require 'cucumber/timecop'
 require 'capybara/poltergeist'
 SimpleCov.command_name "features-" + (ENV['TEST_RUN'] || 'local')
-if ENV["CI"] == "true"
+if ENV["CI"] == "true" && ENV["TRAVIS"] == "true"
   # Only on Travis...
   require "codecov"
   SimpleCov.formatter = SimpleCov::Formatter::Codecov

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,7 +3,7 @@ ENV["RAILS_ENV"] ||= 'test'
 require File.expand_path("../../config/environment", __FILE__)
 require 'simplecov'
 SimpleCov.command_name "rspec-" + (ENV['TEST_RUN'] || '')
-if ENV["CI"] == "true"
+if ENV["CI"] == "true" && ENV["TRAVIS"] == "true"
   # Only on Travis...
   require "codecov"
   SimpleCov.formatter = SimpleCov::Formatter::Codecov


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5393

## Purpose

Tell Code Climate to stop criticizing the test suite, among other things.

Also tell Codeship to stop trying to submit coverage reports: without authentication, we get this at the end of every step:

```
{"error": {"context": null, "reason": "Please provide the repository token to upload reports via `-t :repository-token`"}, "meta": {"status": 400}}
```

## Testing

According to the CC merge check below:
> codeclimate — 336 fixed issues

Those are all from spec or step files.