### PR TITLE
AO3-3293 Touch comments when pseud is changed

### DIFF
--- a/app/models/pseud.rb
+++ b/app/models/pseud.rb
@@ -85,7 +85,7 @@ class Pseud < ApplicationRecord
 
   after_update :check_default_pseud
   after_update :expire_caches
-  after_commit :reindex_creations
+  after_commit :reindex_creations, :touch_comments
 
   scope :on_works, lambda {|owned_works|
     select("DISTINCT pseuds.*").
@@ -454,6 +454,10 @@ class Pseud < ApplicationRecord
     if saved_change_to_name?
       self.works.each{ |work| work.touch }
     end
+  end
+
+  def touch_comments
+    comments.touch_all
   end
 
   # Delete current icon (thus reverting to archive default icon)

--- a/spec/models/pseud_spec.rb
+++ b/spec/models/pseud_spec.rb
@@ -10,7 +10,7 @@ describe Pseud do
   end
 
   it "is invalid if there are special characters" do
-    expect(build(:pseud, name: '*pseud*')).to be_invalid
+    expect(build(:pseud, name: "*pseud*")).to be_invalid
   end
 
   describe "save" do

--- a/spec/models/pseud_spec.rb
+++ b/spec/models/pseud_spec.rb
@@ -10,7 +10,7 @@ describe Pseud do
   end
 
   it "is invalid if there are special characters" do
-      expect(build(:pseud, name: '*pseud*')).to be_invalid
+    expect(build(:pseud, name: '*pseud*')).to be_invalid
   end
 
   describe "save" do
@@ -46,6 +46,21 @@ describe Pseud do
       @pseud.icon_comment_text = "Something that is too long blah blah blah blah blah blah this needs a mere 50 characters"
       expect(@pseud.save).to be_falsey
       @pseud.errors[:icon_comment_text].should_not be_empty
+    end
+  end
+
+  describe "touch_comments" do
+    let(:pseud) { create(:pseud) }
+    let!(:comment) { create(:comment, pseud_id: pseud.id) }
+
+    it "modifies the updated_at of associated comments" do
+      # Without this, the in-memory pseud has 0 comments and the test fails.
+      pseud.reload
+      original_comment_updated_at = comment.updated_at
+      travel(1.day)
+      pseud.name = "New Name"
+      pseud.save
+      expect(comment.reload.updated_at).not_to eq(original_comment_updated_at)
     end
   end
 end

--- a/spec/models/pseud_spec.rb
+++ b/spec/models/pseud_spec.rb
@@ -51,16 +51,15 @@ describe Pseud do
 
   describe "touch_comments" do
     let(:pseud) { create(:pseud) }
-    let!(:comment) { create(:comment, pseud_id: pseud.id) }
+    let!(:comment) { create(:comment, pseud: pseud) }
 
     it "modifies the updated_at of associated comments" do
       # Without this, the in-memory pseud has 0 comments and the test fails.
       pseud.reload
-      original_comment_updated_at = comment.updated_at
       travel(1.day)
-      pseud.name = "New Name"
-      pseud.save
-      expect(comment.reload.updated_at).not_to eq(original_comment_updated_at)
+      expect do
+        pseud.update(name: "New Name")
+      end.to change { comment.reload.updated_at }
     end
   end
 end


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-3293

## Purpose

When we modify a pseud, touch any comments that belong to it to ensure the name and icon are updated.

## Testing Instructions

Refer to Jira.