### PR TITLE
AO3-5446 style change for selected checkbox indicator in the new filter sidebar

### DIFF
--- a/public/stylesheets/site/2.0/18-zone-searchbrowse.css
+++ b/public/stylesheets/site/2.0/18-zone-searchbrowse.css
@@ -193,7 +193,7 @@ needed relative positioning and a left offset to fix a bug in Safari 9 */
 }
 
 .filters input:checked + .indicator:before {
-  border-color: #aaa;
+  border-color: #2a2a2a;
 }
 
 .filters input:checked + .indicator + span {

--- a/public/stylesheets/site/2.0/18-zone-searchbrowse.css
+++ b/public/stylesheets/site/2.0/18-zone-searchbrowse.css
@@ -20,10 +20,10 @@ Arguably filter and search could be styled in interactions but I've put them her
 
 /* INTERACTION: SEARCH */
 
-form.search input[type="text"] {		
-  border-top-color: #999;		
-  padding: 0.15em 0.25em;		
-    border-radius: 1em;		
+form.search input[type="text"] {
+  border-top-color: #999;
+  padding: 0.15em 0.25em;
+    border-radius: 1em;
 }
 
 .search p, li.search form p {
@@ -154,7 +154,7 @@ form.filters {
   font-weight: 500;
 }
 
-.filters .collapsed:after, .filters .expanded:after { 
+.filters .collapsed:after, .filters .expanded:after {
   content: none;
 }
 
@@ -165,20 +165,20 @@ form.filters {
 /* AO3-5370: Normally you'd use absolute positioning here, but we
 needed relative positioning and a left offset to fix a bug in Safari 9 */
 .filters [type="checkbox"], .filters [type="radio"] {
-  border: 0; 
+  border: 0;
   clip: rect(0 0 0 0);
   height: 1px;
   left: -2em;
-  margin: -1px; 
-  overflow: hidden; 
-  padding: 0; 
-  position: relative; 
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: relative;
   width: 1px;
 }
 
 .filters .indicator:before {
   background: #eee;
-  color: #aaa;  
+  color: #aaa;
   display: inline-block;
   border: 1px solid;
   margin-right: 0.25em;


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5446

## Purpose

Changes the border-color of the check/cross icon for selected checkboxes to be the same as the text color. This applies only to the new filters sidebar.

## Testing

Select a checkbox in the new filters sidebar on staging, compare it to a selected checkbox on beta. The border needs to be darker on staging.
