### PR TITLE
AO3-6221 Update and internationalize abuse form text

### DIFF
--- a/app/views/abuse_reports/new.html.erb
+++ b/app/views/abuse_reports/new.html.erb
@@ -1,5 +1,5 @@
 <!--Descriptive page name, messages and instructions-->
-<h2 class="heading"><%= ts("Report Abuse") %></h2>
+<h2 class="heading"><%= t(".heading.page_title") %></h2>
 <%= error_messages_for :abuse_report %>
 <!--/descriptions-->
 
@@ -8,81 +8,74 @@
 
 <!--main content-->
 <div class="userstuff">
-  <p><%= ts("The Abuse committee looks after all of your concerns regarding content and user behavior which breach the
-           Archive %{tos_link}. For technical help, please %{support_link}.",
-            tos_link: (link_to ts("Terms of Service"), tos_path), support_link: (link_to ts("contact Support"),
-                                                                                         new_feedback_report_path)).html_safe %></p>
-  <p><%= ts("<strong>We investigate every report we receive.</strong> For this reason, we ask you to not submit several
-           reports regarding any one issue unless you have additional information to offer. We also ask that you do not
-           encourage other users to submit a report regarding content you have already reported. Doing so slows down our
-           response and reaction time considerably, as we are a small volunteer-based committee.").html_safe %></p>
+  <p><%= t(".purview.about",
+            tos_link: (link_to t(".purview.tos"), tos_path),
+            support_link: (link_to t(".purview.support"), new_feedback_report_path)).html_safe %></p>
+  <p><%= t(".do_not_spam_html") %></p>
   <p>
-    <%= ts("Please submit a report via this form if you have not submitted this report within the past sixty (60) days,
-          and you:") %>
+    <%= t(".reportable.intro") %>
   </p>
   <ul>
-    <li><%= ts("would like to contact us regarding your %{fnok}, or", fnok: (link_to ts("Fannish Next of Kin"), tos_faq_path(anchor: "next_of_kin"))).html_safe %></li>
-    <li><%= ts("believe that your account has been hacked, or that someone is trying to hack your account, or") %></li>
-    <li><%= ts("believe you have found content uploaded to the Archive which breaches our Terms of Service, or") %></li>
-    <li><%= ts("would like to lodge a DMCA claim - please review our %{dmca_link}", dmca_link:
-            (link_to ts("DMCA Policy"), dmca_path)).html_safe %></li>
+    <li><%= t(".reportable.fnok.concerning", fnok_link: (link_to t(".reportable.fnok.fnok"), tos_faq_path(anchor: "next_of_kin"))).html_safe %></li>
+    <li><%= t(".reportable.hack") %></li>
+    <li><%= t(".reportable.tos") %></li>
+    <li><%= t(".reportable.dmca.claim", dmca_link:
+            (link_to t(".reportable.dmca.policy"), dmca_path)).html_safe %></li>
   </ul>
-  <p><%= ts("<strong>We can answer Abuse reports in %{list}.</strong> Please allow for an additional delay for responses
-            in any language other than English.", list: @abuse_languages.map(&:name).to_sentence).html_safe %></p>
+  <p><%= t(".languages_html", list: @abuse_languages.map(&:name).to_sentence).html_safe %></p>
 </div>
 <%= form_for @abuse_report, class: "post" do |f| %>
   <fieldset>
-    <legend><%= ts("Link and Describe Abuse") %></legend>
+    <legend><%= t(".form.legend.abuse") %></legend>
     <dl>
-      <dt><%= f.label :username, ts("Your name (optional)") %></dt>
+      <dt><%= f.label :username, t(".form.name.label") %></dt>
       <dd><%= f.text_field :username %></dd>
-      <dt class="required"><%= f.label :email, ts("Your email (required)") %></dt>
+      <dt class="required"><%= f.label :email, t(".form.email.label") %></dt>
       <dd class="required">
         <%= f.text_field :email, "aria-describedby" => "email-field-description" %>
         <p class="footnote" id="email-field-description">
-          <%= ts("We cannot act on reports without a valid email address.") %>
+          <%= t(".form.email.description") %>
         </p>
       </dd>
       <dt class="required">
-        <%= f.label :language, ts("Select language (required)") %>
+        <%= f.label :language, t(".form.language.label") %>
       </dt>
       <dd class="required">
         <%= f.collection_select(:language, @abuse_languages, :name, :name, { selected: @abuse_report.language || Language.default.name }) %>
       </dd>
       <dt class="required">
-        <%= f.label :summary, ts("Brief summary of Terms of Service Violation (required)") %>
+        <%= f.label :summary, t(".form.summary.label") %>
       </dt>
       <dd class="required">
         <%= f.text_field :summary, class: "observe_textlength" %>
         <%= generate_countdown_html("abuse_report_summary", ArchiveConfig.FEEDBACK_SUMMARY_MAX_DISPLAYED) %>
         <%= live_validation_for_field("abuse_report_summary",
-                                      failureMessage: ts("Please enter a brief summary of your message")) %>
+                                      failureMessage: t(".form.summary.error")) %>
       </dd>
 
-      <dt class="required"><%= f.label :url, ts("Link to the page you are reporting (required)") %></dt>
+      <dt class="required"><%= f.label :url, t(".form.link.label") %></dt>
       <dd class="required">
         <%= f.text_field :url, size: 60, "aria-describedby" => "url-field-description" %>
         <%= live_validation_for_field("abuse_report_url",
-              failureMessage: ts("Please enter the link to the page you are reporting.")) %>
+              failureMessage: t(".form.link.error")) %>
         <p class="footnote" id="url-field-description">
-          <%= ts("If you came here from the abuse link at the bottom of the page, this will be filled in for you.") %>
+          <%= t(".form.link.description") %>
         </p>
       </dd>
       <dt class="required">
-        <%= f.label :comment, ts("Your comment (required)") %>
+        <%= f.label :comment, t(".form.comment.label") %>
       </dt>
       <dd class="required">
         <p id="comment-field-description">
-          <%= ts("Please include all relevant URLs and what about the content violates the Archive %{tos_link}. The more
-              thorough the information the quicker we can start investigating.",
-                  tos_link: (link_to ts("Terms of Service"), tos_path)).html_safe %>
+          <%= t(".form.comment.description",
+                  tos_link: (link_to t(".form.comment.tos"), tos_path)).html_safe %>
         </p>
         <%= f.text_area :comment, "aria-describedby" => "comment-field-description" %>
         <%= live_validation_for_field("abuse_report_comment",
-              failureMessage: ts("Please describe your concern.")) %>
+              failureMessage: t(".form.comment.error")) %>
       </dd>
