### PR TITLE
AO3-6558 Remove fetch_admin_settings hook.

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -175,11 +175,6 @@ protected
 
 public
 
-  before_action :fetch_admin_settings
-  def fetch_admin_settings
-    @admin_settings = AdminSetting.current
-  end
-
   before_action :load_admin_banner
   def load_admin_banner
     if Rails.env.development?
@@ -415,7 +410,7 @@ public
   end
 
   def use_caching?
-    %w(staging production test).include?(Rails.env) && @admin_settings.enable_test_caching?
+    %w(staging production test).include?(Rails.env) && AdminSetting.current.enable_test_caching?
   end
 
   protected
@@ -465,7 +460,7 @@ public
 
   # Make sure user is allowed to access tag wrangling pages
   def check_permission_to_wrangle
-    if @admin_settings.tag_wrangling_off? && !logged_in_as_admin?
+    if AdminSetting.current.tag_wrangling_off? && !logged_in_as_admin?
       flash[:error] = "Wrangling is disabled at the moment. Please check back later."
       redirect_to root_path
     else
@@ -521,8 +516,7 @@ public
   end
 
   # Don't get unnecessary data for json requests
-  skip_before_action  :fetch_admin_settings,
-                      :load_admin_banner,
+  skip_before_action  :load_admin_banner,
                       :set_redirects,
                       :store_location,
                       if: proc { %w(js json).include?(request.format) }

--- a/app/controllers/autocomplete_controller.rb
+++ b/app/controllers/autocomplete_controller.rb
@@ -3,7 +3,6 @@ class AutocompleteController < ApplicationController
 
   skip_before_action :store_location
   skip_before_action :set_current_user, except: [:collection_parent_name, :owned_tag_sets, :site_skins]
-  skip_before_action :fetch_admin_settings
   skip_before_action :set_redirects
   skip_before_action :sanitize_ac_params # can we dare!
 

--- a/app/controllers/downloads_controller.rb
+++ b/app/controllers/downloads_controller.rb
@@ -34,7 +34,7 @@ protected
   # It can't contain unposted chapters, nor unrevealed creators, even
   # if the creator is the one requesting the download.
   def load_work
-    unless @admin_settings.downloads_enabled?
+    unless AdminSetting.current.downloads_enabled?
       flash[:error] = ts("Sorry, downloads are currently disabled.")
       redirect_back_or_default works_path
       return

--- a/app/controllers/invite_requests_controller.rb
+++ b/app/controllers/invite_requests_controller.rb
@@ -8,7 +8,6 @@ class InviteRequestsController < ApplicationController
 
   # GET /invite_requests/1
   def show
-    fetch_admin_settings # we normally skip this for js requests
     @invite_request = InviteRequest.find_by(email: params[:email])
     @position_in_queue = @invite_request.position if @invite_request.present?
     unless (request.xml_http_request?) || @invite_request
@@ -23,7 +22,7 @@ class InviteRequestsController < ApplicationController
 
   # POST /invite_requests
   def create
-    unless @admin_settings.invite_from_queue_enabled?
+    unless AdminSetting.current.invite_from_queue_enabled?
       flash[:error] = ts("<strong>New invitation requests are currently closed.</strong> For more information, please check the %{news}.",
                          news: view_context.link_to("\"Invitations\" tag on AO3 News", admin_posts_path(tag: 143))).html_safe
       redirect_to invite_requests_path

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -66,11 +66,11 @@ class Users::RegistrationsController < Devise::RegistrationsController
 
     token = params[:invitation_token]
 
-    if !@admin_settings.account_creation_enabled?
+    if !AdminSetting.current.account_creation_enabled?
       flash[:error] = ts('Account creation is suspended at the moment. Please check back with us later.')
       redirect_to root_path and return
     else
-      check_account_creation_invite(token) if @admin_settings.creation_requires_invite?
+      check_account_creation_invite(token) if AdminSetting.current.creation_requires_invite?
     end
   end
 
@@ -89,7 +89,7 @@ class Users::RegistrationsController < Devise::RegistrationsController
       return
     end
 
-    if !@admin_settings.invite_from_queue_enabled?
+    if !AdminSetting.current.invite_from_queue_enabled?
       flash[:error] = ts('Account creation currently requires an invitation. We are unable to give out additional invitations at present, but existing invitations can still be used to create an account.')
       redirect_to root_path
     else

--- a/app/views/comments/_commentable.html.erb
+++ b/app/views/comments/_commentable.html.erb
@@ -79,7 +79,7 @@
   <%= flash_div :comment_error, :comment_notice %>
 
   <% commentable_parent = find_parent(commentable) %>
