### PR TITLE
AO3-6344 Add retry-after header when rate limited

### DIFF
--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -50,6 +50,10 @@ class Rack::Attack
     req.ip
   end
 
+  # Add Retry-After response header to let polite clients know
+  # how many seconds they should wait before trying again
+  Rack::Attack.throttled_response_retry_after_header = true
+
   ### Prevent Brute-Force Login Attacks ###
 
   # The most common brute-force login attack is a brute-force password

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -50,10 +50,6 @@ class Rack::Attack
     req.ip
   end
 
-  # Add Retry-After response header to let polite clients know
-  # how many seconds they should wait before trying again
-  Rack::Attack.throttled_response_retry_after_header = true
-
   ### Prevent Brute-Force Login Attacks ###
 
   # The most common brute-force login attack is a brute-force password
@@ -84,6 +80,10 @@ class Rack::Attack
   throttle("logins/email", limit: login_limit, period: login_period) do |req|
     req.params.dig("user", "login").presence if req.path == "/users/login" && req.post?
   end
+  
+  # Add Retry-After response header to let polite clients know
+  # how many seconds they should wait before trying again
+  Rack::Attack.throttled_response_retry_after_header = true
 
   ### Custom Throttle Response ###
 

--- a/spec/requests/rack_attack_spec.rb
+++ b/spec/requests/rack_attack_spec.rb
@@ -63,7 +63,7 @@ describe "Rack::Attack" do
       expect(response).to have_http_status(:too_many_requests)
       expect(response.headers["Retry-After"]).not_to be_nil
       expect(response.headers["Retry-After"].to_i).to be > 0
-      expect(response.headers["Retry-After"].to_i).to be <= ArchiveConfig.RATE_LIMIT_PERIOD
+      expect(response.headers["Retry-After"].to_i).to be <= ArchiveConfig.RATE_LIMIT_LOGIN_PERIOD
     end
 
     it "throttles the next attempt from the same IP" do
@@ -97,7 +97,7 @@ describe "Rack::Attack" do
       expect(response).to have_http_status(:too_many_requests)
       expect(response.headers["Retry-After"]).not_to be_nil
       expect(response.headers["Retry-After"].to_i).to be > 0
-      expect(response.headers["Retry-After"].to_i).to be <= ArchiveConfig.RATE_LIMIT_PERIOD
+      expect(response.headers["Retry-After"].to_i).to be <= ArchiveConfig.RATE_LIMIT_LOGIN_PERIOD
     end
 
     it "throttles the next attempt for the same username" do

--- a/spec/requests/rack_attack_spec.rb
+++ b/spec/requests/rack_attack_spec.rb
@@ -25,6 +25,30 @@ describe "Rack::Attack" do
     expect(response).to have_http_status(:redirect)
   end
 
+  it "successful response does not include retry-after header" do
+    get root_path, env: { "REMOTE_ADDR" => Faker::Internet.unique.ip_v4_address }
+    expect(response).to have_http_status(:ok)
+    expect(response.headers["Retry-After"]).to be_nil
+  end
+
+  context "when there have been max number of requests from an IP address" do
+    let(:ip) { Faker::Internet.unique.ip_v4_address }
+
+    before do
+      ArchiveConfig.RATE_LIMIT_NUMBER.times do
+        get root_path, env: { "REMOTE_ADDR" => ip }
+      end
+    end
+
+    it "response to the next attempt from the same IP includes retry-after header" do
+      get root_path, env: { "REMOTE_ADDR" => ip }
+      expect(response).to have_http_status(:too_many_requests)
+      expect(response.headers["Retry-After"]).not_to be_nil
+      expect(response.headers["Retry-After"].to_i).to be > 0
+      expect(response.headers["Retry-After"].to_i).to be <= ArchiveConfig.RATE_LIMIT_PERIOD
+    end
+  end
+
   context "when there have been max user login attempts from an IP address" do
     let(:ip) { Faker::Internet.unique.ip_v4_address }
 
@@ -32,6 +56,14 @@ describe "Rack::Attack" do
       ArchiveConfig.RATE_LIMIT_LOGIN_ATTEMPTS.times do
         post user_session_path, params: unique_user_params.to_query, env: { "REMOTE_ADDR" => ip }
       end
