### PR TITLE
AO3-5415 Remove the order by on large amounts of kudos

### DIFF
--- a/app/controllers/chapters_controller.rb
+++ b/app/controllers/chapters_controller.rb
@@ -60,7 +60,7 @@ class ChaptersController < ApplicationController
           @work.anonymous? ? ts("Anonymous") : @work.pseuds.sort.collect(&:byline).join(', '),
           @work.title + " - Chapter " + @chapter.position.to_s)
 
-      @kudos = @work.kudos.with_pseud.includes(pseud: :user).order("created_at DESC")
+      @kudos = @work.kudos.with_pseud.includes(pseud: :user)
 
       if current_user.respond_to?(:subscriptions)
         @subscription = current_user.subscriptions.where(subscribable_id: @work.id,

--- a/app/controllers/kudos_controller.rb
+++ b/app/controllers/kudos_controller.rb
@@ -28,7 +28,7 @@ class KudosController < ApplicationController
 
         format.js do
           @commentable = @kudo.commentable
-          @kudos = @commentable.kudos.with_pseud.includes(pseud: :user).order("created_at DESC")
+          @kudos = @commentable.kudos.with_pseud.includes(pseud: :user)
 
           render :create, status: :created
         end

--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -231,7 +231,7 @@ class WorksController < ApplicationController
     end
 
     @tag_categories_limited = Tag::VISIBLE - ['Warning']
-    @kudos = @work.kudos.with_pseud.includes(pseud: :user).order('created_at DESC')
+    @kudos = @work.kudos.with_pseud.includes(pseud: :user)
 
     if current_user.respond_to?(:subscriptions)
       @subscription = current_user.subscriptions.where(subscribable_id: @work.id,

--- a/app/views/kudos/_kudos.html.erb
+++ b/app/views/kudos/_kudos.html.erb
@@ -1,10 +1,10 @@
 <% # expects local variables kudos, guest_kudos_count, commentable %>
 <div id="kudos">
-  <% if kudos.length > 0 || guest_kudos_count > 0 %>
-    <% cache "#{commentable.cache_key}/kudos-v1", skip_digest: true do %>
+  <% cache "#{commentable.cache_key}/kudos-v1", skip_digest: true do %>
+    <% if kudos.length> 0 || guest_kudos_count > 0 %>
       <p class="kudos">
         <% if kudos.length <= ArchiveConfig.MAX_KUDOS_TO_SHOW %>
-          <%= kudos.map {|kudo| link_to kudo.pseud.byline, kudo.pseud.user}.
+          <%= kudos.order("created_at DESC").map {|kudo| link_to kudo.pseud.byline, kudo.pseud.user}.
               to_sentence.
               html_safe %>
         <% else %>
@@ -12,7 +12,7 @@
               to_sentence(last_word_connector: ", ").
               html_safe + ", " %>
           <%= link_to work_kudos_path(commentable), id: "kudos_summary" do %>
-           <% collapsed_count = kudos.length - ArchiveConfig.MAX_KUDOS_TO_SHOW %>
+            <% collapsed_count = kudos.length - ArchiveConfig.MAX_KUDOS_TO_SHOW %>
             <% if collapsed_count == 1 %>
               <%= ts(" and 1 more user") %>
             <% else %>
@@ -20,10 +20,10 @@
             <% end %>
           <% end %>
           <span class="kudos_expanded hidden">
-            <%= kudos[ArchiveConfig.MAX_KUDOS_TO_SHOW..-1].map {|kudo| link_to kudo.pseud.byline, kudo.pseud.user}.
-                to_sentence(two_words_connector: ts(" and "), last_word_connector: ts(" and ")).
-                html_safe %>
-          </span>
+                <%= kudos[ArchiveConfig.MAX_KUDOS_TO_SHOW..-1].map {|kudo| link_to kudo.pseud.byline, kudo.pseud.user}.
+                    to_sentence(two_words_connector: ts(" and "), last_word_connector: ts(" and ")).
+                    html_safe %>
+              </span>
         <% end %>
         <% if guest_kudos_count > 0 %>
           <% if kudos.length > 0 %>
@@ -33,8 +33,8 @@
         <% end %>
         <%= ts(" left kudos on this work!") %>
         <span class="kudos_expanded hidden">
-          <%= link_to ts("(collapse)"), "#", id: "kudos_collapser" %>
-        </span>
+              <%= link_to ts("(collapse)"), "#", id: "kudos_collapser" %>
+            </span>
       </p>
     <% end %>
   <% end %>

--- a/app/views/kudos/show.html.erb
+++ b/app/views/kudos/show.html.erb
@@ -2,4 +2,4 @@
   <%= ts("Kudos on") %> <%= link_to @kudo.commentable.title, @referrer %>
 </h3>
 
-<%= render "kudos/kudos", :kudos => @kudo.commentable.kudos.with_pseud.order("created_at DESC"), :guest_kudos_count => @kudo.commentable.guest_kudos_count, :commentable => @kudo.commentable %>
+<%= render "kudos/kudos", :kudos => @kudo.commentable.kudos.with_pseud, :guest_kudos_count => @kudo.commentable.guest_kudos_count, :commentable => @kudo.commentable %>


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5415
## Purpose

If a work has more than the maximum number of kudos we show a set of them will be displayed in a random order.Works with less than this should be unaffected.

## Testing

Look at works with more and less than the maximum number of kudos we display and check they have the correct kudos
