### PR TITLE
AO3-6165 Skip comment reply notifications for guests with banned emails

### DIFF
--- a/app/mailers/comment_mailer.rb
+++ b/app/mailers/comment_mailer.rb
@@ -33,6 +33,8 @@ class CommentMailer < ActionMailer::Base
   # Sends email to commenter when a reply is posted to their comment
   # This may be a non-user of the archive
   def comment_reply_notification(your_comment, comment)
+    return if your_comment.pseud_id.nil? && AdminBlacklistedEmail.is_blacklisted?(your_comment.comment_owner_email)
+
     @your_comment = your_comment
     @comment = comment
     mail(
@@ -46,6 +48,8 @@ class CommentMailer < ActionMailer::Base
   # Sends email to commenter when a reply to their comment is edited
   # This may be a non-user of the archive
   def edited_comment_reply_notification(your_comment, edited_comment)
+    return if your_comment.pseud_id.nil? && AdminBlacklistedEmail.is_blacklisted?(your_comment.comment_owner_email)
+
     @your_comment = your_comment
     @comment = edited_comment
     mail(

--- a/spec/mailers/admin_mailer_spec.rb
+++ b/spec/mailers/admin_mailer_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require "spec_helper"
 
 describe AdminMailer do
   describe "send_spam_alert" do
@@ -8,24 +8,24 @@ describe AdminMailer do
 
     let(:spam1) do
       create(:work, spam: true, title: "First Spam",
-                           authors: [spam_user.default_pseud])
+                    authors: [spam_user.default_pseud])
     end
 
     let(:spam2) do
       create(:work, spam: true, title: "Second Spam",
-                           authors: [spam_user.default_pseud])
+                    authors: [spam_user.default_pseud])
     end
 
     let(:spam3) do
       create(:work, spam: true, title: "Third Spam",
-                           authors: [spam_user.default_pseud])
+                    authors: [spam_user.default_pseud])
     end
 
     let(:other_user) { create(:user) }
 
     let(:other_spam) do
       create(:work, spam: true, title: "Mistaken Spam",
-                           authors: [other_user.default_pseud])
+                    authors: [other_user.default_pseud])
     end
 
     let!(:report) do
@@ -125,9 +125,7 @@ describe AdminMailer do
           }
         end
 
-        it "aborts delivery" do
-          expect(email.message).to be_a(ActionMailer::Base::NullMail)
-        end
+        it_behaves_like "an unsent email"
       end
     end
   end

--- a/spec/mailers/collection_mailer_spec.rb
+++ b/spec/mailers/collection_mailer_spec.rb
@@ -1,11 +1,11 @@
-require 'spec_helper'
+require "spec_helper"
 
 describe CollectionMailer do
   describe "item_added_notification" do
+    subject(:email) { CollectionMailer.item_added_notification(work.id, collection.id, "Work") }
+
     let(:collection) { create(:collection, email: Faker::Internet.email) } 
     let(:work) { create(:work) }
-
-    subject(:email) { CollectionMailer.item_added_notification(work.id, collection.id, "Work").deliver }
 
     it_behaves_like "an email with a valid sender"
   end

--- a/spec/mailers/comment_mailer_spec.rb
+++ b/spec/mailers/comment_mailer_spec.rb
@@ -62,7 +62,7 @@ describe CommentMailer do
   end
 
   describe "comment_notification" do
-    subject(:email) { CommentMailer.comment_notification(user, comment).deliver }
+    subject(:email) { CommentMailer.comment_notification(user, comment) }
 
     it_behaves_like "an email with a valid sender"
     it_behaves_like "a notification email with a link to the comment"
@@ -93,7 +93,7 @@ describe CommentMailer do
   end
 
   describe "edited_comment_notification" do
-    subject(:email) { CommentMailer.edited_comment_notification(user, comment).deliver }
+    subject(:email) { CommentMailer.edited_comment_notification(user, comment) }
 
     it_behaves_like "an email with a valid sender"
     it_behaves_like "a notification email with a link to the comment"
@@ -124,7 +124,7 @@ describe CommentMailer do
   end
 
   describe "comment_reply_notification" do
-    subject(:email) { CommentMailer.comment_reply_notification(parent_comment, comment).deliver }
+    subject(:email) { CommentMailer.comment_reply_notification(parent_comment, comment) }
 
     let(:parent_comment) { create(:comment) }
     let(:comment) { create(:comment, commentable: parent_comment) }
