### PR TITLE
AO3-5924 Adjust donate page title

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -45,7 +45,7 @@ class HomeController < ApplicationController
   
   # donate
   def donate
-    @page_subtitle = "Donate or Volunteer"
+    @page_subtitle = t("layouts.home.donate.page_title")
     render action: "donate", layout: "application"
   end
   

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -45,7 +45,7 @@ class HomeController < ApplicationController
   
   # donate
   def donate
-    @page_subtitle = t("layouts.home.donate.page_title")
+    @page_subtitle = t(".page_title")
     render action: "donate", layout: "application"
   end
   

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -45,6 +45,7 @@ class HomeController < ApplicationController
   
   # donate
   def donate
+    @page_subtitle = "Donate or Volunteer"
     render action: "donate", layout: "application"
   end
   

--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -70,6 +70,9 @@ en:
     proxy_notice:
       text_html: "Notice: (1) You are using a proxy site that is not affiliated with AO3. (2) The entity that set up the proxy site can see whatever data you submit to the AO3 through the proxy site, including your IP address and the content of comments."
       button: "Dismiss Notice"
+    home:
+      donate:
+        page_title: "Donate or Volunteer"
   users:
     delete_preview:
       heading: "What do you want to do with your works?"

--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -66,13 +66,13 @@ en:
       roles:
         heading: "Your admin roles:"
         none: "You currently have no admin roles assigned to you."
+  home:
+    donate:
+      page_title: "Donate or Volunteer"
   layouts:
     proxy_notice:
       text_html: "Notice: (1) You are using a proxy site that is not affiliated with AO3. (2) The entity that set up the proxy site can see whatever data you submit to the AO3 through the proxy site, including your IP address and the content of comments."
       button: "Dismiss Notice"
-    home:
-      donate:
-        page_title: "Donate or Volunteer"
   users:
     delete_preview:
       heading: "What do you want to do with your works?"

--- a/features/other_a/homepage.feature
+++ b/features/other_a/homepage.feature
@@ -24,3 +24,4 @@ Feature: Various things on the homepage
   When I follow "Site Map"
     And I follow "Donations"
   Then I should see "There are two main ways to support the AO3 - donating your time or money"
+    And I should see the page title "Donate or Volunteer"


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5924

## Purpose

Changes the page title for https://archiveofourown.org/donate to "Donate or Volunteer | Archive of Our Own" as suggested.

## Testing Instructions

Verify page title on donate page.

The scenario in `feature/other_a/homepage.feature` has been extended to check this.

## References

N/A

## Credit

*What name do you want us to use to credit your work in the [Archive of Our Own's Release Notes](https://archiveofourown.org/admin_posts?tag=1)?* tlee911

*What pronouns do you prefer (she/her, he/him, zie/hir etc)?* he/him