### PR TITLE
Include the chapter title as a data attribute

### DIFF
--- a/app/views/chapters/_chapter.html.erb
+++ b/app/views/chapters/_chapter.html.erb
@@ -14,7 +14,7 @@
 <% cache_if(!@preview_mode, "#{@work.cache_key}/#{chapter.cache_key}-show-v3", skip_digest: true) do %>
 
   <div class="chapter<%= ' preface' unless @preview_mode %> group" role="complementary">
-    <h3 class="title" data-title="<%= chapter.title.html_safe %>">
+    <h3 class="title" <% unless chapter.title.blank? %>data-title="<%= chapter.title.html_safe %>"<% end %>>
       <%= link_to chapter.chapter_header, [chapter.work, chapter] %><% unless chapter.title.blank? %>: <%= chapter.title.html_safe %><% end %>
     </h3>
 

--- a/app/views/chapters/_chapter.html.erb
+++ b/app/views/chapters/_chapter.html.erb
@@ -14,7 +14,7 @@
 <% cache_if(!@preview_mode, "#{@work.cache_key}/#{chapter.cache_key}-show-v3", skip_digest: true) do %>
 
   <div class="chapter<%= ' preface' unless @preview_mode %> group" role="complementary">
-    <h3 class="title">
+    <h3 class="title" data-title="<%= chapter.title.html_safe %>">
       <%= link_to chapter.chapter_header, [chapter.work, chapter] %><% unless chapter.title.blank? %>: <%= chapter.title.html_safe %><% end %>
     </h3>
 


### PR DESCRIPTION
# Pull Request Checklist

* [X] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [X] Have you read through the [contributor guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [ ] Have you added tests for any changed functionality?
* [ ] Have you added the [JIRA](https://otwarchive.atlassian.net) issue number as the *first* thing in your pull request title (eg: `AO3-1234 Fix thing`)
* [ ] Have you updated or commented on the JIRA issue with the information below?

## Purpose

Adds the chapter titles to a `data-title` attribute on the `<h3>` element. 
This allow users to specify css like: 
```
#workskin .chapter.preface.group .title::after {
    content: attr(data-title);
    visibility: visible;
    line-height: 1em;
    display: block;
}
```
in order to generically implement custom chapter titles.

## Testing Instructions

The `<h3>` element for chapter titles should include a `data-title` attribute who's value the title of the chapter.