### PR TITLE
AO3-5822 Reverse margins for lists written in RTL languages

### DIFF
--- a/public/stylesheets/site/2.0/21-userstuff.css
+++ b/public/stylesheets/site/2.0/21-userstuff.css
@@ -31,7 +31,6 @@
   display: block;
   line-height: 1.5;
   margin-block-start: 1.25em;
-  margin-inline-end: auto;
   margin-block-end: 1.25em;
   margin-inline-start: 3em;
 }

--- a/public/stylesheets/site/2.0/21-userstuff.css
+++ b/public/stylesheets/site/2.0/21-userstuff.css
@@ -30,7 +30,10 @@
 .userstuff dd {
   display: block;
   line-height: 1.5;
-  margin: 1.25em auto 1.25em 3em;
+  margin-block-start: 1.25em;
+  margin-inline-end: auto;
+  margin-block-end: 1.25em;
+  margin-inline-start: 3em;
 }
 
 .userstuff dd p {
@@ -47,7 +50,10 @@
   font-weight: normal;
   display: list-item;
   list-style-type: disc;
-  margin: 0.75em 0 0.75em 1.75em;
+  margin-block-start: 0.75em;
+  margin-inline-end: 0;
+  margin-block-end: 0.75em;
+  margin-inline-start: 1.75em;
 }
 
 .userstuff ol {
@@ -57,7 +63,10 @@
 
 .userstuff ol li {
   list-style-type: decimal;
-  margin: 0.75em 0 0.75em 1.75em;
+  margin-block-start: 0.75em;
+  margin-inline-end: 0;
+  margin-block-end: 0.75em;
+  margin-inline-start: 1.75em;
 }
 
 .userstuff ol li ol li {
@@ -66,11 +75,6 @@
 
 .userstuff ol li ol li ol li {
   list-style-type: lower-roman;
-}
-
-.userstuff ul[dir="rtl"] li {
-    margin-right: 1.75em;
-    margin-left: 0;
 }
 
 /* headings */

--- a/public/stylesheets/site/2.0/21-userstuff.css
+++ b/public/stylesheets/site/2.0/21-userstuff.css
@@ -68,6 +68,11 @@
   list-style-type: lower-roman;
 }
 
+.userstuff ul[dir="rtl"] li {
+    margin-right: 1.75em;
+    margin-left: 0;
+}
+
 /* headings */
 
 .userstuff h1 {


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5822

## Purpose

adds a `1.75` margin to the right of lists written in RTL languages and changes the left margin to `0`

## Testing Instructions

go to https://archiveofourown.org/admin_posts/13294 and scroll down to the lists in the post. check that there is a margin to the right of each bullet. check that there isn't any left margin by making your browser window tiny and zooming in to create two lines of text per bullet. you can compare how the reversed margins look to the [english version of the same post](https://archiveofourown.org/admin_posts/12035).