### PR TITLE
AO3-6478 checkbox logic includes overlaps

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -414,7 +414,7 @@ module ApplicationHelper
       when options[:checked_method].nil?
         []
       else
-        form.object.send(options[:checked_method]) || []
+        form.object.send(options[:checked_method]).split(', ') || []
       end
 
     checkboxes = choices.map do |choice|

--- a/app/models/tagset_models/tag_set.rb
+++ b/app/models/tagset_models/tag_set.rb
@@ -45,7 +45,7 @@ class TagSet < ApplicationRecord
 
     define_method("#{type}_tagnames") do
       self.instance_variable_get("@#{type}_tagnames") || (self.new_record? ? self.tags.select {|t| t.type == type.classify}.collect(&:name).join(ArchiveConfig.DELIMITER_FOR_OUTPUT) :
-                                                                             self.tags.with_type(type.classify).select('tags.name').order('tags.name').collect(&:name).join(ArchiveConfig.DELIMITER_FOR_OUTPUT))
+                                                                             self.tags.with_type(type.classify).select('tags.name').order('tags.name').collect(&:name))
     end
 
     define_method("#{type}_taglist") do

--- a/app/models/tagset_models/tag_set.rb
+++ b/app/models/tagset_models/tag_set.rb
@@ -45,7 +45,7 @@ class TagSet < ApplicationRecord
 
     define_method("#{type}_tagnames") do
       self.instance_variable_get("@#{type}_tagnames") || (self.new_record? ? self.tags.select {|t| t.type == type.classify}.collect(&:name).join(ArchiveConfig.DELIMITER_FOR_OUTPUT) :
-                                                                             self.tags.with_type(type.classify).select('tags.name').order('tags.name').collect(&:name))
+                                                                             self.tags.with_type(type.classify).select('tags.name').order('tags.name').collect(&:name).join(ArchiveConfig.DELIMITER_FOR_OUTPUT))
     end
 
     define_method("#{type}_taglist") do

--- a/features/gift_exchanges/challenge_giftexchange.feature
+++ b/features/gift_exchanges/challenge_giftexchange.feature
@@ -641,3 +641,11 @@ Feature: Gift Exchange Challenge
       And I uncheck "exchange_collection (recip)"
       And I press "Post"
     Then I should see "For recip."
+
+  Scenario: Editing Gift Exchange sign up does not automatically check every couple from a poly ship.
+    Given the open gift exchange "Overlap Gift Exchange" has overlapping tags
+    When I sign up for "Overlap Gift Exchange" with combination E
+      And I follow "Edit Sign-up"
+    Then the "Sam Carter/Daniel Jackson/Jack O'Neill" checkbox should be checked
+      And the "Sam Carter/Daniel Jackson" checkbox should not be checked
+      And the "Daniel Jackson/Jack O'Neill" checkbox should not be checked

--- a/features/gift_exchanges/challenge_giftexchange.feature
+++ b/features/gift_exchanges/challenge_giftexchange.feature
@@ -642,7 +642,7 @@ Feature: Gift Exchange Challenge
       And I press "Post"
     Then I should see "For recip."
 
-  Scenario: Editing Gift Exchange sign up does not automatically check every couple from a poly ship.
+  Scenario: Editing Gift Exchange sign up does not automatically check every overlapping tag.
     Given the open gift exchange "Overlap Gift Exchange" has overlapping tags
     When I sign up for "Overlap Gift Exchange" with combination E
       And I follow "Edit Sign-up"

--- a/features/prompt_memes_a/challenge_promptmeme_setup.feature
+++ b/features/prompt_memes_a/challenge_promptmeme_setup.feature
@@ -488,3 +488,12 @@ Feature: Prompt Meme Challenge
     And I view prompts for "Battle 12"
     # TODO: Refactor this test once we have a new Capybara version so that we look for .exact(Claim)
   Then I should see "Drop Claim"
