### PR TITLE
AO3-5999 Make comment factories look more like real comments, and reorganize to use traits.

### DIFF
--- a/factories/comments.rb
+++ b/factories/comments.rb
@@ -2,40 +2,28 @@ require 'faker'
 
 FactoryBot.define do
   factory :comment do
-    name { Faker::Name.first_name }
     comment_content { Faker::Lorem.sentence(25) }
-    email { Faker::Internet.email }
-    commentable_type { "Work" }
-    commentable_id { create(:work).id }
-    pseud
-  end
+    commentable { create(:work).last_posted_chapter }
+    pseud { create(:user).default_pseud }
 
-  factory :adminpost_comment, class: Comment do
-    name { Faker::Name.first_name }
-    comment_content { Faker::Lorem.sentence(25) }
-    email { Faker::Internet.email }
-    commentable_type { "AdminPost" }
-    commentable_id { create(:admin_post).id }
-    pseud
-  end
+    trait :by_guest do
+      pseud { nil }
+      name { Faker::Name.first_name }
+      email { Faker::Internet.email }
+    end
 
-  factory :tag_comment, class: Comment do
-    name { Faker::Name.first_name }
-    comment_content { Faker::Lorem.sentence(25) }
-    email { Faker::Internet.email }
-    commentable_type { "Tag" }
-    commentable_id { create(:fandom).id }
-    pseud
-  end
+    trait :on_admin_post do
+      commentable { create(:admin_post) }
+    end
 
-  factory :unreviewed_comment, class: Comment do
-    name { Faker::Name.first_name }
-    comment_content { Faker::Lorem.sentence(25) }
-    email { Faker::Internet.email }
-    commentable_type { "Work" }
-    commentable_id { create(:work, moderated_commenting_enabled: true).id }
-    pseud
-    unreviewed { true }
+    trait :on_tag do
+      commentable { create(:fandom) }
+    end
+
+    trait :unreviewed do
+      commentable { create(:work, moderated_commenting_enabled: true).last_posted_chapter }
+      unreviewed { true }
+    end
   end
 
   factory :inbox_comment do

--- a/features/search/works_stats.feature
+++ b/features/search/works_stats.feature
@@ -147,7 +147,8 @@ Feature: Search works by stats
   Scenario: Search by > a number of comments and sort in ascending order by
     title using the header search
     Given a set of works with comments for searching
-    When I fill in "site_search" with "comments: > 2 sort: title ascending"
+    When I am on the home page
+      And I fill in "site_search" with "comments: > 2 sort: title ascending"
       And I press "Search"
     Then I should see "You searched for: comments count: > 2 sort by: title ascending"
       And I should see "3 Found"
@@ -222,7 +223,8 @@ Feature: Search works by stats
   Scenario: Search by > a number of bookmarks and sort in ascending order by
   title using the header search
     Given a set of works with bookmarks for searching
-    When I fill in "site_search" with "bookmarks: > 2 sort by: title ascending"
+    When I am on the home page
+      And I fill in "site_search" with "bookmarks: > 2 sort by: title ascending"
       And I press "Search"
     Then I should see "You searched for: bookmarks count: > 2 sort by: title ascending"
       And I should see "2 Found"

--- a/features/step_definitions/tag_steps.rb
+++ b/features/step_definitions/tag_steps.rb
@@ -148,12 +148,9 @@ end
 Given /^a tag "([^\"]*)" with(?: (\d+))? comments$/ do |tagname, n_comments|
   tag = Fandom.find_or_create_by_name(tagname)
   step %{I am logged out}
+
   n_comments ||= 3
