### PR TITLE
AO3-6457 Improve the scalability of the StatCounter job.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -57,6 +57,9 @@ Metrics/MethodLength:
 Metrics/ModuleLength:
   Enabled: false
 
+Metrics/ParameterLists:
+  CountKeywordArgs: false
+
 Metrics/PerceivedComplexity:
   Enabled: false
 

--- a/app/jobs/redis_set_job.rb
+++ b/app/jobs/redis_set_job.rb
@@ -1,37 +1,54 @@
+# An abstract class designed to make it easier to queue up jobs with a Redis
+# set, then split those jobs into chunks to process them.
 class RedisSetJob < ApplicationJob
-  extend RedisScanning
+  include RedisScanning
 
+  # The redis server used for this job.
   def self.redis
     REDIS_GENERAL
   end
 
+  # The default key for the Redis set that we want to process. Used by the
+  # RedisSetJobSpawner.
   def self.base_key
     raise "Must be implemented in subclass!"
   end
 
-  def self.batch_size
+  # The number of items we'd like to have in a single job. Used by the
+  # RedisSetJobSpawner.
+  def self.job_size
     1000
   end
 
-  def perform(key)
-    batch = redis.smembers(key)
-    perform_on_batch(batch)
-    redis.srem(key, batch)
+  # The number of items to process in a single call to perform_on_batch. This
+  # should be smaller than job_size, otherwise it'll just use job_size for the
+  # batch size.
+  def self.batch_size
+    100
   end
 
-  def perform_on_batch(batch)
-    raise "Must be implemented in subclass!"
-  end
-
-  def self.split_jobs(key: base_key)
+  def perform(*args, **kwargs)
+    # Use sscan to iterate through the objects for this job:
     scan_set_in_batches(redis, key, batch_size: batch_size) do |batch|
-      batch_id = redis.incr("batch:#{base_key}:batch_id")
-      batch_key = "batch:#{base_key}:#{batch_id}"
-      redis.sadd(batch_key, batch)
-      perform_later(batch_key)
+      perform_on_batch(batch, *args, **kwargs)
       redis.srem(key, batch)
     end
   end
 
-  delegate :redis, to: :class
+  # This is where the real work happens:
+  def perform_on_batch(*)
+    raise "Must be implemented in subclass!"
+  end
+
+  # The Redis key used to store the objects that this job needs to process:
+  def key
+    @key ||= "job:#{self.class.name.underscore}:batch:#{job_id}"
+  end
+
+  # Add items to be processed when this job runs:
+  def add_to_job(batch)
+    redis.sadd(key, batch)
+  end
+
+  delegate :redis, :job_size, :batch_size, to: :class
 end

--- a/app/jobs/redis_set_job.rb
+++ b/app/jobs/redis_set_job.rb
@@ -1,0 +1,37 @@
+class RedisSetJob < ApplicationJob
+  extend RedisScanning
+
+  def self.redis
+    REDIS_GENERAL
+  end
+
+  def self.base_key
+    raise "Must be implemented in subclass!"
+  end
+
+  def self.batch_size
+    1000
+  end
+
+  def perform(key)
+    batch = redis.smembers(key)
+    perform_on_batch(batch)
+    redis.srem(key, batch)
+  end
+
+  def perform_on_batch(batch)
+    raise "Must be implemented in subclass!"
+  end
+
+  def self.split_jobs(key: base_key)
+    scan_set_in_batches(redis, key, batch_size: batch_size) do |batch|
+      batch_id = redis.incr("batch:#{base_key}:batch_id")
+      batch_key = "batch:#{base_key}:#{batch_id}"
+      redis.sadd(batch_key, batch)
+      perform_later(batch_key)
+      redis.srem(key, batch)
+    end
+  end
+
+  delegate :redis, to: :class
+end

