### PR TITLE
AO3-2839 Keep invitation token when sign-up form is submitted

### DIFF
--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -4,11 +4,7 @@ class Users::RegistrationsController < Devise::RegistrationsController
 
   def new
     super do |resource|
-      if params[:invitation_token]
-        @invitation = Invitation.find_by(token: params[:invitation_token])
-        resource.invitation_token = @invitation.token
-        resource.email = @invitation.invitee_email
-      end
+      set_invitation(resource)
 
       @hide_dashboard = true
     end
@@ -27,6 +23,7 @@ class Users::RegistrationsController < Devise::RegistrationsController
         if resource.save
           notify_and_show_confirmation_screen
         else
+          set_invitation(resource)
           render action: 'new'
         end
       end
@@ -34,6 +31,14 @@ class Users::RegistrationsController < Devise::RegistrationsController
   end
 
   private
+
+  def set_invitation(resource)
+    if params[:invitation_token]
+      @invitation = Invitation.find_by(token: params[:invitation_token])
+      resource.invitation_token = @invitation.token
+      resource.email = @invitation.invitee_email if resource.email.blank?
+    end
+  end
 
   def notify_and_show_confirmation_screen
     # deliver synchronously to avoid getting caught in backed-up mail queue

--- a/features/users/user_create.feature
+++ b/features/users/user_create.feature
@@ -34,6 +34,26 @@ Feature: Sign Up for a new account
       | user_registration_age_over_13      | Sorry, you have to be over 13!                                      |
       | user_registration_terms_of_service | Sorry, you need to accept the Terms of Service in order to sign up. |
 
+  Scenario: The user should be able to sign up after fixing form errors.
+    When I fill in the sign up form with valid data
+      And I fill in "Valid email" with "lyingrobot@example.com"
+      And I uncheck "Yes, I have read the Terms of Service and agree to them."
+      And I press "Create Account"
+    Then I should see "Sorry, you need to accept the Terms of Service in order to sign up."
+      And I should not see "Sorry, you have to be over 13!"
+      # Email should be what the user filled in, not the invitee email on the invitation
+      And I should see "lyingrobot@example.com" in the "Valid email" input
+
+    When I check "Yes, I have read the Terms of Service and agree to them."
+      And I fill in "Password" with "password"
+      And I fill in "Confirm password" with "password"
+      And all emails have been delivered
+      And I press "Create Account"
+    Then I should see "Account Created!"
+      And 1 email should be delivered to "lyingrobot@example.com"
+      And I should get a new user activation email
+      And a new user account should exist
+
   Scenario: The user should not be able to sign up with a login that is already in use
     Given the following users exist
       | login | password |

--- a/spec/controllers/users/registrations_controller_spec.rb
+++ b/spec/controllers/users/registrations_controller_spec.rb
@@ -56,10 +56,17 @@ describe Users::RegistrationsController do
           post :create, params: { user_registration: valid_user_attributes,
                                   invitation_token: invitation.token }
 
+          new_user = User.last
+
           expect(response).to be_success
           expect(assigns(:user)).to be_a(User)
-          expect(assigns(:user)).to eq(User.last)
+          expect(assigns(:user)).to eq(new_user)
           expect(assigns(:user).login).to eq("myname")
+
+          invitation.reload
+          expect(invitation.redeemed_at).not_to be_nil
+          expect(invitation.invitee).to eq(new_user)
+          expect(new_user.invitation).to eq(invitation)
         end
       end
 


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-2839

## Purpose

- Sign up with an invitation token, mess up on the form, get errors
- Fix the errors, click "Create Account"
- Get redirected to /invite_requests, no accounts were made, since the invitation token got lost when the form errors. This pull fixes that.

## Testing Instructions

See issue.