### PR TITLE
AO3-4470: Standardize caching of admin settings and default skin

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -157,11 +157,7 @@ public
 
   before_action :fetch_admin_settings
   def fetch_admin_settings
-    if Rails.env.development?
-      @admin_settings = AdminSetting.first
-    else
-      @admin_settings = Rails.cache.fetch("admin_settings"){AdminSetting.first}
-    end
+    @admin_settings = AdminSetting.current
   end
 
   before_action :load_admin_banner

--- a/app/models/admin_setting.rb
+++ b/app/models/admin_setting.rb
@@ -28,20 +28,20 @@ class AdminSetting < ApplicationRecord
     guest_downloading_off?: false,
     downloads_enabled?: true,
     stats_updated_at: nil
-  }
+  }.freeze
 
   def self.current
-    Rails.cache.fetch("admin_settings"){ AdminSetting.first } || OpenStruct.new(DEFAULT_SETTINGS)
+    Rails.cache.fetch("admin_settings") { AdminSetting.first } || OpenStruct.new(DEFAULT_SETTINGS)
   end
 
   class << self
-    delegate *(DEFAULT_SETTINGS.keys), :to => :current
+    delegate *DEFAULT_SETTINGS.keys, :to => :current
   end
 
   def self.default_skin
     settings = current
     if settings.default_skin_id.present?
-      Rails.cache.fetch("admin_default_skin"){ settings.default_skin }
+      Rails.cache.fetch("admin_default_skin") { settings.default_skin }
     else
       Skin.default
     end

--- a/app/models/admin_setting.rb
+++ b/app/models/admin_setting.rb
@@ -12,53 +12,39 @@ class AdminSetting < ApplicationRecord
 
   belongs_to :default_skin, class_name: 'Skin'
 
-  def self.invite_from_queue_enabled?
-    self.first ? self.first.invite_from_queue_enabled? : ArchiveConfig.INVITE_FROM_QUEUE_ENABLED
+  DEFAULT_SETTINGS = {
+    invite_from_queue_enabled?: ArchiveConfig.INVITE_FROM_QUEUE_ENABLED,
+    request_invite_enabled?: false,
+    invite_from_queue_at: nil,
+    invite_from_queue_number: ArchiveConfig.INVITE_FROM_QUEUE_NUMBER,
+    invite_from_queue_frequency: ArchiveConfig.INVITE_FROM_QUEUE_FREQUENCY,
+    account_creation_enabled?: ArchiveConfig.ACCOUNT_CREATION_ENABLED,
+    days_to_purge_unactivated: ArchiveConfig.DAYS_TO_PURGE_UNACTIVATED,
+    suspend_filter_counts?: false,
+    disable_filtering?: false,
+    enable_test_caching?: false,
+    cache_expiration: 10,
+    tag_wrangling_off?: false,
+    guest_downloading_off?: false,
+    downloads_enabled?: true,
+    stats_updated_at: nil
+  }
+
+  def self.current
+    Rails.cache.fetch("admin_settings"){ AdminSetting.first } || OpenStruct.new(DEFAULT_SETTINGS)
   end
-  def self.request_invite_enabled?
-    self.first ? self.first.request_invite_enabled? : false
+
+  class << self
+    delegate *(DEFAULT_SETTINGS.keys), :to => :current
   end
-  def self.invite_from_queue_at
-    self.first.invite_from_queue_at
-  end
-  def self.invite_from_queue_number
-    self.first ? self.first.invite_from_queue_number : ArchiveConfig.INVITE_FROM_QUEUE_NUMBER
-  end
-  def self.invite_from_queue_frequency
-    self.first ? self.first.invite_from_queue_frequency : ArchiveConfig.INVITE_FROM_QUEUE_FREQUENCY
-  end
-  def self.account_creation_enabled?
-    self.first ? self.first.account_creation_enabled? : ArchiveConfig.ACCOUNT_CREATION_ENABLED
-  end
-  def self.days_to_purge_unactivated
-    self.first ? self.first.days_to_purge_unactivated : ArchiveConfig.DAYS_TO_PURGE_UNACTIVATED
-  end
-  def self.suspend_filter_counts?
-    self.first ? self.first.suspend_filter_counts? : false
-  end
-  def self.disable_filtering?
-    self.first ? self.first.disable_filtering? : false
-  end
-  def self.enable_test_caching?
-    self.first ? self.first.enable_test_caching? : false
-  end
-  def self.cache_expiration
-    self.first ? self.first.cache_expiration : 10
-  end
-  def self.tag_wrangling_off?
-    self.first ? self.first.tag_wrangling_off? : false
-  end
-  def self.guest_downloading_off?
-    self.first ? self.first.guest_downloading_off? : false
-  end
-  def self.downloads_enabled?
-    self.first ? self.first.downloads_enabled? : true
-  end
+
   def self.default_skin
