### PR TITLE
AO3-5909 Fix the confirmation message when deleting a skin

### DIFF
--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -140,4 +140,4 @@ en:
         description: "Try to recalculate inherited metatags. Use this option if this tag has grandparent metatags (i.e., a metatag with its own metatag), and the works aren't showing up in the grandparent's listing. You might also try this if you've removed a metatag, but the works are still showing up in the former metatag's listing. If the works still don't go away, ask a staffer to run \"Update Tag Filters\" on this tag."
   skins:
     confirm_delete:
-      confirm_html: Are you sure you want to <strong><em>delete</em></strong> the skin \"%{skin_title}\"?
+      confirm_html: Are you sure you want to <strong><em>delete</em></strong> the skin "%{skin_title}"?


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5909

## Purpose

The PR for this issue was broken on test due to what appears to have been a copy/paste error, this PR fixes the problem.

## Testing Instructions

When deleting a skin with JS disabled (check the Jira ticket for instructions), make sure the confirmation message says "Are you sure you want to **_delete_** the skin "(insert screen here)"?", with no backslashes.

## References

Fixes #3833.

## Credit

Alix R, she/her