### PR TITLE
AO3-3765 Fix links in tag comment notifications.

### DIFF
--- a/app/views/comment_mailer/_comment_notification_footer_for_tag.html.erb
+++ b/app/views/comment_mailer/_comment_notification_footer_for_tag.html.erb
@@ -1,42 +1,18 @@
 <%= style_link("Read all comments on " + @comment.ultimate_parent.name, 
-  {
-    :controller => :comments, 
-    :action => :index, 
-    :tag_id => @comment.ultimate_parent, 
-    :only_path => false
-  }) %>  
+               tag_comments_url(@comment.ultimate_parent)) %>
 <br />
 
 <% unless @noreply %>
   <%= style_link("Reply to this comment",
-    {
-      :controller => :comments, 
-      :action => :index, 
-      :tag_id => @comment.ultimate_parent, 
-      :only_path => false, 
-      :add_comment_reply_id => @comment.id, 
-      :anchor => "comment_#{@comment.id}"
-    }) %>
+                 comment_url(@comment, add_comment_reply_id: @comment.id)) %>
   <br />
 <% end %>
 
 <%= style_link("Go to the thread starting from this comment", 
-  {
-    :controller => :comments, 
-    :action => :index, 
-    :tag_id => @comment.ultimate_parent, 
-    :only_path => false, 
-    :anchor => "comment_#{@comment.id}"
-  }) %>  
+               comment_url(@comment)) %>
 <br />
 
 <% unless @comment.id == @comment.thread %>
   <%= style_link("Go to the thread to which this comment belongs", 
-    {
-      :controller => :comments, 
-      :action => :index, 
-      :tag_id => @comment.ultimate_parent, 
-      :anchor => "comment_#{@comment.thread}", 
-      :only_path => false
-    }) %>
+                 comment_url(@comment.thread)) %>
 <% end %>

--- a/app/views/comment_mailer/_comment_notification_footer_for_tag.text.erb
+++ b/app/views/comment_mailer/_comment_notification_footer_for_tag.text.erb
@@ -1,4 +1,4 @@
-Read all comments on <%= @comment.ultimate_parent.name %>: <%= url_for(:controller => :comments, :action => :index, :tag_id => @comment.ultimate_parent, :only_path => false) %><% unless @noreply %>
-Reply to this comment: <%= url_for(:controller => :comments, :action => :index, :tag_id => @comment.ultimate_parent, :only_path => false, :add_comment_reply_id => @comment.id, :anchor => "comment_#{@comment.id}") %><% end %>
-Go to the thread starting from this comment: <%= url_for(:controller => :comments,  :action => :index,  :tag_id => @comment.ultimate_parent,  :only_path => false,  :anchor => "comment_#{@comment.id}") %><% unless @comment.id == @comment.thread %>
-Go to the thread to which this comment belongs: <%= url_for(:controller => :comments, :action => :index, :tag_id => @comment.ultimate_parent, :anchor => "comment_#{@comment.thread}", :only_path => false) %><% end %>
+Read all comments on <%= @comment.ultimate_parent.name %>: <%= tag_comments_url(@comment.ultimate_parent) %><% unless @noreply %>
+Reply to this comment: <%= comment_url(@comment, add_comment_reply_id: @comment.id) %><% end %>
+Go to the thread starting from this comment: <%= comment_url(@comment) %><% unless @comment.id == @comment.thread %>
+Go to the thread to which this comment belongs: <%= comment_url(@comment.thread) %><% end %>

--- a/features/tags_and_wrangling/tag_comment.feature
+++ b/features/tags_and_wrangling/tag_comment.feature
@@ -129,27 +129,17 @@ I'd like to comment on a tag'
       And the email should contain "left the following comment on"
       And the email should contain "the tag"
 
-    # check that the links in the email go where they should; this is wonky and I don't know why
-    # I'm having the tests only check the html based email for now
-    When I follow "Go to the thread starting from this comment" in the email
-    Then I should see "Reading Comments on Eroica"
+    When I am logged in as "Enigel" with password "wrangulator"
+      And I follow "Go to the thread starting from this comment" in the email
+    Then I should see "Comment on Eroica"
       And I should see "really clever stuff"
-      And I log out
     When I follow "Read all comments on Eroica" in the email
-      And I fill in "User name or email:" with "Cesy"
-      And I fill in "Password:" with "wrangulator"
-      And I press "Log In"
     Then I should see "Reading Comments on Eroica"
       And I should see "really clever stuff"
-      And I log out
     When I follow "Reply to this comment" in the email
-      And I fill in "User name or email:" with "Enigel"
-      And I fill in "Password:" with "wrangulator"
-      And I press "Log In"
-    Then I should see "Reading Comments on Eroica"
+    Then I should see "Comment on Eroica"
       And I should see "really clever stuff"
       And all emails have been delivered
-      And I am logged in as "Enigel" with password "wrangulator"
 
     When I view the tag "Doctor Who"
       And I follow "0 comments"

