### PR TITLE
AO3-6222 i18n Support form, fix text size issue, unlink email field & IP notice

### DIFF
--- a/app/views/feedbacks/new.html.erb
+++ b/app/views/feedbacks/new.html.erb
@@ -1,15 +1,15 @@
 <!--Descriptive page name, messages and instructions-->
 <%= error_messages_for :feedback %>
 
-<h2 class="heading"><%= ts("Support and Feedback") %></h2>
+<h2 class="heading"><%= t(".heading.page_title") %></h2>
 <!--/descriptions-->
 
 <!--subnav-->
-<h4 class="landmark heading"><%= ts("Reference Links") %></h4>
+<h4 class="landmark heading"><%= t(".heading.landmark.reference") %></h4>
 <ul class="navigation actions" role="navigation">
-  <li><%= link_to ts("FAQs & Tutorials"), archive_faqs_path %></li>
-  <li><%= link_to ts("Release Notes"), admin_posts_path(:tag => 1) %></li>
-  <li><%= link_to ts("Known Issues"), known_issues_path %></li>
+  <li><%= link_to t(".navigation.faqs"), archive_faqs_path %></li>
+  <li><%= link_to t(".navigation.release_notes"), admin_posts_path(:tag => 1) %></li>
+  <li><%= link_to t(".navigation.known_issues"), known_issues_path %></li>
 </ul>
 <!--/subnav-->
 
@@ -19,37 +19,37 @@
     <%= raw sanitize_field(@admin_setting, :disabled_support_form_text) %>
   </div>
 <% else %>
-  <h3 class="heading"><%= ts("Please use this form for questions about how to use the Archive and for reporting any technical problems.") %></h3>
+  <h3 class="heading"><%= t(".heading.instructions") %></h3>
   <div class="userstuff">
-    <p><%= ts("For current updates on Archive performance or downtime, please check out our Twitter feed: %{twitter_link}.",  twitter_link: link_to(ts("@AO3_Status"), "https://twitter.com/AO3_Status")).html_safe %></p>
-    <p><%= ts("For reports of violations of the Terms of Service such as harassment, spam, or plagiarism, or if you believe your account has been hacked, please %{contact_abuse_link} instead. We cannot act on these reports or provide information about Policy and Abuse cases.", contact_abuse_link: link_to(ts("contact our Policy and Abuse team"), new_abuse_report_path)).html_safe %></p>
-    <p><%= ts("Some issues you can contact Support about include:") %></p>
+    <p><%= t(".status.current", status_twitter_link: link_to(t(".status.twitter"), "https://twitter.com/AO3_Status")).html_safe %></p>
+    <p><%= t(".abuse", contact_abuse_link: link_to(t(".contact_abuse"), new_abuse_report_path)).html_safe %></p>
+    <p><%= t(".reportable.intro") %></p>
     <ul>
-      <li><%= ts("Bugs, errors, or unexpected site behavior") %></li>
-      <li><%= ts("Questions about how to use the site") %></li>
-      <li><%= ts("Problems setting up your account") %></li>
-      <li><%= ts("Lost password or email preventing access to your account") %></li>
-      <li><%= ts("Requests to canonize or change tags") %></li>
-      <li><%= ts("Feature requests for future development") %></li>
-      <li><%= ts("Questions about orphaned works") %></li>
-      <li><%= ts("Works labeled with the wrong language") %></li>
-      <li><%= ts("General site policy questions") %></li>
+      <li><%= t(".reportable.bugs") %></li>
+      <li><%= t(".reportable.site_questions") %></li>
+      <li><%= t(".reportable.account_creation") %></li>
+      <li><%= t(".reportable.lost_access") %></li>
+      <li><%= t(".reportable.tag_changes") %></li>
+      <li><%= t(".reportable.new_features") %></li>
+      <li><%= t(".reportable.orphaned_works") %></li>
+      <li><%= t(".reportable.work_language") %></li>
+      <li><%= t(".reportable.policy_questions") %></li>
     </ul>
-    <p><%= ts("<strong>We respond to every report we receive, but we are a small volunteer team.</strong> For this reason, we ask you to not submit multiple reports regarding any one issue, or encourage other people to report the same issue, unless there is additional information to offer.").html_safe %></p>
-    <p><%= ts("<strong>We can answer Support inquiries in %{list}.</strong> Please allow for additional delay for responses in any language other than English.", list: @support_languages.map(&:name).to_sentence).html_safe %></p>
+    <p><%= t(".do_not_spam_html") %></p>
+    <p><%= t(".languages_html", list: @support_languages.map(&:name).to_sentence) %></p>
   </div>
   <%= form_for(@feedback, html: {class: "post feedback"}) do |f| %>
     <fieldset>
-      <legend><%= ts("Contact Information") %></legend>
+      <legend><%= t(".form.legend.contact_info") %></legend>
       <p class="notice" id="email-field-description">
