### PR TITLE
AO3-5613 Fix revealing hidden warning tags in work meta

### DIFF
--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -159,6 +159,7 @@ class TagsController < ApplicationController
                         end
       end
 
+      # The string used in views/tags/show_hidden.js.erb
       if params[:tag_type] == 'warnings'
         @display_category = 'warnings'
       else

--- a/app/helpers/tags_helper.rb
+++ b/app/helpers/tags_helper.rb
@@ -187,9 +187,7 @@ module TagsHelper
     sub_ul.html_safe
   end
 
-
   def blurb_tag_block(item, tag_groups=nil)
-    item_class = item.class.to_s.underscore
     tag_groups ||= item.tag_groups
     categories = ['ArchiveWarning', 'Relationship', 'Character', 'Freeform']
     tag_block = ""
@@ -197,12 +195,9 @@ module TagsHelper
     categories.each do |category|
       if tags = tag_groups[category]
         unless tags.empty?
-          class_name = category == "ArchiveWarning" ? "warnings" : category.downcase.pluralize
-
+          class_name = tag_block_class_name(category)
           if (class_name == "warnings" && hide_warnings?(item)) || (class_name == "freeforms" && hide_freeform?(item))
-            open_tags = "<li class='#{class_name}' id='#{item_class}_#{item.id}_category_#{class_name}'><strong>"
-            close_tags = "</strong></li>"
-            tag_block <<  open_tags + show_hidden_tags_link(item, class_name) + close_tags
+            tag_block << show_hidden_tag_link_list_item(item, category)
           elsif class_name == "warnings"
             open_tags = "<li class='#{class_name}'><strong>"
             close_tags = "</strong></li>"
@@ -216,6 +211,28 @@ module TagsHelper
       end
     end
     tag_block.html_safe
+  end
+
+  # Takes a tag category class name, e.g. Relationship, and returns a string.
+  # The returned string is plural and used for things other than the HTML class
+  # attribute, which is why we don't use tag_type_css_class(tag_type).
+  def tag_block_class_name(category)
+    if category == "ArchiveWarning"
+      "warnings"
+    else
+      category.downcase.pluralize
+    end
+  end
+
+  # Wraps hidden tags toggle in <li> and <strong> tags for blurbs and work meta.
+  def show_hidden_tag_link_list_item(item, category, options = {})
+    item_class = item.class.to_s.underscore
+    class_name = tag_block_class_name(category)
+    content_tag(:li,
+                content_tag(:strong, 
+                            show_hidden_tags_link(item, class_name)),
+                class: class_name,
+                id: "#{item_class}_#{item.id}_category_#{class_name}")
   end
 
   def get_title_string(tags, category_name = "")

--- a/app/helpers/tags_helper.rb
+++ b/app/helpers/tags_helper.rb
@@ -214,7 +214,7 @@ module TagsHelper
   end
 
   # Takes a tag category class name, e.g. Relationship, and returns a string.
-  # The returned string is plural and used for things other than the HTML class
+  # The returned string is plural and used for more than the HTML class
   # attribute, which is why we don't use tag_type_css_class(tag_type).
   def tag_block_class_name(category)
     if category == "ArchiveWarning"

--- a/app/helpers/tags_helper.rb
+++ b/app/helpers/tags_helper.rb
@@ -225,13 +225,15 @@ module TagsHelper
   end
 
   # Wraps hidden tags toggle in <li> and <strong> tags for blurbs and work meta.
+  # options[:suppress_toggle_class] is used to skip placing an HTML class on the
+  # toggle in work meta. The class will still be on the tags.
   def show_hidden_tag_link_list_item(item, category, options = {})
     item_class = item.class.to_s.underscore
     class_name = tag_block_class_name(category)
     content_tag(:li,
                 content_tag(:strong, 
                             show_hidden_tags_link(item, class_name)),
-                class: class_name,
+                class: options[:suppress_toggle_class] ? nil : class_name,
                 id: "#{item_class}_#{item.id}_category_#{class_name}")
   end
 

--- a/app/views/tags/show_hidden.js.erb
+++ b/app/views/tags/show_hidden.js.erb
@@ -1,6 +1,6 @@
 <%
 last_tag = @display_tags.last
-if @display_category == 'archive_warnings'
+if @display_category == 'warnings'
   open_tags = "<li class=\"#{@display_category}\"><strong>"
   closing_tags = "</strong></li>"
 else

