### PR TITLE
AO3-5630 Always delete /tmp files after download generation

### DIFF
--- a/app/controllers/downloads_controller.rb
+++ b/app/controllers/downloads_controller.rb
@@ -4,7 +4,7 @@ class DownloadsController < ApplicationController
   before_action :load_work, only: :show
   before_action :check_download_posted_status, only: :show
   before_action :check_download_visibility, only: :show
-  after_action :remove_downloads, only: :show
+  around_action :remove_downloads, only: :show
 
   def show
     respond_to :html, :pdf, :mobi, :epub, :azw3
@@ -45,7 +45,11 @@ protected
   # We're currently just writing everything to tmp and feeding them through
   # nginx so we don't want to keep the files around.
   def remove_downloads
-    @download&.remove unless Rails.env.test?
+    begin
+      yield
+    ensure
+      Download.remove(@work) unless Rails.env.test?
+    end
   end
 
   # We can't use check_visibility because this controller doesn't have access to

--- a/app/controllers/downloads_controller.rb
+++ b/app/controllers/downloads_controller.rb
@@ -45,11 +45,9 @@ protected
   # We're currently just writing everything to tmp and feeding them through
   # nginx so we don't want to keep the files around.
   def remove_downloads
-    begin
-      yield
-    ensure
-      Download.remove(@work) unless Rails.env.test?
-    end
+    yield
+  ensure
+    Download.remove(@work) unless Rails.env.test?
   end
 
   # We can't use check_visibility because this controller doesn't have access to


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5630

## Purpose

Use [around_action with begin/ensure](https://guides.rubyonrails.org/action_controller_overview.html#after-filters-and-around-filters) to run cleanup even when the action has errors.

Use Download.remove because if download generation fails, `@download` will be nil.

## Testing Instructions

Confirm downloads still work on staging.

Locally, I tested this by removing the zip command (`sudo apt remove zip`), forcing epub generation to crash every time, and checking that the `/tmp/<work ID>` directory gets created then deleted properly.