### PR TITLE
AO3-6380 Restrict access to the Admin Activities page to Policy & Abuse and Superadmins.

### DIFF
--- a/app/controllers/admin/activities_controller.rb
+++ b/app/controllers/admin/activities_controller.rb
@@ -1,11 +1,11 @@
 class Admin::ActivitiesController < Admin::BaseController
-
   def index
     @activities = AdminActivity.order("created_at DESC").page(params[:page])
+    authorize @activities
   end
 
   def show
     @activity = AdminActivity.find(params[:id])
+    authorize @activity
   end
-
 end

--- a/app/policies/admin_activity_policy.rb
+++ b/app/policies/admin_activity_policy.rb
@@ -1,0 +1,9 @@
+class AdminActivityPolicy < ApplicationPolicy
+  PERMITTED_ROLES = %w[policy_and_abuse superadmin]
+
+  def index?
+    user_has_roles?(PERMITTED_ROLES)
+  end
+
+  alias show? index?
+end

--- a/app/policies/admin_activity_policy.rb
+++ b/app/policies/admin_activity_policy.rb
@@ -1,5 +1,5 @@
 class AdminActivityPolicy < ApplicationPolicy
-  PERMITTED_ROLES = %w[policy_and_abuse superadmin]
+  PERMITTED_ROLES = %w[policy_and_abuse superadmin].freeze
 
   def index?
     user_has_roles?(PERMITTED_ROLES)

--- a/app/views/admin/_header.html.erb
+++ b/app/views/admin/_header.html.erb
@@ -54,6 +54,10 @@
   <% end %>
   <li><%= link_to ts("Tag Wrangling", key: "header"), tag_wranglings_path %></li>
   <li><%= link_to ts("Locales", key: "header"), locales_path %></li>
-  <li><%= link_to ts("Activities", key: "header"), admin_activities_path %></li>
+
+  <% if policy(AdminActivity).index? %>
+    <li><%= link_to ts("Activities", key: "header"), admin_activities_path %></li>
+  <% end %>
+
   <li><%= link_to ts("Manage API Tokens", key: "header"), admin_api_index_path %></li>
 </ul>

--- a/spec/controllers/admin/activities_controller_spec.rb
+++ b/spec/controllers/admin/activities_controller_spec.rb
@@ -1,0 +1,71 @@
+require "spec_helper"
+
+describe Admin::ActivitiesController do
+  include LoginMacros
+  include RedirectExpectationHelper
+
+  let!(:admin_activity) { create(:admin_activity) }
+  let(:admin) { create(:admin) }
+
+  before { fake_login_admin(admin) }
+
+  shared_examples "unauthorized" do
+    it "redirects with an error" do
+      it_redirects_to_with_error(root_path, "Sorry, only an authorized admin can access the page you were trying to reach.")
+    end
+  end
+
+  describe "GET #index" do
+    before { get :index }
+
+    context "when logged in as an admin with no role" do
+      it_behaves_like "unauthorized"
+    end
+
+    %w[board communications translation tag_wrangling docs support open_doors].each do |role|
+      context "when logged in as an admin with #{role} role" do
+        let(:admin) { create(:admin, roles: [role]) }
+
+        it_behaves_like "unauthorized"
+      end
+    end
+
+    %w[policy_and_abuse superadmin].each do |role|
+      context "when logged in as an admin with #{role} role" do
+        let(:admin) { create(:admin, roles: [role]) }
+
+        it "renders the index" do
+          expect(assigns[:activities]).to eq([admin_activity])
+          expect(response).to render_template(:index)
+        end
+      end
+    end
+  end
+
+  describe "GET #show" do
+    before { get :show, params: { id: admin_activity.id } }
+
+    context "when logged in as an admin with no role" do
+      it_behaves_like "unauthorized"
+    end
+
+    %w[board communications translation tag_wrangling docs support open_doors].each do |role|
+      context "when logged in as an admin with #{role} role" do
+        let(:admin) { create(:admin, roles: [role]) }
+
+        it_behaves_like "unauthorized"
+      end
+    end
+
+    %w[policy_and_abuse superadmin].each do |role|
+      context "when logged in as an admin with #{role} role" do
+        let(:admin) { create(:admin, roles: [role]) }
+
+        it "renders the info about the activity" do
+          expect(assigns[:activity]).to eq(admin_activity)
+          expect(response).to render_template(:show)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6380

## Purpose

Limit access to `Admin::ActivitiesController` to admins with the roles `policy_and_abuse` and `superadmin`.