### PR TITLE
AO3-5941 Index audits on remote address

### DIFF
--- a/db/migrate/20210625232846_index_audits_on_remote_address.rb
+++ b/db/migrate/20210625232846_index_audits_on_remote_address.rb
@@ -1,0 +1,47 @@
+class IndexAuditsOnRemoteAddress < ActiveRecord::Migration[5.2]
+  def up
+    if Rails.env.staging? || Rails.env.production?
+      database = ActiveRecord::Base.connection.current_database
+
+      puts <<~PTOSC
+        Schema Change Command:
+        pt-online-schema-change D=#{database},t=audits \\
+          --alter "ADD INDEX index_audits_on_remote_address (remote_address)" \\
+          --no-drop-old-table \\
+          -uroot --ask-pass --chunk-size=5k --max-flow-ctl 0 --pause-file /tmp/pauseme \\
+          --max-load Threads_running=15 --critical-load Threads_running=100 \\
+          --set-vars innodb_lock_wait_timeout=2 --alter-foreign-keys-method=auto \\
+          --execute
+
+        Table Deletion Command:
+
+        DROP TABLE IF EXISTS `#{database}`.`_audits_old`;
+      PTOSC
+    else
+      add_index :audits, :remote_address, name: "index_audits_on_remote_address"
+    end
+  end
+
+  def down
+    if Rails.env.staging? || Rails.env.production?
+      database = ActiveRecord::Base.connection.current_database
+
+      puts <<~PTOSC
+        Schema Change Command:
+        pt-online-schema-change D=#{database},t=audits \\
+          --alter "DROP INDEX index_audits_on_remote_address" \\
+          --no-drop-old-table \\
+          -uroot --ask-pass --chunk-size=5k --max-flow-ctl 0 --pause-file /tmp/pauseme \\
+          --max-load Threads_running=15 --critical-load Threads_running=100 \\
+          --set-vars innodb_lock_wait_timeout=2 --alter-foreign-keys-method=auto \\
+          --execute
+
+        Table Deletion Command:
+
+        DROP TABLE IF EXISTS `#{database}`.`_audits_old`;
+      PTOSC
+    else
+      remove_index :audits, name: "index_audits_on_remote_address"
+    end
+  end
+end


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5941

## Purpose

Indexes audits on remote address to speed up their retrieval and make AD&T cry with relief.

## Testing Instructions

You do the migrate up, then you do the migrate down, then you do the hokey pokey and turn yourself around (and then migrate back up). 

```ruby
bundle exec rake db:migrate:up VERSION=20210625232846
bundle exec rake db:migrate:down VERSION=20210625232846
```