### PR TITLE
AO3-5598 Set race_condition_ttl on cached AdminSetting

### DIFF
--- a/app/models/admin_setting.rb
+++ b/app/models/admin_setting.rb
@@ -30,7 +30,7 @@ class AdminSetting < ApplicationRecord
   }.freeze
 
   def self.current
-    Rails.cache.fetch("admin_settings") { AdminSetting.first } || OpenStruct.new(DEFAULT_SETTINGS)
+    Rails.cache.fetch("admin_settings", race_condition_ttl: 10.seconds) { AdminSetting.first } || OpenStruct.new(DEFAULT_SETTINGS)
   end
 
   class << self


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5598

## Purpose

> Setting `:race_condition_ttl` is very useful in situations where a cache entry is used very frequently and is under heavy load. If a cache expires and due to heavy load several different processes will try to read data natively and then they all will try to write to cache.

https://api.rubyonrails.org/v5.1.6.2/classes/ActiveSupport/Cache/Store.html#method-i-fetch

## Testing Instructions

See issue.