### PR TITLE
AO3-5925 Add limited HTML instructions to logged out comment forms

### DIFF
--- a/app/views/comments/_comment_form.html.erb
+++ b/app/views/comments/_comment_form.html.erb
@@ -86,6 +86,7 @@
             <%= live_validation_for_field("comment_email_for_#{commentable.id}", :failureMessage => ts('Please enter your email address.')) %>
           </dd>
         </dl>
+        <p class="footnote">(<%= allowed_html_instructions %>)</p>
       <% end %>
 
       <p>


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5925

## Purpose

adds limited html instructions to logged out comment forms on works and news posts

## Testing Instructions

1. go to https://test.archiveofourown.org and ensure that you're logged out
2. go to any news post and check that under the name and email fields in the comment form, there's an additional sentence `Plain text with limited HTML (?)` that leads to [this popup link](https://test.archiveofourown.org/help/html-help.html)
3. go to any published work and check that under the name and email fields you see the above text and link there, too
