### PR TITLE
AO3-6306 Can't bookmark URLs with response codes of 308 or 307

### DIFF
--- a/app/models/external_work.rb
+++ b/app/models/external_work.rb
@@ -45,11 +45,6 @@ class ExternalWork < ApplicationRecord
     self.url = reformat_url(self.url) if self.url
   end
 
-  # Sets the dead? attribute to true if the link is no longer active
-  def set_url_status
-    self.update_attribute(:dead, true) unless url_active?(self.url)
-  end
-
   # Allow encoded characters to display correctly in titles
   def title
     read_attribute(:title).try(:html_safe)

--- a/app/validators/url_active_validator.rb
+++ b/app/validators/url_active_validator.rb
@@ -14,7 +14,7 @@ class UrlActiveValidator < ActiveModel::EachValidator
       status = Timeout::timeout(options[:timeout] || inactive_url_timeout) {
         url = Addressable::URI.parse(value)
         response_code = Net::HTTP.start(url.host, url.port) {|http| http.head(url.path.blank? ? '/' : url.path).code}
-        active_status = %w(200 301 302)
+        active_status = %w[200 301 302 307 308]
         active_status.include? response_code
       }
     rescue

--- a/lib/url_helpers.rb
+++ b/lib/url_helpers.rb
@@ -11,7 +11,7 @@ module UrlHelpers
       begin
         url = Addressable::URI.parse(url)
         response_code = Net::HTTP.start(url.host, url.port) {|http| http.head(url.path.blank? ? '/' : url.path).code}
-        active_status = %w(200 301 302 307 308)
+        active_status = %w[200 301 302 307 308]
         active_status.include? response_code
       rescue
         false

--- a/lib/url_helpers.rb
+++ b/lib/url_helpers.rb
@@ -11,7 +11,7 @@ module UrlHelpers
       begin
         url = Addressable::URI.parse(url)
         response_code = Net::HTTP.start(url.host, url.port) {|http| http.head(url.path.blank? ? '/' : url.path).code}
-        active_status = %w(200 301 302)
+        active_status = %w(200 301 302 307 308)
         active_status.include? response_code
       rescue
         false

--- a/lib/url_helpers.rb
+++ b/lib/url_helpers.rb
@@ -2,23 +2,6 @@ require 'timeout'
 require 'uri'
 
 module UrlHelpers
-  # Checks the status of the webpage at the given url
-  # To speed things up we ONLY request the head and not the entire page.
-  # Bypass check for fanfiction.net because of ip block
-  def url_active?(url, timeout_in_seconds=60)
-    return true if url.match("fanfiction.net")
-    Timeout::timeout(timeout_in_seconds) {
-      begin
-        url = Addressable::URI.parse(url)
-        response_code = Net::HTTP.start(url.host, url.port) {|http| http.head(url.path.blank? ? '/' : url.path).code}
-        active_status = %w[200 301 302 307 308]
-        active_status.include? response_code
-      rescue
-        false
-      end
-    }
-  end
-
   # Make urls consistent
   def reformat_url(url)
     url = url.gsub(/https/, "http")

--- a/spec/models/external_work_spec.rb
+++ b/spec/models/external_work_spec.rb
@@ -31,30 +31,33 @@ describe ExternalWork do
 
     URLS.each do |url|
       # Test each of the possible valid response codes
-      WebMock.stub_request(:any, url).to_return({ status: 200, body: "Success" }, { status: 301, body: "Moved Permanently" }, { status: 302, body: "Found" }, { status: 307, body: "Temporary Redirect" }, { status: 308, body: "Permanent Redirect" })
-
       let(:valid_url_200) { build(:external_work, url: url) }
       it "saves the external work when the URL has a 200 response code" do
+        WebMock.stub_request(:any, url).to_return({ status: 200, body: "Success" })
         expect(valid_url_200.save).to be_truthy
       end
 
       let(:valid_url_301) { build(:external_work, url: url) }
       it "saves the external work when the URL has a 301 response code" do
