### PR TITLE
AO3-6103 Sentence case assignment sent email subject, plus i18n

### DIFF
--- a/app/models/challenge_assignment.rb
+++ b/app/models/challenge_assignment.rb
@@ -294,7 +294,9 @@ class ChallengeAssignment < ApplicationRecord
     collection.assignments.each do |assignment|
       assignment.send_out
     end
-    collection.notify_maintainers("Assignments Sent", "All assignments have now been sent out.")
+    subject = I18n.t("user_mailer.collection_notification.assignments_sent.subject")
+    message = I18n.t("user_mailer.collection_notification.assignments_sent.complete")
+    collection.notify_maintainers(subject, message)
 
     # purge the potential matches! we don't want bazillions of them in our db
     PotentialMatch.clear!(collection)

--- a/app/views/user_mailer/collection_notification.html.erb
+++ b/app/views/user_mailer/collection_notification.html.erb
@@ -1,7 +1,7 @@
 <% content_for :message do %>
 
   <p>
-    You have received a message about your collection <%= style_link(@collection.title, collection_url(@collection)) %>:
+    <%= t(".html.received_message", collection_link: style_link(@collection.title, collection_url(@collection))).html_safe %>
   </p>
 
   <%= style_quote(raw @message) %>

--- a/app/views/user_mailer/collection_notification.text.erb
+++ b/app/views/user_mailer/collection_notification.text.erb
@@ -1,5 +1,5 @@
 <% content_for :message do %>
-You have received a message about your collection "<%= @collection.title %>" (<%= collection_url(@collection) %>):
+<%= t(".text.received_message", collection_title: @collection.title, collection_url: collection_url(@collection)) %>
 <%= text_divider %>
 
 <%= raw @message %>

--- a/config/locales/mailers/en.yml
+++ b/config/locales/mailers/en.yml
@@ -261,6 +261,14 @@ en:
       subject:
         collection: "[%{app_name}][%{collection_title}] A gift work for you from %{collection_title}"
         no_collection: "[%{app_name}] A gift work for you"
+    collection_notification:
+      assignments_sent:
+        subject: "Assignments sent"
+        complete: "All assignments have now been sent out."
+      html:
+        received_message: "You have received a message about your collection %{collection_link}:"
+      text:
+        received_message: "You have received a message about your collection \"%{collection_title}\" (%{collection_url}):"
   users:
     mailer:
       reset_password_instructions:

--- a/features/gift_exchanges/challenge_giftexchange.feature
+++ b/features/gift_exchanges/challenge_giftexchange.feature
@@ -269,7 +269,9 @@ Feature: Gift Exchange Challenge
     Then I should not see "Assignments are now being sent out"
     # 4 users and the mod should get emails :)
       And 1 email should be delivered to "mod1"
+      And the email should have "Assignments sent" in the subject
       And the email should contain "You have received a message about your collection"
+      And the email should not contain "translation missing"
       And 1 email should be delivered to "myname1"
       And the email should contain "You have been assigned the following request"
       And the email should contain "Fandom:"

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -799,4 +799,39 @@ describe UserMailer do
       end
     end
   end
+
+  describe "collection_notification" do
+    subject(:email) { UserMailer.collection_notification(collection.id, subject_text, message_text) }
+
+    let(:collection) { create(:collection) }
+    let(:subject_text) { Faker::Hipster.sentence }
+    let(:message_text) { Faker::Hipster.paragraph }
+
+    # Test the headers
+    it_behaves_like "an email with a valid sender"
+
+    it "has the correct subject line" do
+      subject = "[#{ArchiveConfig.APP_SHORT_NAME}][#{collection.title}] #{subject_text}"
+      expect(email.subject).to eq(subject)
+    end
+
+    # Test both body contents
+    it_behaves_like "a multipart email"
+
+    it_behaves_like "a translated email"
+
+    describe "HTML version" do
+      it "has the correct content" do
+        expect(email).to have_html_part_content("your collection <")
+        expect(email).to have_html_part_content("#{message_text}</blockquote>")
+      end
+    end
+
+    describe "text version" do
+      it "has the correct content" do
+        expect(email).to have_text_part_content("your collection \"#{collection.title}\"")
+        expect(email).to have_text_part_content(message_text)
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6103

## Purpose

Converts the subject line of the assignment sent email to sentence case, and internationalizes that email.

I said I wasn't going to do this in AO3-6103 because the email's done differently than the others, but I forgot and did it. 🤷 

I put the text under the mailer rather than the challenge assignment model because it seemed a bit more sensible a place to look for it, but I can move it. I can also close this and make a new issue like I originally said I'd do.

## Testing Instructions

Send the assignments for a gift exchange and make sure you get an email with the subject "Assignments sent."

