### PR TITLE
AO3-5973 AO3-5881 Add comment permission column, and start updating multiple works form.

### DIFF
--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -691,15 +691,30 @@ class WorksController < ApplicationController
     @user = current_user
     @works = Work.joins(pseuds: :user).where('users.id = ?', @user.id).where(id: params[:work_ids]).readonly(false)
     @errors = []
-    # to avoid overwriting, we entirely trash any blank fields and also any unchecked checkboxes
+
+    # To avoid overwriting, we entirely trash any blank fields and also any
+    # unchecked checkboxes.
+    #
+    # Note that in the current edit_multiple form, we don't actually have any
+    # fields with value 0 (the hidden input used for unchecked checkboxes). So
+    # in a future release, it would be good to stop rejecting the params with
+    # value == '0', and stop checking for these special values below. But for
+    # compatibility with the existing form, we need to keep this code as is for
+    # now, and change it incrementally.
     updated_work_params = work_params.reject { |_key, value| value.blank? || value == '0' }
 
-    # manually allow switching of anon/moderated comments
+    # Special values which would normally be represented by 0, but can't
+    # because of the filter on updated_work_params.
     if updated_work_params[:anon_commenting_disabled] == 'allow_anon'
       updated_work_params[:anon_commenting_disabled] = '0'
     end
+
     if updated_work_params[:moderated_commenting_enabled] == 'not_moderated'
       updated_work_params[:moderated_commenting_enabled] = '0'
+    end
+
+    if updated_work_params[:restricted] == 'unrestricted'
+      updated_work_params[:restricted] = '0'
     end
 
     @works.each do |work|

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -561,4 +561,18 @@ module ApplicationHelper
   def label_indicator_and_text(text)
     content_tag(:span, "", class: "indicator", "aria-hidden": "true") + content_tag(:span, text)
   end
+
+  # Display a collection of radio buttons, wrapped in an unordered list.
+  #
+  # The parameter option_array should be a list of pairs, where the first
+  # element in each pair is the radio button's value, and the second element in
+  # each pair is the radio button's label.
+  def radio_button_list(form, field_name, option_array)
+    content_tag(:ul) do
+      form.collection_radio_buttons(field_name, option_array, :first, :second,
+                                    include_hidden: false) do |builder|
+        content_tag(:li, builder.label { builder.radio_button + builder.text })
+      end
+    end
+  end
 end # end of ApplicationHelper

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -921,6 +921,16 @@ class Work < ApplicationRecord
     )
   end
 
+  def comment_permissions=(value)
+    if has_attribute?(:comment_permissions)
+      write_attribute(:comment_permissions, value)
+    end
+
+    write_attribute(:anon_commenting_disabled, value)
+  end
+
+  alias_method :anon_commenting_disabled=, :comment_permissions=
+
   ########################################################################
   # RELATED WORKS
   # These are for inspirations/remixes/etc

--- a/app/views/works/edit_multiple.html.erb
+++ b/app/views/works/edit_multiple.html.erb
@@ -47,74 +47,50 @@
             {:include_blank => true} %>
       </dd>
 
+      <%
+        # For each of the following radio buttons, we replace the value that
+        # would normally be "0" with a special string that will be replaced
+        # with "0" in the controller. This is for cross-compatibility with the
+        # old code -- see WorksController#update_multiple for details.
+      %>
+
       <dt><%= ts("Visibility") %> <%= link_to_help "registered-users" %></dt>
       <dd>
-        <ul>
-          <li>
-            <label for="work_restricted">
-              <%= form.check_box :restricted %>
-              <%= ts("Only show to registered users") %>
-            </label>
-          </li>
-          <li>
-            <label for="work_unrestricted">
-              <%= form.check_box :unrestricted %>
-              <%= ts("Show to all") %>
-            </label>
-          </li>
-        </ul>
+        <fieldset>
+          <%=
+            radio_button_list(form, :restricted, [
+              ["", ts("Keep current visibility settings")],
+              ["1", ts("Only show to registered users")],
+              ["unrestricted", ts("Show to all")],
+            ])
+          %>
+        </fieldset>
       </dd>
 
       <dt><%= ts("Anonymous Commenting") %><%= link_to_help "comments-anonymous" %></dt>
       <dd>
