### PR TITLE
AO3-2426 Allow admin to change the language of an external work

### DIFF
--- a/app/controllers/external_works_controller.rb
+++ b/app/controllers/external_works_controller.rb
@@ -57,7 +57,7 @@ class ExternalWorksController < ApplicationController
 
   def external_work_params
     params.require(:external_work).permit(
-      :url, :author, :title, :summary
+      :url, :author, :title, :summary, :language_id
     )
   end
 

--- a/app/views/external_works/_blurb.html.erb
+++ b/app/views/external_works/_blurb.html.erb
@@ -14,6 +14,11 @@
       <% fandoms = external_work.tag_groups["Fandom"] %>
       <%= fandoms.collect{ |tag| link_to_tag_works(tag) }.join(", ").html_safe if fandoms %>
     </h5>
+    <% unless external_work.language.blank? %>
+      <h5 class="language heading">
+        <%= ts("Language:") %> <%= external_work.language.name %>
+      </h5>
+    <% end %>
 
     <p class="notice"><%= ts("This work isn't hosted on the Archive so this blurb might not be complete or accurate.") %></p>
 

--- a/app/views/external_works/_blurb.html.erb
+++ b/app/views/external_works/_blurb.html.erb
@@ -14,11 +14,6 @@
       <% fandoms = external_work.tag_groups["Fandom"] %>
       <%= fandoms.collect{ |tag| link_to_tag_works(tag) }.join(", ").html_safe if fandoms %>
     </h5>
-    <% unless external_work.language.blank? %>
-      <h5 class="language heading">
-        <%= ts("Language:") %> <%= external_work.language.name %>
-      </h5>
-    <% end %>
 
     <p class="notice"><%= ts("This work isn't hosted on the Archive so this blurb might not be complete or accurate.") %></p>
 
@@ -42,6 +37,10 @@
 
   <!--stats-->
   <dl class="stats">
+    <% unless external_work.language.blank? %>
+    <dt class="language"><%= ts("Language:") %></dt>
+    <dd class="language"><%= external_work.language.name %></dd>
+    <% end %>
     <% if Bookmark.count_visible_bookmarks(external_work) > 0 %>
     <dt><%= ts("Bookmarks") + ": " %></dt>
     <dd><%= link_to_bookmarkable_bookmarks(external_work) %></dd>

--- a/app/views/external_works/_work_module.html.erb
+++ b/app/views/external_works/_work_module.html.erb
@@ -43,6 +43,11 @@
 
 <!--stats-->
 <dl class="stats">
+  <% unless external_work.language.blank? %>
+    <dt class="language"><%= ts("Language:") %></dt>
+    <dd class="language"><%= external_work.language.name %></dd>
+  <% end %>
+
   <% if Bookmark.count_visible_bookmarks(external_work) > 0 %>
     <dt><%= ts("Bookmarks:") %></dt>
     <dd><%= link_to_bookmarkable_bookmarks(external_work) %></dd>

--- a/app/views/external_works/edit.html.erb
+++ b/app/views/external_works/edit.html.erb
@@ -30,6 +30,13 @@
                                     ArchiveConfig.TITLE_MAX) %>
       </dd>
       <dt>
+        <%= f.label :language_id, ts("Language") %>
+        <%= link_to_help "languages-help" %>
+      </dt>
+      <dd>
+        <%= f.collection_select(:language_id, sorted_languages, :id, :name, prompt: " ") %>
+      </dd>
+      <dt>
         <%= f.label :summary, ts("Creator's Summary") %>
         <%= ts("(please copy and paste from original work)") %>
       </dt>

--- a/features/admins/admin_works.feature
+++ b/features/admins/admin_works.feature
@@ -119,6 +119,7 @@ Feature: Admin Actions for Works, Comments, Series, Bookmarks
 
   Scenario: Can edit external works
     Given basic tags
+      And basic languages
       And I am logged in as "regular_user"
       And I bookmark the external work "External Changes"
     When I am logged in as a "policy_and_abuse" admin
@@ -134,6 +135,7 @@ Feature: Admin Actions for Works, Comments, Series, Bookmarks
       And I fill in "Characters" with "Admin-Added Character"
       And I fill in "Additional Tags" with "Admin-Added Freeform"
       And I check "M/M"
+      And I select "Deutsch" from "Language"
       And it is currently 1 second from now
     When I press "Update External work"
     Then I should see "Admin-Added Creator"
@@ -145,6 +147,7 @@ Feature: Admin Actions for Works, Comments, Series, Bookmarks
       And I should see "Admin-Added Character"
       And I should see "Admin-Added Freeform"
       And I should see "M/M"
+      And I should see "Language: Deutsch"
 
   Scenario: Can delete external works
     Given basic tags


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [x] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [x] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [x] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-2426

## Purpose

External works have language ID which can only be assigned when creating it. This set of changes will add UI elements to allow admins to change the language ID of an external work.

## Testing Instructions

See the Jira issue.

## References

#197

## Credit

Potpotkettle (they/them)