--- a/app/views/works/_meta.html.erb
+++ b/app/views/works/_meta.html.erb
@@ -1,4 +1,4 @@
-<% cache("/v2/#{work.cache_key}-#{Work.work_blurb_tag_cache(work.id)}-meta-#{hide_warnings?(work) ? 'nowarn' : 'showwarn'}-#{hide_freeform?(work)  ? 'nofreeform' : 'showfreeform'}", skip_digest: true) do %>
+<% cache("/v3/#{work.cache_key}-#{Work.work_blurb_tag_cache(work.id)}-meta-#{hide_warnings?(work) ? 'nowarn' : 'showwarn'}-#{hide_freeform?(work)  ? 'nofreeform' : 'showfreeform'}", skip_digest: true) do %>
 <h3 class="landmark heading"><%= ts("Work Header") %></h3>
 
 <div class="wrapper">

--- a/app/views/works/_meta.html.erb
+++ b/app/views/works/_meta.html.erb
@@ -22,8 +22,7 @@
           <dd class="<%= tag_type_css_class(type) %> tags">
             <ul class="commas">
               <% if (type == "ArchiveWarning" && hide_warnings?(work)) || (type == "Freeform" && hide_freeform?(work)) %>
-
-                <li id="work_<%= work.id %>_category_<%= type.tableize %>"><%= show_hidden_tags_link(work, type.tableize) %> </li>
+                <%= show_hidden_tag_link_list_item(work, type) %>
              <% else %>
                <%= tag_link_list(tags, link_to_works=true) %>
              <% end %>

--- a/app/views/works/_meta.html.erb
+++ b/app/views/works/_meta.html.erb
@@ -22,7 +22,7 @@
           <dd class="<%= tag_type_css_class(type) %> tags">
             <ul class="commas">
               <% if (type == "ArchiveWarning" && hide_warnings?(work)) || (type == "Freeform" && hide_freeform?(work)) %>
-                <%= show_hidden_tag_link_list_item(work, type) %>
+                <%= show_hidden_tag_link_list_item(work, type, { suppress_toggle_class: true }) %>
              <% else %>
                <%= tag_link_list(tags, link_to_works=true) %>
              <% end %>

--- a/features/other_a/preferences_edit.feature
+++ b/features/other_a/preferences_edit.feature
@@ -43,7 +43,7 @@ Feature: Edit preferences
     And I should see "Turn off the banner showing on every page."
 
 
-  Scenario: View and edit preferences - viewing history, personal details, view entire work
+  Scenario: View and edit preferences for viewing history, personal details, view entire work
 
   Given the following activated user exists
     | login         | password   |
@@ -99,318 +99,244 @@ Feature: Edit preferences
     And I follow "This has two chapters"
   Then I should not see "Secondy chapter"
 
-  Scenario: View and edit preferences - show/hide warnings and tags
+  @javascript
+  Scenario: User can hide warning and freeform tags and reveal them on a case-
+  by-case basis.
 
-  # set preference
-  Given the following activated users exist
-    | login          | password   |
-    | mywarning1     | password   |
-    | mywarning2     | password   |
-    And a fandom exists with name: "Stargate SG-1", canonical: true
-  When I am logged in as "mywarning1" with password "password"
-  When I post the work "This work has warnings and tags" with fandom "Stargate SG-1, Stargate SG-2"
-    And I follow "Edit"
-    And I check "series-options-show"
-    And I fill in "work_series_attributes_title" with "My new series"
-    And I press "Preview"
-    And I press "Update"
-  Then I should see "Work was successfully updated"
-  When I log out
-  When I am logged in as "mywarning2" with password "password"
-    And I post the work "This also has warnings and tags" with fandom "Stargate SG-1, Stargate SG-2" with freeform "Scarier"
-  When I view the work "This work has warnings and tags"
-    And I follow "Bookmark"
-    And I press "Create"
-  Then I should see "Bookmark was successfully created"
-  When I follow "This work has warnings and tags"
-    And I follow "My new series"
-    And I follow "Bookmark Series"
-    And I press "Create"
-  Then I should see "Bookmark was successfully created"
+  Given I limit myself to the Archive
+    And I am logged in as "someone_else"
+    And I post the work "Someone Else's Work" as part of a series "A Series"
+    And I am logged in as "tester"
+    And I post the work "My Work"
+    And I bookmark the work "Someone Else's Work"
 
