### PR TITLE
AO3-6108 Cache comment counts.

### DIFF
--- a/app/models/chapter.rb
+++ b/app/models/chapter.rb
@@ -193,4 +193,9 @@ class Chapter < ApplicationRecord
   def commentable_name
     self.work.title
   end
+
+  def expire_comments_count
+    super
+    work&.expire_comments_count
+  end
 end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -63,7 +63,7 @@ class Comment < ApplicationRecord
   end
 
   def saved_change_to_visibility?
-    pertinent_attributes = %w(is_deleted hidden_by_admin unreviewed approved)
+    pertinent_attributes = %w[is_deleted hidden_by_admin unreviewed approved]
     (saved_changes.keys & pertinent_attributes).present?
   end
 

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -915,7 +915,7 @@ class Work < ApplicationRecord
     counter = self.stat_counter || self.create_stat_counter
     counter.update_attributes(
       kudos_count: self.kudos.count,
-      comments_count: self.count_visible_comments,
+      comments_count: self.count_visible_comments_uncached,
       bookmarks_count: self.bookmarks.where(private: false).count
     )
   end

--- a/config/config.yml
+++ b/config/config.yml
@@ -477,6 +477,9 @@ CHARACTER_COUNT_SCRIPTS: ["Han", "Hiragana", "Katakana", "Thai"]
 SECONDS_UNTIL_WORK_INDEX_EXPIRE: 1800
 SECONDS_UNTIL_BOOKMARK_INDEX_EXPIRE: 1800
 
+# Cache duration for comment counts:
+SECONDS_UNTIL_COMMENT_COUNTS_EXPIRE: 3600
+
 # Batch size used for the RedisHitCounter class:
 HIT_COUNT_BATCH_SIZE: 100
 

--- a/features/comments_and_kudos/comment_moderation.feature
+++ b/features/comments_and_kudos/comment_moderation.feature
@@ -106,7 +106,8 @@ Feature: Comment Moderation
     Then I should see "Comment approved"
     When I am logged out
       And I view the work "Moderation"
-    Then I should see "Comments (1)"
+    Then I should see "Comments:1"
+      And I should see "Comments (1)"
     When I follow "Comments (1)"
     Then I should see "Test comment"
       And the comment on "Moderation" should not be marked as unreviewed
@@ -128,7 +129,8 @@ Feature: Comment Moderation
       And I should not see "Unreviewed"
       And I should not see "Unread"
     When I view the work "Moderation"
-    Then I should see "Comments (1)"
+    Then I should see "Comments:1"
+      And I should see "Comments (1)"
       And I should not see "Unreviewed Comments (1)"
 
   Scenario: Comments can be approved from the home page inbox
@@ -144,7 +146,8 @@ Feature: Comment Moderation
     When I follow "Unreviewed Comments"
       And I press "Approve"
       And I view the work "Moderation"
-    Then I should see "Comments (1)"
+    Then I should see "Comments:1"
+      And I should see "Comments (1)"
       And I should not see "Unreviewed Comments (1)"
 
   Scenario: Moderated comments can be deleted by the author
@@ -282,6 +285,8 @@ Feature: Comment Moderation
       And it is currently 1 second from now
       And I press "Update"
     Then the comment on "Moderation" should be marked as unreviewed
+      And I should not see "Comments:1"
+      And I should not see "Comments (1)"
 
   Scenario: I can approve multiple comments at once
     Given the moderated work "Moderation" by "author"

--- a/features/comments_and_kudos/comment_moderation.feature
+++ b/features/comments_and_kudos/comment_moderation.feature
@@ -285,7 +285,7 @@ Feature: Comment Moderation
       And it is currently 1 second from now
       And I press "Update"
     Then the comment on "Moderation" should be marked as unreviewed
-      And I should not see "Comments:1"
+      And I should not see "Comments:"
       And I should not see "Comments (1)"
 
   Scenario: I can approve multiple comments at once

--- a/features/comments_and_kudos/comments_delete.feature
+++ b/features/comments_and_kudos/comments_delete.feature
@@ -13,7 +13,9 @@ Feature: Delete a comment
       And I post the comment "Fail comment" on the work "Awesome story"
       And I delete the comment
     Then I should see "Comment deleted."
-    
+      And I should not see "Comments:1"
+      And I should not see a link "Hide Comments (1)"
+
   Scenario: User deletes a comment they added to a work and which is the parent of another comment
     When I am logged in as "author"
       And I post the work "Awesome story"
@@ -24,6 +26,8 @@ Feature: Delete a comment
     Then I should see "Comment deleted."
       And I should see "(Previous comment deleted.)"
       And I should see "I didn't mean that"
+      And I should see "Comments:1"
+      And I should see a link "Hide Comments (1)"
       
   Scenario: Author deletes a comment another user added to their work
     When I am logged in as "author"
@@ -34,6 +38,8 @@ Feature: Delete a comment
       And I view the work "Awesome story" with comments
       And I delete the comment
     Then I should see "Comment deleted."
