### PR TITLE
AO3-5672 Remove hypens from nonprofit and noncommercial on homepage

### DIFF
--- a/app/views/home/_intro_module.html.erb
+++ b/app/views/home/_intro_module.html.erb
@@ -1,5 +1,5 @@
 <div class="intro module">
-  <h2 class="heading"><%= ts("A fan-created, fan-run, non-profit, non-commercial archive for transformative fanworks, like fanfiction, fanart, fan videos, and podfic") %></h2>
+  <h2 class="heading"><%= ts("A fan-created, fan-run, nonprofit, noncommercial archive for transformative fanworks, like fanfiction, fanart, fan videos, and podfic") %></h2>
   <p class="stats"><%= ts("more than %{fandom_count} fandoms | %{user_count} users | %{work_count} works", fandom_count: content_tag(:span, @fandom_count, class: "count"), user_count: content_tag(:span, @user_count, class: "count"), work_count: content_tag(:span, @work_count, class: "count")).html_safe %></p>
   <p class="parent"><%= ts("The Archive of Our Own is a project of the") %> <%= link_to ts("Organization for Transformative Works"), "http://transformativeworks.org" %>.</p>
 


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5672

## Purpose

Remove hypens from nonprofit and noncommercial on homepage

## Testing Instructions

Log out and look at the homepage.

