### PR TITLE
AO3-5415 Favor kudos.any? over kudos.length > 0 for performance

### DIFF
--- a/app/views/kudos/_kudos.html.erb
+++ b/app/views/kudos/_kudos.html.erb
@@ -1,18 +1,18 @@
 <% # expects local variables kudos, guest_kudos_count, commentable %>
 <div id="kudos">
-  <% if kudos.length > 0 || guest_kudos_count > 0 %>
+  <% if kudos.any? || guest_kudos_count > 0 %>
     <% cache "#{commentable.cache_key}/kudos-v1", skip_digest: true do %>
       <p class="kudos">
         <% if kudos.length <= ArchiveConfig.MAX_KUDOS_TO_SHOW %>
-          <%= kudos.map {|kudo| link_to kudo.pseud.byline, kudo.pseud.user}.
+          <%= kudos.map { |kudo| link_to kudo.pseud.byline, kudo.pseud.user }.
               to_sentence.
               html_safe %>
         <% else %>
-          <%= kudos[0,ArchiveConfig.MAX_KUDOS_TO_SHOW].map {|kudo| link_to kudo.pseud.byline, kudo.pseud.user}.
+          <%= kudos[0, ArchiveConfig.MAX_KUDOS_TO_SHOW].map { |kudo| link_to kudo.pseud.byline, kudo.pseud.user }.
               to_sentence(last_word_connector: ", ").
               html_safe + ", " %>
           <%= link_to work_kudos_path(commentable), id: "kudos_summary" do %>
-           <% collapsed_count = kudos.length - ArchiveConfig.MAX_KUDOS_TO_SHOW %>
+            <% collapsed_count = kudos.length - ArchiveConfig.MAX_KUDOS_TO_SHOW %>
             <% if collapsed_count == 1 %>
               <%= ts(" and 1 more user") %>
             <% else %>
@@ -20,7 +20,7 @@
             <% end %>
           <% end %>
           <span class="kudos_expanded hidden">
-            <%= kudos[ArchiveConfig.MAX_KUDOS_TO_SHOW..-1].map {|kudo| link_to kudo.pseud.byline, kudo.pseud.user}.
+            <%= kudos[ArchiveConfig.MAX_KUDOS_TO_SHOW..-1].map { |kudo| link_to kudo.pseud.byline, kudo.pseud.user }.
                 to_sentence(two_words_connector: ts(" and "), last_word_connector: ts(" and ")).
                 html_safe %>
           </span>


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5415

## Purpose

Uses `kudos.any?` instead of `kudos.length > 0` so we aren't counting all the danged kudos before accessing the cache. 

## Testing

Refer to Jira

## References

We're probably going to implement #3359, but it may need a few tweaks to make it less confusing. This is basically a quick, partial improvement.