### PR TITLE
AO3-3880 Don't add "notes" entry to ebook table of contents

### DIFF
--- a/app/models/download_writer.rb
+++ b/app/models/download_writer.rb
@@ -95,6 +95,9 @@ class DownloadWriter
       download.zip_path,
       download.file_path,
       '--input-encoding', 'utf-8',
+      # Prevent it from turning links to endnotes into entries for the table of
+      # contents on works with fewer than the specified number of chapters.
+      '--toc-threshold', '0',
       '--use-auto-toc',
       '--title', meta[:title],
       '--title-sort', meta[:sortable_title],


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-3880

## Purpose

From the [ebook-convert documentation](https://manual.calibre-ebook.com/generated/en/ebook-convert.html#cmdoption-ebook-convert-toc-threshold):

> --toc-threshold
> If fewer than this number of chapters is detected, then links are added to the Table of Contents. Default: 6

So basically what was happening was, if the work had fewer than four chapters (because four actual chapters, plus preface and afterword equals six) and it had work or chapter endnotes, you'd end up with "notes" as a TOC entry. 

This was weird, since it's not like we were also adding entries for the beginning notes or summary. It was even weirder if you had multiple end notes because only _one_ of the endnotes would be linked because, by default, ebook-convert does not allow you to have two TOC entries with the same name.

So anyway, we're going to stop it from turning "notes" into a TOC entry.

## Testing Instructions

Post a work with at least one endnote and less than four chapters and make sure "notes" does not appear in the download file's table of contents.