### PR TITLE
AO3-5382 Store the signup summary in Memcached.

### DIFF
--- a/app/models/challenge_signup_summary.rb
+++ b/app/models/challenge_signup_summary.rb
@@ -7,6 +7,21 @@ class ChallengeSignupSummary
     @challenge = collection.challenge
   end
 
+  ######################################################################
+  # CALCULATING INFO FOR THE SUMMARY
+  ######################################################################
+
+  # The type of tags to be summarized.
+  #
+  # For a multi-fandom challenge, this is probably fandom, but for a
+  # single-fandom challenge, it will probably be character or relationship (or
+  # one of the other tag types, if the challenge doesn't include either).
+  #
+  # Note that this returns the lowercase tag type.
+  def tag_type
+    @tag_type = collection.challenge.topmost_tag_type
+  end
+
   # Returns an array of tag listings that includes the number of requests and
   # offers each tag has in this challenge, sorted by least-offered and most-requested
   def summary
@@ -15,12 +30,10 @@ class ChallengeSignupSummary
 
   private
 
-  # The class of tags to be summarized
-  # For a multi-fandom challenge, this is probably Fandom, but for a single-fandom 
-  # challenge, it may be something else
+  # The class of tags to be summarized. Calls tag_type to retrieve the type.
   def tag_class
-    raise "Redshirt: Attempted to constantize invalid class initialize tag_class #{challenge.topmost_tag_type.classify}" unless Tag::TYPES.include?(challenge.topmost_tag_type.classify)
-    challenge.topmost_tag_type.classify.constantize
+    raise "Redshirt: Attempted to constantize invalid class initialize tag_class #{tag_type.classify}" unless Tag::TYPES.include?(tag_type.classify)
+    tag_type.classify.constantize
   end
 
   # All of the tags of the desired type that have been
@@ -38,6 +51,86 @@ class ChallengeSignupSummary
     end
   end
 
+  public
+
+  ######################################################################
+  # GENERATING THE SUMMARY IN RESQUE
+  ######################################################################
+
+  @queue = :collection
+
+  # The action to be performed when this class is enqueued using Resque.
+  def self.perform(collection_id)
+    collection = Collection.find(collection_id)
+    summary = ChallengeSignupSummary.new(collection)
+    summary.generate_in_background
+  end
+
+  # Asynchronously generate the cached version.
+  def enqueue_for_generation
+    Resque.enqueue(ChallengeSignupSummary, collection.id)
+  end
+
+  # Write the summary to Memcached, so that it can be retrieved and displayed.
+  # takes about 12 minutes for yuletide2010 on beta, about 25 minutes on stage
+  def generate_in_background
+    locals = {
+      challenge_collection: collection,
+      tag_type: self.tag_type,
+      summary_tags: self.summary,
+      generated_live: false
+    }
+
+    partial = "challenge/#{self.challenge.class.name.demodulize.tableize.singularize}/challenge_signups_summary"
+
+    self.cached_contents = ChallengeSignupsController.render(partial: partial,
+                                                             locals: locals)
+  end
+
+  ######################################################################
+  # CACHING THE SUMMARY
+  ######################################################################
+
+  # Retrieve the value of the cache for this signup summary.
+  def cached_contents
+    cached_info[:contents]
+  end
+
+  # Retrieve the time that the cache was last updated.
+  def cached_time
+    cached_info[:time]
+  end
+
+  # The equivalent of touching a file in the file system. Update the
+  # modification time.
+  def touch_cache
+    data = cached_info.dup
+    data[:time] = Time.now
+    Rails.cache.write(cache_key, data)
+  end
+
+  private
+
+  # Set the value of the cache for this signup summary.
+  def cached_contents=(value)
+    data = {
+      contents: value,
+      time: Time.now
+    }
+
+    Rails.cache.write(cache_key, data)
+  end
+
+  # Retrieve the hash containing cached info: the value being cached (if it
+  # exists), and the time that it was updated.
+  def cached_info
+    Rails.cache.read(cache_key) || {}
+  end
+
+  # The key used to store info about the signup summary in memcached.
+  def cache_key
+    "challenge_signup_summaries/#{collection.id}"
+  end
 end
 
 class ChallengeSignupTagSummary < Struct.new(:id, :name, :requests, :offers)

