### PR TITLE
AO3-4313 Display first posted chapter when Chapter 1 is a draft

### DIFF
--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -780,7 +780,11 @@ class WorksController < ApplicationController
   end
 
   def load_first_chapter
-    @chapter = @work.first_chapter
+    if current_user_owns?(@work)
+      @chapter = @work.first_chapter
+    else
+      @chapter = @work.chapters.in_order.posted.first
+    end
   end
 
   # Check whether we should display :new or :edit instead of previewing or

--- a/spec/requests/works_show_request_spec.rb
+++ b/spec/requests/works_show_request_spec.rb
@@ -1,0 +1,20 @@
+require "spec_helper"
+
+describe "Works#show", :type => :request do
+  let(:work) { create(:work) }
+  let(:chapter) { work.chapters.first }
+
+  context "when the first chapter of a work is unposted" do
+    before do
+      work.chapters.create(position: 1, posted: false, content: "Draft content")
+      chapter.update(position: 2)
+    end
+
+    it "displays the first posted chapter" do
+      get "/works/#{work.id}"
+      expect(response).to render_template(:show)
+      expect(response.body).to include(chapter.content)
+      expect(response.body).not_to include("Draft content")
+    end
+  end
+end


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-4313

## Purpose

Fixes issue with works that had a draft chapter set to Chapter 1.

## Testing Instructions

Described in issue: post a work, then add a draft chapter and set that to Chapter 1 of 2. When you access the work as a guest, you should see the existing posted chapter rather than an access denied message (or the draft).
