### PR TITLE
AO3-5936 Enable experimental caching in feature tests

### DIFF
--- a/app/models/admin_setting.rb
+++ b/app/models/admin_setting.rb
@@ -28,6 +28,22 @@ class AdminSetting < ApplicationRecord
     disable_support_form?: false
   }.freeze
 
+  # Create AdminSetting.first on a blank database. We call this only in an initializer
+  # or a testing setup, not as part of any heavily used methods (e.g. AdminSetting.current).
+  def self.default
+    return AdminSetting.first if AdminSetting.first
+
+    settings = AdminSetting.new(
+      invite_from_queue_enabled: ArchiveConfig.INVITE_FROM_QUEUE_ENABLED,
+      invite_from_queue_number: ArchiveConfig.INVITE_FROM_QUEUE_NUMBER,
+      invite_from_queue_frequency: ArchiveConfig.INVITE_FROM_QUEUE_FREQUENCY,
+      account_creation_enabled: ArchiveConfig.ACCOUNT_CREATION_ENABLED,
+      days_to_purge_unactivated: ArchiveConfig.DAYS_TO_PURGE_UNACTIVATED
+    )
+    settings.save(validate: false)
+    settings
+  end
+
   def self.current
     Rails.cache.fetch("admin_settings", race_condition_ttl: 10.seconds) { AdminSetting.first } || OpenStruct.new(DEFAULT_SETTINGS)
   end
@@ -85,5 +101,4 @@ class AdminSetting < ApplicationRecord
       self.invite_from_queue_at = Time.now + self.invite_from_queue_frequency.days
     end
   end
-
 end

--- a/config/initializers/archive_config/settings_for_admin.rb
+++ b/config/initializers/archive_config/settings_for_admin.rb
@@ -1,12 +1,6 @@
 begin
-  ActiveRecord::Base.connection  # if we have no database fall through to rescue
-  if AdminSetting.table_exists? && !AdminSetting.first
-    settings = AdminSetting.new(invite_from_queue_enabled: ArchiveConfig.INVITE_FROM_QUEUE_ENABLED,
-          invite_from_queue_number: ArchiveConfig.INVITE_FROM_QUEUE_NUMBER,
-          invite_from_queue_frequency: ArchiveConfig.INVITE_FROM_QUEUE_FREQUENCY,
-          account_creation_enabled: ArchiveConfig.ACCOUNT_CREATION_ENABLED,
-          days_to_purge_unactivated: ArchiveConfig.DAYS_TO_PURGE_UNACTIVATED)
-    settings.save(validate: false)
-  end
+  # If we have no database, fall through to rescue
+  ActiveRecord::Base.connection
+  AdminSetting.default if AdminSetting.table_exists?
 rescue ActiveRecord::ConnectionNotEstablished
 end

--- a/features/other_a/invite_queue.feature
+++ b/features/other_a/invite_queue.feature
@@ -3,7 +3,6 @@ Feature: Invite queue management
 
   Background:
     Given I have no users
-    And I have an AdminSetting
     And the following admin exists
       | login       | password   | email                    |
       | admin-sam   | password   | test@archiveofourown.org |

--- a/features/other_a/pseud_dashboard.feature
+++ b/features/other_a/pseud_dashboard.feature
@@ -6,7 +6,6 @@ Feature: Pseud dashboard
 
   Scenario: Fandoms on pseud dashboard
 
-  Given tag wrangling is on
   Given the following activated user exists
     | login           | password   |
     | myself          | password   |

--- a/features/other_a/reading.feature
+++ b/features/other_a/reading.feature
@@ -1,74 +1,75 @@
 @users
 Feature: Reading count
 
-  Scenario: only see own reading history
-    Given the following activated user exists
-    | login          | password   |
-    | first_reader        | password   |
+  Scenario: A user can only see their own reading history
+
+  Given the following activated user exists
+    | login        |
+    | first_reader |
   When I am logged in as "second_reader"
     And I go to first_reader's reading page
-    Then I should see "Sorry, you don't have permission"
+  Then I should see "Sorry, you don't have permission"
     And I should not see "History" within "div#dashboard"
   When I go to second_reader's reading page
-    Then I should see "History" within "div#dashboard"
+  Then I should see "History" within "div#dashboard"
 
-  Scenario: Read a work several times, counts show on reading history
-      increment the count whenever you reread a story
-      also updates the date
+  Scenario: A user can read a work several times, updating the count and date in their history
+
     Given I am logged in as "writer"
       And I post the work "some work"
       And all indexing jobs have been run
       And I am logged out
     When I am logged in as "fandomer"
       And fandomer first read "some work" on "2010-05-25"
-    When I go to fandomer's reading page
+      And I go to fandomer's reading page
     Then I should see "some work"
       And I should see "Visited once"
       And I should see "Last visited: 25 May 2010"
-    When I am on writer's works page
-      And I follow "some work"
-    When the reading rake task is run
+
+    When time is frozen at 20/4/2020
+      And I go to the work "some work"
+      And the reading rake task is run
       And I go to fandomer's reading page
     Then I should see "Visited 2 times"
-      And I should see "Last visited: less than 1 minute ago"
+      And I should see "Last visited: 20 Apr 2020"
 
-  Scenario: disable reading history
-    then re-enable and check counts update again
+  Scenario: A user's reading history is updated only when enabled
 
     Given I am logged in as "writer"
       And I post the work "some work"
       And I am logged out
     When I am logged in as "fandomer"
       And fandomer first read "some work" on "2010-05-25"
-    When I go to fandomer's reading page
+      And I go to fandomer's reading page
     Then I should see "some work"
       And I should see "Visited once"
       And I should see "Last visited: 25 May 2010"
