### PR TITLE
AO3-6536 Add elections admin role

### DIFF
--- a/app/models/admin.rb
+++ b/app/models/admin.rb
@@ -1,5 +1,5 @@
 class Admin < ApplicationRecord
-  VALID_ROLES = %w[superadmin board communications translation tag_wrangling docs support policy_and_abuse open_doors].freeze
+  VALID_ROLES = %w[superadmin board communications elections translation tag_wrangling docs support policy_and_abuse open_doors].freeze
 
   serialize :roles, Array
 

--- a/app/policies/comment_policy.rb
+++ b/app/policies/comment_policy.rb
@@ -1,13 +1,21 @@
 class CommentPolicy < ApplicationPolicy
-  DESTROY_ROLES = %w[superadmin board policy_and_abuse communications support].freeze
+  DESTROY_COMMENT_ROLES = %w[superadmin board policy_and_abuse support].freeze
+  DESTROY_ADMIN_POST_COMMENT_ROLES = %w[superadmin board communications elections policy_and_abuse support].freeze
   FREEZE_TAG_COMMENT_ROLES = %w[superadmin tag_wrangling].freeze
   FREEZE_WORK_COMMENT_ROLES = %w[superadmin policy_and_abuse].freeze
   HIDE_TAG_COMMENT_ROLES = %w[superadmin tag_wrangling].freeze
   HIDE_WORK_COMMENT_ROLES = %w[superadmin policy_and_abuse].freeze
-  SPAM_ROLES = %w[superadmin board policy_and_abuse communications support].freeze
+  SPAM_ROLES = %w[superadmin board communications elections policy_and_abuse support].freeze
 
   def can_destroy_comment?
-    user_has_roles?(DESTROY_ROLES)
+    case record.ultimate_parent
+    when AdminPost
+      user_has_roles?(DESTROY_ADMIN_POST_COMMENT_ROLES)
+    when Tag
+      user_has_roles?(DESTROY_COMMENT_ROLES)
+    when Work
+      user_has_roles?(DESTROY_COMMENT_ROLES)
+    end
   end
 
   def can_freeze_comment?

--- a/app/policies/comment_policy.rb
+++ b/app/policies/comment_policy.rb
@@ -11,9 +11,7 @@ class CommentPolicy < ApplicationPolicy
     case record.ultimate_parent
     when AdminPost
       user_has_roles?(DESTROY_ADMIN_POST_COMMENT_ROLES)
-    when Tag
-      user_has_roles?(DESTROY_COMMENT_ROLES)
-    when Work
+    else
       user_has_roles?(DESTROY_COMMENT_ROLES)
     end
   end

--- a/config/locales/models/en.yml
+++ b/config/locales/models/en.yml
@@ -6,6 +6,7 @@ en:
         board: Board
         communications: Communications
         docs: AO3 Docs
+        elections: Elections
         open_doors: Open Doors
         policy_and_abuse: Policy & Abuse
         superadmin: Super admin

--- a/features/comments_and_kudos/admin_info.feature
+++ b/features/comments_and_kudos/admin_info.feature
@@ -34,6 +34,7 @@ Feature: Some admins can see IP addresses and emails for comments
     | board            | should not | should not   |
     | communications   | should not | should not   |
     | docs             | should not | should not   |
+    | elections        | should not | should not   |
     | open_doors       | should not | should not   |
     | tag_wrangling    | should not | should not   |
     | translation      | should not | should not   |

--- a/spec/controllers/admin/activities_controller_spec.rb
+++ b/spec/controllers/admin/activities_controller_spec.rb
@@ -22,7 +22,7 @@ describe Admin::ActivitiesController do
       it_behaves_like "unauthorized"
     end
 
-    %w[board communications elections translation tag_wrangling docs support open_doors].each do |role|
+    (Admin::VALID_ROLES - %w[superadmin policy_and_abuse]).each do |role|
       context "when logged in as an admin with #{role} role" do
         let(:admin) { create(:admin, roles: [role]) }
 
@@ -49,7 +49,7 @@ describe Admin::ActivitiesController do
       it_behaves_like "unauthorized"
     end
 
