### PR TITLE
AO3-5868 Change kudo uniqueness validation to use users instead of pseuds

### DIFF
--- a/app/controllers/kudos_controller.rb
+++ b/app/controllers/kudos_controller.rb
@@ -63,8 +63,20 @@ class KudosController < ApplicationController
     # by database unique indices, use the usual duplicate error message.
     #
     # https://api.rubyonrails.org/v5.1/classes/ActiveRecord/Validations/ClassMethods.html#method-i-validates_uniqueness_of-label-Concurrency+and+integrity
-    flash[:comment_error] = ts("You have already left kudos here. :)")
-    redirect_to request.referer
+    respond_to do |format|
+      format.html do
+        flash[:comment_error] = ts("You have already left kudos here. :)")
+        redirect_to request.referer
+      end
+
+      format.js do
+        # TODO: AO3-5635 Clean up kudos error handling in JS.
+        # The JS error handler only checks for the existence of keys,
+        # e.g. "ip_address" will show the "already left kudos" message.
+        errors = { ip_address: "ERROR" }
+        render json: { errors: errors }, status: :unprocessable_entity
+      end
+    end
   end
 
   private

--- a/app/controllers/kudos_controller.rb
+++ b/app/controllers/kudos_controller.rb
@@ -70,7 +70,6 @@ class KudosController < ApplicationController
       end
 
       format.js do
-        # TODO: AO3-5635 Clean up kudos error handling in JS.
         # The JS error handler only checks for the existence of keys,
         # e.g. "ip_address" will show the "already left kudos" message.
         errors = { ip_address: "ERROR" }

--- a/app/controllers/kudos_controller.rb
+++ b/app/controllers/kudos_controller.rb
@@ -57,20 +57,14 @@ class KudosController < ApplicationController
         end
       end
     end
-  rescue ActiveRecord::RecordNotUnique => e
+  rescue ActiveRecord::RecordNotUnique
     # Uniqueness checks at application level (Rails validations) are inherently
     # prone to race conditions. If we pass Rails validations but get rejected
     # by database unique indices, use the usual duplicate error message.
     #
     # https://api.rubyonrails.org/v5.1/classes/ActiveRecord/Validations/ClassMethods.html#method-i-validates_uniqueness_of-label-Concurrency+and+integrity
-    if e.message =~ /Mysql2?::Error: Duplicate entry/i
-      flash[:comment_error] = ts("You have already left kudos here. :)")
-      redirect_to request.referer
-      return
-    end
-
-    # If we get unknown errors, let them propagate normally.
-    raise
+    flash[:comment_error] = ts("You have already left kudos here. :)")
+    redirect_to request.referer
   end
 
   private

--- a/app/models/kudo.rb
+++ b/app/models/kudo.rb
@@ -9,11 +9,6 @@ class Kudo < ApplicationRecord
   validate :cannot_be_author
   validate :guest_cannot_kudos_restricted_work
 
-  validates_uniqueness_of :pseud_id,
-                          scope: [:commentable_id, :commentable_type],
-                          message: ts("^You have already left kudos here. :)"),
-                          if: proc { |kudo| !kudo.pseud.nil? }
-
   validates_uniqueness_of :ip_address,
                           scope: [:commentable_id, :commentable_type],
                           message: ts("^You have already left kudos here. :)"),

--- a/app/models/kudo.rb
+++ b/app/models/kudo.rb
@@ -10,14 +10,19 @@ class Kudo < ApplicationRecord
   validate :guest_cannot_kudos_restricted_work
 
   validates_uniqueness_of :pseud_id,
-    scope: [:commentable_id, :commentable_type],
-    message: ts("^You have already left kudos here. :)"),
-    if: Proc.new { |kudo| !kudo.pseud.nil? }
+                          scope: [:commentable_id, :commentable_type],
+                          message: ts("^You have already left kudos here. :)"),
+                          if: proc { |kudo| !kudo.pseud.nil? }
 
   validates_uniqueness_of :ip_address,
-    scope: [:commentable_id, :commentable_type],
-    message: ts("^You have already left kudos here. :)"),
-    if: Proc.new { |kudo| !kudo.ip_address.blank? }
+                          scope: [:commentable_id, :commentable_type],
+                          message: ts("^You have already left kudos here. :)"),
+                          if: proc { |kudo| !kudo.ip_address.blank? }
+
+  validates_uniqueness_of :user_id,
+                          scope: [:commentable_id, :commentable_type],
+                          message: ts("^You have already left kudos here. :)"),
+                          if: proc { |kudo| !kudo.user.nil? }
 
   scope :with_pseud, -> { where("pseud_id IS NOT NULL") }
   scope :by_guest, -> { where("pseud_id IS NULL") }

