### PR TITLE
AO3-4634 Prompt meme claims access restriction

### DIFF
--- a/app/controllers/challenge_claims_controller.rb
+++ b/app/controllers/challenge_claims_controller.rb
@@ -74,7 +74,7 @@ class ChallengeClaimsController < ApplicationController
     if params[:collection_id]
       return unless load_collection
 
-      @challenge = @collection.challenge if @collection
+      @challenge = @collection.challenge
       not_allowed(@collection) unless user_scoped? || @challenge.user_allowed_to_see_assignments?(current_user)
 
       @claims = ChallengeClaim.unposted_in_collection(@collection)

--- a/app/controllers/challenge_claims_controller.rb
+++ b/app/controllers/challenge_claims_controller.rb
@@ -73,11 +73,12 @@ class ChallengeClaimsController < ApplicationController
     end
     if params[:collection_id]
       return unless load_collection
+
       @challenge = @collection.challenge if @collection
+      not_allowed(@collection) unless user_scoped? || @challenge.user_allowed_to_see_assignments?(current_user)
+
       @claims = ChallengeClaim.unposted_in_collection(@collection)
-      if params[:for_user] || !@challenge.user_allowed_to_see_claims?(current_user)
-        @claims = @claims.where(claiming_user_id: current_user.id)
-      end
+      @claims = @claims.where(claiming_user_id: current_user.id) if user_scoped?
 
       # sorting
       set_sort_order
@@ -147,4 +148,7 @@ class ChallengeClaimsController < ApplicationController
     )
   end
 
+  def user_scoped?
+    params[:for_user].to_s.casecmp?("true")
+  end
 end

--- a/app/controllers/challenge_claims_controller.rb
+++ b/app/controllers/challenge_claims_controller.rb
@@ -122,18 +122,17 @@ class ChallengeClaimsController < ApplicationController
   end
 
   def destroy
-    @claim = ChallengeClaim.find(params[:id])
+    if @challenge_claim.claiming_user == current_user
 
     begin
-      if @claim.claiming_user == current_user
         @usernotmod = "true"
       end
-      @claim.destroy
       if @usernotmod == "true"
         flash[:notice] = ts("Your claim was deleted.")
       else
         flash[:notice] = ts("The claim was deleted.")
       end
+      @challenge_claim.destroy
     rescue
       flash[:error] = ts("We couldn't delete that right now, sorry! Please try again later.")
     end

--- a/app/controllers/challenge_claims_controller.rb
+++ b/app/controllers/challenge_claims_controller.rb
@@ -122,21 +122,21 @@ class ChallengeClaimsController < ApplicationController
   end
 
   def destroy
+    redirect_path = collection_claims_path(@collection)
+    flash[:notice] = ts("The claim was deleted.")
+
     if @challenge_claim.claiming_user == current_user
+      redirect_path = collection_claims_path(@collection, for_user: true)
+      flash[:notice] = ts("Your claim was deleted.")
+    end
 
     begin
-        @usernotmod = "true"
-      end
-      if @usernotmod == "true"
-        flash[:notice] = ts("Your claim was deleted.")
-      else
-        flash[:notice] = ts("The claim was deleted.")
-      end
       @challenge_claim.destroy
     rescue
+      flash.delete(:notice)
       flash[:error] = ts("We couldn't delete that right now, sorry! Please try again later.")
     end
-    redirect_to collection_claims_path(@collection)
+    redirect_to redirect_path
   end
 
   private

--- a/app/models/challenge_claim.rb
+++ b/app/models/challenge_claim.rb
@@ -9,11 +9,6 @@ class ChallengeClaim < ApplicationRecord
   belongs_to :request_prompt, class_name: "Prompt"
   belongs_to :creation, polymorphic: true
 
-  # have to override the == operator or else two claims by same user on same user's prompts are equal
-  def ==(other)
-    super(other) && other.request_prompt_id == self.request_prompt_id
-  end
-
   scope :for_request_signup, lambda {|signup|
     where('request_signup_id = ?', signup.id)
   }
@@ -112,13 +107,6 @@ class ChallengeClaim < ApplicationRecord
 
   def fulfilled?
     self.creation && (item = get_collection_item) && item.approved?
-  end
-
-  include Comparable
-  def <=>(other)
-    return -1 if self.request_signup.nil? && other.request_signup
-    return 1 if other.request_signup.nil? && self.request_signup
-    return self.request_byline.downcase <=> other.request_byline.downcase
   end
 
   def title

--- a/app/models/challenge_models/prompt_meme.rb
+++ b/app/models/challenge_models/prompt_meme.rb
@@ -45,11 +45,10 @@ class PromptMeme < ApplicationRecord
   before_destroy :clear_challenge_references
 
   def user_allowed_to_see_signups?(user)
-    return true
+    true
   end
 
   def user_allowed_to_see_claims?(user)
-    return true
+    user_allowed_to_see_assignments?(user)
   end
-
 end

--- a/spec/controllers/challenge_claims_controller_spec.rb
+++ b/spec/controllers/challenge_claims_controller_spec.rb
@@ -25,6 +25,28 @@ describe ChallengeClaimsController do
       it_redirects_to_with_error(root_path, \
                                  "You aren't allowed to see that user's claims.")
     end
+
+    context "for a prompt meme" do
+      let(:signup) { create(:prompt_meme_signup) }
+
+      it "will not allow a logged in user to see everyone's claims" do
+        fake_login_known_user(user)
+
+        get :index, params: { collection_id: collection.name }
+
+        it_redirects_to_with_error(collection, "Sorry, you're not allowed to do that.")
+      end
+
+      it "will allow a maintainer to see everyone's claims" do
+        collection.collection_participants.create(pseud: user.pseuds.first, participant_role: "Moderator")
+        fake_login_known_user(user)
+
+        get :index, params: { collection_id: collection.name }
+
+        expect(flash[:error]).to be_blank
+        expect(assigns(:claims))
+      end
+    end
   end
 
   describe 'show' do


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [x] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [x] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [x] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-4634

## Purpose

What does this PR do?

Restricts access to the unposted claims page to the maintainers of the challenge's collection. Users who are not maintainers can only access the page with their unposted claims.

* The challenge claims controller is not restricted to prompt memes, so using a method that is only implemented by prompt memes, `user_allowed_to_see_claims?`, could be brittle. I have chosen `user_allowed_to_see_assignments?` as a proxy for what a claim is roughly equivalent with - it's someone self-assigning themself to that request, more or less, and it's a method implemented in `ChallengeCore`, common to all existing types of challenge.
* If the `for_user` parameter has been removed or otherwise tampered with by a user who doesn't have permission to view all the claims, return them to the collection home page with an error message. (There is no direct link for a regular user to access all the claims in a prompt meme collection, so if we detect such a request we can reject it. There are, however, redirects after deleting a claim, which require fixing.)
* Expand the spec with prompt meme specific scenarios for claim deletion.
* Redirect the user according to the page they have permission to access, whether the deletion succeeded or not. (The redirection in case they don't have permission to destroy the claim is already handled in a before action.)

## Testing Instructions

How can the Archive's QA team verify that this is working as you intended?

Added to Jira.

## References

Are there other relevant issues/pull requests/mailing list discussions?

There is a separate issue involving signups permissions: https://otwarchive.atlassian.net/browse/AO3-5890 so I'd rather not get into that here.

## Credit

*What name do you want us to use to credit your work in the [Archive of Our Own's Release Notes](https://archiveofourown.org/admin_posts?tag=1)?*

Enigel

*What pronouns do you prefer (she/her, he/him, zie/hir etc)?*

she/her
