### PR TITLE
AO3-3507 exclude RSS Feed button from filtered results

### DIFF
--- a/app/views/works/index.html.erb
+++ b/app/views/works/index.html.erb
@@ -33,7 +33,7 @@
         <% if @tag && logged_in? && !@collection %>
           <li><%= render 'favorite_tags/form', current_user: @current_user, favorite_tag: @favorite_tag %></li>
         <% end %>
-        <% if @tag && !@collection && (%w(Fandom Character Relationship).include?(@tag.type.to_s) || @tag.name == "F/F") %>
+        <% if @tag && !@collection && !params[:work_search] && (%w(Fandom Character Relationship).include?(@tag.type.to_s) || @tag.name == "F/F") %>
           <li><%= link_to_rss feed_tag_path(:id => @tag.id, :format => :atom) %></li>
         <% end %>
       </ul>
@@ -69,4 +69,3 @@
 <% if @works.respond_to?(:total_pages) %>
   <%= will_paginate @works %>
 <% end %>
-


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-3507

## Purpose

removes RSS feed button from filtered pages, but not from admin pages or unfiltered tags

## Testing

confirm that RSS feed button has been removed from filtered work result pages, but not from admin pages or unfiltered work results