### PR TITLE
AO3-2839 Update selectors for alert flash messages

### DIFF
--- a/public/stylesheets/site/2.0/22-system-messages.css
+++ b/public/stylesheets/site/2.0/22-system-messages.css
@@ -9,7 +9,8 @@ System messages use the following colours:
   font-weight: 900;
 }
 
-.required, .error, .alert {
+/* We don't generally chain class selectors, but Devise's non-customizable alert class conflicts with ours, making it necessary here */
+.required, .error, .alert.flash {
   color: #900;
 }
 
@@ -28,7 +29,7 @@ div.error {
     border-radius: 0.25em;
 }
 
-.notice, .comment_notice, ul.notes, .caution, .error, .comment_error, .alert {
+.notice, .comment_notice, ul.notes, .caution, .error, .comment_error, .alert.flash {
   background: #d1e1ef;
   border: 1px solid #c2d2df;
   margin: 0.643em auto;
@@ -44,7 +45,7 @@ div.error {
   border-color: #d89e36;
 }
 
-.error, .comment_error, .alert {
+.error, .comment_error, .alert.flash {
   background: #efd1d1;
   border-color: #900;
     box-shadow: 1px 1px 2px;
@@ -58,13 +59,13 @@ form .notice, form ul.notes {
     box-shadow: 0px 0 3px #fff;
 }
 
-ul.notes, .error ul, .alert ul {
+ul.notes, .error ul, .alert.flash ul {
   position: static;
   margin: auto 0.643em;
   padding: 0.25em 2.5em;
 }
 
-ul.notes li, .error ul li, .alert ul li {
+ul.notes li, .error ul li, .alert.flash ul li {
   list-style-type: disc;
   padding-left: 1.5em;
 }


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-2839

## Purpose

Changes the CSS selectors we use for styling the new alert flash notice to prevent it from applying to admin banners.

## Testing Instructions

Put up an alert admin banner and make sure it doesn't have any pink on it.