### PR TITLE
AO3-5838 Expand test coverage of bookmarks controller index action

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -395,7 +395,7 @@ public
   end
 
   def use_caching?
-    %w(staging production).include?(Rails.env) && @admin_settings.enable_test_caching?
+    %w(staging production test).include?(Rails.env) && @admin_settings.enable_test_caching?
   end
 
   protected

--- a/factories/bookmarks.rb
+++ b/factories/bookmarks.rb
@@ -3,7 +3,17 @@ require 'faker'
 FactoryBot.define do
   factory :bookmark do
     bookmarkable_type { "Work" }
-    bookmarkable_id { FactoryBot.create(:work).id }
+    bookmarkable_id { FactoryBot.create(:posted_work).id }
     pseud_id { FactoryBot.create(:pseud).id }
+
+    factory :external_work_bookmark do
+      bookmarkable_type { "ExternalWork" }
+      bookmarkable_id { FactoryBot.create(:external_work).id }
+    end
+
+    factory :series_bookmark do
+      bookmarkable_type { "Series" }
+      bookmarkable_id { FactoryBot.create(:series_with_a_work).id }
+    end
   end
 end

--- a/spec/controllers/bookmarks_controller_spec.rb
+++ b/spec/controllers/bookmarks_controller_spec.rb
@@ -43,7 +43,7 @@ describe BookmarksController do
     end
   end
 
-  describe "index", bookmark_search: true do
+  describe "index" do
     let!(:external_work_bookmark) { create(:external_work_bookmark) }
     let!(:series_bookmark) { create(:series_bookmark) }
     let!(:work_bookmark) { create(:bookmark) }
@@ -152,7 +152,7 @@ describe BookmarksController do
       end
     end
 
-    context "with caching" do
+    context "with caching", bookmark_search: true do
       before do
         AdminSetting.first.update_attribute(:enable_test_caching, true)
         run_all_indexing_jobs

--- a/spec/controllers/bookmarks_controller_spec.rb
+++ b/spec/controllers/bookmarks_controller_spec.rb
@@ -54,7 +54,7 @@ describe BookmarksController, bookmark_search: true do
       expect(assigns(:bookmarks)).to include(work_bookmark)
     end
 
-    context "when given chapter_id parameters" do
+    context "with chapter_id parameters" do
       it "loads the work as the bookmarkable" do
         params = { chapter_id: work_bookmark.bookmarkable.chapters.first.id }
         get :index, params: params
@@ -62,7 +62,7 @@ describe BookmarksController, bookmark_search: true do
       end
     end
 
-    context "when given external_work_id parameters" do
+    context "with external_work_id parameters" do
       it "loads the external work as the bookmarkable" do
         params = { external_work_id: external_work_bookmark.bookmarkable.id }
         get :index, params: params
@@ -71,52 +71,64 @@ describe BookmarksController, bookmark_search: true do
     end
 
     context "with user_id parameters" do
-      it "raises an error if user_id cannot be found" do
-        params = { user_id: "nobody" }
-        expect { get :index, params: params }.to raise_error(
-          ActiveRecord::RecordNotFound,
-          "Couldn't find user named 'nobody'"
-        )
-      end
-      
-      context "with valid user_id and invalid pseud_id parameters" do
-        it "raises an error if pseud_id cannot be found" do
-          params = { user_id: work_bookmark.pseud.user, pseud_id: "nobody" }
+      context "when user_id does not exist" do
+        it "raises a RecordNotFound error" do
+          params = { user_id: "nobody" }
           expect { get :index, params: params }.to raise_error(
             ActiveRecord::RecordNotFound,
-            "Couldn't find pseud named 'nobody'"
+            "Couldn't find user named 'nobody'"
           )
