### PR TITLE
AO3-4080 Fix css regex to support shadow box fully

### DIFF
--- a/lib/css_cleaner.rb
+++ b/lib/css_cleaner.rb
@@ -202,7 +202,7 @@ module CssCleaner
     value_stripped = value.downcase.gsub(/(!important)/, '').strip
 
     # if it's a comma-separated set of valid values it's fine
-    return value if value_stripped =~ /^(#{VALUE_REGEX}\,?)+$/i
+    return value if value_stripped =~ /^(#{VALUE_REGEX}\,?\s*)+$/i
 
     # If it's explicitly in our keywords it's fine
     return value if value_stripped.split(',').all? {|subval| ArchiveConfig.SUPPORTED_CSS_KEYWORDS.include?(subval.strip)}

--- a/spec/models/skin_spec.rb
+++ b/spec/models/skin_spec.rb
@@ -110,7 +110,7 @@ describe Skin do
 
     # This is verified to work in prod and staging, but not dev
     # TODO: fix across environments?
-    xit "should save CSS3 box shadows with multiple shadows" do
+    it "should save CSS3 box shadows with multiple shadows" do
       @skin.css = "li { box-shadow: 5px 5px 5px black, inset 0 0 0 1px #dadada; }"
       expect(@skin.save).to be_truthy
     end

--- a/spec/models/skin_spec.rb
+++ b/spec/models/skin_spec.rb
@@ -100,17 +100,15 @@ describe Skin do
                 background:-ms-linear-gradient(top,#fafafa,#ddd);
                 background:-o-linear-gradient(top,#fafafa,#ddd);
                 background:linear-gradient(top,#fafafa,#ddd);
-                color:#555 }"
+                color:#555 }",
+ 
+        "saves box shadows with multiple shadows" =>
+          "li { box-shadow: 5px 5px 5px black, inset 0 0 0 1px #dadada; }"
     }.each_pair do |condition, css|
       it condition do
         @skin.css = css
         expect(@skin.save).to be_truthy
       end
-    end
-
-    it "should save CSS3 box shadows with multiple shadows" do
-      @skin.css = "li { box-shadow: 5px 5px 5px black, inset 0 0 0 1px #dadada; }"
-      expect(@skin.save).to be_truthy
     end
 
     # bad bad bad css

--- a/spec/models/skin_spec.rb
+++ b/spec/models/skin_spec.rb
@@ -108,8 +108,6 @@ describe Skin do
       end
     end
 
-    # This is verified to work in prod and staging, but not dev
-    # TODO: fix across environments?
     it "should save CSS3 box shadows with multiple shadows" do
       @skin.css = "li { box-shadow: 5px 5px 5px black, inset 0 0 0 1px #dadada; }"
       expect(@skin.save).to be_truthy


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-4080

## Purpose

This fixes the css regex so it doesn't fail on development.

## Testing

I've removed the 'pending' state from the spec test for this bug. I will say this though, I've no idea why this works on production. This regex makes me cry tears of blood.

## Credit

Tal.
Please use he.