### PR TITLE
AO3-5987 Defer generating share options for bookmarks

### DIFF
--- a/app/controllers/bookmarks_controller.rb
+++ b/app/controllers/bookmarks_controller.rb
@@ -276,7 +276,7 @@ class BookmarksController < ApplicationController
     else
       # Avoid getting an unstyled page if JavaScript is disabled
       flash[:error] = ts("Sorry, you need to have JavaScript enabled for this.")
-      redirect_back_or_default(root_path)
+      redirect_back(fallback_location: root_path)
     end
   end
 

--- a/app/controllers/bookmarks_controller.rb
+++ b/app/controllers/bookmarks_controller.rb
@@ -1,12 +1,12 @@
 class BookmarksController < ApplicationController
   before_action :load_collection
   before_action :load_owner, only: [ :index ]
-  before_action :load_bookmarkable, only: [ :index, :new, :create, :fetch_recent, :hide_recent, :share ]
+  before_action :load_bookmarkable, only: [ :index, :new, :create, :fetch_recent, :hide_recent ]
   before_action :users_only, only: [:new, :create, :edit, :update]
   before_action :check_user_status, only: [:new, :create, :edit, :update]
   before_action :load_bookmark, only: [ :show, :edit, :update, :destroy, :fetch_recent, :hide_recent, :confirm_delete, :share ]
   before_action :check_visibility, only: [ :show, :share ]
-  before_action :check_ownership, only: [ :edit, :update, :destroy, :confirm_delete ]
+  before_action :check_ownership, only: [ :edit, :update, :destroy, :confirm_delete, :share ]
 
   before_action :check_pseud_ownership, only: [:create, :update]
 
@@ -268,7 +268,7 @@ class BookmarksController < ApplicationController
   # GET /bookmarks/1/share
   def share
     if request.xhr?
-      if @bookmark.bookmarkable.unrevealed?
+      if @bookmark.bookmarkable.is_a?(Work) && @bookmark.bookmarkable.unrevealed?
         render template: "errors/404", status: :not_found
       else
         render layout: false
@@ -276,12 +276,7 @@ class BookmarksController < ApplicationController
     else
       # Avoid getting an unstyled page if JavaScript is disabled
       flash[:error] = ts("Sorry, you need to have JavaScript enabled for this.")
-      if request.env["HTTP_REFERER"]
-        redirect_to(request.env["HTTP_REFERER"] || root_path)
-      else
-        # else branch needed to deal with bots, which don't have a referer
-        redirect_to root_path
-      end
+      redirect_back_or_default(root_path)
     end
   end
 

--- a/app/controllers/bookmarks_controller.rb
+++ b/app/controllers/bookmarks_controller.rb
@@ -1,12 +1,12 @@
 class BookmarksController < ApplicationController
   before_action :load_collection
-  before_action :load_owner, only: [ :index ]
-  before_action :load_bookmarkable, only: [ :index, :new, :create, :fetch_recent, :hide_recent ]
+  before_action :load_owner, only: [:index]
+  before_action :load_bookmarkable, only: [:index, :new, :create, :fetch_recent, :hide_recent]
   before_action :users_only, only: [:new, :create, :edit, :update]
   before_action :check_user_status, only: [:new, :create, :edit, :update]
-  before_action :load_bookmark, only: [ :show, :edit, :update, :destroy, :fetch_recent, :hide_recent, :confirm_delete, :share ]
-  before_action :check_visibility, only: [ :show, :share ]
-  before_action :check_ownership, only: [ :edit, :update, :destroy, :confirm_delete, :share ]
+  before_action :load_bookmark, only: [:show, :edit, :update, :destroy, :fetch_recent, :hide_recent, :confirm_delete, :share]
+  before_action :check_visibility, only: [:show, :share]
+  before_action :check_ownership, only: [:edit, :update, :destroy, :confirm_delete, :share]
 
   before_action :check_pseud_ownership, only: [:create, :update]
 

--- a/app/views/bookmarks/_bookmark_owner_navigation.html.erb
+++ b/app/views/bookmarks/_bookmark_owner_navigation.html.erb
@@ -6,8 +6,7 @@
   <li id="add_collection_link"><%= collection_link(bookmark) %></li>
   <% if bookmark.bookmarkable.is_a?(Work) && !bookmark.bookmarkable.unrevealed? %>
     <li class="share hidden">
-      <%= link_to_modal ts("Share"), :for => "#share_#{bookmark.id}", :title => ts("Share Bookmark") %>
-      <%= render 'share/share', :shareable => bookmark, :bookmark => bookmark %>
+      <%= link_to_modal ts("Share"), :for => share_bookmark_path(bookmark), :title => ts("Share Bookmark") %>
     </li>
   <% end %>
 </ul>

--- a/app/views/bookmarks/_bookmark_owner_navigation.html.erb
+++ b/app/views/bookmarks/_bookmark_owner_navigation.html.erb
@@ -1,12 +1,12 @@
 <% # expects "bookmark" %>
 <% bookmark_form_id = (bookmark.bookmarkable.blank? ? "#{bookmark.id}" : "#{bookmark.bookmarkable.id}") %>
 <ul class="actions" role="menu">
