### PR TITLE
AO3-5930 Avoid calling serial_works.includes(:works).references(:works).

### DIFF
--- a/app/controllers/series_controller.rb
+++ b/app/controllers/series_controller.rb
@@ -47,10 +47,8 @@ class SeriesController < ApplicationController
   # GET /series/1
   # GET /series/1.xml
   def show
-    @serial_works = \
-      @series.serial_works.includes(:work).references(:works).
-      where(works: { posted: true }).order(:position).
-      select { |sw| sw.work.visible? }
+    @works = @series.works_in_order.posted.select(&:visible?)
+
     # sets the page title with the data for the series
     @page_title = @series.unrevealed? ? ts("Mystery Series") : get_page_title(@series.allfandoms.collect(&:name).join(', '), @series.anonymous? ? ts("Anonymous") : @series.allpseuds.collect(&:byline).join(', '), @series.title)
     if current_user.respond_to?(:subscriptions)

--- a/app/models/series.rb
+++ b/app/models/series.rb
@@ -61,6 +61,10 @@ class Series < ApplicationRecord
     self.works.posted
   end
 
+  def works_in_order
+    works.order("serial_works.position")
+  end
+
   # Get the filters for the works in this series
   def filters
     Tag.joins("JOIN filter_taggings ON tags.id = filter_taggings.filter_id

--- a/app/views/series/show.html.erb
+++ b/app/views/series/show.html.erb
@@ -86,9 +86,7 @@
 
 <h3 class="landmark heading"><%= ts("Listing Series") %></h3>
 <ul class="series work index group">
-  <% for serial in @serial_works %>
-    <%= render "works/work_blurb", work: serial.work %>
-  <% end %>
+  <%= render partial: "works/work_blurb", collection: @works, as: :work %>
 </ul>
 <!--/content-->
 


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5930

## Purpose

This PR replaces the two calls to `serial_works.includes(:works).references(:works)`, which produces queries that enumerate all column names for both the `serial_works` table and the `works` table, with alternative queries.

## Testing Instructions

See the bug report.