### PR TITLE
AO3-5535 Remove series index

### DIFF
--- a/app/controllers/series_controller.rb
+++ b/app/controllers/series_controller.rb
@@ -16,17 +16,15 @@ class SeriesController < ApplicationController
   # GET /series
   # GET /series.xml
   def index
-    @user = User.find_by!(login: params[:user_id]) if params[:user_id]
-    unless @user
+    unless params[:user_id]
       flash[:error] = ts("Whose series did you want to see?")
       redirect_to(root_path) and return
     end
-
+    @user = User.find_by!(login: params[:user_id])
     @page_subtitle = ts("%{username} - Series", username: @user.login)
     pseuds = @user.pseuds
     if params[:pseud_id]
-      @pseud = @user.pseuds.find_by!(name: params[:pseud_id])
-      
+      @pseud = @user.pseuds.find_by!(name: params[:pseud_id])   
       @page_subtitle = ts("by ") + @pseud.byline
       pseuds = [@pseud]
     end

--- a/app/controllers/series_controller.rb
+++ b/app/controllers/series_controller.rb
@@ -16,7 +16,7 @@ class SeriesController < ApplicationController
   # GET /series
   # GET /series.xml
   def index
-    @user = User.find_by(login: params[:user_id]) if params[:user_id]
+    @user = User.find_by!(login: params[:user_id]) if params[:user_id]
     unless @user
       flash[:error] = ts("Whose series did you want to see?")
       redirect_to(root_path) and return
@@ -25,8 +25,7 @@ class SeriesController < ApplicationController
     @page_subtitle = ts("%{username} - Series", username: @user.login)
     pseuds = @user.pseuds
     if params[:pseud_id]
-      @pseud = @user.pseuds.find_by(name: params[:pseud_id])
-      raise ActiveRecord::RecordNotFound, "Couldn't find pseud '#{params[:pseud_id]}'" unless @pseud
+      @pseud = @user.pseuds.find_by!(name: params[:pseud_id])
       
       @page_subtitle = ts("by ") + @pseud.byline
       pseuds = [@pseud]

--- a/app/controllers/series_controller.rb
+++ b/app/controllers/series_controller.rb
@@ -16,21 +16,20 @@ class SeriesController < ApplicationController
   # GET /series
   # GET /series.xml
   def index
-    if params[:user_id]
-      @user = User.find_by(login: params[:user_id])
-      unless @user
-        raise ActiveRecord::RecordNotFound, "Couldn't find user '#{params[:user_id]}'"
-      end
-      @page_subtitle = ts("%{username} - Series", username: @user.login)
-      pseuds = @user.pseuds
-      if params[:pseud_id]
-        @pseud = @user.pseuds.find_by(name: params[:pseud_id])
-        unless @pseud
-          raise ActiveRecord::RecordNotFound, "Couldn't find pseud '#{params[:pseud_id]}'"
-        end
-        @page_subtitle = ts("by ") + @pseud.byline
-        pseuds = [@pseud]
-      end
+    @user = User.find_by(login: params[:user_id]) if params[:user_id]
+    unless @user
+      flash[:error] = ts("Whose series did you want to see?")
+      redirect_to(root_path) and return
+    end
+
+    @page_subtitle = ts("%{username} - Series", username: @user.login)
+    pseuds = @user.pseuds
+    if params[:pseud_id]
+      @pseud = @user.pseuds.find_by(name: params[:pseud_id])
+      raise ActiveRecord::RecordNotFound, "Couldn't find pseud '#{params[:pseud_id]}'" unless @pseud
+      
+      @page_subtitle = ts("by ") + @pseud.byline
+      pseuds = [@pseud]
     end
 
     if current_user.nil?

--- a/features/other_b/errors.feature
+++ b/features/other_b/errors.feature
@@ -17,7 +17,6 @@ Some pages with non existent things raise errors
       And visiting "/users/KnownUser/pseuds/unknown_pseud" should fail with a not found error
       And visiting "/series/999" should fail with a not found error
       And visiting "/users/KnownUser/pseuds/unknown_pseud/series" should fail with a not found error
-      And visiting "/users/UnknownUser/pseuds/unknown_pseud/series" should fail with a not found error
       And visiting "/tags/NonexistentTag" should fail with a not found error
       And visiting "/tags/999999999/feed.atom" should fail with a not found error
       And visiting "/works/999999999" should fail with a not found error
@@ -31,3 +30,4 @@ Some pages with non existent things raise errors
       | login          |
       | wranglerette   |
     Then visiting "/users/UnknownUser" should fail with "Sorry, could not find this user."
+      And visiting "/users/UnknownUser/pseuds/unknown_pseud/series" should fail with "Whose series did you want to see?"

