### PR TITLE
AO3-6512 Fix api works RSpec tests leaking state

### DIFF
--- a/spec/controllers/api/v2/api_works_spec.rb
+++ b/spec/controllers/api/v2/api_works_spec.rb
@@ -144,14 +144,14 @@ describe "API v2 WorksController - Create works", type: :request do
 
     describe "Provided API metadata should be used if present" do
       before(:all) do
-        Language.find_or_create_by(short: "es", name: "Español")
+        Language.create(short: "es", name: "Español")
 
         mock_external
 
-        archivist = create(:archivist)
+        @archivist = create(:archivist)
 
         valid_params = {
-          archivist: archivist.login,
+          archivist: @archivist.login,
           works: [
             { id: "123",
               title: api_fields[:title],
@@ -181,6 +181,9 @@ describe "API v2 WorksController - Create works", type: :request do
       after(:all) do
         @work&.destroy
         WebMock.reset!
+        Language.find_by(short: "es").destroy
+        @archivist.destroy
+        Role.find_by(name: "archivist").destroy
       end
 
 
@@ -228,10 +231,10 @@ describe "API v2 WorksController - Create works", type: :request do
       before(:all) do
         mock_external
 
-        archivist = create(:archivist)
+        @archivist = create(:archivist)
 
         valid_params = {
-          archivist: archivist.login,
+          archivist: @archivist.login,
           works: [
             { external_author_name: api_fields[:external_author_name],
               external_author_email: api_fields[:external_author_email],
@@ -250,6 +253,8 @@ describe "API v2 WorksController - Create works", type: :request do
       after(:all) do
         @work&.destroy
         WebMock.reset!
+        @archivist.destroy
+        Role.find_by(name: "archivist").destroy
       end
 
       it "Title should be detected from the content" do
@@ -294,10 +299,10 @@ describe "API v2 WorksController - Create works", type: :request do
       before(:all) do
         mock_external
 
-        archivist = create(:archivist)
+        @archivist = create(:archivist)
 
         valid_params = {
-          archivist: archivist.login,
+          archivist: @archivist.login,
           works: [
             { external_author_name: api_fields[:external_author_name],
               external_author_email: api_fields[:external_author_email],
@@ -314,6 +319,8 @@ describe "API v2 WorksController - Create works", type: :request do
       after(:all) do
         @work&.destroy
         WebMock.reset!
+        @archivist.destroy
+        Role.find_by(name: "archivist").destroy
       end
 
       it "Title should be the default fallback title for imported works" do
@@ -364,10 +371,10 @@ describe "API v2 WorksController - Create works", type: :request do
       before(:all) do
         mock_external
 
-        archivist = create(:archivist)
+        @archivist = create(:archivist)
 
         valid_params = {
-          archivist: archivist.login,
+          archivist: @archivist.login,
           works: [
             { id: "123",
               title: api_fields[:title],
@@ -396,6 +403,8 @@ describe "API v2 WorksController - Create works", type: :request do
       after(:all) do
         @work&.destroy
         WebMock.reset!
+        @archivist.destroy
+        Role.find_by(name: "archivist").destroy
       end
 
       it "API should override content for Title" do
@@ -443,10 +452,10 @@ describe "API v2 WorksController - Create works", type: :request do
       before(:all) do
         mock_external
 
-        archivist = create(:archivist)
+        @archivist = create(:archivist)
 
         valid_params = {
-          archivist: archivist.login,
+          archivist: @archivist.login,
           works: [
             { external_author_name: api_fields[:external_author_name],
               external_author_email: api_fields[:external_author_email],
@@ -464,6 +473,8 @@ describe "API v2 WorksController - Create works", type: :request do
       after(:all) do
         @work&.destroy
         WebMock.reset!
+        @archivist.destroy
+        Role.find_by(name: "archivist").destroy
       end
 
       it "Title should be detected from the content" do

--- a/spec/controllers/api/v2/api_works_spec.rb
+++ b/spec/controllers/api/v2/api_works_spec.rb
@@ -143,15 +143,15 @@ describe "API v2 WorksController - Create works", type: :request do
     end
 
     describe "Provided API metadata should be used if present" do
-      before(:all) do
+      before do
         Language.create(short: "es", name: "Español")
 
         mock_external
 
-        @archivist = create(:archivist)
+        archivist = create(:archivist)
 
         valid_params = {
-          archivist: @archivist.login,
+          archivist: archivist.login,
           works: [
             { id: "123",
               title: api_fields[:title],
@@ -178,14 +178,9 @@ describe "API v2 WorksController - Create works", type: :request do
         @work = Work.find_by_url(parsed_body[:works].first[:original_url])
       end
 
-      after(:all) do
-        @work&.destroy
+      after do
         WebMock.reset!
-        Language.find_by(short: "es").destroy
-        @archivist.destroy
-        Role.find_by(name: "archivist").destroy
       end
-
 
       it "API should override content for Title" do
         expect(@work.title).to eq(api_fields[:title])
@@ -228,13 +223,13 @@ describe "API v2 WorksController - Create works", type: :request do
     end
 
     describe "Metadata should be extracted from content if no API metadata is supplied" do
-      before(:all) do
+      before do
         mock_external
 
-        @archivist = create(:archivist)
+        archivist = create(:archivist)
 
         valid_params = {
-          archivist: @archivist.login,
+          archivist: archivist.login,
           works: [
             { external_author_name: api_fields[:external_author_name],
               external_author_email: api_fields[:external_author_email],
@@ -250,11 +245,8 @@ describe "API v2 WorksController - Create works", type: :request do
         created_user&.destroy
       end
 
-      after(:all) do
-        @work&.destroy
+      after do
         WebMock.reset!
-        @archivist.destroy
-        Role.find_by(name: "archivist").destroy
       end
 
       it "Title should be detected from the content" do
@@ -296,13 +288,13 @@ describe "API v2 WorksController - Create works", type: :request do
     end
 
     describe "Imports should use fallback values or nil if no metadata is supplied" do
-      before(:all) do
+      before do
         mock_external
 
-        @archivist = create(:archivist)
+        archivist = create(:archivist)
 
         valid_params = {
-          archivist: @archivist.login,
+          archivist: archivist.login,
           works: [
             { external_author_name: api_fields[:external_author_name],
               external_author_email: api_fields[:external_author_email],
@@ -316,11 +308,8 @@ describe "API v2 WorksController - Create works", type: :request do
         @work = Work.find_by_url(parsed_body[:works].first[:original_url])
       end
 
-      after(:all) do
-        @work&.destroy
+      after do
         WebMock.reset!
-        @archivist.destroy
-        Role.find_by(name: "archivist").destroy
       end
 
       it "Title should be the default fallback title for imported works" do
@@ -368,13 +357,13 @@ describe "API v2 WorksController - Create works", type: :request do
     end
 
     describe "Provided API metadata should be used if present and tag detection is turned off" do
-      before(:all) do
+      before do
         mock_external
 
-        @archivist = create(:archivist)
+        archivist = create(:archivist)
 
         valid_params = {
-          archivist: @archivist.login,
+          archivist: archivist.login,
           works: [
             { id: "123",
               title: api_fields[:title],
@@ -400,11 +389,8 @@ describe "API v2 WorksController - Create works", type: :request do
         @work = Work.find_by_url(parsed_body[:works].first[:original_url])
       end
 
-      after(:all) do
-        @work&.destroy
+      after do
         WebMock.reset!
-        @archivist.destroy
-        Role.find_by(name: "archivist").destroy
       end
 
       it "API should override content for Title" do
@@ -449,13 +435,13 @@ describe "API v2 WorksController - Create works", type: :request do
     end
 
     describe "Some fields should be detected and others use fallback values or nil if no metadata is supplied and tag detection is turned off" do
-      before(:all) do
+      before do
         mock_external
 
-        @archivist = create(:archivist)
+        archivist = create(:archivist)
 
         valid_params = {
-          archivist: @archivist.login,
+          archivist: archivist.login,
           works: [
             { external_author_name: api_fields[:external_author_name],
               external_author_email: api_fields[:external_author_email],
@@ -470,11 +456,8 @@ describe "API v2 WorksController - Create works", type: :request do
         @work = Work.find_by_url(parsed_body[:works].first[:original_url])
       end
 
-      after(:all) do
-        @work&.destroy
+      after do
         WebMock.reset!
-        @archivist.destroy
-        Role.find_by(name: "archivist").destroy
       end
 
       it "Title should be detected from the content" do


### PR DESCRIPTION
# Pull Request Checklist

* [X] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [X] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [x] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [x] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [X] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-6512

## Purpose

Fixes that the tests in that `spec/controllers/api/v2/api_works_spec.rb` don't clean up all records created in `before(:all)`. This would leak records to other tests, see https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/BeforeAfterAll.

Before this PR, the following tests fail when run after api_works_spec.rb:
```
rspec ./spec/lib/tasks/after_tasks.rake_spec.rb:374 # rake After:remove_translation_admin_role remove translation admin role
rspec ./spec/helpers/works_helper_spec.rb:50 # WorksHelper#sorted_languages returns all languages sorted alphabetically
rspec ./spec/lib/tasks/work_tasks.rake_spec.rb:125 # rake work:reset_word_counts when there are multiple languages updates only works in the specified language
```

The first test failed due to the archivist role existing, the two other tests failed due to a language with the short "es" existing.

## Testing Instructions

Run the full RSpec test suite with `bundle exec rspec spec` or run `bundle exec rspec spec/controllers/api/v2/api_works_spec.rb spec/lib/tasks/after_tasks.rake_spec.rb spec/helpers/works_helper_spec.rb spec/lib/tasks/work_tasks.rake_spec.rb`. The CI does not reproduce/test this issue because the controller tests are run separately from the other tests.

## Credit

Bilka (he/him)