### PR TITLE
AO3-6153 Allow approval status changes for collection items on invalid works.

### DIFF
--- a/app/models/collection_item.rb
+++ b/app/models/collection_item.rb
@@ -117,7 +117,7 @@ class CollectionItem < ApplicationRecord
   after_update :update_item_for_status_change
   def update_item_for_status_change
     if saved_change_to_user_approval_status? || saved_change_to_collection_approval_status?
-      item.save!
+      item.save!(validate: false)
     end
   end
 

--- a/features/collections/collectible_moderated_collection.feature
+++ b/features/collections/collectible_moderated_collection.feature
@@ -41,3 +41,15 @@ Feature: Collectible items in moderated collections
       And I view the awaiting approval collection items page for "Various Penguins"
     Then I should see "Bookmark of deleted item"
       And I should see "This has been deleted, sorry!"
+
+  Scenario: A work with too many tags can be approved
+    Given the user-defined tag limit is 2
+      And I post the work "Over the Limit" to the collection "Various Penguins"
+      And the work "Over the Limit" has 3 fandom tags
+    When I am logged in as the owner of "Various Penguins"
+      And I approve the work "Over the Limit" in the collection "Various Penguins"
+      And I submit
+    Then I should see "Collection status updated!"
+      And I should not see "Over the Limit"
+    When I view the work "Over the Limit"
+    Then I should see "Various Penguins"

--- a/features/collections/collection_invite.feature
+++ b/features/collections/collection_invite.feature
@@ -87,7 +87,7 @@ Feature: Collection
   When I view the approved collection items page for "anon hidden collection"
   Then I should not see "A Death in Hong Kong"
 
-  Scenario: A work with too many tags can be invited to a collection
+  Scenario: A work with too many tags can be invited to a collection, and the user can accept the invitation
     Given the user-defined tag limit is 2
       And the collection "Favorites"
       And the work "Over the Limit"
@@ -95,3 +95,10 @@ Feature: Collection
     When I am logged in as "moderator"
       And I add the work "Over the Limit" to the collection "Favorites"
     Then I should see "This work has been invited to your collection (Favorites)."
+    When I am logged in as the author of "Over the Limit"
+      And I accept the invitation for my work in the collection "Favorites"
+      And I submit
+    Then I should see "Collection status updated!"
+      And I should not see "Over the Limit"
+    When I view the work "Over the Limit"
+    Then I should see "Favorites"

--- a/features/step_definitions/collection_steps.rb
+++ b/features/step_definitions/collection_steps.rb
@@ -164,6 +164,14 @@ When /^I accept the invitation for my work in the collection "([^\"]*)"$/ do |co
   step %{I select "Approved" from "collection_items_#{collection_item_id}_user_approval_status"}
 end
 
+When "I approve the work {string} in the collection {string}" do |work, collection|
+  work = Work.find_by(title: work)
+  collection = Collection.find_by(title: collection)
+  item_id = CollectionItem.find_by(item: work, collection: collection).id
+  visit collection_items_path(collection)
+  step %{I select "Approved" from "collection_items_#{item_id}_collection_approval_status"}
+end
+
 ### THEN
 
 Then /^"([^"]*)" collection exists$/ do |title|


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6153

## Purpose

Allow invalid works to be approved/rejected from collections, and allow users to accept/reject collection invitations on invalid works.