### PR TITLE
AO3-6100 Grant support admins access to admin posts

### DIFF
--- a/app/policies/admin_post_policy.rb
+++ b/app/policies/admin_post_policy.rb
@@ -1,5 +1,5 @@
 class AdminPostPolicy < ApplicationPolicy
-  POSTING_ROLES = %w[superadmin board communications translation].freeze
+  POSTING_ROLES = %w[superadmin board communications support translation].freeze
 
   def can_post?
     user_has_roles?(POSTING_ROLES)

--- a/spec/controllers/admin_posts_controller_spec.rb
+++ b/spec/controllers/admin_posts_controller_spec.rb
@@ -21,6 +21,7 @@ describe AdminPostsController do
       context "with invalid translated post id" do
         it "renders the new template with error message" do
           post :create, params: { admin_post: { translated_post_id: 0 } }.merge(base_params)
+
           expect(response).to render_template(:new)
           expect(assigns[:admin_post].errors.full_messages).to include("Translated post does not exist")
         end
@@ -32,22 +33,56 @@ describe AdminPostsController do
     let(:admin) { create(:admin) }
     let(:post) { create(:admin_post) }
 
-    context "updating post" do
+    context "with valid title" do
       context "when admin does not have correct authorization" do
-        it "denies random admin access" do
+        it "redirects with error" do
           admin.update(roles: [])
           fake_login_admin(admin)
           put :update, params: { id: post.id, admin_post: { admin_id: admin.id, title: "Modified Title of Post" } }
+
           it_redirects_to_with_error(root_url, "Sorry, only an authorized admin can access the page you were trying to reach.")
         end
       end
 
-      context "when admin has correct roles" do
-        it "allows access to authorized admins and updates admin post" do
-          admin.update(roles: ["communications"])
+      context "when admin has correct authorization" do
+        %w[superadmin board communications support translation].each do |admin_role|
+          context "with #{admin_role} role" do
+            it "updates title and redirects with notice" do
+              admin.update(roles: [admin_role])
+              fake_login_admin(admin)
+              put :update, params: { id: post.id, admin_post: { admin_id: admin.id, title: "Modified Title of Post" } }
+
+              expect(post.reload.title).to eq("Modified Title of Post")
+              it_redirects_to_with_notice(admin_post_path(assigns[:admin_post]), "Admin Post was successfully updated.")
+            end
+          end
+        end
+      end
+    end
+
+    context "with invalid translation_id" do
+      context "when admin does not have correct authorization" do
+        it "redirects with error" do
+          admin.update(roles: [])
           fake_login_admin(admin)
-          put :update, params: { id: post.id, admin_post: { admin_id: admin.id, title: "Modified Title of Post" } }
-          it_redirects_to_with_notice(admin_post_path(assigns[:admin_post]), "Admin Post was successfully updated.")
+          put :update, params: { id: post.id, admin_post: { admin_id: admin.id, translated_post_id: 0 } }
+
+          it_redirects_to_with_error(root_url, "Sorry, only an authorized admin can access the page you were trying to reach.")
+        end
+      end
+
+      context "when admin has correct authorization" do
+        %w[superadmin board communications support translation].each do |admin_role|
+          context "with #{admin_role} role" do
+            it "renders the edit template with error message" do
+              admin.update(roles: ["translation"])
+              fake_login_admin(admin)
+              put :update, params: { id: post.id, admin_post: { admin_id: admin.id, translated_post_id: 0 } }
+
+              expect(response).to render_template(:edit)
+              expect(assigns[:admin_post].errors.full_messages).to include("Translated post does not exist")
+            end
+          end
         end
       end
     end
@@ -58,20 +93,85 @@ describe AdminPostsController do
     let(:post) { create(:admin_post) }
 
     context "when admin does not have correct authorization" do
-      it "denies random admin access" do
+      it "redirects with error" do
         admin.update(roles: [])
         fake_login_admin(admin)
         get :edit, params: { id: post.id }
+
         it_redirects_to_with_error(root_url, "Sorry, only an authorized admin can access the page you were trying to reach.")
       end
     end
 
-    context "when admin has correct roles" do
-      it "allows access to authorized admins and renders edit template" do
-        admin.update(roles: ["communications"])
+    context "when admin has correct authorization" do
+      %w[superadmin board communications support translation].each do |admin_role|
+        context "with #{admin_role} role" do
+          it "renders edit template" do
+            admin.update(roles: [admin_role])
+            fake_login_admin(admin)
+            get :edit, params: { id: post.id }
+
+            expect(response).to render_template(:edit)
+          end
+        end
+      end
+    end
+  end
+
+  describe "GET #new" do
+    let(:admin) { create(:admin) }
+    let(:post) { create(:admin_post) }
+
+    context "when admin does not have correct authorization" do
+      it "redirects with error" do
+        admin.update(roles: [])
         fake_login_admin(admin)
         get :edit, params: { id: post.id }
-        expect(response).to render_template(:edit)
+
+        it_redirects_to_with_error(root_url, "Sorry, only an authorized admin can access the page you were trying to reach.")
+      end
+    end
+
+    context "when admin has correct authorization" do
+      %w[superadmin board communications support translation].each do |admin_role|
+        context "with #{admin_role} role" do
+          it "renders new template" do
+            admin.update(roles: [admin_role])
+            fake_login_admin(admin)
+            get :new, params: { id: post.id }
+
+            expect(response).to render_template(:new)
+          end
+        end
+      end
+    end
+  end
+
+  describe "DELETE #destroy" do
+    let(:admin) { create(:admin) }
+    let(:post) { create(:admin_post) }
+
+    context "when admin does not have correct authorization" do
+      it "redirects with error" do
+        admin.update(roles: [])
+        fake_login_admin(admin)
+        delete :destroy, params: { id: post.id }
+
+        it_redirects_to_with_error(root_url, "Sorry, only an authorized admin can access the page you were trying to reach.")
+      end
+    end
+
+    context "when admin has correct authorization" do
+      %w[superadmin board communications support translation].each do |admin_role|
+        context "with #{admin_role} role" do
+          it "deletes post and redirects without notice" do
+            admin.update(roles: [admin_role])
+            fake_login_admin(admin)
+            delete :destroy, params: { id: post.id }
+
+            expect { post.reload }.to raise_exception(ActiveRecord::RecordNotFound)
+            it_redirects_to(admin_posts_path)
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6100

## Purpose

* Lets admins with the support role create, delete, and modify admin posts.
* Covers [the last untested line in the admin posts controller](https://codecov.io/gh/otwcode/otwarchive/src/0622729c9d4fca1ec7b611235bb5e318256ebd70/app/controllers/admin_posts_controller.rb).

## Testing Instructions

Refer to Jira.