### PR TITLE
AO3-6119 Remove automatically_approve_collections from preferences

### DIFF
--- a/db/migrate/20230429120200_remove_automatically_approve_collections.rb
+++ b/db/migrate/20230429120200_remove_automatically_approve_collections.rb
@@ -1,0 +1,43 @@
+class RemoveAutomaticallyApproveCollections < ActiveRecord::Migration[6.0]
+  def up
+    if Rails.env.staging? || Rails.env.production?
+      database = Preference.connection.current_database
+
+      puts <<~PTSOC
+        Schema Change Command:
+        pt-online-schema-change D=#{database},t=preferences \\
+          --alter "DROP COLUMN automatically_approve_collections" \\
+          --no-drop-old-table \\
+          -uroot --ask-pass --chunk-size=5k --max-flow-ctl 0 --pause-file /tmp/pauseme \\
+          --max-load Threads_running=15 --critical-load Threads_running=100 \\
+          --set-vars innodb_lock_wait_timeout=2 --alter-foreign-keys-method=auto \\
+          --execute
+        Table Deletion Command:
+        DROP TABLE IF EXISTS `#{database}`.`_preferences_old`;
+      PTSOC
+    else
+      remove_column :preferences, :automatically_approve_collections
+    end
+  end
+
+  def down
+    if Rails.env.staging? || Rails.env.production?
+      database = Preference.connection.current_database
+
+      puts <<~PTSOC
+        Schema Change Command:
+        pt-online-schema-change D=#{database},t=preferences \\
+          --alter "ADD COLUMN automatically_approve_collections BOOLEAN NOT NULL DEFAULT 0" \\
+          --no-drop-old-table \\
+          -uroot --ask-pass --chunk-size=5k --max-flow-ctl 0 --pause-file /tmp/pauseme \\
+          --max-load Threads_running=15 --critical-load Threads_running=100 \\
+          --set-vars innodb_lock_wait_timeout=2 --alter-foreign-keys-method=auto \\
+          --execute
+        Table Deletion Command:
+        DROP TABLE IF EXISTS `#{database}`.`_preferences_old`;
+      PTSOC
+    else
+      add_column :preferences, :automatically_approve_collections, :boolean, default: false, null: false
+    end
+  end
+end

--- a/db/migrate/20230429120200_remove_automatically_approve_collections.rb
+++ b/db/migrate/20230429120200_remove_automatically_approve_collections.rb
@@ -5,6 +5,7 @@ class RemoveAutomaticallyApproveCollections < ActiveRecord::Migration[6.0]
 
       puts <<~PTSOC
         Schema Change Command:
+        
         pt-online-schema-change D=#{database},t=preferences \\
           --alter "DROP COLUMN automatically_approve_collections" \\
           --no-drop-old-table \\
@@ -13,6 +14,7 @@ class RemoveAutomaticallyApproveCollections < ActiveRecord::Migration[6.0]
           --set-vars innodb_lock_wait_timeout=2 --alter-foreign-keys-method=auto \\
           --execute
         Table Deletion Command:
+        
         DROP TABLE IF EXISTS `#{database}`.`_preferences_old`;
       PTSOC
     else
@@ -26,6 +28,7 @@ class RemoveAutomaticallyApproveCollections < ActiveRecord::Migration[6.0]
 
       puts <<~PTSOC
         Schema Change Command:
+        
         pt-online-schema-change D=#{database},t=preferences \\
           --alter "ADD COLUMN automatically_approve_collections BOOLEAN NOT NULL DEFAULT 0" \\
           --no-drop-old-table \\
@@ -34,6 +37,7 @@ class RemoveAutomaticallyApproveCollections < ActiveRecord::Migration[6.0]
           --set-vars innodb_lock_wait_timeout=2 --alter-foreign-keys-method=auto \\
           --execute
         Table Deletion Command:
+        
         DROP TABLE IF EXISTS `#{database}`.`_preferences_old`;
       PTSOC
     else

--- a/db/migrate/20230429120200_remove_automatically_approve_collections.rb
+++ b/db/migrate/20230429120200_remove_automatically_approve_collections.rb
@@ -13,6 +13,7 @@ class RemoveAutomaticallyApproveCollections < ActiveRecord::Migration[6.0]
           --max-load Threads_running=15 --critical-load Threads_running=100 \\
           --set-vars innodb_lock_wait_timeout=2 --alter-foreign-keys-method=auto \\
           --execute
