### PR TITLE
AO3-6187 Prevent passing revised_at as a parameter to the WorksController.

### DIFF
--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -893,7 +893,7 @@ class WorksController < ApplicationController
   def work_params
     params.require(:work).permit(
       :rating_string, :fandom_string, :relationship_string, :character_string,
-      :archive_warning_string, :category_string, :expected_number_of_chapters, :revised_at,
+      :archive_warning_string, :category_string, :expected_number_of_chapters,
       :freeform_string, :summary, :notes, :endnotes, :collection_names, :recipients, :wip_length,
       :backdate, :language_id, :work_skin_id, :restricted, :comment_permissions,
       :moderated_commenting_enabled, :title, :pseuds_to_add, :collections_to_add,

--- a/app/views/works/_hidden_fields.html.erb
+++ b/app/views/works/_hidden_fields.html.erb
@@ -41,7 +41,6 @@
 <%= form.hidden_field :expected_number_of_chapters, :value => "#{@work.expected_number_of_chapters}" %>
 <%= form.hidden_field :restricted, :value => "#{@work.restricted}" %>
 <%= form.hidden_field :comment_permissions, :value => "#{@work.comment_permissions}" %>
-<%= form.hidden_field :revised_at, :value => "#{@work.revised_at}" %>
 <%= form.hidden_field :language_id, :value => "#{@work.language_id}" %>
 <%= form.hidden_field :work_skin_id, :value => "#{@work.work_skin_id}" %>
 </div>


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6187

## Purpose

Removes `revised_at` from the list of hidden fields on the preview page, and removes it from the list of permitted attributes in the `WorksController`.