### PR TITLE
AO3-5988 Add task to replace all noncanonical ratings 

### DIFF
--- a/lib/tasks/after_tasks.rake
+++ b/lib/tasks/after_tasks.rake
@@ -798,10 +798,10 @@ namespace :After do
     noncanonical_ratings = Rating.where(canonical: false)
     puts "There are #{noncanonical_ratings.size} noncanonical rating tags."
 
-    unless noncanonical_ratings.empty?
-      puts "The following noncanonical Ratings will be changed into Additional Tags:"
-      puts noncanonical_ratings.map(&:name).join("\n")
-    end
+    exit if noncanonical_ratings.empty?
+
+    puts "The following noncanonical Ratings will be changed into Additional Tags:"
+    puts noncanonical_ratings.map(&:name).join("\n")
 
     work_ids = []
     invalid_work_ids = []

--- a/lib/tasks/after_tasks.rake
+++ b/lib/tasks/after_tasks.rake
@@ -798,7 +798,7 @@ namespace :After do
     noncanonical_ratings = Rating.where(canonical: false)
     puts "There are #{noncanonical_ratings.size} noncanonical rating tags."
 
-    exit if noncanonical_ratings.empty?
+    next if noncanonical_ratings.empty?
 
     puts "The following noncanonical Ratings will be changed into Additional Tags:"
     puts noncanonical_ratings.map(&:name).join("\n")

--- a/lib/tasks/after_tasks.rake
+++ b/lib/tasks/after_tasks.rake
@@ -768,17 +768,17 @@ namespace :After do
     end
     puts(report_string) && STDOUT.flush
   end
-  
+
   desc "Fix works imported with a noncanonical Teen & Up Audiences rating tag"
   task(fix_teen_and_up_imported_rating: :environment) do
     borked_rating_tag = Rating.find_by!(name: "Teen & Up Audiences")
     canonical_rating_tag = Rating.find_by!(name: ArchiveConfig.RATING_TEEN_TAG_NAME)
     works_using_tag = borked_rating_tag.works
     invalid_works = []
-    works_using_tag.each do |work|
+    works_using_tag.find_each do |work|
       work.ratings << canonical_rating_tag
       work.ratings = work.ratings - [borked_rating_tag]
-      invalid_works << work.id if work.save == false
+      invalid_works << work.id unless work.save
       print(".") && STDOUT.flush
     end
 
@@ -788,7 +788,7 @@ namespace :After do
       STDOUT.flush
     end
 
-    puts "Converted #{borked_rating_tag.name} rating tag on #{works_using_tag.size - invalid_works.size} works"
+    puts "Converted '#{borked_rating_tag.name}' rating tag on #{works_using_tag.size - invalid_works.size} works"
     STDOUT.flush
   end
 
@@ -804,38 +804,41 @@ namespace :After do
     end
 
     work_ids = []
-    invalid_works = []
-    noncanonical_ratings.each do |tag|
+    invalid_work_ids = []
+    noncanonical_ratings.find_each do |tag|
       works_using_tag = tag.works
       tag.update_attribute(:type, "Freeform")
 
-      works_using_tag.each do |work|
+      works_using_tag.find_each do |work|
         next unless work.ratings.empty?
 
-        work_ids << work.id
         work.ratings = [canonical_not_rated_tag]
-        invalid_works << work.id if work.save == false
+        if work.save
+          work_ids << work.id
+        else
+          invalid_work_ids << work.id
+        end
       end
     end
 
     unless work_ids.empty?
-      puts "The following works were left without a rating and received the Not Rated rating:"
+      puts "The following works were left without a rating and successfully received the Not Rated rating:"
       puts work_ids.join(", ")
       STDOUT.flush
     end
 
-    unless invalid_works.empty?
+    unless invalid_work_ids.empty?
       puts "The following works failed validations and could not be saved:"
-      puts invalid_works.join(", ")
+      puts invalid_work_ids.join(", ")
       STDOUT.flush
     end
   end
 
   desc "Clean up noncanonical category tags"
   task(clean_up_noncanonical_categories: :environment) do