-  n_comments.to_i.times do |i|
-    step %{I am logged in as a tag wrangler}
-    step %{I post the comment "Comment number #{i}" on the tag "#{tagname}"}
-    step %{I am logged out}
-  end
+  FactoryBot.create_list(:comment, n_comments.to_i, :on_tag, commentable: tag)
 end
 
 Given /^(?:a|the) canonical(?: "([^"]*)")? fandom "([^"]*)" with (\d+) works$/ do |media, tag_name, number_of_works|
@@ -168,12 +165,9 @@ end
 Given /^a period-containing tag "([^\"]*)" with(?: (\d+))? comments$/ do |tagname, n_comments|
   tag = Fandom.find_or_create_by_name(tagname)
   step %{I am logged out}
+
   n_comments ||= 3
-  n_comments.to_i.times do |i|
-    step %{I am logged in as a tag wrangler}
-    step %{I post the comment "Comment number #{i}" on the period-containing tag "#{tagname}"}
-    step %{I am logged out}
-  end
+  FactoryBot.create_list(:comment, n_comments.to_i, :on_tag, commentable: tag)
 end
 
 Given /^the unsorted tags setup$/ do

--- a/features/step_definitions/work_search_steps.rb
+++ b/features/step_definitions/work_search_steps.rb
@@ -134,16 +134,21 @@ end
 Given /^a set of works with comments for searching$/ do
   step %{basic tags}
 
-  # Comments created with factories are not added to a work's stat totals
-  # even after running the rake task, so we're doing it through steps that add
-  # comments through the interface
-  step %{I have a work "Work 1"}
-  step %{the work "Work 2" with 1 comments setup}
-  step %{the work "Work 3" with 1 comments setup}
-  step %{the work "Work 4" with 1 comments setup}
-  step %{the work "Work 5" with 3 comments setup}
-  step %{the work "Work 6" with 3 comments setup}
-  step %{the work "Work 7" with 10 comments setup}
+  counts = {
+    "Work 1" => 0,
+    "Work 2" => 1,
+    "Work 3" => 1,
+    "Work 4" => 1,
+    "Work 5" => 3,
+    "Work 6" => 3,
+    "Work 7" => 10
+  }
+
+  counts.each_pair do |title, comment_count|
+    work = FactoryBot.create(:work, title: title)
+    FactoryBot.create_list(:comment, comment_count, :by_guest,
+                           commentable: work.last_posted_chapter)
+  end
 
   step %{the statistics for all works are updated}
   step %{all indexing jobs have been run}
@@ -189,26 +194,22 @@ end
 Given /^a set of works with bookmarks for searching$/ do
   step %{basic tags}
 
-  # Bookmarks created with factories are not added to a work's stat totals
-  # even after running the rake task, so we're doing it through steps that add
-  # bookmarks through the interface
-  step %{I have a work "Work 1"}
-  step %{the work "Work 2" with 1 bookmark setup}
-  step %{the work "Work 3" with 1 bookmark setup}
-  step %{the work "Work 4" with 2 bookmarks setup}
-  step %{the work "Work 5" with 2 bookmarks setup}
-  step %{the work "Work 6" with 4 bookmarks setup}
-  step %{the work "Work 7" with 10 bookmarks setup}
+  counts = {
+    "Work 1" => 0,
+    "Work 2" => 1,
+    "Work 3" => 1,
+    "Work 4" => 2,
+    "Work 5" => 2,
+    "Work 6" => 4,
+    "Work 7" => 10
+  }
 
-  step %{the statistics for all works are updated}
-
-  # The cache on work blurb stat lines expires every hour -- we need to expire
-  # them so we can check the results
-  7.times do |i|
-    work = Work.find_by_title("Work #{i + 1}")
-    ActionController::Base.new.expire_fragment("#{work.cache_key}/stats-v2")
+  counts.each_pair do |title, bookmark_count|
+    work = FactoryBot.create(:work, title: title)
+    FactoryBot.create_list(:bookmark, bookmark_count, bookmarkable: work)
   end
 
+  step %{the statistics for all works are updated}
   step %{all indexing jobs have been run}
 end
 

--- a/features/step_definitions/work_steps.rb
+++ b/features/step_definitions/work_steps.rb
@@ -123,26 +123,21 @@ Given /^I have no works or comments$/ do
 end
 
 Given /^the chaptered work(?: with ([\d]+) chapters)?(?: with ([\d]+) comments?)? "([^"]*)"$/ do |n_chapters, n_comments, title|
-  step %{I am logged in as a random user}
-  step %{I post the work "#{title}"}
-  work = Work.find_by(title: title)
-  visit work_path(work)
-  n_chapters ||= 2
-  (n_chapters.to_i - 1).times do |i|
-    step %{I follow "Add Chapter"}
-    fill_in("content", with: "Yet another chapter.")
-    click_button("Post")
-  end
   step %{I am logged out}
+  step %{basic tags}
+
+  title ||= "Blabla"
+  n_chapters ||= 2
+
+  work = FactoryBot.create(:work, title: title, expected_number_of_chapters: n_chapters.to_i)
+  FactoryBot.create_list(:chapter, n_chapters.to_i - 1,
+                         work: work,
+                         posted: true)
+
   n_comments ||= 0
