### PR TITLE
AO3-6103 Remove signature from invalid sign-ups text email

### DIFF
--- a/app/views/user_mailer/invalid_signup_notification.text.erb
+++ b/app/views/user_mailer/invalid_signup_notification.text.erb
@@ -8,7 +8,5 @@ Here are the invalid sign-ups:
   <%= collection_signup_url(@collection, signup_id) %>
 <% end %>
 
-AO3 (<%= root_url %>)
-
 <% content_for :sent_at do %><%= Time.now.to_s(:time_for_mailers) %><% end %>
 <% end %>


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6103 

## Purpose

Removes a stray signature.

## Testing Instructions

Refer to Jira.