### PR TITLE
AO3-2839 AO3-5576 Update login forms, password reset emails, and password change notice

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -68,7 +68,7 @@ class UsersController < ApplicationController
     @user.password_confirmation = params[:password_confirmation]
 
     if @user.save
-      flash[:notice] = ts('Your password has been changed')
+      flash[:notice] = ts("Your password has been changed. To protect your account, you have been logged out of all active sessions. Please log in with your new password.")
       @user.create_log_item(options = { action: ArchiveConfig.ACTION_PASSWORD_RESET })
 
       redirect_to(user_profile_path(@user)) && return

--- a/app/validators/email_format_validator.rb
+++ b/app/validators/email_format_validator.rb
@@ -1,10 +1,8 @@
 # From Authlogic, to mimic old behavior
 #
-# https://github.com/binarylogic/authlogic/blob/master/lib/authlogic/regex.rb
-# (line 13)
+# https://github.com/binarylogic/authlogic/blob/v3.6.0/lib/authlogic/regex.rb#L13
 #
-# https://github.com/binarylogic/authlogic/blob/master/lib/authlogic/acts_as_authentic/email.rb
-# (line 90)
+# https://github.com/binarylogic/authlogic/blob/v3.6.0/lib/authlogic/acts_as_authentic/email.rb#L90
 #
 class EmailFormatValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, value)
@@ -23,7 +21,7 @@ class EmailFormatValidator < ActiveModel::EachValidator
 
     unless result
       if options[:allow_blank]
-        record.errors[attribute] << (options[:message] || I18.t('validators.email.format.allow_blank'))
+        record.errors[attribute] << (options[:message] || I18n.t('validators.email.format.allow_blank'))
       else
         record.errors[attribute] << (options[:message] || I18n.t('validators.email.format.no_blank'))
       end

--- a/app/views/users/mailer/reset_password_instructions.html.erb
+++ b/app/views/users/mailer/reset_password_instructions.html.erb
@@ -1,6 +1,6 @@
 <% content_for :message do %>
   <p><%= t('.intro', user: style_bold(@resource.login)).html_safe %></p>
-  <p><%= link_to t(".link_title"), edit_user_password_url(reset_password_token: @token) %></p>
+  <p><%= style_link t(".link_title"), edit_user_password_url(reset_password_token: @token) %></p>
   <p><%= t '.expiration' %></p>
   <p><%= t '.unrequested' %></p>
 <% end %>

--- a/app/views/users/sessions/_passwd.html.erb
+++ b/app/views/users/sessions/_passwd.html.erb
@@ -1,6 +1,6 @@
 <%= form_for(User.new, url: new_user_session_path) do |f| %>
   <dl>
-    <dt><%= f.label :login, ts("User name:") %></dt>
+    <dt><%= f.label :login, ts("User name or email:") %></dt>
     <dd><%= f.text_field :login %></dd>
     <dt><%= f.label :password, ts("Password:") %></dt>
     <dd><%= f.password_field :password %></dd>

--- a/app/views/users/sessions/_passwd_small.html.erb
+++ b/app/views/users/sessions/_passwd_small.html.erb
@@ -1,6 +1,6 @@
 <%= form_for(User.new, url: user_session_path) do |f| %>
 	<dl>
-    <dt><%= f.label :login, ts("User name:") %></dt>
+    <dt><%= f.label :login, ts("User name or email:") %></dt>
     <dd><%= f.text_field :login, :class => 'text', :size => nil %></dd>
     <dt><%= f.label :password, ts("Password:") %></dt>
     <dd><%= f.password_field :password, :class => 'text', :size => nil %></dd>

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -74,7 +74,7 @@ en:
   users:
     mailer:
       reset_password_instructions:
-        subject: "[%{app_name}] Generated reset password link"
+        subject: "[%{app_name}] Reset your password"
         intro: "%{user}, someone has requested a password reset for your account. You can change your account password by following the link below and entering your new password:"
         link_title: "Change my password."
         expiration: "If you do not use this link to reset your password within a week, it will expire, and you will have to request a new one."

--- a/features/other_a/profile_edit.feature
+++ b/features/other_a/profile_edit.feature
@@ -6,50 +6,49 @@ Feature: Edit profile
 
 Background:
   Given the following activated user exists
