### PR TITLE
AO3-6206 Update text of email that is sent when an admin hides a work

### DIFF
--- a/app/helpers/mailer_helper.rb
+++ b/app/helpers/mailer_helper.rb
@@ -46,6 +46,10 @@ module MailerHelper
     style_link(text, root_url + "abuse_reports/new")
   end
 
+  def tos_link(text)
+      style_link(text, root_url + "tos")
+    end
+
   def opendoors_link(text)
     style_link(text, "http://opendoors.transformativeworks.org/contact-open-doors/")
   end

--- a/app/helpers/mailer_helper.rb
+++ b/app/helpers/mailer_helper.rb
@@ -47,7 +47,7 @@ module MailerHelper
   end
 
   def tos_link(text)
-    style_link(text, root_url + "tos")
+    style_link(text, tos_url)
   end
 
   def opendoors_link(text)

--- a/app/helpers/mailer_helper.rb
+++ b/app/helpers/mailer_helper.rb
@@ -47,8 +47,8 @@ module MailerHelper
   end
 
   def tos_link(text)
-      style_link(text, root_url + "tos")
-    end
+    style_link(text, root_url + "tos")
+  end
 
   def opendoors_link(text)
     style_link(text, "http://opendoors.transformativeworks.org/contact-open-doors/")

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -408,7 +408,7 @@ class UserMailer < ActionMailer::Base
 
     mail(
         to: @user.email,
-        subject: t("user_mailer.admin_hidden_work_notification.subject", app_name: ArchiveConfig.APP_SHORT_NAME)
+        subject: default_i18n_subject(app_name: ArchiveConfig.APP_SHORT_NAME)
     )
   end
 

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -408,7 +408,7 @@ class UserMailer < ActionMailer::Base
 
     mail(
         to: @user.email,
-        subject: "[#{ArchiveConfig.APP_SHORT_NAME}] Your work has been hidden by the Abuse Team"
+        subject: t('user_mailer.admin_hidden_work_notification.subject', app_name: ArchiveConfig.APP_SHORT_NAME)
     )
   end
 

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -408,7 +408,7 @@ class UserMailer < ActionMailer::Base
 
     mail(
         to: @user.email,
-        subject: t('user_mailer.admin_hidden_work_notification.subject', app_name: ArchiveConfig.APP_SHORT_NAME)
+        subject: t("user_mailer.admin_hidden_work_notification.subject", app_name: ArchiveConfig.APP_SHORT_NAME)
     )
   end
 

--- a/app/views/user_mailer/admin_hidden_work_notification.html.erb
+++ b/app/views/user_mailer/admin_hidden_work_notification.html.erb
@@ -1,7 +1,7 @@
 <% content_for :message do %>
-  <p><%= t '.hello', user: @user.default_pseud.byline %></p>
+  <p><%= t(".hello", name: style_bold(@user.login)).html_safe %></p>
 
-  <p><%= t('.html.part1', title: "<i>#{style_bold(@work.title.html_safe)}</i>".html_safe).html_safe %></p>
+  <p><%= t(".html.part1", title: style_creation_link(@work.title)).html_safe %></p>
 
   <p><%= t '.html.part2' %></p>
 
@@ -12,5 +12,6 @@
   <p><%= t('.html.part5', abuse_link: abuse_link(t '.abuse_committee')).html_safe %></p>
 
   <p><%= t '.sincerely' %></p>
+
   <p><%= t '.sender' %></p>
 <% end %>

--- a/app/views/user_mailer/admin_hidden_work_notification.html.erb
+++ b/app/views/user_mailer/admin_hidden_work_notification.html.erb
@@ -5,7 +5,7 @@
 
   <p><%= t ".access" %></p>
 
-  <p><%= t ".check_mail" %></p>
+  <p><%= t ".check_email" %></p>
 
   <p><%= t(".html.tos_violation", tos_link: tos_link(t ".tos")).html_safe %></p>
 

--- a/app/views/user_mailer/admin_hidden_work_notification.html.erb
+++ b/app/views/user_mailer/admin_hidden_work_notification.html.erb
@@ -13,5 +13,5 @@
 
   <p><%= t '.sincerely' %></p>
 
