### PR TITLE
AO3-4682 add success message when unassigning wrangler from a fandom

### DIFF
--- a/app/controllers/tag_wranglers_controller.rb
+++ b/app/controllers/tag_wranglers_controller.rb
@@ -85,6 +85,7 @@ class TagWranglersController < ApplicationController
     wrangler = User.find_by(login: params[:id])
     assignment = WranglingAssignment.where(user_id: wrangler.id, fandom_id: params[:fandom_id]).first
     assignment.destroy
+    flash[:notice] = "Wranglers were successfully unassigned!"
     redirect_to tag_wranglers_path(media_id: params[:media_id], fandom_string: params[:fandom_string], wrangler_id: params[:wrangler_id])
   end
 end

--- a/features/tags_and_wrangling/tag_wrangling_admin.feature
+++ b/features/tags_and_wrangling/tag_wrangling_admin.feature
@@ -26,7 +26,7 @@ Feature: Tag wrangling
     Then I should see "tangler" within "#admin_users_table"
     When I uncheck the "Tag Wrangler" role checkbox
       And I press "Update"
-    Then I should see "User was successfully updated." 
+    Then I should see "User was successfully updated."
       And "tangler" should not be a tag wrangler
       And "Testing" should be assigned to the wrangler "tangler"
 
@@ -36,6 +36,7 @@ Feature: Tag wrangling
     When I am logged in as an admin
       And I am on the wranglers page
       And I follow "x"
-    Then "Testing" should not be assigned to the wrangler "tangler"
+    Then I should see "Wranglers were successfully unassigned!"
+      And "Testing" should not be assigned to the wrangler "tangler"
     When I edit the tag "Testing"
     Then I should see "Sign Up"

--- a/features/tags_and_wrangling/tag_wrangling_more.feature
+++ b/features/tags_and_wrangling/tag_wrangling_more.feature
@@ -22,7 +22,7 @@ Feature: Tag wrangling: assigning wranglers, using the filters on the Wranglers 
     Then I should see "Edit"
     When I follow "Edit" within ".header"
     Then I should see "Edit first fandom Tag"
-    
+
     # assigning media to a fandom
     When I fill in "tag[media_string]" with "TV Shows"
       And I press "Save changes"
@@ -33,7 +33,7 @@ Feature: Tag wrangling: assigning wranglers, using the filters on the Wranglers 
     When I follow "Wranglers"
     Then I should see "Tag Wrangling Assignments"
       And I should see "first fandom"
-    
+
     # assigning a fandom to oneself
     When I fill in "tag_fandom_string" with "first fandom"
       And I press "Assign"
@@ -42,7 +42,7 @@ Feature: Tag wrangling: assigning wranglers, using the filters on the Wranglers 
     Then I should see "first fandom"
       And I should see "dizmo" within "ul.wranglers"
     Given I add the fandom "first fandom" to the character "Person A"
-    
+
     # checking that wrangling home shows unfilterables
     When I follow "Wrangling Home"
     Then I should see "first fandom"
@@ -50,11 +50,11 @@ Feature: Tag wrangling: assigning wranglers, using the filters on the Wranglers 
     When I follow "first fandom"
     Then I should see "Wrangle Tags for first fandom"
       And I should see "Characters (1)"
-    
+
     When I log out
       And I am logged in as "Enigel" with password "wrangulator"
       And I follow "Tag Wrangling"
-    
+
     # assigning another wrangler to a fandom
     When I follow "Wranglers"
       And I fill in "fandom_string" with "Ghost"
@@ -88,7 +88,8 @@ Feature: Tag wrangling: assigning wranglers, using the filters on the Wranglers 
       And I am logged in as "tangler" with password "wr@ngl3r"
     When I am on the wranglers page
       And I follow "x"
-    Then "Testing" should not be assigned to the wrangler "tangler"
+    Then I should see "Wranglers were successfully unassigned!"
+      And "Testing" should not be assigned to the wrangler "tangler"
     When I edit the tag "Testing"
     Then I should see "Sign Up"
 
@@ -101,7 +102,8 @@ Feature: Tag wrangling: assigning wranglers, using the filters on the Wranglers 
     When I am logged in as "wranglerette"
       And I am on the wranglers page
       And I follow "x"
-    Then "Testing" should not be assigned to the wrangler "tangler"
+    Then I should see "Wranglers were successfully unassigned!"
+      And "Testing" should not be assigned to the wrangler "tangler"
     When I edit the tag "Testing"
     Then I should see "Sign Up"
 


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-4682

## Purpose

adds a confirmation message when wranglers have successfully been unassigned from fandom. mimics the `wranglers successfully assigned` confirmation message. updates tests in:

`tag_wrangling_admin.feature`
`tag_wrangling_more.feature`

## Testing

1. Log in as an admin or Tag Wrangler
2. Go to the Wranglers page: http://test.archiveofourown.org/tag_wranglers
3. Choose the "x" next to a wrangler's name to unassigned them from a fandom
4. If the action was successful, you should see a `Wranglers were successfully unassigned!` confirmation message