### PR TITLE
AO3-5493 Allow searching for tags used only in drafts

### DIFF
--- a/app/models/search/tag_indexer.rb
+++ b/app/models/search/tag_indexer.rb
@@ -57,7 +57,7 @@ class TagIndexer < Indexer
         :unwrangleable
       ],
       methods: [
-        :draft_only
+        :has_posted_works
       ]
     ).merge(
       tag_type: object.type,

--- a/app/models/search/tag_indexer.rb
+++ b/app/models/search/tag_indexer.rb
@@ -53,8 +53,11 @@ class TagIndexer < Indexer
     object.as_json(
       root: false,
       only: [
-        :id, :name, :sortable_name, :merger_id, :canonical, :created_at, 
+        :id, :name, :sortable_name, :merger_id, :canonical, :created_at,
         :unwrangleable
+      ],
+      methods: [
+        :draft_only
       ]
     ).merge(
       tag_type: object.type,

--- a/app/models/search/tag_indexer.rb
+++ b/app/models/search/tag_indexer.rb
@@ -55,11 +55,9 @@ class TagIndexer < Indexer
       only: [
         :id, :name, :sortable_name, :merger_id, :canonical, :created_at,
         :unwrangleable
-      ],
-      methods: [
-        :has_posted_works
       ]
     ).merge(
+      has_posted_works: object.has_posted_works?,
       tag_type: object.type,
       uses: object.taggings_count_cache
     ).merge(parent_data(object))

--- a/app/models/search/tag_query.rb
+++ b/app/models/search/tag_query.rb
@@ -17,6 +17,7 @@ class TagQuery < Query
       type_filter,
       canonical_filter,
       unwrangleable_filter,
+      draft_only_filter,
       media_filter,
       fandom_filter,
       character_filter,
@@ -76,6 +77,10 @@ class TagQuery < Query
 
   def unwrangleable_filter
     term_filter(:unwrangleable, bool_value(options[:unwrangleable])) unless options[:unwrangleable].nil?
+  end
+
+  def draft_only_filter
+    term_filter(:draft_only, bool_value(options[:draft_only])) unless options[:draft_only].nil?
   end
 
   def media_filter

--- a/app/models/search/tag_query.rb
+++ b/app/models/search/tag_query.rb
@@ -17,7 +17,7 @@ class TagQuery < Query
       type_filter,
       canonical_filter,
       unwrangleable_filter,
-      draft_only_filter,
+      posted_works_filter,
       media_filter,
       fandom_filter,
       character_filter,
@@ -79,8 +79,8 @@ class TagQuery < Query
     term_filter(:unwrangleable, bool_value(options[:unwrangleable])) unless options[:unwrangleable].nil?
   end
 
-  def draft_only_filter
-    term_filter(:draft_only, bool_value(options[:draft_only])) unless options[:draft_only].nil?
+  def posted_works_filter
+    term_filter(:has_posted_works, bool_value(options[:has_posted_works])) unless options[:has_posted_works].nil?
   end
 
   def media_filter

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -625,9 +625,9 @@ class Tag < ApplicationRecord
     !(self.canonical? || self.unwrangleable? || self.merger_id.present? || self.mergers.any?)
   end
 
-  # Returns true if a tag has only been used in drafts
-  def draft_only
-    self.works.unposted.any? && self.works.posted.empty?
+  # Returns true if a tag has been used in posted works
+  def has_posted_works
+    self.works.posted.any?
   end
 
   # sort tags by name

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -626,7 +626,7 @@ class Tag < ApplicationRecord
   end
 
   # Returns true if a tag has been used in posted works
-  def has_posted_works
+  def has_posted_works?
     self.works.posted.any?
   end
 

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -66,8 +66,8 @@ class Tag < ApplicationRecord
 
   def taggings_count=(value)
     expiry_time = Tag.taggings_count_expiry(value)
-    # Only write to the cache if there are more than TAGGINGS_COUNT_MIN_CACHE_COUNT ( defaults to 1,000 ) uses.
-    Rails.cache.write(taggings_count_cache_key, value, race_condition_ttl: 10, expires_in: expiry_time.minutes) if value >= (ArchiveConfig.TAGGINGS_COUNT_MIN_CACHE_COUNT || 1000)
+    # Only write to the cache if there are more than a number of uses.
+    Rails.cache.write(taggings_count_cache_key, value, race_condition_ttl: 10, expires_in: expiry_time.minutes) if value >= ArchiveConfig.TAGGINGS_COUNT_MIN_CACHE_COUNT
     write_taggings_to_redis(value)
   end
 
@@ -81,7 +81,7 @@ class Tag < ApplicationRecord
 
   def update_tag_cache
     cache_read = Rails.cache.read(taggings_count_cache_key)
-    taggings_count if cache_read.nil? || (cache_read < (ArchiveConfig.TAGGINGS_COUNT_MIN_CACHE_COUNT || 1000))
+    taggings_count if cache_read.nil? || (cache_read < ArchiveConfig.TAGGINGS_COUNT_MIN_CACHE_COUNT)
   end
 
   def update_counts_cache(id)
@@ -623,6 +623,11 @@ class Tag < ApplicationRecord
 
   def unwrangled?
     !(self.canonical? || self.unwrangleable? || self.merger_id.present? || self.mergers.any?)
+  end
+
+  # Returns true if a tag has only been used in drafts
+  def draft_only
+    self.works.unposted.any? && self.works.posted.empty?
   end
 
   # sort tags by name

--- a/app/models/tagging.rb
+++ b/app/models/tagging.rb
@@ -48,9 +48,10 @@ class Tagging < ApplicationRecord
   def update_search
     return unless tagger && Tag::USER_DEFINED.include?(tagger.type)
 
-    # Reindex the tag for updated suggested tags, which give you an idea of
-    # how unwrangled tags are used, but only if it has less than a number of uses.
-    # For comprehensive data on really popular tags, we still have work search.
+    # Reindex the tag for updated suggested tags.
+    # Suggested tags help wranglers figure out where to wrangle new tags
+    # and if it's necessary to disambiguate existing canonical/unfilterable tags
+    # in multiple fandoms.
     tagger.enqueue_to_index if tagger.taggings_count < ArchiveConfig.TAGGINGS_COUNT_REINDEX_LIMIT
   end
 end

--- a/app/models/tagging.rb
+++ b/app/models/tagging.rb
@@ -46,11 +46,11 @@ class Tagging < ApplicationRecord
   end
 
   def update_search
-    # When a tag's count is more than this threshold, we start caching it,
-    # so taggings_count becomes less accurate. That's our cue to stop
-    # eagerly reindexing counts as well.
     return unless Tag::USER_DEFINED.include?(tagger.type)
-    reindex_boundary = ArchiveConfig.TAGGINGS_COUNT_MIN_CACHE_COUNT
-    tagger.enqueue_to_index if tagger.taggings_count < reindex_boundary
+
+    # Reindex the tag for updated suggested tags, which give you an idea of
+    # how unwrangled tags are used, but only if it has less than a number of uses.
+    # For comprehensive data on really popular tags, we still have work search.
+    tagger.enqueue_to_index if tagger.taggings_count < ArchiveConfig.TAGGINGS_COUNT_REINDEX_LIMIT
   end
 end

--- a/app/models/tagging.rb
+++ b/app/models/tagging.rb
@@ -46,9 +46,11 @@ class Tagging < ApplicationRecord
   end
 
   def update_search
-    reindex_boundary = 100
-    if %w(Character Relationship Freeform).include?(tagger.type)
-      tagger.enqueue_to_index if tagger.taggings_count < reindex_boundary
-    end
+    # When a tag's count is more than this threshold, we start caching it,
+    # so taggings_count becomes less accurate. That's our cue to stop
+    # eagerly reindexing counts as well.
+    return unless %w[Fandom Character Relationship Freeform].include?(tagger.type)
+    reindex_boundary = ArchiveConfig.TAGGINGS_COUNT_MIN_CACHE_COUNT
+    tagger.enqueue_to_index if tagger.taggings_count < reindex_boundary
   end
 end

--- a/app/models/tagging.rb
+++ b/app/models/tagging.rb
@@ -46,7 +46,7 @@ class Tagging < ApplicationRecord
   end
 
   def update_search
-    return unless Tag::USER_DEFINED.include?(tagger.type)
+    return unless tagger && Tag::USER_DEFINED.include?(tagger.type)
 
     # Reindex the tag for updated suggested tags, which give you an idea of
     # how unwrangled tags are used, but only if it has less than a number of uses.

--- a/app/models/tagging.rb
+++ b/app/models/tagging.rb
@@ -49,7 +49,7 @@ class Tagging < ApplicationRecord
     # When a tag's count is more than this threshold, we start caching it,
     # so taggings_count becomes less accurate. That's our cue to stop
     # eagerly reindexing counts as well.
-    return unless %w[Fandom Character Relationship Freeform].include?(tagger.type)
+    return unless Tag::USER_DEFINED.include?(tagger.type)
     reindex_boundary = ArchiveConfig.TAGGINGS_COUNT_MIN_CACHE_COUNT
     tagger.enqueue_to_index if tagger.taggings_count < reindex_boundary
   end

--- a/config/config.yml
+++ b/config/config.yml
@@ -170,7 +170,7 @@ TAG_UPDATE_BATCH_SIZE: 100
 # We only start caching tag counts for tags used more than a certain number of times
 TAGGINGS_COUNT_MIN_CACHE_COUNT: 1000
 
-# We only reindex tags used less than a certain number of times
+# For tagging changes, we only reindex tags used less than a certain number of times
 TAGGINGS_COUNT_REINDEX_LIMIT: 1000
 
 # how many signups in a challenge before we move to static summaries generated hourly

--- a/config/config.yml
+++ b/config/config.yml
@@ -167,6 +167,9 @@ TAGS_PER_SEARCH_PAGE: 50
 # When updating tag counts, how many to do in one transaction
 TAG_UPDATE_BATCH_SIZE: 100
 
+# We only start caching tag counts for tags used more than a certain number of times
+TAGGINGS_COUNT_MIN_CACHE_COUNT: 1000
+
 # how many signups in a challenge before we move to static summaries generated hourly
 MAX_SIGNUPS_FOR_LIVE_SUMMARY: 20
 

--- a/config/config.yml
+++ b/config/config.yml
@@ -170,6 +170,9 @@ TAG_UPDATE_BATCH_SIZE: 100
 # We only start caching tag counts for tags used more than a certain number of times
 TAGGINGS_COUNT_MIN_CACHE_COUNT: 1000
 
+# We only reindex tags used less than a certain number of times
+TAGGINGS_COUNT_REINDEX_LIMIT: 1000
+
 # how many signups in a challenge before we move to static summaries generated hourly
 MAX_SIGNUPS_FOR_LIVE_SUMMARY: 20
 

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -1,24 +1,25 @@
-require 'spec_helper'
+# frozen_string_literal: true
+
+require "spec_helper"
 
 describe Comment do
 
   context "with an existing comment from the same user" do
-    before(:all) do
-      @first_comment = create(:comment)
-      attributes = %w(pseud_id commentable_id commentable_type comment_content name email)
-      @second_comment = Comment.new(
-        @first_comment.attributes.slice(*attributes)
-      )
+    let(:first_comment) { create(:comment) }
+
+    let(:second_comment) do
+      attributes = %w[pseud_id commentable_id commentable_type comment_content name email]
+      Comment.new(first_comment.attributes.slice(*attributes))
     end
 
     it "should be invalid if exactly duplicated" do
-      expect(@second_comment.valid?).to eq(false)
-      expect(@second_comment.errors.keys).to include(:comment_content)
+      expect(second_comment.valid?).to be_falsy
+      expect(second_comment.errors.keys).to include(:comment_content)
     end
 
     it "should not be invalid if in the process of being deleted" do
-      @second_comment.is_deleted = true
-      expect(@second_comment.valid?).to eq(true)
+      second_comment.is_deleted = true
+      expect(second_comment.valid?).to be_truthy
     end
   end
 end

--- a/spec/models/search/tag_query_wrangling_spec.rb
+++ b/spec/models/search/tag_query_wrangling_spec.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe TagQuery do
+  context "searching tags by draft status" do
+    let!(:work) do
+      create(:posted_work,
+             fandom_string: "jjba,imas",
+             character_string: "bruno,koume",
+             relationship_string: "bruabba,koume/ryo",
+             freeform_string: "slice of life,horror")
+    end
+
+    let!(:draft) do
+      create(:draft,
+             fandom_string: "zombie land saga,imas",
+             character_string: "saki,koume",
+             relationship_string: "saki/ai,koume/ryo",
+             freeform_string: "action,horror")
+    end
+
+    before { run_all_indexing_jobs }
+
+    it "includes tags used only in drafts" do
+      results = TagQuery.new(type: "Fandom", draft_only: true).search_results.map(&:name)
+      expect(results).to contain_exactly("zombie land saga")
+
+      results = TagQuery.new(type: "Character", draft_only: true).search_results.map(&:name)
+      expect(results).to contain_exactly("saki")
+
+      results = TagQuery.new(type: "Relationship", draft_only: true).search_results.map(&:name)
+      expect(results).to contain_exactly("saki/ai")
+
+      results = TagQuery.new(type: "Freeform", draft_only: true).search_results.map(&:name)
+      expect(results).to contain_exactly("action")
+
+      # draft-only tags appear on another posted work
+      create(:posted_work,
+             fandom_string: "zombie land saga",
+             character_string: "saki",
+             relationship_string: "saki/ai",
+             freeform_string: "action")
+      run_all_indexing_jobs
+
+      expect(TagQuery.new(type: "Fandom", draft_only: true).search_results).to be_empty
+      expect(TagQuery.new(type: "Character", draft_only: true).search_results).to be_empty
+      expect(TagQuery.new(type: "Relationship", draft_only: true).search_results).to be_empty
+      expect(TagQuery.new(type: "Freeform", draft_only: true).search_results).to be_empty
+    end
+
+    it "excludes tags used only in drafts" do
+      results = TagQuery.new(type: "Fandom", draft_only: false).search_results.map(&:name)
+      expect(results).to contain_exactly("jjba", "imas")
+
+      results = TagQuery.new(type: "Character", draft_only: false).search_results.map(&:name)
+      expect(results).to contain_exactly("bruno", "koume")
+
+      results = TagQuery.new(type: "Relationship", draft_only: false).search_results.map(&:name)
+      expect(results).to contain_exactly("bruabba", "koume/ryo")
+
+      results = TagQuery.new(type: "Freeform", draft_only: false).search_results.map(&:name)
+      expect(results).to contain_exactly("slice of life", "horror")
+
+      # draft gets posted
+      draft.update_attributes(posted: true)
+      run_all_indexing_jobs
+
+      results = TagQuery.new(type: "Fandom", draft_only: false).search_results.map(&:name)
+      expect(results).to contain_exactly("zombie land saga", "jjba", "imas")
+
+      results = TagQuery.new(type: "Character", draft_only: false).search_results.map(&:name)
+      expect(results).to contain_exactly("saki", "bruno", "koume")
+
+      results = TagQuery.new(type: "Relationship", draft_only: false).search_results.map(&:name)
+      expect(results).to contain_exactly("saki/ai", "bruabba", "koume/ryo")
+
+      results = TagQuery.new(type: "Freeform", draft_only: false).search_results.map(&:name)
+      expect(results).to contain_exactly("action", "slice of life", "horror")
+    end
+
+    it "returns all tags, drafts or not" do
+      results = TagQuery.new(type: "Fandom").search_results.map(&:name)
+      expect(results).to contain_exactly("zombie land saga", "jjba", "imas")
+
+      results = TagQuery.new(type: "Character").search_results.map(&:name)
+      expect(results).to contain_exactly("saki", "bruno", "koume")
+
+      results = TagQuery.new(type: "Relationship").search_results.map(&:name)
+      expect(results).to contain_exactly("saki/ai", "bruabba", "koume/ryo")
+
+      results = TagQuery.new(type: "Freeform").search_results.map(&:name)
+      expect(results).to contain_exactly("action", "slice of life", "horror")
+    end
+  end
+end

--- a/spec/models/search/tag_query_wrangling_spec.rb
+++ b/spec/models/search/tag_query_wrangling_spec.rb
@@ -22,17 +22,17 @@ describe TagQuery do
 
     before { run_all_indexing_jobs }
 
-    it "includes tags used only in drafts" do
-      results = TagQuery.new(type: "Fandom", draft_only: true).search_results.map(&:name)
+    it "returns tags without posted works" do
+      results = TagQuery.new(type: "Fandom", has_posted_works: false).search_results.map(&:name)
       expect(results).to contain_exactly("zombie land saga")
 
-      results = TagQuery.new(type: "Character", draft_only: true).search_results.map(&:name)
+      results = TagQuery.new(type: "Character", has_posted_works: false).search_results.map(&:name)
       expect(results).to contain_exactly("saki")
 
-      results = TagQuery.new(type: "Relationship", draft_only: true).search_results.map(&:name)
+      results = TagQuery.new(type: "Relationship", has_posted_works: false).search_results.map(&:name)
       expect(results).to contain_exactly("saki/ai")
 
-      results = TagQuery.new(type: "Freeform", draft_only: true).search_results.map(&:name)
+      results = TagQuery.new(type: "Freeform", has_posted_works: false).search_results.map(&:name)
       expect(results).to contain_exactly("action")
 
       # draft-only tags appear on another posted work
@@ -43,43 +43,43 @@ describe TagQuery do
              freeform_string: "action")
       run_all_indexing_jobs
 
