### PR TITLE
AO3-5362 Move background logo down and right

### DIFF
--- a/public/stylesheets/site/2.0/05-region-main.css
+++ b/public/stylesheets/site/2.0/05-region-main.css
@@ -42,7 +42,7 @@ http://otwcode.github.com/docs/front_end_coding/patterns/supertypes
 }
 
 #main.session {
-  background: url("/images/logo.png") top left no-repeat;
+  background: url("/images/logo.png") 0.5em 3em no-repeat;
 }
 
 #main.errors h2 {


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5362

## Purpose

This commit moves the background image on the 'login' page down and to the
right. This stops the image from being overlapped by banners
(eg: the 'Please log in' banner).

The issue suggests 2em down and 2em right, but with these dimensions,
the banner still overlapped the logo, and on mobile screens,
the logo overlapped the login text on the right. 0.5em was as far as it
could go! 3em seems to be the minimum it should move down.

## Testing Instructions

*Without this patch applied, browse to:
http://127.0.0.1:7000/users/login

*Apply the patch, restart rails, refresh the page in the browser

*Try a few screen sizes in the web console 'responsive design' mode

## Credit

Name: Z
Pronouns: she/her or they/them