### PR TITLE
AO3-5473 Remove disable_filtering admin setting.

### DIFF
--- a/app/controllers/admin/settings_controller.rb
+++ b/app/controllers/admin/settings_controller.rb
@@ -25,8 +25,8 @@ class Admin::SettingsController < ApplicationController
       :invite_from_queue_frequency, :days_to_purge_unactivated, :last_updated_by,
       :invite_from_queue_at, :suspend_filter_counts, :suspend_filter_counts_at,
       :enable_test_caching, :cache_expiration, :tag_wrangling_off,
-      :disable_filtering, :request_invite_enabled, :creation_requires_invite,
-      :downloads_enabled, :hide_spam, :disable_support_form, :disabled_support_form_text
+      :request_invite_enabled, :creation_requires_invite, :downloads_enabled,
+      :hide_spam, :disable_support_form, :disabled_support_form_text
     )
   end
 end

--- a/app/controllers/bookmarks_controller.rb
+++ b/app/controllers/bookmarks_controller.rb
@@ -94,46 +94,42 @@ class BookmarksController < ApplicationController
       @page_subtitle = index_page_title
 
       if @owner.present?
-        if @admin_settings.disable_filtering?
-          @bookmarks = Bookmark.includes(:bookmarkable, :pseud, :tags, :collections).list_without_filters(@owner, options)
+        @search = BookmarkSearchForm.new(options.merge(faceted: true, parent: @owner))
+
+        if @user.blank?
+          # When it's not a particular user's bookmarks, we want
+          # to list *bookmarkable* items to avoid duplication
+          @bookmarkable_items = @search.bookmarkable_search_results
+          flash_search_warnings(@bookmarkable_items)
+          @facets = @bookmarkable_items.facets
         else
-          @search = BookmarkSearchForm.new(options.merge(faceted: true, parent: @owner))
+          # We're looking at a particular user's bookmarks, so
+          # just retrieve the standard search results and their facets.
+          @bookmarks = @search.search_results
+          flash_search_warnings(@bookmarks)
+          @facets = @bookmarks.facets
+        end
 
-          if @user.blank?
-            # When it's not a particular user's bookmarks, we want
-            # to list *bookmarkable* items to avoid duplication
-            @bookmarkable_items = @search.bookmarkable_search_results
-            flash_search_warnings(@bookmarkable_items)
-            @facets = @bookmarkable_items.facets
-          else
-            # We're looking at a particular user's bookmarks, so
-            # just retrieve the standard search results and their facets.
-            @bookmarks = @search.search_results
-            flash_search_warnings(@bookmarks)
-            @facets = @bookmarks.facets
-          end
+        if @search.options[:excluded_tag_ids].present? || @search.options[:excluded_bookmark_tag_ids].present?
+          # Excluded tags do not appear in search results, so we need to generate empty facets
+          # to keep them as checkboxes on the filters.
+          excluded_tag_ids = @search.options[:excluded_tag_ids] || []
+          excluded_bookmark_tag_ids = @search.options[:excluded_bookmark_tag_ids] || []
 
-          if @search.options[:excluded_tag_ids].present? || @search.options[:excluded_bookmark_tag_ids].present?
-            # Excluded tags do not appear in search results, so we need to generate empty facets
-            # to keep them as checkboxes on the filters.
-            excluded_tag_ids = @search.options[:excluded_tag_ids] || []
-            excluded_bookmark_tag_ids = @search.options[:excluded_bookmark_tag_ids] || []
-
-            # It's possible to determine the tag types by looking at
-            # the original parameters params[:exclude_bookmark_search],
-            # but we need the tag names too, so a database query is unavoidable.
-            tags = Tag.where(id: excluded_tag_ids + excluded_bookmark_tag_ids)
-            tags.each do |tag|
-              if excluded_tag_ids.include?(tag.id.to_s)
-                key = tag.class.to_s.downcase
-                @facets[key] ||= []
-                @facets[key] << QueryFacet.new(tag.id, tag.name, 0)
-              end
-              if excluded_bookmark_tag_ids.include?(tag.id.to_s)
-                key = 'tag'
-                @facets[key] ||= []
-                @facets[key] << QueryFacet.new(tag.id, tag.name, 0)
-              end
+          # It's possible to determine the tag types by looking at
+          # the original parameters params[:exclude_bookmark_search],
+          # but we need the tag names too, so a database query is unavoidable.
+          tags = Tag.where(id: excluded_tag_ids + excluded_bookmark_tag_ids)
+          tags.each do |tag|
+            if excluded_tag_ids.include?(tag.id.to_s)
+              key = tag.class.to_s.downcase
+              @facets[key] ||= []
+              @facets[key] << QueryFacet.new(tag.id, tag.name, 0)
+            end
+            if excluded_bookmark_tag_ids.include?(tag.id.to_s)
+              key = 'tag'
+              @facets[key] ||= []
+              @facets[key] << QueryFacet.new(tag.id, tag.name, 0)
             end
           end
         end