-      expect(TagQuery.new(type: "Fandom", draft_only: true).search_results).to be_empty
-      expect(TagQuery.new(type: "Character", draft_only: true).search_results).to be_empty
-      expect(TagQuery.new(type: "Relationship", draft_only: true).search_results).to be_empty
-      expect(TagQuery.new(type: "Freeform", draft_only: true).search_results).to be_empty
+      expect(TagQuery.new(type: "Fandom", has_posted_works: false).search_results).to be_empty
+      expect(TagQuery.new(type: "Character", has_posted_works: false).search_results).to be_empty
+      expect(TagQuery.new(type: "Relationship", has_posted_works: false).search_results).to be_empty
+      expect(TagQuery.new(type: "Freeform", has_posted_works: false).search_results).to be_empty
     end
 
-    it "excludes tags used only in drafts" do
-      results = TagQuery.new(type: "Fandom", draft_only: false).search_results.map(&:name)
+    it "returns tags with posted works" do
+      results = TagQuery.new(type: "Fandom", has_posted_works: true).search_results.map(&:name)
       expect(results).to contain_exactly("jjba", "imas")
 
-      results = TagQuery.new(type: "Character", draft_only: false).search_results.map(&:name)
+      results = TagQuery.new(type: "Character", has_posted_works: true).search_results.map(&:name)
       expect(results).to contain_exactly("bruno", "koume")
 
