### PR TITLE
AO3-5757 Print feature file names in Cucumber output

### DIFF
--- a/features/support/formatter.rb
+++ b/features/support/formatter.rb
@@ -23,9 +23,8 @@ module Ao3Cucumber
     private
 
     def before_feature(feature)
-      # Print the feature's short description, followed by its file name
-      # in a different color.
-      @io.puts "#{feature} #{format_string(feature.location.file, :comment)}"
+      # Print the feature's file name.
+      @io.puts "#{feature.location.file}"
       @io.flush
       @current_feature = feature
       @start_time = Time.now

--- a/features/support/formatter.rb
+++ b/features/support/formatter.rb
@@ -24,7 +24,7 @@ module Ao3Cucumber
 
     def before_feature(feature)
       # Print the feature's file name.
-      @io.puts "#{feature.location.file}"
+      @io.puts feature.location.file
       @io.flush
       @current_feature = feature
       @start_time = Time.now


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5757

## Purpose

Stop printing feature descriptions, which we don't set consistently.

## Testing Instructions

Just tests. An example of the updated formatter in action: https://travis-ci.com/github/redsummernight/otwarchive/jobs/321432100.