+        end
+      end
+
+      context "when user_id exists" do
+        context "when pseud_id does not exist" do
+          it "raises a RecordNotFound error for the pseud" do
+            params = { user_id: work_bookmark.pseud.user, pseud_id: "nobody" }
+            expect { get :index, params: params }.to raise_error(
+              ActiveRecord::RecordNotFound,
+              "Couldn't find pseud named 'nobody'"
+            )
+          end
         end
       end
     end
 
-    context "when given tag_id parameters" do
+    context "with tag_id parameters" do
       let(:tag) { create(:fandom) }
       let(:merger) { create(:fandom, merger_id: canonical.id) }
       let(:canonical) { create(:canonical_fandom) } 
 
-      it "raises an error if tag_id cannot be found" do
-        params = { tag_id: "nothingness" }
-        expect { get :index, params: params }.to raise_error(
-          ActiveRecord::RecordNotFound,
-          "Couldn't find tag named 'nothingness'"
-        )
+      context "when tag_id does not exist" do
+        it "raises a RecordNotFound error" do
+          params = { tag_id: "nothingness" }
+          expect { get :index, params: params }.to raise_error(
+            ActiveRecord::RecordNotFound,
+            "Couldn't find tag named 'nothingness'"
+          )
+        end
       end
 
-      it "redirects to canonical tag's bookmarks if tag_id is a synonym" do
-        params = { tag_id: merger }
-        get :index, params: params
-        expect(response).to redirect_to(tag_bookmarks_path(canonical))
-      end
+      context "when tag_id is not canonical" do
+        context "when tag_id is a synonym" do
+          it "redirects to the canonical's tag_bookmarks_path" do
+            params = { tag_id: merger }
+            get :index, params: params
+            expect(response).to redirect_to(tag_bookmarks_path(canonical))
+          end
+        end
 
-      it "redirects to tag page if tag_id is neither a canonical nor a synonym" do
-        params = { tag_id: tag }
-        get :index, params: params
-        expect(response).to redirect_to(tag_path(tag))
+        context "when tag_id is not a synonym" do
+          it "redirects to tag_path" do
+            params = { tag_id: tag }
+            get :index, params: params
+            expect(response).to redirect_to(tag_path(tag))
+          end
+        end
       end
     end
 
-    describe "without caching" do
+    context "without caching" do
       before do
         AdminSetting.first.update_attribute(:enable_test_caching, false)
       end
@@ -146,7 +158,7 @@ describe BookmarksController, bookmark_search: true do
       end
     end
 
-    describe "with caching" do
+    context "with caching" do
       before do
         AdminSetting.first.update_attribute(:enable_test_caching, true)
         run_all_indexing_jobs

--- a/spec/controllers/bookmarks_controller_spec.rb
+++ b/spec/controllers/bookmarks_controller_spec.rb
@@ -55,7 +55,7 @@ describe BookmarksController, bookmark_search: true do
     end
 
     context "when given chapter_id parameters" do
-      it "sets the work as the bookmarkable" do
+      it "loads the work as the bookmarkable" do
         params = { chapter_id: work_bookmark.bookmarkable.chapters.first.id }
         get :index, params: params
         expect(assigns(:bookmarkable)).to eq(work_bookmark.bookmarkable)
@@ -63,7 +63,7 @@ describe BookmarksController, bookmark_search: true do
     end
 
     context "when given external_work_id parameters" do
-      it "sets the external work as the bookmarkable" do
+      it "loads the external work as the bookmarkable" do
         params = { external_work_id: external_work_bookmark.bookmarkable.id }
         get :index, params: params
         expect(assigns(:bookmarkable)).to eq(external_work_bookmark.bookmarkable)

--- a/spec/controllers/bookmarks_controller_spec.rb
+++ b/spec/controllers/bookmarks_controller_spec.rb
@@ -1,6 +1,6 @@
 require "spec_helper"
 
-describe BookmarksController, bookmark_search: true do
+describe BookmarksController do
   include LoginMacros
   include RedirectExpectationHelper
 
@@ -158,7 +158,7 @@ describe BookmarksController, bookmark_search: true do
       end
     end
 
