### PR TITLE
AO3-6234 Update Brakeman ignore file

### DIFF
--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -29,7 +29,7 @@
       "line": 14,
       "link": "http://brakemanscanner.org/docs/warning_types/dynamic_render_path/",
       "code": "render(action => (Work.find_by(:id => params[:work_id]) or Chapter.find_by(:id => params[:id]).work).chapters.find_by(:id => params[:id]), {})",
-      "render_path": [{"type":"controller","class":"ChaptersController","method":"update","line":154,"file":"app/controllers/chapters_controller.rb"}],
+      "render_path": [{"type":"controller","class":"ChaptersController","method":"update","line":157,"file":"app/controllers/chapters_controller.rb"}],
       "location": {
         "type": "template",
         "template": "chapters/preview"
@@ -67,7 +67,7 @@
       "line": 6,
       "link": "http://brakemanscanner.org/docs/warning_types/cross_site_scripting",
       "code": "strip_tags(WorkSearchForm.new((clean_work_search_params or {})).summary)",
-      "render_path": [{"type":"controller","class":"WorksController","method":"search","line":43,"file":"app/controllers/works_controller.rb"}],
+      "render_path": [{"type":"controller","class":"WorksController","method":"search","line":45,"file":"app/controllers/works_controller.rb"}],
       "location": {
         "type": "template",
         "template": "works/search_results"
@@ -86,31 +86,12 @@
       "line": 6,
       "link": "http://brakemanscanner.org/docs/warning_types/cross_site_scripting",
       "code": "ts(\"Are you sure you want to <strong><em>delete</em></strong> %{chapter_number} of %{work_title}? This will delete all comments on the chapter as well and cannot be undone!\", :chapter_number => (Work.find_by(:id => params[:work_id]) or Chapter.find_by(:id => params[:id]).work).chapters.find_by(:id => params[:id]).chapter_header, :work_title => (Work.find_by(:id => params[:work_id]) or Chapter.find_by(:id => params[:id]).work).title)",
-      "render_path": [{"type":"controller","class":"ChaptersController","method":"confirm_delete","line":211,"file":"app/controllers/chapters_controller.rb"}],
+      "render_path": [{"type":"controller","class":"ChaptersController","method":"confirm_delete","line":214,"file":"app/controllers/chapters_controller.rb"}],
       "location": {
         "type": "template",
         "template": "chapters/confirm_delete"
       },
       "user_input": "Work.find_by(:id => params[:work_id])",
-      "confidence": "Weak",
-      "note": ""
-    },
-    {
-      "warning_type": "Cross Site Scripting",
-      "warning_code": 2,
-      "fingerprint": "04a2dece009c698540960269d024b874a42b71cf8e06e3216c41f8807e57f9b9",
-      "check_name": "CrossSiteScripting",
-      "message": "Unescaped model attribute",
-      "file": "app/views/kudos/index.html.erb",
-      "line": 9,
-      "link": "http://brakemanscanner.org/docs/warning_types/cross_site_scripting",
-      "code": "Work.find(params[:work_id]).kudos.includes(:user).with_user.map do\n link_to(kudo.user.login, kudo.user)\n end.to_sentence",
-      "render_path": [{"type":"controller","class":"KudosController","method":"index","line":11,"file":"app/controllers/kudos_controller.rb"}],
-      "location": {
-        "type": "template",
-        "template": "kudos/index"
-      },
-      "user_input": "Work.find(params[:work_id]).kudos",
       "confidence": "Weak",
       "note": ""
     },
@@ -160,10 +141,10 @@
       "check_name": "CrossSiteScripting",
       "message": "Unescaped model attribute",
       "file": "app/views/tags/show.html.erb",
-      "line": 61,
+      "line": 59,
       "link": "http://brakemanscanner.org/docs/warning_types/cross_site_scripting",
       "code": "ts(\"%{tag_name} has been made a synonym of %{tag_synonym_link}. Works and bookmarks tagged with %{tag_name} will show up in %{tag_synonym}'s filter.\", :tag_name => Tag.includes(:direct_sub_tags).find_by_name(params[:id]).name, :tag_synonym_link => link_to_tag(Tag.includes(:direct_sub_tags).find_by_name(params[:id]).merger), :tag_synonym => Tag.includes(:direct_sub_tags).find_by_name(params[:id]).merger.name)",
-      "render_path": [{"type":"controller","class":"TagsController","method":"show","line":101,"file":"app/controllers/tags_controller.rb"}],
+      "render_path": [{"type":"controller","class":"TagsController","method":"show","line":82,"file":"app/controllers/tags_controller.rb"}],
       "location": {
         "type": "template",
         "template": "tags/show"
@@ -201,7 +182,7 @@
       "line": 30,
       "link": "http://brakemanscanner.org/docs/warning_types/cross_site_scripting",
       "code": "byline((Work.find_by(:id => params[:work_id]) or Chapter.find_by(:id => params[:id]).work).chapters.find_by(:id => params[:id]))",
-      "render_path": [{"type":"controller","class":"ChaptersController","method":"show","line":77,"file":"app/controllers/chapters_controller.rb"},{"type":"template","name":"chapters/show","line":28,"file":"app/views/chapters/show.html.erb"}],
+      "render_path": [{"type":"controller","class":"ChaptersController","method":"show","line":76,"file":"app/controllers/chapters_controller.rb"},{"type":"template","name":"chapters/show","line":28,"file":"app/views/chapters/show.html.erb"}],
       "location": {
         "type": "template",
         "template": "chapters/_chapter"
@@ -220,7 +201,7 @@
       "line": 29,
       "link": "http://brakemanscanner.org/docs/warning_types/cross_site_scripting",
       "code": "(Work.find_by(:id => params[:work_id]) or Chapter.find_by(:id => params[:id]).work).title",
-      "render_path": [{"type":"controller","class":"ChaptersController","method":"show","line":77,"file":"app/controllers/chapters_controller.rb"},{"type":"template","name":"chapters/show","line":25,"file":"app/views/chapters/show.html.erb"}],
+      "render_path": [{"type":"controller","class":"ChaptersController","method":"show","line":76,"file":"app/controllers/chapters_controller.rb"},{"type":"template","name":"chapters/show","line":25,"file":"app/views/chapters/show.html.erb"}],
       "location": {
         "type": "template",
         "template": "works/_work_header"
@@ -239,7 +220,7 @@
       "line": 4,
       "link": "http://brakemanscanner.org/docs/warning_types/cross_site_scripting",
       "code": "sanitize_field((Work.find_by(:id => params[:work_id]) or Chapter.find_by(:id => params[:id]).work), :endnotes)",
-      "render_path": [{"type":"controller","class":"ChaptersController","method":"show","line":77,"file":"app/controllers/chapters_controller.rb"},{"type":"template","name":"chapters/show","line":37,"file":"app/views/chapters/show.html.erb"}],
+      "render_path": [{"type":"controller","class":"ChaptersController","method":"show","line":76,"file":"app/controllers/chapters_controller.rb"},{"type":"template","name":"chapters/show","line":37,"file":"app/views/chapters/show.html.erb"}],
       "location": {
         "type": "template",
         "template": "works/_work_endnotes"
@@ -258,7 +239,7 @@
       "line": 32,
       "link": "http://brakemanscanner.org/docs/warning_types/cross_site_scripting",
       "code": "byline((Work.find_by(:id => params[:work_id]) or Chapter.find_by(:id => params[:id]).work))",
-      "render_path": [{"type":"controller","class":"ChaptersController","method":"show","line":77,"file":"app/controllers/chapters_controller.rb"},{"type":"template","name":"chapters/show","line":25,"file":"app/views/chapters/show.html.erb"}],
+      "render_path": [{"type":"controller","class":"ChaptersController","method":"show","line":76,"file":"app/controllers/chapters_controller.rb"},{"type":"template","name":"chapters/show","line":25,"file":"app/views/chapters/show.html.erb"}],
       "location": {
         "type": "template",
         "template": "works/_work_header"
@@ -315,7 +296,7 @@
       "line": 16,
       "link": "http://brakemanscanner.org/docs/warning_types/cross_site_scripting",
       "code": "sanitize_field(Work.find_by(:id => params[:id]).first_chapter, :content)",
-      "render_path": [{"type":"controller","class":"WorksController","method":"update","line":370,"file":"app/controllers/works_controller.rb"}],
+      "render_path": [{"type":"controller","class":"WorksController","method":"update","line":387,"file":"app/controllers/works_controller.rb"}],
       "location": {
         "type": "template",
         "template": "works/preview"
@@ -331,7 +312,7 @@
       "check_name": "FileAccess",
       "message": "Model attribute used in file name",
       "file": "app/models/skin.rb",
-      "line": 459,
+      "line": 483,
       "link": "http://brakemanscanner.org/docs/warning_types/file_access/",
       "code": "File.open((\"#{(Skin.site_skins_dir + version)}/\" + \"preview.png\"), \"rb\")",
       "render_path": null,
@@ -351,7 +332,7 @@
       "check_name": "FileAccess",
       "message": "Model attribute used in file name",
       "file": "app/models/skin.rb",
-      "line": 473,
+      "line": 497,
       "link": "http://brakemanscanner.org/docs/warning_types/file_access/",
       "code": "File.open((\"#{(Skin.site_skins_dir + version)}/\" + \"preview.png\"), \"rb\")",
       "render_path": null,
@@ -409,7 +390,7 @@
       "check_name": "Redirect",
       "message": "Possible unprotected redirect",
       "file": "app/controllers/admin/user_creations_controller.rb",
-      "line": 15,
+      "line": 14,
       "link": "http://brakemanscanner.org/docs/warning_types/redirect/",
       "code": "redirect_to(params[:creation_type].constantize.find(params[:id]))",
       "render_path": null,
@@ -471,7 +452,7 @@
       "line": 42,
       "link": "http://brakemanscanner.org/docs/warning_types/cross_site_scripting",
       "code": "sanitize_field((Work.find_by(:id => params[:work_id]) or Chapter.find_by(:id => params[:id]).work), :summary)",
-      "render_path": [{"type":"controller","class":"ChaptersController","method":"show","line":77,"file":"app/controllers/chapters_controller.rb"},{"type":"template","name":"chapters/show","line":25,"file":"app/views/chapters/show.html.erb"}],
+      "render_path": [{"type":"controller","class":"ChaptersController","method":"show","line":76,"file":"app/controllers/chapters_controller.rb"},{"type":"template","name":"chapters/show","line":25,"file":"app/views/chapters/show.html.erb"}],
       "location": {
         "type": "template",
         "template": "works/_work_header"
@@ -490,7 +471,7 @@
       "line": 67,
       "link": "http://brakemanscanner.org/docs/warning_types/cross_site_scripting",
       "code": "sanitize_field((Work.find_by(:id => params[:work_id]) or Chapter.find_by(:id => params[:id]).work).chapters.find_by(:id => params[:id]), :content)",
-      "render_path": [{"type":"controller","class":"ChaptersController","method":"show","line":77,"file":"app/controllers/chapters_controller.rb"},{"type":"template","name":"chapters/show","line":28,"file":"app/views/chapters/show.html.erb"}],
+      "render_path": [{"type":"controller","class":"ChaptersController","method":"show","line":76,"file":"app/controllers/chapters_controller.rb"},{"type":"template","name":"chapters/show","line":28,"file":"app/views/chapters/show.html.erb"}],
       "location": {
         "type": "template",
         "template": "chapters/_chapter"
@@ -506,7 +487,7 @@
       "check_name": "CrossSiteScripting",
       "message": "Unescaped model attribute",
       "file": "app/views/profile/show.html.erb",
-      "line": 33,
+      "line": 35,
       "link": "http://brakemanscanner.org/docs/warning_types/cross_site_scripting",
       "code": "sanitize_field(User.find_by(:login => params[:user_id]).profile, :about_me)",
       "render_path": [{"type":"controller","class":"ProfileController","method":"show","line":19,"file":"app/controllers/profile_controller.rb"}],
@@ -565,7 +546,7 @@
       "check_name": "Redirect",
       "message": "Possible unprotected redirect",
       "file": "app/controllers/admin/user_creations_controller.rb",
-      "line": 49,
+      "line": 50,
       "link": "http://brakemanscanner.org/docs/warning_types/redirect/",
       "code": "redirect_to(params[:creation_type].constantize.find(params[:id]))",
       "render_path": null,
@@ -598,26 +579,6 @@
       "note": ""
     },
     {
-      "warning_type": "File Access",
-      "warning_code": 16,
-      "fingerprint": "45047b931fdb5049a943a5fbfa62ae077a8d457db6ba924db6792fd3e404ec12",
-      "check_name": "FileAccess",
-      "message": "Model attribute used in file name",
-      "file": "app/models/skin.rb",
-      "line": 530,
-      "link": "http://brakemanscanner.org/docs/warning_types/file_access/",
-      "code": "File.open((Skin.site_skins_dir + \"preview.png\"), \"rb\")",
-      "render_path": null,
-      "location": {
-        "type": "method",
-        "class": "Skin",
-        "method": "Skin.create_default"
-      },
-      "user_input": "(Skin.site_skins_dir + \"preview.png\")",
-      "confidence": "Medium",
-      "note": ""
-    },
-    {
       "warning_type": "Cross Site Scripting",
       "warning_code": 2,
       "fingerprint": "46d7eea8c73d9c056352e5fad23fb8348c3ffaae2490e2ce01eeb2c3779ca47c",
@@ -646,7 +607,7 @@
       "line": 70,
       "link": "http://brakemanscanner.org/docs/warning_types/cross_site_scripting",
       "code": "sanitize_field((Work.find_by(:id => params[:work_id]) or Chapter.find_by(:id => params[:id]).work), :notes)",
-      "render_path": [{"type":"controller","class":"ChaptersController","method":"show","line":77,"file":"app/controllers/chapters_controller.rb"},{"type":"template","name":"chapters/show","line":25,"file":"app/views/chapters/show.html.erb"},{"type":"template","name":"works/_work_header","line":49,"file":"app/views/works/_work_header.html.erb"}],
+      "render_path": [{"type":"controller","class":"ChaptersController","method":"show","line":76,"file":"app/controllers/chapters_controller.rb"},{"type":"template","name":"chapters/show","line":25,"file":"app/views/chapters/show.html.erb"},{"type":"template","name":"works/_work_header","line":49,"file":"app/views/works/_work_header.html.erb"}],
       "location": {
         "type": "template",
         "template": "works/_work_header_notes"
@@ -722,7 +683,7 @@
       "line": 13,
       "link": "http://brakemanscanner.org/docs/warning_types/cross_site_scripting",
       "code": "ts(\"Are you sure you want to <strong><em>purge</em></strong> all assignments for\\n           %{collection_title}? This <strong>cannot be undone</strong>. Please only do \\n           this if you absolutely must!\", :collection_title => Collection.find_by(:name => params[:collection_id]).title)",
-      "render_path": [{"type":"controller","class":"ChallengeAssignmentsController","method":"confirm_purge","line":186,"file":"app/controllers/challenge_assignments_controller.rb"}],
+      "render_path": [{"type":"controller","class":"ChallengeAssignmentsController","method":"confirm_purge","line":162,"file":"app/controllers/challenge_assignments_controller.rb"}],
       "location": {
         "type": "template",
         "template": "challenge_assignments/confirm_purge"
@@ -760,7 +721,7 @@
       "line": 6,
       "link": "http://brakemanscanner.org/docs/warning_types/cross_site_scripting",
       "code": "ts(\"Edit Work Tags for %{title}\", :title => Work.find_by(:id => params[:id]).title)",
-      "render_path": [{"type":"controller","class":"WorksController","method":"edit_tags","line":342,"file":"app/controllers/works_controller.rb"}],
+      "render_path": [{"type":"controller","class":"WorksController","method":"edit_tags","line":360,"file":"app/controllers/works_controller.rb"}],
       "location": {
         "type": "template",
         "template": "works/edit_tags"
@@ -776,7 +737,7 @@
       "check_name": "UnsafeReflection",
       "message": "Unsafe reflection method constantize called with parameter value",
       "file": "app/controllers/admin/user_creations_controller.rb",
-      "line": 8,
+      "line": 7,
       "link": "http://brakemanscanner.org/docs/warning_types/remote_code_execution/",
       "code": "params[:creation_type].constantize",
       "render_path": null,
@@ -819,7 +780,7 @@
       "line": 76,
       "link": "http://brakemanscanner.org/docs/warning_types/cross_site_scripting",
       "code": "User.for_claims(prompt.unfulfilled_claims.pluck(:id)).pluck(:login).map do\n content_tag(:li, user)\n end.join(\"\\n\")",
-      "render_path": [{"type":"controller","class":"ChallengeAssignmentsController","method":"show","line":146,"file":"app/controllers/challenge_assignments_controller.rb"},{"type":"template","name":"challenge_assignments/show","line":26,"file":"app/views/challenge_assignments/show.html.erb"},{"type":"template","name":"challenge_signups/_show_requests","line":19,"file":"app/views/challenge_signups/_show_requests.html.erb"}],
+      "render_path": [{"type":"controller","class":"ChallengeAssignmentsController","method":"show","line":115,"file":"app/controllers/challenge_assignments_controller.rb"},{"type":"template","name":"challenge_assignments/show","line":26,"file":"app/views/challenge_assignments/show.html.erb"},{"type":"template","name":"challenge_signups/_show_requests","line":19,"file":"app/views/challenge_signups/_show_requests.html.erb"}],
       "location": {
         "type": "template",
         "template": "prompts/_prompt_blurb"
@@ -857,7 +818,7 @@
       "line": 40,
       "link": "http://brakemanscanner.org/docs/warning_types/cross_site_scripting",
       "code": "strip_images(sanitize_field((Work.find(params[:work_id]) or (Chapter.find(params[:chapter_id]).work or (ExternalWork.find(params[:external_work_id]) or Series.find(params[:series_id])))), :summary))",
-      "render_path": [{"type":"controller","class":"BookmarksController","method":"index","line":148,"file":"app/controllers/bookmarks_controller.rb"},{"type":"template","name":"bookmarks/index","line":59,"file":"app/views/bookmarks/index.html.erb"},{"type":"template","name":"bookmarks/_bookmarks","line":23,"file":"app/views/bookmarks/_bookmarks.html.erb"},{"type":"template","name":"bookmarks/_bookmarkable_blurb","line":13,"file":"app/views/bookmarks/_bookmarkable_blurb.html.erb"},{"type":"template","name":"bookmarks/_bookmark_item_module","line":3,"file":"app/views/bookmarks/_bookmark_item_module.html.erb"}],
+      "render_path": [{"type":"controller","class":"BookmarksController","method":"index","line":150,"file":"app/controllers/bookmarks_controller.rb"},{"type":"template","name":"bookmarks/index","line":59,"file":"app/views/bookmarks/index.html.erb"},{"type":"template","name":"bookmarks/_bookmarks","line":23,"file":"app/views/bookmarks/_bookmarks.html.erb"},{"type":"template","name":"bookmarks/_bookmarkable_blurb","line":13,"file":"app/views/bookmarks/_bookmarkable_blurb.html.erb"},{"type":"template","name":"bookmarks/_bookmark_item_module","line":3,"file":"app/views/bookmarks/_bookmark_item_module.html.erb"}],
       "location": {
         "type": "template",
         "template": "external_works/_work_module"
@@ -953,7 +914,7 @@
       "line": 52,
       "link": "http://brakemanscanner.org/docs/warning_types/cross_site_scripting",
       "code": "sanitize_field((Work.find_by(:id => params[:work_id]) or Chapter.find_by(:id => params[:id]).work).chapters.find_by(:id => params[:id]), :notes)",
-      "render_path": [{"type":"controller","class":"ChaptersController","method":"show","line":77,"file":"app/controllers/chapters_controller.rb"},{"type":"template","name":"chapters/show","line":28,"file":"app/views/chapters/show.html.erb"}],
+      "render_path": [{"type":"controller","class":"ChaptersController","method":"show","line":76,"file":"app/controllers/chapters_controller.rb"},{"type":"template","name":"chapters/show","line":28,"file":"app/views/chapters/show.html.erb"}],
       "location": {
         "type": "template",
         "template": "chapters/_chapter"
@@ -1008,7 +969,7 @@
       "check_name": "ValidationRegex",
       "message": "Insufficient validation for 'name' using /\\p{Alnum}/. Use \\A and \\z as anchors",
       "file": "app/models/pseud.rb",
-      "line": 66,
+      "line": 69,
       "link": "http://brakemanscanner.org/docs/warning_types/format_validation/",
       "code": null,
       "render_path": null,
@@ -1049,7 +1010,7 @@
       "line": 34,
       "link": "http://brakemanscanner.org/docs/warning_types/cross_site_scripting",
       "code": "sanitize_field((Unresolved Model).new, :bookmarker_notes)",
-      "render_path": [{"type":"controller","class":"BookmarksController","method":"index","line":148,"file":"app/controllers/bookmarks_controller.rb"},{"type":"template","name":"bookmarks/index","line":59,"file":"app/views/bookmarks/index.html.erb"},{"type":"template","name":"bookmarks/_bookmarks","line":14,"file":"app/views/bookmarks/_bookmarks.html.erb"}],
+      "render_path": [{"type":"controller","class":"BookmarksController","method":"index","line":150,"file":"app/controllers/bookmarks_controller.rb"},{"type":"template","name":"bookmarks/index","line":59,"file":"app/views/bookmarks/index.html.erb"},{"type":"template","name":"bookmarks/_bookmarks","line":14,"file":"app/views/bookmarks/_bookmarks.html.erb"}],
       "location": {
         "type": "template",
         "template": "bookmarks/_bookmark_blurb_short"
@@ -1065,7 +1026,7 @@
       "check_name": "FileAccess",
       "message": "Model attribute used in file name",
       "file": "app/models/skin.rb",
-      "line": 427,
+      "line": 451,
       "link": "http://brakemanscanner.org/docs/warning_types/file_access/",
       "code": "File.open((\"#{(Skin.site_skins_dir + version)}/\" + skin_file), &:readline)",
       "render_path": null,
@@ -1107,7 +1068,7 @@
       "line": 7,
       "link": "http://brakemanscanner.org/docs/warning_types/cross_site_scripting",
       "code": "ts(\"Are you sure you want to <strong><em>delete</em></strong> \\\"%{work_title}\\\" <strong><em>permanently</em></strong>? This <strong>cannot be undone</strong>.\", :work_title => Work.find_by(:id => params[:id]).title)",
-      "render_path": [{"type":"controller","class":"WorksController","method":"confirm_delete","line":428,"file":"app/controllers/works_controller.rb"}],
+      "render_path": [{"type":"controller","class":"WorksController","method":"confirm_delete","line":445,"file":"app/controllers/works_controller.rb"}],
       "location": {
         "type": "template",
         "template": "works/confirm_delete"
@@ -1123,10 +1084,10 @@
       "check_name": "CrossSiteScripting",
       "message": "Unescaped model attribute",
       "file": "app/views/series/show.html.erb",
-      "line": 47,
+      "line": 51,
       "link": "http://brakemanscanner.org/docs/warning_types/cross_site_scripting",
       "code": "sanitize_field(Series.find_by(:id => params[:id]), :summary)",
-      "render_path": [{"type":"controller","class":"SeriesController","method":"show","line":57,"file":"app/controllers/series_controller.rb"}],
+      "render_path": [{"type":"controller","class":"SeriesController","method":"show","line":55,"file":"app/controllers/series_controller.rb"}],
       "location": {
         "type": "template",
         "template": "series/show"
@@ -1145,7 +1106,7 @@
       "line": 9,
       "link": "http://brakemanscanner.org/docs/warning_types/cross_site_scripting",
       "code": "sanitize_field((AdminBanner.where(:active => true).last or (Rails.cache.fetch(\"admin_banner\") do\n banner = AdminBanner.where(:active => true).last\nif AdminBanner.where(:active => true).last.nil? then\n  \"\"\nelse\n  AdminBanner.where(:active => true).last\nend\n end or nil)), :content)",
-      "render_path": [{"type":"controller","class":"AbuseReportsController","method":"new","line":13,"file":"app/controllers/abuse_reports_controller.rb"},{"type":"template","name":"layouts/application","line":41,"file":"app/views/layouts/application.html.erb"},{"type":"template","name":"layouts/_header","line":77,"file":"app/views/layouts/_header.html.erb"}],
+      "render_path": [{"type":"controller","class":"AbuseReportsController","method":"new","line":13,"file":"app/controllers/abuse_reports_controller.rb"},{"type":"template","name":"layouts/application","line":42,"file":"app/views/layouts/application.html.erb"},{"type":"template","name":"layouts/_header","line":77,"file":"app/views/layouts/_header.html.erb"}],
       "location": {
         "type": "template",
         "template": "layouts/_banner"
@@ -1161,7 +1122,7 @@
       "check_name": "MassAssignment",
       "message": "Parameters should be whitelisted for mass assignment",
       "file": "app/controllers/comments_controller.rb",
-      "line": 584,
+      "line": 634,
       "link": "http://brakemanscanner.org/docs/warning_types/mass_assignment/",
       "code": "params.permit!",
       "render_path": null,
@@ -1181,7 +1142,7 @@
       "check_name": "Redirect",
       "message": "Possible unprotected redirect",
       "file": "app/controllers/admin/user_creations_controller.rb",
-      "line": 57,
+      "line": 59,
       "link": "http://brakemanscanner.org/docs/warning_types/redirect/",
       "code": "redirect_to(params[:creation_type].constantize.find(params[:id]).ultimate_parent)",
       "render_path": null,
@@ -1220,7 +1181,7 @@
       "check_name": "ValidationRegex",
       "message": "Insufficient validation for 'header_image_url' using /\\.(png|gif|jpg)$/. Use \\A and \\z as anchors",
       "file": "app/models/collection.rb",
-      "line": 162,
+      "line": 160,
       "link": "http://brakemanscanner.org/docs/warning_types/format_validation/",
       "code": null,
       "render_path": null,
@@ -1278,10 +1239,10 @@
       "check_name": "CrossSiteScripting",
       "message": "Unescaped model attribute",
       "file": "app/views/works/show.html.erb",
-      "line": 51,
+      "line": 48,
       "link": "http://brakemanscanner.org/docs/warning_types/cross_site_scripting",
       "code": "sanitize_field(Work.find_by(:id => params[:id]).first_chapter, :content)",
-      "render_path": [{"type":"controller","class":"WorksController","method":"show","line":222,"file":"app/controllers/works_controller.rb"}],
+      "render_path": [{"type":"controller","class":"WorksController","method":"show","line":221,"file":"app/controllers/works_controller.rb"}],
       "location": {
         "type": "template",
         "template": "works/show"
@@ -1297,10 +1258,10 @@
       "check_name": "CrossSiteScripting",
       "message": "Unescaped model attribute",
       "file": "app/views/series/show.html.erb",
-      "line": 51,
+      "line": 55,
       "link": "http://brakemanscanner.org/docs/warning_types/cross_site_scripting",
       "code": "sanitize_field(Series.find_by(:id => params[:id]), :series_notes)",
-      "render_path": [{"type":"controller","class":"SeriesController","method":"show","line":57,"file":"app/controllers/series_controller.rb"}],
+      "render_path": [{"type":"controller","class":"SeriesController","method":"show","line":55,"file":"app/controllers/series_controller.rb"}],
       "location": {
         "type": "template",
         "template": "series/show"
@@ -1316,7 +1277,7 @@
       "check_name": "FileAccess",
       "message": "Model attribute used in file name",
       "file": "app/models/skin.rb",
-      "line": 223,
+      "line": 240,
       "link": "http://brakemanscanner.org/docs/warning_types/file_access/",
       "code": "FileUtils.mkdir_p((Skin.skins_dir + skin_dirname))",
       "render_path": null,
@@ -1336,7 +1297,7 @@
       "check_name": "FileAccess",
       "message": "Model attribute used in file name",
       "file": "app/models/skin.rb",
-      "line": 249,
+      "line": 266,
       "link": "http://brakemanscanner.org/docs/warning_types/file_access/",
       "code": "FileUtils.rm_rf((Skin.skins_dir + skin_dirname))",
       "render_path": null,
@@ -1395,7 +1356,7 @@
       "check_name": "FileAccess",
       "message": "Model attribute used in file name",
       "file": "app/models/skin.rb",
-      "line": 240,
+      "line": 257,
       "link": "http://brakemanscanner.org/docs/warning_types/file_access/",
       "code": "File.open(((Skin.skins_dir + skin_dirname) + \"#{2}_#{(\"\" or next_skin.get_sheet_role)}.css\"), \"w\")",
       "render_path": null,
@@ -1456,7 +1417,7 @@
       "line": 14,
       "link": "http://brakemanscanner.org/docs/warning_types/cross_site_scripting",
       "code": "Work.find_by(:id => params[:id]).collections.unrevealed.collect do\n link_to(challenge.title, collection_path(challenge))\n end.join(\", \")",
-      "render_path": [{"type":"controller","class":"WorksController","method":"show","line":222,"file":"app/controllers/works_controller.rb"}],
+      "render_path": [{"type":"controller","class":"WorksController","method":"show","line":221,"file":"app/controllers/works_controller.rb"}],
       "location": {
         "type": "template",
         "template": "works/show"
@@ -1572,7 +1533,7 @@
       "line": 39,
       "link": "http://brakemanscanner.org/docs/warning_types/cross_site_scripting",
       "code": "sanitize_field((Work.find_by(:id => params[:work_id]) or Chapter.find_by(:id => params[:id]).work).chapters.find_by(:id => params[:id]), :summary)",
-      "render_path": [{"type":"controller","class":"ChaptersController","method":"show","line":77,"file":"app/controllers/chapters_controller.rb"},{"type":"template","name":"chapters/show","line":28,"file":"app/views/chapters/show.html.erb"}],
+      "render_path": [{"type":"controller","class":"ChaptersController","method":"show","line":76,"file":"app/controllers/chapters_controller.rb"},{"type":"template","name":"chapters/show","line":28,"file":"app/views/chapters/show.html.erb"}],
       "location": {
         "type": "template",
         "template": "chapters/_chapter"
@@ -1591,7 +1552,7 @@
       "line": 3,
       "link": "http://brakemanscanner.org/docs/warning_types/cross_site_scripting",
       "code": "ts(\"%{title} skin by %{creator}\", :title => Skin.find_by(:id => params[:id]).title, :creator => skin_author_link(Skin.find_by(:id => params[:id])))",
-      "render_path": [{"type":"controller","class":"SkinsController","method":"show","line":48,"file":"app/controllers/skins_controller.rb"},{"type":"template","name":"skins/show","line":4,"file":"app/views/skins/show.html.erb"}],
+      "render_path": [{"type":"controller","class":"SkinsController","method":"show","line":50,"file":"app/controllers/skins_controller.rb"},{"type":"template","name":"skins/show","line":4,"file":"app/views/skins/show.html.erb"}],
       "location": {
         "type": "template",
         "template": "skins/_header"
@@ -1610,7 +1571,7 @@
       "line": 5,
       "link": "http://brakemanscanner.org/docs/warning_types/cross_site_scripting",
       "code": "(Work.find_by(:id => params[:work_id]) or Chapter.find_by(:id => params[:id]).work).collections.unrevealed.collect do\n link_to(challenge.title, collection_path(challenge))\n end.join(\", \")",
-      "render_path": [{"type":"controller","class":"ChaptersController","method":"show","line":77,"file":"app/controllers/chapters_controller.rb"}],
+      "render_path": [{"type":"controller","class":"ChaptersController","method":"show","line":76,"file":"app/controllers/chapters_controller.rb"}],
       "location": {
         "type": "template",
         "template": "chapters/show"
@@ -1649,7 +1610,7 @@
       "line": 3,
       "link": "http://brakemanscanner.org/docs/warning_types/cross_site_scripting",
       "code": "(Work.find_by(:id => params[:work_id]) or Chapter.find_by(:id => params[:id]).work).title",
-      "render_path": [{"type":"controller","class":"ChaptersController","method":"create","line":114,"file":"app/controllers/chapters_controller.rb"}],
+      "render_path": [{"type":"controller","class":"ChaptersController","method":"create","line":117,"file":"app/controllers/chapters_controller.rb"}],
       "location": {
         "type": "template",
         "template": "chapters/new"
@@ -1668,7 +1629,7 @@
       "line": 18,
       "link": "http://brakemanscanner.org/docs/warning_types/cross_site_scripting",
       "code": "(Work.find(params[:work_id]) or (Chapter.find(params[:chapter_id]).work or (ExternalWork.find(params[:external_work_id]) or Series.find(params[:series_id])))).tag_groups[\"Fandom\"].collect do\n link_to_tag_works(tag)\n end.join(\", \")",
-      "render_path": [{"type":"controller","class":"BookmarksController","method":"index","line":148,"file":"app/controllers/bookmarks_controller.rb"},{"type":"template","name":"bookmarks/index","line":59,"file":"app/views/bookmarks/index.html.erb"},{"type":"template","name":"bookmarks/_bookmarks","line":23,"file":"app/views/bookmarks/_bookmarks.html.erb"},{"type":"template","name":"bookmarks/_bookmarkable_blurb","line":13,"file":"app/views/bookmarks/_bookmarkable_blurb.html.erb"},{"type":"template","name":"bookmarks/_bookmark_item_module","line":3,"file":"app/views/bookmarks/_bookmark_item_module.html.erb"}],
+      "render_path": [{"type":"controller","class":"BookmarksController","method":"index","line":150,"file":"app/controllers/bookmarks_controller.rb"},{"type":"template","name":"bookmarks/index","line":59,"file":"app/views/bookmarks/index.html.erb"},{"type":"template","name":"bookmarks/_bookmarks","line":23,"file":"app/views/bookmarks/_bookmarks.html.erb"},{"type":"template","name":"bookmarks/_bookmarkable_blurb","line":13,"file":"app/views/bookmarks/_bookmarkable_blurb.html.erb"},{"type":"template","name":"bookmarks/_bookmark_item_module","line":3,"file":"app/views/bookmarks/_bookmark_item_module.html.erb"}],
       "location": {
         "type": "template",
         "template": "external_works/_work_module"
@@ -1723,10 +1684,10 @@
       "check_name": "LinkToHref",
       "message": "Unsafe model attribute in link_to href",
       "file": "app/views/works/_work_header_navigation.html.erb",
-      "line": 117,
+      "line": 116,
       "link": "http://brakemanscanner.org/docs/warning_types/link_to_href",
       "code": "link_to(ts(format.upcase), download_url_for_work((Work.find_by(:id => params[:work_id]) or Chapter.find_by(:id => params[:id]).work), format))",
-      "render_path": [{"type":"controller","class":"ChaptersController","method":"show","line":77,"file":"app/controllers/chapters_controller.rb"},{"type":"template","name":"chapters/show","line":25,"file":"app/views/chapters/show.html.erb"},{"type":"template","name":"works/_work_header","line":2,"file":"app/views/works/_work_header.html.erb"}],
+      "render_path": [{"type":"controller","class":"ChaptersController","method":"show","line":76,"file":"app/controllers/chapters_controller.rb"},{"type":"template","name":"chapters/show","line":25,"file":"app/views/chapters/show.html.erb"},{"type":"template","name":"works/_work_header","line":2,"file":"app/views/works/_work_header.html.erb"}],
       "location": {
         "type": "template",
         "template": "works/_work_header_navigation"
@@ -1764,7 +1725,7 @@
       "line": 24,
       "link": "http://brakemanscanner.org/docs/warning_types/cross_site_scripting",
       "code": "(Work.find_by(:id => params[:work_id]) or Chapter.find_by(:id => params[:id]).work).chapters.find_by(:id => params[:id]).title",
-      "render_path": [{"type":"controller","class":"ChaptersController","method":"show","line":77,"file":"app/controllers/chapters_controller.rb"},{"type":"template","name":"chapters/show","line":28,"file":"app/views/chapters/show.html.erb"}],
+      "render_path": [{"type":"controller","class":"ChaptersController","method":"show","line":76,"file":"app/controllers/chapters_controller.rb"},{"type":"template","name":"chapters/show","line":28,"file":"app/views/chapters/show.html.erb"}],
       "location": {
         "type": "template",
         "template": "chapters/_chapter"
@@ -1783,7 +1744,7 @@
       "line": 10,
       "link": "http://brakemanscanner.org/docs/warning_types/cross_site_scripting",
       "code": "ts(\"Are you sure you want to <strong><em>delete</em></strong> your bookmark of \\\"%{bookmarkable}\\\"?\", :bookmarkable => Bookmark.find(params[:id]).bookmarkable.title)",
-      "render_path": [{"type":"controller","class":"BookmarksController","method":"confirm_delete","line":268,"file":"app/controllers/bookmarks_controller.rb"}],
+      "render_path": [{"type":"controller","class":"BookmarksController","method":"confirm_delete","line":275,"file":"app/controllers/bookmarks_controller.rb"}],
       "location": {
         "type": "template",
         "template": "bookmarks/confirm_delete"
@@ -1799,7 +1760,7 @@
       "check_name": "UnsafeReflection",
       "message": "Unsafe reflection method constantize called with parameter value",
       "file": "app/controllers/tag_wranglings_controller.rb",
-      "line": 28,
+      "line": 26,
       "link": "http://brakemanscanner.org/docs/warning_types/remote_code_execution/",
       "code": "params[:show].classify.constantize",
       "render_path": null,
@@ -1822,7 +1783,7 @@
       "line": 6,
       "link": "http://brakemanscanner.org/docs/warning_types/cross_site_scripting",
       "code": "ts(\"Are you sure you want to <strong><em>delete</em></strong> the series \\\"%{series_title}\\\"? This will not delete the individual works.\", :series_title => Series.find_by(:id => params[:id]).title)",
-      "render_path": [{"type":"controller","class":"SeriesController","method":"confirm_delete","line":137,"file":"app/controllers/series_controller.rb"}],
+      "render_path": [{"type":"controller","class":"SeriesController","method":"confirm_delete","line":135,"file":"app/controllers/series_controller.rb"}],
       "location": {
         "type": "template",
         "template": "series/confirm_delete"
@@ -1860,33 +1821,13 @@
       "line": 76,
       "link": "http://brakemanscanner.org/docs/warning_types/cross_site_scripting",
       "code": "sanitize_field((Work.find_by(:id => params[:work_id]) or Chapter.find_by(:id => params[:id]).work).chapters.find_by(:id => params[:id]), :endnotes)",
-      "render_path": [{"type":"controller","class":"ChaptersController","method":"show","line":77,"file":"app/controllers/chapters_controller.rb"},{"type":"template","name":"chapters/show","line":28,"file":"app/views/chapters/show.html.erb"}],
+      "render_path": [{"type":"controller","class":"ChaptersController","method":"show","line":76,"file":"app/controllers/chapters_controller.rb"},{"type":"template","name":"chapters/show","line":28,"file":"app/views/chapters/show.html.erb"}],
       "location": {
         "type": "template",
         "template": "chapters/_chapter"
       },
       "user_input": "Work.find_by(:id => params[:work_id])",
       "confidence": "Weak",
-      "note": ""
-    },
-    {
-      "warning_type": "File Access",
-      "warning_code": 16,
-      "fingerprint": "ed9568c987a1ed6812b3ba3a9913e154e51f052a7ff3b6281db9c272ba29b3cf",
-      "check_name": "FileAccess",
-      "message": "Model attribute used in file name",
-      "file": "app/models/skin.rb",
-      "line": 528,
-      "link": "http://brakemanscanner.org/docs/warning_types/file_access/",
-      "code": "File.open(((Skin.site_skins_dir + Skin.get_current_version) + \"/preview.png\"), \"rb\")",
-      "render_path": null,
-      "location": {
-        "type": "method",
-        "class": "Skin",
-        "method": "Skin.create_default"
-      },
-      "user_input": "((Skin.site_skins_dir + Skin.get_current_version) + \"/preview.png\")",
-      "confidence": "Medium",
       "note": ""
     },
     {
@@ -1899,7 +1840,7 @@
       "line": 6,
       "link": "http://brakemanscanner.org/docs/warning_types/cross_site_scripting",
       "code": "strip_tags(BookmarkSearchForm.new((bookmark_search_params or {})).summary)",
-      "render_path": [{"type":"controller","class":"BookmarksController","method":"search","line":57,"file":"app/controllers/bookmarks_controller.rb"}],
+      "render_path": [{"type":"controller","class":"BookmarksController","method":"search","line":59,"file":"app/controllers/bookmarks_controller.rb"}],
       "location": {
         "type": "template",
         "template": "bookmarks/search_results"
@@ -1918,7 +1859,7 @@
       "line": 4,
       "link": "http://brakemanscanner.org/docs/warning_types/cross_site_scripting",
       "code": "ts(\"Edit Work Tags and Language for %{title}\", :title => Work.find_by(:id => params[:id]).title)",
-      "render_path": [{"type":"controller","class":"WorksController","method":"edit_tags","line":342,"file":"app/controllers/works_controller.rb"}],
+      "render_path": [{"type":"controller","class":"WorksController","method":"edit_tags","line":360,"file":"app/controllers/works_controller.rb"}],
       "location": {
         "type": "template",
         "template": "works/edit_tags"
@@ -1937,7 +1878,7 @@
       "line": 9,
       "link": "http://brakemanscanner.org/docs/warning_types/link_to_href",
       "code": "link_to((Work.find(params[:work_id]) or (Chapter.find(params[:chapter_id]).work or (ExternalWork.find(params[:external_work_id]) or Series.find(params[:series_id])))).title, (Work.find(params[:work_id]) or (Chapter.find(params[:chapter_id]).work or (ExternalWork.find(params[:external_work_id]) or Series.find(params[:series_id])))).url)",
-      "render_path": [{"type":"controller","class":"BookmarksController","method":"index","line":148,"file":"app/controllers/bookmarks_controller.rb"},{"type":"template","name":"bookmarks/index","line":59,"file":"app/views/bookmarks/index.html.erb"},{"type":"template","name":"bookmarks/_bookmarks","line":23,"file":"app/views/bookmarks/_bookmarks.html.erb"},{"type":"template","name":"bookmarks/_bookmarkable_blurb","line":13,"file":"app/views/bookmarks/_bookmarkable_blurb.html.erb"},{"type":"template","name":"bookmarks/_bookmark_item_module","line":3,"file":"app/views/bookmarks/_bookmark_item_module.html.erb"}],
+      "render_path": [{"type":"controller","class":"BookmarksController","method":"index","line":150,"file":"app/controllers/bookmarks_controller.rb"},{"type":"template","name":"bookmarks/index","line":59,"file":"app/views/bookmarks/index.html.erb"},{"type":"template","name":"bookmarks/_bookmarks","line":23,"file":"app/views/bookmarks/_bookmarks.html.erb"},{"type":"template","name":"bookmarks/_bookmarkable_blurb","line":13,"file":"app/views/bookmarks/_bookmarkable_blurb.html.erb"},{"type":"template","name":"bookmarks/_bookmark_item_module","line":3,"file":"app/views/bookmarks/_bookmark_item_module.html.erb"}],
       "location": {
         "type": "template",
         "template": "external_works/_work_module"
@@ -1953,7 +1894,7 @@
       "check_name": "FileAccess",
       "message": "Model attribute used in file name",
       "file": "app/models/skin.rb",
-      "line": 230,
+      "line": 247,
       "link": "http://brakemanscanner.org/docs/warning_types/file_access/",
       "code": "File.open(((Skin.skins_dir + skin_dirname) + \"#{1}_#{\"\"}.css\"), \"w\")",
       "render_path": null,
@@ -1967,6 +1908,6 @@
       "note": ""
     }
   ],
-  "updated": "2020-02-09 23:33:40 +0000",
+  "updated": "2021-08-30 17:22:12 -0400",
   "brakeman_version": "3.7.2"
 }


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6234

## Purpose

Updates the Brakeman ignore file, which appears to need it. We'll see how Hakiri feels.

```
brakeman -I

1. Inspect all warnings
2. Hide previously ignored warnings
3. Prune obsolete ignored warnings
4. Skip - use current ignore configuration
?  2

3 fingerprints are unused:
/Users/sarken/.rbenv/versions/2.7.3/lib/ruby/gems/2.7.0/gems/brakeman-3.7.2/bundle/ruby/2.3.0/gems/highline-1.7.8/lib/highline.rb:624: warning: Using the last argument as keyword parameters is deprecated
04a2dece009c698540960269d024b874a42b71cf8e06e3216c41f8807e57f9b9
/Users/sarken/.rbenv/versions/2.7.3/lib/ruby/gems/2.7.0/gems/brakeman-3.7.2/bundle/ruby/2.3.0/gems/highline-1.7.8/lib/highline.rb:624: warning: Using the last argument as keyword parameters is deprecated
45047b931fdb5049a943a5fbfa62ae077a8d457db6ba924db6792fd3e404ec12
/Users/sarken/.rbenv/versions/2.7.3/lib/ruby/gems/2.7.0/gems/brakeman-3.7.2/bundle/ruby/2.3.0/gems/highline-1.7.8/lib/highline.rb:624: warning: Using the last argument as keyword parameters is deprecated
ed9568c987a1ed6812b3ba3a9913e154e51f052a7ff3b6281db9c272ba29b3cf
/Users/sarken/.rbenv/versions/2.7.3/lib/ruby/gems/2.7.0/gems/brakeman-3.7.2/bundle/ruby/2.3.0/gems/highline-1.7.8/lib/highline.rb:624: warning: Using the last argument as keyword parameters is deprecated

Remove fingerprints?
y
```

## Testing Instructions

Automated checks should pass; no manual testing needed.