### PR TITLE
AO3-6052 Append _staging to file name when generating admin accounts on staging

### DIFF
--- a/script/create_admin.rb
+++ b/script/create_admin.rb
@@ -65,7 +65,7 @@ list.each do |user|
     PASSFILE
   end
 
-  puts "==== #{a.login}.txt"
+  puts "==== #{a.login}_staging.txt"
   if a.save
     puts password_file if password_file.present?
     admins << a


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [x] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [x] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [x] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-6052

## Purpose

What does this PR do?

Recommends admins name their file admin-NAME_staging.txt instead of admin-NAME.txt as per Jira issue.

## Testing Instructions

How can the Archive's QA team verify that this is working as you intended?

Create a new admin and check that the instructions are correct.

## References

Are there other relevant issues/pull requests/mailing list discussions?

## Credit

What name and pronouns should we use to credit you in the [Archive of Our Own's Release Notes](https://archiveofourown.org/admin_posts?tag=1)? salt, they/them
