### PR TITLE
AO3-4867 & AO3-4868 Prevent pseud ambiguity issues.

### DIFF
--- a/app/controllers/challenge_assignments_controller.rb
+++ b/app/controllers/challenge_assignments_controller.rb
@@ -191,7 +191,7 @@ class ChallengeAssignmentsController < ApplicationController
       when "cover"
         # cover_[assignment_id] = pinch hitter pseud
         next if val.blank? || assignment.pinch_hitter.try(:byline) == val
-        pseud = Pseud.parse_byline(val).first
+        pseud = Pseud.parse_byline(val)
         if pseud.nil?
           @errors << ts("We couldn't find the user #{val} to assign that to.")
         else

--- a/app/controllers/collection_participants_controller.rb
+++ b/app/controllers/collection_participants_controller.rb
@@ -89,7 +89,7 @@ class CollectionParticipantsController < ApplicationController
   def add
     @participants_added = []
     @participants_invited = []
-    pseud_results = Pseud.parse_bylines(params[:participants_to_invite], assume_matching_login: true)
+    pseud_results = Pseud.parse_bylines(params[:participants_to_invite])
     pseud_results[:pseuds].each do |pseud|
       if @collection.participants.include?(pseud)
         participant = CollectionParticipant.where(collection_id: @collection.id, pseud_id: pseud.id).first

--- a/app/controllers/gifts_controller.rb
+++ b/app/controllers/gifts_controller.rb
@@ -21,7 +21,7 @@ class GiftsController < ApplicationController
         end
       end
     else
-      pseud = Pseud.parse_byline(@recipient_name, assume_matching_login: true).first
+      pseud = Pseud.parse_byline(@recipient_name)
       if pseud
         if current_user.nil?
           @works = pseud.gift_works.visible_to_all

--- a/app/models/block.rb
+++ b/app/models/block.rb
@@ -21,7 +21,7 @@ class Block < ApplicationRecord
   end
 
   def blocked_byline=(byline)
-    pseuds = Pseud.parse_byline(byline, assume_matching_login: true)
-    self.blocked = pseuds.first.user unless pseuds.empty?
+    pseud = Pseud.parse_byline(byline)
+    self.blocked = pseud.user unless pseud.nil?
   end
 end

--- a/app/models/collection_item.rb
+++ b/app/models/collection_item.rb
@@ -218,7 +218,7 @@ class CollectionItem < ApplicationRecord
 
   def notify_of_reveal
     unless self.unrevealed? || !self.posted?
-      recipient_pseuds = Pseud.parse_bylines(self.recipients, assume_matching_login: true)[:pseuds]
+      recipient_pseuds = Pseud.parse_bylines(self.recipients)[:pseuds]
       recipient_pseuds.each do |pseud|
         unless pseud.user.preference.recipient_emails_off
           UserMailer.recipient_notification(pseud.user.id, self.item.id, self.collection.id).deliver_after_commit

--- a/app/models/concerns/creatable.rb
+++ b/app/models/concerns/creatable.rb
@@ -132,13 +132,13 @@ module Creatable
     names = pseud_names.split(",").reject(&:blank?).map(&:strip)
 
     names.each do |name|
-      possible_pseuds = Pseud.parse_byline(name)
+      possible_pseuds = Pseud.parse_byline_ambiguous(name)
 
-      if possible_pseuds.size > 1
-        possible_pseuds = Pseud.parse_byline(name, assume_matching_login: true)
-      end
-
-      pseud = possible_pseuds.first
+      pseud = if possible_pseuds.size > 1
+                Pseud.parse_byline(name)
+              else
+                possible_pseuds.first
+              end
 
       if pseud
         creatorship = creatorships.find_or_initialize_by(pseud: pseud)

--- a/app/models/creatorship.rb
+++ b/app/models/creatorship.rb
@@ -206,7 +206,7 @@ class Creatorship < ApplicationRecord
   # ambiguous/missing pseuds. By storing the desired name in the @byline
   # variable, we can generate nicely formatted messages.
   def byline=(byline)
-    pseuds = Pseud.parse_byline(byline).to_a
+    pseuds = Pseud.parse_byline_ambiguous(byline).to_a
 
     if pseuds.size == 1
       self.pseud = pseuds.first