+
+  Scenario: Editing Gift Exchange sign up does not automatically check every overlapping tag
+
+  Given I have prompt meme "Overlap Prompt Meme" fully set up with overlapping tags
+  When I sign up for "Overlap Prompt Meme" with combination F
+    And I follow "Edit Sign-up"
+  Then the "Sam Carter/Daniel Jackson/Jack O'Neill" checkbox should be checked
+    And the "Sam Carter/Daniel Jackson" checkbox should not be checked
+    And the "Daniel Jackson/Jack O'Neill" checkbox should not be checked

--- a/features/step_definitions/challege_gift_exchange_steps.rb
+++ b/features/step_definitions/challege_gift_exchange_steps.rb
@@ -113,7 +113,7 @@ end
 
 Given /^the open gift exchange "([^\"]*)" has overlapping tags$/ do |challengename|
   step %{I am logged in as "mod1"}
-    step "I have overlapping challenge tags setup" #todo
+    step "I have overlapping challenge tags setup"
     step %{I set up the collection "#{challengename}" with name "#{challengename.gsub(/[^\w]/, '_')}"}
     step %{I select "Gift Exchange" from "challenge_type"}
   click_button("Submit")

--- a/features/step_definitions/challege_gift_exchange_steps.rb
+++ b/features/step_definitions/challege_gift_exchange_steps.rb
@@ -111,6 +111,17 @@ Given /^the gift exchange "([^\"]*)" is ready for signups$/ do |title|
   step %{I open signups for "#{title}"}
 end
 
+Given /^the open gift exchange "([^\"]*)" has overlapping tags$/ do |challengename|
+  step %{I am logged in as "mod1"}
+    step "I have overlapping challenge tags setup" #todo
+    step %{I set up the collection "#{challengename}" with name "#{challengename.gsub(/[^\w]/, '_')}"}
+    step %{I select "Gift Exchange" from "challenge_type"}
+  click_button("Submit")
+  step %{I check "Sign-up open?"}
+  fill_in("Tag Sets To Use:", with: "Standard Challenge Tags")
+  step %{I submit}
+end
+
 # This is going to make broken assignments a la AO3-5748
 Given /^"(.*?)" has two pinchhit assignments in the gift exchange "(.*?)"$/ do |user, collection_title|
   collection = Collection.find_by(title: collection_title)
@@ -203,6 +214,12 @@ When /^I sign up for "([^\"]*)" with combination SG-1$/ do |title|
   step %{I start signing up for "#{title}"}
     step %{I fill in "challenge_signup_requests_attributes_0_tag_set_attributes_fandom_tagnames" with "Stargate SG-1"}
     fill_in("challenge_signup_requests_attributes_0_title", with: "SG1 love")
+    click_button "Submit"
+end
+
+When /^I sign up for "([^\"]*)" with combination E$/ do |title|
+  step %{I start signing up for "#{title}"}
+    step %{I check the 1st checkbox with the value "Sam Carter/Daniel Jackson/Jack O'Neill"}
     click_button "Submit"
 end
 

--- a/features/step_definitions/challenge_promptmeme_steps.rb
+++ b/features/step_definitions/challenge_promptmeme_steps.rb
@@ -26,6 +26,15 @@ Given /^I have single-prompt prompt meme fully set up$/ do
   step "I fill in single-prompt challenge options"
 end
 
+Given /^I have prompt meme "([^\"]*)" fully set up with overlapping tags$/ do |challengename|
+  step %{I am logged in as "mod1"}
+    step "I have overlapping challenge tags setup"
+    step %{I set up the collection "#{challengename}" with name "#{challengename.gsub(/[^\w]/, '_')}"}
+    step %{I select "Prompt Meme" from "challenge_type"}
+  click_button("Submit")
+  step "I fill in overlapping tags challenge options"
+end
+
 Given /^everyone has signed up for Battle 12$/ do
   # no anon
   step %{I am logged in as "myname1"}
