### PR TITLE
AO3-5427 Remove crossover help from filters

### DIFF
--- a/app/views/works/_filters.html.erb
+++ b/app/views/works/_filters.html.erb
@@ -77,10 +77,7 @@
 
       <dd class="more group">
         <dl>
-          <dt id="toggle_work_crossover" class="filter-toggle crossover">
-            <%= ts("Crossovers") %>
-            <%= link_to_help "work-search-crossover-help" %>
-          </dt>
+          <dt id="toggle_work_crossover" class="filter-toggle crossover"><%= ts("Crossovers") %></dt>
           <dd id="work_crossover" class="expandable">
             <ul>
               <li>


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5427
https://otwarchive.atlassian.net/browse/AO3-5442

## Purpose

Removes the help text from the crossover section of the filters. Probably also fixes AO3-5442.

## Testing

Refer to Jira