### PR TITLE
AO3-5603 Revise WorksController to eliminate set_instance_variables.

### DIFF
--- a/app/controllers/chapters_controller.rb
+++ b/app/controllers/chapters_controller.rb
@@ -114,7 +114,7 @@ class ChaptersController < ApplicationController
     @work.wip_length = params[:chapter][:wip_length]
     load_pseuds
 
-    if params[:edit_button] || chapter_is_invalid?
+    if params[:edit_button] || chapter_cannot_be_saved?
       render :new
     elsif chapter_has_pseuds_to_fix?
       render :_choose_coauthor
@@ -149,7 +149,7 @@ class ChaptersController < ApplicationController
     @work.wip_length = params[:chapter][:wip_length]
     load_pseuds
 
-    if params[:edit_button] || chapter_is_invalid?
+    if params[:edit_button] || chapter_cannot_be_saved?
       render :edit
     elsif chapter_has_pseuds_to_fix?
       render :_choose_coauthor
@@ -243,7 +243,7 @@ class ChaptersController < ApplicationController
 
   # Check whether we should display :new or :edit instead of previewing or
   # saving the user's changes.
-  def chapter_is_invalid?
+  def chapter_cannot_be_saved?
     # make sure at least one of the pseuds is actually owned by this user
     if @chapter.authors.present? && (@chapter.authors & current_user.pseuds).empty?
       flash.now[:error] = ts("You're not allowed to use that pseud.")

--- a/app/controllers/chapters_controller.rb
+++ b/app/controllers/chapters_controller.rb
@@ -1,12 +1,13 @@
 class ChaptersController < ApplicationController
   # only registered users and NOT admin should be able to create new chapters
   before_action :users_only, except: [ :index, :show, :destroy, :confirm_delete ]
-  before_action :load_work, except: [:index, :auto_complete_for_pseud_name, :update_positions]
-  # only authors of a work should be able to edit its chapters
-  before_action :check_ownership, only: [ :new, :create, :edit, :update, :manage, :preview, :destroy, :confirm_delete ]
-  before_action :set_instance_variables, only: [ :new, :create, :edit, :update, :preview, :post, :confirm_delete ]
-  before_action :check_visibility, only: [ :show]
   before_action :check_user_status, only: [:new, :create, :edit, :update]
+  before_action :load_work
+  # only authors of a work should be able to edit its chapters
+  before_action :check_ownership, except: [:index, :show]
+  before_action :check_visibility, only: [:show]
+  before_action :load_chapter, only: [:show, :edit, :update, :preview, :post, :confirm_delete, :destroy]
+  before_action :set_author_attributes, only: [:create, :update]
 
   cache_sweeper :feed_sweeper
 
@@ -34,11 +35,6 @@ class ChaptersController < ApplicationController
 
     if params[:selected_id]
       redirect_to url_for(controller: :chapters, action: :show, work_id: @work.id, id: params[:selected_id]) and return
-    end
-    @chapter = @work.chapters.find_by(id: params[:id])
-    unless @chapter
-      flash[:error] = ts("Sorry, we couldn't find the chapter you were looking for.")
-      redirect_to work_path(@work) and return
     end
     @chapters = @work.chapters_in_order(false)
     if !logged_in? || !current_user.is_author_of?(@work)
@@ -86,10 +82,14 @@ class ChaptersController < ApplicationController
   # GET /work/:work_id/chapters/new
   # GET /work/:work_id/chapters/new.xml
   def new
+    @chapter = @work.chapters.build(position: @work.number_of_chapters + 1)
+    load_pseuds
   end
 
   # GET /work/:work_id/chapters/1/edit
   def edit
+    load_pseuds
+
     if params["remove"] == "me"
       @chapter.authors_to_remove = current_user.pseuds
       @chapter.save
@@ -105,15 +105,19 @@ class ChaptersController < ApplicationController
   # POST /work/:work_id/chapters
   # POST /work/:work_id/chapters.xml
   def create
-  	@work.wip_length = params[:chapter][:wip_length]
+    if params[:cancel_button]
+      redirect_back_or_default('/')
+      return
+    end
+
+    @chapter = @work.chapters.build(chapter_params)
+    @work.wip_length = params[:chapter][:wip_length]
     load_pseuds
 
-    if !@chapter.invalid_pseuds.blank? || !@chapter.ambiguous_pseuds.blank?
-      @chapter.valid? ? (render :_choose_coauthor) : (render :new)
-    elsif params[:edit_button]
+    if params[:edit_button] || chapter_is_invalid?
       render :new
-    elsif params[:cancel_button]
-      redirect_back_or_default('/')
+    elsif chapter_has_pseuds_to_fix?
+      render :_choose_coauthor
     else  # :post_without_preview, :preview or :cancel_coauthor_button
       @work.major_version = @work.major_version + 1
       @chapter.posted = true if params[:post_without_preview_button]
@@ -135,12 +139,20 @@ class ChaptersController < ApplicationController
   # PUT /work/:work_id/chapters/1
   # PUT /work/:work_id/chapters/1.xml
   def update
