### PR TITLE
AO3-5820 Add "Select" label to checkboxes for inbox comments

### DIFF
--- a/app/views/inbox/show.html.erb
+++ b/app/views/inbox/show.html.erb
@@ -64,8 +64,11 @@
                 </li>
               <% end %>
 
-              <li class="action">
-                <%= check_box_tag "inbox_comments[]", inbox_comment.id, false, :title => ts("select this comment"), :id => "inbox_comments_#{inbox_comment.id}" %>
+              <li>
+                <%= label_tag "inbox_comments_#{inbox_comment.id}" do %>
+                  <%= check_box_tag "inbox_comments[]", inbox_comment.id, false, :id => "inbox_comments_#{inbox_comment.id}" %>
+                  <%= ts("Select") %>
+                <% end %>
               </li>
             </ul>
           </li>

--- a/app/views/inbox/show.html.erb
+++ b/app/views/inbox/show.html.erb
@@ -66,7 +66,7 @@
 
               <li>
                 <%= label_tag "inbox_comments_#{inbox_comment.id}" do %>
-                  <%= check_box_tag "inbox_comments[]", inbox_comment.id, false, :id => "inbox_comments_#{inbox_comment.id}" %>
+                  <%= check_box_tag "inbox_comments[]", inbox_comment.id, false, id: "inbox_comments_#{inbox_comment.id}" %>
                   <%= ts("Select") %>
                 <% end %>
               </li>

--- a/features/comments_and_kudos/inbox.feature
+++ b/features/comments_and_kudos/inbox.feature
@@ -49,6 +49,21 @@ Feature: Get messages in the inbox
       And I press "Filter"
     Then I should not see "guest on Down for the Count"
 
+  Scenario: A user can select a comment by clicking on 'Select' on the inbox page
+    Given I am logged in as "boxer" with password "10987tko"
+      And I post the work "The Fight"
+      And I set my preferences to turn on messages to my inbox about comments
+    When I am logged in as "cutman"
+      And I post the comment "You should receive this in your inbox." on the work "The Fight"
+    When I am logged in as "boxer" with password "10987tko"
+      And I go to my inbox page
+    Then I should see "cutman on The Fight"
+      And I should see "You should receive this in your inbox."
+      And I should see "Unread"
+    When I press "Select"
+      And I press "Mark Read"
+    Then I should not see "Unread"
+
   Scenario: A user can see some of their unread comments on the homepage
     Given I am logged in as "boxer" with password "10987tko"
       And I post the work "Pre-Fight Coverage"

--- a/features/comments_and_kudos/inbox.feature
+++ b/features/comments_and_kudos/inbox.feature
@@ -52,7 +52,6 @@ Feature: Get messages in the inbox
   Scenario: I can bulk edit comments in my inbox by clicking 'Select'
     Given I am logged in as "boxer"
       And I post the work "The Fight"
-      And I set my preferences to turn on messages to my inbox about comments
     When I am logged in as "cutman"
       And I post the comment "You should receive this in your inbox." on the work "The Fight"
       And I post the comment "A second message for your inbox!" on the work "The Fight"

--- a/features/comments_and_kudos/inbox.feature
+++ b/features/comments_and_kudos/inbox.feature
@@ -49,18 +49,22 @@ Feature: Get messages in the inbox
       And I press "Filter"
     Then I should not see "guest on Down for the Count"
 
-  Scenario: A user can select a comment by clicking on 'Select' on the inbox page
+  Scenario: I can bulk edit comments in my inbox by clicking 'Select'
     Given I am logged in as "boxer" with password "10987tko"
       And I post the work "The Fight"
       And I set my preferences to turn on messages to my inbox about comments
     When I am logged in as "cutman"
       And I post the comment "You should receive this in your inbox." on the work "The Fight"
+      And I post the comment "A second message for your inbox!" on the work "The Fight"
     When I am logged in as "boxer" with password "10987tko"
       And I go to my inbox page
     Then I should see "cutman on The Fight"
       And I should see "You should receive this in your inbox."
-      And I should see "Unread"
-    When I press "Select"
+      And I should see "A second message for your inbox!"
+      And I should see "Unread" within "li.comment:first-child"
+      And I should see "Unread" within "li.comment:last-child"
+    When I check "Select" within "li.comment:first-child"
+      And I check "Select" within "li.comment:last-child"
       And I press "Mark Read"
     Then I should not see "Unread"
 

--- a/features/comments_and_kudos/inbox.feature
+++ b/features/comments_and_kudos/inbox.feature
@@ -50,13 +50,13 @@ Feature: Get messages in the inbox
     Then I should not see "guest on Down for the Count"
 
   Scenario: I can bulk edit comments in my inbox by clicking 'Select'
-    Given I am logged in as "boxer" with password "10987tko"
+    Given I am logged in as "boxer"
       And I post the work "The Fight"
       And I set my preferences to turn on messages to my inbox about comments
     When I am logged in as "cutman"
       And I post the comment "You should receive this in your inbox." on the work "The Fight"
       And I post the comment "A second message for your inbox!" on the work "The Fight"
-    When I am logged in as "boxer" with password "10987tko"
+    When I am logged in as "boxer"
       And I go to my inbox page
     Then I should see "cutman on The Fight"
       And I should see "You should receive this in your inbox."

--- a/features/comments_and_kudos/inbox.feature
+++ b/features/comments_and_kudos/inbox.feature
@@ -49,21 +49,6 @@ Feature: Get messages in the inbox
       And I press "Filter"
     Then I should not see "guest on Down for the Count"
 
-  Scenario: A user can select a comment by clicking on 'Select' on the inbox page
-    Given I am logged in as "boxer" with password "10987tko"
-      And I post the work "The Fight"
-      And I set my preferences to turn on messages to my inbox about comments
-    When I am logged in as "cutman"
-      And I post the comment "You should receive this in your inbox." on the work "The Fight"
-    When I am logged in as "boxer" with password "10987tko"
-      And I go to my inbox page
-    Then I should see "cutman on The Fight"
-      And I should see "You should receive this in your inbox."
-      And I should see "Unread"
-    When I press "Select"
-      And I press "Mark Read"
-    Then I should not see "Unread"
-
   Scenario: A user can see some of their unread comments on the homepage
     Given I am logged in as "boxer" with password "10987tko"
       And I post the work "Pre-Fight Coverage"


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [x] Have you added tests for any changed functionality?
^ had some problems with this - see comments.
* [x] Have you added the [JIRA](https://otwarchive.atlassian.net) issue number as the *first* thing in your pull request title (eg: `AO3-1234 Fix thing`)
* [x] Have you updated or commented on the JIRA issue with the information below?
^ I don't seem to have access to do this, sorry! I must have missed a step somewhere...

## Issue

https://otwarchive.atlassian.net/browse/AO3-5820

## Purpose

This PR adds a "Select" label to the checkbox for bulk-selecting comments in the Inbox, to increase the clickable area and improve accessibility.

## Testing Instructions

1. Log in
2. Find a work and leave a comment on it (or post a work)
3. Log out
4. Reply to the comment you left (or comment on your work)
5. Log in
6. Hi, username! > My Dashboard > Inbox
7. Click on "Select" and verify that the checkbox is selected.

## Credit

*What name do you want us to use to credit your work in the [Archive of Our Own's Release Notes](https://archiveofourown.org/admin_posts?tag=1)?*

Stephen Burrows

*What pronouns do you prefer (she/her, he/him, zie/hir etc)?*

he/him