### PR TITLE
AO3-5906 Set view adult response header for nginx to convert to cookie

### DIFF
--- a/app/controllers/chapters_controller.rb
+++ b/app/controllers/chapters_controller.rb
@@ -29,7 +29,7 @@ class ChaptersController < ApplicationController
     @tag_groups = @work.tag_groups
     if params[:view_adult]
       cookies[:view_adult] = "true"
-      response.set_header('X-view-adult', 'true')
+      response.set_header("X-view-adult", "true")
     elsif @work.adult? && !see_adult?
       render "works/_adult", layout: "application" and return
     end

--- a/app/controllers/chapters_controller.rb
+++ b/app/controllers/chapters_controller.rb
@@ -29,6 +29,7 @@ class ChaptersController < ApplicationController
     @tag_groups = @work.tag_groups
     if params[:view_adult]
       cookies[:view_adult] = "true"
+      response.set_header('X-view-adult', 'true')
     elsif @work.adult? && !see_adult?
       render "works/_adult", layout: "application" and return
     end

--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -193,6 +193,7 @@ class WorksController < ApplicationController
     # Users must explicitly okay viewing of adult content
     if params[:view_adult]
       cookies[:view_adult] = "true"
+      response.set_header('X-view-adult', 'true')
     elsif @work.adult? && !see_adult?
       render('_adult', layout: 'application') && return
     end

--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -193,7 +193,7 @@ class WorksController < ApplicationController
     # Users must explicitly okay viewing of adult content
     if params[:view_adult]
       cookies[:view_adult] = "true"
-      response.set_header('X-view-adult', 'true')
+      response.set_header("X-view-adult", "true")
     elsif @work.adult? && !see_adult?
       render('_adult', layout: 'application') && return
     end

--- a/spec/controllers/chapters_controller_spec.rb
+++ b/spec/controllers/chapters_controller_spec.rb
@@ -103,6 +103,7 @@ describe ChaptersController do
       it "stores adult preference in sessions when given" do
         get :show, params: { work_id: work.id, id: work.chapters.first, view_adult: true }
         expect(cookies[:view_adult]).to eq "true"
+	expect(response.headers["X-view-adult"]).to eq "true"
       end
 
       it "renders _adults template if work is adult and adult permission has not been given" do

--- a/spec/controllers/chapters_controller_spec.rb
+++ b/spec/controllers/chapters_controller_spec.rb
@@ -103,7 +103,7 @@ describe ChaptersController do
       it "stores adult preference in sessions when given" do
         get :show, params: { work_id: work.id, id: work.chapters.first, view_adult: true }
         expect(cookies[:view_adult]).to eq "true"
-	expect(response.headers["X-view-adult"]).to eq "true"
+        expect(response.headers["X-view-adult"]).to eq "true"
       end
 
       it "renders _adults template if work is adult and adult permission has not been given" do


### PR DESCRIPTION
# Pull Request Checklist

* [ ] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [ ] Have you read through the [contributor guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [ ] Have you added tests for any changed functionality?
* [ ] Have you added the [JIRA](https://otwarchive.atlassian.net) issue number as the *first* thing in your pull request title (eg: `AO3-1234 Fix thing`)
* [ ] Have you updated or commented on the JIRA issue with the information below?

## Issue

https://otwarchive.atlassian.net/browse/AO3-5906

## Purpose

This adds an arbitary header we plan on catching in nginx and turning in to a cookie.

## Testing Instructions

Refer to Jira.