### PR TITLE
AO3-5926 Fix chapter re-positioning when deleting chapter one

### DIFF
--- a/app/models/chapter.rb
+++ b/app/models/chapter.rb
@@ -85,7 +85,7 @@ class Chapter < ApplicationRecord
   def fix_positions_before_destroy
     if work&.persisted? && position
       chapters = work.chapters.where(["position > ?", position])
-      chapters.each{|c| c.update_attribute(:position, c.position + 1)}
+      chapters.each { |c| c.update_attribute(:position, c.position - 1) }
     end
   end
 


### PR DESCRIPTION
~~I'm pretty sure this is a fix for both issues - I'll do my best in JIRA to make note of that.~~ (Initially thought this would fix 2247 as well, but it doesn't quite cover all edge cases from that issue).

# Pull Request Checklist

* [x] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [x] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [x] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [x] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-5926

## Purpose

This fixes the `fix_positions_before_destroy` method in the `before_destroy` chapter hook to make all subsequent chapters go down one position instead of up one.

**Extra details if anyone is curious:**
I stepped through the code a bit to figure out why this wasn't causing issues when a chapter besides the first one was deleted... as it turns out, the `fix_positions` method called in a chapter's `after_save` hook combined with the `save_chapters` hook on works was doing some self-healing for this mis-positioning, except in the case of the first chapter being destroyed.

The reason chapters were getting swapped when you deleted the first chapter (Issue 2247) was because after `fix_positions_before_destroy` is called, that `fix_positions` method moves the chapter immediately following the deleted one like this: 
```
chapters = chapters - [self]
chapters.insert(self.position-1, self)
```

So if you've deleted chapter 1, the new chapter 1/old chapter2 was having its position bumped up to 3. So when `fix_positions` did that `.insert`, it was putting chapter 2 at `chapters[2]`, when it should be put at `[0]`, so it was swapping places with the chapter right after it. This wasn't a problem for deleting mid-work chapters, since essentially there was an empty space before the subsequent chapters. 


## Testing Instructions

How can the Archive's QA team verify that this is working as you intended?

Testing instructions are in the JIRA issue.

## References

Are there other relevant issues/pull requests/mailing list discussions?
https://otwarchive.atlassian.net/browse/AO3-2247

## Credit

What name and pronouns should we use to credit you in the [Archive of Our Own's Release Notes](https://archiveofourown.org/admin_posts?tag=1)?

Kate Boyd, she/her
