### PR TITLE
AO3-6169 Prevent loading twitter widgets during automated tests.

### DIFF
--- a/features/support/capybara.rb
+++ b/features/support/capybara.rb
@@ -13,5 +13,12 @@ Capybara.configure do |config|
   config.default_max_wait_time = 25
 end
 
+# Reconfigure poltergeist to block twitter:
+Capybara.register_driver :poltergeist do |app|
+  Capybara::Poltergeist::Driver.new(
+    app, url_blacklist: ["http://platform.twitter.com", "https://platform.twitter.com"]
+  )
+end
+
 Capybara.default_driver = :rack_test
 Capybara.javascript_driver = :poltergeist


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6169

## Purpose

This PR modifies the Poltergeist driver in JS tests so that it no longer loads anything from `platform.twitter.com`. Hopefully this will reduce the number of `StatusFailError`s on the homepage.

## Testing Instructions

Rerun the automated tests a bunch of times to see if you get any `StatusFailError`s.