### PR TITLE
AO3-6496 Switch to Selenium instead of phantomjs for tests with JS enabled.

### DIFF
--- a/.github/workflows/automated-tests.yml
+++ b/.github/workflows/automated-tests.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   automated-tests:
     name: ${{ matrix.tests.command }} ${{ matrix.tests.arguments }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     env:
       CI: true
@@ -103,10 +103,6 @@ jobs:
         run: |
           sudo apt-get install -y redis-server
           ./script/gh-actions/multiple_redis.sh
-
-      - name: Install phantomjs
-        if: ${{ matrix.tests.command == 'cucumber' }}
-        run: sudo apt-get install -y phantomjs
 
       - name: Cache wkhtmltopdf package
         if: ${{ matrix.tests.ebook }}

--- a/Gemfile
+++ b/Gemfile
@@ -120,7 +120,8 @@ group :test do
   gem "capybara"
   gem "cucumber"
   gem 'database_cleaner'
-  gem 'poltergeist'
+  gem "selenium-webdriver"
+  gem "webdrivers"
   gem 'capybara-screenshot'
   gem 'cucumber-rails', require: false
   gem 'launchy'    # So you can do Then show me the page

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -162,7 +162,6 @@ GEM
       launchy
     chronic (0.10.2)
     climate_control (0.2.0)
-    cliver (0.3.2)
     coderay (1.1.3)
     concurrent-ruby (1.2.0)
     connection_pool (2.2.5)
@@ -374,10 +373,6 @@ GEM
     pickle (0.6.2)
       cucumber (>= 3.0, < 8.0)
       rake
-    poltergeist (1.18.1)
-      capybara (>= 2.1, < 4)
-      cliver (~> 0.3.1)
-      websocket-driver (>= 0.2.0)
     power_assert (2.0.1)
     pry (0.13.1)
       coderay (~> 1.1)
@@ -495,6 +490,7 @@ GEM
     ruby-progressbar (1.11.0)
     ruby2_keywords (0.0.5)
     rubyntlm (0.6.3)
+    rubyzip (2.3.2)
     rufus-scheduler (3.6.0)
       fugit (~> 1.1, >= 1.1.6)
     rvm-capistrano (1.5.6)
@@ -502,6 +498,10 @@ GEM
     sanitize (6.0.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
+    selenium-webdriver (4.8.1)
+      rexml (~> 3.2, >= 3.2.5)
+      rubyzip (>= 1.2.2, < 3.0)
+      websocket (~> 1.0)
     shoulda (4.0.0)
       shoulda-context (~> 2.0)
       shoulda-matchers (~> 4.0)
@@ -557,12 +557,17 @@ GEM
       rack (>= 1.0.0)
     warden (1.2.9)
       rack (>= 2.0.9)
+    webdrivers (5.2.0)
+      nokogiri (~> 1.6)
+      rubyzip (>= 1.3.0)
+      selenium-webdriver (~> 4.0)
     webmock (3.18.1)
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.7.0)
     webrobots (0.1.2)
+    websocket (1.2.9)
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
@@ -636,7 +641,6 @@ DEPENDENCIES
   permit_yo
   phraseapp-in-context-editor-ruby (>= 1.0.6)
   pickle
-  poltergeist
   pry-byebug
   pundit
   rack (~> 2.2)
@@ -658,6 +662,7 @@ DEPENDENCIES
   rubocop-rspec (= 1.41.0)
   rvm-capistrano
   sanitize (>= 4.6.5)
+  selenium-webdriver
   shoulda
   simplecov
   simplecov-cobertura
@@ -671,6 +676,7 @@ DEPENDENCIES
   unicorn (~> 5.5)
   unidecoder
   vcr (~> 3.0, >= 3.0.1)
+  webdrivers
   webmock
   whenever (~> 0.6.2)
   whiny_validation

--- a/app/views/external_works/fetch.js.erb
+++ b/app/views/external_works/fetch.js.erb
@@ -8,6 +8,12 @@
   $j('input[id^="external_work_category_strings_"]').each(function() {
     $j(this).prop("checked", categories.indexOf(this.value) >= 0 );
   });
+
+  <% # clear existing autocompletes %>
+  $j("#external_work_fandom_string_autocomplete").parent().parent().find(".delete a").click()
+  $j("#external_work_relationship_string_autocomplete").parent().parent().find(".delete a").click()
+  $j("#external_work_character_string_autocomplete").parent().parent().find(".delete a").click()
+
   $j('#external_work_fandom_string_autocomplete').val("<%= @external_work.fandom_string %>");
   $j('#external_work_relationship_string_autocomplete').val("<%= @external_work.relationship_string %>");
   $j('#external_work_character_string_autocomplete').val("<%= @external_work.character_string %>");

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -48,9 +48,11 @@
     <%= render 'inbox_module', inbox_comments: @homepage.inbox_comments %>
   <% end %>
 
-  <div class="latest tweets module">
-    <h3 class="heading"><%= ts('Tweets') %></h3>
-    <a class="twitter-timeline" href="https://twitter.com/otw_status/lists/otw-tweets" data-dnt="true" data-height="600"><%= ts('Tweets from https://twitter.com/otw_status/lists/otw-tweets') %></a>
-    <script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+"://platform.twitter.com/widgets.js";fjs.parentNode.insertBefore(js,fjs);}}(document,"script","twitter-wjs");</script>
-  </div>
+  <% unless Rails.env.test? %>
+    <div class="latest tweets module">
+      <h3 class="heading"><%= ts('Tweets') %></h3>
+      <a class="twitter-timeline" href="https://twitter.com/otw_status/lists/otw-tweets" data-dnt="true" data-height="600"><%= ts('Tweets from https://twitter.com/otw_status/lists/otw-tweets') %></a>
+      <script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+"://platform.twitter.com/widgets.js";fjs.parentNode.insertBefore(js,fjs);}}(document,"script","twitter-wjs");</script>
+    </div>
+  <% end %>
 </div>

