### PR TITLE
AO3-6220 Update remaining collection FAQ links

### DIFF
--- a/app/views/home/tos_faq.html.erb
+++ b/app/views/home/tos_faq.html.erb
@@ -411,7 +411,7 @@ Please use our search functions for this rather than creating a separate work.</
 			<h3 class="heading" id="specialized_faq">Assorted Specialized Policies</h3>
 			<h4 class="heading" id="collections">Collections</h4>
 			<h5 class="heading" id="collections_def">What do you mean by "collections"?</h5>
-			<p>Collections are groups of works collected together under one heading. Collections can be fic or art fests, exchanges, 'big bangs' matching artists, authors, and/or podficcers, or other types of creative challenges, as well as simple collections of fanworks chosen by the collection maintainer. <%= link_to ts("Learn more about collections."), archive_faq_path("collections-and-challenges") %>
+			<p>Collections are groups of works collected together under one heading. Collections can be fic or art fests, exchanges, 'big bangs' matching artists, authors, and/or podficcers, or other types of creative challenges, as well as simple collections of fanworks chosen by the collection maintainer. <%= link_to ts("Learn more about collections."), archive_faq_path("collections") %>
 			</p>
                         <h5 class="heading">What information can a challenge maintainer see about participants?</h5>
                         <p>A challenge or gift exchange maintainer can see prompts as well as the username and email address that participants use to sign up, in case the maintainer needs to communicate with participants. Other collection maintainers cannot see email addresses by virtue of having a user's work in their collections.</p>

--- a/config/locales/mailers/en.yml
+++ b/config/locales/mailers/en.yml
@@ -261,8 +261,8 @@ en:
       collection_items_link_text: "Approved Collection Items page"
       more_info:
         html: "For more information, visit our %{faq_link}."
-        text: "For more information, visit our Collections and Challenges FAQ: %{faq_url}"
-      faq_link_text: "Collections and Challenges FAQ"
+        text: "For more information, visit our Collections FAQ: %{faq_url}"
+      faq_link_text: "Collections FAQ"
     recipient_notification:
       subject:
         collection: "[%{app_name}][%{collection_title}] A gift work for you from %{collection_title}"


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [ ] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
No tests added. As far as I understand, we do not verify exact content of sent emails and do not test any user-facing large bodies of text like TOS FAQ
* [x] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [x] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-6220

## Purpose

Added more changes to existing ones as per information from tester.

- I believe FAQ itself is not available on development environments, so couldn't check the links by following them, but they look consistent with FAQ provided on AO3.
- both text/html is updated in emails (English version as the only one present in the source code)
- could check it only through developer log, not actual email (didn't figure out which setting to change, `PERFORM_DELIVERIES: true` seemed to have no effect).
- I assume we supply two versions of email (text/html) as we want to support email clients which do not support html

Only remaining "Collections and Challenges" labels that are still left are on the site_map, but they seem reasonable enough and anyway are not covered by the FAQ issue.
Search for "collections-and-challenges" doesn't give any results now.

## References

The original PR #4069.

## Credit

korrien, she/her
