### PR TITLE
AO3-6131 Add user ID and creation ID info to blurbs, with a focus on work blurbs

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -589,8 +589,8 @@ module ApplicationHelper
   # External works are not created by users, so we can skip this.
   # TODO: AO3-6132 to add creator ids to series blurbs.
   def creator_ids_for_css_classes(creation)
-    return unless creation.is_a?(Work)
-    return if creation.anonymous? || creation.unrevealed?
+    return [] unless creation.is_a?(Work)
+    return [] if creation.anonymous? || creation.unrevealed?
 
     creation.users.pluck(:id).uniq.map { |id| "user-#{id}" }
   end
@@ -600,7 +600,7 @@ module ApplicationHelper
 
     Rails.cache.fetch("#{creation.cache_key_with_version}/blurb_css_classes") do
       creation_id = creation_id_for_css_classes(creation)
-      creator_ids = creator_ids_for_css_classes(creation).join(" ") if creator_ids_for_css_classes(creation).present?
+      creator_ids = creator_ids_for_css_classes(creation).join(" ")
       "blurb group #{creation_id} #{creator_ids}".strip
     end
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -577,4 +577,33 @@ module ApplicationHelper
       end
     end
   end
+
+  # Identifier for creation, formatted external-work-12, series-12, work-12.
+  def creation_id_for_css_classes(creation)
+    return if creation.nil?
+    return unless %w(ExternalWork Series Work).include?(creation.class.name)
+
+    "#{creation.class.name.underscore.dasherize}-#{creation.id}"
+  end
+
+  # Space-separated list of creator ids, formatted user-123 user-126.
+  # External works are not created by users, so we can skip this.
+  # TODO: We will want to list users on series blurbs, but when a series becomes
+  # or stops being anonymous, it is not touched, so the cache in
+  # css_classes_for_creation_blurb will not expire.
+  def creator_ids_for_css_classes(creation)
+    return if creation.nil?
+    return unless creation.is_a?(Work)
+    return if creation.anonymous? || creation.unrevealed?
+
+    creation.users.pluck(:id).uniq.map { |id| "user-#{id}" }.join(" ")
+  end
+
+  def css_classes_for_creation_blurb(creation)
+    return if creation.nil?
+
+    Rails.cache.fetch("#{creation.cache_key_with_version}/blurb_css_classes") do
+      "blurb group #{creation_id_for_css_classes(creation)} #{creator_ids_for_css_classes(creation)}".strip
+    end
+  end
 end # end of ApplicationHelper

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -581,7 +581,7 @@ module ApplicationHelper
   # Identifier for creation, formatted external-work-12, series-12, work-12.
   def creation_id_for_css_classes(creation)
     return if creation.nil?
-    return unless %w(ExternalWork Series Work).include?(creation.class.name)
+    return unless %w[ExternalWork Series Work].include?(creation.class.name)
 
     "#{creation.class.name.underscore.dasherize}-#{creation.id}"
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -578,6 +578,18 @@ module ApplicationHelper
     end
   end
 
+  def css_classes_for_creation_blurb(creation)
+    return if creation.nil?
+
+    Rails.cache.fetch("#{creation.cache_key_with_version}/blurb_css_classes") do
+      creation_id = creation_id_for_css_classes(creation)
+      creator_ids = creator_ids_for_css_classes(creation).join(" ") if creator_ids_for_css_classes(creation).present?
+      "blurb group #{creation_id} #{creator_ids}".strip
+    end
+  end
+
+  private
+
   # Identifier for creation, formatted external-work-12, series-12, work-12.
   def creation_id_for_css_classes(creation)
     return if creation.nil?
@@ -586,7 +598,7 @@ module ApplicationHelper
     "#{creation.class.name.underscore.dasherize}-#{creation.id}"
   end
 
-  # Space-separated list of creator ids, formatted user-123 user-126.
+  # Array of creator ids, formatted user-123, user-126.
   # External works are not created by users, so we can skip this.
   # TODO: We will want to list users on series blurbs, but when a series becomes
   # or stops being anonymous, it is not touched, so the cache in
@@ -596,14 +608,6 @@ module ApplicationHelper
     return unless creation.is_a?(Work)
     return if creation.anonymous? || creation.unrevealed?
 
