### PR TITLE
AO3-5928 Disable schema dumping after migrations

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -65,16 +65,13 @@ module Otwarchive
     # Configure sensitive parameters which will be filtered from the log file.
     config.filter_parameters += [:content, :password, :terms_of_service_non_production]
 
-    # configure middleware
-
-    ### things I'm preserving here from our Rails 2 environment.rb that we might or might not need
+    # Disable dumping schemas after migrations.
+    config.active_record.dump_schema_after_migration = false
 
     # Use SQL instead of Active Record's schema dumper when creating the test database.
     # This is necessary if your schema can't be completely dumped by the schema dumper,
     # like if you have constraints or database-specific column types
     config.active_record.schema_format = :sql
-
-    ### end of preservation section
 
     # handle errors with custom error pages:
     config.exceptions_app = self.routes

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -37,11 +37,6 @@ Otwarchive::Application.configure do
   # Inline ActiveJob when testing:
   config.active_job.queue_adapter = :inline
 
-  # Use SQL instead of Active Record's schema dumper when creating the test database.
-  # This is necessary if your schema can't be completely dumped by the schema dumper,
-  # like if you have constraints or database-specific column types
-  # config.active_record.schema_format = :sql
-
   # Print deprecation notices to the stderr
   config.active_support.deprecation = :stderr
 

--- a/lib/tasks/database_seed.rake
+++ b/lib/tasks/database_seed.rake
@@ -3,9 +3,16 @@
 namespace :db do
   desc "Raise an error unless the Rails.env is development"
   task :development_environment_only do
-    raise "ZOMG NOT IN PRODUCTION!" unless Rails.env.development? or Rails.env.test?
+    raise "ZOMG NOT IN PRODUCTION!" unless Rails.env.development? || Rails.env.test?
   end
 
   desc "Reset and then seed the development database with test data from the fixtures"
-  task :otwseed => [:environment, :development_environment_only, :reset, 'fixtures:load', 'work:missing_stat_counters', 'Tag:reset_filters', 'Tag:reset_filter_counts'] 
+  task otwseed: [
+    :environment, :development_environment_only,
+    # We can't use:
+    # - db:reset, because schema files may not be up-to-date and migrations are required.
+    # - db:migrate:reset, because we've deleted old migrations at various points.
+    :drop, :create, "schema:load", :migrate, :seed, "fixtures:load",
+    "work:missing_stat_counters", "Tag:reset_filters", "Tag:reset_filter_counts"
+  ]
 end


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5928

## Purpose

Disable schema dumping after migrations in all environments.

Because schema files are no longer updated when setting up CI tests, db:otwseed, which uses db:reset, which loads the outdated versions of schemas before seeding, fails if there are pending migrations. We need to set up the database and run migrations before seeding.

Also remove `config.active_record.schema_format` from test.rb, since it's already set in application.rb.

## Testing Instructions

See issue.