### PR TITLE
AO3-6256 Restore formatting on single guest kudos

### DIFF
--- a/app/views/kudo_mailer/batch_kudo_notification.html.erb
+++ b/app/views/kudo_mailer/batch_kudo_notification.html.erb
@@ -16,7 +16,7 @@
     %>
 
     <% if kudo_count == 1 && guest_count == 1 %>
-      <%= t(".html.single_guest.left_kudos", giver_list: style_bold(t(".html.single_guest.giver_list")), commentable_link: commentable_link.html_safe).html_safe %>
+      <%= t(".html.single_guest.left_kudos", giver_list: style_bold(t(".html.single_guest.giver_list")).html_safe, commentable_link: commentable_link.html_safe).html_safe %>
     <% else %>
       <%= t(".html.left_kudos", givers_list: givers_list, commentable_link: commentable_link.html_safe, count: kudo_count).html_safe %>
     <% end %>

--- a/app/views/kudo_mailer/batch_kudo_notification.html.erb
+++ b/app/views/kudo_mailer/batch_kudo_notification.html.erb
@@ -16,7 +16,7 @@
     %>
 
     <% if kudo_count == 1 && guest_count == 1 %>
-      <%= t(".html.single_guest", commentable_link: commentable_link.html_safe).html_safe %>
+      <%= t(".html.single_guest", giver_list: style_bold(t(".single_guest.giver_list")), commentable_link: commentable_link.html_safe).html_safe %>
     <% else %>
       <%= t(".html.left_kudos", givers_list: givers_list, commentable_link: commentable_link.html_safe, count: kudo_count).html_safe %>
     <% end %>

--- a/app/views/kudo_mailer/batch_kudo_notification.html.erb
+++ b/app/views/kudo_mailer/batch_kudo_notification.html.erb
@@ -16,7 +16,7 @@
     %>
 
     <% if kudo_count == 1 && guest_count == 1 %>
-      <%= t(".html.single_guest", giver_list: style_bold(t(".single_guest.giver_list")), commentable_link: commentable_link.html_safe).html_safe %>
+      <%= t(".html.single_guest.left_kudos", giver_list: style_bold(t(".html.single_guest.giver_list")), commentable_link: commentable_link.html_safe).html_safe %>
     <% else %>
       <%= t(".html.left_kudos", givers_list: givers_list, commentable_link: commentable_link.html_safe, count: kudo_count).html_safe %>
     <% end %>

--- a/config/locales/mailers/en.yml
+++ b/config/locales/mailers/en.yml
@@ -37,7 +37,9 @@ en:
         left_kudos:
           one: "%{givers_list} left kudos on %{commentable_link}."
           other: "%{givers_list} left kudos on %{commentable_link}."
-        single_guest: "A guest left kudos on %{commentable_link}."
+        single_guest:
+          giver_list: "A guest"
+          left_kudos: "%{giver_list} left kudos on %{commentable_link}."
       text:
         left_kudos:
           one: "%{givers_list} left kudos on \"%{commentable_title}\" (%{commentable_url})."

--- a/features/comments_and_kudos/kudos.feature
+++ b/features/comments_and_kudos/kudos.feature
@@ -161,7 +161,7 @@ Feature: Kudos
       And the email should contain "myname2"
       And the email should contain "someone_else"
       And the email should contain "a guest"
-      And the email should contain "A guesssst"
+      And the email should contain "A guest"
       And the email should contain "Awesome Story"
       And the email should contain "Another Awesome Story"
       And the email should contain "Meh Story"

--- a/features/comments_and_kudos/kudos.feature
+++ b/features/comments_and_kudos/kudos.feature
@@ -161,7 +161,7 @@ Feature: Kudos
       And the email should contain "myname2"
       And the email should contain "someone_else"
       And the email should contain "a guest"
-      And the email should contain "A guest"
+      And the email should contain "A guesssst"
       And the email should contain "Awesome Story"
       And the email should contain "Another Awesome Story"
       And the email should contain "Meh Story"

--- a/spec/mailers/kudo_mailer_spec.rb
+++ b/spec/mailers/kudo_mailer_spec.rb
@@ -1,0 +1,45 @@
+require "spec_helper"
+
+describe KudoMailer do
+  describe "batch_kudo_notification" do
+    subject(:email) { KudoMailer.batch_kudo_notification(creator.id, kudos_json) }
+
+    let!(:creator) { work.users.first }
+    let(:work) { create(:work) }
+
+    context "when there is one work" do
+      context "with one guest kudos" do
+        let(:kudos_json) do
+          hash = {}
+          hash["#{work.class.name}_#{work.id}"] = { guest_count: 1, names: [] }
+          hash.to_json
+        end
+
+        it_behaves_like "an email with a valid sender"
+
+        it "has the correct subject line" do
+          subject = "[#{ArchiveConfig.APP_SHORT_NAME}] You've got kudos!"
+          expect(email).to have_subject(subject)
+        end
+
+        # Test both body contents
+        it_behaves_like "a multipart email"
+
+        it_behaves_like "a translated email"
+
+        describe "HTML version" do
+          it "has the correct content" do
+            expect(email).to have_html_part_content("<b style=\"color:#990000\">A guest</b>")
+            expect(email).to have_html_part_content("left kudos on <")
+          end
+        end
+
+        describe "text version" do
+          it "has the correct content" do
+            expect(email).to have_text_part_content("A guest left kudos on \"#{work.title}\"")
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6256

## Purpose

Makes sure that when your work gets a single kudos, and that single kudos is from a guest, the "A guest" portion of "A  guest left kudos on #{work_link}" is red and bold in the HTML email.

## Testing Instructions

Leave a single guest kudos (and no other kudos) on your work. Run `bundle exec rake notifications:deliver_kudos` and make sure the kudos is style correctly.