### PR TITLE
AO3-5049 Fix bug where error message was not shown immediately.

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -172,7 +172,7 @@ class UsersController < ApplicationController
 
       if new_email != params[:email_confirmation]
         flash[:error] = ts("Email addresses don't match! Please retype and try again")
-        return
+        render :change_email and return
       end
 
       old_email = @user.email

--- a/features/other_a/profile_edit.feature
+++ b/features/other_a/profile_edit.feature
@@ -50,6 +50,13 @@ Scenario: Changing email address - entering an incorrect password
   Then I should see "Your password was incorrect"
     And 0 emails should be delivered
 
+Scenario: Changing email address - entering non-matching new email addresses
+
+  When I enter non-matching emails
+  Then I should see "Email addresses don't match!"
+    And 0 emails should be delivered
+    And I should see "bar@ao3.org"
+
 Scenario: Changing email address and viewing
 
   When I change my email

--- a/features/step_definitions/profile_steps.rb
+++ b/features/step_definitions/profile_steps.rb
@@ -63,6 +63,14 @@ When /^I enter an invalid email$/ do
 end
 
 
+When "I enter non-matching emails" do
+  click_link("Change Email")
+  fill_in("new_email", with: "correct@example.com")
+  fill_in("email_confirmation", with: "invalid@example.com")
+  fill_in("password_check", with: "password")
+  click_button("Change Email")
+end
+
 When /^I enter a duplicate email$/ do
   user = FactoryBot.create(:user, login: "testuser2", password: "password", email: "foo@ao3.org")
   step %{confirmation emails have been delivered}
@@ -73,7 +81,6 @@ When /^I enter a duplicate email$/ do
   fill_in("password_check", with: "password")
   click_button("Change Email")
 end
-
 
 When /^I enter a birthdate that shows I am under age$/ do
   date = 13.years.ago + 1.day


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [x] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [x] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [x] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue
https://otwarchive.atlassian.net/browse/AO3-5049

## Purpose
This fixes the bug described in https://otwarchive.atlassian.net/browse/AO3-5049?focusedCommentId=357672 .

## Testing Instructions
When trying to change a user's email address, enter two email addresses that don't match. An error should appear.

