### PR TITLE
AO3-4659 Tweaks to block user and collection participant forms

### DIFF
--- a/app/views/blocked/users/confirm_block.html.erb
+++ b/app/views/blocked/users/confirm_block.html.erb
@@ -15,9 +15,9 @@
     <p><%= t(".will_not.intro") %></p>
 
     <ul>
+      <li><%= t(".will_not.hide_works") %></li>
       <li><%= t(".will_not.comments_on_works") %></li>
       <li><%= t(".will_not.comments_elsewhere") %></li>
-      <li><%= t(".will_not.hide_works") %></li>
     </ul>
   </div>
 

--- a/app/views/blocked/users/index.html.erb
+++ b/app/views/blocked/users/index.html.erb
@@ -11,9 +11,9 @@
   <p><%= t(".will_not.intro") %></p>
 
   <ul>
+    <li><%= t(".will_not.hide_works") %></li>
     <li><%= t(".will_not.comments_on_works") %></li>
     <li><%= t(".will_not.comments_elsewhere") %></li>
-    <li><%= t(".will_not.hide_works") %></li>
   </ul>
 </div>
 

--- a/app/views/blocked/users/index.html.erb
+++ b/app/views/blocked/users/index.html.erb
@@ -25,7 +25,7 @@
     <p>
       <%= label_tag :blocked_id, t(".label"), class: "landmark" %>
       <%= text_field_tag :blocked_id, "", autocomplete_options("pseud", data: { autocomplete_token_limit: 1 }) %>
-      <%= submit_tag t(".button") %>
+      <span class="submit actions"><%= submit_tag t(".button") %></span>
     </p>
   </fieldset>
 <% end %>

--- a/app/views/collection_participants/_add_participants_form.html.erb
+++ b/app/views/collection_participants/_add_participants_form.html.erb
@@ -4,7 +4,7 @@
     <p>
       <%= label_tag :participants_to_invite, ts("Add new members"), class: "landmark" %>
       <%= text_field_tag :participants_to_invite, nil, autocomplete_options("pseud") %>
-      <%= submit_tag ts("Submit") %>
+      <span class="submit actions"><%= submit_tag ts("Submit") %></span>
     </p>
   </fieldset>
 <% end %>

--- a/public/stylesheets/site/2.0/07-interactions.css
+++ b/public/stylesheets/site/2.0/07-interactions.css
@@ -601,6 +601,10 @@ form.single input[type="submit"] {
   vertical-align: bottom;
 }
 
+form.single span.submit {
+  padding: 0;
+}
+
 form.single ul.autocomplete {
   display: inline-block;
 }
@@ -619,7 +623,7 @@ form.single .autocomplete input[type="text"] {
 }
 
 /* tweak the margin of the submit button only if there's an autocomplete */
-form.single .autocomplete + input + input[type="submit"] {
+form.single .autocomplete + input + span.submit input[type="submit"] {
   margin-bottom: 0.125em;
 }
 

--- a/public/stylesheets/site/2.0/25-media-midsize.css
+++ b/public/stylesheets/site/2.0/25-media-midsize.css
@@ -59,6 +59,30 @@
   width: auto;
 }
 
+/* 07 interactions */
+
+form.single input[type="text"] {
+  width: 100%;
+    box-sizing: border-box;
+}
+
+form.single input[type="submit"] {
+  margin-top: 0.375em;
+}
+
+form.single span.submit {
+  display: block;
+  text-align: right;
+}
+
+form.single ul.autocomplete {
+  display: block;
+}
+
+form.single .autocomplete li.input {
+  margin-right: 0;
+}
+
 /* 16 zone system */
 
 .logged-in .splash > .module {


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-4659

## Purpose

* Makes the form prettier on smaller screens, e.g. tablets and phones -- the button and the text input were overlapping a bit because the min-width on the text input was too big for the space, so I've put them on separate lines to give the text input enough room.
* Reorders the bullet points on the block user form because we wanted the bit about not hiding works to be at the top.

## Testing Instructions

On a phone or a tablet in portrait mode (or a browser with the font size cranked up and the window width narrowed), check the collection participant and blocked users pages and make sure the forms are decent looking and functional.

Also check the order of the bullet points on the block user form; the one about hiding works should be at the top.
