### PR TITLE
AO3-5624 Reorder buttons on homepage unread messages

### DIFF
--- a/app/views/home/_inbox_module.html.erb
+++ b/app/views/home/_inbox_module.html.erb
@@ -19,13 +19,13 @@
             <li>
               <%= render 'inbox/reply_button', feedback_comment: inbox_comment.feedback_comment %>
             </li>
+          <% end %>
           <li id="read_comment_form_<%= inbox_comment.feedback_comment.id %>">
             <%= render 'inbox/read_form', inbox_comment: inbox_comment, current_user: current_user %>
           </li>
           <li>
             <%= render 'inbox/delete_form', inbox_comment: inbox_comment, current_user: current_user %>
           </li>
-          <% end %>
         </ul>
       </li>
     <% end %>

--- a/app/views/home/_inbox_module.html.erb
+++ b/app/views/home/_inbox_module.html.erb
@@ -22,7 +22,7 @@
           <li id="read_comment_form_<%= inbox_comment.feedback_comment.id %>">
             <%= render 'inbox/read_form', inbox_comment: inbox_comment, current_user: current_user %>
           </li>
-		      <li>
+          <li>
             <%= render 'inbox/delete_form', inbox_comment: inbox_comment, current_user: current_user %>
           </li>
           <% end %>

--- a/app/views/home/_inbox_module.html.erb
+++ b/app/views/home/_inbox_module.html.erb
@@ -11,13 +11,7 @@
       <li class="<% if inbox_comment.feedback_comment.unreviewed? %>unreviewed <% end %>unread comment group" id="feedback_comment_<%= inbox_comment.feedback_comment_id %>">
         <%= render 'inbox/inbox_comment_contents', feedback_comment: inbox_comment.feedback_comment %>
         <ul class="actions">
-          <li>
-            <%= render 'inbox/delete_form', inbox_comment: inbox_comment, current_user: current_user %>
-          </li>
-          <li id="read_comment_form_<%= inbox_comment.feedback_comment.id %>">
-            <%= render 'inbox/read_form', inbox_comment: inbox_comment, current_user: current_user %>
-          </li>
-          <% if inbox_comment.feedback_comment.unreviewed? %>
+		  <% if inbox_comment.feedback_comment.unreviewed? %>
             <li class="approve review" id="review_comment_link_<%= inbox_comment.feedback_comment.id %>">
               <%= render 'inbox/approve_button', feedback_comment: inbox_comment.feedback_comment, approved_from: "home" %>
             </li>
@@ -25,6 +19,12 @@
             <li>
               <%= render 'inbox/reply_button', feedback_comment: inbox_comment.feedback_comment %>
             </li>
+          <li id="read_comment_form_<%= inbox_comment.feedback_comment.id %>">
+            <%= render 'inbox/read_form', inbox_comment: inbox_comment, current_user: current_user %>
+          </li>
+		  <li>
+            <%= render 'inbox/delete_form', inbox_comment: inbox_comment, current_user: current_user %>
+          </li>
           <% end %>
         </ul>
       </li>

--- a/app/views/home/_inbox_module.html.erb
+++ b/app/views/home/_inbox_module.html.erb
@@ -11,7 +11,7 @@
       <li class="<% if inbox_comment.feedback_comment.unreviewed? %>unreviewed <% end %>unread comment group" id="feedback_comment_<%= inbox_comment.feedback_comment_id %>">
         <%= render 'inbox/inbox_comment_contents', feedback_comment: inbox_comment.feedback_comment %>
         <ul class="actions">
-		  <% if inbox_comment.feedback_comment.unreviewed? %>
+          <% if inbox_comment.feedback_comment.unreviewed? %>
             <li class="approve review" id="review_comment_link_<%= inbox_comment.feedback_comment.id %>">
               <%= render 'inbox/approve_button', feedback_comment: inbox_comment.feedback_comment, approved_from: "home" %>
             </li>
@@ -22,7 +22,7 @@
           <li id="read_comment_form_<%= inbox_comment.feedback_comment.id %>">
             <%= render 'inbox/read_form', inbox_comment: inbox_comment, current_user: current_user %>
           </li>
-		  <li>
+		      <li>
             <%= render 'inbox/delete_form', inbox_comment: inbox_comment, current_user: current_user %>
           </li>
           <% end %>


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5624

## Purpose

Rearranges the Reply, Mark Read, and Delete bottons on messages in the Unread Message section of the homepage from Delete, Mark Read, Reply, to Reply, Mark Read, Delete, to more closely mirror the order of these buttons on the comments section of works.

## Testing Instructions

Go to https://test.archiveofourown.org/ and log in to an account. On the homepage, scroll to the Unread Messages section. Confirm that the buttons on the message(s) are Reply, Mark Read, and Delete, in that order, and that they work as expected. 

## Credit
Nerine Luna Cyran, she/her