### PR TITLE
AO3-5691 Fix error message when editing a work's publication date to the future

### DIFF
--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -381,7 +381,7 @@ class WorksController < ApplicationController
         in_moderated_collection
         redirect_to(@work)
       else
-        @chapter.errors.each { |err| @work.errors.add(:base, err) }
+        @chapter.errors.full_messages.each { |err| @work.errors.add(:base, err) }
         render :edit
       end
     end

--- a/features/works/work_dates_edit.feature
+++ b/features/works/work_dates_edit.feature
@@ -73,3 +73,13 @@ Feature: Edit Works Dates
 #    When I follow "Full-page index"
 #      Then I should see "1. Chapter 1 (1990-01-01)"
 #      And I should see "2. Chapter 2 (2013-01-16)"
+
+  Scenario: Users cannot backdate a work back to the future
+    Given it is currently 1/1/2019
+      And I am logged in as a random user
+      And I post the work "Beauty and the Beast 2077"
+    When I edit the work "Beauty and the Beast 2077"
+      And I check "Set a different publication date"
+      And I select "December" from "work_chapter_attributes_published_at_2i"
+      And I press "Post Without Preview"
+    Then I should see "Sorry! We couldn't save this work because:Publication date can't be in the future."


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5691

## Purpose

Avoid the "translation missing" error. We have that error because in `@chapter.errors.each { |err| @work.errors.add(:base, err) }`, `err` is a hash thing with a `:base` key, so we nest them into `attributes.base.base`.

## Testing Instructions

See issue.