### PR TITLE
AO3-5540 Altered regex in abuse_report.rb to accept alternate AO3 urls

### DIFF
--- a/app/models/abuse_report.rb
+++ b/app/models/abuse_report.rb
@@ -34,7 +34,7 @@ class AbuseReport < ApplicationRecord
     end
   end
 
-  app_url_regex = Regexp.new('^(https?:\/\/)?(www\.|(insecure\.))?(archiveofourown|ao3).(org|com).*', true)
+  app_url_regex = Regexp.new('^(https?:\/\/)?(www\.|(insecure\.))?(archiveofourown|ao3)\.(org|com).*', true)
   validates_format_of :url, with: app_url_regex,
                             message: ts('does not appear to be on this site.'),
                             multiline: true

--- a/app/models/abuse_report.rb
+++ b/app/models/abuse_report.rb
@@ -34,7 +34,7 @@ class AbuseReport < ApplicationRecord
     end
   end
 
-  app_url_regex = Regexp.new('^(https?:\/\/)?(www\.|(insecure\.))?(archiveofourown|ao3).(org|com)\/.*', true)
+  app_url_regex = Regexp.new('^(https?:\/\/)?(www\.|(insecure\.))?(archiveofourown|ao3).(org|com).*', true)
   validates_format_of :url, with: app_url_regex,
                             message: ts('does not appear to be on this site.'),
                             multiline: true

--- a/app/models/abuse_report.rb
+++ b/app/models/abuse_report.rb
@@ -34,8 +34,7 @@ class AbuseReport < ApplicationRecord
     end
   end
 
-  app_url_regex = Regexp.new('^https?:\/\/(www\.|insecure\.)?' +
-                             ArchiveConfig.APP_HOST, true)
+  app_url_regex = Regexp.new('^(https?:\/\/)?(www\.|(insecure\.))?(archiveofourown|ao3).(org|com)\/.*', true)
   validates_format_of :url, with: app_url_regex,
                             message: ts('does not appear to be on this site.'),
                             multiline: true

--- a/spec/models/abuse_report_spec.rb
+++ b/spec/models/abuse_report_spec.rb
@@ -57,6 +57,26 @@ describe AbuseReport do
     end
   end
 
+  context "alternate url" do
+    let(:no_protocol){build(:abuse_report, url: "archiveofourown.org")}
+    it "no protocol" do
+      expect(no_protocol.save).to be_truthy
+      expect(no_protocol.errors[:url]).to be_empty
+    end
+
+    let(:dot_com){build(:abuse_report, url: "http://archiveofourown.com")}
+    it "dot com" do
+      expect(dot_com.save).to be_truthy
+      expect(dot_com.errors[:url]).to be_empty
+    end
+
+    let(:acronym){build(:abuse_report, url: "http://ao3.org")}
+    it "acronym" do
+      expect(acronym.save).to be_truthy
+      expect(acronym.errors[:url]).to be_empty
+    end
+  end
+
   context "emailed copy" do
     let(:no_email_provided) { build(:abuse_report, email: nil) }
     it "is invalid if an email is not provided" do

--- a/spec/models/abuse_report_spec.rb
+++ b/spec/models/abuse_report_spec.rb
@@ -58,19 +58,19 @@ describe AbuseReport do
   end
 
   context "alternate url" do
-    let(:no_protocol){build(:abuse_report, url: "archiveofourown.org")}
+    let(:no_protocol) { build(:abuse_report, url: "archiveofourown.org") }
     it "no protocol" do
       expect(no_protocol.save).to be_truthy
       expect(no_protocol.errors[:url]).to be_empty
     end
 
-    let(:dot_com){build(:abuse_report, url: "http://archiveofourown.com")}
+    let(:dot_com) { build(:abuse_report, url: "http://archiveofourown.com") }
     it "dot com" do
       expect(dot_com.save).to be_truthy
       expect(dot_com.errors[:url]).to be_empty
     end
 
-    let(:acronym){build(:abuse_report, url: "http://ao3.org")}
+    let(:acronym) { build(:abuse_report, url: "http://ao3.org") }
     it "acronym" do
       expect(acronym.save).to be_truthy
       expect(acronym.errors[:url]).to be_empty


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5540 

## Purpose

This PR fixes an issue where the abuse report form was unnecessarily strict on submitted urls. The form should now match urls of the form

* archiveofourown.org/users/cjrecord (no https://)
* https://archiveofourown.com/users/cjrecord (.com in place of .org)
* https://ao3.org/users/cjrecord (ao3 in place of archiveofourown)
and combinations thereof

## Testing

Try submitting an abuse report with any of the above types of urls!

## Credit

* Name: Lee
* Pronouns: She/her
