### PR TITLE
AO3-5866 used xml:base to resolve relative links and made text byline indicated as html

### DIFF
--- a/app/views/tags/feed.atom.builder
+++ b/app/views/tags/feed.atom.builder
@@ -1,6 +1,7 @@
 atom_feed do |feed|
   feed.title "AO3 works tagged '#{@tag.name}'"
   feed.updated @works.first.created_at if @works.respond_to?(:first) && @works.first.present?
+  feed.tag!('xml:base', 'https://archiveofourown.org')
 
   @works.each do |work|
     unless work.unrevealed?

--- a/app/views/tags/feed.atom.builder
+++ b/app/views/tags/feed.atom.builder
@@ -9,7 +9,7 @@ atom_feed do |feed|
         entry.summary feed_summary(work), :type => 'html'
 
         entry.author do |author|
-          author.name text_byline(work, :visibility => 'public')
+          author.name text_byline(work, :visibility => 'public'), :type => 'html'
         end
       end
     end


### PR DESCRIPTION
sorry if i've made any syntax errors or coding standard errors; i just tried to make a quick correction for a bug my friend was inconvenienced by

## Issue

https://otwarchive.atlassian.net/browse/AO3-5866
(closest issue i could find retroactively searching)

## Purpose

fixes errors with how authours are displayed in atom feeds. follows RFC 4287 the atom syndication format.

## Testing Instructions

like run the code, navigate to any tag's atom feed, and assert all `<name>` elements have the attribute `type="html"` and the `<feed>` element has the attribute `xml:base="https://archiveofourown.org"`.