### PR TITLE
AO3-5099 & AO3-5126 Separate "Name or email" query into two fields, and fix the results count.

### DIFF
--- a/app/controllers/admin/admin_users_controller.rb
+++ b/app/controllers/admin/admin_users_controller.rb
@@ -6,9 +6,10 @@ class Admin::AdminUsersController < ApplicationController
   def index
     @role_values = @roles.map{ |role| [role.name.humanize.titlecase, role.name] }
     @role = Role.find_by(name: params[:role]) if params[:role]
-    @users = User.search_by_role(@role,
-                                 params[:query],
-                                 inactive: params[:inactive], exact: params[:exact], page: params[:page])
+    @users = User.search_by_role(
+      @role, params[:name], params[:email],
+      inactive: params[:inactive], exact: params[:exact], page: params[:page]
+    )
   end
 
   def bulk_search

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -268,7 +268,7 @@ class User < ApplicationRecord
   # Options: inactive, page, exact
   def self.search_by_role(role, name, email, options = {})
     return if role.blank? && name.blank? && email.blank?
-    users = User.select("DISTINCT users.*").order(:login)
+    users = User.distinct.order(:login)
     if options[:inactive]
       users = users.where("confirmed_at IS NULL")
     end

--- a/app/views/admin/admin_users/index.html.erb
+++ b/app/views/admin/admin_users/index.html.erb
@@ -5,10 +5,12 @@
 
   <!--main content-->
   <%= form_tag url_for(controller: "admin/admin_users", action: "index"), method: :get, class: "search", role: "search" do %>
-    <p class="note"><%= ts("Search for a user by username, pseud or email, or search by role.") %></p>
+    <p class="note"><%= ts("Search for a user by username or pseud, by email, or by role.") %></p>
     <dl>
-      <dt><%= label_tag "query", ts("Name or email") %></dt>
-      <dd><%= text_field_tag "query", params[:query] %></dd>
+      <dt><%= label_tag "name", ts("Name") %></dt>
+      <dd><%= text_field_tag "name", params[:name] %></dd>
+      <dt><%= label_tag "email", ts("Email") %></dt>
+      <dd><%= text_field_tag "email", params[:email] %></dd>
       <dt><%= label_tag "role", ts("Role") %></dt>
       <dd><%= select_tag "role", "<option></option>".html_safe + options_for_select(@role_values, @role.try(:name)) %></dd>
       <dt><%= label_tag "status", ts("Status") %></dt>

--- a/app/views/admin/admin_users/index.html.erb
+++ b/app/views/admin/admin_users/index.html.erb
@@ -18,7 +18,7 @@
         <%= check_box_tag "inactive", "1", params[:inactive].present? %>
         <%= label_tag "inactive", ts("Not yet activated") %>
       </dd>
-      <dt><%= label_tag "settings", ts("Search Settings") %></dt>
+      <dt><%= label_tag "settings", ts("Search settings") %></dt>
       <dd>
         <%= check_box_tag "exact", "1", params[:exact].present? %>
         <%= label_tag "exact", ts("Exact match only") %>

--- a/features/admins/users/admin_abuse_users.feature
+++ b/features/admins/users/admin_abuse_users.feature
@@ -51,7 +51,7 @@ Feature: Admin Abuse actions
       And I should see "Suspended Permanently"
       And I should see "To the New Zealand penal colony with you."
     When I follow "Manage Users"
-      And I fill in "query" with "mrparis"
+      And I fill in "Name" with "mrparis"
       And I press "Find"
     Then I should see "1 user found"
     When I follow "Details"

--- a/features/admins/users/admin_find_users.feature
+++ b/features/admins/users/admin_find_users.feature
@@ -14,7 +14,7 @@ Feature: Admin Find Users page
     Then I should see "Find Users"
 
   Scenario: The Find Users page should perform a partial match on name
-    When I fill in "query" with "user"
+    When I fill in "Name" with "user"
       And I submit
     Then I should see "userA"
       And I should see "userB"
@@ -22,16 +22,16 @@ Feature: Admin Find Users page
 
   Scenario: The Find Users page should perform a exact match on name if exact is checked
     When I check "exact"
-      And I fill in "query" with "user"
+      And I fill in "Name" with "user"
       And I submit
     Then I should see "0 users found"
-    When I fill in "query" with "userA"
+    When I fill in "Name" with "userA"
       And I submit
     Then the field labeled "user_email" should contain "a@ao3.org"
       But I should not see "UserB"
 
   Scenario: The Find Users page should perform a partial match by email
-    When I fill in "query" with "bo3"
+    When I fill in "Email" with "bo3"
       And I submit
     Then I should see "userB"
       And I should see "userCB"
