### PR TITLE
AO3-5453 Really encode deleted work email attachments with base64

### DIFF
--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -322,6 +322,7 @@ class UserMailer < BulletproofMailer::Base
     @user = user
     @work = work
     work_copy = generate_attachment_content_from_work(work)
+    work_copy = ::Mail::Encodings::Base64.encode(work_copy)
     filename = work.title.gsub(/[*:?<>|\/\\\"]/,'')
     attachments["#{filename}.txt"] = { content: work_copy, encoding: "base64" }
     attachments["#{filename}.html"] = { content: work_copy, encoding: "base64" }
@@ -342,6 +343,7 @@ class UserMailer < BulletproofMailer::Base
     @user = user
     @work = work
     work_copy = generate_attachment_content_from_work(work)
+    work_copy = ::Mail::Encodings::Base64.encode(work_copy)
     filename = work.title.gsub(/[*:?<>|\/\\\"]/,'')
     attachments["#{filename}.txt"] = { content: work_copy, encoding: "base64" }
     attachments["#{filename}.html"] = { content: work_copy, encoding: "base64" }


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5453

## Purpose

If we specify an encoding, Mail will assume that the content is already encoded and not try to encode it. We'll do it ourselves.

## Testing

See issue.