### PR TITLE
AO3-6290 "Chapter # of [title]" in co-creation emails is not translatable

### DIFF
--- a/app/helpers/mailer_helper.rb
+++ b/app/helpers/mailer_helper.rb
@@ -103,7 +103,7 @@ module MailerHelper
   # emails.
   def creation_title(creation)
     if creation.is_a?(Chapter)
-      t("mailer.general.creation.title_with_chapter",
+      t("mailer.general.creation.title_with_chapter_number",
          position: creation.position, title: creation.work.title)
     else
       creation.title

--- a/app/helpers/mailer_helper.rb
+++ b/app/helpers/mailer_helper.rb
@@ -103,7 +103,7 @@ module MailerHelper
   # emails.
   def creation_title(creation)
     if creation.is_a?(Chapter)
-      ts("Chapter %{position} of %{title}",
+      t("mailer.general.creation.title_with_chapter",
          position: creation.position, title: creation.work.title)
     else
       creation.title

--- a/config/locales/mailers/en.yml
+++ b/config/locales/mailers/en.yml
@@ -14,6 +14,7 @@ en:
       creation:
         link_with_word_count: "%{creation_link} (%{word_count})"
         title_with_word_count: "\"%{creation_title}\" (%{word_count})"
+        title_with_chapter: "Chapter %{position} of %{title}"
         word_count:
           one: "%{count} word"
           other: "%{count} words"

--- a/config/locales/mailers/en.yml
+++ b/config/locales/mailers/en.yml
@@ -14,7 +14,7 @@ en:
       creation:
         link_with_word_count: "%{creation_link} (%{word_count})"
         title_with_word_count: "\"%{creation_title}\" (%{word_count})"
-        title_with_chapter: "Chapter %{position} of %{title}"
+        title_with_chapter_number: "Chapter %{position} of %{title}"
         word_count:
           one: "%{count} word"
           other: "%{count} words"

--- a/config/locales/phrase-exports/zh-CN.yml
+++ b/config/locales/phrase-exports/zh-CN.yml
@@ -71,6 +71,7 @@ zh-CN:
       creation:
         link_with_word_count: "%{creation_link}（%{word_count}）"
         title_with_word_count: '"%{creation_title}"（%{word_count}）'
+        title_with_chapter: "%{title} 第%{position}章"
         word_count:
           other: "%{count} 字符"
       footer:

--- a/config/locales/phrase-exports/zh-CN.yml
+++ b/config/locales/phrase-exports/zh-CN.yml
@@ -71,7 +71,6 @@ zh-CN:
       creation:
         link_with_word_count: "%{creation_link}（%{word_count}）"
         title_with_word_count: '"%{creation_title}"（%{word_count}）'
-        title_with_chapter: "%{title} 第%{position}章"
         word_count:
           other: "%{count} 字符"
       footer:

--- a/spec/helpers/mailer_helper_spec.rb
+++ b/spec/helpers/mailer_helper_spec.rb
@@ -14,7 +14,7 @@ describe MailerHelper do
   describe "#creation_title" do
     context "when creation is a work" do
       it "returns the work title" do
-        expect(creation_title(work)).to eq("#{work.title}")
+        expect(creation_title(work)).to eq(work.title)
       end
     end
 

--- a/spec/helpers/mailer_helper_spec.rb
+++ b/spec/helpers/mailer_helper_spec.rb
@@ -14,7 +14,7 @@ describe MailerHelper do
   describe "#creation_title" do
     context "when creation is a series" do
       it "returns the series title" do
-        expect(creation_title(work)).to eq(work.title)
+        expect(creation_title(series)).to eq(series.title)
       end
     end
 

--- a/spec/helpers/mailer_helper_spec.rb
+++ b/spec/helpers/mailer_helper_spec.rb
@@ -11,6 +11,20 @@ describe MailerHelper do
     end
   end
 
+  describe "#creation_title" do
+    context "when creation is a work" do
+      it "returns the work title" do
+        expect(creation_title(work)).to eq("#{work.title}")
+      end
+    end
+
+    context "when creation is a chapter" do
+      it "returns the work title with the chapter number" do
+        expect(creation_title(chapter)).to eq("Chapter #{chapter.position} of #{work.title}")
+      end
+    end
+  end
+
   describe "#creation_link_with_word_count" do
     context "when creation is a chapter" do
       it "returns hyperlinked full_chapter_title and parenthetical word count" do

--- a/spec/helpers/mailer_helper_spec.rb
+++ b/spec/helpers/mailer_helper_spec.rb
@@ -12,6 +12,12 @@ describe MailerHelper do
   end
 
   describe "#creation_title" do
+    context "when creation is a series" do
+      it "returns the series title" do
+        expect(creation_title(work)).to eq(work.title)
+      end
+    end
+
     context "when creation is a work" do
       it "returns the work title" do
         expect(creation_title(work)).to eq(work.title)


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [x] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [x] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [x] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-6290

## Purpose

Translate "Chapter # of [title]" in co-creation emails.

## Testing Instructions

See JIRA ticket.

## Credit

EchoEkhi (He/him)
