### PR TITLE
AO3-5688 Change "co-author" to "co-creator" on delete preview page

### DIFF
--- a/app/views/users/delete_preview.html.erb
+++ b/app/views/users/delete_preview.html.erb
@@ -1,6 +1,6 @@
 <h2 class="heading"><%=h 'What do you want to do with your works?' %></h2>
 
-<%= form_tag(@user, method: 'delete') do %>
+<%= form_tag(@user, method: :delete) do %>
   <% unless @user.coauthors.blank? %>
     <fieldset>
       <legend><%= t('.users.works_with_others', default: "Works You Made With Others") %></legend>
@@ -11,16 +11,16 @@
         <%= "You are not able to delete these as they are shared works, but you can #{link_to "orphan", archive_faq_path("orphaning")} them or remove yourself completely as a co-creator.".html_safe %>
       </p>
       <p>
-        <%= radio_button_tag 'coauthor', 'keep_pseud', true %>
-        <%= label_tag 'coauthor_keep_pseud', 'Leave my pseud but attach to the orphan account' %>
+        <%= radio_button_tag :coauthor, :keep_pseud, true %>
+        <%= label_tag :coauthor_keep_pseud, 'Leave my pseud but attach to the orphan account' %>
       </p>
       <p>
-        <%= radio_button_tag 'coauthor', 'orphan_pseud' %>
-        <%= label_tag 'coauthor_orphan_pseud', "Change my pseud to 'orphan' and attach to the orphan account" %>
+        <%= radio_button_tag :coauthor, :orphan_pseud %>
+        <%= label_tag :coauthor_orphan_pseud, "Change my pseud to 'orphan' and attach to the orphan account" %>
       </p>
       <p>
-        <%= radio_button_tag 'coauthor', 'remove' %>
-        <%= label_tag 'coauthor_remove', 'Remove me completely as co-creator' %>
+        <%= radio_button_tag :coauthor, :remove %>
+        <%= label_tag :coauthor_remove, 'Remove me completely as co-creator' %>
       </p>
     </fieldset>
   <% end %>
@@ -43,16 +43,16 @@
         <%= t('.users.can_delete_sole_owned', default: "You can delete them, but please consider #{link_to "orphaning", archive_faq_path("orphaning")} them instead!").html_safe %>
       </p>
       <p>
-        <%= radio_button_tag 'sole_author', "keep_pseud", true %>
-        <%= label_tag 'sole_author_keep_pseud', 'Leave my pseud but attach to the orphan account' %>
+        <%= radio_button_tag :sole_author, :keep_pseud, true %>
+        <%= label_tag :sole_author_keep_pseud, 'Leave my pseud but attach to the orphan account' %>
       </p>
       <p>
-        <%= radio_button_tag 'sole_author', "orphan_pseud" %>
-        <%= label_tag 'sole_author_orphan_pseud', "Change my pseud to 'orphan' and attach to the orphan account" %>
+        <%= radio_button_tag :sole_author, :orphan_pseud %>
+        <%= label_tag :sole_author_orphan_pseud, "Change my pseud to 'orphan' and attach to the orphan account" %>
       </p>
       <p>
-        <%= radio_button_tag 'sole_author', "delete" %>
-        <%= label_tag 'sole_author_delete', 'Delete completely' %>
+        <%= radio_button_tag :sole_author, :delete %>
+        <%= label_tag :sole_author_delete, 'Delete completely' %>
       </p>
     </fieldset>
   <% end %>

--- a/app/views/users/delete_preview.html.erb
+++ b/app/views/users/delete_preview.html.erb
@@ -20,7 +20,7 @@
 </p>
 <p>
     <%= radio_button_tag 'coauthor', 'remove' %>
-    <%= label_tag 'coauthor_remove', 'Remove me completely as co-author' %>
+    <%= label_tag 'coauthor_remove', 'Remove me completely as co-creator' %>
 </p>
 </fieldset>
 <% end %>

