### PR TITLE
AO3-5952 Fix table alignment in RTL languages

### DIFF
--- a/public/stylesheets/site/2.0/02-elements.css
+++ b/public/stylesheets/site/2.0/02-elements.css
@@ -225,7 +225,7 @@ td {
 }
 
 th {
-  text-align: left;
+  text-align: start;
 }
 
 thead td {
@@ -245,7 +245,7 @@ th a, th a:visited, th a:link {
 }
 
 tbody tr th {
-  text-align: left;
+  text-align: start;
 }
 
 /*END== */


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5952

## Purpose

This PR replaces the alignment properties of table headers with CSS logical properties, in order to automatically flip them for right-to-left languages.

## Testing Instructions

See Jira ticket. Note that CSS logical properties aren't compatible with 

## References

See also AO3-5822 (#3828) and AO3-5737 (#3742) for similar text alignment issues.

## Credit

Alix R, she/her