+    if params[:cancel_button]
+      # Not quite working yet - should send the user back to wherever they were before they hit edit
+      redirect_back_or_default('/')
+      return
+    end
+
     @chapter.attributes = chapter_params
     @work.wip_length = params[:chapter][:wip_length]
     load_pseuds
 
-    if !@chapter.invalid_pseuds.blank? || !@chapter.ambiguous_pseuds.blank?
-      @chapter.valid? ? (render :_choose_coauthor) : (render :new)
+    if params[:edit_button] || chapter_is_invalid?
+      render :edit
+    elsif chapter_has_pseuds_to_fix?
+      render :_choose_coauthor
     elsif params[:preview_button] || params[:cancel_coauthor_button]
       @preview_mode = true
       if @chapter.posted?
@@ -149,12 +161,6 @@ class ChaptersController < ApplicationController
         draft_flash_message(@work)
       end
       render :preview
-    elsif params[:cancel_button]
-      # Not quite working yet - should send the user back to wherever they were before they hit edit
-      redirect_back_or_default('/')
-    elsif params[:edit_button]
-      flash[:notice] = nil
-      render :edit
     else
       @work.minor_version = @work.minor_version + 1
       @chapter.posted = true if params[:post_button] || params[:post_without_preview_button]
@@ -171,12 +177,11 @@ class ChaptersController < ApplicationController
 
   def update_positions
     if params[:chapters]
-      @work = Work.find(params[:work_id])
       @work.reorder(params[:chapters])
       flash[:notice] = ts("Chapter order has been successfully updated.")
     elsif params[:chapter]
       params[:chapter].each_with_index do |id, position|
-        Chapter.update(id, position: position + 1)
+        @work.chapters.update(id, position: position + 1)
         (@chapters ||= []) << Chapter.find(id)
       end
     end
@@ -189,6 +194,7 @@ class ChaptersController < ApplicationController
   # GET /chapters/1/preview
   def preview
     @preview_mode = true
+    load_pseuds
   end
 
   # POST /chapters/1/post
@@ -216,7 +222,6 @@ class ChaptersController < ApplicationController
   # DELETE /work/:work_id/chapters/1
   # DELETE /work/:work_id/chapters/1.xml
   def destroy
-    @chapter = @work.chapters.find(params[:id])
     if @chapter.is_only_chapter?
       flash[:error] = ts("You can't delete the only chapter in your story. If you want to delete the story, choose 'Delete work'.")
       redirect_to(edit_work_path(@work))
@@ -236,12 +241,33 @@ class ChaptersController < ApplicationController
 
   private
 
+  # Check whether we should display :new or :edit instead of previewing or
+  # saving the user's changes.
+  def chapter_is_invalid?
+    # make sure at least one of the pseuds is actually owned by this user
+    if @chapter.authors.present? && (@chapter.authors & current_user.pseuds).empty?
+      flash.now[:error] = ts("You're not allowed to use that pseud.")
+      return true
+    end
+
+    @chapter.errors.any? || @chapter.invalid?
+  end
+
+  # Check whether we should display _choose_coauthor.
+  def chapter_has_pseuds_to_fix?
+    @chapter.invalid_pseuds.present? || @chapter.ambiguous_pseuds.present?
+  end
+
+  # Set a bunch of instance variables concerning the chapter's pseuds. Requires
+  # @work and @chapter to be defined. Needs to be called for new, create, edit,
+  # update, and preview, before the views are rendered, but after the attribute
+  # author_attributes has been set.
   def load_pseuds
     @allpseuds = (current_user.pseuds + (@work.authors ||= []) + @work.pseuds + (@chapter.authors ||= []) + (@chapter.pseuds ||= [])).uniq
     @pseuds = current_user.pseuds
     @coauthors = @allpseuds.select{ |p| p.user.id != current_user.id}
-    to_select = @chapter.authors.blank? ? @chapter.pseuds.blank? ? @work.pseuds : @chapter.pseuds : @chapter.authors
-    @selected_pseuds = to_select.collect {|pseud| pseud.id.to_i }
+    @to_select = @chapter.authors.blank? ? @chapter.pseuds.blank? ? @work.pseuds : @chapter.pseuds : @chapter.authors
+    @selected_pseuds = @to_select.collect {|pseud| pseud.id.to_i }
   end
 
   # fetch work these chapters belong to from db
@@ -255,39 +281,23 @@ class ChaptersController < ApplicationController
     @check_visibility_of = @work
   end
 
-  # Sets values for @chapter, @coauthor_results, @pseuds, and @selected_pseuds
-  def set_instance_variables
-    # stuff new bylines into author attributes to be parsed by the chapter model
+  # Loads the specified chapter from the database. Redirects to the work if no
+  # chapter is specified, or if the specified chapter doesn't exist.
+  def load_chapter
+    @chapter = @work.chapters.find_by(id: params[:id])
+
+    unless @chapter
+      flash[:error] = ts("Sorry, we couldn't find the chapter you were looking for.")
+      redirect_to work_path(@work)
+    end
+  end
+
+  # Stuff new bylines into author attributes to be parsed by the chapter model.
+  def set_author_attributes
     if params[:chapter] && params[:pseud] && params[:pseud][:byline] && params[:chapter][:author_attributes]
       params[:chapter][:author_attributes][:byline] = params[:pseud][:byline]
       params[:pseud][:byline] = ""
     end