--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -91,38 +91,34 @@ class WorksController < ApplicationController
     end
 
     if @owner.present?
-      if @admin_settings.disable_filtering?
-        @works = Work.includes(:tags, :external_creatorships, :series, :language, collections: [:collection_items], pseuds: [:user]).list_without_filters(@owner, options)
-      else
-        @search = WorkSearchForm.new(options.merge(faceted: true, works_parent: @owner))
-        # If we're using caching we'll try to get the results from cache
-        # Note: we only cache some first initial number of pages since those are biggest bang for
-        # the buck -- users don't often go past them
-        if use_caching? && params[:work_search].blank? && params[:fandom_id].blank? &&
-           (params[:page].blank? || params[:page].to_i <= ArchiveConfig.PAGES_TO_CACHE)
-          # the subtag is for eg collections/COLL/tags/TAG
-          subtag = @tag.present? && @tag != @owner ? @tag : nil
-          user = logged_in? || logged_in_as_admin? ? 'logged_in' : 'logged_out'
-          @works = Rails.cache.fetch("#{@owner.works_index_cache_key(subtag)}_#{user}_page#{params[:page]}_true", expires_in: 20.minutes) do
-            results = @search.search_results
-            # calling this here to avoid frozen object errors
-            results.items
-            results.facets
-            results
-          end
-        else
-          @works = @search.search_results
+      @search = WorkSearchForm.new(options.merge(faceted: true, works_parent: @owner))
+      # If we're using caching we'll try to get the results from cache
+      # Note: we only cache some first initial number of pages since those are biggest bang for
+      # the buck -- users don't often go past them
+      if use_caching? && params[:work_search].blank? && params[:fandom_id].blank? &&
+         (params[:page].blank? || params[:page].to_i <= ArchiveConfig.PAGES_TO_CACHE)
+        # the subtag is for eg collections/COLL/tags/TAG
+        subtag = @tag.present? && @tag != @owner ? @tag : nil
+        user = logged_in? || logged_in_as_admin? ? 'logged_in' : 'logged_out'
+        @works = Rails.cache.fetch("#{@owner.works_index_cache_key(subtag)}_#{user}_page#{params[:page]}_true", expires_in: 20.minutes) do
+          results = @search.search_results
+          # calling this here to avoid frozen object errors
+          results.items
+          results.facets
+          results
         end
+      else
+        @works = @search.search_results
+      end
 
-        flash_search_warnings(@works)
+      flash_search_warnings(@works)
 
-        @facets = @works.facets
-        if @search.options[:excluded_tag_ids].present?
-          tags = Tag.where(id: @search.options[:excluded_tag_ids])
-          tags.each do |tag|
-            @facets[tag.class.to_s.downcase] ||= []
-            @facets[tag.class.to_s.downcase] << QueryFacet.new(tag.id, tag.name, 0)
-          end
+      @facets = @works.facets
+      if @search.options[:excluded_tag_ids].present?
+        tags = Tag.where(id: @search.options[:excluded_tag_ids])
+        tags.each do |tag|
+          @facets[tag.class.to_s.downcase] ||= []
+          @facets[tag.class.to_s.downcase] << QueryFacet.new(tag.id, tag.name, 0)
         end
       end
     elsif use_caching?
@@ -144,14 +140,10 @@ class WorksController < ApplicationController
 
     return unless @user.present?
 
-    if @admin_settings.disable_filtering?
-      @works = Work.collected_without_filters(@user, options)
-    else
-      @search = WorkSearchForm.new(options.merge(works_parent: @user, collected: true))
-      @works = @search.search_results
-      flash_search_warnings(@works)
-      @facets = @works.facets
-    end
+    @search = WorkSearchForm.new(options.merge(works_parent: @user, collected: true))
+    @works = @search.search_results
+    flash_search_warnings(@works)
+    @facets = @works.facets
     set_own_works
     @page_subtitle = ts('%{username} - Collected Works', username: @user.login)
   end

