### PR TITLE
AO3-6091 Changes to the CollectionParticipantsController.

### DIFF
--- a/app/controllers/collection_participants_controller.rb
+++ b/app/controllers/collection_participants_controller.rb
@@ -21,11 +21,10 @@ class CollectionParticipantsController < ApplicationController
   end
 
   def load_participant_and_collection
+    @participant = CollectionParticipant.find_by(id: params[:id])
+
     if params[:collection_participant]
-      @participant = CollectionParticipant.find_by(id: collection_participant_params[:id])
       @new_role = collection_participant_params[:participant_role]
-    else
-      @participant = CollectionParticipant.find_by(id: params[:id])
     end
 
     no_participant and return unless @participant
@@ -139,9 +138,6 @@ class CollectionParticipantsController < ApplicationController
   private
 
   def collection_participant_params
-    params.require(:collection_participant).permit(
-      :id, :participant_role, :collection_id
-    )
+    params.require(:collection_participant).permit(:participant_role)
   end
-
 end

--- a/app/controllers/collection_participants_controller.rb
+++ b/app/controllers/collection_participants_controller.rb
@@ -1,11 +1,11 @@
 class CollectionParticipantsController < ApplicationController
+  before_action :users_only
   before_action :load_collection
-  before_action :load_participant_and_collection, only: [:update, :destroy]
+  before_action :load_participant, only: [:update, :destroy]
   before_action :allowed_to_promote, only: [:update]
   before_action :allowed_to_destroy, only: [:destroy]
   before_action :has_other_owners, only: [:update, :destroy]
   before_action :collection_maintainers_only, only: [:index, :add, :update]
-  before_action :users_only, only: [:join]
 
   cache_sweeper :collection_sweeper
 
@@ -15,23 +15,16 @@ class CollectionParticipantsController < ApplicationController
     false
   end
 
-  def no_participant
-    flash[:error] = t('no_participant', default: "Which participant did you want to work with?")
-    redirect_to root_path
+  def load_collection
+    @collection = Collection.find_by!(name: params[:collection_id])
   end
 
-  def load_participant_and_collection
-    @participant = CollectionParticipant.find_by(id: params[:id])
-
-    if params[:collection_participant]
-      @new_role = collection_participant_params[:participant_role]
-    end
-
-    no_participant and return unless @participant
-    @collection = @participant.collection
+  def load_participant
+    @participant = @collection.collection_participants.find(params[:id])
   end
 
   def allowed_to_promote
+    @new_role = collection_participant_params[:participant_role]
     @participant.user_allowed_to_promote?(current_user, @new_role) || not_allowed(@collection)
   end
 

--- a/app/views/collection_participants/_participant_form.html.erb
+++ b/app/views/collection_participants/_participant_form.html.erb
@@ -2,17 +2,17 @@
 
 <% if participant %>
 <li id="participant_<%= participant.id %>">
-  <%= form_for(participant, :as => :collection_participant, :url => {:controller => "collection_participants", :action => "update"}) do |form| %>
-    <span class="byline"><%= link_to participant.pseud.byline, user_path(participant.pseud.user) %><%= form.hidden_field :id %><%= form.hidden_field :collection_id %></span>
+  <%= form_for(participant, url: collection_participant_path(@collection, participant), as: :collection_participant) do |form| %>
+    <span class="byline"><%= link_to participant.pseud.byline, user_path(participant.pseud.user) %></span>
 
   <ul class="actions" role="menu">
-      <li title="select role"><%= form.select(:participant_role, CollectionParticipant::PARTICIPANT_ROLE_OPTIONS, {}, :id => participant.pseud.user.login + "_role") %></li>
-      <li><%= form.submit ts("Update"), :id => participant.pseud.user.login + "_submit" %></li>
+      <li title="select role"><%= form.select(:participant_role, CollectionParticipant::PARTICIPANT_ROLE_OPTIONS, {}, id: participant.pseud.user.login + "_role") %></li>
+      <li><%= form.submit ts("Update"), id: participant.pseud.user.login + "_submit" %></li>
   <% end %>
       <li><%= button_to ts("Remove"), collection_participant_path(@collection, participant),