-    creation.users.pluck(:id).uniq.map { |id| "user-#{id}" }.join(" ")
-  end
-
-  def css_classes_for_creation_blurb(creation)
-    return if creation.nil?
-
-    Rails.cache.fetch("#{creation.cache_key_with_version}/blurb_css_classes") do
-      "blurb group #{creation_id_for_css_classes(creation)} #{creator_ids_for_css_classes(creation)}".strip
-    end
+    creation.users.pluck(:id).uniq.map { |id| "user-#{id}" }
   end
 end # end of ApplicationHelper

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -578,6 +578,23 @@ module ApplicationHelper
     end
   end
 
+  # Identifier for creation, formatted external-work-12, series-12, work-12.
+  def creation_id_for_css_classes(creation)
+    return unless %w[ExternalWork Series Work].include?(creation.class.name)
+
+    "#{creation.class.name.underscore.dasherize}-#{creation.id}"
+  end
+
+  # Array of creator ids, formatted user-123, user-126.
+  # External works are not created by users, so we can skip this.
+  # TODO: AO3-6132 to add creator ids to series blurbs.
+  def creator_ids_for_css_classes(creation)
+    return unless creation.is_a?(Work)
+    return if creation.anonymous? || creation.unrevealed?
+
+    creation.users.pluck(:id).uniq.map { |id| "user-#{id}" }
+  end
+
   def css_classes_for_creation_blurb(creation)
     return if creation.nil?
 
@@ -586,28 +603,5 @@ module ApplicationHelper
       creator_ids = creator_ids_for_css_classes(creation).join(" ") if creator_ids_for_css_classes(creation).present?
       "blurb group #{creation_id} #{creator_ids}".strip
     end
-  end
-
-  private
-
-  # Identifier for creation, formatted external-work-12, series-12, work-12.
-  def creation_id_for_css_classes(creation)
-    return if creation.nil?
-    return unless %w[ExternalWork Series Work].include?(creation.class.name)
-
-    "#{creation.class.name.underscore.dasherize}-#{creation.id}"
-  end
-
-  # Array of creator ids, formatted user-123, user-126.
-  # External works are not created by users, so we can skip this.
-  # TODO: We will want to list users on series blurbs, but when a series becomes
-  # or stops being anonymous, it is not touched, so the cache in
-  # css_classes_for_creation_blurb will not expire.
-  def creator_ids_for_css_classes(creation)
-    return if creation.nil?
-    return unless creation.is_a?(Work)
-    return if creation.anonymous? || creation.unrevealed?
-
-    creation.users.pluck(:id).uniq.map { |id| "user-#{id}" }
   end
 end # end of ApplicationHelper

--- a/app/views/external_works/_blurb.html.erb
+++ b/app/views/external_works/_blurb.html.erb
@@ -1,4 +1,4 @@
-<li id="external_work_<%= external_work.id %>" class="work blurb group" role="article">
+<li id="external_work_<%= external_work.id %>" class="<%= css_classes_for_creation_blurb(external_work) %>" role="article">
 
   <!--title, author, fandom-->
   <div class="header module">

--- a/app/views/external_works/_blurb.html.erb
+++ b/app/views/external_works/_blurb.html.erb
@@ -1,4 +1,4 @@
-<li class="work blurb group" id="work_<%= external_work.id %>" role="article">
+<li id="external_work_<%= external_work.id %>" class="work blurb group" role="article">
 
   <!--title, author, fandom-->
   <div class="header module">
@@ -14,7 +14,7 @@
       <% fandoms = external_work.tag_groups["Fandom"] %>
       <%= fandoms.collect{ |tag| link_to_tag_works(tag) }.join(", ").html_safe if fandoms %>
     </h5>
-    
+
     <p class="notice"><%= ts("This work isn't hosted on the Archive so this blurb might not be complete or accurate.") %></p>
 
     <%= get_symbols_for(external_work) %>
@@ -27,7 +27,7 @@
     <%= blurb_tag_block(external_work) %>
   </ul>
 
-  <!--summary-->	
+  <!--summary-->
   <% unless external_work.summary.blank? %>
     <h6 class="landmark heading"><%= ts('Summary') %></h6>
     <blockquote class="userstuff summary">

--- a/app/views/gifts/_gift_blurb.html.erb
+++ b/app/views/gifts/_gift_blurb.html.erb
@@ -1,5 +1,5 @@
 <% # expects "work" and "gift" %>
-<li class="<% if is_author_of?(work) %>own <% end %>work blurb group" id="work_<%= work.id %>" role="article">
+<li id="work_<%= work.id %>" class="<% if is_author_of?(work) %>own <% end %>gift work <%= css_classes_for_creation_blurb(work) %>" role="article">
   <%= render "works/work_module", work: work %>
   <% if @user && @user == current_user && (gift = work.gifts.where(:pseud_id => current_user.pseuds.pluck(:id)).first) %>
     <h6 class="landmark heading"><%= ts("Recipient Actions") %></h6>

