### PR TITLE
AO3-5541 Make draft deletion more robust.

### DIFF
--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -335,13 +335,6 @@ class Work < ApplicationRecord
     self.challenge_assignments.each {|a| a.creation = nil; a.save!}
   end
 
-  def self.purge_old_drafts
-    draft_ids = Work.where('works.posted = ? AND works.created_at < ?', false, 1.month.ago).pluck(:id)
-    Chapter.where(work_id: draft_ids).order("position DESC").map(&:destroy)
-    Work.where(id: draft_ids).map(&:destroy)
-    draft_ids.size
-  end
-
   ########################################################################
   # RESQUE
   ########################################################################

--- a/factories/works.rb
+++ b/factories/works.rb
@@ -26,6 +26,10 @@ FactoryGirl.define do
     factory :posted_work do
       posted true
     end
+
+    factory :draft do
+      posted false
+    end
   end
 
   factory :external_work do

--- a/features/step_definitions/admin_steps.rb
+++ b/features/step_definitions/admin_steps.rb
@@ -260,7 +260,7 @@ When /^the invite_from_queue_at is yesterday$/ do
 end
 
 When /^the check_queue rake task is run$/ do
-  AdminSetting.check_queue
+  step %{I run the rake task "invitations:check_queue"}
 end
 
 When /^I edit known issues$/ do

--- a/features/step_definitions/rake_steps.rb
+++ b/features/step_definitions/rake_steps.rb
@@ -1,0 +1,14 @@
+require 'rake'
+
+When /^I run the rake task "(.*?)"$/ do |name|
+  Rails.application.load_tasks unless Rake::Task.task_defined?(name)
+  task = Rake::Task[name]
+  task.invoke
+
+  # As in spec/support/task_example_group.rb, use "invoke" (and re-enable the
+  # task and its prerequisites) over "execute" (which doesn't require
+  # re-enabling, but doesn't run prerequisites) because it more closely matches
+  # the behavior of rake itself.
+  task.all_prerequisite_tasks.each { |prerequisite| Rake::Task[prerequisite].reenable }
+  task.reenable
+end

--- a/features/step_definitions/reading_steps.rb
+++ b/features/step_definitions/reading_steps.rb
@@ -8,5 +8,5 @@ Given /^(.*) first read "([^"]*)" on "([^"]*)"$/ do |login, title, date|
 end
 
 When /^the reading rake task is run$/ do
-   Reading.update_or_create_in_database
+  step %{I run the rake task "readings:to_database"}
 end

--- a/features/step_definitions/work_steps.rb
+++ b/features/step_definitions/work_steps.rb
@@ -406,7 +406,7 @@ When /^I edit multiple works coauthored as "(.*)" with "(.*)"$/ do |author, coau
 end
 
 When /^the purge_old_drafts rake task is run$/ do
-  Work.purge_old_drafts
+  step %{I run the rake task "work:purge_old_drafts"}
 end
 
 When /^the work "([^"]*)" was created (\d+) days ago$/ do |title, number|
@@ -530,8 +530,8 @@ When /^I post the work$/ do
   step %{all indexing jobs have been run}
 end
 When /^the statistics_tasks rake task is run$/ do
