### PR TITLE
AO3-6166 Prevent unrevealed/hidden works title exposure

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -462,6 +462,18 @@ public
     end
   end
 
+  # Checks if user is allowed to see related page if parent page is hidden or in hidden collection
+  def check_parent_visibility(parent)
+    # Only admins and the owner can see related pages on something hidden by an admin.
+    if parent.respond_to?(:hidden_by_admin) && parent.hidden_by_admin
+      logged_in_as_admin? || current_user_owns?(parent) || access_denied(redirect: root_path)
+    end
+    # Only admins and the owner can see related pages on unrevealed works.
+    if parent.respond_to?(:in_unrevealed_collection) && parent.in_unrevealed_collection
+      logged_in_as_admin? || current_user_owns?(parent) || access_denied(redirect: root_path)
+    end
+  end
+
   # Make sure user is allowed to access tag wrangling pages
   def check_permission_to_wrangle
     if @admin_settings.tag_wrangling_off? && !logged_in_as_admin?

--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -25,6 +25,7 @@ class CollectionsController < ApplicationController
 
   def index
     if params[:work_id] && (@work = Work.find_by(id: params[:work_id]))
+      check_parent_visibility(@work)
       @collections = @work.approved_collections.by_title.includes(:parent, :moderators, :children, :collection_preference, owners: [:user]).paginate(page: params[:page])
     elsif params[:collection_id] && (@collection = Collection.find_by(name: params[:collection_id]))
       @collections = @collection.children.by_title.includes(:parent, :moderators, :children, :collection_preference, owners: [:user]).paginate(page: params[:page])

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -62,15 +62,7 @@ class CommentsController < ApplicationController
   end
 
   def check_parent
-    parent = find_parent
-    # Only admins and the owner can see comments on something hidden by an admin.
-    if parent.respond_to?(:hidden_by_admin) && parent.hidden_by_admin
-      logged_in_as_admin? || current_user_owns?(parent) || access_denied(redirect: root_path)
-    end
-    # Only admins and the owner can see comments on unrevealed works.
-    if parent.respond_to?(:in_unrevealed_collection) && parent.in_unrevealed_collection
-      logged_in_as_admin? || current_user_owns?(parent) || access_denied(redirect: root_path)
-    end
+    check_parent_visibility(find_parent)
   end
 
   def check_modify_parent

--- a/app/controllers/kudos_controller.rb
+++ b/app/controllers/kudos_controller.rb
@@ -6,6 +6,7 @@ class KudosController < ApplicationController
 
   def index
     @work = Work.find(params[:work_id])
+    check_parent_visibility(@work)
     @kudos = @work.kudos.includes(:user).with_user
     @guest_kudos_count = @work.kudos.by_guest.count
 

--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -243,6 +243,7 @@ class WorksController < ApplicationController
   end
 
   def navigate
+    check_parent_visibility(@work)
     @chapters = @work.chapters_in_order(
       include_content: false,
       include_drafts: (logged_in_as_admin? ||

--- a/spec/controllers/collections_controller_spec.rb
+++ b/spec/controllers/collections_controller_spec.rb
@@ -1,0 +1,76 @@
+require "spec_helper"
+
+describe CollectionsController do
+  include LoginMacros
+  include RedirectExpectationHelper
+
+  describe "hidden works" do
+    shared_examples "only author and admin can view work collections page" do
+      shared_examples "user can't see work collections" do
+        it "redirects user to login page with error message" do
+          get :index, params: { work_id: work.id }
+          it_redirects_to_with_error(root_path, error_message)
+        end
+      end
+
+      shared_examples "user can see work collections" do
+        it "renders the page" do
+          get :index, params: { work_id: work.id }
+          expect(response).to render_template(:index)
+          expect(assigns(:collections)).to include(collection)
+        end
+      end
+
+      context "when logged out" do
+        it_behaves_like "user can't see work collections" do
+          let(:error_message) { "Sorry, you don't have permission to access the page you were trying to reach. Please log in." }
+        end
+      end
+
+      context "when logged in as a random user" do
+        let(:user) { create(:user) }
+
+        before { fake_login_known_user(user) }
+
+        it_behaves_like "user can't see work collections" do
+          let(:error_message) { "Sorry, you don't have permission to access the page you were trying to reach." }
+        end
+      end
+
+      context "when logged in as the work's owner" do
+        let(:user) { work.users.first }
+
+        before { fake_login_known_user(user) }
+
+        it_behaves_like "user can see work collections"
+      end
+
+      context "when logged in as an admin" do
+        let(:user) { create(:admin, roles: ["policy_and_abuse"]) }
+
+        before { fake_login_admin(user) }
+
+        it_behaves_like "user can see work collections"
+      end
+    end
+
+    let(:author) { create(:user) }
+    let!(:work) { create(:work, authors: [author.pseuds.first]) }
+    let(:collection) { create(:collection) }
+
+    context "on an unrevealed work" do
+      before { work.update!(collection_names: "#{create(:unrevealed_collection).name}, #{collection.name}") }
+
+      it_behaves_like "only author and admin can view work collections page"
+    end
+
+    context "on a work hidden by an admin" do
+      before do
+        work.update!(collection_names: collection.name)
+        work.update_column(:hidden_by_admin, true)
+      end
+
+      it_behaves_like "only author and admin can view work collections page"
+    end
+  end
+end


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [x] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [x] Have you added the [Jira](https://otwarchive.atlassian.net) issue number as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [x] Do you have fewer than 5 pull requests already open? If not, please wait until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-6166

## Purpose

Attempts to make sure that users can't access info in unrevealed/hidden work from most cases.
Had a lot of uncertainty when trying to do this, so mostly ended up writing tests...

- Originally wanted to model bookmarks after comments (as per issue), but it didn't seem to work nicely as for bookmarks works would be visible in various bookmarks indices.
- There are some differences between works hidden by admin/unrevealed works which I am not sure are expected.
- Currently due to various pre-checks redirects happen to various places with various messages. Didn't know if we want to unify them and what to. So at the moment left as they are.
- Tests are probably too extensive, but it is caused by noticed different behavior in various cases. When originally tried to make bookmarks more like comments, noticed that different paths (/bookmarks, /work/id/bookmarks) can cause different behavior. So added it to tests.
- If expected behavior is unified, tests probably can be smaller in size (and faster if we decide that some make no sense).
- Not sure if feature tests are needed. They would nicely show that titles are not exposed (don't think that's possible with rspec), but I wouldn't know which configurations to choose. Running everything would be too slow and choosing just some configurations do not prove "we never disclose the title"
-  Uncertain about some error messages (for example message for author editing bookmark modelled after same in comments)
- Added some paths not mentioned in the issue (like navigate). There may be more, but that's what seemed to make sense.

(also tests for /users/id/bookmarks seem to fail on CI, don't know why. Locally they work, but on CI ES complains)

## Credit

korrien, she/her
