### PR TITLE
AO3-5580 Prevent error in SerialWork after_destroy callback when series is nil.

### DIFF
--- a/app/models/serial_work.rb
+++ b/app/models/serial_work.rb
@@ -26,6 +26,7 @@ class SerialWork < ApplicationRecord
 
   # Ensure series bookmarks are reindexed when a new work is added to a series
   def update_series_index
+    return if series.blank?
     series.enqueue_to_index
     IndexQueue.enqueue_ids(Bookmark, series.bookmarks.pluck(:id), :main)
   end

--- a/spec/models/serial_work_spec.rb
+++ b/spec/models/serial_work_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe SerialWork do
+  describe "#destroy" do
+    context "when the series is missing" do
+      let(:work) { create(:work) }
+      let(:serial_work) { create(:serial_work, series: nil, work: work) }
+
+      it "deletes the SerialWork" do
+        expect { serial_work.destroy }.not_to raise_exception
+        expect { serial_work.reload }.to \
+          raise_exception ActiveRecord::RecordNotFound
+      end
+    end
+
+    context "when the work is missing" do
+      let(:series) { create(:series) }
+      let(:serial_work) { create(:serial_work, series: series, work: nil) }
+
+      it "deletes the SerialWork" do
+        expect { serial_work.destroy }.not_to raise_exception
+        expect { serial_work.reload }.to \
+          raise_exception ActiveRecord::RecordNotFound
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5580

## Purpose

This PR prevents an exception from occurring when trying to delete a SerialWork with no series, thus allowing works with orphaned SerialWorks to be deleted.

## Testing Instructions

See JIRA.