### PR TITLE
AO3-5975 Provide explicit list of non-proxy hosts

### DIFF
--- a/app/views/layouts/_javascripts.html.erb
+++ b/app/views/layouts/_javascripts.html.erb
@@ -110,7 +110,7 @@
 <% if %w(staging production).include?(Rails.env) %>
   <%= javascript_tag do %>
     $j(document).ready(function() {
-      var permitted_hosts = <%= ArchiveConfig.PERMITTED_HOSTS.to_s.html_safe %>;
+      var permitted_hosts = <%= ArchiveConfig.PERMITTED_HOSTS.to_json.html_safe %>;
       var current_host = window.location.hostname;
 
       if (!permitted_hosts.includes(current_host) && Cookies.get("proxy_notice") !== "0") {

--- a/app/views/layouts/_javascripts.html.erb
+++ b/app/views/layouts/_javascripts.html.erb
@@ -107,7 +107,7 @@
 <% end %>
 
 <% # Renders layouts/proxy_notice below skip links in layouts/application. %>
-<% # if %w(staging production).include?(Rails.env) %>
+<% if %w(staging production).include?(Rails.env) %>
   <%= javascript_tag do %>
     $j(document).ready(function() {
       var permitted_hosts = <%= ArchiveConfig.PERMITTED_HOSTS.to_s.html_safe %>;
@@ -118,6 +118,6 @@
       }
     });
   <% end %>
-<% # end %>
+<% end %>
 
 <%= yield :footer_js %>

--- a/app/views/layouts/_javascripts.html.erb
+++ b/app/views/layouts/_javascripts.html.erb
@@ -113,7 +113,7 @@
       var permitted_hosts = <%= ArchiveConfig.PERMITTED_HOSTS.to_s.html_safe %>;
       var current_host = window.location.hostname;
 
-      if (!permitted_hosts.includes(current_host) && Cookies.get("proxy_notice", { domain: current_host }) !== "0") {
+      if (!permitted_hosts.includes(current_host) && Cookies.get("proxy_notice") !== "0") {
         $j("#skiplinks").after("<%= escape_javascript(render "layouts/proxy_notice") %>");
       }
     });

--- a/app/views/layouts/_javascripts.html.erb
+++ b/app/views/layouts/_javascripts.html.erb
@@ -111,7 +111,9 @@
   <%= javascript_tag do %>
     $j(document).ready(function() {
       var permitted_hosts = <%= ArchiveConfig.PERMITTED_HOSTS.to_s.html_safe %>;
-      if (!permitted_hosts.includes(window.location.hostname) && Cookies.get("proxy_notice") !== "0") {
+      var current_host = window.location.hostname;
+
+      if (!permitted_hosts.includes(current_host) && Cookies.get("proxy_notice", { domain: current_host }) !== "0") {
         $j("#skiplinks").after("<%= escape_javascript(render "layouts/proxy_notice") %>");
       }
     });

--- a/app/views/layouts/_javascripts.html.erb
+++ b/app/views/layouts/_javascripts.html.erb
@@ -107,14 +107,15 @@
 <% end %>
 
 <% # Renders layouts/proxy_notice below skip links in layouts/application. %>
-<% if %w(staging production).include?(Rails.env) %>
+<% # if %w(staging production).include?(Rails.env) %>
   <%= javascript_tag do %>
     $j(document).ready(function() {
-      if (window.location.hostname !== "<%= ArchiveConfig.APP_HOST %>" && Cookies.get("proxy_notice") !== "0") {
+      var permitted_hosts = <%= ArchiveConfig.PERMITTED_HOSTS.to_s.html_safe %>;
+      if (!permitted_hosts.includes(window.location.hostname) && Cookies.get("proxy_notice") !== "0") {
         $j("#skiplinks").after("<%= escape_javascript(render "layouts/proxy_notice") %>");
       }
     });
   <% end %>
-<% end %>
+<% # end %>
 
 <%= yield :footer_js %>

--- a/app/views/layouts/_proxy_notice.html.erb
+++ b/app/views/layouts/_proxy_notice.html.erb
@@ -10,7 +10,7 @@
 <%= javascript_tag do %>
   $j(document).ready(function() {
     $j("#proxy-notice-dismiss").on("click", function() {
-      Cookies.set("proxy_notice", "0");
+      Cookies.set("proxy_notice", "0", { domain: window.location.hostname });
       $j("#proxy-notice").slideUp();
     });
   });

--- a/app/views/layouts/_proxy_notice.html.erb
+++ b/app/views/layouts/_proxy_notice.html.erb
@@ -10,7 +10,7 @@
 <%= javascript_tag do %>
   $j(document).ready(function() {
     $j("#proxy-notice-dismiss").on("click", function() {
-      Cookies.set("proxy_notice", "0", { domain: window.location.hostname });
+      Cookies.set("proxy_notice", "0");
       $j("#proxy-notice").slideUp();
     });
   });

--- a/config/config.yml
+++ b/config/config.yml
@@ -484,3 +484,10 @@ HIT_COUNT_ROLLOVER_HOUR: 3
 
 # The batch size for calculating a work's filters from its tags:
 FILTER_UPDATE_BATCH_SIZE: 100
+
+# URLs for which we should not display the proxy notice.
+PERMITTED_HOSTS: [
+  "archiveofourown.org", "download.archiveofourown.org",
+  "insecure.archiveofourown.org", "insecure-test.archiveofourown.org",
+  "www.archiveofourown.org", "test.archiveofourown.org"
+]

--- a/config/config.yml
+++ b/config/config.yml
@@ -485,10 +485,16 @@ HIT_COUNT_ROLLOVER_HOUR: 3
 # The batch size for calculating a work's filters from its tags:
 FILTER_UPDATE_BATCH_SIZE: 100
 
-# URLs for which we should not display the proxy notice.
+# URLs for which we should not display the proxy notice. Alphabetical by
+# enviornment.
 PERMITTED_HOSTS: [
-  "archiveofourown.org", "download.archiveofourown.org",
-  "insecure.archiveofourown.org", "insecure-test.archiveofourown.org",
-  "www.archiveofourown.org", "test.archiveofourown.org",
+  # Production
+  "archiveofourown.org",
+  "download.archiveofourown.org",
+  "insecure.archiveofourown.org",
+  "insecure-test.archiveofourown.org",
+  "www.archiveofourown.org",
+  # Staging
+  "test.archiveofourown.org",
   "testdownload.archiveofourown.org"
 ]

--- a/config/config.yml
+++ b/config/config.yml
@@ -486,15 +486,15 @@ HIT_COUNT_ROLLOVER_HOUR: 3
 FILTER_UPDATE_BATCH_SIZE: 100
 
 # URLs for which we should not display the proxy notice. Alphabetical by
-# enviornment.
+# environment.
 PERMITTED_HOSTS: [
   # Production
   "archiveofourown.org",
   "download.archiveofourown.org",
   "insecure.archiveofourown.org",
-  "insecure-test.archiveofourown.org",
   "www.archiveofourown.org",
   # Staging
+  "insecure-test.archiveofourown.org",
   "test.archiveofourown.org",
   "testdownload.archiveofourown.org"
 ]

--- a/config/config.yml
+++ b/config/config.yml
@@ -489,5 +489,6 @@ FILTER_UPDATE_BATCH_SIZE: 100
 PERMITTED_HOSTS: [
   "archiveofourown.org", "download.archiveofourown.org",
   "insecure.archiveofourown.org", "insecure-test.archiveofourown.org",
-  "www.archiveofourown.org", "test.archiveofourown.org"
+  "www.archiveofourown.org", "test.archiveofourown.org",
+  "testdownload.archiveofourown.org"
 ]


### PR DESCRIPTION
##  Issue

https://otwarchive.atlassian.net/browse/AO3-5975

## Purpose

- Makes sure you won't see the proxy banner if you're on a subdomain we control, e.g. insecure.archiveofourown.org.

## Testing Instructions

Refer to Jira