-  <li><%= link_to ts("Edit"), edit_bookmark_path(bookmark), :id => "bookmark_form_trigger_for_#{bookmark_form_id}", :remote => true %></li>
+  <li><%= link_to ts("Edit"), edit_bookmark_path(bookmark), id: "bookmark_form_trigger_for_#{bookmark_form_id}", remote: true %></li>
   <li><%= link_to ts("Delete"), confirm_delete_bookmark_path(bookmark), data: {confirm: ts('Are you sure you want to delete this bookmark?')} %></li>
   <li id="add_collection_link"><%= collection_link(bookmark) %></li>
   <% if bookmark.bookmarkable.is_a?(Work) && !bookmark.bookmarkable.unrevealed? %>
     <li class="share hidden">
-      <%= link_to_modal ts("Share"), :for => share_bookmark_path(bookmark), :title => ts("Share Bookmark") %>
+      <%= link_to_modal ts("Share"), for: share_bookmark_path(bookmark), title: ts("Share Bookmark") %>
     </li>
   <% end %>
 </ul>

--- a/app/views/bookmarks/index.html.erb
+++ b/app/views/bookmarks/index.html.erb
@@ -75,8 +75,3 @@
   <%= will_paginate @bookmarkable_items %>
 <% end %>
 <!-- /subnav-->
-
-<% # FRONT END NOTE: Twitter widget JavaScript included here for share/_share to ensure it is only loaded once per page %>
-<% content_for :footer_js do %>
-  <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>
-<% end %>

--- a/app/views/bookmarks/share.html.erb
+++ b/app/views/bookmarks/share.html.erb
@@ -1,0 +1,4 @@
+<%= render 'share/share', :shareable => @bookmark, :bookmark => @bookmark %>
+
+<% # FRONT END NOTE: Twitter widget JavaScript included here for share/_share to ensure it is only loaded once per page %>
+<script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/app/views/bookmarks/share.html.erb
+++ b/app/views/bookmarks/share.html.erb
@@ -1,1 +1,1 @@
-<%= render 'share/share', :shareable => @bookmark, :bookmark => @bookmark %>
+<%= render 'share/share', shareable: @bookmark %>

--- a/app/views/bookmarks/share.html.erb
+++ b/app/views/bookmarks/share.html.erb
@@ -1,4 +1,4 @@
 <%= render 'share/share', :shareable => @bookmark, :bookmark => @bookmark %>
 
-<% # FRONT END NOTE: Twitter widget JavaScript included here for share/_share to ensure it is only loaded once per page %>
+<% # FRONTEND NOTE: Twitter widget JavaScript included here to ensure that it is only loaded when users share a bookmark, not on every page load. This improves user privacy. %>
 <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/app/views/bookmarks/share.html.erb
+++ b/app/views/bookmarks/share.html.erb
@@ -1,4 +1,1 @@
 <%= render 'share/share', :shareable => @bookmark, :bookmark => @bookmark %>
-
-<% # FRONTEND NOTE: Twitter widget JavaScript included here to ensure that it is only loaded when users share a bookmark, not on every page load. This improves user privacy. %>
-<script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/app/views/bookmarks/show.html.erb
+++ b/app/views/bookmarks/show.html.erb
@@ -21,8 +21,3 @@
   <%= render 'bookmark_blurb', :bookmark => @bookmark %>
 </ul>
 <!--/content-->
-
-<% # FRONT END NOTE: Twitter widget JavaScript included here for share/_share to ensure it is only loaded once per page %>
-<% content_for :footer_js do %>
-  <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>
-<% end %>

--- a/app/views/share/_share.html.erb
+++ b/app/views/share/_share.html.erb
@@ -1,4 +1,4 @@
-<div id="share<% if shareable.is_a?(Bookmark) %>_<%= bookmark.id %><% end %>">
+<div id="share">
 
   <p class="note"><%= ts("Copy and paste the following code to link back to this work (") %><kbd><%= ts("CTRL A")%></kbd><%= ts("/") %><kbd><%= ts("CMD A")%></kbd><%= ts(" will select all), or use the Tweet or Tumblr links to share the work on your Twitter or Tumblr account.") %></p>
   

--- a/app/views/share/_share.html.erb
+++ b/app/views/share/_share.html.erb
@@ -27,4 +27,18 @@
   
 </div>
 
-<% # FRONT END NOTE: Twitter widget JavaScript is included separately in bookmarks/index, bookmarks/show, and works/_work_header_navigation to ensure it is only loaded once per page %>
+<%
+  # FRONT END NOTE: Twitter widgets library is only loaded once per page.
+  # On first load, widgets.js will load after twitter elements on the page and render them.
+  # On subsequent loads, we call `load()` explicitly to trigger rendering widgets.
+%>
+<script>
+  // If we've already loaded the twitter widgets bundle
+  if(window.twttr){
+    // Trigger rendering of widget elements in the div `share` defined above
+    window.twttr.widgets.load(document.getElementById("share"));
+  } else {
+    // Otherwise, load the widgets bundle
+    window.twttr=(function(d,s,id){ var js,fjs=d.getElementsByTagName(s)[0],t=window.twttr||{};if(d.getElementById(id))return t;js=d.createElement(s);js.id=id;js.src="https://platform.twitter.com/widgets.js";fjs.parentNode.insertBefore(js,fjs);t._e=[];t.ready=function(f){t._e.push(f);};return t;}(document,"script","twitter-wjs"));
+  }
+</script>