--- a/features/comments_and_kudos/kudos.feature
+++ b/features/comments_and_kudos/kudos.feature
@@ -60,6 +60,37 @@ Feature: Kudos
     When I go to the work kudos page for "Awesome Story"
     Then I should see "myname2 and myname3 as well as 1 guest left kudos on this work!"
 
+  @javascript
+  Scenario: Leaving kudos with JavaScript enabled
+
+    # As a registered user
+    When I am logged in as "myname2"
+      And I view the work "Awesome Story"
+      And I press "Kudos ♥"
+    Then I should see "Thank you for leaving kudos!"
+      And I should see "myname2 left kudos on this work!"
+    When I press "Kudos ♥"
+    Then I should see "You have already left kudos here. :)"
+      And I should not see "myname2 and myname2 left kudos on this work!"
+
+    # As another registered user
+    When I am logged in as "myname3"
+      And I view the work "Awesome Story"
+      And I press "Kudos ♥"
+    Then I should see "Thank you for leaving kudos!"
+      And I should see "myname3 and myname2 left kudos on this work!"
+    When I press "Kudos ♥"
+    Then I should see "You have already left kudos here. :)"
+
+    # As a guest user
+    When I am logged out
+      And I view the work "Awesome Story"
+      And I press "Kudos ♥"
+    Then I should see "Thank you for leaving kudos!"
+      And I should see "myname3 and myname2 as well as 1 guest left kudos on this work!"
+    When I press "Kudos ♥"
+    Then I should see "You have already left kudos here. :)"
+
   Scenario: Leaving kudos on a multi-chapter work
 
     Given I am logged in as "myname1"

--- a/features/comments_and_kudos/kudos.feature
+++ b/features/comments_and_kudos/kudos.feature
@@ -1,19 +1,20 @@
-Feature: Leave kudos
+Feature: Kudos
   In order to show appreciation
   As a reader
   I want to leave kudos
 
   Background:
-  Given the following activated users exist
-    | login          | email           |
-    | myname1        | myname1@foo.com |
-    | myname2        | myname2@foo.com |
-    | myname3        | myname3@foo.com |
-    And I am logged in as "myname1"
-    And I post the work "Awesome Story"
-    And I log out
 
-  Scenario: post kudos
+    Given the following activated users exist
+        | login          | email           |
+        | myname1        | myname1@foo.com |
+        | myname2        | myname2@foo.com |
+        | myname3        | myname3@foo.com |
+      And I am logged in as "myname1"
+      And I post the work "Awesome Story"
+      And I log out
+
+  Scenario: Leaving kudos
 
     Given I am logged in as "myname2"
       And all emails have been delivered
@@ -26,7 +27,7 @@ Feature: Leave kudos
       # make sure no emails go out until notifications are sent
       And 0 emails should be delivered
     When kudos are sent
-      Then 1 email should be delivered to "myname1@foo.com"
+    Then 1 email should be delivered to "myname1@foo.com"
       And the email should contain "myname2"
       And the email should contain "left kudos"
       And the email should contain "."
@@ -59,7 +60,8 @@ Feature: Leave kudos
     When I go to the work kudos page for "Awesome Story"
     Then I should see "myname2 and myname3 as well as 1 guest left kudos on this work!"
 
-  Scenario: kudos on a multi-chapter work
+  Scenario: Leaving kudos on a multi-chapter work
+
     Given I am logged in as "myname1"
       And I post the chaptered work "Epic Saga"
       And a draft chapter is added to "Epic Saga"
@@ -71,7 +73,7 @@ Feature: Leave kudos
       And I view the work "Epic Saga"
     Then I should see kudos on every chapter but the draft
 
-  Scenario: deleting pseud and user after creating kudos should orphan them
+  Scenario: Deleting pseud and user after leaving kudos should orphan them
 
     Given I am logged in as "myname3"
     When "myname3" creates the default pseud "foobar"
@@ -80,17 +82,18 @@ Feature: Leave kudos
     Then I should see "foobar (myname3) left kudos on this work!"
     When "myname3" creates the default pseud "barfoo"
       And I am on myname3's pseuds page
-      #'
       And I follow "delete_foobar"
       And I view the work "Awesome Story"
