### PR TITLE
AO3-6083 Use HTML5 data- attributes for custom autocomplete attributes

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -99,7 +99,7 @@ module ApplicationHelper
   def byline(creation, options={})
     if creation.respond_to?(:anonymous?) && creation.anonymous?
       anon_byline = ts("Anonymous").html_safe
-      if options[:visibility] != "public" && (logged_in_as_admin? || is_author_of?(creation)) 
+      if options[:visibility] != "public" && (logged_in_as_admin? || is_author_of?(creation))
         anon_byline += " [#{non_anonymous_byline(creation, options[:only_path])}]".html_safe
       end
       return anon_byline
@@ -298,12 +298,14 @@ module ApplicationHelper
   def autocomplete_options(method, options={})
     {
       class: "autocomplete",
-      autocomplete_method: (method.is_a?(Array) ? method.to_json : "/autocomplete/#{method}"),
-      autocomplete_hint_text: ts("Start typing for suggestions!"),
-      autocomplete_no_results_text: ts("(No suggestions found)"),
-      autocomplete_min_chars: 1,
-      autocomplete_searching_text: ts("Searching...")
-    }.merge(options)
+      data: {
+        autocomplete_method: (method.is_a?(Array) ? method.to_json : "/autocomplete/#{method}"),
+        autocomplete_hint_text: ts("Start typing for suggestions!"),
+        autocomplete_no_results_text: ts("(No suggestions found)"),
+        autocomplete_min_chars: 1,
+        autocomplete_searching_text: ts("Searching...")
+      }
+    }.deep_merge(options)
   end
 
   # see http://asciicasts.com/episodes/197-nested-model-form-part-2

--- a/app/views/admin/skins/index_approved.html.erb
+++ b/app/views/admin/skins/index_approved.html.erb
@@ -86,7 +86,7 @@
     <p class="note"><%= ts("This will change the default skin FOR ALL USERS! Don't use unless you are REALLY SURE.") %></p>
     <p>
       <%= label_tag "set_default", ts("Default Skin Title: ") %>
-      <%= text_field_tag "set_default", AdminSetting.default_skin.try(:title), autocomplete_options("site_skins", :autocomplete_token_limit => 1) %>
+      <%= text_field_tag "set_default", AdminSetting.default_skin.try(:title), autocomplete_options("site_skins", data: { autocomplete_token_limit: 1 }) %>
       <%= hidden_field_tag :last_updated_by, current_admin.id %>
     </p>
   </fieldset>

--- a/app/views/admin_posts/_admin_post_form.html.erb
+++ b/app/views/admin_posts/_admin_post_form.html.erb
@@ -53,7 +53,7 @@
           <%= f.text_field :translated_post_id,
           autocomplete_options('admin_posts', 
                           title: ts('translation of'),
-                          autocomplete_token_limit: 1) %>
+                          data: { autocomplete_token_limit: 1 }) %>
         </dd>
       </dl>
     </fieldset>

--- a/app/views/bookmarks/_external_work_fields.html.erb
+++ b/app/views/bookmarks/_external_work_fields.html.erb
@@ -4,9 +4,9 @@
     <dt class="required"><%= ew.label :url, ts('URL') + '*' %></dt>
     <dd class="required" title="URL">
       <% if !params[:url_from_external].blank? %>
-        <%= ew.text_field :url, autocomplete_options('external_work', :autocomplete_token_limit => 1, :value => params[:url_from_external]) %>
+        <%= ew.text_field :url, autocomplete_options('external_work', data: { autocomplete_token_limit: 1 }, value: params[:url_from_external]) %>
       <% else %>
-        <%= ew.text_field :url, autocomplete_options('external_work', :autocomplete_token_limit => 1) %>
+        <%= ew.text_field :url, autocomplete_options('external_work', data: { autocomplete_token_limit: 1 }) %>
       <% end %>
       <%= hidden_field "fetched", "", :id => "fetched" %>
       <%= content_for :footer_js do %>
@@ -86,13 +86,13 @@
       <%= ew.label :relationship_string, Relationship::NAME.pluralize %> <%= link_to_help "relationships-help" %>
     </dt>
     <dd title="relationships">
-      <%= ew.text_field :relationship_string, autocomplete_options('relationship_in_fandom', :autocomplete_live_params => 'fandom=bookmark_external_fandom_string') %>
+      <%= ew.text_field :relationship_string, autocomplete_options('relationship_in_fandom', data: { autocomplete_live_params: "fandom=bookmark_external_fandom_string" }) %>
     </dd>
     <dt>
       <%= ew.label :character_string, Character::NAME.pluralize %> <%= link_to_help "characters-help" %>
     </dt>
     <dd title="characters">
