### PR TITLE
AO3-4936 Fix 500 error when displaying a work missing fandom in chapter by chapter mode

### DIFF
--- a/app/controllers/chapters_controller.rb
+++ b/app/controllers/chapters_controller.rb
@@ -1,6 +1,6 @@
 class ChaptersController < ApplicationController
   # only registered users and NOT admin should be able to create new chapters
-  before_action :users_only, except: [ :index, :show, :destroy, :confirm_delete ]
+  before_action :users_only, except: [:index, :show, :destroy, :confirm_delete]
   before_action :check_user_status, only: [:new, :create, :edit, :update]
   before_action :load_work
   # only authors of a work should be able to edit its chapters
@@ -33,9 +33,8 @@ class ChaptersController < ApplicationController
       render "works/_adult", layout: "application" and return
     end
 
-    if params[:selected_id]
-      redirect_to url_for(controller: :chapters, action: :show, work_id: @work.id, id: params[:selected_id]) and return
-    end
+    redirect_to url_for(controller: :chapters, action: :show, work_id: @work.id, id: params[:selected_id]) and return if params[:selected_id]
+
     @chapters = @work.chapters_in_order(
       include_content: false,
       include_drafts: (logged_in_as_admin? ||
@@ -46,22 +45,27 @@ class ChaptersController < ApplicationController
     else
       chapter_position = @chapters.index(@chapter)
       if @chapters.length > 1
-        @previous_chapter = @chapters[chapter_position-1] unless chapter_position == 0
-        @next_chapter = @chapters[chapter_position+1]
+        @previous_chapter = @chapters[chapter_position - 1] unless chapter_position.zero?
+        @next_chapter = @chapters[chapter_position + 1]
       end
       @commentable = @work
       @comments = @chapter.comments.reviewed
-
+      fandoms = @tag_groups["Fandom"]
+      page_title_fandom = if fandoms.size > 3
+                            t(".multifandom")
+                          else
+                            fandoms.empty? ? t(".no_fandom") : fandoms[0].name
+                          end
       @page_title = @work.unrevealed? ? ts("Mystery Work - Chapter %{position}", position: @chapter.position.to_s) :
-        get_page_title(@tag_groups.include?("Fandom") ? t(".no_fandom") : @tag_groups["Fandom"][0].name,
-          @work.anonymous? ? ts("Anonymous") : @work.pseuds.sort.collect(&:byline).join(', '),
-          @work.title + " - Chapter " + @chapter.position.to_s)
+        get_page_title(page_title_fandom,
+                       @work.anonymous? ? ts("Anonymous") : @work.pseuds.sort.collect(&:byline).join(", "),
+                       @work.title + " - Chapter " + @chapter.position.to_s)
 
       @kudos = @work.kudos.with_user.includes(:user)
 
       if current_user.respond_to?(:subscriptions)
         @subscription = current_user.subscriptions.where(subscribable_id: @work.id,
-                                                         subscribable_type: 'Work').first ||
+                                                         subscribable_type: "Work").first ||
                         current_user.subscriptions.build(subscribable: @work)
       end
       # update the history.
@@ -82,14 +86,14 @@ class ChaptersController < ApplicationController
 
   # GET /work/:work_id/chapters/1/edit
   def edit
-    if params["remove"] == "me"
-      @chapter.creatorships.for_user(current_user).destroy_all
-      if @work.chapters.any? { |c| current_user.is_author_of?(c) }
-        flash[:notice] = ts("You have been removed as a creator from the chapter.")
-        redirect_to @work
-      else # remove from work if no longer co-creator on any chapter
-        redirect_to edit_work_path(@work, remove: "me")
-      end
+    return unless params["remove"] == "me"
+
+    @chapter.creatorships.for_user(current_user).destroy_all
+    if @work.chapters.any? { |c| current_user.is_author_of?(c) }
+      flash[:notice] = ts("You have been removed as a creator from the chapter.")
+      redirect_to @work
+    else # remove from work if no longer co-creator on any chapter
+      redirect_to edit_work_path(@work, remove: "me")
     end
   end
 
@@ -223,7 +227,7 @@ class ChaptersController < ApplicationController
       else
         flash[:error] = ts("Something went wrong. Please try again.")
       end
-      redirect_to controller: 'works', action: 'show', id: @work
+      redirect_to controller: "works", action: "show", id: @work
     end
   end
 
@@ -238,7 +242,7 @@ class ChaptersController < ApplicationController
   # fetch work these chapters belong to from db
   def load_work
     @work = params[:work_id] ? Work.find_by(id: params[:work_id]) : Chapter.find_by(id: params[:id]).try(:work)
-    unless @work.present?
+    if @work.blank?
       flash[:error] = ts("Sorry, we couldn't find the work you were looking for.")
       redirect_to root_path and return
     end
@@ -250,28 +254,21 @@ class ChaptersController < ApplicationController
   # chapter is specified, or if the specified chapter doesn't exist.
   def load_chapter
     @chapter = @work.chapters.find_by(id: params[:id])
+    return if @chapter
 
-    unless @chapter
-      flash[:error] = ts("Sorry, we couldn't find the chapter you were looking for.")
-      redirect_to work_path(@work)
-    end
+    flash[:error] = ts("Sorry, we couldn't find the chapter you were looking for.")
+    redirect_to work_path(@work)
   end
-
 
   def post_chapter
-    if !@work.posted
-      @work.update_attribute(:posted, true)
-    end
-    flash[:notice] = ts('Chapter has been posted!')
+    @work.update_attribute(:posted, true) unless @work.posted
+    flash[:notice] = ts("Chapter has been posted!")
   end
-
-  private
 
   def chapter_params
     params.require(:chapter).permit(:title, :position, :wip_length, :"published_at(3i)",
                                     :"published_at(2i)", :"published_at(1i)", :summary,
                                     :notes, :endnotes, :content, :published_at,
                                     author_attributes: [:byline, ids: [], coauthors: []])
-
   end
 end

--- a/app/controllers/chapters_controller.rb
+++ b/app/controllers/chapters_controller.rb
@@ -50,16 +50,15 @@ class ChaptersController < ApplicationController
       end
       @commentable = @work
       @comments = @chapter.comments.reviewed
-      fandoms = @tag_groups["Fandom"]
-      page_title_fandom = if fandoms.size > 3
-                            t(".multifandom")
-                          else
-                            fandoms.empty? ? t(".no_fandom") : fandoms[0].name
-                          end
-      @page_title = @work.unrevealed? ? ts("Mystery Work - Chapter %{position}", position: @chapter.position.to_s) :
-        get_page_title(page_title_fandom,
-                       @work.anonymous? ? ts("Anonymous") : @work.pseuds.sort.collect(&:byline).join(", "),
-                       @work.title + " - Chapter " + @chapter.position.to_s)
+
+      if @work.unrevealed?
+        @page_title = t(".unrevealed") + t(".chapter_position", position: @chapter.position.to_s)
+      else
+        fandom = @tag_groups["Fandom"].empty? ? t(".no_fandom") : @tag_groups["Fandom"][0].name
+        title_fandom = @tag_groups["Fandom"].size > 3 ? t(".multifandom") : fandom
+        author = @work.anonymous? ? t(".anonymous") : @work.pseuds.sort.collect(&:byline).join(", ")
+        @page_title = get_page_title(title_fandom, author, t(".chapter_position", position: @chapter.position.to_s))
+      end
 
       @kudos = @work.kudos.with_user.includes(:user)
 

--- a/app/controllers/chapters_controller.rb
+++ b/app/controllers/chapters_controller.rb
@@ -53,7 +53,7 @@ class ChaptersController < ApplicationController
       @comments = @chapter.comments.reviewed
 
       @page_title = @work.unrevealed? ? ts("Mystery Work - Chapter %{position}", position: @chapter.position.to_s) :
-        get_page_title(@tag_groups["Fandom"][0].name,
+        get_page_title(@tag_groups.include?("Fandom") ? t(".no_fandom") : @tag_groups["Fandom"][0].name,
           @work.anonymous? ? ts("Anonymous") : @work.pseuds.sort.collect(&:byline).join(', '),
           @work.title + " - Chapter " + @chapter.position.to_s)
 

--- a/app/controllers/chapters_controller.rb
+++ b/app/controllers/chapters_controller.rb
@@ -57,7 +57,7 @@ class ChaptersController < ApplicationController
         fandom = @tag_groups["Fandom"].empty? ? t(".no_fandom") : @tag_groups["Fandom"][0].name
         title_fandom = @tag_groups["Fandom"].size > 3 ? t(".multifandom") : fandom
         author = @work.anonymous? ? t(".anonymous") : @work.pseuds.sort.collect(&:byline).join(", ")
-        @page_title = get_page_title(title_fandom, author, t(".chapter_position", position: @chapter.position.to_s))
+        @page_title = get_page_title(title_fandom, author, @work.title + t(".chapter_position", position: @chapter.position.to_s))
       end
 
       @kudos = @work.kudos.with_user.includes(:user)

--- a/app/controllers/chapters_controller.rb
+++ b/app/controllers/chapters_controller.rb
@@ -55,8 +55,9 @@ class ChaptersController < ApplicationController
       if @work.unrevealed?
         @page_title = t(".unrevealed") + t(".chapter_position", position: @chapter.position.to_s)
       else
-        fandom = @tag_groups["Fandom"].empty? ? t(".no_fandom") : @tag_groups["Fandom"][0].name
-        title_fandom = @tag_groups["Fandom"].size > 3 ? t(".multifandom") : fandom
+        fandoms = @tag_groups["Fandom"]
+        fandom = fandoms.empty? ? t(".unspecified_fandom") : fandoms[0].name
+        title_fandom = fandoms.size > 3 ? t(".multifandom") : fandom
         author = @work.anonymous? ? t(".anonymous") : @work.pseuds.sort.collect(&:byline).join(", ")
         @page_title = get_page_title(title_fandom, author, @work.title + t(".chapter_position", position: @chapter.position.to_s))
       end

--- a/config/locales/controllers/en.yml
+++ b/config/locales/controllers/en.yml
@@ -4,8 +4,8 @@ en:
     anonymous: Anonymous
     chapter_position: " - Chapter %{position}"
     multifandom: Multifandom
-    no_fandom: No fandom specified
     unrevealed: Mystery Work
+    unspecified_fandom: No fandom specified
   comments:
     check_frozen:
       error: Sorry, you cannot reply to a frozen comment.

--- a/config/locales/controllers/en.yml
+++ b/config/locales/controllers/en.yml
@@ -1,8 +1,11 @@
 ---
 en:
   chapters:
+    anonymous: Anonymous
+    chapter_position: " - Chapter %{position}"
     multifandom: Multifandom
     no_fandom: No fandom specified
+    unrevealed: Mystery Work
   comments:
     check_frozen:
       error: Sorry, you cannot reply to a frozen comment.

--- a/config/locales/controllers/en.yml
+++ b/config/locales/controllers/en.yml
@@ -1,6 +1,7 @@
 ---
 en:
   chapters:
+    multifandom: Multifandom
     no_fandom: No fandom specified
   comments:
     check_frozen:

--- a/config/locales/controllers/en.yml
+++ b/config/locales/controllers/en.yml
@@ -1,5 +1,7 @@
 ---
 en:
+  chapters:
+    no_fandom: No fandom specified
   comments:
     check_frozen:
       error: Sorry, you cannot reply to a frozen comment.

--- a/spec/controllers/chapters_controller_spec.rb
+++ b/spec/controllers/chapters_controller_spec.rb
@@ -715,11 +715,8 @@ describe ChaptersController do
   end
 
   describe "multi-chapter work" do
-    before do
-      @chapter1 = work.chapters.first
-      @chapter2 = create(:chapter, work: work, posted: true, position: 2, authors: [user.pseuds.first])
-      @chapter3 = create(:chapter, work: work, posted: true, position: 3, authors: [user.pseuds.first])
-    end
+    let(:chapter1) { work.chapters.first }
+    let(:chapter2) { create(:chapter, work: work, posted: true, position: 2, authors: [user.pseuds.first]) }
 
     context "missing tags don't cause errors when displayed chapter by chapter" do
       before do
@@ -730,7 +727,7 @@ describe ChaptersController do
       end
 
       it "for the first chapter" do
-        get :show, params: { work_id: work.id, id: @chapter1 }
+        get :show, params: { work_id: work.id, id: chapter1 }
         expect(response).to have_http_status(:ok)
         expect(assigns(:page_title)).to include(assigns(:work).title)
         expect(assigns(:page_title)).to include("No fandom specified")
@@ -738,7 +735,7 @@ describe ChaptersController do
       end
 
       it "for subsequent chapters" do
-        get :show, params: { work_id: work.id, id: @chapter2 }
+        get :show, params: { work_id: work.id, id: chapter2 }
         expect(response).to have_http_status(:ok)
         expect(assigns(:page_title)).to include(assigns(:work).title)
         expect(assigns(:page_title)).to include("No fandom specified")

--- a/spec/controllers/chapters_controller_spec.rb
+++ b/spec/controllers/chapters_controller_spec.rb
@@ -195,23 +195,13 @@ describe ChaptersController do
       expect(assigns[:page_title]).to eq("page title")
     end
 
-    context "when multi-chapter work is missing tags" do
-      let(:chapter1) { work.chapters.first }
-      let(:chapter2) { create(:chapter, work: work, posted: true, position: 2) }
-
-      before do
-        work.taggings.delete_all
-        work.save
-        work.reload
-        fake_login_known_user(user)
-      end
-
-      it "can still render chapter by chapter" do
-        get :show, params: { work_id: work.id, id: chapter1 }
+    context "when work has no fandom" do
+      it "assigns @page_title with a placeholder for the fandom" do
+        allow_any_instance_of(Work).to receive(:tag_groups).and_return("Fandom" => [])
+        expect_any_instance_of(ChaptersController).to receive(:get_page_title).with("No fandom specified", user.pseuds.first.name, "#{work.title} - Chapter 1").and_return("page title")
+        get :show, params: { work_id: work.id, id: work.chapters.first.id }
         expect(response).to have_http_status(:ok)
-        expect(assigns(:page_title)).to include(assigns(:work).title)
-        expect(assigns(:page_title)).to include("No fandom specified")
-        expect(assigns(:page_title)).to include(" - Chapter 1")
+        expect(assigns[:page_title]).to eq("page title")
       end
     end
 

--- a/spec/controllers/chapters_controller_spec.rb
+++ b/spec/controllers/chapters_controller_spec.rb
@@ -731,7 +731,7 @@ describe ChaptersController do
 
       it "for the first chapter" do
         get :show, params: { work_id: work.id, id: @chapter1 }
-        expect(response).to have_http_status(200)
+        expect(response).to have_http_status(:ok)
         expect(assigns(:page_title)).to include(assigns(:work).title)
         expect(assigns(:page_title)).to include("No fandom specified")
         expect(assigns(:page_title)).to include(" - Chapter 1")
@@ -739,47 +739,53 @@ describe ChaptersController do
 
       it "for subsequent chapters" do
         get :show, params: { work_id: work.id, id: @chapter2 }
-        expect(response).to have_http_status(200)
+        expect(response).to have_http_status(:ok)
         expect(assigns(:page_title)).to include(assigns(:work).title)
         expect(assigns(:page_title)).to include("No fandom specified")
         expect(assigns(:page_title)).to include(" - Chapter 2")
       end
     end
+  end
 
-    context "update_positions" do
-      context "when user is logged out" do
-        it "errors and redirects to login" do
-          post :update_positions, params: { work_id: work.id, chapter: [@chapter1, @chapter3, @chapter2] }
-          it_redirects_to_with_error(new_user_session_path, "Sorry, you don't have permission to access the page you were trying to reach. Please log in.")
+  describe "update_positions" do
+    before do
+      @chapter1 = work.chapters.first
+      @chapter2 = create(:chapter, work: work, posted: true, position: 2, authors: [user.pseuds.first])
+      @chapter3 = create(:chapter, work: work, posted: true, position: 3, authors: [user.pseuds.first])
+    end
+
+    context "when user is logged out" do
+      it "errors and redirects to login" do
+        post :update_positions, params: { work_id: work.id, chapter: [@chapter1, @chapter3, @chapter2] }
+        it_redirects_to_with_error(new_user_session_path, "Sorry, you don't have permission to access the page you were trying to reach. Please log in.")
+      end
+    end
+
+    context "when work owner is logged in" do
+      before do
+        fake_login_known_user(user)
+      end
+
+      context "when passing params[:chapters]" do
+        it "updates the positions of the chapters" do
+          post :update_positions, params: { work_id: work.id, chapters: [1, 3, 2] }
+          expect(@chapter1.reload.position).to eq(1)
+          expect(@chapter2.reload.position).to eq(3)
+          expect(@chapter3.reload.position).to eq(2)
+        end
+
+        it "gives a notice and redirects to work" do
+          post :update_positions, params: { work_id: work.id, chapters: [1, 3, 2] }
+          it_redirects_to_with_notice(work, "Chapter order has been successfully updated.")
         end
       end
 
-      context "when work owner is logged in" do
-        before do
-          fake_login_known_user(user)
-        end
-
-        context "when passing params[:chapters]" do
-          it "updates the positions of the chapters" do
-            post :update_positions, params: { work_id: work.id, chapters: [1, 3, 2] }
-            expect(@chapter1.reload.position).to eq(1)
-            expect(@chapter2.reload.position).to eq(3)
-            expect(@chapter3.reload.position).to eq(2)
-          end
-
-          it "gives a notice and redirects to work" do
-            post :update_positions, params: { work_id: work.id, chapters: [1, 3, 2] }
-            it_redirects_to_with_notice(work, "Chapter order has been successfully updated.")
-          end
-        end
-
-        context "when passing params[:chapter]" do
-          it "updates the positions of the chapters" do
-            post :update_positions, params: { work_id: work.id, chapter: [@chapter1, @chapter3, @chapter2], format: :js }
-            expect(@chapter1.reload.position).to eq(1)
-            expect(@chapter2.reload.position).to eq(3)
-            expect(@chapter3.reload.position).to eq(2)
-          end
+      context "when passing params[:chapter]" do
+        it "updates the positions of the chapters" do
+          post :update_positions, params: { work_id: work.id, chapter: [@chapter1, @chapter3, @chapter2], format: :js }
+          expect(@chapter1.reload.position).to eq(1)
+          expect(@chapter2.reload.position).to eq(3)
+          expect(@chapter3.reload.position).to eq(2)
         end
       end
     end


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [x] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [x] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [x] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-4936
## Purpose

No more 500 errors when trying to display in chapter by chapter mode a work which has no fandoms.  The work will now display with fandom data missing.  Translation string was also added for "No fandom specified" (copied from existing entire work display).

## Testing Instructions

- Locate a multi-chapter work which has no fandoms (either existing, or take advantage of AO3-4932, or with DB access delete the fandom tags)
- Set your view to both entire work and chapter by chapter to verify the work will render in both modes
- Verify the page title says "No fandom specified" in both modes

## References

https://otwarchive.atlassian.net/browse/AO3-4932