### PR TITLE
AO3-5529 Order collected works by date updated by default

### DIFF
--- a/app/models/search/work_query.rb
+++ b/app/models/search/work_query.rb
@@ -271,7 +271,7 @@ class WorkQuery < Query
 
   # When searching outside of filters, use relevance instead of date
   def default_sort
-    facet_tags? ? 'revised_at' : '_score'
+    facet_tags? || collected? ? 'revised_at' : '_score'
   end
 
   def aggregations

--- a/app/models/search/work_search_form.rb
+++ b/app/models/search/work_search_form.rb
@@ -196,7 +196,7 @@ class WorkSearchForm
   end
 
   def sort_options
-    options[:faceted] ? SORT_OPTIONS[1..-1] : SORT_OPTIONS
+    options[:faceted] || options[:collected] ? SORT_OPTIONS[1..-1] : SORT_OPTIONS
   end
 
   def sort_values
@@ -209,7 +209,7 @@ class WorkSearchForm
   end
 
   def default_sort_column
-    options[:faceted] ? 'revised_at' : '_score'
+    options[:faceted] || options[:collected] ? 'revised_at' : '_score'
   end
 
   def default_sort_direction


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5529

## Purpose

We accidentally started ordering users' collected works pages by score, not date updated. This puts it back.

## Testing

Refer to Jira.

## Credit

@redsummernight did the app/models/search/work_search_form.rb changes.
