### PR TITLE
AO3-5471 remove servers running elasticsearch

### DIFF
--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -10,7 +10,6 @@ require 'capistrano/gitflow_version'
 server "ao3-app01.ao3.org", :app, :db, :workers, :schedulers
 server "ao3-app02.ao3.org", :app, :workers, :schedulers, primary: true
 server "ao3-app03.ao3.org", :app, :workers, :schedulers
-server "ao3-app04.ao3.org", :app
 server "ao3-front01.ao3.org", :web
 server "ao3-app05.ao3.org", :app
 server "ao3-app08.ao3.org", :app, :workers, :schedulers
@@ -19,7 +18,6 @@ server "ao3-app07.ao3.org", :app
 server "ao3-front02.ao3.org", :web
 server "ao3-app09.ao3.org", :app
 server "ao3-app11.ao3.org", :app, :workers, :schedulers
-server "ao3-app12.ao3.org", :app
 server "ao3-app14.ao3.org", :app
 server "ao3-front04.ao3.org", :web
 


### PR DESCRIPTION


## Issue

https://otwarchive.atlassian.net/browse/AO3-5471

## Purpose
Just take out the nodes which we have stolen for Elasticsearch.

No testing required.

