### PR TITLE
AO3-5561 Fix comment permissions on unrevealed works

### DIFF
--- a/app/helpers/comments_helper.rb
+++ b/app/helpers/comments_helper.rb
@@ -118,7 +118,8 @@ module CommentsHelper
 
   def comment_parent_hidden?(comment)
     parent = comment.ultimate_parent
-    parent.respond_to?(:hidden_by_admin) && parent.hidden_by_admin
+    (parent.respond_to?(:hidden_by_admin) && parent.hidden_by_admin) ||
+      (parent.respond_to?(:in_unrevealed_collection) && parent.in_unrevealed_collection)
   end
 
   def no_anon_reply(comment)

--- a/app/views/comments/_commentable.html.erb
+++ b/app/views/comments/_commentable.html.erb
@@ -81,6 +81,10 @@
     <p class="notice">
       <%= ts("Sorry, you can't add or edit comments on a hidden work.") %>
     </p>
+  <% elsif commentable_parent.is_a?(Work) && commentable_parent.in_unrevealed_collection %>
+    <p class="notice">
+      <%= ts("Sorry, you can't add or edit comments on an unrevealed work.") %>
+    </p>
   <% else %>
     <div id="add_comment_placeholder" title="top level comment">
       <div id="add_comment">

--- a/features/comments_and_kudos/hidden_works.feature
+++ b/features/comments_and_kudos/hidden_works.feature
@@ -1,4 +1,5 @@
 Feature: Comments on Hidden Works
+
   Scenario: When a work is hidden, admins and the creator can see (but not edit or add) comments, while everyone else is redirected.
     Given I am logged in as "creator"
       And I post the work "To Be Hidden"
@@ -9,6 +10,7 @@ Feature: Comments on Hidden Works
       And I view the work "To Be Hidden"
       And I follow "Hide Work"
 
+    # As an admin
     When I go to the work comments page for "To Be Hidden"
     Then I should see "Do you see?"
       But I should not see "Reply"
@@ -34,4 +36,43 @@ Feature: Comments on Hidden Works
       And I go to the work comments page for "To Be Hidden"
     Then I should not see "Do you see?"
       And I should not see "Sorry, you can't add or edit comments on a hidden work."
+      But I should see "Sorry, you don't have permission to access the page you were trying to reach."
+
+  Scenario: When a work is unrevealed, admins and the creator can see (but not edit or add) comments, while everyone else is redirected.
+    Given I am logged in as "creator"
+      And I post the work "Murder, She Wrote"
+      And I post the comment "Can I change this?" on the work "Murder, She Wrote"
+      And I am logged in as "commenter"
+      And I post the comment "Do you see?" on the work "Murder, She Wrote"
+      And I am logged out
+      And I have the hidden collection "Dreamboat"
+      And I am logged in as "creator"
+      And I add the work "Murder, She Wrote" to the collection "Dreamboat"
+
+    # As the work's creator
+    When I go to the work comments page for "Murder, She Wrote"
+    Then I should see "Do you see?"
+      And I should see "Can I change this?"
+      But I should not see "Reply"
+      And I should not see "Post Comment"
+      And I should not see "Edit"
+      And I should see "Sorry, you can't add or edit comments on an unrevealed work."
+
+    When I am logged in as an admin
+      And I go to the work comments page for "Murder, She Wrote"
+    Then I should see "Do you see?"
+      But I should not see "Reply"
+      And I should not see "Post Comment"
+      And I should see "Sorry, you can't add or edit comments on an unrevealed work."
+
+    When I am logged in as "commenter"
+      And I go to the work comments page for "Murder, She Wrote"
+    Then I should not see "Do you see?"
+      And I should not see "Sorry, you can't add or edit comments on an unrevealed work."
+      But I should see "Sorry, you don't have permission to access the page you were trying to reach."
+
+    When I am logged out
+      And I go to the work comments page for "Murder, She Wrote"
+    Then I should not see "Do you see?"
+      And I should not see "Sorry, you can't add or edit comments on an unrevealed work."
       But I should see "Sorry, you don't have permission to access the page you were trying to reach."

--- a/spec/controllers/comments_controller_spec.rb
+++ b/spec/controllers/comments_controller_spec.rb
@@ -893,7 +893,7 @@ describe CommentsController do
     end
   end
 
-  xcontext "on an unrevealed work" do
+  context "on an unrevealed work" do
     it_behaves_like "no one can add or edit comments" do
       let(:edit_error_message) { "Sorry, you can't add or edit comments on an unrevealed work." }
       let(:work) { comment.ultimate_parent }


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5561

## Purpose

Check if the work is unrevealed when viewing/modifying comments. Treat the work pretty much the same as if it's hidden by an admin, just with a different error message.

## Testing Instructions

See issue.

## References

> me: can I copy your homework (#3465)?
@tickinginstant: yeah, but don't make it too obvious
me: