### PR TITLE
AO3-5771 Correct URLs in tag lists generated from "show hidden" links

### DIFF
--- a/app/views/tags/show_hidden.js.erb
+++ b/app/views/tags/show_hidden.js.erb
@@ -7,6 +7,6 @@ else
   open_tags = "<li class=\"#{@display_category}\">"
   closing_tags = "</li>"
 end
-tag_list = @display_tags.map {|tag| open_tags + link_to_tag(tag) + closing_tags }
+tag_list = @display_tags.map {|tag| open_tags + link_to_tag_works(tag) + closing_tags }
 %>
 $j("#<%= "#{@display_creation.class.to_s.underscore}_#{@display_creation.id}_category_#{@display_category}" %>").replaceWith("<%= escape_javascript(tag_list.join(" ").html_safe) %>");

--- a/factories/tags.rb
+++ b/factories/tags.rb
@@ -68,6 +68,10 @@ FactoryBot.define do
     sequence(:name) { |n| "Unsorted Tag #{n}" }
   end
 
+  factory :archive_warning do
+    sequence(:name) { |n| "The #{n} Archive Warning"}
+  end
+
   factory :fandom do
     sequence(:name) { |n| "The #{n} Fandom" }
 

--- a/factories/tags.rb
+++ b/factories/tags.rb
@@ -69,7 +69,7 @@ FactoryBot.define do
   end
 
   factory :archive_warning do
-    sequence(:name) { |n| "The #{n} Archive Warning"}
+    sequence(:name) { |n| "The #{n} Archive Warning" }
   end
 
   factory :fandom do

--- a/factories/tags.rb
+++ b/factories/tags.rb
@@ -68,10 +68,6 @@ FactoryBot.define do
     sequence(:name) { |n| "Unsorted Tag #{n}" }
   end
 
-  factory :archive_warning do
-    sequence(:name) { |n| "The #{n} Archive Warning" }
-  end
-
   factory :fandom do
     sequence(:name) { |n| "The #{n} Fandom" }
 

--- a/features/other_a/preferences_edit.feature
+++ b/features/other_a/preferences_edit.feature
@@ -104,6 +104,7 @@ Feature: Edit preferences
   by-case basis.
 
   Given I limit myself to the Archive
+    And a canonical freeform "Scary tag"
     And I am logged in as "someone_else"
     And I post the work "Someone Else's Work" as part of a series "A Series"
     And I am logged in as "tester"

--- a/features/other_a/preferences_edit.feature
+++ b/features/other_a/preferences_edit.feature
@@ -123,6 +123,8 @@ Feature: Edit preferences
     And I should not see "Show additional tags"
   When I follow "Show warnings"
   Then I should see "No Archive Warnings Apply" within "dl.work.meta"
+  When I follow "No Archive Warnings Apply" within "dl.work.meta"
+  Then I should be on the works tagged "No Archive Warnings Apply"
   When I view the work "My Work"
   Then I should see "No Archive Warnings Apply" within "dl.work.meta"
     And I should not see "Show warnings"
@@ -138,6 +140,8 @@ Feature: Edit preferences
     And I should not see "Show additional tags"
   When I follow "Show warnings"
   Then I should see "No Archive Warnings Apply" within "li.warnings"
+  When I follow "No Archive Warnings Apply" within "li.warnings"
+  Then I should be on the works tagged "No Archive Warnings Apply"
   When I go to my works page
   Then I should see "My Work"
     And I should see "No Archive Warnings Apply" within "li.warnings"
@@ -154,6 +158,8 @@ Feature: Edit preferences
     And I should not see "Show additional tags"
   When I follow "Show warnings"
   Then I should see "No Archive Warnings Apply" within "li.warnings"
+  When I follow "No Archive Warnings Apply" within "li.warnings"
+  Then I should be on the works tagged "No Archive Warnings Apply"
 
   # Warnings are hidden in bookmark blurbs.
   # This is slightly excessive -- bookmarks use the work blurb -- but we'll
@@ -166,6 +172,8 @@ Feature: Edit preferences
     And I should not see "Show additional tags"
   When I follow "Show warnings"
   Then I should see "No Archive Warnings Apply" within "li.warnings"
+  When I follow "No Archive Warnings Apply" within "li.warnings"
+  Then I should be on the works tagged "No Archive Warnings Apply"
 
   # Change tester's preferences to hide freeforms as well as warnings.
   When I go to my preferences page
@@ -250,6 +258,8 @@ Feature: Edit preferences
     And I should not see "Scary tag" within "dl.work.meta"
   When I follow "Show additional tags"
   Then I should see "Scary tag" within "dl.work.meta"
+  When I follow "Scary tag" within "dl.work.meta"
+  Then I should be on the works tagged "Scary tag"
   When I view the work "My Work"
   Then I should see "No Archive Warnings Apply" within "dl.work.meta"
     And I should not see "Show warnings"
@@ -265,6 +275,8 @@ Feature: Edit preferences
     And I should see "Show additional tags"
   When I follow "Show additional tags"
   Then I should see "Scary tag" within "li.freeforms"
+  When I follow "Scary tag" within "li.freeforms"
+  Then I should be on the works tagged "Scary tag"
   When I go to my works page
   Then I should see "My Work"
     And I should see "No Archive Warnings Apply" within "li.warnings"
@@ -281,6 +293,8 @@ Feature: Edit preferences
     And I should see "Show additional tags"
   When I follow "Show additional tags"
   Then I should see "Scary tag" within "li.freeforms"
+  When I follow "Scary tag" within "li.freeforms"
+  Then I should be on the works tagged "Scary tag"
 
   # Freeforms are hidden in bookmark blurbs.
   When I go to my bookmarks page
@@ -291,6 +305,8 @@ Feature: Edit preferences
     And I should see "Show additional tags"
   When I follow "Show additional tags"
   Then I should see "Scary tag" within "li.freeforms"
+  When I follow "Scary tag" within "li.freeforms"
+  Then I should be on the works tagged "Scary tag"
 
   Scenario: User can hide warning and freeform tags on work blurbs and meta with
   JavaScript disabled, but gets an error if they attempt to reveal them.

--- a/spec/controllers/tags_controller_spec.rb
+++ b/spec/controllers/tags_controller_spec.rb
@@ -174,41 +174,20 @@ describe TagsController do
   end
 
   describe "show_hidden" do
-    let!(:fandom1) { create(:fandom, canonical: true) }
-    let!(:freeform1) { create(:freeform, canonical: false) }
-    let!(:character1) { create(:character, canonical: false) }
-    let!(:character2) { create(:character, canonical: false) }
-    let!(:work) do
-      create(:work,
-             posted: true,
-             fandom_string: fandom1.name,
-             character_string: "#{character1.name},#{character2.name}",
-             freeform_string: freeform1.name,
-             archive_warning_string: ArchiveConfig.WARNING_DEFAULT_TAG_NAME)
-    end
+    let(:work) { create(:work, posted: true) }
 
     it "redirects to referer with an error for non-ajax warnings requests" do
-      referer = root_path
+      referer = tags_path
       request.headers["HTTP_REFERER"] = referer
       get :show_hidden, params: { creation_type: "Work", tag_type: "warnings", creation_id: work.id }
       it_redirects_to_with_error(referer, "Sorry, you need to have JavaScript enabled for this.")
     end
 
-    it "returns successfully for ajax warnings requests" do
-      get :show_hidden, xhr: true, params: { creation_type: "Work", tag_type: "warnings", creation_id: work.id }
-      expect(response).to have_http_status(:success)
-    end
-
     it "redirects to referer with an error for non-ajax freeforms requests" do
-      referer = root_path
+      referer = tags_path
       request.headers["HTTP_REFERER"] = referer
       get :show_hidden, params: { creation_type: "Work", tag_type: "freeforms", creation_id: work.id }
       it_redirects_to_with_error(referer, "Sorry, you need to have JavaScript enabled for this.")
-    end
-
-    it "returns successfully for ajax freeforms requests" do
-      get :show_hidden, xhr: true, params: { creation_type: "Work", tag_type: "freeforms", creation_id: work.id }
-      expect(response).to have_http_status(:success)
     end
   end
 

--- a/spec/controllers/tags_controller_spec.rb
+++ b/spec/controllers/tags_controller_spec.rb
@@ -185,15 +185,27 @@ describe TagsController do
                         freeform_string: freeform1.name,
                         archive_warning_string: ArchiveConfig.WARNING_DEFAULT_TAG_NAME) }
 
