### PR TITLE
AO3-6085 Update Capistrano repository URL to use https

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -59,7 +59,7 @@ set :mail_to, "otw-coders@transformativeworks.org otw-testers@transformativework
 
 # git settings
 set :scm, :git
-set :repository, "git://github.com/otwcode/otwarchive.git"
+set :repository, "https://github.com/otwcode/otwarchive.git"
 set :deploy_via, :remote_cache
 
 set :servers, -> { YAML.load_file(File.join(__dir__, "servers.yml")).deep_symbolize_keys[fetch(:stage)] }


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6085

## Purpose

GitHub is [removing support for the unencrypted Git protocol](https://github.blog/2021-09-01-improving-git-protocol-security-github/).

Not really related to the Rails update, but hey, it's in the way.

## Testing Instructions

Deploy should work.