### PR TITLE
AO3-5372 Add padding to user bookmarks

### DIFF
--- a/public/stylesheets/site/2.0/13-group-blurb.css
+++ b/public/stylesheets/site/2.0/13-group-blurb.css
@@ -369,6 +369,10 @@ blurbs on the manage collection items pages, mostly reseting styles inherited fr
 	min-height: 30px;
 }
 
+.bookmark .user .heading {
+  margin-top: 0.375em;
+}
+
 .bookmark .user .datetime, .bookmark .work .datetime {
   top: 0;
 }

--- a/public/stylesheets/site/2.0/13-group-blurb.css
+++ b/public/stylesheets/site/2.0/13-group-blurb.css
@@ -334,11 +334,13 @@ blurbs on the manage collection items pages, mostly reseting styles inherited fr
 
 .bookmark div.user, .bookmark div.recent {
   clear: right;
+  box-sizing: border-box;
 }
 
 .bookmark .user {
   border: 1px solid #ccc;
   margin-top: 0.643em;
+  padding: 0.429em 0.75em;
   overflow: hidden;
 }
 
@@ -369,6 +371,11 @@ blurbs on the manage collection items pages, mostly reseting styles inherited fr
 
 .bookmark .user .datetime, .bookmark .work .datetime {
   top: 0;
+}
+
+.bookmark div.user .datetime {
+  top: 0.75em;
+  right: 0.75em;
 }
 
 .bookmark .short .status {


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [x] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [x] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [x] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-5372

## Purpose

This adds padding to the list of bookmarks on the recent bookmarks page `/bookmarks/` and the user bookmarks page `/users/${userName}/bookmarks`.

## Testing Instructions

**New changes:**
1. Go to the `/bookmarks` page. There should be padding within the bookmark so the content isn't directly up against the borders anymore.
2. Go to the bookmark's list for any specific user (`/users/${userName}/bookmarks`). Same check as above ^
3. Bookmark a work. The gray "bookmarked by `{myUsername}`" bookmark should also have padding now.

**Things that should be unchanged:**
1. Go to the bookmarks for any specific work (`works/${workId}/bookmarks`). The padding within those bookmarks should be unchanged.
2. Bookmark a work. Click "Show Most Recent Bookmarks". The padding within those bookmarks should also be unchanged.

## References

Are there other relevant issues/pull requests/mailing list discussions?
Not that I know of.

## Credit

What name and pronouns should we use to credit you in the [Archive of Our Own's Release Notes](https://archiveofourown.org/admin_posts?tag=1)?
Kate Boyd, she/her

This is my first PR to the archive, I appreciate your patience if I've missed a step!
