### PR TITLE
AO3-5845 Make the Twitter share button appear more often in Chrome on Windows

### DIFF
--- a/public/stylesheets/sandbox.css
+++ b/public/stylesheets/sandbox.css
@@ -30,8 +30,8 @@ and preserve the balance/symmetry of the page */
   margin-left: 2.75em;
 }
 
-/* AO3-5845: Workaround for Twitter button not appearing in some browsers due to
-how the Twitter JavaScript interacts with our modal code. */
+/* AO3-5845: Workaround for Twitter button not always displaying in some
+browsers. */
 .twitter-share-button {
   min-width: 76px;
   min-height: 28px;

--- a/public/stylesheets/sandbox.css
+++ b/public/stylesheets/sandbox.css
@@ -29,3 +29,12 @@ and preserve the balance/symmetry of the page */
 .edit_external_author ul ul {
   margin-left: 2.75em;
 }
+
+/* AO3-5845: Workaround for Twitter button not appearing in some browsers due to
+how the Twitter JavaScript interacts with our modal code. */
+.twitter-share-button {
+  min-width: 76px;
+  min-height: 28px;
+  width: 76px;
+  height: 28px;
+}

--- a/public/stylesheets/site/2.0/07-interactions.css
+++ b/public/stylesheets/site/2.0/07-interactions.css
@@ -543,11 +543,6 @@ a.modal.help {
   margin-top: 0.5em;
 }
 
-.twitter-share-button {
-    min-width: 76px;
-    min-height: 28px;
-}
-
 /*MODE: DYNAMIC is in early dev and so currently sharing styles with toggled */
 
 div.dynamic {


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5845

## Purpose

Following the previous pull request for this issue, the Twitter share button still wasn't always appearing. It was especially stubborn in Chrome on Windows, refusing to load more often than not. Some testers and I experimented and determined setting the `width` and `height` in addition to `min-width` and `min-height` appeared to help, although it probably won't totally fix the problem.

## Testing Instructions

Using Chrome on Windows, go to a work, press the "Share" button, and see if there's a Twitter button.
