### PR TITLE
AO3-6150 Move user_ids & pseud_ids into child document for work search.

### DIFF
--- a/app/models/search/indexer.rb
+++ b/app/models/search/indexer.rb
@@ -2,7 +2,7 @@ class Indexer
 
   BATCH_SIZE = 1000
   INDEXERS_FOR_CLASS = {
-    "Work" => %w(WorkIndexer BookmarkedWorkIndexer),
+    "Work" => %w(WorkIndexer WorkCreatorIndexer BookmarkedWorkIndexer),
     "Bookmark" => %w(BookmarkIndexer),
     "Tag" => %w(TagIndexer),
     "Pseud" => %w(PseudIndexer),
@@ -28,7 +28,8 @@ class Indexer
       BookmarkIndexer,
       PseudIndexer,
       TagIndexer,
-      WorkIndexer
+      WorkIndexer,
+      WorkCreatorIndexer
     ]
   end
 

--- a/app/models/search/work_creator_indexer.rb
+++ b/app/models/search/work_creator_indexer.rb
@@ -1,0 +1,39 @@
+# A class for reindexing private work creator info (info that should not be
+# available during normal searches).
+class WorkCreatorIndexer < Indexer
+  def self.klass
+    "Work"
+  end
+
+  def self.mapping
+    WorkIndexer.mapping
+  end
+
+  def routing_info(id)
+    {
+      "_index" => index_name,
+      "_type" => document_type,
+      "_id" => document_id(id),
+      "routing" => parent_id(id, nil)
+    }
+  end
+
+  def document_id(id)
+    "#{id}-creator"
+  end
+
+  def parent_id(id, _object)
+    id
+  end
+
+  def document(object)
+    {
+      private_user_ids: object.user_ids,
+      private_pseud_ids: object.pseud_ids,
+      creator_join: {
+        name: :creator,
+        parent: object.id
+      }
+    }
+  end
+end

--- a/app/models/search/work_indexer.rb
+++ b/app/models/search/work_indexer.rb
@@ -103,7 +103,7 @@ class WorkIndexer < Indexer
     else
       {
         user_ids: work.user_ids,
-        pseud_ids: work.pseud_ids,
+        pseud_ids: work.pseud_ids
       }
     end
   end

--- a/app/models/search/work_indexer.rb
+++ b/app/models/search/work_indexer.rb
@@ -94,10 +94,10 @@ class WorkIndexer < Indexer
       language_id: object.language&.short,
       series: series_data(object),
       creator_join: { name: :work }
-    ).merge(creator_document(object))
+    ).merge(creator_data(object))
   end
 
-  def creator_document(work)
+  def creator_data(work)
     if work.anonymous? || work.unrevealed?
       {}
     else

--- a/app/models/search/work_indexer.rb
+++ b/app/models/search/work_indexer.rb
@@ -79,8 +79,6 @@ class WorkIndexer < Indexer
         :freeform_ids,
         :filter_ids,
         :tag,
-        :pseud_ids,
-        :user_ids,
         :collection_ids,
         :hits,
         :comments_count,
@@ -94,8 +92,20 @@ class WorkIndexer < Indexer
       ]
     ).merge(
       language_id: object.language&.short,
-      series: series_data(object)
-    )
+      series: series_data(object),
+      creator_join: { name: :work }
+    ).merge(creator_document(object))
+  end
+
+  def creator_document(work)
+    if work.anonymous? || work.unrevealed?
+      {}
+    else
+      {
+        user_ids: work.user_ids,
+        pseud_ids: work.pseud_ids,
+      }
+    end
   end
 
   # Pluck the desired series data and then turn it back

--- a/app/models/search/work_query.rb
+++ b/app/models/search/work_query.rb
@@ -154,7 +154,18 @@ class WorkQuery < Query
   end
 
   def user_filter
-    terms_filter(:user_ids, user_ids) if user_ids.present?
+    return unless user_ids.present?
+
+    if viewing_own_collected_works_page?
+      {
+        has_child: {
+          type: "creator",
+          query: terms_filter(:private_user_ids, user_ids)
+        }
+      }
+    else
+      terms_filter(:user_ids, user_ids)
+    end
   end
 
   def pseud_filter
@@ -300,6 +311,11 @@ class WorkQuery < Query
     options[:collected]
   end
 