-    %w[board communications elections translation tag_wrangling docs support open_doors].each do |role|
+    (Admin::VALID_ROLES - %w[superadmin policy_and_abuse]).each do |role|
       context "when logged in as an admin with #{role} role" do
         let(:admin) { create(:admin, roles: [role]) }
 

--- a/spec/controllers/admin/activities_controller_spec.rb
+++ b/spec/controllers/admin/activities_controller_spec.rb
@@ -22,7 +22,7 @@ describe Admin::ActivitiesController do
       it_behaves_like "unauthorized"
     end
 
-    %w[board communications translation tag_wrangling docs support open_doors].each do |role|
+    %w[board communications elections translation tag_wrangling docs support open_doors].each do |role|
       context "when logged in as an admin with #{role} role" do
         let(:admin) { create(:admin, roles: [role]) }
 
@@ -49,7 +49,7 @@ describe Admin::ActivitiesController do
       it_behaves_like "unauthorized"
     end
 
-    %w[board communications translation tag_wrangling docs support open_doors].each do |role|
+    %w[board communications elections translation tag_wrangling docs support open_doors].each do |role|
       context "when logged in as an admin with #{role} role" do
         let(:admin) { create(:admin, roles: [role]) }
 

--- a/spec/controllers/admin/banners_controller_spec.rb
+++ b/spec/controllers/admin/banners_controller_spec.rb
@@ -16,7 +16,7 @@ describe Admin::BannersController do
       end
     end
 
-    %w[translation tag_wrangling docs elections policy_and_abuse open_doors].each do |role|
+    (Admin::VALID_ROLES - %w[support communications superadmin board]).each do |role|
       it "displays an error to #{role} admins" do
         fake_login_admin(create(:admin, roles: [role]))
         subject

--- a/spec/controllers/admin/banners_controller_spec.rb
+++ b/spec/controllers/admin/banners_controller_spec.rb
@@ -16,7 +16,7 @@ describe Admin::BannersController do
       end
     end
 
-    %w[translation tag_wrangling docs policy_and_abuse open_doors].each do |role|
+    %w[translation tag_wrangling docs elections policy_and_abuse open_doors].each do |role|
       it "displays an error to #{role} admins" do
         fake_login_admin(create(:admin, roles: [role]))
         subject

--- a/spec/controllers/admin/blacklisted_emails_controller_spec.rb
+++ b/spec/controllers/admin/blacklisted_emails_controller_spec.rb
@@ -16,7 +16,7 @@ describe Admin::BlacklistedEmailsController do
       end
     end
 
-    %w[board communications docs elections open_doors tag_wrangling translation].each do |role|
+    (Admin::VALID_ROLES - %w[superadmin policy_and_abuse support]).each do |role|
       it "redirects to root with error for #{role} admins" do
         fake_login_admin(create(:admin, roles: [role]))
         subject

--- a/spec/controllers/admin/blacklisted_emails_controller_spec.rb
+++ b/spec/controllers/admin/blacklisted_emails_controller_spec.rb
@@ -16,7 +16,7 @@ describe Admin::BlacklistedEmailsController do
       end
     end
 
-    %w[board communications docs open_doors tag_wrangling translation].each do |role|
+    %w[board communications docs elections open_doors tag_wrangling translation].each do |role|
       it "redirects to root with error for #{role} admins" do
         fake_login_admin(create(:admin, roles: [role]))
         subject

--- a/spec/controllers/admin/skins_controller_spec.rb
+++ b/spec/controllers/admin/skins_controller_spec.rb
@@ -20,7 +20,7 @@ describe Admin::SkinsController do
         end
       end
 
-      %w[board communications docs open_doors policy_and_abuse tag_wrangling translation].each do |role|
+      %w[board communications docs elections open_doors policy_and_abuse tag_wrangling translation].each do |role|
         context "when admin has #{role} role" do
           let(:admin) { create(:admin, roles: [role]) }
 
@@ -54,7 +54,7 @@ describe Admin::SkinsController do
         it_redirects_to_with_error(root_path, "Sorry, only an authorized admin can access the page you were trying to reach.")
       end
 
-      %w[board communications docs open_doors policy_and_abuse tag_wrangling translation].each do |role|
+      %w[board communications docs elections open_doors policy_and_abuse tag_wrangling translation].each do |role|
         context "when admin has #{role} role" do
           let(:admin) { create(:admin, roles: [role]) }
 
