### PR TITLE
AO3-5162 Stop preloading name and email on guest comment forms

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -247,11 +247,6 @@ class CommentsController < ApplicationController
       # First, try saving the comment
       if @comment.save
         if @comment.approved?
-          # save user's name/email if not logged in, truncated in case of something really long and wacky
-          if @comment.pseud.nil?
-            cookies[:comment_name] = @comment.name[0..100]
-            cookies[:comment_email] = @comment.email[0..100]
-          end
           if @comment.unreviewed?
             flash[:comment_notice] = ts("Your comment was received! It will appear publicly after the work creator has approved it.")
           else

--- a/app/views/comments/_comment_form.html.erb
+++ b/app/views/comments/_comment_form.html.erb
@@ -86,19 +86,6 @@
             <%= live_validation_for_field("comment_email_for_#{commentable.id}", :failureMessage => ts('Please enter your email address.')) %>
           </dd>
         </dl>
-
-        <%= content_for :footer_js do %>
-          <%= javascript_tag do %>
-            var name_id = "#comment_name_for_<%= commentable.id %>";
-            var email_id = "#comment_email_for_<%= commentable.id %>";
-            if (!$j(name_id).val()) {
-              $j(name_id).val($j.cookie('comment_name'));
-            }
-            if (!$j(email_id).val()) {
-              $j(email_id).val($j.cookie('comment_email'));
-            }
-          <% end %>
-        <% end %>
       <% end %>
 
       <p>


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5162

## Purpose

So we can cache individual work and chapter pages for logged-out users.

We still need jquery.cookie for the TOS prompts, however.

## Testing Instructions

See issue.