+  def viewing_own_collected_works_page?
+    collected? && options[:works_parent].present? &&
+      options[:works_parent] == User.current_user
+  end
+
   def include_restricted?
     User.current_user.present? || options[:show_restricted]
   end
@@ -314,7 +330,7 @@ class WorkQuery < Query
   # OR if the user is viewing their own collected works
   def include_anon?
     (user_ids.blank? && pseud_ids.blank?) ||
-      (collected? && options[:works_parent].present? && options[:works_parent] == User.current_user)
+      viewing_own_collected_works_page?
   end
 
   def user_ids

--- a/app/models/search/work_query.rb
+++ b/app/models/search/work_query.rb
@@ -154,7 +154,7 @@ class WorkQuery < Query
   end
 
   def user_filter
-    return unless user_ids.present?
+    return if user_ids.blank?
 
     if viewing_own_collected_works_page?
       {

--- a/app/models/series.rb
+++ b/app/models/series.rb
@@ -232,6 +232,7 @@ class Series < ApplicationRecord
       anonymous: anonymous?,
       unrevealed: unrevealed?,
       pseud_ids: anonymous? || unrevealed? ? nil : pseud_ids,
+      user_ids: anonymous? || unrevealed? ? nil : user_ids,
       bookmarkable_type: 'Series',
       bookmarkable_join: { name: "bookmarkable" }
     )

--- a/app/models/series.rb
+++ b/app/models/series.rb
@@ -225,12 +225,13 @@ class Series < ApplicationRecord
       methods: [
         :revised_at, :posted, :tag, :filter_ids, :rating_ids,
         :archive_warning_ids, :category_ids, :fandom_ids, :character_ids,
-        :relationship_ids, :freeform_ids, :pseud_ids, :creators,
+        :relationship_ids, :freeform_ids, :creators,
         :word_count, :work_types]
     ).merge(
       language_id: language&.short,
       anonymous: anonymous?,
       unrevealed: unrevealed?,
+      pseud_ids: anonymous? || unrevealed? ? nil : pseud_ids,
       bookmarkable_type: 'Series',
       bookmarkable_join: { name: "bookmarkable" }
     )

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -1189,6 +1189,7 @@ class Work < ApplicationRecord
       anonymous: anonymous?,
       unrevealed: unrevealed?,
       pseud_ids: anonymous? || unrevealed? ? nil : pseud_ids,
+      user_ids: anonymous? || unrevealed? ? nil : user_ids,
       bookmarkable_type: 'Work',
       bookmarkable_join: { name: "bookmarkable" }
     )

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -1182,12 +1182,13 @@ class Work < ApplicationRecord
       methods: [
         :tag, :filter_ids, :rating_ids, :archive_warning_ids, :category_ids,
         :fandom_ids, :character_ids, :relationship_ids, :freeform_ids,
-        :pseud_ids, :creators, :collection_ids, :work_types
+        :creators, :collection_ids, :work_types
       ]
     ).merge(
       language_id: language&.short,
       anonymous: anonymous?,
       unrevealed: unrevealed?,
+      pseud_ids: anonymous? || unrevealed? ? nil : pseud_ids,
       bookmarkable_type: 'Work',
       bookmarkable_join: { name: "bookmarkable" }
     )

--- a/lib/tasks/search.rake
+++ b/lib/tasks/search.rake
@@ -3,55 +3,80 @@
 namespace :search do
   BATCH_SIZE = 1000
 
-  desc 'Reindex tags'
+  desc "Recreate tag index"
   task(index_tags: :environment) do
     TagIndexer.index_all
   end
-  desc 'Reindex pseuds'
+
+  desc "Recreate pseud index"
   task(index_pseuds: :environment) do
     PseudIndexer.index_all
   end
-  desc 'Reindex works'
+
+  desc "Recreate work index"
   task(index_works: :environment) do
     WorkIndexer.index_all
+    WorkCreatorIndexer.index_from_db
   end
-  desc 'Reindex bookmarks'
+
+  desc "Recreate boomark index"
   task(index_bookmarks: :environment) do
     BookmarkIndexer.index_all
   end
