### PR TITLE
AO3-6311 Edited comment reply notification sent to creator of deleted comment

### DIFF
--- a/app/mailers/comment_mailer.rb
+++ b/app/mailers/comment_mailer.rb
@@ -41,6 +41,7 @@ class CommentMailer < ApplicationMailer
   def edited_comment_reply_notification(your_comment, edited_comment)
     return if your_comment.comment_owner_email.blank?
     return if your_comment.pseud_id.nil? && AdminBlacklistedEmail.is_blacklisted?(your_comment.comment_owner_email)
+    return if your_comment.is_deleted?
 
     @your_comment = your_comment
     @comment = edited_comment

--- a/features/comments_and_kudos/add_comment.feature
+++ b/features/comments_and_kudos/add_comment.feature
@@ -117,6 +117,22 @@ Scenario: Comment threading, comment editing
     And I should not see "This should be nested" within ".thread .thread .thread .thread"
     And I should see "I loved this" within "ol.thread"
 
+  Scenario: A leaves a comment, B replies to it, A deletes their comment, B edits the comment, A should not receive a comment edit notification email
+
+    Given the work "Generic Work" by "creator"
+      And a comment "A's comment (to be deleted)" by "User_A" on the work "Generic Work"
+      And a reply "B's comment (to be edited)" by "User_B" on the work "Generic Work"
+      And 1 email should be delivered to "User_A"
+    When I am logged in as "User_A"
+      And I view the work "Generic Work" with comments
+      And I delete the comment
+    When I am logged in as "User_B"
+      And I view the work "Generic Work" with comments
+      And I follow "Edit"
+      And I fill in "Comment" with "B's improved comment (edited)"
+      And I press "Update"
+    Then 1 email should be delivered to "User_A"
+  
   Scenario: Try to post an invalid comment
 
     When I am logged in as "author"

--- a/features/comments_and_kudos/add_comment.feature
+++ b/features/comments_and_kudos/add_comment.feature
@@ -123,7 +123,7 @@ Scenario: Comment threading, comment editing
       And a comment "A's comment (to be deleted)" by "User_A" on the work "Generic Work"
       And a reply "B's comment (to be edited)" by "User_B" on the work "Generic Work"
       And 1 email should be delivered to "User_A"
-      # This is the comment_reply_notification email.
+      And all emails have been delivered
     When I am logged in as "User_A"
       And I view the work "Generic Work" with comments
       And I delete the comment
@@ -132,9 +132,7 @@ Scenario: Comment threading, comment editing
       And I follow "Edit"
       And I fill in "Comment" with "B's improved comment (edited)"
       And I press "Update"
-    Then 1 email should be delivered to "User_A"
-    # This checks that only the comment_reply_notification email above exists in user A's inbox
-    # i.e. there is no additional edited_comment_reply_notification email being sent.
+    Then 0 emails should be delivered to "User_A"
   
   Scenario: Try to post an invalid comment
 

--- a/features/comments_and_kudos/add_comment.feature
+++ b/features/comments_and_kudos/add_comment.feature
@@ -123,6 +123,7 @@ Scenario: Comment threading, comment editing
       And a comment "A's comment (to be deleted)" by "User_A" on the work "Generic Work"
       And a reply "B's comment (to be edited)" by "User_B" on the work "Generic Work"
       And 1 email should be delivered to "User_A"
+      # This is the comment_reply_notification email.
     When I am logged in as "User_A"
       And I view the work "Generic Work" with comments
       And I delete the comment
@@ -132,6 +133,8 @@ Scenario: Comment threading, comment editing
       And I fill in "Comment" with "B's improved comment (edited)"
       And I press "Update"
     Then 1 email should be delivered to "User_A"
+    # This checks that only the comment_reply_notification email above exists in user A's inbox
+    # i.e. there is no additional edited_comment_reply_notification email being sent.
   
   Scenario: Try to post an invalid comment
 


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [x] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [x] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [x] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-6311

## Purpose

Do not send a edited comment reply notification to creator of deleted comment

## Testing Instructions

Follow instructions on JIRA.

## Credit

EchoEkhi (He/Him/{/([A-Z][a-z]*)/g})
