### PR TITLE
Cap the amount of tags you can apply to any taggable

### DIFF
--- a/app/models/tagging.rb
+++ b/app/models/tagging.rb
@@ -4,7 +4,7 @@ class Tagging < ApplicationRecord
   belongs_to :taggable, polymorphic: true, touch: true, inverse_of: :taggings
 
   validates_presence_of :tagger, :taggable
-  validate :maximum_amount_of_tags, on: :create
+  validate :maximum_allowed_tags, on: :create
 
   # When we create or destroy a tagging, it may change the taggings count.
   after_create :update_taggings_count

--- a/app/models/tagging.rb
+++ b/app/models/tagging.rb
@@ -48,7 +48,7 @@ class Tagging < ApplicationRecord
   def amount_of_tags
     return unless taggable.tags.count >= maximum_allowed_tags
 
-    errors.add(:tags, ts("Sorry, a collection can only have %{maximum} tags.", maximum: maximum_allowed_tags)
+    errors.add(:tags, ts("Sorry, a collection can only have %{maximum} tags.", maximum: maximum_allowed_tags))
   end
   
   def maximum_allowed_tags


### PR DESCRIPTION
So recently a few users have started adding massive amount of tags to things. It's causing a severe amount of issues for users. I figured I'd at least start a pull request with the idea that I would love to work on it to completion with guidance from the repository owners. I figure there's another hour of work in here at best, including:

  1. Moving to configuration file
  2. Writing data migration
  3. Dealing with the validation during update
  4. Additional PR information if this evolves into something yall want

