### PR TITLE
AO3-5623 AO3-5518 Fix admin creation script, clean up admin-related feature steps

### DIFF
--- a/factories/admin.rb
+++ b/factories/admin.rb
@@ -8,32 +8,22 @@ FactoryBot.define do
     email
 
     factory :superadmin do
-      login { "superadmin" }
-      password { "IHaveThePower" }
       roles { ["superadmin"] }
     end
 
     factory :policy_and_abuse_admin do
-      login { "policy_admin" }
-      password { "policy" }
       roles { ["policy_and_abuse"] }
     end
 
     factory :support_admin do
-      login { "support_admin" }
-      password { "support" }
       roles { ["support"] }
     end
 
     factory :tag_wrangling_admin do
-      login { "tag_wrangling_admin" }
-      password { "tagwrangling" }
       roles { ["tag_wrangling"] }
     end
 
     factory :open_doors_admin do
-      login { "open_doors_admin" }
-      password { "opendoors" }
       roles { ["open_doors"] }
     end
   end

--- a/features/admins/admin_invitations.feature
+++ b/features/admins/admin_invitations.feature
@@ -255,7 +255,7 @@ Feature: Admin Actions to Manage Invitations
       And I should not see "Joining the Archive currently requires an invitation; however, we are not accepting new invitation requests at this time."
 
   Scenario: An admin can send an invitation to a user via email
-    Given I am logged in as a "support" admin
+    Given I am logged in as an admin
       And all emails have been delivered
     When I follow "Invite New Users"
       And I fill in "invitation[invitee_email]" with "fred@bedrock.com"
@@ -264,7 +264,7 @@ Feature: Admin Actions to Manage Invitations
       And 1 email should be delivered
 
   Scenario: An admin can't create an invite without an email address.
-    Given I am logged in as a "support" admin
+    Given I am logged in as an admin
       And all emails have been delivered
     When I follow "Invite New Users"
       And I press "Invite user"
@@ -278,7 +278,7 @@ Feature: Admin Actions to Manage Invitations
       | odo   | mybucket9  |
       And "dax" has "0" invitations
       And "odo" has "3" invitations
-      And I am logged in as a "support" admin
+      And I am logged in as an admin
     When I follow "Invite New Users"
       And I fill in "Number of invitations" with "2"
       And I select "All" from "Users"
@@ -293,7 +293,7 @@ Feature: Admin Actions to Manage Invitations
       | bashir | heytheredoc |
       And "dax" has "5" invitations
       And "bashir" has "0" invitations
-      And I am logged in as a "support" admin
+      And I am logged in as an admin
     When I follow "Invite New Users"
       And I fill in "Number of invitations" with "2"
       And I select "With no unused invitations" from "Users"
@@ -304,7 +304,7 @@ Feature: Admin Actions to Manage Invitations
   Scenario: An admin can see the invitation of an existing user via name or token
     Given the user "dax" exists and is activated
       And "dax" has "2" invitations
-      And I am logged in as a "support" admin
+      And I am logged in as an admin
     When I follow "Invite New Users"
       And I fill in "Enter a user name" with "dax"
       And I press "Go"
@@ -315,14 +315,14 @@ Feature: Admin Actions to Manage Invitations
     Then I should see "copy and use"
 
   Scenario: An admin can't find a invitation for a nonexistent user
-    Given I am logged in as a "support" admin
+    Given I am logged in as an admin
       And I follow "Invite New Users"
     When I fill in "Enter a user name" with "dax"
       And I press "Go"
     Then I should see "No results were found. Try another search"
 
   Scenario: An admin can invite people from the queue
-    Given I am logged in as a "support" admin
+    Given I am logged in as an admin
       And an invitation request for "fred@bedrock.com"
       And an invitation request for "barney@bedrock.com"
       And all emails have been delivered
@@ -352,7 +352,7 @@ Feature: Admin Actions to Manage Invitations
 
   Scenario: An admin can search the invitation queue, and search parameters are
   kept even if deleting without JavaScript
-    Given I am logged in as a "support" admin
+    Given I am logged in as an admin
       And an invitation request for "streamtv@example.com"
       And an invitation request for "livetv@example.com"
       And an invitation request for "clearstream@example.com"

--- a/features/admins/admin_invitations.feature
+++ b/features/admins/admin_invitations.feature
@@ -5,7 +5,7 @@ Feature: Admin Actions to Manage Invitations
   I want to be able to require invitations for new users
 
   Scenario: Admin can set invite from queue number to a number greater than or equal to 1
-    Given I am logged in as superadmin
+    Given I am logged in as a super admin
       And I go to the admin-settings page
       And I fill in "admin_setting_invite_from_queue_number" with "0"
       And I press "Update"
@@ -15,7 +15,7 @@ Feature: Admin Actions to Manage Invitations
     Then I should not see "Invite from queue number must be greater than 0."
 
   Scenario: Account creation enabled, invitations required, users can request invitations, and the queue is enabled
-    Given I am logged in as superadmin
+    Given I am logged in as a super admin
       And I go to the admin-settings page
       And I check "Account creation enabled"
       And I check "Account creation requires invitation"
@@ -30,7 +30,7 @@ Feature: Admin Actions to Manage Invitations
       And I should not see "Joining the Archive currently requires an invitation; however, we are not accepting new invitation requests at this time."
 
   Scenario: Account creation enabled, invitations required, users can request invitations, and the queue is disabled
-    Given I am logged in as superadmin
+    Given I am logged in as a super admin
       And I go to the admin-settings page
       And I check "Account creation enabled"
       And I check "Account creation requires invitation"
@@ -45,7 +45,7 @@ Feature: Admin Actions to Manage Invitations
       And I should see "Joining the Archive currently requires an invitation; however, we are not accepting new invitation requests at this time."
 
   Scenario: Account creation enabled, invitations required, users cannot request invitations, and the queue is enabled
-    Given I am logged in as superadmin
+    Given I am logged in as a super admin
       And I go to the admin-settings page
       And I check "Account creation enabled"
       And I check "Account creation requires invitation"
@@ -64,7 +64,7 @@ Feature: Admin Actions to Manage Invitations
       And I should not see "Joining the Archive currently requires an invitation; however, we are not accepting new invitation requests at this time."
 
   Scenario: Account creation enabled, invitations not required, users can request invitations, and the queue is enabled
-    Given I am logged in as superadmin
+    Given I am logged in as a super admin
       And I go to the admin-settings page
       And I check "Account creation enabled"
       And I uncheck "Account creation requires invitation"
@@ -79,7 +79,7 @@ Feature: Admin Actions to Manage Invitations
       And I should see "Create an Account!"
 
   Scenario: Account creation disabled, invitations required, users can request invitations, and the queue is enabled
-    Given I am logged in as superadmin
+    Given I am logged in as a super admin
       And I go to the admin-settings page
       And I uncheck "Account creation enabled"
       And I check "Account creation requires invitation"
@@ -94,7 +94,7 @@ Feature: Admin Actions to Manage Invitations
       And I should not see "Joining the Archive currently requires an invitation; however, we are not accepting new invitation requests at this time."
 
   Scenario: Account creation enabled, invitations required, users cannot request invitations, and the queue is disabled
-    Given I am logged in as superadmin
+    Given I am logged in as a super admin
       And I go to the admin-settings page
       And I check "Account creation enabled"
       And I check "Account creation requires invitation"
@@ -114,7 +114,7 @@ Feature: Admin Actions to Manage Invitations
       And I should not see "Get an Invitation" within "div#small_login"
 
   Scenario: Account creation enabled, invitations not required, users cannot request invitations, and the queue is enabled
-    Given I am logged in as superadmin
+    Given I am logged in as a super admin
       And I go to the admin-settings page
       And I check "Account creation enabled"
       And I uncheck "Account creation requires invitation"
