### PR TITLE
AO3-6093 Propagate tags from original admin posts to translations

### DIFF
--- a/app/models/admin_post.rb
+++ b/app/models/admin_post.rb
@@ -38,8 +38,8 @@ class AdminPost < ApplicationRecord
 
   scope :for_homepage, -> { order("created_at DESC").limit(ArchiveConfig.NUMBER_OF_ITEMS_VISIBLE_ON_HOMEPAGE) }
 
-  before_save :inherit_translated_post_comment_permissions
-  after_save :expire_cached_home_admin_posts, :update_translation_comment_permissions
+  before_save :inherit_translated_post_comment_permissions, :inherit_translated_post_tags
+  after_save :expire_cached_home_admin_posts, :update_translation_comment_permissions, :update_translation_tags
   after_destroy :expire_cached_home_admin_posts
 
   # Return the name to link comments to for this object
@@ -84,12 +84,29 @@ class AdminPost < ApplicationRecord
     self.comment_permissions = translated_post.comment_permissions
   end
 
+  def inherit_translated_post_tags
+    return if translated_post.blank?
+
+    self.tags = translated_post.tags
+  end
+
   def update_translation_comment_permissions
     return if translations.blank?
 
     transaction do
       translations.find_each do |post|
         post.comment_permissions = self.comment_permissions
+        post.save
+      end
+    end
+  end
+
+  def update_translation_tags
+    return if translations.blank?
+
+    transaction do
+      translations.find_each do |post|
+        post.tags = self.tags
         post.save
       end
     end

--- a/app/views/admin_posts/_admin_post_form.html.erb
+++ b/app/views/admin_posts/_admin_post_form.html.erb
@@ -33,10 +33,18 @@
       <dl>
         <dt><%= f.label :tag_list, t(".tags.label") %></dt>
         <dd>
-          <%= f.text_field :tag_list, autocomplete_options('admin_post_tags') %>
-          <p class="character_counter">
-            <%= ts("Comma separated, %{max} characters per tag", :max => ArchiveConfig.TAG_MAX) %>
-          </p>
+          <% if @admin_post.translated_post %>
+            <ul class="tags commas">
+              <% for tag in @admin_post.tags %>
+                <li><%= link_to tag.name, admin_posts_path(tag: tag.id), class: "tag" %></li>
+              <% end %>
+            </ul>
+          <% else %>
+            <%= f.text_field :tag_list, autocomplete_options("admin_post_tags") %>
+            <p class="character_counter">
+              <%= ts("Comma separated, %{max} characters per tag", max: ArchiveConfig.TAG_MAX) %>
+            </p>
+          <% end %>
         </dd>
         <dt>
           <%= f.label :language_id, t(".language.label") %>
@@ -55,7 +63,8 @@
                           title: ts('translation of'),
                           data: { autocomplete_token_limit: 1 }) %>
           <% unless @admin_post.translated_post %>
-            <p class="footnote"><%= t(".translated_post.footnote") %></p>
+            <p class="footnote"><%= t(".translated_post.footnote_comment_permissions") %></p>
+            <p class="footnote"><%= t(".translated_post.footnote_tags") %></p>
           <% end %>
         </dd>
         <dt class="permissions comments">

--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -66,7 +66,8 @@ en:
       tags:
         label: Tags
       translated_post:
-        footnote: Comment permissions from the selected post will replace any permissions selected on this page.
+        footnote_comment_permissions: Comment permissions from the selected post will replace any permissions selected on this page.
+        footnote_tags: Tags from the selected post will replace any tags entered on this page.
         label: Translation of
   admins:
     index:

--- a/features/admins/admin_post_news.feature
+++ b/features/admins/admin_post_news.feature
@@ -98,6 +98,7 @@ Feature: Admin Actions to Post News
       And I follow "Post AO3 News"
     Then I should see "New AO3 News Post"
       And I should see "Comment permissions from the selected post will replace any permissions selected on this page."
+      And I should see "Tags from the selected post will replace any tags entered on this page."
     When I fill in "admin_post_title" with "Good news, everyone!"
       And I fill in "content" with "I've taught the toaster to feel love."
       And I fill in "Tags" with "quotes, futurama"
