### PR TITLE
AO3-5426 Removed unused link_to_tag_with_count method from pseuds_helper

### DIFF
--- a/app/helpers/pseuds_helper.rb
+++ b/app/helpers/pseuds_helper.rb
@@ -11,11 +11,4 @@ module PseudsHelper
     pseuds -= [@pseud] if @pseud && @pseud.new_record?
     list = pseuds.sort.collect {|pseud| "<li>" + span_if_current(pseud.name, [pseud.user, pseud]) + "</li>"}.join("").html_safe
   end
-
-  # For tag list on /people page
-  def link_to_tag_with_count(pseud, tag_w_count)
-    name = tag_w_count.first.name + " (" + tag_w_count.last.to_s + ")" 
-    url = user_pseud_works_path(pseud.user, pseud, selected_tags: [tag_w_count.first.id])
-    link_to name, url, class: 'tag'  
-  end
 end


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [ ] Have you added tests for any changed functionality?
  ^ N/A
* [x] Have you added the [JIRA](https://otwarchive.atlassian.net) issue number as the *first* thing in your pull request title (eg: `AO3-1234 Fix thing`)
* [x] Have you updated or commented on the JIRA issue with the information below?

## Issue

https://otwarchive.atlassian.net/browse/AO3-5426

## Purpose

This PR removes the unused link_to_tag_with_count method from pseuds_helper.

## Testing Instructions

N/A - no functional changes.

## Credit

*What name do you want us to use to credit your work in the [Archive of Our Own's Release Notes](https://archiveofourown.org/admin_posts?tag=1)?*

Stephen Burrows

*What pronouns do you prefer (she/her, he/him, zie/hir etc)?*

he/him