### PR TITLE
AO3-6409 Make Mail::SMTP respect the enable_starttls_auto option even when it's false.

### DIFF
--- a/config/initializers/monkeypatches/mail_disable_starttls.rb
+++ b/config/initializers/monkeypatches/mail_disable_starttls.rb
@@ -1,0 +1,19 @@
+# from https://github.com/rails/rails/issues/44698#issuecomment-1069675285
+
+module MailDisableStarttls
+  def build_smtp_session
+    super.tap do |smtp|
+      unless settings[:enable_starttls_auto]
+        if smtp.respond_to?(:disable_starttls)
+          smtp.disable_starttls
+        end
+      end
+    end
+  end
+end
+
+if Mail::VERSION::STRING == "2.7.1"
+  Mail::SMTP.prepend MailDisableStarttls
+else
+  puts "WARNING: The monkeypatch #{__FILE__} was written for version 2.7.1 of the mail gem, but you are running #{Mail::VERSION::STRING}. Please update or remove the monkeypatch."
+end


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6409

## Purpose

Add a [monkeypatch](https://github.com/rails/rails/issues/44698#issuecomment-1069675285) to try to make `mail` 2.7.1 compatible with `net-smtp` 0.3.1  by calling `disable_starttls` when the `enable_starttls_auto` setting is set to false.

## Testing Instructions

Do something on staging that causes mail to be sent.

## Credit

h/t @redsummernight 