### PR TITLE
AO3-5443 Make recent bookmarks clear bookmarkable stats and Save button

### DIFF
--- a/public/stylesheets/site/2.0/13-group-blurb.css
+++ b/public/stylesheets/site/2.0/13-group-blurb.css
@@ -335,9 +335,12 @@ blurbs on the manage collection items pages, mostly reseting styles inherited fr
 	top: 28px;
 }
 
+.bookmark div.user, .bookmark div.recent {
+  clear: right;
+}
+
 .bookmark .user {
   border: 1px solid #ccc;
-  clear: right;
   margin-top: 0.643em;
   overflow: hidden;
 }
@@ -383,7 +386,8 @@ blurbs on the manage collection items pages, mostly reseting styles inherited fr
 }
 
 .bookmark .recent .index {
-    width: 100%;
+  float: none;
+  width: 100%;
 }
 
 /* mod: READING */


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5443

## Purpose

On new Elasticsearch's tag bookmark pages, the list of a bookmarkable item's recent bookmarks was overlapping the bookmarkable's stats and Save/Saved button. This makes the recent bookmarks clear those things.

## Testing

Refer to Jira