### PR TITLE
AO3-2064 Cannot make a synonym tag into a canonical in one step

### DIFF
--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -255,7 +255,7 @@ class TagsController < ApplicationController
       @tag.attributes = tag_params
     end
 
-    @tag.syn_string = syn_string if @tag.errors.empty? && @tag.save
+    @tag.syn_string = syn_string
 
     if @tag.errors.empty? && @tag.save
       flash[:notice] = ts('Tag was updated.')

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1005,10 +1005,9 @@ class Tag < ApplicationRecord
   before_save :save_new_merger
   def save_new_merger
     # If there is a newly created merger tag, save it to database
-    if self.new_merger&.save
-      # And set up its relationship with the current tag
-      self.merger_id = self.new_merger.id
-    end
+    return unless self.new_merger&.save
+    # And set up its relationship with the current tag
+    self.merger_id = self.new_merger.id
   end
 
   def merger_string=(tag_string)

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1004,7 +1004,7 @@ class Tag < ApplicationRecord
 
   before_save :save_new_merger
   def save_new_merger
-    unless self.new_merger return
+    return unless self.new_merger
     
     # If there is a newly created merger tag, save it to database
     if self.new_merger.save

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1006,6 +1006,7 @@ class Tag < ApplicationRecord
   def save_new_merger
     # If there is a newly created merger tag, save it to database
     return unless self.new_merger&.save
+    
     # And set up its relationship with the current tag
     self.merger_id = self.new_merger.id
   end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -958,7 +958,7 @@ class Tag < ApplicationRecord
   # NOTE for potential confusion
   # "merger" is the canonical tag of which this one will be a synonym
   # "mergers" are the tags which are (currently) synonyms of THIS one
-  attribute :new_merger, default: false
+  attribute :new_merger, default: nil
 
   def syn_string=(tag_string)
     # If the tag_string is blank, our tag should be given no merger
@@ -1004,10 +1004,8 @@ class Tag < ApplicationRecord
 
   before_save :save_new_merger
   def save_new_merger
-    return unless self.new_merger
-    
     # If there is a newly created merger tag, save it to database
-    if self.new_merger.save
+    if self.new_merger&.save
       # And set up its relationship with the current tag
       self.merger_id = self.new_merger.id
     end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -958,7 +958,7 @@ class Tag < ApplicationRecord
   # NOTE for potential confusion
   # "merger" is the canonical tag of which this one will be a synonym
   # "mergers" are the tags which are (currently) synonyms of THIS one
-  attribute :new_merger, :default => false
+  attribute :new_merger, default: false
 
   def syn_string=(tag_string)
     # If the tag_string is blank, our tag should be given no merger
@@ -1004,8 +1004,10 @@ class Tag < ApplicationRecord
 
   before_save :save_new_merger
   def save_new_merger
+    unless self.new_merger return
+    
     # If there is a newly created merger tag, save it to database
-    if self.new_merger && self.new_merger.save
+    if self.new_merger.save
       # And set up its relationship with the current tag
       self.merger_id = self.new_merger.id
     end

--- a/config/locales/models/en.yml
+++ b/config/locales/models/en.yml
@@ -74,7 +74,7 @@ en:
         abuse_report:
           attributes:
             url:
-              not_on_archive: "does not appear to be on this site."
+              not_on_archive: does not appear to be on this site.
         block:
           attributes:
             blocked:


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [ ] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [x] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [x] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-2064

## Purpose

Refactor `models/tag.rb syn_string=` and `tags_controller.rb update` such that all validations happen before anything is saved to the database, resolving the order-of-execution problem that prevented synonym tags from being converted to a canonical one in one query.

## Testing Instructions

- Check that the tag can be converted from a synonym to a canonical tag in one step
- Check that new tags can still be created by adding a new tag name to the "Synonym of" field in the tag edit page
- Check other tag synonym functionalities still work

## Credit

EchoEkhi