--- a/app/views/profile/show.html.erb
+++ b/app/views/profile/show.html.erb
@@ -12,6 +12,8 @@
       <dd class="pseuds"><%= print_pseud_list(@user.pseuds) %></dd>
       <dt><%= ts("I joined on:") %></dt>
       <dd><%= ts("%{date}", :date => l(@user.created_at.to_date)) %></dd>
+      <dt><%= ts("My user ID is:") %></dt>
+      <dd><%= @user.id %></dd>
       <% if @user.profile.location? %>
         <dt class="location"><%=h ts("I live in:") %></dt>
         <dd><%=h @user.profile.location %></dd>

--- a/app/views/readings/_reading_blurb.html.erb
+++ b/app/views/readings/_reading_blurb.html.erb
@@ -1,5 +1,5 @@
 <% # expects "work" and "reading" %>
-<li <% unless reading.work.nil? %>id="work_<%= work.id %>"<% end %> class="<% if reading.work.nil? %>deleted <% end %><% if is_author_of?(work) %>own <% end %>reading work blurb group" role="article">
+<li <% unless work.nil? %>id="work_<%= work.id %>"<% end %> class="<% if work.nil? %>deleted <% end %><% if is_author_of?(work) %>own <% end %>reading work <%= css_classes_for_creation_blurb(work) %>" role="article">
 
   <% unless reading.work.nil? %>
 
@@ -10,7 +10,7 @@
   <div class="user module group">
     <h4 class="viewed heading">
 
-      <% if reading.work.nil? %>
+      <% if work.nil? %>
 
         <%= ts('(Deleted work, last visited %{date})', date: set_format_for_date(reading.last_viewed)) %>
 
@@ -18,9 +18,9 @@
 
         <span><%= ts('Last visited:') %></span> <%= set_format_for_date(reading.last_viewed) %>
 
-        <% if reading.major_version_read != reading.work.major_version %>
+        <% if reading.major_version_read != work.major_version %>
           <%= ts('(Update available.)') %>
-        <% elsif reading.minor_version_read != reading.work.minor_version %>
+        <% elsif reading.minor_version_read != work.minor_version %>
           <%= ts('(Minor edits made since then.)') %>
         <% else %>
           <%= ts('(Latest version.)') %>

--- a/app/views/series/_series_blurb.html.erb
+++ b/app/views/series/_series_blurb.html.erb
@@ -1,4 +1,4 @@
-<li class="series blurb group <% if is_author_of?(series) %>own<% end %>" id="series_<%= series.id %>_blurb" role="article">
+<li id="series_<%= series.id %>" class="<% if is_author_of?(series) %>own <% end %>series <%= css_classes_for_creation_blurb(series) %>" role="article">
   <%= render 'series/series_module', :series => series %>
   <% if is_author_of?(series) %>
     <h6 class="landmark heading"><%= ts("Author Actions") %></h6>

--- a/app/views/series/show.html.erb
+++ b/app/views/series/show.html.erb
@@ -56,7 +56,7 @@
     <% end %>
 
     <dt class="stats"><%= ts("Stats:") %></dt>
-    <dd class="stats"> 
+    <dd class="stats">
       <dl class="stats">
         <dt><%= ts("Words:") %></dt>
         <dd><%= number_with_delimiter(@series.visible_word_count) %></dd>

--- a/app/views/works/_work_blurb.html.erb
+++ b/app/views/works/_work_blurb.html.erb
@@ -1,5 +1,5 @@
 <% # expects "work" %>
-<li class="<% if is_author_of?(work) %>own <% end %>work blurb group" id="work_<%= work.id %>" role="article">
+<li id="work_<%= work.id %>" class="<% if is_author_of?(work) %>own <% end %>work <%= css_classes_for_creation_blurb(work) %>" role="article">
   <%= render 'works/work_module', :work => work %>
   <% if is_author_of?(work) %>
     <h6 class="landmark heading"><%= ts("Author Actions") %></h6>

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -152,7 +152,7 @@ describe ApplicationHelper do
 
       context "when new user is added" do
         it "returns updated string" do
