### PR TITLE
AO3-5408 Stop storing IP addresses for support requests in the DB

### DIFF
--- a/app/models/feedback.rb
+++ b/app/models/feedback.rb
@@ -1,6 +1,7 @@
 # Class which holds feedback sent to the archive administrators about the archive as a whole
 class Feedback < ApplicationRecord
   include ActiveModel::ForbiddenAttributesProtection
+  attr_accessor :ip_address
 
   # note -- this has NOTHING to do with the Comment class!
   # This is just the name of the text field in the Feedback

--- a/db/migrate/20210603151906_remove_ip_address_from_feedbacks.rb
+++ b/db/migrate/20210603151906_remove_ip_address_from_feedbacks.rb
@@ -1,0 +1,5 @@
+class RemoveIpAddressFromFeedbacks < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :feedbacks, :ip_address, :string
+  end
+end

--- a/spec/models/feedback_spec.rb
+++ b/spec/models/feedback_spec.rb
@@ -70,4 +70,17 @@ describe Feedback do
       expect(safe_report.save).to be_truthy
     end
   end
+
+  context "with IP address" do
+    let(:ip) { Faker::Internet.ip_v4_address }
+    let(:feedback) { create(:feedback, ip_address: ip) }
+
+    it "has IP in Akismet attributes" do
+      expect(feedback.akismet_attributes[:user_ip]).to eq(ip)
+    end
+
+    it "does not store IP in the database" do
+      expect(Feedback.find_by(id: feedback.id)[:ip_address]).to eq(nil)
+    end
+  end
 end

--- a/spec/models/feedback_spec.rb
+++ b/spec/models/feedback_spec.rb
@@ -47,7 +47,7 @@ describe Feedback do
       end
   
       it "does not store IP in the database" do
-        expect(Feedback.find_by(id: feedback.id)[:ip_address]).to be_nil
+        expect(Feedback.find(feedback.id)[:ip_address]).to be_nil
       end
     end
 

--- a/spec/models/feedback_spec.rb
+++ b/spec/models/feedback_spec.rb
@@ -38,6 +38,19 @@ describe Feedback do
       end
     end
 
+    context "with IP address" do
+      let(:ip) { Faker::Internet.ip_v4_address }
+      let(:feedback) { create(:feedback, ip_address: ip) }
+  
+      it "has IP in Akismet attributes" do
+        expect(feedback.akismet_attributes[:user_ip]).to eq(ip)
+      end
+  
+      it "does not store IP in the database" do
+        expect(Feedback.find_by(id: feedback.id)[:ip_address]).to be_nil
+      end
+    end
+
     let(:no_email_provided) { build(:feedback, email: nil) }
     it "is invalid if an email is not provided" do
       expect(no_email_provided.save).to be_falsey
@@ -68,19 +81,6 @@ describe Feedback do
     it "is valid even with spam if logged in and providing correct email" do
       User.current_user = legit_user
       expect(safe_report.save).to be_truthy
-    end
-  end
-
-  context "with IP address" do
-    let(:ip) { Faker::Internet.ip_v4_address }
-    let(:feedback) { create(:feedback, ip_address: ip) }
-
-    it "has IP in Akismet attributes" do
-      expect(feedback.akismet_attributes[:user_ip]).to eq(ip)
-    end
-
-    it "does not store IP in the database" do
-      expect(Feedback.find_by(id: feedback.id)[:ip_address]).to eq(nil)
     end
   end
 end


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [x] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [x] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [x] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-5408

## Purpose

New support requests will no longer store users' IP addresses in the database.  IP will still be sent to Akismet for spam detection, but address is not saved (will be null).

Also adds a DB migration which will drop the column in question.  I've done this in a way that is "reversible" in rails so the column can be added back, but the existing IP address data will be lost if we do need to roll this back (so if we care about recovering the data it should be backed up first).

## Testing Instructions

Automated tests have been added in `feedback_spec.rb`
1. Submit a support request
2. Verify in the database that the value for "ip_address" is null (or the column itself doesn't exist if migrations have been applied)
3. Verify that Akismet data for this request still contains the IP address
