### PR TITLE
AO3-5521 Avoid recording original_creator for rejected co-creations

### DIFF
--- a/app/models/creatorship.rb
+++ b/app/models/creatorship.rb
@@ -182,6 +182,7 @@ class Creatorship < ApplicationRecord
   # This information is stored temporarily to make it available for
   # Policy and Abuse on orphaned works.
   def save_original_creator
+    return unless approved?
     return unless creation.is_a?(Work)
     return if creation.destroyed?
 

--- a/spec/models/creatorship_spec.rb
+++ b/spec/models/creatorship_spec.rb
@@ -1,0 +1,34 @@
+require "spec_helper"
+
+describe Creatorship do
+  describe "#destroy" do
+    context "when the creation is a work" do
+      let(:creation) { create(:work, authors: [build(:pseud), build(:pseud)]) }
+      let(:creatorship) { creation.creatorships.first }
+      
+      context "when the creatorship is approved" do
+        before do
+          creatorship.accept!
+        end
+  
+        it "saves the original creator" do
+          original_creator = creatorship.pseud.user
+          creatorship.destroy!
+          expect(creation.original_creators.length).to eq(1)
+          expect(creation.original_creators.first.user).to eq(original_creator)
+        end
+      end
+  
+      context "when the creatorship is not approved" do
+        before do
+          creatorship.approved = false
+          creatorship.save!(validate: false)
+        end
+
+        it "does not save the original creator" do
+          expect { creatorship.destroy! }.not_to change { creation.original_creators }
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
# Pull Request Checklist

* [X] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [X] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [X] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [X] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [X] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-5521

## Purpose

Fix the behavior from #4251 to avoid saving an original creator for co-creator requests that have been rejected.

## Testing Instructions

See JIRA

## References

https://otwarchive.atlassian.net/browse/AO3-5521?focusedCommentId=359769
https://otwarchive.atlassian.net/browse/AO3-5521?focusedCommentId=359790

## Credit

What name and pronouns should we use to credit you in the [Archive of Our Own's Release Notes](https://archiveofourown.org/admin_posts?tag=1)?

Brian Austin (they/he)

Thanks @redsummernight for the direction on fixing this! I was actually just starting to rabbit hole when you posted that comment.