--- a/config/docker/Dockerfile
+++ b/config/docker/Dockerfile
@@ -5,7 +5,6 @@ RUN apt-get update             && \
     apt-get install -y            \
         calibre                   \
         default-mysql-client      \
-        phantomjs                 \
         shared-mime-info          \
         wkhtmltopdf               \
         zip

--- a/config/docker/Dockerfile
+++ b/config/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:3.0.5-buster
+FROM ruby:3.0.5
 
 # Install additional packages
 RUN apt-get update             && \

--- a/config/initializers/gem-plugin_config/redis.rb
+++ b/config/initializers/gem-plugin_config/redis.rb
@@ -5,7 +5,7 @@ rails_root = ENV["RAILS_ROOT"] || File.dirname(__FILE__) + "/../../.."
 rails_env = ENV["RAILS_ENV"] || "development"
 
 unless ENV["CI"]
-  if rails_env == "test" && !ENV["OTWA_NO_START_REDIS"]
+  if rails_env == "test" && !ENV["DOCKER"]
     # https://gist.github.com/441072
     start_redis!(rails_root, :cucumber)
   end

--- a/config/initializers/gem-plugin_config/webmock.rb
+++ b/config/initializers/gem-plugin_config/webmock.rb
@@ -1,4 +1,5 @@
 if Rails.env.test?
-  WebMock.allow_net_connect!
+  # https://stackoverflow.com/questions/59632283/chromedriver-capybara-too-many-open-files-socket2-for-127-0-0-1-port-951
+  WebMock.allow_net_connect!(net_http_connect_on_start: true)
   WebMock.enable!
 end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,13 +4,22 @@
 #
 # This will handle setting up config files, creating databases, and running migrations.
 #
-# After these oneoff tasks have been performed, on subsequent starts you can simply use:
+# After these oneoff tasks have been performed, you can start the development
+# webserver with the command:
 #
 # ```
 # docker-compose up -d web
 # ```
 #