-
-    if params[:id] # edit, update, preview, post
-      @chapter = @work.chapters.find(params[:id])
-      if params[:chapter]  # editing, save our changes
-        # @chapter.attributes = params[:chapter]
-        @chapter.attributes = chapter_params
-      end
-    elsif params[:chapter] # create
-      @chapter = @work.chapters.build(chapter_params)
-    else # new
-      @chapter = @work.chapters.build(position: @work.number_of_chapters + 1)
-    end
-
-    @allpseuds = (current_user.pseuds + (@work.authors ||= []) + @work.pseuds + (@chapter.authors ||= []) + (@chapter.pseuds ||= [])).uniq
-    @pseuds = current_user.pseuds
-    @coauthors = @allpseuds.select{ |p| p.user.id != current_user.id }
-    @to_select = @chapter.authors.blank? ? @chapter.pseuds.blank? ? @work.pseuds : @chapter.pseuds : @chapter.authors
-    @selected_pseuds = @to_select.collect { |pseud| pseud.id.to_i }
-
-    # make sure at least one of the pseuds is actually owned by this user
-    user_ids = Pseud.where(id: @selected_pseuds).pluck(:user_id).uniq
-    unless user_ids.include?(current_user.id)
-      flash.now[:error] = ts("You're not allowed to use that pseud.")
-      render :new and return
-    end
-
   end
 
   def post_chapter

--- a/app/controllers/chapters_controller.rb
+++ b/app/controllers/chapters_controller.rb
@@ -106,7 +106,7 @@ class ChaptersController < ApplicationController
   # POST /work/:work_id/chapters.xml
   def create
     if params[:cancel_button]
-      redirect_back_or_default('/')
+      redirect_back_or_default(root_path)
       return
     end
 
@@ -141,7 +141,7 @@ class ChaptersController < ApplicationController
   def update
     if params[:cancel_button]
       # Not quite working yet - should send the user back to wherever they were before they hit edit
-      redirect_back_or_default('/')
+      redirect_back_or_default(root_path)
       return
     end
 
@@ -265,9 +265,9 @@ class ChaptersController < ApplicationController
   def load_pseuds
     @allpseuds = (current_user.pseuds + (@work.authors ||= []) + @work.pseuds + (@chapter.authors ||= []) + (@chapter.pseuds ||= [])).uniq
     @pseuds = current_user.pseuds
-    @coauthors = @allpseuds.select{ |p| p.user.id != current_user.id}
-    @to_select = @chapter.authors.blank? ? @chapter.pseuds.blank? ? @work.pseuds : @chapter.pseuds : @chapter.authors
-    @selected_pseuds = @to_select.collect {|pseud| pseud.id.to_i }
+    @coauthors = @allpseuds.select { |p| p.user.id != current_user.id }
+    @to_select = [@chapter.authors, @chapter.pseuds, @work.pseuds].find(&:present?)
+    @selected_pseuds = @to_select.map { |pseud| pseud.id.to_i }
   end
 
   # fetch work these chapters belong to from db

--- a/app/controllers/chapters_controller.rb
+++ b/app/controllers/chapters_controller.rb
@@ -265,8 +265,8 @@ class ChaptersController < ApplicationController
   def load_pseuds
     @allpseuds = (current_user.pseuds + (@work.authors ||= []) + @work.pseuds + (@chapter.authors ||= []) + (@chapter.pseuds ||= [])).uniq
     @pseuds = current_user.pseuds
-    @coauthors = @allpseuds.select { |p| p.user.id != current_user.id }
-    @to_select = [@chapter.authors, @chapter.pseuds, @work.pseuds].find(&:present?)
+    @coauthors = @allpseuds.reject { |p| p.user_id == current_user.id }
+    @to_select = [@chapter.authors, @chapter.pseuds, @work.pseuds].detect(&:present?)
     @selected_pseuds = @to_select.map { |pseud| pseud.id.to_i }
   end
 

--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -303,9 +303,6 @@ class WorksController < ApplicationController
       @work.set_revised_at_by_chapter(@chapter)
 
       if @work.save
-        # HACK: for empty chapter authors in cucumber series tests
-        @chapter.pseuds = @work.pseuds if @chapter.pseuds.blank?
-
         if params[:preview_button] || params[:cancel_coauthor_button]
           flash[:notice] = ts("Draft was successfully created. It will be <strong>automatically deleted</strong> on %{deletion_date}", deletion_date: view_context.time_in_zone(@work.created_at + 1.month)).html_safe
           in_moderated_collection

--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -403,7 +403,7 @@ class WorksController < ApplicationController
     end
 
     @work.preview_mode = !!(params[:preview_button] || params[:edit_button])
-    @work.attributes = work_params
+    @work.attributes = work_tag_params
 
     if params[:edit_button] || work_is_invalid?
       set_work_tag_error_messages
@@ -978,6 +978,15 @@ class WorksController < ApplicationController
         :title, :"published_at(3i)", :"published_at(2i)", :"published_at(1i)",
         :published_at, :content
       ]
