### PR TITLE
AO3-5734 Stop truncating and sanitizing page titles of HTML downloads

### DIFF
--- a/app/models/download.rb
+++ b/app/models/download.rb
@@ -90,16 +90,13 @@ class Download
     @tmpdir
   end
 
-  # Mimic roughly the default way of producing HTML page titles
-  # @see WorksController#show
-  # @see ApplicationController#get_page_title
   def page_title
     fandom = if work.fandoms.size > 3
                "Multifandom"
              elsif work.fandoms.empty?
                "No fandom specified"
              else
-               work.fandoms[0].name
+               work.fandoms.string
              end
     [work.title, authors, fandom].join(" - ")
   end

--- a/app/models/download.rb
+++ b/app/models/download.rb
@@ -90,28 +90,26 @@ class Download
     @tmpdir
   end
 
-  # Utility methods which clean up work data for use in downloads
-
-  def fandoms
-    string = work.fandoms.size > 3 ? "Multifandom" : work.fandoms.string
-    clean(string)
+  # Mimic roughly the default way of producing HTML page titles
+  # @see WorksController#show
+  # @see ApplicationController#get_page_title
+  def page_title
+    fandom = if work.fandoms.size > 3
+               "Multifandom"
+             elsif work.fandoms.empty?
+               "No fandom specified"
+             else
+               work.fandoms[0].name
+             end
+    [work.title, authors, fandom].join(" - ")
   end
 
   def authors
-    author_names.join(', ').to_ascii
+    author_names.join(", ")
   end
 
   def author_names
     work.anonymous? ? ["Anonymous"] : work.pseuds.sort.map(&:byline)
-  end
-
-  # need the next two to be filesystem safe and not overly long
-  def file_authors
-    clean(author_names.join('-'))
-  end
-
-  def page_title
-    [file_name, file_authors, fandoms].join(" - ")
   end
 
   def chapters

--- a/app/models/download.rb
+++ b/app/models/download.rb
@@ -96,7 +96,7 @@ class Download
              elsif work.fandoms.empty?
                "No fandom specified"
              else
-               work.fandoms.string
+               work.fandom_string
              end
     [work.title, authors, fandom].join(" - ")
   end

--- a/features/works/work_download.feature
+++ b/features/works/work_download.feature
@@ -30,6 +30,10 @@ Feature: Download a work
   When I go to the work page with title "Has double quotes"
     And I follow "AZW3"
   Then I should receive a file of type "azw3"
+  When I go to the work page with title "Has double quotes"
+    And I follow "HTML"
+  Then I should receive a file of type "html"
+	  And the page title should include '"Has double quotes"'
 
 
   Scenario: Download works with non-ASCII characters in title

--- a/spec/models/download_spec.rb
+++ b/spec/models/download_spec.rb
@@ -104,15 +104,21 @@ describe Download do
     let(:work) { create(:work, fandoms: [fandom1, fandom2], title: "Foo bar") }
     let(:subject) { Download.new(work) }
 
-    it "includes first fandom name" do
+    it "includes fandom names" do
       expect(subject.page_title).to include(fandom1.name)
-      expect(subject.page_title).not_to include(fandom2.name)
+      expect(subject.page_title).to include(fandom2.name)
     end
 
     it "leaves emojis alone" do
       work.title = "emoji 🥳 is 🚀 awesome"
 
       expect(subject.page_title).to include("emoji 🥳 is 🚀 awesome")
+    end
+
+    it "leaves long titles alone" do
+      work.title = "no title is too long to print nor to read"
+
+      expect(subject.page_title).to include("no title is too long to print nor to read")
     end
 
     context "for a work with multiple authors" do

--- a/spec/models/download_spec.rb
+++ b/spec/models/download_spec.rb
@@ -97,10 +97,10 @@ describe Download do
   end
 
   describe "page_title" do
-    let(:fandom1) { create(:canonical_fandom) }
-    let(:fandom2) { create(:canonical_fandom) }
-    let(:pseud1) { create(:pseud, name: "First", user: create(:user, login: "Zeroth")) }
-    let(:pseud2) { create(:pseud, name: "Second", user: create(:user)) }
+    let(:fandom1) { build(:canonical_fandom) }
+    let(:fandom2) { build(:fandom, name: "Non-Canonical") }
+    let(:pseud1) { build(:pseud, name: "First", user: build(:user, login: "Zeroth")) }
+    let(:pseud2) { build(:pseud, name: "Second", user: build(:user)) }
     let(:work) { create(:work, fandoms: [fandom1, fandom2], title: "Foo bar") }
     let(:subject) { Download.new(work) }
 