@@ -128,9 +128,8 @@ Feature: Admin Actions to Manage Invitations
       And I should see "Create an Account!"
       And I should not see "Joining the Archive currently requires an invitation; however, we are not accepting new invitation requests at this time."
 
-
   Scenario: Account creation disabled, invitations not required, users can request invitations, and the queue is enabled
-    Given I am logged in as superadmin
+    Given I am logged in as a super admin
       And I go to the admin-settings page
       And I uncheck "Account creation enabled"
       And I uncheck "Account creation requires invitation"
@@ -144,7 +143,7 @@ Feature: Admin Actions to Manage Invitations
       And I should not see "Create an Account!"
 
   Scenario: Account creation enabled, invitations not required, users can request invitations, and the queue is disabled
-    Given I am logged in as superadmin
+    Given I am logged in as a super admin
       And I go to the admin-settings page
       And I check "Account creation enabled"
       And I uncheck "Account creation requires invitation"
@@ -159,7 +158,7 @@ Feature: Admin Actions to Manage Invitations
       And I should see "Create an Account!"
 
   Scenario: Account creation disabled, invitations required, users cannot request invitations, and the queue is enabled
-    Given I am logged in as superadmin
+    Given I am logged in as a super admin
       And I go to the admin-settings page
       And I uncheck "Account creation enabled"
       And I check "Account creation requires invitation"
@@ -174,7 +173,7 @@ Feature: Admin Actions to Manage Invitations
       And I should not see "Joining the Archive currently requires an invitation; however, we are not accepting new invitation requests at this time."
 
   Scenario: Account creation enabled, invitations not required, users cannot request invitations, and the queue is disabled
-    Given I am logged in as superadmin
+    Given I am logged in as a super admin
       And I go to the admin-settings page
       And I check "Account creation enabled"
       And I uncheck "Account creation requires invitation"
@@ -192,7 +191,7 @@ Feature: Admin Actions to Manage Invitations
       And I should see "Create Account"
 
   Scenario: Account creation disabled, invitations required, users cannot request invitations, and the queue is disabled
-    Given I am logged in as superadmin
+    Given I am logged in as a super admin
       And I go to the admin-settings page
       And I uncheck "Account creation enabled"
       And I check "Account creation requires invitation"
@@ -207,7 +206,7 @@ Feature: Admin Actions to Manage Invitations
       And I should see "Joining the Archive currently requires an invitation; however, we are not accepting new invitation requests at this time."
 
   Scenario: Account creation disabled, invitations not required, users can request invitations, and the queue is disabled
-    Given I am logged in as superadmin
+    Given I am logged in as a super admin
       And I go to the admin-settings page
       And I uncheck "Account creation enabled"
       And I uncheck "Account creation requires invitation"
@@ -222,7 +221,7 @@ Feature: Admin Actions to Manage Invitations
       And I should not see "Joining the Archive currently requires an invitation; however, we are not accepting new invitation requests at this time."
 
   Scenario: Account creation disabled, invitations not required, users cannot request invitations, and the queue is enabled
-    Given I am logged in as superadmin
+    Given I am logged in as a super admin
       And I go to the admin-settings page
       And I uncheck "Account creation enabled"
       And I uncheck "Account creation requires invitation"
@@ -241,7 +240,7 @@ Feature: Admin Actions to Manage Invitations
       And I should not see "Joining the Archive currently requires an invitation; however, we are not accepting new invitation requests at this time."
 
   Scenario: Account creation disabled, invitations not required, users cannot request invitations, and the queue is disabled
-    Given I am logged in as superadmin
+    Given I am logged in as a super admin
       And I go to the admin-settings page
       And I uncheck "Account creation enabled"
       And I uncheck "Account creation requires invitation"
@@ -256,7 +255,7 @@ Feature: Admin Actions to Manage Invitations
       And I should not see "Joining the Archive currently requires an invitation; however, we are not accepting new invitation requests at this time."
 
   Scenario: An admin can send an invitation to a user via email
-    Given I am logged in as superadmin
+    Given I am logged in as a "support" admin
       And all emails have been delivered
     When I follow "Invite New Users"
       And I fill in "invitation[invitee_email]" with "fred@bedrock.com"
@@ -265,12 +264,12 @@ Feature: Admin Actions to Manage Invitations
       And 1 email should be delivered
 
   Scenario: An admin can't create an invite without an email address.
-   Given I am logged in as superadmin
-     And all emails have been delivered
-   When I follow "Invite New Users"
-     And I press "Invite user"
-   Then I should see "Please enter an email address"
-     And 0 email should be delivered
+    Given I am logged in as a "support" admin
+      And all emails have been delivered
+    When I follow "Invite New Users"
+      And I press "Invite user"
+    Then I should see "Please enter an email address"
+      And 0 email should be delivered
 
   Scenario: An admin can send an invitation to all existing users
     Given the following activated users exist
@@ -279,7 +278,7 @@ Feature: Admin Actions to Manage Invitations
       | odo   | mybucket9  |
       And "dax" has "0" invitations
       And "odo" has "3" invitations
-      And I am logged in as superadmin
+      And I am logged in as a "support" admin
     When I follow "Invite New Users"
       And I fill in "Number of invitations" with "2"
       And I select "All" from "Users"
@@ -292,38 +291,38 @@ Feature: Admin Actions to Manage Invitations
       | login  | password    |
       | dax    | lotsaspots  |
       | bashir | heytheredoc |
-     And "dax" has "5" invitations
-     And "bashir" has "0" invitations
-     And I am logged in as superadmin
-   When I follow "Invite New Users"
-     And I fill in "Number of invitations" with "2"
-     And I select "With no unused invitations" from "Users"
-     And I press "Generate invitations"
-   Then "dax" should have "7" invitations
-     And "bashir" should have "2" invitations
+      And "dax" has "5" invitations
+      And "bashir" has "0" invitations
+      And I am logged in as a "support" admin
+    When I follow "Invite New Users"
+      And I fill in "Number of invitations" with "2"
+      And I select "With no unused invitations" from "Users"
+      And I press "Generate invitations"
+    Then "dax" should have "7" invitations
+      And "bashir" should have "2" invitations
 
   Scenario: An admin can see the invitation of an existing user via name or token
     Given the user "dax" exists and is activated
-     And "dax" has "2" invitations
-     And I am logged in as superadmin
-   When I follow "Invite New Users"
-     And I fill in "Enter a user name" with "dax"
-     And I press "Go"
-   Then I should see "copy and use"
-   When I follow "Invite New Users"
-     And I fill in "Enter an invite token" with "dax's" invite code
-     And I press "Go"
-   Then I should see "copy and use"
+      And "dax" has "2" invitations
+      And I am logged in as a "support" admin
+    When I follow "Invite New Users"
+      And I fill in "Enter a user name" with "dax"
+      And I press "Go"
+    Then I should see "copy and use"
+    When I follow "Invite New Users"
+      And I fill in "Enter an invite token" with "dax's" invite code
+      And I press "Go"
+    Then I should see "copy and use"
 
   Scenario: An admin can't find a invitation for a nonexistent user
-    Given I am logged in as superadmin
+    Given I am logged in as a "support" admin
       And I follow "Invite New Users"
-    Then I fill in "Enter a user name" with "dax"
+    When I fill in "Enter a user name" with "dax"
       And I press "Go"
     Then I should see "No results were found. Try another search"
 
   Scenario: An admin can invite people from the queue
-    Given I am logged in as superadmin
+    Given I am logged in as a "support" admin
       And an invitation request for "fred@bedrock.com"
       And an invitation request for "barney@bedrock.com"
       And all emails have been delivered
@@ -336,24 +335,24 @@ Feature: Admin Actions to Manage Invitations
       And 1 email should be delivered
 
  Scenario: An admin can edit an invitation