-  # see everything on works index and show page
-  When I go to the works page
-  Then I should see "No Archive Warnings Apply"
-    And I should not see "Show warnings"
-    And I should see "Scary tag"
-    And I should not see "Show additional tags"
-  When I follow "This work has warnings and tags"
-  Then I should see "No Archive Warnings Apply" within "dl.work.meta"
-    And I should not see "Show warnings"
-    And I should see "Scary tag"
-    And I should not see "Show additional tags"
-  When I go to the works page
-    And I follow "This also has warnings and tags"
-  Then I should see "No Archive Warnings Apply" within "dl.work.meta"
-    And I should not see "Show warnings"
-    And I should see "Scarier"
-    And I should not see "Show additional tags"
-
-  # see everything on fandoms page, for both canonical and unwrangled fandoms, and bookmarks page and series page
-  When I follow "All Fandoms"
-  Then I should see "Stargate SG-1"
-    And I should see "Stargate SG-2"
-    # we are now looking at a canonical fandom tag
-  When all indexing jobs have been run
-    And I follow "Stargate SG-1"
-  Then I should see "This work has warnings and tags"
-    And I should see "This also has warnings and tags"
-    And I should see "No Archive Warnings Apply" within ".tags"
-    And I should not see "Show warnings"
-    And I should see "Scary tag"
-    And I should see "Scarier"
-    And I should not see "Show additional tags"
-    And I should see "Bookmarks" within "div.navigation.actions"
-    And I should see "Works" within "div.navigation.actions"
-  When I follow "All Fandoms"
-  # we are now looking at a non-canonical fandom tag
-    And I follow "Stargate SG-2"
-  Then I should see "This work has warnings and tags"
-    And I should see "This also has warnings and tags"
-    And I should see "No Archive Warnings Apply" within "div#main.tags-show"
-    And I should not see "Show warnings"
-    And I should see "Scary tag"
-    And I should see "Scarier"
-    And I should not see "Show additional tags"
-    And I should not see "Bookmarks" within "div.work ul.index li.own"
-    And I should not see "Works" within "div.work ul.index li.own"
-  When I follow "My new series"
-  Then I should see "This work has warnings and tags"
-    And I should not see "This also has warnings and tags"
-    And I should see "No Archive Warnings Apply" within "ul.series.work.index.group"
-    And I should not see "Show warnings"
-    And I should see "Scary tag"
-    And I should not see "Scarier"
-    And I should not see "Show additional tags"
-  # change preference to hide warnings
- When I go to mywarning2's user page
-    And I follow "Preferences"
-    And I check "Hide warnings"
-    And I press "Update"
+  # Change tester's preferences to hide warnings.
+  When I set my preferences to hide warnings
   Then I should see "Your preferences were successfully updated"
 
-  # hidden warnings on show page, except for your own works
-  When I go to the works page
-  Then I should see "No Archive Warnings Apply"
+  # Warnings are hidden on work meta, except on user's own works.
+  # We use a selector so it doesn't pick up the info in the Share box.
+  When I view the work "Someone Else's Work"
+  Then I should not see "No Archive Warnings Apply" within "dl.work.meta"
     And I should see "Show warnings"
-    And I should see "Scary tag"
-    And I should see "Scarier"
+    And I should see "Scary tag" within "dl.work.meta"
     And I should not see "Show additional tags"
-  When I follow "This work has warnings and tags"
-  Then I should not see "No Archive Warnings Apply" within "dl.work.meta.group"
-    And I should see "Show warnings"
-    And I should see "Scary tag"
-    And I should not see "Show additional tags"
-  When I go to the works page
-    And I follow "This also has warnings and tags"
-  Then I should see "No Archive Warnings Apply" within "dl.work.meta.group"
+  When I follow "Show warnings"
+  Then I should see "No Archive Warnings Apply" within "dl.work.meta"
+  When I view the work "My Work"
+  Then I should see "No Archive Warnings Apply" within "dl.work.meta"
     And I should not see "Show warnings"
-    And I should see "Scarier"
+    And I should see "Scary tag" within "dl.work.meta"
     And I should not see "Show additional tags"
 