@@ -108,12 +109,12 @@ Feature: Admin Actions to Post News
       And I should see "futurama" within "dd.tags"
 
   Scenario: Admin posts can be filtered by tags and languages
-    Given I have posted an admin post with tags
+    Given I have posted an admin post with tags "quotes, futurama"
       And basic languages
       And I am logged in as a "translation" admin
-    When I make a translation of an admin post with tags
+    When I make a translation of an admin post
       And I am logged in as "ordinaryuser"
-    Then I should see a translated admin post with tags
+    Then I should see a translated admin post with tags "quotes, futurama"
 
     When I follow "News"
     Then "futurama" should be an option within "Tag"
@@ -134,6 +135,24 @@ Feature: Admin Actions to Post News
       And I should see "Deutsch Woerter"
       And "quotes" should be selected within "Tag"
       And "Deutsch" should be selected within "Language"
+
+  Scenario: Translation of an admin post keeps tags of original post
+    Given I have posted an admin post with tags "original1, original2"
+      And basic languages
+      And I am logged in as a "translation" admin
+    When I make a translation of an admin post with tags "ooops"
+    Then I should see "original1 original2" within "dd.tags"
+     And I should not see "ooops"
+    When I follow "Edit Post"
+    Then I should not see the input with id "admin_post_tag_list"
+     And I should not see "Tags from the selected post will replace any tags entered on this page."
+    When I go to the admin-posts page
+     And I follow "Edit"
+    Then I should see the input with id "admin_post_tag_list"
+    When I fill in "Tags" with "updated1, updated2"
+     And I press "Post"
+     And I am logged in as "ordinaryuser"
+    Then I should see a translated admin post with tags "updated1, updated2"
 
   Scenario: If an admin post has characters like & and < and > in the title, the escaped version will not show on the various admin post pages
     Given I am logged in as a "communications" admin

--- a/features/step_definitions/admin_steps.rb
+++ b/features/step_definitions/admin_steps.rb
@@ -144,12 +144,12 @@ Given /^I have posted an admin post without paragraphs$/ do
   step("I log out")
 end
 
-Given /^I have posted an admin post with tags$/ do
+Given /^I have posted an admin post with tags "([^\"]*)"$/ do |tags|
   step(%{I am logged in as a "communications" admin})
   visit new_admin_post_path
   fill_in("admin_post_title", with: "Default Admin Post")
   fill_in("content", with: "Content of the admin post.")
-  fill_in("admin_post_tag_list", with: "quotes, futurama")
+  fill_in("admin_post_tag_list", with: tags)
   click_button("Post")
 end
 
@@ -253,7 +253,7 @@ When /^I uncheck the "([^\"]*)" role checkbox$/ do |role|
   uncheck("user_roles_#{role_id}")
 end
 
-When (/^I make a translation of an admin post( with tags)?$/) do |with_tags|
+When (/^I make a translation of an admin post( with tags "([^\"]*)")?$/) do |tags|
   admin_post = AdminPost.find_by(title: "Default Admin Post")
   # If post doesn't exist, assume we want to reference a non-existent post
   admin_post_id = !admin_post.nil? ? admin_post.id : 0
@@ -262,7 +262,7 @@ When (/^I make a translation of an admin post( with tags)?$/) do |with_tags|
   fill_in("content", with: "Deutsch Woerter")
   step %{I select "Deutsch" from "Choose a language"}
   fill_in("admin_post_translated_post_id", with: admin_post_id)
-  fill_in("admin_post_tag_list", with: "quotes, futurama") if with_tags
+  fill_in("admin_post_tag_list", with: tags) if tags
   click_button("Post")
 end
 
@@ -280,24 +280,19 @@ Then (/^the translation information should still be filled in$/) do
   step %{"Deutsch" should be selected within "Choose a language"}
 end
 
-Then (/^I should see a translated admin post$/) do
+Then (/^I should see a translated admin post( with tags "([^\"]*)")?$/) do |tags|
+  tags = tags.split(/, ?/) if tags
   step %{I go to the admin-posts page}
   step %{I should see "Default Admin Post"}