-   Given the user "dax" exists and is activated
-     And "dax" has "2" invitations
-     And I am logged in as superadmin
-   When I follow "Invite New Users"
-     And I fill in "Enter a user name" with "dax"
-     And I press "Go"
-   Then I should see "copy and use"
-   When I follow "Invite New Users"
-     And I fill in "Enter an invite token" with "dax's" invite code
-     And I press "Go"
-   Then I should see "copy and use"
-   When I fill in "invitation_invitee_email" with "oldman@ds9.com"
-     And I press "Update Invitation"
-   Then I should see "oldman@ds9.com" in the "invitation_invitee_email" input
+    Given the user "dax" exists and is activated
+      And "dax" has "2" invitations
+      And I am logged in as a "support" admin
+    When I follow "Invite New Users"
+      And I fill in "Enter a user name" with "dax"
+      And I press "Go"
+    Then I should see "copy and use"
+    When I follow "Invite New Users"
+      And I fill in "Enter an invite token" with "dax's" invite code
+      And I press "Go"
+    Then I should see "copy and use"
+    When I fill in "invitation_invitee_email" with "oldman@ds9.com"
+      And I press "Update Invitation"
+    Then I should see "oldman@ds9.com" in the "invitation_invitee_email" input
 
   Scenario: An admin can search the invitation queue, and search parameters are
   kept even if deleting without JavaScript
-    Given I am logged in as superadmin
+    Given I am logged in as a "support" admin
       And an invitation request for "streamtv@example.com"
       And an invitation request for "livetv@example.com"
       And an invitation request for "clearstream@example.com"

--- a/features/admins/admin_post_news.feature
+++ b/features/admins/admin_post_news.feature
@@ -5,12 +5,12 @@ Feature: Admin Actions to Post News
   I want to be able to use the Admin Posts screen
 
   Scenario: Must be authorized to post
-    Given I am logged in as admin with role "tag_wrangling"
+    Given I am logged in as a "tag_wrangling" admin
     When I go to the admin-posts page
     Then I should not see "Post AO3 News"
 
   Scenario: Make an admin post
-    Given I am logged in as admin with role "communications"
+    Given I am logged in as a "communications" admin
     When I make an admin post
     Then I should see "Admin Post was successfully created."
 
@@ -21,55 +21,20 @@ Feature: Admin Actions to Post News
     When I am logged out as an admin
       And I am logged in as "happyuser"
       And I go to the admin-posts page
-    Given all emails have been delivered
-    When I follow "Comment"
+    When all emails have been delivered
+      And I follow "Comment"
       And I fill in "Comment" with "Excellent, my dear!"
       And I press "Comment"
     # notification to the admin list for admin post
     Then 1 email should be delivered to "admin@example.org"
       And the email should contain "Excellent"
 
-    # admin replies to comment of regular user
-    Given I am logged out
-      And I am logged in as admin with role "communications"
-      And I go to the admin-posts page
-      And I follow "Default Admin Post"
-    Given all emails have been delivered
-    When I follow "Comments (1)"
-      And I follow "Reply"
-      And I fill in "Comment" with "Thank you very much!" within ".odd"
-      And I press "Comment" within ".odd"
-    Then I should see "Comment created"
-    # Someone can spoof being an admin by using the admin name and a different email, but their icon will not match
-    # We want to improve this so that the name is linked and the spoof is more obvious
-    When "Issue AO3-3685" is fixed
-    # notification to the admin list for admin post
-      And 1 email should be delivered to "admin@example.org"
-    # reply to the user
-      And 1 email should be delivered to "happyuser"
-
-    # regular user replies to comment of admin
-    Given I am logged out as an admin
-      And I am logged in as a random user
-      And I go to the admin-posts page
-    Given all emails have been delivered
-    When I follow "Read 2 Comments"
-      And I follow "Reply" within ".even"
-      And I fill in "Comment" with "Oh, don't grow too big a head, you." within ".even"
-      And I press "Comment" within ".even"
-    # reply to the admin as a regular user
-    Then 1 email should be delivered to "testadmin@example.org"
-    # notification to the admin list for admin post
-      And 1 email should be delivered to "admin@example.org"
-
     # regular user edits their comment
-    Given all emails have been delivered
-    When I follow "Edit"
+    When all emails have been delivered
+      And I follow "Edit"
       And I press "Update"
-    # reply to the admin as a regular user
-    Then 1 email should be delivered to "testadmin@example.org"
     # notification to the admin list for admin post
-      And 1 email should be delivered to "admin@example.org"
+    Then 1 email should be delivered to "admin@example.org"
 
   Scenario: Evil user can impersonate admin in comments
   # However, they can't use an icon, so the admin's icon is the guarantee that they're real
@@ -105,14 +70,14 @@ Feature: Admin Actions to Post News
   Scenario: Make a translation of an admin post
     Given I have posted an admin post
       And basic languages
-      And I am logged in as admin with role "translation"
+      And I am logged in as a "translation" admin
     When I make a translation of an admin post
       And I am logged in as "ordinaryuser"
     Then I should see a translated admin post
 
   Scenario: Make a translation of an admin post that doesn't exist
     Given basic languages
-      And I am logged in as admin with role "translation"
+      And I am logged in as a "translation" admin
     When I make a translation of an admin post
     Then I should see "Sorry! We couldn't save this admin post because:"
       And I should see "Translated post does not exist"
@@ -121,7 +86,7 @@ Feature: Admin Actions to Post News
   Scenario: Make a translation of an admin post stop being a translation
     Given I have posted an admin post
       And basic languages
-      And I am logged in as admin with role "translation"
+      And I am logged in as a "translation" admin
       And I make a translation of an admin post
     When I follow "Edit Post"
       And I fill in "Translation of" with ""
@@ -130,7 +95,7 @@ Feature: Admin Actions to Post News
     Then I should not see a translated admin post
 
   Scenario: Log in as an admin and create an admin post with tags
-    Given I am logged in as admin with role "communications"
+    Given I am logged in as a "communications" admin
     When I follow "Admin Posts"
       And I follow "Post AO3 News"
       Then I should see "New AO3 News Post"
@@ -145,7 +110,7 @@ Feature: Admin Actions to Post News
   Scenario: Admin posts can be filtered by tags and languages
     Given I have posted an admin post with tags
       And basic languages
-      And I am logged in as admin with role "translation"
+      And I am logged in as a "translation" admin
     When I make a translation of an admin post with tags
       And I am logged in as "ordinaryuser"
     Then I should see a translated admin post with tags
@@ -171,7 +136,7 @@ Feature: Admin Actions to Post News
       And "Deutsch" should be selected within "Language"
 
   Scenario: If an admin post has characters like & and < and > in the title, the escaped version will not show on the various admin post pages
-    Given I am logged in as admin with role "communications"
+    Given I am logged in as a "communications" admin
     When I follow "Admin Posts"
       And I follow "Post AO3 News"
       And I fill in "admin_post_title" with "App News & a <strong> Warning"
@@ -212,7 +177,7 @@ Feature: Admin Actions to Post News
 
   Scenario: Edits to an admin post should appear on the homepage
     Given I have posted an admin post without paragraphs
-      And I am logged in as admin with role "communications"
+      And I am logged in as a "communications" admin
     When I go to the admin-posts page
       And I follow "Edit"
       And I fill in "admin_post_title" with "Edited Post"
@@ -226,7 +191,7 @@ Feature: Admin Actions to Post News
 
   Scenario: A deleted admin post should be removed from the homepage
     Given I have posted an admin post
-      And I am logged in as admin with role "communications"
+      And I am logged in as a "communications" admin
     When I go to the admin-posts page
       And I follow "Delete"
     When I go to the homepage

