### PR TITLE
AO3-5667 Use the reindex_world queue for the Tag:reset_filters task (both the filter jobs and the reindexing jobs).

### DIFF
--- a/app/models/concerns/filterable.rb
+++ b/app/models/concerns/filterable.rb
@@ -26,14 +26,16 @@ module Filterable
 
   class_methods do
     # Update the filters for all filterables in this relation.
-    def update_filters(async_update: false)
+    def update_filters(async_update: false,
+                       reindex_queue: :background,
+                       job_queue: :utilities)
       batch_size = ArchiveConfig.FILTER_UPDATE_BATCH_SIZE
 
       select(:id).find_in_batches(batch_size: batch_size) do |batch|
-        updater = FilterUpdater.new(base_class, batch.map(&:id), :background)
+        updater = FilterUpdater.new(base_class, batch.map(&:id), reindex_queue)
 
         if async_update
-          updater.async_update
+          updater.async_update(job_queue: job_queue)
         else
           updater.update
         end

--- a/app/models/indexing/index_queue.rb
+++ b/app/models/indexing/index_queue.rb
@@ -30,6 +30,10 @@ class IndexQueue
     new(key).add_ids(ids)
   end
 
+  def self.from_class_and_label(klass, label)
+    new(get_key(klass, label))
+  end
+
   ####################
   # INSTANCE METHODS
   ####################

--- a/app/models/indexing/scheduled_reindex_job.rb
+++ b/app/models/indexing/scheduled_reindex_job.rb
@@ -1,9 +1,10 @@
 class ScheduledReindexJob
+  MAIN_CLASSES = %w(Pseud Tag Work Bookmark Series ExternalWork).freeze
 
   def self.perform(reindex_type)
     classes = case reindex_type
               when 'main', 'background'
-                %w(Pseud Tag Work Bookmark Series ExternalWork)
+                MAIN_CLASSES
               when 'stats'
                 %w(StatCounter)
               end
@@ -11,7 +12,7 @@ class ScheduledReindexJob
   end
 
   def self.run_queue(klass, reindex_type)
-    IndexQueue.new("index:#{klass.underscore}:#{reindex_type}").run
+    IndexQueue.from_class_and_label(klass, reindex_type).run
   end
 
 end

--- a/lib/tasks/search.rake
+++ b/lib/tasks/search.rake
@@ -56,4 +56,11 @@ namespace :search do
       AsyncIndexer.new(PseudIndexer, :world).enqueue_ids(group.map(&:id))
     end
   end
+
+  desc "Run tasks enqueued to the world queue by IndexQueue."
+  task run_world_index_queue: :environment do
+    ScheduledReindexJob::MAIN_CLASSES.each do |klass|
+      IndexQueue.from_class_and_label(klass, :world).run
+    end
+  end
 end

--- a/lib/tasks/tag_tasks.rake
+++ b/lib/tasks/tag_tasks.rake
@@ -62,15 +62,26 @@ namespace :Tag do
 
   desc "Reset filter taggings"
   task(reset_filters: :environment) do
-    Work.update_filters(async_update: true) do
-      print(".") && STDOUT.flush
-    end
+    puts "Adding jobs for work filter updates to the reindex_world queue:"
 
-    ExternalWork.update_filters(async_update: true) do
+    Work.update_filters(async_update: true,
+                        job_queue: :reindex_world,
+                        reindex_queue: :world) do
       print(".") && STDOUT.flush
     end
 
     print("\n") && STDOUT.flush
+
+    puts "Adding jobs for external work filter updates to the reindex_world queue:"
+    ExternalWork.update_filters(async_update: true,
+                                job_queue: :reindex_world,
+                                reindex_queue: :world) do
+      print(".") && STDOUT.flush
+    end
+
+    print("\n") && STDOUT.flush
+
+    puts "All jobs enqueued! Once all jobs have finished running, call rake search:run_world_index_queue."
   end
 
   desc "Reset inherited meta taggings"

