### PR TITLE
AO3-6485 Optionally use the Codecov upload token

### DIFF
--- a/.github/workflows/automated-tests.yml
+++ b/.github/workflows/automated-tests.yml
@@ -161,6 +161,13 @@ jobs:
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
+        with:
+          # Optional for public repos. However, individual forks can set this
+          # secret to reduce the chance of being rate-limited by GitHub.
+          #
+          # https://github.com/marketplace/actions/codecov#usage
+          # https://community.codecov.com/t/upload-issues-unable-to-locate-build-via-github-actions-api/3954
+          token: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Upload failure screenshots
         if: ${{ failure() && matrix.tests.command == 'cucumber' }}


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6485

## Purpose

To reduce the chance of being rate-limited by GitHub.

## Testing Instructions

None. On my fork, here's [a run without a token](https://github.com/redsummernight/otwarchive/actions/runs/4268648009/jobs/7431280296):
```
[2023-02-25T06:09:24.289Z] ['info'] -> No token specified or token is empty
```
Here's [a run with a token](https://github.com/redsummernight/otwarchive/actions/runs/4268724095/jobs/7431419026):
```
[2023-02-25T06:25:01.366Z] ['info'] ->  Token found by environment variables
```
Both [successfully uploaded coverage](https://app.codecov.io/gh/redsummernight/otwarchive/commits?branch=AO3-6485-token).