### PR TITLE
AO3-5028 Notify creators when a collection maintainer makes their work unrevealed and/or anonymous.

### DIFF
--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -42,6 +42,37 @@ class UserMailer < BulletproofMailer::Base
     )
   end
 
+  def anonymous_or_unrevealed_notification(user_id, work_id, collection_id,
+                                           anonymous:, unrevealed:)
+    return unless anonymous || unrevealed
+
+    @user = User.find(user_id)
+    @work = Work.find(work_id)
+    @collection = Collection.find(collection_id)
+
+    @becoming_anonymous = anonymous
+    @becoming_unrevealed = unrevealed
+
+    I18n.with_locale(Locale.find(@user.preference.preferred_locale).iso) do
+      @status = if anonymous && unrevealed
+                  t(".status.anonymous_unrevealed")
+                elsif anonymous
+                  t(".status.anonymous")
+                else
+                  t(".status.unrevealed")
+                end
+
+      mail(
+        to: @user.email,
+        subject: t(".subject",
+                   status: @status,
+                   app_name: ArchiveConfig.APP_SHORT_NAME)
+      )
+    end
+  ensure
+    I18n.locale = I18n.default_locale
+  end
+
   # Sends an invitation to join the archive
   # Must be sent synchronously as it is rescued
   # TODO refactor to make it asynchronous

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -53,19 +53,19 @@ class UserMailer < BulletproofMailer::Base
     @becoming_anonymous = anonymous
     @becoming_unrevealed = unrevealed
 
-    I18n.with_locale(Locale.find(@user.preference.preferred_locale).iso) do
-      @status = if anonymous && unrevealed
-                  t(".status.anonymous_unrevealed")
-                elsif anonymous
-                  t(".status.anonymous")
-                else
-                  t(".status.unrevealed")
-                end
+    # Symbol used to pick the appropriate translation string:
+    @status = if anonymous && unrevealed
+                :anonymous_unrevealed
+              elsif anonymous
+                :anonymous
+              else
+                :unrevealed
+              end
 
