### PR TITLE
AO3-5658 Remove sentence from privacy help pop-up

### DIFF
--- a/public/help/privacy-preferences.html
+++ b/public/help/privacy-preferences.html
@@ -41,9 +41,7 @@
       receive any notifications.
     </p>
     <p>
-      Changing this setting won't affect any existing shared works. Co-creators
-      can still credit you when adding new chapters to existing shared works,
-      and you or your co-creator(s) can add shared works to series.
+      Changing this setting won't affect any existing shared works.
     </p>
   </dd>
 </dl>


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5658

## Purpose

Remove a sentence from the help pop-up

## Testing Instructions

Make sure it's gone

