### PR TITLE
AO3-5525 Block password resets for certain users

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -201,3 +201,6 @@ Style/SymbolArray:
 
 Style/TernaryParentheses:
   EnforcedStyle: require_parentheses_when_complex
+
+Style/AndOr:
+  EnforcedStyle: conditionals

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -160,6 +160,9 @@ RSpec/NestedGroups:
 RSpec/PredicateMatcher:
   Enabled: false
 
+Style/AndOr:
+  EnforcedStyle: conditionals
+
 Style/ClassAndModuleChildren:
   Enabled: false
 
@@ -201,6 +204,3 @@ Style/SymbolArray:
 
 Style/TernaryParentheses:
   EnforcedStyle: require_parentheses_when_complex
-
-Style/AndOr:
-  EnforcedStyle: conditionals

--- a/app/controllers/users/passwords_controller.rb
+++ b/app/controllers/users/passwords_controller.rb
@@ -6,7 +6,7 @@ class Users::PasswordsController < Devise::PasswordsController
   layout "session"
 
   def create
-    user_id = User.find_for_authentication(login: params[:user][:login])&.id
+    user_id = User.find_for_authentication(login: resource_params[:login])&.id
     if ArchiveConfig.PROTECTED_USER_IDS.include?(user_id)
       flash[:error] = t(".reset_blocked", contact_abuse_link: view_context.link_to(t(".contact_abuse"), new_abuse_report_path)).html_safe
       redirect_to :root

--- a/app/controllers/users/passwords_controller.rb
+++ b/app/controllers/users/passwords_controller.rb
@@ -6,8 +6,7 @@ class Users::PasswordsController < Devise::PasswordsController
   layout "session"
 
   def create
-    user = User.find_for_authentication(login: resource_params[:login])
-    if user.protected_user
+    if User.find_for_authentication(login: resource_params[:login])&.protected_user
       flash[:error] = t(".reset_blocked", contact_abuse_link: view_context.link_to(t(".contact_abuse"), new_abuse_report_path)).html_safe
       redirect_to :root
     else

--- a/app/controllers/users/passwords_controller.rb
+++ b/app/controllers/users/passwords_controller.rb
@@ -8,7 +8,7 @@ class Users::PasswordsController < Devise::PasswordsController
   def create
     if User.find_for_authentication(resource_params.permit(:login))&.protected_user
       flash[:error] = t(".reset_blocked", contact_abuse_link: view_context.link_to(t(".contact_abuse"), new_abuse_report_path)).html_safe
-      redirect_to root_path and return
+      redirect_to root_path && return
     end
     super do |user|
       flash.now[:notice] = ts("We couldn't find an account with that email address or username. Please try again?") if user.nil? || user.new_record?

--- a/app/controllers/users/passwords_controller.rb
+++ b/app/controllers/users/passwords_controller.rb
@@ -6,15 +6,12 @@ class Users::PasswordsController < Devise::PasswordsController
   layout "session"
 
   def create
-    if User.find_for_authentication(login: resource_params[:login])&.protected_user
+    if User.find_for_authentication(resource_params.permit(:login))&.protected_user
       flash[:error] = t(".reset_blocked", contact_abuse_link: view_context.link_to(t(".contact_abuse"), new_abuse_report_path)).html_safe
-      redirect_to :root
-    else
-      super do |user|
-        if user.nil? || user.new_record?
-          flash.now[:notice] = ts("We couldn't find an account with that email address or username. Please try again?")
-        end
-      end
+      redirect_to root_path and return
+    end
+    super do |user|
+      flash.now[:notice] = ts("We couldn't find an account with that email address or username. Please try again?") if user.nil? || user.new_record?
     end
   end
 end

--- a/app/controllers/users/passwords_controller.rb
+++ b/app/controllers/users/passwords_controller.rb
@@ -7,7 +7,7 @@ class Users::PasswordsController < Devise::PasswordsController
 
   def create
     user_id = User.find_for_authentication(login: params[:user][:login])&.id
