### PR TITLE
AO3-6327 Fix admin view of Blocked Users page, and add a Cancel button to the Confirm Block/Unblock pages.

### DIFF
--- a/app/helpers/block_helper.rb
+++ b/app/helpers/block_helper.rb
@@ -1,11 +1,16 @@
 module BlockHelper
   def block_link(user, block: nil)
-    block ||= user.block_by_current_user
+    if block.nil?
+      block = user.block_by_current_user
+      blocking_user = current_user
+    else
+      blocking_user = block.blocker
+    end
 
     if block
-      link_to(t("blocked.unblock"), confirm_unblock_user_blocked_user_path(current_user, block))
+      link_to(t("blocked.unblock"), confirm_unblock_user_blocked_user_path(blocking_user, block))
     else
-      link_to(t("blocked.block"), confirm_block_user_blocked_users_path(current_user, blocked_id: user))
+      link_to(t("blocked.block"), confirm_block_user_blocked_users_path(blocking_user, blocked_id: user))
     end
   end
 

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -73,7 +73,7 @@ class Comment < ApplicationRecord
   scope :for_display, lambda {
     includes(
       pseud: { user: [:roles, :block_of_current_user, :block_by_current_user] },
-      parent: { work: :pseuds }
+      parent: { work: [:pseuds, :users] }
     )
   }
 

--- a/app/views/blocked/users/confirm_block.html.erb
+++ b/app/views/blocked/users/confirm_block.html.erb
@@ -20,5 +20,8 @@
     </ul>
   </div>
 
-  <p class="actions"><%= submit_tag t(".button") %></p>
+  <p class="actions">
+    <%= link_to t(".cancel"), user_blocked_users_path(@user) %>
+    <%= submit_tag t(".button") %>
+  </p>
 <% end %>

--- a/app/views/blocked/users/confirm_unblock.html.erb
+++ b/app/views/blocked/users/confirm_unblock.html.erb
@@ -13,5 +13,8 @@
     </ul>
   </div>
 
-  <p class="actions"><%= submit_tag t(".button") %></p>
+  <p class="actions">
+    <%= link_to t(".cancel"), user_blocked_users_path(@user) %>
+    <%= submit_tag t(".button") %>
+  </p>
 <% end %>

--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -344,6 +344,7 @@ en:
       confirm_block:
         title: "Block %{name}"
         button: "Yes, Block User"
+        cancel: "Cancel"
         block: "block"
         sure_html: "Are you sure you want to %{block} %{username}?"
         will:
@@ -357,6 +358,7 @@ en:
       confirm_unblock:
         title: "Unblock %{name}"
         button: "Yes, Unblock User"
+        cancel: "Cancel"
         unblock: "unblock"
         sure_html: "Are you sure you want to %{unblock} %{username}?"
         resume:

--- a/features/support/paths.rb
+++ b/features/support/paths.rb
@@ -78,7 +78,7 @@ module NavigationHelpers
     when "my blocked users page"
       user_blocked_users_path(User.current_user)
     when /the blocked users page for "([^"]*)"/
-      user_blocked_users_path($1)
+      user_blocked_users_path(Regexp.last_match(1))
     when /my bookmarks page/
       step %{all indexing jobs have been run}
       user_bookmarks_path(User.current_user)

--- a/features/support/paths.rb
+++ b/features/support/paths.rb
@@ -77,6 +77,8 @@ module NavigationHelpers
       user_preferences_path(User.current_user)
     when "my blocked users page"
       user_blocked_users_path(User.current_user)
+    when /the blocked users page for "([^"]*)"/
+      user_blocked_users_path($1)
     when /my bookmarks page/
       step %{all indexing jobs have been run}
       user_bookmarks_path(User.current_user)

--- a/features/users/blocking.feature
+++ b/features/users/blocking.feature
@@ -103,3 +103,19 @@ Feature: Blocking
     When I follow "2" within ".pagination"
     Then I should see "pest2" within "ul.pseud li:nth-child(1)"
       And I should see "pest1" within "ul.pseud li:nth-child(2)"
+
+  Scenario Outline: Authorized admins can see the blocked users page
+    Given the user "blocker" has blocked the user "pest"
+    When I am logged in as a "<role>" admin
+      And I go to the blocked users page for "blocker"
+    Then I should see "pest"
+      And I should see a link "Unblock"
+    When I follow "Unblock"
+    Then I should see "Sorry, you don't have permission to access the page you were trying to reach."
+      And the user "blocker" should have a block for "pest"
+
+    Examples:
+      | role             |
+      | superadmin       |
+      | policy_and_abuse |
+      | support          |


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6327

## Purpose

- Fix the 500 error that occurs when admins try to view a user's Blocked Users page.
- Add a Cancel button to the Confirm Block page and the Confirm Unblock page.