### PR TITLE
AO3-6379 Use accepts_nested_attributes_for for related works.

### DIFF
--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -370,7 +370,6 @@ class WorksController < ApplicationController
     @chapter.attributes = work_params[:chapter_attributes] if work_params[:chapter_attributes]
     @work.ip_address = request.remote_ip
     @work.set_word_count(@work.preview_mode)
-    @work.save_parents if @work.preview_mode
 
     @work.set_challenge_info
     @work.set_challenge_claim_info
@@ -912,7 +911,9 @@ class WorksController < ApplicationController
       archive_warning_strings: [],
       author_attributes: [:byline, ids: [], coauthors: []],
       series_attributes: [:id, :title],
-      parent_attributes: [:url, :title, :author, :language_id, :translation],
+      parent_work_relationships_attributes: [
+        :url, :title, :author, :language_id, :translation
+      ],
       chapter_attributes: [
         :title, :"published_at(3i)", :"published_at(2i)", :"published_at(1i)",
         :published_at, :content

--- a/app/helpers/works_helper.rb
+++ b/app/helpers/works_helper.rb
@@ -42,15 +42,7 @@ module WorksHelper
 
   # Determines whether or not to expand the related work association fields when the work form loads
   def check_parent_box(work)
-    !work.parents.blank? ||
-    (params[:work] && !(work_parent_value(:url).blank? && work_parent_value(:title).blank? && work_parent_value(:author).blank?))
-  end
-
-  # Passes value of fields for related works back to form when an error occurs on posting
-  def work_parent_value(field)
-    if params[:work] && params[:work][:parent_attributes]
-      params[:work][:parent_attributes][field]
-    end
+    work.parents_after_saving.present?
   end
 
   # Determines whether or not "manage series" dropdown should appear
@@ -154,19 +146,19 @@ module WorksHelper
   # Returns true or false to determine whether the work notes module should display
   def show_work_notes?(work)
     work.notes.present? ||
-    work.endnotes.present? ||
-    work.gifts.not_rejected.present? ||
-    work.challenge_claims.present? ||
-    work.parent_work_relationships.present? ||
-    work.approved_related_works.present?
+      work.endnotes.present? ||
+      work.gifts.not_rejected.present? ||
+      work.challenge_claims.present? ||
+      work.parents_after_saving.present? ||
+      work.approved_related_works.present?
   end
 
   # Returns true or false to determine whether the work associations should be included
   def show_associations?(work)
     work.gifts.not_rejected.present? ||
-    work.approved_related_works.where(translation: true).exists? ||
-    work.parent_work_relationships.exists? ||
-    work.challenge_claims.present?
+      work.approved_related_works.where(translation: true).exists? ||
+      work.parents_after_saving.present? ||
+      work.challenge_claims.present?
   end
 
   def all_coauthor_skins

--- a/app/models/external_work.rb
+++ b/app/models/external_work.rb
@@ -27,9 +27,9 @@ class ExternalWork < ApplicationRecord
                                 too_long: ts("must be less than %{max} characters long.",
                                              max: ArchiveConfig.SUMMARY_MAX)
 
-  validates_presence_of :author, message: ts('^Creator can\'t be blank')
+  validates_presence_of :author, message: ts('can\'t be blank')
   validates_length_of :author, maximum: AUTHOR_LENGTH_MAX,
-                               too_long: ts('^Creator must be less than %{max} characters long.',
+                               too_long: ts('must be less than %{max} characters long.',
                                             max: AUTHOR_LENGTH_MAX)
 
   validates :user_defined_tags_count,

--- a/app/models/external_work.rb
+++ b/app/models/external_work.rb
@@ -27,9 +27,9 @@ class ExternalWork < ApplicationRecord
                                 too_long: ts("must be less than %{max} characters long.",
                                              max: ArchiveConfig.SUMMARY_MAX)
 
-  validates_presence_of :author, message: ts('can\'t be blank')
+  validates :author, presence: { message: ts("can't be blank") }
   validates_length_of :author, maximum: AUTHOR_LENGTH_MAX,
-                               too_long: ts('must be less than %{max} characters long.',
+                               too_long: ts("must be less than %{max} characters long.",
                                             max: AUTHOR_LENGTH_MAX)
 
   validates :user_defined_tags_count,

--- a/app/models/related_work.rb
+++ b/app/models/related_work.rb
@@ -18,7 +18,7 @@ class RelatedWork < ActiveRecord::Base
     return if parent
 
     if url.include?(ArchiveConfig.APP_HOST)
-      if url.match(/\/works\/(\d+)/)
+      if url.match(%r{/works/(\d+)})
         self.parent = Work.find_by(id: Regexp.last_match(1))
       else
         errors.add(:parent, :not_work)

--- a/app/models/related_work.rb
+++ b/app/models/related_work.rb
@@ -1,12 +1,50 @@
 class RelatedWork < ActiveRecord::Base
   include ActiveModel::ForbiddenAttributesProtection
   belongs_to :work
-  belongs_to :parent, polymorphic: true
+  belongs_to :parent, polymorphic: true, autosave: true
+
+  attribute :url, :string
+  attribute :title, :string
+  attribute :author, :string
+  attribute :language_id, :integer
 
   scope :posted, -> {
     joins("INNER JOIN `works` `child_works` ON `child_works`.`id` = `related_works`.`work_id`").
     where("child_works.posted = 1")
   }
+
+  before_validation :set_parent, if: :new_record?
+  def set_parent
+    return if parent
+
+    if url.include?(ArchiveConfig.APP_HOST)
+      if url.match(/\/works\/(\d+)/)
+        self.parent = Work.find_by(id: Regexp.last_match(1))
+      else
+        errors.add(:parent, :not_work)
+        throw :abort # don't generate any further errors
+      end
+    else
+      self.parent = ExternalWork.find_or_initialize_by(
+        url: url,
+        title: title,
+        author: author,
+        language_id: language_id
+      )
+    end
+  end
+
+  validates :parent, presence: true, on: :create
+
+  validate :check_parent_protected, on: :create
+  def check_parent_protected
+    return unless parent.respond_to?(:users)
+    return if parent.anonymous? || parent.unrevealed?
+
+    parent.users.each do |user|
+      errors.add(:parent, :protected, login: user.login) if user.protected_user
+    end
+  end
 
   def notify_parent_owners
     if parent.respond_to?(:pseuds)

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -30,6 +30,8 @@ class Work < ApplicationRecord
   has_many :children, through: :related_works, source: :work
   has_many :approved_children, through: :approved_related_works, source: :work
 
+  accepts_nested_attributes_for :parent_work_relationships, allow_destroy: true, reject_if: proc { |attrs| attrs.values_at(:url, :author, :title).all?(&:blank?) }
+
   has_many :gifts, dependent: :destroy
   accepts_nested_attributes_for :gifts, allow_destroy: true
 
@@ -180,21 +182,6 @@ class Work < ApplicationRecord
     end
   end
 
-  validate :new_parents_can_be_cited
-
-  def new_parents_can_be_cited
-    return if self.new_parent.blank?
-
-    parent = self.new_parent[:parent]
-    return unless parent.respond_to?(:pseuds)
-    return if parent.anonymous? || parent.unrevealed?
-
-    users = parent.pseuds.collect(&:user).uniq
-    users.each do |user|
-      self.errors.add(:base, ts("You can't use the related works function to cite works by the protected user #{user.login}.")) if user.protected_user
-    end
-  end
-
   enum comment_permissions: {
     enable_all: 0,
     disable_anon: 1,
@@ -212,7 +199,7 @@ class Work < ApplicationRecord
   after_save :post_first_chapter
   before_save :set_word_count
 
-  after_save :save_chapters, :save_parents, :save_new_gifts
+  after_save :save_chapters, :save_new_gifts
 
   before_create :set_anon_unrevealed
   after_create :notify_after_creation
@@ -945,61 +932,8 @@ class Work < ApplicationRecord
   # These are for inspirations/remixes/etc
   ########################################################################
 
-  # Works (internal or external) that this work was inspired by
-  # Can't make this a has_many association because it's polymorphic
-  def parents
-    self.parent_work_relationships.collect(&:parent).compact
-  end
-
-  # Virtual attribute for parent work, via related_works
-  def parent_attributes=(attributes)
-    unless attributes[:url].blank?
-      if attributes[:url].include?(ArchiveConfig.APP_HOST)
-        if attributes[:url].match(/\/works\/(\d+)/)
-          begin
-            self.new_parent = {parent: Work.find($1), translation: attributes[:translation]}
-          rescue
-            self.errors.add(:base, "The work you listed as an inspiration does not seem to exist.")
-          end
-        else
-          self.errors.add(:base, "Only a link to a work can be listed as an inspiration.")
-        end
-      elsif attributes[:title].blank? || attributes[:author].blank?
-        error_message = ""
-        if attributes[:title].blank?
-          error_message << "A parent work outside the archive needs to have a title. "
-        end
-        if attributes[:author].blank?
-          error_message << "A parent work outside the archive needs to have an author. "
-        end
-        self.errors.add(:base, error_message)
-      else
-        translation = attributes.delete(:translation)
-        ew = ExternalWork.find_by_url(attributes[:url])
-        if ew && (ew.title == attributes[:title]) && (ew.author == attributes[:author])
-          self.new_parent = {parent: ew, translation: translation}
-        else
-          ew = ExternalWork.new(attributes)
-          if ew.save
-            self.new_parent = {parent: ew, translation: translation}
-          else
-            self.errors.add(:base, "Parent work " + ew.errors.full_messages[0])
-          end
-        end
-      end
-    end
-  end
-
-  # Save relationship to parent work if applicable
-  def save_parents
-    if self.new_parent and !(self.parents.include?(self.new_parent))
-      unless self.new_parent.blank? || self.new_parent[:parent].blank?
-        relationship = self.new_parent[:parent].related_works.build work_id: self.id, translation: self.new_parent[:translation]
-        if relationship.save
-          self.new_parent = nil
-        end
-      end
-    end
+  def parents_after_saving
+    parent_work_relationships.reject(&:marked_for_destruction?)
   end
 
   #################################################################################

--- a/app/views/works/_hidden_fields.html.erb
+++ b/app/views/works/_hidden_fields.html.erb
@@ -37,6 +37,15 @@
   <%= s.hidden_field :id, value: "#{work_series_value(:id)}" %>
   <%= s.hidden_field :title, value: "#{work_series_value(:title)}" %>
 <% end %>
+
+<%= form.fields_for :parent_work_relationships, @work.parent_work_relationships.select(&:new_record?) do |p| %>
+  <%= p.hidden_field :url %>
+  <%= p.hidden_field :title %>
+  <%= p.hidden_field :author %>
+  <%= p.hidden_field :language_id %>
+  <%= p.hidden_field :translation %>
+<% end %>
+
 <%= form.hidden_field :backdate, :value => "#{@work.backdate}" %>
 <%= form.hidden_field :wip_length, :value => "#{@work.wip_length}" %>
 <%= form.hidden_field :restricted, :value => "#{@work.restricted}" %>

--- a/app/views/works/_standard_form.html.erb
+++ b/app/views/works/_standard_form.html.erb
@@ -100,10 +100,13 @@
         <!-- Toggles on with parent checkbox -->
         <fieldset id="parent-options">
           <dl>
-            <%= fields_for "work[parent_attributes]" do |p| %>
+            <% new, existing = @work.parent_work_relationships.partition(&:new_record?) %>
+            <% new << @work.parent_work_relationships.build if new.empty? %>
+
+            <%= f.fields_for :parent_work_relationships, new do |p| %>
               <dt><%= p.label :url, ts("URL") %></dt>
               <dd>
-                <%= p.text_field :url, value: work_parent_value(:url),
+                <%= p.text_field :url,
                       "aria-describedby" => "parent-attributes-url-field-description" %>
                 <p class="important footnote" id="parent-attributes-url-field-description">
                   <%= ts("For a work in the Archive, only the URL is required.") %>
@@ -111,10 +114,10 @@
               </dd>
 
               <dt><%= p.label :title %></dt>
-              <dd><%= p.text_field :title, value: work_parent_value(:title) %></dd>
+              <dd><%= p.text_field :title %></dd>
 
               <dt><%= p.label :author %></dt>
-              <dd><%= p.text_field :author, value: work_parent_value(:author) %></dd>
+              <dd><%= p.text_field :author %></dd>
 
               <dt>
                 <%= p.label :language_id, ts("Language") %>
@@ -131,9 +134,9 @@
               </dd>
             <% end %>
 
-            <% unless @work.parent_work_relationships.blank? %>
+            <% unless existing.blank? %>
               <dt><%= ts("Current parent works") %></dt>
-              <% for related_work in @work.parent_work_relationships %>
+              <% existing.each do |related_work| %>
                 <% if related_work.parent %>
                   <dd>
                     <ul class="actions" role="navigation">

--- a/app/views/works/_standard_form.html.erb
+++ b/app/views/works/_standard_form.html.erb
@@ -100,10 +100,10 @@
         <!-- Toggles on with parent checkbox -->
         <fieldset id="parent-options">
           <dl>
-            <% new, existing = @work.parent_work_relationships.partition(&:new_record?) %>
-            <% new << @work.parent_work_relationships.build if new.empty? %>
+            <% new_parent, existing_parents = @work.parent_work_relationships.partition(&:new_record?) %>
+            <% new_parent << @work.parent_work_relationships.build if new_parent.empty? %>
 
-            <%= f.fields_for :parent_work_relationships, new do |p| %>
+            <%= f.fields_for :parent_work_relationships, new_parent do |p| %>
               <dt><%= p.label :url, ts("URL") %></dt>
               <dd>
                 <%= p.text_field :url,
@@ -134,9 +134,9 @@
               </dd>
             <% end %>
 
-            <% unless existing.blank? %>
+            <% unless existing_parents.blank? %>
               <dt><%= ts("Current parent works") %></dt>
-              <% existing.each do |related_work| %>
+              <% existing_parents.each do |related_work| %>
                 <% if related_work.parent %>
                   <dd>
                     <ul class="actions" role="navigation">

--- a/app/views/works/_work_header_notes.html.erb
+++ b/app/views/works/_work_header_notes.html.erb
@@ -27,7 +27,7 @@
     <% end %>
 
     <% # parent works %>
-    <% for related_work in @work.parent_work_relationships %>
+    <% for related_work in @work.parents_after_saving %>
       <% if related_work.parent %>
         <li>
           <% if related_work.translation %>

--- a/config/locales/models/en.yml
+++ b/config/locales/models/en.yml
@@ -36,6 +36,13 @@ en:
               inclusion: "What did you want to leave kudos on?"
           format: "%{message}"
           taken: "You have already left kudos here. :)"
+        related_work:
+          attributes:
+            parent:
+              blank: "The work you listed as an inspiration does not seem to exist."
+              not_work: "Only a link to a work can be listed as an inspiration."
+              protected: "You can't use the related works function to cite works by the protected user %{login}."
+          format: "%{message}"
         user:
           attributes:
             password_confirmation:
@@ -49,6 +56,8 @@ en:
             user_defined_tags_count:
               at_most:
                 "must not add up to more than %{count}. Your work has %{value} of these tags, so you must remove %{diff} of them."
+        work/parent_work_relationships:
+          format: "%{message}"
     models:
       archive_warning:
         one: "Warning"
@@ -141,8 +150,13 @@ en:
       work/chapters:
         content: "Content"
         base: "Invalid chapter:"
+      work/parent_work_relationships/parent:
+        url: "Parent work URL"
+        title: "The title of a parent work outside the archive"
+        author: "The author of a parent work outside the archive"
       external_work:
         user_defined_tags_count: "Fandom, relationship, and character tags"
+        author: "Creator"
       work:
         chapter_total_display: "Chapters"
         summary: "Summary"

--- a/features/step_definitions/work_related_steps.rb
+++ b/features/step_definitions/work_related_steps.rb
@@ -115,13 +115,17 @@ When /^I draft a translation$/ do
 end
 
 When /^I list a series as inspiration$/ do
-  fill_in("work_parent_attributes_url", with: "#{ArchiveConfig.APP_HOST}/series/123")
+  with_scope("#parent-options") do
+    fill_in("URL", with: "#{ArchiveConfig.APP_HOST}/series/123")
+  end
 end
 
 When /^I list a nonexistent work as inspiration$/ do
   work = Work.find_by_id(123)
   work.destroy unless work.nil?
-  fill_in("work_parent_attributes_url", with: "#{ArchiveConfig.APP_HOST}/works/123")
+  with_scope("#parent-options") do
+    fill_in("URL", with: "#{ArchiveConfig.APP_HOST}/works/123")
+  end
 end
 
 ### THEN

--- a/features/step_definitions/work_steps.rb
+++ b/features/step_definitions/work_steps.rb
@@ -512,15 +512,19 @@ When /^I list the work "([^"]*)" as inspiration$/ do |title|
   work = Work.find_by(title: title)
   check("parent-options-show")
   url_of_work = work_url(work).sub("www.example.com", ArchiveConfig.APP_HOST)
-  fill_in("work_parent_attributes_url", with: url_of_work)
+  with_scope("#parent-options") do
+    fill_in("URL", with: url_of_work)
+  end
 end
 
 When /^I list an external work as inspiration$/ do
   check("parent-options-show")
-  fill_in("work_parent_attributes_url", with: "https://example.com")
-  fill_in("work_parent_attributes_title", with: "Example External")
-  fill_in("work_parent_attributes_author", with: "External Author")
-  select("English", from: "work[parent_attributes][language_id]")
+  with_scope("#parent-options") do
+    fill_in("URL", with: "https://example.com")
+    fill_in("Title", with: "Example External")
+    fill_in("Author", with: "External Author")
+    select("English", from: "Language")
+  end
 end
 
 When /^I set the publication date to (\d+) (.*) (\d+)$/ do |day, month, year|

--- a/features/works/work_related.feature
+++ b/features/works/work_related.feature
@@ -245,8 +245,8 @@ Scenario: Listing external works as inspirations
     And I fill in "URL" with "http://example.org/200"
     And I press "Preview"
   Then I should see a save error message
-    And I should see "A parent work outside the archive needs to have a title."
-    And I should see "A parent work outside the archive needs to have an author."
+    And I should see "The title of a parent work outside the archive can't be blank"
+    And I should see "The author of a parent work outside the archive can't be blank"
   When I fill in "Title" with "Worldbuilding"
     And I fill in "Author" with "BNF"
     And I check "This is a translation"
@@ -260,8 +260,8 @@ Scenario: Listing external works as inspirations
     And I fill in "URL" with "http://example.org/301"
     And I press "Preview"
   Then I should see a save error message
-    And I should see "A parent work outside the archive needs to have a title."
-    And I should see "A parent work outside the archive needs to have an author."
+    And I should see "The title of a parent work outside the archive can't be blank"
+    And I should see "The author of a parent work outside the archive can't be blank"
   When I fill in "Title" with "Worldbuilding Two"
     And I fill in "Author" with "BNF"
     And I press "Preview"
@@ -280,7 +280,7 @@ Scenario: Listing external works as inspirations
     And I fill in "Title" with "Worldbuilding Two"
     And I fill in "Author" with "BNF"
     And I press "Preview"
-  Then I should see "Parent work Url could not be reached. If the URL is correct and the site is currently down, please try again later."
+  Then I should see "Parent work URL could not be reached. If the URL is correct and the site is currently down, please try again later."
 
 Scenario: External work language
 

--- a/lib/creation_notifier.rb
+++ b/lib/creation_notifier.rb
@@ -94,8 +94,8 @@ module CreationNotifier
 
   # notify authors of related work
   def notify_parents
-    if !self.parent_work_relationships.empty? && !self.unrevealed?
-      self.parent_work_relationships.each {|relationship| relationship.notify_parent_owners}
-    end
+    return if unrevealed?
+
+    parents_after_saving.each(&:notify_parent_owners)
   end
 end


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6379

## Purpose

Switches the related works code to use `accepts_nested_attributes_for` instead of a custom-built `parent_attributes=` function.