### PR TITLE
AO3-5992 Fix error with keys being converted to symbols in spam alert email.

### DIFF
--- a/app/mailers/admin_mailer.rb
+++ b/app/mailers/admin_mailer.rb
@@ -47,12 +47,14 @@ class AdminMailer < ActionMailer::Base
 
   # Sends a spam report
   def send_spam_alert(spam)
-    @users = User.where(id: spam.keys).to_a
-    return if @users.empty?
-
     # Make sure that the keys of the spam array are integers, so that we can do
-    # an easy look-up with user IDs.
-    @spam = spam.transform_keys(&:to_i)
+    # an easy look-up with user IDs. We call stringify_keys first because
+    # the currently installed version of Resque::Mailer does odd things when
+    # you pass a hash as an argument, and we want to know what we're dealing with.
+    @spam = spam.stringify_keys.transform_keys(&:to_i)
+
+    @users = User.where(id: @spam.keys).to_a
+    return if @users.empty?
 
     # The users might have been retrieved from the database out of order, so
     # re-sort them by their score.


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5992

## Purpose

Call `stringify_keys` before calling `transform_keys(&:to_i)`, to cope with any symbols introduced by `Resque::Mailer`.

(I originally thought that `with_indifferent_access` would be sufficient, instead of `transform_keys(&:to_i)`, but it turns out that `with_indifferent_access` only handles symbols & strings, not numbers. So I still need the `to_i` step on top of something to get rid of the symbols.)