### PR TITLE
AO3-5897 Call check_for_flash when calling redirect_to, so that flash messages are properly displayed even when the redirect occurs before_action.

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -89,6 +89,14 @@ class ApplicationController < ActionController::Base
     cookies[:flash_is_set] = 1 unless flash.empty?
   end
 
+  # Override redirect_to so that if it's called in a before_action hook, it'll
+  # still call check_for_flash after it runs.
+  def redirect_to(*args, **kwargs)
+    super.tap do
+      check_for_flash
+    end
+  end
+
   after_action :ensure_admin_credentials
   def ensure_admin_credentials
     if logged_in_as_admin?

--- a/spec/controllers/comments_controller_spec.rb
+++ b/spec/controllers/comments_controller_spec.rb
@@ -238,6 +238,11 @@ describe CommentsController do
           it_redirects_to_with_error(work_path(work),
                                      "Sorry, this work doesn't allow comments.")
         end
+
+        it "sets flash_is_set to bypass caching" do
+          post :create, params: { work_id: work.id, comment: anon_comment_attributes }
+          expect(cookies[:flash_is_set]).to eq(1)
+        end
       end
 
       context "when the work has anonymous comments disabled" do
@@ -247,6 +252,11 @@ describe CommentsController do
           post :create, params: { work_id: work.id, comment: anon_comment_attributes }
           it_redirects_to_with_error(work_path(work),
                                      "Sorry, this work doesn't allow non-Archive users to comment.")
+        end
+
+        it "sets flash_is_set to bypass caching" do
+          post :create, params: { work_id: work.id, comment: anon_comment_attributes }
+          expect(cookies[:flash_is_set]).to eq(1)
         end
       end
     end


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5897

## Purpose

Override `redirect_to` in the `ApplicationController`, so that we always call `check_for_flash` after `redirect_to` is called. `check_for_flash` is used to make sure that flash messages are displayed even on cached pages, and it's called as an `after_action` hook, but redirecting in a `before_action` hook skips `after_action` hooks.