### PR TITLE
AO3-6160 Lazy pluralization of bookmark count on delete pseud page

### DIFF
--- a/app/views/pseuds/delete_preview.html.erb
+++ b/app/views/pseuds/delete_preview.html.erb
@@ -7,7 +7,7 @@
 
 <% if @pseud.bookmarks %>
   <%= form_tag({:action => "destroy"}, :method => :delete) do %>
-    <p>You have saved <%= @pseud.bookmarks.count %> bookmark(s) using this pseud. You can choose whether to
+    <p>You have saved <%= pluralize(@pseud.bookmarks.count, "bookmark") %> using this pseud. You can choose whether to
     delete them or transfer them to your default pseud.
     </p>
 


### PR DESCRIPTION
# Pull Request Checklist

* [ ] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [ ] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [ ] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [ ] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [ ] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-6160

## Purpose

Uses i18n pluralize function to pluralize "bookmark" when appropriate on delete pseud page. (Previously, the page said "bookmark(s)")

## Testing Instructions

How can the Archive's QA team verify that this is working as you intended?

As per Jira

## References

Are there other relevant issues/pull requests/mailing list discussions?

## Credit

What name and pronouns should we use to credit you in the [Archive of Our Own's Release Notes](https://archiveofourown.org/admin_posts?tag=1)? salt, they/them
