### PR TITLE
AO3-5500: Use collection syntax for partials

### DIFF
--- a/app/views/bookmarks/_bookmarks.html.erb
+++ b/app/views/bookmarks/_bookmarks.html.erb
@@ -11,20 +11,18 @@
   <% # The javascript expanded view that shows more bookmarks for a particular work on an aggregated view %>  
   <% # because this isn't rendered inside the index view we need to put a ul around it %>
   <ul class="index group">
-    <% @bookmarks.each do |bookmark| %><%= render 'bookmarks/bookmark_blurb_short', :bookmark => bookmark %><% end %>
+    <%= render 'bookmarks/bookmark_blurb_short', collection: @bookmarks, as: bookmark %>
   </ul>
 
 <% elsif @bookmarkable %>
   <% # show only partial view for each bookmark since the bookmarked object is already shown above %>
-  <% @bookmarks.each do |bookmark| %><%= render 'bookmarks/bookmark_blurb_short', :bookmark => bookmark %><% end %>
+  <%= render 'bookmarks/bookmark_blurb_short', collection: @bookmarks, as: bookmark %>
 
 <% elsif @bookmarkable_items %>
   <% # Display a list of bookmarkables, with several bookmarks under each %>
-  <% @bookmarkable_items.each do |bookmarkable| %>
-    <%= render 'bookmarks/bookmarkable_blurb', bookmarkable: bookmarkable %>
-  <% end %>
+  <%= render 'bookmarks/bookmarkable_blurb', collection: @bookmarkable_items, as: bookmarkable %>
 <% else %>
   <% # Standard bookmarks index with full blurb %> 
-  <% @bookmarks.each do |bookmark| %><%= render 'bookmarks/bookmark_blurb', :bookmark => bookmark %><% end %>
+  <%= render 'bookmarks/bookmark_blurb', collection: @bookmarks, as: bookmark %>
   
 <% end %>

--- a/app/views/bookmarks/_bookmarks.html.erb
+++ b/app/views/bookmarks/_bookmarks.html.erb
@@ -11,18 +11,18 @@
   <% # The javascript expanded view that shows more bookmarks for a particular work on an aggregated view %>  
   <% # because this isn't rendered inside the index view we need to put a ul around it %>
   <ul class="index group">
-    <%= render 'bookmarks/bookmark_blurb_short', collection: @bookmarks, as: bookmark %>
+    <%= render partial: 'bookmarks/bookmark_blurb_short', collection: @bookmarks, as: :bookmark %>
   </ul>
 
 <% elsif @bookmarkable %>
   <% # show only partial view for each bookmark since the bookmarked object is already shown above %>
-  <%= render 'bookmarks/bookmark_blurb_short', collection: @bookmarks, as: bookmark %>
+  <%= render partial: 'bookmarks/bookmark_blurb_short', collection: @bookmarks, as: :bookmark %>
 
 <% elsif @bookmarkable_items %>
   <% # Display a list of bookmarkables, with several bookmarks under each %>
-  <%= render 'bookmarks/bookmarkable_blurb', collection: @bookmarkable_items, as: bookmarkable %>
+  <%= render partial: 'bookmarks/bookmarkable_blurb', collection: @bookmarkable_items, as: :bookmarkable %>
 <% else %>
   <% # Standard bookmarks index with full blurb %> 
-  <%= render 'bookmarks/bookmark_blurb', collection: @bookmarks, as: bookmark %>
+  <%= render partial: 'bookmarks/bookmark_blurb', collection: @bookmarks, as: :bookmark %>
   
 <% end %>

--- a/app/views/users/_contents.html.erb
+++ b/app/views/users/_contents.html.erb
@@ -38,9 +38,7 @@
   <div class="work listbox group" id="user-works">
     <h3 class="heading"><%= ts("Recent works") %></h3>
     <ul class="index group">
-      <% for work in @works %>
-    	  <%= render :partial => 'works/work_blurb', :locals => {:work => work} %>
-      <% end %>
+      <%= render partial: 'works/work_blurb', collection: @works, as: :work %>
     </ul>
     <% if @pseud %>
       <% if @pseud.works.count > ArchiveConfig.NUMBER_OF_ITEMS_VISIBLE_IN_DASHBOARD %>
@@ -58,9 +56,7 @@
   <div class="series listbox group" id="user-series">
     <h3 class="heading"><%= ts("Recent series") %></h3>
     <ol class="index group">
-      <% for series in @series %>
-        <%= render :partial => 'series/series_blurb', :locals => {:series => series} %>
-      <% end %>
+      <%= render partial: 'series/series_blurb', collection: @series, as: :series %>
     </ol>
     <% if @pseud %>
       <% if @pseud.series.count > ArchiveConfig.NUMBER_OF_ITEMS_VISIBLE_IN_DASHBOARD %>
@@ -78,9 +74,7 @@
   <div class="bookmark listbox group" id="user-bookmarks">
     <h3 class="heading"><%= ts("Recent bookmarks") %></h3>
     <ol class="index group">
-      <% for bookmark in @bookmarks %>
-        <%= render 'bookmarks/bookmark_blurb', :bookmark => bookmark %>
-      <% end %>
+      <%= render partial: 'bookmarks/bookmark_blurb', collection: @bookmarks, as: :bookmark %>
     </ol>
     <% unless @user == User.orphan_account %>
       <% if @pseud %>

--- a/app/views/works/index.html.erb
+++ b/app/views/works/index.html.erb
@@ -53,9 +53,7 @@
 <!--main content-->
 <h3 class="landmark heading"><%= ts("Listing Works") %></h3>
 <ol class="work index group">
-  <% for work in @works %>
-    <% if work %><%= render 'work_blurb', work: work %><% end %>
-  <% end %>
+  <%= render 'work_blurb', collection: @works, as: work %>
 </ol>
 
 <!--/content-->

--- a/app/views/works/index.html.erb
+++ b/app/views/works/index.html.erb
@@ -53,7 +53,7 @@
 <!--main content-->
 <h3 class="landmark heading"><%= ts("Listing Works") %></h3>
 <ol class="work index group">
-  <%= render 'work_blurb', collection: @works, as: work %>
+  <%= render partial: 'work_blurb', collection: @works, as: :work %>
 </ol>
 
 <!--/content-->


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5500

## Purpose

Small change to partial rendering syntax to use collection instead of looping and rendering each partial individually. Affects works index, bookmarks index, and user dashboard.

## Testing

Works, bookmarks, and user dashboard pages should render correctly with no changes.