### PR TITLE
AO3-5869 Modify the kudos table to make the ID a bigint, and add unique indices.

### DIFF
--- a/db/migrate/20200210013551_add_unique_indices_to_kudos_and_change_id_type.rb
+++ b/db/migrate/20200210013551_add_unique_indices_to_kudos_and_change_id_type.rb
@@ -3,30 +3,30 @@ class AddUniqueIndicesToKudosAndChangeIdType < ActiveRecord::Migration[5.1]
     if Rails.env.staging? || Rails.env.production?
       database = Kudo.connection.current_database
 
-      puts <<-PTOSC
-Schema Change Command:
+      puts <<~PTOSC
+        Schema Change Command:
 
-pt-online-schema-change D=#{database},t=kudos \\
-  --alter "ADD UNIQUE INDEX index_kudos_on_commentable_and_user (commentable_id, commentable_type, user_id),
-           ADD UNIQUE INDEX index_kudos_on_commentable_and_ip_address (commentable_id, commentable_type, ip_address),
-           CHANGE COLUMN id id bigint NOT NULL AUTO_INCREMENT" \\
-  --no-swap-tables --no-drop-new-table --no-drop-triggers --no-check-unique-key-change \\
-  -uroot --chunk-size=10k --max-flow-ctl 0 --pause-file /tmp/pauseme \\
-  --max-load Threads_running=25 --critical-load Threads_running=400 \\
-  --set-vars innodb_lock_wait_timeout=2 --alter-foreign-keys-method=auto \\
-  --execute
+        pt-online-schema-change D=#{database},t=kudos \\
+          --alter "ADD UNIQUE INDEX index_kudos_on_commentable_and_user (commentable_id, commentable_type, user_id),
+                   ADD UNIQUE INDEX index_kudos_on_commentable_and_ip_address (commentable_id, commentable_type, ip_address),
+                   CHANGE COLUMN id id bigint NOT NULL AUTO_INCREMENT" \\
+          --no-swap-tables --no-drop-new-table --no-drop-triggers --no-check-unique-key-change \\
+          -uroot --chunk-size=10k --max-flow-ctl 0 --pause-file /tmp/pauseme \\
+          --max-load Threads_running=25 --critical-load Threads_running=400 \\
+          --set-vars innodb_lock_wait_timeout=2 --alter-foreign-keys-method=auto \\
+          --execute
 
-Table Swap and Cleanup Commands:
+        Table Swap and Cleanup Commands:
 
-RENAME TABLE
-  `#{database}`.`kudos` TO `#{database}`.`_kudos_old`,
-  `#{database}`.`_kudos_new` TO `#{database}`.`kudos`;
+        RENAME TABLE
+          `#{database}`.`kudos` TO `#{database}`.`_kudos_old`,
+          `#{database}`.`_kudos_new` TO `#{database}`.`kudos`;
 
-DROP TRIGGER IF EXISTS `#{database}`.`pt_osc_#{database}_kudos_del`;
-DROP TRIGGER IF EXISTS `#{database}`.`pt_osc_#{database}_kudos_ins`;
-DROP TRIGGER IF EXISTS `#{database}`.`pt_osc_#{database}_kudos_upd`;
+        DROP TRIGGER IF EXISTS `#{database}`.`pt_osc_#{database}_kudos_del`;
+        DROP TRIGGER IF EXISTS `#{database}`.`pt_osc_#{database}_kudos_ins`;
+        DROP TRIGGER IF EXISTS `#{database}`.`pt_osc_#{database}_kudos_upd`;
 
-DROP TABLE IF EXISTS `#{database}`.`_kudos_old`;
+        DROP TABLE IF EXISTS `#{database}`.`_kudos_old`;
       PTOSC
     else
       add_index :kudos, [:commentable_id, :commentable_type, :user_id],
@@ -42,30 +42,30 @@ DROP TABLE IF EXISTS `#{database}`.`_kudos_old`;
     if Rails.env.staging? || Rails.env.production?
       database = Kudo.connection.current_database
 
