### PR TITLE
AO3-6201 Remove unused actions from the AutocompleteController

### DIFF
--- a/app/controllers/autocomplete_controller.rb
+++ b/app/controllers/autocomplete_controller.rb
@@ -46,6 +46,17 @@ class AutocompleteController < ApplicationController
   def relationship; tag_output(params[:term], "relationship"); end
   def freeform; tag_output(params[:term], "freeform"); end
 
+
+  ## TAGS IN FANDOMS
+  private
+    def tag_in_fandom_output(params)
+      render_output(Tag.autocomplete_fandom_lookup(params).map {|r| Tag.name_from_autocomplete(r)})
+    end
+  public
+  def character_in_fandom; tag_in_fandom_output(params.merge({tag_type: "character"})); end
+  def relationship_in_fandom; tag_in_fandom_output(params.merge({tag_type: "relationship"})); end
+
+
   ## TAGS IN SETS
   #
   # Note that only tagsets in OwnedTagSets are in autocomplete

--- a/app/controllers/autocomplete_controller.rb
+++ b/app/controllers/autocomplete_controller.rb
@@ -46,18 +46,6 @@ class AutocompleteController < ApplicationController
   def relationship; tag_output(params[:term], "relationship"); end
   def freeform; tag_output(params[:term], "freeform"); end
 
-
-  ## TAGS IN FANDOMS
-  private
-    def tag_in_fandom_output(params)
-      render_output(Tag.autocomplete_fandom_lookup(params).map {|r| Tag.name_from_autocomplete(r)})
-    end
-  public
-  def tag_in_fandom; tag_in_fandom_output(params); end
-  def character_in_fandom; tag_in_fandom_output(params.merge({tag_type: "character"})); end
-  def relationship_in_fandom; tag_in_fandom_output(params.merge({tag_type: "relationship"})); end
-
-
   ## TAGS IN SETS
   #
   # Note that only tagsets in OwnedTagSets are in autocomplete
@@ -103,12 +91,6 @@ class AutocompleteController < ApplicationController
   # more-specific autocompletes should be added below here when they can't be avoided
 
 
-  # Nominated parents
-  def nominated_parents
-    render_output(TagNomination.for_tag_set(OwnedTagSet.find(params[:tag_set_id])).nominated_parents(params[:tagname], params[:term]))
-  end
-
-
   # look up collections ranked by number of items they contain
 
   def collection_fullname
@@ -134,15 +116,6 @@ class AutocompleteController < ApplicationController
   # for looking up existing urls for external works to avoid duplication
   def external_work
     render_output(ExternalWork.where(["url LIKE ?", '%' + params[:term] + '%']).limit(10).order(:url).pluck(:url))
-  end
-
-  # people signed up for a challenge
-  def challenge_participants
-    search_param = params[:term]
-    collection_id = params[:collection_id]
-    render_output(Pseud.limit(10).order(:name).joins(:challenge_signups)
-                    .where(["pseuds.name LIKE ? AND challenge_signups.collection_id = ?",
-                            '%' + search_param + '%', collection_id]).map(&:byline))
   end
 
   # the pseuds of the potential matches who could fulfill the requests in the given signup


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [ ] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [x] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [x] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-6201

## Purpose

What does this PR do?
Removes 3 unused actions from AutocompleteController
* challenge_participants
* nominated_parents
* tag_in_fandom

## Testing Instructions

How can the Archive's QA team verify that this is working as you intended?

If you have a Jira account with access, please update or comment on the issue
with any new or missing testing instructions instead.

## References

Are there other relevant issues/pull requests/mailing list discussions?

## Credit

What name and pronouns should we use to credit you in the [Archive of Our Own's Release Notes](https://archiveofourown.org/admin_posts?tag=1)?

warlockmel (she/her)
