### PR TITLE
AO3-6263 Allow SSL for SMTP to be configurable

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -40,7 +40,7 @@ SMTP_SERVER: localhost
 SMTP_PORT: 25
 SMTP_DOMAIN: localhost
 SMTP_OPENSSL_VERIFY_MODE: none
-SMTP_ENABLE_STARTTTLS_AUTO: false
+SMTP_ENABLE_STARTTLS_AUTO: false
 # if required for email authentication
 #SMTP_USER:
 #SMTP_PASSWORD:

--- a/config/config.yml
+++ b/config/config.yml
@@ -39,6 +39,8 @@ PERFORM_DELIVERIES: false
 SMTP_SERVER: localhost
 SMTP_PORT: 25
 SMTP_DOMAIN: localhost
+SMTP_OPENSSL_VERIFY_MODE: none
+SMTP_ENABLE_STARTTTLS_AUTO: false
 # if required for email authentication
 #SMTP_USER:
 #SMTP_PASSWORD:

--- a/config/initializers/archive_config/mail.rb
+++ b/config/initializers/archive_config/mail.rb
@@ -1,29 +1,25 @@
 # Email settings
 module Otwarchive
   class Application < Rails::Application
-    unless %w(test cucumber).include?(Rails.env)
+    unless %w[test cucumber].include?(Rails.env)
       config.action_mailer.delivery_method = :smtp
-  #    config.action_mailer.default_url_options = {host: ArchiveConfig.APP_URL.gsub(/http:\/\//, '')}
-      ActionMailer::Base.default_url_options = {host: ArchiveConfig.APP_URL.gsub(/http:\/\//, '')}
-  ## TODO: Setting ActionMailer::Base.default_url_options directly is now deprecated, use the configuration option mentioned above to set the default host.
-  ## except... it doesn't work. setting it directly does work.
+      #    config.action_mailer.default_url_options = {host: ArchiveConfig.APP_URL.gsub(/http:\/\//, '')}
+      ActionMailer::Base.default_url_options = { host: ArchiveConfig.APP_URL.gsub(%r{http://}, "") }
+      ## TODO: Setting ActionMailer::Base.default_url_options directly is now deprecated, use the configuration option mentioned above to set the default host.
+      ## except... it doesn't work. setting it directly does work.
+      config.action_mailer.smtp_settings = {
+        address: ArchiveConfig.SMTP_SERVER,
+        domain: ArchiveConfig.SMTP_DOMAIN,
+        port: ArchiveConfig.SMTP_PORT,
+        enable_starttls_auto: ArchiveConfig.SMTP_ENABLE_STARTTLS_AUTO,
+        openssl_verify_mode: ArchiveConfig.SMTP_OPENSSL_VERIFY_MODE
+      }
       if ArchiveConfig.SMTP_AUTHENTICATION
-        config.action_mailer.smtp_settings = {
-          address: ArchiveConfig.SMTP_SERVER,
-          domain: ArchiveConfig.SMTP_DOMAIN,
-          port: ArchiveConfig.SMTP_PORT,
-          user_name: ArchiveConfig.SMTP_USER,
-          password: ArchiveConfig.SMTP_PASSWORD,
-          authentication: ArchiveConfig.SMTP_AUTHENTICATION,
-         }
-      else
-        config.action_mailer.smtp_settings = {
-          address: ArchiveConfig.SMTP_SERVER,
-          domain: ArchiveConfig.SMTP_DOMAIN,
-          port: ArchiveConfig.SMTP_PORT,
-          enable_starttls_auto: ArchiveConfig.SMTP_ENABLE_STARTTTLS_AUTO,
-          openssl_verify_mode: ArchiveConfig.SMTP_OPENSSL_VERIFY_MODE,
-        }
+        config.action_mailer.smtp_settings.merge!({
+                                                    user_name: ArchiveConfig.SMTP_USER,
+                                                    password: ArchiveConfig.SMTP_PASSWORD,
+                                                    authentication: ArchiveConfig.SMTP_AUTHENTICATION
+                                                  })
       end
     end
   end

--- a/config/initializers/archive_config/mail.rb
+++ b/config/initializers/archive_config/mail.rb
@@ -21,6 +21,8 @@ module Otwarchive
           address: ArchiveConfig.SMTP_SERVER,
           domain: ArchiveConfig.SMTP_DOMAIN,
           port: ArchiveConfig.SMTP_PORT,
+          enable_starttls_auto: ArchiveConfig.SMTP_ENABLE_STARTTTLS_AUTO,
+          openssl_verify_mode: ArchiveConfig.SMTP_OPENSSL_VERIFY_MODE,
         }
       end
     end


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [x] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [x] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [x] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-6263

## Purpose

Allow ssl config for email to be configable

## Testing Instructions

On current debian 10 systems check email still flows ( Check sync and via workers, just one of each should be fine. )

Get systems to upgrade staging's systems to debian 11 and test again.