--- a/spec/mailers/comment_mailer_spec.rb
+++ b/spec/mailers/comment_mailer_spec.rb
@@ -42,6 +42,25 @@ describe CommentMailer do
     end
   end
 
+  shared_examples "a notification email with a link to the comment's thread" do
+    describe "HTML email" do
+      it "has a link to the comment's thread" do
+        expect(subject.html_part).to have_xpath(
+          "//a[@href=\"#{comment_url(comment.thread)}\"]",
+          text: "Go to the thread to which this comment belongs"
+        )
+      end
+    end
+
+    describe "text email" do
+      it "has a link to the comment's thread" do
+        expect(subject).to have_text_part_content(
+          "Go to the thread to which this comment belongs: #{comment_url(comment.thread)}"
+        )
+      end
+    end
+  end
+
   describe "comment_notification" do
     subject(:email) { CommentMailer.comment_notification(user, comment).deliver }
 
@@ -49,11 +68,27 @@ describe CommentMailer do
     it_behaves_like "a notification email with a link to the comment"
     it_behaves_like "a notification email with a link to reply to the comment"
 
+    context "when the comment is a reply to another comment" do
+      let(:comment) { create(:comment, commentable: create(:comment)) }
+
+      it_behaves_like "a notification email with a link to the comment"
+      it_behaves_like "a notification email with a link to reply to the comment"
+      it_behaves_like "a notification email with a link to the comment's thread"
+    end
+
     context "when the comment is on a tag" do
       let(:comment) { create(:comment, :on_tag) }
 
       it_behaves_like "a notification email with a link to the comment"
       it_behaves_like "a notification email with a link to reply to the comment"
+
+      context "when the comment is a reply to another comment" do
+        let(:comment) { create(:comment, commentable: create(:comment, :on_tag)) }
+
+        it_behaves_like "a notification email with a link to the comment"
+        it_behaves_like "a notification email with a link to reply to the comment"
+        it_behaves_like "a notification email with a link to the comment's thread"
+      end
     end
   end
 
@@ -64,11 +99,27 @@ describe CommentMailer do
     it_behaves_like "a notification email with a link to the comment"
     it_behaves_like "a notification email with a link to reply to the comment"
 
+    context "when the comment is a reply to another comment" do
+      let(:comment) { create(:comment, commentable: create(:comment)) }
+
+      it_behaves_like "a notification email with a link to the comment"
+      it_behaves_like "a notification email with a link to reply to the comment"
+      it_behaves_like "a notification email with a link to the comment's thread"
+    end
+
     context "when the comment is on a tag" do
       let(:comment) { create(:comment, :on_tag) }
 
       it_behaves_like "a notification email with a link to the comment"
       it_behaves_like "a notification email with a link to reply to the comment"
+
+      context "when the comment is a reply to another comment" do
+        let(:comment) { create(:comment, commentable: create(:comment, :on_tag)) }
+
+        it_behaves_like "a notification email with a link to the comment"
+        it_behaves_like "a notification email with a link to reply to the comment"
+        it_behaves_like "a notification email with a link to the comment's thread"
+      end
     end
   end
 
@@ -81,12 +132,14 @@ describe CommentMailer do
     it_behaves_like "an email with a valid sender"
     it_behaves_like "a notification email with a link to the comment"
     it_behaves_like "a notification email with a link to reply to the comment"
+    it_behaves_like "a notification email with a link to the comment's thread"
 
     context "when the comment is on a tag" do
       let(:parent_comment) { create(:comment, :on_tag) }
 
       it_behaves_like "a notification email with a link to the comment"
       it_behaves_like "a notification email with a link to reply to the comment"
+      it_behaves_like "a notification email with a link to the comment's thread"
     end
   end
 
@@ -99,12 +152,14 @@ describe CommentMailer do
     it_behaves_like "an email with a valid sender"
     it_behaves_like "a notification email with a link to the comment"
     it_behaves_like "a notification email with a link to reply to the comment"
+    it_behaves_like "a notification email with a link to the comment's thread"
 
     context "when the comment is on a tag" do
       let(:parent_comment) { create(:comment, :on_tag) }
 
       it_behaves_like "a notification email with a link to the comment"
       it_behaves_like "a notification email with a link to reply to the comment"
+      it_behaves_like "a notification email with a link to the comment's thread"
     end
   end
 
@@ -114,10 +169,24 @@ describe CommentMailer do
     it_behaves_like "an email with a valid sender"
     it_behaves_like "a notification email with a link to the comment"
 
+    context "when the comment is a reply to another comment" do
+      let(:comment) { create(:comment, commentable: create(:comment)) }
+
+      it_behaves_like "a notification email with a link to the comment"
+      it_behaves_like "a notification email with a link to the comment's thread"
+    end
+
     context "when the comment is on a tag" do
       let(:comment) { create(:comment, :on_tag) }
 
       it_behaves_like "a notification email with a link to the comment"
