### PR TITLE
AO3-6476 Update styling of muted users notice

### DIFF
--- a/app/views/bookmarks/index.html.erb
+++ b/app/views/bookmarks/index.html.erb
@@ -1,4 +1,6 @@
 <!--SEARCHBROWSE descriptive page name and system messages, descriptions, and instructions.-->
+<%= render "muted/muted_items_notice" %>
+
 <h2 class="heading">
   <% if @bookmarkable_items %>
     <%= search_header @bookmarkable_items, @search, "Bookmarked Item", @owner %>
@@ -46,8 +48,6 @@
 <% unless @owner.present? || @bookmarkable.present? %>
   <p><%= ts("These are some of the latest bookmarks created on the Archive. To find more bookmarks, #{link_to 'choose a fandom', media_path} or #{link_to 'try our advanced search', search_bookmarks_path}.").html_safe %>
 <% end %>
-
-<%= render "muted/muted_items_notice" %>
 
 <% if @bookmarks.respond_to?(:total_pages) %>
   <%= will_paginate @bookmarks %>

--- a/app/views/bookmarks/search_results.html.erb
+++ b/app/views/bookmarks/search_results.html.erb
@@ -1,12 +1,12 @@
 <!--Descriptive page name, messages and instructions-->
+<%= render "muted/muted_items_notice" %>
+
 <h2 class="heading"><%= ts('Search Results') %></h2>
 
 <h4 class="heading">
   <%= ts("You searched for:") %>
   <%= (strip_tags @search.summary).html_safe %>
 </h4>
-
-<%= render "muted/muted_items_notice" %>
 <!--/descriptions-->
 
 <!--subnav-->

--- a/app/views/muted/_muted_items_notice.html.erb
+++ b/app/views/muted/_muted_items_notice.html.erb
@@ -1,3 +1,3 @@
 <% if user_has_muted_users? %>
-  <p class="notes"><%= t("muted.muted_items_notice_html", muted_users_link: link_to(t("muted.muted_users_link_text"), user_muted_users_path(current_user))) %></p>
+  <p class="muted notice"><%= t("muted.muted_items_notice_html", muted_users_link: link_to(t("muted.muted_users_link_text"), user_muted_users_path(current_user))) %></p>
 <% end %>

--- a/app/views/series/index.html.erb
+++ b/app/views/series/index.html.erb
@@ -1,4 +1,6 @@
 <!--descriptive page name and system messages, descriptions, and instructions.-->
+<%= render "muted/muted_items_notice" %>
+
 <h2 class="heading">
   <% if @user %>
     <%= search_header @series, nil, "Series", @pseud ? @pseud : @user %>
@@ -6,9 +8,6 @@
     <%=h "View All Series" %>
   <% end %>
 </h2>
-
-<%= render "muted/muted_items_notice" %>
-
 <!-- /descriptions-->
 
 <!--subnavigation-->

--- a/app/views/works/index.html.erb
+++ b/app/views/works/index.html.erb
@@ -1,4 +1,6 @@
 <!--Descriptive page name and system messages, descriptions, and instructions.-->
+<%= render "muted/muted_items_notice" %>
+
 <h2 class="heading">
   <%= search_header @works, @search, "Work", @owner %>
 </h2>
@@ -45,8 +47,6 @@
 <% unless @owner.present? %>
   <p><%= ts("These are some of the latest works posted to the Archive. To find more works, #{link_to 'choose a fandom', media_path} or #{link_to 'try our advanced search', search_works_path}.").html_safe %>
 <% end %>
-
-<%= render "muted/muted_items_notice" %>
 
 <% if @works.respond_to?(:total_pages) %>
   <%= will_paginate @works %>

--- a/app/views/works/search_results.html.erb
+++ b/app/views/works/search_results.html.erb
@@ -1,4 +1,6 @@
 <!--Descriptive page names, messages and instructions-->
+<%= render "muted/muted_items_notice" %>
+
 <h2 class="heading"><%= ts('Search Results') %></h2>
 
 <h4 class="heading">
@@ -6,7 +8,6 @@
   <%= (strip_tags @search.summary).html_safe %>
 </h4>
 
-<%= render "muted/muted_items_notice" %>
 <!--/descriptions-->
 
 <!--subnav-->


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6476

## Purpose

Reposition and restyle the notice about muting affecting the number of items on a page so it better resembles the existing notice about items on a page.  

## Testing Instructions

Refer to Jira.

## Credit

Sarken, she/her