--- a/app/models/admin_setting.rb
+++ b/app/models/admin_setting.rb
@@ -21,7 +21,6 @@ class AdminSetting < ApplicationRecord
     account_creation_enabled?: ArchiveConfig.ACCOUNT_CREATION_ENABLED,
     days_to_purge_unactivated: ArchiveConfig.DAYS_TO_PURGE_UNACTIVATED,
     suspend_filter_counts?: false,
-    disable_filtering?: false,
     enable_test_caching?: false,
     cache_expiration: 10,
     tag_wrangling_off?: false,

--- a/app/models/bookmark.rb
+++ b/app/models/bookmark.rb
@@ -193,18 +193,6 @@ class Bookmark < ApplicationRecord
     return self.tags
   end
 
-  def self.list_without_filters(owner, options)
-    bookmarks = owner.bookmarks
-    user = nil
-    if %w(Pseud User).include?(owner.class.to_s)
-      user = owner.respond_to?(:user) ? owner.user : owner
-    end
-    unless User.current_user == user
-      bookmarks = bookmarks.is_public
-    end
-    bookmarks = bookmarks.paginate(page: options[:page], per_page: ArchiveConfig.ITEMS_PER_PAGE)
-  end
-
   # TODO: Is this necessary anymore?
   before_destroy :save_parent_info
 

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -1078,26 +1078,6 @@ class Work < ApplicationRecord
     end
   end
 
-  protected
-
-  # a string for use in joins: clause to add ownership lookup
-  OWNERSHIP_JOIN = "INNER JOIN creatorships ON (creatorships.creation_id = works.id AND creatorships.creation_type = 'Work')
-                    INNER JOIN pseuds ON creatorships.pseud_id = pseuds.id
-                    INNER JOIN users ON pseuds.user_id = users.id"
-
-  COMMON_TAG_JOIN = "INNER JOIN common_taggings ON (works.id = common_taggings.filterable_id AND common_taggings.filterable_type = 'Work')
-                  INNER JOIN tags ON common_taggings.common_tag_id = tags.id"
-
-
-  VISIBLE_TO_ALL_CONDITIONS = {posted: true, restricted: false, hidden_by_admin: false}
-
-  VISIBLE_TO_USER_CONDITIONS = {posted: true, hidden_by_admin: false}
-
-  VISIBLE_TO_ADMIN_CONDITIONS = {posted: true}
-
-
-
-
   #################################################################################
   #
   # In this section we define various named scopes that can be chained together

--- a/app/sweepers/collection_sweeper.rb
+++ b/app/sweepers/collection_sweeper.rb
@@ -52,14 +52,9 @@ class CollectionSweeper < ActionController::Caching::Sweeper
 
   # Expire the collection blurb and profile
   def self.expire_collection_blurb_and_profile(collection)
-    # Expire all versions of the blurb: whether the new search is enabled or
-    # not, and whether the user is logged in or not.
-    # TODO: After the ES6 upgrade, re-evaluate whether it's necessary to keep
-    # the new-search/old-search distinction for enabling/disabling filtering
-    # (and probably change the name if it is kept).
-    %w[old-search new-search].product(%w[logged-in logged-out]).each do |pair|
-      search, logged_in = pair
-      cache_key = "collection-blurb-#{search}-#{logged_in}-#{collection.id}-v3"
+    # Expire both versions of the blurb, whether the user is logged in or not.
+    %w[logged-in logged-out].each do |logged_in|
+      cache_key = "collection-blurb-#{logged_in}-#{collection.id}-v3"
       ActionController::Base.new.expire_fragment(cache_key)
     end
 

--- a/app/views/admin/settings/index.html.erb
+++ b/app/views/admin/settings/index.html.erb
@@ -51,9 +51,6 @@
     <h3 class="landmark heading"><%= ts("Performance and Misc") %></h3>
     <dl>
 
-      <dt><%= f.check_box :disable_filtering %></dt>
-      <dd><%= f.label :disable_filtering, ts("Turn off filtering on index pages") %></dd>
-
       <dt><%= f.check_box :suspend_filter_counts %></dt>
       <dd><%= f.label :suspend_filter_counts, ts("Suspend some filter tracking due to high posting volume") %></dd>
 

--- a/app/views/collections/_collection_blurb.html.erb
+++ b/app/views/collections/_collection_blurb.html.erb
@@ -1,9 +1,8 @@
 <!-- this partial requires collection; @challenges_count, @works_count, @bookmarks_count must be set -->
 <li class="<% if collection.user_is_owner?(current_user) %>own <% end %>collection picture blurb group" role="article">
   <% logged_in = (logged_in_as_admin? || logged_in?) ? "logged-in" : "logged-out" %>