-        <ul>
-          <li>
-            <label for="work_anon_commenting_disabled_">
-              <%= form.radio_button(:anon_commenting_disabled, '') %>
-              <%= ts("Keep current anonymous comment settings") %>
-            </label>
-          </li>
-          <li>
-            <% # We use "allow_anon" as a placeholder value because the mass edit code strips 0, which is the value we actually want %>
-            <% # The controller will change it to the proper value %>
-            <label for="work_anon_commenting_disabled_allow_anon">
-              <%= form.radio_button(:anon_commenting_disabled, "allow_anon") %>
-              <%= ts("Enable anonymous comments") %>
-            </label>
-          </li>
-          <li>
-            <label for="work_anon_commenting_disabled_1">
-              <%= form.radio_button(:anon_commenting_disabled, "1") %>
-              <%= ts("Disable anonymous comments") %>
-            </label>
-          </li>
-        </ul>
+        <fieldset>
+          <%=
+            radio_button_list(form, :anon_commenting_disabled, [
+              ["", ts("Keep current anonymous comment settings")],
+              ["allow_anon", ts("Enable anonymous comments")],
+              ["1", ts("Disable anonymous comments")]
+            ])
+          %>
+        </fieldset>
       </dd>
 
       <dt><%= ts("Comment Moderation") %><%= link_to_help "comments-moderated" %></dt>
       <dd>
-        <ul>
-          <li>
-            <label for="work_moderated_commenting_enabled_">
-              <%= form.radio_button(:moderated_commenting_enabled, '') %>
-              <%= ts("Keep current comment moderation settings") %>
-            </label>
-          </li>
-          <li>
-            <label for="work_moderated_commenting_enabled_1">
-              <%= form.radio_button(:moderated_commenting_enabled, "1") %>
-              <%= ts("Enable comment moderation") %>
-            </label>
-          </li>
-          <li>
-            <% # We use "not_moderated" as a placeholder value because the mass edit code strips 0, which is the value we actually want %>
-            <% # The controller will change it to the proper value %>
-            <label for="work_moderated_commenting_enabled_not_moderated">
-              <%= form.radio_button(:moderated_commenting_enabled, "not_moderated") %>
-              <%= ts("Disable comment moderation") %>
-            </label>
-          </li>
-        </ul>
+        <fieldset>
+          <%=
+            radio_button_list(form, :moderated_commenting_enabled, [
+              ["", ts("Keep current comment moderation settings")],
+              ["1", ts("Enable comment moderation")],
+              ["not_moderated", ts("Disable comment moderation")],
+            ])
+          %>
+        </fieldset>
       </dd>
     </dl>
   </fieldset>

--- a/db/migrate/20200613211440_add_comment_permissions_to_works.rb
+++ b/db/migrate/20200613211440_add_comment_permissions_to_works.rb
@@ -1,0 +1,49 @@
+class AddCommentPermissionsToWorks < ActiveRecord::Migration[5.1]
+  def up
+    if Rails.env.staging? || Rails.env.production?
+      database = Work.connection.current_database
+
+      puts <<~PTOSC
+        Schema Change Command:
+
+        pt-online-schema-change D=#{database},t=works \\
+          --alter "ADD COLUMN comment_permissions tinyint NOT NULL DEFAULT 0" \\
+          --no-drop-old-table \\
+          -uroot --ask-pass --chunk-size=5k --max-flow-ctl 0 --pause-file /tmp/pauseme \\
+          --max-load Threads_running=15 --critical-load Threads_running=100 \\
+          --set-vars innodb_lock_wait_timeout=2 --alter-foreign-keys-method=auto \\
+          --execute
+
+        Table Deletion Command:
+
+        DROP TABLE IF EXISTS `#{database}`.`_works_old`;
+      PTOSC
+    else
+      add_column :works, :comment_permissions, :tinyint, default: 0, null: false
+    end
+  end
+
+  def down
+    if Rails.env.staging? || Rails.env.production?
+      database = Work.connection.current_database
+
+      puts <<~PTOSC
+        Schema Change Command:
+
+        pt-online-schema-change D=#{database},t=works \\
+          --alter "DROP COLUMN comment_permissions" \\
+          --no-drop-old-table \\
+          -uroot --ask-pass --chunk-size=5k --max-flow-ctl 0 --pause-file /tmp/pauseme \\
+          --max-load Threads_running=15 --critical-load Threads_running=100 \\
+          --set-vars innodb_lock_wait_timeout=2 --alter-foreign-keys-method=auto \\
+          --execute
+
+        Table Deletion Command:
+
+        DROP TABLE IF EXISTS `#{database}`.`_works_old`;
+      PTOSC
+    else
+      remove_column :works, :comment_permissions
+    end
+  end
+end

--- a/lib/tasks/after_tasks.rake
+++ b/lib/tasks/after_tasks.rake
@@ -694,6 +694,16 @@ namespace :After do
       REDIS_GENERAL.del(key)
     end
   end