-      results = TagQuery.new(type: "Relationship", draft_only: false).search_results.map(&:name)
+      results = TagQuery.new(type: "Relationship", has_posted_works: true).search_results.map(&:name)
       expect(results).to contain_exactly("bruabba", "koume/ryo")
 
-      results = TagQuery.new(type: "Freeform", draft_only: false).search_results.map(&:name)
+      results = TagQuery.new(type: "Freeform", has_posted_works: true).search_results.map(&:name)
       expect(results).to contain_exactly("slice of life", "horror")
 
       # draft gets posted
       draft.update_attributes(posted: true)
       run_all_indexing_jobs
 
-      results = TagQuery.new(type: "Fandom", draft_only: false).search_results.map(&:name)
+      results = TagQuery.new(type: "Fandom", has_posted_works: true).search_results.map(&:name)
       expect(results).to contain_exactly("zombie land saga", "jjba", "imas")
 
-      results = TagQuery.new(type: "Character", draft_only: false).search_results.map(&:name)
+      results = TagQuery.new(type: "Character", has_posted_works: true).search_results.map(&:name)
       expect(results).to contain_exactly("saki", "bruno", "koume")
 
-      results = TagQuery.new(type: "Relationship", draft_only: false).search_results.map(&:name)
+      results = TagQuery.new(type: "Relationship", has_posted_works: true).search_results.map(&:name)
       expect(results).to contain_exactly("saki/ai", "bruabba", "koume/ryo")
 
