### PR TITLE
AO3-6333 Try to reduce database queries when viewing comments.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -141,6 +141,7 @@ group :test do
   gem "simplecov"
   gem "codecov", require: false
   gem 'email_spec', '1.6.0'
+  gem "n_plus_one_control"
 end
 
 group :test, :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -338,6 +338,7 @@ GEM
     mustermann (1.1.1)
       ruby2_keywords (~> 0.0.1)
     mysql2 (0.5.2)
+    n_plus_one_control (0.6.2)
     net-http-digest_auth (1.4.1)
     net-http-persistent (4.0.1)
       connection_pool (~> 2.2)
@@ -627,6 +628,7 @@ DEPENDENCIES
   mimemagic (= 0.3.10)
   minitest
   mysql2 (= 0.5.2)
+  n_plus_one_control
   newrelic_rpm
   nokogiri (>= 1.8.5)
   permit_yo

--- a/app/controllers/admin_posts_controller.rb
+++ b/app/controllers/admin_posts_controller.rb
@@ -32,8 +32,6 @@ class AdminPostsController < Admin::BaseController
     @admin_posts = admin_posts.order('created_at DESC').limit(8)
     @previous_admin_post = admin_posts.order('created_at DESC').where('created_at < ?', @admin_post.created_at).first
     @next_admin_post = admin_posts.order('created_at ASC').where('created_at > ?', @admin_post.created_at).first
-    @commentable = @admin_post
-    @comments = @admin_post.comments
     @page_subtitle = @admin_post.title.html_safe
     respond_to do |format|
       format.html # show.html.erb

--- a/app/controllers/chapters_controller.rb
+++ b/app/controllers/chapters_controller.rb
@@ -49,8 +49,6 @@ class ChaptersController < ApplicationController
         @previous_chapter = @chapters[chapter_position-1] unless chapter_position == 0
         @next_chapter = @chapters[chapter_position+1]
       end
-      @commentable = @work
-      @comments = @chapter.comments.reviewed
 
       if @work.unrevealed?
         @page_title = t(".unrevealed") + t(".chapter_position", position: @chapter.position.to_s)

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -213,7 +213,6 @@ class CommentsController < ApplicationController
   def index
     return raise_not_found if @commentable.blank?
 
-    @comments = @commentable.comments.reviewed.page(params[:page])
     return unless @commentable.class == Comment
 
     # we link to the parent object at the top
@@ -221,14 +220,16 @@ class CommentsController < ApplicationController
   end
 
   def unreviewed
-    all_comments = @commentable.find_all_comments
-    @comments = all_comments.blank? ? nil : all_comments.unreviewed_only.page(params[:page])
+    @comments = @commentable.find_all_comments
+      .unreviewed_only
+      .for_display
+      .page(params[:page])
   end
 
   # GET /comments/1
   # GET /comments/1.xml
   def show
-    @comments = [@comment]
+    @comments = CommentDecorator.wrap_comments([@comment])
     @thread_view = true
     @thread_root = @comment
     params[:comment_id] = params[:id]
@@ -438,7 +439,7 @@ class CommentsController < ApplicationController
   end
 
   def show_comments
-    @comments = @commentable.comments.reviewed.page(params[:page])
+    @comments = CommentDecorator.for_commentable(@commentable, page: params[:page])
 
     respond_to do |format|
       format.html do

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -439,8 +439,6 @@ class CommentsController < ApplicationController
   end
 
   def show_comments
-    @comments = CommentDecorator.for_commentable(@commentable, page: params[:page])
-
     respond_to do |format|
       format.html do
         # if non-ajax it could mean sudden javascript failure OR being redirected from login
@@ -451,7 +449,10 @@ class CommentsController < ApplicationController
         options[:page] = params[:page]
         redirect_to_all_comments(@commentable, options)
       end
-      format.js
+
+      format.js do
+        @comments = CommentDecorator.for_commentable(@commentable, page: params[:page])
+      end
     end
   end
 

