### PR TITLE
AO3-6156 Skip logging admin activity for empty edits

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -129,6 +129,8 @@ RSpec/FilePath:
   Exclude:
     # Exception for WorksController, whose many specs need multiple files
     - 'spec/controllers/works/*.rb'
+    # Exception for concern specs, which may test multiple classes
+    - 'spec/models/concerns/**/*.rb'
 
 # Avoid instance variables, except for those not assigned within the spec,
 # e.g. @request.

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -161,7 +161,7 @@ class UsersController < ApplicationController
     authorize @user.profile if logged_in_as_admin?
 
     if @user.profile.update(profile_params)
-      if logged_in_as_admin?
+      if logged_in_as_admin? && @user.profile.ticket_url.present?
         link = view_context.link_to("Ticket ##{@user.profile.ticket_number}", @user.profile.ticket_url)
         AdminActivity.log_action(current_admin, @user, action: "edit profile", summary: link)
       end

--- a/config/locales/models/en.yml
+++ b/config/locales/models/en.yml
@@ -120,3 +120,9 @@ en:
         user_defined_tags_count: "Fandom, relationship, character, and additional tags"
   attributes:
     ticket_number: "Ticket ID"
+  errors:
+    attributes:
+      ticket_number:
+        closed_ticket: "must not be closed"
+        invalid_department: "must be in your department"
+        required: "must exist and not be spam"

--- a/config/locales/models/en.yml
+++ b/config/locales/models/en.yml
@@ -123,6 +123,6 @@ en:
   errors:
     attributes:
       ticket_number:
-        closed_ticket: "must not be closed"
-        invalid_department: "must be in your department"
-        required: "must exist and not be spam"
+        closed_ticket: "must not be closed."
+        invalid_department: "must be in your department."
+        required: "must exist and not be spam."

--- a/features/other_a/profile_edit.feature
+++ b/features/other_a/profile_edit.feature
@@ -48,6 +48,15 @@ Scenario: Change details as an admin
   Then I should see "edit profile"
     And I should see a link "Ticket #480000"
 
+  # Skip logging admin activity if no change was actually made.
+  When I go to editname profile page
+    And I follow "Edit Profile"
+    And I fill in "Ticket ID" with "480000"
+    And I press "Update"
+  Then I should see "Your profile has been successfully updated"
+  When I go to the admin-activities page
+  Then I should see 1 admin activity log entry
+
 Scenario: Changing email address requires reauthenticating
 
   When I follow "Change Email"

--- a/features/step_definitions/admin_steps.rb
+++ b/features/step_definitions/admin_steps.rb
@@ -168,8 +168,12 @@ Given /^I have posted an admin post with comments disabled$/ do
 end
 
 Given "an abuse ticket ID exists" do
-  allow_any_instance_of(ZohoResourceClient).to receive(:find_ticket)
-    .and_return({ "status" => "Open", "departmentId" => ArchiveConfig.ABUSE_ZOHO_DEPARTMENT_ID })
+  ticket = {
+    "departmentId" => ArchiveConfig.ABUSE_ZOHO_DEPARTMENT_ID,
+    "status" => "Open",
+    "webUrl" => Faker::Internet.url
+  }
+  allow_any_instance_of(ZohoResourceClient).to receive(:find_ticket).and_return(ticket)
 end
 
 ### WHEN
@@ -438,6 +442,10 @@ end
 Then /^the work "([^\"]*)" should not be marked as spam/ do |work|
   w = Work.find_by_title(work)
   assert !w.spam?
+end
+
+Then "I should see {int} admin activity log entry/entries" do |count|
+  expect(page).to have_css("tr[id^=admin_activity_]", count: count)
 end
 
 Then /^the user content should be shown as right-to-left$/ do

--- a/features/support/paths.rb
+++ b/features/support/paths.rb
@@ -289,6 +289,8 @@ module NavigationHelpers
       admin_posts_path
     when /^the admin-settings page$/i
       admin_settings_path
+    when /^the admin-activities page$/i
+      admin_activities_path
     when /^the admin-blacklist page$/i
       admin_blacklisted_emails_path
     when /^the manage users page$/

--- a/lib/zoho_resource_client.rb
+++ b/lib/zoho_resource_client.rb
@@ -21,6 +21,8 @@ class ZohoResourceClient
       query: search_params.merge(ticketNumber: ticket_number),
       headers: headers
     ).parsed_response
+
+    # Note that Zoho returns an empty 204 if the ticket is marked as spam.
     return if response.blank? || response.key?("errorCode")
 
     response.fetch("data").first

--- a/spec/models/concerns/justifiable_spec.rb
+++ b/spec/models/concerns/justifiable_spec.rb
@@ -18,6 +18,7 @@ shared_examples "a justifiable model" do
       expect(ZohoResourceClient).not_to receive(:new)
 
       expect(record).to be_valid
+      expect(record.ticket_url).to be_nil
     end
 
     it "requires a ticket ID" do
@@ -26,6 +27,7 @@ shared_examples "a justifiable model" do
       record.assign_attributes(attributes)
       expect(record).not_to be_valid
       expect(record.errors[:ticket_number]).to contain_exactly("can't be blank", "is not a number")
+      expect(record.ticket_url).to be_nil
     end
 
     it "is invalid if the ticket does not exist" do
@@ -34,20 +36,28 @@ shared_examples "a justifiable model" do
 
       record.assign_attributes(attributes.merge(ticket_number: 480_000))
       expect(record).not_to be_valid
