### PR TITLE
AO3-5444 Searches with more results than the max should show the total number of results.

### DIFF
--- a/app/helpers/search_helper.rb
+++ b/app/helpers/search_helper.rb
@@ -39,6 +39,16 @@ module SearchHelper
     header.html_safe
   end
 
+  def search_results_found(results)
+    # ES UPGRADE TRANSITION
+    # Remove the if statement and results.total_entries
+    count = if results.respond_to?(:unlimited_total_entries)
+              results.unlimited_total_entries
+            else
+              results.total_entries
+            end
+    ts("%{count} Found", count: count)
+  end
 
   def random_search_tip
     ArchiveConfig.SEARCH_TIPS[rand(ArchiveConfig.SEARCH_TIPS.size)]

--- a/app/models/search/tag_query.rb
+++ b/app/models/search/tag_query.rb
@@ -20,6 +20,11 @@ class TagQuery < Query
     [name_query].compact
   end
 
+  # Tags have a different default per_page value:
+  def per_page
+    options[:per_page] || ArchiveConfig.TAGS_PER_SEARCH_PAGE || 50
+  end
+
   ################
   # FILTERS
   ################

--- a/app/views/bookmarks/search_results.html.erb
+++ b/app/views/bookmarks/search_results.html.erb
@@ -17,7 +17,7 @@
 <% if @bookmarks.blank? %>
   <p><%= ts("No results found. You may want to edit your search to make it less specific.") %></p>
 <% else %>
-  <h3 class="heading"><%= @bookmarks.total_entries %> Found <%= link_to_help "bookmark-search-results-help" %></h3>
+  <h3 class="heading"><%= search_results_found(@bookmarks) %> <%= link_to_help "bookmark-search-results-help" %></h3>
 
   <h3 class="landmark heading">Bookmarks List</h3>
   <ol class="bookmark index group">

--- a/app/views/people/search.html.erb
+++ b/app/views/people/search.html.erb
@@ -10,7 +10,7 @@
 <% end %>
 
 <% if @people %>
-  <p><strong><%= @people.total_entries %> Found</strong></p>
+  <p><strong><%= search_results_found(@people) %></strong></p>
   <h3 class="landmark heading">People List</h3>
   <ol class="pseud index group">
     <% for person in @people %>

--- a/app/views/tags/search.html.erb
+++ b/app/views/tags/search.html.erb
@@ -5,7 +5,7 @@
 <%= render :partial => 'tags/search_form' %>
 
 <% if @tags %>
-  <h3 class="heading"><%= @tags.total_entries %> Found <%= link_to_help "tag-search-results-help" %></h3>
+  <h3 class="heading"><%= search_results_found(@tags) %> <%= link_to_help "tag-search-results-help" %></h3>
   <h4 class="landmark heading">Listing Tags</h4>
   <ol class="tag index group">
     <% for tag in @tags %>

--- a/app/views/works/search_results.html.erb
+++ b/app/views/works/search_results.html.erb
@@ -17,7 +17,7 @@
 <% if @works.blank? %>
   <p><%= ts("No results found. You may want to edit your search to make it less specific.") %></p>
 <% else %>
-  <h3 class="heading"><%= @works.total_entries %> Found <%= link_to_help "work-search-results-help" %></h3>
+  <h3 class="heading"><%= search_results_found(@works) %> <%= link_to_help "work-search-results-help" %></h3>
 
   <h3 class="landmark heading">Works List</h3>
   <ol class="work index group">

--- a/config/config.yml
+++ b/config/config.yml
@@ -160,6 +160,9 @@ MAX_OPTIONS_TO_SHOW: 20
 MAX_KUDOS_TO_SHOW: 50
 MAX_FAVORITE_TAGS: 20
 
+# The number of tags to show on the search page:
+TAGS_PER_SEARCH_PAGE: 50
+
 # how many signups in a challenge before we move to static summaries generated hourly
 MAX_SIGNUPS_FOR_LIVE_SUMMARY: 20
 

