### PR TITLE
AO3-6153 Limit maximum number of user-defined tags allowed on works & external works.

### DIFF
--- a/app/controllers/bookmarks_controller.rb
+++ b/app/controllers/bookmarks_controller.rb
@@ -187,19 +187,13 @@ class BookmarksController < ApplicationController
   # POST /bookmarks.xml
   def create
     @bookmarkable ||= ExternalWork.new(external_work_params)
-    @bookmark = @bookmarkable.bookmarks.build(bookmark_params)
-    if @bookmarkable.new_record? && @bookmarkable.fandom_string.blank?
-       @bookmark.errors.add(:base, "Fandom tag is required")
-       render :new and return
+    @bookmark = Bookmark.new(bookmark_params.merge(bookmarkable: @bookmarkable))
+    if @bookmark.errors.empty? && @bookmark.save
+      flash[:notice] = ts("Bookmark was successfully created. It should appear in bookmark listings within the next few minutes.")
+      redirect_to(bookmark_path(@bookmark))
+    else
+      render :new
     end
-    if @bookmark.errors.empty?
-      if @bookmark.validate && @bookmarkable.save && @bookmark.save
-        flash[:notice] = ts('Bookmark was successfully created. It should appear in bookmark listings within the next few minutes.')
-        redirect_to(bookmark_path(@bookmark)) && return
-      end
-    end
-    @bookmarkable.errors.full_messages.each { |msg| @bookmark.errors.add(:base, msg) }
-    render action: "new" and return
   end
 
   # PUT /bookmarks/1

--- a/app/controllers/chapters_controller.rb
+++ b/app/controllers/chapters_controller.rb
@@ -237,6 +237,13 @@ class ChaptersController < ApplicationController
   # Check whether we should display :new or :edit instead of previewing or
   # saving the user's changes.
   def chapter_cannot_be_saved?
+    # The chapter can only be saved if the work can be saved:
+    if @work.invalid?
+      @work.errors.full_messages.each do |message|
+        @chapter.errors.add(:base, message)
+      end
+    end
+
     @chapter.errors.any? || @chapter.invalid?
   end
 

--- a/app/models/bookmark.rb
+++ b/app/models/bookmark.rb
@@ -25,14 +25,12 @@ class Bookmark < ApplicationRecord
   def check_new_external_work
     return unless bookmarkable.is_a?(ExternalWork) && bookmarkable.new_record?
 
-    if bookmarkable.fandom_string.blank?
-      errors.add(:base, "Fandom tag is required")
-    end
+    errors.add(:base, "Fandom tag is required") if bookmarkable.fandom_string.blank?
 
-    if bookmarkable.invalid?
-      bookmarkable.errors.full_messages.each do |message|
-        errors.add(:base, message)
-      end
+    return if bookmarkable.valid?
+
+    bookmarkable.errors.full_messages.each do |message|
+      errors.add(:base, message)
     end
   end
 

--- a/app/models/collection_item.rb
+++ b/app/models/collection_item.rb
@@ -109,7 +109,7 @@ class CollectionItem < ApplicationRecord
 
       # For a more helpful error message, raise an error saying that the work
       # is invalid if we fail to save it.
-      raise ActiveRecord::RecordInvalid, work unless work.save
+      raise ActiveRecord::RecordInvalid, work unless work.save(validate: false)
     end
   end
 

--- a/app/models/concerns/taggable.rb
+++ b/app/models/concerns/taggable.rb
@@ -84,6 +84,14 @@ module Taggable
     end
   end
 
+  # Returns the number of tags of type Fandom, Character, Relationship, or
+  # Freeform.
+  def user_defined_tags_count
+    tags_after_saving.count do |tag|
+      Tag::USER_DEFINED.include?(tag.type)
+    end
+  end
+
   private
 
   # Take the list of tags after saving, and filter by type:

--- a/app/models/external_work.rb
+++ b/app/models/external_work.rb
@@ -32,6 +32,9 @@ class ExternalWork < ApplicationRecord
                                too_long: ts('^Creator must be less than %{max} characters long.',
                                             max: AUTHOR_LENGTH_MAX)
 