-    it "redirects to referer with an error for non-ajax requests" do
+    it "redirects to referer with an error for non-ajax warnings requests" do
       referer = root_path
       request.headers["HTTP_REFERER"] = referer
       get :show_hidden, params: { creation_type: "Work", tag_type: "warnings", creation_id: work.id }
       it_redirects_to_with_error(referer, "Sorry, you need to have JavaScript enabled for this.")
     end
 
-    it "returns successfully for ajax requests" do
+    it "returns successfully for ajax warnings requests" do
       get :show_hidden, xhr: true, params: { creation_type: "Work", tag_type: "warnings", creation_id: work.id }
+      expect(response).to have_http_status(:success)
+    end
+
+    it "redirects to referer with an error for non-ajax freeforms requests" do
+      referer = root_path
+      request.headers["HTTP_REFERER"] = referer
+      get :show_hidden, params: { creation_type: "Work", tag_type: "freeforms", creation_id: work.id }
+      it_redirects_to_with_error(referer, "Sorry, you need to have JavaScript enabled for this.")
+    end
+
+    it "returns successfully for ajax freeforms requests" do
+      get :show_hidden, xhr: true, params: { creation_type: "Work", tag_type: "freeforms", creation_id: work.id }
       expect(response).to have_http_status(:success)
     end
   end

