### PR TITLE
AO3-5438 fix typo in prompter_notification.html.erb 

### DIFF
--- a/app/views/user_mailer/prompter_notification.html.erb
+++ b/app/views/user_mailer/prompter_notification.html.erb
@@ -5,7 +5,7 @@
 
   <p>
     <% if @collection.nil? %>
-      <i><b><%= style_link(@work.title.html_safe, work_url(@work)) %></b></i> %> (<%= @work.word_count %> words)
+      <i><b><%= style_link(@work.title.html_safe, work_url(@work)) %></b></i> (<%= @work.word_count %> words)
     <% else %>
       <i><b><%= style_link(@work.title.html_safe, collection_work_url(@collection, @work)) %></b></i> (<%= @work.word_count %> words)
     <% end %>


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5438 

## Purpose

This PR fixes a typo in prompter_notification.html.erb that caused the "A Response to your Prompt" email to have an extra %> after work title.

## Testing

Try to get someone to fill your prompt and see your shiny, clean email!

## Credit

Name: Lee
Pronouns: she/her