-  # hidden warnings on fandoms page except for your own works, for both canonical and unwrangled fandoms
-  When I follow "All Fandoms"
-  Then I should see "Stargate SG-1"
-  # we're looking at a canonical tag preferences set to hide warnings
-  When I follow "Stargate SG-1"
-  Then I should see "This work has warnings and tags"
-    And I should see "This also has warnings and tags"
-    # we can see warnings on works that we created
-    And I should see "No Archive Warnings Apply" within ".own .tags"
-    # Commenting out the following line, because its impossible to get to the correct element.
-    # The functionality is being tested with the 'Show warnings' line, which lets us know that
-    # tags on works that don't belong to us are being hidden.
-    # And I should not see "No Archive Warnings Apply" within "div#main ol.work li.work ul.tags"
-    And I should see "No Archive Warnings Apply" within "div#main ol.work li.own ul.tags"
+  # Warnings are hidden in work blurbs, except on user's own works.
+  When I go to someone_else's works page
+  Then I should see "Someone Else's Work" 
+    And I should not see "No Archive Warnings Apply" within "li.warnings"
     And I should see "Show warnings"
-    And I should see "Scary tag"
-    And I should see "Scarier"
+    And I should see "Scary tag" within "li.freeforms"
     And I should not see "Show additional tags"
-  When I follow "All Fandoms"
-  # we're looking at a non-canonical tag page, preferences set to hide warnings
-    And I follow "Stargate SG-2"
-  Then I should see "This work has warnings and tags"
-    And I should see "This also has warnings and tags"
-    And I should see "No Archive Warnings Apply" within ".own .tags"
-     And I should see "Show warnings"
-  Then I should see "Scary tag"
-    And I should see "Scarier"
-    And I should not see "Show additional tags"
-    # TODO: The next two steps were only passing before Issue 3909 because it was looking at the .navigation in the blurb -- a noncanonical tag page does not have .navigation at the top (where Bookmarks and Works are for canonical tags) unless you are logged in as a wrangler so this will always fail because it cannot find a #main .navigation li
-    # And I should not see "Bookmarks" within "#main .navigation li"
-    # And I should not see "Works" within "#main .navigation li"
-  When I follow "My new series"
-  Then I should see "This work has warnings and tags"
-    And I should not see "This also has warnings and tags"
-    And I should not see "No Archive Warnings Apply" within ".tags"
-    And I should see "Show warnings"
-    And I should see "Scary tag"
-    And I should not see "Scarier"
+  When I follow "Show warnings"
+  Then I should see "No Archive Warnings Apply" within "li.warnings"
+  When I go to my works page
+  Then I should see "My Work"
+    And I should see "No Archive Warnings Apply" within "li.warnings"
+    And I should not see "Show warnings"
+    And I should see "Scary tag" within "li.freeforms"
     And I should not see "Show additional tags"
 
-  # change preference to hide freeforms
-  When I go to mywarning2's user page
-    And I follow "Preferences"
+  # Warnings are hidden in series blurbs.
+  When I go to someone_else's series page
+  Then I should see "A Series"
+    And I should not see "No Archive Warnings Apply" within "li.warnings"
+    And I should see "Show warnings"
+    And I should see "Scary tag" within "li.freeforms"
+    And I should not see "Show additional tags"
+  When I follow "Show warnings"
+  Then I should see "No Archive Warnings Apply" within "li.warnings"
+
+  # Warnings are hidden in bookmark blurbs.
+  # This is slightly excessive -- bookmarks use the work blurb -- but we'll
+  # check in case that ever changes.
+  When I go to my bookmarks page
+  Then I should see "Someone Else's Work"
+    And I should not see "No Archive Warnings Apply" within "li.warnings"
+    And I should see "Show warnings"
+    And I should see "Scary tag" within "li.freeforms"
+    And I should not see "Show additional tags"
+  When I follow "Show warnings"
+  Then I should see "No Archive Warnings Apply" within "li.warnings"
+
+  # Change tester's preferences to hide freeforms as well as warnings.
+  When I go to my preferences page
     And I check "Hide additional tags"
     And I press "Update"
   Then I should see "Your preferences were successfully updated"
 
-  # hidden both on works index and show page, except for your own works
-  When I go to the works page
-  Then I should see "No Archive Warnings Apply"
+  # Freeforms and warnings are hidden on work meta, except for user's own works.
+  When I view the work "Someone Else's Work"
+  Then I should not see "No Archive Warnings Apply" within "dl.work.meta"
     And I should see "Show warnings"
-    And I should not see "Scary tag"
-    And I should see "Scarier"
+    And I should not see "Scary tag" within "dl.work.meta"
     And I should see "Show additional tags"
