### PR TITLE
AO3-6003 Add i18n-tasks to normalize locale files and add tests to detect missing and unused translation keys

### DIFF
--- a/.phrase.yml
+++ b/.phrase.yml
@@ -11,6 +11,10 @@ phrase:
       - file: ./config/locales/devise/en.yml
         params:
           update_translations: true
+      # helpers
+      - file: ./config/locales/helpers/en.yml
+        params:
+          update_translations: true
       # mailers
       - file: ./config/locales/mailers/en.yml
         params:

--- a/Gemfile
+++ b/Gemfile
@@ -144,6 +144,7 @@ group :test, :development do
   gem 'whiny_validation'
   gem "factory_bot_rails"
   gem 'minitest'
+  gem 'i18n-tasks', require: false
 end
 
 group :development do

--- a/Gemfile
+++ b/Gemfile
@@ -144,7 +144,7 @@ group :test, :development do
   gem 'whiny_validation'
   gem "factory_bot_rails"
   gem 'minitest'
-  gem 'i18n-tasks', require: false
+  gem "i18n-tasks", require: false
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -291,6 +291,17 @@ GEM
       multi_xml (>= 0.5.2)
     i18n (1.12.0)
       concurrent-ruby (~> 1.0)
+    i18n-tasks (1.0.12)
+      activesupport (>= 4.0.2)
+      ast (>= 2.1.0)
+      better_html (>= 1.0, < 3.0)
+      erubi
+      highline (>= 2.0.0)
+      i18n
+      parser (>= 2.2.3.0)
+      rails-i18n
+      rainbow (>= 2.2.2, < 4.0)
+      terminal-table (>= 1.5.1)
     jmespath (1.6.1)
     json (2.6.1)
     kgio (2.10.0)
@@ -531,6 +542,8 @@ GEM
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
     stringex (2.8.5)
+    terminal-table (3.0.2)
+      unicode-display_width (>= 1.1.1, < 3)
     terrapin (0.6.0)
       climate_control (>= 0.0.3, < 1.0)
     test-unit (3.5.3)
@@ -622,6 +635,7 @@ DEPENDENCIES
   google_visualr!
   htmlentities
   httparty
+  i18n-tasks
   kgio (= 2.10.0)
   kt-paperclip (>= 5.2.0)
   launchy

--- a/app/controllers/admin/admin_invitations_controller.rb
+++ b/app/controllers/admin/admin_invitations_controller.rb
@@ -7,10 +7,10 @@ class Admin::AdminInvitationsController < Admin::BaseController
     @invitation = current_admin.invitations.new(invitation_params)
 
     if @invitation.invitee_email.blank?
-      flash[:error] = t('no_email', default: "Please enter an email address.")
+      flash[:error] = t("admin.admin_invitations.create.no_email")
       render action: 'index'
     elsif @invitation.save
-      flash[:notice] = t('sent', default: "An invitation was sent to %{email_address}", email_address: @invitation.invitee_email)
+      flash[:notice] = t("admin.admin_invitations.create.sent", email_address: @invitation.invitee_email)
       redirect_to admin_invitations_path
     else
       render action: 'index'
@@ -31,7 +31,7 @@ class Admin::AdminInvitationsController < Admin::BaseController
     else
       Invitation.grant_empty(invitation_params[:number_of_invites].to_i)
     end
-    flash[:notice] = t('invites_created', default: 'Invitations successfully created.')
+    flash[:notice] = t("admin.admin_invitations.grant_invites_to_users.invites_created")
     redirect_to admin_invitations_path
   end
 
@@ -48,7 +48,7 @@ class Admin::AdminInvitationsController < Admin::BaseController
       @invitation = @invitations.first if @invitations.length == 1
     end
     unless @user || @invitation || @invitations
-      flash.now[:error] = t('user_not_found', default: "No results were found. Try another search.")
+      flash.now[:error] = t("admin.admin_invitations.find.user_not_found")
     end
   end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -430,9 +430,9 @@ public
   def check_user_status
     if current_user.is_a?(User) && (current_user.suspended? || current_user.banned?)
       if current_user.suspended?
-        flash[:error] = t('suspension_notice', default: "Your account has been suspended until %{suspended_until}. You may not add or edit content until your suspension has been resolved. Please <a href=\"#{new_abuse_report_path}\">contact Abuse</a> for more information.", suspended_until: localize(current_user.suspended_until)).html_safe
+        flash[:error] = t("application.check_user_status.suspension_notice", contact_abuse_link: view_context.link_to(t("application.check_user_status.contact_abuse"), new_abuse_report_path), suspended_until: localize(current_user.suspended_until)).html_safe
       else
-        flash[:error] = t('ban_notice', default: "Your account has been banned. You are not permitted to add or edit archive content. Please <a href=\"#{new_abuse_report_path}\">contact Abuse</a> for more information.").html_safe
+        flash[:error] = t("application.check_user_status.ban_notice", contact_abuse_link: view_context.link_to(t("application.check_user_status.contact_abuse"), new_abuse_report_path)).html_safe
       end
       redirect_to current_user
     end

--- a/app/controllers/challenge_assignments_controller.rb
+++ b/app/controllers/challenge_assignments_controller.rb
@@ -21,7 +21,7 @@ class ChallengeAssignmentsController < ApplicationController
   end
 
   def no_challenge
-    flash[:error] = t('challenge_assignments.no_challenge', default: "What challenge did you want to work with?")
+    flash[:error] = t("challenge_assignments.no_challenge")
     redirect_to collection_path(@collection) rescue redirect_to '/'
     false
   end
@@ -33,7 +33,7 @@ class ChallengeAssignmentsController < ApplicationController
   def owner_only
     return if current_user == @challenge_assignment.offering_pseud.user
 
-    flash[:error] = t("challenge_assignments.not_owner", default: "You aren't the owner of that assignment.")
+    flash[:error] = t("challenge_assignments.not_owner")
     redirect_to root_path
   end
 
@@ -42,7 +42,7 @@ class ChallengeAssignmentsController < ApplicationController
   end
 
   def signup_open
-    flash[:error] = t('challenge_assignments.signup_open', default: "Signup is currently open, you cannot make assignments now.")
+    flash[:error] = t("challenge_assignments.signup_open")
     redirect_to @collection rescue redirect_to '/'
     false
   end
@@ -52,7 +52,7 @@ class ChallengeAssignmentsController < ApplicationController
   end
 
   def assignments_sent
-    flash[:error] = t('challenge_assignments.assignments_sent', default: "Assignments have already been sent! If necessary, you can purge them.")
+    flash[:error] = t("challenge_assignments.assignments_sent")
     redirect_to collection_assignments_path(@collection) rescue redirect_to '/'
     false
   end
@@ -62,7 +62,7 @@ class ChallengeAssignmentsController < ApplicationController
   end
 
   def assignments_not_sent
-    flash[:error] = t('challenge_assignments.assignments_not_sent', default: "Assignments have not been sent! You might want matching instead.")
+    flash[:error] = t("challenge_assignments.assignments_not_sent")
     redirect_to collection_path(@collection) rescue redirect_to '/'
     false
   end

--- a/app/controllers/challenges_controller.rb
+++ b/app/controllers/challenges_controller.rb
@@ -41,15 +41,13 @@ class ChallengesController < ApplicationController
   before_action :load_collection
 
   def no_collection
-    flash[:error] = t('challenge.no_collection',
-                      default: 'What collection did you want to work with?')
+    flash[:error] = t("challenges.no_collection")
     redirect_to(request.env['HTTP_REFERER'] || root_path)
     false
   end
 
   def no_challenge
-    flash[:error] = t('challenges.no_challenge',
-                      default: 'What challenge did you want to work on?')
+    flash[:error] = t("challenges.no_challenge")
     redirect_to collection_path(@collection) rescue redirect_to '/'
     false
   end

--- a/app/controllers/collection_items_controller.rb
+++ b/app/controllers/collection_items_controller.rb
@@ -65,7 +65,7 @@ class CollectionItemsController < ApplicationController
       redirect_to(request.env["HTTP_REFERER"] || root_path) and return
     end
     if @item.respond_to?(:allow_collection_invitation?) && !@item.allow_collection_invitation?
-      flash[:error] = t(".invitation_not_sent", default: "This item could not be invited.")
+      flash[:error] = t("collection_items.create.invitation_not_sent")
       redirect_to(@item) and return
     end
     # for each collection name

--- a/app/controllers/collection_participants_controller.rb
+++ b/app/controllers/collection_participants_controller.rb
@@ -10,7 +10,7 @@ class CollectionParticipantsController < ApplicationController
   cache_sweeper :collection_sweeper
 
   def owners_required
-    flash[:error] = t('collection_participants.owners_required', default: "You can't remove the only owner!")
+    flash[:error] = t("collection_participants.owners_required")
     redirect_to collection_participants_path(@collection)
     false
   end
@@ -40,7 +40,7 @@ class CollectionParticipantsController < ApplicationController
 
   def join
     unless @collection
-      flash[:error] = t('no_collection', default: "Which collection did you want to join?")
+      flash[:error] = t("collection_participants.no_collection")
       redirect_to(request.env["HTTP_REFERER"] || root_path) and return
     end
     participants = CollectionParticipant.in_collection(@collection).for_user(current_user) unless current_user.nil?
@@ -51,17 +51,17 @@ class CollectionParticipantsController < ApplicationController
         participant_role: CollectionParticipant::NONE
       )
       @participant.save
-      flash[:notice] = t('applied_to_join_collection', default: "You have applied to join %{collection}.", collection: @collection.title)
+      flash[:notice] = t("collection_participants.applied_to_join_collection", collection: @collection.title)
     else
       participants.each do |participant|
         if participant.is_invited?
           participant.approve_membership!
-          flash[:notice] = t('collection_participants.accepted_invite', default: "You are now a member of %{collection}.", collection: @collection.title)
+          flash[:notice] = t("collection_participants.accepted_invite", collection: @collection.title)
           redirect_to(request.env["HTTP_REFERER"] || root_path) and return
         end
       end
 
-      flash[:notice] = t('collection_participants.no_invitation', default: "You have already joined (or applied to) this collection.")
+      flash[:notice] = t("collection_participants.no_invitation")
     end
 
     redirect_to(request.env["HTTP_REFERER"] || root_path)
@@ -73,16 +73,16 @@ class CollectionParticipantsController < ApplicationController
 
   def update
     if @participant.update(collection_participant_params)
-      flash[:notice] = t('collection_participants.update_success', default: "Updated %{participant}.", participant: @participant.pseud.name)
+      flash[:notice] = t("collection_participants.update_success", participant: @participant.pseud.name)
     else
-      flash[:error] = t('collection_participants.update_failure', default: "Couldn't update %{participant}.", participant: @participant.pseud.name)
+      flash[:error] = t("collection_participants.update_failure", participant: @participant.pseud.name)
     end
     redirect_to collection_participants_path(@collection)
   end
 
   def destroy
     @participant.destroy
-    flash[:notice] = t('collection_participants.destroy', default: "Removed %{participant} from collection.", participant: @participant.pseud.name)
+    flash[:notice] = t("collection_participants.destroy", participant: @participant.pseud.name)
     redirect_to(request.env["HTTP_REFERER"] || root_path)
   end
 

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -195,7 +195,7 @@ class CommentsController < ApplicationController
   # Comments cannot be edited after they've been replied to or if they are frozen.
   def check_permission_to_edit
     if @comment&.iced?
-      flash[:error] = t("comment.check_permission_to_edit.error.frozen")
+      flash[:error] = t("comments.check_permission_to_edit.error.frozen")
       redirect_back(fallback_location: root_path)
     elsif !@comment&.count_all_comments&.zero?
       flash[:error] = ts("Comments with replies cannot be edited")

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -211,6 +211,8 @@ class CommentsController < ApplicationController
   def check_permission_to_modify_frozen_status
     return if permission_to_modify_frozen_status
 
+    # i18n-tasks-use t('comments.freeze.permission_denied') # let i18n-tasks know the key is used
+    # i18n-tasks-use t('comments.unfreeze.permission_denied')
     flash[:error] = t(".permission_denied")
     redirect_back(fallback_location: root_path)
   end
@@ -218,6 +220,8 @@ class CommentsController < ApplicationController
   def check_permission_to_modify_hidden_status
     return if policy(@comment).can_hide_comment?
 
+    # i18n-tasks-use t('comments.hide.permission_denied') # let i18n-tasks know the key is used
+    # i18n-tasks-use t('comments.unhide.permission_denied')
     flash[:error] = t(".permission_denied")
     redirect_back(fallback_location: root_path)
   end

--- a/app/controllers/external_authors_controller.rb
+++ b/app/controllers/external_authors_controller.rb
@@ -49,7 +49,7 @@ class ExternalAuthorsController < ApplicationController
     # go ahead and give the user the works
     @external_author.claim!(current_user)
     @invitation.mark_as_redeemed(current_user) if @invitation
-    flash[:notice] = t('external_author_claimed', default: "We have added the stories imported under %{email} to your account.", email: @external_author.email)
+    flash[:notice] = t("external_authors.complete_claim.external_author_claimed", email: @external_author.email)
     redirect_to user_external_authors_path(current_user)
   end
 

--- a/app/controllers/external_works_controller.rb
+++ b/app/controllers/external_works_controller.rb
@@ -45,7 +45,7 @@ class ExternalWorksController < ApplicationController
     @external_work = authorize ExternalWork.find(params[:id])
     @external_work.attributes = work_params
     if @external_work.update(external_work_params)
-      flash[:notice] = t('successfully_updated', default: 'External work was successfully updated.')
+      flash[:notice] = t("external_works.update.successfully_updated")
       redirect_to(@external_work)
     else
       render action: "edit"

--- a/app/controllers/feedbacks_controller.rb
+++ b/app/controllers/feedbacks_controller.rb
@@ -21,12 +21,10 @@ class FeedbacksController < ApplicationController
     @feedback.ip_address = request.remote_ip
     if @feedback.save
       @feedback.email_and_send
-      flash[:notice] = t("successfully_sent",
-        default: "Your message was sent to the Archive team - thank you!")
+      flash[:notice] = t("feedbacks.create.successfully_sent")
       redirect_back_or_default(root_path)
     else
-      flash[:error] = t("failure_send",
-        default: "Sorry, your message could not be saved - please try again!")
+      flash[:error] = t("feedbacks.create.failure_send")
       render action: "new"
     end
   end

--- a/app/controllers/languages_controller.rb
+++ b/app/controllers/languages_controller.rb
@@ -18,7 +18,7 @@ class LanguagesController < ApplicationController
     @language = Language.new(language_params)
     authorize @language
     if @language.save
-      flash[:notice] = t('successfully_added', default: 'Language was successfully added.')
+      flash[:notice] = t("languages.create.successfully_added")
       redirect_to languages_path
     else
       render action: "new"
@@ -34,7 +34,7 @@ class LanguagesController < ApplicationController
     @language = Language.find_by(short: params[:id])
     authorize @language
     if @language.update(language_params)
-      flash[:notice] = t('successfully_updated', default: 'Language was successfully updated.')
+      flash[:notice] = t("languages.update.successfully_updated")
       redirect_to @language
     else
       render action: "new"

--- a/app/controllers/locales_controller.rb
+++ b/app/controllers/locales_controller.rb
@@ -37,7 +37,7 @@ class LocalesController < ApplicationController
     @locale = Locale.new(locale_params)
     authorize @locale
     if @locale.save
-      flash[:notice] = t('successfully_added', default: 'Locale was successfully added.')
+      flash[:notice] = t("locales.create.successfully_added")
       redirect_to locales_path
     else
       @languages = Language.default_order

--- a/app/helpers/mailer_helper.rb
+++ b/app/helpers/mailer_helper.rb
@@ -186,6 +186,12 @@ module MailerHelper
   def work_tag_metadata_label(tags)
     return if tags.empty?
 
+    # i18n-tasks-use t('activerecord.models.archive_warning') # let i18n-tasks know the key is used
+    # i18n-tasks-use t('activerecord.models.character')
+    # i18n-tasks-use t('activerecord.models.fandom')
+    # i18n-tasks-use t('activerecord.models.freeform')
+    # i18n-tasks-use t('activerecord.models.rating')
+    # i18n-tasks-use t('activerecord.models.relationship')
     type = tags.first.type
     t("activerecord.models.#{type.underscore}", count: tags.count) + t("mailer.general.metadata_label_indicator")
   end

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -132,29 +132,29 @@ module UsersHelper
 
   def log_item_action_name(action)
     if action == ArchiveConfig.ACTION_ACTIVATE
-      t('users_helper.log_validated', default: 'Account Validated')
+      t("users_helper.log_validated")
     elsif action == ArchiveConfig.ACTION_ADD_ROLE
-      t('users_helper.log_role_added', default: 'Role Added: ')
+      t("users_helper.log_role_added")
     elsif action == ArchiveConfig.ACTION_REMOVE_ROLE
-      t('users_helper.log_role_removed', default: 'Role Removed: ')
+      t("users_helper.log_role_removed")
     elsif action == ArchiveConfig.ACTION_SUSPEND
-      t('users_helper.log_suspended', default: 'Suspended until ')
+      t("users_helper.log_suspended")
     elsif action == ArchiveConfig.ACTION_UNSUSPEND
-      t('users_helper.log_lift_suspension', default: 'Suspension Lifted')
+      t("users_helper.log_lift_suspension")
     elsif action == ArchiveConfig.ACTION_BAN
-      t('users_helper.log_ban', default: 'Suspended Permanently')
+      t("users_helper.log_ban")
     elsif action == ArchiveConfig.ACTION_WARN
-      t('users_helper.log_warn', default: 'Warned')
+      t("users_helper.log_warn")
     elsif action == ArchiveConfig.ACTION_RENAME
-      t('users_helper.log_rename', default: 'Username Changed')
+      t("users_helper.log_rename")
     elsif action == ArchiveConfig.ACTION_PASSWORD_RESET
-      t('users_helper.log_password_change', default: 'Password Changed')
+      t("users_helper.log_password_change")
     elsif action == ArchiveConfig.ACTION_NEW_EMAIL
-      t('users_helper.log_email_change', default: 'Email Changed')
+      t("users_helper.log_email_change")
     elsif action == ArchiveConfig.ACTION_TROUBLESHOOT
-      t('users_helper.log_troubleshot', default: 'Account Troubleshot')
+      t("users_helper.log_troubleshot")
     elsif action == ArchiveConfig.ACTION_NOTE
-      t('users_helper.log_note', default: 'Note Added')
+      t("users_helper.log_note")
     end
   end
 

--- a/app/mailers/kudo_mailer.rb
+++ b/app/mailers/kudo_mailer.rb
@@ -22,6 +22,7 @@ class KudoMailer < ApplicationMailer
       end
       mail(
         to: user.email,
+        # i18n-tasks-use t('kudo_mailer.batch_kudo_notification.subject')
         subject: default_i18n_subject(app_name: ArchiveConfig.APP_SHORT_NAME)
       )
     end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -216,6 +216,7 @@ class UserMailer < ApplicationMailer
     I18n.with_locale(Locale.find(@assigned_user.preference.preferred_locale).iso) do
       mail(
         to: @assigned_user.email,
+        # i18n-tasks-use t('user_mailer.challenge_assignment_notification.subject')
         subject: default_i18n_subject(app_name: ArchiveConfig.APP_SHORT_NAME, collection_title: @collection.title)
       )
     end
@@ -384,6 +385,7 @@ class UserMailer < ApplicationMailer
     I18n.with_locale(Locale.find(@user.preference.preferred_locale).iso) do
       mail(
         to: @user.email,
+        # i18n-tasks-use t('user_mailer.admin_hidden_work_notification.subject')
         subject: default_i18n_subject(app_name: ArchiveConfig.APP_SHORT_NAME)
       )
     end

--- a/app/views/admin/_admin_nav.html.erb
+++ b/app/views/admin/_admin_nav.html.erb
@@ -9,7 +9,7 @@
 </li>
   <% if params[:controller] == "admin_posts" && params[:action] == "edit" %>
     <li>
-      <%= link_to t("admin.admin_nav.delete", default: "Delete Post"),
+      <%= link_to t("admin.admin_nav.delete"),
                   @admin_post,
                   data: { confirm: "Are you sure you want to delete this news post?" },
                   method: :delete %>

--- a/app/views/admin/admin_invitations/find.html.erb
+++ b/app/views/admin/admin_invitations/find.html.erb
@@ -8,11 +8,11 @@
 <!--main content-->
 <%= form_tag url_for(:controller => 'admin/admin_invitations', :action => 'find'), :method => :get do %>
   <dl>
-    <dt><%= label_tag :user_name, t('.find_user_name', :default => 'Enter a user name:') %></dt>
+    <dt><%= label_tag :user_name, t(".find_user_name") %></dt>
     <dd><%= text_field_tag "invitation[user_name]", params[:invitation][:user_name]  %></dd>
-    <dt><%= label_tag :token, t('.find_token', :default => 'Enter an invite token:') %></dt>
+    <dt><%= label_tag :token, t(".find_token") %></dt>
     <dd><%= text_field_tag "invitation[token]", params[:invitation][:token]  %></dd>
-    <dt><%= label_tag :invitee_email, t('.find_email', :default => 'Enter all or part of an email address:') %></dt>
+    <dt><%= label_tag :invitee_email, t(".find_email") %></dt>
     <dd><%= text_field_tag "invitation[invitee_email]", params[:invitation][:invitee_email], id: "invitee_email"  %></dd>
   </dl>
   <p class="submit actions"><%= submit_tag "Go" %></p>

--- a/app/views/admin/admin_invitations/new.html.erb
+++ b/app/views/admin/admin_invitations/new.html.erb
@@ -1,5 +1,5 @@
 <!--Descriptive page name, messages and instructions-->
-<h2 class="heading"><%= t('.invite_user', :default => "Invite a User") %></h2>
+<h2 class="heading"><%= t(".invite_user") %></h2>
 <!--/descriptions-->
 
 <!--subnav-->
@@ -7,8 +7,8 @@
 
 <!--main content-->
 <%= form_for :invitation, @invitation, :url => { :controller => 'admin/admin_invitations', :action => :create } do |f| %>
-    <p><%= f.label :recipient_email, t('.email_address', :default => "Email address") %> <%= f.text_field :recipient_email %></p>
-    <p class="submit actions"><%= f.submit t('.submit', :default => "Invite!") %></p>
+    <p><%= f.label :recipient_email, t(".email_address") %> <%= f.text_field :recipient_email %></p>
+    <p class="submit actions"><%= f.submit t(".submit") %></p>
 <% end %>
 <!--/content-->
 

--- a/app/views/admin/skins/_navigation.html.erb
+++ b/app/views/admin/skins/_navigation.html.erb
@@ -1,6 +1,6 @@
 <h3 class="landmark heading">Navigation</h3>
 <ul class="navigation actions" role="navigation">
-  <li><%= span_if_current t("skins.approval_queue", :default => "Approval Queue"), admin_skins_path %></li>
-  <li><%= span_if_current t("skins.approved_skins", :default => "Approved Skins"), index_approved_admin_skins_path %></li>
-  <li><%= span_if_current t("skins.rejected_skins", :default => "Rejected Skins"), index_rejected_admin_skins_path %></li>
+  <li><%= span_if_current t("skins.approval_queue"), admin_skins_path %></li>
+  <li><%= span_if_current t("skins.approved_skins"), index_approved_admin_skins_path %></li>
+  <li><%= span_if_current t("skins.rejected_skins"), index_rejected_admin_skins_path %></li>
 </ul>

--- a/app/views/blocked/users/index.html.erb
+++ b/app/views/blocked/users/index.html.erb
@@ -39,7 +39,7 @@
   </fieldset>
 <% end %>
 
-<h3 class="landmark heading"><%= t("heading.landmark.blocked") %> %></h3>
+<h3 class="landmark heading"><%= t(".heading.landmark.blocked_users") %></h3>
 <% if @blocks.present? %>
   <ul class="pseud index group">
     <%= render partial: "blocked_user_blurb", collection: @blocks, as: :block %>

--- a/app/views/comments/show.html.erb
+++ b/app/views/comments/show.html.erb
@@ -1,5 +1,5 @@
 <%= flash_div :comment_error, :comment_notice %>
 
-<h3 class="heading"><%=h t('.comment_on', :default => "Comment on") %>  <%= link_to_comment_ultimate_parent(@comment) %></h3>
+<h3 class="heading"><%=h t(".comment_on") %>  <%= link_to_comment_ultimate_parent(@comment) %></h3>
 
 <%= render :partial => 'comments/comment_thread', :locals => { :comments => @comments, :depth => 0 } %></ol>

--- a/app/views/external_authors/_external_author_name.html.erb
+++ b/app/views/external_authors/_external_author_name.html.erb
@@ -1,6 +1,6 @@
 <div class="external_author_name">
   <dl>
-    <dt><%= form.label :name, t('.label_external_author_name', :default => "Name: ") %></dt>
+    <dt><%= form.label :name, t(".label_external_author_name") %></dt>
     <dd>
        <%= form.text_field :name %>
       <%= remove_name_link(form) %>

--- a/app/views/external_authors/edit.html.erb
+++ b/app/views/external_authors/edit.html.erb
@@ -1,6 +1,6 @@
-<h2 class="heading"><%= t('.edit_external_author', :default => 'Editing external author identity') %></h2>
+<h2 class="heading"><%= t(".edit_external_author") %></h2>
 
 <%= render "external_author_form" %>
 
-<p class="navigation actions" role="navigation"><%= link_to t('.back', :default => 'Back'), user_external_authors_path(@user) %></p>
+<p class="navigation actions" role="navigation"><%= link_to t(".back"), user_external_authors_path(@user) %></p>
 

--- a/app/views/gifts/_gift_search.html.erb
+++ b/app/views/gifts/_gift_search.html.erb
@@ -2,9 +2,9 @@
   <fieldset role="search">
 	<legend>Find gifts for</legend>
 	<p>
-    <%= label_tag :recipient, t('.gifts.recipient_field', :default => "Find gifts for: ")%>
+    <%= label_tag :recipient, t(".gifts.recipient_field")%>
     <%= text_field_tag :recipient, params[:recipient], :class => 'text', :title => 'gift search' %>
-    <span class="submit"><%= submit_tag t('.forms.gift_search', :default => 'Search'), :class => 'button', :name => nil %></span>
+    <span class="submit"><%= submit_tag t(".forms.gift_search"), :class => 'button', :name => nil %></span>
   </p>
 </fieldset>
 <% end %>

--- a/app/views/home/site_map.html.erb
+++ b/app/views/home/site_map.html.erb
@@ -1,57 +1,57 @@
 <h2 class="heading"><%= t(".site_map") %></h2>
 <div class="userstuff">
   <h3 class="heading">Explore</h3>
-	  <ul>
-	    <li><%= link_to t(".homepage"), root_path %></li>
-	    <li><%= link_to t(".fandoms"), media_path %></li>
-	    <li><%= link_to t(".recent_works"), works_path %></li>
-	    <li><%= link_to t(".people"), search_people_path %></li>
-	    <li><%= link_to t(".bookmarks"), bookmarks_path %></li>
-	    <li><%= link_to t(".freeform_tag_cloud"), tags_path %></li>
-	    <li><%= link_to t(".languages"), languages_path %></li>
-	   <li><%= link_to t(".collections"), collections_path %></li>
-	  </ul>
+  <ul>
+    <li><%= link_to t(".homepage"), root_path %></li>
+    <li><%= link_to t(".fandoms"), media_path %></li>
+    <li><%= link_to t(".recent_works"), works_path %></li>
+    <li><%= link_to t(".people"), search_people_path %></li>
+    <li><%= link_to t(".bookmarks"), bookmarks_path %></li>
+    <li><%= link_to t(".freeform_tag_cloud"), tags_path %></li>
+    <li><%= link_to t(".languages"), languages_path %></li>
+    <li><%= link_to t(".collections"), collections_path %></li>
+  </ul>
 
   <h3 class="heading">About the Archive of Our Own</h3>
