### PR TITLE
AO3-6456 AO3-6438 Add missing primary keys and exclude innodb_monitor from schema dumps 

### DIFF
--- a/config/initializers/active_record_schema_ignore_tables.rb
+++ b/config/initializers/active_record_schema_ignore_tables.rb
@@ -1,0 +1,4 @@
+ActiveRecord::SchemaDumper.ignore_tables += [
+  # MySQL/MariaDB internals
+  "innodb_monitor"
+]

--- a/db/migrate/20230113225105_add_primary_key_to_roles_users.rb
+++ b/db/migrate/20230113225105_add_primary_key_to_roles_users.rb
@@ -1,0 +1,5 @@
+class AddPrimaryKeyToRolesUsers < ActiveRecord::Migration[6.0]
+  def change
+    add_column :roles_users, :id, :primary_key
+  end
+end

--- a/db/migrate/20230113225128_add_primary_key_to_schema_migrations.rb
+++ b/db/migrate/20230113225128_add_primary_key_to_schema_migrations.rb
@@ -1,0 +1,19 @@
+class AddPrimaryKeyToSchemaMigrations < ActiveRecord::Migration[6.0]
+  # By default Rails 6 creates the schema_migrations table with its column
+  # "version" as the primary key, but we're missing that in staging and
+  # production.
+  #
+  # Recently created development or test databases (e.g. via Docker) are
+  # not affected.
+  def up
+    if Rails.env.staging? || Rails.env.production?
+      execute "ALTER TABLE schema_migrations ADD PRIMARY KEY (version);"
+    end
+  end
+
+  def down
+    if Rails.env.staging? || Rails.env.production?
+      execute "ALTER TABLE schema_migrations DROP PRIMARY KEY;"
+    end
+  end
+end

--- a/db/migrate/20230113225128_add_primary_key_to_schema_migrations.rb
+++ b/db/migrate/20230113225128_add_primary_key_to_schema_migrations.rb
@@ -6,14 +6,14 @@ class AddPrimaryKeyToSchemaMigrations < ActiveRecord::Migration[6.0]
   # Recently created development or test databases (e.g. via Docker) are
   # not affected.
   def up
-    if Rails.env.staging? || Rails.env.production?
-      execute "ALTER TABLE schema_migrations ADD PRIMARY KEY (version);"
-    end
+    return unless Rails.env.staging? || Rails.env.production?
+
+    execute "ALTER TABLE schema_migrations ADD PRIMARY KEY (version);"
   end
 
   def down
-    if Rails.env.staging? || Rails.env.production?
-      execute "ALTER TABLE schema_migrations DROP PRIMARY KEY;"
-    end
+    return unless Rails.env.staging? || Rails.env.production?
+
+    execute "ALTER TABLE schema_migrations DROP PRIMARY KEY;"
   end
 end


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6456
https://otwarchive.atlassian.net/browse/AO3-6438

## Purpose

Add missing primary keys to:

- `roles_users` (no primary keys in any environment)
  https://github.com/otwcode/otwarchive/blob/17384eb5024f0658c3f307b451096e2d2301b7ba/db/schema.rb#L985

- `schema_migrations` (no primary keys but only in staging/production; Rails [sets column "version" as the primary key](https://github.com/rails/rails/blob/c7b76db7784151c4b47c22e5b234fb2b4c16021f/activerecord/lib/active_record/schema_migration.rb#L38-L40) these days)

Also exclude [`innodb_monitor`](https://mariadb.com/kb/en/xtradb-innodb-monitors/) from schema.rb dumps.

## Testing Instructions

Migrate up/down/up on staging.