-  <p><%= t '.sender' %></p>
+  <p><%= style_bold(t '.sender') %></p>
 <% end %>

--- a/app/views/user_mailer/admin_hidden_work_notification.html.erb
+++ b/app/views/user_mailer/admin_hidden_work_notification.html.erb
@@ -1,12 +1,16 @@
 <% content_for :message do %>
-    <p>Dear <%= @user.default_pseud.byline %>,</p>
+  <p><%= t '.hello', user: @user.default_pseud.byline %></p>
 
-    <p>Your work <i><%= style_link(@work.title.html_safe, work_url(@work)) %></i> has been reported as being in violation of the Archive of Our Own's <%= style_link("Terms of Service", tos_url) %>.</p>
+  <p><%= t('.html.part1', title: "<i>#{style_bold(@work.title.html_safe)}</i>".html_safe).html_safe %></p>
 
-    <p>We are investigating the matter and will contact you once the investigation has been completed. While the work is under investigation it has been hidden; only you will be able to access it.</p>
+  <p><%= t '.html.part2' %></p>
 
-    <p>If you have any questions, please <%= abuse_link("contact our Abuse Team") %>.</p>
+  <p><%= t '.html.part3' %></p>
 
-    <p>Sincerely,</p>
-    <p><%= style_bold("AO3 Abuse") %></p>
+  <p><%= t('.html.part4', tos_link: tos_link(t '.tos')).html_safe %></p>
+
+  <p><%= t('.html.part5', abuse_link: abuse_link(t '.abuse_committee')).html_safe %></p>
+
+  <p><%= t '.sincerely' %></p>
+  <p><%= t '.sender' %></p>
 <% end %>

--- a/app/views/user_mailer/admin_hidden_work_notification.html.erb
+++ b/app/views/user_mailer/admin_hidden_work_notification.html.erb
@@ -1,17 +1,13 @@
 <% content_for :message do %>
   <p><%= t(".hello", name: style_bold(@user.login)).html_safe %></p>
 
-  <p><%= t(".html.part1", title: style_creation_link(@work.title, @work)).html_safe %></p>
+  <p><%= t(".html.hidden", title: style_creation_link(@work.title, @work)).html_safe %></p>
 
-  <p><%= t '.html.part2' %></p>
+  <p><%= t '.access' %></p>
 
-  <p><%= t '.html.part3' %></p>
+  <p><%= t '.check_mail' %></p>
 
-  <p><%= t('.html.part4', tos_link: tos_link(t '.tos')).html_safe %></p>
+  <p><%= t('.html.tos_violation', tos_link: tos_link(t '.tos')).html_safe %></p>
 
-  <p><%= t('.html.part5', abuse_link: abuse_link(t '.abuse_committee')).html_safe %></p>
-
-  <p><%= t '.sincerely' %></p>
-
-  <p><%= style_bold(t '.sender') %></p>
+  <p><%= t('.html.help', contact_abuse_link: abuse_link(t '.abuse_committee')).html_safe %></p>
 <% end %>

--- a/app/views/user_mailer/admin_hidden_work_notification.html.erb
+++ b/app/views/user_mailer/admin_hidden_work_notification.html.erb
@@ -3,11 +3,11 @@
 
   <p><%= t(".html.hidden", title: style_creation_link(@work.title, @work)).html_safe %></p>
 
-  <p><%= t '.access' %></p>
+  <p><%= t ".access" %></p>
 
-  <p><%= t '.check_mail' %></p>
+  <p><%= t ".check_mail" %></p>
 
-  <p><%= t('.html.tos_violation', tos_link: tos_link(t '.tos')).html_safe %></p>
+  <p><%= t(".html.tos_violation", tos_link: tos_link(t ".tos")).html_safe %></p>
 
-  <p><%= t('.html.help', contact_abuse_link: abuse_link(t '.abuse_committee')).html_safe %></p>
+  <p><%= t(".html.help", contact_abuse_link: abuse_link(t ".contact_abuse")).html_safe %></p>
 <% end %>

