### PR TITLE
AO3-5435 Fix 500 error happening on some works pages on new Elasticsearch

### DIFF
--- a/app/models/search/query_result.rb
+++ b/app/models/search/query_result.rb
@@ -55,7 +55,7 @@ class QueryResult
     ids = buckets.map { |result| result['key'] }
     tags = Tag.where(id: ids).group_by(&:id)
     buckets.each do |facet|
-      if tags[facet['key'].to_i].any?
+      unless tags[facet['key'].to_i].blank?
         @facets[type] << QueryFacet.new(facet['key'], tags[facet['key'].to_i].first.name, facet['doc_count'])
       end
     end


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5435

## Purpose

Makes sure we don't try calling `.any?` on `nil`, producing a 500 error. More info on the ticket.

## Testing

Refer to Jira

## Credit

Honestly, credit @redsummernight on this one -- I just happened to be in a position to do it while they went to bed