### PR TITLE
AO3-5947 Add Hound rules for RSpec

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,14 @@
-# options available at https://github.com/bbatsov/rubocop/blob/master/config/default.yml
+# Options available at https://github.com/bbatsov/rubocop/blob/master/config/default.yml
+
+require:
+  - rubocop-rspec
 
 AllCops:
+  RSpec:
+    Patterns:
+      - "(?:^|/)factories/"
+      - "(?:^|/)features/"
+      - "(?:^|/)spec/"
   TargetRubyVersion: 2.6
 
 Bundler/OrderedGems:
@@ -45,6 +53,63 @@ Metrics/ModuleLength:
 Metrics/PerceivedComplexity:
   Enabled: false
 
+# Allow "allow_any_instance_of"
+RSpec/AnyInstance:
+  Enabled: false
+
+# By default allow only prefixes "when", "with", "without".
+# We have too many, so let's allow everything.
+RSpec/ContextWording:
+  Enabled: false
+
+RSpec/DescribedClass:
+  Enabled: false
+
+RSpec/ExampleLength:
+  Enabled: false
+
+# Prefer: expect { run }.to change { Foo.bar }
+# over: expect { run }.to change(Foo, :bar)
+RSpec/ExpectChange:
+  EnforcedStyle: block
+
+RSpec/FilePath:
+  Exclude:
+    # Exception for WorksController, whose many specs need multiple files
+    - 'spec/controllers/works/*.rb'
+
+# Avoid instance variables, except for those not assigned within the spec,
+# e.g. @request.
+RSpec/InstanceVariable:
+  AssignmentOnly: true
+
+# Allow unreferenced let! calls for test setup
+RSpec/LetSetup:
+  Enabled: false
+
+# Allow both "have_received" and "receive" for expectations
+RSpec/MessageSpies:
+  Enabled: false
+
+# Allow multiple top level describes (rake specs)
+RSpec/MultipleDescribes:
+  Enabled: false
+
+# Allow unlimited expectations per test
+RSpec/MultipleExpectations:
+  Enabled: false
+
+# Allow unnamed subjects
+RSpec/NamedSubject:
+  Enabled: false
+
+# Allow unlimited nested groups
+RSpec/NestedGroups:
+  Enabled: false
+
+RSpec/PredicateMatcher:
+  Enabled: false
+
 Style/ClassAndModuleChildren:
   Enabled: false
 
@@ -54,7 +119,7 @@ Style/Documentation:
 Style/EmptyMethod:
   EnforcedStyle: expanded
 
-# prefer template tokens (like %{foo}) over annotated tokens (like %s)
+# Prefer template tokens (like %{foo}) over annotated tokens (like %s)
 Style/FormatStringToken:
   EnforcedStyle: template
 
@@ -66,16 +131,15 @@ Style/GlobalVars:
     - $elasticsearch
     - $rollout
 
-# stop checking if uses of "self" are redundant
+# Stop checking if uses of "self" are redundant
 Style/RedundantSelf:
   Enabled: false
 
 Style/SingleLineMethods:
   AllowIfMethodIsEmpty: false
 
-# stop checking quotation marks
 Style/StringLiterals:
-  Enabled: false
+  EnforcedStyle: double_quotes
 
 Style/SymbolArray:
   Enabled: false

--- a/spec/lib/collectible_spec.rb
+++ b/spec/lib/collectible_spec.rb
@@ -65,7 +65,7 @@ describe Collectible do
     end
   end
 
-  context "being posted to a collection", focus: true do
+  context "being posted to a collection" do
     let(:collection) { create(:collection) }
     # build but don't save so we can change the collection settings
     let(:work) { build(:work, collection_names: collection.name) }

--- a/spec/models/tag_set_spec.rb
+++ b/spec/models/tag_set_spec.rb
@@ -1,5 +1,0 @@
-# encoding: utf-8
-require 'spec_helper'
-
-describe TagSet do
-end


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5947

## Purpose

Rules mentioned in the issue but not added here, because their default values are already good:

- Having context descriptions start with unnecessary "should"s: [RSpec/ExampleWording](https://rubocop-rspec.readthedocs.io/en/latest/cops_rspec/#rspecexamplewording)
- Having duplicate and scattered hooks: [RSpec/ScatteredSetup](https://rubocop-rspec.readthedocs.io/en/latest/cops_rspec/#rspecscatteredsetup)
- Having "all" hooks that lead to state leaking between specs: [RSpec/BeforeAfterAll](https://rubocop-rspec.readthedocs.io/en/latest/cops_rspec/#rspecbeforeafterall)

Extra:

- Start checking double quotes.
- Fix RSpec/Focus by removing the only use of "focus: true".
- Fix RSpec/EmptyExampleGroup by removing empty spec.

[skip codeship tests]

## Testing Instructions

None.