### PR TITLE
AO3-6485 Switch to Codecov GitHub Action

### DIFF
--- a/.github/workflows/automated-tests.yml
+++ b/.github/workflows/automated-tests.yml
@@ -159,6 +159,9 @@ jobs:
       - name: Run test group
         run: bundle exec ${{ matrix.tests.command }} ${{ matrix.tests.arguments }}
 
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v3
+
       - name: Upload failure screenshots
         if: ${{ failure() && matrix.tests.command == 'cucumber' }}
         uses: actions/upload-artifact@v3

--- a/.simplecov
+++ b/.simplecov
@@ -1,7 +1,6 @@
 if ENV["CI"] == "true"
-  require "codecov"
-  SimpleCov.formatter = SimpleCov::Formatter::Codecov
-  Codecov.pass_ci_if_error = true
+  require "simplecov-cobertura"
+  SimpleCov.formatter = SimpleCov::Formatter::CoberturaFormatter
 end
 
 SimpleCov.start "rails" do

--- a/Gemfile
+++ b/Gemfile
@@ -132,7 +132,7 @@ group :test do
   gem 'cucumber-timecop', require: false
   # Code coverage
   gem "simplecov"
-  gem "codecov", require: false
+  gem "simplecov-cobertura", require: false
   gem 'email_spec', '1.6.0'
   gem "n_plus_one_control"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -163,8 +163,6 @@ GEM
     chronic (0.10.2)
     climate_control (0.2.0)
     cliver (0.3.2)
-    codecov (0.6.0)
-      simplecov (>= 0.15, < 0.22)
     coderay (1.1.3)
     concurrent-ruby (1.2.0)
     connection_pool (2.2.5)
@@ -514,6 +512,9 @@ GEM
       docile (~> 1.1)
       simplecov-html (~> 0.11)
       simplecov_json_formatter (~> 0.1)
+    simplecov-cobertura (2.1.0)
+      rexml
+      simplecov (~> 0.19)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.3)
     sinatra (2.2.3)
@@ -598,7 +599,6 @@ DEPENDENCIES
   capistrano-gitflow_version (>= 0.0.3)
   capybara
   capybara-screenshot
-  codecov
   connection_pool
   css_parser
   cucumber
@@ -660,6 +660,7 @@ DEPENDENCIES
   sanitize (>= 4.6.5)
   shoulda
   simplecov
+  simplecov-cobertura
   sprockets (< 4)
   terrapin
   test-unit (~> 3.2)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 OTW-Archive
 =========
-[![Build Status](https://img.shields.io/github/actions/workflow/status/otwcode/otwarchive/automated-tests.yml?branch=master)](https://github.com/otwcode/otwarchive/actions/workflows/automated-tests.yml?query=branch%3Amaster) [![Codeship Status](https://img.shields.io/codeship/1f7468f0-7e15-0131-c059-7a8d26daf885/master.svg?label=codeship)](https://www.codeship.io/projects/14476) [![Coverage Status](https://img.shields.io/codecov/c/github/otwcode/otwarchive/master.svg)](https://codecov.io/gh/otwcode/otwarchive/branch/master)
+[![Build Status](https://img.shields.io/github/actions/workflow/status/otwcode/otwarchive/automated-tests.yml?branch=master)](https://github.com/otwcode/otwarchive/actions/workflows/automated-tests.yml?query=branch%3Amaster) [![Codeship Status](https://img.shields.io/codeship/1f7468f0-7e15-0131-c059-7a8d26daf885/master.svg?label=codeship)](https://www.codeship.io/projects/14476) [![Coverage Status](https://img.shields.io/codecov/c/github/otwcode/otwarchive/master.svg)](https://app.codecov.io/gh/otwcode/otwarchive)
 
 The OTW-Archive software is an open-source web application intended for hosting archives of fanworks, including fanfic, fanart, and fan vids.
 


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6485

## Purpose

Switch to Codecov GitHub Action, since the uploader gem we've been using is deprecated. Follow the [migration plan](https://docs.codecov.com/docs/deprecated-uploader-migration-guide#ruby-uploader).

## Testing Instructions

See issue. Works on [this pull request](https://app.codecov.io/github/otwcode/otwarchive/commit/c59f4676409170359605c87f4e305c683cd13be1).