### PR TITLE
AO3-6307 Add mailer previews for creatorship notifications

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -149,12 +149,11 @@ group :test, :development do
   gem 'brakeman'
   gem 'pry-byebug'
   gem 'whiny_validation'
-  gem 'factory_bot', '~> 5.0.2'
+  gem "factory_bot_rails"
   gem 'minitest'
 end
 
 group :development do
-  gem 'factory_bot_rails'
   gem 'bundler-audit'
   gem 'active_record_query_trace', '~> 1.6', '>= 1.6.1'
 end
@@ -168,6 +167,7 @@ end
 
 group :test, :development, :staging do
   gem 'bullet', '>= 5.7.3'
+  gem "factory_bot", require: false
 end
 
 # Deploy with Capistrano

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -615,7 +615,7 @@ DEPENDENCIES
   email_spec (= 1.6.0)
   erb_lint (= 0.0.29)
   escape_utils (= 1.2.1)
-  factory_bot (~> 5.0.2)
+  factory_bot
   factory_bot_rails
   faker
   fastimage

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -253,13 +253,11 @@ class UserMailer < ApplicationMailer
     @archivist = User.find(archivist_id)
     @user = @creatorship.pseud.user
     @creation = @creatorship.creation
-    I18n.with_locale(Locale.find(@user.preference.preferred_locale).iso) do
-      mail(
-        to: @user.email,
-        subject: t("user_mailer.creatorship_notification_archivist.subject",
-                   app_name: ArchiveConfig.APP_SHORT_NAME)
-      )
-    end
+    mail(
+      to: @user.email,
+      subject: t("user_mailer.creatorship_notification_archivist.subject",
+                 app_name: ArchiveConfig.APP_SHORT_NAME)
+    )
   end
 
   # Sends email when a user is added as a co-creator
@@ -268,13 +266,11 @@ class UserMailer < ApplicationMailer
     @adding_user = User.find(adding_user_id)
     @user = @creatorship.pseud.user
     @creation = @creatorship.creation
-    I18n.with_locale(Locale.find(@user.preference.preferred_locale).iso) do
-      mail(
-        to: @user.email,
-        subject: t("user_mailer.creatorship_notification.subject",
-                   app_name: ArchiveConfig.APP_SHORT_NAME)
-      )
-    end
+    mail(
+      to: @user.email,
+      subject: t("user_mailer.creatorship_notification.subject",
+                 app_name: ArchiveConfig.APP_SHORT_NAME)
+    )
   end
 
   # Sends email when a user is added as an unapproved/pending co-creator
@@ -283,13 +279,11 @@ class UserMailer < ApplicationMailer
     @inviting_user = User.find(inviting_user_id)
     @user = @creatorship.pseud.user
     @creation = @creatorship.creation
-    I18n.with_locale(Locale.find(@user.preference.preferred_locale).iso) do
-      mail(
-        to: @user.email,
-        subject: t("user_mailer.creatorship_request.subject",
-                   app_name: ArchiveConfig.APP_SHORT_NAME)
-      )
-    end
+    mail(
+      to: @user.email,
+      subject: t("user_mailer.creatorship_request.subject",
+                 app_name: ArchiveConfig.APP_SHORT_NAME)
+    )
   end
 
   # Sends emails to creators whose stories were listed as the inspiration of another work

--- a/app/models/creatorship.rb
+++ b/app/models/creatorship.rb
@@ -148,14 +148,16 @@ class Creatorship < ApplicationRecord
                   pseud.user != User.current_user &&
                   pseud.user != User.orphan_account
 
-    if approved?
-      if User.current_user.try(:is_archivist?)
-        UserMailer.creatorship_notification_archivist(id, User.current_user.id).deliver_later
+    I18n.with_locale(Locale.find(pseud.user.preference.preferred_locale).iso) do
+      if approved?
+        if User.current_user.try(:is_archivist?)
+          UserMailer.creatorship_notification_archivist(id, User.current_user.id).deliver_later
+        else
+          UserMailer.creatorship_notification(id, User.current_user.id).deliver_later
+        end
       else
-        UserMailer.creatorship_notification(id, User.current_user.id).deliver_later
+        UserMailer.creatorship_request(id, User.current_user.id).deliver_later
       end
