### PR TITLE
AO3-4681 Add success message when deleting wrangling guideline

### DIFF
--- a/app/controllers/wrangling_guidelines_controller.rb
+++ b/app/controllers/wrangling_guidelines_controller.rb
@@ -63,7 +63,7 @@ class WranglingGuidelinesController < ApplicationController
   def destroy
     @wrangling_guideline = WranglingGuideline.find(params[:id])
     @wrangling_guideline.destroy
-
+    flash[:notice] = ts('Wrangling Guideline was successfully deleted.')
     redirect_to(wrangling_guidelines_path)
   end
 

--- a/features/tags_and_wrangling/wrangling_guidelines.feature
+++ b/features/tags_and_wrangling/wrangling_guidelines.feature
@@ -43,9 +43,10 @@ Feature: Wrangling Guidelines
     And I should see "3. The 1 Wrangling Guideline"
 
   Scenario: Delete Wrangling Guideline
-  
+
   Given I am logged in as an admin
     And I have posted a Wrangling Guideline titled "Relationship Tags"
   When I go to the Wrangling Guidelines page
     And I follow "Delete"
-  Then I should not see "Relationship Tags"
+  Then I should see "Wrangling Guideline was successfully deleted"
+    And I should not see "Relationship Tags"


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-4681

## Purpose

show confirmation that wrangling guidelines were successfully deleted, update wrangling guideline test

## Testing

1. Log in as admin
2. Admin Posts > Wrangling Guidelines > New Wrangling Guideline
3. Fill in required fields
4. Post
5. Follow "Wrangling Guidelines" link to return to list of guidelines
6. Select "Delete" for the guideline you just posted
7. Choose "OK" in the confirmation dialogue
8. You should see a confirmation message `Wrangling Guideline was successfully deleted.`