### PR TITLE
AO3-6088 Filter visible comments by reviewed && approved

### DIFF
--- a/app/helpers/comments_helper.rb
+++ b/app/helpers/comments_helper.rb
@@ -108,11 +108,7 @@ module CommentsHelper
 
   def get_visible_comments(commentable)
     visible_comments = commentable.comments.reviewed
-
-    unless logged_in_as_admin?
-      visible_comments = visible_comments.where(approved: true)
-    end
-
+    visible_comments = visible_comments.where(approved: true) unless logged_in_as_admin?
     visible_comments
   end
 

--- a/app/helpers/comments_helper.rb
+++ b/app/helpers/comments_helper.rb
@@ -106,6 +106,16 @@ module CommentsHelper
         remote: true)
   end
 
+  def get_visible_comments(commentable)
+    visible_comments = commentable.comments.reviewed
+
+    unless logged_in_as_admin?
+      visible_comments = visible_comments.where(approved: true)
+    end
+
+    visible_comments
+  end
+
   #### HELPERS FOR CHECKING WHICH BUTTONS/FORMS TO DISPLAY #####
 
   def can_reply_to_comment?(comment)

--- a/app/views/comments/_comment_thread.html.erb
+++ b/app/views/comments/_comment_thread.html.erb
@@ -4,7 +4,7 @@
     <% if comment.approved? || logged_in_as_admin? %>
 
       <%= render 'comments/single_comment', single_comment: comment %>
-      <% child_comments = comment.comments.reviewed %>
+      <% child_comments = get_visible_comments(comment) %>
 
       <% if child_comments && child_comments.count > 0 %>
         <!-- cut off the recursion when we get too deep, but not if there's just one last measly comment left -->

--- a/app/views/comments/_commentable.html.erb
+++ b/app/views/comments/_commentable.html.erb
@@ -113,7 +113,7 @@
   <!-- If not, and show_comments is true, here is where the comments will be rendered -->
   <div id="comments_placeholder" <% unless params[:show_comments] || params[:tag_id] %>style="display:none;"<% end %>>
     <% if params[:show_comments] || params[:tag_id] %>
-      <% @comments = commentable.comments.reviewed.page(params[:page]) %>
+      <% @comments = get_visible_comments(commentable).page(params[:page]) %>
       <%= will_paginate @comments, params: { anchor: :comments } %>
       <%= render 'comments/comment_thread', { :depth => 0, :comments => @comments } %>
       </ol><!-- need to tack this on to close thread -->

--- a/features/comments_and_kudos/comments_pagination.feature
+++ b/features/comments_and_kudos/comments_pagination.feature
@@ -9,6 +9,23 @@ Scenario: One-chapter work with many comments
   When I follow "Next" within ".pagination"
   Then I should see "1" within ".pagination"
 
+Scenario: Work with many spam comments should have correct pagination for non-admins
+  Given the work "26 Comments" with 26 comments setup
+    And the last 5 comments on the work "26 Comments" are spam
+  When I view the work "26 Comments"
+    And I follow "Comments"
+  Then I should not see "Next"
+    And I should see 21 comments
+
+Scenario: Work with many spam comments should have correct pagination for admins
+  Given the work "28 Comments" with 28 comments setup
+    And the last 5 comments on the work "28 Comments" are spam
+    And I am logged in as an admin
+  When I view the work "28 Comments"
+    And I follow "Comments"
+  Then I should see "2" within ".pagination"
+    And I should see 25 comments
+
 Scenario: Multi-chapter work with many comments per chapter
 
   Given the chaptered work with 6 chapters with 50 comments "Epic WIP"

--- a/features/step_definitions/comment_steps.rb
+++ b/features/step_definitions/comment_steps.rb
@@ -14,6 +14,11 @@ Given /^I have the receive no comment notifications setup$/ do
   user.preference.save
 end
 
+Given "the last {int} comments on the work {string} are spam" do |n, work_name|
+  work = Work.includes(:comments).find_by(title: work_name)
+  work.comments.ordered_by_date.limit(n).find_each(&:mark_as_spam!)
+end
+
 # THEN
 
 Then /^the comment's posted date should be nowish$/ do
@@ -38,6 +43,11 @@ Then /^I should see Last Edited in the right timezone$/ do
   zone = Time.current.in_time_zone(Time.zone).zone
   step %{I should see "#{zone}" within ".comment .posted"}
   step %{I should see "Last Edited"}
+end
+
+Then "I should see {int} comments" do |expected_comment_count|
+  actual_comment_count = page.all("li.comment").count
+  assert actual_comment_count == expected_comment_count
 end
 
 # WHEN


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [x] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [x] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [x]  Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-6088

## Purpose
Fixes a bug where pagination counted *reviewed* comments of a commentable, but displayed *reviewed and accepted* comments, leading to a display disparity.

Now, the pagination uses the count of comments which will actually be displayed (only comments which are both reviewed and accepted).

## Testing Instructions
See JIRA
