### PR TITLE
AO3-5600 Fix google_visualr git gem reference

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -101,7 +101,7 @@ gem 'timeliness'
 # gem 'rpm_contrib', '2.2.0'
 
 # for generating graphs
-gem 'google_visualr', git: 'https://github.com/stephendolan/google_visualr'
+gem 'google_visualr', git: 'https://github.com/winston/google_visualr'
 
 # Copycopter to aid translation
 # gem 'copycopter_client', '~> 2.0.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -15,8 +15,8 @@ GIT
       activemodel (>= 4.0)
 
 GIT
-  remote: https://github.com/stephendolan/google_visualr
-  revision: 1c5f087a0c4412e08b5c15fd2593c0e0c311a3ab
+  remote: https://github.com/winston/google_visualr
+  revision: 17b97114a345baadd011e7b442b9a6c91a2b7ab5
   specs:
     google_visualr (2.5.1)
 


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5600

## Purpose

The fork we've been using was deleted.

## Testing Instructions

See issue.