### PR TITLE
AO3-3468 Reindex everything for username changes in after_commit

### DIFF
--- a/app/controllers/admin/admin_users_controller.rb
+++ b/app/controllers/admin/admin_users_controller.rb
@@ -208,9 +208,9 @@ class Admin::AdminUsersController < ApplicationController
   def troubleshoot
     @user = User.find_by(login: params[:id])
     @user.fix_user_subscriptions
-    @user.reindex_user_works
     @user.set_user_work_dates
-    @user.reindex_user_bookmarks
+    @user.reindex_user_creations
+    @user.update_works_index_timestamp!
     @user.create_log_item(options = { action: ArchiveConfig.ACTION_TROUBLESHOOT, admin_id: current_admin.id })
     flash[:notice] = ts("User account troubleshooting complete.")
     redirect_to(request.env["HTTP_REFERER"] || root_path) && return

--- a/app/models/pseud.rb
+++ b/app/models/pseud.rb
@@ -73,7 +73,7 @@ class Pseud < ApplicationRecord
 
   after_update :check_default_pseud
   after_update :expire_caches
-  after_update :reindex_creations
+  after_commit :reindex_creations
 
   scope :on_works, lambda {|owned_works|
     select("DISTINCT pseuds.*").


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-3468

## Purpose

On test, when renaming a user, the user's works are [reindexed inconsistently](https://otwarchive.atlassian.net/browse/AO3-3468?focusedCommentId=353750&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-353750). It's possible that reindexing is happening before the changes are saved in the database:

> There are two additional callbacks that are triggered by the completion of a database transaction: after_commit and after_rollback. These callbacks are very similar to the after_save callback except that they don't execute until after database changes have either been committed or rolled back. They are most useful when your active record models need to interact with external systems which are not part of the database transaction.

http://guides.rubyonrails.org/active_record_callbacks.html#transaction-callbacks
http://www.justinweiss.com/articles/a-couple-callback-gotchas-and-a-rails-5-fix/

We'll replace `after_save` with `after_commit` and see if that helps.

## Testing

See issue.

## References

We changed callbacks like this before, in #2549. We don't need `test_after_commit` however, because testing should just work on Rails 5.