### PR TITLE
Ignore vulnerability in nokogiri 1.8.3

### DIFF
--- a/script/gem_security.sh
+++ b/script/gem_security.sh
@@ -1,7 +1,9 @@
 #!/bin/sh
 TMP=/tmp/audit.$$
 bundle-audit update
-bundle-audit check --ignore CVE-2018-1000201 > $TMP
+# TODO remove CVE-2018-1000201 after AO3-2839
+# TODO remove CVE-2018-14404 after AO3-5543
+bundle-audit check --ignore CVE-2018-1000201 CVE-2018-14404 > $TMP
 if [ "`cat $TMP |wc -l`" != "1" ]; then
    cat $TMP
    echo "Please either update gem or if that is not possible update ignore list in"


### PR DESCRIPTION
## Issue

None.

## Purpose

Temporarily ignore this warning so builds can pass. We have an issue for the update later on.

## Testing

None.