--- a/app/models/challenge_signup_summary.rb
+++ b/app/models/challenge_signup_summary.rb
@@ -128,7 +128,7 @@ class ChallengeSignupSummary
 
   # The key used to store info about the signup summary in memcached.
   def cache_key
-    "challenge_signup_summaries/#{collection.id}"
+    "/v1/challenge_signup_summaries/#{collection.id}"
   end
 end
 

--- a/app/models/challenge_signup_summary.rb
+++ b/app/models/challenge_signup_summary.rb
@@ -72,7 +72,6 @@ class ChallengeSignupSummary
   end
 
   # Write the summary to Memcached, so that it can be retrieved and displayed.
-  # takes about 12 minutes for yuletide2010 on beta, about 25 minutes on stage
   def generate_in_background
     locals = {
       challenge_collection: collection,

--- a/app/views/challenge_signups/summary.html.erb
+++ b/app/views/challenge_signups/summary.html.erb
@@ -1,9 +1,9 @@
-<% if File.size?("#{ChallengeSignup.summary_file(@collection)}") %>
-  <%=raw File.read("#{ChallengeSignup.summary_file(@collection)}") %>
-<% elsif @generated_live %>
+<% if @generated_live %>
   <% # render differently based on the challenge %>
   <%= render :partial => "challenge/#{challenge_class_name(@collection)}/challenge_signups_summary", 
              :locals => {:challenge_collection => @collection, :tag_type => @tag_type, :summary_tags => @summary_tags, :generated_live => @generated_live} %>
+<% elsif (cached_summary = @summary.cached_contents).present? %>
+  <%=raw cached_summary %>
 <% else %>
   <h2 class="heading"><%= ts("Sign-up Summary for %{collection}", :collection => @collection.title) %></h2>
 

--- a/features/gift_exchanges/signup_summary.feature
+++ b/features/gift_exchanges/signup_summary.feature
@@ -1,0 +1,41 @@
+Feature: Gift Exchange Signup Summary
+
+  Scenario: Updating a live summary
+    Given signup summaries are always visible
+      And all signup summaries are live
+      And I have created the gift exchange "Exchange"
+      And I open signups for "Exchange"
+
+    When I am logged in as "testuser1"
+      And I sign up for "Exchange" with combination C
+      And I view the sign-up summary for "Exchange"
+    Then I should see "Stargate SG-1"
+
+    When I am logged in as "testuser2"
+      And I sign up for "Exchange" with combination D
+      And I view the sign-up summary for "Exchange"
+    Then I should see "Stargate SG-1"
+      And I should see "Stargate Atlantis"
+
+  Scenario: Updating a delayed summary
+    Given signup summaries are always visible
+      And all signup summaries are delayed
+      And I have created the gift exchange "Exchange"
+      And I open signups for "Exchange"
+
+    When I am logged in as "testuser1"
+      And I sign up for "Exchange" with combination C
+      And I view the sign-up summary for "Exchange"
+    Then I should see "Stargate SG-1"
+
+    When I am logged in as "testuser2"
+      And I sign up for "Exchange" with combination D
+      And I view the sign-up summary for "Exchange"
+    Then I should see "Stargate SG-1"
+      But I should not see "Stargate Atlantis"
+
+    When it is currently 61 minutes from now
+      And I view the sign-up summary for "Exchange"
+    Then I should see "Stargate SG-1"
+      And I should see "Stargate Atlantis"
+      And I jump in our Delorean and return to the present

--- a/features/gift_exchanges/signup_summary.feature
+++ b/features/gift_exchanges/signup_summary.feature
@@ -9,13 +9,13 @@ Feature: Gift Exchange Signup Summary
     When I am logged in as "testuser1"
       And I sign up for "Exchange" with combination C
       And I view the sign-up summary for "Exchange"
-    Then I should see "Stargate SG-1"
+    Then I should see "Stargate SG-1 1 1"
 
     When I am logged in as "testuser2"
       And I sign up for "Exchange" with combination D
       And I view the sign-up summary for "Exchange"
-    Then I should see "Stargate SG-1"
-      And I should see "Stargate Atlantis"
+    Then I should see "Stargate SG-1 1 1"
+      And I should see "Stargate Atlantis 1 1"
 
   Scenario: Updating a delayed summary
     Given signup summaries are always visible
@@ -26,16 +26,16 @@ Feature: Gift Exchange Signup Summary
     When I am logged in as "testuser1"
       And I sign up for "Exchange" with combination C
       And I view the sign-up summary for "Exchange"
-    Then I should see "Stargate SG-1"
+    Then I should see "Stargate SG-1 1 1"
 
     When I am logged in as "testuser2"
       And I sign up for "Exchange" with combination D
       And I view the sign-up summary for "Exchange"
-    Then I should see "Stargate SG-1"
+    Then I should see "Stargate SG-1 1 1"
       But I should not see "Stargate Atlantis"
 
     When it is currently 61 minutes from now
       And I view the sign-up summary for "Exchange"
-    Then I should see "Stargate SG-1"
-      And I should see "Stargate Atlantis"
+    Then I should see "Stargate SG-1 1 1"
+      And I should see "Stargate Atlantis 1 1"
       And I jump in our Delorean and return to the present

--- a/features/step_definitions/challenge_steps.rb
+++ b/features/step_definitions/challenge_steps.rb
@@ -126,7 +126,7 @@ When /^I start signing up for "([^\"]*)"$/ do |title|
   step %{I follow "Sign Up"}
 end
 
-When /^I view the sign-up summary for "([^"]*)"$/ do |title|
+When /^I view the sign-up summary for "(.*?)"$/ do |title|
   visit collection_path(Collection.find_by(title: title))
   step %(I follow "Sign-up Summary")
 end

