### PR TITLE
AO3-6317 Allow support admins to delete works and edit FNOK

### DIFF
--- a/app/controllers/admin/admin_users_controller.rb
+++ b/app/controllers/admin/admin_users_controller.rb
@@ -80,7 +80,8 @@ class Admin::AdminUsersController < Admin::BaseController
       return
     end
 
-    fnok = @user.build_fannish_next_of_kin(kin: kin, kin_email: kin_email)
+    fnok = @user.build_fannish_next_of_kin if fnok.blank?
+    fnok.assign_attributes(kin: kin, kin_email: kin_email)
     if fnok.save
       flash[:notice] = ts("Fannish next of kin was updated.")
       redirect_to admin_user_path(@user)

--- a/app/controllers/admin/admin_users_controller.rb
+++ b/app/controllers/admin/admin_users_controller.rb
@@ -43,7 +43,6 @@ class Admin::AdminUsersController < Admin::BaseController
   end
 
   # GET admin/users/1
-  # GET admin/users/1.xml
   def show
     @user = authorize User.find_by!(login: params[:id])
     @hide_dashboard = true

--- a/app/controllers/admin/admin_users_controller.rb
+++ b/app/controllers/admin/admin_users_controller.rb
@@ -45,9 +45,8 @@ class Admin::AdminUsersController < Admin::BaseController
   # GET admin/users/1
   # GET admin/users/1.xml
   def show
+    @user = authorize User.find_by!(login: params[:id])
     @hide_dashboard = true
-    @user = User.find_by!(login: params[:id])
-    authorize @user
     @log_items = @user.log_items.sort_by(&:created_at).reverse
   end
 
@@ -67,20 +66,47 @@ class Admin::AdminUsersController < Admin::BaseController
     redirect_to request.referer || root_path
   end
 
+  def update_next_of_kin
+    @user = authorize User.find_by!(login: params[:user_login])
+    fnok = @user.fannish_next_of_kin
+    kin = User.find_by(login: params[:next_of_kin_name])
+    kin_email = params[:next_of_kin_email]
+
+    if kin.blank? && kin_email.blank?
+      if fnok.present?
+        fnok.destroy
+        flash[:notice] = ts("Fannish next of kin was removed.")
+      end
+      redirect_to admin_user_path(@user)
+      return
+    end
+
+    fnok = @user.build_fannish_next_of_kin(kin: kin, kin_email: kin_email)
+    if fnok.save
+      flash[:notice] = ts("Fannish next of kin was updated.")
+      redirect_to admin_user_path(@user)
+    else
+      @hide_dashboard = true
+      @log_items = @user.log_items.sort_by(&:created_at).reverse
+      render :show
+    end
+  end
+
   def update_status
-    @user = User.find_by(login: params[:user_login])
-    authorize @user
-    @user_manager = UserManager.new(current_admin, params)
+    @user = User.find_by!(login: params[:user_login])
+
+    # Authorize on the manager, as we need to check which specific actions the admin can do.
+    @user_manager = authorize UserManager.new(current_admin, @user, params)
     if @user_manager.save
       flash[:notice] = @user_manager.success_message
-      if params[:admin_action] == "spamban"
+      if @user_manager.admin_action == "spamban"
         redirect_to confirm_delete_user_creations_admin_user_path(@user)
       else
-        redirect_to request.referer || root_path
+        redirect_to admin_user_path(@user)
       end
     else
       flash[:error] = @user_manager.error_message
-      redirect_to request.referer || root_path
+      redirect_to admin_user_path(@user)
     end
   end
 

--- a/app/controllers/admin/user_creations_controller.rb
+++ b/app/controllers/admin/user_creations_controller.rb
@@ -17,7 +17,7 @@ class Admin::UserCreationsController < Admin::BaseController
   
   # Removes an object from public view
   def hide
-    authorize @creation, policy_class: UserCreationPolicy
+    authorize @creation
     @creation.hidden_by_admin = (params[:hidden] == "true")
     @creation.save(validate: false)
     action = @creation.hidden_by_admin? ? "hide" : "unhide"
@@ -33,7 +33,7 @@ class Admin::UserCreationsController < Admin::BaseController
   end  
   
   def set_spam
-    authorize @creation, policy_class: UserCreationPolicy
+    authorize @creation
     action = "mark as " + (params[:spam] == "true" ? "spam" : "not spam")
     AdminActivity.log_action(current_admin, @creation, action: action, summary: @creation.inspect)    
     if params[:spam] == "true"
@@ -49,7 +49,7 @@ class Admin::UserCreationsController < Admin::BaseController
   end
 
   def destroy
-    authorize @creation, policy_class: UserCreationPolicy
+    authorize @creation
     AdminActivity.log_action(current_admin, @creation, action: "destroy", summary: @creation.inspect)
     @creation.destroy
     flash[:notice] = ts("Item was successfully deleted.")

--- a/app/controllers/admin/user_creations_controller.rb
+++ b/app/controllers/admin/user_creations_controller.rb
@@ -53,12 +53,10 @@ class Admin::UserCreationsController < Admin::BaseController
     AdminActivity.log_action(current_admin, @creation, action: "destroy", summary: @creation.inspect)
     @creation.destroy
     flash[:notice] = ts("Item was successfully deleted.")
-    if @creation_class == Comment 
-      redirect_to(@creation.ultimate_parent) 
-    elsif @creation_class == ExternalWork
+    if @creation_class == Bookmark || @creation_class == ExternalWork
       redirect_to bookmarks_path
     else
-     redirect_to works_path
+      redirect_to works_path
     end
   end
 end

--- a/app/controllers/admin/user_creations_controller.rb
+++ b/app/controllers/admin/user_creations_controller.rb
@@ -11,7 +11,7 @@ class Admin::UserCreationsController < Admin::BaseController
   def can_be_marked_as_spam
     unless @creation_class && @creation_class == Work
       flash[:error] = ts("You can only mark works as spam currently.")
-      redirect_to @creation and return
+      redirect_to polymorphic_path(@creation) and return
     end
   end
   
@@ -28,7 +28,7 @@ class Admin::UserCreationsController < Admin::BaseController
     if @creation_class == ExternalWork || @creation_class == Bookmark
       redirect_to(request.env["HTTP_REFERER"] || root_path)
     else
-      redirect_to(@creation)
+      redirect_to polymorphic_path(@creation)
     end
   end  
   
@@ -45,7 +45,7 @@ class Admin::UserCreationsController < Admin::BaseController
       @creation.update_attribute(:hidden_by_admin, false)
       flash[:notice] = ts("Work was marked not spam and unhidden.")
     end
-    redirect_to(@creation)
+    redirect_to polymorphic_path(@creation)
   end
 
   def destroy

--- a/app/controllers/external_works_controller.rb
+++ b/app/controllers/external_works_controller.rb
@@ -1,5 +1,5 @@
 class ExternalWorksController < ApplicationController
-  before_action :admin_only, only: [:edit, :update, :compare, :merge]
+  before_action :admin_only, only: [:edit, :update]
   before_action :users_only, only: [:new]
   before_action :check_user_status, only: [:new]
 
@@ -37,13 +37,12 @@ class ExternalWorksController < ApplicationController
   end
 
   def edit
-    authorize @external_work, policy_class: UserCreationPolicy
-    @external_work = ExternalWork.find(params[:id])
+    @external_work = authorize ExternalWork.find(params[:id])
     @work = @external_work
   end
 
   def update
-    @external_work = ExternalWork.find(params[:id])
+    @external_work = authorize ExternalWork.find(params[:id])
     @external_work.attributes = work_params
     if @external_work.update(external_work_params)
       flash[:notice] = t('successfully_updated', default: 'External work was successfully updated.')

--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -356,6 +356,7 @@ class WorksController < ApplicationController
 
   # GET /works/1/edit_tags
   def edit_tags
+    authorize @work if logged_in_as_admin?
     @page_subtitle = ts("Edit Work Tags")
   end
 
@@ -406,6 +407,7 @@ class WorksController < ApplicationController
   end
 
   def update_tags
+    authorize @work if logged_in_as_admin?
     if params[:cancel_button]
       return cancel_posting_and_redirect
     end

--- a/app/helpers/admin_helper.rb
+++ b/app/helpers/admin_helper.rb
@@ -7,40 +7,40 @@ module AdminHelper
 
   # Show the admin menu with the options for hiding, editing, deleting, or
   # marking user creations as spam.
-  def can_access_admin_options?
+  def can_access_admin_options?(creation)
     return unless logged_in_as_admin?
 
-    admin_can_destroy_creations? ||
-      admin_can_edit_creations? ||
-      admin_can_hide_creations? ||
-      admin_can_mark_creations_spam?
+    admin_can_destroy_creations?(creation) ||
+      admin_can_edit_creations?(creation) ||
+      admin_can_hide_creations?(creation) ||
+      admin_can_mark_creations_spam?(creation)
   end
 
