### PR TITLE
AO3-5049 Fix confusing "email change" error message

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -168,17 +168,23 @@ class UsersController < ApplicationController
 
   def changed_email
     if !params[:new_email].blank? && reauthenticate
-      @old_email = @user.email
-      @user.email = params[:new_email]
       @new_email = params[:new_email]
-      @confirm_email = params[:email_confirmation]
 
-      if @new_email == @confirm_email && @user.save
-        flash[:notice] = ts('Your email has been successfully updated')
+      if @new_email != params[:email_confirmation]
+        flash[:error] = ts("Email addresses don't match! Please retype and try again")
+        return
+      end
+
+      @old_email = @user.email
+      @user.email = @new_email
+
+      if @user.save
+        flash[:notice] = ts("Your email has been successfully updated")
         UserMailer.change_email(@user.id, @old_email, @new_email).deliver_later
         @user.create_log_item(options = { action: ArchiveConfig.ACTION_NEW_EMAIL })
       else
-        flash[:error] = ts("Email addresses don't match! Please retype and try again")
+        # Make sure that on failure, the form still shows the old email as the "current" one.
+        @user.email = @old_email
       end
     end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -168,23 +168,23 @@ class UsersController < ApplicationController
 
   def changed_email
     if !params[:new_email].blank? && reauthenticate
-      @new_email = params[:new_email]
+      new_email = params[:new_email]
 
-      if @new_email != params[:email_confirmation]
+      if new_email != params[:email_confirmation]
         flash[:error] = ts("Email addresses don't match! Please retype and try again")
         return
       end
 
-      @old_email = @user.email
-      @user.email = @new_email
+      old_email = @user.email
+      @user.email = new_email
 
       if @user.save
         flash[:notice] = ts("Your email has been successfully updated")
-        UserMailer.change_email(@user.id, @old_email, @new_email).deliver_later
+        UserMailer.change_email(@user.id, old_email, new_email).deliver_later
         @user.create_log_item(options = { action: ArchiveConfig.ACTION_NEW_EMAIL })
       else
         # Make sure that on failure, the form still shows the old email as the "current" one.
-        @user.email = @old_email
+        @user.email = old_email
       end
     end
 

--- a/features/other_a/profile_edit.feature
+++ b/features/other_a/profile_edit.feature
@@ -86,7 +86,6 @@ Scenario: Changing email address -- can't be the same as another user's
   When I enter a duplicate email
   Then I should see "Email has already been taken"
     And 0 emails should be delivered
-    # Regression test for AO3-5049
     And I should not see "Email addresses don't match!"
     And I should not see "foo@ao3.org"
     And I should see "bar@ao3.org"

--- a/features/other_a/profile_edit.feature
+++ b/features/other_a/profile_edit.feature
@@ -86,6 +86,9 @@ Scenario: Changing email address -- can't be the same as another user's
   When I enter a duplicate email
   Then I should see "Email has already been taken"
     And 0 emails should be delivered
+    # Regression test for AO3-5049
+    And I should not see "Email addresses don't match!"
+    And I should not see "foo@ao3.org"
 
 Scenario: Date of birth - under age
 

--- a/features/other_a/profile_edit.feature
+++ b/features/other_a/profile_edit.feature
@@ -89,6 +89,7 @@ Scenario: Changing email address -- can't be the same as another user's
     # Regression test for AO3-5049
     And I should not see "Email addresses don't match!"
     And I should not see "foo@ao3.org"
+    And I should see "bar@ao3.org"
 
 Scenario: Date of birth - under age
 


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [x] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [x] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [x] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-5049

## Purpose
This PR fixes a confusing error message when a user tries to change their email address to one already in use by another user.

## Testing Instructions
See JIRA
