### PR TITLE
AO3-6148 Limit admin roles that can see IPs on works/comments, and show email for guest comments.

### DIFF
--- a/app/policies/comment_policy.rb
+++ b/app/policies/comment_policy.rb
@@ -26,4 +26,8 @@ class CommentPolicy < ApplicationPolicy
   alias destroy? can_destroy_comment?
   alias approve? can_mark_comment_spam?
   alias reject? can_mark_comment_spam?
+
+  def show_email?
+    user_has_roles?(%w[policy_and_abuse support superadmin])
+  end
 end

--- a/app/policies/user_creation_policy.rb
+++ b/app/policies/user_creation_policy.rb
@@ -49,4 +49,8 @@ class UserCreationPolicy < ApplicationPolicy
   alias hide? can_hide_creations?
   alias set_spam? can_mark_creations_spam?
   alias destroy? can_destroy_creations?
+
+  def show_ip_address?
+    user_has_roles?(%w[superadmin policy_and_abuse])
+  end
 end

--- a/app/views/comments/_single_comment.html.erb
+++ b/app/views/comments/_single_comment.html.erb
@@ -62,7 +62,10 @@
         <% end %>
       <% end %><!-- end caching -->
 
-      <% if logged_in_as_admin? %>
+      <% if policy(single_comment).show_email? && single_comment.email.present? %>
+        <p class="email"><%= ts("Email: %{email}", email: single_comment.email) %></p>
+      <% end %>
+      <% if policy(:user_creation).show_ip_address? %>
         <p class="ip"><%= ts("IP Address: %{ip_address}", ip_address: single_comment.ip_address.blank? ? "No address recorded" : single_comment.ip_address) %></p>
       <% end %>
       <%= render "comments/comment_actions", comment: single_comment %>

--- a/app/views/works/_meta.html.erb
+++ b/app/views/works/_meta.html.erb
@@ -64,7 +64,7 @@
 
       <%= work_meta_list(@work, @chapter) %>
       </dd>
-      <% if logged_in_as_admin? %>
+      <% if policy(:user_creation).show_ip_address? %>
         <dt class="ip">
           <%= ts('IP Address:') %>
         </dt>
@@ -75,6 +75,8 @@
              <%= @work.ip_address %>
           <% end %>
         </dd>
+      <% end %>
+      <% if logged_in_as_admin? %>
         <dt class="akismet">
           <%= ts('Akismet Reported As Spam:') %>
         </dt>

--- a/features/comments_and_kudos/add_comment.feature
+++ b/features/comments_and_kudos/add_comment.feature
@@ -30,25 +30,6 @@ Scenario: When logged in I can comment on a work
     And I follow "Comments (1)"
   Then I should see "commenter on Chapter 1" within "h4.heading.byline"
 
-  Scenario: IP address of the commenter are displayed only to an admin
-
-  Given I have no works or comments
-  When I am logged in as "author"
-    And I post the work "The One Where Neal is Awesome"
-  When I am logged in as "commenter"
-    And I view the work "The One Where Neal is Awesome"
-    And I fill in "Comment" with "I loved this!"
-    And I press "Comment"
-  Then I should see "Comment created!"
-    And I should not see "IP Address"
-  When I am logged in as "author"
-    And I view the work "The One Where Neal is Awesome"
-  Then I should not see "IP Address"
-  When I am logged in as an admin
-    And I view the work "The One Where Neal is Awesome"
-  Then I should see "IP Address"
-
-
 Scenario: I cannot comment with a pseud that I don't own
 
   Given the work "Random Work"

