### PR TITLE
AO3-5781 Add delimiter to search result totals and filterable indexes

### DIFF
--- a/app/helpers/search_helper.rb
+++ b/app/helpers/search_helper.rb
@@ -11,9 +11,9 @@ module SearchHelper
       total_entries = collection.total_entries
       total_entries = collection.unlimited_total_entries if collection.respond_to?(:unlimited_total_entries)
       header << ts(" %{start_number} - %{end_number} of %{total} %{things}",
-                   start_number: collection.offset + 1,
-                   end_number: collection.offset + collection.length,
-                   total: total_entries,
+                   start_number: number_with_delimiter(collection.offset + 1),
+                   end_number: number_with_delimiter(collection.offset + collection.length),
+                   total: number_with_delimiter(total_entries),
                    things: item_name.pluralize)
     end
     header << ts("found") if search.present? && search.query.present?
@@ -35,7 +35,7 @@ module SearchHelper
   end
 
   def search_results_found(results)
-    ts("%{count} Found", count: results.unlimited_total_entries)
+    ts("%{count} Found", count: number_with_delimiter(results.unlimited_total_entries))
   end
 
   def random_search_tip


### PR DESCRIPTION
# Pull Request Checklist

* [X] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [X] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [ ] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [X] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [X] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-5781

## Purpose

Add thousand separator to search result totals and filterable indexes.

## Testing Instructions

See Jira. (No automated tests needed as per previous delimiter related PRs.)

## Notes
I added the thousand separator to all numbers in the heading of the index pages. Example for the works index:
![1,026 - 1,027 of 1,027 Works by testuser](https://user-images.githubusercontent.com/27060268/192144789-e8a419b7-add0-4a06-8418-85d05546ff85.png)

## Credit

Bilka (he/him)
