### PR TITLE
AO3-5248 Change nonexistent user pages to 404

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -8,7 +8,7 @@ class UsersController < ApplicationController
   skip_before_action :store_location, only: [:end_first_login]
 
   def load_user
-    @user = User.find_by(login: params[:id])
+    @user = User.find_by!(login: params[:id])
     @check_ownership_of = @user
   end
 
@@ -19,10 +19,6 @@ class UsersController < ApplicationController
 
   # GET /users/1
   def show
-    if @user.blank?
-      raise ActiveRecord::RecordNotFound, "Couldn't find user named '#{params[:id]}'"
-    end
-
     @page_subtitle = @user.login
 
     visible = visible_items(current_user)

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -20,8 +20,7 @@ class UsersController < ApplicationController
   # GET /users/1
   def show
     if @user.blank?
-      flash[:error] = ts('Sorry, could not find this user.')
-      redirect_to(search_people_path) && return
+      raise ActiveRecord::RecordNotFound, "Couldn't find user named '#{params[:id]}'"
     end
 
     @page_subtitle = @user.login

--- a/features/other_b/errors.feature
+++ b/features/other_b/errors.feature
@@ -24,10 +24,3 @@ Some pages with non existent things raise errors
       And visiting "/tags/UnknownTag/works" should fail with a not found error
     When I am logged in as "wranglerette"
       And visiting "/tags/NonexistentTag/edit" should fail with a not found error
-
-  Scenario: Some pages with non existent things give flash warnings
-    Given the user "KnownUser" exists and is activated
-      And the following activated tag wrangler exists
-      | login          |
-      | wranglerette   |
-    Then visiting "/users/UnknownUser" should fail with "Sorry, could not find this user."

--- a/features/step_definitions/web_steps.rb
+++ b/features/step_definitions/web_steps.rb
@@ -111,11 +111,6 @@ Then /^visiting "([^"]*)" should fail with a not found error$/ do |path|
   }.to raise_error(ActiveRecord::RecordNotFound)
 end
 
-Then /^visiting "([^"]*)" should fail with "([^"]*)"$/ do |path, flash_error|
-  visit path
-  step %{I should see "#{flash_error}" within ".flash"}
-end
-
 Then /^(?:|I )should see JSON:$/ do |expected_json|
   require 'json'
   expected = JSON.pretty_generate(JSON.parse(expected_json))

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -51,9 +51,9 @@ describe UsersController do
     end
 
     context "with an invalid username" do
-    it "raises an error" do
-      expect do
-        get :show, params: { id: "nobody" }
+      it "raises an error" do
+        expect do
+          get :show, params: { id: "nobody" }
         end.to raise_error ActiveRecord::RecordNotFound
       end
     end

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -39,4 +39,23 @@ describe UsersController do
       end
     end
   end
+
+  describe "show" do
+    let(:user) { create(:user) }
+
+    context "with a valid username" do
+      it "renders the show template" do
+        get :show, params: { id: user }
+        expect(response).to render_template(:show)
+      end
+    end
+
+    context "with an invalid username" do
+    it "raises an error" do
+      expect do
+        get :show, params: { id: "nobody" }
+        end.to raise_error ActiveRecord::RecordNotFound
+      end
+    end
+  end
 end


### PR DESCRIPTION
# Pull Request Checklist

* [X] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [X] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [X] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [X] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [X] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-5248

## Purpose

With this PR, accessing the user page for a nonexistent user gives an error 404 instead of redirecting to the people search.

## Testing Instructions

See Jira issue.

## Credit

Bilka (he/him)
