### PR TITLE
AO3-6314 Remove column dead from external_works table

### DIFF
--- a/db/migrate/20230430160300_remove_dead_column.rb
+++ b/db/migrate/20230430160300_remove_dead_column.rb
@@ -1,0 +1,5 @@
+class RemoveDeadColumn < ActiveRecord::Migration[6.0]
+  def change
+    remove_column :external_works, :dead, :boolean
+  end
+end

--- a/features/fixtures/external_works.yml
+++ b/features/fixtures/external_works.yml
@@ -4,7 +4,6 @@ first_ext:
   author: Zooey Glass
   updated_at: 2009-07-17 23:33:05 +00:00
   url: http://zooey-glass.dreamwidth.org/93177.html
-  dead: false
   summary: You've got to read between the years; you've got to write between the lines.
   hidden_by_admin: false
 second_ext:
@@ -13,7 +12,6 @@ second_ext:
   author: parenthetical
   updated_at: 2009-07-18 09:38:18 +00:00
   url: http://parenthetical.livejournal.com/63702.html
-  dead: false
   summary: |-
     Set following 2.04 - Children Shouldn't Play With Dead Things. Dean and Sam try to find a way to move on, but some things can't be outrun. Gen.
     <br />

--- a/test/fixtures/external_works.yml
+++ b/test/fixtures/external_works.yml
@@ -6,7 +6,6 @@ external_work_00001:
   updated_at: 2009-07-17 23:56:42 Z
   url: http://architeuthis.dreamwidth.org/954.html
   id: 1
-  dead: false
   summary: Bathtime fun with Dean and Castiel, war between Heaven and Hell style.
   hidden_by_admin: false
 external_work_00002: 
@@ -16,7 +15,6 @@ external_work_00002:
   updated_at: 2009-07-18 00:33:05 Z
   url: http://zooey-glass.dreamwidth.org/93177.html
   id: 2
-  dead: false
   summary: You've got to read between the years; you've got to write between the lines.
   hidden_by_admin: false
 external_work_00003: 
@@ -26,7 +24,6 @@ external_work_00003:
   updated_at: 2009-07-18 10:38:18 Z
   url: http://parenthetical.livejournal.com/63702.html
   id: 3
-  dead: false
   summary: |-
     Set following 2.04 - Children Shouldn't Play With Dead Things. Dean and Sam try to find a way to move on, but some things can't be outrun. Gen.
     <br />


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [ ] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [x] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [x] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-6314

## Purpose

Removes the "dead" column from the "external_works" table and removes its references in the fixtures. 
## Testing Instructions

Automated tests 

## References

Are there other relevant issues/pull requests/mailing list discussions?

## Credit

warlockmel (she/her)