### PR TITLE
AO3-6189 Don't set Time.zone in challenge controllers.

### DIFF
--- a/app/controllers/challenge/gift_exchange_controller.rb
+++ b/app/controllers/challenge/gift_exchange_controller.rb
@@ -4,18 +4,8 @@ class Challenge::GiftExchangeController < ChallengesController
   before_action :load_collection
   before_action :load_challenge, except: [:new, :create]
   before_action :collection_owners_only, only: [:new, :create, :edit, :update, :destroy]
-  before_action :set_time_zone, only: [:create, :edit, :update]
 
   # ACTIONS
-
-  # we use this to make the times get set in the moderator's specified timezone
-  def set_time_zone
-    if params[:gift_exchange] && gift_exchange_params[:time_zone]
-      Time.zone = gift_exchange_params[:time_zone]
-    elsif @challenge && @challenge.time_zone
-      Time.zone = @challenge.time_zone
-    end
-  end
 
   def show
   end

--- a/app/controllers/challenge/prompt_meme_controller.rb
+++ b/app/controllers/challenge/prompt_meme_controller.rb
@@ -4,18 +4,8 @@ class Challenge::PromptMemeController < ChallengesController
   before_action :load_collection
   before_action :load_challenge, except: [:new, :create]
   before_action :collection_owners_only, only: [:new, :create, :edit, :update, :destroy]
-  before_action :set_time_zone, only: [:create, :edit, :update]
 
   # ACTIONS
-
-  # we use this to make the times get set in the moderator's specified timezone
-  def set_time_zone
-    if params[:prompt_meme] && prompt_meme_params[:time_zone]
-      Time.zone = prompt_meme_params[:time_zone]
-    elsif @challenge && @challenge.time_zone
-      Time.zone = @challenge.time_zone
-    end
-  end
 
   # is actually a blank page - should it be redirected to collection profile?
   def show

--- a/lib/challenge_core.rb
+++ b/lib/challenge_core.rb
@@ -81,10 +81,13 @@ module ChallengeCore
     def override_datetime_setters
       %w(signups_open_at signups_close_at assignments_due_at works_reveal_at authors_reveal_at).each do |datetime_attr|
         define_method("#{datetime_attr}_string") do
-          self.send(datetime_attr).try(:strftime, ArchiveConfig.DEFAULT_DATETIME_FORMAT)
+          return unless (datetime = self[datetime_attr])
+
+          datetime.in_time_zone(time_zone.presence || Time.zone).strftime(ArchiveConfig.DEFAULT_DATETIME_FORMAT)
         end
+
         define_method("#{datetime_attr}_string=") do |datetimestring|
-          self.send("#{datetime_attr}=", Timeliness.parse(datetimestring, zone: (self.time_zone || Time.zone)))
+          self[datetime_attr] = Timeliness.parse(datetimestring, zone: (time_zone.presence || Time.zone))
         end
       end
     end

--- a/spec/controllers/gift_exchange_controller_spec.rb
+++ b/spec/controllers/gift_exchange_controller_spec.rb
@@ -6,16 +6,16 @@ describe Challenge::GiftExchangeController do
   include LoginMacros
   include RedirectExpectationHelper
 
-  before(:each) do
-    @collection = FactoryBot.create(:collection, challenge: GiftExchange.new)
-    @collection.save
-    fake_login_known_user(@collection.owners.first.user)
-  end
+  let(:challenge) { GiftExchange.new }
+  let(:collection) { create(:collection, challenge: challenge) }
+  let(:owner) { collection.owners.first.user }
+
+  before { fake_login_known_user(owner) }
 
   describe "new" do
     context "when a gift exchange challenge already exists for the collection" do
       before do
-        post :new, params: { collection_id: @collection.name }
+        post :new, params: { collection_id: collection.name }
       end
 
       it "sets a flash message" do
@@ -23,16 +23,57 @@ describe Challenge::GiftExchangeController do
       end
 
       it "redirects to the collection's gift exchange edit page" do
-        expect(response).to redirect_to(edit_collection_gift_exchange_path(@collection))
+        expect(response).to redirect_to(edit_collection_gift_exchange_path(collection))
       end
     end
   end
 
   describe "create" do