+    )
+  end
+
+  def work_tag_params
+    params.require(:work).permit(
+      :rating_string, :fandom_string, :relationship_string, :character_string,
+      :warning_string, :category_string, :freeform_string, :language_id,
+      category_string: [],
+      warning_strings: []
     )
   end
 

--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -384,7 +384,7 @@ class WorksController < ApplicationController
 
       @work.minor_version = @work.minor_version + 1
       if @chapter.save && @work.save
-        flash[:notice] = ts("Work was successfully #{posted_changed ? "posted" : "updated"}.")
+        flash[:notice] = ts("Work was successfully #{posted_changed ? 'posted' : 'updated'}.")
         if posted_changed
           flash[:notice] << ts(" It should appear in work listings within the next few minutes.")
         end

--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -13,10 +13,9 @@ class WorksController < ApplicationController
   before_action :check_ownership_or_admin, only: [:edit_tags, :update_tags]
   before_action :log_admin_activity, only: [:update_tags]
   before_action :check_visibility, only: [:show, :navigate]
-  # NOTE: new and create need set_author_attributes or coauthor assignment will break!
-  before_action :set_author_attributes, only: [:new, :create, :edit, :update, :manage_chapters, :preview, :show, :navigate]
-  before_action :set_instance_variables, only: [:new, :create, :edit, :update, :manage_chapters, :preview, :show, :navigate, :import]
-  before_action :set_instance_variables_tags, only: [:edit_tags, :update_tags, :preview_tags]
+
+  before_action :load_first_chapter, only: [:show, :edit, :update, :preview]
+  before_action :set_author_attributes, only: [:create, :update]
 
   cache_sweeper :collection_sweeper
   cache_sweeper :feed_sweeper
@@ -239,77 +238,83 @@ class WorksController < ApplicationController
   # GET /works/new
   def new
     @hide_dashboard = true
-    load_pseuds
-    @series = current_user.series.distinct
     @unposted = current_user.unposted_work
 
-    @work.ip_address = request.remote_ip
+    if params[:load_unposted] && @unposted
+      @work = @unposted
+      @chapter = @work.first_chapter
+    else
+      @work = Work.new
+      @chapter = @work.chapters.build
+    end
+
     # for clarity, add the collection and recipient
     if params[:assignment_id] && (@challenge_assignment = ChallengeAssignment.find(params[:assignment_id])) && @challenge_assignment.offering_user == current_user
       @work.challenge_assignments << @challenge_assignment
-      @work.collections << @challenge_assignment.collection
-      @work.recipients = @challenge_assignment.requesting_pseud.byline
-    elsif @collection
-      @work.collection_names = @collection.name
     end
 
     if params[:claim_id] && (@challenge_claim = ChallengeClaim.find(params[:claim_id])) && User.find(@challenge_claim.claiming_user_id) == current_user
       @work.challenge_claims << @challenge_claim
-      @work.collections << @challenge_claim.collection
-    elsif @collection
-      @work.collection_names = @collection.name
     end
+
+    if @collection
+      @work.add_to_collection(@collection)
+    end
+
+    @work.set_challenge_info
+    @work.set_challenge_claim_info
+    set_work_form_fields
 
     if params[:import]
       @page_subtitle = ts('import')
-      render(:new_import) && return
-    elsif params[:load_unposted]
-      @work = @unposted
-      render(:edit) && return
+      render(:new_import)
+    elsif @work.persisted?
+      render(:edit)
     else
-      render(:new) && return
+      render(:new)
     end
   end
 
   # POST /works
   def create
-    set_edit_form_fields
-
-    @work.ip_address = request.remote_ip
-    # If Edit or Cancel is pressed, bail out and display relevant form
-    if params[:edit_button]
-      render :new && return
-    elsif params[:cancel_button]
+    if params[:cancel_button]
       flash[:notice] = ts('New work posting canceled.')
-      redirect_to current_user and return
-    else
-      # now also treating the cancel_coauthor_button case, bc it should function like a preview, really
+      redirect_to current_user
+      return
+    end
+
+    @work = Work.new(work_params)
+    @chapter = @work.first_chapter
+    @chapter.attributes = work_params[:chapter_attributes] if work_params[:chapter_attributes]
+    @work.ip_address = request.remote_ip
+
+    @work.set_challenge_info
+    @work.set_challenge_claim_info
+    set_work_form_fields
+
+    # If Edit or Cancel is pressed, bail out and display relevant form
+    if params[:edit_button] || work_is_invalid?
       set_work_tag_error_messages
+      render :new
+    elsif work_has_pseuds_to_fix?
+      render :_choose_coauthor
+    else
+      @work.posted = @chapter.posted = true if params[:post_button]
+      @work.set_revised_at_by_chapter(@chapter)
 
-      if @work.errors.empty?
-        if @work.invalid_pseuds.present? || @work.ambiguous_pseuds.present?
-          render :_choose_coauthor and return
+      if @work.save
+        # HACK: for empty chapter authors in cucumber series tests
+        @chapter.pseuds = @work.pseuds if @chapter.pseuds.blank?
+
+        if params[:preview_button] || params[:cancel_coauthor_button]
+          flash[:notice] = ts("Draft was successfully created. It will be <strong>automatically deleted</strong> on %{deletion_date}", deletion_date: view_context.time_in_zone(@work.created_at + 1.month)).html_safe
+          in_moderated_collection
+          redirect_to preview_work_path(@work)
         else
