### PR TITLE
AO3-5807 Drop approved column from feedbacks table.

### DIFF
--- a/app/models/feedback.rb
+++ b/app/models/feedback.rb
@@ -30,17 +30,15 @@ class Feedback < ApplicationRecord
 
   def check_for_spam?
     # don't check for spam while running tests
-    self.approved = Rails.env.test? || !Akismetor.spam?(akismet_attributes)
+    Rails.env.test? || !Akismetor.spam?(akismet_attributes)
   end
 
   def mark_as_spam!
-    update_attribute(:approved, false)
     # don't submit spam reports unless in production mode
     Rails.env.production? && Akismetor.submit_spam(akismet_attributes)
   end
 
   def mark_as_ham!
-    update_attribute(:approved, true)
     # don't submit ham reports unless in production mode
     Rails.env.production? && Akismetor.submit_ham(akismet_attributes)
   end

--- a/db/migrate/20200221045607_drop_approved_from_feedbacks.rb
+++ b/db/migrate/20200221045607_drop_approved_from_feedbacks.rb
@@ -1,0 +1,65 @@
+class DropApprovedFromFeedbacks < ActiveRecord::Migration[5.1]
+  def up
+    if Rails.env.staging? || Rails.env.production?
+      database = Feedback.connection.current_database
+
+      puts <<-PTOSC
+Schema Change Command:
+
+pt-online-schema-change D=#{database},t=feedbacks \\
+  --alter "DROP COLUMN approved" \\
+  --no-swap-tables --no-drop-new-table --no-drop-triggers \\
+  -uroot --chunk-size=10k --max-flow-ctl 0 --pause-file /tmp/pauseme \\
+  --max-load Threads_running=25 --critical-load Threads_running=400 \\
+  --set-vars innodb_lock_wait_timeout=2 --alter-foreign-keys-method=auto \\
+  --execute
+
+Table Swap and Cleanup Commands:
+
+RENAME TABLE
+  `#{database}`.`feedbacks` TO `#{database}`.`_feedbacks_old`,
+  `#{database}`.`_feedbacks_new` TO `#{database}`.`feedbacks`;
+
+DROP TRIGGER IF EXISTS `#{database}`.`pt_osc_#{database}_feedbacks_del`;
+DROP TRIGGER IF EXISTS `#{database}`.`pt_osc_#{database}_feedbacks_ins`;
+DROP TRIGGER IF EXISTS `#{database}`.`pt_osc_#{database}_feedbacks_upd`;
+
+DROP TABLE IF EXISTS `#{database}`.`_feedbacks_old`;
+      PTOSC
+    else
+      remove_column :feedbacks, :approved
+    end
+  end
+
+  def down
+    if Rails.env.staging? || Rails.env.production?
+      database = Feedback.connection.current_database
+
+      puts <<-PTOSC
+Schema Change Command:
+
+pt-online-schema-change D=#{database},t=feedbacks \\
+  --alter "ADD COLUMN approved boolean DEFAULT 0 NOT NULL" \\
+  --no-swap-tables --no-drop-new-table --no-drop-triggers \\
+  -uroot --chunk-size=10k --max-flow-ctl 0 --pause-file /tmp/pauseme \\
+  --max-load Threads_running=25 --critical-load Threads_running=400 \\
+  --set-vars innodb_lock_wait_timeout=2 --alter-foreign-keys-method=auto \\
+  --execute
+
+Table Swap and Cleanup Commands:
+
+RENAME TABLE
+  `#{database}`.`feedbacks` TO `#{database}`.`_feedbacks_old`,
+  `#{database}`.`_feedbacks_new` TO `#{database}`.`feedbacks`;
+
+DROP TRIGGER IF EXISTS `#{database}`.`pt_osc_#{database}_feedbacks_del`;
+DROP TRIGGER IF EXISTS `#{database}`.`pt_osc_#{database}_feedbacks_ins`;
+DROP TRIGGER IF EXISTS `#{database}`.`pt_osc_#{database}_feedbacks_upd`;
+
+DROP TABLE IF EXISTS `#{database}`.`_feedbacks_old`;
+      PTOSC
+    else
+      add_column :feedbacks, :approved, :boolean, null: false, default: false
+    end
+  end
+end

