### PR TITLE
AO3-5869 Update parameters for pt-online-schema-change commands

### DIFF
--- a/db/migrate/20200210013551_add_unique_indices_to_kudos_and_change_id_type.rb
+++ b/db/migrate/20200210013551_add_unique_indices_to_kudos_and_change_id_type.rb
@@ -11,8 +11,8 @@ class AddUniqueIndicesToKudosAndChangeIdType < ActiveRecord::Migration[5.1]
                    ADD UNIQUE INDEX index_kudos_on_commentable_and_ip_address (commentable_id, commentable_type, ip_address),
                    CHANGE COLUMN id id bigint NOT NULL AUTO_INCREMENT" \\
           --no-swap-tables --no-drop-new-table --no-drop-triggers --no-check-unique-key-change \\
-          -uroot --ask-pass --chunk-size=10k --max-flow-ctl 0 --pause-file /tmp/pauseme \\
-          --max-load Threads_running=25 --critical-load Threads_running=400 \\
+          -uroot --ask-pass --chunk-size=5k --max-flow-ctl 0 --pause-file /tmp/pauseme \\
+          --max-load Threads_running=15 --critical-load Threads_running=100 \\
           --set-vars innodb_lock_wait_timeout=2 --alter-foreign-keys-method=auto \\
           --execute
 
@@ -50,8 +50,8 @@ class AddUniqueIndicesToKudosAndChangeIdType < ActiveRecord::Migration[5.1]
                    DROP INDEX index_kudos_on_commentable_and_ip_address,
                    CHANGE COLUMN id id int NOT NULL AUTO_INCREMENT" \\
           --no-swap-tables --no-drop-new-table --no-drop-triggers \\
-          -uroot --ask-pass --chunk-size=10k --max-flow-ctl 0 --pause-file /tmp/pauseme \\
-          --max-load Threads_running=25 --critical-load Threads_running=400 \\
+          -uroot --ask-pass --chunk-size=5k --max-flow-ctl 0 --pause-file /tmp/pauseme \\
+          --max-load Threads_running=15 --critical-load Threads_running=100 \\
           --set-vars innodb_lock_wait_timeout=2 --alter-foreign-keys-method=auto \\
           --execute
 


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5869

## Purpose

Running pt-osc with the initial larger parameters caused errors:
```
2020-03-16T08:30:38 Error copying rows from `otwarchive_production`.`kudos` to `otwarchive_production`.`_kudos_new`: 2020-03-16T08:30:38 DBD::mysql::st execute failed: WSREP has not yet prepared node for application use [for Statement "INSERT LOW_PRIORITY IGNORE INTO `otwarchive_production`.`_kudos_new` (`id`, `pseud_id`, `commentable_id`, `commentable_type`, `created_at`, `updated_at`, `ip_address`, `user_id`) SELECT `id`, `pseud_id`, `commentable_id`, `commentable_type`, `created_at`, `updated_at`, `ip_address`, `user_id` FROM `otwarchive_production`.`kudos` FORCE INDEX(`PRIMARY`) WHERE ((`id` >= ?)) AND ((`id` <= ?)) LOCK IN SHARE MODE /*pt-online-schema-change 142490 copy nibble*/" with ParamValues: 0=24549340, 1=24560752] at /usr/bin/pt-online-schema-change line 11451.
```

## Testing Instructions

None, we already tried this live. Commit will skip all CI builds which don't test pt-osc migrations.