### PR TITLE
AO3-5392 Simplify date computation in set_revised_at_by_chapter.

### DIFF
--- a/spec/controllers/works/default_rails_actions_spec.rb
+++ b/spec/controllers/works/default_rails_actions_spec.rb
@@ -513,13 +513,6 @@ describe WorksController, work_search: true do
       let(:update_work) { create(:work, authors: [update_user.default_pseud]) }
       let(:update_chapter) { update_work.first_chapter }
 
-      before do
-        # These are on the same day in UTC, but in the time zone set by
-        # Rails, they are on different days:
-        update_work.update_column(:revised_at, Time.utc(2022, 1, 1, 3))
-        update_chapter.update_column(:published_at, Date.new(2022, 1, 1))
-      end
-
       let(:attributes) do
         {
           backdate: "1",
@@ -527,6 +520,13 @@ describe WorksController, work_search: true do
             published_at: "2021-09-01"
           }
         }
+      end
+
+      before do
+        # These are on the same day in UTC, but in the time zone set by
+        # Rails, they are on different days:
+        update_work.update_column(:revised_at, Time.utc(2022, 1, 1, 3))
+        update_chapter.update_column(:published_at, Date.new(2022, 1, 1))
       end
 
       it "can be backdated" do


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5392

## Purpose

Modifies the date calculation in `set_revised_at_by_chapter` so that it works even when `revised_at.to_date` doesn't match `published_at` for any of the chapters, while still preventing unnecessary changes to `revised_at`. This allows users to redate any existing works affected by AO3-5392. (New works were handled in #4115.)