### PR TITLE
AO3-6399 Try to fix the flaky test in features/comments_and_kudos/hidden_comments.feature.

### DIFF
--- a/features/comments_and_kudos/hidden_comments.feature
+++ b/features/comments_and_kudos/hidden_comments.feature
@@ -9,7 +9,9 @@ Feature: Comment hiding
       And I post the comment "A suspicious comment" on the work "Popular Fic"
       And I am logged out
 
-    When I am logged in as a super admin
+    # Delay to make sure the cache is expired when the comment is hidden:
+    When it is currently 1 second from now
+      And I am logged in as a super admin
       And I view the work "Popular Fic" with comments
       And I press "Hide Comment"
     Then I should see "Comment successfully hidden!"


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6399

## Purpose

Add an extra delay before hiding the comment, so that the cache is expired when the comment is hidden.

## Testing Instructions

No manual QA necessary. I ran the features/comments_and_kudos/hidden_comments.feature tests [50x](https://github.com/tickinginstant/otwarchive/actions/runs/3074547348/attempts/1) (and then [retried the test once](https://github.com/tickinginstant/otwarchive/actions/runs/3074547348) for good measure), and got no failures or flaky tests.