### PR TITLE
AO3-5194 Update schema and structure files

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 201604030319571) do
+ActiveRecord::Schema.define(version: 20190611212339) do
 
   create_table "abuse_reports", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC" do |t|
     t.string "email"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,4 +1,3 @@
-# encoding: UTF-8
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -9,1324 +8,1298 @@
 # from scratch. The latter is a flawed and unsustainable approach (the more migrations
 # you'll amass, the slower it'll run and the greater likelihood for issues).
 #
-# It's strongly recommended to check this file into your version control system.
+# It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20160706031054) do
+ActiveRecord::Schema.define(version: 201604030319571) do
 
-  create_table "abuse_reports", :force => true do |t|
-    t.string   "email"
-    t.string   "url",                                                   :null => false
-    t.text     "comment",                                               :null => false
+  create_table "abuse_reports", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC" do |t|
+    t.string "email"
+    t.string "url", null: false
+    t.text "comment", null: false
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string   "ip_address"
-    t.integer  "comment_sanitizer_version", :limit => 2, :default => 0, :null => false
-    t.string   "summary"
-    t.string   "summary_sanitizer_version"
-    t.string   "language"
-    t.string   "username"
+    t.string "ip_address"
+    t.integer "comment_sanitizer_version", limit: 2, default: 0, null: false
+    t.string "summary"
+    t.string "summary_sanitizer_version"
+    t.string "language"
+    t.string "username"
   end
 
-  create_table "admin_activities", :force => true do |t|
-    t.integer  "admin_id"
-    t.integer  "target_id"
-    t.string   "target_type"
-    t.string   "action"
-    t.text     "summary"
-    t.integer  "summary_sanitizer_version", :limit => 2, :default => 0, :null => false
-    t.datetime "created_at"
-    t.datetime "updated_at"
-  end
-
-  create_table "admin_banners", :force => true do |t|
-    t.text    "content"
-    t.integer "content_sanitizer_version", :limit => 2, :default => 0,     :null => false
-    t.string  "banner_type"
-    t.boolean "active",                                 :default => false, :null => false
-  end
-
-  create_table "admin_blacklisted_emails", :force => true do |t|
-    t.string   "email"
-    t.datetime "created_at", :null => false
-    t.datetime "updated_at", :null => false
-  end
-
-  add_index "admin_blacklisted_emails", ["email"], :name => "index_admin_blacklisted_emails_on_email", :unique => true
-
-  create_table "admin_post_taggings", :force => true do |t|
-    t.integer  "admin_post_tag_id"
-    t.integer  "admin_post_id"
+  create_table "admin_activities", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC" do |t|
+    t.integer "admin_id"
+    t.integer "target_id"
+    t.string "target_type"
+    t.string "action"
+    t.text "summary"
+    t.integer "summary_sanitizer_version", limit: 2, default: 0, null: false
     t.datetime "created_at"
     t.datetime "updated_at"
   end
 
-  add_index "admin_post_taggings", ["admin_post_id"], :name => "index_admin_post_taggings_on_admin_post_id"
+  create_table "admin_banners", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC" do |t|
+    t.text "content"
+    t.integer "content_sanitizer_version", limit: 2, default: 0, null: false
+    t.string "banner_type"
+    t.boolean "active", default: false, null: false
+  end
 
-  create_table "admin_post_tags", :force => true do |t|
-    t.string   "name"
-    t.integer  "language_id"
+  create_table "admin_blacklisted_emails", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC" do |t|
+    t.string "email"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["email"], name: "index_admin_blacklisted_emails_on_email", unique: true
+  end
+
+  create_table "admin_post_taggings", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC" do |t|
+    t.integer "admin_post_tag_id"
+    t.integer "admin_post_id"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.index ["admin_post_id"], name: "index_admin_post_taggings_on_admin_post_id"
+  end
+
+  create_table "admin_post_tags", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC" do |t|
+    t.string "name"
+    t.integer "language_id"
     t.datetime "created_at"
     t.datetime "updated_at"
   end
 
-  create_table "admin_posts", :force => true do |t|
-    t.integer  "admin_id"
-    t.string   "title"
-    t.text     "content"
+  create_table "admin_posts", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC" do |t|
+    t.integer "admin_id"
+    t.string "title"
+    t.text "content"
     t.datetime "updated_at"
     t.datetime "created_at"
-    t.integer  "content_sanitizer_version", :limit => 2, :default => 0, :null => false
-    t.integer  "translated_post_id"
-    t.integer  "language_id"
+    t.integer "content_sanitizer_version", limit: 2, default: 0, null: false
+    t.integer "translated_post_id"
+    t.integer "language_id"
+    t.index ["created_at"], name: "index_admin_posts_on_created_at"
+    t.index ["translated_post_id"], name: "index_admin_posts_on_post_id"
   end
 
-  add_index "admin_posts", ["created_at"], :name => "index_admin_posts_on_created_at"
-  add_index "admin_posts", ["translated_post_id"], :name => "index_admin_posts_on_post_id"
-
-  create_table "admin_settings", :force => true do |t|
-    t.boolean  "account_creation_enabled",                 :default => true,                  :null => false
-    t.boolean  "invite_from_queue_enabled",                :default => true,                  :null => false
-    t.integer  "invite_from_queue_number",    :limit => 8
-    t.integer  "invite_from_queue_frequency", :limit => 3
-    t.integer  "days_to_purge_unactivated",   :limit => 3
-    t.integer  "last_updated_by",             :limit => 8
+  create_table "admin_settings", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC" do |t|
+    t.boolean "account_creation_enabled", default: true, null: false
+    t.boolean "invite_from_queue_enabled", default: true, null: false
+    t.bigint "invite_from_queue_number"
+    t.integer "invite_from_queue_frequency", limit: 3
+    t.integer "days_to_purge_unactivated", limit: 3
+    t.bigint "last_updated_by"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.datetime "invite_from_queue_at",                     :default => '2009-11-07 21:27:21'
-    t.boolean  "suspend_filter_counts",                    :default => false
+    t.datetime "invite_from_queue_at", default: "2009-11-07 21:27:21"
+    t.boolean "suspend_filter_counts", default: false
     t.datetime "suspend_filter_counts_at"
-    t.boolean  "enable_test_caching",                      :default => false
-    t.integer  "cache_expiration",            :limit => 8, :default => 10
-    t.boolean  "tag_wrangling_off",                        :default => false,                 :null => false
-    t.boolean  "guest_downloading_off",                    :default => false,                 :null => false
-    t.integer  "default_skin_id"
+    t.boolean "enable_test_caching", default: false
+    t.bigint "cache_expiration", default: 10
+    t.boolean "tag_wrangling_off", default: false, null: false
+    t.integer "default_skin_id"
     t.datetime "stats_updated_at"
-    t.boolean  "disable_filtering",                        :default => false,                 :null => false
-    t.boolean  "request_invite_enabled",                   :default => false,                 :null => false
-    t.boolean  "creation_requires_invite",                 :default => false,                 :null => false
-    t.boolean  "downloads_enabled",                        :default => true
+    t.boolean "request_invite_enabled", default: false, null: false
+    t.boolean "creation_requires_invite", default: false, null: false
+    t.boolean "downloads_enabled", default: true
+    t.boolean "hide_spam", default: false, null: false
+    t.boolean "disable_support_form", default: false, null: false
+    t.text "disabled_support_form_text"
+    t.integer "disabled_support_form_text_sanitizer_version", limit: 2, default: 0, null: false
+    t.index ["last_updated_by"], name: "index_admin_settings_on_last_updated_by"
   end
 
-  add_index "admin_settings", ["last_updated_by"], :name => "index_admin_settings_on_last_updated_by"
-
-  create_table "admins", :force => true do |t|
+  create_table "admins", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC" do |t|
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string   "email"
-    t.string   "login"
-    t.string   "encrypted_password"
-    t.string   "password_salt"
+    t.string "email"
+    t.string "login"
+    t.string "encrypted_password"
+    t.string "password_salt"
   end
 
-  create_table "api_keys", :force => true do |t|
-    t.string   "name",                            :null => false
-    t.string   "access_token",                    :null => false
-    t.boolean  "banned",       :default => false, :null => false
-    t.datetime "created_at",                      :null => false
-    t.datetime "updated_at",                      :null => false
+  create_table "api_keys", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC" do |t|
+    t.string "name", null: false
+    t.string "access_token", null: false
+    t.boolean "banned", default: false, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["access_token"], name: "index_api_keys_on_access_token", unique: true
+    t.index ["name"], name: "index_api_keys_on_name", unique: true
   end
 
-  add_index "api_keys", ["access_token"], :name => "index_api_keys_on_access_token", :unique => true
-  add_index "api_keys", ["name"], :name => "index_api_keys_on_name", :unique => true
-
-  create_table "archive_faq_translations", :force => true do |t|
-    t.integer  "archive_faq_id"
-    t.string   "locale",         :null => false
-    t.datetime "created_at",     :null => false
-    t.datetime "updated_at",     :null => false
-    t.string   "title"
+  create_table "archive_faq_translations", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC" do |t|
+    t.integer "archive_faq_id"
+    t.string "locale", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "title"
+    t.index ["archive_faq_id"], name: "index_archive_faq_translations_on_archive_faq_id"
+    t.index ["locale"], name: "index_archive_faq_translations_on_locale"
   end
 
-  add_index "archive_faq_translations", ["archive_faq_id"], :name => "index_archive_faq_translations_on_archive_faq_id"
-  add_index "archive_faq_translations", ["locale"], :name => "index_archive_faq_translations_on_locale"
-
-  create_table "archive_faqs", :force => true do |t|
-    t.integer  "admin_id"
-    t.string   "title"
+  create_table "archive_faqs", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC" do |t|
+    t.integer "admin_id"
+    t.string "title"
     t.datetime "updated_at"
     t.datetime "created_at"
-    t.integer  "position",   :default => 1
-    t.string   "slug",       :default => "", :null => false
+    t.integer "position", default: 1
+    t.string "slug", default: "", null: false
+    t.index ["position"], name: "index_archive_faqs_on_position"
+    t.index ["slug"], name: "index_archive_faqs_on_slug", unique: true
   end
 
-  add_index "archive_faqs", ["position"], :name => "index_archive_faqs_on_position"
-  add_index "archive_faqs", ["slug"], :name => "index_archive_faqs_on_slug", :unique => true
-
-  create_table "audits", :force => true do |t|
-    t.integer  "auditable_id"
-    t.string   "auditable_type"
-    t.integer  "associated_id"
-    t.string   "associated_type"
-    t.integer  "user_id"
-    t.string   "user_type"
-    t.string   "username"
-    t.string   "action"
-    t.text     "audited_changes"
-    t.integer  "version",         :default => 0
-    t.string   "comment"
-    t.string   "remote_address"
+  create_table "audits", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC" do |t|
+    t.integer "auditable_id"
+    t.string "auditable_type"
+    t.integer "associated_id"
+    t.string "associated_type"
+    t.integer "user_id"
+    t.string "user_type"
+    t.string "username"
+    t.string "action"
+    t.text "audited_changes"
+    t.integer "version", default: 0
+    t.string "comment"
+    t.string "remote_address"
     t.datetime "created_at"
+    t.string "request_uuid"
+    t.index ["associated_id", "associated_type"], name: "associated_index"
+    t.index ["auditable_id", "auditable_type"], name: "auditable_index"
+    t.index ["created_at"], name: "index_audits_on_created_at"
+    t.index ["request_uuid"], name: "index_audits_on_request_uuid"
+    t.index ["user_id", "user_type"], name: "user_index"
   end
 
-  add_index "audits", ["associated_id", "associated_type"], :name => "associated_index"
-  add_index "audits", ["auditable_id", "auditable_type"], :name => "auditable_index"
-  add_index "audits", ["created_at"], :name => "index_audits_on_created_at"
-  add_index "audits", ["user_id", "user_type"], :name => "user_index"
-
-  create_table "bookmarks", :force => true do |t|
-    t.datetime "created_at",                                               :null => false
-    t.string   "bookmarkable_type",       :limit => 15,                    :null => false
-    t.integer  "bookmarkable_id",                                          :null => false
-    t.integer  "user_id"
-    t.text     "notes"
-    t.boolean  "private",                               :default => false
+  create_table "bookmarks", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC" do |t|
+    t.datetime "created_at", null: false
+    t.string "bookmarkable_type", limit: 15, null: false
+    t.integer "bookmarkable_id", null: false
+    t.integer "user_id"
+    t.text "bookmarker_notes"
+    t.boolean "private", default: false
     t.datetime "updated_at"
-    t.boolean  "hidden_by_admin",                       :default => false, :null => false
-    t.integer  "pseud_id",                                                 :null => false
-    t.boolean  "rec",                                   :default => false, :null => false
-    t.boolean  "delta",                                 :default => true
-    t.integer  "notes_sanitizer_version", :limit => 2,  :default => 0,     :null => false
+    t.boolean "hidden_by_admin", default: false, null: false
+    t.integer "pseud_id", null: false
+    t.boolean "rec", default: false, null: false
+    t.boolean "delta", default: true
+    t.integer "bookmarker_notes_sanitizer_version", limit: 2, default: 0, null: false
+    t.index ["bookmarkable_id", "bookmarkable_type", "pseud_id"], name: "index_bookmarkable_pseud"
+    t.index ["private", "hidden_by_admin", "created_at"], name: "index_bookmarks_on_private_and_hidden_by_admin_and_created_at"
+    t.index ["pseud_id"], name: "index_bookmarks_on_pseud_id"
+    t.index ["user_id"], name: "fk_bookmarks_user"
   end
 
-  add_index "bookmarks", ["bookmarkable_id", "bookmarkable_type", "pseud_id"], :name => "index_bookmarkable_pseud"
-  add_index "bookmarks", ["private", "hidden_by_admin", "created_at"], :name => "index_bookmarks_on_private_and_hidden_by_admin_and_created_at"
-  add_index "bookmarks", ["pseud_id"], :name => "index_bookmarks_on_pseud_id"
-  add_index "bookmarks", ["user_id"], :name => "fk_bookmarks_user"
-
-  create_table "challenge_assignments", :force => true do |t|
-    t.integer  "collection_id"
-    t.integer  "creation_id"
-    t.string   "creation_type"
-    t.integer  "offer_signup_id"
-    t.integer  "request_signup_id"
-    t.integer  "pinch_hitter_id"
+  create_table "challenge_assignments", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC" do |t|
+    t.integer "collection_id"
+    t.integer "creation_id"
+    t.string "creation_type"
+    t.integer "offer_signup_id"
+    t.integer "request_signup_id"
+    t.integer "pinch_hitter_id"
     t.datetime "sent_at"
     t.datetime "fulfilled_at"
     t.datetime "defaulted_at"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.integer  "pinch_request_signup_id"
+    t.integer "pinch_request_signup_id"
     t.datetime "covered_at"
+    t.index ["collection_id"], name: "index_challenge_assignments_on_collection_id"
+    t.index ["creation_id"], name: "assignments_on_creation_id"
+    t.index ["creation_type"], name: "assignments_on_creation_type"
+    t.index ["defaulted_at"], name: "assignments_on_defaulted_at"
+    t.index ["offer_signup_id"], name: "assignments_on_offer_signup_id"
+    t.index ["pinch_hitter_id"], name: "assignments_on_pinch_hitter_id"
+    t.index ["sent_at"], name: "assignments_on_offer_sent_at"
   end
 
-  add_index "challenge_assignments", ["collection_id"], :name => "index_challenge_assignments_on_collection_id"
-  add_index "challenge_assignments", ["creation_id"], :name => "assignments_on_creation_id"
-  add_index "challenge_assignments", ["creation_type"], :name => "assignments_on_creation_type"
-  add_index "challenge_assignments", ["defaulted_at"], :name => "assignments_on_defaulted_at"
-  add_index "challenge_assignments", ["offer_signup_id"], :name => "assignments_on_offer_signup_id"
-  add_index "challenge_assignments", ["pinch_hitter_id"], :name => "assignments_on_pinch_hitter_id"
-  add_index "challenge_assignments", ["sent_at"], :name => "assignments_on_offer_sent_at"
-
-  create_table "challenge_claims", :force => true do |t|
-    t.integer  "collection_id"
-    t.integer  "creation_id"
-    t.string   "creation_type"
-    t.integer  "request_signup_id"
-    t.integer  "request_prompt_id"
-    t.integer  "claiming_user_id"
+  create_table "challenge_claims", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC" do |t|
+    t.integer "collection_id"
+    t.integer "creation_id"
+    t.string "creation_type"
+    t.integer "request_signup_id"
+    t.integer "request_prompt_id"
+    t.integer "claiming_user_id"
     t.datetime "sent_at"
     t.datetime "fulfilled_at"
     t.datetime "defaulted_at"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.index ["claiming_user_id"], name: "index_challenge_claims_on_claiming_user_id"
+    t.index ["collection_id"], name: "index_challenge_claims_on_collection_id"
+    t.index ["creation_id", "creation_type"], name: "creations"
+    t.index ["request_signup_id"], name: "index_challenge_claims_on_request_signup_id"
   end
 
-  add_index "challenge_claims", ["claiming_user_id"], :name => "index_challenge_claims_on_claiming_user_id"
-  add_index "challenge_claims", ["collection_id"], :name => "index_challenge_claims_on_collection_id"
-  add_index "challenge_claims", ["creation_id", "creation_type"], :name => "creations"
-  add_index "challenge_claims", ["request_signup_id"], :name => "index_challenge_claims_on_request_signup_id"
-
-  create_table "challenge_signups", :force => true do |t|
-    t.integer  "collection_id"
-    t.integer  "pseud_id"
+  create_table "challenge_signups", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC" do |t|
+    t.integer "collection_id"
+    t.integer "pseud_id"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.boolean  "assigned_as_request", :default => false
-    t.boolean  "assigned_as_offer",   :default => false
+    t.boolean "assigned_as_request", default: false
+    t.boolean "assigned_as_offer", default: false
+    t.index ["collection_id"], name: "index_challenge_signups_on_collection_id"
+    t.index ["pseud_id"], name: "signups_on_pseud_id"
   end
 
-  add_index "challenge_signups", ["collection_id"], :name => "index_challenge_signups_on_collection_id"
-  add_index "challenge_signups", ["pseud_id"], :name => "signups_on_pseud_id"
-
-  create_table "chapters", :force => true do |t|
-    t.text     "content",                    :limit => 2147483647,                    :null => false
-    t.integer  "position",                                         :default => 1
-    t.integer  "work_id"
+  create_table "chapters", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+    t.text "content", limit: 4294967295, null: false, collation: "utf8mb4_unicode_ci"
+    t.integer "position", default: 1
+    t.integer "work_id"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.boolean  "posted",                                           :default => false, :null => false
-    t.string   "title"
-    t.text     "notes"
-    t.text     "summary"
-    t.integer  "word_count"
-    t.boolean  "hidden_by_admin",                                  :default => false, :null => false
-    t.date     "published_at"
-    t.text     "endnotes"
-    t.integer  "content_sanitizer_version",  :limit => 2,          :default => 0,     :null => false
-    t.integer  "notes_sanitizer_version",    :limit => 2,          :default => 0,     :null => false
-    t.integer  "summary_sanitizer_version",  :limit => 2,          :default => 0,     :null => false
-    t.integer  "endnotes_sanitizer_version", :limit => 2,          :default => 0,     :null => false
+    t.boolean "posted", default: false, null: false
+    t.string "title", collation: "utf8mb4_unicode_ci"
+    t.text "notes", collation: "utf8mb4_unicode_ci"
+    t.text "summary", collation: "utf8mb4_unicode_ci"
+    t.integer "word_count"
+    t.boolean "hidden_by_admin", default: false, null: false
+    t.date "published_at"
+    t.text "endnotes", collation: "utf8mb4_unicode_ci"
+    t.integer "content_sanitizer_version", limit: 2, default: 0, null: false
+    t.integer "notes_sanitizer_version", limit: 2, default: 0, null: false
+    t.integer "summary_sanitizer_version", limit: 2, default: 0, null: false
+    t.integer "endnotes_sanitizer_version", limit: 2, default: 0, null: false
+    t.index ["work_id"], name: "index_chapters_on_work_id"
+    t.index ["work_id"], name: "works_chapter_index"
   end
 
-  add_index "chapters", ["work_id"], :name => "index_chapters_on_work_id"
-  add_index "chapters", ["work_id"], :name => "works_chapter_index"
-
-  create_table "collection_items", :force => true do |t|
-    t.integer  "collection_id"
-    t.integer  "item_id"
-    t.string   "item_type",                               :default => "Work"
-    t.integer  "user_approval_status",       :limit => 1, :default => 0,      :null => false
-    t.integer  "collection_approval_status", :limit => 1, :default => 0,      :null => false
+  create_table "collection_items", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC" do |t|
+    t.integer "collection_id"
+    t.integer "item_id"
+    t.string "item_type", default: "Work"
+    t.integer "user_approval_status", limit: 1, default: 0, null: false
+    t.integer "collection_approval_status", limit: 1, default: 0, null: false
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.boolean  "anonymous",                               :default => false,  :null => false
-    t.boolean  "unrevealed",                              :default => false,  :null => false
+    t.boolean "anonymous", default: false, null: false
+    t.boolean "unrevealed", default: false, null: false
+    t.index ["anonymous"], name: "collection_items_anonymous"
+    t.index ["collection_id", "item_id", "item_type"], name: "by collection and item", unique: true
+    t.index ["collection_id", "user_approval_status", "collection_approval_status"], name: "index_collection_items_approval_status"
+    t.index ["item_id"], name: "collection_items_item_id"
+    t.index ["unrevealed"], name: "collection_items_unrevealed"
   end
 
-  add_index "collection_items", ["anonymous"], :name => "collection_items_anonymous"
-  add_index "collection_items", ["collection_id", "item_id", "item_type"], :name => "by collection and item", :unique => true
-  add_index "collection_items", ["collection_id", "user_approval_status", "collection_approval_status"], :name => "index_collection_items_approval_status"
-  add_index "collection_items", ["item_id"], :name => "collection_items_item_id"
-  add_index "collection_items", ["unrevealed"], :name => "collection_items_unrevealed"
-
-  create_table "collection_participants", :force => true do |t|
-    t.integer  "collection_id"
-    t.integer  "pseud_id"
-    t.string   "participant_role", :default => "None", :null => false
+  create_table "collection_participants", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC" do |t|
+    t.integer "collection_id"
+    t.integer "pseud_id"
+    t.string "participant_role", default: "None", null: false
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.index ["collection_id", "participant_role"], name: "participants_by_collection_and_role"
+    t.index ["collection_id", "pseud_id"], name: "by collection and pseud", unique: true
+    t.index ["pseud_id"], name: "participants_pseud_id"
   end
 
-  add_index "collection_participants", ["collection_id", "participant_role"], :name => "participants_by_collection_and_role"
-  add_index "collection_participants", ["collection_id", "pseud_id"], :name => "by collection and pseud", :unique => true
-  add_index "collection_participants", ["pseud_id"], :name => "participants_pseud_id"
-
-  create_table "collection_preferences", :force => true do |t|
-    t.integer  "collection_id"
+  create_table "collection_preferences", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC" do |t|
+    t.integer "collection_id"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.boolean  "moderated",     :default => false, :null => false
-    t.boolean  "closed",        :default => false, :null => false
-    t.boolean  "unrevealed",    :default => false, :null => false
-    t.boolean  "anonymous",     :default => false, :null => false
-    t.boolean  "gift_exchange", :default => false, :null => false
-    t.boolean  "show_random",   :default => false, :null => false
-    t.boolean  "prompt_meme",   :default => false, :null => false
-    t.boolean  "email_notify",  :default => false, :null => false
+    t.boolean "moderated", default: false, null: false
+    t.boolean "closed", default: false, null: false
+    t.boolean "unrevealed", default: false, null: false
+    t.boolean "anonymous", default: false, null: false
+    t.boolean "gift_exchange", default: false, null: false
+    t.boolean "show_random", default: false, null: false
+    t.boolean "prompt_meme", default: false, null: false
+    t.boolean "email_notify", default: false, null: false
+    t.index ["collection_id"], name: "index_collection_preferences_on_collection_id"
   end
 
-  add_index "collection_preferences", ["collection_id"], :name => "index_collection_preferences_on_collection_id"
-
-  create_table "collection_profiles", :force => true do |t|
-    t.integer  "collection_id"
-    t.text     "intro",                   :limit => 16777215
-    t.text     "faq",                     :limit => 16777215
-    t.text     "rules",                   :limit => 16777215
+  create_table "collection_profiles", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC" do |t|
+    t.integer "collection_id"
+    t.text "intro", limit: 16777215
+    t.text "faq", limit: 16777215
+    t.text "rules", limit: 16777215
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.text     "gift_notification"
-    t.integer  "intro_sanitizer_version", :limit => 2,        :default => 0, :null => false
-    t.integer  "faq_sanitizer_version",   :limit => 2,        :default => 0, :null => false
-    t.integer  "rules_sanitizer_version", :limit => 2,        :default => 0, :null => false
-    t.text     "assignment_notification"
+    t.text "gift_notification"
+    t.integer "intro_sanitizer_version", limit: 2, default: 0, null: false
+    t.integer "faq_sanitizer_version", limit: 2, default: 0, null: false
+    t.integer "rules_sanitizer_version", limit: 2, default: 0, null: false
+    t.text "assignment_notification"
+    t.index ["collection_id"], name: "index_collection_profiles_on_collection_id"
   end
 
-  add_index "collection_profiles", ["collection_id"], :name => "index_collection_profiles_on_collection_id"
-
-  create_table "collections", :force => true do |t|
-    t.string   "name"
-    t.string   "title"
-    t.string   "email"
-    t.string   "header_image_url"
-    t.text     "description"
+  create_table "collections", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC" do |t|
+    t.string "name"
+    t.string "title"
+    t.string "email"
+    t.string "header_image_url"
+    t.text "description"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.integer  "parent_id"
-    t.integer  "challenge_id"
-    t.string   "challenge_type"
-    t.string   "icon_file_name"
-    t.string   "icon_content_type"
-    t.integer  "icon_file_size"
+    t.integer "parent_id"
+    t.integer "challenge_id"
+    t.string "challenge_type"
+    t.string "icon_file_name"
+    t.string "icon_content_type"
+    t.integer "icon_file_size"
     t.datetime "icon_updated_at"
-    t.integer  "description_sanitizer_version", :limit => 2, :default => 0,  :null => false
-    t.string   "icon_alt_text",                              :default => ""
-    t.string   "icon_comment_text",                          :default => ""
+    t.integer "description_sanitizer_version", limit: 2, default: 0, null: false
+    t.string "icon_alt_text", default: ""
+    t.string "icon_comment_text", default: ""
+    t.index ["name"], name: "index_collections_on_name"
+    t.index ["parent_id"], name: "index_collections_on_parent_id"
   end
 
-  add_index "collections", ["name"], :name => "index_collections_on_name"
-  add_index "collections", ["parent_id"], :name => "index_collections_on_parent_id"
-
-  create_table "comments", :force => true do |t|
-    t.integer  "pseud_id"
-    t.text     "content",                                                   :null => false
-    t.integer  "depth"
-    t.integer  "threaded_left"
-    t.integer  "threaded_right"
-    t.boolean  "is_deleted",                             :default => false, :null => false
-    t.string   "name"
-    t.string   "email"
-    t.string   "ip_address"
-    t.integer  "commentable_id"
-    t.string   "commentable_type"
+  create_table "comments", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC" do |t|
+    t.integer "pseud_id"
+    t.text "comment_content", null: false
+    t.integer "depth"
+    t.integer "threaded_left"
+    t.integer "threaded_right"
+    t.boolean "is_deleted", default: false, null: false
+    t.string "name"
+    t.string "email"
+    t.string "ip_address"
+    t.integer "commentable_id"
+    t.string "commentable_type"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.integer  "thread"
-    t.string   "user_agent"
-    t.boolean  "approved",                               :default => false, :null => false
-    t.boolean  "hidden_by_admin",                        :default => false, :null => false
+    t.integer "thread"
+    t.string "user_agent"
+    t.boolean "approved", default: false, null: false
+    t.boolean "hidden_by_admin", default: false, null: false
     t.datetime "edited_at"
-    t.integer  "parent_id"
-    t.string   "parent_type"
-    t.integer  "content_sanitizer_version", :limit => 2, :default => 0,     :null => false
-    t.boolean  "unreviewed",                             :default => false, :null => false
+    t.integer "parent_id"
+    t.string "parent_type"
+    t.integer "comment_content_sanitizer_version", limit: 2, default: 0, null: false
+    t.boolean "unreviewed", default: false, null: false
+    t.index ["commentable_id", "commentable_type"], name: "index_comments_commentable"
+    t.index ["ip_address"], name: "index_comments_on_ip_address"
+    t.index ["parent_id", "parent_type"], name: "index_comments_parent"
+    t.index ["pseud_id"], name: "index_comments_on_pseud_id"
+    t.index ["thread"], name: "comments_by_thread"
   end
 
-  add_index "comments", ["commentable_id", "commentable_type"], :name => "index_comments_commentable"
-  add_index "comments", ["parent_id", "parent_type"], :name => "index_comments_parent"
-  add_index "comments", ["pseud_id"], :name => "index_comments_on_pseud_id"
-  add_index "comments", ["thread"], :name => "comments_by_thread"
-
-  create_table "common_taggings", :force => true do |t|
-    t.integer  "common_tag_id",                  :null => false
-    t.integer  "filterable_id",                  :null => false
-    t.string   "filterable_type", :limit => 100
+  create_table "common_taggings", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC" do |t|
+    t.integer "common_tag_id", null: false
+    t.integer "filterable_id", null: false
+    t.string "filterable_type", limit: 100
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.index ["common_tag_id", "filterable_type", "filterable_id"], name: "index_common_tags", unique: true
+    t.index ["filterable_id"], name: "index_common_taggings_on_filterable_id"
   end
 
-  add_index "common_taggings", ["common_tag_id", "filterable_type", "filterable_id"], :name => "index_common_tags", :unique => true
-  add_index "common_taggings", ["filterable_id"], :name => "index_common_taggings_on_filterable_id"
-
-  create_table "creatorships", :force => true do |t|
-    t.integer  "creation_id"
-    t.string   "creation_type", :limit => 100
-    t.integer  "pseud_id"
+  create_table "creatorships", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC" do |t|
+    t.integer "creation_id"
+    t.string "creation_type", limit: 100
+    t.integer "pseud_id"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.boolean "approved", default: false, null: false
+    t.index ["creation_id", "creation_type", "pseud_id"], name: "creation_id_creation_type_pseud_id", unique: true
+    t.index ["pseud_id"], name: "index_creatorships_pseud"
   end
 