-      puts <<-PTOSC
-Schema Change Command:
+      puts <<~PTOSC
+        Schema Change Command:
 
-pt-online-schema-change D=#{database},t=kudos \\
-  --alter "DROP INDEX index_kudos_on_commentable_and_user,
-           DROP INDEX index_kudos_on_commentable_and_ip_address,
-           CHANGE COLUMN id id int NOT NULL AUTO_INCREMENT" \\
-  --no-swap-tables --no-drop-new-table --no-drop-triggers \\
-  -uroot --chunk-size=10k --max-flow-ctl 0 --pause-file /tmp/pauseme \\
-  --max-load Threads_running=25 --critical-load Threads_running=400 \\
-  --set-vars innodb_lock_wait_timeout=2 --alter-foreign-keys-method=auto \\
-  --execute
+        pt-online-schema-change D=#{database},t=kudos \\
+          --alter "DROP INDEX index_kudos_on_commentable_and_user,
+                   DROP INDEX index_kudos_on_commentable_and_ip_address,
+                   CHANGE COLUMN id id int NOT NULL AUTO_INCREMENT" \\
+          --no-swap-tables --no-drop-new-table --no-drop-triggers \\
+          -uroot --chunk-size=10k --max-flow-ctl 0 --pause-file /tmp/pauseme \\
+          --max-load Threads_running=25 --critical-load Threads_running=400 \\
+          --set-vars innodb_lock_wait_timeout=2 --alter-foreign-keys-method=auto \\
+          --execute
 
-Table Swap and Cleanup Commands:
+        Table Swap and Cleanup Commands:
 
-RENAME TABLE
-  `#{database}`.`kudos` TO `#{database}`.`_kudos_old`,
-  `#{database}`.`_kudos_new` TO `#{database}`.`kudos`;
+        RENAME TABLE
+          `#{database}`.`kudos` TO `#{database}`.`_kudos_old`,
+          `#{database}`.`_kudos_new` TO `#{database}`.`kudos`;
 
-DROP TRIGGER IF EXISTS `#{database}`.`pt_osc_#{database}_kudos_del`;
-DROP TRIGGER IF EXISTS `#{database}`.`pt_osc_#{database}_kudos_ins`;
-DROP TRIGGER IF EXISTS `#{database}`.`pt_osc_#{database}_kudos_upd`;
+        DROP TRIGGER IF EXISTS `#{database}`.`pt_osc_#{database}_kudos_del`;
+        DROP TRIGGER IF EXISTS `#{database}`.`pt_osc_#{database}_kudos_ins`;
+        DROP TRIGGER IF EXISTS `#{database}`.`pt_osc_#{database}_kudos_upd`;
 
-DROP TABLE IF EXISTS `#{database}`.`_kudos_old`;
+        DROP TABLE IF EXISTS `#{database}`.`_kudos_old`;
       PTOSC
     else
       remove_index :kudos, name: "index_kudos_on_commentable_and_user"

