### PR TITLE
AO3-5607 Move Travis to Ubuntu Xenial 16.04

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
-language: ruby
-dist: trusty
-cache: bundler
 sudo: required
+dist: xenial
+
+language: ruby
+cache: bundler
+
 env:
   - TEST_GROUP="./script/check_syntax"
   - TEST_GROUP="rake db:otwseed"
@@ -24,39 +26,32 @@ env:
   - TEST_GROUP="cucumber -r features features/tags_and_wrangling -f Ao3Cucumber::Formatter --color"
   - TEST_GROUP="cucumber -r features features/users              -f Ao3Cucumber::Formatter --color"
   - TEST_GROUP="cucumber -r features features/works              -f Ao3Cucumber::Formatter --color"
-addons:
-  apt:
-    sources:
-      - mysql-5.7-trusty
-    packages:
-      - mysql-server
-      - mysql-client
-rvm:
-  - "`cat .ruby-version| sed -e 's/ruby //'`"
+
 services:
-  - redis-server
+  - mysql
+  - redis
   - memcached
+
 before_install:
   - bash script/travis_ebook_converters.sh
-script:
-  - RAILS_ENV=test bundle exec rake db:schema:load --trace
-  - RAILS_ENV=test bundle exec rake db:migrate --trace
-  - bundle exec $TEST_GROUP
+
 before_script:
   - bash script/travis_configure.sh
   - bash script/travis_elasticsearch_upgrade.sh
   - bash script/travis_multiple_redis.sh
   - bash script/travis_mysql.sh
+
+script:
+  - RAILS_ENV=test bundle exec rake db:schema:load --trace
+  - RAILS_ENV=test bundle exec rake db:migrate --trace
+  - bundle exec $TEST_GROUP
+
 after_failure:
   - tail -v -n +1 $TRAVIS_BUILD_DIR/tmp/capybara/*.html
+
 notifications:
   email:
     recipients:
       - otw-coders-extra@transformativeworks.org
     on_success: change
     on_failure: always
-  irc:
-   channels:
-     - "irc.freenode.org#otw-dev"
-   on_success: change
-   on_failure: change

--- a/script/travis_ebook_converters.sh
+++ b/script/travis_ebook_converters.sh
@@ -1,12 +1,14 @@
 #!/bin/bash
 set -e
 
+sudo apt-get update -qq
+
 # PDF
-wget https://downloads.wkhtmltopdf.org/0.12/0.12.5/wkhtmltox_0.12.5-1.trusty_amd64.deb
-sudo apt install ./wkhtmltox_0.12.5-1.trusty_amd64.deb
+sudo apt-get install -qq xfonts-75dpi xfonts-base
+wget https://downloads.wkhtmltopdf.org/0.12/0.12.5/wkhtmltox_0.12.5-1.xenial_amd64.deb
+sudo dpkg -i ./wkhtmltox_0.12.5-1.xenial_amd64.deb
 wkhtmltopdf --version
 
 # Calibre
-sudo apt-get update -qq
 sudo apt-get install -qq calibre
 ebook-convert --version

--- a/script/travis_mysql.sh
+++ b/script/travis_mysql.sh
@@ -13,11 +13,7 @@ innodb_file_per_table=1\n\
 /"
 cat /etc/mysql/mysql.conf.d/mysqld.cnf
 
-# Fix table performance_schema.session_variables not existing
-# https://stackoverflow.com/q/31967527
-sudo mysql_upgrade --force
-
-# Both the upgrade and the conf change require a restart
+# The conf change requires a restart
 sudo service mysql restart
 
 mysql -e "CREATE DATABASE otwarchive_test DEFAULT COLLATE utf8mb4_unicode_ci DEFAULT CHARACTER SET utf8mb4;"


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5607

## Purpose

https://docs.travis-ci.com/user/reference/xenial/

Travis offers MySQL 5.7 by default with this OS, so no need to bring in mysql-5.7-trusty or run mysql_upgrade.

Use the correct wkhtmltox package.

Cleanup:

- No need to specify the Ruby version in .travis.yml, since Travis can detect it from .ruby-version.
- Remove IRC notifications.
- Rearrange the build phases in the order they're run.

## Testing Instructions

None, automated.