-	| login    | password   | email  	   |
-	| editname | password   | bar@ao3.org  |
-  And I am logged in as "editname"
-  And I want to edit my profile
-
+    | login    | password   | email  	    |
+    | editname | password   | bar@ao3.org |
+    And I am logged in as "editname"
+    And I want to edit my profile
 
 Scenario: Add details
 
   When I fill in the details of my profile
   Then I should see "Your profile has been successfully updated"
-	  And 0 emails should be delivered
+    And 0 emails should be delivered
 
 Scenario: Change details
 
   When I change the details in my profile
   Then I should see "Your profile has been successfully updated"
-	  And 0 emails should be delivered
+    And 0 emails should be delivered
 
 Scenario: Remove details
 
   When I remove details from my profile
-    Then I should see "Your profile has been successfully updated"
+  Then I should see "Your profile has been successfully updated"
     And 0 emails should be delivered
 
 Scenario: Changing email address requires reauthenticating
 
   When I follow "Change Email"
-  And I fill in "New Email" with "blah@a.com"
-  And I fill in "Confirm New Email" with "blah@a.com"
-  And I press "Change Email"
-    Then I should see "You must enter your password"
+    And I fill in "New Email" with "blah@a.com"
+    And I fill in "Confirm New Email" with "blah@a.com"
+    And I press "Change Email"
+  Then I should see "You must enter your password"
     And 0 emails should be delivered
 
 Scenario: Changing email address - entering an invalid email address
 
   When I enter an invalid email
-	Then I should see "Email does not seem to be a valid address"
-	And 0 emails should be delivered
+  Then I should see "Email does not seem to be a valid address"
+    And 0 emails should be delivered
 
 Scenario: Changing email address - entering an incorrect password
 
   When I enter an incorrect password
-    Then I should see "Your password was incorrect"
-	And 0 emails should be delivered
+  Then I should see "Your password was incorrect"
+    And 0 emails should be delivered
 
 Scenario: Changing email address and viewing
 
@@ -60,7 +59,7 @@ Scenario: Changing email address and viewing
     And the email should contain "the email associated with your account has been changed to"
     And the email should contain "valid2@archiveofourown.org"
     And the email should not contain "translation missing"
-	When I change my preferences to display my email address
+  When I change my preferences to display my email address
   Then I should see "My email address: valid2@archiveofourown.org"
 
 Scenario: Changing email address after requesting temporary password
@@ -101,33 +100,33 @@ Scenario: Changing email address -- can't be the same as another user's
 
   When I enter a duplicate email
   Then I should see "Email has already been taken"
-	  And 0 emails should be delivered
+    And 0 emails should be delivered
 
 Scenario: Date of birth - under age
 
   When I enter a birthdate that shows I am under age
-    Then I should see "You must be over 13"
+  Then I should see "You must be over 13"
 
 Scenario: Entering date of birth and displaying
 
   When I fill in my date of birth
-    Then I should see "Your profile has been successfully updated"
-    When I change my preferences to display my date of birth
-    Then I should see "My birthday: 1980-11-30"
-	  And 0 emails should be delivered
+  Then I should see "Your profile has been successfully updated"
+  When I change my preferences to display my date of birth
+  Then I should see "My birthday: 1980-11-30"
+    And 0 emails should be delivered
 
 Scenario: Change password - mistake in typing old password
 
   When I make a mistake typing my old password
-    Then I should see "Your old password was incorrect"
+  Then I should see "Your old password was incorrect"
 
 Scenario: Change password - mistake in typing new password confirmation
 
   When I make a typing mistake confirming my new password
-    Then I should see "Password confirmation doesn't match confirmation"
+  Then I should see "Password confirmation doesn't match confirmation"
 
 Scenario: Change password
 
   When I change my password
-    Then I should see "Your password has been changed"
-	And 0 emails should be delivered
+  Then I should see "Your password has been changed. To protect your account, you have been logged out of all active sessions. Please log in with your new password."
+    And 0 emails should be delivered

--- a/features/other_a/profile_edit.feature
+++ b/features/other_a/profile_edit.feature
@@ -62,7 +62,7 @@ Scenario: Changing email address and viewing
   When I change my preferences to display my email address
   Then I should see "My email address: valid2@archiveofourown.org"
 
-Scenario: Changing email address after requesting temporary password
+Scenario: Changing email address after requesting password reset
 
   When I am logged out
     And I follow "Forgot password?"
