### PR TITLE
AO3-5233 Case insensitive admin bulk email search

### DIFF
--- a/app/controllers/admin/admin_users_controller.rb
+++ b/app/controllers/admin/admin_users_controller.rb
@@ -13,19 +13,26 @@ class Admin::AdminUsersController < ApplicationController
 
   def bulk_search
     @emails = params[:emails].split if params[:emails]
-    unless @emails.nil? || @emails.blank?
-      found_users, @not_found_emails, @duplicates = User.search_multiple_by_email(@emails)
-      
-      # Cheat to use the shared paginated view even though will_paginate doesn't support POST requests
-      @users = found_users.paginate(page: 1, per_page: found_users.size)
+    if @emails.present?
+      found_users, not_found_emails, duplicates = User.search_multiple_by_email(@emails)
+      @users = found_users.paginate(page: params[:page] || 1)
       
       if params[:download_button]
         header = [%w(Email Username)]
         found = found_users.map { |u| [u.email, u.login] }
-        not_found = @not_found_emails.map { |email| [email, ""] }
+        not_found = not_found_emails.map { |email| [email, ""] }
         send_csv_data(header + found + not_found, "bulk_user_search_#{Time.now.strftime("%Y-%m-%d-%H%M")}.csv")
         flash.now[:notice] = ts("Downloaded CSV")
       end
+      @results = {
+        total: @emails.size,
+        searched: found_users.size + not_found_emails.size,
+        found_users: found_users,
+        not_found_emails: not_found_emails,
+        duplicates: duplicates
+      }
+    else
+      @results = {}
     end
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -299,10 +299,10 @@ class User < ApplicationRecord
     users = User.where(email: unique_emails)
     found_emails = users.map(&:email).map(&:downcase)
     # Remove found users from the total list of unique emails and count duplicates
-    not_found = unique_emails - found_emails
+    not_found_emails = unique_emails - found_emails
     num_duplicates = emails.size - unique_emails.size
-    
-    [users, not_found, num_duplicates]
+
+    [users, not_found_emails, num_duplicates]
   end
 
   ### AUTHENTICATION AND PASSWORDS

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -292,10 +292,17 @@ class User < ApplicationRecord
   private_class_method :filter_by_name_or_email
 
   def self.search_multiple_by_email(emails = [])
-    users = User.where(email: emails)
-    found_emails = users.map(&:email)
-    not_found = emails - found_emails
-    [users, not_found]
+    # Normalise and dedupe emails
+    all_emails = emails.map(&:downcase)
+    unique_emails = all_emails.uniq
+    # Find users and their email addresses
+    users = User.where(email: unique_emails)
+    found_emails = users.map(&:email).map(&:downcase)
+    # Remove found users from the total list of unique emails and count duplicates
+    not_found = unique_emails - found_emails
+    num_duplicates = emails.size - unique_emails.size
+    
+    [users, not_found, num_duplicates]
   end
 
   ### AUTHENTICATION AND PASSWORDS

--- a/app/views/admin/admin_users/bulk_search.html.erb
+++ b/app/views/admin/admin_users/bulk_search.html.erb
@@ -30,12 +30,13 @@
     </fieldset>
   <% end %>
 
-  <% if @not_found || @users %>
-    <p><%= ts("#{@emails.size} emails searched. #{@emails.size - @not_found.size} found. #{@not_found.size} not found.") %></p>
+  <% if @not_found_emails || @users %>
+    <p><%= ts("#{pluralize(@emails.size, "email")} entered. #{@users.size + @not_found_emails.size } searched. " + 
+              "#{@users.size} found. #{@not_found_emails.size} not found. #{pluralize(@duplicates, "duplicate")}.") %></p>
 
-    <% unless @not_found.empty? %>
+    <% unless @not_found_emails.empty? %>
       <h3 class="heading"><%= ts("Not found") %></h3>
-      <p><%= @not_found.join(",") %></p>
+      <p><%= @not_found_emails.join(", ") %></p>
     <% end %>
 
     <% if @users %>

--- a/app/views/admin/admin_users/bulk_search.html.erb
+++ b/app/views/admin/admin_users/bulk_search.html.erb
@@ -30,13 +30,13 @@
     </fieldset>
   <% end %>
 
