### PR TITLE
AO3-5357 Address issues with the related works page & anonymous/unrevealed works.

### DIFF
--- a/app/controllers/related_works_controller.rb
+++ b/app/controllers/related_works_controller.rb
@@ -10,12 +10,14 @@ class RelatedWorksController < ApplicationController
     @translations_by_user = @user.parent_work_relationships.posted.where(translation: true)
     @remixes_by_user = @user.parent_work_relationships.posted.where(translation: false)
 
-    unless @user == current_user
-      @translations_of_user = @translations_of_user.merge(Work.revealed.non_anon)
-      @remixes_of_user = @remixes_of_user.merge(Work.revealed.non_anon)
-      @translations_by_user = @translations_by_user.merge(Work.revealed.non_anon)
-      @remixes_by_user = @remixes_by_user.merge(Work.revealed.non_anon)
-    end
+    return if @user == current_user
+
+    # Extra constraints on what we display if someone else is viewing @user's
+    # related works page:
+    @translations_of_user = @translations_of_user.merge(Work.revealed.non_anon)
+    @remixes_of_user = @remixes_of_user.merge(Work.revealed.non_anon)
+    @translations_by_user = @translations_by_user.merge(Work.revealed.non_anon)
+    @remixes_by_user = @remixes_by_user.merge(Work.revealed.non_anon)
   end
 
   # GET /related_works/1

--- a/app/views/related_works/index.html.erb
+++ b/app/views/related_works/index.html.erb
@@ -144,7 +144,7 @@
             <%= ts("inspired") %>
             <%= link_to related_work.work.title, related_work.work %>
             <% if current_user == @user %>
-              <span class="actions" role="button"><%= button_to ts("Remove"), related_work_path(related_work), data: { confirm: ts("Are you sure?") }, method: :delete %></span>
+              <span class="actions"><%= button_to ts("Remove"), related_work_path(related_work), data: { confirm: ts("Are you sure?") }, method: :delete %></span>
             <% end %>
           </dd>
         <% end %>

--- a/app/views/related_works/index.html.erb
+++ b/app/views/related_works/index.html.erb
@@ -36,10 +36,10 @@
       <% if related_work.parent && related_work.work %>
       <tr>
         <% if related_work.work.unrevealed? %>
-          <td><%= ts("A work in an unrevealed challenge") %></td>
+          <td><%= ts("A work in an unrevealed collection") %></td>
         <% else %>
-          <td scope="row"><%= link_to related_work.work.title.html_safe, related_work.work %> <%= ts("by") %> <%= byline(related_work.work) %></td>
-          <td><%= link_to related_work.parent.title.html_safe, related_work.parent %></td>
+          <td scope="row"><%= link_to related_work.work.title, related_work.work %> <%= ts("by") %> <%= byline(related_work.work) %></td>
+          <td><%= link_to related_work.parent.title, related_work.parent %></td>
           <td>
             <%= ts("From") %> <%= language_link(related_work.parent) %> <%= ts("to") %> <%= language_link(related_work.work) %>
           </td>
@@ -78,17 +78,19 @@
     <% @translations_by_user.each do |related_work| %>
       <% if related_work.parent && related_work.work %>
         <tr>
-          <% if related_work.work.unrevealed? || related_work.work.anonymous? %>
-            <td><%= ts("A work in an unrevealed or anonymous challenge") %></td>
-          <% else %>
-            <td scope="row"><%= link_to related_work.parent.title.html_safe, related_work.parent %> <%= ts("by") %> <%= byline(related_work.parent) %></td>
-            <td><%= link_to related_work.work.title.html_safe, related_work.work %></td>
-            <td>
-              <%= ts("From") %> <%= language_link(related_work.parent) %> <%= ts("to") %> <%= language_link(related_work.work) %>
-            </td>
-            <% if current_user == @user %>
-              <td><%= link_to ts("Remove"), {:controller => :related_works, :action => :destroy, :id => related_work.id},  data: {confirm: ts('Are you sure?')}, :method => :delete %></td>
+          <td scope="row">
+            <% if related_work.parent.is_a?(Work) && related_work.parent.unrevealed? %>
+              <%= ts("A work in an unrevealed collection") %>
+            <% else %>
+              <%= link_to related_work.parent.title, related_work.parent %> <%= ts("by") %> <%= byline(related_work.parent) %>
             <% end %>
