### PR TITLE
 AO3-6177 Fix flaky rate limiting specs

### DIFF
--- a/spec/requests/rack_attack_spec.rb
+++ b/spec/requests/rack_attack_spec.rb
@@ -1,14 +1,21 @@
 require "spec_helper"
 
 describe "Rack::Attack" do
+  around do |example|
+    default_store = Rack::Attack.cache.store
+    Rack::Attack.cache.store = ActiveSupport::Cache::MemoryStore.new
+    example.run
+    Rack::Attack.cache.store = default_store
+  end
+
   before { freeze_time }
 
   def unique_ip_env
-    { "REMOTE_ADDR" => Faker::Internet.unique.ip_v4_address }
+    { "REMOTE_ADDR" => Faker::Internet.unique.public_ip_v4_address }
   end
 
   def unique_user_params
-    { user: { login: Faker::Name.unique.first_name, password: "secret" } }
+    { user: { login: generate(:login), password: "secret" } }
   end
 
   it "test utility returns valid parameters for successful user login attempts" do


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6177

## Purpose

- Use an in-memory cache instead of memcached.
- Use the `:login` sequence because `Faker::Name.first_name` may be too short.
- Use `Faker::Internet.public_ip_v4_address` because it's guaranteed not to be private IPs (10.0.0.0/8), which are safelisted and never throttled.

## Testing Instructions

None. Tests pass [20x4 times](https://github.com/redsummernight/otwarchive/actions/runs/932672070) on my fork.