-  When I follow "This work has warnings and tags"
-  Then I should not see "No Archive Warnings Apply" within ".warning"
-    And I should see "Show warnings"
-    # The following line is commented out, because the test is seeing the text that
-    # would is in the 'Share' textarea. We need to rework this so we can somehow do a
-    # 'should not have this' UNLESS 'this'.
-    #And I should not see "Scary tag"
-    And I should see "Show additional tags"
-  When I go to the works page
-    And I follow "This also has warnings and tags"
-  Then I should see "No Archive Warnings Apply" within "dd.warning.tags"
+  When I follow "Show warnings"
+  Then I should see "No Archive Warnings Apply" within "dl.work.meta"
+    And I should not see "Scary tag" within "dl.work.meta"
+  When I follow "Show additional tags"
+  Then I should see "Scary tag" within "dl.work.meta"
+  When I view the work "My Work"
+  Then I should see "No Archive Warnings Apply" within "dl.work.meta"
     And I should not see "Show warnings"
-    And I should see "Scarier"
+    And I should see "Scary tag" within "dl.work.meta"
     And I should not see "Show additional tags"
 
-  # hidden both on fandoms page and bookmarks page, except for your own works, for both canonical and unwrangled fandoms
-  When I follow "All Fandoms"
-  Then I should see "Stargate SG-1"
-  When I follow "Stargate SG-1"
-  Then I should see "This work has warnings and tags"
-    And I should see "This also has warnings and tags"
-    And I should see "No Archive Warnings Apply" within ".own .tags"
-    # TODO: Figure out how to make this work
-    # And I should not see "No Archive Warnings Apply" within ".tags" when it's not ".own"
+  # Freeforms and warnings are hidden in work blurbs, except on user's own
+  # works.
+  When I go to someone_else's works page
+  Then I should see "Someone Else's Work" 
+    And I should not see "No Archive Warnings Apply" within "li.warnings"
     And I should see "Show warnings"
-    # TODO: Figure out how to make this work
-    And I should not see "Scary tag"
-    And I should see "Scarier"
+    And I should not see "Scary tag" within "li.freeforms"
     And I should see "Show additional tags"
-  When I follow "All Fandoms"
-  # we're looking at a non-canonical page, hiding freeforms and warnings
-    And I follow "Stargate SG-2"
-  Then I should see "This work has warnings and tags"
-    And I should see "This also has warnings and tags"
-    # Line below commented out because we're looking at two works with no way to differentiate between them
-    #And I should not see "No Archive Warnings Apply" within ".tags"
-     And I should see "Show warnings"
-  Then I should not see "Scary tag"
-    And I should see "Scarier"
-    And I should see "Show additional tags"
-    # TODO: The next two steps were only passing before Issue 3909 because it was looking at the .navigation in the blurb -- a noncanonical tag page does not have .navigation at the top (where Bookmarks and Works are for canonical tags) unless you are logged in as a wrangler so this will always fail because it cannot find a #main .navigation li
-    # And I should not see "Bookmarks" within "#main .navigation li"
-    # And I should not see "Works" within "#main .navigation li"
-  Then I should see "This work has warnings and tags"
-  When I follow "My new series"
-  Then I should see "This work has warnings and tags"
-    And I should not see "This also has warnings and tags"
-    And I should not see "No Archive Warnings Apply" within ".tags"
-    And I should see "Show warnings"
-    # Two lines below commented out because of the 'Share' textarea
-    #And I should not see "Scary tag"
-    #And I should not see "Scarier"
-    And I should see "Show additional tags"
+  When I follow "Show warnings"
+  Then I should see "No Archive Warnings Apply" within "li.warnings"
+    And I should not see "Scary tag" within "li.freeforms"
+  When I follow "Show additional tags"
+  Then I should see "Scary tag" within "li.freeforms"
+  When I go to my works page
+  Then I should see "My Work"
+    And I should see "No Archive Warnings Apply" within "li.warnings"
+    And I should not see "Show warnings"
+    And I should see "Scary tag" within "li.freeforms"
+    And I should not see "Show additional tags"
 
