### PR TITLE
AO3-5979 Add unique constraints for login and email on the admins table

### DIFF
--- a/app/models/admin.rb
+++ b/app/models/admin.rb
@@ -15,7 +15,6 @@ class Admin < ApplicationRecord
   has_many :wrangled_tags, class_name: 'Tag', as: :last_wrangler
 
   validates :login, presence: true, uniqueness: true, length: { in: ArchiveConfig.LOGIN_LENGTH_MIN..ArchiveConfig.LOGIN_LENGTH_MAX }
-  validates :email, uniqueness: true
   validates_presence_of :password_confirmation, if: :new_record?
   validates_confirmation_of :password, if: :new_record?
 

--- a/db/migrate/20200707213354_add_unique_indices_to_admin_login_email.rb
+++ b/db/migrate/20200707213354_add_unique_indices_to_admin_login_email.rb
@@ -1,0 +1,6 @@
+class AddUniqueIndicesToAdminLoginEmail < ActiveRecord::Migration[5.1]
+  def change
+    add_index :admins, :email, unique: true
+    add_index :admins, :login, unique: true
+  end
+end


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [x] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [x] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [x] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-5979

## Purpose

This PR updates validation on the `admin` model. Specifically, it:

- removes duplicate validation at the Rails level on admin `email` (this is already enforced by `validatable`)
- enforces admin `email` and `login` uniqueness at the DB level, by adding unique indices for them with a migration

## Testing Instructions

As per the issue description:

> To test, run the migration on staging and make sure it's successful.

I have tested the migration runs locally.

## References

n/a

## Credit

*What name do you want us to use to credit your work in the [Archive of Our Own's Release Notes](https://archiveofourown.org/admin_posts?tag=1)?*

Tom Milligan

*What pronouns do you prefer (she/her, he/him, zie/hir etc)?*

they/them