### PR TITLE
AO3-6351 Fix comment threads from 2009.

### DIFF
--- a/spec/lib/tasks/after_tasks.rake_spec.rb
+++ b/spec/lib/tasks/after_tasks.rake_spec.rb
@@ -380,3 +380,64 @@ describe "rake After:fix_invalid_pseud_icon_data" do
     expect(invalid_pseud.icon_comment_text).to be_empty
   end
 end
+
+describe "rake After:fix_2009_comment_threads" do
+  before { Comment.delete_all }
+
+  let(:comment) { create(:comment, id: 13) }
+  let(:reply) { create(:comment, commentable: comment) }
+
+  context "when a comment has the correct thread set" do
+    it "doesn't change the thread" do
+      expect do
+        subject.invoke
+      end.to output("Updating 0 thread(s)\n").to_stdout
+        .and avoid_changing { comment.reload.thread }
+        .and avoid_changing { reply.reload.thread }
+    end
+  end
+
+  context "when a comment has an incorrect thread set" do
+    before { comment.update_column(:thread, 1) }
+
+    it "fixes the threads" do
+      expect do
+        subject.invoke
+      end.to output("Updating 1 thread(s)\n").to_stdout
+        .and change { comment.reload.thread }.from(1).to(13)
+        .and change { reply.reload.thread }.from(1).to(13)
+    end
+
+    context "when the comment has many replies" do
+      it "fixes the threads for all of them" do
+        replies = create_list(:comment, 10, commentable: comment)
+
+        expect do
+          subject.invoke
+        end.to output("Updating 1 thread(s)\n").to_stdout
+          .and change { comment.reload.thread }.from(1).to(13)
+
+        replies.each do |reply|
+          expect { reply.reload }.to change { reply.thread }.from(1).to(13)
+        end
+      end
+    end
+
+    context "when the comment has deeply nested replies" do
+      it "fixes the threads for all of them" do
+        replies = [reply]
+
+        10.times { replies << create(:comment, commentable: replies.last) }
+
+        expect do
+          subject.invoke
+        end.to output("Updating 1 thread(s)\n").to_stdout
+          .and change { comment.reload.thread }.from(1).to(13)
+
+        replies.each do |reply|
+          expect { reply.reload }.to change { reply.thread }.from(1).to(13)
+        end
+      end
+    end
+  end
+end

--- a/test/fixtures/comments.yml
+++ b/test/fixtures/comments.yml
@@ -1,7 +1,7 @@
---- 
-comment_00006: 
+---
+comment_00006:
   pseud_id: 3
-  name: 
+  name:
   thread: 2
   created_at: 2009-02-27 18:05:43 Z
   commentable_type: Comment
@@ -17,13 +17,13 @@ comment_00006:
   user_agent: Opera/9.60 (Windows NT 6.0; U; en) Presto/2.1.1
   threaded_right: 30
   threaded_left: 5
-  edited_at: 
-  ip_address: 
+  edited_at:
+  ip_address:
   hidden_by_admin: false
-  email: 
-comment_00017: 
+  email:
+comment_00017:
   pseud_id: 3
-  name: 
+  name:
   thread: 2
   created_at: 2009-02-28 02:01:20 Z
   commentable_type: Comment
@@ -39,14 +39,14 @@ comment_00017:
   user_agent: Opera/9.60 (Windows NT 6.0; U; en) Presto/2.1.1
   threaded_right: 12
   threaded_left: 9
-  edited_at: 
-  ip_address: 
+  edited_at:
+  ip_address:
   hidden_by_admin: false
-  email: 
-comment_00039: 
+  email:
+comment_00039:
   pseud_id: 17
-  name: 
-  thread: 12
+  name:
+  thread: 38
   created_at: 2009-09-18 14:11:32 Z
   commentable_type: Comment
   updated_at: 2010-01-09 13:58:25 Z
@@ -61,14 +61,14 @@ comment_00039:
   user_agent: Mozilla/5.0 (Windows; U; Windows NT 5.1; en-GB; rv:1.9.1.3) Gecko/20090824 Firefox/3.5.3 (.NET CLR 3.5.30729)
   threaded_right: 5
   threaded_left: 2
-  edited_at: 
-  ip_address: 
+  edited_at:
+  ip_address:
   hidden_by_admin: false
