### PR TITLE
AO3-5755 Prevent inbox reply form from jumping in Chrome

### DIFF
--- a/public/stylesheets/site/2.0/17-zone-home.css
+++ b/public/stylesheets/site/2.0/17-zone-home.css
@@ -96,4 +96,10 @@ form.inbox fieldset {
   clear: left;
 }
 
+/* AO3-5755: prevent reply form in inbox from jumping around when given focus in Chrome without affecting reply form on homepage */
+.inbox-show #reply-to-comment {
+  top: 0;
+  left: 0;
+}
+
 /*END== */


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5755

## Purpose

Stops the inbox reply form from jumping around when it has focus in Chrome.

## Testing Instructions

Refer to Jira.