### PR TITLE
AO3-6279 Remove defunct video sites from the embed sanitizer

### DIFF
--- a/lib/otw_sanitize/embed_sanitizer.rb
+++ b/lib/otw_sanitize/embed_sanitizer.rb
@@ -10,28 +10,24 @@ module OtwSanitize
       ao3:              %r{^archiveofourown\.org/},
       archiveorg:       %r{^archive\.org\/embed/},
       criticalcommons:  %r{^criticalcommons\.org/},
-      dailymotion:      %r{^dailymotion\.com/},
       eighttracks:      %r{^8tracks\.com/},
       google:           %r{^google\.com/},
-      metacafe:         %r{^metacafe\.com/},
-      ning:             %r{^(static\.)?ning\.com/},
       podfic:           %r{^podfic\.com/},
       soundcloud:       %r{^(w\.)?soundcloud\.com/},
       spotify:          %r{^(open\.)?spotify\.com/},
       viddersnet:       %r{^vidders\.net/},
-      viddertube:       %r{^viddertube\.com/},
       vimeo:            %r{^(player\.)?vimeo\.com/},
       youtube:          %r{^youtube(-nocookie)?\.com/}
     }.freeze
 
     ALLOWS_FLASHVARS = %i[
       ao3 criticalcommons eighttracks google
-      ning podfic soundcloud spotify viddersnet
+      podfic soundcloud spotify viddersnet
     ].freeze
 
     SUPPORTS_HTTPS = %i[
-      ao3 archiveorg dailymotion eighttracks ning podfic
-      soundcloud spotify viddersnet viddertube vimeo youtube
+      ao3 archiveorg eighttracks podfic
+      soundcloud spotify viddersnet vimeo youtube
     ].freeze
 
     # Creates a callable transformer for the sanitizer to use

--- a/lib/otw_sanitize/embed_sanitizer.rb
+++ b/lib/otw_sanitize/embed_sanitizer.rb
@@ -16,6 +16,7 @@ module OtwSanitize
       soundcloud:       %r{^(w\.)?soundcloud\.com/},
       spotify:          %r{^(open\.)?spotify\.com/},
       viddersnet:       %r{^vidders\.net/},
+      viddertube:       %r{^viddertube\.com/},
       vimeo:            %r{^(player\.)?vimeo\.com/},
       youtube:          %r{^youtube(-nocookie)?\.com/}
     }.freeze
@@ -27,7 +28,7 @@ module OtwSanitize
 
     SUPPORTS_HTTPS = %i[
       ao3 archiveorg eighttracks podfic
-      soundcloud spotify viddersnet vimeo youtube
+      soundcloud spotify viddersnet viddertube vimeo youtube
     ].freeze
 
     # Creates a callable transformer for the sanitizer to use

--- a/spec/lib/html_cleaner_spec.rb
+++ b/spec/lib/html_cleaner_spec.rb
@@ -142,9 +142,9 @@ describe HtmlCleaner do
   describe "sanitize_value" do
     ArchiveConfig.FIELDS_ALLOWING_VIDEO_EMBEDS.each do |field|
       context "#{field} is configured to allow video embeds" do
-        %w{youtube.com youtube-nocookie.com vimeo.com player.vimeo.com 
+        %w[youtube.com youtube-nocookie.com vimeo.com player.vimeo.com 
            vidders.net criticalcommons.org google.com archiveofourown.org podfic.com archive.org
-           open.spotify.com spotify.com 8tracks.com w.soundcloud.com soundcloud.com}.each do |source|
+           open.spotify.com spotify.com 8tracks.com w.soundcloud.com soundcloud.com].each do |source|
 
           it "keeps embeds from #{source}" do
             html = '<iframe width="560" height="315" src="//' + source + '/embed/123" frameborder="0"></iframe>'
@@ -153,9 +153,9 @@ describe HtmlCleaner do
           end
         end
 
-        %w{youtube.com youtube-nocookie.com vimeo.com player.vimeo.com
+        %w[youtube.com youtube-nocookie.com vimeo.com player.vimeo.com
            archiveofourown.org archive.org 8tracks.com podfic.com
-           open.spotify.com spotify.com w.soundcloud.com soundcloud.com vidders.net}.each do |source|
+           open.spotify.com spotify.com w.soundcloud.com soundcloud.com vidders.net].each do |source|
 
           it "converts src to https for #{source}" do
             html = '<iframe width="560" height="315" src="http://' + source + '/embed/123" frameborder="0"></iframe>'
@@ -221,7 +221,7 @@ describe HtmlCleaner do
           expect(result).to be_empty
         end
 
-        %w(criticalcommons.org).each do |source|
+        %w[criticalcommons.org].each do |source|
           it "doesn't convert src to https for #{source}" do
             html = '<iframe width="560" height="315" src="http://' + source + '/embed/123" frameborder="0"></iframe>'
             result = sanitize_value(field, html)

