### PR TITLE
AO3-6011 Refactor parameters passed to the ChallengeClaimsController.

### DIFF
--- a/app/controllers/challenge_claims_controller.rb
+++ b/app/controllers/challenge_claims_controller.rb
@@ -112,7 +112,8 @@ class ChallengeClaimsController < ApplicationController
 
   def create
     # create a new claim
-    claim = ChallengeClaim.new(challenge_claim_params)
+    prompt = @collection.prompts.find(params[:prompt_id])
+    claim = prompt.request_claims.build(claiming_user: current_user)
     if claim.save
       flash[:notice] = "New claim made."
     else
@@ -140,12 +141,6 @@ class ChallengeClaimsController < ApplicationController
   end
 
   private
-
-  def challenge_claim_params
-    params.require(:challenge_claim).permit(
-      :collection_id, :request_signup_id, :request_prompt_id, :claiming_user_id
-    )
-  end
 
   def user_scoped?
     params[:for_user].to_s.casecmp?("true")

--- a/app/models/challenge_claim.rb
+++ b/app/models/challenge_claim.rb
@@ -1,13 +1,19 @@
 class ChallengeClaim < ApplicationRecord
   include ActiveModel::ForbiddenAttributesProtection
-  # We use "-1" to represent all the requested items matching
-  ALL = -1
 
   belongs_to :claiming_user, class_name: "User", inverse_of: :request_claims
   belongs_to :collection
   belongs_to :request_signup, class_name: "ChallengeSignup"
   belongs_to :request_prompt, class_name: "Prompt"
   belongs_to :creation, polymorphic: true
+
+  before_create :inherit_fields_from_request_prompt
+  def inherit_fields_from_request_prompt
+    return unless request_prompt
+
+    self.collection = request_prompt.collection
+    self.request_signup = request_prompt.challenge_signup
+  end
 
   scope :for_request_signup, lambda {|signup|
     where('request_signup_id = ?', signup.id)
@@ -122,10 +128,6 @@ class ChallengeClaim < ApplicationRecord
       title += " (#{self.request_byline})"
     end
     return title
-  end
-
-  def claiming_user
-    User.find_by(id: claiming_user_id)
   end
 
   def claiming_pseud

--- a/app/models/prompt.rb
+++ b/app/models/prompt.rb
@@ -29,7 +29,7 @@ class Prompt < ApplicationRecord
   accepts_nested_attributes_for :optional_tag_set
   has_many :optional_tags, through: :optional_tag_set, source: :tag
 
-  has_many :request_claims, class_name: "ChallengeClaim", foreign_key: "request_prompt_id", inverse_of: :request_prompt
+  has_many :request_claims, class_name: "ChallengeClaim", foreign_key: "request_prompt_id", inverse_of: :request_prompt, dependent: :destroy
 
   # SCOPES
 
@@ -43,14 +43,6 @@ class Prompt < ApplicationRecord
     joins("JOIN set_taggings ON set_taggings.tag_set_id = prompts.tag_set_id").
     where("set_taggings.tag_id = ?", tag.id)
   }
-
-  # CALLBACKS
-
-  before_destroy :clear_claims
-  def clear_claims
-    # remove this prompt reference from any existing assignments
-    request_claims.each {|claim| claim.destroy}
-  end
 
   # VALIDATIONS
 

--- a/app/models/prompt.rb
+++ b/app/models/prompt.rb
@@ -29,7 +29,7 @@ class Prompt < ApplicationRecord
   accepts_nested_attributes_for :optional_tag_set
   has_many :optional_tags, through: :optional_tag_set, source: :tag
 
-  has_many :request_claims, class_name: "ChallengeClaim", foreign_key: 'request_prompt_id'
+  has_many :request_claims, class_name: "ChallengeClaim", foreign_key: "request_prompt_id", inverse_of: :request_prompt
 
   # SCOPES
 
@@ -220,17 +220,6 @@ class Prompt < ApplicationRecord
 
   def fulfilled_claims
     self.request_claims.fulfilled
-  end
-
-  # We want to have all the matching methods defined on
-  # TagSet available here, too, without rewriting them,
-  # so we just pass them through method_missing
-  def method_missing(method, *args, &block)
-    super || (tag_set && tag_set.respond_to?(method) ? tag_set.send(method) : super)
-  end
-
-  def respond_to?(method, include_private = false)
-    super || tag_set.respond_to?(method, include_private)
   end
 
   # Computes the "full" tag set (tag_set + optional_tag_set), and stores the

--- a/app/views/prompts/_prompt_controls.html.erb
+++ b/app/views/prompts/_prompt_controls.html.erb
@@ -47,14 +47,7 @@
         <% # The claim link should show up if the user has not already claimed the prompt %>
         <% else %>
         <li>