@@ -88,7 +88,7 @@ describe Admin::SkinsController do
         it_redirects_to_with_error(root_path, "Sorry, only an authorized admin can access the page you were trying to reach.")
       end
 
-      %w[board communications docs open_doors policy_and_abuse tag_wrangling translation].each do |role|
+      %w[board communications docs elections open_doors policy_and_abuse tag_wrangling translation].each do |role|
         context "when admin has #{role} role" do
           let(:admin) { create(:admin, roles: [role]) }
 
@@ -210,7 +210,7 @@ describe Admin::SkinsController do
       it_behaves_like "unauthorized admin cannot update work skin"
     end
 
-    %w[board communications docs open_doors policy_and_abuse tag_wrangling translation].each do |role|
+    %w[board communications docs elections open_doors policy_and_abuse tag_wrangling translation].each do |role|
       context "when admin has #{role} role" do
         let(:admin) { create(:admin, roles: [role]) }
 

--- a/spec/controllers/admin/skins_controller_spec.rb
+++ b/spec/controllers/admin/skins_controller_spec.rb
@@ -20,7 +20,7 @@ describe Admin::SkinsController do
         end
       end
 
-      %w[board communications docs elections open_doors policy_and_abuse tag_wrangling translation].each do |role|
+      (Admin::VALID_ROLES - %w[superadmin support]).each do |role|
         context "when admin has #{role} role" do
           let(:admin) { create(:admin, roles: [role]) }
 
@@ -54,7 +54,7 @@ describe Admin::SkinsController do
         it_redirects_to_with_error(root_path, "Sorry, only an authorized admin can access the page you were trying to reach.")
       end
 
-      %w[board communications docs elections open_doors policy_and_abuse tag_wrangling translation].each do |role|
+      (Admin::VALID_ROLES - %w[superadmin support]).each do |role|
         context "when admin has #{role} role" do
           let(:admin) { create(:admin, roles: [role]) }
 
@@ -88,7 +88,7 @@ describe Admin::SkinsController do
         it_redirects_to_with_error(root_path, "Sorry, only an authorized admin can access the page you were trying to reach.")
       end
 
-      %w[board communications docs elections open_doors policy_and_abuse tag_wrangling translation].each do |role|
+      (Admin::VALID_ROLES - %w[superadmin support]).each do |role|
         context "when admin has #{role} role" do
           let(:admin) { create(:admin, roles: [role]) }
 
@@ -210,7 +210,7 @@ describe Admin::SkinsController do
       it_behaves_like "unauthorized admin cannot update work skin"
     end
 
-    %w[board communications docs elections open_doors policy_and_abuse tag_wrangling translation].each do |role|
+    (Admin::VALID_ROLES - %w[superadmin support]).each do |role|
       context "when admin has #{role} role" do
         let(:admin) { create(:admin, roles: [role]) }
 

--- a/spec/controllers/admin/spam_controller_spec.rb
+++ b/spec/controllers/admin/spam_controller_spec.rb
@@ -16,7 +16,7 @@ describe Admin::SpamController do
       end
     end
 
-    %w[board communications translation tag_wrangling docs support open_doors].each do |role|
+    %w[board communications elections translation tag_wrangling docs support open_doors].each do |role|
       context "when logged in as an admin with #{role} role" do
         let(:admin) { create(:admin, roles: [role]) }
 
@@ -55,7 +55,7 @@ describe Admin::SpamController do
       end
     end
 
-    %w[board communications translation tag_wrangling docs support open_doors].each do |role|
+    %w[board communications elections translation tag_wrangling docs support open_doors].each do |role|
       context "when logged in as an admin with #{role} role" do
         let(:admin) { create(:admin, roles: [role]) }
 

--- a/spec/controllers/admin/spam_controller_spec.rb
+++ b/spec/controllers/admin/spam_controller_spec.rb
@@ -16,7 +16,7 @@ describe Admin::SpamController do
       end
     end
 
-    %w[board communications elections translation tag_wrangling docs support open_doors].each do |role|
+    (Admin::VALID_ROLES - %w[superadmin policy_and_abuse]).each do |role|
       context "when logged in as an admin with #{role} role" do
         let(:admin) { create(:admin, roles: [role]) }
 
