### PR TITLE
AO3-5049 Use flash.now to flash msg on same render

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -171,7 +171,7 @@ class UsersController < ApplicationController
       new_email = params[:new_email]
 
       if new_email != params[:email_confirmation]
-        flash[:error] = ts("Email addresses don't match! Please retype and try again")
+        flash.now[:error] = ts("Email addresses don't match! Please retype and try again")
         render :change_email and return
       end
 
@@ -179,7 +179,7 @@ class UsersController < ApplicationController
       @user.email = new_email
 
       if @user.save
-        flash[:notice] = ts("Your email has been successfully updated")
+        flash.now[:notice] = ts("Your email has been successfully updated")
         UserMailer.change_email(@user.id, old_email, new_email).deliver_later
         @user.create_log_item(options = { action: ArchiveConfig.ACTION_NEW_EMAIL })
       else


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [x] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [x] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [x] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-5049

## Purpose
This makes it so both error and success messages only stick around for one page render instead of two (which looks weird right now)

## Testing Instructions
Successfully change an account's email address. You should see a success message. Navigate to another page. You should no longer see the success message.

