### PR TITLE
AO3-5693 Restrict width of video elements

### DIFF
--- a/public/stylesheets/site/2.0/21-userstuff.css
+++ b/public/stylesheets/site/2.0/21-userstuff.css
@@ -139,6 +139,12 @@
   border: 1px solid;
 }
 
+/* media */
+
+.userstuff video {
+  max-width: 100%;
+}
+
 /*expected behaviours, exceptioning*/
 
 /* WORK MARGINS */


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5693

## Purpose

Makes sure videos embedded with the `<video>` tag aren't bigger than 100% of the width of the container.

## Testing Instructions

Post very large video, ensure it is not very large on a small screen.