+    I18n.with_locale(Locale.find(@user.preference.preferred_locale).iso) do
       mail(
         to: @user.email,
-        subject: t(".subject",
-                   status: @status,
+        subject: t(".subject.#{@status}",
                    app_name: ArchiveConfig.APP_SHORT_NAME)
       )
     end

--- a/app/models/collection_item.rb
+++ b/app/models/collection_item.rb
@@ -341,8 +341,6 @@ class CollectionItem < ApplicationRecord
     return if item.users.include?(User.current_user)
 
     item.users.each do |user|
-      next if user.preference.collection_emails_off
-
       UserMailer.anonymous_or_unrevealed_notification(
         user.id, item.id, collection.id,
         anonymous: newly_anonymous, unrevealed: newly_unrevealed

--- a/app/models/collection_item.rb
+++ b/app/models/collection_item.rb
@@ -320,4 +320,33 @@ class CollectionItem < ApplicationRecord
       end
     end
   end
+
+  after_update :notify_of_unrevealed_or_anonymous
+  def notify_of_unrevealed_or_anonymous
+    # This CollectionItem's anonymous/unrevealed status can only affect the
+    # item's status if (a) the CollectionItem is approved by the user and (b)
+    # the item is a work. (Bookmarks can't be anonymous/unrevealed at the
+    # moment.)
+    return unless approved_by_user? && item.is_a?(Work)
+
+    # Check whether anonymous/unrevealed is becoming true, when the work
+    # currently has it set to false:
+    newly_anonymous = (saved_change_to_anonymous?(to: true) && !item.anonymous?)
+    newly_unrevealed = (saved_change_to_unrevealed?(to: true) && !item.unrevealed?)
+
+    return unless newly_unrevealed || newly_anonymous
+
+    # Don't notify if it's one of the work creators who is changing the work's
+    # status.
+    return if item.users.include?(User.current_user)
+
+    item.users.each do |user|
+      next if user.preference.collection_emails_off
+
+      UserMailer.anonymous_or_unrevealed_notification(
+        user.id, item.id, collection.id,
+        anonymous: newly_anonymous, unrevealed: newly_unrevealed
+      ).deliver
+    end
+  end
 end

--- a/app/views/user_mailer/anonymous_or_unrevealed_notification.html.erb
+++ b/app/views/user_mailer/anonymous_or_unrevealed_notification.html.erb
@@ -1,0 +1,26 @@
+<% content_for :message do %>
+  <p><%= t(".greeting", user: style_bold(@user.default_pseud.byline)).html_safe %></p>
+
+  <p><%= t(".changed_status",
+           collection: style_link(@collection.title, collection_url(@collection)),
+           work: style_link(@work.title.html_safe, work_url(@work)),
+           status: @status).html_safe %></p>
+
+  <% if @becoming_anonymous %>
+    <p><%= t(".anonymous_info") %></p>
+  <% end %>
+
+  <% if @becoming_unrevealed %>
+    <p><%= t(".unrevealed_info") %></p>
+  <% end %>
+
+  <p><%= t(".do_not_want.html",
+           collection_items_link: style_link(t(".collection_items_link_text"),
+                                             user_collection_items_url(@user, approved: true)),
+           status: @status).html_safe %></p>
+
+  <p><%= t(".more_info.html",
+           faq_link: style_link(t(".faq_link_text"),
+                                archive_faq_url("collections-and-challenges",
+                                                anchor: :collectionoptions))).html_safe %></p>
+<% end %>

--- a/app/views/user_mailer/anonymous_or_unrevealed_notification.html.erb
+++ b/app/views/user_mailer/anonymous_or_unrevealed_notification.html.erb
@@ -1,10 +1,9 @@
 <% content_for :message do %>
   <p><%= t(".greeting", user: style_bold(@user.default_pseud.byline)).html_safe %></p>
 
-  <p><%= t(".changed_status",
+  <p><%= t(".changed_status.#{@status}",
            collection: style_link(@collection.title, collection_url(@collection)),
-           work: style_link(@work.title.html_safe, work_url(@work)),
-           status: @status).html_safe %></p>
+           work: style_creation_link(@work.title, work_url(@work))).html_safe %></p>
 
   <% if @becoming_anonymous %>
     <p><%= t(".anonymous_info") %></p>
@@ -14,13 +13,12 @@
     <p><%= t(".unrevealed_info") %></p>
   <% end %>
 
-  <p><%= t(".do_not_want.html",
+  <p><%= t(".do_not_want.#{@status}.html",
            collection_items_link: style_link(t(".collection_items_link_text"),
-                                             user_collection_items_url(@user, approved: true)),
-           status: @status).html_safe %></p>
+                                             user_collection_items_url(@user, approved: true))) %></p>
 
   <p><%= t(".more_info.html",
            faq_link: style_link(t(".faq_link_text"),
                                 archive_faq_url("collections-and-challenges",
-                                                anchor: :collectionoptions))).html_safe %></p>
+                                                anchor: :collectionoptions))) %></p>
 <% end %>

--- a/app/views/user_mailer/anonymous_or_unrevealed_notification.text.erb
+++ b/app/views/user_mailer/anonymous_or_unrevealed_notification.text.erb
@@ -1,0 +1,24 @@
+<% content_for :message do %>
+<%= t(".greeting", user: @user.default_pseud.byline) %>
+
+<%= t(".changed_status",
+      collection: @collection.title,
+      work: @work.title,
+      status: @status) %>
+
+<% if @becoming_anonymous && @becoming_unrevealed %>
+<%= t(".anonymous_info") %>
+
+<%= t(".unrevealed_info") %>
+<% elsif @becoming_anonymous %>
+<%= t(".anonymous_info") %>
+<% else %>
+<%= t(".unrevealed_info") %>
+<% end %>
+
+<%= t(".do_not_want.text",
+      status: @status) %> <%= user_collection_items_url(@user, approved: true) %>
+
+<%= t(".more_info.text") %> <%= archive_faq_url("collections-and-challenges",
+                                                anchor: :collectionoptions) %>
+<% end %>

--- a/app/views/user_mailer/anonymous_or_unrevealed_notification.text.erb
+++ b/app/views/user_mailer/anonymous_or_unrevealed_notification.text.erb
@@ -15,8 +15,10 @@
 <%= t(".unrevealed_info") %>
 <% end %>
 
