### PR TITLE
AO3-6453 Monkey patch Akismetor for Ruby 3

### DIFF
--- a/config/initializers/monkeypatches/akismetor.rb
+++ b/config/initializers/monkeypatches/akismetor.rb
@@ -1,0 +1,10 @@
+# Patch Akismetor, which is not Ruby 3 compatible, as it uses URI.escape:
+# https://github.com/freerobby/akismetor/blob/1cef6c0e237dd69b3f6ae1ee8d719c0862cd77e4/lib/akismetor.rb#L53-L56
+#
+# TODO: Migrate away from this library and handle the API calls ourselves.
+
+class Akismetor
+  def attributes_for_post
+    URI.encode_www_form(attributes)
+  end
+end

--- a/config/initializers/monkeypatches/akismetor.rb
+++ b/config/initializers/monkeypatches/akismetor.rb
@@ -1,7 +1,7 @@
 # Patch Akismetor, which is not Ruby 3 compatible, as it uses URI.escape:
 # https://github.com/freerobby/akismetor/blob/1cef6c0e237dd69b3f6ae1ee8d719c0862cd77e4/lib/akismetor.rb#L53-L56
 #
-# TODO: Migrate away from this library and handle the API calls ourselves.
+# TODO: AO3-6454 Remove this gem and handle the API calls ourselves.
 
 class Akismetor
   def attributes_for_post


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6453

## Purpose

The library uses the [removed method `URI.escape`](https://github.com/ruby/uri/issues/14).

## Testing Instructions

See issue.