### PR TITLE
AO3-6417 Make gifts page for nonexistent user 404

### DIFF
--- a/app/controllers/gifts_controller.rb
+++ b/app/controllers/gifts_controller.rb
@@ -3,7 +3,7 @@ class GiftsController < ApplicationController
   before_action :load_collection
 
   def index
-    @user = User.find_by(login: params[:user_id]) if params[:user_id]
+    @user = User.find_by!(login: params[:user_id]) if params[:user_id]
     @recipient_name = params[:recipient]
     @page_subtitle = ts("Gifts for %{name}", name: (@user ? @user.login : @recipient_name))
     unless @user || @recipient_name

--- a/features/other_a/gift.feature
+++ b/features/other_a/gift.feature
@@ -19,11 +19,6 @@ Feature: Create Gifts
       And I am logged in as "gifter" with password "something"
       And I set up the draft "GiftStory1"
 
-  Scenario: Gifts page without parameters should return error
-    When I go to the gifts page
-    Then I should be on the home page
-      And I should see "Whose gifts did you want to see?"
-
   Scenario: Gifts page for recipient should show recipient's gifts
     When I give the work to "giftee1"
       And I press "Post"

--- a/spec/controllers/gifts_controller_spec.rb
+++ b/spec/controllers/gifts_controller_spec.rb
@@ -29,6 +29,16 @@ describe GiftsController do
       end
     end
 
+    context "with user_id parameter" do
+      context "when user_id does not exist" do
+        it "raises an error" do
+          expect do
+            get :index, params: { user_id: "nobody" }
+          end.to raise_error ActiveRecord::RecordNotFound
+        end
+      end
+    end
+
     context "with recipient parameter" do
       context "when recipient does not have an account" do
         it "does not redirect or error" do

--- a/spec/controllers/gifts_controller_spec.rb
+++ b/spec/controllers/gifts_controller_spec.rb
@@ -28,5 +28,14 @@ describe GiftsController do
         it_redirects_to_with_error(root_path, "Whose gifts did you want to see?")
       end
     end
+
+    context "with recipient parameter" do
+      context "when recipient does not have an account" do
+        it "does not redirect or error" do
+          get :index, params: { recipient: "nobody" }
+          expect(response).to render_template(:index)
+        end
+      end
+    end
   end
 end

--- a/spec/controllers/gifts_controller_spec.rb
+++ b/spec/controllers/gifts_controller_spec.rb
@@ -20,4 +20,13 @@ describe GiftsController do
       it_redirects_to_with_error(user_path(controller.current_user), "Sorry, you don't have permission to access the page you were trying to reach.")
     end
   end
+
+  describe "index" do
+    context "without user_id or recipient parameter" do
+      it "redirects to the homepage with an error" do
+        get :index
+        it_redirects_to_with_error(root_path, "Whose gifts did you want to see?")
+      end
+    end
+  end
 end

--- a/spec/controllers/gifts_controller_spec.rb
+++ b/spec/controllers/gifts_controller_spec.rb
@@ -38,14 +38,5 @@ describe GiftsController do
         end
       end
     end
-
-    context "with recipient parameter" do
-      context "when recipient does not have an account" do
-        it "does not redirect or error" do
-          get :index, params: { recipient: "nobody" }
-          expect(response).to render_template(:index)
-        end
-      end
-    end
   end
 end


### PR DESCRIPTION
# Pull Request Checklist

* [X] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [X] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [X] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [X] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [X] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-6417

## Purpose

With this PR, accessing the gifts page for a nonexistent user gives an error 404 instead of redirecting to the homepage.

## Testing Instructions

See Jira issue.

## Credit

Bilka (he/him)