### PR TITLE
AO3-5667 Allow metatags to be upgraded from inherited to direct, and make removing associations synchronous.

### DIFF
--- a/app/models/meta_tagging.rb
+++ b/app/models/meta_tagging.rb
@@ -7,7 +7,7 @@ class MetaTagging < ApplicationRecord
   validates_presence_of :meta_tag, :sub_tag, message: "does not exist."
   validates_uniqueness_of :meta_tag_id,
                           scope: :sub_tag_id,
-                          message: "has already been added."
+                          message: "has already been added (possibly as an indirect metatag)."
 
   after_create :expire_caching
   after_destroy :expire_caching

--- a/app/models/meta_tagging.rb
+++ b/app/models/meta_tagging.rb
@@ -7,7 +7,7 @@ class MetaTagging < ApplicationRecord
   validates_presence_of :meta_tag, :sub_tag, message: "does not exist."
   validates_uniqueness_of :meta_tag_id,
                           scope: :sub_tag_id,
-                          message: "has already been added (possibly as an indirect metatag)."
+                          message: "has already been added."
 
   after_create :expire_caching
   after_destroy :expire_caching

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -810,9 +810,9 @@ class Tag < ApplicationRecord
     if tag.class == self.class
       if self.mergers.include?(tag)
         tag.update_attributes(merger_id: nil)
-      elsif self.meta_tags.include?(tag)
+      elsif self.direct_meta_tags.include?(tag)
         self.meta_tags.delete(tag)
-      elsif self.sub_tags.include?(tag)
+      elsif self.direct_sub_tags.include?(tag)
         tag.meta_tags.delete(self)
       end
     else
@@ -891,11 +891,13 @@ class Tag < ApplicationRecord
     end
 
     self.direct_meta_tags.find_each do |tag|
-      self.merger.meta_taggings.create(meta_tag: tag)
+      meta_tagging = self.merger.meta_taggings.find_or_initialize_by(meta_tag: tag)
+      meta_tagging.update(direct: true)
     end
 
     self.direct_sub_tags.find_each do |tag|
-      self.merger.sub_taggings.create(sub_tag: tag)
+      sub_tagging = self.merger.sub_taggings.find_or_initialize_by(sub_tag: tag)
+      sub_tagging.update(direct: true)
     end
   end
 
@@ -984,14 +986,16 @@ class Tag < ApplicationRecord
 
   def meta_tag_string=(tag_string)
     parse_tag_string(tag_string) do |name, parent|
-      meta_tagging = meta_taggings.build(meta_tag: parent, direct: true)
+      meta_tagging = meta_taggings.find_or_initialize_by(meta_tag: parent)
+      meta_tagging.direct = true
       save_and_gather_errors(meta_tagging, "Invalid metatag '#{name}':")
     end
   end
 
   def sub_tag_string=(tag_string)
     parse_tag_string(tag_string) do |name, sub|
-      sub_tagging = sub_taggings.build(sub_tag: sub, direct: true)
+      sub_tagging = sub_taggings.find_or_initialize_by(sub_tag: sub)
+      sub_tagging.direct = true
       save_and_gather_errors(sub_tagging, "Invalid subtag '#{name}':")
     end
   end

--- a/features/tags_and_wrangling/tag_wrangling.feature
+++ b/features/tags_and_wrangling/tag_wrangling.feature
@@ -339,6 +339,8 @@ Feature: Tag wrangling
       And I fill in "tag_meta_tag_string" with "Grandparent"
       And I press "Save changes"
     Then I should see "Tag was updated"
+      And I should see "Grandparent" within "#parent_MetaTag_associations_to_remove_checkboxes"
+      But I should not see "Parent" within "#parent_MetaTag_associations_to_remove_checkboxes"
 
     When I view the tag "Child"
     Then I should see "Grandparent" within ".meta"

