### PR TITLE
AO3-6458 Use new batch code for tag count updates to try to address LockWaitTimeout errors.

### DIFF
--- a/app/jobs/tag_count_update_job.rb
+++ b/app/jobs/tag_count_update_job.rb
@@ -20,7 +20,7 @@ class TagCountUpdateJob < RedisSetJob
     Tag.transaction do
       tag_ids.each do |id|
         value = REDIS_GENERAL.get("tag_update_#{id}_value")
-        Tag.where(id: id).update_all(taggings_count_cache: value) unless value.blank?
+        Tag.where(id: id).update_all(taggings_count_cache: value) if value.present?
       end
     end
   end

--- a/app/jobs/tag_count_update_job.rb
+++ b/app/jobs/tag_count_update_job.rb
@@ -1,0 +1,27 @@
+class TagCountUpdateJob < RedisSetJob
+  queue_as :utilities
+
+  retry_on ActiveRecord::Deadlocked, attempts: 10
+  retry_on ActiveRecord::LockWaitTimeout, attempts: 10
+
+  def self.base_key
+    "tag_update"
+  end
+
+  def self.job_size
+    ArchiveConfig.TAG_UPDATE_JOB_SIZE
+  end
+
+  def self.batch_size
+    ArchiveConfig.TAG_UPDATE_BATCH_SIZE
+  end
+
+  def perform_on_batch(tag_ids)
+    Tag.transaction do
+      tag_ids.each do |id|
+        value = REDIS_GENERAL.get("tag_update_#{id}_value")
+        Tag.where(id: id).update_all(taggings_count_cache: value) unless value.blank?
+      end
+    end
+  end
+end

--- a/app/jobs/tag_count_update_job.rb
+++ b/app/jobs/tag_count_update_job.rb
@@ -1,5 +1,5 @@
 class TagCountUpdateJob < RedisSetJob
-  queue_as :utilities
+  queue_as :tag_counts
 
   retry_on ActiveRecord::Deadlocked, attempts: 10
   retry_on ActiveRecord::LockWaitTimeout, attempts: 10

--- a/app/models/scheduled_tag_job.rb
+++ b/app/models/scheduled_tag_job.rb
@@ -5,8 +5,6 @@ class ScheduledTagJob
       Tag.where("taggings_count_cache > ?", 40 * (ArchiveConfig.TAGGINGS_COUNT_CACHE_DIVISOR || 1500)).each do |tag|
         tag.async(:update_counts_cache, tag.id)
       end
-    when 'write_redis_to_database'
-      Tag.write_redis_to_database
     end
   end
 end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -34,21 +34,6 @@ class Tag < ApplicationRecord
     TagIndexer.new({}).document(self)
   end
 
-  def self.write_redis_to_database
-    batch_size = ArchiveConfig.TAG_UPDATE_BATCH_SIZE
-    REDIS_GENERAL.smembers("tag_update").each_slice(batch_size) do |batch|
-      Tag.transaction do
-        batch.each do |id|
-          value = REDIS_GENERAL.get("tag_update_#{id}_value")
-          sql = []
-          sql.push("taggings_count_cache = #{value}") unless value.blank?
-          Tag.where(id: id).update_all(sql.join(",")) unless sql.empty?
-        end
-        REDIS_GENERAL.srem("tag_update", batch)
-      end
-    end
-  end
-
   def self.taggings_count_expiry(count)
     # What we are trying to do here is work out a resonable amount of time for a work to be cached for
     # This should take the number of taggings and divide it by TAGGINGS_COUNT_CACHE_DIVISOR  ( defaults to 1500 )

--- a/config/config.yml
+++ b/config/config.yml
@@ -181,7 +181,10 @@ RATE_LIMIT_SAFELIST: ["127.0.0.0/8", "10.0.0.0/8"]
 # The number of tags to show on the search page:
 TAGS_PER_SEARCH_PAGE: 50
 
