### PR TITLE
AO3-5693 Allow standard html within audio and video tags

### DIFF
--- a/lib/html_cleaner.rb
+++ b/lib/html_cleaner.rb
@@ -218,8 +218,8 @@ module HtmlCleaner
 
   # Tags whose content we don't touch
   def dont_touch_content_tag?(tag)
-    %w(a abbr acronym address br dl h1 h2 h3 h4 h5 h6 hr img ol p
-       pre table ul).include?(tag)
+    %w(a abbr acronym address audio br dl h1 h2 h3 h4 h5 h6 hr img ol p
+       pre source table track video ul).include?(tag)
   end
 
   # Tags that don't contain content
@@ -236,14 +236,14 @@ module HtmlCleaner
 
   # Tags that can't be inside p tags
   def put_outside_p_tag?(tag)
-    %w(dl h1 h2 h3 h4 h5 h6 hr ol p pre table ul).include?(tag)
+    %w(audio dl h1 h2 h3 h4 h5 h6 hr ol p pre source table track ul video).include?(tag)
   end
 
   # Tags before and after which we don't want to convert linebreaks
   # into br's and p's
   def no_break_before_after_tag?(tag)
-    %w(blockquote br center dl div h1 h2 h3 h4 h5 h6
-       hr ol p pre table ul).include?(tag)
+    %w(audio blockquote br center dl div h1 h2 h3 h4 h5 h6
+       hr ol p pre source table track ul video).include?(tag)
   end
 
   # Traverse a Nokogiri document tree recursively in order to insert

--- a/lib/otw_sanitize/media_sanitizer.rb
+++ b/lib/otw_sanitize/media_sanitizer.rb
@@ -18,7 +18,9 @@ module OTWSanitize
     TRACK_ATTRIBUTES = %w[default kind label src srclang].freeze
 
     WHITELIST_CONFIG = {
-      elements: %w[audio video source track],
+      elements: %w[
+        audio video source track
+      ] + Sanitize::Config::ARCHIVE[:elements],
       attributes: {
         'audio'  => AUDIO_ATTRIBUTES,
         'video'  => VIDEO_ATTRIBUTES,
@@ -68,7 +70,8 @@ module OTWSanitize
       return unless media_node?
       return if blacklisted_source?
 
-      Sanitize.clean_node!(node, WHITELIST_CONFIG)
+      config = Sanitize::Config.merge(Sanitize::Config::ARCHIVE, WHITELIST_CONFIG)
+      Sanitize.clean_node!(node, config)
       { node_whitelist: [node] }
     end
 

--- a/spec/miscellaneous/lib/html_cleaner_spec.rb
+++ b/spec/miscellaneous/lib/html_cleaner_spec.rb
@@ -582,6 +582,21 @@ describe HtmlCleaner do
       end
     end
 
+    it "leaves audio tags alone" do
+      original = "<audio controls=\"controls\" crossorigin=\"anonymous\" preload=\"metadata\">
+  <source src=\"http://example.com/podfic.mp3\" type=\"audio/mpeg\"></source>
+  <p>Maybe you want to <a href=\"http://example.com/podfic.mp3\" rel=\"nofollow\">download this podfic instead</a>?</p>
+</audio>"
+      expect(sanitize_value(:content, original)).to eq(original)
+    end
+
+    it "leaves video tags alone" do
+      html = "<video><track>\n</track></video>"
+      result = add_paragraphs_to_text(html)
+      expect(result).not_to match("<p>")
+      expect(result).not_to match("<br")
+    end
+
     it "should not convert linebreaks after p tags" do
       result = add_paragraphs_to_text("<p>A</p>\n<p>B</p>\n\n<p>C</p>\n\n\n")
       doc = Nokogiri::HTML.fragment(result)

--- a/spec/miscellaneous/lib/media_sanitizer_spec.rb
+++ b/spec/miscellaneous/lib/media_sanitizer_spec.rb
@@ -59,6 +59,15 @@ describe OTWSanitize::MediaSanitizer do
         expect(content).to match("flower.webm")
       end
 
+      it "does not remove internal html" do
+        html = "<video>
+          <p>Follow <a href='/xyz'>my link</a></p>
+        </video>"
+        content = Sanitize.fragment(html, config)
+        expect(content).to match("<p>")
+        expect(content).to match("xyz")
+      end
+
       it "removes unwhitelisted attributes" do
         html = "
           <video>


### PR DESCRIPTION

## Issue

https://otwarchive.atlassian.net/browse/AO3-5693

## Purpose

Allows standard html within audio and video tags instead of stripping it out

## Testing Instructions

Post some html (paragraphs, links) within an audio or video tag

## Credit

co-credit @redsummernight 