--- a/app/views/user_mailer/admin_hidden_work_notification.html.erb
+++ b/app/views/user_mailer/admin_hidden_work_notification.html.erb
@@ -1,7 +1,7 @@
 <% content_for :message do %>
   <p><%= t(".hello", name: style_bold(@user.login)).html_safe %></p>
 
-  <p><%= t(".html.part1", title: style_creation_link(@work.title, @work_url)).html_safe %></p>
+  <p><%= t(".html.part1", title: style_creation_link(@work.title, @work)).html_safe %></p>
 
   <p><%= t '.html.part2' %></p>
 

--- a/app/views/user_mailer/admin_hidden_work_notification.html.erb
+++ b/app/views/user_mailer/admin_hidden_work_notification.html.erb
@@ -1,7 +1,7 @@
 <% content_for :message do %>
   <p><%= t(".hello", name: style_bold(@user.login)).html_safe %></p>
 
-  <p><%= t(".html.part1", title: style_creation_link(@work.title)).html_safe %></p>
+  <p><%= t(".html.part1", title: style_creation_link(@work.title, @work_url)).html_safe %></p>
 
   <p><%= t '.html.part2' %></p>
 

--- a/app/views/user_mailer/admin_hidden_work_notification.text.erb
+++ b/app/views/user_mailer/admin_hidden_work_notification.text.erb
@@ -1,12 +1,17 @@
 <% content_for :message do %>
-    Dear <%= @user.default_pseud.byline %>,
+<%= t '.hello', user: @user.default_pseud.byline %>
 
-    Your work "<%= @work.title.html_safe %>" (<%= work_url(@work) %>) has been reported to the Abuse Team as a violation of the Archive of Our Own's Terms of Service (<%= root_url + "tos" %>).
+<%= t('.text.part1', title: @work.title) %>
 
-    We are investigating the matter and will contact you once the investigation has been completed. While the work is under investigation it has been hidden; only you will be able to access it.
+<%= t '.text.part2' %>
 
-    If you have any questions, please contact our Abuse Team (<%= root_url + "abuse_reports/new" %>).
+<%= t '.text.part3' %>
 
-    Sincerely,
-    AO3 Abuse
+<%= t('.text.part4', tos_link: 'http://archiveofourown.org/tos') %>
+
+<%= t('.text.part5', abuse_link: 'http://archiveofourown.org/abuse_reports/new') %>
+
+<%= t '.sincerely' %>
+
+<%= t '.sender' %>
 <% end %>   

--- a/app/views/user_mailer/admin_hidden_work_notification.text.erb
+++ b/app/views/user_mailer/admin_hidden_work_notification.text.erb
@@ -1,13 +1,13 @@
 <% content_for :message do %>
 <%= t(".hello", name: @user.login) %>
 
-<%= t('.text.hidden', title: @work.title, work_url: @work) %>
+<%= t(".text.hidden", title: @work.title, work_url: @work) %>
 
-<%= t '.access' %>
+<%= t ".access" %>
 
-<%= t '.check_mail' %>
+<%= t ".check_mail" %>
 
-<%= t('.text.tos_violation', tos_url: tos_url) %>
+<%= t(".text.tos_violation", tos_url: tos_url) %>
 
-<%= t('.text.help', contact_abuse_url: new_abuse_report_url) %>
+<%= t(".text.help", contact_abuse_url: new_abuse_report_url) %>
 <% end %>

--- a/app/views/user_mailer/admin_hidden_work_notification.text.erb
+++ b/app/views/user_mailer/admin_hidden_work_notification.text.erb
@@ -1,7 +1,7 @@
 <% content_for :message do %>
 <%= t(".hello", name: @user.login) %>
 
-<%= t('.text.part1', title: @work.title, work_url: @work_url) %>
+<%= t('.text.part1', title: @work.title, work_url: @work) %>
 
 <%= t '.text.part2' %>
 

--- a/app/views/user_mailer/admin_hidden_work_notification.text.erb
+++ b/app/views/user_mailer/admin_hidden_work_notification.text.erb
@@ -1,5 +1,5 @@
 <% content_for :message do %>
