### PR TITLE
AO3-6254 Move key for single guest kudos

### DIFF
--- a/app/views/kudo_mailer/batch_kudo_notification.html.erb
+++ b/app/views/kudo_mailer/batch_kudo_notification.html.erb
@@ -16,7 +16,7 @@
     %>
 
     <% if kudo_count == 1 && guest_count == 1 %>
-      <%= t(".html.left_kudos.single_guest", commentable_link: commentable_link.html_safe).html_safe %>
+      <%= t(".html.single_guest", commentable_link: commentable_link.html_safe).html_safe %>
     <% else %>
       <%= t(".html.left_kudos", givers_list: givers_list, commentable_link: commentable_link.html_safe, count: kudo_count).html_safe %>
     <% end %>

--- a/app/views/kudo_mailer/batch_kudo_notification.text.erb
+++ b/app/views/kudo_mailer/batch_kudo_notification.text.erb
@@ -16,7 +16,7 @@
 %>
 
 <% if kudo_count == 1 && guest_count == 1 %>
-<%= t(".text.left_kudos.single_guest", commentable_title: commentable_title, commentable_url: commentable_url) %>
+<%= t(".text.single_guest", commentable_title: commentable_title, commentable_url: commentable_url) %>
 <% else %>
 <%= t(".text.left_kudos", givers_list: givers_list, commentable_title: commentable_title, commentable_url: commentable_url, count: kudo_count) %>
 <% end %>

--- a/config/locales/mailers/en.yml
+++ b/config/locales/mailers/en.yml
@@ -37,12 +37,12 @@ en:
         left_kudos:
           one: "%{givers_list} left kudos on %{commentable_link}."
           other: "%{givers_list} left kudos on %{commentable_link}."
-          single_guest: "A guest left kudos on %{commentable_link}."
+        single_guest: "A guest left kudos on %{commentable_link}."
       text:
         left_kudos:
           one: "%{givers_list} left kudos on \"%{commentable_title}\" (%{commentable_url})."
           other: "%{givers_list} left kudos on \"%{commentable_title}\" (%{commentable_url})."
-          single_guest: "A guest left kudos on \"%{commentable_title}\" (%{commentable_url})."
+        single_guest: "A guest left kudos on \"%{commentable_title}\" (%{commentable_url})."
   user_mailer:
     invite_increase_notification:
       subject: "[%{app_name}] New invitations"


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6254

## Purpose

Having `single_guest` under `left_kudos` wasn't working because it wasn't a standard pluralization key. This moves it so it'll work.

## Testing Instructions

Ask Translation if it works.