-  add_index "creatorships", ["creation_id", "creation_type", "pseud_id"], :name => "creation_id_creation_type_pseud_id", :unique => true
-  add_index "creatorships", ["pseud_id"], :name => "index_creatorships_pseud"
-
-  create_table "delayed_jobs", :force => true do |t|
-    t.integer  "priority",   :default => 0
-    t.integer  "attempts",   :default => 0
-    t.text     "handler"
-    t.text     "last_error"
+  create_table "delayed_jobs", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC" do |t|
+    t.integer "priority", default: 0
+    t.integer "attempts", default: 0
+    t.text "handler"
+    t.text "last_error"
     t.datetime "run_at"
     t.datetime "locked_at"
     t.datetime "failed_at"
-    t.string   "locked_by"
+    t.string "locked_by"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.index ["failed_at"], name: "delayed_jobs_failed_at"
+    t.index ["locked_at"], name: "delayed_jobs_locked_at"
+    t.index ["locked_by"], name: "delayed_jobs_locked_by"
+    t.index ["run_at"], name: "delayed_jobs_run_at"
   end
 
-  add_index "delayed_jobs", ["failed_at"], :name => "delayed_jobs_failed_at"
-  add_index "delayed_jobs", ["locked_at"], :name => "delayed_jobs_locked_at"
-  add_index "delayed_jobs", ["locked_by"], :name => "delayed_jobs_locked_by"
-  add_index "delayed_jobs", ["run_at"], :name => "delayed_jobs_run_at"
-
-  create_table "external_author_names", :force => true do |t|
-    t.integer  "external_author_id", :null => false
-    t.string   "name"
+  create_table "external_author_names", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC" do |t|
+    t.integer "external_author_id", null: false
+    t.string "name"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.index ["external_author_id"], name: "index_external_author_names_on_external_author_id"
   end
 
-  add_index "external_author_names", ["external_author_id"], :name => "index_external_author_names_on_external_author_id"
-
-  create_table "external_authors", :force => true do |t|
-    t.string   "email"
-    t.boolean  "is_claimed",    :default => false, :null => false
-    t.integer  "user_id"
-    t.boolean  "do_not_email",  :default => false, :null => false
-    t.boolean  "do_not_import", :default => false, :null => false
+  create_table "external_authors", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC" do |t|
+    t.string "email"
+    t.boolean "is_claimed", default: false, null: false
+    t.integer "user_id"
+    t.boolean "do_not_email", default: false, null: false
+    t.boolean "do_not_import", default: false, null: false
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.index ["email"], name: "index_external_authors_on_email"
+    t.index ["user_id"], name: "index_external_authors_on_user_id"
   end
 
-  add_index "external_authors", ["email"], :name => "index_external_authors_on_email"
-  add_index "external_authors", ["user_id"], :name => "index_external_authors_on_user_id"
-
-  create_table "external_creatorships", :force => true do |t|
-    t.integer  "creation_id"
-    t.string   "creation_type"
+  create_table "external_creatorships", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC" do |t|
+    t.integer "creation_id"
+    t.string "creation_type"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.integer  "archivist_id"
-    t.integer  "external_author_name_id"
+    t.integer "archivist_id"
+    t.integer "external_author_name_id"
+    t.index ["archivist_id"], name: "index_external_creatorships_on_archivist_id"
+    t.index ["creation_id", "creation_type"], name: "index_external_creatorships_on_creation_id_and_creation_type"
+    t.index ["external_author_name_id"], name: "index_external_creatorships_on_external_author_name_id"
   end
 
-  add_index "external_creatorships", ["archivist_id"], :name => "index_external_creatorships_on_archivist_id"
-  add_index "external_creatorships", ["creation_id", "creation_type"], :name => "index_external_creatorships_on_creation_id_and_creation_type"
-  add_index "external_creatorships", ["external_author_name_id"], :name => "index_external_creatorships_on_external_author_name_id"
-
-  create_table "external_works", :force => true do |t|
-    t.string   "url",                                                       :null => false
-    t.string   "author",                                                    :null => false
-    t.boolean  "dead",                                   :default => false, :null => false
+  create_table "external_works", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC" do |t|
+    t.string "url", null: false
+    t.string "author", null: false
+    t.boolean "dead", default: false, null: false
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string   "title",                                                     :null => false
-    t.text     "summary"
-    t.boolean  "hidden_by_admin",                        :default => false, :null => false
-    t.integer  "summary_sanitizer_version", :limit => 2, :default => 0,     :null => false
-    t.integer  "language_id"
+    t.string "title", null: false
+    t.text "summary"
+    t.boolean "hidden_by_admin", default: false, null: false
+    t.integer "summary_sanitizer_version", limit: 2, default: 0, null: false
+    t.integer "language_id"
   end
 
-  create_table "fannish_next_of_kins", :force => true do |t|
+  create_table "fannish_next_of_kins", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC" do |t|
     t.integer "user_id"
     t.integer "kin_id"
-    t.string  "kin_email"
+    t.string "kin_email"
+    t.index ["user_id"], name: "index_fannish_next_of_kins_on_user_id"
   end
 
-  add_index "fannish_next_of_kins", ["user_id"], :name => "index_fannish_next_of_kins_on_user_id"
-
-  create_table "favorite_tags", :force => true do |t|
+  create_table "favorite_tags", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC" do |t|
     t.integer "user_id"
     t.integer "tag_id"
+    t.index ["user_id", "tag_id"], name: "index_favorite_tags_on_user_id_and_tag_id", unique: true
   end
 
-  add_index "favorite_tags", ["user_id", "tag_id"], :name => "index_favorite_tags_on_user_id_and_tag_id", :unique => true
-
-  create_table "feedbacks", :force => true do |t|
-    t.text     "comment",                                                   :null => false
+  create_table "feedbacks", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC" do |t|
+    t.text "comment", null: false
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string   "email"
-    t.string   "summary"
-    t.string   "user_agent"
-    t.string   "category"
-    t.integer  "comment_sanitizer_version", :limit => 2, :default => 0,     :null => false
-    t.integer  "summary_sanitizer_version", :limit => 2, :default => 0,     :null => false
-    t.boolean  "approved",                               :default => false, :null => false
-    t.string   "ip_address"
-    t.string   "username"
-    t.string   "language"
+    t.string "email"
+    t.string "summary"
+    t.string "user_agent"
+    t.string "category"
+    t.integer "comment_sanitizer_version", limit: 2, default: 0, null: false
+    t.integer "summary_sanitizer_version", limit: 2, default: 0, null: false
+    t.boolean "approved", default: false, null: false
+    t.string "ip_address"
+    t.string "username"
+    t.string "language"
+    t.string "rollout"
   end
 
-  create_table "filter_counts", :force => true do |t|
-    t.integer  "filter_id",            :limit => 8,                :null => false
-    t.integer  "public_works_count",   :limit => 8, :default => 0
-    t.integer  "unhidden_works_count", :limit => 8, :default => 0
+  create_table "filter_counts", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC" do |t|
+    t.bigint "filter_id", null: false
+    t.bigint "public_works_count", default: 0
+    t.bigint "unhidden_works_count", default: 0
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.index ["filter_id"], name: "index_filter_counts_on_filter_id", unique: true
+    t.index ["public_works_count"], name: "index_public_works_count"
+    t.index ["unhidden_works_count"], name: "index_unhidden_works_count"
   end
 
-  add_index "filter_counts", ["filter_id"], :name => "index_filter_counts_on_filter_id", :unique => true
-  add_index "filter_counts", ["public_works_count"], :name => "index_public_works_count"
-  add_index "filter_counts", ["unhidden_works_count"], :name => "index_unhidden_works_count"
-
-  create_table "filter_taggings", :force => true do |t|
-    t.integer  "filter_id",       :limit => 8,                      :null => false
-    t.integer  "filterable_id",   :limit => 8,                      :null => false
-    t.string   "filterable_type", :limit => 100
+  create_table "filter_taggings", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC" do |t|
+    t.bigint "filter_id", null: false
+    t.bigint "filterable_id", null: false
+    t.string "filterable_type", limit: 100
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.boolean  "inherited",                      :default => false, :null => false
+    t.boolean "inherited", default: false, null: false
+    t.index ["filter_id", "filterable_type"], name: "index_filter_taggings_on_filter_id_and_filterable_type"
+    t.index ["filterable_id", "filterable_type"], name: "index_filter_taggings_filterable"
   end
 
-  add_index "filter_taggings", ["filter_id", "filterable_type"], :name => "index_filter_taggings_on_filter_id_and_filterable_type"
-  add_index "filter_taggings", ["filterable_id", "filterable_type"], :name => "index_filter_taggings_filterable"
-
-  create_table "gift_exchanges", :force => true do |t|
-    t.integer  "request_restriction_id"
-    t.integer  "offer_restriction_id"
-    t.integer  "requests_num_required",                                       :default => 1,     :null => false
-    t.integer  "offers_num_required",                                         :default => 1,     :null => false
-    t.integer  "requests_num_allowed",                                        :default => 1,     :null => false
-    t.integer  "offers_num_allowed",                                          :default => 1,     :null => false
+  create_table "gift_exchanges", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC" do |t|
+    t.integer "request_restriction_id"
+    t.integer "offer_restriction_id"
+    t.integer "requests_num_required", default: 1, null: false
+    t.integer "offers_num_required", default: 1, null: false
+    t.integer "requests_num_allowed", default: 1, null: false
+    t.integer "offers_num_allowed", default: 1, null: false
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.text     "signup_instructions_general"
-    t.text     "signup_instructions_requests"
-    t.text     "signup_instructions_offers"
-    t.boolean  "signup_open",                                                 :default => false, :null => false
+    t.text "signup_instructions_general"
+    t.text "signup_instructions_requests"
+    t.text "signup_instructions_offers"
+    t.boolean "signup_open", default: false, null: false
     t.datetime "signups_open_at"
     t.datetime "signups_close_at"
     t.datetime "assignments_due_at"
     t.datetime "works_reveal_at"
     t.datetime "authors_reveal_at"
-    t.integer  "prompt_restriction_id"
-    t.string   "request_url_label"
-    t.string   "request_description_label"
-    t.string   "offer_url_label"
-    t.string   "offer_description_label"
-    t.string   "time_zone"
-    t.integer  "potential_match_settings_id"
+    t.integer "prompt_restriction_id"
+    t.string "request_url_label"
+    t.string "request_description_label"
+    t.string "offer_url_label"
+    t.string "offer_description_label"
+    t.string "time_zone"
+    t.integer "potential_match_settings_id"
     t.datetime "assignments_sent_at"
-    t.integer  "signup_instructions_general_sanitizer_version",  :limit => 2, :default => 0,     :null => false
-    t.integer  "signup_instructions_requests_sanitizer_version", :limit => 2, :default => 0,     :null => false
-    t.integer  "signup_instructions_offers_sanitizer_version",   :limit => 2, :default => 0,     :null => false
-    t.boolean  "requests_summary_visible",                                    :default => false, :null => false
+    t.integer "signup_instructions_general_sanitizer_version", limit: 2, default: 0, null: false
+    t.integer "signup_instructions_requests_sanitizer_version", limit: 2, default: 0, null: false
+    t.integer "signup_instructions_offers_sanitizer_version", limit: 2, default: 0, null: false
+    t.boolean "requests_summary_visible", default: false, null: false
   end
 
-  create_table "gifts", :force => true do |t|
-    t.integer  "work_id"
-    t.string   "recipient_name"
+  create_table "gifts", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC" do |t|
+    t.integer "work_id"
+    t.string "recipient_name"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.integer  "pseud_id"
-    t.boolean  "rejected",       :default => false, :null => false
+    t.integer "pseud_id"
+    t.boolean "rejected", default: false, null: false
+    t.index ["pseud_id"], name: "index_gifts_on_pseud_id"
+    t.index ["recipient_name"], name: "index_gifts_on_recipient_name"
+    t.index ["work_id"], name: "index_gifts_on_work_id"
   end
 
-  add_index "gifts", ["pseud_id"], :name => "index_gifts_on_pseud_id"
-  add_index "gifts", ["recipient_name"], :name => "index_gifts_on_recipient_name"
-  add_index "gifts", ["work_id"], :name => "index_gifts_on_work_id"
-
-  create_table "inbox_comments", :force => true do |t|
-    t.integer  "user_id"
-    t.integer  "feedback_comment_id"
+  create_table "inbox_comments", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC" do |t|
+    t.integer "user_id"
+    t.integer "feedback_comment_id"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.boolean  "read",                :default => false, :null => false
-    t.boolean  "replied_to",          :default => false, :null => false
+    t.boolean "read", default: false, null: false
+    t.boolean "replied_to", default: false, null: false
+    t.index ["feedback_comment_id"], name: "index_inbox_comments_on_feedback_comment_id"
+    t.index ["read", "user_id"], name: "index_inbox_comments_on_read_and_user_id"
+    t.index ["user_id"], name: "index_inbox_comments_on_user_id"
   end
 
-  add_index "inbox_comments", ["feedback_comment_id"], :name => "index_inbox_comments_on_feedback_comment_id"
-  add_index "inbox_comments", ["read", "user_id"], :name => "index_inbox_comments_on_read_and_user_id"
-  add_index "inbox_comments", ["user_id"], :name => "index_inbox_comments_on_user_id"
+  create_table "innodb_monitor", id: false, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+    t.integer "a"
+  end
 
-  create_table "invitations", :force => true do |t|
-    t.integer  "creator_id"
-    t.string   "invitee_email"
-    t.string   "token"
+  create_table "invitations", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC" do |t|
+    t.integer "creator_id"
+    t.string "invitee_email"
+    t.string "token"
     t.datetime "sent_at"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.boolean  "used",               :default => false, :null => false
-    t.integer  "invitee_id"
-    t.string   "invitee_type"
-    t.string   "creator_type"
+    t.boolean "used", default: false, null: false
+    t.integer "invitee_id"
+    t.string "invitee_type"
+    t.string "creator_type"
     t.datetime "redeemed_at"
-    t.boolean  "from_queue",         :default => false, :null => false
-    t.integer  "external_author_id"
+    t.boolean "from_queue", default: false, null: false
+    t.integer "external_author_id"
+    t.index ["creator_id", "creator_type"], name: "index_invitations_on_creator_id_and_creator_type"
+    t.index ["external_author_id"], name: "index_invitations_on_external_author_id"
+    t.index ["invitee_id", "invitee_type"], name: "index_invitations_on_invitee_id_and_invitee_type"
+    t.index ["token"], name: "index_invitations_on_token"
   end
 
-  add_index "invitations", ["creator_id", "creator_type"], :name => "index_invitations_on_creator_id_and_creator_type"
-  add_index "invitations", ["external_author_id"], :name => "index_invitations_on_external_author_id"
-  add_index "invitations", ["invitee_id", "invitee_type"], :name => "index_invitations_on_invitee_id_and_invitee_type"
-  add_index "invitations", ["token"], :name => "index_invitations_on_token"
-
-  create_table "invite_requests", :force => true do |t|
-    t.string   "email"
-    t.integer  "position"
+  create_table "invite_requests", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC" do |t|
+    t.string "email"
+    t.integer "position"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.string "simplified_email", default: "", null: false
+    t.string "ip_address"
+    t.index ["email"], name: "index_invite_requests_on_email"
+    t.index ["simplified_email"], name: "index_invite_requests_on_simplified_email", unique: true
   end
 
-  add_index "invite_requests", ["email"], :name => "index_invite_requests_on_email"
-
-  create_table "known_issues", :force => true do |t|
-    t.integer  "admin_id"
-    t.string   "title"
-    t.text     "content"
+  create_table "known_issues", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC" do |t|
+    t.integer "admin_id"
+    t.string "title"
+    t.text "content"
     t.datetime "updated_at"
     t.datetime "created_at"
-    t.integer  "content_sanitizer_version", :limit => 2, :default => 0, :null => false
+    t.integer "content_sanitizer_version", limit: 2, default: 0, null: false
   end
 
-  create_table "kudos", :force => true do |t|
-    t.integer  "pseud_id"
-    t.integer  "commentable_id"
-    t.string   "commentable_type"
+  create_table "kudos", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC" do |t|
+    t.integer "pseud_id"
+    t.integer "commentable_id"
+    t.string "commentable_type", collation: "utf8_general_ci"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string   "ip_address"
+    t.string "ip_address", collation: "utf8_general_ci"
+    t.index ["commentable_id", "commentable_type", "pseud_id"], name: "index_kudos_on_commentable_id_and_commentable_type_and_pseud_id"
+    t.index ["ip_address"], name: "index_kudos_on_ip_address"
+    t.index ["pseud_id"], name: "index_kudos_on_pseud_id"
   end
 
-  add_index "kudos", ["commentable_id", "commentable_type", "pseud_id"], :name => "index_kudos_on_commentable_id_and_commentable_type_and_pseud_id"
-  add_index "kudos", ["ip_address"], :name => "index_kudos_on_ip_address"
-  add_index "kudos", ["pseud_id"], :name => "index_kudos_on_pseud_id"
-
-  create_table "languages", :force => true do |t|
-    t.string  "short",                   :limit => 4
-    t.string  "name"
-    t.boolean "support_available",                    :default => false, :null => false
-    t.boolean "abuse_support_available",              :default => false, :null => false
+  create_table "languages", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC" do |t|
+    t.string "short", limit: 4
+    t.string "name"
+    t.boolean "support_available", default: false, null: false
+    t.boolean "abuse_support_available", default: false, null: false
+    t.string "sortable_name", default: "", null: false
+    t.index ["short"], name: "index_languages_on_short"
+    t.index ["sortable_name"], name: "index_languages_on_sortable_name"
   end
 
-  add_index "languages", ["short"], :name => "index_languages_on_short"
-
-  create_table "locales", :force => true do |t|
-    t.string   "iso"
-    t.string   "short"
-    t.string   "name"
-    t.boolean  "main"
+  create_table "locales", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC" do |t|
+    t.string "iso"
+    t.string "short"
+    t.string "name"
+    t.boolean "main"
     t.datetime "updated_at"
-    t.integer  "language_id",                          :null => false
-    t.boolean  "interface_enabled", :default => false, :null => false
-    t.boolean  "email_enabled",     :default => false, :null => false
+    t.integer "language_id", null: false
+    t.boolean "interface_enabled", default: false, null: false
+    t.boolean "email_enabled", default: false, null: false
+    t.index ["iso"], name: "index_locales_on_iso"
+    t.index ["language_id"], name: "index_locales_on_language_id"
+    t.index ["short"], name: "index_locales_on_short"
   end
 
-  add_index "locales", ["iso"], :name => "index_locales_on_iso"
-  add_index "locales", ["language_id"], :name => "index_locales_on_language_id"
-  add_index "locales", ["short"], :name => "index_locales_on_short"
-
-  create_table "log_items", :force => true do |t|
-    t.integer  "user_id",                                            :null => false
-    t.integer  "admin_id"
-    t.integer  "role_id"
-    t.integer  "action",                 :limit => 1
-    t.text     "note",                                               :null => false
+  create_table "log_items", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC" do |t|
+    t.integer "user_id", null: false
+    t.integer "admin_id"
+    t.integer "role_id"
+    t.integer "action", limit: 1
+    t.text "note", null: false
     t.datetime "enddate"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.integer  "note_sanitizer_version", :limit => 2, :default => 0, :null => false
+    t.integer "note_sanitizer_version", limit: 2, default: 0, null: false
+    t.index ["admin_id"], name: "index_log_items_on_admin_id"
+    t.index ["role_id"], name: "index_log_items_on_role_id"
+    t.index ["user_id"], name: "index_log_items_on_user_id"
   end
 
-  add_index "log_items", ["admin_id"], :name => "index_log_items_on_admin_id"
-  add_index "log_items", ["role_id"], :name => "index_log_items_on_role_id"
-  add_index "log_items", ["user_id"], :name => "index_log_items_on_user_id"
-
-  create_table "meta_taggings", :force => true do |t|
-    t.integer  "meta_tag_id", :limit => 8,                   :null => false
-    t.integer  "sub_tag_id",  :limit => 8,                   :null => false
-    t.boolean  "direct",                   :default => true
+  create_table "meta_taggings", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC" do |t|
+    t.bigint "meta_tag_id", null: false
+    t.bigint "sub_tag_id", null: false
+    t.boolean "direct", default: true
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.index ["meta_tag_id", "sub_tag_id"], name: "index_meta_taggings_on_meta_tag_id_and_sub_tag_id", unique: true
+    t.index ["sub_tag_id"], name: "index_meta_taggings_on_sub_tag_id"
   end
 
-  add_index "meta_taggings", ["meta_tag_id"], :name => "index_meta_taggings_on_meta_tag_id"
-  add_index "meta_taggings", ["sub_tag_id"], :name => "index_meta_taggings_on_sub_tag_id"
+  create_table "moderated_works", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC" do |t|
+    t.bigint "work_id", null: false
+    t.boolean "approved", default: false, null: false
+    t.boolean "reviewed", default: false, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["work_id"], name: "index_moderated_works_on_work_id"
+  end
 
-  create_table "open_id_authentication_associations", :force => true do |t|
+  create_table "open_id_authentication_associations", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC" do |t|
     t.integer "issued"
     t.integer "lifetime"
-    t.string  "handle"
-    t.string  "assoc_type"
-    t.binary  "server_url"
-    t.binary  "secret"
+    t.string "handle"
+    t.string "assoc_type"
+    t.binary "server_url"
+    t.binary "secret"
   end
 
-  create_table "open_id_authentication_nonces", :force => true do |t|
-    t.integer "timestamp",  :null => false
-    t.string  "server_url"
-    t.string  "salt",       :null => false
+  create_table "open_id_authentication_nonces", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC" do |t|
+    t.integer "timestamp", null: false
+    t.string "server_url"
+    t.string "salt", null: false
   end
 
-  create_table "owned_set_taggings", :force => true do |t|
-    t.integer  "owned_tag_set_id"
-    t.integer  "set_taggable_id"
-    t.string   "set_taggable_type", :limit => 100
+  create_table "owned_set_taggings", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC" do |t|
+    t.integer "owned_tag_set_id"
+    t.integer "set_taggable_id"
+    t.string "set_taggable_type", limit: 100
     t.datetime "created_at"
     t.datetime "updated_at"
   end
 
-  create_table "owned_tag_sets", :force => true do |t|
-    t.integer  "tag_set_id"
-    t.boolean  "visible",                                    :default => false, :null => false
-    t.boolean  "nominated",                                  :default => false, :null => false
-    t.string   "title"
-    t.string   "description"
+  create_table "owned_tag_sets", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC" do |t|
+    t.integer "tag_set_id"
+    t.boolean "visible", default: false, null: false
+    t.boolean "nominated", default: false, null: false
+    t.string "title"
+    t.string "description"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.boolean  "featured",                                   :default => false, :null => false
-    t.integer  "description_sanitizer_version", :limit => 2, :default => 0,     :null => false
-    t.integer  "fandom_nomination_limit",                    :default => 0,     :null => false
-    t.integer  "character_nomination_limit",                 :default => 0,     :null => false
-    t.integer  "relationship_nomination_limit",              :default => 0,     :null => false
-    t.integer  "freeform_nomination_limit",                  :default => 0,     :null => false
-    t.boolean  "usable",                                     :default => false, :null => false
+    t.boolean "featured", default: false, null: false
+    t.integer "description_sanitizer_version", limit: 2, default: 0, null: false
+    t.integer "fandom_nomination_limit", default: 0, null: false
+    t.integer "character_nomination_limit", default: 0, null: false
+    t.integer "relationship_nomination_limit", default: 0, null: false
+    t.integer "freeform_nomination_limit", default: 0, null: false
+    t.boolean "usable", default: false, null: false
   end
 
-  create_table "potential_match_settings", :force => true do |t|
-    t.integer  "num_required_prompts",           :default => 1,     :null => false
-    t.integer  "num_required_fandoms",           :default => 0,     :null => false
-    t.integer  "num_required_characters",        :default => 0,     :null => false
-    t.integer  "num_required_relationships",     :default => 0,     :null => false
-    t.integer  "num_required_freeforms",         :default => 0,     :null => false
-    t.integer  "num_required_categories",        :default => 0,     :null => false
-    t.integer  "num_required_ratings",           :default => 0,     :null => false
-    t.integer  "num_required_warnings",          :default => 0,     :null => false
-    t.boolean  "include_optional_fandoms",       :default => false, :null => false
-    t.boolean  "include_optional_characters",    :default => false, :null => false
-    t.boolean  "include_optional_relationships", :default => false, :null => false
-    t.boolean  "include_optional_freeforms",     :default => false, :null => false
-    t.boolean  "include_optional_categories",    :default => false, :null => false
-    t.boolean  "include_optional_ratings",       :default => false, :null => false
-    t.boolean  "include_optional_warnings",      :default => false, :null => false
+  create_table "potential_match_settings", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC" do |t|
+    t.integer "num_required_prompts", default: 1, null: false
+    t.integer "num_required_fandoms", default: 0, null: false
+    t.integer "num_required_characters", default: 0, null: false
+    t.integer "num_required_relationships", default: 0, null: false
+    t.integer "num_required_freeforms", default: 0, null: false
+    t.integer "num_required_categories", default: 0, null: false
+    t.integer "num_required_ratings", default: 0, null: false
+    t.integer "num_required_archive_warnings", default: 0, null: false
+    t.boolean "include_optional_fandoms", default: false, null: false
+    t.boolean "include_optional_characters", default: false, null: false
+    t.boolean "include_optional_relationships", default: false, null: false
+    t.boolean "include_optional_freeforms", default: false, null: false
+    t.boolean "include_optional_categories", default: false, null: false
+    t.boolean "include_optional_ratings", default: false, null: false
+    t.boolean "include_optional_archive_warnings", default: false, null: false
     t.datetime "created_at"
     t.datetime "updated_at"
   end
 
-  create_table "potential_matches", :force => true do |t|
-    t.integer  "collection_id"
-    t.integer  "offer_signup_id"
-    t.integer  "request_signup_id"
-    t.integer  "num_prompts_matched"
-    t.boolean  "assigned",            :default => false, :null => false
+  create_table "potential_matches", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC" do |t|
+    t.integer "collection_id"
+    t.integer "offer_signup_id"
+    t.integer "request_signup_id"
+    t.integer "num_prompts_matched"
+    t.boolean "assigned", default: false, null: false
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.integer  "max_tags_matched"
+    t.integer "max_tags_matched"
+    t.index ["collection_id"], name: "index_potential_matches_on_collection_id"
+    t.index ["offer_signup_id"], name: "index_potential_matches_on_offer_signup_id"
+    t.index ["request_signup_id"], name: "index_potential_matches_on_request_signup_id"
   end
 
-  add_index "potential_matches", ["collection_id"], :name => "index_potential_matches_on_collection_id"
-  add_index "potential_matches", ["offer_signup_id"], :name => "index_potential_matches_on_offer_signup_id"
-  add_index "potential_matches", ["request_signup_id"], :name => "index_potential_matches_on_request_signup_id"
-
-  create_table "preferences", :force => true do |t|
-    t.integer  "user_id"
-    t.boolean  "history_enabled",                   :default => true
-    t.boolean  "email_visible",                     :default => false
+  create_table "preferences", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC" do |t|
+    t.integer "user_id"
+    t.boolean "history_enabled", default: true
+    t.boolean "email_visible", default: false
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.boolean  "date_of_birth_visible",             :default => false
-    t.boolean  "edit_emails_off",                   :default => false,                     :null => false
-    t.boolean  "comment_emails_off",                :default => false,                     :null => false
-    t.boolean  "adult",                             :default => false
-    t.boolean  "hide_warnings",                     :default => false,                     :null => false
-    t.boolean  "comment_inbox_off",                 :default => false
-    t.boolean  "comment_copy_to_self_off",          :default => true,                      :null => false
-    t.string   "work_title_format",                 :default => "TITLE - AUTHOR - FANDOM"
-    t.boolean  "hide_freeform",                     :default => false,                     :null => false
-    t.boolean  "first_login",                       :default => true
-    t.boolean  "automatically_approve_collections", :default => false,                     :null => false
-    t.boolean  "collection_emails_off",             :default => false,                     :null => false
-    t.boolean  "collection_inbox_off",              :default => false,                     :null => false
-    t.boolean  "hide_private_hit_count",            :default => false,                     :null => false
-    t.boolean  "hide_public_hit_count",             :default => false,                     :null => false
-    t.boolean  "recipient_emails_off",              :default => false,                     :null => false
-    t.boolean  "hide_all_hit_counts",               :default => false,                     :null => false
-    t.boolean  "view_full_works",                   :default => false,                     :null => false
-    t.string   "time_zone"
-    t.boolean  "plain_text_skin",                   :default => false,                     :null => false
-    t.boolean  "admin_emails_off",                  :default => false,                     :null => false
-    t.boolean  "disable_work_skins",                :default => false,                     :null => false
-    t.integer  "skin_id"
-    t.boolean  "minimize_search_engines",           :default => false,                     :null => false
-    t.boolean  "kudos_emails_off",                  :default => false,                     :null => false
-    t.boolean  "disable_share_links",               :default => false,                     :null => false
-    t.boolean  "banner_seen",                       :default => false,                     :null => false
-    t.integer  "preferred_locale",                  :default => 1,                         :null => false
+    t.boolean "date_of_birth_visible", default: false
+    t.boolean "edit_emails_off", default: false, null: false
+    t.boolean "comment_emails_off", default: false, null: false
+    t.boolean "adult", default: false
+    t.boolean "hide_warnings", default: false, null: false
+    t.boolean "comment_inbox_off", default: false
+    t.boolean "comment_copy_to_self_off", default: true, null: false
+    t.string "work_title_format", default: "TITLE - AUTHOR - FANDOM"
+    t.boolean "hide_freeform", default: false, null: false
+    t.boolean "first_login", default: true
+    t.boolean "automatically_approve_collections", default: false, null: false
+    t.boolean "collection_emails_off", default: false, null: false
+    t.boolean "collection_inbox_off", default: false, null: false
+    t.boolean "hide_private_hit_count", default: false, null: false
+    t.boolean "hide_public_hit_count", default: false, null: false
+    t.boolean "recipient_emails_off", default: false, null: false
+    t.boolean "hide_all_hit_counts", default: false, null: false
+    t.boolean "view_full_works", default: false, null: false
+    t.string "time_zone"
+    t.boolean "plain_text_skin", default: false, null: false
+    t.boolean "disable_work_skins", default: false, null: false
+    t.integer "skin_id"
+    t.boolean "minimize_search_engines", default: false, null: false
+    t.boolean "kudos_emails_off", default: false, null: false
+    t.boolean "disable_share_links", default: false, null: false
+    t.boolean "banner_seen", default: false, null: false
+    t.integer "preferred_locale", default: 1, null: false
+    t.boolean "allow_cocreator", default: false
+    t.index ["skin_id"], name: "index_preferences_on_skin_id"
+    t.index ["user_id"], name: "index_preferences_on_user_id"
   end
 
