### PR TITLE
AO3-6096 Replace Dewplayer embeds with audio tags when sanitizing HTML

### DIFF
--- a/lib/otw_sanitize/embed_sanitizer.rb
+++ b/lib/otw_sanitize/embed_sanitizer.rb
@@ -145,8 +145,10 @@ module OTWSanitize
       mp3_urls = CGI.parse(flashvars)["mp3"]
       return if mp3_urls.blank?
 
-      audio_fragment = mp3_urls.map { |url| "<audio src='#{url}'></audio>" }.join
-      node.replace(audio_fragment)
+      # Dewplayer allows specifying multiple sources.
+      mp3_urls = mp3_urls.map { |url| url.split("|") }.flatten
+      audio_fragment = mp3_urls.map { |url| "<audio src='#{url}'></audio>" }.join("<br>")
+      node.replace("<p>#{audio_fragment}</p>")
     end
 
     # We're now certain that this is an embed from a trusted source, but we

--- a/lib/otw_sanitize/embed_sanitizer.rb
+++ b/lib/otw_sanitize/embed_sanitizer.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
+
 require "addressable/uri"
+require "cgi"
 
 module OTWSanitize
   # Creates a Sanitize transformer to sanitize embedded media
@@ -35,6 +37,9 @@ module OTWSanitize
     # Creates a callable transformer for the sanitizer to use
     def self.transformer
       lambda do |env|
+        # Don't continue if this node is already safelisted.
+        return if env[:is_whitelisted]
+
         new(env[:node]).sanitized_node
       end
     end
@@ -51,6 +56,11 @@ module OTWSanitize
       return unless source_url && source
 
       ensure_https
+
+      # If a Dewplayer embed has been replaced with <audio> tags, return
+      # without safelisting them so the Sanitize transformer for <audio>
+      # tags can modify them later.
+      return if replace_dewplayer
 
       if parent_name == 'object'
         sanitize_object
@@ -122,6 +132,23 @@ module OTWSanitize
       end
     end
 
+    # If the embed is hosted on the Archive, it's Dewplayer and can be replaced
+    # with <audio> tag(s).
+    #
+    # Refer to https://archiveofourown.org/admin_posts/250.
+    def replace_dewplayer
+      return unless source == :ao3 && node_name == "embed" && source_url.downcase.include?("dewplayer")
+
+      flashvars = node["flashvars"]
+      return if flashvars.blank?
+
+      mp3_urls = CGI.parse(flashvars)["mp3"]
+      return if mp3_urls.blank?
+
+      audio_fragment = mp3_urls.map { |url| "<audio src='#{url}'></audio>" }.join
+      node.replace(audio_fragment)
+    end
+
     # We're now certain that this is an embed from a trusted source, but we
     # still need to run it through a special Sanitize step to ensure
     # that no unwanted elements or attributes that don't belong in
@@ -161,7 +188,7 @@ module OTWSanitize
         disable_scripts(node)
         node['flashvars'] = "" unless allows_flashvars?
       end
-      { node_whitelist: [node, parent] }
+      { node_whitelist: [node] }
     end
 
     # disable script access and networking

--- a/lib/otw_sanitize/media_sanitizer.rb
+++ b/lib/otw_sanitize/media_sanitizer.rb
@@ -54,6 +54,9 @@ module OTWSanitize
     # Creates a callable transformer for the sanitizer to use
     def self.transformer
       lambda do |env|
+        # Don't continue if this node is already safelisted.
+        return if env[:is_whitelisted]
+
         new(env[:node]).sanitized_node
       end
     end

--- a/lib/otw_sanitize/user_class_sanitizer.rb
+++ b/lib/otw_sanitize/user_class_sanitizer.rb
@@ -6,6 +6,7 @@ module OTWSanitize
   class UserClassSanitizer
     def self.transformer
       lambda do |env|
+        # Check this node even if it is already safelisted.
         new(env[:node]).sanitized_node
       end
     end

--- a/lib/tasks/after_tasks.rake
+++ b/lib/tasks/after_tasks.rake
@@ -704,7 +704,24 @@ namespace :After do
 
     puts && STDOUT.flush
   end
-end # this is the end that you have to put new tasks above
+
+  desc "Replace Archive-hosted Dewplayer embeds with HTML5 audio tags"
+  task(replace_dewplayer_embeds: :environment) do
+    Chapter.find_each do |chapter|
+      puts chapter.id if (chapter.id % 1000).zero?
+      if chapter.content.match /<embed .*dewplayer/
+        begin
+          chapter.content_sanitizer_version = -1
+          chapter.sanitize_field(chapter, :content)
+        rescue StandardError
+          puts "Couldn't update chapter #{chapter.id}"
+        end
+      end
+    end
+  end
+
+  # This is the end that you have to put new tasks above.
+end
 
 ##################
 # ADD NEW MIGRATE TASKS TO THIS LIST ONCE THEY ARE WORKING

--- a/lib/tasks/after_tasks.rake
+++ b/lib/tasks/after_tasks.rake
@@ -707,17 +707,22 @@ namespace :After do
 
   desc "Replace Archive-hosted Dewplayer embeds with HTML5 audio tags"
   task(replace_dewplayer_embeds: :environment) do
+    updated_chapter_count = 0
+
     Chapter.find_each do |chapter|
-      puts chapter.id if (chapter.id % 1000).zero?
+      puts(chapter.id) && STDOUT.flush if (chapter.id % 1000).zero?
       if chapter.content.match /<embed .*dewplayer/
         begin
           chapter.content_sanitizer_version = -1
           chapter.sanitize_field(chapter, :content)
+          updated_chapter_count += 1
         rescue StandardError
