### PR TITLE
AO3-5531 Don't use hidden field for abuse report IP, plus fix live validation

### DIFF
--- a/app/controllers/abuse_reports_controller.rb
+++ b/app/controllers/abuse_reports_controller.rb
@@ -9,7 +9,7 @@ class AbuseReportsController < ApplicationController
       @abuse_report.email = reporter.email
       @abuse_report.username = reporter.login
     end
-    @abuse_report.url = params[:url] || request.env['HTTP_REFERER']
+    @abuse_report.url = params[:url] || request.env["HTTP_REFERER"]
   end
 
   def create
@@ -17,10 +17,10 @@ class AbuseReportsController < ApplicationController
     @abuse_report.ip_address = request.remote_ip
     if @abuse_report.save
       @abuse_report.email_and_send
-      flash[:notice] = ts('Your abuse report was sent to the Abuse team.')
-      redirect_to ''
+      flash[:notice] = ts("Your abuse report was sent to the Abuse team.")
+      redirect_to root_path
     else
-      render action: 'new'
+      render action: "new"
     end
   end
 

--- a/app/controllers/abuse_reports_controller.rb
+++ b/app/controllers/abuse_reports_controller.rb
@@ -14,6 +14,7 @@ class AbuseReportsController < ApplicationController
 
   def create
     @abuse_report = AbuseReport.new(abuse_report_params)
+    @abuse_report.ip_address = request.remote_ip
     if @abuse_report.save
       @abuse_report.email_and_send
       flash[:notice] = ts('Your abuse report was sent to the Abuse team.')

--- a/app/views/abuse_reports/new.html.erb
+++ b/app/views/abuse_reports/new.html.erb
@@ -42,7 +42,6 @@
         <p class='footnote' id='email-field-description'>
           <%= ts("We cannot act on reports without a valid email address.") %>
         </p>
-        <%= f.hidden_field :ip_address, value: request.remote_ip %>
       </dd>
       <dt class="required">
         <%= f.label :language, ts("Select language (required)") %>

--- a/app/views/abuse_reports/new.html.erb
+++ b/app/views/abuse_reports/new.html.erb
@@ -8,27 +8,27 @@
 
 <!--main content-->
 <div class="userstuff">
