### PR TITLE
AO3-5492 Index work tags with numbers

### DIFF
--- a/app/models/search/work_indexer.rb
+++ b/app/models/search/work_indexer.rb
@@ -25,8 +25,7 @@ class WorkIndexer < Indexer
             type: "text"
           },
           tag: {
-            type: "text",
-            analyzer: "simple"
+            type: "text"
           },
           authors_to_sort_on: {
             type: "keyword"


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5492

## Purpose

Use the default analyzer which doesn't discard numbers, unlike [the simple analyzer](https://www.elastic.co/guide/en/elasticsearch/reference/6.6/analysis-simple-analyzer.html).

## Testing Instructions

See issue. The work index will need to be rebuilt (there's a mapping change).