### PR TITLE
AO3-5988 Replace noncanonical categories and ratings

### DIFF
--- a/lib/tasks/after_tasks.rake
+++ b/lib/tasks/after_tasks.rake
@@ -794,6 +794,16 @@ namespace :After do
     STDOUT.flush
   end
 
+  desc "Clean up noncanonical category tags"
+  task(clean_up_noncanonical_categories: :environment) do
+    canonical_categories = %w[Gen M/M F/F F/M Multi Other]
+    Category.where.not(name: canonical_categories).each do |tag|
+      tag.update_column(:type, "Freeform")
+      puts "Noncanonical Category tag #{tag.name} was changed into an Additional Tag."
+    end
+    STDOUT.flush
+  end
+
   # This is the end that you have to put new tasks above.
 end
 


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [x] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [x] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [x] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-5988

## Purpose

What does this PR do?

### Replace a specific noncanonical rating tag

We accidentally imported a large number of works with a noncanonical rating "Teen & Up Audiences".

Given that this is our culpa, we want to fix these works and give them the canonical version, "Teen And Up Audiences".

At the end of the task we make sure that no other works use the erroneous rating, and if so destroy it.

**Must be run before the task that changes the type of all noncanonical rating tags into freeform.**

### Change the type of noncanonical rating and category tags

Before we managed to prevent the creation of noncanonical ratings, we ended up with a number of such ratings in the Archive. Same for category tags.

Change all of them into Additional Tags (AKA freeforms).

## Testing Instructions

How can the Archive's QA team verify that this is working as you intended?

If you have a Jira account with access, please update or comment on the issue
with any new or missing testing instructions instead.

## References

Are there other relevant issues/pull requests/mailing list discussions?

## Credit

What name and pronouns should we use to credit you in the [Archive of Our Own's Release Notes](https://archiveofourown.org/admin_posts?tag=1)?

Enigel (she/her)
