### PR TITLE
AO3-6327 Handle nil blocked_id, and add a little extra information to the description of blocking.

### DIFF
--- a/app/controllers/blocked/users_controller.rb
+++ b/app/controllers/blocked/users_controller.rb
@@ -69,7 +69,8 @@ module Blocked
 
     # Builds (but doesn't save) a block matching the desired params:
     def build_block
-      @block = @user.blocks_as_blocker.build(blocked_byline: params[:blocked_id])
+      blocked_byline = params.fetch(:blocked_id, "")
+      @block = @user.blocks_as_blocker.build(blocked_byline: blocked_byline)
       @blocked = @block.blocked
     end
 

--- a/app/views/blocked/users/confirm_block.html.erb
+++ b/app/views/blocked/users/confirm_block.html.erb
@@ -17,6 +17,7 @@
     <ul>
       <li><%= t(".will_not.comments_on_works") %></li>
       <li><%= t(".will_not.comments_elsewhere") %></li>
+      <li><%= t(".will_not.hide_works") %></li>
     </ul>
   </div>
 

--- a/app/views/blocked/users/index.html.erb
+++ b/app/views/blocked/users/index.html.erb
@@ -13,6 +13,7 @@
   <ul>
     <li><%= t(".will_not.comments_on_works") %></li>
     <li><%= t(".will_not.comments_elsewhere") %></li>
+    <li><%= t(".will_not.hide_works") %></li>
   </ul>
 </div>
 

--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -346,6 +346,7 @@ en:
           intro: "Blocking a user will not:"
           comments_on_works: "delete or hide comments they previously left on your works; you can delete these individually"
           comments_elsewhere: "hide their comments elsewhere on the site"
+          hide_works: "hide their works or bookmarks from you"
       confirm_block:
         title: "Block %{name}"
         button: "Yes, Block User"
@@ -360,6 +361,7 @@ en:
           intro: "Blocking a user will not:"
           comments_on_works: "delete or hide comments they previously left on your works; you can delete these individually"
           comments_elsewhere: "hide their comments elsewhere on the site"
+          hide_works: "hide their works or bookmarks from you"
       confirm_unblock:
         title: "Unblock %{name}"
         button: "Yes, Unblock User"

--- a/spec/controllers/blocked/users_controller_spec.rb
+++ b/spec/controllers/blocked/users_controller_spec.rb
@@ -98,6 +98,16 @@ describe Blocked::UsersController do
         subject.call
         expect(response).to render_template(:confirm_block)
       end
+
+      context "when no blocked_id is specified" do
+        subject { -> { get :confirm_block, params: { user_id: blocker } } }
+
+        it "redirects with an error" do
+          subject.call
+          it_redirects_to_with_error(user_blocked_users_path(blocker),
+                                     "Sorry, we couldn't find a user matching that name.")
+        end
+      end
     end
 
     it_behaves_like "no other users can access it"


### PR DESCRIPTION
# Pull Request Checklist
## Issue

https://otwarchive.atlassian.net/browse/AO3-6327

## Purpose

- Handle when `blocked_id` is unspecified, so that users don't get a 500 error when they delete the `?blocked_id=NAME` section of the URL and go straight to `/users/NAME/blocked/users/confirm_block`.
- Add an extra bullet point to the "Blocking a user will not:" section of the description of blocking, to make it clearer to users that blocking a user will not hide their works/bookmarks.