### PR TITLE
AO3-6102 Prevent unwrangleable tags from being removed from fandom via fandom bins

### DIFF
--- a/app/models/common_tagging.rb
+++ b/app/models/common_tagging.rb
@@ -21,10 +21,11 @@ class CommonTagging < ApplicationRecord
   after_commit :update_search
 
   before_destroy :check_unwrangleable
-  # Check an unwrangleable tag has at least 1 fandom before destroying the link
+  # Check an unwrangleable tag has at least 1 fandom before destroying the association
   def check_unwrangleable
-    tag = Tag.find_by_id(common_tag)
-    return unless tag.unwrangleable && tag.parents.by_type("Fandom").size == 1
+    tag = Tag.find_by(id: common_tag)
+    return unless tag && tag.unwrangleable && tag.parents.by_type("Fandom").size == 1
+
     errors.add(:base, "Unwrangleable tag must have at least one fandom.")
     throw :abort
   end

--- a/app/models/common_tagging.rb
+++ b/app/models/common_tagging.rb
@@ -20,6 +20,15 @@ class CommonTagging < ApplicationRecord
 
   after_commit :update_search
 
+  before_destroy :check_unwrangleable
+  # Check an unwrangleable tag has at least 1 fandom before destroying the link
+  def check_unwrangleable
+    tag = Tag.find_by_id(common_tag)
+    return unless tag.unwrangleable && tag.parents.by_type("Fandom").size == 1
+    errors.add(:base, "Unwrangleable tag must have at least one fandom.")
+    throw :abort
+  end
+
   def update_wrangler
     unless User.current_user.nil?
       common_tag.update_attributes!(last_wrangler: User.current_user)

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -812,9 +812,11 @@ class Tag < ApplicationRecord
       # associations where self is parent
       common_taggings.where(filterable: tag).destroy_all
       return false if common_taggings.where(filterable: tag).any?
+
       # associations where self is child
       child_taggings.where(common_tag: tag).destroy_all
       return false if child_taggings.where(common_tag: tag).any?
+      
     end
 
     tag.touch

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -809,8 +809,12 @@ class Tag < ApplicationRecord
       meta_taggings.where(direct: true, meta_tag: tag).destroy_all
       sub_taggings.where(direct: true, sub_tag: tag).destroy_all
     else
+      # associations where self is parent
       common_taggings.where(filterable: tag).destroy_all
+      return false if common_taggings.where(filterable: tag).any?
+      # associations where self is child
       child_taggings.where(common_tag: tag).destroy_all
+      return false if child_taggings.where(common_tag: tag).any?
     end
 
     tag.touch

--- a/app/views/tags/wrangle.html.erb
+++ b/app/views/tags/wrangle.html.erb
@@ -140,8 +140,13 @@
                 <% unless params[:status] == 'unwrangled' %>
                   <li>
                     <label for="remove_associated_<%= tag.id %>">
-                      <%= ts('Remove') %>
-                      <%= check_box_tag 'remove_associated[]', tag.id, false, id: "remove_associated_#{tag.id}" %>
+                      <% if tag.unwrangleable? && tag.parents.by_type("Fandom").size == 1 %>
+                        <%= ts('Unwrangleable') %>
+                        <%= check_box_tag 'remove_associated[]', tag.id, false, id: "remove_associated_#{tag.id}", disabled: true %>
+                      <% else %>
+                        <%= ts('Remove') %>
+                        <%= check_box_tag 'remove_associated[]', tag.id, false, id: "remove_associated_#{tag.id}" %>
+                      <% end %>
                     </label>
                   </li>
                 <% end %>

