### PR TITLE
AO3-5927 Disable jQuery animations in test environment

### DIFF
--- a/app/views/layouts/_javascripts.html.erb
+++ b/app/views/layouts/_javascripts.html.erb
@@ -33,6 +33,14 @@
       return elem === doc.activeElement && !!(elem.type || elem.href);
     }
   </script>
+  <!--
+    Disable jQuery animations, because the autocomplete dropdown cannot be
+    clicked while it's in the slideDown animation. This causes intermittent
+    failures in javascript-based autocomplete tests.
+  -->
+  <script type="text/javascript">
+    jQuery.fx.off = true;
+  </script>
 <% end %>
 
 <script type="text/javascript">$j = jQuery.noConflict();</script>

--- a/app/views/layouts/_javascripts.html.erb
+++ b/app/views/layouts/_javascripts.html.erb
@@ -36,7 +36,7 @@
   <!--
     Disable jQuery animations, because the autocomplete dropdown cannot be
     clicked while it's in the slideDown animation. This causes intermittent
-    failures in javascript-based autocomplete tests.
+    failures in JavaScript-based autocomplete tests.
   -->
   <script type="text/javascript">
     jQuery.fx.off = true;


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5927

## Purpose

Sets `jQuery.fx.off` to true in the test environment, to disable jQuery animations.