-	  <ul>
-		  <li><%= link_to t(".terms_of_service"), tos_path %></li>
-		<li><%= link_to t(".archive_faq"), archive_faqs_path %></li>
-		  <li><%= link_to t(".ao3_news"), admin_posts_path %></li>
-		  <li><%= link_to t(".known_issues"), known_issues_path %></li>
-		  <li>The Archive of Our Own is a project of the <a href="http://transformativeworks.org"><acronym title="Organization for Transformative Works">OTW</acronym></a></li>
-	  </ul>
+  <ul>
+    <li><%= link_to t(".terms_of_service"), tos_path %></li>
+    <li><%= link_to t(".archive_faq"), archive_faqs_path %></li>
+    <li><%= link_to t(".ao3_news"), admin_posts_path %></li>
+    <li><%= link_to t(".known_issues"), known_issues_path %></li>
+    <li>The Archive of Our Own is a project of the <a href="http://transformativeworks.org"><acronym title="Organization for Transformative Works">OTW</acronym></a></li>
+  </ul>
 
   <% if logged_in? %>
     <h3 class="heading">Access your account</h3>
-	    <ul>
-		   <li><%= link_to t(".my_home"), user_path(current_user) %></li>
-		    <li><%= link_to t(".post_new"), new_work_path %></li>
-		    <li><%= link_to t(".my_works"), user_works_path(current_user) %></li>
-		    <li><%= link_to t(".my_drafts"), drafts_user_works_path(current_user) %></li>
-		    <li><%= link_to t(".my_series"), user_series_index_path(current_user) %></li>
-		    <li><%= link_to t(".my_bookmarks"), user_bookmarks_path(current_user) %></li>
-		    <li><%= link_to t(".my_collections"), user_collections_path(current_user) %></li>
-		    <li><%= link_to t(".my_inbox"), user_inbox_path(current_user) %></li>
-		    <% if current_user.preference.history_enabled? %>
-		      <li><%= link_to t(".my_history"), user_readings_path(current_user) %></li>
-		    <% end %>
-		    <li><%= link_to t(".my_subscriptions"), user_subscriptions_path(current_user) %></li>
-		    <li><%= link_to t(".set_preferences"), user_preferences_path(current_user) %>
-	    </ul>
+    <ul>
+      <li><%= link_to t(".my_home"), user_path(current_user) %></li>
+      <li><%= link_to t(".post_new"), new_work_path %></li>
+      <li><%= link_to t(".my_works"), user_works_path(current_user) %></li>
+      <li><%= link_to t(".my_drafts"), drafts_user_works_path(current_user) %></li>
+      <li><%= link_to t(".my_series"), user_series_index_path(current_user) %></li>
+      <li><%= link_to t(".my_bookmarks"), user_bookmarks_path(current_user) %></li>
+      <li><%= link_to t(".my_collections"), user_collections_path(current_user) %></li>
+      <li><%= link_to t(".my_inbox"), user_inbox_path(current_user) %></li>
+      <% if current_user.preference.history_enabled? %>
+        <li><%= link_to t(".my_history"), user_readings_path(current_user) %></li>
+      <% end %>
+      <li><%= link_to t(".my_subscriptions"), user_subscriptions_path(current_user) %></li>
+      <li><%= link_to t(".set_preferences"), user_preferences_path(current_user) %>
+    </ul>
 
-	  <h3 class="heading">Change your account settings</h3>
-	    <ul>
+    <h3 class="heading">Change your account settings</h3>
+    <ul>
       <li><%= link_to t(".edit_user_profile"), edit_user_path(current_user) %></li>
       <li><%= link_to t(".my_profile"), user_profile_path(current_user) %></li>
       <li><%= link_to t(".manage_pseuds"), user_pseuds_path(current_user) %></li>
       <li><%= link_to ts("Delete My Account"), user_path(current_user), data: {confirm: ts('This will permanently delete your account and cannot be undone. Are you sure?')}, :method => :delete %></li>
-	  </ul>
+    </ul>
   <% end %>
 
   <h3 class="heading">Contact Us</h3>
-	  <ul>
-		  <li><%= link_to t(".support_and_feedback"), new_feedback_report_path %></li>
-		  <li><%= link_to t(".report_abuse"), new_abuse_report_path %></li>
-      <li><%= link_to t(".donate"), donate_path %></li>
-	  </ul>
+  <ul>
+    <li><%= link_to t(".support_and_feedback"), new_feedback_report_path %></li>
+    <li><%= link_to t(".report_abuse"), new_abuse_report_path %></li>
+    <li><%= link_to t(".donate"), donate_path %></li>
+  </ul>
 </div>

--- a/app/views/home/site_map.html.erb
+++ b/app/views/home/site_map.html.erb
@@ -1,57 +1,57 @@
-<h2 class="heading"><%= t('.site_map', :default => 'Site Map') %></h2>
+<h2 class="heading"><%= t(".site_map") %></h2>
 <div class="userstuff">
   <h3 class="heading">Explore</h3>
 	  <ul>
-	    <li><%= link_to t('.homepage', :default => "Homepage"), root_path %></li>
-	    <li><%= link_to t('.fandoms', :default => "Fandoms"), media_path %></li>
-	    <li><%= link_to t('.recent_works', :default => "Recent Works"), works_path %></li>
-	    <li><%= link_to t('.people', :default => "People"), search_people_path %></li>
-	    <li><%= link_to t('.bookmarks', :default => "Bookmarks"), bookmarks_path %></li>
-	    <li><%= link_to t('.freeform_tag_cloud', :default => "Additional Tags Cloud"), tags_path %></li>
-	    <li><%= link_to t('.languages', :default => "Languages"), languages_path %></li>
-	   <li><%= link_to t('.collections', :default => "Collections and Challenges"), collections_path %></li>
+	    <li><%= link_to t(".homepage"), root_path %></li>
+	    <li><%= link_to t(".fandoms"), media_path %></li>
+	    <li><%= link_to t(".recent_works"), works_path %></li>
+	    <li><%= link_to t(".people"), search_people_path %></li>
+	    <li><%= link_to t(".bookmarks"), bookmarks_path %></li>
+	    <li><%= link_to t(".freeform_tag_cloud"), tags_path %></li>
+	    <li><%= link_to t(".languages"), languages_path %></li>
+	   <li><%= link_to t(".collections"), collections_path %></li>
 	  </ul>
 
   <h3 class="heading">About the Archive of Our Own</h3>
 	  <ul>
-		  <li><%= link_to t('.terms_of_service', :default => "Terms of Service"), tos_path %></li>
-		<li><%= link_to t('.archive_faq', :default => "Archive FAQ"), archive_faqs_path %></li>
-		  <li><%= link_to t('.ao3_news', :default => "AO3 News"), admin_posts_path %></li>
-		  <li><%= link_to t('.known_issues', :default => "Known Issues"), known_issues_path %></li>
+		  <li><%= link_to t(".terms_of_service"), tos_path %></li>
+		<li><%= link_to t(".archive_faq"), archive_faqs_path %></li>
+		  <li><%= link_to t(".ao3_news"), admin_posts_path %></li>
+		  <li><%= link_to t(".known_issues"), known_issues_path %></li>
 		  <li>The Archive of Our Own is a project of the <a href="http://transformativeworks.org"><acronym title="Organization for Transformative Works">OTW</acronym></a></li>
 	  </ul>
 
   <% if logged_in? %>
     <h3 class="heading">Access your account</h3>
 	    <ul>
-		   <li><%= link_to t('.my_home', :default => "My Home"), user_path(current_user) %></li>
-		    <li><%= link_to t('.post_new', :default => "Post New"), new_work_path %></li>
-		    <li><%= link_to t('.my_works', :default => "My Works"), user_works_path(current_user) %></li>
-		    <li><%= link_to t('.my_drafts', :default => "Drafts"), drafts_user_works_path(current_user) %></li>
-		    <li><%= link_to t('.my_series', :default => "My Series"), user_series_index_path(current_user) %></li>
-		    <li><%= link_to t('.my_bookmarks', :default => "My Bookmarks"), user_bookmarks_path(current_user) %></li>
-		    <li><%= link_to t('.my_collections', :default => "My Collections and Challenges"), user_collections_path(current_user) %></li>
-		    <li><%= link_to t('.my_inbox', :default => "My Inbox"), user_inbox_path(current_user) %></li>
+		   <li><%= link_to t(".my_home"), user_path(current_user) %></li>
+		    <li><%= link_to t(".post_new"), new_work_path %></li>
+		    <li><%= link_to t(".my_works"), user_works_path(current_user) %></li>
+		    <li><%= link_to t(".my_drafts"), drafts_user_works_path(current_user) %></li>
+		    <li><%= link_to t(".my_series"), user_series_index_path(current_user) %></li>
+		    <li><%= link_to t(".my_bookmarks"), user_bookmarks_path(current_user) %></li>
+		    <li><%= link_to t(".my_collections"), user_collections_path(current_user) %></li>
+		    <li><%= link_to t(".my_inbox"), user_inbox_path(current_user) %></li>
 		    <% if current_user.preference.history_enabled? %>
-		      <li><%= link_to t('.my_history', :default =>"My History"), user_readings_path(current_user) %></li>
+		      <li><%= link_to t(".my_history"), user_readings_path(current_user) %></li>
 		    <% end %>
-		    <li><%= link_to t('.my_subscriptions', :default =>"My Subscriptions"), user_subscriptions_path(current_user) %></li>
-		    <li><%= link_to t('.set_preferences', :default => "Set My Preferences"), user_preferences_path(current_user) %>
+		    <li><%= link_to t(".my_subscriptions"), user_subscriptions_path(current_user) %></li>
+		    <li><%= link_to t(".set_preferences"), user_preferences_path(current_user) %>
 	    </ul>
 
 	  <h3 class="heading">Change your account settings</h3>
 	    <ul>
-      <li><%= link_to t('.edit_user_profile', :default =>"Edit My Profile"), edit_user_path(current_user) %></li>
-      <li><%= link_to t('.my_profile', :default => "My Profile"), user_profile_path(current_user) %></li>
-      <li><%= link_to t('.manage_pseuds', :default => "Manage My Pseuds"), user_pseuds_path(current_user) %></li>
+      <li><%= link_to t(".edit_user_profile"), edit_user_path(current_user) %></li>
+      <li><%= link_to t(".my_profile"), user_profile_path(current_user) %></li>
+      <li><%= link_to t(".manage_pseuds"), user_pseuds_path(current_user) %></li>
       <li><%= link_to ts("Delete My Account"), user_path(current_user), data: {confirm: ts('This will permanently delete your account and cannot be undone. Are you sure?')}, :method => :delete %></li>
 	  </ul>
   <% end %>
 
   <h3 class="heading">Contact Us</h3>
 	  <ul>
-		  <li><%= link_to t('.support_and_feedback', :default => "Technical Support & Feedback"), new_feedback_report_path %></li>
-		  <li><%= link_to t('.report_abuse', :default => "Policy Questions & Abuse Reports"), new_abuse_report_path %></li>
-      <li><%= link_to t('.donate', :default => "Donations"), donate_path %></li>
+		  <li><%= link_to t(".support_and_feedback"), new_feedback_report_path %></li>
+		  <li><%= link_to t(".report_abuse"), new_abuse_report_path %></li>
+      <li><%= link_to t(".donate"), donate_path %></li>
 	  </ul>
 </div>

--- a/app/views/invitations/index.html.erb
+++ b/app/views/invitations/index.html.erb
@@ -21,9 +21,9 @@
     <p>You have <%= @user.invitations.unsent.count.to_s %> open invitations and <%= @user.invitations.unredeemed.count.to_s %> that have been sent but not yet used.</p>
     <%= form_tag invite_friend_user_invitations_path(@user) do  %>
       <dl>
-        <dt><%= label_tag "invitation[invitee_email]", t('.email address', :default => 'Email address') %></dt>
+        <dt><%= label_tag "invitation[invitee_email]", t(".email_address") %></dt>
         <dd><%= text_field_tag "invitation[invitee_email]" %></dd>
-        <dt><%= label_tag :id, t('.choose_invite', :default => 'Choose an invitation') %></dt>
+        <dt><%= label_tag :id, t(".choose_invite") %></dt>
         <dd>
           <ul>
             <% for unsent_invite in @unsent_invitations %>
@@ -35,7 +35,7 @@
           </ul>
         </dd>
       </dl>
-      <p class="submit actions"><%= submit_tag t('.submit_invite', :default => 'Send Invitation')  %></p>
+      <p class="submit actions"><%= submit_tag t(".submit_invite")  %></p>
     <% end %>
   <% end %>
   </div>

--- a/app/views/languages/_form.html.erb
+++ b/app/views/languages/_form.html.erb
@@ -2,26 +2,26 @@
 
 <%= form_for(@language, html: { class: "post" }) do |f| %>
 
-  <p class="required notice">* <%= t('.required_notice', default: "Required information") %></p>
+  <p class="required notice">* <%= t(".required_notice") %></p>
 
   <fieldset>
     <dl>
       <dt class="required">
-        <%= f.label :name, t('.name', default: "Name") + " *" %>
+        <%= f.label :name, t(".name") + " *" %>
       </dt>
       <dd class="required">
         <%= f.text_field :name %>
       </dd>
 
       <dt class="required">
-        <%= f.label :short, t('.short', default: "Abbreviation") + " *" %>
+        <%= f.label :short, t(".short") + " *" %>
       </dt>
       <dd class="required">
         <%= f.text_field :short %>
       </dd>
 
       <dt>
-        <%= f.label :sortable_name, t('.sortable_name', default: "Name for alphabetical sorting") %>
+        <%= f.label :sortable_name, t(".sortable_name") %>
       </dt>
       <dd>
         <%= f.text_field :sortable_name %>
@@ -31,20 +31,20 @@
         <%= f.check_box :support_available %>
       </dt>
       <dd>
-        <%= f.label :support_available, t('.support_available', default: "Support available") %>
+        <%= f.label :support_available, t(".support_available") %>
       </dd>
       <dt>
         <%= f.check_box :abuse_support_available %>
       </dt>
       <dd>
-        <%= f.label :abuse_support_available, t('.abuse_support_available', default: "Abuse support available") %>
+        <%= f.label :abuse_support_available, t(".abuse_support_available") %>
       </dd>
     </dl>
     <p class="submit actions">
       <% if @language.new_record? %>
-        <%= f.submit t('.create', default: "Create Language") %>
+        <%= f.submit t(".create") %>
       <% else %>
-        <%= f.submit t('.update', default: "Update Language") %>
+        <%= f.submit t(".update") %>
       <% end %>
     </p>
   </fieldset>

--- a/app/views/languages/edit.html.erb
+++ b/app/views/languages/edit.html.erb
@@ -1,3 +1,3 @@
-<h2 class="heading"><%= t('.edit_language', :default => 'Edit Language') %></h2>
+<h2 class="heading"><%= t(".edit_language") %></h2>
 
 <%= render 'form' %>

--- a/app/views/languages/new.html.erb
+++ b/app/views/languages/new.html.erb
@@ -1,3 +1,3 @@
-<h2 class="heading"><%= t('.new_language', :default => 'New Language') %></h2>
+<h2 class="heading"><%= t(".new_language") %></h2>
 
 <%= render 'form' %>

--- a/app/views/languages/show.html.erb
+++ b/app/views/languages/show.html.erb
@@ -9,7 +9,7 @@
 </p>
 <!--/subnav-->
 
-<p><%= link_to t('.work_count', :default => "%{count} works", :count => @language.work_count), language_works_path(@language) %> in <%= @language.fandom_count %> fandoms</p>
+<p><%= link_to t(".work_count", :count => @language.work_count), language_works_path(@language) %> in <%= @language.fandom_count %> fandoms</p>
 
 <% unless @works.blank? %>
   <h3 class="heading">Most recent works:</h3>

--- a/app/views/locales/_locale_form.html.erb
+++ b/app/views/locales/_locale_form.html.erb
@@ -1,32 +1,32 @@
 <%= form_for(@locale, html: { class: 'post' }) do |f| %>
-  <p class="required notice">* <%= t('.required_notice', :default => "Required information") %></p>
+  <p class="required notice">* <%= t(".required_notice") %></p>
   
   <fieldset>
-    <legend><%= t('.locale_legend', :default => "Locale") %></legend>
-    <h3 class="landmark heading"><%= t('.locale_heading', :default => "Locale") %></h3>
+    <legend><%= t(".locale_legend") %></legend>
+    <h3 class="landmark heading"><%= t(".locale_heading") %></h3>
     <dl>
-      <dt class="required"><%= f.label :name, t('.name', :default => "Name") + '*' %></dt>
+      <dt class="required"><%= f.label :name, t(".name") + '*' %></dt>
       <dd class="required"><%= f.text_field :name %></dd>
 
-      <dt class="required"><%= f.label :iso, t('.iso', :default => "ISO code") + '*' %></dt>
+      <dt class="required"><%= f.label :iso, t(".iso") + '*' %></dt>
       <dd class="required"><%= f.text_field :iso %></dd>
 
-      <dt class="required"><%= f.label :language_id, t('.language', :default => "Language") + '*' %></dt>
+      <dt class="required"><%= f.label :language_id, t(".language") + '*' %></dt>
       <dd class="required"><%= f.select(:language_id, @languages.collect { |language| [ language.name, language.id ] }) %></dd>
 
       <dt><%= f.check_box :email_enabled %></dt>
-      <dd><%= f.label :email_enabled, t('.enable_email', :default => "Use this locale to send email") %></dd>
+      <dd><%= f.label :email_enabled, t(".enable_email") %></dd>
 
       <dt><%= f.check_box :interface_enabled %></dt>
-      <dd><%= f.label :interface_enabled, t('.enable_interface', :default => "Use this locale for the interface") %></dd>
+      <dd><%= f.label :interface_enabled, t(".enable_interface") %></dd>
 
     </dl>
   </fieldset>
   <fieldset>
-    <legend><%= t('.actions_legend', :default => "Actions") %></legend>
-    <h3 class="landmark heading"><%= t('.actions_heading', :default => "Actions") %></h3>
+    <legend><%= t(".actions_legend") %></legend>
+    <h3 class="landmark heading"><%= t(".actions_heading") %></h3>
     <p class="submit actions">
-      <%= f.submit @locale.new_record? ? t('.create_button', :default => "Create Locale") : t('.edit_button', :default => "Update Locale") %>
+      <%= f.submit @locale.new_record? ? t(".create_button") : t(".edit_button") %>
     </p>
   </fieldset>
 <% end %>

--- a/app/views/locales/_navigation.html.erb
+++ b/app/views/locales/_navigation.html.erb
@@ -1,4 +1,4 @@
 <ul class="navigation actions" role="navigation">
-  <li><%= span_if_current t('.link_to_index', :default => 'Locales'), locales_path %></li>
-  <li><%= span_if_current t('.link_to_new', :default => 'New Locale'), new_locale_path %></li>
+  <li><%= span_if_current t(".link_to_index"), locales_path %></li>
+  <li><%= span_if_current t(".link_to_new"), new_locale_path %></li>
 </ul>

--- a/app/views/locales/edit.html.erb
+++ b/app/views/locales/edit.html.erb
@@ -1,5 +1,5 @@
 <!--Descriptive page name, messages and instructions-->
-<h2 class="heading"><%= t('.edit_locale', :default => 'Edit Locale') %></h2>
+<h2 class="heading"><%= t(".edit_locale") %></h2>
 <%= error_messages_for :locale %>
 <!--/descriptions-->
 

--- a/app/views/locales/index.html.erb
+++ b/app/views/locales/index.html.erb
@@ -1,12 +1,12 @@
 <!--Descriptive page name, messages and instructions-->
-<h2 class="heading"><%= t('.supported_locales', :default => 'Supported Locales') %></h2>
+<h2 class="heading"><%= t(".supported_locales") %></h2>
 <!--/descriptions-->
 
 <!--main content-->
 <%= render 'navigation' %>
 <!--main content-->
-<table summary="<%= t('.locale_table_summary', :default => 'Lists supported locales, along with details of how they are used and options to modify them.') %>">
-  <caption><%= t('.locale_table_caption', :default => 'Supported Locales') %></caption>
+<table summary="<%= t(".locale_table_summary") %>">
+  <caption><%= t(".locale_table_caption") %></caption>
   <thead>
     <tr>
       <th scope="col">Name</th>

--- a/app/views/locales/new.html.erb
+++ b/app/views/locales/new.html.erb
@@ -1,5 +1,5 @@
 <!--Descriptive page name, messages and instructions-->
-<h2 class="heading"><%= t('.add_new_locale', :default => 'New Locale') %></h2>
+<h2 class="heading"><%= t(".add_new_locale") %></h2>
 <%= error_messages_for :locale %>
 <!--/descriptions-->
 

--- a/app/views/muted/users/index.html.erb
+++ b/app/views/muted/users/index.html.erb
@@ -43,7 +43,7 @@
   </fieldset>
 <% end %>
 
-<h3 class="landmark heading"><%= t("heading.landmark.muted") %> %></h3>
+<h3 class="landmark heading"><%= t(".heading.landmark.muted_users") %></h3>
 <% if @mutes.present? %>
   <ul class="pseud index group">
     <%= render partial: "muted_user_blurb", collection: @mutes, as: :mute %>

--- a/app/views/orphans/index.html.erb
+++ b/app/views/orphans/index.html.erb
@@ -1,5 +1,5 @@
 <!--Descriptive page name, messages and instructions-->
-<h2 class="heading"><%=h t('.orphaned_works', :default => 'Orphaned Works') %></h2>
+<h2 class="heading"><%=h t(".orphaned_works") %></h2>
 <!--/descriptions-->
 
 <!--subnav-->

--- a/app/views/orphans/new.html.erb
+++ b/app/views/orphans/new.html.erb
@@ -1,6 +1,6 @@
 <%= render_orphan_partial(@to_be_orphaned) %>
 
 <ul class="actions" role="navigation">
-  <li><%= link_to t('.orphans_about', default: "Read More About The Orphaning Process"), archive_faq_path("orphaning") %></li> 
-  <li><%= link_to t('.links.cancel', default: "Cancel"), :back %></li>
+  <li><%= link_to t(".orphans_about"), archive_faq_path("orphaning") %></li>
+  <li><%= link_to t(".links.cancel"), :back %></li>
 </ul>

--- a/app/views/pseuds/edit.html.erb
+++ b/app/views/pseuds/edit.html.erb
@@ -11,7 +11,7 @@
 <!--/subnav-->
 
 <!--main content-->
-<%= render :partial => 'pseuds_form', :locals => { :button_text => t('.forms.update', :default => "Update") } %>
+<%= render :partial => 'pseuds_form', :locals => { :button_text => t(".forms.update") } %>
 <!--/content-->
 
 <!--subnav-->

--- a/app/views/pseuds/show.html.erb
+++ b/app/views/pseuds/show.html.erb
@@ -7,8 +7,8 @@
 <h3 class="landmark heading">Navigation</h3>
 <ul class="navigation actions" role="navigation">
   <% if @user == current_user %>
-    <li><%= link_to t('.edit_link', :default => 'Edit Pseud'), [:edit, @user, @pseud] %></li>
+    <li><%= link_to t(".edit_link"), [:edit, @user, @pseud] %></li>
   <% end %>
-  <li><%= link_to t('.index_link', :default => 'Back To Pseuds'), user_pseuds_path(@user) %></li>
+  <li><%= link_to t(".index_link"), user_pseuds_path(@user) %></li>
 </ul>
 <!--/subnav-->

--- a/app/views/series/manage.html.erb
+++ b/app/views/series/manage.html.erb
@@ -1,5 +1,5 @@
 <!--Descriptive page name, messages and instructions-->
-<h2 class="heading"><%=h t('.manage_series', :default => "Manage Series:") %> <%=h @series.title %></h2>
+<h2 class="heading"><%=h t(".manage_series") %> <%=h @series.title %></h2>
 <!--/descriptions-->
 
 <!--subnav-->

--- a/app/views/user_mailer/creatorship_notification.html.erb
+++ b/app/views/user_mailer/creatorship_notification.html.erb
@@ -1,6 +1,9 @@
 <% creation_type = @creation.class.name.underscore %>
 <% content_for :message do %>
   <p>
+    <%# i18n-tasks-use t('user_mailer.creatorship_notification.intro_chapter')
+      i18n-tasks-use t('user_mailer.creatorship_notification.intro_series')
+      i18n-tasks-use t('user_mailer.creatorship_notification.intro_work')-%>
     <%= t(".intro_#{creation_type}", adding_user: @adding_user.login, pseud: @creatorship.pseud.name) %>
   </p>
 
@@ -15,6 +18,12 @@
   </p>
 
   <p>
+    <%# i18n-tasks-use t('user_mailer.creatorship_notification.html.remove_chapter')
+      i18n-tasks-use t('user_mailer.creatorship_notification.html.remove_series')
+      i18n-tasks-use t('user_mailer.creatorship_notification.html.remove_work')
+      i18n-tasks-use t('user_mailer.creatorship_notification.html.edit_chapter')
+      i18n-tasks-use t('user_mailer.creatorship_notification.html.edit_series')
+      i18n-tasks-use t('user_mailer.creatorship_notification.html.edit_work')-%>
     <%= t(".html.remove_#{creation_type}", "edit_#{creation_type}_link": style_link(t(".html.edit_#{creation_type}"), edit_polymorphic_url(@creation))).html_safe %>
   </p>
 <% end %>

--- a/app/views/user_mailer/creatorship_notification.text.erb
+++ b/app/views/user_mailer/creatorship_notification.text.erb
@@ -1,5 +1,8 @@
 <% creation_type = @creation.class.name.underscore %>
 <% content_for :message do %>
+<%# i18n-tasks-use t('user_mailer.creatorship_notification.intro_chapter')
+    i18n-tasks-use t('user_mailer.creatorship_notification.intro_series')
+    i18n-tasks-use t('user_mailer.creatorship_notification.intro_work')-%>
 <%= t(".intro_#{creation_type}", adding_user: @adding_user.login, pseud: @creatorship.pseud.name) %>
 
 <%= t ".text.creation", title: creation_title(@creation),
@@ -8,5 +11,8 @@
 
 <%= t ".explanation" %>
 
+<%# i18n-tasks-use t('user_mailer.creatorship_notification.text.remove_chapter')
+  i18n-tasks-use t('user_mailer.creatorship_notification.text.remove_series')
+  i18n-tasks-use t('user_mailer.creatorship_notification.text.remove_work')-%>
 <%= t(".text.remove_#{creation_type}", url: edit_polymorphic_url(@creation)) %>
 <% end %>

--- a/app/views/user_mailer/creatorship_notification_archivist.html.erb
+++ b/app/views/user_mailer/creatorship_notification_archivist.html.erb
@@ -1,6 +1,9 @@
 <% creation_type = @creation.class.name.underscore %>
 <% content_for :message do %>
   <p>
+    <%# i18n-tasks-use t('user_mailer.creatorship_notification_archivist.intro_chapter')
+      i18n-tasks-use t('user_mailer.creatorship_notification_archivist.intro_series')
+      i18n-tasks-use t('user_mailer.creatorship_notification_archivist.intro_work')-%>
     <%= t(".intro_#{creation_type}", archivist: @archivist.login, pseud: @creatorship.pseud.name) %>
   </p>
 
@@ -13,6 +16,12 @@
   <p><%= t(".explanation") %></p>
 
   <p>
+    <%# i18n-tasks-use t('user_mailer.creatorship_notification_archivist.html.remove_chapter')
+      i18n-tasks-use t('user_mailer.creatorship_notification_archivist.html.remove_series')
+      i18n-tasks-use t('user_mailer.creatorship_notification_archivist.html.remove_work')
+      i18n-tasks-use t('user_mailer.creatorship_notification_archivist.html.edit_chapter')
+      i18n-tasks-use t('user_mailer.creatorship_notification_archivist.html.edit_series')
+      i18n-tasks-use t('user_mailer.creatorship_notification_archivist.html.edit_work')-%>
     <%= t(".html.remove_#{creation_type}", "edit_#{creation_type}_link": style_link(t(".html.edit_#{creation_type}"), edit_polymorphic_url(@creation))).html_safe %>
   </p>
 <% end %>

--- a/app/views/user_mailer/creatorship_notification_archivist.text.erb
+++ b/app/views/user_mailer/creatorship_notification_archivist.text.erb
@@ -1,5 +1,8 @@
 <% creation_type = @creation.class.name.underscore %>
 <% content_for :message do %>
+<%# i18n-tasks-use t('user_mailer.creatorship_notification_archivist.intro_chapter')
+    i18n-tasks-use t('user_mailer.creatorship_notification_archivist.intro_series')
+    i18n-tasks-use t('user_mailer.creatorship_notification_archivist.intro_work')-%>
 <%= t(".intro_#{creation_type}", archivist: @archivist.login, pseud: @creatorship.pseud.name) %>
 
 <%= t ".text.creation", title: creation_title(@creation),