--- a/features/admins/admin_works.feature
+++ b/features/admins/admin_works.feature
@@ -6,7 +6,7 @@ Feature: Admin Actions for Works, Comments, Series, Bookmarks
   Scenario: Can troubleshoot works
     Given I am logged in as "regular_user"
       And I post the work "Just a work you know"
-    When I am logged in as superadmin
+    When I am logged in as a "policy_and_abuse" admin
       And I view the work "Just a work you know"
       And I follow "Troubleshoot"
       And I check "Reindex Work"
@@ -16,7 +16,7 @@ Feature: Admin Actions for Works, Comments, Series, Bookmarks
   Scenario: Can hide works
     Given I am logged in as "regular_user"
       And I post the work "ToS Violation"
-    When I am logged in as policy_and_abuse_admin
+    When I am logged in as a "policy_and_abuse" admin
       And I view the work "ToS Violation"
       And I follow "Hide Work"
     Then I should see "Item has been hidden."
@@ -29,7 +29,7 @@ Feature: Admin Actions for Works, Comments, Series, Bookmarks
   Scenario: Can unhide works
     Given I am logged in as "regular_user"
       And I post the work "ToS Violation"
-    When I am logged in as superadmin
+    When I am logged in as a "policy_and_abuse" admin
       And I view the work "ToS Violation"
       And I follow "Hide Work"
       And all indexing jobs have been run
@@ -45,7 +45,7 @@ Feature: Admin Actions for Works, Comments, Series, Bookmarks
   Scenario: Can delete works
     Given I am logged in as "regular_user"
       And I post the work "ToS Violation"
-    When I am logged in as superadmin
+    When I am logged in as a "policy_and_abuse" admin
       And I view the work "ToS Violation"
       And I follow "Delete Work"
       And all indexing jobs have been run
@@ -71,7 +71,7 @@ Feature: Admin Actions for Works, Comments, Series, Bookmarks
       And I press "Create"
       And all indexing jobs have been run
     Then I should see "Bookmark was successfully created"
-    When I am logged in as superadmin
+    When I am logged in as a "policy_and_abuse" admin
       And I am on bad_user's bookmarks page
     When I follow "Hide Bookmark"
       And all indexing jobs have been run
@@ -84,7 +84,7 @@ Feature: Admin Actions for Works, Comments, Series, Bookmarks
     Given basic tags
       And I am logged in as "regular_user"
       And I post the work "Changes" with fandom "User-Added Fandom" with freeform "User-Added Freeform" with category "M/M"
-    When I am logged in as superadmin
+    When I am logged in as a "policy_and_abuse" admin
       And I view the work "Changes"
       And I follow "Edit Tags and Language"
     When I select "Mature" from "Rating"
@@ -121,7 +121,7 @@ Feature: Admin Actions for Works, Comments, Series, Bookmarks
     Given basic tags
       And I am logged in as "regular_user"
       And I bookmark the external work "External Changes"
-    When I am logged in as superadmin
+    When I am logged in as a "policy_and_abuse" admin
       And I view the external work "External Changes"
       And I follow "Edit External Work"
     When I fill in "Creator" with "Admin-Added Creator"
@@ -149,7 +149,7 @@ Feature: Admin Actions for Works, Comments, Series, Bookmarks
     Given basic tags
       And I am logged in as "regular_user"
       And I bookmark the external work "External Changes"
-    When I am logged in as superadmin
+    When I am logged in as a "policy_and_abuse" admin
       And I view the external work "External Changes"
       And I follow "Delete External Work"
     Then I should see "Item was successfully deleted."
@@ -175,7 +175,7 @@ Feature: Admin Actions for Works, Comments, Series, Bookmarks
 
     # comment from registered user cannot be marked as spam.
     # If registered user is spamming, this goes to Abuse team as ToS violation
-    When I am logged in as superadmin
+    When I am logged in as a "policy_and_abuse" admin
     Then I should see "Successfully logged in"
     When I view the work "The One Where Neal is Awesome"
       And I follow "Comments (1)"
@@ -183,7 +183,7 @@ Feature: Admin Actions for Works, Comments, Series, Bookmarks
 
     # now mark a comment as spam
     When I post the comment "Would you like a genuine rolex" on the work "The One Where Neal is Awesome" as a guest
-      And I am logged in as superadmin
+      And I am logged in as a "policy_and_abuse" admin
       And I view the work "The One Where Neal is Awesome"
       And I follow "Comments (2)"
     Then I should see "rolex"
@@ -215,7 +215,7 @@ Feature: Admin Actions for Works, Comments, Series, Bookmarks
       And I should see "I loved this!"
 
     # now mark comment as not spam
-    When I am logged in as superadmin
+    When I am logged in as a "policy_and_abuse" admin
       And I view the work "The One Where Neal is Awesome"
       And I follow "Comments (1)"
       And I follow "Not Spam"
@@ -244,7 +244,7 @@ Feature: Admin Actions for Works, Comments, Series, Bookmarks
       And basic languages
       And I am logged in as "regular_user"
       And I post the work "Wrong Language"
-    When I am logged in as superadmin
+    When I am logged in as a "policy_and_abuse" admin
       And I view the work "Wrong Language"
       And I follow "Edit Tags and Language"
     Then I should see "Edit Work Tags and Language for "
@@ -258,7 +258,7 @@ Feature: Admin Actions for Works, Comments, Series, Bookmarks
       And basic languages
       And I am logged in as "regular_user"
       And I post the work "Wrong Language"
-    When I am logged in as superadmin
+    When I am logged in as a "policy_and_abuse" admin
       And I view the work "Wrong Language"
       And I follow "Edit Tags and Language"
     When I select "Deutsch" from "Choose a language"
@@ -270,7 +270,7 @@ Feature: Admin Actions for Works, Comments, Series, Bookmarks
 
   Scenario: can mark a work as spam
   Given the work "Spammity Spam"
-    And I am logged in as superadmin
+    And I am logged in as a "policy_and_abuse" admin
     And I view the work "Spammity Spam"
   Then I should see "Mark As Spam"
   When I follow "Mark As Spam"
@@ -281,7 +281,7 @@ Feature: Admin Actions for Works, Comments, Series, Bookmarks
 
   Scenario: can mark a spam work as not-spam
   Given the spam work "Spammity Spam"
-    And I am logged in as superadmin
+    And I am logged in as a "policy_and_abuse" admin
     And I view the work "Spammity Spam"
   Then I should see "Mark Not Spam"
   When I follow "Mark Not Spam"
@@ -293,7 +293,7 @@ Feature: Admin Actions for Works, Comments, Series, Bookmarks
   Scenario: Admin can hide a series (e.g. if the series description or notes contain a TOS Violation)
     Given I am logged in as "tosser"
       And I add the work "Legit Work" to series "Violation"
-    When I am logged in as superadmin
+    When I am logged in as a "policy_and_abuse" admin
       And I view the series "Violation"
       And I follow "Hide Series"
     Then I should see "Item has been hidden."
@@ -321,7 +321,7 @@ Feature: Admin Actions for Works, Comments, Series, Bookmarks
   Scenario: Admin can un-hide a series
     Given I am logged in as "tosser"
       And I add the work "Legit Work" to series "Violation"
-      And I am logged in as superadmin
+      And I am logged in as a "policy_and_abuse" admin
       And I view the series "Violation"
       And I follow "Hide Series"
     When I follow "Make Series Visible"

--- a/features/admins/admin_works.feature
+++ b/features/admins/admin_works.feature
@@ -6,7 +6,7 @@ Feature: Admin Actions for Works, Comments, Series, Bookmarks
   Scenario: Can troubleshoot works
     Given I am logged in as "regular_user"
       And I post the work "Just a work you know"
-    When I am logged in as a "policy_and_abuse" admin
+    When I am logged in as a "support" admin
       And I view the work "Just a work you know"
       And I follow "Troubleshoot"
       And I check "Reindex Work"