--- a/app/jobs/redis_set_job_spawner.rb
+++ b/app/jobs/redis_set_job_spawner.rb
@@ -1,0 +1,34 @@
+# An ActiveJob designed to spawn a bunch of subclasses of RedisSetJob, using
+# the contents of a Redis set to generate the jobs.
+class RedisSetJobSpawner < ApplicationJob
+  include RedisScanning
+
+  def perform(job_name, *args, key: nil, redis: nil, job_size: nil, **kwargs)
+    job_class = job_name.constantize
+
+    # Read settings from the job class:
+    redis ||= job_class.redis
+    job_size ||= job_class.job_size
+    key ||= job_class.base_key
+
+    # Bail out early if there's nothing to process:
+    return if redis.scard(key).zero?
+
+    # Rename the job to a unique name to avoid conflicts when this is called
+    # multiple times in a short period:
+    spawn_id = redis.incr("job:#{job_name.underscore}:spawn:id")
+    spawn_key = "job:#{job_name.underscore}:spawn:#{spawn_id}"
+    redis.rename(key, spawn_key)
+
+    # Use sscan to iterate through the set, because it may be large:
+    scan_set_in_batches(redis, spawn_key, batch_size: job_size) do |batch|
+      # Create a new job, add the objects to it, and enqueue:
+      job = job_class.new(*args, **kwargs)
+      job.add_to_job(batch)
+      job.enqueue
+
+      # Then, once everything is safely enqueued, remove it from the set:
+      redis.srem(spawn_key, batch)
+    end
+  end
+end

--- a/app/jobs/stat_counter_job.rb
+++ b/app/jobs/stat_counter_job.rb
@@ -1,8 +1,12 @@
 class StatCounterJob < RedisSetJob
-  queue_as ArchiveConfig.STAT_COUNTER_QUEUE_NAME.to_sym
+  queue_as :stats
 
   def self.base_key
     "works_to_update_stats"
+  end
+
+  def self.job_size
+    ArchiveConfig.STAT_COUNTER_JOB_SIZE
   end
 
   def self.batch_size

--- a/app/jobs/stat_counter_job.rb
+++ b/app/jobs/stat_counter_job.rb
@@ -1,0 +1,15 @@
+class StatCounterJob < RedisSetJob
+  queue_as ArchiveConfig.STAT_COUNTER_QUEUE_NAME.to_sym
+
+  def self.base_key
+    "works_to_update_stats"
+  end
+
+  def self.batch_size
+    ArchiveConfig.STAT_COUNTER_BATCH_SIZE
+  end
+
+  def perform_on_batch(work_ids)
+    Work.where(id: work_ids).find_each(&:update_stat_counter)
+  end
+end

--- a/app/models/stat_counter.rb
+++ b/app/models/stat_counter.rb
@@ -11,21 +11,4 @@ class StatCounter < ApplicationRecord
   def indexers
     [StatCounterIndexer]
   end
-
-  ###############################################
-  ##### MOVING DATA INTO THE DATABASE
-  ###############################################
-
-  # Update stat counters and search indexes for works with new kudos, comments, or bookmarks.
-  def self.stats_to_database
-    StatCounterJob.split_jobs
-  end
-
-  ####################
-  # SCHEDULED JOBS
-  ####################
-
-  def self.perform(method, *args)
-    send(method, *args)
-  end
 end

--- a/app/models/stat_counter.rb
+++ b/app/models/stat_counter.rb
@@ -1,6 +1,4 @@
 class StatCounter < ApplicationRecord
-  extend RedisScanning
-
   belongs_to :work
 
   after_commit :enqueue_to_index, on: :update
@@ -18,31 +16,16 @@ class StatCounter < ApplicationRecord
   ##### MOVING DATA INTO THE DATABASE
   ###############################################
 
-  def self.batch_size
-    ArchiveConfig.STAT_COUNTER_BATCH_SIZE
-  end
-
-  def self.stats_at_key_to_database(key)
-    work_ids = REDIS_GENERAL.smembers(key)
-    Work.where(id: work_ids).find_each(&:update_stat_counter)
-    REDIS_GENERAL.srem(key, work_ids)
-  end
-
   # Update stat counters and search indexes for works with new kudos, comments, or bookmarks.
   def self.stats_to_database
-    scan_set_in_batches(REDIS_GENERAL, "works_to_update_stats", batch_size: batch_size) do |batch|
-      id = REDIS_GENERAL.incr("stat_counter:job_id")
-      key = "stat_counter:job:#{id}"
-      REDIS_GENERAL.sadd(key, batch)
-      async(:stats_at_key_to_database, key)
-      REDIS_GENERAL.srem("works_to_update_stats", batch)
-    end
+    StatCounterJob.split_jobs
   end
 
   ####################
   # SCHEDULED JOBS
   ####################
 
