### PR TITLE
AO3-5497 Don't show TOS prompt if URL has ?tos=yes params

### DIFF
--- a/app/views/layouts/_javascripts.html.erb
+++ b/app/views/layouts/_javascripts.html.erb
@@ -50,8 +50,7 @@
     params[:controller] == "home" && params[:action] == "tos_faq" ||
     params[:controller] == "home" && params[:action] == "dmca" ||
     params[:controller] == "abuse_reports" && params[:action] == "new" ||
-    params[:controller] == "feedbacks" && params[:action] == "new" ||
-    params[:tos] == "yes" %>
+    params[:controller] == "feedbacks" && params[:action] == "new" %>
   <%= javascript_tag do %>
     $j(document).ready(function() {
       <% # Users who haven't accepted this TOS and guests who don't have the

--- a/app/views/layouts/_javascripts.html.erb
+++ b/app/views/layouts/_javascripts.html.erb
@@ -50,7 +50,8 @@
     params[:controller] == "home" && params[:action] == "tos_faq" ||
     params[:controller] == "home" && params[:action] == "dmca" ||
     params[:controller] == "abuse_reports" && params[:action] == "new" ||
-    params[:controller] == "feedbacks" && params[:action] == "new" %>
+    params[:controller] == "feedbacks" && params[:action] == "new" ||
+    params[:tos] == "yes" %>
   <%= javascript_tag do %>
     $j(document).ready(function() {
       <% # Users who haven't accepted this TOS and guests who don't have the cookie need

--- a/app/views/layouts/_javascripts.html.erb
+++ b/app/views/layouts/_javascripts.html.erb
@@ -54,13 +54,31 @@
     params[:tos] == "yes" %>
   <%= javascript_tag do %>
     $j(document).ready(function() {
-      <% # Users who haven't accepted this TOS and guests who don't have the cookie need
-         # the popup. We have to use JavaScript to check the cookie or risk issues
-         # when full page caching is enabled %>
+      <% # Users who haven't accepted this TOS and guests who don't have the
+         # cookie and are not using the bypass params need the popup. For
+         # guests, we have to use JavaScript to check the cookie and params or 
+         # we risk issues when full page caching is enabled. %>
       <% if current_user %>
         $j("body").prepend("<%= escape_javascript(render "layouts/tos_prompt") %>");
       <% else %>
-        if ($j.cookie("accepted_tos") != <%= @current_tos_version.to_s %>) {
+        var getUrlParameter = function getUrlParameter(sParam) {
+          var sPageURL = window.location.search.substring(1),
+            sURLVariables = sPageURL.split("&"),
+            sParameterName,
+            i;
+
+            for (i = 0; i < sURLVariables.length; i++) {
+              sParameterName = sURLVariables[i].split("=");
+
+              if (sParameterName[0] === sParam) {
+                return sParameterName[1] === undefined ? true : decodeURIComponent(sParameterName[1]);
+              }
+            }
+        };
+
+        var tos = getUrlParameter("tos");
+
+        if ($j.cookie("accepted_tos") != <%= @current_tos_version.to_s %> && tos != "yes" ) {
           $j("body").prepend("<%= escape_javascript(render "layouts/tos_prompt") %>");
         }
       <% end %>


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5497

## Purpose

Doesn't add the TOS prompt if the URL has ?tos=yes at the end. (We don't add these parameters to the URL automatically after you press "I agree/consent to its terms" because we don't want people accidentally sharing links with them. We want it to be something a user has to manually add so we can be relatively sure they actually agreed to the TOS and didn't just follow a link that happened to have the ?tos=yes params.)

Needs nginx changes to remember the parameters.

## Testing Instructions

Refer to Jira.