### PR TITLE
AO3-6153 Don't check validity on collection invite.

### DIFF
--- a/app/controllers/collection_items_controller.rb
+++ b/app/controllers/collection_items_controller.rb
@@ -108,7 +108,7 @@ class CollectionItemsController < ApplicationController
       elsif @item.is_a?(Work) && @item.anonymous? && !current_user.is_author_of?(@item)
         errors << ts("%{collection_title}, because you don't own this item and the item is anonymous.", collection_title: collection.title)
       # add the work to a collection, and try to save it
-      elsif @item.add_to_collection(collection) && @item.save
+      elsif @item.add_to_collection(collection) && @item.save(validate: false)
         # approved_by_user and approved_by_collection are both true
         if @item.approved_collections.include?(collection)
           new_collections << collection

--- a/features/bookmarks/bookmark_create.feature
+++ b/features/bookmarks/bookmark_create.feature
@@ -431,18 +431,18 @@ Scenario: A bookmark with duplicate tags other than capitalization has only firs
     And I should not see "Bookmarker's Tags: My Tags"
 
   Scenario: Users can bookmark a work with too many tags
-    Given the user-defined tag limit is 5
+    Given the user-defined tag limit is 2
       And the work "Over the Limit"
-      And the work "Over the Limit" has 6 fandom tags
+      And the work "Over the Limit" has 3 fandom tags
       And I am logged in as "bookmarker"
     When I bookmark the work "Over the Limit"
     Then I should see "Bookmark was successfully created"
 
   Scenario: Users can bookmark a pre-existing external work with too many tags
-    Given the user-defined tag limit is 5
+    Given the user-defined tag limit is 2
       And I am logged in as "bookmarker1"
       And I bookmark the external work "Over the Limit"
-      And the external work "Over the Limit" has 6 fandom tags
+      And the external work "Over the Limit" has 3 fandom tags
       And I am logged in as "bookmarker2"
     When I go to bookmarker1's bookmarks page
       And I follow "Save"

--- a/features/collections/collection_anonymity.feature
+++ b/features/collections/collection_anonymity.feature
@@ -534,11 +534,11 @@ Feature: Collection
       And I should not see "Share"
 
   Scenario: Works that are over the tag limit can be revealed
-    Given the user-defined tag limit is 5
+    Given the user-defined tag limit is 2
       And I have the hidden collection "Hidden Gems"
       And I am logged in as "creator"
       And I post the work "Over the Limit" in the collection "Hidden Gems"
-      And the work "Over the Limit" has 6 fandom tags
+      And the work "Over the Limit" has 3 fandom tags
     When I reveal works for "Hidden Gems"
       And I log out
       And I view the work "Over the Limit"

--- a/features/collections/collection_invite.feature
+++ b/features/collections/collection_invite.feature
@@ -88,10 +88,10 @@ Feature: Collection
   Then I should not see "A Death in Hong Kong"
 
   Scenario: A work with too many tags can be invited to a collection
-    Given the user-defined tag limit is 5
+    Given the user-defined tag limit is 2
       And the collection "Favorites"
       And the work "Over the Limit"
-      And the work "Over the Limit" has 6 fandom tags
+      And the work "Over the Limit" has 3 fandom tags
     When I am logged in as "moderator"
       And I add the work "Over the Limit" to the collection "Favorites"
     Then I should see "This work has been invited to your collection (Favorites)."

--- a/features/collections/collection_invite.feature
+++ b/features/collections/collection_invite.feature
@@ -86,3 +86,12 @@ Feature: Collection
     And 0 emails should be delivered
   When I view the approved collection items page for "anon hidden collection"
   Then I should not see "A Death in Hong Kong"
+
+  Scenario: A work with too many tags can be invited to a collection
+    Given the user-defined tag limit is 5
+      And the collection "Favorites"
+      And the work "Over the Limit"
+      And the work "Over the Limit" has 6 fandom tags
+    When I am logged in as "moderator"
+      And I add the work "Over the Limit" to the collection "Favorites"
+    Then I should see "This work has been invited to your collection (Favorites)."

--- a/features/works/work_delete.feature
+++ b/features/works/work_delete.feature
@@ -193,9 +193,9 @@ Feature: Delete Works
       And I should see "My thoughts on the work"
 
   Scenario: A work with too many tags can be deleted
-    Given the user-defined tag limit is 5
+    Given the user-defined tag limit is 2
       And the work "Over the Limit"
-      And the work "Over the Limit" has 6 fandom tags
+      And the work "Over the Limit" has 3 fandom tags
     When I am logged in as the author of "Over the Limit"
       And I delete the work "Over the Limit"
     Then I should see "Your work Over the Limit was deleted."


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6153

## Purpose

Makes it so that the "Add to Collection" button doesn't check the validity of the item being added to the collection.