### PR TITLE
AO3-5559 Rename bookmark notes, comment content, and series notes columns

### DIFF
--- a/app/controllers/api/v1/bookmarks_controller.rb
+++ b/app/controllers/api/v1/bookmarks_controller.rb
@@ -132,7 +132,7 @@ class Api::V1::BookmarksController < Api::V1::BaseController
         relationship_string: params[:relationship_string],
         character_string: params[:character_string]
       },
-      notes: params[:notes],
+      bookmarker_notes: params[:bookmarker_notes],
       tag_string: params[:tag_string],
       collection_names: params[:collection_names],
       private: params[:private].blank? ? false : params[:private],

--- a/app/controllers/api/v2/bookmarks_controller.rb
+++ b/app/controllers/api/v2/bookmarks_controller.rb
@@ -190,7 +190,7 @@ class Api::V2::BookmarksController < Api::V2::BaseController
         relationship_string: params[:relationship_string] || "",
         character_string: params[:character_string] || ""
       },
-      notes: params[:notes],
+      bookmarker_notes: params[:bookmarker_notes],
       tag_string: params[:tag_string] || "",
       collection_names: params[:collection_names],
       private: params[:private].blank? ? false : params[:private],

--- a/app/controllers/bookmarks_controller.rb
+++ b/app/controllers/bookmarks_controller.rb
@@ -363,7 +363,7 @@ class BookmarksController < ApplicationController
   def bookmark_params
     params.require(:bookmark).permit(
       :bookmarkable_id, :bookmarkable_type,
-      :pseud_id, :notes, :tag_string, :collection_names, :private, :rec,
+      :pseud_id, :bookmarker_notes, :tag_string, :collection_names, :private, :rec,
       external: [
         :url, :author, :title, :fandom_string, :rating_string, :relationship_string,
         :character_string, :summary, category_string: []

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -543,7 +543,7 @@ class CommentsController < ApplicationController
 
   def comment_params
     params.require(:comment).permit(
-      :pseud_id, :content, :name, :email, :edited_at
+      :pseud_id, :comment_content, :name, :email, :edited_at
     )
   end
 

--- a/app/controllers/series_controller.rb
+++ b/app/controllers/series_controller.rb
@@ -170,7 +170,7 @@ class SeriesController < ApplicationController
 
   def series_params
     params.require(:series).permit(
-      :title, :summary, :notes, :complete,
+      :title, :summary, :series_notes, :complete,
       author_attributes: [
         ids: [],
         coauthors: []

--- a/app/helpers/share_helper.rb
+++ b/app/helpers/share_helper.rb
@@ -48,7 +48,7 @@ module ShareHelper
   def get_embed_link_bookmark_meta(bookmark)
     if bookmark.bookmarkable.is_a?(Work)
       tags_text = add_label_for_embed(ts("Bookmarker's Tags: "), bookmark.tags.map {|tag| tag.name}.join(", "), tag("br"))
-      bookmark_text = add_label_for_embed(ts("Bookmarker's Notes: "), raw(sanitize_field(bookmark, :notes)))
+      bookmark_text = add_label_for_embed(ts("Bookmarker's Notes: "), raw(sanitize_field(bookmark, :bookmarker_notes)))
     end
   end
 

--- a/app/models/bookmark.rb
+++ b/app/models/bookmark.rb
@@ -10,7 +10,7 @@ class Bookmark < ApplicationRecord
   has_many :taggings, as: :taggable, dependent: :destroy
   has_many :tags, through: :taggings, source: :tagger, source_type: 'Tag'
 
-  validates_length_of :notes,
+  validates_length_of :bookmarker_notes,
     maximum: ArchiveConfig.NOTES_MAX, too_long: ts("must be less than %{max} letters long.", max: ArchiveConfig.NOTES_MAX)
 
   default_scope -> { order("bookmarks.id DESC") } # id's stand in for creation date
@@ -233,7 +233,7 @@ class Bookmark < ApplicationRecord
   end
 
   def with_notes
-    notes.present?
+    bookmarker_notes.present?
   end
 
   def bookmarkable_pseud_names

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -14,8 +14,8 @@ class Comment < ApplicationRecord
   validates_presence_of :name, unless: :pseud_id
   validates :email, email_veracity: {on: :create, unless: :pseud_id}, email_blacklist: {on: :create, unless: :pseud_id}
 
-  validates_presence_of :content
-  validates_length_of :content,
+  validates_presence_of :comment_content
+  validates_length_of :comment_content,
     maximum: ArchiveConfig.COMMENT_MAX,
     too_long: ts("must be less than %{count} characters long.", count: ArchiveConfig.COMMENT_MAX)
 
@@ -25,7 +25,7 @@ class Comment < ApplicationRecord
     errors.add(:base, ts("This comment looks like spam to our system, sorry! Please try again, or create an account to comment.")) unless check_for_spam?
   end
 
-  validates :content, uniqueness: {
+  validates :comment_content, uniqueness: {
     scope: [:commentable_id, :commentable_type, :name, :email, :pseud_id],
     unless: :is_deleted?,
     message: ts("^This comment has already been left on this work. (It may not appear right away for performance reasons.)")
@@ -52,7 +52,7 @@ class Comment < ApplicationRecord
       user_agent: user_agent,
       comment_author: name,
       comment_author_email: email,
-      comment_content: content
+      comment_content: comment_content
     }
   end
 
@@ -70,9 +70,9 @@ class Comment < ApplicationRecord
     users = []
     admins = []
 
-    if self.saved_change_to_edited_at? && self.saved_change_to_content? && self.moderated_commenting_enabled? && !self.is_creator_comment?
+    if self.saved_change_to_edited_at? && self.saved_change_to_comment_content? && self.moderated_commenting_enabled? && !self.is_creator_comment?
       # we might need to put it back into moderation
-      if content_too_different?(self.content, self.content_was)
+      if content_too_different?(self.comment_content, self.comment_content_was)
         # we use update_column because we don't want to invoke this callback again
         self.update_column(:unreviewed, true)
       end
@@ -398,7 +398,7 @@ class Comment < ApplicationRecord
   end
 
   def sanitized_content
-    sanitize_field self, :content
+    sanitize_field self, :comment_content
   end
   include Responder
 

--- a/app/models/search/bookmark_indexer.rb
+++ b/app/models/search/bookmark_indexer.rb
@@ -85,13 +85,14 @@ class BookmarkIndexer < Indexer
       root: false,
       only: [
         :id, :created_at, :bookmarkable_type, :bookmarkable_id, :user_id,
-        :notes, :private, :updated_at, :hidden_by_admin, :pseud_id, :rec
+        :private, :updated_at, :hidden_by_admin, :pseud_id, :rec
       ],
       methods: [:bookmarker, :collection_ids, :with_notes, :bookmarkable_date]
     ).merge(
       user_id: object.pseud&.user_id,
       tag: tags.map(&:name),
-      tag_ids: tags.map(&:id)
+      tag_ids: tags.map(&:id),
+      notes: object.bookmarker_notes
     )
 
     unless parent_id(object.id, object).match("deleted")

--- a/app/models/series.rb
+++ b/app/models/series.rb
@@ -40,7 +40,7 @@ class Series < ApplicationRecord
     maximum: ArchiveConfig.SUMMARY_MAX,
     too_long: ts("must be less than %{max} letters long.", max: ArchiveConfig.SUMMARY_MAX)
 
-  validates_length_of :notes,
+  validates_length_of :series_notes,
     allow_blank: true,
     maximum: ArchiveConfig.NOTES_MAX,
     too_long: ts("must be less than %{max} letters long.", max: ArchiveConfig.NOTES_MAX)

--- a/app/views/bookmarks/_bookmark_blurb_short.html.erb
+++ b/app/views/bookmarks/_bookmark_blurb_short.html.erb
@@ -28,10 +28,10 @@
     </ul>
   <% end %>
   <!--notes-->
-  <% unless bookmark.notes.blank? %>
+  <% unless bookmark.bookmarker_notes.blank? %>
     <h6 class="landmark heading"><%= ts("Bookmark Notes:") %></h6>
     <blockquote class="userstuff summary">
-      <%=raw sanitize_field(bookmark, :notes) %>
+      <%=raw sanitize_field(bookmark, :bookmarker_notes) %>
     </blockquote>
   <% end %>
   <!--actions-->

--- a/app/views/bookmarks/_bookmark_form.html.erb
+++ b/app/views/bookmarks/_bookmark_form.html.erb
@@ -65,7 +65,7 @@
       <fieldset>
         <legend><%= ts("Write Comments") %></legend>
         <dl>
-          <dt><%= f.label :notes, ts("Notes"), for: notes_id %></dt>
+          <dt><%= f.label :bookmarker_notes, ts("Notes"), for: notes_id %></dt>
           <dd>
             <p class="footnote" id="notes-field-description">
               <% if bookmarkable.class != ExternalWork %>
@@ -73,7 +73,7 @@
               <% end %>
               <%= allowed_html_instructions(show_list = false) %>
             </p>
-            <%= f.text_area :notes, rows: 4, id: notes_id, class: "observe_textlength",
+            <%= f.text_area :bookmarker_notes, rows: 4, id: notes_id, class: "observe_textlength",
                 "aria-describedby" => "notes-field-description" %>
             <%= generate_countdown_html(notes_id, ArchiveConfig.NOTES_MAX) %>
           </dd>

--- a/app/views/bookmarks/_bookmark_user_module.html.erb
+++ b/app/views/bookmarks/_bookmark_user_module.html.erb
@@ -45,10 +45,10 @@
     <% end %>
 
     <!--notes-->
-    <% unless bookmark.notes.blank? %>
+    <% unless bookmark.bookmarker_notes.blank? %>
       <h6 class="landmark heading"><%= ts('Bookmarker\'s Notes') %></h6>
       <blockquote class="userstuff notes">
-        <%=raw sanitize_field(bookmark, :notes) %>
+        <%=raw sanitize_field(bookmark, :bookmarker_notes) %>
       </blockquote>
     <% end %>
     <% # end of information added by the bookmark owner %>

--- a/app/views/comments/_comment_abbreviated_list.html.erb
+++ b/app/views/comments/_comment_abbreviated_list.html.erb
@@ -8,7 +8,7 @@
       <span class="datetime"><%= time_in_zone(comment.created_at) %></span>
     </dt>
     <dd>
-      <%= truncate(comment.content, length: 100, separator: ' ') %>
+      <%= truncate(comment.comment_content, length: 100, separator: ' ') %>
     </dd>
   <% end %>
 </dl>

--- a/app/views/comments/_comment_form.html.erb
+++ b/app/views/comments/_comment_form.html.erb
@@ -104,7 +104,7 @@
       <p>
         <% content_id = "comment_content_for_#{commentable.id}" %>
         <label for="<%= content_id %>" class="landmark"><%= ts("Comment") %></label>
-        <%= f.text_area :content, :id => content_id, :class => "comment_form observe_textlength", :title => ts("Enter Comment") %>
+        <%= f.text_area :comment_content, :id => content_id, :class => "comment_form observe_textlength", :title => ts("Enter Comment") %>
         <input type="hidden" id="controller_name_for_<%= commentable.id %>" name="controller_name" value="<%= @controller_name ||= controller.controller_name %>" />
       </p>
       <%= generate_countdown_html("comment_content_for_#{commentable.id}", ArchiveConfig.COMMENT_MAX) %>

--- a/app/views/comments/_single_comment.html.erb
+++ b/app/views/comments/_single_comment.html.erb
@@ -51,7 +51,7 @@
             <span class="visitor icon"><!-- visitor icon holder --></span>
           <% end %>
         </div>
-        <blockquote class="userstuff"><%=raw sanitize_field(single_comment, :content) %></blockquote>
+        <blockquote class="userstuff"><%=raw sanitize_field(single_comment, :comment_content) %></blockquote>
         <% unless single_comment.edited_at.blank? %>
           <p class="edited datetime">
             <%= ts("Last Edited") %> <%= time_in_zone(single_comment.edited_at) %>

--- a/app/views/comments/_single_comment_abbreviated.html.erb
+++ b/app/views/comments/_single_comment_abbreviated.html.erb
@@ -26,7 +26,7 @@
       <span class="visitor icon"><!-- visitor icon holder --></span>
     <% end %>
   </div>
-  <blockquote class="userstuff"><%=raw sanitize_field(single_comment, :content) %></blockquote>
+  <blockquote class="userstuff"><%=raw sanitize_field(single_comment, :comment_content) %></blockquote>
   <% unless single_comment.edited_at.blank? %>
     <p class="edited datetime">
       <%= ts('Last Edited') %> <%= time_in_zone(single_comment.edited_at) %>

--- a/app/views/inbox/_inbox_comment_contents.html.erb
+++ b/app/views/inbox/_inbox_comment_contents.html.erb
@@ -32,5 +32,5 @@
 
 <% # This feedback_comment used to be inbox_comment... not sure why %>
 <blockquote class="userstuff">
-  <%= raw sanitize_field(feedback_comment, :content) %>
+  <%= raw sanitize_field(feedback_comment, :comment_content) %>
 </blockquote>

--- a/app/views/series/edit.html.erb
+++ b/app/views/series/edit.html.erb
@@ -41,11 +41,11 @@
       </dd>
       
       <dt>
-        <%= f.label :notes, ts("Series Notes") %>
+        <%= f.label :series_notes, ts("Series Notes") %>
       </dt>
       <dd>
         <%= allowed_html_instructions %>
-        <%= f.text_area :notes, :class => "observe_textlength" %>
+        <%= f.text_area :series_notes, :class => "observe_textlength" %>
         <%= live_validation_for_field('series_notes', :presence => false, :maximum_length => ArchiveConfig.NOTES_MAX) %>
         <%= generate_countdown_html("series_notes", ArchiveConfig.NOTES_MAX) %>
       </dd>

--- a/app/views/series/show.html.erb
+++ b/app/views/series/show.html.erb
@@ -40,9 +40,9 @@
       <dt><%= ts('Description:') %></dt>
       <dd><blockquote class="userstuff"><%=raw sanitize_field(@series, :summary) %></blockquote></dd>
     <% end %>
-    <% unless @series.notes.blank? %>
+    <% unless @series.series_notes.blank? %>
       <dt><%= ts('Notes:') %></dt>
-      <dd><blockquote class="userstuff"><%=raw sanitize_field(@series, :notes) %></blockquote></dd>
+      <dd><blockquote class="userstuff"><%=raw sanitize_field(@series, :series_notes) %></blockquote></dd>
     <% end %>
 
     <dt class="stats"><%= ts('Stats:') %></dt>

--- a/app/views/tag_wranglings/discuss.html.erb
+++ b/app/views/tag_wranglings/discuss.html.erb
@@ -20,7 +20,7 @@
   <% for comment in @comments %>
   	<tr>
     	<th scope="row"><%= link_to_tag(comment.parent) %></th>
-    	<td><%= link_to strip_tags(comment.content[0..50]) + '...', comment, :title => strip_tags(comment.content) %></td>
+    	<td><%= link_to strip_tags(comment.comment_content[0..50]) + '...', comment, :title => strip_tags(comment.comment_content) %></td>
     	<td><%= comment.count_all_comments %></td>
     	<td>
     	  <% if comment.pseud %>

--- a/config/config.yml
+++ b/config/config.yml
@@ -263,8 +263,8 @@ FIELDS_ALLOWING_LESS_THAN: ["query", "words", "kudos", "hits", "date", "bookmark
 #
 # This will ensure that the field has been sanitized with the latest version of the sanitizer.
 #
-FIELDS_ALLOWING_HTML: ["about_me", "comment", "content", "description", "endnotes", "faq", "intro", "note", "notes",
-  "rules", "signup_instructions_general", "signup_instructions_offers", "signup_instructions_requests", "summary",
+FIELDS_ALLOWING_HTML: ["about_me", "bookmark_notes", "comment", "comment_content", "content", "description", "endnotes", "faq", "intro", "note", "notes",
+  "rules", "series_notes", "signup_instructions_general", "signup_instructions_offers", "signup_instructions_requests", "summary",
   "screencast", "disabled_support_form_text"]
 
 FIELDS_ALLOWING_HTML_ENTITIES: ["title"]

--- a/config/config.yml
+++ b/config/config.yml
@@ -263,9 +263,8 @@ FIELDS_ALLOWING_LESS_THAN: ["query", "words", "kudos", "hits", "date", "bookmark
 #
 # This will ensure that the field has been sanitized with the latest version of the sanitizer.
 #
-FIELDS_ALLOWING_HTML: ["about_me", "bookmark_notes", "comment", "comment_content", "content", "description", "endnotes", "faq", "intro", "note", "notes",
-  "rules", "series_notes", "signup_instructions_general", "signup_instructions_offers", "signup_instructions_requests", "summary",
-  "screencast", "disabled_support_form_text"]
+FIELDS_ALLOWING_HTML: ["about_me", "bookmark_notes", "comment", "comment_content", "content", "description", "disabled_support_form_text", "endnotes", "faq", "intro", "note", "notes",
+  "rules", "screencast", "series_notes", "signup_instructions_general", "signup_instructions_offers", "signup_instructions_requests", "summary"]
 
 FIELDS_ALLOWING_HTML_ENTITIES: ["title"]
 

--- a/config/config.yml
+++ b/config/config.yml
@@ -263,7 +263,7 @@ FIELDS_ALLOWING_LESS_THAN: ["query", "words", "kudos", "hits", "date", "bookmark
 #
 # This will ensure that the field has been sanitized with the latest version of the sanitizer.
 #
-FIELDS_ALLOWING_HTML: ["about_me", "bookmark_notes", "comment", "comment_content", "content", "description", "disabled_support_form_text", "endnotes", "faq", "intro", "note", "notes",
+FIELDS_ALLOWING_HTML: ["about_me", "bookmarker_notes", "comment", "comment_content", "content", "description", "disabled_support_form_text", "endnotes", "faq", "intro", "note", "notes",
   "rules", "screencast", "series_notes", "signup_instructions_general", "signup_instructions_offers", "signup_instructions_requests", "summary"]
 
 FIELDS_ALLOWING_HTML_ENTITIES: ["title"]

--- a/config/initializers/gem-plugin_config/sanitizer_config.rb
+++ b/config/initializers/gem-plugin_config/sanitizer_config.rb
@@ -4,16 +4,15 @@ class Sanitize
   # This defines the configuration we use for HTML tags and attributes allowed in the archive.
   module Config
 
-    ARCHIVE = {
+    ARCHIVE = freeze_config(
       elements: [
         'a', 'abbr', 'acronym', 'address', 'b', 'big', 'blockquote', 'br', 'caption', 'center', 'cite', 'code', 'col',
         'colgroup', 'dd', 'del', 'dfn', 'div', 'dl', 'dt', 'em', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'hr',
         'i', 'img', 'ins', 'kbd', 'li', 'ol', 'p', 'pre', 'q', 's', 'samp', 'small', 'span', 'strike', 'strong',
         'sub', 'sup', 'table', 'tbody', 'td', 'tfoot', 'th', 'thead', 'tr', 'tt', 'u', 'ul', 'var'],
 
-      # see in the Transformers section for what classes we strip
       attributes: {
-        all: ['align', 'title', 'class', 'dir'],
+        all: ['align', 'title', 'dir'],
         'a' => ['href', 'name'],
         'blockquote' => ['cite'],
         'col' => ['span', 'width'],
@@ -38,9 +37,18 @@ class Sanitize
         'img' => {'src' => ['http', 'https', :relative]},
         'q' => {'cite' => ['http', 'https', :relative]}
       }
-    }
+    )
+
+    CLASS_ATTRIBUTE = freeze_config(
+      # see in the Transformers section for what classes we strip
+      attributes: {
+        all: ARCHIVE[:attributes][:all] + ['class']
+      }
+    )
+
+    CSS_ALLOWED = freeze_config(merge(ARCHIVE, CLASS_ATTRIBUTE))
   end
-  
+
   # This defines the custom sanitizing transformers we use for cleaning data
   module Transformers
     
@@ -48,7 +56,7 @@ class Sanitize
     ALLOW_USER_CLASSES = lambda do |env|
       node      = env[:node]
       classval  = node['class']
-      
+
       # if we don't have a class attribute, away we go
       return if classval.blank?
 
@@ -121,7 +129,7 @@ class Sanitize
       end
       
       # if we don't know the source, sorry
-      return if source.nil?           
+      return if source.nil?
 
       allow_flashvars = ["ning", "vidders.net", "google", "criticalcommons", "archiveofourown", "podfic", "spotify", "8tracks", "soundcloud"]
       supports_https = [
@@ -169,7 +177,7 @@ class Sanitize
           attributes: {
             'embed'  => (['allowfullscreen', 'height', 'src', 'type', 'width'] + (allow_flashvars.include?(source) ? ['wmode', 'flashvars'] : [])),
             'iframe'  => ['frameborder', 'height', 'src', 'title', 'class', 'type', 'width'],
-          }          
+          }
         })
         
         if node_name == 'embed'

--- a/db/migrate/20181113063726_rename_columns_that_do_not_allow_css.rb
+++ b/db/migrate/20181113063726_rename_columns_that_do_not_allow_css.rb
@@ -1,0 +1,19 @@
+class RenameColumnsThatDoNotAllowCss < ActiveRecord::Migration[5.1]
+  def up
+    rename_column :bookmarks, :notes, :bookmarker_notes
+    rename_column :bookmarks, :notes_sanitizer_version, :bookmarker_notes_sanitizer_version
+    rename_column :comments, :content, :comment_content
+    rename_column :comments, :content_sanitizer_version, :comment_content_sanitizer_version
+    rename_column :series, :notes, :series_notes
+    rename_column :series, :notes_sanitizer_version, :series_notes_sanitizer_version
+  end
+
+  def down
+    rename_column :series, :series_notes_sanitizer_version, :notes_sanitizer_version
+    rename_column :series, :series_notes, :notes
+    rename_column :comments, :comment_content_sanitizer_version, :content_sanitizer_version
+    rename_column :comments, :comment_content, :content
+    rename_column :bookmarks, :bookmarker_notes_sanitizer_version, :notes_sanitizer_version
+    rename_column :bookmarks, :bookmarker_notes, :notes
+  end
+end

--- a/factories/comments.rb
+++ b/factories/comments.rb
@@ -3,7 +3,7 @@ require 'faker'
 FactoryGirl.define do
   factory :comment do
     name { Faker::Name.first_name }
-    content { Faker::Lorem.sentence(25) }
+    comment_content { Faker::Lorem.sentence(25) }
     email { Faker::Internet.email }
     commentable_type { "Work" }
     commentable_id { create(:work).id }
@@ -12,7 +12,7 @@ FactoryGirl.define do
 
   factory :adminpost_comment, class: Comment do
     name { Faker::Name.first_name }
-    content { Faker::Lorem.sentence(25) }
+    comment_content { Faker::Lorem.sentence(25) }
     email { Faker::Internet.email }
     commentable_type { "AdminPost" }
     commentable_id { create(:admin_post).id }
@@ -21,7 +21,7 @@ FactoryGirl.define do
 
   factory :tag_comment, class: Comment do
     name { Faker::Name.first_name }
-    content { Faker::Lorem.sentence(25) }
+    comment_content { Faker::Lorem.sentence(25) }
     email { Faker::Internet.email }
     commentable_type { "Tag" }
     commentable_id { create(:fandom).id }
@@ -30,7 +30,7 @@ FactoryGirl.define do
 
   factory :unreviewed_comment, class: Comment do
     name { Faker::Name.first_name }
-    content { Faker::Lorem.sentence(25) }
+    comment_content { Faker::Lorem.sentence(25) }
     email { Faker::Internet.email }
     commentable_type { "Work" }
     commentable_id { create(:work, moderated_commenting_enabled: true).id }

--- a/features/importing/work_import_dw.feature
+++ b/features/importing/work_import_dw.feature
@@ -95,13 +95,10 @@ Feature: Import Works from DW
   @import_dw_comm
   Scenario: Creating a new work from an DW story that is posted to a community
     Given basic tags
-      And the following activated user exists
-        | login          | password    |
-        | cosomeone      | something   |
-      And I am logged in as "cosomeone" with password "something"
+      And I am logged in as "cosomeone"
     When I go to the import page
       And I fill in "urls" with "https://ao3testingcomm.dreamwidth.org/702.html"
-    When I press "Import"
+      And I press "Import"
     Then I should see "Preview"
       And I should see "Testing" within "dd.fandom"
       And I should see "Explicit" within "dd.rating"
@@ -118,8 +115,11 @@ Feature: Import Works from DW
       And I should not see "Entry tags"
     When I press "Post"
     Then I should see "Work was successfully posted."
-    When I am on cosomeone's user page
-      Then I should see "Rails 5.1 Single Chapter from Comm (DW)"
+    When I follow "Edit"
+    Then the "content" field should contain "class"
+      And the "content" field should contain "entry-content"
+    When I go to cosomeone's user page
+    Then I should see "Rails 5.1 Single Chapter from Comm (DW)"
 
   @import_dw_multi_chapter
   Scenario: Creating a new multichapter work from a DW story

--- a/features/other_a/parser.feature
+++ b/features/other_a/parser.feature
@@ -81,3 +81,10 @@ Feature: Parsing HTML
   Then I should see "Comment created!"
   When I follow "Edit"
   Then the "Comment" field should not contain "strip me"
+
+Scenario: Can't use classes in a bookmark note
+  Given the work "Really Good Thing"
+    And I am logged in as "bookmarker"
+  When I bookmark the work "Really Good Thing" with the note "My <span='remove-me'>best yet</span>"
+    And I edit the bookmark for "Really Good Thing"
+  Then the "Notes" field should not contain "remove-me"

--- a/features/other_a/parser.feature
+++ b/features/other_a/parser.feature
@@ -3,8 +3,7 @@ Feature: Parsing HTML
 
   # tests for parsing only are in spec/lib/html_cleaner_spec.rb
 
-  Scenario: Editing a work and saving it without changes should preserve the same content
-  
+  Scenario: Editing a work and saving it without changes should preserve the same content 
   When I am logged in as "newbie" with password "password"
     And I set up the draft "My Awesome Story"
     And I fill in "content" with 
@@ -21,9 +20,7 @@ Feature: Parsing HTML
    And I press "Preview"
   Then I should see the text with tags "<p>This is paragraph 1.</p><p>This is paragraph 2.</p>"
 
-  
   Scenario: HTML Parser should kick in
-  
   When I am logged in as "newbie" with password "password"
     And I set up the draft "My Awesome Story"
     And I fill in "content" with 
@@ -36,4 +33,51 @@ Feature: Parsing HTML
   Then I should see "Preview"
     And I should see the text with tags "<p>A paragraph</p><p>Another paragraph.</p>" 
 
+  Scenario: Work notes and content HTML can have classes and they are kept when editing after previewing
+  Given I am logged in as a random user
+    And I set up the draft "Classy Work"
+  When I fill in "Summary" with "<p class='myclass'>Text</p>"
+    And I fill in "Notes" with "<p class='note'>Text</p>"
+    And I fill in "End Notes" with "<span class='keep-me'>Text</span>"
+    And I fill in "content" with "<p class='size-10'><img src='britney.gif' alt='Britney Spears' />You better work</p>"
+    And I press "Preview"
+  Then I should see "Draft was successfully created."
+    And I should see the image "src" text "britney.gif"
+    And I should see the image "alt" text "Britney Spears"
+  When I press "Edit"
+  Then the "Summary" field should not contain "myclass"
+    And the "Notes" field should contain "note"
+    And the "End Notes" field should contain "keep-me"
+    And the "content" field should contain "size-10"
+  When I press "Post Without Preview"
+  Then I should see "Work was successfully posted."
+    And I should see the image "src" text "britney.gif"
 
+  Scenario: Chapter notes and content HTML keep classes when previewing before posting
+  Given I am logged in as a random user
+    And I post the work "Classy Multichapter Work"
+    And a chapter is set up for "Classy Multichapter Work"
+  When I fill in "Chapter Summary" with "<p class='summary classes'>Text</p>"
+    And I fill in "Notes" with "<p class='note'>Text</p>"
+    And I fill in "End Notes" with "<span class='keep-me'>Text</span>"
+    And I fill in "content" with "<div class='elaborate formatting'><p>The continuation of my <a href='works/123'>masterpiece</a></p></div>"
+    And I press "Preview"
+  Then I should see "This is a draft chapter in a posted work."
+  When I press "Post"
+  Then I should see "Chapter was successfully posted."
+    And I should see the text with tags '<p>The continuation of my <a href="works/123" rel="nofollow">masterpiece</a></p>'
+  When I follow "Edit Chapter"
+  Then the "Chapter Summary" field should not contain "summary classes"
+    And the "Notes" field should contain "note"
+    And the "End Notes" field should contain "keep-me"
+    And the "content" field should contain "elaborate formatting"
+
+  Scenario: Can't use classes in comment content
+  Given the work "Generic Work"
+    And I am logged in as "commenter"
+    And I view the work "Generic Work"
+  When I fill in "Comment" with "<p class='strip me'>Hi there!</p>"
+    And I press "Comment"
+  Then I should see "Comment created!"
+  When I follow "Edit"
+  Then the "Comment" field should not contain "strip me"

--- a/features/step_definitions/bookmark_steps.rb
+++ b/features/step_definitions/bookmark_steps.rb
@@ -72,13 +72,13 @@ Given /^I have bookmarks to search$/ do
   FactoryGirl.create(:bookmark,
                      bookmarkable_id: work5.id,
                      pseud_id: pseud2.id,
-                     notes: "Left me with a broken heart")
+                     bookmarker_notes: "Left me with a broken heart")
 
   FactoryGirl.create(:bookmark,
                      bookmarkable_id: external1.id,
                      bookmarkable_type: "ExternalWork",
                      pseud_id: pseud2.id,
-                     notes: "I enjoyed this")
+                     bookmarker_notes: "I enjoyed this")
 
   FactoryGirl.create(:bookmark,
                      bookmarkable_id: series1.id,
@@ -91,7 +91,7 @@ Given /^I have bookmarks to search$/ do
                      bookmarkable_type: "Series",
                      pseud_id: pseud2.id,
                      rec: true,
-                     notes: "A new classic")
+                     bookmarker_notes: "A new classic")
 
   step %{all indexing jobs have been run}
 end
@@ -113,13 +113,13 @@ Given /^I have bookmarks to search by any field$/ do
                               summary: "Hurt & comfort ficlets")
   series2 = FactoryGirl.create(:series_with_a_work, title: "Ouchless Series")
 
-  FactoryGirl.create(:bookmark, bookmarkable_id: work1.id, notes: "whatever")
+  FactoryGirl.create(:bookmark, bookmarkable_id: work1.id, bookmarker_notes: "whatever")
   FactoryGirl.create(:bookmark, bookmarkable_id: work2.id, tag_string: "more please")
-  FactoryGirl.create(:bookmark, bookmarkable_id: work3.id, notes: "more please")
+  FactoryGirl.create(:bookmark, bookmarkable_id: work3.id, bookmarker_notes: "more please")
   FactoryGirl.create(:bookmark,
                      bookmarkable_id: external1.id,
                      bookmarkable_type: "ExternalWork",
-                     notes: "please rec me more like this")
+                     bookmarker_notes: "please rec me more like this")
   FactoryGirl.create(:bookmark,
                      bookmarkable_id: external2.id,
                      bookmarkable_type: "ExternalWork",
@@ -127,7 +127,7 @@ Given /^I have bookmarks to search by any field$/ do
   FactoryGirl.create(:bookmark,
                      bookmarkable_id: series1.id,
                      bookmarkable_type: "Series",
-                     notes: "needs more comfort please")
+                     bookmarker_notes: "needs more comfort please")
   FactoryGirl.create(:bookmark,
                      bookmarkable_id: series2.id,
                      bookmarkable_type: "Series",
@@ -144,48 +144,48 @@ Given /^I have bookmarks to search by dates$/ do
     work1 = FactoryGirl.create(:posted_work, title: "Old work")
     FactoryGirl.create(:bookmark,
                        bookmarkable_id: work1.id,
-                       notes: "Old bookmark of old work")
+                       bookmarker_notes: "Old bookmark of old work")
 
     series1 = FactoryGirl.create(:series_with_a_work, title: "Old series")
     FactoryGirl.create(:bookmark,
                        bookmarkable_id: series1.id,
                        bookmarkable_type: "Series",
-                       notes: "Old bookmark of old series")
+                       bookmarker_notes: "Old bookmark of old series")
 
     external1 = FactoryGirl.create(:external_work, title: "Old external")
     FactoryGirl.create(:bookmark,
                        bookmarkable_id: external1.id,
                        bookmarkable_type: "ExternalWork",
-                       notes: "Old bookmark of old external work")
+                       bookmarker_notes: "Old bookmark of old external work")
   end
   FactoryGirl.create(:bookmark,
                      bookmarkable_id: work1.id,
-                     notes: "New bookmark of old work")
+                     bookmarker_notes: "New bookmark of old work")
   FactoryGirl.create(:bookmark,
                      bookmarkable_id: series1.id,
                      bookmarkable_type: "Series",
-                     notes: "New bookmark of old series")
+                     bookmarker_notes: "New bookmark of old series")
   FactoryGirl.create(:bookmark,
                      bookmarkable_id: external1.id,
                      bookmarkable_type: "ExternalWork",
-                     notes: "New bookmark of old external work")
+                     bookmarker_notes: "New bookmark of old external work")
 
   work2 = FactoryGirl.create(:posted_work, title: "New work")
   FactoryGirl.create(:bookmark,
                      bookmarkable_id: work2.id,
-                     notes: "New bookmark of new work")
+                     bookmarker_notes: "New bookmark of new work")
 
   series2 = FactoryGirl.create(:series_with_a_work, title: "New series")
   FactoryGirl.create(:bookmark,
                      bookmarkable_id: series2.id,
                      bookmarkable_type: "Series",
-                     notes: "New bookmark of new series")
+                     bookmarker_notes: "New bookmark of new series")
 
   external2 = FactoryGirl.create(:external_work, title: "New external")
   FactoryGirl.create(:bookmark,
                      bookmarkable_id: external2.id,
                      bookmarkable_type: "ExternalWork",
-                     notes: "New bookmark of new external work")
+                     bookmarker_notes: "New bookmark of new external work")
 
   step %{all indexing jobs have been run}
 end

