### PR TITLE
AO3-5526 Too much space between stats lines on work blurbs

### DIFF
--- a/public/stylesheets/site/2.0/13-group-blurb.css
+++ b/public/stylesheets/site/2.0/13-group-blurb.css
@@ -73,7 +73,7 @@ li.blurb:after, .blurb .blurb:after {
 
 .blurb dl.stats {
   float: right;
-  line-height: 2.143;
+  line-height: 1.5;
 }
 
 .blurb .fandoms .landmark {


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [x] Have you added tests for any changed functionality?
* [x] Have you added the [JIRA](https://otwarchive.atlassian.net) issue number as the *first* thing in your pull request title (eg: `AO3-1234 Fix thing`)
* [x] Have you updated or commented on the JIRA issue with the information below?

## Issue
https://otwarchive.atlassian.net/browse/AO3-5526

## Purpose

Modifies the line-height to 1.5 for stats 

## Testing Instructions
Note: This should be done on a Windows machine
1. Look at the works to make sure it looks like these pictures from this ticket: https://otwarchive.atlassian.net/browse/AO3-5420

## References

This was a correction for this change in this ticket: https://otwarchive.atlassian.net/browse/AO3-5420 
## Credit

*What name do you want us to use to credit your work in the [Archive of Our Own's Release Notes](https://archiveofourown.org/admin_posts?tag=1)?* Angela

(If you have an account on JIRA, please include the same name in the "Full name" field on your JIRA profile,
so we can find you and assign you the issues you're working on.)

*What pronouns do you prefer (she/her, he/him, zie/hir etc)?*
She
(If you do not fill this in, we will use your GitHub account name and will use "they" to avoid making assumptions about your gender.)