--- a/spec/controllers/tags_controller_spec.rb
+++ b/spec/controllers/tags_controller_spec.rb
@@ -173,6 +173,46 @@ describe TagsController do
     end
   end
 
+  describe "show_hidden" do
+    render_views
+
+    before do
+      @fandom1 = FactoryBot.create(:fandom, canonical: true)
+
+      @archive_warning = FactoryBot.create(:tag, name: ArchiveConfig.WARNING_VIOLENCE_TAG_NAME)
+      @freeform1 = FactoryBot.create(:freeform, canonical: false)
+      @character1 = FactoryBot.create(:character, canonical: false)
+      @character3 = FactoryBot.create(:character, canonical: false)
+      @character2 = FactoryBot.create(:character, canonical: false, merger: @character3)
+      @work = FactoryBot.create(:work,
+                                 posted: true,
+                                 fandom_string: "#{@fandom1.name}",
+                                 character_string: "#{@character1.name},#{@character2.name}",
+                                 freeform_string: "#{@freeform1.name}",
+                                 archive_warning_string: "#{@archive_warning.name}")
+    end
+    it "redirects to referer with an error for HTML format" do
+      referer = root_path
+      request.headers["HTTP_REFERER"] = referer
+      get :show_hidden, params: { creation_type: "Work", tag_type: "warnings", creation_id: @work.id }
+      it_redirects_to_with_error(referer, "Sorry, you need to have JavaScript enabled for this.")
+    end
+
+    it "returns a jquery callback to replace the caller with a list of warnings tags" do
+      get :show_hidden, xhr: true, params: { creation_type: "Work", tag_type: "warnings", creation_id: @work.id }
+      expect(@response).to have_http_status(:success)
+      expect(@response.body).to include(@archive_warning.name)
+      expect(@response.body).to include(tag_works_path(@archive_warning))
+    end
+
+    it "returns a jquery callback to replace the caller with a list of freeform tags" do
+      get :show_hidden, xhr: true, params: { creation_type: "Work", tag_type: "freeforms", creation_id: @work.id }
+      expect(response).to have_http_status(:success)
+      expect(@response.body).to include(@freeform1.name)
+      expect(@response.body).to include(tag_works_path(@freeform1))
+    end
+  end
+
   describe "edit" do
     context "when editing a banned tag" do
       before do

--- a/spec/controllers/tags_controller_spec.rb
+++ b/spec/controllers/tags_controller_spec.rb
@@ -174,7 +174,6 @@ describe TagsController do
   end
 
   describe "show_hidden" do
-    let(:archive_warning) { create(:archive_warning) }
     let(:fandom1) { create(:fandom, canonical: true) }
     let(:freeform1) { create(:freeform, canonical: false) }
     let(:character1) { create(:character, canonical: false) }
@@ -184,7 +183,7 @@ describe TagsController do
                         fandom_string: fandom1.name,
                         character_string: "#{character1.name},#{character2.name}",
                         freeform_string: freeform1.name,
-                        archive_warning_string: archive_warning.name) }
+                        archive_warning_string: ArchiveConfig.WARNING_DEFAULT_TAG_NAME) }
 
     it "redirects to referer with an error for non-ajax requests" do
       referer = root_path

--- a/spec/controllers/tags_controller_spec.rb
+++ b/spec/controllers/tags_controller_spec.rb
@@ -179,7 +179,7 @@ describe TagsController do
     before do
       @fandom1 = FactoryBot.create(:fandom, canonical: true)
 
-      @archive_warning = FactoryBot.create(:tag, name: ArchiveConfig.WARNING_VIOLENCE_TAG_NAME)
+      @archive_warning = FactoryBot.create(:archive_warning)
       @freeform1 = FactoryBot.create(:freeform, canonical: false)
       @character1 = FactoryBot.create(:character, canonical: false)
       @character3 = FactoryBot.create(:character, canonical: false)

