### PR TITLE
AO3-6109 Add missing with_locale for some internationalized mailers

### DIFF
--- a/app/mailers/archive_devise_mailer.rb
+++ b/app/mailers/archive_devise_mailer.rb
@@ -17,7 +17,5 @@ class ArchiveDeviseMailer < Devise::Mailer
       devise_mail(record, :reset_password_instructions,
                   options.merge(subject: subject))
     end
-  ensure
-    I18n.locale = I18n.default_locale
   end
 end

--- a/app/mailers/comment_mailer.rb
+++ b/app/mailers/comment_mailer.rb
@@ -13,8 +13,6 @@ class CommentMailer < ActionMailer::Base
         subject: "[#{ArchiveConfig.APP_SHORT_NAME}] Comment on " + (@comment.ultimate_parent.is_a?(Tag) ? "the tag " : "") + @comment.ultimate_parent.commentable_name.gsub("&gt;", ">").gsub("&lt;", "<")
       )
     end
-    ensure
-      I18n.locale = I18n.default_locale
   end
 
   # Sends email to an owner of the top-level commentable when a comment is edited
@@ -26,8 +24,6 @@ class CommentMailer < ActionMailer::Base
         subject: "[#{ArchiveConfig.APP_SHORT_NAME}] Edited comment on " + (@comment.ultimate_parent.is_a?(Tag) ? "the tag " : "") + @comment.ultimate_parent.commentable_name.gsub("&gt;", ">").gsub("&lt;", "<")
       )
     end
-    ensure
-      I18n.locale = I18n.default_locale
   end
 
   # Sends email to commenter when a reply is posted to their comment
@@ -41,8 +37,6 @@ class CommentMailer < ActionMailer::Base
       to: @your_comment.comment_owner_email,
       subject: "[#{ArchiveConfig.APP_SHORT_NAME}] Reply to your comment on " + (@comment.ultimate_parent.is_a?(Tag) ? "the tag " : "") + @comment.ultimate_parent.commentable_name.gsub("&gt;", ">").gsub("&lt;", "<")
     )
-    ensure
-      I18n.locale = I18n.default_locale
   end
 
   # Sends email to commenter when a reply to their comment is edited
@@ -56,8 +50,6 @@ class CommentMailer < ActionMailer::Base
       to: @your_comment.comment_owner_email,
       subject: "[#{ArchiveConfig.APP_SHORT_NAME}] Edited reply to your comment on " + (@comment.ultimate_parent.is_a?(Tag) ? "the tag " : "") + @comment.ultimate_parent.commentable_name.gsub("&gt;", ">").gsub("&lt;", "<")
     )
-    ensure
-      I18n.locale = I18n.default_locale
   end
 
   # Sends email to the poster of a comment
@@ -68,8 +60,6 @@ class CommentMailer < ActionMailer::Base
       to: @comment.comment_owner_email,
       subject: "[#{ArchiveConfig.APP_SHORT_NAME}] Comment you left on " + (@comment.ultimate_parent.is_a?(Tag) ? "the tag " : "") + @comment.ultimate_parent.commentable_name.gsub("&gt;", ">").gsub("&lt;", "<")
     )
-    ensure
-      I18n.locale = I18n.default_locale
   end
 
 end

--- a/app/mailers/kudo_mailer.rb
+++ b/app/mailers/kudo_mailer.rb
@@ -44,8 +44,6 @@ class KudoMailer < ActionMailer::Base
         subject: t('mailer.kudos.you_have', app_name: ArchiveConfig.APP_SHORT_NAME)
       )
     end
-    ensure
-      I18n.locale = I18n.default_locale
   end
 
   def guest_kudos(guest_count)

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -228,7 +228,7 @@ class UserMailer < ActionMailer::Base
     @assigned_user = User.find(assigned_user_id)
     assignment = ChallengeAssignment.find(assignment_id)
     @request = (assignment.request_signup || assignment.pinch_request_signup)
-    I18n.with_locale(Locale.find(@user.preference.preferred_locale).iso) do
+    I18n.with_locale(Locale.find(@assigned_user.preference.preferred_locale).iso) do
       mail(
         to: @assigned_user.email,
         subject: default_i18n_subject(app_name: ArchiveConfig.APP_SHORT_NAME, collection_title: @collection.title)

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -234,8 +234,6 @@ class UserMailer < ActionMailer::Base
         subject: default_i18n_subject(app_name: ArchiveConfig.APP_SHORT_NAME, collection_title: @collection.title)
       )
     end
-    ensure
-      I18n.locale = I18n.default_locale
   end
 
   # Asks a user to validate and activate their new account
@@ -247,8 +245,6 @@ class UserMailer < ActionMailer::Base
         subject: t('user_mailer.signup_notification.subject', app_name: ArchiveConfig.APP_SHORT_NAME)
       )
     end
-    ensure
-      I18n.locale = I18n.default_locale
   end
 
   # Confirms to a user that their email was changed
@@ -262,8 +258,6 @@ class UserMailer < ActionMailer::Base
         subject: t('user_mailer.change_email.subject', app_name: ArchiveConfig.APP_SHORT_NAME)
       )
     end
