### PR TITLE
AO3-4037: Automatically retry failing emails

### DIFF
--- a/app/mailers/admin_mailer.rb
+++ b/app/mailers/admin_mailer.rb
@@ -1,10 +1,4 @@
-class AdminMailer < ActionMailer::Base
-  include Resque::Mailer # see README in this directory
-
-  layout 'mailer'
-  helper :mailer
-  default from: "Archive of Our Own " + "<#{ArchiveConfig.RETURN_ADDRESS}>"
-
+class AdminMailer < ArchiveMailer
   def abuse_report(abuse_report_id)
     abuse_report = AbuseReport.find(abuse_report_id)
     @email = abuse_report.email

--- a/app/mailers/archive_mailer.rb
+++ b/app/mailers/archive_mailer.rb
@@ -1,0 +1,8 @@
+class ArchiveMailer < ActionMailer::Base
+  include Resque::Mailer # see README in this directory
+  
+  layout 'mailer'
+  helper :mailer
+  default from: "Archive of Our Own " + "<#{ArchiveConfig.RETURN_ADDRESS}>"
+
+end

--- a/app/mailers/collection_mailer.rb
+++ b/app/mailers/collection_mailer.rb
@@ -1,14 +1,9 @@
-class CollectionMailer < ActionMailer::Base
-  include Resque::Mailer # see README in this directory
+class CollectionMailer < ArchiveMailer
   
   helper :application
-  helper :mailer
   helper :tags
   helper :works
   helper :series
-
-  layout 'mailer'
-  default from: "Archive of Our Own " + "<#{ArchiveConfig.RETURN_ADDRESS}>"
   
   def item_added_notification(creation_id, collection_id, item_type)
     @item_type = item_type

--- a/app/mailers/comment_mailer.rb
+++ b/app/mailers/comment_mailer.rb
@@ -1,9 +1,4 @@
-class CommentMailer < ActionMailer::Base
-  include Resque::Mailer # see README in this directory
-
-  layout 'mailer'
-  helper :mailer
-  default from: "Archive of Our Own " + "<#{ArchiveConfig.RETURN_ADDRESS}>"
+class CommentMailer < ArchiveMailer
 
   # Sends email to an owner of the top-level commentable when a new comment is created
   def comment_notification(user, comment)

--- a/app/mailers/kudo_mailer.rb
+++ b/app/mailers/kudo_mailer.rb
@@ -1,9 +1,4 @@
-class KudoMailer < ActionMailer::Base
-  include Resque::Mailer # see README in this directory
-
-  layout 'mailer'
-  helper :mailer
-  default from: "Archive of Our Own " + "<#{ArchiveConfig.RETURN_ADDRESS}>"
+class KudoMailer < ArchiveMailer
 
   # send a batched-up notification
   # user_kudos is a hash of arrays converted to JSON string format

--- a/config/initializers/gem-plugin_config/resque_mailer.rb
+++ b/config/initializers/gem-plugin_config/resque_mailer.rb
@@ -1,1 +1,10 @@
 Resque::Mailer.excluded_environments = [:test, :cucumber]
+Resque::Mailer.error_handler = lambda { |mailer, message, error, action, args|
+  if error.is_a?(Resque::TermException)
+    Resque.enqueue(mailer, action, *args)
+  elsif error.is_a?(ActiveRecord::RecordNotFound) && !args.include?(:retried)
+    Resque.enqueue_in(5.minutes, mailer, action, :retried, *args)
+  else
+    raise error
+  end
+}


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-4037

## Purpose

Rescues and retries resque email failures that occur when redis is ahead of mysql, which should hopefully keep those out of the failed jobs list, making it easier to track. Also cleans up a bit of duplication in the mailers.

## Testing

It could be hard to simulate this on staging, so we may need a database admin to create some fake failures.