### PR TITLE
AO3-4881 Fix text wrapping on last wrangled by info

### DIFF
--- a/app/views/tags/edit.html.erb
+++ b/app/views/tags/edit.html.erb
@@ -10,7 +10,7 @@
 <!--main content-->
 
 <% if logged_in_as_admin? %>
-  <p><%= ts("Last updated by %{wrangler} on %{date}", wrangler: @tag.last_wrangler.try(:login) || '---', date: @tag.updated_at) %></p>
+  <p class="notes"><%= ts("Last updated by %{wrangler} on %{date}", wrangler: @tag.last_wrangler.try(:login) || '---', date: @tag.updated_at) %></p>
 <% end %>
 
 <%= form_for @tag, :as => :tag, :url => { :action => "update", :id => @tag}, :html => { :method => :put } do |f| %>


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-4881

## Purpose

Stops the last wrangled by info from wrapping around the comment button.

## Testing Instructions

Log in as admin, go to a tag's edit page, and fiddle with the window size to confirm the info about who last wrangled a tag does not get squished.