--- a/features/step_definitions/challenge_steps.rb
+++ b/features/step_definitions/challenge_steps.rb
@@ -21,6 +21,21 @@ end
 
 ### CHALLENGE TAGS
 
+Given /^signup summaries are always visible$/ do
+  stub_const("ArchiveConfig", OpenStruct.new(ArchiveConfig))
+  ArchiveConfig.ANONYMOUS_THRESHOLD_COUNT = 0
+end
+
+Given /^all signup summaries are delayed$/ do
+  stub_const("ArchiveConfig", OpenStruct.new(ArchiveConfig))
+  ArchiveConfig.MAX_SIGNUPS_FOR_LIVE_SUMMARY = 0
+end
+
+Given /^all signup summaries are live$/ do
+  stub_const("ArchiveConfig", OpenStruct.new(ArchiveConfig))
+  ArchiveConfig.MAX_SIGNUPS_FOR_LIVE_SUMMARY = 1_000_000
+end
+
 Given /^I have standard challenge tags set ?up$/ do
   begin
     unless UserSession.find
@@ -109,6 +124,11 @@ end
 When /^I start signing up for "([^\"]*)"$/ do |title|
   visit collection_path(Collection.find_by(title: title))
   step %{I follow "Sign Up"}
+end
+
+When /^I view the sign-up summary for "([^"]*)"$/ do |title|
+  visit collection_path(Collection.find_by(title: title))
+  step %(I follow "Sign-up Summary")
 end
 
 ### Editing signups


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5382

## Purpose

This PR does the following:

1. It modifies the signup summary code so that it uses the Rails cache instead of the file system in order to generate the summary in background. This should ensure that the cached version is generated and saved in a place that's accessible to all servers, so that it can be displayed properly.

2. It moves all of the signup summary code into the `ChallengeSignupSummary` class.

3. In order to render the signup summary, it now uses [`ChallengeSignupsController.render`](https://api.rubyonrails.org/classes/ActionController/Renderer.html).

## Testing

Find or create a gift exchange with enough sign-ups to display a summary (and too many sign-ups to have the summary generated live), and make sure that the summary displays.