### PR TITLE
AO3-5796 Add prefers-color-scheme media query options for skins

### DIFF
--- a/app/models/skin.rb
+++ b/app/models/skin.rb
@@ -13,7 +13,7 @@ class Skin < ApplicationRecord
                  ]
 
   # any media types that are not a single alphanumeric word have to be specially handled in get_media_for_filename/parse_media_from_filename
-  MEDIA = %w(all screen handheld speech print braille embossed projection tty tv) + ['only screen and (max-width: 42em)'] + ['only screen and (max-width: 62em)']
+  MEDIA = %w(all screen handheld speech print braille embossed projection tty tv) + ['only screen and (max-width: 42em)', 'only screen and (max-width: 62em)', '(prefers-color-scheme: dark)', '(prefers-color-scheme: light)']
   IE_CONDITIONS = %w(IE IE5 IE6 IE7 IE8 IE9 IE8_or_lower)
   ROLES = %w(user override)
   ROLE_NAMES = {"user" => "add on to archive skin", "override" => "replace archive skin entirely"}
@@ -257,6 +257,10 @@ class Skin < ApplicationRecord
         "narrow"
       when m.match(/max-width: 62em/)
         "midsize"
+      when m.match(/prefers-color-scheme: dark/)
+        "dark"
+      when m.match(/prefers-color-scheme: light/)
+        "light"
       else
         m
       end
@@ -264,7 +268,11 @@ class Skin < ApplicationRecord
   end
 
   def parse_media_from_filename(media_string)
-    media_string.gsub(/narrow/, 'only screen and (max-width: 42em)').gsub(/midsize/, 'only screen and (max-width: 62em)').gsub('.', ', ')
+    media_string.gsub(/narrow/, 'only screen and (max-width: 42em)')
+      .gsub(/midsize/, 'only screen and (max-width: 62em)')
+      .gsub(/dark/, '(prefers-color-scheme: dark)')
+      .gsub(/light/, '(prefers-color-scheme: light)')
+      .gsub('.', ', ')
   end
 
   def parse_sheet_role(role_string)

--- a/app/models/skin.rb
+++ b/app/models/skin.rb
@@ -12,8 +12,14 @@ class Skin < ApplicationRecord
                    [ts("Work Skin"), "WorkSkin"],
                  ]
 
-  # any media types that are not a single alphanumeric word have to be specially handled in get_media_for_filename/parse_media_from_filename
-  MEDIA = %w(all screen handheld speech print braille embossed projection tty tv) + ['only screen and (max-width: 42em)', 'only screen and (max-width: 62em)', '(prefers-color-scheme: dark)', '(prefers-color-scheme: light)']
+  # any media types that are not a single alphanumeric word have to be specially
+  # handled in get_media_for_filename/parse_media_from_filename
+  MEDIA = %w(all screen handheld speech print braille embossed projection tty tv) + [
+    "only screen and (max-width: 42em)",
+    "only screen and (max-width: 62em)",
+    "(prefers-color-scheme: dark)",
+    "(prefers-color-scheme: light)"
+  ]
   IE_CONDITIONS = %w(IE IE5 IE6 IE7 IE8 IE9 IE8_or_lower)
   ROLES = %w(user override)
   ROLE_NAMES = {"user" => "add on to archive skin", "override" => "replace archive skin entirely"}
@@ -264,15 +270,15 @@ class Skin < ApplicationRecord
       else
         m
       end
-    }.join('.')
+    }.join(".")
   end
 
   def parse_media_from_filename(media_string)
-    media_string.gsub(/narrow/, 'only screen and (max-width: 42em)')
-      .gsub(/midsize/, 'only screen and (max-width: 62em)')
-      .gsub(/dark/, '(prefers-color-scheme: dark)')
-      .gsub(/light/, '(prefers-color-scheme: light)')
-      .gsub('.', ', ')
+    media_string.gsub(/narrow/, "only screen and (max-width: 42em)")
+      .gsub(/midsize/, "only screen and (max-width: 62em)")
+      .gsub(/dark/, "(prefers-color-scheme: dark)")
+      .gsub(/light/, "(prefers-color-scheme: light)")
+      .gsub(".", ", ")
   end
 
   def parse_sheet_role(role_string)

