### PR TITLE
AO3-5773 Avoid re-escaping ampersands in titles of external work bookmarks

### DIFF
--- a/app/models/external_work.rb
+++ b/app/models/external_work.rb
@@ -45,9 +45,8 @@ class ExternalWork < ApplicationRecord
   end
 
   # Allow encoded characters to display correctly in titles
-  before_save :decode_title
-  def decode_title
-    self.title = HTMLEntities.new.decode(self.title)
+  def title
+    read_attribute(:title).try(:html_safe)
   end
 
   ########################################################################

--- a/app/models/external_work.rb
+++ b/app/models/external_work.rb
@@ -44,6 +44,12 @@ class ExternalWork < ApplicationRecord
     self.update_attribute(:dead, true) unless url_active?(self.url)
   end
 
+  # Allow encoded characters to display correctly in titles
+  before_save :decode_title
+  def decode_title
+    self.title = HTMLEntities.new.decode(self.title)
+  end
+
   ########################################################################
   # VISIBILITY
   ########################################################################


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5773

## Purpose

External Works have some characters such as ampersands encoded when posting, even when attempting to edit as an Admin. This PR makes sure the special characters are saved to the DB instead of their HTML encoded versions.

## Testing Instructions

Just need to repeat the Jira ticket's steps on master vs on this branch.

## Credit

bird

*What pronouns do you prefer (she/her, he/him, zie/hir etc)?*

I like they :)
