### PR TITLE
AO3-5759 Revert adding Lockup to remove password protection on staging

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -180,10 +180,6 @@ group :test, :development, :staging do
   gem 'bullet', '>= 5.7.3'
 end
 
-group :staging do
-  gem 'lockup'
-end
-
 # Deploy with Capistrano
 gem 'capistrano-gitflow_version', '>=0.0.3', require: false
 gem 'rvm-capistrano'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -217,8 +217,6 @@ GEM
     kgio (2.10.0)
     launchy (2.4.3)
       addressable (~> 2.3)
-    lockup (1.5.1)
-      rails (>= 3, < 6.1)
     lograge (0.6.0)
       actionpack (>= 4, < 5.2)
       activesupport (>= 4, < 5.2)
@@ -511,7 +509,6 @@ DEPENDENCIES
   httparty
   kgio (= 2.10.0)
   launchy
-  lockup
   lograge
   mechanize
   minitest

--- a/config/application.rb
+++ b/config/application.rb
@@ -3,7 +3,7 @@ require File.expand_path('../boot', __FILE__)
 require 'rails/all'
 
 # If you have a Gemfile, require the gems listed there, including any gems
-# you've limited to :test, :development, :staging, or :production.
+# you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
 
 module Otwarchive

--- a/config/config.yml
+++ b/config/config.yml
@@ -471,7 +471,3 @@ CHARACTER_COUNT_SCRIPTS: ["Han", "Hiragana", "Katakana", "Thai"]
 # Cache durations for work and bookmark searches (in seconds)
 SECONDS_UNTIL_WORK_INDEX_EXPIRE: 1800
 SECONDS_UNTIL_BOOKMARK_INDEX_EXPIRE: 1800
-
-# Case-insensitive password for staging, plus a hint in case you forget.
-LOCKUP_CODEWORD: "secret"
-LOCKUP_HINT: "Don't tell anyone."

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,5 @@
 Otwarchive::Application.routes.draw do
 
-  mount Lockup::Engine, at: '/lockup' if Rails.env.staging?
-
   devise_for :admin,
              module: 'admin',
              only: :sessions,

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -1,13 +1,11 @@
 development:
   secret_key_base: <%= ArchiveConfig.SESSION_SECRET %>
-
+ 
 test:
   secret_key_base: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
  
 staging:
   secret_key_base: <%= ArchiveConfig.SESSION_SECRET %>
-  lockup_codeword: <%= ArchiveConfig.LOCKUP_CODEWORD %>
-  lockup_hint: <%= ArchiveConfig.LOCKUP_HINT %>
 
 production:
   secret_key_base: <%= ArchiveConfig.SESSION_SECRET %>


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5759

## Purpose

Reverts otwcode/otwarchive#3710.

We were getting redirected to `unicorn_write` and `unicorn_story` when following links (not just links with the lockup params, either) or submitting forms, so we're going to revert for now and try again once we have the proper staging site back.

## Testing Instructions

Refer to Jira.