### PR TITLE
AO3-5616 Fix FAQ category display with RTL scripts

### DIFF
--- a/public/stylesheets/site/2.0/16-zone-system.css
+++ b/public/stylesheets/site/2.0/16-zone-system.css
@@ -293,6 +293,10 @@ For practicality, /archive_faqs are also .docs and .support and have the .userst
   list-style-type: circle;
 }
 
+.faq .categories .userstuff {
+  clear: both;
+}
+
 .faq .screencast .label {
   font-weight: 700;
 }


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5616

## Purpose

Fixes a display issue with FAQ categories written in right-to-left languages. The fix is the one that was suggested on the JIRA ticket.

## Testing Instructions

Check this page in the staging environment: https://test.archiveofourown.org/faq?utf8=%E2%9C%93&language_id=ar

## Credit

*What name do you want us to use to credit your work in the [Archive of Our Own's Release Notes](https://archiveofourown.org/admin_posts?tag=1)?*

Alix R

*What pronouns do you prefer (she/her, he/him, zie/hir etc)?*

she/her
