### PR TITLE
AO3-5048 Prevent collection blurbs caching stale usernames/pseuds

### DIFF
--- a/app/views/collections/_collection_blurb.html.erb
+++ b/app/views/collections/_collection_blurb.html.erb
@@ -2,7 +2,7 @@
 <li class="<% if collection.user_is_owner?(current_user) %>own <% end %>collection picture blurb group" role="article">
   <% logged_in = (logged_in_as_admin? || logged_in?) ? "logged-in" : "logged-out" %>
   <% # remember to update collection_sweeper if you change this key %>
-  <% cache("collection-blurb-#{logged_in}-#{collection.id}-v3", skip_digest: true) do %>
+  <% cache("collection-blurb-#{logged_in}-#{collection.id}-v3", expires_in: ArchiveConfig.MINUTES_UNTIL_COLLECTION_BLURBS_EXPIRE.minutes, skip_digest: true) do %>
     <div class="header module group">
       <h4 class="heading">
         <%= link_to collection.title, collection_path(collection) %>

--- a/config/config.yml
+++ b/config/config.yml
@@ -455,6 +455,9 @@ SECONDS_UNTIL_COMMENT_COUNTS_EXPIRE: 3600
 # bookmarks, # of fandoms):
 SECONDS_UNTIL_COLLECTION_COUNTS_EXPIRE: 300
 
+# Cache durations for work and bookmark searches (in minutes)
+MINUTES_UNTIL_COLLECTION_BLURBS_EXPIRE: 120
+
 # Job size used for the HitCountUpdateJob class:
 HIT_COUNT_JOB_SIZE: 1000
 

--- a/features/other_a/pseud_delete.feature
+++ b/features/other_a/pseud_delete.feature
@@ -152,3 +152,53 @@ Feature: Delete pseud.
       And I should see "original_pseud" within ".creatorships"
       And I should see "Co-Creator Requests (1)"
       And I should not see "other_pseud" within ".creatorships"
+
+  Scenario: Collections reflect pseud deletion of the owner after the cache expires
+
+    When I am logged in as "original_pseud"
+      And I add the pseud "other_pseud"
+      And I set up the collection "My Collection Thing"
+      And I select "other_pseud" from "Owner pseud(s)"
+      And I unselect "original_pseud" from "Owner pseud(s)"
+      And I press "Submit"
+      And I go to the collections page
+    Then I should see "My Collection Thing"
+      And I should see "other_pseud (original_pseud)" within "#main"
+
+    When I delete the pseud "other_pseud"
+      And I go to the collections page
+    Then I should see "My Collection Thing"
+      And I should see "other_pseud (original_pseud)" within "#main"
+    When the collection blurb cache has expired
+      And I go to the collections page
+    Then I should see "My Collection Thing"
+      And I should see "original_pseud" within "#main"
+      And I should not see "other_pseud" within "#main"
+
+
+  Scenario: Collections reflect pseud deletion of moderators after the cache expires
+
+    Given "myself" has the pseud "other_pseud"
+    When I have the collection "My Collection Thing"
+      And I am logged in as the owner of "My Collection Thing"
+      And I am on the "My Collection Thing" participants page
+      And I fill in "participants_to_invite" with "other_pseud (myself)"
+      And I press "Submit"
+    Then I should see "New members invited: other_pseud (myself)"
+    When I select "Moderator" from "myself_role"
+      And I submit with the 5th button
+    Then I should see "Updated other_pseud."
+    When I go to the collections page
+    Then I should see "My Collection Thing"
+      And I should see "other_pseud (myself)" within "#main"
+
+    When I am logged in as "myself"
+      And I delete the pseud "other_pseud"
+      And I go to the collections page
+    Then I should see "My Collection Thing"
+      And I should see "other_pseud (myself)" within "#main"
+    When the collection blurb cache has expired
+      And I go to the collections page
+    Then I should see "My Collection Thing"
+      And I should not see "other_pseud (myself)" within "#main"
+      And I should see "myself" within "#main"

--- a/features/other_a/pseuds.feature
+++ b/features/other_a/pseuds.feature
@@ -134,3 +134,52 @@ Scenario: Comments reflect pseud changes immediately
     And I view the work "Interesting" with comments
   Then I should see "after (myself)" within ".comment h4.byline"
     And I should not see "before (myself)"
