### PR TITLE
AO3-5410 Use object notation for relation in bookmarkable documents

### DIFF
--- a/app/models/external_work.rb
+++ b/app/models/external_work.rb
@@ -136,7 +136,7 @@ class ExternalWork < ApplicationRecord
       ]
     ).merge(
       bookmarkable_type: "ExternalWork",
-      bookmarkable_join: "bookmarkable"
+      bookmarkable_join: { name: "bookmarkable" }
     )
   end
 

--- a/app/models/series.rb
+++ b/app/models/series.rb
@@ -237,7 +237,7 @@ class Series < ApplicationRecord
       anonymous: anonymous?,
       unrevealed: unrevealed?,
       bookmarkable_type: 'Series',
-      bookmarkable_join: "bookmarkable"
+      bookmarkable_join: { name: "bookmarkable" }
     )
   end
 

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -1509,7 +1509,7 @@ class Work < ApplicationRecord
       anonymous: anonymous?,
       unrevealed: unrevealed?,
       bookmarkable_type: 'Work',
-      bookmarkable_join: "bookmarkable"
+      bookmarkable_join: { name: "bookmarkable" }
     )
   end
 


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5410

## Purpose

The simpler notation for parent documents somehow leads to errors like: "object mapping for [bookmarkable_join] tried to parse field [bookmarkable_join] as object, but found a concrete value".

## Testing

`BookmarkIndexer.index_all` on production should finish quietly.