### PR TITLE
AO3-2839 Try to prevent page caching when logged in.

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -80,20 +80,17 @@ class ApplicationController < ActionController::Base
     end
   end
 
-  # So if there is not a user_credentials cookie and the user appears to be logged in then
-  # redirect to the logout page
-
-  # TODO: Determine if this is necessary with Devise
-  # before_action :logout_if_not_user_credentials
-
-  def logout_if_not_user_credentials
-    if logged_in? && cookies[:user_credentials].nil? && controller_name != "user_sessions"
-      logger.error "Forcing logout"
-      sign_out
-      redirect_to '/lost_cookie' and return
+  # The user_credentials cookie is used by nginx to figure out whether or not
+  # to cache the page, so we want to make sure that it's set when the user is
+  # logged in, and cleared when the user is logged out.
+  before_action :ensure_user_credentials
+  def ensure_user_credentials
+    if logged_in?
+      cookies[:user_credentials] = 1 unless cookies[:user_credentials]
+    else
+      cookies.delete :user_credentials unless cookies[:user_credentials].nil?
     end
   end
-
 
   # mark the flash as being set (called when flash is set)
   def set_flash_cookie(key=nil, msg=nil)


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-2839

## Purpose

nginx checks various cookies to see whether it should perform full-page caching. Authlogic always set the cookie `user_credentials`, which is what nginx currently uses to try to make sure that it's not caching pages that were generated for a specific user. However, Devise doesn't set any special cookies, so it's hard for nginx to tell whether the user is logged in or not. As a result, it caches pages when the user is logged in and serves them to logged-out users, and it caches pages when the user is logged out and serves them to logged-in users.

This PR copies the logic from `ensure_admin_credentials` (which was added when the admin log-in system was moved over to Devise) to make sure that `user_credentials` is set.

## Testing Instructions

Try browsing the archive logged-in in one browser, and logged-out in another. Try to visit many of the same pages over and over again, and verify that the login information in the upper right corner is correct for each page. (The logged-in user should see their name; the logged-out user should see a button to log in.)