--- a/app/models/gift.rb
+++ b/app/models/gift.rb
@@ -43,9 +43,11 @@ class Gift < ApplicationRecord
 
   scope :for_recipient_name, lambda {|name| where("recipient_name = ?", name)}
 
-  scope :for_name_or_byline, lambda {|name| where("recipient_name = ? OR pseud_id = ?",
-                                                  name,
-                                                  Pseud.parse_byline(name, assume_matching_login: true).first)}
+  scope :for_name_or_byline, lambda { |name|
+    where("recipient_name = ? OR pseud_id = ?",
+          name,
+          Pseud.parse_byline(name))
+  }
 
   scope :in_collection, lambda {|collection|
     select("DISTINCT gifts.*").
@@ -62,7 +64,7 @@ class Gift < ApplicationRecord
   scope :are_rejected, -> { where(rejected: true) }
 
   def recipient=(new_recipient_name)
-    self.pseud = Pseud.parse_byline(new_recipient_name, assume_matching_login: true).first
+    self.pseud = Pseud.parse_byline(new_recipient_name)
     self.recipient_name = pseud ? nil : new_recipient_name
   end
 

--- a/app/models/mute.rb
+++ b/app/models/mute.rb
@@ -29,7 +29,7 @@ class Mute < ApplicationRecord
   end
 
   def muted_byline=(byline)
-    pseuds = Pseud.parse_byline(byline, assume_matching_login: true)
-    self.muted = pseuds.first.user unless pseuds.empty?
+    pseud = Pseud.parse_byline(byline)
+    self.muted = pseud.user unless pseud.nil?
   end
 end

--- a/app/models/pseud.rb
+++ b/app/models/pseud.rb
@@ -178,7 +178,7 @@ class Pseud < ApplicationRecord
   # pseud name, returns [pseud.name, nil].
   def self.split_byline(byline)
     pseud_name, login = byline.split("(", 2)
-    [pseud_name.strip, login&.strip&.delete_suffix(")")]
+    [pseud_name&.strip, login&.strip&.delete_suffix(")")]
   end
 
   # Parse a string of the "pseud.name (user.login)" format into a pseud. If the

--- a/app/models/pseud.rb
+++ b/app/models/pseud.rb
@@ -160,16 +160,6 @@ class Pseud < ApplicationRecord
     @unposted_works = self.works.where(posted: false).order(created_at: :desc)
   end
 
-
-  # look up by byline
-  scope :by_byline, -> (byline) {
-    joins(:user)
-      .where('users.login = ? AND pseuds.name = ?',
-        (byline.include?('(') ? byline.split('(', 2)[1].strip.chop : byline),
-        (byline.include?('(') ? byline.split('(', 2)[0].strip : byline)
-      )
-  }
-
   # Produces a byline that indicates the user's name if pseud is not unique
   def byline
     (name != user_name) ? "#{name} (#{user_name})" : name
@@ -183,52 +173,58 @@ class Pseud < ApplicationRecord
     (past_name != past_user_name) ? "#{past_name} (#{past_user_name})" : past_name
   end
 
-  # Parse a string of the "pseud.name (user.login)" format into a pseud
-  def self.parse_byline(byline, options = {})
-    pseud_name = ""
-    login = ""
-    if byline.include?("(")
-      pseud_name, login = byline.split('(', 2)
-      pseud_name = pseud_name.strip
-      login = login.strip.chop
-      conditions = ['users.login = ? AND pseuds.name = ?', login, pseud_name]
+  # Parse a string of the "pseud.name (user.login)" format into an array
+  # [pseud.name, user.login]. If there is no parenthesized login after the
+  # pseud name, returns [pseud.name, nil].
+  def self.split_byline(byline)
+    pseud_name, login = byline.split("(", 2)
+    [pseud_name.strip, login&.strip&.delete_suffix(")")]
+  end
+
+  # Parse a string of the "pseud.name (user.login)" format into a pseud. If the
+  # form is just "pseud.name" with no parenthesized login, assumes that
+  # pseud.name = user.login and goes from there.
+  def self.parse_byline(byline)
+    pseud_name, login = split_byline(byline)
+    login ||= pseud_name
+
+    Pseud.joins(:user).find_by(pseuds: { name: pseud_name }, users: { login: login })
+  end
+
+  # Parse a string of the "pseud.name (user.login)" format into a list of
+  # pseuds. Usually this will be just one pseud, but if the byline is of the
+  # form "pseud.name" with no parenthesized user name, it'll look for any pseud
+  # with that name.
+  def self.parse_byline_ambiguous(byline)
+    pseud_name, login = split_byline(byline)
+
+    if login
+      Pseud.joins(:user).where(pseuds: { name: pseud_name }, users: { login: login })
     else
-      pseud_name = byline.strip
-      if options[:assume_matching_login]
-        conditions = ['users.login = ? AND pseuds.name = ?', pseud_name, pseud_name]
-      else
-        conditions = ['pseuds.name = ?', pseud_name]
-      end
+      Pseud.where(name: pseud_name)
     end
-    Pseud.joins(:user).where(conditions)
   end
 
   # Takes a comma-separated list of bylines
   # Returns a hash containing an array of pseuds and an array of bylines that couldn't be found
-  def self.parse_bylines(list, options = {})
+  def self.parse_bylines(bylines)
     valid_pseuds = []
-    ambiguous_pseuds = {}
     failures = []
     banned_pseuds = []
-    bylines = list.split ","
-    for byline in bylines
-      pseuds = Pseud.parse_byline(byline, options)
-      if pseuds.length == 1
-        pseud = pseuds.first
-        if pseud.user.banned? || pseud.user.suspended?
-          banned_pseuds << pseud
-        else
-          valid_pseuds << pseud
-        end
-      elsif pseuds.length > 1
-        ambiguous_pseuds[pseuds.first.name] = pseuds
-      else
+
+    bylines.split(",").each do |byline|
+      pseud = parse_byline(byline)
+      if pseud.nil?
         failures << byline.strip
+      elsif pseud.user.banned? || pseud.user.suspended?
+        banned_pseuds << pseud
+      else
+        valid_pseuds << pseud
       end
     end
+
     {
       pseuds: valid_pseuds.flatten.uniq,
-      ambiguous_pseuds: ambiguous_pseuds,
       invalid_pseuds: failures,
       banned_pseuds: banned_pseuds.flatten.uniq.map(&:byline)
     }

--- a/lib/creation_notifier.rb
+++ b/lib/creation_notifier.rb
@@ -31,7 +31,7 @@ module CreationNotifier
   def notify_recipients
     return unless self.posted && self.new_gifts.present? && !self.unrevealed?
 
-    recipient_pseuds = Pseud.parse_bylines(self.new_gifts.collect(&:recipient).join(","), assume_matching_login: true)[:pseuds]
+    recipient_pseuds = Pseud.parse_bylines(self.new_gifts.collect(&:recipient).join(","))[:pseuds]
     # check user prefs to see which recipients want to get gift notifications
     # (since each user has only one preference item, this removes duplicates)
     recip_ids = Preference.where(user_id: recipient_pseuds.map(&:user_id),

--- a/spec/models/challenge_assignment_spec.rb
+++ b/spec/models/challenge_assignment_spec.rb
@@ -83,4 +83,75 @@ describe ChallengeAssignment do
     end
   end
 
+  describe "request_signup_pseud=" do
+    let!(:collection) { create(:collection, challenge: create(:gift_exchange)) }
+
+    let(:assignment) { collection.assignments.build }
+
+    context "when a user has signed up with a pseud matching their login" do
+      let(:user) { create(:user) }
+
+      let!(:signup) do
+        create(:challenge_signup,
+               collection: collection,
+               pseud: user.default_pseud)
+      end
+
+      it "assigns the user's signup when entering the user's login" do
+        assignment.request_signup_pseud = user.login
+        expect(assignment.request_signup).to eq(signup)
+      end
+
+      context "when another user has signed up with the same pseud name" do
+        let(:ambiguous) { create(:pseud, name: user.login) }
+
+        let(:ambiguous_signup) do
+          create(:challenge_signup,
+                 collection: collection,
+                 pseud: ambiguous_signup)
+        end
+
+        it "assigns the first user's signup when entering the first user's login" do
+          assignment.request_signup_pseud = user.login
+          expect(assignment.request_signup).to eq(signup)
+        end
+      end
+    end
+  end
+
+  describe "offer_signup_pseud=" do
+    let!(:collection) { create(:collection, challenge: create(:gift_exchange)) }
+
+    let(:assignment) { collection.assignments.build }
+
+    context "when a user has signed up with a pseud matching their login" do
+      let(:user) { create(:user) }
+
+      let!(:signup) do
+        create(:challenge_signup,
+               collection: collection,
+               pseud: user.default_pseud)
+      end
+
+      it "assigns the user's signup when entering the user's login" do
+        assignment.offer_signup_pseud = user.login
+        expect(assignment.offer_signup).to eq(signup)
+      end
+
+      context "when another user has signed up with the same pseud name" do
+        let(:ambiguous) { create(:pseud, name: user.login) }
+
+        let(:ambiguous_signup) do
+          create(:challenge_signup,
+                 collection: collection,
+                 pseud: ambiguous_signup)
+        end
+
+        it "assigns the first user's signup when entering the first user's login" do
+          assignment.offer_signup_pseud = user.login
+          expect(assignment.offer_signup).to eq(signup)
+        end
+      end
+    end
+  end
 end

--- a/spec/models/challenge_assignment_spec.rb
+++ b/spec/models/challenge_assignment_spec.rb
@@ -105,15 +105,20 @@ describe ChallengeAssignment do
       context "when another user has signed up with the same pseud name" do
         let(:ambiguous) { create(:pseud, name: user.login) }
 
-        let(:ambiguous_signup) do
+        let!(:ambiguous_signup) do
           create(:challenge_signup,
                  collection: collection,
-                 pseud: ambiguous_signup)
+                 pseud: ambiguous)
         end
 
         it "assigns the first user's signup when entering the first user's login" do
           assignment.request_signup_pseud = user.login
           expect(assignment.request_signup).to eq(signup)
+        end
+
+        it "assigns the second user's signup when entering the full byline for the other user's pseud" do
+          assignment.request_signup_pseud = "#{ambiguous.name} (#{ambiguous.user.login})"
+          expect(assignment.request_signup).to eq(ambiguous_signup)
         end
       end
     end
@@ -141,15 +146,20 @@ describe ChallengeAssignment do
       context "when another user has signed up with the same pseud name" do
         let(:ambiguous) { create(:pseud, name: user.login) }
 
-        let(:ambiguous_signup) do
+        let!(:ambiguous_signup) do
           create(:challenge_signup,
                  collection: collection,
-                 pseud: ambiguous_signup)
+                 pseud: ambiguous)
         end
 
         it "assigns the first user's signup when entering the first user's login" do
           assignment.offer_signup_pseud = user.login
           expect(assignment.offer_signup).to eq(signup)
