### PR TITLE
AO3-5472 Fix filter selection using checkboxes with iOS VoiceOver

### DIFF
--- a/public/stylesheets/site/2.0/18-zone-searchbrowse.css
+++ b/public/stylesheets/site/2.0/18-zone-searchbrowse.css
@@ -162,18 +162,24 @@ form.filters {
   margin-top: 1.286em; /* heading top margin minus sort bottom margin */
 }
 
-/* AO3-5370: Normally you'd use absolute positioning here, but we
-needed relative positioning and a left offset to fix a bug in Safari 9 */
 .filters [type="checkbox"], .filters [type="radio"] {
   border: 0;
   clip: rect(0 0 0 0);
   height: 1px;
-  left: -2em;
   margin: -1px;
   overflow: hidden;
   padding: 0;
-  position: relative;
+  position: absolute;
   width: 1px;
+}
+
+/* AO3-5370: Style changes to fix a bug unique to Safari 9. Hack courtesy of
+https://browserstrangeness.github.io/css_hacks.html */
+@supports (overflow:-webkit-marquee) and (justify-content:inherit) {
+  .filters [type="checkbox"], .filters [type="radio"] {
+    left: -2em;
+    position: relative;
+  }
 }
 
 .filters .indicator:before {


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5472

## Purpose

Resolves an issue where tapping checkboxes and radio buttons in the filters does not always work on iOS with VoiceOver.

## Testing

Refer to Jira

## References

This was caused by #3274, which is still needed to fix a bug that only occurs in Safari 9. It uses a browser-specific hack from https://browserstrangeness.github.io/css_hacks.html to make sure that fix is still applied where needed.