### PR TITLE
AO3-6120 Add our IPs and secure URL to PERMITTED_HOSTS to hide proxy notice

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -457,6 +457,9 @@ FILTER_UPDATE_BATCH_SIZE: 100
 # environment.
 PERMITTED_HOSTS: [
   # Production
+  "104.153.64.122",
+  "208.85.241.152",
+  "208.85.241.157",
   "archiveofourown.org",
   "download.archiveofourown.org",
   "insecure.archiveofourown.org",

--- a/config/config.yml
+++ b/config/config.yml
@@ -460,6 +460,7 @@ PERMITTED_HOSTS: [
   "archiveofourown.org",
   "download.archiveofourown.org",
   "insecure.archiveofourown.org",
+  "secure.archiveofourown.org",
   "www.archiveofourown.org",
   # Staging
   "insecure-test.archiveofourown.org",


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [x] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [x] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [x] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-6120

## Purpose

The warning should not occur on https://secure.archiveofourown.org/ 

## Testing Instructions

This can't be tested on staging, apart from noting that we have not got the warning on https://test.archiveofourown.org