-  email: 
-comment_00040: 
+  email:
+comment_00040:
   pseud_id: 25
-  name: 
-  thread: 12
+  name:
+  thread: 38
   created_at: 2009-09-18 14:21:00 Z
   commentable_type: Comment
   updated_at: 2010-01-09 13:58:25 Z
@@ -83,13 +83,13 @@ comment_00040:
   user_agent: Mozilla/5.0 (Windows; U; Windows NT 5.1; en-GB; rv:1.9.1.3) Gecko/20090824 Firefox/3.5.3 (.NET CLR 3.5.30729)
   threaded_right: 4
   threaded_left: 3
-  edited_at: 
-  ip_address: 
+  edited_at:
+  ip_address:
   hidden_by_admin: false
-  email: 
-comment_00018: 
+  email:
+comment_00018:
   pseud_id: 3
-  name: 
+  name:
   thread: 2
   created_at: 2009-03-02 20:11:28 Z
   commentable_type: Comment
@@ -105,13 +105,13 @@ comment_00018:
   user_agent: Opera/9.60 (Windows NT 6.0; U; en) Presto/2.1.1
   threaded_right: 27
   threaded_left: 26
-  edited_at: 
-  ip_address: 
+  edited_at:
+  ip_address:
   hidden_by_admin: false
-  email: 
-comment_00007: 
+  email:
+comment_00007:
   pseud_id: 3
-  name: 
+  name:
   thread: 2
   created_at: 2009-02-27 18:05:57 Z
   commentable_type: Comment
@@ -127,13 +127,13 @@ comment_00007:
   user_agent: Opera/9.60 (Windows NT 6.0; U; en) Presto/2.1.1
   threaded_right: 21
   threaded_left: 6
-  edited_at: 
-  ip_address: 
+  edited_at:
+  ip_address:
   hidden_by_admin: false
-  email: 
-comment_00008: 
+  email:
+comment_00008:
   pseud_id: 3
-  name: 
+  name:
   thread: 2
   created_at: 2009-02-27 18:06:33 Z
   commentable_type: Comment
@@ -149,13 +149,13 @@ comment_00008:
   user_agent: Opera/9.60 (Windows NT 6.0; U; en) Presto/2.1.1
   threaded_right: 16
   threaded_left: 7
-  edited_at: 
-  ip_address: 
+  edited_at:
+  ip_address:
   hidden_by_admin: false
-  email: 
-comment_00019: 
+  email:
+comment_00019:
   pseud_id: 3
-  name: 
+  name:
   thread: 2
   created_at: 2009-03-02 20:18:04 Z
   commentable_type: Comment
@@ -169,19 +169,19 @@ comment_00019:
   parent_id: 19
   comment_content: |-
     whee
-    
+
     now take a fcking bath
   user_agent: Opera/9.60 (Windows NT 6.0; U; en) Presto/2.1.1
   threaded_right: 29
   threaded_left: 28
-  edited_at: 
-  ip_address: 
+  edited_at:
+  ip_address:
   hidden_by_admin: false
-  email: 
-comment_00041: 
+  email:
+comment_00041:
   pseud_id: 29
-  name: 
-  thread: 13
+  name:
+  thread: 41
   created_at: 2009-12-12 21:18:58 Z
   commentable_type: Chapter
   updated_at: 2010-01-09 13:58:24 Z
@@ -194,19 +194,19 @@ comment_00041:
   parent_id: 78
   comment_content: |-
     <i>RPattz is better as Cedric than as Edward.</i>
-    
+
     He totally is!
   user_agent: Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_6_2; en-us) AppleWebKit/531.21.8 (KHTML, like Gecko) Version/4.0.4 Safari/531.21.10
-  threaded_right: 
-  threaded_left: 
-  edited_at: 
-  ip_address: 
+  threaded_right:
+  threaded_left:
+  edited_at:
+  ip_address:
   hidden_by_admin: false
-  email: 
-comment_00042: 
+  email:
+comment_00042:
   pseud_id: 5
-  name: 
-  thread: 14
+  name:
+  thread: 42
   created_at: 2010-01-04 14:03:39 Z
   commentable_type: Chapter
   updated_at: 2010-01-09 13:58:25 Z
