### PR TITLE
AO3-6000 Rename fields on guest comment form to reduce chances of browser autofilling non-fannish names

### DIFF
--- a/app/views/comments/_comment_form.html.erb
+++ b/app/views/comments/_comment_form.html.erb
@@ -75,12 +75,12 @@
         <dl>
           <dt class="landmark"><%= ts("Note") %>:</dt>
           <dd class="instructions comment_form"><%=ts("All fields are required. Your email address will not be published.") %></dd>
-          <dt><%= f.label "name_for_#{commentable.id}", ts("Name: ") %></dt>
+          <dt><%= f.label "name_for_#{commentable.id}", ts("Guest name: ") %></dt>
           <dd>
             <%= f.text_field :name, :id => "comment_name_for_#{commentable.id}" %>
             <%= live_validation_for_field("comment_name_for_#{commentable.id}", :failureMessage => ts('Please enter your name.')) %>
           </dd>
-          <dt><%= f.label "email_for_#{commentable.id}", ts("Email: ") %></dt>
+          <dt><%= f.label "email_for_#{commentable.id}", ts("Guest email: ") %></dt>
           <dd>
             <%= f.text_field :email, :id => "comment_email_for_#{commentable.id}" %>
             <%= live_validation_for_field("comment_email_for_#{commentable.id}", :failureMessage => ts('Please enter your email address.')) %>

--- a/features/admins/admin_email_blacklist.feature
+++ b/features/admins/admin_email_blacklist.feature
@@ -36,7 +36,7 @@ Scenario: Blacklisted email addresses should not be usable in guest comments
   When I post the comment "I loved this" on the work "New Work" as a guest with email "foo@bar.com"
   Then I should see "has been blocked at the owner's request"
     And I should not see "Comments (1)"
-  When I fill in "Email" with "someone@bar.com"
+  When I fill in "Guest email" with "someone@bar.com"
     And I press "Comment"
   Then I should see "Comments (1)"
 

--- a/features/admins/admin_post_news.feature
+++ b/features/admins/admin_post_news.feature
@@ -51,8 +51,8 @@ Feature: Admin Actions to Post News
       And I go to the admin-posts page
       And I follow "Default Admin Post"
       And I fill in "Comment" with "Behold, ye mighty, and despair!"
-      And I fill in "Name" with "admin"
-      And I fill in "Email" with "admin@example.com"
+      And I fill in "Guest name" with "admin"
+      And I fill in "Guest email" with "admin@example.com"
       And I press "Comment"
     Then I should see "Comment created!"
       And I should see "admin"

