### PR TITLE
AO3-4625 Make call to potentially missing bookmarkable safer

### DIFF
--- a/app/controllers/api/v2/bookmarks_controller.rb
+++ b/app/controllers/api/v2/bookmarks_controller.rb
@@ -59,7 +59,7 @@ class Api::V2::BookmarksController < Api::V2::BaseController
   def check_archivist_bookmark(archivist, original_url, archivist_bookmarks)
     current_bookmark_url = original_url
     archivist_bookmarks = archivist_bookmarks
-                            .select { |b| b.bookmarkable.url == current_bookmark_url }
+                            .select { |b| b&.bookmarkable&.url == current_bookmark_url }
                             .map    { |b| [b, b.bookmarkable] }
 
     if archivist_bookmarks.present?

--- a/app/controllers/api/v2/bookmarks_controller.rb
+++ b/app/controllers/api/v2/bookmarks_controller.rb
@@ -56,8 +56,7 @@ class Api::V2::BookmarksController < Api::V2::BaseController
   private
 
   # Find bookmarks for this archivist
-  def check_archivist_bookmark(archivist, original_url, archivist_bookmarks)
-    current_bookmark_url = original_url
+  def check_archivist_bookmark(archivist, current_bookmark_url, archivist_bookmarks)
     archivist_bookmarks = archivist_bookmarks
                             .select { |b| b&.bookmarkable&.url == current_bookmark_url }
                             .map    { |b| [b, b.bookmarkable] }


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-4625

## Purpose

Fix a case of "undefined method 'url' for nil:NilClass" that happens on Staging when using the API to check if a bookmark already exists.

## Testing

This will be tested with the rest of the new API.