-      <%= ew.text_field :character_string, autocomplete_options('character_in_fandom', :autocomplete_live_params => 'fandom=bookmark_external_fandom_string') %>
+      <%= ew.text_field :character_string, autocomplete_options('character_in_fandom', data: { autocomplete_live_params: "fandom=bookmark_external_fandom_string" }) %>
     </dd>
   </dl>
 </fieldset>

--- a/app/views/challenge_assignments/_maintainer_index_defaulted.html.erb
+++ b/app/views/challenge_assignments/_maintainer_index_defaulted.html.erb
@@ -15,7 +15,7 @@
      <%= label_tag "undefault_#{assignment.id}", :class => 'action' do %>
         <%= ts("Undefault") %> <%= assignment.offer_byline %>  <%= check_box_tag "undefault_#{assignment.id}" %>
       <% end %>
-       <label class="autocomplete substitute" title="<%= ts('choose pinch hitter') %>"><%= ts("Pinch Hitter:") %> <%= text_field_tag "cover_#{assignment.id}", nil, autocomplete_options("pseud", :autocomplete_token_limit => 1) %></label>
+       <label class="autocomplete substitute" title="<%= ts('choose pinch hitter') %>"><%= ts("Pinch Hitter:") %> <%= text_field_tag "cover_#{assignment.id}", nil, autocomplete_options("pseud", data: { autocomplete_token_limit: 1 }) %></label>
     </dd>
 
   <% end %>

--- a/app/views/collections/_filters.html.erb
+++ b/app/views/collections/_filters.html.erb
@@ -34,7 +34,7 @@
         <%= text_field_tag "collection_filters[title]",
             params[:collection_filters][:title],
             autocomplete_options("collection_fullname",
-              autocomplete_token_limit: 1) %>
+              data: { autocomplete_token_limit: 1 }) %>
       </dd>
       <dt class="autocomplete search">
         <%= label_tag "collection_filters_fandom", ts("Filter by fandom") %>
@@ -42,7 +42,7 @@
       <dd class="autocomplete search">
         <%= text_field_tag "collection_filters[fandom]",
             params[:collection_filters][:fandom],
-            autocomplete_options("fandom", autocomplete_token_limit: 1) %>
+            autocomplete_options("fandom", data: { autocomplete_token_limit: 1 }) %>
       </dd>
       <dt><%= ts("Closed") %></dt>
       <dd>

--- a/app/views/collections/_form.html.erb
+++ b/app/views/collections/_form.html.erb
@@ -44,7 +44,7 @@
           <%= collection_form.label :parent_name, ts("Parent collection (that you maintain)") %>
         </dt>
         <dd>
-          <%= collection_form.text_field :parent_name, autocomplete_options("collection_parent_name", :autocomplete_token_limit => 1) %>
+          <%= collection_form.text_field :parent_name, autocomplete_options("collection_parent_name", data: { autocomplete_token_limit: 1 }) %>
         </dd>
       <% end %>
 

--- a/app/views/potential_matches/_assignment_with_request.html.erb
+++ b/app/views/potential_matches/_assignment_with_request.html.erb
@@ -11,7 +11,7 @@
       <% if offer_signup %>
         <% # offer an autocomplete of potential matches %>
         <%= assignment_form.text_field :request_signup_pseud, autocomplete_options("potential_requests?signup_id=#{offer_signup.id}", 
-          :autocomplete_min_chars => 0, :autocomplete_token_limit => 1, :size => ArchiveConfig.POTENTIAL_MATCHES_MAX) %>
+          data: { autocomplete_min_chars: 0, autocomplete_token_limit: 1 }, size: ArchiveConfig.POTENTIAL_MATCHES_MAX) %>
       <% else %>
         <%= request_signup.pseud.byline %>
       <% end %>
@@ -21,7 +21,7 @@
       <% if request_signup %>
         <% # offer an autocomplete of potential matches %>
         <%= assignment_form.text_field :offer_signup_pseud, autocomplete_options("potential_offers?signup_id=#{request_signup.id}", 
-          :autocomplete_min_chars => 0, :autocomplete_token_limit => 1, :size => ArchiveConfig.POTENTIAL_MATCHES_MAX) %>
+          data: { autocomplete_min_chars: 0, autocomplete_token_limit: 1 }, size: ArchiveConfig.POTENTIAL_MATCHES_MAX) %>
       <% else %>
         <%= offer_signup.pseud.byline %>
       <% end %>