--- a/spec/controllers/tags_controller_spec.rb
+++ b/spec/controllers/tags_controller_spec.rb
@@ -174,16 +174,18 @@ describe TagsController do
   end
 
   describe "show_hidden" do
-    let(:fandom1) { create(:fandom, canonical: true) }
-    let(:freeform1) { create(:freeform, canonical: false) }
-    let(:character1) { create(:character, canonical: false) }
-    let(:character2) { create(:character, canonical: false) }
-    let(:work) { create(:work,
-                        posted: true,
-                        fandom_string: fandom1.name,
-                        character_string: "#{character1.name},#{character2.name}",
-                        freeform_string: freeform1.name,
-                        archive_warning_string: ArchiveConfig.WARNING_DEFAULT_TAG_NAME) }
+    let!(:fandom1) { create(:fandom, canonical: true) }
+    let!(:freeform1) { create(:freeform, canonical: false) }
+    let!(:character1) { create(:character, canonical: false) }
+    let!(:character2) { create(:character, canonical: false) }
+    let!(:work) do
+      create(:work,
+             posted: true,
+             fandom_string: fandom1.name,
+             character_string: "#{character1.name},#{character2.name}",
+             freeform_string: freeform1.name,
+             archive_warning_string: ArchiveConfig.WARNING_DEFAULT_TAG_NAME)
+    end
 
     it "redirects to referer with an error for non-ajax warnings requests" do
       referer = root_path

--- a/spec/controllers/tags_controller_spec.rb
+++ b/spec/controllers/tags_controller_spec.rb
@@ -185,11 +185,11 @@ describe TagsController do
       @character3 = FactoryBot.create(:character, canonical: false)
       @character2 = FactoryBot.create(:character, canonical: false, merger: @character3)
       @work = FactoryBot.create(:work,
-                                 posted: true,
-                                 fandom_string: "#{@fandom1.name}",
-                                 character_string: "#{@character1.name},#{@character2.name}",
-                                 freeform_string: "#{@freeform1.name}",
-                                 archive_warning_string: "#{@archive_warning.name}")
+                                posted: true,
+                                fandom_string: @fandom1.name,
+                                character_string: "#{@character1.name},#{@character2.name}",
+                                freeform_string: @freeform1.name,
+                                archive_warning_string: @archive_warning.name)
 
       @html_regex = /replaceWith\("(?<html>.*)"\);/
     end
@@ -206,7 +206,7 @@ describe TagsController do
 
       if @html_regex =~ @response.body
         # Unescape javascript string and parse with Capybara
-        html = JSON.load("\"#{Regexp.last_match(:html)}\"")
+        html = JSON.parse("\"#{Regexp.last_match(:html)}\"")
         node = Capybara.string html
         link_node = node.find("li.warnings > strong > a")
         expect(link_node.text).to eq(@archive_warning.name)
@@ -222,7 +222,7 @@ describe TagsController do
 
       if @html_regex =~ @response.body
         # Unescape javascript string and parse with Capybara
-        html = JSON.load("\"#{Regexp.last_match(:html)}\"")
+        html = JSON.parse("\"#{Regexp.last_match(:html)}\"")
         node = Capybara.string html
         link_node = node.find("li.freeforms > a")
         expect(link_node.text).to eq(@freeform1.name)

--- a/spec/controllers/tags_controller_spec.rb
+++ b/spec/controllers/tags_controller_spec.rb
@@ -176,57 +176,53 @@ describe TagsController do
   describe "show_hidden" do
     render_views
 
-    before do
-      @fandom1 = FactoryBot.create(:fandom, canonical: true)
+    let(:archive_warning) { create(:archive_warning) }
+    let(:fandom1) { create(:fandom, canonical: true) }
+    let(:freeform1) { create(:freeform, canonical: false) }
+    let(:character1) { create(:character, canonical: false) }
+    let(:character2) { create(:character, canonical: false) }
+    let(:work) { create(:work,
+                        posted: true,
+                        fandom_string: fandom1.name,
+                        character_string: "#{character1.name},#{character2.name}",
+                        freeform_string: freeform1.name,
+                        archive_warning_string: archive_warning.name) }
+    let(:html_regex) { /replaceWith\("(?<html>.*)"\);/ }
 
-      @archive_warning = FactoryBot.create(:archive_warning)
-      @freeform1 = FactoryBot.create(:freeform, canonical: false)
-      @character1 = FactoryBot.create(:character, canonical: false)
-      @character3 = FactoryBot.create(:character, canonical: false)
-      @character2 = FactoryBot.create(:character, canonical: false, merger: @character3)
-      @work = FactoryBot.create(:work,
-                                posted: true,
-                                fandom_string: @fandom1.name,
-                                character_string: "#{@character1.name},#{@character2.name}",
-                                freeform_string: @freeform1.name,
-                                archive_warning_string: @archive_warning.name)
-
-      @html_regex = /replaceWith\("(?<html>.*)"\);/
-    end
     it "redirects to referer with an error for HTML format" do
       referer = root_path
       request.headers["HTTP_REFERER"] = referer