+        end
+
+        it "assigns the second user's signup when entering the full byline for the other user's pseud" do
+          assignment.offer_signup_pseud = "#{ambiguous.name} (#{ambiguous.user.login})"
+          expect(assignment.offer_signup).to eq(ambiguous_signup)
         end
       end
     end

--- a/spec/models/owned_tag_set_spec.rb
+++ b/spec/models/owned_tag_set_spec.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe OwnedTagSet do
+  let(:owned_tag_set) { create(:owned_tag_set) }
+  let(:user) { create(:user) }
+
+  describe "#owner_changes=" do
+    context "when assigning a user that is not an owner" do
+      it "makes the user an owner" do
+        owned_tag_set.update(owner_changes: user.login)
+        expect(owned_tag_set.owners.reload).to include(user.default_pseud)
+      end
+
+      context "when there is another user with a pseud of the same name" do
+        let!(:other_pseud) { create(:pseud, name: user.login) }
+
+        it "makes the first user an owner" do
+          owned_tag_set.update(owner_changes: user.login)
+          expect(owned_tag_set.owners.reload).to include(user.default_pseud)
+        end
+      end
+    end
+
+    context "when assigning a user that is an owner" do
+      before do
+        owned_tag_set.add_owner(user.default_pseud)
+        owned_tag_set.save
+        owned_tag_set.reload
+      end
+
+      it "removes the user as an owner" do
+        owned_tag_set.update(owner_changes: user.login)
+        expect(owned_tag_set.owners.reload).not_to include(user.default_pseud)
+      end
+
+      context "when there is another user with a pseud of the same name" do
+        let!(:other_pseud) { create(:pseud, name: user.login) }
+
+        it "removes the first user as an owner" do
+          owned_tag_set.update(owner_changes: user.login)
+          expect(owned_tag_set.owners.reload).not_to include(user.default_pseud)
+        end
+      end
+    end
+  end
+
+  describe "#moderator_changes=" do
+    context "when assigning a user that is not a moderator" do
+      it "makes the user a moderator" do
+        owned_tag_set.update(moderator_changes: user.login)
+        expect(owned_tag_set.moderators.reload).to include(user.default_pseud)
+      end
+
+      context "when there is another user with a pseud of the same name" do
+        let!(:other_pseud) { create(:pseud, name: user.login) }
+
+        it "makes the first user a moderator" do
+          owned_tag_set.update(moderator_changes: user.login)
+          expect(owned_tag_set.moderators.reload).to include(user.default_pseud)
+        end
+      end
+    end
+
+    context "when assigning a user that is a moderator" do
+      before do
+        owned_tag_set.add_moderator(user.default_pseud)
+        owned_tag_set.save
+        owned_tag_set.reload
+      end
+
+      it "removes the user as a moderator" do
+        owned_tag_set.update(moderator_changes: user.login)
+        expect(owned_tag_set.moderators.reload).not_to include(user.default_pseud)
+      end
+
+      context "when there is another user with a pseud of the same name" do
+        let!(:other_pseud) { create(:pseud, name: user.login) }
+
+        it "removes the first user as a moderator" do
+          owned_tag_set.update(moderator_changes: user.login)
+          expect(owned_tag_set.moderators.reload).not_to include(user.default_pseud)
+        end
+      end
+    end
+  end
+end