-          @work.posted = @chapter.posted = true if params[:post_button]
-          @work.set_revised_at_by_chapter(@chapter)
-
-          if @work.set_challenge_info && @work.save
-            # HACK: for empty chapter authors in cucumber series tests
-            @chapter.pseuds = @work.pseuds if @chapter.pseuds.blank?
-
-            if params[:preview_button] || params[:cancel_coauthor_button]
-              flash[:notice] = ts("Draft was successfully created. It will be <strong>automatically deleted</strong> on %{deletion_date}", deletion_date: view_context.time_in_zone(@work.created_at + 1.month)).html_safe
-              in_moderated_collection
-              redirect_to preview_work_path(@work)
-            else
-              # We check here to see if we are attempting to post to moderated collection
-              flash[:notice] = ts("Work was successfully posted. It should appear in work listings within the next few minutes.")
-              in_moderated_collection
-              redirect_to work_path(@work)
-            end
-          else
-            render :new
-          end
+          # We check here to see if we are attempting to post to moderated collection
+          flash[:notice] = ts("Work was successfully posted. It should appear in work listings within the next few minutes.")
+          in_moderated_collection
+          redirect_to work_path(@work)
         end
       else
         render :new
@@ -317,30 +322,11 @@ class WorksController < ApplicationController
     end
   end
 
-  def set_work_tag_error_messages
-    unless @work.has_required_tags?
-      error_message = 'Please add all required tags.'
-      error_message << ' Fandom is missing.' if @work.fandoms.blank?
-
-      error_message << ' Warning is missing.' if @work.warnings.blank?
-
-      @work.errors.add(:base, error_message)
-    end
-  end
-
-  def set_edit_form_fields
-    load_pseuds
-    @work.reset_published_at(@chapter)
-    @series = current_user.series.distinct
-    @collection = Collection.find_by(name: params[:work][:collection_names])
-  end
-
   # GET /works/1/edit
   def edit
     @hide_dashboard = true
     @chapters = @work.chapters_in_order(false) if @work.number_of_chapters > 1
-    load_pseuds
-    @series = current_user.series.distinct
+    set_work_form_fields
 
     return unless params['remove'] == 'me'
 
@@ -361,107 +347,79 @@ class WorksController < ApplicationController
 
   # PUT /works/1
   def update
-    set_edit_form_fields
+    if params[:cancel_button]
+      return cancel_posting_and_redirect
+    end
 
+    @work.preview_mode = !!(params[:preview_button] || params[:edit_button] ||
+                            params[:cancel_coauthor_button])
+    @work.attributes = work_params
+    @chapter.attributes = work_params[:chapter_attributes] if work_params[:chapter_attributes]
     @work.ip_address = request.remote_ip
-    # If Edit or Cancel is pressed, bail out and display relevant form
-    if params[:edit_button]
-      render :edit
-    elsif params[:cancel_button]
-      cancel_posting_and_redirect
-    else
-      # Otherwise, check that the work is valid, contains no errors etc
+
+    @work.set_word_count(@work.preview_mode)
+    @work.save_parents if @work.preview_mode
+
+    @work.set_challenge_info
+    @work.set_challenge_claim_info
+    set_work_form_fields
+
+    if params[:edit_button] || work_is_invalid?
       set_work_tag_error_messages
+      render :edit
+    elsif work_has_pseuds_to_fix?
+      render :_choose_coauthor
+    elsif params[:preview_button] || params[:cancel_coauthor_button]
+      unless @work.posted?
+        flash[:notice] = ts("Your changes have not been saved. Please post your work or save without posting if you want to keep them.")
+      end
 
-      if @work.errors.empty?
-        if @work.invalid_pseuds.present? || @work.ambiguous_pseuds.present?
-          @work.valid? ? (render :_choose_coauthor) : (render :new)
-          return
-        elsif params[:preview_button] || params[:cancel_coauthor_button]
-          # If this is a preview, display the preview
-          preview_mode(:edit) do
-            unless @work.posted?
-              flash[:notice] = ts("Your changes have not been saved. Please post your work or save without posting if you want to keep them.")
-            end
+      in_moderated_collection
+      @preview_mode = true
+      render :preview
+    else
+      @work.posted = @chapter.posted = true if params[:post_button]
+      @work.set_revised_at_by_chapter(@chapter)
+      posted_changed = @work.posted_changed?
 