--- a/app/views/users/delete_preview.html.erb
+++ b/app/views/users/delete_preview.html.erb
@@ -1,9 +1,9 @@
 <h2 class="heading"><%=h 'What do you want to do with your works?' %></h2>
 
-<%= form_tag(@user, :method => 'delete') do %>
+<%= form_tag(@user, method: 'delete') do %>
   <% unless @user.coauthors.blank? %>
     <fieldset>
-      <legend><%= t('.users.works_with_others', :default => "Works You Made With Others") %></legend>
+      <legend><%= t('.users.works_with_others', default: "Works You Made With Others") %></legend>
       <p>
         <%= "You have #{@coauthored_works.size} work(s) co-created with the following users: " + print_coauthors(@user)  + "." %>
       </p>
@@ -27,20 +27,20 @@
 
   <% unless @sole_authored_works.empty? && @sole_owned_collections.empty? %>
     <fieldset>
-      <legend><%= t('.users.by_self', :default => "Works and Collections You Made By Yourself") %></legend>
+      <legend><%= t('.users.by_self', default: "Works and Collections You Made By Yourself") %></legend>
       <p>
         <% unless @sole_authored_works.empty? %>
-          <%= t('.users.sole_authored_works', :default => "You have %{num_sole_authored} work(s) under the following pseuds: %{pseuds}.", :num_sole_authored => @sole_authored_works.size, :pseuds => print_pseuds(@user)) %>
+          <%= t('.users.sole_authored_works', default: "You have %{num_sole_authored} work(s) under the following pseuds: %{pseuds}.", num_sole_authored: @sole_authored_works.size, pseuds: print_pseuds(@user)) %>
         <% end %>
         <% unless @sole_owned_collections.empty? %>
           <% unless @sole_authored_works.empty? %><br /><% end %>
-          <%= t('.users.sole_owned_collections', :default => "You have %{num_sole_collections} collection(s) under the following pseuds: %{pseuds}.",
-            :num_sole_collections => @sole_owned_collections.size,
-            :pseuds => @sole_owned_collections.collect(&:all_owners).flatten.uniq.collect(&:name).join(", ")) %>
+          <%= t('.users.sole_owned_collections', default: "You have %{num_sole_collections} collection(s) under the following pseuds: %{pseuds}.",
+            num_sole_collections: @sole_owned_collections.size,
+            pseuds: @sole_owned_collections.collect(&:all_owners).flatten.uniq.collect(&:name).join(", ")) %>
         <% end %>
       </p>
       <p>
-        <%= t('.users.can_delete_sole_owned', :default => "You can delete them, but please consider #{link_to "orphaning", archive_faq_path("orphaning")} them instead!").html_safe %>
+        <%= t('.users.can_delete_sole_owned', default: "You can delete them, but please consider #{link_to "orphaning", archive_faq_path("orphaning")} them instead!").html_safe %>
       </p>
       <p>
         <%= radio_button_tag 'sole_author', "keep_pseud", true %>
@@ -59,7 +59,7 @@
 
   <fieldset>
     <p class="submit cancel actions">
-	   <%= submit_tag "Save", data: {confirm: "Are you sure? This can't be undone!"} %> <%= submit_tag 'Cancel', :name => 'cancel_button', :class => 'cancel' %>
+	   <%= submit_tag "Save", data: { confirm: "Are you sure? This can't be undone!" } %> <%= submit_tag 'Cancel', name: 'cancel_button', class: 'cancel' %>
     </p>
   </fieldset>
 <% end %>

--- a/app/views/users/delete_preview.html.erb
+++ b/app/views/users/delete_preview.html.erb
@@ -1,65 +1,65 @@
 <h2 class="heading"><%=h 'What do you want to do with your works?' %></h2>
 
 <%= form_tag(@user, :method => 'delete') do %>
