### PR TITLE
AO3-5889 Paginate pseuds using items per page limit

### DIFF
--- a/app/controllers/pseuds_controller.rb
+++ b/app/controllers/pseuds_controller.rb
@@ -14,7 +14,7 @@ class PseudsController < ApplicationController
   # GET /pseuds.xml
   def index
     if @user
-      @pseuds = @user.pseuds
+      @pseuds = @user.pseuds.paginate(page: params[:page])
       @rec_counts = Pseud.rec_counts_for_pseuds(@pseuds)
       @work_counts = Pseud.work_counts_for_pseuds(@pseuds)
       @page_subtitle = @user.login

--- a/app/views/pseuds/index.html.erb
+++ b/app/views/pseuds/index.html.erb
@@ -11,6 +11,10 @@
 <% end %>
 <!--/subnav-->
 
+<!--subnav-->
+<%= will_paginate @pseuds %>
+<!--/subnav-->
+
 <!--main content-->
 <h3 class="landmark heading"><%= ts("List of Pseuds") %></h3>
 <ul class="pseud index group">
@@ -20,4 +24,6 @@
 </ul>
 <!--/content-->
 
-
+<!--subnav-->
+<%= will_paginate @pseuds %>
+<!--/subnav-->

--- a/spec/requests/pseuds_spec.rb
+++ b/spec/requests/pseuds_spec.rb
@@ -1,0 +1,40 @@
+require "spec_helper"
+
+describe "Pseuds" do
+  subject { page }
+
+  describe "show" do
+    let(:user) { create(:user, login: "Agrajag") }
+
+    before do
+      create(:pseud, user: user, name: "Zaphod")
+      create(:pseud, user: user, name: "Slartibartfast")
+      create(:pseud, user: user, name: "Betelgeuse")
+    end
+
+    it "shows only the configured maximum number of pseuds" do
+      allow(Pseud).to receive(:per_page).and_return(3)
+
+      visit "/users/Agrajag/pseuds"
+
+      within("ol.pagination", match: :first) do
+        is_expected.to have_content("Next")
+        is_expected.to have_content("1")
+        is_expected.to have_link("2")
+      end
+
+      within("ul.pseud.index.group") do
+        is_expected.to have_content("Agrajag")
+        is_expected.to have_content("Betelgeuse")
+        is_expected.to have_content("Slartibartfast")
+        is_expected.not_to have_content("Zaphod")
+      end
+    end
+
+    it "doesn't show pagination UI when there are fewer pseuds than the limit" do
+      visit "/users/Agrajag/pseuds"
+
+      is_expected.to_not have_css("ol.pagination")
+    end
+  end
+end


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [x] Have you added tests for any changed functionality?
* [x] Have you added the [JIRA](https://otwarchive.atlassian.net) issue number as the *first* thing in your pull request title (eg: `AO3-1234 Fix thing`)
* [x] Have you updated or commented on the JIRA issue with the information below?

## Issue

https://otwarchive.atlassian.net/browse/AO3-5889

## Purpose

What does this PR do?

Paginate pseuds on the user's pseuds page using items per page limit. Pagination elements both at the top and bottom of pseuds list.

## Testing Instructions

How can the Archive's QA team verify that this is working as you intended?

## References

Are there any other relevant issues / PRs / mailing lists discussions related to this?

Yes, https://otwarchive.atlassian.net/browse/AO3-5901

## Credit

*What name do you want us to use to credit your work in the [Archive of Our Own's Release Notes](https://archiveofourown.org/admin_posts?tag=1)?*