### PR TITLE
AO3-5077 Fix TOS FAQ Anchor Links

### DIFF
--- a/app/views/home/tos_faq.html.erb
+++ b/app/views/home/tos_faq.html.erb
@@ -125,12 +125,12 @@
 			<h4 class="heading" id="harassment">Harassment</h4>
 			<h5 class="heading" id="harassment_coverage">Does the harassment policy cover everyone, or just Archive users?</h5>
 			<p>Both Archive users and non-users might potentially complain about harassment.  In today's online environment, the line between non-user and user can be blurry, and so our policy covers both users and non-users.  Writing <abbr title="real person fiction">RPF</abbr> (real-person fiction), however, never constitutes harassment in and of itself, even if the content is objectionable.  Please see the
-				<%= link_to ts("harassment policy"), tos_path(:anchor => "harassment") %> for more information.
+				<%= link_to ts("harassment policy"), tos_path(:anchor => "IV.G.") %> for more information.
 			</p>
 			<h4 class="heading" id="plagiarism">Plagiarism</h4>
 			<h5 class="heading" id="anon_report">Can a person submit a plagiarism complaint anonymously, or without being the author of the plagiarized work?</h5>
 			<p>Yes.  Except in the case of
-				<%= link_to ts("copyright complaints"), tos_path(:anchor => "copyright") %>, a complaining person may submit a complaint via the web form, which does not require identifying information.
+				<%= link_to ts("copyright complaints"), tos_path(:anchor => "IV.D.") %>, a complaining person may submit a complaint via the web form, which does not require identifying information.
 			</p>
 			<h4 class="heading" id="pseudonyms">Pseudonyms</h4>
 			<h5 class="heading" id="different_pseudonyms">Why would I want to have different pseudonyms connected to the same account?</h5>
@@ -210,7 +210,7 @@
 			<p>Creators may also choose to add additional tags to their work. These tags can be serious or humorous. They can be warnings or promises, or whatever else the creator chooses.  Tags may be made synonymous for purposes of filtering by our Tag Wranglers, but your tags will continue to appear in their original form on your work.
 			</p>
 			<p>Please see
-				<%= link_to ts("our ratings and warnings policy"), tos_path(:anchor => "ratings") %> for more information.
+				<%= link_to ts("our ratings and warnings policy"), tos_path(:anchor => "IV.K.2") %> for more information.
 			</p>
 			<h5 class="heading" id="archive_tags">What's the purpose of the Archive tags?</h5>
 			<p>The purpose is to identify subjects that have been the subject of substantial, recurring debate in many sectors of fandom and provide an easy way to warn for those subjects (though a choice not to warn is always acceptable as well).  We also decided to limit the Archive tags to a small number of subjects out of concerns for enforcement.  Concepts like "dubious consent" vary substantially from person to person, and we decided that we could not reasonably expect fair enforcement of a rule requiring warnings (or a signal that the author chose not to warn) for concepts beyond those listed in the Archive warnings.


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5077

## Purpose

Fixes broken anchor links in the TOS FAQ page. 

## References

Replaces #3127 

## Credit

*What name do you want us to use to credit your work in the [Archive of Our Own's Release Notes](http://archiveofourown.org/admin_posts?tag=1)?*
MaxwellsDaemon

*What pronouns do you prefer (she/her, he/him, zie/hir etc)?*
Him