@@ -29,7 +29,7 @@
     
     <% unless params[:no_recipient] %>
       <td><!--BACK END this td should probably be titled, but what with?-->
-        <%= assignment_form.text_field :pinch_hitter_byline, autocomplete_options("pseud", :autocomplete_token_limit => 1, :size => 20) %>
+        <%= assignment_form.text_field :pinch_hitter_byline, autocomplete_options("pseud", data: { autocomplete_token_limit: 1 }, size: 20) %>
       </td>
     <% end %>
   </tr>

--- a/app/views/prompts/_prompt_form_tag_options.html.erb
+++ b/app/views/prompts/_prompt_form_tag_options.html.erb
@@ -54,10 +54,14 @@
         <% autocomplete_method += "&include_wrangled=false" if restriction.restricted?(tag_type, "tag_set") %>
         <dd title="<%= ts("choose #{tag_name.pluralize.downcase} from your selected fandoms") %>">
           <%= tag_set_form.text_field "#{tag_type}_tagnames",
-                            autocomplete_options(autocomplete_method, :autocomplete_min_chars => 0, :autocomplete_token_limit => num_allowed,
-                                    :autocomplete_hint_text => ts("Please select a fandom first!"),
-                                    :autocomplete_searching_text => ts("Searching by fandom..."),
-                                    :autocomplete_live_params => "fandom=#{@fandom_tag_id}") %>
+                            autocomplete_options(autocomplete_method, 
+                              data: {
+                                autocomplete_min_chars: 0,
+                                autocomplete_token_limit: num_allowed,
+                                autocomplete_hint_text: ts("Please select a fandom first!"),
+                                autocomplete_searching_text: ts("Searching by fandom..."),
+                                autocomplete_live_params: "fandom=#{@fandom_tag_id}"
+                            }) %>
           <%= tag_set_form.hidden_field :updated_at, :value => Time.now %>
         </dd>
       <% else # all other cases %>
@@ -80,7 +84,8 @@
           <% else # we have set options but too many for tickyboxes, do autocomplete instead %>
             <dd title="<%= ts("choose #{tag_name.pluralize.downcase} from the challenge options") %>">
               <%= tag_set_form.text_field "#{tag_type}_tagnames",