-<%= t(".do_not_want.#{@status}.text") %> <%= user_collection_items_url(@user, approved: true) %>
+<%= t(".do_not_want.#{@status}.text",
+      collection_items_url: user_collection_items_url(@user, approved: true)) %>
 
-<%= t(".more_info.text") %> <%= archive_faq_url("collections-and-challenges",
-                                                anchor: :collectionoptions) %>
+<%= t(".more_info.text",
+      faq_url: archive_faq_url("collections-and-challenges",
+                               anchor: :collectionoptions)) %>
 <% end %>

--- a/app/views/user_mailer/anonymous_or_unrevealed_notification.text.erb
+++ b/app/views/user_mailer/anonymous_or_unrevealed_notification.text.erb
@@ -1,10 +1,9 @@
 <% content_for :message do %>
 <%= t(".greeting", user: @user.default_pseud.byline) %>
 
-<%= t(".changed_status",
+<%= t(".changed_status.#{@status}",
       collection: @collection.title,
-      work: @work.title,
-      status: @status) %>
+      work: @work.title) %>
 
 <% if @becoming_anonymous && @becoming_unrevealed %>
 <%= t(".anonymous_info") %>
@@ -16,8 +15,7 @@
 <%= t(".unrevealed_info") %>
 <% end %>
 
-<%= t(".do_not_want.text",
-      status: @status) %> <%= user_collection_items_url(@user, approved: true) %>
+<%= t(".do_not_want.#{@status}.text") %> <%= user_collection_items_url(@user, approved: true) %>
 
 <%= t(".more_info.text") %> <%= archive_faq_url("collections-and-challenges",
                                                 anchor: :collectionoptions) %>

--- a/config/locales/mailers/en.yml
+++ b/config/locales/mailers/en.yml
@@ -214,3 +214,21 @@ en:
       main:
         one: "We regret to inform you that your request for a new invitation cannot be fulfilled at this time."
         other: "We regret to inform you that your request for %{count} new invitations cannot be fulfilled at this time."
+    anonymous_or_unrevealed_notification:
+      subject: "[%{app_name}] Your work has become %{status}"
+      status:
+        anonymous: "anonymous"
+        anonymous_unrevealed: "anonymous and unrevealed"
+        unrevealed: "unrevealed"
+      greeting: "Dear %{user},"
+      changed_status: "The collection maintainers of %{collection} have changed the status of your work %{work} to %{status}."
+      anonymous_info: "Anonymous works are included in tag listings, but not on your works page. On the work, your user name will be replaced with \"Anonymous.\""
+      unrevealed_info: "Unrevealed works are not included in tag listings or on your works page. Anyone who follows a link to the work will receive a notice that it is currently unrevealed, and they will be unable to access its content."
+      do_not_want:
+        html: "If you do not want your work to be %{status}, please visit your %{collection_items_link} to remove it from this collection."
+        text: "If you do not want your work to be %{status}, please visit your Approved Collection Items page to remove it from this collection:"
+      collection_items_link_text: "Approved Collection Items page"
+      more_info:
+        html: "For more information, visit our %{faq_link}."
+        text: "For more information, visit our Collections and Challenges FAQ:"
+      faq_link_text: "Collections and Challenges FAQ"

--- a/config/locales/mailers/en.yml
+++ b/config/locales/mailers/en.yml
@@ -229,15 +229,15 @@ en:
       do_not_want:
         anonymous:
           html: "If you do not want your work to be anonymous, please visit your %{collection_items_link} to remove it from this collection."
-          text: "If you do not want your work to be anonymous, please visit your Approved Collection Items page to remove it from this collection:"
+          text: "If you do not want your work to be anonymous, please visit your Approved Collection Items page to remove it from this collection: %{collection_items_url}"
         anonymous_unrevealed:
           html: "If you do not want your work to be anonymous and unrevealed, please visit your %{collection_items_link} to remove it from this collection."
-          text: "If you do not want your work to be anonymous and unrevealed, please visit your Approved Collection Items page to remove it from this collection:"
+          text: "If you do not want your work to be anonymous and unrevealed, please visit your Approved Collection Items page to remove it from this collection: %{collection_items_url}"
         unrevealed:
           html: "If you do not want your work to be unrevealed, please visit your %{collection_items_link} to remove it from this collection."
