### PR TITLE
AO3-6296 Use WebMock to stub external work URLs in specs.

### DIFF
--- a/spec/models/external_work_spec.rb
+++ b/spec/models/external_work_spec.rb
@@ -31,7 +31,11 @@ describe ExternalWork do
 
     URLS.each do |url|
       let(:valid_url) {build(:external_work, url: url)}
+
       it "saves the external work" do
+        # prevent connection failures -- all we care about is the format
+        WebMock.stub_request(:any, url)
+
         expect(valid_url.save).to be_truthy
       end
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -69,6 +69,9 @@ RSpec.configure do |config|
 
     # Assume all spam checks pass by default.
     allow(Akismetor).to receive(:spam?).and_return(false)
+
+    # Stub all requests to example.org, the default external work URL:
+    WebMock.stub_request(:any, "www.example.org")
   end
 
   config.after :each do


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6296

## Purpose

Stub example.org for all rspec tests, and stub the URL used in `./spec/models/external_work_spec.rb:34`.