### PR TITLE
AO3-5749 Fix Elasticsearch 6.8.5 on Codeship

### DIFF
--- a/script/codeship/setup.sh
+++ b/script/codeship/setup.sh
@@ -13,7 +13,20 @@ bundle install
 # https://documentation.codeship.com/basic/services/elasticsearch/
 export ELASTICSEARCH_VERSION=6.8.5
 export ELASTICSEARCH_PORT=9400
-\curl -sSL https://raw.githubusercontent.com/codeship/scripts/master/packages/elasticsearch.sh | bash -s
+# \curl -sSL https://raw.githubusercontent.com/codeship/scripts/master/packages/elasticsearch.sh | bash -s
+
+# The codeship/scripts script doesn't support 6.8.5 archives, which nest
+# everything in an extra directory, so we'll do things ourselves.
+# We can switch back to codeship/scripts for 7.x.x.
+ELASTICSEARCH_DIR="$HOME/el"
+ELASTICSEARCH_DL_URL="https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-${ELASTICSEARCH_VERSION}.tar.gz"
+CACHED_DOWNLOAD="${HOME}/cache/elasticsearch-${ELASTICSEARCH_VERSION}.tar.gz"
+mkdir -p "${ELASTICSEARCH_DIR}"
+wget --continue --output-document "${CACHED_DOWNLOAD}" "${ELASTICSEARCH_DL_URL}"
+tar -xaf "${CACHED_DOWNLOAD}" --strip-components=2 --directory "${ELASTICSEARCH_DIR}"
+echo "http.port: ${ELASTICSEARCH_PORT}" >> ${ELASTICSEARCH_DIR}/config/elasticsearch.yml
+bash -c "${ELASTICSEARCH_DIR}/bin/elasticsearch 2>&1 >/dev/null" >/dev/null & disown
+wget --retry-connrefused --tries=0 --waitretry=1 -O- -nv http://localhost:${ELASTICSEARCH_PORT}
 
 # Downloads
 bash script/codeship/ebook_converters.sh


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5749

## Purpose

Change --strip-components=1 to --strip-components=2 in tar.

## Testing Instructions

Codeship should pass.

## References

https://github.com/elastic/elasticsearch/issues/49417