### PR TITLE
AO3-5422 Remove unused methods in bookmarks_helper

### DIFF
--- a/app/helpers/bookmarks_helper.rb
+++ b/app/helpers/bookmarks_helper.rb
@@ -27,28 +27,6 @@ module BookmarksHelper
     end
   end
 
-  def get_bookmark_link_text(bookmarkable, blurb=false)
-    @bookmark = bookmark_if_exists(bookmarkable)
-    case bookmarkable.class.to_s
-    when blurb == true
-      @bookmark ? ts("Saved") : ts("Save")
-    when "Series"
-      @bookmark ? ts("Edit Series Bookmark") : ts("Bookmark Series")
-    when "ExternalWork"
-      @bookmark ? ts("Edit Bookmark") : ts("Add A New Bookmark")
-    else
-      @bookmark ? ts("Edit Bookmark") : ts("Bookmark")
-    end
-  end
-
-  # Link to bookmark
-  def bookmark_link(bookmarkable, blurb=false)
-    return "" unless logged_in?
-    url = get_bookmark_path(bookmarkable)
-    text = get_bookmark_link_text(bookmarkable, blurb)
-    link_to text, url
-  end
-
   def link_to_user_bookmarkable_bookmarks(bookmarkable)
     id_symbol = (bookmarkable.class.to_s.underscore + '_id').to_sym
     link_to "You have saved multiple bookmarks for this item", {controller: :bookmarks, action: :index, id_symbol => bookmarkable, existing: true}


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [ ] Have you added tests for any changed functionality?
  ^ N/A
* [x] Have you added the [JIRA](https://otwarchive.atlassian.net) issue number as the *first* thing in your pull request title (eg: `AO3-1234 Fix thing`)
* [x] Have you updated or commented on the JIRA issue with the information below?

## Issue

https://otwarchive.atlassian.net/browse/AO3-5422

## Purpose

This PR removes unused methods from bookmarks_helper - specifically get_bookmark_link_text and bookmark_link.

## Testing Instructions

N/A - no functional changes.

## Credit

*What name do you want us to use to credit your work in the [Archive of Our Own's Release Notes](https://archiveofourown.org/admin_posts?tag=1)?*

Stephen Burrows

*What pronouns do you prefer (she/her, he/him, zie/hir etc)?*

he/him