### PR TITLE
AO3-6334 Use a different endpoint for resetting passwords

### DIFF
--- a/app/views/users/passwords/edit.html.erb
+++ b/app/views/users/passwords/edit.html.erb
@@ -4,7 +4,7 @@
 <!--/descriptions-->
 
 <!--main content-->
-<%= form_for resource, url: user_password_path, html: { method: :put } do |f| %>
+<%= form_for resource, url: users_password_reset_path, html: { method: :put } do |f| %>
   <%= f.hidden_field :reset_password_token %>
   <dl>
     <dt><%= label_tag :edit_password, ts("New password") %></dt>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,6 +16,13 @@ Otwarchive::Application.routes.draw do
   devise_scope :user do
     get "signup(/:invitation_token)" => "users/registrations#new", as: "signup"
     get "users/logout" => "users/sessions#confirm_logout"
+
+    # Rails emulate some HTTP methods over POST, so password resets (PUT /users/password)
+    # look the same as password reset requests (POST /users/password).
+    #
+    # To rate limit them differently at nginx, we set up an alias for
+    # the first request type.
+    put "users/password/reset" => "users/passwords#update"
   end
 
   devise_for :users,


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6334

## Purpose

So it can have different rate limits from the endpoint for requesting password resets.

## Testing Instructions

See issue.

This is also covered by the scenario at:

https://github.com/otwcode/otwarchive/blob/59bb5ebc3ca4fa86056b410d922152905b8cc179/features/users/authenticate_users.feature#L51-L56