### PR TITLE
AO3-4750 Expire work blurbs when chapters are reordered

### DIFF
--- a/app/models/chapter.rb
+++ b/app/models/chapter.rb
@@ -68,10 +68,11 @@ class Chapter < ApplicationRecord
           end
         end
       end
-      # We're caching the chapter positions in the comment blurbs
-      # so we need to expire them
+      # We're caching the chapter positions in the comment blurbs and the last
+      # chapter link in the work blurbs so we need to expire them
       if positions_changed
         work.comments.each{ |c| c.touch }
+        work.touch
       end
     end
   end

--- a/features/works/work_browse.feature
+++ b/features/works/work_browse.feature
@@ -99,3 +99,22 @@ whole work by default"
     And I browse the "Canonical Fandom" works
     And I follow the recent chapter link for the work "WIP"
   Then I should be on the 2nd chapter of the work "WIP"
+
+Scenario: The recent chapter link in a work's blurb points to the last posted
+chapter when the chapters are reordered.
+
+  Given I am logged in as a random user
+    And a canonical fandom "Canonical Fandom"
+    And I post the 2 chapter work "My WIP" with fandom "Canonical Fandom"
+  When I browse the "Canonical Fandom" works
+    And I follow the recent chapter link for the work "My WIP"
+  Then I should be on the 2nd chapter of the work "My WIP"
+  When I follow "Edit"
+    And I follow "Manage Chapters"
+    And I fill in "chapter_1" with "2"
+    And I fill in "chapter_2" with "1"
+    And I press "Update Positions"
+    And I browse the "Canonical Fandom" works
+    And I follow the recent chapter link for the work "My WIP"
+  Then I should be on the 2nd chapter of the work "My WIP"
+    And show me the page

--- a/features/works/work_browse.feature
+++ b/features/works/work_browse.feature
@@ -114,6 +114,7 @@ chapter when the chapters are reordered.
     And I fill in "chapters_1" with "2"
     And I fill in "chapters_2" with "1"
     And I press "Update Positions"
-    And I browse the "Canonical Fandom" works
+  Then I should see "Chapter order has been successfully updated."
+  When I browse the "Canonical Fandom" works
     And I follow the recent chapter link for the work "My WIP"
   Then I should be on the 2nd chapter of the work "My WIP"

--- a/features/works/work_browse.feature
+++ b/features/works/work_browse.feature
@@ -111,10 +111,9 @@ chapter when the chapters are reordered.
   Then I should be on the 2nd chapter of the work "My WIP"
   When I follow "Edit"
     And I follow "Manage Chapters"
-    And I fill in "chapter_1" with "2"
-    And I fill in "chapter_2" with "1"
+    And I fill in "chapters_1" with "2"
+    And I fill in "chapters_2" with "1"
     And I press "Update Positions"
     And I browse the "Canonical Fandom" works
     And I follow the recent chapter link for the work "My WIP"
   Then I should be on the 2nd chapter of the work "My WIP"
-    And show me the page


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-4750

## Purpose

If you reorder the chapters in a work, caching means the latest chapter linked in the blurb still points to the old last chapter.

Now we expire the cache.

## Testing Instructions

Do what red did:

* Posted a work and added a chapter. The work blurb in listings showed 2/2, with a link to chapter 2.
* Reordered the chapters, so chapter 2 became chapter 1. The blurb showed 2/2 and linked to the former chapter 2, or the current chapter 1.
