### PR TITLE
AO3-5873 Task to update kudos count on indexed works

### DIFF
--- a/lib/tasks/after_tasks.rake
+++ b/lib/tasks/after_tasks.rake
@@ -657,7 +657,7 @@ namespace :After do
     batch_number = 0
 
     counters.find_in_batches do |batch|
-      batch_number = batch_number + 1
+      batch_number += 1
       progress_msg = "Batch #{batch_number} of #{total_batches} complete"
       batch.each do |counter|
         next unless counter.work

--- a/lib/tasks/after_tasks.rake
+++ b/lib/tasks/after_tasks.rake
@@ -653,8 +653,12 @@ namespace :After do
   desc "Update kudo counts on indexed works"
   task(update_indexed_stat_counter_kudo_count: :environment) do
     counters = StatCounter.where("kudos_count > ?", 0)
+    total_batches = (counters.size + 999) / 1000
+    batch_number = 0
 
     counters.find_in_batches do |batch|
+      batch_number = batch_number + 1
+      progress_msg = "Batch #{batch_number} of #{total_batches} complete"
       batch.each do |counter|
         next unless counter.work
 
@@ -664,7 +668,7 @@ namespace :After do
         # Counters will be queued for reindexing.
         counter.save
       end
-      print(".") && STDOUT.flush
+      puts(progress_msg) && STDOUT.flush
     end
     puts && STDOUT.flush
   end

--- a/lib/tasks/after_tasks.rake
+++ b/lib/tasks/after_tasks.rake
@@ -649,6 +649,25 @@ namespace :After do
     end
     puts && STDOUT.flush
   end
+
+  desc "Update kudo counts on indexed works"
+  task(update_indexed_stat_counter_kudo_count: :environment) do
+    counters = StatCounter.where("kudos_count > ?", 0)
+
+    counters.find_in_batches do |batch|
+      batch.each do |counter|
+        next unless counter.work
+
+        counter.kudos_count = counter.work.kudos.count
+        next unless counter.kudos_count_changed?
+
+        # Counters will be queued for reindexing.
+        counter.save
+      end
+      print(".") && STDOUT.flush
+    end
+    puts && STDOUT.flush
+  end
 end # this is the end that you have to put new tasks above
 
 ##################

--- a/spec/miscellaneous/lib/tasks/after_tasks.rake_spec.rb
+++ b/spec/miscellaneous/lib/tasks/after_tasks.rake_spec.rb
@@ -187,16 +187,13 @@ describe "rake After:update_indexed_stat_counter_kudo_count", work_search: true 
     run_all_indexing_jobs
   end
 
-  it "updates kudos_count" do
-    expect(stat_counter.kudos_count).to eq(3)
-
-    subject.invoke
-
-    stat_counter.reload
-    expect(stat_counter.kudos_count).to eq(work.kudos.count)
+  it "updates kudos_count on StatCounter" do
+    expect { 
+      subject.invoke
+    }.to change { stat_counter.reload.kudos_count }.from(3).to(work.kudos.count)
   end
 
-  it "updates work index" do
+  it "updates kudos_count in work index" do
     expect do
       subject.invoke
       run_all_indexing_jobs

--- a/spec/miscellaneous/lib/tasks/after_tasks.rake_spec.rb
+++ b/spec/miscellaneous/lib/tasks/after_tasks.rake_spec.rb
@@ -188,9 +188,11 @@ describe "rake After:update_indexed_stat_counter_kudo_count", work_search: true 
   end
 
   it "updates kudos_count on StatCounter" do
-    expect { 
+    expect do 
       subject.invoke
-    }.to change { stat_counter.reload.kudos_count }.from(3).to(work.kudos.count)
+    end.to change {
+      stat_counter.reload.kudos_count
+    }.from(3).to(work.kudos.count)
   end
 
   it "updates kudos_count in work index" do

--- a/spec/miscellaneous/lib/tasks/after_tasks.rake_spec.rb
+++ b/spec/miscellaneous/lib/tasks/after_tasks.rake_spec.rb
@@ -182,16 +182,14 @@ describe "rake After:update_indexed_stat_counter_kudo_count", work_search: true 
   let(:stat_counter) { work.stat_counter }
   let!(:kudo_bundle) { create_list(:kudo, 2, commentable_id: work.id) }
 
-  def result_count(options)
-    WorkSearchForm.new(options).search_results.size
-  end
-
   before do
     stat_counter.update_column(:kudos_count, 3)
     run_all_indexing_jobs
   end
 
   it "updates kudos_count" do
+    expect(stat_counter.kudos_count).to eq(3)
+
     subject.invoke
 
     stat_counter.reload
@@ -201,8 +199,9 @@ describe "rake After:update_indexed_stat_counter_kudo_count", work_search: true 
   it "updates work index" do
     expect do
       subject.invoke
-      WorkIndexer.refresh_index
-    end.to change { result_count(kudos_count: "2") }.from(0).to(1)
+      run_all_indexing_jobs
+    end.to change { WorkSearchForm.new(kudos_count: work.kudos.count.to_s)
+                      .search_results.size }.from(0).to(1)
   end
 end
 

--- a/spec/miscellaneous/lib/tasks/after_tasks.rake_spec.rb
+++ b/spec/miscellaneous/lib/tasks/after_tasks.rake_spec.rb
@@ -197,8 +197,8 @@ describe "rake After:update_indexed_stat_counter_kudo_count", work_search: true 
     expect do
       subject.invoke
       run_all_indexing_jobs
-    end.to change { WorkSearchForm.new(kudos_count: work.kudos.count.to_s)
-                      .search_results.size }.from(0).to(1)
+    end.to change { 
+      WorkSearchForm.new(kudos_count: work.kudos.count.to_s).search_results.size
+    }.from(0).to(1)
   end
 end
-


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5873

## Purpose

Adds an after task (`bundle exec rake After:update_indexed_stat_counter_kudo_count`) to update the kudos count on indexed works after the great kudos migration (#3750)  takes place.

## Testing Instructions

Refer to Jira.

## Credit

redsummernight and Sarken