-<%= t '.hello', user: @user.default_pseud.byline %>
+<%= t(".hello", name: @user.login) %>
 
 <%= t('.text.part1', title: @work.title) %>
 

--- a/app/views/user_mailer/admin_hidden_work_notification.text.erb
+++ b/app/views/user_mailer/admin_hidden_work_notification.text.erb
@@ -5,7 +5,7 @@
 
 <%= t ".access" %>
 
-<%= t ".check_mail" %>
+<%= t ".check_email" %>
 
 <%= t(".text.tos_violation", tos_url: tos_url) %>
 

--- a/app/views/user_mailer/admin_hidden_work_notification.text.erb
+++ b/app/views/user_mailer/admin_hidden_work_notification.text.erb
@@ -1,17 +1,13 @@
 <% content_for :message do %>
 <%= t(".hello", name: @user.login) %>
 
-<%= t('.text.part1', title: @work.title, work_url: @work) %>
+<%= t('.text.hidden', title: @work.title, work_url: @work) %>
 
-<%= t '.text.part2' %>
+<%= t '.access' %>
 
-<%= t '.text.part3' %>
+<%= t '.check_mail' %>
 
-<%= t('.text.part4', tos_link: 'http://archiveofourown.org/tos') %>
+<%= t('.text.tos_violation', tos_url: tos_url) %>
 
-<%= t('.text.part5', abuse_link: 'http://archiveofourown.org/abuse_reports/new') %>
-
-<%= t '.sincerely' %>
-
-<%= t '.sender' %>
-<% end %>   
+<%= t('.text.help', contact_abuse_url: new_abuse_report_url) %>
+<% end %>

--- a/app/views/user_mailer/admin_hidden_work_notification.text.erb
+++ b/app/views/user_mailer/admin_hidden_work_notification.text.erb
@@ -1,7 +1,7 @@
 <% content_for :message do %>
 <%= t(".hello", name: @user.login) %>
 
-<%= t('.text.part1', title: @work.title) %>
+<%= t('.text.part1', title: @work.title, work_url: @work_url) %>
 
 <%= t '.text.part2' %>
 

--- a/config/locales/mailers/en.yml
+++ b/config/locales/mailers/en.yml
@@ -64,11 +64,11 @@ en:
         part4: "If your work was hidden due to being in violation of the Archive of Our Own's %{tos_link}, you will be required to take action to correct the violation. Failure to bring your work into compliance with the Terms of Service may lead to your work being deleted from the Archive."
         part5: "If you are uncertain why your work was hidden, and you have not received further communication regarding this matter, please %{abuse_link} directly."
       text:
-        part1: "Your work \%{title}\ has been hidden by the Policy & Abuse team and is no longer publicly accessible."
+        part1: "Your work \%{title}\ (%{work_url}) has been hidden by the Policy & Abuse team and is no longer publicly accessible."
         part2: "While your work is hidden, you will still be able to access it through the link provided above, but it will not be listed on your works page, and it won't be available to other users of the Archive."
         part3: "Please check your email, including your spam folder, as the Policy & Abuse team may have already contacted you explaining why your work was hidden."
-        part4: "If your work was hidden due to being in violation of the Archive of Our Own's (%{tos_link}), you will be required to take action to correct the violation. Failure to bring your work into compliance with the Terms of Service may lead to your work being deleted from the Archive."
-        part5: "If you are uncertain why your work was hidden, and you have not received further communication regarding this matter, please contact Policy & Abuse (%{abuse_link}) directly."
+        part4: "If your work was hidden due to being in violation of the Archive of Our Own's Terms of Service (%{tos_link}), you will be required to take action to correct the violation. Failure to bring your work into compliance with the Terms of Service may lead to your work being deleted from the Archive."
+        part5: "If you are uncertain why your work was hidden, and you have not received further communication regarding this matter, please contact Policy & Abuse directly: (%{abuse_link})"
     delete_work_notification:
       subject: "[%{app_name}] Your work has been deleted"
       support: "contact Support"

