### PR TITLE
AO3-6103 Additional pre-translation email standardization 

### DIFF
--- a/app/views/user_mailer/added_to_collection_notification.html.erb
+++ b/app/views/user_mailer/added_to_collection_notification.html.erb
@@ -2,7 +2,7 @@
   <p><%= t("mailer.general.greeting.formal", name: style_bold(@user.login)).html_safe %></p>
 
   <p>The collection maintainers of <%= style_link(@collection.title, collection_url(@collection)) %> have
-    added your work (<%= style_link(@work.title.html_safe, work_url(@work)) %>) to their collection!</p>
+    added your work <%= style_creation_link(@work.title, work_url(@work)) %> to their collection!</p>
 
   <p>You are receiving this notification because you have previously elected to allow
   automatic inclusion of your works into collections on the Archive of Our Own.</p>
@@ -11,7 +11,7 @@
    <%= style_link("Approved Collection Items page", user_collection_items_url(@user) + "?approved=true") %>.</p>
 
   <p>If in future you would prefer to individually accept or reject requests to add your
-    works to collections, please edit your <%= style_link("Preferences", "#{root_url}users/#{@user.default_pseud.name}/preferences") %>
+    works to collections, please edit your <%= style_link("Preferences", user_preferences_url(@user)) %>
     and untick the box next to: <%= style_quote("\"Automatically agree to your work being collected by others in the Archive.\"") %>
   </p>
 <% end %>

--- a/app/views/user_mailer/added_to_collection_notification.text.erb
+++ b/app/views/user_mailer/added_to_collection_notification.text.erb
@@ -1,12 +1,12 @@
 <% content_for :message do %>
 <%= t("mailer.general.greeting.formal", name: @user.login) %>
 
-The collection maintainers of <%= @collection.title %> have added your work (<%= @work.title.html_safe %>) to their collection!
+The collection maintainers of "<%= @collection.title %>" (<%= collection_url(@collection) %>) have added your work "<%= @work.title.html_safe %>" (<%= work_url(@work) %>) to their collection!
 
 You are receiving this notification because you have previously elected to allow automatic inclusion of your works into collections on the Archive of Our Own.
 
 If you would like to remove your work from this collection, please visit your "Approved Collection Items" page: <%= user_collection_items_url(@user) + "?approved=true" %>.
 
-If in future you would prefer to individually accept or reject requests to add your works to collections, please edit your Preferences (<%= "#{root_url}users/#{@user.default_pseud.name}/preferences" %>) and untick the box next to "Automatically agree to your work being collected by others in the Archive.".
+If in future you would prefer to individually accept or reject requests to add your works to collections, please edit your Preferences (<%= user_preferences_url(@user) %>) and untick the box next to "Automatically agree to your work being collected by others in the Archive."
 
 <% end %>

--- a/app/views/user_mailer/admin_hidden_work_notification.text.erb
+++ b/app/views/user_mailer/admin_hidden_work_notification.text.erb
@@ -1,13 +1,13 @@
 <% content_for :message do %>
-  <%= t("mailer.general.greeting.formal", name: @user.login) %>
+<%= t("mailer.general.greeting.formal", name: @user.login) %>
 
-  <%= t(".text.hidden", title: @work.title, work_url: work_url(@work)) %>
+<%= t(".text.hidden", title: @work.title, work_url: work_url(@work)) %>
 
-  <%= t(".access") %>
+<%= t(".access") %>
 
-  <%= t(".check_email") %>
+<%= t(".check_email") %>
 
-  <%= t(".text.tos_violation", tos_url: tos_url) %>
+<%= t(".text.tos_violation", tos_url: tos_url) %>
 
-  <%= t(".text.help", contact_abuse_url: new_abuse_report_url) %>
+<%= t(".text.help", contact_abuse_url: new_abuse_report_url) %>
 <% end %>

--- a/app/views/user_mailer/admin_spam_work_notification.text.erb
+++ b/app/views/user_mailer/admin_spam_work_notification.text.erb
@@ -1,9 +1,9 @@
 <% content_for :message do %>
-  <%= t("mailer.general.greeting.formal", name: @user.login) %>
+<%= t("mailer.general.greeting.formal", name: @user.login) %>
 