-    ensure
-      I18n.locale = I18n.default_locale
   end
 
   ### WORKS NOTIFICATIONS ###
@@ -281,8 +275,6 @@ class UserMailer < ActionMailer::Base
                    app_name: ArchiveConfig.APP_SHORT_NAME)
       )
     end
-  ensure
-    I18n.locale = I18n.default_locale
   end
 
   # Sends email when a user is added as a co-creator
@@ -298,8 +290,6 @@ class UserMailer < ActionMailer::Base
                    app_name: ArchiveConfig.APP_SHORT_NAME)
       )
     end
-  ensure
-    I18n.locale = I18n.default_locale
   end
 
   # Sends email when a user is added as an unapproved/pending co-creator
@@ -315,8 +305,6 @@ class UserMailer < ActionMailer::Base
                    app_name: ArchiveConfig.APP_SHORT_NAME)
       )
     end
-  ensure
-    I18n.locale = I18n.default_locale
   end
 
   # Sends emails to creators whose stories were listed as the inspiration of another work
@@ -331,8 +319,6 @@ class UserMailer < ActionMailer::Base
         subject: "[#{ArchiveConfig.APP_SHORT_NAME}] Related work notification"
       )
     end
-    ensure
-      I18n.locale = I18n.default_locale
   end
 
   # Emails a recipient to say that a gift has been posted for them
@@ -354,8 +340,6 @@ class UserMailer < ActionMailer::Base
         subject: subject
       )
     end
-    ensure
-      I18n.locale = I18n.default_locale
   end
 
   # Emails a prompter to say that a response has been posted to their prompt
@@ -371,8 +355,6 @@ class UserMailer < ActionMailer::Base
         )
       end
     end
-    ensure
-      I18n.locale = I18n.default_locale
   end
 
   # Sends email to creators when a creation is deleted
@@ -392,8 +374,6 @@ class UserMailer < ActionMailer::Base
         subject: t('user_mailer.delete_work_notification.subject', app_name: ArchiveConfig.APP_SHORT_NAME)
       )
     end
-    ensure
-      I18n.locale = I18n.default_locale
   end
 
   # Sends email to creators when a creation is deleted by an admin
@@ -413,8 +393,6 @@ class UserMailer < ActionMailer::Base
         subject: t('user_mailer.admin_deleted_work_notification.subject', app_name: ArchiveConfig.APP_SHORT_NAME)
       )
     end
-    ensure
-      I18n.locale = I18n.default_locale
   end
 
   # Sends email to creators when a creation is hidden by an admin
@@ -428,8 +406,6 @@ class UserMailer < ActionMailer::Base
         subject: default_i18n_subject(app_name: ArchiveConfig.APP_SHORT_NAME)
       )
     end
-    ensure
-      I18n.locale = I18n.default_locale
   end
 
   def admin_spam_work_notification(creation_id, user_id)

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -70,8 +70,6 @@ class UserMailer < ActionMailer::Base
                    app_name: ArchiveConfig.APP_SHORT_NAME)
       )
     end
-  ensure
-    I18n.locale = I18n.default_locale
   end
 
   # Sends an invitation to join the archive
@@ -115,8 +113,6 @@ class UserMailer < ActionMailer::Base
         subject: "[#{ArchiveConfig.APP_SHORT_NAME}] Works uploaded"
       )
     end
-    ensure
-      I18n.locale = I18n.default_locale
   end
 
   # Sends a batched subscription notification
@@ -160,8 +156,6 @@ class UserMailer < ActionMailer::Base
         subject: "[#{ArchiveConfig.APP_SHORT_NAME}] #{subject}"
       )
     end
-    ensure
-      I18n.locale = I18n.default_locale
   end
 
   # Emails a user to say they have been given more invitations for their friends
@@ -174,8 +168,6 @@ class UserMailer < ActionMailer::Base
         subject: "#{t 'user_mailer.invite_increase_notification.subject', app_name: ArchiveConfig.APP_SHORT_NAME}"
       )
     end
-    ensure
-      I18n.locale = I18n.default_locale
   end
 
   # Emails a user to say that their request for invitation codes has been declined
@@ -189,8 +181,6 @@ class UserMailer < ActionMailer::Base
         subject: t('user_mailer.invite_request_declined.subject', app_name: ArchiveConfig.APP_SHORT_NAME)
       )
     end
-    ensure
-      I18n.locale = I18n.default_locale
   end
 
   # TODO: This may be sent to multiple users simultaneously. We need to ensure

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -429,7 +429,7 @@ class UserMailer < ActionMailer::Base
       )
     end
     ensure
-     I18n.locale = I18n.default_locale
+      I18n.locale = I18n.default_locale
   end
 
   def admin_spam_work_notification(creation_id, user_id)


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6109

## Purpose

There were a couple emails whose content we'd prepared for localization, but for which we hadn't updated the code to send the emails in the users' preferred locale. 

This ensures challenge_assignment_notification and admin_hidden_work_notification take a user's locale preference into account. It also updates some code comments.

## Testing Instructions

For now: 
* As an admin, hide a work. Ensure the work creator gets an email saying the work was hidden.
* Send assignments for a gift exchange. Ensure the participants get emails notifying them of their assignments.

