### PR TITLE
AO3-5611 Restore empty default values for certain string columns

### DIFF
--- a/db/migrate/20190207034230_restore_default_empty_strings.rb
+++ b/db/migrate/20190207034230_restore_default_empty_strings.rb
@@ -1,0 +1,16 @@
+class RestoreDefaultEmptyStrings < ActiveRecord::Migration[5.1]
+  def change
+    change_column_default :archive_faqs, :slug, from: nil, to: ""
+    change_column_default :collections, :icon_alt_text, from: nil, to: ""
+    change_column_default :collections, :icon_comment_text, from: nil, to: ""
+    change_column_default :invite_requests, :simplified_email, from: nil, to: ""
+    change_column_default :languages, :sortable_name, from: nil, to: ""
+    change_column_default :pseuds, :icon_alt_text, from: nil, to: ""
+    change_column_default :pseuds, :icon_comment_text, from: nil, to: ""
+    change_column_default :skins, :icon_alt_text, from: nil, to: ""
+    change_column_default :taggings, :taggable_type, from: nil, to: ""
+    change_column_default :taggings, :tagger_type, from: nil, to: ""
+    change_column_default :tags, :name, from: nil, to: ""
+    change_column_default :tags, :sortable_name, from: nil, to: ""
+  end
+end


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5611

## Purpose

These were unintentionally removed by the UTF8MB4 upgrade script.

## Testing Instructions

I don't think we need to test much as long as the migration runs OK.