### PR TITLE
AO3-5964 Replace excess spaces in some tags

### DIFF
--- a/lib/tasks/after_tasks.rake
+++ b/lib/tasks/after_tasks.rake
@@ -757,9 +757,7 @@ namespace :After do
         old_tag_name = tag.name
         new_tag_name = old_tag_name.gsub(/[[:space:]]/, "_")
 
-        while Tag.find_by_name(new_tag_name) do
-          new_tag_name << "_"
-        end
+        new_tag_name << "_" while Tag.find_by("name", new_tag_name)
         tag.update_attribute(:name, new_tag_name)
 
         report_row = [tag.id, old_tag_name, new_tag_name].join(",") + "\n"

--- a/lib/tasks/after_tasks.rake
+++ b/lib/tasks/after_tasks.rake
@@ -757,7 +757,7 @@ namespace :After do
         old_tag_name = tag.name
         new_tag_name = old_tag_name.gsub(/[[:space:]]/, "_")
 
-        tag.update_column(:name, new_tag_name)
+        tag.update_attribute(:name, new_tag_name)
 
         report_row = [tag.id, old_tag_name, new_tag_name].join(",") + "\n"
         report_string += report_row

--- a/lib/tasks/after_tasks.rake
+++ b/lib/tasks/after_tasks.rake
@@ -746,7 +746,7 @@ namespace :After do
     total_batches = (total_tags + 999) / 1000
     puts "Inspecting #{total_tags} tags in #{total_batches} batches"
 
-    report_string = "Tag ID,Old tag name,New tag name\n"
+    report_string = ["Tag ID", "Old tag name", "New tag name"].to_csv
     Tag.find_in_batches.with_index do |batch, index|
       batch_number = index + 1
       progress_msg = "Batch #{batch_number} of #{total_batches} complete"
@@ -760,7 +760,7 @@ namespace :After do
         new_tag_name << "_" while Tag.find_by(name: new_tag_name)
         tag.update_attribute(:name, new_tag_name)
 
-        report_row = [tag.id, old_tag_name, new_tag_name].join(",") + "\n"
+        report_row = [tag.id, old_tag_name, new_tag_name].to_csv
         report_string += report_row
       end
 

--- a/lib/tasks/after_tasks.rake
+++ b/lib/tasks/after_tasks.rake
@@ -757,6 +757,9 @@ namespace :After do
         old_tag_name = tag.name
         new_tag_name = old_tag_name.gsub(/[[:space:]]/, "_")
 
+        while Tag.find_by_name(new_tag_name) do
+          new_tag_name << "_"
+        end
         tag.update_attribute(:name, new_tag_name)
 
         report_row = [tag.id, old_tag_name, new_tag_name].join(",") + "\n"

--- a/lib/tasks/after_tasks.rake
+++ b/lib/tasks/after_tasks.rake
@@ -757,7 +757,7 @@ namespace :After do
         old_tag_name = tag.name
         new_tag_name = old_tag_name.gsub(/[[:space:]]/, "_")
 
-        new_tag_name << "_" while Tag.find_by("name", new_tag_name)
+        new_tag_name << "_" while Tag.find_by(name: new_tag_name)
         tag.update_attribute(:name, new_tag_name)
 
         report_row = [tag.id, old_tag_name, new_tag_name].join(",") + "\n"

--- a/spec/lib/tasks/after_tasks.rake_spec.rb
+++ b/spec/lib/tasks/after_tasks.rake_spec.rb
@@ -171,7 +171,7 @@ describe "rake After:fix_tags_with_extra_spaces" do
     subject.invoke
 
     borked_tag.reload
-    expect(borked_tag.name).to eql("Borked_tag")
+    expect(borked_tag.name).to eql("Borked_tag_")
   end
 
   it "handles tags with quotes" do

