### PR TITLE
AO3-6419 Clean up params for the PromptsController and ChallengeSignupsController.

### DIFF
--- a/app/controllers/challenge_signups_controller.rb
+++ b/app/controllers/challenge_signups_controller.rb
@@ -352,7 +352,6 @@ protected
   def nested_prompt_params
     [
       :id,
-      :collection_id,
       :title,
       :url,
       :any_fandom,

--- a/app/controllers/prompts_controller.rb
+++ b/app/controllers/prompts_controller.rb
@@ -124,8 +124,6 @@ class PromptsController < ApplicationController
   end
 
   def create
-    params[:prompt].merge!({challenge_signup_id: @challenge_signup.id})
-
     if params[:prompt_type] == "offer"
       @prompt = @challenge_signup.offers.build(prompt_params)
     else
@@ -178,12 +176,10 @@ class PromptsController < ApplicationController
 
   def prompt_params
     params.require(:prompt).permit(
-      :collection_id,
       :title,
       :url,
       :anonymous,
       :description,
-      :challenge_signup_id,
       :any_fandom,
       :any_character,
       :any_relationship,

--- a/app/models/prompt.rb
+++ b/app/models/prompt.rb
@@ -36,16 +36,15 @@ class Prompt < ApplicationRecord
 
   # VALIDATIONS
 
+  before_validation :inherit_from_signup, on: :create, if: :challenge_signup
+  def inherit_from_signup
+    self.pseud = challenge_signup.pseud
+    self.collection = challenge_signup.collection
+  end
+
   validates_presence_of :collection_id
 
   validates_presence_of :challenge_signup
-  before_save :set_pseud
-  def set_pseud
-    unless self.pseud
-      self.pseud = self.challenge_signup.pseud
-    end
-    true
-  end
 
   # based on the prompt restriction
   validates_presence_of :url, if: :url_required?

--- a/app/views/prompts/_prompt_form.html.erb
+++ b/app/views/prompts/_prompt_form.html.erb
@@ -27,10 +27,6 @@
     <legend><%= prompt_label %></legend>
     <h3 class="heading"><%= form.object.new_record? ? prompt_label : link_to(prompt_label, collection_prompt_path(@collection, form.object)) %></h3>  
 
-    <div>
-      <%= form.hidden_field :collection_id, :value => @collection.id %>
-    </div>
-  
     <dl>
       <% if restriction.title_allowed %>
         <dt<%= restriction.title_required ? ' class="required"'.html_safe : '' %>>

--- a/factories/challenges.rb
+++ b/factories/challenges.rb
@@ -1,48 +1,40 @@
 require 'faker'
 FactoryBot.define do
   factory :challenge_assignment do
+    collection { create(:collection, challenge: create(:gift_exchange)) }
+
     after(:build) do |assignment|
-      assignment.collection_id = create(:collection, challenge: create(:gift_exchange)).id unless assignment.collection_id
-      assignment.request_signup = create(:challenge_signup, collection_id: assignment.collection_id)
-      assignment.offer_signup = create(:challenge_signup, collection_id: assignment.collection_id)
+      assignment.request_signup = create(:challenge_signup, collection: assignment.collection)
+      assignment.offer_signup = create(:challenge_signup, collection: assignment.collection)
     end
   end
 
   factory :challenge_signup, aliases: [:gift_exchange_signup] do
-    assigned_as_request { false }
-    assigned_as_offer { false }
-    after(:build) do |signup|
-      signup.pseud_id = create(:pseud).id unless signup.pseud_id
-      signup.collection_id = create(:collection, challenge: create(:gift_exchange)).id unless signup.collection_id
-      signup.offers.build(pseud_id: signup.pseud_id, collection_id: signup.collection_id)
-      signup.requests.build(pseud_id: signup.pseud_id, collection_id: signup.collection_id)
-    end
+    pseud { create(:user).default_pseud }
+    collection { create(:collection, challenge: create(:gift_exchange)) }
+    requests_attributes { [attributes_for(:request)] }
+    offers_attributes { [attributes_for(:offer)] }
   end
 
   factory :prompt_meme_signup, class: ChallengeSignup do
-    assigned_as_request { false }
-    assigned_as_offer { false }
-    after(:build) do |signup|
-      signup.pseud_id = create(:pseud).id unless signup.pseud_id
-      signup.collection_id = create(:collection, challenge: create(:prompt_meme)).id unless signup.collection_id
-      signup.requests.build(pseud_id: signup.pseud_id, collection_id: signup.collection_id)
-    end
+    pseud { create(:user).default_pseud }
+    collection { create(:collection, challenge: create(:prompt_meme)) }
+    requests_attributes { [attributes_for(:request)] }
   end
 
   factory :potential_match do
+    collection { create(:collection, challenge: create(:gift_exchange)) }
+
     after(:build) do |potential_match|
-      potential_match.collection_id = create(:collection, challenge: create(:gift_exchange)).id unless potential_match.collection_id
-      potential_match.offer_signup_id = create(:challenge_signup, collection_id: potential_match.collection_id)
-      potential_match.request_signup_id = create(:challenge_signup, collection_id: potential_match.collection_id)
+      potential_match.offer_signup = create(:challenge_signup, collection: potential_match.collection)
+      potential_match.request_signup = create(:challenge_signup, collection: potential_match.collection)
     end
   end
 
   factory :gift_exchange do
-    after(:build) do |ge|
-      ge.offer_restriction_id = create(:prompt_restriction).id
-      ge.request_restriction_id = create(:prompt_restriction).id
-      ge.prompt_restriction_id = create(:prompt_restriction).id
-    end
+    association :offer_restriction, factory: :prompt_restriction
+    association :request_restriction, factory: :prompt_restriction
+    association :prompt_restriction, factory: :prompt_restriction
 
     trait :open do
       signups_open_at { Time.now - 1.day }
@@ -57,13 +49,8 @@ FactoryBot.define do
     end
   end
 
-  factory :offer
-  factory :request
-
   factory :prompt_meme do
-    after(:build) do |pm|
-      pm.request_restriction_id = create(:prompt_restriction).id
-      pm.prompt_restriction_id = create(:prompt_restriction).id
-    end
+    association :request_restriction, factory: :prompt_restriction
+    association :prompt_restriction, factory: :prompt_restriction
   end
 end

--- a/factories/prompt.rb
+++ b/factories/prompt.rb
@@ -3,5 +3,9 @@ require 'faker'
 
 FactoryBot.define do
   factory :prompt do
+    description { Faker::Lorem.sentence }
   end
+
+  factory :request, parent: :prompt, class: "Request"
+  factory :offer, parent: :prompt, class: "Offer"
 end

--- a/spec/controllers/challenge_signups_controller_spec.rb
+++ b/spec/controllers/challenge_signups_controller_spec.rb
@@ -196,10 +196,12 @@ describe ChallengeSignupsController do
 
     before do
       signup_offer = signup.offers.first
+      signup_offer.description = ""
       signup_offer.tag_set = create(:tag_set)
       signup_offer.save
 
       signup_request = signup.requests.first
+      signup_request.description = ""
       signup_request.tag_set = create(:tag_set)
       signup_request.save
     end
@@ -221,6 +223,7 @@ describe ChallengeSignupsController do
 
     before do
       prompt = signup.prompts.first
+      prompt.description = ""
       prompt.tag_set = create(:tag_set)
       prompt.save
     end

--- a/spec/controllers/prompts_controller_spec.rb
+++ b/spec/controllers/prompts_controller_spec.rb
@@ -127,7 +127,7 @@ describe PromptsController do
   describe "create" do
     let(:user) { Pseud.find(ChallengeSignup.in_collection(open_signup.collection).first.pseud_id).user }
     it "should have no errors and redirect to the edit page" do
-      post :create, params: { collection_id: open_signup.collection.name, prompt_type: "offer", prompt: { collection_id: nil } }
+      post :create, params: { collection_id: open_signup.collection.name, prompt_type: "offer", prompt: { description: "This is a description." } }
       it_redirects_to_simple("#{collection_signups_path(open_signup.collection)}/"\
                       "#{open_signup.collection.prompts.first.challenge_signup_id}/edit")
     end


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6419

## Purpose

- Removes some permitted params in the `PromptsController` and `ChallengeSignupsController` that probably shouldn't be there.
- Adds an extra callback to the prompt class to make sure that it sets its collection from the signup.
- Cleans up some of the challenge-related factories.
