### PR TITLE
AO3-5934 Allow <figure> and <figcaption> HTML tags

### DIFF
--- a/config/initializers/gem-plugin_config/sanitizer_config.rb
+++ b/config/initializers/gem-plugin_config/sanitizer_config.rb
@@ -4,12 +4,12 @@ class Sanitize
   # This defines the configuration we use for HTML tags and attributes allowed in the archive.
   module Config
     ARCHIVE = freeze_config(
-      elements: [
-        'a', 'abbr', 'acronym', 'address', 'b', 'big', 'blockquote', 'br', 'caption', 'center', 'cite', 'code', 'col',
-        'colgroup', 'dd', 'del', 'dfn', 'div', 'dl', 'dt', 'em', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'hr',
-        'i', 'img', 'ins', 'kbd', 'li', 'ol', 'p', 'pre', 'q', 's', 'samp', 'small', 'span', 'strike', 'strong',
-        'sub', 'sup', 'table', 'tbody', 'td', 'tfoot', 'th', 'thead', 'tr', 'tt', 'u', 'ul', 'var'],
-
+      elements: %w[
+        a abbr acronym address b big blockquote br caption center cite code col
+        colgroup figcaption figure dd del dfn div dl dt em h1 h2 h3 h4 h5 h6 hr
+        i img ins kbd li ol p pre q s samp small span strike strong
+        sub sup table tbody td tfoot th thead tr tt u ul var
+      ],
       attributes: {
         all: ['align', 'title', 'dir'],
         'a' => ['href', 'name'],

--- a/lib/html_cleaner.rb
+++ b/lib/html_cleaner.rb
@@ -223,8 +223,8 @@ module HtmlCleaner
 
   # Tags whose content we don't touch
   def dont_touch_content_tag?(tag)
-    %w(a abbr acronym address audio br dl h1 h2 h3 h4 h5 h6 hr img ol p
-       pre source table track video ul).include?(tag)
+    %w[a abbr acronym address audio br dl figure h1 h2 h3 h4 h5 h6 hr img ol p
+       pre source table track video ul].include?(tag)
   end
 
   # Tags that don't contain content
@@ -241,14 +241,14 @@ module HtmlCleaner
 
   # Tags that can't be inside p tags
   def put_outside_p_tag?(tag)
-    %w(audio dl h1 h2 h3 h4 h5 h6 hr ol p pre source table track ul video).include?(tag)
+    %w[audio dl figure h1 h2 h3 h4 h5 h6 hr ol p pre source table track ul video].include?(tag)
   end
 
   # Tags before and after which we don't want to convert linebreaks
   # into br's and p's
   def no_break_before_after_tag?(tag)
-    %w(audio blockquote br center dl div h1 h2 h3 h4 h5 h6
-       hr ol p pre source table track ul video).include?(tag)
+    %w[audio blockquote br center dl div figcaption h1 h2 h3 h4 h5 h6
+       hr ol p pre source table track ul video].include?(tag)
   end
 
   # Traverse a Nokogiri document tree recursively in order to insert

--- a/public/help/html-help.html
+++ b/public/help/html-help.html
@@ -3,7 +3,7 @@
 <h3>Allowed HTML</h3>
 <p>
   <code>a, abbr, acronym, address, [align], [alt], [axis], b, big, blockquote, br, caption, center, cite, [class], code, 
-    col, colgroup, dd, del, dfn, div, dl, dt, em, h1, h2, h3, h4, h5, h6, [height], hr, [href], i, img, 
+    col, colgroup, dd, del, dfn, div, dl, dt, em, figcaption, figure, h1, h2, h3, h4, h5, h6, [height], hr, [href], i, img, 
     ins, kbd, li, [name], ol, p, pre, q, s, samp, small, span, [src], strike, strong, sub, sup, table, tbody, td, 
     tfoot, th, thead, [title], tr, tt, u, ul, var, [width]
   </code>

--- a/spec/lib/html_cleaner_spec.rb
+++ b/spec/lib/html_cleaner_spec.rb
@@ -803,11 +803,11 @@ describe HtmlCleaner do
       expect(doc.xpath("./figure/p")).to be_empty
     end
 
-    it "keeps figure/figcaption and titles" do
+    it "allows alt and title attributes on elements inside figure" do
       html = <<~HTML
         <figure>
           <img src="http://example.com/Camera-icon.svg" alt="camera icon">
-          <figcaption title="here is title"><em>Take picture here</em></figcaption>
+          <figcaption title="here is title">Take picture here</figcaption>
         </figure>
       HTML
 
@@ -816,7 +816,22 @@ describe HtmlCleaner do
 
       expect(doc.xpath("./figure/img/@alt").to_s.strip).to eq("camera icon")
       expect(doc.xpath("./figure/figcaption/@title").to_s.strip).to eq("here is title")
-      expect(doc.xpath("./figure/figcaption/em/node()").to_s.strip).to eq("Take picture here")
+    end
+
+    it "allows other HTML elements inside figcaption" do
+      html = <<~HTML
+        <figure>
+          <img src="http://example.com/Camera-icon.svg">
+          <figcaption><em>Take picture <a href="http://example.com/link">here</a></em></figcaption>
+        </figure>
+      HTML
+
+      result = add_paragraphs_to_text(html)
+      doc = Nokogiri::HTML.fragment(result)
+
+      expect(doc.xpath("./figure/figcaption/em/text()").to_s.strip).to eq("Take picture")
+      expect(doc.xpath("./figure/figcaption/em/a/text()").to_s.strip).to eq("here")
+      expect(doc.xpath("./figure/figcaption/em/a/@href").to_s.strip).to eq("http://example.com/link")
     end
 
     %w(address h1 h2 h3 h4 h5 h6 p pre).each do |tag|


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [x] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [x] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [x] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-5934

## Purpose

The purpose here is to add `<figure> `and `<figcaption>` into the set of allowed HTML tags. These tags are used to show pictures with captions (and more complex content).

For the expected behavior, see the Jira issue. Some of the aspects of the feature as written in the Jira issue are not satisfied exactly in this implementation (at least in its initial version), though.
- If a user tries to wrap `<figure>` with a `<p>`, they can't. It will result in 2 emtpty `<p>`s, one before `<figure>`, another after it. This may not be ideal, but I don't believe we can do much better. Ultimately, most browsers don't support the structure like `<p><figure>`...`</figure></p>`.
- Bare `<figcaption>` is not stripped, they will be left just as entered by the user. I don't think this stripping feature will be useful enough to justify the additional complexity, so I would suggest going without it.

## Testing Instructions

A simple code to be supported looks like this:

```html
<figure>
<img src="https://upload.wikimedia.org/wikipedia/commons/a/aa/Camera-icon.svg" alt="camera icon">
<figcaption>Camera icon, black and white</figcaption>
</figure>
```

## Credit

- Potpotkettle (they/them)