+  validates :user_defined_tags_count,
+            at_most: { maximum: Proc.new { ArchiveConfig.USER_DEFINED_TAGS_LIMIT } }
+
   # TODO: External works should have fandoms, but they currently don't get added through the
   # post new work form so we can't validate them
   #validates_presence_of :fandoms

--- a/app/models/external_work.rb
+++ b/app/models/external_work.rb
@@ -33,7 +33,7 @@ class ExternalWork < ApplicationRecord
                                             max: AUTHOR_LENGTH_MAX)
 
   validates :user_defined_tags_count,
-            at_most: { maximum: proc { ArchiveConfig.USER_DEFINED_TAGS_LIMIT } }
+            at_most: { maximum: proc { ArchiveConfig.USER_DEFINED_TAGS_MAX } }
 
   # TODO: External works should have fandoms, but they currently don't get added through the
   # post new work form so we can't validate them

--- a/app/models/external_work.rb
+++ b/app/models/external_work.rb
@@ -33,7 +33,7 @@ class ExternalWork < ApplicationRecord
                                             max: AUTHOR_LENGTH_MAX)
 
   validates :user_defined_tags_count,
-            at_most: { maximum: Proc.new { ArchiveConfig.USER_DEFINED_TAGS_LIMIT } }
+            at_most: { maximum: proc { ArchiveConfig.USER_DEFINED_TAGS_LIMIT } }
 
   # TODO: External works should have fandoms, but they currently don't get added through the
   # post new work form so we can't validate them

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -152,6 +152,9 @@ class Work < ApplicationRecord
     end
   end
 
