### PR TITLE
AO3-5821 Make Statistics bar chart Y-axis start at 0

### DIFF
--- a/app/controllers/stats_controller.rb
+++ b/app/controllers/stats_controller.rb
@@ -101,7 +101,7 @@ class StatsController < ApplicationController
      chm: "N,000000,0,-1,11"
     })
 
-    @chart = GoogleVisualr::Interactive::ColumnChart.new(@chart_data, title: chart_title)
+    @chart = GoogleVisualr::Interactive::ColumnChart.new(@chart_data, vAxis: { minValue: 0 }, title: chart_title)
 
   end
 


### PR DESCRIPTION
## Issue:

https://otwarchive.atlassian.net/browse/AO3-5821

## Purpose:

This commit forces the Y-axis of the barchart on the user stats page
to start at 0. Previously, the Y-axis would start at a
dynamically-calculated value based on the data in the chart.
This meant that the bars did not work as a visual
representation of the data, because a bar half the size of another
bar did not depict a value half the size of another value.

(eg: if bars depicted hitcount, and the Y-axis started at 50,
a fic with 100 hits would have a bar double the size
of a fic with 75 hits.)

This patch forces the Y-axis to start at 0, by setting the
Google Chart API `vAxis: {Minvalue}` parameter to 0.

## Testing Instructions:

* Without this patch applied, login to an account with
  at least 5 works with significant traffic, and browse to:

  http://127.0.0.1:7000/users/$username/stats

*  Sort by a metric that has a significant value,
   where the top 5 works are relatively close in value -
   word count is the most controllable

The Y-axis will start at the wrong value. Apply this patch,
and repeat. Now it will start from 0!

## Credit

Name: Z
Pronouns: She/her or they/them.
