### PR TITLE
AO3-3846 Make draft chapters display on chapter rearrange page

### DIFF
--- a/app/controllers/chapters_controller.rb
+++ b/app/controllers/chapters_controller.rb
@@ -20,7 +20,7 @@ class ChaptersController < ApplicationController
   # GET /work/:work_id/chapters/manage
   def manage
     @chapters = @work.chapters_in_order(include_content: false,
-                                        include_drafts: false)
+                                        include_drafts: true)
   end
 
   # GET /work/:work_id/chapters/:id

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -689,7 +689,7 @@ class Work < ApplicationRecord
 
   # Change the positions of the chapters in the work
   def reorder_list(positions)
-    SortableList.new(self.chapters.posted.in_order).reorder_list(positions)
+    SortableList.new(chapters_in_order(include_drafts: true)).reorder_list(positions)
     # We're caching the chapter positions in the comment blurbs
     # so we need to expire them
     async(:poke_cached_comments)

--- a/app/views/chapters/manage.html.erb
+++ b/app/views/chapters/manage.html.erb
@@ -24,6 +24,7 @@
                                         id: "chapters_" + chapter.position.to_s %>
         <span id="position-for-<%= chapter.id %>"><%= chapter.position %></span>.
         <%= chapter.chapter_title.html_safe %>
+        <% if !chapter.posted %>(Draft)<% end %>
 
         <ul class="chapter-control actions">
           <li><%= link_to ts("Edit"), [:edit, @work, chapter] %></li>

--- a/features/works/chapter_edit.feature
+++ b/features/works/chapter_edit.feature
@@ -145,12 +145,15 @@ Feature: Edit chapters
     And I should see "Chapter 4"
     And I should see "last chapter" within "#chapter-1"
 
-  # create a draft chapter and post it
+  # create a draft chapter and post it, and verify it shows up on the
+  # rearrange page
   When I am logged in as "epicauthor" with password "password"
     And a draft chapter is added to "New Epic Work"
   When I view the work "New Epic Work"
     And I follow "Edit"
   Then I should see "5 (Draft)"
+  When I follow "Manage Chapters"
+  Then I should see "Chapter 5"
   When I view the work "New Epic Work"
     Then I should see "4/5"
   When I select "5." from "selected_id"

--- a/features/works/chapter_edit.feature
+++ b/features/works/chapter_edit.feature
@@ -153,7 +153,7 @@ Feature: Edit chapters
     And I follow "Edit"
   Then I should see "5 (Draft)"
   When I follow "Manage Chapters"
-  Then I should see "Chapter 5"
+  Then I should see "Chapter 5 (Draft)"
   When I view the work "New Epic Work"
     Then I should see "4/5"
   When I select "5." from "selected_id"

--- a/spec/controllers/chapters_controller_spec.rb
+++ b/spec/controllers/chapters_controller_spec.rb
@@ -712,16 +712,14 @@ describe ChaptersController do
   end
 
   describe "update_positions" do
-    before do
-      @chapter1 = work.chapters.first
-      @chapter2 = create(:chapter, :draft, work: work, position: 2, authors: [user.pseuds.first])
-      @chapter3 = create(:chapter, work: work, position: 3, authors: [user.pseuds.first])
-      @chapter4 = create(:chapter, work: work, position: 4, authors: [user.pseuds.first])
-    end
+    let(:chapter1) { work.chapters.first }
+    let!(:chapter2) { create(:chapter, :draft, work: work, position: 2, authors: [user.pseuds.first]) }
+    let!(:chapter3) { create(:chapter, work: work, position: 3, authors: [user.pseuds.first]) }
+    let!(:chapter4) { create(:chapter, work: work, position: 4, authors: [user.pseuds.first]) }
 
     context "when user is logged out" do
       it "errors and redirects to login" do
-        post :update_positions, params: { work_id: work.id, chapter: [@chapter1, @chapter3, @chapter2] }
+        post :update_positions, params: { work_id: work.id, chapter: [chapter1, chapter3, chapter2, chapter4] }
         it_redirects_to_with_error(new_user_session_path, "Sorry, you don't have permission to access the page you were trying to reach. Please log in.")
       end
     end
@@ -734,26 +732,26 @@ describe ChaptersController do
       context "when passing params[:chapters]" do
         it "updates the positions of the chapters" do
           post :update_positions, params: { work_id: work.id, chapters: [1, 3, 2, 4] }
-          expect(@chapter1.reload.position).to eq(1)
-          expect(@chapter2.reload.position).to eq(3)
-          expect(@chapter3.reload.position).to eq(2)
-          expect(@chapter4.reload.position).to eq(4)
+          expect(chapter1.reload.position).to eq(1)
+          expect(chapter2.reload.position).to eq(3)
+          expect(chapter3.reload.position).to eq(2)
+          expect(chapter4.reload.position).to eq(4)
         end
 
         it "preserves ordering if order values are all empty" do
           post :update_positions, params: { work_id: work.id, chapters: ["", "", "", ""] }