-  add_index "preferences", ["user_id"], :name => "index_preferences_on_user_id"
-
-  create_table "profiles", :force => true do |t|
-    t.integer  "user_id"
-    t.string   "location"
-    t.text     "about_me"
-    t.date     "date_of_birth"
+  create_table "profiles", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC" do |t|
+    t.integer "user_id"
+    t.string "location"
+    t.text "about_me"
+    t.date "date_of_birth"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string   "title"
-    t.integer  "about_me_sanitizer_version", :limit => 2, :default => 0, :null => false
+    t.string "title"
+    t.integer "about_me_sanitizer_version", limit: 2, default: 0, null: false
+    t.index ["user_id"], name: "index_profiles_on_user_id"
   end
 
-  add_index "profiles", ["user_id"], :name => "index_profiles_on_user_id"
-
-  create_table "prompt_memes", :force => true do |t|
-    t.integer  "prompt_restriction_id"
-    t.integer  "request_restriction_id"
-    t.integer  "requests_num_required",                                       :default => 1,     :null => false
-    t.integer  "requests_num_allowed",                                        :default => 5,     :null => false
-    t.boolean  "signup_open",                                                 :default => true,  :null => false
+  create_table "prompt_memes", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC" do |t|
+    t.integer "prompt_restriction_id"
+    t.integer "request_restriction_id"
+    t.integer "requests_num_required", default: 1, null: false
+    t.integer "requests_num_allowed", default: 5, null: false
+    t.boolean "signup_open", default: true, null: false
     t.datetime "signups_open_at"
     t.datetime "signups_close_at"
     t.datetime "assignments_due_at"
     t.datetime "works_reveal_at"
     t.datetime "authors_reveal_at"
-    t.text     "signup_instructions_general"
-    t.text     "signup_instructions_requests"
-    t.string   "request_url_label"
-    t.string   "request_description_label"
-    t.string   "time_zone"
-    t.integer  "signup_instructions_general_sanitizer_version",  :limit => 2, :default => 0,     :null => false
-    t.integer  "signup_instructions_requests_sanitizer_version", :limit => 2, :default => 0,     :null => false
+    t.text "signup_instructions_general"
+    t.text "signup_instructions_requests"
+    t.string "request_url_label"
+    t.string "request_description_label"
+    t.string "time_zone"
+    t.integer "signup_instructions_general_sanitizer_version", limit: 2, default: 0, null: false
+    t.integer "signup_instructions_requests_sanitizer_version", limit: 2, default: 0, null: false
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.boolean  "anonymous",                                                   :default => false, :null => false
+    t.boolean "anonymous", default: false, null: false
   end
 
-  create_table "prompt_restrictions", :force => true do |t|
-    t.integer  "tag_set_id"
-    t.boolean  "optional_tags_allowed",            :default => false, :null => false
-    t.boolean  "description_allowed",              :default => true,  :null => false
-    t.boolean  "url_required",                     :default => false, :null => false
-    t.integer  "fandom_num_required",              :default => 0,     :null => false
-    t.integer  "category_num_required",            :default => 0,     :null => false
-    t.integer  "rating_num_required",              :default => 0,     :null => false
-    t.integer  "character_num_required",           :default => 0,     :null => false
-    t.integer  "relationship_num_required",        :default => 0,     :null => false
-    t.integer  "freeform_num_required",            :default => 0,     :null => false
-    t.integer  "warning_num_required",             :default => 0,     :null => false
-    t.integer  "fandom_num_allowed",               :default => 1,     :null => false
-    t.integer  "category_num_allowed",             :default => 0,     :null => false
-    t.integer  "rating_num_allowed",               :default => 0,     :null => false
-    t.integer  "character_num_allowed",            :default => 1,     :null => false
-    t.integer  "relationship_num_allowed",         :default => 1,     :null => false
-    t.integer  "freeform_num_allowed",             :default => 0,     :null => false
-    t.integer  "warning_num_allowed",              :default => 0,     :null => false
+  create_table "prompt_restrictions", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC" do |t|
+    t.integer "tag_set_id"
+    t.boolean "optional_tags_allowed", default: false, null: false
+    t.boolean "description_allowed", default: true, null: false
+    t.boolean "url_required", default: false, null: false
+    t.integer "fandom_num_required", default: 0, null: false
+    t.integer "category_num_required", default: 0, null: false
+    t.integer "rating_num_required", default: 0, null: false
+    t.integer "character_num_required", default: 0, null: false
+    t.integer "relationship_num_required", default: 0, null: false
+    t.integer "freeform_num_required", default: 0, null: false
+    t.integer "archive_warning_num_required", default: 0, null: false
+    t.integer "fandom_num_allowed", default: 1, null: false
+    t.integer "category_num_allowed", default: 0, null: false
+    t.integer "rating_num_allowed", default: 0, null: false
+    t.integer "character_num_allowed", default: 1, null: false
+    t.integer "relationship_num_allowed", default: 1, null: false
+    t.integer "freeform_num_allowed", default: 0, null: false
+    t.integer "archive_warning_num_allowed", default: 0, null: false
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.boolean  "description_required",             :default => false, :null => false
-    t.boolean  "url_allowed",                      :default => false, :null => false
-    t.boolean  "allow_any_fandom",                 :default => false, :null => false
-    t.boolean  "allow_any_character",              :default => false, :null => false
-    t.boolean  "allow_any_rating",                 :default => false, :null => false
-    t.boolean  "allow_any_relationship",           :default => false, :null => false
-    t.boolean  "allow_any_category",               :default => false, :null => false
-    t.boolean  "allow_any_warning",                :default => false, :null => false
-    t.boolean  "allow_any_freeform",               :default => false, :null => false
-    t.boolean  "require_unique_fandom",            :default => false, :null => false
-    t.boolean  "require_unique_character",         :default => false, :null => false
-    t.boolean  "require_unique_rating",            :default => false, :null => false
-    t.boolean  "require_unique_relationship",      :default => false, :null => false
-    t.boolean  "require_unique_category",          :default => false, :null => false
-    t.boolean  "require_unique_warning",           :default => false, :null => false
-    t.boolean  "require_unique_freeform",          :default => false, :null => false
-    t.boolean  "character_restrict_to_fandom",     :default => false, :null => false
-    t.boolean  "relationship_restrict_to_fandom",  :default => false, :null => false
-    t.boolean  "character_restrict_to_tag_set",    :default => false, :null => false
-    t.boolean  "relationship_restrict_to_tag_set", :default => false, :null => false
-    t.boolean  "title_required",                   :default => false, :null => false
-    t.boolean  "title_allowed",                    :default => false, :null => false
+    t.boolean "description_required", default: false, null: false
+    t.boolean "url_allowed", default: false, null: false
+    t.boolean "allow_any_fandom", default: false, null: false
+    t.boolean "allow_any_character", default: false, null: false
+    t.boolean "allow_any_rating", default: false, null: false
+    t.boolean "allow_any_relationship", default: false, null: false
+    t.boolean "allow_any_category", default: false, null: false
+    t.boolean "allow_any_archive_warning", default: false, null: false
+    t.boolean "allow_any_freeform", default: false, null: false
+    t.boolean "require_unique_fandom", default: false, null: false
+    t.boolean "require_unique_character", default: false, null: false
+    t.boolean "require_unique_rating", default: false, null: false
+    t.boolean "require_unique_relationship", default: false, null: false
+    t.boolean "require_unique_category", default: false, null: false
+    t.boolean "require_unique_archive_warning", default: false, null: false
+    t.boolean "require_unique_freeform", default: false, null: false
+    t.boolean "character_restrict_to_fandom", default: false, null: false
+    t.boolean "relationship_restrict_to_fandom", default: false, null: false
+    t.boolean "character_restrict_to_tag_set", default: false, null: false
+    t.boolean "relationship_restrict_to_tag_set", default: false, null: false
+    t.boolean "title_required", default: false, null: false
+    t.boolean "title_allowed", default: false, null: false
   end
 
-  create_table "prompts", :force => true do |t|
-    t.integer  "collection_id"
-    t.integer  "challenge_signup_id"
-    t.integer  "pseud_id"
-    t.integer  "tag_set_id"
-    t.integer  "optional_tag_set_id"
-    t.string   "title"
-    t.string   "url"
-    t.text     "description"
-    t.integer  "position"
+  create_table "prompts", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC" do |t|
+    t.integer "collection_id"
+    t.integer "challenge_signup_id"
+    t.integer "pseud_id"
+    t.integer "tag_set_id"
+    t.integer "optional_tag_set_id"
+    t.string "title"
+    t.string "url"
+    t.text "description"
+    t.integer "position"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string   "type"
-    t.integer  "description_sanitizer_version", :limit => 2, :default => 0,     :null => false
-    t.boolean  "any_fandom",                                 :default => false, :null => false
-    t.boolean  "any_character",                              :default => false, :null => false
-    t.boolean  "any_rating",                                 :default => false, :null => false
-    t.boolean  "any_relationship",                           :default => false, :null => false
-    t.boolean  "any_category",                               :default => false, :null => false
-    t.boolean  "any_warning",                                :default => false, :null => false
-    t.boolean  "any_freeform",                               :default => false, :null => false
-    t.boolean  "anonymous",                                  :default => false, :null => false
+    t.string "type"
+    t.integer "description_sanitizer_version", limit: 2, default: 0, null: false
+    t.boolean "any_fandom", default: false, null: false
+    t.boolean "any_character", default: false, null: false
+    t.boolean "any_rating", default: false, null: false
+    t.boolean "any_relationship", default: false, null: false
+    t.boolean "any_category", default: false, null: false
+    t.boolean "any_archive_warning", default: false, null: false
+    t.boolean "any_freeform", default: false, null: false
+    t.boolean "anonymous", default: false, null: false
+    t.index ["challenge_signup_id"], name: "index_prompts_on_challenge_signup_id"
+    t.index ["collection_id"], name: "index_prompts_on_collection_id"
+    t.index ["optional_tag_set_id"], name: "index_prompts_on_optional_tag_set_id"
+    t.index ["tag_set_id"], name: "index_prompts_on_tag_set_id"
+    t.index ["type"], name: "index_prompts_on_type"
   end
 
-  add_index "prompts", ["challenge_signup_id"], :name => "index_prompts_on_challenge_signup_id"
-  add_index "prompts", ["collection_id"], :name => "index_prompts_on_collection_id"
-  add_index "prompts", ["optional_tag_set_id"], :name => "index_prompts_on_optional_tag_set_id"
-  add_index "prompts", ["tag_set_id"], :name => "index_prompts_on_tag_set_id"
-  add_index "prompts", ["type"], :name => "index_prompts_on_type"
-
-  create_table "pseuds", :force => true do |t|
-    t.integer  "user_id"
-    t.string   "name",                                                          :null => false
-    t.text     "description"
-    t.boolean  "is_default",                                 :default => false, :null => false
+  create_table "pseuds", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC" do |t|
+    t.integer "user_id"
+    t.string "name", null: false
+    t.text "description"
+    t.boolean "is_default", default: false, null: false
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string   "icon_file_name"
-    t.string   "icon_content_type"
-    t.integer  "icon_file_size"
+    t.string "icon_file_name"
+    t.string "icon_content_type"
+    t.integer "icon_file_size"
     t.datetime "icon_updated_at"
-    t.string   "icon_alt_text",                              :default => ""
-    t.boolean  "delta",                                      :default => true
-    t.integer  "description_sanitizer_version", :limit => 2, :default => 0,     :null => false
-    t.string   "icon_comment_text",                          :default => ""
+    t.string "icon_alt_text", default: ""
+    t.boolean "delta", default: true
+    t.integer "description_sanitizer_version", limit: 2, default: 0, null: false
+    t.string "icon_comment_text", default: ""
+    t.index ["name"], name: "index_psueds_on_name"
+    t.index ["user_id", "name"], name: "index_pseuds_on_user_id_and_name"
   end
 
-  add_index "pseuds", ["name"], :name => "index_psueds_on_name"
-  add_index "pseuds", ["user_id", "name"], :name => "index_pseuds_on_user_id_and_name"
-
-  create_table "question_translations", :force => true do |t|
-    t.integer  "question_id"
-    t.string   "locale",                                                   :null => false
-    t.datetime "created_at",                                               :null => false
-    t.datetime "updated_at",                                               :null => false
-    t.string   "question"
-    t.text     "content"
-    t.integer  "content_sanitizer_version",    :limit => 2, :default => 0, :null => false
-    t.integer  "screencast_sanitizer_version", :limit => 2, :default => 0, :null => false
-    t.string   "is_translated"
+  create_table "question_translations", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC" do |t|
+    t.integer "question_id"
+    t.string "locale", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "question"
+    t.text "content"
+    t.integer "content_sanitizer_version", limit: 2, default: 0, null: false
+    t.integer "screencast_sanitizer_version", limit: 2, default: 0, null: false
+    t.string "is_translated"
+    t.index ["locale"], name: "index_question_translations_on_locale"
+    t.index ["question_id"], name: "index_question_translations_on_question_id"
   end
 
-  add_index "question_translations", ["locale"], :name => "index_question_translations_on_locale"
-  add_index "question_translations", ["question_id"], :name => "index_question_translations_on_question_id"
-
-  create_table "questions", :force => true do |t|
-    t.integer  "archive_faq_id"
-    t.string   "question"
-    t.text     "content"
-    t.string   "anchor"
-    t.text     "screencast"
-    t.datetime "created_at",                    :null => false
-    t.datetime "updated_at",                    :null => false
-    t.integer  "position",       :default => 1
+  create_table "questions", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC" do |t|
+    t.integer "archive_faq_id"
+    t.string "question"
+    t.text "content"
+    t.string "anchor"
+    t.text "screencast"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.integer "position", default: 1
+    t.index ["archive_faq_id", "position"], name: "index_questions_on_archive_faq_id_and_position"
   end
 
-  add_index "questions", ["archive_faq_id", "position"], :name => "index_questions_on_archive_faq_id_and_position"
-
-  create_table "readings", :force => true do |t|
-    t.integer  "major_version_read"
-    t.integer  "minor_version_read"
-    t.integer  "user_id"
-    t.integer  "work_id"
+  create_table "readings", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC" do |t|
+    t.integer "major_version_read"
+    t.integer "minor_version_read"
+    t.integer "user_id"
+    t.integer "work_id"
     t.datetime "created_at"
     t.datetime "last_viewed"
-    t.integer  "view_count",         :default => 0
-    t.boolean  "toread",             :default => false, :null => false
-    t.boolean  "toskip",             :default => false, :null => false
+    t.integer "view_count", default: 0
+    t.boolean "toread", default: false, null: false
+    t.boolean "toskip", default: false, null: false
+    t.index ["user_id"], name: "index_readings_on_user_id"
+    t.index ["work_id"], name: "index_readings_on_work_id"
   end
 
-  add_index "readings", ["user_id"], :name => "index_readings_on_user_id"
-  add_index "readings", ["work_id"], :name => "index_readings_on_work_id"
-
-  create_table "related_works", :force => true do |t|
-    t.integer  "parent_id"
-    t.string   "parent_type"
-    t.integer  "work_id"
-    t.boolean  "reciprocal",  :default => false, :null => false
-    t.datetime "created_at"
-    t.datetime "updated_at"
-    t.boolean  "translation", :default => false, :null => false
-  end
-
-  add_index "related_works", ["parent_id", "parent_type"], :name => "index_related_works_on_parent_id_and_parent_type"
-  add_index "related_works", ["work_id"], :name => "index_related_works_on_work_id"
-
-  create_table "roles", :force => true do |t|
-    t.string   "name",              :limit => 40
-    t.string   "authorizable_type", :limit => 40
-    t.integer  "authorizable_id"
-    t.datetime "created_at"
-    t.datetime "updated_at"
-  end
-
-  add_index "roles", ["authorizable_id", "authorizable_type"], :name => "index_roles_on_authorizable_id_and_authorizable_type"
-  add_index "roles", ["authorizable_type"], :name => "index_roles_on_authorizable_type"
-  add_index "roles", ["name"], :name => "index_roles_on_name"
-
-  create_table "roles_users", :id => false, :force => true do |t|
-    t.integer  "user_id"
-    t.integer  "role_id"
-    t.datetime "created_at"
-    t.datetime "updated_at"
-  end
-
-  add_index "roles_users", ["role_id", "user_id"], :name => "index_roles_users_on_role_id_and_user_id"
-  add_index "roles_users", ["user_id", "role_id"], :name => "index_roles_users_on_user_id_and_role_id"
-
-  create_table "saved_works", :force => true do |t|
-    t.integer  "user_id",    :null => false
-    t.integer  "work_id",    :null => false
-    t.datetime "created_at", :null => false
-    t.datetime "updated_at", :null => false
-  end
-
-  add_index "saved_works", ["user_id", "work_id"], :name => "index_saved_works_on_user_id_and_work_id", :unique => true
-
-  create_table "searches", :force => true do |t|
-    t.integer  "user_id"
-    t.string   "name"
-    t.text     "options"
-    t.string   "type"
-    t.datetime "created_at"
-    t.datetime "updated_at"
-  end
-
-  create_table "serial_works", :force => true do |t|
-    t.integer  "series_id"
-    t.integer  "work_id"
-    t.integer  "position",   :default => 1
-    t.datetime "created_at"
-    t.datetime "updated_at"
-  end
-
-  add_index "serial_works", ["series_id"], :name => "index_serial_works_on_series_id"
-  add_index "serial_works", ["work_id"], :name => "index_serial_works_on_work_id"
-
-  create_table "series", :force => true do |t|
-    t.datetime "created_at"
-    t.datetime "updated_at"
-    t.string   "title",                                                     :null => false
-    t.text     "summary"
-    t.text     "notes"
-    t.boolean  "hidden_by_admin",                        :default => false, :null => false
-    t.boolean  "restricted",                             :default => true,  :null => false
-    t.boolean  "complete",                               :default => false, :null => false
-    t.integer  "summary_sanitizer_version", :limit => 2, :default => 0,     :null => false
-    t.integer  "notes_sanitizer_version",   :limit => 2, :default => 0,     :null => false
-  end
-
-  create_table "set_taggings", :force => true do |t|
-    t.integer  "tag_id"
-    t.integer  "tag_set_id"
-    t.datetime "created_at"
-    t.datetime "updated_at"
-  end
-
-  add_index "set_taggings", ["tag_id"], :name => "index_set_taggings_on_tag_id"
-  add_index "set_taggings", ["tag_set_id"], :name => "index_set_taggings_on_tag_set_id"
-
-  create_table "skin_parents", :force => true do |t|
-    t.integer  "child_skin_id"
-    t.integer  "parent_skin_id"
-    t.integer  "position"
-    t.datetime "created_at"
-    t.datetime "updated_at"
-  end
-
-  create_table "skins", :force => true do |t|
-    t.string   "title"
-    t.integer  "author_id"
-    t.text     "css"
-    t.boolean  "public",                                     :default => false
-    t.boolean  "official",                                   :default => false
-    t.datetime "created_at"
-    t.datetime "updated_at"
-    t.string   "icon_file_name"
-    t.string   "icon_content_type"
-    t.integer  "icon_file_size"
-    t.datetime "icon_updated_at"
-    t.string   "icon_alt_text",                              :default => ""
-    t.integer  "margin"
-    t.integer  "paragraph_gap"
-    t.string   "font"
-    t.integer  "base_em"
-    t.string   "background_color"
-    t.string   "foreground_color"
-    t.text     "description"
-    t.boolean  "rejected",                                   :default => false, :null => false
-    t.string   "admin_note"
-    t.integer  "description_sanitizer_version", :limit => 2, :default => 0,     :null => false
-    t.string   "type"
-    t.float    "paragraph_margin"
-    t.string   "headercolor"
-    t.string   "accent_color"
-    t.string   "role"
-    t.string   "media"
-    t.string   "ie_condition"
-    t.string   "filename"
-    t.boolean  "do_not_upgrade",                             :default => false, :null => false
-    t.boolean  "cached",                                     :default => false, :null => false
-    t.boolean  "unusable",                                   :default => false, :null => false
-    t.boolean  "featured",                                   :default => false, :null => false
-    t.boolean  "in_chooser",                                 :default => false, :null => false
-  end
-
-  add_index "skins", ["author_id"], :name => "index_skins_on_author_id"
-  add_index "skins", ["in_chooser"], :name => "index_skins_on_in_chooser"
-  add_index "skins", ["public", "official"], :name => "index_skins_on_public_and_official"
-  add_index "skins", ["title"], :name => "index_skins_on_title"
-  add_index "skins", ["type"], :name => "index_skins_on_type"
-
-  create_table "stat_counters", :force => true do |t|
+  create_table "related_works", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC" do |t|
+    t.integer "parent_id"
+    t.string "parent_type"
     t.integer "work_id"
-    t.integer "hit_count",       :default => 0, :null => false
-    t.string  "last_visitor"
-    t.integer "download_count",  :default => 0, :null => false
-    t.integer "comments_count",  :default => 0, :null => false
-    t.integer "kudos_count",     :default => 0, :null => false
-    t.integer "bookmarks_count", :default => 0, :null => false
+    t.boolean "reciprocal", default: false, null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.boolean "translation", default: false, null: false
+    t.index ["parent_id", "parent_type"], name: "index_related_works_on_parent_id_and_parent_type"
+    t.index ["work_id"], name: "index_related_works_on_work_id"
   end
 
-  add_index "stat_counters", ["hit_count"], :name => "index_hit_counters_on_hit_count"
-  add_index "stat_counters", ["work_id"], :name => "index_hit_counters_on_work_id", :unique => true
+  create_table "roles", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC" do |t|
+    t.string "name", limit: 40
+    t.string "authorizable_type", limit: 40
+    t.integer "authorizable_id"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.index ["authorizable_id", "authorizable_type"], name: "index_roles_on_authorizable_id_and_authorizable_type"
+    t.index ["authorizable_type"], name: "index_roles_on_authorizable_type"
+    t.index ["name"], name: "index_roles_on_name"
+  end
 
-  create_table "subscriptions", :force => true do |t|
-    t.integer  "user_id"
-    t.integer  "subscribable_id"
-    t.string   "subscribable_type"
+  create_table "roles_users", id: false, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+    t.integer "user_id"
+    t.integer "role_id"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.index ["role_id", "user_id"], name: "index_roles_users_on_role_id_and_user_id"
+    t.index ["user_id", "role_id"], name: "index_roles_users_on_user_id_and_role_id"
+  end
+
+  create_table "searches", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC" do |t|
+    t.integer "user_id"
+    t.string "name"
+    t.text "options"
+    t.string "type"
     t.datetime "created_at"
     t.datetime "updated_at"
   end
 
-  add_index "subscriptions", ["subscribable_id", "subscribable_type"], :name => "subscribable"
-  add_index "subscriptions", ["user_id"], :name => "user_id"
-
-  create_table "tag_nominations", :force => true do |t|
-    t.string   "type"
-    t.integer  "tag_set_nomination_id"
-    t.integer  "fandom_nomination_id"
-    t.string   "tagname"
-    t.string   "parent_tagname"
-    t.boolean  "approved",              :default => false, :null => false
-    t.boolean  "rejected",              :default => false, :null => false
+  create_table "serial_works", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC" do |t|
+    t.integer "series_id"
+    t.integer "work_id"
+    t.integer "position", default: 1
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.boolean  "canonical",             :default => false, :null => false
-    t.boolean  "exists",                :default => false, :null => false
-    t.boolean  "parented",              :default => false, :null => false
-    t.string   "synonym"
+    t.index ["series_id"], name: "index_serial_works_on_series_id"
+    t.index ["work_id"], name: "index_serial_works_on_work_id"
   end
 
-  create_table "tag_set_associations", :force => true do |t|
-    t.integer  "owned_tag_set_id"
-    t.integer  "tag_id"
-    t.integer  "parent_tag_id"
+  create_table "series", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC" do |t|
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.string "title", null: false
+    t.text "summary"
+    t.text "series_notes"
+    t.boolean "hidden_by_admin", default: false, null: false
+    t.boolean "restricted", default: true, null: false
+    t.boolean "complete", default: false, null: false
+    t.integer "summary_sanitizer_version", limit: 2, default: 0, null: false
+    t.integer "series_notes_sanitizer_version", limit: 2, default: 0, null: false
   end
 
-  create_table "tag_set_nominations", :force => true do |t|
-    t.integer  "pseud_id"
-    t.integer  "owned_tag_set_id"
+  create_table "set_taggings", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC" do |t|
+    t.integer "tag_id"
+    t.integer "tag_set_id"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.index ["tag_id"], name: "index_set_taggings_on_tag_id"
+    t.index ["tag_set_id"], name: "index_set_taggings_on_tag_set_id"
   end
 
-  create_table "tag_set_ownerships", :force => true do |t|
-    t.integer  "pseud_id"
-    t.integer  "owned_tag_set_id"
-    t.boolean  "owner",            :default => false, :null => false
-    t.datetime "created_at"
-    t.datetime "updated_at"
-  end
-
-  create_table "tag_sets", :force => true do |t|
+  create_table "skin_parents", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC" do |t|
+    t.integer "child_skin_id"
+    t.integer "parent_skin_id"
+    t.integer "position"
     t.datetime "created_at"
     t.datetime "updated_at"
   end
 
-  create_table "taggings", :force => true do |t|
-    t.integer  "tagger_id"
-    t.integer  "taggable_id",                                  :null => false
-    t.string   "taggable_type", :limit => 100, :default => ""
+  create_table "skins", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC" do |t|
+    t.string "title"
+    t.integer "author_id"
+    t.text "css"
+    t.boolean "public", default: false
+    t.boolean "official", default: false
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string   "tagger_type",   :limit => 100, :default => ""
+    t.string "icon_file_name"
+    t.string "icon_content_type"
+    t.integer "icon_file_size"
+    t.datetime "icon_updated_at"
+    t.string "icon_alt_text", default: ""
+    t.integer "margin"
+    t.integer "paragraph_gap"
+    t.string "font"
+    t.integer "base_em"
+    t.string "background_color"
+    t.string "foreground_color"
+    t.text "description"
+    t.boolean "rejected", default: false, null: false
+    t.string "admin_note"
+    t.integer "description_sanitizer_version", limit: 2, default: 0, null: false
+    t.string "type"
+    t.float "paragraph_margin", limit: 24
+    t.string "headercolor"
+    t.string "accent_color"
+    t.string "role"
+    t.string "media"
+    t.string "ie_condition"
+    t.string "filename"
+    t.boolean "do_not_upgrade", default: false, null: false
+    t.boolean "cached", default: false, null: false
+    t.boolean "unusable", default: false, null: false
+    t.boolean "featured", default: false, null: false
+    t.boolean "in_chooser", default: false, null: false
+    t.index ["author_id"], name: "index_skins_on_author_id"
+    t.index ["in_chooser"], name: "index_skins_on_in_chooser"
+    t.index ["public", "official"], name: "index_skins_on_public_and_official"
+    t.index ["title"], name: "index_skins_on_title"
+    t.index ["type"], name: "index_skins_on_type"
   end
 
-  add_index "taggings", ["taggable_id", "taggable_type"], :name => "index_taggings_taggable"
-  add_index "taggings", ["tagger_id", "tagger_type", "taggable_id", "taggable_type"], :name => "index_taggings_polymorphic", :unique => true
-
-  create_table "tags", :force => true do |t|
-    t.string   "name",               :limit => 100, :default => ""
-    t.boolean  "canonical",                         :default => false, :null => false
-    t.datetime "created_at"
-    t.datetime "updated_at"
-    t.integer  "taggings_count",                    :default => 0
-    t.boolean  "adult",                             :default => false
-    t.string   "type"
-    t.integer  "merger_id"
-    t.boolean  "delta",                             :default => false
-    t.integer  "last_wrangler_id"
-    t.string   "last_wrangler_type"
-    t.boolean  "unwrangleable",                     :default => false, :null => false
-    t.string   "sortable_name",                     :default => "",    :null => false
+  create_table "stat_counters", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC" do |t|
+    t.integer "work_id"
+    t.integer "hit_count", default: 0, null: false
+    t.string "last_visitor"
+    t.integer "download_count", default: 0, null: false
+    t.integer "comments_count", default: 0, null: false
+    t.integer "kudos_count", default: 0, null: false
+    t.integer "bookmarks_count", default: 0, null: false
+    t.index ["hit_count"], name: "index_hit_counters_on_hit_count"
+    t.index ["work_id"], name: "index_hit_counters_on_work_id", unique: true
   end
 
-  add_index "tags", ["canonical"], :name => "index_tags_on_canonical"
-  add_index "tags", ["created_at"], :name => "tag_created_at_index"
-  add_index "tags", ["id", "type"], :name => "index_tags_on_id_and_type"
-  add_index "tags", ["merger_id"], :name => "index_tags_on_merger_id"
-  add_index "tags", ["name"], :name => "index_tags_on_name", :unique => true
-  add_index "tags", ["sortable_name"], :name => "index_tags_on_sortable_name"
-  add_index "tags", ["type"], :name => "index_tags_on_type"
+  create_table "subscriptions", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC" do |t|
+    t.integer "user_id"
+    t.integer "subscribable_id"
+    t.string "subscribable_type"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.index ["subscribable_id", "subscribable_type"], name: "subscribable"
+    t.index ["user_id"], name: "user_id"
+  end
 
-  create_table "user_invite_requests", :force => true do |t|
-    t.integer  "user_id"
-    t.integer  "quantity"
-    t.text     "reason"
-    t.boolean  "granted",    :default => false, :null => false
-    t.boolean  "handled",    :default => false, :null => false
+  create_table "tag_nominations", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC" do |t|
+    t.string "type"
+    t.integer "tag_set_nomination_id"
+    t.integer "fandom_nomination_id"
+    t.string "tagname"
+    t.string "parent_tagname"
+    t.boolean "approved", default: false, null: false
+    t.boolean "rejected", default: false, null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.boolean "canonical", default: false, null: false
+    t.boolean "exists", default: false, null: false
+    t.boolean "parented", default: false, null: false
+    t.string "synonym"
+    t.index ["tagname"], name: "index_tag_nominations_on_tagname"
+    t.index ["type", "fandom_nomination_id"], name: "index_tag_nominations_on_type_and_fandom_nomination_id"
+    t.index ["type", "synonym"], name: "index_tag_nominations_on_type_and_synonym"
+    t.index ["type", "tag_set_nomination_id"], name: "index_tag_nominations_on_type_and_tag_set_nomination_id"
+    t.index ["type", "tagname"], name: "index_tag_nominations_on_type_and_tagname"
+  end
+
+  create_table "tag_set_associations", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC" do |t|
+    t.integer "owned_tag_set_id"
+    t.integer "tag_id"
+    t.integer "parent_tag_id"
     t.datetime "created_at"
     t.datetime "updated_at"
   end
 
