### PR TITLE
AO3-5950 Set "do not track" parameter and update homepage Twitter widget

### DIFF
--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -50,7 +50,7 @@
 
   <div class="latest tweets module">
     <h3 class="heading"><%= ts('Tweets') %></h3>
-    <a class="twitter-timeline" href="https://twitter.com/otw_status/lists/otw-tweets" data-dnt="true" data-height="600"> <%= ts('Tweets from https://twitter.com/otw_status/lists/otw-tweets') %></a>
+    <a class="twitter-timeline" href="https://twitter.com/otw_status/lists/otw-tweets" data-dnt="true" data-height="600"><%= ts('Tweets from https://twitter.com/otw_status/lists/otw-tweets') %></a>
     <script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+"://platform.twitter.com/widgets.js";fjs.parentNode.insertBefore(js,fjs);}}(document,"script","twitter-wjs");</script>
   </div>
 </div>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -50,7 +50,7 @@
 
   <div class="latest tweets module">
     <h3 class="heading"><%= ts('Tweets') %></h3>
-    <a class="twitter-timeline" href="https://twitter.com/otw_status/lists/otw-tweets"><%= ts('Tweets from https://twitter.com/otw_status/lists/otw-tweets') %></a>
+    <a class="twitter-timeline" href="https://twitter.com/otw_status/lists/otw-tweets"> data-dnt="true"<%= ts('Tweets from https://twitter.com/otw_status/lists/otw-tweets') %></a>
     <script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+"://platform.twitter.com/widgets.js";fjs.parentNode.insertBefore(js,fjs);}}(document,"script","twitter-wjs");</script>
   </div>
 </div>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -50,7 +50,7 @@
 
   <div class="latest tweets module">
     <h3 class="heading"><%= ts('Tweets') %></h3>
-    <a class="twitter-timeline" href="https://twitter.com/otw_status/lists/otw-tweets"> data-dnt="true" data-height="600"<%= ts('Tweets from https://twitter.com/otw_status/lists/otw-tweets') %></a>
+    <a class="twitter-timeline" href="https://twitter.com/otw_status/lists/otw-tweets" data-dnt="true" data-height="600"> <%= ts('Tweets from https://twitter.com/otw_status/lists/otw-tweets') %></a>
     <script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+"://platform.twitter.com/widgets.js";fjs.parentNode.insertBefore(js,fjs);}}(document,"script","twitter-wjs");</script>
   </div>
 </div>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -50,7 +50,7 @@
 
   <div class="latest tweets module">
     <h3 class="heading"><%= ts('Tweets') %></h3>
-    <a class="twitter-timeline" href="https://twitter.com/otw_status/lists/otw-tweets"> data-dnt="true"<%= ts('Tweets from https://twitter.com/otw_status/lists/otw-tweets') %></a>
+    <a class="twitter-timeline" href="https://twitter.com/otw_status/lists/otw-tweets"> data-dnt="true" data-height="600"<%= ts('Tweets from https://twitter.com/otw_status/lists/otw-tweets') %></a>
     <script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+"://platform.twitter.com/widgets.js";fjs.parentNode.insertBefore(js,fjs);}}(document,"script","twitter-wjs");</script>
   </div>
 </div>


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5950

## Purpose

The Twitter timeline widget on the home page currently doesn't have the "Do Not Track" parameter set, and takes up way too much space on the page due to a missing `data-height` attribute. This PR fixes both issues by adding the `data-dnt="true"` attribute and setting the widget's height to the previous default of 600 pixels.

## Testing Instructions

Check if the widget is displaying normally again (with a reasonable height). As mentioned on the Jira issue, there's not much of a way to see if the DNT parameter works as intended, but we can at least check if the cookies set by Twitter are different.

## Credit

Alix R, she/her