+  step %{I should see "Tags: #{tags.join(" ")}"} if tags
   step %{I should see "Translations: Deutsch"}
   step %{I follow "Default Admin Post"}
   step %{I should see "Deutsch" within "dd.translations"}
   step %{I follow "Deutsch"}
   step %{I should see "Deutsch Woerter"}
-end
-
-Then (/^I should see a translated admin post with tags$/) do
-  step %{I go to the admin-posts page}
-  step %{I should see "Default Admin Post"}
-  step %{I should see "Tags: quotes futurama"}
-  step %{I should see "Translations: Deutsch"}
-  step %{I follow "Default Admin Post"}
-  step %{I should see "Deutsch" within "dd.translations"}
-  step %{I should see "futurama" within "dd.tags"}
+  tags&.each do |tag|
+    step %{I should see "#{tag}" within "dd.tags"}
+  end
 end
 
 Then (/^I should not see a translated admin post$/) do

--- a/features/step_definitions/admin_steps.rb
+++ b/features/step_definitions/admin_steps.rb
@@ -144,7 +144,7 @@ Given /^I have posted an admin post without paragraphs$/ do
   step("I log out")
 end
 
-Given /^I have posted an admin post with tags "([^\"]*)"$/ do |tags|
+Given /^I have posted an admin post with tags "(.*?)"$/ do |tags|
   step(%{I am logged in as a "communications" admin})
   visit new_admin_post_path
   fill_in("admin_post_title", with: "Default Admin Post")
@@ -253,7 +253,7 @@ When /^I uncheck the "([^\"]*)" role checkbox$/ do |role|
   uncheck("user_roles_#{role_id}")
 end
 
-When (/^I make a translation of an admin post( with tags "([^\"]*)")?$/) do |tags|
+When /^I make a translation of an admin post( with tags "(.*?)")?$/ do |tags|
   admin_post = AdminPost.find_by(title: "Default Admin Post")
   # If post doesn't exist, assume we want to reference a non-existent post
   admin_post_id = !admin_post.nil? ? admin_post.id : 0
@@ -280,11 +280,11 @@ Then (/^the translation information should still be filled in$/) do
   step %{"Deutsch" should be selected within "Choose a language"}
 end
 
-Then (/^I should see a translated admin post( with tags "([^\"]*)")?$/) do |tags|
+Then /^I should see a translated admin post( with tags "(.*?)")?$/ do |tags|
   tags = tags.split(/, ?/) if tags
   step %{I go to the admin-posts page}
   step %{I should see "Default Admin Post"}
-  step %{I should see "Tags: #{tags.join(" ")}"} if tags
+  step %{I should see "Tags: #{tags.join(' ')}"} if tags
   step %{I should see "Translations: Deutsch"}
   step %{I follow "Default Admin Post"}
   step %{I should see "Deutsch" within "dd.translations"}

--- a/features/step_definitions/generic_steps.rb
+++ b/features/step_definitions/generic_steps.rb
@@ -92,17 +92,25 @@ Then /^I should see a success message$/ do
   step %{I should see "success"}
 end
 
