### PR TITLE
AO3-5510: Make tag update transaction size configurable

### DIFF
--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -50,7 +50,8 @@ class Tag < ApplicationRecord
   end
 
   def self.write_redis_to_database
-    REDIS_GENERAL.smembers("tag_update").each_slice(1000) do |batch|
+    batch_size = ArchiveConfig.TAG_UPDATE_BATCH_SIZE
+    REDIS_GENERAL.smembers("tag_update").each_slice(batch_size) do |batch|
       Tag.transaction do
         batch.each do |id|
           value = REDIS_GENERAL.get("tag_update_#{id}_value")

--- a/config/config.yml
+++ b/config/config.yml
@@ -163,6 +163,9 @@ MAX_FAVORITE_TAGS: 20
 # The number of tags to show on the search page:
 TAGS_PER_SEARCH_PAGE: 50
 
+# When updating tag counts, how many to do in one transaction
+TAG_UPDATE_BATCH_SIZE: 100
+
 # how many signups in a challenge before we move to static summaries generated hourly
 MAX_SIGNUPS_FOR_LIVE_SUMMARY: 20
 


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5510

## Purpose

Makes the batch transaction size for tag count updates configurable so that we can tinker with it and see if that's the cause of problematic long-running transactions.

## Testing

Nothing should be visibly different, and tag counts should still eventually update.