### PR TITLE
AO3-6280 Fix inconsistent text in new invitations email

### DIFF
--- a/app/views/user_mailer/invite_increase_notification.html.erb
+++ b/app/views/user_mailer/invite_increase_notification.html.erb
@@ -1,7 +1,7 @@
 <% content_for :message do %>
   <p><%= t("mailer.general.greeting.informal.addressed", name: style_bold(@user.login)).html_safe %></p>
 
-  <p><%= t(".body", count: @total, invitation_page: style_link(t(".invitation_page_link_text"), user_invitations_url(@user))).html_safe %></p>
+  <p><%= t(".html_body", count: @total, invitation_page_link: style_link(t(".invitation_page_link_text"), user_invitations_url(@user))).html_safe %></p>
 
   <p>
     <%= t("mailer.general.closing.informal") %><br />

--- a/app/views/user_mailer/invite_increase_notification.html.erb
+++ b/app/views/user_mailer/invite_increase_notification.html.erb
@@ -1,7 +1,7 @@
 <% content_for :message do %>
   <p><%= t("mailer.general.greeting.informal.addressed", name: style_bold(@user.login)).html_safe %></p>
 
-  <p><%= t(".html_body", count: @total, invitation_page_link: style_link(t(".invitation_page_link_text"), user_invitations_url(@user))).html_safe %></p>
+  <p><%= t(".html.body", count: @total, invitation_page_link: style_link(t(".invitation_page_link_text"), user_invitations_url(@user))).html_safe %></p>
 
   <p>
     <%= t("mailer.general.closing.informal") %><br />

--- a/app/views/user_mailer/invite_increase_notification.text.erb
+++ b/app/views/user_mailer/invite_increase_notification.text.erb
@@ -1,7 +1,7 @@
 <% content_for :message do %>
 <%= t("mailer.general.greeting.informal.addressed", name: @user.login) %>
 
-<%= t(".text_body", count: @total, invitation_page_url: user_invitations_url(@user)) %>
+<%= t(".text.body", count: @total, invitation_page_url: user_invitations_url(@user)) %>
 
 <%= t("mailer.general.closing.informal") %>
 <%= t("mailer.general.signature.app_short_name") %>

--- a/app/views/user_mailer/invite_increase_notification.text.erb
+++ b/app/views/user_mailer/invite_increase_notification.text.erb
@@ -1,7 +1,7 @@
 <% content_for :message do %>
 <%= t("mailer.general.greeting.informal.addressed", name: @user.login) %>
 
-<%= t(".body", count: @total, invitation_page: user_invitations_url(@user)) %>
+<%= t(".text_body", count: @total, invitation_page_url: user_invitations_url(@user)) %>
 
 <%= t("mailer.general.closing.informal") %>
 <%= t("mailer.general.signature.app_short_name") %>

--- a/config/locales/mailers/en.yml
+++ b/config/locales/mailers/en.yml
@@ -54,9 +54,12 @@ en:
   user_mailer:
     invite_increase_notification:
       subject: "[%{app_name}] New invitations"
-      body:
-        one: "We just wanted to let you know that you have %{count} new invitation, which can be used to create a new account at the Archive. You can invite a friend at %{invitation_page}."
-        other: "We just wanted to let you know that you have %{count} new invitations, which can be used to create new accounts at the Archive. You can invite a friend at %{invitation_page}."
+      html_body:
+        one: "We just wanted to let you know that you have %{count} new invitation, which can be used to create a new account at the Archive. You can invite a friend at %{invitation_page_link}."
+        other: "We just wanted to let you know that you have %{count} new invitations, which can be used to create new accounts at the Archive. You can invite a friend at %{invitation_page_link}."
+      text_body:
+        one: "We just wanted to let you know that you have %{count} new invitation, which can be used to create a new account at the Archive. You can invite a friend at your invitations page (%{invitation_page_url})."
+        other: "We just wanted to let you know that you have %{count} new invitations, which can be used to create new accounts at the Archive. You can invite a friend at your invitations page (%{invitation_page_url})."
       invitation_page_link_text: your invitations page
     admin_deleted_work_notification:
       subject: "[%{app_name}] Your work has been deleted by an admin"

