### PR TITLE
AO3-5472 Fix VoiceOver outline position in iOS 10.3.1

### DIFF
--- a/public/stylesheets/site/2.0/18-zone-searchbrowse.css
+++ b/public/stylesheets/site/2.0/18-zone-searchbrowse.css
@@ -171,6 +171,7 @@ form.filters {
   padding: 0;
   position: absolute;
   width: 1px;
+  left: auto; /* fix for VoiceOver outline position in iOS 10.3.1 */
 }
 
 /* AO3-5370: Style changes to fix a bug unique to Safari 9. Hack courtesy of


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5472

## Purpose

When using VoiceOver on iOS 10.3.1 (but not 10.3.3 or 11.4), the outline that indicates the selected item overlapped the right side of the filter. This fixes that.

## Testing

Use VoiceOver on iOS 10.3.1 with the filters. Make sure to tap on the box, not the label text.