+    let(:challenge) { nil }
+
     context "when freeform_num_required is negative (fails to save)" do
       it "renders the new template" do
-        post :create, params: { collection_id: @collection.name, gift_exchange: { requests_num_required: -1 } }
+        post :create, params: { collection_id: collection.name, gift_exchange: { requests_num_required: -1 } }
         expect(response).to render_template("new")
+      end
+    end
+
+    it "parses dates in the specified time zone, but doesn't change Time.zone" do
+      # Use travel_to so that we don't get any daylight savings time issues:
+      travel_to Time.utc(2021, 6, 24) do
+        expect do
+          post :create, params: {
+            collection_id: collection.name,
+            gift_exchange: {
+              signup_open: false,
+              time_zone: "Sydney",
+              signups_open_at_string: "2021-07-01 6:00 AM"
+            }
+          }
+        end.not_to change { Time.zone }
+
+        # Sydney is at +10, so we expect the UTC time to be 10 hours earlier:
+        expect(collection.reload.challenge.signups_open_at).to eq(Time.utc(2021, 6, 30, 20))
+      end
+    end
+  end
+
+  describe "edit" do
+    let(:challenge) do
+      GiftExchange.new(time_zone: "Sydney",
+                       signup_open: false,
+                       signups_open_at: Time.utc(2021, 6, 30, 20))
+    end
+
+    it "displays dates in the challenge time zone, but doesn't change Time.zone" do
+      # Use travel_to so that we don't get any daylight savings time issues:
+      travel_to Time.utc(2021, 6, 24) do
+        expect do
+          get :edit, params: { collection_id: collection.name }
+        end.not_to change { Time.zone }
+
+        # Sydney is at +10, so the time in the form should be 10 hours after the UTC time:
+        expect(assigns[:challenge].signups_open_at_string).to eq("2021-07-01 06:00AM")
       end
     end
   end
@@ -40,24 +81,43 @@ describe Challenge::GiftExchangeController do
   describe "update" do
     context "when freeform_num_required is negative (fails to save)" do
       it "renders the edit template" do
-        post :update, params: { collection_id: @collection.name, gift_exchange: { requests_num_required: -1 } }
+        post :update, params: { collection_id: collection.name, gift_exchange: { requests_num_required: -1 } }
         expect(response).to render_template("edit")
+      end
+    end
+
+    it "parses dates in the specified time zone, but doesn't change Time.zone" do
+      # Use travel_to so that we don't get any daylight savings time issues:
+      travel_to Time.utc(2021, 6, 24) do
+        expect do
+          post :create, params: {
+            collection_id: collection.name,
+            gift_exchange: {
+              signup_open: false,
+              time_zone: "Sydney",
+              signups_open_at_string: "2021-07-01 6:00 AM"
+            }
+          }
+        end.not_to change { Time.zone }
+
+        # Sydney is at +10, so we expect the UTC time to be 10 hours earlier:
+        expect(collection.reload.challenge.signups_open_at).to eq(Time.utc(2021, 6, 30, 20))
       end
     end
   end
 
   describe "destroy" do
-    before(:each) do
-      delete :destroy, params: { id: @collection.challenge.id, collection_id: @collection.name }
+    before do
+      delete :destroy, params: { collection_id: collection.name }
     end
 
     it "removes challenge variables on Collection" do
-      expect(@collection.reload.challenge_id).to eq(nil)
-      expect(@collection.reload.challenge_type).to eq(nil)
+      expect(collection.reload.challenge_id).to eq(nil)
+      expect(collection.reload.challenge_type).to eq(nil)
     end
 
     it "redirects to the collection's main page with a notice" do
-      it_redirects_to_with_notice(@collection, "Challenge settings were deleted.")
+      it_redirects_to_with_notice(collection, "Challenge settings were deleted.")
     end
   end
 end

--- a/spec/controllers/prompt_meme_controller_spec.rb
+++ b/spec/controllers/prompt_meme_controller_spec.rb
@@ -4,12 +4,15 @@ describe Challenge::PromptMemeController do
   include LoginMacros
   include RedirectExpectationHelper
 
