### PR TITLE
AO3-6424 Override Dependabot labels for gem updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,17 @@
 version: 2
 updates:
 
+  - package-ecosystem: "bundler"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    labels:
+      - "Awaiting Review"
+      - "Gem Updates"
+      - "Gem Updates: Security"
+    # Disable version updates
+    open-pull-requests-limit: 0
+
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,8 @@ updates:
       - "Awaiting Review"
       - "Gem Updates"
       - "Gem Updates: Security"
-    # Disable version updates
+    # Disable version updates; this has no impact on security updates,
+    # which have a separate, internal limit of 10 open pull requests.
     open-pull-requests-limit: 0
 
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6424

## Purpose

Configure labels for all Dependabot gem update pull requests. [Disable normal version updates](https://docs.github.com/en/code-security/dependabot/dependabot-security-updates/configuring-dependabot-security-updates#overriding-the-default-behavior-with-a-configuration-file) so this applies only to security updates.

## Testing Instructions

None, until the next Dependabot pull request.

I'll delete the "Dependencies" and "ruby" labels when this is merged.