### PR TITLE
AO3-5671 Update Elasticsearch to 7.15

### DIFF
--- a/.github/workflows/automated-tests.yml
+++ b/.github/workflows/automated-tests.yml
@@ -31,10 +31,12 @@ jobs:
           - 3306:3306
 
       elasticsearch:
-        image: elasticsearch:7.12.0
+        image: docker.elastic.co/elasticsearch/elasticsearch:7.15.2
         ports:
           - 9200:9200
-        options: -e="discovery.type=single-node"
+        options: >-
+          -e="discovery.type=single-node"
+          -e="xpack.security.enabled=false"
 
       memcached:
         image: memcached:1.5

--- a/Gemfile
+++ b/Gemfile
@@ -62,7 +62,7 @@ gem 'resque', '>=1.14.0'
 gem 'resque-scheduler'
 gem 'after_commit_everywhere'
 #gem 'daemon-spawn', require: 'daemon_spawn'
-gem 'elasticsearch', '7.12.0'
+gem "elasticsearch", "7.15.0"
 gem "aws-sdk-s3"
 gem 'css_parser'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -199,12 +199,12 @@ GEM
     docile (1.4.0)
     domain_name (0.5.20190701)
       unf (>= 0.0.5, < 1.0.0)
-    elasticsearch (7.12.0)
-      elasticsearch-api (= 7.12.0)
-      elasticsearch-transport (= 7.12.0)
-    elasticsearch-api (7.12.0)
+    elasticsearch (7.15.0)
+      elasticsearch-api (= 7.15.0)
+      elasticsearch-transport (= 7.15.0)
+    elasticsearch-api (7.15.0)
       multi_json
-    elasticsearch-transport (7.12.0)
+    elasticsearch-transport (7.15.0)
       faraday (~> 1)
       multi_json
     email_spec (1.6.0)
@@ -228,15 +228,11 @@ GEM
       railties (>= 4.2.0)
     faker (2.2.1)
       i18n (>= 0.8)
-    faraday (1.4.0)
-      faraday-excon (~> 1.0)
+    faraday (1.3.0)
       faraday-net_http (~> 1.0)
-      faraday-net_http_persistent (~> 1.0)
       multipart-post (>= 1.2, < 3)
-      ruby2_keywords (>= 0.0.4)
-    faraday-excon (1.1.0)
+      ruby2_keywords
     faraday-net_http (1.0.1)
-    faraday-net_http_persistent (1.1.0)
     fastimage (2.1.7)
     fugit (1.3.6)
       et-orbi (~> 1.1, >= 1.1.8)
@@ -577,7 +573,7 @@ DEPENDENCIES
   delorean
   devise
   devise-async
-  elasticsearch (= 7.12.0)
+  elasticsearch (= 7.15.0)
   email_spec (= 1.6.0)
   erb_lint (= 0.0.29)
   escape_utils (= 1.2.1)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@
 #
 # This will handle setting up config files, creating databases, and running migrations.
 #
-# After these oneoff tasks have been perfomed, on subsequent starts you can simply use:
+# After these oneoff tasks have been performed, on subsequent starts you can simply use:
 #
 # ```
 # docker-compose up -d web
@@ -38,7 +38,7 @@ services:
     volumes:
       - redis-data:/var/lib/redis:rw
   es:
-    image: docker.elastic.co/elasticsearch/elasticsearch:7.12.0
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.15.2
     ports:
       - "9200:9200"
       - "9300:9300"
@@ -50,6 +50,9 @@ services:
       - bootstrap.memory_lock=false
       - "ES_JAVA_OPTS=-Xms1500m -Xmx1500m"
       - discovery.type=single-node
+      # Silence "security features are not enabled" warnings
+      # https://github.com/elastic/elasticsearch/issues/78500
+      - xpack.security.enabled=false
   mc:
     image: memcached:1.5
     ports:


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5671

## Purpose

- Update the gem version to 7.15.0 and fix a dependency conflict; faraday 1.4 and our current resque version expect different versions of ruby2_keywords.
- Update the elasticsearch container image in development and CI to 7.15.2. For CI, switch to docker.elastic.co because hub.docker.com does not yet have the version.
- Silence noisy "security features are not enabled" warnings in CI and development: https://github.com/elastic/elasticsearch/issues/78500.

## Testing Instructions

CI should pass.