### PR TITLE
AO3-6541 Update Works search and filters to use "Creator" instead of "Author/Artist"

### DIFF
--- a/app/models/search/work_search_form.rb
+++ b/app/models/search/work_search_form.rb
@@ -125,7 +125,7 @@ class WorkSearchForm
       summary << "Title: #{@options[:title]}"
     end
     if @options[:creators].present?
-      summary << "Author/Artist: #{@options[:creators]}"
+      summary << "Creator: #{@options[:creators]}"
     end
     tags = @searcher.included_tag_names
     all_tag_ids = @searcher.filter_ids
@@ -177,7 +177,7 @@ class WorkSearchForm
 
   SORT_OPTIONS = [
     ['Best Match', '_score'],
-    ['Author', 'authors_to_sort_on'],
+    ['Creator', 'authors_to_sort_on'],
     ['Title', 'title_to_sort_on'],
     ['Date Posted', 'created_at'],
     ['Date Updated', 'revised_at'],

--- a/app/views/works/_search_form.html.erb
+++ b/app/views/works/_search_form.html.erb
@@ -18,7 +18,7 @@
         <%= f.text_field :title %>
       </dd>
       <dt>
-        <%= f.label :creators, ts("Author/Artist") %>
+        <%= f.label :creators, ts("Creator") %>
       </dt>
       <dd>
         <%= f.text_field :creators %>

--- a/features/search/works_anonymous.feature
+++ b/features/search/works_anonymous.feature
@@ -26,9 +26,9 @@ Feature: Search anonymous works
       And I should see "1 Found"
       And I should see "Fulfilled Story-thing"
     When I go to the search works page
-      And I fill in "Author/Artist" with "Anonymous"
+      And I fill in "Creator" with "Anonymous"
       And I press "Search" within "#new_work_search"
-    Then I should see "You searched for: Author/Artist: Anonymous"
+    Then I should see "You searched for: Creator: Anonymous"
       And I should see "1 Found"
       And I should see "Fulfilled Story-thing"
 
@@ -45,8 +45,8 @@ Feature: Search anonymous works
       And I should see "1 Found"
       And I should see "Fulfilled Story-thing"
     When I go to the search works page
-      And I fill in "Author/Artist" with "mod1"
+      And I fill in "Creator" with "mod1"
       And I press "Search" within "#new_work_search"
-    Then I should see "You searched for: Author/Artist: mod1"
+    Then I should see "You searched for: Creator: mod1"
       And I should see "1 Found"
       And I should see "Fulfilled Story-thing"

--- a/features/search/works_info.feature
+++ b/features/search/works_info.feature
@@ -41,7 +41,7 @@ Feature: Search works by work info
     Then I should see "You searched for: word count: >15000 revised at: > 2 years ago"
       And I should see "No results found"
 
-  Scenario: Search with the header search field and then refine by author/artist
+  Scenario: Search with the header search field and then refine by creator
     Given I have the Battle set loaded
     When I fill in "site_search" with "testuser2"
       And I press "Search"
@@ -54,9 +54,9 @@ Feature: Search works by work info
     Then I should be on the search works page
       And the field labeled "Any Field" should contain "testuser2"
     When I fill in "Any Field" with ""
-      And I fill in "Author/Artist" with "testuser2"
+      And I fill in "Creator" with "testuser2"
       And I press "Search" within "#new_work_search"
-    Then I should see "You searched for: Author/Artist: testuser2"
+    Then I should see "You searched for: Creator: testuser2"
       And I should see "3 Found"
       And I should see "fourth"
       And I should see "fifth"

--- a/public/help/work-search-text-help.html
+++ b/public/help/work-search-text-help.html
@@ -2,7 +2,7 @@
 
 <p>Searches all the fields associated with a work in the database, including summary, notes and tags, but not the full work text.</p>
 
-<p>The characters ":" and "@" have special meanings. Leave them out of your search or you will get unexpected results. Like in the Title and Author/Artist field, you can use the following operators to combine your search terms:</p>
+<p>The characters ":" and "@" have special meanings. Leave them out of your search or you will get unexpected results. Like in the Title and Creator field, you can use the following operators to combine your search terms:</p>
 
 <dl>
   <dt>*: any characters </dt>


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [ ] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [x] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [x] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

This PR is for [AO3-6541](https://otwarchive.atlassian.net/jira/software/c/projects/AO3/issues/AO3-6541), which requested an update of the terminology used on the search forms. This update switches "Author/Artist" to "Creator".

## Purpose

This PR updates instances of "Author/Artist" to "Creator" on the work search forms.

## Credit

calm, they/them