### PR TITLE
AO3-5632 Set Referrer-Policy header

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -80,7 +80,12 @@ module Otwarchive
 
     # Only send referrer information to ourselves
     config.action_dispatch.default_headers = {
-      'Referrer-Policy' => 'same-origin'
+      "Referrer-Policy" => "same-origin",
+      "X-Frame-Options" => "SAMEORIGIN",
+      "X-XSS-Protection" => "1; mode=block",
+      "X-Content-Type-Options" => "nosniff",
+      "X-Download-Options" => "noopen",
+      "X-Permitted-Cross-Domain-Policies" => "none"
     }
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -77,5 +77,10 @@ module Otwarchive
 
     # Bring the log under control
     config.lograge.enabled = true
+
+    # Only send referrer information to ourselves
+    config.action_dispatch.default_headers = {
+      'Referrer-Policy' => 'same-origin'
+    }
   end
 end

--- a/spec/miscellaneous/requests/security_headers_spec.rb
+++ b/spec/miscellaneous/requests/security_headers_spec.rb
@@ -1,0 +1,14 @@
+require "spec_helper"
+
+describe "Security headers", type: :request do
+  it "includes the required headers" do
+    get "/"
+    headers = response.headers
+    expect(headers["Referrer-Policy"]).to eq("same-origin")
+    expect(headers["X-Frame-Options"]).to eq("SAMEORIGIN")
+    expect(headers["X-XSS-Protection"]).to eq("1; mode=block")
+    expect(headers["X-Content-Type-Options"]).to eq("nosniff")
+    expect(headers["X-Download-Options"]).to eq("noopen")
+    expect(headers["X-Permitted-Cross-Domain-Policies"]).to eq("none")
+  end
+end


### PR DESCRIPTION

## Issue

https://otwarchive.atlassian.net/browse/AO3-5632

## Purpose

Adds a referrer policy to our headers.

## Testing Instructions

Check the response headers on staging when you request a page. See issue for details.