### PR TITLE
AO3-5801 Do not close self-closing tags for better HTML5 compliance

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -535,7 +535,7 @@ module ApplicationHelper
 
   def first_paragraph(full_text, placeholder_text = 'No preview available.')
     # is there a paragraph that does not have a child image?
-    paragraph = Nokogiri::HTML.parse(full_text).at_xpath('//p[not(img)]')
+    paragraph = Nokogiri::HTML5.parse(full_text).at_xpath("//p[not(img)]")
     if paragraph.present?
       # if so, get its text and put it in a fresh p tag
       paragraph_text = paragraph.text

--- a/config/initializers/gem-plugin_config/sanitizer_config.rb
+++ b/config/initializers/gem-plugin_config/sanitizer_config.rb
@@ -36,10 +36,6 @@ class Sanitize
         'img' => {'src' => ['http', 'https', :relative]},
         'q' => {'cite' => ['http', 'https', :relative]}
       },
-      
-      # TODO: This can be removed once we upgrade sanitizer gem, AO3-5801
-      # I would leave the tests we added in AO3-5974 though.
-      remove_contents: %w[iframe math noembed noframes noscript plaintext script style svg xmp]
     )
 
     CLASS_ATTRIBUTE = freeze_config(

--- a/features/other_b/sanitizer.feature
+++ b/features/other_b/sanitizer.feature
@@ -5,7 +5,7 @@ Feature: Sanitizing HTML
 
     When I am logged in as "newbie" with password "password"
     And I set up the draft "My Awesome Story"
-    And I fill in "content" with 
+    And I fill in "content" with
     """
     The quick brown fox jumps over the lazy dog.
     <!-- #exec cmd=\"/bin/echo \" -->
@@ -15,6 +15,22 @@ Feature: Sanitizing HTML
     Then I should see "Preview"
     And I should not see the text with tags '<!-- #exec cmd='
     And I should not see the text with tags '<script src=http://ha.ckers.org/xss.js></script>'
+
+
+  Scenario: Sanitizer should leave safe HTML alone
+
+    When I am logged in as "newbie" with password "password"
+    And I set up the draft "My Awesome Story"
+    And I fill in "content" with
+    """
+    1. Lorem ipsim
+
+    2. <a href="https://en.wikipedia.org/wiki/The_quick_brown_fox_jumps_over_the_lazy_dog"><em>The quick brown fox jumps over the lazy dog</em></a>.
+    """
+    And I press "Preview"
+    Then I should see "Preview"
+    And I should see "The quick brown fox jumps over the lazy dog" within "p a em"
+    And I should see the text with tags '"https://en.wikipedia.org/wiki/The_quick_brown_fox_jumps_over_the_lazy_dog"'
 
 
   Scenario: XSS hacks in works should be blocked by sanitizing

--- a/lib/html_cleaner.rb
+++ b/lib/html_cleaner.rb
@@ -38,6 +38,10 @@ module HtmlCleaner
       flatten.include?("p")
     end
 
+    def immediately_inside_paragraph?
+      flatten.select { |x| x.is_a? String }.last == "p"
+    end
+
     def ignore_tag?(tag)
       ["text", "myroot", "#cdata-section"].include?(tag)
     end
@@ -67,13 +71,18 @@ module HtmlCleaner
       end
     end
 
-    def close_and_pop_last
+    def close_and_pop_last(num = nil)
       result = ""
-      pop.reverse.each do |tag, attributes|
+      popped = pop.reverse
+      num ||= popped.size
+      popped[0...num].each do |tag, _|
         next if ignore_tag?(tag)
         result += "</#{tag}>"
       end
-      return result
+
+      push(popped[num..].reverse) unless popped[num..].empty?
+
+      result
     end
 
     def add_p
@@ -169,14 +178,9 @@ module HtmlCleaner
         unfrozen_value = add_paragraphs_to_text(Sanitize.clean(fix_bad_characters(unfrozen_value),
                                Sanitize::Config::ARCHIVE.merge(transformers: transformers))) unless field.to_s == "screencast"
       end
-      doc = Nokogiri::HTML::Document.new
+      doc = Nokogiri::HTML5::Document.new
       doc.encoding = "UTF-8"
-      unfrozen_value = doc.fragment(unfrozen_value).to_xhtml
-
-      # Hack! the herald angels sing
-      # TODO: AO3-5801 Switch to an HTML5 serializer that doesn't add invalid closing tags
-      # to track and source elements.
-      unfrozen_value.gsub!(%r{</(source|track)>}, "")
+      unfrozen_value = doc.fragment(unfrozen_value).to_html
     else
       # clean out all tags
       unfrozen_value = Sanitize.clean(fix_bad_characters(unfrozen_value))
@@ -241,14 +245,14 @@ module HtmlCleaner
 
   # Tags that can't be inside p tags
   def put_outside_p_tag?(tag)
-    %w(audio dl h1 h2 h3 h4 h5 h6 hr ol p pre source table track ul video).include?(tag)
+    %w[address audio blockquote center div dl h1 h2 h3 h4 h5 h6 hr ol p pre source table track ul video].include?(tag)
   end
 
   # Tags before and after which we don't want to convert linebreaks
   # into br's and p's
   def no_break_before_after_tag?(tag)
-    %w(audio blockquote br center dl div h1 h2 h3 h4 h5 h6
-       hr ol p pre source table track ul video).include?(tag)
+    %w[audio blockquote br center div dl h1 h2 h3 h4 h5 h6
+       hr ol p pre source table track ul video].include?(tag)
   end
 
   # Traverse a Nokogiri document tree recursively in order to insert
@@ -258,8 +262,8 @@ module HtmlCleaner
   # creating a string with the resulting html and keep track of the
   # changed path to the current element via a stack.
   def traverse_nodes(node, stack=nil, out_html=nil)
-    stack = stack || TagStack.new
-    out_html = out_html || ""
+    stack ||= TagStack.new
+    out_html ||= ""
 
     # Convert double and triple br tags into paragraph breaks
     if node.name == "br" && node.previous_sibling && node.previous_sibling.name == "br" && node.previous_sibling.previous_sibling && node.previous_sibling.previous_sibling.name == "br"
@@ -278,7 +282,7 @@ module HtmlCleaner
     # this kind of tag
     if dont_touch_content_tag?(node.name)
       if put_inside_p_tag?(node.name) && !stack.inside_paragraph?
-        return [stack, out_html + "<p>#{node.to_s}</p>"]
+        return [stack, out_html + "<p>#{node}</p>"]
       end
 
       if put_outside_p_tag?(node.name) && stack.inside_paragraph?
@@ -290,20 +294,17 @@ module HtmlCleaner
     end
 
     if !node.text? && !node.cdata?
+      out_html += stack.close_and_pop_last(1) if put_outside_p_tag?(node.name) && stack.immediately_inside_paragraph?
+
       out_html += stack.add_p if put_inside_p_tag?(node.name) && !stack.inside_paragraph?
 
       stack << [[node.name, Hash[*(node.attribute_nodes.map { |n| [n.name, n.value] }.flatten)]]]
       out_html += open_tag(node)
 
       # If we are the root node, pre-emptively open a paragraph
-      if node.name == "myroot"
-        out_html += stack.add_p
-      end
+      out_html += stack.add_p if node.name == "myroot" && node.children.any? { |x| put_inside_p_tag?(x.name) || x.text? || x.cdata? }
 
-      if no_break_before_after_tag?(node.name) and !stack.last.include?("p")
-        out_html += stack.add_p
-      end
-
+      out_html += stack.add_p if no_break_before_after_tag?(node.name) && !stack.last.include?("p")
     else
       text = node.to_s
 
@@ -361,8 +362,9 @@ module HtmlCleaner
     end
 
     # Adding paragraphs in place of linebreaks
-    doc = Nokogiri::HTML.fragment("<myroot>#{text}</myroot>")
+    doc = Nokogiri::HTML5.fragment("<myroot>#{text}</myroot>")
     out_html = traverse_nodes(doc.at_css("myroot"))[1]
+
     # Remove empty paragraphs
     out_html.gsub!(/<p>\s*?<\/p>/, "")
     out_html.gsub!(/(\A<myroot>)|(<\/myroot>\Z)|(\A<myroot\/>\Z)/, "")

--- a/lib/otw_sanitize/embed_sanitizer.rb
+++ b/lib/otw_sanitize/embed_sanitizer.rb
@@ -155,7 +155,7 @@ module OtwSanitize
       end
       return if mp3_urls.blank?
 
-      audio_fragment = Nokogiri::HTML::DocumentFragment.parse ""
+      audio_fragment = Nokogiri::HTML5::DocumentFragment.parse ""
       Nokogiri::HTML::Builder.with(audio_fragment) do |fragment|
         fragment.p do
           mp3_urls.each_with_index do |url, i|

--- a/lib/word_counter.rb
+++ b/lib/word_counter.rb
@@ -24,9 +24,9 @@ class WordCounter
     # languages, only characters in these languages would be counted as words,
     # words in other languages are counted as usual
     character_count_scripts = ArchiveConfig.CHARACTER_COUNT_SCRIPTS.map { |lang| "\\p{#{lang}}" }.join("|")
-    body = Nokogiri::HTML(@text).xpath('//body').first
+    body = Nokogiri::HTML5.parse(@text).xpath("//body").first
     body.traverse do |node|
-      if node.is_a? Nokogiri::XML::Text
+      if node.text?
         count += node.inner_text.gsub(/--/, "—").gsub(/['’‘-]/, "")
                      .scan(/[#{character_count_scripts}]|((?!#{character_count_scripts})[[:word:]])+/).size
       end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -364,4 +364,10 @@ describe ApplicationHelper do
       end
     end
   end
+
+  describe "#first_paragraph" do
+    it "extracts first paragraph" do
+      expect(first_paragraph("<p>first</p><p>second</p>")).to eq("<p>first</p>")
+    end
+  end
 end

--- a/spec/lib/html_cleaner_spec.rb
+++ b/spec/lib/html_cleaner_spec.rb
@@ -5,6 +5,10 @@ require 'nokogiri'
 describe HtmlCleaner do
   include HtmlCleaner
 
+  def one_cell_table(content)
+    "<table><tr><td>#{content}</td></tr></table>"
+  end
+
   describe "TagStack" do
     let(:stack) { HtmlCleaner::TagStack.new }
 
@@ -123,11 +127,6 @@ describe HtmlCleaner do
       expect(result).to eq("some <s><i>more text</i></s>")
     end
 
-    it "should close tag before next closing tag" do
-      result = close_unclosed_tag("some <s><i>more text</s>", "i", 1)
-      expect(result).to eq("some <s><i>more text</i></s>")
-    end
-
     it "should close second opening tag" do
       result = close_unclosed_tag("some <i>more</i> <i>text", "i", 1)
       expect(result).to eq("some <i>more</i> <i>text</i>")
@@ -172,10 +171,11 @@ describe HtmlCleaner do
           end
         end
 
-        it "keeps google player embeds" do
-          html = '<embed type="application/x-shockwave-flash" flashvars="audioUrl=http://dl.dropbox.com/u/123/foo.mp3" src="http://www.google.com/reader/ui/123-audio-player.swf" width="400" height="27" allowscriptaccess="never" allownetworking="internal"></embed>'
-          result = sanitize_value(field, html)
-          expect(result).to include(html)
+        it "keeps google player embeds without closing tag" do
+          html1 = '<embed type="application/x-shockwave-flash" flashvars="audioUrl=http://dl.dropbox.com/u/123/foo.mp3" src="http://www.google.com/reader/ui/123-audio-player.swf" width="400" height="27" allowscriptaccess="never" allownetworking="internal">'
+          html2 = "#{html1}</embed>"
+          result = sanitize_value(field, html2)
+          expect(result).to include(html1)
         end
 
         it "converts an Archive-hosted Dewplayer embed into an audio tag" do
@@ -206,7 +206,7 @@ describe HtmlCleaner do
         it "converts an Archive-hosted Dewplayer multi embed into audio tags" do
           html = '<embed type="application/x-shockwave-flash" flashvars="mp3=http://example.com/live-again.mp3|http://example.com/cursed-night.mp3" src="https://archiveofourown.org/system/dewplayer/dewplayer.swf" width="200" height="27" allowscriptaccess="never" allownetworking="internal"></embed>'
           result = sanitize_value(field, html)
-          expect(result.squish).to eq('<p> <audio src="https://example.com/live-again.mp3" controls="controls" crossorigin="anonymous" preload="metadata"></audio> <br /> <audio src="https://example.com/cursed-night.mp3" controls="controls" crossorigin="anonymous" preload="metadata"></audio> </p>')
+          expect(result).to eq('<p><audio src="https://example.com/live-again.mp3" controls="controls" crossorigin="anonymous" preload="metadata"></audio><br><audio src="https://example.com/cursed-night.mp3" controls="controls" crossorigin="anonymous" preload="metadata"></audio></p>')
         end
 
         it "strips embeds with unknown source" do
@@ -268,8 +268,8 @@ describe HtmlCleaner do
         context "class has one value" do
           it "keeps values containing only letters, numbers, and hyphens" do
             result = sanitize_value(field, '<p class="f-5">foobar</p>')
-            doc = Nokogiri::HTML.fragment(result)
-            expect(doc.xpath("./p[@class='f-5']").children.to_s.strip).to eq("foobar")
+            doc = Nokogiri::HTML5.fragment(result)
+            expect(doc.xpath("./p[@class='f-5']/node()").to_s.strip).to eq("foobar")
           end
 
           it "strips values starting with a number" do
@@ -291,8 +291,8 @@ describe HtmlCleaner do
         context "class attribute has multiple values" do
           it "keeps all valid values" do
             result = sanitize_value(field, '<p class="foo bar">foobar</p>')
-            doc = Nokogiri::HTML.fragment(result)
-            expect(doc.xpath("./p[contains(@class, 'foo bar')]").children.to_s.strip).to eq("foobar")
+            doc = Nokogiri::HTML5.fragment(result)
+            expect(doc.xpath("./p[contains(@class, 'foo bar')]/node()").to_s.strip).to eq("foobar")
           end
 
           it "strips values starting with numbers" do
@@ -322,12 +322,12 @@ describe HtmlCleaner do
 
     [:content, :endnotes, :notes, :summary].each do |field|
       context "Sanitize #{field} field" do
-        it "should keep html" do
+        it "keeps html" do
           value = "<em>hello</em> <blockquote>world</blockquote>"
           result = sanitize_value(field, value)
-          doc = Nokogiri::HTML.fragment(result)
-          expect(doc.xpath(".//em").children.to_s.strip).to eq("hello")
-          expect(doc.xpath(".//blockquote").children.to_s.strip).to eq("<p>world</p>")
+          doc = Nokogiri::HTML5.fragment(result)
+          expect(doc.xpath(".//em/node()").to_s.strip).to eq("hello")
+          expect(doc.xpath(".//blockquote/node()").to_s.strip).to eq("<p>world</p>")
         end
 
         it "should keep valid unicode chars as is" do
@@ -335,18 +335,16 @@ describe HtmlCleaner do
           expect(result).to match(/„‚nörmäl’—téxt‘“/)
         end
 
-        it "should allow RTL content in p" do
+        it "allows RTL content in p" do
           html = '<p dir="rtl">This is RTL content</p>'
           result = sanitize_value(field, html)
           expect(result).to eq(html)
         end
 
-        it "should allow RTL content in div" do
+        it "allows RTL content in div" do
           html = '<div dir="rtl"><p>This is RTL content</p></div>'
           result = sanitize_value(field, html)
-          # Yes, this is ugly. We should maybe try to figure out why our parser
-          # wants to wrap All The Things in <p> tags.
-          expect(result.to_s.squish).to eq('<p></p><div dir="rtl"> <p>This is RTL content</p> </div>')
+          expect(result).to eq('<div dir="rtl"><p>This is RTL content</p></div>')
         end
 
         it "should not allow iframes with unknown source" do
@@ -578,12 +576,12 @@ describe HtmlCleaner do
         context "add rel=nofollow to all links to defeat spammers' SEO plans" do
           it "adds rel=nofollow to links with no rel attribute" do
             result = sanitize_value(field, "<a href='foo'>Foo</a>")
-            expect(result).to eq("<p>\n  <a href=\"foo\" rel=\"nofollow\">Foo</a>\n</p>")
+            expect(result).to eq("<p><a href=\"foo\" rel=\"nofollow\">Foo</a></p>")
           end
 
           it "adds rel=nofollow to links with a rel attribute" do
             result = sanitize_value(field, "<a href='foo' rel='help'>Foo</a>")
-            expect(result).to eq("<p>\n  <a href=\"foo\" rel=\"nofollow\">Foo</a>\n</p>")
+            expect(result).to eq("<p><a href=\"foo\" rel=\"nofollow\">Foo</a></p>")
           end
         end
 
@@ -656,10 +654,10 @@ describe HtmlCleaner do
   end
 
   describe "add_paragraphs_to_text" do
-    %w(a abbr acronym address).each do |tag|
-      it "should not add extraneous paragraph breaks after #{tag} tags" do
+    %w[a abbr acronym].each do |tag|
+      it "does not add extraneous paragraph breaks after #{tag} tags" do
         result = add_paragraphs_to_text("<#{tag}>quack</#{tag}> quack")
-        doc = Nokogiri::HTML.fragment(result)
+        doc = Nokogiri::HTML5.fragment(result)
         expect(doc.xpath(".//p").size).to eq(1)
         expect(doc.xpath(".//br")).to be_empty
       end
@@ -679,249 +677,291 @@ describe HtmlCleaner do
       expect(result).not_to match("<br")
     end
 
-    it "should not convert linebreaks after p tags" do
+    it "does not convert linebreaks after p tags" do
       result = add_paragraphs_to_text("<p>A</p>\n<p>B</p>\n\n<p>C</p>\n\n\n")
-      doc = Nokogiri::HTML.fragment(result)
-      expect(doc.xpath(".//p").size).to eq(3)
+      doc = Nokogiri::HTML5.fragment(result)
+      expect(doc.xpath("./p").size).to eq(3)
       expect(doc.xpath(".//br")).to be_empty
     end
 
-    %w(dl h1 h2 h3 h4 h5 h6 ol pre table ul).each do |tag|
-      it "should not convert linebreaks after #{tag} tags" do
+    it "does not convert linebreaks after tables" do
+      result = add_paragraphs_to_text("#{one_cell_table('A')}\n#{one_cell_table('A')}\n\n#{one_cell_table('A')}\n\n\n")
+      expect(result).not_to match("<p>")
+      expect(result).not_to match("<br")
+    end
+
+    %w[dl h1 h2 h3 h4 h5 h6 ol pre ul].each do |tag|
+      it "does not convert linebreaks after #{tag} tags" do
         result = add_paragraphs_to_text("<#{tag}>A</#{tag}>\n<#{tag}>B</#{tag}>\n\n<#{tag}>C</#{tag}>\n\n\n")
-        doc = Nokogiri::HTML.fragment(result)
-        expect(doc.xpath(".//p").size).to eq(0)
-        expect(doc.xpath(".//br")).to be_empty
+        expect(result).not_to match("<p>")
+        expect(result).not_to match("<br")
       end
     end
 
-    %w(blockquote center div).each do |tag|
-      it "should not convert linebreaks after #{tag} tags" do
+    %w[blockquote center div].each do |tag|
+      it "does not convert linebreaks after #{tag} tags which produce blocks" do
         result = add_paragraphs_to_text("<#{tag}>A</#{tag}>\n<#{tag}>B</#{tag}>\n\n<#{tag}>C</#{tag}>\n\n\n")
-        doc = Nokogiri::HTML.fragment(result)
-        expect(doc.xpath(".//p").size).to eq(4)
+        doc = Nokogiri::HTML5.fragment(result)
+        expect(doc.xpath("./#{tag}/p").size).to eq(3)
         expect(doc.xpath(".//br")).to be_empty
+      end
+
+      it "does not wrap #{tag} tag with a paragraph" do
+        result = add_paragraphs_to_text("<#{tag}>A</#{tag}>\n<p>B</p>")
+        # This needs XML parsing because HTML parser will silently reinterprets
+        # <p><div>_</div></p> as <p></p><div>_</div>
+        doc = Nokogiri::XML.fragment(result)
+        expect(doc.xpath("./p/#{tag}").size).to eq(0)
+      end
+
+      it "wraps content inside of nested #{tag} tags with a paragraph" do
+        result = add_paragraphs_to_text("<#{tag}><#{tag}>A</#{tag}></#{tag}>")
+        doc = Nokogiri::HTML5.fragment(result)
+        expect(doc.xpath(".//p").size).to eq(1)
+        expect(doc.xpath("./#{tag}/#{tag}/p/node()").to_s).to eq("A")
+      end
+
+      it "does not wrap paragraphs inside of nested #{tag} tags" do
+        result = add_paragraphs_to_text("<#{tag}><#{tag}><#{tag}><p>A</p></#{tag}><p>B</p></#{tag}></#{tag}>")
+        doc = Nokogiri::HTML5.fragment(result)
+        expect(doc.xpath(".//p").size).to eq(2)
+        expect(doc.xpath("./#{tag}/#{tag}/#{tag}/p/node()").to_s).to eq("A")
+        expect(doc.xpath("./#{tag}/#{tag}/p/node()").to_s).to eq("B")
+      end
+
+      it "does not add paragraphs between a #{tag} tag and a paragraph" do
+        result = add_paragraphs_to_text("<#{tag}>A</#{tag}>\n\n<p>B</p>")
+        doc = Nokogiri::HTML5.fragment(result)
+        expect(doc.xpath("./#{tag}/following-sibling::p/node()").to_s).to eq("B")
       end
     end
 
-    it "should not convert linebreaks after br tags" do
+    it "does not convert linebreaks after br tags" do
       result = add_paragraphs_to_text("A<br>B<br>\n\nC<br>\n\n\n")
-      doc = Nokogiri::HTML.fragment(result)
-      expect(doc.xpath(".//p").size).to eq(1)
+      doc = Nokogiri::HTML5.fragment(result)
+      expect(doc.xpath("./p").size).to eq(1)
       expect(doc.xpath(".//br").size).to eq(3)
     end
 
-    it "should not convert linebreaks after hr tags" do
+    it "does not convert linebreaks after hr tags" do
       result = add_paragraphs_to_text("A<hr>B<hr>\n\nC<hr>\n\n\n")
-      doc = Nokogiri::HTML.fragment(result)
-      expect(doc.xpath(".//p").size).to eq(3)
+      doc = Nokogiri::HTML5.fragment(result)
+      expect(doc.xpath("./p").size).to eq(3)
       expect(doc.xpath(".//br")).to be_empty
     end
 
-    %w(dl h1 h2 h3 h4 h5 h6 ol pre table ul).each do |tag|
-      it "should not wrap #{tag} in p tags" do
+    it "does not wrap table in p tags" do
+      result = add_paragraphs_to_text("aa #{one_cell_table('foo')} bb")
+      doc = Nokogiri::XML.fragment(result)
+      expect(doc.xpath(".//p").size).to eq(2)
+      expect(doc.xpath("./table").size).to eq(1)
+    end
+
+    %w[dl h1 h2 h3 h4 h5 h6 ol pre ul].each do |tag|
+      it "does not wrap #{tag} in p tags" do
         result = add_paragraphs_to_text("aa <#{tag}>foo</#{tag}> bb")
-        doc = Nokogiri::HTML.fragment(result)
+        doc = Nokogiri::XML.fragment(result)
         expect(doc.xpath(".//p").size).to eq(2)
-        expect(doc.xpath(".//#{tag}").children.to_s.strip).to eq("foo")
+        expect(doc.xpath("./#{tag}/node()").to_s.strip).to eq("foo")
       end
     end
 
-    ["ol", "ul"].each do |tag|
-      it "should not convert linebreaks inside #{tag} lists" do
-        html = """
-        <#{tag}>
-          <li>A</li>
-          <li>B</li>
-        </#{tag}>
-        """
+    %w[ol ul].each do |tag|
+      it "does not convert linebreaks inside #{tag} lists" do
+        html = <<~HTML
+          <#{tag}>
+            <li>A</li>
+            <li>B</li>
+          </#{tag}>
+        HTML
 
         result = add_paragraphs_to_text(html)
-        doc = Nokogiri::HTML.fragment(result)
-        expect(doc.xpath("./#{tag}/li[1]").children.to_s.strip).to eq("A")
-        expect(doc.xpath("./#{tag}/li[2]").children.to_s.strip).to eq("B")
+        doc = Nokogiri::HTML5.fragment(result)
+        expect(doc.xpath("./#{tag}/li[1]/node()").to_s.strip).to eq("A")
+        expect(doc.xpath("./#{tag}/li[2]/node()").to_s.strip).to eq("B")
         expect(doc.xpath(".//br")).to be_empty
       end
     end
 
-    it "should not convert linebreaks inside tables" do
-      html = """
-      <table>
-        <tr>
-          <th>A</th>
-          <th>B</th>
-        </tr>
-        <tr>
-          <td>C</td>
-          <td>D</td>
-        </tr>
-      </table>
-      """
+    it "does not convert linebreaks inside tables" do
+      html = <<~TABLE
+        <table>
+          <tr>
+            <th>A</th>
+            <th>B</th>
+          </tr>
+          <tr>
+            <td>C</td>
+            <td>D</td>
+          </tr>
+        </table>
+      TABLE
 
       result = add_paragraphs_to_text(html)
-      doc = Nokogiri::HTML.fragment(result)
-      expect(doc.xpath("./table/tr[1]/th[1]").children.to_s.strip).to eq("A")
-      expect(doc.xpath("./table/tr[1]/th[2]").children.to_s.strip).to eq("B")
-      expect(doc.xpath("./table/tr[2]/td[1]").children.to_s.strip).to eq("C")
-      expect(doc.xpath("./table/tr[2]/td[2]").children.to_s.strip).to eq("D")
+      doc = Nokogiri::HTML5.fragment(result)
+      expect(doc.xpath("./table//tr[1]/th[1]/node()").to_s.strip).to eq("A")
+      expect(doc.xpath("./table//tr[1]/th[2]/node()").to_s.strip).to eq("B")
+      expect(doc.xpath("./table//tr[2]/td[1]/node()").to_s.strip).to eq("C")
+      expect(doc.xpath("./table//tr[2]/td[2]/node()").to_s.strip).to eq("D")
       expect(doc.xpath(".//br")).to be_empty
     end
 
-    it "should not convert linebreaks inside definition lists" do
-      html = """
-      <dl>
-        <dt>A</dt>
-        <dd>aaa</dd>
-        <dt>B</dt>
-        <dd>bbb</dd>
-      </dl>
-      """
+    it "does not convert linebreaks inside definition lists" do
+      html = <<~HTML
+        <dl>
+          <dt>A</dt>
+          <dd>aaa</dd>
+          <dt>B</dt>
+          <dd>bbb</dd>
+        </dl>
+      HTML
 
       result = add_paragraphs_to_text(html)
-      doc = Nokogiri::HTML.fragment(result)
-      expect(doc.xpath("./dl/dt[1]").children.to_s.strip).to eq("A")
-      expect(doc.xpath("./dl/dd[1]").children.to_s.strip).to eq("aaa")
-      expect(doc.xpath("./dl/dt[2]").children.to_s.strip).to eq("B")
-      expect(doc.xpath("./dl/dd[2]").children.to_s.strip).to eq("bbb")
+      doc = Nokogiri::HTML5.fragment(result)
+      expect(doc.xpath("./dl/dt[1]/node()").to_s.strip).to eq("A")
+      expect(doc.xpath("./dl/dd[1]/node()").to_s.strip).to eq("aaa")
+      expect(doc.xpath("./dl/dt[2]/node()").to_s.strip).to eq("B")
+      expect(doc.xpath("./dl/dd[2]/node()").to_s.strip).to eq("bbb")
       expect(doc.xpath(".//br")).to be_empty
     end
 
-    %w(address h1 h2 h3 h4 h5 h6 p pre).each do |tag|
-      it "should not wrap in p and not convert linebreaks inside #{tag} tags" do
+    %w[address h1 h2 h3 h4 h5 h6 p pre].each do |tag|
+      it "does not wrap in p and not convert linebreaks inside #{tag} tags" do
         result = add_paragraphs_to_text("<#{tag}>A\nB\n\nC\n\n\nD</#{tag}>")
-        doc = Nokogiri::HTML.fragment(result)
-        expect(doc.xpath("./#{tag}[1]").children.to_s.strip).to eq("A\nB\n\nC\n\n\nD")
+        doc = Nokogiri::XML.fragment(result)
+        expect(doc.xpath("./#{tag}[1]/node()").to_s.strip).to eq("A\nB\n\nC\n\n\nD")
       end
     end
 
-    %w(a abbr acronym).each do |tag|
-      it "should wrap in p and not convert linebreaks inside #{tag} tags" do
+    %w[a abbr acronym].each do |tag|
+      it "wraps in p and not convert linebreaks inside #{tag} tags" do
         result = add_paragraphs_to_text("<#{tag}>A\nB\n\nC\n\n\nD</#{tag}>")
-        doc = Nokogiri::HTML.fragment(result)
-        expect(doc.xpath("./p/#{tag}[1]").children.to_s.strip).to eq("A\nB\n\nC\n\n\nD")
+        doc = Nokogiri::HTML5.fragment(result)
+        expect(doc.xpath("./p/#{tag}[1]/node()").to_s.strip).to eq("A\nB\n\nC\n\n\nD")
       end
     end
 
-    it "should wrap plain text in p tags" do
+    it "wraps plain text in p tags" do
       result = add_paragraphs_to_text("some text")
-      doc = Nokogiri::HTML.fragment(result)
-      expect(doc.xpath("./p[1]").children.to_s.strip).to eq("some text")
+      doc = Nokogiri::HTML5.fragment(result)
+      expect(doc.xpath("./p[1]/node()").to_s.strip).to eq("some text")
     end
 
-    it "should convert single linebreak to br" do
+    it "converts single linebreak to br" do
       result = add_paragraphs_to_text("some\ntext")
-      doc = Nokogiri::HTML.fragment(result)
-      expect(doc.xpath("./p[1]").children.to_s.strip).to match(/some<br\/?>text/)
+      doc = Nokogiri::HTML5.fragment(result)
+      expect(doc.xpath("./p[1]/node()").to_s.strip).to match(%r{some<br\/?>text})
     end
 
-    it "should convert double linebreaks to paragraph break" do
+    it "converts double linebreaks to paragraph break" do
       result = add_paragraphs_to_text("some\n\ntext")
-      doc = Nokogiri::HTML.fragment(result)
-      expect(doc.xpath("./p[1]").children.to_s.strip).to eq("some")
-      expect(doc.xpath("./p[2]").children.to_s.strip).to eq("text")
+      doc = Nokogiri::HTML5.fragment(result)
+      expect(doc.xpath("./p[1]/node()").to_s.strip).to eq("some")
+      expect(doc.xpath("./p[2]/node()").to_s.strip).to eq("text")
     end
 
-    it "should convert triple linebreaks into blank paragraph" do
+    it "converts triple linebreaks into blank paragraph" do
       result = add_paragraphs_to_text("some\n\n\ntext")
-      doc = Nokogiri::HTML.fragment(result)
-      expect(doc.xpath("./p[1]").children.to_s.strip).to eq("some")
-      expect(doc.xpath("./p[2]").children.to_s.strip.ord).to eq(160)
-      expect(doc.xpath("./p[3]").children.to_s.strip).to eq("text")
+      doc = Nokogiri::HTML5.fragment(result)
+      expect(doc.xpath("./p[1]/node()").to_s.strip).to eq("some")
+      expect(doc.xpath("./p[2]/node()").to_s.strip).to eq("&nbsp;")
+      expect(doc.xpath("./p[3]/node()").to_s.strip).to eq("text")
     end
 
-    it "should convert double br tags into paragraph break" do
+    it "converts double br tags into paragraph break" do
       result = add_paragraphs_to_text("some<br/><br/>text")
-      doc = Nokogiri::HTML.fragment(result)
-      expect(doc.xpath("./p[1]").children.to_s.strip).to eq("some")
-      expect(doc.xpath("./p[2]").children.to_s.strip).to eq("text")
+      doc = Nokogiri::HTML5.fragment(result)
+      expect(doc.xpath("./p[1]/node()").to_s.strip).to eq("some")
+      expect(doc.xpath("./p[2]/node()").to_s.strip).to eq("text")
+      expect(doc.xpath(".//br")).to be_empty
     end
 
-    it "should convert triple br tags into blank paragraph" do
+    it "converts triple br tags into blank paragraph" do
       result = add_paragraphs_to_text("some<br/><br/><br/>text")
-      doc = Nokogiri::HTML.fragment(result)
-      expect(doc.xpath("./p[1]").children.to_s.strip).to eq("some")
-      expect(doc.xpath("./p[2]").children.to_s.strip.ord).to eq(160)
-      expect(doc.xpath("./p[3]").children.to_s.strip).to eq("text")
+      doc = Nokogiri::HTML5.fragment(result)
+      expect(doc.xpath("./p[1]/node()").to_s.strip).to eq("some")
+      expect(doc.xpath("./p[2]/node()").to_s.strip).to eq("&nbsp;")
+      expect(doc.xpath("./p[3]/node()").to_s.strip).to eq("text")
     end
 
-    it "should not convert double br tags inside p tags" do
+    it "does not convert double br tags inside p tags" do
       result = add_paragraphs_to_text("<p>some<br/>\n<br/>text</p>")
-      doc = Nokogiri::HTML.fragment(result)
+      doc = Nokogiri::HTML5.fragment(result)
       expect(doc.xpath(".//p").size).to eq(1)
       expect(doc.xpath(".//br").size).to eq(2)
     end
 
-    it "should not convert triple br tags inside p tags" do
+    it "does not convert triple br tags inside p tags" do
       result = add_paragraphs_to_text("<p>some<br/>\n<br/>\n<br/>text</p>")
-      doc = Nokogiri::HTML.fragment(result)
+      doc = Nokogiri::HTML5.fragment(result)
       expect(doc.xpath(".//p").size).to eq(1)
       expect(doc.xpath(".//br").size).to eq(3)
     end
 
-    %w(b big cite code del dfn em i ins kbd q s samp
-     small span strike strong sub sup tt u var).each do |tag|
-      it "should handle #{tag} inline tags spanning double line breaks" do
+    %w[b big cite code del dfn em i ins kbd q s samp
+       small span strike strong sub sup tt u var].each do |tag|
+      it "handles #{tag} inline tags spanning double line breaks" do
         result = add_paragraphs_to_text("<#{tag}>some\n\ntext</#{tag}>")
-        doc = Nokogiri::HTML.fragment(result)
-        expect(doc.xpath("./p[1]/#{tag}").children.to_s.strip).to eq("some")
-        expect(doc.xpath("./p[2]/#{tag}").children.to_s.strip).to eq("text")
+        doc = Nokogiri::HTML5.fragment(result)
+        expect(doc.xpath("./p[1]/#{tag}/node()").to_s.strip).to eq("some")
+        expect(doc.xpath("./p[2]/#{tag}/node()").to_s.strip).to eq("text")
       end
     end
 
-    it "should handle nested inline tags spanning double line breaks" do
+    it "handles inline tags spanning double line breaks" do
       result = add_paragraphs_to_text("<i>have <b>some\n\ntext</b> yay</i>")
-      doc = Nokogiri::HTML.fragment(result)
-      expect(doc.xpath("./p[1]/i").children.to_s.strip).to match(/\Ahave/)
-      expect(doc.xpath("./p[1]/i/b").children.to_s.strip).to eq("some")
-      expect(doc.xpath("./p[2]/i/b").children.to_s.strip).to eq("text")
-      expect(doc.xpath("./p[2]/i").children.to_s.strip).to match(/ yay\Z/)
+      doc = Nokogiri::HTML5.fragment(result)
+      expect(doc.xpath("./p[1]/i/node()").to_s.strip).to match(/\Ahave/)
+      expect(doc.xpath("./p[1]/i/b/node()").to_s.strip).to eq("some")
+      expect(doc.xpath("./p[2]/i/b/node()").to_s.strip).to eq("text")
+      expect(doc.xpath("./p[2]/i/node()").to_s.strip).to match(/ yay\Z/)
     end
 
-    it "should handle nested inline tags spanning double line breaks" do
+    it "handles nested inline tags spanning double line breaks" do
       result = add_paragraphs_to_text("have <em>some\n\ntext</em> yay")
-      doc = Nokogiri::HTML.fragment(result)
-      expect(doc.xpath("./p[1]").children.to_s.strip).to match(/\Ahave/)
-      expect(doc.xpath("./p[1]/em").children.to_s.strip).to eq("some")
-      expect(doc.xpath("./p[2]/em").children.to_s.strip).to eq("text")
-      expect(doc.xpath("./p[2]").children.to_s.strip).to match(/ yay\Z/)
+      doc = Nokogiri::HTML5.fragment(result)
+      expect(doc.xpath("./p[1]/node()").to_s.strip).to match(/\Ahave/)
+      expect(doc.xpath("./p[1]/em/node()").to_s.strip).to eq("some")
+      expect(doc.xpath("./p[2]/em/node()").to_s.strip).to eq("text")
+      expect(doc.xpath("./p[2]/node()").to_s.strip).to match(/ yay\Z/)
     end
 
-    %w(blockquote center div).each do |tag|
-      it "should convert double linebreaks inside #{tag} tag" do
+    %w[blockquote center div].each do |tag|
+      it "converts double linebreaks inside #{tag} tag" do
         result = add_paragraphs_to_text("<#{tag}>some\n\ntext</#{tag}>")
-        doc = Nokogiri::HTML.fragment(result)
-        expect(doc.xpath("./#{tag}/p[1]").children.to_s.strip).to eq("some")
-        expect(doc.xpath("./#{tag}/p[2]").children.to_s.strip).to eq("text")
+        doc = Nokogiri::HTML5.fragment(result)
+        expect(doc.xpath("./#{tag}/p[1]/node()").to_s.strip).to eq("some")
+        expect(doc.xpath("./#{tag}/p[2]/node()").to_s.strip).to eq("text")
       end
     end
 
-    it "should wrap text in p before and after existing p tag" do
+    it "wraps text in p before and after existing p tag" do
       result = add_paragraphs_to_text("boom\n\n<p>da</p>\n\nyadda")
-      doc = Nokogiri::HTML.fragment(result)
-      expect(doc.xpath("./p[1]").children.to_s.strip).to eq("boom")
-      expect(doc.xpath("./p[2]").children.to_s.strip).to eq("da")
-      expect(doc.xpath("./p[3]").children.to_s.strip).to eq("yadda")
+      doc = Nokogiri::HTML5.fragment(result)
+      expect(doc.xpath("./p[1]/node()").to_s.strip).to eq("boom")
+      expect(doc.xpath("./p[2]/node()").to_s.strip).to eq("da")
+      expect(doc.xpath("./p[3]/node()").to_s.strip).to eq("yadda")
     end
 
-    it "should keep attributes of block elements" do
+    it "keeps attributes of block elements" do
       result = add_paragraphs_to_text("<div class='foo'>some\n\ntext</div>")
-      doc = Nokogiri::HTML.fragment(result)
-      expect(doc.xpath("./div[@class='foo']/p[1]").children.to_s.strip).to eq("some")
-      expect(doc.xpath("./div[@class='foo']/p[2]").children.to_s.strip).to eq("text")
+      doc = Nokogiri::HTML5.fragment(result)
+      expect(doc.xpath("./div[@class='foo']/p[1]/node()").to_s.strip).to eq("some")
+      expect(doc.xpath("./div[@class='foo']/p[2]/node()").to_s.strip).to eq("text")
     end
 
-    it "should keep attributes of inline elements across paragraphs" do
+    it "keeps attributes of inline elements across paragraphs" do
       result = add_paragraphs_to_text("<span class='foo'>some\n\ntext</span>")
-      doc = Nokogiri::HTML.fragment(result)
-      expect(doc.xpath("./p[1]/span[@class='foo']").children.to_s.strip).to eq("some")
-      expect(doc.xpath("./p[2]/span[@class='foo']").children.to_s.strip).to eq("text")
+      doc = Nokogiri::HTML5.fragment(result)
+      expect(doc.xpath("./p[1]/span[@class='foo']/node()").to_s.strip).to eq("some")
+      expect(doc.xpath("./p[2]/span[@class='foo']/node()").to_s.strip).to eq("text")
     end
 
-    it "should handle two classes" do
+    it "handles two classes" do
       result = add_paragraphs_to_text('<p class="foo bar">foobar</p>')
-      doc = Nokogiri::HTML.fragment(result)
-      expect(doc.xpath("./p[contains(@class, 'foo')]").children.to_s.strip).to eq("foobar")
-      expect(doc.xpath("./p[contains(@class, 'bar')]").children.to_s.strip).to eq("foobar")
+      doc = Nokogiri::HTML5.fragment(result)
+      expect(doc.xpath("./p[contains(@class, 'foo')]/node()").to_s.strip).to eq("foobar")
+      expect(doc.xpath("./p[contains(@class, 'bar')]/node()").to_s.strip).to eq("foobar")
     end
 
     # When we call add_paragraphs_to_text, everything gets wrapped inside myroot
@@ -932,126 +972,127 @@ describe HtmlCleaner do
     # very end, so we wouldn't have a mismatch and the strong tag would be
     # reopened in every paragraph, just like the em tag is. More info at:
     # https://github.com/otwcode/otwarchive/pull/3692#issuecomment-558740913
-    it "should close mismatched tags" do
-      html = """Here is an unclosed <em>em tag.
+    it "closes mismatched tags" do
+      html = <<~HTML.strip
+        Here is an unclosed <em>em tag.
 
-      Here is an unclosed <strong>strong tag.
+        Here is an unclosed <strong>strong tag.
 
-      Stuff."""
+        Stuff.
+      HTML
 
-      doc = Nokogiri::HTML.fragment(add_paragraphs_to_text(html))
-      expect(doc.xpath("./p[1]/em").children.to_s.strip).to eq("em tag.")
-      expect(doc.xpath("./p[2]/em/strong").children.to_s.strip).to eq("strong tag.")
-      expect(doc.xpath("./p[3]/em").children.to_s.strip).to eq("Stuff.")
+      doc = Nokogiri::HTML5.fragment(add_paragraphs_to_text(html))
+      expect(doc.xpath("./p[1]/em/node()").to_s.strip).to eq("em tag.")
+      expect(doc.xpath("./p[2]/em/strong/node()").to_s.strip).to eq("strong tag.")
+      expect(doc.xpath("./p[3]/em/node()").to_s.strip).to eq("Stuff.")
     end
 
-    it "should close unclosed tag within other tag" do
+    it "closes unclosed tag within other tag" do
       pending "Opened bug report with Nokogiri"
       html = "<strong><em>unclosed</strong>"
-      doc = Nokogiri::HTML.fragment(add_paragraphs_to_text(html))
-      expect(doc.xpath("./p/strong/em").children.to_s.strip).to eq("unclosed")
+      doc = Nokogiri::HTML5.fragment(add_paragraphs_to_text(html))
+      expect(doc.xpath("./p/strong/em/node()").to_s.strip).to eq("unclosed")
     end
 
-    it "should re-nest mis-nested tags" do
+    it "re-nests mis-nested tags" do
       html = "some <em><strong>text</em></strong>"
-      doc = Nokogiri::HTML.fragment(add_paragraphs_to_text(html))
-      expect(doc.xpath("./p[1]/em/strong").children.to_s.strip).to eq("text")
+      doc = Nokogiri::HTML5.fragment(add_paragraphs_to_text(html))
+      expect(doc.xpath("./p[1]/em/strong/node()").to_s.strip).to eq("text")
     end
 
-    it "should handle mixed uppercase/lowecase html tags" do
+    it "handles mixed uppercase/lowecase html tags" do
       result = add_paragraphs_to_text("<em>mixed</EM> <EM>stuff</em>")
-      doc = Nokogiri::HTML.fragment(result)
-      expect(doc.xpath("./p[1]/em[1]").children.to_s.strip).to eq("mixed")
-      expect(doc.xpath("./p[1]/em[2]").children.to_s.strip).to eq("stuff")
+      doc = Nokogiri::HTML5.fragment(result)
+      expect(doc.xpath("./p[1]/em[1]/node()").to_s.strip).to eq("mixed")
+      expect(doc.xpath("./p[1]/em[2]/node()").to_s.strip).to eq("stuff")
     end
 
-    %w(b big cite code del dfn em i ins kbd q s samp
-       small span strike strong sub sup tt u var).each do |tag|
-      it "should wrap consecutive #{tag} inline tags in one paragraph " do
+    %w[b big cite code del dfn em i ins kbd q s samp
+       small span strike strong sub sup tt u var].each do |tag|
+      it "wraps consecutive #{tag} inline tags in one paragraph " do
         result = add_paragraphs_to_text("<#{tag}>hey</#{tag}> <#{tag}>ho</#{tag}>")
-        doc = Nokogiri::HTML.fragment(result)
-        expect(doc.xpath("./p[1]/#{tag}[1]").children.to_s.strip).to eq("hey")
-        expect(doc.xpath("./p[1]/#{tag}[2]").children.to_s.strip).to eq("ho")
+        doc = Nokogiri::HTML5.fragment(result)
+        expect(doc.xpath("./p[1]/#{tag}[1]/node()").to_s.strip).to eq("hey")
+        expect(doc.xpath("./p[1]/#{tag}[2]/node()").to_s.strip).to eq("ho")
         expect(doc.xpath("./p[1]/text()").to_s).to eq(" ")
       end
     end
 
-    %w(&gt; &lt; &amp;).each do |entity|
-      it "should handle #{entity}" do
-        result = add_paragraphs_to_text("#{entity}")
-        doc = Nokogiri::HTML.fragment(result)
-        expect(doc.xpath("./p[1]").children.to_s.strip).to eq("#{entity}")
+    %w[&gt; &lt; &amp; &nbsp;].each do |entity|
+      it "leaves #{entity} alone" do
+        result = add_paragraphs_to_text(entity)
+        expect(result).to eq("<p>#{entity}</p>")
       end
     end
 
-    it "should not add empty p tags" do
+    it "does not add empty p tags" do
       result = add_paragraphs_to_text("A<p>B</p><p>C</p>")
-      doc = Nokogiri::HTML.fragment(result)
+      doc = Nokogiri::HTML5.fragment(result)
       expect(doc.xpath("./p").size).to eq(3)
-      expect(doc.xpath("./p[1]").children.to_s.strip).to eq("A")
-      expect(doc.xpath("./p[2]").children.to_s.strip).to eq("B")
-      expect(doc.xpath("./p[3]").children.to_s.strip).to eq("C")
+      expect(doc.xpath("./p[1]/node()").to_s.strip).to eq("A")
+      expect(doc.xpath("./p[2]/node()").to_s.strip).to eq("B")
+      expect(doc.xpath("./p[3]/node()").to_s.strip).to eq("C")
     end
 
-    it "should not leave p inside i" do
+    it "does not leave p inside i" do
       result = add_paragraphs_to_text("<i><p>foo</p><p>bar</p></i>")
-      doc = Nokogiri::HTML.fragment(result)
+      doc = Nokogiri::HTML5.fragment(result)
       expect(doc.xpath(".//i/p")).to be_empty
     end
 
-    it "should deal with br tags at the beginning" do
+    it "leaves br tags at the beginning alone" do
       result = add_paragraphs_to_text("</br>text")
-      doc = Nokogiri::HTML.fragment(result)
-      expect(doc.xpath(".//p").children.to_s.strip).to eq("text")
+      doc = Nokogiri::HTML5.fragment(result)
+      expect(doc.xpath(".//p/node()").to_s.strip).to eq("<br>text")
     end
 
-    it "should handle table tags that don't need closing" do
-      html = """
-      <table>
-        <colgroup align=\"left\"><col width=\"20\"></colgroup>
-        <colgroup align=\"right\">
-        <tr>
-          <th>A</th>
-          <th>B</th>
-        </tr>
-        <tr>
-          <td>C</td>
-          <td>D</td>
-        </tr>
-      </table>
-     """
+    it "handles table tags that don't need closing" do
+      html = <<~TABLE
+        <table>
+          <colgroup align=\"left\"><col width=\"20\"></colgroup>
+          <colgroup align=\"right\">
+          <tr>
+            <th>A</th>
+            <th>B</th>
+          </tr>
+          <tr>
+              <td>C</td>
+            <td>D</td>
+          </tr>
+        </table>
+      TABLE
       result = add_paragraphs_to_text(html)
-      doc = Nokogiri::HTML.fragment(result)
+      doc = Nokogiri::HTML5.fragment(result)
       expect(doc.xpath("./table/colgroup[@align='left']/col[@width='20']").size).to eq(1)
       expect(doc.xpath("./table/colgroup[@align='right']").size).to eq(1)
-      expect(doc.xpath("./table/tr[1]/th[1]").children.to_s.strip).to eq("A")
-      expect(doc.xpath("./table/tr[1]/th[2]").children.to_s.strip).to eq("B")
-      expect(doc.xpath("./table/tr[2]/td[1]").children.to_s.strip).to eq("C")
-      expect(doc.xpath("./table/tr[2]/td[2]").children.to_s.strip).to eq("D")
+      expect(doc.xpath("./table//tr[1]/th[1]/node()").to_s.strip).to eq("A")
+      expect(doc.xpath("./table//tr[1]/th[2]/node()").to_s.strip).to eq("B")
+      expect(doc.xpath("./table//tr[2]/td[1]/node()").to_s.strip).to eq("C")
+      expect(doc.xpath("./table//tr[2]/td[2]/node()").to_s.strip).to eq("D")
     end
 
-    %w(script style).each do |tag|
-      it "should keep #{tag} tags as is" do
+    %w[script style].each do |tag|
+      it "keeps #{tag} tags as is" do
         result = add_paragraphs_to_text("<#{tag}>keep me</#{tag}>")
-        doc = Nokogiri::HTML.fragment(result)
-        expect(doc.xpath("./p/#{tag}").children.to_s.strip).to eq("keep me")
+        doc = Nokogiri::HTML5.fragment(result)
+        expect(doc.xpath("./p/node()").to_s.strip).to eq("<#{tag}>keep me</#{tag}>")
       end
     end
 
-    it "should fail gracefully for missing ending quotation marks" do
+    it "fails gracefully for missing ending quotation marks" do
       pending "Opened enhancement request with Nokogiri"
       result = add_paragraphs_to_text("<strong><a href='ao3.org>mylink</a></strong>")
-      doc = Nokogiri::HTML.fragment(result)
+      doc = Nokogiri::HTML5.fragment(result)
       node = doc.xpath(".//a").first
       expect(node.attribute("href").value).not_to match(/strong/)
       expect(node.text.strip).to eq("mylink")
     end
 
-    it "should fail gracefully for missing starting quotation marks" do
+    it "fails gracefully for missing starting quotation marks" do
       result = add_paragraphs_to_text('<strong><a href=ao3.org">mylink</a></strong>')
-      doc = Nokogiri::HTML.fragment(result)
+      doc = Nokogiri::HTML5.fragment(result)
       node = doc.xpath(".//a").first
-      expect(node.attribute("href").value).to eq("ao3.org%22")
+      expect(node.attribute("href").value).to eq('ao3.org"')
       expect(node.text.strip).to eq("mylink")
     end
   end

--- a/spec/models/story_parser_spec.rb
+++ b/spec/models/story_parser_spec.rb
@@ -215,7 +215,7 @@ describe StoryParser do
   def mock_external
     curly_quotes = "String with non-ASCII “Curly quotes” and apostrophes’"
 
-    body = "
+    body = <<~STUB
       Title: #{curly_quotes}
       Summary: #{curly_quotes}
       Fandom: #{curly_quotes}
@@ -227,7 +227,8 @@ describe StoryParser do
       Tags: #{curly_quotes}
       Author's notes: #{curly_quotes}
 
-      stubbed response".gsub('      ', '')
+      stubbed response
+    STUB
 
     WebMock.allow_net_connect!
 
@@ -261,12 +262,12 @@ describe StoryParser do
       WebMock.reset!
     end
 
-    it "should not throw an exception with non-ASCII characters in metadata fields" do
-      urls = %w(http://ascii-8bit http://utf-8 http://win-1252)
+    it "does not throw an exception with non-ASCII characters in metadata fields" do
+      urls = %w[http://ascii-8bit http://utf-8 http://win-1252]
       urls.each do |url|
-        expect {
+        expect do
           @sp.download_and_parse_story(url, pseuds: [@user.default_pseud], do_not_set_current_author: false)
-        }.to_not raise_exception
+        end.not_to raise_exception
       end
     end
 


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [x] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [x] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [x] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-5801

## Purpose

- Some multimedia tags are self-closing in HTML5. So don't try to close them. ``<source ...>`` should remain ``<source ...>``, not ``<source ...></source>``, for example.
- This is an HTML4 vs HTML5 difference, and the current sanitizer uses HTML4 parser. So more broadly, move away from HTML4 and XHTML to HTML5. The HTML output has been declared to be HTML5 as a whole since AO3-4365 (#2217).
- To do so, prefer ``Nokogiri::HTML5`` over ``Nokogiri::HTML`` and ``Nokogiri::HTML4`` (but still use ``Nokogiri::HTML4`` where necessary). Note that ``Nokogiri::HTML`` and ``Nokogiri::HTML4`` are synonymous.
- The shift to HTML5 will bring other miscelleneous changes in how the sanitizer behaves. I hope to make the impact as small as possible and added changes that I believe are necessary, so this set of commits may be bigger than anticipated.(But I'll be honest, I might have been overzealous to make Rubocop happier in parts of the code that are only marginally related to this issue.)

## Testing Instructions

Trying to post and import works with audio/video tags would be a good place to start. However, I'd go beyond that.

This set of changes (at least its initial version) changes the inner working of the sanitization process at some fundamental level, so the scope of testing would probably have to be large. I tried to make the changes minimal and reasonable, but some unintended consequences might still happen. Known side effects are written above.

Posting and importing trigger sanitization, and I think that's mainly where testing is needed. It would be wise to test this as thoroughly as possible, using short and long, old and new content.

If possible, I would check performance metrics (like average time needed to complete one posting action) before and after this change. During my own (limited amount of) manual testing, there was no noticeable difference, though.

## References

- https://github.com/otwcode/otwarchive/pull/3678 by @sarken - I reused some of the test code.
- [AO3-5693](https://otwarchive.atlassian.net/browse/AO3-5693) (#3679) - a hack that should be made obsolete by this change
- [AO3-5974](https://otwarchive.atlassian.net/browse/AO3-5974) (#3847) - same as above

The Jira issue contains some preliminary discussion, too.
 
## Credit

Potpotkettle (they/them)
