### PR TITLE
AO3-5628 Invalidate chapter count cache when saving drafts

### DIFF
--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -576,6 +576,7 @@ class Work < ApplicationRecord
     # Invalidate chapter count cache
     self.invalidate_work_chapter_count(self)
     return if self.posted? && !chapter.posted?
+
     if (self.new_record? || chapter.posted_changed?) && chapter.published_at == Date.current
       self.set_revised_at(Time.current) # a new chapter is being posted, so most recent update is now
     else

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -573,9 +573,9 @@ class Work < ApplicationRecord
   end
 
   def set_revised_at_by_chapter(chapter)
-    return if self.posted? && !chapter.posted?
     # Invalidate chapter count cache
     self.invalidate_work_chapter_count(self)
+    return if self.posted? && !chapter.posted?
     if (self.new_record? || chapter.posted_changed?) && chapter.published_at == Date.current
       self.set_revised_at(Time.current) # a new chapter is being posted, so most recent update is now
     else

--- a/spec/controllers/chapters_controller_spec.rb
+++ b/spec/controllers/chapters_controller_spec.rb
@@ -465,7 +465,7 @@ describe ChaptersController do
               post :create, params: { work_id: work.id, chapter: chapter_attributes, post_without_preview_button: true }
             end.to change { work.number_of_chapters }
               .from(1).to(2)
-              .and change {work.number_of_posted_chapters}
+              .and change { work.number_of_posted_chapters }
               .from(1).to(2)
           end
 
@@ -515,7 +515,7 @@ describe ChaptersController do
               post :create, params: { work_id: work.id, chapter: chapter_attributes, preview_button: true }
             end.to change { work.number_of_chapters }
               .from(1).to(2)
-              .and avoid_changing {work.number_of_posted_chapters}
+              .and avoid_changing { work.number_of_posted_chapters }
           end
 
           it "gives a notice that the chapter is a draft and redirects to the chapter preview" do
@@ -990,7 +990,7 @@ describe ChaptersController do
             delete :destroy, params: { work_id: work.id, id: chapter2.id }
           end.to change { work.number_of_chapters }
             .from(2).to(1)
-            .and change {work.number_of_posted_chapters}
+            .and change { work.number_of_posted_chapters }
             .from(2).to(1)
         end
 
@@ -1064,7 +1064,7 @@ describe ChaptersController do
             delete :destroy, params: { work_id: work.id, id: chapter2.id }
           end.to change { work.number_of_chapters }
             .from(2).to(1)
-            .and avoid_changing {work.number_of_posted_chapters}
+            .and avoid_changing { work.number_of_posted_chapters }
         end
       end
     end

--- a/spec/controllers/chapters_controller_spec.rb
+++ b/spec/controllers/chapters_controller_spec.rb
@@ -461,11 +461,12 @@ describe ChaptersController do
           end
 
           it "updates cached chapter counts" do
-            expect(work.number_of_chapters).to eq 1
-            expect(work.number_of_posted_chapters).to eq 1
-            post :create, params: { work_id: work.id, chapter: chapter_attributes, post_without_preview_button: true }
-            expect(work.number_of_chapters).to eq 2
-            expect(work.number_of_posted_chapters).to eq 2
+            expect do
+              post :create, params: { work_id: work.id, chapter: chapter_attributes, post_without_preview_button: true }
+            end.to change { work.number_of_chapters }
+              .from(1).to(2)
+              .and change {work.number_of_posted_chapters}
+              .from(1).to(2)
           end
 
           it "posts the work if the work was not posted before" do
@@ -510,11 +511,11 @@ describe ChaptersController do
           end
 
           it "updates cached chapter counts" do
