### PR TITLE
AO3-5803 Set minimums for gift exchange requests/offers

### DIFF
--- a/app/models/challenge_models/gift_exchange.rb
+++ b/app/models/challenge_models/gift_exchange.rb
@@ -21,13 +21,15 @@ class GiftExchange < ApplicationRecord
     allow_blank: true,
     maximum: ArchiveConfig.INFO_MAX, too_long: ts("must be less than %{max} letters long.", max: ArchiveConfig.INFO_MAX)
   }
-  validates :requests_num_required, numericality: { greater_than_or_equal_to: 1, only_integer: true }
-  validates :offers_num_required, numericality: { greater_than_or_equal_to: 1, only_integer: true }
 
   PROMPT_TYPES.each do |type|
     %w[required allowed].each do |setting|
       prompt_limit_field = "#{type}_num_#{setting}"
-      validates prompt_limit_field, numericality: { only_integer: true, less_than_or_equal_to: ArchiveConfig.PROMPTS_MAX, greater_than_or_equal_to: 0 }
+      validates prompt_limit_field, numericality: {
+        only_integer: true,
+        less_than_or_equal_to: ArchiveConfig.PROMPTS_MAX,
+        greater_than_or_equal_to: 1
+      }
     end
   end
 

--- a/app/models/challenge_models/gift_exchange.rb
+++ b/app/models/challenge_models/gift_exchange.rb
@@ -22,6 +22,9 @@ class GiftExchange < ApplicationRecord
     maximum: ArchiveConfig.INFO_MAX, too_long: ts("must be less than %{max} letters long.", max: ArchiveConfig.INFO_MAX)
   }
 
+  validates :requests_num_required, numericality: { greater_than_or_equal_to: 1, only_integer: true }
+  validates :offers_num_required, numericality: { greater_than_or_equal_to: 1, only_integer: true }
+
   PROMPT_TYPES.each do |type|
     %w(required allowed).each do |setting|
       prompt_limit_field = "#{type}_num_#{setting}"

--- a/app/models/challenge_models/gift_exchange.rb
+++ b/app/models/challenge_models/gift_exchange.rb
@@ -1,5 +1,5 @@
 class GiftExchange < ApplicationRecord
-  PROMPT_TYPES = %w(requests offers)
+  PROMPT_TYPES = %w[requests offers].freeze
   include ChallengeCore
 
   override_datetime_setters
@@ -17,29 +17,26 @@ class GiftExchange < ApplicationRecord
   belongs_to :potential_match_settings, dependent: :destroy
   accepts_nested_attributes_for :potential_match_settings
 