-    # there's no clean way to expire the cache for all kudos after a pseud change
+    # There's no clean way to expire the cache for all kudos after a pseud change,
+    # but that won't matter after AO3-5859.
+    # TODO: AO3-5859 Remove this comment and "Then" step.
     # Then I should see "barfoo (myname3) left kudos on this work!"
     When "myname3" deletes their account
       And I view the work "Awesome Story"
       And "AO3-2195" is fixed
     # Then I should see "1 guest left kudos on this work!"
 
-  Scenario: redirection when kudosing on a middle chapter, with default preferences
+  Scenario: Redirection when leaving kudos on a middle chapter, with default preferences
 
     Given the chaptered work setup
       And I am logged in as a random user
@@ -100,7 +103,7 @@ Feature: Leave kudos
     Then I should see "Chapter 2" within "div#chapters"
       And I should not see "Chapter 1" within "div#chapters"
 
-  Scenario: redirection when kudosing on a middle chapter, with default preferences but in temporary view full mode
+  Scenario: Redirection when leaving kudos in temporary "Entire Work" mode, with default preferences
 
     Given the chaptered work setup
       And I am logged in as a random user
@@ -109,7 +112,7 @@ Feature: Leave kudos
     Then I should see "Chapter 2" within "div#chapters"
       And I should see "Chapter 3" within "div#chapters"
 
-  Scenario: batched kudos email
+  Scenario: Batched kudos email
 
     Given I am logged in as "myname1"
       And I post the work "Another Awesome Story"