-      expect(record.errors[:ticket_number]).to contain_exactly("must exist")
+      expect(record.errors[:ticket_number]).to contain_exactly("must exist and not be spam")
+      expect(record.ticket_url).to be_nil
     end
 
     it "is invalid if the ticket is closed" do
       expect(ZohoResourceClient).to receive(:new).and_return(zoho_resource_client)
-      expect(zoho_resource_client).to receive(:find_ticket).and_return({ "status" => "Closed" })
+      expect(zoho_resource_client).to receive(:find_ticket).and_return({ "status" => "Closed", "webUrl" => Faker::Internet.url })
 
       record.assign_attributes(attributes.merge(ticket_number: 480_000))
       expect(record).not_to be_valid
-      expect(record.errors[:ticket_number]).to contain_exactly("must exist")
+      expect(record.errors[:ticket_number]).to contain_exactly("must not be closed")
+      expect(record.ticket_url).to be_nil
     end
 
     context "when an open policy and abuse ticket exists" do
-      let(:ticket) { { "departmentId" => ArchiveConfig.ABUSE_ZOHO_DEPARTMENT_ID, "status" => "Open" } }
+      let(:ticket) do
+        {
+          "departmentId" => ArchiveConfig.ABUSE_ZOHO_DEPARTMENT_ID,
+          "status" => "Open",
+          "webUrl" => Faker::Internet.url
+        }
+      end
 
       it "is invalid if the admin does not have role policy_and_abuse" do
         expect(ZohoResourceClient).to receive(:new).and_return(zoho_resource_client)
@@ -55,7 +65,8 @@ shared_examples "a justifiable model" do
 
         record.assign_attributes(attributes.merge(ticket_number: 480_000))
         expect(record).not_to be_valid
-        expect(record.errors[:ticket_number]).to contain_exactly("must exist")
+        expect(record.errors[:ticket_number]).to contain_exactly("must be in your department")
+        expect(record.ticket_url).to be_nil
       end
 
       %w[policy_and_abuse superadmin].each do |role|
@@ -66,12 +77,19 @@ shared_examples "a justifiable model" do
 
           record.assign_attributes(attributes.merge(ticket_number: 480_000))
           expect(record).to be_valid
+          expect(record.ticket_url).to eq(ticket["webUrl"])
         end
       end
     end
 
     context "when an open support ticket exists" do
-      let(:ticket) { { "departmentId" => ArchiveConfig.SUPPORT_ZOHO_DEPARTMENT_ID, "status" => "Open" } }
+      let(:ticket) do
+        {
+          "departmentId" => ArchiveConfig.SUPPORT_ZOHO_DEPARTMENT_ID,
+          "status" => "Open",
+          "webUrl" => Faker::Internet.url
+        }
+      end
 
       it "is invalid if the admin does not have role support" do
         expect(ZohoResourceClient).to receive(:new).and_return(zoho_resource_client)
@@ -79,7 +97,8 @@ shared_examples "a justifiable model" do
 
         record.assign_attributes(attributes.merge(ticket_number: 480_000))
         expect(record).not_to be_valid
-        expect(record.errors[:ticket_number]).to contain_exactly("must exist")
+        expect(record.errors[:ticket_number]).to contain_exactly("must be in your department")
+        expect(record.ticket_url).to be_nil
       end
 
       %w[superadmin support].each do |role|
@@ -90,6 +109,7 @@ shared_examples "a justifiable model" do
 
           record.assign_attributes(attributes.merge(ticket_number: 480_000))
           expect(record).to be_valid
+          expect(record.ticket_url).to eq(ticket["webUrl"])
         end
       end
     end

--- a/spec/models/concerns/justifiable_spec.rb
+++ b/spec/models/concerns/justifiable_spec.rb
@@ -36,7 +36,7 @@ shared_examples "a justifiable model" do
 
       record.assign_attributes(attributes.merge(ticket_number: 480_000))
       expect(record).not_to be_valid
-      expect(record.errors[:ticket_number]).to contain_exactly("must exist and not be spam")
+      expect(record.errors[:ticket_number]).to contain_exactly("must exist and not be spam.")
       expect(record.ticket_url).to be_nil
     end
 
@@ -46,7 +46,7 @@ shared_examples "a justifiable model" do
 
       record.assign_attributes(attributes.merge(ticket_number: 480_000))
       expect(record).not_to be_valid
-      expect(record.errors[:ticket_number]).to contain_exactly("must not be closed")
+      expect(record.errors[:ticket_number]).to contain_exactly("must not be closed.")
       expect(record.ticket_url).to be_nil
     end
 
@@ -65,7 +65,7 @@ shared_examples "a justifiable model" do
 
         record.assign_attributes(attributes.merge(ticket_number: 480_000))
         expect(record).not_to be_valid
-        expect(record.errors[:ticket_number]).to contain_exactly("must be in your department")
+        expect(record.errors[:ticket_number]).to contain_exactly("must be in your department.")
         expect(record.ticket_url).to be_nil
       end
 
@@ -97,7 +97,7 @@ shared_examples "a justifiable model" do
 
         record.assign_attributes(attributes.merge(ticket_number: 480_000))
         expect(record).not_to be_valid
-        expect(record.errors[:ticket_number]).to contain_exactly("must be in your department")
+        expect(record.errors[:ticket_number]).to contain_exactly("must be in your department.")
         expect(record.ticket_url).to be_nil
       end
 


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6156

## Purpose

Also add more specific error messages for failed ticket validations.

## Testing Instructions

See issue.