### PR TITLE
AO3-6370 Case insensitive email validation for User

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -196,6 +196,7 @@ class User < ApplicationRecord
   validates_uniqueness_of :login, case_sensitive: false, message: ts("has already been taken")
   validate :login, :username_is_not_recently_changed, if: :will_save_change_to_login?
 
+  validates_uniqueness_of :email, case_sensitive: false, message: ts("has already been taken")
   validates :email, email_veracity: true, email_format: true
 
   # Virtual attribute for age check and terms of service

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -196,8 +196,7 @@ class User < ApplicationRecord
   validates_uniqueness_of :login, case_sensitive: false, message: ts("has already been taken")
   validate :login, :username_is_not_recently_changed, if: :will_save_change_to_login?
 
-  validates_uniqueness_of :email, case_sensitive: false, message: ts("has already been taken")
-  validates :email, email_veracity: true, email_format: true
+  validates :email, email_veracity: true, email_format: true, uniqueness: { case_sensitive: false }
 
   # Virtual attribute for age check and terms of service
     attr_accessor :age_over_13

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -123,6 +123,12 @@ describe User do
           expect(new_user.save).to be_falsey
           expect(new_user.errors[:email].first).to eq("has already been taken")
         end
+
+        it "does not save a duplicate email with difference capitalization" do
+          new_user.email = existing_user.email.capitalize()
+          expect(new_user.save).to be_falsey
+          expect(new_user.errors[:email].first).to eq("has already been taken")
+        end
       end
     end
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -125,7 +125,7 @@ describe User do
         end
 
         it "does not save a duplicate email with difference capitalization" do
-          new_user.email = existing_user.email.capitalize()
+          new_user.email = existing_user.email.capitalize
           expect(new_user.save).to be_falsey
           expect(new_user.errors[:email].first).to eq("has already been taken")
         end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -124,7 +124,7 @@ describe User do
           expect(new_user.errors[:email].first).to eq("has already been taken")
         end
 
-        it "does not save a duplicate email with difference capitalization" do
+        it "does not save a duplicate email with different capitalization" do
           new_user.email = existing_user.email.capitalize
           expect(new_user.save).to be_falsey
           expect(new_user.errors[:email].first).to eq("has already been taken")


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [x] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [x] Have you added the [Jira](https://otwarchive.atlassian.net) issue number as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [x] Do you have fewer than 5 pull requests already open? If not, please wait until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-6370

## Purpose

Make the User email validation case insensitive. 

## Testing Instructions
Same as written in Jira issue: 
1. Have an existing account with an email address, say `test@example.com`.
2. Get an invitation (or get a site admin to enable sign-ups without invitations).
3. Try to sign up for an account with the same email as your old account, but with a different case, like `TEST@example.com`, or `Test@example.com`.

Now it should redirect back to signup form with the error "Email has already been taken"

## References
N/A

## Credit
ellieyhc (she/her)
