### PR TITLE
AO3-6408 Show different text for tag cloud on collections

### DIFF
--- a/app/views/tags/index.html.erb
+++ b/app/views/tags/index.html.erb
@@ -27,13 +27,13 @@
 <% if @tags %>
   <% if params[:show] == "random" %>
     <% if @collection %>
-      <p><%= t(".about.random_in_collection", search_tags_link: (link_to t(".search_tags"), search_tags_path)).html_safe %></p>
+      <p><%= t(".about.random_in_collection") %></p>
     <% else %>
       <p><%= t(".about.random", search_tags_link: (link_to t(".search_tags"), search_tags_path)).html_safe %></p>
     <% end %>
   <% else %>
     <% if @collection %>
-      <p><%= t(".about.popular_in_collection", search_tags_link: (link_to t(".search_tags"), search_tags_path)).html_safe %></p>
+      <p><%= t(".about.popular_in_collection") %></p>
     <% else %>
       <p><%= t(".about.popular", search_tags_link: (link_to t(".search_tags"), search_tags_path)).html_safe %></p>
     <% end %>

--- a/app/views/tags/index.html.erb
+++ b/app/views/tags/index.html.erb
@@ -26,9 +26,17 @@
 
 <% if @tags %>
   <% if params[:show] == "random" %>
-    <p><%= t(".about.random", search_tags_link: (link_to t(".search_tags"), search_tags_path)).html_safe %></p>
+    <% if @collection %>
+      <p><%= t(".about.random_in_collection", search_tags_link: (link_to t(".search_tags"), search_tags_path)).html_safe %></p>
+    <% else %>
+      <p><%= t(".about.random", search_tags_link: (link_to t(".search_tags"), search_tags_path)).html_safe %></p>
+    <% end %>
   <% else %>
-    <p><%= t(".about.popular", search_tags_link: (link_to t(".search_tags"), search_tags_path)).html_safe %></p>
+    <% if @collection %>
+      <p><%= t(".about.popular_in_collection", search_tags_link: (link_to t(".search_tags"), search_tags_path)).html_safe %></p>
+    <% else %>
+      <p><%= t(".about.popular", search_tags_link: (link_to t(".search_tags"), search_tags_path)).html_safe %></p>
+    <% end %>
   <% end %>
   <ul class="tags cloud index group">
     <!--FRONT END REVIEW: these classes are irregular-->

--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -349,6 +349,8 @@ en:
       about:
         popular: These are some of the most popular tags used on the Archive. To find more tags, %{search_tags_link}.
         random: These are some random tags used on the Archive. To find more tags, %{search_tags_link}.
+        popular_in_collection: These are some of the most popular tags used in the collection.
+        random_in_collection: These are some random tags used in the collection.
       search_tags: try our tag search
   blocked:
     block: "Block"


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [x] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)? - not sure I added any functionality to test
* [x] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [x] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-6408

## Purpose

This PR attempts to fix the issue as described, changing `These are some of the most popular tags used on the Archive.` to `These are some of the most popular tags used in the collection.` on collection tag pages.

## Testing Instructions

I don't have a Jira account with access, but I do have a Jira account on your Jira! You should be able to check localhost:3000/tags and see it has the original text, and go to localhost:3000/collections/TheFirstCollection/tags and see the new text.

## References

No other references as far as I am aware of.

## Credit

Camila Noceda (she/her)

## Other Notes

Hello, hopefully I have formatted this right, please suggest any changes and I can make them. This is my first time working with a Ruby project or contributing to an OSS project.

I followed the existing code, using the `ts` function. I did notice the guide mentions using the `t` function for localised text, but the scope of the ticket does not mention converting this system over, so I was hesitant to do this as I probably don't know why this uses `ts` and not `t`.