### PR TITLE
AO3-5788 Move Travis to Ubuntu Bionic 18.04

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 sudo: required
-dist: xenial
+dist: bionic
 
 language: ruby
 cache: bundler

--- a/script/travis_ebook_converters.sh
+++ b/script/travis_ebook_converters.sh
@@ -5,8 +5,8 @@ sudo apt-get update -qq
 
 # PDF
 sudo apt-get install -qq xfonts-75dpi xfonts-base
-wget https://downloads.wkhtmltopdf.org/0.12/0.12.5/wkhtmltox_0.12.5-1.xenial_amd64.deb
-sudo dpkg -i ./wkhtmltox_0.12.5-1.xenial_amd64.deb
+wget https://downloads.wkhtmltopdf.org/0.12/0.12.5/wkhtmltox_0.12.5-1.bionic_amd64.deb
+sudo dpkg -i ./wkhtmltox_0.12.5-1.bionic_amd64.deb
 wkhtmltopdf --version
 
 # Calibre


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5788

## Purpose

[Bionic](https://docs.travis-ci.com/user/reference/bionic) is closer to the production environment (Debian 10).

Codeship is already on Bionic (#3529).

## Testing Instructions

None, automated.