-# img attributes
-Then /^I should see the image "([^"]*)" text "([^"]*)"(?: within "([^"]*)")?$/ do |attribute, text, selector|
+def assure_xpath_present(tag, attribute, value, selector)
   with_scope(selector) do
-    page.should have_xpath("//img[@#{attribute}='#{text}']")
+    page.should have_xpath("//#{tag}[@#{attribute}='#{value}']")
   end
 end
 
-Then /^I should not see the image "([^"]*)" text "([^"]*)"(?: within "([^"]*)")?$/ do |attribute, text, selector|
+def assure_xpath_not_present(tag, attribute, value, selector)
   with_scope(selector) do
-    page.should_not have_xpath("//img[@#{attribute}='#{text}']")
+    page.should_not have_xpath("//#{tag}[@#{attribute}='#{value}']")
   end
+end
+
+# img attributes
+Then /^I should see the image "([^"]*)" text "([^"]*)"(?: within "([^"]*)")?$/ do |attribute, text, selector|
+  assure_xpath_present("img", attribute, text, selector)
+end
+
+Then /^I should not see the image "([^"]*)" text "([^"]*)"(?: within "([^"]*)")?$/ do |attribute, text, selector|
+  assure_xpath_not_present("img", attribute, text, selector)
 end
 
 Then /^"([^"]*)" should be selected within "([^"]*)"$/ do |value, field|
@@ -118,15 +126,11 @@ Then /^I should see "([^"]*)" in the "([^"]*)" input/ do |content, labeltext|
 end
 
 Then /^I should see (a|an) "([^"]*)" button(?: within "([^"]*)")?$/ do |_article, text, selector|
-  with_scope(selector) do
-    page.should have_xpath("//input[@value='#{text}']")
-  end
+  assure_xpath_present("input", "value", text, selector)
 end
 
 Then /^I should not see (a|an) "([^"]*)" button(?: within "([^"]*)")?$/ do |_article, text, selector|
-  with_scope(selector) do
-    page.should_not have_xpath("//input[@value='#{text}']")
-  end
+  assure_xpath_not_present("input", "value", text, selector)
 end
 
 When /^"([^\"]*)" is fixed$/ do |what|
@@ -155,12 +159,13 @@ Then /^the "([^"]*)" checkbox(?: within "([^"]*)")? should not be disabled$/ do 
   end
 end
 
-Then /^I should not see the field "([^"]*)"(?: within "([^"]*)")?$/ do |id, selector|
-  with_scope(selector) do
-    page.should_not have_xpath("//input[@#{id}='#{id}']")
-  end
+Then /^I should see the input with id "([^"]*)"(?: within "([^"]*)")?$/ do |id, selector|
+  assure_xpath_present("input", "id", id, selector)
 end
 
+Then /^I should not see the input with id "([^"]*)"(?: within "([^"]*)")?$/ do |id, selector|
+  assure_xpath_not_present("input", "id", id, selector)
+end
 
 When /^I check the (\d+)(?:st|nd|rd|th) checkbox with the value "([^"]*)"$/ do |index, value|
   check(page.all("input[type='checkbox']").select {|el| el['value'] == value}[(index.to_i-1)]['id'])

--- a/features/tag_sets/tag_set_nominations.feature
+++ b/features/tag_sets/tag_set_nominations.feature
@@ -64,7 +64,8 @@ Feature: Nominating and reviewing nominations for a tag set
   Then I should see "Not Yet Reviewed (may be edited or deleted)"
     And I should see "Floobry"
   When I follow "Edit"
-    And I fill in "tag_set_nomination_fandom_nominations_attributes_0_tagname" with "Bloob"
+  Then I should see the input with id "tag_set_nomination_fandom_nominations_attributes_0_tagname" within "div#main"
+  When I fill in "tag_set_nomination_fandom_nominations_attributes_0_tagname" with "Bloob"
   When I press "Submit"
   Then I should see "Your nominations were successfully updated"
   Given I am logged in as "tagsetter"
@@ -79,7 +80,7 @@ Feature: Nominating and reviewing nominations for a tag set
     And I follow "My Nominations"
   Then I should see "Partially Reviewed (unreviewed nominations may be edited)"
   When I follow "Edit"
-  Then I should not see the field "tag_set_nomination_fandom_nominations_attributes_0_tagname" within "div#main"
+  Then I should not see the input with id "tag_set_nomination_fandom_nominations_attributes_0_tagname" within "div#main"
 
   Scenario: You should be able to edit your nominated characters when the tagset doesn't allow fandom nominations
   Given I am logged in as "tagsetter"


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [x] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [x] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [x] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-6093

## Purpose

With code similar to the one in 7682597ae9f9a2b18144925154ca6dce32606570 assures the tags in translated admin posts are in sync with the tags in original

## Testing Instructions

As per issue.

Notes:
1. For existing translations: tags will get updated if tags on the original translation are updated.
2. If A is original, B is translation of A, and C is translation of B (as we can do that apparently by forcing post id), all the tags are also in sync.


## Credit

korrien, she/her
