### PR TITLE
AO3-5392 Add task to reset revised_at on backdated works

### DIFF
--- a/lib/tasks/after_tasks.rake
+++ b/lib/tasks/after_tasks.rake
@@ -876,21 +876,28 @@ namespace :After do
 
   desc "Reset blurb date (revised_at) on backdated works"
   task(reset_revised_at_on_backdated_works: :environment) do
-    # Fix all backdated works, as well as works with an arbitrary revised_at
-    # set in the past (possibly because of AO3-6187).
+    # Fix all backdated works, as well as works with an arbitrary revised_at set
+    # in the past (possibly because of AO3-6187). Skip works failing validations.
     works = Work.where("backdate OR revised_at < created_at")
     work_count = works.count
     total_batches = (work_count + 999) / 1000
     puts("Checking #{work_count} works in #{total_batches} batches") && STDOUT.flush
 
+    invalid_work_ids = []
     works.find_in_batches.with_index do |batch, index|
       batch_number = index + 1
 
       batch.each do |work|
         work.revised_at = nil
-        work.save
+        invalid_work_ids << work.id unless work.save
       end
       puts("Batch #{batch_number} of #{total_batches} complete") && STDOUT.flush
+    end
+
+    unless invalid_work_ids.empty?
+      puts "The following #{invalid_work_ids.size} work(s) failed validations and could not be saved:"
+      puts invalid_work_ids.join(", ")
+      STDOUT.flush
     end
   end
 

--- a/spec/lib/tasks/after_tasks.rake_spec.rb
+++ b/spec/lib/tasks/after_tasks.rake_spec.rb
@@ -317,7 +317,7 @@ describe "rake After:reset_revised_at_on_backdated_works" do
         .and avoid_changing { work.reload.revised_at }
     end
 
-    it "resets revised_at if arbitrary set in the past" do
+    it "resets revised_at if arbitrarily set in the past" do
       work.update_column(:revised_at, 10.years.ago)
 
       expect do
@@ -343,6 +343,14 @@ describe "rake After:reset_revised_at_on_backdated_works" do
       end.to change { work.reload.updated_at }
         .and change { work.reload.revised_at }
       expect(work.revised_at.to_date).to eq(Date.new(2021, 12, 5))
+    end
+
+    it "outputs work IDs that fail validations" do
+      allow_any_instance_of(Work).to receive(:save).and_return(false)
+
+      expect do
+        subject.invoke
+      end.to output(/The following 1 work\(s\) failed validations and could not be saved:\n#{work.id}/).to_stdout
     end
   end
 end


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5392

## Purpose

The field `revised_at` is used in work blurbs.

Also reset revised_at for non-backdated works if it's arbitrarily set in the past (possibly because of [AO3-6187](https://otwarchive.atlassian.net/browse/AO3-6187)).

Note that the actual bug was fixed in #4115. This is just to fix the dates on existing works.

## Testing Instructions

Find an existing work from testy affected by the bug, run the task and check that the work now has consistent dates in blurb and meta.