-  <p><%= ts('The Abuse committee looks after all of your concerns regarding content and user behavior which breach the
-           Archive %{tos_link}. For technical help, please contact %{support_link}.',
+  <p><%= ts("The Abuse committee looks after all of your concerns regarding content and user behavior which breach the
+           Archive %{tos_link}. For technical help, please contact %{support_link}.",
             tos_link: (link_to ts("Terms of Service"), tos_path), support_link: (link_to ts("Support"),
                                                                                          new_feedback_report_path)).html_safe %></p>
-  <p><%= ts('<strong>We investigate every report we receive.</strong> For this reason, we ask you to not submit several
+  <p><%= ts("<strong>We investigate every report we receive.</strong> For this reason, we ask you to not submit several
            reports regarding any one issue unless you have additional information to offer. We also ask that you do not
            encourage other users to submit a report regarding content you have already reported. Doing so slows down our
-           response and reaction time considerably, as we are a small volunteer-based committee.').html_safe %></p>
+           response and reaction time considerably, as we are a small volunteer-based committee.").html_safe %></p>
   <p>
-    <%= ts('Please submit a report via this form if you have not submitted this report within the past fourteen (14) days,
-          and you:') %>
+    <%= ts("Please submit a report via this form if you have not submitted this report within the past fourteen (14) days,
+          and you:") %>
   </p>
   <ul>
-    <li><%= ts('would like to contact us regarding your %{fnok}, or', fnok: (link_to ts('Fannish Next of Kin'), tos_faq_path(anchor: 'next_of_kin'))).html_safe %></li>
-    <li><%= ts('have lost or forgotten your login details, or') %></li>
-    <li><%= ts('believe you have found content uploaded to the Archive which breaches our Terms of Service, or') %></li>
-    <li><%= ts('would like to lodge a DMCA claim - please review our %{dmca_link}', dmca_link:
-            (link_to ts('DMCA Policy'), dmca_path)).html_safe %></li>
+    <li><%= ts("would like to contact us regarding your %{fnok}, or", fnok: (link_to ts("Fannish Next of Kin"), tos_faq_path(anchor: "next_of_kin"))).html_safe %></li>
+    <li><%= ts("have lost or forgotten your login details, or") %></li>
+    <li><%= ts("believe you have found content uploaded to the Archive which breaches our Terms of Service, or") %></li>
+    <li><%= ts("would like to lodge a DMCA claim - please review our %{dmca_link}", dmca_link:
+            (link_to ts("DMCA Policy"), dmca_path)).html_safe %></li>
   </ul>
-  <p><%= ts('<strong>We can answer Abuse reports in %{list}.</strong> Please allow for an additional delay for responses
-            in any language other than English.', list: @abuse_languages.map(&:name).to_sentence).html_safe %></p>
+  <p><%= ts("<strong>We can answer Abuse reports in %{list}.</strong> Please allow for an additional delay for responses
+            in any language other than English.", list: @abuse_languages.map(&:name).to_sentence).html_safe %></p>
 </div>
 <%= form_for @abuse_report, class: "post" do |f| %>
   <fieldset>
@@ -36,10 +36,10 @@
     <dl>
       <dt><%= f.label :username, ts("Your name (optional)") %></dt>
       <dd><%= f.text_field :username %></dd>
-      <dt class="required"><%= f.label :email, ts('Your email (required)') %></dt>
+      <dt class="required"><%= f.label :email, ts("Your email (required)") %></dt>
       <dd class="required">
-        <%= f.text_field :email, 'aria-describedby' => 'email-field-description' %>
-        <p class='footnote' id='email-field-description'>
+        <%= f.text_field :email, "aria-describedby" => "email-field-description" %>
+        <p class="footnote" id="email-field-description">
           <%= ts("We cannot act on reports without a valid email address.") %>
         </p>
       </dd>
@@ -54,15 +54,15 @@
       </dt>
       <dd class="required">
         <%= f.text_field :summary, class: "observe_textlength" %>
-        <%= generate_countdown_html("feedback_summary", ArchiveConfig.FEEDBACK_SUMMARY_MAX_DISPLAYED) %>
-        <%= live_validation_for_field('feedback_summary',
+        <%= generate_countdown_html("abuse_report_summary", ArchiveConfig.FEEDBACK_SUMMARY_MAX_DISPLAYED) %>
+        <%= live_validation_for_field("abuse_report_summary",
                                       failureMessage: ts("Please enter a brief summary of your message")) %>
       </dd>
 
       <dt class="required"><%= f.label :url, ts("Link to the page you are reporting (required)") %></dt>
       <dd class="required">
         <%= f.text_field :url, size: 60, "aria-describedby" => "url-field-description" %>
-        <%= live_validation_for_field('abuse_report_url',
+        <%= live_validation_for_field("abuse_report_url",
               failureMessage: ts("Please enter the link to the page you are reporting.")) %>
         <p class="footnote" id="url-field-description">
           <%= ts("If you came here from the abuse link at the bottom of the page, this will be filled in for you.") %>
@@ -73,12 +73,12 @@
       </dt>
       <dd class="required">
         <p id="comment-field-description">
-          <%= ts('Please include all relevant URLs and what about the content violates the Archive %{tos_link}. The more
-              thorough the information the quicker we can start investigating.',
+          <%= ts("Please include all relevant URLs and what about the content violates the Archive %{tos_link}. The more
+              thorough the information the quicker we can start investigating.",
                   tos_link: (link_to ts("Terms of Service"), tos_path)).html_safe %>
         </p>
         <%= f.text_area :comment, "aria-describedby" => "comment-field-description" %>
-        <%= live_validation_for_field('abuse_report_comment',
+        <%= live_validation_for_field("abuse_report_comment",
               failureMessage: ts("Please describe your concern.")) %>
       </dd>
       <dt class="landmark"><%= ts("Send to Abuse Team") %></dt>


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5531

## Purpose

* Gets the IP address for abuse reports in the controller and not via a hidden field, which was subject to manipulation
* Fixes the LiveValidation on the "Brief summary of Terms of Service violation" field
* Updates the quotation marks
* Writers out `root_path` for the redirect instead of using `''` because 😭 old code

I can move any of that to separate, lower priority pull requests as long as we don't mind increasing the pile.

## Testing

Refer to Jira
