### PR TITLE
AO3-6452 Sort to reduce deadlocks in the hit count code.

### DIFF
--- a/app/models/redis_hit_counter.rb
+++ b/app/models/redis_hit_counter.rb
@@ -67,7 +67,7 @@ class RedisHitCounter
     # appropriate StatCounter.
     def save_batch_hit_counts(batch)
       StatCounter.transaction do
-        batch.each do |work_id, value|
+        batch.sort.each do |work_id, value|
           work = Work.find_by(id: work_id)
           stat_counter = StatCounter.lock.find_by(work_id: work_id)
 


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6452

## Purpose

Adds a call to `sort` in the hit counter code, so that stat counters will always be locked in a consistent order. This should prevent issues that arise when one worker has a lock on stat counter 1 and wants a lock on stat counter 2, while another worker has a lock on stat counter 2 and wants a lock on stat counter 1.