+        WebMock.stub_request(:any, url).to_return({ status: 301, body: "Moved Permanently" })
         expect(valid_url_301.save).to be_truthy
       end
 
       let(:valid_url_302) { build(:external_work, url: url) }
       it "saves the external work when the URL has a 302 response code" do
+        WebMock.stub_request(:any, url).to_return({ status: 302, body: "Found" })
         expect(valid_url_302.save).to be_truthy
       end
 
       let(:valid_url_307) { build(:external_work, url: url) }
       it "saves the external work when the URL has a 307 response code" do
+        WebMock.stub_request(:any, url).to_return({ status: 307, body: "Temporary Redirect" })
         expect(valid_url_307.save).to be_truthy
       end
 
       let(:valid_url_308) { build(:external_work, url: url) }
       it "saves the external work when the URL has a 308 response code" do
+        WebMock.stub_request(:any, url).to_return({ status: 308, body: "Permanent Redirect" })
         expect(valid_url_308.save).to be_truthy
       end
     end

--- a/spec/models/external_work_spec.rb
+++ b/spec/models/external_work_spec.rb
@@ -30,13 +30,32 @@ describe ExternalWork do
     URLS = ["http://the--ivorytower.livejournal.com/153798.html"]
 
     URLS.each do |url|
-      let(:valid_url) {build(:external_work, url: url)}
+      # Test each of the possible valid response codes
+      WebMock.stub_request(:any, url).to_return({status: 200, body: "Success"}, {status: 301, body: "Moved Permanently"}, {status: 302, body: "Found"}, {status: 307, body: "Temporary Redirect"}, {status: 308, body: "Permanent Redirect"})
 
-      it "saves the external work" do
-        # prevent connection failures -- all we care about is the format
-        WebMock.stub_request(:any, url)
+      let(:valid_url_200) {build(:external_work, url: url)}
+      it "saves the external work when the URL has a 200 response code" do
+        expect(valid_url_200.save).to be_truthy
+      end
 
-        expect(valid_url.save).to be_truthy
+      let(:valid_url_301) {build(:external_work, url: url)}
+      it "saves the external work when the URL has a 301 response code" do
+        expect(valid_url_301.save).to be_truthy
+      end
+
+      let(:valid_url_302) {build(:external_work, url: url)}
+      it "saves the external work when the URL has a 302 response code" do
+        expect(valid_url_302.save).to be_truthy
+      end
+
+      let(:valid_url_307) {build(:external_work, url: url)}
+      it "saves the external work when the URL has a 307 response code" do
+        expect(valid_url_307.save).to be_truthy
+      end
+
+      let(:valid_url_308) {build(:external_work, url: url)}
+      it "saves the external work when the URL has a 308 response code" do
+        expect(valid_url_308.save).to be_truthy
       end
     end
   end

--- a/spec/models/external_work_spec.rb
+++ b/spec/models/external_work_spec.rb
@@ -26,39 +26,18 @@ describe ExternalWork do
     end
   end
 