-  <% old_search = @admin_settings.disable_filtering? %>
-  <% # remember to update collection_sweeper and challenge_signup_sweeper if you change this %>
-  <% cache("collection-blurb-#{old_search ? "old-search" : "new-search"}-#{logged_in}-#{collection.id}-v3", skip_digest: true) do %>
+  <% # remember to update collection_sweeper if you change this key %>
+  <% cache("collection-blurb-#{logged_in}-#{collection.id}-v3", skip_digest: true) do %>
     <div class="header module group">
       <h4 class="heading">
         <%= link_to collection.title, collection_path(collection) %>

--- a/app/views/collections/_collection_blurb.html.erb
+++ b/app/views/collections/_collection_blurb.html.erb
@@ -53,9 +53,8 @@
       <% end %>
       <dt><%= ts("Works:") %></dt>
       <dd><%= link_to(@works_count, collection_works_path(collection)) %></dd>
-      <% @bookmarks_count = old_search ? collection.all_approved_bookmarks_count : collection.all_bookmarked_items_count %>
-      <% if @bookmarks_count > 0 %>
-        <dt><%= ts(old_search ? "Bookmarks:" : "Bookmarked Items:") %></dt>
+      <% if (@bookmarks_count = collection.all_bookmarked_items_count) > 0 %>
+        <dt><%= ts("Bookmarked Items:") %></dt>
         <dd><%= link_to(@bookmarks_count, collection_bookmarks_path(collection)) %></dd>
       <% end %>
     </dl>

--- a/app/views/collections/_sidebar.html.erb
+++ b/app/views/collections/_sidebar.html.erb
@@ -28,11 +28,7 @@
 
     <li><%= span_if_current ts("Works (%{count})", key: 'dashboard', :count => @collection.all_approved_works_count), collection_works_path(@collection) %></li>
 
-    <% if @admin_settings.disable_filtering? %>
-      <li><%= span_if_current ts("Bookmarks (%{count})", key: 'dashboard', :count => @collection.all_approved_bookmarks_count), collection_bookmarks_path(@collection) %></li>
-    <% else %>
-      <li><%= span_if_current ts("Bookmarked Items (%{count})", key: 'dashboard', :count => @collection.all_bookmarked_items_count), collection_bookmarks_path(@collection) %></li>
-    <% end %>
+    <li><%= span_if_current ts("Bookmarked Items (%{count})", key: 'dashboard', :count => @collection.all_bookmarked_items_count), collection_bookmarks_path(@collection) %></li>
 
     <li>
       <% if controller.controller_name == 'collections' && controller.action_name == 'show' %>

--- a/db/migrate/20190323185300_drop_disable_filtering_from_admin_settings.rb
+++ b/db/migrate/20190323185300_drop_disable_filtering_from_admin_settings.rb
@@ -1,0 +1,5 @@
+class DropDisableFilteringFromAdminSettings < ActiveRecord::Migration[5.1]
+  def change
+    remove_column :admin_settings, :disable_filtering, :boolean, default: false, null: false
+  end
+end

--- a/spec/controllers/works/default_rails_actions_spec.rb
+++ b/spec/controllers/works/default_rails_actions_spec.rb
@@ -302,16 +302,6 @@ describe WorksController do
           expect(assigns(:works).items).not_to include(@work)
         end
 
-        it "shows results when filters are disabled" do
-          allow(controller).to receive(:fetch_admin_settings).and_return(true)
-          admin_settings = AdminSetting.new(disable_filtering: true)
-          controller.instance_variable_set("@admin_settings", admin_settings)
-          get :index, params: { tag_id: @fandom.name }
-          expect(assigns(:works)).to include(@work)
-
-          allow(controller).to receive(:fetch_admin_settings).and_call_original
-        end
-
         context "with restricted works" do
           before do
             @work2 = create(:posted_work, fandom_string: @fandom.name, restricted: true)


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5473

## Purpose

This PR removes the `disable_filtering` admin setting, as well the functions `list_without_filters` and `collected_without_filters` that were used exclusively to implement the ES-free bookmark and work listings. It also removes some nearby scopes in the Work class that are either unused, or used only in the `list_without_filters` and `collected_without_filters` functions.

Note that you may want to view the diff ignoring whitespace, because there are a fair amount of indentation changes in the WorksController and BookmarksController.

## Testing Instructions

See JIRA.