### PR TITLE
AO3-5658 Update co-creator notification text

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -214,7 +214,7 @@ en:
     creatorship_notification:
       subject: "[%{app_name}] Co-creator notification"
       intro: "The user %{adding_user} has listed your pseud %{pseud} as a co-creator on the following %{type}:"
-      explanation: "Regardless of your co-creation settings, you can be added to new chapters and series that are added to the work where you are already listed as one of the co-creators."
+      explanation: "When you're a co-creator on a work, you can be added to new chapters regardless of your co-creation settings. You will also be added to any series the work is added to."
       html:
         creation: "%{creation_link} by %{pseud_links}"
         remove: "If you've been added in error or don't want to be listed as a creator, you can %{edit} to remove yourself as creator."

--- a/features/works/chapter_edit.feature
+++ b/features/works/chapter_edit.feature
@@ -336,7 +336,7 @@ Feature: Edit chapters
     Then I should not see "Chapter by karma"
       And 1 email should be delivered to "sabrina"
       And the email should contain "The user karma has listed your pseud sabrina as a co-creator on the following chapter"
-      And the email should contain "When you're a co-creator on a work, you can be added to new chapters regardless of your co-creation settings. You will also be added to any series the work is added to."
+      And the email should contain "a co-creator on a work, you can be added to new chapters regardless of your co-creation settings. You will also be added to any series the work is added to."
       And the email should not contain "translation missing"
 
 

--- a/features/works/chapter_edit.feature
+++ b/features/works/chapter_edit.feature
@@ -336,7 +336,7 @@ Feature: Edit chapters
     Then I should not see "Chapter by karma"
       And 1 email should be delivered to "sabrina"
       And the email should contain "The user karma has listed your pseud sabrina as a co-creator on the following chapter"
-      And the email should contain "Regardless of your co-creation settings, you can be added to new chapters and series that are added to the work where you are already listed as one of the co-creators."
+      And the email should contain "When you're a co-creator on a work, you can be added to new chapters regardless of your co-creation settings. You will also be added to any series the work is added to."
       And the email should not contain "translation missing"
 
 


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5658

## Purpose

One last tweak to the co-creator notification email text!

## Testing Instructions

Add a series to a co-created work. Your co-creator should get an email with the new text. (You could also check by adding a chapter that lists your co-creator as a co-creator.)

