### PR TITLE
AO3-5428 Fix method call for create_index shard parameter

### DIFF
--- a/app/models/search/bookmark_indexer.rb
+++ b/app/models/search/bookmark_indexer.rb
@@ -11,7 +11,7 @@ class BookmarkIndexer < Indexer
     unless options[:skip_delete]
       options[:skip_delete] = true
       BookmarkableIndexer.delete_index
-      BookmarkableIndexer.create_index(shards: 18)
+      BookmarkableIndexer.create_index(18)
       create_mapping
     end
     BookmarkedExternalWorkIndexer.index_all(skip_delete: true)

--- a/app/models/search/work_indexer.rb
+++ b/app/models/search/work_indexer.rb
@@ -7,7 +7,7 @@ class WorkIndexer < Indexer
   def self.index_all(options = {})
     unless options[:skip_delete]
       delete_index
-      create_index(shards: 12)
+      create_index(12)
     end
     options[:skip_delete] = true
     super(options)


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5428

## Purpose

The previous version using `shards:` didn't work because the `shards` parameter is a single value, not a hash.
