### PR TITLE
AO3-5909 Delete skins without JavaScript

### DIFF
--- a/app/controllers/skins_controller.rb
+++ b/app/controllers/skins_controller.rb
@@ -196,7 +196,7 @@ class SkinsController < ApplicationController
   def check_title
     if params[:skin][:title].match(/archive/i)
       flash[:error] = ts("You can't use the word 'archive' in your skin title, sorry! (We have to reserve it for official skins.)")
-      render (@skin ? :edit : :new)
+      render @skin ? :edit : :new
     end
   end
 
@@ -208,12 +208,11 @@ class SkinsController < ApplicationController
       skin_parent_titles = params[:skin][:skin_parents_attributes].values.map { |v| v[:parent_skin_title] }
       skin_parents = skin_parent_titles.empty? ? [] : Skin.where(title: skin_parent_titles).pluck(:id)
       skin_parents += @skin.get_all_parents.collect(&:id) if @skin
-      unless (skin_parents.uniq & archive_parents.collect(&:id)).empty?
+      unless (skin_parents.uniq & archive_parents.map(&:id)).empty?
         flash[:error] = ts("You already have some of the archive components as parents, so we couldn't load the others. Please remove the existing components first if you really want to do this!")
         return true
       end
-      last_position = params[:skin][:skin_parents_attributes].keys.map { |k| k.to_i }.max rescue 0
-      last_position ||= 0
+      last_position = params[:skin][:skin_parents_attributes]&.keys&.map(&:to_i)&.max || 0
       archive_parents.each do |parent_skin|
         last_position += 1
         new_skin_parent_hash = ActionController::Parameters.new({position: last_position, parent_skin_id: parent_skin.id})

--- a/app/controllers/skins_controller.rb
+++ b/app/controllers/skins_controller.rb
@@ -10,14 +10,15 @@ class SkinsController < ApplicationController
 
   #### ACTIONS
 
+  # GET /skins
   def index
     is_work_skin = params[:skin_type] && params[:skin_type] == "WorkSkin"
     if current_user && current_user.is_a?(User)
       @preference = current_user.preference
     end
-    if params[:user_id] && @user = User.find_by(login: params[:user_id])
+    if params[:user_id] && (@user = User.find_by(login: params[:user_id]))
       redirect_to new_user_session_path and return unless logged_in?
-      if (@user != current_user)
+      if @user != current_user
         flash[:error] = "You can only browse your own skins and approved public skins."
         redirect_to skins_path and return
       end
@@ -43,18 +44,21 @@ class SkinsController < ApplicationController
     end
   end
 
+  # GET /skins/1
   def show
   end
 
+  # GET /skins/new
   def new
     @skin = Skin.new
     if params[:wizard]
-      render :new_wizard and return
+      render :new_wizard
     else
-      render :new and return
+      render :new
     end
   end
 
+  # POST /skins
   def create
     unless params[:skin_type].nil? || params[:skin_type] && %w(Skin WorkSkin).include?(params[:skin_type])
       flash[:error] = ts("What kind of skin did you want to create?")
@@ -68,7 +72,7 @@ class SkinsController < ApplicationController
     end
     @skin.author = current_user
     if @skin.save
-      flash[:notice] =  ts("Skin was successfully created.")
+      flash[:notice] = ts("Skin was successfully created.")
       if loaded
         flash[:notice] += ts(" We've added all the archive skin components as parents. You probably want to remove some of them now!")
         redirect_to edit_skin_path(@skin)
@@ -84,6 +88,7 @@ class SkinsController < ApplicationController
     end
   end
 
+  # GET /skins/1/edit
   def edit
   end
 
@@ -107,6 +112,7 @@ class SkinsController < ApplicationController
     end
   end
 
+  # Get /skins/1/preview
   def preview
     flash[:notice] = []
     flash[:notice] << ts("You are previewing the skin %{title}. This is a randomly chosen page.", title: @skin.title)
@@ -137,6 +143,11 @@ class SkinsController < ApplicationController
     redirect_back_or_default "/"
   end
 
+  # GET /skins/1/confirm_delete
+  def confirm_delete
+  end
+
+  #DELETE /skins/1
   def destroy
     @skin = Skin.find_by(id: params[:id])
     begin
@@ -161,7 +172,7 @@ class SkinsController < ApplicationController
         :foreground_color, :headercolor, :accent_color, :icon,
         {media: []},
         skin_parents_attributes:
-          [:id, :position, :parent_skin_id, :parent_skin_title, :child_skin_id, :_destroy],
+            [:id, :position, :parent_skin_id, :parent_skin_title, :child_skin_id, :_destroy],
     )
   end
 
@@ -178,14 +189,14 @@ class SkinsController < ApplicationController
   def check_editability
     unless @skin.editable?
       flash[:error] = ts("Sorry, you don't have permission to edit this skin")
-      redirect_to @skin and return
+      redirect_to @skin
     end
   end
 
   def check_title
     if params[:skin][:title].match(/archive/i)
       flash[:error] = ts("You can't use the word 'archive' in your skin title, sorry! (We have to reserve it for official skins.)")
-      render (@skin ? :edit : :new) and return
+      render (@skin ? :edit : :new)
     end
   end
 
@@ -194,14 +205,14 @@ class SkinsController < ApplicationController
     if params[:add_site_parents]
       params[:skin][:skin_parents_attributes] ||= ActionController::Parameters.new
       archive_parents = Skin.get_current_site_skin.get_all_parents
-      skin_parent_titles = params[:skin][:skin_parents_attributes].values.map {|v| v[:parent_skin_title]}
+      skin_parent_titles = params[:skin][:skin_parents_attributes].values.map { |v| v[:parent_skin_title] }
       skin_parents = skin_parent_titles.empty? ? [] : Skin.where(title: skin_parent_titles).pluck(:id)
       skin_parents += @skin.get_all_parents.collect(&:id) if @skin
-      if !(skin_parents.uniq & archive_parents.collect(&:id)).empty?
+      unless (skin_parents.uniq & archive_parents.collect(&:id)).empty?
         flash[:error] = ts("You already have some of the archive components as parents, so we couldn't load the others. Please remove the existing components first if you really want to do this!")
         return true
       end
-      last_position = params[:skin][:skin_parents_attributes].keys.map{|k| k.to_i}.max rescue 0
+      last_position = params[:skin][:skin_parents_attributes].keys.map { |k| k.to_i }.max rescue 0
       last_position ||= 0
       archive_parents.each do |parent_skin|
         last_position += 1
@@ -210,6 +221,6 @@ class SkinsController < ApplicationController
       end
       return true
     end
-    return false
+    false
   end
 end

--- a/app/controllers/skins_controller.rb
+++ b/app/controllers/skins_controller.rb
@@ -147,7 +147,7 @@ class SkinsController < ApplicationController
   def confirm_delete
   end
 
-  #DELETE /skins/1
+  # DELETE /skins/1
   def destroy
     @skin = Skin.find_by(id: params[:id])
     begin

--- a/app/views/skins/_skin_actions.html.erb
+++ b/app/views/skins/_skin_actions.html.erb
@@ -15,10 +15,9 @@
       <li><%= span_if_current ts('Edit'), edit_skin_path(skin) %></li>
       <% unless logged_in_as_admin? %>
         <li>
-          <%= button_to ts("Delete"),
-                      skin,
-                      data: { confirm: ts("Are you sure?") },
-                      method: :delete %>
+          <%= link_to ts("Delete"),
+                      confirm_delete_skin_path(skin),
+                      data: {confirm: ts("Are you sure you want to delete this skin?")} %>
         </li>
       <% end %>
     <% end %>

--- a/app/views/skins/_skin_actions.html.erb
+++ b/app/views/skins/_skin_actions.html.erb
@@ -17,7 +17,7 @@
         <li>
           <%= link_to ts("Delete"),
                       confirm_delete_skin_path(skin),
-                      data: {confirm: ts("Are you sure you want to delete this skin?")} %>
+                      data: { confirm: ts("Are you sure you want to delete this skin?") } %>
         </li>
       <% end %>
     <% end %>

--- a/app/views/skins/_skin_actions.html.erb
+++ b/app/views/skins/_skin_actions.html.erb
@@ -15,7 +15,7 @@
       <li><%= span_if_current ts('Edit'), edit_skin_path(skin) %></li>
       <% unless logged_in_as_admin? %>
         <li>
-          <%= link_to ts("Delete"),
+          <%= button_to ts("Delete"),
                       skin,
                       data: { confirm: ts("Are you sure?") },
                       method: :delete %>

