### PR TITLE
AO3-6295 Don't send comment reply notifications to deleted accounts.

### DIFF
--- a/app/mailers/comment_mailer.rb
+++ b/app/mailers/comment_mailer.rb
@@ -25,6 +25,7 @@ class CommentMailer < ApplicationMailer
   # Sends email to commenter when a reply is posted to their comment
   # This may be a non-user of the archive
   def comment_reply_notification(your_comment, comment)
+    return if your_comment.comment_owner_email.blank?
     return if your_comment.pseud_id.nil? && AdminBlacklistedEmail.is_blacklisted?(your_comment.comment_owner_email)
 
     @your_comment = your_comment
@@ -38,6 +39,7 @@ class CommentMailer < ApplicationMailer
   # Sends email to commenter when a reply to their comment is edited
   # This may be a non-user of the archive
   def edited_comment_reply_notification(your_comment, edited_comment)
+    return if your_comment.comment_owner_email.blank?
     return if your_comment.pseud_id.nil? && AdminBlacklistedEmail.is_blacklisted?(your_comment.comment_owner_email)
 
     @your_comment = your_comment


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6295

## Purpose

When trying to send a comment reply notification (or edited comment reply notification) where the person being notified has deleted their account, we should bail out instead of trying to send an email with a blank sender.