### PR TITLE
AO3-5474 Remove admin setting for disabling guest downloads

### DIFF
--- a/app/controllers/admin/settings_controller.rb
+++ b/app/controllers/admin/settings_controller.rb
@@ -24,7 +24,7 @@ class Admin::SettingsController < ApplicationController
       :account_creation_enabled, :invite_from_queue_enabled, :invite_from_queue_number,
       :invite_from_queue_frequency, :days_to_purge_unactivated, :last_updated_by,
       :invite_from_queue_at, :suspend_filter_counts, :suspend_filter_counts_at,
-      :enable_test_caching, :cache_expiration, :tag_wrangling_off, :guest_downloading_off,
+      :enable_test_caching, :cache_expiration, :tag_wrangling_off,
       :disable_filtering, :request_invite_enabled, :creation_requires_invite,
       :downloads_enabled, :hide_spam
     )

--- a/app/controllers/downloads_controller.rb
+++ b/app/controllers/downloads_controller.rb
@@ -3,7 +3,6 @@ class DownloadsController < ApplicationController
   include XhtmlSplitter
 
   skip_before_action :store_location, only: :show
-  before_action :guest_downloading_off, only: :show
   before_action :check_visibility, only: :show
 
   # named route: download_path
@@ -215,12 +214,4 @@ protected
     xhtml = doc.children.to_xhtml
     File.open("#{@work.download_dir}/epub/OEBPS/#{filename}.xhtml", 'w') { |f| f.write(xhtml) }
   end
-
-  def guest_downloading_off
-    if !logged_in? && @admin_settings.guest_downloading_off?
-      redirect_to login_path(high_load: true)
-    end
-  end
-
 end
-

--- a/app/models/admin_setting.rb
+++ b/app/models/admin_setting.rb
@@ -25,7 +25,6 @@ class AdminSetting < ApplicationRecord
     enable_test_caching?: false,
     cache_expiration: 10,
     tag_wrangling_off?: false,
-    guest_downloading_off?: false,
     downloads_enabled?: true,
     stats_updated_at: nil
   }.freeze

--- a/app/views/admin/settings/index.html.erb
+++ b/app/views/admin/settings/index.html.erb
@@ -9,51 +9,48 @@
     <legend><%= ts("Accounts and Invitations") %></legend>
     <h3 class="landmark heading"><%= ts("Accounts and Invitations") %></h3>
     <dl>
-  
+
       <dt><%= f.check_box :account_creation_enabled %></dt>
       <dd><%= f.label :account_creation_enabled, ts("Account creation enabled") %></dd>
       <dt><%= f.check_box :creation_requires_invite %></dt>
       <dd><%= f.label :creation_requires_invite, ts("Account creation requires invitation") %></dd>
       <dt><%= f.check_box :request_invite_enabled %></dt>
       <dd><%= f.label :request_invite_enabled, ts("Users can request invitations") %></dd>
-    
+
       <dt><%= f.check_box :invite_from_queue_enabled %></dt>
       <dd><%= f.label :invite_from_queue_enabled, ts("Invite from queue enabled (People can add themselves to the queue and invitations are sent out automatically)") %></dd>
 
       <dt><%= f.label :invite_from_queue_number, ts("Number of people to invite from the queue at once") %></dt>
       <dd><%= f.text_field :invite_from_queue_number, :size => "3" %></dd>
-    
+
       <dt><%= f.label :invite_from_queue_frequency, ts("How often (in days) should we invite people from the queue") %></dt>
       <dd><%= f.text_field :invite_from_queue_frequency, :size => "3" %></dd>
-    
+
       <dt><%= f.label :days_to_purge_unactivated, ts("How many weeks you have to activate your account before we purge it") %></dt>
       <dd><%= f.text_field :days_to_purge_unactivated, :size => "3" %></dd>
     </dl>
   </fieldset>
-  
+
   <fieldset>
     <legend><%= ts("Performance and Misc") %></legend>
     <h3 class="landmark heading"><%= ts("Performance and Misc") %></h3>
     <dl>
-        
+
       <dt><%= f.check_box :disable_filtering %></dt>
       <dd><%= f.label :disable_filtering, ts("Turn off filtering on index pages") %></dd>
-    
+
       <dt><%= f.check_box :suspend_filter_counts %></dt>
       <dd><%= f.label :suspend_filter_counts, ts("Suspend some filter tracking due to high posting volume") %></dd>
-    
+
       <dt><%= f.check_box :tag_wrangling_off %></dt>
       <dd><%= f.label :tag_wrangling_off, ts("Turn off tag wrangling for non-admins") %></dd>
-    
-      <dt><%= f.check_box :guest_downloading_off %></dt>
-      <dd><%= f.label :guest_downloading_off, ts("Turn off downloading for guests") %></dd>
 
       <dt><%= f.check_box :downloads_enabled %></dt>
       <dd><%= f.label :downloads_enabled, ts("Allow downloads") %></dd>
-    
+
       <dt><%= f.check_box :enable_test_caching %></dt>
       <dd><%= f.label :enable_test_caching, ts("Turn on caching (currently experimental)") %></dd>
