### PR TITLE
AO3-6514 Revert "AO3-2228 Add color picker for skin wizard"

### DIFF
--- a/app/views/skins/_wizard_form.html.erb
+++ b/app/views/skins/_wizard_form.html.erb
@@ -60,26 +60,38 @@
 
 <fieldset>
   <legend><%= ts("Colors") %></legend>
+  <p class="notes">
+    <%= ts('You may wish to refer to this <a href="https://www.w3schools.com/colors/colors_names.asp">handy list of colors</a>.').html_safe %>
+  </p>
   <dl>
     <dt>
       <%= f.label :background_color, ts('Background color') %> 
     </dt>
     <dd>
-      <%= f.color_field :background_color, value: @skin.background_color.presence || "#ffffff" %>
+      <%= f.text_field :background_color, "aria-describedby" => "background-color-field-notes" %>
+      <p class="footnote" id="background-color-field-notes">
+        <%= ts("Name or hex code. Default: <code>#fff</code>".html_safe) %>
+      </p>
     </dd>
 
     <dt>
       <%= f.label :foreground_color, ts('Text color') %>
     </dt>
     <dd>
-      <%= f.color_field :foreground_color, value: @skin.foreground_color.presence || "#2a2a2a" %>
+      <%= f.text_field :foreground_color, "aria-describedby" => "foreground-color-field-notes" %>
+      <p class="footnote" id="foreground-color-field-notes">
+        <%= ts("Name or hex code. Default: <code>#2a2a2a</code>".html_safe) %>
+      </p>
     </dd>
 
     <dt>
       <%= f.label :headercolor, ts('Header color') %> 
     </dt>
     <dd>
-      <%= f.color_field :headercolor, value: @skin.headercolor.presence || "#990000" %>
+      <%= f.text_field :headercolor, "aria-describedby" => "header-color-field-notes" %>
+      <p class="footnote" id="header-color-field-notes">
+        <%= ts("Name or hex code. Default: <code>#900</code>".html_safe) %>
+      </p>
     </dd>
 
     <dt>
@@ -87,7 +99,10 @@
       <%= link_to_help('skins-wizard-accent-color') %>
     </dt>
     <dd>
-      <%= f.color_field :accent_color, value: @skin.accent_color.presence || "#dddddd" %>
+      <%= f.text_field :accent_color, "aria-describedby" => "accent-color-field-notes" %>
+      <p class="footnote" id="accent-color-field-notes">
+        <%= ts("Name or hex code. Default: <code>#ddd</code>".html_safe) %>
+      </p>
     </dd>
   </dl>
   <%= hidden_field_tag 'wizard', true %>

--- a/public/help/skins-wizard-accent-color.html
+++ b/public/help/skins-wizard-accent-color.html
@@ -1,2 +1,2 @@
-﻿<p>The default is: <code>#dddddd</code></p>
+﻿<p>The default is: <code>#ddd</code></p>
 <p>Replace the gray used in numerous places throughout the Archive, including form backgrounds, the dropdown menus in the main navigation, and the "Fandoms" and "Recent works" sections of dashboard pages.</p>


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6514

## Purpose

Reverts otwcode/otwarchive#4366 to change the skin wizard color fields back to plain text fields.

## Testing Instructions

Refer to Jira.