--- a/public/javascripts/application.js
+++ b/public/javascripts/application.js
@@ -455,8 +455,7 @@ $j(document).ready(function() {
         var msg = 'Sorry, we were unable to save your kudos';
         var data = $j.parseJSON(jqXHR.responseText);
 
-        // TODO: AO3-5859 Remove data.errors.pseud_id.
-        if (data.errors && (data.errors.pseud_id || data.errors.ip_address || data.errors.user_id)) {
+        if (data.errors && (data.errors.ip_address || data.errors.user_id)) {
           msg = "You have already left kudos here. :)";
         }
 

--- a/public/javascripts/application.js
+++ b/public/javascripts/application.js
@@ -455,7 +455,8 @@ $j(document).ready(function() {
         var msg = 'Sorry, we were unable to save your kudos';
         var data = $j.parseJSON(jqXHR.responseText);
 
-        if (data.errors && (data.errors.pseud_id || data.errors.ip_address)) {
+        // TODO: AO3-5859 Remove data.errors.pseud_id.
+        if (data.errors && (data.errors.pseud_id || data.errors.ip_address || data.errors.user_id)) {
           msg = "You have already left kudos here. :)";
         }
 

--- a/spec/controllers/kudos_controller_spec.rb
+++ b/spec/controllers/kudos_controller_spec.rb
@@ -77,6 +77,14 @@ describe KudosController do
               post :create, params: { kudo: { commentable_id: work.id, commentable_type: "Work" } }
               it_redirects_to_with_comment_error(referer, "You have already left kudos here. :)")
             end
+
+            context "with format: :js" do
+              it "returns an error in JSON format" do
+                post :create, params: { kudo: { commentable_id: work.id, commentable_type: "Work" }, format: :js }
+                # TODO: AO3-5635 Clean up kudos error handling in JS.
+                expect(JSON.parse(response.body)["errors"]).to include("ip_address")
+              end
+            end
           end
         end
       end

--- a/spec/controllers/kudos_controller_spec.rb
+++ b/spec/controllers/kudos_controller_spec.rb
@@ -81,7 +81,6 @@ describe KudosController do
             context "with format: :js" do
               it "returns an error in JSON format" do
                 post :create, params: { kudo: { commentable_id: work.id, commentable_type: "Work" }, format: :js }
-                # TODO: AO3-5635 Clean up kudos error handling in JS.
                 expect(JSON.parse(response.body)["errors"]).to include("ip_address")
               end
             end

--- a/spec/models/kudo_spec.rb
+++ b/spec/models/kudo_spec.rb
@@ -13,7 +13,6 @@ describe Kudo do
         it "does not save" do
           expect(new_kudo.save).to be_falsy
           expect(new_kudo.errors[:ip_address]).to be_empty
-          expect(new_kudo.errors[:pseud_id].first).to include("already left kudos")
           expect(new_kudo.errors[:user_id].first).to include("already left kudos")
         end
       end
@@ -26,7 +25,6 @@ describe Kudo do
         it "does not save" do
           expect(new_kudo.save).to be_falsy
           expect(new_kudo.errors[:ip_address]).to be_empty
-          expect(new_kudo.errors[:pseud_id]).to be_empty
           expect(new_kudo.errors[:user_id].first).to include("already left kudos")
         end
       end
@@ -53,7 +51,6 @@ describe Kudo do
         it "does not save" do
           expect(new_kudo.save).to be_falsy
           expect(new_kudo.errors[:ip_address].first).to include("already left kudos")
-          expect(new_kudo.errors[:pseud_id]).to be_empty
           expect(new_kudo.errors[:user_id]).to be_empty
         end
       end

--- a/spec/models/kudo_spec.rb
+++ b/spec/models/kudo_spec.rb
@@ -1,0 +1,72 @@
+require "spec_helper"
+
+describe Kudo do
+  describe "#save" do
+    context "for a registered kudos giver" do
+      let(:user) { create(:user) }
+      let(:pseud) { user.default_pseud }
+
+      context "when kudos from the same pseud already exist" do
+        let(:old_kudo) { create(:kudo, pseud: pseud, user: user) }
+        let(:new_kudo) { build(:kudo, pseud: pseud, user: user, commentable: old_kudo.commentable) }
+
+        it "does not save" do
+          expect(new_kudo.save).to be_falsy
+          expect(new_kudo.errors[:ip_address]).to be_empty
+          expect(new_kudo.errors[:pseud_id].first).to include("already left kudos")
+          expect(new_kudo.errors[:user_id].first).to include("already left kudos")
+        end
+      end
+
+      context "when kudos from another pseud but the same user already exist" do
+        let(:puppet_pseud) { create(:pseud, user: user) }
+        let(:old_kudo) { create(:kudo, pseud: pseud, user: user) }
+        let(:new_kudo) { build(:kudo, pseud: puppet_pseud, user: user, commentable: old_kudo.commentable) }
+
+        it "does not save" do
+          expect(new_kudo.save).to be_falsy
+          expect(new_kudo.errors[:ip_address]).to be_empty
+          expect(new_kudo.errors[:pseud_id]).to be_empty
+          expect(new_kudo.errors[:user_id].first).to include("already left kudos")
+        end
+      end
+
+      context "when kudos from another user already exist" do
+        let(:another_user) { create(:user) }
+        let(:old_kudo) { create(:kudo, pseud: another_user.default_pseud, user: another_user) }
+        let(:new_kudo) { build(:kudo, pseud: pseud, user: user, commentable: old_kudo.commentable) }
+
+        it "saves" do
+          expect(new_kudo.save).to be_truthy
+          expect(new_kudo.errors).to be_empty
+        end
+      end
+    end
+
+    context "for a guest kudos giver" do
+      let(:ip_address) { Faker::Internet.ip_v4_address }
+
+      context "when kudos from the same IP already exist" do
+        let(:old_kudo) { create(:kudo, ip_address: ip_address) }
+        let(:new_kudo) { build(:kudo, ip_address: ip_address, commentable: old_kudo.commentable) }
+
+        it "does not save" do
+          expect(new_kudo.save).to be_falsy
+          expect(new_kudo.errors[:ip_address].first).to include("already left kudos")
+          expect(new_kudo.errors[:pseud_id]).to be_empty
+          expect(new_kudo.errors[:user_id]).to be_empty
+        end
+      end
+
+      context "when kudos a different IP already exist" do
+        let(:old_kudo) { create(:kudo, ip_address: Faker::Internet.ip_v4_address) }
+        let(:new_kudo) { build(:kudo, ip_address: ip_address, commentable: old_kudo.commentable) }
+
+        it "saves" do
+          expect(new_kudo.save).to be_truthy
+          expect(new_kudo.errors).to be_empty
+        end
+      end
+    end
+  end
+end

--- a/spec/models/kudo_spec.rb
+++ b/spec/models/kudo_spec.rb
@@ -55,7 +55,7 @@ describe Kudo do
         end
       end
 
-      context "when kudos a different IP already exist" do
+      context "when kudos from a different IP already exist" do
         let(:old_kudo) { create(:kudo, ip_address: Faker::Internet.ip_v4_address) }
         let(:new_kudo) { build(:kudo, ip_address: ip_address, commentable: old_kudo.commentable) }
 


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5868

## Purpose

When we add the uniqueness constraint at the database level (#3750), we'll have the error handling ready at the application level (people will see "left kudos here :)" as usual).

For the rare cases where users can get past the Rails validation and run into the (future) database constraint, we should catch `ActiveRecord::RecordNotUnique` exceptions, similar to what we do on user creations:

https://github.com/otwcode/otwarchive/blob/57e7cab589abc7cc666ddf4d3abe768d801b3493/app/controllers/users_controller.rb#L9-L24

## Testing Instructions

See issue.