### PR TITLE
Revert "AO3-4458 Update mail gem to 2.7.0 (#3408)"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -64,7 +64,6 @@ gem 'rest-client', '~> 1.8.0', :require => 'rest_client'
 gem 'resque', '>=1.14.0'
 gem 'resque_mailer'
 gem 'resque-scheduler'
-gem 'mail', '~> 2.7'
 #gem 'daemon-spawn', :require => 'daemon_spawn'
 gem 'tire'
 gem 'elasticsearch', '>=6.0.0'
@@ -124,7 +123,7 @@ gem 'phraseapp-in-context-editor-ruby', '>=1.0.6'
 gem 'addressable'
 gem 'audited', '~> 4.4'
 
-# For controlling application behaviour dynamically
+# For controlling application behavour dynamically
 gem 'rollout'
 
 #  Place the New Relic gem as low in the list as possible, allowing the

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -234,8 +234,8 @@ GEM
     loofah (2.2.2)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
-    mail (2.7.0)
-      mini_mime (>= 0.1.1)
+    mail (2.6.5)
+      mime-types (>= 1.16, < 4)
     mechanize (2.7.5)
       domain_name (~> 0.5, >= 0.5.1)
       http-cookie (~> 1.0)
@@ -248,7 +248,6 @@ GEM
     method_source (0.8.2)
     mime-types (2.99.3)
     mimemagic (0.3.2)
-    mini_mime (1.0.0)
     mini_portile2 (2.3.0)
     minitest (5.10.2)
     mono_logger (1.1.0)
@@ -534,7 +533,6 @@ DEPENDENCIES
   kgio (= 2.10.0)
   launchy
   lograge
-  mail (~> 2.7)
   mechanize
   minitest
   mysql2 (= 0.3.20)


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-4458

## Purpose

This reverts commit eb352ce870400b2ea2f2aeeae33fc56cc3b59478 (#3408).

2.7.0 has some issues, so we won't update for now:

```
https://github.com/mikel/mail/pull/1168
```

## Testing

See issue.