### PR TITLE
AO3-6307 Fix factory_bot loading for mailer previews

### DIFF
--- a/test/mailers/previews/application_mailer_preview.rb
+++ b/test/mailers/previews/application_mailer_preview.rb
@@ -1,4 +1,6 @@
-require "factory_bot_rails"
+require "factory_bot"
+
+FactoryBot.find_definitions
 
 class ApplicationMailerPreview < ActionMailer::Preview
   include FactoryBot::Syntax::Methods


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6307

## Purpose

We don't use factory_bot_rails in staging to avoid always loading factories, so we need to require factory_bot and manually load factory definitions instead.

## Testing Instructions

The preview UI should be at https://test.archiveofourown.org/rails/mailers.