-# After starting the archive, it will be visible at http://localhost:3000/
+# Once it is running, it will be visible at http://localhost:3000/
+#
+# To run tests, you should use the test container instead of the web container,
+# because it includes a headless chrome container for running JS-based tests.
+# You can run tests like this:
+#
+# ```
+# docker-compose run test bundle exec cucumber features/other_a/autocomplete.feature
+# ```
 
 version: "3"
 volumes:
@@ -58,12 +67,13 @@ services:
     ports:
       - "11211:11211"
   web:
+    profiles:
+      - dev
     build:
       context: .
       dockerfile: ./config/docker/Dockerfile
     environment:
-      - OTWA_NO_START_REDIS=1
-      - QT_QPA_PLATFORM=offscreen
+      - RAILS_ENV=development
     command: bash -c "rm -f tmp/pids/server.pid && bundle exec rails s -p 3000 -b '0.0.0.0'"
     volumes:
       - .:/otwa
@@ -74,3 +84,32 @@ services:
       - redis
       - es
       - mc
+  chrome:
+    profiles:
+      - test
+    image: selenium/standalone-chrome
+    ports:
+      - "4444:4444"
+  test:
+    profiles:
+      - test
+    build:
+      context: .
+      dockerfile: ./config/docker/Dockerfile
+    environment:
+      - RAILS_ENV=test
+      - CHROME_URL=http://chrome:4444
+      - DOCKER=true
+      - CAPYBARA_PORT=5100
+      - OTWA_NO_START_REDIS=1
+    command: bundle exec cucumber
+    volumes:
+      - .:/otwa
+    ports:
+      - "5100:5100"
+    depends_on:
+      - db
+      - redis
+      - es
+      - mc
+      - chrome

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -101,7 +101,6 @@ services:
       - CHROME_URL=http://chrome:4444
       - DOCKER=true
       - CAPYBARA_PORT=5100
-      - OTWA_NO_START_REDIS=1
     command: bundle exec cucumber
     volumes:
       - .:/otwa

--- a/features/admins/admin_skins.feature
+++ b/features/admins/admin_skins.feature
@@ -1,4 +1,4 @@
-@skins
+@set-default-skin
 Feature: Admin manage skins
 
   Scenario: Users should not be able to see the admin skins page

--- a/features/bookmarks/bookmark_share.feature
+++ b/features/bookmarks/bookmark_share.feature
@@ -3,7 +3,7 @@ Feature: Share Bookmarks
   Testing the "Share" button on bookmarks, with JavaScript emulation
 
   # We need to load the site skin to make the share modal work properly:
-  @javascript @site-skins
+  @javascript @load-default-skin
   Scenario: Share a bookmark
     Given I am logged in as "tess"
       And I have a bookmark for "Damp Gravel"

--- a/features/bookmarks/bookmark_share.feature
+++ b/features/bookmarks/bookmark_share.feature
@@ -2,7 +2,8 @@
 Feature: Share Bookmarks
   Testing the "Share" button on bookmarks, with JavaScript emulation
 
-  @javascript
+  # We need to load the site skin to make the share modal work properly:
+  @javascript @site-skins
   Scenario: Share a bookmark
     Given I am logged in as "tess"
       And I have a bookmark for "Damp Gravel"
@@ -23,7 +24,6 @@ Feature: Share Bookmarks
       And I should not see "Characters:" within "#share textarea"
       And I should not see "Summary:" within "#share textarea"
 
-  @javascript
   Scenario: Share option is unavailable if bookmarkable is unrevealed.
     Given there is a work "Hidden Figures" in an unrevealed collection "Backlist"
       And I am logged in as the author of "Hidden Figures"
@@ -38,7 +38,6 @@ Feature: Share Bookmarks
       And I should see "Add To Collection"
       And I should not see "Share"
 
-  @javascript
   Scenario: Sharing a bookmark is not possible when logged out
     Given I am logged in as "tess"
       And I have a bookmark for "Damp Gravel"

