### PR TITLE
AO3-6124 Keep admin post translation comment permissions in sync with original

### DIFF
--- a/app/models/admin_post.rb
+++ b/app/models/admin_post.rb
@@ -70,6 +70,14 @@ class AdminPost < ApplicationRecord
     end
   end
 
+  private
+
+  def expire_cached_home_admin_posts
+    unless Rails.env.development?
+      Rails.cache.delete("home/index/home_admin_posts")
+    end
+  end
+
   def inherit_translated_post_comment_permissions
     return unless translated_post_id.present? && AdminPost.find_by(id: translated_post_id)
 
@@ -77,21 +85,13 @@ class AdminPost < ApplicationRecord
   end
 
   def update_translation_comment_permissions
-    return unless translations.present?
+    return if translations.blank?
 
     transaction do
-      AdminPost.where(translated_post_id: id).each do |post|
+      AdminPost.where(translated_post_id: id).find_each do |post|
         post.comment_permissions = self.comment_permissions
         post.save
       end
-    end
-  end
-
-  private
-
-  def expire_cached_home_admin_posts
-    unless Rails.env.development?
-      Rails.cache.delete("home/index/home_admin_posts")
     end
   end
 end

--- a/app/models/admin_post.rb
+++ b/app/models/admin_post.rb
@@ -38,7 +38,8 @@ class AdminPost < ApplicationRecord
 
   scope :for_homepage, -> { order("created_at DESC").limit(ArchiveConfig.NUMBER_OF_ITEMS_VISIBLE_ON_HOMEPAGE) }
 
-  after_save :expire_cached_home_admin_posts, :inherit_translated_post_comment_permissions, :update_translation_comment_permissions
+  before_save :inherit_translated_post_comment_permissions
+  after_save :expire_cached_home_admin_posts, :update_translation_comment_permissions
   after_destroy :expire_cached_home_admin_posts
 
   # Return the name to link comments to for this object

--- a/app/views/admin_posts/_admin_post_form.html.erb
+++ b/app/views/admin_posts/_admin_post_form.html.erb
@@ -31,7 +31,7 @@
       <legend><%= ts("Set Preferences") %></legend>
       <h3 class="landmark heading"><%= ts("Set Preferences") %></h3>
       <dl>
-        <dt><%= f.label :tag_list, ts("Tags") %></dt>
+        <dt><%= f.label :tag_list, t(".tags.label") %></dt>
         <dd>
           <%= f.text_field :tag_list, autocomplete_options('admin_post_tags') %>
           <p class="character_counter">
@@ -39,7 +39,7 @@
           </p>
         </dd>
         <dt>
-          <%= f.label :language_id, ts("Choose a language") %>
+          <%= f.label :language_id, t(".language.label") %>
         </dt>
         <dd>
           <select id="admin_post_language_id" name="admin_post[language_id]">
@@ -47,27 +47,34 @@
           </select>
         </dd>
         <dt>
-          <%= f.label :translated_post_id, ts("Translation of") %>
+          <%= f.label :translated_post_id, t(".translated_post.label") %>
         </dt>
         <dd>
           <%= f.text_field :translated_post_id,
