### PR TITLE
AO3-5419 Add GDPR information to the edit profile page

### DIFF
--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -9,6 +9,18 @@
 <!--/subnav-->
 
 <!--main content-->
+<p class="notice">
+  <%= ts("Any personal information you post on your public AO3 profile,
+         including your religious or political views, health, racial background,
+         country of origin, sexual identity and/or personal relationships,
+         will be accessible by the general public. Read more about our updated
+         Age and Privacy policies, and see how the AO3 collects data when
+         you're on the site, and why we don't sell it to third parties
+         in the %{tos}.",
+         tos: link_to(ts("Privacy section of AO3 Terms of Service"), tos_path(anchor: "privacy"))
+      ).html_safe %>
+</p>
+
 <h3 class="landmark heading"><%= ts("Change Profile") %></h3>
 <%= form_for(@user) do |f| %>  
   <dl>


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5419

## Purpose

When users edit their public profile, warn them that their profile is public, using the ToS.

## Testing

The ToS link to the privacy section should work and there are no typos.