-# When updating tag counts, how many to do in one transaction
+# When updating tag counts, how many to do in one TagCountUpdateJob:
+TAG_UPDATE_JOB_SIZE: 1000
+
+# When updating tag counts, how many to do in one transaction:
 TAG_UPDATE_BATCH_SIZE: 100
 
 # We only start caching tag counts for tags used more than a certain number of times

--- a/config/resque_schedule.yml
+++ b/config/resque_schedule.yml
@@ -23,10 +23,10 @@ run_add_counts_to_queue:
 run_write_redis_to_database:
   every: 2m
   class: ActiveJob::QueueAdapters::ResqueAdapter::JobWrapper
-  queue: utilities
+  queue: tag_counts
   args:
     job_class: RedisSetJobSpawner
-    queue_name: utilities
+    queue_name: tag_counts
     arguments: ["TagCountUpdateJob"]
   description: "Flush the count updates to mysql"
 

--- a/config/resque_schedule.yml
+++ b/config/resque_schedule.yml
@@ -19,13 +19,16 @@ run_add_counts_to_queue:
   args: add_counts_to_queue
   description: "update the cache of counts of usage for tags"
 
+# from https://github.com/resque/resque-scheduler/issues/613#issuecomment-351484064
 run_write_redis_to_database:
   every: 2m
-  class: "ScheduledTagJob"
+  class: ActiveJob::QueueAdapters::ResqueAdapter::JobWrapper
   queue: utilities
-  args: write_redis_to_database
+  args:
+    job_class: RedisSetJobSpawner
+    queue_name: utilities
+    arguments: ["TagCountUpdateJob"]
   description: "Flush the count updates to mysql"
-
 
 run_stats_reindex_queue:
   every: 30m

--- a/features/step_definitions/series_steps.rb
+++ b/features/step_definitions/series_steps.rb
@@ -45,7 +45,7 @@ When /^I add the work "([^\"]*)" to "(\d+)" series "([^\"]*)"$/ do |work_title, 
     click_button("Post")
     step "I should see \"Work was successfully posted.\""
     step %{all indexing jobs have been run}
-    Tag.write_redis_to_database
+    RedisSetJobSpawner.perform_now("TagCountUpdateJob")
   end
 
   count.to_i.times do |i|

--- a/features/step_definitions/series_steps.rb
+++ b/features/step_definitions/series_steps.rb
@@ -45,7 +45,7 @@ When /^I add the work "([^\"]*)" to "(\d+)" series "([^\"]*)"$/ do |work_title, 
     click_button("Post")
     step "I should see \"Work was successfully posted.\""
     step %{all indexing jobs have been run}
-    RedisSetJobSpawner.perform_now("TagCountUpdateJob")
+    step "the periodic tag count task is run"
   end
 
   count.to_i.times do |i|

--- a/features/step_definitions/tag_steps.rb
+++ b/features/step_definitions/tag_steps.rb
@@ -206,7 +206,7 @@ end
 ### WHEN
 
 When /^the periodic tag count task is run$/i do
-  Tag.write_redis_to_database
+  RedisSetJobSpawner.perform_now("TagCountUpdateJob")
 end
 
 When /^the periodic filter count task is run$/i do

--- a/features/step_definitions/work_steps.rb
+++ b/features/step_definitions/work_steps.rb
@@ -87,7 +87,7 @@ When /^I post (?:a|the) (?:(\d+) chapter )?work "([^"]*)"(?: with fandom "([^"]*
     end
   end
   step %{all indexing jobs have been run}
-  Tag.write_redis_to_database
+  RedisSetJobSpawner.perform_now("TagCountUpdateJob")
   step %(the periodic filter count task is run)
 end
 
@@ -302,7 +302,7 @@ When /^I post the chaptered work "([^"]*)"$/ do |title|
   click_button("Preview")
   step %{I press "Post"}
   step %{all indexing jobs have been run}
-  Tag.write_redis_to_database
+  RedisSetJobSpawner.perform_now("TagCountUpdateJob")
 end
 
 When /^I post the chaptered draft "([^"]*)"$/ do |title|