--- a/app/decorators/comment_decorator.rb
+++ b/app/decorators/comment_decorator.rb
@@ -1,0 +1,68 @@
+class CommentDecorator < SimpleDelegator
+  # Given an array of thread IDs, loads all comments in those threads, wraps
+  # all of them in CommentDecorators, and sets up reviewed_replies for all
+  # comments. Returns a hash mapping from comment IDs to CommentDecorators.
+  def self.from_thread_ids(thread_ids)
+    wrapped_by_id = {}
+
+    # Order by [thread, id] so that the comments in a thread are processed in
+    # the order they were posted. This will ensure that when we process a
+    # reply, its commentable has already been processed, and will also ensure
+    # that the replies to a comment are displayed in the correct order:
+    Comment.for_display.where(thread: thread_ids).order(:thread, :id).each do |comment|
+      wrapped = CommentDecorator.new(comment)
+      wrapped_by_id[comment.id] = wrapped
+
+      next unless comment.reply_comment?
+
+      wrapped_by_id[comment.commentable_id].comments << wrapped
+    end
+
+    wrapped_by_id
+  end
+
+  # Given an array of thread IDs, loads them with from_thread_ids, and then
+  # replaces the contents of the array with the CommentDecorators for each
+  # thread root.
+  def self.wrap_thread_ids(thread_ids)
+    comments_by_id = from_thread_ids(thread_ids)
+
+    wrapped = thread_ids.map do |id|
+      comments_by_id[id]
+    end
+
+    thread_ids.replace(wrapped)
+  end
+
+  # Given an array of comments, loads the threads associated with those
+  # comments using from_thread_ids, and then replaces the contents of the array
+  # with the decorated version of those comments.
+  def self.wrap_comments(comments)
+    comments_by_id = from_thread_ids(comments.map(&:thread))
+
+    wrapped = comments.map do |comment|
+      comments_by_id[comment.id]
+    end
+
+    comments.replace(wrapped)
+  end
+
+  # Given a commentable, gets the desired page of threads for that commentable,
+  # and then loads all of the comments for those threads using wrap_thread_ids.
+  def self.for_commentable(commentable, page:)
+    thread_ids = commentable.comments.reviewed.pluck(:thread)
+      .paginate(page: page, per_page: Comment.per_page)
+
+    wrap_thread_ids(thread_ids)
+  end
+
+  # Override the comments association.
+  def comments
+    @comments ||= []
+  end
+
+  # Override the reviewed_replies association.
+  def reviewed_replies
+    @reviewed_replies ||= comments.reject(&:unreviewed?)
+  end
+end

--- a/app/helpers/comments_helper.rb
+++ b/app/helpers/comments_helper.rb
@@ -288,7 +288,7 @@ module CommentsHelper
 
   # find the parent of the commentable
   def find_parent(commentable)
-    if commentable.is_a?(Comment)
+    if commentable.respond_to?(:ultimate_parent)
       commentable.ultimate_parent
     elsif commentable.respond_to?(:work)
       commentable.work

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -10,6 +10,9 @@ class Comment < ApplicationRecord
   has_many :inbox_comments, foreign_key: 'feedback_comment_id', dependent: :destroy
   has_many :users, through: :inbox_comments
 
+  has_many :reviewed_replies, -> { reviewed },
+           class_name: "Comment", as: :commentable, inverse_of: :commentable
+
   has_many :thread_comments, class_name: 'Comment', foreign_key: :thread
 
   validates_presence_of :name, unless: :pseud_id
@@ -39,6 +42,10 @@ class Comment < ApplicationRecord
   scope :not_deleted,     -> { where(is_deleted: false) }
   scope :reviewed,        -> { where(unreviewed: false) }
   scope :unreviewed_only, -> { where(unreviewed: true) }
+
+  scope :for_display, lambda {
+    includes(pseud: :user, parent: { work: :pseuds })
+  }
 
   # Gets methods and associations from acts_as_commentable plugin
   acts_as_commentable

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -337,11 +337,11 @@ class User < ApplicationRecord
   # Checks authorship of any sort of object
   def is_author_of?(item)
     if item.respond_to?(:pseud_id)
