### PR TITLE
AO3-5863 Add new Devise info to GDPR script

### DIFF
--- a/script/get_user_data.rb
+++ b/script/get_user_data.rb
@@ -66,9 +66,11 @@ u.works.pluck(:ip_address)&.map { |ip| ips << ip unless ip.blank? }
 user_agents = []
 u.comments.pluck(:user_agent)&.map { |ua| user_agents << ua unless ua.blank? }
 
+
 # Lists of IP addresses and previous email addresses and usernames
 # Actions that are or may be taken by admins are excluded to avoid revealing
 # admins' IP addresses
+# We migrated to Devise on 27 December, 2018
 previous_usernames = []
 previous_emails = []
 audits = u.audits.pluck(:action, :audited_changes, :remote_address)
@@ -85,23 +87,51 @@ audits.map do |audit|
       case k
       when "accepted_tos_version"
         ips << ip unless ip.blank?
+      # Activated account, pre-Devise
+      when "activated_at"
+        ips << ip unless ip.blank?
+      # Confirmed account creation, post-Devise
+      when "confirmed_at"
+        ips << ip unless ip.blank?
       # Changed email address
       when "email"
         ips << ip unless ip.blank?
         previous_emails << v[0] unless v[0].blank?
+      # Changed password, post-Devise
+      when "encrypted_password"
+        ips << ip unless ip.blank?
+      # Failed login attempt, post-Devise
+      # This is currently only recorded after a password reset or after the
+      # account is locked and unlocked
+      when "failed_attempts"
+        ips << ip unless ip.blank?
+      # Failed login attempt, pre-Devise
       when "failed_login_count"
+        ips << ip unless ip.blank?
+      # Failed login attempt that resulted in account being locked, post-Devise
+      when "locked_at"
         ips << ip unless ip.blank?
       # Changed username
       when "login"
         ips << ip unless ip.blank?
         previous_usernames << v[0] unless v[0].blank?
-      # Requested password reset email
+      # Requested password reset email, pre-Devise
       when "recently_reset"
+        ips << ip unless ip.blank?
+      # Submitted login form with "Remember me" checked, post-Devise
+      # This is recorded whether the login attempt was successful or not
+      when "remember_created_at"
+        ips << ip unless ip.blank?
+      # Requested password reset email, post-Devise
+      when "reset_password_sent_at"
+        ips << ip unless ip.blank?
+      # Logged in, post-Devise
+      when "sign_in_count"
         ips << ip unless ip.blank?
       end
     end
-  end
-end
+   end
+ end
 
 
 puts "Data for #{u.login} (#{u.email})"

--- a/script/get_user_data.rb
+++ b/script/get_user_data.rb
@@ -103,105 +103,89 @@ audits.map do |audit|
   end
 end
 
-# Date formatted as 20071110 that we'll use in the filename
-todays_date = Date.today.to_formatted_s(:number)
 
