### PR TITLE
AO3-5462 Change the number of tags displayed in the new tag search.

### DIFF
--- a/app/models/search/tag_query.rb
+++ b/app/models/search/tag_query.rb
@@ -20,6 +20,11 @@ class TagQuery < Query
     [name_query].compact
   end
 
+  # Tags have a different default per_page value:
+  def per_page
+    options[:per_page] || ArchiveConfig.TAGS_PER_SEARCH_PAGE || 50
+  end
+
   ################
   # FILTERS
   ################

--- a/config/config.yml
+++ b/config/config.yml
@@ -160,6 +160,9 @@ MAX_OPTIONS_TO_SHOW: 20
 MAX_KUDOS_TO_SHOW: 50
 MAX_FAVORITE_TAGS: 20
 
+# The number of tags to show on the search page:
+TAGS_PER_SEARCH_PAGE: 50
+
 # how many signups in a challenge before we move to static summaries generated hourly
 MAX_SIGNUPS_FOR_LIVE_SUMMARY: 20
 

--- a/spec/models/search/tag_query_spec.rb
+++ b/spec/models/search/tag_query_spec.rb
@@ -150,4 +150,11 @@ describe TagQuery, type: :model do
     results = tag_query.search_results
     results.should include(tags[:rel_unicode])
   end
+
+  it "defaults to TAGS_PER_SEARCH_PAGE to determine the number of results" do
+    allow(ArchiveConfig).to receive(:TAGS_PER_SEARCH_PAGE).and_return(5)
+    tag_query = TagQuery.new(name: "a*")
+    results = tag_query.search_results
+    expect(results.size).to eq 5
+  end
 end


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5462

## Purpose

This PR adds a configurable number TAGS_PER_SEARCH_PAGE (defaulting to 50) that controls the default number of tags returned from a TagQuery.

## Testing

See bug report.