### PR TITLE
AO3-6040 Add a list of reserved unusable usernames and pseuds

### DIFF
--- a/app/controllers/admin/reserved_usernames_controller.rb
+++ b/app/controllers/admin/reserved_usernames_controller.rb
@@ -1,0 +1,41 @@
+class Admin::ReservedUsernamesController < Admin::BaseController
+
+  def index
+    @admin_reserved_username = AdminReservedUsername.new
+    if params[:query]
+      @admin_reserved_usernames = AdminReservedUsername.where(["username LIKE ?", '%' + params[:query] + '%'])
+      @admin_reserved_usernames = @admin_reserved_usernames.paginate(page: params[:page], per_page: ArchiveConfig.ITEMS_PER_PAGE)
+    end
+  end
+
+  def new
+    @admin_reserved_username = AdminReservedUsername.new
+  end
+
+  def create
+    @admin_reserved_username = AdminReservedUsername.new(admin_reserved_username_params)
+
+    if @admin_reserved_username.save
+      flash[:notice] = ts("Username #{@admin_reserved_username.username} added to reserved list.")
+      redirect_to admin_reserved_usernames_path
+    else
+      render action: "index"
+    end
+  end
+
+  def destroy
+    @admin_reserved_username = AdminReservedUsername.find(params[:id])
+    @admin_reserved_username.destroy
+
+    flash[:notice] = ts("User name #{@admin_reserved_username.username} removed from reserved list.")
+    redirect_to admin_reserved_usernames_path
+  end
+
+  private
+
+  def admin_reserved_username_params
+    params.require(:admin_reserved_username).permit(
+      :username
+    )
+  end
+end

--- a/app/models/admin_reserved_username.rb
+++ b/app/models/admin_reserved_username.rb
@@ -1,0 +1,11 @@
+class AdminReservedUsername < ApplicationRecord
+  include ActiveModel::ForbiddenAttributesProtection
+
+  validates :username, presence: true, uniqueness: true, reserved_username: true
+
+  # Check if an email is
+  def self.is_reserved?(username_to_check)
+    AdminReservedUsername.where(username: username_to_check).exists?
+  end
+
+end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -13,6 +13,7 @@ class Comment < ApplicationRecord
   has_many :thread_comments, class_name: 'Comment', foreign_key: :thread
 
   validates_presence_of :name, unless: :pseud_id
+  validates :name, reserved_username: {on: :create}
   validates :email, email_veracity: {on: :create, unless: :pseud_id}, email_blacklist: {on: :create, unless: :pseud_id}
 
   validates_presence_of :comment_content

--- a/app/models/pseud.rb
+++ b/app/models/pseud.rb
@@ -77,6 +77,9 @@ class Pseud < ApplicationRecord
   validates_length_of :icon_comment_text, allow_blank: true, maximum: ArchiveConfig.ICON_COMMENT_MAX,
     too_long: ts("must be less than %{max} characters long.", max: ArchiveConfig.ICON_COMMENT_MAX)
 
+  # AO3-6040 Prevents a pseud from being registered or renamed-to if the username is reserved
+  validates :name, reserved_username: true
+
   after_update :check_default_pseud
   after_update :expire_caches
   after_commit :reindex_creations

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -175,6 +175,9 @@ class User < ApplicationRecord
                       with: /\A[A-Za-z0-9]\w*[A-Za-z0-9]\Z/
   validates_uniqueness_of :login, case_sensitive: false, message: ts("has already been taken")
 
+  # AO3-6040 Prevents a username from being registered or renamed-to if the username is reserved
+  validates :login, reserved_username: true
+
   validates :email, email_veracity: true, email_format: true
 
   # Virtual attribute for age check and terms of service

--- a/app/validators/reserved_username_validator.rb
+++ b/app/validators/reserved_username_validator.rb
@@ -1,0 +1,10 @@
+class ReservedUsernameValidator < ActiveModel::EachValidator
+    def validate_each(record,attribute,value)
+      if AdminReservedUsername.is_reserved?(value)
+        record.errors[attribute] << (options[:message] || I18n.t('validators.username.reserved'))
+        return false
+      else
+        return true
+      end
+    end
+  end

--- a/app/views/admin/_header.html.erb
+++ b/app/views/admin/_header.html.erb
@@ -30,6 +30,7 @@
       <li><%= span_if_current ts("Wrangling Guidelines", key: "header"), wrangling_guidelines_path %></li>
     </ul>
   </li>
+  <li><%= link_to ts("Reserved Names", key: "header"), admin_reserved_usernames_path %></li>
   <li><%= link_to ts("Blacklist", key: "header"), admin_blacklisted_emails_path %></li>
   <li><%= link_to ts("Spam", key: "header"), admin_spam_index_path %></li>
   <% if policy(AdminSetting).can_view_settings? %>

