### PR TITLE
AO3-6397 Try to fix flaky co-creator test in features/works/work_create.feature.

### DIFF
--- a/features/works/work_create.feature
+++ b/features/works/work_create.feature
@@ -387,7 +387,9 @@ Feature: Create Works
     When I am logged in as "barbaz"
       And I view the work "Chaptered Work"
     Then I should not see "Edit"
-    When I follow "Co-Creator Requests page"
+    # Delay to make sure that the cache expires when we accept the request:
+    When it is currently 1 second from now
+      And I follow "Co-Creator Requests page"
       And I check "selected[]"
       And I press "Accept"
     Then I should see "You are now listed as a co-creator on Chaptered Work."


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6397

## Purpose

- Fix the flaky scenario "Inviting a co-author adds the co-author to all existing chapters when they accept the invite."

## Testing Instructions

I ran features/works/work_create.feature 40 times in this run, with no failures or flaky tests: https://github.com/tickinginstant/otwarchive/actions/runs/3064732702/jobs/4948123437