--- a/features/comments_and_kudos/admin_info.feature
+++ b/features/comments_and_kudos/admin_info.feature
@@ -1,0 +1,40 @@
+Feature: Some admins can see IP addresses and emails for comments
+  Scenario: Admin info for comments isn't visible to the work's owner
+    Given the work "Random Work"
+      And a guest comment on the work "Random Work"
+    When I am logged in as the author of "Random Work"
+      And I view the work "Random Work" with comments
+    Then I should not see "IP Address:" within ".work.meta"
+      And I should not see "IP Address:" within ".comment.group"
+      And I should not see "Email:" within ".comment.group"
+
+  Scenario Outline: Only certain admins can see IP addresses and email addresses for comments
+    Given the work "Random Work"
+      And a guest comment on the work "Random Work"
+    When I am logged in as a "<role>" admin
+      And I view the work "Random Work" with comments
+    Then I <should_ip> see "IP Address:" within ".work.meta"
+      And I <should_ip> see "IP Address:" within ".comment.group"
+      And I <should_email> see "Email:" within ".comment.group"
+
+  Examples:
+    | role             | should_ip  | should_email |
+    | superadmin       | should     | should       |
+    | policy_and_abuse | should     | should       |
+    | support          | should not | should       |
+    | board            | should not | should not   |
+    | communications   | should not | should not   |
+    | docs             | should not | should not   |
+    | open_doors       | should not | should not   |
+    | tag_wrangling    | should not | should not   |
+    | translation      | should not | should not   |
+
+  Scenario: No one can see email addresses for comments by registered users
+    Given the work "Random Work"
+      And I am logged in as "commenter"
+      And I post the comment "Hello" on the work "Random Work"
+    When I am logged in as a "superadmin" admin
+      And I view the work "Random Work" with comments
+    Then I should see "IP Address:" within ".work.meta"
+      And I should see "IP Address:" within ".comment.group"
+      But I should not see "Email:" within ".comment.group"

--- a/features/comments_and_kudos/admin_info.feature
+++ b/features/comments_and_kudos/admin_info.feature
@@ -1,4 +1,13 @@
 Feature: Some admins can see IP addresses and emails for comments
+  Scenario: Admin info for comments isn't visible to logged-out users
+    Given the work "Random Work"
+      And a guest comment on the work "Random Work"
+    When I am a visitor
+      And I view the work "Random Work" with comments
+    Then I should not see "IP Address:" within ".work.meta"
+      And I should not see "IP Address:" within ".comment.group"
+      And I should not see "Email:" within ".comment.group"
+
   Scenario: Admin info for comments isn't visible to the work's owner
     Given the work "Random Work"
       And a guest comment on the work "Random Work"

--- a/features/importing/work_import.feature
+++ b/features/importing/work_import.feature
@@ -123,7 +123,7 @@ Feature: Import Works
   Scenario: Admins see IP address on imported works
     Given I import "http://import-site-with-tags" with a mock website
       And I press "Post"
-    When I am logged in as an admin
+    When I am logged in as a "policy_and_abuse" admin
       And I go to the "Detected Title" work page
     Then I should see "IP Address: 127.0.0.1"
 
@@ -131,7 +131,7 @@ Feature: Import Works
     Given I start importing "http://import-site-with-tags" with a mock website
       And I check "Post without previewing"
       And I press "Import"
-    When I am logged in as an admin
+    When I am logged in as a "policy_and_abuse" admin
       And I go to the "Detected Title" work page
     Then I should see "IP Address: 127.0.0.1"
 
@@ -141,7 +141,7 @@ Feature: Import Works
       http://import-site-without-tags
       http://second-import-site-without-tags
       """
-    When I am logged in as an admin
+    When I am logged in as a "policy_and_abuse" admin
       And I go to the "Untitled Imported Work" work page
     Then I should see "Chapters:2/2"
       And I should see "IP Address: 127.0.0.1"

--- a/features/step_definitions/comment_steps.rb
+++ b/features/step_definitions/comment_steps.rb
@@ -14,6 +14,11 @@ Given /^I have the receive no comment notifications setup$/ do
   user.preference.save
 end
 
+Given "a guest comment on the work {string}" do |title|
+  work = Work.find_by(title: title)
+  FactoryBot.create(:comment, :by_guest, commentable: work.first_chapter)
+end
+
 # THEN
 
 Then /^the comment's posted date should be nowish$/ do

--- a/public/stylesheets/site/2.0/24-role-admin.css
+++ b/public/stylesheets/site/2.0/24-role-admin.css
@@ -43,7 +43,7 @@ div.admin + h3.landmark {
   margin: 0.643em;
 }
 
-.comment .ip {
+.comment .ip, .comment .email {
   margin: 1.929em 0.643em 0.643em;
   text-align: right;
 }


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6148

## Purpose

1. Restrict the display of the IP addresses on works and comments so that only Superadmins and Policy & Abuse can see them.
2. Add a line displaying the email address of guest comments to Superadmins, Policy & Abuse, and Support.

## Testing Instructions

See JIRA.