### PR TITLE
AO3-5908 Redirect to a multi-chapter work's first chapter with a relative URL

### DIFF
--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -206,7 +206,7 @@ class WorksController < ApplicationController
         )
       else
         flash.keep
-        redirect_to(work_chapter_path(@work, @chapter)) && return
+        redirect_to([@work, @chapter, { only_path: true }]) && return
       end
     end
 


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5908

## Purpose

If we give [redirect_to](https://api.rubyonrails.org/v5.1/classes/ActionController/Redirecting.html#method-i-redirect_to) a string without protocols, it automatically prepends the current protocol and host, making the URL absolute.

Instead we give it an options hash with which it will call url_for.

## Testing Instructions

See issue.