### PR TITLE
AO3-5411 Reduce REDIS calls in IndexSweeper.

### DIFF
--- a/spec/models/async_indexer_spec.rb
+++ b/spec/models/async_indexer_spec.rb
@@ -73,9 +73,7 @@ describe AsyncIndexer do
     it "should add the ID to the BookmarkedWorkIndexer's permanent failures" do
       AsyncIndexer.index(BookmarkedWorkIndexer, [99_999], "main")
 
-      permanent_store = JSON.parse(
-        IndexSweeper::REDIS.get("BookmarkedWorkIndexer:permanent_failure_store")
-      )
+      permanent_store = IndexSweeper.permanent_failures(BookmarkedWorkIndexer)
 
       expect(permanent_store).to include(
         "99999-work" => { "an error" => "with a message" }


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5411

## Purpose

This PR revises how IndexSweeper stores errors in order to reduce the load on REDIS when there are a large number of errors.

Currently, all errors are stored in one of three different strings on REDIS (one for errors that have occurred once, one for errors that have occurred twice, and one for errors that have occurred three or more times).

This pull request stores all errors in a single REDIS hash. Errors are arranged in the hash by the ID of the document that experienced the error. The value associated with each document ID is a JSON encoding of an array containing information about all errors (including a separate count for each error, which increments every time we see the error).

By separating the errors and hashing them with their ID as a key, it's much easier to delete the errors associated with a document when the document is successfully indexed. (We just have to delete the key for that document.) In addition, it's much easier to figure out whether a particular error has occurred before -- instead of looking through all three error stores for the correct combination of ID and error, we know exactly where the error is stored.

By using `REDIS.hmset` and `REDIS.hmget` and `REDIS.hdel` (which can take multiple arguments), it's possible to ensure that each batch will only send three commands to REDIS. In addition, this way of storing the error data means that the size of the data transmitted to/received from REDIS is proportional to the number of items in the batch, and doesn't have any dependence on the total number of previous errors. This means that in situations where every single Elasticsearch query is triggering an error, the amount of data received by REDIS should be linear in the number of errors, instead of quadratic.

## Testing

This is, unfortunately, very difficult to test on staging, since it requires generating Elasticsearch errors. I think the only way to do that at the moment is to modify the code to deliberately introduce an error.