### PR TITLE
AO3-5438 fix prompt email typo

### DIFF
--- a/app/models/abuse_report.rb
+++ b/app/models/abuse_report.rb
@@ -34,7 +34,7 @@ class AbuseReport < ApplicationRecord
     end
   end
 
-  app_url_regex = Regexp.new('^(https?:\/\/)?(www\.|(insecure\.))?(archiveofourown|ao3).(org|com).*', true)
+  app_url_regex = Regexp.new('^(https?:\/\/)?(www\.|(insecure\.))?(archiveofourown|ao3)\.(org|com).*', true)
   validates_format_of :url, with: app_url_regex,
                             message: ts('does not appear to be on this site.'),
                             multiline: true

--- a/app/models/abuse_report.rb
+++ b/app/models/abuse_report.rb
@@ -34,7 +34,7 @@ class AbuseReport < ApplicationRecord
     end
   end
 
-  app_url_regex = Regexp.new('^(https?:\/\/)?(www\.|(insecure\.))?(archiveofourown|ao3).(org|com)\/.*', true)
+  app_url_regex = Regexp.new('^(https?:\/\/)?(www\.|(insecure\.))?(archiveofourown|ao3).(org|com).*', true)
   validates_format_of :url, with: app_url_regex,
                             message: ts('does not appear to be on this site.'),
                             multiline: true

--- a/app/models/abuse_report.rb
+++ b/app/models/abuse_report.rb
@@ -34,8 +34,7 @@ class AbuseReport < ApplicationRecord
     end
   end
 
-  app_url_regex = Regexp.new('^https?:\/\/(www\.|insecure\.)?' +
-                             ArchiveConfig.APP_HOST, true)
+  app_url_regex = Regexp.new('^(https?:\/\/)?(www\.|(insecure\.))?(archiveofourown|ao3).(org|com)\/.*', true)
   validates_format_of :url, with: app_url_regex,
                             message: ts('does not appear to be on this site.'),
                             multiline: true

--- a/app/views/user_mailer/prompter_notification.html.erb
+++ b/app/views/user_mailer/prompter_notification.html.erb
@@ -5,7 +5,7 @@
 
   <p>
     <% if @collection.nil? %>
-      <i><b><%= style_link(@work.title.html_safe, work_url(@work)) %></b></i> %> (<%= @work.word_count %> words)
+      <i><b><%= style_link(@work.title.html_safe, work_url(@work)) %></b></i> (<%= @work.word_count %> words)
     <% else %>
       <i><b><%= style_link(@work.title.html_safe, collection_work_url(@collection, @work)) %></b></i> (<%= @work.word_count %> words)
     <% end %>

--- a/spec/models/abuse_report_spec.rb
+++ b/spec/models/abuse_report_spec.rb
@@ -57,6 +57,26 @@ describe AbuseReport do
     end
   end
 
+  context "alternate url" do
+    let(:no_protocol){build(:abuse_report, url: "archiveofourown.org")}
+    it "no protocol" do
+      expect(no_protocol.save).to be_truthy
+      expect(no_protocol.errors[:url]).to be_empty
+    end
+
+    let(:dot_com){build(:abuse_report, url: "http://archiveofourown.com")}
+    it "dot com" do
+      expect(dot_com.save).to be_truthy
+      expect(dot_com.errors[:url]).to be_empty
+    end
+
+    let(:acronym){build(:abuse_report, url: "http://ao3.org")}
+    it "acronym" do
+      expect(acronym.save).to be_truthy
+      expect(acronym.errors[:url]).to be_empty
+    end
+  end
+
   context "emailed copy" do
     let(:no_email_provided) { build(:abuse_report, email: nil) }
     it "is invalid if an email is not provided" do

--- a/spec/models/abuse_report_spec.rb
+++ b/spec/models/abuse_report_spec.rb
@@ -58,19 +58,19 @@ describe AbuseReport do
   end
 
   context "alternate url" do
-    let(:no_protocol){build(:abuse_report, url: "archiveofourown.org")}
+    let(:no_protocol) { build(:abuse_report, url: "archiveofourown.org") }
     it "no protocol" do
       expect(no_protocol.save).to be_truthy
       expect(no_protocol.errors[:url]).to be_empty
     end
 
-    let(:dot_com){build(:abuse_report, url: "http://archiveofourown.com")}
+    let(:dot_com) { build(:abuse_report, url: "http://archiveofourown.com") }
     it "dot com" do
       expect(dot_com.save).to be_truthy
       expect(dot_com.errors[:url]).to be_empty
     end
 
-    let(:acronym){build(:abuse_report, url: "http://ao3.org")}
+    let(:acronym) { build(:abuse_report, url: "http://ao3.org") }
     it "acronym" do
       expect(acronym.save).to be_truthy
       expect(acronym.errors[:url]).to be_empty


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5438

## Purpose

This PR fixes a typo which caused the HTML version of the "A Response to your Prompt" email to have an extra %> after work title. 

## Testing

Try having someone fill your prompt, and see your nice clean email!

## Credit

* Name: Lee
* Pronouns: she/her