--- a/spec/lib/tasks/after_tasks.rake_spec.rb
+++ b/spec/lib/tasks/after_tasks.rake_spec.rb
@@ -178,7 +178,7 @@ describe "rake After:fix_tags_with_extra_spaces" do
     borked_tag.update_column(:name, "\u00A0\"'quotes'\"")
     expect do
       subject.invoke
-    end.to output("Inspecting 9 tags in 1 batches\nBatch 1 of 1 complete\nTag ID,Old tag name,New tag name\n#{borked_tag.id},\u00A0\"'quotes'\",_\"'quotes'\"\n").to_stdout
+    end.to output(/.*Tag ID,Old tag name,New tag name\n#{borked_tag.id},\u00A0\"'quotes'\",_\"'quotes'\"\n$/).to_stdout
 
     borked_tag.reload
     expect(borked_tag.name).to eql("_\"'quotes'\"")

--- a/spec/lib/tasks/after_tasks.rake_spec.rb
+++ b/spec/lib/tasks/after_tasks.rake_spec.rb
@@ -178,7 +178,7 @@ describe "rake After:fix_tags_with_extra_spaces" do
     borked_tag.update_column(:name, "\u00A0\"'quotes'\"")
     expect do
       subject.invoke
-    end.to output(/.*Tag ID,Old tag name,New tag name\n#{borked_tag.id},\u00A0\"'quotes'\",_\"'quotes'\"\n$/).to_stdout
+    end.to output(/.*Tag ID,Old tag name,New tag name\n#{borked_tag.id},\"\u00A0\"\"'quotes'\"\"\",\"_\"\"'quotes'\"\"\"\n$/).to_stdout
 
     borked_tag.reload
     expect(borked_tag.name).to eql("_\"'quotes'\"")

--- a/spec/lib/tasks/after_tasks.rake_spec.rb
+++ b/spec/lib/tasks/after_tasks.rake_spec.rb
@@ -166,7 +166,7 @@ describe "rake After:fix_tags_with_extra_spaces" do
   end
 
   it "handles duplicated names" do
-    existing_tag = Freeform.create(name: "Borked_tag")
+    Freeform.create(name: "Borked_tag")
     borked_tag.update_column(:name, "Borked\u00A0tag")
     subject.invoke
 

--- a/spec/lib/tasks/after_tasks.rake_spec.rb
+++ b/spec/lib/tasks/after_tasks.rake_spec.rb
@@ -164,4 +164,23 @@ describe "rake After:fix_tags_with_extra_spaces" do
     borked_tag.reload
     expect(borked_tag.name).to eql("_____Borked____tag_____")
   end
+
+  it "handles duplicated names" do
+    existing_tag = Freeform.create(name: "Borked_tag")
+    borked_tag.update_column(:name, "Borked\u00A0tag")
+    subject.invoke
+
+    borked_tag.reload
+    expect(borked_tag.name).to eql("Borked_tag")
+  end
+
+  it "handles tags with quotes" do
+    borked_tag.update_column(:name, "\u00A0\"'quotes'\"")
+    expect do
+      subject.invoke
+    end.to output("Inspecting 9 tags in 1 batches\nBatch 1 of 1 complete\nTag ID,Old tag name,New tag name\n#{borked_tag.id},\u00A0\"'quotes'\",_\"'quotes'\"\n").to_stdout
+
+    borked_tag.reload
+    expect(borked_tag.name).to eql("_\"'quotes'\"")
+  end
 end


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [x] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [x] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [x] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-5964

## Purpose

Update to #3993 

Quoting from the original:

> This is a one-time After task to:
> - Identify tags that have extraneous spaces in their name
> - Replace each space in their name with an underscore (_)
> - Output the list of tags with their ID, old name, and new name

In the event that the new name with underscores clashes with an existing tag, underscores will be added at the end of the tag name until we get something unique.

## Testing Instructions

Automated tests have been added in `after_tasks.rake_spec.rb`

This can also be tested by creating tags with special spacing characters (may require database or console access) and running the rake task.

## References

#3993 

## Credit

@CristinaRO (Enigel, she/her) did most of the work in the original PR