-  def admin_can_destroy_creations?
+  def admin_can_destroy_creations?(creation)
     return unless logged_in_as_admin?
 
-    UserCreationPolicy.can_destroy_creations?(current_admin)
+    UserCreationPolicy.new(current_admin, creation).can_destroy_creations?
   end
 
   # Currently applies to editing ExternalWorks and the tags or language of
   # Works.
-  def admin_can_edit_creations?
+  def admin_can_edit_creations?(creation)
     return unless logged_in_as_admin?
 
-    UserCreationPolicy.can_edit_creations?(current_admin)
+    UserCreationPolicy.new(current_admin, creation).can_edit_creations?
   end
 
-  def admin_can_hide_creations?
+  def admin_can_hide_creations?(creation)
     return unless logged_in_as_admin?
 
-    UserCreationPolicy.can_hide_creations?(current_admin)
+    UserCreationPolicy.new(current_admin, creation).can_hide_creations?
   end
 
   # Currently applies to Works.
-  def admin_can_mark_creations_spam?
+  def admin_can_mark_creations_spam?(creation)
     return unless logged_in_as_admin?
 
-    UserCreationPolicy.can_mark_creations_spam?(current_admin)
+    UserCreationPolicy.new(current_admin, creation).can_mark_creations_spam?
   end
 
   def admin_setting_disabled?(field)

--- a/app/helpers/admin_helper.rb
+++ b/app/helpers/admin_helper.rb
@@ -5,44 +5,6 @@ module AdminHelper
     activity.admin.nil? ? ts("Admin deleted") : activity.admin_login
   end
 
-  # Show the admin menu with the options for hiding, editing, deleting, or
-  # marking user creations as spam.
-  def can_access_admin_options?(creation)
-    return unless logged_in_as_admin?
-
-    admin_can_destroy_creations?(creation) ||
-      admin_can_edit_creations?(creation) ||
-      admin_can_hide_creations?(creation) ||
-      admin_can_mark_creations_spam?(creation)
-  end
-
-  def admin_can_destroy_creations?(creation)
-    return unless logged_in_as_admin?
-
-    UserCreationPolicy.new(current_admin, creation).can_destroy_creations?
-  end
-
-  # Currently applies to editing ExternalWorks and the tags or language of
-  # Works.
-  def admin_can_edit_creations?(creation)
-    return unless logged_in_as_admin?
-
-    UserCreationPolicy.new(current_admin, creation).can_edit_creations?
-  end
-
-  def admin_can_hide_creations?(creation)
-    return unless logged_in_as_admin?
-
-    UserCreationPolicy.new(current_admin, creation).can_hide_creations?
-  end
-
-  # Currently applies to Works.
-  def admin_can_mark_creations_spam?(creation)
-    return unless logged_in_as_admin?
-
-    UserCreationPolicy.new(current_admin, creation).can_mark_creations_spam?
-  end
-
   def admin_setting_disabled?(field)
     return unless logged_in_as_admin?
 

--- a/app/models/fannish_next_of_kin.rb
+++ b/app/models/fannish_next_of_kin.rb
@@ -1,34 +1,10 @@
 class FannishNextOfKin < ApplicationRecord
   belongs_to :user
+  belongs_to :kin, class_name: "User"
 
-  validates :user_id, presence: true
-  validates :kin_id, presence: true
-  validates :kin_email, presence: true
+  validates :user, :kin, :kin_email, presence: true
 
   def kin_name
-    User.find_by(id: kin_id).try(:login)
-  end
-
-  def self.update_for_user(user, kin_name, kin_email)
-    kin_user = User.find_by(login: kin_name)
-    current_fnok = user.fannish_next_of_kin
-    # first scenario: user has no existing FNOK
-    if current_fnok.nil?
-      return unless kin_user.present? && kin_email.present?
-      create(
-        user_id: user.id,
-        kin_id: kin_user.id,
-        kin_email: kin_email
-      )
-    # second scenario: update user's FNOK
-    elsif kin_user.present? && kin_email.present?
-      current_fnok.update(
-        kin_id: kin_user.id,
-        kin_email: kin_email
-      )
-    # third scenario: delete user's FNOK
-    elsif kin_name.blank? && kin_email.blank?
-      current_fnok.destroy
-    end
+    kin.try(:login)
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -36,7 +36,7 @@ class User < ApplicationRecord
   has_many :external_authors, dependent: :destroy
   has_many :external_creatorships, foreign_key: "archivist_id"
 
-  has_many :fannish_next_of_kins, foreign_key: "kin_id", dependent: :destroy
+  has_many :fannish_next_of_kins, dependent: :delete_all, inverse_of: :kin, foreign_key: :kin_id
   has_one :fannish_next_of_kin, dependent: :destroy
 
   has_many :favorite_tags, dependent: :destroy

--- a/app/models/user_manager.rb
+++ b/app/models/user_manager.rb
@@ -1,5 +1,4 @@
-# Allows admins to manage user status and next of kin
-# via the admin users interface
+# Allows admins to manage user status via the admin users interface
 class UserManager
   attr_reader :admin,
               :user,

--- a/app/models/user_manager.rb
+++ b/app/models/user_manager.rb
@@ -3,8 +3,6 @@
 class UserManager
   attr_reader :admin,
               :user,
-              :kin_name,
-              :kin_email,
               :admin_note,
               :admin_action,
               :suspension_length,
@@ -13,14 +11,12 @@ class UserManager
 
   PERMITTED_ACTIONS = %w[note warn suspend unsuspend ban unban spamban].freeze
 
-  def initialize(admin, params)
+  def initialize(admin, user, params)
     @admin = admin
-    @user  = User.find_by(login: params[:user_login])
-    @kin_name           = params[:next_of_kin_name]
-    @kin_email          = params[:next_of_kin_email]
-    @admin_note         = params[:admin_note]
-    @admin_action       = params[:admin_action]
-    @suspension_length  = params[:suspend_days]
+    @user = user
+    @admin_note = params[:admin_note]
+    @admin_action = params[:admin_action]
+    @suspension_length = params[:suspend_days]
     @errors = []
     @successes = []
   end
@@ -29,8 +25,6 @@ class UserManager
     validate_user_and_admin &&
       validate_admin_note &&
       validate_suspension &&
-      validate_next_of_kin &&
-      save_next_of_kin &&
       save_admin_action
   end
 
@@ -73,51 +67,10 @@ class UserManager
     end
   end
 
-  # Basically, we either want valid data for both name and email
-  # or we want them both to be blank, which means do nothing
-  # or delete anything that already exists
-  def validate_next_of_kin
-    error = nil
-    if kin_name.present?
-      if kin_email.blank?
-        error = "Fannish next of kin email is missing."
-      elsif !User.where(login: kin_name).exists?
-        error = "Fannish next of kin user is invalid."
-      end
-    elsif kin_email.present?
-      error = "Fannish next of kin user is missing."
-    end
-    if error
-      errors << error
-      false
-    else
-      true
-    end
-  end
-
-  def save_next_of_kin
-    return true if user.fannish_next_of_kin.nil? && kin_name.blank? && kin_email.blank?
-
-    same_kin_user = User.find_by(login: kin_name)&.id == user.fannish_next_of_kin&.kin_id
-    same_kin_email = user.fannish_next_of_kin&.kin_email == kin_email
-    return true if same_kin_user && same_kin_email
-
-    if FannishNextOfKin.update_for_user(user, kin_name, kin_email)
-      successes << "Fannish next of kin was updated."
-    else
-      errors << "Fannish next of kin failed to update."
-      false
-    end
-  end
-
   def save_admin_action
     return true if admin_action.blank?
 
-    if admin_action == 'spamban'
-      ban_user
-    elsif PERMITTED_ACTIONS.include?(admin_action)
-      send("#{admin_action}_user")
-    end
+    send("#{admin_action}_user") if PERMITTED_ACTIONS.include?(admin_action)
   end
 
   def note_user
@@ -152,6 +105,7 @@ class UserManager
     log_action(ArchiveConfig.ACTION_BAN)
     successes << "User has been permanently suspended."
   end
+  alias spamban_user ban_user
 
   def unban_user
     user.banned = false

--- a/app/policies/bookmark_policy.rb
+++ b/app/policies/bookmark_policy.rb
@@ -1,0 +1,2 @@
+class BookmarkPolicy < UserCreationPolicy
+end

--- a/app/policies/external_work_policy.rb
+++ b/app/policies/external_work_policy.rb
@@ -1,0 +1,5 @@
+class ExternalWorkPolicy < UserCreationPolicy
+  def update?
+    user_has_roles?(%w[superadmin policy_and_abuse])
+  end
+end

