### PR TITLE
AO3-3880 Fix download file name transliteration

### DIFF
--- a/app/models/download.rb
+++ b/app/models/download.rb
@@ -64,7 +64,7 @@ class Download
   def file_name
     name = clean(work.title)
     name += " Work #{work.id}" if name.length < 3
-    name
+    name.strip
   end
 
   # The public route to this download
@@ -115,13 +115,12 @@ class Download
   # make filesystem-safe
   # ascii encoding
   # squash spaces
-  # strip all alphanumeric
+  # strip all non-alphanumeric
   # truncate to 24 chars at a word boundary
   def clean(string)
     # get rid of any HTML entities to avoid things like "amp" showing up in titles
     string = string.gsub(/\&(\w+)\;/, '')
-    string = ActiveSupport::Inflector.transliterate(string)
-    string = string.encode("us-ascii", "utf-8")
+    string = string.to_ascii
     string = string.gsub(/[^[\w _-]]+/, '')
     string = string.gsub(/ +/, " ")
     string = string.strip

--- a/spec/models/download_spec.rb
+++ b/spec/models/download_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Download do
+  describe "file_name" do
+    let(:work) { Work.new }
+
+    it "transliterates non-ASCII characters" do
+      # Russian
+      work.title = "Укрощение строптивых"
+      expect(Download.new(work).file_name).to eq("Ukroshchieniie")
+
+      # Arabic
+      work.title = "هذا عمل جديد"
+      expect(Download.new(work).file_name).to eq("hdh ml jdyd")
+
+      # Chinese
+      work.title = "我哥好像被奇怪的人盯上了怎么破"
+      expect(Download.new(work).file_name).to eq("Wo Ge Hao Xiang Bei Qi")
+
+      # Japanese
+      work.title = "二重スパイは接点を持つ"
+      expect(Download.new(work).file_name).to eq("Er Zhong supaihaJie Dian")
+
+      # Hebrew
+      work.title = "לחזור הביתה"
+      expect(Download.new(work).file_name).to eq("lkhzvr hbyth")
+    end
+
+    it "removes HTML entities and emojis" do
+      work.title = "Two of Hearts <3 &amp; >.< &"
+      expect(Download.new(work).file_name).to eq("Two of Hearts 3")
+
+      work.title = "Emjoi 🤩 Yay 🥳"
+      expect(Download.new(work).file_name).to eq("Emjoi Yay")
+    end
+
+    it "appends work ID if too short" do
+      work.id = 999_999
+      work.title = "Uh"
+      expect(Download.new(work).file_name).to eq("Uh Work 999999")
+
+      work.title = ""
+      expect(Download.new(work).file_name).to eq("Work 999999")
+
+      work.title = "wat"
+      expect(Download.new(work).file_name).to eq("wat")
+    end
+
+    it "truncates if too long" do
+      work.title = "123456789-123456789-123456789-"
+      expect(Download.new(work).file_name).to eq("123456789-123456789-1234")
+
+      work.title = "123456789 123456789 123456789"
+      expect(Download.new(work).file_name).to eq("123456789 123456789")
+    end
+  end
+end


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-3880

## Purpose

Fix download file name transliteration, nothing groundbreaking, just putting things back the way they were.

https://github.com/otwcode/otwarchive/blob/5c29fc05e5f56019855970763b50f2efff928f4c/app/models/work.rb#L883-L887

## Testing Instructions

Post works with Russian/Farsi/Chinese/Japanese/Hebrew titles and see what the downloaded file names are.