### PR TITLE
AO3-5465 Task for reindexing mistaken crossovers from AO3-5461.

### DIFF
--- a/lib/tasks/after_tasks.rake
+++ b/lib/tasks/after_tasks.rake
@@ -581,6 +581,28 @@ namespace :After do
       end
     end
   end
+
+  desc "Fix crossover status for fandoms with two first-class meta-tags."
+  task(crossover_reindex_two_first_class_meta_tags: :environment) do
+    # Find all fandoms with two first-class meta tags:
+    Fandom.joins(:meta_taggings).
+           joins("LEFT JOIN meta_taggings as first_class_check " \
+                 "ON first_class_check.sub_tag_id = meta_taggings.meta_tag_id").
+           where(first_class_check: { id: nil }).
+           group("tags.id").
+           having("COUNT(meta_taggings.id) > 1").
+           find_each do |fandom|
+      print "Reindexing all filtered works for #{fandom.name}" and STDOUT.flush
+      # For each fandom, reindex all of its filtered works:
+      fandom.filter_taggings.
+             where(filterable_type: "Work").
+             find_in_batches do |batch|
+        print "." and STDOUT.flush
+        AsyncIndexer.index(WorkIndexer, batch.map(&:filterable_id), :background)
+      end
+      print "\n" and STDOUT.flush
+    end
+  end
 end # this is the end that you have to put new tasks above
 
 ##################

--- a/lib/tasks/after_tasks.rake
+++ b/lib/tasks/after_tasks.rake
@@ -586,21 +586,21 @@ namespace :After do
   task(crossover_reindex_two_first_class_meta_tags: :environment) do
     # Find all fandoms with two first-class meta tags:
     Fandom.joins(:meta_taggings).
-           joins("LEFT JOIN meta_taggings as first_class_check " \
-                 "ON first_class_check.sub_tag_id = meta_taggings.meta_tag_id").
-           where(first_class_check: { id: nil }).
-           group("tags.id").
-           having("COUNT(meta_taggings.id) > 1").
-           find_each do |fandom|
-      print "Reindexing all filtered works for #{fandom.name}" and STDOUT.flush
+      joins("LEFT JOIN meta_taggings as first_class_check " \
+            "ON first_class_check.sub_tag_id = meta_taggings.meta_tag_id").
+      where(first_class_check: { id: nil }).
+      group("tags.id").
+      having("COUNT(meta_taggings.id) > 1").
+      find_each do |fandom|
+      print("Reindexing all filtered works for #{fandom.name}") && STDOUT.flush
       # For each fandom, reindex all of its filtered works:
       fandom.filter_taggings.
-             where(filterable_type: "Work").
-             find_in_batches do |batch|
-        print "." and STDOUT.flush
+        where(filterable_type: "Work").
+        find_in_batches do |batch|
+        print(".") && STDOUT.flush
         AsyncIndexer.index(WorkIndexer, batch.map(&:filterable_id), :background)
       end
-      print "\n" and STDOUT.flush
+      print("\n") && STDOUT.flush
     end
   end
 end # this is the end that you have to put new tasks above


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5465

## Purpose

Thanks to AO3-5461, some works in fandoms with multiple first-class metatags are incorrectly classified as crossovers. This adds a task that reindexes all filtered works in those fandoms, so that their crossover field will be recalculated.

## Testing

The bug report contains steps for testing.