### PR TITLE
AO3-5631 Make /tmp download directory unique per generation

### DIFF
--- a/app/controllers/downloads_controller.rb
+++ b/app/controllers/downloads_controller.rb
@@ -48,7 +48,7 @@ protected
   def remove_downloads
     yield
   ensure
-    @download.remove unless Rails.env.test?
+    @download.remove
   end
 
   # We can't use check_visibility because this controller doesn't have access to

--- a/app/controllers/downloads_controller.rb
+++ b/app/controllers/downloads_controller.rb
@@ -8,10 +8,11 @@ class DownloadsController < ApplicationController
 
   def show
     respond_to :html, :pdf, :mobi, :epub, :azw3
-    @download = Download.generate(@work, mime_type: request.format)
+    @download = Download.new(@work, mime_type: request.format)
+    @download.generate
 
     # Make sure we were able to generate the download.
-    unless @download.present? && @download.exists?
+    unless @download.exists?
       flash[:error] = ts("We were not able to render this work. Please try again in a little while or try another format.")
       redirect_to work_path(@work)
       return
@@ -47,7 +48,7 @@ protected
   def remove_downloads
     yield
   ensure
-    Download.remove(@work) unless Rails.env.test?
+    @download.remove unless Rails.env.test?
   end
 
   # We can't use check_visibility because this controller doesn't have access to

--- a/app/models/download.rb
+++ b/app/models/download.rb
@@ -1,15 +1,5 @@
 class Download
-  # Given a work and a format or mime type, generate a download file
-  def self.generate(work, options = {})
-    new(work, options).generate
-  end
-
-  # Remove all downloads for this work
-  def self.remove(work)
-    new(work).remove
-  end
-
-  attr_reader :work, :file_type, :mime_type
+  attr_reader :work, :file_type, :mime_type, :timestamp
 
   def initialize(work, options = {})
     @work = work
@@ -17,6 +7,7 @@ class Download
     # TODO: Our current version of the mime-types gem doesn't include azw3, but
     # the gem cannot be updated without updating rest-client
     @mime_type = @file_type == "azw3" ? "application/x-mobi8-ebook" : MIME::Types.type_for(@file_type).first
+    @timestamp = Time.now.to_i
   end
 
   def generate
@@ -72,7 +63,7 @@ class Download
     "/downloads/#{work.id}/#{file_name}.#{file_type}"
   end
 
-  # The path to the zip file (eg, "/tmp/42/42.zip")
+  # The path to the zip file (eg, "/tmp/42_epub_1551241277/42.zip")
   def zip_path
     "#{dir}/#{work.id}.zip"
   end
@@ -82,14 +73,19 @@ class Download
     "#{dir}/assets"
   end
 
-  # The full path to the file (eg, "/tmp/42/The Hobbit.epub")
+  # The full path to the HTML file (eg, "/tmp/42_epub_1551241277/The Hobbit.html")
+  def html_file_path
+    "#{dir}/#{file_name}.html"
+  end
+
+  # The full path to the file (eg, "/tmp/42_epub_1551241277/The Hobbit.epub")
   def file_path
     "#{dir}/#{file_name}.#{file_type}"
   end
 
   # Write to temp and then immediately clean it up
   def dir
-    "/tmp/#{work.id}"
+    "/tmp/#{work.id}_#{file_type}_#{timestamp}"
   end
 
   # Utility methods which clean up work data for use in downloads

--- a/app/models/download.rb
+++ b/app/models/download.rb
@@ -1,5 +1,5 @@
 class Download
-  attr_reader :work, :file_type, :mime_type, :timestamp
+  attr_reader :work, :file_type, :mime_type
 
   def initialize(work, options = {})
     @work = work
@@ -7,7 +7,6 @@ class Download
     # TODO: Our current version of the mime-types gem doesn't include azw3, but
     # the gem cannot be updated without updating rest-client
     @mime_type = @file_type == "azw3" ? "application/x-mobi8-ebook" : MIME::Types.type_for(@file_type).first
-    @timestamp = Time.now.to_i
   end
 
   def generate
@@ -63,7 +62,7 @@ class Download
     "/downloads/#{work.id}/#{file_name}.#{file_type}"
   end
 
-  # The path to the zip file (eg, "/tmp/42_epub_1551241277/42.zip")
+  # The path to the zip file (eg, "/tmp/42_epub_20190301-24600-17164a8/42.zip")
   def zip_path
     "#{dir}/#{work.id}.zip"
   end
@@ -73,19 +72,22 @@ class Download
     "#{dir}/assets"
   end
 
