### PR TITLE
AO3-5574 Fix cancel button for pseud deletion

### DIFF
--- a/app/controllers/pseuds_controller.rb
+++ b/app/controllers/pseuds_controller.rb
@@ -128,21 +128,26 @@ class PseudsController < ApplicationController
   # DELETE /pseuds/1.xml
   def destroy
     @hide_dashboard = true
+    if params[:cancel_button]
+      flash[:notice] = ts("The pseud was not deleted.")
+      redirect_to(user_pseuds_path(@user)) && return
+    end
+
     @pseud = @user.pseuds.find_by(name: params[:id])
     if @pseud.is_default
       flash[:error] = ts("You cannot delete your default pseudonym, sorry!")
-   elsif @pseud.name == @user.login
+    elsif @pseud.name == @user.login
       flash[:error] = ts("You cannot delete the pseud matching your user name, sorry!")
-   elsif params[:bookmarks_action] == 'transfer_bookmarks'
-     @pseud.change_bookmarks_ownership
-     @pseud.replace_me_with_default
-     flash[:notice] = ts("The pseud was successfully deleted.")
-   elsif params[:bookmarks_action] == 'delete_bookmarks' || @pseud.bookmarks.empty?
-     @pseud.replace_me_with_default
-     flash[:notice] = ts("The pseud was successfully deleted.")
-   else
+    elsif params[:bookmarks_action] == "transfer_bookmarks"
+      @pseud.change_bookmarks_ownership
+      @pseud.replace_me_with_default
+      flash[:notice] = ts("The pseud was successfully deleted.")
+    elsif params[:bookmarks_action] == "delete_bookmarks" || @pseud.bookmarks.empty?
+      @pseud.replace_me_with_default
+      flash[:notice] = ts("The pseud was successfully deleted.")
+    else
       render 'delete_preview' and return
-   end
+    end
 
     redirect_to(user_pseuds_path(@user))
   end

--- a/features/other_a/pseud_delete.feature
+++ b/features/other_a/pseud_delete.feature
@@ -5,34 +5,41 @@ Feature: Delete pseud.
   I want to delete a pseud
 
   Scenario: Delete pseud, have option to move works, delete works, or orphan works. Test if those choices work.
-  Given I have loaded the fixtures
-  When I am logged in as "sad_user_with_no_pseuds" with password "testuser"
-    And I am on sad_user_with_no_pseuds's pseuds page
-  Then I should not see "Delete"
-  When I am logged out
-  And I am logged in as "testuser" with password "testuser"
-    And I am on testuser's pseuds page
-  When I follow "delete_tester_pseud"
-  Then I should see "Delete these bookmarks"
-  When I choose "Delete these bookmarks"
-    And I press "Submit"
-  Then I should see "The pseud was successfully deleted."
-  When I am on testuser's pseuds page
+    Given I have loaded the fixtures
+    When I am logged in as "sad_user_with_no_pseuds"
+      And I am on sad_user_with_no_pseuds's pseuds page
+    Then I should not see "Delete"
+
+    When I am logged out
+      And I am logged in as "testuser"
+      And I am on testuser's pseuds page
+      And I follow "delete_tester_pseud"
+      And I press "Cancel"
+    Then I should see "The pseud was not deleted."
+    When I am on testuser's pseuds page
+      And I follow "tester_pseud"
+    Then I should see "fifth by testuser2"
+
+    When I am on testuser's pseuds page
+      And I follow "delete_tester_pseud"
+      And I choose "Delete these bookmarks"
+      And I press "Submit"
+    Then I should see "The pseud was successfully deleted."
+    When I am on testuser's pseuds page
     Then I should not see "tester_pseud"
-    And I follow "delete_testy"
-    And I choose "Transfer these bookmarks to the default pseud"
-    And I press "Submit"
-  Then I should see "The pseud was successfully deleted."
-  When I am on testuser's pseuds page
-    And I follow "testymctesty"
-  Then I should see "fourth"
-    And I should not see "fifth work"
+
+    When I follow "delete_testy"
+      And I choose "Transfer these bookmarks to the default pseud"
+      And I press "Submit"
+    Then I should see "The pseud was successfully deleted."
+    When I am on testuser's pseuds page
+      And I follow "testymctesty"
+    Then I should see "fourth by testuser2"
 
   Scenario: Deleting a pseud shouldn't break gift exchange signups.
-
     Given I am logged in as "moderator"
       And I set up the collection "Exchange1"
-      And I select "Gift Exchange" from "challenge_type"
+      And I select "Gift Exchange" from "Type of challenge"
       And I press "Submit"
       And I check "Sign-up open?"
       And I press "Submit"
@@ -58,7 +65,6 @@ Feature: Delete pseud.
     Then I should see "Antidisestablishmentarianism."
 
   Scenario: Deleting a pseud shouldn't break prompt meme signups.
-
     Given I am logged in as "moderator"
       And I set up the collection "PromptsGalore"
       And I select "Prompt Meme" from "challenge_type"
@@ -84,4 +90,3 @@ Feature: Delete pseud.
     When I view the collection "PromptsGalore"
       And I follow "My Prompts"
     Then I should see "Antidisestablishmentarianism."
-


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5574

## Purpose

Now you can back out of deleting a pseud.

## Testing Instructions

See issue.