### PR TITLE
AO3-5463 Show anonymous & unrevealed works in user's Works in Collections

### DIFF
--- a/app/models/search/work_query.rb
+++ b/app/models/search/work_query.rb
@@ -234,7 +234,7 @@ class WorkQuery < Query
     [:title, :creators].each do |field|
       search_text << split_query_text_words(field, options[field])
     end
-    if self.options[:collection_ids].blank? && options[:collected]
+    if options[:collection_ids].blank? && collected?
       search_text << " collection_ids:*"
     end
     escape_slashes(search_text.strip)

--- a/app/models/search/work_query.rb
+++ b/app/models/search/work_query.rb
@@ -289,8 +289,8 @@ class WorkQuery < Query
     options[:collection_ids].present? || collected?
   end
 
-  # Include anonymous works unless we're on a user or pseud page
-  # OR unless the user is viewing their own collected works
+  # Include anonymous works if we're not on a user/pseud page
+  # OR if the user is viewing their own collected works
   def include_anon?
     (user_ids.blank? && pseud_ids.blank?) ||
       (collected? && options[:works_parent].present? && options[:works_parent] == User.current_user)

--- a/app/models/search/work_search_form.rb
+++ b/app/models/search/work_search_form.rb
@@ -100,6 +100,7 @@ class WorkSearchForm
     # TODO: Change this to not rely on WorkSearch
     processed_opts = WorkSearch.new(opts).options
     processed_opts.merge!(collected: opts[:collected], faceted: opts[:faceted])
+    processed_opts.merge!(works_parent: opts[:works_parent])
     processed_opts
   end
 

--- a/factories/collections.rb
+++ b/factories/collections.rb
@@ -1,7 +1,6 @@
-require 'faker'
+require "faker"
 
 FactoryGirl.define do
-
   sequence(:collection_name) do |n|
     "basic_collection_#{n}"
   end
@@ -24,14 +23,22 @@ FactoryGirl.define do
   end
 
   factory :collection do |f|
-    name {generate(:collection_name)}
-    title {generate(:collection_title)}
+    name { generate(:collection_name) }
+    title { generate(:collection_title) }
 
     after(:build) do |collection|
-      collection.collection_participants.build(pseud_id: FactoryGirl.create(:pseud).id, participant_role: "Owner")
+      collection.collection_participants.build(pseud_id: create(:pseud).id, participant_role: "Owner")
+    end
+
+    factory :anonymous_collection do
+      association :collection_preference, anonymous: true
+    end
+
+    factory :unrevealed_collection do
+      association :collection_preference, unrevealed: true
     end
   end
-  
+
   factory :collection_item do
     item_type "Work"
   end


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5463

## Purpose

This is missing in new search.

Unrevealed works should appear to all, while anonymous works should only appear if the logged in user is the author.

## Testing

See JIRA issue.