### PR TITLE
AO3-3880 Prevent 500 error when downloading a work that has an anonymous work listed in "Works inspired by this one."

### DIFF
--- a/app/views/downloads/_download_afterword.html.erb
+++ b/app/views/downloads/_download_afterword.html.erb
@@ -15,7 +15,7 @@
           <dt><%= ts('Works inspired by this one') %></dt>
           <dd>
             <%= @work.approved_related_works.where(:translation => false).map{|rw|
-"#{link_to(rw.work.title.html_safe, work_url(rw.work))} #{ts('by')} #{byline(rw.work, only_path: false)}"}.join(",
+"#{link_to(rw.work.title.html_safe, work_url(rw.work))} #{ts('by')} #{byline(rw.work, visibility: 'public', only_path: false)}"}.join(",
 ").html_safe %>
           </dd>
         </dl>


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-3880

## Purpose

When rendering a work to be downloaded, Devise functions are unavailable, so all calls to `ApplicationHelper#byline` on items that could have `anonymous?` set to true need to have `visibility: 'public'` set.

## Testing Instructions

See my comment on the issue.