--- a/app/views/share/_share.html.erb
+++ b/app/views/share/_share.html.erb
@@ -11,47 +11,33 @@
     
     <% # Twitter share %>
     <li class="twitter">
-      <a href="http://twitter.com/share" class="twitter-share-button" data-size="large" data-via="ao3org" data-text="<%= shareable.is_a?(Bookmark)? get_tweet_text_for_bookmark(shareable) : get_tweet_text(@work) %>" data-url="<%= shareable.is_a?(Bookmark)? bookmark_url(shareable) : work_url(@work) %>">
-        <%= ts('Tweet') %>
+      <!-- Sharingbutton Twitter. See https://sharingbuttons.io/ -->
+      <a class="resp-sharing-button__link" href="https://twitter.com/intent/tweet/?text=<%=u shareable.is_a?(Bookmark)? get_tweet_text_for_bookmark(shareable) : get_tweet_text(@work) %>&url=<%=u shareable.is_a?(Bookmark)? bookmark_url(shareable) : work_url(@work) %>&via=ao3org&size=large" target="_blank" rel="noopener" aria-label="Twitter">
+        <div class="resp-sharing-button resp-sharing-button--twitter resp-sharing-button--medium"><div aria-hidden="true" class="resp-sharing-button__icon resp-sharing-button__icon--solid">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+              <path d="M23.44 4.83c-.8.37-1.5.38-2.22.02.93-.56.98-.96 1.32-2.02-.88.52-1.86.9-2.9 1.1-.82-.88-2-1.43-3.3-1.43-2.5 0-4.55 2.04-4.55 4.54 0 .36.03.7.1 1.04-3.77-.2-7.12-2-9.36-4.75-.4.67-.6 1.45-.6 2.3 0 1.56.8 2.95 2 3.77-.74-.03-1.44-.23-2.05-.57v.06c0 2.2 1.56 4.03 3.64 4.44-.67.2-1.37.2-2.06.08.58 1.8 2.26 3.12 4.25 3.16C5.78 18.1 3.37 18.74 1 18.46c2 1.3 4.4 2.04 6.97 2.04 8.35 0 12.92-6.92 12.92-12.93 0-.2 0-.4-.02-.6.9-.63 1.96-1.22 2.56-2.14z"/>
+            </svg>
+          </div>
+          <%= ts('Twitter') %>
+        </div>
       </a>
     </li>
       
     <% # Tumblr share %>
     <li>
-      <a href="http://tumblr.com/widgets/share/tool?canonicalUrl=<%=u shareable.is_a?(Bookmark) ? work_url(shareable.bookmarkable) : work_url(@work) %>&title=<%=u shareable.is_a?(Bookmark) ? get_tumblr_embed_link_title(shareable.bookmarkable) : get_tumblr_embed_link_title(@work) %>&caption=<%=u shareable.is_a?(Bookmark) ? get_tumblr_bookmark_embed_link(shareable) : get_embed_link_meta(@work) %>" title="<%= ts('Share on Tumblr') %>" style="display:inline-block; text-indent:-9999px; overflow:hidden; width:81px; height:20px; background:url('//platform.tumblr.com/v1/share_1.png') top left no-repeat transparent; border-bottom: none;" target="_blank">
-        <%= ts('Share on Tumblr') %>
+      <!-- Sharingbutton Tumblr. See https://sharingbuttons.io/ -->
+      <a class="resp-sharing-button__link" href="http://tumblr.com/widgets/share/tool?canonicalUrl=<%=u shareable.is_a?(Bookmark) ? work_url(shareable.bookmarkable) : work_url(@work) %>&title=<%=u shareable.is_a?(Bookmark) ? get_tumblr_embed_link_title(shareable.bookmarkable) : get_tumblr_embed_link_title(@work) %>&caption=<%=u shareable.is_a?(Bookmark) ? get_tumblr_bookmark_embed_link(shareable) : get_embed_link_meta(@work) %>" target="_blank" rel="noopener" aria-label="Tumblr">
+        <div class="resp-sharing-button resp-sharing-button--tumblr resp-sharing-button--medium">
+          <div aria-hidden="true" class="resp-sharing-button__icon resp-sharing-button__icon--solid">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+              <path d="M13.5.5v5h5v4h-5V15c0 5 3.5 4.4 6 2.8v4.4c-6.7 3.2-12 0-12-4.2V9.5h-3V6.7c1-.3 2.2-.7 3-1.3.5-.5 1-1.2 1.4-2 .3-.7.6-1.7.7-3h3.8z" />
+            </svg>
+          </div>
+          <%= ts('Tumblr') %>
+        </div>
       </a>
     </li>
       
   </ul>
   
 </div>
