### PR TITLE
AO3-6371 Add no resets role

### DIFF
--- a/app/controllers/users/passwords_controller.rb
+++ b/app/controllers/users/passwords_controller.rb
@@ -6,7 +6,7 @@ class Users::PasswordsController < Devise::PasswordsController
   layout "session"
 
   def create
-    if User.find_for_authentication(resource_params.permit(:login))&.protected_user
+    if User.find_for_authentication(resource_params.permit(:login))&.prevent_password_resets?
       flash[:error] = t(".reset_blocked", contact_abuse_link: view_context.link_to(t(".contact_abuse"), new_abuse_report_path)).html_safe
       redirect_to root_path and return
     end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -313,7 +313,7 @@ class User < ApplicationRecord
   end
 
   def prevent_password_resets?
-    is_protected_user? || is_no_resets?
+    is_protected_user? || no_resets?
   end
 
   protected
@@ -421,7 +421,7 @@ class User < ApplicationRecord
 
   # Is this user assigned the no resets role? These users do no wish to receive
   # password resets.
-  def is_no_resets?
+  def no_resets?
     has_role?(:no_resets)
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -312,6 +312,10 @@ class User < ApplicationRecord
     self.preference = Preference.new(preferred_locale: Locale.default.id)
   end
 
+  def prevent_password_resets?
+    is_protected_user? || is_no_resets?
+  end
+
   protected
     def first_save?
       self.new_record?
@@ -406,14 +410,19 @@ class User < ApplicationRecord
   end
 
   # Is this user a protected user? These are users experiencing certain types
-  # of harassment. For now, this is only used to prevent harassment via repeated
-  # password reset requests.
+  # of harassment.
   def protected_user
     self.is_protected_user?
   end
 
   def is_protected_user?
     has_role?(:protected_user)
+  end
+
+  # Is this user assigned the no resets role? These users do no wish to receive
+  # password resets.
+  def is_no_resets?
+    has_role?(:no_resets)
   end
 
   # Creates log item tracking changes to user

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -419,7 +419,7 @@ class User < ApplicationRecord
     has_role?(:protected_user)
   end
 
-  # Is this user assigned the no resets role? These users do no wish to receive
+  # Is this user assigned the no resets role? These users do not wish to receive
   # password resets.
   def no_resets?
     has_role?(:no_resets)

--- a/features/step_definitions/user_steps.rb
+++ b/features/step_definitions/user_steps.rb
@@ -177,6 +177,11 @@ Given "the user {string} is a protected user" do |login|
   user.roles = [Role.find_or_create_by(name: "protected_user")]
 end
 
+Given "the user {string} has the no resets role" do |login|
+  user = User.find_by(login: login)
+  user.roles = [Role.find_or_create_by(name: "no_resets")]
+end
+
 # WHEN
 
 When /^I follow the link for "([^"]*)" first invite$/ do |login|

--- a/features/users/authenticate_users.feature
+++ b/features/users/authenticate_users.feature
@@ -226,11 +226,11 @@ Feature: User Authentication
     Then I should see "Successfully logged in."
       And I should see "You'll stay logged in for 2 weeks even if you close your browser"
 
-  Scenario: Passwords cannot be reset for users who have been given the protected role due to trolling or harassment.
+  Scenario Outline: Passwords cannot be reset for users with certain roles.
     Given the following activated user exists
       | login  | email            |
       | target | user@example.com |
-      And the user "target" is a protected user
+      And the user "target" <role>
     When I am on the home page
       And I follow "Forgot password?"
       And I fill in "Email address or user name" with "target"
@@ -245,21 +245,7 @@ Feature: User Authentication
       And I should see "Password resets are disabled for that user."
       And 0 emails should be delivered
 
-  Scenario: Passwords cannot be reset for users who have been given the no resets role.
-    Given the following activated user exists
-      | login  | email            |
-      | target | user@example.com |
-      And the user "target" has the no resets role
-    When I am on the home page
-      And I follow "Forgot password?"
-      And I fill in "Email address or user name" with "target"
-      And I press "Reset Password"
-    Then I should be on the home page
-      And I should see "Password resets are disabled for that user."
-      And 0 emails should be delivered
-    When I follow "Forgot password?"
-      And I fill in "Email address or user name" with "user@example.com"
-      And I press "Reset Password"
-    Then I should be on the home page
-      And I should see "Password resets are disabled for that user."
-      And 0 emails should be delivered
+    Examples:
+      | role                   |
+      | is a protected user    |
+      | has the no resets role |

--- a/features/users/authenticate_users.feature
+++ b/features/users/authenticate_users.feature
@@ -244,3 +244,22 @@ Feature: User Authentication
     Then I should be on the home page
       And I should see "Password resets are disabled for that user."
       And 0 emails should be delivered
+
+  Scenario: Passwords cannot be reset for users who have been given the no resets role.
+    Given the following activated user exists
+      | login  | email            |
+      | target | user@example.com |
+      And the user "target" has the no resets role
+    When I am on the home page
+      And I follow "Forgot password?"
+      And I fill in "Email address or user name" with "target"
+      And I press "Reset Password"
+    Then I should be on the home page
+      And I should see "Password resets are disabled for that user."
+      And 0 emails should be delivered
+    When I follow "Forgot password?"
+      And I fill in "Email address or user name" with "user@example.com"
+      And I press "Reset Password"
+    Then I should be on the home page
+      And I should see "Password resets are disabled for that user."
+      And 0 emails should be delivered

--- a/lib/tasks/defaults.rake
+++ b/lib/tasks/defaults.rake
@@ -1,7 +1,7 @@
 namespace :defaults do
   desc "Create default roles by name"
   task(create_roles: :environment) do
-    %w[archivist opendoors protected_user tag_wrangler translation_admin translator official].each do |role|
+    %w[archivist no_resets opendoors protected_user tag_wrangler translation_admin translator official].each do |role|
       Role.find_or_create_by(name: role)
     end
   end

--- a/spec/lib/tasks/defaults.rake_spec.rb
+++ b/spec/lib/tasks/defaults.rake_spec.rb
@@ -4,7 +4,7 @@ describe "rake defaults:create_roles" do
   it "creates roles" do
     subject.invoke
 
-    role_names = %w[archivist official opendoors protected_user tag_wrangler translation_admin translator]
+    role_names = %w[archivist no_resets official opendoors protected_user tag_wrangler translation_admin translator]
     expect(Role.all.pluck(:name)).to eq(role_names)
   end
 end


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6371

## Purpose

Maims the English language in service of creating a user role that _only_ prevents password resets, not other forms of harassment.

## Testing Instructions

Refer to Jira.