-  <% if @admin_settings.guest_comments_off? && guest? %>
+  <% if AdminSetting.current.guest_comments_off? && guest? %>
     <p class="notice">
       <%= t(".guest_comments_disabled") %>
     </p>

--- a/app/views/home/_intro_module.html.erb
+++ b/app/views/home/_intro_module.html.erb
@@ -5,7 +5,7 @@
 
   <div class="account module">
 
-    <% if !@admin_settings.invite_from_queue_enabled? && @admin_settings.creation_requires_invite? %>
+    <% if !AdminSetting.current.invite_from_queue_enabled? && AdminSetting.current.creation_requires_invite? %>
       <p>
         <%= ts("Joining the Archive currently requires an invitation; however, we 
                are not accepting new invitation requests at this time. Please check
@@ -27,13 +27,13 @@
       <li><%= ts("Keep track of works you've visited and works you want to check out later") %></li>
     </ul>
 
-    <% if @admin_settings.invite_from_queue_enabled? && @admin_settings.creation_requires_invite? && @admin_settings.request_invite_enabled? %>
+    <% if AdminSetting.current.invite_from_queue_enabled? && AdminSetting.current.creation_requires_invite? && AdminSetting.current.request_invite_enabled? %>
       <p><%= ts("You can join by getting an invitation from another user or from our automated invite queue. All fans and fanworks are welcome!") %></p>
       <p class="actions"><%= link_to ts("Get Invited!"), invite_requests_path %></p>
-    <% elsif @admin_settings.invite_from_queue_enabled? && @admin_settings.creation_requires_invite? %>
+    <% elsif AdminSetting.current.invite_from_queue_enabled? && AdminSetting.current.creation_requires_invite? %>
       <p><%= ts("You can join by getting an invitation from our automated invite queue. All fans and fanworks are welcome!") %></p>
       <p class="actions"><%= link_to ts("Get Invited!"), invite_requests_path %></p>
-    <% elsif @admin_settings.account_creation_enabled? && !@admin_settings.creation_requires_invite? %>
+    <% elsif AdminSetting.current.account_creation_enabled? && !AdminSetting.current.creation_requires_invite? %>
       <p class="actions"><%= link_to ts("Create an Account!"), signup_path %></p>
     <% end %>
   </div>

--- a/app/views/invite_requests/_index_open.html.erb
+++ b/app/views/invite_requests/_index_open.html.erb
@@ -38,6 +38,6 @@
       status: link_to("check your position on the waiting list",
                       status_invite_requests_path),
       count: InviteRequest.count,
-      invites: @admin_settings.invite_from_queue_number).html_safe %>
+      invites: AdminSetting.current.invite_from_queue_number).html_safe %>
 </p>
 <!--/content-->

--- a/app/views/invite_requests/_invite_request.html.erb
+++ b/app/views/invite_requests/_invite_request.html.erb
@@ -7,7 +7,7 @@
 <!--main content-->
 <p>
   <%= t(".position_html", position: tag.strong(@position_in_queue)) %>
-  <% if @admin_settings.invite_from_queue_enabled? %>
+  <% if AdminSetting.current.invite_from_queue_enabled? %>
     <%= t(".date", date: l(invite_request.proposed_fill_date, format: :long)) %>
   <% end %>
 </p>

--- a/app/views/invite_requests/index.html.erb
+++ b/app/views/invite_requests/index.html.erb
@@ -1,5 +1,5 @@
 <% # Page changes depending on whether queue is enabled %>
-<% if @admin_settings.invite_from_queue_enabled? %>
+<% if AdminSetting.current.invite_from_queue_enabled? %>
   <%= render "index_open" %>
 <% else %>
   <%= render "index_closed" %>

--- a/app/views/invite_requests/status.html.erb
+++ b/app/views/invite_requests/status.html.erb
@@ -5,8 +5,8 @@
 
 <p>
   <%= ts("There are currently %{count} people on the waiting list.", count: InviteRequest.count) %>
-  <% if @admin_settings.invite_from_queue_enabled? %>
-    <%= ts("We are sending out %{invites} invitations per day.", invites: @admin_settings.invite_from_queue_number) %>
+  <% if AdminSetting.current.invite_from_queue_enabled? %>
+    <%= ts("We are sending out %{invites} invitations per day.", invites: AdminSetting.current.invite_from_queue_number) %>
   <% end %>
 </p>
 <!--/descriptions-->