-      pseuds.pluck(:id).include?(item.pseud_id)
+      pseud_ids.include?(item.pseud_id)
     elsif item.respond_to?(:user_id)
       id == item.user_id
     elsif item.respond_to?(:pseuds)
-      !(pseuds.pluck(:id) & item.pseuds.pluck(:id)).empty?
+      item.pseuds.pluck(:user_id).include?(id)
     elsif item.respond_to?(:author)
       self == item.author
     elsif item.respond_to?(:creator_id)

--- a/app/views/comments/_comment_form.html.erb
+++ b/app/views/comments/_comment_form.html.erb
@@ -106,7 +106,7 @@
           <a name="comment_cancel" id="comment_cancel"><%= ts("Close") %></a>
         <% elsif comment.persisted? %>
           <%= cancel_edit_comment_link(comment) %>
-        <% elsif commentable.is_a?(Comment) %>
+        <% elsif commentable.is_a?(Comment) || commentable.is_a?(CommentDecorator) %>
           <%= cancel_comment_reply_link(commentable) %>
         <% end %>
       </p>

--- a/app/views/comments/_comment_thread.html.erb
+++ b/app/views/comments/_comment_thread.html.erb
@@ -4,11 +4,11 @@
     <% if comment.approved? || logged_in_as_admin? %>
 
       <%= render 'comments/single_comment', single_comment: comment %>
-      <% child_comments = comment.comments.reviewed %>
+      <% child_comments = comment.reviewed_replies %>
 
-      <% if child_comments && child_comments.count > 0 %>
+      <% if child_comments && child_comments.size > 0 %>
         <!-- cut off the recursion when we get too deep, but not if there's just one last measly comment left -->
-        <% if depth >= ArchiveConfig.COMMENT_THREAD_MAX_DEPTH && child_comments.count > 1 %>
+        <% if depth >= ArchiveConfig.COMMENT_THREAD_MAX_DEPTH && child_comments.size > 1 %>
           <li class="comment"><p>(<%= link_to ts("%{count} more comments in this thread", count: comment.children_count), comment_path(comment) %>)</p></li>
         <% else %>
           <li>

--- a/app/views/comments/_commentable.html.erb
+++ b/app/views/comments/_commentable.html.erb
@@ -113,7 +113,7 @@
   <!-- If not, and show_comments is true, here is where the comments will be rendered -->
   <div id="comments_placeholder" <% unless params[:show_comments] || params[:tag_id] %>style="display:none;"<% end %>>
     <% if params[:show_comments] || params[:tag_id] %>
-      <% @comments = commentable.comments.reviewed.page(params[:page]) %>
+      <% @comments = CommentDecorator.for_commentable(commentable, page: params[:page]) %>
       <%= will_paginate @comments, params: { anchor: :comments } %>
       <%= render 'comments/comment_thread', { :depth => 0, :comments => @comments } %>
       </ol><!-- need to tack this on to close thread -->

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -15,9 +15,12 @@ Otwarchive::Application.configure do
   # Log error messages when you accidentally call methods on nil.
   # config.whiny_nils = true
 
-  # Show full error reports and disable caching
-  config.consider_all_requests_local       = true
-  config.action_controller.perform_caching = false
+  # Show full error reports:
+  config.consider_all_requests_local = true
+
+  # Enable/disable caching. By default caching is disabled, but it can be
+  # toggled on and off by calling rails dev:cache and restarting the server.
+  config.action_controller.perform_caching = Rails.root.join("tmp/caching-dev.txt").exist?
 
   # Don't care if the mailer can't send
   config.action_mailer.raise_delivery_errors = false

--- a/spec/controllers/chapters_controller_spec.rb
+++ b/spec/controllers/chapters_controller_spec.rb
@@ -166,16 +166,6 @@ describe ChaptersController do
       expect(assigns[:next_chapter]).to be_nil
     end
 