--- a/features/collections/collection_anonymity.feature
+++ b/features/collections/collection_anonymity.feature
@@ -513,7 +513,8 @@ Feature: Collection
       And the email should contain "The collection maintainers may later reveal your work but leave it anonymous."
       And the email should not contain "translation missing"
 
-  @javascript
+  # We need to load the site skin to make the share modal work:
+  @javascript @site-skins
   Scenario: Work share modal should not reveal anonymous authors
     Given I have the anonymous collection "Anonymous Hugs"
     When I am logged in as "first_user"

--- a/features/collections/collection_anonymity.feature
+++ b/features/collections/collection_anonymity.feature
@@ -514,7 +514,7 @@ Feature: Collection
       And the email should not contain "translation missing"
 
   # We need to load the site skin to make the share modal work:
-  @javascript @site-skins
+  @javascript @load-default-skin
   Scenario: Work share modal should not reveal anonymous authors
     Given I have the anonymous collection "Anonymous Hugs"
     When I am logged in as "first_user"

--- a/features/other_a/hit_counts.feature
+++ b/features/other_a/hit_counts.feature
@@ -1,8 +1,5 @@
 @javascript
 Feature: Hit Counts
-  Background:
-    Given I limit myself to the Archive
-
   # Throughout these tests, we use the "all hit count information is reset"
   # step because logging in/logging out may result in the user being redirected
   # to the page that the user was just on, i.e. the work whose hit count we're

--- a/features/other_a/preferences_edit.feature
+++ b/features/other_a/preferences_edit.feature
@@ -100,8 +100,7 @@ Feature: Edit preferences
   Scenario: User can hide warning and freeform tags and reveal them on a case-
   by-case basis.
 
-  Given I limit myself to the Archive
-    And a canonical freeform "Scary tag"
+  Given a canonical freeform "Scary tag"
     And I am logged in as "someone_else"
     And I post the work "Someone Else's Work" as part of a series "A Series"
     And I am logged in as "tester"

--- a/features/other_b/skin.feature
+++ b/features/other_b/skin.feature
@@ -1,4 +1,4 @@
-@skins
+@set-default-skin
 Feature: Non-public site and work skins
 
   Scenario: A user should be able to create a skin with CSS

--- a/features/other_b/skin_public.feature
+++ b/features/other_b/skin_public.feature
@@ -1,4 +1,4 @@
-@skins
+@set-default-skin
 Feature: Public skins
 
   Scenario: A user's initial skin should be set to default

--- a/features/other_b/skin_wizard.feature
+++ b/features/other_b/skin_wizard.feature
@@ -1,4 +1,4 @@
-@skins
+@set-default-skin
 Feature: Skin wizard
 
   Scenario: User should be able to toggle between the wizard and the form

--- a/features/step_definitions/generic_steps.rb
+++ b/features/step_definitions/generic_steps.rb
@@ -159,23 +159,17 @@ end
 
 Then /^the "([^"]*)" checkbox(?: within "([^"]*)")? should be disabled$/ do |label, selector|
   with_scope(selector) do
-    field_disabled = find_field(label, disabled: true)
-    if field_disabled.respond_to? :should
-      field_disabled.should be_truthy
-    else
-      assert field_disabled
-    end
+    field = find_field(label, disabled: true)
+    expect(field).to be_present
+    expect(field.disabled?).to be_truthy
   end
 end
 
 Then /^the "([^"]*)" checkbox(?: within "([^"]*)")? should not be disabled$/ do |label, selector|
   with_scope(selector) do
-    field_disabled = find_field(label)['disabled']
-    if field_disabled.respond_to? :should
-      field_disabled.should be_falsey
-    else
-      assert !field_disabled
-    end
+    field = find_field(label)
+    expect(field).to be_present
+    expect(field.disabled?).to be_falsey
   end
 end
 

--- a/features/step_definitions/web_steps.rb
+++ b/features/step_definitions/web_steps.rb
@@ -20,15 +20,6 @@ When /^I take a screenshot$/ do
   screenshot_and_save_page
 end
 
-# We set the default domain to example.org.
-# The phantomjs drive fetchs pages directly so some tests will go to example.org
-# setting this whitelist stops this happening which is in itself a good thing
-# and makes the network traces easier to read as there are less calls to twitter etc.
-
-When /^I limit myself to the Archive$/ do
-  page.driver.browser.url_whitelist = ['http://127.0.0.1']
-end
-
 When /^I clear the network traffic$/ do
   page.driver.clear_network_traffic
 end

--- a/features/step_definitions/work_steps.rb
+++ b/features/step_definitions/work_steps.rb
@@ -568,12 +568,19 @@ When /^I delete the work "([^"]*)"$/ do |work|
   work = Work.find_by(title: CGI.escapeHTML(work))
   visit edit_work_path(work)
   step %{I follow "Delete Work"}