-  # change preference to show warnings, keep freeforms hidden
-  When I go to mywarning2's user page
-    And I follow "Preferences"
+  # Freeforms and warnings are hidden in series blurbs.
+  When I go to someone_else's series page
+  Then I should see "A Series"
+    And I should not see "No Archive Warnings Apply" within "li.warnings"
+    And I should see "Show warnings"
+    And I should not see "Scary tag" within "li.freeforms"
+    And I should see "Show additional tags"
+  When I follow "Show warnings"
+  Then I should see "No Archive Warnings Apply" within "li.warnings"
+    And I should not see "Scary tag" within "li.freeforms"
+  When I follow "Show additional tags"
+  Then I should see "Scary tag" within "li.freeforms"
+
+  # Freeforms and warnings are hidden in bookmark blurbs.
+  When I go to my bookmarks page
+  Then I should see "Someone Else's Work"
+    And I should not see "No Archive Warnings Apply" within "li.warnings"
+    And I should see "Show warnings"
+    And I should not see "Scary tag" within "li.freeforms"
+    And I should see "Show additional tags"
+  When I follow "Show warnings"
+  Then I should see "No Archive Warnings Apply" within "li.warnings"
+    And I should not see "Scary tag" within "li.freeforms"
+  When I follow "Show additional tags"
+  Then I should see "Scary tag" within "li.freeforms"
+
+  # Change tester's preferences to show warnings but keep freeforms hidden.
+  When I go to my preferences page
     And I uncheck "Hide warnings"
     And I press "Update"
   Then I should see "Your preferences were successfully updated"
 
-  # hidden only freeforms on works index and show page, except for your own works
-  When I go to the works page
-  Then I should see "No Archive Warnings Apply"
+  # Freeforms are hidden on work meta, except on user's own works.
+  When I view the work "Someone Else's Work"
+  Then I should see "No Archive Warnings Apply" within "dl.work.meta"
     And I should not see "Show warnings"
-    And I should not see "Scary tag"
-    And I should see "Scarier"
     And I should see "Show additional tags"
-  When I follow "This work has warnings and tags"
-  Then I should see "No Archive Warnings Apply" within "dd.warning.tags"
+    And I should not see "Scary tag" within "dl.work.meta"
+  When I follow "Show additional tags"
+  Then I should see "Scary tag" within "dl.work.meta"
+  When I view the work "My Work"
+  Then I should see "No Archive Warnings Apply" within "dl.work.meta"
     And I should not see "Show warnings"
-    #Commented out because of 'Share' textarea
-    #And I should not see "Scary tag"
-    And I should see "Show additional tags"
-  When I go to the works page
-    And I follow "This also has warnings and tags"
-  Then I should see "No Archive Warnings Apply" within "dd.warning.tags"
-    And I should not see "Show warnings"
-    And I should see "Scarier"
+    And I should see "Scary tag" within "dl.work.meta"
     And I should not see "Show additional tags"
 
-  # hidden only freeforms on fandoms page and bookmarks page, except for your own works, for both canonical and unwrangled fandoms
-  When I follow "All Fandoms"
-  Then I should see "Stargate SG-1"
-  When I follow "Stargate SG-1"
-  Then I should see "This work has warnings and tags"
-    And I should see "This also has warnings and tags"
-    And I should see "No Archive Warnings Apply" within ".tags"
+  # Freeforms are hidden in work blurbs, except on user's own works.
+  When I go to someone_else's works page
+  Then I should see "Someone Else's Work" 
+    And I should see "No Archive Warnings Apply" within "li.warnings"
     And I should not see "Show warnings"
-    And I should not see "Scary tag"
-    And I should see "Scarier"
+    And I should not see "Scary tag" within "li.freeforms"
     And I should see "Show additional tags"
-  When I follow "All Fandoms"
-  # we're looking at a non-canonical tag page
-    And I follow "Stargate SG-2"
-  Then I should see "This work has warnings and tags"
-    And I should see "This also has warnings and tags"
-    And I should see "No Archive Warnings Apply"
+  When I follow "Show additional tags"
+  Then I should see "Scary tag" within "li.freeforms"
+  When I go to my works page
+  Then I should see "My Work"
+    And I should see "No Archive Warnings Apply" within "li.warnings"
     And I should not see "Show warnings"
-  Then I should not see "Scary tag"
-    And I should see "Scarier"
-    And I should see "Show additional tags"
-    And I should not see "Bookmarks" within "div.work ul.index li.own"
-    And I should not see "Works" within "div.work ul.index li.own"
-  When I follow "My new series"
-  Then I should see "This work has warnings and tags"
-    And I should not see "This also has warnings and tags"
-    And I should see "No Archive Warnings Apply"
+    And I should see "Scary tag" within "li.freeforms"
+    And I should not see "Show additional tags"
+
+  # Freeforms are hidden in series blurbs.
+  When I go to someone_else's series page
+  Then I should see "A Series"
+    And I should see "No Archive Warnings Apply" within "li.warnings"
     And I should not see "Show warnings"
-    And I should not see "Scary tag"
-    And I should not see "Scarier"
+    And I should not see "Scary tag" within "li.freeforms"
     And I should see "Show additional tags"
