### PR TITLE
AO3-5738 Update page that appears after account is set up

### DIFF
--- a/app/views/users/confirmation.html.erb
+++ b/app/views/users/confirmation.html.erb
@@ -1,17 +1,17 @@
 <!--Descriptive page name, messages and instructions-->
-<h2 class="heading"><%= ts("Account Created!") %></h2>
+<h2 class="heading"><%= ts("Almost Done!") %></h2>
 <!--/descriptions-->
 <!--main content-->
 <div class="userstuff">
   <p>
-    <%= ts("Within 24 hours, you should receive an email at the address you gave us. This will have the URL you need to go to in order to verify your account and complete the account creation process. You might want to add <strong>%{return_address}</strong> to your address book to make sure you get the mail.", return_address: ArchiveConfig.RETURN_ADDRESS).html_safe %>
+    <%= ts("You should soon receive a confirmation email at the address you gave us.  This will have the link you need to follow in order to activate your account and complete the account creation process.  The confirmation email will come from <strong>%{return_address}</strong> - you might want to add this to your address book to make sure you get the email.", return_address: ArchiveConfig.RETURN_ADDRESS).html_safe %>
   </p>
   <p>
-    <%= ts("If you don't hear from us within 24 hours, and you don't find our email in your spam filter, please <a href='%{support_path}'>drop us a line at Support</a>.", support_path: new_feedback_report_path).html_safe %>
+    <%= ts("If you haven't received this email within 24 hours, and you don't find our email in your spam filter or Social folder, please <a href='%{support_path}'>contact Support for help</a>.", support_path: new_feedback_report_path).html_safe %>
   </p>
   <p>
     <% # We do days_to_purge_unactivated * 7 because it's actually weeks %>
-    <%= ts("<strong>Important!</strong> You must verify your account within %{days_before_purge} days, or your registration will expire.", days_before_purge: AdminSetting.current.days_to_purge_unactivated? ? (AdminSetting.current.days_to_purge_unactivated * 7) : ArchiveConfig.DAYS_TO_PURGE_UNACTIVATED).html_safe %>
+    <%= ts("<strong>Important!</strong> You must confirm your email address within %{days_before_purge} days, or your account will expire.  If this happens, you can sign up again using the same invitation.", days_before_purge: AdminSetting.current.days_to_purge_unactivated? ? (AdminSetting.current.days_to_purge_unactivated * 7) : ArchiveConfig.DAYS_TO_PURGE_UNACTIVATED).html_safe %>
   </p>
   <p>
     <%= link_to ts('Return to Archive front page'), root_path %>

--- a/app/views/users/confirmation.html.erb
+++ b/app/views/users/confirmation.html.erb
@@ -4,14 +4,14 @@
 <!--main content-->
 <div class="userstuff">
   <p>
-    <%= ts("You should soon receive a confirmation email at the address you gave us.  This will have the link you need to follow in order to activate your account and complete the account creation process.  The confirmation email will come from <strong>%{return_address}</strong> - you might want to add this to your address book to make sure you get the email.", return_address: ArchiveConfig.RETURN_ADDRESS).html_safe %>
+    <%= ts("You should soon receive a confirmation email at the address you gave us. This will have the link you need to follow in order to activate your account and complete the account creation process. The confirmation email will come from <strong>%{return_address}</strong> -- you might want to add this to your address book to make sure you get the email.", return_address: ArchiveConfig.RETURN_ADDRESS).html_safe %>
   </p>
   <p>
-    <%= ts("If you haven't received this email within 24 hours, and you don't find our email in your spam filter or Social folder, please <a href='%{support_path}'>contact Support for help</a>.", support_path: new_feedback_report_path).html_safe %>
+    <%= ts("If you haven't received this email within 24 hours, and you don't find our email in your spam filter or Social folder, please <a href='%{support_path}'>contact Support</a> for help.", support_path: new_feedback_report_path).html_safe %>
   </p>
   <p>
     <% # We do days_to_purge_unactivated * 7 because it's actually weeks %>
