### PR TITLE
AO3-3880: Switch to Calibre

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@ language: ruby
 dist: trusty
 cache: bundler
 sudo: required
+before_install:
+  - sudo apt-get update -qq
+  - sudo apt-get install -qq calibre openssl build-essential xorg libssl-dev wkhtmltopdf
 env:
   - TEST_GROUP="./script/check_syntax"
   - TEST_GROUP="rspec spec/controllers"

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,6 +3,11 @@ PROFILER_SESSIONS_FILE = 'used_tags.txt'
 class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception, prepend: true
   rescue_from ActionController::InvalidAuthenticityToken, with: :display_auth_error
+  rescue_from ActionController::UnknownFormat, with: :raise_not_found
+
+  def raise_not_found
+    redirect_to '/404'
+  end
 
   helper :all # include all helpers, all the time
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -120,6 +120,8 @@ class ApplicationController < ActionController::Base
   alias :setflash :set_flash_cookie
 
   def current_user
+    # Don't try to assign a current user when generating downloads
+    return if Authlogic::Session::Base.controller.nil?
     @current_user ||= current_user_session && current_user_session.record
   end
 

--- a/app/controllers/downloads_controller.rb
+++ b/app/controllers/downloads_controller.rb
@@ -3,6 +3,7 @@ class DownloadsController < ApplicationController
   skip_before_action :store_location, only: :show
   before_action :load_work, only: :show
   before_action :check_visibility, only: :show
+  after_action :remove_downloads, only: :show
 
   def show
     respond_to :html, :pdf, :mobi, :epub
@@ -40,5 +41,11 @@ protected
 
     # set this for checking visibility
     @check_visibility_of = @work
+  end
+
+  # We're currently just writing everything to tmp and feeding them through nginx
+  # so we don't want to keep the files around
+  def remove_downloads
+    @download.remove
   end
 end

--- a/app/controllers/downloads_controller.rb
+++ b/app/controllers/downloads_controller.rb
@@ -6,7 +6,7 @@ class DownloadsController < ApplicationController
 
   def show
     respond_to :html, :pdf, :mobi, :epub
-    @download = Download.generate(@work, request.format)
+    @download = Download.generate(@work, mime_type: request.format)
 
     # Make sure we were able to generate the download
     unless @download.present? && @download.exists?
@@ -17,7 +17,7 @@ class DownloadsController < ApplicationController
 
     # send file synchronously so we don't delete it before we have finished sending it
     File.open(@download.file_path, 'r') do |f|
-      send_data f.read, filename: @download.file_name, type: request.format
+      send_data f.read, filename: "#{@download.file_name}.#{@download.file_type}", type: request.format
     end
   end
 

--- a/app/controllers/downloads_controller.rb
+++ b/app/controllers/downloads_controller.rb
@@ -1,226 +1,44 @@
 class DownloadsController < ApplicationController
 
-  include XhtmlSplitter
-
   skip_before_action :store_location, only: :show
-  before_action :guest_downloading_off, only: :show
+  before_action :load_work, only: :show
   before_action :check_visibility, only: :show
 
-  # named route: download_path
-  # Note: only :id and :format need to be correct,
-  # the other two are derived and are there for nginx's benefit
-  # GET /downloads/:download_prefix/:download_authors/:id/:download_title.:format
   def show
-    @work = Work.find(params[:id])
-    @check_visibility_of = @work
+    respond_to :html, :pdf, :mobi, :epub
+    @download = Download.generate(@work, request.format)
 
-    if @work.unrevealed?
-      flash[:error] = ts("Sorry, you can't download an unrevealed work")
-      redirect_back_or_default works_path
+    # Make sure we were able to generate the download
+    unless @download.present? && @download.exists?
+      flash[:error] = ts('We were not able to render this work. Please try again in a little while or try another format.')
+      redirect_to work_path(@work)
       return
     end
 
-    unless @admin_settings.downloads_enabled?
-      flash[:error] = ts("Sorry, downloads are currently disabled.")
-      redirect_back_or_default works_path
-      return
+    # send file synchronously so we don't delete it before we have finished sending it
+    File.open(@download.file_path, 'r') do |f|
+      send_data f.read, filename: @download.file_name, type: request.format
     end
-
-    FileUtils.mkdir_p @work.download_dir
-    @chapters = @work.chapters.order('position ASC').where(posted: true)
-
-    respond_to do |format|
-      format.html do
-        download_html
-        return
-      end
-      format.pdf { download_pdf }
-      # mobipocket for kindle
-      format.mobi { download_mobi }
-      # epub for ibooks
-      format.epub { download_epub }
-    end
-    @work.remove_outdated_downloads
   end
 
 protected
 
-  def download_html
-    data = create_work_html_string
-    # send as HTML
-    send_data data, filename: "#{@work.download_title}.html", type: "text/html"
-  end
+  # Set up the work and check revealed status
+  # once a format has been created, we want nginx to be able to serve
+  # it directly, without going through rails again (until the work changes).
+  # This means no processing per user. consider this the "published" version
+  # It can't contain unposted chapters, nor unrevealed authors, even
+  # if the author is the one requesting the download
+  def load_work
+    @work = Work.find(params[:id])
 