-    Category.where(canonical: false).each do |tag|
+    Category.where(canonical: false).find_each do |tag|
       tag.update_attribute(:type, "Freeform")
-      puts "Noncanonical Category tag #{tag.name} was changed into an Additional Tag."
+      puts "Noncanonical Category tag '#{tag.name}' was changed into an Additional Tag."
     end
     STDOUT.flush
   end
@@ -845,12 +848,11 @@ namespace :After do
     work_count = Work.count
     total_batches = (work_count + 999) / 1000
     puts("Checking #{work_count} works in #{total_batches} batches") && STDOUT.flush
-    batch_number = 0
     updated_works = []
 
-    Work.in_batches do |batch|
-      batch_number += 1
-      
+    Work.find_in_batches.with_index do |batch, index|
+      batch_number = index + 1
+
       batch.each do |work|
         next unless work.ratings.empty?
 

--- a/spec/lib/tasks/after_tasks.rake_spec.rb
+++ b/spec/lib/tasks/after_tasks.rake_spec.rb
@@ -172,7 +172,7 @@ describe "rake After:add_default_rating_to_works" do
 
   context "for a rated work" do
     let!(:work) { create(:work, rating_string: ArchiveConfig.RATING_EXPLICIT_TAG_NAME) }
-  
+
     it "does not modify works which already have a rating" do
       subject.invoke
       work.reload
@@ -180,9 +180,9 @@ describe "rake After:add_default_rating_to_works" do
     end
   end
 end
-  
+
 describe "rake After:fix_teen_and_up_imported_rating" do
-  let!(:noncanonical_teen_rating) do 
+  let!(:noncanonical_teen_rating) do
     tag = Rating.create(name: "Teen & Up Audiences")
     tag.canonical = false
     tag.save!(validate: false)
@@ -201,18 +201,15 @@ describe "rake After:fix_teen_and_up_imported_rating" do
 end
 
 describe "rake After:clean_up_noncanonical_ratings" do
-  let(:noncanonical_rating) { Rating.create(name: "Borked rating tag", canonical: false) }
-  let(:canonical_teen_rating) { Rating.create(name: ArchiveConfig.RATING_TEEN_TAG_NAME, canonical: true) }
-  let!(:default_rating) { Rating.create(name: ArchiveConfig.RATING_DEFAULT_TAG_NAME, canonical: true) }
-  let(:work_with_noncanonical_rating) { create(:work) }
-  let(:work_with_canonical_and_noncanonical_ratings) { create(:work) }
-
-  before do
-    work_with_noncanonical_rating.ratings = [noncanonical_rating]
-    work_with_noncanonical_rating.save!
-    work_with_canonical_and_noncanonical_ratings.ratings = [noncanonical_rating, canonical_teen_rating]
-    work_with_canonical_and_noncanonical_ratings.save!
+  let!(:noncanonical_rating) do
+    tag = Rating.create(name: "Borked rating tag", canonical: false)
+    tag.save!(validate: false)
+    tag
   end
+  let!(:canonical_teen_rating) { Rating.find_or_create_by!(name: ArchiveConfig.RATING_TEEN_TAG_NAME, canonical: true) }
+  let!(:default_rating) { Rating.find_or_create_by!(name: ArchiveConfig.RATING_DEFAULT_TAG_NAME, canonical: true) }
+  let!(:work_with_noncanonical_rating) { create(:work, rating_string: noncanonical_rating.name) }
+  let!(:work_with_canonical_and_noncanonical_ratings) { create(:work, rating_string: [noncanonical_rating.name, canonical_teen_rating.name]) }
 
   it "changes and replaces the noncanonical rating tags" do
     subject.invoke
@@ -223,14 +220,14 @@ describe "rake After:clean_up_noncanonical_ratings" do
     # Changes the noncanonical ratings into freeforms
     noncanonical_rating = Tag.find_by(name: "Borked rating tag")
     expect(noncanonical_rating).to be_a(Freeform)