-  context "valid urls" do
-    URLS = ["http://the--ivorytower.livejournal.com/153798.html"]
-
-    URLS.each do |url|
-      # Test each of the possible valid response codes
-      let(:valid_url_200) { build(:external_work, url: url) }
-      it "saves the external work when the URL has a 200 response code" do
-        WebMock.stub_request(:any, url).to_return({ status: 200, body: "Success" })
-        expect(valid_url_200.save).to be_truthy
-      end
-
-      let(:valid_url_301) { build(:external_work, url: url) }
-      it "saves the external work when the URL has a 301 response code" do
-        WebMock.stub_request(:any, url).to_return({ status: 301, body: "Moved Permanently" })
-        expect(valid_url_301.save).to be_truthy
-      end
-
-      let(:valid_url_302) { build(:external_work, url: url) }
-      it "saves the external work when the URL has a 302 response code" do
-        WebMock.stub_request(:any, url).to_return({ status: 302, body: "Found" })
-        expect(valid_url_302.save).to be_truthy
-      end
-
-      let(:valid_url_307) { build(:external_work, url: url) }
-      it "saves the external work when the URL has a 307 response code" do
-        WebMock.stub_request(:any, url).to_return({ status: 307, body: "Temporary Redirect" })
-        expect(valid_url_307.save).to be_truthy
-      end
-
-      let(:valid_url_308) { build(:external_work, url: url) }
-      it "saves the external work when the URL has a 308 response code" do
-        WebMock.stub_request(:any, url).to_return({ status: 308, body: "Permanent Redirect" })
-        expect(valid_url_308.save).to be_truthy
+  context "for valid URLs" do
+    [200, 301, 302, 307, 308].each do |status|
+      context "returning #{status}" do
+        let(:external_work) { build(:external_work) }
+  
+        before do
+          WebMock.stub_request(:any, external_work.url).to_return(status: status)
+        end
+  
+        it "saves" do
+          expect(external_work.save).to be_truthy
+        end
       end
     end
   end

--- a/spec/models/external_work_spec.rb
+++ b/spec/models/external_work_spec.rb
@@ -31,29 +31,29 @@ describe ExternalWork do
 
     URLS.each do |url|
       # Test each of the possible valid response codes
-      WebMock.stub_request(:any, url).to_return({status: 200, body: "Success"}, {status: 301, body: "Moved Permanently"}, {status: 302, body: "Found"}, {status: 307, body: "Temporary Redirect"}, {status: 308, body: "Permanent Redirect"})
+      WebMock.stub_request(:any, url).to_return({ status: 200, body: "Success" }, { status: 301, body: "Moved Permanently" }, { status: 302, body: "Found" }, { status: 307, body: "Temporary Redirect" }, { status: 308, body: "Permanent Redirect" })
 
-      let(:valid_url_200) {build(:external_work, url: url)}
+      let(:valid_url_200) { build(:external_work, url: url) }
       it "saves the external work when the URL has a 200 response code" do
         expect(valid_url_200.save).to be_truthy
       end
 
-      let(:valid_url_301) {build(:external_work, url: url)}
+      let(:valid_url_301) { build(:external_work, url: url) }
       it "saves the external work when the URL has a 301 response code" do
         expect(valid_url_301.save).to be_truthy
       end
 
-      let(:valid_url_302) {build(:external_work, url: url)}
+      let(:valid_url_302) { build(:external_work, url: url) }
       it "saves the external work when the URL has a 302 response code" do
         expect(valid_url_302.save).to be_truthy
       end
 
-      let(:valid_url_307) {build(:external_work, url: url)}
+      let(:valid_url_307) { build(:external_work, url: url) }
       it "saves the external work when the URL has a 307 response code" do
         expect(valid_url_307.save).to be_truthy
       end
 
-      let(:valid_url_308) {build(:external_work, url: url)}
+      let(:valid_url_308) { build(:external_work, url: url) }
       it "saves the external work when the URL has a 308 response code" do
         expect(valid_url_308.save).to be_truthy
       end


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [x] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [x] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [x] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-6306 

## Purpose

When a user attempts to bookmark an external work, the backend checks that the URL they entered is not a dead link by sending it a HTTP HEAD request. The code to handle this accepts a response of 200, 301, or 302 as a live URL but since it was written before 307 and 308 redirects were added to the HTTP spec, it fails on websites that return those response codes. This PR fixes that.

## Testing Instructions

1. Log in
2. Hi, username! > My Bookmarks > Bookmark External Work
3. Enter a URL that will give a response code of either 307 or 308, e.g. something from https://mangadex.org/ will give a 308
4. Fill in other required fields
5. Press "Create"
6. The bookmark should be created successfully

## References

Are there other relevant issues/pull requests/mailing list discussions?

N/A

## Credit

What name and pronouns should we use to credit you in the [Archive of Our Own's Release Notes](https://archiveofourown.org/admin_posts?tag=1)?

dark-veracity (She/Her)
