### PR TITLE
AO3-4195 Request more invites page required fields not sufficiently marked

### DIFF
--- a/app/views/user_invite_requests/new.html.erb
+++ b/app/views/user_invite_requests/new.html.erb
@@ -12,11 +12,12 @@
 
 <!--main content-->
 <%= form_for(@user_invite_request) do |f| %>
+<p class="required notice"><%= ts("* Required information") %></p>
   <%= error_messages_for @user_invite_request %>
   <dl>
-    <dt class="required"><%= f.label ts("How many invitations would you like? (max %{max})", :max => ArchiveConfig.MAX_USER_INVITE_REQUEST.to_s) %></dt>
+    <dt class="required"><%= f.label ts("How many invitations would you like? (max %{max})*", :max => ArchiveConfig.MAX_USER_INVITE_REQUEST.to_s) %></dt>
     <dd><%= f.text_field :quantity, :size => '2', :class => 'number' %></dd>
-    <dt class="required"><%= f.label ts("Please specify why you'd like them:") %></dt>
+    <dt class="required"><%= f.label ts("Please specify why you'd like them:*") %></dt>
     <dd><%= f.text_area :reason, :size => '50x5' %></dd>
     <dt class="landmark">Submit</dt>
     <dd class="submit actions"><%= f.submit ts("Send Request") %></dd>

--- a/app/views/user_invite_requests/new.html.erb
+++ b/app/views/user_invite_requests/new.html.erb
@@ -12,12 +12,12 @@
 
 <!--main content-->
 <%= form_for(@user_invite_request) do |f| %>
-<p class="required notice"><%= ts("* Required information") %></p>
+  <p class="required notice"><%= ts("* Required information") %></p>
   <%= error_messages_for @user_invite_request %>
   <dl>
-    <dt class="required"><%= f.label ts("How many invitations would you like? (max %{max})*", :max => ArchiveConfig.MAX_USER_INVITE_REQUEST.to_s) %></dt>
+    <dt class="required"><%= f.label ts("How many invitations would you like? (max %{max})", :max => ArchiveConfig.MAX_USER_INVITE_REQUEST.to_s) + "*" %></dt>
     <dd><%= f.text_field :quantity, :size => '2', :class => 'number' %></dd>
-    <dt class="required"><%= f.label ts("Please specify why you'd like them:*") %></dt>
+    <dt class="required"><%= f.label ts("Please specify why you'd like them:") + "*" %></dt>
     <dd><%= f.text_area :reason, :size => '50x5' %></dd>
     <dt class="landmark">Submit</dt>
     <dd class="submit actions"><%= f.submit ts("Send Request") %></dd>


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [x] Have you added tests for any changed functionality?
* [x] Have you added the [JIRA](https://otwarchive.atlassian.net) issue number as the *first* thing in your pull request title (eg: `AO3-1234 Fix thing`)
* [x] Have you updated or commented on the JIRA issue with the information below?

## Issue

https://otwarchive.atlassian.net/browse/AO3-4195

## Purpose

What does this PR do? 
Adds the "* Required Information" notice at the top of the request invites form and adds (*) next to each label.

Note: I realize the notice is a bit off from the form. Perhaps that can be fixed after the first initial pass. 

## Testing Instructions

1. Log in as a user
2. My Dashboards
3. Click on "Invitations" button 
4. Click on "Request Invitations" button 
## References

Are there any other relevant issues / PRs / mailing lists discussions related to this? None that I know of

## Credit

*What name do you want us to use to credit your work in the [Archive of Our Own's Release Notes](https://archiveofourown.org/admin_posts?tag=1)?* Angela is just fine

(If you have an account on JIRA, please include the same name in the "Full name" field on your JIRA profile,
so we can find you and assign you the issues you're working on.)

*What pronouns do you prefer (she/her, he/him, zie/hir etc)?*
She
(If you do not fill this in, we will use your GitHub account name and will use "they" to avoid making assumptions about your gender.)