-    <%= ts("<strong>Important!</strong> You must confirm your email address within %{days_before_purge} days, or your account will expire.  If this happens, you can sign up again using the same invitation.", days_before_purge: AdminSetting.current.days_to_purge_unactivated? ? (AdminSetting.current.days_to_purge_unactivated * 7) : ArchiveConfig.DAYS_TO_PURGE_UNACTIVATED).html_safe %>
+    <%= ts("<strong>Important!</strong> You must confirm your email address within %{days_before_purge} days, or your account will expire. If this happens, you can sign up again using the same invitation.", days_before_purge: AdminSetting.current.days_to_purge_unactivated? ? (AdminSetting.current.days_to_purge_unactivated * 7) : ArchiveConfig.DAYS_TO_PURGE_UNACTIVATED).html_safe %>
   </p>
   <p>
     <%= link_to ts('Return to Archive front page'), root_path %>

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -637,6 +637,25 @@
       "note": ""
     },
     {
+      "warning_type": "Cross Site Scripting",
+      "warning_code": 2,
+      "fingerprint": "4c2812ecba16106adca83fe060ad8671affa5d656e84eab329ba363745b06fae",
+      "check_name": "CrossSiteScripting",
+      "message": "Unescaped model attribute",
+      "file": "app/views/users/confirmation.html.erb",
+      "line": 14,
+      "link": "http://brakemanscanner.org/docs/warning_types/cross_site_scripting",
+      "code": "ts(\"<strong>Important!</strong> You must confirm your email address within %{days_before_purge} days, or your account will expire. If this happens, you can sign up again using the same invitation.\", :days_before_purge => (if AdminSetting.current.days_to_purge_unactivated? then\n  (AdminSetting.current.days_to_purge_unactivated * 7)\nelse\n  ArchiveConfig.DAYS_TO_PURGE_UNACTIVATED\nend))",
+      "render_path": [{"type":"controller","class":"Users::RegistrationsController","method":"notify_and_show_confirmation_screen","line":46,"file":"app/controllers/users/registrations_controller.rb"}],
+      "location": {
+        "type": "template",
+        "template": "users/confirmation"
+      },
+      "user_input": "AdminSetting.current.days_to_purge_unactivated",
+      "confidence": "Weak",
+      "note": ""
+    },
+    {
       "warning_type": "Denial of Service",
       "warning_code": 76,
       "fingerprint": "4d73121092fa0a2969beb6a30406f1eaf92368c96a003244f8a9495a9010d1a3",
@@ -1289,25 +1308,6 @@
         "template": "works/show"
       },
       "user_input": "Work.find_by(:id => params[:id]).first_chapter",
-      "confidence": "Weak",
-      "note": ""
-    },
-    {
-      "warning_type": "Cross Site Scripting",
-      "warning_code": 2,
-      "fingerprint": "a057b1014f4e05e77f051510ec32dca14aa5d7bc12ff94e9795ace4d006ede9a",
-      "check_name": "CrossSiteScripting",
-      "message": "Unescaped model attribute",
-      "file": "app/views/users/confirmation.html.erb",
-      "line": 14,
-      "link": "http://brakemanscanner.org/docs/warning_types/cross_site_scripting",
-      "code": "ts(\"<strong>Important!</strong> You must confirm your email address within %{days_before_purge} days, or your account will expire.  If this happens, you can sign up again using the same invitation.\", :days_before_purge => (if AdminSetting.current.days_to_purge_unactivated? then\n  (AdminSetting.current.days_to_purge_unactivated * 7)\nelse\n  ArchiveConfig.DAYS_TO_PURGE_UNACTIVATED\nend))",
-      "render_path": [{"type":"controller","class":"Users::RegistrationsController","method":"notify_and_show_confirmation_screen","line":46,"file":"app/controllers/users/registrations_controller.rb"}],
-      "location": {
-        "type": "template",
-        "template": "users/confirmation"
-      },
-      "user_input": "AdminSetting.current.days_to_purge_unactivated",
       "confidence": "Weak",
       "note": ""
     },
@@ -2007,6 +2007,6 @@
       "note": ""
     }
   ],
-  "updated": "2019-10-26 19:26:19 +0000",
+  "updated": "2019-10-27 07:20:29 +0000",
   "brakeman_version": "3.7.2"
 }

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -2047,7 +2047,7 @@
       "file": "app/views/users/confirmation.html.erb",
       "line": 14,
       "link": "http://brakemanscanner.org/docs/warning_types/cross_site_scripting",