@@ -55,7 +55,7 @@ describe Admin::SpamController do
       end
     end
 
-    %w[board communications elections translation tag_wrangling docs support open_doors].each do |role|
+    (Admin::VALID_ROLES - %w[superadmin policy_and_abuse]).each do |role|
       context "when logged in as an admin with #{role} role" do
         let(:admin) { create(:admin, roles: [role]) }
 

--- a/spec/controllers/comments_controller_spec.rb
+++ b/spec/controllers/comments_controller_spec.rb
@@ -2597,7 +2597,7 @@ describe CommentsController do
         context "when logged in as an admin" do
           let(:admin) { create(:admin) }
 
-          shared_examples "doesn't destroy comment and redirects with error" do
+          context "with no role" do
             it "doesn't destroy comment and redirects with error" do
               admin.update(roles: [])
               fake_login_admin(admin)
@@ -2608,13 +2608,16 @@ describe CommentsController do
             end
           end
 
-          context "with no role" do
-            it_behaves_like "doesn't destroy comment and redirects with error"
-          end
-
-          %w[communications elections].each do |admin_role|
+          (Admin::VALID_ROLES - %w[superadmin board policy_and_abuse support]).each do |admin_role|
             context "with role #{admin_role}" do
-              it_behaves_like "doesn't destroy comment and redirects with error"
+              it "doesn't destroy comment and redirects with error" do
+                admin.update(roles: [admin_role])
+                fake_login_admin(admin)
+                delete :destroy, params: { id: comment.id }
+  
+                it_redirects_to_with_error(root_path, "Sorry, only an authorized admin can access the page you were trying to reach.")
+                expect { comment.reload }.not_to raise_exception
+              end
             end
           end
 
@@ -2712,7 +2715,7 @@ describe CommentsController do
         context "when logged in as an admin" do
           let(:admin) { create(:admin) }
 
-          shared_examples "doesn't destroy comment and redirects with error" do
+          context "with no role" do
             it "doesn't destroy comment and redirects with error" do
               admin.update(roles: [])
               fake_login_admin(admin)
@@ -2723,13 +2726,16 @@ describe CommentsController do
             end
           end
 
-          context "with no role" do
-            it_behaves_like "doesn't destroy comment and redirects with error"
-          end
-
-          %w[communications elections].each do |admin_role|
+          (Admin::VALID_ROLES - %w[superadmin board policy_and_abuse support]).each do |admin_role|
             context "with role #{admin_role}" do
-              it_behaves_like "doesn't destroy comment and redirects with error"
+              it "doesn't destroy comment and redirects with error" do
+                admin.update(roles: [admin_role])
+                fake_login_admin(admin)
+                delete :destroy, params: { id: comment.id }
+  
+                it_redirects_to_with_error(root_path, "Sorry, only an authorized admin can access the page you were trying to reach.")
+                expect { comment.reload }.not_to raise_exception
+              end
             end
           end
 

--- a/spec/controllers/comments_controller_spec.rb
+++ b/spec/controllers/comments_controller_spec.rb
@@ -3093,7 +3093,7 @@ describe CommentsController do
           it_redirects_to_with_error(root_url, "Sorry, only an authorized admin can access the page you were trying to reach.")
         end
 
-        %w[superadmin board communications policy_and_abuse support].each do |admin_role|
+        %w[superadmin board policy_and_abuse support].each do |admin_role|
           it "successfully deletes the comment when admin has #{admin_role} role" do
             admin.update(roles: [admin_role])
             fake_login_admin(admin)

--- a/spec/controllers/comments_controller_spec.rb
+++ b/spec/controllers/comments_controller_spec.rb
@@ -2543,7 +2543,7 @@ describe CommentsController do
             end
           end
 
-          %w[superadmin board policy_and_abuse communications support].each do |admin_role|
+          %w[superadmin board communications elections policy_and_abuse support].each do |admin_role|
             context "with role #{admin_role}" do
               it "destroys comment and redirects with success message" do
                 admin.update(roles: [admin_role])
@@ -2597,7 +2597,7 @@ describe CommentsController do
         context "when logged in as an admin" do
           let(:admin) { create(:admin) }
 
-          context "with no role" do
+          shared_examples "doesn't destroy comment and redirects with error" do
             it "doesn't destroy comment and redirects with error" do
               admin.update(roles: [])
               fake_login_admin(admin)
