### PR TITLE
AO3-6144 Update error text when citing a protected user's works

### DIFF
--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -191,7 +191,7 @@ class Work < ApplicationRecord
 
     users = parent.pseuds.collect(&:user).uniq
     users.each do |user|
-      self.errors.add(:base, ts("You can't use the related works function to cite works by #{user.login}.")) if user.protected_user
+      self.errors.add(:base, ts("You can't use the related works function to cite works by the protected user #{user.login}.")) if user.protected_user
     end
   end
 

--- a/features/works/work_related.feature
+++ b/features/works/work_related.feature
@@ -403,7 +403,7 @@ Scenario: When a user is notified that a co-authored work has been inspired by a
   Given I have related works setup
     And the user "inspiration" is a protected user
   When I post a related work as remixer
-  Then I should see "You can't use the related works function to cite works by inspiration."
+  Then I should see "You can't use the related works function to cite works by the protected user inspiration."
 
   Scenario: When editing a work with an existing citation of a protected user's work, the citation remains
   Given I have related works setup
@@ -453,7 +453,7 @@ Scenario: When a user is notified that a co-authored work has been inspired by a
   When I am logged in as "inspiration"
     And I add the work "Worldbuilding" to the collection "Anonymous"
   When I post a related work as remixer
-  Then I should not see "You can't use the related works function to cite works by inspiration."
+  Then I should not see "You can't use the related works function to cite works by the protected user inspiration."
   When I am logged in as "remixer"
     And I go to remixer's related works page
   Then I should see "Works that inspired remixer"
@@ -467,7 +467,7 @@ Scenario: When a user is notified that a co-authored work has been inspired by a
   When I am logged in as "inspiration"
     And I add the work "Worldbuilding" to the collection "Hidden"
   When I post a related work as remixer
-  Then I should not see "You can't use the related works function to cite works by inspiration."
+  Then I should not see "You can't use the related works function to cite works by the protected user inspiration."
   When I am logged in as "remixer"
     And I go to remixer's related works page
   Then I should see "Works that inspired remixer"


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [x] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [x] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [x] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-6144

## Purpose

Update the error text message to 

> You can't use the related works function to cite works by the protected user [name].

## References
Main PR: https://github.com/otwcode/otwarchive/pull/4244 
## Credit
weeklies (she/her)