+
+Scenario: Collections reflect pseud changes of the owner after the cache expires
+
+  When I am logged in as "myself"
+    And I add the pseud "before"
+    And I set up the collection "My Collection Thing"
+    And I select "before" from "Owner pseud(s)"
+    And I unselect "myself" from "Owner pseud(s)"
+    And I press "Submit"
+    And I go to the collections page
+  Then I should see "My Collection Thing"
+    And I should see "before (myself)" within "#main"
+
+  When I change the pseud "before" to "after"
+    And I go to the collections page
+  Then I should see "My Collection Thing"
+    And I should see "before (myself)" within "#main"
+  When the collection blurb cache has expired
+    And I go to the collections page
+  Then I should see "My Collection Thing"
+    And I should see "after (myself)" within "#main"
+    And I should not see "before (myself)" within "#main"
+
+Scenario: Collections reflect pseud changes of moderators after the cache expires
+
+  Given "myself" has the pseud "before"
+  When I have the collection "My Collection Thing"
+    And I am logged in as the owner of "My Collection Thing"
+    And I am on the "My Collection Thing" participants page
+    And I fill in "participants_to_invite" with "before (myself)"
+    And I press "Submit"
+  Then I should see "New members invited: before (myself)"
+  When I select "Moderator" from "myself_role"
+    And I submit with the 3rd button
+  Then I should see "Updated before."
+  When I go to the collections page
+  Then I should see "My Collection Thing"
+    And I should see "before (myself)" within "#main"
+
+  When I am logged in as "myself"
+    And I change the pseud "before" to "after"
+    And I go to the collections page
+  Then I should see "My Collection Thing"
+    And I should see "before (myself)" within "#main"
+  When the collection blurb cache has expired
+    And I go to the collections page
+  Then I should see "My Collection Thing"
+    And I should see "after (myself)" within "#main"
+    And I should not see "before (myself)" within "#main"

--- a/features/step_definitions/collection_steps.rb
+++ b/features/step_definitions/collection_steps.rb
@@ -62,6 +62,10 @@ When "the collection counts have expired" do
   step "it is currently #{ArchiveConfig.SECONDS_UNTIL_COLLECTION_COUNTS_EXPIRE} seconds from now"
 end
 
+When "the collection blurb cache has expired" do
+  step "it is currently #{ArchiveConfig.MINUTES_UNTIL_COLLECTION_BLURBS_EXPIRE} minutes from now"
+end
+
 Given /^mod1 lives in Alaska$/ do
   step %{I am logged in as "mod1"}
   step %{I go to mod1 preferences page}

--- a/features/users/user_delete.feature
+++ b/features/users/user_delete.feature
@@ -73,9 +73,8 @@ Scenario: Delete a user with a collection
     And a user account should not exist for "moderator"
   When I go to the collections page
   Then I should see "fake"
-    # TODO: And a caching bug is fixed...
-    # And I should see "orphan_account"
-    # And I should not see "moderator"
+    And I should see "orphan_account"
+    And I should not see "moderator"
 
 Scenario: Delete a user who has coauthored a work
   Given  the following activated users exist

--- a/features/users/user_rename.feature
+++ b/features/users/user_rename.feature
@@ -147,3 +147,37 @@ Feature:
       And I view the work "Interesting" with comments
     Then I should see "after" within ".comment h4.byline"
       And I should not see "mine (before)"
+
+  Scenario: Collections reflect username changes of the owner after the cache expires
+    When I am logged in as "before" with password "password"
+      And I create the collection "My Collection Thing"
+      And I go to the collections page
+    Then I should see "My Collection Thing"
+      And I should see "before" within "#main"
+    When I change my username to "after"
+      And I go to the collections page
+    Then I should see "My Collection Thing"
+      And I should see "before" within "#main"
+    When the collection blurb cache has expired
+      And I go to the collections page
+    Then I should see "My Collection Thing"
+      And I should see "after" within "#main"
+      And I should not see "before" within "#main"
+
+  Scenario: Collections reflect username changes of moderators after the cache expires
+    Given I am logged in as "mod1"
+      And I create the collection "My Collection Thing"
+      And I have added a co-moderator "before" to collection "My Collection Thing"
+    When I go to the collections page
+    Then I should see "My Collection Thing"
+      And I should see "before" within "#main"
+    When I am logged in as "before" with password "password"
+      And I change my username to "after"
+      And I go to the collections page
+    Then I should see "My Collection Thing"
+      And I should see "before" within "#main"
+    When the collection blurb cache has expired
+      And I go to the collections page
+    Then I should see "My Collection Thing"
+      And I should see "after" within "#main"
+      And I should not see "before" within "#main"


### PR DESCRIPTION
# Pull Request Checklist

* [X] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [X] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [X] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [X] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [X] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-5048

## Purpose

Adds configurable time base expiry to the collection blurbs to prevent caching stale usernames/pseuds forever.

## Testing Instructions

See Jira.

## References

Based on #4264 another option would be "(c) directly expire the fragment when we need it to expire" via the CollectionSweeper. However internally (c) was described as the last resort. The other two options don't apply to the kind of cache key that collection blurbs use/it's not feasible to include all moderators in the key.

## Credit

Bilka (he/him)