### PR TITLE
AO3-5613 Prevent error when challenge assignment email contains warning tags

### DIFF
--- a/app/views/user_mailer/challenge_assignment_notification.html.erb
+++ b/app/views/user_mailer/challenge_assignment_notification.html.erb
@@ -32,7 +32,7 @@
       <% if chars %><%= style_bold(Character.human_attribute_name("name_with_colon", count: prompt.any_character ? 1 : tag_groups["Character"].count)) %> <%= chars %><br><% end %>
       <% if ships %><%= style_bold(Relationship.human_attribute_name("name_with_colon", count: prompt.any_relationship ? 1 : tag_groups["Relationship"].count)) %> <%= ships %><br><% end %>
       <% if ratings %><%= style_bold(Rating.human_attribute_name("name_with_colon")) %> <%= ratings %><br><% end %>
-      <% if warnings %><%= style_bold(ArchiveWarning.human_attribute_name("name_with_colon", count: prompt.any_archive_warning ? 1 : tag_groups["Warning"].count)) %> <%= warnings %><br><% end %>
+      <% if warnings %><%= style_bold(ArchiveWarning.human_attribute_name("name_with_colon", count: prompt.any_archive_warning ? 1 : tag_groups["ArchiveWarning"].count)) %> <%= warnings %><br><% end %>
       <% if categories %><%= style_bold(Category.human_attribute_name("name_with_colon", count: prompt.any_category ? 1 : tag_groups["Category"].count)) %> <%= categories %><br><% end %>
       <% if atags %><%= style_bold(Freeform.human_attribute_name("name_with_colon", count: prompt.any_freeform ? 1 : tag_groups["Freeform"].count)) %> <%= atags %><br><% end %>
       <% if otags %><%= style_bold("#{t(".optional_tags")}") %> <%= otags %><br><% end %>

--- a/app/views/user_mailer/challenge_assignment_notification.text.erb
+++ b/app/views/user_mailer/challenge_assignment_notification.text.erb
@@ -14,7 +14,7 @@
 <% chars = prompt.any_character ? t(".any") : tag_list(tag_groups["Character"]) %>
 <% ships = prompt.any_relationship ? t(".any") : tag_list(tag_groups["Relationship"]) %>
 <% ratings = prompt.any_rating ? t(".any") : (tag_groups["Rating"] ? get_title_string(tag_groups["Rating"]) : nil) %>
-<% warnings = prompt.any_archive_warning ? t(".any") : (tag_groups["Warning"] ? get_title_string(tag_groups["Warning"]) : nil) %>
+<% warnings = prompt.any_archive_warning ? t(".any") : (tag_groups["ArchiveWarning"] ? get_title_string(tag_groups["ArchiveWarning"]) : nil) %>
 <% categories = prompt.any_category ? t(".any") : (tag_groups["Category"] ? get_title_string(tag_groups["Category"]) : nil) %>
 <% atags = prompt.any_freeform ? t(".any") : tag_list(tag_groups["Freeform"]) %>
 <% otags = prompt.optional_tag_set ? tag_list(prompt.optional_tag_set.tags) : nil %>
@@ -26,7 +26,7 @@
 <%= Character.human_attribute_name("name_with_colon", count: prompt.any_character ? 1 : tag_groups["Character"].count) %> <%= chars %><% end %><% if ships %>
 <%= Relationship.human_attribute_name("name_with_colon", count: prompt.any_relationship ? 1 : tag_groups["Relationship"].count) %> <%= ships %><% end %><% if ratings %>
 <%= Rating.human_attribute_name("name_with_colon") %> <%= ratings %><% end %><% if warnings %>
-<%= ArchiveWarning.human_attribute_name("name_with_colon", count: prompt.any_archive_warning ? 1 : tag_groups["Warning"].count) %> <%= warnings %><% end %><% if categories %>
+<%= ArchiveWarning.human_attribute_name("name_with_colon", count: prompt.any_archive_warning ? 1 : tag_groups["ArchiveWarning"].count) %> <%= warnings %><% end %><% if categories %>
 <%= Category.human_attribute_name("name_with_colon", count: prompt.any_category ? 1 : tag_groups["Category"].count) %> <%= categories %><% end %><% if atags %>
 <%= Freeform.human_attribute_name("name_with_colon", count: prompt.any_freeform ? 1 : tag_groups["Freeform"].count) %> <%= atags %><% end %><% if otags %>
 <%= t ".optional_tags" %> <%= otags %><% end %><% if prompt.url && !prompt.url.blank? %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -106,6 +106,10 @@ en:
         other: "Warnings"
       work: "Work"
     attributes:
+      archive_warning:
+        name_with_colon:
+          one: "Warning:"
+          other: "Warnings:"
       category:
         name_with_colon:
           one: "Category:"
@@ -128,10 +132,6 @@ en:
         name_with_colon:
           one: "Relationship:"
           other: "Relationships:"
-      warning:
-        name_with_colon:
-          one: "Warning:"
-          other: "Warnings:"
       creatorships:
         pseud_id: "Pseud"
         base: "Invalid creator:"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -78,6 +78,9 @@ en:
             pseud_id:
               taken: "is already listed as a creator."
     models:
+      archive_warning:
+        one: "Warning"
+        other: "Warnings" 
       bookmark: "Bookmark"
       category:
         one: "Category"
@@ -101,9 +104,6 @@ en:
       tag:
         one: "Tag"
         other: "Tags"
-      warning:
-        one: "Warning"
-        other: "Warnings"
       work: "Work"
     attributes:
       archive_warning:

--- a/features/gift_exchanges/notification_emails.feature
+++ b/features/gift_exchanges/notification_emails.feature
@@ -52,3 +52,28 @@ Feature: Gift Exchange Notification Emails
       And "participant2" should receive 1 email
       And the notification message to "participant1" should escape the ampersand
       And the notification message to "participant2" should escape the ampersand
+
+  Scenario: Assignment notifications with warning tags work.
+    Given I have set up the gift exchange "Dark Fic Exchange"
+      And I check "Sign-up open?"
+      And I allow warnings in my gift exchange
+      And I submit
+
+    When I am logged in as "participant1"
+      And I start signing up for "Dark Fic Exchange"
+      And I check "No Archive Warnings Apply"
+      And I submit
+    Then I should see "Sign-up was successfully created."
+
+    When I am logged in as "participant2"
+      And I start signing up for "Dark Fic Exchange"
+      And I check "No Archive Warnings Apply"
+      And I submit
+    Then I should see "Sign-up was successfully created."
+
+    When I close signups for "Dark Fic Exchange"
+      And I have generated matches for "Dark Fic Exchange"
+      And I have sent assignments for "Dark Fic Exchange"
+
+    Then "participant1" should receive 1 email
+      And the notification message to "participant1" should contain the no archive warnings tag

--- a/features/step_definitions/challege_gift_exchange_steps.rb
+++ b/features/step_definitions/challege_gift_exchange_steps.rb
@@ -92,6 +92,13 @@ When /^I fill in single-fandom gift exchange challenge options$/ do
   check("gift_exchange_offer_restriction_attributes_relationship_restrict_to_fandom")
 end
 
+When /^I allow warnings in my gift exchange$/ do
+  fill_in("gift_exchange_request_restriction_attributes_archive_warning_num_allowed", with: "1")
+  check("gift_exchange_request_restriction_attributes_allow_any_archive_warning")
+  fill_in("gift_exchange_offer_restriction_attributes_archive_warning_num_allowed", with: "1")
+  check("gift_exchange_offer_restriction_attributes_allow_any_archive_warning")
+end
+
 Then /^"([^\"]*)" gift exchange should be fully created$/ do |title|
   step %{I should see a create confirmation message}
   step %{"#{title}" collection exists}

--- a/features/step_definitions/challenge_steps.rb
+++ b/features/step_definitions/challenge_steps.rb
@@ -251,6 +251,20 @@ Then /^the notification message to "([^\"]*)" should escape the ampersand$/ do |
   email.html_part.body.should_not =~ /The first thing & the second thing./
 end
 
+Then /^the notification message to "([^\"]*)" should contain the no archive warnings tag$/ do |user|
+  @user = User.find_by(login: user)
+  email = emails("to: \"#{email_for(@user.email)}\"").first
+  email.multipart?.should be == true
+
+  email.text_part.body.should =~ /Warning:/
+  email.text_part.body.should =~ /No Archive Warnings Apply/
+  email.text_part.body.should_not =~ /Name with colon/
+
+  email.html_part.body.should =~ /Warning:/
+  email.html_part.body.should =~ /No Archive Warnings Apply/
+  email.html_part.body.should_not =~ /Name with colon/
+end
+
 # Delete challenge
 
 Given /^the challenge "([^\"]*)" is deleted$/ do |challenge_title|


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5613

https://otwarchive.atlassian.net/browse/AO3-5613?focusedCommentId=355425&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-355425

## Purpose

Prevents error when sending challenge assignment emails containing warning tags. Also ensures the Warning or Warnings label shows up.

## Testing Instructions

* Create a gift exchange that allows users to including warnings in their requests and offers
* Have folks sign up for the exchange with warnings in requests and offers
* Run matching and send assignments

The participants should receive emails containing their assignment, including warning tags.