### PR TITLE
AO3-5584 CollectionItemsController permissions.

### DIFF
--- a/app/controllers/collection_items_controller.rb
+++ b/app/controllers/collection_items_controller.rb
@@ -153,7 +153,7 @@ class CollectionItemsController < ApplicationController
   end
 
   def update_multiple
-    if @collection && @collection.user_is_maintainer?(current_user)
+    if @collection&.user_is_maintainer?(current_user)
       allowed_items = @collection.collection_items
       update_params = collection_update_multiple_params
     elsif @user && @user == current_user
@@ -200,14 +200,14 @@ class CollectionItemsController < ApplicationController
   end
 
   def user_update_multiple_params
-    params.slice(:collection_items).permit(collection_items: [
-      :user_approval_status, :remove
-    ]).require(:collection_items)
+    allowed = %i[user_approval_status remove]
+    params.slice(:collection_items).permit(collection_items: allowed).
+      require(:collection_items)
   end
 
   def collection_update_multiple_params
-    params.slice(:collection_items).permit(collection_items: [
-      :collection_approval_status, :remove, :unrevealed, :anonymous
-    ]).require(:collection_items)
+    allowed = %i[collection_approval_status remove unrevealed anonymous]
+    params.slice(:collection_items).permit(collection_items: allowed).
+      require(:collection_items)
   end
 end

--- a/app/controllers/collection_items_controller.rb
+++ b/app/controllers/collection_items_controller.rb
@@ -154,16 +154,21 @@ class CollectionItemsController < ApplicationController
 
   def update_multiple
     if @collection&.user_is_maintainer?(current_user)
-      allowed_items = @collection.collection_items
-      update_params = collection_update_multiple_params
+      update_multiple_with_params(@collection.collection_items,
+                                  collection_update_multiple_params)
     elsif @user && @user == current_user
-      allowed_items = CollectionItem.for_user(@user)
-      update_params = user_update_multiple_params
+      update_multiple_with_params(CollectionItem.for_user(@user),
+                                  user_update_multiple_params)
     else
       flash[:error] = ts("You don't have permission to do that, sorry!")
-      redirect_to(@collection || @user) && return
+      redirect_to(@collection || @user)
     end
+  end
 
+  # The main work performed by update_multiple. Uses the passed-in parameters
+  # to update, and only updates items that can be found in allowed_items (which
+  # should be a relation on CollectionItems).
+  def update_multiple_with_params(allowed_items, update_params)
     # Collect any failures so that we can display errors:
     @collection_items = []
 

--- a/app/views/collection_items/_item_fields.html.erb
+++ b/app/views/collection_items/_item_fields.html.erb
@@ -4,7 +4,6 @@
       <!--title-->
       <h4 class="heading" id="collection_item_<%= collection_item.id %>">
         <%= error_messages_for collection_item %>
-        <%= form.hidden_field :collection_id %>
         <%= link_to collection_item_display_title(collection_item), collection_item.item %>
       </h4>
 

--- a/spec/controllers/collection_items_controller_spec.rb
+++ b/spec/controllers/collection_items_controller_spec.rb
@@ -170,11 +170,11 @@ describe CollectionItemsController do
         before { fake_login_known_user(work_owner) }
 
         context "setting user_approval_status" do
-          let(:attributes) { { user_approval_status: -1 } }
+          let(:attributes) { { user_approval_status: CollectionItem::REJECTED } }
 
           it "updates the collection item and redirects" do
             patch :update_multiple, params: params
-            expect(item.reload.user_approval_status).to eq(-1)
+            expect(item.reload.user_approval_status).to eq(CollectionItem::REJECTED)
             it_redirects_to_with_notice(user_collection_items_path(work_owner),
                                         "Collection status updated!")
           end
@@ -193,7 +193,7 @@ describe CollectionItemsController do
         end
 
         {
-          collection_approval_status: -1,
+          collection_approval_status: CollectionItem::REJECTED,
           unrevealed: true,
           anonymous: true
         }.each_pair do |field, value|
@@ -243,7 +243,7 @@ describe CollectionItemsController do
         before { fake_login_known_user(collection.owners.first.user) }
 
         {
-          collection_approval_status: -1,
+          collection_approval_status: CollectionItem::REJECTED,
           unrevealed: true,
           anonymous: true
         }.each_pair do |field, value|
