### PR TITLE
AO3-6103 Additional standardization of email signatures, work titles, support links

### DIFF
--- a/app/helpers/mailer_helper.rb
+++ b/app/helpers/mailer_helper.rb
@@ -9,10 +9,15 @@ module MailerHelper
     link_to(body.html_safe, url, html_options)
   end
 
-  # For work, chapter, and series titles
+  # For work, chapter, and series links
   def style_creation_link(title, url, html_options = {})
     html_options[:style] = "color:#990000"
     ("<i><b>" + link_to(title.html_safe, url, html_options) + "</b></i>").html_safe
+  end
+
+  # For work, chapter, and series titles
+  def style_creation_title(title)
+    ("<i><b style=\"color:#990000\">" + title.html_safe + "</b></i>").html_safe
   end
 
   def style_footer_link(body, url, html_options = {})

--- a/app/views/user_mailer/admin_deleted_work_notification.html.erb
+++ b/app/views/user_mailer/admin_deleted_work_notification.html.erb
@@ -1,7 +1,7 @@
 <% content_for :message do %>
   <p><%= t("mailer.general.greeting.formal", name: style_bold(@user.login)).html_safe %></p>
 
-  <p><%= t('.html.part1', title: "<i>#{style_bold(@work.title.html_safe)}</i>".html_safe).html_safe %></p>
+  <p><%= t('.html.part1', title: style_creation_title(@work.title)).html_safe %></p>
 
   <p><%= t('.html.part2', opendoors_link: opendoors_link(t '.opendoors')).html_safe %></p>
 

--- a/app/views/user_mailer/admin_spam_work_notification.html.erb
+++ b/app/views/user_mailer/admin_spam_work_notification.html.erb
@@ -1,7 +1,7 @@
 <% content_for :message do %>
   <p><%= t("mailer.general.greeting.formal", name: style_bold(@user.login)).html_safe %></p>
 
-  <p>Your work <i><%= style_link(@work.title.html_safe, work_url(@work)) %></i> has been flagged by our automated system as spam and hidden until it can be reviewed by our Policy & Abuse team. While the work is hidden it can only be accessed by you and AO3 site admins.</p>
+  <p>Your work <%= style_creation_link(@work.title, @work) %> has been flagged by our automated system as spam and hidden until it can be reviewed by our Policy & Abuse team. While the work is hidden it can only be accessed by you and AO3 site admins.</p>
 
   <p>If we determine that your work is not spam, we'll unhide it. Other users will then be able to access and leave feedback on it as usual. Please note that we do not screen works for other kinds of violations at this time. If your work is reported to us for a different reason in the future, that will be investigated separately.</p>
 

--- a/app/views/user_mailer/claim_notification.html.erb
+++ b/app/views/user_mailer/claim_notification.html.erb
@@ -9,7 +9,7 @@
 
   <p>If this is a mistake and these are not your works, please don't delete them! Please <%= style_link('contact Open Doors', 'http://transformativeworks.org/contact/open%20doors') %> and we will sort it out.</p>
 
-  <p>Depending on the archive, your works may have been imported restricted to registered users only (to keep them out of Google searches). If this is the case, the works will only be accessible by logged-in users unless you choose to make them fully visible. For help unlocking, orphaning, or deleting your works, please <%= support_link('contact Support') %>.</p>
+  <p>Depending on the archive, your works may have been imported restricted to registered users only (to keep them out of Google searches). If this is the case, the works will only be accessible by logged-in users unless you choose to make them fully visible. For help unlocking, orphaning, or deleting your works, please <%= support_link('contact AO3 Support') %>.</p>
 
   <p>These works were written under the e-mail: <%= @external_email %></p>
 
@@ -26,7 +26,7 @@
 
   <p>If you had other works on the imported archive under an e-mail address you can no longer access, please <%= style_link('contact Open Doors', 'http://transformativeworks.org/contact/open%20doors') %> with any information that can help verify your identity.</p>
 
-  <p>For other inquiries, please <%= support_link('contact Support') %>.</p>
+  <p>For other inquiries, please <%= support_link('contact AO3 Support') %>.</p>
 
   <p>If you're contacting us, please add email addresses from @transformativeworks.org to your list of safe contacts and check your spam folders for our reply.</p>
 

