### PR TITLE
AO3-3867 Update link in invited to collection confirmation message

### DIFF
--- a/app/controllers/collection_items_controller.rb
+++ b/app/controllers/collection_items_controller.rb
@@ -134,7 +134,10 @@ class CollectionItemsController < ApplicationController
     unless invited_collections.empty?
       invited_collections.each do |needs_user_approval|
         flash[:notice] ||= ""
-        flash[:notice] = ts("This work has been <a href=\"#{collection_items_path(needs_user_approval)}?invited=true\">invited</a> to your collection (#{needs_user_approval.title}).").html_safe
+        flash[:notice] = t(".invited_to_collections_html",
+          invited_link: view_context.link_to(t(".invited"),
+            collection_items_path(needs_user_approval, status: :unreviewed_by_user)),
+          collection_title: needs_user_approval.title)
       end
     end
     unless unapproved_collections.empty?

--- a/app/controllers/collection_items_controller.rb
+++ b/app/controllers/collection_items_controller.rb
@@ -135,9 +135,9 @@ class CollectionItemsController < ApplicationController
       invited_collections.each do |needs_user_approval|
         flash[:notice] ||= ""
         flash[:notice] = t(".invited_to_collections_html",
-          invited_link: view_context.link_to(t(".invited"),
-            collection_items_path(needs_user_approval, status: :unreviewed_by_user)),
-          collection_title: needs_user_approval.title)
+                           invited_link: view_context.link_to(t(".invited"),
+                                         collection_items_path(needs_user_approval, status: :unreviewed_by_user)),
+                           collection_title: needs_user_approval.title)
       end
     end
     unless unapproved_collections.empty?

--- a/config/locales/controllers/en.yml
+++ b/config/locales/controllers/en.yml
@@ -19,6 +19,10 @@ en:
       multifandom: Multifandom
       unrevealed: Mystery Work
       unspecified_fandom: No fandom specified
+  collection_items:
+    create:
+      invited: invited
+      invited_to_collections_html: This work has been %{invited_link} to your collection (%{collection_title}).
   comments:
     check_blocked:
       parent: Sorry, you have been blocked by one or more of this work's creators.


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-3867

## Purpose

Updates the "invited" link in the confirmation message to point to the page the work is actually on (the one for items awaiting user approval).

## Testing Instructions

Invite someone else's work to your collection and follow the "invited" link in the confirmation message.