### PR TITLE
AO3-5922 Index comments on email

### DIFF
--- a/db/migrate/20210626010047_index_comments_on_email.rb
+++ b/db/migrate/20210626010047_index_comments_on_email.rb
@@ -1,0 +1,47 @@
+class IndexCommentsOnEmail < ActiveRecord::Migration[5.2]
+  def up
+    if Rails.env.staging? || Rails.env.production?
+      database = Comment.connection.current_database
+
+      puts <<~PTOSC
+        Schema Change Command:
+        pt-online-schema-change D=#{database},t=comments \\
+          --alter "ADD INDEX index_comments_on_email (email)" \\
+          --no-drop-old-table \\
+          -uroot --ask-pass --chunk-size=5k --max-flow-ctl 0 --pause-file /tmp/pauseme \\
+          --max-load Threads_running=15 --critical-load Threads_running=100 \\
+          --set-vars innodb_lock_wait_timeout=2 --alter-foreign-keys-method=auto \\
+          --execute
+
+        Table Deletion Command:
+
+        DROP TABLE IF EXISTS `#{database}`.`_comments_old`;
+      PTOSC
+    else
+      add_index :comments, :email, name: "index_comments_on_email"
+    end
+  end
+
+  def down
+    if Rails.env.staging? || Rails.env.production?
+      database = Comment.connection.current_database
+
+      puts <<~PTOSC
+        Schema Change Command:
+        pt-online-schema-change D=#{database},t=comments \\
+          --alter "DROP INDEX index_comments_on_email" \\
+          --no-drop-old-table \\
+          -uroot --ask-pass --chunk-size=5k --max-flow-ctl 0 --pause-file /tmp/pauseme \\
+          --max-load Threads_running=15 --critical-load Threads_running=100 \\
+          --set-vars innodb_lock_wait_timeout=2 --alter-foreign-keys-method=auto \\
+          --execute
+
+        Table Deletion Command:
+
+        DROP TABLE IF EXISTS `#{database}`.`_comments_old`;
+      PTOSC
+    else
+      remove_index :comments, name: "index_comments_on_email"
+    end
+  end
+end


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5922

## Purpose

Indexes comments on email to speed up their retrieval and make AD&T teary-eyed with relief. (We won't actually cry for this because audits are worse.)

## Testing Instructions

Second verse, same as the first. You do the migrate up, then you do the migrate down, then you do the hokey pokey and turn yourself around (and then migrate back up). 

```ruby
bundle exec rake db:migrate:up VERSION=20210626010047
bundle exec rake db:migrate:down VERSION=20210626010047
```