### PR TITLE
AO3-5622 Include images in mobi, epub, and azw3 downloads

### DIFF
--- a/app/models/download.rb
+++ b/app/models/download.rb
@@ -72,6 +72,16 @@ class Download
     "/downloads/#{work.id}/#{file_name}.#{file_type}"
   end
 
+  # The path to the zip file (eg, "/tmp/42/42.zip")
+  def zip_path
+    "#{dir}/#{work.id}.zip"
+  end
+
+  # The path to the folder where web2disk downloads the xhtml and images
+  def assets_path
+    "#{dir}/assets"
+  end
+
   # The full path to the file (eg, "/tmp/42/The Hobbit.epub")
   def file_path
     "#{dir}/#{file_name}.#{file_type}"

--- a/public/stylesheets/ebooks.css
+++ b/public/stylesheets/ebooks.css
@@ -26,3 +26,12 @@
 .userstuff div.userstuff {
   margin: 1em 0;
 }
+
+img, embed, iframe, object {
+  max-width: 100% !important;
+}
+
+/* override default Calibre style for better obedience of max-width */
+embed, iframe, object {
+  border: none !important;
+}


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5622

## Purpose

Make sure mobi, epub, and azw3 downloads of works have images.

We do this by pointing [web2disk](https://manual.calibre-ebook.com/generated/en/web2disk.html) at the HTML download from which the mobi, epub, or azw3 file will be created. web2disk will download any images to a directory and create an xhtml version of the HTML download that updates the `img` elements' `src` attribute to point at the newly-downloaded images (this is a relative path; we're not keeping the images on our servers and hot linking to them for eternity). 

We then create a zip file of the downloaded images and xhtml file and tell ebook-convert to turn the zip file into the desired file type. (Previously, we just had ebook-convert turn the HTML download into a mobi, epub, or azw3.)

## Testing Instructions

Download some works with images! Make sure they display even when you're not online!