### PR TITLE
AO3-6271 Fix blurb icon position on homepage Marked for Later

### DIFF
--- a/public/stylesheets/site/2.0/16-zone-system.css
+++ b/public/stylesheets/site/2.0/16-zone-system.css
@@ -194,7 +194,7 @@ SUBSECTIONS:
 
 /* mod: logged-in */
 
-.logged-in .splash .module {
+.logged-in .splash > .module {
   float: left;
   margin: 0 1% 1.571em 1%;
   width: 48%;


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6271

## Purpose

Makes sure the `float` from `.logged-in .splash .module` isn't applied to the header module in the marked for later blurbs, causing the icons and title to be misaligned.

## Testing Instructions

Refer to Jira.

## Credit

Sarken, she/her