--- a/spec/models/common_tagging_spec.rb
+++ b/spec/models/common_tagging_spec.rb
@@ -1,0 +1,28 @@
+require "spec_helper"
+
+describe CommonTagging do
+  before(:each) do
+    @tag = Freeform.create(name: "NewTag")
+    @parent = Fandom.create(name: "Fandom1", canonical: true)
+    @common_tagging = CommonTagging.create(common_tag: @tag, filterable: @parent)
+  end
+
+  context 'destroy unwrangleable assocation for tag' do
+    before(:each) do
+      @tag.unwrangleable = true
+      @tag.save
+    end
+
+    it 'belonging to a single fandom is not allowed' do
+      @common_tagging.destroy
+      expect(@common_tagging.destroyed?).to be(false)
+    end
+
+    it 'belonging to multiple fandoms is allowed' do
+      CommonTagging.create(common_tag: @tag, filterable: Fandom.create(name: "Fandom2", canonical: true))
+      expect(@tag.parents.by_type("Fandom").size).to be(2)
+      @common_tagging.destroy
+      expect(@common_tagging.destroyed?).to be(true)
+    end
+  end
+end

--- a/spec/models/common_tagging_spec.rb
+++ b/spec/models/common_tagging_spec.rb
@@ -1,28 +1,25 @@
 require "spec_helper"
 
 describe CommonTagging do
-  before(:each) do
-    @tag = Freeform.create(name: "NewTag")
-    @parent = Fandom.create(name: "Fandom1", canonical: true)
-    @common_tagging = CommonTagging.create(common_tag: @tag, filterable: @parent)
-  end
-
-  context 'destroy unwrangleable assocation for tag' do
-    before(:each) do
-      @tag.unwrangleable = true
-      @tag.save
+  let!(:tag) { Freeform.create(name: "NewTag") }
+  let!(:parent) { Fandom.create(name: "Fandom1", canonical: true) }
+  let!(:common_tagging) { CommonTagging.create(common_tag: tag, filterable: parent) }
+    
+  context "destroy unwrangleable assocation for tag" do
+    before do
+      tag.unwrangleable = true
+      tag.save
     end
 
-    it 'belonging to a single fandom is not allowed' do
-      @common_tagging.destroy
-      expect(@common_tagging.destroyed?).to be(false)
+    it "belonging to a single fandom is not allowed" do
+      common_tagging.destroy
+      expect(common_tagging.destroyed?).to be(false)
     end
 
-    it 'belonging to multiple fandoms is allowed' do
-      CommonTagging.create(common_tag: @tag, filterable: Fandom.create(name: "Fandom2", canonical: true))
-      expect(@tag.parents.by_type("Fandom").size).to be(2)
-      @common_tagging.destroy
-      expect(@common_tagging.destroyed?).to be(true)
+    it "belonging to multiple fandoms is allowed" do
+      CommonTagging.create(common_tag: tag, filterable: Fandom.create(name: "Fandom2", canonical: true))
+      common_tagging.destroy
+      expect(common_tagging.destroyed?).to be(true)
     end
   end
 end


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [ ] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [x] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [x] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-6102

## Purpose

Addresses the loophole where it was still possible to remove an unwrangleable tag from its only fandom via the mass update form.  Validation was applied on the tag when making a it unwrangleable, but not on the association (common_tagging) on removal.

I also put in a small view change to disable the checkbox in these scenarios, so it won't be clickable anyway.

## Testing Instructions

Needs more test coverage.  I added `common_tagging_spec.rb` to check the new `before_destroy` validation, but seems this model was not covered at all previously (I only tested my changes, not the whole model).  I've also modified the tag model (minor change, in that removing associations may actually fail, whereas prior it just charged forward regardless) but there's no tests to check that new behaviour.  Also missing tests for the view changes.

**Manual Test:**
- Create a new unwrangleable tag associated to 2 canonical fandoms
- Verify that when wrangling tags in one of those fandoms, the unwrangleable tag can be removed by mass update
- Verify that when wrangling tags in the last fandom, the unwrangleable cannot be removed as the checkbox is disabled
- Enable the checkbox (either via editing the HTML, or modifying the code) and attempt to remove from the last fandom
- Verify that the tag is not removed and error message is displayed

## References

#3891 
