### PR TITLE
AO3-4638 Use MySQL 5.7.22 in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,13 @@ env:
   - TEST_GROUP="cucumber -r features features/tags_and_wrangling -f Ao3Cucumber::Formatter --color"
   - TEST_GROUP="cucumber -r features features/users              -f Ao3Cucumber::Formatter --color"
   - TEST_GROUP="cucumber -r features features/works              -f Ao3Cucumber::Formatter --color"
+addons:
+  apt:
+    sources:
+      - mysql-5.7-trusty
+    packages:
+      - mysql-server
+      - mysql-client
 rvm:
   - "`cat .ruby_version| sed -e 's/ruby //'`"
 services:
@@ -37,7 +44,7 @@ before_script:
   - bash script/travis_configure.sh
   - bash script/travis_elasticsearch_upgrade.sh
   - bash script/travis_multiple_redis.sh
-  - sudo bash script/travis_set_read_isolation.sh
+  - bash script/travis_mysql.sh
 after_failure:
   - tail -v -n +1 $TRAVIS_BUILD_DIR/tmp/capybara/*.html
 notifications:

--- a/config/database.codeship.yml
+++ b/config/database.codeship.yml
@@ -1,6 +1,6 @@
 development:
   adapter: mysql2
-  host: localhost
+  host: 127.0.0.1
   encoding: utf8
   pool: 10
   port: 3307
@@ -9,7 +9,7 @@ development:
   database: development<%= ENV['TEST_ENV_NUMBER'] %>
 test:
   adapter: mysql2
-  host: localhost
+  host: 127.0.0.1
   encoding: utf8
   pool: 10
   port: 3307

--- a/config/database.codeship.yml
+++ b/config/database.codeship.yml
@@ -7,6 +7,8 @@ development:
   username: <%= ENV['MYSQL_USER'] %>
   password: <%= ENV['MYSQL_PASSWORD'] %>
   database: development<%= ENV['TEST_ENV_NUMBER'] %>
+  variables:
+    sql_mode: STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION
 test:
   adapter: mysql2
   host: 127.0.0.1
@@ -16,3 +18,5 @@ test:
   username: <%= ENV['MYSQL_USER'] %>
   password: <%= ENV['MYSQL_PASSWORD'] %>
   database: test<%= ENV['TEST_ENV_NUMBER'] %>
+  variables:
+    sql_mode: STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION

--- a/config/database.travis.yml
+++ b/config/database.travis.yml
@@ -1,6 +1,8 @@
 test:
-   adapter: mysql2
-   database: otwarchive_test
-   username: root
-   encoding: utf8
-   collation: utf8_unicode_ci
+  adapter: mysql2
+  database: otwarchive_test
+  username: root
+  encoding: utf8
+  collation: utf8_unicode_ci
+  variables:
+    sql_mode: STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION

--- a/script/prepare_codeship.sh
+++ b/script/prepare_codeship.sh
@@ -6,7 +6,10 @@
 #
 #
 export RAILS_ENV=test
+export MYSQL_VERSION=5.7.22
 export REDIS_VERSION=3.2.1
+export PATH="$HOME/mysql-$MYSQL_VERSION/bin:$PATH"
+
 bundle install
 \curl -sSL https://raw.githubusercontent.com/codeship/scripts/master/packages/mysql-5.7.sh | bash -s
 \curl -sSL https://raw.githubusercontent.com/codeship/scripts/master/packages/redis.sh | bash -s
@@ -23,6 +26,7 @@ cp config/redis-cucumber.conf.example config/redis-cucumber.conf
 cp config/redis.codeship.example config/redis.yml
 
 bundle exec rake db:create:all --trace
+bundle exec rails runner "puts \"Connecting to database version #{ActiveRecord::Base.connection.show_variable('version')}\""
 mysql -u $MYSQL_USER -p$MYSQL_PASSWORD -e  "ALTER DATABASE test$TEST_ENV_NUMBER CHARACTER SET utf8 COLLATE utf8_general_ci;"
 bundle exec rake db:schema:load --trace
 bundle exec rake db:migrate --trace

--- a/script/travis_configure.sh
+++ b/script/travis_configure.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-mysql -e 'create database otwarchive_test DEFAULT COLLATE utf8_unicode_ci DEFAULT CHARACTER SET utf8 ;'
 cp config/database.travis.yml config/database.yml
 cp config/newrelic.example config/newrelic.yml
 cp config/redis-cucumber.conf.example config/redis-cucumber.conf

--- a/script/travis_mysql.sh
+++ b/script/travis_mysql.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -e
+
+# Use READ-COMMITTED transaction isolation level
+sudo sed -i /etc/mysql/mysql.conf.d/mysqld.cnf  -e "s/\[mysqld\]/[mysqld]\ninnodb_lock_wait_timeout=15\ntransaction-isolation=READ-COMMITTED\n/"
+cat /etc/mysql/mysql.conf.d/mysqld.cnf
+
+# Fix table performance_schema.session_variables not existing
+# https://stackoverflow.com/q/31967527
+sudo mysql_upgrade --force
+
+# Both the upgrade and the conf change require a restart
+sudo service mysql restart
+
+mysql -e "CREATE DATABASE otwarchive_test DEFAULT COLLATE utf8_unicode_ci DEFAULT CHARACTER SET utf8;"

--- a/script/travis_set_read_isolation.sh
+++ b/script/travis_set_read_isolation.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-sed -i  /etc/mysql/my.cnf  -e 's/\[mysqld\]/[mysqld]\ninnodb_lock_wait_timeout=15\ntransaction-isolation = READ-COMMITTED\n/'
-/etc/init.d/mysql restart
-cat  /etc/mysql/my.cnf


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-4638

## Purpose

Have Travis use 5.7 latest (it has 5.7.23 and I can't get 5.7.22 from the APT add-on). Have Codeship use 5.7.22. In both cases we need to exclude ONLY_FULL_GROUP_BY from the SQL mode, or a lot of queries using GROUP BY would break.

## Testing

None, automated.