### PR TITLE
AO3-6428 Fix downloads and attachments of works with no posted chapters

### DIFF
--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -342,7 +342,7 @@ class UserMailer < ApplicationMailer
   def delete_work_notification(user, work)
     @user = user
     @work = work
-    download = Download.new(@work, mime_type: "text/html")
+    download = Download.new(@work, mime_type: "text/html", include_draft_chapters: true)
     html = DownloadWriter.new(download).generate_html
     html = ::Mail::Encodings::Base64.encode(html)
     attachments["#{download.file_name}.html"] = { content: html, encoding: "base64" }
@@ -362,7 +362,7 @@ class UserMailer < ApplicationMailer
   def admin_deleted_work_notification(user, work)
     @user = user
     @work = work
-    download = Download.new(@work, mime_type: "text/html")
+    download = Download.new(@work, mime_type: "text/html", include_draft_chapters: true)
     html = DownloadWriter.new(download).generate_html
     html = ::Mail::Encodings::Base64.encode(html)
     attachments["#{download.file_name}.html"] = { content: html, encoding: "base64" }

--- a/app/models/download.rb
+++ b/app/models/download.rb
@@ -7,6 +7,7 @@ class Download
     # TODO: Our current version of the mime-types gem doesn't include azw3, but
     # the gem cannot be updated without updating rest-client
     @mime_type = @file_type == "azw3" ? "application/x-mobi8-ebook" : MIME::Types.type_for(@file_type).first
+    @include_draft_chapters = options[:include_draft_chapters]
   end
 
   def generate
@@ -115,7 +116,11 @@ class Download
   end
 
   def chapters
-    work.chapters.order('position ASC').where(posted: true)
+    if @include_draft_chapters
+      work.chapters.order('position ASC')
+    else
+      work.chapters.order('position ASC').where(posted: true)
+    end
   end
 
   private

--- a/app/views/downloads/show.html.erb
+++ b/app/views/downloads/show.html.erb
@@ -5,7 +5,8 @@
     <% for chapter in @chapters %>
       <%= render 'downloads/download_chapter.html', :chapter => chapter %>
     <% end %>
-  <% else %>
+  <% # Use elsif so we don't error when there are no chapters. %>
+  <% elsif @chapters.size == 1 %>
     <h2 class="toc-heading"><%= @work.title.html_safe %></h2>
     <div class="userstuff">
       <%=raw sanitize_field(@chapters.first, :content) %>

--- a/factories/chapters.rb
+++ b/factories/chapters.rb
@@ -17,6 +17,7 @@ FactoryBot.define do
     end
 
     trait :draft do
+      content { "Draft content!" }
       posted { false }
     end
   end

--- a/features/works/work_download.feature
+++ b/features/works/work_download.feature
@@ -120,6 +120,16 @@ Feature: Download a work
     And I follow "HTML"
   Then I should see "Chapter 2"
 
+  Scenario: Download of chaptered work without posted chapters does not include chapters
+
+  Given the work "Bazinga"
+    And a draft chapter is added to "Bazinga"
+    And I delete chapter 1 of "Bazinga"
+  When I view the work "Bazinga"
+    And I follow "HTML"
+  Then I should not see "Chapter 1"
+    And I should not see "Chapter 2"
+    And I should be able to download all versions of "Bazinga"
 
   Scenario: Download chaptered works
 

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -1095,18 +1095,11 @@ describe UserMailer do
 
     it_behaves_like "an email with a valid sender"
     it_behaves_like "a translated email"
+    it_behaves_like "an email with a deleted work attached"
 
     it "has the correct subject line" do
       subject = "[#{ArchiveConfig.APP_SHORT_NAME}] Your work has been deleted"
       expect(email).to have_subject(subject)
-    end
-  
-    it "has the correct attachments" do
-      expect(email.attachments.length).to eq(2)
-      expect(email.attachments).to contain_exactly(
-        an_object_having_attributes(filename: "#{work.title}.html"),
-        an_object_having_attributes(filename: "#{work.title}.txt")
-      )
     end
     
     context "HTML version" do
@@ -1123,6 +1116,20 @@ describe UserMailer do
         expect(email).to have_text_part_content("Your work \"#{work.title}\" was deleted at your request")
       end
     end
+
+    context "when work has posted and draft chapters" do
+      let!(:draft_chapter) { create(:chapter, :draft, work: work, position: 2) }
+
+      it_behaves_like "an email with a deleted work attached"
+    end
+
+    context "when work has only draft chapters" do
+      before do
+        work.chapters.first.update_column(:posted, false)
+      end
+
+      it_behaves_like "an email with a deleted work attached"
+    end
   end
 
   describe "admin_deleted_work_notification" do
@@ -1133,18 +1140,11 @@ describe UserMailer do
 
     it_behaves_like "an email with a valid sender"
     it_behaves_like "a translated email"
+    it_behaves_like "an email with a deleted work attached"
 
     it "has the correct subject line" do
       subject = "[#{ArchiveConfig.APP_SHORT_NAME}] Your work has been deleted by an admin"
       expect(email).to have_subject(subject)
-    end
-  
-    it "has the correct attachments" do
-      expect(email.attachments.length).to eq(2)
-      expect(email.attachments).to contain_exactly(
-        an_object_having_attributes(filename: "#{work.title}.html"),
-        an_object_having_attributes(filename: "#{work.title}.txt")
-      )
     end
     
     context "HTML version" do
@@ -1160,6 +1160,20 @@ describe UserMailer do
         expect(email).to have_text_part_content("Dear #{user.login},")
         expect(email).to have_text_part_content("Your work \"#{work.title}\" was deleted from the Archive by a site admin")
       end
