### PR TITLE
AO3-4037 Retry comment notifications when comment does not exist.

### DIFF
--- a/app/jobs/application_mailer_job.rb
+++ b/app/jobs/application_mailer_job.rb
@@ -1,0 +1,22 @@
+class ApplicationMailerJob < ActionMailer::DeliveryJob
+  # TODO: We have a mix of mailers that take ActiveRecords as arguments, and
+  # mailers that take IDs as arguments. If an item is unavailable when the
+  # notification is sent, it'll produce an ActiveJob::DeserializationError in
+  # the former case, and an ActiveRecord::RecordNotFound error in the latter.
+  #
+  # Ideally, we don't want to catch RecordNotFound errors, because they might
+  # be a sign of a different problem. But until we move all of the mailers over
+  # to taking ActiveRecords as arguments, we need to catch both errors.
+
+  retry_on ActiveJob::DeserializationError,
+           attempts: 3,
+           wait: 1.minute do
+    # silently discard job after 3 failures
+  end
+
+  retry_on ActiveRecord::RecordNotFound,
+           attempts: 3,
+           wait: 1.minute do
+    # silently discard job after 3 failures
+  end
+end

--- a/app/mailers/admin_mailer.rb
+++ b/app/mailers/admin_mailer.rb
@@ -1,9 +1,5 @@
-class AdminMailer < ActionMailer::Base
+class AdminMailer < ApplicationMailer
   include HtmlCleaner
-
-  layout 'mailer'
-  helper :mailer
-  default from: "Archive of Our Own " + "<#{ArchiveConfig.RETURN_ADDRESS}>"
 
   def feedback(feedback_id)
     @feedback = Feedback.find(feedback_id)

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,7 +1,7 @@
 class ApplicationMailer < ActionMailer::Base
   self.delivery_job = ApplicationMailerJob
 
-  layout 'mailer'
+  layout "mailer"
   helper :mailer
   default from: "Archive of Our Own " + "<#{ArchiveConfig.RETURN_ADDRESS}>"
 end

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,0 +1,7 @@
+class ApplicationMailer < ActionMailer::Base
+  self.delivery_job = ApplicationMailerJob
+
+  layout 'mailer'
+  helper :mailer
+  default from: "Archive of Our Own " + "<#{ArchiveConfig.RETURN_ADDRESS}>"
+end

--- a/app/mailers/collection_mailer.rb
+++ b/app/mailers/collection_mailer.rb
@@ -1,13 +1,9 @@
-class CollectionMailer < ActionMailer::Base
+class CollectionMailer < ApplicationMailer
   helper :application
-  helper :mailer
   helper :tags
   helper :works
   helper :series
 
-  layout 'mailer'
-  default from: "Archive of Our Own " + "<#{ArchiveConfig.RETURN_ADDRESS}>"
-  
   def item_added_notification(creation_id, collection_id, item_type)
     @item_type = item_type
     @item_type == "Work" ? @creation = Work.find(creation_id) : @creation = Bookmark.find(creation_id)

--- a/app/mailers/comment_mailer.rb
+++ b/app/mailers/comment_mailer.rb
@@ -1,8 +1,4 @@
-class CommentMailer < ActionMailer::Base
-  layout 'mailer'
-  helper :mailer
-  default from: "Archive of Our Own " + "<#{ArchiveConfig.RETURN_ADDRESS}>"
-
+class CommentMailer < ApplicationMailer
   # Sends email to an owner of the top-level commentable when a new comment is created
   def comment_notification(user, comment)
     @comment = comment

--- a/app/mailers/kudo_mailer.rb
+++ b/app/mailers/kudo_mailer.rb
@@ -1,8 +1,4 @@
-class KudoMailer < ActionMailer::Base
-  layout 'mailer'
-  helper :mailer
-  default from: "Archive of Our Own " + "<#{ArchiveConfig.RETURN_ADDRESS}>"
-
+class KudoMailer < ApplicationMailer
   # send a batched-up notification
   # user_kudos is a hash of arrays converted to JSON string format
   # [commentable_type]_[commentable_id] =>

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -1,21 +1,16 @@
-class UserMailer < ActionMailer::Base
-  layout 'mailer'
-
+class UserMailer < ApplicationMailer
   helper_method :current_user
   helper_method :current_admin
   helper_method :logged_in?
   helper_method :logged_in_as_admin?
 
   helper :application
-  helper :mailer
   helper :tags
   helper :works
   helper :users
   helper :date
   helper :series
   include HtmlCleaner
-
-  default from: "Archive of Our Own " + "<#{ArchiveConfig.RETURN_ADDRESS}>"
 
   # Send an email letting creators know their work has been added to a collection
   def added_to_collection_notification(user_id, work_id, collection_id)

--- a/spec/mailers/comment_mailer_spec.rb
+++ b/spec/mailers/comment_mailer_spec.rb
@@ -4,6 +4,16 @@ describe CommentMailer do
   let(:comment) { create(:comment) }
   let(:user) { create(:user) }
 
+  shared_examples "it retries when the comment doesn't exist" do
+    it "tries to send the email 3 times, then fails silently" do
+      comment.delete
+
+      assert_performed_jobs 3, only: ApplicationMailerJob do
+        subject.deliver_later
+      end
+    end
+  end
+
   shared_examples "a notification email with a link to the comment" do
     describe "HTML email" do
       it "has a link to the comment" do
@@ -65,6 +75,7 @@ describe CommentMailer do
     subject(:email) { CommentMailer.comment_notification(user, comment) }
 
     it_behaves_like "an email with a valid sender"
+    it_behaves_like "it retries when the comment doesn't exist"
     it_behaves_like "a notification email with a link to the comment"
     it_behaves_like "a notification email with a link to reply to the comment"
 
@@ -96,6 +107,7 @@ describe CommentMailer do
     subject(:email) { CommentMailer.edited_comment_notification(user, comment) }
 
     it_behaves_like "an email with a valid sender"
+    it_behaves_like "it retries when the comment doesn't exist"
     it_behaves_like "a notification email with a link to the comment"
     it_behaves_like "a notification email with a link to reply to the comment"
 
@@ -130,6 +142,7 @@ describe CommentMailer do
     let(:comment) { create(:comment, commentable: parent_comment) }
 
     it_behaves_like "an email with a valid sender"
+    it_behaves_like "it retries when the comment doesn't exist"
     it_behaves_like "a notification email with a link to the comment"
     it_behaves_like "a notification email with a link to reply to the comment"
     it_behaves_like "a notification email with a link to the comment's thread"
@@ -165,6 +178,7 @@ describe CommentMailer do
     let(:comment) { create(:comment, commentable: parent_comment) }
 
     it_behaves_like "an email with a valid sender"
+    it_behaves_like "it retries when the comment doesn't exist"
     it_behaves_like "a notification email with a link to the comment"
     it_behaves_like "a notification email with a link to reply to the comment"
     it_behaves_like "a notification email with a link to the comment's thread"
@@ -197,6 +211,7 @@ describe CommentMailer do
     subject(:email) { CommentMailer.comment_sent_notification(comment) }
 
     it_behaves_like "an email with a valid sender"
+    it_behaves_like "it retries when the comment doesn't exist"
     it_behaves_like "a notification email with a link to the comment"
 
     context "when the comment is a reply to another comment" do


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-4037

## Purpose

Modify all mailers to retry on a deserialization error or a record not found error. It will try to send the email a total of 3 times, with 1 minute of delay between each attempt. If all three attempts fail, it will silently delete the mailer job, instead of bubbling up to the Resque failures list.