+          </td>
+          <td><%= link_to related_work.work.title, related_work.work %></td>
+          <td>
+            <%= ts("From") %> <%= language_link(related_work.parent) %> <%= ts("to") %> <%= language_link(related_work.work) %>
+          </td>
+          <% if current_user == @user %>
+            <td><%= button_to ts("Remove"), related_work_path(related_work), data: { confirm: ts("Are you sure?") }, method: :delete %></td>
           <% end %>
         </tr>
       <% end %>
@@ -104,11 +106,11 @@
       <% if related_work.parent && related_work.work %>
         <dt class="child">
           <% if related_work.work.unrevealed? %>
-            <%= ts("A work in an unrevealed challenge") %>
+            <%= ts("A work in an unrevealed collection") %>
           <% else %>
-            <%= link_to related_work.work.title.html_safe, related_work.work %> <%= ts("by") %> <%= byline(related_work.work) %>
+            <%= link_to related_work.work.title, related_work.work %> <%= ts("by") %> <%= byline(related_work.work) %>
           </dt>
-          <dd class="parent"><%= ts("was inspired by ") %><%= link_to related_work.parent.title.html_safe, related_work.parent %>
+          <dd class="parent"><%= ts("was inspired by ") %><%= link_to related_work.parent.title, related_work.parent %>
             <% if current_user == @user %>
               <span class="submit actions">
                 <% if related_work.reciprocal? %>
@@ -132,23 +134,17 @@
       <% unless related_work.translation? %>
         <% if related_work.parent && related_work.work %>
           <dt class="parent">
-            <% if related_work.parent.is_a?(ExternalWork) %>
-               <%= link_to related_work.parent.title, related_work.parent %> by <%= byline(related_work.parent) %>
-            <% elsif related_work.parent.unrevealed? || related_work.parent.anonymous? %>
-              <%= ts("A work in an unrevealed or anonymous challenge") %>
+            <% if related_work.parent.is_a?(Work) && related_work.parent.unrevealed? %>
+              <%= ts("A work in an unrevealed collection") %>
             <% else %>
               <%= link_to related_work.parent.title, related_work.parent %> <%= ts("by") %> <%= byline(related_work.parent) %>
             <% end %>
           </dt>
- 		      <dd class="child">
- 		        <%= ts("inspired") %>
-            <% if related_work.work.unrevealed? || related_work.work.anonymous? %>
-              <%= ts("A work in an unrevealed or anonymous challenge") %>
-            <% else %>
-              <%= link_to related_work.work.title, related_work.work %>
-            <% end %>
+          <dd class="child">
+            <%= ts("inspired") %>
+            <%= link_to related_work.work.title, related_work.work %>
             <% if current_user == @user %>
-              <span class="actions" role="button"><%= link_to ts("Remove"), {:controller => :related_works, :action => :destroy, :id => related_work.id},  data: {confirm: ts('Are you sure?')}, :method => :delete %></span>
+              <span class="actions" role="button"><%= button_to ts("Remove"), related_work_path(related_work), data: { confirm: ts("Are you sure?") }, method: :delete %></span>
             <% end %>
           </dd>
         <% end %>

--- a/features/step_definitions/work_related_steps.rb
+++ b/features/step_definitions/work_related_steps.rb
@@ -1,16 +1,17 @@
 ### GIVEN
 
 Given /^I have related works setup$/ do