-
-<script>
-  // Twitter widgets library bundle is only downloaded once per page.
-  if (window.twttr) {
-    // If we've already loaded the widgets bundle,
-    // trigger rendering of widget elements in the div `share` defined above.
-    //
-    // See: https://developer.twitter.com/en/docs/twitter-for-websites/javascript-api/guides/scripting-loading-and-initialization
-    window.twttr.widgets.load(document.getElementById("share"));
-  } else {
-    // Otherwise, load the widgets bundle asynchronously.
-    // Once the bundle is loaded, it will render all widgets on the page.
-    //
-    // See: https://developer.twitter.com/en/docs/twitter-for-websites/javascript-api/guides/set-up-twitter-for-websites
-    window.twttr = (
-      function(d,s,id) {
-        var js, fjs = d.getElementsByTagName(s)[0], t=window.twttr || {};
-        if (d.getElementById(id)) return t;
-        js = d.createElement(s);
-        js.id = id;
-        js.src = "https://platform.twitter.com/widgets.js";
-        fjs.parentNode.insertBefore(js, fjs);
-        t._e = [];
-        t.ready = function(f) { t._e.push(f); };
-        return t;
-      }(document, "script", "twitter-wjs")
-    );
-  }
-</script>

--- a/app/views/share/_share.html.erb
+++ b/app/views/share/_share.html.erb
@@ -27,18 +27,31 @@
   
 </div>
 
-<%
-  # FRONT END NOTE: Twitter widgets library is only loaded once per page.
-  # On first load, widgets.js will load after twitter elements on the page and render them.
-  # On subsequent loads, we call `load()` explicitly to trigger rendering widgets.
-%>
 <script>
