### PR TITLE
AO3-5901 Pseud switcher text on the New Pseud page

### DIFF
--- a/app/helpers/pseuds_helper.rb
+++ b/app/helpers/pseuds_helper.rb
@@ -37,11 +37,15 @@ module PseudsHelper
     end
   end
 
-  # used in the sidebar
-  def print_pseud_selector(pseuds)
-    pseuds -= [@pseud] if @pseud
+  def pseuds_for_sidebar(user, pseud)
+    pseuds = user.pseuds.abbreviated_list - [pseud]
     pseuds = pseuds.sort
-    pseuds = [@pseud] + pseuds if @pseud && !@pseud.new_record?
-    pseuds.collect {|pseud| "<li>" + span_if_current(pseud.name, [pseud.user, pseud]) + "</li>"}.join("").html_safe
+    pseuds = [pseud] + pseuds if pseud && !pseud.new_record?
+    pseuds
+  end
+
+  # used in the sidebar
+  def pseud_selector(pseuds)
+    pseuds.collect { |pseud| "<li>#{span_if_current(pseud.name, [pseud.user, pseud])}</li>" }.join.html_safe
   end
 end

--- a/app/helpers/pseuds_helper.rb
+++ b/app/helpers/pseuds_helper.rb
@@ -39,7 +39,9 @@ module PseudsHelper
 
   # used in the sidebar
   def print_pseud_selector(pseuds)
-    pseuds -= [@pseud] if @pseud && @pseud.new_record?
-    list = pseuds.sort.collect {|pseud| "<li>" + span_if_current(pseud.name, [pseud.user, pseud]) + "</li>"}.join("").html_safe
+    pseuds -= [@pseud] if @pseud
+    pseuds = pseuds.sort
+    pseuds = [@pseud] + pseuds if @pseud && !@pseud.new_record?
+    pseuds.collect {|pseud| "<li>" + span_if_current(pseud.name, [pseud.user, pseud]) + "</li>"}.join("").html_safe
   end
 end

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -15,17 +15,6 @@ module UsersHelper
     current_user.is_a?(User) ? current_user.maintained_collections.present? : false
   end
 
-  def sidebar_pseud_link_text(user, pseud)
-    text = if current_page?(user)
-             ts('Pseuds')
-           elsif pseud.present? && !pseud.new_record?
-             pseud.name
-           else
-             user.login
-           end
-    (text + ' &#8595;').html_safe
-  end
-
   # Prints user pseuds with links to anchors for each pseud on the page and the description as the title
   def print_pseuds(user)
     user.pseuds.collect(&:name).join(', ')

--- a/app/views/users/_sidebar.html.erb
+++ b/app/views/users/_sidebar.html.erb
@@ -5,7 +5,7 @@
   <li><%= span_if_current ts("Profile"), user_profile_path(@user) %></li>
   <% if @user.pseuds.size > 1 %>
     <li class="pseud" aria-haspopup="true">
-      <% pseud_link_text = current_page?(@user) ? ts("Pseuds") : (@pseud ? @pseud.name : @user.login) %>
+      <% pseud_link_text = current_page?(@user) ? ts("Pseuds") : (@pseud ? ( @pseud.name ? @pseud.name : ts("Pseuds") ) : @user.login) %>
       <a href="#" title="<%= ts("Pseud Switcher") %>"><%= pseud_link_text %></a>
       <ul class="expandable secondary">
         <%= print_pseud_selector(@user.pseuds.abbreviated_list) %>

--- a/app/views/users/_sidebar.html.erb
+++ b/app/views/users/_sidebar.html.erb
@@ -5,8 +5,7 @@
   <li><%= span_if_current ts("Profile"), user_profile_path(@user) %></li>
   <% if @user.pseuds.size > 1 %>
     <li class="pseud" aria-haspopup="true">
-      <% pseud_link_text = current_page?(@user) ? ts("Pseuds") : (@pseud ? ( @pseud.name ? @pseud.name : ts("Pseuds") ) : @user.login) %>
-      <a href="#" title="<%= ts("Pseud Switcher") %>"><%= pseud_link_text %></a>
+      <a href="#" title="<%= ts("Pseud Switcher") %>"><%= ts("Pseuds") %></a>
       <ul class="expandable secondary">
         <%= print_pseud_selector(@user.pseuds.abbreviated_list) %>
         <li><%= span_if_current ts("All Pseuds (%{pseud_number})", :pseud_number => @user.pseuds.count), user_pseuds_path(@user) %></li>

--- a/app/views/users/_sidebar.html.erb
+++ b/app/views/users/_sidebar.html.erb
@@ -7,7 +7,7 @@
     <li class="pseud" aria-haspopup="true">
       <a href="#" title="<%= ts("Pseud Switcher") %>"><%= ts("Pseuds") %></a>
       <ul class="expandable secondary">
-        <%= print_pseud_selector(@user.pseuds.abbreviated_list) %>
+        <%= pseud_selector(pseuds_for_sidebar(@user, @pseud)) %>
         <li><%= span_if_current ts("All Pseuds (%{pseud_number})", :pseud_number => @user.pseuds.count), user_pseuds_path(@user) %></li>
       </ul>
     </li>

--- a/features/other_a/pseuds.feature
+++ b/features/other_a/pseuds.feature
@@ -158,8 +158,8 @@ Scenario: Many pseuds
     And I should see "All Pseuds (4)" within "ul.expandable"
 
   When I go to my "Slartibartfast" pseud page
-  Then I should see "Slartibartfast" within "li.pseud > a"
-    And I should not see "Slartibartfast" within "ul.expandable"
+  Then I should see "Pseuds" within "li.pseud > a"
+    And I should see "Slartibartfast" within "ul.expandable"
 
   When I go to my pseuds page
   Then I should not see "Zaphod (Zaphod)" within "ul.pseud.index"


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [ ] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [x] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [x] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-5901

## Purpose

What does this PR do?

Provides fallback text for the edge case of the New Pseud page, where `@pseud` is defined, but doesn't have a `name` yet.

## Testing Instructions

How can the Archive's QA team verify that this is working as you intended?

If you have a Jira account with access, please update or comment on the issue
with any new or missing testing instructions instead.

## References

Are there other relevant issues/pull requests/mailing list discussions?

## Credit

What name and pronouns should we use to credit you in the [Archive of Our Own's Release Notes](https://archiveofourown.org/admin_posts?tag=1)?

If you have a Jira account, please include the same name in the "Full name"
field on your Jira profile, so we can assign you the issues you're working on.

*Please note that if you do not fill in this section, we will use your GitHub account name and
they/them pronouns.*
