### PR TITLE
AO3-5589 Add password_check to list of encrypted fields

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -248,7 +248,7 @@ NONZERO_INTEGER_PARAMETERS:
   per_page: 25
 
 # These fields are encrypted and should not have characters escaped or be treated as HTML
-FIELDS_WITHOUT_SANITIZATION: ["password", "password_confirmation"]
+FIELDS_WITHOUT_SANITIZATION: ["password", "password_check", "password_confirmation"]
 
 # These fields are query fields and are allowed to contain "less than" values
 FIELDS_ALLOWING_LESS_THAN: ["query", "words", "kudos", "hits", "date", "bookmarkable_date", "word_count", "bookmarks_count", "comments_count", "kudos_count", "revised_at"]


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5589

## Purpose

Adds password_check to the list of fields we don't want to sanitize because they're encrypted. If it's not in the list, it's impossible to change an existing password like `i<3ao3`.

This is already fixed on staging but it should be committed to the repo so it works on dev.

