### PR TITLE
AO3-4709 Comment freezing fixes

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -419,11 +419,11 @@ class CommentsController < ApplicationController
     # @comment.full_set.each(&:mark_frozen!)
     if !@comment.iced? && @comment.save
       @comment.set_to_freeze_or_unfreeze.each(&:mark_frozen!)
-      flash[:notice] = t(".success")
+      flash[:comment_notice] = t(".success")
     else
-      flash[:error] = t(".error")
+      flash[:comment_error] = t(".error")
     end
-    redirect_back(fallback_location: root_path)
+    redirect_to_all_comments(@comment.ultimate_parent, show_comments: true)
   end
 
   # PUT /comments/1/unfreeze
@@ -432,11 +432,11 @@ class CommentsController < ApplicationController
     # @comment.full_set.each(&:mark_unfrozen!)
     if @comment.iced? && @comment.save
       @comment.set_to_freeze_or_unfreeze.each(&:mark_unfrozen!)
-      flash[:notice] = t(".success")
+      flash[:comment_notice] = t(".success")
     else
-      flash[:error] = t(".error")
+      flash[:comment_error] = t(".error")
     end
-    redirect_back(fallback_location: root_path)
+    redirect_to_all_comments(@comment.ultimate_parent, show_comments: true)
   end
 
   def show_comments

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -20,7 +20,7 @@ class Comment < ApplicationRecord
     maximum: ArchiveConfig.COMMENT_MAX,
     too_long: ts("must be less than %{count} characters long.", count: ArchiveConfig.COMMENT_MAX)
 
-  validate :check_for_spam
+  validate :check_for_spam, on: :create
 
   def check_for_spam
     errors.add(:base, ts("This comment looks like spam to our system, sorry! Please try again, or create an account to comment.")) unless check_for_spam?