-        <%= ts("Our spam filter does collect IP addresses, but we never see them.") %>
+        <%= t(".form.ip") %>
       </p>
       <dl>
-        <dt><%= f.label :username, ts("Your name (optional)") %></dt>
+        <dt><%= f.label :username, t(".form.name.label") %></dt>
         <dd>
           <%= f.text_field :username %>
         </dd>
-        <dt class="required"><%= f.label :email, ts("Your email (required)") %></dt>
+        <dt class="required"><%= f.label :email, t(".form.email.label") %></dt>
         <dd class="required">
           <%= f.text_field :email, size: 60, "aria-describedby" => "email-field-description" %>
         </dd>
@@ -57,41 +57,41 @@
     </fieldset>
 
     <fieldset>
-      <legend><%= ts("Describe Your Feedback") %></legend>
+      <legend><%= t(".form.legend.feedback") %></legend>
       <dl>
         <dt class="required">
-          <%= f.label :language, ts("Select language (required)") %>
+          <%= f.label :language, t(".form.language.label") %>
         </dt>
         <dd class="required">
           <%= f.collection_select(:language, @support_languages, :name, :name, { selected: @feedback.language || Language.default.name }) %>
         </dd>
         <dt class="required">
-          <%= f.label :summary, ts("Brief summary of your question or problem (required)") %>
+          <%= f.label :summary, t(".form.summary.label") %>
         </dt>
         <dd class="required">
           <%= f.text_field :summary, size: 60, class: "observe_textlength" %>
           <%= generate_countdown_html("feedback_summary", ArchiveConfig.FEEDBACK_SUMMARY_MAX_DISPLAYED) %>
           <%= live_validation_for_field("feedback_summary",
-                failureMessage: ts("Please enter a brief summary of your message")) %>
+                failureMessage: t(".form.summary.error")) %>
         </dd>
         <dt class="required">
-          <%= f.label :comment, ts("Your question or problem (required)") %>
+          <%= f.label :comment, t(".form.comment.label") %>
         </dt>
         <dd class="required">
           <p id="comment-field-description">
-            <%= ts("Please be as specific as possible, including error messages and/or links") %>
+            <%= t(".form.comment.description") %>
           </p>
           <%= f.text_area :comment, cols: 60, "aria-describedby" => "comment-field-description" %>
           <%= live_validation_for_field("feedback_comment",
-                failureMessage: ts("Please enter your feedback")) %>
+                failureMessage: t(".form.comment.error")) %>
         </dd>
       </dl>
     </fieldset>
 
     <fieldset>
-      <legend><%= ts("Send Your Feedback") %></legend>
+      <legend><%= t(".form.legend.send") %></legend>
       <p class="submit actions">
-        <%= f.submit ts("Send"), data: { disable_with: ts("Please wait...") } %>
+        <%= f.submit t(".form.submit.active"), data: { disable_with: t(".form.submit.disabled") } %>
       </p>
     </fieldset>
   <% end %>

--- a/app/views/feedbacks/new.html.erb
+++ b/app/views/feedbacks/new.html.erb
@@ -41,7 +41,7 @@
   <%= form_for(@feedback, html: {class: "post feedback"}) do |f| %>
     <fieldset>
       <legend><%= t(".form.legend.contact_info") %></legend>
-      <p class="notice" id="email-field-description">
+      <p class="notice">
         <%= t(".form.ip") %>
       </p>
       <dl>
@@ -51,7 +51,7 @@
         </dd>
         <dt class="required"><%= f.label :email, t(".form.email.label") %></dt>
         <dd class="required">
-          <%= f.text_field :email, size: 60, "aria-describedby" => "email-field-description" %>
+          <%= f.text_field :email, size: 60 %>
         </dd>
       </dl>
     </fieldset>

--- a/app/views/feedbacks/new.html.erb
+++ b/app/views/feedbacks/new.html.erb
@@ -78,7 +78,7 @@
           <%= f.label :comment, ts("Your question or problem (required)") %>
         </dt>
         <dd class="required">
-          <p class="footnote" id="comment-field-description">
+          <p id="comment-field-description">
             <%= ts("Please be as specific as possible, including error messages and/or links") %>
           </p>
           <%= f.text_area :comment, cols: 60, "aria-describedby" => "comment-field-description" %>

--- a/app/views/feedbacks/new.html.erb
+++ b/app/views/feedbacks/new.html.erb
@@ -21,8 +21,8 @@
 <% else %>
   <h3 class="heading"><%= t(".heading.instructions") %></h3>
   <div class="userstuff">
-    <p><%= t(".status.current", status_twitter_link: link_to(t(".status.twitter"), "https://twitter.com/AO3_Status")).html_safe %></p>
-    <p><%= t(".abuse", contact_abuse_link: link_to(t(".contact_abuse"), new_abuse_report_path)).html_safe %></p>
+    <p><%= t(".status.current", twitter_link: link_to(t(".status.twitter"), "https://twitter.com/AO3_Status")).html_safe %></p>
+    <p><%= t(".abuse.reports", contact_link: link_to(t(".abuse.contact"), new_abuse_report_path)).html_safe %></p>
     <p><%= t(".reportable.intro") %></p>
     <ul>
       <li><%= t(".reportable.bugs") %></li>