--- a/app/policies/series_policy.rb
+++ b/app/policies/series_policy.rb
@@ -1,0 +1,2 @@
+class SeriesPolicy < UserCreationPolicy
+end

--- a/app/policies/user_creation_policy.rb
+++ b/app/policies/user_creation_policy.rb
@@ -1,35 +1,32 @@
 class UserCreationPolicy < ApplicationPolicy
-  # Defines the roles that allow admins to modify user creations.
   # User creations are Bookmarks, ExternalWorks, Series, Works.
+
+  # Roles that allow destroying user creations.
   DESTROY_ROLES = %w[superadmin policy_and_abuse].freeze
-  # Support admins need edit permissions due to AO3-4932.
-  EDIT_ROLES = %w[superadmin support policy_and_abuse].freeze
+
+  # Roles that allow destroying only Works.
+  #
+  # Include support admins for handling FNOK requests.
+  DESTROY_WORK_ROLES = %w[superadmin policy_and_abuse support].freeze
+
+  # Roles that allow editing user creations, specifically:
+  # - ExternalWorks
+  # - Works (only tags and language)
+  #
+  # Admins cannot edit Bookmarks or Series or make any other changes to Works.
+  #
+  # Include support admins due to AO3-4932.
+  EDIT_ROLES = %w[superadmin policy_and_abuse support].freeze
+
   HIDE_ROLES = %w[superadmin policy_and_abuse].freeze
+
+  # Currently applies to Works.
   SPAM_ROLES = %w[superadmin policy_and_abuse].freeze
 
-  def self.can_destroy_creations?(user)
-    self.new(user, nil).can_destroy_creations?
-  end
-
-  def self.can_edit_creations?(user)
-    self.new(user, nil).can_edit_creations?
-  end
-
-  def self.can_hide_creations?(user)
-    self.new(user, nil).can_hide_creations?
-  end
-
-  def self.can_mark_creations_spam?(user)
-    self.new(user, nil).can_mark_creations_spam?
-  end
-
   def can_destroy_creations?
-    user_has_roles?(DESTROY_ROLES)
+    user_has_roles?(DESTROY_ROLES) || user_has_roles?(DESTROY_WORK_ROLES) && record.class == Work
   end
 
-  # Currently applies to editing ExternalWorks and the tags or language of Works.
-  # Admins cannot edit Bookmarks or Series or make any other type of edit to
-  # Works.
   def can_edit_creations?
     user_has_roles?(EDIT_ROLES)
   end
@@ -38,7 +35,6 @@ class UserCreationPolicy < ApplicationPolicy
     user_has_roles?(HIDE_ROLES)
   end
 
-  # Currently applies to Works.
   def can_mark_creations_spam?
     user_has_roles?(SPAM_ROLES)
   end

--- a/app/policies/user_creation_policy.rb
+++ b/app/policies/user_creation_policy.rb
@@ -1,13 +1,13 @@
 class UserCreationPolicy < ApplicationPolicy
   # User creations are Bookmarks, ExternalWorks, Series, Works.
 
-  # Roles that allow destroying user creations.
+  # Roles that allow destroying all types of user creations.
   DESTROY_ROLES = %w[superadmin policy_and_abuse].freeze
 
   # Roles that allow destroying only Works.
   #
-  # Include support admins for handling FNOK requests.
-  DESTROY_WORK_ROLES = %w[superadmin policy_and_abuse support].freeze
+  # Include support admins for handling duplicate works.
+  DESTROY_WORK_ROLES = %w[support].freeze
 
   # Roles that allow editing user creations, specifically:
   # - ExternalWorks

--- a/app/policies/user_creation_policy.rb
+++ b/app/policies/user_creation_policy.rb
@@ -1,50 +1,15 @@
 class UserCreationPolicy < ApplicationPolicy
-  # User creations are Bookmarks, ExternalWorks, Series, Works.
-
-  # Roles that allow destroying all types of user creations.
-  DESTROY_ROLES = %w[superadmin policy_and_abuse].freeze
-
-  # Roles that allow destroying only Works.
-  #
-  # Include support admins for handling duplicate works.
-  DESTROY_WORK_ROLES = %w[support].freeze
-
-  # Roles that allow editing user creations, specifically:
-  # - ExternalWorks
-  # - Works (only tags and language)
-  #
-  # Admins cannot edit Bookmarks or Series or make any other changes to Works.
-  #
-  # Include support admins due to AO3-4932.
-  EDIT_ROLES = %w[superadmin policy_and_abuse support].freeze
-
-  HIDE_ROLES = %w[superadmin policy_and_abuse].freeze
-
-  # Currently applies to Works.
-  SPAM_ROLES = %w[superadmin policy_and_abuse].freeze
-
-  def can_destroy_creations?
-    user_has_roles?(DESTROY_ROLES) || user_has_roles?(DESTROY_WORK_ROLES) && record.class == Work
+  def show_admin_options?
+    destroy? || hide? || edit?
   end
 
-  def can_edit_creations?
-    user_has_roles?(EDIT_ROLES)
+  def destroy?
+    user_has_roles?(%w[superadmin policy_and_abuse])
   end
 
-  def can_hide_creations?
-    user_has_roles?(HIDE_ROLES)
+  def hide?
+    user_has_roles?(%w[superadmin policy_and_abuse])
   end
-
-  def can_mark_creations_spam?
-    user_has_roles?(SPAM_ROLES)
-  end
-
-  # ExternalWorksController
-  alias edit? can_edit_creations?
-  # Admin::UserCreationsController
-  alias hide? can_hide_creations?
-  alias set_spam? can_mark_creations_spam?
-  alias destroy? can_destroy_creations?
 
   def show_ip_address?
     user_has_roles?(%w[superadmin policy_and_abuse])

--- a/app/policies/user_manager_policy.rb
+++ b/app/policies/user_manager_policy.rb
@@ -1,0 +1,18 @@
+class UserManagerPolicy < ApplicationPolicy
+  # Roles that allow adding notes to users.
+  NOTE_ROLES = %w[superadmin policy_and_abuse support].freeze
+
+  # Roles that allow warning, suspending, and banning users.
+  JUDGE_ROLES = %w[superadmin policy_and_abuse].freeze
+
+  def can_manage_users?
+    user_has_roles?(NOTE_ROLES) || user_has_roles?(JUDGE_ROLES)
+  end
+
+  def update_status?
+    return true if user_has_roles?(JUDGE_ROLES)
+    return record.admin_action == "note" if user_has_roles?(NOTE_ROLES)
+
+    false
+  end
+end

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -6,11 +6,11 @@ class UserPolicy < ApplicationPolicy
   # This is further restricted using ALLOWED_ATTRIBUTES_BY_ROLES.
   MANAGE_ROLES = %w[superadmin policy_and_abuse open_doors support tag_wrangling].freeze
 
