### PR TITLE
AO3-6057 Make Persian (Farsi, fa) a right-to-left language

### DIFF
--- a/app/helpers/language_helper.rb
+++ b/app/helpers/language_helper.rb
@@ -1,14 +1,16 @@
+RTL_LOCALES = %w[ar fa he].freeze
+
 module LanguageHelper
   def available_faq_locales
     ArchiveFaq.translated_locales.map { |code| Locale.find_by(iso: code) }
   end
 
   def rtl?
-    %w(ar he).include?(Globalize.locale.to_s)
+    RTL_LOCALES.include?(Globalize.locale.to_s)
   end
 
   def rtl_language?(language)
-    %w(ar he).include?(language.short)
+    RTL_LOCALES.include?(language.short)
   end
 
   def english?

--- a/features/admins/admin_post_news.feature
+++ b/features/admins/admin_post_news.feature
@@ -196,3 +196,17 @@ Feature: Admin Actions to Post News
       And I follow "Delete"
     When I go to the homepage
     Then I should not see "Default Admin Post"
+
+  Scenario: Log in as an admin and create an admin post in a rtl (right-to-left) language
+    Given I am logged in as a "communications" admin
+      And Persian language
+    When I follow "Admin Posts"
+      And I follow "Post AO3 News"
+      Then I should see "New AO3 News Post"
+    When I fill in "admin_post_title" with "فارسی"
+      And I fill in "content" with "چیزهایی هست که باید در حین ایجاد یک گزارش از آنها آگاه باشید"
+      And I select "Persian" from "Choose a language"
+      And I press "Post"
+    Then I should see "Admin Post was successfully created."
+      And I should see "باشید" within "div.admin.home div.userstuff"
+      And the user content should be shown as right-to-left

--- a/features/step_definitions/admin_steps.rb
+++ b/features/step_definitions/admin_steps.rb
@@ -48,6 +48,12 @@ Given /^basic languages$/ do
   Locale.create(iso: "de", name: "Deutsch", language: german)
 end
 
+Given /^Persian language$/ do
+  Language.default
+  persian = Language.find_or_create_by(short: "fa", name: "Persian", support_available: true, abuse_support_available: true)
+  Locale.create(iso: "fa", name: "Persian", language: persian)
+end
+
 Given /^downloads are off$/ do
   step("I am logged in as a super admin")
   visit(admin_settings_path)
@@ -434,4 +440,8 @@ end
 Then /^the work "([^\"]*)" should not be marked as spam/ do |work|
   w = Work.find_by_title(work)
   assert !w.spam?
+end
+
+Then /^the user content should be shown as right-to-left$/ do
+  page.should have_xpath("//div[contains(@class, 'userstuff') and @dir='rtl']")
 end


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [x] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [x] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [x] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-6057

## Purpose

This PR adds support for showing the Persian language as a right-to-left language in admin posts.

## Testing Instructions

Follow the original reprodction steps [in the ticket](https://otwarchive.atlassian.net/browse/AO3-6057), i.e.:

- sign in as a communications admin
- create the Persian language and locale
- create a new post in the Persian language

You should see the admin post shown in right-to-left layout:

![image](https://user-images.githubusercontent.com/12255914/95091151-00df9c80-071e-11eb-8585-edf4805123e1.png)

instead of the current layout, which is left-to-right:

![image](https://user-images.githubusercontent.com/12255914/95091208-148b0300-071e-11eb-9f4f-6d97b6c54160.png)


## References

N/A

## Credit

*What name do you want us to use to credit your work in the [Archive of Our Own's Release Notes](https://archiveofourown.org/admin_posts?tag=1)?*

Tom Milligan

*What pronouns do you prefer (she/her, he/him, zie/hir etc)?*

they/them