@@ -319,7 +319,7 @@ When /^a chapter is added to "([^"]*)"$/ do |work_title|
   step %{a draft chapter is added to "#{work_title}"}
   click_button("Post")
   step %{all indexing jobs have been run}
-  Tag.write_redis_to_database
+  RedisSetJobSpawner.perform_now("TagCountUpdateJob")
 end
 
 When /^a chapter with the co-author "([^\"]*)" is added to "([^\"]*)"$/ do |coauthor, work_title|
@@ -328,7 +328,7 @@ When /^a chapter with the co-author "([^\"]*)" is added to "([^\"]*)"$/ do |coau
   click_button("Post")
   step %{the user "#{coauthor}" accepts all co-creator requests}
   step %{all indexing jobs have been run}
-  Tag.write_redis_to_database
+  RedisSetJobSpawner.perform_now("TagCountUpdateJob")
 end
 
 When /^a draft chapter is added to "([^"]*)"$/ do |work_title|
@@ -336,7 +336,7 @@ When /^a draft chapter is added to "([^"]*)"$/ do |work_title|
   step %{I press "Preview"}
   step %{all indexing jobs have been run}
 
-  Tag.write_redis_to_database
+  RedisSetJobSpawner.perform_now("TagCountUpdateJob")
 end
 
 When /^I delete chapter ([\d]+) of "([^"]*)"$/ do |chapter, title|
@@ -370,7 +370,7 @@ When /^I post the(?: draft)? chapter$/ do
   click_button("Post")
   step %{all indexing jobs have been run}
 
-  Tag.write_redis_to_database
+  RedisSetJobSpawner.perform_now("TagCountUpdateJob")
 end
 
 Then /^I should see the default work content$/ do
@@ -466,7 +466,7 @@ When /^the work "([^"]*)" was created (\d+) days ago$/ do |title, number|
   work.update_attribute(:created_at, number.to_i.days.ago)
   step %{all indexing jobs have been run}
 
-  Tag.write_redis_to_database
+  RedisSetJobSpawner.perform_now("TagCountUpdateJob")
 end
 
 When /^I post the locked work "([^"]*)"$/ do |title|
@@ -479,7 +479,7 @@ When /^I post the locked work "([^"]*)"$/ do |title|
   click_button("Post")
   step %{all indexing jobs have been run}
 
-  Tag.write_redis_to_database
+  RedisSetJobSpawner.perform_now("TagCountUpdateJob")
 end
 
 When /^the locked draft "([^"]*)"$/ do |title|
@@ -553,7 +553,7 @@ When /^I browse the "(.*?)" works$/ do |tagname|
   visit tag_works_path(tag)
   step %{all indexing jobs have been run}
 
-  Tag.write_redis_to_database
+  RedisSetJobSpawner.perform_now("TagCountUpdateJob")
 end
 
 When /^I browse the "(.*?)" works with page parameter "(.*?)"$/ do |tagname, page|
@@ -561,7 +561,7 @@ When /^I browse the "(.*?)" works with page parameter "(.*?)"$/ do |tagname, pag
   visit tag_works_path(tag, page: page)
   step %{all indexing jobs have been run}
 
-  Tag.write_redis_to_database
+  RedisSetJobSpawner.perform_now("TagCountUpdateJob")
 end
 
 When /^I delete the work "([^"]*)"$/ do |work|
@@ -572,25 +572,25 @@ When /^I delete the work "([^"]*)"$/ do |work|
   click_button("Yes, Delete Work") unless @javascript
   step %{all indexing jobs have been run}
 
-  Tag.write_redis_to_database
+  RedisSetJobSpawner.perform_now("TagCountUpdateJob")
 end
 When /^I preview the work$/ do
   click_button("Preview")
   step %{all indexing jobs have been run}
 
-  Tag.write_redis_to_database
+  RedisSetJobSpawner.perform_now("TagCountUpdateJob")
 end
 When /^I update the work$/ do
   click_button("Update")
   step %{all indexing jobs have been run}
 