-    data: {confirm: ts('Are you certain you want to remove %{participant}?',
-              :participant => participant.pseud.name)}, 
-              :method => :delete %>
+                        data: { confirm: ts('Are you certain you want to remove %{participant}?',
+                                            participant: participant.pseud.name) },
+                        method: :delete %>
       </li>
   </ul>
 </li>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -407,11 +407,10 @@ Otwarchive::Application.routes.draw do
     resources :tags do
       resources :works
     end
-    resources :participants, controller: "collection_participants" do
+    resources :participants, controller: "collection_participants", only: [:index, :update, :destroy] do
       collection do
         get :add
         get :join
-        patch :update
       end
     end
     resources :items, controller: "collection_items" do

--- a/spec/controllers/collection_participants_controller_spec.rb
+++ b/spec/controllers/collection_participants_controller_spec.rb
@@ -155,7 +155,7 @@ describe CollectionParticipantsController do
         id: id_to_update,
         collection_id: collection.name,
         collection_participant: {
-          participant_role:  CollectionParticipant::MEMBER
+          participant_role: CollectionParticipant::MEMBER
         }
       }
     end

--- a/spec/controllers/collection_participants_controller_spec.rb
+++ b/spec/controllers/collection_participants_controller_spec.rb
@@ -5,10 +5,13 @@ describe CollectionParticipantsController do
   include LoginMacros
   include RedirectExpectationHelper
 
+  let(:user) { create(:user) }
+  let(:collection) { create(:collection) }
+
   describe "join" do
     context "where user isn't logged in" do
       it "redirects to new user session with error" do
-        get :join, params: { collection_id: 1 }
+        get :join, params: { collection_id: collection.name }
         it_redirects_to_with_error(new_user_session_path,
                                    "Sorry, you don't have permission to access the page"\
                                    " you were trying to reach. Please log in.")
@@ -16,39 +19,24 @@ describe CollectionParticipantsController do
     end
 
     context "where the user is logged in" do
-      let(:user) { FactoryBot.create(:user) }
-
       before do
         fake_login_known_user(user)
       end
 
       context "where there is no collection" do
-        it "redirects to index and displays an error" do
-          get :join, params: { collection_id: 0 }
-          it_redirects_to_with_error(root_path,
-                                     "Which collection did you want to join?")
-        end
-
-        context "where the HTTP_REFERER is set" do
-          before do
-            request.env["HTTP_REFERER"] = collections_path
-          end
-
-          it "navigates back to the previously viewed page" do
+        it "raises a RecordNotFound error" do
+          expect do
             get :join, params: { collection_id: 0 }
-            it_redirects_to_with_error(collections_path,
-                                       "Which collection did you want to join?")
-          end
+          end.to raise_exception(ActiveRecord::RecordNotFound)
         end
       end
 
       context "where there is a collection" do
-        let(:collection) { FactoryBot.create(:collection) }
         let(:current_role) { CollectionParticipant::NONE }
 
         context "where the user is already a participant" do
           let!(:participant) do
