### PR TITLE
AO3-6205 Add user ID to admin user page

### DIFF
--- a/app/views/admin/admin_users/show.html.erb
+++ b/app/views/admin/admin_users/show.html.erb
@@ -1,6 +1,6 @@
 <div class="admin">
   <!--Descriptive page name, messages and instructions-->
-  <h2 class="heading"><%= ts("User") %>: <%= @user.login %></h2>
+  <h2 class="heading"><%= ts("User") %>: <%= @user.login %> (<%= @user.id %>)</h2>
   <!--/descriptions-->
 
   <!--subnav-->


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [ ] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [x] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [x] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-6205

## Purpose

Allow admins viewing the admin user page to see the given user's ID.

## Testing Instructions

1. Log in as a superadmin, support, or policy_and_abuse admin
2. Visit the /admin/users/USERNAME page for some user named USERNAME
3. The page's heading should read "User: USERNAME (USER_ID)" with the correct USERNAME and USER_ID

## Credit

What name and pronouns should we use to credit you in the [Archive of Our Own's Release Notes](https://archiveofourown.org/admin_posts?tag=1)?

NightGlyde (she/her)
