### PR TITLE
AO3-5860 commenting or leaving kudos with admin accounts

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -28,6 +28,7 @@ class CommentsController < ApplicationController
   before_action :check_permission_to_moderate, only: [:approve, :reject]
   before_action :check_permission_to_modify_frozen_status, only: [:freeze, :unfreeze]
   before_action :check_permission_to_modify_hidden_status, only: [:hide, :unhide]
+  before_action :admin_logout_required, only: [:create]
 
   include BlockHelper
 

--- a/app/controllers/kudos_controller.rb
+++ b/app/controllers/kudos_controller.rb
@@ -1,5 +1,6 @@
 class KudosController < ApplicationController
   skip_before_action :store_location
+  before_action :admin_logout_required, only: [:create]
 
   def index
     @work = Work.find(params[:work_id])

--- a/app/views/comments/_comment_form.html.erb
+++ b/app/views/comments/_comment_form.html.erb
@@ -94,7 +94,9 @@
               :maximum_length => ArchiveConfig.COMMENT_MAX,
               :tooLongMessage => ts("must be less than %{count} characters long.", :count => ArchiveConfig.COMMENT_MAX)) %>
       <p class="submit actions">
-        <%= f.submit button_name, :id => "comment_submit_for_#{commentable.id}", data: {disable_with: ts("Please wait...")} %>
+        <% if !logged_in_as_admin? %>
+          <%= f.submit button_name, :id => "comment_submit_for_#{commentable.id}", data: {disable_with: ts("Please wait...")} %>
+        <% end %>
         <% if controller.controller_name == 'inbox' %>
           <a name="comment_cancel" id="comment_cancel"><%= ts("Cancel") %></a>
         <% elsif comment.persisted? %>

--- a/app/views/comments/_comment_form.html.erb
+++ b/app/views/comments/_comment_form.html.erb
@@ -64,13 +64,6 @@
           <p class="footnote">(<%= allowed_html_instructions %>)</p>
         <% end %>
 
-      <% elsif logged_in_as_admin? %>
-        <h4 class="heading"><%= ts("Comment as") %> <span class="byline"><%= current_admin.login %></span>
-          <%= f.hidden_field :name, :value => "#{current_admin.login}", :id => "comment_name_for_#{commentable.id}" %>
-          <%= f.hidden_field :email, :value => "#{current_admin.email}", :id => "comment_email_for_#{commentable.id}" %>
-        </h4>
-        <p class="footnote">(<%= allowed_html_instructions %>)</p>
-
       <% else %>
         <dl>
           <dt class="landmark"><%= ts("Note") %>:</dt>

--- a/app/views/comments/_commentable.html.erb
+++ b/app/views/comments/_commentable.html.erb
@@ -28,7 +28,7 @@
       <li><%= link_to ts('Back to AO3 News Index'), admin_posts_path %></li>
     <% end %>
 
-    <% if @work && !is_author_of?(@work) %>
+    <% if @work && !is_author_of?(@work) && !logged_in_as_admin? %>
       <li>
         <%= form_for(:kudo, url: kudos_path, html: { method: 'post', id: 'new_kudo' }) do |kudo_form| %>
           <%= kudo_form.hidden_field :commentable_id, :value => @work.id %>

--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -99,7 +99,7 @@ en:
       page_title: "Hi, %{login}!"
       confidentiality_reminder: "You are now logged in as an admin. That means you will probably encounter information that is personal or confidential (e.g. usernames, email and IP addresses, creator names on anonymous works, etc). Please do not use this information in ways unrelated to your OTW role. If you have questions about what you can or cannot do with information you see here, contact your committee chair(s)."
       responsibility: "With great power comes great responsibility."
-      log_out_reminder: "Please remember to log out before resuming your normal site activity and leaving comments and kudos!"
+      log_out_reminder: "Please remember to log out before resuming your normal site activity!"
       roles:
         heading: "Your admin roles:"
         none: "You currently have no admin roles assigned to you."

--- a/features/comments_and_kudos/add_comment.feature
+++ b/features/comments_and_kudos/add_comment.feature
@@ -208,12 +208,10 @@ Scenario: Try to post a comment with a < angle bracket before a linebreak, with 
       And I press "Comment"
     Then I should see "Comment created!"
 
