### PR TITLE
AO3-6358 Overwrite local configuration files in Docker init.sh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .bundle
 .idea
 stdout
+*~
 # /
 /*.tmproj
 /sphinx

--- a/script/docker/init.sh
+++ b/script/docker/init.sh
@@ -5,9 +5,9 @@ set -ex
 # Change directory to root of the repo
 cd "$(dirname "$0")/../.."
 
-cp -n config/docker/database.yml config/database.yml
-cp -n config/docker/redis.yml config/redis.yml
-cp -n config/docker/local.yml config/local.yml
+cp -b config/docker/database.yml config/database.yml
+cp -b config/docker/redis.yml config/redis.yml
+cp -b config/docker/local.yml config/local.yml
 
 docker-compose up -d
 


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [ ] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
   * No, but not applicable
* [x] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [x] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-6358

## Purpose

Make installing docker easier if the installation script fails the first time.

## Testing Instructions

No tests needed.

## References

Bug created in response to struggles mentioned in #4254

## Credit

irrationalpie, they/them