+    end
+
+    context "when work has posted and draft chapters" do
+      let!(:draft_chapter) { create(:chapter, :draft, work: work, position: 2) }
+
+      it_behaves_like "an email with a deleted work attached"
+    end
+
+    context "when work has only draft chapters" do
+      before do
+        work.chapters.first.update_column(:posted, false)
+      end
+
+      it_behaves_like "an email with a deleted work attached"
     end
   end
 end

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -1095,11 +1095,18 @@ describe UserMailer do
 
     it_behaves_like "an email with a valid sender"
     it_behaves_like "a translated email"
-    it_behaves_like "an email with a deleted work attached"
 
     it "has the correct subject line" do
       subject = "[#{ArchiveConfig.APP_SHORT_NAME}] Your work has been deleted"
       expect(email).to have_subject(subject)
+    end
+
+    it "has the correct attachments" do
+      expect(email.attachments.length).to eq(2)
+      expect(email.attachments).to contain_exactly(
+        an_object_having_attributes(filename: "#{work.title}.html"),
+        an_object_having_attributes(filename: "#{work.title}.txt")
+      )
     end
     
     context "HTML version" do
@@ -1120,7 +1127,7 @@ describe UserMailer do
     context "when work has posted and draft chapters" do
       let!(:draft_chapter) { create(:chapter, :draft, work: work, position: 2) }
 
-      it_behaves_like "an email with a deleted work attached"
+      it_behaves_like "an email with a deleted work with draft chapters attached"
     end
 
     context "when work has only draft chapters" do
@@ -1128,7 +1135,7 @@ describe UserMailer do
         work.chapters.first.update_column(:posted, false)
       end
 
-      it_behaves_like "an email with a deleted work attached"
+      it_behaves_like "an email with a deleted work with draft chapters attached"
     end
   end
 
@@ -1140,11 +1147,18 @@ describe UserMailer do
 
     it_behaves_like "an email with a valid sender"
     it_behaves_like "a translated email"
-    it_behaves_like "an email with a deleted work attached"
 
     it "has the correct subject line" do
       subject = "[#{ArchiveConfig.APP_SHORT_NAME}] Your work has been deleted by an admin"
       expect(email).to have_subject(subject)
+    end
+
+    it "has the correct attachments" do
+      expect(email.attachments.length).to eq(2)
+      expect(email.attachments).to contain_exactly(
+        an_object_having_attributes(filename: "#{work.title}.html"),
+        an_object_having_attributes(filename: "#{work.title}.txt")
+      )
     end
     
     context "HTML version" do
@@ -1165,7 +1179,7 @@ describe UserMailer do
     context "when work has posted and draft chapters" do
       let!(:draft_chapter) { create(:chapter, :draft, work: work, position: 2) }
 
-      it_behaves_like "an email with a deleted work attached"
+      it_behaves_like "an email with a deleted work with draft chapters attached"
     end
 
     context "when work has only draft chapters" do
@@ -1173,7 +1187,7 @@ describe UserMailer do
         work.chapters.first.update_column(:posted, false)
       end
 
-      it_behaves_like "an email with a deleted work attached"
+      it_behaves_like "an email with a deleted work with draft chapters attached"
     end
   end
 end

--- a/spec/models/download_spec.rb
+++ b/spec/models/download_spec.rb
@@ -131,4 +131,30 @@ describe Download do
       end
     end
   end
+
+  describe "chapters" do
+    let(:work) { create(:work) }
+    let!(:draft_chapter) { create(:chapter, :draft, work: work, position: 2) }
+    let(:subject) { Download.new(work) }
+
+    it "includes only posted chapters by default" do
+      expect(subject.chapters).to eq([work.chapters.first])
+    end
+
+    context "when include_draft_chapters is true" do
+      let(:subject) { Download.new(work, include_draft_chapters: true) }
+
+      it "includes both posted and draft chapters" do
+        expect(subject.chapters).to eq([work.chapters.first, draft_chapter])
+      end
+    end
+
+    context "when include_draft_chapters is false" do
+      let(:subject) { Download.new(work, include_draft_chapters: false) }
+
+      it "includes only posted chapters" do
+        expect(subject.chapters).to eq([work.chapters.first])
+      end
+    end
+  end
 end

--- a/spec/support/shared_examples/mailer_shared_examples.rb
+++ b/spec/support/shared_examples/mailer_shared_examples.rb
@@ -38,3 +38,21 @@ shared_examples "it retries and fails on" do |error|
     end
   end
 end
+
+shared_examples "an email with a deleted work attached" do
+  it "has html and txt attachments" do
+    expect(email.attachments.length).to eq(2)
+    expect(email.attachments).to contain_exactly(
+      an_object_having_attributes(filename: "#{work.title}.html"),
+      an_object_having_attributes(filename: "#{work.title}.txt")
+    )
+  end
+
+  it "includes draft chapters in attachments" do
+    download = Download.new(work, mime_type: "text/html", include_draft_chapters: true)
+    html = DownloadWriter.new(download).generate_html
+    encoded_html = ::Mail::Encodings::Base64.encode(html)
+    expect(email.attachments["#{work.title}.html"].body.raw_source).to eq(encoded_html)
+    expect(email.attachments["#{work.title}.txt"].body.raw_source).to eq(encoded_html)
+  end
+end


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6428

## Purpose

Fixes 500 error when deleting or downloading a posted work with zero posted chapters, with the side effect of always including draft chapters in deleted work downloads.

## Testing Instructions

Refer to Jira.

## Credit

Sarken, she/her