-  // If we've already loaded the twitter widgets bundle
-  if(window.twttr){
-    // Trigger rendering of widget elements in the div `share` defined above
+  // Twitter widgets library bundle is only downloaded once per page.
+  if (window.twttr) {
+    // If we've already loaded the widgets bundle,
+    // trigger rendering of widget elements in the div `share` defined above.
+    //
+    // See: https://developer.twitter.com/en/docs/twitter-for-websites/javascript-api/guides/scripting-loading-and-initialization
     window.twttr.widgets.load(document.getElementById("share"));
   } else {
-    // Otherwise, load the widgets bundle
-    window.twttr=(function(d,s,id){ var js,fjs=d.getElementsByTagName(s)[0],t=window.twttr||{};if(d.getElementById(id))return t;js=d.createElement(s);js.id=id;js.src="https://platform.twitter.com/widgets.js";fjs.parentNode.insertBefore(js,fjs);t._e=[];t.ready=function(f){t._e.push(f);};return t;}(document,"script","twitter-wjs"));
+    // Otherwise, load the widgets bundle asynchronously.
+    // Once the bundle is loaded, it will render all widgets on the page.
+    //
+    // See: https://developer.twitter.com/en/docs/twitter-for-websites/javascript-api/guides/set-up-twitter-for-websites
+    window.twttr = (
+      function(d,s,id) {
+        var js, fjs = d.getElementsByTagName(s)[0], t=window.twttr || {};
+        if (d.getElementById(id)) return t;
+        js = d.createElement(s);
+        js.id = id;
+        js.src = "https://platform.twitter.com/widgets.js";
+        fjs.parentNode.insertBefore(js, fjs);
+        t._e = [];
+        t.ready = function(f) { t._e.push(f); };
+        return t;
+      }(document, "script", "twitter-wjs")
+    );
   }
 </script>

--- a/app/views/share/_share.html.erb
+++ b/app/views/share/_share.html.erb
@@ -4,21 +4,21 @@
   
   <% # HTML share code %>
   <p>
-    <textarea cols="50" rows="4" id="<%= shareable.is_a?(Bookmark) ? "embed_code_#{bookmark.id}" : "embed_code" %>"><%= shareable.is_a?(Bookmark) ? get_bookmark_embed_link(bookmark) : get_embed_link(@work) %></textarea>
+    <textarea cols="50" rows="4" id="<%= shareable.is_a?(Bookmark) ? "embed_code_#{shareable.id}" : "embed_code" %>"><%= shareable.is_a?(Bookmark) ? get_bookmark_embed_link(shareable) : get_embed_link(@work) %></textarea>
   </p>
   
   <ul>
     
     <% # Twitter share %>
     <li class="twitter">
-      <a href="http://twitter.com/share" class="twitter-share-button" data-size="large" data-via="ao3org" data-text="<%= shareable.is_a?(Bookmark)? get_tweet_text_for_bookmark(bookmark) : get_tweet_text(@work) %>" data-url="<%= shareable.is_a?(Bookmark)? bookmark_url(bookmark) : work_url(@work) %>">
+      <a href="http://twitter.com/share" class="twitter-share-button" data-size="large" data-via="ao3org" data-text="<%= shareable.is_a?(Bookmark)? get_tweet_text_for_bookmark(shareable) : get_tweet_text(@work) %>" data-url="<%= shareable.is_a?(Bookmark)? bookmark_url(shareable) : work_url(@work) %>">
         <%= ts('Tweet') %>
       </a>
     </li>
       
     <% # Tumblr share %>
     <li>
-      <a href="http://tumblr.com/widgets/share/tool?canonicalUrl=<%=u shareable.is_a?(Bookmark) ? work_url(bookmark.bookmarkable) : work_url(@work) %>&title=<%=u shareable.is_a?(Bookmark) ? get_tumblr_embed_link_title(bookmark.bookmarkable) : get_tumblr_embed_link_title(@work) %>&caption=<%=u shareable.is_a?(Bookmark) ? get_tumblr_bookmark_embed_link(bookmark) : get_embed_link_meta(@work) %>" title="<%= ts('Share on Tumblr') %>" style="display:inline-block; text-indent:-9999px; overflow:hidden; width:81px; height:20px; background:url('//platform.tumblr.com/v1/share_1.png') top left no-repeat transparent; border-bottom: none;" target="_blank">
+      <a href="http://tumblr.com/widgets/share/tool?canonicalUrl=<%=u shareable.is_a?(Bookmark) ? work_url(shareable.bookmarkable) : work_url(@work) %>&title=<%=u shareable.is_a?(Bookmark) ? get_tumblr_embed_link_title(shareable.bookmarkable) : get_tumblr_embed_link_title(@work) %>&caption=<%=u shareable.is_a?(Bookmark) ? get_tumblr_bookmark_embed_link(shareable) : get_embed_link_meta(@work) %>" title="<%= ts('Share on Tumblr') %>" style="display:inline-block; text-indent:-9999px; overflow:hidden; width:81px; height:20px; background:url('//platform.tumblr.com/v1/share_1.png') top left no-repeat transparent; border-bottom: none;" target="_blank">
         <%= ts('Share on Tumblr') %>
       </a>
     </li>

--- a/app/views/share/_share.html.erb
+++ b/app/views/share/_share.html.erb
@@ -24,7 +24,7 @@
     </li>
       
     <% # Tumblr share %>
-    <li>
+    <li class="tumblr">
       <!-- Sharingbutton Tumblr. See https://sharingbuttons.io/ -->
       <a class="resp-sharing-button__link" href="http://tumblr.com/widgets/share/tool?canonicalUrl=<%=u shareable.is_a?(Bookmark) ? work_url(shareable.bookmarkable) : work_url(@work) %>&title=<%=u shareable.is_a?(Bookmark) ? get_tumblr_embed_link_title(shareable.bookmarkable) : get_tumblr_embed_link_title(@work) %>&caption=<%=u shareable.is_a?(Bookmark) ? get_tumblr_bookmark_embed_link(shareable) : get_embed_link_meta(@work) %>" target="_blank" rel="noopener" aria-label="Tumblr">
         <div class="resp-sharing-button resp-sharing-button--tumblr resp-sharing-button--medium">

--- a/app/views/works/share.html.erb
+++ b/app/views/works/share.html.erb
@@ -1,1 +1,1 @@
-<%= render 'share/share', :shareable => @work %>
+<%= render 'share/share', shareable: @work %>

--- a/app/views/works/share.html.erb
+++ b/app/views/works/share.html.erb
@@ -1,4 +1,1 @@
 <%= render 'share/share', :shareable => @work %>
-
-<% # FRONTEND NOTE: Twitter widget JavaScript included here to ensure that it is only loaded when users share a work, not on every page load. This improves user privacy. %>
-<script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -512,6 +512,7 @@ Otwarchive::Application.routes.draw do
     end
     member do
       get :confirm_delete
+      get :share
     end
     resources :collection_items
   end

--- a/features/bookmarks/bookmark_share.feature
+++ b/features/bookmarks/bookmark_share.feature
@@ -1,0 +1,49 @@
+@bookmarks
+Feature: Share Bookmarks
+  Testing the "Share" button on bookmarks, with Javascript emulation
+
+  @javascript
+  Scenario: Share a bookmark
+    Given I am logged in as "tess"
+      And I have a bookmark for "Damp Gravel"
+    When I view the bookmark for "Damp Gravel"
+    Then I should see "Damp Gravel"
+      And I should see "Share"
+    When I follow "Share"
+    Then I should see "Copy and paste the following code to link back to this work" within "#share"
+      And I should see "or use the Tweet or Tumblr links to share the work" within "#share"
+      And I should see '<strong>Damp Gravel</strong></a> (6 words)' within "#share"
+      And I should see 'by <a href="http://www.example.com/users/tess"><strong>tess</strong></a>' within "#share"
+      And I should see 'Fandom: <a href="http://www.example.com/tags/Stargate%20SG-1">Stargate SG-1</a>' within "#share"
+      And I should see "Rating: Not Rated" within "#share"
+      And I should see "Warnings: No Archive Warnings Apply" within "#share"
+      And the share modal should contain a Twitter share button
+      And I should see "Share on Tumblr" within "div#share ul li a[title]"
+      And I should not see "Series:" within "#share"
+      And I should not see "Relationships:" within "#share"
+      And I should not see "Characters:" within "#share"
+      And I should not see "Summary:" within "#share"
+
+  @javascript
+  Scenario: Share option is unavailable if bookmarkable is unrevealed.
+    Given there is a work "Hidden Figures" in an unrevealed collection "Backlist"
+      And I am logged in as the author of "Hidden Figures"
+    When I view the work "Hidden Figures"
+    Then I should see "Bookmark"
+    When I follow "Bookmark"
+      And I press "Create"
+      And all indexing jobs have been run
+    Then I should see "Bookmark was successfully created"
+    When I view the bookmark for "Hidden Figures"
+    Then I should see "Hidden Figures"
+      And I should see "Add To Collection"
+      And I should not see "Share"
+
+  @javascript
+  Scenario: Sharing a bookmark is not possible when logged out
+    Given I am logged in as "tess"
+      And I have a bookmark for "Damp Gravel"
+    When I am logged out
+      And I view the bookmark for "Damp Gravel"
+    Then I should see "Damp Gravel"
+      And I should not see "Share"

--- a/features/bookmarks/bookmark_share.feature
+++ b/features/bookmarks/bookmark_share.feature
@@ -17,8 +17,7 @@ Feature: Share Bookmarks
       And I should see 'Fandom: <a href="http://www.example.com/tags/Stargate%20SG-1">Stargate SG-1</a>' within "#share"
       And I should see "Rating: Not Rated" within "#share"
       And I should see "Warnings: No Archive Warnings Apply" within "#share"
-      And the share modal should contain a Twitter share button
-      And I should see "Share on Tumblr" within "div#share ul li a[title]"
+      And the share modal should contain social share buttons
       And I should not see "Series:" within "#share"
       And I should not see "Relationships:" within "#share"
       And I should not see "Characters:" within "#share"

--- a/features/bookmarks/bookmark_share.feature
+++ b/features/bookmarks/bookmark_share.feature
@@ -1,12 +1,12 @@
 @bookmarks
 Feature: Share Bookmarks
-  Testing the "Share" button on bookmarks, with Javascript emulation
+  Testing the "Share" button on bookmarks, with JavaScript emulation
 
   @javascript
   Scenario: Share a bookmark
     Given I am logged in as "tess"
       And I have a bookmark for "Damp Gravel"
-    When I view the bookmark for "Damp Gravel"
+    When I go to the first bookmark for the work "Damp Gravel"
     Then I should see "Damp Gravel"
       And I should see "Share"
     When I follow "Share"
@@ -34,7 +34,7 @@ Feature: Share Bookmarks
       And I press "Create"
       And all indexing jobs have been run
     Then I should see "Bookmark was successfully created"
-    When I view the bookmark for "Hidden Figures"
+    When I go to the first bookmark for the work "Hidden Figures"
     Then I should see "Hidden Figures"
       And I should see "Add To Collection"
       And I should not see "Share"
@@ -44,6 +44,6 @@ Feature: Share Bookmarks
     Given I am logged in as "tess"
       And I have a bookmark for "Damp Gravel"
     When I am logged out
-      And I view the bookmark for "Damp Gravel"
+      And I go to the first bookmark for the work "Damp Gravel"
     Then I should see "Damp Gravel"
       And I should not see "Share"

--- a/features/step_definitions/bookmark_steps.rb
+++ b/features/step_definitions/bookmark_steps.rb
@@ -418,3 +418,9 @@ Then /^the cache of the bookmark on "([^\"]*)" should not expire if I have not e
   bookmark.reload
   assert orig_cache_key == bookmark.cache_key, "Cache key #{orig_cache_key} does not match #{bookmark.cache_key}."
 end
+
+When /^I view the bookmark for "([^"]*)"$/ do |title|
+  work = Work.find_by(title: title)
+  bookmark = work.bookmarks.first
+  visit bookmark_path(bookmark)
+end

