### PR TITLE
AO3-5434 Tell Hound to stop caring about self

### DIFF
--- a/config/.rubocop.yml
+++ b/config/.rubocop.yml
@@ -3,8 +3,8 @@
 AllCops:
   TargetRubyVersion: 2.3
 
-# stop checking quotation marks
-Style/StringLiterals:
+# stop checking for ambiguous regexp literal
+Lint/AmbiguousRegexpLiteral:
   Enabled: false
 
 # stop checking line length
@@ -15,10 +15,14 @@ Metrics/LineLength:
 Style/FormatStringToken:
   EnforcedStyle: template
 
-# stop checking for trailing whitespace
-Style/TrailingWhitespace:
+# stop checking if uses of "self" are redundant
+Style/RedundantSelf:
   Enabled: false
 
-# stop checking for ambiguous regexp literal
-Lint/AmbiguousRegexpLiteral:
+# stop checking quotation marks
+Style/StringLiterals:
+  Enabled: false
+
+# stop checking for trailing whitespace
+Style/TrailingWhitespace:
   Enabled: false


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5434

## Purpose

Disable the cop [Style/RedundantSelf](https://www.rubydoc.info/github/bbatsov/RuboCop/RuboCop/Cop/Style/RedundantSelf).

## Testing

```bash
rvm 2.2.5 do rubocop -c config/.rubocop.yml app/models/external_work.rb
```
No "self" violations appeared.