### PR TITLE
AO3-6482 Improve reliability of skins:cache_all_site_skins

### DIFF
--- a/lib/tasks/skin_tasks.rake
+++ b/lib/tasks/skin_tasks.rake
@@ -160,9 +160,10 @@ namespace :skins do
   desc "Cache all site skins"
   task(cache_all_site_skins: :environment) do
     skins = Skin.in_chooser + [Skin.default]
-    successes, failures = [], []
+    successes = []
+    failures = []
 
-    skins.each do  |skin|
+    skins.each do |skin|
       if skin.cache!
         successes << skin.title
       else

--- a/lib/tasks/skin_tasks.rake
+++ b/lib/tasks/skin_tasks.rake
@@ -159,7 +159,9 @@ namespace :skins do
 
   desc "Cache all site skins"
   task(cache_all_site_skins: :environment) do
-    skins = Skin.in_chooser + [Skin.default]
+    # The default skin can be changed to something other than Skin.default via
+    # admin settings, so we want to cache that skin, not Skin.default.
+    skins = Skin.where(id: AdminSetting.default_skin_id).or(Skin.in_chooser)
     successes = []
     failures = []
 

--- a/lib/tasks/skin_tasks.rake
+++ b/lib/tasks/skin_tasks.rake
@@ -158,8 +158,21 @@ namespace :skins do
   end
 
   desc "Cache all site skins"
-  task(:cache_all_site_skins => :environment) do
-    Skin.where(cached: true).each{|skin| skin.cache!}
+  task(cache_all_site_skins: :environment) do
+    skins = Skin.in_chooser + [Skin.default]
+    successes, failures = [], []
+
+    skins.each do  |skin|
+      if skin.cache!
+        successes << skin.title
+      else
+        failures << skin.title
+      end
+    end
+    puts
+    puts("Cached #{successes.join(',')}") if successes.any?
+    puts("Couldn't cache #{failures.join(',')}") if failures.any?
+    STDOUT.flush
   end
 
   desc "Remove all existing skins from preferences"

--- a/spec/lib/tasks/skin_tasks.rake_spec.rb
+++ b/spec/lib/tasks/skin_tasks.rake_spec.rb
@@ -1,8 +1,8 @@
 require "spec_helper"
 
-describe "rake skins:cache_all_site_skins" do
+describe "rake skins:cache_all_site_skins", default_skin: true do
   let(:css) { ".selector { color: yellow; }" }
-  let!(:default_skin) { Skin.default }
+  let!(:default_skin) { Skin.find(AdminSetting.default_skin_id) }
   let!(:chooser_skin) { create(:skin, in_chooser: true, css: css) }
   let!(:user_skin) { create(:skin, css: css) }
 
@@ -23,13 +23,13 @@ describe "rake skins:cache_all_site_skins" do
   it "outputs names of skins that were cached" do
     expect do
       subject.invoke
-    end.to output("\nCached #{chooser_skin.title},#{default_skin.title}\n").to_stdout
+    end.to output("\nCached #{default_skin.title},#{chooser_skin.title}\n").to_stdout
   end
 
   it "outputs names of skins that could not be cached" do
     allow_any_instance_of(Skin).to receive(:cache!).and_return(false)
     expect do
       subject.invoke
-    end.to output("\nCouldn't cache #{chooser_skin.title},#{default_skin.title}\n").to_stdout
+    end.to output("\nCouldn't cache #{default_skin.title},#{chooser_skin.title}\n").to_stdout
   end
 end

--- a/spec/lib/tasks/skin_tasks.rake_spec.rb
+++ b/spec/lib/tasks/skin_tasks.rake_spec.rb
@@ -9,7 +9,7 @@ describe "rake skins:cache_all_site_skins" do
   it "calls cache! on in_chooser skins" do
     expect do
       subject.invoke
-    end.to change{ chooser_skin.reload.public }.from(false).to(true)
+    end.to change { chooser_skin.reload.public }.from(false).to(true)
       .and change { chooser_skin.official }.from(false).to(true)
       .and change { chooser_skin.cached }.from(false).to(true)
       .and avoid_changing { default_skin.reload.public }

--- a/spec/lib/tasks/skin_tasks.rake_spec.rb
+++ b/spec/lib/tasks/skin_tasks.rake_spec.rb
@@ -1,0 +1,35 @@
+require "spec_helper"
+
+describe "rake skins:cache_all_site_skins" do
+  let(:css) { ".selector { color: yellow; }" }
+  let!(:default_skin) { Skin.default }
+  let!(:chooser_skin) { create(:skin, in_chooser: true, css: css) }
+  let!(:user_skin) { create(:skin, css: css) }
+
+  it "calls cache! on in_chooser skins" do
+    expect do
+      subject.invoke
+    end.to change{ chooser_skin.reload.public }.from(false).to(true)
+      .and change { chooser_skin.official }.from(false).to(true)
+      .and change { chooser_skin.cached }.from(false).to(true)
+      .and avoid_changing { default_skin.reload.public }
+      .and avoid_changing { default_skin.official }
+      .and change { default_skin.cached }.from(false).to(true)
+      .and avoid_changing { user_skin.reload.public }
+      .and avoid_changing { user_skin.official }
+      .and avoid_changing { user_skin.cached }
+  end
+
+  it "outputs names of skins that were cached" do
+    expect do
+      subject.invoke
+    end.to output("\nCached #{chooser_skin.title},#{default_skin.title}\n").to_stdout
+  end
+
+  it "outputs names of skins that could not be cached" do
+    allow_any_instance_of(Skin).to receive(:cache!).and_return(false)
+    expect do
+      subject.invoke
+    end.to output("\nCouldn't cache #{chooser_skin.title},#{default_skin.title}\n").to_stdout
+  end
+end


### PR DESCRIPTION

## Issue

https://otwarchive.atlassian.net/browse/AO3-6482

## Purpose

Makes sure that all of the skins in the chooser get cached when `rake skins:cache_all_site_skins` is run, because you can't use a skin in the chooser if it's not cached. 

## Testing Instructions

Refer to Jira.

## Credit

Sarken, she/her