### PR TITLE
AO3-6466 Handle boolean 'open' attribute more nicely.

### DIFF
--- a/config/initializers/gem-plugin_config/sanitizer_config.rb
+++ b/config/initializers/gem-plugin_config/sanitizer_config.rb
@@ -50,5 +50,13 @@ class Sanitize
     )
 
     CSS_ALLOWED = freeze_config(merge(ARCHIVE, CLASS_ATTRIBUTE))
+
+    # On details elements, force boolean attribute "open" to have
+    # value "open", if it exists
+    OPEN_ATTRIBUTE_TRANSFORMER = lambda do |env|
+      return unless env[:node_name] == "details"
+
+      env[:node]["open"] = "open" if env[:node].has_attribute?("open")
+    end
   end
 end

--- a/lib/html_cleaner.rb
+++ b/lib/html_cleaner.rb
@@ -58,7 +58,7 @@ module HtmlCleaner
     end
     if ArchiveConfig.FIELDS_ALLOWING_HTML.include?(field.to_s)
       # We're allowing users to use HTML in this field
-      transformers = []
+      transformers = [Sanitize::Config::OPEN_ATTRIBUTE_TRANSFORMER]
       if ArchiveConfig.FIELDS_ALLOWING_VIDEO_EMBEDS.include?(field.to_s)
         transformers << OtwSanitize::EmbedSanitizer.transformer
         transformers << OtwSanitize::MediaSanitizer.transformer


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [x] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [x] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [x] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-6466

## Purpose

The `open` attribute on `<details>` is a boolean, so the value doesn't matter, so you can theoretically specify it as `<details open>`. However, the sanitizer turns that into `<details open="">`. For consistency with some other boolean attributes [e.g. see media sanitizer](https://github.com/otwcode/otwarchive/blob/1f07422d813dab2acd810857b19b787273f47e3b/lib/otw_sanitize/media_sanitizer.rb#L110-L117), this PR has the sanitizer set the value of `open` to `"open"`, if `open` is present on a `<details>` element.

The automated tests this PR removes are being removed because I realized while testing this change that those tests couldn't possibly fail--`add_paragraphs_to_text` doesn't call the sanitizer, so I could have replaced 'open' with 'bogus' and they still would have passed.

## Testing Instructions

See Jira issue.

## References

Follow-up to #4448 and #4457. See also comments on the Jira article, particular @redsummernight's that raised this tweak. 

## Credit

irrationalpie, they/them