--- a/spec/models/skin_spec.rb
+++ b/spec/models/skin_spec.rb
@@ -165,23 +165,23 @@ describe Skin do
     end
 
     context "when a media query is provided" do
-      {
-        "allows all" => "all",
-        "allows screen" => "screen",
-        "allows handheld" => "handheld",
-        "allows speech" => "speech",
-        "allows print" => "print",
-        "allows braille" => "braille",
-        "allows embossed" => "embossed",
-        "allows projection" => "projection",
-        "allows tty" => "tty",
-        "allows tv" => "tv",
-        "allows only screen and (max-width: 42em)" => "only screen and (max-width: 42em)",
-        "allows only screen and (max-width: 62em)" => "only screen and (max-width: 62em)",
-        "allows (prefers-color-scheme: dark)" => "(prefers-color-scheme: dark)",
-        "allows (prefers-color-scheme: light)" => "(prefers-color-scheme: light)"
-      }.each_pair do |description, media_query|
-        it description do
+      [
+        "all",
+        "screen",
+        "handheld",
+        "speech",
+        "print",
+        "braille",
+        "embossed",
+        "projection",
+        "tty",
+        "tv",
+        "only screen and (max-width: 42em)",
+        "only screen and (max-width: 62em)",
+        "(prefers-color-scheme: dark)",
+        "(prefers-color-scheme: light)"
+      ].each do |media_query|
+        it "allows #{media_query}" do
           @skin.media = [media_query]
           expect(@skin.save).to be_truthy
           expect(@skin.errors[:base]).to be_empty

--- a/spec/models/skin_spec.rb
+++ b/spec/models/skin_spec.rb
@@ -164,13 +164,42 @@ describe Skin do
       expect(@skin.errors[:base].join(' ').match(/upload a screencap/)).to be_truthy
     end
 
-    it "should only allow valid media types" do
-      @skin.media = ["foobar"]
-      expect(@skin.save).not_to be_truthy
-      expect(@skin.errors[:base]).not_to be_empty
-      @skin.media = %w(screen print)
-      expect(@skin.save).to be_truthy
-      expect(@skin.errors[:base]).to be_empty
+    context "when a media query is provided" do
+      {
+        "allows all" => "all",
+        "allows screen" => "screen",
+        "allows handheld" => "handheld",
+        "allows speech" => "speech",
+        "allows print" => "print",
+        "allows braille" => "braille",
+        "allows embossed" => "embossed",
+        "allows projection" => "projection",
+        "allows tty" => "tty",
+        "allows tv" => "tv",
+        "allows only screen and (max-width: 42em)" => "only screen and (max-width: 42em)",
+        "allows only screen and (max-width: 62em)" => "only screen and (max-width: 62em)",
+        "allows (prefers-color-scheme: dark)" => "(prefers-color-scheme: dark)",
+        "allows (prefers-color-scheme: light)" => "(prefers-color-scheme: light)"
+      }.each_pair do |description, media_query|
+        it description do
+          @skin.media = [media_query]
+          expect(@skin.save).to be_truthy
+          expect(@skin.errors[:base]).to be_empty
+        end
+      end
+
+      {
+        "doesn't allow max-width that isn't whitelisted" => "only screen and (max-width: 1024px)",
+        "doesn't allow media that isn't whitelisted" => "(min-aspect-ratio: 8/5)",
+        "doesn't allow two whitelisted media combined with and instead of a comma" => "screen and (prefers-color-scheme: dark",
+        "doesn't allow combination of whitelisted media and non-whitelisted media" => "(prefers-color-scheme: dark), (monochrome)"
+      }.each_pair do |description, media_query|
+        it description do
+          @skin.media = [media_query]
+          expect(@skin.save).not_to be_truthy
+          expect(@skin.errors[:base]).not_to be_empty
+        end
+      end
     end
 
     it "should only allow valid roles" do


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5796

## Purpose

Adds two new media query options for site skins: prefers-color-scheme: light and prefers-color-scheme: dark. These will let users create skins that automatically apply when their OS color scheme is set a certain way.  

## Testing Instructions

Refer to Jira.