### PR TITLE
AO3-5453 Encode deleted work email attachments with base64

### DIFF
--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -323,8 +323,8 @@ class UserMailer < BulletproofMailer::Base
     @work = work
     work_copy = generate_attachment_content_from_work(work)
     filename = work.title.gsub(/[*:?<>|\/\\\"]/,'')
-    attachments["#{filename}.txt"] = {content: work_copy}
-    attachments["#{filename}.html"] = {content: work_copy}
+    attachments["#{filename}.txt"] = { content: work_copy, encoding: "base64" }
+    attachments["#{filename}.html"] = { content: work_copy, encoding: "base64" }
     I18n.with_locale(Locale.find(@user.preference.preferred_locale).iso) do
       mail(
         to: user.email,
@@ -343,8 +343,8 @@ class UserMailer < BulletproofMailer::Base
     @work = work
     work_copy = generate_attachment_content_from_work(work)
     filename = work.title.gsub(/[*:?<>|\/\\\"]/,'')
-    attachments["#{filename}.txt"] = {content: work_copy}
-    attachments["#{filename}.html"] = {content: work_copy}
+    attachments["#{filename}.txt"] = { content: work_copy, encoding: "base64" }
+    attachments["#{filename}.html"] = { content: work_copy, encoding: "base64" }
     I18n.with_locale(Locale.find(@user.preference.preferred_locale).iso) do
       mail(
         to: user.email,


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5453

## Purpose

If the plain text attachment is encoded with 7bit, the email can have long lines that exceed the SMTP limit (998 octets), causing errors. With base64 encoding, attachments have line wrapping by default.

HTML attachments are already base64-encoded, this change just makes that obvious.

## Testing

See issue.