### PR TITLE
AO3-6293 Call queue_flush_work_cache after_update instead of after_save.

### DIFF
--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -224,7 +224,7 @@ class Tag < ApplicationRecord
     end
   end
 
-  after_save :queue_flush_work_cache
+  after_update :queue_flush_work_cache
   def queue_flush_work_cache
     async_after_commit(:flush_work_cache) if saved_change_to_name? || saved_change_to_type?
   end


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6293

## Purpose

Prevents flushing the cache for newly-created tags, which shouldn't even have any works that need their cache flushed. Hopefully this should prevent some Resque errors.