### PR TITLE
AO3-5693 Supply values for whitelisted boolean attributes

### DIFF
--- a/lib/otw_sanitize/media_sanitizer.rb
+++ b/lib/otw_sanitize/media_sanitizer.rb
@@ -72,6 +72,7 @@ module OTWSanitize
 
       config = Sanitize::Config.merge(Sanitize::Config::ARCHIVE, WHITELIST_CONFIG)
       Sanitize.clean_node!(node, config)
+      tidy_boolean_attributes(node)
       { node_whitelist: [node] }
     end
 
@@ -101,6 +102,15 @@ module OTWSanitize
       ArchiveConfig.BLACKLISTED_MULTIMEDIA_SRCS.any? do |blocked|
         source_host.match(blocked)
       end
+    end
+
+    # Sanitize outputs boolean attributes as attribute="". While this works,
+    # attribute="attribute" is more consistent with the way we handle the
+    # boolean attributes we automatically add (e.g. controls="controls").
+    def tidy_boolean_attributes(node)
+      node["default"] = "default" if node["default"]
+      node["loop"] = "loop" if node["loop"]
+      node["muted"] = "muted" if node["muted"]
     end
   end
 end

--- a/spec/miscellaneous/lib/media_sanitizer_spec.rb
+++ b/spec/miscellaneous/lib/media_sanitizer_spec.rb
@@ -68,6 +68,17 @@ describe OTWSanitize::MediaSanitizer do
         expect(content).to match("xyz")
       end
 
+      it "fills in values for whitelisted boolean attributes" do
+        html = "
+          <video muted loop>
+            <track default>
+          </video>"
+        content = Sanitize.fragment(html, config)     
+        expect(content).to match('muted="muted"') 
+        expect(content).to match('loop="loop"') 
+        expect(content).to match('default="default"') 
+      end
+
       it "removes unwhitelisted attributes" do
         html = "
           <video>


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5693

## Purpose

If you use the boolean attributes `loop`, `muted`, or `default` in your media, the attribute value should be the same as the attribute name, e.g. `loop="loop"`, to be consistent with the way we handle our automatically-added boolean attributes, e.g. `controls`.

## Testing Instructions

Use the aforementioned attributes when embedding audio or video, but do not include a correct value (or any value) -- for example, you might do `<video loop="potato" muted>`. After posting, edit your work to check that the HTML is updated to include a value that matches the attribute name (so for our example, the desired outcome would be `<video loop="loop" muted="muted">`).