--- a/public/stylesheets/site/2.0/02-elements.css
+++ b/public/stylesheets/site/2.0/02-elements.css
@@ -26,7 +26,6 @@ a, a:link, a:visited:hover {
   color: #111;
   text-decoration: none;
   border-bottom: 1px solid;
-  cursor: pointer;
 }
 
 a:visited {

--- a/public/stylesheets/site/2.0/07-interactions.css
+++ b/public/stylesheets/site/2.0/07-interactions.css
@@ -1,13 +1,13 @@
 /*==INTERACTIONS: global form rules
 http://otwcode.github.com/docs/front_end_coding/patterns/interactions
 (submit button styling is in actions.css with the other buttons)
-General rules for all form elements, and nearly ALL our forms use just these. 
+General rules for all form elements, and nearly ALL our forms use just these.
 Forms are normally in definition lists <dt label: dd input>
 with some un/ordered lists, normally of checkbox options <li checkbox:label>
 and some paragraphs, normally forms with a single <p label:input> .
 
 We might develop three MODES: .simple .verbose and .dynamic -- .sim and ver in early draft in sandbox
-We also have some jS WIDGETS, which are custom form interactions, like autocomplete 
+We also have some jS WIDGETS, which are custom form interactions, like autocomplete
 and a few variations for INTERACTION TYPES, which are, roughly:
 .post, .login, make .associations, set .preferences, [.search, .filter] => in searchbrowse
 */
@@ -21,8 +21,8 @@ fieldset {
   min-width: 0;
 }
 
-/*Guideline: Forms are written by lots of people, and, this is beta, change a LOT. 
-I've written a load of possible different nests to give a reasonably/broadly consistent view whatever goes in, 
+/*Guideline: Forms are written by lots of people, and, this is beta, change a LOT.
+I've written a load of possible different nests to give a reasonably/broadly consistent view whatever goes in,
 but it's probably not complete. */
 
 fieldset, form dl, fieldset dl dl, fieldset fieldset fieldset, fieldset fieldset dl dl, dd.hideme, form blockquote.userstuff {
@@ -62,7 +62,6 @@ legend, input[type="hidden"] {
 }
 
 label {
-  cursor: pointer;
   margin-right: 0.375em;
 }
 
@@ -149,7 +148,7 @@ form .footnote code {
   display: inline;
 }
 
-/* when we display information that cannot be edited, 
+/* when we display information that cannot be edited,
 like the current username on the change username form */
 form dd p.informational {
   padding-top: 0;
@@ -388,7 +387,7 @@ qTip2 Copyright 2009-2010 Craig Michael Thompson - http://craigsworks.com*/
 
 /* WIDGET: MODAL DIALOGS (called by help links) */
 
-a.modal.help { 
+a.modal.help {
   cursor: help;
 }
 
@@ -416,7 +415,7 @@ a.modal.help {
   width: 124px;
 }
 
-#modal-wrap { 
+#modal-wrap {
   display: none;
   position: absolute;
   right: 0;
@@ -429,7 +428,7 @@ a.modal.help {
   height: 100%;
 }
 
-#modal-wrap:before, #modal { 
+#modal-wrap:before, #modal {
   display: inline-block;
   vertical-align: middle;
 }
@@ -443,7 +442,7 @@ a.modal.help {
   padding-bottom: 44px;
   position: relative;
   text-align: left;
-  width: 80%; 
+  width: 80%;
   z-index: 501;
     box-shadow: 0 0 8px 0 rgba(0, 0, 0, 0.2);
 }
@@ -495,7 +494,7 @@ a.modal.help {
   width: auto;
 }
 
-#modal.img .content { 
+#modal.img .content {
   border: 0;
   overflow: visible;
   padding: 0;
@@ -539,7 +538,7 @@ a.modal.help {
   right: 8px;
 }
 
-#modal .content > h1:first-child, #modal .content > h2:first-child, #modal .content > .heading:first-child { 
+#modal .content > h1:first-child, #modal .content > h2:first-child, #modal .content > .heading:first-child {
   margin-top: 0.5em;
 }
 
@@ -551,7 +550,7 @@ div.dynamic {
   z-index: 500;
 }
 
-/*MODE: VERBOSE for forms with more than three fieldsets 
+/*MODE: VERBOSE for forms with more than three fieldsets
 TO DO: Make VERBOSE a class on FORM across the site; it is a surrounding DIV
 in some areas, hence .verbose form */
 

--- a/public/stylesheets/site/2.0/08-actions.css
+++ b/public/stylesheets/site/2.0/08-actions.css
@@ -33,7 +33,6 @@ ul.actions {
   white-space: nowrap;
   overflow: visible;
   position: relative;
-  cursor: pointer;
   text-decoration: none;
   border: 1px solid #bbb;
   border-bottom: 1px solid #aaa;
@@ -64,9 +63,6 @@ p.submit, input.submit, dd.submit {
   text-align: right;
 }
 
-.actions input.text, .actions input[type="text"] {
-  cursor: text;
-}
 
 .actions input[type="checkbox"] {
   background: transparent;
@@ -115,7 +111,6 @@ ol.pagination, div.pagination, ol.year {
   font-weight: 900;
   margin-right: 0.375em;
   padding: 0 0.1em 0.15em;
-  cursor: pointer;
     box-shadow: -1px -1px 2px rgba(0,0,0,0.75);
     border-radius: 0.875em;
 }

--- a/public/stylesheets/site/2.0/09-roles-states.css
+++ b/public/stylesheets/site/2.0/09-roles-states.css
@@ -1,4 +1,4 @@
-/*==ROLES AND STATES 
+/*==ROLES AND STATES
 http://otwcode.github.com/docs/front_end_coding/patterns/modifiers
 */
 
@@ -27,7 +27,6 @@ span.unread, .replied, span.claimed, .actions span.defaulted {
   white-space: nowrap;
   overflow: visible;
   position: relative;
-  cursor: pointer;
   text-decoration: none;
   border: 1px solid #bbb;
   border-bottom: 1px solid #aaa;
@@ -68,7 +67,7 @@ span.offered.requested {
 
 /* Arrows for the accordion widget */
 
-.collapsed:after { 
+.collapsed:after {
   content: " \2193";
 }
 

--- a/spec/controllers/comments_controller_spec.rb
+++ b/spec/controllers/comments_controller_spec.rb
@@ -811,7 +811,7 @@ describe CommentsController do
       context "when comment is spam" do
         let(:comment) { create(:comment) }
 
-        before  { comment.update_attribute(:approved, false) }
+        before { comment.update_attribute(:approved, false) }
 
         it "freezes the comment and redirects with success message without changing the approved status" do
           fake_login_known_user(comment.ultimate_parent.pseuds.first.user)

--- a/spec/controllers/comments_controller_spec.rb
+++ b/spec/controllers/comments_controller_spec.rb
@@ -794,6 +794,21 @@ describe CommentsController do
         end
       end
 
+      context "when comment is spam" do
+        let(:comment) { create(:comment) }
+
+        before  { comment.update_attribute(:approved, false) }
+
+        it "freezes the comment and redirects with success message without changing the approved status" do
+          fake_login_known_user(comment.ultimate_parent.pseuds.first.user)
+          put :freeze, params: { id: comment.id }
+
+          expect(comment.reload.iced).to be_truthy
+          expect(comment.reload.approved).to be_falsey
+          it_redirects_to_with_notice("/where_i_came_from", "Comment thread successfully frozen!")
+        end
+      end
+
       context "when comment is not saved" do
         let!(:comment) { create(:comment) }
 
@@ -1475,6 +1490,21 @@ describe CommentsController do
           expect(child1.reload.iced).to be_truthy
           expect(child2.reload.iced).to be_truthy
           expect(comment.reload.iced).to be_falsey
+          it_redirects_to_with_notice("/where_i_came_from", "Comment thread successfully unfrozen!")
+        end
+      end
+
+      context "when comment is spam" do
+        let(:comment) { create(:comment, iced: true) }
+
+        before { comment.update_attribute(:approved, false) }
+
+        it "unfreezes the comment and redirects with success message without changing the approved status" do
+          fake_login_known_user(comment.ultimate_parent.pseuds.first.user)
+          put :unfreeze, params: { id: comment.id }
+
+          expect(comment.reload.iced).to be_falsey
+          expect(comment.reload.approved).to be_falsey
           it_redirects_to_with_notice("/where_i_came_from", "Comment thread successfully unfrozen!")
         end
       end

--- a/spec/controllers/comments_controller_spec.rb
+++ b/spec/controllers/comments_controller_spec.rb
@@ -602,9 +602,10 @@ describe CommentsController do
             put :freeze, params: { id: comment.id }
 
             expect(comment.reload.iced).to be_truthy
-            expect(response).to redirect_to(admin_post_path(comment.ultimate_parent, show_comments: true, anchor: :comments))
-            expect(flash[:comment_error]).to be_blank
-            expect(flash[:comment_notice]).to eq("Comment thread successfully frozen!")
+            it_redirects_to_with_comment_notice(
+              admin_post_path(comment.ultimate_parent, show_comments: true, anchor: :comments),
+              "Comment thread successfully frozen!"
+            )
           end
         end
 
@@ -653,9 +654,10 @@ describe CommentsController do
                 put :freeze, params: { id: comment.id }
 
                 expect(comment.reload.iced).to be_truthy
-                expect(response).to redirect_to(comments_path(tag_id: comment.ultimate_parent, anchor: :comments))
-                expect(flash[:comment_error]).to be_blank
-                expect(flash[:comment_notice]).to eq("Comment thread successfully frozen!")
+                it_redirects_to_with_comment_notice(
+                  comments_path(tag_id: comment.ultimate_parent, anchor: :comments),
+                  "Comment thread successfully frozen!"
+                )
               end
             end
           end
@@ -718,9 +720,10 @@ describe CommentsController do
                 put :freeze, params: { id: comment.id }
 
                 expect(comment.reload.iced).to be_truthy
-                expect(response).to redirect_to(work_path(comment.ultimate_parent, show_comments: true, anchor: :comments))
-                expect(flash[:comment_error]).to be_blank
-                expect(flash[:comment_notice]).to eq("Comment thread successfully frozen!")
+                it_redirects_to_with_comment_notice(
+                  work_path(comment.ultimate_parent, show_comments: true, anchor: :comments),
+                  "Comment thread successfully frozen!"
+                )
               end
             end
           end
@@ -742,9 +745,10 @@ describe CommentsController do
             put :freeze, params: { id: comment.id }
 
             expect(comment.reload.iced).to be_truthy
-            expect(response).to redirect_to(work_path(comment.ultimate_parent, show_comments: true, anchor: :comments))
-            expect(flash[:comment_error]).to be_blank
-            expect(flash[:comment_notice]).to eq("Comment thread successfully frozen!")
+            it_redirects_to_with_comment_notice(
+              work_path(comment.ultimate_parent, show_comments: true, anchor: :comments),
+              "Comment thread successfully frozen!"
+            )
           end
         end
       end
@@ -762,9 +766,10 @@ describe CommentsController do
           [comment, child1, child2, grandchild].each do |comment|
             expect(comment.reload.iced).to be_truthy
           end
-          expect(response).to redirect_to(work_path(comment.ultimate_parent, show_comments: true, anchor: :comments))
-          expect(flash[:comment_error]).to be_blank
-          expect(flash[:comment_notice]).to eq("Comment thread successfully frozen!")
+          it_redirects_to_with_comment_notice(
+            work_path(comment.ultimate_parent, show_comments: true, anchor: :comments),
+            "Comment thread successfully frozen!"
+          )
         end
       end
 
@@ -782,9 +787,10 @@ describe CommentsController do
           expect(child.reload.iced).to be_truthy
           expect(parent.reload.iced).to be_falsey
           expect(sibling.reload.iced).to be_falsey
-          expect(response).to redirect_to(work_path(comment.ultimate_parent, show_comments: true, anchor: :comments))
-          expect(flash[:comment_error]).to be_blank
-          expect(flash[:comment_notice]).to eq("Comment thread successfully frozen!")
+          it_redirects_to_with_comment_notice(
+            work_path(comment.ultimate_parent, show_comments: true, anchor: :comments),
+            "Comment thread successfully frozen!"
+          )
         end
       end
 
@@ -802,9 +808,10 @@ describe CommentsController do
           expect(child1.reload.iced).to be_falsey
           expect(child2.reload.iced).to be_falsey
           expect(comment.reload.iced).to be_truthy
-          expect(response).to redirect_to(work_path(comment.ultimate_parent, show_comments: true, anchor: :comments))
-          expect(flash[:comment_error]).to be_blank
-          expect(flash[:comment_notice]).to eq("Comment thread successfully frozen!")
+          it_redirects_to_with_comment_notice(
+            work_path(comment.ultimate_parent, show_comments: true, anchor: :comments),
+            "Comment thread successfully frozen!"
+          )
         end
       end
 
@@ -819,9 +826,10 @@ describe CommentsController do
 
           expect(comment.reload.iced).to be_truthy
           expect(comment.reload.approved).to be_falsey
-          expect(response).to redirect_to(work_path(comment.ultimate_parent, show_comments: true, anchor: :comments))
-          expect(flash[:comment_error]).to be_blank
-          expect(flash[:comment_notice]).to eq("Comment thread successfully frozen!")
+          it_redirects_to_with_comment_notice(
+            work_path(comment.ultimate_parent, show_comments: true, anchor: :comments),
+            "Comment thread successfully frozen!"
+          )
         end
       end
 
@@ -836,9 +844,10 @@ describe CommentsController do
           fake_login_known_user(comment.ultimate_parent.pseuds.first.user)
           put :freeze, params: { id: comment.id }
 
-          expect(response).to redirect_to(work_path(comment.ultimate_parent, show_comments: true, anchor: :comments))
-          expect(flash[:comment_notice]).to be_blank
-          expect(flash[:comment_error]).to eq("Sorry, that comment thread could not be frozen.")
+          it_redirects_to_with_comment_error(
+            work_path(comment.ultimate_parent, show_comments: true, anchor: :comments),
+            "Sorry, that comment thread could not be frozen."
+          )
         end
       end
     end
@@ -864,9 +873,10 @@ describe CommentsController do
             put :freeze, params: { id: comment.id }
 
             expect(comment.reload.iced).to be_truthy
-            expect(response).to redirect_to(admin_post_path(comment.ultimate_parent, show_comments: true, anchor: :comments))
-            expect(flash[:comment_notice]).to be_blank
-            expect(flash[:comment_error]).to eq("Sorry, that comment thread could not be frozen.")
+            it_redirects_to_with_comment_error(
+              admin_post_path(comment.ultimate_parent, show_comments: true, anchor: :comments),
+              "Sorry, that comment thread could not be frozen."
+            )
           end
         end
 
@@ -915,9 +925,10 @@ describe CommentsController do
                 put :freeze, params: { id: comment.id }
 
                 expect(comment.reload.iced).to be_truthy
-                expect(response).to redirect_to(comments_path(tag_id: comment.ultimate_parent, anchor: :comments))
-                expect(flash[:comment_notice]).to be_blank
-                expect(flash[:comment_error]).to eq("Sorry, that comment thread could not be frozen.")
+                it_redirects_to_with_comment_error(
+                  comments_path(tag_id: comment.ultimate_parent, anchor: :comments),
+                  "Sorry, that comment thread could not be frozen."
+                )
               end
             end
           end
@@ -980,9 +991,10 @@ describe CommentsController do
                 put :freeze, params: { id: comment.id }
 
                 expect(comment.reload.iced).to be_truthy
-                expect(response).to redirect_to(work_path(comment.ultimate_parent, show_comments: true, anchor: :comments))
-                expect(flash[:comment_notice]).to be_blank
-                expect(flash[:comment_error]).to eq("Sorry, that comment thread could not be frozen.")
+                it_redirects_to_with_comment_error(
+                  work_path(comment.ultimate_parent, show_comments: true, anchor: :comments),
+                  "Sorry, that comment thread could not be frozen."
+                )
               end
             end
           end
@@ -1004,9 +1016,10 @@ describe CommentsController do
             put :freeze, params: { id: comment.id }
 
             expect(comment.reload.iced).to be_truthy
-            expect(response).to redirect_to(work_path(comment.ultimate_parent, show_comments: true, anchor: :comments))
-            expect(flash[:comment_notice]).to be_blank
-            expect(flash[:comment_error]).to eq("Sorry, that comment thread could not be frozen.")
+            it_redirects_to_with_comment_error(
+              work_path(comment.ultimate_parent, show_comments: true, anchor: :comments),
+              "Sorry, that comment thread could not be frozen."
+            )
           end
         end
       end
@@ -1024,9 +1037,10 @@ describe CommentsController do
           [comment, child1, child2, grandchild].each do |comment|
             expect(comment.reload.iced).to be_truthy
           end
-          expect(response).to redirect_to(work_path(comment.ultimate_parent, show_comments: true, anchor: :comments))
-          expect(flash[:comment_notice]).to be_blank
-          expect(flash[:comment_error]).to eq("Sorry, that comment thread could not be frozen.")
+          it_redirects_to_with_comment_error(
+            work_path(comment.ultimate_parent, show_comments: true, anchor: :comments),
+            "Sorry, that comment thread could not be frozen."
+          )
         end
       end
 
@@ -1043,9 +1057,10 @@ describe CommentsController do
           [comment, child, parent, sibling].each do |comment|
             expect(comment.reload.iced).to be_truthy
           end
-          expect(response).to redirect_to(work_path(comment.ultimate_parent, show_comments: true, anchor: :comments))
-          expect(flash[:comment_notice]).to be_blank
-          expect(flash[:comment_error]).to eq("Sorry, that comment thread could not be frozen.")
+          it_redirects_to_with_comment_error(
+            work_path(comment.ultimate_parent, show_comments: true, anchor: :comments),
+            "Sorry, that comment thread could not be frozen."
+          )
         end
       end
 
@@ -1062,9 +1077,10 @@ describe CommentsController do
           [comment, parent, child1, child2].each do |comment|
             expect(comment.reload.iced).to be_truthy
           end
-          expect(response).to redirect_to(work_path(comment.ultimate_parent, show_comments: true, anchor: :comments))
-          expect(flash[:comment_notice]).to be_blank
-          expect(flash[:comment_error]).to eq("Sorry, that comment thread could not be frozen.")
+          it_redirects_to_with_comment_error(
+            work_path(comment.ultimate_parent, show_comments: true, anchor: :comments),
+            "Sorry, that comment thread could not be frozen."
+          )
         end
       end
 
@@ -1079,9 +1095,10 @@ describe CommentsController do
           fake_login_known_user(comment.ultimate_parent.pseuds.first.user)
           put :freeze, params: { id: comment.id }
 
-          expect(response).to redirect_to(work_path(comment.ultimate_parent, show_comments: true, anchor: :comments))
-          expect(flash[:comment_notice]).to be_blank
-          expect(flash[:comment_error]).to eq("Sorry, that comment thread could not be frozen.")
+          it_redirects_to_with_comment_error(
+            work_path(comment.ultimate_parent, show_comments: true, anchor: :comments),
+            "Sorry, that comment thread could not be frozen."
+          )
         end
       end
     end
@@ -1104,14 +1121,15 @@ describe CommentsController do
         context "when logged in as an admin" do
           let(:admin) { create(:admin) }
 
-          it "leaves comment unfrozen and redirects with success message" do
+          it "leaves comment unfrozen and redirects with error" do
             fake_login_admin(admin)
             put :unfreeze, params: { id: comment.id }
 
             expect(comment.reload.iced).to be_falsey
-            expect(response).to redirect_to(admin_post_path(comment.ultimate_parent, show_comments: true, anchor: :comments))
-            expect(flash[:comment_notice]).to be_blank
-            expect(flash[:comment_error]).to eq("Sorry, that comment thread could not be unfrozen.")
+            it_redirects_to_with_comment_error(
+              admin_post_path(comment.ultimate_parent, show_comments: true, anchor: :comments),
+              "Sorry, that comment thread could not be unfrozen."
+            )
           end
         end
 
@@ -1160,9 +1178,10 @@ describe CommentsController do
                 put :unfreeze, params: { id: comment.id }
 
                 expect(comment.reload.iced).to be_falsey
-                expect(response).to redirect_to(comments_path(tag_id: comment.ultimate_parent, anchor: :comments))
-                expect(flash[:comment_notice]).to be_blank
-                expect(flash[:comment_error]).to eq("Sorry, that comment thread could not be unfrozen.")
+                it_redirects_to_with_comment_error(
+                  comments_path(tag_id: comment.ultimate_parent, anchor: :comments),
+                  "Sorry, that comment thread could not be unfrozen."
+                )
               end
             end
           end
@@ -1225,9 +1244,10 @@ describe CommentsController do
                 put :unfreeze, params: { id: comment.id }
 
                 expect(comment.reload.iced).to be_falsey
-                expect(response).to redirect_to(work_path(comment.ultimate_parent, show_comments: true, anchor: :comments))
-                expect(flash[:comment_notice]).to be_blank
-                expect(flash[:comment_error]).to eq("Sorry, that comment thread could not be unfrozen.")
+                it_redirects_to_with_comment_error(
+                  work_path(comment.ultimate_parent, show_comments: true, anchor: :comments),
+                  "Sorry, that comment thread could not be unfrozen."
+                )
               end
             end
           end
@@ -1249,9 +1269,10 @@ describe CommentsController do
             put :unfreeze, params: { id: comment.id }
 
             expect(comment.reload.iced).to be_falsey
-            expect(response).to redirect_to(work_path(comment.ultimate_parent, show_comments: true, anchor: :comments))
-            expect(flash[:comment_notice]).to be_blank
-            expect(flash[:comment_error]).to eq("Sorry, that comment thread could not be unfrozen.")
+            it_redirects_to_with_comment_error(
+              work_path(comment.ultimate_parent, show_comments: true, anchor: :comments),
+              "Sorry, that comment thread could not be unfrozen."
+            )
           end
         end
       end
@@ -1269,9 +1290,10 @@ describe CommentsController do
           [comment, child1, child2, grandchild].each do |comment|
             expect(comment.reload.iced).to be_falsey
           end
-          expect(response).to redirect_to(work_path(comment.ultimate_parent, show_comments: true, anchor: :comments))
-          expect(flash[:comment_notice]).to be_blank
-          expect(flash[:comment_error]).to eq("Sorry, that comment thread could not be unfrozen.")
+          it_redirects_to_with_comment_error(
+            work_path(comment.ultimate_parent, show_comments: true, anchor: :comments),
+            "Sorry, that comment thread could not be unfrozen."
+          )
         end
       end
 
@@ -1288,9 +1310,10 @@ describe CommentsController do
           [comment, child, parent, sibling].each do |comment|
             expect(comment.reload.iced).to be_falsey
           end
-          expect(response).to redirect_to(work_path(comment.ultimate_parent, show_comments: true, anchor: :comments))
-          expect(flash[:comment_notice]).to be_blank
-          expect(flash[:comment_error]).to eq("Sorry, that comment thread could not be unfrozen.")
+          it_redirects_to_with_comment_error(
+            work_path(comment.ultimate_parent, show_comments: true, anchor: :comments),
+            "Sorry, that comment thread could not be unfrozen."
+          )
         end
       end
 
@@ -1307,9 +1330,10 @@ describe CommentsController do
           [comment, parent, child1, child2].each do |comment|
             expect(comment.reload.iced).to be_falsey
           end
-          expect(response).to redirect_to(work_path(comment.ultimate_parent, show_comments: true, anchor: :comments))
-          expect(flash[:comment_notice]).to be_blank
-          expect(flash[:comment_error]).to eq("Sorry, that comment thread could not be unfrozen.")
+          it_redirects_to_with_comment_error(
+            work_path(comment.ultimate_parent, show_comments: true, anchor: :comments),
+            "Sorry, that comment thread could not be unfrozen."
+          )
         end
       end
 
@@ -1324,9 +1348,10 @@ describe CommentsController do
           fake_login_known_user(comment.ultimate_parent.pseuds.first.user)
           put :unfreeze, params: { id: comment.id }
 
-          expect(response).to redirect_to(work_path(comment.ultimate_parent, show_comments: true, anchor: :comments))
-          expect(flash[:comment_notice]).to be_blank
-          expect(flash[:comment_error]).to eq("Sorry, that comment thread could not be unfrozen.")
+          it_redirects_to_with_comment_error(
+            work_path(comment.ultimate_parent, show_comments: true, anchor: :comments),
+            "Sorry, that comment thread could not be unfrozen."
+          )
         end
       end
     end
@@ -1352,9 +1377,10 @@ describe CommentsController do
             put :unfreeze, params: { id: comment.id }
 
             expect(comment.reload.iced).to be_falsey
-            expect(response).to redirect_to(admin_post_path(comment.ultimate_parent, show_comments: true, anchor: :comments))
-            expect(flash[:comment_error]).to be_blank
-            expect(flash[:comment_notice]).to eq("Comment thread successfully unfrozen!")
+            it_redirects_to_with_comment_notice(
+              admin_post_path(comment.ultimate_parent, show_comments: true, anchor: :comments),
+              "Comment thread successfully unfrozen!"
+            )
           end
         end
 
@@ -1403,9 +1429,10 @@ describe CommentsController do
                 put :unfreeze, params: { id: comment.id }
 
                 expect(comment.reload.iced).to be_falsey
-                expect(response).to redirect_to(comments_path(tag_id: comment.ultimate_parent, anchor: :comments))
-                expect(flash[:comment_error]).to be_blank
-                expect(flash[:comment_notice]).to eq("Comment thread successfully unfrozen!")
+                it_redirects_to_with_comment_notice(
+                  comments_path(tag_id: comment.ultimate_parent, anchor: :comments),
+                  "Comment thread successfully unfrozen!"
+                )
               end
             end
           end
@@ -1468,9 +1495,10 @@ describe CommentsController do
                 put :unfreeze, params: { id: comment.id }
 
                 expect(comment.reload.iced).to be_falsey
-                expect(response).to redirect_to(work_path(comment.ultimate_parent, show_comments: true, anchor: :comments))
-                expect(flash[:comment_error]).to be_blank
-                expect(flash[:comment_notice]).to eq("Comment thread successfully unfrozen!")
+                it_redirects_to_with_comment_notice(
+                  work_path(comment.ultimate_parent, show_comments: true, anchor: :comments),
+                  "Comment thread successfully unfrozen!"
+                )
               end
             end
           end
@@ -1492,9 +1520,10 @@ describe CommentsController do
             put :unfreeze, params: { id: comment.id }
 
             expect(comment.reload.iced).to be_falsey
-            expect(response).to redirect_to(work_path(comment.ultimate_parent, show_comments: true, anchor: :comments))
-            expect(flash[:comment_error]).to be_blank
-            expect(flash[:comment_notice]).to eq("Comment thread successfully unfrozen!")
+            it_redirects_to_with_comment_notice(
+              work_path(comment.ultimate_parent, show_comments: true, anchor: :comments),
+              "Comment thread successfully unfrozen!"
+            )
           end
         end
       end
@@ -1512,9 +1541,10 @@ describe CommentsController do
           [comment, child1, child2, grandchild].each do |comment|
             expect(comment.reload.iced).to be_falsey
           end
-          expect(response).to redirect_to(work_path(comment.ultimate_parent, show_comments: true, anchor: :comments))
-          expect(flash[:comment_error]).to be_blank
-          expect(flash[:comment_notice]).to eq("Comment thread successfully unfrozen!")
+          it_redirects_to_with_comment_notice(
+            work_path(comment.ultimate_parent, show_comments: true, anchor: :comments),
+            "Comment thread successfully unfrozen!"
+          )
         end
       end
 
@@ -1532,9 +1562,10 @@ describe CommentsController do
           expect(child.reload.iced).to be_falsey
           expect(parent.reload.iced).to be_truthy
           expect(sibling.reload.iced).to be_truthy
-          expect(response).to redirect_to(work_path(comment.ultimate_parent, show_comments: true, anchor: :comments))
-          expect(flash[:comment_error]).to be_blank
-          expect(flash[:comment_notice]).to eq("Comment thread successfully unfrozen!")
+          it_redirects_to_with_comment_notice(
+            work_path(comment.ultimate_parent, show_comments: true, anchor: :comments),
+            "Comment thread successfully unfrozen!"
+          )
         end
       end
 
@@ -1552,9 +1583,10 @@ describe CommentsController do
           expect(child1.reload.iced).to be_truthy
           expect(child2.reload.iced).to be_truthy
           expect(comment.reload.iced).to be_falsey
-          expect(response).to redirect_to(work_path(comment.ultimate_parent, show_comments: true, anchor: :comments))
-          expect(flash[:comment_error]).to be_blank
-          expect(flash[:comment_notice]).to eq("Comment thread successfully unfrozen!")
+          it_redirects_to_with_comment_notice(
+            work_path(comment.ultimate_parent, show_comments: true, anchor: :comments),
+            "Comment thread successfully unfrozen!"
+          )
         end
       end
 
@@ -1569,9 +1601,10 @@ describe CommentsController do
 
           expect(comment.reload.iced).to be_falsey
           expect(comment.reload.approved).to be_falsey
-          expect(response).to redirect_to(work_path(comment.ultimate_parent, show_comments: true, anchor: :comments))
-          expect(flash[:comment_error]).to be_blank
-          expect(flash[:comment_notice]).to eq("Comment thread successfully unfrozen!")
+          it_redirects_to_with_comment_notice(
+            work_path(comment.ultimate_parent, show_comments: true, anchor: :comments),
+            "Comment thread successfully unfrozen!"
+          )
         end
       end
 
@@ -1586,9 +1619,10 @@ describe CommentsController do
           fake_login_known_user(comment.ultimate_parent.pseuds.first.user)
           put :unfreeze, params: { id: comment.id }
 
-          expect(response).to redirect_to(work_path(comment.ultimate_parent, show_comments: true, anchor: :comments))
-          expect(flash[:comment_notice]).to be_blank
-          expect(flash[:comment_error]).to eq("Sorry, that comment thread could not be unfrozen.")
+          it_redirects_to_with_comment_error(
+            work_path(comment.ultimate_parent, show_comments: true, anchor: :comments),
+            "Sorry, that comment thread could not be unfrozen."
+          )
         end
       end
     end
@@ -2320,18 +2354,20 @@ describe CommentsController do
 
       it "PUT #freeze successfully freezes the comment" do
         put :freeze, params: { id: comment.id }
-        expect(response).to redirect_to(work_path(comment.ultimate_parent, show_comments: true, anchor: :comments))
-        expect(flash[:comment_error]).to be_blank
-        expect(flash[:comment_notice]).to eq("Comment thread successfully frozen!")
+        it_redirects_to_with_comment_notice(
+          work_path(comment.ultimate_parent, show_comments: true, anchor: :comments),
+          "Comment thread successfully frozen!"
+        )
         expect(comment.reload.iced).to be_truthy
       end
 
       it "PUT #unfreeze successfully unfreezes the comment" do
         comment.update(iced: true)
         put :unfreeze, params: { id: comment.id }
-        expect(response).to redirect_to(work_path(comment.ultimate_parent, show_comments: true, anchor: :comments))
-        expect(flash[:comment_error]).to be_blank
-        expect(flash[:comment_notice]).to eq("Comment thread successfully unfrozen!")
+        it_redirects_to_with_comment_notice(
+          work_path(comment.ultimate_parent, show_comments: true, anchor: :comments),
+          "Comment thread successfully unfrozen!"
+        )
         expect(comment.reload.iced).to be_falsey
       end
     end
@@ -2420,9 +2456,10 @@ describe CommentsController do
             admin.update(roles: [admin_role])
             fake_login_admin(admin)
             put :freeze, params: { id: comment.id }
-            expect(response).to redirect_to(work_path(comment.ultimate_parent, show_comments: true, anchor: :comments))
-            expect(flash[:comment_error]).to be_blank
-            expect(flash[:comment_notice]).to eq("Comment thread successfully frozen!")
+            it_redirects_to_with_comment_notice(
+              work_path(comment.ultimate_parent, show_comments: true, anchor: :comments),
+              "Comment thread successfully frozen!"
+            )
             expect(comment.reload.iced).to be_truthy
           end
         end
@@ -2443,9 +2480,10 @@ describe CommentsController do
             admin.update(roles: [admin_role])
             fake_login_admin(admin)
             put :unfreeze, params: { id: comment.id }
-            expect(response).to redirect_to(work_path(comment.ultimate_parent, show_comments: true, anchor: :comments))
-            expect(flash[:comment_error]).to be_blank
-            expect(flash[:comment_notice]).to eq("Comment thread successfully unfrozen!")
+            it_redirects_to_with_comment_notice(
+              work_path(comment.ultimate_parent, show_comments: true, anchor: :comments),
+              "Comment thread successfully unfrozen!"
+            )
             expect(comment.reload.iced).to be_falsey
           end
         end

--- a/spec/controllers/comments_controller_spec.rb
+++ b/spec/controllers/comments_controller_spec.rb
@@ -602,7 +602,9 @@ describe CommentsController do
             put :freeze, params: { id: comment.id }
 
             expect(comment.reload.iced).to be_truthy
-            it_redirects_to_with_notice("/where_i_came_from", "Comment thread successfully frozen!")
+            expect(response).to redirect_to(admin_post_path(comment.ultimate_parent, show_comments: true, anchor: :comments))
+            expect(flash[:comment_error]).to be_blank
+            expect(flash[:comment_notice]).to eq("Comment thread successfully frozen!")
           end
         end
 
@@ -651,7 +653,9 @@ describe CommentsController do
                 put :freeze, params: { id: comment.id }
 
                 expect(comment.reload.iced).to be_truthy
-                it_redirects_to_with_notice("/where_i_came_from", "Comment thread successfully frozen!")
+                expect(response).to redirect_to(comments_path(tag_id: comment.ultimate_parent, anchor: :comments))
+                expect(flash[:comment_error]).to be_blank
+                expect(flash[:comment_notice]).to eq("Comment thread successfully frozen!")
               end
             end
           end
@@ -714,7 +718,9 @@ describe CommentsController do
                 put :freeze, params: { id: comment.id }
 
                 expect(comment.reload.iced).to be_truthy
-                it_redirects_to_with_notice("/where_i_came_from", "Comment thread successfully frozen!")
+                expect(response).to redirect_to(work_path(comment.ultimate_parent, show_comments: true, anchor: :comments))
+                expect(flash[:comment_error]).to be_blank
+                expect(flash[:comment_notice]).to eq("Comment thread successfully frozen!")
               end
             end
           end
@@ -736,7 +742,9 @@ describe CommentsController do
             put :freeze, params: { id: comment.id }
 
             expect(comment.reload.iced).to be_truthy
-            it_redirects_to_with_notice("/where_i_came_from", "Comment thread successfully frozen!")
+            expect(response).to redirect_to(work_path(comment.ultimate_parent, show_comments: true, anchor: :comments))
+            expect(flash[:comment_error]).to be_blank
+            expect(flash[:comment_notice]).to eq("Comment thread successfully frozen!")
           end
         end
       end
@@ -754,7 +762,9 @@ describe CommentsController do
           [comment, child1, child2, grandchild].each do |comment|
             expect(comment.reload.iced).to be_truthy
           end
-          it_redirects_to_with_notice("/where_i_came_from", "Comment thread successfully frozen!")
+          expect(response).to redirect_to(work_path(comment.ultimate_parent, show_comments: true, anchor: :comments))
+          expect(flash[:comment_error]).to be_blank
+          expect(flash[:comment_notice]).to eq("Comment thread successfully frozen!")
         end
       end
 
@@ -772,7 +782,9 @@ describe CommentsController do
           expect(child.reload.iced).to be_truthy
           expect(parent.reload.iced).to be_falsey
           expect(sibling.reload.iced).to be_falsey
-          it_redirects_to_with_notice("/where_i_came_from", "Comment thread successfully frozen!")
+          expect(response).to redirect_to(work_path(comment.ultimate_parent, show_comments: true, anchor: :comments))
+          expect(flash[:comment_error]).to be_blank
+          expect(flash[:comment_notice]).to eq("Comment thread successfully frozen!")
         end
       end
 
@@ -790,7 +802,9 @@ describe CommentsController do
           expect(child1.reload.iced).to be_falsey
           expect(child2.reload.iced).to be_falsey
           expect(comment.reload.iced).to be_truthy
-          it_redirects_to_with_notice("/where_i_came_from", "Comment thread successfully frozen!")
+          expect(response).to redirect_to(work_path(comment.ultimate_parent, show_comments: true, anchor: :comments))
+          expect(flash[:comment_error]).to be_blank
+          expect(flash[:comment_notice]).to eq("Comment thread successfully frozen!")
         end
       end
 
@@ -805,7 +819,9 @@ describe CommentsController do
 
           expect(comment.reload.iced).to be_truthy
           expect(comment.reload.approved).to be_falsey
-          it_redirects_to_with_notice("/where_i_came_from", "Comment thread successfully frozen!")
+          expect(response).to redirect_to(work_path(comment.ultimate_parent, show_comments: true, anchor: :comments))
+          expect(flash[:comment_error]).to be_blank
+          expect(flash[:comment_notice]).to eq("Comment thread successfully frozen!")
         end
       end
 
@@ -820,7 +836,9 @@ describe CommentsController do
           fake_login_known_user(comment.ultimate_parent.pseuds.first.user)
           put :freeze, params: { id: comment.id }
 
-          it_redirects_to_with_error("/where_i_came_from", "Sorry, that comment thread could not be frozen.")
+          expect(response).to redirect_to(work_path(comment.ultimate_parent, show_comments: true, anchor: :comments))
+          expect(flash[:comment_notice]).to be_blank
+          expect(flash[:comment_error]).to eq("Sorry, that comment thread could not be frozen.")
         end
       end
     end
@@ -846,7 +864,9 @@ describe CommentsController do
             put :freeze, params: { id: comment.id }
 
             expect(comment.reload.iced).to be_truthy
-            it_redirects_to_with_error("/where_i_came_from", "Sorry, that comment thread could not be frozen.")
+            expect(response).to redirect_to(admin_post_path(comment.ultimate_parent, show_comments: true, anchor: :comments))
+            expect(flash[:comment_notice]).to be_blank
+            expect(flash[:comment_error]).to eq("Sorry, that comment thread could not be frozen.")
           end
         end
 
@@ -895,7 +915,9 @@ describe CommentsController do
                 put :freeze, params: { id: comment.id }
 
                 expect(comment.reload.iced).to be_truthy
-                it_redirects_to_with_error("/where_i_came_from", "Sorry, that comment thread could not be frozen.")
+                expect(response).to redirect_to(comments_path(tag_id: comment.ultimate_parent, anchor: :comments))
+                expect(flash[:comment_notice]).to be_blank
+                expect(flash[:comment_error]).to eq("Sorry, that comment thread could not be frozen.")
               end
             end
           end
@@ -958,7 +980,9 @@ describe CommentsController do
                 put :freeze, params: { id: comment.id }
 
                 expect(comment.reload.iced).to be_truthy
-                it_redirects_to_with_error("/where_i_came_from", "Sorry, that comment thread could not be frozen.")
+                expect(response).to redirect_to(work_path(comment.ultimate_parent, show_comments: true, anchor: :comments))
+                expect(flash[:comment_notice]).to be_blank
+                expect(flash[:comment_error]).to eq("Sorry, that comment thread could not be frozen.")
               end
             end
           end
@@ -980,7 +1004,9 @@ describe CommentsController do
             put :freeze, params: { id: comment.id }
 
             expect(comment.reload.iced).to be_truthy
-            it_redirects_to_with_error("/where_i_came_from", "Sorry, that comment thread could not be frozen.")
+            expect(response).to redirect_to(work_path(comment.ultimate_parent, show_comments: true, anchor: :comments))
+            expect(flash[:comment_notice]).to be_blank
+            expect(flash[:comment_error]).to eq("Sorry, that comment thread could not be frozen.")
           end
         end
       end
@@ -998,7 +1024,9 @@ describe CommentsController do
           [comment, child1, child2, grandchild].each do |comment|
             expect(comment.reload.iced).to be_truthy
           end
-          it_redirects_to_with_error("/where_i_came_from", "Sorry, that comment thread could not be frozen.")
+          expect(response).to redirect_to(work_path(comment.ultimate_parent, show_comments: true, anchor: :comments))
+          expect(flash[:comment_notice]).to be_blank
+          expect(flash[:comment_error]).to eq("Sorry, that comment thread could not be frozen.")
         end
       end
 
@@ -1015,7 +1043,9 @@ describe CommentsController do
           [comment, child, parent, sibling].each do |comment|
             expect(comment.reload.iced).to be_truthy
           end
-          it_redirects_to_with_error("/where_i_came_from", "Sorry, that comment thread could not be frozen.")
+          expect(response).to redirect_to(work_path(comment.ultimate_parent, show_comments: true, anchor: :comments))
+          expect(flash[:comment_notice]).to be_blank
+          expect(flash[:comment_error]).to eq("Sorry, that comment thread could not be frozen.")
         end
       end
 
@@ -1032,7 +1062,9 @@ describe CommentsController do
           [comment, parent, child1, child2].each do |comment|
             expect(comment.reload.iced).to be_truthy
           end
-          it_redirects_to_with_error("/where_i_came_from", "Sorry, that comment thread could not be frozen.")
+          expect(response).to redirect_to(work_path(comment.ultimate_parent, show_comments: true, anchor: :comments))
+          expect(flash[:comment_notice]).to be_blank
+          expect(flash[:comment_error]).to eq("Sorry, that comment thread could not be frozen.")
         end
       end
 
@@ -1047,7 +1079,9 @@ describe CommentsController do
           fake_login_known_user(comment.ultimate_parent.pseuds.first.user)
           put :freeze, params: { id: comment.id }
 
-          it_redirects_to_with_error("/where_i_came_from", "Sorry, that comment thread could not be frozen.")
+          expect(response).to redirect_to(work_path(comment.ultimate_parent, show_comments: true, anchor: :comments))
+          expect(flash[:comment_notice]).to be_blank
+          expect(flash[:comment_error]).to eq("Sorry, that comment thread could not be frozen.")
         end
       end
     end
@@ -1075,7 +1109,9 @@ describe CommentsController do
             put :unfreeze, params: { id: comment.id }
 
             expect(comment.reload.iced).to be_falsey
-            it_redirects_to_with_error("/where_i_came_from", "Sorry, that comment thread could not be unfrozen.")
+            expect(response).to redirect_to(admin_post_path(comment.ultimate_parent, show_comments: true, anchor: :comments))
+            expect(flash[:comment_notice]).to be_blank
+            expect(flash[:comment_error]).to eq("Sorry, that comment thread could not be unfrozen.")
           end
         end
 
@@ -1124,7 +1160,9 @@ describe CommentsController do
                 put :unfreeze, params: { id: comment.id }
 
                 expect(comment.reload.iced).to be_falsey
-                it_redirects_to_with_error("/where_i_came_from", "Sorry, that comment thread could not be unfrozen.")
+                expect(response).to redirect_to(comments_path(tag_id: comment.ultimate_parent, anchor: :comments))
+                expect(flash[:comment_notice]).to be_blank
+                expect(flash[:comment_error]).to eq("Sorry, that comment thread could not be unfrozen.")
               end
             end
           end
@@ -1187,7 +1225,9 @@ describe CommentsController do
                 put :unfreeze, params: { id: comment.id }
 
                 expect(comment.reload.iced).to be_falsey
-                it_redirects_to_with_error("/where_i_came_from", "Sorry, that comment thread could not be unfrozen.")
+                expect(response).to redirect_to(work_path(comment.ultimate_parent, show_comments: true, anchor: :comments))
+                expect(flash[:comment_notice]).to be_blank
+                expect(flash[:comment_error]).to eq("Sorry, that comment thread could not be unfrozen.")
               end
             end
           end
@@ -1209,7 +1249,9 @@ describe CommentsController do
             put :unfreeze, params: { id: comment.id }
 
             expect(comment.reload.iced).to be_falsey
-            it_redirects_to_with_error("/where_i_came_from", "Sorry, that comment thread could not be unfrozen.")
+            expect(response).to redirect_to(work_path(comment.ultimate_parent, show_comments: true, anchor: :comments))
+            expect(flash[:comment_notice]).to be_blank
+            expect(flash[:comment_error]).to eq("Sorry, that comment thread could not be unfrozen.")
           end
         end
       end
@@ -1227,7 +1269,9 @@ describe CommentsController do
           [comment, child1, child2, grandchild].each do |comment|
             expect(comment.reload.iced).to be_falsey
           end
-          it_redirects_to_with_error("/where_i_came_from", "Sorry, that comment thread could not be unfrozen.")
+          expect(response).to redirect_to(work_path(comment.ultimate_parent, show_comments: true, anchor: :comments))
+          expect(flash[:comment_notice]).to be_blank
+          expect(flash[:comment_error]).to eq("Sorry, that comment thread could not be unfrozen.")
         end
       end
 
@@ -1244,7 +1288,9 @@ describe CommentsController do
           [comment, child, parent, sibling].each do |comment|
             expect(comment.reload.iced).to be_falsey
           end
-          it_redirects_to_with_error("/where_i_came_from", "Sorry, that comment thread could not be unfrozen.")
+          expect(response).to redirect_to(work_path(comment.ultimate_parent, show_comments: true, anchor: :comments))
+          expect(flash[:comment_notice]).to be_blank
+          expect(flash[:comment_error]).to eq("Sorry, that comment thread could not be unfrozen.")
         end
       end
 
@@ -1261,7 +1307,9 @@ describe CommentsController do
           [comment, parent, child1, child2].each do |comment|
             expect(comment.reload.iced).to be_falsey
           end
-          it_redirects_to_with_error("/where_i_came_from", "Sorry, that comment thread could not be unfrozen.")
+          expect(response).to redirect_to(work_path(comment.ultimate_parent, show_comments: true, anchor: :comments))
+          expect(flash[:comment_notice]).to be_blank
+          expect(flash[:comment_error]).to eq("Sorry, that comment thread could not be unfrozen.")
         end
       end
 
@@ -1276,7 +1324,9 @@ describe CommentsController do
           fake_login_known_user(comment.ultimate_parent.pseuds.first.user)
           put :unfreeze, params: { id: comment.id }
 
-          it_redirects_to_with_error("/where_i_came_from", "Sorry, that comment thread could not be unfrozen.")
+          expect(response).to redirect_to(work_path(comment.ultimate_parent, show_comments: true, anchor: :comments))
+          expect(flash[:comment_notice]).to be_blank
+          expect(flash[:comment_error]).to eq("Sorry, that comment thread could not be unfrozen.")
         end
       end
     end
@@ -1302,7 +1352,9 @@ describe CommentsController do
             put :unfreeze, params: { id: comment.id }
 
             expect(comment.reload.iced).to be_falsey
-            it_redirects_to_with_notice("/where_i_came_from", "Comment thread successfully unfrozen!")
+            expect(response).to redirect_to(admin_post_path(comment.ultimate_parent, show_comments: true, anchor: :comments))
+            expect(flash[:comment_error]).to be_blank
+            expect(flash[:comment_notice]).to eq("Comment thread successfully unfrozen!")
           end
         end
 
@@ -1351,7 +1403,9 @@ describe CommentsController do
                 put :unfreeze, params: { id: comment.id }
 
                 expect(comment.reload.iced).to be_falsey
-                it_redirects_to_with_notice("/where_i_came_from", "Comment thread successfully unfrozen!")
+                expect(response).to redirect_to(comments_path(tag_id: comment.ultimate_parent, anchor: :comments))
+                expect(flash[:comment_error]).to be_blank
+                expect(flash[:comment_notice]).to eq("Comment thread successfully unfrozen!")
               end
             end
           end
@@ -1414,7 +1468,9 @@ describe CommentsController do
                 put :unfreeze, params: { id: comment.id }
 
                 expect(comment.reload.iced).to be_falsey
-                it_redirects_to_with_notice("/where_i_came_from", "Comment thread successfully unfrozen!")
+                expect(response).to redirect_to(work_path(comment.ultimate_parent, show_comments: true, anchor: :comments))
+                expect(flash[:comment_error]).to be_blank
+                expect(flash[:comment_notice]).to eq("Comment thread successfully unfrozen!")
               end
             end
           end
@@ -1436,7 +1492,9 @@ describe CommentsController do
             put :unfreeze, params: { id: comment.id }
 
             expect(comment.reload.iced).to be_falsey
-            it_redirects_to_with_notice("/where_i_came_from", "Comment thread successfully unfrozen!")
+            expect(response).to redirect_to(work_path(comment.ultimate_parent, show_comments: true, anchor: :comments))
+            expect(flash[:comment_error]).to be_blank
+            expect(flash[:comment_notice]).to eq("Comment thread successfully unfrozen!")
           end
         end
       end
@@ -1454,7 +1512,9 @@ describe CommentsController do
           [comment, child1, child2, grandchild].each do |comment|
             expect(comment.reload.iced).to be_falsey
           end
-          it_redirects_to_with_notice("/where_i_came_from", "Comment thread successfully unfrozen!")
+          expect(response).to redirect_to(work_path(comment.ultimate_parent, show_comments: true, anchor: :comments))
+          expect(flash[:comment_error]).to be_blank
+          expect(flash[:comment_notice]).to eq("Comment thread successfully unfrozen!")
         end
       end
 
@@ -1472,7 +1532,9 @@ describe CommentsController do
           expect(child.reload.iced).to be_falsey
           expect(parent.reload.iced).to be_truthy
           expect(sibling.reload.iced).to be_truthy
-          it_redirects_to_with_notice("/where_i_came_from", "Comment thread successfully unfrozen!")
+          expect(response).to redirect_to(work_path(comment.ultimate_parent, show_comments: true, anchor: :comments))
+          expect(flash[:comment_error]).to be_blank
+          expect(flash[:comment_notice]).to eq("Comment thread successfully unfrozen!")
         end
       end
 
@@ -1490,7 +1552,9 @@ describe CommentsController do
           expect(child1.reload.iced).to be_truthy
           expect(child2.reload.iced).to be_truthy
           expect(comment.reload.iced).to be_falsey
-          it_redirects_to_with_notice("/where_i_came_from", "Comment thread successfully unfrozen!")
+          expect(response).to redirect_to(work_path(comment.ultimate_parent, show_comments: true, anchor: :comments))
+          expect(flash[:comment_error]).to be_blank
+          expect(flash[:comment_notice]).to eq("Comment thread successfully unfrozen!")
         end
       end
 
@@ -1505,7 +1569,9 @@ describe CommentsController do
 
           expect(comment.reload.iced).to be_falsey
           expect(comment.reload.approved).to be_falsey
-          it_redirects_to_with_notice("/where_i_came_from", "Comment thread successfully unfrozen!")
+          expect(response).to redirect_to(work_path(comment.ultimate_parent, show_comments: true, anchor: :comments))
+          expect(flash[:comment_error]).to be_blank
+          expect(flash[:comment_notice]).to eq("Comment thread successfully unfrozen!")
         end
       end
 
@@ -1520,7 +1586,9 @@ describe CommentsController do
           fake_login_known_user(comment.ultimate_parent.pseuds.first.user)
           put :unfreeze, params: { id: comment.id }
 
-          it_redirects_to_with_error("/where_i_came_from", "Sorry, that comment thread could not be unfrozen.")
+          expect(response).to redirect_to(work_path(comment.ultimate_parent, show_comments: true, anchor: :comments))
+          expect(flash[:comment_notice]).to be_blank
+          expect(flash[:comment_error]).to eq("Sorry, that comment thread could not be unfrozen.")
         end
       end
     end
@@ -2252,14 +2320,18 @@ describe CommentsController do
 
       it "PUT #freeze successfully freezes the comment" do
         put :freeze, params: { id: comment.id }
-        it_redirects_to_with_notice("/where_i_came_from", "Comment thread successfully frozen!")
+        expect(response).to redirect_to(work_path(comment.ultimate_parent, show_comments: true, anchor: :comments))
+        expect(flash[:comment_error]).to be_blank
+        expect(flash[:comment_notice]).to eq("Comment thread successfully frozen!")
         expect(comment.reload.iced).to be_truthy
       end
 
       it "PUT #unfreeze successfully unfreezes the comment" do
         comment.update(iced: true)
         put :unfreeze, params: { id: comment.id }
-        it_redirects_to_with_notice("/where_i_came_from", "Comment thread successfully unfrozen!")
+        expect(response).to redirect_to(work_path(comment.ultimate_parent, show_comments: true, anchor: :comments))
+        expect(flash[:comment_error]).to be_blank
+        expect(flash[:comment_notice]).to eq("Comment thread successfully unfrozen!")
         expect(comment.reload.iced).to be_falsey
       end
     end
@@ -2348,7 +2420,9 @@ describe CommentsController do
             admin.update(roles: [admin_role])
             fake_login_admin(admin)
             put :freeze, params: { id: comment.id }
-            it_redirects_to_with_notice("/where_i_came_from", "Comment thread successfully frozen!")
+            expect(response).to redirect_to(work_path(comment.ultimate_parent, show_comments: true, anchor: :comments))
+            expect(flash[:comment_error]).to be_blank
+            expect(flash[:comment_notice]).to eq("Comment thread successfully frozen!")
             expect(comment.reload.iced).to be_truthy
           end
         end
@@ -2369,7 +2443,9 @@ describe CommentsController do
             admin.update(roles: [admin_role])
             fake_login_admin(admin)
             put :unfreeze, params: { id: comment.id }
-            it_redirects_to_with_notice("/where_i_came_from", "Comment thread successfully unfrozen!")
+            expect(response).to redirect_to(work_path(comment.ultimate_parent, show_comments: true, anchor: :comments))
+            expect(flash[:comment_error]).to be_blank
+            expect(flash[:comment_notice]).to eq("Comment thread successfully unfrozen!")
             expect(comment.reload.iced).to be_falsey
           end
         end


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-4709

## Purpose

* Stops checking comments for spam whenever they are saved. This will allow spam comments to be frozen/unfrozen and prevent errors when you freeze/unfreeze the same comments repeatedly for testing purposes. It will also prevent comments you manually marked as spam from getting reverted by the spam checker.
* Removes the `cursor: pointer` CSS style that was being applied to all manner of things. Now we defer to whatever cursor the browser chooses for specific elements. (This will stop the pointer from showing up on "Frozen" and other things with the `.current` style, incorrectly making it look clickable. It also means some clickable things like buttons will now have the default arrow cursor, because that's what browsers do for those.)
* Update the redirect when freezing and unfreezing comments. Simply redirecting back would result in the comment section collapsing if you'd loaded comments with AJAX. So now we redirect to all comments, expanded, like when you mark something as ham/spam. AO3-6036 is the existing issue for it not redirecting you to the proper page.


## Testing Instructions

* Mark a comment as spam and make sure it doesn't get unmarked as spam when you freeze or unfreeze it.
* Make sure you don't get an error when repeatedly freezing and unfreezing the same comment.
* Make sure the "Frozen" indicator doesn't have the same cursor you see when hovering over a link.
* Make sure you get redirected to the comment's ultimate parent with comments shown when freezing/unfreezing.