-  StatCounter.hits_to_database
-  StatCounter.stats_to_database
+  step %{I run the rake task "statistics:update_stat_counters"}
+  step %{I run the rake task "statistics:update_stats"}
 end
 
 When /^I add the co-author "([^"]*)" to the work "([^"]*)"$/ do |coauthor, work|

--- a/lib/tasks/work_tasks.rake
+++ b/lib/tasks/work_tasks.rake
@@ -1,7 +1,17 @@
 namespace :work do
   desc "Purge drafts created more than a month ago"
   task(:purge_old_drafts => :environment) do
-    count = Work.purge_old_drafts
+    count = 0
+    Work.unposted.where('works.created_at < ?', 1.month.ago).find_each do |work|
+      begin
+        work.destroy!
+        count += 1
+      rescue StandardError => e
+        puts "The following error occurred while trying to destroy draft #{work.id}:"
+        puts "#{e.class}: #{e.message}"
+        puts e.backtrace
+      end
+    end
     puts "Unposted works (#{count}) created more than one month ago have been purged"
   end
 

--- a/spec/miscellaneous/lib/tasks/work_tasks.rake_spec.rb
+++ b/spec/miscellaneous/lib/tasks/work_tasks.rake_spec.rb
@@ -1,0 +1,109 @@
+require 'spec_helper'
+
+describe "rake work:purge_old_drafts" do
+  context "when the draft is 27 days old" do
+    it "doesn't delete the draft" do
+      draft = Delorean.time_travel_to 27.days.ago do
+        create(:draft)
+      end
+
+      subject.invoke
+
+      expect { draft.reload }.not_to \
+        raise_exception
+    end
+  end
+
+  context "when there is a posted work that is 32 days old" do
+    it "doesn't delete the work" do
+      work = Delorean.time_travel_to 32.days.ago do
+        create(:posted_work)
+      end
+
+      subject.invoke
+
+      expect { work.reload }.not_to \
+        raise_exception
+    end
+  end
+
+  context "when the draft has multiple chapters" do
+    it "deletes the draft" do
+      draft = Delorean.time_travel_to 32.days.ago do
+        create(:draft)
+      end
+
+      create(:chapter, work: draft, authors: draft.pseuds, position: 2)
+      create(:chapter, work: draft, authors: draft.pseuds, position: 3)
+      expect(draft.chapters.count).to eq(3)
+
+      subject.invoke
+
+      expect { draft.reload }.to \
+        raise_exception(ActiveRecord::RecordNotFound)
+    end
+  end
+
+  context "when the draft is in a collection" do
+    let(:collection) { create(:collection) }
+
+    it "deletes the draft" do
+      draft = Delorean.time_travel_to 32.days.ago do
+        create(:draft, collections: [collection])
+      end
+
+      subject.invoke
+
+      expect { draft.reload }.to \
+        raise_exception(ActiveRecord::RecordNotFound)
+    end
+  end
+
+  context "when the draft is the last work in a series" do
+    let(:series) { create(:series) }
+
+    it "deletes the draft" do
+      draft = Delorean.time_travel_to 32.days.ago do
+        create(:draft, series: [series])
+      end
+
+      subject.invoke
+
+      expect { draft.reload }.to \
+        raise_exception(ActiveRecord::RecordNotFound)
+      expect { series.reload }.to \
+        raise_exception(ActiveRecord::RecordNotFound)
+    end
+  end
+
+  context "when one of the drafts cannot be deleted" do
+    let(:collection) { create(:collection) }
+
+    it "deletes the other drafts and prints an error" do
+      draft1 = Delorean.time_travel_to 34.days.ago do
+        create(:draft)
+      end
+
+      draft2 = Delorean.time_travel_to 33.days.ago do
+        create(:draft, collections: [collection])
+      end
+
+      draft3 = Delorean.time_travel_to 32.days.ago do
+        create(:draft)
+      end
+
+      # Make the deletion of draft 2 fail.
+      allow_any_instance_of(CollectionItem).to \
+        receive(:destroy).and_raise("deletion failed!")
+
+      subject.invoke
+
+      expect { draft1.reload }.to \
+        raise_exception(ActiveRecord::RecordNotFound)
+      expect { draft2.reload }.not_to \
+        raise_exception
+      expect { draft3.reload }.to \
+        raise_exception(ActiveRecord::RecordNotFound)
+    end
+  end
+end


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5541

## Purpose

This PR makes it so that chapters are no longer deleted separately from their works in the draft deletion task. This should ensure that drafts are deleted in the same transaction as their chapters, so that there will be fewer works without chapters hanging around in the future.

In addition, I rewrote the draft purge task to make it more resistant to failures, and made it print out errors for all of the drafts that couldn't be deleted (instead of stopping as soon as one work deletion throws an error).

## Testing Instructions

See the comments on JIRA.
