### PR TITLE
AO3-6025 Change wording in Open Doors emails

### DIFF
--- a/app/views/user_mailer/claim_notification.html.erb
+++ b/app/views/user_mailer/claim_notification.html.erb
@@ -28,7 +28,7 @@
 
   <p>For other inquiries, please <%= support_link('contact Support') %>.</p>
 
-  <p>If you're contacting us, please whitelist email addresses from @transformativeworks.org and check your spam folders for our reply.</p>
+  <p>If you're contacting us, please add email addresses from @transformativeworks.org to your list of safe contacts and check your spam folders for our reply.</p>
 
   <p>Best,<br/>
     The Open Doors team<br/>

--- a/app/views/user_mailer/claim_notification.text.erb
+++ b/app/views/user_mailer/claim_notification.text.erb
@@ -22,7 +22,7 @@
 
   For other inquiries, please contact Support at <%= root_url %>support.
 
-  If you're contacting us, please whitelist email addresses from @transformativeworks.org and check your spam folders for our reply.
+  If you're contacting us, please add email addresses from @transformativeworks.org to your list of safe contacts and check your spam folders for our reply.
 
   Best,
   The Open Doors team

--- a/config/locales/mailers/en.yml
+++ b/config/locales/mailers/en.yml
@@ -178,7 +178,7 @@ en:
 
       part6: "The works uploaded include:"
       part8: "To preserve rec lists and bookmarks, the imported archive's web addresses may redirect to the imported copy of these works for a limited time (check the announcement post for your archive to be sure). If you've already uploaded a copy of these works and you did NOT use the import from URL feature, there will be two copies of the same work on the archive."
-      part12: "If you're contacting us, please whitelist email addresses from @transformativeworks.org and check your spam folders for our reply."
+      part12: "If you're contacting us, please add email addresses from @transformativeworks.org to your list of safe contacts and check your spam folders for our reply."
       text:
         part1: "You're receiving this e-mail because an archive has recently been imported by Open Doors (%{open_doors_link}) into the %{app_name} (%{app_short_name} - %{app_url}), and we believe that the following fanworks belong to you. We'd like to give you a chance to claim (or delete/orphan) these works if you want to. And if you don't already have an account under a different e-mail, we'd like to invite you aboard!"
         part2: "You can read announcements about recent archive moves at AO3 News (%{news_link}), and find additional information on Open Doors' FAQ page (%{open_doors_faq_link}) or tutorials page (%{open_doors_tutorial_link}). For any questions not answered in the FAQ, tutorials, or this e-mail, please contact Support at %{support_link}."


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6025

## Purpose

Fixes confusing wording in the Open Doors "Invitation to claim works" and "Works uploaded" notification emails.

## Testing Instructions

See the Jira reproduction steps.

## Credit

Alix R, she/her