### PR TITLE
AO3-5964 Replace excess spaces in some tags

### DIFF
--- a/lib/tasks/after_tasks.rake
+++ b/lib/tasks/after_tasks.rake
@@ -740,6 +740,34 @@ namespace :After do
     WorkIndexer.create_mapping
   end
 
+  desc "Fix tags with extra spaces"
+  task(fix_tags_with_extra_spaces: :environment) do
+    total_tags = Tag.count
+    total_batches = (total_tags + 999) / 1000
+    puts "Inspecting #{total_tags} tags in #{total_batches} batches"
+
+    report_string = "Tag ID,Old tag name,New tag name\n"
+    Tag.find_in_batches.with_index do |batch, index|
+      batch_number = index + 1
+      progress_msg = "Batch #{batch_number} of #{total_batches} complete"
+
+      batch.each do |tag|
+        next unless tag.name != tag.name.squish
+
+        old_tag_name = tag.name
+        new_tag_name = old_tag_name.gsub(/[[:space:]]/, "_")
+
+        tag.update_column(:name, new_tag_name)
+
+        report_row = [tag.id, old_tag_name, new_tag_name].join(",") + "\n"
+        report_string += report_row
+      end
+
+      puts(progress_msg) && STDOUT.flush
+    end
+    puts(report_string) && STDOUT.flush
+  end
+
   # This is the end that you have to put new tasks above.
 end
 

--- a/spec/lib/tasks/after_tasks.rake_spec.rb
+++ b/spec/lib/tasks/after_tasks.rake_spec.rb
@@ -153,3 +153,15 @@ describe "rake After:replace_dewplayer_embeds" do
     end.to output("Couldn't convert 1 chapter(s): #{dewplayer_work.first_chapter.id}\nConverted 0 chapter(s).\n").to_stdout
   end
 end
+
+describe "rake After:fix_tags_with_extra_spaces" do
+  let(:borked_tag) { Freeform.create(name: "whatever") }
+
+  it "replaces the spaces with the same number of underscores" do
+    borked_tag.update_column(:name, "\u00A0\u2002\u2003\u202F\u205FBorked\u00A0\u2002\u2003\u202Ftag\u00A0\u2002\u2003\u202F\u205F")
+    subject.invoke
+
+    borked_tag.reload
+    expect(borked_tag.name).to eql("_____Borked____tag_____")
+  end
+end


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [x] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [x] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [x] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-5964

## Purpose

What does this PR do?

This is a one-time After task to:
- Identify tags that have extraneous spaces in their name
- Replace each space in their name with an underscore (`_`)
- Output the list of tags with their ID, old name, and new name

We have to use `update_column` because only admins are allowed to rename tags the regular way.

The way these tags have sneaked through our validation process is most likely the fact that `squish` used to use a more lax regular expression to compress blank spaces (`\s`) than the one it currently uses (`[[:space]]`). (Thank you @tickinginstant for explaining the issue!)

## Testing Instructions

How can the Archive's QA team verify that this is working as you intended?

## References

Are there other relevant issues/pull requests/mailing list discussions?

This issue is part of the prerequisites for AO3-6153.

## Credit

*What name do you want us to use to credit your work in the [Archive of Our Own's Release Notes](https://archiveofourown.org/admin_posts?tag=1)?*

Enigel

*What pronouns do you prefer (she/her, he/him, zie/hir etc)?*

she/her