### PR TITLE
AO3-6335 Fix comment cache expiration.

### DIFF
--- a/app/views/comments/_single_comment.html.erb
+++ b/app/views/comments/_single_comment.html.erb
@@ -14,7 +14,7 @@
     <% elsif single_comment.hidden_by_admin? && !logged_in_as_admin? %>
       <p class="message"><%= ts("(This comment is under review by an admin and is currently unavailable.)") %></p>
     <% else %>
-      <% cache(key: "/v2/single_comment/#{single_comment.id}/#{single_comment.edited_at}/#{single_comment.updated_at}", expires_in: 1.week, skip_digest: true ) do %>
+      <% cache(single_comment, expires_in: 1.week) do %>
         <% # FRONT END, update this if a.user comes in %>
         <h4 class="heading byline">
           <% if !single_comment.pseud.nil? %>

--- a/features/comments_and_kudos/add_comment.feature
+++ b/features/comments_and_kudos/add_comment.feature
@@ -30,7 +30,7 @@ Scenario: When logged in I can comment on a work
     When a chapter is added to "The One Where Neal is Awesome"
       And I view the work "The One Where Neal is Awesome" in full mode
       And I follow "Comments (1)"
-    When "comment expiration" is fixed
+    When "AO3-4214" is fixed
     # Then I should see "commenter on Chapter 1" within "h4.heading.byline"
 
   Scenario: IP address of the commenter are displayed only to an admin

--- a/features/comments_and_kudos/add_comment.feature
+++ b/features/comments_and_kudos/add_comment.feature
@@ -118,7 +118,6 @@ Scenario: Comment threading, comment editing
     And I fill in "Comment" with "Actually, I meant something different"
     And I press "Update"
   Then I should see "Comment was successfully updated"
-    #TODO Someone should figure out why this fails intermittently on Travis. Caching? The success message is there but the old comment text lingers.
     And I should see "Actually, I meant something different"
     And I should not see "Mistaken comment"
     And I should see Last Edited in the right timezone
@@ -129,7 +128,6 @@ Scenario: Comment threading, comment editing
     And I fill in "Comment" with "This should be nested" within ".thread .even"
     And I press "Comment" within ".thread .even"
   Then I should see "Comment created!"
-    # TODO Someone should figure out why this fails intermittently on Travis. Caching? The success message is there but the old comment text lingers.
     And I should not see "Mistaken comment"
     And I should see "Actually, I meant something different" within "ol.thread li ol.thread li ol.thread li ol.thread"
     And I should see "I loved it, too." within "ol.thread"

--- a/features/comments_and_kudos/add_comment.feature
+++ b/features/comments_and_kudos/add_comment.feature
@@ -6,29 +6,32 @@ Feature: Comment on work
 
 Scenario: Comment links from downloads and static pages
 
-  When I am logged in as "author"
-    And I post the work "Generic Work"
+  Given the work "Generic Work"
   When I am logged in as "commenter"
     And I visit the new comment page for the work "Generic Work"
   Then I should see the comment form
 
 Scenario: When logged in I can comment on a work
 
-  Given I have no works or comments
-  When I am logged in as "author"
-    And I post the work "The One Where Neal is Awesome"
+  Given the work "The One Where Neal is Awesome"
   When I am logged in as "commenter"
     And I view the work "The One Where Neal is Awesome"
     And I fill in "Comment" with "I loved this! 😍🤩"
     And I press "Comment"
   Then I should see "Comment created!"
     And I should see "I loved this! 😍🤩" within ".odd"
-    And I should not see "on Chapter 1" within ".odd"
-  When I am logged in as "author"
-    And a chapter is added to "The One Where Neal is Awesome"
-    And I follow "Entire Work"
-    And I follow "Comments (1)"
-  Then I should see "commenter on Chapter 1" within "h4.heading.byline"
+
+  Scenario: When a one-shot work becomes multi-chapter, all previous comments say "on Chapter 1"
+    Given the work "The One Where Neal is Awesome"
+      And I am logged in as "commenter"
+      And I post the comment "I loved this! 😍🤩" on the work "The One Where Neal is Awesome"
+    When I view the work "The One Where Neal is Awesome" with comments
+    Then I should not see "commenter on Chapter 1" within "h4.heading.byline"
+    When a chapter is added to "The One Where Neal is Awesome"
+      And I view the work "The One Where Neal is Awesome" in full mode
+      And I follow "Comments (1)"
+    When "comment expiration" is fixed
+    # Then I should see "commenter on Chapter 1" within "h4.heading.byline"
 
   Scenario: IP address of the commenter are displayed only to an admin
 

