### PR TITLE
AO3-6307 Don't translate key names in creatorship emails

### DIFF
--- a/app/views/user_mailer/creatorship_notification.html.erb
+++ b/app/views/user_mailer/creatorship_notification.html.erb
@@ -1,4 +1,4 @@
-<% creation_type = @creation.class.name.downcase %>
+<% creation_type = @creation.class.name.underscore %>
 <% content_for :message do %>
   <p>
     <%= t(".intro_#{creation_type}", adding_user: @adding_user.login, pseud: @creatorship.pseud.name) %>

--- a/app/views/user_mailer/creatorship_notification.html.erb
+++ b/app/views/user_mailer/creatorship_notification.html.erb
@@ -1,4 +1,4 @@
-<% creation_type = @creation.model_name.human.downcase %>
+<% creation_type = @creation.class.name.downcase %>
 <% content_for :message do %>
   <p>
     <%= t(".intro_#{creation_type}", adding_user: @adding_user.login, pseud: @creatorship.pseud.name) %>

--- a/app/views/user_mailer/creatorship_notification.text.erb
+++ b/app/views/user_mailer/creatorship_notification.text.erb
@@ -1,4 +1,4 @@
-<% creation_type = @creation.class.name.downcase %>
+<% creation_type = @creation.class.name.underscore %>
 <% content_for :message do %>
 <%= t(".intro_#{creation_type}", adding_user: @adding_user.login, pseud: @creatorship.pseud.name) %>
 

--- a/app/views/user_mailer/creatorship_notification.text.erb
+++ b/app/views/user_mailer/creatorship_notification.text.erb
@@ -1,4 +1,4 @@
-<% creation_type = @creation.model_name.human.downcase %>
+<% creation_type = @creation.class.name.downcase %>
 <% content_for :message do %>
 <%= t(".intro_#{creation_type}", adding_user: @adding_user.login, pseud: @creatorship.pseud.name) %>
 

--- a/app/views/user_mailer/creatorship_notification_archivist.html.erb
+++ b/app/views/user_mailer/creatorship_notification_archivist.html.erb
@@ -1,4 +1,4 @@
-<% creation_type = @creation.class.name.downcase %>
+<% creation_type = @creation.class.name.underscore %>
 <% content_for :message do %>
   <p>
     <%= t(".intro_#{creation_type}", archivist: @archivist.login, pseud: @creatorship.pseud.name) %>

--- a/app/views/user_mailer/creatorship_notification_archivist.html.erb
+++ b/app/views/user_mailer/creatorship_notification_archivist.html.erb
@@ -1,4 +1,4 @@
-<% creation_type = @creation.model_name.human.downcase %>
+<% creation_type = @creation.class.name.downcase %>
 <% content_for :message do %>
   <p>
     <%= t(".intro_#{creation_type}", archivist: @archivist.login, pseud: @creatorship.pseud.name) %>

--- a/app/views/user_mailer/creatorship_notification_archivist.text.erb
+++ b/app/views/user_mailer/creatorship_notification_archivist.text.erb
@@ -1,4 +1,4 @@
-<% creation_type = @creation.model_name.human.downcase %>
+<% creation_type = @creation.class.name.downcase %>
 <% content_for :message do %>
 <%= t(".intro_#{creation_type}", archivist: @archivist.login, pseud: @creatorship.pseud.name) %>
 

--- a/app/views/user_mailer/creatorship_notification_archivist.text.erb
+++ b/app/views/user_mailer/creatorship_notification_archivist.text.erb
@@ -1,4 +1,4 @@
-<% creation_type = @creation.class.name.downcase %>
+<% creation_type = @creation.class.name.underscore %>
 <% content_for :message do %>
 <%= t(".intro_#{creation_type}", archivist: @archivist.login, pseud: @creatorship.pseud.name) %>
 

--- a/app/views/user_mailer/creatorship_request.html.erb
+++ b/app/views/user_mailer/creatorship_request.html.erb
@@ -1,4 +1,4 @@
-<% creation_type = @creation.model_name.human.downcase %>
+<% creation_type = @creation.class.name.downcase %>
 <% content_for :message do %>
   <p>
     <%= t(".intro_#{creation_type}", inviting_user: @inviting_user.login, pseud: @creatorship.pseud.name) %>

--- a/app/views/user_mailer/creatorship_request.html.erb
+++ b/app/views/user_mailer/creatorship_request.html.erb
@@ -11,7 +11,7 @@
   </p>
 
   <p>
-    <%= t(".html.instructions", type: creation_type,
+    <%= t(".html.instructions",
           page_name: style_link(t(".html.page_name"), user_creatorships_url(@user))).html_safe %>
   </p>
 <% end %>

--- a/app/views/user_mailer/creatorship_request.html.erb
+++ b/app/views/user_mailer/creatorship_request.html.erb
@@ -1,4 +1,4 @@
-<% creation_type = @creation.class.name.downcase %>
+<% creation_type = @creation.class.name.underscore %>
 <% content_for :message do %>
   <p>
     <%= t(".intro_#{creation_type}", inviting_user: @inviting_user.login, pseud: @creatorship.pseud.name) %>

--- a/app/views/user_mailer/creatorship_request.text.erb
+++ b/app/views/user_mailer/creatorship_request.text.erb
@@ -1,4 +1,4 @@
-<% creation_type = @creation.class.name.downcase %>
+<% creation_type = @creation.class.name.underscore %>
 <% content_for :message do %>
 <%= t(".intro_#{creation_type}", inviting_user: @inviting_user.login, pseud: @creatorship.pseud.name) %>
 

--- a/app/views/user_mailer/creatorship_request.text.erb
+++ b/app/views/user_mailer/creatorship_request.text.erb
@@ -7,5 +7,5 @@
       url: polymorphic_url(@creation),
       pseuds: @creation.pseuds.map(&:byline).to_sentence) %>
 
-<%= t(".text.instructions", type: creation_type, url: user_creatorships_url(@user)) %>
+<%= t(".text.instructions", url: user_creatorships_url(@user)) %>
 <% end %>

--- a/app/views/user_mailer/creatorship_request.text.erb
+++ b/app/views/user_mailer/creatorship_request.text.erb
@@ -1,4 +1,4 @@
-<% creation_type = @creation.model_name.human.downcase %>
+<% creation_type = @creation.class.name.downcase %>
 <% content_for :message do %>
 <%= t(".intro_#{creation_type}", inviting_user: @inviting_user.login, pseud: @creatorship.pseud.name) %>
 


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6307

## Purpose

* Remove unused variables from creatorship request emails.
* Use `@creation.class.name.downcase` instead of `@creation.model_name.human.downcase` for key names -- the latter will get the translated model name in the email locale, which will result in nonexistent keys like `.intro_capitulo` or `intro_obra` instead of `.intro_chapter` and `.intro_work`. 

## Testing Instructions

Refer to Jira.