### PR TITLE
AO3-5697 Add unique index to meta_taggings table.

### DIFF
--- a/db/migrate/20190611212339_add_unique_index_to_meta_taggings.rb
+++ b/db/migrate/20190611212339_add_unique_index_to_meta_taggings.rb
@@ -1,0 +1,6 @@
+class AddUniqueIndexToMetaTaggings < ActiveRecord::Migration[5.1]
+  def change
+    add_index :meta_taggings, [:meta_tag_id, :sub_tag_id], unique: true
+    remove_index :meta_taggings, [:meta_tag_id]
+  end
+end


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5697

## Purpose

This PR replaces the index on `meta_tag_id` for the `meta_taggings` table with a unique index on `(meta_tag_id, sub_tag_id)`.

For `pt-online-schema-change`, I believe the argument to `--alter` corresponding to this migration is:
```
  ADD UNIQUE INDEX
    index_meta_taggings_on_meta_tag_id_and_sub_tag_id
    (meta_tag_id, sub_tag_id),
  DROP INDEX
    index_meta_taggings_on_meta_tag_id
```
The argument `--nocheck-unique-key-change` may also be necessary, since `pt-online-schema-change` tries to ensure that data will not be lost when adding a new unique index.