-      get :show_hidden, params: { creation_type: "Work", tag_type: "warnings", creation_id: @work.id }
+      get :show_hidden, params: { creation_type: "Work", tag_type: "warnings", creation_id: work.id }
       it_redirects_to_with_error(referer, "Sorry, you need to have JavaScript enabled for this.")
     end
 
     it "returns a jquery callback to replace the caller with a list of warnings tags" do
-      get :show_hidden, xhr: true, params: { creation_type: "Work", tag_type: "warnings", creation_id: @work.id }
-      expect(@response).to have_http_status(:success)
+      get :show_hidden, xhr: true, params: { creation_type: "Work", tag_type: "warnings", creation_id: work.id }
+      expect(response).to have_http_status(:success)
 
-      if @html_regex =~ @response.body
+      if html_regex =~ response.body
         # Unescape javascript string and parse with Capybara
         html = JSON.parse("\"#{Regexp.last_match(:html)}\"")
         node = Capybara.string html
         link_node = node.find("li.warnings > strong > a")
-        expect(link_node.text).to eq(@archive_warning.name)
-        expect(link_node[:href]).to eq(tag_works_path(@archive_warning))
+        expect(link_node.text).to eq(archive_warning.name)
+        expect(link_node[:href]).to eq(tag_works_path(archive_warning))
       else
         raise "No html found"
       end
     end
 
     it "returns a jquery callback to replace the caller with a list of freeform tags" do
-      get :show_hidden, xhr: true, params: { creation_type: "Work", tag_type: "freeforms", creation_id: @work.id }
+      get :show_hidden, xhr: true, params: { creation_type: "Work", tag_type: "freeforms", creation_id: work.id }
       expect(response).to have_http_status(:success)
 
-      if @html_regex =~ @response.body
+      if html_regex =~ response.body
         # Unescape javascript string and parse with Capybara
         html = JSON.parse("\"#{Regexp.last_match(:html)}\"")
         node = Capybara.string html
         link_node = node.find("li.freeforms > a")
-        expect(link_node.text).to eq(@freeform1.name)
-        expect(link_node[:href]).to eq(tag_works_path(@freeform1))
+        expect(link_node.text).to eq(freeform1.name)
+        expect(link_node[:href]).to eq(tag_works_path(freeform1))
       else
         raise "No html found"
       end


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [x] Have you added tests for any changed functionality?
* [x] Have you added the [JIRA](https://otwarchive.atlassian.net) issue number as the *first* thing in your pull request title (eg: `AO3-1234 Fix thing`)
* [x] Have you updated or commented on the JIRA issue with the information below?

## Issue

https://otwarchive.atlassian.net/browse/AO3-5771 (please fill in issue number and remove this comment)

## Purpose

Users can decide to hide archive warnings and/or freeform tags in their preferences. If they do, the tag lists they see on work list and detail pages will have "show warnings" / "show additional tags" links instead of the respective tag lists. Clicking on one of those links causes an AJAX request to `/tags/show_hidden` which returns a javascript file that replaces the link with custom-generated tag content.

Previously, the view for /tags/show_hidden generated links to the tag detail pages; however, the single location that uses the show_hidden functionality explicitly links to tag works, as can be seen here: https://github.com/otwcode/otwarchive/blob/030fa46/app/views/works/_meta.html.erb#L27\

This PR corrects the mismatch by making the response from /tags/show_hidden use tag works urls instead of tag detail urls.

## Testing Instructions

1. View a work and click on a warning / freeform tag
2. The link will go to the /tags/TAG/works page for that tag
3. View a work list page (like Browse > works) and click on a warning / freeform tag
4. The link will go to the /tags/TAG/works page for that tag
5. Go to preferences and turn on hide warnings/hide additional tags
6. View the work and show the hidden tags and click on one
7. The link should go to the /tags/TAG/works page for that tag
8. View a work list page (like Browse > works) and show the hidden tags and click on one
9. The link should go to the /tags/TAG/works page for that tag

## Credit

*What name do you want us to use to credit your work in the [Archive of Our Own's Release Notes](https://archiveofourown.org/admin_posts?tag=1)?*
Stephen Burrows

*What pronouns do you prefer (she/her, he/him, zie/hir etc)?*
he/him