### PR TITLE
AO3-6440 Restrict access to password reset pages

### DIFF
--- a/app/controllers/admin/passwords_controller.rb
+++ b/app/controllers/admin/passwords_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Admin::PasswordsController < Devise::PasswordsController
-  before_action :user_logout_required
+  before_action :user_logout_required, only: [:new, :edit]
   skip_before_action :store_location
   layout "session"
 end

--- a/app/controllers/admin/passwords_controller.rb
+++ b/app/controllers/admin/passwords_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Admin::PasswordsController < Devise::PasswordsController
-  before_action :user_logout_required, only: [:new, :edit]
+  before_action :user_logout_required
   skip_before_action :store_location
   layout "session"
 end

--- a/app/controllers/admin/passwords_controller.rb
+++ b/app/controllers/admin/passwords_controller.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class Admin::PasswordsController < Devise::PasswordsController
+  before_action :user_logout_required
   skip_before_action :store_location
   layout "session"
 end

--- a/app/controllers/users/passwords_controller.rb
+++ b/app/controllers/users/passwords_controller.rb
@@ -2,7 +2,7 @@
 
 # Use for resetting lost passwords
 class Users::PasswordsController < Devise::PasswordsController
-  before_action :admin_logout_required, [:new]
+  before_action :admin_logout_required, only: [:new, :edit]
   skip_before_action :store_location
   layout "session"
 

--- a/app/controllers/users/passwords_controller.rb
+++ b/app/controllers/users/passwords_controller.rb
@@ -2,7 +2,7 @@
 
 # Use for resetting lost passwords
 class Users::PasswordsController < Devise::PasswordsController
-  before_action :admin_logout_required, only: [:new, :edit]
+  before_action :admin_logout_required
   skip_before_action :store_location
   layout "session"
 

--- a/app/controllers/users/passwords_controller.rb
+++ b/app/controllers/users/passwords_controller.rb
@@ -2,6 +2,7 @@
 
 # Use for resetting lost passwords
 class Users::PasswordsController < Devise::PasswordsController
+  before_action :admin_logout_required, [:new]
   skip_before_action :store_location
   layout "session"
 

--- a/app/models/admin.rb
+++ b/app/models/admin.rb
@@ -9,7 +9,6 @@ class Admin < ApplicationRecord
          :validatable,
          password_length: ArchiveConfig.ADMIN_PASSWORD_LENGTH_MIN..ArchiveConfig.ADMIN_PASSWORD_LENGTH_MAX,
          reset_password_within: ArchiveConfig.DAYS_UNTIL_ADMIN_RESET_PASSWORD_LINK_EXPIRES.days,
-         reset_password_keys: [:email, :login],
          lock_strategy: :none,
          unlock_strategy: :none
 

--- a/app/models/admin.rb
+++ b/app/models/admin.rb
@@ -9,6 +9,7 @@ class Admin < ApplicationRecord
          :validatable,
          password_length: ArchiveConfig.ADMIN_PASSWORD_LENGTH_MIN..ArchiveConfig.ADMIN_PASSWORD_LENGTH_MAX,
          reset_password_within: ArchiveConfig.DAYS_UNTIL_ADMIN_RESET_PASSWORD_LINK_EXPIRES.days,
+         reset_password_keys: [:email, :login],
          lock_strategy: :none,
          unlock_strategy: :none
 

--- a/features/admins/authenticate_admins.feature
+++ b/features/admins/authenticate_admins.feature
@@ -11,17 +11,23 @@ Feature: Authenticate Admin Users
     And I press "Log In"
   Then I should see "The password or user name you entered doesn't match our records"
 
-  Scenario: Ordinary user cannot log in as admin.
+  Scenario: Ordinary user cannot log in or reset password as admin.
   Given the following activated user exists
     | login       | password      |
     | dizmo       | wrangulator   |
-    And I have loaded the "roles" fixture
   When I go to the admin login page
     And I fill in "Admin user name" with "dizmo"
     And I fill in "Admin password" with "wrangulator"
     And I press "Log In as Admin"
   Then I should not see "Successfully logged in"
     And I should see "The password or admin user name you entered doesn't match our records."
+  When I am logged in as "dizmo" with password "wrangulator"
+    And I go to the new admin password page
+  Then I should be on the homepage
+    And I should see "Please log out of your user account first!"
+  When I go to the edit admin password page
+  Then I should be on the homepage
+    And I should see "Please log out of your user account first!"
 
   Scenario: Admin gets email with password reset link on account creation.
   Given the following admin exists

--- a/features/support/paths.rb
+++ b/features/support/paths.rb
@@ -291,6 +291,10 @@ module NavigationHelpers
       external_works_path
     when /^the external works page with only duplicates$/i
       external_works_path(show: :duplicates)
+    when /^the new user password page$/i
+      new_user_password_path
+    when /^the edit user password page$/i
+      edit_user_password_path
 
     # Admin Pages
     when /^the admin-posts page$/i
@@ -307,6 +311,10 @@ module NavigationHelpers
       bulk_search_admin_users_path
     when /^the abuse administration page for "(.*)"$/i
       admin_user_path(User.find_by(login: $1))
+    when /^the new admin password page$/i
+      new_admin_password_path
+    when /^the edit admin password page$/i
+      edit_admin_password_path
 
     # Here is an example that pulls values out of the Regexp:
     #

--- a/features/users/authenticate_users.feature
+++ b/features/users/authenticate_users.feature
@@ -249,3 +249,21 @@ Feature: User Authentication
       | role                   |
       | is a protected user    |
       | has the no resets role |
+
+  Scenario: Admin cannot log in or reset password as ordinary user.
+    Given the following admin exists
+      | login | password      |
+      | admin | adminpassword |
+    When I go to the login page
+      And I fill in "User name or email" with "admin"
+      And I fill in "Password" with "adminpassword"
+      And I press "Log In"
+    Then I should not see "Successfully logged in"
+      And I should see "The password or user name you entered doesn't match our records."
+    When I am logged in as an admin
+      And I go to the new user password page
+    Then I should be on the homepage
+      And I should see "Please log out of your admin account first!"
+    When I go to the edit user password page
+    Then I should be on the homepage
+      And I should see "Please log out of your admin account first!"


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6440

## Purpose

If you're logged in as an admin and try to access the new or edit user password pages, redirect to homepage with reminder to log out.

If you're logged in as a user and try to access the new or edit admin password pages, redirect to homepage with reminder to log out.

## Testing Instructions

Log in as an admin and try to go to /users/password/new and /users/password/edit. You should be redirected with a friendly blue log out reminder.

Log in as a user and try to go to /admin/password/new and /admin/password/edit. You should be redirected with a friendly blue log out reminder.