### PR TITLE
AO3-6103 Shuffle URL position in challenge assignment email

### DIFF
--- a/app/views/user_mailer/challenge_assignment_notification.text.erb
+++ b/app/views/user_mailer/challenge_assignment_notification.text.erb
@@ -1,5 +1,5 @@
 <% content_for :message do %>
-<%= t ".text.part1", collection_title: @collection.title, collection_url: collection_url(@collection) %>
+<%= t ".text.assignment", collection_title: @collection.title, collection_url: collection_url(@collection) %>
 
 <%= t ".recipient" %> <%= @request.nil? ? t(".recipient_missing") : text_pseud(@request.pseud) %>
 

--- a/config/locales/mailers/en.yml
+++ b/config/locales/mailers/en.yml
@@ -182,7 +182,7 @@ en:
       due: "This assignment is due at:"
       any: "Any"
       text:
-        part1: "You have been assigned the following request in the \"%{collection_title}\" (%{collection_url}) challenge at the Archive of Our Own!"
+        assignment: "You have been assigned the following request in the \"%{collection_title}\" challenge (%{collection_url}) at the Archive of Our Own!"
         look_up: "You can look up this assignment from your Assignments page at %{link}."
         footer: "You're receiving this email because you signed up for the %{title} challenge (%{url}). For more information about this challenge and contact information for the moderators, please visit %{profile_url}."
       html:


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6103

## Purpose

Switch from `"%{collection_title}" (%{collection_url}) challenge` to `"%{collection_title}" challenge  (%{collection_url})`. 

Why? Because we have two instances of `"<%= @collection.title %>" collection (<%= collection_url(@collection) %>)` and one of `%{title} challenge (%{url})`.

I've renamed the key as well, since existing translations need updating now anyway. I didn't rename the corresponding key for the HTML version because those translations are still valid. We rename that one with i18n-tasks post-Phrase export. 

