### PR TITLE
AO3-5527 Reset invitations for purged accounts.

### DIFF
--- a/lib/tasks/admin_tasks.rake
+++ b/lib/tasks/admin_tasks.rake
@@ -20,6 +20,13 @@ namespace :admin do
     puts users.map(&:login).join(", ")
     users.map(&:destroy)
     puts "Unvalidated accounts created more than two weeks ago have been purged"
+
+    # Purged users are allowed to reuse their invitations:
+    invite_ids = users.map(&:invitation_id)
+    Invitation.includes(:creator).where(id: invite_ids).each do |invite|
+      invite.update(redeemed_at: nil, invitee: nil)
+    end
+    puts "Invitations for the purged accounts have been reset"
   end
 
 end

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'rake'
 
 describe UsersController do
   include RedirectExpectationHelper
@@ -62,7 +63,7 @@ describe UsersController do
       end
 
       context "signing up with a valid invitation" do
-        it "succeeeds in creating the account" do
+        it "succeeds in creating the account" do
           post :create, params: { user: valid_user_attributes,
                                   invitation_token: invitation.token }
 
@@ -104,6 +105,31 @@ describe UsersController do
               "This invitation has already been used to create an account, " \
               "sorry!"
             )
+          end
+        end
+
+        context "when the previous user's account was purged" do
+          before do
+            # Code for activating rake, adapted from
+            # spec/miscellaneous/lib/tasks/resque.rake_spec.rb
+            @rake = Rake.application
+            @rake.init
+            @rake.load_rakefile
+
+            # Make sure the previous user's account fits the requirements to be
+            # purged by the task:
+            previous_user.update(activated_at: nil, created_at: 1.month.ago)
+            @rake["admin:purge_unvalidated_users"].invoke
+          end
+
+          it "succeeds in creating the account" do
+            post :create, params: { user: valid_user_attributes,
+                                    invitation_token: invitation.token }
+
+            expect(response).to be_success
+            expect(assigns(:user)).to be_a(User)
+            expect(assigns(:user)).to eq(User.last)
+            expect(assigns(:user).login).to eq("myname")
           end
         end
       end


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5527

## Purpose

My fix for the issue of invitations used on deleted accounts made it so that users who sign up, fail to confirm their account within the 2 week deadline, and subsequently have their account purged will not be able to reuse their invitations. But we want them to be able to reuse their invitations, so this PR adds a few lines to the account-purging rake task to reset the invitations for any purged accounts.

## Testing

This one's probably a bit tricky to test manually unless you have a two-week old unconfirmed account lying around, or you're willing to wait two weeks for QA. You might consider creating an unconfirmed account, then using the Rails console to update its `created_at` date so that it's caught in the next purge.