### PR TITLE
AO3-6316 Use separate path for staging's pseud icons, add task to fix invalid pseuds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,7 +44,9 @@ REVISION
 /public/downloads
 /public/stylesheets/cached_for_screen.css
 /public/stylesheets/skins
+public/system/development
 /public/system/skins
+public/system/test
 /public/system/work_skins
 /public/tags
 

--- a/app/models/pseud.rb
+++ b/app/models/pseud.rb
@@ -8,9 +8,9 @@ class Pseud < ApplicationRecord
     path: if Rails.env.production?
             ":attachment/:id/:style.:extension"
           elsif Rails.env.staging?
-            "staging/:attachment/:id/:style.:extension"
+            ":rails_env/:attachment/:id/:style.:extension"
           else
-            ":rails_root/public:url"
+            ":rails_root/public/system/:rails_env/:class/:attachment/:id_partition/:style/:filename"
           end,
     storage: %w(staging production).include?(Rails.env) ? :s3 : :filesystem,
     s3_protocol: "https",

--- a/app/models/pseud.rb
+++ b/app/models/pseud.rb
@@ -5,7 +5,13 @@ class Pseud < ApplicationRecord
 
   has_attached_file :icon,
     styles: { standard: "100x100>" },
-    path: %w(staging production).include?(Rails.env) ? ":attachment/:id/:style.:extension" : ":rails_root/public:url",
+    path: if Rails.env.production?
+            ":attachment/:id/:style.:extension"
+          elsif Rails.env.staging?
+            "staging/:attachment/:id/:style.:extension"
+          else
+            ":rails_root/public:url"
+          end,
     storage: %w(staging production).include?(Rails.env) ? :s3 : :filesystem,
     s3_protocol: "https",
     s3_credentials: "#{Rails.root}/config/s3.yml",

--- a/lib/tasks/after_tasks.rake
+++ b/lib/tasks/after_tasks.rake
@@ -874,8 +874,8 @@ namespace :After do
     puts("Added default rating to works: #{updated_works}") && STDOUT.flush
   end
 
-  desc "Delete invalid icon data from pseuds"
-  task(delete_invalid_pseud_icon_data: :environment) do
+  desc "Fix pseuds with invalid icon data"
+  task(fix_invalid_pseud_icon_data: :environment) do
     # From validates_attachment_content_type in pseuds model.
     valid_types = %w[image/gif image/jpeg image/png]
 
@@ -891,8 +891,10 @@ namespace :After do
     puts("Updating #{invalid_pseuds_count} pseuds") && STDOUT.flush
 
     invalid_pseuds.each do |pseud|
+      # Change icon content type to jpeg if it's jpg.
+      pseud.icon_content_type = "image/jpeg" if pseud.icon_content_type = "image/jpg"
       # Delete the icon if it's not a valid type.
-      pseud.icon = nil unless valid_types.include?(pseud.icon_content_type)
+      pseud.icon = nil unless (valid_types + ["image/jpg"]).include?(pseud.icon_content_type)
       # Delete the icon alt text if it's too long.
       pseud.icon_alt_text = "" if pseud.icon_alt_text.length > ArchiveConfig.ICON_ALT_MAX
       # Delete the icon comment if it's too long.

--- a/lib/tasks/after_tasks.rake
+++ b/lib/tasks/after_tasks.rake
@@ -892,7 +892,7 @@ namespace :After do
 
     invalid_pseuds.each do |pseud|
       # Change icon content type to jpeg if it's jpg.
-      pseud.icon_content_type = "image/jpeg" if pseud.icon_content_type = "image/jpg"
+      pseud.icon_content_type = "image/jpeg" if pseud.icon_content_type == "image/jpg"
       # Delete the icon if it's not a valid type.
       pseud.icon = nil unless (valid_types + ["image/jpg"]).include?(pseud.icon_content_type)
       # Delete the icon alt text if it's too long.

--- a/lib/tasks/after_tasks.rake
+++ b/lib/tasks/after_tasks.rake
@@ -874,6 +874,42 @@ namespace :After do
     puts("Added default rating to works: #{updated_works}") && STDOUT.flush
   end
 
