### PR TITLE
AO3-6504 Avoid resetting dev databases twice for Docker

### DIFF
--- a/lib/tasks/database_seed.rake
+++ b/lib/tasks/database_seed.rake
@@ -1,18 +1,21 @@
-# This task will reset the db and load in clean test data using the fixtures
-# Usage: rake db:otwseed
 namespace :db do
-  desc "Raise an error unless the Rails.env is development"
-  task :development_environment_only do
-    raise "ZOMG NOT IN PRODUCTION!" unless Rails.env.development? || Rails.env.test?
+  desc "Raise an error unless the environment is development or test"
+  task :test_environment_only do
+    raise "Only supported in test and development!" unless Rails.env.development? || Rails.env.test?
   end
 
-  desc "Reset and then seed the development database with test data from the fixtures"
-  task otwseed: [
-    :environment, :development_environment_only,
+  desc "Drop the database, recreate it from schema files and run remaining migrations"
+  task reset_and_migrate: [
+    :environment, :test_environment_only,
     # We can't use:
     # - db:reset, because schema files may not be up-to-date and migrations are required.
     # - db:migrate:reset, because we've deleted old migrations at various points.
-    :drop, :create, "schema:load", :migrate, :seed, "fixtures:load",
+    :drop, :create, "schema:load", :migrate
+  ]
+
+  desc "Reset and seed the database with data from test/fixtures/"
+  task otwseed: [
+    :reset_and_migrate, :seed, "fixtures:load",
     "work:missing_stat_counters", "Tag:reset_filters", "Tag:reset_filter_counts"
   ]
 end

--- a/script/reset_database.sh
+++ b/script/reset_database.sh
@@ -3,24 +3,21 @@
 set -ex
 
 case "${RAILS_ENV}" in
-test) ;;
-development) ;;
+test)
+  bundle install
+  bundle exec rake db:reset_and_migrate
+  ;;
+development)
+  bundle install
+  bundle exec rake db:otwseed
+  bundle exec rake skins:load_site_skins
+  bundle exec rake search:index_tags
+  bundle exec rake search:index_works
+  bundle exec rake search:index_pseuds
+  bundle exec rake search:index_bookmarks
+  ;;
 *)
   echo "Only supported in test and development (e.g. 'RAILS_ENV=test ./script/reset_database.sh')"
   exit 1
   ;;
 esac
-
-bundle install
-
-if [ "${RAILS_ENV}" = "test" ] ; then
-  bundle exec rake db:reset_and_migrate
-  exit 0
-fi
-
-bundle exec rake db:otwseed
-bundle exec rake skins:load_site_skins
-bundle exec rake search:index_tags
-bundle exec rake search:index_works
-bundle exec rake search:index_pseuds
-bundle exec rake search:index_bookmarks

--- a/script/reset_database.sh
+++ b/script/reset_database.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -ex
+
 case "${RAILS_ENV}" in
 test) ;;
 development) ;;
@@ -10,19 +12,14 @@ development) ;;
 esac
 
 bundle install
-bundle exec rake db:drop
-bundle exec rake db:create
-bundle exec rails db:environment:set
-bundle exec rake db:schema:load
-bundle exec rake db:migrate
+
 if [ "${RAILS_ENV}" = "test" ] ; then
+  bundle exec rake db:reset_and_migrate
   exit 0
 fi
+
 bundle exec rake db:otwseed
-
-bundle exec rake work:missing_stat_counters
 bundle exec rake skins:load_site_skins
-
 bundle exec rake search:index_tags
 bundle exec rake search:index_works
 bundle exec rake search:index_pseuds


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6504

## Purpose

The task `db:otwseed` depends on `db:drop`, `db:create`, etc. so we shouldn’t be [running both in the development environment](https://github.com/otwcode/otwarchive/blob/ccd24c3697144cc303f17c0e19cc65ff24915a5b/script/reset_database.sh#L13-L21).

## Testing Instructions

Tested locally by:
- Running the script from scratch: `./script/docker/init.sh`;
- Running `docker-compose run --rm test script/reset_database.sh` after the development environment has been set up and checking that only the test database is reset (and only once);
- Running `docker-compose run -e RAILS_ENV=staging --rm test script/reset_database.sh` and getting the error for an unsupported environment.