--- a/features/step_definitions/bookmark_steps.rb
+++ b/features/step_definitions/bookmark_steps.rb
@@ -418,9 +418,3 @@ Then /^the cache of the bookmark on "([^\"]*)" should not expire if I have not e
   bookmark.reload
   assert orig_cache_key == bookmark.cache_key, "Cache key #{orig_cache_key} does not match #{bookmark.cache_key}."
 end
-
-When /^I view the bookmark for "([^"]*)"$/ do |title|
-  work = Work.find_by(title: title)
-  bookmark = work.bookmarks.first
-  visit bookmark_path(bookmark)
-end

--- a/features/step_definitions/share_steps.rb
+++ b/features/step_definitions/share_steps.rb
@@ -1,6 +1,6 @@
 Then /^the share modal should contain a Twitter share button$/ do
-  with_scope('#share') do
-    iframe = find('li.twitter #twitter-widget-0')
+  with_scope("#share") do
+    iframe = find("li.twitter #twitter-widget-0")
     within_frame(iframe) do
       page.should have_content("Tweet")
     end

--- a/features/step_definitions/share_steps.rb
+++ b/features/step_definitions/share_steps.rb
@@ -1,8 +1,6 @@
-Then /^the share modal should contain a Twitter share button$/ do
+Then /^the share modal should contain social share buttons$/ do
   with_scope("#share") do
-    iframe = find("li.twitter #twitter-widget-0")
-    within_frame(iframe) do
-      page.should have_content("Tweet")
-    end
+    expect(page).to have_css("li.twitter", text: "Twitter")
+    expect(page).to have_css("li.tumblr", text: "Tumblr")
   end
 end

--- a/features/step_definitions/share_steps.rb
+++ b/features/step_definitions/share_steps.rb
@@ -1,0 +1,8 @@
+Then /^the share modal should contain a Twitter share button$/ do
+  with_scope('#share') do
+    iframe = find('li.twitter #twitter-widget-0')
+    within_frame(iframe) do
+      page.should have_content("Tweet")
+    end
+  end
+end

