### PR TITLE
AO3-6122 Allow fandom tags and tags without fandoms to be unwrangleable

### DIFF
--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -183,8 +183,6 @@ class Tag < ApplicationRecord
 
     self.errors.add(:unwrangleable, "can't be set on a canonical or synonymized tag.") if canonical? || merger_id.present?
     self.errors.add(:unwrangleable, "can't be set on an unsorted tag.") if is_a?(UnsortedTag)
-    self.errors.add(:unwrangleable, "can't be set on a fandom.") if is_a?(Fandom)
-    self.errors.add(:unwrangleable, "can't be set on a tag with no fandoms.") if self.parents.by_type("Fandom").blank?
   end
 
   before_validation :check_synonym

--- a/app/views/tags/edit.html.erb
+++ b/app/views/tags/edit.html.erb
@@ -108,13 +108,11 @@
         </dd>
       <% end %>
 
-      <% unless @tag.is_a?(Fandom) %>
-        <dt><%= f.label :unwrangleable %></dt>
-        <dd>
-          <%= f.check_box(:unwrangleable, disabled: (@tag.class.name == "UnsortedTag")) %>&nbsp;
-          <p><%= ts("This tag will never be merged or made canonical and should not be included on wrangling pages.") %></p>
-        </dd>
-      <% end %>
+      <dt><%= f.label :unwrangleable %></dt>
+      <dd>
+        <%= f.check_box(:unwrangleable, disabled: (@tag.class.name == "UnsortedTag")) %>&nbsp;
+        <p><%= ts("This tag will never be merged or made canonical and should not be included on wrangling pages.") %></p>
+      </dd>
     </dl>
   </fieldset>
 

--- a/features/tags_and_wrangling/tag_wrangling.feature
+++ b/features/tags_and_wrangling/tag_wrangling.feature
@@ -10,7 +10,7 @@ Feature: Tag wrangling
       And I go to the manage users page
       And I fill in "Name" with "dizmo"
       And I press "Find"
-    Then I should see "dizmo" within "#admin_users_table"    
+    Then I should see "dizmo" within "#admin_users_table"
     # admin making user tag wrangler
     When I check "user_roles_1"
       And I press "Update"
@@ -33,7 +33,7 @@ Feature: Tag wrangling
       And I should see "Relationships by fandom (1)"
     When I follow <link_text>
     Then I should see <heading>
-    
+
     Examples:
       | link_text                     | heading                            |
       | "Wranglers"                   | "Tag Wrangling Assignments"        |
@@ -41,7 +41,7 @@ Feature: Tag wrangling
       | "Characters by fandom (2)"    | "Mass Wrangle New/Unwrangled Tags" |
       | "Relationships by fandom (1)" | "Mass Wrangle New/Unwrangled Tags" |
       | "Fandoms by media (3)"        | "Mass Wrangle New/Unwrangled Tags" |
-      
+
   Scenario: Edit tag page
     Given the tag wrangling setup
       And I am logged in as a tag wrangler
@@ -55,10 +55,6 @@ Feature: Tag wrangling
       And I should see "Unwrangleable"
       And I should see "Fandom"
       And I should see "Meta"
-    When I go to the "Stargate SG-1" tag edit page
-    Then I should see "Edit Stargate SG-1 Tag"
-      # Fandoms cannot be unwrangleable
-      And I should not see "Unwrangleable"
 
   Scenario: Making a fandom canonical and assigning media to it
     Given the tag wrangling setup
@@ -107,7 +103,7 @@ Feature: Tag wrangling
     Then I should see "Tag was updated"
       And the "Daniel Jackson" tag should not be canonical
       And the "Daniel Jackson" tag should be in the "Stargate SG-1" fandom
-    
+
   Scenario: Merging canonical and non-canonical character tags
     Given the tag wrangling setup
       And I have a canonical "TV Shows" fandom tag named "Stargate SG-1"
@@ -121,7 +117,7 @@ Feature: Tag wrangling
     When I view the tag "Stargate SG-1"
     Then I should see "Jack O'Neil"
       And I should see "Jack O'Neill"
-      
+
   Scenario Outline: Creating new non-canonical tags
     Given I am logged in as a tag wrangler
       And I go to my wrangling page
@@ -132,7 +128,7 @@ Feature: Tag wrangling
     Then I should see "Tag was successfully created"
       And the "MyNewTag" tag should be a <type> tag
       And the "MyNewTag" tag should not be canonical
-    
+
     Examples:
       | type        |
       | "Fandom"    |
@@ -149,12 +145,12 @@ Feature: Tag wrangling
     Then I should see "Tag was successfully created"
       And the "MyNewTag" tag should be a <type> tag
       And the "MyNewTag" tag should be canonical
-    
+
     Examples:
       | type        |
       | "Fandom"    |
       | "Character" |
-    
+
   Scenario: Trying to assign a non-canonical fandom to a character
     Given the tag wrangling setup
       And a non-canonical fandom "Stargate Atlantis"
@@ -166,7 +162,7 @@ Feature: Tag wrangling
     Then I should see "Cannot add association to 'Stargate Atlantis':"
       And I should see "Parent tag is not canonical."
       And I should not see "Stargate Atlantis" within "form"
-    
+
   Scenario: Assigning a fandom to a non-canonical relationship tag
     Given the tag wrangling setup
       And I have a canonical "TV Shows" fandom tag named "Stargate Atlantis"
@@ -178,7 +174,7 @@ Feature: Tag wrangling
     When I follow "JackDaniel"
     Then I should see "Stargate Atlantis"
 
-  Scenario: Creating a canonical merger and adding characters to a non-canonical relationship 
+  Scenario: Creating a canonical merger and adding characters to a non-canonical relationship
     Given I have a canonical "TV Shows" fandom tag named "RWBY"
       And a canonical character "Blake Belladonna" in fandom "RWBY"
       And a canonical character "Yang Xiao Long" in fandom "RWBY"

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -114,18 +114,6 @@ describe Tag do
       tag.unwrangleable = true
       expect(tag).not_to be_valid
     end
-
-    it "is not valid for fandom type tag" do
-      tag = FactoryBot.create(:fandom, name: "NewFandom")
-      tag.unwrangleable = true
-      expect(tag).not_to be_valid
-    end
-
-    it "is not valid for a tag with no fandom" do
-      tag = Freeform.create(name: "NewTag")
-      tag.unwrangleable = true
-      expect(tag).not_to be_valid
-    end
   end
 
   context "when checking for synonym/name change" do


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6122

## Purpose

Removes changes that would prevent the use of certain tags or works or render works uneditable:

* unwrangleable validation check for fandom tags and tags that have no fandom
* visibility change on the unwrangleable checkbox for fandoms (arguably, this one could stay, though it may give us a false sense of security)

I didn't do a straight revert of #3891 because it would be nice to keep the test and syntax tweaks.  

## Testing Instructions

Refer to Jira.