### PR TITLE
AO3-4842 Stop stripping carriage returns from Support and Abuse request descriptions

### DIFF
--- a/app/models/feedback_reporters/feedback_reporter.rb
+++ b/app/models/feedback_reporters/feedback_reporter.rb
@@ -20,10 +20,6 @@ class FeedbackReporter
     strip_html_breaks_simple(@title)
   end
 
-  def description
-    @description
-  end
-
   def send_report!
     HTTParty.post("#{ArchiveConfig.NEW_BUGS_SITE}#{project_path}",
                   body: "&xml=#{xml.to_str}")

--- a/app/models/feedback_reporters/feedback_reporter.rb
+++ b/app/models/feedback_reporters/feedback_reporter.rb
@@ -21,16 +21,12 @@ class FeedbackReporter
   end
 
   def description
-    strip_html_breaks_simple(@description)
+    @description
   end
 
   def send_report!
-    # We're sending the XML data via a URL to our Support ticket service. The
-    # URL needs to be Percent-encoded so that everything shows up correctly on
-    # the other end. (https://en.wikipedia.org/wiki/Percent-encoding)
-    encoded_xml = CGI.escape(xml.to_str)
     HTTParty.post("#{ArchiveConfig.NEW_BUGS_SITE}#{project_path}",
-                  body: "&xml=#{encoded_xml}")
+                  body: "&xml=#{xml.to_str}")
   end
 
   def xml


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-4842

## Purpose

Formatting was previously being stripped before being sent to the Bugtracker. This was because of changed that occured in https://otwarchive.atlassian.net/browse/AO3-4216 . This was no longer desired behavior, so I have removed the format stripping from the 'description' field only. 

## Testing

Submit an Abuse and Support request and make sure that formatting (italics, bold, newline, etc.) correctly show up on the Bug/Abuse trackers. 

## References

Original issue that called for removing formatting: https://otwarchive.atlassian.net/browse/AO3-4216