--- a/features/step_definitions/work_steps.rb
+++ b/features/step_definitions/work_steps.rb
@@ -693,12 +693,3 @@ end
 Then /^the Remove Me As Chapter Co-Creator option should not be on the ([\d]+)(?:st|nd|rd|th) chapter$/ do |chapter_number|
   step %{I should not see "Remove Me As Chapter Co-Creator" within "ul#sortable_chapter_list > li:nth-of-type(#{chapter_number})"}
 end
-
-Then /^the share modal should contain a Twitter share button$/ do
-  with_scope('#share') do
-    iframe = find('li.twitter #twitter-widget-0')
-    within_frame(iframe) do
-      page.should have_content("Tweet")
-    end
-  end
-end

--- a/features/support/paths.rb
+++ b/features/support/paths.rb
@@ -215,7 +215,7 @@ module NavigationHelpers
       step %{all indexing jobs have been run}
       collection_bookmarks_path(Collection.find_by(title: $1))
     when /^the first bookmark for the work "(.*?)"$/i
-      work = Work.find_by(title: $1)
+      work = Work.find_by(title: Regexp.last_match(1))
       bookmark_path(work.bookmarks.first)
     when /^the tag comments? page for "(.*)"$/i
       tag_comments_path(Tag.find_by_name($1))

--- a/features/support/paths.rb
+++ b/features/support/paths.rb
@@ -214,6 +214,9 @@ module NavigationHelpers
     when /^the bookmarks in collection "(.*)"$/i
       step %{all indexing jobs have been run}
       collection_bookmarks_path(Collection.find_by(title: $1))
+    when /^the first bookmark for the work "(.*?)"$/i
+      work = Work.find_by(title: $1)
+      bookmark_path(work.bookmarks.first)
     when /^the tag comments? page for "(.*)"$/i
       tag_comments_path(Tag.find_by_name($1))
     when /^the work comments? page for "(.*?)"$/i

--- a/features/works/work_share.feature
+++ b/features/works/work_share.feature
@@ -4,7 +4,8 @@ Feature: Share Works
 
   @javascript
   Scenario: Share a work
-    Given I have a work "Blabla"
+    Given I am logged in as "testuser1"
+      And I post the work "Blabla"
     When I view the work "Blabla"
     Then I should see "Share"
     When I follow "Share"
@@ -15,8 +16,7 @@ Feature: Share Works
       And I should see 'Fandom: <a href="http://www.example.com/tags/Stargate%20SG-1">Stargate SG-1</a>' within "#share"
       And I should see "Rating: Not Rated" within "#share"
       And I should see "Warnings: No Archive Warnings Apply" within "#share"
-      And the share modal should contain a Twitter share button
-      And I should see "Share on Tumblr" within "div#share ul li a[title]"
+      And the share modal should contain social share buttons
       And I should not see "Series:" within "#share"
       And I should not see "Relationships:" within "#share"
       And I should not see "Characters:" within "#share"
@@ -32,8 +32,7 @@ Feature: Share Works
       And I should see 'Fandom: <a href="http://www.example.com/tags/Stargate%20SG-1">Stargate SG-1</a>' within "#share"
       And I should see "Rating: Not Rated" within "#share"
       And I should see "Warnings: No Archive Warnings Apply" within "#share"
-      And the share modal should contain a Twitter share button
-      And I should see "Share on Tumblr" within "div#share ul li a[title]"
+      And the share modal should contain social share buttons
       And I should not see "Series:" within "#share"
       And I should not see "Relationships:" within "#share"
       And I should not see "Characters:" within "#share"

--- a/public/stylesheets/sandbox.css
+++ b/public/stylesheets/sandbox.css
@@ -30,8 +30,86 @@ and preserve the balance/symmetry of the page */
   margin-left: 2.75em;
 }
 
