### PR TITLE
Use 24-hour time format by default, to improve user experience

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -308,14 +308,14 @@ module ApplicationHelper
     time_in_zone = time.in_time_zone(zone)
     time_in_zone_string = time_in_zone.strftime('<abbr class="day" title="%A">%a</abbr> <span class="date">%d</span>
                                                  <abbr class="month" title="%B">%b</abbr> <span class="year">%Y</span>
-                                                 <span class="time">%I:%M%p</span>') +
+                                                 <span class="time">%H:%M</span>') +
                           " <abbr class=\"timezone\" title=\"#{zone}\">#{time_in_zone.zone}</abbr> "
 
     user_time_string = ""
     if user.is_a?(User) && user.preference.time_zone
       if user.preference.time_zone != zone
         user_time = time.in_time_zone(user.preference.time_zone)
-        user_time_string = "(" + user_time.strftime('<span class="time">%I:%M%p</span>') +
+        user_time_string = "(" + user_time.strftime('<span class="time">%H:%M</span>') +
                            " <abbr class=\"timezone\" title=\"#{user.preference.time_zone}\">#{user_time.zone}</abbr>)"
       elsif !user.preference.time_zone
         user_time_string = link_to ts("(set timezone)"), user_preferences_path(user)

--- a/config/config.yml
+++ b/config/config.yml
@@ -245,7 +245,7 @@ COMMON_CATEGORY_NAME: 'Common'
 BANNED_CATEGORY_NAME: 'Banned'
 
 # DATE TIME FORMAT see http://ruby-doc.org/core/classes/Time.html#M000392
-DEFAULT_DATETIME_FORMAT: '%Y-%m-%d %I:%M%p'
+DEFAULT_DATETIME_FORMAT: '%Y-%m-%d %H:%M'
 
 # SEARCH TIPS
 SEARCH_TIPS: ['arthur merlin words>1000 sort:hits', 'words:100', 'buffy gen teen AND "no archive warnings apply"', 'lex m/m (mature OR explicit)',

--- a/features/step_definitions/comment_steps.rb
+++ b/features/step_definitions/comment_steps.rb
@@ -56,12 +56,12 @@ end
 # THEN
 
 Then /^the comment's posted date should be nowish$/ do
-  nowish = Time.zone.now.strftime('%a %d %b %Y %I:%M%p')
+  nowish = Time.zone.now.strftime('%a %d %b %Y %H:%M')
   step %{I should see "#{nowish}" within ".posted.datetime"}
 end
 
 Then /^I should see Last Edited nowish$/ do
-  nowish = Time.zone.now.strftime('%a %d %b %Y %I:%M%p')
+  nowish = Time.zone.now.strftime('%a %d %b %Y %H:%M')
   step "I should see \"Last Edited #{nowish}\""
 end
 

--- a/spec/controllers/gift_exchange_controller_spec.rb
+++ b/spec/controllers/gift_exchange_controller_spec.rb
@@ -73,7 +73,7 @@ describe Challenge::GiftExchangeController do
         end.not_to change { Time.zone }
 
         # Sydney is at +10, so the time in the form should be 10 hours after the UTC time:
-        expect(assigns[:challenge].signups_open_at_string).to eq("2021-07-01 06:00AM")
+        expect(assigns[:challenge].signups_open_at_string).to eq("2021-07-01 06:00")
       end
     end
   end

--- a/spec/controllers/prompt_meme_controller_spec.rb
+++ b/spec/controllers/prompt_meme_controller_spec.rb
@@ -60,7 +60,7 @@ describe Challenge::PromptMemeController do
         end.not_to change { Time.zone }
 
         # Sydney is at +10, so the time in the form should be 10 hours after the UTC time:
-        expect(assigns[:challenge].signups_open_at_string).to eq("2021-07-01 06:00AM")
+        expect(assigns[:challenge].signups_open_at_string).to eq("2021-07-01 06:00")
       end
     end
   end


### PR DESCRIPTION
The vast majority of countries (except USA, parts of Canada (not even the whole country), Australia, Newzealand and the Philippines) on the world uses the modern 24-hour format (and americans would know it from military use in their country as well). For the vast majority of people, the AM/PM thing is very hard to read, the placement of 12 AM/PM especially is illogical.

Switch the default until someone makes this, or ideally the whole date/time format, a user-customisable preference.

This solves support ticket 610765.

# Pull Request Checklist

* [ ] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [ ] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [ ] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [ ] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [✓] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

[## 610765 ##] [AO3] Support - time format

## Purpose

See above.

## Testing Instructions

Look at comment timestamps.

## Credit

What name and pronouns should we use to credit you in the [Archive of Our Own's Release Notes](https://archiveofourown.org/admin_posts?tag=1)?

Just `mirabilos`, initial minuscule. It’s trivial though, so I don’t need to be credited.