### PR TITLE
AO3-6406 Fix flaky chapter co-creator test.

### DIFF
--- a/features/works/chapter_edit.feature
+++ b/features/works/chapter_edit.feature
@@ -551,6 +551,8 @@ Feature: Edit chapters
     Then I should not see "Edit"
     When I follow "Co-Creator Requests page"
       And I check "selected[]"
+      # Delay before accepting the request to make sure the cache is expired:
+      And it is currently 1 second from now
       And I press "Accept"
     Then I should see "You are now listed as a co-creator on Chapter 2 of Rusty Has Two Moms."
     When I follow "Rusty Has Two Moms"


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6406

## Purpose

Add a simulated delay to one of the chapter co-creator tests, so that the cache is expired when the co-creator request is accepted and we don't get an intermittent failure.

## Testing Instructions

No manual QA required. I ran the test 50x [here](https://github.com/tickinginstant/otwarchive/actions/runs/3305268321), with no failures or flaky steps.