+
+      context "when the comment is a reply to another comment" do
+        let(:comment) { create(:comment, commentable: create(:comment, :on_tag)) }
+
+        it_behaves_like "a notification email with a link to the comment"
+        it_behaves_like "a notification email with a link to the comment's thread"
+      end
     end
   end
 end

--- a/spec/mailers/comment_mailer_spec.rb
+++ b/spec/mailers/comment_mailer_spec.rb
@@ -1,11 +1,123 @@
-require 'spec_helper'
+require "spec_helper"
 
 describe CommentMailer do
-  describe "comment_sent_notification" do
-    let(:comment) { create(:comment) } 
+  let(:comment) { create(:comment) }
+  let(:user) { create(:user) }
 
+  shared_examples "a notification email with a link to the comment" do
+    describe "HTML email" do
+      it "has a link to the comment" do
+        expect(subject.html_part).to have_xpath(
+          "//a[@href=\"#{comment_url(comment)}\"]",
+          text: "Go to the thread starting from this comment"
+        )
+      end
+    end
+
+    describe "text email" do
+      it "has a link to the comment" do
+        expect(subject).to have_text_part_content(
+          "Go to the thread starting from this comment: #{comment_url(comment)}"
+        )
+      end
+    end
+  end
+
+  shared_examples "a notification email with a link to reply to the comment" do
+    describe "HTML email" do
+      it "has a link to reply to the comment" do
+        expect(subject.html_part).to have_xpath(
+          "//a[@href=\"#{comment_url(comment, add_comment_reply_id: comment.id)}\"]",
+          text: "Reply to this comment"
+        )
+      end
+    end
+
+    describe "text email" do
+      it "has a link to reply to the comment" do
+        expect(subject).to have_text_part_content(
+          "Reply to this comment: #{comment_url(comment, add_comment_reply_id: comment.id)}"
+        )
+      end
+    end
+  end
+
+  describe "comment_notification" do
+    subject(:email) { CommentMailer.comment_notification(user, comment).deliver }
+
+    it_behaves_like "an email with a valid sender"
+    it_behaves_like "a notification email with a link to the comment"
+    it_behaves_like "a notification email with a link to reply to the comment"
+
+    context "when the comment is on a tag" do
+      let(:comment) { create(:comment, :on_tag) }
+
+      it_behaves_like "a notification email with a link to the comment"
+      it_behaves_like "a notification email with a link to reply to the comment"
+    end
+  end
+
+  describe "edited_comment_notification" do
+    subject(:email) { CommentMailer.edited_comment_notification(user, comment).deliver }
+
+    it_behaves_like "an email with a valid sender"
+    it_behaves_like "a notification email with a link to the comment"
+    it_behaves_like "a notification email with a link to reply to the comment"
+
+    context "when the comment is on a tag" do
+      let(:comment) { create(:comment, :on_tag) }
+
+      it_behaves_like "a notification email with a link to the comment"
+      it_behaves_like "a notification email with a link to reply to the comment"
+    end
+  end
+
+  describe "comment_reply_notification" do
+    subject(:email) { CommentMailer.comment_reply_notification(parent_comment, comment).deliver }
+
+    let(:parent_comment) { create(:comment) }
+    let(:comment) { create(:comment, commentable: parent_comment) }
+
+    it_behaves_like "an email with a valid sender"
+    it_behaves_like "a notification email with a link to the comment"
+    it_behaves_like "a notification email with a link to reply to the comment"
+
+    context "when the comment is on a tag" do
+      let(:parent_comment) { create(:comment, :on_tag) }
+
+      it_behaves_like "a notification email with a link to the comment"
+      it_behaves_like "a notification email with a link to reply to the comment"
+    end
+  end
+
+  describe "edited_comment_reply_notification" do
+    subject(:email) { CommentMailer.edited_comment_reply_notification(parent_comment, comment).deliver }
+
+    let(:parent_comment) { create(:comment) }
+    let(:comment) { create(:comment, commentable: parent_comment) }
+
+    it_behaves_like "an email with a valid sender"
+    it_behaves_like "a notification email with a link to the comment"
+    it_behaves_like "a notification email with a link to reply to the comment"
+
+    context "when the comment is on a tag" do
+      let(:parent_comment) { create(:comment, :on_tag) }
+
+      it_behaves_like "a notification email with a link to the comment"
+      it_behaves_like "a notification email with a link to reply to the comment"
+    end
+  end
+
+  describe "comment_sent_notification" do
     subject(:email) { CommentMailer.comment_sent_notification(comment).deliver }
 
     it_behaves_like "an email with a valid sender"
+    it_behaves_like "a notification email with a link to the comment"
+
+    context "when the comment is on a tag" do
+      let(:comment) { create(:comment, :on_tag) }
+
+      it_behaves_like "a notification email with a link to the comment"
+    end
   end
 end


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-3765

## Purpose

Changes the links in tag comment notifications so that they point to the individual comment, and not the page for all comments on that tag.