-  <% if @not_found_emails || @users %>
-    <p><%= ts("#{pluralize(@emails.size, "email")} entered. #{@users.size + @not_found_emails.size } searched. " + 
-              "#{@users.size} found. #{@not_found_emails.size} not found. #{pluralize(@duplicates, "duplicate")}.") %></p>
+  <% if @results[:not_found_emails] || @results[:users] %>
+    <p><%= ts("#{pluralize(@results[:total], "email")} entered. #{@results[:searched]} searched. " + 
+              "#{@results[:found_users].size} found. #{@results[:not_found_emails].size} not found. #{pluralize(@results[:duplicates], "duplicate")}.") %></p>
 
-    <% unless @not_found_emails.empty? %>
+    <% if @results[:not_found_emails] %>
       <h3 class="heading"><%= ts("Not found") %></h3>
-      <p><%= @not_found_emails.join(", ") %></p>
+      <p><%= @results[:not_found_emails].join(", ") %></p>
     <% end %>
 
     <% if @users %>

--- a/features/admins/users/admin_find_users.feature
+++ b/features/admins/users/admin_find_users.feature
@@ -72,17 +72,19 @@ Feature: Admin Find Users page
       And I should see "userA"
       But I should not see "userCB"
 
-  Scenario: The Bulk Email Search page should list emails found and not found
+  Scenario: The Bulk Email Search page should list emails found, not found and duplicates
     When I go to the Bulk Email Search page
       And I fill in "Email addresses *" with
       """
         b@bo3.org
         a@ao3.org
         c@co3.org
+        C@CO3.org
       """
       And I press "Find"
     Then I should see "2 found"
       And I should see "1 not found"
+      And I should see "1 duplicate"
 
   Scenario: The Bulk Email Search page should find an exact match
     When I go to the Bulk Email Search page

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -112,4 +112,33 @@ describe User, :ready do
       end
     end
   end
+
+  describe "search_multiple_by_email" do
+    let(:user_bundle) { create_list(:user, 5) }
+
+    it "removes exact duplicates from the list" do
+      emails = user_bundle.map(&:email) << user_bundle.first.email
+      expect(emails.size).to be > user_bundle.size
+      expect(User.search_multiple_by_email(emails).first.size).to eq(emails.size - 1)
+    end
+
+    it "ignores case differences" do
+      emails = user_bundle.map(&:email) << user_bundle.first.email.upcase
+      expect(emails.size).to be > user_bundle.size
+      expect(User.search_multiple_by_email(emails).first.size).to eq(emails.size - 1)
+    end
+
+    it "returns found users, not found emails and the number of duplicates" do
+      more_emails = [ user_bundle.second.email, user_bundle.first.email.upcase, "unknown@ao3.org", "UnKnown@AO3.org", "nobody@example.com"]
+      emails = user_bundle.map(&:email) + more_emails
+
+      found, not_found, duplicates = User.search_multiple_by_email(emails)
+
+      expect(not_found).to eq([ "unknown@ao3.org", "nobody@example.com" ])
+      expect(found.size).to eq(emails.map(&:downcase).uniq.size - not_found.size)
+      expect(duplicates).to eq(3)
+    end
+  end
+
+
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -129,16 +129,14 @@ describe User, :ready do
     end
 
     it "returns found users, not found emails and the number of duplicates" do
-      more_emails = [ user_bundle.second.email, user_bundle.first.email.upcase, "unknown@ao3.org", "UnKnown@AO3.org", "nobody@example.com"]
+      more_emails = [user_bundle.second.email, user_bundle.first.email.upcase, "unknown@ao3.org", "UnKnown@AO3.org", "nobody@example.com"]
       emails = user_bundle.map(&:email) + more_emails
 
       found, not_found, duplicates = User.search_multiple_by_email(emails)
 
-      expect(not_found).to eq([ "unknown@ao3.org", "nobody@example.com" ])
+      expect(not_found).to eq(["unknown@ao3.org", "nobody@example.com"])
       expect(found.size).to eq(emails.map(&:downcase).uniq.size - not_found.size)
       expect(duplicates).to eq(3)
     end
   end
-
-
 end


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5233

## Purpose

This improves the bulk email search in the admin section so it looks for case insensitive emails and reports on the number of duplicates to make it easier to know how many matches there were.

## Testing Instructions

This can be tested through the Admin interface. See Jira for the steps to reproduce the original bug.