-          <% new_claim = ChallengeClaim.new %>
-            <%= form_for [collection, new_claim], :url => collection_claims_path(collection) do |claim_form| %>
-                <%= claim_form.hidden_field :collection_id, :value => collection.id %>
-                <%= claim_form.hidden_field :request_signup_id, :value => challenge_signup.id %>
-                <%= claim_form.hidden_field :request_prompt_id, :value => prompt.id %>
-                <%= claim_form.hidden_field :claiming_user_id, :value => current_user.id %>
-                <%= submit_tag ts("Claim"), :id => "prompt_" + prompt.id.to_s %>
-            <% end %>
+          <%= button_to ts("Claim"), collection_claims_path(collection, prompt_id: prompt.id) %>
         </li>
       <% end %>
     <% end %>

--- a/spec/controllers/challenge_claims_controller_spec.rb
+++ b/spec/controllers/challenge_claims_controller_spec.rb
@@ -4,8 +4,9 @@ require 'spec_helper'
 describe ChallengeClaimsController do
   include LoginMacros
   include RedirectExpectationHelper
+
   let(:user) { create(:user) }
-  let(:signup) { create(:challenge_signup) }
+  let(:signup) { create(:prompt_meme_signup) }
   let(:collection) { signup.collection }
   let(:claim) { create(:challenge_claim, collection: collection) }
 
@@ -94,9 +95,11 @@ describe ChallengeClaimsController do
   end
 
   describe 'create' do
+    let(:prompt) { signup.requests.first }
+
     it 'sets a notice and redirects' do
       fake_login_known_user(user)
-      post :create, params: { collection_id: collection.name, challenge_claim: {collection_id: collection.id} }
+      post :create, params: { collection_id: collection.name, prompt_id: prompt.id }
       it_redirects_to_with_notice(collection_claims_path(collection, for_user: true), \
                                   "New claim made.")
     end
@@ -104,7 +107,7 @@ describe ChallengeClaimsController do
     it 'on an exception gives an error and redirects' do
       fake_login_known_user(user)
       allow_any_instance_of(ChallengeClaim).to receive(:save) { false }
-      post :create, params: { collection_id: collection.name, challenge_claim: {collection_id: collection.id} }
+      post :create, params: { collection_id: collection.name, prompt_id: prompt.id }
       it_redirects_to_with_error(collection_claims_path(collection, for_user: true), \
                                  "We couldn't save the new claim.")
     end
@@ -112,8 +115,6 @@ describe ChallengeClaimsController do
 
   describe "destroy" do
     context "for a prompt meme" do
-      let(:signup) { create(:prompt_meme_signup) }
-
       context "when a user deletes their own claim" do
         before do
           claim.update!(claiming_user: user)

--- a/spec/controllers/challenge_claims_controller_spec.rb
+++ b/spec/controllers/challenge_claims_controller_spec.rb
@@ -27,8 +27,7 @@ describe ChallengeClaimsController do
                                  "You aren't allowed to see that user's claims.")
     end
 
-    context "for a prompt meme" do
-      let(:signup) { create(:prompt_meme_signup) }
+    context "when multiple users have claims" do
       let!(:claim_by_other_user) { create(:challenge_claim, collection: collection, claiming_user: create(:user)) }
 
       it "does not allow a logged in user to access the page with everyone's claims" do
@@ -114,31 +113,29 @@ describe ChallengeClaimsController do
   end
 
   describe "destroy" do
-    context "for a prompt meme" do
-      context "when a user deletes their own claim" do
-        before do
-          claim.update!(claiming_user: user)
-        end
-
-        it "redirects them to their claims in collection page" do
-          fake_login_known_user(user)
-
-          delete :destroy, params: { id: claim.id, collection_id: collection.name }
-
-          it_redirects_to_with_notice(collection_claims_path(collection, for_user: true),
-                                      "Your claim was deleted.")
-        end
+    context "when a user deletes their own claim" do
+      before do
+        claim.update!(claiming_user: user)
       end
 
-      context "when a maintainer deletes someone else's claim" do
-        it "redirects them to the collection claims page" do
-          fake_login_known_user(collection.all_owners.first.user)
+      it "redirects them to their claims in collection page" do
+        fake_login_known_user(user)
 
-          delete :destroy, params: { id: claim.id, collection_id: collection.name }
+        delete :destroy, params: { id: claim.id, collection_id: collection.name }
 
-          it_redirects_to_with_notice(collection_claims_path(collection),
-                                      "The claim was deleted.")
-        end
+        it_redirects_to_with_notice(collection_claims_path(collection, for_user: true),
+                                    "Your claim was deleted.")
+      end
+    end
+
+    context "when a maintainer deletes someone else's claim" do
+      it "redirects them to the collection claims page" do
+        fake_login_known_user(collection.all_owners.first.user)
+
+        delete :destroy, params: { id: claim.id, collection_id: collection.name }
+
+        it_redirects_to_with_notice(collection_claims_path(collection),
+                                    "The claim was deleted.")
       end
     end
 


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6011

## Purpose

There's currently a lot of redundant information passed to the `ChallengeClaimsController` -- the `claiming_user_id` should always be the current user, and the `collection_id` and `request_signup_id` can both be derived from the prompt. This PR refactors the parameters passed to the `ChallengeClaimsController` to avoid this redundancy.

I also cleaned up some unused/unusable code while I was in the area.