### PR TITLE
AO3-6414 Clean up unnecessary calls to include ActiveModel::ForbiddenAttributesProtection.

### DIFF
--- a/app/models/abuse_report.rb
+++ b/app/models/abuse_report.rb
@@ -1,6 +1,4 @@
 class AbuseReport < ApplicationRecord
-  include ActiveModel::ForbiddenAttributesProtection
-
   validates :email, email_format: { allow_blank: false }
   validates_presence_of :language
   validates_presence_of :summary

--- a/app/models/admin.rb
+++ b/app/models/admin.rb
@@ -1,5 +1,4 @@
 class Admin < ApplicationRecord
-  include ActiveModel::ForbiddenAttributesProtection
   VALID_ROLES = %w[superadmin board communications translation tag_wrangling docs support policy_and_abuse open_doors].freeze
 
   serialize :roles, Array

--- a/app/models/admin_activity.rb
+++ b/app/models/admin_activity.rb
@@ -1,5 +1,4 @@
 class AdminActivity < ApplicationRecord
-  include ActiveModel::ForbiddenAttributesProtection
   belongs_to :admin
   belongs_to :target, polymorphic: true
 

--- a/app/models/admin_banner.rb
+++ b/app/models/admin_banner.rb
@@ -1,6 +1,4 @@
 class AdminBanner < ApplicationRecord
-  include ActiveModel::ForbiddenAttributesProtection
-
   validates_presence_of :content
 
   after_save :expire_cached_admin_banner, if: :should_expire_cache?
@@ -27,5 +25,4 @@ class AdminBanner < ApplicationRecord
       Rails.cache.delete("admin_banner")
     end
   end
-
 end

--- a/app/models/admin_blacklisted_email.rb
+++ b/app/models/admin_blacklisted_email.rb
@@ -1,6 +1,4 @@
 class AdminBlacklistedEmail < ApplicationRecord
-  include ActiveModel::ForbiddenAttributesProtection
-
   before_validation :canonicalize_email
 
   validates :email, presence: true, uniqueness: true, email_veracity: true
@@ -32,5 +30,4 @@ class AdminBlacklistedEmail < ApplicationRecord
   def self.is_blacklisted?(email_to_check)
     AdminBlacklistedEmail.where(email: AdminBlacklistedEmail.canonical_email(email_to_check)).exists?
   end
-
 end

--- a/app/models/admin_post.rb
+++ b/app/models/admin_post.rb
@@ -1,6 +1,4 @@
 class AdminPost < ApplicationRecord
-  include ActiveModel::ForbiddenAttributesProtection
-
   self.per_page = 8 # option for WillPaginate
 
   acts_as_commentable

--- a/app/models/admin_setting.rb
+++ b/app/models/admin_setting.rb
@@ -1,6 +1,4 @@
 class AdminSetting < ApplicationRecord