+  desc "Delete invalid icon data from pseuds"
+  task(delete_invalid_pseud_icon_data: :environment) do
+    # From validates_attachment_content_type in pseuds model.
+    valid_types = %w[image/gif image/jpeg image/png]
+
+    # If you change either of these, update lookup_invalid_pseuds.rb in
+    # otwcode/otw-scripts to ensure the proper users are notified.
+    pseuds_with_invalid_icons = Pseud.where("icon_file_name IS NOT NULL AND icon_content_type NOT IN (?)", valid_types)
+    pseuds_with_invalid_text = Pseud.where("CHAR_LENGTH(icon_alt_text) > ? OR CHAR_LENGTH(icon_comment_text) > ?", ArchiveConfig.ICON_ALT_MAX, ArchiveConfig.ICON_COMMENT_MAX)
+
+    invalid_pseuds = [pseuds_with_invalid_icons, pseuds_with_invalid_text].flatten.uniq
+    invalid_pseuds_count = invalid_pseuds.count
+
+    # Update the pseuds.
+    puts("Updating #{invalid_pseuds_count} pseuds") && STDOUT.flush
+
+    invalid_pseuds.each do |pseud|
+      # Delete the icon if it's not a valid type.
+      unless valid_types.include?(pseud.icon_content_type)
+        pseud.icon = nil
+      end
+
+      # Delete the icon alt text if it's too long.
+      if pseud.icon_alt_text.length > ArchiveConfig.ICON_ALT_MAX
+        pseud.icon_alt_text = ""
+      end
+
+      # Delete the icon comment if it's too long.
+      if pseud.icon_comment_text.length > ArchiveConfig.ICON_COMMENT_MAX
+        pseud.icon_comment_text = ""
+      end
+      pseud.save
+      print(".") && STDOUT.flush
+    end
+  end
+
   # This is the end that you have to put new tasks above.
 end
 

--- a/lib/tasks/after_tasks.rake
+++ b/lib/tasks/after_tasks.rake
@@ -892,19 +892,11 @@ namespace :After do
 
     invalid_pseuds.each do |pseud|
       # Delete the icon if it's not a valid type.
-      unless valid_types.include?(pseud.icon_content_type)
-        pseud.icon = nil
-      end
-
+      pseud.icon = nil unless valid_types.include?(pseud.icon_content_type)
       # Delete the icon alt text if it's too long.
-      if pseud.icon_alt_text.length > ArchiveConfig.ICON_ALT_MAX
-        pseud.icon_alt_text = ""
-      end
-
+      pseud.icon_alt_text = "" if pseud.icon_alt_text.length > ArchiveConfig.ICON_ALT_MAX
       # Delete the icon comment if it's too long.
-      if pseud.icon_comment_text.length > ArchiveConfig.ICON_COMMENT_MAX
-        pseud.icon_comment_text = ""
-      end
+      pseud.icon_comment_text = "" if pseud.icon_comment_text.length > ArchiveConfig.ICON_COMMENT_MAX
       pseud.save
       print(".") && STDOUT.flush
     end

--- a/lib/tasks/after_tasks.rake
+++ b/lib/tasks/after_tasks.rake
@@ -887,6 +887,8 @@ namespace :After do
     invalid_pseuds = [pseuds_with_invalid_icons, pseuds_with_invalid_text].flatten.uniq
     invalid_pseuds_count = invalid_pseuds.count
 
+    skipped_pseud_ids = []
+
     # Update the pseuds.
     puts("Updating #{invalid_pseuds_count} pseuds") && STDOUT.flush
 
@@ -899,8 +901,12 @@ namespace :After do
       pseud.icon_alt_text = "" if pseud.icon_alt_text.length > ArchiveConfig.ICON_ALT_MAX
       # Delete the icon comment if it's too long.
       pseud.icon_comment_text = "" if pseud.icon_comment_text.length > ArchiveConfig.ICON_COMMENT_MAX
-      pseud.save
+      skipped_pseud_ids << pseud.id unless pseud.save
       print(".") && STDOUT.flush
+    end
+    if skipped_pseud_ids.any?
+      puts
+      puts("Couldn't update #{skipped_pseud_ids.size} pseud(s): #{skipped_pseud_ids.join(',')}") && STDOUT.flush
     end
   end
 

