### PR TITLE
AO3-5893 Download wkhtmltox packages from GitHub

### DIFF
--- a/script/codeship/ebook_converters.sh
+++ b/script/codeship/ebook_converters.sh
@@ -3,7 +3,7 @@ set -e
 
 # PDF
 pushd $HOME/cache
-wget https://downloads.wkhtmltopdf.org/0.12/0.12.5/wkhtmltox_0.12.5-1.bionic_amd64.deb
+wget https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/0.12.5/wkhtmltox_0.12.5-1.bionic_amd64.deb
 sudo dpkg -i ./wkhtmltox_0.12.5-1.bionic_amd64.deb
 popd
 sudo apt-get install -f

--- a/script/travis/ebook_converters.sh
+++ b/script/travis/ebook_converters.sh
@@ -5,7 +5,7 @@ sudo apt-get update -qq
 
 # PDF
 sudo apt-get install -qq xfonts-75dpi xfonts-base
-wget https://downloads.wkhtmltopdf.org/0.12/0.12.5/wkhtmltox_0.12.5-1.bionic_amd64.deb
+wget https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/0.12.5/wkhtmltox_0.12.5-1.bionic_amd64.deb
 sudo dpkg -i ./wkhtmltox_0.12.5-1.bionic_amd64.deb
 wkhtmltopdf --version
 


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5893

## Purpose

downloads.wkhtmltopdf.org is deprecated.

## Testing Instructions

Travis/Codeship should pass.