### PR TITLE
AO3-4842 Add <br /> between paragraphs for Support and PAC tickets

### DIFF
--- a/app/models/feedback.rb
+++ b/app/models/feedback.rb
@@ -63,7 +63,7 @@ class Feedback < ApplicationRecord
   end
 
   def send_report
-    # return unless %w(staging production).include?(Rails.env)
+    return unless %w(staging production).include?(Rails.env)
     reporter = SupportReporter.new(
       title: summary,
       description: comment,

--- a/app/models/feedback.rb
+++ b/app/models/feedback.rb
@@ -63,7 +63,7 @@ class Feedback < ApplicationRecord
   end
 
   def send_report
-    return unless %w(staging production).include?(Rails.env)
+    # return unless %w(staging production).include?(Rails.env)
     reporter = SupportReporter.new(
       title: summary,
       description: comment,

--- a/app/models/feedback_reporters/feedback_reporter.rb
+++ b/app/models/feedback_reporters/feedback_reporter.rb
@@ -21,7 +21,7 @@ class FeedbackReporter
   end
 
   def description
-    double_html_paragraphs(@description)
+    add_break_between_paragraphs(@description)
   end
 
   def send_report!

--- a/app/models/feedback_reporters/feedback_reporter.rb
+++ b/app/models/feedback_reporters/feedback_reporter.rb
@@ -20,6 +20,10 @@ class FeedbackReporter
     strip_html_breaks_simple(@title)
   end
 
+  def description
+    double_html_paragraphs(@description)
+  end
+
   def send_report!
     HTTParty.post("#{ArchiveConfig.NEW_BUGS_SITE}#{project_path}",
                   body: "&xml=#{xml.to_str}")

--- a/lib/html_cleaner.rb
+++ b/lib/html_cleaner.rb
@@ -398,8 +398,8 @@ module HtmlCleaner
           strip
   end
 
-  def double_html_paragraphs(value)
+  def add_break_between_paragraphs(value)
     return "" if value.blank?
-    value.gsub(/\s*<\/p>\s*<p>s*/, "</p><p>&nbsp;</p><p>")
+    value.gsub(/\s*<\/p>\s*<p>s*/, "</p><br /><p>")
   end
 end

--- a/lib/html_cleaner.rb
+++ b/lib/html_cleaner.rb
@@ -398,4 +398,8 @@ module HtmlCleaner
           strip
   end
 
+  def double_html_paragraphs(value)
+    return "" if value.blank?
+    value.gsub(/\s*<\/p>\s*<p>s*/, "</p><p>&nbsp;</p><p>")
+  end
 end

--- a/spec/miscellaneous/lib/html_cleaner_spec.rb
+++ b/spec/miscellaneous/lib/html_cleaner_spec.rb
@@ -921,4 +921,12 @@ describe HtmlCleaner do
     end
 
   end
+
+  describe "double_html_paragraphs" do
+    it "adds new paragraphs with nonbreakable spaces between paragraphs" do
+      original = "<p>Hi!</p><p>I need more space.</p>"
+      result = "<p>Hi!</p><p>&nbsp;</p><p>I need more space.</p>"
+      expect(double_html_paragraphs(original)).to eq(result)
+    end
+  end
 end

--- a/spec/miscellaneous/lib/html_cleaner_spec.rb
+++ b/spec/miscellaneous/lib/html_cleaner_spec.rb
@@ -922,11 +922,11 @@ describe HtmlCleaner do
 
   end
 
-  describe "double_html_paragraphs" do
-    it "adds new paragraphs with nonbreakable spaces between paragraphs" do
+  describe "add_break_between_paragraphs" do
+    it "adds <br /> between paragraphs" do
       original = "<p>Hi!</p><p>I need more space.</p>"
-      result = "<p>Hi!</p><p>&nbsp;</p><p>I need more space.</p>"
-      expect(double_html_paragraphs(original)).to eq(result)
+      result = "<p>Hi!</p><br /><p>I need more space.</p>"
+      expect(add_break_between_paragraphs(original)).to eq(result)
     end
   end
 end


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-4842

## Purpose

Adds a `<br />` between the paragraphs in Support and PAC tickets because the ticket tracker's paragraph styling doesn't have margins, so the paragraphs looked more like:

Paragraph 1
Paragraph 2

than like

Paragraph 1

Paragraph 2

even though they were correctly HTMLified as `<p>Paragraph 1</p><p>Paragraph 2</p>`

They are now rather horrifically done as  `<p>Paragraph 1</p><br /><p>Paragraph 2</p>` because a single empty `<p></p>` did not have sufficient line height to resemble a blank line, and `&nbsp;` or `&#160;` caused the tickets not to make it to the tracker, while an actual typed out space would get stripped and go right back to the line height not resembling a blank line.

## Testing

Refer to Jira