### PR TITLE
AO3-6190 Don't use Time.now and Date.today in the work/chapter date calculations.

### DIFF
--- a/app/models/chapter.rb
+++ b/app/models/chapter.rb
@@ -172,8 +172,8 @@ class Chapter < ApplicationRecord
   # Checks the chapter published_at date isn't in the future
   def validate_published_at
     if !self.published_at
-      self.published_at = Date.today
-    elsif self.published_at > Date.today
+      self.published_at = Date.current
+    elsif self.published_at > Date.current
       errors.add(:base, ts("Publication date can't be in the future."))
       throw :abort
     end

--- a/app/models/story_parser.rb
+++ b/app/models/story_parser.rb
@@ -304,7 +304,7 @@ class StoryParser
     work.ip_address = options[:ip_address]
     work.expected_number_of_chapters = work.chapters.length
     work.revised_at = work.chapters.last.published_at
-    if work.revised_at && work.revised_at.to_date < Date.today
+    if work.revised_at && work.revised_at.to_date < Date.current
       work.backdate = true
     end
 
@@ -904,7 +904,7 @@ class StoryParser
         date = Time.at(Regex.last_match[1].to_i)
       end
       date ||= Date.parse(date_string)
-      return '' if date > Date.today
+      return '' if date > Date.current
       return date
     rescue ArgumentError, TypeError
       return ''

--- a/app/views/chapters/_chapter_form.html.erb
+++ b/app/views/chapters/_chapter_form.html.erb
@@ -21,7 +21,7 @@
           </p>
         </dd>
         <dt id="managePublicationDate"><%= f.label :published_at, ts("Chapter Publication Date") %>  <%= link_to_help "backdating-help" %></dt>
-        <dd class="datetime"><%= f.date_select "published_at", start_year: Date.today.year, end_year: 1950, default: @work.default_date, order: [:day, :month, :year] %></dd>
+        <dd class="datetime"><%= f.date_select "published_at", start_year: Date.current.year, end_year: 1950, default: @work.default_date, order: [:day, :month, :year] %></dd>
       </dl>
     </fieldset>
 

--- a/app/views/works/_standard_form.html.erb
+++ b/app/views/works/_standard_form.html.erb
@@ -230,7 +230,7 @@
               <dt><%= label_tag "published_at", ts("Set publication date") %></dt>
               <dd id="managePublicationDate" class="datetime" title="<%= ts("set date") %>">
                 <!--BACK END, this select box does not seem to be acquiring the label published_at -->
-                <%= c.date_select("published_at", :start_year => Date.today.year, :end_year => 1950, :default => Date.today, :value => @chapter.published_at, :order => [:day, :month, :year]) %>
+                <%= c.date_select("published_at", :start_year => Date.current.year, :end_year => 1950, :default => Date.current, :value => @chapter.published_at, :order => [:day, :month, :year]) %>
               </dd>
             </dl>
           </fieldset>

--- a/features/step_definitions/work_steps.rb
+++ b/features/step_definitions/work_steps.rb
@@ -511,7 +511,7 @@ When /^I list the work "([^"]*)" as inspiration$/ do |title|
   fill_in("work_parent_attributes_url", with: url_of_work)
 end
 When /^I set the publication date to today$/ do
-  today = Time.new
+  today = Date.current
   month = today.strftime("%B")
 
   if page.has_selector?("#backdate-options-show")
@@ -689,22 +689,22 @@ end
 
 ### THEN
 Then /^I should see Updated today$/ do
-  today = Time.zone.today.to_s
+  today = Date.current.to_s
   step "I should see \"Updated:#{today}\""
 end
 
 Then /^I should not see Updated today$/ do
-  today = Date.today.to_s
+  today = Date.current.to_s
   step "I should not see \"Updated:#{today}\""
 end
 
 Then /^I should see Completed today$/ do
-  today = Time.zone.today.to_s
+  today = Date.current.to_s
   step "I should see \"Completed:#{today}\""
 end
 
 Then /^I should not see Completed today$/ do
