### PR TITLE
AO3-5534 Encode form data in PAC/Support ticket requests

### DIFF
--- a/app/models/feedback_reporters/feedback_reporter.rb
+++ b/app/models/feedback_reporters/feedback_reporter.rb
@@ -26,7 +26,7 @@ class FeedbackReporter
 
   def send_report!
     HTTParty.post("#{ArchiveConfig.NEW_BUGS_SITE}#{project_path}",
-                  body: "&xml=#{xml.to_str}")
+                  body: "&xml=#{URI.encode_www_form_component(xml.to_str)}")
   end
 
   def xml


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5534

## Purpose

The request body is application/x-www-form-urlencoded which means plus signs need to be percent-encoded or they will be interpreted as spaces.

## Testing

See issue.

## Credit

@sarken, who tried out the fix locally.