### PR TITLE
AO3-5198 remove user-facing count on all skins

### DIFF
--- a/app/views/skins/_header.html.erb
+++ b/app/views/skins/_header.html.erb
@@ -26,8 +26,6 @@
   </blockquote>
 
   <dl class="stats">
-    <dt><%= ts('Users:') %></dt>
-    <dd><%= @skin.preferences.count %></dd>
     <dt><%= ts('Role:') %></dt>
     <dd><%= @skin.role %></dd>
     <dt><%= ts('Media:') %></dt>


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5198

## Purpose

remove the user count on all archive skins, since work counts sometimes display inaccurate numbers and it's not important enough to fix

## Testing

1) visit https://archiveofourown.org/skins?skin_type=Site
2) click on any random skin and confirm there's no `Users: ###` count in the info
3) do the same for a work skin https://archiveofourown.org/skins?skin_type=WorkSkin