### PR TITLE
AO3-6183 Make live validation errors screen readable

### DIFF
--- a/public/javascripts/livevalidation_standalone.js
+++ b/public/javascripts/livevalidation_standalone.js
@@ -365,6 +365,7 @@ LiveValidation.prototype = {
     	  var textNode = document.createTextNode(this.message);
       	span.appendChild(textNode);
         span.role = "alert";
+        span.id = `${this.element.id}_${this.messageClass}`;
         return span;
     },
     
@@ -392,9 +393,13 @@ LiveValidation.prototype = {
         this.removeFieldClass();
         if(!this.validationFailed){
             if(this.displayMessageWhenEmpty || this.element.value != ''){
+                this.element.setAttribute("aria-invalid", false);
+                this.element.removeAttribute("aria-describedby");
                 if(this.element.className.indexOf(this.validFieldClass) == -1) this.element.className += ' ' + this.validFieldClass;
             }
-        }else{
+        } else {
+            this.element.setAttribute("aria-invalid", true);
+            this.element.setAttribute("aria-describedby", `${this.element.id}_${this.messageClass}`);
             if(this.element.className.indexOf(this.invalidFieldClass) == -1) this.element.className += ' ' + this.invalidFieldClass;
         }
     },

--- a/public/javascripts/livevalidation_standalone.js
+++ b/public/javascripts/livevalidation_standalone.js
@@ -365,7 +365,7 @@ LiveValidation.prototype = {
     	var textNode = document.createTextNode(this.message);
       	span.appendChild(textNode);
         span.role = "alert";
-        span.id = `${this.element.id}_${this.messageClass}`;
+        span.id = this.element.id + "_" + this.messageClass;
         return span;
     },
     
@@ -399,7 +399,7 @@ LiveValidation.prototype = {
             }
         } else {
             this.element.setAttribute("aria-invalid", true);
-            this.element.setAttribute("aria-describedby", `${this.element.id}_${this.messageClass}`);
+            this.element.setAttribute("aria-describedby", this.element.id + "_" + this.messageClass);
             if(this.element.className.indexOf(this.invalidFieldClass) == -1) this.element.className += ' ' + this.invalidFieldClass;
         }
     },

--- a/public/javascripts/livevalidation_standalone.js
+++ b/public/javascripts/livevalidation_standalone.js
@@ -380,9 +380,9 @@ LiveValidation.prototype = {
         elementToInsert.className += ' ' + this.messageClass + ' ' + className;
         if(this.insertAfterWhatNode.nextSibling){
             this.insertAfterWhatNode.parentNode.insertBefore(elementToInsert, this.insertAfterWhatNode.nextSibling);
-    		} else {
+        } else {
             this.insertAfterWhatNode.parentNode.appendChild(elementToInsert);
-    	  }
+        }
     },
     
     

--- a/public/javascripts/livevalidation_standalone.js
+++ b/public/javascripts/livevalidation_standalone.js
@@ -362,7 +362,7 @@ LiveValidation.prototype = {
      */
     createMessageSpan: function(){
         var span = document.createElement('span');
-    	  var textNode = document.createTextNode(this.message);
+    	var textNode = document.createTextNode(this.message);
       	span.appendChild(textNode);
         span.role = "alert";
         span.id = `${this.element.id}_${this.messageClass}`;

--- a/public/javascripts/livevalidation_standalone.js
+++ b/public/javascripts/livevalidation_standalone.js
@@ -119,6 +119,7 @@ LiveValidation.prototype = {
       	    this.element.onblur = function(e){ self.doOnBlur(e); return self.oldOnBlur.call(this, e); }
         }
       }
+      this.validate();
     },
 	
 	/**
@@ -210,7 +211,6 @@ LiveValidation.prototype = {
      */
     doOnFocus: function(e){
       this.focused = true;
-      this.removeMessageAndFieldClass();
     },
     
     /**
@@ -362,8 +362,9 @@ LiveValidation.prototype = {
      */
     createMessageSpan: function(){
         var span = document.createElement('span');
-    	var textNode = document.createTextNode(this.message);
+    	  var textNode = document.createTextNode(this.message);
       	span.appendChild(textNode);
+        span.role = "alert";
         return span;
     },
     
@@ -374,16 +375,13 @@ LiveValidation.prototype = {
      */
     insertMessage: function(elementToInsert){
       	this.removeMessage();
-      	if( (this.displayMessageWhenEmpty && (this.elementType == LiveValidation.CHECKBOX || this.element.value == ''))
-    	  || this.element.value != '' ){
-            var className = this.validationFailed ? this.invalidClass : this.validClass;
-    	  	elementToInsert.className += ' ' + this.messageClass + ' ' + className;
-            if(this.insertAfterWhatNode.nextSibling){
-    		  		this.insertAfterWhatNode.parentNode.insertBefore(elementToInsert, this.insertAfterWhatNode.nextSibling);
-    		}else{
-    			    this.insertAfterWhatNode.parentNode.appendChild(elementToInsert);
-    	    }
-    	}
+        var className = this.validationFailed ? this.invalidClass : this.validClass;
+        elementToInsert.className += ' ' + this.messageClass + ' ' + className;
+        if(this.insertAfterWhatNode.nextSibling){
+            this.insertAfterWhatNode.parentNode.insertBefore(elementToInsert, this.insertAfterWhatNode.nextSibling);
+    		} else {
+            this.insertAfterWhatNode.parentNode.appendChild(elementToInsert);
+    	  }
     },
     
     


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6183

- Ensure span that holds the error message is included in the DOM on load and has role="alert" set. 

- Do not remove error message when invalid field is in focus. 

- Use aria-invalid and aria-describedby to associate the invalid field with the error span. 

## Testing Instructions

See Jira issue. I've added an additional testing instruction in a comment.

## References

Related open issue: https://otwarchive.atlassian.net/browse/AO3-3585

## Credit
weeklies (she/her)