--- a/spec/lib/tasks/search_tasks.rake_spec.rb
+++ b/spec/lib/tasks/search_tasks.rake_spec.rb
@@ -1,0 +1,59 @@
+require "spec_helper"
+
+describe "rake search:run_world_index_queue" do
+  it "reindexes works" do
+    work = create(:work)
+    IndexQueue.enqueue(work, :world)
+    expect(WorkIndexer).to receive(:new)
+      .with([work.id.to_s]).and_call_original
+    expect(BookmarkedWorkIndexer).to receive(:new)
+      .with([work.id.to_s]).and_call_original
+
+    subject.invoke
+  end
+
+  it "reindexes pseuds" do
+    pseud = create(:pseud)
+    IndexQueue.enqueue(pseud, :world)
+    expect(PseudIndexer).to receive(:new)
+      .with([pseud.id.to_s]).and_call_original
+
+    subject.invoke
+  end
+
+  it "reindexes tags" do
+    tag = create(:tag)
+    IndexQueue.enqueue(tag, :world)
+    expect(TagIndexer).to receive(:new)
+      .with([tag.id.to_s]).and_call_original
+
+    subject.invoke
+  end
+
+  it "reindexes bookmarks" do
+    bookmark = create(:bookmark)
+    IndexQueue.enqueue(bookmark, :world)
+    expect(BookmarkIndexer).to receive(:new)
+      .with([bookmark.id.to_s]).and_call_original
+
+    subject.invoke
+  end
+
+  it "reindexes series" do
+    series = create(:series)
+    IndexQueue.enqueue(series, :world)
+    expect(BookmarkedSeriesIndexer).to receive(:new)
+      .with([series.id.to_s]).and_call_original
+
+    subject.invoke
+  end
+
+  it "reindexes external works" do
+    external_work = create(:external_work)
+    IndexQueue.enqueue(external_work, :world)
+    expect(BookmarkedExternalWorkIndexer).to receive(:new)
+      .with([external_work.id.to_s]).and_call_original
+
+    subject.invoke
+  end
+end

--- a/spec/lib/tasks/tag_tasks.rake_spec.rb
+++ b/spec/lib/tasks/tag_tasks.rake_spec.rb
@@ -172,4 +172,11 @@ describe "rake Tag:reset_filters" do
     expect(work.filters.reload).not_to include(extra)
     expect(work.direct_filters.reload).not_to include(extra)
   end
+
+  it "adds works to the world reindex queue" do
+    work.filters.delete(meta)
+    expect do
+      subject.invoke
+    end.to add_to_reindex_queue(work, :world)
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -157,8 +157,11 @@ def suspend_resque_workers
   # Set up an array to keep track of delayed actions.
   queue = []
 
-  # Override the default Resque.enqueue behavior.
-  allow(Resque).to receive(:enqueue) do |klass, *args|
+  # Override the default Resque.enqueue_to behavior.
+  #
+  # The first argument is which queue the job is supposed to be added to, but
+  # it doesn't matter for our purposes, so we ignore it.
+  allow(Resque).to receive(:enqueue_to) do |_, klass, *args|
     queue << [klass, args]
   end
 
@@ -171,6 +174,6 @@ def suspend_resque_workers
     klass.perform(*args)
   end
 
-  # Resume the original Resque.enqueue behavior.
-  allow(Resque).to receive(:enqueue).and_call_original
+  # Resume the original Resque.enqueue_to behavior.
+  allow(Resque).to receive(:enqueue_to).and_call_original
 end


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5667

## Purpose

We don't want the `Tag:reset_filters` task to hold up normal operations when it's being run, so we modify it to use the `reindex_world` queue for the asynchronous `FilterUpdate` jobs, and use the reindexing queue `world` (which maps to the `reindex_world` Resque queue) instead of `background` (which maps to the `reindex_low` Resque queue).

Because the `IndexQueue` doesn't normally reindex items added to the `world` queue, we additionally add a rake task `search:run_world_index_queue` that runs the `IndexQueue`s for the `world` queue. This task should be run after all of the filter updates are done and the `reindex_world` queue is empty. If it's run any sooner, there may be items that were added to the `world` queue that won't be reindexed. (Though that can be corrected by running `rake search:run_world_index_queue` again.)

## Testing Instructions

1. Run `bundle exec rake Tag:reset_filters`.
2. Check the Resque queues. There should be almost nothing in the `utilities` queue, and there should be 5000+ jobs in the `reindex_world` queue.
3. Keep an eye on the `reindex_world` queue and wait for all jobs in the queue to finish.
4. Run `bundle exec rake search:run_world_index_queue`.
5. Check the Resque queues. There should be almost nothing in the `reindex_low` queue, and there should be 500+ jobs in the `reindex_world` queue.