-/* AO3-5907 avoid size change for modal during twitter button loads */
-.twitter {
-  width: 76px;
-  height: 28px;
+/* While implementing AO3-5987 it was suggested we move to non-JS share buttons.
+ * These are statically styled with CSS instead.
+ *
+ * These styles are currently only used in app/views/share/_share.html.erb.
+ *
+ * Sourced from: https://sharingbuttons.io/
+ * See: https://github.com/otwcode/otwarchive/pull/3874#pullrequestreview-460459176
+ */
+
+a.resp-sharing-button__link,
+.resp-sharing-button__icon {
+  display: inline-block
+}
+
+a.resp-sharing-button__link {
+  text-decoration: none;
+  color: #fff;
+}
+
+.resp-sharing-button {
+  border-radius: 5px;
+  transition: 25ms ease-out;
+  padding: 0.5em 0.75em;
+  font-family: Helvetica Neue,Helvetica,Arial,sans-serif
+}
+
+.resp-sharing-button__icon svg {
+  width: 1em;
+  height: 1em;
+  margin-right: 0.4em;
+  vertical-align: top
+}
+
+/* Non solid icons get a stroke */
+.resp-sharing-button__icon {
+  stroke: #fff;
+  fill: none
+}
+
+/* Solid icons get a fill */
+.resp-sharing-button__icon--solid,
+.resp-sharing-button__icon--solidcircle {
+  fill: #fff;
+  stroke: none
+}
+
+.resp-sharing-button--twitter {
+  background-color: #55acee
+}
+
+.resp-sharing-button--twitter:hover {
+  background-color: #2795e9
+}
+
+.resp-sharing-button--tumblr {
+  background-color: #35465C
+}
+
+.resp-sharing-button--tumblr:hover {
+  background-color: #222d3c
+}
+
+.resp-sharing-button--twitter {
+  background-color: #55acee;
+  border-color: #55acee;
+}
+
+.resp-sharing-button--twitter:hover,
+.resp-sharing-button--twitter:active {
+  background-color: #2795e9;
+  border-color: #2795e9;
+}
+
+.resp-sharing-button--tumblr {
+  background-color: #35465C;
+  border-color: #35465C;
+}
+
+.resp-sharing-button--tumblr:hover,
+.resp-sharing-button--tumblr:active {
+  background-color: #222d3c;
+  border-color: #222d3c;
 }

--- a/spec/controllers/bookmarks_controller_spec.rb
+++ b/spec/controllers/bookmarks_controller_spec.rb
@@ -43,6 +43,37 @@ describe BookmarksController do
     end
   end
 
+  describe "share" do
+    it "returns correct response for bookmark to revealed work" do
+      bookmark = create :bookmark
+      # Assert this bookmark is of an revealed work
+      expect(bookmark.bookmarkable.unrevealed?).to eq(false)
+
+      get :share, params: { id: bookmark.id }, xhr: true
+      expect(response.status).to eq(200)
+      expect(response).to render_template("bookmarks/share")
+    end
+
+    it "returns a 404 response for bookmark to unrevealed work" do
+      unrevealed_collection = create :unrevealed_collection
+      unrevealed_work = create :work, collections: [unrevealed_collection]
+      unrevealed_bookmark = create :bookmark, bookmarkable_id: unrevealed_work.id
+      # Assert this bookmark is of an unrevealed work
+      expect(unrevealed_bookmark.bookmarkable.unrevealed?).to eq(true)
+
+      get :share, params: { id: unrevealed_bookmark.id }, xhr: true
+      expect(response.status).to eq(404)
+    end
+
+    it "redirects to referer with an error for non-ajax warnings requests" do
+      bookmark = create(:bookmark)
+      referer = bookmark_path(bookmark)
+      request.headers["HTTP_REFERER"] = referer
+      get :share, params: { id: bookmark.id }
+      it_redirects_to_with_error(referer, "Sorry, you need to have JavaScript enabled for this.")
+    end
+  end
+
   describe "index" do
     let!(:external_work_bookmark) { create(:external_work_bookmark) }
     let!(:series_bookmark) { create(:series_bookmark) }

--- a/spec/controllers/bookmarks_controller_spec.rb
+++ b/spec/controllers/bookmarks_controller_spec.rb
@@ -49,6 +49,7 @@ describe BookmarksController do
       # Assert this bookmark is of an revealed work
       expect(bookmark.bookmarkable.unrevealed?).to eq(false)
 
+      fake_login_known_user(bookmark.pseud.user)
       get :share, params: { id: bookmark.id }, xhr: true
       expect(response.status).to eq(200)
       expect(response).to render_template("bookmarks/share")
@@ -61,16 +62,17 @@ describe BookmarksController do
       # Assert this bookmark is of an unrevealed work
       expect(unrevealed_bookmark.bookmarkable.unrevealed?).to eq(true)
 
+      fake_login_known_user(unrevealed_bookmark.pseud.user)
       get :share, params: { id: unrevealed_bookmark.id }, xhr: true
       expect(response.status).to eq(404)
     end
 
     it "redirects to referer with an error for non-ajax warnings requests" do
       bookmark = create(:bookmark)
-      referer = bookmark_path(bookmark)
-      request.headers["HTTP_REFERER"] = referer
+
+      fake_login_known_user(bookmark.pseud.user)
       get :share, params: { id: bookmark.id }
-      it_redirects_to_with_error(referer, "Sorry, you need to have JavaScript enabled for this.")
+      it_redirects_to_with_error(root_path, "Sorry, you need to have JavaScript enabled for this.")
     end
   end
 


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [x] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [x] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [x] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-5987

## Purpose

Moves the sharing options off of the bookmark pages and into their own controller, to be loaded dynamically when the user presses the "Share" button.

## Testing Instructions

Make sure that you can still use the "Share" button on bookmarks - behaviour should remain unchanged.

Some edge cases that should be tested:

- JavaScript disabled
- Bookmark is private
- Work is unrevealed/part of an unrevealed collection
- Logged out user should not have option to share bookmark

## References

There has already been very similar work done for the `works` page, which I used as a reference while writing this PR.
- Issue: https://otwarchive.atlassian.net/browse/AO3-5907
- PR: https://github.com/otwcode/otwarchive/pull/3815

## Credit

*What name do you want us to use to credit your work in the [Archive of Our Own's Release Notes](https://archiveofourown.org/admin_posts?tag=1)?*

Tom Milligan

*What pronouns do you prefer (she/her, he/him, zie/hir etc)?*

they/them