### PR TITLE
AO3-6096 Handle encoded characters in Dewplayer audio URLs

### DIFF
--- a/lib/otw_sanitize/embed_sanitizer.rb
+++ b/lib/otw_sanitize/embed_sanitizer.rb
@@ -155,8 +155,16 @@ module OTWSanitize
       end
       return if mp3_urls.blank?
 
-      audio_fragment = mp3_urls.map { |url| "<audio src='#{url}'></audio>" }.join("<br>")
-      node.replace("<p>#{audio_fragment}</p>")
+      audio_fragment = Nokogiri::HTML::DocumentFragment.parse ""
+      Nokogiri::HTML::Builder.with(audio_fragment) do |fragment|
+        fragment.p do
+          mp3_urls.each_with_index do |url, i|
+            fragment.br unless i.zero?
+            fragment.audio(src: url)
+          end
+        end
+      end
+      node.replace(audio_fragment)
     end
 
     # We're now certain that this is an embed from a trusted source, but we

--- a/lib/otw_sanitize/media_sanitizer.rb
+++ b/lib/otw_sanitize/media_sanitizer.rb
@@ -93,11 +93,11 @@ module OTWSanitize
 
     def source_host
       url = source_url
-      return nil if url.blank?
-
       # Just in case we're missing a protocol
-      url = "https://" + url unless url =~ /http/
-      Addressable::URI.parse(url).normalize.host
+      unless url =~ /http/
+        url = "https://" + url
+      end
+      URI(url).host
     end
 
     def blacklisted_source?

--- a/lib/otw_sanitize/media_sanitizer.rb
+++ b/lib/otw_sanitize/media_sanitizer.rb
@@ -93,10 +93,10 @@ module OTWSanitize
 
     def source_host
       url = source_url
+      return nil if url.blank?
+
       # Just in case we're missing a protocol
-      unless url =~ /http/
-        url = "https://" + url
-      end
+      url = "https://" + url unless url =~ /http/
       Addressable::URI.parse(url).normalize.host
     end
 

--- a/lib/otw_sanitize/media_sanitizer.rb
+++ b/lib/otw_sanitize/media_sanitizer.rb
@@ -93,11 +93,11 @@ module OTWSanitize
 
     def source_host
       url = source_url
+      return nil if url.blank?
+
       # Just in case we're missing a protocol
-      unless url =~ /http/
-        url = "https://" + url
-      end
-      URI(url).host
+      url = "https://" + url unless url =~ /http/
+      Addressable::URI.parse(url).normalize.host
     end
 
     def blacklisted_source?

--- a/lib/otw_sanitize/media_sanitizer.rb
+++ b/lib/otw_sanitize/media_sanitizer.rb
@@ -97,7 +97,7 @@ module OTWSanitize
       unless url =~ /http/
         url = "https://" + url
       end
-      URI(url).host
+      Addressable::URI.parse(url).normalize.host
     end
 
     def blacklisted_source?

--- a/lib/tasks/after_tasks.rake
+++ b/lib/tasks/after_tasks.rake
@@ -708,6 +708,7 @@ namespace :After do
   desc "Replace Archive-hosted Dewplayer embeds with HTML5 audio tags"
   task(replace_dewplayer_embeds: :environment) do
     updated_chapter_count = 0
+    errored_chapters = []
 
     Chapter.find_each do |chapter|
       puts(chapter.id) && STDOUT.flush if (chapter.id % 1000).zero?
@@ -717,11 +718,15 @@ namespace :After do
           chapter.sanitize_field(chapter, :content)
           updated_chapter_count += 1
         rescue StandardError
-          puts("Couldn't update chapter #{chapter.id}") && STDOUT.flush
+          errored_chapters << chapter.id
         end
       end
     end
 
+    if errored_chapters.any?
+      puts("Couldn't update #{errored_chapters.size} chapter(s): #{errored_chapters.join(',')}")
+      STDOUT.flush
+    end
     puts("Updated #{updated_chapter_count} chapter(s).") && STDOUT.flush
   end
 

--- a/spec/lib/html_cleaner_spec.rb
+++ b/spec/lib/html_cleaner_spec.rb
@@ -179,8 +179,18 @@ describe HtmlCleaner do
         end
 
         it "converts an Archive-hosted Dewplayer embed into an audio tag" do