-  # The full path to the HTML file (eg, "/tmp/42_epub_1551241277/The Hobbit.html")
+  # The full path to the HTML file (eg, "/tmp/42_epub_20190301-24600-17164a8/The Hobbit.html")
   def html_file_path
     "#{dir}/#{file_name}.html"
   end
 
-  # The full path to the file (eg, "/tmp/42_epub_1551241277/The Hobbit.epub")
+  # The full path to the file (eg, "/tmp/42_epub_20190301-24600-17164a8/The Hobbit.epub")
   def file_path
     "#{dir}/#{file_name}.#{file_type}"
   end
 
-  # Write to temp and then immediately clean it up
+  # Get the temporary directory where downloads will be generated,
+  # creating the directory if it doesn't exist.
   def dir
-    "/tmp/#{work.id}_#{file_type}_#{timestamp}"
+    return @tmpdir if @tmpdir
+    @tmpdir = Dir.mktmpdir("#{work.id}_#{file_type}_")
+    @tmpdir
   end
 
   # Utility methods which clean up work data for use in downloads

--- a/app/models/download_writer.rb
+++ b/app/models/download_writer.rb
@@ -9,8 +9,6 @@ class DownloadWriter
   end
 
   def write
-    # Create the directory
-    FileUtils.mkdir_p download.dir
     generate_html_download
     generate_ebook_download unless download.file_type == "html"
     download

--- a/app/models/download_writer.rb
+++ b/app/models/download_writer.rb
@@ -1,12 +1,11 @@
 require 'open3'
 
 class DownloadWriter
-  attr_reader :download, :work, :html_download
+  attr_reader :download, :work
 
   def initialize(download)
     @download = download
     @work = download.work
-    @html_download = Download.new(work, format: "html")
   end
 
   def write
@@ -21,7 +20,7 @@ class DownloadWriter
 
   # Write the HTML version
   def generate_html_download
-    return if html_download.exists?
+    return if download.exists?
 
     renderer = ApplicationController.renderer.new(
       http_host: ArchiveConfig.APP_HOST
@@ -35,9 +34,9 @@ class DownloadWriter
         chapters: download.chapters
       }
     )
-        
+
     # write to file
-    File.open(html_download.file_path, 'w:UTF-8') { |f| f.write(@html) }
+    File.open(download.html_file_path, 'w:UTF-8') { |f| f.write(@html) }
   end
 
   # transform HTML version into ebook version
@@ -74,7 +73,7 @@ class DownloadWriter
       '--disable-smart-shrinking',
       '--log-level', 'none',
       '--title', download.file_name,
-      html_download.file_path, download.file_path
+      download.html_file_path, download.file_path
     ]
   end
 
@@ -126,7 +125,7 @@ class DownloadWriter
       '--base-dir', download.assets_path,
       '--max-recursions', '0',
       '--dont-download-stylesheets',
-      "file://#{html_download.file_path}"
+      "file://#{download.html_file_path}"
     ]
   end
 

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -846,11 +846,6 @@ class Work < ApplicationRecord
     end
   end
 
-  after_update :remove_outdated_downloads
-  def remove_outdated_downloads
-    Download.remove(self)
-  end
-
   #######################################################################
   # TAGGING
   # Works are taggable objects.

--- a/features/step_definitions/work_download_steps.rb
+++ b/features/step_definitions/work_download_steps.rb
@@ -1,7 +1,8 @@
 Then /^I should receive a file of type "(.*?)"$/ do |filetype|
   mime_type = filetype == "azw3" ? "application/x-mobi8-ebook" : MIME::Types.type_for("foo.#{filetype}").first