-  desc 'Reindex all'
+
+  desc "Reindex all works without recreating the index"
+  task(reindex_works: :environment) do
+    WorkIndexer.index_from_db
+    WorkCreatorIndexer.index_from_db
+  end
+
+  desc "Reindex all bookmarkables without recreating the index"
+  task(reindex_bookmarkables: :environment) do
+    BookmarkedExternalWorkIndexer.index_from_db
+    BookmarkedSeriesIndexer.index_from_db
+    BookmarkedWorkIndexer.index_from_db
+  end
+
+  desc "Reindex all recently-modified items"
   task timed_all: %i[timed_works timed_tags timed_pseud timed_bookmarks] do
   end
-  desc 'Reindex bookmarks'
+
+  desc "Reindex recent bookmarks"
   task timed_bookmarks: :environment do
-    time = ENV['TIME_PERIOD'] || 'NOW() - INTERVAL 1 DAY'
+    time = ENV["TIME_PERIOD"] || "NOW() - INTERVAL 1 DAY"
     ExternalWork.where("external_works.updated_at >  #{time}").select(:id).find_in_batches(batch_size: BATCH_SIZE) do |group|
       AsyncIndexer.new(BookmarkedExternalWorkIndexer, :world).enqueue_ids(group.map(&:id))
     end
     Series.where("series.updated_at >  #{time}").select(:id).find_in_batches(batch_size: BATCH_SIZE) do |group|
       AsyncIndexer.new(BookmarkedSeriesIndexer, :world).enqueue_ids(group.map(&:id))
     end
-    Work.includes(:stat_counter).where('stat_counters.bookmarks_count > 0').references(:stat_counters).where("works.revised_at >  #{time}").select(:id).find_in_batches(batch_size: BATCH_SIZE) do |group|
-      AsyncIndexer.new(TagIndexer, :world).enqueue_ids(group.map(&:id))
+    Work.where("works.revised_at >  #{time}").select(:id).find_in_batches(batch_size: BATCH_SIZE) do |group|
+      AsyncIndexer.new(BookmarkedWorkIndexer, :world).enqueue_ids(group.map(&:id))
+    end
+    Bookmark.where("bookmarks.updated_at >  #{time}").select(:id).find_in_batches(batch_size: BATCH_SIZE) do |group|
+      AsyncIndexer.new(BookmarkIndexer, :world).enqueue_ids(group.map(&:id))
     end
   end
-  desc 'Reindex works'
+
+  desc "Reindex recent works"
   task timed_works: :environment do
-    time = ENV['TIME_PERIOD'] || 'NOW() - INTERVAL 1 DAY'
+    time = ENV["TIME_PERIOD"] || "NOW() - INTERVAL 1 DAY"
     Work.where("works.revised_at >  #{time}").select(:id).find_in_batches(batch_size: BATCH_SIZE) do |group|
       AsyncIndexer.new(WorkIndexer, :world).enqueue_ids(group.map(&:id))
     end
   end
-  desc 'Reindex tags'
+
+  desc "Reindex recent tags"
   task timed_tags: :environment  do
-    time = ENV['TIME_PERIOD'] || 'NOW() - INTERVAL 1 DAY'
+    time = ENV["TIME_PERIOD"] || "NOW() - INTERVAL 1 DAY"
     Tag.where("tags.updated_at >  #{time}").select(:id).find_in_batches(batch_size: BATCH_SIZE) do |group|
       AsyncIndexer.new(TagIndexer, :world).enqueue_ids(group.map(&:id))
     end
   end
-  desc 'Reindex psueds'
+
+  desc "Reindex psueds"
   task timed_pseud: :environment do
-    time = ENV['TIME_PERIOD'] || 'NOW() - INTERVAL 1 DAY'
+    time = ENV["TIME_PERIOD"] || "NOW() - INTERVAL 1 DAY"
     Pseud.where("pseuds.updated_at >  #{time}").select(:id).find_in_batches(batch_size: BATCH_SIZE) do |group|
       AsyncIndexer.new(PseudIndexer, :world).enqueue_ids(group.map(&:id))
     end

--- a/spec/controllers/works/default_rails_actions_spec.rb
+++ b/spec/controllers/works/default_rails_actions_spec.rb
@@ -635,13 +635,21 @@ describe WorksController, work_search: true do
 
       before { run_all_indexing_jobs }
 
