### PR TITLE
AO3-3828 Link to prompt in the notes of a prompt fill

### DIFF
--- a/app/controllers/prompts_controller.rb
+++ b/app/controllers/prompts_controller.rb
@@ -1,6 +1,6 @@
 class PromptsController < ApplicationController
 
-  before_action :users_only
+  before_action :users_only, except: [:show]
   before_action :load_collection, except: [:index]
   before_action :load_challenge, except: [:index]
   before_action :load_prompt_from_id, only: [:show, :edit, :update, :destroy]

--- a/app/views/works/_work_header_notes.html.erb
+++ b/app/views/works/_work_header_notes.html.erb
@@ -50,7 +50,7 @@
     <% # prompts %>
     <% @work.challenge_claims.each do |claim| %>
       <% unless claim.request_prompt.nil? %>
-        <li><%= ts("In response to a prompt by") %>
+        <li><%= ts("In response to a ") %><%= link_to("prompt", collection_prompt_path(claim.collection, claim.request_prompt)) %><%= ts(" by") %>
           <% if claim.request_prompt.anonymous? %>
             <%= ts("Anonymous in the ") %><%= link_to(claim.collection.name, collection_path(claim.collection)) %>
           <% else %>

--- a/app/views/works/_work_header_notes.html.erb
+++ b/app/views/works/_work_header_notes.html.erb
@@ -50,7 +50,7 @@
     <% # prompts %>
     <% @work.challenge_claims.each do |claim| %>
       <% unless claim.request_prompt.nil? %>
-        <li><%= ts("In response to a ") %><%= link_to("prompt", collection_prompt_path(claim.collection, claim.request_prompt)) %><%= ts(" by") %>
+        <li><%= ts("In response to a ") %><%= link_to("prompt", collection_prompt_path(claim.collection, claim.request_prompt)) %> <%= ts("by") %>
           <% if claim.request_prompt.anonymous? %>
             <%= ts("Anonymous in the ") %><%= link_to(claim.collection.name, collection_path(claim.collection)) %>
           <% else %>

--- a/features/prompt_memes_b/challenge_promptmeme_posting_fills.feature
+++ b/features/prompt_memes_b/challenge_promptmeme_posting_fills.feature
@@ -461,39 +461,39 @@ Feature: Prompt Meme Challenge
     And I should see "Anonymous" within ".byline"
     And I should see a link "prompt"
 
-  Scenario: Fic links to the prompt it fulfils, for all users
+  Scenario: Work links to the prompt it fulfils, for all users
 
   Given I have Battle 12 prompt meme fully set up
-  When I am logged in as "myname1"
-  When I sign up for Battle 12 with combination B
+    And I am logged in as "myname1"
+    And I sign up for Battle 12 with combination B
     And I am logged in as "myname4"
     And I claim a prompt from "Battle 12"
-  When I fulfill my claim
-  When I reveal works for "Battle 12"
-  When I view the work "Fulfilled Story"
+    And I fulfill my claim
+    And I reveal works for "Battle 12"
+    And I view the work "Fulfilled Story"
   Then I should see "Fulfilled Story"
     And I should see "In response to a prompt by Anonymous"
     And I should see a link "prompt"
-    And I follow "prompt"
-    And I should see "Request by Anonymous"
+  When I follow "prompt"
+  Then I should see "Request by Anonymous"
   When I am logged in as "myname2"
     And I view the work "Fulfilled Story"
   Then I should see "Fulfilled Story"
     And I should see "In response to a prompt by Anonymous"
     And I should see a link "prompt"
-    And I follow "prompt"
-    And I should see "Request by Anonymous"
+  When I follow "prompt"
+  Then I should see "Request by Anonymous"
   When I am logged in as "mod"
     And I view the work "Fulfilled Story"
   Then I should see "Fulfilled Story"
     And I should see "In response to a prompt by Anonymous"
     And I should see a link "prompt"
