### PR TITLE
AO3-6224 Return a 404 when wrangler is not found

### DIFF
--- a/app/controllers/tag_wranglers_controller.rb
+++ b/app/controllers/tag_wranglers_controller.rb
@@ -36,7 +36,7 @@ class TagWranglersController < ApplicationController
   end
 
   def show
-    @wrangler = User.find_by(login: params[:id])
+    @wrangler = User.find_by!(login: params[:id])
     @page_subtitle = @wrangler.login
     @fandoms = @wrangler.fandoms.by_name
     @counts = {}

--- a/spec/controllers/tag_wranglers_controller_spec.rb
+++ b/spec/controllers/tag_wranglers_controller_spec.rb
@@ -1,0 +1,20 @@
+require "spec_helper"
+
+describe TagWranglersController do
+  include LoginMacros
+  include RedirectExpectationHelper
+
+  let(:user) { create(:tag_wrangler) }
+
+  before { fake_login_known_user(user) }
+
+  describe "#show" do
+    context "when the target user does not exist" do
+      it "raises a 404 error" do
+        expect do
+          get :show, params: { id: -1 }
+        end.to raise_exception(ActiveRecord::RecordNotFound)
+      end
+    end
+  end
+end


### PR DESCRIPTION
# Pull Request Checklist

* [X] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [X] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [X] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [X] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [X] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-6224

## Purpose

Raise a 404 error rather than a 500 when accessing the wrangler page for a non-existent user.

## Testing Instructions

See the Jira ticket's description. (Note: to test this locally, I had to flip https://github.com/otwcode/otwarchive/blob/master/config/environments/development.rb#L19)

## References

Are there other relevant issues/pull requests/mailing list discussions?

## Credit

What name and pronouns should we use to credit you in the [Archive of Our Own's Release Notes](https://archiveofourown.org/admin_posts?tag=1)?

**Brian Austin (they/he)**