-          text: "If you do not want your work to be unrevealed, please visit your Approved Collection Items page to remove it from this collection:"
+          text: "If you do not want your work to be unrevealed, please visit your Approved Collection Items page to remove it from this collection: %{collection_items_url}"
       collection_items_link_text: "Approved Collection Items page"
       more_info:
         html: "For more information, visit our %{faq_link}."
-        text: "For more information, visit our Collections and Challenges FAQ:"
+        text: "For more information, visit our Collections and Challenges FAQ: %{faq_url}"
       faq_link_text: "Collections and Challenges FAQ"

--- a/config/locales/mailers/en.yml
+++ b/config/locales/mailers/en.yml
@@ -215,18 +215,27 @@ en:
         one: "We regret to inform you that your request for a new invitation cannot be fulfilled at this time."
         other: "We regret to inform you that your request for %{count} new invitations cannot be fulfilled at this time."
     anonymous_or_unrevealed_notification:
-      subject: "[%{app_name}] Your work has become %{status}"
-      status:
-        anonymous: "anonymous"
-        anonymous_unrevealed: "anonymous and unrevealed"
-        unrevealed: "unrevealed"
+      subject:
+        anonymous: "[%{app_name}] Your work has become anonymous"
+        anonymous_unrevealed: "[%{app_name}] Your work has become anonymous and unrevealed"
+        unrevealed: "[%{app_name}] Your work has become unrevealed"
       greeting: "Dear %{user},"
-      changed_status: "The collection maintainers of %{collection} have changed the status of your work %{work} to %{status}."
+      changed_status:
+        anonymous: "The collection maintainers of %{collection} have changed the status of your work %{work} to anonymous."
+        anonymous_unrevealed: "The collection maintainers of %{collection} have changed the status of your work %{work} to anonymous and unrevealed."
+        unrevealed: "The collection maintainers of %{collection} have changed the status of your work %{work} to unrevealed."
       anonymous_info: "Anonymous works are included in tag listings, but not on your works page. On the work, your user name will be replaced with \"Anonymous.\""
       unrevealed_info: "Unrevealed works are not included in tag listings or on your works page. Anyone who follows a link to the work will receive a notice that it is currently unrevealed, and they will be unable to access its content."
       do_not_want:
-        html: "If you do not want your work to be %{status}, please visit your %{collection_items_link} to remove it from this collection."
-        text: "If you do not want your work to be %{status}, please visit your Approved Collection Items page to remove it from this collection:"
+        anonymous:
+          html: "If you do not want your work to be anonymous, please visit your %{collection_items_link} to remove it from this collection."
+          text: "If you do not want your work to be anonymous, please visit your Approved Collection Items page to remove it from this collection:"
+        anonymous_unrevealed:
+          html: "If you do not want your work to be anonymous and unrevealed, please visit your %{collection_items_link} to remove it from this collection."
+          text: "If you do not want your work to be anonymous and unrevealed, please visit your Approved Collection Items page to remove it from this collection:"
+        unrevealed:
+          html: "If you do not want your work to be unrevealed, please visit your %{collection_items_link} to remove it from this collection."
+          text: "If you do not want your work to be unrevealed, please visit your Approved Collection Items page to remove it from this collection:"
       collection_items_link_text: "Approved Collection Items page"
       more_info:
         html: "For more information, visit our %{faq_link}."

--- a/features/collections/collection_anonymity.feature
+++ b/features/collections/collection_anonymity.feature
@@ -454,3 +454,60 @@ Feature: Collection
       And I press "Post"
       And I go to my works page
     Then I should see "Secret Work"
