### PR TITLE
AO3-6145 Fix error when saving bookmark with duplicate tags

### DIFF
--- a/app/models/concerns/taggable.rb
+++ b/app/models/concerns/taggable.rb
@@ -98,7 +98,16 @@ module Taggable
       string.strip!
       next if string.blank?
 
-      self.tags << (Tag.find_by_name(string) || UnsortedTag.create(name: string))
+      # AO3-6145: if tag isn't found, it needs to be created and added to the array
+      # if a tag already exists (case-insensitive) in self.tags then don't add anything to tags list
+      # otherwise the returned tags list has duplicates and throws a RecordNotUnique error when trying to save them
+      tag = Tag.find_by_name(string.downcase)
+      unless tag    # no tag found so create a new one and add to tags array
+        self.tags << UnsortedTag.create(name: string.downcase)
+      end
+      if tag && !self.tags.include?(tag)   # tag exists and isn't part of tags array
+        self.tags << tag
+      end
     end
 
     self.tags

--- a/app/models/concerns/taggable.rb
+++ b/app/models/concerns/taggable.rb
@@ -98,8 +98,6 @@ module Taggable
       string.strip!
       next if string.blank?
 
-      # AO3-6145: tags list has duplicates that need to be removed or
-      # it throws a RecordNotUnique error when trying to save them
       tags << (Tag.find_by_name(string) || UnsortedTag.create(name: string))
     end
 

--- a/app/models/concerns/taggable.rb
+++ b/app/models/concerns/taggable.rb
@@ -102,12 +102,12 @@ module Taggable
       # if a tag already exists (case-insensitive) in self.tags then don't add anything to tags list
       # otherwise the returned tags list has duplicates and throws a RecordNotUnique error when trying to save them
       tag = Tag.find_by_name(string)
-      unless tag    # no tag found so create a new one and add to tags array
-        self.tags << UnsortedTag.create(name: string)
-      end
-      if tag && !self.tags.include?(tag)   # tag exists and isn't part of tags array
-        self.tags << tag
-      end
+      # no tag found so create a new one and add to tags array
+      self.tags << UnsortedTag.create(name: string) unless tag
+
+      # tag exists and isn't part of tags array
+      self.tags << tag if tag && !self.tags.include?(tag)
+
     end
 
     self.tags

--- a/app/models/concerns/taggable.rb
+++ b/app/models/concerns/taggable.rb
@@ -101,9 +101,9 @@ module Taggable
       # AO3-6145: if tag isn't found, it needs to be created and added to the array
       # if a tag already exists (case-insensitive) in self.tags then don't add anything to tags list
       # otherwise the returned tags list has duplicates and throws a RecordNotUnique error when trying to save them
-      tag = Tag.find_by_name(string.downcase)
+      tag = Tag.find_by_name(string)
       unless tag    # no tag found so create a new one and add to tags array
-        self.tags << UnsortedTag.create(name: string.downcase)
+        self.tags << UnsortedTag.create(name: string)
       end
       if tag && !self.tags.include?(tag)   # tag exists and isn't part of tags array
         self.tags << tag

--- a/features/bookmarks/bookmark_create.feature
+++ b/features/bookmarks/bookmark_create.feature
@@ -410,7 +410,7 @@ Scenario: Can use "Show Most Recent Bookmarks" from the bookmarks page
     And I should not see "Love it" within ".recent"
     And I should see "Show Most Recent Bookmarks" within "li.bookmark"
 
-Scenario: A bookmark with duplicate tags other than capitalization has only one lowercase tag saved
+Scenario: A bookmark with duplicate tags other than capitalization has only first version of tag saved
   Given I am logged in as "bookmark_user"
     When I am on bookmark_user's user page
       And I post the work "Revenge of the Sith"

--- a/features/bookmarks/bookmark_create.feature
+++ b/features/bookmarks/bookmark_create.feature
@@ -412,13 +412,10 @@ Scenario: Can use "Show Most Recent Bookmarks" from the bookmarks page
 
 Scenario: A bookmark with duplicate tags other than capitalization has only first version of tag saved
   Given I am logged in as "bookmark_user"
-    When I am on bookmark_user's user page
-      And I post the work "Revenge of the Sith"
-    Then I should see "Bookmark"
-    When I follow "Bookmark"
-      And I fill in "bookmark_notes" with "I liked this story"
-      And I fill in "bookmark_tag_string" with "my tags,My Tags"
-      And I press "Create"
-    Then I should see "Bookmark was successfully created"
-      And I should see "Bookmarker's Tags: my tags"
-      And I should not see "Bookmarker's Tags: My Tags"
+  When I post the work "Revenge of the Sith"
+    And I follow "Bookmark"
+    And I fill in "Your tags" with "my tags,My Tags"
+    And I press "Create"
+  Then I should see "Bookmark was successfully created"
+    And I should see "Bookmarker's Tags: my tags"
+    And I should not see "Bookmarker's Tags: My Tags"

--- a/features/bookmarks/bookmark_create.feature
+++ b/features/bookmarks/bookmark_create.feature
@@ -409,3 +409,16 @@ Scenario: Can use "Show Most Recent Bookmarks" from the bookmarks page
   Then I should not see "bookmarker1" within ".recent"
     And I should not see "Love it" within ".recent"
     And I should see "Show Most Recent Bookmarks" within "li.bookmark"
+
+Scenario: A bookmark with duplicate tags other than capitalization has only one lowercase tag saved
+  Given I am logged in as "bookmark_user"
+    When I am on bookmark_user's user page
+      And I post the work "Revenge of the Sith"
+    Then I should see "Bookmark"
+    When I follow "Bookmark"
+      And I fill in "bookmark_notes" with "I liked this story"
+      And I fill in "bookmark_tag_string" with "my tags,My Tags"
+      And I press "Create"
+    Then I should see "Bookmark was successfully created"
+      And I should see "Bookmarker's Tags: my tags"
+      And I should not see "Bookmarker's Tags: My Tags"


### PR DESCRIPTION
# Pull Request Checklist

* [X] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [X] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [X] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [X] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [X] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-6145

## Purpose

When creating a bookmark with duplicate tags e.g. Mytag and MYTAG, a 500 RecordNotUnique error is no longer thrown on create. A lowercase version of the tag will be saved.

## Testing Instructions

How can the Archive's QA team verify that this is working as you intended?

1. Either create a work and view it, or open any existing work
2. Click bookmark and add the tags "Duplicate" and "DUPLICATE" and create the bookmark
3. On your bookmark's page, the "bookmarker's tags" section for the bookmark should only show "duplicate"

## Credit

*What name do you want us to use to credit your work in the [Archive of Our Own's Release Notes](https://archiveofourown.org/admin_posts?tag=1)?*
agenderdanvers

*What pronouns do you prefer (she/her, he/him, zie/hir etc)?*
they/them