@@ -39,10 +39,10 @@ Feature: Admin Find Users page
 
   Scenario: The Find Users page should perform a exact match on email if exact is checked
     When I check "exact"
-      And I fill in "query" with "not_email"
+      And I fill in "Email" with "not_email"
       And I submit
     Then I should see "0 users found"
-    When I fill in "query" with "a@ao3.org"
+    When I fill in "Email" with "a@ao3.org"
       And I submit
     Then I should see "userA"
       But I should not see "UserB"
@@ -55,7 +55,7 @@ Feature: Admin Find Users page
       And I should not see "userCB"
 
   Scenario: The Find Users should display an appropriate message if no users are found
-    When I fill in "query" with "co3"
+    When I fill in "Name" with "co3"
       And I submit
     Then I should see "0 users found"
 

--- a/features/admins/users/admin_fnok.feature
+++ b/features/admins/users/admin_fnok.feature
@@ -17,7 +17,7 @@ Feature: Admin Fannish Next Of Kind actions
     Then I should see "Fannish next of kin was updated."
 
     When I go to the manage users page
-      And I fill in "Name or email" with "harrykim"
+      And I fill in "Name" with "harrykim"
       And I press "Find"
     Then I should see "libby"
 
@@ -77,7 +77,7 @@ Feature: Admin Fannish Next Of Kind actions
     Then I should get confirmation that I changed my username
     When I am logged in as an admin
       And I go to the manage users page
-      And I fill in "Name or email" with "harrykim"
+      And I fill in "Name" with "harrykim"
       And I press "Find"
     Then I should see "newlibby"
 
@@ -91,7 +91,7 @@ Feature: Admin Fannish Next Of Kind actions
     Then I should get confirmation that I changed my username
     When I am logged in as an admin
       And I go to the manage users page
-      And I fill in "Name or email" with "harrykim2"
+      And I fill in "Name" with "harrykim2"
       And I press "Find"
     Then I should see "libby"
 

--- a/features/admins/users/admin_manage_users.feature
+++ b/features/admins/users/admin_manage_users.feature
@@ -10,7 +10,7 @@ Feature: Admin Actions to manage users
       | dizmo | wrangulator |
     And I have loaded the "roles" fixture
     When I am logged in as an admin
-    And I fill in "query" with "dizmo"
+    And I fill in "Name" with "dizmo"
     And I press "Find"
     Then I should see "dizmo" within "#admin_users_table"
 

--- a/features/step_definitions/archivist_steps.rb
+++ b/features/step_definitions/archivist_steps.rb
@@ -19,10 +19,11 @@ end
 ### WHEN
 
 When /^I make "([^\"]*)" an archivist$/ do |name|
-  step(%{I fill in "query" with "#{name}"})
-    step(%{I press "Find"})
+  step(%{I fill in "Name" with "#{name}"})
+  step(%{I check "Exact match only"})
+  step(%{I press "Find"})
   step(%{I check "user_roles_4"})
-    step(%{I press "Update"})
+  step(%{I press "Update"})
 end
 
 When /^I make "([^\"]*)" an Open Doors committee member$/ do |name|

--- a/features/tags_and_wrangling/tag_wrangling.feature
+++ b/features/tags_and_wrangling/tag_wrangling.feature
@@ -7,7 +7,7 @@ Feature: Tag wrangling
     When I am logged in as "dizmo"
     Then I should not see "Tag Wrangling" within "#header"
     When I am logged in as an admin
-      And I fill in "query" with "dizmo"
+      And I fill in "Name" with "dizmo"
       And I press "Find"
     Then I should see "dizmo" within "#admin_users_table"    
     # admin making user tag wrangler

--- a/features/tags_and_wrangling/tag_wrangling_admin.feature
+++ b/features/tags_and_wrangling/tag_wrangling_admin.feature
@@ -21,7 +21,7 @@ Feature: Tag wrangling
     Given the tag wrangler "tangler" with password "wr@ngl3r" is wrangler of "Testing"
     When I am logged in as an admin
       And I am on the manage users page
-    When I fill in "Name or email" with "tangler"
+    When I fill in "Name" with "tangler"
       And I press "Find"
     Then I should see "tangler" within "#admin_users_table"
     When I uncheck the "Tag Wrangler" role checkbox


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5099
https://otwarchive.atlassian.net/browse/AO3-5126

## Purpose

I updated the Admin Users page to split the "Name or email" query into separate "Name" and "Email" queries. I also changed the capitalization of "Search settings" to match the screencap included in the JIRA issue, and changed the text on the page to better reflect the new search options.

I also changed `User.search_by_role` so that it uses `distinct` instead of `select("DISTINCT(users.*)")`, which could produce incorrect result counts.