--- a/features/admins/users/admin_abuse_users.feature
+++ b/features/admins/users/admin_abuse_users.feature
@@ -6,7 +6,7 @@ Feature: Admin Abuse actions
 
   Background:
     Given the user "mrparis" exists and is activated
-      And I am logged in as policy_and_abuse_admin
+      And I am logged in as a "policy_and_abuse" admin
     When I go to the abuse administration page for "mrparis"
 
   Scenario: An admin adds a note to a user
@@ -67,7 +67,7 @@ Feature: Admin Abuse actions
 
   Scenario: A user cannot be banned without a note
     Given the user "mrparis" exists and is activated
-      And I am logged in as superadmin
+      And I am logged in as a "policy_and_abuse" admin
     When I go to the abuse administration page for "mrparis"
       And I choose "Suspend permanently (ban user)"
     When I press "Update"
@@ -75,7 +75,7 @@ Feature: Admin Abuse actions
 
   Scenario: A user's suspension is lifted with a note
     Given the user "mrparis" is suspended
-      And I am logged in as superadmin
+      And I am logged in as a "policy_and_abuse" admin
     When I go to the abuse administration page for "mrparis"
       And I choose "Lift temporary suspension, effective immediately."
       And I fill in "Notes" with "Good behavior."
@@ -86,7 +86,7 @@ Feature: Admin Abuse actions
 
   Scenario: A user's suspension cannot be lifted without a note
     Given the user "mrparis" is suspended
-      And I am logged in as superadmin
+      And I am logged in as a "policy_and_abuse" admin
     When I go to the abuse administration page for "mrparis"
       And I choose "Lift temporary suspension, effective immediately."
     When I press "Update"
@@ -94,7 +94,7 @@ Feature: Admin Abuse actions
 
   Scenario: A user's ban is lifted with a note
     Given the user "mrparis" is banned
-      And I am logged in as superadmin
+      And I am logged in as a "policy_and_abuse" admin
     When I go to the abuse administration page for "mrparis"
       And I choose "Lift permanent suspension, effective immediately."
       And I fill in "Notes" with "Need him to infiltrate the Maquis."
@@ -105,7 +105,7 @@ Feature: Admin Abuse actions
 
   Scenario: A user's ban cannot be lifted without a note
     Given the user "mrparis" is banned
-      And I am logged in as superadmin
+      And I am logged in as a "policy_and_abuse" admin
     When I go to the abuse administration page for "mrparis"
       And I choose "Lift permanent suspension, effective immediately."
     When I press "Update"
@@ -121,7 +121,7 @@ Feature: Admin Abuse actions
       And I bookmark the work "Not Spam"
       And I add the work "Loads of Spam" to series "One Spam After Another"
       And I post the comment "I like spam" on the work "Not Spam"
-      And I am logged in as superadmin
+      And I am logged in as a "policy_and_abuse" admin
     When I go to the abuse administration page for "Spamster"
       And I choose "Spammer: ban and delete all creations"
       And I press "Update"
@@ -150,7 +150,7 @@ Feature: Admin Abuse actions
   Scenario: A user's works cannot be destroyed unless they are banned
     Given I am logged in as "Spamster"
       And I post the work "Loads of Spam"
-      And I am logged in as superadmin
+      And I am logged in as a "policy_and_abuse" admin
       And I go to the abuse administration page for "Spamster"
       And I choose "Spammer: ban and delete all creations"
       And I press "Update"
@@ -161,7 +161,7 @@ Feature: Admin Abuse actions
 
   Scenario: An already-banned user can have their works destroyed
     Given the user "Spamster" is banned
-      And I am logged in as superadmin
+      And I am logged in as a "policy_and_abuse" admin
     When I go to the abuse administration page for "Spamster"
       And I choose "Spammer: ban and delete all creations"
       And I press "Update"

--- a/features/admins/users/admin_find_users.feature
+++ b/features/admins/users/admin_find_users.feature
@@ -8,7 +8,7 @@ Feature: Admin Find Users page
         | userB  | b@bo3.org  |
         | userCB | cb@bo3.org |
       And the user "userB" exists and has the role "archivist"
-      And I am logged in as superadmin
+      And I am logged in as an "open_doors" admin
       And I go to the manage users page
 
   Scenario: The Find Users page should perform a partial match on name

--- a/features/admins/users/admin_fnok.feature
+++ b/features/admins/users/admin_fnok.feature
@@ -9,7 +9,7 @@ Feature: Admin Fannish Next Of Kind actions
       | login    | password   |
       | harrykim | diesalot   |
       | libby    | stillalive |
-      And I am logged in as policy_and_abuse_admin
+      And I am logged in as a "policy_and_abuse" admin
     When I go to the abuse administration page for "harrykim"
       And I fill in "Fannish next of kin's username" with "libby"
       And I fill in "Fannish next of kin's email" with "testy@foo.com"
@@ -26,7 +26,7 @@ Feature: Admin Fannish Next Of Kind actions
 
   Scenario: An invalid Fannish Next of Kin username is added
     Given the fannish next of kin "libby" for the user "harrykim"
-      And I am logged in as superadmin
+      And I am logged in as a "policy_and_abuse" admin
     When I go to the abuse administration page for "harrykim"
       And I fill in "Fannish next of kin's username" with "userididnotcreate"
       And I press "Update"
@@ -34,7 +34,7 @@ Feature: Admin Fannish Next Of Kind actions
 
   Scenario: A blank Fannish Next of Kin username can't be added
     Given the fannish next of kin "libby" for the user "harrykim"
-      And I am logged in as superadmin
+      And I am logged in as a "policy_and_abuse" admin
     When I go to the abuse administration page for "harrykim"
       And I fill in "Fannish next of kin's username" with ""
       And I press "Update"
@@ -42,7 +42,7 @@ Feature: Admin Fannish Next Of Kind actions
 
   Scenario: A blank Fannish Next of Kin email can't be added
     Given the fannish next of kin "libby" for the user "harrykim"
-      And I am logged in as superadmin
+      And I am logged in as a "policy_and_abuse" admin
     When I go to the abuse administration page for "harrykim"
       And I fill in "Fannish next of kin's email" with ""
       And I press "Update"
@@ -51,7 +51,7 @@ Feature: Admin Fannish Next Of Kind actions
   Scenario: A Fannish Next of Kin is edited
     Given the fannish next of kin "libby" for the user "harrykim"
       And the user "newlibby" exists and is activated
-      And I am logged in as superadmin
+      And I am logged in as a "policy_and_abuse" admin
     When I go to the abuse administration page for "harrykim"
       And I fill in "Fannish next of kin's username" with "newlibby"
       And I fill in "Fannish next of kin's email" with "newlibby@foo.com"
@@ -60,7 +60,7 @@ Feature: Admin Fannish Next Of Kind actions
 
   Scenario: A Fannish Next of Kin is removed
     Given the fannish next of kin "libby" for the user "harrykim"
-      And I am logged in as superadmin
+      And I am logged in as a "policy_and_abuse" admin
     When I go to the abuse administration page for "harrykim"
       And I fill in "Fannish next of kin's username" with ""
       And I fill in "Fannish next of kin's email" with ""
@@ -75,7 +75,7 @@ Feature: Admin Fannish Next Of Kind actions
       And I fill in "Password" with "password"
       And I press "Change User Name"
     Then I should get confirmation that I changed my username
-    When I am logged in as superadmin
+    When I am logged in as a "policy_and_abuse" admin
       And I go to the manage users page
       And I fill in "Name" with "harrykim"
       And I press "Find"
@@ -89,7 +89,7 @@ Feature: Admin Fannish Next Of Kind actions
       And I fill in "Password" with "password"
       And I press "Change User Name"
     Then I should get confirmation that I changed my username