@@ -8,5 +11,8 @@
 
 <%= t(".explanation") %>
 
+<%# i18n-tasks-use t('user_mailer.creatorship_notification_archivist.text.remove_chapter')
+    i18n-tasks-use t('user_mailer.creatorship_notification_archivist.text.remove_series')
+    i18n-tasks-use t('user_mailer.creatorship_notification_archivist.text.remove_work')-%>
 <%= t(".text.remove_#{creation_type}", url: edit_polymorphic_url(@creation)) %>
 <% end %>

--- a/app/views/user_mailer/creatorship_request.html.erb
+++ b/app/views/user_mailer/creatorship_request.html.erb
@@ -1,6 +1,9 @@
 <% creation_type = @creation.class.name.underscore %>
 <% content_for :message do %>
   <p>
+    <%# i18n-tasks-use t('user_mailer.creatorship_request.intro_chapter')
+      i18n-tasks-use t('user_mailer.creatorship_request.intro_series')
+      i18n-tasks-use t('user_mailer.creatorship_request.intro_work')-%>
     <%= t(".intro_#{creation_type}", inviting_user: @inviting_user.login, pseud: @creatorship.pseud.name) %>
   </p>
 

--- a/app/views/user_mailer/creatorship_request.text.erb
+++ b/app/views/user_mailer/creatorship_request.text.erb
@@ -1,5 +1,8 @@
 <% creation_type = @creation.class.name.underscore %>
 <% content_for :message do %>
