### PR TITLE
AO3-2839 Use separate migration for failed_attempts default

### DIFF
--- a/db/migrate/20181017032400_moves_users_to_devise.rb
+++ b/db/migrate/20181017032400_moves_users_to_devise.rb
@@ -30,7 +30,6 @@ class MovesUsersToDevise < ActiveRecord::Migration[5.1]
 
       # Lockable
       t.rename :failed_login_count, :failed_attempts
-      t.change :failed_attempts, :integer, default: 0
       t.string :unlock_token
       t.index :unlock_token
       t.datetime :locked_at

--- a/db/migrate/20181201022717_change_failed_attempts_default.rb
+++ b/db/migrate/20181201022717_change_failed_attempts_default.rb
@@ -1,0 +1,5 @@
+class ChangeFailedAttemptsDefault < ActiveRecord::Migration[5.1]
+  def change
+    change_column_default :users, :failed_attempts, from: nil, to: 0
+  end
+end


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-2839

## Purpose

When we ran the Devise migration on staging, we got:
```
== 20181017032400 MovesUsersToDevise: migrating ===============================
-- change_table(:users)
rake aborted!
StandardError: An error has occurred, all later migrations canceled:

No such column: users.failed_attempts
```

Maybe this happens because we try to rename and change the same column on a big table in one go? Let's see if moving `t.change :failed_attempts, :integer, default: 0` to its own migration helps.

## Testing Instructions

On staging, first we run:

```sh
bundle exec rake db:migrate:up VERSION=20181201022717
```

This will do nothing because the column already has default 0, but it will allow us to migrate down, setting default back to null like before the Devise migration, because the Devise migration itself doesn't roll back this particular change in its own `down`.

Next, we down both:

```sh
bundle exec rake db:migrate:down VERSION=20181201022717
bundle exec rake db:migrate:down VERSION=20181017032400
```

Now we have the table as it was before Devise. Then we retry up for both, and there should hopefully be no errors.