-    context "with caching" do
+    context "with caching", bookmark_search: true do
       before do
         AdminSetting.first.update_attribute(:enable_test_caching, true)
         run_all_indexing_jobs

--- a/spec/controllers/bookmarks_controller_spec.rb
+++ b/spec/controllers/bookmarks_controller_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require "spec_helper"
 
 describe BookmarksController, bookmark_search: true do
   include LoginMacros
@@ -8,37 +8,37 @@ describe BookmarksController, bookmark_search: true do
     it_redirects_to_simple new_user_session_path
   end
 
-  describe 'new' do
-    context 'without javascript' do
-      it 'should not return the form for anyone not logged in' do
+  describe "new" do
+    context "without javascript" do
+      it "should not return the form for anyone not logged in" do
         get :new
         it_redirects_to_user_login
       end
 
-      it 'should render the form if logged in' do
+      it "should render the form if logged in" do
         fake_login
         get :new
-        expect(response).to render_template('new')
+        expect(response).to render_template("new")
       end
     end
 
-    context 'with javascript' do
-      it 'should render the bookmark_form_dynamic form if logged in' do
+    context "with javascript" do
+      it "should render the bookmark_form_dynamic form if logged in" do
         fake_login
         get :new, params: { format: :js }, xhr: true
-        expect(response).to render_template('bookmark_form_dynamic')
+        expect(response).to render_template("bookmark_form_dynamic")
       end
     end
   end
 
-  describe 'edit' do
-    context 'with javascript' do
+  describe "edit" do
+    context "with javascript" do
       let(:bookmark) { FactoryBot.create(:bookmark) }
 
-      it 'should render the bookmark_form_dynamic form' do
+      it "should render the bookmark_form_dynamic form" do
         fake_login_known_user(bookmark.pseud.user)
         get :edit, params: { id: bookmark.id, format: :js }, xhr: true
-        expect(response).to render_template('bookmark_form_dynamic')
+        expect(response).to render_template("bookmark_form_dynamic")
       end
     end
   end

--- a/spec/controllers/bookmarks_controller_spec.rb
+++ b/spec/controllers/bookmarks_controller_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe BookmarksController do
+describe BookmarksController, bookmark_search: true do
   include LoginMacros
   include RedirectExpectationHelper
 
@@ -39,6 +39,84 @@ describe BookmarksController do
         fake_login_known_user(bookmark.pseud.user)
         get :edit, params: { id: bookmark.id, format: :js }, xhr: true
         expect(response).to render_template('bookmark_form_dynamic')
+      end
+    end
+  end
+
+  describe "index" do
+    let!(:external_work_bookmark) { create(:external_work_bookmark) }
+    let!(:series_bookmark) { create(:series_bookmark) }
+    let!(:work_bookmark) { create(:bookmark) }
+
+    it "returns search results when given bookmark_search parameters" do
+      params = { :bookmark_search => { bookmarkable_query: "restricted: false" } }
+      get :index, params: params
+      expect(assigns(:bookmarks)).to include(work_bookmark)
+    end
+
+    describe "without caching" do
+      before do
+        AdminSetting.first.update_attribute(:enable_test_caching, false)
+      end
+
+      it "returns work bookmarks" do
+        get :index
+        expect(assigns(:bookmarks)).to include(work_bookmark)
+      end
+
+      it "does not return external work bookmarks" do
+        get :index
+        expect(assigns(:bookmarks)).not_to include(external_work_bookmark)
+      end
+
+      it "does not return series bookmarks" do
+        get :index
+        expect(assigns(:bookmarks)).not_to include(series_bookmark)
+      end
+
+      it "returns the result with new bookmarks the second time" do
+        get :index
+        expect(assigns(:bookmarks)).to include(work_bookmark)
+        work_bookmark2 = create(:bookmark)
+        get :index
+        expect(assigns(:bookmarks)).to include(work_bookmark)
+        expect(assigns(:bookmarks)).to include(work_bookmark2)
+      end
+    end
+
+    describe "with caching" do
+      before do
+        AdminSetting.first.update_attribute(:enable_test_caching, true)
+        run_all_indexing_jobs
+      end
+
+      it "returns work bookmarks" do
+        get :index
+        expect(assigns(:bookmarks)).to include(work_bookmark)
+      end
+
+      it "returns external work bookmarks" do
+        get :index
+        expect(assigns(:bookmarks)).to include(external_work_bookmark)
+      end
+
+      it "returns series bookmarks" do
+        get :index
+        expect(assigns(:bookmarks)).to include(series_bookmark)
+      end
+
+      it "returns the same result the second time when a new bookmark is created within the expiration time" do
+        get :index
+        expect(assigns(:bookmarks)).to include(external_work_bookmark)
+        expect(assigns(:bookmarks)).to include(series_bookmark)
+        expect(assigns(:bookmarks)).to include(work_bookmark)
+        work_bookmark2 = create(:bookmark)
+        run_all_indexing_jobs
+        get :index
+        expect(assigns(:bookmarks)).to include(external_work_bookmark)
+        expect(assigns(:bookmarks)).to include(series_bookmark)
+        expect(assigns(:bookmarks)).to include(work_bookmark)
+        expect(assigns(:bookmarks)).not_to include(work_bookmark2)
       end
     end
   end