-  page.driver.response.headers['Content-Disposition'].should =~ /filename=.+\.#{filetype}/
-  page.response_headers['Content-Type'].should == mime_type
+  expect(page.response_headers['Content-Disposition']).to match(/filename=.+\.#{filetype}/)
+  expect(page.response_headers['Content-Length'].to_i).to be_positive
+  expect(page.response_headers['Content-Type']).to eq(mime_type)
 end
 
 Then /^I should be able to download all versions of "(.*?)"$/ do |title|
@@ -11,16 +12,14 @@ Then /^I should be able to download all versions of "(.*?)"$/ do |title|
 end
 
 Then /^I should be able to download the (\w+) version of "(.*?)"$/ do |filetype, title|
-  step %{time is frozen at this second}
   work = Work.find_by_title(title)
-  download = Download.new(work, format: filetype)
   visit work_url(work)
   step %{I follow "#{filetype.upcase}"}
-  step %{I jump in our Delorean and return to the present}
 
-  filename = download.file_path # the full path of the download file we expect to exist
+  download = Download.new(work, format: filetype)
+  filename = "#{download.file_name}.#{download.file_type}"
   mime_type = filetype == "azw3" ? "application/x-mobi8-ebook" : MIME::Types.type_for(filename).first
-  assert File.exist?(filename), "#{filename} does not exist"
-  page.driver.response.headers['Content-Disposition'].should =~ /filename=\"#{File.basename(filename)}\"/
-  page.response_headers['Content-Type'].should == mime_type
+  expect(page.response_headers['Content-Disposition']).to match(/filename="#{filename}"/)
+  expect(page.response_headers['Content-Length'].to_i).to be_positive
+  expect(page.response_headers['Content-Type']).to eq(mime_type)
 end

--- a/features/step_definitions/work_download_steps.rb
+++ b/features/step_definitions/work_download_steps.rb
@@ -1,56 +1,26 @@
-Then /^I should receive a file of type "([^"]*)"$/ do |filetype|
+Then /^I should receive a file of type "(.*?)"$/ do |filetype|
   mime_type = filetype == "azw3" ? "application/x-mobi8-ebook" : MIME::Types.type_for("foo.#{filetype}").first
   page.driver.response.headers['Content-Disposition'].should =~ /filename=.+\.#{filetype}/
   page.response_headers['Content-Type'].should == mime_type
 end
 
-Then /^I should be able to download all versions of "(.*)"$/ do |title|
+Then /^I should be able to download all versions of "(.*?)"$/ do |title|
   (ArchiveConfig.DOWNLOAD_FORMATS - ['html']).each do |filetype|
     step %{I should be able to download the #{filetype} version of "#{title}"}
   end
 end
 
-Then /^I (?:should be able to )?download the (\w+) version of "(.*)"$/ do |filetype, title|
+Then /^I should be able to download the (\w+) version of "(.*?)"$/ do |filetype, title|
+  step %{time is frozen at this second}
   work = Work.find_by_title(title)
   download = Download.new(work, format: filetype)
   visit work_url(work)
   step %{I follow "#{filetype.upcase}"}
+  step %{I jump in our Delorean and return to the present}
+
   filename = download.file_path # the full path of the download file we expect to exist
   mime_type = filetype == "azw3" ? "application/x-mobi8-ebook" : MIME::Types.type_for(filename).first
   assert File.exist?(filename), "#{filename} does not exist"
   page.driver.response.headers['Content-Disposition'].should =~ /filename=\"#{File.basename(filename)}\"/
   page.response_headers['Content-Type'].should == mime_type
-end
-
-Then /^I should not be able to download the (\w+) version of "(.*)"$/ do |filetype, title|
-  work = Work.find_by_title(title)
-  download = Download.new(work, format: filetype)
-  visit work_url(work)
-  step %{I follow "#{filetype.upcase}"}
-  filename = download.file_path # the full path of the download file we expect to exist
-  mime_type = filetype == "azw3" ? "application/x-mobi8-ebook" : MIME::Types.type_for(filename).first
-  page.driver.response.headers['Content-Disposition'].should_not =~ /filename=\"#{File.basename(filename)}\"/
-  page.response_headers['Content-Type'].should_not == mime_type
-end
-
-Then /^I should not be able to manually download the (\w+) version of "(.*)"$/ do |filetype, title|
-  work = Work.find_by_title(title)
-  download = Download.new(work, format: filetype)
-  download_url = "#{ArchiveConfig.APP_URL}#{download.public_path}"
-  filename = download.file_path # the full path of the download file we expect to exist
-  mime_type = filetype == "azw3" ? "application/x-mobi8-ebook" : MIME::Types.type_for(filename).first
-  visit download_url
-  page.driver.response.headers['Content-Disposition'].should_not =~ /filename=\"#{File.basename(filename)}\"/
-  page.response_headers['Content-Type'].should_not == mime_type
-end
-
-Then /^the (.*) version of "([^"]*)" should exist$/ do |filetype, title|
-  work = Work.find_by_title(title)
-  filename = "#{work.download_basename}.#{filetype}" # the full path of the download file we expect to exist
-  assert Download.new(work, format: filetype).exists?, "#{filename} does not exist"
-end
-
-Then /^the (.*) version of "([^"]*)" should not exist$/ do |filetype, title|
-  work = Work.find_by_title(title)
-  assert !Download.new(work, format: filetype).exists?, "#{filename} does exist"
 end


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5631

## Purpose

Add the file type and current timestamp to the directory name. This means each generation has to stay with the same Download instance for proper cleanup, and the Download class methods become obsolete.

Having timestamped directory names means we need to freeze time so the tests can find the generated files.

## Testing Instructions

Confirm downloads still work on staging.

Locally, I repeated the testing I did for #3528 as well.