### PR TITLE
AO3-5518 Tweak admin index HTML and add i18n

### DIFF
--- a/app/views/admins/index.html.erb
+++ b/app/views/admins/index.html.erb
@@ -1,22 +1,29 @@
-<h2>Hi, <%= current_admin.login %>!</h2>
+<!--Descriptive page name, messages and instructions-->
+<h2 class="heading">Hi, <%= current_admin.login %>!</h2>
+<!--/descriptions-->
 
-<p>You are now logged in as an admin. That means you will probably encounter information that is personal or confidential (e.g. usernames, email and IP addresses, creator names on anonymous works, etc). Please do not use this information in ways unrelated to your OTW role. If you have questions about what you can or cannot do with information you see here, contact your committee chair(s).</p>
+<!--subnav-->
+<!--/subnav-->
 
-<p><strong>With great power comes great responsibility.</strong></p>
+<!--main content-->
+<div class="admin userstuff">
+  <p>You are now logged in as an admin. That means you will probably encounter information that is personal or confidential (e.g. usernames, email and IP addresses, creator names on anonymous works, etc). Please do not use this information in ways unrelated to your OTW role. If you have questions about what you can or cannot do with information you see here, contact your committee chair(s).</p>
 
-<hr />
+  <p><strong>With great power comes great responsibility.</strong></p>
 
-<h3>Your admin roles:</h3>
-<% if current_admin.roles.any? %>
-  <ul>
-  <% current_admin.roles.each do |role| %>
-    <li><%= role.titleize %></li>
+  <h3 class="heading">Your admin roles:</h3>
+  <% if current_admin.roles.any? %>
+    <ul>
+      <% current_admin.roles.each do |role| %>
+        <li><%= role.titleize %></li>
+      <% end %>
+    </ul>
+  <% else %>
+    <p>You currently have no admin roles assigned to you.</p>
   <% end %>
-  </ul>
-<% else %>
-  <p>You currently have no admin roles assigned to you.</p>
-<% end %>
 
-<hr />
+  <hr />
 
-<p>Please remember to log out before resuming your normal site activity and leaving comments and kudos!</p>
+  <p>Please remember to log out before resuming your normal site activity and leaving comments and kudos!</p>
+</div>
+<!--/content-->

--- a/app/views/admins/index.html.erb
+++ b/app/views/admins/index.html.erb
@@ -15,7 +15,7 @@
   <% if current_admin.roles.any? %>
     <ul>
       <% current_admin.roles.each do |role| %>
-        <li><%= role.titleize %></li>
+        <li><%= t("activerecord.attributes.admin/role.#{role}") %></li>
       <% end %>
     </ul>
   <% else %>

--- a/app/views/admins/index.html.erb
+++ b/app/views/admins/index.html.erb
@@ -1,5 +1,5 @@
 <!--Descriptive page name, messages and instructions-->
-<h2 class="heading">Hi, <%= current_admin.login %>!</h2>
+<h2 class="heading"><%= t(".page_title", login: current_admin.login) %></h2>
 <!--/descriptions-->
 
 <!--subnav-->
@@ -7,11 +7,11 @@
 
 <!--main content-->
 <div class="admin userstuff">
-  <p>You are now logged in as an admin. That means you will probably encounter information that is personal or confidential (e.g. usernames, email and IP addresses, creator names on anonymous works, etc). Please do not use this information in ways unrelated to your OTW role. If you have questions about what you can or cannot do with information you see here, contact your committee chair(s).</p>
+  <p><%= t(".confidentiality_reminder") %></p>
 
-  <p><strong>With great power comes great responsibility.</strong></p>
+  <p class="important"><%= t(".responsibility") %></p>
 
-  <h3 class="heading">Your admin roles:</h3>
+  <h3 class="heading"><%= t(".roles.heading") %></h3>
   <% if current_admin.roles.any? %>
     <ul>
       <% current_admin.roles.each do |role| %>
@@ -19,11 +19,11 @@
       <% end %>
     </ul>
   <% else %>
-    <p>You currently have no admin roles assigned to you.</p>
+    <p><%= t(".roles.none") %></p>
   <% end %>
 
   <hr />
 
-  <p>Please remember to log out before resuming your normal site activity and leaving comments and kudos!</p>
+  <p><%= t(".log_out_reminder") %></p>
 </div>
 <!--/content-->

--- a/config/locales/models/en.yml
+++ b/config/locales/models/en.yml
@@ -39,6 +39,15 @@ en:
         other: "Tags"
       work: "Work"
     attributes:
+      admin/role:
+        communications: "Communications"
+        docs: "AO3 Docs"
+        open_doors: "Open Doors"
+        policy_and_abuse: "Policy & Abuse"
+        superadmin: "Super admin"
+        support: "Support"
+        tag_wrangling: "Tag Wrangling"
+        translation: "Translation"
       archive_warning:
         name_with_colon:
           one: "Warning:"

--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -4,6 +4,15 @@ en:
       emails_found:
         one: "one email found"
         other: "%{count} emails found"
+  admins:
+    index:
+      page_title: "Hi, %{login}!"
+      confidentiality_reminder: "You are now logged in as an admin. That means you will probably encounter information that is personal or confidential (e.g. usernames, email and IP addresses, creator names on anonymous works, etc). Please do not use this information in ways unrelated to your OTW role. If you have questions about what you can or cannot do with information you see here, contact your committee chair(s)."
+      responsibility: "With great power comes great responsibility."
+      log_out_reminder: "Please remember to log out before resuming your normal site activity and leaving comments and kudos!"
+      roles:
+        heading: "Your admin roles:"
+        none: "You currently have no admin roles assigned to you."
   users:
     delete_preview:
       heading: "What do you want to do with your works?"


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5518

## Purpose

Adds some missing HTML to the admin index page, e.g. the `heading` class and the `<div class="admin userstuff">` container that was preventing the list of roles from showing as an actual bulleted list. Also does i18n for the text on that page.

## Testing Instructions

Refer to Jira.

