### PR TITLE
AO3-6300 Use default Rails time_zone (UTC)

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -49,7 +49,7 @@ module Otwarchive
 
     # Set Time.zone default to the specified zone and make Active Record auto-convert to this zone.
     # Run "rake -D time" for a list of tasks for finding time zone names. Default is UTC.
-    # config.time_zone = 'Central Time (US & Canada)'
+    config.time_zone = "UTC"
 
     # The default locale is :en and all translations from config/locales/**/*.rb,yml are auto loaded.
     config.i18n.load_path += Dir[Rails.root.join("config/locales/**/*.{rb,yml}")]

--- a/config/application.rb
+++ b/config/application.rb
@@ -50,7 +50,6 @@ module Otwarchive
     # Set Time.zone default to the specified zone and make Active Record auto-convert to this zone.
     # Run "rake -D time" for a list of tasks for finding time zone names. Default is UTC.
     # config.time_zone = 'Central Time (US & Canada)'
-    config.time_zone = "Eastern Time (US & Canada)"
 
     # The default locale is :en and all translations from config/locales/**/*.rb,yml are auto loaded.
     config.i18n.load_path += Dir[Rails.root.join("config/locales/**/*.{rb,yml}")]

--- a/features/admins/users/admin_manage_users.feature
+++ b/features/admins/users/admin_manage_users.feature
@@ -79,6 +79,6 @@ Feature: Admin Actions to manage users
       And I am logged in as a "support" admin
       And I go to the abuse administration page for "new_user"
     Then I should not see "No login recorded"
-      And I should see "2019-01-01 12:00:00 -0500 Current Login IP Address: 127.0.0.1"
-      And I should see "2019-01-01 12:00:00 -0500 Previous Login IP Address: 127.0.0.1"
+      And I should see "2019-01-01 12:00:00 UTC Current Login IP Address: 127.0.0.1"
+      And I should see "2019-01-01 12:00:00 UTC Previous Login IP Address: 127.0.0.1"
 

--- a/features/step_definitions/reading_steps.rb
+++ b/features/step_definitions/reading_steps.rb
@@ -1,7 +1,7 @@
 Given /^(.*) first read "([^"]*)" on "([^"]*)"$/ do |login, title, date|
   user = User.find_by(login: login)
   work = Work.find_by(title: title)
-  time = date.to_time
+  time = date.to_time.in_time_zone("UTC")
   # create the reading
   reading_json = [user.id, time, work.id, work.major_version, work.minor_version, false].to_json
   Reading.reading_object(reading_json)

--- a/features/step_definitions/reading_steps.rb
+++ b/features/step_definitions/reading_steps.rb
@@ -1,7 +1,7 @@
 Given /^(.*) first read "([^"]*)" on "([^"]*)"$/ do |login, title, date|
   user = User.find_by(login: login)
   work = Work.find_by(title: title)
-  time = date.to_time.in_time_zone("EST") + 1.day
+  time = date.to_time
   # create the reading
   reading_json = [user.id, time, work.id, work.major_version, work.minor_version, false].to_json
   Reading.reading_object(reading_json)

--- a/spec/controllers/works/default_rails_actions_spec.rb
+++ b/spec/controllers/works/default_rails_actions_spec.rb
@@ -567,7 +567,6 @@ describe WorksController, work_search: true do
         put :update, params: { id: update_work.id, work: attributes }
       end
 
-      # We have a work posted at November 30, 2 PM UTC
       context "before midnight UTC and after midnight Samara" do
         # December 5, 3 AM Europe/Samara (UTC+04:00) -- still December 4 in UTC
         let(:redate_time) { Time.new(2021, 12, 5, 3, 0, 0, "+04:00") }

--- a/spec/controllers/works/default_rails_actions_spec.rb
+++ b/spec/controllers/works/default_rails_actions_spec.rb
@@ -559,7 +559,7 @@ describe WorksController, work_search: true do
       before do
         travel_to(redate_time)
 
-        # Simulate the system time being Europe/Samara:
+        # Simulate the system time being UTC:
         allow(Time).to receive(:now).and_return(redate_time)
         allow(DateTime).to receive(:now).and_return(redate_time)
         allow(Date).to receive(:today).and_return(redate_time.to_date)


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6300

## Purpose

Stops setting Rails' timezone to US Eastern (and consequently starts using the default of UTC).

If you want, it can a) explicitly set it to UTC and/or b) remove the comments about how to change the Rails timezone.

## Testing Instructions

Refer to Jira.

## Credit

Sarken, she/her
