### PR TITLE
AO3-6425 Don't mangle reported chapter URLs without schemes

### DIFF
--- a/app/models/abuse_report.rb
+++ b/app/models/abuse_report.rb
@@ -48,14 +48,13 @@ class AbuseReport < ApplicationRecord
   def standardize_url
     return unless url =~ %r{((chapters|works)/\d+)} || url =~ %r{(users\/\w+)}
 
-    url_with_scheme = add_scheme_to_url(url)
-    clean_url = clean_url(url_with_scheme)
-    standardized_url = add_work_id_to_url(clean_url)
-    self.url = standardized_url
+    self.url = add_scheme_to_url(url)
+    self.url = clean_url(url)
+    self.url = add_work_id_to_url(self.url)
   end
 
   def add_scheme_to_url(url)
-    uri = Addressable::URI.parse url
+    uri = Addressable::URI.parse(url)
     return url unless uri.scheme.nil?
 
     "https://#{uri}"
@@ -66,7 +65,7 @@ class AbuseReport < ApplicationRecord
   # If the URL ends without a / at the end, add it: url_is_not_over_reported
   # uses the / so "/works/1234" isn't a match for "/works/123"
   def clean_url(url)
-    uri = Addressable::URI.parse url
+    uri = Addressable::URI.parse(url)
 
     uri.query = nil
     uri.fragment = nil
@@ -87,8 +86,8 @@ class AbuseReport < ApplicationRecord
 
     return url if work_id.nil?
     
-    uri = Addressable::URI.parse url
-    uri.path = "/works/" + work_id.to_s + uri.path
+    uri = Addressable::URI.parse(url)
+    uri.path = "/works/#{work_id}" + uri.path
 
     uri.to_s
   end

--- a/app/models/abuse_report.rb
+++ b/app/models/abuse_report.rb
@@ -58,7 +58,7 @@ class AbuseReport < ApplicationRecord
     uri = Addressable::URI.parse url
     return url unless uri.scheme.nil?
 
-    "https://#{uri.to_s}"
+    "https://#{uri}"
   end
 
   # Clean work or profile URLs so we can prevent the same URLs from getting

--- a/app/models/abuse_report.rb
+++ b/app/models/abuse_report.rb
@@ -39,42 +39,58 @@ class AbuseReport < ApplicationRecord
 
   scope :by_date, -> { order('created_at DESC') }
 
-  before_validation :add_work_id_to_url, :clean_url, on: :create
-  
-  # Clean work or profile URLs so we can prevent the same URLs from
-  # getting reported too many times.
-  # If the URL ends without a / at the end, add it:
-  # url_is_not_over_reported uses the / so "/works/1234" isn't a match
-  # for "/works/123"
-  def clean_url
-    # Work URLs: "works/123"
-    # Profile URLs: "users/username"
-    if url =~ /(works\/\d+)/ || url =~ /(users\/\w+)/
-      uri = Addressable::URI.parse url
-      uri.query = nil
-      uri.fragment = nil
-      uri.path += "/" unless uri.path.end_with? "/"
-      self.url = uri.to_s
-    else
-      url
-    end
+  # Standardize the format of work, chapter, and profile URLs to get it ready
+  # for the url_is_not_over_reported validation.
+  # Work URLs: "works/123"
+  # Chapter URLs: "chapters/123"
+  # Profile URLs: "users/username"
+  before_validation :standardize_url, on: :create
+  def standardize_url
+    return unless url =~ %r{((chapters|works)/\d+)} || url =~ %r{(users\/\w+)}
+
+    url_with_scheme = add_scheme_to_url(url)
+    clean_url = clean_url(url_with_scheme)
+    standardized_url = add_work_id_to_url(clean_url)
+    self.url = standardized_url
   end
 