-<% unless @user.coauthors.blank? %>
-<fieldset>
-	<legend><%= t('.users.works_with_others', :default => "Works You Made With Others") %></legend>
-<p>
-    <%= "You have #{@coauthored_works.size} work(s) co-created with the following users: " + print_coauthors(@user)  + "." %>
-</p>
-<p>
-    <%= "You are not able to delete these as they are shared works, but you can #{link_to "orphan", archive_faq_path("orphaning")} them or remove yourself completely as a co-creator.".html_safe %>
-</p>
-<p>
-    <%= radio_button_tag 'coauthor', 'keep_pseud', true %>
-    <%= label_tag 'coauthor_keep_pseud', 'Leave my pseud but attach to the orphan account' %>
-</p>
-<p>
-    <%= radio_button_tag 'coauthor', 'orphan_pseud' %>
-    <%= label_tag 'coauthor_orphan_pseud', "Change my pseud to 'orphan' and attach to the orphan account" %>
-</p>
-<p>
-    <%= radio_button_tag 'coauthor', 'remove' %>
-    <%= label_tag 'coauthor_remove', 'Remove me completely as co-creator' %>
-</p>
-</fieldset>
-<% end %>
-
-
-<% unless @sole_authored_works.empty? && @sole_owned_collections.empty? %>
-<fieldset>
-	<legend><%= t('.users.by_self', :default => "Works and Collections You Made By Yourself") %></legend>
-<p>
-  <% unless @sole_authored_works.empty? %>
-    <%= t('.users.sole_authored_works', :default => "You have %{num_sole_authored} work(s) under the following pseuds: %{pseuds}.", :num_sole_authored => @sole_authored_works.size, :pseuds => print_pseuds(@user)) %>
+  <% unless @user.coauthors.blank? %>
+    <fieldset>
+      <legend><%= t('.users.works_with_others', :default => "Works You Made With Others") %></legend>
+      <p>
+        <%= "You have #{@coauthored_works.size} work(s) co-created with the following users: " + print_coauthors(@user)  + "." %>
+      </p>
+      <p>
+        <%= "You are not able to delete these as they are shared works, but you can #{link_to "orphan", archive_faq_path("orphaning")} them or remove yourself completely as a co-creator.".html_safe %>
+      </p>
+      <p>
+        <%= radio_button_tag 'coauthor', 'keep_pseud', true %>
+        <%= label_tag 'coauthor_keep_pseud', 'Leave my pseud but attach to the orphan account' %>
+      </p>
+      <p>
+        <%= radio_button_tag 'coauthor', 'orphan_pseud' %>
+        <%= label_tag 'coauthor_orphan_pseud', "Change my pseud to 'orphan' and attach to the orphan account" %>
+      </p>
+      <p>
+        <%= radio_button_tag 'coauthor', 'remove' %>
+        <%= label_tag 'coauthor_remove', 'Remove me completely as co-creator' %>
+      </p>
+    </fieldset>
   <% end %>
