### PR TITLE
AO3-6156 Rewrite Zoho client specs to use WebMock

### DIFF
--- a/spec/lib/zoho_auth_client_spec.rb
+++ b/spec/lib/zoho_auth_client_spec.rb
@@ -1,14 +1,6 @@
 require "spec_helper"
 
 describe ZohoAuthClient do
-  def stub_access_token_request
-    allow(HTTParty).to receive(:post).and_return(response)
-  end
-
-  let(:response) do
-    double(:response, body: '{"access_token":"1a2b3c","expires_in_sec":3600}')
-  end
-
   before do
     stub_const("ArchiveConfig", OpenStruct.new(ArchiveConfig))
     ArchiveConfig.ZOHO_CLIENT_ID = "111"
@@ -17,40 +9,50 @@ describe ZohoAuthClient do
     ArchiveConfig.ZOHO_ORG_ID = "123"
     ArchiveConfig.ZOHO_REDIRECT_URI = "https://archiveofourown.org/support"
 
-    stub_access_token_request
+    WebMock.disable_net_connect!
+  end
+
+  after do
+    WebMock.allow_net_connect!
   end
 
   describe "#access_token" do
-    it "makes a well formed request" do
-      ZohoAuthClient.new.access_token
+    context "when no token is cached" do
+      before do
+        WebMock.stub_request(:post, /zoho/)
+          .with(query: hash_including({ grant_type: "refresh_token" }))
+          .to_return(
+            headers: { content_type: "application/json" },
+            body: '{"access_token":"1a2b3c","expires_in_sec":3600}'
+          )
+      end
 
-      expect(HTTParty).to have_received(:post).
-        with("https://accounts.zoho.com/oauth/v2/token",
-             query: { client_id: "111",
-                      client_secret: "a1b2c3",
-                      redirect_uri: "https://archiveofourown.org/support",
-                      scope: "Desk.tickets.ALL,Desk.contacts.READ,Desk.contacts.WRITE,Desk.contacts.CREATE,Desk.basic.READ,Desk.search.READ",
-                      grant_type: "refresh_token",
-                      refresh_token: "x1y2z3" })
+      it "fetches a new access token from Zoho and caches it" do
+        expect(ZohoAuthClient.new.access_token).to eq("1a2b3c")
+        expect(Rails.cache.read(ZohoAuthClient::ACCESS_TOKEN_CACHE_KEY)).to eq("1a2b3c")
+
+        expected_query = {
+          client_id: "111",
+          client_secret: "a1b2c3",
+          redirect_uri: "https://archiveofourown.org/support",
+          scope: "Desk.tickets.ALL,Desk.contacts.READ,Desk.contacts.WRITE,Desk.contacts.CREATE,Desk.basic.READ,Desk.search.READ",
+          grant_type: "refresh_token",
+          refresh_token: "x1y2z3"
+        }
+        expect(WebMock).to have_requested(:post, "https://accounts.zoho.com/oauth/v2/token")
+          .with(query: expected_query)
+      end
     end
 
-    it "returns the access token from the response" do
-      expect(ZohoAuthClient.new.access_token).to eq("1a2b3c")
-    end
+    context "when a token is cached" do
+      before do
+        Rails.cache.write(ZohoAuthClient::ACCESS_TOKEN_CACHE_KEY, "1a2b3c-cached")
+      end
 
-    it "caches the access token from the response" do
-      ZohoAuthClient.new.access_token
-
-      expect(Rails.cache.read(ZohoAuthClient::ACCESS_TOKEN_CACHE_KEY)).to \
-        eq("1a2b3c")
-    end
-
-    it "returns the cached token if it's available" do
-      Rails.cache.write(ZohoAuthClient::ACCESS_TOKEN_CACHE_KEY,
-                        "1a2b3c-cached")
-
-      expect(ZohoAuthClient.new.access_token).to eq("1a2b3c-cached")
-      expect(HTTParty).not_to have_received(:post)
+      it "returns the cached token without making any Zoho requests" do
+        expect(ZohoAuthClient.new.access_token).to eq("1a2b3c-cached")
+        expect(WebMock).not_to have_requested(:any, /zoho/)
+      end
     end
   end
 end

--- a/spec/lib/zoho_resource_client_spec.rb
+++ b/spec/lib/zoho_resource_client_spec.rb
@@ -8,7 +8,7 @@ describe ZohoResourceClient do
     }
   end
 
-  let(:expected_headers) do
+  let(:expected_request_headers) do
     {
       "Content-Type" => "application/json",
       "orgId" => "123",
@@ -16,78 +16,86 @@ describe ZohoResourceClient do
     }
   end
 