+
+  desc "Copy anon_commenting_disabled to comment_permissions."
+  task(copy_anon_commenting_disabled_to_comment_permissions: :environment) do
+    Work.in_batches do |batch|
+      batch.update_all("comment_permissions = anon_commenting_disabled")
+      print(".") && STDOUT.flush
+    end
+
+    puts && STDOUT.flush
+  end
 end # this is the end that you have to put new tasks above
 
 ##################

--- a/spec/controllers/works/multiple_actions_spec.rb
+++ b/spec/controllers/works/multiple_actions_spec.rb
@@ -88,8 +88,7 @@ describe WorksController do
           collections_to_add: "",
           language_id: "",
           work_skin_id: "",
-          restricted: "0",
-          unrestricted: "0",
+          restricted: "",
           anon_commenting_disabled: "",
           moderated_commenting_enabled: ""
         }

--- a/spec/lib/tasks/after_tasks.rake_spec.rb
+++ b/spec/lib/tasks/after_tasks.rake_spec.rb
@@ -125,3 +125,20 @@ describe "rake After:update_indexed_stat_counter_kudo_count", work_search: true 
     }.from(0).to(1)
   end
 end
+
+describe "rake After:copy_anon_commenting_disabled_to_comment_permissions" do
+  let(:work) { create(:work) }
+
+  before do
+    work.update_columns(anon_commenting_disabled: true,
+                        comment_permissions: 0)
+  end
+
+  it "updates comment_permissions to match anon_commenting_disabled" do
+    expect do
+      subject.invoke
+    end.to change {
+      work.reload.comment_permissions
+    }.from(0).to(1)
+  end
+end

--- a/spec/models/work_spec.rb
+++ b/spec/models/work_spec.rb
@@ -573,4 +573,60 @@ describe Work do
       end
     end
   end
+
+  describe "#anon_commenting_disabled=" do
+    let(:work) { create(:work) }
+
+    it "updating anon_commenting_disabled also updates comment_permissions" do
+      expect(work.anon_commenting_disabled).to eq(false)
+      expect(work.comment_permissions).to eq(0)
+
+      work.anon_commenting_disabled = true
+
+      expect(work.anon_commenting_disabled).to eq(true)
+      expect(work.comment_permissions).to eq(1)
+
+      work.save!
+      work.reload
+
+      expect(work.anon_commenting_disabled).to eq(true)
+      expect(work.comment_permissions).to eq(1)
+    end
+  end
+
+  describe "#comment_permissions=" do
+    let(:work) { create(:work) }
+
+    it "updating comment_permissions also updates anon_commenting_disabled" do
+      expect(work.comment_permissions).to eq(0)
+      expect(work.anon_commenting_disabled).to eq(false)
+
+      work.comment_permissions = 1
+
+      expect(work.comment_permissions).to eq(1)
+      expect(work.anon_commenting_disabled).to eq(true)
+
+      work.save!
+      work.reload
+
+      expect(work.comment_permissions).to eq(1)
+      expect(work.anon_commenting_disabled).to eq(true)
+    end
+
+    it "setting comment_permissions to 2 also sets anon_commenting_disabled to true" do
+      expect(work.comment_permissions).to eq(0)
+      expect(work.anon_commenting_disabled).to eq(false)
+
+      work.comment_permissions = 2
+
+      expect(work.comment_permissions).to eq(2)
+      expect(work.anon_commenting_disabled).to eq(true)
+
+      work.save!
+      work.reload
+
+      expect(work.comment_permissions).to eq(2)
+      expect(work.anon_commenting_disabled).to eq(true)
+    end
+  end
 end


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5973
https://otwarchive.atlassian.net/browse/AO3-5881

## Purpose

- Add a column `comment_permissions` that will eventually be used to control whether comments are enabled, and whether anonymous comments are enabled.
- Add a rake task `After:copy_anon_commenting_disabled_to_comment_permissions` to copy the current values in `anon_commenting_disabled` over to the `comment_permissions` column.
- Fix up the Edit Multiple Works form so that it no longer presents mutually exclusive checkboxes for "Only show to registered users" and "Show to all." (I included this because I'd eventually like to get rid of the special values representing zero in the Edit Multiple Works form, so that the options for the new `comment_permissions` column look nicer. But this requires multiple steps if we want to avoid issues with people opening the form just prior to the deploy, and submitting the form just after it.)

## Testing Instructions

See the two bug reports for testing instructions.

## References

First part of #3852.