### PR TITLE
Revert "AO3-6243 Remove condition for comment form to be 'remote' to avoid CSRF token missing error"

### DIFF
--- a/app/views/comments/_comment_form.html.erb
+++ b/app/views/comments/_comment_form.html.erb
@@ -3,7 +3,7 @@
   <% commentable = @commentable %>
 <% end %>
 <div class="post comment" id="comment_form_for_<%= commentable.id %>">
-  <%= form_for value_for_comment_form(commentable, comment), remote: !comment.new_record?, authenticity_token: true, html: { id: "comment_for_#{commentable.id}" } do |f| %>
+  <%= form_for value_for_comment_form(commentable, comment), :remote => !comment.new_record?, :html => {:id => "comment_for_#{commentable.id}"} do |f| %>
     <fieldset>
       <legend><%= ts("Post Comment") %></legend>
 


### PR DESCRIPTION
Reverts otwcode/otwarchive#4322 -- something came up, so we're bumping it to the next release