### PR TITLE
AO3-5420 Add more line-height for stats links in blurbs

### DIFF
--- a/public/stylesheets/site/2.0/13-group-blurb.css
+++ b/public/stylesheets/site/2.0/13-group-blurb.css
@@ -73,7 +73,7 @@ li.blurb:after, .blurb .blurb:after {
 
 .blurb dl.stats {
   float: right;
-  line-height: 1.429;
+  line-height: 2.143;
 }
 
 .blurb .fandoms .landmark {


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5420

## Purpose

Use the Archive's [em scale](http://otwcode.github.io/docs/front_end_coding/em-scale.html): 30px/14px = 2.143.

## Testing

See issue.