### PR TITLE
AO3-5884 Fix deleting roles when admins can't update roles

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -30,6 +30,12 @@ Layout/MultilineMethodCallIndentation:
 Layout/TrailingWhitespace:
   Enabled: false
 
+Lint/AmbiguousBlockAssociation:
+  Exclude:
+    # Exception for specs where we use change matchers:
+    # https://github.com/rubocop-hq/rubocop/issues/4222
+    - 'spec/**/*.rb'
+
 Lint/AmbiguousRegexpLiteral:
   Enabled: false
 

--- a/app/controllers/admin/admin_users_controller.rb
+++ b/app/controllers/admin/admin_users_controller.rb
@@ -56,12 +56,16 @@ class Admin::AdminUsersController < Admin::BaseController
 
   # POST admin/users/update
   def update
-    @user = User.find_by(login: params[:id])
-    authorize @user
-    if @user.admin_update(permitted_attributes(@user))
+    @user = authorize User.find_by(login: params[:id])
+
+    attributes = permitted_attributes(@user)
+    @user.email = attributes[:email] if attributes[:email].present?
+    @user.roles = Role.where(id: attributes[:roles]) if attributes[:roles].present?
+
+    if @user.save
       flash[:notice] = ts("User was successfully updated.")
     else
-      flash[:error] = ts("There was an error updating user %{name}", name: params[:id])
+      flash[:error] = ts("The user %{name} could not be updated: %{errors}", name: params[:id], errors: @user.errors.full_messages.join(" "))
     end
     redirect_to request.referer || root_path
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -357,32 +357,6 @@ class User < ApplicationRecord
     User.fetch_orphan_account if ArchiveConfig.ORPHANING_ALLOWED
   end
 
-  # Allow admins to set roles and change email
-  def admin_update(attributes)
-    if User.current_user.is_a?(Admin)
-      success = true
-      success = set_roles(attributes[:roles])
-      if success && attributes[:email]
-        self.email = attributes[:email]
-        success = self.save(validate: false)
-      end
-      success
-    end
-  end
-
-  private
-
-  # Set the roles for this user
-  def set_roles(role_list)
-    if role_list
-      self.roles = Role.where(id: role_list)
-    else
-      self.roles = []
-    end
-  end
-
-  public
-
   # Is this user an authorized translation admin?
   def translation_admin
     self.is_translation_admin?

--- a/factories/users.rb
+++ b/factories/users.rb
@@ -13,7 +13,7 @@ FactoryBot.define do
   end
 
   factory :role do
-    name { Faker::Book.genre }
+    name { Faker::Company.profession }
   end
 
   factory :user do

--- a/features/admins/users/admin_manage_users.feature
+++ b/features/admins/users/admin_manage_users.feature
@@ -16,9 +16,14 @@ Feature: Admin Actions to manage users
     Then I should see "dizmo" within "#admin_users_table"
 
     # change user email
+    When I fill in "user_email" with "not even an email"
+      And I press "Update"
+    Then I should see "The user dizmo could not be updated: Email is invalid"
+
     When I fill in "user_email" with "dizmo@fake.com"
       And I press "Update"
     Then the "user_email" field should contain "dizmo@fake.com"
+      And I should see "User was successfully updated."
 
     # Adding and removing roles
     When I check "user_roles_1"

--- a/spec/controllers/admin/admin_users_controller_spec.rb
+++ b/spec/controllers/admin/admin_users_controller_spec.rb
@@ -138,7 +138,7 @@ describe Admin::AdminUsersController do
             end.to change { user.reload.roles.pluck(:name) }
               .from([old_role.name])
               .to([role.name])
-              .and not_change { user.reload.email }
+              .and avoid_changing { user.reload.email }
 
             it_redirects_to_with_notice(root_path, "User was successfully updated.")
           end
@@ -162,7 +162,7 @@ describe Admin::AdminUsersController do
             end.to change { user.reload.email }
               .from("user@example.com")
               .to("updated@example.com")
-              .and not_change { user.reload.roles.pluck(:name) }
+              .and avoid_changing { user.reload.roles.pluck(:name) }
 
             it_redirects_to_with_notice(root_path, "User was successfully updated.")
           end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -143,7 +143,7 @@ RSpec.configure do |config|
   config.file_fixture_path = "spec/support/fixtures"
 end
 
-RSpec::Matchers.define_negated_matcher :not_change, :change
+RSpec::Matchers.define_negated_matcher :avoid_changing, :change
 
 def clean_the_database
   # Now clear memcached

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -143,6 +143,8 @@ RSpec.configure do |config|
   config.file_fixture_path = "spec/support/fixtures"
 end
 
+RSpec::Matchers.define_negated_matcher :not_change, :change
+
 def clean_the_database
   # Now clear memcached
   Rails.cache.clear


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5884

## Purpose

Previously, if an admin does not have permissions to update roles, and we don't include "roles" in the permitted attributes, the user's roles will be set to an empty array. Now we skip setting roles entirely in that case.

Also stop skipping validations when updating users, and show validation errors to admins, so admins can't accidentally break users by saving blank emails, etc.

## Testing Instructions

See issue. Specifically:

- PAC admins clicking "Update" should not clear all roles of a user.
- PAC/Support admins should be prevented from entering invalid emails for a user (emails already in use, or blank strings).