--- a/db/migrate/20200210013551_add_unique_indices_to_kudos_and_change_id_type.rb
+++ b/db/migrate/20200210013551_add_unique_indices_to_kudos_and_change_id_type.rb
@@ -1,0 +1,77 @@
+class AddUniqueIndicesToKudosAndChangeIdType < ActiveRecord::Migration[5.1]
+  def up
+    if Rails.env.staging? || Rails.env.production?
+      database = Kudo.connection.current_database
+
+      puts <<-PTOSC
+Schema Change Command:
+
+pt-online-schema-change D=#{database},t=kudos \\
+  --alter "ADD UNIQUE INDEX index_kudos_on_commentable_and_user (commentable_id, commentable_type, user_id),
+           ADD UNIQUE INDEX index_kudos_on_commentable_and_ip_address (commentable_id, commentable_type, ip_address),
+           CHANGE COLUMN id id bigint NOT NULL AUTO_INCREMENT" \\
+  --no-swap-tables --no-drop-new-table --no-drop-triggers --no-check-unique-key-change \\
+  -uroot --chunk-size=10k --max-flow-ctl 0 --pause-file /tmp/pauseme \\
+  --max-load Threads_running=25 --critical-load Threads_running=400 \\
+  --set-vars innodb_lock_wait_timeout=2 --alter-foreign-keys-method=auto \\
+  --execute
+
+Table Swap and Cleanup Commands:
+
+RENAME TABLE
+  `#{database}`.`kudos` TO `#{database}`.`_kudos_old`,
+  `#{database}`.`_kudos_new` TO `#{database}`.`kudos`;
+
+DROP TRIGGER IF EXISTS `#{database}`.`pt_osc_#{database}_kudos_del`;
+DROP TRIGGER IF EXISTS `#{database}`.`pt_osc_#{database}_kudos_ins`;
+DROP TRIGGER IF EXISTS `#{database}`.`pt_osc_#{database}_kudos_upd`;
+
+DROP TABLE IF EXISTS `#{database}`.`_kudos_old`;
+      PTOSC
+    else
+      add_index :kudos, [:commentable_id, :commentable_type, :user_id],
+                unique: true, name: "index_kudos_on_commentable_and_user"
+      add_index :kudos, [:commentable_id, :commentable_type, :ip_address],
+                unique: true, name: "index_kudos_on_commentable_and_ip_address"
+
+      change_column :kudos, :id, "bigint AUTO_INCREMENT"
+    end
+  end
+
+  def down
+    if Rails.env.staging? || Rails.env.production?
+      database = Kudo.connection.current_database
+
+      puts <<-PTOSC
+Schema Change Command:
+
+pt-online-schema-change D=#{database},t=kudos \\
+  --alter "DROP INDEX index_kudos_on_commentable_and_user,
+           DROP INDEX index_kudos_on_commentable_and_ip_address,
+           CHANGE COLUMN id id int NOT NULL AUTO_INCREMENT" \\
+  --no-swap-tables --no-drop-new-table --no-drop-triggers \\
+  -uroot --chunk-size=10k --max-flow-ctl 0 --pause-file /tmp/pauseme \\
+  --max-load Threads_running=25 --critical-load Threads_running=400 \\
+  --set-vars innodb_lock_wait_timeout=2 --alter-foreign-keys-method=auto \\
+  --execute
+
+Table Swap and Cleanup Commands:
+
+RENAME TABLE
+  `#{database}`.`kudos` TO `#{database}`.`_kudos_old`,
+  `#{database}`.`_kudos_new` TO `#{database}`.`kudos`;
+
+DROP TRIGGER IF EXISTS `#{database}`.`pt_osc_#{database}_kudos_del`;
+DROP TRIGGER IF EXISTS `#{database}`.`pt_osc_#{database}_kudos_ins`;
+DROP TRIGGER IF EXISTS `#{database}`.`pt_osc_#{database}_kudos_upd`;
+
+DROP TABLE IF EXISTS `#{database}`.`_kudos_old`;
+      PTOSC
+    else
+      remove_index :kudos, name: "index_kudos_on_commentable_and_user"
+      remove_index :kudos, name: "index_kudos_on_commentable_and_ip_address"
+
+      change_column :kudos, :id, "int AUTO_INCREMENT"
+    end
+  end
+end

--- a/db/migrate/20200210013551_add_unique_indices_to_kudos_and_change_id_type.rb
+++ b/db/migrate/20200210013551_add_unique_indices_to_kudos_and_change_id_type.rb
@@ -11,7 +11,7 @@ class AddUniqueIndicesToKudosAndChangeIdType < ActiveRecord::Migration[5.1]
                    ADD UNIQUE INDEX index_kudos_on_commentable_and_ip_address (commentable_id, commentable_type, ip_address),
                    CHANGE COLUMN id id bigint NOT NULL AUTO_INCREMENT" \\
           --no-swap-tables --no-drop-new-table --no-drop-triggers --no-check-unique-key-change \\
