### PR TITLE
AO3-6049 Fix intermittent failures in tests for comments and more

### DIFF
--- a/factories/users.rb
+++ b/factories/users.rb
@@ -8,12 +8,9 @@ FactoryBot.define do
   sequence :email do |n|
     Faker::Internet.email(name="#{Faker::Name.first_name}_#{n}")
   end
-  sequence :admin_login do |n|
-    "testadmin#{n}"
-  end
 
   factory :role do
-    name { Faker::Company.profession }
+    sequence(:name) { |n| "#{Faker::Company.profession}_#{n}" }
   end
 
   factory :user do

--- a/features/comments_and_kudos/comment_moderation.feature
+++ b/features/comments_and_kudos/comment_moderation.feature
@@ -3,8 +3,8 @@ Feature: Comment Moderation
   In order to avoid spam and troll comments
   As an author
   I'd like to be able to moderate comments
-  
-  
+
+
   Scenario: Turn off comments from anonymous users who can still leave kudos
     Given I am logged in as "author"
       And I set up the draft "No Anons"
@@ -14,7 +14,7 @@ Feature: Comment Moderation
     When I view the work "No Anons"
     Then I should see "Sorry, this work doesn't allow non-Archive users to comment."
     When I press "Kudos ♥"
-    Then I should see "Thank you for leaving kudos"    
+    Then I should see "Thank you for leaving kudos"
 
   Scenario: Turn off comments from everyone, but everyone can still leave kudos
     Given I am logged in as "author"
@@ -41,7 +41,7 @@ Feature: Comment Moderation
     When I am logged in as "commenter"
       And I view the work "Moderation"
     Then I should see "has chosen to moderate comments"
-    
+
   Scenario: Post a moderated comment
     Given the moderated work "Moderation" by "author"
     When I am logged in as "commenter"
@@ -81,7 +81,7 @@ Feature: Comment Moderation
       And I view the work "Moderation"
       And I follow "Unreviewed Comments (1)"
     Then I should see "Edited unfail comment"
-      
+
   Scenario: Author comments do not need to be approved
     Given the moderated work "Moderation" by "author"
     When I am logged in as "author"
@@ -91,7 +91,7 @@ Feature: Comment Moderation
       And I should see "Comment created"
       And I should not see "Unreviewed Comments (1)"
       And I should see "Comments:1"
-      
+
   Scenario: Moderated comments can be approved by the author
     Given the moderated work "Moderation" by "author"
       And I am logged in as "commenter"
@@ -110,7 +110,7 @@ Feature: Comment Moderation
     When I follow "Comments (1)"
     Then I should see "Test comment"
       And the comment on "Moderation" should not be marked as unreviewed
-      
+
   Scenario: Moderated comments can be approved from the inbox
     Given the moderated work "Moderation" by "author"
       And I am logged in as "commenter"
@@ -146,7 +146,7 @@ Feature: Comment Moderation
       And I view the work "Moderation"
     Then I should see "Comments (1)"
       And I should not see "Unreviewed Comments (1)"
-    
+
   Scenario: Moderated comments can be deleted by the author
     Given the moderated work "Moderation" by "author"
       And I am logged in as "commenter"
@@ -158,7 +158,7 @@ Feature: Comment Moderation
     # Then I should see "Comment deleted"
     #   And I should not see "Test comment"
     #   And I should see "No unreviewed comments"
-      
+
   Scenario: Moderation should work on threaded comments
     Given the moderated work "Moderation" by "author"
       And I am logged in as "author"
@@ -188,7 +188,7 @@ Feature: Comment Moderation
     When I am logged in as "author"
       And I view the unreviewed comments page for "Moderation"
     Then I should not see "Reply"
-      
+
   Scenario: The commenter can edit their unapproved comment
     Given the moderated work "Moderation" by "author"
       And I am logged in as "commenter"
@@ -201,7 +201,7 @@ Feature: Comment Moderation
       And I should see "Delete"
     When I edit a comment
     Then I should see "Comment was successfully updated"
-      
+
   Scenario: Users should not see unapproved replies to their own comments
     Given the moderated work "Moderation" by "author" with the approved comment "Test comment" by "commenter"
       And I am logged in as "new_commenter"
@@ -233,11 +233,11 @@ Feature: Comment Moderation
     When I am logged in as "commenter"
       And I go to my inbox page
     Then I should see "A moderated reply"
-    
+
   Scenario: When I turn off moderation, comments stay unreviewed
     Given the moderated work "Moderation" by "author"
       And I am logged in as "commenter"