--- a/spec/lib/tasks/after_tasks.rake_spec.rb
+++ b/spec/lib/tasks/after_tasks.rake_spec.rb
@@ -309,20 +309,20 @@ describe "rake After:fix_invalid_pseud_icon_data" do
   before do
     stub_const("ArchiveConfig", OpenStruct.new(ArchiveConfig))
     ArchiveConfig.ICON_ALT_MAX = 5
-    ArchiveConfig.ICON_COMMENT_MAX = 3
-
-    valid_pseud.icon = File.new(Rails.root.join("features/fixtures/icon.gif"))
-    valid_pseud.icon_alt_text = "hi"
-    valid_pseud.icon_comment_text = "okay"
+    ArchiveConfig.ICON_COMMENT_MAX = 5
   end
 
   it "removes invalid icon" do
+    valid_pseud.icon = File.new(Rails.root.join("features/fixtures/icon.gif"))
+    valid_pseud.save
     invalid_pseud.icon = File.new(Rails.root.join("features/fixtures/icon.gif"))
     invalid_pseud.save
     invalid_pseud.update_column(:icon_content_type, "not/valid")
+
     subject.invoke
 
     invalid_pseud.reload
+    valid_pseud.reload
     expect(invalid_pseud.icon.exists?).to be_falsey
     expect(invalid_pseud.icon_content_type).to be_nil
     expect(valid_pseud.icon.exists?).to be_truthy
@@ -331,26 +331,33 @@ describe "rake After:fix_invalid_pseud_icon_data" do
 
   it "removes invalid icon_alt_text" do
     invalid_pseud.update_column(:icon_alt_text, "not valid")
+    valid_pseud.update_attribute(:icon_alt_text, "valid")
+
     subject.invoke
 
     invalid_pseud.reload
+    valid_pseud.reload
     expect(invalid_pseud.icon_alt_text).to be_empty
-    expect(valid_pseud.icon_alt_text).to eq("hi")
+    expect(valid_pseud.icon_alt_text).to eq("valid")
   end
 
   it "removes invalid icon_comment_text" do
     invalid_pseud.update_column(:icon_comment_text, "not valid")
+    valid_pseud.update_attribute(:icon_comment_text, "valid")
+
     subject.invoke
 
     invalid_pseud.reload
+    valid_pseud.reload
     expect(invalid_pseud.icon_comment_text).to be_empty
-    expect(valid_pseud.icon_comment_text).to eq("okay")
+    expect(valid_pseud.icon_comment_text).to eq("valid")
   end
 
   it "updates icon_content_type from jpg to jpeg" do
     invalid_pseud.icon = File.new(Rails.root.join("features/fixtures/icon.jpg"))
     invalid_pseud.save
     invalid_pseud.update_column(:icon_content_type, "image/jpg")
+
     subject.invoke
 
     invalid_pseud.reload

--- a/spec/lib/tasks/after_tasks.rake_spec.rb
+++ b/spec/lib/tasks/after_tasks.rake_spec.rb
@@ -308,12 +308,14 @@ describe "rake After:delete_invalid_pseud_icon_data" do
            icon_alt_text: "hi",
            icon_comment_text: "okay",
            icon: File.new(
-             Rails.root.join("public/images/feed-icon-14x14.png")))
+             Rails.root.join("public/images/feed-icon-14x14.png"))
+          )
   end
   let(:invalid_pseud) do
     create(:pseud,
            icon: File.new(
-             Rails.root.join("public/images/feed-icon-14x14.png")))
+             Rails.root.join("public/images/feed-icon-14x14.png"))
+          )
   end
 
   before do

--- a/spec/lib/tasks/after_tasks.rake_spec.rb
+++ b/spec/lib/tasks/after_tasks.rake_spec.rb
@@ -302,7 +302,7 @@ describe "rake After:fix_tags_with_extra_spaces" do
   end
 end
 
-describe "rake After:delete_invalid_pseud_icon_data" do
+describe "rake After:fix_invalid_pseud_icon_data" do
   let(:valid_pseud) { create(:user).default_pseud }
   let(:invalid_pseud) { create(:user).default_pseud }
 
