### PR TITLE
AO3-5818 Update Referrer-Policy for YouTube's embedding restrictions

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -84,7 +84,7 @@ module Otwarchive
 
     # Only send referrer information to ourselves
     config.action_dispatch.default_headers = {
-      "Referrer-Policy" => "same-origin",
+      "Referrer-Policy" => "strict-origin-when-cross-origin",
       "X-Frame-Options" => "SAMEORIGIN",
       "X-XSS-Protection" => "1; mode=block",
       "X-Content-Type-Options" => "nosniff",

--- a/spec/miscellaneous/requests/security_headers_spec.rb
+++ b/spec/miscellaneous/requests/security_headers_spec.rb
@@ -4,7 +4,7 @@ describe "Security headers", type: :request do
   it "includes the required headers" do
     get "/"
     headers = response.headers
-    expect(headers["Referrer-Policy"]).to eq("same-origin")
+    expect(headers["Referrer-Policy"]).to eq("strict-origin-when-cross-origin")
     expect(headers["X-Frame-Options"]).to eq("SAMEORIGIN")
     expect(headers["X-XSS-Protection"]).to eq("1; mode=block")
     expect(headers["X-Content-Type-Options"]).to eq("nosniff")


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5818

## Purpose

Use strict-origin-when-cross-origin because:

- YouTube embedding can be [blocked based on domains](https://support.google.com/youtube/answer/6301625?hl=en) and they can block playback if referrer information is missing.
- We still want to avoid sending too much referrer information to other sites (see [AO3-5632](https://otwarchive.atlassian.net/browse/AO3-5632)), so sending just the origin (protocol + domain + port, without path or querystring) is a good compromise.
- Within the site, we do need to send the path and querystring, which we use to identify last known visited pages and to calculate hit counts (#2779).

This is also [Rails 5.2's default choice](https://guides.rubyonrails.org/v5.2/configuring.html#configuring-action-dispatch) for Referrer-Policy. Rails 5.1 [leaves it unset](https://guides.rubyonrails.org/v5.1/configuring.html#configuring-action-dispatch).

## Testing Instructions

- Check that YouTube embeds work, especially ones that are currently broken on beta.
- Test [AO3-5632](https://otwarchive.atlassian.net/browse/AO3-5632) again (e.g. for Twitter requests) again but expect `Referer: https://archiveofourown.org/` where it used to be none.

## References

https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Referrer-Policy#Examples

- For YouTube embeds, eliminate `no-referrer`, `same-origin`.
- For in-site navigation and eventually hit counts, eliminate `origin`, `strict-origin`.
- For [AO3-5632](https://otwarchive.atlassian.net/browse/AO3-5632), eliminate `unsafe-url` and `no-referrer-when-downgrade`.
- It comes down to `origin-when-cross-origin` and `strict-origin-when-cross-origin`, pick the strict version.