### PR TITLE
AO3-6082 Use colors in test logs and max concurrent jobs in GitHub Actions

### DIFF
--- a/.github/workflows/automated-tests.yml
+++ b/.github/workflows/automated-tests.yml
@@ -19,6 +19,7 @@ jobs:
       TEST_GROUP: ${{ matrix.tests.command }}
       CUCUMBER_RETRY: 1
       CUCUMBER_FORMAT: Ao3Cucumber::Formatter
+      SPEC_OPTS: --force-color
 
     services:
       database:

--- a/.github/workflows/automated-tests.yml
+++ b/.github/workflows/automated-tests.yml
@@ -41,7 +41,6 @@ jobs:
           - 11211:11211
 
     strategy:
-      max-parallel: 5
       fail-fast: false
       matrix:
         tests:

--- a/ACKNOWLEDGMENTS.md
+++ b/ACKNOWLEDGMENTS.md
@@ -20,10 +20,8 @@ Acknowledgments
 <p><a href="https://www.percona.com/software/mysql-database/percona-xtradb-cluster"><img alt="" valign="middle" src="http://media.archiveofourown.org/ao3/logos/logo_percona_xtradbcluster_new.png" width="200"/> Percona XtraDB Cluster</a> for our relational database.</p>
 <p><a href="http://rubyonrails.org/"><img alt="" valign="middle" src="http://media.archiveofourown.org/ao3/logos/rails.png" width="200"/> Rails</a> for our framework.</p>
 <p><a href="https://redis.io/"><img alt="" valign="middle" src="http://media.archiveofourown.org/ao3/logos/Redis_Logo.svg" width="200"/> Redis</a> for NoSQL.</p>
-<p><a href="http://rspec.info/"><img alt="" valign="middle" src="http://media.archiveofourown.org/ao3/logos/rspec.png" width="200"/> Rspec</a> for unit tests.</p>
+<p><a href="http://rspec.info/"><img alt="" valign="middle" src="http://media.archiveofourown.org/ao3/logos/rspec.png" width="200"/> RSpec</a> for unit tests.</p>
 <p><a href="https://www.ruby-lang.org/en/"><img alt="" valign="middle" src="http://media.archiveofourown.org/ao3/logos/ruby.png" width="200"/> Ruby</a> as our language.</p>
 <p><a href="https://www.jetbrains.com/ruby/"><img alt="" valign="middle" src="http://media.archiveofourown.org/ao3/logos/logo_RubyMine.svg" width="200"/> RubyMine</a> for our integrated development environment.</p>
 <p><a href="https://slack.com/"><img alt="" valign="middle" src="http://media.archiveofourown.org/ao3/logos/Slack_RGB.svg" width="200"/> Slack</a> for communications.</p>
-<p><a href="https://travis-ci.com/"><img alt="" valign="middle" src="http://media.archiveofourown.org/ao3/logos/TravisCI-Full-Color-45e242791b7752b745a7ae53f265acd4.png" width="200"/> Travis</a> for continuous integration.</p>
 <p><a href="https://www.vagrantup.com/"><img alt="" valign="middle" src="http://media.archiveofourown.org/ao3/logos/logo_wide-56017ded.png" width="200"/> Vagrant</a> for our development environment.</p>
-

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 OTW-Archive
 =========
-[![Build Status](https://img.shields.io/travis/com/otwcode/otwarchive/master?label=travis-ci)](https://travis-ci.com/github/otwcode/otwarchive) [![Codeship Status](https://img.shields.io/codeship/1f7468f0-7e15-0131-c059-7a8d26daf885/master.svg?label=codeship)](https://www.codeship.io/projects/14476) [![Coverage Status](https://img.shields.io/codecov/c/github/otwcode/otwarchive/master.svg)](https://codecov.io/gh/otwcode/otwarchive/branch/master)
+[![Build Status](https://img.shields.io/github/workflow/status/otwcode/otwarchive/Automated%20Tests/master)](https://github.com/otwcode/otwarchive/actions?query=workflow%3A%22Automated+Tests%22+branch%3Amaster) [![Codeship Status](https://img.shields.io/codeship/1f7468f0-7e15-0131-c059-7a8d26daf885/master.svg?label=codeship)](https://www.codeship.io/projects/14476) [![Coverage Status](https://img.shields.io/codecov/c/github/otwcode/otwarchive/master.svg)](https://codecov.io/gh/otwcode/otwarchive/branch/master)
 
 The OTW-Archive software is an open-source web application intended for hosting archives of fanworks, including fanfic, fanart, and fan vids.
 
@@ -27,7 +27,6 @@ The Archive code is licensed under [GPL](https://www.gnu.org/licenses/gpl-2.0.ht
 We benefit from software and services that are free to use for Open Source projects, including:
 
 * [RubyMine IDE](https://www.jetbrains.com/ruby/) by JetBrains
-* [Travis CI](https://travis-ci.org/)
 * [Codeship](https://codeship.com/)
 * [Hound](https://houndci.com/) by [thoughtbot](https://thoughtbot.com/)
 * [BrowserStack](https://www.browserstack.com)

--- a/config/cucumber.yml
+++ b/config/cucumber.yml
@@ -3,7 +3,7 @@ rerun = File.file?('rerun.txt') ? IO.read('rerun.txt') : ""
 rerun = rerun.strip.gsub /\s/, ' '
 rerun_opts = rerun.empty? ? "--format #{ENV['CUCUMBER_FORMAT'] || 'progress'} features" : "--format #{ENV['CUCUMBER_FORMAT'] || 'pretty'} #{rerun}"
 retry_opts = "--retry #{ENV['CUCUMBER_RETRY'] || '0'} --no-strict-flaky"
-std_opts = "--format #{ENV['CUCUMBER_FORMAT'] || 'pretty'} --strict --tags 'not @wip' #{retry_opts}"
+std_opts = "--format #{ENV['CUCUMBER_FORMAT'] || 'pretty'} --strict --tags 'not @wip' #{retry_opts} --color"
 %>
 default: <%= std_opts %> features
 wip: --tags @wip:3 --wip features

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -141,8 +141,6 @@ RSpec.configure do |config|
     metadata[:type] = :task
   end
 
-  # Set default formatter to print out the description of each test as it runs
-  config.color = true
   config.formatter = :documentation
 
   config.file_fixture_path = "spec/support/fixtures"


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6082

## Purpose

- Update README and build status badge.
- Use all available concurrent jobs.
- Use colors for RSpec and Cucumber output in GitHub Actions.
  - By default, both RSpec and Cucumber will print colors only if the output is TTY (as opposed to e.g. files), but [the default environment of GitHub Actions does not identify itself as running within a TTY enabled device](https://github.community/t/ansi-color-output-in-webview/17621). So we need to use options to force color in output. For RSpec, it's easy to do that just in CI by setting SPEC_OPTS. For Cucumber, I just do that in the default profile, instead of adding logic to check if we're running in CI.
  - Also remove the deprecated "color" option of RSpec.