-    
+
       <dt><%= f.label :cache_expiration, ts("How often (in minutes) should we refresh caching") %></dt>
       <dd><%= f.text_field :cache_expiration, :size => "3" %></dd>
 
@@ -61,11 +58,11 @@
       <dd><%= f.label :hide_spam, ts("Automatically hide spam works") %></dd>
     </dl>
   </fieldset>
-  
+
   <fieldset>
     <legend><%= ts("Actions") %></legend>
     <h3 class="landmark heading"><%= ts("Actions") %></h3>
-    
+
     <%= f.hidden_field :last_updated_by, :value => current_admin.id %>
     <p class="submit actions"><%= f.submit ts('Update') %></p>
   </fieldset>

--- a/app/views/user_sessions/new.html.erb
+++ b/app/views/user_sessions/new.html.erb
@@ -7,15 +7,6 @@
       <%= link_to ts("Or join us for free - it's easy."), new_user_path %>
     <% end %>
   </p>
-<% elsif params[:high_load] %>
-  <h3 class="heading"><%= ts('We are very sorry.') %></h3>
-  <p>
-    <%= ts('Due to current high load, downloads are currently available to registered users of the Archive only.') %>
-    <%= ts('If you already have an Archive of Our Own account, log in now.') %>
-    <% if @admin_settings.account_creation_enabled? %>
-      <%= link_to ts("Or join us for free - it's easy."), new_user_path %>
-    <% end %>
-  </p>
 <% elsif params[:restricted_commenting] %>
   <h3 class="heading"><%= ts('Sorry!') %></h3>
   <p>

--- a/db/migrate/20180712000145_remove_guest_downloading_off_from_admin_settings.rb
+++ b/db/migrate/20180712000145_remove_guest_downloading_off_from_admin_settings.rb
@@ -1,0 +1,5 @@
+class RemoveGuestDownloadingOffFromAdminSettings < ActiveRecord::Migration[5.1]
+  def change
+    remove_column :admin_settings, :guest_downloading_off, :boolean
+  end
+end

--- a/features/admins/admin_settings.feature
+++ b/features/admins/admin_settings.feature
@@ -2,29 +2,7 @@
 Feature: Admin Settings Page
   In order to improve performance
   As an admin
-  I want to be able to control guest downloading and tag wrangling.
-
-  Scenario: Settings page shows options for guest downloading and tag wrangling
-    Given I am logged in as an admin
-    When I go to the admin-settings page
-    Then I should see "Turn off downloading for guests"
-      And I should see "Turn off tag wrangling for non-admins"
-
-  Scenario: Update tag wrangling and guest downloading
-    Given I am logged in as an admin
-    When I go to the admin-settings page
-      And I check "Turn off downloading for guests"
-      And I check "Turn off tag wrangling for non-admins"
-      And I press "Update"
-    Then I should see "Archive settings were successfully updated."
-
-  Scenario: Turn off guest downloading
-    Given guest downloading is off
-      And I have a work "Storytime"
-    When I log out
-      And I view the work "Storytime"
-      And I follow "MOBI"
-    Then I should see "Due to current high load"
+  I want to be able to control downloading and tag wrangling.
 
   Scenario: Turn off downloads
     Given downloads are off
@@ -41,7 +19,7 @@ Feature: Admin Settings Page
       And the following activated tag wrangler exists
         | login           |
         | dizmo           |
-      And a character exists with name: "Ianto Jones", canonical: true    
+      And a canonical character "Ianto Jones"
     When I am logged in as "dizmo"
       And I edit the tag "Ianto Jones"
     Then I should see "Wrangling is disabled at the moment. Please check back later."

--- a/features/step_definitions/admin_steps.rb
+++ b/features/step_definitions/admin_steps.rb
@@ -70,20 +70,6 @@ Given /^advanced languages$/ do
   Language.find_or_create_by(short: "FR", name: "Francais")
 end
 
-Given /^guest downloading is off$/ do
-  step("I am logged in as an admin")
-  visit(admin_settings_path)
-  check("Turn off downloading for guests")
-  click_button("Update")
-end
-
-Given /^guest downloading is on$/ do
-  step("I am logged in as an admin")
-  visit(admin_settings_path)
-  uncheck("Turn off downloading for guests")
-  click_button("Update")
-end
-
 Given /^downloads are off$/ do
   step("I am logged in as an admin")
   visit(admin_settings_path)
@@ -193,13 +179,6 @@ When /^I fill in "([^"]*)" with "([^"]*)'s" invite code$/  do |field, login|
   user = User.find_by(login: login)
   token = user.invitations.first.token
   fill_in(field, with: token)
-end
-
-When /^I turn off guest downloading$/ do
-  step("I am logged in as an admin")
-  visit(admin_settings_path)
-  step("I check \"Turn off downloading for guests\"")
-  step("I press \"Update\"")
 end
 
 When /^I make an admin post$/ do


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5474

## Purpose

Remove an admin setting we rarely use.

## Testing

See issue.