### PR TITLE
AO3-4857 Fix anonymous creator comment message.

### DIFF
--- a/app/helpers/comments_helper.rb
+++ b/app/helpers/comments_helper.rb
@@ -318,7 +318,7 @@ module CommentsHelper
   def current_user_is_anonymous_creator(commentable)
     if logged_in?
       parent = find_parent(commentable)
-      parent.respond_to?(:work) && parent.anonymous? && current_user.is_author_of?(parent)
+      parent.is_a?(Work) && parent.anonymous? && current_user.is_author_of?(parent)
     end
   end
 

--- a/features/collections/collection_anonymity.feature
+++ b/features/collections/collection_anonymity.feature
@@ -318,3 +318,19 @@ Feature: Collection
       And subscription notifications are sent
 
     Then 0 emails should be delivered
+
+  Scenario: When a creator views their own anonymous work, they should see a message explaining that their comment will be anonymous, and their comment should be anonymous.
+
+    Given I have the anonymous collection "Anon Forever"
+      And I am logged in as "shy_author"
+      And I post the work "Hidden Masterpiece" to the collection "Anon Forever"
+
+    When I view the work "Hidden Masterpiece"
+    Then I should see "While this work is anonymous, comments you post will also be listed anonymously."
+
+    When I post a comment "Reply from the author."
+      And I am logged out
+      And I view the work "Hidden Masterpiece" with comments
+    Then I should see "Reply from the author."
+      And I should see "Anonymous Creator"
+      And I should not see "shy_author"


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-4857

## Purpose

It fixes the notice telling anonymous creators that their comments on their own works will be anonymous. When commenting on a chapter, `find_parent` returns the work, not the chapter, so `parent.respond_to?(:work)` would always return false. This changes it to check whether `parent.is_a?(Work)` instead (so that checking `parent.anonymous?` won't fail on e.g. Admin Posts).

## Testing Instructions

See JIRA.