### PR TITLE
AO3-6475 Let QueryResults use scopes, so that we can start work on reducing N+1 queries for works & bookmarks.

### DIFF
--- a/app/controllers/bookmarks_controller.rb
+++ b/app/controllers/bookmarks_controller.rb
@@ -53,7 +53,7 @@ class BookmarksController < ApplicationController
       if @search.query.present?
         @page_subtitle = ts("Bookmarks Matching '%{query}'", query: @search.query)
       end
-      @bookmarks = @search.search_results
+      @bookmarks = @search.search_results.scope(:for_blurb)
       flash_search_warnings(@bookmarks)
       set_own_bookmarks
       render 'search_results'
@@ -101,13 +101,13 @@ class BookmarksController < ApplicationController
         if @user.blank?
           # When it's not a particular user's bookmarks, we want
           # to list *bookmarkable* items to avoid duplication
-          @bookmarkable_items = @search.bookmarkable_search_results
+          @bookmarkable_items = @search.bookmarkable_search_results.scope(:for_blurb)
           flash_search_warnings(@bookmarkable_items)
           @facets = @bookmarkable_items.facets
         else
           # We're looking at a particular user's bookmarks, so
           # just retrieve the standard search results and their facets.
-          @bookmarks = @search.search_results
+          @bookmarks = @search.search_results.scope(:for_blurb)
           flash_search_warnings(@bookmarks)
           @facets = @bookmarks.facets
         end
@@ -138,12 +138,12 @@ class BookmarksController < ApplicationController
       elsif use_caching?
         @bookmarks = Rails.cache.fetch("bookmarks/index/latest/v2_true", expires_in: ArchiveConfig.SECONDS_UNTIL_BOOKMARK_INDEX_EXPIRE.seconds) do
           search = BookmarkSearchForm.new(show_private: false, show_restricted: false, sort_column: 'created_at')
-          results = search.search_results
+          results = search.search_results.scope(:for_blurb)
           flash_search_warnings(results)
           results.to_a
         end
       else
-        @bookmarks = Bookmark.latest.includes(:bookmarkable, :pseud, :tags, :collections).to_a
+        @bookmarks = Bookmark.latest.for_blurb.to_a
       end
     end
     set_own_bookmarks

--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -39,7 +39,7 @@ class WorksController < ApplicationController
         @page_subtitle = ts("Works Matching '%{query}'", query: @search.query)
       end
 
-      @works = @search.search_results
+      @works = @search.search_results.scope(:for_blurb)
       set_own_works
       flash_search_warnings(@works)
       render 'search_results'
@@ -103,14 +103,14 @@ class WorksController < ApplicationController
         subtag = @tag.present? && @tag != @owner ? @tag : nil
         user = logged_in? || logged_in_as_admin? ? 'logged_in' : 'logged_out'
         @works = Rails.cache.fetch("#{@owner.works_index_cache_key(subtag)}_#{user}_page#{params[:page]}_true", expires_in: ArchiveConfig.SECONDS_UNTIL_WORK_INDEX_EXPIRE.seconds) do
-          results = @search.search_results
+          results = @search.search_results.scope(:for_blurb)
           # calling this here to avoid frozen object errors
           results.items
           results.facets
           results
         end
       else
-        @works = @search.search_results
+        @works = @search.search_results.scope(:for_blurb)
       end
 
       flash_search_warnings(@works)
@@ -125,10 +125,10 @@ class WorksController < ApplicationController
       end
     elsif use_caching?
       @works = Rails.cache.fetch('works/index/latest/v1', expires_in: ArchiveConfig.SECONDS_UNTIL_WORK_INDEX_EXPIRE.seconds) do
-        Work.latest.includes(:tags, :external_creatorships, :series, :language, :approved_collections, pseuds: [:user]).to_a
+        Work.latest.for_blurb.to_a
       end
     else
-      @works = Work.latest.includes(:tags, :external_creatorships, :series, :language, :approved_collections, pseuds: [:user]).to_a
+      @works = Work.latest.for_blurb.to_a
     end
     set_own_works
   end
@@ -140,7 +140,7 @@ class WorksController < ApplicationController
 
     @user = User.find_by!(login: params[:user_id])
     @search = WorkSearchForm.new(options.merge(works_parent: @user, collected: true))
-    @works = @search.search_results
+    @works = @search.search_results.scope(:for_blurb)
     flash_search_warnings(@works)
     @facets = @works.facets
     set_own_works
@@ -162,9 +162,9 @@ class WorksController < ApplicationController
 
     if params[:pseud_id]
       @pseud = @user.pseuds.find_by(name: params[:pseud_id])
-      @works = @pseud.unposted_works.paginate(page: params[:page])
+      @works = @pseud.unposted_works.for_blurb.paginate(page: params[:page])
     else
