### PR TITLE
AO3-5499 List roles in user admin page meta

### DIFF
--- a/app/views/admin/admin_users/show.html.erb
+++ b/app/views/admin/admin_users/show.html.erb
@@ -33,6 +33,8 @@
       <dd><%= @user.email %></dd>
       <dt><%= t(".info.invitation") %></dt>
       <dd><%= @user.invitation ? link_to(@user.invitation.id, invitation_path(@user.invitation.id)) : t(".info.no_invitation") %></dd>
+      <dt><%= t(".info.role", count: @user.roles.size) %></dt>
+      <dd><%= @user.roles.any? ? @user.roles.map { |role| t("activerecord.attributes.role.#{role.name}") }.to_sentence : t(".info.no_role") %></dd>
     </dl>
   </div>
 

--- a/config/locales/models/en.yml
+++ b/config/locales/models/en.yml
@@ -52,6 +52,14 @@ en:
         name_with_colon:
           one: 'Relationship:'
           other: 'Relationships:'
+      role:
+        archivist: Archivist
+        no_resets: No Resets
+        official: Official
+        opendoors: Open Doors
+        protected_user: Protected User
+        tag_wrangler: Tag Wrangler
+        translator: Translator
       series/creatorships:
         base: 'Invalid creator:'
         pseud_id: Pseud

--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -121,6 +121,10 @@ en:
           heading: User Information
           invitation: 'Invitation:'
           no_invitation: Created without invitation
+          no_role: No roles
+          role:
+            one: 'Role:'
+            other: 'Roles:'
         navigation:
           activate: Activate
           invitations:

--- a/features/admins/users/admin_manage_users.feature
+++ b/features/admins/users/admin_manage_users.feature
@@ -32,7 +32,8 @@ Feature: Admin Actions to manage users
     Then I should see "User was successfully updated"
       And the "user_roles_1" checkbox should be checked
     When I follow "Details"
-    Then I should see "Role Added: tag_wrangler"
+    Then I should see "Role: Tag Wrangler" within ".meta"
+      And I should see "Role Added: tag_wrangler" within "#user_history"
       And I should see "Change made by testadmin-superadmin"
     When I follow "Manage Roles"
       And I uncheck "user_roles_1"
@@ -40,7 +41,8 @@ Feature: Admin Actions to manage users
     Then I should see "User was successfully updated"
       And the "user_roles_1" checkbox should not be checked
     When I follow "Details"
-    Then I should see "Role Removed: tag_wrangler"
+    Then I should see "Roles: No roles" within ".meta"
+    And I should see "Role Removed: tag_wrangler" within "#user_history"
 
   Scenario: Troubleshooting a user displays a message
     Given the user "mrparis" exists and is activated


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5499

## Purpose

Lists a user's roles on the user admin page.

## Testing Instructions

Modify a user's roles and ensure the list on the user's admin page updates as expected.