### PR TITLE
AO3-5233 Remove Not Found heading in bulk admin search

### DIFF
--- a/app/views/admin/admin_users/bulk_search.html.erb
+++ b/app/views/admin/admin_users/bulk_search.html.erb
@@ -34,7 +34,7 @@
     <p><%= ts("#{pluralize(@results[:total], "email")} entered. #{@results[:searched]} searched. " + 
               "#{@results[:found_users].size} found. #{@results[:not_found_emails].size} not found. #{pluralize(@results[:duplicates], "duplicate")}.") %></p>
 
-    <% if @results[:not_found_emails] %>
+    <% if @results[:not_found_emails]&.any? %>
       <h3 class="heading"><%= ts("Not found") %></h3>
       <p><%= @results[:not_found_emails].join(", ") %></p>
     <% end %>

--- a/features/admins/users/admin_find_users.feature
+++ b/features/admins/users/admin_find_users.feature
@@ -71,6 +71,7 @@ Feature: Admin Find Users page
     Then I should see "userB"
       And I should see "userA"
       But I should not see "userCB"
+      And I should not see "Not found"
 
   Scenario: The Bulk Email Search page should list emails found, not found and duplicates
     When I go to the Bulk Email Search page
@@ -85,6 +86,7 @@ Feature: Admin Find Users page
     Then I should see "2 found"
       And I should see "1 not found"
       And I should see "1 duplicate"
+      And I should see "Not found"
 
   Scenario: The Bulk Email Search page should find an exact match
     When I go to the Bulk Email Search page
@@ -93,6 +95,7 @@ Feature: Admin Find Users page
     Then I should see "userB"
       But I should not see "userA"
       And I should not see "userCB"
+      And I should not see "Not found"
 
    Scenario: Admins can download a CSV of found emails
      When I go to the Bulk Email Search page


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5233

## Purpose

Remove the Not Found header when there are no emails found during a bulk email admin search

## Testing Instructions

Search for email addresses that are all found and hopefully observe that there is no Not Founder heading randomly appearing on the page

