### PR TITLE
AO3-5509 Wait for ES startup on Codeship

### DIFF
--- a/script/check_syntax
+++ b/script/check_syntax
@@ -9,7 +9,7 @@ mysql -e "SHOW VARIABLES LIKE 'tx_isolation';" | grep -s "READ-COMMITTED"
 if [  $? -ne 0 ] ; then 
   exit 1
 fi
-ERRORS=`find {app,lib} -iname "*.rb" -print0 | xargs -0 -n 1 ./script/check_syntax_file`
+ERRORS=`find app lib -iname "*.rb" -print0 | xargs -0 -n 1 ./script/check_syntax_file`
 if [ -z "${ERRORS}" ] ; then 
   exit 0
 fi

--- a/script/prepare_codeship.sh
+++ b/script/prepare_codeship.sh
@@ -40,6 +40,8 @@ cd elasticsearch-${ES_VERSION}
 echo "http.port: ${ES_PORT}" >> config/elasticsearch.yml
 # Make sure to use the exact parameters you want for elasticsearch and give it enough sleep time to properly start up
 nohup bash -c "./bin/elasticsearch 2>&1" &
+wget -q --waitretry=1 --retry-connrefused -T 20 -O - "http://127.0.0.1:${ES_PORT}/_cluster/health?wait_for_status=yellow"
+echo
 
 cd ~/clone
 echo "BCRYPT_COST: 4"  >> config/local.yml


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5509

## Purpose

Similar to #3394 but this time for Codeship.

Also fix the find command in check_syntax.
```
find: `{app,lib}': No such file or directory
```

## Testing

None, automated.