### PR TITLE
AO3-5470 Make Work.index_name always return the old index name (for IndexSubqueue compatibility)

### DIFF
--- a/app/models/bookmark.rb
+++ b/app/models/bookmark.rb
@@ -159,13 +159,9 @@ class Bookmark < ApplicationRecord
   end
 
   # ES UPGRADE TRANSITION #
-  # Remove conditional and Tire reference
+  # Remove this function.
   def self.index_name
-    if use_new_search?
-      "#{ArchiveConfig.ELASTICSEARCH_PREFIX}_#{Rails.env}_bookmarks"
-    else
-      tire.index.name
-    end
+    tire.index.name
   end
 
   # Returns the number of bookmarks on an item visible to the current user

--- a/app/models/pseud.rb
+++ b/app/models/pseud.rb
@@ -128,13 +128,9 @@ class Pseud < ApplicationRecord
   }
 
   # ES UPGRADE TRANSITION #
-  # Remove conditional and Tire reference
+  # Remove this function.
   def self.index_name
-    if use_new_search?
-      "#{ArchiveConfig.ELASTICSEARCH_PREFIX}_#{Rails.env}_pseuds"
-    else
-      tire.index.name
-    end
+    tire.index.name
   end
 
   def self.not_orphaned

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -26,13 +26,9 @@ class Tag < ApplicationRecord
   USER_DEFINED = ['Fandom', 'Character', 'Relationship', 'Freeform']
 
   # ES UPGRADE TRANSITION #
-  # Remove conditional and Tire reference
+  # Remove this function.
   def self.index_name
-    if use_new_search?
-      "#{ArchiveConfig.ELASTICSEARCH_PREFIX}_#{Rails.env}_works"
-    else
-      tire.index.name
-    end
+    tire.index.name
   end
 
   # ES UPGRADE TRANSITION #

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -266,13 +266,9 @@ class Work < ApplicationRecord
   end
 
   # ES UPGRADE TRANSITION #
-  # Remove conditional and Tire reference
+  # Remove this function.
   def self.index_name
-    if use_new_search?
-      "#{ArchiveConfig.ELASTICSEARCH_PREFIX}_#{Rails.env}_works"
-    else
-      tire.index.name
-    end
+    tire.index.name
   end
 
   def self.work_blurb_tag_cache_key(id)

--- a/spec/models/elasticsearch/rollout_elasticsearch_upgrade_spec.rb
+++ b/spec/models/elasticsearch/rollout_elasticsearch_upgrade_spec.rb
@@ -2,28 +2,30 @@ require 'spec_helper'
 
 describe 'Rolling out the upgrade' do
 
-  describe 'the work model' do
-    it 'should return new index name when use_new_search? is true' do
+  # The index_name functions on the models are used exclusivly by the old
+  # indexer; the index_name functions on the Indexer classes are used
+  # exclusively by the new indexer.
+  describe "Work.index_name" do
+    it "returns the old index name when use_new_search? is enabled" do
       Work.stub(:use_new_search?) { true }
-      expect(Work.index_name).to eq("ao3_test_works")
+      expect(Work.index_name).to eq("otwarchive_test_works")
     end
 
-    it 'should return old inex name when use_new_search? is false' do
+    it "returns the old index name when use_new_search? is disabled" do
       Work.stub(:use_new_search?) { false }
       expect(Work.index_name).to eq("otwarchive_test_works")
     end
   end
 
-  describe 'the bookmark model' do
-    it 'should return new index name when use_new_search? is true' do
+  describe "Bookmark.index_name" do
+    it "returns the old index name when use_new_search? is enabled" do
       Bookmark.stub(:use_new_search?) { true }
-      expect(Bookmark.index_name).to eq('ao3_test_bookmarks')
+      expect(Bookmark.index_name).to eq("otwarchive_test_bookmarks")
     end
 
-    it 'should return old index name when use_new_search? is false' do
+    it "returns the old index name when use_new_search? is disabled" do
       Bookmark.stub(:use_new_search?) { false }
-      expect(Bookmark.index_name).to eq('otwarchive_test_bookmarks')
+      expect(Bookmark.index_name).to eq("otwarchive_test_bookmarks")
     end
   end
-
 end

--- a/spec/models/index_subqueue_spec.rb
+++ b/spec/models/index_subqueue_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
-describe IndexSubqueue do
 
+describe IndexSubqueue do
   let(:subqueue) { IndexSubqueue.new("index:work:main:1234567:0") }
 
   it "should have ids added to it" do
@@ -17,4 +17,37 @@ describe IndexSubqueue do
     expect(subqueue.label).to eq("main")
   end
 
+  describe "#run" do
+    let(:work) { create(:posted_work) }
+
+    deprecate_old_elasticsearch_test do
+      context "when the new search is disabled" do
+        before { $rollout.deactivate(:use_new_search) }
+
+        it "reindexes new works" do
+          subqueue.add_ids([work.id])
+          expect(subqueue).to receive(:respond_to_success).and_call_original
+          expect(Work).to receive(:successful_reindex).and_call_original
+          subqueue.run
+
+          Work.tire.index.refresh
+          expect(WorkSearch.new.search_results.items).to include(work)
+        end
+      end
+
+      context "when the new search is enabled" do
+        before { $rollout.activate(:use_new_search) }
+
+        it "reindexes new works" do
+          subqueue.add_ids([work.id])
+          expect(subqueue).to receive(:respond_to_success).and_call_original
+          expect(Work).to receive(:successful_reindex).and_call_original
+          subqueue.run
+
+          Work.tire.index.refresh
+          expect(WorkSearch.new.search_results.items).to include(work)
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5470

## Purpose

The index_name functions in the Work, Bookmark, Tag, and Pseud classes are exclusively used in the IndexSubqueue (the old indexing class) to perform indexing. However, they're currently set up to return a different index name when use_new_search is enabled for all users. This means that once all users have the new search, all old indexing tasks will try to use the wrong index name, and fail.

This pull request changes the four index_name functions (in the ActiveModel classes, not the Indexer classes) so that they always return the name of the old index. It also adds a few tests to check that the index names are correct and the works are being indexed properly.

## Testing

Switch on use_new_search for all users, create a new work, and wait a few minutes for the work to be indexed. Then deactivate use_new_search and see if you can find the work in the old search. (Alternatively, check error logs.)