-    if ArchiveConfig.TARGETED_USER_IDS.include?(user_id)
+    if ArchiveConfig.PROTECTED_USER_IDS.include?(user_id)
       flash[:error] = t(".reset_blocked", contact_abuse_link: view_context.link_to(t(".contact_abuse"), new_abuse_report_path)).html_safe
       redirect_to :root
     else

--- a/app/controllers/users/passwords_controller.rb
+++ b/app/controllers/users/passwords_controller.rb
@@ -6,9 +6,15 @@ class Users::PasswordsController < Devise::PasswordsController
   layout "session"
 
   def create
-    super do |user|
-      if user.nil? || user.new_record?
-        flash.now[:notice] = ts("We couldn't find an account with that email address or username. Please try again?")
+    user_id = User.find_for_authentication(login: params[:user][:login])&.id
+    if ArchiveConfig.TARGETED_USER_IDS.include?(user_id)
+      flash[:error] = t(".reset_blocked", contact_abuse_link: view_context.link_to(t(".contact_abuse"), new_abuse_report_path)).html_safe
+      redirect_to :root
+    else
+      super do |user|
+        if user.nil? || user.new_record?
+          flash.now[:notice] = ts("We couldn't find an account with that email address or username. Please try again?")
+        end
       end
     end
   end

--- a/app/controllers/users/passwords_controller.rb
+++ b/app/controllers/users/passwords_controller.rb
@@ -8,7 +8,7 @@ class Users::PasswordsController < Devise::PasswordsController
   def create
     if User.find_for_authentication(resource_params.permit(:login))&.protected_user
       flash[:error] = t(".reset_blocked", contact_abuse_link: view_context.link_to(t(".contact_abuse"), new_abuse_report_path)).html_safe
-      redirect_to root_path && return
+      redirect_to root_path and return
     end
     super do |user|
       flash.now[:notice] = ts("We couldn't find an account with that email address or username. Please try again?") if user.nil? || user.new_record?

--- a/app/controllers/users/passwords_controller.rb
+++ b/app/controllers/users/passwords_controller.rb
@@ -6,8 +6,8 @@ class Users::PasswordsController < Devise::PasswordsController
   layout "session"
 
   def create
-    user_id = User.find_for_authentication(login: resource_params[:login])&.id
-    if ArchiveConfig.PROTECTED_USER_IDS.include?(user_id)
+    user = User.find_for_authentication(login: resource_params[:login])
+    if user.protected_user
       flash[:error] = t(".reset_blocked", contact_abuse_link: view_context.link_to(t(".contact_abuse"), new_abuse_report_path)).html_safe
       redirect_to :root
     else

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -384,6 +384,17 @@ class User < ApplicationRecord
     has_role?(:archivist)
   end
 