-Scenario: Asked to logged out first if trying to post a comment as an admin
+Scenario: Cannot comment (no button) while logged as admin
 
     Given the work "Generic Work"
       And I am logged in as an admin
       And I view the work "Generic Work"
-    When I fill in "Comment" with "Nice work!"
-      And I press "Comment"
-    Then I should see "Please log out of your admin account first!"
-      And I should not see "Comment created!"
+    Then I should see "Generic Work"
+      And I should not see a "Comment" button

--- a/features/comments_and_kudos/add_comment.feature
+++ b/features/comments_and_kudos/add_comment.feature
@@ -207,3 +207,13 @@ Scenario: Try to post a comment with a < angle bracket before a linebreak, with 
       """
       And I press "Comment"
     Then I should see "Comment created!"
+
+Scenario: Asked to logged out first if trying to post a comment as an admin
+
+    Given the work "Generic Work"
+      And I am logged in as an admin
+      And I view the work "Generic Work"
+    When I fill in "Comment" with "Nice work!"
+      And I press "Comment"
+    Then I should see "Please log out of your admin account first!"
+      And I should not see "Comment created!"

--- a/features/comments_and_kudos/kudos.feature
+++ b/features/comments_and_kudos/kudos.feature
@@ -167,3 +167,11 @@ Feature: Kudos
       And the email should contain "Meh Story"
       And the email should not contain "0 guests"
       And the email should not contain "translation missing"
+
+Scenario: Asked to log out first when trying to leave kudos as admin
+
+    Given I am logged in as an admin
+      And I view the work "Awesome Story"
+    When I press "Kudos ♥"
+    Then I should see "Please log out of your admin account first!"
+      And I should not see "left kudos on this work!"

--- a/features/comments_and_kudos/kudos.feature
+++ b/features/comments_and_kudos/kudos.feature
@@ -168,10 +168,9 @@ Feature: Kudos
       And the email should not contain "0 guests"
       And the email should not contain "translation missing"
 
-Scenario: Asked to log out first when trying to leave kudos as admin
+Scenario: Cannot leave kudos (no button) while logged as admin
 
     Given I am logged in as an admin
       And I view the work "Awesome Story"
-    When I press "Kudos ♥"
-    Then I should see "Please log out of your admin account first!"
-      And I should not see "left kudos on this work!"
+    Then I should see "Awesome Story"
+      And I should not see a "Kudos ♥" button

--- a/spec/controllers/comments_controller_spec.rb
+++ b/spec/controllers/comments_controller_spec.rb
@@ -247,16 +247,9 @@ describe CommentsController do
       context "when logged in as an admin" do
         before { fake_login_admin(create(:admin)) }
 
-        it "posts the comment and shows it in context" do
+        it "asks to log out first" do
           post :create, params: { tag_id: fandom.name, comment: anon_comment_attributes }
-          comment = Comment.last
-          expect(comment.commentable).to eq fandom
-          expect(comment.name).to eq anon_comment_attributes[:name]
-          expect(comment.email).to eq anon_comment_attributes[:email]
-          expect(comment.comment_content).to include anon_comment_attributes[:comment_content]
-          path = comments_path(tag_id: fandom.to_param,
-                               anchor: "comment_#{comment.id}")
-          expect(response).to redirect_to path
+          expect(flash[:notice]).to eq("Please log out of your admin account first!")
         end
       end
 

--- a/spec/controllers/kudos_controller_spec.rb
+++ b/spec/controllers/kudos_controller_spec.rb
@@ -182,5 +182,17 @@ describe KudosController do
         end
       end
     end
+
+    context "when kudos giver is admin" do
+      let(:work) { create(:work) }
+      let(:admin) { create(:admin) }
+
+      before { fake_login_admin(admin) }
+
+      it "asks to log out first" do
+        post :create, params: { kudo: { commentable_id: work.id, commentable_type: "Work" } }
+        expect(flash[:notice]).to eq("Please log out of your admin account first!")
+      end
+    end
   end
 end


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [x] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [x] Have you added the [Jira](https://otwarchive.atlassian.net) issue number as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [x] Do you have fewer than 5 pull requests already open? If not, please wait until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-5860

## Purpose

Enjoy admins to log out before leaving a comment or kudo.

More exactly:
Hide the relevant buttons as long as they're logged as admin
Return an error message in case such a request reaches the back regardless

## Testing Instructions

See JIRA issues (including comments).

## Credit

Ceithir (he/him)