### PR TITLE
AO3-5356 Add lang attribute to language names

### DIFF
--- a/app/helpers/works_helper.rb
+++ b/app/helpers/works_helper.rb
@@ -57,7 +57,7 @@ module WorksHelper
 
   def language_link(work)
     if work.respond_to?(:language) && work.language
-      link_to work.language.name, work.language
+      link_to work.language.name, work.language, lang: work.language.short
     else
       "N/A"
     end

--- a/app/models/search/bookmark_search_form.rb
+++ b/app/models/search/bookmark_search_form.rb
@@ -107,7 +107,7 @@ class BookmarkSearchForm
     if self.language_id.present?
       language = Language.find_by(short: self.language_id)
       if language.present?
-        summary << "Work language: #{language.name}"
+        summary << "Work language: <span lang=#{language.short}>#{language.name}</span>"
       end
     end
     if %w(1 true).include?(self.rec.to_s)

--- a/app/models/search/work_search_form.rb
+++ b/app/models/search/work_search_form.rb
@@ -151,7 +151,7 @@ class WorkSearchForm
     if @options[:language_id].present?
       language = Language.find_by(short: @options[:language_id])
       if language.present?
-        summary << "Language: #{language.name}"
+        summary << "Language: <span lang=#{language.short}>#{language.name}</span>"
       end
     end
     [:word_count, :hits, :kudos_count, :comments_count, :bookmarks_count, :revised_at].each do |countable|

--- a/app/views/abuse_reports/new.html.erb
+++ b/app/views/abuse_reports/new.html.erb
@@ -21,7 +21,8 @@
     <li><%= t(".reportable.dmca.claim", dmca_link:
             (link_to t(".reportable.dmca.policy"), dmca_path)).html_safe %></li>
   </ul>
-  <p><%= t(".languages_html", list: @abuse_languages.map(&:name).to_sentence).html_safe %></p>
+  <p><%= t(".languages_html", list:
+         @abuse_languages.map { |language| tag.span(language.name, lang: language.short) }.to_sentence.html_safe).html_safe %></p>
 </div>
 <%= form_for @abuse_report, class: "post" do |f| %>
   <fieldset>
@@ -40,7 +41,8 @@
         <%= f.label :language, t(".form.language.label") %>
       </dt>
       <dd class="required">
-        <%= f.collection_select(:language, @abuse_languages, :name, :name, { selected: @abuse_report.language || Language.default.name }) %>
+        <%= f.select(:language, @abuse_languages.map { |language| [language.name, language.name, { lang: language.short }] },
+              { selected: @abuse_report.language || Language.default.name }) %>
       </dd>
       <dt class="required">
         <%= f.label :summary, t(".form.summary.label") %>

--- a/app/views/admin_posts/_admin_post.html.erb
+++ b/app/views/admin_posts/_admin_post.html.erb
@@ -17,7 +17,7 @@
       <dd class="translations">
         <ul class="languages commas">
           <% for translation in sorted_translations(admin_post) %>
-            <li><%= link_to translation.language.name, translation %></li>
+            <li><%= link_to translation.language.name, translation, lang: translation.language.short %></li>
           <% end %>
         </ul>
       </dd>

--- a/app/views/admin_posts/_admin_post_form.html.erb
+++ b/app/views/admin_posts/_admin_post_form.html.erb
@@ -51,7 +51,7 @@
         </dt>
         <dd>
           <select id="admin_post_language_id" name="admin_post[language_id]">
-            <%= options_from_collection_for_select(@news_languages, :id, :name, @admin_post.language_id || Language.default.id) %>
+            <%= options_for_select(@news_languages.map { |language| [language.name, language.id, { lang: language.short }] }, @admin_post.language_id || Language.default.id) %>
           </select>
         </dd>
         <dt>