+      And I should not see "Comments:1"
+      And I should not see a link "Hide Comments (1)"
     
   Scenario: Author deletes a parent comment that another user added to their work
     When I am logged in as "author"
@@ -47,6 +53,8 @@ Feature: Delete a comment
     Then I should see "Comment deleted."
       And I should see "(Previous comment deleted.)"
       And I should see "I didn't mean that"
+      And I should see "Comments:1"
+      And I should see a link "Hide Comments (1)"
 
   Scenario: Deleting higher-level comments in a deep comment thread should still allow readers to access the deeper comments.
 

--- a/features/comments_and_kudos/comments_delete.feature
+++ b/features/comments_and_kudos/comments_delete.feature
@@ -13,7 +13,7 @@ Feature: Delete a comment
       And I post the comment "Fail comment" on the work "Awesome story"
       And I delete the comment
     Then I should see "Comment deleted."
-      And I should not see "Comments:1"
+      And I should not see "Comments:"
       And I should not see a link "Hide Comments (1)"
 
   Scenario: User deletes a comment they added to a work and which is the parent of another comment
@@ -38,7 +38,7 @@ Feature: Delete a comment
       And I view the work "Awesome story" with comments
       And I delete the comment
     Then I should see "Comment deleted."
-      And I should not see "Comments:1"
+      And I should not see "Comments:"
       And I should not see a link "Hide Comments (1)"
     
   Scenario: Author deletes a parent comment that another user added to their work

--- a/features/step_definitions/comment_steps.rb
+++ b/features/step_definitions/comment_steps.rb
@@ -130,7 +130,7 @@ When /^I post a guest comment$/ do
 end
 
 When /^all comments by "([^"]*)" are marked as spam$/ do |name|
-  Comment.where(name: name).update_all(approved: false)
+  Comment.where(name: name).find_each(&:mark_as_spam!)
 end
 
 When /^I compose an invalid comment(?: within "([^"]*)")?$/ do |selector|

--- a/lib/plugins/acts_as_commentable/commentable_entity.rb
+++ b/lib/plugins/acts_as_commentable/commentable_entity.rb
@@ -41,11 +41,14 @@ module CommentableEntity
 
   # The total number of visible comments on this commentable. Cached to reduce
   # computation. The cache is manually expired whenever a comment is added,
-  # removed, or changes visibility, but the cache also expires after an hour in
-  # case of issues with the cache (e.g. stale data when calculating the count).
+  # removed, or changes visibility, but the cache also expires after a fixed
+  # amount of time in case of issues with the cache (e.g. stale data when
+  # calculating the count).
   def count_visible_comments
     @count_visible_comments ||=
-      Rails.cache.fetch(count_visible_comments_key, expires_in: 1.hour) do
+      Rails.cache.fetch(count_visible_comments_key,
+                        expires_in: ArchiveConfig.SECONDS_UNTIL_COMMENT_COUNTS_EXPIRE.seconds,
+                        race_condition_ttl: 10.seconds) do
         count_visible_comments_uncached
       end
   end  

--- a/lib/plugins/acts_as_commentable/commentable_entity.rb
+++ b/lib/plugins/acts_as_commentable/commentable_entity.rb
@@ -23,17 +23,41 @@ module CommentableEntity
 
   # These below have all been redefined to work for the archive
 
-  # redefined for our archive to also not include
-  # hidden-by-admin comments.
-  # returns number of visible (not deleted) comments
-  def count_visible_comments
+  # The total number of visible comments on this commentable, not including
+  # deleted comments, spam comments, unreviewed comments, and comments hidden
+  # by an admin.
+  #
+  # This is the uncached version, and should only be used when calculating an
+  # accurate value is important (e.g. when updating the StatCounter in the
+  # database).
+  def count_visible_comments_uncached
     self.total_comments.where(
       hidden_by_admin: false,
       is_deleted: false,
       unreviewed: false,
       approved: true
     ).count
+  end
+
+  # The total number of visible comments on this commentable. Cached to reduce
+  # computation. The cache is manually expired whenever a comment is added,
+  # removed, or changes visibility, but the cache also expires after an hour in
+  # case of issues with the cache (e.g. stale data when calculating the count).
+  def count_visible_comments
+    @count_visible_comments ||=
+      Rails.cache.fetch(count_visible_comments_key, expires_in: 1.hour) do
+        count_visible_comments_uncached
+      end
   end  
+
+  def count_visible_comments_key
+    "#{self.class.table_name}/#{self.id}/count_visible_comments"
+  end
+
+  def expire_comments_count
+    @count_visible_comments = nil
+    Rails.cache.delete(count_visible_comments_key)
+  end
 
   # Return the name of this commentable object
   # Should be overridden in the implementing class if necessary


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6108

## Purpose

Adds caching for various comment counts on works & admin posts. The cache is automatically expired when a comment is added, removed, or changes visibility, so it shouldn't affect the user experience, but it might reduce the server load a little.