### PR TITLE
AO3-5465 Update crossover check to make two fandoms count as related if they share a meta tag.

### DIFF
--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -1570,32 +1570,31 @@ class Work < ApplicationRecord
     # as synonyms should have no meta tags themselves
     all_without_syns = fandoms.map { |f| f.merger || f }.uniq
 
-    # For each fandom, find the set of top-level meta tags (i.e. meta-tags that
-    # don't have meta-tags of their own, or the tag itself if it doesn't have
-    # meta-tags) associated with that fandom.
-    top_meta_groups = all_without_syns.map do |f|
+    # For each fandom, find the set of all meta tags for that fandom (including
+    # the fandom itself).
+    meta_tag_groups = all_without_syns.map do |f|
       # TODO: This is more complicated than it has to be. Once the
       # meta_taggings table is fixed so that the inherited meta-tags are
       # correctly calculated, this can be simplified.
       boundary = [f] + f.meta_tags
       all_meta_tags = []
 
-      loop do
+      until boundary.empty?
         all_meta_tags.concat(boundary)
         boundary = boundary.flat_map(&:meta_tags).uniq - all_meta_tags
-        break if boundary.empty?
       end
 
-      all_meta_tags.select { |m| m.meta_taggings.empty? }.uniq
+      all_meta_tags.uniq
     end
 
-    # Find the biggest group of top-level meta tags.
-    biggest_group_size = top_meta_groups.map(&:size).max
-
-    # If the biggest group is the same size as the total number in all groups,
-    # that means that all top-level meta-tags in all groups also occur in the
-    # biggest group, so we don't have any fandoms that are unrelated to it.
-    top_meta_groups.flatten.uniq.size > biggest_group_size
+    # Two fandoms are "related" if they share at least one meta tag. A work is
+    # considered a crossover if there is no single fandom on the work that all
+    # the other fandoms on the work are "related" to.
+    meta_tag_groups.none? do |meta_tags1|
+      meta_tag_groups.all? do |meta_tags2|
+        (meta_tags1 & meta_tags2).any?
+      end
+    end
   end
 
   # Does this work have only one relationship tag?

--- a/spec/models/work_spec.rb
+++ b/spec/models/work_spec.rb
@@ -225,15 +225,24 @@ describe Work do
         expect(work.crossover).to be_falsey
       end
 
-      it "is a crossover with another fandom sharing one meta tag, but with a second unrelated meta tag" do
+      it "is not a crossover with another fandom with two unrelated meta tags, only one of which is shared by both fandoms" do
         # The tag fandom and the tag other share one meta tag (meta2), but
         # fandom has a meta tag meta1 completely unrelated to other, and other
-        # has a meta tag meta3 completely unrelated to fandom. So for the
-        # purposes of this check, they count as unrelated, and thus a work
-        # tagged with both is a crossover.
+        # has a meta tag meta3 completely unrelated to fandom. However, the
+        # shared meta tag means that they are related, and thus a work tagged
+        # with both is not a crossover.
         meta3 = create(:canonical_fandom)
         other = create(:canonical_fandom)
         other.update_attribute(:meta_tag_string, "#{meta2.name},#{meta3.name}")
+        work = create(:work, fandom_string: "#{fandom.name},#{other.name}")
+        expect(work.crossover).to be_falsey
+      end
+
+      it "is a crossover with another fandom with two unrelated meta tags, when none of the meta tags are shared" do
+        meta3 = create(:canonical_fandom)
+        meta4 = create(:canonical_fandom)
+        other = create(:canonical_fandom)
+        other.update_attribute(:meta_tag_string, "#{meta3.name},#{meta4.name}")
         work = create(:work, fandom_string: "#{fandom.name},#{other.name}")
         expect(work.crossover).to be_truthy
       end


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5465

## Purpose

Currently, two fandoms are considered "related" for the purposes of the crossover check if one fandom's first-class meta tags are a subset of the other fandom's first-class meta tags. This means that if you have a fandom A with meta tags C and D, and a fandom B with meta tags D and E, then any work tagged with A and B counts as a crossover (because A has a meta tag C that isn't shared by B, and B has a meta tag E that isn't shared by A).

This pull request modifies the crossover check so that two fandoms count as "related" if they share a meta tag, meaning that fandoms A and B would count as related, and works tagged with both won't automatically count as crossovers.

## Testing

Check to see whether works tagged "Captain America (Movies), The Avengers (Marvel Movie)" automatically count as crossovers on the test servers.