-            in_moderated_collection
-            @chapter = @work.chapters.first unless @chapter
-            render :preview
-          end
-        else
-          @work.posted = @chapter.posted = true if params[:post_button]
-          @work.set_revised_at_by_chapter(@chapter)
-          posted_changed = @work.posted_changed?
-
-          unless @work.challenge_claims.empty?
-            @included = 0
-            @work.challenge_claims.each do |claim|
-              @work.collections.each do |collection|
-                @included = 1 if collection == claim.collection
-              end
-
-              @work.collections << claim.collection if @included.zero?
-
-              @included = 0
-            end
-          end
-
-          @work.minor_version = @work.minor_version + 1
-          @work.set_challenge_info
-
-          if @chapter.save && @work.save
-            flash[:notice] = ts("Work was successfully #{posted_changed ? "posted" : "updated"}.")
-            if posted_changed
-              flash[:notice] << ts(" It should appear in work listings within the next few minutes.")
-            end
-            in_moderated_collection
-            redirect_to(@work)
-          else
-            unless @chapter.valid?
-              @chapter.errors.each { |err| @work.errors.add(:base, err) }
-            end
-            render :edit
-          end
+      @work.minor_version = @work.minor_version + 1
+      if @chapter.save && @work.save
+        flash[:notice] = ts("Work was successfully #{posted_changed ? "posted" : "updated"}.")
+        if posted_changed
+          flash[:notice] << ts(" It should appear in work listings within the next few minutes.")
         end
+        in_moderated_collection
+        redirect_to(@work)
       else
+        @chapter.errors.each { |err| @work.errors.add(:base, err) }
         render :edit
       end
     end
   end
 
   def update_tags
-    # If Edit or Cancel is pressed, bail out and display relevant form
-    if params[:edit_button]
-      render :edit_tags
-    elsif params[:cancel_button]
-      cancel_posting_and_redirect
-    else
-      # Otherwise, check that the work is valid, contains no errors etc
-      set_work_tag_error_messages
+    if params[:cancel_button]
+      return cancel_posting_and_redirect
+    end
 
-      if @work.errors.empty?
-        if params[:preview_button]
-          preview_mode(:edit_tags) do
-            render :preview_tags
-          end
-        elsif params[:save_button]
-          Work.expire_work_tag_groups_id(@work.id)
-          flash[:notice] = ts('Tags were successfully updated.')
-          redirect_to(@work)
-        else
-          if @work.has_required_tags? && @work.invalid_tags.blank?
-            @work.posted = true
-            @work.minor_version = @work.minor_version + 1
-            @work.save
-            flash[:notice] = ts('Work was successfully updated.')
-            redirect_to(@work) and return
-          else
-            render :edit_tags
-          end
-        end
-      else
-        render :edit_tags
-      end
+    @work.preview_mode = !!(params[:preview_button] || params[:edit_button])
+    @work.attributes = work_params
+
+    if params[:edit_button] || work_is_invalid?
+      set_work_tag_error_messages
+      render :edit_tags
+    elsif params[:preview_button]
+      render :preview_tags
+    elsif params[:save_button]
+      Work.expire_work_tag_groups_id(@work.id)
+      flash[:notice] = ts('Tags were successfully updated.')
+      redirect_to(@work)
+    else # Post Without Preview
+      @work.posted = true
+      @work.minor_version = @work.minor_version + 1
+      @work.save
+      flash[:notice] = ts('Work was successfully updated.')
+      redirect_to(@work)
     end
   end
 
@@ -826,60 +784,27 @@ class WorksController < ApplicationController
     @check_visibility_of = @work
   end
 
-  # Sets values for @work, @chapter, @coauthor_results, @pseuds, and @selected_pseuds
-  # and @tags[category]
-  def set_instance_variables
-    if params[:id] # edit, update, preview, manage_chapters
-      set_instance_variables_id
-    elsif params[:work] # create
-      set_instance_variables_work
-    else # new
-      set_instance_variables_default
-    end
-
-    @serial_works = @work.serial_works
-
+  def load_first_chapter
     @chapter = @work.first_chapter
-
-    if params[:claim_id]
-      @posting_claim = ChallengeClaim.find_by(id: params[:claim_id])
-    end
-
-    # If we're in preview mode, we want to pick up any changes that have been made to the first chapter
-    if params[:work] && work_params[:chapter_attributes]
-      @chapter.attributes = work_params[:chapter_attributes]
-    end
   end
 
-  # edit, update, preview, manage_chapters
-  def set_instance_variables_id
-    @work ||= Work.find(params[:id])
-    if params[:work] # editing, save our changes
-      @work.preview_mode = if params[:preview_button] || params[:cancel_button]
-                             true
-                           else
-                             false
-                           end
-
-      @work.attributes = work_params
-      @work.set_word_count(@work.preview_mode)
-      @work.save_parents if @work.preview_mode
+  # Check whether we should display :new or :edit instead of previewing or
+  # saving the user's changes.
+  def work_is_invalid?
+    if @work.authors.present? && (@work.authors & current_user.pseuds).empty?
+      flash.now[:error] = ts("You're not allowed to use that pseud.")
+      return true
     end
+
+    !(@work.errors.empty? &&
+      @work.has_required_tags? &&
+      @work.valid?)
   end
 
-  # create
-  def set_instance_variables_work
-    @work = Work.new(work_params)
-  end
-
-  # new
-  def set_instance_variables_default
-    if params[:load_unposted] && current_user.unposted_work
-      @work = current_user.unposted_work
-    else
-      @work = Work.new
-      @work.chapters.build
-    end
+  # Check whether we should display _choose_coauthor.
+  def work_has_pseuds_to_fix?
+    !(@work.invalid_pseuds.blank? &&
+      @work.ambiguous_pseuds.blank?)
   end
 
   # set the author attributes
