### PR TITLE
AO3-5232 Limit search result count

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -484,6 +484,14 @@ public
     !param.blank? && ['asc', 'desc'].include?(param.to_s.downcase)
   end
 
+  def flash_max_search_results_notice(result)
+    # ES UPGRADE TRANSITION #
+    # Remove return statement
+    return unless use_new_search?
+    notice = result.max_search_results_notice
+    flash.now[:notice] = notice if notice.present?
+  end
+
   # Don't get unnecessary data for json requests
   skip_before_action  :fetch_admin_settings,
                       :load_admin_banner,

--- a/app/controllers/bookmarks_controller.rb
+++ b/app/controllers/bookmarks_controller.rb
@@ -58,6 +58,7 @@ class BookmarksController < ApplicationController
         @page_subtitle = ts("Bookmarks Matching '%{query}'", query: @search.query)
       end
       @bookmarks = @search.search_results
+      flash_max_search_results_notice(@bookmarks)
       render 'search_results'
     end
   end
@@ -114,12 +115,14 @@ class BookmarksController < ApplicationController
             # bookmarks. That means that instead of the normal bookmark
             # listing, we want to list *bookmarkable* items.
             @bookmarkable_items = @search.bookmarkable_search_results
+            flash_max_search_results_notice(@bookmarkable_items)
             @facets = @bookmarkable_items.facets
           else
             # Either we're using the old search, or we are looking at a
             # particular user's bookmarks. Either way, we want to just retrieve
             # the standard search results and their facets.
             @bookmarks = @search.search_results
+            flash_max_search_results_notice(@bookmarks)
             @facets = @bookmarks.facets
           end
 
@@ -152,7 +155,8 @@ class BookmarksController < ApplicationController
             search = BookmarkSearch.new(show_private: false, show_restricted: false, sort_column: 'created_at')
           end
           results = search.search_results
-          @bookmarks = search.search_results.to_a
+          flash_max_search_results_notice(results)
+          @bookmarks = results.to_a
         end
       else
         @bookmarks = Bookmark.latest.includes(:bookmarkable, :pseud, :tags, :collections).to_a

--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -21,6 +21,7 @@ class PeopleController < ApplicationController
       options = people_search_params.merge(page: params[:page])
       @search = PseudSearchForm.new(options)
       @people = @search.search_results
+      flash_max_search_results_notice(@people)
     end
   end
 

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -73,6 +73,7 @@ class TagsController < ApplicationController
       if use_new_search?
         search = TagSearchForm.new(options)
         @tags = search.search_results
+        flash_max_search_results_notice(@tags)
       else
         @tags = TagSearch.search(options)
       end

--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -46,6 +46,7 @@ class WorksController < ApplicationController
       end
 
       @works = @search.search_results
+      flash_max_search_results_notice(@works)
       render 'search_results'
     end
   end
@@ -125,6 +126,8 @@ class WorksController < ApplicationController
           @works = @search.search_results
         end
 
+        flash_max_search_results_notice(@works)
+
         @facets = @works.facets
         if @search.options[:excluded_tag_ids].present?
           tags = Tag.where(id: @search.options[:excluded_tag_ids])
@@ -163,6 +166,7 @@ class WorksController < ApplicationController
         @search = WorkSearch.new(options.merge(works_parent: @user, collected: true))
       end
       @works = @search.search_results
+      flash_max_search_results_notice(@works)
       @facets = @works.facets
     end
 

--- a/app/helpers/search_helper.rb
+++ b/app/helpers/search_helper.rb
@@ -8,10 +8,12 @@ module SearchHelper
     elsif collection.total_pages < 2
       header = pluralize(collection.size, item_name)
     else
+      total_entries = collection.total_entries
+      total_entries = collection.unlimited_total_entries if collection.respond_to?(:unlimited_total_entries)
       header = %{ %d - %d of %d }% [
                 collection.offset + 1,
                 collection.offset + collection.length,
-                collection.total_entries
+                total_entries
                 ] + item_name.pluralize
     end
     if search.present? && search.query.present?