-          autocomplete_options('admin_posts', 
+          autocomplete_options('admin_posts',
                           title: ts('translation of'),
                           data: { autocomplete_token_limit: 1 }) %>
+          <% unless @admin_post.translated_post %>
+            <p class="footnote"><%= t(".translated_post.footnote") %></p>
+          <% end %>
         </dd>
         <dt class="permissions comments">
-          <%= ts("Who can comment on this admin post") %>
+          <%= t(".comment_permissions.label") %>
         </dt>
         <dd class="permissions comments">
-          <fieldset>
-            <%=
-              radio_button_list(f, :comment_permissions, [
-                [:enable_all, ts("Registered users and guests can comment")],
-                [:disable_anon, ts("Only registered users can comment")],
-                [:disable_all, ts("No one can comment")]
-              ])
-            %>
-          </fieldset>
+          <% if @admin_post.translated_post %>
+            <p><%= t("comments.commentable.permissions.options.#{@admin_post.comment_permissions}") %></p>
+          <% else %>
+            <fieldset>
+              <%=
+                radio_button_list(f, :comment_permissions, [
+                  [:enable_all, t("comments.commentable.permissions.options.enable_all")],
+                  [:disable_anon, t("comments.commentable.permissions.options.disable_anon")],
+                  [:disable_all, t("comments.commentable.permissions.options.disable_all")]
+                ])
+              %>
+            </fieldset>
+          <% end %>
         </dd>
       </dl>
     </fieldset>

--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -57,6 +57,17 @@ en:
         update: "Update"
       update:
         success: "Archive settings were successfully updated."
+  admin_posts:
+    admin_post_form:
+      comment_permissions:
+        label: Who can comment on this admin post
+      language:
+        label: Choose a language
+      tags:
+        label: Tags
+      translated_post:
+        footnote: Comment permissions from the selected post will replace any permissions selected on this page.
+        label: Translation of
   admins:
     index:
       page_title: "Hi, %{login}!"
@@ -82,12 +93,16 @@ en:
       actions:
         comment: "Comment"
       permissions:
-        admin_post: 
+        options:
+          disable_all: No one can comment
+          disable_anon: Only registered users can comment
+          enable_all: Registered users and guests can comment
+        admin_post:
           alt_action: "You can however %{support_link} with any feedback or questions."
           disable_all: "Sorry, this news post doesn't allow comments."
           disable_anon: "Sorry, this news post doesn't allow non-Archive users to comment."
           support_link: "contact Support"
-        work: 
+        work:
           alt_action: "You can however still leave Kudos!"
           disable_all: "Sorry, this work doesn't allow comments."
           disable_anon: "Sorry, this work doesn't allow non-Archive users to comment."

--- a/features/admins/admin_post_news.feature
+++ b/features/admins/admin_post_news.feature
@@ -97,6 +97,7 @@ Feature: Admin Actions to Post News
     When I follow "Admin Posts"
       And I follow "Post AO3 News"
     Then I should see "New AO3 News Post"
+      And I should see "Comment permissions from the selected post will replace any permissions selected on this page."
     When I fill in "admin_post_title" with "Good news, everyone!"
       And I fill in "content" with "I've taught the toaster to feel love."
       And I fill in "Tags" with "quotes, futurama"

--- a/features/comments_and_kudos/comments_adminposts.feature
+++ b/features/comments_and_kudos/comments_adminposts.feature
@@ -134,6 +134,4 @@ Feature: Commenting on admin posts
     Then I should see "Sorry, this news post doesn't allow comments."
     When I follow "Edit Post"
     Then I should see "No one can comment"
-      And I should not see "Registered users and guests can comment"
-      And I should not see "Only registered users can comment"
-      And I should not see "Comment permissions from the selected post will replace any permissions selected on this page."
+    # TODO: Test that the other options aren't available/selected in a non-brittle way

--- a/features/comments_and_kudos/comments_adminposts.feature
+++ b/features/comments_and_kudos/comments_adminposts.feature
@@ -113,6 +113,19 @@ Feature: Commenting on admin posts
     Then I should see "Comment created!"
       And I should see "zug zug"
 
+  Scenario: Modifying the comment permissions of an admin post with translations
+    Given I have posted an admin post
+      And basic languages
+      And I am logged in as a "translation" admin
+    When I make a translation of an admin post
+      And I follow "Back to AO3 News Index"
+      And I follow "Edit"
+      And I choose "Only registered users can comment"
+      And I press "Post"
+    Then I should see "Sorry, this news post doesn't allow non-Archive users to comment."
+    When I follow "Deutsch"
+    Then I should see "Sorry, this news post doesn't allow non-Archive users to comment."
+
   Scenario: Translation of admin post with comments disabled
     Given I have posted an admin post with comments disabled
       And basic languages

--- a/features/comments_and_kudos/comments_adminposts.feature
+++ b/features/comments_and_kudos/comments_adminposts.feature
@@ -112,3 +112,15 @@ Feature: Commenting on admin posts
       And I press "Comment"
     Then I should see "Comment created!"
       And I should see "zug zug"
+
+  Scenario: Translation of admin post with comments disabled
+    Given I have posted an admin post with comments disabled
+      And basic languages
+      And I am logged in as a "translation" admin
+    When I make a translation of an admin post
+    Then I should see "Sorry, this news post doesn't allow comments."
+    When I follow "Edit Post"
+    Then I should see "No one can comment"
+      And I should not see "Registered users and guests can comment"
+      And I should not see "Only registered users can comment"
+      And I should not see "Comment permissions from the selected post will replace any permissions selected on this page."

--- a/features/step_definitions/admin_steps.rb
+++ b/features/step_definitions/admin_steps.rb
@@ -61,7 +61,7 @@ Given /^tag wrangling is off$/ do
   step(%{I am logged in as a "tag_wrangling" admin})
   visit(admin_settings_path)
   step(%{I check "Turn off tag wrangling for non-admins"})
-  step(%{I press "Update"})  
+  step(%{I press "Update"})
   step("I log out")
 end
 
@@ -164,6 +164,14 @@ Given(/^the following language exists$/) do |table|
   end
 end
 
+Given /^I have posted an admin post with comments disabled$/ do
+  step %{I am logged in as a "communications" admin}
+  step %{I start to make an admin post}
+  choose("No one can comment")
+  click_button("Post")
+  step %{I log out}
+end
+
 ### WHEN
 
 When /^I visit the last activities item$/ do
@@ -176,10 +184,14 @@ When /^I fill in "([^"]*)" with "([^"]*)'s" invite code$/ do |field, login|
   fill_in(field, with: token)
 end
 
-When /^I make an admin post$/ do
+When /^I start to make an admin post$/ do
   visit new_admin_post_path
   fill_in("admin_post_title", with: "Default Admin Post")
   fill_in("content", with: "Content of the admin post.")
+end
+
+When /^I make an admin post$/ do
+  step %(I start to make an admin post)
   click_button("Post")
 end
 

--- a/spec/controllers/admin_posts_controller_spec.rb
+++ b/spec/controllers/admin_posts_controller_spec.rb
@@ -34,24 +34,12 @@ describe AdminPostsController do
     let(:post) { create(:admin_post) }
 
     context "when admin does not have correct authorization" do
-      context "with valid title" do
-        it "redirects with error" do
-          admin.update(roles: [])
-          fake_login_admin(admin)
-          put :update, params: { id: post.id, admin_post: { admin_id: admin.id, title: "Modified Title of Post" } }
+      it "redirects with error" do
+        admin.update(roles: [])
+        fake_login_admin(admin)
+        put :update, params: { id: post.id, admin_post: { admin_id: admin.id } }
 
-          it_redirects_to_with_error(root_url, "Sorry, only an authorized admin can access the page you were trying to reach.")
-        end
-      end
-
-      context "with invalid translated_post_id" do
-        it "redirects with error" do
-          admin.update(roles: [])
-          fake_login_admin(admin)
-          put :update, params: { id: post.id, admin_post: { admin_id: admin.id, translated_post_id: 0 } }
-
-          it_redirects_to_with_error(root_url, "Sorry, only an authorized admin can access the page you were trying to reach.")
-        end
+        it_redirects_to_with_error(root_url, "Sorry, only an authorized admin can access the page you were trying to reach.")
       end
     end
 
@@ -88,8 +76,7 @@ describe AdminPostsController do
                 admin.update(roles: [admin_role])
                 fake_login_admin(admin)
                 expect {
-                  put :update,
-                  params: {
+                  put :update, params: {
                     id: translation.id,
                     admin_post: {
                       admin_id: admin.id,

--- a/spec/controllers/admin_posts_controller_spec.rb
+++ b/spec/controllers/admin_posts_controller_spec.rb
@@ -96,7 +96,7 @@ describe AdminPostsController do
                       comment_permissions: :disable_all
                     }
                   }
-                }.to_not change(AdminPost, :comment_permissions)
+                }.not_to change { AdminPost.comment_permissions }
 
                 expect(translation.reload.comment_permissions).to eq(post.comment_permissions)
                 it_redirects_to_with_notice(admin_post_path(translation), "Admin Post was successfully updated.")

--- a/spec/controllers/admin_posts_controller_spec.rb
+++ b/spec/controllers/admin_posts_controller_spec.rb
@@ -75,7 +75,7 @@ describe AdminPostsController do
               it "does not change comment_permissions and redirects with notice" do
                 admin.update(roles: [admin_role])
                 fake_login_admin(admin)
-                expect {
+                expect do
                   put :update, params: {
                     id: translation.id,
                     admin_post: {
@@ -83,7 +83,7 @@ describe AdminPostsController do
                       comment_permissions: :disable_all
                     }
                   }
-                }.not_to change { AdminPost.comment_permissions }
+                end.not_to change { AdminPost.comment_permissions }
 
                 expect(translation.reload.comment_permissions).to eq(post.comment_permissions)
                 it_redirects_to_with_notice(admin_post_path(translation), "Admin Post was successfully updated.")

--- a/spec/helpers/admin_post_helper_spec.rb
+++ b/spec/helpers/admin_post_helper_spec.rb
@@ -13,7 +13,7 @@ describe AdminPostHelper do
       finnish_post = create(:admin_post, language: finnish, translated_post: english_post)
       indonesian_post = create(:admin_post, language: indonesian, translated_post: english_post)
 
-      expect(sorted_translations(english_post)).to eq([indonesian_post, german_post, finnish_post])
+      expect(sorted_translations(english_post.reload)).to eq([indonesian_post, german_post, finnish_post])
     end
   end
 end


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6124

## Purpose

Makes it so when you post a translation of an admin post, the translation inherits its comment permissions from the original admin post.

Also, if you update the comment permissions of an admin post that has translations, it updates the comment permissions of the translation.

## Testing Instructions

Refer to Jira