### PR TITLE
AO3-6400 Try to fix the flaky test in features/admins/admin_skins.feature.

### DIFF
--- a/features/step_definitions/skin_steps.rb
+++ b/features/step_definitions/skin_steps.rb
@@ -45,6 +45,10 @@ Given /^I edit the skin "([^"]*)"$/ do |skin_name|
 end
 
 Given /^the unapproved public skin "([^"]*)" with css "([^"]*)"$/ do |skin_name, css|
+  # Delay to make sure all skins have at least 1 second of separation in their
+  # creation dates, so that they will be listed in the right order:
+  step "it is currently 1 second from now"
+
   step %{I am logged in as "skinner"}
   step %{I set up the skin "#{skin_name}" with css "#{css}"}
   attach_file("skin_icon", "features/fixtures/skin_test_preview.png")


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6400

## Purpose

- Adds a simulated delay at the start of the "unapproved public skin" step, to try to prevent two public skins from being created during the same second and ending up sorted in the wrong order on the admin skin page.

## Testing Instructions

I ran the features/admins/admin_skins.feature tests 40 times with no failures or flaky tests in this run: https://github.com/tickinginstant/otwarchive/actions/runs/3065242802/jobs/4949148966