### PR TITLE
AO3-6261 Update Contact Open Doors link in work claim emails

### DIFF
--- a/app/views/external_authors/claim.html.erb
+++ b/app/views/external_authors/claim.html.erb
@@ -14,7 +14,7 @@
 <p class="message">
   <%= ts("If you want to take another look at your work(s) before you make your decision, but don’t have an Archive
   account,") %>
-  <%= link_to ts("contact Open Doors"), "http://transformativeworks.org/contact/open%20doors" %>
+  <%= link_to ts("contact Open Doors"), "https://opendoors.transformativeworks.org/en/contact-open-doors/" %>
   <%= ts("with your pseud and the titles of your work(s) and we will send you a copy.") %>
 </p>
 

--- a/app/views/user_mailer/claim_notification.html.erb
+++ b/app/views/user_mailer/claim_notification.html.erb
@@ -7,7 +7,7 @@
 
   <p>You can read announcements about recent archive moves at <%= style_link('AO3 News', 'http://archiveofourown.org/admin_posts?tag=18') %>, and find additional information on Open Doors' <%= style_link('FAQ page', 'http://opendoors.transformativeworks.org/faq') %> or <%= style_link('tutorials page', 'http://opendoors.transformativeworks.org/tutorials') %>. For any questions not answered in the FAQ, tutorials, or this e-mail, please <%= support_link('contact AO3 Support') %>.</p>
 
-  <p>If this is a mistake and these are not your works, please don't delete them! Please <%= style_link('contact Open Doors', 'http://transformativeworks.org/contact/open%20doors') %> and we will sort it out.</p>
+  <p>If this is a mistake and these are not your works, please don't delete them! Please <%= style_link('contact Open Doors', 'https://opendoors.transformativeworks.org/en/contact-open-doors/') %> and we will sort it out.</p>
 
   <p>Depending on the archive, your works may have been imported restricted to registered users only (to keep them out of Google searches). If this is the case, the works will only be accessible by logged-in users unless you choose to make them fully visible. For help unlocking, orphaning, or deleting your works, please <%= support_link('contact AO3 Support') %>.</p>
 
@@ -22,9 +22,9 @@
 
   <p>To preserve rec lists and bookmarks, the imported archive's web addresses may redirect to the imported copy of these works for a limited time (check the announcement post for your archive to be sure). If you've already uploaded a copy of these works and you did NOT use the import from URL feature, there will be two copies of the same work on the archive.</p>
 
-  <p>If you would like Open Doors to update the redirect to point to your pre-existing work, please delete the imported copy, and <%= style_link('contact Open Doors', 'http://transformativeworks.org/contact/open%20doors') %> with your AO3 account name, your account name on the imported archive, and the title and URL of the fanwork you would like the redirect to point to. (If you have multiple works you would like to change the redirects for, you can list these in one email.)</p>
+  <p>If you would like Open Doors to update the redirect to point to your pre-existing work, please delete the imported copy, and <%= style_link('contact Open Doors', 'https://opendoors.transformativeworks.org/en/contact-open-doors/') %> with your AO3 account name, your account name on the imported archive, and the title and URL of the fanwork you would like the redirect to point to. (If you have multiple works you would like to change the redirects for, you can list these in one email.)</p>
 
-  <p>If you had other works on the imported archive under an e-mail address you can no longer access, please <%= style_link('contact Open Doors', 'http://transformativeworks.org/contact/open%20doors') %> with any information that can help verify your identity.</p>
+  <p>If you had other works on the imported archive under an e-mail address you can no longer access, please <%= style_link('contact Open Doors', 'https://opendoors.transformativeworks.org/en/contact-open-doors/') %> with any information that can help verify your identity.</p>
 
   <p>For other inquiries, please <%= support_link('contact AO3 Support') %>.</p>
 

--- a/app/views/user_mailer/claim_notification.text.erb
+++ b/app/views/user_mailer/claim_notification.text.erb
@@ -5,7 +5,7 @@
 
   You can read announcements about recent archive moves at AO3 News (<%= root_url %>admin_posts?tag=18), and find additional information on Open Doors's FAQ page (http://opendoors.transformativeworks.org/faq) or tutorials page (http://opendoors.transformativeworks.org/tutorials). For any questions not answered in the FAQ, tutorials, or this e-mail, please contact AO3 Support at <%= root_url %>support.
 
-  If this is a mistake and these are not your works, please don't delete them! Please contact Open Doors (http://transformativeworks.org/contact/open%20doors) and we will sort it out.
+  If this is a mistake and these are not your works, please don't delete them! Please contact Open Doors ( https://opendoors.transformativeworks.org/en/contact-open-doors/ ) and we will sort it out.
 
   Depending on the archive, your works may have been imported restricted to registered users only (to keep them out of Google searches). If this is the case, the works will only be accessible by logged-in users unless you choose to make them fully visible. For help unlocking, orphaning, or deleting your works, please contact Support.
 
@@ -16,7 +16,7 @@
 
   To preserve rec lists and bookmarks, the imported archive's web addresses may redirect to the imported copy of these works for a limited time (check the announcement post for your archive to be sure). If you've already uploaded a copy of these works and you did NOT use the import from URL feature, there will be two copies of the same work on the archive.
 
-  If you would like Open Doors to update the redirect to point to your pre-existing work, please delete the imported copy, and contact Open Doors at http://transformativeworks.org/contact/open%20doors with your AO3 account name, your account name on the imported archive, and the title and URL of the fanwork you would like the redirect to point to. (If you have multiple works you would like to change the redirects for, you can list these in one email.)
+  If you would like Open Doors to update the redirect to point to your pre-existing work, please delete the imported copy, and contact Open Doors at https://opendoors.transformativeworks.org/en/contact-open-doors/ with your AO3 account name, your account name on the imported archive, and the title and URL of the fanwork you would like the redirect to point to. (If you have multiple works you would like to change the redirects for, you can list these in one email.)
 
   If you had other works on the imported archive under an e-mail address you can no longer access, please contact Open Doors with any information that can help verify your identity.
 

--- a/app/views/user_mailer/claim_notification.text.erb
+++ b/app/views/user_mailer/claim_notification.text.erb
@@ -5,7 +5,7 @@
 
   You can read announcements about recent archive moves at AO3 News (<%= root_url %>admin_posts?tag=18), and find additional information on Open Doors's FAQ page (http://opendoors.transformativeworks.org/faq) or tutorials page (http://opendoors.transformativeworks.org/tutorials). For any questions not answered in the FAQ, tutorials, or this e-mail, please contact AO3 Support at <%= root_url %>support.
 
-  If this is a mistake and these are not your works, please don't delete them! Please contact Open Doors ( https://opendoors.transformativeworks.org/en/contact-open-doors/ ) and we will sort it out.
+  If this is a mistake and these are not your works, please don't delete them! Please contact Open Doors (https://opendoors.transformativeworks.org/en/contact-open-doors/) and we will sort it out.
 
   Depending on the archive, your works may have been imported restricted to registered users only (to keep them out of Google searches). If this is the case, the works will only be accessible by logged-in users unless you choose to make them fully visible. For help unlocking, orphaning, or deleting your works, please contact Support.
 

--- a/app/views/user_mailer/invitation_to_claim.html.erb
+++ b/app/views/user_mailer/invitation_to_claim.html.erb
@@ -7,7 +7,7 @@
 
   <p><%= t('.html.part2', news_link: style_link(t('.html.ao3_news'), admin_posts_url + "?tag=18"), open_doors_faq_link: style_link(t('.html.faq_page'), "http://opendoors.transformativeworks.org/faq"), open_doors_tutorial_link: style_link(t('.html.tutorial_page'), "http://opendoors.transformativeworks.org/tutorials"), support_link: support_link(t '.html.contact_support')).html_safe %></p>
 
-  <p><%= t('.html.part3', open_doors_link: style_link(t('.html.contact_open_doors'), 'http://transformativeworks.org/contact/open%20doors')).html_safe %></p>
+  <p><%= t('.html.part3', open_doors_link: style_link(t('.html.contact_open_doors'), 'https://opendoors.transformativeworks.org/en/contact-open-doors/')).html_safe %></p>
 
   <p><%= t('.html.part4', support_link: support_link(t '.html.contact_support')).html_safe %></p>
 
@@ -26,9 +26,9 @@
 
   <p><%= t '.part8' %></p>
 
-  <p><%= t('.html.part9', open_doors_link: style_link(t('.html.contact_open_doors'), 'http://transformativeworks.org/contact/open%20doors')).html_safe %></p>
+  <p><%= t('.html.part9', open_doors_link: style_link(t('.html.contact_open_doors'), 'https://opendoors.transformativeworks.org/en/contact-open-doors/')).html_safe %></p>
 
-  <p><%= t('.html.part10', open_doors_link: style_link(t('.html.contact_open_doors'), 'http://transformativeworks.org/contact/open%20doors')).html_safe %></p>
+  <p><%= t('.html.part10', open_doors_link: style_link(t('.html.contact_open_doors'), 'https://opendoors.transformativeworks.org/en/contact-open-doors/')).html_safe %></p>
 
   <p><%= t('.html.part11', support_link: support_link(t '.html.contact_support')).html_safe %></p>
 

--- a/app/views/user_mailer/invitation_to_claim.text.erb
+++ b/app/views/user_mailer/invitation_to_claim.text.erb
@@ -5,7 +5,7 @@
 
   <%= t '.text.part2', news_link: admin_posts_url + "?tag=18", open_doors_faq_link: "http://opendoors.transformativeworks.org/faq", open_doors_tutorial_link: "http://opendoors.transformativeworks.org/tutorials", support_link: new_feedback_report_url %>
 
-  <%= t '.text.part3', open_doors_link: "http://transformativeworks.org/contact/open%20doors" %>
+  <%= t '.text.part3', open_doors_link: "https://opendoors.transformativeworks.org/en/contact-open-doors/" %>
 
   <%= t '.text.part4' %>
 
@@ -20,7 +20,7 @@
 
   <%= t '.part8' %>
 
-  <%= t '.text.part9', open_doors_link: "http://transformativeworks.org/contact/open%20doors" %>
+  <%= t '.text.part9', open_doors_link: "https://opendoors.transformativeworks.org/en/contact-open-doors/" %>
 
   <%= t '.text.part10' %>
 


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [x] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [x] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [x] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-6261

## Purpose

Fixes an outdated link to Contact Open Doors in two emails (both HTML and text versions) and one web page.

## Testing Instructions

Per the ticket, import a work, twice, once with a email associated with an account, and once with an email not associated, both of which emails you have access to. Review the resulting emails to confirm the URL is updated.

I am not entirely certain how to access the updated web page to verify it, but I think it may be linked from the emails?

## Credit

Please credit me (if this is a big enough fix to bother with credit) as "Jesse Weinstein (he/him)".