-  let(:collection) { create(:collection, challenge: PromptMeme.new) }
+  let(:challenge) { PromptMeme.new }
+  let(:collection) { create(:collection, challenge: challenge) }
+  let(:owner) { collection.owners.first.user }
+
+  before { fake_login_known_user(owner) }
 
   describe "new" do
     context "when the collection already has a challenge" do
       before do
-        fake_login_known_user(collection.owners.first.user)
         post :new, params: { collection_id: collection.name }
       end
 
@@ -19,31 +22,83 @@ describe Challenge::PromptMemeController do
     end
   end
 
+  describe "create" do
+    let(:challenge) { nil }
+
+    it "parses dates in the specified time zone, but doesn't change Time.zone" do
+      # Use travel_to so that we don't get any daylight savings time issues:
+      travel_to Time.utc(2021, 6, 24) do
+        expect do
+          post :create, params: {
+            collection_id: collection.name,
+            prompt_meme: {
+              signup_open: false,
+              time_zone: "Sydney",
+              signups_open_at_string: "2021-07-01 6:00 AM"
+            }
+          }
+        end.not_to change { Time.zone }
+
+        # Sydney is at +10, so we expect the UTC time to be 10 hours earlier:
+        expect(collection.reload.challenge.signups_open_at).to eq(Time.utc(2021, 6, 30, 20))
+      end
+    end
+  end
+
+  describe "edit" do
+    let(:challenge) do
+      PromptMeme.new(time_zone: "Sydney",
+                     signup_open: false,
+                     signups_open_at: Time.utc(2021, 6, 30, 20))
+    end
+
+    it "displays dates in the challenge time zone, but doesn't change Time.zone" do
+      # Use travel_to so that we don't get any daylight savings time issues:
+      travel_to Time.utc(2021, 6, 24) do
+        expect do
+          get :edit, params: { collection_id: collection.name }
+        end.not_to change { Time.zone }
+
+        # Sydney is at +10, so the time in the form should be 10 hours after the UTC time:
+        expect(assigns[:challenge].signups_open_at_string).to eq("2021-07-01 06:00AM")
+      end
+    end
+  end
+
   describe "update" do
     context "when it fails to update parameters" do
       before do
-        fake_login_known_user(collection.owners.first.user)
-        allow_any_instance_of(PromptMeme).to receive(:update_attributes).and_return(false)
-        allow(controller).to receive(:prompt_meme_params).and_return({})
-        post :update, params: { collection_id: collection.name, prompt_meme: {} }
+        post :update, params: { collection_id: collection.name, prompt_meme: { requests_num_required: -1 } }
       end
 
       it "renders edit page" do
         expect(response).to render_template "edit"
       end
+    end
 
-      after do
-        allow(controller).to receive(:prompt_meme_params).and_call_original
-        allow_any_instance_of(PromptMeme).to receive(:update_attributes).and_call_original
+    it "parses dates in the specified time zone, but doesn't change Time.zone" do
+      # Use travel_to so that we don't get any daylight savings time issues:
+      travel_to Time.utc(2021, 6, 24) do
+        expect do
+          put :update, params: {
+            collection_id: collection.name,
+            prompt_meme: {
+              signup_open: false,
+              time_zone: "Sydney",
+              signups_open_at_string: "2021-07-01 6:00 AM"
+            }
+          }
+        end.not_to change { Time.zone }
+
+        # Sydney is at +10, so we expect the UTC time to be 10 hours earlier:
+        expect(collection.reload.challenge.signups_open_at).to eq(Time.utc(2021, 6, 30, 20))
       end
     end
   end
 
   describe "destroy" do
-    before(:each) do
-      collection.save
-      fake_login_known_user(collection.owners.first.user)
-      delete :destroy, params: { id: collection.challenge.id, collection_id: collection.name }
+    before do
+      delete :destroy, params: { collection_id: collection.name }
     end
 
     it "remove challenge variables on Collection" do


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6189

## Purpose

Removes the code in `GiftExchangeController` and `PromptMemeController` that sets `Time.zone` to the challenge's time zone.

Also modifies the datetime string conversion in `lib/challenge_core.rb` so that it formats dates in the challenge's time zone.

## Testing Instructions

See Jira.