### PR TITLE
AO3-5637 Check include/exclude before caching in work listings.

### DIFF
--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -99,7 +99,8 @@ class WorksController < ApplicationController
         # Note: we only cache some first initial number of pages since those are biggest bang for
         # the buck -- users don't often go past them
         if use_caching? && params[:work_search].blank? && params[:fandom_id].blank? &&
-           (params[:page].blank? || params[:page].to_i <= ArchiveConfig.PAGES_TO_CACHE)
+            params[:include_work_search].blank? && params[:exclude_work_search].blank? &&
+            (params[:page].blank? || params[:page].to_i <= ArchiveConfig.PAGES_TO_CACHE)
           # the subtag is for eg collections/COLL/tags/TAG
           subtag = @tag.present? && @tag != @owner ? @tag : nil
           user = logged_in? || logged_in_as_admin? ? 'logged_in' : 'logged_out'

--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -99,8 +99,8 @@ class WorksController < ApplicationController
         # Note: we only cache some first initial number of pages since those are biggest bang for
         # the buck -- users don't often go past them
         if use_caching? && params[:work_search].blank? && params[:fandom_id].blank? &&
-            params[:include_work_search].blank? && params[:exclude_work_search].blank? &&
-            (params[:page].blank? || params[:page].to_i <= ArchiveConfig.PAGES_TO_CACHE)
+           params[:include_work_search].blank? && params[:exclude_work_search].blank? &&
+           (params[:page].blank? || params[:page].to_i <= ArchiveConfig.PAGES_TO_CACHE)
           # the subtag is for eg collections/COLL/tags/TAG
           subtag = @tag.present? && @tag != @owner ? @tag : nil
           user = logged_in? || logged_in_as_admin? ? 'logged_in' : 'logged_out'


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5637

## Purpose

This PR modifies the code in `WorksController#index` that checks whether the list of works can be cached to ensure that it doesn't cache when either `params[:include_work_search]` or `params[:exclude_work_search]` is set.

## Testing Instructions

See JIRA.