### PR TITLE
AO3-5973 Make the WorksController forward-compatible.

### DIFF
--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -929,7 +929,7 @@ class WorksController < ApplicationController
       :rating_string, :fandom_string, :relationship_string, :character_string,
       :archive_warning_string, :category_string, :expected_number_of_chapters, :revised_at,
       :freeform_string, :summary, :notes, :endnotes, :collection_names, :recipients, :wip_length,
-      :backdate, :language_id, :work_skin_id, :restricted, :anon_commenting_disabled,
+      :backdate, :language_id, :work_skin_id, :restricted, :anon_commenting_disabled, :comment_permissions,
       :moderated_commenting_enabled, :title, :pseuds_to_add, :collections_to_add,
       :unrestricted,
       current_user_pseud_ids: [],

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -147,6 +147,12 @@ class Work < ApplicationRecord
   # Run Taggable#check_for_invalid_tags as a validation.
   validate :check_for_invalid_tags
 
+  enum comment_permissions: {
+    enable_all: 0,
+    disable_anon: 1,
+    disable_all: 2
+  }, _suffix: :comments
+
   ########################################################################
   # HOOKS
   # These are methods that run before/after saves and updates to ensure
@@ -922,14 +928,25 @@ class Work < ApplicationRecord
   end
 
   def comment_permissions=(value)
-    if has_attribute?(:comment_permissions)
-      write_attribute(:comment_permissions, value)
-    end
+    return unless has_attribute?(:comment_permissions)
 
-    write_attribute(:anon_commenting_disabled, value)
+    write_attribute(:comment_permissions, value)
+
+    # Map the special value back to an integer, and write it to the
+    # anon_commenting_disabled column so that if we do have to revert, we can
+    # go back to using the anon_commenting_disabled column without data loss.
+    write_attribute(:anon_commenting_disabled,
+                    Work.comment_permissions[comment_permissions])
   end
 
-  alias_method :anon_commenting_disabled=, :comment_permissions=
+  def anon_commenting_disabled=(value)
+    write_attribute(:anon_commenting_disabled, value)
+
+    if has_attribute?(:comment_permissions)
+      write_attribute(:comment_permissions,
+                      anon_commenting_disabled ? :disable_anon : :enable_all)
+    end
+  end
 
   ########################################################################
   # RELATED WORKS

--- a/spec/lib/tasks/after_tasks.rake_spec.rb
+++ b/spec/lib/tasks/after_tasks.rake_spec.rb
@@ -131,7 +131,7 @@ describe "rake After:copy_anon_commenting_disabled_to_comment_permissions" do
 
   before do
     work.update_columns(anon_commenting_disabled: true,
-                        comment_permissions: 0)
+                        comment_permissions: :enable_all)
   end
 
   it "updates comment_permissions to match anon_commenting_disabled" do
@@ -139,6 +139,6 @@ describe "rake After:copy_anon_commenting_disabled_to_comment_permissions" do
       subject.invoke
     end.to change {
       work.reload.comment_permissions
-    }.from(0).to(1)
+    }.from("enable_all").to("disable_anon")
   end
 end

--- a/spec/models/work_spec.rb
+++ b/spec/models/work_spec.rb
@@ -579,53 +579,53 @@ describe Work do
 
     it "updating anon_commenting_disabled also updates comment_permissions" do
       expect(work.anon_commenting_disabled).to eq(false)
-      expect(work.comment_permissions).to eq(0)
+      expect(work.comment_permissions).to eq("enable_all")
 
       work.anon_commenting_disabled = true
 
       expect(work.anon_commenting_disabled).to eq(true)
-      expect(work.comment_permissions).to eq(1)
+      expect(work.comment_permissions).to eq("disable_anon")
 
       work.save!
       work.reload
 
       expect(work.anon_commenting_disabled).to eq(true)
-      expect(work.comment_permissions).to eq(1)
+      expect(work.comment_permissions).to eq("disable_anon")
     end
   end
 
   describe "#comment_permissions=" do
     let(:work) { create(:work) }
 
-    it "updating comment_permissions also updates anon_commenting_disabled" do
-      expect(work.comment_permissions).to eq(0)
+    it "setting comment_permissions to disable_anon also updates anon_commenting_disabled" do
+      expect(work.comment_permissions).to eq("enable_all")
       expect(work.anon_commenting_disabled).to eq(false)
 
-      work.comment_permissions = 1
+      work.comment_permissions = "disable_anon"
 
-      expect(work.comment_permissions).to eq(1)
+      expect(work.comment_permissions).to eq("disable_anon")
       expect(work.anon_commenting_disabled).to eq(true)
 
       work.save!
       work.reload
 
-      expect(work.comment_permissions).to eq(1)
+      expect(work.comment_permissions).to eq("disable_anon")
       expect(work.anon_commenting_disabled).to eq(true)
     end
 
-    it "setting comment_permissions to 2 also sets anon_commenting_disabled to true" do
-      expect(work.comment_permissions).to eq(0)
+    it "setting comment_permissions to disable_all also sets anon_commenting_disabled to true" do
+      expect(work.comment_permissions).to eq("enable_all")
       expect(work.anon_commenting_disabled).to eq(false)
 
-      work.comment_permissions = 2
+      work.comment_permissions = "disable_all"
 
-      expect(work.comment_permissions).to eq(2)
+      expect(work.comment_permissions).to eq("disable_all")
       expect(work.anon_commenting_disabled).to eq(true)
 
       work.save!
       work.reload
 
-      expect(work.comment_permissions).to eq(2)
+      expect(work.comment_permissions).to eq("disable_all")
       expect(work.anon_commenting_disabled).to eq(true)
     end
   end


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5973

## Purpose

The view `works/standard_form` in #3852 has radio buttons for the name `work[comment_permissions]`. But at the moment, the `WorksController` doesn't include `comment_permissions` in the permitted `work_params`. So if someone accesses the form from a worker running the new code, then submits the form to a worker that's still running the old code, the user's choice of `comment_permissions` would disappear and be reverted to the default.

The deploy involves restarting all the workers over the course of an hour, so we need to plan around the new form being submitted to the old controller, and vice versa. So this PR adds `comment_permissions` to the list of permitted `work_params`.

In addition, the new form in #3852 uses `enable_all`, `disable_anon`, and `disable_all` as the form values, relying on the enum to convert those values. So we need to back-port the enum from #3852.

## Testing Instructions

See the issue description.

## References

This modifies the code introduced in #3851 so that it's forward-compatible with #3852.