### PR TITLE
AO3-6038 Prevent replying to comments marked as spam

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -22,6 +22,7 @@ class CommentsController < ApplicationController
   before_action :check_parent_comment_permissions, only: [:new, :create, :add_comment_reply]
   before_action :check_unreviewed, only: [:add_comment_reply]
   before_action :check_frozen, only: [:new, :create, :add_comment_reply]
+  before_action :check_not_replying_to_spam, only: [:new, :create, :add_comment_reply]
   before_action :check_permission_to_review, only: [:unreviewed]
   before_action :check_permission_to_access_single_unreviewed, only: [:show]
   before_action :check_permission_to_moderate, only: [:approve, :reject]
@@ -121,6 +122,13 @@ class CommentsController < ApplicationController
     return unless @commentable.respond_to?(:iced?) && @commentable.iced?
 
     flash[:error] = t("comments.check_frozen.error")
+    redirect_back(fallback_location: root_path)
+  end
+
+  def check_not_replying_to_spam
+    return unless @commentable.respond_to?(:approved?) && !@commentable.approved?
+
+    flash[:error] = t("comments.check_not_replying_to_spam.error")
     redirect_back(fallback_location: root_path)
   end
 

--- a/config/locales/controllers/en.yml
+++ b/config/locales/controllers/en.yml
@@ -9,6 +9,8 @@ en:
   comments:
     check_frozen:
       error: Sorry, you cannot reply to a frozen comment.
+    check_not_replying_to_spam:
+      error: Sorry, you can't reply to a comment that has been marked as spam.
     check_permission_to_edit:
       error:
         frozen: Frozen comments cannot be edited.

--- a/spec/controllers/comments_controller_spec.rb
+++ b/spec/controllers/comments_controller_spec.rb
@@ -384,21 +384,15 @@ describe CommentsController do
         end
       end
 
-      # TODO: AO3-6038 Because this is quite wrong.
       context "when the commentable is spam" do
-        let(:comment) { create(:comment, approved: false) }
+        let(:spam_comment) { create(:comment) }
+        before { spam_comment.update_attribute(:approved, false) }
 
-        it "creates comment, gives success notice, and marks previous comment as approved" do
-          post :create, params: { comment_id: comment.id, comment: anon_comment_attributes }
+        it "shows an error and redirects if commentable is a comment marked as spam" do
+          post :create, params: { comment_id: spam_comment.id, comment: anon_comment_attributes }
 
-          latest_comment = Comment.last
-          expect(latest_comment.commentable).to eq comment
-          expect(latest_comment.name).to eq anon_comment_attributes[:name]
-          expect(latest_comment.email).to eq anon_comment_attributes[:email]
-          expect(latest_comment.comment_content).to include anon_comment_attributes[:comment_content]
-
-          expect(flash[:comment_notice]).to eq "Comment created!"
-          expect(comment.reload.approved).to be_truthy
+          it_redirects_to_with_error("/where_i_came_from",
+                                     "Sorry, you can't reply to a comment that has been marked as spam.")
         end
       end
     end

--- a/spec/controllers/comments_controller_spec.rb
+++ b/spec/controllers/comments_controller_spec.rb
@@ -386,6 +386,7 @@ describe CommentsController do
 
       context "when the commentable is spam" do
         let(:spam_comment) { create(:comment) }
+
         before { spam_comment.update_attribute(:approved, false) }
 
         it "shows an error and redirects if commentable is a comment marked as spam" do


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [x] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [x] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [x] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-6038

## Purpose

This helps resolve the bug where a commenter can accidentally unmark a comment as spam by replying to it.

Note: this was already partially fixed by https://github.com/otwcode/otwarchive/pull/3963, which changed the `check_for_spam` validation to run only when new comments are created.

The main thing this PR adds is a validation check on the controller to ensure that the comment you're replying to (i.e. the "commentable", a.k.a. the "immediate parent", not to be confused with the "parent" a.k.a. "ultimate parent") is not marked as spam. And also updates to the rspec test for this.

(If I understand correctly, there is still a possible race condition where the parent comment is marked as spam in that very narrow window of time _after_ the controller check but _before_ we save the new comment to database. But in this case, it's basically the same as if the parent comment were marked as spam _after_ the reply was submitted.)

### Caveat (and question)

Note: This validation check only checks the immediate parent. If there's a nested comment thread like this:

```
Commenter A: Spammy comment
└─ Commenter B: Oh no
   └─ Commenter C: Oh no
        └─ Commenter D: <typing response...>
```

and if Comment A gets marked as spam, then when Commenter D hits "Reply", the comment will still go through and D will get the "Comment created!" confirmation message. But it will not be visible because A was marked as spam. (This is the same as currently live behaviour.)

Do we want to do anything differently here? Or is it okay to only check the immediate parent?

## Testing Instructions

1. Log in
    1. Post > New Work
    2. Fill in required information
    3. Post
    4. Do not log out or close this window/browser
2. In an incognito/private window or another browser, make sure you are logged out
    1. Go to the work you posted
    2. Leave a comment (this will be the spammy one! :3)
    3. Press the "Reply" button on your spammy comment to open the reply form, and get everything ready to leave a reply comment
    4. Switch back to the window/browser where you are logged in
3. Go back to the window where you are logged in.
    1. Mark the spammy comment as spam
4. Go back to the window/browser where you are not logged in
    1. Press the button to submit your reply comment

### Expected behaviour

1. You should get an error message "Sorry, you can't reply to a comment that has been marked as spam."
2. The spammy comment should remain marked as spam and thus should remain hidden.

## Credit

ahiijny (they/them)