+          
         Table Deletion Command:
         
         DROP TABLE IF EXISTS `#{database}`.`_preferences_old`;
@@ -36,6 +37,7 @@ class RemoveAutomaticallyApproveCollections < ActiveRecord::Migration[6.0]
           --max-load Threads_running=15 --critical-load Threads_running=100 \\
           --set-vars innodb_lock_wait_timeout=2 --alter-foreign-keys-method=auto \\
           --execute
+          
         Table Deletion Command:
         
         DROP TABLE IF EXISTS `#{database}`.`_preferences_old`;

--- a/test/fixtures/preferences.yml
+++ b/test/fixtures/preferences.yml
@@ -24,7 +24,6 @@ preference_484751134:
   edit_emails_off: false
   minimize_search_engines: false
   hide_warnings: false
-  automatically_approve_collections: false
   disable_work_skins: false
 preference_484751112: 
   history_enabled: true
@@ -51,7 +50,6 @@ preference_484751112:
   edit_emails_off: false
   minimize_search_engines: false
   hide_warnings: false
-  automatically_approve_collections: false
   disable_work_skins: false
 preference_484751123: 
   history_enabled: true
@@ -78,7 +76,6 @@ preference_484751123:
   edit_emails_off: false
   minimize_search_engines: false
   hide_warnings: false
-  automatically_approve_collections: false
   disable_work_skins: false
 preference_484751124: 
   history_enabled: true
@@ -105,7 +102,6 @@ preference_484751124:
   edit_emails_off: false
   minimize_search_engines: false
   hide_warnings: false
-  automatically_approve_collections: false
   disable_work_skins: false
 preference_484751113: 
   history_enabled: true
@@ -132,7 +128,6 @@ preference_484751113:
   edit_emails_off: false
   minimize_search_engines: false
   hide_warnings: false
-  automatically_approve_collections: false
   disable_work_skins: false
 preference_484751135: 
   history_enabled: true
@@ -159,7 +154,6 @@ preference_484751135:
   edit_emails_off: false
   minimize_search_engines: false
   hide_warnings: false
-  automatically_approve_collections: false
   disable_work_skins: false
 preference_484751136: 
   history_enabled: true
@@ -186,7 +180,6 @@ preference_484751136:
   edit_emails_off: false
   minimize_search_engines: false
   hide_warnings: false
-  automatically_approve_collections: false
   disable_work_skins: false
 preference_484751114: 
   history_enabled: true
@@ -213,7 +206,6 @@ preference_484751114:
   edit_emails_off: false
   minimize_search_engines: false
   hide_warnings: false
-  automatically_approve_collections: false
   disable_work_skins: false
 preference_484751125: 
   history_enabled: true
@@ -240,7 +232,6 @@ preference_484751125:
   edit_emails_off: false
   minimize_search_engines: false
   hide_warnings: false
-  automatically_approve_collections: false
   disable_work_skins: false
 preference_484751126: 
   history_enabled: true
@@ -267,7 +258,6 @@ preference_484751126:
   edit_emails_off: false
   minimize_search_engines: false
   hide_warnings: false
-  automatically_approve_collections: false
   disable_work_skins: false
 preference_484751115: 
   history_enabled: true
@@ -294,7 +284,6 @@ preference_484751115:
   edit_emails_off: false
   minimize_search_engines: false
   hide_warnings: false
-  automatically_approve_collections: false
   disable_work_skins: false
 preference_78869998: 
   history_enabled: true
@@ -321,7 +310,6 @@ preference_78869998:
   edit_emails_off: false
   minimize_search_engines: false
   hide_warnings: false
-  automatically_approve_collections: false
   disable_work_skins: false
 preference_484751116: 
   history_enabled: true
@@ -348,7 +336,6 @@ preference_484751116:
   edit_emails_off: false
   minimize_search_engines: false
   hide_warnings: false
-  automatically_approve_collections: false
   disable_work_skins: false
 preference_484751127: 
   history_enabled: true
@@ -375,7 +362,6 @@ preference_484751127:
   edit_emails_off: false
   minimize_search_engines: false
   hide_warnings: false
-  automatically_approve_collections: false
   disable_work_skins: false
 preference_484751128: 
   history_enabled: true
@@ -402,7 +388,6 @@ preference_484751128:
   edit_emails_off: false
   minimize_search_engines: false
   hide_warnings: false
-  automatically_approve_collections: false
   disable_work_skins: false
 preference_484751117: 
   history_enabled: true
