### PR TITLE
AO3-6044 Use PERMITTED_HOSTS to validate abuse report URLs

### DIFF
--- a/app/models/abuse_report.rb
+++ b/app/models/abuse_report.rb
@@ -92,7 +92,7 @@ class AbuseReport < ApplicationRecord
     uri.to_s
   end
 
-  app_url_regex = Regexp.new('^(https?:\/\/)?(www\.|(insecure\.))?(archiveofourown|ao3)\.(org|com).*', true)
+  app_url_regex = Regexp.new(ArchiveConfig.APP_URL_REGEX, true)
   validates_format_of :url, with: app_url_regex,
                             message: ts('does not appear to be on this site.'),
                             multiline: true

--- a/config/config.yml
+++ b/config/config.yml
@@ -483,7 +483,11 @@ PERMITTED_HOSTS: [
   "ao3.org",
   "www.archiveofourown.com",
   "www.archiveofourown.net",
-  "www.archiveofourown.org"
+  "www.archiveofourown.org",
+  # Staging
+  "insecure-test.archiveofourown.org",
+  "test.archiveofourown.org",
+  "testdownload.archiveofourown.org"
 ]
 
 USER_RENAME_LIMIT_DAYS: 7

--- a/config/config.yml
+++ b/config/config.yml
@@ -480,7 +480,7 @@ PERMITTED_HOSTS: [
   "download.archiveofourown.org",
   "insecure.archiveofourown.org",
   "secure.archiveofourown.org",
-  "ao3.org",
+  "www.ao3.org",
   "www.archiveofourown.com",
   "www.archiveofourown.net",
   "www.archiveofourown.org",

--- a/config/config.yml
+++ b/config/config.yml
@@ -503,3 +503,7 @@ STAT_COUNTER_BATCH_SIZE: 100
 # Number of hours to retain the original creator for works that have been
 # orphaned.
 ORIGINAL_CREATOR_TTL_HOURS: 72
+
+# Regex for the site's domains, used to validate that user-supplied
+# links are located on the Archive when appropriate.
+APP_URL_REGEX: "^(https?:\\/\\/)?(www\\.|(insecure\\.))?(archiveofourown|ao3)\\.(org|com).*"

--- a/config/config.yml
+++ b/config/config.yml
@@ -473,17 +473,17 @@ PERMITTED_HOSTS: [
   "104.153.64.122",
   "208.85.241.152",
   "208.85.241.157",
+  "ao3.org",
+  "archiveofourown.com",
+  "archiveofourown.net",
   "archiveofourown.org",
   "download.archiveofourown.org",
   "insecure.archiveofourown.org",
   "secure.archiveofourown.org",
+  "ao3.org",
   "www.archiveofourown.com",
   "www.archiveofourown.net",
-  "www.archiveofourown.org",
-  # Staging
-  "insecure-test.archiveofourown.org",
-  "test.archiveofourown.org",
-  "testdownload.archiveofourown.org"
+  "www.archiveofourown.org"
 ]
 
 USER_RENAME_LIMIT_DAYS: 7
@@ -503,7 +503,3 @@ STAT_COUNTER_BATCH_SIZE: 100
 # Number of hours to retain the original creator for works that have been
 # orphaned.
 ORIGINAL_CREATOR_TTL_HOURS: 72
-
-# Regex for the site's domains, used to validate that user-supplied
-# links are located on the Archive when appropriate.
-APP_URL_REGEX: "^(https?:\\/\\/)?(www\\.|(insecure\\.))?(archiveofourown|ao3)\\.(org|com).*"

--- a/config/locales/models/en.yml
+++ b/config/locales/models/en.yml
@@ -2,6 +2,10 @@ en:
   activerecord:
     errors:
       models:
+        abuse_report:
+          attributes:
+            url:
+              not_on_archive: "does not appear to be on this site."
         block:
           format: "%{message}"
           attributes:


### PR DESCRIPTION
# Pull Request Checklist

* [X] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [X] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [ ] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)? (n/a)
* [X] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [X] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-6044

## Purpose

Move the regex used to validate URLs in abuse reports to config.yaml. This will allow us to override it on test environment(s).

## Testing Instructions

Listed in the Jira description.

## References

Are there other relevant issues/pull requests/mailing list discussions?

## Credit

What name and pronouns should we use to credit you in the [Archive of Our Own's Release Notes](https://archiveofourown.org/admin_posts?tag=1)?

Brian Austin (they/he)