-      <dt class="landmark"><%= ts("Send to Abuse Team") %></dt>
-      <dd class="submit actions"><%= f.submit ts("Submit") %></dd>
+      <dt class="landmark"><%= t(".form.landmark.send") %></dt>
+      <dd class="submit actions"><%= f.submit t(".form.submit.active") %></dd>
     </dl>
   </fieldset>
 

--- a/app/views/abuse_reports/new.html.erb
+++ b/app/views/abuse_reports/new.html.erb
@@ -9,20 +9,20 @@
 <!--main content-->
 <div class="userstuff">
   <p><%= ts("The Abuse committee looks after all of your concerns regarding content and user behavior which breach the
-           Archive %{tos_link}. For technical help, please contact %{support_link}.",
-            tos_link: (link_to ts("Terms of Service"), tos_path), support_link: (link_to ts("Support"),
+           Archive %{tos_link}. For technical help, please %{support_link}.",
+            tos_link: (link_to ts("Terms of Service"), tos_path), support_link: (link_to ts("contact Support"),
                                                                                          new_feedback_report_path)).html_safe %></p>
   <p><%= ts("<strong>We investigate every report we receive.</strong> For this reason, we ask you to not submit several
            reports regarding any one issue unless you have additional information to offer. We also ask that you do not
            encourage other users to submit a report regarding content you have already reported. Doing so slows down our
            response and reaction time considerably, as we are a small volunteer-based committee.").html_safe %></p>
   <p>
-    <%= ts("Please submit a report via this form if you have not submitted this report within the past fourteen (14) days,
+    <%= ts("Please submit a report via this form if you have not submitted this report within the past sixty (60) days,
           and you:") %>
   </p>
   <ul>
     <li><%= ts("would like to contact us regarding your %{fnok}, or", fnok: (link_to ts("Fannish Next of Kin"), tos_faq_path(anchor: "next_of_kin"))).html_safe %></li>
-    <li><%= ts("have lost or forgotten your login details, or") %></li>
+    <li><%= ts("believe that your account has been hacked, or that someone is trying to hack your account, or") %></li>
     <li><%= ts("believe you have found content uploaded to the Archive which breaches our Terms of Service, or") %></li>
     <li><%= ts("would like to lodge a DMCA claim - please review our %{dmca_link}", dmca_link:
             (link_to ts("DMCA Policy"), dmca_path)).html_safe %></li>

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -657,25 +657,6 @@
     {
       "warning_type": "Cross Site Scripting",
       "warning_code": 2,
-      "fingerprint": "4f78e7c315b88714e75a021b21acc1f20dd1148c558a4c8d1ad2b5378ab73165",
-      "check_name": "CrossSiteScripting",
-      "message": "Unescaped model attribute",
-      "file": "app/views/abuse_reports/new.html.erb",
-      "line": 31,
-      "link": "http://brakemanscanner.org/docs/warning_types/cross_site_scripting",
-      "code": "ts(\"<strong>We can answer Abuse reports in %{list}.</strong> Please allow for an additional delay for responses\\n            in any language other than English.\", :list => Language.where(:abuse_support_available => true).default_order.map(&:name).to_sentence)",
-      "render_path": [{"type":"controller","class":"AbuseReportsController","method":"create","line":23,"file":"app/controllers/abuse_reports_controller.rb"}],
-      "location": {
-        "type": "template",
-        "template": "abuse_reports/new"
-      },
-      "user_input": "Language.where(:abuse_support_available => true).default_order",
-      "confidence": "Weak",
-      "note": ""
-    },
-    {
-      "warning_type": "Cross Site Scripting",
-      "warning_code": 2,
       "fingerprint": "4fb400b7bf3636d332686edfe800d418c29f8229587690d6a7724789600f49f1",
       "check_name": "CrossSiteScripting",
       "message": "Unescaped model attribute",
@@ -1249,6 +1230,25 @@
       },
       "user_input": null,
       "confidence": "High",
+      "note": ""
+    },
+    {
+      "warning_type": "Cross Site Scripting",
+      "warning_code": 2,
+      "fingerprint": "989c498b72a408d1131482d595850cdad4a03ab0fa1c7bbd3ce1067b46c4d0b0",
+      "check_name": "CrossSiteScripting",
+      "message": "Unescaped model attribute",
+      "file": "app/views/abuse_reports/new.html.erb",
+      "line": 25,
+      "link": "http://brakemanscanner.org/docs/warning_types/cross_site_scripting",
+      "code": "t(\".languages_html\", :list => Language.where(:abuse_support_available => true).default_order.map(&:name).to_sentence)",
+      "render_path": [{"type":"controller","class":"AbuseReportsController","method":"create","line":23,"file":"app/controllers/abuse_reports_controller.rb"}],
+      "location": {
+        "type": "template",
+        "template": "abuse_reports/new"
+      },
+      "user_input": "Language.where(:abuse_support_available => true).default_order",
+      "confidence": "Weak",
       "note": ""
     },
     {
@@ -1908,6 +1908,6 @@
       "note": ""
     }
   ],
-  "updated": "2021-09-01 16:35:03 +0700",
+  "updated": "2021-09-17 16:29:36 -0400",
   "brakeman_version": "3.7.2"
 }

--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -180,3 +180,49 @@ en:
   skins:
     confirm_delete:
       confirm_html: Are you sure you want to <strong><em>delete</em></strong> the skin "%{skin_title}"?
+  abuse_reports:
+    new:
+      heading:
+        page_title: Report Abuse
+      purview:
+        about: The Abuse committee looks after all of your concerns regarding content and user behavior which breach the Archive %{tos_link}. For technical help, please %{support_link}.
+        tos: Terms of Service
+        support: contact Support
+      do_not_spam_html: <strong>We investigate every report we receive.</strong> For this reason, we ask you to not submit several reports regarding any one issue unless you have additional information to offer. We also ask that you do not encourage other users to submit a report regarding content you have already reported. Doing so slows down our response and reaction time considerably, as we are a small volunteer-based committee.
+      reportable:
+        intro: 'Please submit a report via this form if you have not submitted this report within the past sixty (60) days, and you:'
+        fnok:
+          concerning: would like to contact us regarding your %{fnok_link}, or
+          fnok: Fannish Next of Kin
+        hack: believe that your account has been hacked, or that someone is trying to hack your account, or
+        tos: believe you have found content uploaded to the Archive which breaches our Terms of Service, or
+        dmca:
+          claim: would like to lodge a DMCA claim - please review our %{dmca_link}
+          policy: DMCA Policy
+      languages_html: <strong>We can answer Abuse reports in %{list}.</strong> Please allow for an additional delay for responses in any language other than English.
+      form:
+        legend:
+          abuse: Link and Describe Abuse
+        landmark:
+          send: Send to Abuse Team
+        submit:
+          active: Submit
+        name:
+          label: Your name (optional)
+        email:
+          label: Your email (required)
+          description: We cannot act on reports without a valid email address.
+        language:
+          label: Select language (required)
+        summary:
+          label: Brief summary of Terms of Service Violation (required)
+          error: Please enter a brief summary of your message
+        comment:
+          label: Your comment (required)
+          error: Please describe your concern.
+          description: Please include all relevant URLs and what about the content violates the Archive %{tos_link}. The more thorough the information the quicker we can start investigating.
+          tos: Terms of Service
+        link:
+          label: Link to the page you are reporting (required)
+          error: Please enter the link to the page you are reporting.
+          description: If you came here from the abuse link at the bottom of the page, this will be filled in for you.


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6221

## Purpose

We announced purview change for Support and PAC; this updates the abuse form accordingly. The main support form changes were already merged, but additional changes are in #4085.

## Testing Instructions

* Read the page text and compare to what is on production and what is in the issue
* Press "Submit" with all fields blank and make sure "Brief summary of Terms of Service Violation (required)" and "Your comment (required)" get errors displayed


## References

I used the same structure for the keys as #4085 even when not quite necessary because the pages often mirror each other in structure/content/behavior and tweaks to bring them closer in line would not surprise me.