+<%# i18n-tasks-use t('user_mailer.creatorship_request.intro_chapter')
+    i18n-tasks-use t('user_mailer.creatorship_request.intro_series')
+    i18n-tasks-use t('user_mailer.creatorship_request.intro_work')-%>
 <%= t(".intro_#{creation_type}", inviting_user: @inviting_user.login, pseud: @creatorship.pseud.name) %>
 
 <%= t(".text.creation",

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -33,7 +33,7 @@ data:
   # External locale data (e.g. gems).
   # This data is not considered unused and is never written to.
   external:
-    - "<%= %x[bundle info rails-i18n --path].chomp %>/rails/locale/%{locale}.yml"
+    - <%= %x[bundle info rails-i18n --path].chomp %>/rails/locale/%{locale}.yml
 
   ## Specify the router (see Readme for details). Valid values: conservative_router, pattern_router, or a custom class.
   # router: conservative_router
@@ -50,6 +50,8 @@ data:
   #     space: ' '
   #     object_nl: "\n"
   #     array_nl: "\n"
+
+<% require("i18n/tasks/scanners/ast_matchers/rails_model_matcher.rb") %>
 
 # Find translate calls
 search:
@@ -95,7 +97,7 @@ search:
   ##     User.human_attribute_name(:email) and User.model_name.human
   ##
   ## To implement your own, please see `I18n::Tasks::Scanners::AstMatchers::BaseMatcher`.
-  <%# I18n::Tasks.add_ast_matcher('I18n::Tasks::Scanners::AstMatchers::RailsModelMatcher') %>
+  <% I18n::Tasks.add_ast_matcher('I18n::Tasks::Scanners::AstMatchers::RailsModelMatcher') %>
 
   ## Multiple scanners can be used. Their results are merged.
   ## The options specified above are passed down to each scanner. Per-scanner options can be specified as well.

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -32,8 +32,7 @@ data:
   # External locale data (e.g. gems).
   # This data is not considered unused and is never written to.
   external:
-    ## Example (replace %#= with %=):
-    # - "<%#= %x[bundle info vagrant --path].chomp %>/templates/locales/%{locale}.yml"
+    - "<%= %x[bundle info rails-i18n --path].chomp %>/rails/locale/%{locale}.yml"
 
   ## Specify the router (see Readme for details). Valid values: conservative_router, pattern_router, or a custom class.
   # router: conservative_router

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -113,9 +113,10 @@ search:
 #   # deepl_version: "v2"
 
 ## Do not consider these keys missing:
-# ignore_missing:
+ignore_missing:
 # - 'errors.messages.{accepted,blank,invalid,too_short,too_long}'
 # - '{devise,simple_form}.*'
+  - comments.check_permission_to_modify_{frozen,hidden}_status.permission_denied
 
 ## Consider these keys used:
 # ignore_unused:

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -121,8 +121,9 @@ ignore_missing:
   - comments.check_permission_to_modify_{frozen,hidden}_status.permission_denied
 
 ## Consider these keys used:
-# ignore_unused:
-# - 'activerecord.attributes.*'
+ignore_unused:
+- activerecord.attributes.*
+- activerecord.errors.models.*
 # - '{devise,kaminari,will_paginate}.*'
 # - 'simple_form.{yes,no}'
 # - 'simple_form.{placeholders,hints,labels}.*'

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -15,16 +15,14 @@ data:
 
   # Locale files or `File.find` patterns where translations are read from:
   read:
-    ## Default:
-    # - config/locales/%{locale}.yml
-    ## More files:
-    # - config/locales/**/*.%{locale}.yml
     - config/locales/**/en.yml
-    # - config/locales/phrase-exports/%{locale}.yml # All languages, not just English
+    - config/locales/phrase-exports/%{locale}.yml
+    # - locales/views/zh-CN.yml # These are also in the phrase exports
 
   # Locale files to write new keys to, based on a list of key pattern => file rules. Matched from top to bottom:
   # `i18n-tasks normalize -p` will force move the keys according to these rules
   write:
+    # - 'config/locales/phrase-exports/%{locale}.yml' # Cannot route by language, 'en' files end up in the wrong place
     ## For example, write devise and simple form keys to their respective files:
     # - ['{devise, simple_form}.*', 'config/locales/\1.%{locale}.yml']
     ## Catch-all default:

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -19,7 +19,8 @@ data:
     # - config/locales/%{locale}.yml
     ## More files:
     # - config/locales/**/*.%{locale}.yml
-    - config/locales/**/%{locale}.{rb,yml}
+    - config/locales/**/en.yml
+    # - config/locales/phrase-exports/%{locale}.yml # All languages, not just English
 
   # Locale files to write new keys to, based on a list of key pattern => file rules. Matched from top to bottom:
   # `i18n-tasks normalize -p` will force move the keys according to these rules

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -1,0 +1,154 @@
+# i18n-tasks finds and manages missing and unused translations: https://github.com/glebm/i18n-tasks
+
+# The "main" locale.
+base_locale: en
+## All available locales are inferred from the data by default. Alternatively, specify them explicitly:
+# locales: [es, fr]
+## Reporting locale, default: en. Available: en, ru.
+# internal_locale: en
+
+# Read and write translations.
+data:
+  ## Translations are read from the file system. Supported format: YAML, JSON.
+  ## Provide a custom adapter:
+  # adapter: I18n::Tasks::Data::FileSystem
+
+  # Locale files or `File.find` patterns where translations are read from:
+  read:
+    ## Default:
+    # - config/locales/%{locale}.yml
+    ## More files:
+    # - config/locales/**/*.%{locale}.yml
+    - config/locales/**/%{locale}.{rb,yml}
+
+  # Locale files to write new keys to, based on a list of key pattern => file rules. Matched from top to bottom:
+  # `i18n-tasks normalize -p` will force move the keys according to these rules
+  write:
+    ## For example, write devise and simple form keys to their respective files:
+    # - ['{devise, simple_form}.*', 'config/locales/\1.%{locale}.yml']
+    ## Catch-all default:
+    # - config/locales/%{locale}.yml
+
+  # External locale data (e.g. gems).
+  # This data is not considered unused and is never written to.
+  external:
+    ## Example (replace %#= with %=):
+    # - "<%#= %x[bundle info vagrant --path].chomp %>/templates/locales/%{locale}.yml"
+
+  ## Specify the router (see Readme for details). Valid values: conservative_router, pattern_router, or a custom class.
+  # router: conservative_router
+
+  yaml:
+    write:
+      # do not wrap lines at 80 characters
+      line_width: -1
+
+  ## Pretty-print JSON:
+  # json:
+  #   write:
+  #     indent: '  '
+  #     space: ' '
+  #     object_nl: "\n"
+  #     array_nl: "\n"
+
+# Find translate calls
+search:
+  ## Paths or `File.find` patterns to search in:
+  # paths:
+  #  - app/
+
+  ## Root directories for relative keys resolution.
+  # relative_roots:
+  #   - app/controllers
+  #   - app/helpers
+  #   - app/mailers
+  #   - app/presenters
+  #   - app/views
+
+  ## Directories where method names which should not be part of a relative key resolution.
+  # By default, if a relative translation is used inside a method, the name of the method will be considered part of the resolved key.
+  # Directories listed here will not consider the name of the method part of the resolved key
+  #
+  # relative_exclude_method_name_paths:
+  #  -
+
+  ## Files or `File.fnmatch` patterns to exclude from search. Some files are always excluded regardless of this setting:
+  ##   *.jpg *.jpeg *.png *.gif *.svg *.ico *.eot *.otf *.ttf *.woff *.woff2 *.pdf *.css *.sass *.scss *.less
+  ##   *.yml *.json *.zip *.tar.gz *.swf *.flv *.mp3 *.wav *.flac *.webm *.mp4 *.ogg *.opus *.webp *.map *.xlsx
+  exclude:
+    - app/assets/images
+    - app/assets/fonts
+    - app/assets/videos
+    - app/assets/builds
+
+  ## Alternatively, the only files or `File.fnmatch patterns` to search in `paths`:
+  ## If specified, this settings takes priority over `exclude`, but `exclude` still applies.
+  # only: ["*.rb", "*.html.slim"]
+
+  ## If `strict` is `false`, guess usages such as t("categories.#{category}.title"). The default is `true`.
+  # strict: true
+
+  ## Allows adding ast_matchers for finding translations using the AST-scanners
+  ## The available matchers are:
+  ## - RailsModelMatcher
+  ##     Matches ActiveRecord translations like
+  ##     User.human_attribute_name(:email) and User.model_name.human
+  ##
+  ## To implement your own, please see `I18n::Tasks::Scanners::AstMatchers::BaseMatcher`.
+  <%# I18n::Tasks.add_ast_matcher('I18n::Tasks::Scanners::AstMatchers::RailsModelMatcher') %>
+
+  ## Multiple scanners can be used. Their results are merged.
+  ## The options specified above are passed down to each scanner. Per-scanner options can be specified as well.
+  ## See this example of a custom scanner: https://github.com/glebm/i18n-tasks/wiki/A-custom-scanner-example
+
+## Translation Services
+# translation:
+#   # Google Translate
+#   # Get an API key and set billing info at https://code.google.com/apis/console to use Google Translate
+#   google_translate_api_key: "AbC-dEf5"
+#   # DeepL Pro Translate
+#   # Get an API key and subscription at https://www.deepl.com/pro to use DeepL Pro
+#   deepl_api_key: "48E92789-57A3-466A-9959-1A1A1A1A1A1A"
+#   # deepl_host: "https://api.deepl.com"
+#   # deepl_version: "v2"
+
+## Do not consider these keys missing:
+# ignore_missing:
+# - 'errors.messages.{accepted,blank,invalid,too_short,too_long}'
+# - '{devise,simple_form}.*'
+
+## Consider these keys used:
+# ignore_unused:
+# - 'activerecord.attributes.*'
+# - '{devise,kaminari,will_paginate}.*'
+# - 'simple_form.{yes,no}'
+# - 'simple_form.{placeholders,hints,labels}.*'
+# - 'simple_form.{error_notification,required}.:'
+
+## Exclude these keys from the `i18n-tasks eq-base' report:
+# ignore_eq_base:
+#   all:
+#     - common.ok
+#   fr,es:
+#     - common.brand
+
+## Exclude these keys from the `i18n-tasks check-consistent-interpolations` report:
+# ignore_inconsistent_interpolations:
+# - 'activerecord.attributes.*'
+
+## Ignore these keys completely:
+# ignore:
+#  - kaminari.*
+
+## Sometimes, it isn't possible for i18n-tasks to match the key correctly,
+## e.g. in case of a relative key defined in a helper method.
+## In these cases you can use the built-in PatternMapper to map patterns to keys, e.g.:
+#
+# <%# I18n::Tasks.add_scanner 'I18n::Tasks::Scanners::PatternMapper',
+#       only: %w(*.html.haml *.html.slim),
+#       patterns: [['= title\b', '.page_title']] %>
+#
+# The PatternMapper can also match key literals via a special %{key} interpolation, e.g.:
+#
+# <%# I18n::Tasks.add_scanner 'I18n::Tasks::Scanners::PatternMapper',
+#       patterns: [['\bSpree\.t[( ]\s*%{key}', 'spree.%{key}']] %>

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -125,6 +125,8 @@ ignore_unused:
 - activerecord.attributes.*
 - activerecord.errors.models.*
 - devise.*
+- errors.attributes.ticket_number.{closed_ticket,invalid_department,required}
+- attributes.ticket_number
 # - 'simple_form.{yes,no}'
 # - 'simple_form.{placeholders,hints,labels}.*'
 # - 'simple_form.{error_notification,required}.:'

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -124,7 +124,7 @@ ignore_missing:
 ignore_unused:
 - activerecord.attributes.*
 - activerecord.errors.models.*
-# - '{devise,kaminari,will_paginate}.*'
+- devise.*
 # - 'simple_form.{yes,no}'
 # - 'simple_form.{placeholders,hints,labels}.*'
 # - 'simple_form.{error_notification,required}.:'

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -116,20 +116,16 @@ search:
 
 ## Do not consider these keys missing:
 ignore_missing:
-# - 'errors.messages.{accepted,blank,invalid,too_short,too_long}'
-# - '{devise,simple_form}.*'
   - comments.check_permission_to_modify_{frozen,hidden}_status.permission_denied
 
 ## Consider these keys used:
 ignore_unused:
-- activerecord.attributes.*
-- activerecord.errors.models.*
-- devise.*
-- errors.attributes.ticket_number.{closed_ticket,invalid_department,required}
-- attributes.ticket_number
-# - 'simple_form.{yes,no}'
-# - 'simple_form.{placeholders,hints,labels}.*'
-# - 'simple_form.{error_notification,required}.:'
+  - activerecord.attributes.*
+  - activerecord.errors.models.*
+  - devise.*
+  - errors.messages.*
+  - errors.attributes.ticket_number.{closed_ticket,invalid_department,required}
+  - attributes.ticket_number
 
 ## Exclude these keys from the `i18n-tasks eq-base' report:
 # ignore_eq_base:

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -51,7 +51,7 @@ data:
   #     object_nl: "\n"
   #     array_nl: "\n"
 
-<% require("i18n/tasks/scanners/ast_matchers/rails_model_matcher.rb") %>
+<% require "i18n/tasks/scanners/ast_matchers/rails_model_matcher.rb" %>
 
 # Find translate calls
 search:
@@ -77,11 +77,11 @@ search:
   ## Files or `File.fnmatch` patterns to exclude from search. Some files are always excluded regardless of this setting:
   ##   *.jpg *.jpeg *.png *.gif *.svg *.ico *.eot *.otf *.ttf *.woff *.woff2 *.pdf *.css *.sass *.scss *.less
   ##   *.yml *.json *.zip *.tar.gz *.swf *.flv *.mp3 *.wav *.flac *.webm *.mp4 *.ogg *.opus *.webp *.map *.xlsx
-  exclude:
-    - app/assets/images
-    - app/assets/fonts
-    - app/assets/videos
-    - app/assets/builds
+  # exclude:
+  #   - app/assets/images
+  #   - app/assets/fonts
+  #   - app/assets/videos
+  #   - app/assets/builds
 
   ## Alternatively, the only files or `File.fnmatch patterns` to search in `paths`:
   ## If specified, this settings takes priority over `exclude`, but `exclude` still applies.
@@ -138,6 +138,10 @@ ignore_unused:
 ## Exclude these keys from the `i18n-tasks check-consistent-interpolations` report:
 # ignore_inconsistent_interpolations:
 # - 'activerecord.attributes.*'
+
+## Exclude these keys from the newlines test task:
+# ignore_newlines:
+# - user_mailer.signup_notification.*
 
 ## Ignore these keys completely:
 # ignore:

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -122,6 +122,7 @@ ignore_missing:
 ignore_unused:
   - activerecord.attributes.*
   - activerecord.errors.models.*
+  - activerecord.models.*
   - devise.*
   - errors.messages.*
   - errors.attributes.ticket_number.{closed_ticket,invalid_department,required}

--- a/config/locales/controllers/en.yml
+++ b/config/locales/controllers/en.yml
@@ -23,6 +23,9 @@ en:
         muted: "You have muted the user %{name}."
       destroy:
         unmuted: "You have unmuted the user %{name}."
+  challenges:
+    no_collection: What collection did you want to work with?
+    no_challenge: What challenge did you want to work on?
   challenge_assignments:
     no_challenge: What challenge did you want to work with?
     not_owner: You aren't the owner of that assignment.

--- a/config/locales/controllers/en.yml
+++ b/config/locales/controllers/en.yml
@@ -6,6 +6,11 @@ en:
         success:
           one: "%{count} person from the invite queue is being invited."
           other: "%{count} people from the invite queue are being invited."
+  application:
+    check_user_status:
+      ban_notice: "Your account has been banned. You are not permitted to add or edit archive content. Please %{contact_abuse_link} for more information."
+      suspension_notice: "Your account has been suspended until %{suspended_until}. You may not add or edit content until your suspension has been resolved. Please %{contact_abuse_link} for more information."
+      contact_abuse: contact Abuse
   blocked:
     users:
       create:

--- a/config/locales/controllers/en.yml
+++ b/config/locales/controllers/en.yml
@@ -29,6 +29,15 @@ en:
     multifandom: Multifandom
     unrevealed: Mystery Work
     unspecified_fandom: No fandom specified
+  collection_participants:
+    owners_required: You can't remove the only owner!
+    no_collection: Which collection did you want to join?
+    applied_to_join_collection: "You have applied to join %{collection}."
+    accepted_invite: "You are now a member of %{collection}."
+    no_invitation: You have already joined (or applied to) this collection.
+    update_success: "Updated %{participant}."
+    update_failure: "Couldn't update %{participant}."
+    destroy: "Removed %{participant} from collection."
   comments:
     check_blocked:
       parent: "Sorry, you have been blocked by one or more of this work's creators."

--- a/config/locales/controllers/en.yml
+++ b/config/locales/controllers/en.yml
@@ -77,6 +77,10 @@ en:
       error: Sorry, that comment could not be unhidden.
       permission_denied: Sorry, you don't have permission to unhide that comment.
       success: Comment successfully unhidden!
+  feedbacks:
+    create:
+      successfully_sent: Your message was sent to the Archive team - thank you!
+      failure_send: Sorry, your message could not be saved - please try again!
   kudos:
     create:
       success: Thank you for leaving kudos!

--- a/config/locales/controllers/en.yml
+++ b/config/locales/controllers/en.yml
@@ -23,6 +23,12 @@ en:
         muted: "You have muted the user %{name}."
       destroy:
         unmuted: "You have unmuted the user %{name}."
+  challenge_assignments:
+    no_challenge: What challenge did you want to work with?
+    not_owner: You aren't the owner of that assignment.
+    signup_open: Signup is currently open, you cannot make assignments now.
+    assignments_sent: Assignments have already been sent! If necessary, you can purge them.
+    assignments_not_sent: Assignments have not been sent! You might want matching instead.
   chapters:
     anonymous: Anonymous
     chapter_position: " - Chapter %{position}"

--- a/config/locales/controllers/en.yml
+++ b/config/locales/controllers/en.yml
@@ -6,6 +6,13 @@ en:
         success:
           one: "%{count} person from the invite queue is being invited."
           other: "%{count} people from the invite queue are being invited."
+      create:
+        no_email: Please enter an email address.
+        sent: "An invitation was sent to %{email_address}"
+      grant_invites_to_users:
+        invites_created: Invitations successfully created.
+      find:
+        user_not_found: No results were found. Try another search.
   application:
     check_user_status:
       ban_notice: "Your account has been banned. You are not permitted to add or edit archive content. Please %{contact_abuse_link} for more information."

--- a/config/locales/controllers/en.yml
+++ b/config/locales/controllers/en.yml
@@ -33,11 +33,12 @@ en:
     assignments_sent: Assignments have already been sent! If necessary, you can purge them.
     assignments_not_sent: Assignments have not been sent! You might want matching instead.
   chapters:
-    anonymous: Anonymous
-    chapter_position: " - Chapter %{position}"
-    multifandom: Multifandom
-    unrevealed: Mystery Work
-    unspecified_fandom: No fandom specified
+    show:
+      anonymous: Anonymous
+      chapter_position: " - Chapter %{position}"
+      multifandom: Multifandom
+      unrevealed: Mystery Work
+      unspecified_fandom: No fandom specified
   collection_participants:
     owners_required: You can't remove the only owner!
     no_collection: Which collection did you want to join?

--- a/config/locales/controllers/en.yml
+++ b/config/locales/controllers/en.yml
@@ -46,6 +46,9 @@ en:
       multifandom: Multifandom
       unrevealed: Mystery Work
       unspecified_fandom: No fandom specified
+  collection_items:
+    create:
+      invitation_not_sent: This item could not be invited.
   collection_participants:
     owners_required: You can't remove the only owner!
     no_collection: Which collection did you want to join?
@@ -84,6 +87,12 @@ en:
       error: Sorry, that comment could not be unhidden.
       permission_denied: Sorry, you don't have permission to unhide that comment.
       success: Comment successfully unhidden!
+  external_authors:
+    complete_claim:
+      external_author_claimed: "We have added the stories imported under %{email} to your account."
+  external_works:
+    update:
+      successfully_updated: External work was successfully updated.
   feedbacks:
     create:
       successfully_sent: Your message was sent to the Archive team - thank you!
@@ -91,6 +100,14 @@ en:
   kudos:
     create:
       success: Thank you for leaving kudos!
+  locales:
+    create:
+      successfully_added: Locale was successfully added.
+  languages:
+    update:
+      successfully_updated: Language was successfully updated.
+    create:
+      successfully_added: Language was successfully added.
   users:
     passwords:
       create:

--- a/config/locales/controllers/en.yml
+++ b/config/locales/controllers/en.yml
@@ -2,43 +2,37 @@
 en:
   admin:
     admin_invitations:
+      create:
+        no_email: Please enter an email address.
+        sent: An invitation was sent to %{email_address}
+      find:
+        user_not_found: No results were found. Try another search.
+      grant_invites_to_users:
+        invites_created: Invitations successfully created.
       invite_from_queue:
         success:
           one: "%{count} person from the invite queue is being invited."
           other: "%{count} people from the invite queue are being invited."
-      create:
-        no_email: Please enter an email address.
-        sent: "An invitation was sent to %{email_address}"
-      grant_invites_to_users:
-        invites_created: Invitations successfully created.
-      find:
-        user_not_found: No results were found. Try another search.
   application:
     check_user_status:
-      ban_notice: "Your account has been banned. You are not permitted to add or edit archive content. Please %{contact_abuse_link} for more information."
-      suspension_notice: "Your account has been suspended until %{suspended_until}. You may not add or edit content until your suspension has been resolved. Please %{contact_abuse_link} for more information."
+      ban_notice: Your account has been banned. You are not permitted to add or edit archive content. Please %{contact_abuse_link} for more information.
       contact_abuse: contact Abuse
+      suspension_notice: Your account has been suspended until %{suspended_until}. You may not add or edit content until your suspension has been resolved. Please %{contact_abuse_link} for more information.
   blocked:
     users:
       create:
-        blocked: "You have blocked the user %{name}."
+        blocked: You have blocked the user %{name}.
       destroy:
-        unblocked: "You have unblocked the user %{name}."
-  muted:
-    users:
-      create:
-        muted: "You have muted the user %{name}."
-      destroy:
-        unmuted: "You have unmuted the user %{name}."
-  challenges:
-    no_collection: What collection did you want to work with?
-    no_challenge: What challenge did you want to work on?
+        unblocked: You have unblocked the user %{name}.
   challenge_assignments:
+    assignments_not_sent: Assignments have not been sent! You might want matching instead.
+    assignments_sent: Assignments have already been sent! If necessary, you can purge them.
     no_challenge: What challenge did you want to work with?
     not_owner: You aren't the owner of that assignment.
     signup_open: Signup is currently open, you cannot make assignments now.
-    assignments_sent: Assignments have already been sent! If necessary, you can purge them.
-    assignments_not_sent: Assignments have not been sent! You might want matching instead.
+  challenges:
+    no_challenge: What challenge did you want to work on?
+    no_collection: What collection did you want to work with?
   chapters:
     show:
       anonymous: Anonymous
@@ -50,18 +44,18 @@ en:
     create:
       invitation_not_sent: This item could not be invited.
   collection_participants:
-    owners_required: You can't remove the only owner!
+    accepted_invite: You are now a member of %{collection}.
+    applied_to_join_collection: You have applied to join %{collection}.
+    destroy: Removed %{participant} from collection.
     no_collection: Which collection did you want to join?
-    applied_to_join_collection: "You have applied to join %{collection}."
-    accepted_invite: "You are now a member of %{collection}."
     no_invitation: You have already joined (or applied to) this collection.
-    update_success: "Updated %{participant}."
-    update_failure: "Couldn't update %{participant}."
-    destroy: "Removed %{participant} from collection."
+    owners_required: You can't remove the only owner!
+    update_failure: Couldn't update %{participant}.
+    update_success: Updated %{participant}.
   comments:
     check_blocked:
-      parent: "Sorry, you have been blocked by one or more of this work's creators."
-      reply: "Sorry, you have been blocked by that user."
+      parent: Sorry, you have been blocked by one or more of this work's creators.
+      reply: Sorry, you have been blocked by that user.
     check_frozen:
       error: Sorry, you cannot reply to a frozen comment.
     check_hidden_by_admin:
@@ -75,39 +69,45 @@ en:
       error: Sorry, that comment thread could not be frozen.
       permission_denied: Sorry, you don't have permission to freeze that comment thread.
       success: Comment thread successfully frozen!
-    unfreeze:
-      error: Sorry, that comment thread could not be unfrozen.
-      permission_denied: Sorry, you don't have permission to unfreeze that comment thread.
-      success: Comment thread successfully unfrozen!
     hide:
       error: Sorry, that comment could not be hidden.
       permission_denied: Sorry, you don't have permission to hide that comment.
       success: Comment successfully hidden!
+    unfreeze:
+      error: Sorry, that comment thread could not be unfrozen.
+      permission_denied: Sorry, you don't have permission to unfreeze that comment thread.
+      success: Comment thread successfully unfrozen!
     unhide:
       error: Sorry, that comment could not be unhidden.
       permission_denied: Sorry, you don't have permission to unhide that comment.
       success: Comment successfully unhidden!
   external_authors:
     complete_claim:
-      external_author_claimed: "We have added the stories imported under %{email} to your account."
+      external_author_claimed: We have added the stories imported under %{email} to your account.
   external_works:
     update:
       successfully_updated: External work was successfully updated.
   feedbacks:
     create:
-      successfully_sent: Your message was sent to the Archive team - thank you!
       failure_send: Sorry, your message could not be saved - please try again!
+      successfully_sent: Your message was sent to the Archive team - thank you!
   kudos:
     create:
       success: Thank you for leaving kudos!
+  languages:
+    create:
+      successfully_added: Language was successfully added.
+    update:
+      successfully_updated: Language was successfully updated.
   locales:
     create:
       successfully_added: Locale was successfully added.
-  languages:
-    update:
-      successfully_updated: Language was successfully updated.
-    create:
-      successfully_added: Language was successfully added.
+  muted:
+    users:
+      create:
+        muted: You have muted the user %{name}.
+      destroy:
+        unmuted: You have unmuted the user %{name}.
   users:
     passwords:
       create:

--- a/config/locales/devise/en.yml
+++ b/config/locales/devise/en.yml
@@ -1,73 +1,72 @@
-# Additional translations at https://github.com/plataformatec/devise/wiki/I18n
-
+---
 en:
   devise:
     confirmations:
-      confirmed: "Your email address has been successfully confirmed."
-      send_instructions: "You will receive an email with instructions for how to confirm your email address in a few minutes."
-      send_paranoid_instructions: "If your email address exists in our database, you will receive an email with instructions for how to confirm your email address in a few minutes."
+      confirmed: Your email address has been successfully confirmed.
+      send_instructions: You will receive an email with instructions for how to confirm your email address in a few minutes.
+      send_paranoid_instructions: If your email address exists in our database, you will receive an email with instructions for how to confirm your email address in a few minutes.
     failure:
-      user:
-        already_authenticated: "You are already signed in."
-        inactive: "You'll need to activate your account before you can log in. Please check your email or contact support."
-        invalid: "The password or user name you entered doesn't match our records. Please try again or <a href=\"%{reset_path}\">reset your password</a>. If you still can't log in, please visit <a href=\"%{problems_path}\">Problems When Logging In</a> for help."
-        locked: "Your account has been locked for 5 minutes due to too many failed login attempts."
-        last_attempt: "You have one more attempt before your account is locked."
-        not_found_in_database: "The password or user name you entered doesn't match our records. Please try again or <a href=\"%{reset_path}\">reset your password</a>. If you still can't log in, please visit <a href=\"%{problems_path}\">Problems When Logging In</a> for help."
-        timeout: "Your session expired. Please sign in again to continue."
-        unauthenticated: "You need to sign in or sign up before continuing."
-        unconfirmed: "You have to confirm your email before continuing. Please check your email for the confirmation link."
       admin:
-        already_authenticated: "You are already signed in."
-        inactive: "Your account is not activated yet."
-        invalid: "The password or admin user name you entered doesn't match our records."
-        locked: "Your account is locked."
-        last_attempt: "You have one more attempt before your account is locked."
-        not_found_in_database: "The password or admin user name you entered doesn't match our records."
-        timeout: "Your session expired. Please sign in again to continue."
-        unauthenticated: "You need to sign in or sign up before continuing."
-        unconfirmed: "You have to confirm your email address before continuing."
+        already_authenticated: You are already signed in.
+        inactive: Your account is not activated yet.
+        invalid: The password or admin user name you entered doesn't match our records.
+        last_attempt: You have one more attempt before your account is locked.
+        locked: Your account is locked.
+        not_found_in_database: The password or admin user name you entered doesn't match our records.
+        timeout: Your session expired. Please sign in again to continue.
+        unauthenticated: You need to sign in or sign up before continuing.
+        unconfirmed: You have to confirm your email address before continuing.
+      user:
+        already_authenticated: You are already signed in.
+        inactive: You'll need to activate your account before you can log in. Please check your email or contact support.
+        invalid: The password or user name you entered doesn't match our records. Please try again or <a href="%{reset_path}">reset your password</a>. If you still can't log in, please visit <a href="%{problems_path}">Problems When Logging In</a> for help.
+        last_attempt: You have one more attempt before your account is locked.
+        locked: Your account has been locked for 5 minutes due to too many failed login attempts.
+        not_found_in_database: The password or user name you entered doesn't match our records. Please try again or <a href="%{reset_path}">reset your password</a>. If you still can't log in, please visit <a href="%{problems_path}">Problems When Logging In</a> for help.
+        timeout: Your session expired. Please sign in again to continue.
+        unauthenticated: You need to sign in or sign up before continuing.
+        unconfirmed: You have to confirm your email before continuing. Please check your email for the confirmation link.
     mailer:
       confirmation_instructions:
-        subject: "Confirmation instructions"
+        subject: Confirmation instructions
+      password_change:
+        subject: Password Changed
       reset_password_instructions:
         subject: "[%{app_name}] Generated reset password link"
       unlock_instructions:
-        subject: "Unlock instructions"
-      password_change:
-        subject: "Password Changed"
+        subject: Unlock instructions
     omniauth_callbacks:
-      failure: "Could not authenticate you from %{kind} because \"%{reason}\"."
-      success: "Successfully authenticated from %{kind} account."
+      failure: Could not authenticate you from %{kind} because "%{reason}".
+      success: Successfully authenticated from %{kind} account.
     passwords:
-      no_token: "You can't access this page without coming from a password reset email. If you do come from a password reset email, please make sure you used the full URL provided."
-      send_instructions: "Check your email for instructions on how to reset your password."
-      send_paranoid_instructions: "If your email address exists in our database, you will receive a password recovery link at your email address in a few minutes."
-      updated: "Your password has been changed successfully. You are now signed in."
-      updated_not_active: "Your password has been changed successfully."
+      no_token: You can't access this page without coming from a password reset email. If you do come from a password reset email, please make sure you used the full URL provided.
+      send_instructions: Check your email for instructions on how to reset your password.
+      send_paranoid_instructions: If your email address exists in our database, you will receive a password recovery link at your email address in a few minutes.
+      updated: Your password has been changed successfully. You are now signed in.
+      updated_not_active: Your password has been changed successfully.
     registrations:
-      destroyed: "Bye! Your account has been successfully cancelled. We hope to see you again soon."
-      signed_up: "Welcome! You have signed up successfully."
-      signed_up_but_inactive: "You have signed up successfully. However, we could not sign you in because your account is not yet activated."
-      signed_up_but_locked: "You have signed up successfully. However, we could not sign you in because your account is locked."
-      signed_up_but_unconfirmed: "A message with a confirmation link has been sent to your email address. Please follow the link to activate your account."
-      update_needs_confirmation: "You updated your account successfully, but we need to verify your new email address. Please check your email and follow the confirm link to confirm your new email address."
-      updated: "Your account has been updated successfully."
+      destroyed: Bye! Your account has been successfully cancelled. We hope to see you again soon.
+      signed_up: Welcome! You have signed up successfully.
+      signed_up_but_inactive: You have signed up successfully. However, we could not sign you in because your account is not yet activated.
+      signed_up_but_locked: You have signed up successfully. However, we could not sign you in because your account is locked.
+      signed_up_but_unconfirmed: A message with a confirmation link has been sent to your email address. Please follow the link to activate your account.
+      update_needs_confirmation: You updated your account successfully, but we need to verify your new email address. Please check your email and follow the confirm link to confirm your new email address.
+      updated: Your account has been updated successfully.
     sessions:
-      signed_in: "Successfully logged in."
-      signed_out: "Successfully logged out."
-      already_signed_out: "Successfully logged out."
+      already_signed_out: Successfully logged out.
+      signed_in: Successfully logged in.
+      signed_out: Successfully logged out.
     unlocks:
-      send_instructions: "You will receive an email with instructions for how to unlock your account in a few minutes."
-      send_paranoid_instructions: "If your account exists, you will receive an email with instructions for how to unlock it in a few minutes."
-      unlocked: "Your account has been unlocked successfully. Please sign in to continue."
+      send_instructions: You will receive an email with instructions for how to unlock your account in a few minutes.
+      send_paranoid_instructions: If your account exists, you will receive an email with instructions for how to unlock it in a few minutes.
+      unlocked: Your account has been unlocked successfully. Please sign in to continue.
   errors:
     messages:
-      already_confirmed: "was already confirmed, please try signing in"
-      confirmation_period_expired: "needs to be confirmed within %{period}, please request a new one"
-      expired: "has expired, please request a new one"
-      not_found: "not found"
-      not_locked: "was not locked"
+      already_confirmed: was already confirmed, please try signing in
+      confirmation_period_expired: needs to be confirmed within %{period}, please request a new one
+      expired: has expired, please request a new one
+      not_found: not found
+      not_locked: was not locked
       not_saved:
-        one: "1 error prohibited this %{resource} from being saved:"
+        one: '1 error prohibited this %{resource} from being saved:'
         other: "%{count} errors prohibited this %{resource} from being saved:"

--- a/config/locales/helpers/en.yml
+++ b/config/locales/helpers/en.yml
@@ -1,14 +1,15 @@
+---
 en:
   users_helper:
-    log_validated: Account Validated
-    log_role_added: "Role Added: "
-    log_role_removed: "Role Removed: "
-    log_suspended: "Suspended until "
-    log_lift_suspension: Suspension Lifted
     log_ban: Suspended Permanently
-    log_warn: Warned
-    log_rename: Username Changed
-    log_password_change: Password Changed
     log_email_change: Email Changed
-    log_troubleshot: Account Troubleshot
+    log_lift_suspension: Suspension Lifted
     log_note: Note Added
+    log_password_change: Password Changed
+    log_rename: Username Changed
+    log_role_added: 'Role Added: '
+    log_role_removed: 'Role Removed: '
+    log_suspended: 'Suspended until '
+    log_troubleshot: Account Troubleshot
+    log_validated: Account Validated
+    log_warn: Warned

--- a/config/locales/helpers/en.yml
+++ b/config/locales/helpers/en.yml
@@ -1,0 +1,14 @@
+en:
+  users_helper:
+    log_validated: Account Validated
+    log_role_added: "Role Added: "
+    log_role_removed: "Role Removed: "
+    log_suspended: "Suspended until "
+    log_lift_suspension: Suspension Lifted
+    log_ban: Suspended Permanently
+    log_warn: Warned
+    log_rename: Username Changed
+    log_password_change: Password Changed
+    log_email_change: Email Changed
+    log_troubleshot: Account Troubleshot
+    log_note: Note Added

--- a/config/locales/mailers/en.yml
+++ b/config/locales/mailers/en.yml
@@ -1,58 +1,33 @@
+---
 en:
-  mailer:
-    general:
-      closing:
-        formal: "Sincerely,"
-        informal: "Best,"
-      greeting:
-        formal: "Dear %{name},"
-        informal:
-          addressed: "Hi, %{name}!"
-          unaddressed: "Hi!"
-        introductory: "Hello from the Archive of Our Own!"
-      metadata_label_indicator: ": "
-      creation:
-        link_with_word_count: "%{creation_link} (%{word_count})"
-        title_with_word_count: "\"%{creation_title}\" (%{word_count})"
-        title_with_chapter_number: "Chapter %{position} of %{title}"
-        word_count:
-          one: "%{count} word"
-          other: "%{count} words"
-      signature:
-        app_short_name: AO3
-        open_doors: The Open Doors team
-        parent_org: Organization for Transformative Works
-        support: The AO3 Support team
-      footer:
-        general:
-          html:
-            support_link_text: contact Support
-            donate_link_text: your donations
-            part1: "If you've received this message in error, please %{support_link}."
-            part2: "The Archive of Our Own is a fan-run and fan-supported archive that relies on %{donate_link}."
-          text:
-            part1: "If you've received this message in error, please contact Support at %{support_url}."
-            part2: "The Archive of Our Own is a fan-run and fan-supported archive that relies on your donations: %{donate_url}."
-        sent_at: "Sent at %{sent_at}."
+  admin:
+    mailer:
+      reset_password_instructions:
+        expiration:
+          one: If you do not use this link to reset your password within %{count} day, it will expire, and you will have to request a new one.
+          other: If you do not use this link to reset your password within %{count} days, it will expire, and you will have to request a new one.
+        intro: 'Someone has requested a password reset for your account. You can change your account password by following the link below and entering your new password:'
+        link_title_html: Change my password.
+        subject: "[%{app_name}] Reset your admin password"
+        unrequested: If you did not request this password reset, you may ignore this email and your previous password will continue to work.
   admin_mailer:
     set_password_notification:
-      subject: "[%{app_name}] Your AO3 admin account"
       created: Your AO3 admin account has been created.
-      username: Admin username
-      url: Admin login URL
-      finish: "Please follow this link to set your password so you can log in: %{set_password_url}."
-      finish_html: "Please %{set_password_link} so you can log in."
-      set_password: "follow this link to set your password"
-      request_reset: request a password reset
-      expiration_html:
-        one: "The link to set your password is good for %{count} day. If it no longer works, you can %{request_reset_link} and use the link that will be emailed to you instead."
-        other: "The link to set your password is good for %{count} days. If it no longer works, you can %{request_reset_link} and use the link that will be emailed to you instead."
       expiration:
-        one: "The link to set your password is good for %{count} day. If it no longer works, you can request a password reset and use the link that will be emailed to you instead: %{request_reset_url}."
-        other: "The link to set your password is good for %{count} days. If it no longer works, you can request a password reset and use the link that will be emailed to you instead: %{request_reset_url}."
+        one: 'The link to set your password is good for %{count} day. If it no longer works, you can request a password reset and use the link that will be emailed to you instead: %{request_reset_url}.'
+        other: 'The link to set your password is good for %{count} days. If it no longer works, you can request a password reset and use the link that will be emailed to you instead: %{request_reset_url}.'
+      expiration_html:
+        one: The link to set your password is good for %{count} day. If it no longer works, you can %{request_reset_link} and use the link that will be emailed to you instead.
+        other: The link to set your password is good for %{count} days. If it no longer works, you can %{request_reset_link} and use the link that will be emailed to you instead.
+      finish: 'Please follow this link to set your password so you can log in: %{set_password_url}.'
+      finish_html: Please %{set_password_link} so you can log in.
+      request_reset: request a password reset
+      set_password: follow this link to set your password
+      subject: "[%{app_name}] Your AO3 admin account"
+      url: Admin login URL
+      username: Admin username
   kudo_mailer:
     batch_kudo_notification:
-      subject: "[%{app_name}] You've got kudos!"
       guest:
         one: a guest
         other: "%{count} guests"
@@ -61,282 +36,305 @@ en:
           one: "%{givers_list} left kudos on %{commentable_link}."
           other: "%{givers_list} left kudos on %{commentable_link}."
         single_guest:
-          giver_list: "A guest"
+          giver_list: A guest
           left_kudos: "%{giver_list} left kudos on %{commentable_link}."
+      subject: "[%{app_name}] You've got kudos!"
       text:
         left_kudos:
-          one: "%{givers_list} left kudos on \"%{commentable_title}\" (%{commentable_url})."
-          other: "%{givers_list} left kudos on \"%{commentable_title}\" (%{commentable_url})."
-        single_guest: "A guest left kudos on \"%{commentable_title}\" (%{commentable_url})."
+          one: '%{givers_list} left kudos on "%{commentable_title}" (%{commentable_url}).'
+          other: '%{givers_list} left kudos on "%{commentable_title}" (%{commentable_url}).'
+        single_guest: A guest left kudos on "%{commentable_title}" (%{commentable_url}).
+  mailer:
+    general:
+      closing:
+        formal: Sincerely,
+        informal: Best,
+      creation:
+        link_with_word_count: "%{creation_link} (%{word_count})"
+        title_with_chapter_number: Chapter %{position} of %{title}
+        title_with_word_count: '"%{creation_title}" (%{word_count})'
+        word_count:
+          one: "%{count} word"
+          other: "%{count} words"
+      footer:
+        general:
+          html:
+            donate_link_text: your donations
+            part1: If you've received this message in error, please %{support_link}.
+            part2: The Archive of Our Own is a fan-run and fan-supported archive that relies on %{donate_link}.
+            support_link_text: contact Support
+          text:
+            part1: If you've received this message in error, please contact Support at %{support_url}.
+            part2: 'The Archive of Our Own is a fan-run and fan-supported archive that relies on your donations: %{donate_url}.'
+        sent_at: Sent at %{sent_at}.
+      greeting:
+        formal: Dear %{name},
+        informal:
+          addressed: Hi, %{name}!
+          unaddressed: Hi!
+        introductory: Hello from the Archive of Our Own!
+      metadata_label_indicator: ": "
+      signature:
+        app_short_name: AO3
+        open_doors: The Open Doors team
+        parent_org: Organization for Transformative Works
+        support: The AO3 Support team
   user_mailer:
-    invite_increase_notification:
-      subject: "[%{app_name}] New invitations"
-      html:
-        body:
-          one: "We just wanted to let you know that you have %{count} new invitation, which can be used to create a new account at the Archive. You can invite a friend at %{invitation_page_link}."
-          other: "We just wanted to let you know that you have %{count} new invitations, which can be used to create new accounts at the Archive. You can invite a friend at %{invitation_page_link}."
-      text:
-        body:
-          one: "We just wanted to let you know that you have %{count} new invitation, which can be used to create a new account at the Archive. You can invite a friend at your invitations page (%{invitation_page_url})."
-          other: "We just wanted to let you know that you have %{count} new invitations, which can be used to create new accounts at the Archive. You can invite a friend at your invitations page (%{invitation_page_url})."
-      invitation_page_link_text: your invitations page
-    admin_deleted_work_notification:
-      subject: "[%{app_name}] Your work has been deleted by an admin"
-      opendoors: "contact Open Doors"
-      contact_abuse: "contact our Policy & Abuse team"
-      bye: "Attached is a copy of your work for your reference."
-      html:
-        part1: "Your work %{title} was deleted from the Archive by a site admin."
-        part2: "If your work was part of an import project managed by our Open Doors team, please %{opendoors_link} with any further questions."
-        tos_violation: "If it's possible your work violated the Archive's Terms of Service, please %{contact_abuse_link}."
-      text:
-        part1: "Your work \"%{title}\" was deleted from the Archive by a site admin."
-        part2: "If your work was part of an import project managed by our Open Doors team, please contact Open Doors (%{opendoors_link}) with any further questions."
-        tos_violation: "If it's possible your work violated the Archive's Terms of Service, please contact our Policy & Abuse team (%{contact_abuse_url})."
-    admin_hidden_work_notification:
-      subject: "[%{app_name}] Your work has been hidden by the Policy & Abuse team"
-      tos: "Terms of Service"
-      contact_abuse: "contact Policy & Abuse"
-      access: "While your work is hidden, you will still be able to access it through the link provided above, but it will not be listed on your works page, and it won't be available to other users of the Archive."
-      check_email: "Please check your email, including your spam folder, as the Policy & Abuse team may have already contacted you explaining why your work was hidden."
-      html:
-        hidden: "Your work %{title} has been hidden by the Policy & Abuse team and is no longer publicly accessible."
-        tos_violation: "If your work was hidden due to being in violation of the Archive of Our Own's %{tos_link}, you will be required to take action to correct the violation. Failure to bring your work into compliance with the Terms of Service may lead to your work being deleted from the Archive."
-        help: "If you are uncertain why your work was hidden, and you have not received further communication regarding this matter, please %{contact_abuse_link} directly."
-      text:
-        hidden: "Your work \"%{title}\" (%{work_url}) has been hidden by the Policy & Abuse team and is no longer publicly accessible."
-        tos_violation: "If your work was hidden due to being in violation of the Archive of Our Own's Terms of Service (%{tos_url}), you will be required to take action to correct the violation. Failure to bring your work into compliance with the Terms of Service may lead to your work being deleted from the Archive."
-        help: "If you are uncertain why your work was hidden, and you have not received further communication regarding this matter, please contact Policy & Abuse directly: %{contact_abuse_url}."
-    delete_work_notification:
-      subject: "[%{app_name}] Your work has been deleted"
-      support: "contact Support"
-      part3: "Attached is a copy of your work for your reference."
-      html:
-        part2: "If you have questions, please %{support}."
-        part1_other: "Your work %{title} was deleted at the request of %{pseud}."
-        part1_yourself: "Your work %{title} was deleted at your request."
-      text:
-        part2: "If you have questions, please %{support} (%{url})."
-        part1_other: "Your work \"%{title}\" was deleted at the request of %{pseud}."
-        part1_yourself: "Your work \"%{title}\" was deleted at your request."
-    creatorship_notification_archivist:
-      subject: "[%{app_name}] Archivist co-creator notification"
-      intro_work: "The user %{archivist} has added your pseud %{pseud} as a co-creator on the following work:"
-      intro_chapter: "The user %{archivist} has added your pseud %{pseud} as a co-creator on the following chapter:"
-      intro_series: "The user %{archivist} has added your pseud %{pseud} as a co-creator on the following series:"
-      explanation: "Because they are acting in their official capacity as an Open Doors archivist, they are allowed to add you without a request, even if you have co-creation disabled."
-      html:
-        creation: "%{creation_link} by %{pseud_links}"
-        remove_work: "If you've been added in error or don't want to be listed as a creator, you can %{edit_work_link} to remove yourself as creator."
-        remove_chapter: "If you've been added in error or don't want to be listed as a creator, you can %{edit_chapter_link} to remove yourself as creator."
-        remove_series: "If you've been added in error or don't want to be listed as a creator, you can %{edit_series_link} to remove yourself as creator."
-        edit_work: "edit the work"
-        edit_chapter: "edit the chapter"
-        edit_series: "edit the series"
-      text:
-        creation: "%{title} (%{url}) by %{pseuds}"
-        remove_work: "If you've been added in error or don't want to be listed as a creator, you can edit the work to remove yourself as creator: %{url}"
-        remove_chapter: "If you've been added in error or don't want to be listed as a creator, you can edit the chapter to remove yourself as creator: %{url}"
-        remove_series: "If you've been added in error or don't want to be listed as a creator, you can edit the series to remove yourself as creator: %{url}"
-    creatorship_notification:
-      subject: "[%{app_name}] Co-creator notification"
-      intro_work: "The user %{adding_user} has listed your pseud %{pseud} as a co-creator on the following work:"
-      intro_chapter: "The user %{adding_user} has listed your pseud %{pseud} as a co-creator on the following chapter:"
-      intro_series: "The user %{adding_user} has listed your pseud %{pseud} as a co-creator on the following series:"
-      explanation: "When you're a co-creator on a work, you can be added to new chapters regardless of your co-creation settings. You will also be added to any series the work is added to."
-      html:
-        creation: "%{creation_link} by %{pseud_links}"
-        remove_work: "If you've been added in error or don't want to be listed as a creator, you can %{edit_work_link} to remove yourself as creator."
-        remove_chapter: "If you've been added in error or don't want to be listed as a creator, you can %{edit_chapter_link} to remove yourself as creator."
-        remove_series: "If you've been added in error or don't want to be listed as a creator, you can %{edit_series_link} to remove yourself as creator."
-        edit_work: "edit the work"
-        edit_chapter: "edit the chapter"
-        edit_series: "edit the series"
-      text:
-        creation: "%{title} (%{url}) by %{pseuds}"
-        remove_work: "If you've been added in error or don't want to be listed as a creator, you can edit the work to remove yourself as creator: %{url}"
-        remove_chapter: "If you've been added in error or don't want to be listed as a creator, you can edit the chapter to remove yourself as creator: %{url}"
-        remove_series: "If you've been added in error or don't want to be listed as a creator, you can edit the series to remove yourself as creator: %{url}"
-    creatorship_request:
-      subject: "[%{app_name}] Co-creator request"
-      intro_work: "The user %{inviting_user} has invited your pseud %{pseud} to be listed as a co-creator on the following work:"
-      intro_series: "The user %{inviting_user} has invited your pseud %{pseud} to be listed as a co-creator on the following series:"
-      intro_chapter: "The user %{inviting_user} has invited your pseud %{pseud} to be listed as a co-creator on the following chapter:"
-      html:
-        creation: "%{creation_link} by %{pseud_links}"
-        instructions: "You can accept or reject this request on your %{page_name} page."
-        page_name: "Co-Creator Requests"
-      text:
-        creation: "%{title} (%{url}) by %{pseuds}"
-        instructions: "You can accept or reject this request on your Co-Creator Requests page: %{url}"
-    change_email:
-      subject: "[%{app_name}] Email changed"
-      part1: "%{login}, the email associated with your account has been changed to %{email}"
-    signup_notification:
-      subject: "[%{app_name}] Activate your account"
-      faq: "FAQ"
-      admin_posts: "AO3 News"
-      contact_support: "contact Support"
-      activate_your_account: "follow this link to activate your account"
-      welcome: "Welcome to the Archive of Our Own, %{login}!"
-      bye: "We hope you enjoy using the Archive."
-      text:
-        part1: "Please follow this link to activate your account: %{activate_account_url}"
-        part2: "Once your account is up and running, you can post your fanworks, set up email subscriptions to let you know when your favorite creators or works have updated, set preferences to customize the way the site looks and works for you, keep track of the works you've accessed on the Archive via your history, and much more."
-        part3: "There's lots of information and advice on how to use the Archive in our FAQ at %{faq_url}. You'll find the latest news about site developments on AO3 News at %{admin_posts_url}. If you need more help, run into a bug, or have questions or comments, please contact Support, who are always happy to help out: %{contact_support_url}."
-      html:
-        part1: "Please %{activate_account_link}."
-        part2: "Once your account is up and running, you can post your fanworks, set up email subscriptions to let you know when your favorite creators or works have updated, set preferences to customize the way the site looks and works for you, keep track of the works you've accessed on the Archive via your history, and much more."
-        part3: "There's lots of information and advice on how to use the Archive in our %{faq_link}. You'll find the latest news about site developments on %{admin_posts_link}. If you need more help, run into a bug, or have questions or comments, please %{contact_support_link}, who are always happy to help out."
-    invitation:
-      subject: "[%{app_name}] Invitation"
-      has_invited: "%{user_name} has invited you to join the Archive of Our Own!"
-      been_invited: "You've been invited to join the Archive of Our Own!"
-
-      features: "With an account, you can post fanworks, use bookmarks to keep track of works you enjoyed, receive subscription emails when your favorite creators or works update, customize the way the site looks for you, and more!"
-      text:
-        about: "The Archive of Our Own (AO3) is a free, noncommercial archive built by and for fans. Our servers are owned by our parent nonprofit, the Organization for Transformative Works (%{otw_url}), which works to protect fan rights and preserve fanworks. We welcome all kinds of fanworks, including fanfiction, fanart, fanvids, and podfic from any fandom."
-        faq: "For more information, please check our FAQ: %{faq_url}."
-        join: "If you'd like to join us, please follow this link to sign up: %{invitation_url}."
-        activation_support: "After you sign up, you'll receive an account activation email. If you do not receive this email after 48 hours, please contact Support: %{support_url}."
-      html:
-        about: "The Archive of Our Own (AO3) is a free, noncommercial archive built by and for fans. Our servers are owned by our parent nonprofit, the %{otw_link}, which works to protect fan rights and preserve fanworks. We welcome all kinds of fanworks, including fanfiction, fanart, fanvids, and podfic from any fandom."
-        otw_link_text: "Organization for Transformative Works"
-        join: "If you'd like to join us, please %{invitation_link}."
-        invitation_link_text: "follow this link to sign up"
-        activation_support: "After you sign up, you'll receive an account activation email. If you do not receive this email after 48 hours, please %{support_link}."
-        support_link_text: "contact Support"
-        faq: "For more information, please check %{faq_link}."
-        faq_link_text: "our FAQ"
     abuse_report:
+      description_para: 'Description of the abuse:'
+      para1: 'The following abuse report has been sent to the Abuse team:'
       subject: "[%{app_name}] Your abuse report"
-      para1: "The following abuse report has been sent to the Abuse team:"
-      url_para: "URL of the page the abuse is on:"
-      description_para: "Description of the abuse:"
-    challenge_assignment_notification:
-      subject: "[%{app_name}][%{collection_title}] Your assignment!"
-      recipient: "Recipient:" # this is followed by the name of the gift recipient
-      recipient_missing: "None: contact a moderator for help!"
-      prompts: "Prompts:"
-      optional_tags: "Optional Tags:"
-      prompt_url: "Prompt URL:"
-      description: "Description:"
-      due: "This assignment is due at:"
-      any: "Any"
-      text:
-        assignment: "You have been assigned the following request in the \"%{collection_title}\" challenge (%{collection_url}) at the Archive of Our Own!"
-        look_up: "You can look up this assignment from your Assignments page at %{link}."
-        footer: "You're receiving this email because you signed up for the %{title} challenge (%{url}). For more information about this challenge and contact information for the moderators, please visit %{profile_url}."
+      url_para: 'URL of the page the abuse is on:'
+    admin_deleted_work_notification:
+      bye: Attached is a copy of your work for your reference.
+      contact_abuse: contact our Policy & Abuse team
       html:
-        part1: "You have been assigned the following request in the %{link} challenge at the Archive of Our Own!"
-        look_up: "You can look up this assignment from %{link}."
-        look_up_link: "your Assignments page"
-        footer: "You're receiving this email because you signed up for the %{title} challenge. For more information about this challenge and contact information for the moderators, please visit %{footer_link}."
-        footer_link: "the challenge profile page"
-
-    invitation_to_claim:
-      subject: "[%{app_name}] Invitation to claim works"
-
-      part6: "The works uploaded include:"
-      part8: "To preserve rec lists and bookmarks, the imported archive's web addresses may redirect to the imported copy of these works for a limited time (check the announcement post for your archive to be sure). If you've already uploaded a copy of these works and you did NOT use the import from URL feature, there will be two copies of the same work on the archive."
-      part12: "If you're contacting us, please add email addresses from @transformativeworks.org to your list of safe contacts and check your spam folders for our reply."
+        part1: Your work %{title} was deleted from the Archive by a site admin.
+        part2: If your work was part of an import project managed by our Open Doors team, please %{opendoors_link} with any further questions.
+        tos_violation: If it's possible your work violated the Archive's Terms of Service, please %{contact_abuse_link}.
+      opendoors: contact Open Doors
+      subject: "[%{app_name}] Your work has been deleted by an admin"
       text:
-        part1: "You're receiving this e-mail because an archive has recently been imported by Open Doors (%{open_doors_link}) into the %{app_name} (%{app_short_name} - %{app_url}), and we believe that the following fanworks belong to you. We'd like to give you a chance to claim (or delete/orphan) these works if you want to. And if you don't already have an account under a different e-mail, we'd like to invite you aboard!"
-        part2: "You can read announcements about recent archive moves at AO3 News (%{news_link}), and find additional information on Open Doors' FAQ page (%{open_doors_faq_link}) or tutorials page (%{open_doors_tutorial_link}). For any questions not answered in the FAQ, tutorials, or this e-mail, please contact Support at %{support_link}."
-        part3: "If this is a mistake and these are not your works, please don't delete them! Please just contact Open Doors (%{open_doors_link}) and we will sort it out."
-        part4: "Depending on the archive, your works may have been imported restricted to registered users only (to keep them out of Google searches). If this is the case, the works will only be accessible by logged-in users unless you choose to make them fully visible. For help unlocking, orphaning, or deleting your works, please contact AO3 Support."
-        part5: "Claim or remove your works here: %{claim_url}"
-        part7: "If these works do belong to you, but you don't want them, you can orphan (so that they remain on the AO3, but with your name removed) or delete them (so that they are entirely removed from the AO3). You do not need to add these works to any account in order to orphan or delete them--you can do this directly from the claim link above. (For assistance, please contact Support at %{support_link}.)"
-        part9: "If you would like Open Doors to update the redirect to point to your pre-existing work, please delete the imported copy, and contact Open Doors at %{open_doors_link} with your AO3 account name, your account name on the imported archive, and the title and URL of the fanwork you would like the redirect to point to. (If you have multiple works you would like to change the redirects for, you can list these in one email.)"
-        part10: "If you had other works on the imported archive under an e-mail address you can no longer access, please contact Open Doors with any information that can help verify your identity."
-        part11: "For other inquiries, please contact AO3 Support at %{support_link}."
+        part1: Your work "%{title}" was deleted from the Archive by a site admin.
+        part2: If your work was part of an import project managed by our Open Doors team, please contact Open Doors (%{opendoors_link}) with any further questions.
+        tos_violation: If it's possible your work violated the Archive's Terms of Service, please contact our Policy & Abuse team (%{contact_abuse_url}).
+    admin_hidden_work_notification:
+      access: While your work is hidden, you will still be able to access it through the link provided above, but it will not be listed on your works page, and it won't be available to other users of the Archive.
+      check_email: Please check your email, including your spam folder, as the Policy & Abuse team may have already contacted you explaining why your work was hidden.
+      contact_abuse: contact Policy & Abuse
       html:
-        part1: "You're receiving this e-mail because an archive has recently been imported by %{open_doors_name_link} into the %{app_link} (%{app_short_name}), and we believe that the following fanworks belong to you. We'd like to give you a chance to claim (or delete/orphan) these works if you want to. And if you don't already have an account under a different e-mail, we'd like to invite you aboard!"
-        open_doors_name: "Open Doors"
-        part2: "You can read announcements about recent archive moves at %{ao3_news_link}, and find additional information on Open Doors' %{faq_page_link} or %{tutorial_page_link}. For any questions not answered in the FAQ, tutorials, or this e-mail, please %{contact_support_link}."
-        ao3_news: "AO3 News"
-        faq_page: "FAQ page"
-        tutorial_page: "tutorial page"
-        contact_support: "contact AO3 Support"
-        part3: "If this is a mistake and these are not your works, please don't delete them! Please just %{contact_open_doors_link} and we will sort it out."
-        contact_open_doors: "contact Open Doors"
-        part4: "Depending on the archive, your works may have been imported restricted to registered users only (to keep them out of Google searches). If this is the case, the works will only be accessible by logged-in users unless you choose to make them fully visible. For help unlocking, orphaning, or deleting your works, please %{contact_support_link}."
-        part5: "Claim or remove your works here."
-        part7: "If these works do belong to you, but you don't want them, you can orphan (so that they remain on the AO3, but with your name removed) or delete them (so that they are entirely removed from the AO3). You do not need to add these works to any account in order to orphan or delete them--you can do this directly from the claim link above. (For assistance, please %{contact_support_link}.)"
-        part9: "If you would like Open Doors to update the redirect to point to your pre-existing work, please delete the imported copy, and %{contact_open_doors_link} with your AO3 account name, your account name on the imported archive, and the title and URL of the fanwork you would like the redirect to point to. (If you have multiple works you would like to change the redirects for, you can list these in one email.)"
-        part10: "If you had other works on the imported archive under an e-mail address you can no longer access, please %{contact_open_doors_link} with any information that can help verify your identity."
-        part11: "For other inquiries, please %{contact_support_link}."
-    invite_request_declined:
-      subject: "[%{app_name}] Additional invitation request declined"
-      reason: "Your request was:"
-      main:
-        one: "We regret to inform you that your request for a new invitation cannot be fulfilled at this time."
-        other: "We regret to inform you that your request for %{count} new invitations cannot be fulfilled at this time."
+        help: If you are uncertain why your work was hidden, and you have not received further communication regarding this matter, please %{contact_abuse_link} directly.
+        hidden: Your work %{title} has been hidden by the Policy & Abuse team and is no longer publicly accessible.
+        tos_violation: If your work was hidden due to being in violation of the Archive of Our Own's %{tos_link}, you will be required to take action to correct the violation. Failure to bring your work into compliance with the Terms of Service may lead to your work being deleted from the Archive.
+      subject: "[%{app_name}] Your work has been hidden by the Policy & Abuse team"
+      text:
+        help: 'If you are uncertain why your work was hidden, and you have not received further communication regarding this matter, please contact Policy & Abuse directly: %{contact_abuse_url}.'
+        hidden: Your work "%{title}" (%{work_url}) has been hidden by the Policy & Abuse team and is no longer publicly accessible.
+        tos_violation: If your work was hidden due to being in violation of the Archive of Our Own's Terms of Service (%{tos_url}), you will be required to take action to correct the violation. Failure to bring your work into compliance with the Terms of Service may lead to your work being deleted from the Archive.
+      tos: Terms of Service
     anonymous_or_unrevealed_notification:
+      anonymous_info: Anonymous works are included in tag listings, but not on your works page. On the work, your user name will be replaced with "Anonymous."
+      anonymous_unrevealed_info: The collection maintainers may later reveal your work but leave it anonymous. People who subscribe to you will not be notified of this change. Your work will be included in tag listings, but not on your works page. On the work, your user name will be replaced with "Anonymous."
+      changed_status:
+        anonymous:
+          html: The collection maintainers of %{collection_link} have changed the status of your work %{work_link} to anonymous.
+          text: The collection maintainers of "%{collection_title}" (%{collection_url}) have changed the status of your work "%{work_title}" (%{work_url}) to anonymous.
+        anonymous_unrevealed:
+          html: The collection maintainers of %{collection_link} have changed the status of your work %{work_link} to anonymous and unrevealed.
+          text: The collection maintainers of "%{collection_title}" (%{collection_url}) have changed the status of your work "%{work_title}" (%{work_url}) to anonymous and unrevealed.
+        unrevealed:
+          html: The collection maintainers of %{collection_link} have changed the status of your work %{work_link} to unrevealed.
+          text: The collection maintainers of "%{collection_title}" (%{collection_url}) have changed the status of your work "%{work_title}" (%{work_url}) to unrevealed.
+      collection_items_link_text: Approved Collection Items page
+      do_not_want:
+        anonymous:
+          html: If you do not want your work to be anonymous, please visit your %{collection_items_link} to remove it from this collection.
+          text: 'If you do not want your work to be anonymous, please visit your Approved Collection Items page to remove it from this collection: %{collection_items_url}'
+        anonymous_unrevealed:
+          html: If you do not want your work to be anonymous and unrevealed, please visit your %{collection_items_link} to remove it from this collection.
+          text: 'If you do not want your work to be anonymous and unrevealed, please visit your Approved Collection Items page to remove it from this collection: %{collection_items_url}'
+        unrevealed:
+          html: If you do not want your work to be unrevealed, please visit your %{collection_items_link} to remove it from this collection.
+          text: 'If you do not want your work to be unrevealed, please visit your Approved Collection Items page to remove it from this collection: %{collection_items_url}'
+      faq_link_text: Collections FAQ
+      more_info:
+        html: For more information, visit our %{faq_link}.
+        text: 'For more information, visit our Collections FAQ: %{faq_url}'
       subject:
         anonymous: "[%{app_name}] Your work was made anonymous"
         anonymous_unrevealed: "[%{app_name}] Your work was made anonymous and unrevealed"
         unrevealed: "[%{app_name}] Your work was made unrevealed"
-      changed_status:
-        anonymous:
-          html: "The collection maintainers of %{collection_link} have changed the status of your work %{work_link} to anonymous."
-          text: "The collection maintainers of \"%{collection_title}\" (%{collection_url}) have changed the status of your work \"%{work_title}\" (%{work_url}) to anonymous."
-        anonymous_unrevealed:
-          html: "The collection maintainers of %{collection_link} have changed the status of your work %{work_link} to anonymous and unrevealed."
-          text: "The collection maintainers of \"%{collection_title}\" (%{collection_url}) have changed the status of your work \"%{work_title}\" (%{work_url}) to anonymous and unrevealed."
-        unrevealed:
-          html: "The collection maintainers of %{collection_link} have changed the status of your work %{work_link} to unrevealed."
-          text: "The collection maintainers of \"%{collection_title}\" (%{collection_url}) have changed the status of your work \"%{work_title}\" (%{work_url}) to unrevealed."
-      anonymous_info: "Anonymous works are included in tag listings, but not on your works page. On the work, your user name will be replaced with \"Anonymous.\""
-      unrevealed_info: "Unrevealed works are not included in tag listings or on your works page. Anyone who follows a link to the work will receive a notice that it is currently unrevealed, and they will be unable to access its content."
-      anonymous_unrevealed_info: "The collection maintainers may later reveal your work but leave it anonymous. People who subscribe to you will not be notified of this change. Your work will be included in tag listings, but not on your works page. On the work, your user name will be replaced with \"Anonymous.\""
-      do_not_want:
-        anonymous:
-          html: "If you do not want your work to be anonymous, please visit your %{collection_items_link} to remove it from this collection."
-          text: "If you do not want your work to be anonymous, please visit your Approved Collection Items page to remove it from this collection: %{collection_items_url}"
-        anonymous_unrevealed:
-          html: "If you do not want your work to be anonymous and unrevealed, please visit your %{collection_items_link} to remove it from this collection."
-          text: "If you do not want your work to be anonymous and unrevealed, please visit your Approved Collection Items page to remove it from this collection: %{collection_items_url}"
-        unrevealed:
-          html: "If you do not want your work to be unrevealed, please visit your %{collection_items_link} to remove it from this collection."
-          text: "If you do not want your work to be unrevealed, please visit your Approved Collection Items page to remove it from this collection: %{collection_items_url}"
-      collection_items_link_text: "Approved Collection Items page"
-      more_info:
-        html: "For more information, visit our %{faq_link}."
-        text: "For more information, visit our Collections FAQ: %{faq_url}"
-      faq_link_text: "Collections FAQ"
+      unrevealed_info: Unrevealed works are not included in tag listings or on your works page. Anyone who follows a link to the work will receive a notice that it is currently unrevealed, and they will be unable to access its content.
+    challenge_assignment_notification:
+      any: Any
+      description: 'Description:'
+      due: 'This assignment is due at:'
+      html:
+        footer: You're receiving this email because you signed up for the %{title} challenge. For more information about this challenge and contact information for the moderators, please visit %{footer_link}.
+        footer_link: the challenge profile page
+        look_up: You can look up this assignment from %{link}.
+        look_up_link: your Assignments page
+        part1: You have been assigned the following request in the %{link} challenge at the Archive of Our Own!
+      optional_tags: 'Optional Tags:'
+      prompt_url: 'Prompt URL:'
+      prompts: 'Prompts:'
+      recipient: 'Recipient:'
+      recipient_missing: 'None: contact a moderator for help!'
+      subject: "[%{app_name}][%{collection_title}] Your assignment!"
+      text:
+        assignment: You have been assigned the following request in the "%{collection_title}" challenge (%{collection_url}) at the Archive of Our Own!
+        footer: You're receiving this email because you signed up for the %{title} challenge (%{url}). For more information about this challenge and contact information for the moderators, please visit %{profile_url}.
+        look_up: You can look up this assignment from your Assignments page at %{link}.
+    change_email:
+      part1: "%{login}, the email associated with your account has been changed to %{email}"
+      subject: "[%{app_name}] Email changed"
+    collection_notification:
+      assignments_sent:
+        complete: All assignments have now been sent out.
+        subject: Assignments sent
+      html:
+        received_message: 'You have received a message about your collection %{collection_link}:'
+      text:
+        received_message: 'You have received a message about your collection "%{collection_title}" (%{collection_url}):'
+    creatorship_notification:
+      explanation: When you're a co-creator on a work, you can be added to new chapters regardless of your co-creation settings. You will also be added to any series the work is added to.
+      html:
+        creation: "%{creation_link} by %{pseud_links}"
+        edit_chapter: edit the chapter
+        edit_series: edit the series
+        edit_work: edit the work
+        remove_chapter: If you've been added in error or don't want to be listed as a creator, you can %{edit_chapter_link} to remove yourself as creator.
+        remove_series: If you've been added in error or don't want to be listed as a creator, you can %{edit_series_link} to remove yourself as creator.
+        remove_work: If you've been added in error or don't want to be listed as a creator, you can %{edit_work_link} to remove yourself as creator.
+      intro_chapter: 'The user %{adding_user} has listed your pseud %{pseud} as a co-creator on the following chapter:'
+      intro_series: 'The user %{adding_user} has listed your pseud %{pseud} as a co-creator on the following series:'
+      intro_work: 'The user %{adding_user} has listed your pseud %{pseud} as a co-creator on the following work:'
+      subject: "[%{app_name}] Co-creator notification"
+      text:
+        creation: "%{title} (%{url}) by %{pseuds}"
+        remove_chapter: 'If you''ve been added in error or don''t want to be listed as a creator, you can edit the chapter to remove yourself as creator: %{url}'
+        remove_series: 'If you''ve been added in error or don''t want to be listed as a creator, you can edit the series to remove yourself as creator: %{url}'
+        remove_work: 'If you''ve been added in error or don''t want to be listed as a creator, you can edit the work to remove yourself as creator: %{url}'
+    creatorship_notification_archivist:
+      explanation: Because they are acting in their official capacity as an Open Doors archivist, they are allowed to add you without a request, even if you have co-creation disabled.
+      html:
+        creation: "%{creation_link} by %{pseud_links}"
+        edit_chapter: edit the chapter
+        edit_series: edit the series
+        edit_work: edit the work
+        remove_chapter: If you've been added in error or don't want to be listed as a creator, you can %{edit_chapter_link} to remove yourself as creator.
+        remove_series: If you've been added in error or don't want to be listed as a creator, you can %{edit_series_link} to remove yourself as creator.
+        remove_work: If you've been added in error or don't want to be listed as a creator, you can %{edit_work_link} to remove yourself as creator.
+      intro_chapter: 'The user %{archivist} has added your pseud %{pseud} as a co-creator on the following chapter:'
+      intro_series: 'The user %{archivist} has added your pseud %{pseud} as a co-creator on the following series:'
+      intro_work: 'The user %{archivist} has added your pseud %{pseud} as a co-creator on the following work:'
+      subject: "[%{app_name}] Archivist co-creator notification"
+      text:
+        creation: "%{title} (%{url}) by %{pseuds}"
+        remove_chapter: 'If you''ve been added in error or don''t want to be listed as a creator, you can edit the chapter to remove yourself as creator: %{url}'
+        remove_series: 'If you''ve been added in error or don''t want to be listed as a creator, you can edit the series to remove yourself as creator: %{url}'
+        remove_work: 'If you''ve been added in error or don''t want to be listed as a creator, you can edit the work to remove yourself as creator: %{url}'
+    creatorship_request:
+      html:
+        creation: "%{creation_link} by %{pseud_links}"
+        instructions: You can accept or reject this request on your %{page_name} page.
+        page_name: Co-Creator Requests
+      intro_chapter: 'The user %{inviting_user} has invited your pseud %{pseud} to be listed as a co-creator on the following chapter:'
+      intro_series: 'The user %{inviting_user} has invited your pseud %{pseud} to be listed as a co-creator on the following series:'
+      intro_work: 'The user %{inviting_user} has invited your pseud %{pseud} to be listed as a co-creator on the following work:'
+      subject: "[%{app_name}] Co-creator request"
+      text:
+        creation: "%{title} (%{url}) by %{pseuds}"
+        instructions: 'You can accept or reject this request on your Co-Creator Requests page: %{url}'
+    delete_work_notification:
+      html:
+        part1_other: Your work %{title} was deleted at the request of %{pseud}.
+        part1_yourself: Your work %{title} was deleted at your request.
+        part2: If you have questions, please %{support}.
+      part3: Attached is a copy of your work for your reference.
+      subject: "[%{app_name}] Your work has been deleted"
+      support: contact Support
+      text:
+        part1_other: Your work "%{title}" was deleted at the request of %{pseud}.
+        part1_yourself: Your work "%{title}" was deleted at your request.
+        part2: If you have questions, please %{support} (%{url}).
+    invitation:
+      been_invited: You've been invited to join the Archive of Our Own!
+      features: With an account, you can post fanworks, use bookmarks to keep track of works you enjoyed, receive subscription emails when your favorite creators or works update, customize the way the site looks for you, and more!
+      has_invited: "%{user_name} has invited you to join the Archive of Our Own!"
+      html:
+        about: The Archive of Our Own (AO3) is a free, noncommercial archive built by and for fans. Our servers are owned by our parent nonprofit, the %{otw_link}, which works to protect fan rights and preserve fanworks. We welcome all kinds of fanworks, including fanfiction, fanart, fanvids, and podfic from any fandom.
+        activation_support: After you sign up, you'll receive an account activation email. If you do not receive this email after 48 hours, please %{support_link}.
+        faq: For more information, please check %{faq_link}.
+        faq_link_text: our FAQ
+        invitation_link_text: follow this link to sign up
+        join: If you'd like to join us, please %{invitation_link}.
+        otw_link_text: Organization for Transformative Works
+        support_link_text: contact Support
+      subject: "[%{app_name}] Invitation"
+      text:
+        about: The Archive of Our Own (AO3) is a free, noncommercial archive built by and for fans. Our servers are owned by our parent nonprofit, the Organization for Transformative Works (%{otw_url}), which works to protect fan rights and preserve fanworks. We welcome all kinds of fanworks, including fanfiction, fanart, fanvids, and podfic from any fandom.
+        activation_support: 'After you sign up, you''ll receive an account activation email. If you do not receive this email after 48 hours, please contact Support: %{support_url}.'
+        faq: 'For more information, please check our FAQ: %{faq_url}.'
+        join: 'If you''d like to join us, please follow this link to sign up: %{invitation_url}.'
+    invitation_to_claim:
+      html:
+        ao3_news: AO3 News
+        contact_open_doors: contact Open Doors
+        contact_support: contact AO3 Support
+        faq_page: FAQ page
+        open_doors_name: Open Doors
+        part1: You're receiving this e-mail because an archive has recently been imported by %{open_doors_name_link} into the %{app_link} (%{app_short_name}), and we believe that the following fanworks belong to you. We'd like to give you a chance to claim (or delete/orphan) these works if you want to. And if you don't already have an account under a different e-mail, we'd like to invite you aboard!
+        part10: If you had other works on the imported archive under an e-mail address you can no longer access, please %{contact_open_doors_link} with any information that can help verify your identity.
+        part11: For other inquiries, please %{contact_support_link}.
+        part2: You can read announcements about recent archive moves at %{ao3_news_link}, and find additional information on Open Doors' %{faq_page_link} or %{tutorial_page_link}. For any questions not answered in the FAQ, tutorials, or this e-mail, please %{contact_support_link}.
+        part3: If this is a mistake and these are not your works, please don't delete them! Please just %{contact_open_doors_link} and we will sort it out.
+        part4: Depending on the archive, your works may have been imported restricted to registered users only (to keep them out of Google searches). If this is the case, the works will only be accessible by logged-in users unless you choose to make them fully visible. For help unlocking, orphaning, or deleting your works, please %{contact_support_link}.
+        part5: Claim or remove your works here.
+        part7: If these works do belong to you, but you don't want them, you can orphan (so that they remain on the AO3, but with your name removed) or delete them (so that they are entirely removed from the AO3). You do not need to add these works to any account in order to orphan or delete them--you can do this directly from the claim link above. (For assistance, please %{contact_support_link}.)
+        part9: If you would like Open Doors to update the redirect to point to your pre-existing work, please delete the imported copy, and %{contact_open_doors_link} with your AO3 account name, your account name on the imported archive, and the title and URL of the fanwork you would like the redirect to point to. (If you have multiple works you would like to change the redirects for, you can list these in one email.)
+        tutorial_page: tutorial page
+      part12: If you're contacting us, please add email addresses from @transformativeworks.org to your list of safe contacts and check your spam folders for our reply.
+      part6: 'The works uploaded include:'
+      part8: To preserve rec lists and bookmarks, the imported archive's web addresses may redirect to the imported copy of these works for a limited time (check the announcement post for your archive to be sure). If you've already uploaded a copy of these works and you did NOT use the import from URL feature, there will be two copies of the same work on the archive.
+      subject: "[%{app_name}] Invitation to claim works"
+      text:
+        part1: You're receiving this e-mail because an archive has recently been imported by Open Doors (%{open_doors_link}) into the %{app_name} (%{app_short_name} - %{app_url}), and we believe that the following fanworks belong to you. We'd like to give you a chance to claim (or delete/orphan) these works if you want to. And if you don't already have an account under a different e-mail, we'd like to invite you aboard!
+        part10: If you had other works on the imported archive under an e-mail address you can no longer access, please contact Open Doors with any information that can help verify your identity.
+        part11: For other inquiries, please contact AO3 Support at %{support_link}.
+        part2: You can read announcements about recent archive moves at AO3 News (%{news_link}), and find additional information on Open Doors' FAQ page (%{open_doors_faq_link}) or tutorials page (%{open_doors_tutorial_link}). For any questions not answered in the FAQ, tutorials, or this e-mail, please contact Support at %{support_link}.
+        part3: If this is a mistake and these are not your works, please don't delete them! Please just contact Open Doors (%{open_doors_link}) and we will sort it out.
+        part4: Depending on the archive, your works may have been imported restricted to registered users only (to keep them out of Google searches). If this is the case, the works will only be accessible by logged-in users unless you choose to make them fully visible. For help unlocking, orphaning, or deleting your works, please contact AO3 Support.
+        part5: 'Claim or remove your works here: %{claim_url}'
+        part7: If these works do belong to you, but you don't want them, you can orphan (so that they remain on the AO3, but with your name removed) or delete them (so that they are entirely removed from the AO3). You do not need to add these works to any account in order to orphan or delete them--you can do this directly from the claim link above. (For assistance, please contact Support at %{support_link}.)
+        part9: If you would like Open Doors to update the redirect to point to your pre-existing work, please delete the imported copy, and contact Open Doors at %{open_doors_link} with your AO3 account name, your account name on the imported archive, and the title and URL of the fanwork you would like the redirect to point to. (If you have multiple works you would like to change the redirects for, you can list these in one email.)
+    invite_increase_notification:
+      html:
+        body:
+          one: We just wanted to let you know that you have %{count} new invitation, which can be used to create a new account at the Archive. You can invite a friend at %{invitation_page_link}.
+          other: We just wanted to let you know that you have %{count} new invitations, which can be used to create new accounts at the Archive. You can invite a friend at %{invitation_page_link}.
+      invitation_page_link_text: your invitations page
+      subject: "[%{app_name}] New invitations"
+      text:
+        body:
+          one: We just wanted to let you know that you have %{count} new invitation, which can be used to create a new account at the Archive. You can invite a friend at your invitations page (%{invitation_page_url}).
+          other: We just wanted to let you know that you have %{count} new invitations, which can be used to create new accounts at the Archive. You can invite a friend at your invitations page (%{invitation_page_url}).
+    invite_request_declined:
+      main:
+        one: We regret to inform you that your request for a new invitation cannot be fulfilled at this time.
+        other: We regret to inform you that your request for %{count} new invitations cannot be fulfilled at this time.
+      reason: 'Your request was:'
+      subject: "[%{app_name}] Additional invitation request declined"
     recipient_notification:
+      html:
+        collection: A gift work has been posted for you in the %{collection_link} collection at the Archive of Our Own!
+      no_collection: A gift work has been posted for you at the Archive of Our Own!
       subject:
         collection: "[%{app_name}][%{collection_title}] A gift work for you from %{collection_title}"
         no_collection: "[%{app_name}] A gift work for you"
-      no_collection: "A gift work has been posted for you at the Archive of Our Own!"
-      html:
-        collection: "A gift work has been posted for you in the %{collection_link} collection at the Archive of Our Own!"
       text:
-        collection: "A gift work has been posted for you in the \"%{collection_title}\" collection (%{collection_url}) at the Archive of Our Own!"
-    collection_notification:
-      assignments_sent:
-        subject: "Assignments sent"
-        complete: "All assignments have now been sent out."
+        collection: A gift work has been posted for you in the "%{collection_title}" collection (%{collection_url}) at the Archive of Our Own!
+    signup_notification:
+      activate_your_account: follow this link to activate your account
+      admin_posts: AO3 News
+      bye: We hope you enjoy using the Archive.
+      contact_support: contact Support
+      faq: FAQ
       html:
-        received_message: "You have received a message about your collection %{collection_link}:"
+        part1: Please %{activate_account_link}.
+        part2: Once your account is up and running, you can post your fanworks, set up email subscriptions to let you know when your favorite creators or works have updated, set preferences to customize the way the site looks and works for you, keep track of the works you've accessed on the Archive via your history, and much more.
+        part3: There's lots of information and advice on how to use the Archive in our %{faq_link}. You'll find the latest news about site developments on %{admin_posts_link}. If you need more help, run into a bug, or have questions or comments, please %{contact_support_link}, who are always happy to help out.
+      subject: "[%{app_name}] Activate your account"
       text:
-        received_message: "You have received a message about your collection \"%{collection_title}\" (%{collection_url}):"
+        part1: 'Please follow this link to activate your account: %{activate_account_url}'
+        part2: Once your account is up and running, you can post your fanworks, set up email subscriptions to let you know when your favorite creators or works have updated, set preferences to customize the way the site looks and works for you, keep track of the works you've accessed on the Archive via your history, and much more.
+        part3: 'There''s lots of information and advice on how to use the Archive in our FAQ at %{faq_url}. You''ll find the latest news about site developments on AO3 News at %{admin_posts_url}. If you need more help, run into a bug, or have questions or comments, please contact Support, who are always happy to help out: %{contact_support_url}.'
+      welcome: Welcome to the Archive of Our Own, %{login}!
   users:
     mailer:
       reset_password_instructions:
+        expiration: If you do not use this link to reset your password within a week, it will expire, and you will have to request a new one.
+        intro: 'Someone has requested a password reset for your account. You can change your account password by following the link below and entering your new password:'
+        link_title: Change my password.
         subject: "[%{app_name}] Reset your password"
-        intro: "Someone has requested a password reset for your account. You can change your account password by following the link below and entering your new password:"
-        link_title: "Change my password."
-        expiration: "If you do not use this link to reset your password within a week, it will expire, and you will have to request a new one."
-        unrequested: "If you did not request this password reset, you may ignore this email and your previous password will continue to work."
-  admin:
-    mailer:
-      reset_password_instructions:
-        subject: "[%{app_name}] Reset your admin password"
-        intro: "Someone has requested a password reset for your account. You can change your account password by following the link below and entering your new password:"
-        link_title_html: "Change my password."
-        expiration:
-          one: "If you do not use this link to reset your password within %{count} day, it will expire, and you will have to request a new one."
-          other: "If you do not use this link to reset your password within %{count} days, it will expire, and you will have to request a new one."
-        unrequested: "If you did not request this password reset, you may ignore this email and your previous password will continue to work."
+        unrequested: If you did not request this password reset, you may ignore this email and your previous password will continue to work.

--- a/config/locales/mailers/en.yml
+++ b/config/locales/mailers/en.yml
@@ -182,29 +182,12 @@ en:
       bye: "We hope you enjoy using the Archive."
       text:
         part1: "Please follow this link to activate your account: %{activate_account_url}"
-        part2: |-
-                  Once your account is up and running, you can post your fanworks, set up email
-                  subscriptions to let you know when your favorite creators or works have updated,
-                  set preferences to customize the way the site looks and works for you, keep
-                  track of the works you've accessed on the Archive via your history, and much more.
-        part3: |-
-                  There's lots of information and advice on how to use the Archive in our FAQ
-                  at %{faq_url}. You'll find the latest news about site developments on AO3 News at
-                  %{admin_posts_url}. If you need more help, run into a bug, or have questions or
-                  comments, please contact Support, who are always happy to help out:
-                  %{contact_support_url}.
+        part2: "Once your account is up and running, you can post your fanworks, set up email subscriptions to let you know when your favorite creators or works have updated, set preferences to customize the way the site looks and works for you, keep track of the works you've accessed on the Archive via your history, and much more."
+        part3: "There's lots of information and advice on how to use the Archive in our FAQ at %{faq_url}. You'll find the latest news about site developments on AO3 News at %{admin_posts_url}. If you need more help, run into a bug, or have questions or comments, please contact Support, who are always happy to help out: %{contact_support_url}."
       html:
         part1: "Please %{activate_account_link}."
-        part2: |-
-                  Once your account is up and running, you can post your fanworks, set up email
-                  subscriptions to let you know when your favorite creators or works have updated,
-                  set preferences to customize the way the site looks and works for you, keep
-                  track of the works you've accessed on the Archive via your history, and much more.
-        part3: |-
-                  There's lots of information and advice on how to use the Archive in our %{faq_link}.
-                  You'll find the latest news about site developments on %{admin_posts_link}.
-                  If you need more help, run into a bug, or have questions or comments, please
-                  %{contact_support_link}, who are always happy to help out.
+        part2: "Once your account is up and running, you can post your fanworks, set up email subscriptions to let you know when your favorite creators or works have updated, set preferences to customize the way the site looks and works for you, keep track of the works you've accessed on the Archive via your history, and much more."
+        part3: "There's lots of information and advice on how to use the Archive in our %{faq_link}. You'll find the latest news about site developments on %{admin_posts_link}. If you need more help, run into a bug, or have questions or comments, please %{contact_support_link}, who are always happy to help out."
     invitation:
       subject: "[%{app_name}] Invitation"
       has_invited: "%{user_name} has invited you to join the Archive of Our Own!"

--- a/config/locales/models/en.yml
+++ b/config/locales/models/en.yml
@@ -1,187 +1,186 @@
+---
 en:
   activerecord:
+    attributes:
+      admin/role:
+        board: Board
+        communications: Communications
+        docs: AO3 Docs
+        open_doors: Open Doors
+        policy_and_abuse: Policy & Abuse
+        superadmin: Super admin
+        support: Support
+        tag_wrangling: Tag Wrangling
+        translation: Translation
+      archive_warning:
+        name_with_colon:
+          one: 'Warning:'
+          other: 'Warnings:'
+      category:
+        name_with_colon:
+          one: 'Category:'
+          other: 'Categories:'
+      chapters/creatorships:
+        base: 'Invalid creator:'
+        pseud_id: Pseud
+      character:
+        name_with_colon:
+          one: 'Character:'
+          other: 'Characters:'
+      creatorships:
+        base: 'Invalid creator:'
+        pseud_id: Pseud
+      external_work:
+        author: Creator
+        user_defined_tags_count: Fandom, relationship, and character tags
+      fandom:
+        name_with_colon:
+          one: 'Fandom:'
+          other: 'Fandoms:'
+      freeform:
+        name_with_colon:
+          one: 'Additional Tag:'
+          other: 'Additional Tags:'
+      meta_tagging:
+        meta_tag: Metatag
+        meta_tag_id: Metatag
+        sub_tag: Subtag
+        sub_tag_id: Subtag
+      rating:
+        name_with_colon: 'Rating:'
+      relationship:
+        name_with_colon:
+          one: 'Relationship:'
+          other: 'Relationships:'
+      series/creatorships:
+        base: 'Invalid creator:'
+        pseud_id: Pseud
+      work:
+        chapter_total_display: Chapters
+        summary: Summary
+        user_defined_tags_count: Fandom, relationship, character, and additional tags
+      work/chapters:
+        base: 'Invalid chapter:'
+        content: Content
+      work/creatorships:
+        base: 'Invalid creator:'
+        pseud_id: Pseud
+      work/parent_work_relationships/parent:
+        author: The author of a parent work outside the archive
+        title: The title of a parent work outside the archive
+        url: Parent work URL
     errors:
       models:
         block:
-          format: "%{message}"
           attributes:
-            blocked_id:
-              taken: "You have already blocked that user."
             blocked:
-              blank: "Sorry, we couldn't find a user matching that name."
-              self: "Sorry, you can't block yourself."
-              official: "Sorry, you can't block an official user."
-              limit: "Sorry, you have blocked too many accounts."
-        mute:
+              blank: Sorry, we couldn't find a user matching that name.
+              limit: Sorry, you have blocked too many accounts.
+              official: Sorry, you can't block an official user.
+              self: Sorry, you can't block yourself.
+            blocked_id:
+              taken: You have already blocked that user.
           format: "%{message}"
-          attributes:
-            muted_id:
-              taken: "You have already muted that user."
-            muted:
-              blank: "Sorry, we couldn't find a user matching that name."
-              self: "Sorry, you can't mute yourself."
-              official: "Sorry, you can't mute an official user."
-              limit: "Sorry, you have muted too many accounts."
         comment:
           attributes:
             user:
+              blocked_comment: Sorry, you have been blocked by one or more of this work's creators.
+              blocked_reply: Sorry, you have been blocked by that user.
               format: "%{message}"
-              blocked_comment: "Sorry, you have been blocked by one or more of this work's creators."
-              blocked_reply: "Sorry, you have been blocked by that user."
         creatorship:
           attributes:
             pseud_id:
-              taken: "is already listed as a creator."
+              taken: is already listed as a creator.
         external_work:
           attributes:
             user_defined_tags_count:
-              at_most:
-                "must not add up to more than %{count}. You have entered %{value} of these tags, so you must remove %{diff} of them."
+              at_most: must not add up to more than %{count}. You have entered %{value} of these tags, so you must remove %{diff} of them.
         kudo:
           attributes:
             commentable:
-              author_on_own_work: "You can't leave kudos on your own work."
-              blank: "What did you want to leave kudos on?"
-              guest_on_restricted: "You can't leave guest kudos on a restricted work."
-              user_is_suspended: "You cannot leave kudos while your account is suspended."
-              user_is_banned: "You cannot leave kudos while your account is banned."
+              author_on_own_work: You can't leave kudos on your own work.
+              blank: What did you want to leave kudos on?
+              guest_on_restricted: You can't leave guest kudos on a restricted work.
+              user_is_banned: You cannot leave kudos while your account is banned.
+              user_is_suspended: You cannot leave kudos while your account is suspended.
             commentable_type:
-              inclusion: "What did you want to leave kudos on?"
+              inclusion: What did you want to leave kudos on?
           format: "%{message}"
-          taken: "You have already left kudos here. :)"
+          taken: You have already left kudos here. :)
+        mute:
+          attributes:
+            muted:
+              blank: Sorry, we couldn't find a user matching that name.
+              limit: Sorry, you have muted too many accounts.
+              official: Sorry, you can't mute an official user.
+              self: Sorry, you can't mute yourself.
+            muted_id:
+              taken: You have already muted that user.
+          format: "%{message}"
         related_work:
           attributes:
             parent:
-              blank: "The work you listed as an inspiration does not seem to exist."
-              not_work: "Only a link to a work can be listed as an inspiration."
-              protected: "You can't use the related works function to cite works by the protected user %{login}."
+              blank: The work you listed as an inspiration does not seem to exist.
+              not_work: Only a link to a work can be listed as an inspiration.
+              protected: You can't use the related works function to cite works by the protected user %{login}.
           format: "%{message}"
         user:
           attributes:
-            password_confirmation:
-              confirmation: "doesn't match new password."
             login:
               changed_too_recently:
-                one: "can only be changed once per day. You last changed your user name on %{renamed_at}."
-                other: "can only be changed once every %{count} days. You last changed your user name on %{renamed_at}."
+                one: can only be changed once per day. You last changed your user name on %{renamed_at}.
+                other: can only be changed once every %{count} days. You last changed your user name on %{renamed_at}.
+            password_confirmation:
+              confirmation: doesn't match new password.
         work:
           attributes:
             user_defined_tags_count:
-              at_most:
-                "must not add up to more than %{count}. Your work has %{value} of these tags, so you must remove %{diff} of them."
+              at_most: must not add up to more than %{count}. Your work has %{value} of these tags, so you must remove %{diff} of them.
         work/parent_work_relationships:
           format: "%{message}"
     models:
       admin_blacklisted_email:
-        one: "Banned Email"
-        other: "Banned Emails"
+        one: Banned Email
+        other: Banned Emails
       archive_warning:
-        one: "Warning"
-        other: "Warnings"
-      bookmark: "Bookmark"
+        one: Warning
+        other: Warnings
+      bookmark: Bookmark
       category:
-        one: "Category"
-        other: "Categories"
+        one: Category
+        other: Categories
       chapter:
-        one: "Chapter"
-        other: "Chapters"
+        one: Chapter
+        other: Chapters
       character:
-        one: "Character"
-        other: "Characters"
-      comment: "Comment"
+        one: Character
+        other: Characters
+      comment: Comment
       fandom:
-        one: "Fandom"
-        other: "Fandoms"
+        one: Fandom
+        other: Fandoms
       freeform:
-        one: "Additional Tag"
-        other: "Additional Tags"
-      pseud: "Pseud"
+        one: Additional Tag
+        other: Additional Tags
+      pseud: Pseud
       rating:
-        one: "Rating"
-        other: "Ratings"
+        one: Rating
+        other: Ratings
       relationship:
-        one: "Relationship"
-        other: "Relationships"
+        one: Relationship
+        other: Relationships
       series:
-        one: "Series"
-        other: "Series"
+        one: Series
+        other: Series
       tag:
-        one: "Tag"
-        other: "Tags"
-      work: "Work"
-    attributes:
-      admin/role:
-        board: "Board"
-        communications: "Communications"
-        docs: "AO3 Docs"
-        open_doors: "Open Doors"
-        policy_and_abuse: "Policy & Abuse"
-        superadmin: "Super admin"
-        support: "Support"
-        tag_wrangling: "Tag Wrangling"
-        translation: "Translation"
-      archive_warning:
-        name_with_colon:
-          one: "Warning:"
-          other: "Warnings:"
-      category:
-        name_with_colon:
-          one: "Category:"
-          other: "Categories:"
-      character:
-        name_with_colon:
-          one: "Character:"
-          other: "Characters:"
-      fandom:
-        name_with_colon:
-          one: "Fandom:"
-          other: "Fandoms:"
-      freeform:
-        name_with_colon:
-          one: "Additional Tag:"
-          other: "Additional Tags:"
-      rating:
-        name_with_colon: "Rating:"
-      relationship:
-        name_with_colon:
-          one: "Relationship:"
-          other: "Relationships:"
-      meta_tagging:
-        meta_tag_id: "Metatag"
-        meta_tag: "Metatag"
-        sub_tag_id: "Subtag"
-        sub_tag: "Subtag"
-      creatorships:
-        pseud_id: "Pseud"
-        base: "Invalid creator:"
-      series/creatorships:
-        pseud_id: "Pseud"
-        base: "Invalid creator:"
-      chapters/creatorships:
-        pseud_id: "Pseud"
-        base: "Invalid creator:"
-      work/creatorships:
-        pseud_id: "Pseud"
-        base: "Invalid creator:"
-      work/chapters:
-        content: "Content"
-        base: "Invalid chapter:"
-      work/parent_work_relationships/parent:
-        url: "Parent work URL"
-        title: "The title of a parent work outside the archive"
-        author: "The author of a parent work outside the archive"
-      external_work:
-        user_defined_tags_count: "Fandom, relationship, and character tags"
-        author: "Creator"
-      work:
-        chapter_total_display: "Chapters"
-        summary: "Summary"
-        user_defined_tags_count: "Fandom, relationship, character, and additional tags"
+        one: Tag
+        other: Tags
+      work: Work
   attributes:
-    ticket_number: "Ticket ID"
+    ticket_number: Ticket ID
   errors:
     attributes:
       ticket_number:
-        closed_ticket: "must not be closed."
-        invalid_department: "must be in your department."
-        required: "must exist and not be spam."
+        closed_ticket: must not be closed.
+        invalid_department: must be in your department.
+        required: must exist and not be spam.

--- a/config/locales/validators/en.yml
+++ b/config/locales/validators/en.yml
@@ -1,10 +1,11 @@
+---
 en:
   validators:
     email:
-      blacklist: "has been blocked at the owner's request. That means it can't be used in guest comments. Please check the address to make sure it's yours to use and contact AO3 Support if you have any questions."
-      veracity:
-        allow_blank: "does not seem to be a valid address. Please use a different address or leave blank."
-        no_blank: "does not seem to be a valid address."
+      blacklist: has been blocked at the owner's request. That means it can't be used in guest comments. Please check the address to make sure it's yours to use and contact AO3 Support if you have any questions.
       format:
-        allow_blank: "should look like an email address. Please use a different address or leave blank."
-        no_blank: "should look like an email address."
+        allow_blank: should look like an email address. Please use a different address or leave blank.
+        no_blank: should look like an email address.
+      veracity:
+        allow_blank: does not seem to be a valid address. Please use a different address or leave blank.
+        no_blank: does not seem to be a valid address.

--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -585,6 +585,12 @@ en:
       back: Back
     external_author_name:
       label_external_author_name: "Name: "
+  gifts:
+    gift_search:
+      forms:
+        gift_search: Search
+      gifts:
+        recipient_field: "Find gifts for: "
   invitations:
     index:
       email_address: Email address

--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -54,6 +54,16 @@ en:
         navigation:
           queue: "Manage Queue"
           requests: "Manage Requests"
+      find:
+        find_email: "Enter all or part of an email address:"
+        find_token: "Enter an invite token:"
+        find_user_name: "Enter a user name:"
+      new:
+        email_address: "Email address"
+        invite_user: "Invite a User"
+        submit: "Invite!"
+    admin_nav:
+      delete: "Delete Post"
     passwords:
       new:
         page_heading: "Forgotten your admin password?"

--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -580,3 +580,17 @@ en:
       abuse_support_available: Abuse support available
       create: Create Language
       update: Update Language
+  locales:
+    locale_form:
+      required_notice: Required information
+      locale_legend: Locale
+      locale_heading: Locale
+      name: Name
+      iso: ISO code
+      language: Language
+      enable_email: Use this locale to send email
+      enable_interface: Use this locale for the interface
+      actions_legend: Actions
+      actions_heading: Actions
+      create_button: Create Locale
+      edit_button: Update Locale

--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -570,6 +570,12 @@ en:
       add_bookmark_header: "Add Bookmark to collections"
       invite: "Invite"
       add: "Add"
+  external_authors:
+    edit:
+      edit_external_author: Editing external author identity
+      back: Back
+    external_author_name:
+      label_external_author_name: "Name: "
   languages:
     form:
       required_notice: Required information

--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -594,3 +594,14 @@ en:
       actions_heading: Actions
       create_button: Create Locale
       edit_button: Update Locale
+    edit:
+      edit_locale: Edit Locale
+    index:
+      supported_locales: Supported Locales
+      locale_table_summary: Lists supported locales, along with details of how they are used and options to modify them.
+      locale_table_caption: Supported Locales
+    navigation:
+      link_to_index: Locales
+      link_to_new: New Locale
+    new:
+      add_new_locale: New Locale

--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -308,6 +308,9 @@ en:
   skins:
     confirm_delete:
       confirm_html: Are you sure you want to <strong><em>delete</em></strong> the skin "%{skin_title}"?
+    approval_queue: Approval Queue
+    approved_skins: Approved Skins
+    rejected_skins: Rejected Skins
   feedbacks:
     new:
       heading:

--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -1,125 +1,169 @@
+---
 en:
   a11y:
-    navigation: "Navigation"
+    navigation: Navigation
+  abuse_reports:
+    new:
+      do_not_spam_html: "<strong>We investigate every report we receive.</strong> For this reason, we ask you to not submit several reports regarding any one issue unless you have additional information to offer. We also ask that you do not encourage other users to submit a report regarding content you have already reported. Doing so slows down our response and reaction time considerably, as we are a small volunteer-based committee."
+      form:
+        comment:
+          description: Please include all relevant URLs and what about the content violates the Archive %{tos_link}. The more thorough the information the quicker we can start investigating.
+          error: Please describe your concern.
+          label: Your comment (required)
+          tos: Terms of Service
+        email:
+          description: We cannot act on reports without a valid email address.
+          label: Your email (required)
+        landmark:
+          send: Send to Abuse Team
+        language:
+          label: Select language (required)
+        legend:
+          abuse: Link and Describe Abuse
+        link:
+          description: If you came here from the abuse link at the bottom of the page, this will be filled in for you.
+          error: Please enter the link to the page you are reporting.
+          label: Link to the page you are reporting (required)
+        name:
+          label: Your name (optional)
+        submit:
+          active: Submit
+        summary:
+          error: Please enter a brief summary of your message
+          label: Brief summary of Terms of Service Violation (required)
+      heading:
+        page_title: Report Abuse
+      languages_html: "<strong>We can answer Abuse reports in %{list}.</strong> Please allow for an additional delay for responses in any language other than English."
+      purview:
+        about: The Abuse committee looks after all of your concerns regarding content and user behavior which breach the Archive %{tos_link}. For technical help, please %{support_link}.
+        support: contact Support
+        tos: Terms of Service
+      reportable:
+        dmca:
+          claim: would like to lodge a DMCA claim - please review our %{dmca_link}
+          policy: DMCA Policy
+        hack: believe that your account has been hacked, or that someone is trying to hack your account, or
+        intro: 'Please submit a report via this form if you have not submitted this report within the past sixty (60) days, and you:'
+        tos: believe you have found content uploaded to the Archive which breaches our Terms of Service, or
   admin:
+    admin_invitations:
+      find:
+        find_email: 'Enter all or part of an email address:'
+        find_token: 'Enter an invite token:'
+        find_user_name: 'Enter a user name:'
+      index:
+        navigation:
+          queue: Manage Queue
+          requests: Manage Requests
+        page_heading: Invite New Users
+      new:
+        email_address: Email address
+        invite_user: Invite a User
+        submit: Invite!
+    admin_nav:
+      delete: Delete Post
     admin_options:
       delete:
-        bookmark: "Delete Bookmark"
-        confirmation: "Are you sure you want to delete this?"
-        external_work: "Delete External Work"
-        series: "Delete Series"
-        work: "Delete Work"
+        bookmark: Delete Bookmark
+        confirmation: Are you sure you want to delete this?
+        external_work: Delete External Work
+        series: Delete Series
+        work: Delete Work
       edit:
-        external_work: "Edit External Work"
-      edit_tags: "Edit Tags and Language"
+        external_work: Edit External Work
+      edit_tags: Edit Tags and Language
       hide:
-        bookmark: "Hide Bookmark"
-        external_work: "Hide External Work"
-        series: "Hide Series"
-        work: "Hide Work"
-      landmark: "Admin Actions"
-      not_spam: "Mark Not Spam"
-      spam: "Mark As Spam"
+        bookmark: Hide Bookmark
+        external_work: Hide External Work
+        series: Hide Series
+        work: Hide Work
+      landmark: Admin Actions
+      not_spam: Mark Not Spam
+      spam: Mark As Spam
       unhide:
-        bookmark: "Make Bookmark Visible"
-        external_work: "Make External Work Visible"
-        series: "Make Series Visible"
-        work: "Make Work Visible"
-    blacklisted_emails:
-      index:
-        browser_title: "Banned Emails"
-        page_heading: "Manage Banned Emails"
-        notes:
-          guest_comments: "Banned email addresses cannot be used in guest comments."
-          canonical_format: "All emails are stored in a single canonical format and common variants of the same address are not allowed (for instance, foo+whatever@bar.com will not be allowed if foo@bar.com is banned)."
-        heading:
-          new: "Ban email address"
-          search: "Find banned emails"
-        form:
-          new:
-            label: "Email to ban"
-            submit: "Ban Email"
-          search:
-            submit: "Search Banned Emails"
-        confirm_remove: "Are you sure you want to remove %{email} from the banned emails list?"
-      create:
-        browser_title: "Create Banned Email"
+        bookmark: Make Bookmark Visible
+        external_work: Make External Work Visible
+        series: Make Series Visible
+        work: Make Work Visible
     blacklist:
       emails_found:
-        one: "one email found"
+        one: one email found
         other: "%{count} emails found"
-    admin_invitations:
+    blacklisted_emails:
+      create:
+        browser_title: Create Banned Email
       index:
-        page_heading: "Invite New Users"
-        navigation:
-          queue: "Manage Queue"
-          requests: "Manage Requests"
-      find:
-        find_email: "Enter all or part of an email address:"
-        find_token: "Enter an invite token:"
-        find_user_name: "Enter a user name:"
-      new:
-        email_address: "Email address"
-        invite_user: "Invite a User"
-        submit: "Invite!"
-    admin_nav:
-      delete: "Delete Post"
+        browser_title: Banned Emails
+        confirm_remove: Are you sure you want to remove %{email} from the banned emails list?
+        form:
+          new:
+            label: Email to ban
+            submit: Ban Email
+          search:
+            submit: Search Banned Emails
+        heading:
+          new: Ban email address
+          search: Find banned emails
+        notes:
+          canonical_format: All emails are stored in a single canonical format and common variants of the same address are not allowed (for instance, foo+whatever@bar.com will not be allowed if foo@bar.com is banned).
+          guest_comments: Banned email addresses cannot be used in guest comments.
+        page_heading: Manage Banned Emails
     passwords:
-      new:
-        page_heading: "Forgotten your admin password?"
-        instructions: "If you've forgotten or would like to change your admin password, we can send instructions that will allow you to reset it. Please tell us the user name for your admin account."
-        reset_login_html: "Admin user name"
-        submit: Reset Admin Password
       edit:
-        page_heading: Set My Admin Password
-        label:
-          password: New password
-          confirmation: Confirm new password
         describedby:
           password_length: "%{minimum} to %{maximum} characters"
+        label:
+          confirmation: Confirm new password
+          password: New password
         landmark:
           submit: Submit
+        page_heading: Set My Admin Password
         submit: Set Admin Password
+      new:
+        instructions: If you've forgotten or would like to change your admin password, we can send instructions that will allow you to reset it. Please tell us the user name for your admin account.
+        page_heading: Forgotten your admin password?
+        reset_login_html: Admin user name
+        submit: Reset Admin Password
     sessions:
       new:
-        page_heading: "Log In as Admin"
         label:
-          login: "Admin user name"
-          password: "Admin password"
+          login: Admin user name
+          password: Admin password
         landmark:
-          reset: "Reset password"
-        reset_link: "Forgot admin password?"
-        submit: "Log In as Admin"
+          reset: Reset password
+        page_heading: Log In as Admin
+        reset_link: Forgot admin password?
+        submit: Log In as Admin
     settings:
       index:
         fields:
-          account_creation_enabled: "Account creation enabled"
-          cache_expiration: "How often (in minutes) should we refresh caching"
-          creation_requires_invite: "Account creation requires invitation"
-          days_to_purge_unactivated: "How many weeks you have to activate your account before we purge it"
-          disable_support_form: "Turn off support form"
-          disabled_support_form_text: "Disabled support form text"
-          downloads_enabled: "Allow downloads"
-          enable_test_caching: "Turn on caching (currently experimental)"
-          hide_spam: "Automatically hide spam works"
-          invite_from_queue_enabled: "Invite from queue enabled (People can add themselves to the queue and invitations are sent out automatically)"
-          invite_from_queue_frequency: "How often (in days) should we invite people from the queue"
-          invite_from_queue_number: "Number of people to invite from the queue at once"
-          request_invite_enabled: "Users can request invitations"
-          suspend_filter_counts: "Suspend some filter tracking due to high posting volume"
-          tag_wrangling_off: "Turn off tag wrangling for non-admins"
-        heading: "Archive Settings"
+          account_creation_enabled: Account creation enabled
+          cache_expiration: How often (in minutes) should we refresh caching
+          creation_requires_invite: Account creation requires invitation
+          days_to_purge_unactivated: How many weeks you have to activate your account before we purge it
+          disable_support_form: Turn off support form
+          disabled_support_form_text: Disabled support form text
+          downloads_enabled: Allow downloads
+          enable_test_caching: Turn on caching (currently experimental)
+          hide_spam: Automatically hide spam works
+          invite_from_queue_enabled: Invite from queue enabled (People can add themselves to the queue and invitations are sent out automatically)
+          invite_from_queue_frequency: How often (in days) should we invite people from the queue
+          invite_from_queue_number: Number of people to invite from the queue at once
+          request_invite_enabled: Users can request invitations
+          suspend_filter_counts: Suspend some filter tracking due to high posting volume
+          tag_wrangling_off: Turn off tag wrangling for non-admins
+        heading: Archive Settings
+        last_updated_by_admin: Last updated on %{updated_at} by %{admin_name}.
         legend:
-          account_and_invitations: "Accounts and Invitations"
-          disable_support_form: "Turn Off Support Form"
-          performance_and_misc: "Performance and Misc"
-          actions: "Actions"
-        last_updated_by_admin: "Last updated on %{updated_at} by %{admin_name}."
+          account_and_invitations: Accounts and Invitations
+          actions: Actions
+          disable_support_form: Turn Off Support Form
+          performance_and_misc: Performance and Misc
         queue_status: "%{number} people are scheduled to be sent invitations on %{date}."
         queue_status_help: "(The automatic task that invites people from the queue only runs once a day. Don't be alarmed if the date you see is yesterday's. Do be alarmed if the date you see is more than one day in the past and the queue is supposed to be active.)"
-        update: "Update"
+        update: Update
       update:
-        success: "Archive settings were successfully updated."
+        success: Archive settings were successfully updated.
   admin_posts:
     admin_post_form:
       comment_permissions:
@@ -134,283 +178,67 @@ en:
         label: Translation of
   admins:
     index:
-      page_title: "Hi, %{login}!"
-      confidentiality_reminder: "You are now logged in as an admin. That means you will probably encounter information that is personal or confidential (e.g. usernames, email and IP addresses, creator names on anonymous works, etc). Please do not use this information in ways unrelated to your OTW role. If you have questions about what you can or cannot do with information you see here, contact your committee chair(s)."
-      responsibility: "With great power comes great responsibility."
-      log_out_reminder: "Please remember to log out before resuming your normal site activity and leaving comments and kudos!"
+      confidentiality_reminder: You are now logged in as an admin. That means you will probably encounter information that is personal or confidential (e.g. usernames, email and IP addresses, creator names on anonymous works, etc). Please do not use this information in ways unrelated to your OTW role. If you have questions about what you can or cannot do with information you see here, contact your committee chair(s).
+      log_out_reminder: Please remember to log out before resuming your normal site activity and leaving comments and kudos!
+      page_title: Hi, %{login}!
+      responsibility: With great power comes great responsibility.
       roles:
