### PR TITLE
AO3-6085 Change memcached namespace in all environments

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -10,7 +10,7 @@ Otwarchive::Application.configure do
   memcached_servers = "127.0.0.1:11211"
   memcached_servers = YAML.load_file(Rails.root.join("config/local.yml")).fetch("MEMCACHED_SERVERS", memcached_servers) if File.file?(Rails.root.join("config/local.yml"))
   config.cache_store = :mem_cache_store, memcached_servers,
-                       { namespace: "ao3-v1-dev", compress: true, pool_size: 10 }
+                       { namespace: "ao3-v2-dev", compress: true, pool_size: 10 }
 
   # Log error messages when you accidentally call methods on nil.
   # config.whiny_nils = true

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -34,7 +34,7 @@ Otwarchive::Application.configure do
 
   # Use a different cache store in production
   config.cache_store = :mem_cache_store, ArchiveConfig.MEMCACHED_SERVERS,
-                       { namespace: "ao3-v1", compress: true, pool_size: 10 }
+                       { namespace: "ao3-v2", compress: true, pool_size: 10 }
 
   # Disable Rails's static asset server
   # In production, Apache or nginx will already do this

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -34,7 +34,7 @@ Otwarchive::Application.configure do
 
   # Use a different cache store in production
   config.cache_store = :mem_cache_store, ArchiveConfig.MEMCACHED_SERVERS,
-                       { namespace: "ao3-v1", compress: true, pool_size: 5 }
+                       { namespace: "ao3-v2", compress: true, pool_size: 5 }
 
   # Disable Rails's static asset server
   # In production, Apache or nginx will already do this

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -19,7 +19,7 @@ Otwarchive::Application.configure do
   config.action_mailer.perform_caching = true
 
   config.cache_store = :mem_cache_store, ArchiveConfig.MEMCACHED_SERVERS,
-                       { namespace: "ao3-v1-test", compress: true, pool_size: 10, raise_errors: true }
+                       { namespace: "ao3-v2-test", compress: true, pool_size: 10, raise_errors: true }
 
   # Raise exceptions instead of rendering exception templates
   config.action_dispatch.show_exceptions = false


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6085

## Purpose

Cached data between Dalli versions 2 and 3 are [incompatible](https://github.com/petergoldstein/dalli/blob/313c2d84f45e20149c1b7ee4c1e8337f975791d9/3.0-Upgrade.md).

## Testing Instructions

Site loads normally.