@@ -345,6 +345,17 @@ describe "rake After:delete_invalid_pseud_icon_data" do
     invalid_pseud.reload
     expect(invalid_pseud.icon_comment_text).to be_empty
     expect(valid_pseud.icon_comment_text).to eq("okay")
+  end
+
+  it "updates icon_content_type from jpg to jpeg" do
+    invalid_pseud.icon = File.new(Rails.root.join("features/fixtures/icon.jpg"))
+    invalid_pseud.save
+    invalid_pseud.update_column(:icon_content_type, "image/jpg")
+    subject.invoke
+
+    invalid_pseud.reload
+    expect(invalid_pseud.icon.exists?).to be_truthy
+    expect(invalid_pseud.icon_content_type).to eq("image/jpeg")
   end
 
   it "updates multiple invalid fields on the same pseud" do

--- a/spec/lib/tasks/after_tasks.rake_spec.rb
+++ b/spec/lib/tasks/after_tasks.rake_spec.rb
@@ -308,16 +308,12 @@ describe "rake After:delete_invalid_pseud_icon_data" do
       icon_alt_text: "hi",
       icon_comment_text: "okay",
       icon: File.new(
-        Rails.root.join("public/images/feed-icon-14x14.png")
-      )
-    )
+        Rails.root.join("public/images/feed-icon-14x14.png")))
   end
   let(:invalid_pseud) do
     create(:pseud,
       icon: File.new(
-        Rails.root.join("public/images/feed-icon-14x14.png")
-      )
-    )
+        Rails.root.join("public/images/feed-icon-14x14.png")))
   end
 
   before do

--- a/spec/lib/tasks/after_tasks.rake_spec.rb
+++ b/spec/lib/tasks/after_tasks.rake_spec.rb
@@ -304,18 +304,18 @@ end
 
 describe "rake After:delete_invalid_pseud_icon_data" do
   let!(:valid_pseud) do
-    create(:pseud,
-           icon_alt_text: "hi",
-           icon_comment_text: "okay",
-           icon: File.new(
-             Rails.root.join("public/images/feed-icon-14x14.png"))
-          )
+    create(
+      :pseud,
+      icon_alt_text: "hi",
+      icon_comment_text: "okay",
+      icon: File.new(Rails.root.join("public/images/feed-icon-14x14.png"))
+    )
   end
   let(:invalid_pseud) do
-    create(:pseud,
-           icon: File.new(
-             Rails.root.join("public/images/feed-icon-14x14.png"))
-          )
+    create(
+      :pseud,
+      icon: File.new(Rails.root.join("public/images/feed-icon-14x14.png"))
+    )
   end
 
   before do

--- a/spec/lib/tasks/after_tasks.rake_spec.rb
+++ b/spec/lib/tasks/after_tasks.rake_spec.rb
@@ -308,13 +308,13 @@ describe "rake After:delete_invalid_pseud_icon_data" do
       :pseud,
       icon_alt_text: "hi",
       icon_comment_text: "okay",
-      icon: File.new(Rails.root.join("public/images/feed-icon-14x14.png"))
+      icon: File.new(Rails.root.join("features/fixtures/icon.gif"))
     )
   end
   let(:invalid_pseud) do
     create(
       :pseud,
-      icon: File.new(Rails.root.join("public/images/feed-icon-14x14.png"))
+      icon: File.new(Rails.root.join("features/fixtures/icon.gif"))
     )
   end
 

--- a/spec/lib/tasks/after_tasks.rake_spec.rb
+++ b/spec/lib/tasks/after_tasks.rake_spec.rb
@@ -320,8 +320,9 @@ describe "rake After:delete_invalid_pseud_icon_data" do
     subject.invoke
 
     invalid_pseud.reload
-    expect(invalid_pseud.icon).to be_nil
+    expect(invalid_pseud.icon.exists?).to be_falsey
     expect(invalid_pseud.icon_content_type).to be_nil
+    expect(valid_pseud.icon.exists?).to be_truthy
     expect(valid_pseud.icon_content_type).to eq("image/png")
   end
 
@@ -344,11 +345,13 @@ describe "rake After:delete_invalid_pseud_icon_data" do
   end
 
   it "updates multiple invalid fields on the same pseud" do