@@ -219,15 +219,15 @@ comment_00042:
   parent_id: 170
   comment_content: If I comment to myself does it show up in the inbox?
   user_agent: Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10.6; en-US; rv:1.9.1.6) Gecko/20091201 Firefox/3.5.6
-  threaded_right: 
-  threaded_left: 
-  edited_at: 
-  ip_address: 
+  threaded_right:
+  threaded_left:
+  edited_at:
+  ip_address:
   hidden_by_admin: false
-  email: 
-comment_00020: 
+  email:
+comment_00020:
   pseud_id: 3
-  name: 
+  name:
   thread: 2
   created_at: 2009-03-02 20:19:09 Z
   commentable_type: Comment
@@ -243,13 +243,13 @@ comment_00020:
   user_agent: Opera/9.60 (Windows NT 6.0; U; en) Presto/2.1.1
   threaded_right: 36
   threaded_left: 35
-  edited_at: 
-  ip_address: 
+  edited_at:
+  ip_address:
   hidden_by_admin: false
-  email: 
-comment_00009: 
+  email:
+comment_00009:
   pseud_id: 3
-  name: 
+  name:
   thread: 2
   created_at: 2009-02-27 18:08:01 Z
   commentable_type: Comment
@@ -263,19 +263,19 @@ comment_00009:
   parent_id: 19
   comment_content: |-
     alas, replying to 6 didn't reload the original thread, but went instead straight to 6.
-    
+
     (this is 7, by the way, the missing Cylon. :( )
   user_agent: Opera/9.60 (Windows NT 6.0; U; en) Presto/2.1.1
   threaded_right: 13
   threaded_left: 8
-  edited_at: 
-  ip_address: 
+  edited_at:
+  ip_address:
   hidden_by_admin: false
-  email: 
-comment_00032: 
+  email:
+comment_00032:
   pseud_id: 2
-  name: 
-  thread: 9
+  name:
+  thread: 32
   created_at: 2009-05-10 17:41:50 Z
   commentable_type: Chapter
   updated_at: 2010-01-09 13:58:24 Z
@@ -290,14 +290,14 @@ comment_00032:
   user_agent: Mozilla/5.0 (Windows; U; Windows NT 5.1; en-GB; rv:1.9.0.10) Gecko/2009042316 Firefox/3.0.10 (.NET CLR 3.5.30729)
   threaded_right: 10
   threaded_left: 1
-  edited_at: 
-  ip_address: 
+  edited_at:
+  ip_address:
   hidden_by_admin: false
-  email: 
-comment_00010: 
+  email:
+comment_00010:
   pseud_id: 3
-  name: 
-  thread: 3
+  name:
+  thread: 10
   created_at: 2009-02-27 23:24:22 Z
   commentable_type: Chapter
   updated_at: 2010-01-09 13:58:23 Z
@@ -310,16 +310,16 @@ comment_00010:
   parent_id: 19
   comment_content: yet another tlc
   user_agent: Opera/9.60 (Windows NT 6.0; U; en) Presto/2.1.1
-  threaded_right: 
-  threaded_left: 
-  edited_at: 
-  ip_address: 
+  threaded_right:
+  threaded_left:
+  edited_at:
+  ip_address:
   hidden_by_admin: false
-  email: 
-comment_00021: 
+  email:
+comment_00021:
   pseud_id: 3
-  name: 
-  thread: 4
+  name:
+  thread: 21
   created_at: 2009-03-02 20:20:26 Z
   commentable_type: Chapter
   updated_at: 2010-01-09 13:58:23 Z
@@ -332,16 +332,16 @@ comment_00021:
   parent_id: 19
   comment_content: Rodney?
   user_agent: Opera/9.60 (Windows NT 6.0; U; en) Presto/2.1.1
-  threaded_right: 
-  threaded_left: 
-  edited_at: 
-  ip_address: 
+  threaded_right:
+  threaded_left:
+  edited_at:
+  ip_address:
   hidden_by_admin: false
-  email: 
-comment_00043: 
+  email:
+comment_00043:
   pseud_id: 25
-  name: 
-  thread: 9
+  name:
+  thread: 32
   created_at: 2010-01-04 16:03:22 Z
   commentable_type: Comment
   updated_at: 2010-01-09 13:58:25 Z
@@ -356,13 +356,13 @@ comment_00043:
   user_agent: Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10.6; en-US; rv:1.9.1.6) Gecko/20091201 Firefox/3.5.6
   threaded_right: 6
   threaded_left: 5
