### PR TITLE
AO3-6249 Make Pseuds dropdown on user page sidebar always label itself as Pseuds

### DIFF
--- a/app/views/users/_sidebar.html.erb
+++ b/app/views/users/_sidebar.html.erb
@@ -5,8 +5,7 @@
   <li><%= span_if_current ts("Profile"), user_profile_path(@user) %></li>
   <% if @user.pseuds.size > 1 %>
     <li class="pseud" aria-haspopup="true">
-      <% pseud_link_text = ts("Pseuds") %>
-      <a href="#" title="<%= ts("Pseud Switcher") %>"><%= pseud_link_text %></a>
+      <a href="#" title="<%= ts("Pseud Switcher") %>"><%= ts("Pseuds") %></a>
       <ul class="expandable secondary">
         <%= print_pseud_selector(@user.pseuds) %>
         <li><%= span_if_current ts("All Pseuds (%{pseud_number})", :pseud_number => @user.pseuds.count), user_pseuds_path(@user) %></li>

--- a/app/views/users/_sidebar.html.erb
+++ b/app/views/users/_sidebar.html.erb
@@ -5,7 +5,7 @@
   <li><%= span_if_current ts("Profile"), user_profile_path(@user) %></li>
   <% if @user.pseuds.size > 1 %>
     <li class="pseud" aria-haspopup="true">
-      <% pseud_link_text = current_page?(@user) ? ts("Pseuds") : (@author ? @author.name : @user.login) %>
+      <% pseud_link_text = ts("Pseuds") %>
       <a href="#" title="<%= ts("Pseud Switcher") %>"><%= pseud_link_text %></a>
       <ul class="expandable secondary">
         <%= print_pseud_selector(@user.pseuds) %>


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [x] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [x] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [x] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-6249

## Purpose

Changes the "Pseuds" dropdown on /users/USERNAME/* pages to always read as "Pseuds" rather than showing the pseud that is currently being acted on

## Testing Instructions

1. Log in as a user who has more than one pseud
2. Click the "Pseuds ↓" dropdown
3. Switch to another pseud
4. See that the "Pseuds ↓" dropdown is no longer changing :)

## References

## Credit

Arianna Story (she/her)