### PR TITLE
AO3-5484 Handle missing inherited meta tags when computing first-class meta tags for crossover check.

### DIFF
--- a/spec/models/work_spec.rb
+++ b/spec/models/work_spec.rb
@@ -177,6 +177,20 @@ describe Work do
       expect(work.crossover).to be_truthy
     end
 
+    it "is a crossover when missing meta-taggings" do
+      f1 = create(:canonical_fandom)
+      f2 = create(:canonical_fandom)
+      f3 = create(:canonical_fandom)
+      unrelated = create(:canonical_fandom)
+
+      f2.update_attribute(:meta_tag_string, f3.name)
+      f2.update_attribute(:sub_tag_string, f1.name)
+      f1.meta_tags.delete(f3)
+
+      work = create(:work, fandom_string: "#{f1.name}, #{unrelated.name}")
+      expect(work.crossover).to be_truthy
+    end
+
     context "when one tagged fandom has two unrelated meta tags" do
       let(:meta1) { create(:canonical_fandom) }
       let(:meta2) { create(:canonical_fandom) }


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5484

## Purpose

The updated crossover check from #3363 currently relies on the correctness of the meta-taggings table to return the correct results. Unfortunately, the meta-taggings table in production is missing some inherited meta-taggings, so this will return incorrect results for some works.

This PR modifies the crossover check to perform BFS when computing the list of all meta tags.

## Testing

See bug report.