-      results = TagQuery.new(type: "Freeform", draft_only: false).search_results.map(&:name)
+      results = TagQuery.new(type: "Freeform", has_posted_works: true).search_results.map(&:name)
       expect(results).to contain_exactly("action", "slice of life", "horror")
     end
 
-    it "returns all tags, drafts or not" do
+    it "returns all tags, with or without posted works" do
       results = TagQuery.new(type: "Fandom").search_results.map(&:name)
       expect(results).to contain_exactly("zombie land saga", "jjba", "imas")
 

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -255,13 +255,7 @@ describe Tag do
 
     it "is true if only used in drafts" do
       expect(Tag.find_by(name: "zombie land saga").draft_only).to be_truthy
-    end
-
-    it "is false if only used in posted works" do
       expect(Tag.find_by(name: "love live").draft_only).to be_falsey
-    end
-
-    it "is false if used in drafts and posted works" do
       expect(Tag.find_by(name: "jjba").draft_only).to be_falsey
     end
   end

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -247,16 +247,16 @@ describe Tag do
     end
   end
 
-  describe "has_posted_works" do
+  describe "has_posted_works?" do
     before do
       create(:posted_work, fandom_string: "love live,jjba")
       create(:draft, fandom_string: "zombie land saga,jjba")
     end
 
     it "is true if used in posted works" do
