### PR TITLE
AO3-5576 Remove outdated footnote on change email page

### DIFF
--- a/app/views/users/change_email.html.erb
+++ b/app/views/users/change_email.html.erb
@@ -20,12 +20,7 @@
     <dd><%= email_field_tag :email_confirmation %></dd>
 
     <dt><%= label_tag :password_check, ts("Password") %></dt>
-    <dd>
-      <%= password_field_tag :password_check, nil, "aria-describedby" => "password-field-description" %>
-      <p class="footnote" id="password-field-description">
-        <%= ts("This must be your current password, not a reset password that was emailed to you.") %>
-      </p>
-    </dd>
+    <dd><%= password_field_tag :password_check %></dd>
 
     <dt class="landmark"><%= label_tag :submit, ts("Submit") %></dt>
     <dd class="submit actions">


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5576

## Purpose

Removes a note referring to emailing reset passwords.

## Testing Instructions

Go to the change email page and make sure it no longer says "This must be your current password, not a reset password that was emailed to you."