@@ -140,11 +140,26 @@ describe CommentMailer do
       it_behaves_like "a notification email with a link to the comment"
       it_behaves_like "a notification email with a link to reply to the comment"
       it_behaves_like "a notification email with a link to the comment's thread"
+    end
+
+    context "when the comment is from a user using a banned email" do
+      before { create(:admin_blacklisted_email, email: parent_comment.comment_owner_email) }
+
+      # Don't consider banned emails for registered users.
+      it_behaves_like "a notification email with a link to the comment"
+    end
+
+    context "when the comment is from a guest using a banned email" do
+      let(:parent_comment) { create(:comment, :by_guest) }
+
+      before { create(:admin_blacklisted_email, email: parent_comment.comment_owner_email) }
+
+      it_behaves_like "an unsent email"
     end
   end
 
   describe "edited_comment_reply_notification" do
-    subject(:email) { CommentMailer.edited_comment_reply_notification(parent_comment, comment).deliver }
+    subject(:email) { CommentMailer.edited_comment_reply_notification(parent_comment, comment) }
 
     let(:parent_comment) { create(:comment) }
     let(:comment) { create(:comment, commentable: parent_comment) }
@@ -161,10 +176,25 @@ describe CommentMailer do
       it_behaves_like "a notification email with a link to reply to the comment"
       it_behaves_like "a notification email with a link to the comment's thread"
     end
+
+    context "when the comment is from a user using a banned email" do
+      before { create(:admin_blacklisted_email, email: parent_comment.comment_owner_email) }
+
+      # Don't consider banned emails for registered users.
+      it_behaves_like "a notification email with a link to the comment"
+    end
+
+    context "when the comment is from a guest using a banned email" do
+      let(:parent_comment) { create(:comment, :by_guest) }
+
+      before { create(:admin_blacklisted_email, email: parent_comment.comment_owner_email) }
+
+      it_behaves_like "an unsent email"
+    end
   end
 
   describe "comment_sent_notification" do
-    subject(:email) { CommentMailer.comment_sent_notification(comment).deliver }
+    subject(:email) { CommentMailer.comment_sent_notification(comment) }
 
     it_behaves_like "an email with a valid sender"
     it_behaves_like "a notification email with a link to the comment"

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -4,11 +4,12 @@ describe UserMailer do
   describe "claim_notification" do
     title = "Façade"
     title2 = Faker::Book.title
+
+    subject(:email) { UserMailer.claim_notification(author.id, [work.id, work2.id], true) }
+
     let(:author) { create(:user) }
     let(:work) { create(:work, title: title, authors: [author.pseuds.first]) }
     let(:work2) { create(:work, title: title2, authors: [author.pseuds.first]) }
-
-    subject(:email) { UserMailer.claim_notification(author.id, [work.id, work2.id], true).deliver }
 
     # Shared content tests for both email types
     shared_examples_for "a claim notification" do
@@ -65,6 +66,8 @@ describe UserMailer do
     title = Faker::Book.title
     title2 = Faker::Book.title
 
+    subject(:email) { UserMailer.invitation_to_claim(invitation.id, archivist.login) }
+
     let(:archivist) { create(:user) }
     let(:external_author) { create(:external_author) }
 
@@ -92,8 +95,6 @@ describe UserMailer do
              creation_id: work2.id,
              external_author_name_id: external_author_name.id)
     end
-
-    subject(:email) { UserMailer.invitation_to_claim(invitation.id, archivist.login).deliver }
 
     # Shared content tests for both email types
     shared_examples_for "an invitation to claim content" do
@@ -150,10 +151,10 @@ describe UserMailer do
   
   describe "invitation" do
     context "when sent by a user" do
+      subject(:email) { UserMailer.invitation(invitation.id) }
+
       let(:user) { create(:user) }
       let(:invitation) { create(:invitation, creator: user) }
-
-      subject(:email) { UserMailer.invitation(invitation.id).deliver }
 
       # Test the headers
       it_behaves_like "an email with a valid sender"
@@ -184,9 +185,9 @@ describe UserMailer do
     end
 
     context "when sent from the queue or by an admin" do
-      let(:invitation) { create(:invitation) }
+      subject(:email) { UserMailer.invitation(invitation.id) }
 
-      subject(:email) { UserMailer.invitation(invitation.id).deliver }
+      let(:invitation) { create(:invitation) }
 
       # Test the headers
       it_behaves_like "an email with a valid sender"
