### PR TITLE
AO3-6474 Only load media for the menu when needed.

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -384,13 +384,6 @@ public
     @page_title.html_safe
   end
 
-  # Define media for fandoms menu
-  before_action :set_media
-  def set_media
-    uncategorized = Media.uncategorized
-    @menu_media = Media.by_name - [Media.find_by_name(ArchiveConfig.MEDIA_NO_TAG_NAME), uncategorized] + [uncategorized]
-  end
-
   public
 
   #### -- AUTHORIZATION -- ####
@@ -530,7 +523,6 @@ public
   skip_before_action  :fetch_admin_settings,
                       :load_admin_banner,
                       :set_redirects,
-                      :set_media,
                       :store_location,
                       if: proc { %w(js json).include?(request.format) }
 

--- a/app/models/media.rb
+++ b/app/models/media.rb
@@ -15,9 +15,9 @@ class Media < Tag
     tag
   end
 
-  # The list of media used for the menu on every page. All media except No
-  # Media and Uncategorized Fandoms are listed in order, and then Uncategorized
-  # Fandoms is tacked onto the list at the end.
+  # The list of media used for the menu on every page. All media except "No
+  # Media" and "Uncategorized Fandoms" are listed in order, and then
+  # "Uncategorized Fandoms" is tacked onto the list at the end.
   def self.for_menu
     by_name.where.not(
       name: [ArchiveConfig.MEDIA_UNCATEGORIZED_NAME,

--- a/app/models/media.rb
+++ b/app/models/media.rb
@@ -14,4 +14,14 @@ class Media < Tag
     tag.update(canonical: true) unless tag.canonical
     tag
   end
+
+  # The list of media used for the menu on every page. All media except No
+  # Media and Uncategorized Fandoms are listed in order, and then Uncategorized
+  # Fandoms is tacked onto the list at the end.
+  def self.for_menu
+    by_name.where.not(
+      name: [ArchiveConfig.MEDIA_UNCATEGORIZED_NAME,
+             ArchiveConfig.MEDIA_NO_TAG_NAME]
+    ).to_a + [uncategorized]
+  end
 end

--- a/app/views/menu/_menu_fandoms.html.erb
+++ b/app/views/menu/_menu_fandoms.html.erb
@@ -1,7 +1,7 @@
 <ul class="menu" role="menu">
   <li><%= link_to ts('All Fandoms', key: 'header.fandom'), media_path %></li>
-  <% cache "menu-fandoms-version3", skip_digest: true do %>
-    <% for medium in @menu_media %>
+  <% cache "menu-fandoms-version4", skip_digest: true do %>
+    <% Media.for_menu.each do |medium| %>
       <% unless medium.id.nil? %>
         <li id="medium_<%= medium.id %>"><%= link_to ts("#{medium.name}", key: 'header.fandom'), medium_fandoms_path(medium) %></li>
       <% end %>


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6474

## Purpose

Remove `ApplicationController#set_media` so that we only load the media list for the menu when we actually need to load the tags to regenerate the cache.
