### PR TITLE
AO3-6160 Fix grammatical error on delete pseud page

### DIFF
--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -413,7 +413,7 @@ en:
       heading: "Pseud deletion"
       notice: "When you delete your pseud, any works, series, or comments you have created under it will be transferred to your default pseud."
       saved_bookmarks: 
-        one: "You have saved %{count} bookmark using this pseud. You can choose whether to delete it or transfer them to your default pseud."
+        one: "You have saved %{count} bookmark using this pseud. You can choose whether to delete it or transfer it to your default pseud."
         other: "You have saved %{count} bookmarks using this pseud. You can choose whether to delete them or transfer them to your default pseud."
       delete: 
         one: "Delete this bookmark"


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6160

## Purpose

Updates the text on the delete pseud page when the pseud you're deleting only has one bookmark.

## Testing Instructions

Refer to Jira.