### PR TITLE
AO3-6365 Text tweaks for muting and blocking

### DIFF
--- a/app/views/muted/users/confirm_mute.html.erb
+++ b/app/views/muted/users/confirm_mute.html.erb
@@ -23,7 +23,7 @@
     </p>
 
     <p>
-      <%= t(".site_skin_warning_html", restore_site_skin_faq_link: link_to(t(".restore_site_skin_faq_link_test"), archive_faq_url("skins-and-archive-interface", anchor: :restoresiteskin))) %>
+      <%= t(".site_skin_warning_html", restore_site_skin_faq_link: link_to(t(".restore_site_skin_faq_link_text"), archive_faq_path("skins-and-archive-interface", anchor: :restoresiteskin))) %>
     </p>
   </div>
 

--- a/app/views/muted/users/index.html.erb
+++ b/app/views/muted/users/index.html.erb
@@ -26,7 +26,7 @@
   </p>
 
   <p>
-    <%= t(".site_skin_warning_html", restore_site_skin_faq_link: link_to(t(".restore_site_skin_faq_link_test"), archive_faq_url("skins-and-archive-interface", anchor: :restoresiteskin))) %>
+    <%= t(".site_skin_warning_html", restore_site_skin_faq_link: link_to(t(".restore_site_skin_faq_link_text"), archive_faq_path("skins-and-archive-interface", anchor: :restoresiteskin))) %>
   </p>
 </div>
 

--- a/config/locales/models/en.yml
+++ b/config/locales/models/en.yml
@@ -10,7 +10,7 @@ en:
             blocked:
               blank: "Sorry, we couldn't find a user matching that name."
               self: "Sorry, you can't block yourself."
-              official: "Sorry, you can't block an official account."
+              official: "Sorry, you can't block an official user."
               limit: "Sorry, you have blocked too many accounts."
         mute:
           format: "%{message}"
@@ -20,7 +20,7 @@ en:
             muted:
               blank: "Sorry, we couldn't find a user matching that name."
               self: "Sorry, you can't mute yourself."
-              official: "Sorry, you can't mute an official account."
+              official: "Sorry, you can't mute an official user."
               limit: "Sorry, you have muted too many accounts."
         comment:
           attributes:

--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -488,7 +488,7 @@ en:
         sure_html: "Are you sure you want to %{unmute} %{username}?"
         resume:
           intro: "Unmuting a user allows you to:"
-          see_content: "see their works, series, bookmarks and comments on the site"
+          see_content: "see their works, series, bookmarks, and comments on the site"
   preferences:
     index:
       blocked_users: "Blocked Users"

--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -462,7 +462,7 @@ en:
         block_users_instead_html: "To prevent a user from commenting on your works or replying to your comments elsewhere on the site, visit %{blocked_users_link}."
         blocked_users_link_text: "your Blocked Users page"
         site_skin_warning_html: "Please note that if you are not using the default site skin, muting may not work properly. The Skins and Archive Interface FAQ has %{restore_site_skin_faq_link}."
-        restore_site_skin_faq_link_test: "instructions for reverting to the default site skin"
+        restore_site_skin_faq_link_text: "instructions for reverting to the default site skin"
       confirm_mute:
         title: "Mute %{name}"
         button: "Yes, Mute User"
@@ -479,7 +479,7 @@ en:
         block_users_instead_html: "To prevent a user from commenting on your works or replying to your comments elsewhere on the site, visit %{blocked_users_link}."
         blocked_users_link_text: "your Blocked Users page"
         site_skin_warning_html: "Please note that if you are not using the default site skin, muting may not work properly. The Skins and Archive Interface FAQ has %{restore_site_skin_faq_link}."
-        restore_site_skin_faq_link_test: "instructions for reverting to the default site skin"
+        restore_site_skin_faq_link_text: "instructions for reverting to the default site skin"
       confirm_unmute:
         title: "Unmute %{name}"
         button: "Yes, Unmute User"

--- a/features/users/blocking.feature
+++ b/features/users/blocking.feature
@@ -39,7 +39,7 @@ Feature: Blocking
       And I am logged in as "blocker"
     When I go to pest's user page
       And I follow "Block"
-    Then I should see "Sorry, you can't block an official account."
+    Then I should see "Sorry, you can't block an official user."
       And I should not see a "Yes, Block User" button
 
   Scenario: Users cannot block themselves

--- a/features/users/muting.feature
+++ b/features/users/muting.feature
@@ -29,7 +29,7 @@ Feature: Muting
       And I am logged in as "muter"
     When I go to pest's user page
       And I follow "Mute"
-    Then I should see "Sorry, you can't mute an official account."
+    Then I should see "Sorry, you can't mute an official user."
       And I should not see a "Yes, Mute User" button
 
   Scenario: Users cannot mute themselves


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6365

## Purpose

Add a missing Oxford comma and change "official account" to "official user" because we realized we generally prefer "user" to "account."

## Testing Instructions

- Try to both block and mute an official user and confirm the message says "user" and not "account"
- Mute someone, and then unmute them and make sure the confirmation page says "see their works, series, bookmarks, and comments on the site"
- Check the FAQ link on your muted users page and the mute confirmation page and ensure it is relative
