### PR TITLE
AO3-4120 Prevent comments caching stale username and pseud

### DIFF
--- a/app/views/comments/_single_comment.html.erb
+++ b/app/views/comments/_single_comment.html.erb
@@ -14,7 +14,7 @@
     <% elsif !can_see_hidden_comment?(single_comment) %>
       <p class="message"><%= ts("(This comment is under review by an admin and is currently unavailable.)") %></p>
     <% else %>
-      <% cache(single_comment, expires_in: 1.week) do %>
+      <% cache([single_comment, single_comment.comment_owner], expires_in: 1.week) do %>
         <% # FRONT END, update this if a.user comes in %>
         <h4 class="heading byline">
           <% if single_comment.by_anonymous_creator? %>

--- a/features/other_a/pseuds.feature
+++ b/features/other_a/pseuds.feature
@@ -130,6 +130,7 @@ Scenario: Comments reflect pseud changes immediately
   Then I should see "before (myself)" within "h4.heading.byline"
 
   When I change the pseud "before" to "after"
+    And it is currently 10 seconds from now
     And I view the work "Interesting" with comments
   Then I should see "after (myself)" within "h4.heading.byline"
     And I should not see "before (myself)"

--- a/features/other_a/pseuds.feature
+++ b/features/other_a/pseuds.feature
@@ -117,3 +117,19 @@ Scenario: Manage pseuds - add, edit
     And I should see "My new fancy name (editpseuds)"
     And I should see "I wanted to add another fancy name"
     And I should not see "My new name (editpseuds)"
+
+Scenario: Comments reflect pseud changes immediately
+
+  Given the work "Interesting"
+    And I am logged in as "myself"
+    And I add the pseud "before"
+  When I set up the comment "Wow!" on the work "Interesting"
+    And I select "before" from "comment[pseud_id]"
+    And I press "Comment"
+    And I view the work "Interesting" with comments
+  Then I should see "before (myself)" within "h4.heading.byline"
+
+  When I change the pseud "before" to "after"
+    And I view the work "Interesting" with comments
+  Then I should see "after (myself)" within "h4.heading.byline"
+    And I should not see "before (myself)"

--- a/features/other_a/pseuds.feature
+++ b/features/other_a/pseuds.feature
@@ -129,8 +129,8 @@ Scenario: Comments reflect pseud changes immediately
     And I view the work "Interesting" with comments
   Then I should see "before (myself)" within "h4.heading.byline"
 
-  When I change the pseud "before" to "after"
-    And it is currently 10 seconds from now
+  When it is currently 2 seconds from now
+    And I change the pseud "before" to "after"
     And I view the work "Interesting" with comments
   Then I should see "after (myself)" within "h4.heading.byline"
     And I should not see "before (myself)"

--- a/features/other_a/pseuds.feature
+++ b/features/other_a/pseuds.feature
@@ -127,10 +127,10 @@ Scenario: Comments reflect pseud changes immediately
     And I select "before" from "comment[pseud_id]"
     And I press "Comment"
     And I view the work "Interesting" with comments
-  Then I should see "before (myself)" within "h4.heading.byline"
+  Then I should see "before (myself)" within ".comment h4.byline"
 
-  When it is currently 2 seconds from now
+  When it is currently 1 second from now
     And I change the pseud "before" to "after"
     And I view the work "Interesting" with comments
-  Then I should see "after (myself)" within "h4.heading.byline"
+  Then I should see "after (myself)" within ".comment h4.byline"
     And I should not see "before (myself)"

--- a/features/users/user_rename.feature
+++ b/features/users/user_rename.feature
@@ -130,7 +130,7 @@ Feature:
     When I search for works containing "newusername"
     Then I should see "Epic story"
 
-  Scenario: Comments reflect username changes after the cache expires in a week
+  Scenario: Comments reflect username changes immediately
     Given the work "Interesting"
       And I am logged in as "before" with password "password"
       And I add the pseud "mine"
@@ -144,7 +144,5 @@ Feature:
       And I fill in "Password" with "password"
       And I press "Change User Name"
       And I view the work "Interesting" with comments
-    Then I should see "mine (before)"
-    When it is currently 7 days from now
-      And I view the work "Interesting" with comments
-    Then I should not see "mine (before)"
+    Then I should see "after" within "h4.heading.byline"
+      And I should not see "mine (before)"

--- a/features/users/user_rename.feature
+++ b/features/users/user_rename.feature
@@ -139,7 +139,8 @@ Feature:
       And I press "Comment"
       And I view the work "Interesting" with comments
     Then I should see "mine (before)"
-    When I visit the change username page for before
+    When it is currently 2 seconds from now
+      And I visit the change username page for before
       And I fill in "New user name" with "after"
       And I fill in "Password" with "password"
       And I press "Change User Name"

--- a/features/users/user_rename.feature
+++ b/features/users/user_rename.feature
@@ -139,11 +139,11 @@ Feature:
       And I press "Comment"
       And I view the work "Interesting" with comments
     Then I should see "mine (before)"
-    When it is currently 2 seconds from now
+    When it is currently 1 second from now
       And I visit the change username page for before
       And I fill in "New user name" with "after"
       And I fill in "Password" with "password"
       And I press "Change User Name"
       And I view the work "Interesting" with comments
-    Then I should see "after" within "h4.heading.byline"
+    Then I should see "after" within ".comment h4.byline"
       And I should not see "mine (before)"


### PR DESCRIPTION
Please do not review yet. I want to see if the CI behaviour matches something strange I see locally before marking as review-ready.

# Pull Request Checklist

* [X] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [X] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [X] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [X] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [X] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-4120

## Purpose

Update the cache key for single comments to avoid displaying a stale commenter name

## Testing Instructions

See Jira bug description for STR

## References

Epic: https://otwarchive.atlassian.net/browse/AO3-5051
Comment by @tickinginstant with suggested solution: https://otwarchive.atlassian.net/browse/AO3-4120?focusedCommentId=358747

## Credit

What name and pronouns should we use to credit you in the [Archive of Our Own's Release Notes](https://archiveofourown.org/admin_posts?tag=1)?

**Brian (they/he)**
