### PR TITLE
AO3-6307 Fix faker loading for mailer previews

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -168,6 +168,7 @@ end
 group :test, :development, :staging do
   gem 'bullet', '>= 5.7.3'
   gem "factory_bot", require: false
+  gem "faker", require: false
 end
 
 # Deploy with Capistrano

--- a/Gemfile
+++ b/Gemfile
@@ -131,7 +131,6 @@ group :test do
   gem 'cucumber-rails', require: false
   gem 'launchy'    # So you can do Then show me the page
   gem 'delorean'
-  gem "faker"
   # Record and replay data from external URLs
   gem 'vcr', '~> 3.0', '>= 3.0.1'
   gem 'webmock', '~> 3.7.6'


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6307

## Purpose

We're missing the faker gem in staging.

I found a way to test this locally. By default `bundle install` will add every gem regardless of which group it's in. I used `bundle install --without development test production` in the Dockerfile to get only the staging set to reproduce the 500 error in mailer previews and verify the fix.

## Testing Instructions

https://test.archiveofourown.org/rails/mailers loads.