### PR TITLE
AO3-5900 Make spam checks pass in tests by default

### DIFF
--- a/features/other_a/abuse_report.feature
+++ b/features/other_a/abuse_report.feature
@@ -3,9 +3,6 @@ Feature: Filing an abuse report
   As an annoyed user
   I want to file an abuse ticket
 
-  Background:
-  Given the abuse report will not be considered spam
-
   Scenario: File an abuse request with default options
 
   Given basic languages

--- a/features/step_definitions/admin_steps.rb
+++ b/features/step_definitions/admin_steps.rb
@@ -184,10 +184,6 @@ Given(/^the following language exists$/) do |table|
   end
 end
 
-Given /^the abuse report will not be considered spam$/ do
-  allow(Akismetor).to receive(:spam?).and_return(false)
-end
-
 ### WHEN
 
 When /^I visit the last activities item$/ do

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -71,6 +71,9 @@ Before do
 
   language = Language.find_or_create_by(short: 'en', name: 'English')
   Locale.set_base_locale(iso: "en", name: "English (US)", language_id: language.id)
+
+  # Assume all spam checks pass by default.
+  allow(Akismetor).to receive(:spam?).and_return(false)
 end
 
 Before '@disable_caching' do

--- a/spec/mailers/admin_mailer_spec.rb
+++ b/spec/mailers/admin_mailer_spec.rb
@@ -136,11 +136,6 @@ describe AdminMailer do
     let(:feedback) { create(:feedback) }
     let(:email) { AdminMailer.feedback(feedback.id) }
 
-    # Assume all of these reports pass the spam check
-    before(:each) do
-      allow(Akismetor).to receive(:spam?).and_return(false)
-    end
-
     it "has the correct subject" do
       expect(email).to have_subject("[#{ArchiveConfig.APP_SHORT_NAME}] Support - #{feedback.summary}")
     end
@@ -180,11 +175,6 @@ describe AdminMailer do
     let(:report) { create(:abuse_report) }
     let(:email) { AdminMailer.abuse_report(report.id) }
     let(:email2) { UserMailer.abuse_report(report.id) }
-
-    # Assume all of these reports pass the spam check
-    before(:each) do
-      allow(Akismetor).to receive(:spam?).and_return(false)
-    end
 
     it "has the correct subject" do
       expect(email).to have_subject "[#{ArchiveConfig.APP_SHORT_NAME}] Admin Abuse Report"

--- a/spec/models/abuse_report_spec.rb
+++ b/spec/models/abuse_report_spec.rb
@@ -2,12 +2,6 @@ require 'spec_helper'
 
 describe AbuseReport do
   context "when report is not spam" do
-
-    # Assume all of these reports pass the spam check
-    before(:each) do
-      allow(Akismetor).to receive(:spam?).and_return(false)
-    end
-
     context "valid reports" do
       it "is valid" do
         expect(build(:abuse_report)).to be_valid
@@ -258,15 +252,17 @@ describe AbuseReport do
     let(:spam_report) { build(:abuse_report, username: 'viagra-test-123') }
     let(:safe_report) { build(:abuse_report, username: 'viagra-test-123', email: legit_user.email) }
 
-    it "is not valid if Akismet flags it as spam" do
+    before do
       allow(Akismetor).to receive(:spam?).and_return(true)
+    end
+
+    it "is not valid if Akismet flags it as spam" do
       expect(spam_report.save).to be_falsey
       expect(spam_report.errors[:base]).to include("This report looks like spam to our system!")
     end
 
     it "is valid even with spam if logged in and providing correct email" do
       User.current_user = legit_user
-      allow(Akismetor).to receive(:spam?).and_return(true)
       expect(safe_report.save).to be_truthy
     end
   end

--- a/spec/models/feedback_spec.rb
+++ b/spec/models/feedback_spec.rb
@@ -2,11 +2,6 @@ require 'spec_helper'
 
 describe Feedback do
   context "when report is not spam" do
-    # Assume all of these reports pass the spam check
-    before(:each) do
-      allow(Akismetor).to receive(:spam?).and_return(false)
-    end
-
     context "valid reports" do
       it "is valid" do
         expect(build(:feedback)).to be_valid
@@ -61,15 +56,17 @@ describe Feedback do
     let(:spam_report) { build(:feedback, username: 'viagra-test-123') }
     let(:safe_report) { build(:feedback, username: 'viagra-test-123', email: legit_user.email) }
 
-    it "is not valid if Akismet flags it as spam" do
+    before do
       allow(Akismetor).to receive(:spam?).and_return(true)
+    end
+
+    it "is not valid if Akismet flags it as spam" do
       expect(spam_report.save).to be_falsey
       expect(spam_report.errors[:base]).to include("This report looks like spam to our system!")
     end
 
     it "is valid even with spam if logged in and providing correct email" do
       User.current_user = legit_user
-      allow(Akismetor).to receive(:spam?).and_return(true)
       expect(safe_report.save).to be_truthy
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -49,6 +49,9 @@ RSpec.configure do |config|
     DatabaseCleaner.start
     User.current_user = nil
     clean_the_database
+
+    # Assume all spam checks pass by default.
+    allow(Akismetor).to receive(:spam?).and_return(false)
   end
 
   config.after :each do


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5900

## Purpose

Tests for spam check failures need to override this behavior. In all cases, tests should not actually hit Akismet.

Without this PR, this test is failing pretty much every run on Travis:

https://github.com/otwcode/otwarchive/blob/6201f4e055e125590cf9c14f58676205d32a7b00/features/other_b/support.feature#L6

## Testing Instructions

None.