--- a/features/step_definitions/comment_steps.rb
+++ b/features/step_definitions/comment_steps.rb
@@ -45,7 +45,7 @@ end
 When /^I set up the comment "([^"]*)" on the work "([^"]*)"$/ do |comment_text, work|
   work = Work.find_by(title: work)
   visit work_path(work)
-  fill_in("comment[content]", with: comment_text)
+  fill_in("comment[comment_content]", with: comment_text)
 end
 
 When /^I attempt to comment on "([^"]*)" with a pseud that is not mine$/ do |work|
@@ -81,13 +81,13 @@ end
 
 When /^I edit a comment$/ do
   step %{I follow "Edit"}
-  fill_in("comment[content]", with: "Edited comment")
+  fill_in("comment[comment_content]", with: "Edited comment")
   click_button "Update"
 end
 
 # this step assumes we are on a page with a comment form
 When /^I post a comment "([^"]*)"$/ do |comment_text|
-  fill_in("comment[content]", with: comment_text)
+  fill_in("comment[comment_content]", with: comment_text)
   click_button("Comment")
 end
 
@@ -96,7 +96,7 @@ When /^I reply to a comment with "([^"]*)"$/ do |comment_text|
   step %{I follow "Reply"}
   step %{I should see the reply to comment form}
   with_scope(".odd") do