--- a/config/locales/mailers/en.yml
+++ b/config/locales/mailers/en.yml
@@ -64,7 +64,7 @@ en:
         part4: "If your work was hidden due to being in violation of the Archive of Our Own's %{tos_link}, you will be required to take action to correct the violation. Failure to bring your work into compliance with the Terms of Service may lead to your work being deleted from the Archive."
         part5: "If you are uncertain why your work was hidden, and you have not received further communication regarding this matter, please %{abuse_link} directly."
       text:
-        part1: "Your work \%{title}\ (%{work_url}) has been hidden by the Policy & Abuse team and is no longer publicly accessible."
+        part1: "Your work %{title} (%{work_url}) has been hidden by the Policy & Abuse team and is no longer publicly accessible."
         part2: "While your work is hidden, you will still be able to access it through the link provided above, but it will not be listed on your works page, and it won't be available to other users of the Archive."
         part3: "Please check your email, including your spam folder, as the Policy & Abuse team may have already contacted you explaining why your work was hidden."
         part4: "If your work was hidden due to being in violation of the Archive of Our Own's Terms of Service (%{tos_link}), you will be required to take action to correct the violation. Failure to bring your work into compliance with the Terms of Service may lead to your work being deleted from the Archive."

--- a/config/locales/mailers/en.yml
+++ b/config/locales/mailers/en.yml
@@ -52,7 +52,7 @@ en:
         part3: "If it's possible your work violated the Archive's Terms of Service, please contact our Abuse Committee (%{abuse_link})."
     admin_hidden_work_notification:
       subject: "[%{app_name}] Your work has been hidden by the Abuse Team"
-      hello: "Dear %{user},"
+      hello: "Dear %{name},"
       tos: "Terms of Service"
       abuse_committee: "contact Policy & Abuse"
       sincerely: "Sincerely,"

--- a/config/locales/mailers/en.yml
+++ b/config/locales/mailers/en.yml
@@ -51,14 +51,12 @@ en:
         part2: "If your work was part of an import project managed by our Open Doors team, please contact Open Doors (%{opendoors_link}) with any further questions."
         part3: "If it's possible your work violated the Archive's Terms of Service, please contact our Abuse Committee (%{abuse_link})."
     admin_hidden_work_notification:
-      subject: "[%{app_name}] Your work has been hidden by the Policy & Abuse Team"
+      subject: "[%{app_name}] Your work has been hidden by the Policy & Abuse team"
       hello: "Dear %{name},"
       tos: "Terms of Service"
-      abuse_committee: "contact Policy & Abuse"
+      contact_abuse: "contact Policy & Abuse"
       access: "While your work is hidden, you will still be able to access it through the link provided above, but it will not be listed on your works page, and it won't be available to other users of the Archive."
       check_email: "Please check your email, including your spam folder, as the Policy & Abuse team may have already contacted you explaining why your work was hidden."
-      sincerely: "Sincerely,"
-      sender: "AO3 Abuse"
       html:
         hidden: "Your work %{title} has been hidden by the Policy & Abuse team and is no longer publicly accessible."
         tos_violation: "If your work was hidden due to being in violation of the Archive of Our Own's %{tos_link}, you will be required to take action to correct the violation. Failure to bring your work into compliance with the Terms of Service may lead to your work being deleted from the Archive."

--- a/config/locales/mailers/en.yml
+++ b/config/locales/mailers/en.yml
@@ -50,6 +50,25 @@ en:
         part1: "Your work \"%{title}\" was deleted from the Archive by a site admin."
         part2: "If your work was part of an import project managed by our Open Doors team, please contact Open Doors (%{opendoors_link}) with any further questions."
         part3: "If it's possible your work violated the Archive's Terms of Service, please contact our Abuse Committee (%{abuse_link})."