-  def send_file_sync(file_type, mime_type)
-    # send file synchronously so we don't delete it before we have finsihed sending it.
-    File.open("#{@work.download_basename}.#{file_type}", 'r') do |f|
-      send_data f.read, filename: "#{@work.download_title}.#{file_type}", type: mime_type
-    end
-  end
-
-  def download_pdf
-    create_work_html
-
-    # convert to PDF
-    # title needs to be escaped
-    title = Shellwords.escape(@work.title)
-    cmd = %Q{cd "#{@work.download_dir}"; wkhtmltopdf --encoding utf-8 --disable-javascript --title #{title} "#{@work.download_title}.html" "#{@work.download_title}.pdf"}
-    Rails.logger.debug cmd
-    `#{cmd} 2> /dev/null`
-
-    # send as PDF, if file exists, or flash error and redirect
-    unless check_for_file("pdf")
-      flash[:error] = ts('We were not able to render this work. Please try another format')
-      redirect_back_or_default work_path(@work) and return
-    end
-    send_file_sync("pdf", "application/pdf")
-  end
-
-  def download_mobi
-    cmd_pre = %Q{cd "#{@work.download_dir}"; html2mobi }
-    # metadata needs to be escaped for command line
-    title = Shellwords.escape(@work.title)
-    author = Shellwords.escape(@work.display_authors)
-    cmd_post = %Q{ --mobifile "#{@work.download_title}.mobi" --title #{title} --author #{author} }
-
-    # more than one chapter
-    # create a table of contents out of separate chapter files
-    mobi_files = create_mobi_html
-    cmd = cmd_pre + mobi_files + cmd_post
-    if @chapters.length > 1
-      cmd << " --gentoc"
-    end
-    Rails.logger.debug cmd
-    `#{cmd} 2> /dev/null`
-
-    # send as mobi, if file exists, or flash error and redirect
-    unless check_for_file("mobi")
-      flash[:error] = ts('We were not able to render this work. Please try another format')
-      redirect_back_or_default work_path(@work) and return
-    end
-    send_file_sync("mobi", "application/x-mobipocket-ebook")
-  end
-
-  def download_epub
-    create_epub_files
-
-    # stuff contents of epub directory into a zip file named with
-    # .epub extension
-    #
-    # note: we have to zip this up in this particular order because
-    # "mimetype" must be the first item in the zipfile and mustn't be
-    # compressed
-    cmd = %Q{cd "#{@work.download_dir}/epub"; zip -0 "#{@work.download_basename}.epub" mimetype; zip -r "#{@work.download_basename}.epub" META-INF OEBPS}
-    Rails.logger.debug cmd
-   `#{cmd} 2> /dev/null`
-
-    # send as epub, if file exists, or flash error and redirect
-    unless check_for_file("epub")
-      flash[:error] = ts('We were not able to render this work. Please try another format')
-      redirect_back_or_default work_path(@work) and return
-    end
-    send_file_sync("epub", "application/epub+zip")
-  end
-
-  # redirect and return inside this method would only exit *this* method, not the controller action it was called from
-  def check_for_file(format)
-    File.exist?("#{@work.download_basename}.#{format}")
-  end
-
-  def create_work_html_string
-    @page_title = [@work.download_title, @work.download_authors, @work.download_fandoms].join(" - ")
-    render_to_string(template: "downloads/show.html", layout: 'barebones.html')
-  end
-
-  def create_work_html
-    return if File.exist?("#{@work.download_basename}.html")
-    # write to file
-    File.open("#{@work.download_basename}.html", 'w') { |f| f.write(create_work_html_string) }
-  end
-
-  def create_mobi_html
-    FileUtils.mkdir_p "#{@work.download_dir}/mobi"
-
-    # the preface contains meta tag information, the title/author, work summary and work notes
-    @page_title = ts("Preface")
-    render_mobi_html("_download_preface", "preface")
-
-    # each chapter may have its own byline, notes and endnotes
-    @chapters.each_with_index do |chapter, index|
-      @chapter = chapter
-      @page_title = chapter.chapter_title
-      render_mobi_html("_download_chapter", "chapter#{index + 1}")
+    if @work.in_unrevealed_collection?
+      flash[:error] = ts("Sorry, you can't download an unrevealed work.")
+      redirect_to work_path(@work)
+      return
     end
 
-    # the afterword contains the works end notes, any related works, and a link back to comment
-    @page_title = ts("Afterword")
-    render_mobi_html("_download_afterword", "afterword")
-
-    chapter_file_names = 1.upto(@chapters.size).map { |i| "mobi/chapter#{i}.html" }
-    ["mobi/preface.html", chapter_file_names.join(' '), "mobi/afterword.html"].join(' ')
+    # set this for checking visibility
+    @check_visibility_of = @work
   end
-
-  def render_mobi_html(template, basename)
-    @mobi = true
-    html = render_to_string(template: "downloads/#{template}.html", layout: 'barebones.html')
-    html = html.to_ascii
-    File.open("#{@work.download_dir}/mobi/#{basename}.html", 'w') { |f| f.write(html) }
-  end
-
-  def create_epub_files
-    return if File.exist?("#{@work.download_basename}.epub")
-    # Manually building an epub file here
-    # See http://www.jedisaber.com/eBooks/tutorial.asp for details
-    epubdir = "#{@work.download_dir}/epub"
-    FileUtils.mkdir_p epubdir
-
-    # copy mimetype and container files which don't need processing
-    FileUtils.cp("#{Rails.root}/app/views/epub/mimetype", epubdir)
-    FileUtils.mkdir_p "#{epubdir}/META-INF"
-    FileUtils.cp("#{Rails.root}/app/views/epub/container.xml", "#{epubdir}/META-INF")
-
-    # write the OEBPS content files
-    FileUtils.mkdir_p "#{epubdir}/OEBPS"
-    preface = render_to_string(template: "downloads/_download_preface.html", layout: 'barebones.html')
-    render_xhtml(preface, "preface")
-
-    @parts = []
-    @chapters.each_with_index do |chapter, index|
-      @chapter = chapter
-
-      # split chapters into multiple parts if they are too big
-      @parts << split_xhtml(sanitize_field(@chapter, :content))
-      @parts[-1].each_with_index do |part, partindex|
-        @content = part
-        # we only need the chapter meta/endnotes info if it's a
-        # multichaptered work and if we are displaying the first/last
-        # part of a chapter
-        @suppress_chapter_meta = @chapters.size == 1 || partindex > 0
-        @suppress_chapter_endnotes = @chapters.size == 1 || partindex < @parts[-1].size
-        html = render_to_string(template: "downloads/_download_chapter.html", layout: "barebones.html")
-        render_xhtml(html, "chapter#{index + 1}_#{partindex + 1}")
-      end
-    end
-
-    afterword = render_to_string(template: "downloads/_download_afterword.html", layout: 'barebones.html')
-    render_xhtml(afterword, "afterword")
-
-    # write the OEBPS navigation files
-    File.open("#{epubdir}/OEBPS/toc.ncx", 'w') { |f| f.write(render_to_string(file: "#{Rails.root}/app/views/epub/toc.ncx", layout: false)) }
-    File.open("#{epubdir}/OEBPS/content.opf", 'w') { |f| f.write(render_to_string(file: "#{Rails.root}/app/views/epub/content.opf", layout: false)) }
-  end
-
-  def render_xhtml(html, filename)
-    doc = Nokogiri::XML.parse(html)
-    xhtml = doc.children.to_xhtml
-    File.open("#{@work.download_dir}/epub/OEBPS/#{filename}.xhtml", 'w') { |f| f.write(xhtml) }
-  end
-
-  def guest_downloading_off
-    if !logged_in? && @admin_settings.guest_downloading_off?
-      redirect_to login_path(high_load: true)
-    end
-  end
-
 end
-

--- a/app/helpers/works_helper.rb
+++ b/app/helpers/works_helper.rb
@@ -134,8 +134,8 @@ module WorksHelper
   end
 
   def download_url_for_work(work, format)
-    base = Rails.cache.fetch("download_base_#{work.id}", race_condition_ttl: 10, expires_in: 1.day) { "/#{work.download_folder}/#{work.download_title}." }
-    url_for ("#{base}#{format}?updated_at=#{work.updated_at.to_i}").gsub(' ', '%20')
+    path = Download.new(work, format: format).public_path
+    url_for("#{path}?updated_at=#{work.updated_at.to_i}").gsub(' ', '%20')
   end
 
   # Generates a list of a work's tags and details for use in feeds

--- a/app/models/download.rb
+++ b/app/models/download.rb
@@ -1,0 +1,93 @@
+class Download
+
+  def self.generate(work, mime_type)
+    new(work, mime_type).generate
+  end
+
+  def self.remove(work)
+    new(work, "text/html").remove
+  end
+
+  attr_reader :work
+
+  def initialize(work, mime_type)
+    @work = work
+    @mime_type = mime_type
+  end
+
+  def generate
+    DownloadWriter.new(self).write
+  end
+
+  def exists?
+    File.exists?(file_path)
+  end
+
+  def remove
+    FileUtils.rm_rf(dir)
+  end
+
+  def file_type
+    ext = MimeMagic.new(@mime_type.to_s).subtype
+    ext == "x-mobipocket-ebook" ? "mobi" : ext
+  end
+
+  def file_name
+    clean(work.title) || "Work #{work.id}"
+  end
+
+  def file_path
+    "#{dir}/#{file_name}"
+  end
+
+  def dir
+    "/tmp/#{work.id}"
+  end
+
+  def fandoms
+    string = work.fandoms.size > 3 ? ts("Multifandom") : work.fandoms.string
+    clean(string)
+  end
+
+  def authors
+    author_names.join(', ').to_ascii
+  end
+
+  def author_names
+    work.anonymous? ? [ts("Anonymous")] : work.pseuds.sort.map(&:name)
+  end
+
+  # need the next two to be filesystem safe and not overly long
+  def file_authors
+    clean(author_names.join('-'))
+  end
+
+  def page_title
+    [file_name, file_authors, fandoms].join(" - ")
+  end
+  
+  def chapters
+    work.chapters.order('position ASC').where(:posted => true)
+  end
+
+
+  private
+
+  # make filesystem-safe
+  # ascii encoding
+  # squash spaces
+  # strip all alphanumeric
+  # truncate to 24 chars at a word boundary
+  def clean(string)
+    # get rid of any HTML entities to avoid things like "amp" showing up in titles
+    string = string.gsub(/\&(\w+)\;/, '')
+    string = ActiveSupport::Inflector.transliterate(string)
+    string = string.encode("us-ascii", "utf-8")
+    string = string.gsub(/[^[\w _-]]+/, '')
+    string = string.gsub(/ +/, " ")
+    string = string.strip
+    string = string.truncate(24, separator: ' ', omission: '')
+    string
+  end
+
+end

--- a/app/models/download.rb
+++ b/app/models/download.rb
@@ -1,22 +1,23 @@
 class Download
 
-  def self.generate(work, mime_type)
-    new(work, mime_type).generate
+  def self.generate(work, options = {})
+    new(work, options).generate
   end
 
   def self.remove(work)
-    new(work, "text/html").remove
+    new(work).remove
   end
 
-  attr_reader :work
+  attr_reader :work, :file_type
 
-  def initialize(work, mime_type)
+  def initialize(work, options = {})
     @work = work
-    @mime_type = mime_type
+    @file_type = set_file_type(options.slice(:mime_type, :format))
   end
 
   def generate
     DownloadWriter.new(self).write
+    self
   end
 
   def exists?
@@ -27,17 +28,30 @@ class Download
     FileUtils.rm_rf(dir)
   end
 
-  def file_type
-    ext = MimeMagic.new(@mime_type.to_s).subtype
-    ext == "x-mobipocket-ebook" ? "mobi" : ext
+  # Given either a file extension or a mime type, figure out
+  # what format we're generating
+  # Defaults to html
+  def set_file_type(options)
+    if options[:mime_type]
+      ext = MimeMagic.new(options[:mime_type].to_s).subtype
+      ext == "x-mobipocket-ebook" ? "mobi" : ext
+    elsif %w(html pdf mobi epub).include?(options[:format].to_s)
+      options[:format].to_s
+    else
+      "html"
+    end
   end
 
   def file_name
     clean(work.title) || "Work #{work.id}"
   end
 
+  def public_path
+    "/downloads/#{work.id}/#{file_name}.#{file_type}"
+  end
+
   def file_path
-    "#{dir}/#{file_name}"
+    "#{dir}/#{file_name}.#{file_type}"
   end
 
   def dir

--- a/app/models/download.rb
+++ b/app/models/download.rb
@@ -8,11 +8,12 @@ class Download
     new(work).remove
   end
 
-  attr_reader :work, :file_type
+  attr_reader :work, :file_type, :mime_type
 
   def initialize(work, options = {})
     @work = work
     @file_type = set_file_type(options.slice(:mime_type, :format))
+    @mime_type = MIME::Types.type_for(@file_type).first
   end
 
   def generate
@@ -35,7 +36,7 @@ class Download
     if options[:mime_type]
       ext = MimeMagic.new(options[:mime_type].to_s).subtype
       ext == "x-mobipocket-ebook" ? "mobi" : ext
-    elsif %w(html pdf mobi epub).include?(options[:format].to_s)
+    elsif ArchiveConfig.DOWNLOAD_FORMATS.include?(options[:format].to_s)
       options[:format].to_s
     else
       "html"
@@ -43,7 +44,9 @@ class Download
   end
 
   def file_name
-    clean(work.title) || "Work #{work.id}"
+    name = clean(work.title)
+    name = "Work #{work.id}" if name.length < 3
+    name
   end
 
   def public_path

--- a/app/models/download_writer.rb
+++ b/app/models/download_writer.rb
@@ -1,0 +1,138 @@
+require 'open3'
+
+class DownloadWriter
+
+  include Rails.application.routes.url_helpers
+  include ApplicationHelper
+  include TagsHelper
+
+  attr_reader :download, :work, :html_download
+
+  def initialize(download)
+    @download = download
+    @work = download.work
+    @html_download = Download.new(work, "text/html")
+  end
+
+  def write
+    # Create the directory
+    FileUtils.mkdir_p download.dir
+    generate_html_download
+    generate_ebook_download unless download.file_type == "html"
+    return download.file_name
+  end
+
+  private
+
+  # Write the HTML version
+  def generate_html_download
+    return if html_download.exists?
+    # sneaking around MVC division, but the rendering of downloads belongs in a module IMO and not
+    # in the controller
+    # set this to handle host lookups
+    Otwarchive::Application.routes.default_url_options = { host: ArchiveConfig.APP_HOST }
+    @html = download_view.render(
+      template: "/downloads/show",
+      formats: [:html],
+      layout: '/layouts/barebones.html',
+      locals: {
+        :@work => work,
+        :@page_title => download.page_title,
+        :@chapters => download.chapters
+      }
+    )
+    # reset back so tests don't get confused
+    Otwarchive::Application.routes.default_url_options = {}    
+        
+    # write to file
+    File.open(html_download.file_path, 'w:UTF-8') { |f| f.write(@html) }
+  end
+
+  # transform HTML version into ebook version
+  def generate_ebook_download
+    return unless %w(mobi epub pdf).include?(download.file_type)
+    return if download.exists?
+
+    cmd = get_command
+
+    # Make sure the command is sanitary, and use popen3 in order to
+    # capture and discard the stdin/out info
+    # See http://stackoverflow.com/a/5970819/469544 for details
+    exit_status = nil
+    Open3.popen3(*cmd) { |stdin, stdout, stderr, wait_thread| exit_status = wait_thread.value }
+    unless exit_status
+      Rails.logger.debug "Download generation failed: " + cmd.to_s
+    end
+  end
+
+  # Get the version of the command we need to execute
+  def get_command
+    download.file_type == "pdf" ? get_pdf_command : get_calibre_command
+  end
+
+  # We're sticking with wkhtmltopdf for PDF files since using calibre for PDF requires the use of xvfb
+  def get_pdf_command
+    [
+      'wkhtmltopdf',
+      '--encoding', 'utf-8', 
+      '--title', work.title,
+      "#{download.file_name}.html", "#{download.file_name}.pdf"
+    ]
+  end
+
+  # Create the format-specific command-line call to calibre/ebook-convert
+  def get_calibre_command
+    # Add info about first series if any
+    series = []
+    if meta[:series_title].present?
+      series = ['--series', meta[:series_title], '--series-index', meta[:series_position]]
+    end
+
+    ### Format-specific options
+    # Mobi: ignore margins to keep it from padding on the left
+    mobi = download.file_type == "mobi" ? ['--mobi-ignore-margins'] : []
+
+    ### 
+    ebook_convert_command = [
+      'ebook-convert',
+      "#{download.file_name}.html",
+      "#{download.file_name}.#{download.file_type}",
+      '--input-encoding', 'utf-8',
+      '--use-auto-toc',
+      '--title', meta[:title],
+      '--authors', meta[:authors],
+      '--comments', meta[:summary],
+      '--tags', meta[:tags],
+      '--pubdate', meta[:pubdate]
+    ] + series + mobi
+  end
+
+  # Set up a Rails view so we can render standard view files
+  def download_view
+    @view = ActionView::Base.new(ActionController::Base.view_paths, {})
+    @view.class_eval do
+      def current_user; nil; end
+    end
+    @view
+  end
+
+  # A hash of the work data calibre needs
+  def meta
+    return @metadata if @metadata
+    @metadata = {
+      title:    work.title,
+      authors:  work.pseuds.pluck(:name).join("&"),
+      tags:     work.tags.pluck(:name).join(","),
+      pubdate:  work.revised_at.to_date.to_s,
+      summary:  work.summary
+    }
+    if work.series.exist?
+      series = work.series.first
+      @metadata.merge(
+        series_title: series.title,
+        series_position: series.position_of(work).to_s
+      )
+    end
+    @metadata
+  end
+end

--- a/app/models/download_writer.rb
+++ b/app/models/download_writer.rb
@@ -67,8 +67,9 @@ class DownloadWriter
   def get_pdf_command
     [
       'wkhtmltopdf',
-      '--encoding', 'utf-8', 
-      '--title', work.title,
+      '--encoding', 'utf-8',
+      '--disable-javascript',
+      '--title', download.file_name,
       html_download.file_path, download.file_path
     ]
   end

--- a/app/models/download_writer.rb
+++ b/app/models/download_writer.rb
@@ -69,7 +69,7 @@ class DownloadWriter
       'wkhtmltopdf',
       '--encoding', 'utf-8', 
       '--title', work.title,
-      "#{download.file_name}.html", "#{download.file_name}.pdf"
+      html_download.file_path, download.file_path
     ]
   end
 

--- a/app/models/series.rb
+++ b/app/models/series.rb
@@ -147,6 +147,11 @@ class Series < ApplicationRecord
     SortableList.new(self.serial_works.in_order).reorder_list(positions)
   end
 
+  def position_of(work)
+    serial_works.where(work_id: work.id).pluck(:position).first
+  end
+
+
   # return list of pseuds on this series
   def allpseuds
     works.collect(&:pseuds).flatten.compact.uniq.sort

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -855,46 +855,7 @@ class Work < ApplicationRecord
 
   after_update :remove_outdated_downloads
   def remove_outdated_downloads
-    FileUtils.rm_rf(self.download_dir)
-  end
-
-  # spread downloads out by first two letters of authorname
-  def download_dir
-    "/tmp/#{self.id}"
-  end
-
-  # split out so we can use this in works_helper
-  def download_folder
-    dl_authors = self.download_authors
-    "downloads/#{dl_authors[0..1]}/#{dl_authors}/#{self.id}"
-  end
-
-  def download_fandoms
-    string = self.fandoms.size > 3 ? ts("Multifandom") : self.fandoms.string
-    string = string.to_ascii
-    string.gsub(/[^[\w _-]]+/, '')
-  end
-
-  def display_authors
-    string = self.anonymous? ? ts("Anonymous") : self.pseuds.sort.map(&:name).join(', ')
-    string.to_ascii
-  end
-
-  # need the next two to be filesystem safe and not overly long
-  def download_authors
-    string = self.anonymous? ? ts("Anonymous") : self.pseuds.sort.map(&:name).join('-')
-    string = string.to_ascii.gsub(/[^[\w _-]]+/, '')
-    string.gsub(/^(.{24}[\w.]*).*/) {$1}
-  end
-
-  def download_title
-    string = title.to_ascii.gsub(/[^[\w _]]+/, '')
-    string = "Work by " + download_authors if string.blank?
-    string.gsub(/ +/, " ").strip.gsub(/^(.{24}[\w.]*).*/) {$1}
-  end
-
-  def download_basename
-    "#{self.download_dir}/#{self.download_title}"
+    Download.remove(self)
   end
 
   #######################################################################

--- a/app/views/downloads/_download_chapter.html.erb
+++ b/app/views/downloads/_download_chapter.html.erb
@@ -1,31 +1,29 @@
 <% @chapter = chapter if defined?(chapter) %>
 
-<% unless @suppress_chapter_meta %>
-  <div class="meta group">
-    <% unless @mobi %><h2 class="heading"><%= @chapter.chapter_title.html_safe %></h2><% end %>
-    <% if (!@chapter.pseuds.blank? && (@chapter.pseuds != @work.pseuds) && (!@work.anonymous?)) %>
-      <%# only display byline if different from the main byline %>
-      <p class="byline"><%= ts('Chapter by') %> <%= byline(@chapter, only_path: false) %></p>
-    <% end %>
+<div class="meta group">
+  <h2 class="heading"><%= @chapter.chapter_title.html_safe %></h2>
+  <% if (!@chapter.pseuds.blank? && (@chapter.pseuds != @work.pseuds) && (!@work.anonymous?)) %>
+    <%# only display byline if different from the main byline %>
+    <p class="byline"><%= ts('Chapter by') %> <%= byline(@chapter, only_path: false) %></p>
+  <% end %>
 
-    <% unless @chapter.summary.blank? %>
-      <p><%= ts('Chapter Summary') %></p>
-      <blockquote class="userstuff"><%=raw sanitize_field(@chapter, :summary) %></blockquote>
+  <% unless @chapter.summary.blank? %>
+    <p><%= ts('Chapter Summary') %></p>
+    <blockquote class="userstuff"><%=raw sanitize_field(@chapter, :summary) %></blockquote>
+  <% end %>
+
+  <% unless @chapter.notes.blank? && @chapter.endnotes.blank? %>
+    <p><%= ts('Chapter Notes') %></p>
+    <% unless @chapter.notes.blank? %>
+      <blockquote class="userstuff"><%=raw sanitize_field(@chapter, :notes) %></blockquote>
     <% end %>
-  
-    <% unless @chapter.notes.blank? && @chapter.endnotes.blank? %>
-      <p><%= ts('Chapter Notes') %></p>
-      <% unless @chapter.notes.blank? %>
-        <blockquote class="userstuff"><%=raw sanitize_field(@chapter, :notes) %></blockquote>
-      <% end %>
-      <% unless @chapter.endnotes.blank? %>
-        <div class="endnote-link">
-          <%= ts("See the end of the chapter for") %> <% unless @chapter.notes.blank? %><%= ts("more") %><% end %> <%= link_to ts("notes"), "#endnotes#{@chapter.position}" %>
-        </div>
-      <% end %> 
+    <% unless @chapter.endnotes.blank? %>
+      <div class="endnote-link">
+        <%= ts("See the end of the chapter for") %> <% unless @chapter.notes.blank? %><%= ts("more") %><% end %> <%= link_to ts("notes"), "#endnotes#{@chapter.position}" %>
+      </div>
     <% end %>
-  </div>
-<% end %>
+  <% end %>
+</div>
 
 <!--chapter content-->
 <div class="userstuff">
@@ -33,7 +31,7 @@
 </div>
 <!--/chapter content-->
 
-<% unless @suppress_chapter_endnotes || @chapter.endnotes.blank? %>
+<% unless @chapter.endnotes.blank? %>
   <div class="meta" id="endnotes<%= @chapter.position %>">
     <p><%= ts('Chapter End Notes') %></p>
     <blockquote class="userstuff"><%= raw sanitize_field(@chapter, :endnotes) %></blockquote>

--- a/app/views/downloads/_download_preface.html.erb
+++ b/app/views/downloads/_download_preface.html.erb
@@ -5,8 +5,7 @@
   <dl class="tags">
     <% Tag::VISIBLE.each do |type| %>
       <% tags = @work.tag_groups[type] %>
-      <% unless tags.blank? || (type == "Warning" && hide_warnings?(@work)) || (type == "Freeform" &&
-hide_freeform?(@work)) %>
+      <% unless tags.blank? %>
         <dt><%= type.constantize::NAME %>:</dt>
         <dd><%= tags.map {|t| link_to(t.name, tag_url(t))}.join(", ").html_safe %></dd>
       <% end %>

--- a/app/views/downloads/show.html.erb
+++ b/app/views/downloads/show.html.erb
@@ -1,9 +1,9 @@
-<%= render 'download_preface.html' %>
+<%= render 'downloads/download_preface.html' %>
 
 <div id="chapters" class="userstuff">
   <% if @chapters.size > 1 %>
     <% for chapter in @chapters %>
-      <%= render 'download_chapter.html', :chapter => chapter %>
+      <%= render 'downloads/download_chapter.html', :chapter => chapter %>
     <% end %>
   <% else %>
     <div class="userstuff">
@@ -12,4 +12,4 @@
   <% end %>
 </div>
 
-<%= render 'download_afterword.html' %>
+<%= render 'downloads/download_afterword.html' %>

--- a/app/views/works/_work_header_navigation.html.erb
+++ b/app/views/works/_work_header_navigation.html.erb
@@ -112,10 +112,9 @@
     <li class="download" aria-haspopup="true">
       <a href="#"><%= ts("Download") %></a>
       <ul class="expandable secondary">
-        <li><%= link_to ts("MOBI"), download_url_for_work(@work, "mobi") %></li>
-        <li><%= link_to ts("EPUB"), download_url_for_work(@work, "epub") %></li>
-        <li><%= link_to ts("PDF"), download_url_for_work(@work, "pdf") %></li>
-        <li><%= link_to ts("HTML"), download_url_for_work(@work, "html") %></li>
+        <% ArchiveConfig.DOWNLOAD_FORMATS.each do |format| %>
+          <li><%= link_to ts(format.upcase), download_url_for_work(@work, format) %></li>
+        <% end %>
       </ul>
     </li>
   <% end %>

--- a/config/config.yml
+++ b/config/config.yml
@@ -166,6 +166,8 @@ TAGS_PER_SEARCH_PAGE: 50
 # how many signups in a challenge before we move to static summaries generated hourly
 MAX_SIGNUPS_FOR_LIVE_SUMMARY: 20
 
+DOWNLOAD_FORMATS: ['mobi', 'epub', 'pdf', 'html']
+
 # Tag kinds and default tags
 WARNING_CATEGORY_NAME: 'Archive Warning'
 WARNING_DEFAULT_TAG_NAME: 'Choose Not To Use Archive Warnings'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,7 +19,7 @@ Otwarchive::Application.routes.draw do
 
   #### DOWNLOADS ####
 
-  get 'downloads/:download_prefix/:download_authors/:id/:download_title.:format' => 'downloads#show', as: 'download'
+  get 'downloads/:id/:download_title.:format' => 'downloads#show', as: 'download'
 
   #### OPEN DOORS ####
   namespace :opendoors do

--- a/features/step_definitions/work_download_steps.rb
+++ b/features/step_definitions/work_download_steps.rb
@@ -1,0 +1,62 @@
+Then /^I should receive a file of type "([^"]*)"$/ do |filetype|
+  page.driver.response.headers['Content-Disposition'].should =~ /filename=.+\.#{filetype}/
+  page.response_headers['Content-Type'].should == MIME::Types.type_for("foo.#{filetype}").first
+end
+
+Then /^I should be able to download all versions of "(.*)"$/ do |title|
+  (ArchiveConfig.DOWNLOAD_FORMATS - ['html']).each do |filetype|
+    step %{I should be able to download the #{filetype} version of "#{title}"}
+  end
+end
+
+Then /^I (?:should be able to )?download the (\w+) version of "(.*)"$/ do |filetype, title|
+  work = Work.find_by_title(title)
+  download = Download.new(work, format: filetype)
+  visit work_url(work)
+  step %{I follow "#{filetype.upcase}"}
+  filename = download.file_path # the full path of the download file we expect to exist
+  assert File.exists?(filename), "#{filename} does not exist"
+  page.driver.response.headers['Content-Disposition'].should =~ /filename=\"#{File.basename(filename)}\"/
+  page.response_headers['Content-Type'].should == MIME::Types.type_for(filename).first
+end
+
+Then /^I should not be able to download the (\w+) version of "(.*)"$/ do |filetype, title|
+  work = Work.find_by_title(title)
+  download = Download.new(work, format: filetype)
+  visit work_url(work)
+  step %{I follow "#{filetype.upcase}"}
+  filename = download.file_path # the full path of the download file we expect to exist
+  page.driver.response.headers['Content-Disposition'].should_not =~ /filename=\"#{File.basename(filename)}\"/
+  page.response_headers['Content-Type'].should_not == MIME::Types.type_for(filename).first
+end
+
+Then /^I should not be able to manually download the (\w+) version of "(.*)"$/ do |filetype, title|
+  work = Work.find_by_title(title)
+  download = Download.new(work, format: filetype)
+  download_url = "#{ArchiveConfig.APP_URL}#{download.public_path}"
+  filename = download.file_path # the full path of the download file we expect to exist
+  visit download_url
+  page.driver.response.headers['Content-Disposition'].should_not =~ /filename=\"#{File.basename(filename)}\"/
+  page.response_headers['Content-Type'].should_not == MIME::Types.type_for(filename).first
+end
+
+Then /^the (.*) version of "([^"]*)" should exist$/ do |filetype, title|
+  work = Work.find_by_title(title)
+  filename = "#{work.download_basename}.#{filetype}" # the full path of the download file we expect to exist
+  assert Download.new(work, format: filetype).exists?, "#{filename} does not exist"
+end
+
+Then /^the (.*) version of "([^"]*)" should not exist$/ do |filetype, title|
+  work = Work.find_by_title(title)
+  assert !Download.new(work, format: filetype).exists?, "#{filename} does exist"
+end
+
+When /^I try and fail to download the (\w+) version of "(.*)"$/ do |filetype, title|
+  work = Work.find_by_title(title)
+  download = Download.new(work, format: filetype)
+  download_url = "#{ArchiveConfig.APP_URL}#{download.public_path}?dont_generate_download=1"
+  visit download_url
+  filename = download.file_path # the full path of the download file we expect to exist
+  page.driver.response.headers['Content-Disposition'].should_not =~ /filename=\"#{File.basename(filename)}\"/
+  page.response_headers['Content-Type'].should_not == MIME::Types.type_for(filename).first
+end

