### PR TITLE
AO3-6545 Default FAQ to last valid locale instead of always English

### DIFF
--- a/app/controllers/archive_faqs_controller.rb
+++ b/app/controllers/archive_faqs_controller.rb
@@ -127,26 +127,26 @@ class ArchiveFaqsController < ApplicationController
 
   # Set the locale as an instance variable first
   def set_locale
-    session[:language_id] = params[:language_id].presence if session[:language_id] != params[:language_id].presence
+    session[:language_id] = params[:language_id] if Locale.exists?(iso: params[:language_id])
 
     if current_user.present? && $rollout.active?(:set_locale_preference,
                                                  current_user)
-      @i18n_locale = session[:language_id] || Locale.find(current_user.
+      @i18n_locale = session[:language_id].presence || Locale.find(current_user.
         preference.preferred_locale).iso
     else
-      @i18n_locale = session[:language_id] || I18n.default_locale
+      @i18n_locale = session[:language_id].presence || I18n.default_locale
     end
   end
 
   def validate_locale
-    return if Locale.exists?(iso: @i18n_locale)
+    return if params[:language_id].blank? || Locale.exists?(iso: params[:language_id])
 
     flash[:error] = "The specified locale does not exist."
     redirect_to url_for(request.query_parameters.merge(language_id: I18n.default_locale))
   end
 
   def require_language_id
-    return if params[:language_id].present?
+    return if params[:language_id].present? && Locale.exists?(iso: params[:language_id])
 
     redirect_to url_for(request.query_parameters.merge(language_id: @i18n_locale.to_s))
   end

--- a/app/controllers/archive_faqs_controller.rb
+++ b/app/controllers/archive_faqs_controller.rb
@@ -131,8 +131,7 @@ class ArchiveFaqsController < ApplicationController
 
     if current_user.present? && $rollout.active?(:set_locale_preference,
                                                  current_user)
-      @i18n_locale = session[:language_id].presence || Locale.find(current_user.
-        preference.preferred_locale).iso
+      @i18n_locale = session[:language_id].presence || Locale.find(current_user.preference.preferred_locale).iso
     else
       @i18n_locale = session[:language_id].presence || I18n.default_locale
     end

--- a/spec/controllers/archive_faqs_controller_spec.rb
+++ b/spec/controllers/archive_faqs_controller_spec.rb
@@ -38,13 +38,17 @@ describe ArchiveFaqsController do
     context "when logged in as a regular user" do
       before { fake_login_known_user(user) }
 
-      it "redirects to the default locale when the locale param is invalid" do
-        expect(I18n).not_to receive(:with_locale)
-        get :index, params: { language_id: "eldritch" }
-        it_redirects_to(archive_faqs_path(language_id: I18n.default_locale))
+      context "when the set locale preference feature flag is off" do
+        before { $rollout.deactivate_user(:set_locale_preference, user) }
+
+        it "redirects to the default locale when the locale param is invalid" do
+          expect(I18n).not_to receive(:with_locale)
+          get :index, params: { language_id: "eldritch" }
+          it_redirects_to(archive_faqs_path(language_id: I18n.default_locale))
+        end
       end
 
-      context "with set_locale_preference" do
+      context "when the set locale preference feature flag is on" do
         before { $rollout.activate_user(:set_locale_preference, user) }
 
         it "redirects to the user preferred locale when the locale param is invalid" do

--- a/spec/controllers/archive_faqs_controller_spec.rb
+++ b/spec/controllers/archive_faqs_controller_spec.rb
@@ -29,7 +29,7 @@ describe ArchiveFaqsController do
         it_redirects_to(archive_faqs_path(language_id: I18n.default_locale))
       end
 
-      it "redirects to the default locale when the locale param and the session locale are empty" do
+      it "redirects to the default locale when the locale param and the session locale are _explicty_ empty (legacy session behavior)" do
         expect(I18n).not_to receive(:with_locale)
         get :index, params: { language_id: "" }, session: { language_id: "" }
         it_redirects_to(archive_faqs_path(language_id: "en"))


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [x] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [x] Have you added the [Jira](https://otwarchive.atlassian.net) issue number as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [x] Do you have fewer than 5 pull requests already open? If not, please wait until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-6545

## Purpose

If accessing FAQ with no specified locale or an invalid locale, redirect to last locale in session, then user preferred locale, then default locale.

## Testing Instructions

As per JIRA. To be tested as guest, logged in standard user, and admin.

## Credit

Ceithir (he/him)