### PR TITLE
AO3-5499 Correct class name on user admin page note

### DIFF
--- a/app/views/admin/admin_users/show.html.erb
+++ b/app/views/admin/admin_users/show.html.erb
@@ -25,7 +25,7 @@
   <!--/subnav-->
 
   <!--main content-->
-  <p class="note"><%= t(".note") %></p>
+  <p class="notes"><%= t(".note") %></p>
   <h3 class="heading"><%= t(".info.heading") %></h3>
   <div class="wrapper">
     <dl class="user meta group">


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5499

## Purpose

Changes the `note` class to `notes` so it properly clears the buttons. At some point I need to do this to a whole bunch of places. 🙃 

## Testing Instructions

Go to the user admin page and shrink the width of your browser window and ensure the rest doesn't partially bunch up to the left of the buttons.

