### PR TITLE
AO3-6309 Update abuse form error for over-reporting URLs

### DIFF
--- a/app/models/abuse_report.rb
+++ b/app/models/abuse_report.rb
@@ -86,9 +86,9 @@ class AbuseReport < ApplicationRecord
   # make sure it isn't reported more than ABUSE_REPORTS_PER_WORK_MAX
   # or ABUSE_REPORTS_PER_USER_MAX times per month
   def url_is_not_over_reported
-    message = ts('This page has already been reported. Our volunteers
-                  only need one report in order to investigate and resolve
-                  an issue, so please be patient and do not submit another report.')
+    message = ts('This page has already been reported. Our volunteers only
+                 need one report in order to investigate and resolve an issue,
+                 so please be patient and do not submit another report.')
     if url =~ /\/works\/\d+/
       # use "/works/123/" to avoid matching chapter or external work ids
       work_params_only = url.match(/\/works\/\d+\//).to_s

--- a/app/models/abuse_report.rb
+++ b/app/models/abuse_report.rb
@@ -86,9 +86,9 @@ class AbuseReport < ApplicationRecord
   # make sure it isn't reported more than ABUSE_REPORTS_PER_WORK_MAX
   # or ABUSE_REPORTS_PER_USER_MAX times per month
   def url_is_not_over_reported
-    message = ts('URL has already been reported. To make sure the Abuse Team
-                 can handle reports quickly and efficiently, we limit the number
-                 of times a URL can be reported.')
+    message = ts('This page has already been reported. Our volunteers
+                  only need one report in order to investigate and resolve
+                  an issue, so please be patient and do not submit another report.')
     if url =~ /\/works\/\d+/
       # use "/works/123/" to avoid matching chapter or external work ids
       work_params_only = url.match(/\/works\/\d+\//).to_s

--- a/spec/models/abuse_report_spec.rb
+++ b/spec/models/abuse_report_spec.rb
@@ -87,7 +87,7 @@ describe AbuseReport do
       let(:report) { build(:abuse_report, url: url) }
       it "can't be submitted" do
         expect(report.save).to be_falsey
-        expect(report.errors[:base].first).to include("URL has already been reported.")
+        expect(report.errors[:base].first).to include("This page has already been reported.")
       end
     end
 


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6309

## Purpose

Updated abuse form error message to discourage over-reporting. 

Original: 

> URL has already been reported. To make sure the Abuse Team can handle reports quickly and efficiently, we limit the number of times a URL can be reported.

New:

>This page has already been reported. Our volunteers only need one report in order to investigate and resolve an issue, so please be patient and do not submit another report.

## Testing Instructions

See issue.

## Credit

Tara Rosenthal(she/her)
