### PR TITLE
AO3-6342 Limit ability to list, create, update, and destroy admin banners.

### DIFF
--- a/app/controllers/admin/banners_controller.rb
+++ b/app/controllers/admin/banners_controller.rb
@@ -2,27 +2,29 @@ class Admin::BannersController < Admin::BaseController
 
   # GET /admin/banners
   def index
+    authorize(AdminBanner)
+
     @admin_banners = AdminBanner.order("id DESC").paginate(page: params[:page])
   end
 
   # GET /admin/banners/1
   def show
-    @admin_banner = AdminBanner.find(params[:id])
+    @admin_banner = authorize AdminBanner.find(params[:id])
   end
 
   # GET /admin/banners/new
   def new
-    @admin_banner = AdminBanner.new
+    @admin_banner = authorize AdminBanner.new
   end
 
   # GET /admin/banners/1/edit
   def edit
-    @admin_banner = AdminBanner.find(params[:id])
+    @admin_banner = authorize AdminBanner.find(params[:id])
   end
 
   # POST /admin/banners
   def create
-    @admin_banner = AdminBanner.new(admin_banner_params)
+    @admin_banner = authorize AdminBanner.new(admin_banner_params)
 
     if @admin_banner.save
       if @admin_banner.active?
@@ -39,7 +41,7 @@ class Admin::BannersController < Admin::BaseController
 
   # PUT /admin/banners/1
   def update
-    @admin_banner = AdminBanner.find(params[:id])
+    @admin_banner = authorize AdminBanner.find(params[:id])
 
     if !@admin_banner.update(admin_banner_params)
       render action: 'edit'
@@ -59,12 +61,12 @@ class Admin::BannersController < Admin::BaseController
 
   # GET /admin/banners/1/confirm_delete
   def confirm_delete
-    @admin_banner = AdminBanner.find(params[:id])
+    @admin_banner = authorize AdminBanner.find(params[:id])
   end
 
   # DELETE /admin/banners/1
   def destroy
-    @admin_banner = AdminBanner.find(params[:id])
+    @admin_banner = authorize AdminBanner.find(params[:id])
     @admin_banner.destroy
 
     flash[:notice] = ts('Banner successfully deleted.')

--- a/app/policies/admin_banner_policy.rb
+++ b/app/policies/admin_banner_policy.rb
@@ -1,11 +1,10 @@
 class AdminBannerPolicy < ApplicationPolicy
-  def manage?
+  def index?
     user_has_roles?(%w[superadmin board communications support])
   end
 
-  alias index? manage?
-  alias show? manage?
-  alias create? manage?
-  alias update? manage?
-  alias destroy? manage?
+  alias show? index?
+  alias create? index?
+  alias update? index?
+  alias destroy? index?
 end

--- a/app/policies/admin_banner_policy.rb
+++ b/app/policies/admin_banner_policy.rb
@@ -1,0 +1,11 @@
+class AdminBannerPolicy < ApplicationPolicy
+  def manage?
+    user_has_roles?(%w[superadmin board communications support])
+  end
+
+  alias index? manage?
+  alias show? manage?
+  alias create? manage?
+  alias update? manage?
+  alias destroy? manage?
+end

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -34,6 +34,10 @@ class ApplicationPolicy
     false
   end
 
+  def confirm_delete?
+    destroy?
+  end
+
   # Explicitly check that the user is an admin because regular users can have
   # roles (e.g. archivist) as well, but we don't handle those with pundit.
   def user_has_roles?(roles)

--- a/app/views/admin/_header.html.erb
+++ b/app/views/admin/_header.html.erb
@@ -36,7 +36,7 @@
     <li><%= link_to ts("Settings", key: "header"), admin_settings_path %></li>
   <% end %>
 
-  <% if policy(AdminBanner).manage? %>
+  <% if policy(AdminBanner).index? %>
     <li><%= link_to ts("Banners", key: "header"), admin_banners_path %></li>
   <% end %>
 

--- a/app/views/admin/_header.html.erb
+++ b/app/views/admin/_header.html.erb
@@ -35,7 +35,11 @@
   <% if policy(AdminSetting).can_view_settings? %>
     <li><%= link_to ts("Settings", key: "header"), admin_settings_path %></li>
   <% end %>
