### PR TITLE
AO3-2839 Make full-page caching logged-in cookies permanent

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -72,7 +72,7 @@ class ApplicationController < ActionController::Base
     if logged_in_as_admin?
       # if we are logged in as an admin and we don't have the admin_credentials
       # set then set that cookie
-      cookies[:admin_credentials] = 1 unless cookies[:admin_credentials]
+      cookies.permanent[:admin_credentials] = 1 unless cookies[:admin_credentials]
     else
       # if we are NOT logged in as an admin and we have the admin_credentials
       # set then delete that cookie
@@ -98,7 +98,7 @@ class ApplicationController < ActionController::Base
   after_action :ensure_user_credentials
   def ensure_user_credentials
     if logged_in?
-      cookies[:user_credentials] = 1 unless cookies[:user_credentials]
+      cookies.permanent[:user_credentials] = 1 unless cookies[:user_credentials]
     else
       cookies.delete :user_credentials unless cookies[:user_credentials].nil?
     end


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-2839

## Purpose

nginx checks for the cookies `user_credentials` and `admin_credentials` to avoid full-page caching if the page is from a logged in user or admin. These cookies should stick around (20 years) so users don't get redirected to /lost_cookie when they close and reopen browsers, which clears session cookies.

## Testing Instructions

- Log in (as admin, as user, as user with "Remember Me" checked)
- Close the browser
- Reopen it, you should still be logged in, not get redirected to "Forced Logout"

## Credit

@tickinginstant found the issue and the fix.