### PR TITLE
AO3-5826 Update nokogiri to 1.10.5

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -261,7 +261,7 @@ GEM
     netrc (0.11.0)
     newrelic_rpm (6.4.0.356)
     nio4r (2.3.1)
-    nokogiri (1.10.4)
+    nokogiri (1.10.5)
       mini_portile2 (~> 2.4.0)
     nokogumbo (1.4.9)
       nokogiri

--- a/lib/html_cleaner.rb
+++ b/lib/html_cleaner.rb
@@ -354,15 +354,8 @@ module HtmlCleaner
   end
 
   def add_paragraphs_to_text(text)
-    # By default, Nokogiri closes unclosed tags very late, often at
-    # the end of the document. We want runaway tags closed at the end
-    # of the line
     doc = Nokogiri::XML.parse("<myroot>#{text}</myroot>")
     doc.errors.each do |error|
-      match = error.message.match(/Premature end of data in tag (\w+) line (\d+)/)
-
-      text = close_unclosed_tag(text, match[1], match[2]) if match
-
       match = error.message.match(/Opening and ending tag mismatch: (\w+) line (\d+) and myroot/)
       text = close_unclosed_tag(text, match[1], match[2]) if match
     end

--- a/spec/miscellaneous/lib/html_cleaner_spec.rb
+++ b/spec/miscellaneous/lib/html_cleaner_spec.rb
@@ -845,7 +845,15 @@ describe HtmlCleaner do
       expect(doc.xpath("./p[contains(@class, 'bar')]").children.to_s.strip).to eq("foobar")
     end
 
-    it "should reopen unclosed inline tags in the next paragraph" do
+    # When we call add_paragraphs_to_text, everything gets wrapped inside myroot
+    # tags, and the closing myroot tag is treated as a mismatch for strong, ergo
+    # strong is closed on the second paragraph while the em tag remains open.
+    # In real world use, however, this content would most likely be run through
+    # Sanitize.clean first, which would close both the em and strong tags at the
+    # very end, so we wouldn't have a mismatch and the strong tag would be
+    # reopened in every paragraph, just like the em tag is. More info at:
+    # https://github.com/otwcode/otwarchive/pull/3692#issuecomment-558740913
+    it "should close mismatched tags" do
       html = """Here is an unclosed <em>em tag.
 
       Here is an unclosed <strong>strong tag.
@@ -855,10 +863,10 @@ describe HtmlCleaner do
       doc = Nokogiri::HTML.fragment(add_paragraphs_to_text(html))
       expect(doc.xpath("./p[1]/em").children.to_s.strip).to eq("em tag.")
       expect(doc.xpath("./p[2]/em/strong").children.to_s.strip).to eq("strong tag.")
-      expect(doc.xpath("./p[3]").children.to_s.strip).to eq("Stuff.")
+      expect(doc.xpath("./p[3]/em").children.to_s.strip).to eq("Stuff.")
     end
 
-    it "should close unclosed tag withing other tag" do
+    it "should close unclosed tag within other tag" do
       pending "Opened bug report with Nokogiri"
       html = "<strong><em>unclosed</strong>"
       doc = Nokogiri::HTML.fragment(add_paragraphs_to_text(html))

--- a/spec/miscellaneous/lib/html_cleaner_spec.rb
+++ b/spec/miscellaneous/lib/html_cleaner_spec.rb
@@ -855,7 +855,7 @@ describe HtmlCleaner do
       doc = Nokogiri::HTML.fragment(add_paragraphs_to_text(html))
       expect(doc.xpath("./p[1]/em").children.to_s.strip).to eq("em tag.")
       expect(doc.xpath("./p[2]/em/strong").children.to_s.strip).to eq("strong tag.")
-      expect(doc.xpath("./p[3]/em").children.to_s.strip).to eq("Stuff.")
+      expect(doc.xpath("./p[3]/em/strong").children.to_s.strip).to eq("Stuff.")
     end
 
     it "should close unclosed tag withing other tag" do

--- a/spec/miscellaneous/lib/html_cleaner_spec.rb
+++ b/spec/miscellaneous/lib/html_cleaner_spec.rb
@@ -855,7 +855,7 @@ describe HtmlCleaner do
       doc = Nokogiri::HTML.fragment(add_paragraphs_to_text(html))
       expect(doc.xpath("./p[1]/em").children.to_s.strip).to eq("em tag.")
       expect(doc.xpath("./p[2]/em/strong").children.to_s.strip).to eq("strong tag.")
-      expect(doc.xpath("./p[3]/em/strong").children.to_s.strip).to eq("Stuff.")
+      expect(doc.xpath("./p[3]").children.to_s.strip).to eq("Stuff.")
     end
 
     it "should close unclosed tag withing other tag" do

--- a/spec/miscellaneous/lib/html_cleaner_spec.rb
+++ b/spec/miscellaneous/lib/html_cleaner_spec.rb
@@ -845,7 +845,7 @@ describe HtmlCleaner do
       expect(doc.xpath("./p[contains(@class, 'bar')]").children.to_s.strip).to eq("foobar")
     end
 
-    it "should close unclosed inline tags before double linebreak" do
+    it "should reopen unclosed inline tags in the next paragraph" do
       html = """Here is an unclosed <em>em tag.
 
       Here is an unclosed <strong>strong tag.
@@ -854,8 +854,8 @@ describe HtmlCleaner do
 
       doc = Nokogiri::HTML.fragment(add_paragraphs_to_text(html))
       expect(doc.xpath("./p[1]/em").children.to_s.strip).to eq("em tag.")
-      expect(doc.xpath("./p[2]/strong").children.to_s.strip).to eq("strong tag.")
-      expect(doc.xpath("./p[3]").children.to_s.strip).to eq("Stuff.")
+      expect(doc.xpath("./p[2]/em/strong").children.to_s.strip).to eq("strong tag.")
+      expect(doc.xpath("./p[3]/em").children.to_s.strip).to eq("Stuff.")
     end
 
     it "should close unclosed tag withing other tag" do


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5826

## Purpose

Updates the nokogiri gem and fixes a test to reflect a resultant change in behavior.

## References

Replaces #3692 