### PR TITLE
AO3-6227 Restore missing classes to deleted work history blurbs

### DIFF
--- a/app/views/readings/_reading_blurb.html.erb
+++ b/app/views/readings/_reading_blurb.html.erb
@@ -1,5 +1,12 @@
 <% # expects "work" and "reading" %>
-<li <% unless work.nil? %>id="work_<%= work.id %>"<% end %> class="<% if work.nil? %>deleted <% end %><% if is_author_of?(work) %>own <% end %>reading work <%= css_classes_for_creation_blurb(work) %>" role="article">
+<% css_classes = if work.nil?
+                   "deleted reading work blurb group"
+                 elsif is_author_of?(work)
+                   "own reading work #{css_classes_for_creation_blurb(work)}"
+                 else
+                   "reading work #{css_classes_for_creation_blurb(work)}"
+                 end %>
+<li <% unless work.nil? %>id="work_<%= work.id %>"<% end %> class="<%= css_classes %>" role="article">
 
   <% unless reading.work.nil? %>
 


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6227

## Purpose

Makes sure the blurbs for deleted works in your history have the `blurb group` classes that give it the proper behavior and style.

I did consider doing this in the `css_classes_for_creation_blurb(creation)` helper, but I couldn't think of another instance where it'll be necessary, plus I think this just makes the view tidier than when the logic was all crammed into the `class` attribute itself.

## Testing Instructions

On the Jira issue!

## Credit

Sarken, she/her