-  Your work "<%= @work.title.html_safe %>" (<%= work_url(@work) %>) has been flagged by our automated system as spam and hidden until it can be reviewed by our Abuse team. While the work is hidden it can only be accessed by you and AO3 site admins.
+Your work "<%= @work.title.html_safe %>" (<%= work_url(@work) %>) has been flagged by our automated system as spam and hidden until it can be reviewed by our Abuse team. While the work is hidden it can only be accessed by you and AO3 site admins.
 
-  If we determine that your work is not spam, we'll unhide it. Other users will then be able to access and leave feedback on it as usual. Please note that we do not screen works for other kinds of violations at this time. If your work is reported to us for a different reason in the future, that will be investigated separately.
+If we determine that your work is not spam, we'll unhide it. Other users will then be able to access and leave feedback on it as usual. Please note that we do not screen works for other kinds of violations at this time. If your work is reported to us for a different reason in the future, that will be investigated separately.
 
-  If you have any questions, please contact our Policy & Abuse team (<%= new_abuse_report_url %>).
+If you have any questions, please contact our Policy & Abuse team (<%= new_abuse_report_url %>).
 <% end %>

--- a/app/views/user_mailer/anonymous_or_unrevealed_notification.html.erb
+++ b/app/views/user_mailer/anonymous_or_unrevealed_notification.html.erb
@@ -1,9 +1,9 @@
 <% content_for :message do %>
   <p><%= t("mailer.general.greeting.formal", name: style_bold(@user.login)).html_safe %></p>
 
-  <p><%= t(".changed_status.#{@status}",
-           collection: style_link(@collection.title, collection_url(@collection)),
-           work: style_creation_link(@work.title, work_url(@work))).html_safe %></p>
+  <p><%= t(".changed_status.#{@status}.html",
+           collection_link: style_link(@collection.title, collection_url(@collection)),
+           work_link: style_creation_link(@work.title, work_url(@work))).html_safe %></p>
 
   <% if @becoming_anonymous && @becoming_unrevealed %>
     <p><%= t(".unrevealed_info") %></p>

--- a/app/views/user_mailer/anonymous_or_unrevealed_notification.text.erb
+++ b/app/views/user_mailer/anonymous_or_unrevealed_notification.text.erb
@@ -1,9 +1,11 @@
 <% content_for :message do %>
 <%= t("mailer.general.greeting.formal", name: @user.login) %>
 
-<%= t(".changed_status.#{@status}",
-      collection: @collection.title,
-      work: @work.title) %>
+<%= t(".changed_status.#{@status}.text",
+      collection_title: @collection.title,
+      collection_url: collection_url(@collection),
+      work_title: @work.title,
+      work_url: work_url(@work)) %>
 
 <% if @becoming_anonymous && @becoming_unrevealed %>
 <%= t(".unrevealed_info") %>

--- a/app/views/user_mailer/invite_request_declined.text.erb
+++ b/app/views/user_mailer/invite_request_declined.text.erb
@@ -1,7 +1,10 @@
 <% content_for :message do %>
 <%= t("mailer.general.greeting.formal", name: @user.login) %>
+
 <%= t(".main", count: @total) %>
+
 <%= t(".reason") %>
+
 <%= to_plain_text(raw @reason) %>
 
 <%= t("mailer.general.closing.formal") %>

--- a/app/views/user_mailer/invited_to_collection_notification.html.erb
+++ b/app/views/user_mailer/invited_to_collection_notification.html.erb
@@ -2,12 +2,12 @@
   <p><%= t("mailer.general.greeting.formal", name: style_bold(@user.login)).html_safe %></p>
 
   <p>The collection maintainers of <%= style_link(@collection.title, collection_url(@collection)) %> would
-    like to include your work (<%= style_link(@work.title.html_safe, work_url(@work)) %>) in their collection!</p>
+    like to include your work <%= style_creation_link(@work.title, work_url(@work)) %> in their collection!</p>
 
   <p>To approve or reject this request, please visit your <%= style_link("Collection Items page", user_collection_items_url(@user)) %>.</p>
 
   <p>If in future you would prefer to automatically approve requests to add your