-  edited_at: 
-  ip_address: 
+  edited_at:
+  ip_address:
   hidden_by_admin: false
-  email: 
-comment_00044: 
+  email:
+comment_00044:
   pseud_id: 2
-  name: 
+  name:
   thread: 44
   created_at: 2010-01-07 14:53:17 Z
   commentable_type: Chapter
@@ -376,16 +376,16 @@ comment_00044:
   parent_id: 169
   comment_content: Haha, I realise now that "border bottom" was a CSS term, but in connection with Harry/Draco I first wondered if it was some unknown to me fannish trope... *facepalm* Too much fandom!
   user_agent: Mozilla/5.0 (Windows; U; Windows NT 6.0; en-US; rv:1.9.1.7) Gecko/20091221 Firefox/3.5.7 (.NET CLR 3.5.30729)
-  threaded_right: 
-  threaded_left: 
-  edited_at: 
-  ip_address: 
+  threaded_right:
+  threaded_left:
+  edited_at:
+  ip_address:
   hidden_by_admin: false
-  email: 
-comment_00022: 
+  email:
+comment_00022:
   pseud_id: 3
-  name: 
-  thread: 5
+  name:
+  thread: 22
   created_at: 2009-03-02 20:20:52 Z
   commentable_type: Chapter
   updated_at: 2010-01-09 13:58:23 Z
@@ -398,15 +398,15 @@ comment_00022:
   parent_id: 19
   comment_content: John!
   user_agent: Opera/9.60 (Windows NT 6.0; U; en) Presto/2.1.1
-  threaded_right: 
-  threaded_left: 
-  edited_at: 
-  ip_address: 
+  threaded_right:
+  threaded_left:
+  edited_at:
+  ip_address:
   hidden_by_admin: false
-  email: 
-comment_00011: 
+  email:
+comment_00011:
   pseud_id: 3
-  name: 
+  name:
   thread: 2
   created_at: 2009-02-27 23:25:15 Z
   commentable_type: Comment
@@ -420,19 +420,19 @@ comment_00011:
   parent_id: 19
   comment_content: |-
     trivial case rly
-    
+
     ETA: norly?
   user_agent: Opera/9.60 (Windows NT 6.0; U; en) Presto/2.1.1
   threaded_right: 33
   threaded_left: 32
-  edited_at: 
-  ip_address: 
+  edited_at:
+  ip_address:
   hidden_by_admin: false
-  email: 
-comment_00033: 
+  email:
+comment_00033:
   pseud_id: 1
-  name: 
-  thread: 9
+  name:
+  thread: 32
   created_at: 2009-05-10 17:44:37 Z
   commentable_type: Comment
   updated_at: 2010-01-09 13:58:25 Z
@@ -447,14 +447,14 @@ comment_00033:
   user_agent: Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US) AppleWebKit/525.19 (KHTML, like Gecko) Chrome/1.0.154.65 Safari/525.19
   threaded_right: 9
   threaded_left: 2
-  edited_at: 
-  ip_address: 
+  edited_at:
+  ip_address:
   hidden_by_admin: false
-  email: 
-comment_00034: 
+  email:
+comment_00034:
   pseud_id: 5
-  name: 
-  thread: 9
+  name:
+  thread: 32
   created_at: 2009-05-10 17:45:06 Z
   commentable_type: Comment
   updated_at: 2010-01-09 13:58:25 Z
@@ -469,13 +469,13 @@ comment_00034:
   user_agent: Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US) AppleWebKit/525.19 (KHTML, like Gecko) Chrome/1.0.154.65 Safari/525.19
   threaded_right: 8
   threaded_left: 3
-  edited_at: 
-  ip_address: 
+  edited_at:
+  ip_address:
   hidden_by_admin: false
-  email: 
-comment_00012: 
+  email:
+comment_00012:
   pseud_id: 3
-  name: 
+  name:
   thread: 2
   created_at: 2009-02-27 23:26:09 Z
   commentable_type: Comment
@@ -491,13 +491,13 @@ comment_00012:
   user_agent: Opera/9.60 (Windows NT 6.0; U; en) Presto/2.1.1
   threaded_right: 18
   threaded_left: 17