--- a/features/step_definitions/work_steps.rb
+++ b/features/step_definitions/work_steps.rb
@@ -208,6 +208,11 @@ Given /^there is a work "([^"]*)" in an unrevealed collection "([^"]*)"$/ do |wo
   step %{I am logged out}
 end
 
+Given /^I am logged in as the author of "([^"]*)"$/ do |work|
+  work = Work.find_by_title(work)
+  step %{I am logged in as "#{work.users.first.login}"}
+end
+
 Given /^the spam work "([^\"]*)"$/ do |work|
   step %{I have a work "#{work}"}
   step %{I am logged out}

--- a/features/works/work_download.feature
+++ b/features/works/work_download.feature
@@ -1,176 +1,77 @@
 # encoding=utf-8
 
 @works
-
 Feature: Download a work
-  @wip
-  Scenario: Download an ordinary work
 
-  Given the work "Tittle with doubble letters"
-  When I view the work "Tittle with doubble letters"
-  Then I should see the text with tags "Tittle%20with%20doubble%20letters.mobi"
-  When I follow "MOBI"
-  Then I should see "Tittle with doubble letters"
-    And I should see the text with tags "Tittle with doubble letters"
-  When I view the work "Tittle with doubble letters"
-    And I follow "PDF"
-  # Then...
-  When I view the work "Tittle with doubble letters"
-    And I follow "HTML"
-  Then I should see "Tittle with doubble letters"
-  When I view the work "Tittle with doubble letters"
-    And I follow "EPUB"
-  # Then...
+  Scenario: Download a work in various formats
 
