### PR TITLE
AO3-6258 Update sign-up email subject

### DIFF
--- a/config/locales/mailers/en.yml
+++ b/config/locales/mailers/en.yml
@@ -121,7 +121,7 @@ en:
       subject: "[%{app_name}] Email changed"
       part1: "%{login}, the email associated with your account has been changed to %{email}"
     signup_notification:
-      subject: "[%{app_name}] Confirmation"
+      subject: "[%{app_name}] Activate your account"
       faq: "FAQ"
       admin_posts: "AO3 News"
       contact_support: "contact Support"

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -297,7 +297,7 @@ describe UserMailer do
     it_behaves_like "an email with a valid sender"
 
     it "has the correct subject line" do
-      subject = "[#{ArchiveConfig.APP_SHORT_NAME}] Confirmation"
+      subject = "[#{ArchiveConfig.APP_SHORT_NAME}] Activate your account"
       expect(email).to have_subject(subject)
     end
 


### PR DESCRIPTION
# Pull Request Checklist

* [X] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [X] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [X] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)? (updated existing test)
* [X] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [X] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-6258

## Purpose

Updates the subject of the email a user receives on sign up, from `[AO3] Confirmation` to `[AO3] Activate your account`.

## Testing Instructions

1. If not already enabled, turn on account creation (https://github.com/otwcode/otwarchive/wiki/Development-Data#creating-users).
2. Create a user (with valid email) via the "Create an Account!" button on the home page.
3. Check the email account for an email with the subject "[AO3] Activate your account".

## References

## Credit

What name and pronouns should we use to credit you in the [Archive of Our Own's Release Notes](https://archiveofourown.org/admin_posts?tag=1)?
**Brian Austin (he/they)**