-      @works = @user.unposted_works.paginate(page: params[:page])
+      @works = @user.unposted_works.for_blurb.paginate(page: params[:page])
     end
   end
 

--- a/app/decorators/pseud_decorator.rb
+++ b/app/decorators/pseud_decorator.rb
@@ -5,8 +5,8 @@ class PseudDecorator < SimpleDelegator
   # Pseuds need to be decorated with various stats from the "_source" when
   # viewing search results, so we first load the pseuds with the base search
   # class, and then decorate them with the data.
-  def self.load_from_elasticsearch(hits)
-    items = Pseud.load_from_elasticsearch(hits)
+  def self.load_from_elasticsearch(hits, **options)
+    items = Pseud.load_from_elasticsearch(hits, **options)
     decorate_from_search(items, hits)
   end
 

--- a/app/models/bookmark.rb
+++ b/app/models/bookmark.rb
@@ -102,6 +102,8 @@ class Bookmark < ApplicationRecord
 
   scope :latest, -> { is_public.limit(ArchiveConfig.ITEMS_PER_PAGE).join_work }
 
+  scope :for_blurb, -> { includes(:bookmarkable, :pseud, :tags, :collections) }
+
   # a complicated dynamic scope here:
   # if the user is an Admin, we use the "visible_to_admin" scope
   # if the user is not a logged-in User, we use the "visible_to_all" scope

--- a/app/models/external_work.rb
+++ b/app/models/external_work.rb
@@ -11,6 +11,8 @@ class ExternalWork < ApplicationRecord
   # .duplicate.count.size returns the number of URLs with multiple external works
   scope :duplicate, -> { group(:url).having("count(DISTINCT id) > 1") }
 
+  scope :for_blurb, -> { includes(:language, :tags) }
+
   AUTHOR_LENGTH_MAX = 500
 
   validates_presence_of :title

--- a/app/models/search/query_result.rb
+++ b/app/models/search/query_result.rb
@@ -20,15 +20,16 @@ class QueryResult
   def items
     return [] if response[:error]
     if @items.nil?
-      @items = klass.load_from_elasticsearch(hits)
+      @items = klass.load_from_elasticsearch(hits, scopes: @scopes)
     end
     @items
   end
 
-  # Laying some groundwork for making better use of search results
-  def decorate_items(items)
-    return items unless klass == Pseud
-    PseudDecorator.decorate_from_search(items, hits)
+  def scope(*args)
+    @scopes ||= []
+    @scopes += args
+    @items = nil # reset the items in case we already loaded them
+    self # for chaining
   end
 
   def each(&block)

--- a/app/models/series.rb
+++ b/app/models/series.rb
@@ -56,6 +56,8 @@ class Series < ApplicationRecord
     where("creatorships.pseud_id IN (?)", pseuds.collect(&:id))
   }
 
+  scope :for_blurb, -> { includes(:work_tags, :pseuds) }
+
   def posted_works
     self.works.posted
   end

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -1002,6 +1002,19 @@ class Work < ApplicationRecord
     where("series.id = ?", series.id)
   end
 
+  scope :with_columns_for_blurb, lambda {
+    select(:id, :created_at, :updated_at, :expected_number_of_chapters,
+           :posted, :language_id, :restricted, :title, :summary, :word_count,
+           :hidden_by_admin, :revised_at, :complete, :in_anon_collection,
+           :in_unrevealed_collection, :summary_sanitizer_version)
+  }
+
+  scope :with_includes_for_blurb, lambda {
+    includes(:pseuds)
+  }
+
+  scope :for_blurb, -> { with_columns_for_blurb.with_includes_for_blurb }
+
   ########################################################################
   # SORTING
   ########################################################################

--- a/spec/requests/works_n_plus_one_spec.rb
+++ b/spec/requests/works_n_plus_one_spec.rb
@@ -29,7 +29,7 @@ describe "n+1 queries in the WorksController" do
         run_all_indexing_jobs
       end
 
-      it "performs around 12 queries per work" do
+      it "performs around 13 queries per work" do
         # TODO: Ideally, we'd like the uncached work listings to also have a
         # constant number of queries, instead of the linear number of queries
         # we're checking for here. But we also don't want to put too much
@@ -38,7 +38,7 @@ describe "n+1 queries in the WorksController" do
         expect do
           subject.call
           expect(response.body.scan('<li id="work_').size).to eq(current_scale.to_i)
-        end.to perform_linear_number_of_queries(slope: 12).with_warming_up
+        end.to perform_linear_number_of_queries(slope: 13).with_warming_up
       end
     end
   end

