### PR TITLE
AO3-5028 Assorted text changes for the anonymous/unrevealed notification emails.

### DIFF
--- a/app/views/user_mailer/anonymous_or_unrevealed_notification.html.erb
+++ b/app/views/user_mailer/anonymous_or_unrevealed_notification.html.erb
@@ -5,11 +5,13 @@
            collection: style_link(@collection.title, collection_url(@collection)),
            work: style_creation_link(@work.title, work_url(@work))).html_safe %></p>
 
-  <% if @becoming_anonymous %>
-    <p><%= t(".anonymous_info") %></p>
-  <% end %>
+  <% if @becoming_anonymous && @becoming_unrevealed %>
+    <p><%= t(".unrevealed_info") %></p>
 
-  <% if @becoming_unrevealed %>
+    <p><%= t(".anonymous_unrevealed_info") %></p>
+  <% elsif @becoming_anonymous %>
+    <p><%= t(".anonymous_info") %></p>
+  <% else %>
     <p><%= t(".unrevealed_info") %></p>
   <% end %>
 

--- a/app/views/user_mailer/anonymous_or_unrevealed_notification.text.erb
+++ b/app/views/user_mailer/anonymous_or_unrevealed_notification.text.erb
@@ -6,9 +6,9 @@
       work: @work.title) %>
 
 <% if @becoming_anonymous && @becoming_unrevealed %>
-<%= t(".anonymous_info") %>
-
 <%= t(".unrevealed_info") %>
+
+<%= t(".anonymous_unrevealed_info") %>
 <% elsif @becoming_anonymous %>
 <%= t(".anonymous_info") %>
 <% else %>

--- a/config/locales/mailers/en.yml
+++ b/config/locales/mailers/en.yml
@@ -232,6 +232,7 @@ en:
         unrevealed: "The collection maintainers of %{collection} have changed the status of your work %{work} to unrevealed."
       anonymous_info: "Anonymous works are included in tag listings, but not on your works page. On the work, your user name will be replaced with \"Anonymous.\""
       unrevealed_info: "Unrevealed works are not included in tag listings or on your works page. Anyone who follows a link to the work will receive a notice that it is currently unrevealed, and they will be unable to access its content."
+      anonymous_unrevealed_info: "The collection maintainers may later reveal your work but leave it anonymous. People who subscribe to you will not be notified of this change. Your work will be included in tag listings, but not on your works page. On the work, your user name will be replaced with \"Anonymous.\""
       do_not_want:
         anonymous:
           html: "If you do not want your work to be anonymous, please visit your %{collection_items_link} to remove it from this collection."

--- a/config/locales/mailers/en.yml
+++ b/config/locales/mailers/en.yml
@@ -222,9 +222,9 @@ en:
         other: "We regret to inform you that your request for %{count} new invitations cannot be fulfilled at this time."
     anonymous_or_unrevealed_notification:
       subject:
-        anonymous: "[%{app_name}] Your work has become anonymous"
-        anonymous_unrevealed: "[%{app_name}] Your work has become anonymous and unrevealed"
-        unrevealed: "[%{app_name}] Your work has become unrevealed"
+        anonymous: "[%{app_name}] Your work was made anonymous"
+        anonymous_unrevealed: "[%{app_name}] Your work was made anonymous and unrevealed"
+        unrevealed: "[%{app_name}] Your work was made unrevealed"
       greeting: "Dear %{user},"
       changed_status:
         anonymous: "The collection maintainers of %{collection} have changed the status of your work %{work} to anonymous."

--- a/features/collections/collection_anonymity.feature
+++ b/features/collections/collection_anonymity.feature
@@ -508,6 +508,6 @@ Feature: Collection
       And I submit
     Then "creator" should be emailed
       And the email should have "Your work was made anonymous and unrevealed" in the subject
-      And the email should contain "Anonymous works are included in tag listings, but not on your works page."
       And the email should contain "Unrevealed works are not included in tag listings or on your works page."
+      And the email should contain "The collection maintainers may later reveal your work but leave it anonymous."
       And the email should not contain "translation missing"

--- a/features/collections/collection_anonymity.feature
+++ b/features/collections/collection_anonymity.feature
@@ -469,7 +469,7 @@ Feature: Collection
       And I check "Anonymous"
       And I submit
     Then "creator" should be emailed
-      And the email should have "Your work has become anonymous" in the subject
+      And the email should have "Your work was made anonymous" in the subject
       And the email should contain "Anonymous works are included in tag listings, but not on your works page."
       And the email should not contain "translation missing"
 
@@ -487,7 +487,7 @@ Feature: Collection
       And I check "Unrevealed"
       And I submit
     Then "creator" should be emailed
-      And the email should have "Your work has become unrevealed" in the subject
+      And the email should have "Your work was made unrevealed" in the subject
       And the email should contain "Unrevealed works are not included in tag listings or on your works page."
       And the email should not contain "translation missing"
 
@@ -507,7 +507,7 @@ Feature: Collection
       And I check "Unrevealed"
       And I submit
     Then "creator" should be emailed
-      And the email should have "Your work has become anonymous and unrevealed" in the subject
+      And the email should have "Your work was made anonymous and unrevealed" in the subject
       And the email should contain "Anonymous works are included in tag listings, but not on your works page."
       And the email should contain "Unrevealed works are not included in tag listings or on your works page."
       And the email should not contain "translation missing"


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5028

## Purpose

- Changes the subject lines of the anonymous/unrevealed notification from "Your work has become [status]" to "Your work was made [status]."
- Changes the info included in the email when the work is becoming both anonymous and unrevealed.