### PR TITLE
AO3-6492 Tweak abuse report form and email

### DIFF
--- a/app/views/abuse_reports/new.html.erb
+++ b/app/views/abuse_reports/new.html.erb
@@ -115,7 +115,7 @@
       <dd class="required">
         <p id="comment-field-description">
           <%= t(".form.comment.description_html",
-                tos_link: (link_to t(".form.comment.tos"), tos_path),
+                tos_link: (link_to t(".form.comment.tos"), tos_path(anchor: "content")),
                 include_link: (link_to t(".form.comment.include"), anchor: "reporthow")) %>
         </p>
         <%= f.text_area :comment, "aria-describedby" => "comment-field-description" %>

--- a/app/views/user_mailer/abuse_report.html.erb
+++ b/app/views/user_mailer/abuse_report.html.erb
@@ -21,6 +21,7 @@
 
   <p>
     <%= style_work_metadata_label(t(".copy.summary")) %>
+    <% TODO: Remove to_plain_text when AO3-6519 is fixed. %>
     <%= to_plain_text(raw @summary) %>
   </p>
 

--- a/app/views/user_mailer/abuse_report.html.erb
+++ b/app/views/user_mailer/abuse_report.html.erb
@@ -21,7 +21,7 @@
 
   <p>
     <%= style_work_metadata_label(t(".copy.summary")) %>
-    <% TODO: Remove to_plain_text when AO3-6519 is fixed. %>
+    <% # TODO: Remove to_plain_text when AO3-6519 is fixed. %>
     <%= to_plain_text(raw @summary) %>
   </p>
 

--- a/app/views/user_mailer/abuse_report.html.erb
+++ b/app/views/user_mailer/abuse_report.html.erb
@@ -21,7 +21,7 @@
 
   <p>
     <%= style_work_metadata_label(t(".copy.summary")) %>
-    <%= raw @summary %>
+    <%= to_plain_text(raw @summary) %>
   </p>
 
   <p><%= style_work_metadata_label(t(".copy.comment")) %></p>

--- a/app/views/user_mailer/abuse_report.text.erb
+++ b/app/views/user_mailer/abuse_report.text.erb
@@ -1,5 +1,5 @@
 <% content_for :message do %>
-<% if @username %>
+<% if @username.present? %>
 <%= t("mailer.general.greeting.informal.addressed", name: @username) %>
 <% else %>
 <%= t("mailer.general.greeting.informal.unaddressed") %>

--- a/config/locales/mailers/en.yml
+++ b/config/locales/mailers/en.yml
@@ -84,7 +84,7 @@ en:
     abuse_report:
       copy:
         comment: Description of the content or issue
-        intro: "Here is a copy of your report for your reference:"
+        intro: 'Here is a copy of your report for your reference:'
         summary: Terms of Service violation
         url: URL of the reported page
       report_received: The Policy & Abuse team has received your report, and our volunteers will investigate as soon as they can. Because our team is small and we receive thousands of reports each month, it may take some time for us to get to your report.

--- a/config/locales/mailers/en.yml
+++ b/config/locales/mailers/en.yml
@@ -84,7 +84,7 @@ en:
     abuse_report:
       copy:
         comment: Description of the content or issue
-        intro: Here is a copy of your report for your reference
+        intro: "Here is a copy of your report for your reference:"
         summary: Terms of Service violation
         url: URL of the reported page
       report_received: The Policy & Abuse team has received your report, and our volunteers will investigate as soon as they can. Because our team is small and we receive thousands of reports each month, it may take some time for us to get to your report.

--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -8,7 +8,7 @@ en:
       form:
         comment:
           description_html: Explain what about this content violates the %{tos_link}. Please be as specific as possible and %{include_link}. All information provided will remain confidential.
-          error: Please describe your concern.
+          error: Please describe what you are reporting and why you are reporting it.
           include: include all relevant links and other information in your report
           label: Description of the content you are reporting (required)
           tos: AO3 Terms of Service
@@ -31,7 +31,7 @@ en:
           active: Submit
         summary:
           description: For example, "harassment", "not a fanwork", "commercial activities", etc.
-          error: Please enter a brief summary of your message
+          error: Please enter a subject line for your report.
           label: Brief summary of Terms of Service violation (required)
       heading:
         page_title: Policy Questions & Abuse Reports

--- a/features/other_a/abuse_report.feature
+++ b/features/other_a/abuse_report.feature
@@ -53,7 +53,7 @@ Feature: Filing an abuse report
     And I fill in "Your email (required)" with ""
     And I select "Deutsch" from "abuse_report_language"
     And I press "Submit"
-    And I should see "We cannot contact you if the email address you provide is invalid."
+    And I should see "Email should look like an email address."
     And "Deutsch" should be selected within "Select language (required)"
   Then I fill in "Your email (required)" with "valid@archiveofourown.org"
     And I press "Submit"


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6492

## Purpose

* Update the live validation errors on the form.
* Fix a link on the form.
* Revert a change to a test.
* Format the summary as plain text in the HTML email to avoid unwanted paragraph tags until [AO3-6519](https://otwarchive.atlassian.net/browse/AO3-6519) can be fixed.
* Make sure proper greeting appears in text email when no name is entered for the report.

## Testing Instructions

Refer to Jira.


[AO3-6519]: https://otwarchive.atlassian.net/browse/AO3-6519?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