### PR TITLE
AO3-5028 Don't use keyword arguments in the mailer.

### DIFF
--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -42,21 +42,24 @@ class UserMailer < BulletproofMailer::Base
     )
   end
 
-  def anonymous_or_unrevealed_notification(user_id, work_id, collection_id,
-                                           anonymous:, unrevealed:)
-    return unless anonymous || unrevealed
+  # We use an options hash here, instead of keyword arguments, to avoid
+  # compatibility issues with resque/resque_mailer.
+  def anonymous_or_unrevealed_notification(user_id, work_id, collection_id, options = {})
+    options = options.with_indifferent_access
+
+    @becoming_anonymous = options.fetch(:anonymous, false)
+    @becoming_unrevealed = options.fetch(:unrevealed, false)
+
+    return unless @becoming_anonymous || @becoming_unrevealed
 
     @user = User.find(user_id)
     @work = Work.find(work_id)
     @collection = Collection.find(collection_id)
 
-    @becoming_anonymous = anonymous
-    @becoming_unrevealed = unrevealed
-
     # Symbol used to pick the appropriate translation string:
-    @status = if anonymous && unrevealed
+    @status = if @becoming_anonymous && @becoming_unrevealed
                 :anonymous_unrevealed
-              elsif anonymous
+              elsif @becoming_anonymous
                 :anonymous
               else
                 :unrevealed


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5028

## Purpose

Modify the mailer action introduced in #3738 to use an options hash instead of keyword arguments.