+  # Is this user a protected user? These are users experiencing certain types
+  # of harassment. For now, this is only used to prevent harassment via repeated
+  # password reset requests.
+  def protected_user
+    self.is_protected_user?
+  end
+
+  def is_protected_user?
+    has_role?(:protected_user)
+  end
+
   # Creates log item tracking changes to user
   def create_log_item(options = {})
     options.reverse_merge! note: "System Generated", user_id: self.id

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -15,7 +15,7 @@ class UserPolicy < ApplicationPolicy
   # Define which roles can update which attributes.
   ALLOWED_ATTRIBUTES_BY_ROLES = {
     "open_doors" => [roles: []],
-    "policy_and_abuse" => %i[email],
+    "policy_and_abuse" => [:email, roles: []],
     "superadmin" => [:email, roles: []],
     "support" => %i[email],
     "tag_wrangling" => [roles: []]

--- a/config/config.yml
+++ b/config/config.yml
@@ -507,4 +507,4 @@ PERMITTED_HOSTS: [
 
 # IDs of users experiencing certain types of harassment. For now, this is only
 # used to prevent harassment via repeated password reset requests.
-TARGETED_USER_IDS: []
+PROTECTED_USER_IDS: []

--- a/config/config.yml
+++ b/config/config.yml
@@ -504,3 +504,7 @@ PERMITTED_HOSTS: [
   "test.archiveofourown.org",
   "testdownload.archiveofourown.org"
 ]
+
+# IDs of users experiencing certain types of harassment. For now, this is only
+# used to prevent harassment via repeated password reset requests.
+TARGETED_USER_IDS: []

--- a/config/config.yml
+++ b/config/config.yml
@@ -504,7 +504,3 @@ PERMITTED_HOSTS: [
   "test.archiveofourown.org",
   "testdownload.archiveofourown.org"
 ]
-
-# IDs of users experiencing certain types of harassment. For now, this is only
-# used to prevent harassment via repeated password reset requests.
-PROTECTED_USER_IDS: []

--- a/config/locales/controllers/en.yml
+++ b/config/locales/controllers/en.yml
@@ -14,3 +14,8 @@ en:
       error: Sorry, that comment thread could not be unfrozen.
       permission_denied: Sorry, you don't have permission to unfreeze that comment thread.
       success: Comment thread successfully unfrozen!
+  users:
+    passwords:
+      create:
+        contact_abuse: contact Policy & Abuse
+        reset_blocked: Password resets are disabled for that user. For more information, please %{contact_abuse_link}.

--- a/features/step_definitions/user_steps.rb
+++ b/features/step_definitions/user_steps.rb
@@ -166,6 +166,11 @@ Given(/^I coauthored the work "(.*?)" as "(.*?)" with "(.*?)"$/) do |title, logi
   work.creatorships.unapproved.each(&:accept!)
 end
 
+Given /^the user "(.*?)" is blocked from resetting their password$/ do |login|
+  user_id = User.find_by(login: login).id
+  allow(ArchiveConfig).to receive(:TARGETED_USER_IDS).and_return([user_id])
+end
+
 # WHEN
 
 When /^I follow the link for "([^"]*)" first invite$/ do |login|

--- a/features/step_definitions/user_steps.rb
+++ b/features/step_definitions/user_steps.rb
@@ -166,7 +166,7 @@ Given(/^I coauthored the work "(.*?)" as "(.*?)" with "(.*?)"$/) do |title, logi
   work.creatorships.unapproved.each(&:accept!)
 end
 
-Given /^the user "(.*?)" is blocked from resetting their password$/ do |login|
+Given "the user {string} is blocked from resetting their password" do |login|
   user_id = User.find_by(login: login).id
   allow(ArchiveConfig).to receive(:PROTECTED_USER_IDS).and_return([user_id])
 end

--- a/features/step_definitions/user_steps.rb
+++ b/features/step_definitions/user_steps.rb
@@ -166,9 +166,9 @@ Given(/^I coauthored the work "(.*?)" as "(.*?)" with "(.*?)"$/) do |title, logi
   work.creatorships.unapproved.each(&:accept!)
 end
 
-Given "the user {string} is blocked from resetting their password" do |login|
-  user_id = User.find_by(login: login).id
-  allow(ArchiveConfig).to receive(:PROTECTED_USER_IDS).and_return([user_id])
+Given "the user {string} is a protected user" do |login|
+  user = User.find_by(login: login)
+  user.roles = [Role.find_or_create_by(name: "protected_user")]
 end
 
 # WHEN

--- a/features/step_definitions/user_steps.rb
+++ b/features/step_definitions/user_steps.rb
@@ -168,7 +168,7 @@ end
 
 Given /^the user "(.*?)" is blocked from resetting their password$/ do |login|
   user_id = User.find_by(login: login).id
-  allow(ArchiveConfig).to receive(:TARGETED_USER_IDS).and_return([user_id])
+  allow(ArchiveConfig).to receive(:PROTECTED_USER_IDS).and_return([user_id])
 end
 
 # WHEN

