### PR TITLE
AO3-6225 Make comparison of email addresses case-insensitive

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -170,17 +170,14 @@ class UsersController < ApplicationController
     if !params[:new_email].blank? && reauthenticate
       new_email = params[:new_email]
 
-      # Please note: This comparison is not technically
-      # correct. According to RFC 5321, the local part of
-      # an email address is case sensitive, while the
-      # domain is case insensitive. That said, all major
-      # email providers treat the local part as case
-      # insensitive, so it would probably cause more confusion
-      # if we did this correctly.
+      # Please note: This comparison is not technically correct. According to
+      # RFC 5321, the local part of an email address is case sensitive, while the
+      # domain is case insensitive. That said, all major email providers treat
+      # the local part as case insensitive, so it would probably cause more
+      # confusion if we did this correctly.
       #
-      # Also, email addresses are validated on the client, and
-      # will only contain a limited subset of ASCII, so we don't
-      # need to do a unicode casefolding pass.
+      # Also, email addresses are validated on the client, and will only contain
+      # a limited subset of ASCII, so we don't need to do a unicode casefolding pass.
       if new_email.downcase != params[:email_confirmation].downcase
         flash.now[:error] = ts("Email addresses don't match! Please retype and try again")
         render :change_email and return

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -179,7 +179,7 @@ class UsersController < ApplicationController
       # Also, email addresses are validated on the client, and will only contain
       # a limited subset of ASCII, so we don't need to do a unicode casefolding pass.
       if new_email.downcase != params[:email_confirmation].downcase
-        flash.now[:error] = ts("Email addresses don't match! Please retype and try again")
+        flash.now[:error] = ts("Email addresses don't match! Please retype and try again.")
         render :change_email and return
       end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -170,7 +170,18 @@ class UsersController < ApplicationController
     if !params[:new_email].blank? && reauthenticate
       new_email = params[:new_email]
 
-      if new_email != params[:email_confirmation]
+      # Please note: This comparison is not technically
+      # correct. According to RFC 5321, the local part of
+      # an email address is case sensitive, while the
+      # domain is case insensitive. That said, all major
+      # email providers treat the local part as case
+      # insensitive, so it would probably cause more confusion
+      # if we did this correctly.
+      #
+      # Also, email addresses are validated on the client, and
+      # will only contain a limited subset of ASCII, so we don't
+      # need to do a unicode casefolding pass.
+      if new_email.downcase != params[:email_confirmation].downcase
         flash.now[:error] = ts("Email addresses don't match! Please retype and try again")
         render :change_email and return
       end

--- a/features/other_a/profile_edit.feature
+++ b/features/other_a/profile_edit.feature
@@ -44,12 +44,12 @@ Scenario: Changing email address - entering an invalid email address
   Then I should see "Email does not seem to be a valid address"
     And 0 emails should be delivered
 
-Scenario: Changing email address - case-insensitive comparison
+Scenario: Changing email address - case-insensitive confirmation
 
   When I follow "Change Email"
     And I fill in "New Email" with "foo@example.com"
     And I fill in "Confirm New Email" with "FoO@example.com"
-    And I enter my password
+    And I fill in "Password" with "password"
     And I press "Change Email"
   Then I should see "Your email has been successfully updated"
     And 1 email should be delivered to "bar@ao3.org"

--- a/features/other_a/profile_edit.feature
+++ b/features/other_a/profile_edit.feature
@@ -44,6 +44,22 @@ Scenario: Changing email address - entering an invalid email address
   Then I should see "Email does not seem to be a valid address"
     And 0 emails should be delivered
 
+Scenario: Changing email address - case-insensitive comparison
+
+  When I follow "Change Email"
+    And I fill in "New Email" with "foo@example.com"
+    And I fill in "Confirm New Email" with "FoO@example.com"
+    And I enter my password
+    And I press "Change Email"
+  Then I should see "Your email has been successfully updated"
+    And 1 email should be delivered to "bar@ao3.org"
+    And all emails have been delivered
+    And the email should contain "the email associated with your account has been changed to"
+    And the email should contain "foo@example.com"
+    And the email should not contain "translation missing"
+  When I change my preferences to display my email address
+  Then I should see "My email address: foo@example.com"
+
 Scenario: Changing email address - entering an incorrect password
 
   When I enter an incorrect password

--- a/features/step_definitions/profile_steps.rb
+++ b/features/step_definitions/profile_steps.rb
@@ -46,9 +46,6 @@ When /^I change my email$/ do
   click_button("Change Email")
 end
 
-When /^I enter my password$/ do
-  fill_in("password_check", with: "password")
-end
 
 When /^I view my profile$/ do
   visit user_path(User.current_user)

--- a/features/step_definitions/profile_steps.rb
+++ b/features/step_definitions/profile_steps.rb
@@ -46,6 +46,9 @@ When /^I change my email$/ do
   click_button("Change Email")
 end
 
+When /^I enter my password$/ do
+  fill_in("password_check", with: "password")
+end
 
 When /^I view my profile$/ do
   visit user_path(User.current_user)


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [x] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [x] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [x] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-6225

## Purpose

This PR makes it so that the email address confirmation is compared case-insensitively when a user changes their email.

## Testing Instructions

Follow the Steps to Reproduce from the JIRA ticket, and ensure that no error message is seen.

## References

None that I'm aware of.

## Credit

What name and pronouns should we use to credit you in the [Archive of Our Own's Release Notes](https://archiveofourown.org/admin_posts?tag=1)?

Daroc Alden, they/them