### PR TITLE
AO3-5667 Add unique index to filter_taggings table

### DIFF
--- a/db/migrate/20200423205608_add_unique_index_to_filter_taggings.rb
+++ b/db/migrate/20200423205608_add_unique_index_to_filter_taggings.rb
@@ -1,0 +1,57 @@
+class AddUniqueIndexToFilterTaggings < ActiveRecord::Migration[5.1]
+  def up
+    if Rails.env.staging? || Rails.env.production?
+      database = FilterTagging.connection.current_database
+
+      puts <<~PTOSC
+        Schema Change Command:
+
+        pt-online-schema-change D=#{database},t=filter_taggings \\
+          --alter "ADD UNIQUE INDEX index_filter_taggings_on_filter_and_filterable (filter_id, filterable_type, filterable_id),
+                   DROP INDEX index_filter_taggings_on_filter_id_and_filterable_type" \\
+          --no-drop-old-table --no-check-unique-key-change \\
+          -uroot --ask-pass --chunk-size=5k --max-flow-ctl 0 --pause-file /tmp/pauseme \\
+          --max-load Threads_running=15 --critical-load Threads_running=100 \\
+          --set-vars innodb_lock_wait_timeout=2 --alter-foreign-keys-method=auto \\
+          --execute
+
+        Table Deletion Command:
+
+        DROP TABLE IF EXISTS `#{database}`.`_filter_taggings_old`;
+      PTOSC
+    else
+      add_index :filter_taggings, [:filter_id, :filterable_type, :filterable_id],
+                unique: true, name: "index_filter_taggings_on_filter_and_filterable"
+
+      remove_index :filter_taggings, name: "index_filter_taggings_on_filter_id_and_filterable_type"
+    end
+  end
+
+  def down
+    if Rails.env.staging? || Rails.env.production?
+      database = FilterTagging.connection.current_database
+
+      puts <<~PTOSC
+        Schema Change Command:
+
+        pt-online-schema-change D=#{database},t=filter_taggings \\
+          --alter "DROP INDEX index_filter_taggings_on_filter_and_filterable,
+                   ADD INDEX index_filter_taggings_on_filter_id_and_filterable_type (filter_id, filterable_type)" \\
+          --no-drop-old-table \\
+          -uroot --ask-pass --chunk-size=5k --max-flow-ctl 0 --pause-file /tmp/pauseme \\
+          --max-load Threads_running=15 --critical-load Threads_running=100 \\
+          --set-vars innodb_lock_wait_timeout=2 --alter-foreign-keys-method=auto \\
+          --execute
+
+        Table Deletion Command:
+
+        DROP TABLE IF EXISTS `#{database}`.`_filter_taggings_old`;
+      PTOSC
+    else
+      remove_index :filter_taggings, name: "index_filter_taggings_on_filter_and_filterable"
+
+      add_index :filter_taggings, [:filter_id, :filterable_type],
+                name: "index_filter_taggings_on_filter_id_and_filterable_type"
+    end
+  end
+end

--- a/spec/lib/tasks/tag_tasks.rake_spec.rb
+++ b/spec/lib/tasks/tag_tasks.rake_spec.rb
@@ -172,11 +172,4 @@ describe "rake Tag:reset_filters" do
     expect(work.filters.reload).not_to include(extra)
     expect(work.direct_filters.reload).not_to include(extra)
   end
-
-  it "remove duplicate filters" do
-    work.filter_taggings.build(filter: sub).save!(validate: false)
-    expect(sub.filtered_works.reload.count).to eq(2)
-    subject.invoke
-    expect(sub.filter_taggings.reload.count).to eq(1)
-  end
 end


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5667

## Purpose

This PR modifies the `filter_taggings` table to replace the existing index on `(filter_id, filterable_type)` with a unique index on `(filter_id, filterable_type, filterable_id)`.

## Testing Instructions

The usual steps for testing a migration should be sufficient: run it, then roll it back, then run it again. That should ensure that both the migration and its reverse are working.