--- a/features/comments_and_kudos/add_comment.feature
+++ b/features/comments_and_kudos/add_comment.feature
@@ -70,8 +70,9 @@ Scenario: Comment editing
     And I post the work "The One Where Neal is Awesome"
   When I am logged in as "commenter"
     And I post the comment "Mistaken comment" on the work "The One Where Neal is Awesome"
+    And it is currently 1 second from now
     And I follow "Edit"
-  And I fill in "Comment" with "Actually, I meant something different"
+    And I fill in "Comment" with "Actually, I meant something different"
     And I press "Update"
   Then I should see "Comment was successfully updated"
     And I should see "Actually, I meant something different"
@@ -109,6 +110,7 @@ Scenario: Comment threading, comment editing
     And I follow "Reply" within ".thread .thread .odd"
     And I fill in "Comment" with "Mistaken comment" within ".thread .thread .odd"
     And I press "Comment" within ".thread .thread .odd"
+    And it is currently 1 second from now
     And I follow "Edit" within "ol.thread li ol.thread li ol.thread li ol.thread ul.actions"
     And I fill in "Comment" with "Actually, I meant something different"
     And I press "Update"
@@ -152,6 +154,7 @@ Scenario: Comment threading, comment editing
       And I should see "Sed mollis sapien ac massa pulvinar facilisis"
     When I fill in "Comment" with "This is a valid reply comment"
       And I press "Comment"
+      And it is currently 1 second from now
       And I follow "Edit"
       And I compose an invalid comment
       And I press "Update"

--- a/features/comments_and_kudos/comment_moderation.feature
+++ b/features/comments_and_kudos/comment_moderation.feature
@@ -72,6 +72,7 @@ Feature: Comment Moderation
     Given the moderated work "Moderation" by "author"
       And I am logged in as "commenter"
       And I post the comment "Fail comment" on the work "Moderation"
+      And it is currently 1 second from now
     When I follow "Edit"
       And I fill in "Comment" with "Edited unfail comment"
       And I press "Update"
@@ -269,7 +270,8 @@ Feature: Comment Moderation
       And I am logged in as "author"
       And I view the unreviewed comments page for "Moderation"
       And I press "Approve"
-    When I am logged in as "commenter"
+    When it is currently 1 second from now
+      And I am logged in as "commenter"
       And I view the work "Moderation"
       And I follow "Comments (1)"
       And I follow "Edit"
@@ -280,7 +282,8 @@ Feature: Comment Moderation
     Then I should see "Comments (1)"
     When I follow "Comments (1)"
     Then I should see "Interesting Commentary"
-    When I follow "Edit"
+    When it is currently 1 second from now
+      And I follow "Edit"
       And I fill in "Comment" with "AHAHAHA LOOK I HAVE TOTALLY CHANGED IT"
       And it is currently 1 second from now
       And I press "Update"

--- a/features/tags_and_wrangling/tag_comment.feature
+++ b/features/tags_and_wrangling/tag_comment.feature
@@ -28,7 +28,8 @@ I'd like to comment on a tag'
       And it is currently Mon Mar 27 22:00:00 UTC 2017
     When I am logged in as "dizmo"
     When I post the comment "Shouldn't this be a metatag with Stargate?" on the tag "Stargate Atlantis"
-    When I follow "Edit"
+    When it is currently 1 second from now
+      And I follow "Edit"
     Then the "Comment" field should contain "Shouldn't this be a metatag with Stargate?"
       And I should see "Cancel"
     When I fill in "Comment" with "Yep, we should have a Stargate franchise metatag."

--- a/features/users/user_rename.feature
+++ b/features/users/user_rename.feature
@@ -129,3 +129,22 @@ Feature:
       And I should not see "Epic story"
     When I search for works containing "newusername"
     Then I should see "Epic story"
+
+  Scenario: Comments reflect username changes after the cache expires in a week
+    Given the work "Interesting"
+      And I am logged in as "before" with password "password"
+      And I add the pseud "mine"
+    When I set up the comment "Wow!" on the work "Interesting"
+      And I select "mine" from "comment[pseud_id]"
+      And I press "Comment"
+      And I view the work "Interesting" with comments
+    Then I should see "mine (before)"
+    When I visit the change username page for before
+      And I fill in "New user name" with "after"
+      And I fill in "Password" with "password"
+      And I press "Change User Name"
+      And I view the work "Interesting" with comments
+    Then I should see "mine (before)"
+    When it is currently 7 days from now
+      And I view the work "Interesting" with comments
+    Then I should not see "mine (before)"


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6335

## Purpose

Fix the arguments to `cache` in `comments/single_comment`. I also switched to a simpler cache key, because we now have better tools to handle the intermittent test failures that `edited_at` was added to prevent.