### PR TITLE
AO3-5425 Remove unused methods in comments_helper

### DIFF
--- a/app/helpers/comments_helper.rb
+++ b/app/helpers/comments_helper.rb
@@ -273,43 +273,6 @@ module CommentsHelper
     end
   end
 
-  # non-JavaScript fallbacks for great justice!
-
-  def fallback_url_for_top_level(commentable, options = {})
-    default_options = {anchor: "comments"}
-    if commentable.is_a?(Tag)
-      default_options[:controller] = :comments
-      default_options[:action] = :index
-      default_options[:tag_id] = commentable.name
-    else
-      default_options[:controller] = commentable.class.to_s.underscore.pluralize
-      default_options[:action] = "show"
-      default_options[:id] = commentable.id
-    end
-    default_options[:add_comment] = params[:add_comment] if params[:add_comment]
-    default_options[:show_comments] = params[:show_comments] if params[:show_comments]
-
-    options = default_options.merge(options)
-    url_for(options)
-  end
-
-  def fallback_url_for_comment(comment, options = {})
-    default_options = {anchor: "comment_#{comment.id}"}
-    default_options[:action] = "show"
-    default_options[:show_comments] = true
-    default_options[:id] = comment.id if comment.ultimate_parent.is_a?(Tag)
-
-    options = default_options.merge(options)
-
-    if @thread_view # hopefully means we're on a Thread page
-      options[:id] = @thread_root if @thread_root
-      url_for(options)
-    else # Top Level Commentable
-      fallback_url_for_top_level(comment.ultimate_parent, options)
-    end
-
-  end
-
   # find the parent of the commentable
   def find_parent(commentable)
     if commentable.is_a?(Comment)


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [ ] Have you added tests for any changed functionality?
  ^ N/A
* [x] Have you added the [JIRA](https://otwarchive.atlassian.net) issue number as the *first* thing in your pull request title (eg: `AO3-1234 Fix thing`)
* [x] Have you updated or commented on the JIRA issue with the information below?

## Issue

https://otwarchive.atlassian.net/browse/AO3-5425

## Purpose

This PR removes unused methods from comments_helper, specifically fallback_url_for_comment and fallback_url_for_top_level.

## Testing Instructions

N/A - no functional changes.

## Credit

*What name do you want us to use to credit your work in the [Archive of Our Own's Release Notes](https://archiveofourown.org/admin_posts?tag=1)?*

Stephen Burrows

*What pronouns do you prefer (she/her, he/him, zie/hir etc)?*

he/him