### PR TITLE
AO3-5844 Migration to add user_id column to kudos table

### DIFF
--- a/db/migrate/20200115232918_add_user_id_to_kudos.rb
+++ b/db/migrate/20200115232918_add_user_id_to_kudos.rb
@@ -1,0 +1,6 @@
+class AddUserIdToKudos < ActiveRecord::Migration[5.1]
+  def change
+    add_column :kudos, :user_id, :int
+    add_index :kudos, :user_id
+  end
+end

--- a/db/migrate/20200115232918_add_user_id_to_kudos.rb
+++ b/db/migrate/20200115232918_add_user_id_to_kudos.rb
@@ -1,6 +1,34 @@
 class AddUserIdToKudos < ActiveRecord::Migration[5.1]
-  def change
-    add_column :kudos, :user_id, :int
-    add_index :kudos, :user_id
+  def up
+    if Rails.env.staging? || Rails.env.production?
+=begin
+      pt-online-schema-change -uroot --alter \
+      "ADD COLUMN user_id INT, ADD INDEX index_kudos_on_user_id (user_id)" \
+      D=$DATABASE,t=kudos --chunk-size=10k --max-flow-ctl 0 \
+      --pause-file /tmp/pauseme --max-load Threads_running=25 \
+      --critical-load Threads_running=400 --set-vars innodb_lock_wait_timeout=2 \
+      --alter-foreign-keys-method=auto --execute
+      insert into schema_migrations (version) values ("20200115232918")
+=end
+    else
+      add_column :kudos, :user_id, :int
+      add_index :kudos, :user_id
+    end
+  end
+
+  def down
+    if Rails.env.staging? || Rails.env.production?
+=begin
+      pt-online-schema-change -uroot --alter \
+      "DROP COLUMN user_id, DROP INDEX index_kudos_on_user_id (user_id)" \
+      D=$DATABASE,t=kudos --chunk-size=10k --max-flow-ctl 0 \
+      --pause-file /tmp/pauseme --max-load Threads_running=25 \
+      --critical-load Threads_running=400 --set-vars innodb_lock_wait_timeout=2 \
+      --alter-foreign-keys-method=auto --execute
+=end
+    else
+      remove_index :kudos, name: 'index_kudos_on_user_id'
+      remove_column :kudos, :user_id
+    end
   end
 end

--- a/db/migrate/20200115232918_add_user_id_to_kudos.rb
+++ b/db/migrate/20200115232918_add_user_id_to_kudos.rb
@@ -19,15 +19,13 @@ class AddUserIdToKudos < ActiveRecord::Migration[5.1]
   def down
     if Rails.env.staging? || Rails.env.production?
 =begin
-      pt-online-schema-change -uroot --alter \
-      "DROP COLUMN user_id, DROP INDEX index_kudos_on_user_id (user_id)" \
+      pt-online-schema-change -uroot --alter "DROP COLUMN user_id" \
       D=$DATABASE,t=kudos --chunk-size=10k --max-flow-ctl 0 \
       --pause-file /tmp/pauseme --max-load Threads_running=25 \
       --critical-load Threads_running=400 --set-vars innodb_lock_wait_timeout=2 \
       --alter-foreign-keys-method=auto --execute
 =end
     else
-      remove_index :kudos, name: 'index_kudos_on_user_id'
       remove_column :kudos, :user_id
     end
   end


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5844

## Purpose

This PR adds a new (unused) user_id column and (not yet unique) index to the kudos table.

For staging + beta, use pt-online-schema-change --alter args:

up:
```
ADD COLUMN user_id INT 
ADD INDEX index_kudos_on_user_id (user_id)
```

down:
```
DROP COLUMN user_id 
DROP INDEX index_kudos_on_user_id (user_id)
```

Side note: I've seen migrations (outside of otw) that require a ptosc in specific environments wrap the migration code in a conditional a la:
```
def up
    if Rails.env.production? || Rails.env.staging?
    =begin
        pt-online-schema-change command with ADD COLUMN and ADD INDEX in block comment
    =end
    else
        # migration code
    end
end

def down
    # Same as above but reversed
end
```

But I didn't see this done in any of our existing migrations. How do we normally prevent migrations from being run in beta and staging?

## References

Epic: https://otwarchive.atlassian.net/browse/AO3-5597

## Credit

*What name do you want us to use to credit your work in the [Archive of Our Own's Release Notes](https://archiveofourown.org/admin_posts?tag=1)?*

cyrilcee

*What pronouns do you prefer (she/her, he/him, zie/hir etc)?*

she/her