-filename_and_path = "/tmp/user_data_for_#{u.login}_#{todays_date}.txt"
-
-open(filename_and_path, "w") do |f|
-  f.puts "Data for #{u.login} (#{u.email})"
-  unless previous_usernames.empty?
-    f.puts
-    f.puts "Previous Usernames: #{previous_usernames.to_sentence}"
-  end
-  unless previous_emails.empty?
-    f.puts
-    f.puts "Previous Email Addresses: #{previous_emails.to_sentence}"
-  end
-  unless ips.empty?
-    f.puts
-    f.puts "IP Addresses:"
-    ips.uniq.map do |ip|
-      f.puts "  #{ip}"
-    end
-  end
-  unless user_agents.empty?
-    f.puts
-    f.puts "User Agents:"
-    user_agents.uniq.map do |user_agent|
-      f.puts "  #{user_agent}"
-    end
-  end
-  if u.fannish_next_of_kin || !next_of_kin_for.empty?
-    f.puts
-    f.puts "Fannish Next of Kin: #{next_of_kin}" if u.fannish_next_of_kin
-    f.puts "Fannish Next of Kin For: #{next_of_kin_for.to_sentence}" unless next_of_kin_for.empty?
-  end
-  f.puts
-  f.puts "Pseuds: #{user_pseuds_url(u)}"
-  f.puts "Profile: #{user_profile_url(u)}"
-  f.puts "Preferences: #{user_preferences_url(u)}"
-  f.puts
-  f.puts "Works: #{user_works_url(u)}"
-  f.puts "Drafts: #{drafts_user_works_url(u)}"
-  f.puts "Series: #{user_series_index_url(u)}"
-  f.puts "Bookmarks: #{user_bookmarks_url(u)}"
-  f.puts
-  f.puts "Collections: #{user_collections_url(u)}"
-  unless collection_roles.empty?
-    f.puts "Collection Roles: "
-    collection_roles.map do |role|
-      f.puts "  #{role}"
-    end
-  end
-  f.puts
-  f.puts "Tag Sets: #{user_tag_sets_url(u)}"
-  unless tag_set_nomination_urls.empty?
-    f.puts "Tag Set Nominations: "
-    tag_set_nomination_urls.map do |url|
-      f.puts "  #{url}"
-    end
-  end
-  f.puts
-  f.puts "Challenge Sign-ups: #{user_signups_url(u)}"
-  f.puts "Gift Exchange Assignments: #{user_assignments_url(u)}"
-  f.puts "Prompt Meme Claims: #{user_claims_url(u)}"
-  f.puts
-  f.puts "History and Marked for Later: #{user_readings_url(u)}"
-  f.puts "Subscriptions: #{user_subscriptions_url(u)}"
-  f.puts
-  f.puts "Gifts: #{user_gifts_url(u)}"
-  f.puts "Related Works: #{user_related_works_url(u)}"
-  f.puts
-  f.puts "Skins: #{user_skins_url(u)}"
-  f.puts
-  f.puts "Invitations: #{user_invitations_url(u)}"
-  unless favorite_tags.empty?
-    f.puts
-    f.puts "Favorite Tags: #{favorite_tags.to_sentence}"
-  end
-  unless comment_urls.empty?
-    f.puts
-    f.puts "Comments Left: "
-    comment_urls.map do |url|
-      f.puts "  #{url}"
-    end
-  end
-  unless kudosed_item_urls.empty?
-    f.puts
-    f.puts "Kudos Given To: "
-    kudosed_item_urls.map do |url|
-      f.puts "  #{url}"
-    end
+puts "Data for #{u.login} (#{u.email})"
+unless previous_usernames.empty?
+  puts
+  puts "Previous Usernames: #{previous_usernames.to_sentence}"
+end
+unless previous_emails.empty?
+  puts
+  puts "Previous Email Addresses: #{previous_emails.to_sentence}"
+end
+unless ips.empty?
+  puts
+  puts "IP Addresses:"
+  ips.uniq.map do |ip|
+    puts "  #{ip}"
   end
 end
-
-puts "User data has been written to #{filename_and_path}"
+unless user_agents.empty?
+  puts
+  puts "User Agents:"
+  user_agents.uniq.map do |user_agent|
+    puts "  #{user_agent}"
+  end
+end
+if u.fannish_next_of_kin || !next_of_kin_for.empty?
+  puts
+  puts "Fannish Next of Kin: #{next_of_kin}" if u.fannish_next_of_kin
+  puts "Fannish Next of Kin For: #{next_of_kin_for.to_sentence}" unless next_of_kin_for.empty?
+end
 puts
-puts "*************************************************"
-puts "*                                               *"
-puts "* DELETE FILE AS SOON AS YOU HAVE DOWNLOADED IT *"
-puts "*                                               *"
-puts "*************************************************"
+puts "Pseuds: #{user_pseuds_url(u)}"
+puts "Profile: #{user_profile_url(u)}"
+puts "Preferences: #{user_preferences_url(u)}"
 puts
