### PR TITLE
AO3-5830 Remove blank option in Work & Tag Search

### DIFF
--- a/app/views/tags/_search_form.html.erb
+++ b/app/views/tags/_search_form.html.erb
@@ -64,8 +64,7 @@
       </dt>
       <dd>
         <%= f.select :sort_direction,
-          options_for_select([["Ascending", "asc"], ["Descending", "desc"]], @search.sort_direction),
-          { :include_blank => true } %>
+          options_for_select([["Ascending", "asc"], ["Descending", "desc"]], @search.sort_direction) %>
       </dd>
     </dl>
     <p class="submit actions"><%= f.submit ts("Search Tags") %></p>

--- a/app/views/works/_search_form.html.erb
+++ b/app/views/works/_search_form.html.erb
@@ -203,8 +203,7 @@
       </dt>
       <dd>
         <%= f.select :sort_direction,
-          options_for_select([["Ascending", "asc"], ["Descending", "desc"]], @search.sort_direction),
-          { :include_blank => true } %>
+          options_for_select([["Ascending", "asc"], ["Descending", "desc"]], @search.sort_direction) %>
       </dd>
     </dl>
     <p class="submit"><%= f.submit ts("Search") %></p>


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [ ] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [x] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [x] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-5830

## Purpose

Remove blank option in the sort direction of Work & Tag Search

## Testing Instructions

Check the list for "Sort direction" in Work and Tag Search pages show only "Ascending" and "Descending" options. 

## References

https://github.com/otwcode/otwarchive/pull/4144

## Credit

weeklies (she/her)