-    it "assigns @comments to only reviewed comments" do
-      moderated_work = create(:work, moderated_commenting_enabled: true)
-      comment = create(:comment, commentable: moderated_work.chapters.first)
-      comment.unreviewed = false
-      comment.save
-      create(:comment, unreviewed: true, commentable: moderated_work.chapters.first)
-      get :show, params: { work_id: moderated_work.id, id: moderated_work.chapters.first.id }
-      expect(assigns[:comments]).to eq [comment]
-    end
-
     it "assigns @page_title with fandom, author name, work title, and chapter" do
       expect_any_instance_of(ChaptersController).to receive(:get_page_title).with("Testing", user.pseuds.first.name, "My title is long enough - Chapter 1").and_return("page title")
       get :show, params: { work_id: work.id, id: work.chapters.first.id }
@@ -215,7 +205,6 @@ describe ChaptersController do
     it "assigns instance variables correctly" do
       second_chapter = create(:chapter, work: work, position: 2)
       third_chapter = create(:chapter, work: work, position: 3)
-      comment = create(:comment, commentable: second_chapter)
       kudo = create(:kudo, commentable: work, user: create(:user))
       tag = create(:fandom)
       expect_any_instance_of(Work).to receive(:tag_groups).and_return("Fandom" => [tag])
@@ -227,8 +216,6 @@ describe ChaptersController do
       expect(assigns[:chapters]).to eq [work.chapters.first, second_chapter, third_chapter]
       expect(assigns[:previous_chapter]).to eq work.chapters.first
       expect(assigns[:next_chapter]).to eq third_chapter
-      expect(assigns[:commentable]).to eq work
-      expect(assigns[:comments]).to eq [comment]
       expect(assigns[:page_title]).to eq "page title"
       expect(assigns[:kudos]).to eq [kudo]
       expect(assigns[:subscription]).to be_nil

--- a/spec/controllers/comments_controller_spec.rb
+++ b/spec/controllers/comments_controller_spec.rb
@@ -76,15 +76,16 @@ describe CommentsController do
   describe "GET #unreviewed" do
     let!(:user) { create(:user) }
     let!(:work) { create(:work, authors: [user.default_pseud], moderated_commenting_enabled: true) }
+    let(:comment) { create(:comment, :unreviewed, commentable: work.first_chapter) }
 
     it "redirects logged out users to login path with an error" do
-      get :unreviewed, params: { work_id: work.id }
+      get :unreviewed, params: { comment_id: comment.id, work_id: work.id }
       it_redirects_to_with_error(new_user_session_path, "Sorry, you don't have permission to see those unreviewed comments.")
     end
 
     it "redirects to root path with an error when logged in user does not own the commentable" do
       fake_login
-      get :unreviewed, params: { work_id: work.id }
+      get :unreviewed, params: { comment_id: comment.id, work_id: work.id }
       it_redirects_to_with_error(root_path, "Sorry, you don't have permission to see those unreviewed comments.")
     end
 
@@ -98,26 +99,6 @@ describe CommentsController do
       fake_login_admin(create(:admin))
       get :unreviewed, params: { work_id: work.id }
       expect(response).to render_template("unreviewed")
-    end
-
-    context "when displaying multiple comments", n_plus_one: true do
-      before do
-        # Skip authorization because it's a headache and a half:
-        allow(controller).to receive(:check_permission_to_review)
-      end
-
-      populate do |n|
-        create_list(:comment, n, :unreviewed, commentable: work.first_chapter)
-      end
-
-      render_views
-
-      it "produces a constant number of queries" do
-        expect do
-          Rails.cache.clear
-          get :unreviewed, params: { work_id: work.id }
-        end.to perform_constant_number_of_queries
-      end
     end
   end
 
@@ -1642,60 +1623,6 @@ describe CommentsController do
     end
   end
 