-            FactoryBot.create(
+            create(
               :collection_participant,
               collection: collection,
               pseud: user.default_pseud,
@@ -91,9 +79,7 @@ describe CollectionParticipantsController do
   end
 
   describe "index" do
-    let(:collection) { FactoryBot.create(:collection) }
     let(:current_role) { CollectionParticipant::NONE }
-    let(:user) { FactoryBot.create(:user) }
 
     context "user is not logged in" do
       it "redirects to the index and displays an access denied message" do
@@ -104,7 +90,7 @@ describe CollectionParticipantsController do
 
     context "user is logged in" do
       let!(:participant) do
-        FactoryBot.create(
+        create(
           :collection_participant,
           collection: collection,
           pseud: user.default_pseud,
@@ -131,8 +117,8 @@ describe CollectionParticipantsController do
         context "where the collection has several participants" do
           let!(:users) do
             Array.new(3) do
-              user = FactoryBot.create(:user)
-              FactoryBot.create(
+              user = create(:user)
+              create(
                 :collection_participant,
                 collection: collection,
                 pseud: user.default_pseud
@@ -154,11 +140,9 @@ describe CollectionParticipantsController do
   end
 
   describe "update" do
-    let(:user) { FactoryBot.create(:user) }
-    let(:collection) { FactoryBot.create(:collection) }
     let(:user_role) { CollectionParticipant::NONE }
     let!(:user_participant) do
-      FactoryBot.create(
+      create(
         :collection_participant,
         pseud: user.default_pseud,
         collection: collection,
@@ -181,25 +165,37 @@ describe CollectionParticipantsController do
     end
 
     context "where there is no participant" do
-      it "displays an error and redirects to the index" do
-        put :update, params: params
-        it_redirects_to_with_error(root_path, "Which participant did you want to work with?")
+      it "raises a RecordNotFound error" do
+        expect do
+          put :update, params: params
+        end.to raise_exception(ActiveRecord::RecordNotFound)
       end
     end
 
     context "where there is a participant" do
       let(:participant) do
-        FactoryBot.create(
+        create(
           :collection_participant,
           collection: user_participant.collection,
           participant_role: CollectionParticipant::NONE
         )
       end
       let(:id_to_update) { participant.id }
+
       context "where the user is not a collection maintainer" do
         it "redirects to the collection page and displays an error" do
           put :update, params: params
           it_redirects_to_with_error(collection_path(collection), "Sorry, you're not allowed to do that.")
+        end
+      end
+
+      context "when the participant is from another collection" do
+        let(:id_to_update) { create(:collection_participant).id }
+
+        it "raises a RecordNotFound error" do
+          expect do
+            put :update, params: params
+          end.to raise_exception(ActiveRecord::RecordNotFound)
         end
       end
 
@@ -227,12 +223,10 @@ describe CollectionParticipantsController do
   end
 
   describe "destroy" do
-    let(:user) { FactoryBot.create(:user) }
     let(:pseud_name) { user.default_pseud.name }
-    let(:collection) { FactoryBot.create(:collection) }
     let(:user_participant_role) { CollectionParticipant::MEMBER }
     let!(:user_participant) do
-      FactoryBot.create(
+      create(
         :collection_participant,
         pseud: user.default_pseud,
         collection: collection,
@@ -240,19 +234,20 @@ describe CollectionParticipantsController do
       )
     end
     let(:params) do
-      { id: user_participant.id, collection_id: collection.id }
+      { id: user_participant.id, collection_id: collection.name }
     end
 
     before do
       fake_login_known_user(user)
     end
 
-    context "where there is no participant found" do
-      let(:params) { { id: 0, collection_id: create(:collection).id } }
+    context "where there is no participant" do
+      let(:params) { { id: 0, collection_id: collection.name } }
 
-      it "displays an error and redirects to the index" do
-        delete :destroy, params: params
-        it_redirects_to_with_error(root_path, "Which participant did you want to work with?")
+      it "raises a RecordNotFound error" do
+        expect do
+          delete :destroy, params: params
+        end.to raise_exception(ActiveRecord::RecordNotFound)
       end
     end
 
@@ -266,16 +261,24 @@ describe CollectionParticipantsController do
           end
         end
 
+        context "when the participant is from another collection" do
+          it "raises a RecordNotFound error" do
+            expect do
+              put :update, params: { id: create(:collection_participant).id, collection_id: collection.name }
+            end.to raise_exception(ActiveRecord::RecordNotFound)
+          end
+        end
+
         context "where the user is trying to destroy another participant" do
           let(:other_participant) do
-            FactoryBot.create(
+            create(
               :collection_participant,
               collection: collection,
               participant_role: CollectionParticipant::MEMBER
             )
           end
           let(:pseud_name) { other_participant.pseud.name }
-          let(:params) { { id: other_participant.id, collection_id: collection.id } }
+          let(:params) { { id: other_participant.id, collection_id: collection.name } }
 
           it "doesn't allow the destroy and redirects to the collection page" do
             delete :destroy, params: params
@@ -287,9 +290,8 @@ describe CollectionParticipantsController do
 
       context "where user is a maintainer" do
         let(:user_participant_role) { CollectionParticipant::MODERATOR }
-        let(:collection) { FactoryBot.create(:collection) }
         let(:other_participant) do
-          FactoryBot.create(
+          create(
             :collection_participant,
             collection: collection,
             participant_role: CollectionParticipant::MEMBER
@@ -297,7 +299,7 @@ describe CollectionParticipantsController do
         end
         let(:pseud_name) { other_participant.pseud.name }
         let(:params) do
-          { id: other_participant.id, collection_id: collection.id }
+          { id: other_participant.id, collection_id: collection.name }
         end
 
         context "where participant to be destroyed is not an owner" do
@@ -310,7 +312,7 @@ describe CollectionParticipantsController do
 
         context "where participant to be destroyed is an owner" do
           let(:delete_participant_id) { CollectionParticipant.find_by(pseud_id: collection.owners.first.id) }
-          let(:params) { { id: delete_participant_id, collection_id: collection.id } }
+          let(:params) { { id: delete_participant_id, collection_id: collection.name } }
 
           context "where there are no other owners" do
             it "displays an error and redirects to the collection participants path" do
@@ -323,7 +325,7 @@ describe CollectionParticipantsController do
           context "where there are other owners" do
             let!(:pseud_name) { CollectionParticipant.find(delete_participant_id.id).pseud.name }
             let!(:other_owner) do
-              FactoryBot.create(
+              create(
                 :collection_participant,
                 collection: collection,
                 participant_role: CollectionParticipant::OWNER
@@ -342,8 +344,6 @@ describe CollectionParticipantsController do
   end
 
   describe "add" do
-    let(:user) { FactoryBot.create(:user) }
-    let(:collection) { FactoryBot.create(:collection) }
     let(:participants_to_invite) { "" }
     let!(:params) do
       {
@@ -353,7 +353,7 @@ describe CollectionParticipantsController do
     end
     let(:user_participant_role) { CollectionParticipant::MEMBER }
     let!(:user_participant) do
-      FactoryBot.create(
+      create(
         :collection_participant,
         pseud: user.default_pseud,
         collection: collection,
@@ -375,7 +375,7 @@ describe CollectionParticipantsController do
     context "where the user is a maintainer" do
       let(:user_participant_role) { CollectionParticipant:: MODERATOR }
       let(:banned) { false }
-      let(:users) { Array.new(3) { FactoryBot.create(:user, banned: banned) } }
+      let(:users) { Array.new(3) { create(:user, banned: banned) } }
       let(:participants_to_invite) do
         users.map(&:default_pseud).map(&:byline).map(&:to_s).join(",")
       end
@@ -383,7 +383,7 @@ describe CollectionParticipantsController do
       context "where users to be added have already applied to the collection" do
         let!(:participants) do
           users.each do |user|
-            FactoryBot.create(
+            create(
               :collection_participant,
               collection: collection,
               pseud: user.default_pseud,

--- a/spec/controllers/collection_participants_controller_spec.rb
+++ b/spec/controllers/collection_participants_controller_spec.rb
@@ -165,13 +165,13 @@ describe CollectionParticipantsController do
         participant_role: user_role
       )
     end
-    let(:id_to_update) { nil }
+    let(:id_to_update) { "" }
     let(:params) do
       {
-        collection_id: collection.id,
+        id: id_to_update,
+        collection_id: collection.name,
         collection_participant: {
-          participant_role:  CollectionParticipant::MEMBER,
-          id: id_to_update
+          participant_role:  CollectionParticipant::MEMBER
         }
       }
     end


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6091

## Purpose

This PR removes the unnecessary `collection_id` and `id` from the parameters in `collection_participant_params`. This makes the `update` action behave more like a normal nested resource (retrieving `id` from the URL).

I also modified the controller to use `find` and `find_by!` instead of `find_by`, so that it generates a 404 error instead of setting a flash message and redirecting when the collection or participant is invalid.