### PR TITLE
Updated Harry Potter references from search help to Sam Wilson

### DIFF
--- a/public/help/bookmark-search-text-help.html
+++ b/public/help/bookmark-search-text-help.html
@@ -8,7 +8,7 @@
   <dt>*: any characters </dt>
   <dd><kbd>book*</kbd> will find <samp>book</samp> and <samp>books</samp> and <samp>booking</samp>.</dd>
   <dt>space: a space acts like AND </dt>
-  <dd><kbd>Sam Wilson</kbd> will find <samp>Sam Wilson</samp> and <samp>Sam Thomas Wilson</samp> but not <spam>Sam</samp>.</dd>
+  <dd><kbd>Sam Wilson</kbd> will find <samp>Sam Wilson</samp> and <samp>Sam Thomas Wilson</samp> but not <samp>Sam</samp>.</dd>
   <dt>||: OR (not exclusive) </dt>
   <dd><kbd>Sam || Wilson</kbd> will find <samp>Sam</samp>, <samp>Sam Wilson</samp>, and <samp>Wilson</samp>.</dd>
   <dt>"": words in exact sequence </dt>

--- a/public/help/bookmark-search-text-help.html
+++ b/public/help/bookmark-search-text-help.html
@@ -8,11 +8,11 @@
   <dt>*: any characters </dt>
   <dd><kbd>book*</kbd> will find <samp>book</samp> and <samp>books</samp> and <samp>booking</samp>.</dd>
   <dt>space: a space acts like AND </dt>
-  <dd><kbd>Harry Potter</kbd> will find <samp>Harry Potter</samp> and <samp>Harry James Potter</samp> but not <spam>Harry</samp>.</dd>
+  <dd><kbd>Sam Wilson</kbd> will find <samp>Sam Wilson</samp> and <samp>Sam Thomas Wilson</samp> but not <spam>Sam</samp>.</dd>
   <dt>||: OR (not exclusive) </dt>
-  <dd><kbd>Harry || Potter</kbd> will find <samp>Harry</samp>, <samp>Harry Potter</samp>, and <samp>Potter</samp>.</dd>
+  <dd><kbd>Sam || Wilson</kbd> will find <samp>Sam</samp>, <samp>Sam Wilson</samp>, and <samp>Wilson</samp>.</dd>
   <dt>"": words in exact sequence </dt>
-  <dd><kbd>"Harry Lockhart"</kbd> will find <samp>Harry Lockhart</samp> but not <samp>Harry Potter/Gilderoy Lockhart</samp>.</dd>
+  <dd><kbd>"Sam Barnes"</kbd> will find <samp>Sam Barnes</samp> but not <samp>James "Bucky" Barnes/Sam Wilson</samp>.</dd>
   <dt>-: NOT </dt>
-  <dd><kbd>Harry -Lockhart</kbd> will find <samp>Harry Potter</samp> but not <samp>Harry Lockhart</samp> or <samp>Gilderoy Lockhart/Harry Potter</samp>.</dd>
+  <dd><kbd>Sam -Barnes</kbd> will find <samp>Sam Wilson</samp> but not <samp>Sam Barnes</samp> or <samp>James "Bucky" Barnes/Sam Wilson</samp>.</dd>
 </dl>

--- a/public/help/tag-search-text-help.html
+++ b/public/help/tag-search-text-help.html
@@ -13,31 +13,31 @@
     space: a space acts like AND
   </dt>
   <dd>
-    <kbd>Harry Potter</kbd> will find <samp>Harry Potter</samp> and <samp>Harry
-    James Potter</samp> but not <samp>Harry</samp>.
+    <kbd>Sam Wilson</kbd> will find <samp>Sam Wilson</samp> and <samp>Sam
+    Thomas Wilson</samp> but not <samp>Sam</samp>.
   </dd>
 
   <dt>
     ||: OR (not exclusive)
   </dt>
   <dd>
-    <kbd>Harry || Potter</kbd> will find <samp>Harry</samp>, <samp>Harry
-    Potter</samp>, and <samp>Potter</samp>.
+    <kbd>Sam || Wilson</kbd> will find <samp>Sam</samp>, <samp>Sam
+    Wilson</samp>, and <samp>Wilson</samp>.
   </dd>
 
   <dt>
     ": words in exact sequence
   </dt>
   <dd>
-    <kbd>"Harry Lockhart"</kbd> will find <samp>"Harry Lockhart"</samp> but not
-    <samp>Harry Potter/Gilderoy Lockhart</samp>.
+    <kbd>"Sam Barnes"</kbd> will find <samp>Sam Barnes</samp> but not
+    <samp>James "Bucky" Barnes/Sam Wilson</samp>.
   </dd>
 
   <dt>
     NOT: NOT
   </dt>
   <dd>