-    When I am logged in as superadmin
+    When I am logged in as a "policy_and_abuse" admin
       And I go to the manage users page
       And I fill in "Name" with "harrykim2"
       And I press "Find"
@@ -98,7 +98,7 @@ Feature: Admin Fannish Next Of Kind actions
   Scenario: A Fannish Next of Kin can update even after an invalid user is entered
     Given the fannish next of kin "libby" for the user "harrykim"
       And the user "harrysmom" exists and is activated
-      And I am logged in as superadmin
+      And I am logged in as a "policy_and_abuse" admin
     When I go to the abuse administration page for "harrykim"
       And I fill in "Fannish next of kin's username" with "libbylibby"
       And I fill in "Fannish next of kin's email" with "libbylibby@example.com"

--- a/features/admins/users/admin_manage_users.feature
+++ b/features/admins/users/admin_manage_users.feature
@@ -9,7 +9,7 @@ Feature: Admin Actions to manage users
       | login | password    |
       | dizmo | wrangulator |
     And I have loaded the "roles" fixture
-    When I am logged in as superadmin
+    When I am logged in as a "support" admin
     And I go to the manage users page
     And I fill in "Name" with "dizmo"
     And I press "Find"
@@ -33,14 +33,14 @@ Feature: Admin Actions to manage users
 
   Scenario: Troubleshooting a user displays a message
     Given the user "mrparis" exists and is activated
-      And I am logged in as superadmin
+      And I am logged in as a "support" admin
     When I go to the abuse administration page for "mrparis"
       And I follow "Troubleshoot Account"
     Then I should see "User account troubleshooting complete."
 
   Scenario: A admin can activate a user account
     Given the user "mrparis" exists and is not activated
-      And I am logged in as support_admin
+      And I am logged in as a "support" admin
     When I go to the abuse administration page for "mrparis"
       And I press "Activate User Account"
     Then I should see "User Account Activated"
@@ -50,7 +50,7 @@ Feature: Admin Actions to manage users
     Given the following users exist
       | login  | password  | email                | confirmation_token |
       | torres | something | torres@starfleet.org | fake_code          |
-      And I am logged in as superadmin
+      And I am logged in as a "support" admin
       And all emails have been delivered
     When I go to the abuse administration page for "torres"
       And I press "Send Activation Email"
@@ -59,7 +59,7 @@ Feature: Admin Actions to manage users
 
   Scenario: An admin can view a user's last login date
     Given the user "new_user" exists and is activated
-      And I am logged in as superadmin
+      And I am logged in as a "support" admin
     When I go to the abuse administration page for "new_user"
     Then I should see "Current Login No login recorded"
       And I should see "Previous Login No previous login recorded"
@@ -67,7 +67,7 @@ Feature: Admin Actions to manage users
       And I am logged in as "new_user"
       And I am logged out
       And I jump in our Delorean and return to the present
-      And I am logged in as superadmin
+      And I am logged in as a "support" admin
       And I go to the abuse administration page for "new_user"
     Then I should not see "No login recorded"
       And I should see "2019-01-01 12:00:00 -0500 Current Login IP Address: 127.0.0.1"

--- a/features/bookmarks/delete_bookmarkable.feature
+++ b/features/bookmarks/delete_bookmarkable.feature
@@ -46,7 +46,7 @@ Feature: Bookmarks of deleted items
     Given basic tags
       And I am logged in as "Alice"
       And I bookmark the external work "Extremely Objectionable Content"
-      And I am logged in as policy_and_abuse_admin
+      And I am logged in as a "policy_and_abuse" admin
       And I view the external work "Extremely Objectionable Content"
       And I follow "Delete External Work"
       And all indexing jobs have been run

--- a/features/comments_and_kudos/hidden_works.feature
+++ b/features/comments_and_kudos/hidden_works.feature
@@ -6,7 +6,7 @@ Feature: Comments on Hidden Works
       And I post the comment "Can I change this?" on the work "To Be Hidden"
       And I am logged in as "commenter"
       And I post the comment "Do you see?" on the work "To Be Hidden"
-      And I am logged in as policy_and_abuse_admin
+      And I am logged in as a "policy_and_abuse" admin
       And I view the work "To Be Hidden"
       And I follow "Hide Work"
 

--- a/features/comments_and_kudos/spam_comments.feature
+++ b/features/comments_and_kudos/spam_comments.feature
@@ -23,7 +23,7 @@ Feature: Marking comments as spam
     Then I should see "Comment Threads: 1"
 
   Scenario: Spam comments are not included in an admin post's comment count
-    Given I am logged in as admin with role "communications"
+    Given I am logged in as a "communications" admin
       And I make an admin post
       And I am logged out as an admin
       And I go to the admin-posts page

--- a/features/importing/archivist.feature
+++ b/features/importing/archivist.feature
@@ -13,7 +13,7 @@ Feature: Archivist bulk imports
 
   Scenario: Make a user an archivist
     Given I have pre-archivist setup for "not_archivist"
-      And I am logged in as open_doors_admin
+      And I am logged in as an "open_doors" admin
     When I make "not_archivist" an archivist
     Then I should see "User was successfully updated"
 

--- a/features/other_a/invite_queue.feature
+++ b/features/other_a/invite_queue.feature
@@ -12,7 +12,7 @@ Feature: Invite queue management
 
   Scenario: Can turn queue off in Admin Settings and it displays as off
 
-    Given I am logged in as superadmin
+    Given I am logged in as a super admin
       And I go to the admin-settings page
       And I uncheck "admin_setting_invite_from_queue_enabled"
       And I press "Update"
@@ -23,7 +23,7 @@ Feature: Invite queue management
 
   Scenario: Can turn queue on in Admin Settings and it displays as on
 
-    Given I am logged in as superadmin
+    Given I am logged in as a super admin
       And account creation requires an invitation
       And I go to the admin-settings page
       And I check "admin_setting_invite_from_queue_enabled"
@@ -37,7 +37,7 @@ Feature: Invite queue management
   Scenario: An admin can delete people from the queue
 
     Given an invitation request for "invitee@example.org"
-      And I am logged in as superadmin
+      And I am logged in as an admin
     When I go to the manage invite queue page
       And I press "Delete"
     Then I should see "Request for invitee@example.org was removed from the queue."
@@ -105,7 +105,7 @@ Feature: Invite queue management
       And I should see "If you can't find it, your invitation may have already been emailed to that address;"
 
     # invite can be used
-    When I am logged in as superadmin
+    When I am logged in as an admin
       And I follow "Invitations"
       And I fill in "track_invitation_invitee_email" with "test@archiveofourown.org"
       And I press "Go"

--- a/features/other_a/invite_request.feature
+++ b/features/other_a/invite_request.feature
@@ -111,21 +111,21 @@ Feature: Invite requests
     Then I should see "Invitation was successfully sent."
 
   Scenario: An admin can get to a user's invitations page
-    Given I am logged in as superadmin
+    Given I am logged in as a "support" admin
       And the user "steven" exists and is activated
     When I go to the abuse administration page for "steven"
       And I follow "Add User Invitations"
     Then I should be on steven's invitations page
 
   Scenario: An admin can get to a user's manage invitations page
-    Given I am logged in as superadmin
+    Given I am logged in as a "support" admin
       And the user "steven" exists and is activated
     When I go to the abuse administration page for "steven"
       And I follow "Manage User Invitations"
     Then I should be on steven's manage invitations page
 
   Scenario: An admin can create a user's invitations
-    Given I am logged in as superadmin
+    Given I am logged in as a "support" admin
       And the user "steven" exists and is activated
     When I go to steven's invitations page
     Then I should see "Create more invitations for this user"
