### PR TITLE
AO3-5619 Update Report Abuse link text in footer and site map

### DIFF
--- a/app/views/home/site_map.html.erb
+++ b/app/views/home/site_map.html.erb
@@ -51,7 +51,7 @@
   <h3 class="heading">Contact Us</h3>
 	  <ul>
 		  <li><%= link_to t('.support_and_feedback', :default => "Support and Feedback"), new_feedback_report_path %></li>
-		  <li><%= link_to t('.report_abuse', :default => "Report Abuse"), new_abuse_report_path %></li>
+		  <li><%= link_to t('.report_abuse', :default => "Policy Questions & Abuse Reports"), new_abuse_report_path %></li>
       <li><%= link_to t('.donate', :default => "Donations"), donate_path %></li>
 	  </ul>
 </div>

--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -34,7 +34,7 @@
     <li class="module group">
       <h4 class="heading"><%= ts('Contact Us', key: 'footer') %></h4>
       <ul class="menu">
-        <li><%= link_to ts('Report Abuse', key: 'footer'), new_abuse_report_path %></li>
+        <li><%= link_to ts('Policy Questions & Abuse Reports', key: 'footer'), new_abuse_report_path %></li>
         <li><%= link_to ts('Technical Support and Feedback', key: 'footer'), new_feedback_report_path %></li>
       </ul>
     </li>

--- a/features/admins/admin_languages.feature
+++ b/features/admins/admin_languages.feature
@@ -29,7 +29,7 @@ Scenario: Adding Abuse support for a language
     And I check "Abuse support available"
     And I press "Update Language"
   Then I should see "Language was successfully updated."
-  When I follow "Report Abuse"
+  When I follow "Policy Questions & Abuse Reports"
   Then I should see "Arabic" within "select#abuse_report_language"
     And I should not see "Espanol" within "select#abuse_report_language"
 

--- a/features/other_a/abuse_report.feature
+++ b/features/other_a/abuse_report.feature
@@ -8,7 +8,7 @@ Feature: Filing an abuse report
   Given basic languages
   When I am logged in as "otheruser"
     And I am on the home page
-    And I follow "Report Abuse"
+    And I follow "Policy Questions & Abuse Reports"
     And I should see the text with tags 'value="http://www.example.com/'
   When I fill in "Your comment (required)" with "This is wrong"
     And I fill in "Brief summary of Terms of Service Violation (required)" with "This is a summary of bad things"
@@ -25,14 +25,14 @@ Feature: Filing an abuse report
     And basic languages
   When I am logged in as "otheruser"
     And I view the work "Illegal thing"
-    And I follow "Report Abuse"
+    And I follow "Policy Questions & Abuse Reports"
   Then I should see the text with tags 'value="http://www.example.com/works/'
 
   Scenario: File an abuse request while logged out
 
   Given basic languages
   When I am on the home page
-    And I follow "Report Abuse"
+    And I follow "Policy Questions & Abuse Reports"
   Then I should see "We investigate every report we receive."
   When I fill in "Brief summary of Terms of Service Violation (required)" with "This is a summary of bad things"
     And I fill in "Your comment (required)" with "This is wrong"
@@ -47,7 +47,7 @@ Feature: Filing an abuse report
   When I am logged in as "otheruser"
     And basic languages
     And I am on the home page
-    And I follow "Report Abuse"
+    And I follow "Policy Questions & Abuse Reports"
     And I fill in "Brief summary of Terms of Service Violation (required)" with "This is a summary of bad things"
     And I fill in "Your comment (required)" with "This is wrong"
     And I fill in "Link to the page you are reporting" with "http://www.archiveofourown.org/works"

--- a/public/403.html
+++ b/public/403.html
@@ -118,7 +118,7 @@
           <li class="module group">
             <h4 class="heading">Contact Us</h4>
             <ul class="menu">
-              <li><a href="/abuse_reports/new">Report Abuse</a></li>
+              <li><a href="/abuse_reports/new">Policy Questions & Abuse Reports</a></li>
               <li><a href="/support">Technical Support and Feedback</a></li>
             </ul>
           </li>

--- a/public/445.html
+++ b/public/445.html
@@ -116,7 +116,7 @@
           <li class="module group">
             <h4 class="heading">Contact Us</h4>
             <ul class="menu">
-              <li><a href="/abuse_reports/new">Report Abuse</a></li>
+              <li><a href="/abuse_reports/new">Policy Questions & Abuse Reports</a></li>
               <li><a href="/support">Technical Support and Feedback</a></li>
             </ul>
           </li>

--- a/public/500.html
+++ b/public/500.html
@@ -117,7 +117,7 @@
           <li class="module group">
             <h4 class="heading">Contact Us</h4>
             <ul class="menu">
-              <li><a href="/abuse_reports/new">Report Abuse</a></li>
+              <li><a href="/abuse_reports/new">Policy Questions & Abuse Reports</a></li>
               <li><a href="/support">Technical Support and Feedback</a></li>
             </ul>
           </li>

--- a/public/502.html
+++ b/public/502.html
@@ -119,7 +119,7 @@
           <li class="module group">
             <h4 class="heading">Contact Us</h4>
             <ul class="menu">
-              <li><a href="/abuse_reports/new">Report Abuse</a></li>
+              <li><a href="/abuse_reports/new">Policy Questions & Abuse Reports</a></li>
               <li><a href="/support">Technical Support and Feedback</a></li>
             </ul>
           </li>

--- a/public/503.html
+++ b/public/503.html
@@ -119,7 +119,7 @@
           <li class="module group">
             <h4 class="heading">Contact Us</h4>
             <ul class="menu">
-              <li><a href="/abuse_reports/new">Report Abuse</a></li>
+              <li><a href="/abuse_reports/new">Policy Questions & Abuse Reports</a></li>
               <li><a href="/support">Technical Support and Feedback</a></li>
             </ul>
           </li>

--- a/public/507.html
+++ b/public/507.html
@@ -119,7 +119,7 @@
           <li class="module group">
             <h4 class="heading">Contact Us</h4>
             <ul class="menu">
-              <li><a href="/abuse_reports/new">Report Abuse</a></li>
+              <li><a href="/abuse_reports/new">Policy Questions & Abuse Reports</a></li>
               <li><a href="/support">Technical Support and Feedback</a></li>
             </ul>
           </li>

--- a/public/nomaintenance.html
+++ b/public/nomaintenance.html
@@ -117,7 +117,7 @@
           <li class="module group">
             <h4 class="heading">Contact Us</h4>
             <ul class="menu">
-              <li><a href="/abuse_reports/new">Report Abuse</a></li>
+              <li><a href="/abuse_reports/new">Policy Questions & Abuse Reports</a></li>
               <li><a href="/support">Technical Support and Feedback</a></li>
             </ul>
           </li>


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [x] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [x] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [x] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-5619

## Purpose

Change the "Report Abuse" link text in the footer, site map and static error pages to "Policy Questions & Abuse Reports".

## Testing Instructions

1. Go to archiveofourown.org
2. Scroll down the page and under "Contact Us", check if first link text has been changed
3. Repeat for static error pages and site_map. (Links are in the Jira ticket)

## References

## Credit

weeklies (she/her)