--- a/spec/models/owned_tag_set_spec.rb
+++ b/spec/models/owned_tag_set_spec.rb
@@ -7,8 +7,8 @@ describe OwnedTagSet do
   let(:user) { create(:user) }
 
   describe "#owner_changes=" do
-    context "when assigning a user that is not an owner" do
-      it "makes the user an owner" do
+    context "given a user that is not an owner" do
+      it "makes the user an owner when assigning their login" do
         owned_tag_set.update(owner_changes: user.login)
         expect(owned_tag_set.owners.reload).to include(user.default_pseud)
       end
@@ -16,39 +16,59 @@ describe OwnedTagSet do
       context "when there is another user with a pseud of the same name" do
         let!(:other_pseud) { create(:pseud, name: user.login) }
 
-        it "makes the first user an owner" do
+        it "makes the first user an owner when assigning their login" do
           owned_tag_set.update(owner_changes: user.login)
           expect(owned_tag_set.owners.reload).to include(user.default_pseud)
+          expect(owned_tag_set.owners.reload).not_to include(other_pseud)
+        end
+
+        it "makes the second user an owner when assigning the full byline for the other user's pseud" do
+          owned_tag_set.update(owner_changes: "#{other_pseud.name} (#{other_pseud.user.login})")
+          expect(owned_tag_set.owners.reload).not_to include(user.default_pseud)
+          expect(owned_tag_set.owners.reload).to include(other_pseud)
         end
       end
     end
 