-    expect(work_with_noncanonical_rating.freeforms.to_a).to include(noncanonical_rating)
-    expect(work_with_canonical_and_noncanonical_ratings.freeforms.to_a).to include(noncanonical_rating)
+    expect(work_with_noncanonical_rating.freeforms.to_a).to contain_exactly(noncanonical_rating)
+    expect(work_with_canonical_and_noncanonical_ratings.freeforms.to_a).to contain_exactly(noncanonical_rating)
 
     # Adds the default rating to works left without any other rating
-    expect(work_with_noncanonical_rating.rating_string).to eq(default_rating.name)
+    expect(work_with_noncanonical_rating.ratings.to_a).to contain_exactly(default_rating)
 
     # Doesn't add the default rating to works that have other ratings
-    expect(work_with_canonical_and_noncanonical_ratings.ratings.to_a).to eql([canonical_teen_rating])
+    expect(work_with_canonical_and_noncanonical_ratings.ratings.to_a).to contain_exactly(canonical_teen_rating)
   end
 end
 
@@ -242,7 +239,7 @@ describe "rake After:clean_up_noncanonical_categories" do
     tag.save!(validate: false)
     return tag
   end
-  let!(:work_with_noncanonical_categ) do 
+  let!(:work_with_noncanonical_categ) do
     work = create(:work)
     work.categories = [noncanonical_category_tag]
     work.save!(validate: false)

--- a/spec/lib/tasks/after_tasks.rake_spec.rb
+++ b/spec/lib/tasks/after_tasks.rake_spec.rb
@@ -200,6 +200,40 @@ describe "rake After:fix_teen_and_up_imported_rating" do
   end
 end
 
+describe "rake After:clean_up_noncanonical_ratings" do
+  let(:noncanonical_rating) { Rating.create(name: "Borked rating tag", canonical: false) }
+  let(:canonical_teen_rating) { Rating.create(name: ArchiveConfig.RATING_TEEN_TAG_NAME, canonical: true) }
+  let!(:default_rating) { Rating.create(name: ArchiveConfig.RATING_DEFAULT_TAG_NAME, canonical: true) }
+  let(:work_with_noncanonical_rating) { create(:work) }
+  let(:work_with_canonical_and_noncanonical_ratings) { create(:work) }
+
+  before do
+    work_with_noncanonical_rating.ratings = [noncanonical_rating]
+    work_with_noncanonical_rating.save!
+    work_with_canonical_and_noncanonical_ratings.ratings = [noncanonical_rating, canonical_teen_rating]
+    work_with_canonical_and_noncanonical_ratings.save!
+  end
+
+  it "changes and replaces the noncanonical rating tags" do
+    subject.invoke
+
+    work_with_noncanonical_rating.reload
+    work_with_canonical_and_noncanonical_ratings.reload
+
+    # Changes the noncanonical ratings into freeforms
+    noncanonical_rating = Tag.find_by(name: "Borked rating tag")
+    expect(noncanonical_rating).to be_a(Freeform)
+    expect(work_with_noncanonical_rating.freeforms.to_a).to include(noncanonical_rating)
+    expect(work_with_canonical_and_noncanonical_ratings.freeforms.to_a).to include(noncanonical_rating)
+
+    # Adds the default rating to works left without any other rating
+    expect(work_with_noncanonical_rating.rating_string).to eq(default_rating.name)
+
+    # Doesn't add the default rating to works that have other ratings
+    expect(work_with_canonical_and_noncanonical_ratings.ratings.to_a).to eql([canonical_teen_rating])
+  end
+end
+
 describe "rake After:clean_up_noncanonical_categories" do
   let!(:canonical_category_tag) { Category.find_or_create_by(name: ArchiveConfig.CATEGORY_GEN_TAG_NAME, canonical: true) }
   let!(:noncanonical_category_tag) do


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5988

## Purpose

Originally we were adding a task to fix just "Teen & Up Audiences", the only non-canonical rating on production. But [there are other non-canonical ratings on staging, so we still need a more generic task](https://github.com/otwcode/otwarchive/pull/4022#discussion_r656790379). 

## Testing Instructions

See issue.

## Credit

@CristinaRO and @tlee911; the task was added in #4022 but removed during review.