### PR TITLE
AO3-5656 Fix downloading works with nil summary

### DIFF
--- a/app/models/download_writer.rb
+++ b/app/models/download_writer.rb
@@ -154,7 +154,7 @@ class DownloadWriter
       # it would otherwise be the work's rating, which is weird.
       tags:              "Fanworks, " + work.tags.pluck(:name).join(", "),
       pubdate:           work.revised_at.to_date.to_s,
-      summary:           work.summary,
+      summary:           work.summary.to_s,
       language:          work.language.short
     }
     if work.series.exists?


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5656

## Purpose

Fixes 500 error when the user tries to download the work with nil summary in the formats epub, azw3, or mobi.

## Testing Instructions

Someone with access to the test server can manually set the summary of a work to nil and then try downloading it in the formats epub, azw3, and mobi.

## Credit

lethnie, she/her