-      "code": "ts(\"<strong>Important!</strong> You must verify your account within %{days_before_purge} days, or your registration will expire.\", :days_before_purge => (if AdminSetting.current.days_to_purge_unactivated? then\n  (AdminSetting.current.days_to_purge_unactivated * 7)\nelse\n  ArchiveConfig.DAYS_TO_PURGE_UNACTIVATED\nend))",
+      "code": "ts(\"<strong>Important!</strong> You must confirm your email address within %{days_before_purge}days, or your account will expire.  If this happens, you can sign up again using the same invitation.\", :days_before_purge => (if AdminSetting.current.days_to_purge_unactivated? then\n  (AdminSetting.current.days_to_purge_unactivated * 7)\nelse\n  ArchiveConfig.DAYS_TO_PURGE_UNACTIVATED\nend))",
       "render_path": [{"type":"controller","class":"Users::RegistrationsController","method":"notify_and_show_confirmation_screen","line":46,"file":"app/controllers/users/registrations_controller.rb"}],
       "location": {
         "type": "template",

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -2047,7 +2047,7 @@
       "file": "app/views/users/confirmation.html.erb",
       "line": 14,
       "link": "http://brakemanscanner.org/docs/warning_types/cross_site_scripting",
-      "code": "ts(\"<strong>Important!</strong> You must confirm your email address within %{days_before_purge}days, or your account will expire.  If this happens, you can sign up again using the same invitation.\", :days_before_purge => (if AdminSetting.current.days_to_purge_unactivated? then\n  (AdminSetting.current.days_to_purge_unactivated * 7)\nelse\n  ArchiveConfig.DAYS_TO_PURGE_UNACTIVATED\nend))",
+      "code": "ts(\"<strong>Important!</strong> You must confirm your email address within %{days_before_purge} days, or your account will expire.  If this happens, you can sign up again using the same invitation.\", :days_before_purge => (if AdminSetting.current.days_to_purge_unactivated? then\n  (AdminSetting.current.days_to_purge_unactivated * 7)\nelse\n  ArchiveConfig.DAYS_TO_PURGE_UNACTIVATED\nend))",
       "render_path": [{"type":"controller","class":"Users::RegistrationsController","method":"notify_and_show_confirmation_screen","line":46,"file":"app/controllers/users/registrations_controller.rb"}],
       "location": {
         "type": "template",

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -296,7 +296,7 @@
       "line": 16,
       "link": "http://brakemanscanner.org/docs/warning_types/cross_site_scripting",
       "code": "sanitize_field(Work.find_by(:id => params[:id]).first_chapter, :content)",
-      "render_path": [{"type":"controller","class":"WorksController","method":"update","line":371,"file":"app/controllers/works_controller.rb"}],
+      "render_path": [{"type":"controller","class":"WorksController","method":"update","line":370,"file":"app/controllers/works_controller.rb"}],
       "location": {
         "type": "template",
         "template": "works/preview"
@@ -1109,7 +1109,7 @@
       "line": 7,
       "link": "http://brakemanscanner.org/docs/warning_types/cross_site_scripting",
       "code": "ts(\"Are you sure you want to <strong><em>delete</em></strong> \\\"%{work_title}\\\" <strong><em>permanently</em></strong>? This <strong>cannot be undone</strong>.\", :work_title => Work.find_by(:id => params[:id]).title)",
-      "render_path": [{"type":"controller","class":"WorksController","method":"confirm_delete","line":429,"file":"app/controllers/works_controller.rb"}],
+      "render_path": [{"type":"controller","class":"WorksController","method":"confirm_delete","line":428,"file":"app/controllers/works_controller.rb"}],
       "location": {
         "type": "template",
         "template": "works/confirm_delete"
@@ -1153,57 +1153,6 @@
         "template": "layouts/_banner"
       },
       "user_input": "AdminBanner.where(:active => true).last",
-      "confidence": "Weak",
-      "note": ""
-    },
-    {
-      "warning_type": "Cross Site Scripting",
-      "warning_code": 2,
-      "fingerprint": "80956874bb517bc1a8d91a9e56c8ab08fb829db9c24b85cddb2691db51e9b9c0",
-      "check_name": "CrossSiteScripting",
-      "message": "Unescaped model attribute",
-      "file": "app/views/external_works/_work_module.html.erb",
-      "line": 17,
-      "link": "http://brakemanscanner.org/docs/warning_types/cross_site_scripting",
-      "code": "(Work.find(params[:work_id]) or (Chapter.find(params[:chapter_id]).work or (ExternalWork.find(params[:external_work_id]) or Series.find(params[:series_id])))).fandom_tags.collect do\n link_to_tag_works(tag)\n end.join(\", \")",
-      "render_path": [
-        {
-          "type": "controller",
-          "class": "BookmarksController",
-          "method": "index",
-          "line": 148,
-          "file": "app/controllers/bookmarks_controller.rb"
-        },
-        {
-          "type": "template",
-          "name": "bookmarks/index",
-          "line": 59,
-          "file": "app/views/bookmarks/index.html.erb"
-        },
-        {
-          "type": "template",
-          "name": "bookmarks/_bookmarks",
-          "line": 23,
-          "file": "app/views/bookmarks/_bookmarks.html.erb"
-        },
-        {
-          "type": "template",
-          "name": "bookmarks/_bookmarkable_blurb",
-          "line": 13,
-          "file": "app/views/bookmarks/_bookmarkable_blurb.html.erb"
-        },
-        {
-          "type": "template",
-          "name": "bookmarks/_bookmark_item_module",
-          "line": 3,
-          "file": "app/views/bookmarks/_bookmark_item_module.html.erb"
-        }
-      ],
-      "location": {
-        "type": "template",
-        "template": "external_works/_work_module"
-      },
-      "user_input": "Work.find(params[:work_id])",
       "confidence": "Weak",
       "note": ""
     },
@@ -1340,6 +1289,25 @@
         "template": "works/show"
       },
       "user_input": "Work.find_by(:id => params[:id]).first_chapter",
+      "confidence": "Weak",
+      "note": ""
+    },
+    {
+      "warning_type": "Cross Site Scripting",
+      "warning_code": 2,
+      "fingerprint": "a057b1014f4e05e77f051510ec32dca14aa5d7bc12ff94e9795ace4d006ede9a",
+      "check_name": "CrossSiteScripting",
+      "message": "Unescaped model attribute",
+      "file": "app/views/users/confirmation.html.erb",
+      "line": 14,
+      "link": "http://brakemanscanner.org/docs/warning_types/cross_site_scripting",
+      "code": "ts(\"<strong>Important!</strong> You must confirm your email address within %{days_before_purge} days, or your account will expire.  If this happens, you can sign up again using the same invitation.\", :days_before_purge => (if AdminSetting.current.days_to_purge_unactivated? then\n  (AdminSetting.current.days_to_purge_unactivated * 7)\nelse\n  ArchiveConfig.DAYS_TO_PURGE_UNACTIVATED\nend))",
+      "render_path": [{"type":"controller","class":"Users::RegistrationsController","method":"notify_and_show_confirmation_screen","line":46,"file":"app/controllers/users/registrations_controller.rb"}],
+      "location": {
+        "type": "template",
+        "template": "users/confirmation"
+      },
+      "user_input": "AdminSetting.current.days_to_purge_unactivated",
       "confidence": "Weak",
       "note": ""
     },
