### PR TITLE
AO3-6361 Fix admin email change text

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -562,7 +562,7 @@ class User < ApplicationRecord
       action: ArchiveConfig.ACTION_NEW_EMAIL,
       admin_id: current_admin&.id
     }
-    options[:note] = "Change made by admin #{current_admin&.login}" if current_admin
+    options[:note] = "Change made by #{current_admin&.login}" if current_admin
     create_log_item(options)
   end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -206,7 +206,7 @@ describe User do
         log_item = existing_user.log_items.last
         expect(log_item.action).to eq(ArchiveConfig.ACTION_NEW_EMAIL)
         expect(log_item.admin_id).to eq(admin.id)
-        expect(log_item.note).to eq("Change made by admin #{admin.login}")
+        expect(log_item.note).to eq("Change made by #{admin.login}")
       end
     end
   end


### PR DESCRIPTION
# Pull Request Checklist

* [X] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [X] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [X] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [X] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [X] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-6361

## Purpose

Fix the text in the log when an admin changes a user's email.

## Testing Instructions

See Jira ticket (note that the steps will need to be followed again, as any existing logs will have the old text).

If you have a Jira account with access, please update or comment on the issue
with any new or missing testing instructions instead.

## References

Follow-up to #4302

## Credit

What name and pronouns should we use to credit you in the [Archive of Our Own's Release Notes](https://archiveofourown.org/admin_posts?tag=1)? **Brian Austin (they/he)**
