### PR TITLE
AO3-5964 AO3-6065 Reorder tag clean-up rake tasks

### DIFF
--- a/lib/tasks/after_tasks.rake
+++ b/lib/tasks/after_tasks.rake
@@ -768,29 +768,6 @@ namespace :After do
     end
     puts(report_string) && STDOUT.flush
   end
-
-  desc "Add default rating to works missing a rating"
-  task(add_default_rating_to_works: :environment) do
-    work_count = Work.count
-    total_batches = (work_count + 999) / 1000
-    puts("Checking #{work_count} works in #{total_batches} batches") && STDOUT.flush
-    batch_number = 0
-    updated_works = []
-
-    Work.in_batches do |batch|
-      batch_number += 1
-      
-      batch.each do |work|
-        next unless work.ratings.empty?
-
-        work.ratings << Rating.find_by!(name: ArchiveConfig.RATING_DEFAULT_TAG_NAME)
-        work.save
-        updated_works << work.id
-      end
-      puts("Batch #{batch_number} of #{total_batches} complete") && STDOUT.flush
-    end
-    puts("Added default rating to works: #{updated_works}") && STDOUT.flush
-  end
   
   desc "Fix works imported with a noncanonical Teen & Up Audiences rating tag"
   task(fix_teen_and_up_imported_rating: :environment) do
@@ -822,6 +799,29 @@ namespace :After do
       puts "Noncanonical Category tag #{tag.name} was changed into an Additional Tag."
     end
     STDOUT.flush
+  end
+
+  desc "Add default rating to works missing a rating"
+  task(add_default_rating_to_works: :environment) do
+    work_count = Work.count
+    total_batches = (work_count + 999) / 1000
+    puts("Checking #{work_count} works in #{total_batches} batches") && STDOUT.flush
+    batch_number = 0
+    updated_works = []
+
+    Work.in_batches do |batch|
+      batch_number += 1
+      
+      batch.each do |work|
+        next unless work.ratings.empty?
+
+        work.ratings << Rating.find_by!(name: ArchiveConfig.RATING_DEFAULT_TAG_NAME)
+        work.save
+        updated_works << work.id
+      end
+      puts("Batch #{batch_number} of #{total_batches} complete") && STDOUT.flush
+    end
+    puts("Added default rating to works: #{updated_works}") && STDOUT.flush
   end
 
   # This is the end that you have to put new tasks above.

--- a/lib/tasks/after_tasks.rake
+++ b/lib/tasks/after_tasks.rake
@@ -740,6 +740,35 @@ namespace :After do
     WorkIndexer.create_mapping
   end
 
+  desc "Fix tags with extra spaces"
+  task(fix_tags_with_extra_spaces: :environment) do
+    total_tags = Tag.count
+    total_batches = (total_tags + 999) / 1000
+    puts "Inspecting #{total_tags} tags in #{total_batches} batches"
+
+    report_string = ["Tag ID", "Old tag name", "New tag name"].to_csv
+    Tag.find_in_batches.with_index do |batch, index|
+      batch_number = index + 1
+      progress_msg = "Batch #{batch_number} of #{total_batches} complete"
+
+      batch.each do |tag|
+        next unless tag.name != tag.name.squish
+
+        old_tag_name = tag.name
+        new_tag_name = old_tag_name.gsub(/[[:space:]]/, "_")
+
+        new_tag_name << "_" while Tag.find_by(name: new_tag_name)
+        tag.update_attribute(:name, new_tag_name)
+
+        report_row = [tag.id, old_tag_name, new_tag_name].to_csv
+        report_string += report_row
+      end
+
+      puts(progress_msg) && STDOUT.flush
+    end
+    puts(report_string) && STDOUT.flush
+  end
+
   desc "Add default rating to works missing a rating"
   task(add_default_rating_to_works: :environment) do
     work_count = Work.count
@@ -793,35 +822,6 @@ namespace :After do
       puts "Noncanonical Category tag #{tag.name} was changed into an Additional Tag."
     end
     STDOUT.flush
-  end
-
-  desc "Fix tags with extra spaces"
-  task(fix_tags_with_extra_spaces: :environment) do
-    total_tags = Tag.count
-    total_batches = (total_tags + 999) / 1000
-    puts "Inspecting #{total_tags} tags in #{total_batches} batches"
-
-    report_string = ["Tag ID", "Old tag name", "New tag name"].to_csv
-    Tag.find_in_batches.with_index do |batch, index|
-      batch_number = index + 1
-      progress_msg = "Batch #{batch_number} of #{total_batches} complete"
-
-      batch.each do |tag|
-        next unless tag.name != tag.name.squish
-
-        old_tag_name = tag.name
-        new_tag_name = old_tag_name.gsub(/[[:space:]]/, "_")
-
-        new_tag_name << "_" while Tag.find_by(name: new_tag_name)
-        tag.update_attribute(:name, new_tag_name)
-
-        report_row = [tag.id, old_tag_name, new_tag_name].to_csv
-        report_string += report_row
-      end
-
-      puts(progress_msg) && STDOUT.flush
-    end
-    puts(report_string) && STDOUT.flush
   end
 
   # This is the end that you have to put new tasks above.


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5964
https://otwarchive.atlassian.net/browse/AO3-6065

## Purpose

Ensures the rake tasks are listed in the order they should be run. 

- The space-fixing task is supposed to come before the task for cleaning up noncanonical categories and ratings ([AO3-5988](https://otwarchive.atlassian.net/browse/AO3-5988)) because "otherwise we may run into validation errors when we update tags, as we did in AO3-4275."
- The task to add Not Rated should go after the tasks for AO3-5988 "since some of the works without ratings actually have non-canonical ratings. Running it after also double checks no works slipped through the cracks without getting a rating added."