-  add_index "user_invite_requests", ["user_id"], :name => "index_user_invite_requests_on_user_id"
-
-  create_table "users", :force => true do |t|
+  create_table "tag_set_nominations", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC" do |t|
+    t.integer "pseud_id"
+    t.integer "owned_tag_set_id"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string   "email"
-    t.string   "activation_code"
-    t.string   "login"
-    t.datetime "activated_at"
-    t.string   "crypted_password"
-    t.string   "salt"
-    t.boolean  "recently_reset",     :default => false, :null => false
-    t.boolean  "suspended",          :default => false, :null => false
-    t.boolean  "banned",             :default => false, :null => false
-    t.integer  "invitation_id"
+  end
+
+  create_table "tag_set_ownerships", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC" do |t|
+    t.integer "pseud_id"
+    t.integer "owned_tag_set_id"
+    t.boolean "owner", default: false, null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
+
+  create_table "tag_sets", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC" do |t|
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
+
+  create_table "taggings", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC" do |t|
+    t.integer "tagger_id"
+    t.integer "taggable_id", null: false
+    t.string "taggable_type", limit: 100, default: ""
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.string "tagger_type", limit: 100, default: ""
+    t.index ["taggable_id", "taggable_type"], name: "index_taggings_taggable"
+    t.index ["tagger_id", "tagger_type", "taggable_id", "taggable_type"], name: "index_taggings_polymorphic", unique: true
+  end
+
+  create_table "tags", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC" do |t|
+    t.string "name", limit: 100, default: ""
+    t.boolean "canonical", default: false, null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.integer "taggings_count_cache", default: 0
+    t.boolean "adult", default: false
+    t.string "type"
+    t.integer "merger_id"
+    t.boolean "delta", default: false
+    t.integer "last_wrangler_id"
+    t.string "last_wrangler_type"
+    t.boolean "unwrangleable", default: false, null: false
+    t.string "sortable_name", default: "", null: false
+    t.index ["canonical"], name: "index_tags_on_canonical"
+    t.index ["created_at"], name: "tag_created_at_index"
+    t.index ["id", "type"], name: "index_tags_on_id_and_type"
+    t.index ["merger_id"], name: "index_tags_on_merger_id"
+    t.index ["name"], name: "index_tags_on_name", unique: true
+    t.index ["sortable_name"], name: "index_tags_on_sortable_name"
+    t.index ["taggings_count_cache"], name: "index_tags_on_taggings_count_cache"
+    t.index ["type"], name: "index_tags_on_type"
+  end
+
+  create_table "user_invite_requests", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC" do |t|
+    t.integer "user_id"
+    t.integer "quantity"
+    t.text "reason"
+    t.boolean "granted", default: false, null: false
+    t.boolean "handled", default: false, null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.index ["user_id"], name: "index_user_invite_requests_on_user_id"
+  end
+
+  create_table "users", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC" do |t|
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.string "email"
+    t.string "confirmation_token"
+    t.string "login"
+    t.datetime "confirmed_at"
+    t.string "encrypted_password"
+    t.string "password_salt"
+    t.boolean "suspended", default: false, null: false
+    t.boolean "banned", default: false, null: false
+    t.integer "invitation_id"
     t.datetime "suspended_until"
-    t.boolean  "out_of_invites",     :default => true,  :null => false
-    t.string   "persistence_token",                     :null => false
-    t.integer  "failed_login_count"
+    t.boolean "out_of_invites", default: true, null: false
+    t.integer "failed_attempts", default: 0
+    t.integer "accepted_tos_version"
+    t.datetime "confirmation_sent_at"
+    t.string "reset_password_token"
+    t.datetime "reset_password_sent_at"
+    t.datetime "remember_created_at"
+    t.integer "sign_in_count", default: 0
+    t.datetime "current_sign_in_at"
+    t.datetime "last_sign_in_at"
+    t.string "current_sign_in_ip"
+    t.string "last_sign_in_ip"
+    t.string "unlock_token"
+    t.datetime "locked_at"
+    t.boolean "recently_reset"
+    t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
+    t.index ["email"], name: "index_users_on_email", unique: true
+    t.index ["login"], name: "index_users_on_login", unique: true
+    t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
+    t.index ["unlock_token"], name: "index_users_on_unlock_token", unique: true
   end
 
-  add_index "users", ["activation_code"], :name => "index_users_on_activation_code"
-  add_index "users", ["email"], :name => "index_users_on_email"
-  add_index "users", ["login"], :name => "index_users_on_login", :unique => true
-
-  create_table "work_links", :force => true do |t|
-    t.integer  "work_id"
-    t.string   "url"
-    t.integer  "count"
+  create_table "work_links", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC" do |t|
+    t.integer "work_id"
+    t.string "url"
+    t.integer "count"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.index ["work_id", "url"], name: "work_links_work_id_url", unique: true
   end
 
-  add_index "work_links", ["work_id", "url"], :name => "work_links_work_id_url", :unique => true
-
-  create_table "works", :force => true do |t|
-    t.integer  "expected_number_of_chapters",               :default => 1
+  create_table "works", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC" do |t|
+    t.integer "expected_number_of_chapters", default: 1
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.integer  "major_version",                             :default => 1
-    t.integer  "minor_version",                             :default => 0
-    t.boolean  "posted",                                    :default => false, :null => false
-    t.integer  "language_id"
-    t.boolean  "restricted",                                :default => false, :null => false
-    t.string   "title",                                                        :null => false
-    t.text     "summary"
-    t.text     "notes"
-    t.integer  "word_count"
-    t.boolean  "hidden_by_admin",                           :default => false, :null => false
-    t.boolean  "delta",                                     :default => false
+    t.integer "major_version", default: 1
+    t.integer "minor_version", default: 0
+    t.boolean "posted", default: false, null: false
+    t.integer "language_id"
+    t.boolean "restricted", default: false, null: false
+    t.string "title", null: false
+    t.text "summary"
+    t.text "notes"
+    t.integer "word_count"
+    t.boolean "hidden_by_admin", default: false, null: false
+    t.boolean "delta", default: false
     t.datetime "revised_at"
-    t.string   "authors_to_sort_on"
-    t.string   "title_to_sort_on"
-    t.boolean  "backdate",                                  :default => false, :null => false
-    t.text     "endnotes"
-    t.string   "imported_from_url"
-    t.integer  "hit_count_old",                             :default => 0,     :null => false
-    t.string   "last_visitor_old"
-    t.boolean  "complete",                                  :default => false, :null => false
-    t.integer  "summary_sanitizer_version",    :limit => 2, :default => 0,     :null => false
-    t.integer  "notes_sanitizer_version",      :limit => 2, :default => 0,     :null => false
-    t.integer  "endnotes_sanitizer_version",   :limit => 2, :default => 0,     :null => false
-    t.integer  "work_skin_id"
-    t.boolean  "in_anon_collection",                        :default => false, :null => false
-    t.boolean  "in_unrevealed_collection",                  :default => false, :null => false
-    t.boolean  "anon_commenting_disabled",                  :default => false, :null => false
-    t.string   "ip_address"
-    t.boolean  "spam",                                      :default => false, :null => false
+    t.string "title_to_sort_on"
+    t.boolean "backdate", default: false, null: false
+    t.text "endnotes"
+    t.string "imported_from_url"
+    t.integer "hit_count_old", default: 0, null: false
+    t.string "last_visitor_old"
+    t.boolean "complete", default: false, null: false
+    t.integer "summary_sanitizer_version", limit: 2, default: 0, null: false
+    t.integer "notes_sanitizer_version", limit: 2, default: 0, null: false
+    t.integer "endnotes_sanitizer_version", limit: 2, default: 0, null: false
+    t.integer "work_skin_id"
+    t.boolean "in_anon_collection", default: false, null: false
+    t.boolean "in_unrevealed_collection", default: false, null: false
+    t.boolean "anon_commenting_disabled", default: false, null: false
+    t.string "ip_address"
+    t.boolean "spam", default: false, null: false
     t.datetime "spam_checked_at"
-    t.boolean  "moderated_commenting_enabled",              :default => false, :null => false
+    t.boolean "moderated_commenting_enabled", default: false, null: false
+    t.index ["complete", "posted", "hidden_by_admin"], name: "complete_works"
+    t.index ["delta"], name: "index_works_on_delta"
+    t.index ["imported_from_url"], name: "index_works_on_imported_from_url"
+    t.index ["ip_address"], name: "index_works_on_ip_address"
+    t.index ["language_id"], name: "index_works_on_language_id"
+    t.index ["restricted", "posted", "hidden_by_admin"], name: "visible_works"
+    t.index ["revised_at"], name: "index_works_on_revised_at"
+    t.index ["spam"], name: "index_works_on_spam"
   end
 
-  add_index "works", ["complete", "posted", "hidden_by_admin"], :name => "complete_works"
-  add_index "works", ["delta"], :name => "index_works_on_delta"
-  add_index "works", ["imported_from_url"], :name => "index_works_on_imported_from_url"
-  add_index "works", ["ip_address"], :name => "index_works_on_ip_address"
-  add_index "works", ["language_id"], :name => "index_works_on_language_id"
-  add_index "works", ["restricted", "posted", "hidden_by_admin"], :name => "visible_works"
-  add_index "works", ["revised_at"], :name => "index_works_on_revised_at"
-  add_index "works", ["spam"], :name => "index_works_on_spam"
-
-  create_table "wrangling_assignments", :force => true do |t|
+  create_table "wrangling_assignments", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC" do |t|
     t.integer "user_id"
     t.integer "fandom_id"
+    t.index ["fandom_id"], name: "wrangling_assignments_by_fandom_id"
+    t.index ["user_id"], name: "wrangling_assignments_by_user_id"
   end
 
-  add_index "wrangling_assignments", ["fandom_id"], :name => "wrangling_assignments_by_fandom_id"
-  add_index "wrangling_assignments", ["user_id"], :name => "wrangling_assignments_by_user_id"
-
-  create_table "wrangling_guidelines", :force => true do |t|
-    t.integer  "admin_id"
-    t.string   "title"
-    t.text     "content"
+  create_table "wrangling_guidelines", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC" do |t|
+    t.integer "admin_id"
+    t.string "title"
+    t.text "content"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.integer  "position"
-    t.integer  "content_sanitizer_version", :limit => 2, :default => 0, :null => false
+    t.integer "position"
+    t.integer "content_sanitizer_version", limit: 2, default: 0, null: false
   end
 
 end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1,50 +1,76 @@
+
+/*!40101 SET @OLD_CHARACTER_SET_CLIENT=@@CHARACTER_SET_CLIENT */;
+/*!40101 SET @OLD_CHARACTER_SET_RESULTS=@@CHARACTER_SET_RESULTS */;
+/*!40101 SET @OLD_COLLATION_CONNECTION=@@COLLATION_CONNECTION */;
+/*!40101 SET NAMES utf8mb4 */;
+/*!40103 SET @OLD_TIME_ZONE=@@TIME_ZONE */;
+/*!40103 SET TIME_ZONE='+00:00' */;
+/*!40014 SET @OLD_UNIQUE_CHECKS=@@UNIQUE_CHECKS, UNIQUE_CHECKS=0 */;
+/*!40014 SET @OLD_FOREIGN_KEY_CHECKS=@@FOREIGN_KEY_CHECKS, FOREIGN_KEY_CHECKS=0 */;
+/*!40101 SET @OLD_SQL_MODE=@@SQL_MODE, SQL_MODE='NO_AUTO_VALUE_ON_ZERO' */;
+/*!40111 SET @OLD_SQL_NOTES=@@SQL_NOTES, SQL_NOTES=0 */;
+DROP TABLE IF EXISTS `abuse_reports`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `abuse_reports` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
-  `email` varchar(255) DEFAULT NULL,
-  `url` varchar(255) NOT NULL,
-  `comment` text NOT NULL,
+  `email` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `url` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `comment` text COLLATE utf8mb4_unicode_ci NOT NULL,
   `created_at` datetime DEFAULT NULL,
   `updated_at` datetime DEFAULT NULL,
-  `ip_address` varchar(255) DEFAULT NULL,
+  `ip_address` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `comment_sanitizer_version` smallint(6) NOT NULL DEFAULT '0',
-  `summary` varchar(255) DEFAULT NULL,
-  `summary_sanitizer_version` varchar(255) DEFAULT NULL,
-  `language` varchar(255) DEFAULT NULL,
-  `username` varchar(255) DEFAULT NULL,
+  `summary` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `summary_sanitizer_version` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `language` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `username` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
-
+) ENGINE=InnoDB AUTO_INCREMENT=771690 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+/*!40101 SET character_set_client = @saved_cs_client */;
+DROP TABLE IF EXISTS `admin_activities`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `admin_activities` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `admin_id` int(11) DEFAULT NULL,
   `target_id` int(11) DEFAULT NULL,
-  `target_type` varchar(255) DEFAULT NULL,
-  `action` varchar(255) DEFAULT NULL,
-  `summary` text,
+  `target_type` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `action` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `summary` text COLLATE utf8mb4_unicode_ci,
   `summary_sanitizer_version` smallint(6) NOT NULL DEFAULT '0',
   `created_at` datetime DEFAULT NULL,
   `updated_at` datetime DEFAULT NULL,
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
-
+) ENGINE=InnoDB AUTO_INCREMENT=230752 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+/*!40101 SET character_set_client = @saved_cs_client */;
+DROP TABLE IF EXISTS `admin_banners`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `admin_banners` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
-  `content` text,
+  `content` text COLLATE utf8mb4_unicode_ci,
   `content_sanitizer_version` smallint(6) NOT NULL DEFAULT '0',
-  `banner_type` varchar(255) DEFAULT NULL,
+  `banner_type` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `active` tinyint(1) NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
-
+) ENGINE=InnoDB AUTO_INCREMENT=273 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+/*!40101 SET character_set_client = @saved_cs_client */;
+DROP TABLE IF EXISTS `admin_blacklisted_emails`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `admin_blacklisted_emails` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
-  `email` varchar(255) DEFAULT NULL,
+  `email` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `created_at` datetime NOT NULL,
   `updated_at` datetime NOT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_admin_blacklisted_emails_on_email` (`email`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
-
+) ENGINE=InnoDB AUTO_INCREMENT=586 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+/*!40101 SET character_set_client = @saved_cs_client */;
+DROP TABLE IF EXISTS `admin_post_taggings`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `admin_post_taggings` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `admin_post_tag_id` int(11) DEFAULT NULL,
@@ -53,22 +79,28 @@ CREATE TABLE `admin_post_taggings` (
   `updated_at` datetime DEFAULT NULL,
   PRIMARY KEY (`id`),
   KEY `index_admin_post_taggings_on_admin_post_id` (`admin_post_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
-
+) ENGINE=InnoDB AUTO_INCREMENT=30498 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+/*!40101 SET character_set_client = @saved_cs_client */;
+DROP TABLE IF EXISTS `admin_post_tags`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `admin_post_tags` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
-  `name` varchar(255) DEFAULT NULL,
+  `name` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `language_id` int(11) DEFAULT NULL,
   `created_at` datetime DEFAULT NULL,
   `updated_at` datetime DEFAULT NULL,
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
-
+) ENGINE=InnoDB AUTO_INCREMENT=198 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+/*!40101 SET character_set_client = @saved_cs_client */;
+DROP TABLE IF EXISTS `admin_posts`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `admin_posts` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `admin_id` int(11) DEFAULT NULL,
-  `title` varchar(255) DEFAULT NULL,
-  `content` text,
+  `title` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `content` text COLLATE utf8mb4_unicode_ci,
   `updated_at` datetime DEFAULT NULL,
   `created_at` datetime DEFAULT NULL,
   `content_sanitizer_version` smallint(6) NOT NULL DEFAULT '0',