-    invalid_pseud.update_columns(icon_comment_text: "not valid",
-                                 icon_alt_text: "not valid")
+    invalid_pseud.update_columns(icon_content_type: "not/valid",
+                                 icon_alt_text: "not valid",
+                                 icon_comment_text: "not valid")
     subject.invoke
 
     invalid_pseud.reload
+    expect(invalid_pseud.icon.exists?).to be_falsey
     expect(invalid_pseud.icon_alt_text).to be_empty
     expect(invalid_pseud.icon_comment_text).to be_empty
   end

--- a/spec/lib/tasks/after_tasks.rake_spec.rb
+++ b/spec/lib/tasks/after_tasks.rake_spec.rb
@@ -360,6 +360,7 @@ describe "rake After:fix_invalid_pseud_icon_data" do
 
   it "updates multiple invalid fields on the same pseud" do
     invalid_pseud.icon = File.new(Rails.root.join("features/fixtures/icon.gif"))
+    invalid_pseud.save
     invalid_pseud.update_columns(icon_content_type: "not/valid",
                                  icon_alt_text: "not valid",
                                  icon_comment_text: "not valid")
@@ -367,6 +368,7 @@ describe "rake After:fix_invalid_pseud_icon_data" do
 
     invalid_pseud.reload
     expect(invalid_pseud.icon.exists?).to be_falsey
+    expect(invalid_pseud.icon_content_type).to be_nil
     expect(invalid_pseud.icon_alt_text).to be_empty
     expect(invalid_pseud.icon_comment_text).to be_empty
   end

--- a/spec/lib/tasks/after_tasks.rake_spec.rb
+++ b/spec/lib/tasks/after_tasks.rake_spec.rb
@@ -306,9 +306,13 @@ describe "rake After:delete_invalid_pseud_icon_data" do
   let!(:valid_pseud) { create(:pseud,
                               icon_alt_text: "hi",
                               icon_comment_text: "okay",
-                              icon: File.new("#{Rails.root}/public/images/feed-icon-14x14.png")) }
+                              icon: File.new(
+                                Rails.root.join("public/images/feed-icon-14x14.png")
+                              )) }
   let(:invalid_pseud) { create(:pseud,
-                               icon: File.new("#{Rails.root}/public/images/feed-icon-14x14.png")) }
+                               icon: File.new(
+                                 Rails.root.join("public/images/feed-icon-14x14.png")
+                               )) }
 
   before do
     ArchiveConfig.ICON_ALT_MAX = 5

--- a/spec/lib/tasks/after_tasks.rake_spec.rb
+++ b/spec/lib/tasks/after_tasks.rake_spec.rb
@@ -303,16 +303,22 @@ describe "rake After:fix_tags_with_extra_spaces" do
 end
 
 describe "rake After:delete_invalid_pseud_icon_data" do
-  let!(:valid_pseud) { create(:pseud,
-                              icon_alt_text: "hi",
-                              icon_comment_text: "okay",
-                              icon: File.new(
-                                Rails.root.join("public/images/feed-icon-14x14.png")
-                              )) }
-  let(:invalid_pseud) { create(:pseud,
-                               icon: File.new(
-                                 Rails.root.join("public/images/feed-icon-14x14.png")
-                               )) }
+  let!(:valid_pseud) do
+    create(:pseud,
+      icon_alt_text: "hi",
+      icon_comment_text: "okay",
+      icon: File.new(
+        Rails.root.join("public/images/feed-icon-14x14.png")
+      )
+    )
+  end
+  let(:invalid_pseud) do
+    create(:pseud,
+      icon: File.new(
+        Rails.root.join("public/images/feed-icon-14x14.png")
+      )
+    )
+  end
 
   before do
     ArchiveConfig.ICON_ALT_MAX = 5

--- a/spec/lib/tasks/after_tasks.rake_spec.rb
+++ b/spec/lib/tasks/after_tasks.rake_spec.rb
@@ -303,28 +303,22 @@ describe "rake After:fix_tags_with_extra_spaces" do
 end
 
 describe "rake After:delete_invalid_pseud_icon_data" do
