### PR TITLE
AO3-5821 Adjustments to Statistics chart display

### DIFF
--- a/app/controllers/stats_controller.rb
+++ b/app/controllers/stats_controller.rb
@@ -101,7 +101,11 @@ class StatsController < ApplicationController
      chm: "N,000000,0,-1,11"
     })
 
-    @chart = GoogleVisualr::Interactive::ColumnChart.new(@chart_data, vAxis: { minValue: 0 }, title: chart_title)
+    options = {
+      vAxis: { minValue: 0 },
+      title: chart_title
+    }
+    @chart = GoogleVisualr::Interactive::ColumnChart.new(@chart_data, options)
 
   end
 

--- a/app/controllers/stats_controller.rb
+++ b/app/controllers/stats_controller.rb
@@ -105,8 +105,6 @@ class StatsController < ApplicationController
       colors: ["#993333"],
       title: chart_title,
       vAxis: { 
-        minValue: 0,
-        viewWindowMode: "explicit", 
         viewWindow: { min: 0 }
       }
     }

--- a/app/controllers/stats_controller.rb
+++ b/app/controllers/stats_controller.rb
@@ -102,6 +102,7 @@ class StatsController < ApplicationController
     })
 
     options = {
+      colors: ["#993333"],
       vAxis: { minValue: 0 },
       title: chart_title
     }

--- a/app/controllers/stats_controller.rb
+++ b/app/controllers/stats_controller.rb
@@ -103,8 +103,12 @@ class StatsController < ApplicationController
 
     options = {
       colors: ["#993333"],
-      vAxis: { minValue: 0 },
-      title: chart_title
+      title: chart_title,
+      vAxis: { 
+        minValue: 0,
+        viewWindowMode: "explicit", 
+        viewWindow: { min: 0 }
+      }
     }
     @chart = GoogleVisualr::Interactive::ColumnChart.new(@chart_data, options)
 


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5821

## Purpose

Tweaks the way the JavaScript-based chart displays on the Statistics page.

* Makes the bars a dusty version of our red instead of default Google blue
* Prevents the graph from showing negative numbers when all values are zero

## Testing Instructions

Log in, go to your Statistics page, and check the color. Then switch to a year and/or stat that you have no data for and make sure no negative numbers are on the y-axis.