-    fill_in("comment[content]", with: comment_text)
+    fill_in("comment[comment_content]", with: comment_text)
     click_button("Comment")
   end
 end
@@ -109,14 +109,14 @@ end
 When /^I comment on an admin post$/ do
   step "I go to the admin-posts page"
     step %{I follow "Comment"}
-    step %{I fill in "comment[content]" with "Excellent, my dear!"}
+    step %{I fill in "comment[comment_content]" with "Excellent, my dear!"}
     step %{I press "Comment"}
 end
 
 When /^I post a spam comment$/ do
   fill_in("comment[name]", with: "spammer")
   fill_in("comment[email]", with: "spammer@example.org")
-  fill_in("comment[content]", with: "Buy my product! http://spam.org")
+  fill_in("comment[comment_content]", with: "Buy my product! http://spam.org")
   click_button("Comment")
   step %{I should see "Comment created!"}
 end
@@ -124,7 +124,7 @@ end
 When /^I post a guest comment$/ do
   fill_in("comment[name]", with: "guest")
   fill_in("comment[email]", with: "guest@example.org")
-  fill_in("comment[content]", with: "This was really lovely!")
+  fill_in("comment[comment_content]", with: "This was really lovely!")
   click_button("Comment")
   step %{I should see "Comment created!"}
 end
