### PR TITLE
AO3-5180 Better word breaking for mobile headings

### DIFF
--- a/public/stylesheets/site/2.0/26-media-narrow.css
+++ b/public/stylesheets/site/2.0/26-media-narrow.css
@@ -8,6 +8,8 @@
 
 h1, h2, h3 {
     word-break: break-all;
+    /* not supported in all browsers, so we need break-all as a fallback */
+    word-break: break-word;
 }
 
 /* non-JavaScript states


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5180

## Purpose

Modifies our narrow stylesheet so it prefers _not_ to break long words when they'll fit on a single line while still allowing long words that _need_ to be broken to break wherever. (See issue for illustration.)

Replaces #3069, which I added way too many files to when attempting to merge with master. (It didn't have merge conflicts; I was just annoyed by the outdated test failure. That'll teach me.) 

I'm just going to slap the ready to merge label back on it because there were no changes.

## Testing

Refer to JIRA