### PR TITLE
AO3-6085 Remove explicit dependency on nokogumbo

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -52,7 +52,6 @@ gem 'whenever', '~>0.6.2', require: false
 gem 'nokogiri', '>= 1.8.5'
 gem 'mechanize'
 gem 'sanitize', '>= 4.6.5'
-gem "nokogumbo"
 gem "rest-client", "~> 2.1.0", require: "rest_client"
 gem 'resque', '>=1.14.0'
 gem 'resque-scheduler'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -354,8 +354,6 @@ GEM
     nokogiri (1.13.3)
       mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
-    nokogumbo (2.0.5)
-      nokogiri (~> 1.8, >= 1.8.4)
     orm_adapter (0.5.0)
     parallel (1.21.0)
     parser (3.1.0.0)
@@ -631,7 +629,6 @@ DEPENDENCIES
   mysql2 (= 0.5.2)
   newrelic_rpm
   nokogiri (>= 1.8.5)
-  nokogumbo
   permit_yo
   phraseapp-in-context-editor-ruby (>= 1.0.6)
   pickle


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6085

## Purpose

The gem has been merged into nokogiri 1.12.0.

Remove its deprecation warnings (sparklemotion/nokogiri#2205).

## Testing Instructions

See issue.