-  # If JavaScript is enabled, window.confirm will be used and this button will not appear
-  click_button("Yes, Delete Work") unless @javascript
+
+  # If JavaScript is enabled, window.confirm will be used and we'll have to accept
+  if @javascript
+    expect(page.accept_alert).to eq("Are you sure you want to delete this work? This will destroy all comments and kudos on this work as well and CANNOT BE UNDONE!")
+  else
+    click_button("Yes, Delete Work")
+  end
+
   step %{all indexing jobs have been run}
 
   step "the periodic tag count task is run"
 end
+
 When /^I preview the work$/ do
   click_button("Preview")
   step %{all indexing jobs have been run}

--- a/features/support/capybara.rb
+++ b/features/support/capybara.rb
@@ -1,7 +1,10 @@
-require 'capybara/poltergeist'
-
 # Produce a screenshot for each failure.
 require 'capybara-screenshot/cucumber'
+
+# Use environment variables to set the host and the port used for tests:
+CAPYBARA_HOST = ENV["DOCKER"] ? `hostname`.strip : "localhost"
+CAPYBARA_PORT = ENV["CAPYBARA_PORT"] || 5100
+CAPYBARA_URL = "http://#{CAPYBARA_HOST}:#{CAPYBARA_PORT}"
 
 Capybara.configure do |config|
   # Capybara 1.x behavior.
@@ -17,14 +20,58 @@ Capybara.configure do |config|
   # (a dependency of Mechanize, used for importing; also used for the
   # Rails development server), so we'll stick with that for now.
   config.server = :webrick
+
+  # Make server accessible from the outside world. Note that we don't use
+  # CAPYBARA_HOST here because this is the IP that the server binds to, not the
+  # host that we want to use for tests:
+  config.server_host = "0.0.0.0" if ENV["CHROME_URL"]
+
+  # Specify the port used for tests:
+  config.server_port = CAPYBARA_PORT
 end
 
-# Reconfigure poltergeist to block twitter:
-Capybara.register_driver :poltergeist do |app|
-  Capybara::Poltergeist::Driver.new(
-    app, url_blacklist: ["http://platform.twitter.com", "https://platform.twitter.com"]
-  )
+# Modified from https://github.com/teamcapybara/capybara/blob/49cf69c40f4b25931aecab162fb3285d8fe5bff7/lib/capybara/registrations/drivers.rb#L31-L42
+Capybara.register_driver :selenium_chrome_headless do |app|
+  browser_options = ::Selenium::WebDriver::Chrome::Options.new.tap do |opts|
+    opts.add_argument('--headless')
+    opts.add_argument('--disable-gpu') if Gem.win_platform?
+    opts.add_argument('--disable-site-isolation-trials')
+  end
+
+  options = if ENV["CHROME_URL"]
+              # Special handling for Docker, modified from the instructions at
+              # https://evilmartians.com/chronicles/system-of-a-test-setting-up-end-to-end-rails-testing
+              { browser: :remote, options: browser_options, url: ENV["CHROME_URL"] }
+            else
+              { browser: :chrome, options: browser_options }
+            end
+
+  Capybara::Selenium::Driver.new(app, **options)
+end
+
+# Make sure we get full-page screenshots on failure:
+Capybara::Screenshot.register_driver :selenium_chrome_headless do |driver, path|
+  # From https://github.com/madebylotus/capybara-full_screenshot/blob/bf1c3ede89e01b847f7b0dc7d71cd73b25175cd5/lib/capybara/full_screenshot/rspec_helpers.rb#L5-L8
+  width  = Capybara.page.execute_script(<<~WIDTH_SCRIPT.squish)
+    return Math.max(document.body.scrollWidth,
+                    document.body.offsetWidth,
+                    document.documentElement.clientWidth,
+                    document.documentElement.scrollWidth,
+                    document.documentElement.offsetWidth);
+  WIDTH_SCRIPT
+
+  height = Capybara.page.execute_script(<<~HEIGHT_SCRIPT.squish)
+    return Math.max(document.body.scrollHeight,
+                    document.body.offsetHeight,
+                    document.documentElement.clientHeight,
+                    document.documentElement.scrollHeight,
+                    document.documentElement.offsetHeight);
+  HEIGHT_SCRIPT
+
+  Capybara.current_session.current_window.resize_to(width + 100, height + 100)
+
+  driver.browser.save_screenshot(path)
 end
 
 Capybara.default_driver = :rack_test