-  # Roles that allow:
-  # - updating a user's Fannish Next of Kin
-  # - suspending and banning
-  # - deleting all of a spammer's creations
-  JUDGE_ROLES = %w[superadmin policy_and_abuse].freeze
+  # Roles that allow updating the Fannish Next Of Kin of a user.
+  MANAGE_NEXT_OF_KIN_ROLES = %w[superadmin policy_and_abuse support].freeze
+
+  # Roles that allow deleting all of a spammer's creations.
+  SPAM_CLEANUP_ROLES = %w[superadmin policy_and_abuse].freeze
 
   # Define which roles can update which attributes.
   ALLOWED_ATTRIBUTES_BY_ROLES = {
@@ -25,8 +25,12 @@ class UserPolicy < ApplicationPolicy
     user_has_roles?(MANAGE_ROLES)
   end
 
-  def can_judge_users?
-    user_has_roles?(JUDGE_ROLES)
+  def can_manage_next_of_kin?
+    user_has_roles?(MANAGE_NEXT_OF_KIN_ROLES)
+  end
+
+  def can_destroy_spam_creations?
+    user_has_roles?(SPAM_CLEANUP_ROLES)
   end
 
   def permitted_attributes
@@ -38,9 +42,10 @@ class UserPolicy < ApplicationPolicy
   alias show? can_manage_users?
   alias update? can_manage_users?
 
-  alias update_status? can_judge_users?
-  alias confirm_delete_user_creations? can_judge_users?
-  alias destroy_user_creations? can_judge_users?
+  alias update_next_of_kin? can_manage_next_of_kin?
+
+  alias confirm_delete_user_creations? can_destroy_spam_creations?
+  alias destroy_user_creations? can_destroy_spam_creations?
 
   alias troubleshoot? can_manage_users?
   alias send_activation? can_manage_users?

--- a/app/policies/work_policy.rb
+++ b/app/policies/work_policy.rb
@@ -1,0 +1,22 @@
+class WorkPolicy < UserCreationPolicy
+  def show_admin_options?
+    super || edit_tags? || set_spam?
+  end
+
+  # Allow admins to edit work tags and languages.
+  # Include support admins due to AO3-4932.
+  def update_tags?
+    user_has_roles?(%w[superadmin policy_and_abuse support])
+  end
+
+  alias edit_tags? update_tags?
+
+  # Support admins need to be able to delete duplicate works.
+  def destroy?
+    super || user_has_roles?(%w[support])
+  end
+
+  def set_spam?
+    user_has_roles?(%w[superadmin policy_and_abuse])
+  end
+end

--- a/app/views/abuse_reports/new.html.erb
+++ b/app/views/abuse_reports/new.html.erb
@@ -16,7 +16,6 @@
     <%= t(".reportable.intro") %>
   </p>
   <ul>
-    <li><%= t(".reportable.fnok.concerning", fnok_link: (link_to t(".reportable.fnok.fnok"), tos_faq_path(anchor: "next_of_kin"))).html_safe %></li>
     <li><%= t(".reportable.hack") %></li>
     <li><%= t(".reportable.tos") %></li>
     <li><%= t(".reportable.dmca.claim", dmca_link:

--- a/app/views/admin/_admin_options.html.erb
+++ b/app/views/admin/_admin_options.html.erb
@@ -5,7 +5,7 @@
 
   <h3 class="landmark heading"><%= t(".landmark") %></h3>
   <ul class="management actions">
-    <% if admin_can_hide_creations? %>
+    <% if admin_can_hide_creations?(item) %>
       <li>
         <% if item.hidden_by_admin? %>
           <%= link_to t(".unhide.#{item_type}"),
@@ -19,12 +19,12 @@
       </li>
     <% end %>
     <% if @work.present? %>
-      <% if admin_can_edit_creations? %>
+      <% if admin_can_edit_creations?(@work) %>
         <li>
           <%= link_to t(".edit_tags"), edit_tags_work_path(@work) %>
         </li>
       <% end %>
-      <% if admin_can_mark_creations_spam? %>
+      <% if admin_can_mark_creations_spam?(@work) %>
         <li>
           <% if @work.spam? %>
             <%= link_to t(".not_spam"),
@@ -39,13 +39,13 @@
       <% end %>
     <% end %>
     <% if item.class == ExternalWork %>
-      <% if admin_can_edit_creations? %>
+      <% if admin_can_edit_creations?(item) %>
         <li>
           <%= link_to t(".edit.#{item_type}"), edit_external_work_path(item) %>
         </li>
       <% end %>
     <% end %>
-    <% if admin_can_destroy_creations? %>
+    <% if admin_can_destroy_creations?(item) %>
       <li>
         <%= link_to t(".delete.#{item_type}"),
                     admin_user_creation_path(item, creation_type: item.class),

--- a/app/views/admin/_admin_options.html.erb
+++ b/app/views/admin/_admin_options.html.erb
@@ -5,7 +5,7 @@
 
   <h3 class="landmark heading"><%= t(".landmark") %></h3>
   <ul class="management actions">
-    <% if admin_can_hide_creations?(item) %>
+    <% if policy(item).hide? %>
       <li>
         <% if item.hidden_by_admin? %>
           <%= link_to t(".unhide.#{item_type}"),
@@ -19,12 +19,12 @@
       </li>
     <% end %>
     <% if @work.present? %>
-      <% if admin_can_edit_creations?(@work) %>
+      <% if policy(@work).edit_tags? %>
         <li>
           <%= link_to t(".edit_tags"), edit_tags_work_path(@work) %>
         </li>
       <% end %>
-      <% if admin_can_mark_creations_spam?(@work) %>
+      <% if policy(@work).set_spam? %>
         <li>
           <% if @work.spam? %>
             <%= link_to t(".not_spam"),
@@ -39,13 +39,13 @@
       <% end %>
     <% end %>
     <% if item.class == ExternalWork %>
-      <% if admin_can_edit_creations?(item) %>
+      <% if policy(item).edit? %>
         <li>
           <%= link_to t(".edit.#{item_type}"), edit_external_work_path(item) %>
         </li>
       <% end %>
     <% end %>
-    <% if admin_can_destroy_creations?(item) %>
+    <% if policy(item).destroy? %>
       <li>
         <%= link_to t(".delete.#{item_type}"),
                     admin_user_creation_path(item, creation_type: item.class),

--- a/app/views/admin/admin_users/show.html.erb
+++ b/app/views/admin/admin_users/show.html.erb
@@ -28,9 +28,10 @@
 
   <!--main content-->
   <h3 class="heading"><%= ts("Abuse Administration") %></h3>
-  <%= form_tag action: "update_status", controller: "admin/admin_users" do %>
+  <%= form_tag action: "update_next_of_kin", controller: "admin/admin_users" do %>
+    <%= error_messages_for @user.fannish_next_of_kin %>
     <%= hidden_field_tag "user_login", @user.login %>
-    <fieldset<% unless policy(@user).can_judge_users? %> disabled="disabled"<% end %>>
+    <fieldset<% unless policy(@user).can_manage_next_of_kin? %> disabled="disabled"<% end %>>
       <legend><%= ts("Fannish Next of Kin") %></legend>
       <h4 class="heading"><%= ts("Fannish Next of Kin") %></h4>
       <dl>
@@ -48,7 +49,12 @@
         </dd>
       </dl>
     </fieldset>
-    <fieldset<% unless policy(@user).can_judge_users? %> disabled="disabled"<% end %>>
+    <p class="submit"><%= submit_tag ts("Update Fannish Next of Kin") %></p>
+  <% end %>
+
+  <%= form_tag action: "update_status", controller: "admin/admin_users" do %>
+    <%= hidden_field_tag "user_login", @user.login %>
+    <fieldset<% unless policy(UserManager).can_manage_users? %> disabled="disabled"<% end %>>
       <legend><%= ts("Warnings and Suspensions") %></legend>
       <h4 class="heading"><%= ts("Warnings and Suspensions") %></h4>
       <ul>
@@ -86,7 +92,7 @@
         </li>
       </ul>
     </fieldset>
-    <fieldset<% unless policy(@user).can_judge_users? %> disabled="disabled"<% end %>>
+    <fieldset<% unless policy(UserManager).can_manage_users? %> disabled="disabled"<% end %>>
       <legend><%= ts("Notes") %></legend>
       <h4 class="heading"><%= label_tag "admin_note", ts("Notes") %></h4>
       <p class="note">

--- a/app/views/bookmarks/_bookmark_user_module.html.erb
+++ b/app/views/bookmarks/_bookmark_user_module.html.erb
@@ -57,7 +57,7 @@
   <!--navigation and actions-->
   <% if is_author_of?(bookmark) %>
     <%= render "bookmarks/bookmark_owner_navigation", bookmark: bookmark %>
-  <% elsif can_access_admin_options?(bookmark) %>
+  <% elsif policy(bookmark).show_admin_options? %>
     <%= render "admin/admin_options", item: bookmark %>
   <% end %>
 </div>

--- a/app/views/bookmarks/_bookmark_user_module.html.erb
+++ b/app/views/bookmarks/_bookmark_user_module.html.erb
@@ -57,7 +57,7 @@
   <!--navigation and actions-->
   <% if is_author_of?(bookmark) %>
     <%= render "bookmarks/bookmark_owner_navigation", bookmark: bookmark %>
-  <% elsif can_access_admin_options? %>
+  <% elsif can_access_admin_options?(bookmark) %>
     <%= render "admin/admin_options", item: bookmark %>
   <% end %>
 </div>

--- a/app/views/chapters/show.html.erb
+++ b/app/views/chapters/show.html.erb
@@ -11,7 +11,7 @@
 <!--/descriptions-->
 
 <!--subnav-->
-<% if can_access_admin_options?(@work) %>
+<% if policy(@work).show_admin_options? %>
   <%= render "admin/admin_options", item: @work %>
 <% end %>
 <!--/subnav-->

--- a/app/views/chapters/show.html.erb
+++ b/app/views/chapters/show.html.erb
@@ -11,7 +11,7 @@
 <!--/descriptions-->
 
 <!--subnav-->
-<% if can_access_admin_options? %>
+<% if can_access_admin_options?(@work) %>
   <%= render "admin/admin_options", item: @work %>
 <% end %>
 <!--/subnav-->

--- a/app/views/external_works/_blurb.html.erb
+++ b/app/views/external_works/_blurb.html.erb
@@ -50,7 +50,7 @@
     <dd><%= link_to external_work.related_works.count.to_s, external_work  %></dd>
   </dl>
 
-  <% if can_access_admin_options?(external_work) %>
+  <% if policy(external_work).show_admin_options? %>
     <%= render "admin/admin_options", item: external_work %>
   <% end %>
 

--- a/app/views/external_works/_blurb.html.erb
+++ b/app/views/external_works/_blurb.html.erb
@@ -50,7 +50,7 @@
     <dd><%= link_to external_work.related_works.count.to_s, external_work  %></dd>
   </dl>
 
-  <% if can_access_admin_options? %>
+  <% if can_access_admin_options?(external_work) %>
     <%= render "admin/admin_options", item: external_work %>
   <% end %>
 

--- a/app/views/feedbacks/new.html.erb
+++ b/app/views/feedbacks/new.html.erb
@@ -25,6 +25,7 @@
     <p><%= t(".abuse.reports", contact_link: link_to(t(".abuse.contact"), new_abuse_report_path)).html_safe %></p>
     <p><%= t(".reportable.intro") %></p>
     <ul>
+      <li><%= t(".reportable.fnok.concerning", fnok_link: link_to(t(".reportable.fnok.fnok"), tos_faq_path(anchor: "next_of_kin"))).html_safe %></li>
       <li><%= t(".reportable.bugs") %></li>
       <li><%= t(".reportable.site_questions") %></li>
       <li><%= t(".reportable.account_creation") %></li>

--- a/app/views/feedbacks/new.html.erb
+++ b/app/views/feedbacks/new.html.erb
@@ -25,7 +25,7 @@
     <p><%= t(".abuse.reports", contact_link: link_to(t(".abuse.contact"), new_abuse_report_path)).html_safe %></p>
     <p><%= t(".reportable.intro") %></p>
     <ul>
-      <li><%= t(".reportable.fnok.concerning", fnok_link: link_to(t(".reportable.fnok.fnok"), tos_faq_path(anchor: "next_of_kin"))).html_safe %></li>
+      <li><%= t(".reportable.fnok.concerning_html", fnok_link: link_to(t(".reportable.fnok.fnok"), tos_faq_path(anchor: "next_of_kin"))) %></li>
       <li><%= t(".reportable.bugs") %></li>
       <li><%= t(".reportable.site_questions") %></li>
       <li><%= t(".reportable.account_creation") %></li>
@@ -33,7 +33,7 @@
       <li><%= t(".reportable.tag_changes") %></li>
       <li><%= t(".reportable.new_features") %></li>
       <li><%= t(".reportable.orphaned_works") %></li>
-      <li><%= t(".reportable.work_language") %></li>
+      <li><%= t(".reportable.work_problems") %></li>
       <li><%= t(".reportable.policy_questions") %></li>
     </ul>
     <p><%= t(".do_not_spam_html") %></p>

--- a/app/views/series/show.html.erb
+++ b/app/views/series/show.html.erb
@@ -18,7 +18,7 @@
 </h2>
 <!--/descriptions-->
 
-<% if can_access_admin_options? %>
+<% if can_access_admin_options?(@series) %>
   <div><%= render "admin/admin_options", item: @series %></div>
 <% end %>
 

--- a/app/views/series/show.html.erb
+++ b/app/views/series/show.html.erb
@@ -18,7 +18,7 @@
 </h2>
 <!--/descriptions-->
 
-<% if can_access_admin_options?(@series) %>
+<% if policy(@series).show_admin_options? %>
   <div><%= render "admin/admin_options", item: @series %></div>
 <% end %>
 

--- a/app/views/works/show.html.erb
+++ b/app/views/works/show.html.erb
@@ -21,7 +21,7 @@
 <!--/descriptions-->
 
 <!--subnav-->
-<% if can_access_admin_options?(@work) %>
+<% if policy(@work).show_admin_options? %>
   <%= render "admin/admin_options", item: @work %>
 <% end %>
 <!--/subnav-->

--- a/app/views/works/show.html.erb
+++ b/app/views/works/show.html.erb
@@ -21,7 +21,7 @@
 <!--/descriptions-->
 
 <!--subnav-->
-<% if can_access_admin_options? %>
+<% if can_access_admin_options?(@work) %>
   <%= render "admin/admin_options", item: @work %>
 <% end %>
 <!--/subnav-->

--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -257,6 +257,9 @@ en:
         contact: contact our Policy and Abuse team
       reportable:
         intro: 'Some issues you can contact Support about include:'
+        fnok:
+          concerning: Setting up, changing, or activating your %{fnok_link}
+          fnok: Fannish Next of Kin
         bugs: Bugs, errors, or unexpected site behavior
         site_questions: Questions about how to use the site
         account_creation: Problems setting up your account
@@ -264,7 +267,7 @@ en:
         tag_changes: Requests to canonize or change tags
         new_features: Feature requests for future development
         orphaned_works: Questions about orphaned works
-        work_language: Works labeled with the wrong language
+        work_language: Works labeled with the wrong language or duplicate works
         policy_questions: General site policy questions
       do_not_spam_html: <strong>We respond to every report we receive, but we are a small volunteer team.</strong> For this reason, we ask you to not submit multiple reports regarding any one issue, or encourage other people to report the same issue, unless there is additional information to offer.
       languages_html: <strong>We can answer Support inquiries in %{list}.</strong> Please allow for additional delay for responses in any language other than English.
@@ -301,9 +304,6 @@ en:
       do_not_spam_html: <strong>We investigate every report we receive.</strong> For this reason, we ask you to not submit several reports regarding any one issue unless you have additional information to offer. We also ask that you do not encourage other users to submit a report regarding content you have already reported. Doing so slows down our response and reaction time considerably, as we are a small volunteer-based committee.
       reportable:
         intro: 'Please submit a report via this form if you have not submitted this report within the past sixty (60) days, and you:'
-        fnok:
-          concerning: would like to contact us regarding your %{fnok_link}, or
-          fnok: Fannish Next of Kin
         hack: believe that your account has been hacked, or that someone is trying to hack your account, or
         tos: believe you have found content uploaded to the Archive which breaches our Terms of Service, or
         dmca:

--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -258,7 +258,7 @@ en:
       reportable:
         intro: 'Some issues you can contact Support about include:'
         fnok:
-          concerning: Setting up, changing, or activating your %{fnok_link}
+          concerning_html: Setting up, changing, or activating your %{fnok_link}
           fnok: Fannish Next of Kin
         bugs: Bugs, errors, or unexpected site behavior
         site_questions: Questions about how to use the site
@@ -267,7 +267,7 @@ en:
         tag_changes: Requests to canonize or change tags
         new_features: Feature requests for future development
         orphaned_works: Questions about orphaned works
-        work_language: Works labeled with the wrong language or duplicate works
+        work_problems: Works labeled with the wrong language or duplicate works
         policy_questions: General site policy questions
       do_not_spam_html: <strong>We respond to every report we receive, but we are a small volunteer team.</strong> For this reason, we ask you to not submit multiple reports regarding any one issue, or encourage other people to report the same issue, unless there is additional information to offer.
       languages_html: <strong>We can answer Support inquiries in %{list}.</strong> Please allow for additional delay for responses in any language other than English.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -373,8 +373,6 @@ Otwarchive::Application.routes.draw do
 
   resources :external_works do
     collection do
-      get :compare
-      post :merge
       get :fetch
     end
     resources :bookmarks

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -180,7 +180,7 @@ Otwarchive::Application.routes.draw do
         put :set_spam
       end
     end
-    resources :users, controller: 'admin_users' do
+    resources :users, controller: "admin_users", only: [:index, :show] do
       member do
         get :confirm_delete_user_creations
         post :destroy_user_creations
@@ -193,6 +193,7 @@ Otwarchive::Application.routes.draw do
         post :bulk_search
         post :update
         post :update_status
+        post :update_next_of_kin
       end
     end
     resources :invitations, controller: 'admin_invitations' do

--- a/features/admins/users/admin_fnok.feature
+++ b/features/admins/users/admin_fnok.feature
@@ -9,11 +9,11 @@ Feature: Admin Fannish Next Of Kind actions
       | login    | password   |
       | harrykim | diesalot   |
       | libby    | stillalive |
-      And I am logged in as a "policy_and_abuse" admin
+      And I am logged in as a "support" admin
     When I go to the abuse administration page for "harrykim"
       And I fill in "Fannish next of kin's username" with "libby"
       And I fill in "Fannish next of kin's email" with "testy@foo.com"
-      And I press "Update"
+      And I press "Update Fannish Next of Kin"
     Then I should see "Fannish next of kin was updated."
 
     When I go to the manage users page
@@ -26,46 +26,46 @@ Feature: Admin Fannish Next Of Kind actions
 
   Scenario: An invalid Fannish Next of Kin username is added
     Given the fannish next of kin "libby" for the user "harrykim"
-      And I am logged in as a "policy_and_abuse" admin
+      And I am logged in as a "support" admin
     When I go to the abuse administration page for "harrykim"
       And I fill in "Fannish next of kin's username" with "userididnotcreate"
-      And I press "Update"
-    Then I should see "Fannish next of kin user is invalid."
+      And I press "Update Fannish Next of Kin"
+    Then I should see "Kin can't be blank"
 
   Scenario: A blank Fannish Next of Kin username can't be added
     Given the fannish next of kin "libby" for the user "harrykim"
-      And I am logged in as a "policy_and_abuse" admin
+      And I am logged in as a "support" admin
     When I go to the abuse administration page for "harrykim"
       And I fill in "Fannish next of kin's username" with ""
-      And I press "Update"
-    Then I should see "Fannish next of kin user is missing."
+      And I press "Update Fannish Next of Kin"
+    Then I should see "Kin can't be blank"
 
   Scenario: A blank Fannish Next of Kin email can't be added
     Given the fannish next of kin "libby" for the user "harrykim"
-      And I am logged in as a "policy_and_abuse" admin
+      And I am logged in as a "support" admin
     When I go to the abuse administration page for "harrykim"
       And I fill in "Fannish next of kin's email" with ""
-      And I press "Update"
-    Then I should see "Fannish next of kin email is missing."
+      And I press "Update Fannish Next of Kin"
+    Then I should see "Kin email can't be blank"
 
   Scenario: A Fannish Next of Kin is edited
     Given the fannish next of kin "libby" for the user "harrykim"
       And the user "newlibby" exists and is activated
-      And I am logged in as a "policy_and_abuse" admin
+      And I am logged in as a "support" admin
     When I go to the abuse administration page for "harrykim"
       And I fill in "Fannish next of kin's username" with "newlibby"
       And I fill in "Fannish next of kin's email" with "newlibby@foo.com"
-      And I press "Update"
+      And I press "Update Fannish Next of Kin"
     Then I should see "Fannish next of kin was updated."
 
   Scenario: A Fannish Next of Kin is removed
     Given the fannish next of kin "libby" for the user "harrykim"
-      And I am logged in as a "policy_and_abuse" admin
+      And I am logged in as a "support" admin
     When I go to the abuse administration page for "harrykim"
       And I fill in "Fannish next of kin's username" with ""
       And I fill in "Fannish next of kin's email" with ""
-      And I press "Update"
-    Then I should see "Fannish next of kin was updated."
+      And I press "Update Fannish Next of Kin"
+    Then I should see "Fannish next of kin was removed."
 
   Scenario: A Fannish Next of Kin updates when the next of kin user changes their username
     Given the fannish next of kin "libby" for the user "harrykim"
@@ -75,7 +75,7 @@ Feature: Admin Fannish Next Of Kind actions
       And I fill in "Password" with "password"
       And I press "Change User Name"
     Then I should get confirmation that I changed my username
-    When I am logged in as a "policy_and_abuse" admin
+    When I am logged in as a "support" admin
       And I go to the manage users page
       And I fill in "Name" with "harrykim"
       And I press "Find"
@@ -89,7 +89,7 @@ Feature: Admin Fannish Next Of Kind actions
       And I fill in "Password" with "password"
       And I press "Change User Name"
     Then I should get confirmation that I changed my username
-    When I am logged in as a "policy_and_abuse" admin
+    When I am logged in as a "support" admin
       And I go to the manage users page
       And I fill in "Name" with "harrykim2"
       And I press "Find"
@@ -98,15 +98,15 @@ Feature: Admin Fannish Next Of Kind actions
   Scenario: A Fannish Next of Kin can update even after an invalid user is entered
     Given the fannish next of kin "libby" for the user "harrykim"
       And the user "harrysmom" exists and is activated
-      And I am logged in as a "policy_and_abuse" admin
+      And I am logged in as a "support" admin
     When I go to the abuse administration page for "harrykim"
       And I fill in "Fannish next of kin's username" with "libbylibby"
       And I fill in "Fannish next of kin's email" with "libbylibby@example.com"
-      And I press "Update"
-    Then I should see "Fannish next of kin user is invalid."
+      And I press "Update Fannish Next of Kin"
+    Then I should see "Kin can't be blank"
     When I fill in "Fannish next of kin's username" with "harrysmom"
       And I fill in "Fannish next of kin's email" with "harrysmom@example.com"
-      And I press "Update"
+      And I press "Update Fannish Next of Kin"
     Then I should see "Fannish next of kin was updated."
       And the "Fannish next of kin's username" field should contain "harrysmom"
       And the "Fannish next of kin's email" field should contain "harrysmom@example.com"

--- a/features/admins/users/admin_fnok.feature
+++ b/features/admins/users/admin_fnok.feature
@@ -104,6 +104,11 @@ Feature: Admin Fannish Next Of Kind actions
       And I fill in "Fannish next of kin's email" with "libbylibby@example.com"
       And I press "Update Fannish Next of Kin"
     Then I should see "Kin can't be blank"
+      And the "Fannish next of kin's username" input should be blank
+      And I should see "libbylibby@example.com" in the "Fannish next of kin's email" input
+    When I go to the abuse administration page for "harrykim"
+      And I should see "libby" in the "Fannish next of kin's username" input
+      And I should see "fnok@example.com" in the "Fannish next of kin's email" input
     When I fill in "Fannish next of kin's username" with "harrysmom"
       And I fill in "Fannish next of kin's email" with "harrysmom@example.com"
       And I press "Update Fannish Next of Kin"

--- a/features/step_definitions/admin_steps.rb
+++ b/features/step_definitions/admin_steps.rb
@@ -108,14 +108,10 @@ Given "the admin post {string}" do |title|
   FactoryBot.create(:admin_post, title: title)
 end
 
-Given /^the fannish next of kin "([^\"]*)" for the user "([^\"]*)"$/ do |kin, user|
-  step %{the user "#{kin}" exists and is activated}
-  step %{the user "#{user}" exists and is activated}
-  step %{I am logged in as a "policy_and_abuse" admin}
-  step %{I go to the abuse administration page for "#{user}"}
-  fill_in("Fannish next of kin's username", with: "#{kin}")
-  fill_in("Fannish next of kin's email", with: "testing@foo.com")
-  click_button("Update")
+Given "the fannish next of kin {string} for the user {string}" do |kin, user|
+  user = ensure_user(user)
+  kin = ensure_user(kin)
+  user.create_fannish_next_of_kin(kin: kin, kin_email: "testing@foo.com")
 end
 
 Given /^the user "([^\"]*)" is suspended$/ do |user|

--- a/features/step_definitions/admin_steps.rb
+++ b/features/step_definitions/admin_steps.rb
@@ -111,7 +111,7 @@ end
 Given "the fannish next of kin {string} for the user {string}" do |kin, user|
   user = ensure_user(user)
   kin = ensure_user(kin)
-  user.create_fannish_next_of_kin(kin: kin, kin_email: "testing@foo.com")
+  user.create_fannish_next_of_kin(kin: kin, kin_email: "fnok@example.com")
 end
 
 Given /^the user "([^\"]*)" is suspended$/ do |user|

--- a/features/step_definitions/generic_steps.rb
+++ b/features/step_definitions/generic_steps.rb
@@ -125,6 +125,10 @@ Then /^I should see "([^"]*)" in the "([^"]*)" input/ do |content, labeltext|
   find_field("#{labeltext}").value.should == content
 end
 
+Then "the {string} input should be blank" do |label|
+  expect(find_field(label).value).to be_blank
+end
+
 Then /^I should see (a|an) "([^"]*)" button(?: within "([^"]*)")?$/ do |_article, text, selector|
   assure_xpath_present("input", "value", text, selector)
 end

--- a/spec/controllers/admin/admin_users_controller_spec.rb
+++ b/spec/controllers/admin/admin_users_controller_spec.rb
@@ -189,29 +189,70 @@ describe Admin::AdminUsersController do
     let(:admin) { create(:admin) }
     let(:user) { create(:user) }
 
-    context "when admin does not have correct authorization" do
-      it "redirects with error" do
-        admin.update(roles: [])
-        fake_login_admin(admin)
-        post :update_status, params: {
-          user_login: user.login, admin_action: "suspend", suspend_days: "3", admin_note: "User violated community guidelines"
-        }
+    before { fake_login_admin(admin) }
 
-        it_redirects_to_with_error(root_url, "Sorry, only an authorized admin can access the page you were trying to reach.")
+    shared_examples "unauthorized admin cannot add note to user" do
+      it "redirects with error" do
+        post :update_status, params: {
+          user_login: user.login, admin_action: "note", admin_note: "User likes me, user likes me not."
+        }
+        it_redirects_to_with_error(root_path, "Sorry, only an authorized admin can access the page you were trying to reach.")
       end
     end
 
-    context "when admin has correct authorization" do
-      it "allows admins to suspend user with note" do
-        admin.update(roles: ["policy_and_abuse"])
-        fake_login_admin(admin)
+    shared_examples "authorized admin can add note to user" do
+      it "redirects with notice" do
+        admin_note = "User likes me, user likes me not."
+        post :update_status, params: {
+          user_login: user.login, admin_action: "note", admin_note: admin_note
+        }
+        it_redirects_to_with_notice(admin_user_path(user), "Note was recorded.")
+        expect(user.reload.log_items.last.action).to eq(ArchiveConfig.ACTION_NOTE)
+        expect(user.log_items.last.note).to eq(admin_note)
+      end
+    end
+
+    shared_examples "unauthorized admin cannot suspend user" do
+      it "redirects with error" do
         post :update_status, params: {
           user_login: user.login, admin_action: "suspend", suspend_days: "3", admin_note: "User violated community guidelines"
         }
-
-        user.reload
-        expect(user.suspended).to be_truthy
+        it_redirects_to_with_error(root_path, "Sorry, only an authorized admin can access the page you were trying to reach.")
+        expect(user.reload.suspended).to be_falsey
       end
+    end
+
+    shared_examples "authorized admin can suspend user" do
+      it "redirects with notice" do
+        post :update_status, params: {
+          user_login: user.login, admin_action: "suspend", suspend_days: "3", admin_note: "User violated community guidelines"
+        }
+        it_redirects_to_with_notice(admin_user_path(user), "User has been temporarily suspended.")
+        expect(user.reload.suspended).to be_truthy
+      end
+    end
+
+    context "when admin does not have correct authorization" do
+      before { admin.update(roles: []) }
+
+      it_behaves_like "unauthorized admin cannot add note to user"
+      it_behaves_like "unauthorized admin cannot suspend user"
+    end
+
+    %w[superadmin policy_and_abuse].each do |role|
+      context "when admin has #{role} role" do
+        let(:admin) { create(:admin, roles: [role]) }
+
+        it_behaves_like "authorized admin can add note to user"
+        it_behaves_like "authorized admin can suspend user"
+      end
+    end
+
+    context "when admin has support role" do
+      let(:admin) { create(:support_admin) }
+
+      it_behaves_like "authorized admin can add note to user"
+      it_behaves_like "unauthorized admin cannot suspend user"
     end
   end
 

--- a/spec/controllers/admin/admin_users_controller_spec.rb
+++ b/spec/controllers/admin/admin_users_controller_spec.rb
@@ -185,6 +185,49 @@ describe Admin::AdminUsersController do
     end
   end
 
+  describe "POST #update_next_of_kin" do
+    let(:admin) { create(:admin) }
+    let(:user) { create(:user) }
+    let(:kin) { create(:user) }
+
+    before { fake_login_admin(admin) }
+
+    shared_examples "unauthorized admin cannot add next of kin" do
+      it "redirects with error" do
+        post :update_next_of_kin, params: {
+          user_login: user.login, next_of_kin_name: kin.login, next_of_kin_email: kin.email
+        }
+        it_redirects_to_with_error(root_path, "Sorry, only an authorized admin can access the page you were trying to reach.")
+        expect(user.reload.fannish_next_of_kin).to be_nil
+      end
+    end
+
+    shared_examples "authorized admin can add next of kin" do
+      it "adds next of kin and redirects with notice" do
+        post :update_next_of_kin, params: {
+          user_login: user.login, next_of_kin_name: kin.login, next_of_kin_email: kin.email
+        }
+        it_redirects_to_with_notice(admin_user_path(user), "Fannish next of kin was updated.")
+        expect(user.reload.fannish_next_of_kin.kin).to eq(kin)
+        expect(user.reload.fannish_next_of_kin.kin_email).to eq(kin.email)
+      end
+    end
+
+    context "when admin does not have correct authorization" do
+      before { admin.update(roles: []) }
+
+      it_behaves_like "unauthorized admin cannot add next of kin"
+    end
+
+    %w[superadmin policy_and_abuse support].each do |role|
+      context "when admin has #{role} role" do
+        let(:admin) { create(:admin, roles: [role]) }
+
+        it_behaves_like "authorized admin can add next of kin"
+      end
+    end
+  end
+
   describe "POST #update_status" do
     let(:admin) { create(:admin) }
     let(:user) { create(:user) }
@@ -201,7 +244,7 @@ describe Admin::AdminUsersController do
     end
 
     shared_examples "authorized admin can add note to user" do
-      it "redirects with notice" do
+      it "saves note and redirects with notice" do
         admin_note = "User likes me, user likes me not."
         post :update_status, params: {
           user_login: user.login, admin_action: "note", admin_note: admin_note
@@ -223,7 +266,7 @@ describe Admin::AdminUsersController do
     end
 
     shared_examples "authorized admin can suspend user" do
-      it "redirects with notice" do
+      it "suspends user and redirects with notice" do
         post :update_status, params: {
           user_login: user.login, admin_action: "suspend", suspend_days: "3", admin_note: "User violated community guidelines"
         }

--- a/spec/controllers/admin/user_creations_controller_spec.rb
+++ b/spec/controllers/admin/user_creations_controller_spec.rb
@@ -101,29 +101,67 @@ describe Admin::UserCreationsController do
   describe "DELETE #destroy" do
     let(:admin) { create(:admin) }
 
-    context "when user creation is a work" do
+    before { fake_login_admin(admin) }
+
+    shared_examples "unauthorized admin cannot delete works" do
       let(:work) { create(:work) }
 
-      context "when admin does not have correct authorization" do
-        it "redirects with error" do
-          admin.update(roles: [])
-          fake_login_admin(admin)
-          delete :destroy, params: { id: work.id, creation_type: "Work" }
-
-          it_redirects_to_with_error(root_url, "Sorry, only an authorized admin can access the page you were trying to reach.")
-        end
+      it "redirects with error" do
+        delete :destroy, params: { id: work.id, creation_type: "Work" }
+        it_redirects_to_with_error(root_url, "Sorry, only an authorized admin can access the page you were trying to reach.")
       end
+    end
 
-      context "when admin has correct authorization" do
-        it "destroys item and redirects with notice" do
-          admin.update(roles: ["policy_and_abuse"])
-          fake_login_admin(admin)
-          delete :destroy, params: { id: work.id, creation_type: "Work" }
+    shared_examples "authorized admin can delete works" do
+      let(:work) { create(:work) }
 
-          it_redirects_to_with_notice(works_path, "Item was successfully deleted.")
-          expect { work.reload }.to raise_exception(ActiveRecord::RecordNotFound)
-        end
+      it "destroys the work and redirects with notice" do
+        delete :destroy, params: { id: work.id, creation_type: "Work" }
+        it_redirects_to_with_notice(works_path, "Item was successfully deleted.")
+        expect { work.reload }.to raise_exception(ActiveRecord::RecordNotFound)
       end
+    end
+
+    shared_examples "unauthorized admin cannot delete bookmarks" do
+      let(:bookmark) { create(:bookmark) }
+
+      it "redirects with error" do
+        delete :destroy, params: { id: bookmark.id, creation_type: "Bookmark" }
+        it_redirects_to_with_error(root_url, "Sorry, only an authorized admin can access the page you were trying to reach.")
+      end
+    end
+
+    shared_examples "authorized admin can delete bookmarks" do
+      let(:bookmark) { create(:bookmark) }
+
+      it "destroys the bookmark and redirects with notice" do
+        delete :destroy, params: { id: bookmark.id, creation_type: "Bookmark" }
+        it_redirects_to_with_notice(bookmarks_path, "Item was successfully deleted.")
+        expect { bookmark.reload }.to raise_exception(ActiveRecord::RecordNotFound)
+      end
+    end
+
+    context "when admin does not have correct authorization" do
+      before { admin.update(roles: []) }
+
+      it_behaves_like "unauthorized admin cannot delete works"
+      it_behaves_like "unauthorized admin cannot delete bookmarks"
+    end
+
+    %w[superadmin policy_and_abuse].each do |role|
+      context "when admin has #{role} role" do
+        let(:admin) { create(:admin, roles: [role]) }
+
+        it_behaves_like "authorized admin can delete works"
+        it_behaves_like "authorized admin can delete bookmarks"
+      end
+    end
+
+    context "when admin has support role" do
+      let(:admin) { create(:support_admin) }
+
+      it_behaves_like "authorized admin can delete works"
+      it_behaves_like "unauthorized admin cannot delete bookmarks"
     end
   end
 end

--- a/spec/controllers/external_works_controller_spec.rb
+++ b/spec/controllers/external_works_controller_spec.rb
@@ -1,6 +1,9 @@
-require 'spec_helper'
+require "spec_helper"
 
 describe ExternalWorksController do
+  include LoginMacros
+  include RedirectExpectationHelper
+
   describe "GET #fetch" do
     let(:url) { "http://example.org/200" }
 
@@ -39,6 +42,48 @@ describe ExternalWorksController do
       it "responds with blank" do
         get :fetch, params: { external_work_url: url, format: :json }
         expect(assigns(:external_work)).to be_nil
+      end
+    end
+  end
+
+  describe "POST #update" do
+    let(:admin) { create(:admin) }
+    let(:external_work) { create(:external_work) }
+
+    before { fake_login_admin(admin) }
+
+    shared_examples "unauthorized admin cannot update external works" do
+      it "redirects with error" do
+        expect do
+          post :update, params: {
+            id: external_work, external_work: attributes_for(:external_work), work: { relationship_string: "takotori" }
+          }
+        end.to avoid_changing { external_work.reload.updated_at }
+        it_redirects_to_with_error(root_path, "Sorry, only an authorized admin can access the page you were trying to reach.")
+      end
+    end
+
+    shared_examples "authorized admin can update external works" do
+      it "updates the external work and redirects with notice" do
+        post :update, params: {
+          id: external_work, external_work: attributes_for(:external_work), work: { relationship_string: "takotori" }
+        }
+        it_redirects_to_with_notice(external_work_path(external_work), "External work was successfully updated.")
+        expect(external_work.reload.relationship_string).to eq("takotori")
+      end
+    end
+
+    context "when admin does not have correct authorization" do
+      before { admin.update(roles: []) }
+
+      it_behaves_like "unauthorized admin cannot update external works"
+    end
+
+    %w[superadmin policy_and_abuse].each do |role|
+      context "when admin has #{role} role" do
+        let(:admin) { create(:admin, roles: [role]) }
+
+        it_behaves_like "authorized admin can update external works"
       end
     end
   end

--- a/spec/controllers/works/updating_tags_spec.rb
+++ b/spec/controllers/works/updating_tags_spec.rb
@@ -1,0 +1,60 @@
+require "spec_helper"
+
+describe WorksController do
+  include LoginMacros
+  include RedirectExpectationHelper
+
+  describe "POST #update_tags" do
+    let(:admin) { create(:admin) }
+    let(:work) { create(:work) }
+    let!(:language) { create(:language) }
+
+    shared_examples "cannot update work tags and language" do
+      it "redirects with error" do
+        expect do
+          post :update_tags, params: {
+            id: work, work: { relationship_string: "kronfaumei", language_id: language.id }
+          }
+        end.to avoid_changing { work.reload.updated_at }
+        it_redirects_to_with_error(root_path, "Sorry, only an authorized admin can access the page you were trying to reach.")
+      end
+    end
+
+    shared_examples "can update work tags and language" do
+      it "updates the work and redirects with notice" do
+        post :update_tags, params: {
+          id: work, work: { relationship_string: "kronfaumei", language_id: language.id }
+        }
+        puts flash.inspect
+        it_redirects_to_with_notice(work_path(work), "Work was successfully updated.")
+        expect(work.reload.relationship_string).to eq("kronfaumei")
+        expect(work.language).to eq(language)
+      end
+    end
+
+    context "when logged in as the work creator" do
+      before { fake_login_known_user(work.users.first) }
+
+      it_behaves_like "can update work tags and language"
+    end
+
+    context "when admin does not have correct authorization" do
+      before do
+        admin.update(roles: [])
+        fake_login_admin(admin)
+      end
+
+      it_behaves_like "cannot update work tags and language"
+    end
+
+    %w[superadmin policy_and_abuse support].each do |role|
+      context "when admin has #{role} role" do
+        let(:admin) { create(:admin, roles: [role]) }
+
+        before { fake_login_admin(admin) }
+
+        it_behaves_like "can update work tags and language"
+      end
+    end
+  end
+end

--- a/spec/models/user_manager_spec.rb
+++ b/spec/models/user_manager_spec.rb
@@ -6,9 +6,19 @@ describe UserManager do
     let(:user) { create(:user) }
 
     it "returns error without user" do
-      manager = UserManager.new(admin, nil, admin_action: "note")
+      manager = UserManager.new(admin, nil, {})
       expect(manager.save).to be_falsey
       expect(manager.errors).to eq ["Must have a valid user and admin account to proceed."]
+    end
+
+    it "does nothing without an admin action" do
+      manager = UserManager.new(admin, user, {})
+      expect do
+        manager.save
+      end.to avoid_changing { user.reload.updated_at }
+        .and avoid_changing { user.reload.log_items.count }
+      expect(manager.save).to be_truthy
+      expect(manager.successes).to be_empty
     end
 
     it "returns error if notes are missing when suspending" do

--- a/spec/models/user_manager_spec.rb
+++ b/spec/models/user_manager_spec.rb
@@ -3,66 +3,53 @@ require "spec_helper"
 describe UserManager do
   describe "#save" do
     let(:admin) { create(:admin) }
-    let(:next_of_kin) { create(:user) }
     let(:user) { create(:user) }
 
     it "returns error without user" do
-      manager = UserManager.new(admin, user_login: nil)
+      manager = UserManager.new(admin, nil, admin_action: "note")
       expect(manager.save).to be_falsey
       expect(manager.errors).to eq ["Must have a valid user and admin account to proceed."]
     end
 
-    it "returns error if next of kin email is missing" do
-      manager = UserManager.new(admin, user_login: user.login, next_of_kin_name: next_of_kin.login)
-      expect(manager.save).to be_falsey
-      expect(manager.errors).to eq ["Fannish next of kin email is missing."]
-    end
-
     it "returns error if notes are missing when suspending" do
-      manager = UserManager.new(admin, user_login: user.login, admin_action: "suspend", suspend_days: "7")
+      manager = UserManager.new(admin, user, admin_action: "suspend", suspend_days: "7")
       expect(manager.save).to be_falsey
       expect(manager.errors).to eq ["You must include notes in order to perform this action."]
     end
 
     it "returns error for suspension without time span" do
-      manager = UserManager.new(admin, user_login: user.login, admin_action: "suspend", admin_note: "User violated community guidelines")
+      manager = UserManager.new(admin, user, admin_action: "suspend", admin_note: "User violated community guidelines")
       expect(manager.save).to be_falsey
       expect(manager.errors).to eq ["Please enter the number of days for which the user should be suspended."]
     end
 
     it "returns error for invalid admin actions" do
-      manager = UserManager.new(admin, user_login: user.login, admin_action: "something_wicked")
+      manager = UserManager.new(admin, user, admin_action: "something_wicked")
       expect(manager.save).to be_falsey
     end
 
-    it "succeeds with next of kin info" do
-      manager = UserManager.new(admin, user_login: user.login, next_of_kin_name: next_of_kin.login, next_of_kin_email: next_of_kin.email)
-      expect(manager.save).to be_truthy
-      expect(manager.successes).to eq ["Fannish next of kin was updated."]
-    end
-
     it "succeeds in suspending user" do
-      manager = UserManager.new(admin, user_login: user.login, admin_action: "suspend", suspend_days: "5", admin_note: "User violated community guidelines")
+      manager = UserManager.new(admin, user, admin_action: "suspend", suspend_days: "5", admin_note: "User violated community guidelines")
       expect(manager.save).to be_truthy
       expect(manager.successes).to eq ["User has been temporarily suspended."]
     end
 
     it "succeeds in banning user" do
-      manager = UserManager.new(admin, user_login: user.login, admin_action: "ban", admin_note: "User violated community guidelines")
+      manager = UserManager.new(admin, user, admin_action: "ban", admin_note: "User violated community guidelines")
       expect(manager.save).to be_truthy
       expect(manager.successes).to eq ["User has been permanently suspended."]
     end
 
     it "succeeds in unsuspending user" do
       user.update(suspended: true, suspended_until: 4.days.from_now)
-      manager = UserManager.new(admin, user_login: user.login, admin_action: "unsuspend", admin_note: "There was a mistake in the review process")
+      manager = UserManager.new(admin, user, admin_action: "unsuspend", admin_note: "There was a mistake in the review process")
       expect(manager.save).to be_truthy
       expect(manager.successes).to eq ["Suspension has been lifted."]
     end
 
     it "succeeds in unbanning user" do
       user.update(banned: true)
-      manager = UserManager.new(admin, user_login: user.login, admin_action: "unban", admin_note: "There was a mistake in the review process")
+      manager = UserManager.new(admin, user, admin_action: "unban", admin_note: "There was a mistake in the review process")
       expect(manager.save).to be_truthy
       expect(manager.successes).to eq ["Suspension has been lifted."]
     end


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6317

## Purpose

- Remove editing FNOK from UserManager, and add a new endpoint/form covered by a new permission in UserPolicy.
- Update the FNOK model to use Rails associations.
- Add a new policy class for UserManager, to check that PAC admins can perform all actions (add notes, suspend, etc.) but support admins can only add notes.
- Allow support admins to delete works, but not other types of user creations (bookmarks, external works, series).
- Fix redirect after an admin successfully deletes a bookmark.
- Fix redirect after an admin successfully adds notes, etc.
- Enforce admin permissions on editing work tags and external works.
- Update text on both the PAC form and the Support form.

## Testing Instructions

See issue.