--- a/spec/requests/works_n_plus_one_spec.rb
+++ b/spec/requests/works_n_plus_one_spec.rb
@@ -1,0 +1,145 @@
+require "spec_helper"
+
+describe "n+1 queries in the WorksController" do
+  include LoginMacros
+
+  shared_examples "displaying multiple works efficiently" do
+    context "when all works are cached", :n_plus_one do
+      populate do |n|
+        User.current_user = nil # prevent treating the logged-in user as the work creator
+        WorkIndexer.prepare_for_testing
+        create_list(:work, n, **work_attributes)
+        run_all_indexing_jobs
+        subject.call
+      end
+
+      it "performs a constant number of queries" do
+        expect do
+          subject.call
+          expect(response.body.scan('<li id="work_').size).to eq(current_scale.to_i)
+        end.to perform_constant_number_of_queries
+      end
+    end
+
+    context "when no works are cached", :n_plus_one do
+      populate do |n|
+        User.current_user = nil # prevent treating the logged-in user as the work creator
+        WorkIndexer.prepare_for_testing
+        create_list(:work, n, **work_attributes)
+        run_all_indexing_jobs
+      end
+
+      it "performs around 12 queries per work" do
+        # TODO: Ideally, we'd like the uncached work listings to also have a
+        # constant number of queries, instead of the linear number of queries
+        # we're checking for here. But we also don't want to put too much
+        # unnecessary load on the databases when we have a bunch of cache hits,
+        # so this requires some care & tuning.
+        expect do
+          subject.call
+          expect(response.body.scan('<li id="work_').size).to eq(current_scale.to_i)
+        end.to perform_linear_number_of_queries(slope: 12).with_warming_up
+      end
+    end
+  end
+
+  describe "#index" do
+    context "when viewing the works for a tag" do
+      subject do
+        proc do
+          get tag_works_path(fandom)
+        end
+      end
+
+      let!(:work_attributes) { { fandom_string: fandom.name } }
+      let!(:fandom) { create(:canonical_fandom) }
+
+      context "when logged in" do
+        before { fake_login }
+
+        it_behaves_like "displaying multiple works efficiently"
+      end
+
+      context "when logged out" do
+        it_behaves_like "displaying multiple works efficiently"
+      end
+    end
+
+    context "when viewing recent works" do
+      subject do
+        proc do
+          get works_path
+        end
+      end
+
+      let!(:work_attributes) { {} }
+
+      context "when logged in" do
+        before { fake_login }
+
+        it_behaves_like "displaying multiple works efficiently"
+      end
+
+      context "when logged out" do
+        it_behaves_like "displaying multiple works efficiently"
+      end
+    end
+  end
+
+  describe "#collected" do
+    subject do
+      proc do
+        get collected_user_works_path(user)
+      end
+    end
+
+    let!(:work_attributes) { { authors: [user.default_pseud], collections: [collection] } }
+    let!(:user) { create(:user) }
+    let!(:collection) { create(:collection) }
+
+    context "when logged in" do
+      before { fake_login }
+
+      it_behaves_like "displaying multiple works efficiently"
+    end
+
+    context "when logged out" do
+      it_behaves_like "displaying multiple works efficiently"
+    end
+  end
+
+  describe "#drafts" do
+    subject do
+      proc do
+        fake_login_known_user(user.reload)
+        get drafts_user_works_path(user)
+      end
+    end
+
+    let!(:work_attributes) { { authors: [user.default_pseud], posted: false } }
+    let!(:user) { create(:user) }
+
+    it_behaves_like "displaying multiple works efficiently"
+  end
+
+  describe "#search" do
+    subject do
+      proc do
+        get search_works_path(work_search: { query: fandom.name })
+      end
+    end
+
+    let!(:work_attributes) { { fandom_string: fandom.name } }
+    let!(:fandom) { create(:canonical_fandom) }
+
+    context "when logged in" do
+      before { fake_login }
+
+      it_behaves_like "displaying multiple works efficiently"
+    end
+
+    context "when logged out" do
+      it_behaves_like "displaying multiple works efficiently"
+    end
+  end
+end


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6475

## Purpose

Add a `scope()` function to the `QueryResult` class that lets you add scopes that you want to use when retrieving records from the database. This is passed as an optional `scopes:` argument to the `load_from_elasticsearch` function, and applied to the `ActiveRecord` relation before loading.

Also changes the `WorksController` and the `BookmarksController` to use the `for_blurb` scope for works, bookmarks, series, and external works.

Works are heavily cached, so by default we only call `includes(:pseuds)` for the work's `for_blurb` scope (this is necessary for `set_own_works`, which calls `work.pseuds.pluck(:id)` for each work in the listing when the viewer is logged-in, even when everything else is fully cached).

The other three types aren't as heavily cached, so I added a couple of associations to start with, but this is far from done. (Series, in particular, cause a lot of queries that can't currently be handled by preloading more things.)