--- a/spec/lib/html_cleaner_spec.rb
+++ b/spec/lib/html_cleaner_spec.rb
@@ -142,9 +142,9 @@ describe HtmlCleaner do
   describe "sanitize_value" do
     ArchiveConfig.FIELDS_ALLOWING_VIDEO_EMBEDS.each do |field|
       context "#{field} is configured to allow video embeds" do
-        %w{youtube.com youtube-nocookie.com vimeo.com player.vimeo.com static.ning.com ning.com dailymotion.com
-           metacafe.com vidders.net criticalcommons.org google.com archiveofourown.org podfic.com archive.org
-           open.spotify.com spotify.com 8tracks.com w.soundcloud.com soundcloud.com viddertube.com}.each do |source|
+        %w{youtube.com youtube-nocookie.com vimeo.com player.vimeo.com 
+           vidders.net criticalcommons.org google.com archiveofourown.org podfic.com archive.org
+           open.spotify.com spotify.com 8tracks.com w.soundcloud.com soundcloud.com}.each do |source|
 
           it "keeps embeds from #{source}" do
             html = '<iframe width="560" height="315" src="//' + source + '/embed/123" frameborder="0"></iframe>'
@@ -154,8 +154,8 @@ describe HtmlCleaner do
         end
 
         %w{youtube.com youtube-nocookie.com vimeo.com player.vimeo.com
-           archiveofourown.org archive.org dailymotion.com 8tracks.com static.ning.com ning.com podfic.com
-           open.spotify.com spotify.com w.soundcloud.com soundcloud.com vidders.net viddertube.com}.each do |source|
+           archiveofourown.org archive.org 8tracks.com podfic.com
+           open.spotify.com spotify.com w.soundcloud.com soundcloud.com vidders.net}.each do |source|
 
           it "converts src to https for #{source}" do
             html = '<iframe width="560" height="315" src="http://' + source + '/embed/123" frameborder="0"></iframe>'
@@ -221,7 +221,7 @@ describe HtmlCleaner do
           expect(result).to be_empty
         end
 
-        %w(metacafe.com criticalcommons.org).each do |source|
+        %w(criticalcommons.org).each do |source|
           it "doesn't convert src to https for #{source}" do
             html = '<iframe width="560" height="315" src="http://' + source + '/embed/123" frameborder="0"></iframe>'
             result = sanitize_value(field, html)

--- a/spec/lib/html_cleaner_spec.rb
+++ b/spec/lib/html_cleaner_spec.rb
@@ -144,7 +144,7 @@ describe HtmlCleaner do
       context "#{field} is configured to allow video embeds" do
         %w[youtube.com youtube-nocookie.com vimeo.com player.vimeo.com 
            vidders.net criticalcommons.org google.com archiveofourown.org podfic.com archive.org
-           open.spotify.com spotify.com 8tracks.com w.soundcloud.com soundcloud.com].each do |source|
+           open.spotify.com spotify.com 8tracks.com w.soundcloud.com soundcloud.com viddertube.com].each do |source|
 
           it "keeps embeds from #{source}" do
             html = '<iframe width="560" height="315" src="//' + source + '/embed/123" frameborder="0"></iframe>'
@@ -155,7 +155,7 @@ describe HtmlCleaner do
 
         %w[youtube.com youtube-nocookie.com vimeo.com player.vimeo.com
            archiveofourown.org archive.org 8tracks.com podfic.com
-           open.spotify.com spotify.com w.soundcloud.com soundcloud.com vidders.net].each do |source|
+           open.spotify.com spotify.com w.soundcloud.com soundcloud.com vidders.net viddertube.com].each do |source|
 
           it "converts src to https for #{source}" do
             html = '<iframe width="560" height="315" src="http://' + source + '/embed/123" frameborder="0"></iframe>'


### PR DESCRIPTION
# Pull Request Checklist

* [X] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [X] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [X] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [X] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [X] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-6279

## Purpose

As stated in jira issue:
  - metacafe.com shut down in August 2021
  - ning.com does not appear to host videos any longer
  - DailyMotion blocks all fanvids upon upload

PR removed metacafe.com, ning.com, and dailymotion.com from HtmlCleaner and OtwSanitize. 
Not sufficiently tested for unwanted results

## Testing Instructions

Test case 1: 
a) try to embed nonfunctional link from listed sites into archive work
b) try to embed working link from listed sites into archive work
c) try to embed working link from i.e. youtube into archive work
d) try to embed nonfunctional link from i.e. youtube into archive work

Test case 2: 
a) look at - now defunct - links embedded into works from listed sites; check if any unwanted errors occur
b) look at works with embedded links to i.e. youtube; check if everything is as should be

## References

Are there other relevant issues/pull requests/mailing list discussions?

not afaik

## Credit

What name and pronouns should we use to credit you in the [Archive of Our Own's Release Notes](https://archiveofourown.org/admin_posts?tag=1)?

juro and them - or any pronoun - is fine