-Capybara.javascript_driver = :poltergeist
+Capybara.javascript_driver = :selenium_chrome_headless

--- a/features/support/capybara.rb
+++ b/features/support/capybara.rb
@@ -4,7 +4,7 @@ require 'capybara-screenshot/cucumber'
 # Use environment variables to set the host and the port used for tests:
 CAPYBARA_HOST = ENV["DOCKER"] ? `hostname`.strip : "localhost"
 CAPYBARA_PORT = ENV["CAPYBARA_PORT"] || 5100
-CAPYBARA_URL = "http://#{CAPYBARA_HOST}:#{CAPYBARA_PORT}"
+CAPYBARA_URL = "http://#{CAPYBARA_HOST}:#{CAPYBARA_PORT}".freeze
 
 Capybara.configure do |config|
   # Capybara 1.x behavior.
@@ -33,9 +33,9 @@ end
 # Modified from https://github.com/teamcapybara/capybara/blob/49cf69c40f4b25931aecab162fb3285d8fe5bff7/lib/capybara/registrations/drivers.rb#L31-L42
 Capybara.register_driver :selenium_chrome_headless do |app|
   browser_options = ::Selenium::WebDriver::Chrome::Options.new.tap do |opts|
-    opts.add_argument('--headless')
-    opts.add_argument('--disable-gpu') if Gem.win_platform?
-    opts.add_argument('--disable-site-isolation-trials')
+    opts.add_argument("--headless")
+    opts.add_argument("--disable-gpu") if Gem.win_platform?
+    opts.add_argument("--disable-site-isolation-trials")
   end
 
   options = if ENV["CHROME_URL"]
@@ -52,7 +52,7 @@ end
 # Make sure we get full-page screenshots on failure:
 Capybara::Screenshot.register_driver :selenium_chrome_headless do |driver, path|
   # From https://github.com/madebylotus/capybara-full_screenshot/blob/bf1c3ede89e01b847f7b0dc7d71cd73b25175cd5/lib/capybara/full_screenshot/rspec_helpers.rb#L5-L8
