### PR TITLE
AO3-5313 Set Auth Error page title correctly

### DIFF
--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -10,6 +10,7 @@ class ErrorsController < ApplicationController
   end
 
   def auth_error
+    @page_title = "Auth Error"
   end
   
 end


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5313

## Purpose

Fixes Auth Error page title.

## Testing

Open auth error page and check title.

## Credit

Tal.
Please use he.