-        heading: "Your admin roles:"
-        none: "You currently have no admin roles assigned to you."
-  home:
-    donate:
-      page_title: "Donate or Volunteer"
-    site_map:
-      site_map: Site Map
-      homepage: Homepage
-      fandoms: Fandoms
-      recent_works: Recent Works
-      people: People
-      bookmarks: Bookmarks
-      freeform_tag_cloud: Additional Tags Cloud
-      languages: Languages
-      collections: Collections and Challenges
-      terms_of_service: Terms of Service
-      archive_faq: Archive FAQ
-      ao3_news: AO3 News
-      known_issues: Known Issues
-      my_home: My Home
-      post_new: Post New
-      my_works: My Works
-      my_drafts: Drafts
-      my_series: My Series
-      my_bookmarks: My Bookmarks
-      my_collections: My Collections and Challenges
-      my_inbox: My Inbox
-      my_history: My History
-      my_subscriptions: My Subscriptions
-      set_preferences: Set My Preferences
-      edit_user_profile: Edit My Profile
-      my_profile: My Profile
-      manage_pseuds: Manage My Pseuds
-      support_and_feedback: Technical Support & Feedback
-      report_abuse: Policy Questions & Abuse Reports
-      donate: Donations
-  kudos:
-    user_links:
-      more_link:
-        one: "%{count} more user"
-        other: "%{count} more users"
-    guest_header:
-      one: "%{count} guest has also left kudos"
-      other: "%{count} guests have also left kudos"
-  comments:
-    commentable:
-      actions:
-        comment: "Comment"
-      permissions:
-        options:
-          disable_all: No one can comment
-          disable_anon: Only registered users can comment
-          enable_all: Registered users and guests can comment
-        admin_post:
-          alt_action: "You can however %{support_link} with any feedback or questions."
-          disable_all: "Sorry, this news post doesn't allow comments."
-          disable_anon: "Sorry, this news post doesn't allow non-Archive users to comment."
-          support_link: "contact Support"
-        work:
-          alt_action: "You can however still leave Kudos!"
-          disable_all: "Sorry, this work doesn't allow comments."
-          disable_anon: "Sorry, this work doesn't allow non-Archive users to comment."
-          hidden: "Sorry, you can't add or edit comments on a hidden work."
-          unrevealed: "Sorry, you can't add or edit comments on an unrevealed work."
-      blocked: "Sorry, you have been blocked by one or more of this work's creators."
-      invite_to_collections_link: "Invite To Collections"
-    show:
-      comment_on: Comment on
-  layouts:
-    proxy_notice:
-      faux_heading: "Important message:"
-      point1: "You are using a proxy site that is not part of the Archive of Our Own."
-      point2: "The entity that set up the proxy site can see what you submit, including your IP address. If you log in through the proxy site, it can see your password."
-      button: "Dismiss Notice"
-  users:
-    sessions:
-      new:
-        restricted:
-          sorry: "Sorry!"
-          work_unavailable: "This work is only available to registered users of the Archive."
-          commenting_unavailable: "Commenting on this work is only available to registered users of the Archive."
-          account_exists: "If you already have an Archive of Our Own account, log in now."
-          no_account: "If you don't have an account, you can %{request_invite_link}."
-          request_invite: "request an invitation to join"
-          signup: "Or join us for free - it's easy."
-        login:
-          log_in: "Log in"
-          forgot: "Forgot your password or user name? %{reset_password_link}."
-          reset_password: "Reset password"
-          no_account: "Don't have an account? %{join_link}."
-          request_invite: "Request an invitation to join"
-          create_account: "Create an account now"
-        beta_reminder:
-          reminder: "Reminder:"
-          warning: "This site is in beta. Things may break or crash without notice."
-          report_bugs: "Please report any pesky bugs and %{give_feedback_link}!"
-          give_feedback: "give us your feedback"
-    delete_preview:
-      heading: "What do you want to do with your works?"
-      orphan: "orphan"
-      orphaning: "orphaning"
-      submit: "Save"
-      cancel: "Cancel"
-      confirm: "Are you sure? This can't be undone!"
-      options:
-        keep_pseud: "Leave my pseud but attach to the orphan account"
-        orphan_pseud: "Change my pseud to \"orphan\" and attach to the orphan account"
-        remove: "Remove me completely as co-creator"
-        delete: "Delete completely"
-      co_creations:
-        legend: "Works You Made With Others"
-        summary: "You have %{work_count} work(s) co-created with the following users: %{co_creators}."
-        orphan_info: "You are not able to delete these as they are shared works, but you can %{orphan_link} them or remove yourself completely as a co-creator."
-      sole_creations:
-        legend: "Works and Collections You Made By Yourself"
-        works_summary: "You have %{work_count} work(s) under the following pseuds: %{pseuds}."
-        collections_summary: "You have %{collection_count} collection(s) under the following pseuds: %{pseuds}."
-        options_info: "You can delete them, but please consider %{orphaning_link} them instead!"
-    show:
-      login_banner:
-        dismiss: "Dismiss permanently"
-        help_link: "Learn some tips and tricks"
-        help_text: "For more guidance on using the site, %{link_faq}!  If you need technical support, you can %{link_support}. If you experience harassment or have specific questions about the %{link_tos}, you can %{link_abuse}."
-        help_title: "First login help"
-        hide: "Hide first login help banner"
-        link_abuse: "contact our Policy & Abuse team"
-        link_faq: "check out our FAQ"
-        link_support: "contact us through our Support and Feedback form"
-        link_tos: "Terms of Service"
-        welcome_text: "Hi! It looks like you've just logged into the Archive for the first time. %{help_link} or dismiss this message permanently."
-    change_username:
-      caution: "Please use this feature with caution."
-      change_window:
-        one: "You can change your user name once per day."
-        other: "You can change your user name once every %{count} days."
-      last_renamed: "You last changed your user name on %{renamed_at}."
-      more_info: "For information on how changing your user name will affect your account, please check out the %{account_faq_link}. Note that changes to your user name may take several days or longer to appear. If you are still seeing your old user name on your works, bookmarks, series, or collections after a week, please %{contact_support_link}."
-      account_faq: "Account FAQ"
-      contact_support: "contact Support"
-  troubleshooting:
-    show:
-      page_title:
-        tag: "Troubleshoot Tag"
-        work: "Troubleshoot Work"
-      page_description:
-        tag: "If this tag is exhibiting undesirable behavior, try one of these options to fix it."
-        work: "If this work is exhibiting undesirable behavior, try one of these options to fix it."
-      update_work_filters:
-        title: "Update Work Filters"
-        description: "Recalculate the filters for this work based on the current set of tags. Use this option if wrangling seems to have gone wrong. (e.g. If you synned one of this work's tags to a canonical but it's not showing up in the tag listings, or if the wrong tags are listed in the sidebar when you drill down to a search that includes only this work.)"
-      reindex_work:
-        title: "Reindex Work"
-        description: "Send in this work to be reindexed. Use this option if the work isn't appearing in searches, or is appearing in searches that it shouldn't. (e.g. If someone has orphaned their work and it can still be found with the old name, or if it's not behaving as expected when you filter crossovers, completion status, word count, etc.)"
-      update_tag_filters:
-        title: "Update Tag Filters"
-        description: "Recalculate filters for all works directly tagged with this tag or one of its synonyms. Does not include subtags. Use this option if the filters include old canonical tags that have been renamed or old parent tags that works aren't tagged with, or if the tag counts are wildly off. Also use this option if the works from a synonym are not showing on the works page of the canonical within a half hour of the tag being synned. Keep in mind that the tags listed in the filters will never be 100% correct."
-      reindex_tag:
-        title: "Reindex Tag"
-        description: "Reindex this tag and all related works, bookmarks, series, pseuds, and external works. Use this option if none of the others have worked. It will not fix autocomplete issues."
-      fix_counts:
-        title: "Fix Tag Counts"
-        description: "Try to recalculate some counts associated with this tag (both filter counts and taggings counts). Keep in mind that the tag counts listed in the fandom lists include unrevealed works and drafts, so if the count is only a little off it may just be unrevealed works or drafts."
-      fix_associations:
-        title: "Fix Tag Associations"
-        description: "Try to delete invalid associations involving this tag (e.g., parents of the wrong type, children of the wrong type, duplicate parents/children/metatags/subtags, etc.). Most of these impossible relationships appear on tag landing pages."
-      fix_meta_tags:
-        title: "Fix Metatags"
-        description: "Try to recalculate inherited metatags. Use this option if this tag has grandparent metatags (i.e., a metatag with its own metatag), and the works aren't showing up in the grandparent's listing. You might also try this if you've removed a metatag, but the works are still showing up in the former metatag's listing. If the works still don't go away, ask a staffer to run \"Update Tag Filters\" on this tag."
-  skins:
-    confirm_delete:
-      confirm_html: Are you sure you want to <strong><em>delete</em></strong> the skin "%{skin_title}"?
-    approval_queue: Approval Queue
-    approved_skins: Approved Skins
-    rejected_skins: Rejected Skins
-  feedbacks:
-    new:
-      heading:
-        page_title: Support and Feedback
-        instructions: Please use this form for questions about how to use the Archive and for reporting any technical problems.
-        landmark:
-          reference: Reference Links
-      navigation:
-        faqs: FAQs & Tutorials
-        release_notes: Release Notes
-        known_issues: Known Issues
-      status:
-        current: 'For current updates on Archive performance or downtime, please check out our Twitter feed: %{twitter_link}.'
-        twitter: '@AO3_Status'
-      abuse:
-        reports: For reports of violations of the Terms of Service such as harassment, spam, or plagiarism, or if you believe your account has been hacked, please %{contact_link} instead. We cannot act on these reports or provide information about Policy and Abuse cases.
-        contact: contact our Policy and Abuse team
-      reportable:
-        intro: 'Some issues you can contact Support about include:'
-        fnok:
-          concerning_html: Setting up, changing, or activating your %{fnok_link}
-          fnok: Fannish Next of Kin
-        bugs: Bugs, errors, or unexpected site behavior
-        site_questions: Questions about how to use the site
-        account_creation: Problems setting up your account
-        lost_access: Lost password or email preventing access to your account
-        tag_changes: Requests to canonize or change tags
-        new_features: Feature requests for future development
-        orphaned_works: Questions about orphaned works
-        work_problems: Works labeled with the wrong language or duplicate works
-        policy_questions: General site policy questions
-      do_not_spam_html: <strong>We respond to every report we receive, but we are a small volunteer team.</strong> For this reason, we ask you to not submit multiple reports regarding any one issue, or encourage other people to report the same issue, unless there is additional information to offer.
-      languages_html: <strong>We can answer Support inquiries in %{list}.</strong> Please allow for additional delay for responses in any language other than English.
-      form:
-        legend:
-          contact_info: Contact Information
-          feedback: Describe Your Feedback
-          send: Send Your Feedback
-        submit:
-          active: Send
-          disabled: Please wait...
-        name:
-          label: Your name (optional)
-        email:
-          label: Your email (required)
-        language:
-          label: Select language (required)
-        summary:
-          label: Brief summary of your question or problem (required)
-          error: Please enter a brief summary of your message
-        comment:
-          label: Your question or problem (required)
-          error: Please enter your feedback
-          description: Please be as specific as possible, including error messages and/or links
-        ip: Our spam filter does collect IP addresses, but we never see them.
-  abuse_reports:
-    new:
-      heading:
-        page_title: Report Abuse
-      purview:
-        about: The Abuse committee looks after all of your concerns regarding content and user behavior which breach the Archive %{tos_link}. For technical help, please %{support_link}.
-        tos: Terms of Service
-        support: contact Support
-      do_not_spam_html: <strong>We investigate every report we receive.</strong> For this reason, we ask you to not submit several reports regarding any one issue unless you have additional information to offer. We also ask that you do not encourage other users to submit a report regarding content you have already reported. Doing so slows down our response and reaction time considerably, as we are a small volunteer-based committee.
-      reportable:
-        intro: 'Please submit a report via this form if you have not submitted this report within the past sixty (60) days, and you:'
-        hack: believe that your account has been hacked, or that someone is trying to hack your account, or
-        tos: believe you have found content uploaded to the Archive which breaches our Terms of Service, or
-        dmca:
-          claim: would like to lodge a DMCA claim - please review our %{dmca_link}
-          policy: DMCA Policy
-      languages_html: <strong>We can answer Abuse reports in %{list}.</strong> Please allow for an additional delay for responses in any language other than English.
-      form:
-        legend:
-          abuse: Link and Describe Abuse
-        landmark:
-          send: Send to Abuse Team
-        submit:
-          active: Submit
-        name:
-          label: Your name (optional)
-        email:
-          label: Your email (required)
-          description: We cannot act on reports without a valid email address.
-        language:
-          label: Select language (required)
-        summary:
-          label: Brief summary of Terms of Service Violation (required)
-          error: Please enter a brief summary of your message
-        comment:
-          label: Your comment (required)
-          error: Please describe your concern.
-          description: Please include all relevant URLs and what about the content violates the Archive %{tos_link}. The more thorough the information the quicker we can start investigating.
-          tos: Terms of Service
-        link:
-          label: Link to the page you are reporting (required)
-          error: Please enter the link to the page you are reporting.
-          description: If you came here from the abuse link at the bottom of the page, this will be filled in for you.
+        heading: 'Your admin roles:'
+        none: You currently have no admin roles assigned to you.
+  blocked:
+    block: Block
+    unblock: Unblock
+    users:
+      confirm_block:
+        block: block
+        button: Yes, Block User
+        cancel: Cancel
+        mute_users_instead_html: To hide a user's works, bookmarks, series, and comments from you, visit %{muted_users_link}.
+        muted_users_link_text: your Muted Users page
+        sure_html: Are you sure you want to %{block} %{username}?
+        title: Block %{name}
+        will:
+          commenting: commenting on your works
+          intro: 'Blocking a user prevents them from:'
+          replying: replying to your comments anywhere on the site
+        will_not:
+          comments_elsewhere: hide their comments elsewhere on the site
+          comments_on_works: delete or hide comments they previously left on your works; you can delete these individually
+          hide_works: hide their works or bookmarks from you
+          intro: 'Blocking a user will not:'
+      confirm_unblock:
+        button: Yes, Unblock User
+        cancel: Cancel
+        resume:
+          commenting: commenting on your works
+          intro: 'Unblocking a user allows them to resume:'
+          replying: replying to your comments anywhere on the site
+        sure_html: Are you sure you want to %{unblock} %{username}?
+        title: Unblock %{name}
+        unblock: unblock
+      index:
+        blocked_users: Blocked Users
+        button: Block
+        heading:
+          landmark:
+            blocked_users: Listing Blocked Users
+        label: User
+        legend: Block a user
+        mute_users_instead_html: To hide a user's works, bookmarks, series, and comments from you, visit %{muted_users_link}.
+        muted_users_link_text: your Muted Users page
+        none: You have not blocked any users.
+        title: Blocked Users
+        will:
+          commenting: commenting on your works
+          intro:
+            one: 'You can block up to %{block_limit} user. Blocking a user prevents them from:'
+            other: 'You can block up to %{block_limit} users. Blocking a user prevents them from:'
+          replying: replying to your comments anywhere on the site
+        will_not:
+          comments_elsewhere: hide their comments elsewhere on the site
+          comments_on_works: delete or hide comments they previously left on your works; you can delete these individually
+          hide_works: hide their works or bookmarks from you
+          intro: 'Blocking a user will not:'
   challenge_signups:
     signup_form:
       notice:
@@ -419,233 +247,406 @@ en:
           preferences_link_text: update your preferences
           prompt_meme: Signing up for this challenge will allow any user who claims your prompt to gift you a work in response to your prompt regardless of your preference settings. If you wish to receive additional gifts from users who have not claimed your prompts, please %{preferences_link} to allow gifts from anyone. You can always %{refuse_link}.
           refuse_link_text: refuse a gift
-  tags:
+  collection_items:
+    collection_item_form:
+      add: Add
+      add_bookmark_header: Add Bookmark to collections
+      invite: Invite
+      invite_header_html: Invite %{title} to collections
+  comments:
+    commentable:
+      actions:
+        comment: Comment
+      blocked: Sorry, you have been blocked by one or more of this work's creators.
+      invite_to_collections_link: Invite To Collections
+      permissions:
+        admin_post:
+          alt_action: You can however %{support_link} with any feedback or questions.
+          disable_all: Sorry, this news post doesn't allow comments.
+          disable_anon: Sorry, this news post doesn't allow non-Archive users to comment.
+          support_link: contact Support
+        options:
+          disable_all: No one can comment
+          disable_anon: Only registered users can comment
+          enable_all: Registered users and guests can comment
+        work:
+          alt_action: You can however still leave Kudos!
+          disable_all: Sorry, this work doesn't allow comments.
+          disable_anon: Sorry, this work doesn't allow non-Archive users to comment.
+          hidden: Sorry, you can't add or edit comments on a hidden work.
+          unrevealed: Sorry, you can't add or edit comments on an unrevealed work.
+    show:
+      comment_on: Comment on
+  external_authors:
+    edit:
+      back: Back
+      edit_external_author: Editing external author identity
+    external_author_name:
+      label_external_author_name: 'Name: '
+  feedbacks:
+    new:
+      abuse:
+        contact: contact our Policy and Abuse team
+        reports: For reports of violations of the Terms of Service such as harassment, spam, or plagiarism, or if you believe your account has been hacked, please %{contact_link} instead. We cannot act on these reports or provide information about Policy and Abuse cases.
+      do_not_spam_html: "<strong>We respond to every report we receive, but we are a small volunteer team.</strong> For this reason, we ask you to not submit multiple reports regarding any one issue, or encourage other people to report the same issue, unless there is additional information to offer."
+      form:
+        comment:
+          description: Please be as specific as possible, including error messages and/or links
+          error: Please enter your feedback
+          label: Your question or problem (required)
+        email:
+          label: Your email (required)
+        ip: Our spam filter does collect IP addresses, but we never see them.
+        language:
+          label: Select language (required)
+        legend:
+          contact_info: Contact Information
+          feedback: Describe Your Feedback
+          send: Send Your Feedback
+        name:
+          label: Your name (optional)
+        submit:
+          active: Send
+          disabled: Please wait...
+        summary:
+          error: Please enter a brief summary of your message
+          label: Brief summary of your question or problem (required)
+      heading:
+        instructions: Please use this form for questions about how to use the Archive and for reporting any technical problems.
+        landmark:
+          reference: Reference Links
+        page_title: Support and Feedback
+      languages_html: "<strong>We can answer Support inquiries in %{list}.</strong> Please allow for additional delay for responses in any language other than English."
+      navigation:
+        faqs: FAQs & Tutorials
+        known_issues: Known Issues
+        release_notes: Release Notes
+      reportable:
+        account_creation: Problems setting up your account
+        bugs: Bugs, errors, or unexpected site behavior
+        fnok:
+          concerning_html: Setting up, changing, or activating your %{fnok_link}
+          fnok: Fannish Next of Kin
+        intro: 'Some issues you can contact Support about include:'
+        lost_access: Lost password or email preventing access to your account
+        new_features: Feature requests for future development
+        orphaned_works: Questions about orphaned works
+        policy_questions: General site policy questions
+        site_questions: Questions about how to use the site
+        tag_changes: Requests to canonize or change tags
+        work_problems: Works labeled with the wrong language or duplicate works
+      status:
+        current: 'For current updates on Archive performance or downtime, please check out our Twitter feed: %{twitter_link}.'
+        twitter: "@AO3_Status"
+  gifts:
+    gift_search:
+      forms:
+        gift_search: Search
+      gifts:
+        recipient_field: 'Find gifts for: '
+  home:
+    donate:
+      page_title: Donate or Volunteer
+    site_map:
+      ao3_news: AO3 News
+      archive_faq: Archive FAQ
+      bookmarks: Bookmarks
+      collections: Collections and Challenges
+      donate: Donations
+      edit_user_profile: Edit My Profile
+      fandoms: Fandoms
+      freeform_tag_cloud: Additional Tags Cloud
+      homepage: Homepage
+      known_issues: Known Issues
+      languages: Languages
+      manage_pseuds: Manage My Pseuds
+      my_bookmarks: My Bookmarks
+      my_collections: My Collections and Challenges
+      my_drafts: Drafts
+      my_history: My History
+      my_home: My Home
+      my_inbox: My Inbox
+      my_profile: My Profile
+      my_series: My Series
+      my_subscriptions: My Subscriptions
+      my_works: My Works
+      people: People
+      post_new: Post New
+      recent_works: Recent Works
+      report_abuse: Policy Questions & Abuse Reports
+      set_preferences: Set My Preferences
+      site_map: Site Map
+      support_and_feedback: Technical Support & Feedback
+      terms_of_service: Terms of Service
+  invitations:
     index:
-      about:
-        popular: These are some of the most popular tags used on the Archive. To find more tags, %{search_tags_link}.
-        random: These are some random tags used on the Archive. To find more tags, %{search_tags_link}.
-        popular_in_collection: These are some of the most popular tags used in the collection.
-        random_in_collection: These are some random tags used in the collection.
-      search_tags: try our tag search
-  blocked:
-    block: "Block"
-    unblock: "Unblock"
-    users:
-      index:
-        title: "Blocked Users"
-        blocked_users: "Blocked Users"
-        button: "Block"
-        none: "You have not blocked any users."
-        legend: "Block a user"
-        label: "User"
-        heading:
-          landmark:
-            blocked_users: "Listing Blocked Users"
-        will:
-          intro: 
-            one: "You can block up to %{block_limit} user. Blocking a user prevents them from:"
-            other: "You can block up to %{block_limit} users. Blocking a user prevents them from:"
-          commenting: "commenting on your works"
-          replying: "replying to your comments anywhere on the site"
-        will_not:
-          intro: "Blocking a user will not:"
-          comments_on_works: "delete or hide comments they previously left on your works; you can delete these individually"
-          comments_elsewhere: "hide their comments elsewhere on the site"
-          hide_works: "hide their works or bookmarks from you"
-        mute_users_instead_html: "To hide a user's works, bookmarks, series, and comments from you, visit %{muted_users_link}."
-        muted_users_link_text: "your Muted Users page"
-      confirm_block:
-        title: "Block %{name}"
-        button: "Yes, Block User"
-        cancel: "Cancel"
-        block: "block"
-        sure_html: "Are you sure you want to %{block} %{username}?"
-        will:
-          intro: "Blocking a user prevents them from:"
-          commenting: "commenting on your works"
-          replying: "replying to your comments anywhere on the site"
-        will_not:
-          intro: "Blocking a user will not:"
-          comments_on_works: "delete or hide comments they previously left on your works; you can delete these individually"
-          comments_elsewhere: "hide their comments elsewhere on the site"
-          hide_works: "hide their works or bookmarks from you"
-        mute_users_instead_html: "To hide a user's works, bookmarks, series, and comments from you, visit %{muted_users_link}."
-        muted_users_link_text: "your Muted Users page"
-      confirm_unblock:
-        title: "Unblock %{name}"
-        button: "Yes, Unblock User"
-        cancel: "Cancel"
-        unblock: "unblock"
-        sure_html: "Are you sure you want to %{unblock} %{username}?"
-        resume:
-          intro: "Unblocking a user allows them to resume:"
-          commenting: "commenting on your works"
-          replying: "replying to your comments anywhere on the site"
-  muted:
-    mute: "Mute"
-    unmute: "Unmute"
-    muted_items_notice_html: "You have muted some users on the Archive. Some items may not be shown, and any counts may be inaccurate. You can mute or unmute users on %{muted_users_link}."
-    muted_users_link_text: "your Muted Users page"
-    users:
-      index:
-        title: "Muted Users"
-        muted_users: "Muted Users"
-        button: "Mute"
-        none: "You have not muted any users."
-        legend: "Mute a user"
-        label: "User"
-        heading:
-          landmark:
-            muted_users: "Listing Muted Users"
-        will:
-          intro: 
-            one: "You can mute up to %{mute_limit} user. Muting a user:"
-            other: "You can mute up to %{mute_limit} users. Muting a user:"
-          seeing_content: "completely hides their works, series, bookmarks, and comments from you; there will be no empty space, placeholder text, or other indication something has been removed"
-        will_not:
-          intro: "Muting a user will not:"
-          prevent_emails: "prevent you from receiving comment or subscription emails from this user"
-          hide_content_for_others: "hide their works, series, bookmarks, and comments from anyone else"
-        block_users_instead_html: "To prevent a user from commenting on your works or replying to your comments elsewhere on the site, visit %{blocked_users_link}."
-        blocked_users_link_text: "your Blocked Users page"
-        site_skin_warning_html: "Please note that if you are not using the default site skin, muting may not work properly. The Skins and Archive Interface FAQ has %{restore_site_skin_faq_link}."
-        restore_site_skin_faq_link_text: "instructions for reverting to the default site skin"
-      confirm_mute:
-        title: "Mute %{name}"
-        button: "Yes, Mute User"
-        cancel: "Cancel"
-        mute: "mute"
-        sure_html: "Are you sure you want to %{mute} %{username}?"
-        will:
-          intro: "Muting a user:"
-          seeing_content: "completely hides their works, series, bookmarks, and comments from you; there will be no empty space, placeholder text, or other indication something has been removed"
-        will_not:
-          intro: "Muting a user will not:"
-          prevent_emails: "prevent you from receiving comment or subscription emails from this user"
-          hide_content_for_others: "hide their works, series, bookmarks, and comments from anyone else"
-        block_users_instead_html: "To prevent a user from commenting on your works or replying to your comments elsewhere on the site, visit %{blocked_users_link}."
-        blocked_users_link_text: "your Blocked Users page"
-        site_skin_warning_html: "Please note that if you are not using the default site skin, muting may not work properly. The Skins and Archive Interface FAQ has %{restore_site_skin_faq_link}."
-        restore_site_skin_faq_link_text: "instructions for reverting to the default site skin"
-      confirm_unmute:
-        title: "Unmute %{name}"
-        button: "Yes, Unmute User"
-        cancel: "Cancel"
-        unmute: "unmute"
-        sure_html: "Are you sure you want to %{unmute} %{username}?"
-        resume:
-          intro: "Unmuting a user allows you to:"
-          see_content: "see their works, series, bookmarks, and comments on the site"
-  preferences:
-    index:
-      blocked_users: "Blocked Users"
-      allow_collection_invitation: "Allow others to invite my works to collections."
-      muted_users: "Muted Users"
-  works:
-    meta:
-      original_creators:
-        one: "Original Creator ID:"
-        other: "Original Creator IDs:"
+      choose_invite: Choose an invitation
+      email_address: Email address
+      submit_invite: Send Invitation
   invite_requests:
     invite_request:
-      title: "Invitation Status for %{email}"
-      position_html: "You are currently number %{position} on our waiting list!"
-      date: "At our current rate, you should receive an invitation on or around: %{date}."
-  tag_wranglers:
+      date: 'At our current rate, you should receive an invitation on or around: %{date}.'
+      position_html: You are currently number %{position} on our waiting list!
+      title: Invitation Status for %{email}
+  kudos:
+    guest_header:
+      one: "%{count} guest has also left kudos"
+      other: "%{count} guests have also left kudos"
+    user_links:
+      more_link:
+        one: "%{count} more user"
+        other: "%{count} more users"
+  languages:
+    edit:
+      edit_language: Edit Language
+    form:
+      abuse_support_available: Abuse support available
+      create: Create Language
+      name: Name
+      required_notice: Required information
+      short: Abbreviation
+      sortable_name: Name for alphabetical sorting
+      support_available: Support available
+      update: Update Language
+    new:
+      new_language: New Language
     show:
-      last_wrangled_html: "%{wrangler_login} last wrangled at %{time}."
+      work_count: "%{count} works"
+  layouts:
+    proxy_notice:
+      button: Dismiss Notice
+      faux_heading: 'Important message:'
+      point1: You are using a proxy site that is not part of the Archive of Our Own.
+      point2: The entity that set up the proxy site can see what you submit, including your IP address. If you log in through the proxy site, it can see your password.
+  locales:
+    edit:
+      edit_locale: Edit Locale
+    index:
+      locale_table_caption: Supported Locales
+      locale_table_summary: Lists supported locales, along with details of how they are used and options to modify them.
+      supported_locales: Supported Locales
+    locale_form:
+      actions_heading: Actions
+      actions_legend: Actions
+      create_button: Create Locale
+      edit_button: Update Locale
+      enable_email: Use this locale to send email
+      enable_interface: Use this locale for the interface
+      iso: ISO code
+      language: Language
+      locale_heading: Locale
+      locale_legend: Locale
+      name: Name
+      required_notice: Required information
+    navigation:
+      link_to_index: Locales
+      link_to_new: New Locale
+    new:
+      add_new_locale: New Locale
+  muted:
+    mute: Mute
+    muted_items_notice_html: You have muted some users on the Archive. Some items may not be shown, and any counts may be inaccurate. You can mute or unmute users on %{muted_users_link}.
+    muted_users_link_text: your Muted Users page
+    unmute: Unmute
+    users:
+      confirm_mute:
+        block_users_instead_html: To prevent a user from commenting on your works or replying to your comments elsewhere on the site, visit %{blocked_users_link}.
+        blocked_users_link_text: your Blocked Users page
+        button: Yes, Mute User
+        cancel: Cancel
+        mute: mute
+        restore_site_skin_faq_link_text: instructions for reverting to the default site skin
+        site_skin_warning_html: Please note that if you are not using the default site skin, muting may not work properly. The Skins and Archive Interface FAQ has %{restore_site_skin_faq_link}.
+        sure_html: Are you sure you want to %{mute} %{username}?
+        title: Mute %{name}
+        will:
+          intro: 'Muting a user:'
+          seeing_content: completely hides their works, series, bookmarks, and comments from you; there will be no empty space, placeholder text, or other indication something has been removed
+        will_not:
+          hide_content_for_others: hide their works, series, bookmarks, and comments from anyone else
+          intro: 'Muting a user will not:'
+          prevent_emails: prevent you from receiving comment or subscription emails from this user
+      confirm_unmute:
+        button: Yes, Unmute User
+        cancel: Cancel
+        resume:
+          intro: 'Unmuting a user allows you to:'
+          see_content: see their works, series, bookmarks, and comments on the site
+        sure_html: Are you sure you want to %{unmute} %{username}?
+        title: Unmute %{name}
+        unmute: unmute
+      index:
+        block_users_instead_html: To prevent a user from commenting on your works or replying to your comments elsewhere on the site, visit %{blocked_users_link}.
+        blocked_users_link_text: your Blocked Users page
+        button: Mute
+        heading:
+          landmark:
+            muted_users: Listing Muted Users
+        label: User
+        legend: Mute a user
+        muted_users: Muted Users
+        none: You have not muted any users.
+        restore_site_skin_faq_link_text: instructions for reverting to the default site skin
+        site_skin_warning_html: Please note that if you are not using the default site skin, muting may not work properly. The Skins and Archive Interface FAQ has %{restore_site_skin_faq_link}.
+        title: Muted Users
+        will:
+          intro:
+            one: 'You can mute up to %{mute_limit} user. Muting a user:'
+            other: 'You can mute up to %{mute_limit} users. Muting a user:'
+          seeing_content: completely hides their works, series, bookmarks, and comments from you; there will be no empty space, placeholder text, or other indication something has been removed
+        will_not:
+          hide_content_for_others: hide their works, series, bookmarks, and comments from anyone else
+          intro: 'Muting a user will not:'
+          prevent_emails: prevent you from receiving comment or subscription emails from this user
+  orphans:
+    index:
+      orphaned_works: Orphaned Works
+    new:
+      links:
+        cancel: Cancel
+      orphans_about: Read More About The Orphaning Process
+  preferences:
+    index:
+      allow_collection_invitation: Allow others to invite my works to collections.
+      blocked_users: Blocked Users
+      muted_users: Muted Users
   pseuds:
     delete_preview:
-      heading: "Pseud deletion"
-      notice: "When you delete your pseud, any works, series, or comments you have created under it will be transferred to your default pseud."
-      saved_bookmarks:
-        one: "You have saved %{count} bookmark using this pseud. You can choose whether to delete it or transfer it to your default pseud."
-        other: "You have saved %{count} bookmarks using this pseud. You can choose whether to delete them or transfer them to your default pseud."
+      cancel: Cancel
+      confirm: Are you sure? This can't be undone!
       delete:
-        one: "Delete this bookmark"
-        other: "Delete these bookmarks"
+        one: Delete this bookmark
+        other: Delete these bookmarks
+      heading: Pseud deletion
+      notice: When you delete your pseud, any works, series, or comments you have created under it will be transferred to your default pseud.
+      saved_bookmarks:
+        one: You have saved %{count} bookmark using this pseud. You can choose whether to delete it or transfer it to your default pseud.
+        other: You have saved %{count} bookmarks using this pseud. You can choose whether to delete them or transfer them to your default pseud.
       transfer:
-        one: "Transfer this bookmark to the default pseud"
-        other: "Transfer these bookmarks to the default pseud"
-      confirm: "Are you sure? This can't be undone!"
-      cancel: "Cancel"
+        one: Transfer this bookmark to the default pseud
+        other: Transfer these bookmarks to the default pseud
     edit:
       forms:
         update: Update
     show:
       edit_link: Edit Pseud
       index_link: Back To Pseuds
-  collection_items:
-    collection_item_form:
-      invite_header_html: "Invite %{title} to collections"
-      add_bookmark_header: "Add Bookmark to collections"
-      invite: "Invite"
-      add: "Add"
-  external_authors:
-    edit:
-      edit_external_author: Editing external author identity
-      back: Back
-    external_author_name:
-      label_external_author_name: "Name: "
-  gifts:
-    gift_search:
-      forms:
-        gift_search: Search
-      gifts:
-        recipient_field: "Find gifts for: "
-  invitations:
-    index:
-      email_address: Email address
-      choose_invite: Choose an invitation
-      submit_invite: Send Invitation
-  languages:
-    form:
-      required_notice: Required information
-      name: Name
-      short: Abbreviation
-      sortable_name: Name for alphabetical sorting
-      support_available: Support available
-      abuse_support_available: Abuse support available
-      create: Create Language
-      update: Update Language
-    edit:
-      edit_language: Edit Language
-    new:
-      new_language: New Language
-    show:
-      work_count: "%{count} works"
-  locales:
-    locale_form:
-      required_notice: Required information
-      locale_legend: Locale
-      locale_heading: Locale
-      name: Name
-      iso: ISO code
-      language: Language
-      enable_email: Use this locale to send email
-      enable_interface: Use this locale for the interface
-      actions_legend: Actions
-      actions_heading: Actions
-      create_button: Create Locale
-      edit_button: Update Locale
-    edit:
-      edit_locale: Edit Locale
-    index:
-      supported_locales: Supported Locales
-      locale_table_summary: Lists supported locales, along with details of how they are used and options to modify them.
-      locale_table_caption: Supported Locales
-    navigation:
-      link_to_index: Locales
-      link_to_new: New Locale
-    new:
-      add_new_locale: New Locale
-  orphans:
-    index:
-      orphaned_works: Orphaned Works
-    new:
-      orphans_about: Read More About The Orphaning Process
-      links:
-        cancel: Cancel
   series:
     manage:
-      manage_series: "Manage Series:"
+      manage_series: 'Manage Series:'
+  skins:
+    approval_queue: Approval Queue
+    approved_skins: Approved Skins
+    confirm_delete:
+      confirm_html: Are you sure you want to <strong><em>delete</em></strong> the skin "%{skin_title}"?
+    rejected_skins: Rejected Skins
+  tag_wranglers:
+    show:
+      last_wrangled_html: "%{wrangler_login} last wrangled at %{time}."
+  tags:
+    index:
+      about:
+        popular: These are some of the most popular tags used on the Archive. To find more tags, %{search_tags_link}.
+        popular_in_collection: These are some of the most popular tags used in the collection.
+        random: These are some random tags used on the Archive. To find more tags, %{search_tags_link}.
+        random_in_collection: These are some random tags used in the collection.
+      search_tags: try our tag search
+  troubleshooting:
+    show:
+      fix_associations:
+        description: Try to delete invalid associations involving this tag (e.g., parents of the wrong type, children of the wrong type, duplicate parents/children/metatags/subtags, etc.). Most of these impossible relationships appear on tag landing pages.
+        title: Fix Tag Associations
+      fix_counts:
+        description: Try to recalculate some counts associated with this tag (both filter counts and taggings counts). Keep in mind that the tag counts listed in the fandom lists include unrevealed works and drafts, so if the count is only a little off it may just be unrevealed works or drafts.
+        title: Fix Tag Counts
+      fix_meta_tags:
+        description: Try to recalculate inherited metatags. Use this option if this tag has grandparent metatags (i.e., a metatag with its own metatag), and the works aren't showing up in the grandparent's listing. You might also try this if you've removed a metatag, but the works are still showing up in the former metatag's listing. If the works still don't go away, ask a staffer to run "Update Tag Filters" on this tag.
+        title: Fix Metatags
+      page_description:
+        tag: If this tag is exhibiting undesirable behavior, try one of these options to fix it.
+        work: If this work is exhibiting undesirable behavior, try one of these options to fix it.
+      page_title:
+        tag: Troubleshoot Tag
+        work: Troubleshoot Work
+      reindex_tag:
+        description: Reindex this tag and all related works, bookmarks, series, pseuds, and external works. Use this option if none of the others have worked. It will not fix autocomplete issues.
+        title: Reindex Tag
+      reindex_work:
+        description: Send in this work to be reindexed. Use this option if the work isn't appearing in searches, or is appearing in searches that it shouldn't. (e.g. If someone has orphaned their work and it can still be found with the old name, or if it's not behaving as expected when you filter crossovers, completion status, word count, etc.)
+        title: Reindex Work
+      update_tag_filters:
+        description: Recalculate filters for all works directly tagged with this tag or one of its synonyms. Does not include subtags. Use this option if the filters include old canonical tags that have been renamed or old parent tags that works aren't tagged with, or if the tag counts are wildly off. Also use this option if the works from a synonym are not showing on the works page of the canonical within a half hour of the tag being synned. Keep in mind that the tags listed in the filters will never be 100% correct.
+        title: Update Tag Filters
+      update_work_filters:
+        description: Recalculate the filters for this work based on the current set of tags. Use this option if wrangling seems to have gone wrong. (e.g. If you synned one of this work's tags to a canonical but it's not showing up in the tag listings, or if the wrong tags are listed in the sidebar when you drill down to a search that includes only this work.)
+        title: Update Work Filters
+  users:
+    change_username:
+      account_faq: Account FAQ
+      caution: Please use this feature with caution.
+      change_window:
+        one: You can change your user name once per day.
+        other: You can change your user name once every %{count} days.
+      contact_support: contact Support
+      last_renamed: You last changed your user name on %{renamed_at}.
+      more_info: For information on how changing your user name will affect your account, please check out the %{account_faq_link}. Note that changes to your user name may take several days or longer to appear. If you are still seeing your old user name on your works, bookmarks, series, or collections after a week, please %{contact_support_link}.
+    delete_preview:
+      cancel: Cancel
+      co_creations:
+        legend: Works You Made With Others
+        orphan_info: You are not able to delete these as they are shared works, but you can %{orphan_link} them or remove yourself completely as a co-creator.
+        summary: 'You have %{work_count} work(s) co-created with the following users: %{co_creators}.'
+      confirm: Are you sure? This can't be undone!
+      heading: What do you want to do with your works?
+      options:
+        delete: Delete completely
+        keep_pseud: Leave my pseud but attach to the orphan account
+        orphan_pseud: Change my pseud to "orphan" and attach to the orphan account
+        remove: Remove me completely as co-creator
+      orphan: orphan
+      orphaning: orphaning
+      sole_creations:
+        collections_summary: 'You have %{collection_count} collection(s) under the following pseuds: %{pseuds}.'
+        legend: Works and Collections You Made By Yourself
+        options_info: You can delete them, but please consider %{orphaning_link} them instead!
+        works_summary: 'You have %{work_count} work(s) under the following pseuds: %{pseuds}.'
+      submit: Save
+    sessions:
+      new:
+        beta_reminder:
+          give_feedback: give us your feedback
+          reminder: 'Reminder:'
+          report_bugs: Please report any pesky bugs and %{give_feedback_link}!
+          warning: This site is in beta. Things may break or crash without notice.
+        login:
+          create_account: Create an account now
+          forgot: Forgot your password or user name? %{reset_password_link}.
+          log_in: Log in
+          no_account: Don't have an account? %{join_link}.
+          request_invite: Request an invitation to join
+          reset_password: Reset password
+        restricted:
+          account_exists: If you already have an Archive of Our Own account, log in now.
+          commenting_unavailable: Commenting on this work is only available to registered users of the Archive.
+          no_account: If you don't have an account, you can %{request_invite_link}.
+          request_invite: request an invitation to join
+          signup: Or join us for free - it's easy.
+          sorry: Sorry!
+          work_unavailable: This work is only available to registered users of the Archive.
+    show:
+      login_banner:
+        dismiss: Dismiss permanently
+        help_link: Learn some tips and tricks
+        help_text: For more guidance on using the site, %{link_faq}!  If you need technical support, you can %{link_support}. If you experience harassment or have specific questions about the %{link_tos}, you can %{link_abuse}.
+        help_title: First login help
+        hide: Hide first login help banner
+        link_abuse: contact our Policy & Abuse team
+        link_faq: check out our FAQ
+        link_support: contact us through our Support and Feedback form
+        link_tos: Terms of Service
+        welcome_text: Hi! It looks like you've just logged into the Archive for the first time. %{help_link} or dismiss this message permanently.
+  works:
+    meta:
+      original_creators:
+        one: 'Original Creator ID:'
+        other: 'Original Creator IDs:'

--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -591,6 +591,12 @@ en:
       abuse_support_available: Abuse support available
       create: Create Language
       update: Update Language
+    edit:
+      edit_language: Edit Language
+    new:
+      new_language: New Language
+    show:
+      work_count: "%{count} works"
   locales:
     locale_form:
       required_notice: Required information

--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -564,6 +564,12 @@ en:
         other: "Transfer these bookmarks to the default pseud"
       confirm: "Are you sure? This can't be undone!"
       cancel: "Cancel"
+    edit:
+      forms:
+        update: Update
+    show:
+      edit_link: Edit Pseud
+      index_link: Back To Pseuds
   collection_items:
     collection_item_form:
       invite_header_html: "Invite %{title} to collections"

--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -576,6 +576,11 @@ en:
       back: Back
     external_author_name:
       label_external_author_name: "Name: "
+  invitations:
+    index:
+      email_address: Email address
+      choose_invite: Choose an invitation
+      submit_invite: Send Invitation
   languages:
     form:
       required_notice: Required information

--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -622,3 +622,10 @@ en:
       link_to_new: New Locale
     new:
       add_new_locale: New Locale
+  orphans:
+    index:
+      orphaned_works: Orphaned Works
+    new:
+      orphans_about: Read More About The Orphaning Process
+      links:
+        cancel: Cancel

--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -144,6 +144,37 @@ en:
   home:
     donate:
       page_title: "Donate or Volunteer"
+    site_map:
+      site_map: Site Map
+      homepage: Homepage
+      fandoms: Fandoms
+      recent_works: Recent Works
+      people: People
+      bookmarks: Bookmarks
+      freeform_tag_cloud: Additional Tags Cloud
+      languages: Languages
+      collections: Collections and Challenges
+      terms_of_service: Terms of Service
+      archive_faq: Archive FAQ
+      ao3_news: AO3 News
+      known_issues: Known Issues
+      my_home: My Home
+      post_new: Post New
+      my_works: My Works
+      my_drafts: Drafts
+      my_series: My Series
+      my_bookmarks: My Bookmarks
+      my_collections: My Collections and Challenges
+      my_inbox: My Inbox
+      my_history: My History
+      my_subscriptions: My Subscriptions
+      set_preferences: Set My Preferences
+      edit_user_profile: Edit My Profile
+      my_profile: My Profile
+      manage_pseuds: Manage My Pseuds
+      support_and_feedback: Technical Support & Feedback
+      report_abuse: Policy Questions & Abuse Reports
+      donate: Donations
   kudos:
     user_links:
       more_link:

--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -570,3 +570,13 @@ en:
       add_bookmark_header: "Add Bookmark to collections"
       invite: "Invite"
       add: "Add"
+  languages:
+    form:
+      required_notice: Required information
+      name: Name
+      short: Abbreviation
+      sortable_name: Name for alphabetical sorting
+      support_available: Support available
+      abuse_support_available: Abuse support available
+      create: Create Language
+      update: Update Language

--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -205,6 +205,8 @@ en:
           unrevealed: "Sorry, you can't add or edit comments on an unrevealed work."
       blocked: "Sorry, you have been blocked by one or more of this work's creators."
       invite_to_collections_link: "Invite To Collections"
+    show:
+      comment_on: Comment on
   layouts:
     proxy_notice:
       faux_heading: "Important message:"
@@ -644,3 +646,6 @@ en:
       orphans_about: Read More About The Orphaning Process
       links:
         cancel: Cancel
+  series:
+    manage:
+      manage_series: "Manage Series:"

--- a/lib/i18n_newlines_tasks.rb
+++ b/lib/i18n_newlines_tasks.rb
@@ -1,0 +1,16 @@
+module I18nNewlinesTasks
+  def newlines(locales: nil)
+    locales ||= self.locales
+    forest = empty_forest
+
+    locales.each do |locale|
+      forest.merge!(data[locale].select_keys do |key, _node|
+        next if ignore_key?(key, :newlines)
+
+        _node.value.is_a?(String) && _node.value.include?("\n")
+      end)
+    end
+
+    forest
+  end
+end

--- a/lib/i18n_newlines_tasks.rb
+++ b/lib/i18n_newlines_tasks.rb
@@ -4,10 +4,10 @@ module I18nNewlinesTasks
     forest = empty_forest
 
     locales.each do |locale|
-      forest.merge!(data[locale].select_keys do |key, _node|
+      forest.merge!(data[locale].select_keys do |key, node|
         next if ignore_key?(key, :newlines)
 
-        _node.value.is_a?(String) && _node.value.include?("\n")
+        node.value.is_a?(String) && node.value.include?("\n")
       end)
     end
 

--- a/spec/i18n_spec.rb
+++ b/spec/i18n_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require 'i18n/tasks'
+
+RSpec.describe I18n do
+  let(:i18n) { I18n::Tasks::BaseTask.new }
+  let(:missing_keys) { i18n.missing_keys }
+  let(:unused_keys) { i18n.unused_keys }
+  let(:inconsistent_interpolations) { i18n.inconsistent_interpolations }
+
+  it 'does not have missing keys' do
+    expect(missing_keys).to be_empty,
+                            "Missing #{missing_keys.leaves.count} i18n keys, run `i18n-tasks missing' to show them"
+  end
+
+  it 'does not have unused keys' do
+    expect(unused_keys).to be_empty,
+                           "#{unused_keys.leaves.count} unused i18n keys, run `i18n-tasks unused' to show them"
+  end
+
+  it 'files are normalized' do
+    non_normalized = i18n.non_normalized_paths
+    error_message = "The following files need to be normalized:\n" \
+                    "#{non_normalized.map { |path| "  #{path}" }.join("\n")}\n" \
+                    "Please run `i18n-tasks normalize' to fix"
+    expect(non_normalized).to be_empty, error_message
+  end
+
+  it 'does not have inconsistent interpolations' do
+    error_message = "#{inconsistent_interpolations.leaves.count} i18n keys have inconsistent interpolations.\n" \
+                    "Run `i18n-tasks check-consistent-interpolations' to show them"
+    expect(inconsistent_interpolations).to be_empty, error_message
+  end
+end

--- a/spec/i18n_spec.rb
+++ b/spec/i18n_spec.rb
@@ -1,11 +1,13 @@
 # frozen_string_literal: true
 
 require "i18n/tasks"
+require "./lib/i18n_newlines_tasks.rb"
 
 RSpec.describe I18n do
   let(:i18n) { I18n::Tasks::BaseTask.new }
   let(:missing_keys) { i18n.missing_keys }
   let(:unused_keys) { i18n.unused_keys }
+  let(:newlines) { i18n.extend(I18nNewlinesTasks).newlines }
 
   it "does not have missing keys" do
     expect(missing_keys).to be_empty,
@@ -23,5 +25,11 @@ RSpec.describe I18n do
                     "#{non_normalized.map { |path| "  #{path}" }.join("\n")}\n" \
                     "Please run `i18n-tasks normalize' to fix"
     expect(non_normalized).to be_empty, error_message
+  end
+
+  it "does not have values with newlines" do
+    error_message = "The following locale keys have values that contain newlines:\n" \
+                    "#{newlines.key_names(root: true)}"
+    expect(newlines).to be_empty, error_message
   end
 end

--- a/spec/i18n_spec.rb
+++ b/spec/i18n_spec.rb
@@ -1,34 +1,27 @@
 # frozen_string_literal: true
 
-require 'i18n/tasks'
+require "i18n/tasks"
 
 RSpec.describe I18n do
   let(:i18n) { I18n::Tasks::BaseTask.new }
   let(:missing_keys) { i18n.missing_keys }
   let(:unused_keys) { i18n.unused_keys }
-  let(:inconsistent_interpolations) { i18n.inconsistent_interpolations }
 
-  it 'does not have missing keys' do
+  it "does not have missing keys" do
     expect(missing_keys).to be_empty,
                             "Missing #{missing_keys.leaves.count} i18n keys, run `i18n-tasks missing' to show them"
   end
 
-  it 'does not have unused keys' do
+  it "does not have unused keys" do
     expect(unused_keys).to be_empty,
                            "#{unused_keys.leaves.count} unused i18n keys, run `i18n-tasks unused' to show them"
   end
 
-  it 'files are normalized' do
+  it "files are normalized" do
     non_normalized = i18n.non_normalized_paths
     error_message = "The following files need to be normalized:\n" \
                     "#{non_normalized.map { |path| "  #{path}" }.join("\n")}\n" \
                     "Please run `i18n-tasks normalize' to fix"
     expect(non_normalized).to be_empty, error_message
-  end
-
-  it 'does not have inconsistent interpolations' do
-    error_message = "#{inconsistent_interpolations.leaves.count} i18n keys have inconsistent interpolations.\n" \
-                    "Run `i18n-tasks check-consistent-interpolations' to show them"
-    expect(inconsistent_interpolations).to be_empty, error_message
   end
 end

--- a/spec/lib/i18n/i18n_tasks_spec.rb
+++ b/spec/lib/i18n/i18n_tasks_spec.rb
@@ -1,9 +1,7 @@
-# frozen_string_literal: true
-
 require "i18n/tasks"
 require "./lib/i18n_newlines_tasks.rb"
 
-RSpec.describe I18n do
+describe I18n do
   let(:i18n) { I18n::Tasks::BaseTask.new }
   let(:missing_keys) { i18n.missing_keys }
   let(:unused_keys) { i18n.unused_keys }

--- a/spec/lib/i18n/i18n_tasks_spec.rb
+++ b/spec/lib/i18n/i18n_tasks_spec.rb
@@ -9,7 +9,7 @@ describe I18n do
 
   it "en does not have missing keys" do
     expect(missing_keys).to be_empty,
-                            "Missing #{missing_keys.leaves.count} i18n keys, run `bundle exec i18n-tasks missing -l en -t used,plural' to show them"
+                            "Missing #{missing_keys.leaves.count} i18n keys, run `i18n-tasks missing -l en -t used,plural' to show them"
   end
 
   it "en does not have unused keys" do

--- a/spec/lib/i18n/i18n_tasks_spec.rb
+++ b/spec/lib/i18n/i18n_tasks_spec.rb
@@ -3,29 +3,29 @@ require "./lib/i18n_newlines_tasks.rb"
 
 describe I18n do
   let(:i18n) { I18n::Tasks::BaseTask.new }
-  let(:missing_keys) { i18n.missing_keys }
-  let(:unused_keys) { i18n.unused_keys }
-  let(:newlines) { i18n.extend(I18nNewlinesTasks).newlines }
+  let(:missing_keys) { i18n.missing_keys(locales: ["en"], types: [:used, :plural]) }
+  let(:unused_keys) { i18n.unused_keys(locales: ["en"]) }
+  let(:newlines) { i18n.extend(I18nNewlinesTasks).newlines(locales: ["en"]) }
 
-  it "does not have missing keys" do
+  it "en does not have missing keys" do
     expect(missing_keys).to be_empty,
-                            "Missing #{missing_keys.leaves.count} i18n keys, run `i18n-tasks missing' to show them"
+                            "Missing #{missing_keys.leaves.count} i18n keys, run `bundle exec i18n-tasks missing -l en -t used,plural' to show them"
   end
 
-  it "does not have unused keys" do
+  it "en does not have unused keys" do
     expect(unused_keys).to be_empty,
-                           "#{unused_keys.leaves.count} unused i18n keys, run `i18n-tasks unused' to show them"
+                           "#{unused_keys.leaves.count} unused i18n keys, run `i18n-tasks unused -l en' to show them"
   end
 
-  it "files are normalized" do
-    non_normalized = i18n.non_normalized_paths
+  it "en files are normalized" do
+    non_normalized = i18n.non_normalized_paths.select { |path| path.end_with?("en.yml") }
     error_message = "The following files need to be normalized:\n" \
                     "#{non_normalized.map { |path| "  #{path}" }.join("\n")}\n" \
-                    "Please run `i18n-tasks normalize' to fix"
+                    "Please run `i18n-tasks normalize -l en' to fix"
     expect(non_normalized).to be_empty, error_message
   end
 
-  it "does not have values with newlines" do
+  it "en does not have values with newlines" do
     error_message = "The following locale keys have values that contain newlines:\n" \
                     "#{newlines.key_names(root: true)}"
     expect(newlines).to be_empty, error_message


### PR DESCRIPTION
# Pull Request Checklist

* [X] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [X] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [X] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [X] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [X] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-6003

## Purpose

Install and configure the i18n-tasks gem.
Enable tests for missing, unused locale keys and normalized locale files (all English only).
Move all default locale inside `t()` calls to locale files, to prevent it from being reported as missing.
Fix 3 broken locales: [`comments.check_permission_to_edit.error.frozen`](https://github.com/otwcode/otwarchive/commit/310949703443e8684a556d1c634c73173273af7d), [`blocked.users.index.heading.landmark.blocked_users` and `muted.users.index.heading.landmark.muted_users`](https://github.com/otwcode/otwarchive/commit/fe2a1826a33f8397fe9cdcdc050070834d10551a).
Ignore incorrect reporting of unused locales/mark locales as used where possible.
Add test for ensuring no locale values contain newlines. (English only)
Remove newlines from [signup_notification mailer locale](https://github.com/otwcode/otwarchive/commit/23def42a66029234e08cf55b58ab20098f9a601c).
Normalize English locale files.

## Testing Instructions

I don't think it was expected that this would touch so many files, so this may require more testing than what the Jira issue states. I would request that at least it is tested that all pages/emails that I touched load, don't care if automated or manual.

I manually verified that the 3 locales I fixed are broken on production and fixed in dev. I also manually verified that 5c98a61e62491ff1dad8b0b58ce263eaee7c9b5a is correct.

## Notes

The tests are configured to run only for the English locale. If they would run for all locales, "missing" would simply report missing translations (about [1000](https://gist.github.com/Bilka2/c96920d14599186c8480c49f73334e7d#file-missing-txt)) and "normalized" expects different formatting than the phrase export produces, more info below. The tests that make sense to run for all locales are the "unused" test and the "newlines" test. However the problems would have to be fixed, probably in phrase?

### Test: Unused keys (all locales)
Reports 120 unused keys. Some of these are related to 83e6e2d730135cdbb16959d250645e3c5f727199, but most are legitimate unused keys, mostly in the mailers. Output from the task: https://gist.github.com/Bilka2/c96920d14599186c8480c49f73334e7d#file-unused-txt

### Test: Newlines in values (all locales)

The following locale keys have values that contain newlines:
`["fa.user_mailer.signup_notification.text.part3", "fr.user_mailer.signup_notification.text.part3", "id.user_mailer.invitation_to_claim.text.part2", "pt-BR.user_mailer.invitation_to_claim.text.part7", "uk.user_mailer.anonymous_or_unrevealed_notification.anonymous_info"]`

### Multi locale configuration problems

The gem does not allow routing locale writes by language. This means that [moving locales](https://otwarchive.atlassian.net/browse/AO3-6240) will place the locale in the wrong files. The config has a commented out line to make it work correctly for any locale besides en.

Moving locales is further complicated by the fact that the gem normalizes files that locale is moved to/in. The gem disagrees how files should be normalized compared to phrase: Alphabetical sorting is slightly different (`users` vs `user_mailer`) and handling of line_length (when configured) is different.

So [AO3-6240](https://otwarchive.atlassian.net/browse/AO3-6240) will not work as is, but may work with some workarounds:
* Uncommenting the line in the config
* Running the move tasks
* Manually merging the produced en.yml file with the mailers/en.yml file
* (optional) manually undoing the different normalization of the other locale files before the phrase import.
* Removing the line in the config again 

## Credit

Bilka (he/him)

[AO3-6240]: https://otwarchive.atlassian.net/browse/AO3-6240?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