@@ -227,7 +227,7 @@ When /^I post a deeply nested comment thread on "([^\"]*?)"$/ do |work|
     commentable = Comment.create(
       commentable: commentable,
       parent: chapter,
-      content: "This is a comment at depth #{i}.",
+      comment_content: "This is a comment at depth #{i}.",
       pseud: user.default_pseud
     )
   end
@@ -239,7 +239,7 @@ When /^I post a deeply nested comment thread on "([^\"]*?)"$/ do |work|
     Comment.create(
       commentable: commentable,
       parent: chapter,
-      content: "This is the #{ordinal} hidden comment.",
+      comment_content: "This is the #{ordinal} hidden comment.",
       pseud: user.default_pseud
     )
   end

--- a/features/step_definitions/work_steps.rb
+++ b/features/step_definitions/work_steps.rb
@@ -127,7 +127,7 @@ Given /^the chaptered work(?: with ([\d]+) chapters)?(?: with ([\d]+) comments?)
   n_comments.to_i.times do |i|
     step %{I am logged in as a random user}
     visit work_url(work)
-    fill_in("comment[content]", with: "Bla bla")
+    fill_in("comment[comment_content]", with: "Bla bla")
     click_button("Comment")
     step %{I am logged out}
   end

--- a/lib/html_cleaner.rb
+++ b/lib/html_cleaner.rb
@@ -158,10 +158,14 @@ module HtmlCleaner
       if ArchiveConfig.FIELDS_ALLOWING_CSS.include?(field.to_s)
         transformers << Sanitize::Transformers::ALLOW_USER_CLASSES
       end
-      # the screencast field shouldn't be wrapped in <p> tags
-      unless field.to_s == "screencast"
+      # Now that we know what transformers we need, let's sanitize the unfrozen value
+      if ArchiveConfig.FIELDS_ALLOWING_CSS.include?(field.to_s)
         unfrozen_value = add_paragraphs_to_text(Sanitize.clean(fix_bad_characters(unfrozen_value),
-                               Sanitize::Config::ARCHIVE.merge(transformers: transformers)))
+                               Sanitize::Config::CSS_ALLOWED.merge(transformers: transformers)))
+      else
+        # the screencast field shouldn't be wrapped in <p> tags
+        unfrozen_value = add_paragraphs_to_text(Sanitize.clean(fix_bad_characters(unfrozen_value),
+                               Sanitize::Config::ARCHIVE.merge(transformers: transformers))) unless field.to_s == "screencast"
       end
       doc = Nokogiri::HTML::Document.new
       doc.encoding = "UTF-8"

--- a/lib/plugins/acts_as_commentable/comment_methods.rb
+++ b/lib/plugins/acts_as_commentable/comment_methods.rb
@@ -33,7 +33,7 @@ module CommentMethods
     def destroy_or_mark_deleted
       if self.children_count > 0
         self.is_deleted = true
-        self.content = "deleted comment" # wipe out the content
+        self.comment_content = "deleted comment" # wipe out the content
         self.save
       else
         self.destroy

--- a/spec/controllers/api/v1/api_bookmarks_spec.rb
+++ b/spec/controllers/api/v1/api_bookmarks_spec.rb
@@ -14,7 +14,7 @@ describe "API v1 BookmarksController", type: :request do
                category_string: ["M/M"],
                relationship_string: "Starsky/Hutch",
                character_string: "Starsky,hutch",
-               notes: "<p>Notes</p>",
+               bookmarker_notes: "<p>Notes</p>",
                tag_string: "youpi",
                collection_names: "",
                private: "0",

--- a/spec/controllers/api/v2/api_bookmarks_spec.rb
+++ b/spec/controllers/api/v2/api_bookmarks_spec.rb
@@ -14,7 +14,7 @@ describe "API v2 BookmarksController", type: :request do
                category_string: ["M/M"],
                relationship_string: "Starsky/Hutch",
                character_string: "Starsky,hutch",
-               notes: "<p>Notes</p>",
+               bookmarker_notes: "<p>Notes</p>",
                tag_string: "youpi",
                collection_names: "",
                private: "0",

--- a/spec/controllers/comments_controller_spec.rb
+++ b/spec/controllers/comments_controller_spec.rb
@@ -143,7 +143,7 @@ describe CommentsController do
 
   describe "POST #create" do
     let(:anon_comment_attributes) do
-      attributes_for(:comment).slice(:name, :email, :content)
+      attributes_for(:comment).slice(:name, :email, :comment_content)
     end
 
     context "when replying from the inbox" do
@@ -158,7 +158,7 @@ describe CommentsController do
       it "creates the reply and redirects to user inbox path" do
         comment_attributes = {
           pseud_id: user.default_pseud_id,
-          content: "Hello fellow human!"
+          comment_content: "Hello fellow human!"
         }
         post :create, params: { comment_id: comment.id, comment: comment_attributes, filters: { date: 'asc' } }
         expect(response).to redirect_to(user_inbox_path(user, filters: { date: 'asc' }))
@@ -178,7 +178,7 @@ describe CommentsController do
           expect(comment.commentable).to eq fandom
           expect(comment.name).to eq anon_comment_attributes[:name]
           expect(comment.email).to eq anon_comment_attributes[:email]
-          expect(comment.content).to include anon_comment_attributes[:content]
+          expect(comment.comment_content).to include anon_comment_attributes[:comment_content]
           path = comments_path(tag_id: fandom.to_param,
                                anchor: "comment_#{comment.id}")
           expect(response).to redirect_to path
@@ -197,7 +197,7 @@ describe CommentsController do
           expect(comment.commentable).to eq fandom
           expect(comment.name).to eq anon_comment_attributes[:name]
           expect(comment.email).to eq anon_comment_attributes[:email]
-          expect(comment.content).to include anon_comment_attributes[:content]
+          expect(comment.comment_content).to include anon_comment_attributes[:comment_content]
           path = comments_path(tag_id: fandom.to_param,
                                anchor: "comment_#{comment.id}")
           expect(response).to redirect_to path

--- a/spec/miscellaneous/lib/html_cleaner_spec.rb
+++ b/spec/miscellaneous/lib/html_cleaner_spec.rb
@@ -144,56 +144,116 @@ describe HtmlCleaner do
 
   describe "sanitize_value" do
     