-  step %{I am logged in as "inspiration"}
-  step %{I am logged in as "translator"}
-  step %{I am logged in as "remixer"}
-    step "basic tags"
-    step "all emails have been delivered"
-    step %{I have loaded the "languages" fixture}
-    step %{I am logged in as "inspiration"}
-    step %{I post the work "Worldbuilding"}
-    step %{I post the work "Worldbuilding Two"}
-    step "I am logged out"
+  step "basic tags"
+  step "all emails have been delivered"
+  step "I am logged out"
+  step %{I have loaded the "languages" fixture}
+
+  inspiration = FactoryBot.create(:user, login: "inspiration", confirmed_at: Time.now)
+  FactoryBot.create(:user, login: "translator", confirmed_at: Time.now)
+  FactoryBot.create(:user, login: "remixer", confirmed_at: Time.now)
+
+  FactoryBot.create(:work, title: "Worldbuilding", authors: inspiration.pseuds)
+  FactoryBot.create(:work, title: "Worldbuilding Two", authors: inspiration.pseuds)
 end
 
 Given /^an inspiring parent work has been posted$/ do

--- a/features/step_definitions/work_related_steps.rb
+++ b/features/step_definitions/work_related_steps.rb
@@ -6,9 +6,9 @@ Given /^I have related works setup$/ do
   step "I am logged out"
   step %{I have loaded the "languages" fixture}
 
-  inspiration = FactoryBot.create(:user, login: "inspiration", confirmed_at: Time.now)
-  FactoryBot.create(:user, login: "translator", confirmed_at: Time.now)
-  FactoryBot.create(:user, login: "remixer", confirmed_at: Time.now)
+  inspiration = FactoryBot.create(:user, login: "inspiration", confirmed_at: Time.now.utc)
+  FactoryBot.create(:user, login: "translator", confirmed_at: Time.now.utc)
+  FactoryBot.create(:user, login: "remixer", confirmed_at: Time.now.utc)
 
   FactoryBot.create(:work, title: "Worldbuilding", authors: inspiration.pseuds)
   FactoryBot.create(:work, title: "Worldbuilding Two", authors: inspiration.pseuds)

--- a/features/works/work_related.feature
+++ b/features/works/work_related.feature
@@ -129,17 +129,6 @@ Scenario: The creator of the original work can see approved and unapproved relat
   Then I should see "Worldbuilding Approve"
     And I should see "Deutsch Remove"
 
-Scenario: A user cannot see another user's related works page
-
-  Given I have related works setup
-    And a related work has been posted
-  When I am logged in as "inspiration"
-  When I go to remixer's user page
-  Then I should not see "Related Works"
-  When I go to remixer's related works page
-  # It's currently possible to access a user's related works page directly
-  # Then I should see "Sorry, you don't have permission to access the page you were trying to reach."
-
 Scenario: The creator of the original work can remove a previously approved related work
 
   Given I have related works setup
@@ -409,3 +398,188 @@ Scenario: When a user is notified that a co-authored work has been inspired by a
   When I list a nonexistent work as inspiration
     And I press "Post"
   Then I should see "The work you listed as an inspiration does not seem to exist."