--- a/spec/controllers/bookmarks_controller_spec.rb
+++ b/spec/controllers/bookmarks_controller_spec.rb
@@ -49,7 +49,7 @@ describe BookmarksController do
     let!(:work_bookmark) { create(:bookmark) }
 
     it "returns search results when given bookmark_search parameters" do
-      params = { :bookmark_search => { bookmarkable_query: "restricted: false" } }
+      params = { bookmark_search: { bookmarkable_query: "restricted: false" } }
       get :index, params: params
       expect(assigns(:bookmarks)).to include(work_bookmark)
     end

--- a/spec/controllers/bookmarks_controller_spec.rb
+++ b/spec/controllers/bookmarks_controller_spec.rb
@@ -90,16 +90,6 @@ describe BookmarksController, bookmark_search: true do
       end
     end
 
-    context "when given invalid tag_id parameters" do
-      it "raises an error" do
-        params = { tag_id: "nothingness" }
-        expect { get :index, params: params }.to raise_error(
-          ActiveRecord::RecordNotFound,
-          "Couldn't find tag named 'nothingness'"
-        )
-      end
-    end
-
     context "when given tag_id parameters" do
       let(:tag) { create(:fandom) }
       let(:merger) { create(:fandom, merger_id: canonical.id) }

--- a/spec/controllers/bookmarks_controller_spec.rb
+++ b/spec/controllers/bookmarks_controller_spec.rb
@@ -10,12 +10,12 @@ describe BookmarksController do
 
   describe "new" do
     context "without javascript" do
-      it "should not return the form for anyone not logged in" do
+      it "redirects anyone not logged in" do
         get :new
         it_redirects_to_user_login
       end
 
-      it "should render the form if logged in" do
+      it "renders the new form template if logged in" do
         fake_login
         get :new
         expect(response).to render_template("new")
@@ -23,7 +23,7 @@ describe BookmarksController do
     end
 
     context "with javascript" do
-      it "should render the bookmark_form_dynamic form if logged in" do
+      it "renders the bookmark_form_dynamic form if logged in" do
         fake_login
         get :new, params: { format: :js }, xhr: true
         expect(response).to render_template("bookmark_form_dynamic")
@@ -35,7 +35,7 @@ describe BookmarksController do
     context "with javascript" do
       let(:bookmark) { FactoryBot.create(:bookmark) }
 
-      it "should render the bookmark_form_dynamic form" do
+      it "renders the bookmark_form_dynamic form if logged in" do
         fake_login_known_user(bookmark.pseud.user)
         get :edit, params: { id: bookmark.id, format: :js }, xhr: true
         expect(response).to render_template("bookmark_form_dynamic")