@@ -2608,7 +2608,17 @@ describe CommentsController do
             end
           end
 
-          %w[superadmin board policy_and_abuse communications support].each do |admin_role|
+          context "with no role" do
+            it_behaves_like "doesn't destroy comment and redirects with error"
+          end
+
+          %w[communications elections].each do |admin_role|
+            context "with role #{admin_role}" do
+              it_behaves_like "doesn't destroy comment and redirects with error"
+            end
+          end
+
+          %w[superadmin board policy_and_abuse support].each do |admin_role|
             context "with the #{admin_role} role" do
               it "destroys comment and redirects with success message" do
                 admin.update(roles: [admin_role])
@@ -2702,7 +2712,7 @@ describe CommentsController do
         context "when logged in as an admin" do
           let(:admin) { create(:admin) }
 
-          context "with no role" do
+          shared_examples "doesn't destroy comment and redirects with error" do
             it "doesn't destroy comment and redirects with error" do
               admin.update(roles: [])
               fake_login_admin(admin)
@@ -2713,7 +2723,17 @@ describe CommentsController do
             end
           end
 
-          %w[superadmin policy_and_abuse].each do |admin_role|
+          context "with no role" do
+            it_behaves_like "doesn't destroy comment and redirects with error"
+          end
+
+          %w[communications elections].each do |admin_role|
+            context "with role #{admin_role}" do
+              it_behaves_like "doesn't destroy comment and redirects with error"
+            end
+          end
+
+          %w[superadmin board policy_and_abuse support].each do |admin_role|
             context "with the #{admin_role} role" do
               it "destroys comment and redirects with success message" do
                 admin.update(roles: [admin_role])

--- a/spec/controllers/comments_controller_spec.rb
+++ b/spec/controllers/comments_controller_spec.rb
@@ -3093,7 +3093,7 @@ describe CommentsController do
           it_redirects_to_with_error(root_url, "Sorry, only an authorized admin can access the page you were trying to reach.")
         end
 
-        %w[superadmin board policy_and_abuse support].each do |admin_role|
+        %w[superadmin board support policy_and_abuse].each do |admin_role|
           it "successfully deletes the comment when admin has #{admin_role} role" do
             admin.update(roles: [admin_role])
             fake_login_admin(admin)

--- a/spec/controllers/invite_requests_controller_spec.rb
+++ b/spec/controllers/invite_requests_controller_spec.rb
@@ -181,7 +181,7 @@ describe InviteRequestsController do
         end
       end
 
-      %w[board communications docs elections open_doors tag_wrangling translation].each do |admin_role|
+      (Admin::VALID_ROLES - %w[superadmin policy_and_abuse support]).each do |admin_role|
         context "with #{admin_role} role" do
           before do
             admin.update(roles: [admin_role])
@@ -283,7 +283,7 @@ describe InviteRequestsController do
         end
       end
 
-      %w[board communications docs elections open_doors tag_wrangling translation].each do |admin_role|
+      (Admin::VALID_ROLES - %w[superadmin policy_and_abuse support]).each do |admin_role|
         context "with #{admin_role} role" do
           before do
             admin.update(roles: [admin_role])

--- a/spec/controllers/invite_requests_controller_spec.rb
+++ b/spec/controllers/invite_requests_controller_spec.rb
@@ -181,7 +181,7 @@ describe InviteRequestsController do
         end
       end
 
-      %w[board communications docs open_doors tag_wrangling translation].each do |admin_role|
+      %w[board communications docs elections open_doors tag_wrangling translation].each do |admin_role|
         context "with #{admin_role} role" do
           before do
             admin.update(roles: [admin_role])
@@ -283,7 +283,7 @@ describe InviteRequestsController do
         end
       end
 
-      %w[board communications docs open_doors tag_wrangling translation].each do |admin_role|
+      %w[board communications docs elections open_doors tag_wrangling translation].each do |admin_role|
         context "with #{admin_role} role" do
           before do
             admin.update(roles: [admin_role])

--- a/spec/controllers/languages_controller_spec.rb
+++ b/spec/controllers/languages_controller_spec.rb
@@ -12,7 +12,7 @@ describe LanguagesController do
       end
     end
     
