### PR TITLE
AO3-6252 Add error message for kudos rate limit

### DIFF
--- a/public/javascripts/application.js
+++ b/public/javascripts/application.js
@@ -442,7 +442,7 @@ $j(document).ready(function() {
       error: function(jqXHR, textStatus, errorThrown) {
         var msg = 'Sorry, we were unable to save your kudos';
 
-        // When we hit the rate limit, the response is a plain text 429.
+        // When we hit the rate limit, the response from Rack::Attack is a plain text 429.
         if (jqXHR.status == "429") {
           msg = "Sorry, you can't leave more kudos right now. Please try again in a few minutes.";
         } else {

--- a/public/javascripts/application.js
+++ b/public/javascripts/application.js
@@ -451,7 +451,6 @@ $j(document).ready(function() {
           if (data.errors && (data.errors.ip_address || data.errors.user_id)) {
             msg = "You have already left kudos here. :)";
           }
-
           if (data.errors && data.errors.cannot_be_author) {
             msg = "You can't leave kudos on your own work.";
           }

--- a/public/javascripts/application.js
+++ b/public/javascripts/application.js
@@ -439,19 +439,25 @@ $j(document).ready(function() {
       type: 'POST',
       url: '/kudos.js',
       data: jQuery('#new_kudo').serialize(),
-      error: function(jqXHR, textStatus, errorThrown ) {
+      error: function(jqXHR, textStatus, errorThrown) {
         var msg = 'Sorry, we were unable to save your kudos';
-        var data = $j.parseJSON(jqXHR.responseText);
 
-        if (data.errors && (data.errors.ip_address || data.errors.user_id)) {
-          msg = "You have already left kudos here. :)";
-        }
+        // When we hit the rate limit, the response is a plain text 429.
+        if (jqXHR.status == "429") {
+          msg = "Sorry, you can't leave more kudos right now. Please try again in a few minutes.";
+        } else {
+          var data = $j.parseJSON(jqXHR.responseText);
 
-        if (data.errors && data.errors.cannot_be_author) {
-          msg = "You can't leave kudos on your own work.";
-        }
-        if (data.errors && data.errors.guest_on_restricted) {
-          msg = "You can't leave guest kudos on a restricted work.";
+          if (data.errors && (data.errors.ip_address || data.errors.user_id)) {
+            msg = "You have already left kudos here. :)";
+          }
+
+          if (data.errors && data.errors.cannot_be_author) {
+            msg = "You can't leave kudos on your own work.";
+          }
+          if (data.errors && data.errors.guest_on_restricted) {
+            msg = "You can't leave guest kudos on a restricted work.";
+          }
         }
 
         $j('#kudos_message').addClass('kudos_error').text(msg);


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6252

## Purpose

If you submit kudos using JavaScript and run into a rate limit, you should get a meaningful error.

## Testing Instructions

As a guest, submit more kudos than allowed in a given time period. Verify the error message appears. Also verify you get the usual "You have already left kudos here. :)" error if submitting duplicate kudos without going over the rate limit.