### PR TITLE
AO3-5819 Automatically label pull requests.

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,26 @@
+# Label to be added when the PR is updated:
+"Awaiting Review":
+  - "**/*"
+
+# Labels to be removed when the PR is updated:
+"Reviewed: Ready to Merge": []
+"Reviewed: Action Needed": []
+
+# Labels based on which files are modified:
+"Gem Updates":
+  - "Gemfile"
+  - "Gemfile.lock"
+
+"Has Migrations":
+  - "db/migrate/**/*"
+
+"Has Production Config Changes":
+  - "config/config.yml"
+
+"Scope: i18n Only":
+  - all:
+    - "config/locales/**/*"
+
+"Scope: Tests Only":
+  - all:
+    - "+(factories|features|spec|test)/**/*"

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -14,13 +14,10 @@
 "Has Migrations":
   - "db/migrate/**/*"
 
-"Has Production Config Changes":
-  - "config/config.yml"
-
 "Scope: i18n Only":
   - all:
     - "config/locales/**/*"
 
 "Scope: Tests Only":
   - all:
-    - "+(factories|features|spec|test)/**/*"
+    - "+(factories|features|spec|test|.github)/**/*"

--- a/.github/labeler/awaiting.yml
+++ b/.github/labeler/awaiting.yml
@@ -1,0 +1,2 @@
+"Awaiting Review":
+  - "**/*"

--- a/.github/labeler/contents.yml
+++ b/.github/labeler/contents.yml
@@ -1,12 +1,3 @@
-# Label to be added when the PR is updated:
-"Awaiting Review":
-  - "**/*"
-
-# Labels to be removed when the PR is updated:
-"Reviewed: Ready to Merge": []
-"Reviewed: Action Needed": []
-
-# Labels based on which files are modified:
 "Gem Updates":
   - "Gemfile"
   - "Gemfile.lock"

--- a/.github/labeler/review.yml
+++ b/.github/labeler/review.yml
@@ -1,0 +1,6 @@
+# Label to be added when the PR is updated:
+"Coder Has Actioned Review":
+  - "**/*"
+
+# Label to be removed when the PR is updated:
+"Reviewed: Action Needed": []

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,12 +1,30 @@
 name: "Pull Request Labeler"
 on:
-- pull_request_target
+  - pull_request_target
 
 jobs:
   labeler:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/labeler@v3
-      with:
-        repo-token: "${{ secrets.GITHUB_TOKEN }}"
-        sync-labels: true
+
+      - name: Content-Based
+        uses: actions/labeler@v3
+        with:
+          configuration-path: ".github/labeler/contents.yml"
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Awaiting Review
+        uses: actions/labeler@v3
+        if: github.event.action == 'opened'
+        with:
+          configuration-path: ".github/labeler/awaiting.yml"
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Coder Has Actioned Review
+        uses: actions/labeler@v3
+        # https://github.community/t/do-something-if-a-particular-label-is-set/17149/4
+        if: "contains(github.event.pull_request.labels.*.name, 'Reviewed: Action Needed')"
+        with:
+          configuration-path: ".github/labeler/review.yml"
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"
+          sync-labels: true

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,12 @@
+name: "Pull Request Labeler"
+on:
+- pull_request_target
+
+jobs:
+  labeler:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/labeler@v3
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"
+        sync-labels: true


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5819

## Purpose

This PR sets up the automatic pull request labeler action. It will run whenever a pull request is submitted, updated, or reopened, and it will automatically add ~~and/or remove~~ labels according to which paths are being modified.

~~It will also remove the two "Reviewed" labels and add back the "Awaiting Review" label any time the pull request is modified, which isn't exactly the desired behavior (it'd be better to add "Coder Has Actioned Review" instead of "Awaiting Review"), but I don't think it's possible to configure it to only add "Coder Has Actioned Review" if it previously had one of the "Reviewed" labels and "Awaiting Review" otherwise.~~

~~I picked this approach because it makes the set-up simpler, and I think re-adding "Awaiting Review" when a PR Is modified makes sense, but I can also see the argument for leaving all "Reviewed" => "Awaiting Review" changes manual. If you'd prefer, I can modify the labeler so that it only runs when the PR is first opened. Or I can try running two labeler actions, one to add "Awaiting Review" (which only runs when the PR is first opened), and one to add/remove the rest of the labels (which runs every time the PR is updated).~~

The labels are changed in three ways:
1. When a pull request is submitted, updated, or reopened, the labels "Gem Updates," "Has Migrations," "Scope: i18n Only," and "Scope: Tests Only" are added according to which files the pull request modifies. *They will not be removed automatically.* (I wanted to avoid situations where someone manually adds a "Scope: Tests Only" label, and has to keep re-adding it every time the pull request is updated.) 
2. When a pull request is opened, the "Awaiting Review" label is added automatically.
3. When a pull request with the tag "Reviewed: Action Needed" is updated or reopened, the "Reviewed: Action Needed" label is removed and the "Coder Has Actioned Review" label is added.

