### PR TITLE
AO3-6048 Revert "AO3-6048 Add linters to main Gemfile (and install pwgen)"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ stdout
 /.dropbox
 /.dropbox.attr
 /.rspec
+Gemfile.linters.lock
 REVISION
 
 # /config/

--- a/.hound.yml
+++ b/.hound.yml
@@ -1,7 +1,7 @@
 # Available linter versions:
 # http://help.houndci.com/en/articles/2461415-supported-linters
 #
-# Keep versions in sync with Gemfile.
+# Keep versions in sync with Gemfile.linters.
 
 erblint:
   enabled: true

--- a/Gemfile
+++ b/Gemfile
@@ -165,11 +165,6 @@ group :development do
   gem 'factory_bot_rails'
   gem 'bundler-audit'
   gem 'active_record_query_trace', '~> 1.6', '>= 1.6.1'
-  # Linters
-  gem "erb_lint", "0.0.29"
-  gem "rubocop", "0.83.0"
-  gem "rubocop-rails", "2.6.0"
-  gem "rubocop-rspec", "1.41.0"
 end
 
 group :test, :development, :staging do

--- a/Gemfile.linters
+++ b/Gemfile.linters
@@ -1,0 +1,14 @@
+# All gems required to run linters:
+#
+#     BUNDLE_GEMFILE=Gemfile.linters bundle install
+#     BUNDLE_GEMFILE=Gemfile.linters bundle exec rubocop .
+#     BUNDLE_GEMFILE=Gemfile.linters bundle exec erblint .
+#
+# Keep linters in sync with .hound.yml.
+
+eval_gemfile "Gemfile"
+
+gem "erb_lint", "0.0.29"
+gem "rubocop", "0.83.0"
+gem "rubocop-rails", "2.6.0"
+gem "rubocop-rspec", "1.41.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -83,7 +83,6 @@ GEM
       activerecord (>= 4.2)
     akismetor (1.0.0)
     arel (9.0.0)
-    ast (2.4.1)
     audited (4.9.0)
       activerecord (>= 4.2, < 6.1)
     awesome_print (1.8.0)
@@ -1003,14 +1002,6 @@ GEM
       aws-eventstream (~> 1, >= 1.0.2)
     backports (3.18.1)
     bcrypt (3.1.13)
-    better_html (1.0.15)
-      actionview (>= 4.0)
-      activesupport (>= 4.0)
-      ast (~> 2.0)
-      erubi (~> 1.4)
-      html_tokenizer (~> 0.0.6)
-      parser (>= 2.4)
-      smart_properties
     brakeman (3.7.2)
     builder (3.2.4)
     bullet (6.1.0)
@@ -1111,13 +1102,6 @@ GEM
     email_spec (1.6.0)
       launchy (~> 2.1)
       mail (~> 2.2)
-    erb_lint (0.0.29)
-      activesupport
-      better_html (~> 1.0.7)
-      html_tokenizer
-      rainbow
-      rubocop (~> 0.51)
-      smart_properties
     erubi (1.9.0)
     escape_utils (1.2.1)
     et-orbi (1.2.4)
@@ -1141,7 +1125,6 @@ GEM
     god (0.13.7)
     hashdiff (1.0.1)
     highline (2.0.3)
-    html_tokenizer (0.0.7)
     htmlentities (4.3.4)
     http-cookie (1.0.3)
       domain_name (~> 0.5)
@@ -1214,9 +1197,6 @@ GEM
       mime-types
       mimemagic (~> 0.3.0)
       terrapin (~> 0.6.0)
-    parallel (1.19.2)
-    parser (2.7.1.4)
-      ast (~> 2.4.1)
     permit_yo (2.1.3)
     phraseapp-in-context-editor-ruby (1.3.1)
       i18n (>= 0.6)
@@ -1279,7 +1259,6 @@ GEM
       method_source
       rake (>= 0.8.7)
       thor (>= 0.19.0, < 2.0)
-    rainbow (3.0.0)
     raindrops (0.19.1)
     rake (13.0.1)
     redis (3.3.5)
@@ -1305,7 +1284,6 @@ GEM
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 3.0)
       netrc (~> 0.7)
-    rexml (3.2.4)
     rollout (2.4.3)
     rspec (3.8.0)
       rspec-core (~> 3.8.0)
@@ -1328,20 +1306,6 @@ GEM
       rspec-mocks (~> 3.8.0)
       rspec-support (~> 3.8.0)
     rspec-support (3.8.3)
-    rubocop (0.83.0)
-      parallel (~> 1.10)
-      parser (>= 2.7.0.1)
-      rainbow (>= 2.2.2, < 4.0)
-      rexml
-      ruby-progressbar (~> 1.7)
-      unicode-display_width (>= 1.4.0, < 2.0)
-    rubocop-rails (2.6.0)
-      activesupport (>= 4.2.0)
-      rack (>= 1.1)
-      rubocop (>= 0.82.0)
-    rubocop-rspec (1.41.0)
-      rubocop (>= 0.68.1)
-    ruby-progressbar (1.10.1)
     ruby2_keywords (0.0.2)
     rufus-scheduler (3.6.0)
       fugit (~> 1.1, >= 1.1.6)
@@ -1368,7 +1332,6 @@ GEM
       rack (~> 2.0)
       rack-protection (= 2.0.8.1)
       tilt (~> 2.0)
-    smart_properties (1.15.0)
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -1397,7 +1360,6 @@ GEM
       unf_ext
     unf_ext (0.0.7.7)
     unicode (0.4.4.4)
-    unicode-display_width (1.7.0)
     unicorn (5.5.5)
       kgio (~> 2.6)
       raindrops (~> 0.7)
@@ -1462,7 +1424,6 @@ DEPENDENCIES
   devise-async
   elasticsearch (= 6.8.0)
   email_spec (= 1.6.0)
-  erb_lint (= 0.0.29)
   escape_utils (= 1.2.1)
   factory_bot (~> 5.0.2)
   factory_bot_rails
@@ -1503,9 +1464,6 @@ DEPENDENCIES
   rollout
   rspec (~> 3.8)
   rspec-rails (~> 3.8.2)
-  rubocop (= 0.83.0)
-  rubocop-rails (= 2.6.0)
-  rubocop-rspec (= 1.41.0)
   rvm-capistrano
   sanitize (>= 4.6.5)
   shoulda

--- a/config/docker/Dockerfile
+++ b/config/docker/Dockerfile
@@ -6,7 +6,6 @@ RUN apt-get update             && \
         calibre                   \
         default-mysql-client      \
         phantomjs                 \
-        pwgen                     \
         wkhtmltopdf               \
         zip
 


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6048

## Purpose

Removes linters from the main Gemfile. Unfortunately, we were running into some errors loading Vagrant and Homebrew development environments because erb-lint switches the ERB parser to better-html. 

We're on the fence as to whether we're going to want to proceed with adding erb-lint to the Gemfile or not: using a different parser on dev means we risk encountering errors in dev that don't occur in other environments (e.g. the one preventing it from loading) _or_ that we might have errors that occur in production, but that we can't see on dev. Ergo, we're going to revert this for now.

## Testing Instructions

Make sure development environments load.

## References

Reverts otwcode/otwarchive#3895