-    context "Sanitize tags allowed only in the content field" do
-      %w{youtube.com youtube-nocookie.com vimeo.com player.vimeo.com static.ning.com ning.com dailymotion.com
-         metacafe.com vidders.net criticalcommons.org google.com archiveofourown.org podfic.com archive.org
-         open.spotify.com spotify.com 8tracks.com w.soundcloud.com soundcloud.com viddertube.com}.each do |source|
+    ArchiveConfig.FIELDS_ALLOWING_VIDEO_EMBEDS.each do |field|
+      context "#{field} is configured to allow video embeds" do
+      
+        %w{youtube.com youtube-nocookie.com vimeo.com player.vimeo.com static.ning.com ning.com dailymotion.com
+           metacafe.com vidders.net criticalcommons.org google.com archiveofourown.org podfic.com archive.org
+           open.spotify.com spotify.com 8tracks.com w.soundcloud.com soundcloud.com viddertube.com}.each do |source|
 
-        it "should allow embeds from #{source}" do
-          html = '<iframe width="560" height="315" src="//' + source + '/embed/123" frameborder="0"></iframe>'
-          result = sanitize_value(:content, html)
+          it "keeps embeds from #{source}" do
+            html = '<iframe width="560" height="315" src="//' + source + '/embed/123" frameborder="0"></iframe>'
+            result = sanitize_value(field, html)
+            expect(result).to include(html)
+          end
+        end
+
+        %w{youtube.com youtube-nocookie.com vimeo.com player.vimeo.com
+           archiveofourown.org archive.org dailymotion.com 8tracks.com podfic.com
+           open.spotify.com spotify.com w.soundcloud.com soundcloud.com viddertube.com}.each do |source|
+
+          it "converts src to https for #{source}" do
+            html = '<iframe width="560" height="315" src="http://' + source + '/embed/123" frameborder="0"></iframe>'
+            result = sanitize_value(field, html)
+            expect(result).to match('https:')
+          end
+        end
+
+        it "keeps google player embeds" do
+          html = '<embed type="application/x-shockwave-flash" flashvars="audioUrl=http://dl.dropbox.com/u/123/foo.mp3" src="http://www.google.com/reader/ui/123-audio-player.swf" width="400" height="27" allowscriptaccess="never" allownetworking="internal"></embed>'
+          result = sanitize_value(field, html)
           expect(result).to include(html)
         end
-      end
 
-      %w{youtube.com youtube-nocookie.com vimeo.com player.vimeo.com
-         archiveofourown.org archive.org dailymotion.com 8tracks.com podfic.com
-         open.spotify.com spotify.com w.soundcloud.com soundcloud.com viddertube.com}.each do |source|
-
-        it "should convert to https for #{source}" do
-          html = '<iframe width="560" height="315" src="http://' + source + '/embed/123" frameborder="0"></iframe>'
-          result = sanitize_value(:content, html)
-          expect(result).to match('https:')
+        it "strips embeds with unknown source" do
+          html = '<embed src="http://www.evil.org"></embed>'
+          result = sanitize_value(field, html)
+          expect(result).to be_empty
         end
-      end
 
-      it "should allow google player embeds" do
-        html = '<embed type="application/x-shockwave-flash" flashvars="audioUrl=http://dl.dropbox.com/u/123/foo.mp3" src="http://www.google.com/reader/ui/123-audio-player.swf" width="400" height="27" allowscriptaccess="never" allownetworking="internal"></embed>'
-        result = sanitize_value(:content, html)
-        expect(result).to include(html)
-      end
-
-      it "should not allow embeds with unknown source" do
-        html = '<embed src="http://www.evil.org"></embed>'
-        result = sanitize_value(:content, html)
-        expect(result).to be_empty
-      end
-
-      %w(metacafe.com vidders.net criticalcommons.org static.ning.com ning.com).each do |source|
-        it "should not convert to https for #{source}" do
-          html = '<iframe width="560" height="315" src="http://' + source + '/embed/123" frameborder="0"></iframe>'
-          result = sanitize_value(:content, html)
-          expect(result).not_to match('https:')
+        %w(metacafe.com vidders.net criticalcommons.org static.ning.com ning.com).each do |source|
+          it "doesn't convert src to https for #{source}" do
+            html = '<iframe width="560" height="315" src="http://' + source + '/embed/123" frameborder="0"></iframe>'
+            result = sanitize_value(field, html)
+            expect(result).not_to match('https:')
+          end
         end
       end
     end
-    
+
     context "Strip out tags not allowed in text fields other than content" do
       [:endnotes, :notes, :summary].each do |field|
         it "should strip iframes" do
           value = '<iframe width="560" height="315" src="//youtube.com/embed/123" frameborder="0"></iframe>'
           result = sanitize_value(field, value)
           expect(result).to eq("")
+        end
+      end
+    end
+
+    ArchiveConfig.FIELDS_ALLOWING_CSS.each do |field|
+      context "#{field} field allows class attribute for CSS" do
+        context "class has one value" do
+          it "keeps values containing only letters, numbers, and hyphens" do
+            result = sanitize_value(field, '<p class="f-5">foobar</p>')
+            doc = Nokogiri::HTML.fragment(result)
+            expect(doc.xpath("./p[@class='f-5']").children.to_s.strip).to eq("foobar")
+          end
+
+          it "strips values starting with a number" do
+            result = sanitize_value(field, '<p class="8ball">foobar</p>')
+            expect(result).not_to match(/8ball/)
+          end
+
+          it "strips values starting with a hyphen" do
+            result = sanitize_value(field, '<p class="-dash">foobar</p>')
+            expect(result).not_to match(/-dash/)
+          end
+
+          it "strips values with special characters" do
+            result = sanitize_value(field, '<p class="foo@bar">foobar</p>')
+            expect(result).not_to match(/foo@bar/)
+          end
+        end
+
+        context "class attribute has multiple values" do
+          it "keeps all valid values" do
+            result = sanitize_value(field, '<p class="foo bar">foobar</p>')
+            doc = Nokogiri::HTML.fragment(result)
+            expect(doc.xpath("./p[contains(@class, 'foo bar')]").children.to_s.strip).to eq("foobar")
+          end
+
+          it "strips values starting with numbers" do
+            result = sanitize_value(field, '<p class="magic 8ball">foobar</p>')
+            expect(result).not_to match(/8ball/)
+            expect(result).to match(/magic/)
+          end
+
+          it "strips values starting with hypens" do
+            result = sanitize_value(field, '<p class="rainbow -dash">foobar</p>')
+            expect(result).not_to match(/-dash/)
+            expect(result).to match(/rainbow/)
+          end
+        end
+      end
+    end
+
+    [:comment_content, :bookmarker_notes, :summary].each do |field|
+      context "#{field} field does not allow class attribute" do
+        it "strips attribute even if value is valid" do
+          result = sanitize_value(field, '<p class="f-5">foobar</p>')
+          expect(result).not_to match(/f-5/)
+          expect(result).not_to match(/class/)
         end
       end
     end
@@ -212,49 +272,6 @@ describe HtmlCleaner do
         it "should keep valid unicode chars as is" do
           result = sanitize_value(field, "„‚nörmäl’—téxt‘“")
           expect(result).to match(/„‚nörmäl’—téxt‘“/)
-        end
-  
-        it "should allow classes with letters, numbers and hyphens" do
-          result = sanitize_value(field, '<p class="f-5">foobar</p>')
-          doc = Nokogiri::HTML.fragment(result)
-          expect(doc.xpath("./p[@class='f-5']").children.to_s.strip).to eq("foobar")
-        end
-  
-        it "should not allow CSS classes starting with numbers" do
-          if field == :summary
-            skip("AO3-5238 Summary field does not sanitise CSS classes")
-          else
-            result = sanitize_value(field, '<p class="8ball">foobar</p>')
-            expect(result).not_to match(/8ball/)
-            result = sanitize_value(field, '<p class="magic 8ball">foobar</p>')
-            expect(result).not_to match(/8ball/)
-          end
-        end
-  
-        it "should not allow classes starting with hyphens" do
-          if field == :summary
-            skip("AO3-5238 Summary field does not sanitise CSS classes")
-          else
-            result = sanitize_value(field, '<p class="-dash">foobar</p>')
-            expect(result).not_to match(/-dash/)
-            result = sanitize_value(field, '<p class="rainbow -dash">foobar</p>')
-            expect(result).not_to match(/-dash/)
-          end
-        end
-  
-        it "should not allow classes with special characters" do
-          if field == :summary
-            skip("AO3-5238 Summary field does not sanitise CSS classes")
-          else
-            result = sanitize_value(field, '<p class="foo@bar">foobar</p>')
-            expect(result).not_to match(/foo@bar/)
-          end
-        end
-  
-        it "should allow two classes" do
-          result = sanitize_value(field, '<p class="foo bar">foobar</p>')
-          doc = Nokogiri::HTML.fragment(result)
-          expect(doc.xpath("./p[contains(@class, 'foo bar')]").children.to_s.strip).to eq("foobar")
         end
   
         it "should allow RTL content in p" do

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -5,7 +5,7 @@ describe Comment do
   context "with an existing comment from the same user" do
     before(:all) do
       @first_comment = create(:comment)
-      attributes = %w(pseud_id commentable_id commentable_type content name email)
+      attributes = %w(pseud_id commentable_id commentable_type comment_content name email)
       @second_comment = Comment.new(
         @first_comment.attributes.slice(*attributes)
       )
@@ -13,7 +13,7 @@ describe Comment do
 
     it "should be invalid if exactly duplicated" do
       expect(@second_comment.valid?).to eq(false)
-      expect(@second_comment.errors.keys).to include(:content)
+      expect(@second_comment.errors.keys).to include(:comment_content)
     end
 
     it "should not be invalid if in the process of being deleted" do

--- a/test/fixtures/bookmarks.yml
+++ b/test/fixtures/bookmarks.yml
@@ -7,7 +7,7 @@ bookmark_00017:
   delta: true
   updated_at: 2009-07-18 00:16:47 Z
   private: false
-  notes: How much do I want to see Dean's scandalised face? THIS MUCH.
+  bookmarker_notes: How much do I want to see Dean's scandalised face? THIS MUCH.
   rec: false
   id: 17
   user_id: 
@@ -20,7 +20,7 @@ bookmark_00039:
   delta: true
   updated_at: 2009-07-18 10:43:57 Z
   private: true
-  notes: I'm so ashamed about wanting to re-read this that I'm going to bookmark it privately.
+  bookmarker_notes: I'm so ashamed about wanting to re-read this that I'm going to bookmark it privately.
   rec: false
   id: 39
   user_id: 
@@ -33,7 +33,7 @@ bookmark_00028:
   delta: true
   updated_at: 2009-07-18 10:04:33 Z
   private: false
-  notes: Testing fandom is the BEST! It's where all the best works of art live.
+  bookmarker_notes: Testing fandom is the BEST! It's where all the best works of art live.
   rec: false
   id: 28
   user_id: 
@@ -46,7 +46,7 @@ bookmark_00006:
   delta: true
   updated_at: 2009-03-20 23:41:05 Z
   private: false
