### PR TITLE
AO3-5987 Fix hover and focus styling on social media share links

### DIFF
--- a/public/stylesheets/sandbox.css
+++ b/public/stylesheets/sandbox.css
@@ -44,9 +44,11 @@ a.resp-sharing-button__link,
   display: inline-block
 }
 
-a.resp-sharing-button__link {
+a.resp-sharing-button__link,
+a.resp-sharing-button__link:hover {
   text-decoration: none;
   color: #fff;
+  border: none;
 }
 
 .resp-sharing-button {

--- a/public/stylesheets/sandbox.css
+++ b/public/stylesheets/sandbox.css
@@ -55,7 +55,6 @@ a.resp-sharing-button__link:hover {
   border-radius: 5px;
   transition: 25ms ease-out;
   padding: 0.5em 0.75em;
-  font-family: Helvetica Neue, Helvetica, Arial, sans-serif;
 }
 
 .resp-sharing-button__icon svg {
@@ -81,7 +80,7 @@ a.resp-sharing-button__link:hover {
   background-color: #55acee;
 }
 
-.resp-sharing-button--twitter:hover, .resp-sharing-button--twitter:focus {
+.resp-sharing-button--twitter:hover, a:focus .resp-sharing-button--twitter {
   background-color: #2795e9;
 }
 
@@ -89,7 +88,7 @@ a.resp-sharing-button__link:hover {
   background-color: #35465C;
 }
 
-.resp-sharing-button--tumblr:hover, .resp-sharing-button--tumblr:focus {
+.resp-sharing-button--tumblr:hover, a:focus .resp-sharing-button--tumblr {
   background-color: #222d3c;
 }
 

--- a/public/stylesheets/sandbox.css
+++ b/public/stylesheets/sandbox.css
@@ -41,7 +41,7 @@ and preserve the balance/symmetry of the page */
 
 a.resp-sharing-button__link,
 .resp-sharing-button__icon {
-  display: inline-block
+  display: inline-block;
 }
 
 a.resp-sharing-button__link,
@@ -55,7 +55,7 @@ a.resp-sharing-button__link:hover {
   border-radius: 5px;
   transition: 25ms ease-out;
   padding: 0.5em 0.75em;
-  font-family: Helvetica Neue,Helvetica,Arial,sans-serif
+  font-family: Helvetica Neue, Helvetica, Arial, sans-serif;
 }
 
 .resp-sharing-button__icon svg {
@@ -68,30 +68,29 @@ a.resp-sharing-button__link:hover {
 /* Non solid icons get a stroke */
 .resp-sharing-button__icon {
   stroke: #fff;
-  fill: none
+  fill: none;
 }
 
 /* Solid icons get a fill */
-.resp-sharing-button__icon--solid,
-.resp-sharing-button__icon--solidcircle {
+.resp-sharing-button__icon--solid {
   fill: #fff;
-  stroke: none
+  stroke: none;
 }
 
 .resp-sharing-button--twitter {
-  background-color: #55acee
+  background-color: #55acee;
 }
 
-.resp-sharing-button--twitter:hover {
-  background-color: #2795e9
+.resp-sharing-button--twitter:hover, .resp-sharing-button--twitter:focus {
+  background-color: #2795e9;
 }
 
 .resp-sharing-button--tumblr {
-  background-color: #35465C
+  background-color: #35465C;
 }
 
-.resp-sharing-button--tumblr:hover {
-  background-color: #222d3c
+.resp-sharing-button--tumblr:hover, .resp-sharing-button--tumblr:focus {
+  background-color: #222d3c;
 }
 
 .resp-sharing-button--twitter {


### PR DESCRIPTION
# Issue

https://otwarchive.atlassian.net/browse/AO3-5987

## Purpose

* Remove unwanted border and dark text when hovering on visited share links
* Make sure the share link background color changes on keyboard focus
* Use our default font on the share buttons
* Do a little cleanup to make the CSS match our code style

Some day in the future, we should clean up all the various class names here to actually match our system -- then we can move it out of the sandbox file. I lack the enthusiasm to do that at the moment, though.

## Testing Instructions

For focus styles:
* Click inside the text area with the share HTML
* Press your keyboard's Tab key to move to the Twitter link, and then press it again to move to the Tumblr link
* The background colors of the links should change, just like they do when you hover

For the visited share links:
* Follow the Twitter share link to open Twitter's compose tweet screen in a new tab/window
* Close that tab/window and return to the tab/window where you have the share box open
* Hover over the Twitter share link again
* It should not have a black border on the bottom or black text
