### PR TITLE
AO3-5906 Move adult content warning acceptance to separate cookie

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -387,7 +387,7 @@ public
   def see_adult?
     params[:anchor] = "comments" if (params[:show_comments] && params[:anchor].blank?)
     Rails.logger.debug "Added anchor #{params[:anchor]}"
-    return true if session[:adult] || logged_in_as_admin?
+    return true if cookies[:view_adult] || logged_in_as_admin?
     return false unless current_user
     return true if current_user.is_author_of?(@work)
     return true if current_user.preference && current_user.preference.adult

--- a/app/controllers/chapters_controller.rb
+++ b/app/controllers/chapters_controller.rb
@@ -28,7 +28,7 @@ class ChaptersController < ApplicationController
   def show
     @tag_groups = @work.tag_groups
     if params[:view_adult]
-      session[:adult] = true
+      cookies[:view_adult] = "true"
     elsif @work.adult? && !see_adult?
       render "works/_adult", layout: "application" and return
     end

--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -192,7 +192,7 @@ class WorksController < ApplicationController
 
     # Users must explicitly okay viewing of adult content
     if params[:view_adult]
-      session[:adult] = true
+      cookies[:view_adult] = "true"
     elsif @work.adult? && !see_adult?
       render('_adult', layout: 'application') && return
     end

--- a/spec/controllers/chapters_controller_spec.rb
+++ b/spec/controllers/chapters_controller_spec.rb
@@ -102,7 +102,7 @@ describe ChaptersController do
 
       it "stores adult preference in sessions when given" do
         get :show, params: { work_id: work.id, id: work.chapters.first, view_adult: true }
-        expect(session[:adult]).to be true
+        expect(cookies[:view_adult]).to eq "true"
       end
 
       it "renders _adults template if work is adult and adult permission has not been given" do


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5906

## Purpose

Creates a new session cookie for users who have accepted the adult content warning. We can use this cookie to determine which cached page nginx should give a user.

Note: We had some trouble with the session cookie not being sticky enough for logins, which is why even a non-"Remember me" log in lasts two weeks. We might have to set the expiry on this to 2 weeks as well.

## Testing

Refer to Jira.