--- a/db/migrate/20200221045607_drop_approved_from_feedbacks.rb
+++ b/db/migrate/20200221045607_drop_approved_from_feedbacks.rb
@@ -3,28 +3,28 @@ class DropApprovedFromFeedbacks < ActiveRecord::Migration[5.1]
     if Rails.env.staging? || Rails.env.production?
       database = Feedback.connection.current_database
 
-      puts <<-PTOSC
-Schema Change Command:
+      puts <<~PTOSC
+        Schema Change Command:
 
-pt-online-schema-change D=#{database},t=feedbacks \\
-  --alter "DROP COLUMN approved" \\
-  --no-swap-tables --no-drop-new-table --no-drop-triggers \\
-  -uroot --chunk-size=10k --max-flow-ctl 0 --pause-file /tmp/pauseme \\
-  --max-load Threads_running=25 --critical-load Threads_running=400 \\
-  --set-vars innodb_lock_wait_timeout=2 --alter-foreign-keys-method=auto \\
-  --execute
+        pt-online-schema-change D=#{database},t=feedbacks \\
+          --alter "DROP COLUMN approved" \\
+          --no-swap-tables --no-drop-new-table --no-drop-triggers \\
+          -uroot --chunk-size=10k --max-flow-ctl 0 --pause-file /tmp/pauseme \\
+          --max-load Threads_running=25 --critical-load Threads_running=400 \\
+          --set-vars innodb_lock_wait_timeout=2 --alter-foreign-keys-method=auto \\
+          --execute
 
-Table Swap and Cleanup Commands:
+        Table Swap and Cleanup Commands:
 
-RENAME TABLE
-  `#{database}`.`feedbacks` TO `#{database}`.`_feedbacks_old`,
-  `#{database}`.`_feedbacks_new` TO `#{database}`.`feedbacks`;
+        RENAME TABLE
+          `#{database}`.`feedbacks` TO `#{database}`.`_feedbacks_old`,
+          `#{database}`.`_feedbacks_new` TO `#{database}`.`feedbacks`;
 
-DROP TRIGGER IF EXISTS `#{database}`.`pt_osc_#{database}_feedbacks_del`;
-DROP TRIGGER IF EXISTS `#{database}`.`pt_osc_#{database}_feedbacks_ins`;
-DROP TRIGGER IF EXISTS `#{database}`.`pt_osc_#{database}_feedbacks_upd`;
+        DROP TRIGGER IF EXISTS `#{database}`.`pt_osc_#{database}_feedbacks_del`;
+        DROP TRIGGER IF EXISTS `#{database}`.`pt_osc_#{database}_feedbacks_ins`;
+        DROP TRIGGER IF EXISTS `#{database}`.`pt_osc_#{database}_feedbacks_upd`;
 
-DROP TABLE IF EXISTS `#{database}`.`_feedbacks_old`;
+        DROP TABLE IF EXISTS `#{database}`.`_feedbacks_old`;
       PTOSC
     else
       remove_column :feedbacks, :approved
@@ -35,28 +35,28 @@ DROP TABLE IF EXISTS `#{database}`.`_feedbacks_old`;
     if Rails.env.staging? || Rails.env.production?
       database = Feedback.connection.current_database
 
-      puts <<-PTOSC
-Schema Change Command:
+      puts <<~PTOSC
+        Schema Change Command:
 
-pt-online-schema-change D=#{database},t=feedbacks \\
-  --alter "ADD COLUMN approved boolean DEFAULT 0 NOT NULL" \\
-  --no-swap-tables --no-drop-new-table --no-drop-triggers \\
-  -uroot --chunk-size=10k --max-flow-ctl 0 --pause-file /tmp/pauseme \\
-  --max-load Threads_running=25 --critical-load Threads_running=400 \\
-  --set-vars innodb_lock_wait_timeout=2 --alter-foreign-keys-method=auto \\
-  --execute
+        pt-online-schema-change D=#{database},t=feedbacks \\
+          --alter "ADD COLUMN approved boolean DEFAULT 0 NOT NULL" \\
+          --no-swap-tables --no-drop-new-table --no-drop-triggers \\
+          -uroot --chunk-size=10k --max-flow-ctl 0 --pause-file /tmp/pauseme \\
+          --max-load Threads_running=25 --critical-load Threads_running=400 \\
+          --set-vars innodb_lock_wait_timeout=2 --alter-foreign-keys-method=auto \\
+          --execute
 
