### PR TITLE
AO3-6462 Make scan_set_in_batches return more consistent batch sizes.

### DIFF
--- a/lib/redis_scanning.rb
+++ b/lib/redis_scanning.rb
@@ -1,11 +1,5 @@
 module RedisScanning
-  def scan_set_in_batches(redis, key, batch_size:)
-    cursor = "0"
-
-    loop do
-      cursor, batch = redis.sscan(key, cursor, count: batch_size)
-      yield batch unless batch.empty?
-      break if cursor == "0"
-    end
+  def scan_set_in_batches(redis, key, batch_size:, &block)
+    redis.sscan_each(key, count: batch_size).each_slice(batch_size, &block)
   end
 end


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6462

## Purpose

Make the `scan_set_in_batches` method use `each_slice` to make sure that the batch sizes are more consistent. This should (hopefully) make the transaction sizes more consistent when processing readings.