### PR TITLE
AO3-6090 Finish TODOs from dropping the anon_commenting_disabled column from the works table.

### DIFF
--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -692,20 +692,6 @@ class WorksController < ApplicationController
     # To avoid overwriting, we entirely trash any blank fields.
     updated_work_params = work_params.reject { |_key, value| value.blank? }
 
-    # It takes around 1 hour to restart all the workers when deploying, so the
-    # old code and the new code need to co-exist. The old Edit Multiple Works
-    # form used to use special values instead of the value "0", so the new
-    # WorksController needs to know how to handle those values.
-    #
-    # TODO: Delete this after AO3-6016 is deployed.
-    if updated_work_params[:moderated_commenting_enabled] == 'not_moderated'
-      updated_work_params[:moderated_commenting_enabled] = '0'
-    end
-
-    if updated_work_params[:restricted] == 'unrestricted'
-      updated_work_params[:restricted] = '0'
-    end
-
     @works.each do |work|
       # now we can just update each work independently, woo!
       unless work.update_attributes(updated_work_params)

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -1,7 +1,4 @@
 class Work < ApplicationRecord
-  # TODO: Remove this after AO3-6016 is deployed.
-  self.ignored_columns = [:anon_commenting_disabled]
-
   include Filterable
   include CreationNotifier
   include Collectible

--- a/spec/controllers/works/multiple_actions_spec.rb
+++ b/spec/controllers/works/multiple_actions_spec.rb
@@ -104,7 +104,7 @@ describe WorksController do
         {
           work: {
             comment_permissions: "enable_all",
-            moderated_commenting_enabled: "not_moderated"
+            moderated_commenting_enabled: "0"
           }
         }
       }


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6090

## Purpose

Finish off the TODOs from #3885, which drops the `anon_commenting_disabled` column from the works table.

We temporarily added `anon_commenting_disabled` to the list of `ignored_columns` (to try to avoid 500 errors during the migration). Once AO3-6016 has been deployed and the migration has been run, we need to remove it again, which is the purpose of this PR.

In addition, this PR deletes some extra code used for backwards-compatibility with the old Edit Multiple Works form.