### PR TITLE
AO3-5658 AO3-5751 Make the ability to view drafts more consistent, and add admin access to the user drafts page.

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -433,12 +433,6 @@ public
                   (@check_visibility_of.respond_to?(:visible?) && !@check_visibility_of.visible?) ||
                   (@check_visibility_of.respond_to?(:hidden_by_admin?) && @check_visibility_of.hidden_by_admin?)
       can_view_hidden = logged_in_as_admin? || current_user_owns?(@check_visibility_of)
-
-      # Override the standard visibility check if the user has a creator invite:
-      if @check_visibility_of.is_a?(Creatable)
-        can_view_hidden ||= @check_visibility_of.user_has_creator_invite?(current_user)
-      end
-
       access_denied if (is_hidden && !can_view_hidden)
     end
   end

--- a/app/controllers/bookmarks_controller.rb
+++ b/app/controllers/bookmarks_controller.rb
@@ -60,7 +60,7 @@ class BookmarksController < ApplicationController
 
   def index
     if @bookmarkable
-      access_denied unless is_admin? || @bookmarkable.visible
+      access_denied unless is_admin? || @bookmarkable.visible?
       @bookmarks = @bookmarkable.bookmarks.is_public.paginate(page: params[:page], per_page: ArchiveConfig.ITEMS_PER_PAGE)
     else
       base_options = {

--- a/app/controllers/chapters_controller.rb
+++ b/app/controllers/chapters_controller.rb
@@ -19,7 +19,8 @@ class ChaptersController < ApplicationController
 
   # GET /work/:work_id/chapters/manage
   def manage
-    @chapters = @work.chapters_in_order(false).select(&:posted)
+    @chapters = @work.chapters_in_order(include_content: false,
+                                        include_drafts: false)
   end
 
   # GET /work/:work_id/chapters/:id
@@ -35,10 +36,11 @@ class ChaptersController < ApplicationController
     if params[:selected_id]
       redirect_to url_for(controller: :chapters, action: :show, work_id: @work.id, id: params[:selected_id]) and return
     end
-    @chapters = @work.chapters_in_order(false)
-    if !logged_in? || !current_user.is_author_of?(@work)
-      @chapters = @chapters.select(&:posted)
-    end
+    @chapters = @work.chapters_in_order(
+      include_content: false,
+      include_drafts: (logged_in_as_admin? ||
+                       @work.user_is_owner_or_invited?(current_user))
+    )
     if !@chapters.include?(@chapter)
       access_denied
     else

--- a/app/controllers/series_controller.rb
+++ b/app/controllers/series_controller.rb
@@ -47,7 +47,10 @@ class SeriesController < ApplicationController
   # GET /series/1
   # GET /series/1.xml
   def show
-    @serial_works = @series.serial_works.includes(:work).where('works.posted = ?', true).references(:works).order(:position).select{ |sw| sw.work.visible? }
+    @serial_works = \
+      @series.serial_works.includes(:work).references(:works).
+      where(works: { posted: true }).order(:position).
+      select { |sw| sw.work.visible? }
     # sets the page title with the data for the series
     @page_title = @series.unrevealed? ? ts("Mystery Series") : get_page_title(@series.allfandoms.collect(&:name).join(', '), @series.anonymous? ? ts("Anonymous") : @series.allpseuds.collect(&:byline).join(', '), @series.title)
     if current_user.respond_to?(:subscriptions)

--- a/app/controllers/series_controller.rb
+++ b/app/controllers/series_controller.rb
@@ -47,7 +47,7 @@ class SeriesController < ApplicationController
   # GET /series/1
   # GET /series/1.xml
   def show
-    @serial_works = @series.serial_works.includes(:work).where('works.posted = ?', true).references(:works).order(:position).select{ |sw| sw.work.visible(User.current_user) }
+    @serial_works = @series.serial_works.includes(:work).where('works.posted = ?', true).references(:works).order(:position).select{ |sw| sw.work.visible? }
     # sets the page title with the data for the series
     @page_title = @series.unrevealed? ? ts("Mystery Series") : get_page_title(@series.allfandoms.collect(&:name).join(', '), @series.anonymous? ? ts("Anonymous") : @series.allpseuds.collect(&:byline).join(', '), @series.title)
     if current_user.respond_to?(:subscriptions)

--- a/app/helpers/series_helper.rb
+++ b/app/helpers/series_helper.rb
@@ -9,13 +9,10 @@ module SeriesHelper
   def series_data_for_work(work)
     series = work.series.select(&:visible?)
     series.map do |serial|
-      serial_works = serial.serial_works
-                           .includes(:work)
-                           .where('works.posted = ?', true)
-                           .order(:position)
-                           .references(:works)
-                           .map(&:work)
-                           .select(&:visible?)
+      serial_works = \
+        serial.serial_works.includes(:work).references(:works).
+        where(works: { posted: true }).order(:position).
+        map(&:work).select(&:visible?)
       visible_position = serial_works.index(work) || serial_works.length
       unless !visible_position
         # Span used at end of previous_link and beginning of next_link to prevent extra

--- a/app/helpers/series_helper.rb
+++ b/app/helpers/series_helper.rb
@@ -7,15 +7,15 @@ module SeriesHelper
 
   # this should only show prev and next works visible to the current user
   def series_data_for_work(work)
-    series = work.series.select { |s| s.visible?(current_user) }
+    series = work.series.select(&:visible?)
     series.map do |serial|
       serial_works = serial.serial_works
                            .includes(:work)
                            .where('works.posted = ?', true)
                            .order(:position)
                            .references(:works)
-                           .select { |sw| sw.work.visible(current_user) }
                            .map(&:work)
+                           .select(&:visible?)
       visible_position = serial_works.index(work) || serial_works.length
       unless !visible_position
         # Span used at end of previous_link and beginning of next_link to prevent extra

--- a/app/helpers/works_helper.rb
+++ b/app/helpers/works_helper.rb
@@ -93,15 +93,8 @@ module WorksHelper
   end
 
   # Check whether this user has permission to view this work even if it's
-  # unrevealed and they're not listed as a creator:
+  # unrevealed:
   def can_see_work(work, user)
-    # Invited co-creators can also see unrevealed works, even though they're
-    # not officially listed as creators (because creators are allowed to edit,
-    # and invited co-creators aren't):
-    if work.user_has_creator_invite?(current_user)
-      return true
-    end
-
     # Moderators can see unrevealed works:
     work.collections.each do |collection|
       return true if collection.user_is_maintainer?(user)

--- a/app/models/bookmark.rb
+++ b/app/models/bookmark.rb
@@ -144,7 +144,7 @@ class Bookmark < ApplicationRecord
         return true if pseud.user == current_user
       else
         if self.bookmarkable_type == 'Work' || self.bookmarkable_type == 'Series' || self.bookmarkable_type == 'ExternalWork'
-          return true if self.bookmarkable.visible(current_user)
+          return true if self.bookmarkable.visible?(current_user)
         else
           return true
         end

--- a/app/models/concerns/creatable.rb
+++ b/app/models/concerns/creatable.rb
@@ -213,4 +213,11 @@ module Creatable
     return false unless user.is_a?(User)
     creatorships.unapproved.for_user(user).exists?
   end
+
+  # Check whether the given user has some kind of creatorship (approved or
+  # unapproved) associated with this item.
+  def user_is_owner_or_invited?(user)
+    return false unless user.is_a?(User)
+    creatorships.for_user(user).exists?
+  end
 end

--- a/app/models/external_work.rb
+++ b/app/models/external_work.rb
@@ -69,8 +69,6 @@ class ExternalWork < ApplicationRecord
     self.hidden_by_admin? ? user.kind_of?(Admin) : true
   end
 
-  alias_method :visible, :visible?
-
   # Visibility has changed, which means we need to reindex
   # the external work's bookmarker pseuds, to update their bookmark counts.
   def should_reindex_pseuds?

--- a/app/models/series.rb
+++ b/app/models/series.rb
@@ -92,7 +92,7 @@ class Series < ApplicationRecord
     return true if super
 
     works.joins(:creatorships).merge(user.creatorships).exists? ||
-      works.joins(:chapters => :creatorships).merge(user.creatorships).exists?
+      works.joins(chapters: :creatorships).merge(user.creatorships).exists?
   end
 
   def visible_work_count

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -390,6 +390,15 @@ class Work < ApplicationRecord
     end
   end
 
+  # Override the default behavior so that we also check for creatorships
+  # associated with one of the chapters.
+  def user_is_owner_or_invited?(user)
+    return false unless user.is_a?(User)
+    return true if super
+
+    chapters.joins(:creatorships).merge(user.creatorships).exists?
+  end
+
   def set_challenge_info
     # if this is fulfilling a challenge, add the collection and recipient
     challenge_assignments.each do |assignment|
@@ -482,18 +491,14 @@ class Work < ApplicationRecord
   # VISIBILITY
   ########################################################################
 
-  def visible(current_user=User.current_user)
-    if current_user.nil? || current_user == :false
-      return self if self.posted unless self.restricted || self.hidden_by_admin
-    elsif self.posted && !self.hidden_by_admin
-      return self
-    elsif self.hidden_by_admin?
-      return self if current_user.kind_of?(Admin) || current_user.is_author_of?(self)
-    end
-  end
+  def visible?(user = User.current_user)
+    return true if user.is_a?(Admin)
 
-  def visible?(user=User.current_user)
-    self.visible(user) == self
+    if posted && !hidden_by_admin
+      user.is_a?(User) || !restricted
+    else
+      user_is_owner_or_invited?(user)
+    end
   end
 
   def unrestricted=(setting)
@@ -699,13 +704,11 @@ class Work < ApplicationRecord
     end
   end
 
-  def chapters_in_order(include_content = true)
+  def chapters_in_order(include_drafts: false, include_content: true)
     # in order
     chapters = self.chapters.order('position ASC')
-    # only posted chapters unless author
-    unless User.current_user && (User.current_user.is_a?(Admin) || User.current_user.is_author_of?(self))
-      chapters = chapters.where(posted: true)
-    end
+    # only posted chapters unless specified
+    chapters = chapters.where(posted: true) unless include_drafts
     # when doing navigation pass false as contents are not needed
     chapters = chapters.select('published_at, id, work_id, title, position, posted') unless include_content
     chapters
@@ -1124,7 +1127,7 @@ class Work < ApplicationRecord
   ########################################################################
 
   def akismet_attributes
-    content = chapters_in_order.map { |c| c.content }.join
+    content = chapters_in_order(include_drafts: true).map(&:content).join
     user = users.first
     {
       comment_type: "fanwork-post",

--- a/app/views/chapters/_chapter.html.erb
+++ b/app/views/chapters/_chapter.html.erb
@@ -6,7 +6,7 @@
       <%= ts("This chapter is a draft and hasn't been posted yet!") %>
     </p>
   <% end %>
-  <% if @chapter.user_has_creator_invite?(current_user) %>
+  <% if chapter.user_has_creator_invite?(current_user) %>
     <p class="notice">
       <%= ts("You've been invited to become a co-creator of this chapter. To accept or reject the invitation, visit your %{creator_invitations_page}.",
              creator_invitations_page: link_to(ts("Creator Invitations page"), user_creatorships_path(current_user))).html_safe %>

--- a/app/views/chapters/show.html.erb
+++ b/app/views/chapters/show.html.erb
@@ -19,7 +19,7 @@
 <% end %>
 <!--/subnav-->
 
-<% if !@work.unrevealed? || logged_in_as_admin? || is_author_of?(@work) || (@work.unrevealed? && can_see_work(@work, current_user)) %>
+<% if !@work.unrevealed? || logged_in_as_admin? || @work.user_is_owner_or_invited?(current_user) || can_see_work(@work, current_user) %>
   <!-- BEGIN work -->
   <div class="work"><p class="landmark"><a name="top">&nbsp;</a></p>
     <%= render :partial => 'works/work_header' %>

--- a/app/views/users/_sidebar.html.erb
+++ b/app/views/users/_sidebar.html.erb
@@ -24,7 +24,7 @@
 <h4 class="landmark heading"><%= ts("Pitch")%></h4>
 <ul class="navigation actions">
 	<li><%= print_works_link(@user, @pseud) %></li>
-	<% if @user == current_user %>
+	<% if @user == current_user || logged_in_as_admin? %>
 	  <li><%= span_if_current ts("Drafts") + " (#{@user.unposted_works.size})", drafts_user_works_path(@user) %></li>
   <% end %>
 	<li><%= print_series_link(@user, @pseud) %></li>

--- a/app/views/works/show.html.erb
+++ b/app/views/works/show.html.erb
@@ -30,7 +30,7 @@
 <!--/subnav-->
 
 <!-- BEGIN revealed -->
-<% if !@work.unrevealed? || logged_in_as_admin? || is_author_of?(@work) || (@work.unrevealed? && can_see_work(@work, current_user)) %>
+<% if !@work.unrevealed? || logged_in_as_admin? || @work.user_is_owner_or_invited?(current_user) || can_see_work(@work, current_user) %>
 <!-- BEGIN work -->
 <!--work description, metadata, notes and messages-->
   <%= render :partial => 'works/work_header' %>
@@ -41,11 +41,9 @@
 
 <!--chapter content-->
     <div id="chapters" role="article">
-      <% if @chapters && @chapters.size > 1 %>
+      <% if @chapters %>
         <% for chapter in @chapters %>
-          <% if chapter.posted? || is_author_of?(chapter) %>
-            <%= render :partial => 'chapters/chapter', :locals => {:chapter => chapter, :hide_work_info => true} %>
-          <% end %>
+          <%= render 'chapters/chapter', chapter: chapter, hide_work_info: true %>
         <% end %>
       <% else %>
         <h3 class="landmark heading" id="work"><%= ts("Work Text:") %></h3>

--- a/app/views/works/show.html.erb
+++ b/app/views/works/show.html.erb
@@ -43,7 +43,7 @@
     <div id="chapters" role="article">
       <% if @chapters %>
         <% for chapter in @chapters %>
-          <%= render 'chapters/chapter', chapter: chapter, hide_work_info: true %>
+          <%= render 'chapters/chapter', chapter: chapter %>
         <% end %>
       <% else %>
         <h3 class="landmark heading" id="work"><%= ts("Work Text:") %></h3>

--- a/spec/controllers/works/drafts_spec.rb
+++ b/spec/controllers/works/drafts_spec.rb
@@ -77,7 +77,6 @@ describe WorksController do
                                    "You can only see your own drafts, sorry!")
       end
     end
-
   end
 
   describe "post_draft" do

--- a/spec/controllers/works/drafts_spec.rb
+++ b/spec/controllers/works/drafts_spec.rb
@@ -19,47 +19,65 @@ describe WorksController do
   end
 
   describe "drafts" do
-    let(:other_drafts_user) { create(:user) }
-
-    before do
-      fake_login_known_user(drafts_user)
-    end
-
-    context "no user_id" do
-      it "should redirect to the user controller and display an appropriate error message" do
+    context "when no user_id is specified" do
+      it "redirects to the user controller and display an appropriate error message" do
         get :drafts
         it_redirects_to_with_error(users_path, "Whose drafts did you want to look at?")
       end
     end
 
-    context "with a valid user_id" do
-      context "if the user_id requested doesn't belong to the current user" do
-        it "displays an error and redirects" do
-          get :drafts, params: { user_id: other_drafts_user.login }
-          it_redirects_to_with_error(user_path(drafts_user), "You can only see your own drafts, sorry!")
-        end
-      end
+    context "when logged out" do
+      before { fake_logout }
 
-      context "if the user_id is that of the current user" do
-        it "should display no errors" do
-          get :drafts, params: { user_id: drafts_user.login }
-          expect(response).to have_http_status(200)
-          expect(flash[:error]).to be_nil
-        end
-
-        it "should display all the user's drafts if no pseud_id is specified" do
-          get :drafts, params: { user_id: drafts_user.login }
-          expect(assigns(:works)).to include(other_pseud_work)
-          expect(assigns(:works)).to include(default_pseud_work)
-        end
-
-        it "should display only the drafts for a specific pseud if a pseud_id is specified" do
-          get :drafts, params: { user_id: drafts_user.login, pseud_id: drafts_user_pseud.name }
-          expect(assigns(:works)).to include(other_pseud_work)
-          expect(assigns(:works)).not_to include(default_pseud_work)
-        end
+      it "redirects to the login page and displays a error message" do
+        get :drafts, params: { user_id: drafts_user.login }
+        it_redirects_to_with_error(new_user_session_path,
+                                   "You can only see your own drafts, sorry!")
       end
     end
+
+    context "when logged in as an admin" do
+      before { fake_login_admin(create(:admin)) }
+
+      it "displays the drafts" do
+        get :drafts, params: { user_id: drafts_user.login }
+        expect(assigns[:works]).to contain_exactly(default_pseud_work,
+                                                   other_pseud_work)
+      end
+    end
+
+    context "when logged in as the user with the desired user_id" do
+      before { fake_login_known_user(drafts_user) }
+
+      it "displays no errors" do
+        get :drafts, params: { user_id: drafts_user.login }
+        expect(response).to have_http_status(200)
+        expect(flash[:error]).to be_nil
+      end
+
+      it "displays all the user's drafts if no pseud_id is specified" do
+        get :drafts, params: { user_id: drafts_user.login }
+        expect(assigns(:works)).to include(other_pseud_work)
+        expect(assigns(:works)).to include(default_pseud_work)
+      end
+
+      it "displays only the drafts for a specific pseud if a pseud_id is specified" do
+        get :drafts, params: { user_id: drafts_user.login, pseud_id: drafts_user_pseud.name }
+        expect(assigns(:works)).to include(other_pseud_work)
+        expect(assigns(:works)).not_to include(default_pseud_work)
+      end
+    end
+
+    context "when logged in as another user" do
+      before { fake_login }
+
+      it "redirects to the current user's dashboard with an error message" do
+        get :drafts, params: { user_id: drafts_user.login }
+        it_redirects_to_with_error(user_path(User.current_user),
+                                   "You can only see your own drafts, sorry!")
+      end
+    end
+
   end
 
   describe "post_draft" do


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5658
https://otwarchive.atlassian.net/browse/AO3-5751

## Purpose

The pre-existing code for handling who's allowed to see drafts and draft chapters was inconsistent. In particular:
- Admins could see single-chapter drafts, but not multi-chapter drafts.
- In a multi-chapter work with multiple creators, a draft chapter with only one creator was only visible to the other creator in chapter-by-chapter mode, not in view full work mode.
- A user invited to be co-creator on a single-chapter draft could see the work, but a user invited to be a co-creator on one chapter of a multi-chapter draft could not see the work.
- A user invited to be co-creator on an unposted work with a series could not see the series unless the series contained another work.

This PR tries to address all of these issues, as well as adding the ability for admins to view users' drafts pages.

It also tries to address a similar issue when a user is invited to be a co-creator on one chapter of an unrevealed work.

## Testing Instructions

- Log in as an admin, and view the dashboard of a user with drafts. Click on the Drafts link in their sidebar, and click on some of the works to make sure you can view them. Make sure that you find some multi-chapter drafts to view, as well as some draft chapters in previously posted works.
- Create a multi-chapter posted work with multiple approved co-creators, and create a draft chapter as one of the co-creators. Then log in as the other co-creator and click the "Entire Work" button to see if the chapter is visible.
- Create a multi-chapter draft, and invite a user to one of the chapters. Log in as the other user, and  make sure that you can see the draft if you click the link in the email.
- Create a draft in a brand new series, and invite a user to the draft (but not the series!). Log in as the other user, and click on the link in the email to view the draft. Make sure you can see the series in the header.
- Create a multi-chapter work in an unrevealed collection, and invite a co-creator to one of the chapters. Log in as the invited user and make sure that you can see the work when you click the link from the email.