-          expect(@chapter1.reload.position).to eq(1)
-          expect(@chapter2.reload.position).to eq(2)
-          expect(@chapter3.reload.position).to eq(3)
-          expect(@chapter4.reload.position).to eq(4)
+          expect(chapter1.reload.position).to eq(1)
+          expect(chapter2.reload.position).to eq(2)
+          expect(chapter3.reload.position).to eq(3)
+          expect(chapter4.reload.position).to eq(4)
         end
 
         it "preserves ordering for empty values" do
           post :update_positions, params: { work_id: work.id, chapters: ["", "", "", 1] }
-          expect(@chapter1.reload.position).to eq(2)
-          expect(@chapter2.reload.position).to eq(3)
-          expect(@chapter3.reload.position).to eq(4)
-          expect(@chapter4.reload.position).to eq(1)
+          expect(chapter1.reload.position).to eq(2)
+          expect(chapter2.reload.position).to eq(3)
+          expect(chapter3.reload.position).to eq(4)
+          expect(chapter4.reload.position).to eq(1)
         end
 
         it "gives a notice and redirects to work" do
@@ -764,11 +762,11 @@ describe ChaptersController do
 
       context "when passing params[:chapter]" do
         it "updates the positions of the chapters" do
-          post :update_positions, params: { work_id: work.id, chapter: [@chapter1, @chapter3, @chapter2, @chapter4], format: :js }
-          expect(@chapter1.reload.position).to eq(1)
-          expect(@chapter2.reload.position).to eq(3)
-          expect(@chapter3.reload.position).to eq(2)
-          expect(@chapter4.reload.position).to eq(4)
+          post :update_positions, params: { work_id: work.id, chapter: [chapter1, chapter3, chapter2, chapter4], format: :js }
+          expect(chapter1.reload.position).to eq(1)
+          expect(chapter2.reload.position).to eq(3)
+          expect(chapter3.reload.position).to eq(2)
+          expect(chapter4.reload.position).to eq(4)
         end
       end
     end

--- a/spec/controllers/chapters_controller_spec.rb
+++ b/spec/controllers/chapters_controller_spec.rb
@@ -45,7 +45,7 @@ describe ChaptersController do
         expect(response).to render_template(:manage)
       end
 
-      it "assigns @chapters to include draft works" do
+      it "assigns @chapters to include draft chapters" do
         chapter = create(:chapter, :draft, work: work, position: 2)
         get :manage, params: { work_id: work.id }
         expect(assigns[:chapters]).to eq([work.chapters.first, chapter])

--- a/spec/controllers/chapters_controller_spec.rb
+++ b/spec/controllers/chapters_controller_spec.rb
@@ -748,6 +748,14 @@ describe ChaptersController do
           expect(@chapter4.reload.position).to eq(4)
         end
 
+        it "preserves ordering for empty values" do
+          post :update_positions, params: { work_id: work.id, chapters: ["", "", "", 1] }
+          expect(@chapter1.reload.position).to eq(2)
+          expect(@chapter2.reload.position).to eq(3)
+          expect(@chapter3.reload.position).to eq(4)
+          expect(@chapter4.reload.position).to eq(1)
+        end
+
         it "gives a notice and redirects to work" do
           post :update_positions, params: { work_id: work.id, chapters: [1, 3, 2, 4] }
           it_redirects_to_with_notice(work, "Chapter order has been successfully updated.")

--- a/spec/controllers/chapters_controller_spec.rb
+++ b/spec/controllers/chapters_controller_spec.rb
@@ -45,10 +45,10 @@ describe ChaptersController do
         expect(response).to render_template(:manage)
       end
 
-      it "assigns @chapters to only posted chapters" do
-        create(:chapter, :draft, work: work)
+      it "assigns @chapters to include draft works" do
+        chapter = create(:chapter, :draft, work: work, position: 2)
         get :manage, params: { work_id: work.id }
-        expect(assigns[:chapters]).to eq([work.chapters.first])
+        expect(assigns[:chapters]).to eq([work.chapters.first, chapter])
       end
 
       it "assigns @chapters to chapters in order" do


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [x] Have you added tests for any changed functionality?
* [x] Have you added the [JIRA](https://otwarchive.atlassian.net) issue number as the *first* thing in your pull request title (eg: `AO3-1234 Fix thing`)
* [x] Have you updated or commented on the JIRA issue with the information below?

## Issue

https://otwarchive.atlassian.net/browse/AO3-3846

## Purpose

Makes it so that draft chapters are displayed on the chapter rearranging page rather than excluded. This allows them to be rearranged in the same way as other chapters.

## Testing Instructions

1. Create a multi-chapter work.
2. Add a draft chapter to the work.
3. Visit the work's Edit page.
4. Visit "Manage Chapters".
5. Verify that the draft chapter appears on the page.
6. Move draft chapter and save.
7. Verify that draft chapter number was updated.

## Credit

*What name do you want us to use to credit your work in the [Archive of Our Own's Release Notes](https://archiveofourown.org/admin_posts?tag=1)?*

Stephen Lewis

*What pronouns do you prefer (she/her, he/him, zie/hir etc)?*

he/him