### PR TITLE
AO3-5995 Add boolean column named spam to comments table

### DIFF
--- a/db/migrate/20230418074141_add_spam_to_comments.rb
+++ b/db/migrate/20230418074141_add_spam_to_comments.rb
@@ -1,0 +1,49 @@
+class AddSpamToComments < ActiveRecord::Migration[6.0]
+  def up
+    if Rails.env.staging? || Rails.env.production?
+      database = Comment.connection.current_database
+
+      puts <<~PTOSC
+        Schema Change Command:
+
+        pt-online-schema-change D=#{database},t=comments \\
+          --alter "ADD COLUMN spam BOOLEAN NOT NULL DEFAULT 0" \\
+          --no-drop-old-table \\
+          -uroot --ask-pass --chunk-size=5k --max-flow-ctl 0 --pause-file /tmp/pauseme \\
+          --max-load Threads_running=15 --critical-load Threads_running=100 \\
+          --set-vars innodb_lock_wait_timeout=2 --alter-foreign-keys-method=auto \\
+          --execute
+
+        Table Deletion Command:
+
+        DROP TABLE IF EXISTS `#{database}`.`_comments_old`;
+      PTOSC
+    else
+      add_column :comments, :spam, :boolean, default: 0, null: false
+    end
+  end
+
+  def down
+    if Rails.env.staging? || Rails.env.production?
+      database = Comment.connection.current_database
+
+      puts <<~PTOSC
+        Schema Change Command:
+
+        pt-online-schema-change D=#{database},t=comments \\
+          --alter "DROP COLUMN spam" \\
+          --no-drop-old-table \\
+          -uroot --ask-pass --chunk-size=5k --max-flow-ctl 0 --pause-file /tmp/pauseme \\
+          --max-load Threads_running=15 --critical-load Threads_running=100 \\
+          --set-vars innodb_lock_wait_timeout=2 --alter-foreign-keys-method=auto \\
+          --execute
+
+        Table Deletion Command:
+
+        DROP TABLE IF EXISTS `#{database}`.`_comments_old`;
+      PTOSC
+    else
+      remove_column :comments, :spam
+    end
+  end
+end


### PR DESCRIPTION
# Pull Request Checklist

* [ ] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [ ] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [ ] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [ ] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [ ] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-5995
## Purpose

What does this PR do?

Adds a boolean column "spam" to the comments table using pt-online-schema-change in line with previous migrations that have changed this table.

## Testing Instructions

A database admin should migrate up, down, and back up. 


## References

Are there other relevant issues/pull requests/mailing list discussions?

## Credit

What name and pronouns should we use to credit you in the [Archive of Our Own's Release Notes](https://archiveofourown.org/admin_posts?tag=1)?

salt, they/them