--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -191,12 +191,13 @@ en:
         faqs: FAQs & Tutorials
         release_notes: Release Notes
         known_issues: Known Issues
-      contact_abuse: contact our Policy and Abuse team
       small_team: We respond to every report we receive, but we are a small volunteer team.
       status:
-        current: 'For current updates on Archive performance or downtime, please check out our Twitter feed: %{status_twitter_link}.'
+        current: 'For current updates on Archive performance or downtime, please check out our Twitter feed: %{twitter_link}.'
         twitter: '@AO3_Status'
-      abuse: For reports of violations of the Terms of Service such as harassment, spam, or plagiarism, or if you believe your account has been hacked, please %{contact_abuse_link} instead. We cannot act on these reports or provide information about Policy and Abuse cases.
+      abuse:
+        reports: For reports of violations of the Terms of Service such as harassment, spam, or plagiarism, or if you believe your account has been hacked, please %{contact_link} instead. We cannot act on these reports or provide information about Policy and Abuse cases.
+        contact: contact our Policy and Abuse team
       reportable:
         intro: 'Some issues you can contact Support about include:'
         bugs: Bugs, errors, or unexpected site behavior

--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -232,7 +232,3 @@ en:
           error: Please enter your feedback
           description: Please be as specific as possible, including error messages and/or links
         ip: Our spam filter does collect IP addresses, but we never see them.
-
-
-
-

--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -180,3 +180,59 @@ en:
   skins:
     confirm_delete:
       confirm_html: Are you sure you want to <strong><em>delete</em></strong> the skin "%{skin_title}"?
+  feedbacks:
+    new:
+      heading:
+        page_title: Support and Feedback
+        instructions: Please use this form for questions about how to use the Archive and for reporting any technical problems.
+        landmark:
+          reference: Reference Links
+      navigation:
+        faqs: FAQs & Tutorials
+        release_notes: Release Notes
+        known_issues: Known Issues
+      contact_abuse: contact our Policy and Abuse team
+      small_team: We respond to every report we receive, but we are a small volunteer team.
+      status:
+        current: 'For current updates on Archive performance or downtime, please check out our Twitter feed: %{status_twitter_link}.'
+        twitter: '@AO3_Status'
+      abuse: For reports of violations of the Terms of Service such as harassment, spam, or plagiarism, or if you believe your account has been hacked, please %{contact_abuse_link} instead. We cannot act on these reports or provide information about Policy and Abuse cases.
+      reportable:
+        intro: 'Some issues you can contact Support about include:'
+        bugs: Bugs, errors, or unexpected site behavior
+        site_questions: Questions about how to use the site
+        account_creation: Problems setting up your account
+        lost_access: Lost password or email preventing access to your account
+        tag_changes: Requests to canonize or change tags
+        new_features: Feature requests for future development
+        orphaned_works: Questions about orphaned works
+        work_language: Works labeled with the wrong language
+        policy_questions: General site policy questions
+      do_not_spam_html: <strong>We respond to every report we receive, but we are a small volunteer team.</strong> For this reason, we ask you to not submit multiple reports regarding any one issue, or encourage other people to report the same issue, unless there is additional information to offer.
+      languages_html: <strong>We can answer Support inquiries in %{list}.</strong> Please allow for additional delay for responses in any language other than English.
+      form:
+        legend:
+          contact_info: Contact Information
+          feedback: Describe Your Feedback
+          send: Send Your Feedback
+        submit:
+          active: Send
+          disabled: Please wait...
+        name:
+          label: Your name (optional)
+        email:
+          label: Your email (required)
+        language:
+          label: Select language (required)
+        summary:
+          label: Brief summary of your question or problem (required)
+          error: Please enter a brief summary of your message
+        comment:
+          label: Your question or problem (required)
+          error: Please enter your feedback
+          description: Please be as specific as possible, including error messages and/or links
+        ip: Our spam filter does collect IP addresses, but we never see them.
+
+
+
+

--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -191,7 +191,6 @@ en:
         faqs: FAQs & Tutorials
         release_notes: Release Notes
         known_issues: Known Issues
-      small_team: We respond to every report we receive, but we are a small volunteer team.
       status:
         current: 'For current updates on Archive performance or downtime, please check out our Twitter feed: %{twitter_link}.'
         twitter: '@AO3_Status'


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6222

## Purpose

* Removes the `footnote` class that was making a description too small
* Removes the ARIA connection between the email address field and IP notice (why did I ever do that?)
* i18n per original issue description
  * We don't use `*_html` keys in emails, but we have them for other views, so wheee.

## Testing Instructions

* Read contents of page and compare with text in issue
* Submit blank form and make sure error messages appear on summary and comment fields and "Send" button becomes "Please wait..."
