### PR TITLE
AO3-5459 Update Elasticsearch to 6.2.4 for Codeship and Travis CI

### DIFF
--- a/script/prepare_codeship.sh
+++ b/script/prepare_codeship.sh
@@ -35,7 +35,7 @@ cd elasticsearch-${VERSION}
 echo "http.port: ${PORT}" >> config/elasticsearch.yml
 # Make sure to use the exact parameters you want for elasticsearch and give it enough sleep time to properly start up
 nohup bash -c "./bin/elasticsearch 2>&1" &
-NEW_ES_VERSION="6.0.0"
+NEW_ES_VERSION="6.2.4"
 NEW_ES_PORT="9334"
 cd ~
 wget https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-${NEW_ES_VERSION}.zip

--- a/script/travis_elasticsearch_upgrade.sh
+++ b/script/travis_elasticsearch_upgrade.sh
@@ -15,15 +15,14 @@ case $ES in
 esac
 cd /tmp
 wget https://download.elastic.co/elasticsearch/elasticsearch/elasticsearch-0.90.13.tar.gz
-wget https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-6.0.0.tar.gz
+wget https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-6.2.4.tar.gz
 tar xvfz /tmp/elasticsearch-0.90.13.tar.gz
-tar xvfz /tmp/elasticsearch-6.0.0.tar.gz
-sed -i elasticsearch-6.0.0/config/elasticsearch.yml  -e 's/#http.port: 9200/http.port: 9400/'
+tar xvfz /tmp/elasticsearch-6.2.4.tar.gz
+sed -i elasticsearch-6.2.4/config/elasticsearch.yml  -e 's/#http.port: 9200/http.port: 9400/'
 sed -i elasticsearch-0.90.13/config/elasticsearch.yml  -e 's/# http.port: 9200/http.port: 9500/'
-nohup ./elasticsearch-6.0.0/bin/elasticsearch &
+nohup ./elasticsearch-6.2.4/bin/elasticsearch &
 wget -q --waitretry=1 --retry-connrefused -T 20 -O - http://127.0.0.1:9400
 if [ "$ES" != "2" ] ; then
  nohup ./elasticsearch-0.90.13/bin/elasticsearch &
  wget -q --waitretry=1 --retry-connrefused -T 10 -O - http://127.0.0.1:9500
 fi
-


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5459

## Purpose

Use ES 6.2.4 in test environments to match production.

## Testing

It just works.