### PR TITLE
AO3-5965 Handle CSRF errors on JSON requests.

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -37,7 +37,7 @@ class ApplicationController < ActionController::Base
       format.html do
         redirect_to auth_error_path
       end
-      format.js do
+      format.any(:js, :json) do
         render json: {
           errors: {
             auth_error: "Your current session has expired and we can't authenticate your request. Try logging in again, refreshing the page, or <a href='http://kb.iu.edu/data/ahic.html'>clearing your cache</a> if you continue to experience problems.".html_safe


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5965

## Purpose

Modifies `display_auth_error`, which handles CSRF errors, so that it doesn't generate an error in New Relic on a JSON request.

## Testing Instructions

Available in the bug report.