-  shared_examples "a hierarchical view with constant queries" do
-    context "when displaying multiple comments", n_plus_one: true do
-      render_views
-
-      context "when the comments are flat" do
-        populate { |n| create_list(:comment, n, commentable: commentable) }
-
-        it "produces a constant number of queries when logged out" do
-          expect do
-            Rails.cache.clear # prevent inconsistencies from cached values
-            subject.call
-          end.to perform_constant_number_of_queries
-        end
-
-        it "produces a constant number of queries when logged in" do
-          user = create(:user)
-
-          expect do
-            Rails.cache.clear
-            fake_login_known_user(user.reload)
-            subject.call
-            fake_logout
-          end.to perform_constant_number_of_queries
-        end
-      end
-
-      context "when the comments are nested" do
-        populate do |n|
-          n.times.inject(commentable) do |parent|
-            create(:comment, commentable: parent)
-          end
-        end
-
-        it "produces a constant number of queries when logged out" do
-          expect do
-            Rails.cache.clear
-            subject.call
-          end.to perform_constant_number_of_queries
-        end
-
-        it "produces a constant number of queries when logged in" do
-          user = create(:user)
-
-          expect do
-            Rails.cache.clear
-            fake_login_known_user(user.reload)
-            subject.call
-            fake_logout
-          end.to perform_constant_number_of_queries
-        end
-      end
-    end
-  end
-
   describe "GET #show_comments" do
     context "when the commentable is a valid tag" do
       let(:fandom) { create(:fandom) }
@@ -1755,17 +1682,6 @@ describe CommentsController do
                                      "reach. Please log in.")
         end
       end
-    end
-
-    it_behaves_like "a hierarchical view with constant queries" do
-      subject do
-        proc do
-          get :show_comments, params: { work_id: work, format: :js }, xhr: true
-        end
-      end
-
-      let!(:work) { create(:work) }
-      let!(:commentable) { work.first_chapter }
     end
   end
 
@@ -2162,17 +2078,6 @@ describe CommentsController do
       get :show, params: { id: unreviewed_comment.id }
       it_redirects_to_with_error(root_path, "Sorry, that comment is currently in moderation.")
     end
-
-    it_behaves_like "a hierarchical view with constant queries" do
-      subject do
-        proc do
-          get :show, params: { id: comment }
-        end
-      end
-
-      let!(:comment) { create(:comment) }
-      let!(:commentable) { comment }
-    end
   end
 
   describe "GET #index" do
@@ -2188,17 +2093,6 @@ describe CommentsController do
       get :index
 
       it_redirects_to_simple("/404")
-    end
-
-    it_behaves_like "a hierarchical view with constant queries" do
-      subject do
-        proc do
-          get :index, params: { work_id: work, show_comments: true }
-        end
-      end
-
-      let!(:work) { create(:work) }
-      let!(:commentable) { work.first_chapter }
     end
   end
 

--- a/spec/requests/comments_n_plus_one_spec.rb
+++ b/spec/requests/comments_n_plus_one_spec.rb
@@ -97,7 +97,7 @@ describe "n+1 queries in the CommentsController" do
       before { fake_login_known_user(work.users.first) }
 
       populate do |n|
-        User.current_user = nil # prevent bugs with unreviewed check
+        User.current_user = nil # log out to prevent commenting as work creator
         create_list(:comment, n, commentable: work.first_chapter)
       end
 
@@ -106,7 +106,6 @@ describe "n+1 queries in the CommentsController" do
       it "produces a constant number of queries" do
         expect do
           get unreviewed_work_comments_path(work)
-          expect(assigns(:comments).size).to eq(current_scale)
         end.to perform_constant_number_of_queries
       end
     end