-  # Gets the chapter id from the URL and tries to get the work id
-  # If successful, the work id is then added to the URL in front of "/chapters"
-  def add_work_id_to_url
-    return unless url =~ %r{(chapters/\d+)} && url !~ %r{(works/\d+)}
+  def add_scheme_to_url(url)
+    uri = Addressable::URI.parse url
+    return url unless uri.scheme.nil?
+
+    "https://#{uri.to_s}"
+  end
+
+  # Clean work or profile URLs so we can prevent the same URLs from getting
+  # reported too many times.
+  # If the URL ends without a / at the end, add it: url_is_not_over_reported
+  # uses the / so "/works/1234" isn't a match for "/works/123"
+  def clean_url(url)
+    uri = Addressable::URI.parse url
+
+    uri.query = nil
+    uri.fragment = nil
+    uri.path += "/" unless uri.path.end_with? "/"
+
+    uri.to_s
+  end
+
+  # Get the chapter id from the URL and try to get the work id
+  # If successful, add the work id to the URL in front of "/chapters"
+  def add_work_id_to_url(url)
+    return url unless url =~ %r{(chapters/\d+)} && url !~ %r{(works/\d+)}
 
     chapter_regex = %r{(chapters/)(\d+)}
     regex_groups = chapter_regex.match url
     chapter_id = regex_groups[2]
     work_id = Chapter.find_by(id: chapter_id).try(:work_id)
 
-    return if work_id.nil?
+    return url if work_id.nil?
     
     uri = Addressable::URI.parse url
     uri.path = "/works/" + work_id.to_s + uri.path
-    self.url = uri.to_s
+
+    uri.to_s
   end
 
   app_url_regex = Regexp.new('^(https?:\/\/)?(www\.|(insecure\.))?(archiveofourown|ao3)\.(org|com).*', true)

--- a/spec/models/abuse_report_spec.rb
+++ b/spec/models/abuse_report_spec.rb
@@ -42,11 +42,20 @@ describe AbuseReport do
       context "when the chapter exists" do
         let(:work) { create(:work) }
         let(:chapter) { work.chapters.first }
-        let(:missing_work_id) { build(:abuse_report, url: "http://archiveofourown.org/chapters/#{chapter.id}") }
+        let(:missing_work_id) { build(:abuse_report, url: "http://archiveofourown.org/chapters/#{chapter.id}/") }
         
         it "saves and adds the correct work id to the URL" do
           expect(missing_work_id.save).to be_truthy
           expect(missing_work_id.url).to eq("http://archiveofourown.org/works/#{work.id}/chapters/#{chapter.id}/")
+        end
+
+        context "when the URL does not include the scheme" do
+          let(:missing_work_id) { build(:abuse_report, url: "archiveofourown.org/chapters/#{chapter.id}/") }
+
+          it "saves and adds a scheme and correct work id to the URL" do
+            expect(missing_work_id.save).to be_truthy
+            expect(missing_work_id.url).to eq("https://archiveofourown.org/works/#{work.id}/chapters/#{chapter.id}/")
+          end
         end
       end
 
@@ -54,9 +63,19 @@ describe AbuseReport do
         let(:chapter_url) { "http://archiveofourown.org/chapters/000" }
         let(:missing_work_id) { build(:abuse_report, url: chapter_url) }
 
-        it "saves without modifying the URL" do
+        it "saves without adding a work id to the URL" do
           expect(missing_work_id.save).to be_truthy
-          expect(missing_work_id.url).to eq(chapter_url)
+          expect(missing_work_id.url).to eq("#{chapter_url}/")
+        end
+
+        context "when the URL does not include the scheme" do
+          let(:chapter_url) { "archiveofourown.org/chapters/000" }
+          let(:missing_work_id) { build(:abuse_report, url: chapter_url) }
+
+          it "saves and adds a scheme but no work id to the URL" do
+            expect(missing_work_id.save).to be_truthy
+            expect(missing_work_id.url).to eq("https://#{chapter_url}/")
+          end
         end
       end
     end


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6425

## Purpose

When you reported a chapter URL without including http or https at the start, the URL was coming back with the work ID at the front: `/works/1080706archiveofourown.org/chapters/2165131/`

This adds the scheme to the start of URLs so that won't happen.

I didn't have much time so I wanted to get something functional, but it is ugly. Please help me make it less ugly.

## Testing Instructions

Submit an abuse report with a URL like archiveofourown.org/chapters/123 and make sure it doesn't error.