@@ -2037,27 +2005,8 @@
       "user_input": "((Skin.skins_dir + skin_dirname) + \"#{1}_#{\"\"}.css\")",
       "confidence": "Medium",
       "note": ""
-    },
-    {
-      "warning_type": "Cross Site Scripting",
-      "warning_code": 2,
-      "fingerprint": "fc5488b7f49a45176e39345f3f21356882a47161efadee214554e6d418edb9a0",
-      "check_name": "CrossSiteScripting",
-      "message": "Unescaped model attribute",
-      "file": "app/views/users/confirmation.html.erb",
-      "line": 14,
-      "link": "http://brakemanscanner.org/docs/warning_types/cross_site_scripting",
-      "code": "ts(\"<strong>Important!</strong> You must confirm your email address within %{days_before_purge} days, or your account will expire.  If this happens, you can sign up again using the same invitation.\", :days_before_purge => (if AdminSetting.current.days_to_purge_unactivated? then\n  (AdminSetting.current.days_to_purge_unactivated * 7)\nelse\n  ArchiveConfig.DAYS_TO_PURGE_UNACTIVATED\nend))",
-      "render_path": [{"type":"controller","class":"Users::RegistrationsController","method":"notify_and_show_confirmation_screen","line":46,"file":"app/controllers/users/registrations_controller.rb"}],
-      "location": {
-        "type": "template",
-        "template": "users/confirmation"
-      },
-      "user_input": "AdminSetting.current.days_to_purge_unactivated",
-      "confidence": "Weak",
-      "note": ""
     }
   ],
-  "updated": "2019-09-12 23:17:01 -0400",
+  "updated": "2019-10-26 19:26:19 +0000",
   "brakeman_version": "3.7.2"
 }

--- a/features/importing/archivist.feature
+++ b/features/importing/archivist.feature
@@ -179,7 +179,7 @@ Feature: Archivist bulk imports
     Then I should see "Create Account"
     When I fill in the sign up form with valid data
     And I press "Create Account"
-    Then I should see "Account Created!"
+    Then I should see "Almost Done!"
 
   Scenario: Orphan a work in response to an invite, leaving name on it
     Given I have an orphan account

