### PR TITLE
AO3-5955 AO3-5956 AO3-6294 Retry email sending on NoMethodError and ActionView::Template::Error

### DIFF
--- a/app/jobs/application_mailer_job.rb
+++ b/app/jobs/application_mailer_job.rb
@@ -19,4 +19,16 @@ class ApplicationMailerJob < ActionMailer::MailDeliveryJob
            wait: 1.minute do
     # silently discard job after 3 failures
   end
+
+  # Retry three times when calling a method on a nil association, and then fall
+  # back on the Resque failure queue if the error persists (so that we have a
+  # record of it). This should address the issues that arise when we
+  # successfully load an object, but can't load its associations because the
+  # original object has been deleted in the meantime.
+  #
+  # (Most errors for calling a method on a nil object will be NoMethodErrors,
+  # but any that occur within the template itself will be converted to
+  # ActionView::Template:Errors. So we handle both.)
+  retry_on NoMethodError, attempts: 3, wait: 1.minute
+  retry_on ActionView::Template::Error, attempts: 3, wait: 1.minute
 end

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -1,13 +1,33 @@
 require "spec_helper"
 
 describe UserMailer do
+  shared_examples "it retries and fails on" do |error|
+    it "retries 3 times and ultimately fails with a #{error}" do
+      assert_performed_jobs 3, only: ApplicationMailerJob do
+        expect { subject.deliver_later }.to raise_exception(error)
+      end
+    end
+  end
+
   describe "creatorship_request" do
-    subject(:email) { UserMailer.creatorship_request(work_creatorship.id, author.id).deliver }
+    subject(:email) { UserMailer.creatorship_request(work_creatorship.id, author.id) }
 
     let(:author) { create(:user) }
     let(:second_author) { create(:user) }
     let(:work) { create(:work, authors: [author.default_pseud, second_author.default_pseud]) }
     let(:work_creatorship) { Creatorship.find_by(creation_id: work.id, pseud_id: second_author.default_pseud.id) }
+
+    context "when the creation is unavailable" do
+      before { work_creatorship.creation.delete }
+
+      include_examples "it retries and fails on", ActionView::Template::Error
+    end
+
+    context "when the pseud being invited is unavailable" do
+      before { work_creatorship.pseud.delete }
+
+      include_examples "it retries and fails on", NoMethodError
+    end
 
     # Test the headers
     it_behaves_like "an email with a valid sender"
@@ -38,12 +58,24 @@ describe UserMailer do
   end
 
   describe "creatorship_notification" do
-    subject(:email) { UserMailer.creatorship_notification(work_creatorship.id, author.id).deliver }
+    subject(:email) { UserMailer.creatorship_notification(work_creatorship.id, author.id) }
 
     let(:author) { create(:user) }
     let(:second_author) { create(:user) }
     let(:work) { create(:work, authors: [author.default_pseud, second_author.default_pseud]) }
     let(:work_creatorship) { Creatorship.find_by(creation_id: work.id, pseud_id: second_author.default_pseud.id) }
+
+    context "when the creation is unavailable" do
+      before { work_creatorship.creation.delete }
+
+      include_examples "it retries and fails on", ActionView::Template::Error
+    end
+
+    context "when the pseud being invited is unavailable" do
+      before { work_creatorship.pseud.delete }
+
+      include_examples "it retries and fails on", NoMethodError
+    end
 
     # Test the headers
     it_behaves_like "an email with a valid sender"
@@ -74,12 +106,24 @@ describe UserMailer do
   end
 
   describe "creatorship_notification_archivist" do
-    subject(:email) { UserMailer.creatorship_notification_archivist(work_creatorship.id, author.id).deliver }
+    subject(:email) { UserMailer.creatorship_notification_archivist(work_creatorship.id, author.id) }
 
     let(:author) { create(:user) }
     let(:second_author) { create(:user) }
     let(:work) { create(:work, authors: [author.default_pseud, second_author.default_pseud]) }
     let(:work_creatorship) { Creatorship.find_by(creation_id: work.id, pseud_id: second_author.default_pseud.id) }
+
+    context "when the creation is unavailable" do
+      before { work_creatorship.creation.delete }
+
+      include_examples "it retries and fails on", ActionView::Template::Error
+    end
+
+    context "when the pseud being invited is unavailable" do
+      before { work_creatorship.pseud.delete }
+
+      include_examples "it retries and fails on", NoMethodError
+    end
 
     # Test the headers
     it_behaves_like "an email with a valid sender"
@@ -499,6 +543,18 @@ describe UserMailer do
     let(:work) { create(:work, summary: "<p>Paragraph <u>one</u>.</p><p>Paragraph 2.</p>") }
     let(:chapter) { create(:chapter, work: work, posted: true, summary: "<p><b>Another</b> HTML summary.</p>") }
     let(:subscription) { create(:subscription, subscribable: work) }
+
+    context "when the user is unavailable" do
+      before { subscription.user.delete }
+
+      include_examples "it retries and fails on", NoMethodError
+    end
+
+    context "when the user's preferences are unavailable" do
+      before { subscription.user.preference.delete }
+
+      include_examples "it retries and fails on", NoMethodError
+    end
 
     # Test the headers
     it_behaves_like "an email with a valid sender"

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -1,14 +1,6 @@
 require "spec_helper"
 
 describe UserMailer do
-  shared_examples "it retries and fails on" do |error|
-    it "retries 3 times and ultimately fails with a #{error}" do
-      assert_performed_jobs 3, only: ApplicationMailerJob do
-        expect { subject.deliver_later }.to raise_exception(error)
-      end
-    end
-  end
-
   describe "creatorship_request" do
     subject(:email) { UserMailer.creatorship_request(work_creatorship.id, author.id) }
 

--- a/spec/support/shared_examples/mailer_shared_examples.rb
+++ b/spec/support/shared_examples/mailer_shared_examples.rb
@@ -30,3 +30,11 @@ shared_examples_for "an unsent email" do
     expect(email.message).to be_a(ActionMailer::Base::NullMail)
   end
 end
+
+shared_examples "it retries and fails on" do |error|
+  it "retries 3 times and ultimately fails with a #{error}" do
+    assert_performed_jobs 3, only: ApplicationMailerJob do
+      expect { subject.deliver_later }.to raise_exception(error)
+    end
+  end
+end


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5955
https://otwarchive.atlassian.net/browse/AO3-5956
https://otwarchive.atlassian.net/browse/AO3-6294

## Purpose

Sometimes, if an object is deleted around the time that an email is sent about it, the email will successfully load certain objects (thus preventing an `ActiveRecord::RecordNotFound` error that might trigger a retry), but will then fail to load that object's associations. For example, if a user deletes their account around the time that they are supposed to receive an email, it's possible that the email job will be able to load the `User` object, but not the associated `Preference` object. This produces an error when we subsequently try to access the locale associated with the user.

This PR causes email jobs to be retried on two types of error: `NoMethodError` (which is the error produced when calling an invalid method on `nil`), and `ActionView::Template::Error` (which is the error that gets wrapped around the `NoMethodError` when it occurs within a template).

It doesn't discard after three tries, unlike the retry for `ActiveRecord::RecordNotFound`, because we don't want to ignore errors that might be a sign of something wrong with the code. The hope is that the error won't recur, because the second time around, both the `User` object and the associated `Preference` object should be unavailable (triggering an `ActiveRecord::RecordNotFound` error, which will get cleaned up).