-          puts "Couldn't update chapter #{chapter.id}"
+          puts("Couldn't update chapter #{chapter.id}") && STDOUT.flush
         end
       end
     end
+
+    puts("Updated #{updated_chapter_count} chapter(s).") && STDOUT.flush
   end
 
   # This is the end that you have to put new tasks above.

--- a/spec/lib/html_cleaner_spec.rb
+++ b/spec/lib/html_cleaner_spec.rb
@@ -178,6 +178,11 @@ describe HtmlCleaner do
           expect(result).to include(html)
         end
 
+        it "converts Archive-hosted Dewplayer embeds into audio tags" do
+          html = '<embed type="application/x-shockwave-flash" flashvars="mp3=http://example.com/next-color-planet.mp3" src="https://archiveofourown.org/system/dewplayer/dewplayer.swf" width="200" height="27" allowscriptaccess="never" allownetworking="internal"></embed>'
+          expect(sanitize_value(field, html)).to include('<audio src="https://example.com/next-color-planet.mp3" controls="controls" crossorigin="anonymous" preload="metadata"></audio>')
+        end
+
         it "strips embeds with unknown source" do
           html = '<embed src="http://www.evil.org"></embed>'
           result = sanitize_value(field, html)

--- a/spec/lib/html_cleaner_spec.rb
+++ b/spec/lib/html_cleaner_spec.rb
@@ -178,9 +178,16 @@ describe HtmlCleaner do
           expect(result).to include(html)
         end
 
-        it "converts Archive-hosted Dewplayer embeds into audio tags" do
+        it "converts an Archive-hosted Dewplayer embed into an audio tag" do
           html = '<embed type="application/x-shockwave-flash" flashvars="mp3=http://example.com/next-color-planet.mp3" src="https://archiveofourown.org/system/dewplayer/dewplayer.swf" width="200" height="27" allowscriptaccess="never" allownetworking="internal"></embed>'
           expect(sanitize_value(field, html)).to include('<audio src="https://example.com/next-color-planet.mp3" controls="controls" crossorigin="anonymous" preload="metadata"></audio>')
+        end
+
+        it "converts an Archive-hosted Dewplayer multi embed into audio tags" do
+          html = '<embed type="application/x-shockwave-flash" flashvars="mp3=http://example.com/live-again.mp3|http://example.com/cursed-night.mp3" src="https://archiveofourown.org/system/dewplayer/dewplayer.swf" width="200" height="27" allowscriptaccess="never" allownetworking="internal"></embed>'
+          result = sanitize_value(field, html)
+          expect(result).to include('<audio src="https://example.com/live-again.mp3" controls="controls" crossorigin="anonymous" preload="metadata"></audio>')
+          expect(result).to include('<audio src="https://example.com/cursed-night.mp3" controls="controls" crossorigin="anonymous" preload="metadata"></audio>')
         end
 
         it "strips embeds with unknown source" do

--- a/spec/lib/otw_sanitize/media_sanitizer_spec.rb
+++ b/spec/lib/otw_sanitize/media_sanitizer_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require "spec_helper"
 
 describe OTWSanitize::MediaSanitizer do
   describe ".transformer" do

--- a/spec/lib/tasks/after_tasks.rake_spec.rb
+++ b/spec/lib/tasks/after_tasks.rake_spec.rb
@@ -134,6 +134,7 @@ describe "rake After:replace_dewplayer_embeds" do
     expect do
       subject.invoke
     end.to avoid_changing { embed_work.reload.first_chapter.content }
-      .and change { dewplayer_work.reload.first_chapter.content }.to('<audio src="https://example.com/HINOTORI.mp3" controls="controls" crossorigin="anonymous" preload="metadata"></audio>')
+
+    expect(dewplayer_work.reload.first_chapter.content).to include('<audio src="https://example.com/HINOTORI.mp3" controls="controls" crossorigin="anonymous" preload="metadata"></audio>')
   end
 end

--- a/spec/lib/tasks/after_tasks.rake_spec.rb
+++ b/spec/lib/tasks/after_tasks.rake_spec.rb
@@ -125,3 +125,15 @@ describe "rake After:update_indexed_stat_counter_kudo_count", work_search: true 
     }.from(0).to(1)
   end
 end
+
+describe "rake After:replace_dewplayer_embeds" do
+  let!(:dewplayer_work) { create(:work, chapter_attributes: { content: '<embed type="application/x-shockwave-flash" flashvars="mp3=https://example.com/HINOTORI.mp3" src="https://archiveofourown.org/system/dewplayer/dewplayer-vol.swf" width="250" height="27"></embed>' }) }
+  let!(:embed_work) { create(:work, chapter_attributes: { content: '<embed type="application/x-shockwave-flash" flashvars="audioUrl=https://example.com/失礼しますが、RIP♡-Explicit.mp3" src="http://podfic.com/player/audio-player.swf" width="400" height="27"></embed>' }) }
+
+  it "updates only works using Dewplayer embeds" do
+    expect do
+      subject.invoke
+    end.to avoid_changing { embed_work.reload.first_chapter.content }
+      .and change { dewplayer_work.reload.first_chapter.content }.to('<audio src="https://example.com/HINOTORI.mp3" controls="controls" crossorigin="anonymous" preload="metadata"></audio>')
+  end
+end


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6096

## Purpose

- Update the embed sanitizer to replace Dewplayer embeds with HTML5 audio tags.
- Add a rake task to re-sanitize existing works using Dewplayer embeds.

## Testing Instructions

- Post a work using the old embed code, then after the staging deploy, run the rake and make sure the work is updated.
- Post a work using the old embed code after the staging deploy. The work should automatically be updated as well.