### PR TITLE
AO3-5467 Standardize fallback fonts in certain places

### DIFF
--- a/public/stylesheets/site/2.0/08-actions.css
+++ b/public/stylesheets/site/2.0/08-actions.css
@@ -47,7 +47,7 @@ ul.actions {
 }
 
 button {
-  font-family: 'Lucida Grande', 'Lucida Sans Unicode', 'Arial Unicode MS', 'GNU Unifont', sans-serif;
+  font-family: 'Lucida Grande', 'Lucida Sans Unicode', 'GNU Unifont', Verdana, Helvetica, sans-serif;
   box-sizing: content-box;
 }
 
@@ -152,7 +152,7 @@ ul#skiplinks, .landmark, .landmark a, .index .heading.landmark {
 
 .heading .actions, .heading .action, .heading span.actions {
   height: auto;
-  font: 100 75%/1.286 'Lucida Grande', 'Lucida Sans Unicode', 'Arial Unicode MS', 'GNU Unifont',sans-serif;
+  font: 100 75%/1.286 'Lucida Grande', 'Lucida Sans Unicode', 'GNU Unifont', Verdana, Helvetica, sans-serif;
   padding: 0.15em 0.375em;
 }
 

--- a/public/stylesheets/site/2.0/09-roles-states.css
+++ b/public/stylesheets/site/2.0/09-roles-states.css
@@ -19,7 +19,7 @@ span.unread, .replied, span.claimed, .actions span.defaulted {
   background: #ccc;
   color: #900;
   width: auto;
-  font: 100 100%/1.286 'Lucida Grande', 'Lucida Sans Unicode', 'Arial Unicode MS', 'GNU Unifont', sans-serif;
+  font: 100 100%/1.286 'Lucida Grande', 'Lucida Sans Unicode', 'GNU Unifont', Verdana, Helvetica, sans-serif;
   height: 1.286em;
   vertical-align: middle;
   display: inline-block;


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5467

## Purpose

Makes sure we're using the same fallback fonts everywhere we should be -- that is, in all the non-IE stylesheets where the first two fonts are Lucida Grande and Lucida Sans Unicode.

## Testing

Refer to Jira