### PR TITLE
AO3-6327 Assorted fixes for the comment blocking code.

### DIFF
--- a/app/controllers/blocked/users_controller.rb
+++ b/app/controllers/blocked/users_controller.rb
@@ -18,6 +18,8 @@ module Blocked
       @pseuds = @blocks.map { |b| b.blocked.default_pseud }
       @rec_counts = Pseud.rec_counts_for_pseuds(@pseuds)
       @work_counts = Pseud.work_counts_for_pseuds(@pseuds)
+
+      @page_subtitle = "Blocked Users"
     end
 
     # GET /users/:user_id/blocked/users/confirm_block

--- a/app/controllers/blocked/users_controller.rb
+++ b/app/controllers/blocked/users_controller.rb
@@ -13,7 +13,7 @@ module Blocked
     def index
       @blocks = @user.blocks_as_blocker
         .joins(:blocked).includes(blocked: :default_pseud)
-        .order(id: :desc).page(params[:page])
+        .order(created_at: :desc).order(id: :desc).page(params[:page])
 
       @pseuds = @blocks.map { |b| b.blocked.default_pseud }
       @rec_counts = Pseud.rec_counts_for_pseuds(@pseuds)
@@ -59,7 +59,7 @@ module Blocked
 
     private
 
-    # Set the user whose blocks we're viewing/modifying.
+    # Sets the user whose blocks we're viewing/modifying.
     def set_user
       @user = User.find_by!(login: params[:user_id])
       @check_ownership_of = @user

--- a/app/validators/not_blocked_validator.rb
+++ b/app/validators/not_blocked_validator.rb
@@ -20,8 +20,6 @@ class NotBlockedValidator < ActiveModel::EachValidator
 
     return unless Block.exists?(blocker: blocker_users, blocked: blocked_users)
 
-    record.errors.add(attribute, options.fetch(:message, :blocked),
-                      blocked: blocked_users.map(&:login).to_sentence,
-                      blocker: blocker_users.map(&:login).to_sentence)
+    record.errors.add(attribute, options.fetch(:message, :blocked))
   end
 end

--- a/app/views/blocked/users/_blocked_user_blurb.html.erb
+++ b/app/views/blocked/users/_blocked_user_blurb.html.erb
@@ -1,4 +1,3 @@
-<% # modified from pseuds/pseud_blurb to include a block buttton %>
 <% pseud = block.blocked.default_pseud %>
 <li class="user pseud picture blurb group" role="article">
   <%= render "pseuds/pseud_module", pseud: pseud %>

--- a/features/step_definitions/comment_steps.rb
+++ b/features/step_definitions/comment_steps.rb
@@ -21,7 +21,7 @@ end
 
 ParameterType(
   name: "commentable",
-  regexp: /the (work|admin post|tag) "([^"]*?)"/,
+  regexp: /the (work|admin post|tag) "([^"]*)"/,
   type: ActsAsCommentable::Commentable,
   transformer: lambda { |type, title|
     case type

--- a/lib/acts_as_commentable/comment_methods.rb
+++ b/lib/acts_as_commentable/comment_methods.rb
@@ -92,13 +92,14 @@ module ActsAsCommentable::CommentMethods
     # Adds a child to this object in the tree. This method will update all of the
     # other elements in the tree and shift them to the right, keeping everything
     # balanced.
+    #
+    # Skips validations so that we can reply to invalid comments.
     def add_child( child )
       if ( (self.threaded_left == nil) || (self.threaded_right == nil) )
         # Looks like we're now the root node!  Woo
         self.threaded_left = 1
         self.threaded_right = 4
 
-        # What do to do about validation?
         return nil unless save(validate: false)
 
         child.commentable_id = self.id


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6327

## Purpose

Minor fixes for comment blocking, as suggested in the post-merge review on #4237:
- a few tweaked comments
- order blocks by both `created_at` and `id`, instead of just `id`
- remove the unused info from the error added by `NotBlockedValidator`
- remove an unnecessary lazy quantifier
- change the title of the Blocked Users page