--- a/app/views/admin_posts/_filters.html.erb
+++ b/app/views/admin_posts/_filters.html.erb
@@ -3,6 +3,6 @@
   <p><%= label_tag :tag, ts("Tag:") %>
   <%= select_tag :tag, ('<option></option>' + options_from_collection_for_select(@tags, :id, :name, params[:tag])).html_safe %>
   <%= label_tag :language_id, ts("Language:") %>
-  <%= select_tag :language_id, options_from_collection_for_select(@news_languages, :short, :name, params[:language_id] || Language.default.short) %>
+  <%= select_tag :language_id, options_for_select(@news_languages.map { |language| [language.name, language.short, { lang: language.short }] }, params[:language_id] || Language.default.short) %>
   <%= submit_tag ts('Go') %></p>
 <% end %>

--- a/app/views/archive_faqs/_filters.html.erb
+++ b/app/views/archive_faqs/_filters.html.erb
@@ -2,9 +2,9 @@
 <%= form_tag archive_faqs_path, :method => :get do %>
   <p><%= label_tag :language_id, ts("Language:") %>
     <% if User.current_user.is_a?(Admin) %>
-      <%= select_tag :language_id, ('<option></option>' + options_from_collection_for_select(Locale.default_order, :iso, :name, params[:language_id])).html_safe %>
+      <%= select_tag :language_id, ("<option></option>" + options_for_select(Locale.default_order.map { |locale| [locale.name, locale.iso, { lang: locale.language.short }] }, params[:language_id])).html_safe %>
     <% else %>
-      <%= select_tag :language_id, ('<option></option>' + options_from_collection_for_select(available_faq_locales, :iso, :name, params[:language_id])).html_safe %>
+      <%= select_tag :language_id, ("<option></option>" + options_for_select(available_faq_locales.map { |locale| [locale.name, locale.iso, { lang: locale.language.short }] }, params[:language_id])).html_safe %>
     <% end %>
   <%= submit_tag ts('Go') %></p>
 <% end %>

--- a/app/views/bookmarks/_filters.html.erb
+++ b/app/views/bookmarks/_filters.html.erb
@@ -105,7 +105,7 @@
             <%= f.label :language_id, ts("Work language") %>
           </dt>
           <dd class="language">
-            <%= f.collection_select(:language_id, Language.default_order, :short, :name, include_blank: true) %>
+            <%= f.select(:language_id, Language.default_order.map { |language| [language.name, language.short, { lang: language.short }] }, include_blank: true) %>
           </dd>
 
           <dt class="options"><%= ts("Bookmark types") %></dt>

--- a/app/views/bookmarks/_search_form.html.erb
+++ b/app/views/bookmarks/_search_form.html.erb
@@ -31,7 +31,7 @@
         <%= f.label :language_id, ts("Work language") %>
       </dt>
       <dd>
-        <%= f.collection_select :language_id, @languages, :short, :name, include_blank: true %>
+        <%= f.select(:language_id, @languages.map { |language| [language.name, language.short, { lang: language.short }] }, include_blank: true) %>
       </dd>
       <dt>
         <%= f.label :bookmarkable_date, ts("Date updated") %>

--- a/app/views/bookmarks/search_results.html.erb
+++ b/app/views/bookmarks/search_results.html.erb
@@ -3,7 +3,7 @@
 
 <h4 class="heading">
   <%= ts("You searched for:") %>
-  <%= (strip_tags @search.summary).html_safe %>
+  <%= (sanitize @search.summary, tags: %w[span], attributes: %w[lang]).html_safe %>
 </h4>
 <!--/descriptions-->
 

--- a/app/views/external_works/_blurb.html.erb
+++ b/app/views/external_works/_blurb.html.erb
@@ -39,7 +39,7 @@
   <dl class="stats">
     <% unless external_work.language.blank? %>
     <dt class="language"><%= ts("Language:") %></dt>
