### PR TITLE
AO3-5967 Ignore http_proxy for requests to New Relic collectors

### DIFF
--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -19,7 +19,7 @@ server "ao3-app12", :app
 server "ao3-app09", :app
 server "ao3-app15", :app, primary: true
 server "ao3-app20", :app
-server "ao3-app11", :app, :workers, :schedulers
+server "ao3-front04", :web
 server "ao3-app17", :app, :workers, :schedulers
 server "ao3-app18", :app, :workers, :schedulers
 server "ao3-app14", :app

--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -19,7 +19,7 @@ server "ao3-app12", :app
 server "ao3-app09", :app
 server "ao3-app15", :app, primary: true
 server "ao3-app20", :app
-server "ao3-front04", :web
+server "ao3-app11", :app, :workers, :schedulers
 server "ao3-app17", :app, :workers, :schedulers
 server "ao3-app18", :app, :workers, :schedulers
 server "ao3-app14", :app

--- a/config/initializers/new_relic.rb
+++ b/config/initializers/new_relic.rb
@@ -1,7 +1,6 @@
 module NewRelic
   module Agent
     class NewRelicService
-
       def create_http_connection
         if Agent.config[:proxy_host]
           ::NewRelic::Agent.logger.debug("Using proxy server #{Agent.config[:proxy_host]}:#{Agent.config[:proxy_port]}")

--- a/config/initializers/new_relic.rb
+++ b/config/initializers/new_relic.rb
@@ -1,0 +1,30 @@
+module NewRelic
+  module Agent
+    class NewRelicService
+
+      def create_http_connection
+        if Agent.config[:proxy_host]
+          ::NewRelic::Agent.logger.debug("Using proxy server #{Agent.config[:proxy_host]}:#{Agent.config[:proxy_port]}")
+
+          proxy = Net::HTTP::Proxy(
+            Agent.config[:proxy_host],
+            Agent.config[:proxy_port],
+            Agent.config[:proxy_user],
+            Agent.config[:proxy_pass]
+          )
+          conn = proxy.new(@collector.name, @collector.port)
+        else
+          # adding nil as prxy_addr here bypasses http_proxy environment variable if it is present.
+          # https://docs.ruby-lang.org/en/2.6.0/Net/HTTP.html#class-Net::HTTP-label-Proxies
+          conn = Net::HTTP.new(@collector.name, @collector.port, nil) 
+        end
+
+        setup_connection_for_ssl(conn)
+        setup_connection_timeouts(conn)
+
+        ::NewRelic::Agent.logger.debug("Created PATCHED net/http handle to #{conn.address}:#{conn.port}")
+        conn
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5967

## Purpose

Currently all http connections go to a restricted proxy, this routes New Relic connections away from the proxy.

## Testing Instructions

This can only be tested by Systems once the New Relic configuration is updated.
(Log on to the proxy and check that there are no connections to New Relic.)

## References

https://discuss.newrelic.com/t/avoiding-a-global-proxy-config/104464

## Credit

Please credit New Relic Ruby agent development team.

https://discuss.newrelic.com/t/avoiding-a-global-proxy-config/104464/4