### PR TITLE
AO3-4139 Reversi: Make notes on required fields easier to read

### DIFF
--- a/public/stylesheets/masters/reversi/reversi_site_screen_.css
+++ b/public/stylesheets/masters/reversi/reversi_site_screen_.css
@@ -329,6 +329,10 @@ fieldset fieldset.listbox {
   outline: none;
 }
 
+fieldset .footnote, .character_counter, #comment-field-description {
+  color:#FFF;
+}
+
 .mce-container input:focus {
   background: #F3EFEC;
 }

--- a/public/stylesheets/masters/reversi/reversi_site_screen_.css
+++ b/public/stylesheets/masters/reversi/reversi_site_screen_.css
@@ -329,8 +329,8 @@ fieldset fieldset.listbox {
   outline: none;
 }
 
-fieldset .footnote, .character_counter, #comment-field-description {
-  color:#FFF;
+form dd.required {
+  background: #eee;
 }
 
 .mce-container input:focus {


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-4139

## Purpose

the notes on required fields are hard to read - this PR changes the text colour to white so that it can be read more easily

## Testing Instructions

set your site skin to reversi, then try creating a new work or a new collection, and check that the notes on required fields have white text