### PR TITLE
AO3-6262 Update pluralization rule for Croatian

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -107,6 +107,8 @@ RSpec/ContextWording:
 
 RSpec/DescribeClass:
   Exclude:
+    # Exception for specs about I18n configurations
+    - 'spec/lib/i18n/**/*.rb'
     # Exception for rake specs, where the top level describe uses a task name
     - 'spec/lib/tasks/*.rake_spec.rb'
     # Exception for integration specs, which may not test a specific class

--- a/config/locales/README.md
+++ b/config/locales/README.md
@@ -1,16 +1,17 @@
-The contents of the following folders should not be edited.
-
 ## `phrase-exports/`
 
-These files are updated by Phrase. Refer to `.phrase.yml`.
+These files are updated by Phrase and should not be edited. Refer to `.phrase.yml`.
 
 ## `rails-i18n/`
 
 We use locale files, pluralization and transliteration rules from the installed
 gem [rails-i18n](https://github.com/svenfuchs/rails-i18n).
 
+This folder contains patches to rails-i18n.
+
 We [manually install](https://github.com/svenfuchs/rails-i18n#manual-installation)
-the following locales from rails-i18n version 6.0.0 in order to rename them:
+the following locales from rails-i18n version 6.0.0 in order to rename them.
+Aside from the locale name, the files should not be edited.
 
 - "mr-IN" to "mr"
 - "tl" to "fil"

--- a/config/locales/rails-i18n/pluralization/hr.rb
+++ b/config/locales/rails-i18n/pluralization/hr.rb
@@ -1,0 +1,41 @@
+# Croatian has categories "one", "few", and "other", according to the CLDR
+# plural rules used by Phrase. However, the rails-i18n implementation also
+# requires "many".
+#
+# Note that Croatian has rules for fraction digits, but like rails-i18n
+# we will only handle integers for now.
+#
+# https://unicode-org.github.io/cldr-staging/charts/latest/supplemental/language_plural_rules.html#hr
+
+module RailsI18n
+  module Pluralization
+    module Croatian
+      def self.rule
+        lambda do |n|
+          n ||= 0
+          mod10 = n % 10
+          mod100 = n % 100
+
+          if mod10 == 1 && mod100 != 11
+            :one
+          elsif [2, 3, 4].include?(mod10) && ![12, 13, 14].include?(mod100)
+            :few
+          else
+            :other
+          end
+        end
+      end
+    end
+  end
+end
+
+{
+  hr: {
+    i18n: {
+      plural: {
+        keys: [:one, :few, :other],
+        rule: RailsI18n::Pluralization::Croatian.rule
+      }
+    }
+  }
+}

--- a/spec/lib/i18n/pluralization_spec.rb
+++ b/spec/lib/i18n/pluralization_spec.rb
@@ -1,0 +1,35 @@
+require "spec_helper"
+
+describe "Pluralization rule for" do
+  let(:plural_keys) do |example|
+    I18n.t("i18n.plural.keys", locale: example.metadata[:locale], resolve: false)
+  end
+
+  let(:rule) do |example|
+    I18n.t("i18n.plural.rule", locale: example.metadata[:locale], resolve: false)
+  end
+
+  describe "Croatian", locale: "hr" do
+    it "has 'one', 'few', and 'other' plural keys" do
+      expect(plural_keys).to contain_exactly(:one, :few, :other)
+    end
+
+    [1, 21, 31, 41, 51, 101, 1001].each do |count|
+      it "puts #{count} in category 'one'" do
+        expect(rule.call(count)).to eq(:one)
+      end
+    end
+
+    [2, 3, 4, 22, 23, 24, 102, 103, 104].each do |count|
+      it "puts #{count} in category 'few'" do
+        expect(rule.call(count)).to eq(:few)
+      end
+    end
+
+    [0, 5, 9, 10, 11, 12, 13, 14, 15, 19, 20, 25, 29, 30].each do |count|
+      it "puts #{count} in category 'other'" do
+        expect(rule.call(count)).to eq(:other)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6262

## Purpose

Phrase follows CLDR rules, where Croatian uses [one/few/other](https://unicode-org.github.io/cldr-staging/charts/latest/supplemental/language_plural_rules.html#hr) but rails-i18n expects [one/few/other/many](https://github.com/svenfuchs/rails-i18n/blob/f6cc43ec8cfc08d0db7a06ca8299d7834c517a05/lib/rails_i18n/common_pluralizations/east_slavic.rb#L37).

## Testing Instructions

See issue.