-      it "returns unrevealed works in collections for guests" do
+      it "doesn't return unrevealed works in collections for guests" do
         get :collected, params: { user_id: collected_user.login }
-        expect(assigns(:works)).to include(work, unrevealed_work)
+        expect(assigns(:works)).to include(work)
+        expect(assigns(:works)).not_to include(unrevealed_work)
       end
 
-      it "returns unrevealed works in collections for logged-in users" do
+      it "doesn't return unrevealed works in collections for logged-in users" do
         fake_login
+        get :collected, params: { user_id: collected_user.login }
+        expect(assigns(:works)).to include(work)
+        expect(assigns(:works)).not_to include(unrevealed_work)
+      end
+
+      it "returns unrevealed works in collections for the author" do
+        fake_login_known_user(collected_user)
         get :collected, params: { user_id: collected_user.login }
         expect(assigns(:works)).to include(work, unrevealed_work)
       end

--- a/spec/models/search/bookmark_search_form_spec.rb
+++ b/spec/models/search/bookmark_search_form_spec.rb
@@ -91,18 +91,18 @@ describe BookmarkSearchForm, bookmark_search: true do
     end
 
     describe "searching" do
-      let(:language) { create(:language, short: "ptBR") }
-
-      let(:work1) { create(:work) }
-      let(:work2) { create(:work, language_id: language.id) }
-
-      let!(:bookmark1) { create(:bookmark, bookmarkable: work1) }
-      let!(:bookmark2) { create(:bookmark, bookmarkable: work2) }
-
-      before { run_all_indexing_jobs }
-
       context "by work language" do
+        let(:language) { create(:language, short: "ptBR") }
+
+        let(:work1) { create(:work) }
+        let(:work2) { create(:work, language_id: language.id) }
+
+        let!(:bookmark1) { create(:bookmark, bookmarkable: work1) }
+        let!(:bookmark2) { create(:bookmark, bookmarkable: work2) }
+
         let(:unused_language) { create(:language, short: "tlh") }
+
+        before { run_all_indexing_jobs }
 
         it "returns work bookmarkables with specified language" do
           # "Work language" dropdown, with short names
@@ -128,6 +128,47 @@ describe BookmarkSearchForm, bookmark_search: true do
           results = bsf.bookmarkable_search_results
           expect(results).not_to include work1
           expect(results).to include work2
+        end
+      end
+
+      context "using pseud_ids in the bookmarkable query" do
+        let(:pseud) { create(:pseud) }
+        let(:collection) { create(:collection) }
+
+        let(:work) { create(:work, authors: [pseud], collections: [collection]) }
+        let(:series) { create(:series, authors: [pseud], works: [work]) }
+
+        let!(:bookmark1) { create(:bookmark, bookmarkable: work) }
+        let!(:bookmark2) { create(:bookmark, bookmarkable: series) }
+
+        before { run_all_indexing_jobs }
+
+        context "when a work & series are anonymous" do
+          let(:collection) { create(:anonymous_collection) }
+
+          it "doesn't include the work or the series" do
+            results = BookmarkSearchForm.new(bookmarkable_query: "pseud_ids: #{pseud.id}").bookmarkable_search_results
+            expect(results).not_to include work
+            expect(results).not_to include series
+          end
+        end
+
+        context "when a work & series are unrevealed" do
+          let(:collection) { create(:unrevealed_collection) }
+
+          it "doesn't include the work or the series" do
+            results = BookmarkSearchForm.new(bookmarkable_query: "pseud_ids: #{pseud.id}").bookmarkable_search_results
+            expect(results).not_to include work
+            expect(results).not_to include series
+          end
+        end
+
+        context "when a work & series are neither unrevealed nor anonymous" do
+          it "includes the work and the series" do
+            results = BookmarkSearchForm.new(bookmarkable_query: "pseud_ids: #{pseud.id}").bookmarkable_search_results
+            expect(results).to include work
+            expect(results).to include series
+          end
         end
       end
     end

--- a/spec/models/search/bookmark_search_form_spec.rb
+++ b/spec/models/search/bookmark_search_form_spec.rb
@@ -171,6 +171,47 @@ describe BookmarkSearchForm, bookmark_search: true do
           end
         end
       end