@@ -136,7 +136,7 @@ Feature: Invite requests
   Scenario: An admin can delete a user's invitations
     Given the user "user1" exists and is activated
       And "user1" has "5" invitations
-      And I am logged in as superadmin
+      And I am logged in as a "support" admin
     When I follow "Invite New Users"
       And I fill in "invitation[user_name]" with "user1"
       And I press "Go"

--- a/features/other_a/media.feature
+++ b/features/other_a/media.feature
@@ -56,7 +56,7 @@ Feature: The All Fandoms page.
       And I go to the media page
     Then I should see "Lord of the Rings (1)"
 
-    When I am logged in as superadmin
+    When I am logged in as a "policy_and_abuse" admin
       And I go to the media page
     Then I should see "Lord of the Rings (2)"
 

--- a/features/step_definitions/admin_steps.rb
+++ b/features/step_definitions/admin_steps.rb
@@ -45,7 +45,7 @@ end
 Given /^basic languages$/ do
   Language.default
   german = Language.find_or_create_by(short: "DE", name: "Deutsch", support_available: true, abuse_support_available: true)
-  de = Locale.create(iso: "de", name: "Deutsch", language: german)
+  Locale.create(iso: "de", name: "Deutsch", language: german)
 end
 
 Given /^downloads are off$/ do

--- a/features/step_definitions/admin_steps.rb
+++ b/features/step_definitions/admin_steps.rb
@@ -13,89 +13,29 @@ Given /the following admins? exists?/ do |table|
   end
 end
 
-Given /^I am logged in as admin with role "(.*?)"$/ do |role|
-  step("I am logged in as an admin")
-  admin = Admin.find_by(login: "testadmin")
-  admin.roles << role
-  admin.save!
+Given "I am logged in as a super admin" do
+  step %{I am logged in as a "superadmin" admin}
 end
 
-Given /^I am logged in as an admin$/ do
-  step("I am logged out")
-  admin = Admin.find_by(login: "testadmin")
-  if admin.blank?
-    FactoryBot.create(:admin, login: "testadmin", password: "testadmin", email: "testadmin@example.org")
-  end
+Given "I am logged in as a(n) {string} admin" do |role|
+  step %{I am logged out}
+  login = "testadmin-#{role}"
+  FactoryBot.create(:admin, login: login, roles: [role]) if Admin.find_by(login: login).nil?
+  visit new_admin_session_path
+  fill_in "Admin user name", with: login
+  fill_in "Admin password", with: "password"
+  click_button "Log in as admin"
+  step %{I should see "Successfully logged in"}
+end
+
+Given "I am logged in as an admin" do
+  step %{I am logged out}
+  FactoryBot.create(:admin, login: "testadmin", email: "testadmin@example.org") if Admin.find_by(login: "testadmin").nil?
   visit new_admin_session_path
   fill_in "Admin user name", with: "testadmin"
-  fill_in "Admin password", with: "testadmin"
+  fill_in "Admin password", with: "password"
   click_button "Log in as admin"
-  step(%{I should see "Successfully logged in"})
-end
-
-Given /^I am logged in as superadmin$/ do
-  step("I am logged out")
-  admin = Admin.find_by(login: "superadmin")
-  if admin.blank?
-    FactoryBot.create(:superadmin)
-  end
-  visit new_admin_session_path
-  fill_in "Admin user name", with: "superadmin"
-  fill_in "Admin password", with: "IHaveThePower"
-  click_button "Log in as admin"
-  step(%{I should see "Successfully logged in"})
-end
-
-Given /^I am logged in as policy_and_abuse_admin$/ do
-  step("I am logged out")
-  admin = Admin.find_by(login: "policy_admin")
-  if admin.blank?
-    FactoryBot.create(:policy_and_abuse_admin)
-  end
-  visit new_admin_session_path
-  fill_in "Admin user name", with: "policy_admin"
-  fill_in "Admin password", with: "policy"
-  click_button "Log in as admin"
-  step(%{I should see "Successfully logged in"})
-end
-
-Given /^I am logged in as support_admin$/ do
-  step("I am logged out")
-  admin = Admin.find_by(login: "support_admin")
-  if admin.blank?
-    FactoryBot.create(:support_admin)
-  end
-  visit new_admin_session_path
-  fill_in "Admin user name", with: "support_admin"
-  fill_in "Admin password", with: "support"
-  click_button "Log in as admin"
-  step(%{I should see "Successfully logged in"})
-end
-
-Given /^I am logged in as tag_wrangling_admin$/ do
-  step("I am logged out")
-  admin = Admin.find_by(login: "tag_wrangling_admin")
-  if admin.blank?
-    FactoryBot.create(:tag_wrangling_admin)
-  end
-  visit new_admin_session_path
-  fill_in "Admin user name", with: "tag_wrangling_admin"
-  fill_in "Admin password", with: "tagwrangling"
-  click_button "Log in as admin"
-  step(%{I should see "Successfully logged in"})
-end
-
-Given /^I am logged in as open_doors_admin$/ do
-  step("I am logged out")
-  admin = Admin.find_by(login: "open_doors_admin")
-  if admin.blank?
-    FactoryBot.create(:open_doors_admin)
-  end
-  visit new_admin_session_path
-  fill_in "Admin user name", with: "open_doors_admin"
-  fill_in "Admin password", with: "opendoors"
-  click_button "Log in as admin"
-  step(%{I should see "Successfully logged in"})
+  step %{I should see "Successfully logged in"}
 end
 
 Given /^I am logged out as an admin$/ do
@@ -105,22 +45,18 @@ end
 Given /^basic languages$/ do
   Language.default
   german = Language.find_or_create_by(short: "DE", name: "Deutsch", support_available: true, abuse_support_available: true)
-  de = Locale.new
-  de.iso = 'de'
-  de.name = 'Deutsch'
-  de.language_id = german.id
-  de.save!
+  de = Locale.create(iso: "de", name: "Deutsch", language: german)
 end
 
 Given /^downloads are off$/ do
-  step("I am logged in as superadmin")
+  step("I am logged in as a super admin")
   visit(admin_settings_path)
   uncheck("Allow downloads")
   click_button("Update")
 end
 
 Given /^tag wrangling is off$/ do
-  step("I am logged in as tag_wrangling_admin")
+  step(%{I am logged in as a "tag_wrangling" admin})
   visit(admin_settings_path)
   step(%{I check "Turn off tag wrangling for non-admins"})
   step(%{I press "Update"})  
@@ -128,7 +64,7 @@ Given /^tag wrangling is off$/ do
 end
 
 Given /^tag wrangling is on$/ do
-  step("I am logged in as tag_wrangling_admin")
+  step(%{I am logged in as a "tag_wrangling" admin})
   visit(admin_settings_path)
   step(%{I uncheck "Turn off tag wrangling for non-admins"})
   step(%{I press "Update"})
@@ -136,7 +72,7 @@ Given /^tag wrangling is on$/ do
 end
 
 Given /^the support form is disabled and its text field set to "Please don't contact us"$/ do
-  step("I am logged in as support_admin")
+  step(%{I am logged in as a "support" admin})
   visit(admin_settings_path)
   check("Turn off support form")
   fill_in(:admin_setting_disabled_support_form_text, with: "Please don't contact us")
@@ -144,7 +80,7 @@ Given /^the support form is disabled and its text field set to "Please don't con
 end
 
 Given /^the support form is enabled$/ do
-  step("I am logged in as superadmin")
+  step(%{I am logged in as a "support" admin})
   visit(admin_settings_path)
   uncheck("Turn off support form")
   click_button("Update")
@@ -166,7 +102,7 @@ Given /^I have posted known issues$/ do
 end
 
 Given /^I have posted an admin post$/ do
-  step(%{I am logged in as admin with role "communications"})
+  step(%{I am logged in as a "communications" admin})
   step("I make an admin post")
   step("I am logged out as an admin")
 end