--- a/features/users/authenticate_users.feature
+++ b/features/users/authenticate_users.feature
@@ -226,7 +226,7 @@ Feature: User Authentication
     Then I should see "Successfully logged in."
       And I should see "You'll stay logged in for 2 weeks even if you close your browser"
 
-  Scenario: Passwords cannot be reset for users who are on the config list of users being trolled or harassed.
+  Scenario: Passwords cannot be reset for users who have been given the protected role due to trolling or harassment.
     Given the following activated user exists
       | login  | email            |
       | target | user@example.com |

--- a/features/users/authenticate_users.feature
+++ b/features/users/authenticate_users.feature
@@ -230,7 +230,7 @@ Feature: User Authentication
     Given the following activated user exists
       | login  | email            |
       | target | user@example.com |
-      And the user "target" is blocked from resetting their password
+      And the user "target" is a protected user
     When I am on the home page
       And I follow "Forgot password?"
       And I fill in "Email address or user name" with "target"

--- a/features/users/authenticate_users.feature
+++ b/features/users/authenticate_users.feature
@@ -228,8 +228,8 @@ Feature: User Authentication
 
   Scenario: Passwords cannot be reset for users who are on the config list of users being trolled or harassed.
     Given the following activated user exists
-      | login  | email            | password
-      | target | user@example.com | password
+      | login  | email            |
+      | target | user@example.com |
       And the user "target" is blocked from resetting their password
     When I am on the home page
       And I follow "Forgot password?"

--- a/features/users/authenticate_users.feature
+++ b/features/users/authenticate_users.feature
@@ -226,22 +226,21 @@ Feature: User Authentication
     Then I should see "Successfully logged in."
       And I should see "You'll stay logged in for 2 weeks even if you close your browser"
 
-  # TODO make this an actual test - it's been 4 years...
-  Scenario Outline: Show or hide preferences link
-    Given I have no users
-      And the following activated users exist
-      | login    | password |
-      | sam      | secret   |
-      | dean     | secret   |
-    And I am logged in as "<login>" with password "secret"
-    When I am on <user>'s user page
-    Then I should <action>
-
-    Examples:
-      | login | user  | action                   |
-      | sam   | sam   | not see "Log In"         |
-      | sam   | sam   | see "Log Out"            |
-      | sam   | sam   | see "Preferences" within "#dashboard"    |
-      | sam   | dean  | see "Log Out"            |
-      | sam   | dean  | not see "Preferences" within "#dashboard" |
-      | sam   | dean  | not see "Log In"         |
+  Scenario: Passwords cannot be reset for users who are on the config list of users being trolled or harassed.
+    Given the following activated user exists
+      | login  | email            | password |
+      | target | user@example.com | password |
+      And the user "target" is blocked from resetting their password
+    When I am on the home page
+      And I follow "Forgot password?"
+      And I fill in "Email address or user name" with "target"
+      And I press "Reset Password"
+    Then I should be on the home page
+      And I should see "Password resets are disabled for that user."
+      And 0 emails should be delivered
+    When I follow "Forgot password?"
+      And I fill in "Email address or user name" with "user@example.com"
+      And I press "Reset Password"
+    Then I should be on the home page
+      And I should see "Password resets are disabled for that user."
+      And 0 emails should be delivered

--- a/features/users/authenticate_users.feature
+++ b/features/users/authenticate_users.feature
@@ -228,8 +228,8 @@ Feature: User Authentication
 
   Scenario: Passwords cannot be reset for users who are on the config list of users being trolled or harassed.
     Given the following activated user exists
-      | login  | email            | password |
-      | target | user@example.com | password |
+      | login  | email            | password
+      | target | user@example.com | password
       And the user "target" is blocked from resetting their password
     When I am on the home page
       And I follow "Forgot password?"

--- a/lib/tasks/defaults.rake
+++ b/lib/tasks/defaults.rake
@@ -1,5 +1,4 @@
 namespace :defaults do
