### PR TITLE
AO3-6274 Limit number of abuse reports per email per day

### DIFF
--- a/app/models/abuse_report.rb
+++ b/app/models/abuse_report.rb
@@ -7,6 +7,7 @@ class AbuseReport < ApplicationRecord
   validates_presence_of :comment
   validates_presence_of :url
   validate :url_is_not_over_reported
+  validate :email_is_not_over_reporting
   validates_length_of :summary, maximum: ArchiveConfig.FEEDBACK_SUMMARY_MAX,
                                 too_long: ts('must be less than %{max}
                                              characters long.',
@@ -108,6 +109,20 @@ class AbuseReport < ApplicationRecord
       if existing_reports_total >= ArchiveConfig.ABUSE_REPORTS_PER_USER_MAX
         errors[:base] << message
       end
+    end
+  end
+
+  def email_is_not_over_reporting
+    message = ts("You have reached our daily reporting limit. To keep our
+                 volunteers from being overwhelmed, please do not seek out
+                 violations to report, but only report violations you encounter
+                 during your normal browsing.")
+    existing_reports_total = AbuseReport.where("created_at > ? AND
+                                                email LIKE ?",
+                                                1.day.ago,
+                                                email).count
+    if existing_reports_total >= ArchiveConfig.ABUSE_REPORTS_PER_EMAIL_MAX
+      errors[:base] << message
     end
   end
 end

--- a/app/models/abuse_report.rb
+++ b/app/models/abuse_report.rb
@@ -113,16 +113,15 @@ class AbuseReport < ApplicationRecord
   end
 
   def email_is_not_over_reporting
-    message = ts("You have reached our daily reporting limit. To keep our
-                 volunteers from being overwhelmed, please do not seek out
-                 violations to report, but only report violations you encounter
-                 during your normal browsing.")
     existing_reports_total = AbuseReport.where("created_at > ? AND
-                                                email LIKE ?",
-                                                1.day.ago,
-                                                email).count
-    if existing_reports_total >= ArchiveConfig.ABUSE_REPORTS_PER_EMAIL_MAX
-      errors[:base] << message
-    end
+                                               email LIKE ?",
+                                               1.day.ago,
+                                               email).count
+    return if existing_reports_total < ArchiveConfig.ABUSE_REPORTS_PER_EMAIL_MAX
+
+    errors[:base] << ts("You have reached our daily reporting limit. To keep our
+                        volunteers from being overwhelmed, please do not seek
+                        out violations to report, but only report violations you
+                        encounter during your normal browsing.")
   end
 end

--- a/config/config.yml
+++ b/config/config.yml
@@ -147,7 +147,7 @@ IMPORT_MAX_WORKS_BY_ARCHIVIST: 200
 ABUSE_REPORTS_PER_USER_MAX: 5
 # max number of abuse reports to accept for a given work URL
 ABUSE_REPORTS_PER_WORK_MAX: 5
-# max number of abuse reports an email can report
+# max number of abuse reports to accept from a given email
 ABUSE_REPORTS_PER_EMAIL_MAX: 5
 
 # number of items in various displays

--- a/config/config.yml
+++ b/config/config.yml
@@ -147,6 +147,8 @@ IMPORT_MAX_WORKS_BY_ARCHIVIST: 200
 ABUSE_REPORTS_PER_USER_MAX: 5
 # max number of abuse reports to accept for a given work URL
 ABUSE_REPORTS_PER_WORK_MAX: 5
+# max number of abuse reports an email can report
+ABUSE_REPORTS_PER_EMAIL_MAX: 5
 
 # number of items in various displays
 ITEMS_PER_PAGE: 25

--- a/spec/models/abuse_report_spec.rb
+++ b/spec/models/abuse_report_spec.rb
@@ -156,6 +156,7 @@ describe AbuseReport do
 
       context "a month later" do
         before { travel(32.days) }
+
         after { travel_back }
 
         it_behaves_like "alright", work_url
@@ -208,6 +209,7 @@ describe AbuseReport do
 
       context "a month later" do
         before { travel(32.days) }
+
         after { travel_back }
 
         it_behaves_like "alright", user_url

--- a/spec/models/abuse_report_spec.rb
+++ b/spec/models/abuse_report_spec.rb
@@ -157,8 +157,6 @@ describe AbuseReport do
       context "a month later" do
         before { travel(32.days) }
 
-        after { travel_back }
-
         it_behaves_like "alright", work_url
       end
     end
@@ -209,8 +207,6 @@ describe AbuseReport do
 
       context "a month later" do
         before { travel(32.days) }
-
-        after { travel_back }
 
         it_behaves_like "alright", user_url
       end
@@ -278,8 +274,6 @@ describe AbuseReport do
 
         context "when it's a day later" do
           before { travel(1.day) }
-
-          after { travel_back }
 
           it "can be submitted" do
             expect(report.save).to be_truthy

--- a/spec/models/abuse_report_spec.rb
+++ b/spec/models/abuse_report_spec.rb
@@ -155,8 +155,8 @@ describe AbuseReport do
       it_behaves_like "alright", "http://archiveofourown.org/users/someone"
 
       context "a month later" do
-        before { Timecop.freeze(32.days.from_now) }
-        after { Timecop.return }
+        before { travel(32.days) }
+        after { travel_back }
 
         it_behaves_like "alright", work_url
       end
@@ -207,8 +207,8 @@ describe AbuseReport do
       it_behaves_like "alright", "http://archiveofourown.org/works/789"
 
       context "a month later" do
-        before { Timecop.freeze(32.days.from_now) }
-        after { Timecop.return }
+        before { travel(32.days) }
+        after { travel_back }
 
         it_behaves_like "alright", user_url
       end
@@ -275,9 +275,9 @@ describe AbuseReport do
         end
 
         context "when it's a day later" do
-          before { Timecop.freeze(1.day.from_now) }
+          before { travel(1.day) }
 
-          after { Timecop.return }
+          after { travel_back }
 
           it "can be submitted" do
             expect(report.save).to be_truthy

--- a/spec/models/abuse_report_spec.rb
+++ b/spec/models/abuse_report_spec.rb
@@ -248,12 +248,12 @@ describe AbuseReport do
 
     context "when email is valid" do
       let(:report) { build(:abuse_report, email: "email@example.com") }
+
       context "when email has submitted less than the maximum daily number of reports" do
         before do
           (ArchiveConfig.ABUSE_REPORTS_PER_EMAIL_MAX - 1).times do
             create(:abuse_report, email: "email@example.com")
           end
-          expect(AbuseReport.count).to eq((ArchiveConfig.ABUSE_REPORTS_PER_EMAIL_MAX - 1))
         end
 
         it "can be submitted" do
@@ -267,7 +267,6 @@ describe AbuseReport do
           ArchiveConfig.ABUSE_REPORTS_PER_EMAIL_MAX.times do
             create(:abuse_report, email: "email@example.com")
           end
-          expect(AbuseReport.count).to eq(ArchiveConfig.ABUSE_REPORTS_PER_EMAIL_MAX)
         end
 
         it "can't be submitted" do
@@ -277,6 +276,7 @@ describe AbuseReport do
 
         context "when it's a day later" do
           before { Timecop.freeze(1.day.from_now) }
+
           after { Timecop.return }
 
           it "can be submitted" do


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6274

## Purpose

Limits how many times per day an email address can submit an abuse report.

## Testing Instructions

Refer to Jira.

## Credit

Sarken, she/her