@@ -272,13 +272,13 @@ describe CollectionItemsController do
         end
 
         context "setting user_approval_status" do
-          let(:attributes) { { user_approval_status: -1 } }
+          let(:attributes) { { user_approval_status: CollectionItem::REJECTED } }
 
           it "throws an error and doesn't update" do
             expect do
               patch :update_multiple, params: params
             end.to raise_exception(ActionController::UnpermittedParameters)
-            expect(item.reload.user_approval_status).not_to eq(-1)
+            expect(item.reload.user_approval_status).not_to eq(CollectionItem::REJECTED)
           end
         end
       end
@@ -292,14 +292,14 @@ describe CollectionItemsController do
         {
           user_id: user.login,
           collection_items: {
-            item.id => { user_approval_status: -1 }
+            item.id => { user_approval_status: CollectionItem::REJECTED }
           }
         }
       end
 
       it "silently fails to update the collection item" do
         patch :update_multiple, params: params
-        expect(item.reload.user_approval_status).not_to eq(-1)
+        expect(item.reload.user_approval_status).not_to eq(CollectionItem::REJECTED)
         it_redirects_to_with_notice(user_collection_items_path(user),
                                     "Collection status updated!")
       end
@@ -313,14 +313,14 @@ describe CollectionItemsController do
         {
           collection_id: other_collection.name,
           collection_items: {
-            item.id => { collection_approval_status: -1 }
+            item.id => { collection_approval_status: CollectionItem::REJECTED }
           }
         }
       end
 
       it "silently fails to update the collection item" do
         patch :update_multiple, params: params
-        expect(item.reload.collection_approval_status).not_to eq(-1)
+        expect(item.reload.collection_approval_status).not_to eq(CollectionItem::REJECTED)
         it_redirects_to_with_notice(collection_items_path(other_collection),
                                     "Collection status updated!")
       end

--- a/spec/controllers/collection_items_controller_spec.rb
+++ b/spec/controllers/collection_items_controller_spec.rb
@@ -119,4 +119,211 @@ describe CollectionItemsController do
       end
     end
   end
