### PR TITLE
AO3-5587 Add unique index to user emails

### DIFF
--- a/db/migrate/20181224173813_add_unique_index_to_user_emails.rb
+++ b/db/migrate/20181224173813_add_unique_index_to_user_emails.rb
@@ -1,0 +1,6 @@
+class AddUniqueIndexToUserEmails < ActiveRecord::Migration[5.1]
+  def change
+    remove_index :users, :email
+    add_index :users, :email, unique: true
+  end
+end


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5587

## Purpose

Enforce email uniqueness at database level, on just at Rails level.

## Testing Instructions

The migration should run OK.