### PR TITLE
AO3-5316 Fix flash messages in UsersController#activate.

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -110,7 +110,7 @@ class UsersController < ApplicationController
   def activate
     if params[:id].blank?
       flash[:error] = ts('Your activation key is missing.')
-      redirect_to ''
+      redirect_to root_path
 
       return
     end
@@ -119,13 +119,13 @@ class UsersController < ApplicationController
 
     unless @user
       flash[:error] = ts("Your activation key is invalid. If you didn't activate within 14 days, your account was deleted. Please sign up again, or contact support via the link in our footer for more help.").html_safe
-      redirect_to ''
+      redirect_to root_path
 
       return
     end
 
     if @user.active?
-      flash.now[:error] = ts('Your account has already been activated.')
+      flash[:error] = ts("Your account has already been activated.")
       redirect_to @user
 
       return
@@ -133,7 +133,7 @@ class UsersController < ApplicationController
 
     @user.activate
 
-    flash[:notice] = ts('Signup complete! Please log in.')
+    flash[:notice] = ts("Account activation complete! Please log in.")
 
     @user.create_log_item(action: ArchiveConfig.ACTION_ACTIVATE)
 

--- a/features/other_a/invite_queue.feature
+++ b/features/other_a/invite_queue.feature
@@ -139,6 +139,9 @@ Feature: Invite queue management
     # user activates account
     When all emails have been delivered
       And I click the first link in the email
+    Then I should be on the login page
+      And I should see "Account activation complete! Please log in."
+
     When I am logged in as "newuser" with password "password1"
     Then I should see "Successfully logged in."
 

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -1,0 +1,42 @@
+require "spec_helper"
+
+describe UsersController do
+  include RedirectExpectationHelper
+
+  describe "GET #activate" do
+    let(:user) { create(:user, confirmed_at: nil) }
+
+    context "with no activation key" do
+      it "redirects with an error" do
+        get :activate, params: { id: "" }
+        it_redirects_to_with_error(root_path, "Your activation key is missing.")
+      end
+    end
+
+    context "with an invalid activation key" do
+      it "redirects with an error" do
+        get :activate, params: { id: "foobar" }
+        it_redirects_to_with_error(root_path, "Your activation key is invalid. If you didn't activate within 14 days, your account was deleted. Please sign up again, or contact support via the link in our footer for more help.")
+      end
+    end
+
+    context "with a used activation key" do
+      before { user.activate }
+
+      it "redirects with an error" do
+        expect(user.active?).to be_truthy
+        get :activate, params: { id: user.confirmation_token }
+        it_redirects_to_with_error(user_path(user), "Your account has already been activated.")
+      end
+    end
+
+    context "with a valid activation key" do
+      it "activates the account and redirects with a success message" do
+        expect(user.active?).to be_falsey
+        get :activate, params: { id: user.confirmation_token }
+        expect(user.reload.active?).to be_truthy
+        it_redirects_to_with_notice(new_user_session_path, "Account activation complete! Please log in.")
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5316

## Purpose

- Change the message when activating a user account from "Signup complete! Please log in." to "Account activation complete! Please log in."
- Change the error message when activating an account that has already been activated to use `flash` instead of `flash.now`, so that the error message will show up after redirect.
- Change the other two errors in the `UsersController#activate` to redirect to `root_path` instead of a blank string. This doesn't actually change where it redirects to, but it makes the code a little clearer.
- Add a few new specs to increase coverage of the `activate` action.

## Testing Instructions

See JIRA.

(Though I'm not sure whether the nginx changes have been applied to staging. If they haven't, that may need to be addressed before any of these flash messages can appear.)