-          html = '<embed type="application/x-shockwave-flash" flashvars="mp3=http://example.com/next%20color%20planet%27.mp3?dl=0" src="https://archiveofourown.org/system/dewplayer/dewplayer.swf" width="200" height="27" allowscriptaccess="never" allownetworking="internal"></embed>'
-          expect(sanitize_value(field, html)).to include('<audio src="https://example.com/next%20color%20planet%27.mp3?dl=0" controls="controls" crossorigin="anonymous" preload="metadata"></audio>')
+          html = '<embed type="application/x-shockwave-flash" flashvars="mp3=http://example.com/next%20color%20planet.mp3?dl=0" src="https://archiveofourown.org/system/dewplayer/dewplayer.swf" width="200" height="27" allowscriptaccess="never" allownetworking="internal"></embed>'
+          expect(sanitize_value(field, html)).to include('<audio src="https://example.com/next%20color%20planet.mp3?dl=0" controls="controls" crossorigin="anonymous" preload="metadata"></audio>')
+        end
+
+        it "converts an Archive-hosted Dewplayer embed with single quotes in the source URL into an audio tag" do
+          html = '<embed type="application/x-shockwave-flash" flashvars="mp3=http://example.com/\'quote%27.mp3" src="https://archiveofourown.org/system/dewplayer/dewplayer.swf" width="200" height="27" allowscriptaccess="never" allownetworking="internal"></embed>'
+          expect(sanitize_value(field, html)).to include('<audio src="https://example.com/\'quote%27.mp3" controls="controls" crossorigin="anonymous" preload="metadata"></audio>')
+        end
+
+        it "converts an Archive-hosted Dewplayer embed with double quotes in the source URL into an audio tag" do
+          html = '<embed type="application/x-shockwave-flash" flashvars=\'mp3=http://example.com/"quote%22.mp3\' src="https://archiveofourown.org/system/dewplayer/dewplayer.swf" width="200" height="27" allowscriptaccess="never" allownetworking="internal"></embed>'
+          expect(sanitize_value(field, html)).to include('<audio src="https://example.com/%22quote%22.mp3" controls="controls" crossorigin="anonymous" preload="metadata"></audio>')
         end
 
         it "converts an Archive-hosted Dewplayer embed with an encoded source URL into an audio tag" do
@@ -191,8 +201,7 @@ describe HtmlCleaner do
         it "converts an Archive-hosted Dewplayer multi embed into audio tags" do
           html = '<embed type="application/x-shockwave-flash" flashvars="mp3=http://example.com/live-again.mp3|http://example.com/cursed-night.mp3" src="https://archiveofourown.org/system/dewplayer/dewplayer.swf" width="200" height="27" allowscriptaccess="never" allownetworking="internal"></embed>'
           result = sanitize_value(field, html)
-          expect(result).to include('<audio src="https://example.com/live-again.mp3" controls="controls" crossorigin="anonymous" preload="metadata"></audio>')
-          expect(result).to include('<audio src="https://example.com/cursed-night.mp3" controls="controls" crossorigin="anonymous" preload="metadata"></audio>')
+          expect(result.squish).to eq('<p> <audio src="https://example.com/live-again.mp3" controls="controls" crossorigin="anonymous" preload="metadata"></audio> <br /> <audio src="https://example.com/cursed-night.mp3" controls="controls" crossorigin="anonymous" preload="metadata"></audio> </p>')
         end
 
         it "strips embeds with unknown source" do

--- a/spec/lib/html_cleaner_spec.rb
+++ b/spec/lib/html_cleaner_spec.rb
@@ -179,8 +179,13 @@ describe HtmlCleaner do
         end
 
         it "converts an Archive-hosted Dewplayer embed into an audio tag" do