-    %w[board communications policy_and_abuse tag_wrangling docs support open_doors translation superadmin].each do |role|
+    %w[board communications elections policy_and_abuse tag_wrangling docs support open_doors translation superadmin].each do |role|
       context "when logged in as an admin with #{role} role" do
         let(:admin) { create(:admin, roles: [role]) }
 
@@ -33,7 +33,7 @@ describe LanguagesController do
       end
     end
 
-    %w[board communications policy_and_abuse tag_wrangling docs support open_doors translation superadmin].each do |role|
+    %w[board communications elections policy_and_abuse tag_wrangling docs support open_doors translation superadmin].each do |role|
       context "when logged in as an admin with #{role} role" do
         let(:admin) { create(:admin, roles: [role]) }
 
@@ -53,7 +53,7 @@ describe LanguagesController do
       end
     end
 
-    %w[board communications policy_and_abuse tag_wrangling docs support open_doors].each do |role|
+    %w[board communications elections policy_and_abuse tag_wrangling docs support open_doors].each do |role|
       context "when logged in as an admin with #{role} role" do
         let(:admin) { create(:admin, roles: [role]) }
         
@@ -99,7 +99,7 @@ describe LanguagesController do
       end
     end
 
-    %w[board communications policy_and_abuse tag_wrangling docs support open_doors].each do |role|
+    %w[board communications elections policy_and_abuse tag_wrangling docs support open_doors].each do |role|
       context "when logged in as an admin with #{role} role" do
         let(:admin) { create(:admin, roles: [role]) }
         
@@ -146,7 +146,7 @@ describe LanguagesController do
       end
     end
     
-    %w[board communications policy_and_abuse tag_wrangling docs support open_doors].each do |role|
+    %w[board communications elections policy_and_abuse tag_wrangling docs support open_doors].each do |role|
       context "when logged in as an admin with #{role} role" do
         let(:admin) { create(:admin, roles: [role]) }
         
@@ -195,7 +195,7 @@ describe LanguagesController do
       end
     end
 
-    %w[board communications policy_and_abuse tag_wrangling docs support open_doors].each do |role|
+    %w[board communications elections policy_and_abuse tag_wrangling docs support open_doors].each do |role|
       context "when logged in as an admin with #{role} role" do
         let(:admin) { create(:admin, roles: [role]) }
         

--- a/spec/controllers/languages_controller_spec.rb
+++ b/spec/controllers/languages_controller_spec.rb
@@ -12,7 +12,7 @@ describe LanguagesController do
       end
     end
     
-    %w[board communications elections policy_and_abuse tag_wrangling docs support open_doors translation superadmin].each do |role|
+    Admin::VALID_ROLES.each do |role|
       context "when logged in as an admin with #{role} role" do
         let(:admin) { create(:admin, roles: [role]) }
 
@@ -33,7 +33,7 @@ describe LanguagesController do
       end
     end
 
-    %w[board communications elections policy_and_abuse tag_wrangling docs support open_doors translation superadmin].each do |role|
+    Admin::VALID_ROLES.each do |role|
       context "when logged in as an admin with #{role} role" do
         let(:admin) { create(:admin, roles: [role]) }
 
@@ -53,7 +53,7 @@ describe LanguagesController do
       end
     end
 
-    %w[board communications elections policy_and_abuse tag_wrangling docs support open_doors].each do |role|
+    (Admin::VALID_ROLES - %w[superadmin translation]).each do |role|
       context "when logged in as an admin with #{role} role" do
         let(:admin) { create(:admin, roles: [role]) }
         
@@ -99,7 +99,7 @@ describe LanguagesController do
       end
     end
 
-    %w[board communications elections policy_and_abuse tag_wrangling docs support open_doors].each do |role|
+    (Admin::VALID_ROLES - %w[superadmin translation]).each do |role|
       context "when logged in as an admin with #{role} role" do
         let(:admin) { create(:admin, roles: [role]) }
         
@@ -146,7 +146,7 @@ describe LanguagesController do
       end
     end
     
-    %w[board communications elections policy_and_abuse tag_wrangling docs support open_doors].each do |role|
+    (Admin::VALID_ROLES - %w[superadmin translation]).each do |role|
       context "when logged in as an admin with #{role} role" do
         let(:admin) { create(:admin, roles: [role]) }
         
