### PR TITLE
AO3-6188 Don't ignore any non-ASCII character when renaming tags

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,6 +38,7 @@ gem 'redis-namespace'
 # Used to convert strings to ascii
 gem 'unicode'
 gem 'unidecoder'
+gem 'unicode_utils', '>=1.4.0'
 
 # Lograge is opinionated, very opinionated.
 gem "lograge" # https://github.com/roidrage/lograge

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -506,6 +506,7 @@ GEM
     unf_ext (0.0.7.7)
     unicode (0.4.4.4)
     unicode-display_width (1.7.0)
+    unicode_utils (1.4.0)
     unicorn (5.5.5)
       kgio (~> 2.6)
       raindrops (~> 0.7)
@@ -627,6 +628,7 @@ DEPENDENCIES
   transaction_isolation (= 1.0.5)
   transaction_retry
   unicode
+  unicode_utils (>= 1.4.0)
   unicorn (~> 5.5)
   unidecoder
   vcr (~> 3.0, >= 3.0.1)

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -190,9 +190,7 @@ class Tag < ApplicationRecord
     if !self.new_record? && self.name_changed?
       # ordinary wranglers can change case and accents but not punctuation or the actual letters in the name
       # admins can change tags with no restriction
-      unless User.current_user.is_a?(Admin) || (self.name.downcase == self.name_was.downcase) || (self.name.mb_chars.normalize(:kd).gsub(/[\u0300-\u036F]/u,'').downcase.to_s == self.name_was.mb_chars.normalize(:kd).gsub(/[\u0300-\u036F]/u,'').downcase.to_s)
-        self.errors.add(:name, "can only be changed by an admin.")
-      end
+      self.errors.add(:name, "can only be changed by an admin.") unless User.current_user.is_a?(Admin) || (self.name.downcase == self.name_was.downcase) || (self.name.mb_chars.normalize(:kd).gsub(/[\u0300-\u036F]/u, "").downcase.to_s == self.name_was.mb_chars.normalize(:kd).gsub(/[\u0300-\u036F]/u, "").downcase.to_s)
     end
     if self.merger_id
       if self.canonical?

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1,3 +1,5 @@
+require "unicode_utils/casefold"
+
 class Tag < ApplicationRecord
 
   include ActiveModel::ForbiddenAttributesProtection
@@ -190,7 +192,7 @@ class Tag < ApplicationRecord
     if !self.new_record? && self.name_changed?
       # ordinary wranglers can change case and accents but not punctuation or the actual letters in the name
       # admins can change tags with no restriction
-      self.errors.add(:name, "can only be changed by an admin.") unless User.current_user.is_a?(Admin) || (self.name.downcase == self.name_was.downcase) || (self.name.mb_chars.normalize(:kd).gsub(/[\u0300-\u036F]/u, "").downcase.to_s == self.name_was.mb_chars.normalize(:kd).gsub(/[\u0300-\u036F]/u, "").downcase.to_s)
+      self.errors.add(:name, "can only be changed by an admin.") unless User.current_user.is_a?(Admin) || (self.name.downcase == self.name_was.downcase) || (UnicodeUtils.casefold(self.name).mb_chars.normalize(:kd).gsub(/[\u0300-\u036F]/u, "").to_s == UnicodeUtils.casefold(self.name_was).mb_chars.normalize(:kd).gsub(/[\u0300-\u036F]/u, "").to_s)
     end
     if self.merger_id
       if self.canonical?

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -190,7 +190,7 @@ class Tag < ApplicationRecord
     if !self.new_record? && self.name_changed?
       # ordinary wranglers can change case and accents but not punctuation or the actual letters in the name
       # admins can change tags with no restriction
-      unless User.current_user.is_a?(Admin) || (self.name.downcase == self.name_was.downcase) || (self.name.mb_chars.normalize(:kd).gsub(/[^\x00-\x7F]/u,'').downcase.to_s == self.name_was.mb_chars.normalize(:kd).gsub(/[^\x00-\x7F]/u,'').downcase.to_s)
+      unless User.current_user.is_a?(Admin) || (self.name.downcase == self.name_was.downcase) || (self.name.mb_chars.normalize(:kd).gsub(/[\u0300-\u036F]/u,'').downcase.to_s == self.name_was.mb_chars.normalize(:kd).gsub(/[\u0300-\u036F]/u,'').downcase.to_s)
         self.errors.add(:name, "can only be changed by an admin.")
       end
     end

