### PR TITLE
AO3-5737 Put border on right side for RTL blockquotes

### DIFF
--- a/public/stylesheets/site/2.0/21-userstuff.css
+++ b/public/stylesheets/site/2.0/21-userstuff.css
@@ -123,31 +123,9 @@
 /* quotes and stresses */
 
 .userstuff blockquote {
-  border-width: 0;
-  border-color: #999;
-  border-style: solid;
-  margin: auto;
+  margin-inline-start: 1.5em;
   padding: 0.75em;
-  border-left-width: 2px;
-  margin-left: 1.5em;
-}
-
-.userstuff[dir="rtl"] blockquote,
-.userstuff [dir="rtl"] blockquote,
-.userstuff blockquote[dir="rtl"] {
-  border-left-width: inherit;
-  border-right-width: 2px;
-  margin-right: 1.5em;
-  margin-left: unset;
-}
-
-.userstuff [dir="ltr"] blockquote,
-.userstuff blockquote[dir="ltr"] {
-  border-left-width: 2px;
-  border-right-width: inherit;
-  margin-right: unset;
-  margin-left: 1.5em;
-  text-align: left;
+  border-inline-start: 2px solid #999;
 }
 
 .userstuff blockquote blockquote {

--- a/public/stylesheets/site/2.0/21-userstuff.css
+++ b/public/stylesheets/site/2.0/21-userstuff.css
@@ -133,6 +133,13 @@
   border: 0;
 }
 
+.userstuff[dir="rtl"] blockquote:not([dir="ltr"]),
+.userstuff blockquote[dir="rtl"] {
+  margin: auto 1.5em auto auto;
+  border-left: none;
+  border-right: 2px solid #999;
+}
+
 .userstuff hr {
   width: 33%;
   margin: 0.875em auto 1.2525em auto;

--- a/public/stylesheets/site/2.0/21-userstuff.css
+++ b/public/stylesheets/site/2.0/21-userstuff.css
@@ -123,28 +123,36 @@
 /* quotes and stresses */
 
 .userstuff blockquote {
-  margin: auto auto auto 1.5em;
+  border-width: 0;
+  border-color: #999;
+  border-style: solid;
+  margin: auto;
   padding: 0.75em;
-  border-left: 2px solid #999;
+  border-left-width: 2px;
+  margin-left: 1.5em;
 }
 
+.userstuff[dir="rtl"] blockquote,
+.userstuff [dir="rtl"] blockquote,
+.userstuff blockquote[dir="rtl"] {
+  border-left-width: inherit;
+  border-right-width: 2px;
+  margin-right: 1.5em;
+  margin-left: unset;
+}
+
+.userstuff [dir="ltr"] blockquote,
 .userstuff blockquote[dir="ltr"] {
+  border-left-width: 2px;
+  border-right-width: inherit;
+  margin-right: unset;
+  margin-left: 1.5em;
   text-align: left;
 }
 
-.userstuff blockquote blockquote,
-.userstuff blockquote blockquote[dir="rtl"] {
+.userstuff blockquote blockquote {
   padding: 0.25em;
   border: 0;
-}
-
-.userstuff[dir="rtl"] blockquote:not([dir="ltr"]),
-.userstuff [dir="rtl"] blockquote:not([dir="ltr"]),
-.userstuff blockquote[dir="rtl"] {
-  margin: auto 1.5em auto auto;
-  border-left: none;
-  border-right: 2px solid #999;
-  text-align: right;
 }
 
 .userstuff hr {

--- a/public/stylesheets/site/2.0/21-userstuff.css
+++ b/public/stylesheets/site/2.0/21-userstuff.css
@@ -128,16 +128,23 @@
   border-left: 2px solid #999;
 }
 
-.userstuff blockquote blockquote {
+.userstuff blockquote[dir="ltr"] {
+  text-align: left;
+}
+
+.userstuff blockquote blockquote,
+.userstuff blockquote blockquote[dir="rtl"] {
   padding: 0.25em;
   border: 0;
 }
 
 .userstuff[dir="rtl"] blockquote:not([dir="ltr"]),
+.userstuff [dir="rtl"] blockquote:not([dir="ltr"]),
 .userstuff blockquote[dir="rtl"] {
   margin: auto 1.5em auto auto;
   border-left: none;
   border-right: 2px solid #999;
+  text-align: right;
 }
 
 .userstuff hr {


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5737

## Purpose

This PR moves the border and margin to the right for `blockquote` elements either with or inheriting the `dir="rtl"` attribute. The addition to the stylesheet is exactly the same as written in the Jira issue. Here is a comparison using [this news post](https://archiveofourown.org/admin_posts/13531) (with the HTML edited to add the `dir="rtl"` attribute to the blockquote):

Without the fix:

![Screenshot_2020-01-27 ארכיון משלנו זכה בפרס הוגו לשנת 2019 עבור היצירה הקשורה הטובה ביותר Archive of Our Own](https://user-images.githubusercontent.com/26982181/73175404-62208c00-410a-11ea-94bd-0f106e1254dc.png)

With the fix:

![Screenshot_2020-01-27 ארכיון משלנו זכה בפרס הוגו לשנת 2019 עבור היצירה הקשורה הטובה ביותר Archive of Our Own(1)](https://user-images.githubusercontent.com/26982181/73175415-68af0380-410a-11ea-87b0-1eaa0cc16fa7.png)

## Testing Instructions

See testing instructions on the Jira ticket.

## References

[AO3-5735](https://otwarchive.atlassian.net/browse/AO3-5735), once done and deployed, should mean admin posts in a RTL language wouldn't have to be edited to add the `dir="rtl"` attribute to all blockquote elements.

## Credit

Alix R, she/her