-    <dd class="language"><%= external_work.language.name %></dd>
+    <dd class="language" lang="<%= external_work.language.short %>"><%= external_work.language.name %></dd>
     <% end %>
     <% if Bookmark.count_visible_bookmarks(external_work) > 0 %>
     <dt><%= ts("Bookmarks") + ": " %></dt>

--- a/app/views/external_works/_work_module.html.erb
+++ b/app/views/external_works/_work_module.html.erb
@@ -45,7 +45,7 @@
 <dl class="stats">
   <% unless external_work.language.blank? %>
     <dt class="language"><%= ts("Language:") %></dt>
-    <dd class="language"><%= external_work.language.name %></dd>
+    <dd class="language" lang="<%= external_work.language.short %>"><%= external_work.language.name %></dd>
   <% end %>
 
   <% if Bookmark.count_visible_bookmarks(external_work) > 0 %>

--- a/app/views/external_works/edit.html.erb
+++ b/app/views/external_works/edit.html.erb
@@ -34,7 +34,7 @@
         <%= link_to_help "languages-help" %>
       </dt>
       <dd>
-        <%= f.collection_select(:language_id, sorted_languages, :id, :name, prompt: " ") %>
+        <%= f.select(:language_id, sorted_languages.map { |language| [language.name, language.id, { lang: language.short }] }, prompt: " ") %>
       </dd>
       <dt>
         <%= f.label :summary, ts("Creator's Summary") %>

--- a/app/views/feedbacks/new.html.erb
+++ b/app/views/feedbacks/new.html.erb
@@ -37,7 +37,7 @@
       <li><%= t(".reportable.policy_questions") %></li>
     </ul>
     <p><%= t(".do_not_spam_html") %></p>
-    <p><%= t(".languages_html", list: @support_languages.map(&:name).to_sentence) %></p>
+    <p><%= t(".languages_html", list: @support_languages.map { |language| tag.span(language.name, lang: language.short) }.to_sentence.html_safe) %></p>
   </div>
   <%= form_for(@feedback, html: {class: "post feedback"}) do |f| %>
     <fieldset>
@@ -64,7 +64,8 @@
           <%= f.label :language, t(".form.language.label") %>
         </dt>
         <dd class="required">
-          <%= f.collection_select(:language, @support_languages, :name, :name, { selected: @feedback.language || Language.default.name }) %>
+          <%= f.select(:language, @support_languages.map { |language| [language.name, language.name, { lang: language.short }] },
+                { selected: @feedback.language || Language.default.name }) %>
         </dd>
         <dt class="required">
           <%= f.label :summary, t(".form.summary.label") %>

--- a/app/views/languages/index.html.erb
+++ b/app/views/languages/index.html.erb
@@ -17,12 +17,12 @@
   <% for language in @languages %>
 
     <% if language == Language.default %>
-      <dt><%= language.name %></dt>
+      <dt><span lang="<%= language.short %>"><%= language.name %></span></dt>
       <dd>
         <%= link_to ts("%{count} works", count: language.works.count), works_path %>
       </dd>
     <% else %>
-      <dt><%= link_to language.name, language %></dt>
+      <dt><%= link_to language.name, language, lang: language.short %></dt>
       <dd>
         <%= link_to ts("%{count} works", count: language.works.count), language_works_path(language) %>
         <% if logged_in_as_admin? %>

--- a/app/views/languages/show.html.erb
+++ b/app/views/languages/show.html.erb
@@ -1,4 +1,4 @@
-<h2 class="heading"><%= @language.name %></h2>
+<h2 class="heading" lang="<%= @language.short %>"><%= @language.name %></h2>
 
 <!--subnav-->
 <% if logged_in_as_admin? %>

--- a/app/views/locales/_locale_form.html.erb
+++ b/app/views/locales/_locale_form.html.erb
@@ -12,7 +12,7 @@
       <dd class="required"><%= f.text_field :iso %></dd>
 
       <dt class="required"><%= f.label :language_id, t('.language', :default => "Language") + '*' %></dt>
