### PR TITLE
AO3-5666 changed invalid username error text

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -203,7 +203,9 @@ class User < ApplicationRecord
                                    max_pwd: ArchiveConfig.PASSWORD_LENGTH_MAX)
 
   validates_format_of :login,
-                      message: ts("must be 3 to 40 characters (A-Z, a-z, _, 0-9 only), no spaces, cannot begin or end with underscore (_)."),
+                      message: ts("must be %{min_pwd} to %{max_pwd} characters (A-Z, a-z, _, 0-9 only), no spaces, cannot begin or end with underscore (_).",
+                                    min_pwd: ArchiveConfig.LOGIN_LENGTH_MIN,
+                                    max_pwd: ArchiveConfig.LOGIN_LENGTH_MAX),
                       with: /\A[A-Za-z0-9]\w*[A-Za-z0-9]\Z/
   validates :login, uniqueness: { message: ts("has already been taken") }
   validate :login, :username_is_not_recently_changed, if: :will_save_change_to_login?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -188,9 +188,9 @@ class User < ApplicationRecord
   ## used in app/views/users/new.html.erb
   validates_length_of :login,
                       within: ArchiveConfig.LOGIN_LENGTH_MIN..ArchiveConfig.LOGIN_LENGTH_MAX,
-                      too_short: ts("is too short (minimum is %{min_login} characters)",
+                      too_short: ts("^User name is too short (minimum is %{min_login} characters)",
                                     min_login: ArchiveConfig.LOGIN_LENGTH_MIN),
-                      too_long: ts("is too long (maximum is %{max_login} characters)",
+                      too_long: ts("^User name is too long (maximum is %{max_login} characters)",
                                    max_login: ArchiveConfig.LOGIN_LENGTH_MAX)
 
   # allow nil so can save existing users
@@ -203,11 +203,11 @@ class User < ApplicationRecord
                                    max_pwd: ArchiveConfig.PASSWORD_LENGTH_MAX)
 
   validates_format_of :login,
-                      message: ts("must be %{min_pwd} to %{max_pwd} characters (A-Z, a-z, _, 0-9 only), no spaces, cannot begin or end with underscore (_).",
+                      message: ts("^User name must be %{min_pwd} to %{max_pwd} characters (A-Z, a-z, _, 0-9 only), no spaces, cannot begin or end with underscore (_).",
                                     min_pwd: ArchiveConfig.LOGIN_LENGTH_MIN,
                                     max_pwd: ArchiveConfig.LOGIN_LENGTH_MAX),
                       with: /\A[A-Za-z0-9]\w*[A-Za-z0-9]\Z/
-  validates :login, uniqueness: { message: ts("has already been taken") }
+  validates :login, uniqueness: { message: ts("^User name has already been taken") }
   validate :login, :username_is_not_recently_changed, if: :will_save_change_to_login?
 
   validates :email, email_veracity: true, email_format: true, uniqueness: true

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -203,9 +203,9 @@ class User < ApplicationRecord
                                    max_pwd: ArchiveConfig.PASSWORD_LENGTH_MAX)
 
   validates_format_of :login,
-                      message: ts("^User name must be %{min_pwd} to %{max_pwd} characters (A-Z, a-z, _, 0-9 only), no spaces, cannot begin or end with underscore (_).",
-                                  min_pwd: ArchiveConfig.LOGIN_LENGTH_MIN,
-                                  max_pwd: ArchiveConfig.LOGIN_LENGTH_MAX),
+                      message: ts("^User name must be %{min_login} to %{max_login} characters (A-Z, a-z, _, 0-9 only), no spaces, cannot begin or end with underscore (_).",
+                                  min_login: ArchiveConfig.LOGIN_LENGTH_MIN,
+                                  max_login: ArchiveConfig.LOGIN_LENGTH_MAX),
                       with: /\A[A-Za-z0-9]\w*[A-Za-z0-9]\Z/
   validates :login, uniqueness: { message: ts("^User name has already been taken") }
   validate :login, :username_is_not_recently_changed, if: :will_save_change_to_login?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -204,8 +204,8 @@ class User < ApplicationRecord
 
   validates_format_of :login,
                       message: ts("^User name must be %{min_pwd} to %{max_pwd} characters (A-Z, a-z, _, 0-9 only), no spaces, cannot begin or end with underscore (_).",
-                                    min_pwd: ArchiveConfig.LOGIN_LENGTH_MIN,
-                                    max_pwd: ArchiveConfig.LOGIN_LENGTH_MAX),
+                                  min_pwd: ArchiveConfig.LOGIN_LENGTH_MIN,
+                                  max_pwd: ArchiveConfig.LOGIN_LENGTH_MAX),
                       with: /\A[A-Za-z0-9]\w*[A-Za-z0-9]\Z/
   validates :login, uniqueness: { message: ts("^User name has already been taken") }
   validate :login, :username_is_not_recently_changed, if: :will_save_change_to_login?

--- a/app/views/users/registrations/new.html.erb
+++ b/app/views/users/registrations/new.html.erb
@@ -1,14 +1,7 @@
 <!--Descriptive page name, messages and instructions-->
 <h2 class="heading"><%= ts("Create Account") %></h2>
 <% if resource.errors.any? %>
