### PR TITLE
AO3-5758 Fix renamed cop in rubocop 0.72.0

### DIFF
--- a/config/.rubocop.yml
+++ b/config/.rubocop.yml
@@ -9,7 +9,7 @@ Bundler/OrderedGems:
 Layout/DotPosition:
   EnforcedStyle: leading
 
-Layout/IndentArray:
+Layout/IndentFirstArrayElement:
   EnforcedStyle: consistent
 
 Layout/MultilineMethodCallIndentation:


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5758

## Purpose

Fix this error:
```
Error: The `Layout/IndentArray` cop has been renamed to `Layout/IndentFirstArrayElement`.
(obsolete configuration found in .rubocop.yml, please update it)
```

## Testing Instructions

None.