### PR TITLE
AO3-5571 Add better error handling to bookmark import

### DIFF
--- a/app/controllers/api/v2/base_controller.rb
+++ b/app/controllers/api/v2/base_controller.rb
@@ -56,7 +56,7 @@ module Api
       # Return a standard HTTP + Json envelope for errors that drop through other handling
       def render_standard_error_response(exception)
         message = "An error occurred in the Archive code: #{exception.message}"
-        render status: :internal_server_error, json: { status: :internal_server_error, messages: message }
+        render status: :internal_server_error, json: { status: :internal_server_error, messages: [message] }
       end
     end
   end


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5571

## Purpose

Fixes a crash in the mass import bookmark search.

## Testing Instructions

See Jira ticket
