### PR TITLE
AO3-5905 Don't yield empty batches in the new hit count code.

### DIFF
--- a/app/models/redis_hit_counter.rb
+++ b/app/models/redis_hit_counter.rb
@@ -117,7 +117,7 @@ class RedisHitCounter
 
       loop do
         cursor, batch = redis.send(scan_method, key, cursor, count: batch_size)
-        block.call(batch)
+        block.call(batch) if batch.any?
         break if cursor == "0"
       end
     end


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5905

## Purpose

Modifies the batch scanning code so that if it does retrieve an empty batch from Redis, it doesn't yield it to the block. This prevents issues if the batch is passed to, e.g. `SREM`, which won't accept an empty list as the second argument.