### PR TITLE
AO3-6275 Update rails-i18n to 7.0.3

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -417,7 +417,7 @@ GEM
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.4.2)
       loofah (~> 2.3)
-    rails-i18n (7.0.1)
+    rails-i18n (7.0.3)
       i18n (>= 0.7, < 2)
       railties (>= 6.0.0, < 8)
     railties (6.0.4.6)


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6275

## Purpose

When loading the Rails console, you get yelled at about Serbian pluralization already being loaded: https://github.com/svenfuchs/rails-i18n/issues/965

Updating should prevent being yelled at.

## Testing Instructions

Run `bundle exec rails c` in your dev environment after updating.

## References

h/t @redsummernight 