-    works to collections, please edit your <%= style_link("Preferences", "#{root_url}users/#{@user.default_pseud.name}/preferences") %>
+    works to collections, please edit your <%= style_link("Preferences", user_preferences_url(@user)) %>
     and tick the box next to: <%= style_quote("\"Automatically agree to your work being collected by others in the Archive.\"") %>
   </p>
 

--- a/app/views/user_mailer/invited_to_collection_notification.text.erb
+++ b/app/views/user_mailer/invited_to_collection_notification.text.erb
@@ -1,12 +1,10 @@
 <% content_for :message do %>
 <%= t("mailer.general.greeting.formal", name: @user.login) %>
 
-The collection maintainers of <%= @collection.title %> would like to include your work (<%= @work.title.html_safe %>) in their collection!
+The collection maintainers of "<%= @collection.title %>" (<%= collection_url(@collection) %>) would like to include your work "<%= @work.title.html_safe %>" (<%= work_url(@work) %>) in their collection!
 
 To approve or reject this request, please visit your "Collection Items" page: <%= user_collection_items_url(@user) %>.
 
-If in future you would prefer to automatically approve requests to add your
-works to collections, please edit your Preferences (<%= "#{root_url}users/#{@user.default_pseud.name}/preferences" %>)
-and tick the box next to "Automatically agree to your work being collected by others in the Archive.".
+If in future you would prefer to automatically approve requests to add your works to collections, please edit your Preferences (<%= user_preferences_url(@user) %>) and tick the box next to "Automatically agree to your work being collected by others in the Archive."
 
 <% end %>

--- a/app/views/user_mailer/prompter_notification.html.erb
+++ b/app/views/user_mailer/prompter_notification.html.erb
@@ -1,13 +1,13 @@
 <% content_for :message do %>
   <p>
-    A response to your prompt has been posted <% if @collection then %>in the <i><%= @collection.title %></i> collection <% end %>at the Archive of Our Own!
+    A response to your prompt has been posted <% if @collection %>in the <%= style_link(@collection.title, collection_url(@collection)) %> collection <% end %>at the Archive of Our Own!
   </p>
 
   <p>
     <% if @collection.nil? %>
-      <i><b><%= style_link(@work.title.html_safe, work_url(@work)) %></b></i> (<%= @work.word_count %> words)
+      <%= style_creation_link(@work.title, work_url(@work)) %> (<%= @work.word_count %> words)
     <% else %>
-      <i><b><%= style_link(@work.title.html_safe, collection_work_url(@collection, @work)) %></b></i> (<%= @work.word_count %> words)
+      <%= style_creation_link(@work.title, collection_work_url(@collection, @work)) %> (<%= @work.word_count %> words)
     <% end %>
     <br>
     by <%= @work.anonymous? ? style_bold("an anonymous responder") : (@work.pseuds.map{|p| style_pseud_link(p)}.to_sentence.html_safe) %>

--- a/app/views/user_mailer/prompter_notification.text.erb
+++ b/app/views/user_mailer/prompter_notification.text.erb
@@ -1,5 +1,5 @@
 <% content_for :message do %>
-A response to your prompt has been posted<% if @collection then %> in the "<%= @collection.title %>" collection<% end %> at the Archive of Our Own!
+A response to your prompt has been posted<% if @collection %> in the "<%= @collection.title %>" collection (<%= collection_url(@collection) %>)<% end %> at the Archive of Our Own!
 
 "<%= @work.title.html_safe %>" (<%= @work.word_count %> words)
 <%= @collection ? collection_work_url(@collection, @work) : work_url(@work) %>

--- a/app/views/user_mailer/recipient_notification.html.erb
+++ b/app/views/user_mailer/recipient_notification.html.erb
@@ -3,14 +3,14 @@
   <p><%= t("mailer.general.greeting.informal.addressed", name: style_bold(@user.login)).html_safe %></p>
 
   <p>
-    A gift work has been posted for you <%= @collection ? " in the #{@collection.title} collection " : "" %>at the Archive of Our Own!
+    A gift work has been posted for you <% if @collection %>in the <%= style_link(@collection.title, collection_url(@collection)) %> collection <% end %>at the Archive of Our Own!
   </p>
 
   <p>
     <% if @collection.nil? %>