+    admin_hidden_work_notification:
+      subject: "[%{app_name}] Your work has been hidden by the Abuse Team"
+      hello: "Dear %{user},"
+      tos: "Terms of Service"
+      abuse_committee: "contact Policy & Abuse"
+      sincerely: "Sincerely,"
+      sender: "AO3 Abuse"
+      html:
+        part1: "Your work %{title} has been hidden by the Policy & Abuse team and is no longer publicly accessible."
+        part2: "While your work is hidden, you will still be able to access it through the link provided above, but it will not be listed on your works page, and it won't be available to other users of the Archive."
+        part3: "Please check your email, including your spam folder, as the Policy & Abuse team may have already contacted you explaining why your work was hidden."
+        part4: "If your work was hidden due to being in violation of the Archive of Our Own's %{tos_link}, you will be required to take action to correct the violation. Failure to bring your work into compliance with the Terms of Service may lead to your work being deleted from the Archive."
+        part5: "If you are uncertain why your work was hidden, and you have not received further communication regarding this matter, please %{abuse_link} directly."
+      text:
+        part1: "Your work \%{title}\ has been hidden by the Policy & Abuse team and is no longer publicly accessible."
+        part2: "While your work is hidden, you will still be able to access it through the link provided above, but it will not be listed on your works page, and it won't be available to other users of the Archive."
+        part3: "Please check your email, including your spam folder, as the Policy & Abuse team may have already contacted you explaining why your work was hidden."
+        part4: "If your work was hidden due to being in violation of the Archive of Our Own's (%{tos_link}), you will be required to take action to correct the violation. Failure to bring your work into compliance with the Terms of Service may lead to your work being deleted from the Archive."
+        part5: "If you are uncertain why your work was hidden, and you have not received further communication regarding this matter, please contact Policy & Abuse (%{abuse_link}) directly."
     delete_work_notification:
       subject: "[%{app_name}] Your work has been deleted"
       support: "contact Support"

--- a/config/locales/mailers/en.yml
+++ b/config/locales/mailers/en.yml
@@ -31,7 +31,7 @@ en:
     invite_increase_notification:
       subject: "[%{app_name}] New Invitations"
       greeting: "Hi %{login}!"
-      body: 
+      body:
         one: "We just wanted to let you know that you have %{count} new invitation, which can be used to create a new account at the Archive. You can invite a friend at %{invitation_page}."
         other: "We just wanted to let you know that you have %{count} new invitations, which can be used to create new accounts at the Archive. You can invite a friend at %{invitation_page}."
       invitation_page_link_text: your invitations page
@@ -51,24 +51,22 @@ en:
         part2: "If your work was part of an import project managed by our Open Doors team, please contact Open Doors (%{opendoors_link}) with any further questions."
         part3: "If it's possible your work violated the Archive's Terms of Service, please contact our Abuse Committee (%{abuse_link})."
     admin_hidden_work_notification:
-      subject: "[%{app_name}] Your work has been hidden by the Abuse Team"
+      subject: "[%{app_name}] Your work has been hidden by the Policy & Abuse Team"
       hello: "Dear %{name},"
       tos: "Terms of Service"
       abuse_committee: "contact Policy & Abuse"
+      access: "While your work is hidden, you will still be able to access it through the link provided above, but it will not be listed on your works page, and it won't be available to other users of the Archive."
+      check_email: "Please check your email, including your spam folder, as the Policy & Abuse team may have already contacted you explaining why your work was hidden."
       sincerely: "Sincerely,"
       sender: "AO3 Abuse"
       html:
-        part1: "Your work %{title} has been hidden by the Policy & Abuse team and is no longer publicly accessible."
-        part2: "While your work is hidden, you will still be able to access it through the link provided above, but it will not be listed on your works page, and it won't be available to other users of the Archive."
-        part3: "Please check your email, including your spam folder, as the Policy & Abuse team may have already contacted you explaining why your work was hidden."
-        part4: "If your work was hidden due to being in violation of the Archive of Our Own's %{tos_link}, you will be required to take action to correct the violation. Failure to bring your work into compliance with the Terms of Service may lead to your work being deleted from the Archive."
-        part5: "If you are uncertain why your work was hidden, and you have not received further communication regarding this matter, please %{abuse_link} directly."
+        hidden: "Your work %{title} has been hidden by the Policy & Abuse team and is no longer publicly accessible."
+        tos_violation: "If your work was hidden due to being in violation of the Archive of Our Own's %{tos_link}, you will be required to take action to correct the violation. Failure to bring your work into compliance with the Terms of Service may lead to your work being deleted from the Archive."
+        help: "If you are uncertain why your work was hidden, and you have not received further communication regarding this matter, please %{contact_abuse_link} directly."
       text:
-        part1: "Your work %{title} (%{work_url}) has been hidden by the Policy & Abuse team and is no longer publicly accessible."
-        part2: "While your work is hidden, you will still be able to access it through the link provided above, but it will not be listed on your works page, and it won't be available to other users of the Archive."
-        part3: "Please check your email, including your spam folder, as the Policy & Abuse team may have already contacted you explaining why your work was hidden."
-        part4: "If your work was hidden due to being in violation of the Archive of Our Own's Terms of Service (%{tos_link}), you will be required to take action to correct the violation. Failure to bring your work into compliance with the Terms of Service may lead to your work being deleted from the Archive."
-        part5: "If you are uncertain why your work was hidden, and you have not received further communication regarding this matter, please contact Policy & Abuse directly: (%{abuse_link})"
+        hidden: "Your work %{title} (%{work_url}) has been hidden by the Policy & Abuse team and is no longer publicly accessible."
+        tos_violation: "If your work was hidden due to being in violation of the Archive of Our Own's Terms of Service (%{tos_url}), you will be required to take action to correct the violation. Failure to bring your work into compliance with the Terms of Service may lead to your work being deleted from the Archive."
+        help: "If you are uncertain why your work was hidden, and you have not received further communication regarding this matter, please contact Policy & Abuse directly: %{contact_abuse_url}."
     delete_work_notification:
       subject: "[%{app_name}] Your work has been deleted"
       support: "contact Support"
@@ -136,20 +134,20 @@ en:
         part3: |-
                   There's lots of information and advice on how to use the Archive in our FAQ
                   at %{faq_url}. You'll find the latest news about site developments on AO3 News at
-                  %{admin_posts_url}. If you need more help, run into a bug, or have questions or 
+                  %{admin_posts_url}. If you need more help, run into a bug, or have questions or
                   comments, please contact Support, who are always happy to help out:
                   %{contact_support_url}.
       html:
         part1: "Please %{activate_account_link}."
         part2: |-
-                  Once your account is up and running, you can post your fanworks, set up email 
-                  subscriptions to let you know when your favorite creators or works have updated, 
-                  set preferences to customize the way the site looks and works for you, keep 
+                  Once your account is up and running, you can post your fanworks, set up email
+                  subscriptions to let you know when your favorite creators or works have updated,
+                  set preferences to customize the way the site looks and works for you, keep
                   track of the works you've accessed on the Archive via your history, and much more.
         part3: |-
-                  There's lots of information and advice on how to use the Archive in our %{faq_link}. 
-                  You'll find the latest news about site developments on %{admin_posts_link}. 
-                  If you need more help, run into a bug, or have questions or comments, please 
+                  There's lots of information and advice on how to use the Archive in our %{faq_link}.
+                  You'll find the latest news about site developments on %{admin_posts_link}.
+                  If you need more help, run into a bug, or have questions or comments, please
                   %{contact_support_link}, who are always happy to help out.
     invitation:
       subject: "[%{app_name}] Invitation"

--- a/features/admins/admin_works.feature
+++ b/features/admins/admin_works.feature
@@ -24,7 +24,7 @@ Feature: Admin Actions for Works, Comments, Series, Bookmarks
       And logged in users should not see the hidden work "ToS Violation" by "regular_user"
       And "regular_user" should see their work "ToS Violation" is hidden
       And 1 email should be delivered
-      And the email should contain "you will be required to take action to correct the violation"
+      And the email should contain "Abuse team may have already contacted you explaining why your work was hidden"
 
   Scenario: Can unhide works
     Given I am logged in as "regular_user"

