### PR TITLE
AO3-6230 Let certain admins search by user ID

### DIFF
--- a/app/controllers/admin/admin_users_controller.rb
+++ b/app/controllers/admin/admin_users_controller.rb
@@ -6,7 +6,7 @@ class Admin::AdminUsersController < Admin::BaseController
     @role_values = @roles.map{ |role| [role.name.humanize.titlecase, role.name] }
     @role = Role.find_by(name: params[:role]) if params[:role]
     @users = User.search_by_role(
-      @role, params[:name], params[:email],
+      @role, params[:name], params[:email], params[:user_id],
       inactive: params[:inactive], exact: params[:exact], page: params[:page]
     )
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -221,8 +221,8 @@ class User < ApplicationRecord
 
   # Find users with a particular role and/or by name and/or by email
   # Options: inactive, page, exact
-  def self.search_by_role(role, name, email, options = {})
-    return if role.blank? && name.blank? && email.blank?
+  def self.search_by_role(role, name, email, user_id, options = {})
+    return if role.blank? && name.blank? && email.blank? && user_id.blank?
     users = User.distinct.order(:login)
     if options[:inactive]
       users = users.where("confirmed_at IS NULL")
@@ -235,6 +235,9 @@ class User < ApplicationRecord
     end
     if email.present?
       users = users.filter_by_email(email, options[:exact])
+    end
+    if user_id.present?
+      users = users.where(["users.id = ?", user_id])
     end
     users.paginate(page: options[:page] || 1)
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -219,10 +219,11 @@ class User < ApplicationRecord
     where("challenge_claims.id IN (?)", claims_ids)
   end
 
-  # Find users with a particular role and/or by name and/or by email
+  # Find users with a particular role and/or by name, email, and/or id
   # Options: inactive, page, exact
   def self.search_by_role(role, name, email, user_id, options = {})
     return if role.blank? && name.blank? && email.blank? && user_id.blank?
+
     users = User.distinct.order(:login)
     if options[:inactive]
       users = users.where("confirmed_at IS NULL")

--- a/app/views/admin/admin_users/index.html.erb
+++ b/app/views/admin/admin_users/index.html.erb
@@ -5,12 +5,18 @@
 
   <!--main content-->
   <%= form_tag url_for(controller: "admin/admin_users", action: "index"), method: :get, class: "search", role: "search" do %>
-    <p class="note"><%= ts("Search for a user by username or pseud, by email, or by role.") %></p>
     <dl>
       <dt><%= label_tag "name", ts("Name") %></dt>
-      <dd><%= text_field_tag "name", params[:name] %></dd>
+      <dd>
+        <%= text_field_tag "name", params[:name], "aria-describedby" => "name-field-description" %>
+        <p class="footnote" id="name-field-description">
+          <%= ts("Search for users with matching usernames or pseuds.") %>
+        </p>
+      </dd>
       <dt><%= label_tag "email", ts("Email") %></dt>
       <dd><%= text_field_tag "email", params[:email] %></dd>
+      <dt><%= label_tag "user_id", ts("User ID") %></dt>
+      <dd><%= text_field_tag "user_id", params[:user_id] %></dd>
       <dt><%= label_tag "role", ts("Role") %></dt>
       <dd><%= select_tag "role", "<option></option>".html_safe + options_for_select(@role_values, @role.try(:name)) %></dd>
       <dt><%= label_tag "status", ts("Status") %></dt>

--- a/features/admins/users/admin_find_users.feature
+++ b/features/admins/users/admin_find_users.feature
@@ -57,6 +57,21 @@ Feature: Admin Find Users page
       And I submit
     Then I should see "0 users found"
 
+  Scenario: The Find Users page should perform an exact match by ID in addition to any other criteria
+    When the search criteria contains the ID for "userB"
+      And I submit
+    Then I should see "1 user found"
+      And I should see "userB"
+      But I should not see "userA"
+      And I should not see "userCB"
+    When I fill in "Name" with "A"
+      And I submit
+    Then I should see "0 users found"
+    When I fill in "Name" with "B"
+      And I submit
+    Then I should see "1 user found"
+      And I should see "userB"
+
   # Bulk email search
   Scenario: The Bulk Email Search page should find all existing matching users
     When I go to the Bulk Email Search page

--- a/features/step_definitions/admin_steps.rb
+++ b/features/step_definitions/admin_steps.rb
@@ -272,6 +272,11 @@ When /^I hide the work "(.*?)"$/ do |title|
   step %{I follow "Hide Work"}
 end
 
+When "the search criteria contains the ID for {string}" do |login|
+  user_id = User.find_by(login: login).id
+  fill_in("user_id", with: user_id)
+end
+
 ### THEN
 
 Then (/^the translation information should still be filled in$/) do


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6230

## Purpose

Allows admins who can search users to search by user ID.

## Testing Instructions

Refer to Jira.

## Credit

Sarken, she/her