-      expect(Tag.find_by(name: "zombie land saga").has_posted_works).to be_falsey
-      expect(Tag.find_by(name: "love live").has_posted_works).to be_truthy
-      expect(Tag.find_by(name: "jjba").has_posted_works).to be_truthy
+      expect(Tag.find_by(name: "zombie land saga").has_posted_works?).to be_falsey
+      expect(Tag.find_by(name: "love live").has_posted_works?).to be_truthy
+      expect(Tag.find_by(name: "jjba").has_posted_works?).to be_truthy
     end
   end
 

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -247,6 +247,25 @@ describe Tag do
     end
   end
 
+  describe "draft_only" do
+    before do
+      create(:posted_work, fandom_string: "love live,jjba")
+      create(:draft, fandom_string: "zombie land saga,jjba")
+    end
+
+    it "is true if only used in drafts" do
+      expect(Tag.find_by(name: "zombie land saga").draft_only).to be_truthy
+    end
+
+    it "is false if only used in posted works" do
+      expect(Tag.find_by(name: "love live").draft_only).to be_falsey
+    end
+
+    it "is false if used in drafts and posted works" do
+      expect(Tag.find_by(name: "jjba").draft_only).to be_falsey
+    end
+  end
+
   describe "can_change_type?" do
     it "should be false for a wrangled tag" do
       tag = Freeform.create(name: "wrangled", canonical: true)

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -247,16 +247,16 @@ describe Tag do
     end
   end
 