--- a/features/other_b/errors.feature
+++ b/features/other_b/errors.feature
@@ -17,6 +17,7 @@ Some pages with non existent things raise errors
       And visiting "/users/KnownUser/pseuds/unknown_pseud" should fail with a not found error
       And visiting "/series/999" should fail with a not found error
       And visiting "/users/KnownUser/pseuds/unknown_pseud/series" should fail with a not found error
+      And visiting "/users/UnknownUser/pseuds/unknown_pseud/series" should fail with a not found error
       And visiting "/tags/NonexistentTag" should fail with a not found error
       And visiting "/tags/999999999/feed.atom" should fail with a not found error
       And visiting "/works/999999999" should fail with a not found error
@@ -30,4 +31,3 @@ Some pages with non existent things raise errors
       | login          |
       | wranglerette   |
     Then visiting "/users/UnknownUser" should fail with "Sorry, could not find this user."
-      And visiting "/users/UnknownUser/pseuds/unknown_pseud/series" should fail with "Whose series did you want to see?"

--- a/spec/controllers/series_controller_spec.rb
+++ b/spec/controllers/series_controller_spec.rb
@@ -109,9 +109,10 @@ describe SeriesController do
 
     context "with user_id parameter" do
       context "when user_id does not exist" do
-        it "redirects to the homepage with an error" do
-          get :index, params: { user_id: "nobody" }
-          it_redirects_to_with_error(root_path, "Whose series did you want to see?")
+        it "raises an error" do
+          expect do
+            get :index, params: { user_id: "nobody" }
+          end.to raise_error ActiveRecord::RecordNotFound
         end
       end
 
@@ -125,12 +126,10 @@ describe SeriesController do
 
         context "with pseud_id parameter" do
           context "when pseud_id does not exist" do
-            it "raises a RecordNotFound error for the pseud" do
-              params = { user_id: user, pseud_id: "nobody" }
-              expect { get :index, params: params }.to raise_error(
-                ActiveRecord::RecordNotFound,
-                "Couldn't find pseud 'nobody'"
-              )
+            it "raises an error" do
+              expect do
+                get :index, params: { user_id: user, pseud_id: "nobody" }
+              end.to raise_error ActiveRecord::RecordNotFound
             end
           end
 

--- a/spec/controllers/series_controller_spec.rb
+++ b/spec/controllers/series_controller_spec.rb
@@ -89,13 +89,59 @@ describe SeriesController do
     end
   end
 
-  describe 'destory' do
+  describe 'destroy' do
     it 'on an exception gives an error and redirects' do
       fake_login_known_user(user)
       allow_any_instance_of(Series).to receive(:destroy) { false }
       delete :destroy, params: { id: series }
       it_redirects_to_with_error(series_path(series), \
                                  "Sorry, we couldn't delete the series. Please try again.")
+    end
+  end
+
+  describe "index" do
+    context "without user_id parameter" do
+      it "redirects to the homepage with an error" do
+        get :index
+        it_redirects_to_with_error(root_path, "Whose series did you want to see?")
+      end
+    end
+
+    context "with user_id parameter" do
+      context "when user_id does not exist" do
+        it "redirects to the homepage with an error" do
+          get :index, params: { user_id: "nobody" }
+          it_redirects_to_with_error(root_path, "Whose series did you want to see?")
+        end
+      end
+
+      context "when user_id exists" do
+        context "without pseud_id parameter" do
+          it "renders the index template" do
+            get :index, params: { user_id: user }
+            expect(response).to render_template(:index)
+          end
+        end
+
+        context "with pseud_id parameter" do
+          context "when pseud_id does not exist" do
+            it "raises a RecordNotFound error for the pseud" do
+              params = { user_id: user, pseud_id: "nobody" }
+              expect { get :index, params: params }.to raise_error(
+                ActiveRecord::RecordNotFound,
+                "Couldn't find pseud 'nobody'"
+              )
+            end
+          end
+
+          context "when pseud_id exists" do
+            it "renders the index template" do
+              get :index, params: { user_id: user, pseud_id: user.default_pseud }
+              expect(response).to render_template(:index)
+            end
+          end
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
# Pull Request Checklist

* [X] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [X] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [X] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [X] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [X] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-5535

## Purpose

Remove series index, so accessing `/series` redirects to the homepage and gives a red flash error that asks, "Whose series did you want to see?"

## Notes

As visible in the tests, trying to access the series of a user that does not exist like `/users/invalid_user/series` also redirects.
Previously, this page would throw a `ActiveRecord::RecordNotFound` error and 404. The behaviour I implemented here mirrors that of gift_controller, which also redirects for an invalid user name.

Trying to access the series of an invalid pseud (`users/valid_user/pseuds/invalid_pseud/series`) does not redirect. I left it with the original behaviour because I don't know if it should be changed, since gift_controller doesn't handle pseuds. However, I think it would make sense if this also redirected.

## References

I referenced the gift_controller for code and behaviour.

## Credit

Bilka (he/him)