### PR TITLE
AO3-5442 Remove space before "Crossovers" filter expander text

### DIFF
--- a/app/views/works/_filters.html.erb
+++ b/app/views/works/_filters.html.erb
@@ -77,10 +77,7 @@
 
       <dd class="more group">
         <dl>
-          <dt id="toggle_work_crossover" class="filter-toggle crossover">
-            <%= ts("Crossovers") %>
-            <%= link_to_help "work-search-crossover-help" %>
-          </dt>
+          <dt id="toggle_work_crossover" class="filter-toggle crossover"><%= ts("Crossovers") %><%= link_to_help "work-search-crossover-help" %></dt>
           <dd id="work_crossover" class="expandable">
             <ul>
               <li>


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5442

## Purpose

Puts the text "Crossovers" on the same line as the <dt> it is in to prevent the text from becoming " Crossovers" with a space at the beginning.

## Testing

Refer to Jira