-  <% unless @sole_owned_collections.empty? %>
-    <% unless @sole_authored_works.empty? %><br /><% end %>
-    <%= t('.users.sole_owned_collections', :default => "You have %{num_sole_collections} collection(s) under the following pseuds: %{pseuds}.",
+
+  <% unless @sole_authored_works.empty? && @sole_owned_collections.empty? %>
+    <fieldset>
+      <legend><%= t('.users.by_self', :default => "Works and Collections You Made By Yourself") %></legend>
+      <p>
+        <% unless @sole_authored_works.empty? %>
+          <%= t('.users.sole_authored_works', :default => "You have %{num_sole_authored} work(s) under the following pseuds: %{pseuds}.", :num_sole_authored => @sole_authored_works.size, :pseuds => print_pseuds(@user)) %>
+        <% end %>
+        <% unless @sole_owned_collections.empty? %>
+          <% unless @sole_authored_works.empty? %><br /><% end %>
+          <%= t('.users.sole_owned_collections', :default => "You have %{num_sole_collections} collection(s) under the following pseuds: %{pseuds}.",
             :num_sole_collections => @sole_owned_collections.size,
             :pseuds => @sole_owned_collections.collect(&:all_owners).flatten.uniq.collect(&:name).join(", ")) %>
+        <% end %>
+      </p>
+      <p>
+        <%= t('.users.can_delete_sole_owned', :default => "You can delete them, but please consider #{link_to "orphaning", archive_faq_path("orphaning")} them instead!").html_safe %>
+      </p>
+      <p>
+        <%= radio_button_tag 'sole_author', "keep_pseud", true %>
+        <%= label_tag 'sole_author_keep_pseud', 'Leave my pseud but attach to the orphan account' %>
+      </p>
+      <p>
+        <%= radio_button_tag 'sole_author', "orphan_pseud" %>
+        <%= label_tag 'sole_author_orphan_pseud', "Change my pseud to 'orphan' and attach to the orphan account" %>
+      </p>
+      <p>
+        <%= radio_button_tag 'sole_author', "delete" %>
+        <%= label_tag 'sole_author_delete', 'Delete completely' %>
+      </p>
+    </fieldset>
   <% end %>
-</p>
-<p>
-    <%= t('.users.can_delete_sole_owned', :default => "You can delete them, but please consider #{link_to "orphaning", archive_faq_path("orphaning")} them instead!").html_safe %>
-</p>
-<p>
-    <%= radio_button_tag 'sole_author', "keep_pseud", true %>
-    <%= label_tag 'sole_author_keep_pseud', 'Leave my pseud but attach to the orphan account' %>
-</p>
-<p>
-    <%= radio_button_tag 'sole_author', "orphan_pseud" %>
-    <%= label_tag 'sole_author_orphan_pseud', "Change my pseud to 'orphan' and attach to the orphan account" %>
-</p>
-<p>
-    <%= radio_button_tag 'sole_author', "delete" %>
-    <%= label_tag 'sole_author_delete', 'Delete completely' %>
-</p>
-</fieldset>
-<% end %>
-<fieldset>
-<p class="submit cancel actions">
-		<%= submit_tag "Save", data: {confirm: "Are you sure? This can't be undone!"} %> <%= submit_tag 'Cancel', :name => 'cancel_button', :class => 'cancel' %>
-</p>
-</fieldset>
+
+  <fieldset>
+    <p class="submit cancel actions">
+	   <%= submit_tag "Save", data: {confirm: "Are you sure? This can't be undone!"} %> <%= submit_tag 'Cancel', :name => 'cancel_button', :class => 'cancel' %>
+    </p>
+  </fieldset>
 <% end %>

--- a/app/views/users/delete_preview.html.erb
+++ b/app/views/users/delete_preview.html.erb
@@ -1,9 +1,9 @@
-<h2 class="heading"><%=h 'What do you want to do with your works?' %></h2>
+<h2 class="heading"><%=h "What do you want to do with your works?" %></h2>
 
 <%= form_tag(@user, method: :delete) do %>
   <% unless @user.coauthors.blank? %>
     <fieldset>
-      <legend><%= t('.users.works_with_others', default: "Works You Made With Others") %></legend>
+      <legend><%= t(".users.works_with_others", default: "Works You Made With Others") %></legend>
       <p>
         <%= "You have #{@coauthored_works.size} work(s) co-created with the following users: " + print_coauthors(@user)  + "." %>
       </p>
@@ -12,7 +12,7 @@
       </p>
       <p>
         <%= radio_button_tag :coauthor, :keep_pseud, true %>
-        <%= label_tag :coauthor_keep_pseud, 'Leave my pseud but attach to the orphan account' %>
+        <%= label_tag :coauthor_keep_pseud, "Leave my pseud but attach to the orphan account" %>
       </p>
       <p>
         <%= radio_button_tag :coauthor, :orphan_pseud %>
@@ -20,31 +20,31 @@
       </p>
       <p>
         <%= radio_button_tag :coauthor, :remove %>
-        <%= label_tag :coauthor_remove, 'Remove me completely as co-creator' %>
+        <%= label_tag :coauthor_remove, "Remove me completely as co-creator" %>
       </p>
     </fieldset>
   <% end %>
 
   <% unless @sole_authored_works.empty? && @sole_owned_collections.empty? %>
     <fieldset>
-      <legend><%= t('.users.by_self', default: "Works and Collections You Made By Yourself") %></legend>
+      <legend><%= t(".users.by_self", default: "Works and Collections You Made By Yourself") %></legend>
       <p>
         <% unless @sole_authored_works.empty? %>
-          <%= t('.users.sole_authored_works', default: "You have %{num_sole_authored} work(s) under the following pseuds: %{pseuds}.", num_sole_authored: @sole_authored_works.size, pseuds: print_pseuds(@user)) %>
+          <%= t(".users.sole_authored_works", default: "You have %{num_sole_authored} work(s) under the following pseuds: %{pseuds}.", num_sole_authored: @sole_authored_works.size, pseuds: print_pseuds(@user)) %>
         <% end %>
         <% unless @sole_owned_collections.empty? %>
           <% unless @sole_authored_works.empty? %><br /><% end %>
-          <%= t('.users.sole_owned_collections', default: "You have %{num_sole_collections} collection(s) under the following pseuds: %{pseuds}.",
+          <%= t(".users.sole_owned_collections", default: "You have %{num_sole_collections} collection(s) under the following pseuds: %{pseuds}.",
             num_sole_collections: @sole_owned_collections.size,
             pseuds: @sole_owned_collections.collect(&:all_owners).flatten.uniq.collect(&:name).join(", ")) %>
         <% end %>
       </p>
       <p>
-        <%= t('.users.can_delete_sole_owned', default: "You can delete them, but please consider #{link_to "orphaning", archive_faq_path("orphaning")} them instead!").html_safe %>
+        <%= t(".users.can_delete_sole_owned", default: "You can delete them, but please consider #{link_to "orphaning", archive_faq_path("orphaning")} them instead!").html_safe %>
       </p>
       <p>
         <%= radio_button_tag :sole_author, :keep_pseud, true %>
-        <%= label_tag :sole_author_keep_pseud, 'Leave my pseud but attach to the orphan account' %>
+        <%= label_tag :sole_author_keep_pseud, "Leave my pseud but attach to the orphan account" %>
       </p>
       <p>
         <%= radio_button_tag :sole_author, :orphan_pseud %>
@@ -52,14 +52,14 @@
       </p>
       <p>
         <%= radio_button_tag :sole_author, :delete %>
-        <%= label_tag :sole_author_delete, 'Delete completely' %>
+        <%= label_tag :sole_author_delete, "Delete completely" %>
       </p>
     </fieldset>
   <% end %>
 
   <fieldset>
     <p class="submit cancel actions">
-	   <%= submit_tag "Save", data: { confirm: "Are you sure? This can't be undone!" } %> <%= submit_tag 'Cancel', name: 'cancel_button', class: 'cancel' %>
+	   <%= submit_tag "Save", data: { confirm: "Are you sure? This can't be undone!" } %> <%= submit_tag "Cancel", name: "cancel_button", class: "cancel" %>
     </p>
   </fieldset>
 <% end %>

--- a/features/users/user_delete.feature
+++ b/features/users/user_delete.feature
@@ -86,7 +86,7 @@ Scenario: Delete a user who has coauthored a work
     And I wait 1 second
   When I try to delete my account
   Then I should see "What do you want to do with your works?"
-  When I choose "Remove me completely as co-author"
+  When I choose "Remove me completely as co-creator"
     And I press "Save"
   Then I should see "You have successfully deleted your account"
     And a user account should not exist for "testuser"


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5688

## Purpose

* Changes remaining "co-author" to "co-creator."
* Improves indenting/spacing.
* Stops using hash rockets.
* Uses symbols rather than strings where possible.
* Uses double quotes for strings.

## References

If you're feeling adventurous, I also have a version that makes it mostly translatable: https://github.com/otwcode/otwarchive/compare/master...sarken:AO3-5688_BOT_i18n?expand=1 ("Mostly" because I didn't change the way it handles the list of pseuds.)