### PR TITLE
AO3-6093 Prevent creation of translation tags in system

### DIFF
--- a/app/models/admin_post.rb
+++ b/app/models/admin_post.rb
@@ -59,6 +59,8 @@ class AdminPost < ApplicationRecord
   end
 
   def tag_list=(list)
+    return if translated_post.present?
+
     self.tags = list.split(",").uniq.collect { |t|
       AdminPostTag.fetch(name: t.strip, language_id: self.language_id, post: self)
       }.compact

--- a/features/admins/admin_post_news.feature
+++ b/features/admins/admin_post_news.feature
@@ -147,7 +147,8 @@ Feature: Admin Actions to Post News
     Then I should not see the input with id "admin_post_tag_list"
      And I should not see "Tags from the selected post will replace any tags entered on this page."
     When I go to the admin-posts page
-     And I follow "Edit"
+    Then "ooops" should not be an option within "Tag"
+    When I follow "Edit"
     Then I should see the input with id "admin_post_tag_list"
     When I fill in "Tags" with "updated1, updated2"
      And I press "Post"


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [x] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [x] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [x] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-6093

## Purpose

Update after testing.
Hope I understood the issue and suggested solution correctly 😄 
Provided translation tags are not saved. However, when tag is updated on original post, old tag still shows up in search even though it was used only in that one post. As it has nothing to do with translation issue, did nothing with it.

## Credit
korrien, she/her