--- a/app/models/search/indexer.rb
+++ b/app/models/search/indexer.rb
@@ -42,7 +42,10 @@ class Indexer
       body: {
         settings: {
           index: {
+            # static settings
             number_of_shards: shards,
+            # dynamic settings
+            max_result_window: ArchiveConfig.MAX_SEARCH_RESULTS,
           }
         }.merge(settings),
         mappings: mapping,

--- a/app/models/search/query.rb
+++ b/app/models/search/query.rb
@@ -19,7 +19,7 @@ class Query
 
   def search_results
     response = search
-    QueryResult.new(klass, response, options.slice(:page, :per_page))
+    QueryResult.new(klass, response, { page: page, per_page: per_page })
   end
 
   # Perform a count query based on the given options
@@ -115,11 +115,19 @@ class Query
   end
 
   def per_page
-    options[:per_page] || 20
+    options[:per_page] || ArchiveConfig.ITEMS_PER_PAGE
+  end
+
+  # Example: if the limit is 3 results, and we're displaying 2 per page,
+  # disallow pages beyond page 2.
+  def page
+    [
+      options[:page] || 1,
+      (ArchiveConfig.MAX_SEARCH_RESULTS / per_page.to_f).ceil
+    ].min
   end
 
   def pagination_offset
-    page = options[:page] || 1
     (page * per_page) - per_page
   end
 

--- a/app/models/search/query_result.rb
+++ b/app/models/search/query_result.rb
@@ -8,7 +8,7 @@ class QueryResult
     @klass = model_name.classify.constantize
     @response = response
     @current_page = options[:page] || 1
-    @per_page = options[:per_page] || 20
+    @per_page = options[:per_page] || ArchiveConfig.ITEMS_PER_PAGE
   end
 
   def hits
@@ -95,7 +95,12 @@ class QueryResult
     (total_entries / per_page.to_f).ceil rescue 0
   end
 
+  # For pagination / fetching results.
   def total_entries
+    [unlimited_total_entries, ArchiveConfig.MAX_SEARCH_RESULTS].min
+  end
+
+  def unlimited_total_entries
     response['hits']['total']
   end
 
@@ -103,6 +108,14 @@ class QueryResult
     (current_page * per_page) - per_page
   end
 
+  def max_search_results_notice
+    # if we're on the last page of search results AND there are more results than we can show
+    return unless current_page >= total_pages && unlimited_total_entries > total_entries
+    ActionController::Base.helpers.ts("Displaying %{displayed} results out of %{total}. Please use the filters or edit your search to customize this list further.",
+                                      displayed: total_entries,
+                                      total: unlimited_total_entries
+                                   ).html_safe
+  end
 end
 
 class QueryFacet < Struct.new(:id, :name, :count)

--- a/config/config.yml
+++ b/config/config.yml
@@ -217,6 +217,13 @@ SEARCH_TIPS: ['arthur merlin words>1000 sort:hits', 'words:100', 'buffy gen teen
 # enabled, cached on production/test environments.
 MAX_RECENT: 20
 
+# This determines the maximum value of (from + size) for searches
+# to all indices (Elasticsearch index setting max_result_window).
+# If a search has more results than this limit, the last page of
+# search results will include a message advising the user to narrow
+# their search or change their sorting options.
+MAX_SEARCH_RESULTS: 100000
+
 # This is used to determine how many works or how many authors have to be
 # present in order for anonymous or mystery works to begin being displayed
 ANONYMOUS_THRESHOLD_COUNT: 10

--- a/features/step_definitions/search_steps.rb
+++ b/features/step_definitions/search_steps.rb
@@ -46,6 +46,16 @@ Given /^all indexing jobs have been run$/ do
   end
 end
 
+Given /^the max search result count is (\d+)$/ do |max|
+  stub_const("ArchiveConfig", OpenStruct.new(ArchiveConfig))
+  ArchiveConfig.MAX_SEARCH_RESULTS = max.to_i
+end
+
+Given /^(\d+) items are displayed per page$/ do |per_page|
+  stub_const("ArchiveConfig", OpenStruct.new(ArchiveConfig))
+  ArchiveConfig.ITEMS_PER_PAGE = per_page.to_i
+end
+
 When /^(\w+) can use the new search/ do |login|
   user = User.find_by(login: login)
   $rollout.activate_user(:use_new_search, user)

--- a/features/step_definitions/work_steps.rb
+++ b/features/step_definitions/work_steps.rb
@@ -480,16 +480,17 @@ When /^I set the publication date to today$/ do
   end
 end
 
-When /^I browse the "([^"]+)" works$/ do |tagname|
+When /^I browse the "(.*?)" works$/ do |tagname|
   tag = Tag.find_by_name(tagname)
   visit tag_works_path(tag)
   step %{all indexing jobs have been run}
 
   Tag.write_redis_to_database
 end