-          travel_to(Time.parse("2021-01-01"))
+          travel_to(1.day.ago)
           original_cache_key = "#{work.cache_key_with_version}/blurb_css_classes"
           expect(css_classes_for_creation_blurb(work)).to eq("#{default_classes} work-#{work.id} user-#{user1.id}")
 
@@ -165,7 +165,7 @@ describe ApplicationHelper do
 
       context "when user is removed" do
         it "returns updated string" do
-          travel_to(Time.parse("2021-01-01"))
+          travel_to(1.day.ago)
           work.creatorships.find_or_create_by(pseud_id: user2.default_pseud_id)
           original_cache_key = "#{work.cache_key_with_version}/blurb_css_classes"
           expect(css_classes_for_creation_blurb(work)).to eq("#{default_classes} work-#{work.id} user-#{user1.id} user-#{user2.id}")
@@ -181,7 +181,7 @@ describe ApplicationHelper do
         let(:collection) { create(:anonymous_collection) }
 
         it "returns updated string" do
-          travel_to(Time.parse("2021-01-01"))
+          travel_to(1.day.ago)
           original_cache_key = "#{work.cache_key_with_version}/blurb_css_classes"
           expect(css_classes_for_creation_blurb(work)).to eq("#{default_classes} work-#{work.id} user-#{user1.id}")
 
@@ -196,7 +196,7 @@ describe ApplicationHelper do
         let(:collection) { create(:unrevealed_collection) }
 
         it "returns updated string" do