@@ -174,7 +110,7 @@ end
 Given /^the fannish next of kin "([^\"]*)" for the user "([^\"]*)"$/ do |kin, user|
   step %{the user "#{kin}" exists and is activated}
   step %{the user "#{user}" exists and is activated}
-  step %{I am logged in as policy_and_abuse_admin}
+  step %{I am logged in as a "policy_and_abuse" admin}
   step %{I go to the abuse administration page for "#{user}"}
   fill_in("Fannish next of kin's username", with: "#{kin}")
   fill_in("Fannish next of kin's email", with: "testing@foo.com")
@@ -183,7 +119,7 @@ end
 
 Given /^the user "([^\"]*)" is suspended$/ do |user|
   step %{the user "#{user}" exists and is activated}
-  step %{I am logged in as policy_and_abuse_admin}
+  step %{I am logged in as a "policy_and_abuse" admin}
   step %{I go to the abuse administration page for "#{user}"}
   choose("admin_action_suspend")
   fill_in("suspend_days", with: 30)
@@ -193,7 +129,7 @@ end
 
 Given /^the user "([^\"]*)" is banned$/ do |user|
   step %{the user "#{user}" exists and is activated}
-  step %{I am logged in as superadmin}
+  step(%{I am logged in as a "policy_and_abuse" admin})
   step %{I go to the abuse administration page for "#{user}"}
   choose("admin_action_ban")
   fill_in("Notes", with: "Why they are banned")
@@ -206,13 +142,13 @@ Then /^the user "([^\"]*)" should be permanently banned$/ do |user|
 end
 
 Given /^I have posted an admin post without paragraphs$/ do
-  step(%{I am logged in as admin with role "communications"})
+  step(%{I am logged in as a "communications" admin})
   step("I make an admin post without paragraphs")
   step("I am logged out as an admin")
 end
 
 Given /^I have posted an admin post with tags$/ do
-  step(%{I am logged in as admin with role "communications"})
+  step(%{I am logged in as a "communications" admin})
   visit new_admin_post_path
   fill_in("admin_post_title", with: "Default Admin Post")
   fill_in("content", with: "Content of the admin post.")

--- a/features/step_definitions/external_work_steps.rb
+++ b/features/step_definitions/external_work_steps.rb
@@ -37,7 +37,7 @@ When /^the (character|fandom|relationship) "(.*?)" is removed from the external 
   external_work = ExternalWork.find_by(title: title)
   tags = external_work.tags.where(type: tag_type).pluck(:name) - [tag]
   tag_string = tags.join(", ")
-  step %{I am logged in as policy_and_abuse_admin}
+  step %{I am logged in as a "policy_and_abuse" admin}
   visit edit_external_work_path(external_work)
   fill_in("work_#{tag_type}", with: tag_string)
   click_button("Update External work")

--- a/features/tags_and_wrangling/brand_new_fandoms.feature
+++ b/features/tags_and_wrangling/brand_new_fandoms.feature
@@ -43,7 +43,7 @@ Feature: Brand new fandoms
       And I fill in "Fandoms" with "My Brand New Fandom"
       And I submit
       And the periodic tag count task is run
-    When I am logged in as policy_and_abuse_admin
+    When I am logged in as a "policy_and_abuse" admin
       And I view the external work "External Work To Be Deleted"
       And I follow "Delete External Work"
     Then I should see "Item was successfully deleted."
@@ -89,7 +89,7 @@ Feature: Brand new fandoms
       And I fill in "Fandoms" with "My Brand New Fandom"
       And I submit
       And the periodic tag count task is run
-    When I am logged in as superadmin
+    When I am logged in as a "policy_and_abuse" admin
       And I view the external work "External Work To Be Deleted"
       And I follow "Delete External Work"
     Then I should see "Item was successfully deleted."

--- a/features/tags_and_wrangling/tag_wrangling.feature
+++ b/features/tags_and_wrangling/tag_wrangling.feature
@@ -6,7 +6,7 @@ Feature: Tag wrangling
     Given I have loaded the "roles" fixture
     When I am logged in as "dizmo"
     Then I should not see "Tag Wrangling" within "#header"
-    When I am logged in as tag_wrangling_admin
+    When I am logged in as a "tag_wrangling" admin
       And I go to the manage users page
       And I fill in "Name" with "dizmo"
       And I press "Find"

--- a/features/tags_and_wrangling/tag_wrangling_admin.feature
+++ b/features/tags_and_wrangling/tag_wrangling_admin.feature
@@ -19,7 +19,7 @@ Feature: Tag wrangling
   Scenario: Admin can remove a user's wrangling privileges from the manage users page (this will leave assignments intact)
 
     Given the tag wrangler "tangler" with password "wr@ngl3r" is wrangler of "Testing"
-    When I am logged in as tag_wrangling_admin
+    When I am logged in as a "tag_wrangling" admin
       And I am on the manage users page
     When I fill in "Name" with "tangler"
       And I press "Find"

--- a/features/works/work_download.feature
+++ b/features/works/work_download.feature
@@ -108,6 +108,6 @@ Feature: Download a work
 
   Given I am logged in
     And I post the work "TOS Violation"
-  When I am logged in as policy_and_abuse_admin
+  When I am logged in as a "policy_and_abuse" admin
     And I hide the work "TOS Violation"
   Then I should not see "Download"

--- a/script/create_admin.rb
+++ b/script/create_admin.rb
@@ -59,24 +59,25 @@ list.each do |user|
     a.password_confirmation = password
 
     password_file = <<~PASSFILE
-
       username: #{a.login}
       password: #{password}
-      #{new_admin_session_url}"
-
+      #{new_admin_session_url}
     PASSFILE
   end
 
+  puts "==== #{a.login}.txt"
   if a.save
     puts password_file if password_file.present?
     admins << a
   else
     puts a.errors.full_messages
   end
+  puts
 end
 
 puts "\nFor all saved admins, copy and paste into the wiki at https://wiki.transformativeworks.org/mediawiki/AO3_Admins:\n"
 
+admins.sort_by!(&:created_at)
 admins.each do |admin|
   role_description = admin.roles.map { |r| I18n.t("activerecord.attributes.admin/role.#{r}") }.sort.join(", ")
   role_description = "UPDATE WITH USER COMMITTEE" if role_description.blank?


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5623
https://otwarchive.atlassian.net/browse/AO3-5980
https://otwarchive.atlassian.net/browse/AO3-5518

## Purpose

AO3-5623 AO3-5980 Fix minor issues with admin creation script

- Remove stray quote.
- Print filename so we can identify error messages.
- Sort wiki output by admins' created timestamps.

AO3-5518 Clean up feature steps to create admins

- Have one step for all types of admins.
- Use the admin role in the admin's username so we can reuse the admin later when we need the same role.
- Use a more specific role than "superadmin" whenever we can.
- Use the generic no-role admin if the feature under test is not yet locked behind any admin roles.
- Remove tests where admins reply to news post comments, as we won't do AO3-3685.

## Testing Instructions

Run the script:

<details>

    Pandemonica,monika2@example.com,support,tag_wrangling
    Malina
    Beelzebub,,
    Hell taker,,support
    Justice,prosecutest@example.com,translation
    Lucifer,lucifer@example.com,policy_and_abuse


    For new admins, copy and paste each section into a separate file and upload to the admin's Vault:
    ==== admin-Pandemonica.txt

    ==== admin-Malina.txt
    Email can't be blank

    ==== admin-Beelzebub.txt
    Email can't be blank

    ==== admin-Helltaker.txt
    Email can't be blank

    ==== admin-Justice.txt

    ==== admin-Lucifer.txt
    username: admin-Lucifer
    password: aiT0iewo
    https://127.0.0.1/admin/login

</details>