-  edited_at: 
-  ip_address: 
+  edited_at:
+  ip_address:
   hidden_by_admin: false
-  email: 
-comment_00001: 
+  email:
+comment_00001:
   pseud_id: 13
-  name: 
+  name:
   thread: 1
   created_at: 2008-12-06 23:22:00 Z
   commentable_type: Chapter
@@ -511,15 +511,15 @@ comment_00001:
   parent_id: 11
   comment_content: "Cheerful. I liked Boccaccio's version better. "
   user_agent: Mozilla/5.0 (Windows; U; Windows NT 5.1; en-GB; rv:1.9.0.4) Gecko/2008102920 Firefox/3.0.4 (.NET CLR 3.5.30729)
-  threaded_right: 
-  threaded_left: 
-  edited_at: 
-  ip_address: 
+  threaded_right:
+  threaded_left:
+  edited_at:
+  ip_address:
   hidden_by_admin: false
-  email: 
-comment_00023: 
+  email:
+comment_00023:
   pseud_id: 3
-  name: 
+  name:
   thread: 2
   created_at: 2009-03-02 20:21:50 Z
   commentable_type: Comment
@@ -535,13 +535,13 @@ comment_00023:
   user_agent: Opera/9.60 (Windows NT 6.0; U; en) Presto/2.1.1
   threaded_right: 24
   threaded_left: 23
-  edited_at: 
-  ip_address: 
+  edited_at:
+  ip_address:
   hidden_by_admin: false
-  email: 
-comment_00024: 
+  email:
+comment_00024:
   pseud_id: 3
-  name: 
+  name:
   thread: 2
   created_at: 2009-03-02 20:24:35 Z
   commentable_type: Comment
@@ -557,13 +557,13 @@ comment_00024:
   user_agent: Opera/9.60 (Windows NT 6.0; U; en) Presto/2.1.1
   threaded_right: 11
   threaded_left: 10
-  edited_at: 
-  ip_address: 
+  edited_at:
+  ip_address:
   hidden_by_admin: false
-  email: 
-comment_00002: 
+  email:
+comment_00002:
   pseud_id: 3
-  name: 
+  name:
   thread: 2
   created_at: 2009-02-27 16:51:22 Z
   commentable_type: Chapter
@@ -579,13 +579,13 @@ comment_00002:
   user_agent: Opera/9.60 (Windows NT 6.0; U; en) Presto/2.1.1
   threaded_right: 40
   threaded_left: 1
-  edited_at: 
-  ip_address: 
+  edited_at:
+  ip_address:
   hidden_by_admin: false
-  email: 
-comment_00013: 
+  email:
+comment_00013:
   pseud_id: 3
-  name: 
+  name:
   thread: 2
   created_at: 2009-02-27 23:30:36 Z
   commentable_type: Comment
@@ -601,14 +601,14 @@ comment_00013:
   user_agent: Opera/9.60 (Windows NT 6.0; U; en) Presto/2.1.1
   threaded_right: 20
   threaded_left: 19
-  edited_at: 
-  ip_address: 
+  edited_at:
+  ip_address:
   hidden_by_admin: false
-  email: 
-comment_00035: 
+  email:
+comment_00035:
   pseud_id: 2
-  name: 
-  thread: 9
+  name:
+  thread: 32
   created_at: 2009-05-10 17:45:55 Z
   commentable_type: Comment
   updated_at: 2010-01-09 13:58:25 Z
@@ -623,14 +623,14 @@ comment_00035:
   user_agent: Mozilla/5.0 (Windows; U; Windows NT 5.1; en-GB; rv:1.9.0.10) Gecko/2009042316 Firefox/3.0.10 (.NET CLR 3.5.30729)
   threaded_right: 7
   threaded_left: 4
-  edited_at: 
-  ip_address: 
+  edited_at:
+  ip_address:
   hidden_by_admin: false
-  email: 
-comment_00036: 
+  email:
+comment_00036:
   pseud_id: 1
-  name: 
-  thread: 10
+  name:
+  thread: 36
   created_at: 2009-05-24 01:44:00 Z
   commentable_type: Chapter
   updated_at: 2010-01-09 13:58:24 Z
@@ -646,25 +646,25 @@ comment_00036:
     <li>Is</li>
     <li>An Ordered List</li>
     </ul>