-  today = Date.today.to_s
+  today = Date.current.to_s
   step "I should not see \"Completed:#{today}\""
 end
 

--- a/spec/controllers/works/default_rails_actions_spec.rb
+++ b/spec/controllers/works/default_rails_actions_spec.rb
@@ -510,7 +510,7 @@ describe WorksController, work_search: true do
     end
 
     # If the time zone in config/application.rb is changed to something other
-    # than "Eastern Time (US & Canada", these tests will need adjusting:
+    # than "Eastern Time (US & Canada)", these tests will need adjusting:
     context "when redating to the present" do
       let!(:update_work) do
         # November 30, 2 PM UTC -- no time zone oddities here

--- a/spec/controllers/works/default_rails_actions_spec.rb
+++ b/spec/controllers/works/default_rails_actions_spec.rb
@@ -508,6 +508,56 @@ describe WorksController, work_search: true do
       expect(update_work.pseuds.reload).not_to include(no_co_creator.default_pseud)
       expect(update_work.user_has_creator_invite?(no_co_creator)).to be_falsey
     end
+
+    context "when redating to the present" do
+      let!(:update_work) do
+        # November 30, 2 PM UTC -- no time zone oddities here
+        travel_to(Time.utc(2021, 11, 30, 14)) do
+          create(:work, authors: [update_user.default_pseud])
+        end
+      end
+
+      let(:attributes) do
+        {
+          backdate: "1",
+          chapter_attributes: {
+            published_at: "2021-12-05"
+          }
+        }
+      end
+
+      before do
+        travel_to(redate_time)
+
+        # Simulate the system time being UTC:
+        allow(Time).to receive(:now).and_return(redate_time)
+        allow(DateTime).to receive(:now).and_return(redate_time)
+        allow(Date).to receive(:today).and_return(redate_time.to_date)
+
+        put :update, params: { id: update_work.id, work: attributes }
+      end
+
+      context "between midnight Eastern and midnight UTC" do
+        # December 5, 3 AM UTC -- still December 4 in Eastern Time
+        let(:redate_time) { Time.utc(2021, 12, 5, 3) }
+
+        it "prevents setting the publication date to the future" do
+          expect(response).to render_template :edit
+          expect(assigns[:work].errors.full_messages).to \
+            include("Publication date can't be in the future.")
+        end
+      end
+
+      context "before noon UTC" do
+        # December 5, 6 AM UTC -- before noon, but after midnight in both time zones
+        let(:redate_time) { Time.utc(2021, 12, 5, 6) }
+
+        it "doesn't set revised_at to the future" do
+          update_work.reload
+          expect(update_work.revised_at).to be <= Time.current
+        end
+      end
+    end
   end
 
   describe "collected" do

--- a/spec/controllers/works/default_rails_actions_spec.rb
+++ b/spec/controllers/works/default_rails_actions_spec.rb
@@ -509,6 +509,8 @@ describe WorksController, work_search: true do
       expect(update_work.user_has_creator_invite?(no_co_creator)).to be_falsey
     end
 
+    # If the time zone in config/application.rb is changed to something other
+    # than "Eastern Time (US & Canada", these tests will need adjusting:
     context "when redating to the present" do
       let!(:update_work) do
         # November 30, 2 PM UTC -- no time zone oddities here


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6190

## Purpose

Stop using Time.now and Date.today in the work/chapter date calculations, because they return the time/date in the system time zone (UTC, for production), which doesn't match all of the times/dates that use the time zone set here:
https://github.com/otwcode/otwarchive/blob/72b975cf5ed90ce28cf212e84420aaccea871372/config/application.rb#L50-L53
This should prevent all future works from encountering https://otwarchive.atlassian.net/browse/AO3-5392, but won't address any pre-existing works with a `revised_at`/`published_at` mismatch.

I also modified `set_revised_at` so that redating to the current day will no longer set `revised_at` to noon UTC, even if noon UTC is in the future.