### PR TITLE
AO3-6269 Allow invitations to be selected with their label

### DIFF
--- a/app/views/invitations/index.html.erb
+++ b/app/views/invitations/index.html.erb
@@ -29,7 +29,7 @@
             <% for unsent_invite in @unsent_invitations %>
             <li>
               <%= radio_button_tag "invitation[id]", unsent_invite.id, checked: (unsent_invite == @unsent_invitations.first) %>
-              <%= label_tag 'id_' + unsent_invite.id.to_s, unsent_invite.token %>
+              <%= label_tag 'invitation_id_' + unsent_invite.id.to_s, unsent_invite.token %>
             </li>
             <% end %>
           </ul>


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [x] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [x] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [x] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-6269

## Purpose

Allows a user to click the "keysmash" label of an invitation rather than needing to select the radio box

## Testing Instructions

1. Log in as a user who has unused invitations
2. Go to your invitations page: https://archiveofourown.org/users/USERNAME/invitations
3. Click/tap on one of the keysmashes – as in, the text itself – in the "Choose an invitation" section

## References

## Credit

Arianna Story (she/her)