--- a/config/locales/mailers/en.yml
+++ b/config/locales/mailers/en.yml
@@ -54,12 +54,14 @@ en:
   user_mailer:
     invite_increase_notification:
       subject: "[%{app_name}] New invitations"
-      html_body:
-        one: "We just wanted to let you know that you have %{count} new invitation, which can be used to create a new account at the Archive. You can invite a friend at %{invitation_page_link}."
-        other: "We just wanted to let you know that you have %{count} new invitations, which can be used to create new accounts at the Archive. You can invite a friend at %{invitation_page_link}."
-      text_body:
-        one: "We just wanted to let you know that you have %{count} new invitation, which can be used to create a new account at the Archive. You can invite a friend at your invitations page (%{invitation_page_url})."
-        other: "We just wanted to let you know that you have %{count} new invitations, which can be used to create new accounts at the Archive. You can invite a friend at your invitations page (%{invitation_page_url})."
+      html:
+        body:
+          one: "We just wanted to let you know that you have %{count} new invitation, which can be used to create a new account at the Archive. You can invite a friend at %{invitation_page_link}."
+          other: "We just wanted to let you know that you have %{count} new invitations, which can be used to create new accounts at the Archive. You can invite a friend at %{invitation_page_link}."
+      text:
+        body:
+          one: "We just wanted to let you know that you have %{count} new invitation, which can be used to create a new account at the Archive. You can invite a friend at your invitations page (%{invitation_page_url})."
+          other: "We just wanted to let you know that you have %{count} new invitations, which can be used to create new accounts at the Archive. You can invite a friend at your invitations page (%{invitation_page_url})."
       invitation_page_link_text: your invitations page
     admin_deleted_work_notification:
       subject: "[%{app_name}] Your work has been deleted by an admin"

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -488,12 +488,14 @@ describe UserMailer do
       describe "HTML version" do
         it "has the correct content" do
           expect(email).to have_html_part_content("you have #{count} new invitation, which")
+          expect(email).to have_html_part_content("your invitations page</a>.")
         end
       end
 
       describe "text version" do
         it "has the correct content" do
           expect(email).to have_text_part_content("you have #{count} new invitation, which")
+          expect(email).to have_text_part_content("your invitations page (")
         end
       end
     end
@@ -518,12 +520,14 @@ describe UserMailer do
       describe "HTML version" do
         it "has the correct content" do
           expect(email).to have_html_part_content("you have #{count} new invitations, which")
+          expect(email).to have_html_part_content("your invitations page</a>.")
         end
       end
 
       describe "text version" do
         it "has the correct content" do
           expect(email).to have_text_part_content("you have #{count} new invitations, which")
+          expect(email).to have_text_part_content("your invitations page (")
         end
       end
     end


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [x] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [x] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [x] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-6280 

## Purpose

What does this PR do?
Fix inconsistent text in new invitations email, update some variable names to comply with i18n standards, add unit tests to check the updated new invitations email text 

## Testing Instructions

How can the Archive's QA team verify that this is working as you intended
Run updated unit tests to verify that the invitations email text has been updated 

If you have a Jira account with access, please update or comment on the issue
with any new or missing testing instructions instead.

## References

Are there other relevant issues/pull requests/mailing list discussions?

## Credit

What name and pronouns should we use to credit you in the [Archive of Our Own's Release Notes](https://archiveofourown.org/admin_posts?tag=1)?
Cesium-Ice, she/her

If you have a Jira account, please include the same name in the "Full name"
field on your Jira profile, so we can assign you the issues you're working on.

*Please note that if you do not fill in this section, we will use your GitHub account name and
they/them pronouns.*