-  <li><%= link_to ts("Banners", key: "header"), admin_banners_path %></li>
+
+  <% if policy(AdminBanner).manage? %>
+    <li><%= link_to ts("Banners", key: "header"), admin_banners_path %></li>
+  <% end %>
+
   <li class="dropdown">
     <%= link_to ts("Skins", key: "header"), admin_skins_path %>
     <ul class="menu" role="menu">

--- a/factories/admin_banner.rb
+++ b/factories/admin_banner.rb
@@ -1,4 +1,4 @@
-require 'faker'
+require "faker"
 
 FactoryBot.define do
   factory :admin_banner do

--- a/factories/admin_banner.rb
+++ b/factories/admin_banner.rb
@@ -1,0 +1,13 @@
+require 'faker'
+
+FactoryBot.define do
+  factory :admin_banner do
+    sequence(:content) { |n| "#{Faker::Lorem.paragraph} (#{n})" }
+
+    active { false }
+
+    trait :active do
+      active { true }
+    end
+  end
+end

--- a/features/other_a/banner_general.feature
+++ b/features/other_a/banner_general.feature
@@ -83,7 +83,7 @@ Scenario: User can turn off banner in preferences, but will still see a banner w
 Scenario: Admin can delete a banner and it will no longer be shown to users
   Given there are no banners
     And an admin creates an active banner
-  When I am logged in as an admin
+  When I am logged in as a "communications" admin
     And I am on the admin_banners page
     And I follow "Delete"
     And I press "Yes, Delete Banner"
@@ -93,14 +93,14 @@ Scenario: Admin can delete a banner and it will no longer be shown to users
 
 Scenario: Admin should not have option to make minor updates on a new banner
   Given there are no banners
-    And I am logged in as an admin
+    And I am logged in as a "communications" admin
   When I am on the new_admin_banner page
   Then I should not see "This is a minor update (Do not turn the banner back on for users who have dismissed it)"
 
 Scenario: Admin should not have option to make minor updates on banner that is not active
   Given there are no banners
     And an admin creates a banner
-  When I am logged in as an admin
+  When I am logged in as a "communications" admin
     And I am on the admin_banners page
     And I follow "Edit"
   Then I should not see "This is a minor update (Do not turn the banner back on for users who have dismissed it)"
@@ -118,5 +118,3 @@ Scenario: Admin can make minor changes to the text of an active banner without t
   Then I should see the banner with minor edits
   When I am logged in as "banner_tester_4"
   Then I should see the banner with minor edits
-  
-  

--- a/features/step_definitions/banner_steps.rb
+++ b/features/step_definitions/banner_steps.rb
@@ -9,7 +9,7 @@ end
 ### WHEN
 
 When /^an admin creates an?( active)?(?: "([^\"]*)")? banner$/ do |active, banner_type|
-  step %{I am logged in as an admin}
+  step %{I am logged in as a "communications" admin}
   visit(new_admin_banner_path)
   fill_in("admin_banner_content", with: "This is some banner text")
   if banner_type.present?
@@ -27,7 +27,7 @@ When /^an admin creates an?( active)?(?: "([^\"]*)")? banner$/ do |active, banne
 end
 
 When /^an admin deactivates the banner$/ do
-  step %{I am logged in as an admin}
+  step %{I am logged in as a "communications" admin}
   visit(admin_banners_path)
   step %{I follow "Edit"}
   uncheck("admin_banner_active")
@@ -36,7 +36,7 @@ When /^an admin deactivates the banner$/ do
 end
 
 When /^an admin edits the active banner$/ do
-  step %{I am logged in as an admin}
+  step %{I am logged in as a "communications" admin}
   visit(admin_banners_path)
   step %{I follow "Edit"}
   fill_in("admin_banner_content", with: "This is some edited banner text")
@@ -45,7 +45,7 @@ When /^an admin edits the active banner$/ do
 end
 
 When /^an admin makes a minor edit to the active banner$/ do