-    context "when assigning a user that is an owner" do
+    context "given a user that is a co-owner" do
       before do
         owned_tag_set.add_owner(user.default_pseud)
         owned_tag_set.save
         owned_tag_set.reload
       end
 
-      it "removes the user as an owner" do
+      it "removes the user as an owner when assigning their login" do
         owned_tag_set.update(owner_changes: user.login)
         expect(owned_tag_set.owners.reload).not_to include(user.default_pseud)
       end
 
-      context "when there is another user with a pseud of the same name" do
+      context "when there is another user with a pseud of the same name who is also a co-owner" do
         let!(:other_pseud) { create(:pseud, name: user.login) }
 
-        it "removes the first user as an owner" do
+        before do
+          owned_tag_set.add_owner(other_pseud)
+          owned_tag_set.save
+          owned_tag_set.reload
+        end
+
+        it "removes the first user as an owner when assigning their login" do
           owned_tag_set.update(owner_changes: user.login)
           expect(owned_tag_set.owners.reload).not_to include(user.default_pseud)
+          expect(owned_tag_set.owners.reload).to include(other_pseud)
+        end
+
+        it "removes the second user an owner when assigning the full byline for the other user's pseud" do
+          owned_tag_set.update(owner_changes: "#{other_pseud.name} (#{other_pseud.user.login})")
+          expect(owned_tag_set.owners.reload).to include(user.default_pseud)
+          expect(owned_tag_set.owners.reload).not_to include(other_pseud)
         end
       end
     end
   end
 
   describe "#moderator_changes=" do