-    <kbd>Harry NOT Lockhart</kbd> will find <samp>Harry Potter</samp> but not
-    <samp>Harry Lockhart</samp> or <samp>Gilderoy Lockhart/Harry Potter</samp>.
+    <kbd>Sam NOT Barnes</kbd> will find <samp>Sam Wilson</samp> but not
+    <samp>Sam Barnes</samp> or <samp>James "Bucky" Barnes/Sam Wilson</samp>.
   </dd>
 </dl>

--- a/public/help/work-search-text-help.html
+++ b/public/help/work-search-text-help.html
@@ -9,19 +9,19 @@
   <dd><kbd>book*</kbd> will find <samp>book</samp> and <samp>books</samp> and <samp>booking</samp>.</dd>
   
   <dt>space: acts like AND for search terms in the same field of the work </dt>
-  <dd><kbd>Harry Potter</kbd> will find <samp>Harry Potter</samp> and <samp>Harry James Potter</samp> in any field, but it won't find works by a creator named <samp>Harry</samp> with the character tag <samp>Sherman Potter</samp>.</dd>
+  <dd><kbd>Sam Wilson</kbd> will find <samp>Sam Wilson</samp> and <samp>Sam Thomas Wilson</samp> in any field, but it won't find works by a creator named <samp>Sam</samp> with the character tag <samp>Sherman Wilson</samp>.</dd>
 
   <dt>AND: searches for works which have both terms in any field </dt>
-  <dd><kbd>Harry AND Potter</kbd> will find works by a creator named <samp>Harry</samp> with the character tag <samp>Sherman Potter</samp>.</dd>
+  <dd><kbd>Sam AND Wilson</kbd> will find works by a creator named <samp>Sam</samp> with the character tag <samp>Sherman Wilson</samp>.</dd>
   
   <dt>||: OR (not exclusive) </dt>
-  <dd><kbd>Harry || Potter</kbd> will find <samp>Harry</samp>, <samp>Harry Potter</samp>, and <samp>Potter</samp>.</dd>
+  <dd><kbd>Sam || Wilson</kbd> will find <samp>Sam</samp>, <samp>Sam Wilson</samp>, and <samp>Wilson</samp>.</dd>
   
   <dt>"": words in exact sequence </dt>
-  <dd><kbd>"Harry Lockhart"</kbd> will find <samp>Harry Lockhart</samp> but not <samp>Harry Potter/Gilderoy Lockhart</samp>.</dd>
+  <dd><kbd>"Sam Barnes"</kbd> will find <samp>Sam Barnes</samp> but not <samp>James "Bucky" Barnes/Sam Wilson</samp>.</dd>
   
   <dt>-: NOT </dt>
-  <dd><kbd>Harry -Lockhart</kbd> will find <samp>Harry Potter</samp> but not <samp>Harry Lockhart</samp> or <samp>Gilderoy Lockhart/Harry Potter</samp>.</dd>
+  <dd><kbd>Sam -Barnes</kbd> will find <samp>Sam Wilson</samp> but not <samp>Sam Barnes</samp> or <samp>James "Bucky" Barnes/Sam Wilson</samp>.</dd>
 </dl>
 
 <h5>Examples</h5>


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [x] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* ~[ ] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)~ N/A
* [x] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

N/A - I believe this falls under the "spelling corrections and documentation improvements" clause.

## Purpose
Updates the help text for bookmark, work, and tag searching to use Sam Wilson (and Bucky Barnes) as examples instead of Harry Potter (and Gilderoy Lockehart).

I believe Harry Potter was likely the most popular fandom on AO3 when the archive was first created; however, over time that has [switched to the MCU](https://www.reddit.com/r/AO3/comments/v9h4ae/analysis_of_the_top_fandoms_on_ao3_percentages/).

I also corrected an HTML tag: `spam` -> `samp`

## Testing Instructions

Go to the bookmark, work, and tag search pages and check whether the new text is displayed.

## References

N/A

## Credit

What name and pronouns should we use to credit you in the [Archive of Our Own's Release Notes](https://archiveofourown.org/admin_posts?tag=1)?

If you have a Jira account, please include the same name in the "Full name"
field on your Jira profile, so we can assign you the issues you're working on.

*Please note that if you do not fill in this section, we will use your GitHub account name and
they/them pronouns.*

Stephen Lewis, he/him