+
+  Scenario: When a remix is anonymous, it's visible on the original creator's related works page, but not on the remixer's related works page
+    Given an anonymous collection "Anonymous"
+      And I have related works setup
+      And I post a related work as remixer
+    When I am logged in as "remixer"
+      And I add the work "Followup" to the collection "Anonymous"
+      And I go to remixer's related works page
+    Then I should see "Works that inspired remixer"
+      And I should see "Worldbuilding by inspiration"
+    When I go to inspiration's related works page
+    Then I should see "Works inspired by inspiration"
+      And I should see "Followup by Anonymous [remixer]"
+    When I am logged in as "inspiration"
+      And I go to remixer's related works page
+    Then I should not see "Works that inspired remixer"
+      And I should not see "Worldbuilding by inspiration"
+    When I go to inspiration's related works page
+    Then I should see "Works inspired by inspiration"
+      And I should see "Followup by Anonymous"
+      And I should not see "remixer"
+
+  Scenario: When a remix is unrevealed, it's visible on the original creator's related works page, but not on the remixer's related works page
+    Given a hidden collection "Hidden"
+      And I have related works setup
+      And I post a related work as remixer
+    When I am logged in as "remixer"
+      And I add the work "Followup" to the collection "Hidden"
+      And I go to remixer's related works page
+    Then I should see "Works that inspired remixer"
+      And I should see "Worldbuilding by inspiration"
+    When I go to inspiration's related works page
+    Then I should see "Works inspired by inspiration"
+      And I should see "A work in an unrevealed collection"
+    When I am logged in as "inspiration"
+      And I go to remixer's related works page
+    Then I should not see "Works that inspired remixer"
+      And I should not see "A work in an unrevealed collection"
+      And I should not see "Worldbuilding by inspiration"
+    When I go to inspiration's related works page
+    Then I should see "Works inspired by inspiration"
+      And I should see "A work in an unrevealed collection"
+      And I should not see "remixer"
+
+  Scenario: A remix of an anonymous work is shown on the remixer's related works page, but not on the original creator's related works page
+    Given an anonymous collection "Anonymous"
+      And I have related works setup
+      And I post a related work as remixer
+    When I am logged in as "inspiration"
+      And I add the work "Worldbuilding" to the collection "Anonymous"
+      And I go to remixer's related works page
+    Then I should see "Works that inspired remixer"
+      And I should see "Worldbuilding by Anonymous [inspiration]"
+    When I go to inspiration's related works page
+    Then I should see "Works inspired by inspiration"
+      And I should see "Followup by remixer"
+    When I am logged in as "remixer"
+      And I go to remixer's related works page
+    Then I should see "Works that inspired remixer"
+      And I should see "Worldbuilding by Anonymous"
+      And I should not see "inspiration"
+    When I go to inspiration's related works page
+    Then I should not see "Works inspired by inspiration"
+      And I should not see "Followup"
+
+  Scenario: A remix of an unrevealed work is shown on the remixer's related works page, but not on the original creator's related works page
+    Given a hidden collection "Hidden"
+      And I have related works setup
+      And I post a related work as remixer
+    When I am logged in as "inspiration"
+      And I add the work "Worldbuilding" to the collection "Hidden"
+      And I go to remixer's related works page
+    Then I should see "Works that inspired remixer"
+      And I should see "A work in an unrevealed collection"
+    When I go to inspiration's related works page
+    Then I should see "Works inspired by inspiration"
+      And I should see "Followup by remixer"
+    When I am logged in as "remixer"
+      And I go to remixer's related works page
+    Then I should see "Works that inspired remixer"
+      And I should see "A work in an unrevealed collection"
+      And I should not see "inspiration"
+    When I go to inspiration's related works page
+    Then I should not see "Works inspired by inspiration"
+      And I should not see "A work in an unrevealed collection"
+      And I should not see "Followup"
+
+  Scenario: When a translation is anonymous, it's visible on the original creator's related works page, but not on the translator's related works page
+    Given an anonymous collection "Anonymous"
+      And I have related works setup
+      And I post a translation as translator
+    When I am logged in as "translator"
+      And I add the work "Worldbuilding Translated" to the collection "Anonymous"
+      And I go to translator's related works page
+    Then I should see "Works translated by translator"
+      And I should see "Worldbuilding by inspiration"
+      And I should see "From English to Deutsch"
+    When I go to inspiration's related works page
+    Then I should see "Translations of inspiration's works"
+      And I should see "Worldbuilding Translated by Anonymous [translator]"
+      And I should see "From English to Deutsch"
+    When I am logged in as "inspiration"
+      And I go to translator's related works page
+    Then I should not see "Works translated by translator"
+      And I should not see "Worldbuilding by inspiration"
+      And I should not see "From English to Deutsch"
+    When I go to inspiration's related works page
+    Then I should see "Translations of inspiration's works"
+      And I should see "Worldbuilding Translated by Anonymous"
+      And I should see "From English to Deutsch"
+      And I should not see "translator"
+
+  Scenario: When a translation is unrevealed, it's visible on the original creator's related works page, but not on the translator's related works page
+    Given a hidden collection "Hidden"
+      And I have related works setup
+      And I post a translation as translator
+    When I am logged in as "translator"
+      And I add the work "Worldbuilding Translated" to the collection "Hidden"
+      And I go to translator's related works page
+    Then I should see "Works translated by translator"
+      And I should see "Worldbuilding by inspiration"
+      And I should see "From English to Deutsch"
+    When I go to inspiration's related works page
+    Then I should see "Translations of inspiration's works"
+      And I should see "A work in an unrevealed collection"
+    When I am logged in as "inspiration"
+      And I go to translator's related works page
+    Then I should not see "Works translated by translator"
+      And I should not see "Worldbuilding by inspiration"
+      And I should not see "From English to Deutsch"
+    When I go to inspiration's related works page
+    Then I should see "Translations of inspiration's works"
+      And I should see "A work in an unrevealed collection"
+      And I should not see "translator"
+
+  Scenario: A translation of an anonymous work is shown on the translator's related works page, but not on the original creator's related works page
+    Given an anonymous collection "Anonymous"
+      And I have related works setup
+      And I post a translation as translator
+    When I am logged in as "inspiration"
+      And I add the work "Worldbuilding" to the collection "Anonymous"
+      And I go to translator's related works page
+    Then I should see "Works translated by translator"
+      And I should see "Worldbuilding by Anonymous [inspiration]"
+      And I should see "From English to Deutsch"
+    When I go to inspiration's related works page
+    Then I should see "Translations of inspiration's works"
+      And I should see "Worldbuilding Translated by translator"
+      And I should see "From English to Deutsch"
+    When I am logged in as "translator"
+      And I go to translator's related works page
+    Then I should see "Works translated by translator"
+      And I should see "Worldbuilding by Anonymous"
+      And I should see "From English to Deutsch"
+      And I should not see "inspiration"
+    When I go to inspiration's related works page
+    Then I should not see "Translations of inspiration's works"
+      And I should not see "Worldbuilding Translated by translator"
+      And I should not see "From English to Deutsch"
+
+  Scenario: A translation of an unrevealed work is shown on the translator's related works page, but not on the original creator's related works page
+    Given a hidden collection "Hidden"
+      And I have related works setup
+      And I post a translation as translator
+    When I am logged in as "inspiration"
+      And I add the work "Worldbuilding" to the collection "Hidden"
+      And I go to translator's related works page
+    Then I should see "Works translated by translator"
+      And I should see "A work in an unrevealed collection"
+      And I should see "From English to Deutsch"
+    When I go to inspiration's related works page
+    Then I should see "Translations of inspiration's works"
+      And I should see "Worldbuilding Translated by translator"
+      And I should see "From English to Deutsch"
+    When I am logged in as "translator"
+      And I go to translator's related works page
+    Then I should see "Works translated by translator"
+      And I should see "A work in an unrevealed collection"
+      And I should see "From English to Deutsch"
+      And I should not see "inspiration"
+    When I go to inspiration's related works page
+    Then I should not see "Translations of inspiration's works"
+      And I should not see "A work in an unrevealed collection"
+      And I should not see "Worldbuilding Translated by translator"
+      And I should not see "From English to Deutsch"


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5357

## Purpose

Modify the related works page so that it no longer displays anonymous/unrevealed remixes on the remixer's related works page, and no longer displays remixes inspired by an anonymous/unrelated work on the original creator's related works page. (The same also holds for translations.)

Since I was in the area, I also made a few other changes to the `related_works/index` template:
- Omitted `html_safe` on all of the titles, since that's unnecessary for both [works](https://github.com/otwcode/otwarchive/blob/5333e396ca4be8238d40369d8533789bda6843dd/app/models/work.rb#L74-L77) and [external works](https://github.com/otwcode/otwarchive/blob/5333e396ca4be8238d40369d8533789bda6843dd/app/models/external_work.rb#L49-L52).
- Changed the phrasing from "A work in an unrevealed challenge" to "A work in an unrevealed collection," as suggested in [AO3-3929](https://otwarchive.atlassian.net/browse/AO3-3929). (Though that's the only part of that issue I tackled.)
- Changed two links with `method: :delete` to use `button_to`, to support browsers with JS disabled. [The redirect after clicking the button is still broken, but that's a separate issue.](https://otwarchive.atlassian.net/browse/AO3-2151)