### PR TITLE
AO3-6352 Add default Content-Security-Policy response header

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -83,6 +83,7 @@ module Otwarchive
 
     # Only send referrer information to ourselves
     config.action_dispatch.default_headers = {
+      "Content-Security-Policy" => "frame-ancestors 'self'",
       "Referrer-Policy" => "strict-origin-when-cross-origin",
       "X-Frame-Options" => "SAMEORIGIN",
       "X-XSS-Protection" => "1; mode=block",

--- a/spec/requests/security_headers_spec.rb
+++ b/spec/requests/security_headers_spec.rb
@@ -4,6 +4,7 @@ describe "Security headers" do
   it "includes the required headers" do
     get "/"
     headers = response.headers
+    expect(headers["Content-Security-Policy"]).to eq("frame-ancestors 'self'")
     expect(headers["Referrer-Policy"]).to eq("strict-origin-when-cross-origin")
     expect(headers["X-Frame-Options"]).to eq("SAMEORIGIN")
     expect(headers["X-XSS-Protection"]).to eq("1; mode=block")


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [x] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [x] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [x] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-6352

## Purpose

This PR adds a `Content-Security-Policy: frame-ancestors 'self'` header to the default response headers. I've also added a corresponding unit test.

## Testing Instructions

There's a unit test in `spec/requests/security_headers_spec.rb`. The functionality can also be tested manually by opening the root page in a web browser, opening the developer tools and verifying that the `Content-Security-Policy` response header has been set.

## Credit

printfn, they/them