+
+  describe "PATCH #update_multiple" do
+    let(:collection) { create(:collection) }
+    let(:work) { create(:work) }
+    let(:item) { create(:collection_item, collection: collection, item: work) }
+
+    let(:attributes) { { remove: "1" } }
+
+    describe "on the user collection items page for the work's owner" do
+      let(:work_owner) { work.pseuds.first.user }
+
+      let(:params) do
+        {
+          user_id: work_owner.login,
+          collection_items: {
+            item.id => attributes
+          }
+        }
+      end
+
+      context "when logged out" do
+        before { fake_logout }
+
+        it "errors and redirects" do
+          patch :update_multiple, params: params
+          it_redirects_to_with_error(work_owner, "You don't have permission to do that, sorry!")
+        end
+      end
+
+      context "when logged in as a random user" do
+        before { fake_login }
+
+        it "errors and redirects" do
+          patch :update_multiple, params: params
+          it_redirects_to_with_error(work_owner, "You don't have permission to do that, sorry!")
+        end
+      end
+
+      context "when logged in as the collection owner" do
+        before { fake_login_known_user(collection.owners.first.user) }
+
+        it "errors and redirects" do
+          patch :update_multiple, params: params
+          it_redirects_to_with_error(work_owner, "You don't have permission to do that, sorry!")
+        end
+      end
+
+      context "when logged in as the work's owner" do
+        before { fake_login_known_user(work_owner) }
+
+        context "setting user_approval_status" do
+          let(:attributes) { { user_approval_status: -1 } }
+
+          it "updates the collection item and redirects" do
+            patch :update_multiple, params: params
+            expect(item.reload.user_approval_status).to eq(-1)
+            it_redirects_to_with_notice(user_collection_items_path(work_owner),
+                                        "Collection status updated!")
+          end
+        end
+
+        context "setting remove" do
+          let(:attributes) { { remove: "1" } }
+
+          it "deletes the collection item and redirects" do
+            patch :update_multiple, params: params
+            expect { item.reload }.to \
+              raise_exception(ActiveRecord::RecordNotFound)
+            it_redirects_to_with_notice(user_collection_items_path(work_owner),
+                                        "Collection status updated!")
+          end
+        end
+
+        {
+          collection_approval_status: -1,
+          unrevealed: true,
+          anonymous: true
+        }.each_pair do |field, value|
+          context "setting #{field}" do
+            let(:attributes) { { field => value } }
+
+            it "throws an error and doesn't update" do
+              expect do
+                patch :update_multiple, params: params
+              end.to raise_exception(ActionController::UnpermittedParameters)
+              expect(item.reload.send(field)).not_to eq(value)
+            end
+          end
+        end
+      end
+    end
+
+    describe "on the collection items page for the work's collection" do
+      let(:params) do
+        {
+          collection_id: collection.name,
+          collection_items: {
+            item.id => attributes
+          }
+        }
+      end
+
+      context "when logged out" do
+        before { fake_logout }
+
+        it "errors and redirects" do
+          patch :update_multiple, params: params
+          it_redirects_to_with_error(collection, "You don't have permission to do that, sorry!")
+        end
+      end
+
+      context "when logged in as a random user" do
+        before { fake_login }
+
+        it "errors and redirects" do
+          patch :update_multiple, params: params
+          it_redirects_to_with_error(collection, "You don't have permission to do that, sorry!")
+        end
+      end
+
+      context "when logged in as a maintainer" do
+        before { fake_login_known_user(collection.owners.first.user) }
+
+        {
+          collection_approval_status: -1,
+          unrevealed: true,
+          anonymous: true
+        }.each_pair do |field, value|
+          context "setting #{field}" do
+            let(:attributes) { { field => value } }
+
+            it "updates the collection item and redirects" do
+              patch :update_multiple, params: params
+              expect(item.reload.send(field)).to eq(value)
+              it_redirects_to_with_notice(collection_items_path(collection),
+                                          "Collection status updated!")
+            end
+          end
+        end
+
+        context "setting remove" do
+          let(:attributes) { { remove: "1" } }
+
+          it "deletes the collection item and redirects" do
+            patch :update_multiple, params: params
+            expect { item.reload }.to \
+              raise_exception(ActiveRecord::RecordNotFound)
+            it_redirects_to_with_notice(collection_items_path(collection),
+                                        "Collection status updated!")
+          end
+        end
+
+        context "setting user_approval_status" do
+          let(:attributes) { { user_approval_status: -1 } }
+
+          it "throws an error and doesn't update" do
+            expect do
+              patch :update_multiple, params: params
+            end.to raise_exception(ActionController::UnpermittedParameters)
+            expect(item.reload.user_approval_status).not_to eq(-1)
+          end
+        end
+      end
+    end
+
+    describe "on the collection items page for a different user" do
+      let(:user) { create(:user) }
+      before { fake_login_known_user(user) }
+
+      let(:params) do
+        {
+          user_id: user.login,
+          collection_items: {
+            item.id => { user_approval_status: -1 }
+          }
+        }
+      end
+
+      it "silently fails to update the collection item" do
+        patch :update_multiple, params: params
+        expect(item.reload.user_approval_status).not_to eq(-1)
+        it_redirects_to_with_notice(user_collection_items_path(user),
+                                    "Collection status updated!")
+      end
+    end
+
+    describe "on the collection items page for a different collection" do
+      let(:other_collection) { create(:collection) }
+      before { fake_login_known_user(other_collection.owners.first.user) }
+
+      let(:params) do
+        {
+          collection_id: other_collection.name,
+          collection_items: {
+            item.id => { collection_approval_status: -1 }
+          }
+        }
+      end
+
+      it "silently fails to update the collection item" do
+        patch :update_multiple, params: params
+        expect(item.reload.collection_approval_status).not_to eq(-1)
+        it_redirects_to_with_notice(collection_items_path(other_collection),
+                                    "Collection status updated!")
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5584

## Purpose

This PR modifies `CollectionItemsController#update_multiple` in several ways:
1. It checks whether the user has permission to perform the desired action.
2. It checks whether the IDs submitted to be updated are from assignments that belong to the correct user/collection, and silently excludes the ID if it doesn't belong.
3. It restricts the allowed parameters so that collection owners can't update `user_approval_status`, and the work's owner can't update `collection_approval_status`, `unrevealed`, or `anonymous`. (And neither one can update `collection_id`.)

## Testing Instructions

Available on Slack, or the Wiki.