### PR TITLE
AO3-5167: Improve performance of ownership checks

### DIFF
--- a/app/controllers/bookmarks_controller.rb
+++ b/app/controllers/bookmarks_controller.rb
@@ -59,6 +59,7 @@ class BookmarksController < ApplicationController
       end
       @bookmarks = @search.search_results
       flash_max_search_results_notice(@bookmarks)
+      set_own_bookmarks
       render 'search_results'
     end
   end
@@ -167,6 +168,7 @@ class BookmarksController < ApplicationController
         @bookmarks = Bookmark.latest.includes(:bookmarkable, :pseud, :tags, :collections).to_a
       end
     end
+    set_own_bookmarks
   end
 
   # GET    /:locale/bookmark/:id
@@ -304,6 +306,7 @@ class BookmarksController < ApplicationController
     respond_to do |format|
       format.js {
         @bookmarks = @bookmarkable.bookmarks.visible.order("created_at DESC").offset(1).limit(4)
+        set_own_bookmarks
       }
       format.html do
         id_symbol = (@bookmarkable.class.to_s.underscore + '_id').to_sym
@@ -361,6 +364,17 @@ class BookmarksController < ApplicationController
       "#{owner_name} - Bookmarks".html_safe
     else
       "Latest Bookmarks"
+    end
+  end
+
+  def set_own_bookmarks
+    return unless @bookmarks
+    @own_bookmarks = []
+    if current_user.is_a?(User)
+      pseud_ids = current_user.pseuds.pluck(:id)
+      @own_bookmarks = @bookmarks.select do |b|
+        pseud_ids.include?(b.pseud_id)
+      end
     end
   end
 

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -1,7 +1,13 @@
 module UsersHelper
   # Can be used to check ownership of items
   def is_author_of?(item)
-    current_user.is_a?(User) ? current_user.is_author_of?(item) : false
+    if @own_bookmarks && item.is_a?(Bookmark)
+      @own_bookmarks.include?(item)
+    elsif @own_works && item.is_a?(Work)
+      @own_works.include?(item)
+    else
+      current_user.is_a?(User) && current_user.is_author_of?(item)
+    end
   end
 
   # Can be used to check if user is maintainer of any collections

--- a/app/models/collection_item.rb
+++ b/app/models/collection_item.rb
@@ -149,7 +149,7 @@ class CollectionItem < ApplicationRecord
         when "Work"
           users = item.users || [User.current_user] # if the work has no users, it is also new and being created by the current user
         when "Bookmark"
-          users = [item.user] || [User.current_user]
+          users = [item.pseud.user] || [User.current_user]
         end
 
         users.each do |user|

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -363,6 +363,8 @@
       !(pseuds.pluck(:id) & item.pseuds.pluck(:id)).empty?
     elsif item.respond_to?(:author)
       self == item.author
+    elsif item.respond_to?(:creator_id)
+      self.id == item.creator_id
     else
       false
     end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -355,16 +355,14 @@
 
   # Checks authorship of any sort of object
   def is_author_of?(item)
-    if item.respond_to?(:user)
-      self == item.user
-    elsif item.respond_to?(:pseud)
-      self.pseuds.include?(item.pseud)
+    if item.respond_to?(:pseud_id)
+      pseuds.pluck(:id).include?(item.pseud_id)
+    elsif item.respond_to?(:user_id)
+      id == item.user_id
     elsif item.respond_to?(:pseuds)
-      !(self.pseuds & item.pseuds).empty?
+      !(pseuds.pluck(:id) & item.pseuds.pluck(:id)).empty?
     elsif item.respond_to?(:author)
       self == item.author
-    elsif item.respond_to?(:creator)
-      self == item.creator
     else
       false
     end


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5167

## Purpose

Switches is_author_of? method to compare based on ids rather than objects, which should save on some db calls and memory. Also preloads the set of current works/bookmarks owned by the current user on index pages so that we don't have to run separate checks over and over.

Replaces https://github.com/otwcode/otwarchive/pull/3054 which was approved but then became hopelessly conflicted.

## Testing

Nothing should change: appropriate footers for work and bookmark blurbs should appear if they're yours, and anonymity should be respected.