-      <i><b><%= style_link(@work.title.html_safe, work_url(@work)) %></b></i> <%= "(#{@work.word_count} words)" %>
+      <%= style_creation_link(@work.title, work_url(@work)) %> <%= "(#{@work.word_count} words)" %>
     <% else %>
-      <i><b><%= style_link(@work.title.html_safe, collection_work_url(@collection, @work)) %></b></i> <%= "(#{@work.word_count} words)" %>
+      <%= style_creation_link(@work.title, collection_work_url(@collection, @work)) %> <%= "(#{@work.word_count} words)" %>
     <% end %>
     <br>
     by <%= @work.anonymous? ? "an anonymous responder" : (@work.pseuds.map{|p| style_pseud_link(p)}.to_sentence.html_safe) %>

--- a/app/views/user_mailer/recipient_notification.text.erb
+++ b/app/views/user_mailer/recipient_notification.text.erb
@@ -1,7 +1,7 @@
 <% content_for :message do %>
 <%= t("mailer.general.greeting.informal.addressed", name: @user.login) %>
 
-A gift work has been posted for you<% if @collection then %> in the <%= "#{@collection.title}" %> collection<% end %> at the Archive of Our Own!
+A gift work has been posted for you<% if @collection %> in the "<%= @collection.title %>" collection (<%= collection_url(@collection) %>)<% end %> at the Archive of Our Own!
 
 "<%= @work.title.html_safe %>" (<%= @work.word_count %> words)
 <%= @collection ? collection_work_url(@collection, @work) : work_url(@work) %>

--- a/app/views/users/mailer/reset_password_instructions.text.erb
+++ b/app/views/users/mailer/reset_password_instructions.text.erb
@@ -1,5 +1,6 @@
 <% content_for :message do %>
 <%= t("mailer.general.greeting.formal", name: @resource.login) %>
+
 <%= t(".intro") %>
 
 <%= edit_user_password_url(reset_password_token: @token) %>

--- a/config/locales/mailers/en.yml
+++ b/config/locales/mailers/en.yml
@@ -182,7 +182,7 @@ en:
       due: "This assignment is due at:"
       any: "Any"
       text:
-        part1: "You have been assigned the following request in the %{collection_title} (%{collection_url}) challenge at the Archive of Our Own!"
+        part1: "You have been assigned the following request in the \"%{collection_title}\" (%{collection_url}) challenge at the Archive of Our Own!"
         look_up: "You can look up this assignment from your Assignments page at %{link}."
         footer: "You're receiving this email because you signed up for the %{title} challenge (%{url}). For more information about this challenge and contact information for the moderators, please visit %{profile_url}."
       html:
@@ -236,9 +236,15 @@ en:
         anonymous_unrevealed: "[%{app_name}] Your work was made anonymous and unrevealed"
         unrevealed: "[%{app_name}] Your work was made unrevealed"
       changed_status:
-        anonymous: "The collection maintainers of %{collection} have changed the status of your work %{work} to anonymous."
-        anonymous_unrevealed: "The collection maintainers of %{collection} have changed the status of your work %{work} to anonymous and unrevealed."
-        unrevealed: "The collection maintainers of %{collection} have changed the status of your work %{work} to unrevealed."
+        anonymous:
+          html: "The collection maintainers of %{collection_link} have changed the status of your work %{work_link} to anonymous."
+          text: "The collection maintainers of \"%{collection_title}\" (%{collection_url}) have changed the status of your work \"%{work_title}\" (%{work_url}) to anonymous."
+        anonymous_unrevealed:
+          html: "The collection maintainers of %{collection_link} have changed the status of your work %{work_link} to anonymous and unrevealed."
+          text: "The collection maintainers of \"%{collection_title}\" (%{collection_url}) have changed the status of your work \"%{work_title}\" (%{work_url}) to anonymous and unrevealed."
+        unrevealed:
+          html: "The collection maintainers of %{collection_link} have changed the status of your work %{work_link} to unrevealed."
+          text: "The collection maintainers of \"%{collection_title}\" (%{collection_url}) have changed the status of your work \"%{work_title}\" (%{work_url}) to unrevealed."
       anonymous_info: "Anonymous works are included in tag listings, but not on your works page. On the work, your user name will be replaced with \"Anonymous.\""
       unrevealed_info: "Unrevealed works are not included in tag listings or on your works page. Anyone who follows a link to the work will receive a notice that it is currently unrevealed, and they will be unable to access its content."
       anonymous_unrevealed_info: "The collection maintainers may later reveal your work but leave it anonymous. People who subscribe to you will not be notified of this change. Your work will be included in tag listings, but not on your works page. On the work, your user name will be replaced with \"Anonymous.\""

