### PR TITLE
AO3-5915 Write TOS acceptance to cookie when localStorage not available

### DIFF
--- a/app/views/layouts/_javascripts.html.erb
+++ b/app/views/layouts/_javascripts.html.erb
@@ -52,14 +52,14 @@
     params[:controller] == "abuse_reports" && params[:action] == "new" ||
     params[:controller] == "feedbacks" && params[:action] == "new" %>
   <%= javascript_tag do %>
-    <% # localStorage polyfill we only needed for guests. %>
-    <% if !current_user %>
+    <% # localStorage polyfill we only need for guests. %>
+    <% unless current_user %>
       // We can't rely on !window.localStorage to test localStorage support in
       // browsers like Safari 9, which technically support it, but which have a
       // storage length of 0 in private mode.
       // Credit: https://github.com/getgrav/grav-plugin-admin/commit/cfe2188f10c4ca604e03c96f3e21537fda1cdf9a
       function isSupported() {
-          var item = "localStoragePollyfill";
+          var item = "localStoragePolyfill";
           try {
               localStorage.setItem(item, item);
               localStorage.removeItem(item);
@@ -76,8 +76,8 @@
       // Credit: https://developer.mozilla.org/en-US/docs/Web/API/Web_Storage_API/Local_storage
       if (!isSupported()) {
         // 20 years is the Rails maximum and what we previous used.  
-        var expiry_date = new Date;
-        expiry_date.setFullYear(expiry_date.getFullYear() + 20);
+        var expiryDate = new Date;
+        expiryDate.setFullYear(expiryDate.getFullYear() + 20);
 
         // window.localStorage is read only, ergo we must delete it for this to
         // work in instances like Safari 9 private mode.
@@ -92,7 +92,7 @@
           },
           setItem: function (sKey, sValue) {
             if(!sKey) { return; }
-            document.cookie = escape(sKey) + "=" + escape(sValue) + "; expires=" + expiry_date.toUTCString() + "; path=/";
+            document.cookie = escape(sKey) + "=" + escape(sValue) + "; expires=" + expiryDate.toUTCString() + "; path=/";
             this.length = document.cookie.match(/\=/g).length;
           },
           length: 0,

--- a/app/views/layouts/_javascripts.html.erb
+++ b/app/views/layouts/_javascripts.html.erb
@@ -52,6 +52,63 @@
     params[:controller] == "abuse_reports" && params[:action] == "new" ||
     params[:controller] == "feedbacks" && params[:action] == "new" %>
   <%= javascript_tag do %>
+    <% # localStorage polyfill we only needed for guests. %>
+    <% if !current_user %>
+      // We can't rely on !window.localStorage to test localStorage support in
+      // browsers like Safari 9, which technically support it, but which have a
+      // storage length of 0 in private mode.
+      // Credit: https://github.com/getgrav/grav-plugin-admin/commit/cfe2188f10c4ca604e03c96f3e21537fda1cdf9a
+      function isSupported() {
+          var item = "localStoragePollyfill";
+          try {
+              localStorage.setItem(item, item);
+              localStorage.removeItem(item);
+              sessionStorage.setItem(item, item);
+              sessionStorage.removeItem(item);
+              return true;
+          } catch (e) {
+              return false;
+          }
+      }
+
+      // For browsers that don't support localStorage according to our check,
+      // make its functions handle cookies instead.
+      // Credit: https://developer.mozilla.org/en-US/docs/Web/API/Web_Storage_API/Local_storage
+      if (!isSupported()) {
+        // 20 years is the Rails maximum and what we previous used.  
+        var expiry_date = new Date;
+        expiry_date.setFullYear(expiry_date.getFullYear() + 20);
+
+        // window.localStorage is read only, ergo we must delete it for this to
+        // work in instances like Safari 9 private mode.
+        delete window.localStorage;
+        window.localStorage = {
+          getItem: function (sKey) {
+            if (!sKey || !this.hasOwnProperty(sKey)) { return null; }
+            return unescape(document.cookie.replace(new RegExp("(?:^|.*;\\s*)" + escape(sKey).replace(/[\-\.\+\*]/g, "\\$&") + "\\s*\\=\\s*((?:[^;](?!;))*[^;]?).*"), "$1"));
+          },
+          key: function (nKeyId) {
+            return unescape(document.cookie.replace(/\s*\=(?:.(?!;))*$/, "").split(/\s*\=(?:[^;](?!;))*[^;]?;\s*/)[nKeyId]);
+          },
+          setItem: function (sKey, sValue) {
+            if(!sKey) { return; }
+            document.cookie = escape(sKey) + "=" + escape(sValue) + "; expires=" + expiry_date.toUTCString() + "; path=/";
+            this.length = document.cookie.match(/\=/g).length;
+          },
+          length: 0,
+          removeItem: function (sKey) {
+            if (!sKey || !this.hasOwnProperty(sKey)) { return; }
+            document.cookie = escape(sKey) + "=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/";
+            this.length--;
+          },
+          hasOwnProperty: function (sKey) {
+            return (new RegExp("(?:^|;\\s*)" + escape(sKey).replace(/[\-\.\+\*]/g, "\\$&") + "\\s*\\=")).test(document.cookie);
+          }
+        };
+        window.localStorage.length = (document.cookie.match(/\=/g) || window.localStorage).length;
+      }
+    <% end %>
+
     $j(document).ready(function() {
       <% if current_user %>
         <% # Users who haven't accepted this TOS need the popup. %>


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5915

## Purpose

Some browsers that support localStorage do weird things like stop you from putting anything in it in private mode. This means visitors using those browsers can't get past the GDPR TOS prompt.

So what we're doing here is testing setting something in localStorage and then, if that doesn't work, repurposing it to create (or update or remove) a cookie.

## Testing Instructions

Refer to Jira.

## References

Refer to code comments.

