### PR TITLE
AO3-5570 Upgrade tests to use Elasticsearch 6.5.0

### DIFF
--- a/script/prepare_codeship.sh
+++ b/script/prepare_codeship.sh
@@ -35,7 +35,7 @@ bundle exec rake db:migrate --trace
 #sed -e 's/PRODUCTION_CACHE.*$//' -i config/config.yml
 #wget http://media.transformativeworks.org/ao3/codeship/prepare_part2.sh -O - | bash -x
 
-ES_VERSION="6.4.3"
+ES_VERSION="6.5.0"
 ES_PORT="9400"
 cd ~
 wget https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-${ES_VERSION}.zip

--- a/script/travis_elasticsearch_upgrade.sh
+++ b/script/travis_elasticsearch_upgrade.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-ES_VERSION="6.4.3"
+ES_VERSION="6.5.0"
 ES_PORT="9400"
 cd /tmp
 wget https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-${ES_VERSION}.tar.gz


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5570

## Purpose

Upgrade the tests to use Elasticsearch 6.5.0.

## Testing Instructions

Refer to Jira