-  work = Work.find_by(title: title)
-  n_comments.to_i.times do |i|
-    step %{I am logged in as a random user}
-    visit work_path(work)
-    fill_in("comment[comment_content]", with: "Bla bla")
-    click_button("Comment")
-    step %{I am logged out}
-  end
+  FactoryBot.create_list(:comment, n_comments.to_i, :by_guest,
+                         commentable: work.chapters.posted.first,
+                         comment_content: "Bla bla")
 end
 
 Given /^I have a work "([^"]*)"$/ do |work|
@@ -161,27 +156,26 @@ Given /^I have a multi-chapter draft$/ do
 end
 
 Given /^the work(?: "([^"]*)")? with(?: (\d+))? comments setup$/ do |title, n_comments|
-  title ||= "Blabla"
-  step %{I have a work "#{title}"}
   step %{I am logged out}
+  step %{basic tags}
+
+  title ||= "Blabla"
+  work = FactoryBot.create(:work, title: title)
+
   n_comments ||= 3
-  n_comments.to_i.times do |i|
-    step %{I am logged in as a random user}
-    step %{I post the comment "Keep up the good work" on the work "#{title}"}
-    step %{I am logged out}
-  end
+  FactoryBot.create_list(:comment, n_comments.to_i, :by_guest,
+                         commentable: work.last_posted_chapter)
 end
 
 Given /^the work(?: "([^"]*)")? with(?: (\d+))? bookmarks? setup$/ do |title, n_bookmarks|
-  title ||= "Blabla"
-  step %{I have a work "#{title}"}
   step %{I am logged out}
+  step %{basic tags}
+
+  title ||= "Blabla"
+  work = FactoryBot.create(:work, title: title)
+
   n_bookmarks ||= 3
-  n_bookmarks.to_i.times do |i|
-    step %{I am logged in as a random user}
-    step %{I bookmark the work "#{title}"}
-    step %{I am logged out}
-  end
+  FactoryBot.create_list(:bookmark, n_bookmarks.to_i, bookmarkable: work)
 end
 
 Given /^the chaptered work setup$/ do

--- a/features/step_definitions/work_steps.rb
+++ b/features/step_definitions/work_steps.rb
@@ -134,9 +134,12 @@ Given /^the chaptered work(?: with ([\d]+) chapters)?(?: with ([\d]+) comments?)
                          work: work,
                          posted: true)
 
+  # Make sure that the word count is set properly:
+  work.save
+
   n_comments ||= 0
   FactoryBot.create_list(:comment, n_comments.to_i, :by_guest,
-                         commentable: work.chapters.posted.first,
+                         commentable: work.first_chapter,
                          comment_content: "Bla bla")
 end
 

--- a/features/step_definitions/work_steps.rb
+++ b/features/step_definitions/work_steps.rb
@@ -130,9 +130,12 @@ Given /^the chaptered work(?: with ([\d]+) chapters)?(?: with ([\d]+) comments?)
   n_chapters ||= 2
 
   work = FactoryBot.create(:work, title: title, expected_number_of_chapters: n_chapters.to_i)
-  FactoryBot.create_list(:chapter, n_chapters.to_i - 1,
-                         work: work,
-                         posted: true)
+
+  # In order to make sure that the chapter positions are valid, we have to set
+  # them manually. So we can't use create_list, and have to loop instead:
+  (n_chapters.to_i - 1).times do |index|
+    FactoryBot.create(:chapter, work: work, posted: true, position: index + 2)
+  end
 
   # Make sure that the word count is set properly:
   work.save

--- a/features/works/work_share.feature
+++ b/features/works/work_share.feature
@@ -62,7 +62,7 @@ Feature: Share Works
     Then I should see "Share"
     When I follow "Share"
     Then I should see "Copy and paste the following code to link back to this work"
-      And I should see "><strong>Whatever</strong></a> (9 words) b"
+      And I should see "><strong>Whatever</strong></a> (10 words) b"
 
   @javascript
   Scenario: Share URL should not be used for post-login redirect

--- a/spec/controllers/chapters_controller_spec.rb
+++ b/spec/controllers/chapters_controller_spec.rb
@@ -168,10 +168,10 @@ describe ChaptersController do
 
     it "assigns @comments to only reviewed comments" do
       moderated_work = create(:work, moderated_commenting_enabled: true)