-          travel_to(Time.parse("2021-01-01"))
+          travel_to(1.day.ago)
           original_cache_key = "#{work.cache_key_with_version}/blurb_css_classes"
           expect(css_classes_for_creation_blurb(work)).to eq("#{default_classes} work-#{work.id} user-#{user1.id}")
 

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1,0 +1,211 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe ApplicationHelper do
+  describe "#creation_id_for_css_classes" do
+    context "when creation is ExternalWork" do
+      let(:external_work) { create(:external_work) }
+
+      it "returns string for exteral work" do
+        result = creation_id_for_css_classes(external_work)
+        expect(result).to eq("external-work-#{external_work.id}")
+      end
+    end
+
+    context "when creation is Series" do
+      let(:series) { create(:series) }
+
+      it "returns string for series" do
+        result = creation_id_for_css_classes(series)
+        expect(result).to eq("series-#{series.id}")
+      end
+    end
+
+    context "when creation is Work" do
+      let(:work) { create(:work) }
+
+      it "returns string for work" do
+        result = creation_id_for_css_classes(work)
+        expect(result).to eq("work-#{work.id}")
+      end
+    end
+  end
+
+  describe "#creator_ids_for_css_classes" do
+    context "when creation is ExternalWork" do
+      let(:external_work) { create(:external_work) }
+
+      it "returns nil for exteral work" do
+        result = creator_ids_for_css_classes(external_work)
+        expect(result).to be_nil
+      end
+    end
+
+    context "when creation is Series" do
+      let(:series) { create(:series) }
+
+      it "returns nil for series" do
+        result = creator_ids_for_css_classes(series)
+        expect(result).to be_nil
+      end
+    end
+
+    context "when creation is Work" do
+      let(:work) { create(:work) }
+      let(:user1) { work.users.first }
+
+      it "returns string for work" do
+        result = creator_ids_for_css_classes(work)
+        expect(result).to eq("user-#{user1.id}")
+      end
+
+      context "with multiple pseuds from same user" do
+        let(:user1_pseud2) { create(:pseud, user: user1) }
+
+        before do
+          work.creatorships.find_or_create_by(pseud_id: user1_pseud2.id)
+        end
+
+        it "returns string with one user" do
+          result = creator_ids_for_css_classes(work)
+          expect(result).to eq("user-#{user1.id}")
+        end
+      end
+
+      context "with pseuds from multiple users" do
+        let(:user2) { create(:user) }
+
+        before do
+          work.creatorships.find_or_create_by(pseud_id: user2.default_pseud_id)
+        end
+
+        it "returns string with all users" do
+          result = creator_ids_for_css_classes(work)
+          expect(result).to eq("user-#{user1.id} user-#{user2.id}")
+        end
+      end
+
+      context "when work is anonymous" do
+        let(:collection) { create(:anonymous_collection) }
+
+        before { work.collections << collection }
+
+        it "returns nil" do
+          result = creator_ids_for_css_classes(work)
+          expect(result).to be_nil
+        end
+      end
+
+      context "when work is unrevealed" do
+        let(:collection) { create(:unrevealed_collection) }
+
+        before { work.collections << collection }
+
+        it "returns nil" do
+          result = creator_ids_for_css_classes(work)
+          expect(result).to be_nil
+        end
+      end
+
+      context "when work has external author" do
+        let(:external_creatorship) { create(:external_creatorship, work: work) }
+
+        it "returns string with user" do
+          result = creator_ids_for_css_classes(work)
+          expect(result).to eq("user-#{user1.id}")
+        end
+      end
+    end
+  end
+
+  describe "#css_classes_for_creation_blurb" do
+    let(:default_classes) { "blurb group" }
+
+    context "when creation is ExternalWork" do
+      let(:external_work) { create(:external_work) }
+
+      it "returns string with default classes and creation info" do
+        result = css_classes_for_creation_blurb(external_work)
+        expect(result).to eq("#{default_classes} external-work-#{external_work.id}")
+      end
+    end
+
+    context "when creation is Series" do
+      let(:series) { create(:series) }
+
+      it "returns string with default classes and creation info" do
+        result = css_classes_for_creation_blurb(series)
+        expect(result).to eq("#{default_classes} series-#{series.id}")
+      end
+    end
+
+    context "when creation is Work" do
+      let(:work) { create(:work) }
+      let(:user1) { work.users.first }
+      let(:user2) { create(:user) }
+
+      it "returns string with default classes and creation and creator info" do
+        result = css_classes_for_creation_blurb(work)
+        expect(result).to eq("#{default_classes} work-#{work.id} user-#{user1.id}")
+      end
+
+      context "when new user is added" do
+        it "returns updated string" do
+          travel_to(Time.parse("2021-01-01"))
+          original_cache_key = "#{work.cache_key_with_version}/blurb_css_classes"
+          expect(css_classes_for_creation_blurb(work)).to eq("#{default_classes} work-#{work.id} user-#{user1.id}")
+
+          travel_back
+          work.creatorships.find_or_create_by(pseud_id: user2.default_pseud_id)
+          expect(css_classes_for_creation_blurb(work)).to eq("#{default_classes} work-#{work.id} user-#{user1.id} user-#{user2.id}")
+          expect(original_cache_key).not_to eq("#{work.cache_key_with_version}/blurb_css_classes")
+        end
+      end
+
+      context "when user is removed" do
+        it "returns updated string" do
+          travel_to(Time.parse("2021-01-01"))
+          work.creatorships.find_or_create_by(pseud_id: user2.default_pseud_id)
+          original_cache_key = "#{work.cache_key_with_version}/blurb_css_classes"
+          expect(css_classes_for_creation_blurb(work)).to eq("#{default_classes} work-#{work.id} user-#{user1.id} user-#{user2.id}")
+
+          travel_back
+          work.creatorships.find_by(pseud_id: user2.default_pseud_id).destroy
+          expect(css_classes_for_creation_blurb(work)).to eq("#{default_classes} work-#{work.id} user-#{user1.id}")
+          expect(original_cache_key).not_to eq("#{work.cache_key_with_version}/blurb_css_classes")
+        end
+      end
+
+      context "when work becomes anonymous" do
+        let(:collection) { create(:anonymous_collection) }
+
+        it "returns updated string" do
+          travel_to(Time.parse("2021-01-01"))
+          original_cache_key = "#{work.cache_key_with_version}/blurb_css_classes"
+          expect(css_classes_for_creation_blurb(work)).to eq("#{default_classes} work-#{work.id} user-#{user1.id}")
+
+          travel_back
+          work.collections << collection
+          expect(css_classes_for_creation_blurb(work)).to eq("#{default_classes} work-#{work.id}")
+          expect(original_cache_key).not_to eq("#{work.cache_key_with_version}/blurb_css_classes")
+        end
+      end
+
+      context "when work becomes unrevealed" do
+        let(:collection) { create(:unrevealed_collection) }
+
+        it "returns updated string" do
+          travel_to(Time.parse("2021-01-01"))
+          original_cache_key = "#{work.cache_key_with_version}/blurb_css_classes"
+          expect(css_classes_for_creation_blurb(work)).to eq("#{default_classes} work-#{work.id} user-#{user1.id}")
+
+          travel_back
+          work.collections << collection
+          expect(css_classes_for_creation_blurb(work)).to eq("#{default_classes} work-#{work.id}")
+          expect(original_cache_key).not_to eq("#{work.cache_key_with_version}/blurb_css_classes")
+        end
+      end
+    end
+  end
+end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -57,7 +57,7 @@ describe ApplicationHelper do
 
       it "returns string for work" do
         result = creator_ids_for_css_classes(work)