--- a/features/search/exceeding_maximum.feature
+++ b/features/search/exceeding_maximum.feature
@@ -1,0 +1,48 @@
+Feature: Large searches
+  As a user
+  I want to see how many results my search returns if it's more than the max
+
+  Scenario: Work search should show the correct number of results
+    Given a set of Kirk/Spock works for searching
+      And the max search result count is 2
+      And 1 item is displayed per page
+    When I search for works containing "James T. Kirk"
+    Then I should see "4 Found"
+
+  Scenario: Bookmark search should show the correct number of results
+    Given I have bookmarks to search
+      And the max search result count is 2
+      And 1 item is displayed per page
+    When I am on the search bookmarks page
+      And I select "Work" from "Type"
+      And I press "Search Bookmarks"
+    Then I should see "5 Found"
+
+  @new-search
+  Scenario: People search should show the correct number of results
+    Given the following activated users exist
+      | login      |
+      | test_alice |
+      | test_betsy |
+      | test_carol |
+      | test_diana |
+      And the max search result count is 2
+      And 1 item is displayed per page
+      And all indexing jobs have been run
+    When I go to the search people page
+      And I fill in "Search all fields" with "test"
+      And I press "Search People"
+    Then I should see "4 Found"
+
+  @new-search
+  Scenario: Tag search should show the correct number of results
+    Given a canonical freeform "Fluff"
+      And a canonical freeform "Angst"
+      And a canonical freeform "Smut"
+      And a canonical freeform "Alternate Universe"
+      And the max search result count is 2
+      And 1 tag is displayed per search page
+    When I go to the search tags page
+      And I select "Freeform" from "query[type]"
+      And I press "Search tags"
+    Then I should see "4 Found"

--- a/features/step_definitions/search_steps.rb
+++ b/features/step_definitions/search_steps.rb
@@ -51,9 +51,14 @@ Given /^the max search result count is (\d+)$/ do |max|
   ArchiveConfig.MAX_SEARCH_RESULTS = max.to_i
 end
 
-Given /^(\d+) items are displayed per page$/ do |per_page|
+Given /^(\d+) item(?:s)? (?:is|are) displayed per page$/ do |per_page|
   stub_const("ArchiveConfig", OpenStruct.new(ArchiveConfig))
   ArchiveConfig.ITEMS_PER_PAGE = per_page.to_i
+end
+
+Given /^(\d+) tag(?:s)? (?:is|are) displayed per search page$/ do |per_page|
+  stub_const("ArchiveConfig", OpenStruct.new(ArchiveConfig))
+  ArchiveConfig.TAGS_PER_SEARCH_PAGE = per_page.to_i
 end
 
 When /^(\w+) can use the new search/ do |login|

--- a/spec/models/search/tag_query_spec.rb
+++ b/spec/models/search/tag_query_spec.rb
@@ -150,4 +150,11 @@ describe TagQuery, type: :model do
     results = tag_query.search_results
     results.should include(tags[:rel_unicode])
   end
+
+  it "defaults to TAGS_PER_SEARCH_PAGE to determine the number of results" do
+    allow(ArchiveConfig).to receive(:TAGS_PER_SEARCH_PAGE).and_return(5)
+    tag_query = TagQuery.new(name: "a*")
+    results = tag_query.search_results
+    expect(results.size).to eq 5
+  end
 end


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5444

## Purpose

The PR extracts the "x Found" text at the top of works, bookmarks, tags, and people search into a single helper function search_results_found, which uses the unlimited_total_entries field whenever it's available. This means that when the number of search results is greater than 100000, the true number of search results will still be displayed (and not just capped at 100000).

## Testing

See the bug report for test steps.

## References

The full number of results needs to be visible on every page, not just the last page of results. So I deliberately set up the automated tests to cut down on the number of results per page, and check whether the number appears on the first of two pages. Because #3364 affects the number of tags displayed per page, I decided to include it.