### PR TITLE
AO3-5648 Keep anchor links intact in imported works

### DIFF
--- a/app/models/story_parser.rb
+++ b/app/models/story_parser.rb
@@ -549,14 +549,15 @@ class StoryParser
     @doc = Nokogiri::HTML.parse(story.prepend("<foo/>"), nil, encoding) rescue ""
 
     # Try to convert all relative links to absolute
-    base = @doc.at_css('base') ? @doc.css('base')[0]['href'] : location.split('?').first
+    base = @doc.at_css("base") ? @doc.css("base")[0]["href"] : location.split("?").first
     if base.present?
-      @doc.css('a').each do |link|
-        next if link['href'].blank?
+      @doc.css("a").each do |link|
+        next if link["href"].blank? || link["href"].start_with?("#")
         begin
-          query = link['href'].match(/(\?.*)$/) ? $1 : ''
-          link['href'] = URI.join(base, link['href'].gsub(/(\?.*)$/, '')).to_s + query
+          query = link["href"].match(/(\?.*)$/) ? $1 : ""
+          link["href"] = URI.join(base, link["href"].gsub(/(\?.*)$/, "")).to_s + query
         rescue
+# ignored
         end
       end
     end

--- a/spec/models/story_parser_spec.rb
+++ b/spec/models/story_parser_spec.rb
@@ -156,7 +156,7 @@ describe StoryParser do
   end
 
   describe "#parse_common" do
-    it "should convert relative to absolute links" do
+    it "converts relative to absolute links" do
       # This one doesn't work because the sanitizer is converting the & to &amp;
       # ['http://foo.com/bar.html', 'search.php?here=is&a=query'] => 'http://foo.com/search.php?here=is&a=query',
       {
@@ -174,6 +174,14 @@ describe StoryParser do
         results = @sp.parse_common(story_in, location)
         expect(results[:chapter_attributes][:content]).to include(story_out)
       end
+    end
+
+    it "does NOT convert raw anchor links to absolute links" do
+      location = "http://external_site"
+      story_in = "<html><body><p><a href=#local>local href</p></body></html>"
+      result = @sp.parse_common(story_in, location)
+      expect(result[:chapter_attributes][:content]).not_to include(location)
+      expect(result[:chapter_attributes][:content]).to include("#local")
     end
   end
 


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5648

## Purpose

Preserves internal anchor links in imported documents

## Testing Instructions

When importing a work which contains links to anchors within the document (eg: `#notes`), the links should no longer be turned into absolute links to the external site url.

