### PR TITLE
AO3-6472 Skip indirect gem dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,8 @@ updates:
     # Disable version updates; this has no impact on security updates,
     # which have a separate, internal limit of 10 open pull requests.
     open-pull-requests-limit: 0
+    allow:
+      - dependency-type: "direct"
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6472

## Purpose

In security updates like #4442, don't bump indirect dependencies like mini_portile2 and racc.

## Testing Instructions

Comment `@dependabot recreate` on #4442 after this is merged.