@@ -80,21 +80,6 @@ Scenario: Changing email address after requesting temporary password
     And the email should not contain "translation missing"
   When I change my preferences to display my email address
   Then I should see "My email address: valid2@archiveofourown.org"
-
-Scenario: Changing email address after requesting temporary password by entering temporary password
-
-  When I am logged out
-    And I am on the home page
-    And I follow "Forgot password?"
-    And I fill in "Email address or user name:" with "editname"
-    And I press "Reset Password"
-  Then 1 email should be delivered to "bar@ao3.org"
-  When all emails have been delivered
-    And I am logged in as "editname"
-    And I want to edit my profile
-    And I enter a temporary password for user editname
-  Then I should see "Your password was incorrect"
-    And 0 emails should be delivered
 
 Scenario: Changing email address -- can't be the same as another user's
 

--- a/features/step_definitions/profile_steps.rb
+++ b/features/step_definitions/profile_steps.rb
@@ -37,14 +37,6 @@ When /^I enter an incorrect password$/ do
   click_button("Change Email")
 end
 
-When /^I enter a temporary password for user (.*)$/ do |login|
-  click_link("Change Email")
-  fill_in("new_email", with: "valid2@archiveofourown.org")
-  fill_in("email_confirmation", with: "valid2@archiveofourown.org")
-  user = User.find_by(login: login)
-  fill_in("password_check", with: user.confirmation_token)
-  click_button("Change Email")
-end
 
 When /^I change my email$/ do
   click_link("Change Email")

--- a/features/step_definitions/tag_steps.rb
+++ b/features/step_definitions/tag_steps.rb
@@ -134,8 +134,8 @@ Given /^the tag wrangler "([^\"]*)" with password "([^\"]*)" is wrangler of "([^
   visit new_user_session_path
   user_record = find_or_create_new_user(user, password)
 
-  fill_in "User name", with: user
-  fill_in "Password", with: password
+  fill_in "User name or email:", with: user
+  fill_in "Password:", with: password
   check "Remember Me"
   click_button "Log In"
 

