### PR TITLE
AO3-6185 Remove unused add_comment/cancel_comment actions.

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,10 +1,10 @@
 class CommentsController < ApplicationController
   skip_before_action :store_location, except: [:show, :index, :new]
-  before_action :load_commentable, only: [ :index, :new, :create, :edit, :update,
-                                              :show_comments, :hide_comments, :add_comment,
-                                              :cancel_comment, :add_comment_reply,
-                                              :cancel_comment_reply,
-                                              :delete_comment, :cancel_comment_delete, :unreviewed, :review_all ]
+  before_action :load_commentable,
+                only: [:index, :new, :create, :edit, :update, :show_comments,
+                       :hide_comments, :add_comment_reply,
+                       :cancel_comment_reply, :delete_comment,
+                       :cancel_comment_delete, :unreviewed, :review_all]
   before_action :check_user_status, only: [:new, :create, :edit, :update, :destroy]
   before_action :load_comment, only: [:show, :edit, :update, :delete_comment, :destroy, :cancel_comment_edit, :cancel_comment_delete, :review, :approve, :reject, :freeze, :unfreeze]
   before_action :check_visibility, only: [:show]
@@ -12,9 +12,8 @@ class CommentsController < ApplicationController
   before_action :check_tag_wrangler_access
   before_action :check_parent
   before_action :check_modify_parent,
-                only: [:new, :create, :edit, :update, :add_comment,
-                       :add_comment_reply, :cancel_comment_reply,
-                       :cancel_comment_edit, :cancel_comment]
+                only: [:new, :create, :edit, :update, :add_comment_reply,
+                       :cancel_comment_reply, :cancel_comment_edit]
   before_action :check_pseud_ownership, only: [:create, :update]
   before_action :check_ownership, only: [:edit, :update, :cancel_comment_edit]
   before_action :check_permission_to_edit, only: [:edit, :update ]
@@ -446,7 +445,6 @@ class CommentsController < ApplicationController
         # if non-ajax it could mean sudden javascript failure OR being redirected from login
         # so we're being extra-nice and preserving any intention to comment along with the show comments option
         options = {show_comments: true}
-        options[:add_comment] = params[:add_comment] if params[:add_comment]
         options[:add_comment_reply_id] = params[:add_comment_reply_id] if params[:add_comment_reply_id]
         options[:view_full_work] = params[:view_full_work] if params[:view_full_work]
         options[:page] = params[:page]
@@ -459,21 +457,7 @@ class CommentsController < ApplicationController
   def hide_comments
     respond_to do |format|
       format.html do
-        options[:add_comment] = params[:add_comment] if params[:add_comment]
         redirect_to_all_comments(@commentable)
-      end
-      format.js
-    end
-  end
-
-  def add_comment
-    @comment = Comment.new
-    respond_to do |format|
-      format.html do
-        options = {add_comment: true}
-        options[:show_comments] = params[:show_comments] if params[:show_comments]
-        options[:page] = params[:page] if params[:page]
-        redirect_to_all_comments(@commentable, options)
       end
       format.js
     end
@@ -501,17 +485,6 @@ class CommentsController < ApplicationController
         end
       end
       format.js { @commentable = Comment.find(params[:id]) }
-    end
-  end
-
-  def cancel_comment
-    respond_to do |format|
-      format.html do
-        options = {}
-        options[:show_comments] = params[:show_comments] if params[:show_comments]
-        redirect_to_all_comments(@commentable, options)
-      end
-      format.js
     end
   end
 
@@ -592,7 +565,6 @@ class CommentsController < ApplicationController
 
     if commentable.is_a?(Tag)
       redirect_to comments_path(tag_id: commentable.to_param,
-                  add_comment: options[:add_comment],
                   add_comment_reply_id: options[:add_comment_reply_id],
                   delete_comment_id: options[:delete_comment_id],
                   page: options[:page],
@@ -605,7 +577,6 @@ class CommentsController < ApplicationController
                   action: :show,
                   id: commentable.id,
                   show_comments: options[:show_comments],
-                  add_comment: options[:add_comment],
                   add_comment_reply_id: options[:add_comment_reply_id],
                   delete_comment_id: options[:delete_comment_id],
                   view_full_work: options[:view_full_work],

--- a/app/helpers/comments_helper.rb
+++ b/app/helpers/comments_helper.rb
@@ -214,52 +214,14 @@ module CommentsHelper
       remote: true)
   end
 