@@ -122,6 +131,13 @@ end
 When /^I create Battle 12 promptmeme$/ do
   step "I set up Battle 12 promptmeme collection"
   step "I fill in Battle 12 challenge options"
+end
+
+When /^I fill in overlapping tags challenge options$/ do 
+  step %{I fill in "General Sign-up Instructions" with "Here are some general tips"}
+    fill_in("Tag Sets To Use:", with: "Standard Challenge Tags")
+    step %{I check "Sign-up open?"}
+    step %{I submit}
 end
 
 When /^I fill in Battle 12 challenge options$/ do
@@ -257,6 +273,13 @@ When /^I sign up for Battle 12 with combination E$/ do
     step "I follow \"Sign Up\""
     step %{I fill in "Description:" with "Weird description"}
     step "I press \"Submit\""
+end
+
+When /^I sign up for "([^\"]*)" with combination F$/ do |title|
+  step %{I start signing up for "#{title}"}
+    step %{I check the 1st checkbox with the value "Sam Carter/Daniel Jackson/Jack O'Neill"}
+    click_button "Submit"
+  step %{I should see "Sign-up was successfully created"}
 end
 
 When /^I sign up for "([^\"]*)" fixed-fandom prompt meme$/ do |title|

--- a/features/step_definitions/challenge_steps.rb
+++ b/features/step_definitions/challenge_steps.rb
@@ -68,6 +68,14 @@ Given /^I have Yuletide challenge tags set ?up$/ do
     step %{a canonical fandom "Unrequested"}
 end
 
+Given /^I have overlapping challenge tags set ?up$/ do 
+  step "I have standard challenge tags setup"
+    step %{I add the relationship tags "Sam Carter/Daniel Jackson/Jack O'Neill", "Sam Carter/Daniel Jackson", "Daniel Jackson/Jack O'Neill" to the tag set "Standard Challenge Tags"}
+    step %{a canonical relationship "Daniel Jackson/Jack O'Neill"}
+    step %{a canonical relationship "Sam Carter/Daniel Jackson"}
+    step %{a canonical relationship "Sam Carter/Daniel Jackson/Jack O'Neill"}
+end
+
 ### General Challenge Settings
 
 When /^I edit settings for "([^\"]*)" challenge$/ do |title|

--- a/features/step_definitions/challenge_steps.rb
+++ b/features/step_definitions/challenge_steps.rb
@@ -70,7 +70,7 @@ end
 
 Given /^I have overlapping challenge tags set ?up$/ do 
   step "I have standard challenge tags setup"
-    step %{I add the relationship tags "Sam Carter/Daniel Jackson/Jack O'Neill", "Sam Carter/Daniel Jackson", "Daniel Jackson/Jack O'Neill" to the tag set "Standard Challenge Tags"}
+    step %{I add the relationship tags "Sam Carter/Daniel Jackson, Daniel Jackson/Jack O'Neill, Sam Carter/Daniel Jackson/Jack O'Neill" to the tag set "Standard Challenge Tags"}
     step %{a canonical relationship "Daniel Jackson/Jack O'Neill"}
     step %{a canonical relationship "Sam Carter/Daniel Jackson"}
     step %{a canonical relationship "Sam Carter/Daniel Jackson/Jack O'Neill"}


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [x] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [x] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [x] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-6478

## Purpose

When populating checkboxes in prompt memes/gift exchanges the method checkbox_section accepts a list of checked tags in string form. .include? on that string allowed tags that were substrings of checked tags to appear checked even if they were not originally. Splitting that string to an array ensures it checks equality and not substring. (Both splitting the string before it's passed in and changing ".include?" to ".eq?" result in errors elsewhere)

## Testing Instructions

Create a new collection either gift exchange or prompt meme and add a tag set where at least one tag is a substring of another (ex: "diana/bruce/clark" and "diana/bruce"). Sign up for your challenge with the larger tag selected. Edit your sign up. You should see only the tag you selected checked, and the substring tag unchecked. 

## References

## Credit

pinkpurpleblue (she/her)
