### PR TITLE
AO3-6516 Replace "Chilling Effects" with "Lumen" on DMCA page

### DIFF
--- a/app/views/home/_dmca.html.erb
+++ b/app/views/home/_dmca.html.erb
@@ -36,7 +36,7 @@
     Once you have initiated a <acronym title="Digital Millennium Copyright Act">DMCA</acronym> takedown notice...
   </h3>
   <p>
-    If the <acronym title="Organization for Transformative Works">OTW</acronym> receives a valid and statutorily-compliant <acronym title="Digital Millennium Copyright Act">DMCA</acronym> takedown notice, the <acronym title="Organization for Transformative Works">OTW</acronym> will remove the content upon satisfactory review of the merits of the infringement claim. Once the content is removed, we will send the report to Chilling Effects and other third parties if appropriate. We will also take reasonable steps to notify the content uploader of the <acronym title="Digital Millennium Copyright Act">DMCA</acronym> notice. 
+    If the <acronym title="Organization for Transformative Works">OTW</acronym> receives a valid and statutorily-compliant <acronym title="Digital Millennium Copyright Act">DMCA</acronym> takedown notice, the <acronym title="Organization for Transformative Works">OTW</acronym> will remove the content upon satisfactory review of the merits of the infringement claim. Once the content is removed, we will send the report to Lumen and other third parties if appropriate. We will also take reasonable steps to notify the content uploader of the <acronym title="Digital Millennium Copyright Act">DMCA</acronym> notice.
   </p>
   <p>
     The content uploader may respond with a <acronym title="Digital Millennium Copyright Act">DMCA</acronym> counternotice. The counternotice operates much like the original notice, but works in the reverse. Please note that there is no statute of limitations for counternotices.
@@ -49,7 +49,7 @@
     If you are an uploader of content...
   </h3>
   <p>
-    If you are the uploader of content that has been subject to removal in response to a <acronym title="Digital Millennium Copyright Act">DMCA</acronym> takedown notice, we will make reasonable efforts to notify you of the action. In an effort to be transparent, we will also post the <acronym title="Digital Millennium Copyright Act">DMCA</acronym> takedown notice on Chilling Effects and elsewhere if appropriate.
+    If you are the uploader of content that has been subject to removal in response to a <acronym title="Digital Millennium Copyright Act">DMCA</acronym> takedown notice, we will make reasonable efforts to notify you of the action. In an effort to be transparent, we will also post the <acronym title="Digital Millennium Copyright Act">DMCA</acronym> takedown notice on Lumen and elsewhere if appropriate.
   </p>
   <p>
     If a contribution of yours was the subject of a <acronym title="Digital Millennium Copyright Act">DMCA</acronym> takedown and you believe that the contribution did not violate copyright laws, you may wish to file a counternotice. Please consider that filing a counternotice may lead to legal proceedings between you and the sender of the takedown notice to determine ownership and legality of the use of the material. You may wish to consult an attorney before filing a counternotice.
@@ -82,8 +82,8 @@
   </p>
   <ol>
     <li> <a href="http://www.dmlp.org/legal-guide/responding-dmca-takedown-notice-targeting-your-content">"Responding to a <acronym title="Digital Millennium Copyright Act">DMCA</acronym> Takedown Notice Targeting Your Content"</a> at Digital Media Law Project</li>
-    <li> <a href="https://www.lumendatabase.org/topics/14">Chilling Effects Clearinghouse FAQ</a></li>
-    <li> <a href="https://www.lumendatabase.org/topics/29#topic-faqs">Chilling Effects Clearinghouse DMCA Notices FAQ</a></li>
+    <li> <a href="https://www.lumendatabase.org/topics/14"Lumen FAQ</a></li>
+    <li> <a href="https://www.lumendatabase.org/topics/29#topic-faqs">Lumen DMCA Notices FAQ</a></li>
     <li> <a href="http://www.newmediarights.org/guide/legal/copyright/dmca/Sample_DMCA_CounterNotice_letter_when_claiming_fair_use_of_a_copyrighted_work">newmediarights.org</a></li>
   </ol>
   <p>

--- a/app/views/home/_dmca.html.erb
+++ b/app/views/home/_dmca.html.erb
@@ -82,7 +82,7 @@
   </p>
   <ol>
     <li> <a href="http://www.dmlp.org/legal-guide/responding-dmca-takedown-notice-targeting-your-content">"Responding to a <acronym title="Digital Millennium Copyright Act">DMCA</acronym> Takedown Notice Targeting Your Content"</a> at Digital Media Law Project</li>
-    <li> <a href="https://www.lumendatabase.org/topics/14"Lumen FAQ</a></li>
+    <li> <a href="https://www.lumendatabase.org/topics/14">Lumen FAQ</a></li>
     <li> <a href="https://www.lumendatabase.org/topics/29#topic-faqs">Lumen DMCA Notices FAQ</a></li>
     <li> <a href="http://www.newmediarights.org/guide/legal/copyright/dmca/Sample_DMCA_CounterNotice_letter_when_claiming_fair_use_of_a_copyrighted_work">newmediarights.org</a></li>
   </ol>


### PR DESCRIPTION
Replaces "Chilling Effects" with "Lumen" on DMCA page

# Pull Request Checklist

* [x] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [ ] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [x] Have you added the [Jira](https://otwarchive.atlassian.net) issue number as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [x] Do you have fewer than 5 pull requests already open? If not, please wait until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-6516 

## Purpose

Updates the copy in the DMCA policy.

## Testing Instructions

1) Visit https://archiveofourown.org/dmca
2) Verify references to "Chilling Effects" and "Chilling Effects Clearinghouse" have been changed to "Lumen"

## References

N/A

## Credit

paradoxe, they/them
