### PR TITLE
AO3-6472 Revert "Skip indirect gem dependency updates"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,8 +12,6 @@ updates:
     # Disable version updates; this has no impact on security updates,
     # which have a separate, internal limit of 10 open pull requests.
     open-pull-requests-limit: 0
-    allow:
-      - dependency-type: "direct"
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6472

## Purpose

Reverts otwcode/otwarchive#4444. Recreating #4442 didn't remove the indirect dependency bumps as expected.