### PR TITLE
AO3-4750 Expire work index caches when a work's chapters are reordered

### DIFF
--- a/app/models/chapter.rb
+++ b/app/models/chapter.rb
@@ -69,10 +69,11 @@ class Chapter < ApplicationRecord
         end
       end
       # We're caching the chapter positions in the comment blurbs and the last
-      # chapter link in the work blurbs so we need to expire them
+      # chapter link in the work blurbs so we need to expire the blurbs and the
+      # work indexes.
       if positions_changed
         work.comments.each{ |c| c.touch }
-        work.touch
+        work.expire_caches
       end
     end
   end

--- a/features/works/work_browse.feature
+++ b/features/works/work_browse.feature
@@ -103,7 +103,9 @@ whole work by default"
 Scenario: The recent chapter link in a work's blurb points to the last posted
 chapter when the chapters are reordered.
 
-  Given I am logged in as a random user
+  Given the following admin settings are configured:
+    | enable_test_caching | 1 |
+    And I am logged in as a random user
     And a canonical fandom "Canonical Fandom"
     And I post the 2 chapter work "My WIP" with fandom "Canonical Fandom"
   When I browse the "Canonical Fandom" works


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-4750

## Purpose

Makes sure we're expiring the work blurb and index caches when a work's chapters are reordered, ensuring we always have the correct recent chapter link.

