### PR TITLE
AO3-6132 Version cache key for blurb CSS classes

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -601,7 +601,7 @@ module ApplicationHelper
   def css_classes_for_creation_blurb(creation)
     return if creation.nil?
 
-    Rails.cache.fetch("#{creation.cache_key_with_version}/blurb_css_classes") do
+    Rails.cache.fetch("#{creation.cache_key_with_version}/blurb_css_classes-v2") do
       creation_id = creation_id_for_css_classes(creation)
       creator_ids = creator_ids_for_css_classes(creation).join(" ")
       "blurb group #{creation_id} #{creator_ids}".strip

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -204,13 +204,13 @@ describe ApplicationHelper do
       context "when series is updated" do
         context "when new user is added" do
           it "returns updated string" do
-            original_cache_key = "#{series.cache_key_with_version}/blurb_css_classes"
+            original_cache_key = "#{series.cache_key_with_version}/blurb_css_classes-v2"
             expect(helper.css_classes_for_creation_blurb(series)).to eq("#{default_classes} series-#{series.id} user-#{user1.id}")
 
             travel(1.day)
             series.creatorships.find_or_create_by(pseud_id: user2.default_pseud_id)
             expect(helper.css_classes_for_creation_blurb(series.reload)).to eq("#{default_classes} series-#{series.id} user-#{user1.id} user-#{user2.id}")
-            expect(original_cache_key).not_to eq("#{series.cache_key_with_version}/blurb_css_classes")
+            expect(original_cache_key).not_to eq("#{series.cache_key_with_version}/blurb_css_classes-v2")
             travel_back
           end
         end
@@ -219,13 +219,13 @@ describe ApplicationHelper do
           before { series.creatorships.find_or_create_by(pseud_id: user2.default_pseud_id) }
 
           it "returns updated string" do
-            original_cache_key = "#{series.cache_key_with_version}/blurb_css_classes"
+            original_cache_key = "#{series.cache_key_with_version}/blurb_css_classes-v2"
             expect(helper.css_classes_for_creation_blurb(series)).to eq("#{default_classes} series-#{series.id} user-#{user1.id} user-#{user2.id}")
 
             travel(1.day)
             series.creatorships.find_by(pseud_id: user2.default_pseud_id).destroy
             expect(helper.css_classes_for_creation_blurb(series.reload)).to eq("#{default_classes} series-#{series.id} user-#{user1.id}")
-            expect(original_cache_key).not_to eq("#{series.cache_key_with_version}/blurb_css_classes")
+            expect(original_cache_key).not_to eq("#{series.cache_key_with_version}/blurb_css_classes-v2")
             travel_back
           end
         end
@@ -234,13 +234,13 @@ describe ApplicationHelper do
       context "when series' work is updated" do
         context "when new user is added to series' work" do
           it "returns updated string" do
-            original_cache_key = "#{series.cache_key_with_version}/blurb_css_classes"
+            original_cache_key = "#{series.cache_key_with_version}/blurb_css_classes-v2"
             expect(helper.css_classes_for_creation_blurb(series)).to eq("#{default_classes} series-#{series.id} user-#{user1.id}")
 
             travel(1.day)
             work.creatorships.find_or_create_by(pseud_id: user2.default_pseud_id)
             expect(helper.css_classes_for_creation_blurb(series.reload)).to eq("#{default_classes} series-#{series.id} user-#{user1.id} user-#{user2.id}")
-            expect(original_cache_key).not_to eq("#{series.cache_key_with_version}/blurb_css_classes")
+            expect(original_cache_key).not_to eq("#{series.cache_key_with_version}/blurb_css_classes-v2")
             travel_back
           end
         end
@@ -253,13 +253,13 @@ describe ApplicationHelper do
 
           # TODO: AO3-5739 Co-creators removed from all works in a series are not removed from series
           it "returns same string" do
-            original_cache_key = "#{series.cache_key_with_version}/blurb_css_classes"
+            original_cache_key = "#{series.cache_key_with_version}/blurb_css_classes-v2"
             expect(helper.css_classes_for_creation_blurb(series)).to eq("#{default_classes} series-#{series.id} user-#{user1.id} user-#{user2.id}")
 
             travel(1.day)
             work.creatorships.find_by(pseud_id: user2.default_pseud_id).destroy
             expect(helper.css_classes_for_creation_blurb(series.reload)).to eq("#{default_classes} series-#{series.id} user-#{user1.id} user-#{user2.id}")
-            expect(original_cache_key).to eq("#{series.cache_key_with_version}/blurb_css_classes")
+            expect(original_cache_key).to eq("#{series.cache_key_with_version}/blurb_css_classes-v2")
             travel_back
           end
         end
@@ -268,13 +268,13 @@ describe ApplicationHelper do
           let(:collection) { create(:anonymous_collection) }
 
           it "returns updated string" do
-            original_cache_key = "#{series.cache_key_with_version}/blurb_css_classes"
+            original_cache_key = "#{series.cache_key_with_version}/blurb_css_classes-v2"
             expect(helper.css_classes_for_creation_blurb(series)).to eq("#{default_classes} series-#{series.id} user-#{user1.id}")
 
             travel(1.day)
             work.collections << collection
             expect(helper.css_classes_for_creation_blurb(series.reload)).to eq("#{default_classes} series-#{series.id}")
