### PR TITLE
AO3-5097 Don't display update success message when FNOK is unchanged

### DIFF
--- a/app/models/user_manager.rb
+++ b/app/models/user_manager.rb
@@ -96,6 +96,9 @@ class UserManager
 
   def save_next_of_kin
     return true if user.fannish_next_of_kin.nil? && kin_name.blank? && kin_email.blank?
+    same_kin_user = User.find_by(login: kin_name)&.id == user.fannish_next_of_kin&.kin_id
+    same_kin_email = user.fannish_next_of_kin&.kin_email == kin_email
+    return true if same_kin_user && same_kin_email
     if FannishNextOfKin.update_for_user(user, kin_name, kin_email)
       successes << "Fannish next of kin was updated."
     else


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5097

## Purpose

Stops the "Fannish next of kin was updated" success message from being added when a user has a FNOK but the FNOK is not changed.

## Testing Instructions

Refer to issue