-        expect(result).to eq("user-#{user1.id}")
+        expect(result).to eq(["user-#{user1.id}"])
       end
 
       context "with multiple pseuds from same user" do
@@ -69,7 +69,7 @@ describe ApplicationHelper do
 
         it "returns string with one user" do
           result = creator_ids_for_css_classes(work)
-          expect(result).to eq("user-#{user1.id}")
+          expect(result).to eq(["user-#{user1.id}"])
         end
       end
 
@@ -82,7 +82,7 @@ describe ApplicationHelper do
 
         it "returns string with all users" do
           result = creator_ids_for_css_classes(work)
-          expect(result).to eq("user-#{user1.id} user-#{user2.id}")
+          expect(result).to eq(["user-#{user1.id}", "user-#{user2.id}"])
         end
       end
 
@@ -113,7 +113,7 @@ describe ApplicationHelper do
 
         it "returns string with user" do
           result = creator_ids_for_css_classes(work)
-          expect(result).to eq("user-#{user1.id}")
+          expect(result).to eq(["user-#{user1.id}"])
         end
       end
     end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -8,7 +8,7 @@ describe ApplicationHelper do
       let(:external_work) { create(:external_work) }
 
       it "returns string for exteral work" do
-        result = creation_id_for_css_classes(external_work)
+        result = helper.creation_id_for_css_classes(external_work)
         expect(result).to eq("external-work-#{external_work.id}")
       end
     end
@@ -17,7 +17,7 @@ describe ApplicationHelper do
       let(:series) { create(:series) }
 
       it "returns string for series" do
-        result = creation_id_for_css_classes(series)
+        result = helper.creation_id_for_css_classes(series)
         expect(result).to eq("series-#{series.id}")
       end
     end
@@ -26,7 +26,7 @@ describe ApplicationHelper do
       let(:work) { create(:work) }
 
       it "returns string for work" do
-        result = creation_id_for_css_classes(work)
+        result = helper.creation_id_for_css_classes(work)
         expect(result).to eq("work-#{work.id}")
       end
     end
@@ -37,7 +37,7 @@ describe ApplicationHelper do
       let(:external_work) { create(:external_work) }
 
       it "returns nil for exteral work" do
-        result = creator_ids_for_css_classes(external_work)
+        result = helper.creator_ids_for_css_classes(external_work)
         expect(result).to be_nil
       end
     end
@@ -46,7 +46,7 @@ describe ApplicationHelper do
       let(:series) { create(:series) }
 
       it "returns nil for series" do
-        result = creator_ids_for_css_classes(series)
+        result = helper.creator_ids_for_css_classes(series)
         expect(result).to be_nil
       end
     end
@@ -56,7 +56,7 @@ describe ApplicationHelper do
       let(:user1) { work.users.first }
 
       it "returns string for work" do
-        result = creator_ids_for_css_classes(work)
+        result = helper.creator_ids_for_css_classes(work)
         expect(result).to eq(["user-#{user1.id}"])
       end
 
@@ -68,7 +68,7 @@ describe ApplicationHelper do
         end
 
         it "returns string with one user" do
-          result = creator_ids_for_css_classes(work)
+          result = helper.creator_ids_for_css_classes(work)
           expect(result).to eq(["user-#{user1.id}"])
         end
       end
@@ -81,7 +81,7 @@ describe ApplicationHelper do
         end
 
         it "returns string with all users" do
-          result = creator_ids_for_css_classes(work)
+          result = helper.creator_ids_for_css_classes(work)
           expect(result).to eq(["user-#{user1.id}", "user-#{user2.id}"])
         end
       end
@@ -92,7 +92,7 @@ describe ApplicationHelper do
         before { work.collections << collection }
 
         it "returns nil" do
-          result = creator_ids_for_css_classes(work)
+          result = helper.creator_ids_for_css_classes(work)
           expect(result).to be_nil
         end
       end
@@ -103,7 +103,7 @@ describe ApplicationHelper do
         before { work.collections << collection }
 
         it "returns nil" do
-          result = creator_ids_for_css_classes(work)
+          result = helper.creator_ids_for_css_classes(work)
           expect(result).to be_nil
         end
       end
@@ -112,7 +112,7 @@ describe ApplicationHelper do
         let(:external_creatorship) { create(:external_creatorship, work: work) }
 
         it "returns string with user" do