-  describe "draft_only" do
+  describe "has_posted_works" do
     before do
       create(:posted_work, fandom_string: "love live,jjba")
       create(:draft, fandom_string: "zombie land saga,jjba")
     end
 
-    it "is true if only used in drafts" do
-      expect(Tag.find_by(name: "zombie land saga").draft_only).to be_truthy
-      expect(Tag.find_by(name: "love live").draft_only).to be_falsey
-      expect(Tag.find_by(name: "jjba").draft_only).to be_falsey
+    it "is true if used in posted works" do
+      expect(Tag.find_by(name: "zombie land saga").has_posted_works).to be_falsey
+      expect(Tag.find_by(name: "love live").has_posted_works).to be_truthy
+      expect(Tag.find_by(name: "jjba").has_posted_works).to be_truthy
     end
   end
 


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5493

## Purpose

This just sets up indexing/querying, without actually using it in the wrangling UI yet.

Move `TAGGINGS_COUNT_MIN_CACHE_COUNT` to config.yml, so we don't need to specify a default every time. Use this property for the tagging reindex limit, instead of hard-coding 100.

Tags are reindexed to get updated draft-only status in two ways:

- When taggings are created/destroyed; this currently only applies to characters, relationships, and freeforms, so we need to add fandoms.
- When works become posted; we need to add a reindex callback.

## Testing Instructions

None(?), we have no UI for this yet.