--- a/features/tags_and_wrangling/tag_wrangling.feature
+++ b/features/tags_and_wrangling/tag_wrangling.feature
@@ -321,3 +321,40 @@ Feature: Tag wrangling
       And I am logged in as an admin
     When I view the tag "Cowboy Bebop"
     Then I should see "Troubleshoot"
+
+  Scenario: Can simultaneously add a grandparent metatag as a direct metatag and remove the parent metatag
+    Given a canonical fandom "Grandparent"
+      And a canonical fandom "Parent"
+      And a canonical fandom "Child"
+      And "Grandparent" is a metatag of the fandom "Parent"
+      And "Parent" is a metatag of the fandom "Child"
+      And I am logged in as a random user
+      And I post the work "Oldest" with fandom "Grandparent"
+      And I post the work "Middle" with fandom "Parent"
+      And I post the work "Youngest" with fandom "Child"
+      And I am logged in as a tag wrangler
+
+    When I edit the tag "Child"
+      And I check the 1st checkbox with id matching "MetaTag"
+      And I fill in "tag_meta_tag_string" with "Grandparent"
+      And I press "Save changes"
+    Then I should see "Tag was updated"
+
+    When I view the tag "Child"
+    Then I should see "Grandparent" within ".meta"
+      But I should not see "Parent" within ".meta"
+
+    When I go to the works tagged "Grandparent"
+    Then I should see "Oldest"
+      And I should see "Middle"
+      And I should see "Youngest"
+
+    When I go to the works tagged "Parent"
+    Then I should see "Middle"
+      But I should not see "Oldest"
+      And I should not see "Youngest"
+
+    When I go to the works tagged "Child"
+    Then I should see "Youngest"
+      But I should not see "Oldest"
+      And I should not see "Middle"

--- a/spec/controllers/tags_controller_spec.rb
+++ b/spec/controllers/tags_controller_spec.rb
@@ -427,15 +427,10 @@ describe TagsController do
           grandparent
         end
 
-        it "has a useful error" do
-          expect(assigns[:tag].errors.full_messages).to include(
-            "Invalid metatag '#{meta.name}': Metatag has already been " \
-            "added (possibly as an indirect metatag)."
-          )
-        end
+        include_examples "success message"
 
-        it "does not create two meta-taggings" do
-          expect(MetaTagging.where(sub_tag: tag, meta_tag: meta).count).to eq 1
+        it "marks the formerly inherited meta tagging as direct" do
+          expect(MetaTagging.find_by(sub_tag: tag, meta_tag: meta).direct).to be_truthy
         end
       end
     end


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5667

## Purpose

- If there's a metatag tree where A is the metatag of B is the metatag of C, and you decide that you want C to be the direct subtag of A instead of the direct subtag of B, the current way to do that involves removing B as C's metatag, waiting for the inherited association with C to be cleaned up, and then adding C as a direct metatag. This PR makes it possible to upgrade inherited metatags to direct metatags, to make the process easier for tag wranglers.
- In the current code, when you check the box to remove a metatag, it doesn't immediately remove the metatag. Instead, it queues up a job to remove the metatag. This means that the metatag remains on the edit page until the user refreshes (or, if the utilities queue is long, after the the queue has finished running and the user refreshes). This PR makes the action synchronous, and modifies the `remove_association` function to ensure that removing the association is a fast operation.

## Testing Instructions

1. Pick three canonical tags of the same type, with works under each.
2. Wrangle them into a chain, so that A is the metatag of B, and B is the metatag of C.
3. Wait until the works of C show up under both B and A to make sure that this worked.
4. Edit tag C.
5. Check the box to remove B as a metatag.
6. Fill in the name of A in the "Add MetaTag" box.
7. Press "Save changes."
8. Look at the MetaTags section on the edit page to make sure the changes went through.
9. View the tag, and check the "Metatags" section to make sure the changes are reflected there.
10. Wait about 10-20 minutes.
11. Check the works pages for each of the tags to make sure that A has works from all three tags, but B and C each have works only from their own tag.