-puts "How to delete: File.delete(\"#{filename_and_path}\")"
+puts "Works: #{user_works_url(u)}"
+puts "Drafts: #{drafts_user_works_url(u)}"
+puts "Series: #{user_series_index_url(u)}"
+puts "Bookmarks: #{user_bookmarks_url(u)}"
+puts
+puts "Collections: #{user_collections_url(u)}"
+unless collection_roles.empty?
+  puts "Collection Roles: "
+  collection_roles.map do |role|
+    puts "  #{role}"
+  end
+end
+puts
+puts "Tag Sets: #{user_tag_sets_url(u)}"
+unless tag_set_nomination_urls.empty?
+  puts "Tag Set Nominations: "
+  tag_set_nomination_urls.map do |url|
+    puts "  #{url}"
+  end
+end
+puts
+puts "Challenge Sign-ups: #{user_signups_url(u)}"
+puts "Gift Exchange Assignments: #{user_assignments_url(u)}"
+puts "Prompt Meme Claims: #{user_claims_url(u)}"
+puts
+puts "History and Marked for Later: #{user_readings_url(u)}"
+puts "Subscriptions: #{user_subscriptions_url(u)}"
+puts
+puts "Gifts: #{user_gifts_url(u)}"
+puts "Related Works: #{user_related_works_url(u)}"
+puts
+puts "Skins: #{user_skins_url(u)}"
+puts
+puts "Invitations: #{user_invitations_url(u)}"
+unless favorite_tags.empty?
+  puts
+  puts "Favorite Tags: #{favorite_tags.to_sentence}"
+end
+unless comment_urls.empty?
+  puts
+  puts "Comments Left: "
+  comment_urls.map do |url|
+    puts "  #{url}"
+  end
+end
+unless kudosed_item_urls.empty?
+  puts
+  puts "Kudos Given To: "
+  kudosed_item_urls.map do |url|
+    puts "  #{url}"
+  end
+end

--- a/script/get_user_data.rb
+++ b/script/get_user_data.rb
@@ -66,7 +66,6 @@ u.works.pluck(:ip_address)&.map { |ip| ips << ip unless ip.blank? }
 user_agents = []
 u.comments.pluck(:user_agent)&.map { |ua| user_agents << ua unless ua.blank? }
 
-
 # Lists of IP addresses and previous email addresses and usernames
 # Actions that are or may be taken by admins are excluded to avoid revealing
 # admins' IP addresses
@@ -130,8 +129,8 @@ audits.map do |audit|
         ips << ip unless ip.blank?
       end
     end
-   end
- end
+  end
+end
 
 
 puts "Data for #{u.login} (#{u.email})"

--- a/script/get_user_data.rb
+++ b/script/get_user_data.rb
@@ -67,8 +67,8 @@ user_agents = []
 u.comments.pluck(:user_agent)&.map { |ua| user_agents << ua unless ua.blank? }
 
 # Lists of IP addresses and previous email addresses and usernames
-# Actions that are or may be taken by admins are excluded to avoid revealing
-# admins' IP addresses
+# Actions that are or may be taken by admins, e.g. account activation, are
+# excluded to avoid revealing admins' IP addresses
 # We migrated to Devise on 27 December, 2018
 previous_usernames = []
 previous_emails = []
@@ -85,12 +85,6 @@ audits.map do |audit|
     changes.each do |k, v|
       case k
       when "accepted_tos_version"
-        ips << ip unless ip.blank?
-      # Activated account, pre-Devise
-      when "activated_at"
-        ips << ip unless ip.blank?
-      # Confirmed account creation, post-Devise
-      when "confirmed_at"
         ips << ip unless ip.blank?
       # Changed email address
       when "email"


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5863

## Purpose

When we updated to Devise, we started auditing IP addresses for some new things, or the names of the things we were already auditing changed. This updates the GDPR user data script in light of that.

- Add encrypted_password case to handle IPs recorded when someone changes their password.
- Add failed_attempts case to handle recorded IPs from failed login attempts, which are currently only logged in certain cases due to the way Devise updates the count of failed attempts.
- Add locked_at case to handle recorded IPs from the last failed login attempt before an account is locked due to too many login attempts.
- Clarify that the recently_reset case is from before the Devise change, and add a reset_password_sent_at case to handle IPs recorded for password reset requests now that we're using Devise.
- Add sign_in_count case to handle IPs recorded when someone successfully signs in to an account.

## Testing Instructions

Refer to Jira.

## References

Includes #3744 