+
     When I follow "Preferences"
       And I uncheck "Turn on Viewing History"
       And I press "Update"
       And all indexing jobs have been run
     Then I should not see "My History"
-    When I am on writer's works page
-      And I follow "some work"
-    When I am on writer's works page
-      And I follow "some work"
-    When the reading rake task is run
+
+    When I go to the work "some work"
+      And the reading rake task is run
       And I go to fandomer's reading page
     Then I should see "You have reading history disabled"
       And I should not see "some work"
+
     When I check "Turn on Viewing History"
       And I press "Update"
     Then I should see "Your preferences were successfully updated."
+
     When I go to fandomer's reading page
     Then I should see "Visited once"
       And I should see "Last visited: 25 May 2010"
-    When I am on writer's works page
-      And I follow "some work"
-    When the reading rake task is run
+    When time is frozen at 20/4/2020
+      And I go to the work "some work"
+      And the reading rake task is run
       And I go to fandomer's reading page
     Then I should see "Visited 2 times"
-      And I should see "Last visited: less than 1 minute ago"
+      And I should see "Last visited: 20 Apr 2020"
 
   Scenario: Clear entire reading history
 
@@ -78,7 +79,7 @@ Feature: Reading count
       And I follow "First work"
       And I am on testuser's works page
       And I follow "second work"
-      And I am on testuser2's works page
+      And I am on testuser2 works page
       And I follow "fifth"
       And I should see "fifth by testuser2"
       And I follow "Proceed"

--- a/features/support/hooks.rb
+++ b/features/support/hooks.rb
@@ -3,6 +3,13 @@ require 'cucumber/timecop'
 require 'email_spec/cucumber'
 
 Before do
+  # Create default settings if necessary, since the database is truncated
+  # after every test.
+  #
+  # Enable our experimental caching, skipping validations which require
+  # setting an admin as the last updater.
+  AdminSetting.default.update_attribute(:enable_test_caching, true)
+
   # Create default language and locale.
   Locale.default
 

--- a/features/support/paths.rb
+++ b/features/support/paths.rb
@@ -25,8 +25,14 @@ module NavigationHelpers
       step %{all indexing jobs have been run}
       search_people_path
     when /^the bookmarks page$/i
+      # This cached page only expires by time, not by any user action;
+      # just clear it every time.
+      Rails.cache.delete "bookmarks/index/latest/v2_true"
       bookmarks_path
     when /^the works page$/i
+      # This cached page only expires by time, not by any user action;
+      # just clear it every time.
+      Rails.cache.delete "works/index/latest/v1"
       works_path
     when /^the admin login page$/i
       new_admin_session_path

--- a/features/tags_and_wrangling/tag_cloud.feature
+++ b/features/tags_and_wrangling/tag_cloud.feature
@@ -15,8 +15,7 @@ Scenario: tag cloud should only contain top-level canonical freeforms in "No Fan
     metatag freeforms with uses show up and their subtags do not anymore TODO
     metatag freeforms with no uses do not show and neither do their subtags (which I think is bad) TODO
 
-  Given tag wrangling is on
-    And the following activated tag wrangler exists
+  Given the following activated tag wrangler exists
     | login  | password    |
     | Enigel | wrangulate! |
     And basic tags

--- a/features/tags_and_wrangling/tag_wrangling_fandoms.feature
+++ b/features/tags_and_wrangling/tag_wrangling_fandoms.feature
@@ -148,7 +148,6 @@ Scenario: fandoms wrangling - syns, mergers, autocompletes, metatags
 Scenario: Checking the media pages
 
   Given basic tags
-    And tag wrangling is on
     And a media exists with name: "TV Shows", canonical: true
     And a media exists with name: "Video Games", canonical: true
     And a media exists with name: "Books", canonical: true

--- a/features/works/work_browse.feature
+++ b/features/works/work_browse.feature
@@ -103,9 +103,7 @@ whole work by default"
 Scenario: The recent chapter link in a work's blurb points to the last posted
 chapter when the chapters are reordered.
 
-  Given the following admin settings are configured:
-    | enable_test_caching | 1 |
-    And I am logged in as a random user
+  Given I am logged in as a random user
     And a canonical fandom "Canonical Fandom"
     And I post the 2 chapter work "My WIP" with fandom "Canonical Fandom"
   When I browse the "Canonical Fandom" works

--- a/features/works/work_delete.feature
+++ b/features/works/work_delete.feature
@@ -156,7 +156,8 @@ Feature: Delete Works
       And I fill in "Notes" with "My thoughts on the work"
       And I press "Create"
     Then I should see "Bookmark was successfully created"
-    When I go to the bookmarks page
+    When all indexing jobs have been run
+      And I go to the bookmarks page
     Then I should see "All Something Breaks Loose"
     When I am logged in as "thorough"
       And I go to giftee's user page
@@ -172,8 +173,8 @@ Feature: Delete Works
     When I go to thorough's user page
     Then I should not see "All Something Breaks Loose"
     # This is correct behaviour - bookmark details are preserved even though the work is gone
-    Then all indexing jobs have been run
-    Then I go to the bookmarks page
+    When all indexing jobs have been run
+      And I go to the bookmarks page
     Then I should not see "All Something Breaks Loose"
     When I go to someone_else's bookmarks page
     Then I should not see "All Something Breaks Loose"


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5936

## Purpose

- Add AdminSetting.default for use in both initializers and testing setups.
- Fix reading history tests, because with experimental caching, timestamps of readings are not relative.
- Simplify step definitions for setting up AdminSetting.first, remove step for turning on wrangling (it's on by default).
- Always clear cached results of "Latest Works" and "Latest Bookmarks" before checking them, as these caches never get expired by any user action.

## Testing Instructions

None.