### PR TITLE
AO3-5892 Fix intermittent failures in UserMailer specs

### DIFF
--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -1,7 +1,6 @@
 require "spec_helper"
 
 describe UserMailer do
-
   describe "claim_notification" do
     title = "Façade"
     title2 = Faker::Book.title
@@ -43,7 +42,7 @@ describe UserMailer do
       end
 
       it "only has style_to links in the HTML body" do
-        expect(email.html_part).not_to have_xpath("//a[not(@style)]")
+        expect(email.html_part.decoded).not_to have_xpath("//a[not(@style)]")
       end
     end
 
@@ -122,15 +121,15 @@ describe UserMailer do
       end
 
       it "lists the first imported work in an unordered list in the HTML body" do
-        expect(email.html_part).to have_xpath("//ul/li", text: title)
+        expect(email.html_part.decoded).to have_xpath("//ul/li", text: title)
       end
 
       it "lists the second imported work in an unordered list in the HTML body" do
-        expect(email.html_part).to have_xpath("//ul/li", text: title2)
+        expect(email.html_part.decoded).to have_xpath("//ul/li", text: title2)
       end
 
       it "only has style_to links in the HTML body" do
-        expect(email.html_part).not_to have_xpath("//a[not(@style)]")
+        expect(email.html_part.decoded).not_to have_xpath("//a[not(@style)]")
       end
     end
 
@@ -140,7 +139,7 @@ describe UserMailer do
       end
 
       it "lists the first imported work as plain text" do
-        expect(email.text_part).not_to have_xpath("//ul/li", text: title)
+        expect(email.text_part.decoded).not_to have_xpath("//ul/li", text: title)
       end
 
       it "lists the second imported work with a leading hyphen" do


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5892

## Purpose

Check contents of decoded emails. This is only necessary when we need to look for work titles in HTML emails; the other changes are just for consistency.

## Testing Instructions

Travis.

## References

This fix is the same as #3696.