### PR TITLE
AO3-5677 AO3-6041 Remove unused methods & rescue block from the UsersController.

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -7,23 +7,6 @@ class UsersController < ApplicationController
   before_action :check_ownership_or_admin, only: [:edit, :update]
   skip_before_action :store_location, only: [:end_first_login]
 
-  # This is meant to rescue from race conditions that sometimes occur on user creation
-  # The unique index on login (database level) prevents the duplicate user from being created,
-  # but ideally we can still send the user the activation code and show them the confirmation page
-  rescue_from ActiveRecord::RecordNotUnique do |exception|
-    # ensure we actually have a duplicate user situation
-    if exception.message =~ /Mysql2?::Error: Duplicate entry/i &&
-       @user && User.count(conditions: { login: @user.login }) > 0 &&
-       # and that we can find the original, valid user record
-       (@user = User.find_by(login: @user.login))
-      notify_and_show_confirmation_screen
-    else
-      # re-raise the exception and make it catchable by Rails and Airbrake
-      # (see http://www.simonecarletti.com/blog/2009/11/re-raise-a-ruby-exception-in-a-rails-rescue_from-statement/)
-      rescue_action_without_handler(exception)
-    end
-  end
-
   def load_user
     @user = User.find_by(login: params[:id])
     @check_ownership_of = @user
@@ -97,16 +80,6 @@ class UsersController < ApplicationController
       @user.reload
       render :change_username
     end
-  end
-
-  def notify_and_show_confirmation_screen
-    # deliver synchronously to avoid getting caught in backed-up mail queue
-    UserMailer.signup_notification(@user.id).deliver_now
-
-    flash[:notice] = ts("During testing you can activate via <a href='%{activation_url}'>your activation url</a>.",
-                        activation_url: activate_path(@user.confirmation_token)).html_safe if Rails.env.development?
-
-    render 'confirmation'
   end
 
   def activate
@@ -374,13 +347,6 @@ class UsersController < ApplicationController
   end
 
   private
-
-  def user_params
-    params.require(:user).permit(
-      :login, :email, :age_over_13, :terms_of_service,
-      :password, :password_confirmation
-    )
-  end
 
   def profile_params
     params.require(:profile_attributes).permit(


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5677
https://otwarchive.atlassian.net/browse/AO3-6041

## Purpose

The `UsersController` is no longer used for creating `User` objects, so we can clean up some unused code.