-  width  = Capybara.page.execute_script(<<~WIDTH_SCRIPT.squish)
+  width = Capybara.page.execute_script(<<~WIDTH_SCRIPT.squish)
     return Math.max(document.body.scrollWidth,
                     document.body.offsetWidth,
                     document.documentElement.clientWidth,

--- a/features/support/capybara.rb
+++ b/features/support/capybara.rb
@@ -34,7 +34,8 @@ end
 Capybara.register_driver :selenium_chrome_headless do |app|
   browser_options = ::Selenium::WebDriver::Chrome::Options.new.tap do |opts|
     opts.add_argument("--headless")
-    opts.add_argument("--disable-gpu") if Gem.win_platform?
+
+    # Workaround from https://bugs.chromium.org/p/chromedriver/issues/detail?id=2660#c13
     opts.add_argument("--disable-site-isolation-trials")
   end
 

--- a/features/support/hooks.rb
+++ b/features/support/hooks.rb
@@ -69,12 +69,12 @@ After "@disable_caching" do
   ActionController::Base.perform_caching = true
 end
 
-Before "@skins" do
+Before "@set-default-skin" do
   # Create a default skin:
   AdminSetting.current.update_attribute(:default_skin, Skin.default)
 end
 
-Before "@site-skins" do
+Before "@load-default-skin" do
   # Load the site skin and make it the default:
   Skin.load_site_css
   Skin.set_default_to_current_version

--- a/features/support/hooks.rb
+++ b/features/support/hooks.rb
@@ -53,6 +53,12 @@ end
 @javascript = false
 Before "@javascript" do
   @javascript = true
+
+  Capybara.app_host = CAPYBARA_URL
+end
+
+Before "not @javascript" do
+  Capybara.app_host = "http://www.example.com"
 end
 
 Before "@disable_caching" do
@@ -65,5 +71,12 @@ end
 
 Before "@skins" do
   # Create a default skin:
+  AdminSetting.current.update_attribute(:default_skin, Skin.default)
+end
+
+Before "@site-skins" do
+  # Load the site skin and make it the default:
+  Skin.load_site_css
+  Skin.set_default_to_current_version
   AdminSetting.current.update_attribute(:default_skin, Skin.default)
 end

--- a/features/works/work_share.feature
+++ b/features/works/work_share.feature
@@ -1,5 +1,5 @@
 # We need to load the site skin to make the share modal work properly:
-@works @site-skins
+@works @load-default-skin
 Feature: Share Works
   Testing the "Share" button on works, with Javascript emulation
 

--- a/features/works/work_share.feature
+++ b/features/works/work_share.feature
@@ -1,4 +1,5 @@
-@works
+# We need to load the site skin to make the share modal work properly:
+@works @site-skins
 Feature: Share Works
   Testing the "Share" button on works, with Javascript emulation
 
@@ -75,6 +76,7 @@ Feature: Share Works
     When I follow "Share"
     Then I should see "Close" within "#modal"
     When I follow "Close"
+      And I follow "Log In"
       And I fill in "User name or email:" with "maduser"
       And I fill in "Password:" with "password"
       And I press "Log In"

--- a/script/docker/init.cmd
+++ b/script/docker/init.cmd
@@ -9,5 +9,5 @@ docker-compose up -d
 
 timeout 60
 
-docker-compose run -e RAILS_ENV=development web script/reset_database.sh
-docker-compose run -e RAILS_ENV=test web script/reset_database.sh
+docker-compose run web script/reset_database.sh
+docker-compose run test script/reset_database.sh

--- a/script/docker/init.sh
+++ b/script/docker/init.sh
@@ -13,5 +13,5 @@ docker-compose up -d
 
 sleep 60
 
-docker-compose run -e RAILS_ENV=development web script/reset_database.sh
-docker-compose run -e RAILS_ENV=test web script/reset_database.sh
+docker-compose run web script/reset_database.sh
+docker-compose run test script/reset_database.sh


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6496

## Purpose

- Adds the `selenium-webdriver` library and the `webdrivers` library.
- Removes the `poltergeist` library and the code for installing `phantomjs`.
- Modifies the twitter widget on the homepage so that it's not displayed in tests, since Selenium doesn't offer native URL blocking.
- Removes the `I limit myself to the Archive` step, because Selenium doesn't offer native URL blocking.
- Modifies `docker-compose.yml` to add a separate `test` container that has access to a headless chrome container with selenium installed.
- Modifies most of the tests involving the Share modal to add the new `@site-skins` tag, because modals don't display properly without the site CSS loaded.
- Adds a custom screenshot driver to allow full-page screenshots on failure.
- Fixes a bug with the external work autocomplete, where the code that was intended to replace the Fandom/Character/Relationship values with the values from the autocompleted external work actually just appended the new values.