-      <dd class="required"><%= f.select(:language_id, @languages.collect { |language| [ language.name, language.id ] }) %></dd>
+      <dd class="required"><%= f.select(:language_id, @languages.collect { |language| [language.name, language.id, { lang: language.short }] }) %></dd>
 
       <dt><%= f.check_box :email_enabled %></dt>
       <dd><%= f.label :email_enabled, t('.enable_email', :default => "Use this locale to send email") %></dd>

--- a/app/views/locales/index.html.erb
+++ b/app/views/locales/index.html.erb
@@ -22,7 +22,7 @@
     <tbody>
       <% for locale in @locales %>
         <tr>
-          <th scope="row"><%= locale.name %></th>
+          <th scope="row" lang="<%= locale.language.short %>"><%= locale.name %></th>
           <td><%= locale.iso %></td>
           <td><%= locale.main %></td>
           <td><%= locale.email_enabled %></td>
@@ -38,7 +38,7 @@
 <% else %>
   <ul>
     <% for locale in @locales %>
-      <li><%= locale.name %></li>
+      <li lang="<%= locale.language.short %>"><%= locale.name %></li>
     <% end %>
   </ul>
   <p class="navigation actions" role="navigation">

--- a/app/views/preferences/index.html.erb
+++ b/app/views/preferences/index.html.erb
@@ -80,7 +80,8 @@
       <dd><%= f.time_zone_select :time_zone, nil, :default => Time.zone.name %></dd>
       <% if Rails.env.test? || Rails.env.development? || $rollout.active?(:set_locale_preference, @user) %>
         <dt><%= f.label :preferred_locale, ts('Your locale') %> <%= link_to_help 'locale-preferences' %></dt>
-        <dd><%= f.select :preferred_locale, @available_locales.collect{|locale| [locale.name, locale.id]}, :default => @preference.preferred_locale %></dd>
+        <dd><%= f.select :preferred_locale, @available_locales.collect { |locale| [locale.name, locale.id, { lang: locale.language.short }] },
+                  default: @preference.preferred_locale %></dd>
       <% end %>
       <dt><%= f.label :work_title_format, ts('Browser page title format') %> <%= link_to_help 'work_title_format' %></dt>
       <dd><%= f.text_field :work_title_format %></dd>

--- a/app/views/works/_filters.html.erb
+++ b/app/views/works/_filters.html.erb
@@ -154,7 +154,7 @@
             <%= f.label :language_id, ts("Language") %>
           </dt>
           <dd class="language">
-            <%= f.collection_select(:language_id, Language.default_order, :short, :name, include_blank: true) %>
+            <%= f.select(:language_id, Language.default_order.map { |language| [language.name, language.short, { lang: language.short }] }, include_blank: true) %>
           </dd>
         </dl>
       </dd>

--- a/app/views/works/_meta.html.erb
+++ b/app/views/works/_meta.html.erb
@@ -35,7 +35,7 @@
       <dt class="language">
         <%= ts("Language:") %>
       </dt>
-      <dd class="language">
+      <dd class="language" lang="<%= @work.language.short %>">
         <%= @work.language.name %>
       </dd>
     <% end %>

--- a/app/views/works/_search_form.html.erb
+++ b/app/views/works/_search_form.html.erb
@@ -85,7 +85,7 @@
         <%= link_to_help "work-search-language-help" %>
       </dt>
       <dd>
-        <%= f.collection_select :language_id, @languages, :short, :name, include_blank: true %>
+        <%= f.select(:language_id, @languages.map { |language| [language.name, language.short, { lang: language.short }] }, include_blank: true) %>
       </dd>
     </dl>
   </fieldset>

--- a/app/views/works/_standard_form.html.erb
+++ b/app/views/works/_standard_form.html.erb
@@ -124,7 +124,7 @@
                 <%= link_to_help "languages-help" %>
               </dt>
               <dd>
