### PR TITLE
AO3-4571 Fix challenge assignment equality check.

### DIFF
--- a/app/models/challenge_assignment.rb
+++ b/app/models/challenge_assignment.rb
@@ -166,7 +166,6 @@ class ChallengeAssignment < ApplicationRecord
   end
   alias_method :defaulted?, :defaulted
 
-  include Comparable
   # sort in order that puts assignments with no request ahead of assignments with no offer,
   # ahead of assignments with both request and offer, and within each group sorts by
   # request byline and then offer byline.

--- a/app/models/challenge_assignment.rb
+++ b/app/models/challenge_assignment.rb
@@ -166,19 +166,6 @@ class ChallengeAssignment < ApplicationRecord
   end
   alias_method :defaulted?, :defaulted
 
-  # sort in order that puts assignments with no request ahead of assignments with no offer,
-  # ahead of assignments with both request and offer, and within each group sorts by
-  # request byline and then offer byline.
-  def <=>(other)
-    return -1 if self.request_signup.nil? && other.request_signup
-    return 1 if other.request_signup.nil? && self.request_signup
-    return -1 if self.offer_signup.nil? && other.offer_signup
-    return 1 if other.offer_signup.nil? && self.offer_signup
-    cmp = self.request_byline.downcase <=> other.request_byline.downcase
-    return cmp if cmp != 0
-    self.offer_byline.downcase <=> other.offer_byline.downcase
-  end
-
   def offer_signup_pseud=(pseud_byline)
     if pseud_byline.blank?
       self.offer_signup = nil

--- a/features/gift_exchanges/challenge_giftexchange.feature
+++ b/features/gift_exchanges/challenge_giftexchange.feature
@@ -294,11 +294,8 @@ Feature: Gift Exchange Challenge
       And everyone has their assignments for "Second Challenge"
     When I am logged in as "myname1"
       And I start to fulfill my assignment
-      And "AO3-4571" is fixed
-    # "I start to fulfill" will use the first Fulfill option on the page
-    # which will be for the oldest assignment
-    # Then the "Awesome Gift Exchange (myname3)" checkbox should be checked
-    #   And the "Second Challenge (myname3)" checkbox should not be checked
+    Then the "Awesome Gift Exchange (myname3)" checkbox should be checked
+      And the "Second Challenge (myname3)" checkbox should not be checked
 
   Scenario: User has more than one pseud on signup form
     Given "myname1" has the pseud "othername"


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-4571

## Purpose

When the work form is trying to figure out which assignment checkboxes ought to be checked by default, it checks whether each of the user's assignments is included in the work's assignments. This inclusion check calls the `ChallengeAssignment` class's equality check.

Because the `ChallengeAssignment` class includes `Comparable` and defines a comparison function `<=>`, the comparison function overrides the default rails equality check.  But the `<=>` function only checks the offering/recipients pseuds, not the assignment ID or the challenge name. This means that if a user has the same assigned recipient in multiple challenges, all of the assignments are treated as "equivalent" by the work form.

This PR removes the unnecessary comparison function, so that the work form will use rails' built-in equality check (which relies on IDs) to determine which assignments to check by default.

## Testing Instructions

See JIRA.