-Table Swap and Cleanup Commands:
+        Table Swap and Cleanup Commands:
 
-RENAME TABLE
-  `#{database}`.`feedbacks` TO `#{database}`.`_feedbacks_old`,
-  `#{database}`.`_feedbacks_new` TO `#{database}`.`feedbacks`;
+        RENAME TABLE
+          `#{database}`.`feedbacks` TO `#{database}`.`_feedbacks_old`,
+          `#{database}`.`_feedbacks_new` TO `#{database}`.`feedbacks`;
 
-DROP TRIGGER IF EXISTS `#{database}`.`pt_osc_#{database}_feedbacks_del`;
-DROP TRIGGER IF EXISTS `#{database}`.`pt_osc_#{database}_feedbacks_ins`;
-DROP TRIGGER IF EXISTS `#{database}`.`pt_osc_#{database}_feedbacks_upd`;
+        DROP TRIGGER IF EXISTS `#{database}`.`pt_osc_#{database}_feedbacks_del`;
+        DROP TRIGGER IF EXISTS `#{database}`.`pt_osc_#{database}_feedbacks_ins`;
+        DROP TRIGGER IF EXISTS `#{database}`.`pt_osc_#{database}_feedbacks_upd`;
 
-DROP TABLE IF EXISTS `#{database}`.`_feedbacks_old`;
+        DROP TABLE IF EXISTS `#{database}`.`_feedbacks_old`;
       PTOSC
     else
       add_column :feedbacks, :approved, :boolean, null: false, default: false


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5807

## Purpose

- Remove the last references to `approved` in the Feedback class.
- Add a migration to drop the column from the table.

The migration is patterned after the one in #3750, so it uses the same technique: when run in staging or production, it prints out a list of commands to run that looks something like this:
```
== 20200221045607 DropApprovedFromFeedbacks: migrating ========================
Schema Change Command:

pt-online-schema-change D=ao3_test,t=feedbacks \
  --alter "DROP COLUMN approved" \
  --no-swap-tables --no-drop-new-table --no-drop-triggers \
  -uroot --chunk-size=10k --max-flow-ctl 0 --pause-file /tmp/pauseme \
  --max-load Threads_running=25 --critical-load Threads_running=400 \
  --set-vars innodb_lock_wait_timeout=2 --alter-foreign-keys-method=auto \
  --execute

Table Swap and Cleanup Commands:

RENAME TABLE
  `ao3_test`.`feedbacks` TO `ao3_test`.`_feedbacks_old`,
  `ao3_test`.`_feedbacks_new` TO `ao3_test`.`feedbacks`;

DROP TRIGGER IF EXISTS `ao3_test`.`pt_osc_ao3_test_feedbacks_del`;
DROP TRIGGER IF EXISTS `ao3_test`.`pt_osc_ao3_test_feedbacks_ins`;
DROP TRIGGER IF EXISTS `ao3_test`.`pt_osc_ao3_test_feedbacks_upd`;

DROP TABLE IF EXISTS `ao3_test`.`_feedbacks_old`;
== 20200221045607 DropApprovedFromFeedbacks: migrated (0.0026s) ===============
```
The combination of flags `--no-swap-tables --no-drop-new-table --no-drop-triggers` is intended to ensure that the `pt-online-schema-change` command can be run in the background without causing downtime, and then the table swap/table drop commands can be run during a shorter downtime period.

## Testing Instructions

1. Run the migration.
2. Copy the commands that it prints to a file.
3. Run the `pt-online-schema-change` command (but no SQL commands).
4. Submit a new support request.
5. Count the number of rows in `feedbacks`.
6. Run the SQL commands to swap the tables and drop the old table.
7. Count the number of rows in `feedbacks`, and make sure it's the same as before.
8. Double-check to make sure that the `approved` column has been dropped.