-  @wip
-  Scenario: Download works with quotation marks in the title doesn't bomb
+  Given I am logged in as "myname"
+    And I post the work "Tittle with doubble letters"
+  Then I should be able to download all versions of "Tittle with doubble letters"
 
-  Given I am logged in as a random user
-    And I set up the draft "Title I'll Replace In A Sec"
+  Scenario: Download works with double quotes in title
+
+  Given I am logged in as "myname"
+    And I set up the draft "Foo"
     And I fill in "Work Title" with
-      """
-      "Has double quotes"
-      """
-  When I press "Post Without Preview"
-    And I follow "MOBI"
-  # Then...
-  When I go to the work page with title "Has double quotes"
+        """
+        "Has double quotes"
+        """
+    And I fill in "content" with "some random stuff"
+  When I press "Preview"
+    And I press "Post"
     And I follow "PDF"
-  # Then...
+  Then I should receive a file of type "pdf"
   When I go to the work page with title "Has double quotes"
-    And I follow "HTML"
-  # Then...
+    And I follow "MOBI"
+  Then I should receive a file of type "mobi"
   When I go to the work page with title "Has double quotes"
     And I follow "EPUB"
-  # Then...
-
-  @wip
-  Scenario: Download works with Cyrillic in the title doesn't bomb
-
-  Given I set up the draft "Title I'll Replace In A Sec"
-    And I fill in "Work Title" with
-      """
-      Первый_маг
-      """
-  When I press "Post Without Preview"
-  # TODO: Think about whether we can invent a better name than this
-  Then I should see the text with tags "_.mobi"
-  When I follow "MOBI"
-  # Then...
-  When I go to the work page with title Первый_маг
-    And I follow "PDF"
-  # Then...
-  When I go to the work page with title Первый_маг
-    And I follow "HTML"
-  # Then...
-  When I go to the work page with title Первый_маг
-    And I follow "EPUB"
-  # Then...
-
-  @wip
-  Scenario: Download works with curly quotes in the title doesn't bomb
-
-  Given I set up the draft "Title I'll Replace In A Sec"
-    And I fill in "Work Title" with
-      """
-      Has curly’d quotes
-      """
-  When I press "Post Without Preview"
-    And I follow "MOBI"
-  # Then...
-  When I go to the work page with title Has curly’d quotes
-    And I follow "PDF"
-  # Then...
-  When I go to the work page with title Has curly’d quotes
-    And I follow "HTML"
-  # Then...
-  When I go to the work page with title Has curly’d quotes
-    And I follow "EPUB"
-  # Then...
-
-  @wip
-  Scenario: Download works with curly and straight quotes and accented 
-  characters in the title doesn't bomb
-
-  Given I set up the draft "Title I'll Replace In A Sec"
-    And I fill in "Work Title" with
-      """
-      "Hàs curly’d quotes"
-      """
-  When I press "Post Without Preview"
-    And I follow "MOBI"
-  # Then...
-  When I go to the work page with title "Hàs curly’d quotes"
-    And I follow "PDF"
-  # Then...
-  When I go to the work page with title "Hàs curly’d quotes"
-    And I follow "HTML"
-  # Then...
-  When I go to the work page with title "Hàs curly’d quotes"
-    And I follow "EPUB"
-  # Then...
-
-  @wip
-  Scenario: Download chaptered works doesn't bomb
- 
-  Given the chaptered work "Epic Novel"
-  When I view the work "Epic Novel"
-    And I follow "HTML"
-  Then I should see "Epic Novel"
-    And I should see "Another Chapter"
-    And I should not see "Comments"
-  When I view the work "Epic Novel"
-    And I follow "PDF"
-  # Then...
-  When I view the work "Epic Novel"
-    And I follow "MOBI"
-  # Then...
-  When I view the work "Epic Novel"
-    And I follow "EPUB"
-
-  @wip
-  Scenario: Download MOBI and PDF for works with unusual characters in the title
-
-  Given I set up the draft "Title I'll Replace In A Sec"
-    And I fill in "Work Title" with
-      """
-      ♥ and é Türkçe Karakterler başlıkta nasıl görünüyor
-      """
-  When I press "Post Without Preview"
-    And I follow "MOBI"
-  # Then...
-  When I go to the work page with title ♥ and é Türkçe Karakterler başlıkta nasıl görünüyor
-    And I follow "PDF"
-  # Then...
-
-  @wip
-  Scenario: Download MOBI and PDF for works with more unusual characters in the title
-
-  Given I set up the draft "Title I'll Replace In A Sec"
-    And I fill in "Work Title" with
-      """
-      à ø something
-      """
-  When I press "Post Without Preview"
-    And I follow "MOBI"
-  # Then...
-  When I go to the work page with title à ø something
-    And I follow "PDF"
-  # Then...
-
-  Scenario: Download chaptered works as HTML
-
+  Then I should receive a file of type "epub"
+  
+  
+  
+  Scenario: Download works with non-ASCII characters in title
+  
+  Given I am logged in as "myname"
+  When I post the work "Первый_маг"
+  Then I should be able to download all versions of "Первый_маг"
+  When I post the work "Hàs curly’d quotes"
+  Then I should be able to download all versions of "Hàs curly’d quotes"
+  When I post the work "♥ é Türkçe Karakterler başlıkta nasıl görünüyor"
+  Then I should be able to download all versions of "♥ é Türkçe Karakterler başlıkta nasıl görünüyor"
+  When I post the work "à ø something"
+  Then I should be able to download all versions of "à ø something"
+  When I post the work "流亡在阿尔比恩"
+  Then I should be able to download all versions of "流亡在阿尔比恩"
+  When I post the work "-dash in title-"
+  Then I should be able to download all versions of "-dash in title-"
+  
+  
+  Scenario: Download of chaptered works includes chapters
+  
   Given the chaptered work "Bazinga"
   When I view the work "Bazinga"
     And I follow "HTML"
   Then I should see "Chapter 2"