-                <%= p.collection_select(:language_id, sorted_languages, :id, :name, prompt: " ") %>
+                <%= p.select(:language_id, sorted_languages.map { |language| [language.name, language.id, { lang: language.short }] }, prompt: " ") %>
               </dd>
 
               <dt class="translation"><%= p.check_box :translation %></dt>

--- a/app/views/works/_work_approved_children.html.erb
+++ b/app/views/works/_work_approved_children.html.erb
@@ -8,17 +8,17 @@
       <% if child_work.work.is_a?(ExternalWork) %>
         <%= link_to child_work.work.title.html_safe, child_work.work %> <%= ts("by") %> <%= byline(child_work.work) %>
         <% if child_work.translation %>
-          <%= ts('(translation into %{language})', :language => child_work.work.language.name) %>
+          <%= ts("(translation into %{language})", language: tag.span(child_work.work.language.name, lang: child_work.work.language.short)).html_safe %>
         <% end %>
       <% elsif child_work.work.restricted? && !logged_in? %>
         <%= ts("A [Restricted Work] by") %> <%= byline(child_work.work) %>
         <% if child_work.translation %>
-          <%= ts('(translation into %{language})', :language => child_work.work.language.name) %>
+          <%= ts("(translation into %{language})", language: tag.span(child_work.work.language.name, lang: child_work.work.language.short)).html_safe %>
         <% end %> <%= ts("Log in to view.") %>
       <% else %>
         <%= link_to child_work.work.title.html_safe, child_work.work %> <%= ts("by") %> <%= byline(child_work.work) %>
         <% if child_work.translation %>
-          <%= ts('(translation into %{language})', :language => child_work.work.language.name) %>
+          <%= ts("(translation into %{language})", language: tag.span(child_work.work.language.name, lang: child_work.work.language.short)).html_safe %>
         <% end %>
       <% end %>
     </li>

--- a/app/views/works/_work_form_associations_language.html.erb
+++ b/app/views/works/_work_form_associations_language.html.erb
@@ -6,7 +6,6 @@
 <dd class="language required">
   <select id="work_language_id" name="work[language_id]">
     <option value=""><%= ts("Please select a language") %></option>
-    <%= options_from_collection_for_select(sorted_languages, :id, :name,
-      @work.language_id) %>
+    <%= options_for_select(sorted_languages.map { |language| [language.name, language.id, { lang: language.short }] }, @work.language_id) %>
   </select>
 </dd>

--- a/app/views/works/_work_header_notes.html.erb
+++ b/app/views/works/_work_header_notes.html.erb
@@ -14,7 +14,8 @@
     <% for related_work in @work.approved_related_works %>
       <% if related_work.translation %>
         <li>
-          <%= ts('Translation into %{language} available: ', :language => related_work.work.language.name) %>
+          <%= ts("Translation into %{language} available: ",
+                language: tag.span(related_work.work.language.name, lang: related_work.work.language.short)).html_safe %>
           <% if related_work.work.restricted? && !logged_in? %>
             <%= ts("[Restricted Work] by") %> <%= byline(related_work.work) %>. <%= ts("Log in to view.") %>
           <% else %>

--- a/app/views/works/_work_module.html.erb
+++ b/app/views/works/_work_module.html.erb
@@ -80,7 +80,7 @@
   <dl class="stats">
     <% if work.language.present? %>
       <dt class="language"><%= ts("Language") %>:</dt>
-      <dd class="language"><%= work.language.name %></dd>
+      <dd class="language" lang="<%= work.language.short %>"><%= work.language.name %></dd>
     <% end %>
     <dt class="words"><%= ts('Words') %>:</dt>
     <dd class="words"><%= number_with_delimiter(work.word_count) %></dd>

