### PR TITLE
AO3-3582 Fix scrolling when loading comments via AJAX

### DIFF
--- a/public/javascripts/application.js
+++ b/public/javascripts/application.js
@@ -475,7 +475,7 @@ $j(document).ready(function() {
   });
 
   // Scroll to the top of the comments section when loading additional pages via Ajax in comment pagination.
-  $j('#comments_placeholder').find('.pagination').on('click.rails', 'a[data-remote]', function(e){
+  $j('#comments_placeholder').on('click.rails', '.pagination a[data-remote]', function(e){
     $j.scrollTo('#comments_placeholder');
   });
 


### PR DESCRIPTION
# Pull Request Checklist

* [X] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [X] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [ ] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
   ^ N/A - I don't think this behavior can be tested with the current automated testing?
* [X] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [X] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-3582

## Purpose

This PR fixes scrolling when loading comments via AJAX. Previously, this was handled with Livequery; now that it's using jQuery directly, we need to take into account that `.pagination` doesn't exist on page load. Follow-up to https://github.com/otwcode/otwarchive/pull/3798 (which introduced the bug while upgrading the version of the Livequery plugin.)

## Testing Instructions

1. Visit a page with a large number of comments.
2. Press the "Show comments" button at the top of the page.
3. Scroll to the bottom of the page.
4. Press "next", "previous", or any page number.
5. Verify that you are scrolled to the top of the comments area, just above the pagination (i.e. NOT including the comment form.)

## References

https://github.com/otwcode/otwarchive/pull/3798

## Credit

*What name do you want us to use to credit your work in the [Archive of Our Own's Release Notes](https://archiveofourown.org/admin_posts?tag=1)?*

Stephen Burrows

*What pronouns do you prefer (she/her, he/him, zie/hir etc)?*

he/him
