### PR TITLE
AO3-5398 update forced logout message with login page suggestion

### DIFF
--- a/app/views/home/lost_cookie.html.erb
+++ b/app/views/home/lost_cookie.html.erb
@@ -1,5 +1,5 @@
 ﻿<h2 class="heading"><%= ts('Forced Logout') %></h2>
 
 <div class="userstuff">
-  <p><%= ts("You have been automatically logged out to protect your privacy.  Please make sure that your browser is set to accept cookies from archiveofourown.org and delete any existing Archive cookies.  If you continue to have problems logging in, please  <a href=\"#{new_feedback_report_url}\">contact Support</a>.".html_safe)  %></p>
+  <p><%= ts("You have been automatically logged out to protect your privacy. Please make sure that your browser is set to accept cookies from archiveofourown.org and delete any existing Archive cookies. If you continue to have problems logging in, please try using the <a href=\"#{login_url}\">Log In</a> page. If you still have problems after trying that, please <a href=\"#{new_feedback_report_url}\">contact Support</a>.".html_safe)  %></p>
 </div>


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5398

## Purpose

Updates lost_cookie page text with workaround for being unable to log back in using corner login box after forced logout.

## Testing

See Jira. Nothing automated since... temporary?

## References

Describes workaround for [AO3-5396](https://otwarchive.atlassian.net/browse/AO3-5396) [Forced logout leaves user unable to log back in using corner login box].

I also wasn't able to recreate 5396 locally, but wouldn't mind trying again if it's something I just overlooked.

What I tried was setting `cookies.delete(:user_credentials)` for some arbitrary page's controller and navigating to it when logged in, which seemed to trigger `application_controller.logout_if_not_user_credentials` correctly with a logout + redirect. However at that point I seemed to log in just fine using corner box :thinking: 