-    
+
     <ol><li>This</li>
     <li>Is</li>
     <li>An UnOrdered List</li>
     </ol>
-    
+
     <big>Big</big>
-    
+
     <small>Small</small>
   user_agent: Mozilla/5.0 (Windows; U; Windows NT 5.1; en-GB; rv:1.9.0.10) Gecko/2009042316 Firefox/3.0.10 (.NET CLR 3.5.30729)
-  threaded_right: 
-  threaded_left: 
+  threaded_right:
+  threaded_left:
   edited_at: 2009-05-24 01:59:01 Z
-  ip_address: 
+  ip_address:
   hidden_by_admin: false
-  email: 
-comment_00014: 
+  email:
+comment_00014:
   pseud_id: 3
-  name: 
+  name:
   thread: 2
   created_at: 2009-02-28 01:08:46 Z
   commentable_type: Comment
@@ -678,18 +678,18 @@ comment_00014:
   parent_id: 19
   comment_content: |-
     oooooh breakthrough! (7b)
-    
+
     I want to break freeee!
   user_agent: Opera/9.60 (Windows NT 6.0; U; en) Presto/2.1.1
   threaded_right: 15
   threaded_left: 14
-  edited_at: 
-  ip_address: 
+  edited_at:
+  ip_address:
   hidden_by_admin: false
-  email: 
-comment_00003: 
+  email:
+comment_00003:
   pseud_id: 3
-  name: 
+  name:
   thread: 2
   created_at: 2009-02-27 16:58:28 Z
   commentable_type: Comment
@@ -705,14 +705,14 @@ comment_00003:
   user_agent: Opera/9.60 (Windows NT 6.0; U; en) Presto/2.1.1
   threaded_right: 39
   threaded_left: 2
-  edited_at: 
-  ip_address: 
+  edited_at:
+  ip_address:
   hidden_by_admin: false
-  email: 
-comment_00025: 
+  email:
+comment_00025:
   pseud_id: 1
-  name: 
-  thread: 6
+  name:
+  thread: 25
   created_at: 2009-03-14 18:00:27 Z
   commentable_type: Chapter
   updated_at: 2010-01-09 13:58:23 Z
@@ -725,16 +725,16 @@ comment_00025:
   parent_id: 19
   comment_content: are you still working?
   user_agent: Mozilla/5.0 (Windows; U; Windows NT 6.0; en-US; rv:1.8.1.20) Gecko/20081217 Firefox/2.0.0.20 (.NET CLR 3.5.30729)
-  threaded_right: 
-  threaded_left: 
-  edited_at: 
-  ip_address: 
+  threaded_right:
+  threaded_left:
+  edited_at:
+  ip_address:
   hidden_by_admin: false
-  email: 
-comment_00026: 
-  pseud_id: 
+  email:
+comment_00026:
+  pseud_id:
   name: Random Dent
-  thread: 7
+  thread: 26
   created_at: 2009-03-20 23:53:38 Z
   commentable_type: Chapter
   updated_at: 2010-01-09 13:58:24 Z
