### PR TITLE
AO3-5397 Don't automatically check "Remember me" on /login

### DIFF
--- a/app/views/user_sessions/_passwd.html.erb
+++ b/app/views/user_sessions/_passwd.html.erb
@@ -6,7 +6,7 @@
     <dt><%= f.label :password, ts("Password:") %></dt>
     <dd><%= f.password_field :password %></dd>
     <dt><%= f.label :remember_me, ts("Remember me") %></dt>
-    <dd><%= f.check_box :remember_me %></dd>
+    <dd><%= check_box_tag "user_session[remember_me]", 1, false, id: "user_session_remember_me" %></dd>
     <dt class="landmark"><%= ts("Submit") %></dt>
     <dd class="submit actions">
       <%= f.submit ts("Log in"), class: "submit" %>


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5397

## Purpose

Makes it so "Remember me" on the non-JavaScript form on /login isn't pre-checked when the page loads.

## Testing

Go to the page, look at the thing.