--- a/app/views/skins/confirm_delete.html.erb
+++ b/app/views/skins/confirm_delete.html.erb
@@ -1,0 +1,17 @@
+<!--Descriptive page name, messages and instructions-->
+<h2 class="heading"><%= ts("Delete Skin") %></h2>
+
+<!--main content-->
+<%= form_for(@skin, :html => {:method => :delete, :class => "simple destroy"}) do |f| %>
+  <p class="caution notice">
+    <% if @skin.title.nil? %>
+      <%= ts('Are you sure you want to <strong><em>delete</em></strong> this skin?').html_safe %>
+    <% else %>
+      <%= ts('Are you sure you want to <strong><em>delete</em></strong> the skin "%{skin_title}"?', :skin_title => @skin.title).html_safe %>
+    <% end %>
+  </p>
+  <p class="actions">
+    <%= f.submit ts("Yes, Delete Skin") %>
+  </p>
+<% end %>
+<!--/content-->

--- a/app/views/skins/confirm_delete.html.erb
+++ b/app/views/skins/confirm_delete.html.erb
@@ -2,13 +2,9 @@
 <h2 class="heading"><%= ts("Delete Skin") %></h2>
 
 <!--main content-->
-<%= form_for(@skin, :html => {:method => :delete, :class => "simple destroy"}) do |f| %>
+<%= form_for(@skin, :html => { method: :delete, class: "simple destroy" }) do |f| %>
   <p class="caution notice">
-    <% if @skin.title.nil? %>
-      <%= ts('Are you sure you want to <strong><em>delete</em></strong> this skin?').html_safe %>
-    <% else %>
-      <%= ts('Are you sure you want to <strong><em>delete</em></strong> the skin "%{skin_title}"?', :skin_title => @skin.title).html_safe %>
-    <% end %>
+    <%= ts("Are you sure you want to <strong><em>delete</em></strong> the skin \"%{skin_title}\"?", skin_title: @skin.title).html_safe %>
   </p>
   <p class="actions">
     <%= f.submit ts("Yes, Delete Skin") %>

--- a/app/views/skins/confirm_delete.html.erb
+++ b/app/views/skins/confirm_delete.html.erb
@@ -4,7 +4,7 @@
 <!--main content-->
 <%= form_for(@skin, html: { method: :delete, class: "simple destroy" }) do |f| %>
   <p class="caution notice">
-    <%= t("skins.confirm_delete_html", skin_title: @skin.title) %>
+    <%= t(".confirm_html", skin_title: @skin.title) %>
   </p>
   <p class="actions">
     <%= f.submit ts("Yes, Delete Skin") %>

--- a/app/views/skins/confirm_delete.html.erb
+++ b/app/views/skins/confirm_delete.html.erb
@@ -2,9 +2,9 @@
 <h2 class="heading"><%= ts("Delete Skin") %></h2>
 
 <!--main content-->
-<%= form_for(@skin, :html => { method: :delete, class: "simple destroy" }) do |f| %>
+<%= form_for(@skin, html: { method: :delete, class: "simple destroy" }) do |f| %>
   <p class="caution notice">
-    <%= ts("Are you sure you want to <strong><em>delete</em></strong> the skin \"%{skin_title}\"?", skin_title: @skin.title).html_safe %>
+    <%= t("skins.confirm_delete_html", skin_title: @skin.title) %>
   </p>
   <p class="actions">
     <%= f.submit ts("Yes, Delete Skin") %>

--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -56,4 +56,5 @@ en:
         title: "Fix Metatags"
         description: "Try to recalculate inherited metatags. Use this option if this tag has grandparent metatags (i.e., a metatag with its own metatag), and the works aren't showing up in the grandparent's listing. You might also try this if you've removed a metatag, but the works are still showing up in the former metatag's listing. If the works still don't go away, ask a staffer to run \"Update Tag Filters\" on this tag."
   skins:
-    confirm_delete_html: Are you sure you want to <strong><em>delete</em></strong> the skin \"%{skin_title}\"?
+    confirm_delete:
+      confirm_html: Are you sure you want to <strong><em>delete</em></strong> the skin \"%{skin_title}\"?

--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -55,3 +55,5 @@ en:
       fix_meta_tags:
         title: "Fix Metatags"
         description: "Try to recalculate inherited metatags. Use this option if this tag has grandparent metatags (i.e., a metatag with its own metatag), and the works aren't showing up in the grandparent's listing. You might also try this if you've removed a metatag, but the works are still showing up in the former metatag's listing. If the works still don't go away, ask a staffer to run \"Update Tag Filters\" on this tag."
