### PR TITLE
AO3-6094 Correctly set sent_at during invitation after_save callback

### DIFF
--- a/app/models/invitation.rb
+++ b/app/models/invitation.rb
@@ -74,8 +74,7 @@ class Invitation < ApplicationRecord
           UserMailer.invitation(self.id).deliver_now
         end
 
-        # We cannot simple use "self.sent_at = Time.now" since that change is not persisted when this
-        # function is called during after_save. Using update_column, it is.
+        # Skip callbacks within after_save by using update_column to avoid a callback loop
         self.update_column(:sent_at, Time.now)
       rescue Exception => exception
         errors.add(:base, "Notification email could not be sent: #{exception.message}")

--- a/app/models/invitation.rb
+++ b/app/models/invitation.rb
@@ -73,7 +73,10 @@ class Invitation < ApplicationRecord
           # send invitations actively sent by a user synchronously to avoid delays
           UserMailer.invitation(self.id).deliver_now
         end
-        self.sent_at = Time.now
+
+        # We cannot simple use "self.sent_at = Time.now" since that change is not persisted when this
+        # function is called during after_save. Using update_column, it is.
+        self.update_column(:sent_at, Time.now)
       rescue Exception => exception
         errors.add(:base, "Notification email could not be sent: #{exception.message}")
       end

--- a/spec/models/invitation_spec.rb
+++ b/spec/models/invitation_spec.rb
@@ -81,15 +81,16 @@ describe Invitation, :ready do
 
     # Regression test for AO3-6094
     context "Sending an invitation to a valid email" do
-      let(:invite) {build(:invitation, invitee_email: "foo@example.com")}
+      let(:invite) { build(:invitation, invitee_email: "foo@example.com") }
+
       it "succeeds and 'sent_at' is set" do
         expect(invite.save).to be_truthy
-        expect(invite.id).to_not be_nil
+        expect(invite.id).not_to be_nil
 
         # Reload invite to make sure that change to invite.sent_at is actually persisted
         # on the database (not just on the 'invite' object currently being created).
         reloaded_invite = Invitation.find_by(id: invite.id)
-        expect(reloaded_invite).to_not be_nil
+        expect(reloaded_invite).not_to be_nil
         expect(reloaded_invite.sent_at).not_to be_nil
       end
     end

--- a/spec/models/invitation_spec.rb
+++ b/spec/models/invitation_spec.rb
@@ -78,5 +78,20 @@ describe Invitation, :ready do
         end
       end
     end
+
+    # Regression test for AO3-6094
+    context "Sending an invitation to a valid email" do
+      let(:invite) {build(:invitation, invitee_email: "foo@example.com")}
+      it "succeeds and 'sent_at' is set" do
+        expect(invite.save).to be_truthy
+        expect(invite.id).to_not be_nil
+
+        # Reload invite to make sure that change to invite.sent_at is actually persisted
+        # on the database (not just on the 'invite' object currently being created).
+        reloaded_invite = Invitation.find_by(id: invite.id)
+        expect(reloaded_invite).to_not be_nil
+        expect(reloaded_invite.sent_at).not_to be_nil
+      end
+    end
   end
 end

--- a/spec/models/invitation_spec.rb
+++ b/spec/models/invitation_spec.rb
@@ -79,7 +79,6 @@ describe Invitation, :ready do
       end
     end
 
-    # Regression test for AO3-6094
     context "Sending an invitation to a valid email" do
       let(:invite) { build(:invitation, invitee_email: "foo@example.com") }
 
@@ -87,11 +86,8 @@ describe Invitation, :ready do
         expect(invite.save).to be_truthy
         expect(invite.id).not_to be_nil
 
-        # Reload invite to make sure that change to invite.sent_at is actually persisted
-        # on the database (not just on the 'invite' object currently being created).
-        reloaded_invite = Invitation.find_by(id: invite.id)
-        expect(reloaded_invite).not_to be_nil
-        expect(reloaded_invite.sent_at).not_to be_nil
+        invite.reload
+        expect(invite.sent_at).not_to be_nil
       end
     end
   end

--- a/spec/models/invitation_spec.rb
+++ b/spec/models/invitation_spec.rb
@@ -84,10 +84,7 @@ describe Invitation, :ready do
 
       it "succeeds and 'sent_at' is set" do
         expect(invite.save).to be_truthy
-        expect(invite.id).not_to be_nil
-
-        invite.reload
-        expect(invite.sent_at).not_to be_nil
+        expect(invite.reload.sent_at).not_to be_nil
       end
     end
   end


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [x] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [x] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [x] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue
https://otwarchive.atlassian.net/browse/AO3-6094 

## Purpose
This persists the change to invitation.sent_at during send_and_set_date to the database. (Previously, it only occurred on the record in memory)

## Testing Instructions
See JIRA ticket. After this fix, inspecting the sent invitation on e.g. /users/{username}/invitations/{sent_invitation_id} should both have a "Created at" timestamp (as before) and a "Sent at" timestamp listed (new).

## References
AFAICT, originally introduced during https://github.com/otwcode/otwarchive/commit/c328cdd980a5ce985367a9b7ef52e8e2ded2ecd8, which fixed https://code.google.com/archive/p/otwarchive/issues/3115 .
