### PR TITLE
AO3-6289 Introduce current_path_with instead of using params.permit!

### DIFF
--- a/app/views/bookmarks/search_results.html.erb
+++ b/app/views/bookmarks/search_results.html.erb
@@ -9,7 +9,7 @@
 
 <!--subnav-->
 <ul class="navigation actions" role="navigation">
-  <li><%= link_to ts("Edit Your Search"), url_for(params.permit!.merge(edit_search: true)) %></li>
+  <li><%= link_to ts("Edit Your Search"), current_path_with(edit_search: true) %></li>
 </ul>
 <!--/subnav-->
 

--- a/app/views/layouts/_banner.html.erb
+++ b/app/views/layouts/_banner.html.erb
@@ -10,7 +10,7 @@
     </blockquote>
     <% if current_user.nil? %>
       <p class="submit">
-        <%= link_to "&times;".html_safe, url_for(params.permit!.merge :hide_banner => true, :anchor => params[:anchor]), :class => 'showme action', :title => ts("hide banner") %>
+        <%= link_to "&times;".html_safe, current_path_with(hide_banner: true), :class => 'showme action', :title => ts("hide banner") %>
       </p>
     <% else %>
       <%= form_tag end_banner_user_path(current_user), :method => :post, :remote => true do %>

--- a/app/views/stats/index.html.erb
+++ b/app/views/stats/index.html.erb
@@ -14,7 +14,7 @@
       <% if @current_year == year %>
         <span class="current"><%= year %></span>
       <% else %>
-        <%= link_to year, request.parameters.merge({:year => year}) %>
+        <%= link_to year, current_path_with(year: year) %>
       <% end %>
     </li>
   <% end %>
@@ -57,8 +57,8 @@
   </ul>
 
   <ul class="view actions" role="menu">
-    <li><%= span_if_current ts("Fandoms View"), url_for(params.permit!.merge :flat_view => nil), params[:flat_view].blank? %></li>
-    <li><%= span_if_current ts("Flat View"), url_for(params.permit!.merge :flat_view => true) %></li>
+    <li><%= span_if_current ts("Fandoms View"), current_path_with(flat_view: nil), params[:flat_view].blank? %></li>
+    <li><%= span_if_current ts("Flat View"), current_path_with(flat_view: true) %></li>
   </ul>
 </div>
 

--- a/app/views/works/_adult.html.erb
+++ b/app/views/works/_adult.html.erb
@@ -4,7 +4,7 @@
 
 <ul class="actions" role="navigation">
   <li>
-    <%= link_to ts('Proceed'), url_for(params.permit!.merge :view_adult => true, :anchor => params[:anchor]) %>
+    <%= link_to ts('Proceed'), current_path_with(view_adult: true) %>
   </li>
   <li>
     <%= link_to ts('Go Back'), :back %>

--- a/app/views/works/search_results.html.erb
+++ b/app/views/works/search_results.html.erb
@@ -9,7 +9,7 @@
 
 <!--subnav-->
 <ul class="navigation actions" role="navigation">
-  <li><%= link_to ts("Edit Your Search"), url_for(params.permit!.merge(edit_search: true)) %></li>
+  <li><%= link_to ts("Edit Your Search"), current_path_with(edit_search: true) %></li>
 </ul>
 <!--/subnav-->
 


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6289

## Purpose

There are a number of pages on the archive that want to link back to the current path, but with slightly different parameters. Currently, they accomplish this by passing `params.permit!` or `request.parameters` to `url_for`, with small modifications. This PR introduces a new function `current_path_with` that handles the path generation in a more consistent way.

The method is loosely modeled on the way that `will_paginate` generates page links, on the theory that the gem has enough users that most of its security issues have probably been ironed out.