### PR TITLE
AO3-4881 wrangling admin: move "last updated by" paragraph under navigation

### DIFF
--- a/app/views/tags/edit.html.erb
+++ b/app/views/tags/edit.html.erb
@@ -10,7 +10,7 @@
 <!--main content-->
 
 <% if logged_in_as_admin? %>
-  <p><%= ts("Last updated by") %> <%= @tag.last_wrangler.try(:login) || '---' %> <%= ts("on") %> <%= @tag.updated_at %></p>
+  <p><%= ts("Last updated by %{wrangler} on %{date}", wrangler: @tag.last_wrangler.try(:login) || '---', date: @tag.updated_at) %></p>
 <% end %>
 
 <%= form_for @tag, :as => :tag, :url => { :action => "update", :id => @tag}, :html => { :method => :put } do |f| %>

--- a/app/views/tags/edit.html.erb
+++ b/app/views/tags/edit.html.erb
@@ -9,6 +9,10 @@
 
 <!--main content-->
 
+<% if logged_in_as_admin? %>
+  <p><%= ts("Last updated by") %> <%= @tag.last_wrangler.try(:login) || '---' %> <%= ts("on") %> <%= @tag.updated_at %></p>
+<% end %>
+
 <%= form_for @tag, :as => :tag, :url => { :action => "update", :id => @tag}, :html => { :method => :put } do |f| %>
 
   <fieldset>
@@ -185,9 +189,6 @@
   </fieldset>
 <% end %>
 
-<% if logged_in_as_admin? %>
-  <p><%= ts("Last updated by") %> <%= @tag.last_wrangler.try(:login) || '---' %> <%= ts("on") %> <%= @tag.updated_at %></p>
-<% end %>
 <!--/content-->
 
 <!--subnav-->


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-4881

## Purpose

moves the `last updated by` paragraph on tag edit pages to the top for convenience

## Testing

1. Log in as admin
2. Go to a tag's edit page, e.g. http://test.archiveofourown.org/tags/Testing/edit
3. Confirm the `last updated by xxx` information is now at the top of the page on all screen sizes as opposed to the bottom of the page 