### PR TITLE
AO3-6391 Improve the tag callbacks for updating TagNominations.

### DIFF
--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1070,7 +1070,6 @@ class Tag < ApplicationRecord
     if tag.canonical
       tag.add_to_autocomplete
     end
-    update_tag_nominations(tag)
   end
 
   after_update :after_update
@@ -1113,8 +1112,6 @@ class Tag < ApplicationRecord
     if tag.saved_change_to_unwrangleable?
       tag.reindex_document
     end
-
-    update_tag_nominations(tag)
   end
 
   before_destroy :before_destroy
@@ -1123,25 +1120,40 @@ class Tag < ApplicationRecord
     if Tag::USER_DEFINED.include?(tag.type) && tag.canonical
       tag.remove_from_autocomplete
     end
-    update_tag_nominations(tag, true)
   end
 
   private
 
-  def update_tag_nominations(tag, deleted=false)
-    values = {}
-    if deleted
-      values[:canonical] = false
-      values[:exists] = false
-      values[:parented] = false
-      values[:synonym] = nil
-    else
-      values[:canonical] = tag.canonical
-      values[:synonym] = tag.merger.nil? ? nil : tag.merger.name
-      values[:parented] = tag.parents.any? {|p| p.is_a?(Fandom)}
-      values[:exists] = true
-    end
-    TagNomination.where(tagname: tag.name).update_all(values)
+  after_save :update_tag_nominations
+  def update_tag_nominations
+    TagNomination.where(tagname: name).update_all(
+      canonical: canonical,
+      synonym: merger.nil? ? nil : merger.name,
+      parented: false, # we'll fix this later
+      exists: true
+    )
+
+    # Calculate the fandoms associated with this tag, because we'll set any
+    # TagNominations with a matching parent_tagname to have parented: true.
+    parent_names = parents.where(type: "Fandom").pluck(:name)
+
+    # If this tag has any fandoms at all, we also want to count it as parented
+    # for nominations with a blank parent_tagname. See the set_parented
+    # function in TagNominations for the calculation that we're trying to mimic
+    # here.
+    parent_names << "" if parent_names.present?
+
+    TagNomination.where(tagname: name, parent_tagname: parent_names).update_all(parented: true)
+  end
+
+  before_destroy :clear_tag_nominations
+  def clear_tag_nominations
+    TagNomination.where(tagname: name).update_all(
+      canonical: false,
+      exists: false,
+      parented: false,
+      synonym: nil
+    )
   end
 
   def only_case_changed?

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1129,7 +1129,7 @@ class Tag < ApplicationRecord
     TagNomination.where(tagname: name).update_all(
       canonical: canonical,
       synonym: merger.nil? ? nil : merger.name,
-      parented: false, # we'll fix this later
+      parented: false, # we'll fix this later in the callback
       exists: true
     )
 

--- a/features/step_definitions/tag_set_steps.rb
+++ b/features/step_definitions/tag_set_steps.rb
@@ -186,6 +186,14 @@ When /^I view the tag set "([^\"]*)"/ do |tagset|
   visit tag_set_path(tagset)
 end
 
+When "the cache for the tag set {string} is expired" do |tagset|
+  tag_set_id = OwnedTagSet.find_by(title: tagset).tag_set_id
+  ActionController::Base.new.expire_fragment("tag_set_show_#{tag_set_id}")
+  TagSet::TAG_TYPES.each do |type|
+    ActionController::Base.new.expire_fragment("tag_set_show_#{tag_set_id}_#{type}")
+  end
+end
+
 When /^I view associations for a tag set that does not exist/ do
   id = 1
   tagset = OwnedTagSet.find_by(id: id)

--- a/features/tag_sets/tag_set_associations.feature
+++ b/features/tag_sets/tag_set_associations.feature
@@ -21,7 +21,7 @@ Feature: Reviewing tag set associations
     And the tag "Zarrr" is canonized
   When I review associations for "Nominated Tags"
   Then I should not see "Zarrr → Floobry"
-  # Remove this step when AO3-3757 is fixed:
+  # TODO: Remove this step when AO3-3757 is fixed:
   When the cache for the tag set "Nominated Tags" is expired
     And I view the tag set "Nominated Tags"
   Then I should not see "Unassociated Characters & Relationships"

--- a/features/tag_sets/tag_set_associations.feature
+++ b/features/tag_sets/tag_set_associations.feature
@@ -14,15 +14,33 @@ Feature: Reviewing tag set associations
   Then I should see "Nominated associations were added"
     And I should not see "don't seem to be associated"
 
-  Scenario: If a nominated tag and its parent are wrangled after approval it should still be possible to associate them
+  Scenario: If a nominated tag is wrangled into its nominated parent after approval, it should be automatically associated with the parent
   Given I nominate and approve fandom "Floobry" and character "Zarrr" in "Nominated Tags"
-    And a canonical character "Zarrr" in fandom "Floobry"
+    And the tag "Floobry" is canonized
+    And I add the fandom "Floobry" to the character "Zarrr"
+    And the tag "Zarrr" is canonized
+  When I review associations for "Nominated Tags"
+  Then I should not see "Zarrr → Floobry"
+  # Remove this step when AO3-3757 is fixed:
+  When the cache for the tag set "Nominated Tags" is expired
+    And I view the tag set "Nominated Tags"
+  Then I should not see "Unassociated Characters & Relationships"
+    And I should not see "don't seem to be associated"
+    And "Zarrr" should be associated with the "Uncategorized" fandom "Floobry"
+
+  Scenario: If a nominated tag is wrangled to a different fandom after approval, it should still be possible to associate them
+  Given I nominate and approve fandom "Floobry" and character "Zarrr" in "Nominated Tags"
+    And a canonical fandom "Barbar"
+    And I add the fandom "Barbar" to the character "Zarrr"
+    And the tag "Zarrr" is canonized
   When I review associations for "Nominated Tags"
   Then I should see "Zarrr → Floobry"
   When I check "Zarrr → Floobry"
     And I submit
   Then I should see "Nominated associations were added"
+    And I should not see "Unassociated Characters & Relationships"
     And I should not see "don't seem to be associated"
+    And "Zarrr" should be associated with the "Uncategorized" fandom "Floobry"
 
   Scenario: If a tag set does not exist, no one should be able to see its associations
   Given I am logged in as "tagsetter"


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6391

## Purpose

- Cleans up the `update_tag_nominations` function by (a) splitting it into two separate callbacks, one for updating and one for clearing, and (b) avoiding passing around `tag` as a variable (which is vestige of the fact that this code used to be in a sweeper at one point).
- Modifies the `update_tag_nominations` function so that it now sets `parented` similarly to the way that `TagNomination#set_parented` sets the value of `parented`. In particular: https://github.com/otwcode/otwarchive/blob/8e03660aaa2b470011109a0af187716bf34e575c/app/models/tagset_models/tag_nomination.rb#L77-L81
- Fixes the test "If a nominated tag and its parent are wrangled after approval it should still be possible to associate them" so that it now accurately reflects reality (namely, that if a nominated tag is wrangled into its parent tag after approval, the association will disappear from the Review Associations page, and the two tags will appear associated in the tag set — although of course https://otwarchive.atlassian.net/browse/AO3-5714 is an ever-present problem).
- Adds a new test to check that when the nominated tag is wrangled into a *different* fandom, the nominated association won't be removed from the Review Associations page.