### PR TITLE
AO3-5852 Ensure archive.org iframe src is in embed directory

### DIFF
--- a/lib/otw_sanitize/embed_sanitizer.rb
+++ b/lib/otw_sanitize/embed_sanitizer.rb
@@ -5,7 +5,7 @@ module OTWSanitize
   class EmbedSanitizer
     WHITELIST_REGEXES = {
       ao3:              %r{^archiveofourown\.org/},
-      archiveorg:       %r{^archive\.org/},
+      archiveorg:       %r{^archive\.org\/embed/},
       criticalcommons:  %r{^criticalcommons\.org/},
       dailymotion:      %r{^dailymotion\.com/},
       eighttracks:      %r{^8tracks\.com/},

--- a/spec/miscellaneous/lib/html_cleaner_spec.rb
+++ b/spec/miscellaneous/lib/html_cleaner_spec.rb
@@ -176,6 +176,12 @@ describe HtmlCleaner do
           expect(result).to be_empty
         end
 
+        it "strips archive.org iframe if the src is not the embed directory" do
+          html = '<iframe src="http://archive.org/123/wrong/456.html"></iframe>'
+          result = sanitize_value(field, html)
+          expect(result).to be_empty
+        end
+
         %w(metacafe.com vidders.net criticalcommons.org static.ning.com ning.com).each do |source|
           it "doesn't convert src to https for #{source}" do
             html = '<iframe width="560" height="315" src="http://' + source + '/embed/123" frameborder="0"></iframe>'


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5852

## Purpose

Makes sure archive.org iframe embeds are from archive.org/embed.

## Testing Instructions

Refer to Jira