### PR TITLE
AO3-5423 Remove unused methods in users_helper

### DIFF
--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -15,16 +15,6 @@ module UsersHelper
     current_user.is_a?(User) ? current_user.maintained_collections.present? : false
   end
 
-  # print all works that belong to a given pseud
-  def print_works(pseud)
-    result = ''
-    conditions = logged_in? ? 'posted = 1' : 'posted = 1 AND restricted = 0 OR restricted IS NULL'
-    pseud.works.find(:all, order: 'works.revised_at DESC', conditions: conditions).each do |work|
-      result += (render partial: 'works/work_blurb', locals: { work: work })
-    end
-    result
-  end
-
   def sidebar_pseud_link_text(user, pseud)
     text = if current_page?(user)
              ts('Pseuds')
@@ -138,25 +128,6 @@ module UsersHelper
       items += visible_recs == 1 ? link_to(visible_recs.to_s + ' rec', user_pseud_bookmarks_path(pseud.user, pseud, recs_only: true)) : link_to(visible_recs.to_s + ' recs', user_pseud_bookmarks_path(pseud.user, pseud, recs_only: true))
     end
     items.html_safe
-  end
-
-  def authors_header(collection, what = 'People')
-    if collection.total_pages < 2
-      case collection.size
-      when 0
-        "0 #{what}"
-      when 1
-        "1 #{what.singularize}"
-      else
-        collection.total_entries.to_s + " #{what}"
-      end
-    else
-      %( %d - %d of %d ) %[
-        collection.offset + 1,
-        collection.offset + collection.length,
-        collection.total_entries
-      ] + what
-    end
   end
 
   def log_item_action_name(action)


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [ ] Have you added tests for any changed functionality?
  ^ N/A
* [x] Have you added the [JIRA](https://otwarchive.atlassian.net) issue number as the *first* thing in your pull request title (eg: `AO3-1234 Fix thing`)
* [x] Have you updated or commented on the JIRA issue with the information below?

## Issue

https://otwarchive.atlassian.net/browse/AO3-5423

## Purpose

This PR removes unused methods in users_helper, specifically print_works and authors_header.

## Testing Instructions

N/A - no functional changes.

## Credit

*What name do you want us to use to credit your work in the [Archive of Our Own's Release Notes](https://archiveofourown.org/admin_posts?tag=1)?*

Stephen Burrows

*What pronouns do you prefer (she/her, he/him, zie/hir etc)?*

he/him