### PR TITLE
AO3-6278 Fix pipe char being counted as word word_counter.rb

### DIFF
--- a/lib/word_counter.rb
+++ b/lib/word_counter.rb
@@ -23,7 +23,7 @@ class WordCounter
     # are counted based on the number of characters. If a text include mixed
     # languages, only characters in these languages would be counted as words,
     # words in other languages are counted as usual
-    character_count_scripts = ArchiveConfig.CHARACTER_COUNT_SCRIPTS.map { |lang| "\\p{#{lang}}" }.join("|")
+    character_count_scripts = ArchiveConfig.CHARACTER_COUNT_SCRIPTS.map { |lang| "\\p{#{lang}}" }.join("")
     body = Nokogiri::HTML(@text).xpath('//body').first
     body.traverse do |node|
       if node.is_a? Nokogiri::XML::Text


### PR DESCRIPTION
# Pull Request Checklist

* [✅ ] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [✅ ] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [❌ ] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [✅ ] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [✅ ] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-6278

## Purpose

The pipe char is currently being miscounted as a word in chapters, this fixes that issue by no longer joining the character based languages by pipe char or any other char as it is not needed considering the regex. 

## Testing Instructions

Follow the test outlined in the jira issue. Though do note that I believe setting the text of the work to "foo bar |" should result in a word count of 2, not 3 as described in the jira issue. That should be a typo.

Should also test character based languages by setting the text of a work to "大大大大大大大大大大" and verify the word count results in 10.

## References


## Credit

GoodGithubAccount