### PR TITLE
AO3-2839 Handle lost cookies for users

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -80,17 +80,20 @@ class ApplicationController < ActionController::Base
     end
   end
 
-  # The user_credentials cookie is used by nginx to figure out whether or not
-  # to cache the page, so we want to make sure that it's set when the user is
-  # logged in, and cleared when the user is logged out.
-  before_action :ensure_user_credentials
-  def ensure_user_credentials
-    if logged_in?
-      cookies[:user_credentials] = 1 unless cookies[:user_credentials]
-    else
-      cookies.delete :user_credentials unless cookies[:user_credentials].nil?
+  # So if there is not a user_credentials cookie and the user appears to be logged in then
+  # redirect to the logout page
+
+  # TODO: Determine if this is necessary with Devise
+  # before_action :logout_if_not_user_credentials
+
+  def logout_if_not_user_credentials
+    if logged_in? && cookies[:user_credentials].nil? && controller_name != "user_sessions"
+      logger.error "Forcing logout"
+      sign_out
+      redirect_to '/lost_cookie' and return
     end
   end
+
 
   # mark the flash as being set (called when flash is set)
   def set_flash_cookie(key=nil, msg=nil)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -86,7 +86,7 @@ class ApplicationController < ActionController::Base
   before_action :logout_if_not_user_credentials
 
   def logout_if_not_user_credentials
-    if logged_in? && cookies[:user_credentials].nil? && controller_name != "user_sessions"
+    if logged_in? && cookies[:user_credentials].nil? && controller_name != "users/sessions"
       logger.error "Forcing logout"
       sign_out
       redirect_to '/lost_cookie' and return

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -83,8 +83,7 @@ class ApplicationController < ActionController::Base
   # So if there is not a user_credentials cookie and the user appears to be logged in then
   # redirect to the logout page
 
-  # TODO: Determine if this is necessary with Devise
-  # before_action :logout_if_not_user_credentials
+  before_action :logout_if_not_user_credentials
 
   def logout_if_not_user_credentials
     if logged_in? && cookies[:user_credentials].nil? && controller_name != "user_sessions"

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -100,6 +100,7 @@ class ApplicationController < ActionController::Base
       logger.error "Forcing logout"
       sign_out
       redirect_to '/lost_cookie' and return
+    end
   end
 
   # mark the flash as being set (called when flash is set)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -80,19 +80,27 @@ class ApplicationController < ActionController::Base
     end
   end
 
+  # The user_credentials cookie is used by nginx to figure out whether or not
+  # to cache the page, so we want to make sure that it's set when the user is
+  # logged in, and cleared when the user is logged out.
+  before_action :ensure_user_credentials
+  def ensure_user_credentials
+    if logged_in?
+      cookies[:user_credentials] = 1 unless cookies[:user_credentials]
+    else
+      cookies.delete :user_credentials unless cookies[:user_credentials].nil?
+    end
+  end
+
   # So if there is not a user_credentials cookie and the user appears to be logged in then
   # redirect to the logout page
-
   before_action :logout_if_not_user_credentials
-
   def logout_if_not_user_credentials
     if logged_in? && cookies[:user_credentials].nil? && controller_name != "users/sessions"
       logger.error "Forcing logout"
       sign_out
       redirect_to '/lost_cookie' and return
-    end
   end
-
 
   # mark the flash as being set (called when flash is set)
   def set_flash_cookie(key=nil, msg=nil)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -67,7 +67,7 @@ class ApplicationController < ActionController::Base
     cookies[:flash_is_set] = 1 unless flash.empty?
   end
 
-  before_action :ensure_admin_credentials
+  after_action :ensure_admin_credentials
   def ensure_admin_credentials
     if logged_in_as_admin?
       # if we are logged in as an admin and we don't have the admin_credentials
@@ -95,7 +95,7 @@ class ApplicationController < ActionController::Base
   # The user_credentials cookie is used by nginx to figure out whether or not
   # to cache the page, so we want to make sure that it's set when the user is
   # logged in, and cleared when the user is logged out.
-  before_action :ensure_user_credentials
+  after_action :ensure_user_credentials
   def ensure_user_credentials
     if logged_in?
       cookies[:user_credentials] = 1 unless cookies[:user_credentials]

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -85,7 +85,7 @@ class ApplicationController < ActionController::Base
   # the user_credentials cookie or it won't fire.
   before_action :logout_if_not_user_credentials
   def logout_if_not_user_credentials
-    if logged_in? && cookies[:user_credentials].nil? && controller_name != "users/sessions"
+    if logged_in? && cookies[:user_credentials].nil? && controller_name != "sessions"
       logger.error "Forcing logout"
       sign_out
       redirect_to '/lost_cookie' and return

--- a/app/views/home/lost_cookie.html.erb
+++ b/app/views/home/lost_cookie.html.erb
@@ -1,5 +1,5 @@
 ﻿<h2 class="heading"><%= ts('Forced Logout') %></h2>
 
 <div class="userstuff">
-  <p><%= ts("You have been automatically logged out to protect your privacy. Please make sure that your browser is set to accept cookies from archiveofourown.org and delete any existing Archive cookies. If you continue to have problems logging in, please try using the <a href=\"#{login_url}\">Log In</a> page. If you still have problems after trying that, please <a href=\"#{new_feedback_report_url}\">contact Support</a>.".html_safe)  %></p>
+  <p><%= ts("You have been automatically logged out to protect your privacy. Please make sure that your browser is set to accept cookies from archiveofourown.org and delete any existing Archive cookies. If you continue to have problems logging in, please try using the <a href=\"#{ new_user_session_path}\">Log In</a> page. If you still have problems after trying that, please <a href=\"#{new_feedback_report_path}\">contact Support</a>.".html_safe)  %></p>
 </div>

--- a/app/views/home/lost_cookie.html.erb
+++ b/app/views/home/lost_cookie.html.erb
@@ -1,5 +1,5 @@
 ﻿<h2 class="heading"><%= ts('Forced Logout') %></h2>
 
 <div class="userstuff">
-  <p><%= ts("You have been automatically logged out to protect your privacy. Please make sure that your browser is set to accept cookies from archiveofourown.org and delete any existing Archive cookies. If you continue to have problems logging in, please try using the <a href=\"#{ new_user_session_path}\">Log In</a> page. If you still have problems after trying that, please <a href=\"#{new_feedback_report_path}\">contact Support</a>.".html_safe)  %></p>
+  <p><%= ts("You have been automatically logged out to protect your privacy. Please make sure that your browser is set to accept cookies from archiveofourown.org and delete any existing Archive cookies. If you continue to have problems logging in, please try using the <a href=\"#{new_user_session_path}\">Log In</a> page. If you still have problems after trying that, please <a href=\"#{new_feedback_report_path}\">contact Support</a>.".html_safe)  %></p>
 </div>


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-2839

## Purpose

Sign users out and redirect if they've lost their user_credentials cookie to prevent logged out users from seeing cached logged in pages. (We'll need this for admins, too, but that's a known issue, whereas this is something that was previously fixed.)
