### PR TITLE
AO3-5287 Install Redis 3.2.1 on Codeship

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,7 +30,7 @@ gem 'transaction_retry'
 gem 'activerecord-mysql-reconnect', '~> 0.4.1'
 
 # Version of redis-rb gem
-# We are currently running Redis 2.6.4 (12/6/2012)
+# We are currently running Redis 3.2.1 (7/2018)
 gem 'redis', ">=3.0"
 gem 'redis-namespace'
 

--- a/script/prepare_codeship.sh
+++ b/script/prepare_codeship.sh
@@ -6,14 +6,22 @@
 #
 #
 export RAILS_ENV=test
+export REDIS_VERSION=3.2.1
 bundle install
 \curl -sSL https://raw.githubusercontent.com/codeship/scripts/master/packages/mysql-5.7.sh | bash -s
+\curl -sSL https://raw.githubusercontent.com/codeship/scripts/master/packages/redis.sh | bash -s
+
+# When this script is run a second time, redis.sh will fail (ln does not overwrite existing symlinks)
+# and not start the default Redis instance, so we need to make sure it's started.
+redis-server $HOME/redis/redis.conf
+redis-server config/codeship/redis1.conf
+redis-server config/codeship/redis2.conf
+
 cp config/database.codeship.yml config/database.yml
 cp config/newrelic.example config/newrelic.yml
 cp config/redis-cucumber.conf.example config/redis-cucumber.conf
 cp config/redis.codeship.example config/redis.yml
-/usr/bin/redis-server config/codeship/redis1.conf
-/usr/bin/redis-server config/codeship/redis2.conf
+
 bundle exec rake db:create:all --trace
 mysql -u $MYSQL_USER -p$MYSQL_PASSWORD -e  "ALTER DATABASE test$TEST_ENV_NUMBER CHARACTER SET utf8 COLLATE utf8_general_ci;"
 bundle exec rake db:schema:load --trace


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5287

## Purpose

FilterCount uses SPOP which requires 3.2. This is also to match the production Redis version.

## Testing

Travis and Codeship should both pass.

## References

See instructions on [installing a specific version of Redis on Codeship](https://documentation.codeship.com/basic/queues/redis/).

Note that Codeship's script installs new Redis into `${HOME}/bin`, so we have to run Redis with `redis-server`. `/usr/bin/redis-server` still points to the older default version (2.8.4).