--- a/spec/controllers/bookmarks_controller_spec.rb
+++ b/spec/controllers/bookmarks_controller_spec.rb
@@ -43,16 +43,10 @@ describe BookmarksController do
     end
   end
 
-  describe "index" do
+  describe "index", bookmark_search: true do
     let!(:external_work_bookmark) { create(:external_work_bookmark) }
     let!(:series_bookmark) { create(:series_bookmark) }
     let!(:work_bookmark) { create(:bookmark) }
-
-    it "returns search results when given bookmark_search parameters" do
-      params = { bookmark_search: { bookmarkable_query: "restricted: false" } }
-      get :index, params: params
-      expect(assigns(:bookmarks)).to include(work_bookmark)
-    end
 
     context "with chapter_id parameters" do
       it "loads the work as the bookmarkable" do
@@ -158,7 +152,7 @@ describe BookmarksController do
       end
     end
 
-    context "with caching", bookmark_search: true do
+    context "with caching" do
       before do
         AdminSetting.first.update_attribute(:enable_test_caching, true)
         run_all_indexing_jobs

--- a/spec/controllers/works/default_rails_actions_spec.rb
+++ b/spec/controllers/works/default_rails_actions_spec.rb
@@ -315,12 +315,6 @@ describe WorksController, work_search: true do
       expect(assigns(:fandom)).to eq(@fandom)
     end
 
-    it "returns search results when given work_search parameters" do
-      params = { work_search: { query: "fandoms: #{@fandom.name}" } }
-      get :index, params: params
-      expect(assigns(:works)).to include(@work)
-    end
-
     describe "without caching" do
       before do
         AdminSetting.first.update_attribute(:enable_test_caching, false)

--- a/spec/controllers/works/default_rails_actions_spec.rb
+++ b/spec/controllers/works/default_rails_actions_spec.rb
@@ -323,7 +323,7 @@ describe WorksController, work_search: true do
 
     describe "without caching" do
       before do
-        allow(controller).to receive(:use_caching?).and_return(false)
+        AdminSetting.first.update_attribute(:enable_test_caching, false)
       end
 
       it "returns the result with different works the second time" do
@@ -337,7 +337,7 @@ describe WorksController, work_search: true do
 
     describe "with caching" do
       before do
-        allow(controller).to receive(:use_caching?).and_return(true)
+        AdminSetting.first.update_attribute(:enable_test_caching, true)
       end
 
       context "with NO owner tag" do

--- a/spec/controllers/works/default_rails_actions_spec.rb
+++ b/spec/controllers/works/default_rails_actions_spec.rb
@@ -316,7 +316,7 @@ describe WorksController, work_search: true do
     end
 
     it "returns search results when given work_search parameters" do
-      params = { :work_search => { query: "fandoms: #{@fandom.name}" } }
+      params = { work_search: { query: "fandoms: #{@fandom.name}" } }
       get :index, params: params
       expect(assigns(:works)).to include(@work)
     end

--- a/spec/models/bookmark_spec.rb
+++ b/spec/models/bookmark_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe Bookmark do
+  it "has a valid factory" do
+    expect(build(:bookmark)).to be_valid
+  end
+
+  it "has a valid factory for external work bookmarks" do
+    expect(build(:external_work_bookmark)).to be_valid
+  end
+
+  it "has a valid factory for series bookmarks" do
+    expect(build(:series_bookmark)).to be_valid
+  end
+end

--- a/spec/models/bookmark_spec.rb
+++ b/spec/models/bookmark_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require "spec_helper"
 
 describe Bookmark do
   it "has a valid factory" do


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5838

## Purpose

Makes sure the bookmarks controller index action is covered a bit better by automated tests, particularly when the experimental caching setting is enabled. It also allows us to actually enable that setting in tests 😭 

## Testing Instructions

None, automated.