### PR TITLE
AO3-5649 Sort authors_to_sort_on to match byline

### DIFF
--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -1170,14 +1170,13 @@ class Work < ApplicationRecord
 
   SORTED_AUTHOR_REGEX = %r{^[\+\-=_\?!'"\.\/]}
 
-  # TODO drop unused database column authors_to_sort_on
   def authors_to_sort_on
     if self.anonymous?
       "Anonymous"
     elsif self.authors.present?
-      self.authors.map(&:name).join(",  ").downcase.gsub(SORTED_AUTHOR_REGEX, '')
+      self.authors.map(&:name).sort.join(",  ").downcase.gsub(SORTED_AUTHOR_REGEX, '')
     else
-      self.pseuds.map(&:name).join(",  ").downcase.gsub(SORTED_AUTHOR_REGEX, '')
+      self.pseuds.map(&:name).sort.join(",  ").downcase.gsub(SORTED_AUTHOR_REGEX, '')
     end
   end
 

--- a/spec/models/work_spec.rb
+++ b/spec/models/work_spec.rb
@@ -306,7 +306,7 @@ describe Work do
     let(:work) { build(:work) }
 
     context "when the pseuds start with special characters" do
-      it "should remove those characters" do
+      it "removes those characters" do
         work.authors = [Pseud.new(name: "-jolyne")]
         expect(work.authors_to_sort_on).to eq "jolyne"
 
@@ -316,14 +316,14 @@ describe Work do
     end
 
     context "when the pseuds start with numbers" do
-      it "should not remove numbers" do
+      it "does not remove numbers" do
         work.authors = [Pseud.new(name: "007james")]
         expect(work.authors_to_sort_on).to eq "007james"
       end
     end
 
     context "when the work is anonymous" do
-      it "should set the author sorting to Anonymous" do
+      it "returns Anonymous" do
         work.in_anon_collection = true
         work.authors = [Pseud.new(name: "stealthy")]
         expect(work.authors_to_sort_on).to eq "Anonymous"
@@ -331,9 +331,12 @@ describe Work do
     end
 
     context "when the work has multiple pseuds" do
-      it "should combine them with commas" do
+      it "sorts them like the byline then joins them with commas" do
         work.authors = [Pseud.new(name: "diavolo"), Pseud.new(name: "doppio")]
         expect(work.authors_to_sort_on).to eq "diavolo,  doppio"
+
+        work.authors = [Pseud.new(name: "tiziano"), Pseud.new(name: "squalo")]
+        expect(work.authors_to_sort_on).to eq "squalo,  tiziano"
       end
     end
   end


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5649

## Purpose

When a work has multiple co-creators, `authors_to_sort_on` should sort them similar to how the byline does it:

https://github.com/otwcode/otwarchive/blob/d7c8504d24eb9c1d2a8a69ffe538c5781a75e5dd/app/helpers/application_helper.rb#L117-L124

## Testing Instructions

How can the Archive's QA team verify that this is working as you intended? (If you have access, please copy this into the JIRA ticket for them!)

## References

See issue. Works need to be reindexed.