+  validates :user_defined_tags_count,
+            at_most: { maximum: Proc.new { ArchiveConfig.USER_DEFINED_TAGS_LIMIT } }
+
   enum comment_permissions: {
     enable_all: 0,
     disable_anon: 1,

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -153,7 +153,7 @@ class Work < ApplicationRecord
   end
 
   validates :user_defined_tags_count,
-            at_most: { maximum: proc { ArchiveConfig.USER_DEFINED_TAGS_LIMIT } }
+            at_most: { maximum: proc { ArchiveConfig.USER_DEFINED_TAGS_MAX } }
 
   enum comment_permissions: {
     enable_all: 0,

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -153,7 +153,7 @@ class Work < ApplicationRecord
   end
 
   validates :user_defined_tags_count,
-            at_most: { maximum: Proc.new { ArchiveConfig.USER_DEFINED_TAGS_LIMIT } }
+            at_most: { maximum: proc { ArchiveConfig.USER_DEFINED_TAGS_LIMIT } }
 
   enum comment_permissions: {
     enable_all: 0,

--- a/app/validators/at_most_validator.rb
+++ b/app/validators/at_most_validator.rb
@@ -1,0 +1,17 @@
+# This validator is very similar to the less_than_or_equal_to option for the
+# numericality validator, but it computes the difference between the value and
+# the maximum so that it can be included in the error message.
+class AtMostValidator < ActiveModel::EachValidator
+  def validate_each(record, attribute, value)
+    maximum = options[:maximum]
+    maximum = record.send(maximum) if maximum.is_a?(Symbol)
+    maximum = maximum.call(record) if maximum.is_a?(Proc)
+
+    return unless value > maximum
+
+    record.errors.add(
+      attribute, :at_most,
+      value: value, count: maximum, diff: value - maximum
+    )
+  end
+end

--- a/app/views/bookmarks/_external_work_fields.html.erb
+++ b/app/views/bookmarks/_external_work_fields.html.erb
@@ -69,7 +69,7 @@
   <legend><%= ts("Creator's Tags") %></legend>
   <p>
     <%= ts("Creator's Tags (comma separated, %{max} characters per tag). Only a fandom is required. Fandom, relationship, and character tags must not add up to more than %{limit}. Category and rating tags do not count toward this limit.",
-           limit: ArchiveConfig.USER_DEFINED_TAGS_LIMIT,
+           limit: ArchiveConfig.USER_DEFINED_TAGS_MAX,
            max: ArchiveConfig.TAG_MAX) %>
   </p>
   <dl>

--- a/app/views/bookmarks/_external_work_fields.html.erb
+++ b/app/views/bookmarks/_external_work_fields.html.erb
@@ -68,7 +68,9 @@
 <fieldset class="external">
   <legend><%= ts("Creator's Tags") %></legend>
   <p>
-    <%= ts("Creator's Tags (comma separated, %{max} characters per tag). Only a fandom is required.", max: ArchiveConfig.TAG_MAX) %>
+    <%= ts("Creator's Tags (comma separated, %{max} characters per tag). Only a fandom is required. Fandom, relationship, and character tags must not add up to more than %{limit}. Category and rating tags do not count toward this limit.",
+           limit: ArchiveConfig.USER_DEFINED_TAGS_LIMIT,
+           max: ArchiveConfig.TAG_MAX) %>
   </p>
   <dl>
     <dt class="required">

--- a/app/views/works/_meta.html.erb
+++ b/app/views/works/_meta.html.erb
@@ -85,6 +85,12 @@
              <%= @work.spam? %>
           <% end %>
         </dd>
+        <dt class="limit">
+          <%= ts("Over Tag Limit:") %>
+        </dt>
+        <dd class="limit">
+          <%= @work.user_defined_tags_count > ArchiveConfig.USER_DEFINED_TAGS_LIMIT ? ts("Yes") : ts("No") %>
+        </dd>
         <% if @work.gifts.are_rejected.exists? %>
           <dt class="gift">
             <%= ts('Refused As Gift:') %>

--- a/app/views/works/_meta.html.erb
+++ b/app/views/works/_meta.html.erb
@@ -89,7 +89,7 @@
           <%= ts("Over Tag Limit:") %>
         </dt>
         <dd class="limit">
-          <%= @work.user_defined_tags_count > ArchiveConfig.USER_DEFINED_TAGS_LIMIT ? ts("Yes") : ts("No") %>
+          <%= @work.user_defined_tags_count > ArchiveConfig.USER_DEFINED_TAGS_MAX ? ts("Yes") : ts("No") %>
         </dd>
         <% if @work.gifts.are_rejected.exists? %>
           <dt class="gift">

--- a/app/views/works/_work_form_tags.html.erb
+++ b/app/views/works/_work_form_tags.html.erb
@@ -2,7 +2,11 @@
   <legend><%= ts('Tags') %></legend>
   <h3 class="landmark heading"><%= ts('Tags') %></h3>
 
-  <p class="note"><%= ts('Tags are comma separated, %{max} characters per tag.', :max => ArchiveConfig.TAG_MAX) %></p>
+  <p class="note">
+    <%= ts("Tags are comma separated, %{max} characters per tag. Fandom, relationship, character, and additional tags must not add up to more than %{limit}. Archive warning, category, and rating tags do not count toward this limit.",
+           limit: ArchiveConfig.USER_DEFINED_TAGS_LIMIT,
+           max: ArchiveConfig.TAG_MAX) %>
+  </p>
 
   <dl>
     <dt class="rating required">

--- a/app/views/works/_work_form_tags.html.erb
+++ b/app/views/works/_work_form_tags.html.erb
@@ -4,7 +4,7 @@
 
   <p class="note">
     <%= ts("Tags are comma separated, %{max} characters per tag. Fandom, relationship, character, and additional tags must not add up to more than %{limit}. Archive warning, category, and rating tags do not count toward this limit.",
-           limit: ArchiveConfig.USER_DEFINED_TAGS_LIMIT,
+           limit: ArchiveConfig.USER_DEFINED_TAGS_MAX,
            max: ArchiveConfig.TAG_MAX) %>
   </p>
 

--- a/config/config.yml
+++ b/config/config.yml
@@ -108,7 +108,7 @@ PASSWORD_LENGTH_MAX: 40
 COLLECTION_TAGS_MAX: 10
 
 # The maximum number of user-defined tags you can add to a work or external work
-USER_DEFINED_TAGS_LIMIT: 75
+USER_DEFINED_TAGS_MAX: 75
 
 # max number of tags of each type allowed in challenge prompts (requests/offers)
 # increasing this number can lead to slower automated matching

--- a/config/config.yml
+++ b/config/config.yml
@@ -107,6 +107,9 @@ PASSWORD_LENGTH_MAX: 40
 # The maximum number of tags you can add to a collection
 COLLECTION_TAGS_MAX: 10
 
+# The maximum number of user-defined tags you can add to a work or external work
+USER_DEFINED_TAGS_LIMIT: 75
+
 # max number of tags of each type allowed in challenge prompts (requests/offers)
 # increasing this number can lead to slower automated matching
 PROMPT_TAGS_MAX: 20

--- a/config/locales/models/en.yml
+++ b/config/locales/models/en.yml
@@ -6,10 +6,20 @@ en:
           attributes:
             pseud_id:
               taken: "is already listed as a creator."
+        external_work:
+          attributes:
+            user_defined_tags_count:
+              at_most:
+                "must not add up to more than %{count}. You have entered %{value} of these tags, so you must remove %{diff} of them."
         user:
           attributes:
             password_confirmation:
               confirmation: "doesn't match new password."
+        work:
+          attributes:
+            user_defined_tags_count:
+              at_most:
+                "must not add up to more than %{count}. Your work has %{value} of these tags, so you must remove %{diff} of them."
     models:
       archive_warning:
         one: "Warning"
@@ -95,3 +105,7 @@ en:
       work/chapters:
         content: "Content"
         base: "Invalid chapter:"
+      external_work:
+        user_defined_tags_count: "Fandom, relationship, and character tags"
+      work:
+        user_defined_tags_count: "Fandom, relationship, character, and additional tags"

--- a/features/admins/admin_works.feature
+++ b/features/admins/admin_works.feature
@@ -346,3 +346,17 @@ Feature: Admin Actions for Works, Comments, Series, Bookmarks
       And I should see "Violation"
     When I view the series "Violation"
     Then I should see "Violation"
+
+  Scenario: Admins can see when a work has too many tags
+    Given the user-defined tag limit is 7
+      And the work "Under the Limit"
+      And the work "Over the Limit"
+      And the work "Over the Limit" has 2 fandom tags
+      And the work "Over the Limit" has 2 character tags
+      And the work "Over the Limit" has 2 relationship tags
+      And the work "Over the Limit" has 2 freeform tags
+    When I am logged in as an admin
+      And I view the work "Under the Limit"
+    Then I should see "Over Tag Limit: No"
+    When I view the work "Over the Limit"
+    Then I should see "Over Tag Limit: Yes"

--- a/features/bookmarks/bookmark_create.feature
+++ b/features/bookmarks/bookmark_create.feature
@@ -429,3 +429,32 @@ Scenario: A bookmark with duplicate tags other than capitalization has only firs
   Then I should see "Bookmark was successfully created"
     And I should see "Bookmarker's Tags: my tags"
     And I should not see "Bookmarker's Tags: My Tags"
+
+  Scenario: Users can bookmark a work with too many tags
+    Given the user-defined tag limit is 5
+      And the work "Over the Limit"
+      And the work "Over the Limit" has 6 fandom tags
+      And I am logged in as "bookmarker"
+    When I bookmark the work "Over the Limit"
+    Then I should see "Bookmark was successfully created"
+
+  Scenario: Users can bookmark a pre-existing external work with too many tags
+    Given the user-defined tag limit is 5
+      And I am logged in as "bookmarker1"
+      And I bookmark the external work "Over the Limit"
+      And the external work "Over the Limit" has 6 fandom tags
+      And I am logged in as "bookmarker2"
+    When I go to bookmarker1's bookmarks page
+      And I follow "Save"
+      And I press "Create"
+    Then I should see "Bookmark was successfully created"
+
+  Scenario: Users cannot bookmark a new external work with too many tags
+    Given the user-defined tag limit is 5
+      And I am logged in as "bookmarker"
+    When I set up an external work
+      And I fill in "Fandoms" with "Fandom 1, Fandom 2"
+      And I fill in "Characters" with "Character 1, Character 2"
+      And I fill in "Relationships" with "Relationship 1, Relationship 2"
+      And I press "Create"
+    Then I should see "Fandom, relationship, and character tags must not add up to more than 5. You have entered 6 of these tags, so you must remove 1 of them."

--- a/features/collections/collection_anonymity.feature
+++ b/features/collections/collection_anonymity.feature
@@ -532,3 +532,14 @@ Feature: Collection
     When I am logged in as "moderator"
     Then the work "Old Snippet" should be visible to me
       And I should not see "Share"
+
+  Scenario: Works that are over the tag limit can be revealed
+    Given the user-defined tag limit is 5
+      And I have the hidden collection "Hidden Gems"
+      And I am logged in as "creator"
+      And I post the work "Over the Limit" in the collection "Hidden Gems"
+      And the work "Over the Limit" has 6 fandom tags
+    When I reveal works for "Hidden Gems"
+      And I log out
+      And I view the work "Over the Limit"
+    Then I should see "Over the Limit"

--- a/features/step_definitions/external_work_steps.rb
+++ b/features/step_definitions/external_work_steps.rb
@@ -53,6 +53,11 @@ Given "{string} has bookmarked an external work" do |user|
   click_button("Create")
 end
 
+Given "the external work {string} has {int} {word} tag(s)" do |title, count, type|
+  work = ExternalWork.find_by(title: title)
+  work.send("#{type.pluralize}=", FactoryBot.create_list(type.to_sym, count))
+end
+
 When /^I view the external work "([^\"]*)"$/ do |external_work|
   external_work = ExternalWork.find_by_title(external_work)
   visit external_work_url(external_work)

--- a/features/step_definitions/work_steps.rb
+++ b/features/step_definitions/work_steps.rb
@@ -243,6 +243,15 @@ Given /^the spam work "([^\"]*)"$/ do |work|
   w.update_attribute(:hidden_by_admin, true)
 end
 
+Given "the user-defined tag limit is {int}" do |count|
+  allow(ArchiveConfig).to receive(:USER_DEFINED_TAGS_LIMIT).and_return(count)
+end
+
+Given "the work {string} has {int} {word} tag(s)" do |title, count, type|
+  work = Work.find_by(title: title)
+  work.send("#{type.pluralize}=", FactoryBot.create_list(type.to_sym, count))
+end
+
 ### WHEN
 
 When /^I view the ([\d]+)(?:st|nd|rd|th) chapter$/ do |chapter_no|

--- a/features/step_definitions/work_steps.rb
+++ b/features/step_definitions/work_steps.rb
@@ -244,7 +244,7 @@ Given /^the spam work "([^\"]*)"$/ do |work|
 end
 
 Given "the user-defined tag limit is {int}" do |count|
-  allow(ArchiveConfig).to receive(:USER_DEFINED_TAGS_LIMIT).and_return(count)
+  allow(ArchiveConfig).to receive(:USER_DEFINED_TAGS_MAX).and_return(count)
 end
 
 Given "the work {string} has {int} {word} tag(s)" do |title, count, type|

--- a/features/works/chapter_edit.feature
+++ b/features/works/chapter_edit.feature
@@ -595,3 +595,19 @@ Feature: Edit chapters
       And I follow "Chapter 2"
       And I follow "Edit Chapter"
       And I should see "Remove Me As Chapter Co-Creator"
+
+  Scenario: You can't add a chapter to a work with too many tags
+    Given the user-defined tag limit is 7
+      And I am logged in as a random user
+      And I post the work "Over the Limit"
+      And the work "Over the Limit" has 2 fandom tags
+      And the work "Over the Limit" has 2 character tags
+      And the work "Over the Limit" has 2 relationship tags
+      And the work "Over the Limit" has 2 freeform tags
+    When I follow "Add Chapter"
+      And I fill in "content" with "this is my second chapter"
+      And I press "Post"
+    Then I should see "Fandom, relationship, character, and additional tags must not add up to more than 7. Your work has 8 of these tags, so you must remove 1 of them."
+    When I view the work "Over the Limit"
+    Then I should see "1/1"
+      And I should not see "Next Chapter"

--- a/features/works/work_create.feature
+++ b/features/works/work_create.feature
@@ -395,3 +395,14 @@ Feature: Create Works
     When I follow "Next Chapter"
     Then I should see "barbaz, foobar"
       And I should not see "Chapter by"
+
+  Scenario: You cannot create a work with too many tags
+    Given the user-defined tag limit is 7
+      And I am logged in as a random user
+    When I set up the draft "Over the Limit"
+      And I fill in "Fandoms" with "Fandom 1, Fandom 2"
+      And I fill in "Characters" with "Character 1, Character 2"
+      And I fill in "Relationships" with "Relationship 1, Relationship 2"
+      And I fill in "Additional Tags" with "Additional Tag 1, Additional Tag 2"
+      And I press "Post"
+    Then I should see "Fandom, relationship, character, and additional tags must not add up to more than 7. Your work has 8 of these tags, so you must remove 1 of them."

--- a/features/works/work_delete.feature
+++ b/features/works/work_delete.feature
@@ -191,3 +191,11 @@ Feature: Delete Works
     Then I should not see "All Something Breaks Loose"
       And I should see "This has been deleted, sorry!"
       And I should see "My thoughts on the work"
+
+  Scenario: A work with too many tags can be deleted
+    Given the user-defined tag limit is 5
+      And the work "Over the Limit"
+      And the work "Over the Limit" has 6 fandom tags
+    When I am logged in as the author of "Over the Limit"
+      And I delete the work "Over the Limit"
+    Then I should see "Your work Over the Limit was deleted."

--- a/features/works/work_edit.feature
+++ b/features/works/work_edit.feature
@@ -289,3 +289,28 @@ Feature: Edit Works
     When the user "Georgiou" accepts all co-creator requests
       And I view the work "Thats not my Spock, it has too much beard"
     Then I should see "Georgiou, Michael (Burnham), testuser"
+
+  Scenario: You cannot edit a work to add too many tags
+    Given the user-defined tag limit is 7
+      And the work "Over the Limit"
+      And I am logged in as the author of "Over the Limit"
+    When I edit the work "Over the Limit"
+      And I fill in "Fandoms" with "Fandom 1, Fandom 2"
+      And I fill in "Characters" with "Character 1, Character 2"
+      And I fill in "Relationships" with "Relationship 1, Relationship 2"
+      And I fill in "Additional Tags" with "Additional Tag 1, Additional Tag 2"
+      And I press "Post"
+    Then I should see "Fandom, relationship, character, and additional tags must not add up to more than 7. Your work has 8 of these tags, so you must remove 1 of them."
+
+  Scenario: If a work has too many tags, you cannot update it without removing tags
+    Given the user-defined tag limit is 7
+      And the work "Over the Limit"
+      And the work "Over the Limit" has 2 fandom tags
+      And the work "Over the Limit" has 2 character tags
+      And the work "Over the Limit" has 2 relationship tags
+      And the work "Over the Limit" has 2 freeform tags
+      And I am logged in as the author of "Over the Limit"
+    When I edit the work "Over the Limit"
+      And I fill in "Title" with "Over the Limit Redux"
+      And I press "Post"
+    Then I should see "Fandom, relationship, character, and additional tags must not add up to more than 7. Your work has 8 of these tags, so you must remove 1 of them."

--- a/lib/bookmarkable.rb
+++ b/lib/bookmarkable.rb
@@ -2,7 +2,7 @@ module Bookmarkable
 
   def self.included(bookmarkable)
     bookmarkable.class_eval do
-      has_many :bookmarks, as: :bookmarkable
+      has_many :bookmarks, as: :bookmarkable, inverse_of: :bookmarkable
       has_many :user_tags, through: :bookmarks, source: :tags
       after_update :update_bookmarks_index
       after_update :update_bookmarker_pseuds_index

--- a/lib/work_chapter_count_caching.rb
+++ b/lib/work_chapter_count_caching.rb
@@ -9,11 +9,7 @@ module WorkChapterCountCaching
   end
 
   def invalidate_work_chapter_count(work)
-    # Caching is not configured on development environments
-    # Trying to delete a non-existent cache made chapter deletion fail
-    unless Rails.env == "development"
-      Rails.cache.delete(key_for_chapter_total_counting(work))
-      Rails.cache.delete(key_for_chapter_posted_counting(work))
-    end
+    Rails.cache.delete(key_for_chapter_total_counting(work))
+    Rails.cache.delete(key_for_chapter_posted_counting(work))
   end
 end


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6153

## Purpose

- Limit the number of user-defined tags used on works to 75 (configurable).
- Limit the number of user-defined tags used on external works to 75 (configurable).
- Add assorted messages and error messages.
- Modify `BookmarksController` so that it no longer explicitly calls `@bookmarkable.save`. Instead, we rely on Rails' built-in behavior when saving objects that refer to other unsaved objects, and add some checks to the bookmark class to make sure that we only save the bookmark when the new external work is valid and has a fandom.
- Modify `CollectionItem#update_work` so that it skips validations when saving the work. This is so that works can be revealed/de-anoned even if they're over the tag limit.