+  When I follow "Show additional tags"
+  Then I should see "Scary tag" within "li.freeforms"
 
-  @javascript
-  Scenario: A user can see hidden tags
-    Given the following typed tags exists
-        | name                                   | type         | canonical |
-        | Cowboy Bebop                           | Fandom       | true      |
-        | Faye Valentine is a sweetie            | Freeform     | false     |
-        | Ed is a sweetie                        | Freeform     | false     |
-      And I am logged in as "first_user"
-      And I post the work "Asteroid Blues" with fandom "Cowboy Bebop" with freeform "Ed is a sweetie" with second freeform "Faye Valentine is a sweetie"
-      And I should see "Work was successfully posted."
-      And I am logged in as "second_user" with password "secure_password" with preferences set to hidden warnings and additional tags
-    When I view the work "Asteroid Blues"
-      And I follow "Show additional tags"
-    Then I should see "Additional Tags: Ed is a sweetie, Faye Valentine is a sweetie"
-     And I should not see "Show additional tags"
+  # Freeforms are hidden in bookmark blurbs.
+  When I go to my bookmarks page
+  Then I should see "Someone Else's Work"
+    And I should see "No Archive Warnings Apply" within "li.warnings"
+    And I should not see "Show warnings"
+    And I should not see "Scary tag" within "li.freeforms"
+    And I should see "Show additional tags"
+  When I follow "Show additional tags"
+  Then I should see "Scary tag" within "li.freeforms"
 
-  @javascript
-  Scenario: A user can see hidden tags on a series
+  Scenario: User can hide warning and freeform tags on work blurbs and meta with
+  JavaScript disabled, but gets an error if they attempt to reveal them.
 
-    Given the following typed tags exists
-        | name                                   | type         | canonical |
-        | Cowboy Bebop                           | Fandom       | true      |
-        | Faye Valentine is a sweetie            | Freeform     | false     |
-        | Ed is a sweetie                        | Freeform     | false     |
-      And I limit myself to the Archive
-      And I am logged in as "first_user"
-      And I post the work "Asteroid Blues" with fandom "Cowboy Bebop" with freeform "Ed is a sweetie" as part of a series "Cowboy Bebop Blues"
-      And I post the work "Wild Horses" with fandom "Cowboy Bebop" with freeform "Faye Valentine is a sweetie" as part of a series "Cowboy Bebop Blues"
-    When I am logged in as "second_user" with password "secure_password" with preferences set to hidden warnings and additional tags
-      And I go to first_user's user page
-      And I follow "Cowboy Bebop Blues"
+    Given I am logged in as "first_user"
+      And I post the work "Asteroid Blues" with fandom "Cowboy Bebop" with freeform "Ed is a sweetie"
+    When I am logged in
+      And I set my preferences to hide both warnings and freeforms
+      And I go to first_user's works page
+
+    # Check hidden tags on the blurb
     Then I should see "Asteroid Blues"
-      And I should see "Wild Horses"
+      And I should not see "No Archive Warnings Apply" within "li.warnings"
       And I should not see "Ed is a sweetie"
     When I follow "Show additional tags"
-    Then I should see "Ed is a sweetie"
-      And I should not see "No Archive Warnings Apply" within "li.warnings"
+    Then I should see "Sorry, you need to have JavaScript enabled for this."
+      And I should see "Show additional tags"
     When I follow "Show warnings"
-    Then I should see "No Archive Warnings Apply" within "li.warnings"
+    Then I should see "Sorry, you need to have JavaScript enabled for this."
+      And I should see "Show warnings"
+
+    # Check hidden tags in the meta
+    When I view the work "Asteroid Blues"
+      And I follow "Show additional tags"
+    Then I should see "Sorry, you need to have JavaScript enabled for this."
+      And I should see "Show additional tags"
+    When I follow "Show warnings"
+    Then I should see "Sorry, you need to have JavaScript enabled for this."
+      And I should see "Show warnings"
+
+  Scenario: User can hide warning and freeform tags on series blurbs with
+  JavaScript disabled, but gets an error if they attempt to reveal them.
+
+    Given I am logged in as "first_user"
+      And I post the work "Asteroid Blues" with fandom "Cowboy Bebop" with freeform "Ed is a sweetie" as part of a series "Cowboy Bebop Blues"
+      And I post the work "Wild Horses" with fandom "Cowboy Bebop" with freeform "Faye Valentine is a sweetie" as part of a series "Cowboy Bebop Blues"
+    When I am logged in
+      And I set my preferences to hide both warnings and freeforms
+      And I go to first_user's series page
+    Then I should see "Cowboy Bebop Blues"
+      And I should not see "No Archive Warnings Apply" within "li.warnings"
+      And I should not see "Ed is a sweetie"
+      And I should not see "Faye Valentine is a sweetie"
+    When I follow "Show additional tags"
+    Then I should see "Sorry, you need to have JavaScript enabled for this."
+      And I should see "Show additional tags"
+    When I follow "Show warnings"
+    Then I should see "Sorry, you need to have JavaScript enabled for this."
+      And I should see "Show warnings"