-
-  Scenario: Unrevealed works cannot be downloaded
-
-  Given there is a work "Now You See Me" in an unrevealed collection "Invisibility"
-  When I am logged in as the owner of "Invisibility"
-    And I view the work "Now You See Me"
-    And I follow "HTML"
-    And "AO3-4706" is fixed
-  # Then I should see "Sorry, you can't download an unrevealed work"
-  #   And I should be on the works page
+  
+  
+  Scenario: It should be possible to download chaptered works
+  
+  Given I am logged in as "author"
+  When I post the chaptered work "Epic Novel"
+  Then I should be able to download all versions of "Epic Novel"
+        
+  Scenario: works cannot be downloaded if unrevealed
+  
+  Given there is a work "Blabla" in an unrevealed collection "Unrevealed"
+    And I am logged in as the author of "Blabla"
+  Then I should not be able to download the mobi version of "Blabla"
+    And I should see "can't download an unrevealed"
+    
+  Scenario: graceful error message when file can't be generated
+  
+  Given I am logged in as "author"
+    And I post the work "Whatever"
+    And I try and fail to download the mobi version of "Whatever"
+  Then I should see "Please try again"


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-3880

## Purpose

Uses Calibre to generate epub and mobi files. Also extracts download code into its own classes and out of the controller and the work model.

Incorporates and replaces https://github.com/otwcode/otwarchive/pull/2157 (merge conflicts and Rails upgrades, oh my)

As per the original pull request, it should also fix:

Closed hole that allowed unrevealed works to be downloaded
https://code.google.com/p/otwarchive/issues/detail?id=3055

Removed html entities from download filenames entirely instead of just stripping the & and ;
https://code.google.com/p/otwarchive/issues/detail?id=2645

Fixed issue with not providing error message when the download file wasn't rendered yet
https://code.google.com/p/otwarchive/issues/detail?id=3024

issues with mobi downloads for dash at start of title
https://code.google.com/p/otwarchive/issues/detail?id=3908

## Testing

Make sure downloads generate correctly and have the correct formatting.