### PR TITLE
AO3-5567 Tell Hound to stop caring about length

### DIFF
--- a/config/.rubocop.yml
+++ b/config/.rubocop.yml
@@ -3,12 +3,25 @@
 AllCops:
   TargetRubyVersion: 2.3
 
-# stop checking for ambiguous regexp literal
+Layout/TrailingWhitespace:
+  Enabled: false
+
 Lint/AmbiguousRegexpLiteral:
   Enabled: false
 
-# stop checking line length
+Metrics/BlockLength:
+  Enabled: false
+
+Metrics/ClassLength:
+  Enabled: false
+
 Metrics/LineLength:
+  Enabled: false
+
+Metrics/MethodLength:
+  Enabled: false
+
+Metrics/ModuleLength:
   Enabled: false
 
 # prefer template tokens (like %{foo}) over annotated tokens (like %s)
@@ -21,8 +34,4 @@ Style/RedundantSelf:
 
 # stop checking quotation marks
 Style/StringLiterals:
-  Enabled: false
-
-# stop checking for trailing whitespace
-Style/TrailingWhitespace:
   Enabled: false


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5567

## Purpose

Disable metrics cops about length: block, class, line, method, module.

The TrailingWhitespace cop has been moved from Style to Layout.

```
https://github.com/rubocop-hq/rubocop/pull/4278
```

## Testing Instructions

None.