-  step %{I am logged in as an admin}
+  step %{I am logged in as a "communications" admin}
   visit(admin_banners_path)
   step %{I follow "Edit"}
   fill_in("admin_banner_content", with: "This is some banner text!")
@@ -55,7 +55,7 @@ When /^an admin makes a minor edit to the active banner$/ do
 end
 
 When /^an admin creates a different active banner$/ do
-  step %{I am logged in as an admin}
+  step %{I am logged in as a "communications" admin}
   visit(new_admin_banner_path)
   fill_in("admin_banner_content", with: "This is new banner text")
   check("admin_banner_active")

--- a/spec/controllers/admin/banners_controller_spec.rb
+++ b/spec/controllers/admin/banners_controller_spec.rb
@@ -1,0 +1,109 @@
+require "spec_helper"
+
+describe Admin::BannersController do
+  include LoginMacros
+  include RedirectExpectationHelper
+
+  let(:admin_banner) { create(:admin_banner) }
+  let(:admin_banner_params) { attributes_for(:admin_banner) }
+
+  shared_examples "only authorized admins are allowed" do
+    %w[support communications superadmin board].each do |role|
+      it "succeeds for #{role} admins" do
+        fake_login_admin(create(:admin, roles: [role]))
+        subject
+        success
+      end
+    end
+
+    %w[translation tag_wrangling docs policy_and_abuse open_doors].each do |role|
+      it "displays an error to #{role} admins" do
+        fake_login_admin(create(:admin, roles: [role]))
+        subject
+        it_redirects_to_with_error(root_path, "Sorry, only an authorized admin can access the page you were trying to reach.")
+      end
+    end
+  end
+
+  describe "GET #index" do
+    subject { get :index }
+
+    let(:success) do
+      expect(response).to render_template(:index)
+    end
+
+    it_behaves_like "only authorized admins are allowed"
+  end
+
+  describe "GET #show" do
+    subject { get :show, params: { id: admin_banner } }
+
+    let(:success) do
+      expect(response).to render_template(:show)
+    end
+
+    it_behaves_like "only authorized admins are allowed"
+  end
+
+  describe "GET #new" do
+    subject { get :new }
+
+    let(:success) do
+      expect(response).to render_template(:new)
+    end
+
+    it_behaves_like "only authorized admins are allowed"
+  end
+
+  describe "POST #create" do
+    subject { post :create, params: { admin_banner: admin_banner_params } }
+
+    let(:success) do
+      it_redirects_to_with_notice(assigns[:admin_banner], "Banner successfully created.")
+    end
+
+    it_behaves_like "only authorized admins are allowed"
+  end
+
+  describe "GET #edit" do
+    subject { get :edit, params: { id: admin_banner } }
+
+    let(:success) do
+      expect(response).to render_template(:edit)
+    end
+
+    it_behaves_like "only authorized admins are allowed"
+  end
+
+  describe "PUT #update" do
+    subject { put :update, params: { id: admin_banner, admin_banner: admin_banner_params } }
+
+    let(:success) do
+      expect { admin_banner.reload }.to change { admin_banner.content }
+      it_redirects_to_with_notice(admin_banner, "Banner successfully updated.")
+    end
+
+    it_behaves_like "only authorized admins are allowed"
+  end
+
+  describe "GET #confirm_delete" do
+    subject { get :confirm_delete, params: { id: admin_banner } }
+
+    let(:success) do
+      expect(response).to render_template(:confirm_delete)
+    end
+
+    it_behaves_like "only authorized admins are allowed"
+  end
+
+  describe "DELETE #destroy" do
+    subject { delete :destroy, params: { id: admin_banner } }
+
+    let(:success) do
+      expect { admin_banner.reload }.to raise_exception(ActiveRecord::RecordNotFound)
+      it_redirects_to_with_notice(admin_banners_path, "Banner successfully deleted.")
+    end
+
+    it_behaves_like "only authorized admins are allowed"
+  end
+end


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6342

## Purpose

Add a new policy class for `AdminBanner`s, with all permissions set to allow only four admin roles: superadmin, support, communications, and board. Also modifies the controller to call `authorize` for each action, and hides the "Banner" link for other admins.