### PR TITLE
AO3-6410 Re-enable dependabot for Github Actions workflow updates.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "Awaiting Review"
+      - "Scope: Tests Only"

--- a/.github/workflows/automated-tests.yml
+++ b/.github/workflows/automated-tests.yml
@@ -110,7 +110,7 @@ jobs:
 
       - name: Cache wkhtmltopdf package
         if: ${{ matrix.tests.ebook }}
-        uses: actions/cache@v3.0.11
+        uses: actions/cache@v3
         with:
           path: wkhtmltopdf
           key: wkhtmltopdf-${{ hashFiles('script/gh-actions/ebook_converters.sh') }}
@@ -121,11 +121,11 @@ jobs:
 
       - name: Cache VCR cassettes
         if: ${{ matrix.tests.vcr }}
-        uses: actions/cache@v3.0.11
+        uses: actions/cache@v3
         with:
           path: features/cassette_library
 
-          # Unfortunately, the actions/cache@v3.0.11 version doesn't allow the cache
+          # Unfortunately, the actions/cache@v3 version doesn't allow the cache
           # key to be overwritten if there's an exact match. So instead we add
           # a unique identifier to the key to always force a "cache miss", and
           # restore from related keys to make sure that we still get to load a


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6410

## Purpose

- Restores the `.github/dependabot.yml` file originally created in https://github.com/otwcode/otwarchive/pull/4359 and then removed again in https://github.com/otwcode/otwarchive/pull/4368. We had to remove it because it was submitting PRs to all forks with no way to disable it, but [that behavior has since been fixed](https://github.blog/changelog/2022-11-07-dependabot-pull-requests-off-by-default-for-forks/).
- Changes the `actions/cache` version number to be `v3` instead of `v3.0.11`. In Github Actions, the convention is to have the major version numbers like `v3` be updated every time a minor `v3.x.y` version is released. This means that by setting your version number to a major version, you automatically get rolling updates, and don't have to spend as much time updating things. We originally were using major version updates for everything, but when we temporarily enabled dependabot back in October, the dependabot pull request https://github.com/otwcode/otwarchive/pull/4364 changed the version number from major to minor. [This was a bug, and has since been fixed](https://github.com/dependabot/dependabot-core/pull/5891), but I wanted to make sure we weren't permanently stuck on minor versions.

## Testing Instructions

I'm not sure whether the workflows actually need updates at this point, so this might be difficult to test. Is it enough that we know it worked the first time around? Or should I deliberately lower the version number of one of the actions to test it?