-  # TO DO: create fallbacks to support non-JavaScript requests!
-  # return button to cancel adding a comment. kind of ugly because we want it
-  # to work for the comment form no matter where it appears, but oh well
-  def cancel_comment_button(comment, commentable)
-    if comment.new_record?
-      if commentable.class == comment.class
-        # canceling a reply to a comment
-        commentable_id = commentable.ultimate_parent.is_a?(Tag) ?
-                            :tag_id :
-                            "#{commentable.ultimate_parent.class.to_s.underscore}_id".to_sym
-        commentable_value = commentable.ultimate_parent.is_a?(Tag) ?
-                              commentable.ultimate_parent.name :
-                              commentable.ultimate_parent.id
-        link_to(
-          ts("Cancel"),
-          url_for(controller: :comments,
-                  action: :cancel_comment_reply,
-                  id: commentable.id,
-                  comment_id: params[:comment_id],
-                  commentable_id => commentable_value),
-          remote: true)
-       else
-        # canceling a reply to a different commentable thingy
-        commentable_id = commentable.is_a?(Tag) ?
-                            :tag_id :
-                            "#{commentable.class.to_s.underscore}_id".to_sym
-        commentable_value = commentable.is_a?(Tag) ?
-                              commentable.name :
-                              commentable.id
-        link_to(
-          ts("Cancel"),
-          url_for(controller: :comments,
-                  action: :cancel_comment,
-                  commentable_id => commentable_value),
-          remote: true)
-      end
-    else
-      # canceling an edit
-      link_to(
-        ts("Cancel"),
-        url_for(controller: :comments,
-                action: :cancel_comment_edit,
-                id: (comment.id),
-                comment_id: params[:comment_id]),
-        remote: true)
-    end
+  # canceling an edit
+  def cancel_edit_comment_link(comment)
+    link_to(ts("Cancel"),
+            url_for(controller: :comments,
+                    action: :cancel_comment_edit,
+                    id: comment.id,
+                    comment_id: params[:comment_id]),
+            remote: true)
   end
 
   # return html link to edit comment

--- a/app/views/comments/_comment_form.html.erb
+++ b/app/views/comments/_comment_form.html.erb
@@ -104,8 +104,10 @@
         <%= f.submit button_name, :id => "comment_submit_for_#{commentable.id}", data: {disable_with: ts("Please wait...")} %>
         <% if controller.controller_name == 'inbox' %>
           <a name="comment_cancel" id="comment_cancel"><%= ts("Close") %></a>
-        <% elsif commentable.class.name == "Comment" || !comment.new_record? %>
-          <%= cancel_comment_button(comment, commentable) %>
+        <% elsif comment.persisted? %>
+          <%= cancel_edit_comment_link(comment) %>
+        <% elsif commentable.is_a?(Comment) %>
+          <%= cancel_comment_reply_link(commentable) %>
         <% end %>
       </p>
     </fieldset>

--- a/app/views/comments/add_comment.js.erb
+++ b/app/views/comments/add_comment.js.erb
@@ -1,3 +1,0 @@
-$j("#add_comment_link").html("<%= escape_javascript(cancel_comment_link(@commentable)) %>");
-$j("#add_comment_placeholder").html("<%= escape_javascript(render :partial => "comments/comment_form", :locals => {:comment => @comment, :commentable => @commentable, :button_name => ts("Comment")}) %>");
-$j("#add_comment_placeholder").slideDown();

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -498,8 +498,6 @@ Otwarchive::Application.routes.draw do
     collection do
       get :hide_comments
       get :show_comments
