### PR TITLE
AO3-5845 Prevent Twitter share button from vanishing in Firefox and Chrome

### DIFF
--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -193,7 +193,7 @@ class WorksController < ApplicationController
     # Users must explicitly okay viewing of adult content
     if params[:view_adult]
       session[:adult] = true
-    elsif @work.adult? && !see_adult?
+    elsif params[:format] == "html" && @work.adult? && !see_adult?
       render('_adult', layout: 'application') && return
     end
 

--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -193,7 +193,7 @@ class WorksController < ApplicationController
     # Users must explicitly okay viewing of adult content
     if params[:view_adult]
       session[:adult] = true
-    elsif params[:format] == "html" && @work.adult? && !see_adult?
+    elsif @work.adult? && !see_adult?
       render('_adult', layout: 'application') && return
     end
 

--- a/public/stylesheets/site/2.0/07-interactions.css
+++ b/public/stylesheets/site/2.0/07-interactions.css
@@ -543,6 +543,11 @@ a.modal.help {
   margin-top: 0.5em;
 }
 
+.twitter-share-button {
+    min-width: 76px;
+    min-height: 28px;
+}
+
 /*MODE: DYNAMIC is in early dev and so currently sharing styles with toggled */
 
 div.dynamic {


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [ ] Have you added tests for any changed functionality?
* [ ] Have you added the [JIRA](https://otwarchive.atlassian.net) issue number as the *first* thing in your pull request title (eg: `AO3-1234 Fix thing`)
* [ ] Have you updated or commented on the JIRA issue with the information below?

## Issue

https://otwarchive.atlassian.net/browse/AO3-5845

## Purpose

Force the twitter share button to be visible. There are doubtlessly more elegant fixes but this works.

## Testing Instructions

Stage the changes. Click share. Note that the share button is visible.

## References

No.

## Credit

*What name do you want us to use to credit your work in the [Archive of Our Own's Release Notes](https://archiveofourown.org/admin_posts?tag=1)?*

derenrch

*What pronouns do you prefer (she/her, he/him, zie/hir etc)?*

he/him