-    context "when assigning a user that is not a moderator" do
-      it "makes the user a moderator" do
+    context "given a user that is not a moderator" do
+      it "makes the user a moderator when assigning their login" do
         owned_tag_set.update(moderator_changes: user.login)
         expect(owned_tag_set.moderators.reload).to include(user.default_pseud)
       end
@@ -56,31 +76,51 @@ describe OwnedTagSet do
       context "when there is another user with a pseud of the same name" do
         let!(:other_pseud) { create(:pseud, name: user.login) }
 
-        it "makes the first user a moderator" do
+        it "makes the first user a moderator when assigning their login" do
           owned_tag_set.update(moderator_changes: user.login)
           expect(owned_tag_set.moderators.reload).to include(user.default_pseud)
+          expect(owned_tag_set.moderators.reload).not_to include(other_pseud)
+        end
+
+        it "makes the second user a moderator when assigning the full byline for the other user's pseud" do
+          owned_tag_set.update(moderator_changes: "#{other_pseud.name} (#{other_pseud.user.login})")
+          expect(owned_tag_set.moderators.reload).not_to include(user.default_pseud)
+          expect(owned_tag_set.moderators.reload).to include(other_pseud)
         end
       end
     end
 
-    context "when assigning a user that is a moderator" do
+    context "given a user that is a moderator" do
       before do
         owned_tag_set.add_moderator(user.default_pseud)
         owned_tag_set.save
         owned_tag_set.reload
       end
 
-      it "removes the user as a moderator" do
+      it "removes the user as a moderator when assigning their login" do
         owned_tag_set.update(moderator_changes: user.login)
         expect(owned_tag_set.moderators.reload).not_to include(user.default_pseud)
       end
 
-      context "when there is another user with a pseud of the same name" do
+      context "when there is another user with a pseud of the same name who is also a moderator" do
         let!(:other_pseud) { create(:pseud, name: user.login) }
 
-        it "removes the first user as a moderator" do
+        before do
+          owned_tag_set.add_moderator(other_pseud)
+          owned_tag_set.save
+          owned_tag_set.reload
+        end
+
+        it "removes the first user as a moderator when assigning their login" do
           owned_tag_set.update(moderator_changes: user.login)
           expect(owned_tag_set.moderators.reload).not_to include(user.default_pseud)
+          expect(owned_tag_set.moderators.reload).to include(other_pseud)
+        end
+
+        it "removes the second user a moderator when assigning the full byline for the other user's pseud" do
+          owned_tag_set.update(moderator_changes: "#{other_pseud.name} (#{other_pseud.user.login})")
+          expect(owned_tag_set.moderators.reload).to include(user.default_pseud)
+          expect(owned_tag_set.moderators.reload).not_to include(other_pseud)
         end
       end
     end


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-4867
https://otwarchive.atlassian.net/browse/AO3-4868

## Purpose

Changes the way that the `parse_byline` and `parse_bylines` functions are defined:
- The original functionality of `parse_byline` has been split into two functions: `parse_byline`, which returns a single pseud, and behaves like the old `assume_matching_login` option was enabled (if you call `first` on the result); and `parse_byline_ambiguous`, which returns an array of pseuds, and behaves like the old `assume_matching_login` option wasn't enabled.
- The function `parse_bylines` has been modified so that instead of allowing `assume_matching_login` as an option, it always calls the new, unambiguous `parse_byline`, because after AO3-4867 there are no cases where it should behave like `assume_matching_login: false` (and in general, I don't think it's a good idea to introduce any cases like that — the user interface gets messy when you have to let users disambiguate multiple pseuds).
- Removed the scope `by_byline`, because it was being used as a shorter replacement for `parse_byline` with the `assume_matching_login` option enabled.
- The `request_signup_pseud=` and `offer_signup_pseud=` functions were modified to use `parse_byline`.