### PR TITLE
AO3-2839 Fix Devise settings, remove unused code in users_controller

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -195,7 +195,7 @@ Devise.setup do |config|
   # Time interval you can reset your password with a reset password key.
   # Don't put a too small interval or your users won't have the time to
   # change their passwords.
-  config.reset_password_within = 6.hours
+  config.reset_password_within = 48.hours
 
   # When set to false, does not sign a user in automatically after their password is
   # reset. Defaults to true, so a user is signed in automatically after a reset.

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -132,7 +132,7 @@ Devise.setup do |config|
 
   # ==> Configuration for :rememberable
   # The time the user will be remembered without asking for credentials again.
-  config.remember_for = ArchiveConfig.DEFAULT_SESSION_LENGTH_IN_WEEKS.weeks
+  config.remember_for = ArchiveConfig.REMEMBERED_SESSION_LENGTH_IN_MONTHS.months
 
   # Invalidates all the remember me tokens when the user signs out.
   config.expire_all_remember_me_on_sign_out = true

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -208,7 +208,7 @@ Otwarchive::Application.routes.draw do
   resources :passwords, only: [:new, :create]
 
   # When adding new nested resources, please keep them in alphabetical order
-  resources :users do
+  resources :users, except: [:new, :create] do
     member do
       get :browse
       get :change_email


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-2839

## Purpose

- Remove unused routes users#new and users#create, which have been moved to registrations_controller.
- Set password reset tokens to expire in 48h.
- Set remember me sessions to expire in 3 months.