### PR TITLE
AO3-6147 Add task to update work index mapping for new creator join

### DIFF
--- a/app/models/search/work_indexer.rb
+++ b/app/models/search/work_indexer.rb
@@ -17,6 +17,10 @@ class WorkIndexer < Indexer
     {
       "work" => {
         properties: {
+          creator_join: {
+            type: :join,
+            relations: { work: :creator }
+          },
           title: {
             type: "text",
             analyzer: "simple"

--- a/lib/tasks/after_tasks.rake
+++ b/lib/tasks/after_tasks.rake
@@ -735,6 +735,11 @@ namespace :After do
     puts("Converted #{updated_chapter_count} chapter(s).") && STDOUT.flush
   end
 
+  desc "Update the mapping for the work index"
+  task(update_work_mapping: :environment) do
+    WorkIndexer.create_mapping
+  end
+
   # This is the end that you have to put new tasks above.
 end
 


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6147

## Purpose

This PR changes the work index to include a parent/child relationship (to be used for some creator information), and adds a rake task to update the index. This is to prevent the index from being incorrectly updated.

## Testing Instructions

1. Run `rake After:update_work_mapping`.
2. From the rails console, run `$elasticsearch.indices.get_field_mapping(index: WorkIndexer.index_name, field: "creator_join")` and check that the result includes information about the `creator_join` field.