### PR TITLE
AO3-5779 Add thousands separator to long numbers on statistics page

### DIFF
--- a/app/views/stats/index.html.erb
+++ b/app/views/stats/index.html.erb
@@ -31,10 +31,10 @@
          word_count: ts("Word Count:") }.each do |stat, stat_text| %>
       <% stat == :word_count ? html_class = "words" : html_class = stat.to_s.humanize.downcase %>
       <dt class="<%= html_class %>"><%= stat_text %></dt>
-      <dd class="<%= html_class %>"><%= @totals[stat] %></dd>
+      <dd class="<%= html_class %>"><%= number_with_delimiter(@totals[stat]) %></dd>
     <% end %>
     <dt class="hits"><%= ts("Hits:") %></dt>
-    <dd class="hits"><%= @totals[:hits] %></dd>
+    <dd class="hits"><%= number_with_delimiter(@totals[:hits]) %></dd>
   </dl>
 </div>
 
@@ -76,23 +76,23 @@
               <dt>
                 <%= link_to work.title, work_path(:id => work.id) %> 
                 <% if params[:flat_view] %><span class="fandom">(<%= work.fandom_string %>)</span><% end %>
-                <span class="words">(<%= ts("%{wordcount} words", wordcount: work.word_count) %>)</span>
+                <span class="words">(<%= ts("%{wordcount} words", wordcount: number_with_delimiter(work.word_count)) %>)</span>
               </dt>
               <dd>
                 <dl class="stats">
                   <% if (work_subscriber_count = Subscription.where(:subscribable_id => work.id, :subscribable_type => 'Work').count) > 0 %>
                     <dt class="subscriptions"><%= ts("Subscriptions:") %></dt>
-                    <dd class="subscriptions"><%= work_subscriber_count %></dd>
+                    <dd class="subscriptions"><%= number_with_delimiter(work_subscriber_count) %></dd>
                   <% end %>
                   <dt class="hits"><%= ts("Hits:") %></dt>
-                  <dd class="hits"><%= work.hits %></dd>
+                  <dd class="hits"><%= number_with_delimiter(work.hits) %></dd>
                   <% # dt ts("Downloads:") /dt dd work.downloads /dd %>
                   <dt class="kudos"><%= ts("Kudos:") %></dt>
-                  <dd class="kudos"><%= work.kudos.count %></dd>
+                  <dd class="kudos"><%= number_with_delimiter(work.kudos.count) %></dd>
                   <dt class="comments"><%= ts("Comment Threads:") %></dt>
-                  <dd class="comments"><%= work.comment_thread_count %></dd>
+                  <dd class="comments"><%= number_with_delimiter(work.comment_thread_count) %></dd>
                   <dt class="bookmarks"><%= ts("Bookmarks:") %></dt>
-                  <dd class="bookmarks"><%= work.bookmarks.count %></dd>
+                  <dd class="bookmarks"><%= number_with_delimiter(work.bookmarks.count) %></dd>
                   <% # dt ts("Newest Link:") /dt %>
                     <% # dd %>
                     <% # work.work_links.last.try(:url) || ts("none yet") %>


### PR DESCRIPTION
# Pull Request Checklist

* [X] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [X] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [ ] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [X] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [X] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-5779

## Purpose

Add thousands separator to long numbers on statistics page

## Testing Instructions

Not sure here. In #4254 no automated tests were necessary except to see if the page loads at all. A "page loads at all" test already exists in `features/other_b/stats.features` and passes.

For manual testing, log into a user with a work with a word count > 1000, go to the stats page and verify that the thousand separator shows up.

## References

I mostly referenced #4254 for what I should do.

## Credit

Bilka (he/him)