### PR TITLE
AO3-6118: Hide non-JS collection form when invite disabled

### DIFF
--- a/app/views/comments/_commentable.html.erb
+++ b/app/views/comments/_commentable.html.erb
@@ -126,7 +126,7 @@
   </div>
 
   <% if logged_in? && @work %>
-    <% if is_author_of?(@work) || is_maintainer? %>
+    <% if is_maintainer? && @work.allow_collection_invitation? %>
       <div id="collection_item_form_placement" class="wrapper toggled">
         <%= render "collection_items/collection_item_form", :item => @work, :in_page => true %>
       </div>

--- a/features/collections/collectible_multiple_collections.feature
+++ b/features/collections/collectible_multiple_collections.feature
@@ -11,13 +11,7 @@ Feature: Collectible items in multiple collections
       And I am logged in as a random user
       And I set my preferences to allow collection invitations
       And I post the work "Blabla" to the collection "ModeratedCollection"
-    When I view the work "Blabla"
-      And I fill in "Collection name(s):" with "ModeratedCollection2"
-      And I press "Invite"
-    Then I should see "You have submitted your work to the moderated collection 'ModeratedCollection2'."
-      And I should see "It will not become a part of the collection until it has been approved by a moderator."
-    When I follow "Edit"
-      And I press "Post"
+    When I edit the work "Blabla" to be in the collections "ModeratedCollection,ModeratedCollection2"
     Then I should see "Work was successfully updated. You have submitted your work to moderated collections (ModeratedCollection, ModeratedCollection2). It will not become a part of those collections until it has been approved by a moderator."
 
   Scenario: Add my work to both moderated and unmoderated collections by editing
@@ -55,14 +49,12 @@ Feature: Collectible items in multiple collections
     Then I should see "We couldn't add your submission to the following collection(s):"
       And I should see "MyCollection, because you don't own this item and the item is anonymous."
 
-  Scenario: Work creator can add their own anonymous work to a collection using
-  the Add to Collections option on the work
+  Scenario: Work creator can add their own anonymous work to another collection
     Given I have the anonymous collection "AnonymousCollection"
       And I have the collection "OtherCollection"
       And I am logged in as a random user
       And I set my preferences to allow collection invitations
       And I post the work "Some Work" to the collection "AnonymousCollection"
-    When I view the work "Some Work"
-      And I fill in "Collection name(s):" with "OtherCollection"
-      And I press "Invite"
-    Then I should see "Added to collection(s): OtherCollection."
+    When I edit the work "Some Work" to be in the collections "AnonymousCollection,OtherCollection"
+    Then I should see "Work was successfully updated."
+      And I should see "OtherCollection"

--- a/features/collections/collectible_multiple_collections.feature
+++ b/features/collections/collectible_multiple_collections.feature
@@ -4,8 +4,7 @@ Feature: Collectible items in multiple collections
   As a user
   I want to be unable to add items to more than one collection
 
-  Scenario: Add a work that is already in a moderated collection to a second
-  moderated collection using the Add to Collections option on the work
+  Scenario: Add a work that is already in a moderated collection to a second moderated collection
     Given I have the moderated collection "ModeratedCollection"
       And I have the moderated collection "ModeratedCollection2"
       And I am logged in as a random user

--- a/features/step_definitions/generic_steps.rb
+++ b/features/step_definitions/generic_steps.rb
@@ -43,11 +43,11 @@ Then /^show me the (\d+)(?:st|nd|rd|th) form$/ do |index|
 end
 
 Then "I should see the {string} form" do |form_id|
-  assert page.has_xpath?("//form[@id='#{form_id}']")
+  expect(page).to have_css("form##{form_id}")
 end
 
 Then "I should not see the {string} form" do |form_id|
-  assert page.has_no_xpath?("//form[@id='#{form_id}']")
+  expect(page).not_to have_css("form##{form_id}")
 end
 
 Given /^I wait (\d+) seconds?$/ do |number|

--- a/features/step_definitions/generic_steps.rb
+++ b/features/step_definitions/generic_steps.rb
@@ -42,6 +42,14 @@ Then /^show me the (\d+)(?:st|nd|rd|th) form$/ do |index|
   puts "\n" + page.all("#main form")[(index.to_i-1)].native.inner_html
 end
 
+Then "I should see the {string} form" do |form_id|
+  assert page.has_xpath?("//form[@id='#{form_id}']")
+end
+
+Then "I should not see the {string} form" do |form_id|
+  assert page.has_no_xpath?("//form[@id='#{form_id}']")
+end
+
 Given /^I wait (\d+) seconds?$/ do |number|
   Kernel::sleep number.to_i
 end

--- a/features/works/work_view.feature
+++ b/features/works/work_view.feature
@@ -45,11 +45,11 @@ Feature: View a work with various options
 
   Scenario: other users cannot collect a work by default
   Given the work "Whatever"
-    And I am logged in as the author of "Whatever"
   When I have the collection "test collection" with name "test_collection"
     And I am logged in as "moderator"
     And I view the work "Whatever"
   Then I should not see a link "Invite To Collections"
+    And I should not see the "new_collection_item" form
 
   Scenario: other users can collect a work when the creator has opted-in
   Given the work "Whatever"
@@ -59,3 +59,4 @@ Feature: View a work with various options
     And I am logged in as "moderator"
     And I view the work "Whatever"
   Then I should see a link "Invite To Collections"
+    And I should see the "new_collection_item" form


### PR DESCRIPTION
# Pull Request Checklist

* [X] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [X] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [X] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [X] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [X] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-6118 (Please fill in issue number and remove this comment.)

## Purpose

Follow-up to #4348 in order to fix the add/invite form still being shown when JavaScript is off. Thanks to @tickinginstant for finding the bug!

## Testing Instructions

How can the Archive's QA team verify that this is working as you intended?

If you have a Jira account with access, please update or comment on the issue
with any new or missing testing instructions instead.

## References

https://otwarchive.atlassian.net/browse/AO3-6118?focusedCommentId=359763

## Credit

What name and pronouns should we use to credit you in the [Archive of Our Own's Release Notes](https://archiveofourown.org/admin_posts?tag=1)?

Brian Austin (they/he)
