### PR TITLE
AO3-5780 Add thousands separators to long numbers on series pages

### DIFF
--- a/app/views/series/_series_module.html.erb
+++ b/app/views/series/_series_module.html.erb
@@ -47,6 +47,6 @@
   <dd><%= series.visible_work_count %></dd>
   <% if (bookmark_count = series.bookmarks.is_public.count) > 0 %>
     <dt><%= ts('Bookmarks:') %></dt>
-    <dd><%= link_to_bookmarkable_bookmarks(series, bookmark_count.to_s) %></dd>
+    <dd><%= link_to_bookmarkable_bookmarks(series, number_with_delimiter(bookmark_count)) %></dd>
   <% end %>
 </dl>

--- a/app/views/series/_series_module.html.erb
+++ b/app/views/series/_series_module.html.erb
@@ -44,7 +44,7 @@
   <dt><%= ts('Words:') %></dt> 
   <dd><%= number_with_delimiter(series.visible_word_count) %></dd>
   <dt><%= ts('Works:') %></dt> 
-  <dd><%= series.visible_work_count %></dd>
+  <dd><%= number_with_delimiter(series.visible_work_count) %></dd>
   <% if (bookmark_count = series.bookmarks.is_public.count) > 0 %>
     <dt><%= ts('Bookmarks:') %></dt>
     <dd><%= link_to_bookmarkable_bookmarks(series, number_with_delimiter(bookmark_count)) %></dd>

--- a/app/views/series/show.html.erb
+++ b/app/views/series/show.html.erb
@@ -61,7 +61,7 @@
         <dt><%= ts("Words:") %></dt>
         <dd><%= number_with_delimiter(@series.visible_word_count) %></dd>
         <dt><%= ts("Works:") %></dt>
-        <dd><%= @series.visible_work_count %></dd>
+        <dd><%= number_with_delimiter(@series.visible_work_count) %></dd>
         <dt><%= ts("Complete:") %></dt>
         <dd><%= @series.complete? ? ts("Yes") : ts("No") %></dd>
         <% if (bookmark_count = @series.bookmarks.is_public.count) > 0 %>

--- a/app/views/series/show.html.erb
+++ b/app/views/series/show.html.erb
@@ -66,7 +66,7 @@
         <dd><%= @series.complete? ? ts("Yes") : ts("No") %></dd>
         <% if (bookmark_count = @series.bookmarks.is_public.count) > 0 %>
           <dt><%= ts("Bookmarks:") %></dt>
-          <dd><%= link_to_bookmarkable_bookmarks(@series, bookmark_count.to_s) %></dd>
+          <dd><%= link_to_bookmarkable_bookmarks(@series, number_with_delimiter(bookmark_count)) %></dd>
         <% end %>
       </dl>
     </dd>

--- a/features/other_b/series.feature
+++ b/features/other_b/series.feature
@@ -240,6 +240,15 @@ Feature: Create and Edit Series
     Then I should see "Part 2 of the Ponies series" within "dd.series"
       And I should see "Part 1 of the Black Beauty series" within "dd.series"
 
+  Scenario: A series's metadata is visible when viewing the series
+    Given I am logged in as a random user
+      And I post the work "Story" as part of a series "Excellent Series"
+      And I bookmark the series "Excellent Series"
+    When I view the series "Excellent Series"
+    Then I should see "Words: 6" within ".series.meta"
+      And I should see "Bookmarks: 1" within ".series.meta"
+      And I should see "Works: 1" within ".series.meta"
+
   Scenario: When editing a series, the title field should not escape HTML
     Given I am logged in as "whoever"
       And I post the work "whatever" as part of a series "What a title! :< :& :>"


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [ ] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [x] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [x] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-5780

## Purpose

This uses `number_with_delimiter` to display bookmark counts on the series page or on the series bookmarks page with delimiters if they have more than 3 digits.

Note: it was unclear to me whether this issue also referred to number of works in a series, so I left that alone, but I can add that in if it should be included!

## Testing Instructions

If you just want to see that the bookmark number still exists after this change, you can

1. create or find a work in a series
2. go to the series page
3. bookmark the series
  a. verify that after "bookmarks:" there's a 1 that's a link
4. go back to the series page
  a. verify that after "bookmarks:" there's a 1 that's a link

... I'm very new to docker, ruby/rails, *and* this project and could not figure out how to get existing automated tests to pass even before my changes, unfortunately, let alone find the relevant tests and modify or add to them. I'd love to learn! I got a ton of errors that looked like the following when I tried to run the spec tests, which I'm not even sure is the correct place to be looking for tests of these files.
```
NameError:
        undefined local variable or method `renamed_at' for #<User:0x000055ad2c583c78>
        Did you mean?  created_at
```
I suspect I must have failed to set up the test database correctly (`docker exec web bundle exec rake db:test:prepare`?)? I notice that `test/fixtures/users.yml` seems to have "created_at" info on users but not "renamed_at" info, but I have no idea if that's relevant.

## Credit

irrationalpie, they/them
