### PR TITLE
AO3-5428 Specify number of shards

### DIFF
--- a/app/models/search/bookmark_indexer.rb
+++ b/app/models/search/bookmark_indexer.rb
@@ -7,11 +7,13 @@ class BookmarkIndexer < Indexer
   # Create the bookmarkable index/mapping first
   # Skip delete on the subclasses so it doesn't delete the ones we've just
   # reindexed
-  def self.index_all(options={})
-    options[:skip_delete] = true
-    BookmarkableIndexer.delete_index
-    BookmarkableIndexer.create_index
-    create_mapping
+  def self.index_all(options = {})
+    unless options[:skip_delete]
+      options[:skip_delete] = true
+      BookmarkableIndexer.delete_index
+      BookmarkableIndexer.create_index(shards: 12)
+      create_mapping
+    end
     BookmarkedExternalWorkIndexer.index_all(skip_delete: true)
     BookmarkedSeriesIndexer.index_all(skip_delete: true)
     BookmarkedWorkIndexer.index_all(skip_delete: true)

--- a/app/models/search/bookmark_indexer.rb
+++ b/app/models/search/bookmark_indexer.rb
@@ -11,7 +11,7 @@ class BookmarkIndexer < Indexer
     unless options[:skip_delete]
       options[:skip_delete] = true
       BookmarkableIndexer.delete_index
-      BookmarkableIndexer.create_index(shards: 12)
+      BookmarkableIndexer.create_index(shards: 18)
       create_mapping
     end
     BookmarkedExternalWorkIndexer.index_all(skip_delete: true)

--- a/app/models/search/work_indexer.rb
+++ b/app/models/search/work_indexer.rb
@@ -4,6 +4,15 @@ class WorkIndexer < Indexer
     "Work"
   end
 
+  def self.index_all(options={})
+    unless options[:skip_delete]
+      delete_index
+      create_index(shards: 9)
+    end
+    options[:skip_delete] = true
+    super(options)
+  end
+
   def self.mapping
     {
       "work" => {

--- a/app/models/search/work_indexer.rb
+++ b/app/models/search/work_indexer.rb
@@ -4,10 +4,10 @@ class WorkIndexer < Indexer
     "Work"
   end
 
-  def self.index_all(options={})
+  def self.index_all(options = {})
     unless options[:skip_delete]
       delete_index
-      create_index(shards: 9)
+      create_index(shards: 12)
     end
     options[:skip_delete] = true
     super(options)


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5428
## Purpose

Sets the number of shards on the elastic search cluster.

## Testing

Get an admin to use curl  for example:

```james_@elastic04:~$ curl -X GET "localhost:8201/_cat/indices?v"
health status index                    uuid                   pri rep docs.count docs.deleted store.size pri.store.size
green  open   ao3_production_tags      EOfrTO0AS-yvltks0tsclg   5   1    6700754      1963506      2.2gb            1gb
green  open   ao3_production_bookmarks PuHTs8c3Q06Tz2HGx7GMzg   5   1   63794528            0     36.7gb         18.5gb
green  open   ao3_production_pseuds    mOT6HShOSOav7jf5D75xSQ   5   1    1571111       212730        1gb        519.9mb
green  open   ao3_production_works     5096D7qBTyG1HzC4T7nnnA   5   1    3889071       936128     20.2gb          9.8gb```
Each index has 5  primary shards

