### PR TITLE
AO3-5908 Redirect to work_chapter_path after accepting adult content warning

### DIFF
--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -206,7 +206,7 @@ class WorksController < ApplicationController
         )
       else
         flash.keep
-        redirect_to([@work, @chapter]) && return
+        redirect_to(work_chapter_path(@work, @chapter)) && return
       end
     end
 


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5908

## Purpose

Makes an attempt at redirecting to a path rather than a URL after accepting the adult content warning on a multichapter work. The idea is to stop bouncing people on the insecure site to secure.
