### PR TITLE
AO3-5652 Index more series data

### DIFF
--- a/app/models/search/work_indexer.rb
+++ b/app/models/search/work_indexer.rb
@@ -26,8 +26,8 @@ class WorkIndexer < Indexer
           tag: {
             type: "text"
           },
-          series_titles: {
-            type: "text"
+          series: {
+            type: "object"
           },
           authors_to_sort_on: {
             type: "keyword"
@@ -88,7 +88,17 @@ class WorkIndexer < Indexer
         :nonfiction
       ]
     ).merge(
-      series_titles: object.series.pluck(:title)
+      series: series_data(object)
     )
+  end
+
+  def series_data(object)
+    object.serial_works.with_title.map do |s|
+      {
+        id: s.series_id,
+        title: s.title,
+        position: s.position
+      }
+    end
   end
 end

--- a/app/models/search/work_indexer.rb
+++ b/app/models/search/work_indexer.rb
@@ -92,13 +92,12 @@ class WorkIndexer < Indexer
     )
   end
 
+  # Pluck the desired series data and then turn it back
+  # into a hash
   def series_data(object)
-    object.serial_works.with_title.map do |s|
-      {
-        id: s.series_id,
-        title: s.title,
-        position: s.position
-      }
+    series_attrs = [:id, :title, :position]
+    object.series.pluck(*series_attrs).map do |values|
+      series_attrs.zip(values).to_h
     end
   end
 end

--- a/app/models/search/work_query.rb
+++ b/app/models/search/work_query.rb
@@ -39,8 +39,7 @@ class WorkQuery < Query
   # In this case, name is the only text field
   def queries
     @queries = [
-      general_query,
-      series_query
+      general_query
     ].flatten.compact
   end
 
@@ -249,22 +248,16 @@ class WorkQuery < Query
     } unless query.blank?
   end
 
-  def series_query
-    return unless options[:series_titles].present?
-    {
-      query_string: {
-        query: options[:series_titles],
-        fields: ["series.title"],
-        default_operator: "AND"
-      }
-    }
-  end
-
   def generate_search_text(query = '')
     search_text = query
     %i[title creators].each do |field|
       search_text << split_query_text_words(field, options[field])
     end
+
+    if options[:series_titles].present?
+      search_text << split_query_text_words("series.title", options[:series_titles])
+    end
+
     if options[:collection_ids].blank? && collected?
       search_text << " collection_ids:*"
     end

--- a/app/models/serial_work.rb
+++ b/app/models/serial_work.rb
@@ -12,11 +12,6 @@ class SerialWork < ApplicationRecord
 
   scope :in_order, -> { order(:position) }
 
-  def self.with_title
-    select("*, series.title AS title").
-    joins(:series)
-  end
-
   # If you add or remove a work from a series, make sure restricted? is still accurate
   def adjust_series_visibility
     self.series.adjust_restricted unless self.series.blank?

--- a/app/models/serial_work.rb
+++ b/app/models/serial_work.rb
@@ -12,6 +12,11 @@ class SerialWork < ApplicationRecord
 
   scope :in_order, -> { order(:position) }
 
+  def self.with_title
+    select("*, series.title AS title").
+    joins(:series)
+  end
+
   # If you add or remove a work from a series, make sure restricted? is still accurate
   def adjust_series_visibility
     self.series.adjust_restricted unless self.series.blank?

--- a/spec/models/search/work_search_form_spec.rb
+++ b/spec/models/search/work_search_form_spec.rb
@@ -193,20 +193,26 @@ describe WorkSearchForm do
       context "using the \"query\" field" do
         before { run_all_indexing_jobs }
 
+        it "works with general queries" do
+          results = WorkSearchForm.new(query: "dancing").search_results
+          expect(results).to include(work)
+          expect(results).not_to include(second_work, standalone_work)
+        end
+
         it "returns only works in matching series" do
-          results = WorkSearchForm.new(query: "series_titles: dancing").search_results
+          results = WorkSearchForm.new(query: "series.title: dancing").search_results
           expect(results).to include(work)
           expect(results).not_to include(second_work, standalone_work)
         end
 
         it "returns only works in matching series with numbers in titles" do
-          results = WorkSearchForm.new(query: "series_titles: \"persona 5\"").search_results
+          results = WorkSearchForm.new(query: "series.title: \"persona 5\"").search_results
           expect(results).to include(second_work)
           expect(results).not_to include(work, standalone_work)
         end
 
         it "returns all works in series for wildcard queries" do
-          results = WorkSearchForm.new(query: "series_titles: *").search_results
+          results = WorkSearchForm.new(query: "series.title: *").search_results
           expect(results).to include(work, second_work)
           expect(results).not_to include(standalone_work)
         end


### PR DESCRIPTION

## Issue

https://otwarchive.atlassian.net/browse/AO3-5652

## Purpose

Slightly changes and expands the series data being indexed with works. The behavior should be similar (with a small change from "series_titles:" to "series.title:") but the extra data should give us more to work with later on. General searches should also include the series title field, though at a lower priority than the work title.

## Testing Instructions

See instructions in issue.

## Credit

elz and redsummernight