### PR TITLE
AO3-5709 Use pseud byline for download authors

### DIFF
--- a/app/models/download.rb
+++ b/app/models/download.rb
@@ -102,7 +102,7 @@ class Download
   end
 
   def author_names
-    work.anonymous? ? ["Anonymous"] : work.pseuds.sort.map(&:name)
+    work.anonymous? ? ["Anonymous"] : work.pseuds.sort.map(&:byline)
   end
 
   # need the next two to be filesystem safe and not overly long
@@ -113,7 +113,7 @@ class Download
   def page_title
     [file_name, file_authors, fandoms].join(" - ")
   end
-  
+
   def chapters
     work.chapters.order('position ASC').where(posted: true)
   end

--- a/spec/models/download_spec.rb
+++ b/spec/models/download_spec.rb
@@ -56,4 +56,79 @@ describe Download do
       expect(Download.new(work).file_name).to eq("123456789 123456789")
     end
   end
+
+  describe "author_names" do
+    let(:work) { Work.new }
+    let(:subject) { Download.new(work) }
+    let(:simple_user) { FactoryGirl.build(:user, login: "SimpleAuthor") }
+    let(:simple_author) { FactoryGirl.build(:pseud, name: "SimpleAuthor", user: simple_user) }
+    let(:complex_user) { FactoryGirl.build(:user, login: "ComplexUser") }
+    let(:complex_author) { FactoryGirl.build(:pseud, name: "ComplexAuthor", user: complex_user) }
+
+    it "returns Anonymous when the work is anonymous" do
+      allow(work).to receive(:anonymous?).and_return(true)
+
+      expect(subject.author_names).to eq(["Anonymous"])
+    end
+
+    context "when the pseud is the same as the username" do
+      it "returns the pseud by itself" do
+        allow(work).to receive(:pseuds).and_return([simple_author])
+
+        expect(subject.author_names).to eq(["SimpleAuthor"])
+      end
+    end
+
+    context "when the pseud is different from the username" do
+      it "returns the disambiguated pseud" do
+        allow(work).to receive(:pseuds).and_return([complex_author])
+
+        expect(subject.author_names).to eq(["ComplexAuthor (ComplexUser)"])
+      end
+    end
+
+    context "for a work with multiple authors" do
+      it "returns the pseuds in alphabetical order" do
+        allow(work).to receive(:pseuds).and_return([simple_author, complex_author])
+
+        expect(subject.author_names).to eq(["ComplexAuthor (ComplexUser)", "SimpleAuthor"])
+      end
+    end
+  end
+
+  describe "authors" do
+    let(:work) { Work.new }
+    let(:subject) { Download.new(work) }
+
+    it "joins the author names separated by a comma and a space" do
+      allow(subject).to receive(:author_names).and_return(["First (Zeroth)", "Second"])
+
+      expect(subject.authors).to eq("First (Zeroth), Second")
+    end
+
+    it "transliterates non-ASCII characters" do
+      allow(subject).to receive(:author_names).and_return(["我哥好像被奇怪的人盯上了怎么破"])
+
+      expect(subject.authors).to eq("Wo Ge Hao Xiang Bei Qi Guai De Ren Cheng Shang Liao Zen Yao Po ")
+    end
+  end
+
+  describe "file_authors" do
+    let(:work) { Work.new }
+    let(:subject) { Download.new(work) }
+
+    it "truncates if too long" do
+      allow(subject).to receive(:author_names).and_return(["ComplexAuthor (ComplexUser)", "SimpleAuthor"])
+
+      expect(subject.file_authors).to eq("ComplexAuthor")
+    end
+
+    context "for a work with multiple authors" do
+      it "joins the author names with a simple dash" do
+        allow(subject).to receive(:author_names).and_return(["First (Zeroth)", "Second"])
+
+        expect(subject.file_authors).to eq("First Zeroth-Second")
+      end
+    end
+  end
 end


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [x] Have you added tests for any changed functionality?
* [x] Have you added the [JIRA](https://otwarchive.atlassian.net) issue number as the *first* thing in your pull request title (eg: `AO3-1234 Fix thing`)
* [x] Have you updated or commented on the JIRA issue with the information below?

## Issue

https://otwarchive.atlassian.net/browse/AO3-5709

## Purpose

What does this PR do?

The pseud byline includes the user name when it's different from the pseud name, so we use the byline instead of the name for generating the `author_names`.

I've also added a bunch of specs for previously unspecced methods, so we can see what knock-on effects changing the way we generate `author_names` will have.

In addition to the metadata generator, `author_names` is also used to generate the `page_title` as `file_authors`, so it needs to be "filesystem safe" and on the short side.

Getting truncated at 24 characters could make one creator with a parenthetical name push all the others out of the listing. OTOH this can already happen with a pseud that's the same as the user name, so I guess we're not making it much worse?

## Testing Instructions

How can the Archive's QA team verify that this is working as you intended? (If you have access, please copy this into the JIRA ticket for them!)

Already listed in JIRA.

## References

Are there any other relevant issues / PRs / mailing lists discussions related to this?

## Credit

*What name do you want us to use to credit your work in the [Archive of Our Own's Release Notes](https://archiveofourown.org/admin_posts?tag=1)?*

Enigel

*What pronouns do you prefer (she/her, he/him, zie/hir etc)?*

she/her