@@ -908,31 +833,33 @@ class WorksController < ApplicationController
     if params[:work][:author_attributes] && params[:work][:author_attributes][:coauthors]
       params[:work][:author_attributes][:ids].concat(params[:work][:author_attributes][:coauthors]).uniq!
     end
+  end
 
-    # make sure at least one of the pseuds is actually owned by this user
-    user_ids = Pseud.where(id: params[:work][:author_attributes][:ids]).pluck(:user_id).uniq
-    unless user_ids.include?(current_user.id)
-      flash.now[:error] = ts("You're not allowed to use that pseud.")
-      render :new and return
+  def set_work_tag_error_messages
+    unless @work.has_required_tags?
+      error_message = 'Please add all required tags.'
+      error_message << ' Fandom is missing.' if @work.fandoms.blank?
+
+      error_message << ' Warning is missing.' if @work.warnings.blank?
+
+      @work.errors.add(:base, error_message)
     end
   end
 
-  # Sets values for @work and @tags[category]
-  def set_instance_variables_tags
-    return unless params[:id] # edit_tags, update_tags, preview_tags
+  def set_work_form_fields
+    load_pseuds
 
-    @work ||= Work.find(params[:id])
-    if params[:work] # editing, save our changes
-      if params[:preview_button] || params[:cancel_button] || params[:edit_button]
-        @work.preview_mode = true
-      else
-        @work.preview_mode = false
-      end
+    @work.reset_published_at(@chapter)
+    @series = current_user.series.distinct
+    @serial_works = @work.serial_works
 
-      @work.attributes = work_params
-      @work.save_parents if @work.preview_mode
+    if @collection.nil?
+      @collection = @work.approved_collections.first
     end
-  rescue
+
+    if params[:claim_id]
+      @posting_claim = ChallengeClaim.find_by(id: params[:claim_id])
+    end
   end
 
   def set_own_works
@@ -1002,28 +929,6 @@ class WorksController < ApplicationController
   end
 
   private
-
-  # NOTE: The reason for the gross condition=(...) thing is because I don't know
-  #       what potential values `saved` has as used elsewhere (which is what is
-  #       passed as `condition`) and thus the usual approach of condition=nil
-  #       followed by a ||= cannot be reliably used. -@duckinator
-  def preview_mode(page_name, condition = (@work.has_required_tags? && @work.invalid_tags.blank?))
-    @preview_mode = true
-
-    if condition
-      yield
-    else
-      @work.check_for_invalid_tags unless @work.invalid_tags.blank?
-
-      if @work.fandoms.blank?
-        @work.errors.add(:base, 'Updating: Please add all required tags. Fandom is missing.')
-      elsif !@work.has_required_tags?
-        @work.errors.add(:base, 'Updating: Please add all required tags.')
-      end
-
-      render page_name
-    end
-  end
 
   def build_options(params)
     pseuds_to_apply =

--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -293,7 +293,7 @@ class WorksController < ApplicationController
     set_work_form_fields
 
     # If Edit or Cancel is pressed, bail out and display relevant form
-    if params[:edit_button] || work_is_invalid?
+    if params[:edit_button] || work_cannot_be_saved?
       set_work_tag_error_messages
       render :new
     elsif work_has_pseuds_to_fix?
@@ -364,7 +364,7 @@ class WorksController < ApplicationController
     @work.set_challenge_claim_info
     set_work_form_fields
 
-    if params[:edit_button] || work_is_invalid?
+    if params[:edit_button] || work_cannot_be_saved?
       set_work_tag_error_messages
       render :edit
     elsif work_has_pseuds_to_fix?
@@ -405,7 +405,7 @@ class WorksController < ApplicationController
     @work.preview_mode = !!(params[:preview_button] || params[:edit_button])
     @work.attributes = work_tag_params
 
-    if params[:edit_button] || work_is_invalid?
+    if params[:edit_button] || work_cannot_be_saved?
       set_work_tag_error_messages
       render :edit_tags
     elsif params[:preview_button]
@@ -790,7 +790,7 @@ class WorksController < ApplicationController
 
   # Check whether we should display :new or :edit instead of previewing or
   # saving the user's changes.
-  def work_is_invalid?
+  def work_cannot_be_saved?
     if @work.authors.present? && (@work.authors & current_user.pseuds).empty?
       flash.now[:error] = ts("You're not allowed to use that pseud.")
       return true

--- a/features/works/chapter_edit.feature
+++ b/features/works/chapter_edit.feature
@@ -401,8 +401,7 @@ Feature: Edit chapters
     Then I should see "Chapter 1"
       And I should see "Chapter by originalposter"
     When I follow "Edit Chapter"
-      And "AO3-4699" is fixed 
-    # Then I should not see "You're not allowed to use that pseud."
+    Then I should not see "You're not allowed to use that pseud."
     When I fill in "content" with "opsfriend was here"
       And I post the chapter
     Then I should see "opsfriend was here"