-          result = creator_ids_for_css_classes(work)
+          result = helper.creator_ids_for_css_classes(work)
           expect(result).to eq(["user-#{user1.id}"])
         end
       end
@@ -126,7 +126,7 @@ describe ApplicationHelper do
       let(:external_work) { create(:external_work) }
 
       it "returns string with default classes and creation info" do
-        result = css_classes_for_creation_blurb(external_work)
+        result = helper.css_classes_for_creation_blurb(external_work)
         expect(result).to eq("#{default_classes} external-work-#{external_work.id}")
       end
     end
@@ -135,7 +135,7 @@ describe ApplicationHelper do
       let(:series) { create(:series) }
 
       it "returns string with default classes and creation info" do
-        result = css_classes_for_creation_blurb(series)
+        result = helper.css_classes_for_creation_blurb(series)
         expect(result).to eq("#{default_classes} series-#{series.id}")
       end
     end
@@ -146,7 +146,7 @@ describe ApplicationHelper do
       let(:user2) { create(:user) }
 
       it "returns string with default classes and creation and creator info" do
-        result = css_classes_for_creation_blurb(work)
+        result = helper.css_classes_for_creation_blurb(work)
         expect(result).to eq("#{default_classes} work-#{work.id} user-#{user1.id}")
       end
 
@@ -154,11 +154,11 @@ describe ApplicationHelper do
         it "returns updated string" do
           travel_to(1.day.ago)
           original_cache_key = "#{work.cache_key_with_version}/blurb_css_classes"
-          expect(css_classes_for_creation_blurb(work)).to eq("#{default_classes} work-#{work.id} user-#{user1.id}")
+          expect(helper.css_classes_for_creation_blurb(work)).to eq("#{default_classes} work-#{work.id} user-#{user1.id}")
 
           travel_back
           work.creatorships.find_or_create_by(pseud_id: user2.default_pseud_id)
-          expect(css_classes_for_creation_blurb(work)).to eq("#{default_classes} work-#{work.id} user-#{user1.id} user-#{user2.id}")
+          expect(helper.css_classes_for_creation_blurb(work)).to eq("#{default_classes} work-#{work.id} user-#{user1.id} user-#{user2.id}")
           expect(original_cache_key).not_to eq("#{work.cache_key_with_version}/blurb_css_classes")
         end
       end
@@ -168,11 +168,11 @@ describe ApplicationHelper do
           travel_to(1.day.ago)
           work.creatorships.find_or_create_by(pseud_id: user2.default_pseud_id)
           original_cache_key = "#{work.cache_key_with_version}/blurb_css_classes"
-          expect(css_classes_for_creation_blurb(work)).to eq("#{default_classes} work-#{work.id} user-#{user1.id} user-#{user2.id}")
+          expect(helper.css_classes_for_creation_blurb(work)).to eq("#{default_classes} work-#{work.id} user-#{user1.id} user-#{user2.id}")
 
           travel_back
           work.creatorships.find_by(pseud_id: user2.default_pseud_id).destroy
-          expect(css_classes_for_creation_blurb(work)).to eq("#{default_classes} work-#{work.id} user-#{user1.id}")
+          expect(helper.css_classes_for_creation_blurb(work)).to eq("#{default_classes} work-#{work.id} user-#{user1.id}")
           expect(original_cache_key).not_to eq("#{work.cache_key_with_version}/blurb_css_classes")
         end
       end
@@ -183,11 +183,11 @@ describe ApplicationHelper do
         it "returns updated string" do
           travel_to(1.day.ago)
           original_cache_key = "#{work.cache_key_with_version}/blurb_css_classes"
-          expect(css_classes_for_creation_blurb(work)).to eq("#{default_classes} work-#{work.id} user-#{user1.id}")
+          expect(helper.css_classes_for_creation_blurb(work)).to eq("#{default_classes} work-#{work.id} user-#{user1.id}")
 
           travel_back
           work.collections << collection
-          expect(css_classes_for_creation_blurb(work)).to eq("#{default_classes} work-#{work.id}")
+          expect(helper.css_classes_for_creation_blurb(work)).to eq("#{default_classes} work-#{work.id}")
           expect(original_cache_key).not_to eq("#{work.cache_key_with_version}/blurb_css_classes")
         end
       end
@@ -198,11 +198,11 @@ describe ApplicationHelper do
         it "returns updated string" do
           travel_to(1.day.ago)
           original_cache_key = "#{work.cache_key_with_version}/blurb_css_classes"
