### PR TITLE
AO3-6103 Make recipient_notification email subject sentence case

### DIFF
--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -330,7 +330,7 @@ class UserMailer < ActionMailer::Base
   end
 
   # Emails a recipient to say that a gift has been posted for them
-  def recipient_notification(user_id, work_id, collection_id=nil)
+  def recipient_notification(user_id, work_id, collection_id = nil)
     @user = User.find(user_id)
     @work = Work.find(work_id)
     @collection = Collection.find(collection_id) if collection_id

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -334,10 +334,18 @@ class UserMailer < ActionMailer::Base
     @user = User.find(user_id)
     @work = Work.find(work_id)
     @collection = Collection.find(collection_id) if collection_id
+    subject = if @collection
+                t("user_mailer.recipient_notification.subject.collection",
+                  app_name: ArchiveConfig.APP_SHORT_NAME,
+                  collection_title: @collection.title)
+              else
+                t("user_mailer.recipient_notification.subject.no_collection",
+                  app_name: ArchiveConfig.APP_SHORT_NAME)
+              end
     I18n.with_locale(Locale.find(@user.preference.preferred_locale).iso) do
       mail(
         to: @user.email,
-        subject: "[#{ArchiveConfig.APP_SHORT_NAME}]#{@collection ? '[' + @collection.title + ']' : ''} A Gift Work For You #{@collection ? 'From ' + @collection.title : ''}"
+        subject: subject
       )
     end
     ensure

--- a/config/locales/mailers/en.yml
+++ b/config/locales/mailers/en.yml
@@ -257,6 +257,10 @@ en:
         html: "For more information, visit our %{faq_link}."
         text: "For more information, visit our Collections and Challenges FAQ: %{faq_url}"
       faq_link_text: "Collections and Challenges FAQ"
+    recipient_notification:
+      subject:
+        collection: "[%{app_name}][%{collection_title}] A gift work for you from %{collection_title}"
+        no_collection: "[%{app_name}] A gift work for you"
   users:
     mailer:
       reset_password_instructions:

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -682,7 +682,7 @@ describe UserMailer do
       it_behaves_like "an email with a valid sender"
 
       it "has the correct subject line" do
-        subject = "[#{ArchiveConfig.APP_SHORT_NAME}][#{collection.title}] A Gift Work For You From #{collection.title}"
+        subject = "[#{ArchiveConfig.APP_SHORT_NAME}][#{collection.title}] A gift work for you from #{collection.title}"
         expect(email).to have_subject(subject)
       end
 
@@ -713,7 +713,7 @@ describe UserMailer do
       it_behaves_like "an email with a valid sender"
 
       it "has the correct subject line" do
-        subject = "[#{ArchiveConfig.APP_SHORT_NAME}] A Gift Work For You "
+        subject = "[#{ArchiveConfig.APP_SHORT_NAME}] A gift work for you"
         expect(email).to have_subject(subject)
       end
 


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6103

## Purpose

Make the subject of the email that gets sent when you receive a gift sentence case rather than title case.

## Testing Instructions

Refer to Jira.