-      get :add_comment
-      get :cancel_comment
       get :add_comment_reply
       get :cancel_comment_reply
       get :cancel_comment_edit

--- a/spec/controllers/comments_controller_spec.rb
+++ b/spec/controllers/comments_controller_spec.rb
@@ -1693,34 +1693,6 @@ describe CommentsController do
     end
   end
 
-  describe "GET #add_comment" do
-    context "when comment is unreviewed" do
-      it "redirects to the comment path with add_comment params and without an error" do
-        get :add_comment, params: { comment_id: unreviewed_comment.id }
-        expect(flash[:error]).to be_nil
-        expect(response).to redirect_to(comment_path(unreviewed_comment, add_comment: true, anchor: "comments"))
-      end
-    end
-  end
-
-  describe "GET #cancel_comment" do
-    context "with only valid params" do
-      it "redirects to comment path with the comments anchor and without an error" do
-        get :cancel_comment, params: { comment_id: comment.id }
-        expect(flash[:error]).to be_nil
-        expect(response).to redirect_to(comment_path(comment, anchor: "comments"))
-      end
-    end
-
-    context "with valid and invalid params" do
-      it "removes invalid params and redirects without an error to comment path with valid params and the comments anchor" do
-        get :cancel_comment, params: { comment_id: comment.id, show_comments: "yes", random_option: "no" }
-        expect(flash[:error]).to be_nil
-        expect(response).to redirect_to(comment_path(comment, show_comments: "yes", anchor: "comments"))
-      end
-    end
-  end
-
   describe "GET #cancel_comment_reply" do
     context "with only valid params" do
       it "redirects to comment path with the comments anchor and without an error" do
@@ -2135,11 +2107,6 @@ describe CommentsController do
         it_redirects_to_with_error(root_path, "Sorry, you don't have permission to access the page you were trying to reach. Please log in.")
       end
 
-      it "GET #add_comment redirects to the home page with an error" do
-        get :add_comment, params: { work_id: work.id }
-        it_redirects_to_with_error(root_path, "Sorry, you don't have permission to access the page you were trying to reach. Please log in.")
-      end
-
       it "GET #add_comment_reply redirects to the home page with an error" do
         get :add_comment_reply, params: { comment_id: comment.id }
         it_redirects_to_with_error(root_path, "Sorry, you don't have permission to access the page you were trying to reach. Please log in.")
@@ -2196,11 +2163,6 @@ describe CommentsController do
 
       it "DELETE #destroy redirects to the home page with an error" do
         delete :destroy, params: { id: comment.id }
-        it_redirects_to_with_error(root_path, "Sorry, you don't have permission to access the page you were trying to reach.")
-      end
-
-      it "GET #add_comment redirects to the home page with an error" do
-        get :add_comment, params: { work_id: work.id }
         it_redirects_to_with_error(root_path, "Sorry, you don't have permission to access the page you were trying to reach.")
       end
 
@@ -2304,11 +2266,6 @@ describe CommentsController do
         expect { comment.reload }.to raise_exception(ActiveRecord::RecordNotFound)
       end
 
-      it "GET #add_comment redirects to the work with an error" do
-        get :add_comment, params: { work_id: work.id }
-        it_redirects_to_with_error(work_path(work), edit_error_message)
-      end
-
       it "GET #add_comment_reply redirects to the work with an error" do
         get :add_comment_reply, params: { comment_id: comment.id }
         it_redirects_to_with_error(work_path(work), edit_error_message)
@@ -2393,11 +2350,6 @@ describe CommentsController do
             expect { comment.reload }.to raise_exception(ActiveRecord::RecordNotFound)
           end
         end
-      end
-
-      it "GET #add_comment redirects to the work with an error" do
-        get :add_comment, params: { work_id: work.id }
-        it_redirects_to_with_error(work_path(work), edit_error_message)
       end
 
       it "GET #add_comment_reply redirects to the work with an error" do


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6185

## Purpose

Remove the unused `add_comment` and `cancel_comment` actions.