-            expect(original_cache_key).not_to eq("#{series.cache_key_with_version}/blurb_css_classes")
+            expect(original_cache_key).not_to eq("#{series.cache_key_with_version}/blurb_css_classes-v2")
             travel_back
           end
         end
@@ -283,13 +283,13 @@ describe ApplicationHelper do
           let(:collection) { create(:unrevealed_collection) }
 
           it "returns same string" do
-            original_cache_key = "#{series.cache_key_with_version}/blurb_css_classes"
+            original_cache_key = "#{series.cache_key_with_version}/blurb_css_classes-v2"
             expect(helper.css_classes_for_creation_blurb(series)).to eq("#{default_classes} series-#{series.id} user-#{user1.id}")
 
             travel(1.day)
             work.collections << collection
             expect(helper.css_classes_for_creation_blurb(series.reload)).to eq("#{default_classes} series-#{series.id} user-#{user1.id}")
-            expect(original_cache_key).to eq("#{series.cache_key_with_version}/blurb_css_classes")
+            expect(original_cache_key).to eq("#{series.cache_key_with_version}/blurb_css_classes-v2")
             travel_back
           end
         end
@@ -309,13 +309,13 @@ describe ApplicationHelper do
       context "when new user is added" do
         it "returns updated string" do
           travel_to(1.day.ago)
-          original_cache_key = "#{work.cache_key_with_version}/blurb_css_classes"
+          original_cache_key = "#{work.cache_key_with_version}/blurb_css_classes-v2"
           expect(helper.css_classes_for_creation_blurb(work)).to eq("#{default_classes} work-#{work.id} user-#{user1.id}")
 
           travel_back
           work.creatorships.find_or_create_by(pseud_id: user2.default_pseud_id)
           expect(helper.css_classes_for_creation_blurb(work)).to eq("#{default_classes} work-#{work.id} user-#{user1.id} user-#{user2.id}")
-          expect(original_cache_key).not_to eq("#{work.cache_key_with_version}/blurb_css_classes")
+          expect(original_cache_key).not_to eq("#{work.cache_key_with_version}/blurb_css_classes-v2")
         end
       end
 
@@ -323,13 +323,13 @@ describe ApplicationHelper do
         it "returns updated string" do
           travel_to(1.day.ago)
           work.creatorships.find_or_create_by(pseud_id: user2.default_pseud_id)
-          original_cache_key = "#{work.cache_key_with_version}/blurb_css_classes"
+          original_cache_key = "#{work.cache_key_with_version}/blurb_css_classes-v2"
           expect(helper.css_classes_for_creation_blurb(work)).to eq("#{default_classes} work-#{work.id} user-#{user1.id} user-#{user2.id}")
 
           travel_back
           work.creatorships.find_by(pseud_id: user2.default_pseud_id).destroy
           expect(helper.css_classes_for_creation_blurb(work)).to eq("#{default_classes} work-#{work.id} user-#{user1.id}")
-          expect(original_cache_key).not_to eq("#{work.cache_key_with_version}/blurb_css_classes")
+          expect(original_cache_key).not_to eq("#{work.cache_key_with_version}/blurb_css_classes-v2")
         end
       end
 
@@ -338,13 +338,13 @@ describe ApplicationHelper do
 
         it "returns updated string" do
           travel_to(1.day.ago)
-          original_cache_key = "#{work.cache_key_with_version}/blurb_css_classes"
+          original_cache_key = "#{work.cache_key_with_version}/blurb_css_classes-v2"
           expect(helper.css_classes_for_creation_blurb(work)).to eq("#{default_classes} work-#{work.id} user-#{user1.id}")
 
           travel_back
           work.collections << collection
           expect(helper.css_classes_for_creation_blurb(work)).to eq("#{default_classes} work-#{work.id}")
-          expect(original_cache_key).not_to eq("#{work.cache_key_with_version}/blurb_css_classes")
+          expect(original_cache_key).not_to eq("#{work.cache_key_with_version}/blurb_css_classes-v2")
         end
       end
 
@@ -353,13 +353,13 @@ describe ApplicationHelper do
 
         it "returns updated string" do
           travel_to(1.day.ago)
-          original_cache_key = "#{work.cache_key_with_version}/blurb_css_classes"
+          original_cache_key = "#{work.cache_key_with_version}/blurb_css_classes-v2"
           expect(helper.css_classes_for_creation_blurb(work)).to eq("#{default_classes} work-#{work.id} user-#{user1.id}")
 
           travel_back
           work.collections << collection
           expect(helper.css_classes_for_creation_blurb(work)).to eq("#{default_classes} work-#{work.id}")
-          expect(original_cache_key).not_to eq("#{work.cache_key_with_version}/blurb_css_classes")
+          expect(original_cache_key).not_to eq("#{work.cache_key_with_version}/blurb_css_classes-v2")
         end
       end
     end


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6132

## Purpose

Adds a version number to the cache key so everything is expired on deploy.