--- a/features/step_definitions/preferences_steps.rb
+++ b/features/step_definitions/preferences_steps.rb
@@ -23,15 +23,15 @@ When /^I set my preferences to turn off notification emails for gifts$/ do
 end
 
 When /^I set my preferences to hide warnings$/ do
-  user = User.current_user
-  user.preference.hide_warnings = true
-  user.preference.save
+  step %{I follow "My Preferences"}
+  check("preference_hide_warnings")
+  click_button("Update")
 end
 
 When /^I set my preferences to hide freeform$/ do
-  user = User.current_user
-  user.preference.hide_freeform = true
-  user.preference.save
+  step %{I follow "My Preferences"}
+  check("preference_hide_freeform")
+  click_button("Update")
 end
 
 When /^I set my preferences to hide all hit counts$/ do
@@ -94,20 +94,6 @@ When /^I set my time zone to "([^"]*)"$/ do |time_zone|
   user.preference.save
 end
 
-When /^I set my preferences to hide warnings by browser$/ do
-  step %{I follow "My Preferences"}
-  check("preference[hide_warnings]")
-  click_button("Update")
-  step %{I should see "Your preferences were successfully updated"}
-end
-
-When /^I set my preferences to hide freeform by browser$/ do
-  step %{I follow "My Preferences"}
-  check("preference[hide_freeform]")
-  click_button("Update")
-  step %{I should see "Your preferences were successfully updated"}
-end
-
 When /^I set my preferences to automatically agree to my work being collected$/ do
   user = User.current_user
   user.preference.automatically_approve_collections = true
@@ -118,6 +104,13 @@ When /^I set my preferences to require my approval for my work to be collected$/
   user = User.current_user
   user.preference.automatically_approve_collections = false
   user.preference.save
+end
+
+When /^I set my preferences to hide both warnings and freeforms$/ do
+  step %{I follow "My Preferences"}
+  check("preference_hide_warnings")
+  check("preference_hide_freeform")
+  click_button("Update")
 end
 
 Given(/^the user "(.*?)" disallows co-creators$/) do |login|

--- a/features/step_definitions/user_steps.rb
+++ b/features/step_definitions/user_steps.rb
@@ -99,14 +99,9 @@ Given /^the user "([^"]*)" exists and has the role "([^"]*)"/ do |login, role|
   user.save
 end
 
-Given /^I am logged in as "([^"]*)" with password "([^"]*)"(?:( with preferences set to hidden warnings and additional tags))?$/ do |login, password, hidden|
+Given /^I am logged in as "([^"]*)" with password "([^"]*)"?$/ do |login, password|
   user = find_or_create_new_user(login, password)
   step("I am logged out")
-  if hidden.present?
-    user.preference.hide_warnings = true
-    user.preference.hide_freeform = true
-    user.preference.save
-  end
   step %{I am on the homepage}
   find_link('login-dropdown').click
 


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5613

https://otwarchive.atlassian.net/browse/AO3-5613?focusedCommentId=355413&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-355413

## Purpose

If you enable the “Hide warnings” preference, the “Show warnings” link in the work meta should once again show the warning tags.

* Grabs the tests from #3290, which originally revealed the problem.
* Refactors `blurb_tag_block(item, tag_groups=nil)` so the code branch responsible for handling the "Show warnings..." is a separate method (`show_hidden_tag_link_list_item(item, category, options = {})`).
* Updates views/works/_meta to use the new method.

There were a few variable names I wanted to change and some methods that could have had better names, but I wanted to keep it clear for the reviewer how the new code relates to the old. 

## Testing Instructions

* Enable the preference for hiding warning tags. 
* Go to a work and make sure you can still show the warnings.
* Make sure there are no changes to how tags on work blurbs display/function normally.

## References

I was originally going to put this in #3290, which can't be merged without this fix, but decided it was better to have it as a separate pull request.