@@ -218,13 +219,13 @@ describe UserMailer do
   end
 
   describe "challenge_assignment_notification" do
+    subject(:email) { UserMailer.challenge_assignment_notification(collection.id, otheruser.id, open_assignment.id) }
+
     let!(:gift_exchange) { create(:gift_exchange) }
     let!(:collection) { create(:collection, challenge: gift_exchange, challenge_type: "GiftExchange") }
     let!(:otheruser) { create(:user) }
     let!(:offer) { create(:challenge_signup, collection: collection, pseud: otheruser.default_pseud) }
     let!(:open_assignment) { create(:challenge_assignment, collection: collection, offer_signup: offer) }
-
-    subject(:email) { UserMailer.challenge_assignment_notification(collection.id, otheruser.id, open_assignment.id).deliver }
 
     # Test the headers
     it_behaves_like "an email with a valid sender"
@@ -253,11 +254,11 @@ describe UserMailer do
   end
 
   describe "invite_request_declined" do
+    subject(:email) { UserMailer.invite_request_declined(user.id, total, reason) }
+
     let(:user) { create(:user) }
     let(:total) { 2 }
     let(:reason) { "You smell" }
-
-    subject(:email) { UserMailer.invite_request_declined(user.id, total, reason).deliver }
 
     # Test the headers
     it_behaves_like "an email with a valid sender"
@@ -286,9 +287,9 @@ describe UserMailer do
   end
 
   describe "signup_notification" do
-    let(:user) { create(:user, :unconfirmed) }
+    subject(:email) { UserMailer.signup_notification(user.id) }
 
-    subject(:email) { UserMailer.signup_notification(user.id).deliver }
+    let(:user) { create(:user, :unconfirmed) }
 
     # Test the headers
     it_behaves_like "an email with a valid sender"
@@ -322,9 +323,9 @@ describe UserMailer do
     let!(:user) { create(:user) }
 
     context "when 1 invitation is issued" do
-      let(:count) { 1 }
+      subject(:email) { UserMailer.invite_increase_notification(user.id, count) }
 
-      subject(:email) { UserMailer.invite_increase_notification(user.id, count).deliver }
+      let(:count) { 1 }
 
       # Test the headers
       it_behaves_like "an email with a valid sender"
@@ -352,9 +353,9 @@ describe UserMailer do
     end
 
     context "when multiple invitations are issued" do
-      let(:count) { 5 }
+      subject(:email) { UserMailer.invite_increase_notification(user.id, count) }
 
-      subject(:email) { UserMailer.invite_increase_notification(user.id, count).deliver }
+      let(:count) { 5 }
 
       # Test the headers
       it_behaves_like "an email with a valid sender"
@@ -383,11 +384,11 @@ describe UserMailer do
   end
 
   describe "batch_subscription_notification" do
+    subject(:email) { UserMailer.batch_subscription_notification(subscription.id, ["Work_#{work.id}", "Chapter_#{chapter.id}"].to_json) }
+
     let(:work) { create(:work, summary: "<p>Paragraph <u>one</u>.</p><p>Paragraph 2.</p>") }
     let(:chapter) { create(:chapter, work: work, posted: true, summary: "<p><b>Another</b> HTML summary.</p>") } 
     let(:subscription) { create(:subscription, subscribable: work) }
-
-    subject(:email) { UserMailer.batch_subscription_notification(subscription.id, ["Work_#{work.id}", "Chapter_#{chapter.id}"].to_json).deliver }
 
     # Test the headers
     it_behaves_like "an email with a valid sender"

--- a/spec/support/shared_examples/mailer_shared_examples.rb
+++ b/spec/support/shared_examples/mailer_shared_examples.rb
@@ -24,3 +24,9 @@ shared_examples_for "an email with a valid sender" do
     expect(email).to deliver_from("Archive of Our Own <#{ArchiveConfig.RETURN_ADDRESS}>")
   end
 end
+
+shared_examples_for "an unsent email" do
+  it "is not delivered" do
+    expect(email.message).to be_a(ActionMailer::Base::NullMail)
+  end
+end


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6165

## Purpose

Before sending reply notifications for guest comments (but not logged in comments), we should check if the comment's email is in the banned list. If it is, we should skip the notification.

Also make sure the subject of mailer specs is the mailer object, not the message object (returned by "deliver").

## Testing Instructions

See issue.