### PR TITLE
AO3-5658 Don't escape error messages on the Edit Multiple Works page, and make the invalid tag error message appear.

### DIFF
--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -774,8 +774,8 @@ class WorksController < ApplicationController
   # saving the user's changes.
   def work_cannot_be_saved?
     !(@work.errors.empty? &&
-      @work.has_required_tags? &&
-      @work.valid?)
+      @work.valid? &&
+      @work.has_required_tags?)
   end
 
   def set_work_tag_error_messages

--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -671,7 +671,7 @@ class WorksController < ApplicationController
     @works.each do |work|
       # now we can just update each work independently, woo!
       unless work.update_attributes(updated_work_params)
-        @errors << ts('The work %{title} could not be edited: %{error}', title: work.title, error: work.errors.full_messages.join(" "))
+        @errors << ts('The work %{title} could not be edited: %{error}', title: work.title, error: work.errors.full_messages.join(" ")).html_safe
       end
 
       if params[:remove_me]


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5475
https://otwarchive.atlassian.net/browse/AO3-5658

## Purpose

1. Make sure that the error messages for `WorksController#update_multiple` have `.html_safe` applied so that they don't get escaped

2. Make sure that the work validations will be run even if the work is missing required tags. This will cause it to generate the error message about invalid tags when a work's only fandom is invalid, instead of just saying that no fandom was provided.