### PR TITLE
AO3-5905 Use one set for the hit count code.

### DIFF
--- a/config/resque_schedule.yml
+++ b/config/resque_schedule.yml
@@ -62,9 +62,9 @@ save_recent_counts_to_database:
   args: save_recent_counts
   description: "Save recent hit counts to database."
 
-remove_outdated_hit_count_keys:
+remove_old_hit_count_data:
   cron: "0 12 * * *"
   class: "RedisHitCounter"
   queue: utilities
-  args: remove_outdated_keys
+  args: remove_old_visits
   description: "Remove old hit count information from redis."


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5905

## Purpose

This PR modifies how IP addresses are stored by the hit count code. Instead of having one set of IP addresses for each `(work, timestamp)` pair, we have one set for each timestamp, storing pairs of `(work, ip_address)`. This still ensures that we don't count multiple hits on a single work by an IP address within a short period, but has a few advantages over the old system:
1. Because all of the data for a particular day is stored in one set, it's easier to delete batches of data. In the old system, if there was a work that received 2 hits in one day, the associated set and its elements would have to be removed in a separate Redis command, only 2 items in a single command. This way, each deletion command should remove roughly the same number of elements, which should hopefully be faster.
2. I think this representation might require less space, as well.
3. In the rewritten code, we use `SCAN` to iterate over all keys instead of using a Redis hash to keep track of all keys and their associated timestamps. This has the advantage that `RedisHitCounter.add` performs fewer Redis commands, potentially making it faster.

## Testing Instructions

Same as the original implementation.