### PR TITLE
AO3-5024 Correct error message when entering wrong password for admin

### DIFF
--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -20,7 +20,7 @@ en:
       admin:
         already_authenticated: "You are already signed in."
         inactive: "Your account is not activated yet."
-        invalid: "Invalid %{authentication_keys} or password."
+        invalid: "The password or admin user name you entered doesn't match our records."
         locked: "Your account is locked."
         last_attempt: "You have one more attempt before your account is locked."
         not_found_in_database: "The password or admin user name you entered doesn't match our records."

--- a/features/admins/authenticate_admins.feature
+++ b/features/admins/authenticate_admins.feature
@@ -23,7 +23,7 @@ Feature: Authenticate Admin Users
       And I fill in "admin_password" with "wrangulator"
       And I press "Log in as admin"
     Then I should not see "Successfully logged in"
-      And I should see "The password or admin user name you entered doesn't match our records"
+      And I should see "The password or admin user name you entered doesn't match our records."
 
   Scenario: Admin can log in
   Given I have no users
@@ -46,3 +46,14 @@ Feature: Authenticate Admin Users
       And I fill in "admin_password" with "secret"
       And I press "Log in as admin"
     Then I should see "Successfully logged in"
+
+  Scenario: Admin cannot log in with wrong password
+  Given the following admin exists
+    | login       | password |
+    | Zooey       | secret   |
+  When I go to the admin login page
+    And I fill in "Admin user name" with "Zooey"
+    And I fill in "Admin password" with "notsecret"
+    And I press "Log In"
+  Then I should see "The password or user name you entered doesn't match our records."
+

--- a/features/admins/authenticate_admins.feature
+++ b/features/admins/authenticate_admins.feature
@@ -1,53 +1,51 @@
-
 @admin
 Feature: Authenticate Admin Users
 
-  Scenario: admin cannot log in as an ordinary user - it is a different type of account
+  Scenario: Admin cannot log in as an ordinary user.
   Given the following admin exists
-      | login       | password |
-      | Zooey       | secret   |
+    | login       | password |
+    | Zooey       | secret   |
   When I go to the home page
-      And I fill in "User name or email" with "Zooey"
-      And I fill in "Password" with "secret"
-      And I press "Log In"
-    Then I should see "The password or user name you entered doesn't match our records"
+    And I fill in "User name or email" with "Zooey"
+    And I fill in "Password" with "secret"
+    And I press "Log In"
+  Then I should see "The password or user name you entered doesn't match our records"
 
-  Scenario: Ordinary user cannot log in as admin
-    Given the following activated user exists
-      | login       | password      |
-      | dizmo       | wrangulator   |
-      And I have loaded the "roles" fixture
-
+  Scenario: Ordinary user cannot log in as admin.
+  Given the following activated user exists
+    | login       | password      |
+    | dizmo       | wrangulator   |
+    And I have loaded the "roles" fixture
   When I go to the admin login page
-      And I fill in "admin_login" with "dizmo"
-      And I fill in "admin_password" with "wrangulator"
-      And I press "Log in as admin"
-    Then I should not see "Successfully logged in"
-      And I should see "The password or admin user name you entered doesn't match our records."
+    And I fill in "Admin user name" with "dizmo"
+    And I fill in "Admin password" with "wrangulator"
+    And I press "Log in as admin"
+  Then I should not see "Successfully logged in"
+    And I should see "The password or admin user name you entered doesn't match our records."
 
-  Scenario: Admin can log in
+  Scenario: Admin can log in.
   Given I have no users
     And the following admin exists
       | login       | password |
       | Zooey       | secret   |
-      And I have loaded the "roles" fixture
-    When I go to the admin login page
-      And I fill in "admin_login" with "Zooey"
-      And I fill in "admin_password" with "secret"
-      And I press "Log in as admin"
-    Then I should see "Successfully logged in"
+    And I have loaded the "roles" fixture
+  When I go to the admin login page
+    And I fill in "Admin user name" with "Zooey"
+    And I fill in "Admin password" with "secret"
+    And I press "Log in as admin"
+  Then I should see "Successfully logged in"
 
-  Scenario: Login case (in)sensitivity
-    Given the following admin exists
-      | login       | password |
-      | TheMadAdmin | secret   |
-    When I go to the admin login page
-      And I fill in "admin_login" with "themadadmin"
-      And I fill in "admin_password" with "secret"
-      And I press "Log in as admin"
-    Then I should see "Successfully logged in"
+  Scenario: Admin user name is case insensitive.
+  Given the following admin exists
+    | login       | password |
+    | TheMadAdmin | secret   |
+  When I go to the admin login page
+    And I fill in "Admin user name" with "themadadmin"
+    And I fill in "Admin password" with "secret"
+    And I press "Log in as admin"
+  Then I should see "Successfully logged in"
 
-  Scenario: Admin cannot log in with wrong password
+  Scenario: Admin cannot log in with wrong password.
   Given the following admin exists
     | login       | password |
     | Zooey       | secret   |


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5024

## Purpose

* Updates the error message you try to log in with an existing admin name with the wrong password.
* Tests aforementioned scenario.
* Tidies the tests in the relevant feature file:
  * Consistent indenting and spacing.
  * Updated scenario descriptions.
  * Use the label text for the field names.

## Testing Instructions

Try to log in as an admin using an existing admin username, but an incorrect password.
