### PR TITLE
AO3-5549 Handle deleted users in spam alert.

### DIFF
--- a/app/mailers/admin_mailer.rb
+++ b/app/mailers/admin_mailer.rb
@@ -1,4 +1,4 @@
-class AdminMailer < BulletproofMailer::Base
+class AdminMailer < ActionMailer::Base
   include Resque::Mailer # see README in this directory
 
   layout 'mailer'
@@ -48,7 +48,7 @@ class AdminMailer < BulletproofMailer::Base
   # Sends a spam report
   def send_spam_alert(spam)
     @users = User.where(id: spam.keys).to_a
-    abort_delivery if @users.empty?
+    return if @users.empty?
 
     # Make sure that the keys of the spam array are integers, so that we can do
     # an easy look-up with user IDs.

--- a/app/mailers/admin_mailer.rb
+++ b/app/mailers/admin_mailer.rb
@@ -1,4 +1,4 @@
-class AdminMailer < ActionMailer::Base
+class AdminMailer < BulletproofMailer::Base
   include Resque::Mailer # see README in this directory
 
   layout 'mailer'
@@ -47,7 +47,17 @@ class AdminMailer < ActionMailer::Base
 
   # Sends a spam report
   def send_spam_alert(spam)
-    @spam = spam
+    @users = User.where(id: spam.keys).to_a
+    abort_delivery if @users.empty?
+
+    # Make sure that the keys of the spam array are integers, so that we can do
+    # an easy look-up with user IDs.
+    @spam = spam.transform_keys(&:to_i)
+
+    # The users might have been retrieved from the database out of order, so
+    # re-sort them by their score.
+    @users.sort_by! { |user| @spam[user.id]["score"] }.reverse!
+
     mail(
       to: ArchiveConfig.SPAM_ALERT_ADDRESS,
       subject: "[#{ArchiveConfig.APP_SHORT_NAME}] Potential spam alert"

--- a/app/views/admin_mailer/send_spam_alert.html.erb
+++ b/app/views/admin_mailer/send_spam_alert.html.erb
@@ -1,8 +1,8 @@
 <% content_for :message do %>
 
   <p>The following accounts have a suspicious level of traffic:</p>
-  <% @spam.each_pair do |user_id, info| %>
-    <% user = User.find(user_id) %>
+  <% @users.each do |user| %>
+    <% info = @spam[user.id] %>
     User <%= style_link(user.login, user_works_url(user)) %> has a score of 
     <%= info["score"] %>
     <ul>

--- a/app/views/admin_mailer/send_spam_alert.text.erb
+++ b/app/views/admin_mailer/send_spam_alert.text.erb
@@ -2,8 +2,8 @@
 
   The following accounts have a suspicious level of traffic:
 
-  <% @spam.each_pair do |user_id, info| %>
-    <% user = User.find(user_id) %>
+  <% @users.each do |user| %>
+    <% info = @spam[user.id] %>
     User <%= user.login %> (<%= user_works_url(user) %>) has a score of <%= info["score"] %>
 
     <% Work.where(id: info["work_ids"]).each do |work| %>

--- a/spec/miscellaneous/mailers/admin_mailer_spec.rb
+++ b/spec/miscellaneous/mailers/admin_mailer_spec.rb
@@ -1,0 +1,100 @@
+require 'spec_helper'
+
+describe AdminMailer, type: :mailer do
+  describe "send_spam_email" do
+    let(:spam_user) { create(:user) }
+
+    let(:spam1) { create(:posted_work, spam: true, title: "First Spam",
+                         authors: [spam_user.default_pseud]) }
+    let(:spam2) { create(:posted_work, spam: true, title: "Second Spam",
+                         authors: [spam_user.default_pseud]) }
+    let(:spam3) { create(:posted_work, spam: true, title: "Third Spam",
+                         authors: [spam_user.default_pseud]) }
+
+    let(:other_user) { create(:user) }
+    let(:other_spam) { create(:posted_work, spam: true, title: "Mistaken Spam",
+                              authors: [other_user.default_pseud]) }
+
+    let!(:report) do
+      {
+        spam_user.id => { "score" => 13, "work_ids" => [spam1.id, spam2.id, spam3.id] },
+        other_user.id => { "score" => 5, "work_ids" => [other_spam.id] }
+      }
+    end
+
+    let(:mail) { AdminMailer.send_spam_alert(report) }
+
+    context "when the report is valid" do
+      it "has the correct subject" do
+        expect(mail).to have_subject "[#{ArchiveConfig.APP_SHORT_NAME}] Potential spam alert"
+      end
+
+      it "delivers to the correct address" do
+        expect(mail).to deliver_to ArchiveConfig.SPAM_ALERT_ADDRESS
+      end
+
+      it "delivers from the correct address" do
+        expect(mail).to deliver_from("Archive of Our Own <#{ArchiveConfig.RETURN_ADDRESS}>")
+      end
+
+      it "lists the usernames and all work titles" do
+        expect(mail.text_part).to have_body_text(/#{spam_user.login}/)
+        expect(mail.text_part).to have_body_text(/#{spam1.title}/)
+        expect(mail.text_part).to have_body_text(/#{spam2.title}/)
+        expect(mail.text_part).to have_body_text(/#{spam3.title}/)
+
+        expect(mail.text_part).to have_body_text(/#{other_user.login}/)
+        expect(mail.text_part).to have_body_text(/#{other_spam.title}/)
+
+        expect(mail.html_part).to have_body_text(/#{spam_user.login}/)
+        expect(mail.html_part).to have_body_text(/#{spam1.title}/)
+        expect(mail.html_part).to have_body_text(/#{spam2.title}/)
+        expect(mail.html_part).to have_body_text(/#{spam3.title}/)
+
+        expect(mail.html_part).to have_body_text(/#{other_user.login}/)
+        expect(mail.html_part).to have_body_text(/#{other_spam.title}/)
+      end
+
+      it "lists the users in the correct order" do
+        expect(mail.text_part).to have_body_text(/#{spam_user.login}.*#{other_user.login}/m)
+        expect(mail.html_part).to have_body_text(/#{spam_user.login}.*#{other_user.login}/m)
+      end
+    end
+
+    context "when a user has been deleted" do
+      before { spam_user.destroy }
+
+      context "when there are other users to list" do
+        it "silently omits the missing user" do
+          expect(mail.text_part).not_to have_body_text(/#{spam_user.login}/)
+          expect(mail.text_part).not_to have_body_text(/#{spam1.title}/)
+          expect(mail.text_part).not_to have_body_text(/#{spam2.title}/)
+          expect(mail.text_part).not_to have_body_text(/#{spam3.title}/)
+
+          expect(mail.text_part).to have_body_text(/#{other_user.login}/)
+          expect(mail.text_part).to have_body_text(/#{other_spam.title}/)
+
+          expect(mail.html_part).not_to have_body_text(/#{spam_user.login}/)
+          expect(mail.html_part).not_to have_body_text(/#{spam1.title}/)
+          expect(mail.html_part).not_to have_body_text(/#{spam2.title}/)
+          expect(mail.html_part).not_to have_body_text(/#{spam3.title}/)
+
+          expect(mail.html_part).to have_body_text(/#{other_user.login}/)
+          expect(mail.html_part).to have_body_text(/#{other_spam.title}/)
+        end
+      end
+
+      context "when there are no other users to list" do
+        let!(:report) do
+          {
+            spam_user.id => { "score" => 13, "work_ids" => [spam1.id, spam2.id, spam3.id] }
+          }
+        end
+
+        it "aborts delivery" do
+          expect(mail.actual_message).to eq(BulletproofMailer::BlackholeMailMessage)
+        end
+      end
+    end
+  end
+end

--- a/spec/miscellaneous/mailers/admin_mailer_spec.rb
+++ b/spec/miscellaneous/mailers/admin_mailer_spec.rb
@@ -1,19 +1,32 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe AdminMailer, type: :mailer do
   describe "send_spam_email" do
     let(:spam_user) { create(:user) }
 
-    let(:spam1) { create(:posted_work, spam: true, title: "First Spam",
-                         authors: [spam_user.default_pseud]) }
-    let(:spam2) { create(:posted_work, spam: true, title: "Second Spam",
-                         authors: [spam_user.default_pseud]) }
-    let(:spam3) { create(:posted_work, spam: true, title: "Third Spam",
-                         authors: [spam_user.default_pseud]) }
+    let(:spam1) do
+      create(:posted_work, spam: true, title: "First Spam",
+                           authors: [spam_user.default_pseud])
+    end
+
+    let(:spam2) do
+      create(:posted_work, spam: true, title: "Second Spam",
+                           authors: [spam_user.default_pseud])
+    end
+
+    let(:spam3) do
+      create(:posted_work, spam: true, title: "Third Spam",
+                           authors: [spam_user.default_pseud])
+    end
 
     let(:other_user) { create(:user) }
-    let(:other_spam) { create(:posted_work, spam: true, title: "Mistaken Spam",
-                              authors: [other_user.default_pseud]) }
+
+    let(:other_spam) do
+      create(:posted_work, spam: true, title: "Mistaken Spam",
+                           authors: [other_user.default_pseud])
+    end
 
     let!(:report) do
       {

--- a/spec/miscellaneous/mailers/admin_mailer_spec.rb
+++ b/spec/miscellaneous/mailers/admin_mailer_spec.rb
@@ -105,7 +105,7 @@ describe AdminMailer, type: :mailer do
         end
 
         it "aborts delivery" do
-          expect(mail.actual_message).to eq(BulletproofMailer::BlackholeMailMessage)
+          expect(mail.actual_message).to be_a(ActionMailer::Base::NullMail)
         end
       end
     end


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5549

## Purpose

This PR updates the spam report email so that it won't generate an error when a user's account is deleted after the spam report is generated, but before the email with that report is sent. Instead, it silently omits any missing users (and aborts the entire email if all listed users have been deleted).

## Testing Instructions

See JIRA.