### PR TITLE
AO3-6409 Use ruby:3.0.5-buster image for development

### DIFF
--- a/config/docker/Dockerfile
+++ b/config/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:3.0.5
+FROM ruby:3.0.5-buster
 
 # Install additional packages
 RUN apt-get update             && \
@@ -19,7 +19,7 @@ VOLUME /otwa
 # Install ruby packages
 COPY Gemfile .
 COPY Gemfile.lock .
-RUN gem install bundler -v 1.17.3 && bundle install
+RUN gem install bundler -v 2.2.33 && bundle install
 
 # Default command to run in a new container
 EXPOSE 3000


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6409

## Purpose

ruby:2.7.3 is based on Debian Buster, but ruby:3.0.5 is based on Debian Bullseye, which has no installation candidate for phantomjs. For now, we'll pin the Debian release. From https://hub.docker.com/_/ruby:

> Some of these tags may have names like bullseye or buster in them. These are the suite code names for releases of [Debian](https://wiki.debian.org/DebianReleases) and indicate which release the image is based on. If your image needs to install any additional packages beyond what comes with the image, you'll likely want to specify one of these explicitly to minimize breakage when there are new releases of Debian.

Also use a newer bundler version for Docker to match Gemfile.lock.

## Testing Instructions

None. I ran tests locally fine:
```sh
docker-compose up --build --force-recreate --no-deps -d web
docker-compose exec web bundle exec cucumber features/admins/users/admin_abuse_users.feature:34
```
