### PR TITLE
AO3-5515 Remove rubyzip 1.2.1 and selenium-webdriver

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -143,7 +143,6 @@ group :test do
   gem 'capybara', '~> 2.6.2'
   gem 'database_cleaner', '1.5.2'
   gem 'cucumber', '~> 2.4.0'
-  gem 'selenium-webdriver'
   gem 'poltergeist'
   gem 'capybara-screenshot'
   gem 'cucumber-rails', '~> 1.5', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -123,8 +123,6 @@ GEM
     capybara-screenshot (1.0.14)
       capybara (>= 1.0, < 3)
       launchy
-    childprocess (0.7.0)
-      ffi (~> 1.0, >= 1.0.11)
     chronic (0.10.2)
     climate_control (0.2.0)
     cliver (0.3.2)
@@ -387,7 +385,6 @@ GEM
       rspec-mocks (~> 3.6.0)
       rspec-support (~> 3.6.0)
     rspec-support (3.6.0)
-    rubyzip (1.2.1)
     rufus-scheduler (3.4.2)
       et-orbi (~> 1.0)
     rvm-capistrano (1.5.6)
@@ -399,10 +396,6 @@ GEM
       nokogumbo (~> 1.4)
     scrypt (3.0.5)
       ffi-compiler (>= 1.0, < 2.0)
-    selenium-webdriver (3.4.0)
-      childprocess (~> 0.5)
-      rubyzip (~> 1.0)
-      websocket (~> 1.0)
     shoulda (3.5.0)
       shoulda-context (~> 1.0, >= 1.0.1)
       shoulda-matchers (>= 1.4.1, < 3.0)
@@ -462,7 +455,6 @@ GEM
       crack (>= 0.3.2)
       hashdiff
     webrobots (0.1.2)
-    websocket (1.2.4)
     websocket-driver (0.6.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.2)
@@ -552,7 +544,6 @@ DEPENDENCIES
   rspec-rails (~> 3.6.0)
   rvm-capistrano
   sanitize (>= 4.6.5)
-  selenium-webdriver
   shoulda
   simplecov (~> 0.14.0)
   test-unit (~> 3.2)


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5515

## Purpose

rubyzip 1.2.1 is affected by [CVE-2018-1000544](https://nvd.nist.gov/vuln/detail/CVE-2018-1000544) and only used by selenium-webdriver, a test-only dependency. We can remove both.

## Testing

None.