### PR TITLE
AO3-6435 Remove prompt_restriction_id column from the gift_exchanges and prompt_memes tables.

### DIFF
--- a/app/controllers/challenge_requests_controller.rb
+++ b/app/controllers/challenge_requests_controller.rb
@@ -15,7 +15,7 @@ class ChallengeRequestsController < ApplicationController
   end
 
   def index
-    @show_request_fandom_tags = (@collection.challenge.request_restriction.allowed("fandom") > 0 || (!@collection.challenge.prompt_restriction.nil? && @collection.challenge.prompt_restriction.allowed("fandom") > 0))
+    @show_request_fandom_tags = @collection.challenge.request_restriction.allowed("fandom").positive?
 
     # sorting
     set_sort_order

--- a/app/helpers/prompt_restrictions_helper.rb
+++ b/app/helpers/prompt_restrictions_helper.rb
@@ -1,15 +1,4 @@
 module PromptRestrictionsHelper
-
-  def get_prompt_restriction(for_offer=false)
-    if @collection && @collection.challenge
-      if for_offer
-        @collection.challenge.offer_restriction || @collection.challenge.prompt_restriction
-      else
-        @collection.challenge.request_restriction || @collection.challenge.prompt_restriction
-      end
-    end
-  end
-
   def prompt_restriction_settings(form, include_description = false, allowany, hasprompts)
 
     result = "<!-- prompt restriction settings helper function -->".html_safe
@@ -84,5 +73,4 @@ module PromptRestrictionsHelper
       "#{tag_name.titleize}:"
     end
   end
-
 end

--- a/app/models/challenge_models/gift_exchange.rb
+++ b/app/models/challenge_models/gift_exchange.rb
@@ -8,9 +8,6 @@ class GiftExchange < ApplicationRecord
   has_one :collection, as: :challenge
 
   # limits the kind of prompts users can submit
-  belongs_to :prompt_restriction, class_name: "PromptRestriction", dependent: :destroy
-  accepts_nested_attributes_for :prompt_restriction
-
   belongs_to :request_restriction, class_name: "PromptRestriction", dependent: :destroy
   accepts_nested_attributes_for :request_restriction
 

--- a/app/models/challenge_models/prompt_meme.rb
+++ b/app/models/challenge_models/prompt_meme.rb
@@ -8,9 +8,6 @@ class PromptMeme < ApplicationRecord
   has_one :collection, as: :challenge
 
   # limits the kind of prompts users can submit
-  belongs_to :prompt_restriction, class_name: "PromptRestriction", dependent: :destroy
-  accepts_nested_attributes_for :prompt_restriction
-
   belongs_to :request_restriction, class_name: "PromptRestriction", dependent: :destroy
   accepts_nested_attributes_for :request_restriction
 

--- a/app/models/offer.rb
+++ b/app/models/offer.rb
@@ -1,11 +1,7 @@
 class Offer < Prompt
   belongs_to :challenge_signup, touch: true, inverse_of: :offers
 
-  def get_prompt_restriction
-    if collection && collection.challenge
-      collection.challenge.offer_restriction
-    else
-      nil
-    end
+  def prompt_restriction
+    collection&.challenge&.offer_restriction
   end
 end

--- a/app/models/prompt.rb
+++ b/app/models/prompt.rb
@@ -50,18 +50,13 @@ class Prompt < ApplicationRecord
   validates_presence_of :url, if: :url_required?
   validates_presence_of :description, if: :description_required?
   validates_presence_of :title, if: :title_required?
-  def url_required?
-    (restriction = get_prompt_restriction) && restriction.url_required
-  end
-  def description_required?
-    (restriction = get_prompt_restriction) && restriction.description_required
-  end
+
+  delegate :url_required?, :description_required?, :title_required?,
+           to: :prompt_restriction, allow_nil: true
+
   validates_length_of :description,
     maximum: ArchiveConfig.NOTES_MAX,
     too_long: ts("must be less than %{max} letters long.", max: ArchiveConfig.NOTES_MAX)
-  def title_required?
-    (restriction = get_prompt_restriction) && restriction.title_required
-  end
   validates_length_of :title,
     maximum: ArchiveConfig.TITLE_MAX,
     too_long: ts("must be less than %{max} letters long.", max: ArchiveConfig.TITLE_MAX)
@@ -76,7 +71,7 @@ class Prompt < ApplicationRecord
   validate :correct_number_of_tags
   def correct_number_of_tags
     prompt_type = self.class.name
