### PR TITLE
AO3-6356 Use ActiveJob for asynchronous tag jobs.

### DIFF
--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -1,3 +1,14 @@
 class ApplicationJob < ActiveJob::Base
+  include AfterCommitEverywhere
+  extend AfterCommitEverywhere
+
   queue_as :utilities
+
+  def self.perform_after_commit(*args, **kwargs)
+    after_commit { perform_later(*args, **kwargs) }
+  end
+
+  def enqueue_after_commit
+    after_commit { enqueue }
+  end
 end

--- a/app/jobs/instance_method_job.rb
+++ b/app/jobs/instance_method_job.rb
@@ -1,0 +1,10 @@
+# Job for calling an instance method on an object.
+class InstanceMethodJob < ApplicationJob
+  def perform(object, *args, **kwargs)
+    object.send(*args, **kwargs)
+  end
+
+  retry_on ActiveJob::DeserializationError, attempts: 3, wait: 5.minutes do
+    # silently discard job after 3 failures
+  end
+end

--- a/app/jobs/tag_method_job.rb
+++ b/app/jobs/tag_method_job.rb
@@ -1,0 +1,11 @@
+# Subclass of InstanceMethodJob with a custom retry setting that is useful for
+# wrangling-related jobs.
+class TagMethodJob < InstanceMethodJob
+  # Retry if we insert a non-unique record.
+  #
+  # The jobs for this class mostly already check for uniqueness in validations,
+  # so the only way this can be raised is if there are multiple transactions
+  # trying to insert the same record at roughly the same time.
+  retry_on ActiveRecord::RecordNotUnique,
+           attempts: 3, wait: 5.minutes
+end

--- a/app/models/concerns/async_with_active_job.rb
+++ b/app/models/concerns/async_with_active_job.rb
@@ -1,0 +1,17 @@
+# A concern defining the async/async_after_commit functions, which allow
+# instance methods on an object to be used as ActiveJobs.
+module AsyncWithActiveJob
+  extend ActiveSupport::Concern
+
+  included do
+    class_attribute :async_job_class, default: InstanceMethodJob
+  end
+
+  def async(*args, job_class: async_job_class, **kwargs)
+    job_class.perform_later(self, *args, **kwargs)
+  end
+
+  def async_after_commit(*args, job_class: async_job_class, **kwargs)
+    job_class.perform_after_commit(self, *args, **kwargs)
+  end
+end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1,7 +1,6 @@
 require "unicode_utils/casefold"
 
 class Tag < ApplicationRecord
-
   include ActiveModel::ForbiddenAttributesProtection
   include Searchable
   include StringCleaner
@@ -403,10 +402,9 @@ class Tag < ApplicationRecord
     in_challenge(collection, 'Offer')
   }
 
-  # Resque
-
-  include AsyncWithResque
-  @queue = :utilities
+  # Code for delayed jobs:
+  include AsyncWithActiveJob
+  self.async_job_class = TagMethodJob
 
   # Class methods
 
@@ -471,6 +469,12 @@ class Tag < ApplicationRecord
 
   def display_name
     name
+  end
+
+  # Make sure that the global ID doesn't depend on the type, so that we don't
+  # experience errors when switching types:
+  def to_global_id(options = {})
+    GlobalID.create(becomes(Tag), options)
   end
 
   ## AUTOCOMPLETE

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -180,35 +180,6 @@ def run_all_indexing_jobs
   Indexer.all.map(&:refresh_index)
 end
 
-# Suspend resque workers for the duration of the block, then resume after the
-# contents of the block have run. Simulates what happens when there's a lot of
-# jobs already in the queue, so there's a long delay between jobs being
-# enqueued and jobs being run.
-def suspend_resque_workers
-  # Set up an array to keep track of delayed actions.
-  queue = []
-
-  # Override the default Resque.enqueue_to behavior.
-  #
-  # The first argument is which queue the job is supposed to be added to, but
-  # it doesn't matter for our purposes, so we ignore it.
-  allow(Resque).to receive(:enqueue_to) do |_, klass, *args|
-    queue << [klass, args]
-  end
-
-  # Run the code inside the block.
-  yield
-
-  # Empty out the queue and perform all of the operations.
-  while queue.any?
-    klass, args = queue.shift
-    klass.perform(*args)
-  end
-
-  # Resume the original Resque.enqueue_to behavior.
-  allow(Resque).to receive(:enqueue_to).and_call_original
-end
-
 def create_invalid(*args, **kwargs)
   build(*args, **kwargs).tap do |object|
     object.save!(validate: false)


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6356

## Purpose

- Create a new `InstanceMethodJob` class used to run instance methods on objects.
- Create a new `TagMethodJob` subclass that retries on `RecordNotUnique`.
- Create a new `AsyncWithActiveJob` concern that can be swapped in for the `AsyncWithResque` concern, as long as the class in question only uses instance methods for delayed jobs.
- Set up `Tag`s to use `AsyncWithActiveJob` and `TagMethodJob` to run wrangling tasks instead of `AsyncWithResque`.