### PR TITLE
AO3-5184 Make Advanced section of skins toggleable again in Safari

### DIFF
--- a/public/stylesheets/site/2.0/08-actions.css
+++ b/public/stylesheets/site/2.0/08-actions.css
@@ -150,6 +150,10 @@ ul#skiplinks, .landmark, .landmark a, .index .heading.landmark {
 
 /* CONTEXTS */
 
+legend .action:link {
+  position: static;
+}
+
 .heading .actions, .heading .action, .heading span.actions {
   height: auto;
   font: 100 75%/1.286 'Lucida Grande', 'Lucida Sans Unicode', 'GNU Unifont', Verdana, Helvetica, sans-serif;


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5184

## Purpose

In desktop Safari and on iOS browsers, you can't open the Advanced section of the skins edit page. This fixes that.

## Testing Instructions

Refer to Jira.
