### PR TITLE
AO3-5499 Remove send_activation code from routes and user policy

### DIFF
--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -48,6 +48,5 @@ class UserPolicy < ApplicationPolicy
   alias destroy_user_creations? can_destroy_spam_creations?
 
   alias troubleshoot? can_manage_users?
-  alias send_activation? can_manage_users?
   alias activate? can_manage_users?
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -199,7 +199,6 @@ Otwarchive::Application.routes.draw do
         get :confirm_delete_user_creations
         post :destroy_user_creations
         post :activate
-        post :send_activation
         get :check_user
       end
       collection do


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5499

## Purpose

Removes send_activation code from user policy and from routes because we removed the `send_activation` action in #4469.