--- a/features/step_definitions/comment_steps.rb
+++ b/features/step_definitions/comment_steps.rb
@@ -74,8 +74,8 @@ end
 When /^I post the comment "([^"]*)" on the work "([^"]*)" as a guest(?: with email "([^"]*)")?$/ do |comment_text, work, email|
   step "I am logged out"
   step "I set up the comment \"#{comment_text}\" on the work \"#{work}\""
-  fill_in("Name", with: "guest")
-  fill_in("Email", with: (email || "guest@foo.com"))
+  fill_in("Guest name", with: "guest")
+  fill_in("Guest email", with: (email || "guest@foo.com"))
   click_button "Comment"
 end
 


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [x] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [x] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [x] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-6000

## Purpose

There have been increasing reports of people accidentally letting their browser autofill their real names on guest comments, so this PR changes the field names on the guest comment form from "Name:" to "Guest name:" and "Email" to "Guest email" to try and prevent that.

## Testing Instructions

* Open a guest comment form on production in Chrome and see how form autofill works. Try that on staging and see if the autofilled values are different.
* Make sure the fields have new names, and label association works (clicking on the label puts the focus/cursor on the field next to it).
* Make sure you can still post guest comments.

## Misc. side notes about autofill/autocomplete

So, it looks like there are multiple factors that influence which autocomplete options the browser gives you when you're filling out a form. This includes:

* The `name` attribute on the `<input>` element
* The [`autocomplete`](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofilling-form-controls:-the-autocomplete-attribute) attribute on the `<input>` element (may or may not be there)
* The `<label>` element corresponding to the `<input>` element

To make things more confusing, it looks like Chrome has [two separate autofill mechanisms](https://stackoverflow.com/questions/57367813/2019-chrome-76-approach-to-autocomplete-off) that activate under different conditions.

1. First, there's normal autocomplete, which gives you a dropdown with values you previously entered for input fields with the same `name` attribute.

    I believe this is corresponds to the data that gets stored in the [autofill table](https://superuser.com/questions/884029/see-all-autofill-data) in Chrome's Google/Chrome/User Data/Default/Web Data database and the [moz_formhistory table](https://stackoverflow.com/questions/302017/browsing-and-editing-saved-form-data-in-firefox) in Firefox's Mozilla/Firefox/Profiles/xxxxx/formhistory.sqlite database. These seem to be independent of URL (i.e. if I just whip up a raw html file with the same `name` attributes on an `<input>` as another site, the same autocomplete options show up.)

    Looks something like this:
        
    ![Autofill 1](https://user-images.githubusercontent.com/5766317/91248728-525e3a00-e723-11ea-9d05-f413814e26f5.PNG)
2. Then there's Chrome's address autofill, which can be identified by a "Manage addresses..." option in the dropdown. This can autofill lots of different kinds of data all at once, including name, email, address, phone number, etc..

    It looks like Chrome uses heuristics on the `<label>` text, the `<input>` name attribute, and the `autocomplete` attribute to determine if this dropdown appears. (There's a Chrome flag `#show-autofill-type-predictions` that shows you what heuristic type it infers for input fields.) Additionally, this dropdown can activate even when [`autocomplete` is set to `off`](https://bugs.chromium.org/p/chromium/issues/detail?id=468153#c164). Additionally, this dropdown overrides the normal autocomplete dropdown. So even if you previously entered different values for this particular field, it will only show you predictions from your Chrome "save and fill addresses" data store (until you type something that doesn't match any of those predictions, in which case it will fall back to showing you predictions from the normal autocomplete).

    Looks something like this:

    ![Autofill 2](https://user-images.githubusercontent.com/5766317/91248984-f34cf500-e723-11ea-9a9a-8a332523dd9d.PNG)

### Other observations on Chrome autofill behaviour

Context: I previously entered "Chrome Guest User" in a guest comment on my local dev instance.

<details>
<summary>A large table</summary>

| `<label>` | `<input>` name attribute | `autocomplete` attribute | Autocomplete suggestions |
| --- | --- | --- | --- |
| Name: | comment[name] | (not present) | My full name (address) / Manage addresses... |
| Name: | comment[name] | off | My full name (address) / Manage addresses... |
| Name: | comment[name] | tel | My telephone number (address) / Manage addresses... |
| Name: | comment[name] | asdfghjklasdfghjkl | (Nothing) |
| Name: | asdfghjklasdfghjkl | (not present) | My full name (address) / Manage addresses... |
| Name: | asdfghjklasdfghjkl | off | My full name (address) / Manage addresses... |
| Name: | asdfghjklasdfghjkl | tel | My telephone number (address) / Manage addresses... |
| Name: | asdfghjklasdfghjkl | asdfghjklasdfghjkl | (Nothing) |
| Nom: | asdfghjklasdfghjkl | (not present) | My full name (address) / Manage addresses... |
| 名字: | asdfghjklasdfghjkl | (not present) | My first name (address) / Manage addresses... |
| 名前: | asdfghjklasdfghjkl | (not present) | My first name (address) / Manage addresses... |
| Guest name: | comment[name] | (not present) | Chrome Guest User |
| Guest name: | comment[name] | off | (Nothing) |
| Guest name: | comment[name] | tel  | My telephone number (address) / Manage addresses... |
| Guest name: | comment[name] | asdfghjklasdfghjkl  | (Nothing) |
| Guest name: | asdfghjklasdfghjkl | (not present) | (Nothing) |
| Guest name: | asdfghjklasdfghjkl | off | (Nothing) |
| Guest name: | asdfghjklasdfghjkl | tel | My telephone number (address) / Manage addresses... |
| Guest name: | asdfghjklasdfghjkl | asdfghjklasdfghjkl | (Nothing) |
| Asdfghjklasdfghjkl: | comment[name] | (not present) | Chrome Guest User |
| Asdfghjklasdfghjkl: | comment[name] | off | (Nothing) |
| Asdfghjklasdfghjkl: | comment[name] | tel | My telephone number (address) / Manage addresses... |
| Asdfghjklasdfghjkl: | comment[name] | asdfghjklasdfghjkl | (Nothing) |
| Asdfghjklasdfghjkl: | asdfghjklasdfghjkl | (not present) | (Nothing) |
| Asdfghjklasdfghjkl: | asdfghjklasdfghjkl | off | (Nothing) |
| Asdfghjklasdfghjkl: | asdfghjklasdfghjkl | tel | My telephone number (address) / Manage addresses... |
| Asdfghjklasdfghjkl: | asdfghjklasdfghjkl | asdfghjklasdfghjkl | (Nothing) |

</details>

# Credit

ahiijny (they/them is fine), same name on Jira