@@ -195,7 +195,7 @@ describe LanguagesController do
       end
     end
 
-    %w[board communications elections policy_and_abuse tag_wrangling docs support open_doors].each do |role|
+    (Admin::VALID_ROLES - %w[superadmin translation]).each do |role|
       context "when logged in as an admin with #{role} role" do
         let(:admin) { create(:admin, roles: [role]) }
         

--- a/spec/controllers/locales_controller_spec.rb
+++ b/spec/controllers/locales_controller_spec.rb
@@ -22,7 +22,7 @@ describe LocalesController do
       end
     end
     
-    %w[board communications elections policy_and_abuse tag_wrangling docs support open_doors].each do |role|
+    (Admin::VALID_ROLES - %w[superadmin translation]).each do |role|
       context "when logged in as an admin with #{role} role" do
         let(:admin) { create(:admin, roles: [role]) }
         
@@ -67,7 +67,7 @@ describe LocalesController do
       end
     end
 
-    %w[board communications elections policy_and_abuse tag_wrangling docs support open_doors].each do |role|
+    (Admin::VALID_ROLES - %w[superadmin translation]).each do |role|
       context "when logged in as an admin with #{role} role" do
         let(:admin) { create(:admin, roles: [role]) }
         
@@ -116,7 +116,7 @@ describe LocalesController do
       end
     end
 
-    %w[board communications elections policy_and_abuse tag_wrangling docs support open_doors].each do |role|
+    (Admin::VALID_ROLES - %w[superadmin translation]).each do |role|
       context "when logged in as an admin with #{role} role" do
         let(:admin) { create(:admin, roles: [role]) }
         
@@ -164,7 +164,7 @@ describe LocalesController do
       end
     end
 
-    %w[board communications elections policy_and_abuse tag_wrangling docs support open_doors].each do |role|
+    (Admin::VALID_ROLES - %w[superadmin translation]).each do |role|
       context "when logged in as an admin with #{role} role" do
         let(:admin) { create(:admin, roles: [role]) }
         
@@ -225,7 +225,7 @@ describe LocalesController do
       end
     end
 
-    %w[board communications elections policy_and_abuse tag_wrangling docs support open_doors].each do |role|
+    (Admin::VALID_ROLES - %w[superadmin translation]).each do |role|
       context "when logged in as an admin with #{role} role" do
         let(:admin) { create(:admin, roles: [role]) }
         

--- a/spec/controllers/locales_controller_spec.rb
+++ b/spec/controllers/locales_controller_spec.rb
@@ -22,7 +22,7 @@ describe LocalesController do
       end
     end
     
-    %w[board communications policy_and_abuse tag_wrangling docs support open_doors].each do |role|
+    %w[board communications elections policy_and_abuse tag_wrangling docs support open_doors].each do |role|
       context "when logged in as an admin with #{role} role" do
         let(:admin) { create(:admin, roles: [role]) }
         
@@ -67,7 +67,7 @@ describe LocalesController do
       end
     end
 
-    %w[board communications policy_and_abuse tag_wrangling docs support open_doors].each do |role|
+    %w[board communications elections policy_and_abuse tag_wrangling docs support open_doors].each do |role|
       context "when logged in as an admin with #{role} role" do
         let(:admin) { create(:admin, roles: [role]) }
         
@@ -116,7 +116,7 @@ describe LocalesController do
       end
     end
 
-    %w[board communications policy_and_abuse tag_wrangling docs support open_doors].each do |role|
+    %w[board communications elections policy_and_abuse tag_wrangling docs support open_doors].each do |role|
       context "when logged in as an admin with #{role} role" do
         let(:admin) { create(:admin, roles: [role]) }
         
@@ -164,7 +164,7 @@ describe LocalesController do
       end
     end
 
-    %w[board communications policy_and_abuse tag_wrangling docs support open_doors].each do |role|
+    %w[board communications elections policy_and_abuse tag_wrangling docs support open_doors].each do |role|
       context "when logged in as an admin with #{role} role" do
         let(:admin) { create(:admin, roles: [role]) }
         
@@ -225,7 +225,7 @@ describe LocalesController do
       end
     end
 
