### PR TITLE
AO3-6228 Remove the mysql reconnect gem, to prevent half-transactions.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,8 +24,6 @@ gem 'mysql2', '0.5.2'
 # at the latest version to avoid errors
 gem 'transaction_isolation', '1.0.5'
 gem 'transaction_retry'
-#https://github.com/winebarrel/activerecord-mysql-reconnect
-gem 'activerecord-mysql-reconnect', '~> 0.4.1'
 
 gem 'rack-attack'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -63,9 +63,6 @@ GEM
       activemodel (= 5.2.6)
       activesupport (= 5.2.6)
       arel (>= 9.0)
-    activerecord-mysql-reconnect (0.4.2)
-      activerecord
-      mysql2
     activestorage (5.2.6)
       actionpack (= 5.2.6)
       activerecord (= 5.2.6)
@@ -549,7 +546,6 @@ DEPENDENCIES
   actionpack-page_caching
   active_record_query_trace (~> 1.6, >= 1.6.1)
   activemodel-serializers-xml
-  activerecord-mysql-reconnect (~> 0.4.1)
   acts_as_list (~> 0.9.7)
   addressable
   after_commit_everywhere

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -50,12 +50,5 @@ Otwarchive::Application.configure do
   # Send deprecation notices to registered listeners
   config.active_support.deprecation = :notify
 
-  # https://github.com/winebarrel/activerecord-mysql-reconnect
-  config.active_record.enable_retry = true
-  config.active_record.execution_tries = 20 # times
-  config.active_record.execution_retry_wait = 0.3 # sec
-  # :rw Retry in all SQL, but does not retry if Lost connection has happened in write SQL
-  config.active_record.retry_mode = :rw
-
   config.middleware.use Rack::Attack
 end

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -63,12 +63,5 @@ Otwarchive::Application.configure do
     Bullet.counter_cache_enable = false
   end
 
-  # https://github.com/winebarrel/activerecord-mysql-reconnect
-  config.active_record.enable_retry = true
-  config.active_record.execution_tries = 20 # times
-  config.active_record.execution_retry_wait = 0.3 # sec
-  # :rw Retry in all SQL, but does not retry if Lost connection has happened in write SQL
-  config.active_record.retry_mode = :rw
-
   config.middleware.use Rack::Attack
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -38,13 +38,6 @@ Otwarchive::Application.configure do
   # Print deprecation notices to the stderr
   config.active_support.deprecation = :stderr
 
-  # https://github.com/winebarrel/activerecord-mysql-reconnect
-  config.active_record.enable_retry = true
-  config.active_record.execution_tries = 20 # times
-  config.active_record.execution_retry_wait = 0.3 # sec
-  # :rw Retry in all SQL, but does not retry if Lost connection has happened in write SQL
-  config.active_record.retry_mode = :rw
-
   # Configure strong parameters to raise an exception if an unpermitted attribute is used
   config.action_controller.action_on_unpermitted_parameters = :raise
 


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6228

## Purpose

Removes the `activerecord-mysql-reconnect` gem, and all of the references to it in the configuration files. This is half of what's needed to prevent reconnects from breaking up large transactions and causing inconsistencies.

(The other half is removing `reconnect: true` from `config/database.yml`, which is not under version control.)