### PR TITLE
AO3-6066 Avoid errors when indexing batch is empty.

### DIFF
--- a/app/models/search/async_indexer.rb
+++ b/app/models/search/async_indexer.rb
@@ -10,6 +10,9 @@ class AsyncIndexer
     Rails.logger.info "Blueshirt: Logging use of constantize class self.perform #{name.split(":").first}"
     indexer = name.split(":").first.constantize
     ids = REDIS.smembers(name)
+
+    return if ids.empty?
+
     batch = indexer.new(ids).index_documents
     IndexSweeper.new(batch, indexer).process_batch
     REDIS.del(name)

--- a/app/models/search/index_sweeper.rb
+++ b/app/models/search/index_sweeper.rb
@@ -18,6 +18,8 @@ class IndexSweeper
   end
 
   def process_batch
+    return if @batch.nil?
+
     load_errors
 
     @batch["items"].each do |item|

--- a/app/models/search/indexer.rb
+++ b/app/models/search/indexer.rb
@@ -175,6 +175,8 @@ class Indexer
   end
 
   def batch
+    return @batch if @batch
+
     @batch = []
     ids.each do |id|
       object = objects[id.to_i]
@@ -189,7 +191,7 @@ class Indexer
   end
 
   def index_documents
-    return if (batch = self.batch).empty?
+    return if batch.empty?
 
     $elasticsearch.bulk(body: batch)
   end

--- a/app/models/search/indexer.rb
+++ b/app/models/search/indexer.rb
@@ -189,6 +189,8 @@ class Indexer
   end
 
   def index_documents
+    return if (batch = self.batch).empty?
+
     $elasticsearch.bulk(body: batch)
   end
 

--- a/app/models/search/stat_counter_indexer.rb
+++ b/app/models/search/stat_counter_indexer.rb
@@ -26,6 +26,8 @@ class StatCounterIndexer
   end
 
   def batch
+    return @batch if @batch
+
     @batch = []
     objects.each do |object|
       @batch << { update: routing_info(object) }
@@ -35,7 +37,7 @@ class StatCounterIndexer
   end
 
   def index_documents
-    return if (batch = self.batch).empty?
+    return if batch.empty?
 
     $elasticsearch.bulk(body: batch)
   end

--- a/app/models/search/stat_counter_indexer.rb
+++ b/app/models/search/stat_counter_indexer.rb
@@ -35,6 +35,8 @@ class StatCounterIndexer
   end
 
   def index_documents
+    return if (batch = self.batch).empty?
+
     $elasticsearch.bulk(body: batch)
   end
 

--- a/spec/models/search/async_indexer_spec.rb
+++ b/spec/models/search/async_indexer_spec.rb
@@ -1,7 +1,6 @@
 require 'spec_helper'
 
 describe AsyncIndexer do
-
   it "should enqueue ids" do
     tag = Tag.new
     tag.id = 34
@@ -78,6 +77,18 @@ describe AsyncIndexer do
       expect(permanent_store).to include(
         "99999-work" => { "an error" => "with a message" }
       )
+    end
+  end
+
+  context "when there are no IDs to index" do
+    before do
+      allow(AsyncIndexer::REDIS).to receive(:smembers).and_return([])
+    end
+
+    it "doesn't call the indexer" do
+      expect(WorkIndexer).not_to receive(:new)
+
+      AsyncIndexer.perform("WorkIndexer:34:#{Time.now.to_i}")
     end
   end
 end

--- a/spec/models/search/index_sweeper_spec.rb
+++ b/spec/models/search/index_sweeper_spec.rb
@@ -130,6 +130,11 @@ describe IndexSweeper do
     expect(sweeper.process_batch).to be(true)
   end
 
+  it "doesn't trigger an error if the batch results are empty" do
+    sweeper = IndexSweeper.new(nil, WorkIndexer)
+    expect { sweeper.process_batch }.not_to raise_exception
+  end
+
   private
 
   def batch(id = 53)

--- a/spec/models/search/stat_counter_indexer_spec.rb
+++ b/spec/models/search/stat_counter_indexer_spec.rb
@@ -56,5 +56,13 @@ describe StatCounterIndexer, work_search: true do
         WorkIndexer.refresh_index
       end.not_to change { result_count(title: "unique title") }
     end
+
+    context "when there are no IDs in the batch" do
+      let(:indexer) { WorkIndexer.new([]) }
+
+      it "returns a valid result" do
+        expect(indexer.index_documents).to be_nil
+      end
+    end
   end
 end

--- a/spec/models/search/work_indexer_spec.rb
+++ b/spec/models/search/work_indexer_spec.rb
@@ -3,13 +3,22 @@ require "spec_helper"
 describe WorkIndexer, work_search: true do
   describe "#index_documents" do
     let(:work) { create(:work) }
-    let(:indexer) { WorkIndexer.new([work.id]) }
 
     context "when a work in the batch has no stat_counter" do
+      let(:indexer) { WorkIndexer.new([work.id]) }
+
       before { work.stat_counter.delete }
 
       it "doesn't error" do
         expect { indexer.index_documents }.not_to raise_exception
+      end
+    end
+
+    context "when there are no IDs in the batch" do
+      let(:indexer) { WorkIndexer.new([]) }
+
+      it "returns nil" do
+        expect(indexer.index_documents).to be_nil
       end
     end
   end


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6066

## Purpose

Add a bunch of checks for blank/nil batches, so that we can avoid producing `BadRequest` errors whenever we try to index an empty batch.