### PR TITLE
AO3-5527 Prevent users from using invitations that were previously used by a deleted user.

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -348,7 +348,7 @@ class UsersController < ApplicationController
       if !invitation
         flash[:error] = ts('There was an error with your invitation token, please contact support')
         redirect_to new_feedback_report_path
-      elsif invitation.redeemed_at && invitation.invitee
+      elsif invitation.redeemed_at
         flash[:error] = ts('This invitation has already been used to create an account, sorry!')
         redirect_to root_path
       end


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5527

## Purpose

In the existing code, the error message "This invitation has already been used to create an account, sorry!" doesn't appear when the user has been deleted because it checks
```
invitation.redeemed_at && invitation.invitee
```
However, `invitation.invitee` is a polymorphic field based on `invitation.invitee_id` and `invitation.invitee_type`, so it will only be non-nil if the invitee (that is, the user account previously created) still exists in the database.

This PR changes that check so that it only examines `invitation.redeemed_at`. As far as I can tell, this matches the behavior in other locations:

https://github.com/otwcode/otwarchive/blob/db06765a8cfa5d300efabcbc33f4e39302aaf1a3/app/models/invitation.rb#L23

https://github.com/otwcode/otwarchive/blob/db06765a8cfa5d300efabcbc33f4e39302aaf1a3/app/views/invitations/_invitation.html.erb#L7-L7

https://github.com/otwcode/otwarchive/blob/db06765a8cfa5d300efabcbc33f4e39302aaf1a3/app/views/invitations/_user_invitations.html.erb#L21-L26

## Testing

See JIRA.