### PR TITLE
AO3-6230 Add description to user_id field on admin search

### DIFF
--- a/app/views/admin/admin_users/index.html.erb
+++ b/app/views/admin/admin_users/index.html.erb
@@ -8,7 +8,7 @@
     <dl>
       <dt><%= label_tag "name", ts("Name") %></dt>
       <dd>
-        <%= text_field_tag "name", params[:name], "aria-describedby" => "name-field-description" %>
+        <%= text_field_tag "name", params[:name], "aria-describedby": "name-field-description" %>
         <p class="footnote" id="name-field-description">
           <%= ts("Search for users with matching usernames or pseuds.") %>
         </p>
@@ -16,7 +16,12 @@
       <dt><%= label_tag "email", ts("Email") %></dt>
       <dd><%= text_field_tag "email", params[:email] %></dd>
       <dt><%= label_tag "user_id", ts("User ID") %></dt>
-      <dd><%= text_field_tag "user_id", params[:user_id] %></dd>
+      <dd>
+        <%= text_field_tag "user_id", params[:user_id], "aria-describedby": "user-id-field-description" %>
+        <p class="footnote" id="user-id-field-description">
+          <%= ts("Search for user with exact ID.") %>
+        </p>
+        </dd>
       <dt><%= label_tag "role", ts("Role") %></dt>
       <dd><%= select_tag "role", "<option></option>".html_safe + options_for_select(@role_values, @role.try(:name)) %></dd>
       <dt><%= label_tag "status", ts("Status") %></dt>


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6230

## Purpose

Adds a description to the User ID field on admin user search form.

## Testing Instructions

Log in as an admin who can manage users, go to Find Users, and confirm the note is under the User ID input.

## Credit

Sarken, she/her