+    end
+
+    it "response to the next attempt from the same IP includes retry-after header" do
+      post user_session_path, params: unique_user_params.to_query, env: { "REMOTE_ADDR" => ip }
+      expect(response).to have_http_status(:too_many_requests)
+      expect(response.headers["Retry-After"]).not_to be_nil
+      expect(response.headers["Retry-After"].to_i).to be > 0
+      expect(response.headers["Retry-After"].to_i).to be <= ArchiveConfig.RATE_LIMIT_PERIOD
     end
 
     it "throttles the next attempt from the same IP" do
@@ -58,6 +90,14 @@ describe "Rack::Attack" do
       ArchiveConfig.RATE_LIMIT_LOGIN_ATTEMPTS.times do
         post user_session_path, params: params, env: unique_ip_env
       end
+    end
+
+    it "response to the next attempt for the same username includes retry-after header" do
+      post user_session_path, params: params, env: unique_ip_env
+      expect(response).to have_http_status(:too_many_requests)
+      expect(response.headers["Retry-After"]).not_to be_nil
+      expect(response.headers["Retry-After"].to_i).to be > 0
+      expect(response.headers["Retry-After"].to_i).to be <= ArchiveConfig.RATE_LIMIT_PERIOD
     end
 
     it "throttles the next attempt for the same username" do

--- a/spec/requests/rack_attack_spec.rb
+++ b/spec/requests/rack_attack_spec.rb
@@ -26,13 +26,13 @@ describe "Rack::Attack" do
   end
 
   it "successful response does not include retry-after header" do
-    get root_path, env: { "REMOTE_ADDR" => Faker::Internet.unique.ip_v4_address }
+    get root_path, env: { "REMOTE_ADDR" => Faker::Internet.unique.public_ip_v4_address }
     expect(response).to have_http_status(:ok)
     expect(response.headers["Retry-After"]).to be_nil
   end
 
   context "when there have been max number of requests from an IP address" do
-    let(:ip) { Faker::Internet.unique.ip_v4_address }
+    let(:ip) { Faker::Internet.unique.public_ip_v4_address }
 
     before do
       ArchiveConfig.RATE_LIMIT_NUMBER.times do
@@ -43,14 +43,13 @@ describe "Rack::Attack" do
     it "response to the next attempt from the same IP includes retry-after header" do
       get root_path, env: { "REMOTE_ADDR" => ip }
       expect(response).to have_http_status(:too_many_requests)
-      expect(response.headers["Retry-After"]).not_to be_nil
       expect(response.headers["Retry-After"].to_i).to be > 0
       expect(response.headers["Retry-After"].to_i).to be <= ArchiveConfig.RATE_LIMIT_PERIOD
     end
   end
 
   context "when there have been max user login attempts from an IP address" do
-    let(:ip) { Faker::Internet.unique.ip_v4_address }
+    let(:ip) { Faker::Internet.unique.public_ip_v4_address }
 
     before do
       ArchiveConfig.RATE_LIMIT_LOGIN_ATTEMPTS.times do
@@ -61,7 +60,6 @@ describe "Rack::Attack" do
     it "response to the next attempt from the same IP includes retry-after header" do
       post user_session_path, params: unique_user_params.to_query, env: { "REMOTE_ADDR" => ip }
       expect(response).to have_http_status(:too_many_requests)
-      expect(response.headers["Retry-After"]).not_to be_nil
       expect(response.headers["Retry-After"].to_i).to be > 0
       expect(response.headers["Retry-After"].to_i).to be <= ArchiveConfig.RATE_LIMIT_LOGIN_PERIOD
     end
@@ -95,7 +93,6 @@ describe "Rack::Attack" do
     it "response to the next attempt for the same username includes retry-after header" do
       post user_session_path, params: params, env: unique_ip_env
       expect(response).to have_http_status(:too_many_requests)
-      expect(response.headers["Retry-After"]).not_to be_nil
       expect(response.headers["Retry-After"].to_i).to be > 0
       expect(response.headers["Retry-After"].to_i).to be <= ArchiveConfig.RATE_LIMIT_LOGIN_PERIOD
     end


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6344

## Purpose

Add "Retry-After" response header to "too many requests" responses so that polite clients know how long to back off for

## Testing Instructions

- Change RATE_LIMIT_NUMBER in config.yml to 1 and navigate to the root page with the network tab open
- Refresh the page, you should see "Retry later"
- Check the response headers in the network tab to ensure that "Retry-After" is present

## Credit

Name: nianeyna
Jira name: Nia Neyna
Pronouns: she/her