### PR TITLE
AO3-6509 Retry TagMethodJobs on deadlock and lock wait timeout.

### DIFF
--- a/app/jobs/tag_method_job.rb
+++ b/app/jobs/tag_method_job.rb
@@ -8,4 +8,8 @@ class TagMethodJob < InstanceMethodJob
   # trying to insert the same record at roughly the same time.
   retry_on ActiveRecord::RecordNotUnique,
            attempts: 3, wait: 5.minutes
+
+  # Try to prevent deadlocks and lock wait timeouts:
+  retry_on ActiveRecord::Deadlocked, attempts: 10, wait: 5.minutes
+  retry_on ActiveRecord::LockWaitTimeout, attempts: 10, wait: 5.minutes
 end


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6509

## Purpose

Adds two `retry_on` calls to the `TagMethodJob` class, one for deadlocks and one for lock wait timeouts. Set to a wait of 5 minutes (plus or minus the default jitter) so that hopefully whatever job we're conflicting with has time to finish.