### PR TITLE
AO3-5754 Increase right margin on live validation message for Firefox

### DIFF
--- a/public/stylesheets/site/2.0/07-interactions.css
+++ b/public/stylesheets/site/2.0/07-interactions.css
@@ -179,7 +179,7 @@ We only use error messages for LiveValidation. Style spoofs the system error mes
   font-weight: 900;
   position: absolute;
   margin-top: 0.643em;
-  margin-right: 13em;
+  margin-right: 15em;
 }
 
 .LV_invalid {


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5754

## Purpose

Increases the margin on the live validation messages from 13em to the 15em originally requested in the issue, since a larger margin appears necessary in Firefox.

