### PR TITLE
AO3-2452 Fix CommonTagging/MetaTagging deletion tasks and add tests.

### DIFF
--- a/app/models/common_tagging.rb
+++ b/app/models/common_tagging.rb
@@ -62,7 +62,7 @@ class CommonTagging < ApplicationRecord
 
   # If a tag's parent changes, reindex immediately to update unwrangled bins.
   def update_search
-    common_tag.reindex_document
+    common_tag&.reindex_document
   end
 
   # Go through all CommonTaggings and destroy the invalid ones.

--- a/app/models/meta_tagging.rb
+++ b/app/models/meta_tagging.rb
@@ -64,7 +64,7 @@ class MetaTagging < ApplicationRecord
   end
 
   def expire_caching
-    self.meta_tag.update_works_index_timestamp!
+    self.meta_tag&.update_works_index_timestamp!
   end
 
   # Go through all MetaTaggings and destroy the invalid ones.
@@ -75,10 +75,18 @@ class MetaTagging < ApplicationRecord
       # Let callers do something on each iteration.
       yield mt, valid if block_given?
 
-      # We use this method instead of mt.destroy because we want to trigger the
-      # before_remove callbacks on mt.sub_tag, thus ensuring that we clean up
-      # the filter_taggings associated with this MetaTagging.
-      mt.sub_tag.meta_tags.delete(mt.meta_tag) unless valid
+      next if valid
+
+      if mt.sub_tag && mt.meta_tag
+        # We use this method instead of mt.destroy because we want to trigger the
+        # before_remove callbacks on mt.sub_tag, thus ensuring that we clean up
+        # the filter_taggings associated with this MetaTagging.
+        mt.sub_tag.meta_tags.delete(mt.meta_tag)
+      else
+        # But in this case, one of the two tags is missing, so we can only
+        # properly delete the meta tagging by calling mt.destroy:
+        mt.destroy
+      end
     end
   end
 end

--- a/spec/miscellaneous/lib/tasks/tag_tasks.rake_spec.rb
+++ b/spec/miscellaneous/lib/tasks/tag_tasks.rake_spec.rb
@@ -1,0 +1,113 @@
+require "spec_helper"
+
+describe "rake Tag:destroy_invalid_common_taggings" do
+  it "deletes CommonTaggings with a missing child" do
+    parent = create(:canonical_fandom)
+    child = create(:character)
+    common_tagging = CommonTagging.create(filterable: parent, common_tag: child)
+    child.delete
+
+    expect { subject.invoke }.not_to raise_exception
+    expect { common_tagging.reload }.to raise_exception(ActiveRecord::RecordNotFound)
+  end
+
+  it "deletes CommonTaggings with a missing parent" do
+    parent = create(:canonical_fandom)
+    child = create(:character)
+    common_tagging = CommonTagging.create(filterable: parent, common_tag: child)
+    parent.delete
+
+    expect { subject.invoke }.not_to raise_exception
+    expect { common_tagging.reload }.to raise_exception(ActiveRecord::RecordNotFound)
+  end
+
+  it "deletes CommonTaggings with a non-canonical parent" do
+    parent = create(:fandom)
+    child = create(:character)
+    common_tagging = CommonTagging.new(filterable: parent, common_tag: child)
+    common_tagging.save(validate: false)
+
+    expect { subject.invoke }.not_to raise_exception
+    expect { common_tagging.reload }.to raise_exception(ActiveRecord::RecordNotFound)
+  end
+
+  it "deletes CommonTaggings with mismatched types" do
+    parent = create(:canonical_character)
+    child = create(:fandom)
+    common_tagging = CommonTagging.new(filterable: parent, common_tag: child)
+    common_tagging.save(validate: false)
+
+    expect { subject.invoke }.not_to raise_exception
+    expect { common_tagging.reload }.to raise_exception(ActiveRecord::RecordNotFound)
+  end
+
+  it "doesn't delete valid CommonTaggings" do
+    parent = create(:canonical_fandom)
+    child = create(:character)
+    common_tagging = CommonTagging.create(filterable: parent, common_tag: child)
+
+    expect { subject.invoke }.not_to raise_exception
+    expect { common_tagging.reload }.not_to raise_exception
+  end
+end
+
+describe "rake Tag:destroy_invalid_meta_taggings" do
+  it "deletes MetaTaggings with a missing child" do
+    parent = create(:canonical_fandom)
+    child = create(:canonical_fandom)
+    meta_tagging = MetaTagging.create(meta_tag: parent, sub_tag: child)
+    child.delete
+
+    expect { subject.invoke }.not_to raise_exception
+    expect { meta_tagging.reload }.to raise_exception(ActiveRecord::RecordNotFound)
+  end
+
+  it "deletes MetaTaggings with a missing parent" do
+    parent = create(:canonical_fandom)
+    child = create(:canonical_fandom)
+    meta_tagging = MetaTagging.create(meta_tag: parent, sub_tag: child)
+    parent.delete
+
+    expect { subject.invoke }.not_to raise_exception
+    expect { meta_tagging.reload }.to raise_exception(ActiveRecord::RecordNotFound)
+  end
+
+  it "deletes MetaTaggings with a non-canonical child" do
+    parent = create(:canonical_fandom)
+    child = create(:fandom)
+    meta_tagging = MetaTagging.new(meta_tag: parent, sub_tag: child)
+    meta_tagging.save(validate: false)
+
+    expect { subject.invoke }.not_to raise_exception
+    expect { meta_tagging.reload }.to raise_exception(ActiveRecord::RecordNotFound)
+  end
+
+  it "deletes MetaTaggings with a non-canonical parent" do
+    parent = create(:fandom)
+    child = create(:canonical_fandom)
+    meta_tagging = MetaTagging.new(meta_tag: parent, sub_tag: child)
+    meta_tagging.save(validate: false)
+
+    expect { subject.invoke }.not_to raise_exception
+    expect { meta_tagging.reload }.to raise_exception(ActiveRecord::RecordNotFound)
+  end
+
+  it "deletes MetaTaggings with mismatched types" do
+    parent = create(:canonical_character)
+    child = create(:canonical_fandom)
+    meta_tagging = MetaTagging.new(meta_tag: parent, sub_tag: child)
+    meta_tagging.save(validate: false)
+
+    expect { subject.invoke }.not_to raise_exception
+    expect { meta_tagging.reload }.to raise_exception(ActiveRecord::RecordNotFound)
+  end
+
+  it "doesn't delete valid MetaTaggings" do
+    parent = create(:canonical_fandom)
+    child = create(:canonical_fandom)
+    meta_tagging = MetaTagging.create(meta_tag: parent, sub_tag: child)
+
+    expect { subject.invoke }.not_to raise_exception
+    expect { meta_tagging.reload }.not_to raise_exception
+  end
+end


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-2452

## Purpose

It adds tests for the two deletion tasks, and fixes up some issues that arose when deleting MetaTaggings/CommonTaggings that were missing one or more tags.