--- a/features/admins/admin_works.feature
+++ b/features/admins/admin_works.feature
@@ -24,7 +24,7 @@ Feature: Admin Actions for Works, Comments, Series, Bookmarks
       And logged in users should not see the hidden work "ToS Violation" by "regular_user"
       And "regular_user" should see their work "ToS Violation" is hidden
       And 1 email should be delivered
-      And the email should contain "We are investigating the matter and will contact you"
+      And the email should contain "you will be required to take action to correct the violation"
 
   Scenario: Can unhide works
     Given I am logged in as "regular_user"

--- a/features/admins/admin_works.feature
+++ b/features/admins/admin_works.feature
@@ -24,7 +24,7 @@ Feature: Admin Actions for Works, Comments, Series, Bookmarks
       And logged in users should not see the hidden work "ToS Violation" by "regular_user"
       And "regular_user" should see their work "ToS Violation" is hidden
       And 1 email should be delivered
-      And the email should contain "Abuse team may have already contacted you explaining why your work was hidden"
+      And the email should contain "We are investigating the matter and will contact you"
 
   Scenario: Can unhide works
     Given I am logged in as "regular_user"

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -147,7 +147,7 @@ describe UserMailer do
       end
     end
   end
-  
+
   describe "invitation" do
     context "when sent by a user" do
       let(:user) { create(:user) }
@@ -317,7 +317,7 @@ describe UserMailer do
       end
     end
   end
-  
+
   describe "invite_increase_notification" do
     let!(:user) { create(:user) }
 
@@ -384,7 +384,7 @@ describe UserMailer do
 
   describe "batch_subscription_notification" do
     let(:work) { create(:work, summary: "<p>Paragraph <u>one</u>.</p><p>Paragraph 2.</p>") }
-    let(:chapter) { create(:chapter, work: work, posted: true, summary: "<p><b>Another</b> HTML summary.</p>") } 
+    let(:chapter) { create(:chapter, work: work, posted: true, summary: "<p><b>Another</b> HTML summary.</p>") }
     let(:subscription) { create(:subscription, subscribable: work) }
 
     subject(:email) { UserMailer.batch_subscription_notification(subscription.id, ["Work_#{work.id}", "Chapter_#{chapter.id}"].to_json).deliver }
@@ -429,6 +429,41 @@ describe UserMailer do
 
       it "reformats HTML from the chapter summary" do
         expect(email).to have_text_part_content("*Another* HTML summary.")
+      end
+    end
+  end
+
+  describe "admin_hidden_work_notification" do
+    subject(:email) { UserMailer.admin_hidden_work_notification(work.id, user.id) }
+
+    let(:user) { create(:user) }
+    let(:work) { create(:work, authors: [user.pseuds.first]) }
+
+    # Test the headers
+    it_behaves_like "an email with a valid sender"
+
+    it "has the correct subject line" do
+      subject = "[#{ArchiveConfig.APP_SHORT_NAME}] Your work has been hidden by the Policy & Abuse team"
+      expect(email.subject).to eq(subject)
+    end
+
+    # Test both body contents
+    it_behaves_like "a multipart email"
+
+    it_behaves_like "a translated email"
+
+    describe "HTML version" do
+      it "has the correct content" do
+        expect(email).to have_html_part_content("Dear <b")
+        expect(email).to have_html_part_content("#{user.login}</b>,")
+        expect(email).to have_html_part_content("> has been hidden")
+      end
+    end
+
+    describe "text version" do
+      it "has the correct content" do
+        expect(email).to have_text_part_content("Dear #{user.login},")
+        expect(email).to have_text_part_content(") has been hidden")
       end
     end
   end


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6206

## Purpose

Updates the content of the html and text versions, apply `style_bold` to `user`, apply `style_creation_link` to `work`, make `user` username instead of default pseud

## Testing Instructions

1. Log in, making sure to use an account that's hooked up to an email address you can access
2. Post > New Work
3. Fill in required information
4. Press "Post"
5. Make note of the URL
6. Log out
7. Log in as an admin with the role policy_and_abuse or superadmin
8. Go to the work you posted
9. Press "Hide Work"
10. Ensure the email text is as described below

If you have a Jira account with access, please update or comment on the issue with any new or missing testing instructions instead.