-    restriction = get_prompt_restriction
+    restriction = prompt_restriction
     if restriction
       # make sure tagset has no more/less than the required/allowed number of tags of each type
       TagSet::TAG_TYPES.each do |tag_type|
@@ -120,7 +115,7 @@ class Prompt < ApplicationRecord
   # are within that set, or otherwise canonical
   validate :allowed_tags
   def allowed_tags
-    restriction = get_prompt_restriction
+    restriction = prompt_restriction
     if restriction && tag_set
       TagSet::TAG_TYPES.each do |tag_type|
         # if we have a specified set of tags of this type, make sure that all the
@@ -152,7 +147,7 @@ class Prompt < ApplicationRecord
   # actually in the fandom they have chosen.
   validate :restricted_tags
   def restricted_tags
-    restriction = get_prompt_restriction
+    restriction = prompt_restriction
     if restriction
       TagSet::TAG_TYPES_RESTRICTED_TO_FANDOM.each do |tag_type|
         if restriction.send("#{tag_type}_restrict_to_fandom")
@@ -247,12 +242,8 @@ class Prompt < ApplicationRecord
     send("any_#{type.downcase}")
   end
 
-  def get_prompt_restriction
-    if collection && collection.challenge
-      collection.challenge.prompt_restriction
-    else
-      nil
-    end
+  def prompt_restriction
+    raise "Base-type Prompt objects cannot have prompt restrictions. Try creating a Request or an Offer."
   end
 
   # tag groups

--- a/app/models/request.rb
+++ b/app/models/request.rb
@@ -1,13 +1,7 @@
 class Request < Prompt
   belongs_to :challenge_signup, touch: true, inverse_of: :requests
 
-  def get_prompt_restriction
-    if collection && collection.challenge
-      collection.challenge.request_restriction
-    else
-      nil
-    end
+  def prompt_restriction
+    collection&.challenge&.request_restriction
   end
-
-
 end

--- a/db/migrate/20221205223816_remove_prompt_restriction_id_column.rb
+++ b/db/migrate/20221205223816_remove_prompt_restriction_id_column.rb
@@ -1,0 +1,6 @@
+class RemovePromptRestrictionIdColumn < ActiveRecord::Migration[6.0]
+  def change
+    remove_column :gift_exchanges, :prompt_restriction_id, :integer
+    remove_column :prompt_memes, :prompt_restriction_id, :integer
+  end
+end

--- a/factories/challenges.rb
+++ b/factories/challenges.rb
@@ -34,7 +34,6 @@ FactoryBot.define do
   factory :gift_exchange do
     association :offer_restriction, factory: :prompt_restriction
     association :request_restriction, factory: :prompt_restriction
-    association :prompt_restriction, factory: :prompt_restriction
 
     trait :open do
       signups_open_at { Time.now - 1.day }
@@ -51,6 +50,5 @@ FactoryBot.define do
 
   factory :prompt_meme do
     association :request_restriction, factory: :prompt_restriction
-    association :prompt_restriction, factory: :prompt_restriction
   end
 end

--- a/spec/controllers/challenge_claims_controller_spec.rb
+++ b/spec/controllers/challenge_claims_controller_spec.rb
@@ -78,7 +78,7 @@ describe ChallengeClaimsController do
 
   describe 'show' do
     it 'redirects logged in user to the prompt' do
-      request_prompt = create(:prompt, collection_id: collection.id, challenge_signup_id: signup.id)
+      request_prompt = create(:request, collection_id: collection.id, challenge_signup_id: signup.id)
       claim_with_prompt = create(:challenge_claim, collection: collection, request_prompt_id: request_prompt.id)
       fake_login_known_user(user)
       get :show, params: { id: claim_with_prompt.id, collection_id: collection.name }


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6435

## Purpose

- Drops `prompt_restriction_id` from gift exchanges and prompt memes.
- Removes all remaining references to it in code, including the challenge factories.
- Remove the unused `get_prompt_restriction` method in `app/helpers/prompt_restrictions_helper.rb`.
- Renames the `get_prompt_restriction` method for prompts/requests/offers to something that Rubocop likes better (see [Naming/AccessorMethodName](https://docs.rubocop.org/rubocop/cops_naming.html#namingaccessormethodname)), and simplify the code for Requests and Offers.
- Simplifies the definition for `title_required?`, `url_required?`, and `description_required?` in prompts.