--- a/app/views/users/sessions/_passwd_small.html.erb
+++ b/app/views/users/sessions/_passwd_small.html.erb
@@ -20,11 +20,11 @@
 
 <ul class="footnote actions">
   <li><%= link_to ts("Forgot password?"), new_user_password_path %></li>
-  <% if @admin_settings.account_creation_enabled? && !@admin_settings.creation_requires_invite? %>
+  <% if AdminSetting.current.account_creation_enabled? && !AdminSetting.current.creation_requires_invite? %>
     <li>
       <%= link_to ts("Create an Account"), signup_path %>
     </li>
-  <% elsif @admin_settings.invite_from_queue_enabled? %>
+  <% elsif AdminSetting.current.invite_from_queue_enabled? %>
     <li>
       <%= link_to ts("Get an Invitation"), invite_requests_path %>
     </li>

--- a/app/views/users/sessions/new.html.erb
+++ b/app/views/users/sessions/new.html.erb
@@ -3,9 +3,9 @@
   <p>
     <%= t(".restricted.work_unavailable") %>
     <%= t(".restricted.account_exists") %>
-    <% if @admin_settings.invite_from_queue_enabled? && @admin_settings.creation_requires_invite? %>
+    <% if AdminSetting.current.invite_from_queue_enabled? && AdminSetting.current.creation_requires_invite? %>
       <%= t(".restricted.no_account", request_invite_link: link_to(t(".restricted.request_invite"), invite_requests_path)).html_safe %>
-    <% elsif @admin_settings.account_creation_enabled? && !@admin_settings.creation_requires_invite? %>
+    <% elsif AdminSetting.current.account_creation_enabled? && !AdminSetting.current.creation_requires_invite? %>
       <%= link_to t(".restricted.signup"), signup_path %>
     <% end %>
   </p>
@@ -14,9 +14,9 @@
   <p>
     <%= t(".restricted.commenting_unavailable") %>
     <%= t(".restricted.account_exists") %>
-    <% if @admin_settings.invite_from_queue_enabled? && @admin_settings.creation_requires_invite? %>
+    <% if AdminSetting.current.invite_from_queue_enabled? && AdminSetting.current.creation_requires_invite? %>
       <%= t(".restricted.no_account", request_invite_link: link_to(t(".restricted.request_invite"), invite_requests_path)).html_safe %>
-    <% elsif @admin_settings.account_creation_enabled? && !@admin_settings.creation_requires_invite? %>
+    <% elsif AdminSetting.current.account_creation_enabled? && !AdminSetting.current.creation_requires_invite? %>
       <%= link_to t(".restricted.signup"), signup_path %>
     <% end %>
   </p>
@@ -35,9 +35,9 @@
 
 <p>
   <%= t(".login.forgot", reset_password_link: link_to(t(".login.reset_password"), new_user_password_path)).html_safe %>
-  <% if @admin_settings.invite_from_queue_enabled? && @admin_settings.creation_requires_invite? %>
+  <% if AdminSetting.current.invite_from_queue_enabled? && AdminSetting.current.creation_requires_invite? %>
     <br \><%= t(".login.no_account", join_link: link_to(t(".login.request_invite"), invite_requests_path)).html_safe %>
-  <% elsif @admin_settings.account_creation_enabled? && !@admin_settings.creation_requires_invite? %>
+  <% elsif AdminSetting.current.account_creation_enabled? && !AdminSetting.current.creation_requires_invite? %>
     <br \><%= t(".login.no_account", join_link: link_to(t(".login.create_account"), signup_path)).html_safe %>
   <% end %>
 </p>

--- a/app/views/works/_work_header_navigation.html.erb
+++ b/app/views/works/_work_header_navigation.html.erb
@@ -108,7 +108,7 @@
     </li>
   <% end %>
 
-  <% if downloadable? && @admin_settings.downloads_enabled? %>
+  <% if downloadable? && AdminSetting.current.downloads_enabled? %>
     <li class="download" aria-haspopup="true">
       <a href="#"><%= ts("Download") %></a>
       <ul class="expandable secondary">

--- a/spec/controllers/invite_requests_controller_spec.rb
+++ b/spec/controllers/invite_requests_controller_spec.rb
@@ -89,7 +89,6 @@ describe InviteRequestsController do
         post :create, params: { invite_request: { email: generate(:email) } }
         it_redirects_to_simple(invite_requests_path)
         expect(flash[:error]).to include("New invitation requests are currently closed.")
-        expect(assigns(:admin_settings).invite_from_queue_enabled?).to be_falsey
       end
     end
   end


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6558

## Purpose

Removes the `fetch_admin_settings` hook, and replaces all uses of the variable `@admin_settings` with `AdminSetting.current`.