-    %w[board communications policy_and_abuse tag_wrangling docs support open_doors].each do |role|
+    %w[board communications elections policy_and_abuse tag_wrangling docs support open_doors].each do |role|
       context "when logged in as an admin with #{role} role" do
         let(:admin) { create(:admin, roles: [role]) }
         

--- a/spec/controllers/skins_controller_spec.rb
+++ b/spec/controllers/skins_controller_spec.rb
@@ -54,7 +54,7 @@ describe SkinsController do
         it_behaves_like "unauthorized admin cannot edit"
       end
 
-      %w[board communications docs elections open_doors policy_and_abuse tag_wrangling translation].each do |role|
+      (Admin::VALID_ROLES - %w[superadmin support]).each do |role|
         context "when admin has #{role} role" do
           let(:admin) { create(:admin, roles: [role]) }
 
@@ -126,7 +126,7 @@ describe SkinsController do
         it_behaves_like "unauthorized admin cannot update"
       end
 
-      %w[board communications docs elections open_doors policy_and_abuse tag_wrangling translation].each do |role|
+      (Admin::VALID_ROLES - %w[superadmin support]).each do |role|
         context "when admin has #{role} role" do
           let(:admin) { create(:admin, roles: [role]) }
 

--- a/spec/controllers/skins_controller_spec.rb
+++ b/spec/controllers/skins_controller_spec.rb
@@ -32,7 +32,7 @@ describe SkinsController do
         it_behaves_like "unauthorized admin cannot edit"
       end
 
-      %w[board communications docs open_doors policy_and_abuse support tag_wrangling translation].each do |role|
+      %w[board communications docs elections open_doors policy_and_abuse support tag_wrangling translation].each do |role|
         context "when admin has #{role} role" do
           let(:admin) { create(:admin, roles: [role]) }
 
@@ -54,7 +54,7 @@ describe SkinsController do
         it_behaves_like "unauthorized admin cannot edit"
       end
 
-      %w[board communications docs open_doors policy_and_abuse tag_wrangling translation].each do |role|
+      %w[board communications docs elections open_doors policy_and_abuse tag_wrangling translation].each do |role|
         context "when admin has #{role} role" do
           let(:admin) { create(:admin, roles: [role]) }
 
@@ -104,7 +104,7 @@ describe SkinsController do
         it_behaves_like "unauthorized admin cannot update"
       end
 
-      %w[board communications docs open_doors policy_and_abuse support tag_wrangling translation].each do |role|
+      %w[board communications docs elections open_doors policy_and_abuse support tag_wrangling translation].each do |role|
         context "when admin has #{role} role" do
           let(:admin) { create(:admin, roles: [role]) }
 
@@ -126,7 +126,7 @@ describe SkinsController do
         it_behaves_like "unauthorized admin cannot update"
       end
 
-      %w[board communications docs open_doors policy_and_abuse tag_wrangling translation].each do |role|
+      %w[board communications docs elections open_doors policy_and_abuse tag_wrangling translation].each do |role|
         context "when admin has #{role} role" do
           let(:admin) { create(:admin, roles: [role]) }
 

--- a/spec/controllers/skins_controller_spec.rb
+++ b/spec/controllers/skins_controller_spec.rb
@@ -32,7 +32,7 @@ describe SkinsController do
         it_behaves_like "unauthorized admin cannot edit"
       end
 
-      %w[board communications docs elections open_doors policy_and_abuse support tag_wrangling translation].each do |role|
+      (Admin::VALID_ROLES - %w[superadmin]).each do |role|
         context "when admin has #{role} role" do
           let(:admin) { create(:admin, roles: [role]) }
 
@@ -104,7 +104,7 @@ describe SkinsController do
         it_behaves_like "unauthorized admin cannot update"
       end
 
-      %w[board communications docs elections open_doors policy_and_abuse support tag_wrangling translation].each do |role|
+      (Admin::VALID_ROLES - %w[superadmin]).each do |role|
         context "when admin has #{role} role" do
           let(:admin) { create(:admin, roles: [role]) }
 


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [x] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [x] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [x] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-6536

## Purpose

Add elections admin role to allow them to hide, freeze and delete comments on news posts.

Elections and communications admins also have their deletion powers restricted to admin posts only.

## Testing Instructions

See JIRA ticket.

## Credit

EchoEkhi