--- a/spec/requests/comments_n_plus_one_spec.rb
+++ b/spec/requests/comments_n_plus_one_spec.rb
@@ -1,0 +1,114 @@
+require "spec_helper"
+
+describe CommentsController do
+  include LoginMacros
+
+  shared_examples "a hierarchical view with constant queries" do
+    context "when displaying multiple comments", n_plus_one: true do
+      context "when the comments are flat" do
+        populate { |n| create_list(:comment, n, commentable: commentable) }
+
+        warmup { subject.call }
+
+        it "produces a constant number of queries when logged out" do
+          expect do
+            subject.call
+          end.to perform_constant_number_of_queries
+        end
+
+        it "produces a constant number of queries when logged in" do
+          fake_login
+
+          expect do
+            subject.call
+          end.to perform_constant_number_of_queries
+        end
+      end
+
+      context "when the comments are nested" do
+        populate do |n|
+          n.times.inject(commentable) do |parent|
+            create(:comment, commentable: parent)
+          end
+        end
+
+        warmup { subject.call }
+
+        it "produces a constant number of queries when logged out" do
+          expect do
+            subject.call
+          end.to perform_constant_number_of_queries
+        end
+
+        it "produces a constant number of queries when logged in" do
+          fake_login
+
+          expect do
+            subject.call
+          end.to perform_constant_number_of_queries
+        end
+      end
+    end
+  end
+
+  describe "#show_comments" do
+    subject do
+      proc do
+        get show_comments_comments_path(work_id: work, format: :js), xhr: true
+      end
+    end
+
+    let!(:work) { create(:work) }
+    let!(:commentable) { work.first_chapter }
+
+    it_behaves_like "a hierarchical view with constant queries"
+  end
+
+  describe "#show" do
+    subject do
+      proc do
+        get comment_path(comment)
+      end
+    end
+
+    let!(:comment) { create(:comment) }
+    let!(:commentable) { comment }
+
+    it_behaves_like "a hierarchical view with constant queries"
+  end
+
+  describe "#index" do
+    subject do
+      proc do
+        get work_comments_path(work, show_comments: true)
+      end
+    end
+
+    let!(:work) { create(:work) }
+    let!(:commentable) { work.first_chapter }
+
+    it_behaves_like "a hierarchical view with constant queries"
+  end
+
+  describe "#unreviewed" do
+    let!(:work) { create(:work, moderated_commenting_enabled: true) }
+
+    context "when displaying multiple comments", n_plus_one: true do
+      before { fake_login_known_user(work.users.first) }
+
+      populate do |n|
+        User.current_user = nil # prevent bugs with unreviewed check
+        create_list(:comment, n, commentable: work.first_chapter)
+      end
+
+      warmup { get unreviewed_work_comments_path(work) }
+
+      it "produces a constant number of queries" do
+        expect do
+          get unreviewed_work_comments_path(work)
+          expect(assigns(:comments).size).to eq(current_scale)
+        end.to perform_constant_number_of_queries
+      end
+    end
+  end
+end

--- a/spec/requests/comments_n_plus_one_spec.rb
+++ b/spec/requests/comments_n_plus_one_spec.rb
@@ -1,6 +1,6 @@
 require "spec_helper"
 
-describe CommentsController do
+describe "n+1 queries in the CommentsController" do
   include LoginMacros
 
   shared_examples "a hierarchical view with constant queries" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,6 +8,7 @@ require "factory_bot"
 require "database_cleaner"
 require "email_spec"
 require "webmock/rspec"
+require "n_plus_one_control/rspec"
 
 DatabaseCleaner.start
 DatabaseCleaner.clean


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6333

## Purpose

When displaying a bunch of comments, try to avoid any database queries involving single comments. This should avoid the n+1 queries problem, where we load n comments in a single query, then perform 1 query for each of the n comments.

In particular, the actions that we address this for are:
- `CommentsController#show`
- `CommentsController#index`
- `CommentsController#unreviewed`
- `CommentsController#show_comments`

Because `CommentsController#index` uses the `comments/commentable` view, this should also reduce the number of comment-related queries in the actions that use that view:
- `WorksController#show` with the `show_comments` param
- `ChaptersController#show` with the `show_comments` param
- `AdminPostsController#show` with the `show_comments` param

But I don't make any guarantees about any non-comment-related queries produced by those controllers.