--- a/app/views/works/edit_multiple.html.erb
+++ b/app/views/works/edit_multiple.html.erb
@@ -38,7 +38,7 @@
     <dl>
       <dt><%= form.label :language_id, ts("Language") %> <%= link_to_help "languages-help" %></dt>
       <dd>
-        <%= form.collection_select :language_id, sorted_languages, :id, :name, {:include_blank => true} %>
+        <%= form.select :language_id, sorted_languages.map { |language| [language.name, language.id, { lang: language.short }] }, { include_blank: true } %>
       </dd>
 
       <dt><%= form.label :work_skin_id, ts("Select Work Skin") %> <%= link_to_help "work-skins" %></dt>

--- a/app/views/works/new_import.html.erb
+++ b/app/views/works/new_import.html.erb
@@ -46,7 +46,7 @@
       <dd class="required">
         <select id="language_id" name="language_id">
           <option value=""><%= ts("Please select a language") %></option>
-          <%= options_from_collection_for_select(sorted_languages, :id, :name, @language_id) %>
+          <%= options_for_select(sorted_languages.map { |language| [language.name, language.id, { lang: language.short }] }, @language_id) %>
         </select>
       </dd>
       <dt><%= label_tag "encoding", ts("Set custom encoding") %> <%= link_to_help "encoding-help" %></dt> 

--- a/app/views/works/search_results.html.erb
+++ b/app/views/works/search_results.html.erb
@@ -3,7 +3,7 @@
 
 <h4 class="heading">
   <%= ts("You searched for:") %>
-  <%= (strip_tags @search.summary).html_safe %>
+  <%= (sanitize @search.summary, tags: %w[span], attributes: %w[lang]).html_safe %>
 </h4>
 <!--/descriptions-->
 

--- a/test/fixtures/languages.yml
+++ b/test/fixtures/languages.yml
@@ -31,7 +31,7 @@ Czech:
   short: cs
 Russian:
   id: 8
-  name: Pyccĸий
+  name: Русский
   short: ru
 Suomi:
   id: 9

--- a/test/fixtures/locales.yml
+++ b/test/fixtures/locales.yml
@@ -43,7 +43,7 @@ Czech:
   main: "0"
 Russian:
   id: 8
-  name: Pyccĸий
+  name: Русский
   iso: ru-RU
   language_id: 8
   main: "0"


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [ ] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [x] Have you added the [Jira](https://otwarchive.atlassian.net) issue number as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [x] Do you have fewer than 5 pull requests already open? If not, please wait until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-5356

## Purpose

Try to make sure most places where we have language different than English are marked with lang attribute. Browser translation tools seemed to work same with or without the attribute (Chrome for some reason struggled in both cases, Edge was better). Experience with screen reader has improved though. I tested with screen reader just one of the changes, but I believe it should be the same for everything else too. 

Updated: almost everything I could find. Divided into many commits for easier overview during review.

Not Updated:
1. Download language under `app/views/downloads/_download_preface.html.erb`
I recall that everything that touches download should be merged separately, so I assume it requires its own issue?
2. Feed summary under `app/helpers/works_helper.rb`
I know nothing about RSS/atom feed readers and wasn't able to set up an environment to test the behavior. I can update the html that we send, but I am not sure if that would be enough. I found some references that we need to use `xml:lang` instead, but as I don't know how that is supposed to work, I just left it as is.


Remarks:
1. I am not familiar with html code safety, but I assume all places where I added `html_safe` are fine as we validate language on input. (If there was a way to avoid that, I don't know. My Ruby skills are still pretty much nonexistent).
    - Though it is possible to create weird languages with for example abbreviation `<p>en`. Something gets saved and language show/edit page doesn't load for me. Hope it's still ok...
2. Wasn't able to find how to properly reach "translation into" code in `app/views/works/_work_approved_children.html.erb`, so had to test rendering by disabling `child_work.translation`. Also couldn't properly test FAQ filter for users, but that was probably due to my broken setup.


## Credit

korrien, she/her