-                  autocomplete_options("tags_in_sets?tag_type=#{tag_type}&tag_set=#{restriction.tag_set_ids.join(',')}", :autocomplete_token_limit => num_allowed) %>
+                  autocomplete_options("tags_in_sets?tag_type=#{tag_type}&tag_set=#{restriction.tag_set_ids.join(',')}",
+                    data: { autocomplete_token_limit: num_allowed }) %>
               <p class="actions" role="button">
                 <% # TODO: would be nice to improve this for the case of multiple tag sets, currently it links to just an index of all the tag sets for this challenge %>
                 <%= link_to( ts("List %{taglist_size} %{tag_name}", :taglist_size => restriction.tags(tag_type).count, :tag_name => tag_name.pluralize.titleize),
@@ -91,7 +96,7 @@
           <% end %>
         <% else # no specified tags so let's just go with standard autocomplete %>
           <dd title="<%= ts("choose #{tag_name.pluralize.downcase} from canonical archive tags") %>">
-            <%= tag_set_form.text_field "#{tag_type}_tagnames", autocomplete_options(tag_type, :autocomplete_token_limit => num_allowed) %>
+            <%= tag_set_form.text_field "#{tag_type}_tagnames", autocomplete_options(tag_type, data: { autocomplete_token_limit: num_allowed }) %>
             <%= tag_set_form.hidden_field :updated_at, :value => Time.now %>
           </dd>
         <% end %>

--- a/app/views/skins/_skin_parent_fields.html.erb
+++ b/app/views/skins/_skin_parent_fields.html.erb
@@ -5,7 +5,7 @@
       <span class="actions cancel" title="<%= ts('cancel')%>"><%= link_to_remove_section ts('x'), form %></span>
       <%= ts('Parent #') %><%= form.text_field :position, :class => 'number', :value => (form.object.position || index), :title => ts('position of parent as integer') %>
     </p>
-    <%= form.text_field :parent_skin_title, autocomplete_options('site_skins', :autocomplete_token_limit => 1, :title => ts('title of parent skin')) %>
+    <%= form.text_field :parent_skin_title, autocomplete_options('site_skins', data: { autocomplete_token_limit: 1 }, title: ts('title of parent skin')) %>
   </fieldset>
 </li>
 <li class="last_id" style="display:none;"><%= index.is_a?(String) ? index : index + 1 %></li>

--- a/app/views/tag_set_nominations/_review_individual_nom.html.erb
+++ b/app/views/tag_set_nominations/_review_individual_nom.html.erb
@@ -25,7 +25,7 @@
       <% end %>
     </dd>
 
-    <dd class="autocomplete"><%= text_field_tag "#{tag_type}_change_#{tagname}", nil, autocomplete_options("tag?type=#{tag_type}", :autocomplete_token_limit => 1, :title => "change tag name") %></dd>
+    <dd class="autocomplete"><%= text_field_tag "#{tag_type}_change_#{tagname}", nil, autocomplete_options("tag?type=#{tag_type}", data: { autocomplete_token_limit: 1 }, title: "change tag name") %></dd>
 
 
     <% if nom.synonym %>

--- a/app/views/tag_set_nominations/_tag_nominations.html.erb
+++ b/app/views/tag_set_nominations/_tag_nominations.html.erb
@@ -10,7 +10,7 @@
           <% else %>
 
             <div title="<%= ts("%{tag_type} %{index}", tag_type: tag_type_label_name(tag_type), index: index + 1) %>">
-              <%= nom_form.text_field :tagname, autocomplete_options(tag_type, :autocomplete_token_limit => 1) %>
+              <%= nom_form.text_field :tagname, autocomplete_options(tag_type, data: { autocomplete_token_limit: 1 }) %>
             </div>
           <% end %>
         </dd>
@@ -22,7 +22,7 @@
               <% @past_first = true %>
             <% end %>
           </dt>
-          <dd title="<%= ts("which fandom?") %>"><%= nom_form.text_field :parent_tagname, autocomplete_options("fandom", :autocomplete_token_limit => 1) %></dd>
+          <dd title="<%= ts("which fandom?") %>"><%= nom_form.text_field :parent_tagname, autocomplete_options("fandom", data: { autocomplete_token_limit: 1 }) %></dd>
         <% end %>
 
       <% end %>

--- a/app/views/tag_set_nominations/_tag_nominations_by_fandom.html.erb
+++ b/app/views/tag_set_nominations/_tag_nominations_by_fandom.html.erb
@@ -8,7 +8,7 @@
           <% if nom.approved || nom.rejected %>
             <%= nom.tagname %>  <%= nomination_status(nom) %>
           <% else %>
-            <div title="<%= ts("Fandom %{index}") %>"><%= nom_form.text_field :tagname, autocomplete_options("fandom", :autocomplete_token_limit => 1, :class => "autocomplete") %></div>
+            <div title="<%= ts("Fandom %{index}") %>"><%= nom_form.text_field :tagname, autocomplete_options("fandom", data: { autocomplete_token_limit: 1 }, class: "autocomplete") %></div>
           <% end %>
         </dd>
 
@@ -22,8 +22,11 @@
                   <%= nom_form2.object.tagname %> <%= nomination_status(nom_form2.object) %>
                 <% else %>
                   <div title="<%= ts("%{tag_type}", tag_type: tag_type_label_name(tag_type)) %>"> <%= nom_form2.text_field :tagname,
-                            autocomplete_options("#{tag_type}_in_fandom", :autocomplete_token_limit => 1,
-                            :autocomplete_live_params => "fandom=tag_set_nomination_fandom_nominations_attributes_#{index}_tagname") %></div>
+                            autocomplete_options("#{tag_type}_in_fandom",
+                              data: {
+                                autocomplete_token_limit: 1,
+                                autocomplete_live_params: "fandom=tag_set_nomination_fandom_nominations_attributes_#{index}_tagname"
+                            }) %></div>
                 <% end %>
                 <%= nom_form2.hidden_field :from_fandom_nomination, :value => true %>
               </dd>

--- a/app/views/tags/edit.html.erb
+++ b/app/views/tags/edit.html.erb
@@ -90,7 +90,8 @@
         <dd>
           <%= f.text_field :syn_string,
                 autocomplete_options("tag?type=#{@tag.type.downcase}",
-                class: "autocomplete tags", autocomplete_token_limit: 1) %>
+                class: "autocomplete tags",
+                data: { autocomplete_token_limit: 1 }) %>
           <p>
             <%= ts("Choose an existing tag or add a new tag name here to create a new canonical and make this tag its synonym.") %>
           </p>
