### PR TITLE
AO3-6436 Disallow Common Crawl bot

### DIFF
--- a/public/robots.public.txt
+++ b/public/robots.public.txt
@@ -31,8 +31,8 @@ Disallow: /*?*user_id
 Disallow: /*?*pseud=
 Disallow: /people?*show=
 
-User-agent: Slurp
-Crawl-delay: 30
-
 User-agent: CCBot
 Disallow: /
+
+User-agent: Slurp
+Crawl-delay: 30

--- a/public/robots.public.txt
+++ b/public/robots.public.txt
@@ -33,3 +33,6 @@ Disallow: /people?*show=
 
 User-agent: Slurp
 Crawl-delay: 30
+
+User-agent: CCBot
+Disallow: /


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6436

## Purpose

Prevents CCBot from crawling the archive.

## Testing Instructions

Refer to Jira.

## Credit

Sarken, she/her