### PR TITLE
AO3-6064 Avoid DelegationError when indexing pseuds with deleted users.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -198,3 +198,6 @@ Style/StringLiterals:
 
 Style/SymbolArray:
   Enabled: false
+
+Style/TernaryParentheses:
+  EnforcedStyle: require_parentheses_when_complex

--- a/app/models/pseud.rb
+++ b/app/models/pseud.rb
@@ -20,7 +20,10 @@ class Pseud < ApplicationRecord
   DESCRIPTION_MAX = 500
 
   belongs_to :user
-  delegate :login, to: :user, prefix: true
+
+  delegate :login, to: :user, prefix: true, allow_nil: true
+  alias user_name user_login
+
   has_many :bookmarks, dependent: :destroy
   has_many :recs, -> { where(rec: true) }, class_name: 'Bookmark'
   has_many :comments
@@ -123,11 +126,6 @@ class Pseud < ApplicationRecord
     (self.name.downcase <=> other.name.downcase) == 0 ? (self.user_name.downcase <=> other.user_name.downcase) : (self.name.downcase <=> other.name.downcase)
   end
 
-  # For use with the work and chapter forms
-  def user_name
-     self.user.login
-  end
-
   def to_param
     name
   end
@@ -214,7 +212,7 @@ class Pseud < ApplicationRecord
 
   # Produces a byline that indicates the user's name if pseud is not unique
   def byline
-    (name != user_name) ? name + " (" + user_name + ")" : name
+    (name != user_name) ? "#{name} (#{user_name})" : name
   end
 
   # get the former byline

--- a/spec/models/search/bookmark_indexer_spec.rb
+++ b/spec/models/search/bookmark_indexer_spec.rb
@@ -1,0 +1,16 @@
+require "spec_helper"
+
+describe BookmarkIndexer, bookmark_search: true do
+  describe "#index_documents" do
+    let(:bookmark) { create(:bookmark) }
+    let(:indexer) { BookmarkIndexer.new([bookmark.id]) }
+
+    context "when the bookmarker of one of the bookmarks has no user" do
+      before { bookmark.pseud.user.delete }
+
+      it "doesn't error" do
+        expect { indexer.index_documents }.not_to raise_exception
+      end
+    end
+  end
+end

--- a/spec/models/search/pseud_indexer_spec.rb
+++ b/spec/models/search/pseud_indexer_spec.rb
@@ -1,0 +1,16 @@
+require "spec_helper"
+
+describe PseudIndexer, pseud_search: true do
+  describe "#index_documents" do
+    let(:pseud) { create(:pseud) }
+    let(:indexer) { PseudIndexer.new([pseud.id]) }
+
+    context "when a pseud in the batch has no user" do
+      before { pseud.user.delete }
+
+      it "doesn't error" do
+        expect { indexer.index_documents }.not_to raise_exception
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6064

## Purpose

This PR modifies the `user_login` method of the pseud class so that it returns `nil` if there is no user.

It also modifies `byline` (and `user_name`, which is used by `byline`) so that we don't get an error when calling it on pseuds with deleted users, because `byline` is also included in the pseud document:
https://github.com/otwcode/otwarchive/blob/bedbbef8c43585d97b5a56062355921e4c8f5fa7/app/models/search/pseud_indexer.rb#L35-L45