### PR TITLE
AO3-5250 Update button text when editing series bookmark

### DIFF
--- a/app/views/series/show.html.erb
+++ b/app/views/series/show.html.erb
@@ -66,7 +66,7 @@
 <% if logged_in? %>
   <div id="bookmark_form_placement" class="wrapper toggled">
     <% if @bookmark %>
-      <%= render "bookmarks/bookmark_form", :bookmarkable => @series, :bookmark => @bookmark, :button_name => ts("Edit"), :action => :update, :in_page => true %>
+      <%= render "bookmarks/bookmark_form", :bookmarkable => @series, :bookmark => @bookmark, :button_name => ts("Update"), :action => :update, :in_page => true %>
     <% else %>
       <%= render "bookmarks/bookmark_form", :bookmarkable => @series, :bookmark => Bookmark.new, :button_name => ts("Create"), :action => :create, :in_page => true %>
     <% end %>

--- a/app/views/series/show.html.erb
+++ b/app/views/series/show.html.erb
@@ -2,7 +2,7 @@
 <h2 class="heading">
 	<%= @series.title %>
 	<% if @series.restricted %>
-		<%= image_tag("lockblue.png", :size => "15x15", :alt => "(Restricted)", :title => "Restricted", skip_pipeline: true) %>
+		<%= image_tag("lockblue.png", size: "15x15", alt: "(Restricted)", title: "Restricted", skip_pipeline: true) %>
 	<% end %>
   <% if @series.hidden_by_admin %>
     <%= image_tag("lockred.png", size: "15x15", alt: ts("(Hidden by Admin)"),
@@ -24,38 +24,38 @@
   <dl class="series meta group">
 
     <% if @series.pseuds.many?%>
-      <dt><%= ts('Creators:') %></dt>
+      <dt><%= ts("Creators:") %></dt>
       <dd><%= byline(@series) %></dd>
     <% else %>
-      <dt><%= ts('Creator:') %></dt>
+      <dt><%= ts("Creator:") %></dt>
       <dd><%= byline(@series) %></dd>
     <% end %>
 
-    <dt><%= ts('Series Begun:') %></dt>
+    <dt><%= ts("Series Begun:") %></dt>
     <dd><%= @series.published_at.to_date %></dd>
-    <dt><%= ts('Series Updated:') %></dt>
+    <dt><%= ts("Series Updated:") %></dt>
     <dd><%= @series.revised_at ? @series.revised_at.to_date : @series.published_at %></dd>
 
     <% unless @series.summary.blank? %>
-      <dt><%= ts('Description:') %></dt>
+      <dt><%= ts("Description:") %></dt>
       <dd><blockquote class="userstuff"><%=raw sanitize_field(@series, :summary) %></blockquote></dd>
     <% end %>
     <% unless @series.series_notes.blank? %>
-      <dt><%= ts('Notes:') %></dt>
+      <dt><%= ts("Notes:") %></dt>
       <dd><blockquote class="userstuff"><%=raw sanitize_field(@series, :series_notes) %></blockquote></dd>
     <% end %>
 
-    <dt class="stats"><%= ts('Stats:') %></dt>
+    <dt class="stats"><%= ts("Stats:") %></dt>
     <dd class="stats"> 
       <dl class="stats">
-        <dt><%= ts('Words:') %></dt>
+        <dt><%= ts("Words:") %></dt>
         <dd><%= number_with_delimiter(@series.visible_word_count) %></dd>
-        <dt><%= ts('Works:') %></dt>
+        <dt><%= ts("Works:") %></dt>
         <dd><%= @series.visible_work_count %></dd>
-        <dt><%= ts('Complete:') %></dt>
+        <dt><%= ts("Complete:") %></dt>
         <dd><%= @series.complete? ? ts("Yes") : ts("No") %></dd>
         <% if (bookmark_count = @series.bookmarks.is_public.count) > 0 %>
-          <dt><%= ts('Bookmarks:') %></dt>
+          <dt><%= ts("Bookmarks:") %></dt>
           <dd><%= link_to_bookmarkable_bookmarks(@series, bookmark_count.to_s) %></dd>
         <% end %>
       </dl>
@@ -66,9 +66,9 @@
 <% if logged_in? %>
   <div id="bookmark_form_placement" class="wrapper toggled">
     <% if @bookmark %>
-      <%= render "bookmarks/bookmark_form", :bookmarkable => @series, :bookmark => @bookmark, :button_name => ts("Update"), :action => :update, :in_page => true %>
+      <%= render "bookmarks/bookmark_form", bookmarkable: @series, bookmark: @bookmark, button_name: ts("Update"), action: :update, in_page: true %>
     <% else %>
-      <%= render "bookmarks/bookmark_form", :bookmarkable => @series, :bookmark => Bookmark.new, :button_name => ts("Create"), :action => :create, :in_page => true %>
+      <%= render "bookmarks/bookmark_form", bookmarkable: @series, bookmark: Bookmark.new, button_name: ts("Create"), action: :create, in_page: true %>
     <% end %>
   </div>
 <% end %>


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5250

## Purpose

When you edit a series bookmark, the button to save your changes should say "Update" instead of "Edit."

## Testing Instructions

Bookmark a series, edit that bookmark, confirm the button says "Update" instead of "Edit."
