### PR TITLE
AO3-6132 Fix intermittent failure in series blurb helper tests

### DIFF
--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -246,7 +246,10 @@ describe ApplicationHelper do
         end
 
         context "when user is removed from series' work" do
-          before { work.creatorships.find_or_create_by(pseud_id: user2.default_pseud_id) }
+          before do
+            work.creatorships.find_or_create_by(pseud_id: user2.default_pseud_id)
+            series.reload # make sure the series has the right value for updated_at
+          end
 
           # TODO: AO3-5739 Co-creators removed from all works in a series are not removed from series
           it "returns same string" do


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6132

## Purpose

Fixes an intermittent test failure introduced in the tests for AO3-6132. Adding `user2` as a creator of the work in `spec/helpers/application_helper_spec.rb:248` causes the series to be touched, but the series object that has `touch` called on it is a different in-memory copy of the series defined in the `let` above. This causes the initial cache key to be computed incorrectly, which breaks the test.