### PR TITLE
AO3-5452 Add (0) checkboxes for the same tag in multiple bookmark filter exclude sections

### DIFF
--- a/app/controllers/bookmarks_controller.rb
+++ b/app/controllers/bookmarks_controller.rb
@@ -127,21 +127,26 @@ class BookmarksController < ApplicationController
           end
 
           if @search.options[:excluded_tag_ids].present? || @search.options[:excluded_bookmark_tag_ids].present?
-            ids = [
-              @search.options[:excluded_tag_ids],
-              @search.options[:excluded_bookmark_tag_ids]
-            ].flatten.compact
+            # Excluded tags do not appear in search results, so we need to generate empty facets
+            # to keep them as checkboxes on the filters.
+            excluded_tag_ids = @search.options[:excluded_tag_ids] || []
+            excluded_bookmark_tag_ids = @search.options[:excluded_bookmark_tag_ids] || []
 
-            tags = Tag.where(id: ids)
-            excluded_bookmark_tag_ids = params.dig(:exclude_bookmark_search, :tag_ids) || []
+            # It's possible to determine the tag types by looking at
+            # the original parameters params[:exclude_bookmark_search],
+            # but we need the tag names too, so a database query is unavoidable.
+            tags = Tag.where(id: excluded_tag_ids + excluded_bookmark_tag_ids)
             tags.each do |tag|
+              if excluded_tag_ids.include?(tag.id.to_s)
+                key = tag.class.to_s.downcase
+                @facets[key] ||= []
+                @facets[key] << QueryFacet.new(tag.id, tag.name, 0)
+              end
               if excluded_bookmark_tag_ids.include?(tag.id.to_s)
                 key = 'tag'
-              else
-                key = tag.class.to_s.downcase
+                @facets[key] ||= []
+                @facets[key] << QueryFacet.new(tag.id, tag.name, 0)
               end
-              @facets[key] ||= []
-              @facets[key] << QueryFacet.new(tag.id, tag.name, 0)
             end
           end
         end

--- a/features/search/filters.feature
+++ b/features/search/filters.feature
@@ -266,6 +266,17 @@ Feature: Filters
       And the "The Hobbit (0)" checkbox within "#exclude_tag_tags" should be checked
       And the "The Hobbit (1)" checkbox within "#exclude_fandom_tags" should not be checked
 
+    # Exclude a tag as a bookmarker's tag AND as a work tag
+    When I go to my bookmarks page
+      And I check "The Hobbit (1)" within "#exclude_fandom_tags"
+      And I check "The Hobbit (1)" within "#exclude_tag_tags"
+      And I press "Sort and Filter"
+    Then I should see "0 Bookmarks by recengine"
+      And I should not see "Bilbo Does the Thing"
+      And I should not see "Roonal Woozlib and the Ferrets of Nimh"
+      And the "The Hobbit (0)" checkbox within "#exclude_fandom_tags" should be checked
+      And the "The Hobbit (0)" checkbox within "#exclude_tag_tags" should be checked
+
   @javascript
   Scenario: Filter a user's bookmarks by non-existent tags
     Given the tag "legend korra" does not exist


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5452

## Purpose

Another place where we assume tags can only be on bookmarkable or bookmark filters, when they can appear on both.

## Testing

See issue.