--- a/app/views/user_mailer/delete_work_notification.html.erb
+++ b/app/views/user_mailer/delete_work_notification.html.erb
@@ -1,12 +1,11 @@
 <% content_for :message do %>
-<% pretty_title = "<i>#{style_bold(@work.title.html_safe)}</i>".html_safe %>
 <p><%= t("mailer.general.greeting.formal", name: style_bold(@user.login)).html_safe %></p>
 <p><%= (@work.pseuds.count > 1 && @user != User.current_user) ?
 t('.html.part1_other',
-        title: pretty_title,
+        title: style_creation_title(@work.title),
         pseud: style_pseud_link(User.current_user.default_pseud)).html_safe :
 t('.html.part1_yourself',
-        title: pretty_title).html_safe %></p>
+        title: style_creation_title(@work.title)).html_safe %></p>
 <p><%= t('.html.part2', support: support_link(t '.support')).html_safe %></p>
 <p><%= t('.part3') %></p>
 <% end %>

--- a/app/views/user_mailer/invite_increase_notification.html.erb
+++ b/app/views/user_mailer/invite_increase_notification.html.erb
@@ -5,6 +5,6 @@
 
   <p>
     <%= t("mailer.general.closing.informal") %><br />
-    <%= style_link(t("mailer.general.signature.app_short_name"), root_url) %>
+    <%= t("mailer.general.signature.app_short_name") %>
   </p>
 <% end %>

--- a/app/views/user_mailer/invite_request_declined.html.erb
+++ b/app/views/user_mailer/invite_request_declined.html.erb
@@ -5,8 +5,6 @@
   <p><%= t(".reason") %></p>
   <p><%= style_quote(@reason) %></p>
 
-  <p><%= t("mailer.general.closing.formal") %></p>
-  <p><%= style_link(t("mailer.general.signature.app_short_name"), root_url) %></p>
+  <p><%= t("mailer.general.closing.formal") %><br />
+  <%= t("mailer.general.signature.app_short_name") %></p>
 <% end %>
-
-

--- a/config/locales/mailers/en.yml
+++ b/config/locales/mailers/en.yml
@@ -215,7 +215,7 @@ en:
         ao3_news: "AO3 News"
         faq_page: "FAQ page"
         tutorial_page: "tutorial page"
-        contact_support: "contact AO3 support"
+        contact_support: "contact AO3 Support"
         part3: "If this is a mistake and these are not your works, please don't delete them! Please just %{open_doors_link} and we will sort it out."
         contact_open_doors: "contact Open Doors"
         part4: "Depending on the archive, your works may have been imported restricted to registered users only (to keep them out of Google searches). If this is the case, the works will only be accessible by logged-in users unless you choose to make them fully visible. For help unlocking, orphaning, or deleting your works, please %{support_link}."

--- a/config/locales/mailers/en.yml
+++ b/config/locales/mailers/en.yml
@@ -70,7 +70,7 @@ en:
         tos_violation: "If your work was hidden due to being in violation of the Archive of Our Own's %{tos_link}, you will be required to take action to correct the violation. Failure to bring your work into compliance with the Terms of Service may lead to your work being deleted from the Archive."
         help: "If you are uncertain why your work was hidden, and you have not received further communication regarding this matter, please %{contact_abuse_link} directly."
       text:
-        hidden: "Your work %{title} (%{work_url}) has been hidden by the Policy & Abuse team and is no longer publicly accessible."
+        hidden: "Your work \"%{title}\" (%{work_url}) has been hidden by the Policy & Abuse team and is no longer publicly accessible."
         tos_violation: "If your work was hidden due to being in violation of the Archive of Our Own's Terms of Service (%{tos_url}), you will be required to take action to correct the violation. Failure to bring your work into compliance with the Terms of Service may lead to your work being deleted from the Archive."
         help: "If you are uncertain why your work was hidden, and you have not received further communication regarding this matter, please contact Policy & Abuse directly: %{contact_abuse_url}."
     delete_work_notification:


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6103

## Purpose

* Removes a link from the signature of emails relating to invitation requests 
* Removes extra blank line from the signature of the invitation request declined email
* Consistently refers to Support as "AO3 Support" in the Open Doors emails
* Adds quotation marks around the work title in the plain text version of the hidden work email
* Updates the style of the work link in the spam work HTML email
* Adds and uses helper method to style non-linked work titles in deleted work emails

## Testing Instructions

Refer to Jira


