### PR TITLE
AO3-5938 Links in bookmark blurb stats have their bottom borders cut off (on Windows)

### DIFF
--- a/public/stylesheets/site/2.0/13-group-blurb.css
+++ b/public/stylesheets/site/2.0/13-group-blurb.css
@@ -357,7 +357,7 @@ blurbs on the manage collection items pages, mostly reseting styles inherited fr
   clear: both;
 }
 
-.bookmark .blurb dl.stats {
+.bookmark dl.stats {
   margin-bottom: 0.643em;
 }
 

--- a/public/stylesheets/site/2.0/13-group-blurb.css
+++ b/public/stylesheets/site/2.0/13-group-blurb.css
@@ -3,12 +3,12 @@ http://otwcode.github.com/docs/front_end_coding/patterns/blurb
 The blurb class is used wherever we show a list of works, collections, bookmarks, etc; each list item is a blurb
 it shows all the tags, stats and other associations we hold on that object, and sometimes it shows short user notes too, like a summary, bookmark notes, or collection description.
 
-Intrepid skinsers: 
-Probably 40% of this sheet deals with icon block rules, but it's not very complicated, 
-just the same thing repeated for each icon. 
-The positioning and sizing is for 25px icons; 
+Intrepid skinsers:
+Probably 40% of this sheet deals with icon block rules, but it's not very complicated,
+just the same thing repeated for each icon.
+The positioning and sizing is for 25px icons;
 there is a full set available at 50px, in /default_large.
-You can use your own icon set, or choose to show the text instead, 
+You can use your own icon set, or choose to show the text instead,
 by overriding the rules in the marked off section.
 Perhaps we can make a wizard for this specific task.
 */
@@ -80,7 +80,7 @@ li.blurb:after, .blurb .blurb:after {
   position: absolute;
 }
 
-.blurb dl.stats + .heading.landmark { 
+.blurb dl.stats + .heading.landmark {
   display: inline;
 }
 
@@ -237,7 +237,7 @@ li.blurb:after, .blurb .blurb:after {
   text-align: justify;
 }
 
-/*modification: PICTURE 
+/*modification: PICTURE
 use this along with "index" and "blurb" for indices where we have icon pictures,
 eg collections, users, skins, instead of the 4-icon list
 */
@@ -357,6 +357,10 @@ blurbs on the manage collection items pages, mostly reseting styles inherited fr
   clear: both;
 }
 
+.bookmark .blurb dl.stats {
+  margin-bottom: 0.643em;
+}
+
 /* line break between types of meta */
 .bookmark .user ul.meta:after {
 	content: '\A';
@@ -393,7 +397,7 @@ blurbs on the manage collection items pages, mostly reseting styles inherited fr
 
 /* mod: READING */
 
-.reading .user { 
+.reading .user {
   float: left;
 }
 


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5938

## Purpose

makes bottom borders visible again under stats (follow issue link for pictures)

## Testing Instructions

on a windows device (or emulator) go to https://test.archiveofourown.org/users/testy/bookmarks and check that all stats links for each work (chapter count, bookmark count, collection count, comment count) have borders underneath them. try making your browser window smaller and check that borders under these links don't disappear when they're pushed down to a second line.