### PR TITLE
AO3-6027 Test comment permissions on admin post edit form

### DIFF
--- a/features/comments_and_kudos/comments_adminposts.feature
+++ b/features/comments_and_kudos/comments_adminposts.feature
@@ -46,6 +46,8 @@ Feature: Commenting on admin posts
     When I choose "No one can comment"
       And I press "Post"
     Then I should see "successfully updated"
+    When I follow "Edit Post"
+    Then the "No one can comment" radio button should be checked
     When I am logged out
       And I go to the admin-posts page
       And I follow "Default Admin Post"
@@ -65,6 +67,8 @@ Feature: Commenting on admin posts
     When I choose "Only registered users can comment"
       And I press "Post"
     Then I should see "successfully updated"
+    When I follow "Edit Post"
+    Then the "Only registered users can comment" radio button should be checked
     When I am logged out
       And I go to the admin-posts page
       And I follow "Default Admin Post"
@@ -90,6 +94,8 @@ Feature: Commenting on admin posts
     When I choose "Registered users and guests can comment"
       And I press "Post"
     Then I should see "successfully updated"
+    When I follow "Edit Post"
+    Then the "Registered users and guests can comment" radio button should be checked
     When I am logged out
       And I go to the admin-posts page
       And I follow "Default Admin Post"

--- a/features/step_definitions/web_steps.rb
+++ b/features/step_definitions/web_steps.rb
@@ -253,7 +253,7 @@ Then /^the "([^"]*)" field(?: within "([^"]*)")? should not contain "([^"]*)"$/ 
   end
 end
 
-Then /^the "(.*?)" (checkbox|radio button)(?: within "(.*?)")? should be checked( and disabled)?$/ do |label, input_type, selector, disabled|
+Then /^the "(.*?)" (checkbox|radio button)(?: within "(.*?)")? should be checked( and disabled)?$/ do |label, _input_type, selector, disabled|
   with_scope(selector) do
     assert has_checked_field?(label, disabled: disabled.present?)
   end

--- a/features/step_definitions/web_steps.rb
+++ b/features/step_definitions/web_steps.rb
@@ -253,7 +253,7 @@ Then /^the "([^"]*)" field(?: within "([^"]*)")? should not contain "([^"]*)"$/ 
   end
 end
 
-Then /^the "(.*?)" checkbox(?: within "(.*?)")? should be checked( and disabled)?$/ do |label, selector, disabled|
+Then /^the "(.*?)" (checkbox|radio button)(?: within "(.*?)")? should be checked( and disabled)?$/ do |label, input_type, selector, disabled|
   with_scope(selector) do
     assert has_checked_field?(label, disabled: disabled.present?)
   end


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [x] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [x] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [x] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-6027

## Purpose

Adds some extra tests steps to validate that admin post permissions are still displayed correctly when editing the post.

## Testing Instructions

This PR changes testing only.

## References

See #3919 for original implementation

