### PR TITLE
AO3-5482 Avoid saving long paths in session cookie

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -180,9 +180,12 @@ public
     if session[:return_to] == "redirected"
       Rails.logger.debug "Return to back would cause infinite loop"
       session.delete(:return_to)
-    elsif request.fullpath.length <= 200
+    elsif request.fullpath.length > 200
       # Sessions are stored in cookies, which has a 4KB size limit.
       # Don't store paths that are too long (e.g. filters with lots of exclusions).
+      # Also remove the previous stored path.
+      session.delete(:return_to)
+    else
       session[:return_to] = request.fullpath
       Rails.logger.debug "Return to: #{session[:return_to]}"
     end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -180,7 +180,9 @@ public
     if session[:return_to] == "redirected"
       Rails.logger.debug "Return to back would cause infinite loop"
       session.delete(:return_to)
-    else
+    elsif request.fullpath.length <= 200
+      # Sessions are stored in cookies, which has a 4KB size limit.
+      # Don't store paths that are too long (e.g. filters with lots of exclusions).
       session[:return_to] = request.fullpath
       Rails.logger.debug "Return to: #{session[:return_to]}"
     end


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5482

## Purpose

Sessions are stored in cookies, which has a 4KB size limit. If we store paths that are too long (e.g. filters with lots of exclusions), we will run into CookieOverflow errors.

## Testing

Filter works, exclude some tags... some more tags... more tags... See issue.