### PR TITLE
AO3-6349 When reindexing works, try to perform fewer database queries.

### DIFF
--- a/app/models/search/bookmarked_work_indexer.rb
+++ b/app/models/search/bookmarked_work_indexer.rb
@@ -2,4 +2,17 @@ class BookmarkedWorkIndexer < BookmarkableIndexer
   def self.klass
     "Work"
   end
+
+  def self.klass_with_includes
+    Work.includes(
+      :approved_collections,
+      :direct_filters,
+      :external_author_names,
+      :filters,
+      :language,
+      :tags,
+      :users,
+      pseuds: :user
+    )
+  end
 end

--- a/app/models/search/indexer.rb
+++ b/app/models/search/indexer.rb
@@ -1,5 +1,4 @@
 class Indexer
-
   BATCH_SIZE = 1000
   INDEXERS_FOR_CLASS = {
     Work: %w[WorkIndexer WorkCreatorIndexer BookmarkedWorkIndexer],
@@ -10,7 +9,7 @@ class Indexer
     ExternalWork: %w[BookmarkedExternalWorkIndexer]
   }.freeze
 
-  delegate :klass, :index_name, :document_type, to: :class
+  delegate :klass, :klass_with_includes, :index_name, :document_type, to: :class
 
   ##################
   # CLASS METHODS
@@ -18,6 +17,10 @@ class Indexer
 
   def self.klass
     raise "Must be defined in subclass"
+  end
+
+  def self.klass_with_includes
+    klass.constantize
   end
 
   def self.all
@@ -166,8 +169,7 @@ class Indexer
   end
 
   def objects
-    Rails.logger.info "Blueshirt: Logging use of constantize class objects #{klass}"
-    @objects ||= klass.constantize.where(id: ids).inject({}) do |h, obj|
+    @objects ||= klass_with_includes.where(id: ids).inject({}) do |h, obj|
       h.merge(obj.id => obj)
     end
   end

--- a/app/models/search/work_creator_indexer.rb
+++ b/app/models/search/work_creator_indexer.rb
@@ -5,6 +5,10 @@ class WorkCreatorIndexer < Indexer
     "Work"
   end
 
+  def self.klass_with_includes
+    Work.includes(:pseuds, :users)
+  end
+
   def self.mapping
     WorkIndexer.mapping
   end

--- a/app/models/search/work_indexer.rb
+++ b/app/models/search/work_indexer.rb
@@ -1,7 +1,23 @@
 class WorkIndexer < Indexer
-
   def self.klass
     "Work"
+  end
+
+  def self.klass_with_includes
+    Work.includes(
+      :approved_collections,
+      :direct_filters,
+      :external_author_names,
+      :filters,
+      :language,
+      :stat_counter,
+      :tags,
+      :users,
+      fandoms: { meta_tags: :meta_tags, merger: { meta_tags: :meta_tags } },
+      pseuds: :user,
+      relationships: :merger,
+      serial_works: :series
+    )
   end
 
   def self.index_all(options = {})
@@ -106,12 +122,14 @@ class WorkIndexer < Indexer
     end
   end
 
-  # Pluck the desired series data and then turn it back
-  # into a hash
+  # Format the id, title, and position of each series as a hash:
   def series_data(object)
-    series_attrs = [:id, :title, :position]
-    object.series.pluck(*series_attrs).map do |values|
-      series_attrs.zip(values).to_h
+    object.serial_works.map do |sw|
+      {
+        id: sw.series_id,
+        title: sw.series&.title,
+        position: sw.position
+      }
     end
   end
 end

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -1230,7 +1230,7 @@ class Work < ApplicationRecord
   # to one another can be considered a crossover
   def crossover
     # Short-circuit the check if there's only one fandom tag:
-    return false if fandoms.count == 1
+    return false if fandoms.size == 1
 
     # Replace fandoms with their mergers if possible,
     # as synonyms should have no meta tags themselves
@@ -1266,7 +1266,8 @@ class Work < ApplicationRecord
   # Does this work have only one relationship tag?
   # (not counting synonyms)
   def otp
-    return true if relationships.count == 1
+    return true if relationships.size == 1
+
     all_without_syns = relationships.map { |r| r.merger ? r.merger : r }.uniq.compact
     all_without_syns.count == 1
   end

--- a/spec/models/search/bookmarked_work_indexer_spec.rb
+++ b/spec/models/search/bookmarked_work_indexer_spec.rb
@@ -1,0 +1,15 @@
+require "spec_helper"
+
+describe BookmarkedWorkIndexer, bookmark_search: true do
+  describe "#index_documents" do
+    context "with multiple works in a batch", :n_plus_one do
+      populate { |n| create_list(:work, n) }
+
+      it "generates a constant number of database queries" do
+        expect do
+          BookmarkedWorkIndexer.new(Work.ids).index_documents
+        end.to perform_constant_number_of_queries
+      end
+    end
+  end
+end

--- a/spec/models/search/work_creator_indexer_spec.rb
+++ b/spec/models/search/work_creator_indexer_spec.rb
@@ -1,0 +1,15 @@
+require "spec_helper"
+
+describe WorkCreatorIndexer, work_search: true do
+  describe "#index_documents" do
+    context "with multiple works in a batch", :n_plus_one do
+      populate { |n| create_list(:work, n) }
+
+      it "generates a constant number of database queries" do
+        expect do
+          WorkCreatorIndexer.new(Work.ids).index_documents
+        end.to perform_constant_number_of_queries
+      end
+    end
+  end
+end

--- a/spec/models/search/work_indexer_spec.rb
+++ b/spec/models/search/work_indexer_spec.rb
@@ -21,5 +21,15 @@ describe WorkIndexer, work_search: true do
         expect(indexer.index_documents).to be_nil
       end
     end
+
+    context "with multiple works in a batch", :n_plus_one do
+      populate { |n| create_list(:work, n) }
+
+      it "generates a constant number of database queries" do
+        expect do
+          WorkIndexer.new(Work.ids).index_documents
+        end.to perform_constant_number_of_queries
+      end
+    end
   end
 end


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6349

## Purpose

This PR uses `includes()` to try to reduce the number of database queries performed when reindexing works, in an attempt to make reindexing faster. On my machine this makes reindexing works 3-5x faster, but your mileage may vary.