### PR TITLE
AO3-5667 Clear work blurb cache only when necessary.

### DIFF
--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -219,9 +219,9 @@ class Tag < ApplicationRecord
     end
   end
 
-  after_commit :queue_flush_work_cache
+  after_save :queue_flush_work_cache
   def queue_flush_work_cache
-    async(:flush_work_cache) if persisted?
+    async_after_commit(:flush_work_cache) if saved_change_to_name? || saved_change_to_type?
   end
 
   def flush_work_cache


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5667

## Purpose

`Tag#queue_flush_work_cache`, which expires the work blurb cache (and the tag group cache), is currently called `after_commit`. As a result, adding or removing a single child or parent tag results in a number of `Tag#flush_work_cache` jobs being added to the queue.

Two from the touches when a `CommonTagging` is created or deleted:
https://github.com/otwcode/otwarchive/blob/2774866fa0f2760471b78e15a864582e3bdbb9b8/app/models/common_tagging.rb#L11-L12

Another two from the tag being saved twice in the controller:
https://github.com/otwcode/otwarchive/blob/2774866fa0f2760471b78e15a864582e3bdbb9b8/app/controllers/tags_controller.rb#L254-L256

And when the association is being deleted, another two jobs from the calls to `touch` in `remove_association`:
https://github.com/otwcode/otwarchive/blob/2774866fa0f2760471b78e15a864582e3bdbb9b8/app/models/tag.rb#L817-L818

This is excessive, particularly since the work blurb only uses two properties of the work's tags: the name, and the type. Mergers, parents, and children don't affect the display at all.

This PR modifies `queue_flush_work_cache` so that it only adds the job after updating the name and/or type of a tag.

## Testing Instructions

**Renaming check:**
1. Pick a tag and a work in that tag.
2. View the work blurb.
3. Modify the tag name.
4. View the work blurb and ensure it's updated.

**Type change check:**
1. Pick a tag and a work in that tag.
2. View the work blurb.
3. Log into the rails console, and modify the type of the tag. You might want to switch it to or from a fandom, so that the type change is obvious.
4. View the work blurb and ensure that the tags are displayed correctly.