### PR TITLE
AO3-6174 Make titles wrap inside blurbs and news/collection/work pages

### DIFF
--- a/public/stylesheets/site/2.0/02-elements.css
+++ b/public/stylesheets/site/2.0/02-elements.css
@@ -54,7 +54,6 @@ h1, h2, h3, h4, h5, h6, .heading {
   font-family: Georgia, serif;
   font-weight: 400;
     word-wrap: break-word;
-
 }
 
 h1 {

--- a/public/stylesheets/site/2.0/02-elements.css
+++ b/public/stylesheets/site/2.0/02-elements.css
@@ -53,6 +53,8 @@ a:focus img {
 h1, h2, h3, h4, h5, h6, .heading {
   font-family: Georgia, serif;
   font-weight: 400;
+    word-wrap: break-word;
+
 }
 
 h1 {

--- a/public/stylesheets/site/2.0/13-group-blurb.css
+++ b/public/stylesheets/site/2.0/13-group-blurb.css
@@ -268,10 +268,6 @@ eg collections, users, skins, instead of the 4-icon list
 
 /*various little mods*/
 
-.heading {
-    word-wrap: break-word;
-}
-
 /* mod: ITEM
 blurbs on the manage collection items pages, mostly reseting styles inherited from interactions (forms)
 */

--- a/public/stylesheets/site/2.0/13-group-blurb.css
+++ b/public/stylesheets/site/2.0/13-group-blurb.css
@@ -268,8 +268,8 @@ eg collections, users, skins, instead of the 4-icon list
 
 /*various little mods*/
 
-.collection .name {
-    word-wrap: break-word;
+.blurb .header {
+  word-wrap: break-word;
 }
 
 /* mod: ITEM

--- a/public/stylesheets/site/2.0/13-group-blurb.css
+++ b/public/stylesheets/site/2.0/13-group-blurb.css
@@ -268,8 +268,8 @@ eg collections, users, skins, instead of the 4-icon list
 
 /*various little mods*/
 
-.blurb .header {
-  word-wrap: break-word;
+.heading {
+    word-wrap: break-word;
 }
 
 /* mod: ITEM


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6174

## Purpose

makes obnoxiously long titles wrap.

## Testing Instructions

1. try creating a work with the title "a_really_obnoxiously_long_outlier_of_a_collection_name_for_this_google_code_issue_whee_i_am_so_happy_i_cannot_contain_my_joy_it_is_a_new_bug" and check that the title text wraps inside the blurb. click on the title and check that the title text also wraps inside the work.
2. try creating a collection with the same title. check that the title text wraps inside the blurb. click on the title and check that the title text also wraps inside the collection page.
3. try creating a news post with the same title. check that the title text wraps inside the landing page's news feed blurbs. click on the title and check that the title text also wraps inside the news post.

## References

the changes made to resolve this issue have been undone https://otwarchive.atlassian.net/browse/AO3-3992

## Comments

this fixes the issue where titles run outside of blurbs, but they still scroll inside work skins/news articles/collection pages, which can be fixed with

```
.heading {
    word-wrap: break-word;
}
```

but i wasn't sure if this was a fix to tack onto this issue or if it would require its own issue, or if it's something we should ignore for now