### PR TITLE
AO3-6157 Switch to kt-paperclip and update rest-client and mime-types gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -56,7 +56,7 @@ gem 'sanitize', '>= 4.6.5'
 # https://otwarchive.atlassian.net/browse/AO3-4957
 # https://github.com/rubys/nokogumbo/issues/50
 gem 'nokogumbo', '1.4.9'
-gem 'rest-client', '~> 2.1.0', require: 'rest_client'
+gem "rest-client", ""~> 2.1.0", require: "rest_client"
 gem 'resque', '>=1.14.0'
 gem 'resque-scheduler'
 gem 'after_commit_everywhere'

--- a/Gemfile
+++ b/Gemfile
@@ -66,7 +66,7 @@ gem 'aws-sdk'
 gem 'css_parser'
 
 gem "terrapin"
-gem 'paperclip', '>= 5.2.0'
+gem "kt-paperclip", ">= 5.2.0"
 
 # for looking up image dimensions quickly
 gem 'fastimage'

--- a/Gemfile
+++ b/Gemfile
@@ -56,7 +56,7 @@ gem 'sanitize', '>= 4.6.5'
 # https://otwarchive.atlassian.net/browse/AO3-4957
 # https://github.com/rubys/nokogumbo/issues/50
 gem 'nokogumbo', '1.4.9'
-gem "rest-client", ""~> 2.1.0", require: "rest_client"
+gem "rest-client", "~> 2.1.0", require: "rest_client"
 gem 'resque', '>=1.14.0'
 gem 'resque-scheduler'
 gem 'after_commit_everywhere'

--- a/Gemfile
+++ b/Gemfile
@@ -56,7 +56,7 @@ gem 'sanitize', '>= 4.6.5'
 # https://otwarchive.atlassian.net/browse/AO3-4957
 # https://github.com/rubys/nokogumbo/issues/50
 gem 'nokogumbo', '1.4.9'
-gem 'rest-client', '~> 1.8.0', require: 'rest_client'
+gem 'rest-client', '~> 2.1.0', require: 'rest_client'
 gem 'resque', '>=1.14.0'
 gem 'resque-scheduler'
 gem 'after_commit_everywhere'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1126,6 +1126,7 @@ GEM
     hashdiff (1.0.1)
     highline (2.0.3)
     htmlentities (4.3.4)
+    http-accept (1.7.0)
     http-cookie (1.0.3)
       domain_name (~> 0.5)
     httparty (0.16.2)
@@ -1165,7 +1166,9 @@ GEM
       webrick (~> 1.7)
       webrobots (>= 0.0.9, < 0.2)
     method_source (1.0.0)
-    mime-types (2.99.3)
+    mime-types (3.3.1)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2021.0225)
     mimemagic (0.3.10)
       nokogiri (~> 1)
       rake
@@ -1284,10 +1287,11 @@ GEM
       redis (>= 3.3)
       resque (>= 1.26)
       rufus-scheduler (~> 3.2)
-    rest-client (1.8.0)
+    rest-client (2.1.0)
+      http-accept (>= 1.7.0, < 2.0)
       http-cookie (>= 1.0.2, < 2.0)
-      mime-types (>= 1.16, < 3.0)
-      netrc (~> 0.7)
+      mime-types (>= 1.16, < 4.0)
+      netrc (~> 0.8)
     rollout (2.4.3)
     rspec (3.8.0)
       rspec-core (~> 3.8.0)
@@ -1465,7 +1469,7 @@ DEPENDENCIES
   redis-namespace
   resque (>= 1.14.0)
   resque-scheduler
-  rest-client (~> 1.8.0)
+  rest-client (~> 2.1.0)
   rollout
   rspec (~> 3.8)
   rspec-rails (~> 3.8.2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1135,6 +1135,12 @@ GEM
     jmespath (1.4.0)
     json (2.3.1)
     kgio (2.10.0)
+    kt-paperclip (6.4.1)
+      activemodel (>= 4.2.0)
+      activesupport (>= 4.2.0)
+      mime-types
+      mimemagic (~> 0.3.0)
+      terrapin (~> 0.6.0)
     launchy (2.5.0)
       addressable (~> 2.7)
     lograge (0.11.2)
@@ -1194,12 +1200,6 @@ GEM
       nokogiri
     ntlm-http (0.1.1)
     orm_adapter (0.5.0)
-    paperclip (6.1.0)
-      activemodel (>= 4.2.0)
-      activesupport (>= 4.2.0)
-      mime-types
-      mimemagic (~> 0.3.0)
-      terrapin (~> 0.6.0)
     permit_yo (2.1.3)
     phraseapp-in-context-editor-ruby (1.3.1)
       i18n (>= 0.6)
@@ -1440,6 +1440,7 @@ DEPENDENCIES
   htmlentities
   httparty
   kgio (= 2.10.0)
+  kt-paperclip (>= 5.2.0)
   launchy
   lograge
   mechanize
@@ -1448,7 +1449,6 @@ DEPENDENCIES
   newrelic_rpm
   nokogiri (>= 1.8.5)
   nokogumbo (= 1.4.9)
-  paperclip (>= 5.2.0)
   permit_yo
   phraseapp-in-context-editor-ruby (>= 1.0.6)
   pickle


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6157

## Purpose

Updates mime-types gem to 3.3.1 to deal with [an error message that happens with Ruby 2.7](https://github.com/mime-types/ruby-mime-types/pull/146). This also means switching from paperclip to kt-paperclip (#3989) and updating rest-client to 2.1.0.

## Testing Instructions

Tests should run and pass, site should load, uploading and deleting icons should work.

## References

Links in the Purpose section.

## Credit

Sarken and Enigel (@CristinaRO), both she/her