### PR TITLE
AO3-5694 Don't load fandoms list on orphan_account user dashboard

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -285,18 +285,18 @@ class UsersController < ApplicationController
                  []
                else
                  Fandom.select('tags.*, count(tags.id) as work_count').
-                        joins(:direct_filter_taggings).
-                        joins("INNER JOIN works
-                               ON filter_taggings.filterable_id = works.id
-                               AND filter_taggings.filterable_type = 'Work'").
-                        group('tags.id').
-                        merge(Work.send(visible_method).revealed.non_anon).
-                        merge(Work.joins("INNER JOIN creatorships
-                                          ON creatorships.creation_id = works.id
-                                          AND creatorships.creation_type = 'Work'
-                                          INNER JOIN pseuds ON creatorships.pseud_id = pseuds.id
-                                          INNER JOIN users ON pseuds.user_id = users.id").
-                                  where('users.id = ?', @user.id))
+                   joins(:direct_filter_taggings).
+                   joins("INNER JOIN works
+                     ON filter_taggings.filterable_id = works.id
+                     AND filter_taggings.filterable_type = 'Work'").
+                   group('tags.id').
+                   merge(Work.send(visible_method).revealed.non_anon).
+                   merge(Work.joins("INNER JOIN creatorships
+                     ON creatorships.creation_id = works.id
+                     AND creatorships.creation_type = 'Work'
+                     INNER JOIN pseuds ON creatorships.pseud_id = pseuds.id
+                     INNER JOIN users ON pseuds.user_id = users.id").
+                   where('users.id = ?', @user.id))
                end
     visible_works = @user.works.send(visible_method)
     visible_series = @user.series.send(visible_method)

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -281,14 +281,23 @@ class UsersController < ApplicationController
     visible_method = current_user.nil? && current_admin.nil? ? :visible_to_all : :visible_to_registered_user
 
     # hahaha omg so ugly BUT IT WORKS :P
-    @fandoms = Fandom.select('tags.*, count(tags.id) as work_count')
-                     .joins(:direct_filter_taggings)
-                     .joins("INNER JOIN works ON filter_taggings.filterable_id = works.id AND filter_taggings.filterable_type = 'Work'")
-                     .group('tags.id')
-                     .merge(Work.send(visible_method).revealed.non_anon)
-                     .merge(Work.joins("INNER JOIN creatorships ON creatorships.creation_id = works.id AND creatorships.creation_type = 'Work'
-  INNER JOIN pseuds ON creatorships.pseud_id = pseuds.id
-  INNER JOIN users ON pseuds.user_id = users.id").where('users.id = ?', @user.id))
+    @fandoms = if @user == User.orphan_account
+                 []
+               else
+                 Fandom.select('tags.*, count(tags.id) as work_count').
+                        joins(:direct_filter_taggings).
+                        joins("INNER JOIN works
+                               ON filter_taggings.filterable_id = works.id
+                               AND filter_taggings.filterable_type = 'Work'").
+                        group('tags.id').
+                        merge(Work.send(visible_method).revealed.non_anon).
+                        merge(Work.joins("INNER JOIN creatorships
+                                          ON creatorships.creation_id = works.id
+                                          AND creatorships.creation_type = 'Work'
+                                          INNER JOIN pseuds ON creatorships.pseud_id = pseuds.id
+                                          INNER JOIN users ON pseuds.user_id = users.id").
+                                  where('users.id = ?', @user.id))
+               end
     visible_works = @user.works.send(visible_method)
     visible_series = @user.series.send(visible_method)
     visible_bookmarks = @user.bookmarks.send(visible_method)


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5694

## Purpose

Makes `@fandoms = []` for the orphan_account so we can see if loading that list is the reason the orphan_account's dashboard has stopped loading. 

This is a temporary change (famous last words!) to help us diagnose the actual problem. If the orphan_account dashboard starts loading once this is deployed, we should come up with a new way of counting fandoms. If it doesn't start loading, we should remove this code and keep looking for the problem.

## Testing Instructions

Refer to Jira.