-When /^I browse the "([^"]+)" works with an empty page parameter$/ do |tagname|
+
+When /^I browse the "(.*?)" works with page parameter "(.*?)"$/ do |tagname, page|
   tag = Tag.find_by_name(tagname)
-  visit tag_works_path(tag, page: "")
+  visit tag_works_path(tag, page: page)
   step %{all indexing jobs have been run}
 
   Tag.write_redis_to_database

--- a/features/works/work_browse.feature
+++ b/features/works/work_browse.feature
@@ -1,10 +1,41 @@
 @works @browse
-Feature: browsing works from various contexts
+Feature: Browsing works from various contexts
 
-Scenario: browsing works with incorrect page params in query string
-
-  Given I am logged in as a random user
-    And a fandom exists with name: "Johnny Be Good", canonical: true
+Scenario: Browsing works with incorrect page params in query string
+  Given a canonical fandom "Johnny Be Good"
+    And I am logged in
     And I post the work "Whatever" with fandom "Johnny Be Good"
-  When I browse the "Johnny Be Good" works with an empty page parameter
+  When I browse the "Johnny Be Good" works with page parameter ""
   Then I should see "1 Work"
+
+@new-search
+Scenario: If works in a listing exceed the maximum search result count,
+  display a notice on the last page of results
+
+  Given a canonical fandom "Aggressive Retsuko"
+    And the max search result count is 4
+    And 2 items are displayed per page
+    And I am logged in
+    And I post the work "Whatever 1" with fandom "Aggressive Retsuko"
+    And I post the work "Whatever 2" with fandom "Aggressive Retsuko"
+    And I post the work "Whatever 3" with fandom "Aggressive Retsuko"
+    And I post the work "Whatever 4" with fandom "Aggressive Retsuko"
+
+  When I browse the "Aggressive Retsuko" works with page parameter "2"
+  Then I should see "3 - 4 of 4 Works"
+    And I should not see "Please use the filters"
+
+  When I post the work "Whatever 5" with fandom "Aggressive Retsuko"
+    And I browse the "Aggressive Retsuko" works
+  Then I should see "1 - 2 of 5 Works"
+    And I should not see "Please use the filters"
+  When I follow "Next"
+  Then I should see "3 - 4 of 5 Works"
+    And I should see "Displaying 4 results out of 5. Please use the filters"
+
+  When I browse the "Aggressive Retsuko" works with page parameter "3"
+  Then I should see "3 - 4 of 5 Works"
+    And I should see "Displaying 4 results out of 5. Please use the filters"
+  When I follow "Previous"
+  Then I should see "1 - 2 of 5 Works"
+    And I should not see "Please use the filters"


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5232

## Purpose

By default, each Elasticsearch index has index.max_result_window set to 10000. We increase it to 100000 and update the UI to match:

- Display the real, uncapped result count in the search header.
- Paginate search results only up to the limit.
- If users visit a page beyond the last result page, show the last page.
- On the last result page, if there are more results not shown, display a notice about the limit.

The limit will apply to:

- Search results for works/bookmarks/pseuds/tags
- Listings for works/bookmarks (of a tag/user/pseud/collection)

## Testing

See issue.