-      And I post the comment "Interesting Comment" on the work "Moderation"      
+      And I post the comment "Interesting Comment" on the work "Moderation"
     When I am logged in as "author"
       And I edit the work "Moderation"
       And I uncheck "Enable comment moderation"
@@ -258,11 +258,11 @@ Feature: Comment Moderation
     When I follow "Comments (1)"
     Then I should see "New Comment"
       And I should not see "Interesting Comment"
-    
+
   Scenario: When an approved comment is edited significantly it gets moderated again
     Given the moderated work "Moderation" by "author"
       And I am logged in as "commenter"
-      And I post the comment "Interesting Comment" on the work "Moderation"      
+      And I post the comment "Interesting Comment" on the work "Moderation"
       And I am logged in as "author"
       And I view the unreviewed comments page for "Moderation"
       And I press "Approve"
@@ -279,9 +279,10 @@ Feature: Comment Moderation
     Then I should see "Interesting Commentary"
     When I follow "Edit"
       And I fill in "Comment" with "AHAHAHA LOOK I HAVE TOTALLY CHANGED IT"
+      And it is currently 1 second from now
       And I press "Update"
     Then the comment on "Moderation" should be marked as unreviewed
-      
+
   Scenario: I can approve multiple comments at once
     Given the moderated work "Moderation" by "author"
       And I am logged in as "commenter"

--- a/features/importing/archivist_creatorships.feature
+++ b/features/importing/archivist_creatorships.feature
@@ -57,6 +57,7 @@ Feature: Special co-creator behavior for archivists
     When I view the series "Imported Series"
       And I follow "Edit Series"
       And I try to invite the co-author "allow"
+      And it is currently 1 second from now
       And I press "Update"
     Then "allow" should be a co-creator of the series "Imported Series"
       And 1 email should be delivered to "allow"
@@ -70,6 +71,7 @@ Feature: Special co-creator behavior for archivists
     When I view the series "Imported Series"
       And I follow "Edit Series"
       And I try to invite the co-author "disallow"
+      And it is currently 1 second from now
       And I press "Update"
     Then "disallow" should be a co-creator of the series "Imported Series"
       And 1 email should be delivered to "disallow"

--- a/features/users/user_dashboard.feature
+++ b/features/users/user_dashboard.feature
@@ -81,6 +81,8 @@ Feature: User dashboard
   Given I am logged in as "meatloaf"
     And I post the work "My Work"
   When I add the work "My Work" to the series "Oldest Series"
+    # Make sure all other series are more recent
+    And it is currently 1 second from now
     And I add the work "My Work" to the series "Series 2"
     And I add the work "My Work" to the series "Series 3"
     And I add the work "My Work" to the series "Series 4"

--- a/features/works/chapter_edit.feature
+++ b/features/works/chapter_edit.feature
@@ -334,6 +334,8 @@ Feature: Edit chapters
     When I follow "Edit Chapter"
     Then the "sabrina" checkbox should not be checked
     When I check "sabrina"
+      # Expire cached byline
+      And it is currently 1 second from now
       And I post the chapter
     Then I should not see "Chapter by karma"
       And 1 email should be delivered to "sabrina"

--- a/features/works/work_edit.feature
+++ b/features/works/work_edit.feature
@@ -140,6 +140,8 @@ Feature: Edit Works
     Then I should not see "Edit"
     When I follow "Creator Invitations page"
       And I check "selected[]"
+      # Expire cached byline
+      And it is currently 1 second from now
       And I press "Accept"
     Then I should see "You are now listed as a co-creator on Dialogue."
     When I follow "Dialogue"


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6049

## Purpose

- `spec/controllers/admin/admin_users_controller_spec.rb`: fix admin role factory to avoid reusing the same name and failing tests for changing roles.
- `features/comments_and_kudos/comment_moderation.feature`: jump ahead 1 second before editing a comment to expire its cache.
- `features/importing/archivist_creatorships.feature`: jump ahead 1 second before adding co-creators to expire the series' byline.
- `features/users/user_dashboard.feature`: jump ahead 1 second before adding more series to make sure "Oldest Series" stays oldest.
- `features/works/chapter_edit.feature`: jump ahead 1 second before adding a chapter co-creator to expire the chapter's byline.
- `features/works/work_edit.feature`: jump ahead 1 second before accepting a co-creator request to expire the work's byline.

Tests were run multiple times on my fork:
- https://travis-ci.com/github/redsummernight/otwarchive/builds/182805350
- https://travis-ci.com/github/redsummernight/otwarchive/builds/182922692

## Testing Instructions

None, automated.