### PR TITLE
AO3-6176 Use correct version of bundler in Docker image

### DIFF
--- a/config/docker/Dockerfile
+++ b/config/docker/Dockerfile
@@ -19,7 +19,9 @@ VOLUME /otwa
 # Install ruby packages
 COPY Gemfile .
 COPY Gemfile.lock .
-RUN gem install bundler -v 1.17.3 && bundle install
+RUN gem install bundler -v 1.17.3
+RUN alias bundle="bundle _1.17.3_" && alias bundler="bundler _1.17.3_"
+RUN bundle install
 
 # Default command to run in a new container
 EXPOSE 3000


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [x] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [x] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [x] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-6176

## Purpose

Aligns bundler versions in the Docker image to be the same as production (v1.17.3).  The version in the Docker image was unintentionally upgraded to 2.1.4 as that version of bundler comes prepackaged in the ruby:2.7.3  image.

## Testing Instructions

1.  Build the Docker image `docker compose up -d --build`
2. Confirm bundler is the correct version (1.17.3): `docker compose exec web bundle version` and `docker compose exec web bundler version`

## References

https://otwarchive.atlassian.net/browse/AO3-6157
#3992 
