### PR TITLE
AO3-5448 Return 404 instead of 500 for nonexistent FAQs

### DIFF
--- a/app/controllers/archive_faqs_controller.rb
+++ b/app/controllers/archive_faqs_controller.rb
@@ -19,7 +19,7 @@ class ArchiveFaqsController < ApplicationController
   # GET /archive_faqs/1
   def show
     @questions = []
-    @archive_faq = ArchiveFaq.find_by(slug: params[:id])
+    @archive_faq = ArchiveFaq.find_by!(slug: params[:id])
     if params[:language_id] == "en"
       @questions = @archive_faq.questions
     else

--- a/spec/controllers/archive_faqs_controller_spec.rb
+++ b/spec/controllers/archive_faqs_controller_spec.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe ArchiveFaqsController do
+  describe "GET #show" do
+    it "raises a 404 for an invalid id" do
+      params = { id: "angst", language_id: "en" }
+      expect { get :show, params: params }.to raise_error ActiveRecord::RecordNotFound
+    end
+  end
+end


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5448

## Purpose

Return 404 instead of 500 for nonexistent FAQs, so these errors can stop showing up in New Relic.

## Testing

See issue.