@@ -429,7 +414,6 @@ preference_484751117:
   edit_emails_off: false
   minimize_search_engines: false
   hide_warnings: false
-  automatically_approve_collections: false
   disable_work_skins: false
 preference_78869999: 
   history_enabled: true
@@ -456,7 +440,6 @@ preference_78869999:
   edit_emails_off: false
   minimize_search_engines: false
   hide_warnings: false
-  automatically_approve_collections: false
   disable_work_skins: false
 preference_484751107: 
   history_enabled: true
@@ -483,7 +466,6 @@ preference_484751107:
   edit_emails_off: false
   minimize_search_engines: false
   hide_warnings: true
-  automatically_approve_collections: false
   disable_work_skins: false
 preference_78870000: 
   history_enabled: true
@@ -510,7 +492,6 @@ preference_78870000:
   edit_emails_off: false
   minimize_search_engines: false
   hide_warnings: false
-  automatically_approve_collections: false
   disable_work_skins: false
 preference_484751118: 
   history_enabled: true
@@ -537,7 +518,6 @@ preference_484751118:
   edit_emails_off: false
   minimize_search_engines: false
   hide_warnings: false
-  automatically_approve_collections: false
   disable_work_skins: false
 preference_484751129: 
   history_enabled: true
@@ -564,7 +544,6 @@ preference_484751129:
   edit_emails_off: false
   minimize_search_engines: false
   hide_warnings: false
-  automatically_approve_collections: false
   disable_work_skins: false
 preference_484751130: 
   history_enabled: true
@@ -591,7 +570,6 @@ preference_484751130:
   edit_emails_off: false
   minimize_search_engines: false
   hide_warnings: false
-  automatically_approve_collections: false
   disable_work_skins: false
 preference_484751119: 
   history_enabled: true
@@ -618,7 +596,6 @@ preference_484751119:
   edit_emails_off: false
   minimize_search_engines: false
   hide_warnings: false
-  automatically_approve_collections: false
   disable_work_skins: false
 preference_484751108: 
   history_enabled: true
@@ -645,7 +622,6 @@ preference_484751108:
   edit_emails_off: false
   minimize_search_engines: false
   hide_warnings: false
-  automatically_approve_collections: false
   disable_work_skins: false
 preference_484751109: 
   history_enabled: true
@@ -672,7 +648,6 @@ preference_484751109:
   edit_emails_off: false
   minimize_search_engines: false
   hide_warnings: false
-  automatically_approve_collections: false
   disable_work_skins: false
 preference_484751120: 
   history_enabled: true
@@ -699,7 +674,6 @@ preference_484751120:
   edit_emails_off: false
   minimize_search_engines: false
   hide_warnings: false
-  automatically_approve_collections: false
   disable_work_skins: false
 preference_484751131: 
   history_enabled: true
@@ -726,7 +700,6 @@ preference_484751131:
   edit_emails_off: false
   minimize_search_engines: false
   hide_warnings: false
-  automatically_approve_collections: false
   disable_work_skins: false
 preference_484751132: 
   history_enabled: true
@@ -753,7 +726,6 @@ preference_484751132:
   edit_emails_off: false
   minimize_search_engines: false
   hide_warnings: false
-  automatically_approve_collections: false
   disable_work_skins: false
 preference_484751110: 
   history_enabled: true
@@ -780,7 +752,6 @@ preference_484751110:
   edit_emails_off: false
   minimize_search_engines: false
   hide_warnings: false
-  automatically_approve_collections: false
   disable_work_skins: false
 preference_484751122: 
   history_enabled: true
@@ -807,7 +778,6 @@ preference_484751122:
   edit_emails_off: false
   minimize_search_engines: false
   hide_warnings: false
-  automatically_approve_collections: false
   disable_work_skins: false
 preference_484751111: 
   history_enabled: true
@@ -834,7 +804,6 @@ preference_484751111:
   edit_emails_off: false
   minimize_search_engines: false
   hide_warnings: false
-  automatically_approve_collections: false
   disable_work_skins: false
 preference_484751133: 
   history_enabled: true
@@ -861,5 +830,4 @@ preference_484751133:
   edit_emails_off: false
   minimize_search_engines: false
   hide_warnings: false
-  automatically_approve_collections: false
   disable_work_skins: false


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [ ] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [x] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [x] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-6119

## Purpose

Remove the automatically_approve_collections column from the preferences table with a migration

## Testing Instructions


## References


## Credit

warlockmel (she/her)
