### PR TITLE
Ignore vulnerability in ruby-ffi 1.9.18

### DIFF
--- a/script/gem_security.sh
+++ b/script/gem_security.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 TMP=/tmp/audit.$$
 bundle-audit update
-bundle-audit check  > $TMP
+bundle-audit check --ignore CVE-2018-1000201 > $TMP
 if [ "`cat $TMP |wc -l`" != "1" ]; then
    cat $TMP
    echo "Please either update gem or if that is not possible update ignore list in"


### PR DESCRIPTION
## Issue

None.

## Purpose

This only affects Windows, and the gem will be removed when we switch from Authlogic to Devise.

## Testing

None, automated.

## References

See also #3378.