-  Tag.write_redis_to_database
+  RedisSetJobSpawner.perform_now("TagCountUpdateJob")
 end
 When /^I post the work without preview$/ do
   click_button "Post"
   step %{all indexing jobs have been run}
 
-  Tag.write_redis_to_database
+  RedisSetJobSpawner.perform_now("TagCountUpdateJob")
 end
 When /^I post the work$/ do
   click_button "Post"

--- a/features/step_definitions/work_steps.rb
+++ b/features/step_definitions/work_steps.rb
@@ -87,7 +87,7 @@ When /^I post (?:a|the) (?:(\d+) chapter )?work "([^"]*)"(?: with fandom "([^"]*
     end
   end
   step %{all indexing jobs have been run}
-  RedisSetJobSpawner.perform_now("TagCountUpdateJob")
+  step "the periodic tag count task is run"
   step %(the periodic filter count task is run)
 end
 
@@ -302,7 +302,7 @@ When /^I post the chaptered work "([^"]*)"$/ do |title|
   click_button("Preview")
   step %{I press "Post"}
   step %{all indexing jobs have been run}
-  RedisSetJobSpawner.perform_now("TagCountUpdateJob")
+  step "the periodic tag count task is run"
 end
 
 When /^I post the chaptered draft "([^"]*)"$/ do |title|
@@ -319,7 +319,7 @@ When /^a chapter is added to "([^"]*)"$/ do |work_title|
   step %{a draft chapter is added to "#{work_title}"}
   click_button("Post")
   step %{all indexing jobs have been run}
-  RedisSetJobSpawner.perform_now("TagCountUpdateJob")
+  step "the periodic tag count task is run"
 end
 
 When /^a chapter with the co-author "([^\"]*)" is added to "([^\"]*)"$/ do |coauthor, work_title|
@@ -328,7 +328,7 @@ When /^a chapter with the co-author "([^\"]*)" is added to "([^\"]*)"$/ do |coau
   click_button("Post")
   step %{the user "#{coauthor}" accepts all co-creator requests}
   step %{all indexing jobs have been run}
-  RedisSetJobSpawner.perform_now("TagCountUpdateJob")
+  step "the periodic tag count task is run"
 end
 
 When /^a draft chapter is added to "([^"]*)"$/ do |work_title|
@@ -336,7 +336,7 @@ When /^a draft chapter is added to "([^"]*)"$/ do |work_title|
   step %{I press "Preview"}
   step %{all indexing jobs have been run}
 
-  RedisSetJobSpawner.perform_now("TagCountUpdateJob")
+  step "the periodic tag count task is run"
 end
 
 When /^I delete chapter ([\d]+) of "([^"]*)"$/ do |chapter, title|
@@ -370,7 +370,7 @@ When /^I post the(?: draft)? chapter$/ do
   click_button("Post")
   step %{all indexing jobs have been run}
 
-  RedisSetJobSpawner.perform_now("TagCountUpdateJob")
+  step "the periodic tag count task is run"
 end
 
 Then /^I should see the default work content$/ do
@@ -466,7 +466,7 @@ When /^the work "([^"]*)" was created (\d+) days ago$/ do |title, number|
   work.update_attribute(:created_at, number.to_i.days.ago)
   step %{all indexing jobs have been run}
 
-  RedisSetJobSpawner.perform_now("TagCountUpdateJob")
+  step "the periodic tag count task is run"
 end
 
 When /^I post the locked work "([^"]*)"$/ do |title|
@@ -479,7 +479,7 @@ When /^I post the locked work "([^"]*)"$/ do |title|
   click_button("Post")
   step %{all indexing jobs have been run}
 
-  RedisSetJobSpawner.perform_now("TagCountUpdateJob")
+  step "the periodic tag count task is run"
 end
 
 When /^the locked draft "([^"]*)"$/ do |title|
@@ -553,7 +553,7 @@ When /^I browse the "(.*?)" works$/ do |tagname|
   visit tag_works_path(tag)
   step %{all indexing jobs have been run}
 
