### PR TITLE
AO3-6466 Allow open attribute on details element.

### DIFF
--- a/config/initializers/gem-plugin_config/sanitizer_config.rb
+++ b/config/initializers/gem-plugin_config/sanitizer_config.rb
@@ -15,6 +15,7 @@ class Sanitize
         "blockquote" => %w[cite],
         "col" => %w[span width],
         "colgroup" => %w[span width],
+        "details" => %w[open],
         "hr" => %w[align width],
         "img" => %w[align alt border height src width],
         "ol" => %w[start type],

--- a/spec/lib/html_cleaner_spec.rb
+++ b/spec/lib/html_cleaner_spec.rb
@@ -609,6 +609,36 @@ describe HtmlCleaner do
       end
     end
 
+    it "allows details to have an 'open' attribute" do
+      html = <<~HTML
+        <details open>
+          <summary>Automated Status: Operational</summary>
+          <p>Velocity: 12m/s</p>
+          <p>Direction: North</p>
+        </details>
+      HTML
+
+      result = add_paragraphs_to_text(html)
+      doc = Nokogiri::HTML.fragment(result)
+
+      expect(doc.xpath("./details[@open]").size).to eq(1)
+    end
+
+    it "does not require details to have an 'open' attribute" do
+      html = <<~HTML
+        <details>
+          <summary>Automated Status: Operational</summary>
+          <p>Velocity: 12m/s</p>
+          <p>Direction: North</p>
+        </details>
+      HTML
+
+      result = add_paragraphs_to_text(html)
+      doc = Nokogiri::HTML.fragment(result)
+
+      expect(doc.xpath("./details[@open]")).to be_empty
+    end
+
     it "does not wrap details in p tags" do
       html = <<~HTML
         aa


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [x] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [x] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [x] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-6466

## Purpose

Allow details element to have an open attribute, as suggested in comments of the Jira issue.

## Testing Instructions

See Jira.

## References

Follow-up to previous PR for this issue, #4448 

## Credit

irrationalpie, they/them