### PR TITLE
AO3-5969 Make "Update Tag Filters" troubleshooting option work for unfilterable tags.

### DIFF
--- a/app/controllers/troubleshooting_controller.rb
+++ b/app/controllers/troubleshooting_controller.rb
@@ -150,7 +150,7 @@ class TroubleshootingController < ApplicationController
   def update_tag_filters
     @item.async(:update_filters_for_taggables)
 
-    @item.synonyms.find_each do |syn|
+    @item.mergers.find_each do |syn|
       syn.async(:update_filters_for_taggables)
     end
 

--- a/spec/controllers/troubleshooting_controller_spec.rb
+++ b/spec/controllers/troubleshooting_controller_spec.rb
@@ -206,6 +206,19 @@ describe TroubleshootingController do
         it_redirects_to_simple(tag_path(tag))
       end
 
+      it "recalculates filters for unfilterable tags" do
+        unfilterable = create(:fandom)
+        work = create(:work, fandoms: [unfilterable])
+
+        # Create an unnecessary filter tagging:
+        work.filter_taggings.create(filter: unfilterable)
+
+        put :update, params: { tag_id: unfilterable.to_param, actions: ["update_tag_filters"] }
+
+        expect(work.filters.reload).not_to include(unfilterable)
+        it_redirects_to_simple(tag_path(unfilterable))
+      end
+
       it "reindexes the work and redirects" do
         expect do
           put :update, params: { work_id: work.id, actions: ["reindex_work"] }


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5969

## Purpose

Modifies the "Update Tag Filters" troubleshooting option to use `Tag#mergers` instead of `Tag#synonyms`, because `Tag#synonyms` gives a nil error for any tag that is neither canonical, nor the synonym of a canonical.

## Testing Instructions

See the bug report.