-          html = '<embed type="application/x-shockwave-flash" flashvars="mp3=http://example.com/next%20color%20planet.mp3?dl=0" src="https://archiveofourown.org/system/dewplayer/dewplayer.swf" width="200" height="27" allowscriptaccess="never" allownetworking="internal"></embed>'
-          expect(sanitize_value(field, html)).to include('<audio src="https://example.com/next%20color%20planet.mp3?dl=0" controls="controls" crossorigin="anonymous" preload="metadata"></audio>')
+          html = '<embed type="application/x-shockwave-flash" flashvars="mp3=http://example.com/next%20color%20planet%27.mp3?dl=0" src="https://archiveofourown.org/system/dewplayer/dewplayer.swf" width="200" height="27" allowscriptaccess="never" allownetworking="internal"></embed>'
+          expect(sanitize_value(field, html)).to include('<audio src="https://example.com/next%20color%20planet%27.mp3?dl=0" controls="controls" crossorigin="anonymous" preload="metadata"></audio>')
+        end
+
+        it "converts an Archive-hosted Dewplayer embed with an encoded source URL into an audio tag" do
+          html = '<embed type="application/x-shockwave-flash" flashvars="param=val&amp;mp3=http%3A%2F%2Fexample.com%2Fnext%2520color%2520planet%2527.mp3%3Fdl%3D0" src="https://archiveofourown.org/system/dewplayer/dewplayer.swf" width="200" height="27" allowscriptaccess="never" allownetworking="internal"></embed>'
+          expect(sanitize_value(field, html)).to include('<audio src="https://example.com/next%20color%20planet%27.mp3?dl=0" controls="controls" crossorigin="anonymous" preload="metadata"></audio>')
         end
 
         it "converts an Archive-hosted Dewplayer multi embed into audio tags" do

--- a/spec/lib/html_cleaner_spec.rb
+++ b/spec/lib/html_cleaner_spec.rb
@@ -179,8 +179,8 @@ describe HtmlCleaner do
         end
 
         it "converts an Archive-hosted Dewplayer embed into an audio tag" do
-          html = '<embed type="application/x-shockwave-flash" flashvars="mp3=http://example.com/next-color-planet.mp3" src="https://archiveofourown.org/system/dewplayer/dewplayer.swf" width="200" height="27" allowscriptaccess="never" allownetworking="internal"></embed>'
-          expect(sanitize_value(field, html)).to include('<audio src="https://example.com/next-color-planet.mp3" controls="controls" crossorigin="anonymous" preload="metadata"></audio>')
+          html = '<embed type="application/x-shockwave-flash" flashvars="mp3=http://example.com/next%20color%20planet.mp3?dl=0" src="https://archiveofourown.org/system/dewplayer/dewplayer.swf" width="200" height="27" allowscriptaccess="never" allownetworking="internal"></embed>'
+          expect(sanitize_value(field, html)).to include('<audio src="https://example.com/next%20color%20planet.mp3?dl=0" controls="controls" crossorigin="anonymous" preload="metadata"></audio>')
         end
 
         it "converts an Archive-hosted Dewplayer multi embed into audio tags" do

--- a/spec/lib/tasks/after_tasks.rake_spec.rb
+++ b/spec/lib/tasks/after_tasks.rake_spec.rb
@@ -134,7 +134,15 @@ describe "rake After:replace_dewplayer_embeds" do
     expect do
       subject.invoke
     end.to avoid_changing { embed_work.reload.first_chapter.content }
+      .and output("Updated 1 chapter(s).\n").to_stdout
 
     expect(dewplayer_work.reload.first_chapter.content).to include('<audio src="https://example.com/HINOTORI.mp3" controls="controls" crossorigin="anonymous" preload="metadata"></audio>')
+  end
+
+  it "outputs chapter IDs with Dewplayer embeds that couldn't be updated" do
+    allow_any_instance_of(Chapter).to receive(:update_attribute).and_raise("monkey wrench")
+    expect do
+      subject.invoke
+    end.to output("Couldn't update 1 chapter(s): #{dewplayer_work.first_chapter.id}\nUpdated 0 chapter(s).\n").to_stdout
   end
 end


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6096

## Purpose

URL-encoded spaces in audio URLs of Dewplayer embeds get decoded when we [parse flashvars](https://helpx.adobe.com/flash/kb/pass-variables-swfs-flashvars.html), then the URLs with unencoded spaces get rejected as invalid by `URI` when we try to check their hosts in `MediaSanitizer`. We'll instead use `Addressable::URI` to parse URLs, which is more forgiving.

Also print out errored chapter IDs at the end of the rake task.

## Testing Instructions

See issue.