-            expect(work.number_of_chapters).to eq 1
-            expect(work.number_of_posted_chapters).to eq 1
-            post :create, params: { work_id: work.id, chapter: chapter_attributes, preview_button: true }
-            expect(work.number_of_chapters).to eq 2
-            expect(work.number_of_posted_chapters).to eq 1
+            expect do
+              post :create, params: { work_id: work.id, chapter: chapter_attributes, preview_button: true }
+            end.to change { work.number_of_chapters }
+              .from(1).to(2)
+              .and avoid_changing {work.number_of_posted_chapters}
           end
 
           it "gives a notice that the chapter is a draft and redirects to the chapter preview" do
@@ -985,11 +986,12 @@ describe ChaptersController do
         end
 
         it "updates cached chapter counts" do
-          expect(work.number_of_chapters).to eq 2
-          expect(work.number_of_posted_chapters).to eq 2
-          delete :destroy, params: { work_id: work.id, id: chapter2.id }
-          expect(work.number_of_chapters).to eq 1
-          expect(work.number_of_posted_chapters).to eq 1
+          expect do
+            delete :destroy, params: { work_id: work.id, id: chapter2.id }
+          end.to change { work.number_of_chapters }
+            .from(2).to(1)
+            .and change {work.number_of_posted_chapters}
+            .from(2).to(1)
         end
 
         it "gives a notice that the chapter was deleted and redirects to work" do
@@ -1058,11 +1060,11 @@ describe ChaptersController do
         let!(:chapter2) { create(:chapter, work: work, posted: false, position: 2, authors: [user.pseuds.first]) }
 
         it "updates cached chapter counts" do
-          expect(work.number_of_chapters).to eq 2
-          expect(work.number_of_posted_chapters).to eq 1
-          delete :destroy, params: { work_id: work.id, id: chapter2.id }
-          expect(work.number_of_chapters).to eq 1
-          expect(work.number_of_posted_chapters).to eq 1
+          expect do
+            delete :destroy, params: { work_id: work.id, id: chapter2.id }
+          end.to change { work.number_of_chapters }
+            .from(2).to(1)
+            .and avoid_changing {work.number_of_posted_chapters}
         end
       end
     end

--- a/spec/controllers/chapters_controller_spec.rb
+++ b/spec/controllers/chapters_controller_spec.rb
@@ -461,7 +461,6 @@ describe ChaptersController do
           end
 
           it "updates cached chapter counts" do
-            work.invalidate_work_chapter_count(work)
             expect(work.number_of_chapters).to eq 1
             expect(work.number_of_posted_chapters).to eq 1
             post :create, params: { work_id: work.id, chapter: chapter_attributes, post_without_preview_button: true }
@@ -511,7 +510,6 @@ describe ChaptersController do
           end
 
           it "updates cached chapter counts" do
-            work.invalidate_work_chapter_count(work)
             expect(work.number_of_chapters).to eq 1
             expect(work.number_of_posted_chapters).to eq 1
             post :create, params: { work_id: work.id, chapter: chapter_attributes, preview_button: true }
@@ -987,7 +985,6 @@ describe ChaptersController do
         end
 
         it "updates cached chapter counts" do
-          work.invalidate_work_chapter_count(work)
           expect(work.number_of_chapters).to eq 2
           expect(work.number_of_posted_chapters).to eq 2
           delete :destroy, params: { work_id: work.id, id: chapter2.id }
@@ -1061,7 +1058,6 @@ describe ChaptersController do
         let!(:chapter2) { create(:chapter, work: work, posted: false, position: 2, authors: [user.pseuds.first]) }
 
         it "updates cached chapter counts" do
-          work.invalidate_work_chapter_count(work)
           expect(work.number_of_chapters).to eq 2
           expect(work.number_of_posted_chapters).to eq 1
           delete :destroy, params: { work_id: work.id, id: chapter2.id }


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [x] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [x] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [x] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-5628

## Purpose

Ensures that work chapter counts get properly updated when a draft chapter is added, which is important to ensuring that the "manage chapters" button shows up if there are two chapters and one is draft.

## Testing Instructions

On Jira issue

## Credit

Stephen Lewis, he/him