-  RedisSetJobSpawner.perform_now("TagCountUpdateJob")
+  step "the periodic tag count task is run"
 end
 
 When /^I browse the "(.*?)" works with page parameter "(.*?)"$/ do |tagname, page|
@@ -561,7 +561,7 @@ When /^I browse the "(.*?)" works with page parameter "(.*?)"$/ do |tagname, pag
   visit tag_works_path(tag, page: page)
   step %{all indexing jobs have been run}
 
-  RedisSetJobSpawner.perform_now("TagCountUpdateJob")
+  step "the periodic tag count task is run"
 end
 
 When /^I delete the work "([^"]*)"$/ do |work|
@@ -572,25 +572,25 @@ When /^I delete the work "([^"]*)"$/ do |work|
   click_button("Yes, Delete Work") unless @javascript
   step %{all indexing jobs have been run}
 
-  RedisSetJobSpawner.perform_now("TagCountUpdateJob")
+  step "the periodic tag count task is run"
 end
 When /^I preview the work$/ do
   click_button("Preview")
   step %{all indexing jobs have been run}
 
-  RedisSetJobSpawner.perform_now("TagCountUpdateJob")
+  step "the periodic tag count task is run"
 end
 When /^I update the work$/ do
   click_button("Update")
   step %{all indexing jobs have been run}
 
-  RedisSetJobSpawner.perform_now("TagCountUpdateJob")
+  step "the periodic tag count task is run"
 end
 When /^I post the work without preview$/ do
   click_button "Post"
   step %{all indexing jobs have been run}
 
-  RedisSetJobSpawner.perform_now("TagCountUpdateJob")
+  step "the periodic tag count task is run"
 end
 When /^I post the work$/ do
   click_button "Post"

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -43,7 +43,7 @@ describe Tag do
     context 'updating taggings_count_cache' do
       it 'should not cache tags which are not used much' do
         FactoryBot.create(:work, fandom_string: @fandom_tag.name)
-        Tag.write_redis_to_database
+        RedisSetJobSpawner.perform_now("TagCountUpdateJob")
         @fandom_tag.reload
         expect(@fandom_tag.taggings_count_cache).to eq 1
         expect(@fandom_tag.taggings_count).to eq 1
@@ -52,13 +52,13 @@ describe Tag do
       it 'will start caching a when tag when that tag is used significantly' do
         (1..ArchiveConfig.TAGGINGS_COUNT_MIN_CACHE_COUNT).each do |try|
           FactoryBot.create(:work, fandom_string: @fandom_tag.name)
-          Tag.write_redis_to_database
+          RedisSetJobSpawner.perform_now("TagCountUpdateJob")
           @fandom_tag.reload
           expect(@fandom_tag.taggings_count_cache).to eq try
           expect(@fandom_tag.taggings_count).to eq try
         end
         FactoryBot.create(:work, fandom_string: @fandom_tag.name)
-        Tag.write_redis_to_database
+        RedisSetJobSpawner.perform_now("TagCountUpdateJob")
         @fandom_tag.reload
         # This value should be cached and wrong
         expect(@fandom_tag.taggings_count_cache).to eq ArchiveConfig.TAGGINGS_COUNT_MIN_CACHE_COUNT
@@ -72,7 +72,7 @@ describe Tag do
           expect(@fandom_tag.taggings_count_cache).to eq 0
         end
         @fandom_tag.taggings_count = 40 * ArchiveConfig.TAGGINGS_COUNT_CACHE_DIVISOR
-        Tag.write_redis_to_database
+        RedisSetJobSpawner.perform_now("TagCountUpdateJob")
         @fandom_tag.reload
         expect(@fandom_tag.taggings_count_cache).to eq 40 * ArchiveConfig.TAGGINGS_COUNT_CACHE_DIVISOR
       end


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6458

## Purpose

Use the new `RedisSetJob` and `RedisSetJobSpawner`, introduced in #4433, to handle taggings count updates. Retries the job on deadlocks and on lock wait timeouts, so that hopefully the jobs will run more consistently.