-  validates_length_of :signup_instructions_general, :signup_instructions_requests, :signup_instructions_offers, {
+  validates :signup_instructions_general, :signup_instructions_requests, :signup_instructions_offers, length: {
     allow_blank: true,
     maximum: ArchiveConfig.INFO_MAX, too_long: ts("must be less than %{max} letters long.", max: ArchiveConfig.INFO_MAX)
   }
-
   validates :requests_num_required, numericality: { greater_than_or_equal_to: 1, only_integer: true }
   validates :offers_num_required, numericality: { greater_than_or_equal_to: 1, only_integer: true }
 
   PROMPT_TYPES.each do |type|
-    %w(required allowed).each do |setting|
+    %w[required allowed].each do |setting|
       prompt_limit_field = "#{type}_num_#{setting}"
-      validates_numericality_of prompt_limit_field, only_integer: true, less_than_or_equal_to: ArchiveConfig.PROMPTS_MAX, greater_than_or_equal_to: 0
+      validates prompt_limit_field, numericality: { only_integer: true, less_than_or_equal_to: ArchiveConfig.PROMPTS_MAX, greater_than_or_equal_to: 0 }
     end
   end
 
   before_validation :update_allowed_values
   def update_allowed_values
-    %w(request offer).each do |prompt_type|
-      required = eval("#{prompt_type}s_num_required")
-      allowed = eval("#{prompt_type}s_num_allowed")
-      if required > allowed
-        eval("#{prompt_type}s_num_allowed = required")
-      end
+    %w[request offer].each do |prompt_type|
+      required = send("#{prompt_type}s_num_required")
+      allowed = send("#{prompt_type}s_num_allowed")
+      send("#{prompt_type}s_num_allowed=", required) if required > allowed
     end
   end
 
@@ -51,16 +48,16 @@ class GiftExchange < ApplicationRecord
 
   after_save :copy_tag_set_from_offer_to_request
   def copy_tag_set_from_offer_to_request
-    if self.offer_restriction
-      self.request_restriction.set_owned_tag_sets(self.offer_restriction.owned_tag_sets)
+    return unless self.offer_restriction
 
-      # copy the tag-set-based restriction settings
-      self.request_restriction.character_restrict_to_fandom = self.offer_restriction.character_restrict_to_fandom
-      self.request_restriction.relationship_restrict_to_fandom = self.offer_restriction.relationship_restrict_to_fandom
-      self.request_restriction.character_restrict_to_tag_set = self.offer_restriction.character_restrict_to_tag_set
-      self.request_restriction.relationship_restrict_to_tag_set = self.offer_restriction.relationship_restrict_to_tag_set
-      self.request_restriction.save
-    end
+    self.request_restriction.set_owned_tag_sets(self.offer_restriction.owned_tag_sets)
+
+    # copy the tag-set-based restriction settings
+    self.request_restriction.character_restrict_to_fandom = self.offer_restriction.character_restrict_to_fandom
+    self.request_restriction.relationship_restrict_to_fandom = self.offer_restriction.relationship_restrict_to_fandom
+    self.request_restriction.character_restrict_to_tag_set = self.offer_restriction.character_restrict_to_tag_set
+    self.request_restriction.relationship_restrict_to_tag_set = self.offer_restriction.relationship_restrict_to_tag_set
+    self.request_restriction.save
   end
 
   # override core

--- a/config/locales/models/en.yml
+++ b/config/locales/models/en.yml
@@ -42,10 +42,10 @@ en:
           one: 'Additional Tag:'
           other: 'Additional Tags:'
       gift_exchange:
-        offers_num_allowed: 'Number of offers allowed per sign-up'
-        offers_num_required: 'Number of offers required per sign-up'
-        requests_num_allowed: 'Number of requests allowed per sign-up'
-        requests_num_required: 'Number of requests required per sign-up'
+        offers_num_allowed: Number of offers allowed per sign-up
+        offers_num_required: Number of offers required per sign-up
+        requests_num_allowed: Number of requests allowed per sign-up
+        requests_num_required: Number of requests required per sign-up
       meta_tagging:
         meta_tag: Metatag
         meta_tag_id: Metatag

--- a/config/locales/models/en.yml
+++ b/config/locales/models/en.yml
@@ -41,6 +41,11 @@ en:
         name_with_colon:
           one: 'Additional Tag:'
           other: 'Additional Tags:'
+      gift_exchange:
+        offers_num_allowed: 'Number of offers allowed per sign-up'
+        offers_num_required: 'Number of offers required per sign-up'
+        requests_num_allowed: 'Number of requests allowed per sign-up'
+        requests_num_required: 'Number of requests required per sign-up'
       meta_tagging:
         meta_tag: Metatag
         meta_tag_id: Metatag

--- a/spec/models/gift_exchange_spec.rb
+++ b/spec/models/gift_exchange_spec.rb
@@ -19,5 +19,27 @@ describe GiftExchange do
     it "succeeds with a valid gift exchange" do
       expect(challenge.save).to be_truthy
     end
+
+    context "when allowed offers is bellow required offers" do
+      before do
+        challenge.offers_num_allowed = challenge.requests_num_required - 1
+      end
+
+      it "sets allowed offers to the same number as required" do
+        challenge.save!
+        expect(challenge.offers_num_allowed).to eq(challenge.offers_num_required)
+      end
+    end
+
+    context "when allowed requests is below required requests" do
+      before do
+        challenge.requests_num_allowed = challenge.requests_num_required - 1
+      end
+
+      it "sets allowed requests to same number as required" do
+        challenge.save!
+        expect(challenge.requests_num_allowed).to eq(challenge.requests_num_required)
+      end
+    end
   end
 end

--- a/spec/models/gift_exchange_spec.rb
+++ b/spec/models/gift_exchange_spec.rb
@@ -1,18 +1,23 @@
-require 'spec_helper'
+require "spec_helper"
 
 describe GiftExchange do
-
-  describe "a gift exchange challenge" do
-    before do
-      @collection = FactoryBot.create(:collection)
-      @collection.challenge = GiftExchange.new
-      @challenge = @collection.challenge
-    end
-
-    it "should save" do
-      expect(@challenge.save).to be_truthy
-    end
-
+  it do
+    is_expected.to validate_numericality_of(:requests_num_required)
+      .is_greater_than_or_equal_to(1)
+      .only_integer
   end
 
+  it do
+    is_expected.to validate_numericality_of(:offers_num_required)
+      .is_greater_than_or_equal_to(1)
+      .only_integer
+  end
+
+  describe "#save" do
+    let(:challenge) { build(:gift_exchange) }
+
+    it "succeeds with a valid gift exchange" do
+      expect(challenge.save).to be_truthy
+    end
+  end
 end


### PR DESCRIPTION
# Pull Request Checklist

* [X] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [X] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [X] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [X] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [X] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-5803

## Purpose

Require at least 1 request and offer per gift exchange signup. This avoids weird behavior when the requirements are 0. Also fixes the problem where 'allowed' values below 'required' were permitted.

## Testing Instructions

Refer to Jira ticket

## References

Are there other relevant issues/pull requests/mailing list discussions?

## Credit

Brian Austin (they/he)
