### PR TITLE
AO3-6072 Make English an available support/abuse language in fixtures

### DIFF
--- a/test/fixtures/languages.yml
+++ b/test/fixtures/languages.yml
@@ -3,6 +3,8 @@ English:
   id: 1
   name: English
   short: en
+  support_available: 1
+  abuse_support_available: 1
 French:
   id: 2
   name: Français

--- a/test/fixtures/languages.yml
+++ b/test/fixtures/languages.yml
@@ -3,8 +3,8 @@ English:
   id: 1
   name: English
   short: en
-  support_available: 1
-  abuse_support_available: 1
+  support_available: true
+  abuse_support_available: true
 French:
   id: 2
   name: Français


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [x] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [x] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [x] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-6072

## Purpose

Allows the support and abuse forms to work out-of-the-box for new development environments by setting English as the default language in the seed data.

## Testing Instructions

- Reset your development database (via script/reset_database.sh) or build a new one
- Verify in the DB that support_available=1 and abuse_support_available=1 for English in the `languages` table
- Start the application and verify that both support and abuse forms default to English as language (instead of being blank) and that both forms can be submitted

Before:
![Screen Shot 2021-06-04 at 09 20 40](https://user-images.githubusercontent.com/6746746/120850186-1626f800-c545-11eb-9603-0e08c9afd016.png)

After:
![Screen Shot 2021-06-04 at 14 50 50](https://user-images.githubusercontent.com/6746746/120850235-28089b00-c545-11eb-846c-29a606974268.png)
