### PR TITLE
AO3-5986 Create an 'Official' role

### DIFF
--- a/app/helpers/comments_helper.rb
+++ b/app/helpers/comments_helper.rb
@@ -49,6 +49,8 @@ module CommentsHelper
     if comment.pseud_id
       if comment.pseud.nil?
         ts("Account Deleted")
+      elsif comment.pseud.user.official
+        link_to (comment.pseud.byline + content_tag(:span, " (Official)", :class => "role")).html_safe, [comment.pseud.user, comment.pseud]
       else
         link_to comment.pseud.byline, [comment.pseud.user, comment.pseud]
       end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -388,6 +388,15 @@ class User < ApplicationRecord
     has_role?(:archivist)
   end
 
+  # Is this user an authorized official?
+  def official
+    self.is_official?
+  end
+
+  def is_official?
+    has_role?(:official)
+  end
+
   # Is this user a protected user? These are users experiencing certain types
   # of harassment. For now, this is only used to prevent harassment via repeated
   # password reset requests.

--- a/app/views/comments/_single_comment.html.erb
+++ b/app/views/comments/_single_comment.html.erb
@@ -1,5 +1,5 @@
 <!-- START of single comment -->
-<li class="<% if single_comment.unreviewed? %>unreviewed <% end %>comment group <%= cycle :odd, :even %>" id="comment_<%= single_comment.id %>" role="article">
+<li class="<% if !single_comment.pseud.nil? && single_comment.pseud.user.official %>official <% end %><% if single_comment.unreviewed? %>unreviewed <% end %>comment group <%= cycle :odd, :even %>" id="comment_<%= single_comment.id %>" role="article">
   <% if params[:edit_comment_id] && params[:edit_comment_id] == single_comment.id.to_s && can_edit_comment?(single_comment) %>
     <!-- we're editing this comment -->
     <%= render 'comments/comment_form',

--- a/app/views/home/_inbox_module.html.erb
+++ b/app/views/home/_inbox_module.html.erb
@@ -8,7 +8,7 @@
   <p class="note"><%= ts('The latest unread items from your inbox.') %></p>
   <ul class="abbreviated comment group">
     <% inbox_comments.each do |inbox_comment| %>
-      <li class="<% if inbox_comment.feedback_comment.unreviewed? %>unreviewed <% end %>unread comment group" id="feedback_comment_<%= inbox_comment.feedback_comment_id %>">
+      <li class="<% if !inbox_comment.feedback_comment.pseud.nil? && inbox_comment.feedback_comment.pseud.user.official %>official <% end %><% if inbox_comment.feedback_comment.unreviewed? %>unreviewed <% end %>unread comment group" id="feedback_comment_<%= inbox_comment.feedback_comment_id %>">
         <%= render 'inbox/inbox_comment_contents', feedback_comment: inbox_comment.feedback_comment %>
         <ul class="actions">
           <% if inbox_comment.feedback_comment.iced? %>

--- a/app/views/inbox/show.html.erb
+++ b/app/views/inbox/show.html.erb
@@ -37,7 +37,7 @@
           <% feedback_comment = inbox_comment.feedback_comment %>
 
           <!-- START of single comment -->
-          <li class="<% if feedback_comment.unreviewed? %>unreviewed <% end %><%= inbox_comment.read? ? 'read' : 'unread' %> comment group" role="article" id="feedback_comment_<%= feedback_comment.id %>">
+          <li class="<% if !feedback_comment.pseud.nil? && feedback_comment.pseud.user.official %>official <% end %><% if feedback_comment.unreviewed? %>unreviewed <% end %><%= inbox_comment.read? ? 'read' : 'unread' %> comment group" role="article" id="feedback_comment_<%= feedback_comment.id %>">
 
             <%= render "inbox_comment_contents", feedback_comment: feedback_comment %>
 

--- a/features/fixtures/roles.yml
+++ b/features/fixtures/roles.yml
@@ -10,3 +10,6 @@ translation_admin:
 archivist:
   id: 4
   name: archivist
+official:
+  id: 5
+  name: official

--- a/lib/tasks/defaults.rake
+++ b/lib/tasks/defaults.rake
@@ -1,7 +1,7 @@
 namespace :defaults do
   desc "Create default roles by name"
   task(create_roles: :environment) do
-    %w[archivist opendoors protected_user tag_wrangler translation_admin translator].each do |role|
+    %w[archivist opendoors protected_user tag_wrangler translation_admin translator official].each do |role|
       Role.find_or_create_by(name: role)
     end
   end

--- a/public/stylesheets/site/2.0/15-group-comments.css
+++ b/public/stylesheets/site/2.0/15-group-comments.css
@@ -61,7 +61,7 @@ div.comment, li.comment {
 fieldset.comments, .comment .userstuff {
   background: transparent;
   border: none;
-    box-shadow: none;
+  box-shadow: none;
 }
 
 .comment .userstuff {
@@ -80,6 +80,15 @@ fieldset.comments, .comment .userstuff {
 
 .comment .edited {
   margin: 1.286em 0.643em 0.25em;
+}
+
+.comment span.role {
+  font-weight: bold;
+  color: #900;
+}
+
+.comment.official {
+  background-color: #FCC;
 }
 
 /* mods */

--- a/spec/lib/tasks/defaults.rake_spec.rb
+++ b/spec/lib/tasks/defaults.rake_spec.rb
@@ -4,7 +4,7 @@ describe "rake defaults:create_roles" do
   it "creates roles" do
     subject.invoke
 
-    role_names = %w[archivist opendoors protected_user tag_wrangler translation_admin translator]
+    role_names = %w[archivist opendoors protected_user tag_wrangler translation_admin translator official]
     expect(Role.all.pluck(:name)).to eq(role_names)
   end
 end

--- a/test/fixtures/roles.yml
+++ b/test/fixtures/roles.yml
@@ -48,3 +48,10 @@ role_00007:
   authorizable_type:
   id: 7
   authorizable_id:
+role_00008:
+  name: official
+  updated_at: 2021-04-21 14:27:00 Z
+  created_at: 2021-04-21 14:27:00 Z
+  authorizable_type:
+  id: 8
+  authorizable_id:


### PR DESCRIPTION
## To do (maybe)

- [ ] Add tests
- [ ] Apply changes on comment notification emails

## Issue

https://otwarchive.atlassian.net/browse/AO3-5986

## Purpose

Introduces the 'official' role, and alters the appearance of comments left by official accounts to make clear that this is official AO3 communication and to make it harder for users to imitate official accounts.

## Testing Instructions

Run `rake defaults:create_roles`
Then follow JIRA ticket.

## References

Maybe we should merge this before implementing tests and email changes, as it is blocking [AO3-6327](https://otwarchive.atlassian.net/browse/AO3-6327).

## Credit

EchoEkhi (He/him)
