### PR TITLE
AO3-5791 Restrict width of user-inserted images

### DIFF
--- a/public/stylesheets/site/2.0/21-userstuff.css
+++ b/public/stylesheets/site/2.0/21-userstuff.css
@@ -178,8 +178,4 @@
 	margin-bottom: 1.286em;
 }
 
-.news .userstuff img {
-  max-width: 100%;
-}
-
 /*END== */

--- a/public/stylesheets/site/2.0/21-userstuff.css
+++ b/public/stylesheets/site/2.0/21-userstuff.css
@@ -139,6 +139,11 @@
   border: 1px solid;
 }
 
+.userstuff img {
+  max-width: 100%;
+  height: auto;
+}
+
 /*expected behaviours, exceptioning*/
 
 /* WORK MARGINS */


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5791

## Purpose

Makes it so images in works, admin posts, etc can only be 100% of the container's width to avoid overflow/horizontal scrolling on screens smaller than the images. 

## Testing Instructions

Refer to Jira.

## References

~Don't merge until the post is ready -- hence "Deferred or Superseded."~ Post is ready! Just needs to go out a few days before deploy.