--- a/app/views/admin/reserved_usernames/index.html.erb
+++ b/app/views/admin/reserved_usernames/index.html.erb
@@ -1,0 +1,62 @@
+<div class="admin">
+  <!--Descriptive page name, messages and instructions-->
+  <h2 class="heading"><%= t("admin.admin_reserved_username.index.page_heading", default: "Manage Reserved Usernames") %></h2>
+
+  <ul class="notes">
+    <li><%= ts("Reserved user names cannot be used in guest comments, nor can a user change their username (or pseud) to them.") %></li>
+    <li><%= ts("They do not affect any user who currently has a name on this list.") %></li>
+  </ul>
+  <!--/descriptions-->
+
+  <!--main content-->
+  <h3 class="heading"><%= ts("Add user names to reserved list") %></h3>
+
+  <%= form_for(@admin_reserved_username, html: { class: "simple post" }) do |f| %>
+    <%= error_messages_for @admin_reserved_username %>
+    <fieldset>
+      <p>
+        <%= f.label :username, ts("Username to add") %>
+        <%= f.text_field :username %>
+        <%= f.submit ts("Add To Reserved List") %>
+      </p>
+    </fieldset>
+  <% end %>
+
+  <h3 class="heading"><%= ts("Find reserved user names")%></h3>
+
+  <!-- search form -->
+  <%= form_tag url_for(controller: "admin/reserved_usernames", action: "index"),
+               method: :get, class: "simple search", role: "search" do %>
+    <fieldset>
+      <p>
+        <%= label_tag "query", ts("Username to find") %>
+        <%= text_field_tag "query", params[:query] %>
+        <%= submit_tag ts("Search Reserved List") %>
+      </p>
+    </fieldset>
+  <% end %>
+
+  <!-- list of search results -->
+  <% if @admin_reserved_usernames %>
+    <div class="results module">
+      <h3 class="heading">
+        <%= t("admin.reserved.usernames_found", count: @admin_reserved_usernames.count) %>
+      </h3>
+      <% if @admin_reserved_usernames.count > 0 %>
+        <ol class="usernames index group">
+          <% @admin_reserved_usernames.each do |reserved_username| %>
+          <li>
+            <%= link_to ts("Remove %{username}", username: reserved_username.username),
+                        reserved_username,
+                        method: :delete,
+                        data: { confirm: ts("Are you sure you want to remove %{username} from the reserved list?",
+                                username: reserved_username.username) } %>
+          </li>
+          <% end %>
+        </ul>
+        <%= will_paginate @admin_reserved_usernames %>
+      <% end %>
+    </div>
+  <% end %>
+  <!--/content-->
+</div>

--- a/config/locales/validators/en.yml
+++ b/config/locales/validators/en.yml
@@ -8,3 +8,5 @@ en:
       format:
         allow_blank: "should look like an email address. Please use a different address or leave blank."
         no_blank: "should look like an email address."
+    username:
+      reserved: "is reserved. Please use a different username."

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -156,6 +156,7 @@ Otwarchive::Application.routes.draw do
         get :confirm_delete
       end
     end
+    resources :reserved_usernames, only: [:index, :new, :create, :destroy]
     resources :blacklisted_emails, only: [:index, :new, :create, :destroy]
     resources :settings
     resources :skins do

--- a/db/migrate/20211231064707_create_admin_reserved_usernames.rb
+++ b/db/migrate/20211231064707_create_admin_reserved_usernames.rb
@@ -1,0 +1,11 @@
+class CreateAdminReservedUsernames < ActiveRecord::Migration[4.2]
+    def change
+      create_table :admin_reserved_usernames do |t|
+        t.string :username
+
+        t.timestamps
+      end
+
+      add_index :admin_reserved_usernames, :username, unique: true
+    end
+  end

--- a/factories/admin_reserved_username.rb
+++ b/factories/admin_reserved_username.rb
@@ -1,0 +1,7 @@
+require 'faker'
+
+FactoryBot.define do
+  factory :admin_reserved_username do
+    username
+  end
+end


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [ ] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [x] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [x] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-6040

## Purpose

This PR adds a way to list certain names as reserved, preventing their use in usernames, pseuds, and in comments. 

## Testing Instructions

1. Log in as an administrator
2. Visit the new "Reserved Names" menu item
3. Add "reserved" to the reserved names list
4. In incognito, attempt to create a user with the name "reserved"
5. In incognito (as a guest), attempt to leave a comment on a work with the name "reserved"
5. Log in as a non-admin
6. Attempt to rename yourself to "reserved"
7. Attempt to create a pseud with the name "reserved"
8. Attempt to create a pseud with the name "reserved-but-not-really" (should work!)

## References

## Credit

Arianna Story (she/her)
