### PR TITLE
AO3-5735 Add direction attributes for admin posts

### DIFF
--- a/app/views/admin_posts/_admin_post.html.erb
+++ b/app/views/admin_posts/_admin_post.html.erb
@@ -1,5 +1,5 @@
 <% # expects "admin_post" %>
-<div class="header">
+<div <% if rtl? %>dir="rtl"<% end %> class="header">
   <h3 class="heading">
     <%= link_to admin_post.title.html_safe, admin_post %>
   </h3>
@@ -34,6 +34,6 @@
     <% end %>
   </dl>
 </div>
-<div class="userstuff">
+<div <% if rtl? %>dir="rtl"<% end %> class="userstuff">
   <%=raw sanitize_field(admin_post, :content) %>
 </div>


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5735

## Purpose

If a news post is written in a right-to-left language, this adds the `dir="rtl"` attribute to the header and userstuff divs.

## Testing Instructions

1. Log in as admin
2. Admin Posts > Post AO3 News
3. Fill in a title and content using a right-to-left language
4. Select appropriate language from the "Choose a language" menu
5. Press "Post"
6. Check the HTML source of the news post to make sure the `header` and `userstuff` divs both have the attribute `dir="rtl"`

## Credit

Alix R, she/her
