### PR TITLE
AO3-5844 Remove unnecessary schema_migrations insert comment from migration

### DIFF
--- a/db/migrate/20200115232918_add_user_id_to_kudos.rb
+++ b/db/migrate/20200115232918_add_user_id_to_kudos.rb
@@ -8,7 +8,6 @@ class AddUserIdToKudos < ActiveRecord::Migration[5.1]
       --pause-file /tmp/pauseme --max-load Threads_running=25 \
       --critical-load Threads_running=400 --set-vars innodb_lock_wait_timeout=2 \
       --alter-foreign-keys-method=auto --execute
-      insert into schema_migrations (version) values ("20200115232918")
 =end
     else
       add_column :kudos, :user_id, :int


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5844

## Purpose

According to comments in the [JIRA issue](https://otwarchive.atlassian.net/browse/AO3-5844), we no longer need to run "insert into schema_migrations..." now that rake db:migrate can run in all environments. So this PR removes this unnecessary comment.

Sorry about all the back and forth on this straightforward JIRA ticket, everyone! But since this is the first time we're adding the migration commands for staging and prod in the migration file as comments, hopefully this can serve as an example for future migrations to mimic.

## References

Previous PR, already merged into otwcode/otwarchive:master: https://github.com/otwcode/otwarchive/pull/3723