-  let!(:valid_pseud) do
-    create(
-      :pseud,
-      icon_alt_text: "hi",
-      icon_comment_text: "okay",
-      icon: File.new(Rails.root.join("features/fixtures/icon.gif"))
-    )
-  end
-  let(:invalid_pseud) do
-    create(
-      :pseud,
-      icon: File.new(Rails.root.join("features/fixtures/icon.gif"))
-    )
-  end
+  let(:valid_pseud) { create(:user).default_pseud }
+  let(:invalid_pseud) { create(:user).default_pseud }
 
   before do
     stub_const("ArchiveConfig", OpenStruct.new(ArchiveConfig))
     ArchiveConfig.ICON_ALT_MAX = 5
     ArchiveConfig.ICON_COMMENT_MAX = 3
+
+    valid_pseud.icon = File.new(Rails.root.join("features/fixtures/icon.gif"))
+    valid_pseud.icon_alt_text = "hi"
+    valid_pseud.icon_comment_text = "okay"
   end
 
   it "removes invalid icon" do
+    invalid_pseud.icon = File.new(Rails.root.join("features/fixtures/icon.gif"))
+    invalid_pseud.save
     invalid_pseud.update_column(:icon_content_type, "not/valid")
     subject.invoke
 
@@ -354,6 +348,7 @@ describe "rake After:delete_invalid_pseud_icon_data" do
   end
 
   it "updates multiple invalid fields on the same pseud" do
+    invalid_pseud.icon = File.new(Rails.root.join("features/fixtures/icon.gif"))
     invalid_pseud.update_columns(icon_content_type: "not/valid",
                                  icon_alt_text: "not valid",
                                  icon_comment_text: "not valid")

--- a/spec/lib/tasks/after_tasks.rake_spec.rb
+++ b/spec/lib/tasks/after_tasks.rake_spec.rb
@@ -319,6 +319,7 @@ describe "rake After:delete_invalid_pseud_icon_data" do
   end
 
   before do
+    stub_const("ArchiveConfig", OpenStruct.new(ArchiveConfig))
     ArchiveConfig.ICON_ALT_MAX = 5
     ArchiveConfig.ICON_COMMENT_MAX = 3
   end
@@ -331,7 +332,7 @@ describe "rake After:delete_invalid_pseud_icon_data" do
     expect(invalid_pseud.icon.exists?).to be_falsey
     expect(invalid_pseud.icon_content_type).to be_nil
     expect(valid_pseud.icon.exists?).to be_truthy
-    expect(valid_pseud.icon_content_type).to eq("image/png")
+    expect(valid_pseud.icon_content_type).to eq("image/gif")
   end
 
   it "removes invalid icon_alt_text" do

--- a/spec/lib/tasks/after_tasks.rake_spec.rb
+++ b/spec/lib/tasks/after_tasks.rake_spec.rb
@@ -305,15 +305,15 @@ end
 describe "rake After:delete_invalid_pseud_icon_data" do
   let!(:valid_pseud) do
     create(:pseud,
-      icon_alt_text: "hi",
-      icon_comment_text: "okay",
-      icon: File.new(
-        Rails.root.join("public/images/feed-icon-14x14.png")))
+           icon_alt_text: "hi",
+           icon_comment_text: "okay",
+           icon: File.new(
+             Rails.root.join("public/images/feed-icon-14x14.png")))
   end
   let(:invalid_pseud) do
     create(:pseud,
-      icon: File.new(
-        Rails.root.join("public/images/feed-icon-14x14.png")))
+           icon: File.new(
+             Rails.root.join("public/images/feed-icon-14x14.png")))
   end
 
   before do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -83,6 +83,11 @@ RSpec.configure do |config|
     Indexer.all.map(&:delete_index)
   end
 
+  # Remove the folder where test images are saved.
+  config.after(:suite) do
+    FileUtils.rm_rf(Dir[Rails.root.join("public/system/test")])
+  end
+
   config.before :each, bookmark_search: true do
     BookmarkIndexer.prepare_for_testing
   end


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6316

## Purpose

* Puts the pseud icons for staging under a different path so we can change those when testing without affecting production
* Add a task to fix invalid pseud icons, icon alt text, and icon comment text

## Testing Instructions

Refer to Jira 

## References

https://github.com/otwcode/otw-scripts/pull/18

## Credit

Sarken, she/her
