### PR TITLE
AO3-6063 Fix indexing works with no stat counter.

### DIFF
--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -1200,15 +1200,8 @@ class Work < ApplicationRecord
     approved_collections.pluck(:id, :parent_id).flatten.uniq.compact
   end
 
-  def comments_count
-    self.stat_counter.comments_count
-  end
-  def kudos_count
-    self.stat_counter.kudos_count
-  end
-  def bookmarks_count
-    self.stat_counter.bookmarks_count
-  end
+  delegate :comments_count, :kudos_count, :bookmarks_count,
+           to: :stat_counter, allow_nil: true
 
   def hits
     stat_counter&.hit_count

--- a/spec/models/search/work_indexer_spec.rb
+++ b/spec/models/search/work_indexer_spec.rb
@@ -1,0 +1,16 @@
+require "spec_helper"
+
+describe WorkIndexer, work_search: true do
+  describe "#index_documents" do
+    let(:work) { create(:work) }
+    let(:indexer) { WorkIndexer.new([work.id]) }
+
+    context "when a work in the batch has no stat_counter" do
+      before { work.stat_counter.delete }
+
+      it "doesn't error" do
+        expect { indexer.index_documents }.not_to raise_exception
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6063

## Purpose

Modifies `comments_count`, `kudos_count`, and `bookmarks_count` so that they don't error if you call them on a work with no `stat_counter`. The stat counter should only be deleted when the work is deleted, but the stat counter is loaded after the work is, so it's not guaranteed to be available when indexing the work.

Even if we wrapped indexing in a transaction to try to get a consistent database view, the transaction isolation level is currently set at `READ COMMITTED`, so if the transaction deleting the work finishes after the work is loaded but before its stat counter is loaded, you'd still end up with a work with no stat counter. The only way to avoid errors is to lock the work during indexing so that it can't be deleted during that period, or rewrite the code to handle a nil `stat_counter`. I chose the latter approach.