-  <div class="error">
-     <h4 class="heading"><%= ts("Oops, there's some problems with the stuff you told us.") %></h4>
-     <ul>
-        <% resource.errors.full_messages.each do |msg| %>
-          <li><%= msg %></li>
-        <% end %>
-     </ul>
-  </div>
+  <%= error_messages_for :user %>
 <% end %>
 <!--/descriptions-->
 

--- a/app/views/users/registrations/new.html.erb
+++ b/app/views/users/registrations/new.html.erb
@@ -1,8 +1,6 @@
 <!--Descriptive page name, messages and instructions-->
 <h2 class="heading"><%= ts("Create Account") %></h2>
-<% if resource.errors.any? %>
-  <%= error_messages_for :user %>
-<% end %>
+<%= error_messages_for :user %>
 <!--/descriptions-->
 
 <!--main content-->

--- a/features/users/user_create.feature
+++ b/features/users/user_create.feature
@@ -17,8 +17,8 @@ Feature: Sign Up for a new account
       And I should not see "Almost Done!"
     Examples:
       | field                      | value          | error                                           |
-      | user_registration_login                 | xx             | Login is too short (minimum is 3 characters)    |
-      | user_registration_login                 | 87151d8ae964d55515cb986d40394f79ca5c8329c07a8e59f2f783cbfbe401f69a780f27277275b7b2 | Login is too long (maximum is 40 characters)    |
+      | user_registration_login                 | xx             | User name is too short (minimum is 3 characters)|
+      | user_registration_login                 | 87151d8ae964d55515cb986d40394f79ca5c8329c07a8e59f2f783cbfbe401f69a780f27277275b7b2 | User name is too long (maximum is 40 characters)    |
       | user_registration_password              | pass           | Password is too short (minimum is 6 characters) |
       | user_registration_password              | 87151d8ae964d55515cb986d40394f79ca5c8329c07a8e59f2f783cbfbe401f69a780f27277275b7b2 | Password is too long (maximum is 40 characters)    |
       | user_registration_password_confirmation | password2      | Password confirmation doesn't match             |
@@ -61,7 +61,7 @@ Feature: Sign Up for a new account
     When I fill in the sign up form with valid data
       And I fill in "user_registration_login" with "user1"
       And I press "Create Account"
-    Then I should see "Login has already been taken"
+    Then I should see "User name has already been taken"
       And I should not see "Almost Done!"
 
   Scenario: The user should not be able to sign up with a login that is already in use, no matter the case
@@ -71,7 +71,7 @@ Feature: Sign Up for a new account
     When I fill in the sign up form with valid data
       And I fill in "user_registration_login" with "USER1"
       And I press "Create Account"
-    Then I should see "Login has already been taken"
+    Then I should see "User name has already been taken"
       And I should not see "Almost Done!"
 
   Scenario: The user should be able to create a new account with a valid email and password

--- a/features/users/user_rename.feature
+++ b/features/users/user_rename.feature
@@ -30,7 +30,7 @@ Feature:
       And I fill in "New user name" with "otheruser"
       And I fill in "Password" with "password"
     When I press "Change"
-      Then I should see "Login has already been taken"
+      Then I should see "User name has already been taken"
 
   Scenario: The user should not be able to change their username to another user's name even if the capitalization is different
     Given I have no users
@@ -42,7 +42,7 @@ Feature:
       And I fill in "New user name" with "OtherUser"
       And I fill in "Password" with "password"
       And I press "Change User Name"
-    Then I should see "Login has already been taken"
+    Then I should see "User name has already been taken"
 
   Scenario: The user should be able to change their username if username and password are valid
     Given I am logged in as "downthemall" with password "password"

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -115,19 +115,19 @@ describe User do
         it "does not save a duplicate login" do
           new_user.login = existing_user.login
           expect(new_user.save).to be_falsey
-          expect(new_user.errors[:login].first).to eq("has already been taken")
+          expect(new_user.errors[:login].first).to include("has already been taken")
         end
 
         it "does not save a duplicate email" do
           new_user.email = existing_user.email
           expect(new_user.save).to be_falsey
-          expect(new_user.errors[:email].first).to eq("has already been taken")
+          expect(new_user.errors[:email].first).to include("has already been taken")
         end
 
         it "does not save a duplicate email with different capitalization" do
           new_user.email = existing_user.email.capitalize
           expect(new_user.save).to be_falsey
-          expect(new_user.errors[:email].first).to eq("has already been taken")
+          expect(new_user.errors[:email].first).to include("has already been taken")
         end
       end
     end


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [x] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [x] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [x] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-5666

## Purpose

Changes all invalid username errors from "Login ..." to "User name ..." for consistency of language. Also switched out more HTML heavy error display logic for user creation, in favor of calling a function in a .rb file.

## Testing Instructions

Jira ticket explains how to reach the error and verify the changed text — should look like this
<img width="874" alt="Screenshot 2023-03-05 at 3 56 47 PM" src="https://user-images.githubusercontent.com/44508369/222995479-d3ec1165-d3be-4ce1-a0bf-66a161e1e899.png">
<img width="665" alt="Screenshot 2023-03-05 at 4 00 57 PM" src="https://user-images.githubusercontent.com/44508369/222995495-a24317cd-a409-4ce0-9437-42ab6026626b.png">
<img width="869" alt="image" src="https://user-images.githubusercontent.com/44508369/222995536-c40f8d6f-6411-475c-8348-35326488111a.png">

You also may want to run user_rename.feature, user_create.feature, and user_spec.rb

## Credit

pinkpurpleblue (she/her)