--- a/lib/taggable.rb
+++ b/lib/taggable.rb
@@ -148,8 +148,6 @@ module Taggable
           errors.add(:base, error)
         end
       end
-
-      throw :abort
     end
   end
 

--- a/spec/controllers/chapters_controller_spec.rb
+++ b/spec/controllers/chapters_controller_spec.rb
@@ -383,6 +383,7 @@ describe ChaptersController do
     context "when work owner is logged in" do
       before do
         fake_login_known_user(user)
+        @chapter_attributes[:author_attributes] = { ids: [user.pseuds.first.id] }
       end
 
       it "errors and redirects to user page when user is banned" do
@@ -586,7 +587,7 @@ describe ChaptersController do
         user2 = create(:user)
         @chapter_attributes[:author_attributes] = { ids: [user2.pseuds.first.id] }
         put :update, params: { work_id: work.id, id: work.chapters.first.id, chapter: @chapter_attributes }
-        expect(response).to render_template("new")
+        expect(response).to render_template("edit")
         expect(flash[:error]).to eq "You're not allowed to use that pseud."
       end
 
@@ -615,9 +616,9 @@ describe ChaptersController do
           expect(response).to render_template("_choose_coauthor")
         end
 
-        it "renders new if chapter is not valid" do
+        it "renders edit if chapter is not valid" do
           put :update, params: { work_id: work.id, id: work.chapters.first.id, chapter: { content: "" } }
-          expect(response).to render_template(:new)
+          expect(response).to render_template(:edit)
         end
       end
 
@@ -630,9 +631,9 @@ describe ChaptersController do
           expect(response).to render_template("_choose_coauthor")
         end
 
-        it "renders new if chapter is not valid" do
+        it "renders edit if chapter is not valid" do
           put :update, params: { work_id: work.id, id: work.chapters.first.id, chapter: { content: "" } }
-          expect(response).to render_template(:new)
+          expect(response).to render_template(:edit)
         end
       end
 
@@ -899,14 +900,6 @@ describe ChaptersController do
         post :post, params: { work_id: work.id, id: @chapter_to_post.id }
         expect(assigns[:work].updated_at).not_to eq(old_updated_at)
       end
-
-      it "assigns instance variables correctly" do
-        post :post, params: { work_id: work.id, id: @chapter_to_post.id }
-        expect(assigns[:allpseuds]).to eq user.pseuds
-        expect(assigns[:pseuds]).to eq user.pseuds
-        expect(assigns[:coauthors]).to eq []
-        expect(assigns[:selected_pseuds]).to eq [user.pseuds.first.id]
-      end
     end
 
     context "when other user is logged in" do
@@ -915,7 +908,6 @@ describe ChaptersController do
       end
 
       it "errors and redirects to work" do
-        pending "non-work owner should not be able to post works"
         post :post, params: { work_id: work.id, id: @chapter_to_post.id }
         it_redirects_to_with_error(work_path(work), "Sorry, you don't have permission to access the page you were trying to reach.")
       end
@@ -944,10 +936,6 @@ describe ChaptersController do
         get :confirm_delete, params: { work_id: work.id, id: work.chapters.first.id }
         expect(assigns[:work]).to eq work
         expect(assigns[:chapter]).to eq work.chapters.first
-        expect(assigns[:allpseuds]).to eq user.pseuds
-        expect(assigns[:pseuds]).to eq user.pseuds
-        expect(assigns[:coauthors]).to eq []
-        expect(assigns[:selected_pseuds]).to eq [user.pseuds.first.id]
       end
     end
 


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5603

## Purpose

1. I overhauled the WorksController and the ChaptersController to try to eliminate the function `set_instance_variables`.
    - I moved the code to build a blank item into `#new`, the code to build an item from params into `#create`, and the code to modify an existing item into `#update`.
    - I moved the instance variable assignment into `load_pseuds` (for the ChaptersController) and `set_work_form_fields` (for the WorksController).
    - I did a similar thing for `WorksController#set_instance_variables_tags`.
2. In the process, I cleaned up the before_action filters a little for both controllers.
3. I also refactored several of the functions that I was modifying, to make it easier to follow the flow of control.
    - I moved the check for `params[:cancel_button]` to the very beginning of the function, before assigning to attributes. Because some attribute assignment is written to the database immediately (e.g. tags), I figured that that was contrary to the purpose of the button.
    - To further simplify the WorksController code, I also fixed up the work function `set_challenge_claim_info`. This means that it can be used alongside `set_challenge_info` (which works only for the work's assignments).
    - I also changed `Work#check_for_invalid_tags` into a validation. (It used to be a before_save callback that aborted in case of error, which meant that it would only display an error to the user if `Work#save` was called. Hence the complicated code in the `WorksController#preview_mode` function to try to catch invalid tags on preview.)
4. I added a new function `WorksController#work_tag_params` to make sure that it only allows the tags (and the language) to be changed, and not any of the other fields that are available in `WorksController#work_params`.
5. I also rearranged a few functions in the WorksController to make sure that more of the utility functions were protected, instead of mixed in alongside the public actions.

## Testing

See Slack. In addition, it would be good to check that the refactored code behaves as expected.