### PR TITLE
AO3-5693 Remove invalid closing tags on track and source elements

### DIFF
--- a/lib/html_cleaner.rb
+++ b/lib/html_cleaner.rb
@@ -176,7 +176,7 @@ module HtmlCleaner
       # Hack! the herald angels sing
       # TODO: AO3-5801 Switch to an HTML5 serializer that doesn't add invalid closing tags
       # to track and source elements.
-      unfrozen_value.gsub!(/<\/(source|track)>/, "")
+      unfrozen_value.gsub!(%r{</(source|track)>}, "")
     else
       # clean out all tags
       unfrozen_value = Sanitize.clean(fix_bad_characters(unfrozen_value))

--- a/lib/html_cleaner.rb
+++ b/lib/html_cleaner.rb
@@ -172,6 +172,11 @@ module HtmlCleaner
       doc = Nokogiri::HTML::Document.new
       doc.encoding = "UTF-8"
       unfrozen_value = doc.fragment(unfrozen_value).to_xhtml
+
+      # Hack! the herald angels sing
+      # TODO: AO3-5801 Switch to an HTML5 serializer that doesn't add invalid closing tags
+      # to track and source elements.
+      unfrozen_value.gsub!(/<\/(source|track)>/, "")
     else
       # clean out all tags
       unfrozen_value = Sanitize.clean(fix_bad_characters(unfrozen_value))

--- a/spec/miscellaneous/lib/html_cleaner_spec.rb
+++ b/spec/miscellaneous/lib/html_cleaner_spec.rb
@@ -185,18 +185,18 @@ describe HtmlCleaner do
         end
 
         it "allows video tags" do
-          html = '''<video controls="controls" width="250" playsinline="playsinline" crossorigin="anonymous" preload="metadata">
-              <track kind="subtitles" src="http://example.com/english.vtt" srclang="en">
-              <track kind="subtitles" src="http://example.com/japanese.vtt" srclang="ja" default="default">
-            </video>'''
+          html = '<video controls="controls" width="250" playsinline="playsinline" crossorigin="anonymous" preload="metadata">\
+              <track kind="subtitles" src="http://example.com/english.vtt" srclang="en">\
+              <track kind="subtitles" src="http://example.com/japanese.vtt" srclang="ja" default="default">\
+            </video>'
           expect(sanitize_value(field, html)).to eq(html)
         end
 
         it "allows audio tags" do
-          html = '''<audio controls="controls" crossorigin="anonymous" preload="metadata" loop="loop">
-              <source src="http://example.com/podfic.mp3" type="audio/mpeg">
-              <p>Maybe you want to <a href="http://example.com/podfic.mp3" rel="nofollow">download this podfic instead</a>?</p>
-            </audio>'''
+          html = '<audio controls="controls" crossorigin="anonymous" preload="metadata" loop="loop">\
+              <source src="http://example.com/podfic.mp3" type="audio/mpeg">\
+              <p>Maybe you want to <a href="http://example.com/podfic.mp3" rel="nofollow">download this podfic instead</a>?</p>\
+            </audio>'
           expect(sanitize_value(field, html)).to eq(html)
         end
       end

--- a/spec/miscellaneous/lib/html_cleaner_spec.rb
+++ b/spec/miscellaneous/lib/html_cleaner_spec.rb
@@ -185,15 +185,19 @@ describe HtmlCleaner do
         end
 
         it "allows video tags" do
-          html = "<video></video>"
-          result = sanitize_value(field, html)
-          expect(result).to match('video')
+          html = '''<video controls="controls" width="250" playsinline="playsinline" crossorigin="anonymous" preload="metadata">
+              <track kind="subtitles" src="http://example.com/english.vtt" srclang="en">
+              <track kind="subtitles" src="http://example.com/japanese.vtt" srclang="ja" default="default">
+            </video>'''
+          expect(sanitize_value(field, html)).to eq(html)
         end
 
         it "allows audio tags" do
-          html = "<audio></audio>"
-          result = sanitize_value(field, html)
-          expect(result).to match('audio')
+          html = '''<audio controls="controls" crossorigin="anonymous" preload="metadata" loop="loop">
+              <source src="http://example.com/podfic.mp3" type="audio/mpeg">
+              <p>Maybe you want to <a href="http://example.com/podfic.mp3" rel="nofollow">download this podfic instead</a>?</p>
+            </audio>'''
+          expect(sanitize_value(field, html)).to eq(html)
         end
       end
     end
@@ -583,15 +587,14 @@ describe HtmlCleaner do
     end
 
     it "leaves audio tags alone" do
-      original = "<audio controls=\"controls\" crossorigin=\"anonymous\" preload=\"metadata\">
-  <source src=\"http://example.com/podfic.mp3\" type=\"audio/mpeg\"></source>
-  <p>Maybe you want to <a href=\"http://example.com/podfic.mp3\" rel=\"nofollow\">download this podfic instead</a>?</p>
-</audio>"
-      expect(sanitize_value(:content, original)).to eq(original)
+      html = "<audio><source>\n</audio>"
+      result = add_paragraphs_to_text(html)
+      expect(result).not_to match("<p>")
+      expect(result).not_to match("<br")
     end
 
     it "leaves video tags alone" do
-      html = "<video><track>\n</track></video>"
+      html = "<video><track>\n</video>"
       result = add_paragraphs_to_text(html)
       expect(result).not_to match("<p>")
       expect(result).not_to match("<br")


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5693

## Purpose

This is a hack until we switch to an HTML5 serializer.

## Testing Instructions

See issue.