--- a/features/tags_and_wrangling/tag_wrangling_admin.feature
+++ b/features/tags_and_wrangling/tag_wrangling_admin.feature
@@ -16,6 +16,27 @@ Feature: Tag wrangling
       And I should see "Amélie"
       And I should not see "Amelie"
 
+  Scenario: Admin can rename a tag using Eastern characters
+
+  Given I am logged in as an admin
+    And a fandom exists with name: "先生", canonical: false
+  When I edit the tag "先生"
+    And I fill in "Name" with "てりやき"
+    And I press "Save changes"
+  Then I should see "Tag was updated"
+    And I should see "てりやき"
+    And I should not see "先生"
+
+  Scenario: Tag wrangler cannot rename a tag using Eastern characters
+
+  Given I am logged in as a tag wrangler
+    And a fandom exists with name: "先生", canonical: false
+  When I edit the tag "先生"
+    And I fill in "Name" with "てりやき"
+    And I press "Save changes"
+  Then I should not see "Tag was updated"
+    And I should see "Only changes to capitalization and diacritic marks are permitted"
+
   Scenario: Admin can remove a user's wrangling privileges from the manage users page (this will leave assignments intact)
 
     Given the tag wrangler "tangler" with password "wr@ngl3r" is wrangler of "Testing"

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -1,4 +1,4 @@
-# coding: utf-8
+# encoding: UTF-8
 require 'spec_helper'
 
 describe Tag do

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -1,4 +1,4 @@
-# encoding: UTF-8
+# encoding: utf-8
 require 'spec_helper'
 
 describe Tag do
@@ -147,6 +147,16 @@ describe Tag do
         @tag.save
 
         @tag.name = "Weiß Kreuz"
+        @tag.check_synonym
+        expect(@tag.errors).not_to be_empty
+        expect(@tag.save).to be_falsey
+      end
+
+      it "should ignore capitalization of ß" do
+        @tag.name = "Weiß Kreuz"
+        @tag.save
+
+        @tag.name = "WeiSS Kreuz"
         @tag.check_synonym
         expect(@tag.errors).to be_empty
         expect(@tag.save).to be_truthy

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -1,3 +1,4 @@
+# coding: utf-8
 require 'spec_helper'
 
 describe Tag do
@@ -140,17 +141,6 @@ describe Tag do
         tag.check_synonym
         expect(tag.errors).to be_empty
         expect(tag.save).to be_truthy
-      end
-
-      it "is careful with the ß" do
-        tag = Tag.new
-        tag.name = "Wei Kreuz"
-        tag.save
-
-        tag.name = "Weiß Kreuz"
-        tag.check_synonym
-        expect(tag.errors).not_to be_empty
-        expect(tag.save).to be_falsey
       end
 
       it "ignores the capitalization of ß" do

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -1,11 +1,6 @@
-# encoding: utf-8
 require 'spec_helper'
 
 describe Tag do
-  before(:each) do
-    @tag = Tag.new
-  end
-
   after(:each) do
     User.current_user = nil
   end
@@ -84,22 +79,25 @@ describe Tag do
   end
 
   it "should not be valid without a name" do
-    expect(@tag.save).not_to be_truthy
+    tag = Tag.new
+    expect(tag.save).not_to be_truthy
 
-    @tag.name = "something or other"
-    expect(@tag.save).to be_truthy
+    tag.name = "something or other"
+    expect(tag.save).to be_truthy
   end
 
   it "should not be valid if too long" do
-    @tag.name = "a" * 101
-    expect(@tag.save).not_to be_truthy
-    expect(@tag.errors[:name].join).to match(/too long/)
+    tag = Tag.new
+    tag.name = "a" * 101
+    expect(tag.save).not_to be_truthy
+    expect(tag.errors[:name].join).to match(/too long/)
   end
 
   it "should not be valid with disallowed characters" do
-    @tag.name = "bad<tag"
-    expect(@tag.save).to be_falsey
-    expect(@tag.errors[:name].join).to match(/restricted characters/)
+    tag = Tag.new
+    tag.name = "bad<tag"
+    expect(tag.save).to be_falsey
+    expect(tag.errors[:name].join).to match(/restricted characters/)
   end
 
   context "unwrangleable" do
@@ -123,63 +121,69 @@ describe Tag do
       end
 
       it "should ignore capitalisation" do
-        @tag.name = "yuletide"
-        @tag.save
+        tag = Tag.new
+        tag.name = "yuletide"
+        tag.save
 
