### PR TITLE
AO3-6209 Indices for tag_set_nominations and tag_nominations tables.

### DIFF
--- a/db/migrate/20210831214137_index_tag_nominations_and_tag_set_nominations.rb
+++ b/db/migrate/20210831214137_index_tag_nominations_and_tag_set_nominations.rb
@@ -1,0 +1,55 @@
+class IndexTagNominationsAndTagSetNominations < ActiveRecord::Migration[5.2]
+  def up
+    if Rails.env.staging? || Rails.env.production?
+      database = TagNomination.connection.current_database
+
+      puts <<~PTOSC
+        Schema Change Command:
+
+        pt-online-schema-change D=#{database},t=tag_nominations \\
+          --alter "ADD INDEX index_tag_nominations_on_tag_set_nomination_id_and_type (tag_set_nomination_id, type)" \\
+          --no-drop-old-table \\
+          -uroot --ask-pass --chunk-size=5k --max-flow-ctl 0 --pause-file /tmp/pauseme \\
+          --max-load Threads_running=15 --critical-load Threads_running=100 \\
+          --set-vars innodb_lock_wait_timeout=2 --alter-foreign-keys-method=auto \\
+          --execute
+
+        Table Deletion Command:
+
+        DROP TABLE IF EXISTS `#{database}`.`_tag_nominations_old`;
+      PTOSC
+    else
+      add_index :tag_nominations, [:tag_set_nomination_id, :type]
+    end
+
+    add_index :tag_set_nominations, [:owned_tag_set_id]
+    add_index :tag_set_nominations, [:pseud_id, :owned_tag_set_id]
+  end
+
+  def down
+    if Rails.env.staging? || Rails.env.production?
+      database = TagNomination.connection.current_database
+
+      puts <<~PTOSC
+        Schema Change Command:
+
+        pt-online-schema-change D=#{database},t=tag_nominations \\
+          --alter "DROP INDEX index_tag_nominations_on_tag_set_nomination_id_and_type" \\
+          --no-drop-old-table \\
+          -uroot --ask-pass --chunk-size=5k --max-flow-ctl 0 --pause-file /tmp/pauseme \\
+          --max-load Threads_running=15 --critical-load Threads_running=100 \\
+          --set-vars innodb_lock_wait_timeout=2 --alter-foreign-keys-method=auto \\
+          --execute
+
+        Table Deletion Command:
+
+        DROP TABLE IF EXISTS `#{database}`.`_tag_nominations_old`;
+      PTOSC
+    else
+      remove_index :tag_nominations, [:tag_set_nomination_id, :type]
+    end
+
+    remove_index :tag_set_nominations, [:owned_tag_set_id]
+    remove_index :tag_set_nominations, [:pseud_id, :owned_tag_set_id]
+  end
+end

--- a/db/migrate/20210831214137_index_tag_nominations_on_tag_set_nomination.rb
+++ b/db/migrate/20210831214137_index_tag_nominations_on_tag_set_nomination.rb
@@ -1,4 +1,4 @@
-class IndexTagNominationsAndTagSetNominations < ActiveRecord::Migration[5.2]
+class IndexTagNominationsOnTagSetNomination < ActiveRecord::Migration[5.2]
   def up
     if Rails.env.staging? || Rails.env.production?
       database = TagNomination.connection.current_database
@@ -21,9 +21,6 @@ class IndexTagNominationsAndTagSetNominations < ActiveRecord::Migration[5.2]
     else
       add_index :tag_nominations, [:tag_set_nomination_id, :type]
     end
-
-    add_index :tag_set_nominations, [:owned_tag_set_id]
-    add_index :tag_set_nominations, [:pseud_id, :owned_tag_set_id]
   end
 
   def down
@@ -48,8 +45,5 @@ class IndexTagNominationsAndTagSetNominations < ActiveRecord::Migration[5.2]
     else
       remove_index :tag_nominations, [:tag_set_nomination_id, :type]
     end
-
-    remove_index :tag_set_nominations, [:owned_tag_set_id]
-    remove_index :tag_set_nominations, [:pseud_id, :owned_tag_set_id]
   end
 end

--- a/db/migrate/20210902040827_index_tag_set_nominations.rb
+++ b/db/migrate/20210902040827_index_tag_set_nominations.rb
@@ -1,0 +1,6 @@
+class IndexTagSetNominations < ActiveRecord::Migration[5.2]
+  def change
+    add_index :tag_set_nominations, [:owned_tag_set_id]
+    add_index :tag_set_nominations, [:pseud_id, :owned_tag_set_id]
+  end
+end


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6209

## Purpose

Add an index starting with `tag_set_nomination_id` to the `tag_nominations` table using PTOSC, and add two indices (one starting with `pseud_id`, one starting with `owned_tag_set_id`) to the `tag_set_nominations` table.