@@ -77,8 +109,11 @@ CREATE TABLE `admin_posts` (
   PRIMARY KEY (`id`),
   KEY `index_admin_posts_on_post_id` (`translated_post_id`),
   KEY `index_admin_posts_on_created_at` (`created_at`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
-
+) ENGINE=InnoDB AUTO_INCREMENT=14122 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+/*!40101 SET character_set_client = @saved_cs_client */;
+DROP TABLE IF EXISTS `admin_settings`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `admin_settings` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `account_creation_enabled` tinyint(1) NOT NULL DEFAULT '1',
@@ -95,113 +130,149 @@ CREATE TABLE `admin_settings` (
   `enable_test_caching` tinyint(1) DEFAULT '0',
   `cache_expiration` bigint(20) DEFAULT '10',
   `tag_wrangling_off` tinyint(1) NOT NULL DEFAULT '0',
-  `guest_downloading_off` tinyint(1) NOT NULL DEFAULT '0',
   `default_skin_id` int(11) DEFAULT NULL,
   `stats_updated_at` datetime DEFAULT NULL,
-  `disable_filtering` tinyint(1) NOT NULL DEFAULT '0',
   `request_invite_enabled` tinyint(1) NOT NULL DEFAULT '0',
   `creation_requires_invite` tinyint(1) NOT NULL DEFAULT '0',
   `downloads_enabled` tinyint(1) DEFAULT '1',
+  `hide_spam` tinyint(1) NOT NULL DEFAULT '0',
+  `disable_support_form` tinyint(1) NOT NULL DEFAULT '0',
+  `disabled_support_form_text` text COLLATE utf8mb4_unicode_ci,
+  `disabled_support_form_text_sanitizer_version` smallint(6) NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`),
   KEY `index_admin_settings_on_last_updated_by` (`last_updated_by`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
-
+) ENGINE=InnoDB AUTO_INCREMENT=2 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+/*!40101 SET character_set_client = @saved_cs_client */;
+DROP TABLE IF EXISTS `admins`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `admins` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `created_at` datetime DEFAULT NULL,
   `updated_at` datetime DEFAULT NULL,
-  `email` varchar(255) DEFAULT NULL,
-  `login` varchar(255) DEFAULT NULL,
-  `encrypted_password` varchar(255) DEFAULT NULL,
-  `password_salt` varchar(255) DEFAULT NULL,
+  `email` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `login` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `encrypted_password` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `password_salt` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
-
+) ENGINE=InnoDB AUTO_INCREMENT=614 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+/*!40101 SET character_set_client = @saved_cs_client */;
+DROP TABLE IF EXISTS `api_keys`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `api_keys` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
-  `name` varchar(255) NOT NULL,
-  `access_token` varchar(255) NOT NULL,
+  `name` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `access_token` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
   `banned` tinyint(1) NOT NULL DEFAULT '0',
   `created_at` datetime NOT NULL,
   `updated_at` datetime NOT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_api_keys_on_name` (`name`),
   UNIQUE KEY `index_api_keys_on_access_token` (`access_token`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
-
+) ENGINE=InnoDB AUTO_INCREMENT=4 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+/*!40101 SET character_set_client = @saved_cs_client */;
+DROP TABLE IF EXISTS `ar_internal_metadata`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `ar_internal_metadata` (
+  `key` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `value` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `created_at` datetime NOT NULL,
+  `updated_at` datetime NOT NULL,
+  PRIMARY KEY (`key`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+/*!40101 SET character_set_client = @saved_cs_client */;
+DROP TABLE IF EXISTS `archive_faq_translations`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `archive_faq_translations` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `archive_faq_id` int(11) DEFAULT NULL,
-  `locale` varchar(255) NOT NULL,
+  `locale` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
   `created_at` datetime NOT NULL,
   `updated_at` datetime NOT NULL,
-  `title` varchar(255) DEFAULT NULL,
+  `title` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   PRIMARY KEY (`id`),
   KEY `index_archive_faq_translations_on_archive_faq_id` (`archive_faq_id`),
   KEY `index_archive_faq_translations_on_locale` (`locale`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
-
+) ENGINE=InnoDB AUTO_INCREMENT=2538 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+/*!40101 SET character_set_client = @saved_cs_client */;
+DROP TABLE IF EXISTS `archive_faqs`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `archive_faqs` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `admin_id` int(11) DEFAULT NULL,
-  `title` varchar(255) DEFAULT NULL,
+  `title` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `updated_at` datetime DEFAULT NULL,
   `created_at` datetime DEFAULT NULL,
   `position` int(11) DEFAULT '1',
-  `slug` varchar(255) NOT NULL DEFAULT '',
+  `slug` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_archive_faqs_on_slug` (`slug`),
   KEY `index_archive_faqs_on_position` (`position`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
-
+) ENGINE=InnoDB AUTO_INCREMENT=105 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+/*!40101 SET character_set_client = @saved_cs_client */;
+DROP TABLE IF EXISTS `audits`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `audits` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `auditable_id` int(11) DEFAULT NULL,
-  `auditable_type` varchar(255) DEFAULT NULL,
+  `auditable_type` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `associated_id` int(11) DEFAULT NULL,
-  `associated_type` varchar(255) DEFAULT NULL,
+  `associated_type` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `user_id` int(11) DEFAULT NULL,
-  `user_type` varchar(255) DEFAULT NULL,
-  `username` varchar(255) DEFAULT NULL,
-  `action` varchar(255) DEFAULT NULL,
-  `audited_changes` text,
+  `user_type` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `username` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `action` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `audited_changes` text COLLATE utf8mb4_unicode_ci,
   `version` int(11) DEFAULT '0',
-  `comment` varchar(255) DEFAULT NULL,
-  `remote_address` varchar(255) DEFAULT NULL,
+  `comment` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `remote_address` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `created_at` datetime DEFAULT NULL,
+  `request_uuid` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   PRIMARY KEY (`id`),
   KEY `auditable_index` (`auditable_id`,`auditable_type`),
   KEY `associated_index` (`associated_id`,`associated_type`),
   KEY `user_index` (`user_id`,`user_type`),
-  KEY `index_audits_on_created_at` (`created_at`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
-
+  KEY `index_audits_on_created_at` (`created_at`),
+  KEY `index_audits_on_request_uuid` (`request_uuid`)
+) ENGINE=InnoDB AUTO_INCREMENT=123338553 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+/*!40101 SET character_set_client = @saved_cs_client */;
+DROP TABLE IF EXISTS `bookmarks`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `bookmarks` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `created_at` datetime NOT NULL,
-  `bookmarkable_type` varchar(15) NOT NULL,
+  `bookmarkable_type` varchar(15) COLLATE utf8mb4_unicode_ci NOT NULL,
   `bookmarkable_id` int(11) NOT NULL,
   `user_id` int(11) DEFAULT NULL,
-  `notes` text,
+  `bookmarker_notes` text COLLATE utf8mb4_unicode_ci,
   `private` tinyint(1) DEFAULT '0',
   `updated_at` datetime DEFAULT NULL,
   `hidden_by_admin` tinyint(1) NOT NULL DEFAULT '0',
   `pseud_id` int(11) NOT NULL,
   `rec` tinyint(1) NOT NULL DEFAULT '0',
   `delta` tinyint(1) DEFAULT '1',
-  `notes_sanitizer_version` smallint(6) NOT NULL DEFAULT '0',
+  `bookmarker_notes_sanitizer_version` smallint(6) NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`),
   KEY `fk_bookmarks_user` (`user_id`),
   KEY `index_bookmarks_on_pseud_id` (`pseud_id`),
   KEY `index_bookmarkable_pseud` (`bookmarkable_id`,`bookmarkable_type`,`pseud_id`),
   KEY `index_bookmarks_on_private_and_hidden_by_admin_and_created_at` (`private`,`hidden_by_admin`,`created_at`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
-
+) ENGINE=InnoDB AUTO_INCREMENT=407812491 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+/*!40101 SET character_set_client = @saved_cs_client */;
+DROP TABLE IF EXISTS `challenge_assignments`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `challenge_assignments` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `collection_id` int(11) DEFAULT NULL,
   `creation_id` int(11) DEFAULT NULL,
-  `creation_type` varchar(255) DEFAULT NULL,
+  `creation_type` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `offer_signup_id` int(11) DEFAULT NULL,
   `request_signup_id` int(11) DEFAULT NULL,
   `pinch_hitter_id` int(11) DEFAULT NULL,
@@ -220,13 +291,16 @@ CREATE TABLE `challenge_assignments` (
   KEY `assignments_on_pinch_hitter_id` (`pinch_hitter_id`),
   KEY `assignments_on_defaulted_at` (`defaulted_at`),
   KEY `index_challenge_assignments_on_collection_id` (`collection_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
-
+) ENGINE=InnoDB AUTO_INCREMENT=2245158 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+/*!40101 SET character_set_client = @saved_cs_client */;
+DROP TABLE IF EXISTS `challenge_claims`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `challenge_claims` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `collection_id` int(11) DEFAULT NULL,
   `creation_id` int(11) DEFAULT NULL,
-  `creation_type` varchar(255) DEFAULT NULL,
+  `creation_type` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `request_signup_id` int(11) DEFAULT NULL,
   `request_prompt_id` int(11) DEFAULT NULL,
   `claiming_user_id` int(11) DEFAULT NULL,
@@ -240,8 +314,11 @@ CREATE TABLE `challenge_claims` (
   KEY `index_challenge_claims_on_claiming_user_id` (`claiming_user_id`),
   KEY `index_challenge_claims_on_request_signup_id` (`request_signup_id`),
   KEY `index_challenge_claims_on_collection_id` (`collection_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
-
+) ENGINE=InnoDB AUTO_INCREMENT=55665 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+/*!40101 SET character_set_client = @saved_cs_client */;
+DROP TABLE IF EXISTS `challenge_signups`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `challenge_signups` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `collection_id` int(11) DEFAULT NULL,
@@ -253,23 +330,26 @@ CREATE TABLE `challenge_signups` (
   PRIMARY KEY (`id`),
   KEY `signups_on_pseud_id` (`pseud_id`),
   KEY `index_challenge_signups_on_collection_id` (`collection_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
-
+) ENGINE=InnoDB AUTO_INCREMENT=204405 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+/*!40101 SET character_set_client = @saved_cs_client */;
+DROP TABLE IF EXISTS `chapters`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `chapters` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
-  `content` longtext NOT NULL,
+  `content` longtext CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
   `position` int(11) DEFAULT '1',
   `work_id` int(11) DEFAULT NULL,
   `created_at` datetime DEFAULT NULL,
   `updated_at` datetime DEFAULT NULL,
   `posted` tinyint(1) NOT NULL DEFAULT '0',
-  `title` varchar(255) DEFAULT NULL,
-  `notes` text,
-  `summary` text,
+  `title` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `notes` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
+  `summary` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
   `word_count` int(11) DEFAULT NULL,
   `hidden_by_admin` tinyint(1) NOT NULL DEFAULT '0',
   `published_at` date DEFAULT NULL,
-  `endnotes` text,
+  `endnotes` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
   `content_sanitizer_version` smallint(6) NOT NULL DEFAULT '0',
   `notes_sanitizer_version` smallint(6) NOT NULL DEFAULT '0',
   `summary_sanitizer_version` smallint(6) NOT NULL DEFAULT '0',
@@ -277,13 +357,16 @@ CREATE TABLE `chapters` (
   PRIMARY KEY (`id`),
   KEY `works_chapter_index` (`work_id`),
   KEY `index_chapters_on_work_id` (`work_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
-
+) ENGINE=InnoDB AUTO_INCREMENT=50665233 DEFAULT CHARSET=utf8;
+/*!40101 SET character_set_client = @saved_cs_client */;
+DROP TABLE IF EXISTS `collection_items`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `collection_items` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `collection_id` int(11) DEFAULT NULL,
   `item_id` int(11) DEFAULT NULL,
-  `item_type` varchar(255) DEFAULT 'Work',
+  `item_type` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT 'Work',
   `user_approval_status` tinyint(4) NOT NULL DEFAULT '0',
   `collection_approval_status` tinyint(4) NOT NULL DEFAULT '0',
   `created_at` datetime DEFAULT NULL,
@@ -296,21 +379,27 @@ CREATE TABLE `collection_items` (
   KEY `collection_items_unrevealed` (`unrevealed`),
   KEY `collection_items_anonymous` (`anonymous`),
   KEY `collection_items_item_id` (`item_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
-
+) ENGINE=InnoDB AUTO_INCREMENT=6757044 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+/*!40101 SET character_set_client = @saved_cs_client */;
+DROP TABLE IF EXISTS `collection_participants`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `collection_participants` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `collection_id` int(11) DEFAULT NULL,
   `pseud_id` int(11) DEFAULT NULL,
-  `participant_role` varchar(255) NOT NULL DEFAULT 'None',
+  `participant_role` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'None',
   `created_at` datetime DEFAULT NULL,
   `updated_at` datetime DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `by collection and pseud` (`collection_id`,`pseud_id`),
   KEY `participants_by_collection_and_role` (`collection_id`,`participant_role`),
   KEY `participants_pseud_id` (`pseud_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
-
+) ENGINE=InnoDB AUTO_INCREMENT=449475 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+/*!40101 SET character_set_client = @saved_cs_client */;
+DROP TABLE IF EXISTS `collection_preferences`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `collection_preferences` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `collection_id` int(11) DEFAULT NULL,
@@ -326,114 +415,134 @@ CREATE TABLE `collection_preferences` (
   `email_notify` tinyint(1) NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`),
   KEY `index_collection_preferences_on_collection_id` (`collection_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
-
+) ENGINE=InnoDB AUTO_INCREMENT=235521 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+/*!40101 SET character_set_client = @saved_cs_client */;
+DROP TABLE IF EXISTS `collection_profiles`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `collection_profiles` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `collection_id` int(11) DEFAULT NULL,
-  `intro` mediumtext,
-  `faq` mediumtext,
-  `rules` mediumtext,
+  `intro` mediumtext COLLATE utf8mb4_unicode_ci,
+  `faq` mediumtext COLLATE utf8mb4_unicode_ci,
+  `rules` mediumtext COLLATE utf8mb4_unicode_ci,
   `created_at` datetime DEFAULT NULL,
   `updated_at` datetime DEFAULT NULL,
-  `gift_notification` text,
+  `gift_notification` text COLLATE utf8mb4_unicode_ci,
   `intro_sanitizer_version` smallint(6) NOT NULL DEFAULT '0',
   `faq_sanitizer_version` smallint(6) NOT NULL DEFAULT '0',
   `rules_sanitizer_version` smallint(6) NOT NULL DEFAULT '0',
-  `assignment_notification` text,
+  `assignment_notification` text COLLATE utf8mb4_unicode_ci,
   PRIMARY KEY (`id`),
   KEY `index_collection_profiles_on_collection_id` (`collection_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
-
+) ENGINE=InnoDB AUTO_INCREMENT=235525 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+/*!40101 SET character_set_client = @saved_cs_client */;
+DROP TABLE IF EXISTS `collections`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `collections` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
-  `name` varchar(255) DEFAULT NULL,
-  `title` varchar(255) DEFAULT NULL,
-  `email` varchar(255) DEFAULT NULL,
-  `header_image_url` varchar(255) DEFAULT NULL,
-  `description` text,
+  `name` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `title` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `email` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `header_image_url` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `description` text COLLATE utf8mb4_unicode_ci,
   `created_at` datetime DEFAULT NULL,
   `updated_at` datetime DEFAULT NULL,
   `parent_id` int(11) DEFAULT NULL,
   `challenge_id` int(11) DEFAULT NULL,
-  `challenge_type` varchar(255) DEFAULT NULL,
-  `icon_file_name` varchar(255) DEFAULT NULL,
-  `icon_content_type` varchar(255) DEFAULT NULL,
+  `challenge_type` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `icon_file_name` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `icon_content_type` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `icon_file_size` int(11) DEFAULT NULL,
   `icon_updated_at` datetime DEFAULT NULL,
   `description_sanitizer_version` smallint(6) NOT NULL DEFAULT '0',
-  `icon_alt_text` varchar(255) DEFAULT '',
-  `icon_comment_text` varchar(255) DEFAULT '',
+  `icon_alt_text` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT '',
+  `icon_comment_text` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT '',
   PRIMARY KEY (`id`),
   KEY `index_collections_on_name` (`name`),
   KEY `index_collections_on_parent_id` (`parent_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
-
+) ENGINE=InnoDB AUTO_INCREMENT=235716 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+/*!40101 SET character_set_client = @saved_cs_client */;
+DROP TABLE IF EXISTS `comments`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `comments` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `pseud_id` int(11) DEFAULT NULL,
-  `content` text NOT NULL,
+  `comment_content` text COLLATE utf8mb4_unicode_ci NOT NULL,
   `depth` int(11) DEFAULT NULL,
   `threaded_left` int(11) DEFAULT NULL,
   `threaded_right` int(11) DEFAULT NULL,
   `is_deleted` tinyint(1) NOT NULL DEFAULT '0',
-  `name` varchar(255) DEFAULT NULL,
-  `email` varchar(255) DEFAULT NULL,
-  `ip_address` varchar(255) DEFAULT NULL,
+  `name` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `email` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `ip_address` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `commentable_id` int(11) DEFAULT NULL,
-  `commentable_type` varchar(255) DEFAULT NULL,
+  `commentable_type` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `created_at` datetime DEFAULT NULL,
   `updated_at` datetime DEFAULT NULL,
   `thread` int(11) DEFAULT NULL,
-  `user_agent` varchar(255) DEFAULT NULL,
+  `user_agent` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `approved` tinyint(1) NOT NULL DEFAULT '0',
   `hidden_by_admin` tinyint(1) NOT NULL DEFAULT '0',
   `edited_at` datetime DEFAULT NULL,
   `parent_id` int(11) DEFAULT NULL,
-  `parent_type` varchar(255) DEFAULT NULL,
-  `content_sanitizer_version` smallint(6) NOT NULL DEFAULT '0',
+  `parent_type` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `comment_content_sanitizer_version` smallint(6) NOT NULL DEFAULT '0',
   `unreviewed` tinyint(1) NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`),
   KEY `index_comments_commentable` (`commentable_id`,`commentable_type`),
   KEY `index_comments_on_pseud_id` (`pseud_id`),
   KEY `index_comments_parent` (`parent_id`,`parent_type`),
-  KEY `comments_by_thread` (`thread`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
-
+  KEY `comments_by_thread` (`thread`),
+  KEY `index_comments_on_ip_address` (`ip_address`)
+) ENGINE=InnoDB AUTO_INCREMENT=260045305 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+/*!40101 SET character_set_client = @saved_cs_client */;
+DROP TABLE IF EXISTS `common_taggings`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `common_taggings` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `common_tag_id` int(11) NOT NULL,
   `filterable_id` int(11) NOT NULL,
-  `filterable_type` varchar(100) DEFAULT NULL,
+  `filterable_type` varchar(100) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `created_at` datetime DEFAULT NULL,
   `updated_at` datetime DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_common_tags` (`common_tag_id`,`filterable_type`,`filterable_id`),
   KEY `index_common_taggings_on_filterable_id` (`filterable_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
-
+) ENGINE=InnoDB AUTO_INCREMENT=43064373 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+/*!40101 SET character_set_client = @saved_cs_client */;
+DROP TABLE IF EXISTS `creatorships`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `creatorships` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `creation_id` int(11) DEFAULT NULL,
-  `creation_type` varchar(100) DEFAULT NULL,
+  `creation_type` varchar(100) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `pseud_id` int(11) DEFAULT NULL,
   `created_at` datetime DEFAULT NULL,
   `updated_at` datetime DEFAULT NULL,
+  `approved` tinyint(1) NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`),
   UNIQUE KEY `creation_id_creation_type_pseud_id` (`creation_id`,`creation_type`,`pseud_id`),
   KEY `index_creatorships_pseud` (`pseud_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
-
+) ENGINE=InnoDB AUTO_INCREMENT=77405046 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+/*!40101 SET character_set_client = @saved_cs_client */;
+DROP TABLE IF EXISTS `delayed_jobs`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `delayed_jobs` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `priority` int(11) DEFAULT '0',
   `attempts` int(11) DEFAULT '0',
-  `handler` text,
-  `last_error` text,
+  `handler` text COLLATE utf8mb4_unicode_ci,
+  `last_error` text COLLATE utf8mb4_unicode_ci,
   `run_at` datetime DEFAULT NULL,
   `locked_at` datetime DEFAULT NULL,
   `failed_at` datetime DEFAULT NULL,
-  `locked_by` varchar(255) DEFAULT NULL,
+  `locked_by` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `created_at` datetime DEFAULT NULL,
   `updated_at` datetime DEFAULT NULL,
   PRIMARY KEY (`id`),
@@ -441,21 +550,27 @@ CREATE TABLE `delayed_jobs` (
   KEY `delayed_jobs_locked_at` (`locked_at`),
   KEY `delayed_jobs_locked_by` (`locked_by`),
   KEY `delayed_jobs_failed_at` (`failed_at`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
-
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+/*!40101 SET character_set_client = @saved_cs_client */;
+DROP TABLE IF EXISTS `external_author_names`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `external_author_names` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `external_author_id` int(11) NOT NULL,
-  `name` varchar(255) DEFAULT NULL,
+  `name` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `created_at` datetime DEFAULT NULL,
   `updated_at` datetime DEFAULT NULL,
   PRIMARY KEY (`id`),
   KEY `index_external_author_names_on_external_author_id` (`external_author_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
-
+) ENGINE=InnoDB AUTO_INCREMENT=83586 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+/*!40101 SET character_set_client = @saved_cs_client */;
+DROP TABLE IF EXISTS `external_authors`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `external_authors` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
-  `email` varchar(255) DEFAULT NULL,
+  `email` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `is_claimed` tinyint(1) NOT NULL DEFAULT '0',
   `user_id` int(11) DEFAULT NULL,
   `do_not_email` tinyint(1) NOT NULL DEFAULT '0',
@@ -465,12 +580,15 @@ CREATE TABLE `external_authors` (
   PRIMARY KEY (`id`),
   KEY `index_external_authors_on_user_id` (`user_id`),
   KEY `index_external_authors_on_email` (`email`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
-
+) ENGINE=InnoDB AUTO_INCREMENT=40096 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+/*!40101 SET character_set_client = @saved_cs_client */;
+DROP TABLE IF EXISTS `external_creatorships`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `external_creatorships` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `creation_id` int(11) DEFAULT NULL,
-  `creation_type` varchar(255) DEFAULT NULL,
+  `creation_type` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `created_at` datetime DEFAULT NULL,
   `updated_at` datetime DEFAULT NULL,
   `archivist_id` int(11) DEFAULT NULL,
@@ -479,58 +597,74 @@ CREATE TABLE `external_creatorships` (
   KEY `index_external_creatorships_on_creation_id_and_creation_type` (`creation_id`,`creation_type`),
   KEY `index_external_creatorships_on_external_author_name_id` (`external_author_name_id`),
   KEY `index_external_creatorships_on_archivist_id` (`archivist_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
-
+) ENGINE=InnoDB AUTO_INCREMENT=214140 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+/*!40101 SET character_set_client = @saved_cs_client */;
+DROP TABLE IF EXISTS `external_works`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `external_works` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
-  `url` varchar(255) NOT NULL,
-  `author` varchar(255) NOT NULL,
+  `url` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `author` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
   `dead` tinyint(1) NOT NULL DEFAULT '0',
   `created_at` datetime DEFAULT NULL,
   `updated_at` datetime DEFAULT NULL,
-  `title` varchar(255) NOT NULL,
-  `summary` text,
+  `title` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `summary` text COLLATE utf8mb4_unicode_ci,
   `hidden_by_admin` tinyint(1) NOT NULL DEFAULT '0',
   `summary_sanitizer_version` smallint(6) NOT NULL DEFAULT '0',
   `language_id` int(11) DEFAULT NULL,
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
-
+) ENGINE=InnoDB AUTO_INCREMENT=531280 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+/*!40101 SET character_set_client = @saved_cs_client */;
+DROP TABLE IF EXISTS `fannish_next_of_kins`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `fannish_next_of_kins` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `user_id` int(11) DEFAULT NULL,
   `kin_id` int(11) DEFAULT NULL,
-  `kin_email` varchar(255) DEFAULT NULL,
+  `kin_email` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   PRIMARY KEY (`id`),
   KEY `index_fannish_next_of_kins_on_user_id` (`user_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
-
+) ENGINE=InnoDB AUTO_INCREMENT=1023 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+/*!40101 SET character_set_client = @saved_cs_client */;
+DROP TABLE IF EXISTS `favorite_tags`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `favorite_tags` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `user_id` int(11) DEFAULT NULL,
   `tag_id` int(11) DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_favorite_tags_on_user_id_and_tag_id` (`user_id`,`tag_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
-
+) ENGINE=InnoDB AUTO_INCREMENT=12377268 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+/*!40101 SET character_set_client = @saved_cs_client */;
+DROP TABLE IF EXISTS `feedbacks`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `feedbacks` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
-  `comment` text NOT NULL,
+  `comment` text COLLATE utf8mb4_unicode_ci NOT NULL,
   `created_at` datetime DEFAULT NULL,
   `updated_at` datetime DEFAULT NULL,
-  `email` varchar(255) DEFAULT NULL,
-  `summary` varchar(255) DEFAULT NULL,
-  `user_agent` varchar(255) DEFAULT NULL,
-  `category` varchar(255) DEFAULT NULL,
+  `email` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `summary` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `user_agent` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `category` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `comment_sanitizer_version` smallint(6) NOT NULL DEFAULT '0',
   `summary_sanitizer_version` smallint(6) NOT NULL DEFAULT '0',
   `approved` tinyint(1) NOT NULL DEFAULT '0',
-  `ip_address` varchar(255) DEFAULT NULL,
-  `username` varchar(255) DEFAULT NULL,
-  `language` varchar(255) DEFAULT NULL,
+  `ip_address` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `username` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `language` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `rollout` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
-
+) ENGINE=InnoDB AUTO_INCREMENT=228771 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+/*!40101 SET character_set_client = @saved_cs_client */;
+DROP TABLE IF EXISTS `filter_counts`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `filter_counts` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `filter_id` bigint(20) NOT NULL,
@@ -542,21 +676,27 @@ CREATE TABLE `filter_counts` (
   UNIQUE KEY `index_filter_counts_on_filter_id` (`filter_id`),
   KEY `index_unhidden_works_count` (`unhidden_works_count`),
   KEY `index_public_works_count` (`public_works_count`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
-
+) ENGINE=InnoDB AUTO_INCREMENT=2473120 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+/*!40101 SET character_set_client = @saved_cs_client */;
+DROP TABLE IF EXISTS `filter_taggings`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `filter_taggings` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `filter_id` bigint(20) NOT NULL,
   `filterable_id` bigint(20) NOT NULL,
-  `filterable_type` varchar(100) DEFAULT NULL,
+  `filterable_type` varchar(100) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `created_at` datetime DEFAULT NULL,
   `updated_at` datetime DEFAULT NULL,
   `inherited` tinyint(1) NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`),
   KEY `index_filter_taggings_filterable` (`filterable_id`,`filterable_type`),
   KEY `index_filter_taggings_on_filter_id_and_filterable_type` (`filter_id`,`filterable_type`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
-
+) ENGINE=InnoDB AUTO_INCREMENT=488188270 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+/*!40101 SET character_set_client = @saved_cs_client */;
+DROP TABLE IF EXISTS `gift_exchanges`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `gift_exchanges` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `request_restriction_id` int(11) DEFAULT NULL,
@@ -567,9 +707,9 @@ CREATE TABLE `gift_exchanges` (
   `offers_num_allowed` int(11) NOT NULL DEFAULT '1',
   `created_at` datetime DEFAULT NULL,
   `updated_at` datetime DEFAULT NULL,
-  `signup_instructions_general` text,
-  `signup_instructions_requests` text,
-  `signup_instructions_offers` text,
+  `signup_instructions_general` text COLLATE utf8mb4_unicode_ci,
+  `signup_instructions_requests` text COLLATE utf8mb4_unicode_ci,
+  `signup_instructions_offers` text COLLATE utf8mb4_unicode_ci,
   `signup_open` tinyint(1) NOT NULL DEFAULT '0',
   `signups_open_at` datetime DEFAULT NULL,
   `signups_close_at` datetime DEFAULT NULL,
@@ -577,11 +717,11 @@ CREATE TABLE `gift_exchanges` (
   `works_reveal_at` datetime DEFAULT NULL,
   `authors_reveal_at` datetime DEFAULT NULL,
   `prompt_restriction_id` int(11) DEFAULT NULL,
-  `request_url_label` varchar(255) DEFAULT NULL,
-  `request_description_label` varchar(255) DEFAULT NULL,
-  `offer_url_label` varchar(255) DEFAULT NULL,
-  `offer_description_label` varchar(255) DEFAULT NULL,
-  `time_zone` varchar(255) DEFAULT NULL,
+  `request_url_label` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `request_description_label` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `offer_url_label` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `offer_description_label` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `time_zone` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `potential_match_settings_id` int(11) DEFAULT NULL,
   `assignments_sent_at` datetime DEFAULT NULL,
   `signup_instructions_general_sanitizer_version` smallint(6) NOT NULL DEFAULT '0',
@@ -589,12 +729,15 @@ CREATE TABLE `gift_exchanges` (
   `signup_instructions_offers_sanitizer_version` smallint(6) NOT NULL DEFAULT '0',
   `requests_summary_visible` tinyint(1) NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
-
+) ENGINE=InnoDB AUTO_INCREMENT=7017 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+/*!40101 SET character_set_client = @saved_cs_client */;
+DROP TABLE IF EXISTS `gifts`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `gifts` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `work_id` int(11) DEFAULT NULL,
-  `recipient_name` varchar(255) DEFAULT NULL,
+  `recipient_name` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `created_at` datetime DEFAULT NULL,
   `updated_at` datetime DEFAULT NULL,
   `pseud_id` int(11) DEFAULT NULL,
@@ -603,8 +746,11 @@ CREATE TABLE `gifts` (
   KEY `index_gifts_on_recipient_name` (`recipient_name`),
   KEY `index_gifts_on_work_id` (`work_id`),
   KEY `index_gifts_on_pseud_id` (`pseud_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
-
+) ENGINE=InnoDB AUTO_INCREMENT=1665787 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+/*!40101 SET character_set_client = @saved_cs_client */;
+DROP TABLE IF EXISTS `inbox_comments`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `inbox_comments` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `user_id` int(11) DEFAULT NULL,
@@ -617,20 +763,30 @@ CREATE TABLE `inbox_comments` (
   KEY `index_inbox_comments_on_read_and_user_id` (`read`,`user_id`),
   KEY `index_inbox_comments_on_feedback_comment_id` (`feedback_comment_id`),
   KEY `index_inbox_comments_on_user_id` (`user_id`)
+) ENGINE=InnoDB AUTO_INCREMENT=247581756 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+/*!40101 SET character_set_client = @saved_cs_client */;
+DROP TABLE IF EXISTS `innodb_monitor`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `innodb_monitor` (
+  `a` int(11) DEFAULT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
-
+/*!40101 SET character_set_client = @saved_cs_client */;
+DROP TABLE IF EXISTS `invitations`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `invitations` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `creator_id` int(11) DEFAULT NULL,
-  `invitee_email` varchar(255) DEFAULT NULL,
-  `token` varchar(255) DEFAULT NULL,
+  `invitee_email` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `token` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `sent_at` datetime DEFAULT NULL,
   `created_at` datetime DEFAULT NULL,
   `updated_at` datetime DEFAULT NULL,
   `used` tinyint(1) NOT NULL DEFAULT '0',
   `invitee_id` int(11) DEFAULT NULL,
-  `invitee_type` varchar(255) DEFAULT NULL,
-  `creator_type` varchar(255) DEFAULT NULL,
+  `invitee_type` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `creator_type` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `redeemed_at` datetime DEFAULT NULL,
   `from_queue` tinyint(1) NOT NULL DEFAULT '0',
   `external_author_id` int(11) DEFAULT NULL,
@@ -639,58 +795,78 @@ CREATE TABLE `invitations` (
   KEY `index_invitations_on_external_author_id` (`external_author_id`),
   KEY `index_invitations_on_creator_id_and_creator_type` (`creator_id`,`creator_type`),
   KEY `index_invitations_on_token` (`token`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
-
+) ENGINE=InnoDB AUTO_INCREMENT=32609151 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+/*!40101 SET character_set_client = @saved_cs_client */;
+DROP TABLE IF EXISTS `invite_requests`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `invite_requests` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
-  `email` varchar(255) DEFAULT NULL,
+  `email` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `position` int(11) DEFAULT NULL,
   `created_at` datetime DEFAULT NULL,
   `updated_at` datetime DEFAULT NULL,
+  `simplified_email` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `ip_address` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   PRIMARY KEY (`id`),
+  UNIQUE KEY `index_invite_requests_on_simplified_email` (`simplified_email`),
   KEY `index_invite_requests_on_email` (`email`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
-
+) ENGINE=InnoDB AUTO_INCREMENT=8654665 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+/*!40101 SET character_set_client = @saved_cs_client */;
+DROP TABLE IF EXISTS `known_issues`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `known_issues` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `admin_id` int(11) DEFAULT NULL,
-  `title` varchar(255) DEFAULT NULL,
-  `content` text,
+  `title` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `content` text COLLATE utf8mb4_unicode_ci,
   `updated_at` datetime DEFAULT NULL,
   `created_at` datetime DEFAULT NULL,
   `content_sanitizer_version` smallint(6) NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
-
+) ENGINE=InnoDB AUTO_INCREMENT=2 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+/*!40101 SET character_set_client = @saved_cs_client */;
+DROP TABLE IF EXISTS `kudos`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `kudos` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `pseud_id` int(11) DEFAULT NULL,
   `commentable_id` int(11) DEFAULT NULL,
-  `commentable_type` varchar(255) DEFAULT NULL,
+  `commentable_type` varchar(255) CHARACTER SET utf8 DEFAULT NULL,
   `created_at` datetime DEFAULT NULL,
   `updated_at` datetime DEFAULT NULL,
-  `ip_address` varchar(255) DEFAULT NULL,
+  `ip_address` varchar(255) CHARACTER SET utf8 DEFAULT NULL,
   PRIMARY KEY (`id`),
   KEY `index_kudos_on_pseud_id` (`pseud_id`),
   KEY `index_kudos_on_ip_address` (`ip_address`),
   KEY `index_kudos_on_commentable_id_and_commentable_type_and_pseud_id` (`commentable_id`,`commentable_type`,`pseud_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
-
+) ENGINE=InnoDB AUTO_INCREMENT=1792468252 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+/*!40101 SET character_set_client = @saved_cs_client */;
+DROP TABLE IF EXISTS `languages`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `languages` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
-  `short` varchar(4) DEFAULT NULL,
-  `name` varchar(255) DEFAULT NULL,
+  `short` varchar(4) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `name` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `support_available` tinyint(1) NOT NULL DEFAULT '0',
   `abuse_support_available` tinyint(1) NOT NULL DEFAULT '0',
+  `sortable_name` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   PRIMARY KEY (`id`),
-  KEY `index_languages_on_short` (`short`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
-
+  KEY `index_languages_on_short` (`short`),
+  KEY `index_languages_on_sortable_name` (`sortable_name`)
+) ENGINE=InnoDB AUTO_INCREMENT=107 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+/*!40101 SET character_set_client = @saved_cs_client */;
+DROP TABLE IF EXISTS `locales`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `locales` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
-  `iso` varchar(255) DEFAULT NULL,
-  `short` varchar(255) DEFAULT NULL,
-  `name` varchar(255) DEFAULT NULL,
+  `iso` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `short` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `name` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `main` tinyint(1) DEFAULT NULL,
   `updated_at` datetime DEFAULT NULL,
   `language_id` int(11) NOT NULL,
@@ -700,15 +876,18 @@ CREATE TABLE `locales` (
   KEY `index_locales_on_iso` (`iso`),
   KEY `index_locales_on_short` (`short`),
   KEY `index_locales_on_language_id` (`language_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
-
+) ENGINE=InnoDB AUTO_INCREMENT=119 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+/*!40101 SET character_set_client = @saved_cs_client */;
+DROP TABLE IF EXISTS `log_items`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `log_items` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `user_id` int(11) NOT NULL,
   `admin_id` int(11) DEFAULT NULL,
   `role_id` int(11) DEFAULT NULL,
   `action` tinyint(4) DEFAULT NULL,
-  `note` text NOT NULL,
+  `note` text COLLATE utf8mb4_unicode_ci NOT NULL,
   `enddate` datetime DEFAULT NULL,
   `created_at` datetime DEFAULT NULL,
   `updated_at` datetime DEFAULT NULL,
@@ -717,8 +896,11 @@ CREATE TABLE `log_items` (
   KEY `index_log_items_on_user_id` (`user_id`),
   KEY `index_log_items_on_admin_id` (`admin_id`),
   KEY `index_log_items_on_role_id` (`role_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
-
+) ENGINE=InnoDB AUTO_INCREMENT=14055339 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+/*!40101 SET character_set_client = @saved_cs_client */;
+DROP TABLE IF EXISTS `meta_taggings`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `meta_taggings` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `meta_tag_id` bigint(20) NOT NULL,
@@ -727,46 +909,72 @@ CREATE TABLE `meta_taggings` (
   `created_at` datetime DEFAULT NULL,
   `updated_at` datetime DEFAULT NULL,
   PRIMARY KEY (`id`),
-  KEY `index_meta_taggings_on_meta_tag_id` (`meta_tag_id`),
+  UNIQUE KEY `index_meta_taggings_on_meta_tag_id_and_sub_tag_id` (`meta_tag_id`,`sub_tag_id`),
   KEY `index_meta_taggings_on_sub_tag_id` (`sub_tag_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
-
+) ENGINE=InnoDB AUTO_INCREMENT=792340 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+/*!40101 SET character_set_client = @saved_cs_client */;
+DROP TABLE IF EXISTS `moderated_works`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `moderated_works` (
+  `id` bigint(20) NOT NULL AUTO_INCREMENT,
+  `work_id` bigint(20) NOT NULL,
+  `approved` tinyint(1) NOT NULL DEFAULT '0',
+  `reviewed` tinyint(1) NOT NULL DEFAULT '0',
+  `created_at` datetime NOT NULL,
+  `updated_at` datetime NOT NULL,
+  PRIMARY KEY (`id`),
+  KEY `index_moderated_works_on_work_id` (`work_id`)
+) ENGINE=InnoDB AUTO_INCREMENT=169876 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+/*!40101 SET character_set_client = @saved_cs_client */;
+DROP TABLE IF EXISTS `open_id_authentication_associations`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `open_id_authentication_associations` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `issued` int(11) DEFAULT NULL,
   `lifetime` int(11) DEFAULT NULL,
-  `handle` varchar(255) DEFAULT NULL,
-  `assoc_type` varchar(255) DEFAULT NULL,
+  `handle` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `assoc_type` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `server_url` blob,
   `secret` blob,
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
-
+) ENGINE=InnoDB AUTO_INCREMENT=232 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+/*!40101 SET character_set_client = @saved_cs_client */;
+DROP TABLE IF EXISTS `open_id_authentication_nonces`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `open_id_authentication_nonces` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `timestamp` int(11) NOT NULL,
-  `server_url` varchar(255) DEFAULT NULL,
-  `salt` varchar(255) NOT NULL,
+  `server_url` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `salt` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
-
+) ENGINE=InnoDB AUTO_INCREMENT=3953 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+/*!40101 SET character_set_client = @saved_cs_client */;
+DROP TABLE IF EXISTS `owned_set_taggings`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `owned_set_taggings` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `owned_tag_set_id` int(11) DEFAULT NULL,
   `set_taggable_id` int(11) DEFAULT NULL,
-  `set_taggable_type` varchar(100) DEFAULT NULL,
+  `set_taggable_type` varchar(100) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `created_at` datetime DEFAULT NULL,
   `updated_at` datetime DEFAULT NULL,
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
-
+) ENGINE=InnoDB AUTO_INCREMENT=40333 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+/*!40101 SET character_set_client = @saved_cs_client */;
+DROP TABLE IF EXISTS `owned_tag_sets`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `owned_tag_sets` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `tag_set_id` int(11) DEFAULT NULL,
   `visible` tinyint(1) NOT NULL DEFAULT '0',
   `nominated` tinyint(1) NOT NULL DEFAULT '0',
-  `title` varchar(255) DEFAULT NULL,
-  `description` varchar(255) DEFAULT NULL,
+  `title` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `description` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `created_at` datetime DEFAULT NULL,
   `updated_at` datetime DEFAULT NULL,
   `featured` tinyint(1) NOT NULL DEFAULT '0',
@@ -777,8 +985,11 @@ CREATE TABLE `owned_tag_sets` (
   `freeform_nomination_limit` int(11) NOT NULL DEFAULT '0',
   `usable` tinyint(1) NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
-
+) ENGINE=InnoDB AUTO_INCREMENT=3589 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+/*!40101 SET character_set_client = @saved_cs_client */;
+DROP TABLE IF EXISTS `potential_match_settings`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `potential_match_settings` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `num_required_prompts` int(11) NOT NULL DEFAULT '1',
@@ -788,19 +999,22 @@ CREATE TABLE `potential_match_settings` (
   `num_required_freeforms` int(11) NOT NULL DEFAULT '0',
   `num_required_categories` int(11) NOT NULL DEFAULT '0',
   `num_required_ratings` int(11) NOT NULL DEFAULT '0',
-  `num_required_warnings` int(11) NOT NULL DEFAULT '0',
+  `num_required_archive_warnings` int(11) NOT NULL DEFAULT '0',
   `include_optional_fandoms` tinyint(1) NOT NULL DEFAULT '0',
   `include_optional_characters` tinyint(1) NOT NULL DEFAULT '0',
   `include_optional_relationships` tinyint(1) NOT NULL DEFAULT '0',
   `include_optional_freeforms` tinyint(1) NOT NULL DEFAULT '0',
   `include_optional_categories` tinyint(1) NOT NULL DEFAULT '0',
   `include_optional_ratings` tinyint(1) NOT NULL DEFAULT '0',
-  `include_optional_warnings` tinyint(1) NOT NULL DEFAULT '0',
+  `include_optional_archive_warnings` tinyint(1) NOT NULL DEFAULT '0',
   `created_at` datetime DEFAULT NULL,
   `updated_at` datetime DEFAULT NULL,
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
-
+) ENGINE=InnoDB AUTO_INCREMENT=7023 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+/*!40101 SET character_set_client = @saved_cs_client */;
+DROP TABLE IF EXISTS `potential_matches`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `potential_matches` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `collection_id` int(11) DEFAULT NULL,
@@ -815,8 +1029,11 @@ CREATE TABLE `potential_matches` (
   KEY `index_potential_matches_on_collection_id` (`collection_id`),
   KEY `index_potential_matches_on_offer_signup_id` (`offer_signup_id`),
   KEY `index_potential_matches_on_request_signup_id` (`request_signup_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
-
+) ENGINE=InnoDB AUTO_INCREMENT=25269903 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+/*!40101 SET character_set_client = @saved_cs_client */;
+DROP TABLE IF EXISTS `preferences`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `preferences` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `user_id` int(11) DEFAULT NULL,
@@ -831,7 +1048,7 @@ CREATE TABLE `preferences` (
   `hide_warnings` tinyint(1) NOT NULL DEFAULT '0',
   `comment_inbox_off` tinyint(1) DEFAULT '0',
   `comment_copy_to_self_off` tinyint(1) NOT NULL DEFAULT '1',
-  `work_title_format` varchar(255) DEFAULT 'TITLE - AUTHOR - FANDOM',
+  `work_title_format` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT 'TITLE - AUTHOR - FANDOM',
   `hide_freeform` tinyint(1) NOT NULL DEFAULT '0',
   `first_login` tinyint(1) DEFAULT '1',
   `automatically_approve_collections` tinyint(1) NOT NULL DEFAULT '0',
@@ -842,9 +1059,8 @@ CREATE TABLE `preferences` (
   `recipient_emails_off` tinyint(1) NOT NULL DEFAULT '0',
   `hide_all_hit_counts` tinyint(1) NOT NULL DEFAULT '0',
   `view_full_works` tinyint(1) NOT NULL DEFAULT '0',
-  `time_zone` varchar(255) DEFAULT NULL,
+  `time_zone` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `plain_text_skin` tinyint(1) NOT NULL DEFAULT '0',
-  `admin_emails_off` tinyint(1) NOT NULL DEFAULT '0',
   `disable_work_skins` tinyint(1) NOT NULL DEFAULT '0',
   `skin_id` int(11) DEFAULT NULL,
   `minimize_search_engines` tinyint(1) NOT NULL DEFAULT '0',
@@ -852,24 +1068,32 @@ CREATE TABLE `preferences` (
   `disable_share_links` tinyint(1) NOT NULL DEFAULT '0',
   `banner_seen` tinyint(1) NOT NULL DEFAULT '0',
   `preferred_locale` int(11) NOT NULL DEFAULT '1',
+  `allow_cocreator` tinyint(1) DEFAULT '0',
   PRIMARY KEY (`id`),
-  KEY `index_preferences_on_user_id` (`user_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
-
+  KEY `index_preferences_on_user_id` (`user_id`),
+  KEY `index_preferences_on_skin_id` (`skin_id`)
+) ENGINE=InnoDB AUTO_INCREMENT=6265057 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+/*!40101 SET character_set_client = @saved_cs_client */;
+DROP TABLE IF EXISTS `profiles`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `profiles` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `user_id` int(11) DEFAULT NULL,
-  `location` varchar(255) DEFAULT NULL,
-  `about_me` text,
+  `location` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `about_me` text COLLATE utf8mb4_unicode_ci,
   `date_of_birth` date DEFAULT NULL,
   `created_at` datetime DEFAULT NULL,
   `updated_at` datetime DEFAULT NULL,
-  `title` varchar(255) DEFAULT NULL,
+  `title` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `about_me_sanitizer_version` smallint(6) NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`),
   KEY `index_profiles_on_user_id` (`user_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
-
+) ENGINE=InnoDB AUTO_INCREMENT=6264852 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+/*!40101 SET character_set_client = @saved_cs_client */;
+DROP TABLE IF EXISTS `prompt_memes`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `prompt_memes` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `prompt_restriction_id` int(11) DEFAULT NULL,
@@ -882,19 +1106,22 @@ CREATE TABLE `prompt_memes` (
   `assignments_due_at` datetime DEFAULT NULL,
   `works_reveal_at` datetime DEFAULT NULL,
   `authors_reveal_at` datetime DEFAULT NULL,
-  `signup_instructions_general` text,
-  `signup_instructions_requests` text,
-  `request_url_label` varchar(255) DEFAULT NULL,
-  `request_description_label` varchar(255) DEFAULT NULL,
-  `time_zone` varchar(255) DEFAULT NULL,
+  `signup_instructions_general` text COLLATE utf8mb4_unicode_ci,
+  `signup_instructions_requests` text COLLATE utf8mb4_unicode_ci,
+  `request_url_label` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `request_description_label` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `time_zone` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `signup_instructions_general_sanitizer_version` smallint(6) NOT NULL DEFAULT '0',
   `signup_instructions_requests_sanitizer_version` smallint(6) NOT NULL DEFAULT '0',
   `created_at` datetime DEFAULT NULL,
   `updated_at` datetime DEFAULT NULL,
   `anonymous` tinyint(1) NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
-
+) ENGINE=InnoDB AUTO_INCREMENT=6471 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+/*!40101 SET character_set_client = @saved_cs_client */;
+DROP TABLE IF EXISTS `prompt_restrictions`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `prompt_restrictions` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `tag_set_id` int(11) DEFAULT NULL,
@@ -907,14 +1134,14 @@ CREATE TABLE `prompt_restrictions` (
   `character_num_required` int(11) NOT NULL DEFAULT '0',
   `relationship_num_required` int(11) NOT NULL DEFAULT '0',
   `freeform_num_required` int(11) NOT NULL DEFAULT '0',
-  `warning_num_required` int(11) NOT NULL DEFAULT '0',
+  `archive_warning_num_required` int(11) NOT NULL DEFAULT '0',
   `fandom_num_allowed` int(11) NOT NULL DEFAULT '1',
   `category_num_allowed` int(11) NOT NULL DEFAULT '0',
   `rating_num_allowed` int(11) NOT NULL DEFAULT '0',
   `character_num_allowed` int(11) NOT NULL DEFAULT '1',
   `relationship_num_allowed` int(11) NOT NULL DEFAULT '1',
   `freeform_num_allowed` int(11) NOT NULL DEFAULT '0',
-  `warning_num_allowed` int(11) NOT NULL DEFAULT '0',
+  `archive_warning_num_allowed` int(11) NOT NULL DEFAULT '0',
   `created_at` datetime DEFAULT NULL,
   `updated_at` datetime DEFAULT NULL,
   `description_required` tinyint(1) NOT NULL DEFAULT '0',
@@ -924,14 +1151,14 @@ CREATE TABLE `prompt_restrictions` (
   `allow_any_rating` tinyint(1) NOT NULL DEFAULT '0',
   `allow_any_relationship` tinyint(1) NOT NULL DEFAULT '0',
   `allow_any_category` tinyint(1) NOT NULL DEFAULT '0',
-  `allow_any_warning` tinyint(1) NOT NULL DEFAULT '0',
+  `allow_any_archive_warning` tinyint(1) NOT NULL DEFAULT '0',
   `allow_any_freeform` tinyint(1) NOT NULL DEFAULT '0',
   `require_unique_fandom` tinyint(1) NOT NULL DEFAULT '0',
   `require_unique_character` tinyint(1) NOT NULL DEFAULT '0',
   `require_unique_rating` tinyint(1) NOT NULL DEFAULT '0',
   `require_unique_relationship` tinyint(1) NOT NULL DEFAULT '0',
   `require_unique_category` tinyint(1) NOT NULL DEFAULT '0',
-  `require_unique_warning` tinyint(1) NOT NULL DEFAULT '0',
+  `require_unique_archive_warning` tinyint(1) NOT NULL DEFAULT '0',
   `require_unique_freeform` tinyint(1) NOT NULL DEFAULT '0',
   `character_restrict_to_fandom` tinyint(1) NOT NULL DEFAULT '0',
   `relationship_restrict_to_fandom` tinyint(1) NOT NULL DEFAULT '0',
@@ -940,8 +1167,11 @@ CREATE TABLE `prompt_restrictions` (
   `title_required` tinyint(1) NOT NULL DEFAULT '0',
   `title_allowed` tinyint(1) NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
-
+) ENGINE=InnoDB AUTO_INCREMENT=20691 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+/*!40101 SET character_set_client = @saved_cs_client */;
+DROP TABLE IF EXISTS `prompts`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `prompts` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `collection_id` int(11) DEFAULT NULL,
@@ -949,20 +1179,20 @@ CREATE TABLE `prompts` (
   `pseud_id` int(11) DEFAULT NULL,
   `tag_set_id` int(11) DEFAULT NULL,
   `optional_tag_set_id` int(11) DEFAULT NULL,
-  `title` varchar(255) DEFAULT NULL,
-  `url` varchar(255) DEFAULT NULL,
-  `description` text,
+  `title` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `url` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `description` text COLLATE utf8mb4_unicode_ci,
   `position` int(11) DEFAULT NULL,
   `created_at` datetime DEFAULT NULL,
   `updated_at` datetime DEFAULT NULL,
-  `type` varchar(255) DEFAULT NULL,
+  `type` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `description_sanitizer_version` smallint(6) NOT NULL DEFAULT '0',
   `any_fandom` tinyint(1) NOT NULL DEFAULT '0',
   `any_character` tinyint(1) NOT NULL DEFAULT '0',
   `any_rating` tinyint(1) NOT NULL DEFAULT '0',
   `any_relationship` tinyint(1) NOT NULL DEFAULT '0',
   `any_category` tinyint(1) NOT NULL DEFAULT '0',
-  `any_warning` tinyint(1) NOT NULL DEFAULT '0',
+  `any_archive_warning` tinyint(1) NOT NULL DEFAULT '0',
   `any_freeform` tinyint(1) NOT NULL DEFAULT '0',
   `anonymous` tinyint(1) NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`),
@@ -971,61 +1201,73 @@ CREATE TABLE `prompts` (
   KEY `index_prompts_on_collection_id` (`collection_id`),
   KEY `index_prompts_on_optional_tag_set_id` (`optional_tag_set_id`),
   KEY `index_prompts_on_challenge_signup_id` (`challenge_signup_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
-
+) ENGINE=InnoDB AUTO_INCREMENT=1429782 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+/*!40101 SET character_set_client = @saved_cs_client */;
+DROP TABLE IF EXISTS `pseuds`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `pseuds` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `user_id` int(11) DEFAULT NULL,
-  `name` varchar(255) NOT NULL,
-  `description` text,
+  `name` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `description` text COLLATE utf8mb4_unicode_ci,
   `is_default` tinyint(1) NOT NULL DEFAULT '0',
   `created_at` datetime DEFAULT NULL,
   `updated_at` datetime DEFAULT NULL,
-  `icon_file_name` varchar(255) DEFAULT NULL,
-  `icon_content_type` varchar(255) DEFAULT NULL,
+  `icon_file_name` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `icon_content_type` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `icon_file_size` int(11) DEFAULT NULL,
   `icon_updated_at` datetime DEFAULT NULL,
-  `icon_alt_text` varchar(255) DEFAULT '',
+  `icon_alt_text` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT '',
   `delta` tinyint(1) DEFAULT '1',
   `description_sanitizer_version` smallint(6) NOT NULL DEFAULT '0',
-  `icon_comment_text` varchar(255) DEFAULT '',
+  `icon_comment_text` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT '',
   PRIMARY KEY (`id`),
   KEY `index_pseuds_on_user_id_and_name` (`user_id`,`name`),
   KEY `index_psueds_on_name` (`name`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
-
+) ENGINE=InnoDB AUTO_INCREMENT=6702403 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+/*!40101 SET character_set_client = @saved_cs_client */;
+DROP TABLE IF EXISTS `question_translations`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `question_translations` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `question_id` int(11) DEFAULT NULL,
-  `locale` varchar(255) NOT NULL,
+  `locale` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
   `created_at` datetime NOT NULL,
   `updated_at` datetime NOT NULL,
-  `question` varchar(255) DEFAULT NULL,
-  `content` text,
+  `question` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `content` text COLLATE utf8mb4_unicode_ci,
   `content_sanitizer_version` smallint(6) NOT NULL DEFAULT '0',
   `screencast_sanitizer_version` smallint(6) NOT NULL DEFAULT '0',
-  `is_translated` varchar(255) DEFAULT NULL,
+  `is_translated` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   PRIMARY KEY (`id`),
   KEY `index_question_translations_on_question_id` (`question_id`),
   KEY `index_question_translations_on_locale` (`locale`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
-
+) ENGINE=InnoDB AUTO_INCREMENT=38935 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+/*!40101 SET character_set_client = @saved_cs_client */;
+DROP TABLE IF EXISTS `questions`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `questions` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `archive_faq_id` int(11) DEFAULT NULL,
-  `question` varchar(255) DEFAULT NULL,
-  `content` text,
-  `anchor` varchar(255) DEFAULT NULL,
-  `screencast` text,
+  `question` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `content` text COLLATE utf8mb4_unicode_ci,
+  `anchor` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `screencast` text COLLATE utf8mb4_unicode_ci,
   `created_at` datetime NOT NULL,
   `updated_at` datetime NOT NULL,
   `position` int(11) DEFAULT '1',
   PRIMARY KEY (`id`),
   KEY `index_questions_on_archive_faq_id_and_position` (`archive_faq_id`,`position`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
-
+) ENGINE=InnoDB AUTO_INCREMENT=1932 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+/*!40101 SET character_set_client = @saved_cs_client */;
+DROP TABLE IF EXISTS `readings`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `readings` (
-  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `id` bigint(20) NOT NULL AUTO_INCREMENT,
   `major_version_read` int(11) DEFAULT NULL,
   `minor_version_read` int(11) DEFAULT NULL,
   `user_id` int(11) DEFAULT NULL,
@@ -1038,12 +1280,15 @@ CREATE TABLE `readings` (
   PRIMARY KEY (`id`),
   KEY `index_readings_on_work_id` (`work_id`),
   KEY `index_readings_on_user_id` (`user_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
-
+) ENGINE=InnoDB AUTO_INCREMENT=5582675520 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+/*!40101 SET character_set_client = @saved_cs_client */;
+DROP TABLE IF EXISTS `related_works`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `related_works` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `parent_id` int(11) DEFAULT NULL,
-  `parent_type` varchar(255) DEFAULT NULL,
+  `parent_type` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `work_id` int(11) DEFAULT NULL,
   `reciprocal` tinyint(1) NOT NULL DEFAULT '0',
   `created_at` datetime DEFAULT NULL,
@@ -1052,12 +1297,15 @@ CREATE TABLE `related_works` (
   PRIMARY KEY (`id`),
   KEY `index_related_works_on_parent_id_and_parent_type` (`parent_id`,`parent_type`),
   KEY `index_related_works_on_work_id` (`work_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
-
+) ENGINE=InnoDB AUTO_INCREMENT=470719 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+/*!40101 SET character_set_client = @saved_cs_client */;
+DROP TABLE IF EXISTS `roles`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `roles` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
-  `name` varchar(40) DEFAULT NULL,
-  `authorizable_type` varchar(40) DEFAULT NULL,
+  `name` varchar(40) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `authorizable_type` varchar(40) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `authorizable_id` int(11) DEFAULT NULL,
   `created_at` datetime DEFAULT NULL,
   `updated_at` datetime DEFAULT NULL,
@@ -1065,8 +1313,11 @@ CREATE TABLE `roles` (
   KEY `index_roles_on_authorizable_id_and_authorizable_type` (`authorizable_id`,`authorizable_type`),
   KEY `index_roles_on_authorizable_type` (`authorizable_type`),
   KEY `index_roles_on_name` (`name`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
-
+) ENGINE=InnoDB AUTO_INCREMENT=7 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+/*!40101 SET character_set_client = @saved_cs_client */;
+DROP TABLE IF EXISTS `roles_users`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `roles_users` (
   `user_id` int(11) DEFAULT NULL,
   `role_id` int(11) DEFAULT NULL,
@@ -1075,33 +1326,32 @@ CREATE TABLE `roles_users` (
   KEY `index_roles_users_on_role_id_and_user_id` (`role_id`,`user_id`),
   KEY `index_roles_users_on_user_id_and_role_id` (`user_id`,`role_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
-
-CREATE TABLE `saved_works` (
-  `id` int(11) NOT NULL AUTO_INCREMENT,
-  `user_id` int(11) NOT NULL,
-  `work_id` int(11) NOT NULL,
-  `created_at` datetime NOT NULL,
-  `updated_at` datetime NOT NULL,
-  PRIMARY KEY (`id`),
-  UNIQUE KEY `index_saved_works_on_user_id_and_work_id` (`user_id`,`work_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
-
+/*!40101 SET character_set_client = @saved_cs_client */;
+DROP TABLE IF EXISTS `schema_migrations`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `schema_migrations` (
-  `version` varchar(255) NOT NULL,
+  `version` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
   UNIQUE KEY `unique_schema_migrations` (`version`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
-
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+/*!40101 SET character_set_client = @saved_cs_client */;
+DROP TABLE IF EXISTS `searches`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `searches` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `user_id` int(11) DEFAULT NULL,
-  `name` varchar(255) DEFAULT NULL,
-  `options` text,
-  `type` varchar(255) DEFAULT NULL,
+  `name` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `options` text COLLATE utf8mb4_unicode_ci,
+  `type` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `created_at` datetime DEFAULT NULL,
   `updated_at` datetime DEFAULT NULL,
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
-
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+/*!40101 SET character_set_client = @saved_cs_client */;
+DROP TABLE IF EXISTS `serial_works`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `serial_works` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `series_id` int(11) DEFAULT NULL,
@@ -1112,23 +1362,29 @@ CREATE TABLE `serial_works` (
   PRIMARY KEY (`id`),
   KEY `index_serial_works_on_work_id` (`work_id`),
   KEY `index_serial_works_on_series_id` (`series_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
-
+) ENGINE=InnoDB AUTO_INCREMENT=4888665 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+/*!40101 SET character_set_client = @saved_cs_client */;
+DROP TABLE IF EXISTS `series`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `series` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `created_at` datetime DEFAULT NULL,
   `updated_at` datetime DEFAULT NULL,
-  `title` varchar(255) NOT NULL,
-  `summary` text,
-  `notes` text,
+  `title` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `summary` text COLLATE utf8mb4_unicode_ci,
+  `series_notes` text COLLATE utf8mb4_unicode_ci,
   `hidden_by_admin` tinyint(1) NOT NULL DEFAULT '0',
   `restricted` tinyint(1) NOT NULL DEFAULT '1',
   `complete` tinyint(1) NOT NULL DEFAULT '0',
   `summary_sanitizer_version` smallint(6) NOT NULL DEFAULT '0',
-  `notes_sanitizer_version` smallint(6) NOT NULL DEFAULT '0',
+  `series_notes_sanitizer_version` smallint(6) NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
-
+) ENGINE=InnoDB AUTO_INCREMENT=1533895 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+/*!40101 SET character_set_client = @saved_cs_client */;
+DROP TABLE IF EXISTS `set_taggings`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `set_taggings` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `tag_id` int(11) DEFAULT NULL,
@@ -1138,8 +1394,11 @@ CREATE TABLE `set_taggings` (
   PRIMARY KEY (`id`),
   KEY `index_set_taggings_on_tag_id` (`tag_id`),
   KEY `index_set_taggings_on_tag_set_id` (`tag_set_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
-
+) ENGINE=InnoDB AUTO_INCREMENT=12441852 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+/*!40101 SET character_set_client = @saved_cs_client */;
+DROP TABLE IF EXISTS `skin_parents`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `skin_parents` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `child_skin_id` int(11) DEFAULT NULL,
@@ -1148,40 +1407,43 @@ CREATE TABLE `skin_parents` (
   `created_at` datetime DEFAULT NULL,
   `updated_at` datetime DEFAULT NULL,
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
-
+) ENGINE=InnoDB AUTO_INCREMENT=63460 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+/*!40101 SET character_set_client = @saved_cs_client */;
+DROP TABLE IF EXISTS `skins`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `skins` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
-  `title` varchar(255) DEFAULT NULL,
+  `title` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `author_id` int(11) DEFAULT NULL,
-  `css` text,
+  `css` text COLLATE utf8mb4_unicode_ci,
   `public` tinyint(1) DEFAULT '0',
   `official` tinyint(1) DEFAULT '0',
   `created_at` datetime DEFAULT NULL,
   `updated_at` datetime DEFAULT NULL,
-  `icon_file_name` varchar(255) DEFAULT NULL,
-  `icon_content_type` varchar(255) DEFAULT NULL,
+  `icon_file_name` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `icon_content_type` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `icon_file_size` int(11) DEFAULT NULL,
   `icon_updated_at` datetime DEFAULT NULL,
-  `icon_alt_text` varchar(255) DEFAULT '',
+  `icon_alt_text` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT '',
   `margin` int(11) DEFAULT NULL,
   `paragraph_gap` int(11) DEFAULT NULL,
-  `font` varchar(255) DEFAULT NULL,
+  `font` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `base_em` int(11) DEFAULT NULL,
-  `background_color` varchar(255) DEFAULT NULL,
-  `foreground_color` varchar(255) DEFAULT NULL,
-  `description` text,
+  `background_color` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `foreground_color` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `description` text COLLATE utf8mb4_unicode_ci,
   `rejected` tinyint(1) NOT NULL DEFAULT '0',
-  `admin_note` varchar(255) DEFAULT NULL,
+  `admin_note` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `description_sanitizer_version` smallint(6) NOT NULL DEFAULT '0',
-  `type` varchar(255) DEFAULT NULL,
+  `type` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `paragraph_margin` float DEFAULT NULL,
-  `headercolor` varchar(255) DEFAULT NULL,
-  `accent_color` varchar(255) DEFAULT NULL,
-  `role` varchar(255) DEFAULT NULL,
-  `media` varchar(255) DEFAULT NULL,
-  `ie_condition` varchar(255) DEFAULT NULL,
-  `filename` varchar(255) DEFAULT NULL,
+  `headercolor` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `accent_color` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `role` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `media` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `ie_condition` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `filename` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `do_not_upgrade` tinyint(1) NOT NULL DEFAULT '0',
   `cached` tinyint(1) NOT NULL DEFAULT '0',
   `unusable` tinyint(1) NOT NULL DEFAULT '0',
@@ -1193,13 +1455,16 @@ CREATE TABLE `skins` (
   KEY `index_skins_on_author_id` (`author_id`),
   KEY `index_skins_on_in_chooser` (`in_chooser`),
   KEY `index_skins_on_title` (`title`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
-
+) ENGINE=InnoDB AUTO_INCREMENT=260944 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+/*!40101 SET character_set_client = @saved_cs_client */;
+DROP TABLE IF EXISTS `stat_counters`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `stat_counters` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `work_id` int(11) DEFAULT NULL,
   `hit_count` int(11) NOT NULL DEFAULT '0',
-  `last_visitor` varchar(255) DEFAULT NULL,
+  `last_visitor` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `download_count` int(11) NOT NULL DEFAULT '0',
   `comments_count` int(11) NOT NULL DEFAULT '0',
   `kudos_count` int(11) NOT NULL DEFAULT '0',
@@ -1207,27 +1472,33 @@ CREATE TABLE `stat_counters` (
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_hit_counters_on_work_id` (`work_id`),
   KEY `index_hit_counters_on_hit_count` (`hit_count`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
-
+) ENGINE=InnoDB AUTO_INCREMENT=20631568 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+/*!40101 SET character_set_client = @saved_cs_client */;
+DROP TABLE IF EXISTS `subscriptions`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `subscriptions` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `user_id` int(11) DEFAULT NULL,
   `subscribable_id` int(11) DEFAULT NULL,
-  `subscribable_type` varchar(255) DEFAULT NULL,
+  `subscribable_type` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `created_at` datetime DEFAULT NULL,
   `updated_at` datetime DEFAULT NULL,
   PRIMARY KEY (`id`),
   KEY `user_id` (`user_id`),
   KEY `subscribable` (`subscribable_id`,`subscribable_type`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
-
+) ENGINE=InnoDB AUTO_INCREMENT=276125836 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+/*!40101 SET character_set_client = @saved_cs_client */;
+DROP TABLE IF EXISTS `tag_nominations`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `tag_nominations` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
-  `type` varchar(255) DEFAULT NULL,
+  `type` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `tag_set_nomination_id` int(11) DEFAULT NULL,
   `fandom_nomination_id` int(11) DEFAULT NULL,
-  `tagname` varchar(255) DEFAULT NULL,
-  `parent_tagname` varchar(255) DEFAULT NULL,
+  `tagname` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `parent_tagname` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `approved` tinyint(1) NOT NULL DEFAULT '0',
   `rejected` tinyint(1) NOT NULL DEFAULT '0',
   `created_at` datetime DEFAULT NULL,
@@ -1235,10 +1506,18 @@ CREATE TABLE `tag_nominations` (
   `canonical` tinyint(1) NOT NULL DEFAULT '0',
   `exists` tinyint(1) NOT NULL DEFAULT '0',
   `parented` tinyint(1) NOT NULL DEFAULT '0',
-  `synonym` varchar(255) DEFAULT NULL,
-  PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
-
+  `synonym` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  KEY `index_tag_nominations_on_tagname` (`tagname`),
+  KEY `index_tag_nominations_on_type_and_tag_set_nomination_id` (`type`,`tag_set_nomination_id`),
+  KEY `index_tag_nominations_on_type_and_fandom_nomination_id` (`type`,`fandom_nomination_id`),
+  KEY `index_tag_nominations_on_type_and_synonym` (`type`,`synonym`),
+  KEY `index_tag_nominations_on_type_and_tagname` (`type`,`tagname`)
+) ENGINE=InnoDB AUTO_INCREMENT=2377353 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+/*!40101 SET character_set_client = @saved_cs_client */;
+DROP TABLE IF EXISTS `tag_set_associations`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `tag_set_associations` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `owned_tag_set_id` int(11) DEFAULT NULL,
@@ -1247,8 +1526,11 @@ CREATE TABLE `tag_set_associations` (
   `created_at` datetime DEFAULT NULL,
   `updated_at` datetime DEFAULT NULL,
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
-
+) ENGINE=InnoDB AUTO_INCREMENT=1091112 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+/*!40101 SET character_set_client = @saved_cs_client */;
+DROP TABLE IF EXISTS `tag_set_nominations`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `tag_set_nominations` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `pseud_id` int(11) DEFAULT NULL,
@@ -1256,8 +1538,11 @@ CREATE TABLE `tag_set_nominations` (
   `created_at` datetime DEFAULT NULL,
   `updated_at` datetime DEFAULT NULL,
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
-
+) ENGINE=InnoDB AUTO_INCREMENT=132648 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+/*!40101 SET character_set_client = @saved_cs_client */;
+DROP TABLE IF EXISTS `tag_set_ownerships`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `tag_set_ownerships` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `pseud_id` int(11) DEFAULT NULL,
@@ -1266,43 +1551,52 @@ CREATE TABLE `tag_set_ownerships` (
   `created_at` datetime DEFAULT NULL,
   `updated_at` datetime DEFAULT NULL,
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
-
+) ENGINE=InnoDB AUTO_INCREMENT=6496 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+/*!40101 SET character_set_client = @saved_cs_client */;
+DROP TABLE IF EXISTS `tag_sets`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `tag_sets` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `created_at` datetime DEFAULT NULL,
   `updated_at` datetime DEFAULT NULL,
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
-
+) ENGINE=InnoDB AUTO_INCREMENT=2705380 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+/*!40101 SET character_set_client = @saved_cs_client */;
+DROP TABLE IF EXISTS `taggings`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `taggings` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `tagger_id` int(11) DEFAULT NULL,
   `taggable_id` int(11) NOT NULL,
-  `taggable_type` varchar(100) DEFAULT '',
+  `taggable_type` varchar(100) COLLATE utf8mb4_unicode_ci DEFAULT '',
   `created_at` datetime DEFAULT NULL,
   `updated_at` datetime DEFAULT NULL,
-  `tagger_type` varchar(100) DEFAULT '',
+  `tagger_type` varchar(100) COLLATE utf8mb4_unicode_ci DEFAULT '',
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_taggings_polymorphic` (`tagger_id`,`tagger_type`,`taggable_id`,`taggable_type`),
   KEY `index_taggings_taggable` (`taggable_id`,`taggable_type`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
-
+) ENGINE=InnoDB AUTO_INCREMENT=413111889 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+/*!40101 SET character_set_client = @saved_cs_client */;
+DROP TABLE IF EXISTS `tags`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `tags` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
-  `name` varchar(100) DEFAULT '',
+  `name` varchar(100) COLLATE utf8mb4_unicode_ci DEFAULT '',
   `canonical` tinyint(1) NOT NULL DEFAULT '0',
   `created_at` datetime DEFAULT NULL,
   `updated_at` datetime DEFAULT NULL,
-  `taggings_count` int(11) DEFAULT '0',
+  `taggings_count_cache` int(11) DEFAULT '0',
   `adult` tinyint(1) DEFAULT '0',
-  `type` varchar(255) DEFAULT NULL,
+  `type` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `merger_id` int(11) DEFAULT NULL,
   `delta` tinyint(1) DEFAULT '0',
   `last_wrangler_id` int(11) DEFAULT NULL,
-  `last_wrangler_type` varchar(255) DEFAULT NULL,
+  `last_wrangler_type` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `unwrangleable` tinyint(1) NOT NULL DEFAULT '0',
-  `sortable_name` varchar(255) NOT NULL DEFAULT '',
+  `sortable_name` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_tags_on_name` (`name`),
   KEY `index_tags_on_merger_id` (`merger_id`),
@@ -1310,57 +1604,83 @@ CREATE TABLE `tags` (
   KEY `index_tags_on_canonical` (`canonical`),
   KEY `tag_created_at_index` (`created_at`),
   KEY `index_tags_on_type` (`type`),
-  KEY `index_tags_on_sortable_name` (`sortable_name`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
-
+  KEY `index_tags_on_sortable_name` (`sortable_name`),
+  KEY `index_tags_on_taggings_count_cache` (`taggings_count_cache`)
+) ENGINE=InnoDB AUTO_INCREMENT=36280167 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+/*!40101 SET character_set_client = @saved_cs_client */;
+DROP TABLE IF EXISTS `user_invite_requests`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `user_invite_requests` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `user_id` int(11) DEFAULT NULL,
   `quantity` int(11) DEFAULT NULL,
-  `reason` text,
+  `reason` text COLLATE utf8mb4_unicode_ci,
   `granted` tinyint(1) NOT NULL DEFAULT '0',
   `handled` tinyint(1) NOT NULL DEFAULT '0',
   `created_at` datetime DEFAULT NULL,
   `updated_at` datetime DEFAULT NULL,
   PRIMARY KEY (`id`),
   KEY `index_user_invite_requests_on_user_id` (`user_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
-
+) ENGINE=InnoDB AUTO_INCREMENT=78256 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+/*!40101 SET character_set_client = @saved_cs_client */;
+DROP TABLE IF EXISTS `users`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `users` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `created_at` datetime DEFAULT NULL,
   `updated_at` datetime DEFAULT NULL,
-  `email` varchar(255) DEFAULT NULL,
-  `activation_code` varchar(255) DEFAULT NULL,
-  `login` varchar(255) DEFAULT NULL,
-  `activated_at` datetime DEFAULT NULL,
-  `crypted_password` varchar(255) DEFAULT NULL,
-  `salt` varchar(255) DEFAULT NULL,
-  `recently_reset` tinyint(1) NOT NULL DEFAULT '0',
+  `email` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `confirmation_token` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `login` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `confirmed_at` datetime DEFAULT NULL,
+  `encrypted_password` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `password_salt` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `suspended` tinyint(1) NOT NULL DEFAULT '0',
   `banned` tinyint(1) NOT NULL DEFAULT '0',
   `invitation_id` int(11) DEFAULT NULL,
   `suspended_until` datetime DEFAULT NULL,
   `out_of_invites` tinyint(1) NOT NULL DEFAULT '1',
-  `persistence_token` varchar(255) NOT NULL,
-  `failed_login_count` int(11) DEFAULT NULL,
+  `failed_attempts` int(11) DEFAULT '0',
+  `accepted_tos_version` int(11) DEFAULT NULL,
+  `confirmation_sent_at` datetime DEFAULT NULL,
+  `reset_password_token` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `reset_password_sent_at` datetime DEFAULT NULL,
+  `remember_created_at` datetime DEFAULT NULL,
+  `sign_in_count` int(11) DEFAULT '0',
+  `current_sign_in_at` datetime DEFAULT NULL,
+  `last_sign_in_at` datetime DEFAULT NULL,
+  `current_sign_in_ip` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `last_sign_in_ip` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `unlock_token` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `locked_at` datetime DEFAULT NULL,
+  `recently_reset` tinyint(1) DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_users_on_login` (`login`),
-  KEY `index_users_on_activation_code` (`activation_code`),
-  KEY `index_users_on_email` (`email`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
-
+  UNIQUE KEY `index_users_on_reset_password_token` (`reset_password_token`),
+  UNIQUE KEY `index_users_on_unlock_token` (`unlock_token`),
+  UNIQUE KEY `index_users_on_confirmation_token` (`confirmation_token`),
+  UNIQUE KEY `index_users_on_email` (`email`)
+) ENGINE=InnoDB AUTO_INCREMENT=6267541 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+/*!40101 SET character_set_client = @saved_cs_client */;
+DROP TABLE IF EXISTS `work_links`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `work_links` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `work_id` int(11) DEFAULT NULL,
-  `url` varchar(255) DEFAULT NULL,
+  `url` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `count` int(11) DEFAULT NULL,
   `created_at` datetime DEFAULT NULL,
   `updated_at` datetime DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `work_links_work_id_url` (`work_id`,`url`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
-
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+/*!40101 SET character_set_client = @saved_cs_client */;
+DROP TABLE IF EXISTS `works`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `works` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `expected_number_of_chapters` int(11) DEFAULT '1',
@@ -1371,20 +1691,19 @@ CREATE TABLE `works` (
   `posted` tinyint(1) NOT NULL DEFAULT '0',
   `language_id` int(11) DEFAULT NULL,
   `restricted` tinyint(1) NOT NULL DEFAULT '0',
-  `title` varchar(255) NOT NULL,
-  `summary` text,
-  `notes` text,
+  `title` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `summary` text COLLATE utf8mb4_unicode_ci,
+  `notes` text COLLATE utf8mb4_unicode_ci,
   `word_count` int(11) DEFAULT NULL,
   `hidden_by_admin` tinyint(1) NOT NULL DEFAULT '0',
   `delta` tinyint(1) DEFAULT '0',
   `revised_at` datetime DEFAULT NULL,
-  `authors_to_sort_on` varchar(255) DEFAULT NULL,
-  `title_to_sort_on` varchar(255) DEFAULT NULL,
+  `title_to_sort_on` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `backdate` tinyint(1) NOT NULL DEFAULT '0',
-  `endnotes` text,
-  `imported_from_url` varchar(255) DEFAULT NULL,
+  `endnotes` text COLLATE utf8mb4_unicode_ci,
+  `imported_from_url` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `hit_count_old` int(11) NOT NULL DEFAULT '0',
-  `last_visitor_old` varchar(255) DEFAULT NULL,
+  `last_visitor_old` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `complete` tinyint(1) NOT NULL DEFAULT '0',
   `summary_sanitizer_version` smallint(6) NOT NULL DEFAULT '0',
   `notes_sanitizer_version` smallint(6) NOT NULL DEFAULT '0',
@@ -1393,7 +1712,7 @@ CREATE TABLE `works` (
   `in_anon_collection` tinyint(1) NOT NULL DEFAULT '0',
   `in_unrevealed_collection` tinyint(1) NOT NULL DEFAULT '0',
   `anon_commenting_disabled` tinyint(1) NOT NULL DEFAULT '0',
-  `ip_address` varchar(255) DEFAULT NULL,
+  `ip_address` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `spam` tinyint(1) NOT NULL DEFAULT '0',
   `spam_checked_at` datetime DEFAULT NULL,
   `moderated_commenting_enabled` tinyint(1) NOT NULL DEFAULT '0',
@@ -1406,8 +1725,11 @@ CREATE TABLE `works` (
   KEY `complete_works` (`complete`,`posted`,`hidden_by_admin`),
   KEY `index_works_on_ip_address` (`ip_address`),
   KEY `index_works_on_spam` (`spam`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
-
+) ENGINE=InnoDB AUTO_INCREMENT=21278410 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+/*!40101 SET character_set_client = @saved_cs_client */;
+DROP TABLE IF EXISTS `wrangling_assignments`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `wrangling_assignments` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `user_id` int(11) DEFAULT NULL,
@@ -1415,588 +1737,354 @@ CREATE TABLE `wrangling_assignments` (
   PRIMARY KEY (`id`),
   KEY `wrangling_assignments_by_fandom_id` (`fandom_id`),
   KEY `wrangling_assignments_by_user_id` (`user_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
-
+) ENGINE=InnoDB AUTO_INCREMENT=152491 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+/*!40101 SET character_set_client = @saved_cs_client */;
+DROP TABLE IF EXISTS `wrangling_guidelines`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `wrangling_guidelines` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `admin_id` int(11) DEFAULT NULL,
-  `title` varchar(255) DEFAULT NULL,
-  `content` text,
+  `title` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `content` text COLLATE utf8mb4_unicode_ci,
   `created_at` datetime DEFAULT NULL,
   `updated_at` datetime DEFAULT NULL,
   `position` int(11) DEFAULT NULL,
   `content_sanitizer_version` smallint(6) NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB AUTO_INCREMENT=18 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40103 SET TIME_ZONE=@OLD_TIME_ZONE */;
+
+/*!40101 SET SQL_MODE=@OLD_SQL_MODE */;
+/*!40014 SET FOREIGN_KEY_CHECKS=@OLD_FOREIGN_KEY_CHECKS */;
+/*!40014 SET UNIQUE_CHECKS=@OLD_UNIQUE_CHECKS */;
+/*!40101 SET CHARACTER_SET_CLIENT=@OLD_CHARACTER_SET_CLIENT */;
+/*!40101 SET CHARACTER_SET_RESULTS=@OLD_CHARACTER_SET_RESULTS */;
+/*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
+/*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
+
+INSERT INTO `schema_migrations` (version) VALUES
+('1'),
+('20080726215505'),
+('20080727030151'),
+('20080803045759'),
+('20080803124959'),
+('20080803125332'),
+('20080805021608'),
+('20080901172442'),
+('20080904135616'),
+('20080906193922'),
+('20080912233749'),
+('20080914202646'),
+('20080916213733'),
+('20080920020544'),
+('20080920052318'),
+('20080922015228'),
+('20080922060611'),
+('20080927172047'),
+('20080927172113'),
+('20080927191115'),
+('20080929233315'),
+('20080930163408'),
+('20081001035116'),
+('20081001160257'),
+('20081002011129'),
+('20081002011130'),
+('20081012185902'),
+('20081014183856'),
+('20081026180141'),
+('20081102050355'),
+('20081109004140'),
+('20081114043420'),
+('20081114164535'),
+('20081115041645'),
+('20081122025525'),
+('20090127012544'),
+('20090127045219'),
+('20090214045954'),
+('20090218223404'),
+('20090307152243'),
+('20090313212917'),
+('20090315182538'),
+('20090318004340'),
+('20090322182529'),
+('20090328235607'),
+('20090329002541'),
+('20090331012516'),
+('20090331205830'),
+('20090419175827'),
+('20090419184639'),
+('20090420003418'),
+('20090420032457'),
+('20090504020354'),
+('20090524195217'),
+('20090524201025'),
+('20090604221238'),
+('20090610010041'),
+('20090613092005'),
+('20090706214616'),
+('20090723205349'),
+('20090816092821'),
+('20090816092952'),
+('20090902191851'),
+('20090907021029'),
+('20090913221007'),
+('20090913234257'),
+('20090916140506'),
+('20090917004451'),
+('20090918112658'),
+('20090918212755'),
+('20090919125723'),
+('20090919161520'),
+('20090921210056'),
+('20090930033753'),
+('20091018155535'),
+('20091018161438'),
+('20091018174444'),
+('20091019013949'),
+('20091021225848'),
+('20091029224425'),
+('20091107214504'),
+('20091121200119'),
+('20091122210634'),
+('20091205204625'),
+('20091206140850'),
+('20091206150153'),
+('20091206172751'),
+('20091206180109'),
+('20091206180907'),
+('20091207234702'),
+('20091208200602'),
+('20091209202619'),
+('20091209215213'),
+('20091212035917'),
+('20091212051923'),
+('20091213013846'),
+('20091213035516'),
+('20091216001101'),
+('20091216150855'),
+('20091217004235'),
+('20091217005945'),
+('20091217162252'),
+('20091219192317'),
+('20091220182557'),
+('20091221011225'),
+('20091221145401'),
+('20091223002020'),
+('20091223003205'),
+('20091223180731'),
+('20091227192528'),
+('20091228042140'),
+('20100104041510'),
+('20100104144922'),
+('20100104232731'),
+('20100104232756'),
+('20100105043033'),
+('20100108002148'),
+('20100112034428'),
+('20100123004135'),
+('20100202154135'),
+('20100202154255'),
+('20100210180708'),
+('20100210214240'),
+('20100220022635'),
+('20100220031906'),
+('20100220062829'),
+('20100222011208'),
+('20100222074558'),
+('20100223204450'),
+('20100223205231'),
+('20100223212822'),
+('20100225063636'),
+('20100227013502'),
+('20100301211829'),
+('20100304193643'),
+('20100307211947'),
+('20100312165910'),
+('20100313165910'),
+('20100314021317'),
+('20100314035644'),
+('20100314044409'),
+('20100320165910'),
+('20100326170256'),
+('20100326170652'),
+('20100326170924'),
+('20100326171229'),
+('20100328215724'),
+('20100402163915'),
+('20100403191349'),
+('20100404223432'),
+('20100405191217'),
+('20100407222411'),
+('20100413231821'),
+('20100414231821'),
+('20100415231821'),
+('20100416145044'),
+('20100419131629'),
+('20100420211328'),
+('20100502024059'),
+('20100506203017'),
+('20100506231821'),
+('20100530152111'),
+('20100530161827'),
+('20100618021343'),
+('20100620185742'),
+('20100727212342'),
+('20100728220657'),
+('20100804185744'),
+('20100812175429'),
+('20100821165448'),
+('20100901154501'),
+('20100901165448'),
+('20100907015632'),
+('20100929044155'),
+('20101015053927'),
+('20101016131743'),
+('20101022002353'),
+('20101022160603'),
+('20101024232837'),
+('20101025022733'),
+('20101103185307'),
+('20101107005107'),
+('20101107212421'),
+('20101108003021'),
+('20101109204730'),
+('20101128051309'),
+('20101130074147'),
+('20101204042756'),
+('20101204061318'),
+('20101204062558'),
+('20101205015909'),
+('20101216165336'),
+('20101219191929'),
+('20101231171104'),
+('20101231174606'),
+('20110130093600'),
+('20110130093601'),
+('20110130093602'),
+('20110130093604'),
+('20110212162042'),
+('20110214171104'),
+('20110222093602'),
+('20110223031701'),
+('20110304042756'),
+('20110312174241'),
+('20110401185831'),
+('20110401201033'),
+('20110513145847'),
+('20110515182045'),
+('20110526203419'),
+('20110601200556'),
+('20110619091214'),
+('20110619091342'),
+('20110621015359'),
+('20110710033732'),
+('20110712003637'),
+('20110712140002'),
+('20110713013317'),
+('20110801134913'),
+('20110810012317'),
+('20110810150044'),
+('20110812012725'),
+('20110823015903'),
+('20110827153658'),
+('20110827185228'),
+('20110828172403'),
+('20110829125505'),
+('20110905184626'),
+('20110908191743'),
+('20111006032145'),
+('20111007235357'),
+('20111013010307'),
+('20111027173425'),
+('20111122225340'),
+('20111122225341'),
+('20111123011929'),
+('20111206225341'),
+('20120131225520'),
+('20120206034312'),
+('20120226024139'),
+('20120415134615'),
+('20120501210459'),
+('20120809161528'),
+('20120809164434'),
+('20120825165632'),
+('20120901113344'),
+('20120913222728'),
+('20120921094037'),
+('20121023221449'),
+('20121102002223'),
+('20121129192353'),
+('20121205215503'),
+('20121220012746'),
+('20130113003307'),
+('20130327164311'),
+('20130707160714'),
+('20130707160814'),
+('20140208200234'),
+('20140326130206'),
+('20140327111111'),
+('20140406043239'),
+('20140808220904'),
+('20140922024405'),
+('20140922025054'),
+('20140924023950'),
+('20141003204623'),
+('20141003205439'),
+('20141004123421'),
+('20141127004302'),
+('20150106211421'),
+('20150111203000'),
+('20150217034225'),
+('20150725141326'),
+('20150901024743'),
+('20150901132832'),
+('20151018165632'),
+('20151129234505'),
+('20151130183602'),
+('20160331005706'),
+('201604030319571'),
+('20160416163754'),
+('20160706031054'),
+('20160724234958'),
+('20160916172116'),
+('20160918223157'),
+('20170321202522'),
+('20170322092920'),
+('20170331170222'),
+('20170414154143'),
+('20170615090455'),
+('20170918172719'),
+('20170919143944'),
+('20171006090901'),
+('20171030201300'),
+('20171030220348'),
+('20171031204025'),
+('20171114212142'),
+('20180108220405'),
+('20180428201347'),
+('20180519055830'),
+('20180712000145'),
+('20180731034724'),
+('20180811160316'),
+('20180822202259'),
+('20180909203857'),
+('20180917212655'),
+('20181017032400'),
+('20181113063726'),
+('20181201022717'),
+('20181222022628'),
+('20181222042042'),
+('20181224173813'),
+('20190207034230'),
+('20190213230717'),
+('20190213231821'),
+('20190214054439'),
+('20190323185300'),
+('20190405191806'),
+('20190421213603'),
+('20190423215601'),
+('20190611212339');
 
-INSERT INTO schema_migrations (version) VALUES ('1');
 
-INSERT INTO schema_migrations (version) VALUES ('20080726215505');
-
-INSERT INTO schema_migrations (version) VALUES ('20080727030151');
-
-INSERT INTO schema_migrations (version) VALUES ('20080803045759');
-
-INSERT INTO schema_migrations (version) VALUES ('20080803124959');
-
-INSERT INTO schema_migrations (version) VALUES ('20080803125332');
-
-INSERT INTO schema_migrations (version) VALUES ('20080805021608');
-
-INSERT INTO schema_migrations (version) VALUES ('20080901172442');
-
-INSERT INTO schema_migrations (version) VALUES ('20080904135616');
-
-INSERT INTO schema_migrations (version) VALUES ('20080906193922');
-
-INSERT INTO schema_migrations (version) VALUES ('20080912233749');
-
-INSERT INTO schema_migrations (version) VALUES ('20080914202646');
-
-INSERT INTO schema_migrations (version) VALUES ('20080916213733');
-
-INSERT INTO schema_migrations (version) VALUES ('20080920020544');
-
-INSERT INTO schema_migrations (version) VALUES ('20080920052318');
-
-INSERT INTO schema_migrations (version) VALUES ('20080922015228');
-
-INSERT INTO schema_migrations (version) VALUES ('20080922060611');
-
-INSERT INTO schema_migrations (version) VALUES ('20080927172047');
-
-INSERT INTO schema_migrations (version) VALUES ('20080927172113');
-
-INSERT INTO schema_migrations (version) VALUES ('20080927191115');
-
-INSERT INTO schema_migrations (version) VALUES ('20080929233315');
-
-INSERT INTO schema_migrations (version) VALUES ('20080930163408');
-
-INSERT INTO schema_migrations (version) VALUES ('20081001035116');
-
-INSERT INTO schema_migrations (version) VALUES ('20081001160257');
-
-INSERT INTO schema_migrations (version) VALUES ('20081002011129');
-
-INSERT INTO schema_migrations (version) VALUES ('20081002011130');
-
-INSERT INTO schema_migrations (version) VALUES ('20081012185902');
-
-INSERT INTO schema_migrations (version) VALUES ('20081014183856');
-
-INSERT INTO schema_migrations (version) VALUES ('20081026180141');
-
-INSERT INTO schema_migrations (version) VALUES ('20081102050355');
-
-INSERT INTO schema_migrations (version) VALUES ('20081109004140');
-
-INSERT INTO schema_migrations (version) VALUES ('20081114043420');
-
-INSERT INTO schema_migrations (version) VALUES ('20081114164535');
-
-INSERT INTO schema_migrations (version) VALUES ('20081115041645');
-
-INSERT INTO schema_migrations (version) VALUES ('20081122025525');
-
-INSERT INTO schema_migrations (version) VALUES ('20090127012544');
-
-INSERT INTO schema_migrations (version) VALUES ('20090127045219');
-
-INSERT INTO schema_migrations (version) VALUES ('20090214045954');
-
-INSERT INTO schema_migrations (version) VALUES ('20090218223404');
-
-INSERT INTO schema_migrations (version) VALUES ('20090307152243');
-
-INSERT INTO schema_migrations (version) VALUES ('20090313212917');
-
-INSERT INTO schema_migrations (version) VALUES ('20090315182538');
-
-INSERT INTO schema_migrations (version) VALUES ('20090318004340');
-
-INSERT INTO schema_migrations (version) VALUES ('20090322182529');
-
-INSERT INTO schema_migrations (version) VALUES ('20090328235607');
-
-INSERT INTO schema_migrations (version) VALUES ('20090329002541');
-
-INSERT INTO schema_migrations (version) VALUES ('20090331012516');
-
-INSERT INTO schema_migrations (version) VALUES ('20090331205830');
-
-INSERT INTO schema_migrations (version) VALUES ('20090419175827');
-
-INSERT INTO schema_migrations (version) VALUES ('20090419184639');
-
-INSERT INTO schema_migrations (version) VALUES ('20090420003418');
-
-INSERT INTO schema_migrations (version) VALUES ('20090420032457');
-
-INSERT INTO schema_migrations (version) VALUES ('20090504020354');
-
-INSERT INTO schema_migrations (version) VALUES ('20090524195217');
-
-INSERT INTO schema_migrations (version) VALUES ('20090524201025');
-
-INSERT INTO schema_migrations (version) VALUES ('20090604221238');
-
-INSERT INTO schema_migrations (version) VALUES ('20090610010041');
-
-INSERT INTO schema_migrations (version) VALUES ('20090613092005');
-
-INSERT INTO schema_migrations (version) VALUES ('20090706214616');
-
-INSERT INTO schema_migrations (version) VALUES ('20090723205349');
-
-INSERT INTO schema_migrations (version) VALUES ('20090816092821');
-
-INSERT INTO schema_migrations (version) VALUES ('20090816092952');
-
-INSERT INTO schema_migrations (version) VALUES ('20090902191851');
-
-INSERT INTO schema_migrations (version) VALUES ('20090907021029');
-
-INSERT INTO schema_migrations (version) VALUES ('20090913221007');
-
-INSERT INTO schema_migrations (version) VALUES ('20090913234257');
-
-INSERT INTO schema_migrations (version) VALUES ('20090916140506');
-
-INSERT INTO schema_migrations (version) VALUES ('20090917004451');
-
-INSERT INTO schema_migrations (version) VALUES ('20090918112658');
-
-INSERT INTO schema_migrations (version) VALUES ('20090918212755');
-
-INSERT INTO schema_migrations (version) VALUES ('20090919125723');
-
-INSERT INTO schema_migrations (version) VALUES ('20090919161520');
-
-INSERT INTO schema_migrations (version) VALUES ('20090921210056');
-
-INSERT INTO schema_migrations (version) VALUES ('20090930033753');
-
-INSERT INTO schema_migrations (version) VALUES ('20091018155535');
-
-INSERT INTO schema_migrations (version) VALUES ('20091018161438');
-
-INSERT INTO schema_migrations (version) VALUES ('20091018174444');
-
-INSERT INTO schema_migrations (version) VALUES ('20091019013949');
-
-INSERT INTO schema_migrations (version) VALUES ('20091021225848');
-
-INSERT INTO schema_migrations (version) VALUES ('20091029224425');
-
-INSERT INTO schema_migrations (version) VALUES ('20091107214504');
-
-INSERT INTO schema_migrations (version) VALUES ('20091121200119');
-
-INSERT INTO schema_migrations (version) VALUES ('20091122210634');
-
-INSERT INTO schema_migrations (version) VALUES ('20091205204625');
-
-INSERT INTO schema_migrations (version) VALUES ('20091206140850');
-
-INSERT INTO schema_migrations (version) VALUES ('20091206150153');
-
-INSERT INTO schema_migrations (version) VALUES ('20091206172751');
-
-INSERT INTO schema_migrations (version) VALUES ('20091206180109');
-
-INSERT INTO schema_migrations (version) VALUES ('20091206180907');
-
-INSERT INTO schema_migrations (version) VALUES ('20091207234702');
-
-INSERT INTO schema_migrations (version) VALUES ('20091208200602');
-
-INSERT INTO schema_migrations (version) VALUES ('20091209202619');
-
-INSERT INTO schema_migrations (version) VALUES ('20091209215213');
-
-INSERT INTO schema_migrations (version) VALUES ('20091212035917');
-
-INSERT INTO schema_migrations (version) VALUES ('20091212051923');
-
-INSERT INTO schema_migrations (version) VALUES ('20091213013846');
-
-INSERT INTO schema_migrations (version) VALUES ('20091213035516');
-
-INSERT INTO schema_migrations (version) VALUES ('20091216001101');
-
-INSERT INTO schema_migrations (version) VALUES ('20091216150855');
-
-INSERT INTO schema_migrations (version) VALUES ('20091217004235');
-
-INSERT INTO schema_migrations (version) VALUES ('20091217005945');
-
-INSERT INTO schema_migrations (version) VALUES ('20091217162252');
-
-INSERT INTO schema_migrations (version) VALUES ('20091219192317');
-
-INSERT INTO schema_migrations (version) VALUES ('20091220182557');
-
-INSERT INTO schema_migrations (version) VALUES ('20091221011225');
-
-INSERT INTO schema_migrations (version) VALUES ('20091221145401');
-
-INSERT INTO schema_migrations (version) VALUES ('20091223002020');
-
-INSERT INTO schema_migrations (version) VALUES ('20091223003205');
-
-INSERT INTO schema_migrations (version) VALUES ('20091223180731');
-
-INSERT INTO schema_migrations (version) VALUES ('20091227192528');
-
-INSERT INTO schema_migrations (version) VALUES ('20091228042140');
-
-INSERT INTO schema_migrations (version) VALUES ('20100104041510');
-
-INSERT INTO schema_migrations (version) VALUES ('20100104144922');
-
-INSERT INTO schema_migrations (version) VALUES ('20100104232731');
-
-INSERT INTO schema_migrations (version) VALUES ('20100104232756');
-
-INSERT INTO schema_migrations (version) VALUES ('20100105043033');
-
-INSERT INTO schema_migrations (version) VALUES ('20100108002148');
-
-INSERT INTO schema_migrations (version) VALUES ('20100112034428');
-
-INSERT INTO schema_migrations (version) VALUES ('20100123004135');
-
-INSERT INTO schema_migrations (version) VALUES ('20100202154135');
-
-INSERT INTO schema_migrations (version) VALUES ('20100202154255');
-
-INSERT INTO schema_migrations (version) VALUES ('20100210180708');
-
-INSERT INTO schema_migrations (version) VALUES ('20100210214240');
-
-INSERT INTO schema_migrations (version) VALUES ('20100220022635');
-
-INSERT INTO schema_migrations (version) VALUES ('20100220031906');
-
-INSERT INTO schema_migrations (version) VALUES ('20100220062829');
-
-INSERT INTO schema_migrations (version) VALUES ('20100222011208');
-
-INSERT INTO schema_migrations (version) VALUES ('20100222074558');
-
-INSERT INTO schema_migrations (version) VALUES ('20100223204450');
-
-INSERT INTO schema_migrations (version) VALUES ('20100223205231');
-
-INSERT INTO schema_migrations (version) VALUES ('20100223212822');
-
-INSERT INTO schema_migrations (version) VALUES ('20100225063636');
-
-INSERT INTO schema_migrations (version) VALUES ('20100227013502');
-
-INSERT INTO schema_migrations (version) VALUES ('20100301211829');
-
-INSERT INTO schema_migrations (version) VALUES ('20100304193643');
-
-INSERT INTO schema_migrations (version) VALUES ('20100307211947');
-
-INSERT INTO schema_migrations (version) VALUES ('20100312165910');
-
-INSERT INTO schema_migrations (version) VALUES ('20100313165910');
-
-INSERT INTO schema_migrations (version) VALUES ('20100314021317');
-
-INSERT INTO schema_migrations (version) VALUES ('20100314035644');
-
-INSERT INTO schema_migrations (version) VALUES ('20100314044409');
-
-INSERT INTO schema_migrations (version) VALUES ('20100320165910');
-
-INSERT INTO schema_migrations (version) VALUES ('20100326170256');
-
-INSERT INTO schema_migrations (version) VALUES ('20100326170652');
-
-INSERT INTO schema_migrations (version) VALUES ('20100326170924');
-
-INSERT INTO schema_migrations (version) VALUES ('20100326171229');
-
-INSERT INTO schema_migrations (version) VALUES ('20100328215724');
-
-INSERT INTO schema_migrations (version) VALUES ('20100402163915');
-
-INSERT INTO schema_migrations (version) VALUES ('20100403191349');
-
-INSERT INTO schema_migrations (version) VALUES ('20100404223432');
-
-INSERT INTO schema_migrations (version) VALUES ('20100405191217');
-
-INSERT INTO schema_migrations (version) VALUES ('20100407222411');
-
-INSERT INTO schema_migrations (version) VALUES ('20100413231821');
-
-INSERT INTO schema_migrations (version) VALUES ('20100414231821');
-
-INSERT INTO schema_migrations (version) VALUES ('20100415231821');
-
-INSERT INTO schema_migrations (version) VALUES ('20100416145044');
-
-INSERT INTO schema_migrations (version) VALUES ('20100419131629');
-
-INSERT INTO schema_migrations (version) VALUES ('20100420211328');
-
-INSERT INTO schema_migrations (version) VALUES ('20100502024059');
-
-INSERT INTO schema_migrations (version) VALUES ('20100506203017');
-
-INSERT INTO schema_migrations (version) VALUES ('20100506231821');
-
-INSERT INTO schema_migrations (version) VALUES ('20100530152111');
-
-INSERT INTO schema_migrations (version) VALUES ('20100530161827');
-
-INSERT INTO schema_migrations (version) VALUES ('20100618021343');
-
-INSERT INTO schema_migrations (version) VALUES ('20100620185742');
-
-INSERT INTO schema_migrations (version) VALUES ('20100727212342');
-
-INSERT INTO schema_migrations (version) VALUES ('20100728220657');
-
-INSERT INTO schema_migrations (version) VALUES ('20100804185744');
-
-INSERT INTO schema_migrations (version) VALUES ('20100812175429');
-
-INSERT INTO schema_migrations (version) VALUES ('20100821165448');
-
-INSERT INTO schema_migrations (version) VALUES ('20100901154501');
-
-INSERT INTO schema_migrations (version) VALUES ('20100901165448');
-
-INSERT INTO schema_migrations (version) VALUES ('20100907015632');
-
-INSERT INTO schema_migrations (version) VALUES ('20100929044155');
-
-INSERT INTO schema_migrations (version) VALUES ('20101015053927');
-
-INSERT INTO schema_migrations (version) VALUES ('20101016131743');
-
-INSERT INTO schema_migrations (version) VALUES ('20101022002353');
-
-INSERT INTO schema_migrations (version) VALUES ('20101022160603');
-
-INSERT INTO schema_migrations (version) VALUES ('20101024232837');
-
-INSERT INTO schema_migrations (version) VALUES ('20101025022733');
-
-INSERT INTO schema_migrations (version) VALUES ('20101103185307');
-
-INSERT INTO schema_migrations (version) VALUES ('20101107005107');
-
-INSERT INTO schema_migrations (version) VALUES ('20101107212421');
-
-INSERT INTO schema_migrations (version) VALUES ('20101108003021');
-
-INSERT INTO schema_migrations (version) VALUES ('20101109204730');
-
-INSERT INTO schema_migrations (version) VALUES ('20101128051309');
-
-INSERT INTO schema_migrations (version) VALUES ('20101130074147');
-
-INSERT INTO schema_migrations (version) VALUES ('20101204042756');
-
-INSERT INTO schema_migrations (version) VALUES ('20101204061318');
-
-INSERT INTO schema_migrations (version) VALUES ('20101204062558');
-
-INSERT INTO schema_migrations (version) VALUES ('20101205015909');
-
-INSERT INTO schema_migrations (version) VALUES ('20101216165336');
-
-INSERT INTO schema_migrations (version) VALUES ('20101219191929');
-
-INSERT INTO schema_migrations (version) VALUES ('20101231171104');
-
-INSERT INTO schema_migrations (version) VALUES ('20101231174606');
-
-INSERT INTO schema_migrations (version) VALUES ('20110130093600');
-
-INSERT INTO schema_migrations (version) VALUES ('20110130093601');
-
-INSERT INTO schema_migrations (version) VALUES ('20110130093602');
-
-INSERT INTO schema_migrations (version) VALUES ('20110130093604');
-
-INSERT INTO schema_migrations (version) VALUES ('20110212162042');
-
-INSERT INTO schema_migrations (version) VALUES ('20110214171104');
-
-INSERT INTO schema_migrations (version) VALUES ('20110222093602');
-
-INSERT INTO schema_migrations (version) VALUES ('20110223031701');
-
-INSERT INTO schema_migrations (version) VALUES ('20110304042756');
-
-INSERT INTO schema_migrations (version) VALUES ('20110312174241');
-
-INSERT INTO schema_migrations (version) VALUES ('20110401185831');
-
-INSERT INTO schema_migrations (version) VALUES ('20110401201033');
-
-INSERT INTO schema_migrations (version) VALUES ('20110513145847');
-
-INSERT INTO schema_migrations (version) VALUES ('20110515182045');
-
-INSERT INTO schema_migrations (version) VALUES ('20110526203419');
-
-INSERT INTO schema_migrations (version) VALUES ('20110601200556');
-
-INSERT INTO schema_migrations (version) VALUES ('20110619091214');
-
-INSERT INTO schema_migrations (version) VALUES ('20110619091342');
-
-INSERT INTO schema_migrations (version) VALUES ('20110621015359');
-
-INSERT INTO schema_migrations (version) VALUES ('20110710033732');
-
-INSERT INTO schema_migrations (version) VALUES ('20110712003637');
-
-INSERT INTO schema_migrations (version) VALUES ('20110712140002');
-
-INSERT INTO schema_migrations (version) VALUES ('20110713013317');
-
-INSERT INTO schema_migrations (version) VALUES ('20110801134913');
-
-INSERT INTO schema_migrations (version) VALUES ('20110810012317');
-
-INSERT INTO schema_migrations (version) VALUES ('20110810150044');
-
-INSERT INTO schema_migrations (version) VALUES ('20110812012725');
-
-INSERT INTO schema_migrations (version) VALUES ('20110823015903');
-
-INSERT INTO schema_migrations (version) VALUES ('20110827153658');
-
-INSERT INTO schema_migrations (version) VALUES ('20110827185228');
-
-INSERT INTO schema_migrations (version) VALUES ('20110828172403');
-
-INSERT INTO schema_migrations (version) VALUES ('20110829125505');
-
-INSERT INTO schema_migrations (version) VALUES ('20110905184626');
-
-INSERT INTO schema_migrations (version) VALUES ('20110908191743');
-
-INSERT INTO schema_migrations (version) VALUES ('20111006032145');
-
-INSERT INTO schema_migrations (version) VALUES ('20111007235357');
-
-INSERT INTO schema_migrations (version) VALUES ('20111013010307');
-
-INSERT INTO schema_migrations (version) VALUES ('20111027173425');
-
-INSERT INTO schema_migrations (version) VALUES ('20111122225340');
-
-INSERT INTO schema_migrations (version) VALUES ('20111122225341');
-
-INSERT INTO schema_migrations (version) VALUES ('20111123011929');
-
-INSERT INTO schema_migrations (version) VALUES ('20111206225341');
-
-INSERT INTO schema_migrations (version) VALUES ('20120131225520');
-
-INSERT INTO schema_migrations (version) VALUES ('20120206034312');
-
-INSERT INTO schema_migrations (version) VALUES ('20120226024139');
-
-INSERT INTO schema_migrations (version) VALUES ('20120415134615');
-
-INSERT INTO schema_migrations (version) VALUES ('20120501210459');
-
-INSERT INTO schema_migrations (version) VALUES ('20120809161528');
-
-INSERT INTO schema_migrations (version) VALUES ('20120809164434');
-
-INSERT INTO schema_migrations (version) VALUES ('20120825165632');
-
-INSERT INTO schema_migrations (version) VALUES ('20120901113344');
-
-INSERT INTO schema_migrations (version) VALUES ('20120913222728');
-
-INSERT INTO schema_migrations (version) VALUES ('20120921094037');
-
-INSERT INTO schema_migrations (version) VALUES ('20121023221449');
-
-INSERT INTO schema_migrations (version) VALUES ('20121102002223');
-
-INSERT INTO schema_migrations (version) VALUES ('20121129192353');
-
-INSERT INTO schema_migrations (version) VALUES ('20121205215503');
-
-INSERT INTO schema_migrations (version) VALUES ('20121220012746');
-
-INSERT INTO schema_migrations (version) VALUES ('20130113003307');
-
-INSERT INTO schema_migrations (version) VALUES ('20130327164311');
-
-INSERT INTO schema_migrations (version) VALUES ('20130707160714');
-
-INSERT INTO schema_migrations (version) VALUES ('20130707160814');
-
-INSERT INTO schema_migrations (version) VALUES ('20140206031705');
-
-INSERT INTO schema_migrations (version) VALUES ('20140208200234');
-
-INSERT INTO schema_migrations (version) VALUES ('20140326130206');
-
-INSERT INTO schema_migrations (version) VALUES ('20140327111111');
-
-INSERT INTO schema_migrations (version) VALUES ('20140406043239');
-
-INSERT INTO schema_migrations (version) VALUES ('20140808220904');
-
-INSERT INTO schema_migrations (version) VALUES ('20140922024405');
-
-INSERT INTO schema_migrations (version) VALUES ('20140922025054');
-
-INSERT INTO schema_migrations (version) VALUES ('20140924023950');
-
-INSERT INTO schema_migrations (version) VALUES ('20141003204623');
-
-INSERT INTO schema_migrations (version) VALUES ('20141003205439');
-
-INSERT INTO schema_migrations (version) VALUES ('20141004123421');
-
-INSERT INTO schema_migrations (version) VALUES ('20141127004302');
-
-INSERT INTO schema_migrations (version) VALUES ('20150106211421');
-
-INSERT INTO schema_migrations (version) VALUES ('20150111203000');
-
-INSERT INTO schema_migrations (version) VALUES ('20150217034225');
-
-INSERT INTO schema_migrations (version) VALUES ('20150725141326');
-
-INSERT INTO schema_migrations (version) VALUES ('20150901024743');
-
-INSERT INTO schema_migrations (version) VALUES ('20150901132832');
-
-INSERT INTO schema_migrations (version) VALUES ('20151018165632');
-
-INSERT INTO schema_migrations (version) VALUES ('20151129234505');
-
-INSERT INTO schema_migrations (version) VALUES ('20151130183602');
-
-INSERT INTO schema_migrations (version) VALUES ('20160331005706');
-
-INSERT INTO schema_migrations (version) VALUES ('201604030319571');
-
-INSERT INTO schema_migrations (version) VALUES ('20160416163754');
-
-INSERT INTO schema_migrations (version) VALUES ('20160706031054');
-
-INSERT INTO schema_migrations (version) VALUES ('20160724234958');
-
-INSERT INTO schema_migrations (version) VALUES ('20160916172116');
-
-INSERT INTO schema_migrations (version) VALUES ('20160918223157');

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -26,7 +26,7 @@ CREATE TABLE `abuse_reports` (
   `language` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `username` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB AUTO_INCREMENT=771690 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `admin_activities`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
@@ -42,7 +42,7 @@ CREATE TABLE `admin_activities` (
   `created_at` datetime DEFAULT NULL,
   `updated_at` datetime DEFAULT NULL,
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB AUTO_INCREMENT=230752 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `admin_banners`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
@@ -54,7 +54,7 @@ CREATE TABLE `admin_banners` (
   `banner_type` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `active` tinyint(1) NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB AUTO_INCREMENT=273 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `admin_blacklisted_emails`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
@@ -66,7 +66,7 @@ CREATE TABLE `admin_blacklisted_emails` (
   `updated_at` datetime NOT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_admin_blacklisted_emails_on_email` (`email`)
-) ENGINE=InnoDB AUTO_INCREMENT=586 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `admin_post_taggings`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
@@ -79,7 +79,7 @@ CREATE TABLE `admin_post_taggings` (
   `updated_at` datetime DEFAULT NULL,
   PRIMARY KEY (`id`),
   KEY `index_admin_post_taggings_on_admin_post_id` (`admin_post_id`)
-) ENGINE=InnoDB AUTO_INCREMENT=30498 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `admin_post_tags`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
@@ -91,7 +91,7 @@ CREATE TABLE `admin_post_tags` (
   `created_at` datetime DEFAULT NULL,
   `updated_at` datetime DEFAULT NULL,
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB AUTO_INCREMENT=198 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `admin_posts`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
@@ -109,7 +109,7 @@ CREATE TABLE `admin_posts` (
   PRIMARY KEY (`id`),
   KEY `index_admin_posts_on_post_id` (`translated_post_id`),
   KEY `index_admin_posts_on_created_at` (`created_at`)
-) ENGINE=InnoDB AUTO_INCREMENT=14122 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `admin_settings`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
@@ -141,7 +141,7 @@ CREATE TABLE `admin_settings` (
   `disabled_support_form_text_sanitizer_version` smallint(6) NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`),
   KEY `index_admin_settings_on_last_updated_by` (`last_updated_by`)
-) ENGINE=InnoDB AUTO_INCREMENT=2 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `admins`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
@@ -155,7 +155,7 @@ CREATE TABLE `admins` (
   `encrypted_password` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `password_salt` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB AUTO_INCREMENT=614 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `api_keys`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
@@ -170,7 +170,7 @@ CREATE TABLE `api_keys` (
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_api_keys_on_name` (`name`),
   UNIQUE KEY `index_api_keys_on_access_token` (`access_token`)
-) ENGINE=InnoDB AUTO_INCREMENT=4 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `ar_internal_metadata`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
@@ -196,7 +196,7 @@ CREATE TABLE `archive_faq_translations` (
   PRIMARY KEY (`id`),
   KEY `index_archive_faq_translations_on_archive_faq_id` (`archive_faq_id`),
   KEY `index_archive_faq_translations_on_locale` (`locale`)
-) ENGINE=InnoDB AUTO_INCREMENT=2538 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `archive_faqs`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
@@ -212,7 +212,7 @@ CREATE TABLE `archive_faqs` (
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_archive_faqs_on_slug` (`slug`),
   KEY `index_archive_faqs_on_position` (`position`)
-) ENGINE=InnoDB AUTO_INCREMENT=105 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `audits`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
@@ -239,7 +239,7 @@ CREATE TABLE `audits` (
   KEY `user_index` (`user_id`,`user_type`),
   KEY `index_audits_on_created_at` (`created_at`),
   KEY `index_audits_on_request_uuid` (`request_uuid`)
-) ENGINE=InnoDB AUTO_INCREMENT=123338553 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `bookmarks`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
@@ -263,7 +263,7 @@ CREATE TABLE `bookmarks` (
   KEY `index_bookmarks_on_pseud_id` (`pseud_id`),
   KEY `index_bookmarkable_pseud` (`bookmarkable_id`,`bookmarkable_type`,`pseud_id`),
   KEY `index_bookmarks_on_private_and_hidden_by_admin_and_created_at` (`private`,`hidden_by_admin`,`created_at`)
-) ENGINE=InnoDB AUTO_INCREMENT=407812491 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `challenge_assignments`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
@@ -291,7 +291,7 @@ CREATE TABLE `challenge_assignments` (
   KEY `assignments_on_pinch_hitter_id` (`pinch_hitter_id`),
   KEY `assignments_on_defaulted_at` (`defaulted_at`),
   KEY `index_challenge_assignments_on_collection_id` (`collection_id`)
-) ENGINE=InnoDB AUTO_INCREMENT=2245158 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `challenge_claims`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
@@ -314,7 +314,7 @@ CREATE TABLE `challenge_claims` (
   KEY `index_challenge_claims_on_claiming_user_id` (`claiming_user_id`),
   KEY `index_challenge_claims_on_request_signup_id` (`request_signup_id`),
   KEY `index_challenge_claims_on_collection_id` (`collection_id`)
-) ENGINE=InnoDB AUTO_INCREMENT=55665 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `challenge_signups`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
@@ -330,7 +330,7 @@ CREATE TABLE `challenge_signups` (
   PRIMARY KEY (`id`),
   KEY `signups_on_pseud_id` (`pseud_id`),
   KEY `index_challenge_signups_on_collection_id` (`collection_id`)
-) ENGINE=InnoDB AUTO_INCREMENT=204405 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `chapters`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
@@ -357,7 +357,7 @@ CREATE TABLE `chapters` (
   PRIMARY KEY (`id`),
   KEY `works_chapter_index` (`work_id`),
   KEY `index_chapters_on_work_id` (`work_id`)
-) ENGINE=InnoDB AUTO_INCREMENT=50665233 DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `collection_items`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
@@ -379,7 +379,7 @@ CREATE TABLE `collection_items` (
   KEY `collection_items_unrevealed` (`unrevealed`),
   KEY `collection_items_anonymous` (`anonymous`),
   KEY `collection_items_item_id` (`item_id`)
-) ENGINE=InnoDB AUTO_INCREMENT=6757044 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `collection_participants`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
@@ -395,7 +395,7 @@ CREATE TABLE `collection_participants` (
   UNIQUE KEY `by collection and pseud` (`collection_id`,`pseud_id`),
   KEY `participants_by_collection_and_role` (`collection_id`,`participant_role`),
   KEY `participants_pseud_id` (`pseud_id`)
-) ENGINE=InnoDB AUTO_INCREMENT=449475 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `collection_preferences`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
@@ -415,7 +415,7 @@ CREATE TABLE `collection_preferences` (
   `email_notify` tinyint(1) NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`),
   KEY `index_collection_preferences_on_collection_id` (`collection_id`)
-) ENGINE=InnoDB AUTO_INCREMENT=235521 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `collection_profiles`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
@@ -435,7 +435,7 @@ CREATE TABLE `collection_profiles` (
   `assignment_notification` text COLLATE utf8mb4_unicode_ci,
   PRIMARY KEY (`id`),
   KEY `index_collection_profiles_on_collection_id` (`collection_id`)
-) ENGINE=InnoDB AUTO_INCREMENT=235525 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `collections`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
@@ -462,7 +462,7 @@ CREATE TABLE `collections` (
   PRIMARY KEY (`id`),
   KEY `index_collections_on_name` (`name`),
   KEY `index_collections_on_parent_id` (`parent_id`)
-) ENGINE=InnoDB AUTO_INCREMENT=235716 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `comments`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
@@ -497,7 +497,7 @@ CREATE TABLE `comments` (
   KEY `index_comments_parent` (`parent_id`,`parent_type`),
   KEY `comments_by_thread` (`thread`),
   KEY `index_comments_on_ip_address` (`ip_address`)
-) ENGINE=InnoDB AUTO_INCREMENT=260045305 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `common_taggings`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
@@ -512,7 +512,7 @@ CREATE TABLE `common_taggings` (
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_common_tags` (`common_tag_id`,`filterable_type`,`filterable_id`),
   KEY `index_common_taggings_on_filterable_id` (`filterable_id`)
-) ENGINE=InnoDB AUTO_INCREMENT=43064373 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `creatorships`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
@@ -528,7 +528,7 @@ CREATE TABLE `creatorships` (
   PRIMARY KEY (`id`),
   UNIQUE KEY `creation_id_creation_type_pseud_id` (`creation_id`,`creation_type`,`pseud_id`),
   KEY `index_creatorships_pseud` (`pseud_id`)
-) ENGINE=InnoDB AUTO_INCREMENT=77405046 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `delayed_jobs`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
@@ -563,7 +563,7 @@ CREATE TABLE `external_author_names` (
   `updated_at` datetime DEFAULT NULL,
   PRIMARY KEY (`id`),
   KEY `index_external_author_names_on_external_author_id` (`external_author_id`)
-) ENGINE=InnoDB AUTO_INCREMENT=83586 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `external_authors`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
@@ -580,7 +580,7 @@ CREATE TABLE `external_authors` (
   PRIMARY KEY (`id`),
   KEY `index_external_authors_on_user_id` (`user_id`),
   KEY `index_external_authors_on_email` (`email`)
-) ENGINE=InnoDB AUTO_INCREMENT=40096 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `external_creatorships`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
@@ -597,7 +597,7 @@ CREATE TABLE `external_creatorships` (
   KEY `index_external_creatorships_on_creation_id_and_creation_type` (`creation_id`,`creation_type`),
   KEY `index_external_creatorships_on_external_author_name_id` (`external_author_name_id`),
   KEY `index_external_creatorships_on_archivist_id` (`archivist_id`)
-) ENGINE=InnoDB AUTO_INCREMENT=214140 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `external_works`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
@@ -615,7 +615,7 @@ CREATE TABLE `external_works` (
   `summary_sanitizer_version` smallint(6) NOT NULL DEFAULT '0',
   `language_id` int(11) DEFAULT NULL,
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB AUTO_INCREMENT=531280 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `fannish_next_of_kins`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
@@ -627,7 +627,7 @@ CREATE TABLE `fannish_next_of_kins` (
   `kin_email` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   PRIMARY KEY (`id`),
   KEY `index_fannish_next_of_kins_on_user_id` (`user_id`)
-) ENGINE=InnoDB AUTO_INCREMENT=1023 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `favorite_tags`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
@@ -638,7 +638,7 @@ CREATE TABLE `favorite_tags` (
   `tag_id` int(11) DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_favorite_tags_on_user_id_and_tag_id` (`user_id`,`tag_id`)
-) ENGINE=InnoDB AUTO_INCREMENT=12377268 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `feedbacks`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
@@ -660,7 +660,7 @@ CREATE TABLE `feedbacks` (
   `language` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `rollout` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB AUTO_INCREMENT=228771 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `filter_counts`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
@@ -676,7 +676,7 @@ CREATE TABLE `filter_counts` (
   UNIQUE KEY `index_filter_counts_on_filter_id` (`filter_id`),
   KEY `index_unhidden_works_count` (`unhidden_works_count`),
   KEY `index_public_works_count` (`public_works_count`)
-) ENGINE=InnoDB AUTO_INCREMENT=2473120 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `filter_taggings`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
@@ -692,7 +692,7 @@ CREATE TABLE `filter_taggings` (
   PRIMARY KEY (`id`),
   KEY `index_filter_taggings_filterable` (`filterable_id`,`filterable_type`),
   KEY `index_filter_taggings_on_filter_id_and_filterable_type` (`filter_id`,`filterable_type`)
-) ENGINE=InnoDB AUTO_INCREMENT=488188270 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `gift_exchanges`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
@@ -729,7 +729,7 @@ CREATE TABLE `gift_exchanges` (
   `signup_instructions_offers_sanitizer_version` smallint(6) NOT NULL DEFAULT '0',
   `requests_summary_visible` tinyint(1) NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB AUTO_INCREMENT=7017 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `gifts`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
@@ -746,7 +746,7 @@ CREATE TABLE `gifts` (
   KEY `index_gifts_on_recipient_name` (`recipient_name`),
   KEY `index_gifts_on_work_id` (`work_id`),
   KEY `index_gifts_on_pseud_id` (`pseud_id`)
-) ENGINE=InnoDB AUTO_INCREMENT=1665787 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `inbox_comments`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
@@ -763,7 +763,7 @@ CREATE TABLE `inbox_comments` (
   KEY `index_inbox_comments_on_read_and_user_id` (`read`,`user_id`),
   KEY `index_inbox_comments_on_feedback_comment_id` (`feedback_comment_id`),
   KEY `index_inbox_comments_on_user_id` (`user_id`)
-) ENGINE=InnoDB AUTO_INCREMENT=247581756 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `innodb_monitor`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
@@ -795,7 +795,7 @@ CREATE TABLE `invitations` (
   KEY `index_invitations_on_external_author_id` (`external_author_id`),
   KEY `index_invitations_on_creator_id_and_creator_type` (`creator_id`,`creator_type`),
   KEY `index_invitations_on_token` (`token`)
-) ENGINE=InnoDB AUTO_INCREMENT=32609151 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `invite_requests`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
@@ -811,7 +811,7 @@ CREATE TABLE `invite_requests` (
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_invite_requests_on_simplified_email` (`simplified_email`),
   KEY `index_invite_requests_on_email` (`email`)
-) ENGINE=InnoDB AUTO_INCREMENT=8654665 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `known_issues`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
@@ -825,7 +825,7 @@ CREATE TABLE `known_issues` (
   `created_at` datetime DEFAULT NULL,
   `content_sanitizer_version` smallint(6) NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB AUTO_INCREMENT=2 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `kudos`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
@@ -842,7 +842,7 @@ CREATE TABLE `kudos` (
   KEY `index_kudos_on_pseud_id` (`pseud_id`),
   KEY `index_kudos_on_ip_address` (`ip_address`),
   KEY `index_kudos_on_commentable_id_and_commentable_type_and_pseud_id` (`commentable_id`,`commentable_type`,`pseud_id`)
-) ENGINE=InnoDB AUTO_INCREMENT=1792468252 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `languages`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
@@ -857,7 +857,7 @@ CREATE TABLE `languages` (
   PRIMARY KEY (`id`),
   KEY `index_languages_on_short` (`short`),
   KEY `index_languages_on_sortable_name` (`sortable_name`)
-) ENGINE=InnoDB AUTO_INCREMENT=107 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `locales`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
@@ -876,7 +876,7 @@ CREATE TABLE `locales` (
   KEY `index_locales_on_iso` (`iso`),
   KEY `index_locales_on_short` (`short`),
   KEY `index_locales_on_language_id` (`language_id`)
-) ENGINE=InnoDB AUTO_INCREMENT=119 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `log_items`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
@@ -896,7 +896,7 @@ CREATE TABLE `log_items` (
   KEY `index_log_items_on_user_id` (`user_id`),
   KEY `index_log_items_on_admin_id` (`admin_id`),
   KEY `index_log_items_on_role_id` (`role_id`)
-) ENGINE=InnoDB AUTO_INCREMENT=14055339 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `meta_taggings`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
@@ -911,7 +911,7 @@ CREATE TABLE `meta_taggings` (
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_meta_taggings_on_meta_tag_id_and_sub_tag_id` (`meta_tag_id`,`sub_tag_id`),
   KEY `index_meta_taggings_on_sub_tag_id` (`sub_tag_id`)
-) ENGINE=InnoDB AUTO_INCREMENT=792340 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `moderated_works`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
@@ -925,7 +925,7 @@ CREATE TABLE `moderated_works` (
   `updated_at` datetime NOT NULL,
   PRIMARY KEY (`id`),
   KEY `index_moderated_works_on_work_id` (`work_id`)
-) ENGINE=InnoDB AUTO_INCREMENT=169876 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `open_id_authentication_associations`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
@@ -939,7 +939,7 @@ CREATE TABLE `open_id_authentication_associations` (
   `server_url` blob,
   `secret` blob,
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB AUTO_INCREMENT=232 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `open_id_authentication_nonces`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
@@ -950,7 +950,7 @@ CREATE TABLE `open_id_authentication_nonces` (
   `server_url` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `salt` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB AUTO_INCREMENT=3953 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `owned_set_taggings`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
@@ -963,7 +963,7 @@ CREATE TABLE `owned_set_taggings` (
   `created_at` datetime DEFAULT NULL,
   `updated_at` datetime DEFAULT NULL,
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB AUTO_INCREMENT=40333 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `owned_tag_sets`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
@@ -985,7 +985,7 @@ CREATE TABLE `owned_tag_sets` (
   `freeform_nomination_limit` int(11) NOT NULL DEFAULT '0',
   `usable` tinyint(1) NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB AUTO_INCREMENT=3589 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `potential_match_settings`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
@@ -1010,7 +1010,7 @@ CREATE TABLE `potential_match_settings` (
   `created_at` datetime DEFAULT NULL,
   `updated_at` datetime DEFAULT NULL,
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB AUTO_INCREMENT=7023 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `potential_matches`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
@@ -1029,7 +1029,7 @@ CREATE TABLE `potential_matches` (
   KEY `index_potential_matches_on_collection_id` (`collection_id`),
   KEY `index_potential_matches_on_offer_signup_id` (`offer_signup_id`),
   KEY `index_potential_matches_on_request_signup_id` (`request_signup_id`)
-) ENGINE=InnoDB AUTO_INCREMENT=25269903 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `preferences`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
@@ -1072,7 +1072,7 @@ CREATE TABLE `preferences` (
   PRIMARY KEY (`id`),
   KEY `index_preferences_on_user_id` (`user_id`),
   KEY `index_preferences_on_skin_id` (`skin_id`)
-) ENGINE=InnoDB AUTO_INCREMENT=6265057 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `profiles`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
@@ -1089,7 +1089,7 @@ CREATE TABLE `profiles` (
   `about_me_sanitizer_version` smallint(6) NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`),
   KEY `index_profiles_on_user_id` (`user_id`)
-) ENGINE=InnoDB AUTO_INCREMENT=6264852 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `prompt_memes`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
@@ -1117,7 +1117,7 @@ CREATE TABLE `prompt_memes` (
   `updated_at` datetime DEFAULT NULL,
   `anonymous` tinyint(1) NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB AUTO_INCREMENT=6471 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `prompt_restrictions`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
@@ -1167,7 +1167,7 @@ CREATE TABLE `prompt_restrictions` (
   `title_required` tinyint(1) NOT NULL DEFAULT '0',
   `title_allowed` tinyint(1) NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB AUTO_INCREMENT=20691 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `prompts`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
@@ -1201,7 +1201,7 @@ CREATE TABLE `prompts` (
   KEY `index_prompts_on_collection_id` (`collection_id`),
   KEY `index_prompts_on_optional_tag_set_id` (`optional_tag_set_id`),
   KEY `index_prompts_on_challenge_signup_id` (`challenge_signup_id`)
-) ENGINE=InnoDB AUTO_INCREMENT=1429782 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `pseuds`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
@@ -1225,7 +1225,7 @@ CREATE TABLE `pseuds` (
   PRIMARY KEY (`id`),
   KEY `index_pseuds_on_user_id_and_name` (`user_id`,`name`),
   KEY `index_psueds_on_name` (`name`)
-) ENGINE=InnoDB AUTO_INCREMENT=6702403 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `question_translations`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
@@ -1244,7 +1244,7 @@ CREATE TABLE `question_translations` (
   PRIMARY KEY (`id`),
   KEY `index_question_translations_on_question_id` (`question_id`),
   KEY `index_question_translations_on_locale` (`locale`)
-) ENGINE=InnoDB AUTO_INCREMENT=38935 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `questions`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
@@ -1261,7 +1261,7 @@ CREATE TABLE `questions` (
   `position` int(11) DEFAULT '1',
   PRIMARY KEY (`id`),
   KEY `index_questions_on_archive_faq_id_and_position` (`archive_faq_id`,`position`)
-) ENGINE=InnoDB AUTO_INCREMENT=1932 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `readings`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
@@ -1280,7 +1280,7 @@ CREATE TABLE `readings` (
   PRIMARY KEY (`id`),
   KEY `index_readings_on_work_id` (`work_id`),
   KEY `index_readings_on_user_id` (`user_id`)
-) ENGINE=InnoDB AUTO_INCREMENT=5582675520 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `related_works`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
@@ -1297,7 +1297,7 @@ CREATE TABLE `related_works` (
   PRIMARY KEY (`id`),
   KEY `index_related_works_on_parent_id_and_parent_type` (`parent_id`,`parent_type`),
   KEY `index_related_works_on_work_id` (`work_id`)
-) ENGINE=InnoDB AUTO_INCREMENT=470719 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `roles`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
@@ -1313,7 +1313,7 @@ CREATE TABLE `roles` (
   KEY `index_roles_on_authorizable_id_and_authorizable_type` (`authorizable_id`,`authorizable_type`),
   KEY `index_roles_on_authorizable_type` (`authorizable_type`),
   KEY `index_roles_on_name` (`name`)
-) ENGINE=InnoDB AUTO_INCREMENT=7 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `roles_users`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
@@ -1362,7 +1362,7 @@ CREATE TABLE `serial_works` (
   PRIMARY KEY (`id`),
   KEY `index_serial_works_on_work_id` (`work_id`),
   KEY `index_serial_works_on_series_id` (`series_id`)
-) ENGINE=InnoDB AUTO_INCREMENT=4888665 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `series`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
@@ -1380,7 +1380,7 @@ CREATE TABLE `series` (
   `summary_sanitizer_version` smallint(6) NOT NULL DEFAULT '0',
   `series_notes_sanitizer_version` smallint(6) NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB AUTO_INCREMENT=1533895 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `set_taggings`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
@@ -1394,7 +1394,7 @@ CREATE TABLE `set_taggings` (
   PRIMARY KEY (`id`),
   KEY `index_set_taggings_on_tag_id` (`tag_id`),
   KEY `index_set_taggings_on_tag_set_id` (`tag_set_id`)
-) ENGINE=InnoDB AUTO_INCREMENT=12441852 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `skin_parents`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
@@ -1407,7 +1407,7 @@ CREATE TABLE `skin_parents` (
   `created_at` datetime DEFAULT NULL,
   `updated_at` datetime DEFAULT NULL,
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB AUTO_INCREMENT=63460 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `skins`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
@@ -1455,7 +1455,7 @@ CREATE TABLE `skins` (
   KEY `index_skins_on_author_id` (`author_id`),
   KEY `index_skins_on_in_chooser` (`in_chooser`),
   KEY `index_skins_on_title` (`title`)
-) ENGINE=InnoDB AUTO_INCREMENT=260944 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `stat_counters`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
@@ -1472,7 +1472,7 @@ CREATE TABLE `stat_counters` (
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_hit_counters_on_work_id` (`work_id`),
   KEY `index_hit_counters_on_hit_count` (`hit_count`)
-) ENGINE=InnoDB AUTO_INCREMENT=20631568 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `subscriptions`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
@@ -1487,7 +1487,7 @@ CREATE TABLE `subscriptions` (
   PRIMARY KEY (`id`),
   KEY `user_id` (`user_id`),
   KEY `subscribable` (`subscribable_id`,`subscribable_type`)
-) ENGINE=InnoDB AUTO_INCREMENT=276125836 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `tag_nominations`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
@@ -1513,7 +1513,7 @@ CREATE TABLE `tag_nominations` (
   KEY `index_tag_nominations_on_type_and_fandom_nomination_id` (`type`,`fandom_nomination_id`),
   KEY `index_tag_nominations_on_type_and_synonym` (`type`,`synonym`),
   KEY `index_tag_nominations_on_type_and_tagname` (`type`,`tagname`)
-) ENGINE=InnoDB AUTO_INCREMENT=2377353 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `tag_set_associations`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
@@ -1526,7 +1526,7 @@ CREATE TABLE `tag_set_associations` (
   `created_at` datetime DEFAULT NULL,
   `updated_at` datetime DEFAULT NULL,
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB AUTO_INCREMENT=1091112 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `tag_set_nominations`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
@@ -1538,7 +1538,7 @@ CREATE TABLE `tag_set_nominations` (
   `created_at` datetime DEFAULT NULL,
   `updated_at` datetime DEFAULT NULL,
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB AUTO_INCREMENT=132648 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `tag_set_ownerships`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
@@ -1551,7 +1551,7 @@ CREATE TABLE `tag_set_ownerships` (
   `created_at` datetime DEFAULT NULL,
   `updated_at` datetime DEFAULT NULL,
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB AUTO_INCREMENT=6496 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `tag_sets`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
@@ -1561,7 +1561,7 @@ CREATE TABLE `tag_sets` (
   `created_at` datetime DEFAULT NULL,
   `updated_at` datetime DEFAULT NULL,
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB AUTO_INCREMENT=2705380 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `taggings`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
@@ -1577,7 +1577,7 @@ CREATE TABLE `taggings` (
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_taggings_polymorphic` (`tagger_id`,`tagger_type`,`taggable_id`,`taggable_type`),
   KEY `index_taggings_taggable` (`taggable_id`,`taggable_type`)
-) ENGINE=InnoDB AUTO_INCREMENT=413111889 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `tags`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
@@ -1606,7 +1606,7 @@ CREATE TABLE `tags` (
   KEY `index_tags_on_type` (`type`),
   KEY `index_tags_on_sortable_name` (`sortable_name`),
   KEY `index_tags_on_taggings_count_cache` (`taggings_count_cache`)
-) ENGINE=InnoDB AUTO_INCREMENT=36280167 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `user_invite_requests`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
@@ -1622,7 +1622,7 @@ CREATE TABLE `user_invite_requests` (
   `updated_at` datetime DEFAULT NULL,
   PRIMARY KEY (`id`),
   KEY `index_user_invite_requests_on_user_id` (`user_id`)
-) ENGINE=InnoDB AUTO_INCREMENT=78256 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `users`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
@@ -1662,7 +1662,7 @@ CREATE TABLE `users` (
   UNIQUE KEY `index_users_on_unlock_token` (`unlock_token`),
   UNIQUE KEY `index_users_on_confirmation_token` (`confirmation_token`),
   UNIQUE KEY `index_users_on_email` (`email`)
-) ENGINE=InnoDB AUTO_INCREMENT=6267541 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `work_links`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
@@ -1725,7 +1725,7 @@ CREATE TABLE `works` (
   KEY `complete_works` (`complete`,`posted`,`hidden_by_admin`),
   KEY `index_works_on_ip_address` (`ip_address`),
   KEY `index_works_on_spam` (`spam`)
-) ENGINE=InnoDB AUTO_INCREMENT=21278410 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `wrangling_assignments`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
@@ -1737,7 +1737,7 @@ CREATE TABLE `wrangling_assignments` (
   PRIMARY KEY (`id`),
   KEY `wrangling_assignments_by_fandom_id` (`fandom_id`),
   KEY `wrangling_assignments_by_user_id` (`user_id`)
-) ENGINE=InnoDB AUTO_INCREMENT=152491 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `wrangling_guidelines`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
@@ -1752,7 +1752,7 @@ CREATE TABLE `wrangling_guidelines` (
   `position` int(11) DEFAULT NULL,
   `content_sanitizer_version` smallint(6) NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB AUTO_INCREMENT=18 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40103 SET TIME_ZONE=@OLD_TIME_ZONE */;
 


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5194

## Purpose

Generate new versions of schema dumps from production:
```sh
bundle exec rake db:schema:dump    # Ruby dump
bundle exec rake db:structure:dump # SQL dump
```
Manually edit the resulting files:
- Ruby dump: Change the version in `ActiveRecord::Schema.define` to the latest migration timestamp. Then we need to check the existing pull requests for migrations and [bump their timestamps to later](https://stackoverflow.com/a/4047884).
- SQL dump: Remove [AUTO_INCREMENT values](https://stackoverflow.com/questions/2210719/out-of-sync-auto-increment-values-in-development-structure-sql-from-rails-mysql).

Replaces #3643.

## Testing Instructions

Travis build should pass.