@@ -747,15 +747,15 @@ comment_00026:
   parent_id: 58
   comment_content: I can't seem to be able to access the next story in the series, what's with that? :(
   user_agent: Mozilla/5.0 (Windows; U; Windows NT 6.0; en-US; rv:1.8.1.20) Gecko/20081217 Firefox/2.0.0.20 (.NET CLR 3.5.30729)
-  threaded_right: 
-  threaded_left: 
-  edited_at: 
+  threaded_right:
+  threaded_left:
+  edited_at:
   ip_address: 127.0.0.1
   hidden_by_admin: false
   email: random@example.com
-comment_00004: 
+comment_00004:
   pseud_id: 3
-  name: 
+  name:
   thread: 2
   created_at: 2009-02-27 16:58:47 Z
   commentable_type: Comment
@@ -771,13 +771,13 @@ comment_00004:
   user_agent: Opera/9.60 (Windows NT 6.0; U; en) Presto/2.1.1
   threaded_right: 38
   threaded_left: 3
-  edited_at: 
-  ip_address: 
+  edited_at:
+  ip_address:
   hidden_by_admin: false
-  email: 
-comment_00015: 
+  email:
+comment_00015:
   pseud_id: 3
-  name: 
+  name:
   thread: 2
   created_at: 2009-02-28 01:21:42 Z
   commentable_type: Comment
@@ -793,14 +793,14 @@ comment_00015:
   user_agent: Opera/9.60 (Windows NT 6.0; U; en) Presto/2.1.1
   threaded_right: 37
   threaded_left: 34
-  edited_at: 
-  ip_address: 
+  edited_at:
+  ip_address:
   hidden_by_admin: false
-  email: 
-comment_00037: 
+  email:
+comment_00037:
   pseud_id: 1
-  name: 
-  thread: 11
+  name:
+  thread: 37
   created_at: 2009-05-24 01:58:18 Z
   commentable_type: Chapter
   updated_at: 2010-01-09 13:58:24 Z
@@ -814,24 +814,24 @@ comment_00037:
   comment_content: |-
     This
     Is
-    Just 
-    A 
+    Just
+    A
     Lot
     Of
     Paragraphs
-    
+
     <img src="http://l-userpic.livejournal.com/87470347/15766754">
   user_agent: Mozilla/5.0 (Windows; U; Windows NT 5.1; en-GB; rv:1.9.0.10) Gecko/2009042316 Firefox/3.0.10 (.NET CLR 3.5.30729)
-  threaded_right: 
-  threaded_left: 
+  threaded_right:
+  threaded_left:
   edited_at: 2009-05-24 12:53:58 Z
-  ip_address: 
+  ip_address:
   hidden_by_admin: false
-  email: 
-comment_00038: 
+  email:
+comment_00038:
   pseud_id: 25
-  name: 
-  thread: 12
+  name:
+  thread: 38
   created_at: 2009-09-18 14:11:10 Z
   commentable_type: Chapter
   updated_at: 2010-01-09 13:58:24 Z
@@ -846,13 +846,13 @@ comment_00038:
   user_agent: Mozilla/5.0 (Windows; U; Windows NT 5.1; en-GB; rv:1.9.1.3) Gecko/20090824 Firefox/3.5.3 (.NET CLR 3.5.30729)
   threaded_right: 6
   threaded_left: 1
-  edited_at: 
-  ip_address: 
+  edited_at:
+  ip_address:
   hidden_by_admin: false
-  email: 
-comment_00016: 
+  email:
+comment_00016:
   pseud_id: 3
-  name: 
+  name:
   thread: 2
   created_at: 2009-02-28 02:00:10 Z
   commentable_type: Comment
@@ -868,13 +868,13 @@ comment_00016:
   user_agent: Opera/9.60 (Windows NT 6.0; U; en) Presto/2.1.1
   threaded_right: 25
   threaded_left: 22
-  edited_at: 
-  ip_address: 
+  edited_at:
+  ip_address:
   hidden_by_admin: false
-  email: 
-comment_00005: 
+  email:
+comment_00005:
   pseud_id: 3
-  name: 
+  name:
   thread: 2
   created_at: 2009-02-27 18:05:22 Z
   commentable_type: Comment
@@ -890,14 +890,14 @@ comment_00005:
   user_agent: Opera/9.60 (Windows NT 6.0; U; en) Presto/2.1.1
   threaded_right: 31
   threaded_left: 4
-  edited_at: 
-  ip_address: 
+  edited_at:
+  ip_address:
   hidden_by_admin: false
-  email: 
-comment_00027: 
+  email:
+comment_00027:
   pseud_id: 1
-  name: 
-  thread: 8
+  name:
+  thread: 27
   created_at: 2009-05-10 17:33:15 Z
   commentable_type: Chapter
   updated_at: 2010-01-09 13:58:24 Z
@@ -912,7 +912,7 @@ comment_00027:
   user_agent: Mozilla/5.0 (Windows; U; Windows NT 5.1; en-GB; rv:1.9.0.10) Gecko/2009042316 Firefox/3.0.10 (.NET CLR 3.5.30729)
   threaded_right: 2
   threaded_left: 1
-  edited_at: 
-  ip_address: 
+  edited_at:
+  ip_address:
   hidden_by_admin: false
-  email: 
+  email:


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6351

## Purpose

Add a rake task `rake After:fix_2009_comment_threads` to fix comment threads, add some specs to confirm that it works the way it's supposed to, and modify the `test/fixtures/comments.yml` file to fix the seed data.