+  skins:
+    confirm_delete_html: Are you sure you want to <strong><em>delete</em></strong> the skin \"%{skin_title}\"?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -514,6 +514,7 @@ Otwarchive::Application.routes.draw do
     member do
       get :preview
       get :set
+      get :confirm_delete
     end
     collection do
       get :unset

--- a/features/other_b/skin.feature
+++ b/features/other_b/skin.feature
@@ -13,7 +13,7 @@ Feature: Non-public site and work skins
     And I should see "(No Description Provided)"
     And I should see "by skinner"
     But I should see "Use"
-    And I should see "Delete"
+    And I should see a "Delete" button
     And I should see "Edit"
     And I should not see "Stop Using"
     And I should not see "(Approved)"
@@ -211,7 +211,7 @@ Feature: Non-public site and work skins
   Given I am logged in as "skinner"
     And I create the skin "Ugly Skin"
   When I go to "Ugly Skin" skin page
-    And I follow "Delete"
+    And I press "Delete"
   Then I should see "The skin was deleted."
     And I should be on skinner's skins page
     And I should not see "Ugly Skin"
@@ -222,7 +222,7 @@ Feature: Non-public site and work skins
     And I create the skin "Ugly Skin"
     And I change my skin to "Ugly Skin"
   When I go to skinner's skins page
-    And I follow "Delete"
+    And I press "Delete"
   Then I should see "The skin was deleted."
   When I go to skinner's preferences page
   Then "Default" should be selected within "preference_skin_id"

--- a/features/other_b/skin.feature
+++ b/features/other_b/skin.feature
@@ -13,7 +13,7 @@ Feature: Non-public site and work skins
     And I should see "(No Description Provided)"
     And I should see "by skinner"
     But I should see "Use"
-    And I should see a "Delete" button
+    And I should see "Delete"
     And I should see "Edit"
     And I should not see "Stop Using"
     And I should not see "(Approved)"
@@ -211,7 +211,8 @@ Feature: Non-public site and work skins
   Given I am logged in as "skinner"
     And I create the skin "Ugly Skin"
   When I go to "Ugly Skin" skin page
-    And I press "Delete"
+    And I follow "Delete"
+    And I press "Yes, Delete Skin"
   Then I should see "The skin was deleted."
     And I should be on skinner's skins page
     And I should not see "Ugly Skin"
@@ -222,7 +223,8 @@ Feature: Non-public site and work skins
     And I create the skin "Ugly Skin"
     And I change my skin to "Ugly Skin"
   When I go to skinner's skins page
-    And I press "Delete"
+    And I follow "Delete"
+    And I press "Yes, Delete Skin"
   Then I should see "The skin was deleted."
   When I go to skinner's preferences page
   Then "Default" should be selected within "preference_skin_id"


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5909

## Purpose

It currently isn't possible for a user to delete a skin without Javascript enabled. This is due to the fact that the HTML `a` element natively supports only GET requests, and that setting the request method to DELETE (actually handled by Ruby as a POST with an extra `method: :delete` parameter) requires the use of jQuery UJS.

A workaround for this is simply to replace `link_to` with `button_to`, which creates a form element natively supporting the generated POST request. This is possible in this case, because the "Delete" link was already styled as a button anyway.

## Testing Instructions

See Jira ticket. Javascript can be disabled through the use of a browser extension such as NoScript.

Note that without JS, there is currently no confirmation: the skin gets deleted immediately after pressing the button.

## References

I have found the same combinations of `link_to` and `method: :delete` (or `method: :put`, or `:method => :delete`, etc) in other files, some seemingly related to existing issues:
- [AO3-2520](https://otwarchive.atlassian.net/browse/AO3-2520) (High priority)
- [AO3-4974](https://otwarchive.atlassian.net/browse/AO3-4974)
- Potentially [AO3-2151](https://otwarchive.atlassian.net/browse/AO3-2151) (The problem exists there and will need to be fixed, but I'm not sure whether it's causing the current issue)

Other issues I've noticed and tested seem to currently be unreported on Jira, such as an inability to delete admin posts without JS. Essentially, if it's about not being able to delete or edit something without Javascript, this is probably what's responsible.

This problem also causes some difficulties in solving [AO3-5685](https://otwarchive.atlassian.net/browse/AO3-5685) (High priority), since replacing the logout link with a button would change its style.

The other links (Set For Session and Edit) use GET requests and aren't affected, so I didn't touch them, but they'll need to be fixed for [AO3-5953](https://otwarchive.atlassian.net/browse/AO3-5953).

## Credit

Alix R, she/her
