### PR TITLE
AO3-5880 Don't display anonymous series on user page

### DIFF
--- a/app/controllers/pseuds_controller.rb
+++ b/app/controllers/pseuds_controller.rb
@@ -46,6 +46,7 @@ class PseudsController < ApplicationController
     end
 
     visible_works = visible_works.revealed.non_anon
+    visible_series = visible_series.exclude_anonymous
 
     @fandoms = \
       Fandom.select("tags.*, count(DISTINCT works.id) as work_count").

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -271,6 +271,7 @@ class UsersController < ApplicationController
     visible_bookmarks = @user.bookmarks.send(visible_method)
 
     visible_works = visible_works.revealed.non_anon
+    visible_series = visible_series.exclude_anonymous
     @fandoms = if @user == User.orphan_account
                  []
                else

--- a/features/users/user_dashboard.feature
+++ b/features/users/user_dashboard.feature
@@ -77,6 +77,17 @@ Feature: User dashboard
     And I should see "Oldest Work"
     And I should see "Newest Work"
 
+  Scenario: The user dashboard should not list anonymous works by the user
+  Given I have the anonymous collection "Anon Treasury"
+    And I am logged in as "meatloaf"
+    And I post the work "Anon Work" to the collection "Anon Treasury"
+  When I go to meatloaf's user page
+  Then I should not see "Recent Works"
+  When I post the work "New Work"
+    And I go to meatloaf's user page
+  Then I should see "Recent works"
+    And I should not see "Anon Work" within "#user-works"
+
   Scenario: The user dashboard should list up to five of the user's series and link to more
   Given I am logged in as "meatloaf"
     And I post the work "My Work"
@@ -98,6 +109,18 @@ Feature: User dashboard
   Then I should see "6 Series by meatloaf"
     And I should see "Oldest Series"
     And I should see "Newest Series"
+
+  Scenario: The user dashboard should not list anonymous series by the user
+  Given I have the anonymous collection "Anon Treasury"
+    And I am logged in as "meatloaf"
+    And I post the work "Anon Work" to the collection "Anon Treasury"
+    And I add the work "Anon Work" to series "Anon Series"
+  When I go to meatloaf's user page
+  Then I should not see "Recent Series"
+  When I add the work "New Work" to series "Cool Series"
+    And I go to meatloaf's user page
+  Then I should see "Recent series"
+    And I should not see "Anon Series" within "#user-series"
 
   Scenario: The user dashboard should list up to five of the user's bookmarks and link to more
   Given dashboard counts expire after 10 seconds


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [x] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [x] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [x] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-5880

## Purpose

Don't display anonymous series on a user's page.

This change removes series that have anonymous works from the 'Recent series' section on a user's page. This brings it into line with the user's series page, where anonymous series are already not displayed, and fixes a user privacy issue.

## Testing Instructions

- Create a new work, posting it to an anonymous collection and adding it to a new series
- Go to your dashboard, and see that the series is not included in the 'Recent series' section there
- Go to the page of the pseud that posted the series, and see that the series is not listed in 'Recent series' there either

## Credit

*What name do you want us to use to credit your work in the [Archive of Our Own's Release Notes](https://archiveofourown.org/admin_posts?tag=1)?*

katzenfabrik

*What pronouns do you prefer (she/her, he/him, zie/hir etc)?*

they/them