--- a/spec/models/download_spec.rb
+++ b/spec/models/download_spec.rb
@@ -96,39 +96,15 @@ describe Download do
     end
   end
 
-  describe "authors" do
-    let(:work) { Work.new }
-    let(:subject) { Download.new(work) }
-    let(:pseud1) { create(:pseud, name: "First", user: create(:user)) }
-    let(:pseud2) { create(:pseud, name: "Second", user: create(:user)) }
-
-    it "joins the author names separated by a comma and a space" do
-      allow(pseud1).to receive(:byline).and_return("First (Zeroth)")
-      allow(pseud2).to receive(:byline).and_return("Second")
-      allow(work).to receive(:pseuds).and_return([pseud1, pseud2])
-
-      expect(subject.authors).to eq("First (Zeroth), Second")
-    end
-
-    it "leaves Chinese characters alone" do
-      allow(pseud1).to receive(:byline).and_return("我哥好像被奇怪的人盯上了怎么破")
-      allow(work).to receive(:pseuds).and_return([pseud1])
-
-      expect(subject.authors).to eq("我哥好像被奇怪的人盯上了怎么破")
-    end
-  end
-
   describe "page_title" do
     let(:fandom1) { create(:canonical_fandom) }
     let(:fandom2) { create(:canonical_fandom) }
-    let(:pseud1) { create(:pseud, name: "First", user: create(:user)) }
+    let(:pseud1) { create(:pseud, name: "First", user: create(:user, login: "Zeroth")) }
     let(:pseud2) { create(:pseud, name: "Second", user: create(:user)) }
-    let(:work) { create(:work, fandoms: [fandom1, fandom2]) }
+    let(:work) { create(:work, fandoms: [fandom1, fandom2], title: "Foo bar") }
     let(:subject) { Download.new(work) }
 
     it "includes first fandom name" do
-      work.title = "Foo bar"
-
       expect(subject.page_title).to include(fandom1.name)
       expect(subject.page_title).not_to include(fandom2.name)
     end
@@ -141,12 +117,17 @@ describe Download do
 
     context "for a work with multiple authors" do
       it "joins the author names with a comma and a space" do
-        allow(pseud1).to receive(:byline).and_return("First (Zeroth)")
-        allow(pseud2).to receive(:byline).and_return("Second")
         allow(work).to receive(:pseuds).and_return([pseud1, pseud2])
 
         expect(subject.page_title).to include("First (Zeroth), Second")
       end
+    end
+
+    it "leaves author names containing Chinese characters alone" do
+      allow(pseud1).to receive(:byline).and_return("我哥好像被奇怪的人盯上了怎么破")
+      allow(work).to receive(:pseuds).and_return([pseud1])
+
+      expect(subject.page_title).to include(" - 我哥好像被奇怪的人盯上了怎么破 - ")
     end
   end
 end

--- a/spec/models/download_spec.rb
+++ b/spec/models/download_spec.rb
@@ -101,7 +101,7 @@ describe Download do
     let(:fandom2) { build(:fandom, name: "Non-Canonical") }
     let(:pseud1) { build(:pseud, name: "First", user: build(:user, login: "Zeroth")) }
     let(:pseud2) { build(:pseud, name: "Second", user: build(:user)) }
-    let(:work) { create(:work, fandoms: [fandom1, fandom2], title: "Foo bar") }
+    let(:work) { build(:work, fandoms: [fandom1, fandom2], title: "Foo bar") }
     let(:subject) { Download.new(work) }
 
     it "includes fandom names" do


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [x] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [x] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [x] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-5734

## Purpose

To stop doing truncation and cleaning of the page title shown in the downloaded HTML file which seem unnecessary.

## Testing Instructions

(Using Docker) Go to http://localhost:3000/works/107 and choose Download > HTML. Open the downloaded HTML file. The title (as shown in a browser tab) should read "Addding tags for stats purposes" instead of "Addding tags for stats"

Note: Title lines shown inside the screen (in bold text) should be fine before this set of changes and should remain that way. Also, the file name should be in ASCII before and after.

EDIT: I actually don't know if work IDs (107 here) of test data are same across installations.

## Credit

Potpotkettle (they/them)
