### PR TITLE
AO3-4458 Update mail gem to 2.7.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -64,6 +64,7 @@ gem 'rest-client', '~> 1.8.0', :require => 'rest_client'
 gem 'resque', '>=1.14.0'
 gem 'resque_mailer'
 gem 'resque-scheduler'
+gem 'mail', '~> 2.7'
 #gem 'daemon-spawn', :require => 'daemon_spawn'
 gem 'tire'
 gem 'elasticsearch', '>=6.0.0'
@@ -123,7 +124,7 @@ gem 'phraseapp-in-context-editor-ruby', '>=1.0.6'
 gem 'addressable'
 gem 'audited', '~> 4.4'
 
-# For controlling application behavour dynamically
+# For controlling application behaviour dynamically
 gem 'rollout'
 
 #  Place the New Relic gem as low in the list as possible, allowing the

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -234,8 +234,8 @@ GEM
     loofah (2.2.2)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
-    mail (2.6.5)
-      mime-types (>= 1.16, < 4)
+    mail (2.7.0)
+      mini_mime (>= 0.1.1)
     mechanize (2.7.5)
       domain_name (~> 0.5, >= 0.5.1)
       http-cookie (~> 1.0)
@@ -248,6 +248,7 @@ GEM
     method_source (0.8.2)
     mime-types (2.99.3)
     mimemagic (0.3.2)
+    mini_mime (1.0.0)
     mini_portile2 (2.3.0)
     minitest (5.10.2)
     mono_logger (1.1.0)
@@ -533,6 +534,7 @@ DEPENDENCIES
   kgio (= 2.10.0)
   launchy
   lograge
+  mail (~> 2.7)
   mechanize
   minitest
   mysql2 (= 0.3.20)


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-4458

## Purpose

Update the gem, since 2.7.0 might fix an issue we have with [AO3-5453](https://otwarchive.atlassian.net/browse/AO3-5453).

```
https://github.com/mikel/mail/pull/1157
```
> Fix base64 attachment transfer encoding being overridden by quoted-printable

## Testing

See issue.