-
   desc "Create default roles by name"
   task(:create_roles) do
     %w[archivist opendoors protected_user tag_wrangler translation_admin translator].each do |role|

--- a/lib/tasks/defaults.rake
+++ b/lib/tasks/defaults.rake
@@ -1,0 +1,9 @@
+namespace :defaults do
+
+  desc "Create default roles by name"
+  task(:create_roles) do
+    %w[archivist opendoors protected_user tag_wrangler translation_admin translator].each do |role|
+      Role.find_or_create_by(name: role)
+    end
+  end
+end

--- a/spec/controllers/admin/admin_users_controller_spec.rb
+++ b/spec/controllers/admin/admin_users_controller_spec.rb
@@ -101,26 +101,28 @@ describe Admin::AdminUsersController do
     context "when admin has correct authorization" do
       before { fake_login_admin(admin) }
 
-      context "when admin has superadmin role" do
-        before { admin.update(roles: ["superadmin"]) }
+      %w[policy_and_abuse superadmin].each do |admin_role|
+        context "when admin has #{admin_role} role" do
+          before { admin.update(roles: [admin_role]) }
 
-        it "allows admins to update all attributes" do
-          expect do
-            put :update, params: {
-              id: user.login,
-              user: {
-                email: "updated@example.com",
-                roles: [role.id.to_s]
+          it "allows admins to update all attributes" do
+            expect do
+              put :update, params: {
+                id: user.login,
+                user: {
+                  email: "updated@example.com",
+                  roles: [role.id.to_s]
+                }
               }
-            }
-          end.to change { user.reload.roles.pluck(:name) }
-            .from([old_role.name])
-            .to([role.name])
-            .and change { user.reload.email }
-            .from("user@example.com")
-            .to("updated@example.com")
+            end.to change { user.reload.roles.pluck(:name) }
+              .from([old_role.name])
+              .to([role.name])
+              .and change { user.reload.email }
+              .from("user@example.com")
+              .to("updated@example.com")
 
-          it_redirects_to_with_notice(root_path, "User was successfully updated.")
+            it_redirects_to_with_notice(root_path, "User was successfully updated.")
+          end
         end
       end
 
@@ -148,7 +150,8 @@ describe Admin::AdminUsersController do
         end
       end
 
-      %w[support policy_and_abuse].each do |admin_role|
+      # Keep the array in case we need to add another role like this.
+      %w[support].each do |admin_role|
         context "when admin has #{admin_role} role" do
           before { admin.update(roles: [admin_role]) }
 

--- a/spec/lib/tasks/defaults.rake_spec.rb
+++ b/spec/lib/tasks/defaults.rake_spec.rb
@@ -1,0 +1,10 @@
+require "spec_helper"
+
+describe "rake defaults:create_roles" do
+  it "creates roles" do
+    subject.invoke
+
+    role_names = %w[archivist opendoors protected_user tag_wrangler translation_admin translator]
+    expect(Role.all.pluck(:name)).to eq(role_names)
+  end
+end


### PR DESCRIPTION

## Issue

https://otwarchive.atlassian.net/browse/AO3-5525

## Purpose

Allows us to provide a list of user IDs in the config file that we do not want to send password reset emails to. Replaces an old (April 2018) hot fix that never made it into the repo.

This is one possible way to approach this. Two other options:

1. Place the check in the [Devise mailer's reset_password_instructions method](https://github.com/otwcode/otwarchive/blob/1f7610f25b28388bd6b2beb4715f2a80ece78ef7/app/mailers/archive_devise_mailer.rb#L11) _and_ include error message handling here in the controller. This would be slightly neater, since the error message could be inside the `super do |user|` block. However, that just makes it harder to send the email a reset email from the console in case of an emergency, or to one day allow Support/PAC to send such emails from admin.
2. In the User model, override Devise's `send_reset_password_instructions` method as described in [this StackOverflow answer](https://stackoverflow.com/a/62299668). This is ugly and has the same drawback as the first one.

## Testing Instructions

Refer to Jira 