--- a/features/other_a/invite_queue.feature
+++ b/features/other_a/invite_queue.feature
@@ -129,7 +129,7 @@ Feature: Invite queue management
         | user_registration_password_confirmation | password1                |
       And all emails have been delivered
     When I press "Create Account"
-    Then I should see "Account Created!"
+    Then I should see "Almost Done!"
     Then 1 email should be delivered
       And the email should contain "Welcome to the Archive of Our Own,"
       And the email should contain "newuser"

--- a/features/other_a/invite_request.feature
+++ b/features/other_a/invite_request.feature
@@ -83,9 +83,9 @@ Feature: Invite requests
         | user_registration_password               | password1 |
         | user_registration_password_confirmation  | password1 |
       And I press "Create Account"
-    Then I should see "Within 24 hours, you should receive an email at the address you gave us."
+    Then I should see "You should soon receive a confirmation email at the address you gave us"
       And I should see how long I have to activate my account
-      And I should see "If you don't hear from us within 24 hours"
+      And I should see "If you haven't received this email within 24 hours"
 
   Scenario: Banned users cannot access their invitations page
 

--- a/features/step_definitions/invite_steps.rb
+++ b/features/step_definitions/invite_steps.rb
@@ -146,7 +146,7 @@ end
 
 Then /^I should see how long I have to activate my account$/ do
   days_to_activate = AdminSetting.first.days_to_purge_unactivated? ? (AdminSetting.first.days_to_purge_unactivated * 7) : ArchiveConfig.DAYS_TO_PURGE_UNACTIVATED
-  step %{I should see "You must verify your account within #{days_to_activate} days"}
+  step %{I should see "You must confirm your email address within #{days_to_activate} days"}
 end
 
 Then /^"([^"]*)" should have "([^"]*)" invitations$/ do |login, invitation_count|

--- a/features/users/user_create.feature
+++ b/features/users/user_create.feature
@@ -14,7 +14,7 @@ Feature: Sign Up for a new account
       And I fill in "<field>" with "<value>"
       And I press "Create Account"
     Then I should see "<error>"
-      And I should not see "Account Created!"
+      And I should not see "Almost Done!"
     Examples:
       | field                      | value          | error                                           |
       | user_registration_login                 | xx             | Login is too short (minimum is 3 characters)    |
@@ -28,7 +28,7 @@ Feature: Sign Up for a new account
   Scenario Outline: The user should see validation errors when signing up without filling in required fields.
     When I press "Create Account"
     Then I should see "<error>"
-      And I should not see "Account Created!"
+      And I should not see "Almost Done!"
     Examples:
       | field                 | error                                                               |
       | user_registration_age_over_13      | Sorry, you have to be over 13!                                      |
@@ -49,7 +49,7 @@ Feature: Sign Up for a new account
       And I fill in "Confirm password" with "password"
       And all emails have been delivered
       And I press "Create Account"
-    Then I should see "Account Created!"
+    Then I should see "Almost Done!"
       And 1 email should be delivered to "lyingrobot@example.com"
       And I should get a new user activation email
       And a new user account should exist
@@ -62,7 +62,7 @@ Feature: Sign Up for a new account
       And I fill in "user_registration_login" with "user1"
       And I press "Create Account"
     Then I should see "Login has already been taken"
-      And I should not see "Account Created!"
+      And I should not see "Almost Done!"
 
   Scenario: The user should not be able to sign up with a login that is already in use, no matter the case
     Given the following users exist
@@ -72,12 +72,12 @@ Feature: Sign Up for a new account
       And I fill in "user_registration_login" with "USER1"
       And I press "Create Account"
     Then I should see "Login has already been taken"
-      And I should not see "Account Created!"
+      And I should not see "Almost Done!"
 
   Scenario: The user should be able to create a new account with a valid email and password
     When I fill in the sign up form with valid data
       And all emails have been delivered
       And I press "Create Account"
-    Then I should see "Account Created!"
+    Then I should see "Almost Done!"
       And I should get a new user activation email
       And a new user account should exist


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5738

## Purpose

This PR updates the page users see after creating an account to contain the text indicated in the JIRA issue page. It also updates the related Cucumber tests.

## Testing Instructions

- Set up an account
- Check if the correct text is shown

## Credit

*What name do you want us to use to credit your work in the [Archive of Our Own's Release Notes](https://archiveofourown.org/admin_posts?tag=1)?*

Alix R

*What pronouns do you prefer (she/her, he/him, zie/hir etc)?*

She/her