-          expect(css_classes_for_creation_blurb(work)).to eq("#{default_classes} work-#{work.id} user-#{user1.id}")
+          expect(helper.css_classes_for_creation_blurb(work)).to eq("#{default_classes} work-#{work.id} user-#{user1.id}")
 
           travel_back
           work.collections << collection
-          expect(css_classes_for_creation_blurb(work)).to eq("#{default_classes} work-#{work.id}")
+          expect(helper.css_classes_for_creation_blurb(work)).to eq("#{default_classes} work-#{work.id}")
           expect(original_cache_key).not_to eq("#{work.cache_key_with_version}/blurb_css_classes")
         end
       end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -36,18 +36,18 @@ describe ApplicationHelper do
     context "when creation is ExternalWork" do
       let(:external_work) { create(:external_work) }
 
-      it "returns nil for exteral work" do
+      it "returns empty array for exteral work" do
         result = helper.creator_ids_for_css_classes(external_work)
-        expect(result).to be_nil
+        expect(result).to be_empty
       end
     end
 
     context "when creation is Series" do
       let(:series) { create(:series) }
 
-      it "returns nil for series" do
+      it "returns empty array for series" do
         result = helper.creator_ids_for_css_classes(series)
-        expect(result).to be_nil
+        expect(result).to be_empty
       end
     end
 
@@ -55,7 +55,7 @@ describe ApplicationHelper do
       let(:work) { create(:work) }
       let(:user1) { work.users.first }
 
-      it "returns string for work" do
+      it "returns array of strings for work" do
         result = helper.creator_ids_for_css_classes(work)
         expect(result).to eq(["user-#{user1.id}"])
       end
@@ -67,7 +67,7 @@ describe ApplicationHelper do
           work.creatorships.find_or_create_by(pseud_id: user1_pseud2.id)
         end
 
-        it "returns string with one user" do
+        it "returns array of strings with one user" do
           result = helper.creator_ids_for_css_classes(work)
           expect(result).to eq(["user-#{user1.id}"])
         end
@@ -80,7 +80,7 @@ describe ApplicationHelper do
           work.creatorships.find_or_create_by(pseud_id: user2.default_pseud_id)
         end
 
-        it "returns string with all users" do
+        it "returns array of strings with all users" do
           result = helper.creator_ids_for_css_classes(work)
           expect(result).to eq(["user-#{user1.id}", "user-#{user2.id}"])
         end
@@ -91,9 +91,9 @@ describe ApplicationHelper do
 
         before { work.collections << collection }
 
-        it "returns nil" do
+        it "returns empty array" do
           result = helper.creator_ids_for_css_classes(work)
-          expect(result).to be_nil
+          expect(result).to be_empty
         end
       end
 
@@ -102,18 +102,27 @@ describe ApplicationHelper do
 
         before { work.collections << collection }
 
-        it "returns nil" do
+        it "returns empty array" do
           result = helper.creator_ids_for_css_classes(work)
-          expect(result).to be_nil
+          expect(result).to be_empty
         end
       end
 
       context "when work has external author" do
         let(:external_creatorship) { create(:external_creatorship, work: work) }
 
-        it "returns string with user" do
+        it "returns array of strings with user" do
           result = helper.creator_ids_for_css_classes(work)
           expect(result).to eq(["user-#{user1.id}"])
+        end
+      end
+
+      context "when work has no user" do
+        before { work.creatorships.delete_all }
+
+        it "returns empty array" do
+          result = helper.creator_ids_for_css_classes(work)
+          expect(result).to be_empty
         end
       end
     end


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6131

## Purpose

* Adds user ID to user profiles
* Adds user ID to work blurb classes
* Adds creation ID to work, series, and external work blurb classes
* Cache that stuff!
* Standardizes the ID attributes so series and external works no longer have the` _blurb` suffix
* Tidy a bit

Although we usually put the most specific classes first, e.g. `own work blurb group`, I opted to put the user and creation IDs at the end of our standard classes, since they're not like our standard "styling the site" classes.

To cut back on repetition, I moved the `blurb group` part into the helper method. I could move the bits for checking if we include `own` and whether we use `work` or `series` into the helper as well, but I wasn't sure if it was worth the additional `is_a?(Work)`/`is_a?(Series)`/`is_a?(ExternalWork)`. (While passing work or series as a string is certainly an option, it doesn't really help all that much in terms of cutting back on the number of places you'd need to change it.) 

## Testing Instructions

Refer to Jira.