-        @tag.name = "Yuletide"
-        @tag.check_synonym
-        expect(@tag.errors).to be_empty
-        expect(@tag.save).to be_truthy
+        tag.name = "Yuletide"
+        tag.check_synonym
+        expect(tag.errors).to be_empty
+        expect(tag.save).to be_truthy
       end
 
-      it "should ignore accented characters" do
-        @tag.name = "Amelie"
-        @tag.save
+      it "ignores accented characters" do
+        tag = Tag.new
+        tag.name = "Amelie"
+        tag.save
 
-        @tag.name = "Amélie"
-        @tag.check_synonym
-        expect(@tag.errors).to be_empty
-        expect(@tag.save).to be_truthy
+        tag.name = "Amélie"
+        tag.check_synonym
+        expect(tag.errors).to be_empty
+        expect(tag.save).to be_truthy
       end
 
-      it "should be careful with the ß" do
-        @tag.name = "Wei Kreuz"
-        @tag.save
+      it "is careful with the ß" do
+        tag = Tag.new
+        tag.name = "Wei Kreuz"
+        tag.save
 
-        @tag.name = "Weiß Kreuz"
-        @tag.check_synonym
-        expect(@tag.errors).not_to be_empty
-        expect(@tag.save).to be_falsey
+        tag.name = "Weiß Kreuz"
+        tag.check_synonym
+        expect(tag.errors).not_to be_empty
+        expect(tag.save).to be_falsey
       end
 
-      it "should ignore capitalization of ß" do
-        @tag.name = "Weiß Kreuz"
-        @tag.save
+      it "ignores the capitalization of ß" do
+        tag = Tag.new
+        tag.name = "Weiß Kreuz"
+        tag.save
 
-        @tag.name = "WeiSS Kreuz"
-        @tag.check_synonym
-        expect(@tag.errors).to be_empty
-        expect(@tag.save).to be_truthy
+        tag.name = "WeiSS Kreuz"
+        tag.check_synonym
+        expect(tag.errors).to be_empty
+        expect(tag.save).to be_truthy
       end
 
       it "should not ignore punctuation" do
-        @tag.name = "Snatch."
-        @tag.save
+        tag = Tag.new
+        tag.name = "Snatch."
+        tag.save
 
-        @tag.name = "Snatch"
-        @tag.check_synonym
-        expect(@tag.errors).not_to be_empty
-        expect(@tag.save).to be_falsey
+        tag.name = "Snatch"
+        tag.check_synonym
+        expect(tag.errors).not_to be_empty
+        expect(tag.save).to be_falsey
       end
 
       it "should not ignore whitespace" do
-        @tag.name = "JohnSheppard"
-        @tag.save
+        tag = Tag.new
+        tag.name = "JohnSheppard"
+        tag.save
 
-        @tag.name = "John Sheppard"
-        @tag.check_synonym
-        expect(@tag.errors).not_to be_empty
-        expect(@tag.save).to be_falsey
+        tag.name = "John Sheppard"
+        tag.check_synonym
+        expect(tag.errors).not_to be_empty
+        expect(tag.save).to be_falsey
       end
 
       it 'autocomplete should work' do
@@ -207,13 +211,14 @@ describe Tag do
       end
 
       it "should allow any change" do
-        @tag.name = "yuletide.ssé"
-        @tag.save
+        tag = Tag.new
+        tag.name = "yuletide.ssé"
+        tag.save
 
-        @tag.name = "Yuletide ße something"
-        @tag.check_synonym
-        expect(@tag.errors).to be_empty
-        expect(@tag.save).to be_truthy
+        tag.name = "Yuletide ße something"
+        tag.check_synonym
+        expect(tag.errors).to be_empty
+        expect(tag.save).to be_truthy
       end
     end
   end


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [x] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [x] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [x] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-6188

## Purpose

This PR tightens the overly-broad regex that was being used to compare previous and new names for a tag. Before this pull request, no non-ASCII charactetrs were compared, so a tag wrangler could rewrite "ø" to "てりやき".

Now, only characters that are latin diacritical marks are stripped.

## Testing Instructions

To test this, please try to rename a tag and ensure that, for example, "ø" can be renamed to "o", but not to "てりやき".

## References

There are no other references that I'm aware of.

## Credit

What name and pronouns should we use to credit you in the [Archive of Our Own's Release Notes](https://archiveofourown.org/admin_posts?tag=1)?

Daroc Alden, they/them