-          -uroot --chunk-size=10k --max-flow-ctl 0 --pause-file /tmp/pauseme \\
+          -uroot --ask-pass --chunk-size=10k --max-flow-ctl 0 --pause-file /tmp/pauseme \\
           --max-load Threads_running=25 --critical-load Threads_running=400 \\
           --set-vars innodb_lock_wait_timeout=2 --alter-foreign-keys-method=auto \\
           --execute
@@ -50,7 +50,7 @@ class AddUniqueIndicesToKudosAndChangeIdType < ActiveRecord::Migration[5.1]
                    DROP INDEX index_kudos_on_commentable_and_ip_address,
                    CHANGE COLUMN id id int NOT NULL AUTO_INCREMENT" \\
           --no-swap-tables --no-drop-new-table --no-drop-triggers \\
-          -uroot --chunk-size=10k --max-flow-ctl 0 --pause-file /tmp/pauseme \\
+          -uroot --ask-pass --chunk-size=10k --max-flow-ctl 0 --pause-file /tmp/pauseme \\
           --max-load Threads_running=25 --critical-load Threads_running=400 \\
           --set-vars innodb_lock_wait_timeout=2 --alter-foreign-keys-method=auto \\
           --execute


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5869

## Purpose

This PR performs three modifications to the kudos table:
- change the type of the primary key to `bigint`
- add a unique index on `commentable_id, commentable_type, user_id`
- add a unique index on `commentable_id, commentable_type, ip_address`

It's currently written so that instead of performing the changes on staging or production, it prints out the commands that need to be run (with the database name filled in using info from Rails). The output should look something like this:
```
== 20200210013551 AddUniqueIndicesToKudosAndChangeIdType: migrating ===========
Schema Change Command:

pt-online-schema-change D=ao3_test,t=kudos \
  --alter "ADD UNIQUE INDEX index_kudos_on_commentable_and_user (commentable_id, commentable_type, user_id),
           ADD UNIQUE INDEX index_kudos_on_commentable_and_ip_address (commentable_id, commentable_type, ip_address),
           CHANGE COLUMN id id bigint NOT NULL AUTO_INCREMENT" \
  --no-swap-tables --no-drop-new-table --no-drop-triggers --no-check-unique-key-change \
  -uroot --chunk-size=10k --max-flow-ctl 0 --pause-file /tmp/pauseme \
  --max-load Threads_running=25 --critical-load Threads_running=400 \
  --set-vars innodb_lock_wait_timeout=2 --alter-foreign-keys-method=auto \
  --execute

Table Swap and Cleanup Commands:

RENAME TABLE
  `ao3_test`.`kudos` TO `ao3_test`.`_kudos_old`,
  `ao3_test`.`_kudos_new` TO `ao3_test`.`kudos`;

DROP TRIGGER IF EXISTS `ao3_test`.`pt_osc_ao3_test_kudos_del`;
DROP TRIGGER IF EXISTS `ao3_test`.`pt_osc_ao3_test_kudos_ins`;
DROP TRIGGER IF EXISTS `ao3_test`.`pt_osc_ao3_test_kudos_upd`;

DROP TABLE IF EXISTS `ao3_test`.`_kudos_old`;
== 20200210013551 AddUniqueIndicesToKudosAndChangeIdType: migrated (0.0047s) ==
```
The `pt-online-schema-change` command includes flags (`--no-swap-tables --no-drop-new-table --no-drop-triggers`) that should prevent the table swap from being performed at the end, so that the part that's much more likely to produce downtime is isolated from the rest of the job. 🤞 I've also included a bunch of SQL commands to perform the swap and drop the old table, which should only be run once everyone's ready for downtime.

## Testing Instructions

1. Run the migration.
2. Copy the commands that it prints to a file.
3. Run the `pt-online-schema-change` command, but not any of the SQL commands that follow it.
4. Create a brand new kudos, and note the ID in the database.
5. Run the SQL commands. (`RENAME TABLE`, `DROP TRIGGER`, and `DROP TABLE`)
6. Check whether the kudos that you created is still there.
7. Try to insert a duplicate kudos, bypassing validations, and make sure that it generates an error.

## References

I borrowed many of the pt-osc settings from #3723. Please let me know if they need to be changed at all!