-  notes: ack, I hope this is not the conclusion to the series ;_;
+  bookmarker_notes: ack, I hope this is not the conclusion to the series ;_;
   rec: false
   id: 6
   user_id: 
@@ -59,7 +59,7 @@ bookmark_00007:
   delta: true
   updated_at: 2009-07-17 23:46:13 Z
   private: false
-  notes: Bela! &lt;3 I was so gutted to see her go.
+  bookmarker_notes: Bela! &lt;3 I was so gutted to see her go.
   rec: false
   id: 7
   user_id: 
@@ -72,7 +72,7 @@ bookmark_00029:
   delta: true
   updated_at: 2009-07-18 10:07:01 Z
   private: false
-  notes: "Awwwwwwwwww, I loved this. Now I will write super long notes longer than the actual work to explain why: love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love "
+  bookmarker_notes: "Awwwwwwwwww, I loved this. Now I will write super long notes longer than the actual work to explain why: love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love love "
   rec: false
   id: 29
   user_id: 
@@ -85,7 +85,7 @@ bookmark_00040:
   delta: true
   updated_at: 2009-07-18 10:45:22 Z
   private: true
-  notes: Here's a private bookmark on a work the admin is going to hide
+  bookmarker_notes: Here's a private bookmark on a work the admin is going to hide
   rec: false
   id: 40
   user_id: 
@@ -98,7 +98,7 @@ bookmark_00018:
   delta: true
   updated_at: 2009-07-18 00:18:28 Z
   private: false
-  notes: Kind of disturbing, and yet.
+  bookmarker_notes: Kind of disturbing, and yet.
   rec: false
   id: 18
   user_id: 
@@ -111,7 +111,7 @@ bookmark_00019:
   delta: true
   updated_at: 2009-07-18 00:21:37 Z
   private: false
-  notes: Heeee, boys! Don't worry, Jared, everyone has a crush on Dean, it's part of the nature of the universe.
+  bookmarker_notes: Heeee, boys! Don't worry, Jared, everyone has a crush on Dean, it's part of the nature of the universe.
   rec: false
   id: 19
   user_id: 
@@ -124,7 +124,7 @@ bookmark_00041:
   delta: true
   updated_at: 2009-07-18 10:46:23 Z
   private: false
-  notes: Work with no author's summary
+  bookmarker_notes: Work with no author's summary
   rec: false
   id: 41
   user_id: 
@@ -137,7 +137,7 @@ bookmark_00030:
   delta: true
   updated_at: 2009-07-18 10:10:30 Z
   private: false
-  notes: My love for Uriel knows no bounds. He can get righteous on <em>my</em> ass any time.
+  bookmarker_notes: My love for Uriel knows no bounds. He can get righteous on <em>my</em> ass any time.
   rec: false
   id: 30
   user_id: 
@@ -150,7 +150,7 @@ bookmark_00008:
   delta: true
   updated_at: 2009-07-17 23:48:57 Z
   private: false
-  notes: Blah blah blah blah blah really long user notes. Blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah
+  bookmarker_notes: Blah blah blah blah blah really long user notes. Blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah
   rec: false
   id: 8
   user_id: 
@@ -163,7 +163,7 @@ bookmark_00009:
   delta: true
   updated_at: 2009-07-17 23:51:41 Z
   private: false
-  notes: I really want a bouquet of chocolate flowers now.
+  bookmarker_notes: I really want a bouquet of chocolate flowers now.
   rec: false
   id: 9
   user_id: 
@@ -176,7 +176,7 @@ bookmark_00031:
   delta: true
   updated_at: 2009-07-18 10:16:59 Z
   private: false
-  notes: |-
+  bookmarker_notes: |-
     Notes with allowed html in them!
     <a href="http://parenthetical.livejournal.com/friends">Link</a>
     <b>b</b>
@@ -219,7 +219,7 @@ bookmark_00042:
   delta: true
   updated_at: 2009-07-18 10:47:31 Z
   private: true
-  notes: All the bookmarks on this work are private.
+  bookmarker_notes: All the bookmarks on this work are private.
   rec: false
   id: 42
   user_id: 
@@ -232,7 +232,7 @@ bookmark_00020:
   delta: true
   updated_at: 2009-07-18 00:23:43 Z
   private: false
-  notes: I really enjoyed this too!
+  bookmarker_notes: I really enjoyed this too!
   rec: false
   id: 20
   user_id: 
@@ -245,7 +245,7 @@ bookmark_00021:
   delta: true
   updated_at: 2009-07-18 00:33:05 Z
   private: false
-  notes: Genius fic of geniusness. &lt;3
+  bookmarker_notes: Genius fic of geniusness. &lt;3
   rec: false
   id: 21
   user_id: 
@@ -258,7 +258,7 @@ bookmark_00043:
   delta: true
   updated_at: 2009-07-18 10:48:43 Z
   private: false
-  notes: It's a tragedy that this work wasn't recced earlier.
+  bookmarker_notes: It's a tragedy that this work wasn't recced earlier.
   rec: false
   id: 43
   user_id: 
@@ -271,7 +271,7 @@ bookmark_00032:
   delta: true
   updated_at: 2009-07-18 10:23:33 Z
   private: false
-  notes: I've never seen Torchwood, but this fic made me want to.
+  bookmarker_notes: I've never seen Torchwood, but this fic made me want to.
   rec: false
   id: 32
   user_id: 
@@ -284,7 +284,7 @@ bookmark_00010:
   delta: true
   updated_at: 2009-07-17 23:53:17 Z
   private: false
-  notes: Bookmark on a work which is going to be hidden by an admin for being TOO SCHMOOPY TO LIVE.
+  bookmarker_notes: Bookmark on a work which is going to be hidden by an admin for being TOO SCHMOOPY TO LIVE.
   rec: false
   id: 10
   user_id: 
@@ -297,7 +297,7 @@ bookmark_00011:
   delta: true
   updated_at: 2009-07-17 23:56:42 Z
   private: false
-  notes: A bookmark on an external work
+  bookmarker_notes: A bookmark on an external work
   rec: false
   id: 11
   user_id: 
@@ -310,7 +310,7 @@ bookmark_00033:
   delta: true
   updated_at: 2009-07-18 10:25:53 Z
   private: false