--- a/features/gift_exchanges/challenge_yuletide.feature
+++ b/features/gift_exchanges/challenge_yuletide.feature
@@ -571,8 +571,9 @@ Feature: Collection
   When I reload the page
   # 5 gift notification emails are delivered for the 5 stories that have been posted so far (4 standard, 1 pinch-hit, 1 still a draft)
   Then 5 emails should be delivered
-    And the email should contain "A gift work has been posted for you"
-    And the email should contain "in the Yuletide collection at the Archive of Our Own"
+    And the email should contain "A gift work has been posted for you in the"
+    And the email should contain "Yuletide"
+    And the email should contain "at the Archive of Our Own"
     And the email should contain "by an anonymous responder"
     And the email should not contain "by myname1"
     And the email should not contain "by myname2"

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -834,4 +834,71 @@ describe UserMailer do
       end
     end
   end
+
+  describe "prompter_notification" do
+    context "when collection is present" do
+      subject(:email) { UserMailer.prompter_notification(work.id, collection.id) }
+
+      let(:collection) { create(:collection) }
+      let(:claim) { create(:challenge_claim, request_signup: create(:prompt_meme_signup)) }
+      let(:work) { create(:work, challenge_claims: [claim]) }
+
+      # Test the headers
+      it_behaves_like "an email with a valid sender"
+
+      it "has the correct subject line" do
+        subject = "[#{ArchiveConfig.APP_SHORT_NAME}] A response to your prompt"
+        expect(email).to have_subject(subject)
+      end
+
+      # Test both body contents
+      it_behaves_like "a multipart email"
+
+      describe "HTML version" do
+        it "has the correct content" do
+          expect(email).to have_html_part_content("A response to your prompt")
+          expect(email).to have_html_part_content("#{collection.title}</a>")
+        end
+      end
+
+      describe "text version" do
+        it "has the correct content" do
+          expect(email).to have_text_part_content("A response to your prompt")
+          expect(email).to have_text_part_content("\"#{collection.title}\" collection (#{collection_url(collection)})")
+        end
+      end
+    end
+
+    context "when no collection is present" do
+      subject(:email) { UserMailer.prompter_notification(work.id) }
+
+      let(:claim) { create(:challenge_claim, request_signup: create(:prompt_meme_signup)) }
+      let(:work) { create(:work, challenge_claims: [claim]) }
+
+      # Test the headers
+      it_behaves_like "an email with a valid sender"
+
+      it "has the correct subject line" do
+        subject = "[#{ArchiveConfig.APP_SHORT_NAME}] A response to your prompt"
+        expect(email).to have_subject(subject)
+      end
+
+      # Test both body contents
+      it_behaves_like "a multipart email"
+
+      describe "HTML version" do
+        it "has the correct content" do
+          expect(email).to have_html_part_content("posted at the Archive")
+          expect(email).not_to have_html_part_content("collection")
+        end
+      end
+
+      describe "text version" do
+        it "has the correct content" do
+          expect(email).to have_text_part_content("posted at the Archive")
+          expect(email).not_to have_text_part_content("collection")
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6103

## Purpose

- Makes collection titles links in HTML emails; wraps them in double quotes and includes their URL in text emails.
- Formats work titles with style_creation_link in HTML emails; wraps them in double quotes and includes their URL in text emails.
- Corrects the preferences URL. It previously used your default pseud name instead of your username.
- Removes an extra period after the name of a preference.
- Adds paragraph spacing to text emails.
- Removes indenting from text emails.

## Testing Instructions

[Refer to Jira comment](https://otwarchive.atlassian.net/browse/AO3-6103?focusedCommentId=357885)