-  include ActiveModel::ForbiddenAttributesProtection
-
   belongs_to :last_updated, class_name: 'Admin', foreign_key: :last_updated_by
   validates_presence_of :last_updated_by
   validates :invite_from_queue_number, numericality: { greater_than_or_equal_to: 1,

--- a/app/models/api_key.rb
+++ b/app/models/api_key.rb
@@ -1,6 +1,4 @@
 class ApiKey < ApplicationRecord
-  include ActiveModel::ForbiddenAttributesProtection
-  
   validates :name, presence: true, uniqueness: { case_sensitive: false }
   validates :access_token, presence: true, uniqueness: { case_sensitive: false }
 

--- a/app/models/archive_faq.rb
+++ b/app/models/archive_faq.rb
@@ -1,6 +1,4 @@
 class ArchiveFaq < ApplicationRecord
-  include ActiveModel::ForbiddenAttributesProtection
-
   acts_as_list
   translates :title
   translation_class.include(Globalized)
@@ -31,5 +29,4 @@ class ArchiveFaq < ApplicationRecord
   def self.reorder_list(positions)
     SortableList.new(self.order('position ASC')).reorder_list(positions)
   end
-
 end

--- a/app/models/bookmark.rb
+++ b/app/models/bookmark.rb
@@ -1,6 +1,4 @@
 class Bookmark < ApplicationRecord
-
-  include ActiveModel::ForbiddenAttributesProtection
   include Collectible
   include Searchable
   include Responder

--- a/app/models/challenge_assignment.rb
+++ b/app/models/challenge_assignment.rb
@@ -1,6 +1,4 @@
 class ChallengeAssignment < ApplicationRecord
-  include ActiveModel::ForbiddenAttributesProtection
-
   # We use "-1" to represent all the requested items matching
   ALL = -1
 
@@ -503,5 +501,4 @@ class ChallengeAssignment < ApplicationRecord
       end
     end
   end
-
 end

--- a/app/models/challenge_claim.rb
+++ b/app/models/challenge_claim.rb
@@ -1,6 +1,4 @@
 class ChallengeClaim < ApplicationRecord
-  include ActiveModel::ForbiddenAttributesProtection
-
   belongs_to :claiming_user, class_name: "User", inverse_of: :request_claims
   belongs_to :collection
   belongs_to :request_signup, class_name: "ChallengeSignup"
@@ -154,5 +152,4 @@ class ChallengeClaim < ApplicationRecord
   def prompt_description
     request_prompt&.description || ""
   end
-
 end

--- a/app/models/challenge_models/gift_exchange.rb
+++ b/app/models/challenge_models/gift_exchange.rb
@@ -1,6 +1,5 @@
 class GiftExchange < ApplicationRecord
   PROMPT_TYPES = %w(requests offers)
-  include ActiveModel::ForbiddenAttributesProtection
   include ChallengeCore
 
   override_datetime_setters

--- a/app/models/challenge_models/prompt_meme.rb
+++ b/app/models/challenge_models/prompt_meme.rb
@@ -1,6 +1,4 @@
 class PromptMeme < ApplicationRecord
-  include ActiveModel::ForbiddenAttributesProtection
-
   PROMPT_TYPES = %w(requests)
   include ChallengeCore
 

--- a/app/models/challenge_signup.rb
+++ b/app/models/challenge_signup.rb
@@ -1,5 +1,4 @@
 class ChallengeSignup < ApplicationRecord
-  include ActiveModel::ForbiddenAttributesProtection
   include TagTypeHelper
 
   # -1 represents all matching
@@ -200,5 +199,4 @@ class ChallengeSignup < ApplicationRecord
 
     builder.build_potential_match
   end
-
 end

--- a/app/models/chapter.rb
+++ b/app/models/chapter.rb
@@ -1,7 +1,6 @@
 # encoding=utf-8
 
 class Chapter < ApplicationRecord
-  include ActiveModel::ForbiddenAttributesProtection
   include HtmlCleaner
   include WorkChapterCountCaching
   include CreationNotifier

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -1,5 +1,4 @@
 class Collection < ApplicationRecord
-  include ActiveModel::ForbiddenAttributesProtection
   include Filterable
   include UrlHelpers
   include WorksOwner
@@ -425,5 +424,4 @@ class Collection < ApplicationRecord
   def clear_icon
     self.icon = nil if delete_icon? && !icon.dirty?
   end
-
 end

--- a/app/models/collection_item.rb
+++ b/app/models/collection_item.rb
@@ -1,6 +1,4 @@
 class CollectionItem < ApplicationRecord
-  include ActiveModel::ForbiddenAttributesProtection
-
   APPROVAL_OPTIONS = [
     ["", :unreviewed],
     [ts("Approved"), :approved],

--- a/app/models/collection_participant.rb
+++ b/app/models/collection_participant.rb
@@ -1,6 +1,4 @@
 class CollectionParticipant < ApplicationRecord
-  include ActiveModel::ForbiddenAttributesProtection
-
   belongs_to :pseud
   has_one :user, through: :pseud
   belongs_to :collection
@@ -56,5 +54,4 @@ class CollectionParticipant < ApplicationRecord
   def user_allowed_to_promote?(user, role)
     (role == MEMBER || role == NONE) ? self.collection.user_is_maintainer?(user) : self.collection.user_is_owner?(user)
   end
-
 end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,5 +1,4 @@
 class Comment < ApplicationRecord
-  include ActiveModel::ForbiddenAttributesProtection
   include HtmlCleaner
   include AfterCommitEverywhere
 
@@ -479,5 +478,4 @@ class Comment < ApplicationRecord
     sanitize_field self, :comment_content
   end
   include Responder
-
 end

--- a/app/models/external_author.rb
+++ b/app/models/external_author.rb
@@ -1,6 +1,4 @@
 class ExternalAuthor < ApplicationRecord
-  include ActiveModel::ForbiddenAttributesProtection
-
   # send :include, Activation # eventually we will let users create new identities
 
   EMAIL_LENGTH_MIN = 3

--- a/app/models/external_work.rb
+++ b/app/models/external_work.rb
@@ -1,6 +1,4 @@
 class ExternalWork < ApplicationRecord
-  include ActiveModel::ForbiddenAttributesProtection
-
   include UrlHelpers
   include Bookmarkable
   include Filterable

--- a/app/models/favorite_tag.rb
+++ b/app/models/favorite_tag.rb
@@ -1,6 +1,4 @@
 class FavoriteTag < ApplicationRecord
-  include ActiveModel::ForbiddenAttributesProtection
-
   belongs_to :user
   belongs_to :tag
 

--- a/app/models/feedback.rb
+++ b/app/models/feedback.rb
@@ -1,6 +1,5 @@
 # Class which holds feedback sent to the archive administrators about the archive as a whole
 class Feedback < ApplicationRecord
-  include ActiveModel::ForbiddenAttributesProtection
   attr_accessor :ip_address
 
   # note -- this has NOTHING to do with the Comment class!

--- a/app/models/invitation.rb
+++ b/app/models/invitation.rb
@@ -1,8 +1,6 @@
 # Beta invitations
 # http://railscasts.com/episodes/124-beta-invitations
 class Invitation < ApplicationRecord
-  include ActiveModel::ForbiddenAttributesProtection
-
   belongs_to :creator, polymorphic: true
   belongs_to :invitee, polymorphic: true
   belongs_to :external_author
@@ -89,5 +87,4 @@ class Invitation < ApplicationRecord
       self.creator.save!(validate: false)
     end
   end
-
 end

--- a/app/models/invite_request.rb
+++ b/app/models/invite_request.rb
@@ -1,6 +1,4 @@
 class InviteRequest < ApplicationRecord
-  include ActiveModel::ForbiddenAttributesProtection
-
   self.ignored_columns = [:position]
 
   validates :email, presence: true, email_veracity: true

--- a/app/models/known_issue.rb
+++ b/app/models/known_issue.rb
@@ -1,5 +1,4 @@
 class KnownIssue < ApplicationRecord
-  include ActiveModel::ForbiddenAttributesProtection
   # why is this included here? FIXME?
   include HtmlCleaner
 
@@ -18,5 +17,4 @@ class KnownIssue < ApplicationRecord
 
   validates_length_of :content, maximum: ArchiveConfig.CONTENT_MAX,
     too_long: ts("cannot be more than %{max} characters long.", max: ArchiveConfig.CONTENT_MAX)
-
 end

--- a/app/models/kudo.rb
+++ b/app/models/kudo.rb
@@ -1,5 +1,4 @@
 class Kudo < ApplicationRecord
-  include ActiveModel::ForbiddenAttributesProtection
   include Responder
 
   VALID_COMMENTABLE_TYPES = %w[Work].freeze

--- a/app/models/language.rb
+++ b/app/models/language.rb
@@ -1,6 +1,4 @@
 class Language < ApplicationRecord
-  include ActiveModel::ForbiddenAttributesProtection
-
   validates_presence_of :short
   validates_uniqueness_of :short, case_sensitive: false
   validates_presence_of :name
@@ -27,5 +25,4 @@ class Language < ApplicationRecord
   def fandom_count
     Fandom.joins(:works).where(works: {id: self.works.posted.collect(&:id)}).distinct.select('tags.id').count
   end
-
 end

--- a/app/models/locale.rb
+++ b/app/models/locale.rb
@@ -1,6 +1,4 @@
 class Locale < ApplicationRecord
-  include ActiveModel::ForbiddenAttributesProtection
-
   belongs_to :language
   validates_presence_of :iso
   validates_uniqueness_of :iso, case_sensitive: false

--- a/app/models/media.rb
+++ b/app/models/media.rb
@@ -1,6 +1,4 @@
 class Media < Tag
-  include ActiveModel::ForbiddenAttributesProtection
-
   NAME = ArchiveConfig.MEDIA_CATEGORY_NAME
 
   has_many :common_taggings, as: :filterable

--- a/app/models/preference.rb
+++ b/app/models/preference.rb
@@ -1,6 +1,4 @@
 class Preference < ApplicationRecord
-  include ActiveModel::ForbiddenAttributesProtection
-
   belongs_to :user
   belongs_to :skin
 

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -1,5 +1,4 @@
 class Profile < ApplicationRecord
-  include ActiveModel::ForbiddenAttributesProtection
   include Justifiable
 
   PROFILE_TITLE_MAX = 255
@@ -25,5 +24,4 @@ class Profile < ApplicationRecord
       throw :abort
     end
   end
-
 end

--- a/app/models/prompt.rb
+++ b/app/models/prompt.rb
@@ -1,6 +1,4 @@
 class Prompt < ApplicationRecord
-  include ActiveModel::ForbiddenAttributesProtection
-
   include UrlHelpers
   include TagTypeHelper
 

--- a/app/models/pseud.rb
+++ b/app/models/pseud.rb
@@ -1,5 +1,4 @@
 class Pseud < ApplicationRecord
-  include ActiveModel::ForbiddenAttributesProtection
   include Searchable
   include WorksOwner
 

--- a/app/models/related_work.rb
+++ b/app/models/related_work.rb
@@ -1,5 +1,4 @@
 class RelatedWork < ActiveRecord::Base
-  include ActiveModel::ForbiddenAttributesProtection
   belongs_to :work
   belongs_to :parent, polymorphic: true, autosave: true
 
@@ -57,5 +56,4 @@ class RelatedWork < ActiveRecord::Base
       end
     end
   end
-
 end

--- a/app/models/series.rb
+++ b/app/models/series.rb
@@ -1,5 +1,4 @@
 class Series < ApplicationRecord
-  include ActiveModel::ForbiddenAttributesProtection
   include Bookmarkable
   include Searchable
   include Creatable

--- a/app/models/skin.rb
+++ b/app/models/skin.rb
@@ -1,8 +1,6 @@
 require 'fileutils'
 
 class Skin < ApplicationRecord
-  include ActiveModel::ForbiddenAttributesProtection
-
   include HtmlCleaner
   include CssCleaner
   include SkinCacheHelper

--- a/app/models/skin_parent.rb
+++ b/app/models/skin_parent.rb
@@ -1,6 +1,4 @@
 class SkinParent < ApplicationRecord
-  include ActiveModel::ForbiddenAttributesProtection
-
   belongs_to :child_skin, class_name: "Skin", inverse_of: :skin_parents, touch: true
   belongs_to :parent_skin, class_name: "Skin", inverse_of: :skin_children
 
@@ -76,5 +74,4 @@ class SkinParent < ApplicationRecord
    def parent_skin_title=(title)
      self.parent_skin = Skin.find_by(title: title)
    end
-
 end

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -1,6 +1,4 @@
 class Subscription < ApplicationRecord
-  include ActiveModel::ForbiddenAttributesProtection
-
   VALID_SUBSCRIBABLES = %w(Work User Series).freeze
 
   belongs_to :user

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1,7 +1,6 @@
 require "unicode_utils/casefold"
 
 class Tag < ApplicationRecord
-  include ActiveModel::ForbiddenAttributesProtection
   include Searchable
   include StringCleaner
   include WorksOwner

--- a/app/models/tagset_models/owned_tag_set.rb
+++ b/app/models/tagset_models/owned_tag_set.rb
@@ -1,5 +1,4 @@
 class OwnedTagSet < ApplicationRecord
-  include ActiveModel::ForbiddenAttributesProtection
   # Rather than use STI or polymorphic associations, since really what we want to do here
   # is build an extra layer of functionality on top of the generic tag set structure,
   # I've gone with creating a separate model and making it contain a generic tag set

--- a/app/models/tagset_models/tag_nomination.rb
+++ b/app/models/tagset_models/tag_nomination.rb
@@ -1,6 +1,4 @@
 class TagNomination < ApplicationRecord
-  include ActiveModel::ForbiddenAttributesProtection
-
   belongs_to :tag_set_nomination, inverse_of: :tag_nominations
   has_one :owned_tag_set, through: :tag_set_nomination
 
@@ -181,5 +179,4 @@ class TagNomination < ApplicationRecord
   def times_nominated(tag_set)
     TagNomination.for_tag_set(tag_set).where(tagname: self.tagname).count
   end
-
 end

--- a/app/models/unsorted_tag.rb
+++ b/app/models/unsorted_tag.rb
@@ -1,6 +1,3 @@
 class UnsortedTag < Tag
-  include ActiveModel::ForbiddenAttributesProtection
-
   NAME = "Unsorted Tag"
-
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,5 @@
 class User < ApplicationRecord
   audited
-  include ActiveModel::ForbiddenAttributesProtection
   include WorksOwner
 
   devise :database_authenticatable,

--- a/app/models/user_invite_request.rb
+++ b/app/models/user_invite_request.rb
@@ -1,6 +1,4 @@
 class UserInviteRequest < ApplicationRecord
-  include ActiveModel::ForbiddenAttributesProtection
-
   MAX_USER_INVITE_REQUEST = ArchiveConfig.MAX_USER_INVITE_REQUEST
 
   belongs_to :user

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -6,7 +6,6 @@ class Work < ApplicationRecord
   include Searchable
   include BookmarkCountCaching
   include WorkChapterCountCaching
-  include ActiveModel::ForbiddenAttributesProtection
   include Creatable
 
   ########################################################################

--- a/app/models/work_skin.rb
+++ b/app/models/work_skin.rb
@@ -1,6 +1,4 @@
 class WorkSkin < Skin
-  include ActiveModel::ForbiddenAttributesProtection
-
   include SkinCacheHelper
 
   has_many :works

--- a/app/models/wrangling_guideline.rb
+++ b/app/models/wrangling_guideline.rb
@@ -1,5 +1,4 @@
 class WranglingGuideline < ApplicationRecord
-  include ActiveModel::ForbiddenAttributesProtection
   acts_as_list
 
   validates_presence_of :content, :title


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6414

## Purpose

I removed all lines like the following:
```
include ActiveModel::ForbiddenAttributesProtection
```
These were added when AO3 was still using Rails 3, to prepare for the transition to Rails 4. But Rails 4+ includes it automatically in `ActiveRecord::Base`, so the lines are no longer necessary.
 
I also called `rubocop -a --only "Layout/EmptyLinesAroundClassBody"` on all affected files, to clean up extra newlines.