### PR TITLE
AO3-6291 Rename bookmarkable id indexing field

### DIFF
--- a/app/models/search/bookmark_indexer.rb
+++ b/app/models/search/bookmark_indexer.rb
@@ -51,7 +51,7 @@ class BookmarkIndexer < Indexer
           type: "text",
           analyzer: "simple"
         },
-        id: {
+        sort_id: {
           type: "keyword"
         }
       }

--- a/app/models/search/bookmarkable_indexer.rb
+++ b/app/models/search/bookmarkable_indexer.rb
@@ -26,7 +26,7 @@ class BookmarkableIndexer < Indexer
 
   def document(object)
     object.bookmarkable_json.merge(
-      id: document_id(object.id)
+      sort_id: document_id(object.id)
     )
   end
 

--- a/app/models/search/bookmarkable_query.rb
+++ b/app/models/search/bookmarkable_query.rb
@@ -103,7 +103,7 @@ class BookmarkableQuery < Query
       sort_hash = { _score: { order: sort_direction } }
     end
 
-    [sort_hash, { id: { order: sort_direction } }]
+    [sort_hash, { sort_id: { order: sort_direction } }]
   end
 
   # Define the aggregations for the search


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [ ] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [x] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [x] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-6291

## Purpose

Refer to the issue's comments.

Unsure if I implemented suggestion correctly, as I am unable to reproduce the original failure and not sure of the setup.

Not sure if the "id - keyword" field simply can be renamed or if I should keep id with type "long" there as well.
Locally with dev data from testing I now had the opposite problem from reported - re-indexing bookmarks jobs failed because id was not found, so got error on fandom/bookmarks pages. Had to run indexing job to fix.
Not sure if same could happen on staging if it was possible to create new bookmarks, or if failing re-indexing job was enough to prevent any inconsistencies.

## Credit

korrien, she/her
