### PR TITLE
AO3-6159 Corrected pseud deletion preview text

### DIFF
--- a/app/views/pseuds/delete_preview.html.erb
+++ b/app/views/pseuds/delete_preview.html.erb
@@ -1,8 +1,8 @@
 <h2 class="heading"><%=h 'Pseud deletion' %></h2>
 
 <p>
-  When you delete your pseud, any works and series you have written under it will be transferred to
-  your default pseud. Any comments you have left using it will be made anonymous.
+  When you delete your pseud, any works, series, or comments you have created under it will be 
+  transferred to your default pseud.
 </p>
 
 <% if @pseud.bookmarks %>


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?

* [x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [ ] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)? (There were no relevant tests to add)
* [x] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [x] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-6159 
## Purpose

This PR corrects the text that's displayed when previewing the deletion of a pseud.

## Testing Instructions

The instructions on the Jira issue should be enough.
## References

Nothing to add.

## Credit

C.M. Carreiro, she/they pronouns