-  notes: Ash is too hot for <em>anyone</em> to handle. TRUFAX. (It's the mullet.)
+  bookmarker_notes: Ash is too hot for <em>anyone</em> to handle. TRUFAX. (It's the mullet.)
   rec: false
   id: 33
   user_id: 
@@ -323,7 +323,7 @@ bookmark_00044:
   delta: true
   updated_at: 2009-08-26 21:17:46 Z
   private: true
-  notes: This is a marvellous story
+  bookmarker_notes: This is a marvellous story
   rec: true
   id: 44
   user_id: 
@@ -336,7 +336,7 @@ bookmark_00022:
   delta: true
   updated_at: 2009-07-18 00:38:19 Z
   private: false
-  notes: Woe, the angst bunny made me cry. :(
+  bookmarker_notes: Woe, the angst bunny made me cry. :(
   rec: false
   id: 22
   user_id: 
@@ -349,7 +349,7 @@ bookmark_00001:
   delta: true
   updated_at: 2009-03-18 13:14:26 Z
   private: false
-  notes: "Girls always get what they want. "
+  bookmarker_notes: "Girls always get what they want. "
   rec: false
   id: 1
   user_id: 
@@ -362,7 +362,7 @@ bookmark_00023:
   delta: true
   updated_at: 2009-07-18 09:56:43 Z
   private: false
-  notes: There needs to be moar Bela in the world.
+  bookmarker_notes: There needs to be moar Bela in the world.
   rec: false
   id: 23
   user_id: 
@@ -375,7 +375,7 @@ bookmark_00045:
   delta: true
   updated_at: 2009-12-17 13:52:03 Z
   private: false
-  notes: oh wow this form is broken remind me to come back and fix this layout
+  bookmarker_notes: oh wow this form is broken remind me to come back and fix this layout
   rec: true
   id: 45
   user_id: 
@@ -388,7 +388,7 @@ bookmark_00034:
   delta: true
   updated_at: 2009-07-18 10:29:29 Z
   private: false
-  notes: I do love a good, long, multi-chapter epic. OF DOOM.
+  bookmarker_notes: I do love a good, long, multi-chapter epic. OF DOOM.
   rec: false
   id: 34
   user_id: 
@@ -401,7 +401,7 @@ bookmark_00012:
   delta: true
   updated_at: 2009-07-17 23:59:25 Z
   private: false
-  notes: Sam is totally onto something re Shakira.
+  bookmarker_notes: Sam is totally onto something re Shakira.
   rec: false
   id: 12
   user_id: 
@@ -414,7 +414,7 @@ bookmark_00013:
   delta: true
   updated_at: 2009-07-18 00:03:03 Z
   private: false
-  notes: Poor wee!Dean! He needs lots and lots of hugs, omg.
+  bookmarker_notes: Poor wee!Dean! He needs lots and lots of hugs, omg.
   rec: false
   id: 13
   user_id: 
@@ -427,7 +427,7 @@ bookmark_00035:
   delta: true
   updated_at: 2009-07-18 10:58:01 Z
   private: false
-  notes: Awwwwwww, boys. I'm going to go into such graphic detail about what I want to do with them that an admin is going to feel it necessary to hide this bookmark. Dude.
+  bookmarker_notes: Awwwwwww, boys. I'm going to go into such graphic detail about what I want to do with them that an admin is going to feel it necessary to hide this bookmark. Dude.
   rec: false
   id: 35
   user_id: 
@@ -440,7 +440,7 @@ bookmark_00046:
   delta: true
   updated_at: 2009-12-17 13:53:30 Z
   private: false
-  notes: Looks like the inside fieldset is em-widthed. This might cause issues in IE6 and 7
+  bookmarker_notes: Looks like the inside fieldset is em-widthed. This might cause issues in IE6 and 7
   rec: true
   id: 46
   user_id: 
@@ -453,7 +453,7 @@ bookmark_00024:
   delta: true
   updated_at: 2009-07-18 09:58:41 Z
   private: false
-  notes: It's all so tragic!
+  bookmarker_notes: It's all so tragic!
   rec: false
   id: 24
   user_id: 
@@ -466,7 +466,7 @@ bookmark_00002:
   delta: true
   updated_at: 2009-03-18 13:14:26 Z
   private: false
-  notes: I'm not sure why, but I'm slightly weirded out by this. The characters seem familiar somehow...
+  bookmarker_notes: I'm not sure why, but I'm slightly weirded out by this. The characters seem familiar somehow...
   rec: false
   id: 2
   user_id: 
@@ -479,7 +479,7 @@ bookmark_00003:
   delta: true
   updated_at: 2009-03-20 23:36:59 Z
   private: false
-  notes: awesome story with OT3 potential
+  bookmarker_notes: awesome story with OT3 potential
   rec: false
   id: 3
   user_id: 
@@ -492,7 +492,7 @@ bookmark_00025:
   delta: true
   updated_at: 2009-07-18 10:00:31 Z
   private: false
-  notes: Man, I love the way it loads the summary for me SO MUCH. ...The fic's awesome too! \0/
+  bookmarker_notes: Man, I love the way it loads the summary for me SO MUCH. ...The fic's awesome too! \0/
   rec: false
   id: 25
   user_id: 
@@ -505,7 +505,7 @@ bookmark_00036:
   delta: true
   updated_at: 2009-07-18 10:34:58 Z
   private: false
-  notes: Long author's notes are long, dude.
+  bookmarker_notes: Long author's notes are long, dude.
   rec: false
   id: 36
   user_id: 
@@ -518,7 +518,7 @@ bookmark_00014:
   delta: true
   updated_at: 2009-07-18 00:09:10 Z
   private: true
-  notes: I really enjoyed this! Private bookmark on an external work
+  bookmarker_notes: I really enjoyed this! Private bookmark on an external work
   rec: false
   id: 14
   user_id: 
@@ -531,7 +531,7 @@ bookmark_00015:
   delta: true
   updated_at: 2009-07-18 00:12:40 Z
   private: false
-  notes: Dean breaks my heart! *huggles him*
+  bookmarker_notes: Dean breaks my heart! *huggles him*
   rec: false
   id: 15
   user_id: 
@@ -544,7 +544,7 @@ bookmark_00037:
   delta: true
   updated_at: 2009-07-18 10:38:18 Z
   private: false
-  notes: Man, I suck at writing summaries.
+  bookmarker_notes: Man, I suck at writing summaries.
   rec: false
   id: 37
   user_id: 
@@ -557,7 +557,7 @@ bookmark_00026:
   delta: true
   updated_at: 2009-07-18 10:01:39 Z
   private: false
-  notes: I really don't want to eat popcorn any time soon now.
+  bookmarker_notes: I really don't want to eat popcorn any time soon now.
   rec: false
   id: 26
   user_id: 
@@ -570,7 +570,7 @@ bookmark_00004:
   delta: true
   updated_at: 2009-03-20 23:38:19 Z
   private: false
-  notes: rather disturbing but good
+  bookmarker_notes: rather disturbing but good
   rec: false
   id: 4
   user_id: 
@@ -583,7 +583,7 @@ bookmark_00005:
   delta: true
   updated_at: 2009-03-20 23:39:06 Z
   private: true
-  notes: nnggg, so hot
+  bookmarker_notes: nnggg, so hot
   rec: false
   id: 5
   user_id: 
@@ -596,7 +596,7 @@ bookmark_00027:
   delta: true
   updated_at: 2009-07-18 10:03:11 Z
   private: false
-  notes: Some other fucking pseud is a great author. I love their name, too. &lt;3
+  bookmarker_notes: Some other fucking pseud is a great author. I love their name, too. &lt;3
   rec: false
   id: 27
   user_id: 
@@ -609,7 +609,7 @@ bookmark_00038:
   delta: true
   updated_at: 2009-07-18 10:42:57 Z
   private: false
-  notes: These authors chose not to to warn for Mary Sue, clearly.
+  bookmarker_notes: These authors chose not to to warn for Mary Sue, clearly.
   rec: false
   id: 38
   user_id: 
@@ -622,7 +622,7 @@ bookmark_00016:
   delta: true
   updated_at: 2009-07-18 00:14:46 Z
   private: false
-  notes: I love Luna SO MUCH, omg. She wins at life! Dean/Luna is a bit of a random pairing, but I love the idea of them hanging out together.
+  bookmarker_notes: I love Luna SO MUCH, omg. She wins at life! Dean/Luna is a bit of a random pairing, but I love the idea of them hanging out together.
   rec: false
   id: 16
   user_id: 

--- a/test/fixtures/comments.yml
+++ b/test/fixtures/comments.yml
@@ -13,7 +13,7 @@ comment_00006:
   approved: true
   is_deleted: false
   parent_id: 19
-  content: level fooour (4)
+  comment_content: level fooour (4)
   user_agent: Opera/9.60 (Windows NT 6.0; U; en) Presto/2.1.1
   threaded_right: 30
   threaded_left: 5
@@ -35,7 +35,7 @@ comment_00017:
   approved: true
   is_deleted: false
   parent_id: 19
-  content: wheeeeeeee!! (8 behaves as expected. hm.)
+  comment_content: wheeeeeeee!! (8 behaves as expected. hm.)
   user_agent: Opera/9.60 (Windows NT 6.0; U; en) Presto/2.1.1
   threaded_right: 12
   threaded_left: 9
@@ -57,7 +57,7 @@ comment_00039:
   approved: true
   is_deleted: false
   parent_id: 74
-  content: Bleh
+  comment_content: Bleh
   user_agent: Mozilla/5.0 (Windows; U; Windows NT 5.1; en-GB; rv:1.9.1.3) Gecko/20090824 Firefox/3.5.3 (.NET CLR 3.5.30729)
   threaded_right: 5
   threaded_left: 2
@@ -79,7 +79,7 @@ comment_00040:
   approved: true
   is_deleted: false
   parent_id: 74
-  content: Argh
+  comment_content: Argh
   user_agent: Mozilla/5.0 (Windows; U; Windows NT 5.1; en-GB; rv:1.9.1.3) Gecko/20090824 Firefox/3.5.3 (.NET CLR 3.5.30729)
   threaded_right: 4
   threaded_left: 3
@@ -101,7 +101,7 @@ comment_00018:
   approved: true
   is_deleted: false
   parent_id: 19
-  content: blah!
+  comment_content: blah!
   user_agent: Opera/9.60 (Windows NT 6.0; U; en) Presto/2.1.1
   threaded_right: 27
   threaded_left: 26
@@ -123,7 +123,7 @@ comment_00007:
   approved: true
   is_deleted: false
   parent_id: 19
-  content: level 5 arrives!
+  comment_content: level 5 arrives!
   user_agent: Opera/9.60 (Windows NT 6.0; U; en) Presto/2.1.1
   threaded_right: 21
   threaded_left: 6
@@ -145,7 +145,7 @@ comment_00008:
   approved: true
   is_deleted: false
   parent_id: 19
-  content: 6 is here! (and it got a separate thread).
+  comment_content: 6 is here! (and it got a separate thread).
   user_agent: Opera/9.60 (Windows NT 6.0; U; en) Presto/2.1.1
   threaded_right: 16
   threaded_left: 7
@@ -167,7 +167,7 @@ comment_00019:
   approved: true
   is_deleted: false
   parent_id: 19
-  content: |-
+  comment_content: |-
     whee
     
     now take a fcking bath
@@ -192,7 +192,7 @@ comment_00041:
   approved: true
   is_deleted: false
   parent_id: 78
-  content: |-
+  comment_content: |-
     <i>RPattz is better as Cedric than as Edward.</i>
     
     He totally is!
@@ -217,7 +217,7 @@ comment_00042:
   approved: true
   is_deleted: false
   parent_id: 170
-  content: If I comment to myself does it show up in the inbox?
+  comment_content: If I comment to myself does it show up in the inbox?
   user_agent: Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10.6; en-US; rv:1.9.1.6) Gecko/20091201 Firefox/3.5.6
   threaded_right: 
   threaded_left: 
@@ -239,7 +239,7 @@ comment_00020:
   approved: true
   is_deleted: false
   parent_id: 19
-  content: avocado! :D
+  comment_content: avocado! :D
   user_agent: Opera/9.60 (Windows NT 6.0; U; en) Presto/2.1.1
   threaded_right: 36
   threaded_left: 35
@@ -261,7 +261,7 @@ comment_00009:
   approved: true
   is_deleted: false
   parent_id: 19
-  content: |-
+  comment_content: |-
     alas, replying to 6 didn't reload the original thread, but went instead straight to 6.
     
     (this is 7, by the way, the missing Cylon. :( )
@@ -286,7 +286,7 @@ comment_00032:
   approved: true
   is_deleted: true
   parent_id: 56
-  content: deleted comment
+  comment_content: deleted comment
   user_agent: Mozilla/5.0 (Windows; U; Windows NT 5.1; en-GB; rv:1.9.0.10) Gecko/2009042316 Firefox/3.0.10 (.NET CLR 3.5.30729)
   threaded_right: 10
   threaded_left: 1
@@ -308,7 +308,7 @@ comment_00010:
   approved: true
   is_deleted: false
   parent_id: 19
-  content: yet another tlc
+  comment_content: yet another tlc
   user_agent: Opera/9.60 (Windows NT 6.0; U; en) Presto/2.1.1
   threaded_right: 
   threaded_left: 
@@ -330,7 +330,7 @@ comment_00021:
   approved: true
   is_deleted: false
   parent_id: 19
-  content: Rodney?
+  comment_content: Rodney?
   user_agent: Opera/9.60 (Windows NT 6.0; U; en) Presto/2.1.1
   threaded_right: 
   threaded_left: 
@@ -352,7 +352,7 @@ comment_00043:
   approved: true
   is_deleted: false
   parent_id: 56
-  content: does this work
+  comment_content: does this work
   user_agent: Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10.6; en-US; rv:1.9.1.6) Gecko/20091201 Firefox/3.5.6
   threaded_right: 6
   threaded_left: 5
@@ -374,7 +374,7 @@ comment_00044:
   approved: true
   is_deleted: false
   parent_id: 169
-  content: Haha, I realise now that "border bottom" was a CSS term, but in connection with Harry/Draco I first wondered if it was some unknown to me fannish trope... *facepalm* Too much fandom!
+  comment_content: Haha, I realise now that "border bottom" was a CSS term, but in connection with Harry/Draco I first wondered if it was some unknown to me fannish trope... *facepalm* Too much fandom!
   user_agent: Mozilla/5.0 (Windows; U; Windows NT 6.0; en-US; rv:1.9.1.7) Gecko/20091221 Firefox/3.5.7 (.NET CLR 3.5.30729)
   threaded_right: 
   threaded_left: 
@@ -396,7 +396,7 @@ comment_00022:
   approved: true
   is_deleted: false
   parent_id: 19
-  content: John!
+  comment_content: John!
   user_agent: Opera/9.60 (Windows NT 6.0; U; en) Presto/2.1.1
   threaded_right: 
   threaded_left: 
@@ -418,7 +418,7 @@ comment_00011:
   approved: true
   is_deleted: false
   parent_id: 19
-  content: |-
+  comment_content: |-
     trivial case rly
     
     ETA: norly?
@@ -443,7 +443,7 @@ comment_00033:
   approved: true
   is_deleted: true
   parent_id: 56
-  content: deleted comment
+  comment_content: deleted comment
   user_agent: Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US) AppleWebKit/525.19 (KHTML, like Gecko) Chrome/1.0.154.65 Safari/525.19
   threaded_right: 9
   threaded_left: 2
@@ -465,7 +465,7 @@ comment_00034:
   approved: true
   is_deleted: true
   parent_id: 56
-  content: deleted comment
+  comment_content: deleted comment
   user_agent: Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US) AppleWebKit/525.19 (KHTML, like Gecko) Chrome/1.0.154.65 Safari/525.19
   threaded_right: 8
   threaded_left: 3
@@ -487,7 +487,7 @@ comment_00012:
   approved: true
   is_deleted: false
   parent_id: 19
-  content: "non-trivial: I'm going to be a level 6 comment :*"
+  comment_content: "non-trivial: I'm going to be a level 6 comment :*"
   user_agent: Opera/9.60 (Windows NT 6.0; U; en) Presto/2.1.1
   threaded_right: 18
   threaded_left: 17
@@ -509,7 +509,7 @@ comment_00001:
   approved: true
   is_deleted: false
   parent_id: 11
-  content: "Cheerful. I liked Boccaccio's version better. "
+  comment_content: "Cheerful. I liked Boccaccio's version better. "
   user_agent: Mozilla/5.0 (Windows; U; Windows NT 5.1; en-GB; rv:1.9.0.4) Gecko/2008102920 Firefox/3.0.4 (.NET CLR 3.5.30729)
   threaded_right: 
   threaded_left: 
@@ -531,7 +531,7 @@ comment_00023:
   approved: true
   is_deleted: false
   parent_id: 19
-  content: gah (I am a Six, but a marginal one)
+  comment_content: gah (I am a Six, but a marginal one)
   user_agent: Opera/9.60 (Windows NT 6.0; U; en) Presto/2.1.1
   threaded_right: 24
   threaded_left: 23
@@ -553,7 +553,7 @@ comment_00024:
   approved: true
   is_deleted: false
   parent_id: 19
-  content: 9?
+  comment_content: 9?
   user_agent: Opera/9.60 (Windows NT 6.0; U; en) Presto/2.1.1
   threaded_right: 11
   threaded_left: 10
@@ -575,7 +575,7 @@ comment_00002:
   approved: true
   is_deleted: false
   parent_id: 19
-  content: 0 level comment.
+  comment_content: 0 level comment.
   user_agent: Opera/9.60 (Windows NT 6.0; U; en) Presto/2.1.1
   threaded_right: 40
   threaded_left: 1
@@ -597,7 +597,7 @@ comment_00013:
   approved: true
   is_deleted: false
   parent_id: 19
-  content: bah, humbug (6) (Sonia Six? :D)
+  comment_content: bah, humbug (6) (Sonia Six? :D)
   user_agent: Opera/9.60 (Windows NT 6.0; U; en) Presto/2.1.1
   threaded_right: 20
   threaded_left: 19
@@ -619,7 +619,7 @@ comment_00035:
   approved: true
   is_deleted: false
   parent_id: 56
-  content: What?
+  comment_content: What?
   user_agent: Mozilla/5.0 (Windows; U; Windows NT 5.1; en-GB; rv:1.9.0.10) Gecko/2009042316 Firefox/3.0.10 (.NET CLR 3.5.30729)
   threaded_right: 7
   threaded_left: 4
@@ -641,7 +641,7 @@ comment_00036:
   approved: true
   is_deleted: false
   parent_id: 61
-  content: |-
+  comment_content: |-
     <ul><li>This</li>
     <li>Is</li>
     <li>An Ordered List</li>
@@ -676,7 +676,7 @@ comment_00014:
   approved: true
   is_deleted: false
   parent_id: 19
-  content: |-
+  comment_content: |-
     oooooh breakthrough! (7b)
     
     I want to break freeee!
@@ -701,7 +701,7 @@ comment_00003:
   approved: true
   is_deleted: false
   parent_id: 19
-  content: 1 level
+  comment_content: 1 level
   user_agent: Opera/9.60 (Windows NT 6.0; U; en) Presto/2.1.1
   threaded_right: 39
   threaded_left: 2
@@ -723,7 +723,7 @@ comment_00025:
   approved: true
   is_deleted: false
   parent_id: 19
-  content: are you still working?
+  comment_content: are you still working?
   user_agent: Mozilla/5.0 (Windows; U; Windows NT 6.0; en-US; rv:1.8.1.20) Gecko/20081217 Firefox/2.0.0.20 (.NET CLR 3.5.30729)
   threaded_right: 
   threaded_left: 
@@ -745,7 +745,7 @@ comment_00026:
   approved: true
   is_deleted: false
   parent_id: 58
-  content: I can't seem to be able to access the next story in the series, what's with that? :(
+  comment_content: I can't seem to be able to access the next story in the series, what's with that? :(
   user_agent: Mozilla/5.0 (Windows; U; Windows NT 6.0; en-US; rv:1.8.1.20) Gecko/20081217 Firefox/2.0.0.20 (.NET CLR 3.5.30729)
   threaded_right: 
   threaded_left: 
@@ -767,7 +767,7 @@ comment_00004:
   approved: true
   is_deleted: false
   parent_id: 19
-  content: level 2
+  comment_content: level 2
   user_agent: Opera/9.60 (Windows NT 6.0; U; en) Presto/2.1.1
   threaded_right: 38
   threaded_left: 3
@@ -789,7 +789,7 @@ comment_00015:
   approved: true
   is_deleted: false
   parent_id: 19
-  content: guacamole?
+  comment_content: guacamole?
   user_agent: Opera/9.60 (Windows NT 6.0; U; en) Presto/2.1.1
   threaded_right: 37
   threaded_left: 34
@@ -811,7 +811,7 @@ comment_00037:
   approved: true
   is_deleted: false
   parent_id: 61
-  content: |-
+  comment_content: |-
     This
     Is
     Just 
@@ -842,7 +842,7 @@ comment_00038:
   approved: true
   is_deleted: false
   parent_id: 74
-  content: meh
+  comment_content: meh
   user_agent: Mozilla/5.0 (Windows; U; Windows NT 5.1; en-GB; rv:1.9.1.3) Gecko/20090824 Firefox/3.5.3 (.NET CLR 3.5.30729)
   threaded_right: 6
   threaded_left: 1
@@ -864,7 +864,7 @@ comment_00016:
   approved: true
   is_deleted: false
   parent_id: 19
-  content: ngngng! (heh)
+  comment_content: ngngng! (heh)
   user_agent: Opera/9.60 (Windows NT 6.0; U; en) Presto/2.1.1
   threaded_right: 25
   threaded_left: 22
@@ -886,7 +886,7 @@ comment_00005:
   approved: true
   is_deleted: false
   parent_id: 19
-  content: level 3 lalala
+  comment_content: level 3 lalala
   user_agent: Opera/9.60 (Windows NT 6.0; U; en) Presto/2.1.1
   threaded_right: 31
   threaded_left: 4
@@ -908,7 +908,7 @@ comment_00027:
   approved: true
   is_deleted: true
   parent_id: 56
-  content: deleted comment
+  comment_content: deleted comment
   user_agent: Mozilla/5.0 (Windows; U; Windows NT 5.1; en-GB; rv:1.9.0.10) Gecko/2009042316 Firefox/3.0.10 (.NET CLR 3.5.30729)
   threaded_right: 2
   threaded_left: 1

--- a/test/fixtures/series.yml
+++ b/test/fixtures/series.yml
@@ -4,7 +4,7 @@ series_00001:
   created_at: 2008-11-09 01:26:02 Z
   title: Test Series
   updated_at: 2009-12-18 14:59:03 Z
-  notes: |-
+  series_notes: |-
     blabla
     blablabla
     blaaaablablablabla
@@ -19,7 +19,7 @@ series_00002:
   created_at: 2008-12-06 22:39:32 Z
   title: Decameron
   updated_at: 2008-12-06 22:39:32 Z
-  notes: 
+  series_notes: 
   id: 2
   complete: false
   summary: 
@@ -29,7 +29,7 @@ series_00003:
   created_at: 2009-02-24 05:16:08 Z
   title: New Series
   updated_at: 2009-02-24 05:20:30 Z
-  notes: also not empty!
+  series_notes: also not empty!
   id: 3
   complete: false
   summary: not empty!
@@ -39,7 +39,7 @@ series_00004:
   created_at: 2009-03-20 23:12:48 Z
   title: Series Made of Restricted Works
   updated_at: 2009-03-20 23:30:10 Z
-  notes: This series contains only restricted works, to test that unregistered users see no trace of it.
+  series_notes: This series contains only restricted works, to test that unregistered users see no trace of it.
   id: 4
   complete: false
   summary: Series consisting entirely of restricted works. Not logged in users should see no trace of this series!
@@ -49,7 +49,7 @@ series_00005:
   created_at: 2009-03-20 23:17:43 Z
   title: Series Made of Public and Restricted Works
   updated_at: 2009-03-20 23:25:56 Z
-  notes: This series includes both public and restricted works, to test that unregistered users see no trace of the restricted ones.
+  series_notes: This series includes both public and restricted works, to test that unregistered users see no trace of the restricted ones.
   id: 5
   complete: false
   summary: Series including both public and restricted works, unregistered users should see no trace of the restricted ones!
@@ -59,7 +59,7 @@ series_00006:
   created_at: 2009-12-12 22:43:13 Z
   title: NCIS and the...
   updated_at: 2009-12-12 22:43:13 Z
-  notes: 
+  series_notes: 
   id: 6
   complete: false
   summary: 
@@ -69,7 +69,7 @@ series_00007:
   created_at: 2009-12-12 22:48:20 Z
   title: NCIS and the...
   updated_at: 2009-12-12 22:48:20 Z
-  notes: 
+  series_notes: 
   id: 7
   complete: false
   summary: 
@@ -79,7 +79,7 @@ series_00008:
   created_at: 2009-12-12 23:00:53 Z
   title: Bridges verse
   updated_at: 2009-12-12 23:01:10 Z
-  notes: 
+  series_notes: 
   id: 8
   complete: false
   summary: 
@@ -89,7 +89,7 @@ series_00009:
   created_at: 2009-12-12 23:51:58 Z
   title: Brave New Challenge
   updated_at: 2009-12-12 23:53:07 Z
-  notes: 
+  series_notes: 
   id: 9
   complete: false
   summary: 


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5559

## Purpose

Renames some columns (and updates code accordingly) so we can apply a different sanitizer to them.

Quick note on why I chose `bookmarker_notes` rather than `bookmark_notes`: to make sure bookmark notes are displayed correctly, we need the parser to add HTML to them. However, we previously ran into an issue with search where calling the field `notes` meant HTML would be added to it, so [we did this](https://github.com/otwcode/otwarchive/blob/bd4f323003a7f63d0e708ff334fd666e4760601a/app/models/search/bookmark_search_form.rb#L72) to work around it. If I had gone with `bookmark_notes` for the new column name, we would've needed to change that as well. It just seemed easier to stick the `er` on the column name than to make more code changes. :P 

## Testing Instructions

Hahaha sob. I'll update the issue.