+
+  Scenario: Changing a collection item to anonymous triggers a notification
+    Given a collection "Changeable"
+      And I am logged in as "creator"
+      And I post the work "Lovely" in the collection "Changeable"
+      And all emails have been delivered
+
+    When I am logged in as the owner of "Changeable"
+      And I go to "Changeable" collection edit page
+      And I check "This collection is anonymous"
+      And I press "Update"
+      And I view the approved collection items page for "Changeable"
+      And I check "Anonymous"
+      And I submit
+    Then "creator" should be emailed
+      And the email should have "Your work has become anonymous" in the subject
+      And the email should contain "Anonymous works are included in tag listings, but not on your works page."
+      And the email should not contain "translation missing"
+
+  Scenario: Changing a collection item to unrevealed triggers a notification
+    Given a collection "Changeable"
+      And I am logged in as "creator"
+      And I post the work "Lovely" in the collection "Changeable"
+      And all emails have been delivered
+
+    When I am logged in as the owner of "Changeable"
+      And I go to "Changeable" collection edit page
+      And I check "This collection is unrevealed"
+      And I press "Update"
+      And I view the approved collection items page for "Changeable"
+      And I check "Unrevealed"
+      And I submit
+    Then "creator" should be emailed
+      And the email should have "Your work has become unrevealed" in the subject
+      And the email should contain "Unrevealed works are not included in tag listings or on your works page."
+      And the email should not contain "translation missing"
+
+  Scenario: Changing a collection item to anonymous and unrevealed triggers a notification
+    Given a collection "Changeable"
+      And I am logged in as "creator"
+      And I post the work "Lovely" in the collection "Changeable"
+      And all emails have been delivered
+
+    When I am logged in as the owner of "Changeable"
+      And I go to "Changeable" collection edit page
+      And I check "This collection is anonymous"
+      And I check "This collection is unrevealed"
+      And I press "Update"
+      And I view the approved collection items page for "Changeable"
+      And I check "Anonymous"
+      And I check "Unrevealed"
+      And I submit
+    Then "creator" should be emailed
+      And the email should have "Your work has become anonymous and unrevealed" in the subject
+      And the email should contain "Anonymous works are included in tag listings, but not on your works page."
+      And the email should contain "Unrevealed works are not included in tag listings or on your works page."
+      And the email should not contain "translation missing"

--- a/public/help/collection-preferences.html
+++ b/public/help/collection-preferences.html
@@ -6,7 +6,7 @@
   <dd>By default, if another user adds your work to a collection, you will be asked to confirm whether you are willing for your work to be displayed as part of that collection. If you'd like people to be able to add your work to collections without waiting for confirmation from you, enable this option.</dd>
   
   <dt>Turn off emails from collections</dt>
-  <dd>Enable this option if you would prefer not to receive email alerts from collections, for example, notifying you when hidden works are revealed. Notifications will still be delivered to your Archive inbox unless you have chosen to disable them.</dd>
+  <dd>Enable this option if you would prefer not to receive email alerts from collections, such as creator and work reveals. We’ll still email you if your username or work is hidden after being added to a collection. Notifications will still be delivered to your Archive inbox unless you have chosen to disable them.</dd>
   
   <dt>Turn off inbox messages from collections</dt>
   <dd>Enable this option if you would prefer not to receive notifications in your Archive inbox from collections, for example, notifying you when hidden works are revealed. Notifications will still be emailed to you unless you have chosen to disable them.</dd>

--- a/public/help/collection-preferences.html
+++ b/public/help/collection-preferences.html
@@ -6,7 +6,7 @@
   <dd>By default, if another user adds your work to a collection, you will be asked to confirm whether you are willing for your work to be displayed as part of that collection. If you'd like people to be able to add your work to collections without waiting for confirmation from you, enable this option.</dd>
   
   <dt>Turn off emails from collections</dt>
-  <dd>Enable this option if you would prefer not to receive email alerts from collections, such as creator and work reveals. We’ll still email you if your username or work is hidden after being added to a collection. Notifications will still be delivered to your Archive inbox unless you have chosen to disable them.</dd>
+  <dd>Enable this option if you would prefer not to receive email alerts when your works are added or invited to collections.</dd>
   
   <dt>Turn off inbox messages from collections</dt>
   <dd>Enable this option if you would prefer not to receive notifications in your Archive inbox from collections, for example, notifying you when hidden works are revealed. Notifications will still be emailed to you unless you have chosen to disable them.</dd>


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5028

## Purpose

This PR adds a new callback to the CollectionItem class that checks whether the maintainer is making the item unrevealed/anonymous when the work isn't already unrevealed/anonymous. If so, the callback sends a notification email to all of the work's creators.

## Testing Instructions

See JIRA.