-    self.first ? (self.first.default_skin_id ? self.first.default_skin : Skin.default) : Skin.default
-  end
-  def self.stats_updated_at
-    self.first ? self.first.stats_updated_at : nil
+    settings = current
+    if settings.default_skin_id.present?
+      Rails.cache.fetch("admin_default_skin"){ settings.default_skin }
+    else
+      Skin.default
+    end
   end
 
   # run once a day from cron

--- a/app/models/invite_request.rb
+++ b/app/models/invite_request.rb
@@ -31,7 +31,7 @@ class InviteRequest < ApplicationRecord
   end
 
   def proposed_fill_date
-    admin_settings = Rails.cache.fetch("admin_settings"){AdminSetting.first}
+    admin_settings = AdminSetting.current
     number_of_rounds = (self.position.to_f/admin_settings.invite_from_queue_number.to_f).ceil - 1
     proposed_date = admin_settings.invite_from_queue_at.to_date + (admin_settings.invite_from_queue_frequency * number_of_rounds).days
     Date.today > proposed_date ? Date.today : proposed_date
@@ -47,7 +47,7 @@ class InviteRequest < ApplicationRecord
 
   #Invite a specified number of users
   def self.invite
-    admin_settings = Rails.cache.fetch("admin_settings"){AdminSetting.first}
+    admin_settings = AdminSetting.current
     self.order(:position).limit(admin_settings.invite_from_queue_number).each do |request|
       request.invite_and_remove
     end

--- a/app/models/skin.rb
+++ b/app/models/skin.rb
@@ -502,7 +502,9 @@ class Skin < ApplicationRecord
   end
 
   def self.default
-    Skin.find_by(title: "Default", official: true) || Skin.create_default
+    Rails.cache.fetch("site_default_skin") do
+      Skin.find_by(title: "Default", official: true) || Skin.create_default
+    end
   end
 
   def self.create_default

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -968,7 +968,7 @@ class Tag < ApplicationRecord
   end
 
   def reset_filter_count
-    admin_settings = Rails.cache.fetch("admin_settings") { AdminSetting.first }
+    admin_settings = AdminSetting.current
     return if admin_settings.suspend_filter_counts?
     current_filter = filter
     # we only need to cache values for user-defined tags

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -984,7 +984,7 @@ class Work < ApplicationRecord
 
   # Determine if filter counts need to be reset after the work is saved
   def check_filter_counts
-    admin_settings = Rails.cache.fetch("admin_settings"){AdminSetting.first}
+    admin_settings = AdminSetting.current
     self.should_reset_filters = (self.new_record? || self.visibility_changed?)
     if admin_settings.suspend_filter_counts? && !(self.restricted_changed? || self.hidden_by_admin_changed?)
       self.should_reset_filters = false
@@ -1420,7 +1420,7 @@ class Work < ApplicationRecord
 
   def hide_spam
     return unless spam?
-    admin_settings = Rails.cache.fetch("admin_settings"){ AdminSetting.first }
+    admin_settings = AdminSetting.current
     if admin_settings.hide_spam?
       self.hidden_by_admin = true
     end

--- a/app/views/users/confirmation.html.erb
+++ b/app/views/users/confirmation.html.erb
@@ -11,7 +11,7 @@
   </p>
   <p>
     <% # We do days_to_purge_unactivated * 7 because it's actually weeks %>
-    <%= ts("<strong>Important!</strong> You must verify your account within %{days_before_purge} days, or your registration will expire.", days_before_purge: AdminSetting.first.days_to_purge_unactivated? ? (AdminSetting.first.days_to_purge_unactivated * 7) : ArchiveConfig.DAYS_TO_PURGE_UNACTIVATED).html_safe %>
+    <%= ts("<strong>Important!</strong> You must verify your account within %{days_before_purge} days, or your registration will expire.", days_before_purge: AdminSetting.current.days_to_purge_unactivated? ? (AdminSetting.current.days_to_purge_unactivated * 7) : ArchiveConfig.DAYS_TO_PURGE_UNACTIVATED).html_safe %>
   </p>
   <p>
     <%= link_to ts('Return to Archive front page'), root_path %>

--- a/lib/tasks/tag_tasks.rake
+++ b/lib/tasks/tag_tasks.rake
@@ -73,7 +73,7 @@ namespace :Tag do
 
   desc "Reset filter counts from date"
   task(unsuspend_filter_counts: :environment) do
-    admin_settings = Rails.cache.fetch("admin_settings") { AdminSetting.first }
+    admin_settings = AdminSetting.current
     if admin_settings && admin_settings.suspend_filter_counts_at
       FilterTagging.update_filter_counts_since(admin_settings.suspend_filter_counts_at)
     end


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-4470

## Purpose

Adds a new wrapper method that utilizes caching for admin settings and calls that wherever we need the current settings. Also simplifies some class methods via delegation and adds extra caching for default skins.

## Testing

Everything should continue to work as it did before, but with fewer database calls.