### PR TITLE
AO3-5452 Avoid having the same tag checked in multiple bookmark filter exclude sections

### DIFF
--- a/app/helpers/advanced_search_helper.rb
+++ b/app/helpers/advanced_search_helper.rb
@@ -19,12 +19,13 @@ def advanced_search_string=(term_string)
     if filter_action == "include"
       @search.send("#{tag_type}_ids").present? &&
         @search.send("#{tag_type}_ids").include?(tag_id)
+    elsif tag_type == "tag" && @search.respond_to?(:excluded_bookmark_tag_ids)
+      # Bookmarker's tag exclude checkboxes on bookmark filters
+      @search.excluded_bookmark_tag_ids.present? && @search.excluded_bookmark_tag_ids.include?(tag_id)
     else
-      value = @search.excluded_tag_ids.present? && @search.excluded_tag_ids.include?(tag_id)
-      if @search.respond_to?(:excluded_bookmark_tag_ids)
-        value ||= @search.excluded_bookmark_tag_ids.present? && @search.excluded_bookmark_tag_ids.include?(tag_id)
-      end
-      value
+      # Work tag exclude checkboxes on bookmark filters,
+      # or exclude checkboxes on work filters
+      @search.excluded_tag_ids.present? && @search.excluded_tag_ids.include?(tag_id)
     end
   end
 end

--- a/features/search/filters.feature
+++ b/features/search/filters.feature
@@ -237,6 +237,35 @@ Feature: Filters
       And I should not see "A Hobbit's Meandering"
       And I should see "Roonal Woozlib and the Ferrets of Nimh"
 
+  @new-search
+  Scenario: Filter bookmarks by a tag that appears both on bookmarked works and in bookmarker's tags
+    Given I am logged in as "recengine"
+      And I bookmark the work "Bilbo Does the Thing"
+      And I bookmark the work "Roonal Woozlib and the Ferrets of Nimh" with the tags "The Hobbit"
+
+    # Exclude a tag as a work tag but not as a bookmarker's tag
+    When I go to my bookmarks page
+    Then the "The Hobbit (1)" checkbox within "#exclude_fandom_tags" should not be checked
+      And the "The Hobbit (1)" checkbox within "#exclude_tag_tags" should not be checked
+
+    When I check "The Hobbit (1)" within "#exclude_fandom_tags"
+      And I press "Sort and Filter"
+    Then I should see "1 Bookmark by recengine"
+      And I should not see "Bilbo Does the Thing"
+      And I should see "Roonal Woozlib and the Ferrets of Nimh"
+      And the "The Hobbit (0)" checkbox within "#exclude_fandom_tags" should be checked
+      And the "The Hobbit (1)" checkbox within "#exclude_tag_tags" should not be checked
+
+    # Exclude a tag as a bookmarker's tag but not as a work tag
+    When I go to my bookmarks page
+      And I check "The Hobbit (1)" within "#exclude_tag_tags"
+      And I press "Sort and Filter"
+    Then I should see "1 Bookmark by recengine"
+      And I should see "Bilbo Does the Thing"
+      And I should not see "Roonal Woozlib and the Ferrets of Nimh"
+      And the "The Hobbit (0)" checkbox within "#exclude_tag_tags" should be checked
+      And the "The Hobbit (1)" checkbox within "#exclude_fandom_tags" should not be checked
+
   @javascript
   Scenario: Filter a user's bookmarks by non-existent tags
     Given the tag "legend korra" does not exist


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5452

## Purpose

Check to exclude a work tag and submit, then the same tag appearing in the "Bookmarker's Tags" exclude section should not be checked.

Check to exclude a bookmarker's tag and submit, then the same tag appearing in the work tag exclude sections should not be checked.

## Testing

See issue.

## References

Really should have been done in #3258, where I kept work tags and bookmarker's tags separate everywhere except the helper.