### PR TITLE
AO3-5582 Update elasticsearch on CI to 6.5.2

### DIFF
--- a/script/prepare_codeship.sh
+++ b/script/prepare_codeship.sh
@@ -35,7 +35,7 @@ bundle exec rake db:migrate --trace
 #sed -e 's/PRODUCTION_CACHE.*$//' -i config/config.yml
 #wget http://media.transformativeworks.org/ao3/codeship/prepare_part2.sh -O - | bash -x
 
-ES_VERSION="6.5.0"
+ES_VERSION="6.5.2"
 ES_PORT="9400"
 cd ~
 wget https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-${ES_VERSION}.zip

--- a/script/travis_elasticsearch_upgrade.sh
+++ b/script/travis_elasticsearch_upgrade.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-ES_VERSION="6.5.0"
+ES_VERSION="6.5.2"
 ES_PORT="9400"
 cd /tmp
 wget https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-${ES_VERSION}.tar.gz


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5582

## Purpose

Changes the version of Elasticsearch in use on Travis and Codeship to be 6.5.2, which is currently in use on production.

## Testing Instructions

No user testing required.