### PR TITLE
AO3-6105 Prevent mismatches in OwnedTagSets for TagSetNominations.

### DIFF
--- a/app/controllers/tag_set_nominations_controller.rb
+++ b/app/controllers/tag_set_nominations_controller.rb
@@ -26,7 +26,7 @@ class TagSetNominationsController < ApplicationController
   end
 
   def load_nomination
-    @tag_set_nomination = TagSetNomination.find_by_id(params[:id])
+    @tag_set_nomination = @tag_set.tag_set_nominations.find_by(id: params[:id])
     unless @tag_set_nomination
       flash[:error] = ts("Which nominations did you want to work with?")
       redirect_to tag_set_path(@tag_set) and return
@@ -99,7 +99,7 @@ class TagSetNominationsController < ApplicationController
   end
 
   def create
-    @tag_set_nomination = TagSetNomination.new(tag_set_nomination_params)
+    @tag_set_nomination = @tag_set.tag_set_nominations.build(tag_set_nomination_params)
     if @tag_set_nomination.save
       flash[:notice] = ts('Your nominations were successfully submitted.')
       redirect_to tag_set_nomination_path(@tag_set, @tag_set_nomination)
@@ -340,7 +340,6 @@ class TagSetNominationsController < ApplicationController
   def tag_set_nomination_params
     params.require(:tag_set_nomination).permit(
       :pseud_id,
-      :owned_tag_set_id,
       fandom_nominations_attributes: [
         :id,
         :tagname,

--- a/app/views/tag_set_nominations/_nomination_form.html.erb
+++ b/app/views/tag_set_nominations/_nomination_form.html.erb
@@ -24,8 +24,8 @@
   <fieldset>
     <legend>Basic Information</legend>
     <dl>
-      <dt><%= f.label :owned_tag_set_id, ts("Nominating For: ") %></dt>
-      <dd><%= f.hidden_field :owned_tag_set_id, :value => @tag_set_nomination.owned_tag_set.id %><%= link_to @tag_set_nomination.owned_tag_set.title, tag_set_path(@tag_set_nomination.owned_tag_set) %></dd>
+      <dt><%= ts("Nominating For: ") %></dt>
+      <dd><%= link_to @tag_set_nomination.owned_tag_set.title, tag_set_path(@tag_set_nomination.owned_tag_set) %></dd>
         
       <dt><%= f.label :pseud_id, ts("Pseud: ") %></dt>
       <dd><%= f.select :pseud_id, current_user.pseuds.collect {|p| [p.name, p.id] } %></dd>

--- a/spec/controllers/tag_set_nominations_controller_spec.rb
+++ b/spec/controllers/tag_set_nominations_controller_spec.rb
@@ -910,8 +910,8 @@ describe TagSetNominationsController do
           end
 
           it 'builds a new tag set nomination' do
-            expect { post :create, params: { tag_set_id: owned_tag_set.id, tag_set_nomination: { pseud_id: random_user.default_pseud.id } } }.
-              not_to change { owned_tag_set.tag_set_nominations.count }
+            expect { post :create, params: { tag_set_id: owned_tag_set.id, tag_set_nomination: { pseud_id: random_user.default_pseud.id } } }
+              .not_to change { owned_tag_set.tag_set_nominations.count }
             expect(assigns(:tag_set_nomination).new_record?).to be_truthy
             expect(assigns(:tag_set_nomination).pseud).to eq(random_user.default_pseud)
             expect(assigns(:tag_set_nomination).owned_tag_set).to eq(owned_tag_set)
@@ -1178,8 +1178,8 @@ describe TagSetNominationsController do
             end
 
             it "doesn't update the nominations" do
-              expect(fandom_nom.reload.tagname).not_to eq('Renamed Fandom')
-              expect(character_nom.reload.tagname).not_to eq('Renamed Character')
+              expect(fandom_nom.reload.tagname).not_to eq("Renamed Fandom")
+              expect(character_nom.reload.tagname).not_to eq("Renamed Character")
             end
           end
         end

--- a/spec/controllers/tag_set_nominations_controller_spec.rb
+++ b/spec/controllers/tag_set_nominations_controller_spec.rb
@@ -471,6 +471,16 @@ describe TagSetNominationsController do
             get :show, params: { id: tag_set_nomination.id, tag_set_id: owned_tag_set.id }
             expect(response).to render_template('show')
           end
+
+          context "when the nomination is from a different tag set" do
+            let(:owned_tag_set) { create(:owned_tag_set) }
+
+            it "redirects and returns an error message" do
+              get :show, params: { id: tag_set_nomination.id, tag_set_id: owned_tag_set.id }
+              it_redirects_to_with_error(tag_set_path(owned_tag_set),
+                                         "Which nominations did you want to work with?")
+            end
+          end
         end
       end
     end
@@ -715,6 +725,15 @@ describe TagSetNominationsController do
               to eq(['New Relationship 0'])
             expect(assigns(:tag_set_nomination).freeform_nominations.map(&:tagname)).to eq(['New Freeform 0'])
           end
+
+          context "when the nomination is from a different tag set" do
+            let(:owned_tag_set) { create(:owned_tag_set) }
+
+            it "redirects and returns an error message" do
+              it_redirects_to_with_error(tag_set_path(owned_tag_set),
+                                         "Which nominations did you want to work with?")
+            end
+          end
         end
 
         def add_character_nominations(num)
@@ -790,7 +809,6 @@ describe TagSetNominationsController do
                  tag_set_id: owned_tag_set.id,
                  tag_set_nomination: {
                    pseud_id: random_user.default_pseud.id,
-                   owned_tag_set_id: owned_tag_set.id,
                    character_nominations_attributes: {
                      "0": {
                        tagname: "Character A",
@@ -849,7 +867,6 @@ describe TagSetNominationsController do
             post :create, params: {
                  tag_set_id: owned_tag_set.id,
                  tag_set_nomination: { pseud_id: random_user.default_pseud.id,
-                                       owned_tag_set_id: owned_tag_set.id,
                                        fandom_nominations_attributes: {
                                          '0': { tagname: 'New Fandom',
                                                 character_nominations_attributes: {
@@ -888,14 +905,12 @@ describe TagSetNominationsController do
           end
 
           it 'renders the new template' do
-            post :create, params: { tag_set_id: owned_tag_set.id, tag_set_nomination: { pseud_id: random_user.default_pseud.id,
-                                                                              owned_tag_set_id: owned_tag_set.id } }
+            post :create, params: { tag_set_id: owned_tag_set.id, tag_set_nomination: { pseud_id: random_user.default_pseud.id } }
             expect(response).to render_template('new')
           end
 
           it 'builds a new tag set nomination' do
-            expect { post :create, params: { tag_set_id: owned_tag_set.id, tag_set_nomination: { pseud_id: random_user.default_pseud.id,
-                                                                                       owned_tag_set_id: owned_tag_set.id } } }.
+            expect { post :create, params: { tag_set_id: owned_tag_set.id, tag_set_nomination: { pseud_id: random_user.default_pseud.id } } }.
               not_to change { owned_tag_set.tag_set_nominations.count }
             expect(assigns(:tag_set_nomination).new_record?).to be_truthy
             expect(assigns(:tag_set_nomination).pseud).to eq(random_user.default_pseud)
@@ -907,8 +922,7 @@ describe TagSetNominationsController do
             owned_tag_set.update_column(:character_nomination_limit, 2)
             owned_tag_set.update_column(:relationship_nomination_limit, 3)
             owned_tag_set.update_column(:freeform_nomination_limit, 1)
-            post :create, params: { tag_set_id: owned_tag_set.id, tag_set_nomination: { pseud_id: random_user.default_pseud.id,
-                                                                              owned_tag_set_id: owned_tag_set.id } }
+            post :create, params: { tag_set_id: owned_tag_set.id, tag_set_nomination: { pseud_id: random_user.default_pseud.id } }
 
             expect(assigns(:tag_set_nomination).fandom_nominations.size).to eq(1)
             expect(assigns(:tag_set_nomination).fandom_nominations[0].character_nominations.size).to eq(2)
@@ -1011,7 +1025,6 @@ describe TagSetNominationsController do
                    id: tag_set_nom.id,
                    tag_set_nomination: {
                      pseud_id: tag_set_nom.pseud.id,
-                     owned_tag_set_id: owned_tag_set.id,
                      character_nominations_attributes: {
                        "0": {
                          id: character_nom.id,
@@ -1072,7 +1085,6 @@ describe TagSetNominationsController do
                   tag_set_id: owned_tag_set.id,
                   id: tag_set_nomination.id,
                   tag_set_nomination: { pseud_id: tag_nominator_pseud.id,
-                                        owned_tag_set_id: owned_tag_set.id,
                                         fandom_nominations_attributes: {
                                           '0': { tagname: 'Renamed Fandom',
                                                  id: fandom_nom.id,
@@ -1107,8 +1119,7 @@ describe TagSetNominationsController do
               put :update, params: {
                   tag_set_id: owned_tag_set.id,
                   id: tag_set_nomination.id,
-                  tag_set_nomination: { pseud_id: tag_nominator_pseud.id,
-                                        owned_tag_set_id: owned_tag_set.id }
+                  tag_set_nomination: { pseud_id: tag_nominator_pseud.id }
                 }
             end
 
@@ -1136,7 +1147,6 @@ describe TagSetNominationsController do
                 tag_set_id: owned_tag_set.id,
                 id: tag_set_nomination.id,
                 tag_set_nomination: { pseud_id: mod_pseud.id,
-                                      owned_tag_set_id: owned_tag_set.id,
                                       fandom_nominations_attributes: {
                                         '0': { tagname: 'Renamed Fandom',
                                                id: fandom_nom.id,
@@ -1157,6 +1167,20 @@ describe TagSetNominationsController do
           it 'redirects and returns a success message' do
             it_redirects_to_with_notice(tag_set_nomination_path(owned_tag_set, tag_set_nomination),
                                         'Your nominations were successfully updated.')
+          end
+
+          context "when the nomination is from a different tag set" do
+            let(:owned_tag_set) { create(:owned_tag_set) }
+
+            it "redirects and returns an error message" do
+              it_redirects_to_with_error(tag_set_path(owned_tag_set),
+                                         "Which nominations did you want to work with?")
+            end
+
+            it "doesn't update the nominations" do
+              expect(fandom_nom.reload.tagname).not_to eq('Renamed Fandom')
+              expect(character_nom.reload.tagname).not_to eq('Renamed Character')
+            end
           end
         end
       end
@@ -1194,18 +1218,19 @@ describe TagSetNominationsController do
       end
 
       context 'valid params' do
-        before do
-          allow(TagSetNomination).to receive(:find_by_id) { tag_set_nomination }
-        end
-
         context 'user is not moderator of tag set' do
           before do
             fake_login_known_user(tag_nominator.reload)
           end
 
           context 'at least one tag nomination associated with tag_set_nomination is reviewed' do
+            let(:fandom_nomination) do
+              FandomNomination.create(tag_set_nomination: tag_set_nomination,
+                                      tagname: "New Fandom")
+            end
+
             before do
-              allow(tag_set_nomination).to receive(:unreviewed?) { false }
+              fandom_nomination.update_column(:rejected, true)
             end
 
             it 'does not delete the tag set nomination' do
@@ -1221,10 +1246,6 @@ describe TagSetNominationsController do
           end
 
           context 'all tag nominations associated with tag_set_nomination are unreviewed' do
-            before do
-              allow(tag_set_nomination).to receive(:unreviewed?) { true }
-            end
-
             it 'deletes the tag set nomination' do
               expect { delete :destroy, params: { id: tag_set_nomination.id, tag_set_id: owned_tag_set.id } }.
                 to change { TagSetNomination.count }.by(-1)
@@ -1239,7 +1260,6 @@ describe TagSetNominationsController do
 
         context 'user is moderator of tag set' do
           before do
-            allow(tag_set_nomination).to receive(:unreviewed?) { false }
             fake_login_known_user(moderator.reload)
           end
 
@@ -1251,6 +1271,21 @@ describe TagSetNominationsController do
           it 'redirects and returns a success message' do
             delete :destroy, params: { id: tag_set_nomination.id, tag_set_id: owned_tag_set.id }
             it_redirects_to_with_notice(tag_set_path(owned_tag_set), 'Your nominations were deleted.')
+          end
+
+          context "when the nomination is from a different tag set" do
+            let(:owned_tag_set) { create(:owned_tag_set) }
+
+            it "redirects and returns an error message" do
+              delete :destroy, params: { id: tag_set_nomination.id, tag_set_id: owned_tag_set.id }
+              it_redirects_to_with_error(tag_set_path(owned_tag_set),
+                                         "Which nominations did you want to work with?")
+            end
+
+            it "doesn't delete the nomination" do
+              delete :destroy, params: { id: tag_set_nomination.id, tag_set_id: owned_tag_set.id }
+              expect { tag_set_nomination.reload }.not_to raise_exception
+            end
           end
         end
       end


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6105

## Purpose

The `TagSetNominations` controller allows you to view pages like `/tag_sets/:owned_tag_set_id/nominations/:id` where the tag set nomination's `owned_tag_set_id` doesn't match the `owned_tag_set_id` specified in the URL. This modifies the `before_action` hooks to make sure that the only tag set nominations accessible for a given `OwnedTagSet` are nominations for that tag set.