### PR TITLE
AO3-5488 Make ticket tracker URLs more configurable

### DIFF
--- a/app/models/feedback_reporters/abuse_reporter.rb
+++ b/app/models/feedback_reporters/abuse_reporter.rb
@@ -1,5 +1,5 @@
 class AbuseReporter < FeedbackReporter
-  PROJECT_PATH = "authtoken=#{ArchiveConfig.ABUSE_AUTH}&portal=ao3abuse&department=AO3%20Abuse"
+  PROJECT_PATH = "authtoken=#{ArchiveConfig.ABUSE_AUTH}&portal=#{ArchiveConfig.ABUSE_PORTAL}&department=#{ArchiveConfig.ABUSE_DEPARTMENT}"
   attr_accessor :ip_address
 
   def template

--- a/app/models/feedback_reporters/support_reporter.rb
+++ b/app/models/feedback_reporters/support_reporter.rb
@@ -1,5 +1,5 @@
 class SupportReporter < FeedbackReporter
-  PROJECT_PATH = "authtoken=#{ArchiveConfig.SUPPORT_AUTH}&portal=ao3support&department=Support"
+  PROJECT_PATH = "authtoken=#{ArchiveConfig.SUPPORT_AUTH}&portal=#{ArchiveConfig.SUPPORT_PORTAL}&department=#{ArchiveConfig.SUPPORT_DEPARTMENT}"
   attr_accessor :user_agent, :site_revision, :rollout
 
   def template

--- a/config/config.yml
+++ b/config/config.yml
@@ -326,12 +326,16 @@ AKISMET_NAME: 'http://transformativeworks.org'
 DEFENSIO_KEY: '521476c0edf3ac96eab7e297f6fb92c8'
 DEFENSIO_NAME: 'http://archiveofourown.org'
 
-# bug-reporting site for the archive -- we use 16bugs; if you use something else,
-# you will need to change feedbacks_controller.rb and abuse_reports_controller.rb
-# to properly send to your own support tool.
-BUGS_SITE: 'url for your 16bugs site like https://otw.16bugs.com'
-BUGS_USER: 'admin username for your 16bugs site which should only be put into your local.yml on your production server'
-BUGS_PASSWORD: 'admin password for your 16bugs site which should only be put into your local.yml on your production server'
+# Abuse and support ticket trackers; you may need to change
+# feedbacks_controller.rb and abuse_reports_controller.rb
+# to properly send to your own ticket tracker.
+NEW_BUGS_SITE: 'url for your 16bugs site like https://otw.16bugs.com'
+ABUSE_AUTH: 'authtoken'
+ABUSE_PORTAL: 'ao3abuse'
+ABUSE_DEPARTMENT: 'AO3%20Abuse'
+SUPPORT_AUTH: 'authtoken'
+SUPPORT_PORTAL: 'ao3support'
+SUPPORT_DEPARTMENT: 'Support'
 
 DEFAULT_LANGUAGE_SHORT: 'en'
 DEFAULT_LANGUAGE_NAME: 'English'


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5488

## Purpose

What it says on the tin. This will make it easier to switch Support to their paid account whenever they're ready.

In theory, we could just do ABUSE_PROJECT_PATH and SUPPORT_PROJECT_PATH and call it a day, but iirc, we originally avoided that because the whole long path (`authtoken=keysmash123&portal=ao3abuse&department=AO3%20Abuse`) would be a longer string to hunt for typos in in the event of brokenness.

## Testing

Refer to Jira