### PR TITLE
AO3-6389 Stop using Dreamwidth URLs in external work tests.

### DIFF
--- a/features/step_definitions/autocomplete_steps.rb
+++ b/features/step_definitions/autocomplete_steps.rb
@@ -200,9 +200,8 @@ Then /^the fandom-specific tag autocomplete fields should list only fandom-speci
 end
 
 Then /^the external url autocomplete field should list the urls of existing external works$/ do
-  step %{I enter "zoo" in the "URL" autocomplete field}
-  step %{I should see "zooey-glass.dreamwidth.org" in the autocomplete}
-  step %{I should not see "parenthetical.livejournal.com" in the autocomplete}
+  step %{I enter "exam" in the "URL" autocomplete field}
+  step %{I should see "http://example.org/200" in the autocomplete}
 end
 
 Given /^a set of users for testing autocomplete$/ do

--- a/features/step_definitions/external_work_steps.rb
+++ b/features/step_definitions/external_work_steps.rb
@@ -1,4 +1,4 @@
-DEFAULT_EXTERNAL_URL = "http://zooey-glass.dreamwidth.org"
+DEFAULT_EXTERNAL_URL = "http://example.org/200"
 DEFAULT_EXTERNAL_CREATOR = "Zooey Glass"
 DEFAULT_EXTERNAL_TITLE = "A Work Not Posted To The AO3"
 DEFAULT_EXTERNAL_SUMMARY = "This is my story, I am its author."
@@ -15,6 +15,7 @@ Given /^an external work$/ do
 end
 
 Given /^I set up an external work$/ do
+  step %{mock websites with no content}
   visit new_external_work_path
   fill_in("URL", with: DEFAULT_EXTERNAL_URL)
   fill_in("external_work_author", with: DEFAULT_EXTERNAL_CREATOR)
@@ -41,7 +42,7 @@ Given "{string} has bookmarked an external work" do |user|
   # field's id attribute over its label. But in this case,
   # we have to use the labels for some fields because the ids
   # change when JavaScript is enabled.
-  fill_in("URL", with: "http://example.org/200")
+  fill_in("URL", with: DEFAULT_EXTERNAL_URL)
   fill_in("external_work_author", with: DEFAULT_EXTERNAL_CREATOR)
   fill_in("external_work_title", with: DEFAULT_EXTERNAL_TITLE)
   fill_in("external_work_summary", with: DEFAULT_EXTERNAL_SUMMARY)

--- a/spec/controllers/external_works_controller_spec.rb
+++ b/spec/controllers/external_works_controller_spec.rb
@@ -2,13 +2,13 @@ require 'spec_helper'
 
 describe ExternalWorksController do
   describe "GET #fetch" do
-    url = "http://ao3testing.dreamwidth.org/593.html"
+    let(:url) { "http://example.org/200" }
 
-    before(:each) do
-      @external_work = FactoryBot.create(:external_work, url: url)
-    end
+    before { WebMock.stub_request(:any, url) }
 
-    context "URL that has an external work" do
+    context "when the URL has an external work" do
+      let!(:external_work) { create(:external_work, url: url) }
+
       it "responds with json" do
         get :fetch, params: { external_work_url: url, format: :json }
         expect(response.content_type).to match("application/json")
@@ -16,30 +16,28 @@ describe ExternalWorksController do
 
       it "responds with the matching work" do
         get :fetch, params: { external_work_url: url, format: :json }
-        expect(assigns(:external_work)).to eq(@external_work)
+        expect(assigns(:external_work)).to eq(external_work)
       end
 
-      before do
-        @external_work2 = FactoryBot.create(:external_work, url: url)
-      end
+      context "when the URL has a second external work" do
+        let!(:external_work2) { create(:external_work, url: url) }
 
-      it "responds with the first matching work" do
-        get :fetch, params: { external_work_url: url, format: :json }
-        expect(assigns(:external_work)).to eq(@external_work)
-        expect(assigns(:external_work)).not_to eq(@external_work2)
+        it "responds with the first matching work" do
+          get :fetch, params: { external_work_url: url, format: :json }
+          expect(assigns(:external_work)).to eq(external_work)
+          expect(assigns(:external_work)).not_to eq(external_work2)
+        end
       end
     end
 
-    context "URL that does not have an external work" do
-      url_2 = "http://ao3testing.dreamwidth.org"
-
+    context "when the URL doesn't have an exteral work" do
       it "responds with json" do
-        get :fetch, params: { external_work_url: url_2, format: :json }
+        get :fetch, params: { external_work_url: url, format: :json }
         expect(response.content_type).to match("application/json")
       end
 
       it "responds with blank" do
-        get :fetch, params: { external_work_url: url_2, format: :json }
+        get :fetch, params: { external_work_url: url, format: :json }
         expect(assigns(:external_work)).to be_nil
       end
     end


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6389

## Purpose

- Use example.org instead of dreamwidth.org in external work tests.
- Use `WebMock` to stub the URLs to prevent connection errors.

## Testing Instructions

Make sure the automated tests pass.