### PR TITLE
AO3-4377 Associate remember me label and field in header login form

### DIFF
--- a/app/views/users/sessions/_passwd_small.html.erb
+++ b/app/views/users/sessions/_passwd_small.html.erb
@@ -13,7 +13,7 @@
               id: "user_session_password_small" %></dd>
   </dl>
   <p class="submit actions">
-    <label for="user_remember_me" class="action"><%= check_box_tag "user[remember_me]", 1, false, id: "user_remember_me_small" %><%= ts("Remember Me") %></label>
+    <label for="user_remember_me_small" class="action"><%= check_box_tag "user[remember_me]", 1, false, id: "user_remember_me_small" %><%= ts("Remember Me") %></label>
     <%= f.submit ts("Log In") %>
   </p>
 <% end %>


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-4377

## Purpose

Fixes the problem where clicking "Remember me" in the header login form would put the focus on the wrong field if you were on the login page.

## Testing Instructions

Go to the page and clicky clicky.