-  let(:subject) { ZohoResourceClient.new(resource_params) }
-
-  let(:search_response) { double(:response, body: '{"data":[{"id":"1"}]}') }
-  let(:contact_create_response) { double(:response, body: '{"id":"2"}') }
+  let(:subject) { ZohoResourceClient.new(**resource_params) }
 
   before do
     stub_const("ArchiveConfig", OpenStruct.new(ArchiveConfig))
     ArchiveConfig.ZOHO_ORG_ID = "123"
 
-    allow(HTTParty).to receive(:get).and_return(search_response)
-    allow(HTTParty).to receive(:post)
+    WebMock.disable_net_connect!
+  end
+
+  after do
+    WebMock.allow_net_connect!
   end
 
   describe "#retrieve_contact_id" do
-    it "makes a get request to the correct endpoint with the expected arguments" do
-      subject.retrieve_contact_id
+    context "for an existing contact" do
+      before do
+        WebMock.stub_request(:get, /zoho/)
+          .with(query: hash_including({ email: "email@example.org" }))
+          .to_return(headers: { content_type: "application/json" }, body: '{"data":[{"id":"1"}]}')
+      end
 
-      expect(HTTParty).to have_received(:get).
-        with("https://desk.zoho.com/api/v1/contacts/search",
-             query: { email: "email@example.org", limit: 1, sortBy: "modifiedTime" },
-             headers: expected_headers)
-    end
+      it "returns the contact id, without attempting to create a new one" do
+        expect(subject.retrieve_contact_id).to eq("1")
 
-    it "returns the contact id" do
-      expect(subject.retrieve_contact_id).to eq("1")
-    end
+        expect(WebMock).to have_requested(:get, "https://desk.zoho.com/api/v1/contacts/search")
+          .with(
+            headers: expected_request_headers,
+            query: { email: "email@example.org", limit: 1, sortBy: "modifiedTime" }
+          )
 
-    it "does not attempt to create a new one" do
-      subject.retrieve_contact_id
-
-      expect(HTTParty).to_not have_received(:post)
+        expect(WebMock).not_to have_requested(:post, /zoho/)
+      end
     end
 
     context "when no contact was found" do
       before do
-        allow(HTTParty).to receive(:get).and_return(nil)
-        allow(HTTParty).to receive(:post).and_return(contact_create_response)
+        WebMock.stub_request(:get, /zoho/)
+          .with(query: hash_including({ email: "email@example.org" }))
+          .to_return(status: 204)
+
+        WebMock.stub_request(:post, /zoho/)
+          .to_return(headers: { content_type: "application/json" }, body: '{"id":"2"}')
       end
 
       it "creates a new contact using the email for the required field lastName" do
-        subject.retrieve_contact_id
-
-        expect(HTTParty).to have_received(:post).
-          with("https://desk.zoho.com/api/v1/contacts",
-               headers: expected_headers,
-               body: { "lastName" => "email@example.org", "email" => "email@example.org" }.to_json)
-      end
-
-      it "returns the new contact id" do
         expect(subject.retrieve_contact_id).to eq("2")
+
+        expect(WebMock).to have_requested(:get, "https://desk.zoho.com/api/v1/contacts/search")
+          .with(
+            headers: expected_request_headers,
+            query: { email: "email@example.org", limit: 1, sortBy: "modifiedTime" }
+          )
+
+        expect(WebMock).to have_requested(:post, "https://desk.zoho.com/api/v1/contacts")
+          .with(
+            headers: expected_request_headers,
+            body: { "lastName" => "email@example.org", "email" => "email@example.org" }.to_json
+          )
       end
     end
   end
 
   describe "#create_ticket" do
-    let(:minimum_viable_ticket_attrs) do
+    let(:ticket_attributes) do
       { foo: "bar" }
     end
 
-    let(:ticket_create_response) { double(:response, body: '{"id":"ticket_id"}') }
-
     before do
-      allow(HTTParty).to receive(:post).and_return(ticket_create_response)
+      WebMock.stub_request(:post, /zoho/)
+        .to_return(headers: { content_type: "application/json" }, body: '{"id":"3"}')
     end
 
     it "submits a post request to the correct endpoint with the expected arguments" do
-      subject.create_ticket(ticket_attributes: minimum_viable_ticket_attrs)
+      expect(subject.create_ticket(ticket_attributes: ticket_attributes).fetch("id")).to eq("3")
 
-      expect(HTTParty).to have_received(:post).
-        with("https://desk.zoho.com/api/v1/tickets",
-             headers: expected_headers,
-             body: minimum_viable_ticket_attrs.to_json)
+      expect(WebMock).to have_requested(:post, "https://desk.zoho.com/api/v1/tickets")
+        .with(
+          headers: expected_request_headers,
+          body: ticket_attributes.to_json
+        )
     end
   end
 end


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6156

## Purpose

Now we don't need to know how the client classes implement HTTParty.

Profile editing by admins will be in a follow-up PR.

## Testing Instructions

None.