--- a/features/step_definitions/user_steps.rb
+++ b/features/step_definitions/user_steps.rb
@@ -110,8 +110,8 @@ Given /^I am logged in as "([^"]*)" with password "([^"]*)"(?:( with preferences
   step %{I am on the homepage}
   find_link('login-dropdown').click
 
-  fill_in "User name", with: login
-  fill_in "Password", with: password
+  fill_in "User name or email:", with: login
+  fill_in "Password:", with: password
   check "Remember Me"
   click_button "Log In"
   step %{confirmation emails have been delivered}

--- a/features/tags_and_wrangling/tag_comment.feature
+++ b/features/tags_and_wrangling/tag_comment.feature
@@ -93,12 +93,12 @@ I'd like to comment on a tag'
   Scenario: Issue 2185: email notifications for tag commenting; TO DO: replies to comments
 
     Given the following activated tag wranglers exist
-        | login       | password      | email             |
-        | dizmo       | wrangulator   | dizmo@example.org |
-        | Enigel      | wrangulator   | enigel@example.org|
-        | Cesy        | wrangulator   | cesy@example.org|
-      And a fandom exists with name: "Eroica", canonical: true
-      And a fandom exists with name: "Doctor Who", canonical: true
+        | login       | password      | email              |
+        | dizmo       | wrangulator   | dizmo@example.org  |
+        | Enigel      | wrangulator   | enigel@example.org |
+        | Cesy        | wrangulator   | cesy@example.org   |
+      And a canonical fandom "Eroica"
+      And a canonical fandom "Doctor Who"
       And the tag wrangler "Enigel" with password "wrangulator" is wrangler of "Eroica"
       And the tag wrangler "Cesy" with password "wrangulator" is wrangler of "Doctor Who"
       And the tag wrangler "dizmo" with password "wrangulator" is wrangler of "Doctor Who"
@@ -136,17 +136,17 @@ I'd like to comment on a tag'
       And I should see "really clever stuff"
       And I log out
     When I follow "Read all comments on Eroica" in the email
-      And I fill in "User name:" with "Cesy"
+      And I fill in "User name or email:" with "Cesy"
       And I fill in "Password:" with "wrangulator"
       And I press "Log In"
-     Then I should see "Reading Comments on Eroica"
-     And I should see "really clever stuff"
-     And I log out
+    Then I should see "Reading Comments on Eroica"
+      And I should see "really clever stuff"
+      And I log out
     When I follow "Reply to this comment" in the email
-      And I fill in "User name:" with "Enigel"
+      And I fill in "User name or email:" with "Enigel"
       And I fill in "Password:" with "wrangulator"
       And I press "Log In"
-     Then I should see "Reading Comments on Eroica"
+    Then I should see "Reading Comments on Eroica"
       And I should see "really clever stuff"
       And all emails have been delivered
       And I am logged in as "Enigel" with password "wrangulator"

--- a/features/users/authenticate_users.feature
+++ b/features/users/authenticate_users.feature
@@ -105,7 +105,7 @@ Feature: User Authentication
       And I fill in "New password" with "newpass"
       And I fill in "Confirm new password" with "newpass"
       And I press "Change Password"
-    Then I should see "Your password has been changed"
+    Then I should see "Your password has been changed successfully."
       And I should see "Hi, sam"
 
   Scenario: Forgot password, with expired password token

--- a/features/users/authenticate_users.feature
+++ b/features/users/authenticate_users.feature
@@ -9,8 +9,8 @@ Feature: User Authentication
       | sam      | secret   |
       And all emails have been delivered
     When I am on the home page
-      And I fill in "User name" with "sam"
-      And I fill in "Password" with "test"
+      And I fill in "User name or email:" with "sam"
+      And I fill in "Password:" with "test"
       And I press "Log In"
     Then I should see "The password or user name you entered doesn't match our records"
       And I should see "Forgot your password or user name?"
@@ -26,8 +26,8 @@ Feature: User Authentication
 
     # existing password should still work
     When I am on the homepage
-      And I fill in "User name" with "sam"
-      And I fill in "Password" with "secret"
+      And I fill in "User name or email:" with "sam"
+      And I fill in "Password:" with "secret"
       And I press "Log In"
     Then I should see "Hi, sam"
 
@@ -67,24 +67,24 @@ Feature: User Authentication
     # old password should no longer work
     When I am logged out
       And I am on the homepage
-      And I fill in "User name" with "sam"
-      And I fill in "Password" with "secret"
+      And I fill in "User name or email:" with "sam"
+      And I fill in "Password:" with "secret"
       And I press "Log In"
     Then I should not see "Hi, sam"
 
     # new password should work
     When I am logged out
       And I am on the homepage
-      And I fill in "User name" with "sam"
-      And I fill in "Password" with "newpass"
+      And I fill in "User name or email:" with "sam"
+      And I fill in "Password:" with "newpass"
       And I press "Log In"
     Then I should see "Hi, sam"
 
     # password entered the second time should not work
     When I am logged out
       And I am on the homepage
-      And I fill in "User name" with "sam"
-      And I fill in "Password" with "override"
+      And I fill in "User name or email:" with "sam"
+      And I fill in "Password:" with "override"
       And I press "Log In"
     Then I should not see "Hi, sam"
 
@@ -140,16 +140,16 @@ Feature: User Authentication
       And all emails have been delivered
       And the user "sam" has failed to log in 50 times
       When I am on the home page
-        And I fill in "User name" with "sam"
-        And I fill in "Password" with "badpassword"
+        And I fill in "User name or email:" with "sam"
+        And I fill in "Password:" with "badpassword"
         And I press "Log In"
       Then I should see "Your account has been locked for 5 minutes"
         And I should not see "Hi, sam!"
 
       # User should not be able to log back in even with correct password
       When I am on the home page
-        And I fill in "User name" with "sam"
-        And I fill in "Password" with "password"
+        And I fill in "User name or email:" with "sam"
+        And I fill in "Password:" with "password"
         And I press "Log In"
       Then I should see "Your account has been locked for 5 minutes"
         And I should not see "Hi, sam!"
@@ -157,8 +157,8 @@ Feature: User Authentication
       # User should be able to log in with the correct password 5 minutes later
       When it is currently 5 minutes from now
         And I am on the home page
-        And I fill in "User name" with "sam"
-        And I fill in "Password" with "password"
+        And I fill in "User name or email:" with "sam"
+        And I fill in "Password:" with "password"
         And I press "Log In"
       Then I should see "Successfully logged in."
         And I should see "Hi, sam!"
@@ -170,8 +170,8 @@ Feature: User Authentication
       | sam      | secret   |
       And all emails have been delivered
     When I am on the home page
-      And I fill in "User name" with "sammy"
-      And I fill in "Password" with "test"
+      And I fill in "User name or email:" with "sammy"
+      And I fill in "Password:" with "test"
       And I press "Log In"
     Then I should see "The password or user name you entered doesn't match our records. Please try again or reset your password. If you still can't log in, please visit Problems When Logging In for help."
 
@@ -182,8 +182,8 @@ Feature: User Authentication
       | sam      | secret   |
       And all emails have been delivered
     When I am on the home page
-      And I fill in "User name" with "sam"
-      And I fill in "Password" with "tester"
+      And I fill in "User name or email:" with "sam"
+      And I fill in "Password:" with "tester"
       And I press "Log In"
     Then I should see "The password or user name you entered doesn't match our records. Please try again or reset your password. If you still can't log in, please visit Problems When Logging In for help."
 
@@ -200,8 +200,8 @@ Feature: User Authentication
       | login      | password |
       | TheMadUser | password1 |
     When I am on the home page
-      And I fill in "User name" with "themaduser"
-      And I fill in "Password" with "password1"
+      And I fill in "User name or email:" with "themaduser"
+      And I fill in "Password:" with "password1"
       And I press "Log In"
     Then I should see "Successfully logged in."
       And I should see "Hi, TheMadUser!"
@@ -211,8 +211,8 @@ Feature: User Authentication
       | login      | email                  | password |
       | TheMadUser | themaduser@example.com | password |
     When I am on the home page
-      And I fill in "User name" with "themaduser@example.com"
-      And I fill in "Password" with "password"
+      And I fill in "User name or email:" with "themaduser@example.com"
+      And I fill in "Password:" with "password"
       And I press "Log In"
       Then I should see "Successfully logged in."
         And I should see "Hi, TheMadUser!"
@@ -222,8 +222,8 @@ Feature: User Authentication
       | login   | password |
       | MadUser | password |
     When I am on the home page
-      And I fill in "User name" with "maduser"
-      And I fill in "Password" with "password"
+      And I fill in "User name or email:" with "maduser"
+      And I fill in "Password:" with "password"
       And I press "Log In"
     Then I should see "Successfully logged in."
       And I should see "You'll stay logged in for 2 weeks even if you close your browser"

--- a/features/users/password_compatibility.feature
+++ b/features/users/password_compatibility.feature
@@ -10,8 +10,8 @@ Feature:
       | login | password |
       | user1 | password |
     When I am on the homepage
-      And I fill in "User name" with "user1"
-      And I fill in "Password" with "password"
+      And I fill in "User name or email:" with "user1"
+      And I fill in "Password:" with "password"
       And I press "Log In"
     Then I should see "Successfully logged in."
       And I should see "Hi, user1!"
@@ -21,8 +21,8 @@ Feature:
       | login | password |
       | user1 | password |
     When I am on the homepage
-      And I fill in "User name" with "user1"
-      And I fill in "Password" with "password"
+      And I fill in "User name or email:" with "user1"
+      And I fill in "Password:" with "password"
       And I press "Log In"
     Then I should see "Successfully logged in."
       And I should see "Hi, user1!"
@@ -32,8 +32,8 @@ Feature:
       | login | password |
       | user1 | password |
     When I am on the homepage
-      And I fill in "User name" with "user1"
-      And I fill in "Password" with "password"
+      And I fill in "User name or email:" with "user1"
+      And I fill in "Password:" with "password"
       And I press "Log In"
     Then I should see "Successfully logged in."
       And I should see "Hi, user1!"

--- a/spec/miscellaneous/requests/comments_spec.rb
+++ b/spec/miscellaneous/requests/comments_spec.rb
@@ -100,8 +100,8 @@ describe "Comments", type: :request do
       @user = create(:user)
       visit new_user_session_path
       within("div#small_login") do
-        fill_in "User name:",with: "#{@user.login}" ,  exact: true
-        fill_in "Password", with: "password"
+        fill_in "User name or email:", with: "#{@user.login}", exact: true
+        fill_in "Password:", with: "password"
         check "Remember Me"
         click_button "Log In"
       end


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-2839
https://otwarchive.atlassian.net/browse/AO3-5576

## Purpose

- Update subject and link style of the reset password email.
- Update notice after users change password.
- Update login forms to use "User name or email:".

## Testing Instructions

- Request a password reset and check the resulting email.
- Change the password (from the profile editing section) and check the notice after.
- Check that login forms have "User name or email:". The registration form should still have "User name:", and a separate field for emails.