### PR TITLE
AO3-6071 Set sortable_name when manually configuring environment locale

### DIFF
--- a/config/initializers/archive_config/locale.rb
+++ b/config/initializers/archive_config/locale.rb
@@ -10,7 +10,7 @@ rescue ActiveRecord::ConnectionNotEstablished
 rescue
   # ArchiveConfig didn't work, try to set it manually
   if Language.table_exists? && Locale.table_exists?
-    language = Language.find_or_create_by(short: 'en', name: 'English')
+    language = Language.find_or_create_by(short: "en", name: "English", sortable_name: "English")
     Locale.set_base_locale(iso: "en", name: "English (US)", language_id: language.id)
   end
 end


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6071

## Purpose

Sets a sortable_name when manually configuring the environment locale. 

## Testing Instructions

Uh. A dev could probably comment out the preceding lines in the file and then try running `bundle exec rake db:migrate RAILS_ENV=test`?

