### PR TITLE
AO3-6048 Add pwgen to Dockerfile

### DIFF
--- a/config/docker/Dockerfile
+++ b/config/docker/Dockerfile
@@ -6,6 +6,7 @@ RUN apt-get update             && \
         calibre                   \
         default-mysql-client      \
         phantomjs                 \
+        pwgen                     \
         wkhtmltopdf               \
         zip
 


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [x] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [x] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [x] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-6048

## Purpose

Adds pwgen to the Dockerfile so we can create test users for development without needing to install any extra dependencies.  Take 2, without including lint dependencies which didn't work last time.  This is really a developer convenience change (environment setup).

## Testing Instructions

Development setup only:
1. Build the docker environment
2. Create a new admin user without installing pwgen first

## References

The original failed attempt that including lint dependencies:
https://github.com/otwcode/otwarchive/pull/3895

## Credit

tlee911 (they/them)