-    else
-      UserMailer.creatorship_request(id, User.current_user.id).deliver_later
     end
   end
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -25,6 +25,9 @@ Otwarchive::Application.configure do
   # Don't care if the mailer can't send
   config.action_mailer.raise_delivery_errors = false
 
+  # Enable mailer previews at http://localhost:3000/rails/mailers.
+  config.action_mailer.show_previews = true
+
   # Print deprecation notices to the Rails logger
   config.active_support.deprecation = :log
 

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -46,6 +46,9 @@ Otwarchive::Application.configure do
   # Disable delivery errors, bad email addresses will be ignored
   # config.action_mailer.raise_delivery_errors = false
 
+  # Enable mailer previews.
+  config.action_mailer.show_previews = true
+
   # Enable threaded mode
   # config.threadsafe!
 

--- a/config/initializers/monkeypatches/mailers_controller.rb
+++ b/config/initializers/monkeypatches/mailers_controller.rb
@@ -1,0 +1,10 @@
+module MailersController
+  extend ActiveSupport::Concern
+
+  included do
+    # Hide the dev mark in mailer previews.
+    skip_rack_dev_mark
+  end
+end
+
+::Rails::MailersController.include MailersController

--- a/features/support/factories.rb
+++ b/features/support/factories.rb
@@ -1,2 +1,0 @@
-FactoryBot.find_definitions
-FactoryBot.definition_file_paths = %w(factories)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,9 +17,6 @@ DatabaseCleaner.clean
 # in spec/support/ and its subdirectories.
 Dir[Rails.root.join("spec/support/**/*.rb")].sort.each { |f| require f }
 
-FactoryBot.find_definitions
-FactoryBot.definition_file_paths = %w[factories]
-
 RSpec.configure do |config|
   config.mock_with :rspec
 

--- a/test/mailers/previews/application_mailer_preview.rb
+++ b/test/mailers/previews/application_mailer_preview.rb
@@ -1,0 +1,15 @@
+require "factory_bot_rails"
+
+class ApplicationMailerPreview < ActionMailer::Preview
+  include FactoryBot::Syntax::Methods
+
+  # Avoid saving data created for mailer previews.
+  def self.call(...)
+    message = nil
+    ActiveRecord::Base.transaction do
+      message = super(...)
+      raise ActiveRecord::Rollback
+    end
+    message
+  end
+end

--- a/test/mailers/previews/user_mailer_preview.rb
+++ b/test/mailers/previews/user_mailer_preview.rb
@@ -1,0 +1,29 @@
+class UserMailerPreview < ApplicationMailerPreview
+  # Sends email when an archivist adds someone as a co-creator.
+  def creatorship_notification_archivist
+    second_creatorship, first_creator = creatorship_notification_data
+    UserMailer.creatorship_notification_archivist(second_creatorship.id, first_creator.id)
+  end
+
+  # Sends email when a user is added as a co-creator
+  def creatorship_notification
+    second_creatorship, first_creator = creatorship_notification_data
+    UserMailer.creatorship_notification(second_creatorship.id, first_creator.id)
+  end
+
+  # Sends email when a user is added as an unapproved/pending co-creator
+  def creatorship_request
+    second_creatorship, first_creator = creatorship_notification_data
+    UserMailer.creatorship_request(second_creatorship.id, first_creator.id)
+  end
+
+  private
+
+  def creatorship_notification_data
+    first_creator = create(:user, login: "JayceHexmaster")
+    second_creator = create(:user, login: "viktor_the_machine")
+    work = create(:work, authors: [first_creator.default_pseud, second_creator.default_pseud])
+    second_creatorship = Creatorship.find_by(creation: work, pseud: second_creator.default_pseud)
+    [second_creatorship, first_creator]
+  end
+end


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6307

## Purpose

Enable mailer previews in development and staging.

- Patch the preview UI to [hide the ribbon dev mark](https://github.com/dtaniwaki/rack-dev-mark#temporarily-disable-the-dev-mark).
- To make the previews' locale selector work, move the `I18n.with_locale` block outside the mailer methods.
- Wrap the previews in a transaction and roll back to avoid saving preview data to the database.
- Use factory_bot to generate preview data.

Simplify factory_bot setup.

- In development and test, include factory_bot_rails which automatically finds and loads definitions.
- In staging, install only factory_bot without loading it by default, because we don't want it used outside mailer previews where we explicitly require it.

## Testing Instructions

The preview UI should be at https://test.archiveofourown.org/rails/mailers.