@@ -136,7 +137,7 @@
             <% if @parents[tag_type].present? %>
               <h4 class="heading"><%= ts("Check to remove:") %></h4>
               <%= check_all_none("All", "None", tag_type) %>
-              <%= checkbox_section(f, "associations_to_remove", @parents[tag_type], 
+              <%= checkbox_section(f, "associations_to_remove", @parents[tag_type],
                     name_helper_method: "remove_tag_association_label",
                     extra_info_method: "link_to_edit_tag",
                     field_id: "parent_#{tag_type}_associations_to_remove",

--- a/app/views/works/_work_form_pseuds.html.erb
+++ b/app/views/works/_work_form_pseuds.html.erb
@@ -20,4 +20,4 @@
 <% end %>
 
 <dt><%= form.label :pseuds_to_add, ts("Add Co-Creators") %></dt>
-<dd><%= form.text_field :pseuds_to_add, autocomplete_options("pseud", autocomplete_min_chars: 0) %></dd>
+<dd><%= form.text_field :pseuds_to_add, autocomplete_options("pseud", data: { autocomplete_min_chars: 0 }) %></dd>

--- a/app/views/works/_work_form_tags.html.erb
+++ b/app/views/works/_work_form_tags.html.erb
@@ -75,9 +75,9 @@
     <dd class="relationship" title="<%= ts('relationships') %>">
       <%= text_field_tag "work[relationship_string]", include_blank ? "" : @work.relationship_string, 
                          autocomplete_options("relationship_in_fandom",
-                           :id => "work_relationship",
-                           :title => ts('relationships'),
-                           :autocomplete_live_params => 'fandom=work_fandom') %>
+                           id: "work_relationship",
+                           title: ts('relationships'),
+                           data: { autocomplete_live_params: "fandom=work_fandom" }) %>
     </dd>
 
     <dt class="character" title="<%= ts('characters') %>">
@@ -87,9 +87,9 @@
     <dd class="character" title="<%= ts('characters') %>">
       <%= text_field_tag "work[character_string]", include_blank ? "" : @work.character_string, 
                         autocomplete_options('character_in_fandom', 
-                          :id => "work_character",
-                          :title => ts('characters'),
-                          :autocomplete_live_params => 'fandom=work_fandom') %>
+                          id: "work_character",
+                          title: ts('characters'),
+                          data: { autocomplete_live_params: "fandom=work_fandom" }) %>
     </dd>
 
     <dt class="freeform" title="<%= ts('additional tags') %>">

--- a/public/javascripts/application.js
+++ b/public/javascripts/application.js
@@ -36,15 +36,15 @@ $j(document).ready(function() {
 
 function get_token_input_options(self) {
   return {
-    searchingText: self.attr('autocomplete_searching_text'),
-    hintText: self.attr('autocomplete_hint_text'),
-    noResultsText: self.attr('autocomplete_no_results_text'),
-    minChars: self.attr('autocomplete_min_chars'),
+    searchingText: self.data('autocomplete-searching-text'),
+    hintText: self.data('autocomplete-hint-text'),
+    noResultsText: self.data('autocomplete-no-results-text'),
+    minChars: self.data('autocomplete-min-chars'),
     queryParam: "term",
     preventDuplicates: true,
-    tokenLimit: self.attr('autocomplete_token_limit'),
-    liveParams: self.attr('autocomplete_live_params'),
-    makeSortable: self.attr('autocomplete_sortable')
+    tokenLimit: self.data('autocomplete-token-limit'),
+    liveParams: self.data('autocomplete-live-params'),
+    makeSortable: self.data('autocomplete-sortable')
   };
 }
 
@@ -58,9 +58,9 @@ if (input.livequery) {
       var token_input_options = get_token_input_options(self);
       var method;
       try {
-          method = $.parseJSON(self.attr('autocomplete_method'));
+          method = $.parseJSON(self.data('autocomplete-method'));
       } catch (err) {
-          method = self.attr('autocomplete_method');
+          method = self.data('autocomplete-method');
       }
       self.tokenInput(method, token_input_options);
     });


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6083

## Purpose

Keeps part of the wanted changes from #3698, which I have now separated out into their own issue like I should've done in the first place.

* Uses HTML5 `data-*` attributes for the autocomplete's custom attributes. This means we don't get as many validation errors on our HTML now. 🎉

## Testing Instructions

Refer to Jira.

## References

Initially part of #3698 for [AO3-3306](https://otwarchive.atlassian.net/browse/AO3-3306).