-      comment = create(:comment, commentable_type: "Chapter", commentable_id: moderated_work.chapters.first.id)
+      comment = create(:comment, commentable: moderated_work.chapters.first)
       comment.unreviewed = false
       comment.save
-      create(:comment, unreviewed: true, commentable_type: "Chapter", commentable_id: moderated_work.chapters.first.id)
+      create(:comment, unreviewed: true, commentable: moderated_work.chapters.first)
       get :show, params: { work_id: moderated_work.id, id: moderated_work.chapters.first.id }
       expect(assigns[:comments]).to eq [comment]
     end
@@ -196,7 +196,7 @@ describe ChaptersController do
     end
 
     it "assigns @kudos to non-anonymous kudos" do
-      kudo = create(:kudo, commentable_id: work.id, user: create(:user))
+      kudo = create(:kudo, commentable: work, user: create(:user))
       create(:kudo, commentable: work)
       get :show, params: { work_id: work.id, id: work.chapters.first.id }
       expect(assigns[:kudos]).to eq [kudo]
@@ -205,8 +205,8 @@ describe ChaptersController do
     it "assigns instance variables correctly" do
       second_chapter = create(:chapter, work: work, position: 2, posted: true)
       third_chapter = create(:chapter, work: work, position: 3, posted: true)
-      comment = create(:comment, commentable_type: "Chapter", commentable_id: second_chapter.id)
-      kudo = create(:kudo, commentable_id: work.id, user: create(:user))
+      comment = create(:comment, commentable: second_chapter)
+      kudo = create(:kudo, commentable: work, user: create(:user))
       tag = create(:fandom)
       expect_any_instance_of(Work).to receive(:tag_groups).and_return("Fandom" => [tag])
       expect_any_instance_of(ChaptersController).to receive(:get_page_title).with(tag.name, user.pseuds.first.name, "My title is long enough - Chapter 2").and_return("page title")

--- a/spec/helpers/inbox_helper_spec.rb
+++ b/spec/helpers/inbox_helper_spec.rb
@@ -12,7 +12,7 @@ describe InboxHelper do
 
     context "for Tags" do
       it "should return a link to the Comment on the Tag" do
-        @commentable = FactoryBot.create(:tag_comment)
+        @commentable = FactoryBot.create(:comment, :on_tag)
         string = commentable_description_link(@commentable)
         expect(string.gsub("%20", " ")).to eq "<a href=\"/tags/#{@commentable.ultimate_parent.name}/comments/#{@commentable.id}\">#{@commentable.ultimate_parent.name}</a>"
       end
@@ -20,7 +20,7 @@ describe InboxHelper do
 
     context "for AdminPosts" do
       it "should return a link to the Comment on the Adminpost" do
-        @commentable = FactoryBot.create(:adminpost_comment)
+        @commentable = FactoryBot.create(:comment, :on_admin_post)
         expect(commentable_description_link(@commentable)).to eq "<a href=\"/admin_posts/#{@commentable.ultimate_parent.id}/comments/#{@commentable.id}\">#{@commentable.ultimate_parent.title}</a>"
       end
     end

--- a/spec/requests/comments_spec.rb
+++ b/spec/requests/comments_spec.rb
@@ -14,7 +14,7 @@ shared_examples_for "on unrestricted works", :pending do
       @work2 = create(:work, fandom_string: "Merlin (TV)", title: "My title is long enough", restricted: false)
       @work2.reindex_document
       @comment2 = create(:comment)
-      @work2.first_chapter.comments << @comment2
+      @work2.last_posted_chapter.comments << @comment2
     end
 
     #has been added
@@ -24,7 +24,7 @@ shared_examples_for "on unrestricted works", :pending do
     end
 
     it "should be creatable on a work's chapter" do
-      visit "/works/#{@work2.id}/chapters/#{@work2.chapters.last.id}/comments/new"
+      visit "/works/#{@work2.id}/chapters/#{@work2.last_posted_chapter.id}/comments/new"
       is_expected.to have_content("#{@work2.title}")
     end
 
@@ -34,7 +34,7 @@ shared_examples_for "on unrestricted works", :pending do
     end
 
     it "should be readable on a work's chapter" do
-      visit "/works/#{@work2.id}/chapters/#{@work2.chapters.last.id}/comments"
+      visit "/works/#{@work2.id}/chapters/#{@work2.last_posted_chapter.id}/comments"
       is_expected.to have_content("#{@work2.title}")
     end
 
