### PR TITLE
AO3-6068 Load default skin in rake task

### DIFF
--- a/lib/tasks/skin_tasks.rake
+++ b/lib/tasks/skin_tasks.rake
@@ -149,8 +149,7 @@ namespace :skins do
   desc "Load site skins"
   task(:load_site_skins => :environment) do
     settings = AdminSetting.first
-    if settings.default_skin_id.nil?
-      settings.update(default_skin_id: Skin.default.id, last_updated_by: Admin.first.id)
+    settings.update(default_skin_id: Skin.default.id, last_updated_by: Admin.first.id) if settings.default_skin_id.nil?
     end
     
     Skin.load_site_css

--- a/lib/tasks/skin_tasks.rake
+++ b/lib/tasks/skin_tasks.rake
@@ -150,8 +150,6 @@ namespace :skins do
   task(:load_site_skins => :environment) do
     settings = AdminSetting.first
     settings.update(default_skin_id: Skin.default.id, last_updated_by: Admin.first.id) if settings.default_skin_id.nil?
-    end
-    
     Skin.load_site_css
     Skin.set_default_to_current_version
   end

--- a/lib/tasks/skin_tasks.rake
+++ b/lib/tasks/skin_tasks.rake
@@ -148,6 +148,11 @@ namespace :skins do
 
   desc "Load site skins"
   task(:load_site_skins => :environment) do
+    settings = AdminSetting.first
+    if settings.default_skin_id.nil?
+      settings.update(default_skin_id: Skin.default.id, last_updated_by: Admin.first.id)
+    end
+    
     Skin.load_site_css
     Skin.set_default_to_current_version
   end

--- a/lib/tasks/skin_tasks.rake
+++ b/lib/tasks/skin_tasks.rake
@@ -149,7 +149,10 @@ namespace :skins do
   desc "Load site skins"
   task(:load_site_skins => :environment) do
     settings = AdminSetting.first
-    settings.update(default_skin_id: Skin.default.id, last_updated_by: Admin.first.id) if settings.default_skin_id.nil?
+    if settings.default_skin_id.nil?
+      settings.default_skin_id = Skin.default.id
+      settings.save(validate: false)
+    end
     Skin.load_site_css
     Skin.set_default_to_current_version
   end


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [x] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [x] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [x] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-6068

## Purpose

Fixes new installations (dev environments) to correctly load the default site skin so that CSS is available.

## Testing Instructions

On a development environment:
1. Run reset_database.sh
2. Visit any page
3. Verify CSS is present and default site skin is used

## References

https://otwarchive.atlassian.net/browse/AO3-6051

## Credit

tlee911 (they/them)
Also @tickinginstant proposed this cleaner implementation over my hackery