-    And I follow "prompt"
-    And I should see "Request by Anonymous"
+  When I follow "prompt"
+  Then I should see "Request by Anonymous"
   When I log out
     And I view the work "Fulfilled Story"
   Then I should see "Fulfilled Story"
     And I should see "In response to a prompt by Anonymous"
     And I should see a link "prompt"
-    And I follow "prompt"
-    And I should see "Request by Anonymous"
+  When I follow "prompt"
+  Then I should see "Request by Anonymous"

--- a/features/prompt_memes_b/challenge_promptmeme_posting_fills.feature
+++ b/features/prompt_memes_b/challenge_promptmeme_posting_fills.feature
@@ -42,6 +42,7 @@ Feature: Prompt Meme Challenge
   Then I should see "Kinky Story"
     And I should find a list for associations
     And I should see "In response to a prompt by Anonymous in the promptcollection collection"
+    And I should see a link "prompt"
     And 1 email should be delivered to "my1@e.org"
 # TODO: when work_anonymous is implemented, test that the prompt filler can be anon too
 
@@ -458,3 +459,4 @@ Feature: Prompt Meme Challenge
   Then I should see "In response to a prompt by myname4"
     And I should see "Fandom: Stargate Atlantis"
     And I should see "Anonymous" within ".byline"
+    And I should see a link "prompt"

--- a/features/prompt_memes_b/challenge_promptmeme_posting_fills.feature
+++ b/features/prompt_memes_b/challenge_promptmeme_posting_fills.feature
@@ -460,3 +460,40 @@ Feature: Prompt Meme Challenge
     And I should see "Fandom: Stargate Atlantis"
     And I should see "Anonymous" within ".byline"
     And I should see a link "prompt"
+
+  Scenario: Fic links to the prompt it fulfils, for all users
+
+  Given I have Battle 12 prompt meme fully set up
+  When I am logged in as "myname1"
+  When I sign up for Battle 12 with combination B
+    And I am logged in as "myname4"
+    And I claim a prompt from "Battle 12"
+  When I fulfill my claim
+  When I reveal works for "Battle 12"
+  When I view the work "Fulfilled Story"
+  Then I should see "Fulfilled Story"
+    And I should see "In response to a prompt by Anonymous"
+    And I should see a link "prompt"
+    And I follow "prompt"
+    And I should see "Request by Anonymous"
+  When I am logged in as "myname2"
+    And I view the work "Fulfilled Story"
+  Then I should see "Fulfilled Story"
+    And I should see "In response to a prompt by Anonymous"
+    And I should see a link "prompt"
+    And I follow "prompt"
+    And I should see "Request by Anonymous"
+  When I am logged in as "mod"
+    And I view the work "Fulfilled Story"
+  Then I should see "Fulfilled Story"
+    And I should see "In response to a prompt by Anonymous"
+    And I should see a link "prompt"
+    And I follow "prompt"
+    And I should see "Request by Anonymous"
+  When I log out
+    And I view the work "Fulfilled Story"
+  Then I should see "Fulfilled Story"
+    And I should see "In response to a prompt by Anonymous"
+    And I should see a link "prompt"
+    And I follow "prompt"
+    And I should see "Request by Anonymous"


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [x] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [x] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [x] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-3828

## Purpose

When a work has been submitted to fulfill a prompt in a Prompt Meme collection, an automatically-inserted text in the work notes says so. This PR adds a link to the specific prompt to that text.

## Testing Instructions

1. Post a work that fulfills a prompt
2. Look at the automatically-inserted text in the work notes
3. Note that it says: "In response to a prompt by CREATOR in the COLLECTION_NAME collection."
4. Note that the word "prompt" is a link to the prompt in question.

## Credit

What name and pronouns should we use to credit you in the [Archive of Our Own's Release Notes](https://archiveofourown.org/admin_posts?tag=1)?

katzenfabrik, they/them
