### PR TITLE
AO3-5491 Use cluster health API to wait for Travis ES startup

### DIFF
--- a/script/travis_elasticsearch_upgrade.sh
+++ b/script/travis_elasticsearch_upgrade.sh
@@ -4,4 +4,4 @@ wget https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-6.2.4.ta
 tar xvfz /tmp/elasticsearch-6.2.4.tar.gz
 sed -i elasticsearch-6.2.4/config/elasticsearch.yml  -e 's/#http.port: 9200/http.port: 9400/'
 nohup ./elasticsearch-6.2.4/bin/elasticsearch &
-wget -q --waitretry=1 --retry-connrefused -T 20 -O - http://127.0.0.1:9400
+wget -q --waitretry=1 --retry-connrefused -T 20 -O - "http://127.0.0.1:9400/_cluster/health?wait_for_status=yellow"


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5491

## Purpose

Wait for ES startup more reliably. The root URL can return 503 if ES is not completely ready, which fails wget.

## Testing

Travis builds should (more) consistently pass.