### PR TITLE
AO3-5496: Update transaction gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,7 +27,7 @@ gem 'mysql2', '0.3.20'
 #https://github.com/qertoip/transaction_retry
 # We don't use the isolation gem directly, but it needs to be
 # at the latest version to avoid errors
-# gem 'transaction_isolation', '1.0.5'
+gem 'transaction_isolation', '1.0.5'
 gem 'transaction_retry'
 #https://github.com/winebarrel/activerecord-mysql-reconnect
 gem 'activerecord-mysql-reconnect', '~> 0.4.1'

--- a/Gemfile
+++ b/Gemfile
@@ -25,6 +25,9 @@ gem 'rails-controller-testing'
 gem 'mysql2', '0.3.20'
 
 #https://github.com/qertoip/transaction_retry
+# We don't use the isolation gem directly, but it needs to be
+# at the latest version to avoid errors
+# gem 'transaction_isolation', '1.0.5'
 gem 'transaction_retry'
 #https://github.com/winebarrel/activerecord-mysql-reconnect
 gem 'activerecord-mysql-reconnect', '~> 0.4.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -444,9 +444,9 @@ GEM
       multi_json (~> 1.3)
       rake
       rest-client (~> 1.6)
-    transaction_isolation (1.0.3)
+    transaction_isolation (1.0.5)
       activerecord (>= 3.0.11)
-    transaction_retry (1.0.2)
+    transaction_retry (1.0.3)
       activerecord (>= 3.0.11)
       transaction_isolation (>= 1.0.2)
     tzinfo (1.2.3)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -568,6 +568,7 @@ DEPENDENCIES
   timecop
   timeliness
   tire
+  transaction_isolation (= 1.0.5)
   transaction_retry
   unicode
   unicorn (>= 5.1.0)


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5496

## Purpose

Updates transaction isolation gem to fix confusing error messages when db transactions fail.

## Testing

Make sure automated tests pass and the staging site doesn't blow up.