### PR TITLE
AO3-5666 clarify invalid username error message 

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -203,7 +203,7 @@ class User < ApplicationRecord
                                    max_pwd: ArchiveConfig.PASSWORD_LENGTH_MAX)
 
   validates_format_of :login,
-                      message: ts("must begin and end with a letter or number; it may also contain underscores but no other characters."),
+                      message: ts("must be 3 to 40 characters (A-Z, a-z, _, 0-9 only), no spaces, cannot begin or end with underscore (_)."),
                       with: /\A[A-Za-z0-9]\w*[A-Za-z0-9]\Z/
   validates :login, uniqueness: { message: ts("has already been taken") }
   validate :login, :username_is_not_recently_changed, if: :will_save_change_to_login?


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [x] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [x] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [x] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-5666

## Purpose

Invalid username error message text was unclear: "Login must begin and end with a letter or number; it may also contain underscores but no other characters." Changed it to "Login must be 3 to 40 characters (A-Z, a-z, \_, 0-9 only), no spaces, cannot begin or end with underscore (\_).", per the Jira ticket comments.

## Testing Instructions

In Jira ticket & comments. Should look like this for existing user and new user respectively:
<img width="911" alt="Screenshot 2023-03-01 at 10 31 49 AM" src="https://user-images.githubusercontent.com/44508369/222244563-bcc58e40-b158-457b-854f-843c351da4a6.png">

<img width="1133" alt="Screenshot 2023-03-01 at 10 30 59 AM" src="https://user-images.githubusercontent.com/44508369/222244613-273e4b56-c22c-4984-a4fd-ab8a11fa5c48.png">

## References

Are there other relevant issues/pull requests/mailing list discussions?

## Credit

pinkpurpleblue (she/her)
