### PR TITLE
AO3-2839 Add unique index to Devise token columns

### DIFF
--- a/db/migrate/20181017032400_moves_users_to_devise.rb
+++ b/db/migrate/20181017032400_moves_users_to_devise.rb
@@ -15,7 +15,7 @@ class MovesUsersToDevise < ActiveRecord::Migration[5.1]
 
       # Recoverable
       t.string :reset_password_token
-      t.index :reset_password_token
+      t.index :reset_password_token, unique: true
       t.datetime :reset_password_sent_at
 
       # Rememberable
@@ -31,7 +31,7 @@ class MovesUsersToDevise < ActiveRecord::Migration[5.1]
       # Lockable
       t.rename :failed_login_count, :failed_attempts
       t.string :unlock_token
-      t.index :unlock_token
+      t.index :unlock_token, unique: true
       t.datetime :locked_at
     end
   end

--- a/db/migrate/20181222042042_add_unique_index_to_user_confirmation_tokens.rb
+++ b/db/migrate/20181222042042_add_unique_index_to_user_confirmation_tokens.rb
@@ -1,0 +1,6 @@
+class AddUniqueIndexToUserConfirmationTokens < ActiveRecord::Migration[5.1]
+  def change
+    remove_index :users, :confirmation_token
+    add_index :users, :confirmation_token, unique: true
+  end
+end


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-2839

## Purpose

These columns should not have duplicate values. Reference the auto-generated migration from Devise:

https://github.com/plataformatec/devise/blob/8266e8557622c978e6927a635d62e245bf54f239/lib/generators/active_record/templates/migration.rb

## Testing Instructions

On staging, run:
```rb
bundle exec rake db:migrate:down VERSION=20181201022717
bundle exec rake db:migrate:down VERSION=20181017032400
```
since we will need to rerun `20181017032400`.

Then retry up `20181017032400`, then `20181201022717`, then the new migration in this pull.