### PR TITLE
AO3-5754 Tweak implementation of live validation message styling

### DIFF
--- a/public/stylesheets/site/2.0/07-interactions.css
+++ b/public/stylesheets/site/2.0/07-interactions.css
@@ -178,14 +178,14 @@ We only use error messages for LiveValidation. Style spoofs the system error mes
 .LV_validation_message {
   font-weight: 900;
   position: absolute;
+  margin-top: 0.643em;
+  margin-right: 13em;
 }
 
 .LV_invalid {
   background: #efd1d1;
   border: 1px solid #900;
   color: #900;
-  margin-top: 0.643em;
-  margin-right: 13em;
   padding: 0.25em 0.375em;
     box-shadow: 1px 1px 2px;
     border-radius: 0.25em;


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5754

## Purpose

Moves the style tweaks from #3673 around a bit for future proofing. (The `LV_validation_message` gets applied to both success and failure messages, so it's good to keep general style stuff there.)

