### PR TITLE
AO3-5653 Fix intermittent AbuseReport alternate URL test failures

### DIFF
--- a/spec/models/abuse_report_spec.rb
+++ b/spec/models/abuse_report_spec.rb
@@ -232,25 +232,24 @@ describe AbuseReport do
         expect(common_report.errors[:base]).to be_empty
       end
     end
-  end
 
-  context "alternate url" do
-    let(:no_protocol) { build(:abuse_report, url: "archiveofourown.org") }
-    it "no protocol" do
-      expect(no_protocol.save).to be_truthy
-      expect(no_protocol.errors[:url]).to be_empty
-    end
+    context "for alternate URL format" do
+      let(:report) { build(:abuse_report) }
 
-    let(:dot_com) { build(:abuse_report, url: "http://archiveofourown.com") }
-    it "dot com" do
-      expect(dot_com.save).to be_truthy
-      expect(dot_com.errors[:url]).to be_empty
-    end
+      it "no protocol" do
+        report.url = "archiveofourown.org"
+        expect(report.valid?).to be_truthy
+      end
 
-    let(:acronym) { build(:abuse_report, url: "http://ao3.org") }
-    it "acronym" do
-      expect(acronym.save).to be_truthy
-      expect(acronym.errors[:url]).to be_empty
+      it "dot com" do
+        report.url = "http://archiveofourown.com"
+        expect(report.valid?).to be_truthy
+      end
+
+      it "acronym" do
+        report.url = "http://ao3.org"
+        expect(report.valid?).to be_truthy
+      end
     end
   end
 


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5653

## Purpose

These tests need to be in the "when report is not spam" block which stubs Akismetor.

## Testing Instructions

Travis should be good.