### PR TITLE
AO3-6496 Add the --rm option to docker-compose run commands.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@
 # You can run tests like this:
 #
 # ```
-# docker-compose run test bundle exec cucumber features/other_a/autocomplete.feature
+# docker-compose run --rm test bundle exec cucumber features/other_a/autocomplete.feature
 # ```
 
 version: "3"

--- a/script/docker/init.cmd
+++ b/script/docker/init.cmd
@@ -9,5 +9,8 @@ docker-compose up -d
 
 timeout 60
 
-docker-compose run web script/reset_database.sh
-docker-compose run test script/reset_database.sh
+docker-compose run --rm web script/reset_database.sh
+
+:: The development database reset will do everything except run migrations for
+:: the test environment:
+docker-compose run --rm test bundle exec rake db:migrate

--- a/script/docker/init.sh
+++ b/script/docker/init.sh
@@ -13,5 +13,8 @@ docker-compose up -d
 
 sleep 60
 
-docker-compose run web script/reset_database.sh
-docker-compose run test script/reset_database.sh
+docker-compose run --rm web script/reset_database.sh
+
+# The development database reset will do everything except run migrations for
+# the test environment:
+docker-compose run --rm test bundle exec rake db:migrate


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6496

## Purpose

- Adds the `--rm` option when calling `docker-compose run`, to avoid leaving behind dead containers.
- Changes the init scripts to use `rake db:migrate` instead of `script/reset_database.sh` for the test environment, because the development script already creates the database and loads the schema for the test environment.