@@ -44,12 +44,12 @@ shared_examples_for "on unrestricted works", :pending do
     end
 
     it "should be directly readable on a chapter" do
-      visit "/chapters/#{@work2.chapters.last.id}/comments/#{@comment2.id}"
+      visit "/chapters/#{@work2.last_posted_chapter.id}/comments/#{@comment2.id}"
       is_expected.to have_content("#{@work2.title}")
     end
 
     it "should be directly readable on a work's chapter" do
-      visit "/works/#{@work2.id}/chapters/#{@work2.chapters.last.id}/comments/#{@comment2.id}"
+      visit "/works/#{@work2.id}/chapters/#{@work2.last_posted_chapter.id}/comments/#{@comment2.id}"
       is_expected.to have_content("#{@work2.title}")
     end
 end
@@ -60,8 +60,8 @@ describe "Comments" do
     before do
       @work1 = create(:work, fandom_string: "Merlin (TV)", title: "My title is long enough", restricted: true)
       @work1.reindex_document
-      @comment = create(:comment, commentable_id: @work1.id)
-      @comment2 = create(:comment, commentable_id: @work1.chapters.last.id, commentable_type: "Chapter")
+      @comment = create(:comment, commentable: @work1.last_posted_chapter)
+      @comment2 = create(:comment, commentable: @work1.last_posted_chapter)
     end
 
     it "should not be creatable by guests on a work" do
@@ -69,7 +69,7 @@ describe "Comments" do
       is_expected.to have_content("Commenting on this work is only available to registered users of the Archive.")
     end
     it "should not be creatable by guests on a work's chapter" do
-      visit "/works/#{@work1.id}/chapters/#{@work1.chapters.last.id}/comments/new"
+      visit "/works/#{@work1.id}/chapters/#{@work1.last_posted_chapter.id}/comments/new"
       is_expected.to have_content("Commenting on this work is only available to registered users of the Archive.")
     end
     it "should not be readable by guests on a work" do
@@ -77,7 +77,7 @@ describe "Comments" do
       is_expected.to have_content("Commenting on this work is only available to registered users of the Archive.")
     end
     it "should not be readable by guests on a work's chapter" do
-      visit "/works/#{@work1.id}/chapters/#{@work1.chapters.last.id}/comments"
+      visit "/works/#{@work1.id}/chapters/#{@work1.last_posted_chapter.id}/comments"
       is_expected.to have_content("Commenting on this work is only available to registered users of the Archive.")
     end
     it "should not be directly readable by guests on a work" do
@@ -85,7 +85,7 @@ describe "Comments" do
       is_expected.to have_content("Commenting on this work is only available to registered users of the Archive.")
     end
     it "should not be directly readable by guests on a work's chapter" do
-      visit "/works/#{@work1.id}/chapters/#{@work1.chapters.last.id}/comments/#{@comment2.id}"
+      visit "/works/#{@work1.id}/chapters/#{@work1.last_posted_chapter.id}/comments/#{@comment2.id}"
       is_expected.to have_content("Commenting on this work is only available to registered users of the Archive.")
     end
   end
@@ -127,7 +127,7 @@ describe "Comments" do
     end
 
     it "should not be creatable by guests on a work's chapter" do
-      visit "/works/#{@work.id}/chapters/#{@work.chapters.last.id}/comments/new"
+      visit "/works/#{@work.id}/chapters/#{@work.last_posted_chapter.id}/comments/new"
       is_expected.to have_content("Sorry, this work doesn't allow non-Archive users to comment.")
       is_expected.not_to have_button "Reply"
       is_expected.not_to have_button "Comment"
@@ -139,7 +139,7 @@ describe "Comments" do
     end
 
     it "should not be able to be replied to by guests on a work's chapter" do
-      visit "/works/#{@work.id}/chapters/#{@work.chapters.last.id}/comments/#{@comment.id}"
+      visit "/works/#{@work.id}/chapters/#{@work.last_posted_chapter.id}/comments/#{@comment.id}"
       is_expected.not_to have_button "Reply"
     end
   end


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5999

## Purpose

Refactor comment factories so that they don't include all three of `pseud`, `email`, and `name`, and so that they default to having their commentable set to a chapter instead of a work.

Also modifies the structure of comment factories to use traits, so that it's easier to generate comments with different sets of properties. This reduces the amount of repetition on the factory definitions.

## Testing Instructions

This is tests-only, so just check whether the automated tests pass.