### PR TITLE
AO3-6530 Display validation messages on top of footer

### DIFF
--- a/public/stylesheets/site/2.0/07-interactions.css
+++ b/public/stylesheets/site/2.0/07-interactions.css
@@ -180,6 +180,7 @@ We only use error messages for LiveValidation. Style spoofs the system error mes
   position: absolute;
   margin-top: 0.643em;
   margin-right: 15em;
+  z-index: 1;
 }
 
 .LV_invalid {


### PR DESCRIPTION
# Pull Request Checklist

* [X] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [X] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [ ] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [X] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [X] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-6530

## Purpose

Adds a z-index to the validation message class so that it displays on top of the footer. Please let me know if you feel there's a better alternative solution!

Before:
<img width="354" alt="Screenshot 2023-07-09 at 6 38 05 PM" src="https://github.com/otwcode/otwarchive/assets/61703668/efbb7028-2e89-41f4-9266-3ae2f43a4b05">

After:
<img width="366" alt="Screenshot 2023-07-09 at 6 37 41 PM" src="https://github.com/otwcode/otwarchive/assets/61703668/d7b841b4-8cb5-4400-a953-09a26c59ecab">


## Testing Instructions

Instructions found within [the JIRA issue](https://otwarchive.atlassian.net/browse/AO3-6530) work well!

1. Log in
2. If you’re not testing on an iPhone SE 2, create a site skin to increase the font size on your live validation errors:
a. Hi, username! > My Dashboard > Skins > Create Site Skin
b. Fill in a title
c. Enter some CSS to change the font size of your live validation errors: .LV_validation_message { font-size: 20px !important } (anywhere between 18-22 is probably sufficient on most phones)
d. Submit
e. Use
3. Access a form where there is a fairly long live validation message low on the page, e.g. the work content area on the posting form or the description field on the abuse report form
4. Tap the final field to select it
5. Tap outside the field without entering any text to make the message appear

## References

N/A

## Credit

Name: MitchStark10
Pronouns: he/him
