### PR TITLE
Add TODOs for known issues with kudos cache expiration

### DIFF
--- a/app/models/pseud.rb
+++ b/app/models/pseud.rb
@@ -350,7 +350,7 @@ class Pseud < ApplicationRecord
     # the cache is invalidated and the pseud change will be visible.
     Comment.where(pseud_id: self.id).update_all(pseud_id: replacement.id,
                                                 updated_at: Time.now)
-    # NB: updates the kudos to use the new default pseud, but the cache will not expire
+    # TODO: AO3-5054 Expire kudos cache when changing default pseuds.
     Kudo.where(pseud_id: self.id).update_all(pseud_id: replacement.id)
     change_collections_membership
     change_gift_recipients

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -135,7 +135,8 @@ class User < ApplicationRecord
   end
 
   def remove_pseud_from_kudos
-    # NB: updates the kudos to remove the pseud, but the cache will not expire, and there's also issue 2198
+    # TODO: AO3-5054 Expire kudos cache when deleting a user.
+    # TODO: AO3-2195 Display orphaned kudos (no pseuds; no IPs so not counted as guest kudos).
     pseuds_list = pseuds.map(&:id)
     Kudo.where(["pseud_id IN (?)", pseuds_list]).update_all("pseud_id = NULL") if pseuds_list.present?
   end


### PR DESCRIPTION
## Issue

None.

## Purpose

Cached kudos should update when deleting users or changing default pseuds.
Orphaned kudos should appear somewhere.

[skip ci]

## Testing Instructions

None, just comments.