-  include AsyncWithResque
-  @queue = ArchiveConfig.STAT_COUNTER_QUEUE_NAME.to_sym
+  def self.perform(method, *args)
+    send(method, *args)
+  end
 end

--- a/config/config.yml
+++ b/config/config.yml
@@ -477,3 +477,10 @@ PERMITTED_HOSTS: [
 USER_RENAME_LIMIT_DAYS: 7
 
 READING_BATCHSIZE: 1000
+
+# The number of works to fetch from the database in one query when updating stat counters:
+STAT_COUNTER_BATCH_SIZE: 1000
+
+# The Resque queue to use for stat counter updates. Change this to a different
+# queue if you want to throttle it differently than normal utilities jobs:
+STAT_COUNTER_QUEUE_NAME: utilities

--- a/config/config.yml
+++ b/config/config.yml
@@ -478,9 +478,8 @@ USER_RENAME_LIMIT_DAYS: 7
 
 READING_BATCHSIZE: 1000
 
-# The number of works to fetch from the database in one query when updating stat counters:
-STAT_COUNTER_BATCH_SIZE: 1000
+# The number of work IDs to include in a single StatCounterJob:
+STAT_COUNTER_JOB_SIZE: 1000
 
-# The Resque queue to use for stat counter updates. Change this to a different
-# queue if you want to throttle it differently than normal utilities jobs:
-STAT_COUNTER_QUEUE_NAME: utilities
+# The number of works to fetch from the database in one query when updating stat counters:
+STAT_COUNTER_BATCH_SIZE: 100

--- a/config/resque_schedule.yml
+++ b/config/resque_schedule.yml
@@ -48,11 +48,15 @@ run_update_filter_counts_large:
   args: update_counts_for_large_queue
   description: "Update filter counts for large filters"
 
+# from https://github.com/resque/resque-scheduler/issues/613#issuecomment-351484064
 update_stat_counters:
   cron: "0,30 * * * *"
-  class: "StatCounter"
-  queue: utilities
-  args: stats_to_database
+  class: ActiveJob::QueueAdapters::ResqueAdapter::JobWrapper
+  queue: stats
+  args:
+    job_class: RedisSetJobSpawner
+    queue_name: stats
+    arguments: ["StatCounterJob"]
   description: "Update kudos/bookmark/comment counts on StatCounters."
 
 save_recent_counts_to_database:

--- a/features/step_definitions/work_steps.rb
+++ b/features/step_definitions/work_steps.rb
@@ -598,7 +598,7 @@ When /^I post the work$/ do
 end
 
 When /^the statistics for all works are updated$/ do
-  StatCounter.stats_to_database
+  RedisSetJobSpawner.perform_now("StatCounterJob")
   step %{the hit counts for all works are updated}
 end
 

--- a/lib/redis_scanning.rb
+++ b/lib/redis_scanning.rb
@@ -1,0 +1,11 @@
+module RedisScanning
+  def scan_set_in_batches(redis, key, batch_size:)
+    cursor = "0"
+
+    loop do
+      cursor, batch = redis.sscan(key, cursor, count: batch_size)
+      yield batch unless batch.empty?
+      break if cursor == "0"
+    end
+  end
+end


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6457

## Purpose

1. Introduce a library to make it easier to scan through redis sets in batches, and modify the existing `ReadingsToDatabaseJob` to use it.
2. Create a new abstract job class `RedisSetJob` with a linked job `RedisSetJobSpawner` that's designed around breaking Redis sets down into smaller batches, and then running one job per batch. This new system should be easy to extend to [tag counts](https://github.com/otwcode/otwarchive/commit/1556ede32fc7f2e1e97394e8d51ab0e677b8454f) and [readings](https://github.com/otwcode/otwarchive/commit/8691fea11e5dc1f1f5409693f16c213a1414fa14).
3. Create a `StatCounterJob` class extending the `RedisSetJob` class that calls `update_stat_counter` for all works with IDs in the `works_to_update_stats` set.