### PR TITLE
AO3-6056 Update confirmation text on the "Drop Claim" button for prompts

### DIFF
--- a/app/views/prompts/_prompt_controls.html.erb
+++ b/app/views/prompts/_prompt_controls.html.erb
@@ -9,10 +9,10 @@
     <% # The edit link should show up if signups are open and the current user owns the prompt, OR if the challenge is a gift exchange and signups are closed and the current user is the maintainer %>
     <% if (challenge.signup_open && user == current_user) || (collection.challenge_type == "GiftExchange" && !challenge.signup_open && collection.user_is_maintainer?(current_user)) %>
       <li>
-        <%= link_to(ts('Edit Sign-up'), edit_collection_signup_path(collection, challenge_signup)) %>
+        <%= link_to(ts("Edit Sign-up"), edit_collection_signup_path(collection, challenge_signup)) %>
       </li>
       <li>
-        <%= link_to(ts('Edit Prompt'), edit_collection_prompt_path(collection, prompt)) %>
+        <%= link_to(ts("Edit Prompt"), edit_collection_prompt_path(collection, prompt)) %>
       </li>
     <% end %>
 
@@ -21,16 +21,16 @@
     <li>
       <%= link_to ts("Delete Prompt"),
         collection_prompt_path(collection, prompt),
-        data: {confirm: ts("Are you sure? All information in this prompt will be lost.")},
-        :method => :delete %>
+        data: { confirm: ts("Are you sure? All information in this prompt will be lost.") },
+        method: :delete %>
     </li>
     <% end %>
     <% # Moderators should be able to delete entire sign-ups from the /requests page in PromptMemes.  %>
     <% if collection.user_is_maintainer?(current_user) && collection.challenge_type == "PromptMeme" %>
       <li><%= link_to ts("Delete Sign-up"),
                   collection_signup_path(collection, challenge_signup),
-                  data: {confirm: ts("Are you sure? All prompts in this sign-up will be lost.")},
-                  :method => :delete %>
+                  data: { confirm: ts("Are you sure? All prompts in this sign-up will be lost.") },
+                  method: :delete %>
       </li>
     <% end %>
 
@@ -43,7 +43,7 @@
           <li><%= link_to ts("Fulfill"), new_collection_work_path(collection, :claim_id => claim.id) %></li>
         <% end %>
         <% # The drop claim link should show up if the current user has claimed the prompt %>
-        <li><%= link_to ts("Drop Claim"), collection_claim_path(collection, claim), data: {confirm: ts('Do you really want to drop this claim?')}, :method => :delete %></li>
+        <li><%= link_to ts("Drop Claim"), collection_claim_path(collection, claim), data: { confirm: ts("Do you really want to drop this claim?") }, method: :delete %></li>
         <% # The claim link should show up if the user has not already claimed the prompt %>
         <% else %>
         <li>

--- a/app/views/prompts/_prompt_controls.html.erb
+++ b/app/views/prompts/_prompt_controls.html.erb
@@ -43,7 +43,7 @@
           <li><%= link_to ts("Fulfill"), new_collection_work_path(collection, :claim_id => claim.id) %></li>
         <% end %>
         <% # The drop claim link should show up if the current user has claimed the prompt %>
-        <li><%= link_to ts("Drop Claim"), collection_claim_path(collection, claim), data: {confirm: ts('Do you really want to delete this claim?')}, :method => :delete %></li>
+        <li><%= link_to ts("Drop Claim"), collection_claim_path(collection, claim), data: {confirm: ts('Do you really want to drop this claim?')}, :method => :delete %></li>
         <% # The claim link should show up if the user has not already claimed the prompt %>
         <% else %>
         <li>


### PR DESCRIPTION
Note: I ran the tests (rspec and cucumber) and verified that everything passed in docker—if there's anything I should watch out for with the docker dev environment please let me know!

# Pull Request Checklist

* [x] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [x] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)? _No changed functionality, and no specs testing the string being updated._
* [x] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)?
* [x] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-6056

## Purpose

The confirmation message after selecting the "Drop Claim" button on a claimed prompt currently could imply that the prompt itself is being deleted. This updates the confirmation text to match the button text, and clarify that it's the claim that's being dropped/deleted, not the prompt.

## Testing Instructions

No tests check this exact string, so no tests were added or updated for this change.

To test manually, if desired:

* Log in as a user who does not have ownership of a prompt
* Adopt a prompt from a challenge
* View the claimed prompt
* Click "Drop Claim"
* Verify the text says _"Do you really want to drop this claim?"_ and does not say "delete"

(No Jira account)

## References

Are there other relevant issues/pull requests/mailing list discussions?
None that I'm aware of!

## Credit

*What name do you want us to use to credit your work in the [Archive of Our Own's Release Notes](https://archiveofourown.org/admin_posts?tag=1)?*
translatorzepp

(If you have a Jira account, please include the same name in the "Full name"
field on your Jira profile, so we can assign you the issues you're working on.)

*What pronouns do you prefer (she/her, he/him, zie/hir etc)?*
she/her