+
+      context "using user_ids in the bookmarkable query" do
+        let(:user) { create(:user) }
+        let(:collection) { create(:collection) }
+
+        let(:work) { create(:work, authors: [user.default_pseud], collections: [collection]) }
+        let(:series) { create(:series, authors: [user.default_pseud], works: [work]) }
+
+        let!(:bookmark1) { create(:bookmark, bookmarkable: work) }
+        let!(:bookmark2) { create(:bookmark, bookmarkable: series) }
+
+        before { run_all_indexing_jobs }
+
+        context "when a work & series are anonymous" do
+          let(:collection) { create(:anonymous_collection) }
+
+          it "doesn't include the work or the series" do
+            results = BookmarkSearchForm.new(bookmarkable_query: "user_ids: #{user.id}").bookmarkable_search_results
+            expect(results).not_to include work
+            expect(results).not_to include series
+          end
+        end
+
+        context "when a work & series are unrevealed" do
+          let(:collection) { create(:unrevealed_collection) }
+
+          it "doesn't include the work or the series" do
+            results = BookmarkSearchForm.new(bookmarkable_query: "user_ids: #{user.id}").bookmarkable_search_results
+            expect(results).not_to include work
+            expect(results).not_to include series
+          end
+        end
+
+        context "when a work & series are neither unrevealed nor anonymous" do
+          it "includes the work and the series" do
+            results = BookmarkSearchForm.new(bookmarkable_query: "user_ids: #{user.id}").bookmarkable_search_results
+            expect(results).to include work
+            expect(results).to include series
+          end
+        end
+      end
     end
   end
 

--- a/spec/models/search/work_search_form_spec.rb
+++ b/spec/models/search/work_search_form_spec.rb
@@ -176,6 +176,64 @@ describe WorkSearchForm, work_search: true do
       expect(results).to include second_work
     end
 
+    describe "when searching using user_ids in the query" do
+      let(:user_id) { second_work.user_ids.first }
+
+      context "when the work is in an anonymous collection" do
+        let(:collection) { create(:anonymous_collection) }
+
+        it "doesn't include the work" do
+          work_search = WorkSearchForm.new(query: "user_ids: #{user_id}")
+          expect(work_search.search_results).not_to include second_work
+        end
+      end
+
+      context "when the work is in an unrevealed collection" do
+        let(:collection) { create(:unrevealed_collection) }
+
+        it "doesn't include the work" do
+          work_search = WorkSearchForm.new(query: "user_ids: #{user_id}")
+          expect(work_search.search_results).not_to include second_work
+        end
+      end
+
+      context "when the work is neither anonymous or unrevealed" do
+        it "includes the work" do
+          work_search = WorkSearchForm.new(query: "user_ids: #{user_id}")
+          expect(work_search.search_results).to include second_work
+        end
+      end
+    end
+
+    describe "when searching using pseud_ids in the query" do
+      let(:pseud_id) { second_work.pseud_ids.first }
+
+      context "when the work is in an anonymous collection" do
+        let(:collection) { create(:anonymous_collection) }
+
+        it "doesn't include the work" do
+          work_search = WorkSearchForm.new(query: "pseud_ids: #{pseud_id}")
+          expect(work_search.search_results).not_to include second_work
+        end
+      end
+
+      context "when the work is in an unrevealed collection" do
+        let(:collection) { create(:unrevealed_collection) }
+
+        it "doesn't include the work" do
+          work_search = WorkSearchForm.new(query: "pseud_ids: #{pseud_id}")
+          expect(work_search.search_results).not_to include second_work
+        end
+      end
+
+      context "when the work is neither anonymous or unrevealed" do
+        it "includes the work" do
+          work_search = WorkSearchForm.new(query: "pseud_ids: #{pseud_id}")
+          expect(work_search.search_results).to include second_work
+        end
+      end
+    end
+
     describe "when searching unposted works" do
       before(:each) do
         work.update_attribute(:posted, false)


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6150

## Purpose

Move a copy of `user_ids` and `pseud_ids` to a child document, and make the usual `user_ids` and `pseud_ids` nil when the work is unrevealed and/or anonymous. Also modifies bookmarkables to make the `pseud_ids` nil when the bookmarkable is anonymous/unrevealed.

Also adds two tasks to reindex all works/bookmarkables without recreating the index (so that most searches will continue to work during the deployment).