### PR TITLE
AO3-4309 Internationalize batch subscription notification

### DIFF
--- a/app/helpers/mailer_helper.rb
+++ b/app/helpers/mailer_helper.rb
@@ -133,26 +133,23 @@ module MailerHelper
       creation_title: title, word_count: creation_word_count(creation))
   end
 
-  # The bylines used in subscription emails to prevent exposing the name(s) of
-  # anonymous creator(s).
+  # TODO: Update all mailers to use creator_links or creator_text as
+  # appropriate to eliminate pseuds.map { etc }.to_sentence in the views. Note
+  # that these should never be used on anonymous creations. Text dealing with
+  # Anonymous creations should always have a separate translation, as in the
+  # creation_attribution_ and batch_subscription_subject methods below.
   def creator_links(creation)
-    if creation.anonymous?
-      "Anonymous"
-    else
-      creation.pseuds.map { |p| style_pseud_link(p) }.to_sentence.html_safe
-    end
+    creation.pseuds.map { |p| style_pseud_link(p) }.to_sentence.html_safe
   end
 
   def creator_text(creation)
-    if creation.anonymous?
-      "Anonymous"
-    else
-      creation.pseuds.map { |p| text_pseud(p) }.to_sentence.html_safe
-    end
+    creation.pseuds.map { |p| text_pseud(p) }.to_sentence.html_safe
   end
 
-  # by name, which appears under or after creation titles
-  # plain text if anonymous
+  # "by name" or "by name, name, and name", which appears under or after
+  # creation titles.
+  # It's always plain text if the creation is anonymous, so we share that
+  # translation between two methods.
   def creation_attribution_links(creation)
     if creation.anonymous?
       t("mailer.general.creation.attribution.anon")

--- a/app/helpers/mailer_helper.rb
+++ b/app/helpers/mailer_helper.rb
@@ -248,6 +248,28 @@ module MailerHelper
     t(computed_key, **variables)
   end
 
+  def batch_subscription_text_preface(creation)
+    work = creation.is_a?(Chapter) ? creation.work : creation
+
+    variables = {}
+    variables[:creators] = creator_text(work) unless creation.anonymous?
+    variables[:work_title_with_word_count] = creation_title_with_word_count(creation.work) unless creation.is_a?(Work)
+    variables[:count] = creation.pseuds.size unless creation.anonymous?
+
+    t(batch_subscription_preface_key(creation, email_format: "text"), **variables)
+  end
+
+  def batch_subscription_html_preface(creation)
+    work = creation.is_a?(Chapter) ? creation.work : creation
+
+    variables = {}
+    variables[:creator_links] = creator_links(work) unless creation.anonymous?
+    variables[:work_link_with_word_count] = creation_link_with_word_count(creation.work, work_url(creation.work)) unless creation.is_a?(Work)
+    variables[:count] = creation.pseuds.size unless creation.anonymous?
+
+    t(batch_subscription_preface_key(creation, email_format: "html"), **variables)
+  end
+
   private
 
   # e.g., 1 word or 50 words
@@ -286,5 +308,29 @@ module MailerHelper
     else
       work_tag_metadata_list(tags)
     end
+  end
+
+  def batch_subscription_preface_key(creation, email_format:)
+    work = creation.is_a?(Chapter) ? creation.work : creation
+
+    base_key = "user_mailer.batch_subscription_notification.preface"
+    creator_key = creation.anonymous? ? "anon" : "named"
+    creation_key = creation.is_a?(Chapter) ? "chapter" : "work"
+    dating_key = creation.backdate ? ".backdated" : ".new" if creation.is_a?(Work)
+    format_key = ".#{email_format}" unless creation.is_a?(Work) && creation.anonymous?
+
+    # Note the lack of . before dating and format keys, which are not always
+    # included.
+    # i18n-tasks-use t("user_mailer.batch_subscription_notification.preface.anon.chapter.html")
+    # i18n-tasks-use t("user_mailer.batch_subscription_notification.preface.anon.chapter.text")
+    # i18n-tasks-use t("user_mailer.batch_subscription_notification.preface.anon.work.backdated")
+    # i18n-tasks-use t("user_mailer.batch_subscription_notification.preface.anon.work.new")
+    # i18n-tasks-use t("user_mailer.batch_subscription_notification.preface.named.chapter.html")
+    # i18n-tasks-use t("user_mailer.batch_subscription_notification.preface.named.chapter.text")
+    # i18n-tasks-use t("user_mailer.batch_subscription_notification.preface.named.work.backdated.html")
+    # i18n-tasks-use t("user_mailer.batch_subscription_notification.preface.named.work.backdated.text")
+    # i18n-tasks-use t("user_mailer.batch_subscription_notification.preface.named.work.new.html")
+    # i18n-tasks-use t("user_mailer.batch_subscription_notification.preface.naemd.work.new.text")
+    computed_key = "#{base_key}.#{creator_key}.#{creation_key}#{dating_key}#{format_key}"
   end
 end # end of MailerHelper

--- a/app/helpers/mailer_helper.rb
+++ b/app/helpers/mailer_helper.rb
@@ -311,8 +311,6 @@ module MailerHelper
   end
 
   def batch_subscription_preface_key(creation, email_format:)
-    work = creation.is_a?(Chapter) ? creation.work : creation
-
     base_key = "user_mailer.batch_subscription_notification.preface"
     creator_key = creation.anonymous? ? "anon" : "named"
     creation_key = creation.is_a?(Chapter) ? "chapter" : "work"
@@ -331,6 +329,6 @@ module MailerHelper
     # i18n-tasks-use t("user_mailer.batch_subscription_notification.preface.named.work.backdated.text")
     # i18n-tasks-use t("user_mailer.batch_subscription_notification.preface.named.work.new.html")
     # i18n-tasks-use t("user_mailer.batch_subscription_notification.preface.naemd.work.new.text")
-    computed_key = "#{base_key}.#{creator_key}.#{creation_key}#{dating_key}#{format_key}"
+    "#{base_key}.#{creator_key}.#{creation_key}#{dating_key}#{format_key}"
   end
 end # end of MailerHelper

--- a/app/helpers/mailer_helper.rb
+++ b/app/helpers/mailer_helper.rb
@@ -207,6 +207,7 @@ module MailerHelper
     work = creation.is_a?(Chapter) ? creation.work : creation
     series = subscription.subscribable if subscribable_type == "series"
     creator_list = creation.pseuds.map(&:byline).to_sentence unless creation.anonymous?
+    # For pluralization: creator publicó, creator y creator2 publicaron.
     creators_count = creation.pseuds.size unless creation.anonymous?
     chapter_header = creation.chapter_header if creation_type == "chapter"
 
@@ -231,7 +232,7 @@ module MailerHelper
     # i18n-tasks-use t("user_mailer.batch_subscription_notification.subject.named.work.one_entry")
     computed_key = "#{base_key}.#{creator_key}.#{creation_key}.#{entries_key}"
 
-    # "and X more," translated separately so we can pluralize based on X.
+    # "and X more," translated separately so we can pluralize "more" based on X.
     # i18n-tasks-use t("user_mailer.batch_subscription_notification.subject.more")
     more_translation = t("#{base_key}.more", count: additional_creations_count) unless additional_creations_count.zero?
 
@@ -242,7 +243,7 @@ module MailerHelper
     variables[:chapter_header] = chapter_header if creation_type == "chapter"
     variables[:work_title] = work.title
     variables[:series_title] = series.title if subscribable_type == "series"
-    variables[:more] = more_translation unless additional_creations_count.zero?
+    variables[:more] = more_translation
 
     t(computed_key, **variables)
   end

--- a/app/helpers/mailer_helper.rb
+++ b/app/helpers/mailer_helper.rb
@@ -135,20 +135,77 @@ module MailerHelper
 
   # The bylines used in subscription emails to prevent exposing the name(s) of
   # anonymous creator(s).
-  def creator_links(work)
-    if work.anonymous?
+  def creator_links(creation)
+    if creation.anonymous?
       "Anonymous"
     else
-      work.pseuds.map { |p| style_pseud_link(p) }.to_sentence.html_safe
+      creation.pseuds.map { |p| style_pseud_link(p) }.to_sentence.html_safe
     end
   end
 
-  def creator_text(work)
-    if work.anonymous?
+  def creator_text(creation)
+    if creation.anonymous?
       "Anonymous"
     else
-      work.pseuds.map { |p| text_pseud(p) }.to_sentence.html_safe
+      creation.pseuds.map { |p| text_pseud(p) }.to_sentence.html_safe
     end
+  end
+
+  # by name, which appears under or after creation titles
+  # plain text if anonymous
+  def creation_attribution_links(creation)
+    if creation.anonymous?
+      t("mailer.general.creation.attribution.anon")
+    else
+      t("mailer.general.creation.attribution.named.html", creator_links: creator_links(creation))
+    end
+  end
+
+  def creation_attribution_text(creation)
+    if creation.anonymous?
+      t("mailer.general.creation.attribution.anon")
+    else
+      t("mailer.general.creation.attribution.named.text", creators: creator_text(creation))
+    end
+  end
+
+  # The subject of batch_subscription_notification is based on the first
+  # creation in the email. It uses that creation's creator, so if you subscribe
+  # to user X, who has co-created a work with user Y, and Y posts a chapter that
+  # is not co-created, the subject line will say just "Y posted" even though the
+  # subscription is for X.
+  def subscription_subject(subscription, creation, additional_creations_count)
+    return if subscription.subscribable_type == "User" && creation.anonymous?
+
+    subscribable_type = subscription.subscribable_type.downcase
+
+    creation_type = creation.is_a?(Chapter) ? "chapter" : "work"
+
+    work = creation.is_a?(Chapter) ? creation.work : creation
+    series = subscription.subscribable if subscribable_type == "series"
+    creator_list = creation.pseuds.map(&:byline).to_sentence unless creation.anonymous?
+    creators_count = creation.pseuds.size unless creation.anonymous?
+    chapter_header = creation.chapter_header if creation_type == "chapter"
+
+    base_key = "user_mailer.batch_subscription_notification.subject"
+    creator_key = creation.anonymous? ? "anon" : "named"
+    creation_key = subscribable_type == "series" ? "series.#{creation_type}" : creation_type
+    entries_key = additional_creations_count.zero? ? "one_entry" : "multiple_entries"
+
+    computed_key = "#{base_key}.#{creator_key}.#{creation_key}.#{entries_key}"
+
+    # "and X more," translated separately so we can pluralize based on X.
+    more_translation = t("#{base_key}.more", count: additional_creations_count) unless additional_creations_count.zero?
+
+    variables = {}
+    variables[:creators] = creator_list unless creation.anonymous?
+    variables[:count] = creators_count unless creation.anonymous?
+    variables[:chapter_header] = chapter_header if creation_type == "chapter"
+    variables[:work_title] = work.title
+    variables[:series_title] = series.title if subscribable_type == "series"
+    variables[:more] = more_translation unless additional_creations_count.zero?
+
+    t("#{computed_key}", **variables)
   end
 
   def work_metadata_label(text)

--- a/app/helpers/mailer_helper.rb
+++ b/app/helpers/mailer_helper.rb
@@ -214,9 +214,24 @@ module MailerHelper
     creation_key = subscribable_type == "series" ? "series.#{creation_type}" : creation_type
     entries_key = additional_creations_count.zero? ? "one_entry" : "multiple_entries"
 
+    # i18n-tasks-use t(".user_mailer.batch_subscription_notification.subject.anon.chapter.multiple_entries")
+    # i18n-tasks-use t(".user_mailer.batch_subscription_notification.subject.anon.chapter.one_entry")
+    # i18n-tasks-use t(".user_mailer.batch_subscription_notification.subject.anon.series.chapter.multiple_entries")
+    # i18n-tasks-use t(".user_mailer.batch_subscription_notification.subject.anon.series.chapter.one_entry")
+    # i18n-tasks-use t(".user_mailer.batch_subscription_notification.subject.anon.series.work.multiple_entries")
+    # i18n-tasks-use t(".user_mailer.batch_subscription_notification.subject.anon.series.work.one_entry")
+    # i18n-tasks-use t(".user_mailer.batch_subscription_notification.subject.named.chapter.multiple_entries")
+    # i18n-tasks-use t(".user_mailer.batch_subscription_notification.subject.named.chapter.one_entry")
+    # i18n-tasks-use t(".user_mailer.batch_subscription_notification.subject.named.series.chapter.multiple_entries")
+    # i18n-tasks-use t(".user_mailer.batch_subscription_notification.subject.named.series.chapter.one_entry")
+    # i18n-tasks-use t(".user_mailer.batch_subscription_notification.subject.named.series.work.multiple_entries")
+    # i18n-tasks-use t(".user_mailer.batch_subscription_notification.subject.named.series.work.one_entry")
+    # i18n-tasks-use t(".user_mailer.batch_subscription_notification.subject.named.work.multiple_entries")
+    # i18n-tasks-use t(".user_mailer.batch_subscription_notification.subject.named.work.one_entry")
     computed_key = "#{base_key}.#{creator_key}.#{creation_key}.#{entries_key}"
 
     # "and X more," translated separately so we can pluralize based on X.
+    # i18n-tasks-use t("user_mailer.batch_subscription_notification.subject.more")
     more_translation = t("#{base_key}.more", count: additional_creations_count) unless additional_creations_count.zero?
 
     variables = {}

--- a/app/helpers/mailer_helper.rb
+++ b/app/helpers/mailer_helper.rb
@@ -328,7 +328,7 @@ module MailerHelper
     # i18n-tasks-use t("user_mailer.batch_subscription_notification.preface.named.work.backdated.html")
     # i18n-tasks-use t("user_mailer.batch_subscription_notification.preface.named.work.backdated.text")
     # i18n-tasks-use t("user_mailer.batch_subscription_notification.preface.named.work.new.html")
-    # i18n-tasks-use t("user_mailer.batch_subscription_notification.preface.naemd.work.new.text")
+    # i18n-tasks-use t("user_mailer.batch_subscription_notification.preface.named.work.new.text")
     "#{base_key}.#{creator_key}.#{creation_key}#{dating_key}#{format_key}"
   end
 end # end of MailerHelper

--- a/app/helpers/mailer_helper.rb
+++ b/app/helpers/mailer_helper.rb
@@ -196,6 +196,9 @@ module MailerHelper
   # to user X, who has co-created a work with user Y, and Y posts a chapter that
   # is not co-created, the subject line will say just "Y posted" even though the
   # subscription is for X.
+  # Note that we assume this is being used in batch_subscription_notification,
+  # after a subscription.valid_notification_entry?(creation) check. You can
+  # otherwise pass invalid or anonymity-breaking combinations of data to this.
   def batch_subscription_subject(subscription, creation, additional_creations_count)
     subscribable_type = subscription.subscribable_type.downcase
 
@@ -241,7 +244,7 @@ module MailerHelper
     variables[:series_title] = series.title if subscribable_type == "series"
     variables[:more] = more_translation unless additional_creations_count.zero?
 
-    t("#{computed_key}", **variables)
+    t(computed_key, **variables)
   end
 
   private

--- a/app/helpers/mailer_helper.rb
+++ b/app/helpers/mailer_helper.rb
@@ -197,8 +197,6 @@ module MailerHelper
   # is not co-created, the subject line will say just "Y posted" even though the
   # subscription is for X.
   def batch_subscription_subject(subscription, creation, additional_creations_count)
-    return if !subscription.valid_notification_entry?(creation)
-
     subscribable_type = subscription.subscribable_type.downcase
 
     creation_type = creation.is_a?(Chapter) ? "chapter" : "work"

--- a/app/helpers/mailer_helper.rb
+++ b/app/helpers/mailer_helper.rb
@@ -214,20 +214,20 @@ module MailerHelper
     creation_key = subscribable_type == "series" ? "series.#{creation_type}" : creation_type
     entries_key = additional_creations_count.zero? ? "one_entry" : "multiple_entries"
 
-    # i18n-tasks-use t(".user_mailer.batch_subscription_notification.subject.anon.chapter.multiple_entries")
-    # i18n-tasks-use t(".user_mailer.batch_subscription_notification.subject.anon.chapter.one_entry")
-    # i18n-tasks-use t(".user_mailer.batch_subscription_notification.subject.anon.series.chapter.multiple_entries")
-    # i18n-tasks-use t(".user_mailer.batch_subscription_notification.subject.anon.series.chapter.one_entry")
-    # i18n-tasks-use t(".user_mailer.batch_subscription_notification.subject.anon.series.work.multiple_entries")
-    # i18n-tasks-use t(".user_mailer.batch_subscription_notification.subject.anon.series.work.one_entry")
-    # i18n-tasks-use t(".user_mailer.batch_subscription_notification.subject.named.chapter.multiple_entries")
-    # i18n-tasks-use t(".user_mailer.batch_subscription_notification.subject.named.chapter.one_entry")
-    # i18n-tasks-use t(".user_mailer.batch_subscription_notification.subject.named.series.chapter.multiple_entries")
-    # i18n-tasks-use t(".user_mailer.batch_subscription_notification.subject.named.series.chapter.one_entry")
-    # i18n-tasks-use t(".user_mailer.batch_subscription_notification.subject.named.series.work.multiple_entries")
-    # i18n-tasks-use t(".user_mailer.batch_subscription_notification.subject.named.series.work.one_entry")
-    # i18n-tasks-use t(".user_mailer.batch_subscription_notification.subject.named.work.multiple_entries")
-    # i18n-tasks-use t(".user_mailer.batch_subscription_notification.subject.named.work.one_entry")
+    # i18n-tasks-use t("user_mailer.batch_subscription_notification.subject.anon.chapter.multiple_entries")
+    # i18n-tasks-use t("user_mailer.batch_subscription_notification.subject.anon.chapter.one_entry")
+    # i18n-tasks-use t("user_mailer.batch_subscription_notification.subject.anon.series.chapter.multiple_entries")
+    # i18n-tasks-use t("user_mailer.batch_subscription_notification.subject.anon.series.chapter.one_entry")
+    # i18n-tasks-use t("user_mailer.batch_subscription_notification.subject.anon.series.work.multiple_entries")
+    # i18n-tasks-use t("user_mailer.batch_subscription_notification.subject.anon.series.work.one_entry")
+    # i18n-tasks-use t("user_mailer.batch_subscription_notification.subject.named.chapter.multiple_entries")
+    # i18n-tasks-use t("user_mailer.batch_subscription_notification.subject.named.chapter.one_entry")
+    # i18n-tasks-use t("user_mailer.batch_subscription_notification.subject.named.series.chapter.multiple_entries")
+    # i18n-tasks-use t("user_mailer.batch_subscription_notification.subject.named.series.chapter.one_entry")
+    # i18n-tasks-use t("user_mailer.batch_subscription_notification.subject.named.series.work.multiple_entries")
+    # i18n-tasks-use t("user_mailer.batch_subscription_notification.subject.named.series.work.one_entry")
+    # i18n-tasks-use t("user_mailer.batch_subscription_notification.subject.named.work.multiple_entries")
+    # i18n-tasks-use t("user_mailer.batch_subscription_notification.subject.named.work.one_entry")
     computed_key = "#{base_key}.#{creator_key}.#{creation_key}.#{entries_key}"
 
     # "and X more," translated separately so we can pluralize based on X.

--- a/app/helpers/mailer_helper.rb
+++ b/app/helpers/mailer_helper.rb
@@ -207,7 +207,7 @@ module MailerHelper
     work = creation.is_a?(Chapter) ? creation.work : creation
     series = subscription.subscribable if subscribable_type == "series"
     creator_list = creation.pseuds.map(&:byline).to_sentence unless creation.anonymous?
-    # For pluralization: creator publicó, creator y creator2 publicaron.
+    # For pluralization: creator publico, creator y creator2 publicaron.
     creators_count = creation.pseuds.size unless creation.anonymous?
     chapter_header = creation.chapter_header if creation_type == "chapter"
 

--- a/app/helpers/mailer_helper.rb
+++ b/app/helpers/mailer_helper.rb
@@ -197,7 +197,7 @@ module MailerHelper
   # is not co-created, the subject line will say just "Y posted" even though the
   # subscription is for X.
   def batch_subscription_subject(subscription, creation, additional_creations_count)
-    return if subscription.subscribable_type == "User" && creation.anonymous?
+    return if !subscription.valid_notification_entry?(creation)
 
     subscribable_type = subscription.subscribable_type.downcase
 

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -128,11 +128,8 @@ class UserMailer < ApplicationMailer
       next if creation.pseuds.any? {|p| p.user == User.orphan_account} # no notifications for orphan works
       # TODO: allow subscriptions to orphan_account to receive notifications
 
-      # If the subscription notification is for a user subscription, we don't
-      # want to send updates about works that have recently become anonymous.
-      if @subscription.subscribable_type == 'User'
-        next if Subscription.anonymous_creation?(creation)
-      end
+      # Guard against scenarios that may break anonymity or other things.
+      next unless @subscription.valid_notification_entry?(creation)
 
       @creations << creation
     end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -140,8 +140,9 @@ class UserMailer < ApplicationMailer
     I18n.with_locale(Locale.find(@subscription.user.preference.preferred_locale).iso) do
       mail(
         to: @subscription.user.email,
-        subject: batch_subscription_subject(@subscription,
-          @creations.first, additional_creations_count)
+        subject: batch_subscription_subject(
+                  @subscription,
+                  @creations.first, additional_creations_count)
       )
     end
   end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -123,10 +123,6 @@ class UserMailer < ApplicationMailer
     creation_entries.each do |creation_info|
       creation_type, creation_id = creation_info.split("_")
       creation = creation_type.constantize.where(id: creation_id).first
-      next unless creation && creation.try(:posted)
-      next if (creation.is_a?(Chapter) && !creation.work.try(:posted))
-      next if creation.pseuds.any? {|p| p.user == User.orphan_account} # no notifications for orphan works
-      # TODO: allow subscriptions to orphan_account to receive notifications
 
       # Guard against scenarios that may break anonymity or other things.
       next unless @subscription.valid_notification_entry?(creation)
@@ -144,7 +140,8 @@ class UserMailer < ApplicationMailer
     I18n.with_locale(Locale.find(@subscription.user.preference.preferred_locale).iso) do
       mail(
         to: @subscription.user.email,
-        subject: batch_subscription_subject(@subscription, @creations.first, additional_creations_count)
+        subject: batch_subscription_subject(@subscription,
+          @creations.first, additional_creations_count)
       )
     end
   end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -141,9 +141,8 @@ class UserMailer < ApplicationMailer
       mail(
         to: @subscription.user.email,
         subject: batch_subscription_subject(
-                  @subscription,
-                  @creations.first, additional_creations_count)
-      )
+          @subscription,
+          @creations.first, additional_creations_count))
     end
   end
 

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -11,6 +11,7 @@ class UserMailer < ApplicationMailer
   helper :date
   helper :series
   include HtmlCleaner
+  include MailerHelper
 
   # Send an email letting a creator know that their work has been added to a collection by an archivist
   def archivist_added_to_collection_notification(user_id, work_id, collection_id)
@@ -141,17 +142,12 @@ class UserMailer < ApplicationMailer
     # make sure we only notify once per creation
     @creations.uniq!
 
-    main_creation = @creations.first
     additional_creations_count = @creations.count - 1
 
-    subject = @subscription.subject_text(@creations.first)
-    if @creations.count > 1
-      subject += " and #{@creations.count - 1} more"
-    end
     I18n.with_locale(Locale.find(@subscription.user.preference.preferred_locale).iso) do
       mail(
         to: @subscription.user.email,
-        subject: "[#{ArchiveConfig.APP_SHORT_NAME}] #{subject}"
+        subject: batch_subscription_subject(@subscription, @creations.first, additional_creations_count)
       )
     end
   end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -142,7 +142,9 @@ class UserMailer < ApplicationMailer
         to: @subscription.user.email,
         subject: batch_subscription_subject(
           @subscription,
-          @creations.first, additional_creations_count))
+          @creations.first, additional_creations_count
+        )
+      )
     end
   end
 

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -141,6 +141,9 @@ class UserMailer < ApplicationMailer
     # make sure we only notify once per creation
     @creations.uniq!
 
+    main_creation = @creations.first
+    additional_creations_count = @creations.count - 1
+
     subject = @subscription.subject_text(@creations.first)
     if @creations.count > 1
       subject += " and #{@creations.count - 1} more"

--- a/app/models/chapter.rb
+++ b/app/models/chapter.rb
@@ -40,6 +40,8 @@ class Chapter < ApplicationRecord
     end
   end
 
+  delegate :anonymous?, to: :work
+
   before_save :strip_title
   before_save :set_word_count
   before_save :validate_published_at
@@ -199,9 +201,5 @@ class Chapter < ApplicationRecord
   def expire_comments_count
     super
     work&.expire_comments_count
-  end
-
-  def anonymous?
-    work.anonymous?
   end
 end

--- a/app/models/chapter.rb
+++ b/app/models/chapter.rb
@@ -116,7 +116,7 @@ class Chapter < ApplicationRecord
   end
 
   def chapter_header
-    "#{ts("Chapter")} #{position}"
+    I18n.t("activerecord.attributes.chapters.chapter_header", position: position)
   end
 
   def chapter_title
@@ -199,5 +199,9 @@ class Chapter < ApplicationRecord
   def expire_comments_count
     super
     work&.expire_comments_count
+  end
+
+  def anonymous?
+    work.anonymous?
   end
 end

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -35,18 +35,6 @@ class Subscription < ApplicationRecord
     end
   end
 
-  def subject_text(creation)
-    authors = if self.class.anonymous_creation?(creation)
-                "Anonymous"
-              else
-                creation.pseuds.map(&:byline).to_sentence
-              end
-    chapter_text = creation.is_a?(Chapter) ? "#{creation.chapter_header} of " : ""
-    work_title = creation.is_a?(Chapter) ? creation.work.title : creation.title
-    text = "#{authors} posted #{chapter_text}#{work_title}"
-    text += subscribable_type == "Series" ? " in the #{self.name} series" : ""
-  end
-
   def self.anonymous_creation?(creation)
     (creation.is_a?(Work) && creation.anonymous?) || (creation.is_a?(Chapter) && creation.work.anonymous?)
   end

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -35,10 +35,6 @@ class Subscription < ApplicationRecord
     end
   end
 
-  def self.anonymous_creation?(creation)
-    (creation.is_a?(Work) && creation.anonymous?) || (creation.is_a?(Chapter) && creation.work.anonymous?)
-  end
-
   # Guard against scenarios that may break anonymity or other things.
   # Subscriptions can only contain works or chapters.
   # Subs to users should never contain anon works or chapters.

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -54,8 +54,8 @@ class Subscription < ApplicationRecord
     return false if subscribable_type == "User" && creation.anonymous?
     return false if subscribable_type == "Work" && !creation.is_a?(Chapter)
     return false if subscribable.respond_to?(:anonymous?) &&
-      subscribable.anonymous? != creation.anonymous?
+                    subscribable.anonymous? != creation.anonymous?
 
-    return true
+    true
   end
 end

--- a/app/views/user_mailer/_work_info.html.erb
+++ b/app/views/user_mailer/_work_info.html.erb
@@ -18,7 +18,7 @@
   <% end %>
 </p>
 
-<% unless work.summary.blank? %>
+<% unless work.summary.blank? || local_assigns[:suppress_summary] %>
   <p><%= style_work_metadata_label(Work.human_attribute_name("summary")) %></p>
   <%= style_quote(raw sanitize_field(work, :summary)) %>
 <% end %>

--- a/app/views/user_mailer/_work_info.text.erb
+++ b/app/views/user_mailer/_work_info.text.erb
@@ -15,7 +15,7 @@
 <% unless work.series.count.zero? %>
 <%= work_metadata_label(Series.model_name.human(count: work.series.count)) %><%= raw to_plain_text(series_list_for_feeds(work)) %>
 <% end %>
-<% unless work.summary.blank? %>
+<% unless work.summary.blank? || local_assigns[:suppress_summary] %>
 
 <%= work_metadata_label(Work.human_attribute_name("summary")) %>
     <%= raw to_plain_text(sanitize_field(work, :summary)) %>

--- a/app/views/user_mailer/batch_subscription_notification.html.erb
+++ b/app/views/user_mailer/batch_subscription_notification.html.erb
@@ -6,20 +6,19 @@
     <% this_work = creation.respond_to?(:work) ? creation.work : creation %>
     <% creation_url = creation.is_a?(Work) ? work_url(this_work) : work_chapter_url(this_work, creation) %>
     <% dating_key = this_work.backdate ? "backdated" : "new" %>
-    <% work_with_word_count = creation_link_with_word_count(this_work, work_url(this_work)) %>
 
     <% cache("/v1/subscription-email-preface-#{creation.cache_key}") do %>
       <p>
-        <% if creation.is_a?(Work) && this_work.anonymous? %>
+        <% if creation.is_a?(Work) && creation.anonymous? %>
           <%= t(".anon.preface.work.#{dating_key}") %>
-        <% elsif creation.is_a?(Chapter) && this_work.anonymous? %>
-          <%= t(".anon.preface.chapter.html", work_link_with_word_count: work_with_word_count) %>
+        <% elsif creation.is_a?(Chapter) && creation.anonymous? %>
+          <%= t(".anon.preface.chapter.html", work_link_with_word_count: creation_link_with_word_count(this_work, work_url(this_work)) %>
         <% elsif creation.is_a?(Work) %>
           <%# i18n-tasks-use t("user_mailer.batch_subscription_notification.named.preface.work.backdated.html")
               i18n-tasks-use t("user_mailer.batch_subscription_notification.named.preface.work.new.html")-%>
           <%= t(".named.preface.work.#{dating_key}.html", creator_links: creator_links(this_work), count: this_work.creators.size) %>
         <% else %>
-          <%= t(".named.preface.chapter.html", creator_links: creator_links(this_work), count: this_work.creators.size, work_link_with_word_count: work_with_word_count ) %>
+          <%= t(".named.preface.chapter.html", creator_links: creator_links(this_work), count: this_work.creators.size, work_link_with_word_count: creation_link_with_word_count(this_work, work_url(this_work)) %>
         <% end %>
       </p>
     <% end %>

--- a/app/views/user_mailer/batch_subscription_notification.html.erb
+++ b/app/views/user_mailer/batch_subscription_notification.html.erb
@@ -15,6 +15,8 @@
         <% elsif creation.is_a?(Chapter) && this_work.anonymous? %>
           <%= t(".anon.preface.chapter.html", work_link_with_word_count: work_with_word_count) %>
         <% elsif creation.is_a?(Work) %>
+          <%# i18n-tasks-use t("user_mailer.batch_subscription_notification.named.preface.work.backdated.html")
+              i18n-tasks-use t("user_mailer.batch_subscription_notification.named.preface.work.new.html")-%>
           <%= t(".named.preface.work.#{dating_key}.html", creator_links: creator_links(this_work), count: this_work.creators.size) %>
         <% else %>
           <%= t(".named.preface.chapter.html", creator_links: creator_links(this_work), count: this_work.creators.size, work_link_with_word_count: work_with_word_count ) %>

--- a/app/views/user_mailer/batch_subscription_notification.html.erb
+++ b/app/views/user_mailer/batch_subscription_notification.html.erb
@@ -5,22 +5,9 @@
 
     <% this_work = creation.respond_to?(:work) ? creation.work : creation %>
     <% creation_url = creation.is_a?(Work) ? work_url(this_work) : work_chapter_url(this_work, creation) %>
-    <% dating_key = this_work.backdate ? "backdated" : "new" %>
 
     <% cache("/v1/subscription-email-preface-#{creation.cache_key}") do %>
-      <p>
-        <% if creation.is_a?(Work) && creation.anonymous? %>
-          <%= t(".anon.preface.work.#{dating_key}") %>
-        <% elsif creation.is_a?(Chapter) && creation.anonymous? %>
-          <%= t(".anon.preface.chapter.html", work_link_with_word_count: creation_link_with_word_count(this_work, work_url(this_work))) %>
-        <% elsif creation.is_a?(Work) %>
-          <%# i18n-tasks-use t("user_mailer.batch_subscription_notification.named.preface.work.backdated.html")
-              i18n-tasks-use t("user_mailer.batch_subscription_notification.named.preface.work.new.html")-%>
-          <%= t(".named.preface.work.#{dating_key}.html", creator_links: creator_links(this_work), count: this_work.creators.size) %>
-        <% else %>
-          <%= t(".named.preface.chapter.html", creator_links: creator_links(this_work), count: this_work.creators.size, work_link_with_word_count: creation_link_with_word_count(this_work, work_url(this_work))) %>
-        <% end %>
-      </p>
+      <p><%= batch_subscription_html_preface(creation) %></p>
     <% end %>
 
     <p>

--- a/app/views/user_mailer/batch_subscription_notification.html.erb
+++ b/app/views/user_mailer/batch_subscription_notification.html.erb
@@ -12,13 +12,13 @@
         <% if creation.is_a?(Work) && creation.anonymous? %>
           <%= t(".anon.preface.work.#{dating_key}") %>
         <% elsif creation.is_a?(Chapter) && creation.anonymous? %>
-          <%= t(".anon.preface.chapter.html", work_link_with_word_count: creation_link_with_word_count(this_work, work_url(this_work)) %>
+          <%= t(".anon.preface.chapter.html", work_link_with_word_count: creation_link_with_word_count(this_work, work_url(this_work))) %>
         <% elsif creation.is_a?(Work) %>
           <%# i18n-tasks-use t("user_mailer.batch_subscription_notification.named.preface.work.backdated.html")
               i18n-tasks-use t("user_mailer.batch_subscription_notification.named.preface.work.new.html")-%>
           <%= t(".named.preface.work.#{dating_key}.html", creator_links: creator_links(this_work), count: this_work.creators.size) %>
         <% else %>
-          <%= t(".named.preface.chapter.html", creator_links: creator_links(this_work), count: this_work.creators.size, work_link_with_word_count: creation_link_with_word_count(this_work, work_url(this_work)) %>
+          <%= t(".named.preface.chapter.html", creator_links: creator_links(this_work), count: this_work.creators.size, work_link_with_word_count: creation_link_with_word_count(this_work, work_url(this_work))) %>
         <% end %>
       </p>
     <% end %>

--- a/app/views/user_mailer/batch_subscription_notification.html.erb
+++ b/app/views/user_mailer/batch_subscription_notification.html.erb
@@ -4,62 +4,37 @@
   <% @creations.each_with_index do |creation, index| %>
 
     <% this_work = creation.respond_to?(:work) ? creation.work : creation %>
-    <% work_link = style_link(this_work.title.html_safe, work_url(this_work)) %>
+    <% creation_url = creation.is_a?(Work) ? work_url(this_work) : work_chapter_url(this_work, creation) %>
 
-    <% cache("subscription-email-preface-#{creation.cache_key}") do %>
-      <%= creator_links(this_work) %> posted a
-      <% if creation.is_a?(Work) %>
-        <%= this_work.backdate ? "backdated" : "new" %> work:
-      <% else %>
-        new chapter of <i><b><%= work_link %></b></i> (<%= this_work.word_count %> words):
-      <% end %>
+    <% cache("/v1/subscription-email-preface-#{creation.cache_key}") do %>
+      <p>
+        <% if creation.is_a?(Work) %>
+          <%= t(".preface.work.#{this_work.backdate ? "backdated" : "new"}.html", creator_links: creator_links(this_work)) %>
+        <% else %>
+          <%= t(".preface.chapter.html", creator_links: creator_links(this_work), work_link_with_word_count: creation_link_with_word_count(this_work, work_url(this_work))) %>
+        <% end %>
+      </p>
     <% end %>
 
     <p>
-      <i>
-        <%= style_bold(creation.is_a?(Work) ? work_link :
-          style_link(creation.full_chapter_title.html_safe, work_chapter_url(this_work, creation))) %>
-      </i> (<%= creation.word_count%> words)
-
-      <% unless @seen[this_work.id] %>
-        <br>
-
-        by <%= creator_links(this_work) %>
-      <% end %>
+      <%= creation_link_with_word_count(creation, creation_url) %><% unless @seen[this_work.id] %><br><%= t(".creation_byline.html", creator_links: creator_links(this_work)) %><% end %>
     </p>
 
     <% if creation.summary.present? && creation.is_a?(Chapter) %>
-      <p><%= style_bold("Chapter Summary:") %></p>
+      <p><%= style_work_metadata_label(t(".chapter_summary")) %></p>
       <%= style_quote(raw sanitize_field(creation, :summary)) %>
     <% end %>
 
     <% unless @seen[this_work.id] %>
-      <% cache("subscription-email-meta-#{creation.cache_key}") do %>
-      <p>
-        <%= style_bold("Chapters:") %> <%= chapter_total_display(this_work) %>
-        <br><%= style_bold("Fandom:") %> <%= this_work.fandoms.map{|f| style_link(f.name, fandom_url(f))}.to_sentence.html_safe %>
-        <br><%= style_bold("Rating:") %> <%= this_work.rating_string %>
-        <br><%= style_bold("Warnings:") %> <%= this_work.archive_warning_string %>
-        <% if this_work.relationship_string && !this_work.relationship_string.blank? %>
-          <br><%= style_bold("Relationships:") %> <%= this_work.relationship_string %>
-        <% end %>
-        <% if this_work.character_string && !this_work.character_string.blank? %>
-          <br><%= style_bold("Characters:") %> <%= this_work.character_string %>
-        <% end %>
-        <% if this_work.freeform_string && !this_work.freeform_string.blank? %>
-          <br><%= style_bold("Additional Tags:") %> <%= this_work.freeform_string %>
-        <% end %>
-        <% if this_work.series.count > 0 %>
-          <br><%= style_bold("Series:") %> <%= series_list_for_feeds(this_work).html_safe %>
-        <% end %>
-      </p>
+      <% cache("/v1/subscription-email-meta-#{creation.cache_key}") do %>
+        <p><%= render "work_info", work: this_work, suppress_summary: true %></p>
       <% end %>
 
       <% @seen[this_work.id] = true %>
     <% end %>
 
     <% unless @seen_summary[this_work.id] || this_work.summary.blank? %>
-      <p><%= style_bold("Summary:") %></p>
+      <p><%= style_work_metadata_label(Work.human_attribute_name("summary")) %></p>
       <%= style_quote(raw sanitize_field(this_work, :summary)) %>
       <% @seen_summary[this_work.id] = true %>
     <% end %>
@@ -73,5 +48,5 @@
 
 
 <% content_for :footer_note do %>
-  You're receiving this email because you've subscribed to <%= style_footer_link(@subscription.name, polymorphic_url(@subscription.subscribable)) %>. Follow the link to unsubscribe if you no longer wish to receive updates.
+  <%= t(".footer_note.html", subscription_link: style_footer_link(@subscription.name, polymorphic_url(@subscription.subscribable))) %>
 <% end %>

--- a/app/views/user_mailer/batch_subscription_notification.html.erb
+++ b/app/views/user_mailer/batch_subscription_notification.html.erb
@@ -5,19 +5,25 @@
 
     <% this_work = creation.respond_to?(:work) ? creation.work : creation %>
     <% creation_url = creation.is_a?(Work) ? work_url(this_work) : work_chapter_url(this_work, creation) %>
+    <% dating_key = this_work.backdate ? "backdated" : "new" %>
+    <% work_with_word_count = creation_link_with_word_count(this_work, work_url(this_work)) %>
 
     <% cache("/v1/subscription-email-preface-#{creation.cache_key}") do %>
       <p>
-        <% if creation.is_a?(Work) %>
-          <%= t(".preface.work.#{this_work.backdate ? "backdated" : "new"}.html", creator_links: creator_links(this_work)) %>
+        <% if creation.is_a?(Work) && this_work.anonymous? %>
+          <%= t(".anon.preface.work.#{dating_key}") %>
+        <% elsif creation.is_a?(Chapter) && this_work.anonymous? %>
+          <%= t(".anon.preface.chapter.html", work_link_with_word_count: work_with_word_count) %>
+        <% elsif creation.is_a?(Work) %>
+          <%= t(".named.preface.work.#{dating_key}.html", creator_links: creator_links(this_work), count: this_work.creators.size) %>
         <% else %>
-          <%= t(".preface.chapter.html", creator_links: creator_links(this_work), work_link_with_word_count: creation_link_with_word_count(this_work, work_url(this_work))) %>
+          <%= t(".named.preface.chapter.html", creator_links: creator_links(this_work), count: this_work.creators.size, work_link_with_word_count: work_with_word_count ) %>
         <% end %>
       </p>
     <% end %>
 
     <p>
-      <%= creation_link_with_word_count(creation, creation_url) %><% unless @seen[this_work.id] %><br><%= t(".creation_byline.html", creator_links: creator_links(this_work)) %><% end %>
+      <%= creation_link_with_word_count(creation, creation_url) %><% unless @seen[this_work.id] %><br><%= creation_attribution_links(this_work) %><% end %>
     </p>
 
     <% if creation.summary.present? && creation.is_a?(Chapter) %>

--- a/app/views/user_mailer/batch_subscription_notification.text.erb
+++ b/app/views/user_mailer/batch_subscription_notification.text.erb
@@ -3,17 +3,23 @@
 <% @seen_summary = {} %>
 <% @creations.each_with_index do |creation, index| %>
 <% this_work = creation.respond_to?(:work) ? creation.work : creation %>
+<% dating_key = this_work.backdate ? "backdated" : "new" %>
+<% work_with_word_count = creation_title_with_word_count(this_work) %>
 <% cache "/v1/subscription-email-txt-preface-#{creation.cache_key}" do %>
-<% if creation.is_a?(Work) %>
-<%= t(".preface.work.#{this_work.backdate ? "backdated" : "new"}.text", creators: creator_text(this_work)) %>
+<% if creation.is_a?(Work) && this_work.anonymous? %>
+<%= t(".anon.preface.work.#{dating_key}") %>
+<% elsif creation.is_a?(Chapter) && this_work.anonymous? %>
+<%= t(".anon.preface.chapter.text", work_title_with_word_count: work_with_word_count) %>
+<% elsif creation.is_a?(Work) %>
+<%= t(".named.preface.work.#{dating_key}.text", creators: creator_text(this_work), count: this_work.creators.size) %>
 <% else %>
-<%= t(".preface.chapter.text", creators: creator_text(this_work), work_title_with_word_count: creation_title_with_word_count(this_work)) %>
+<%= t(".named.preface.chapter.text", creators: creator_text(this_work), count: this_work.creators.size, work_title_with_word_count: work_with_word_count) %>
 <% end %>
 <%= creation.is_a?(Work) ? work_url(this_work) : work_chapter_url(this_work, creation) %>
 <% end %>
 
 <%= creation_title_with_word_count(creation) %><% unless @seen[this_work.id] %>
-<%= t(".creation_byline.text", creators: creator_text(this_work)) %><% end %>
+<%= creation_attribution_text(this_work) %><% end %>
 
 <% if !creation.summary.blank? && creation.is_a?(Chapter) %>
 <%= work_metadata_label(t(".chapter_summary")) %><%= raw to_plain_text(sanitize_field(creation, :summary)) %>

--- a/app/views/user_mailer/batch_subscription_notification.text.erb
+++ b/app/views/user_mailer/batch_subscription_notification.text.erb
@@ -3,19 +3,8 @@
 <% @seen_summary = {} %>
 <% @creations.each_with_index do |creation, index| %>
 <% this_work = creation.respond_to?(:work) ? creation.work : creation %>
-<% dating_key = this_work.backdate ? "backdated" : "new" %>
 <% cache "/v1/subscription-email-txt-preface-#{creation.cache_key}" do %>
-<% if creation.is_a?(Work) && creation.anonymous? %>
-<%= t(".anon.preface.work.#{dating_key}") %>
-<% elsif creation.is_a?(Chapter) && creation.anonymous? %>
-<%= t(".anon.preface.chapter.text", work_title_with_word_count: creation_title_with_word_count(this_work)) %>
-<% elsif creation.is_a?(Work) %>
-<%# i18n-tasks-use t("user_mailer.batch_subscription_notification.named.preface.work.backdated.text")
-    i18n-tasks-use t("user_mailer.batch_subscription_notification.named.preface.work.new.text")-%>
-<%= t(".named.preface.work.#{dating_key}.text", creators: creator_text(this_work), count: this_work.creators.size) %>
-<% else %>
-<%= t(".named.preface.chapter.text", creators: creator_text(this_work), count: this_work.creators.size, work_title_with_word_count: creation_title_with_word_count(this_work)) %>
-<% end %>
+<%= batch_subscription_text_preface(creation) %>
 <%= creation.is_a?(Work) ? work_url(this_work) : work_chapter_url(this_work, creation) %>
 <% end %>
 

--- a/app/views/user_mailer/batch_subscription_notification.text.erb
+++ b/app/views/user_mailer/batch_subscription_notification.text.erb
@@ -3,32 +3,29 @@
 <% @seen_summary = {} %>
 <% @creations.each_with_index do |creation, index| %>
 <% this_work = creation.respond_to?(:work) ? creation.work : creation %>
-<% cache "subscription-email-txt-preface-#{creation.cache_key}" do %>
-<%= creator_text(this_work) %> posted a <% if creation.is_a?(Work) then %><%= this_work.backdate ? "backdated" : "new" %> work:<% else %>new chapter of <%= this_work.title %> (<%= this_work.word_count %> words):<% end %>
+<% cache "/v1/subscription-email-txt-preface-#{creation.cache_key}" do %>
+<% if creation.is_a?(Work) %>
+<%= t(".preface.work.#{this_work.backdate ? "backdated" : "new"}.text", creators: creator_text(this_work)) %>
+<% else %>
+<%= t(".preface.chapter.text", creators: creator_text(this_work), work_title_with_word_count: creation_title_with_word_count(this_work)) %>
+<% end %>
 <%= creation.is_a?(Work) ? work_url(this_work) : work_chapter_url(this_work, creation) %>
 <% end %>
 
-<%= creation.is_a?(Work) ? this_work.title.html_safe : creation.full_chapter_title.html_safe %> (<%= creation.word_count%> words)<% unless @seen[this_work.id] %>
-by <%= creator_text(this_work) %><% end %>
+<%= creation_title_with_word_count(creation) %><% unless @seen[this_work.id] %>
+<%= t(".creation_byline.text", creators: creator_text(this_work)) %><% end %>
 
 <% if !creation.summary.blank? && creation.is_a?(Chapter) %>
-Chapter Summary: <%= raw to_plain_text(sanitize_field(creation, :summary)) %>
+<%= work_metadata_label(t(".chapter_summary")) %><%= raw to_plain_text(sanitize_field(creation, :summary)) %>
 <% end %>
 
 <% unless @seen[this_work.id] %>
-<% cache "subscription-email-txt-meta-#{creation.cache_key}" do %>
-Chapters: <%= chapter_total_display(this_work) %>
-Fandom: <%= this_work.fandoms.map{|f| f.name}.to_sentence.html_safe %>
-Rating: <%= this_work.rating_string %>
-Warnings: <%= this_work.archive_warning_string %>
-<% if this_work.relationship_string && !this_work.relationship_string.blank? then %>Relationships: <%= this_work.relationship_string %><% end %>
-<% if this_work.character_string && !this_work.character_string.blank? then %>Characters: <%= this_work.character_string %><% end %>
-<% if this_work.freeform_string && !this_work.freeform_string.blank? %>Additional Tags: <%= this_work.freeform_string %><% end %>
-<% if this_work.series.count > 0 %>Series: <%=raw to_plain_text(series_list_for_feeds(this_work)) %><% end %>
+<% cache "/v1/subscription-email-txt-meta-#{creation.cache_key}" do %>
+<%= render "work_info", work: this_work, suppress_summary: true %>
 <% end %><% @seen[this_work.id] = true %><% end %>
 
 <% unless @seen_summary[this_work.id] || this_work.summary.blank? %>
-Summary:
+<%= work_metadata_label(Work.human_attribute_name("summary")) %>
     <%= raw to_plain_text(sanitize_field(this_work, :summary)) %><% @seen_summary[this_work.id] = true %><% end %><% if (index < @creations.length-1) %>
 
 <%= text_divider %>
@@ -36,5 +33,5 @@ Summary:
 <% end %><% end %><% end %>
 
 <% content_for :footer_note do %>
-You're receiving this email because you've subscribed to <%= @subscription.name %>. Follow the link to unsubscribe if you no longer wish to receive updates: <%= polymorphic_url(@subscription.subscribable) %>
+<%= t(".footer_note.text", subscription_name: @subscription.name, unsubscribe_url: polymorphic_url(@subscription.subscribable)) %>
 <% end %>

--- a/app/views/user_mailer/batch_subscription_notification.text.erb
+++ b/app/views/user_mailer/batch_subscription_notification.text.erb
@@ -11,6 +11,8 @@
 <% elsif creation.is_a?(Chapter) && this_work.anonymous? %>
 <%= t(".anon.preface.chapter.text", work_title_with_word_count: work_with_word_count) %>
 <% elsif creation.is_a?(Work) %>
+<%# i18n-tasks-use t("user_mailer.batch_subscription_notification.named.preface.work.backdated.text")
+    i18n-tasks-use t("user_mailer.batch_subscription_notification.named.preface.work.new.text")-%>
 <%= t(".named.preface.work.#{dating_key}.text", creators: creator_text(this_work), count: this_work.creators.size) %>
 <% else %>
 <%= t(".named.preface.chapter.text", creators: creator_text(this_work), count: this_work.creators.size, work_title_with_word_count: work_with_word_count) %>

--- a/app/views/user_mailer/batch_subscription_notification.text.erb
+++ b/app/views/user_mailer/batch_subscription_notification.text.erb
@@ -4,18 +4,17 @@
 <% @creations.each_with_index do |creation, index| %>
 <% this_work = creation.respond_to?(:work) ? creation.work : creation %>
 <% dating_key = this_work.backdate ? "backdated" : "new" %>
-<% work_with_word_count = creation_title_with_word_count(this_work) %>
 <% cache "/v1/subscription-email-txt-preface-#{creation.cache_key}" do %>
-<% if creation.is_a?(Work) && this_work.anonymous? %>
+<% if creation.is_a?(Work) && creation.anonymous? %>
 <%= t(".anon.preface.work.#{dating_key}") %>
-<% elsif creation.is_a?(Chapter) && this_work.anonymous? %>
-<%= t(".anon.preface.chapter.text", work_title_with_word_count: work_with_word_count) %>
+<% elsif creation.is_a?(Chapter) && creation.anonymous? %>
+<%= t(".anon.preface.chapter.text", work_title_with_word_count: creation_title_with_word_count(this_work)) %>
 <% elsif creation.is_a?(Work) %>
 <%# i18n-tasks-use t("user_mailer.batch_subscription_notification.named.preface.work.backdated.text")
     i18n-tasks-use t("user_mailer.batch_subscription_notification.named.preface.work.new.text")-%>
 <%= t(".named.preface.work.#{dating_key}.text", creators: creator_text(this_work), count: this_work.creators.size) %>
 <% else %>
-<%= t(".named.preface.chapter.text", creators: creator_text(this_work), count: this_work.creators.size, work_title_with_word_count: work_with_word_count) %>
+<%= t(".named.preface.chapter.text", creators: creator_text(this_work), count: this_work.creators.size, work_title_with_word_count: creation_title_with_word_count(this_work)) %>
 <% end %>
 <%= creation.is_a?(Work) ? work_url(this_work) : work_chapter_url(this_work, creation) %>
 <% end %>

--- a/app/views/user_mailer/recipient_notification.html.erb
+++ b/app/views/user_mailer/recipient_notification.html.erb
@@ -14,7 +14,7 @@
     <% url = @collection ? collection_work_url(@collection, @work) : work_url(@work) %>
     <%= creation_link_with_word_count(@work, url) %>
     <br>
-    by <%= creator_links(@work) %>
+    <%= creation_attribution_links(@work) %>
   </p>
 
   <%= render "work_info", work: @work %>

--- a/app/views/user_mailer/recipient_notification.text.erb
+++ b/app/views/user_mailer/recipient_notification.text.erb
@@ -10,7 +10,7 @@
 <%= creation_title_with_word_count(@work) %>
 <%= @collection ? collection_work_url(@collection, @work) : work_url(@work) %>
 
-by <%= creator_text(@work) %>
+<%= creation_attribution_text(@work) %>
 
 <%= render "work_info", work: @work %>
 

--- a/config/locales/mailers/en.yml
+++ b/config/locales/mailers/en.yml
@@ -164,6 +164,25 @@ en:
       work_added:
         html: The collection maintainers of %{collection_link} have added your work %{work_link} to their collection!
         text: The collection maintainers of "%{collection_title}" (%{collection_url}) have added your work "%{work_title}" (%{work_url}) to their collection!
+    batch_subscription_notification:
+      chapter_summary: Chapter Summary
+      creation_byline:
+        html: by %{creator_links}
+        text: by %{creators}
+      footer_note:
+        html: You're receiving this email because you've subscribed to %{subscription_link}. Follow the link to unsubscribe if you no longer wish to receive updates.
+        text: 'You''re receiving this email because you''ve subscribed to %{subscription_name}. Follow the link to unsubscribe if you no longer wish to receive updates: %{unsubscribe_url}'
+      preface:
+        chapter:
+          html: "%{creator_links} posted a new chapter of %{work_link_with_word_count}:"
+          text: "%{creators} posted a new chapter of %{work_title_with_word_count}:"
+        work:
+          backdated:
+            html: "%{creator_links} posted a backdated work:"
+            text: "%{creators} posted a backdated work:"
+          new:
+            html: "%{creator_links} posted a new work:"
+            text: "%{creators} posted a new work:"
     challenge_assignment_notification:
       any: Any
       assignment:

--- a/config/locales/mailers/en.yml
+++ b/config/locales/mailers/en.yml
@@ -50,17 +50,17 @@ en:
         formal: Sincerely,
         informal: Best,
       creation:
+        attribution:
+          anon: by Anonymous
+          named:
+            html: by %{creator_links}
+            text: by %{creators}
         link_with_word_count: "%{creation_link} (%{word_count})"
         title_with_chapter_number: Chapter %{position} of %{title}
         title_with_word_count: '"%{creation_title}" (%{word_count})'
         word_count:
           one: "%{count} word"
           other: "%{count} words"
-        attribution:
-          anon: by Anonymous
-          named:
-            html: "by %{creator_links}"
-            text: "by %{creators}"
       footer:
         general:
           about:
@@ -170,18 +170,18 @@ en:
         html: The collection maintainers of %{collection_link} have added your work %{work_link} to their collection!
         text: The collection maintainers of "%{collection_title}" (%{collection_url}) have added your work "%{work_title}" (%{work_url}) to their collection!
     batch_subscription_notification:
+      anon:
+        preface:
+          chapter:
+            html: 'Anonymous posted a new chapter of %{work_link_with_word_count}:'
+            text: 'Anonymous posted a new chapter of %{work_title_with_word_count}:'
+          work:
+            backdated: 'Anonymous posted a backdated work:'
+            new: 'Anonymous posted a new work:'
       chapter_summary: Chapter Summary
       footer_note:
         html: You're receiving this email because you've subscribed to %{subscription_link}. Follow the link to unsubscribe if you no longer wish to receive updates.
         text: 'You''re receiving this email because you''ve subscribed to %{subscription_name}. Follow the link to unsubscribe if you no longer wish to receive updates: %{unsubscribe_url}'
-      anon:
-        preface:
-          chapter:
-            html: "Anonymous posted a new chapter of %{work_link_with_word_count}:"
-            text: "Anonymous posted a new chapter of %{work_title_with_word_count}:"
-          work:
-            backdated: "Anonymous posted a backdated work:"
-            new: "Anonymous posted a new work:"
       named:
         preface:
           chapter:
@@ -218,13 +218,16 @@ en:
             work:
               multiple_entries: "[%{app_name}] Anonymous posted %{work_title} in the %{series_title} series %{more}"
               one_entry: "[%{app_name}] Anonymous posted %{work_title} in the %{series_title} series"
+        more:
+          one: and %{count} more
+          other: and %{count} more
         named:
           chapter:
             multiple_entries:
               one: "[%{app_name}] %{creators} posted %{chapter_header} of %{work_title} %{more}"
               other: "[%{app_name}] %{creators} posted %{chapter_header} of %{work_title} %{more}"
             one_entry:
-              one:  "[%{app_name}] %{creators} posted %{chapter_header} of %{work_title}"
+              one: "[%{app_name}] %{creators} posted %{chapter_header} of %{work_title}"
               other: "[%{app_name}] %{creators} posted %{chapter_header} of %{work_title}"
           series:
             chapter:
@@ -248,9 +251,6 @@ en:
             one_entry:
               one: "[%{app_name}] %{creators} posted %{work_title}"
               other: "[%{app_name}] %{creators} posted %{work_title}"
-        more:
-          one: "and %{count} more"
-          other: "and %{count} more"
     challenge_assignment_notification:
       any: Any
       assignment:

--- a/config/locales/mailers/en.yml
+++ b/config/locales/mailers/en.yml
@@ -56,6 +56,11 @@ en:
         word_count:
           one: "%{count} word"
           other: "%{count} words"
+        attribution:
+          anon: by Anonymous
+          named:
+            html: "by %{creator_links}"
+            text: "by %{creators}"
       footer:
         general:
           about:
@@ -166,23 +171,86 @@ en:
         text: The collection maintainers of "%{collection_title}" (%{collection_url}) have added your work "%{work_title}" (%{work_url}) to their collection!
     batch_subscription_notification:
       chapter_summary: Chapter Summary
-      creation_byline:
-        html: by %{creator_links}
-        text: by %{creators}
       footer_note:
         html: You're receiving this email because you've subscribed to %{subscription_link}. Follow the link to unsubscribe if you no longer wish to receive updates.
         text: 'You''re receiving this email because you''ve subscribed to %{subscription_name}. Follow the link to unsubscribe if you no longer wish to receive updates: %{unsubscribe_url}'
-      preface:
-        chapter:
-          html: "%{creator_links} posted a new chapter of %{work_link_with_word_count}:"
-          text: "%{creators} posted a new chapter of %{work_title_with_word_count}:"
-        work:
-          backdated:
-            html: "%{creator_links} posted a backdated work:"
-            text: "%{creators} posted a backdated work:"
-          new:
-            html: "%{creator_links} posted a new work:"
-            text: "%{creators} posted a new work:"
+      anon:
+        preface:
+          chapter:
+            html: "Anonymous posted a new chapter of %{work_link_with_word_count}:"
+            text: "Anonymous posted a new chapter of %{work_title_with_word_count}:"
+          work:
+            backdated: "Anonymous posted a backdated work:"
+            new: "Anonymous posted a new work:"
+      named:
+        preface:
+          chapter:
+            html:
+              one: "%{creator_links} posted a new chapter of %{work_link_with_word_count}:"
+              other: "%{creator_links} posted a new chapter of %{work_link_with_word_count}:"
+            text:
+              one: "%{creators} posted a new chapter of %{work_title_with_word_count}:"
+              other: "%{creators} posted a new chapter of %{work_title_with_word_count}:"
+          work:
+            backdated:
+              html:
+                one: "%{creator_links} posted a backdated work:"
+                other: "%{creator_links} posted a backdated work:"
+              text:
+                one: "%{creators} posted a backdated work:"
+                other: "%{creators} posted a backdated work:"
+            new:
+              html:
+                one: "%{creator_links} posted a new work:"
+                other: "%{creator_links} posted a new work:"
+              text:
+                one: "%{creators} posted a new work:"
+                other: "%{creators} posted a new work:"
+      subject:
+        anon:
+          chapter:
+            multiple_entries: "Anonymous posted %{chapter_header} of %{work_title} %{more}"
+            one_entry: "Anonymous posted %{chapter_header} of %{work_title}"
+          series:
+            chapter:
+              multiple_entries: "Anonymous posted %{chapter_header} of %{work_title} in the %{series_title} series %{more}"
+              one_entry: "Anonymous posted %{chapter_header} of %{work_title} in the %{series_title} series"
+            work:
+              multiple_entries: "Anonymous posted %{work_title} in the %{series_title} series %{more}"
+              one_entry: "Anonymous posted %{work_title} in the %{series_title} series"
+        named:
+          chapter:
+            multiple_entries:
+              one: "%{creators} posted %{chapter_header} of %{work_title} %{more}"
+              other: "%{creators} posted %{chapter_header} of %{work_title} %{more}"
+            one_entry:
+              one:  "%{creators} posted %{chapter_header} of %{work_title}"
+              other: "%{creators} posted %{chapter_header} of %{work_title}"
+          series:
+            chapter:
+              multiple_entries:
+                one: "%{creators} posted %{chapter_header} of %{work_title} in the %{series_title} series %{more}"
+                other: "%{creators} posted %{chapter_header} of %{work_title} in the %{series_title} series %{more}"
+              one_entry:
+                one: "%{creators} posted %{chapter_header} of %{work_title} in the %{series_title} series"
+                other: "%{creators} posted %{chapter_header} of %{work_title} in the %{series_title} series"
+            work:
+              multiple_entries:
+                one: "%{creators} posted %{work_title} in the %{series_title} series %{more}"
+                other: "%{creators} posted %{work_title} in the %{series_title} series %{more}"
+              one_entry:
+                one: "%{creators} posted %{work_title} in the %{series_title} series"
+                other: "%{creators} posted %{work_title} in the %{series_title} series"
+          work:
+            multiple_entries:
+              one: "%{creators} posted %{work_title} %{more}"
+              other: "%{creators} posted %{work_title} %{more}"
+            one_entry:
+              one: "%{creators} posted %{work_title}"
+              other: "%{creators} posted %{work_title}"
+        more:
+          one: "and %{count} more"
+          other: "and %{count} more"
     challenge_assignment_notification:
       any: Any
       assignment:

--- a/config/locales/mailers/en.yml
+++ b/config/locales/mailers/en.yml
@@ -170,20 +170,19 @@ en:
         html: The collection maintainers of %{collection_link} have added your work %{work_link} to their collection!
         text: The collection maintainers of "%{collection_title}" (%{collection_url}) have added your work "%{work_title}" (%{work_url}) to their collection!
     batch_subscription_notification:
-      anon:
-        preface:
+      chapter_summary: Chapter Summary
+      footer_note:
+        html: You're receiving this email because you've subscribed to %{subscription_link}. Follow the link to unsubscribe if you no longer wish to receive updates.
+        text: 'You''re receiving this email because you''ve subscribed to %{subscription_name}. Follow the link to unsubscribe if you no longer wish to receive updates: %{unsubscribe_url}'
+      preface:
+        anon:
           chapter:
             html: 'Anonymous posted a new chapter of %{work_link_with_word_count}:'
             text: 'Anonymous posted a new chapter of %{work_title_with_word_count}:'
           work:
             backdated: 'Anonymous posted a backdated work:'
             new: 'Anonymous posted a new work:'
-      chapter_summary: Chapter Summary
-      footer_note:
-        html: You're receiving this email because you've subscribed to %{subscription_link}. Follow the link to unsubscribe if you no longer wish to receive updates.
-        text: 'You''re receiving this email because you''ve subscribed to %{subscription_name}. Follow the link to unsubscribe if you no longer wish to receive updates: %{unsubscribe_url}'
-      named:
-        preface:
+        named:
           chapter:
             html:
               one: "%{creator_links} posted a new chapter of %{work_link_with_word_count}:"

--- a/config/locales/mailers/en.yml
+++ b/config/locales/mailers/en.yml
@@ -209,45 +209,45 @@ en:
       subject:
         anon:
           chapter:
-            multiple_entries: "Anonymous posted %{chapter_header} of %{work_title} %{more}"
-            one_entry: "Anonymous posted %{chapter_header} of %{work_title}"
+            multiple_entries: "[%{app_name}] Anonymous posted %{chapter_header} of %{work_title} %{more}"
+            one_entry: "[%{app_name}] Anonymous posted %{chapter_header} of %{work_title}"
           series:
             chapter:
-              multiple_entries: "Anonymous posted %{chapter_header} of %{work_title} in the %{series_title} series %{more}"
-              one_entry: "Anonymous posted %{chapter_header} of %{work_title} in the %{series_title} series"
+              multiple_entries: "[%{app_name}] Anonymous posted %{chapter_header} of %{work_title} in the %{series_title} series %{more}"
+              one_entry: "[%{app_name}] Anonymous posted %{chapter_header} of %{work_title} in the %{series_title} series"
             work:
-              multiple_entries: "Anonymous posted %{work_title} in the %{series_title} series %{more}"
-              one_entry: "Anonymous posted %{work_title} in the %{series_title} series"
+              multiple_entries: "[%{app_name}] Anonymous posted %{work_title} in the %{series_title} series %{more}"
+              one_entry: "[%{app_name}] Anonymous posted %{work_title} in the %{series_title} series"
         named:
           chapter:
             multiple_entries:
-              one: "%{creators} posted %{chapter_header} of %{work_title} %{more}"
-              other: "%{creators} posted %{chapter_header} of %{work_title} %{more}"
+              one: "[%{app_name}] %{creators} posted %{chapter_header} of %{work_title} %{more}"
+              other: "[%{app_name}] %{creators} posted %{chapter_header} of %{work_title} %{more}"
             one_entry:
-              one:  "%{creators} posted %{chapter_header} of %{work_title}"
-              other: "%{creators} posted %{chapter_header} of %{work_title}"
+              one:  "[%{app_name}] %{creators} posted %{chapter_header} of %{work_title}"
+              other: "[%{app_name}] %{creators} posted %{chapter_header} of %{work_title}"
           series:
             chapter:
               multiple_entries:
-                one: "%{creators} posted %{chapter_header} of %{work_title} in the %{series_title} series %{more}"
-                other: "%{creators} posted %{chapter_header} of %{work_title} in the %{series_title} series %{more}"
+                one: "[%{app_name}] %{creators} posted %{chapter_header} of %{work_title} in the %{series_title} series %{more}"
+                other: "[%{app_name}] %{creators} posted %{chapter_header} of %{work_title} in the %{series_title} series %{more}"
               one_entry:
-                one: "%{creators} posted %{chapter_header} of %{work_title} in the %{series_title} series"
-                other: "%{creators} posted %{chapter_header} of %{work_title} in the %{series_title} series"
+                one: "[%{app_name}] %{creators} posted %{chapter_header} of %{work_title} in the %{series_title} series"
+                other: "[%{app_name}] %{creators} posted %{chapter_header} of %{work_title} in the %{series_title} series"
             work:
               multiple_entries:
-                one: "%{creators} posted %{work_title} in the %{series_title} series %{more}"
-                other: "%{creators} posted %{work_title} in the %{series_title} series %{more}"
+                one: "[%{app_name}] %{creators} posted %{work_title} in the %{series_title} series %{more}"
+                other: "[%{app_name}] %{creators} posted %{work_title} in the %{series_title} series %{more}"
               one_entry:
-                one: "%{creators} posted %{work_title} in the %{series_title} series"
-                other: "%{creators} posted %{work_title} in the %{series_title} series"
+                one: "[%{app_name}] %{creators} posted %{work_title} in the %{series_title} series"
+                other: "[%{app_name}] %{creators} posted %{work_title} in the %{series_title} series"
           work:
             multiple_entries:
-              one: "%{creators} posted %{work_title} %{more}"
-              other: "%{creators} posted %{work_title} %{more}"
+              one: "[%{app_name}] %{creators} posted %{work_title} %{more}"
+              other: "[%{app_name}] %{creators} posted %{work_title} %{more}"
             one_entry:
-              one: "%{creators} posted %{work_title}"
-              other: "%{creators} posted %{work_title}"
+              one: "[%{app_name}] %{creators} posted %{work_title}"
+              other: "[%{app_name}] %{creators} posted %{work_title}"
         more:
           one: "and %{count} more"
           other: "and %{count} more"

--- a/config/locales/models/en.yml
+++ b/config/locales/models/en.yml
@@ -21,7 +21,7 @@ en:
           one: 'Category:'
           other: 'Categories:'
       chapters:
-        chapter_header: 'Chapter %{position}'
+        chapter_header: Chapter %{position}
       chapters/creatorships:
         base: 'Invalid creator:'
         pseud_id: Pseud

--- a/config/locales/models/en.yml
+++ b/config/locales/models/en.yml
@@ -20,6 +20,8 @@ en:
         name_with_colon:
           one: 'Category:'
           other: 'Categories:'
+      chapters:
+        chapter_header: 'Chapter %{position}'
       chapters/creatorships:
         base: 'Invalid creator:'
         pseud_id: Pseud

--- a/spec/helpers/mailer_helper_spec.rb
+++ b/spec/helpers/mailer_helper_spec.rb
@@ -165,136 +165,198 @@ describe MailerHelper do
   end
 
   describe "#batch_subscription_subject" do
-    subject { batch_subscription_subject(subscription, creation, additional_entries) }
+    subject do
+      batch_subscription_subject(subscription, creation, additional_entries)
+    end
     let(:creator) { create(:user, login: "creator").default_pseud }
     let(:cocreator) { create(:user, login: "cocreator").default_pseud }
-    let(:cocreated_work) { create(:work, authors: [creator, cocreator]) }
-    let(:first_creator_byline) { creation.pseuds.first.byline }
-    let(:last_creator_byline) { creation.pseuds.last.byline }
+    let(:creator_byline) { creation.pseuds.first.byline }
+    let(:cocreator_byline) { creation.pseuds.last.byline }
     let(:chapter_header) { creation.chapter_header }
+    let(:app_nick) { "[#{ArchiveConfig.APP_SHORT_NAME}]" }
 
     [0, 1, 2].each do |number|
       context "when notification has #{number} additional entries" do
         let(:additional_entries) { number }
-        let(:more) { additional_entries.zero? ? "" : " and #{additional_entries} more"}
+        let(:more) do
+          additional_entries.zero? ? "" : " and #{additional_entries} more"
+        end
 
         context "when subscription is to a series" do
-          let(:series) { create(:series_with_a_work) }
+          let(:work) do
+            create(:work,
+              authors: [creator],
+              series: [create(:series, title: "Series Title")],
+              title: "Work Title"
+            )
+          end
+          let(:series) { work.series.first }
           let(:subscription) { create(:subscription, subscribable: series) }
 
           context "when main creation is a chapter" do
-            let(:work) { series.works.first }
             let(:creation) { create(:chapter, work: work) }
 
-            it { is_expected.to eq("[#{ArchiveConfig.APP_SHORT_NAME}] #{first_creator_byline} posted #{chapter_header} of #{work.title} in the #{series.title} series#{more}") }
-
-            context "when work is anonymous" do
-              before do
-                work.collections = [create(:anonymous_collection)]
-                work.save
-              end
-
-              it { is_expected.to eq("[#{ArchiveConfig.APP_SHORT_NAME}] Anonymous posted #{chapter_header} of #{work.title} in the #{series.title} series#{more}") }
-            end
+            it { is_expected.to eq("#{app_nick} #{creator_byline} posted #{chapter_header} of #{work.title} in the #{series.title} series#{more}") }
 
             context "when chapter is co-created" do
-              let(:creation) { create(:chapter, work: work, authors: [work.pseuds.first, cocreator]) }
+              let(:creation) do
+                create(:chapter,
+                  authors: [creator, cocreator],
+                  work: work
+                )
+              end
 
-              it { is_expected.to eq("[#{ArchiveConfig.APP_SHORT_NAME}] #{first_creator_byline} and #{last_creator_byline} posted #{chapter_header} of #{work.title} in the #{series.title} series#{more}") }
+              it { is_expected.to eq("#{app_nick} #{creator_byline} and #{cocreator_byline} posted #{chapter_header} of #{work.title} in the #{series.title} series#{more}") }
+            end
+
+            context "when work is anonymous" do
+              let(:work) do
+                create(:work,
+                  authors: [creator],
+                  collections: [create(:anonymous_collection)],
+                  title: "Work Title",
+                  series: [create(:series, title: "Series Title")]
+                )
+              end
+
+              it { is_expected.to eq("#{app_nick} Anonymous posted #{chapter_header} of #{work.title} in the #{series.title} series#{more}") }
             end
           end
 
           context "when main creation is a work" do
-            let(:creation) { create(:work, series: [series]) }
-
-            it { is_expected.to eq("[#{ArchiveConfig.APP_SHORT_NAME}] #{first_creator_byline} posted #{creation.title} in the #{series.title} series#{more}") }
-
-            context "when work is anonymous" do
-              let(:creation) { create(:work, collections: [create(:anonymous_collection)], series: [series]) }
-
-              it { is_expected.to eq("[#{ArchiveConfig.APP_SHORT_NAME}] Anonymous posted #{work.title} in the #{series.title} series#{more}") }
+            let(:creation) do
+              create(:work,
+                authors: [creator],
+                series: [series],
+                title: "Work Title"
+              )
             end
 
-            context "when work is co-created" do
-              let(:creation) { create(:work, authors: [series.pseuds.first, cocreator], series: [series]) }
+            it { is_expected.to eq("#{app_nick} #{creator_byline} posted #{creation.title} in the #{series.title} series#{more}") }
 
-              it { is_expected.to eq("[#{ArchiveConfig.APP_SHORT_NAME}] #{first_creator_byline} and #{last_creator_byline} posted #{work.title} in the #{series.title} series#{more}") }
+            context "when work is co-created" do
+              let(:creation) do
+                create(:work,
+                  authors: [creator, cocreator],
+                  series: [series],
+                  title: "Work Title"
+                )
+              end
+
+              it { is_expected.to eq("#{app_nick} #{creator_byline} and #{cocreator_byline} posted #{work.title} in the #{series.title} series#{more}") }
+            end
+
+            context "when work is anonymous" do
+              let(:creation) do
+                create(:work,
+                  collections: [create(:anonymous_collection)],
+                  series: [series],
+                  title: "Work Title"
+                  )
+              end
+
+              it { is_expected.to eq("#{app_nick} Anonymous posted #{work.title} in the #{series.title} series#{more}") }
             end
           end
         end
 
         context "when subscription is to a user" do
-          let(:work) { create(:work, authors: [creator]) }
-          let(:anonymous_work) { create(:work, authors: [creator], collections: [create(:anonymous_collection)]) }
-          let(:subscription) { create(:subscription, subscribable: creator.user) }
+          let(:work) { create(:work, authors: [creator], title: "Work Title") }
+          let(:anonymous_work) do
+            create(:work,
+              authors: [creator],
+              collections: [create(:anonymous_collection)],
+              title: "Work Title"
+            )
+          end
+          let(:subscription) do
+            create(:subscription, subscribable: creator.user)
+          end
 
           context "when main creation is a chapter" do
-            let(:creation) { create(:chapter, work: work, authors: [creator]) }
+            let(:creation) { create(:chapter, authors: [creator], work: work) }
 
-            it { is_expected.to eq("[#{ArchiveConfig.APP_SHORT_NAME}] #{first_creator_byline} posted #{chapter_header} of #{work.title}#{more}") }
-
-            context "when work is anonymous" do
-              let(:work) { anonymous_work }
-
-              it { is_expected.to be_nil }
-            end
+            it { is_expected.to eq("#{app_nick} #{creator_byline} posted #{chapter_header} of #{work.title}#{more}") }
 
             context "when chapter is co-created" do
-              let(:creation) { create(:chapter, work: work, authors: [creator, cocreator]) }
+              let(:creation) do
+                create(:chapter, authors: [creator, cocreator], work: work )
+              end
 
-              it { is_expected.to eq("[#{ArchiveConfig.APP_SHORT_NAME}] #{first_creator_byline} and #{last_creator_byline} posted #{chapter_header} of #{work.title}#{more}") }
+              it { is_expected.to eq("#{app_nick} #{creator_byline} and #{cocreator_byline} posted #{chapter_header} of #{work.title}#{more}") }
             end
 
             context "when work is co-created but chapter is not" do
-              let(:creation) { create(:chapter, work: cocreated_work, authors: [creator]) }
+              let(:work) do
+                create(:work,
+                  authors: [creator, cocreator], title: "Work Title"
+                )
+              end
+              let(:creation) do
+                create(:chapter, work: work, authors: [creator])
+              end
 
-              it { is_expected.to eq("[#{ArchiveConfig.APP_SHORT_NAME}] #{first_creator_byline} posted #{chapter_header} of #{work.title}#{more}") }
+              it { is_expected.to eq("#{app_nick} #{creator_byline} posted #{chapter_header} of #{work.title}#{more}") }
             end
           end
 
           context "when main creation is a work" do
-            let(:creation) { work }
-
-            it { is_expected.to eq("[#{ArchiveConfig.APP_SHORT_NAME}] #{first_creator_byline} posted #{creation.title}#{more}") }
-
-            context "when work is co-created" do
-              let(:creation) { cocreated_work }
-
-              it { is_expected.to eq("[#{ArchiveConfig.APP_SHORT_NAME}] #{first_creator_byline} and #{last_creator_byline} posted #{creation.title}#{more}") }
+            let(:creation) do
+              create(:work, authors: [creator], title: "Work Title")
             end
 
-            context "when work is anonymous" do
-              let(:creation) { create(:work, collections: [create(:anonymous_collection)]) }
+            it { is_expected.to eq("#{app_nick} #{creator_byline} posted #{creation.title}#{more}") }
 
-              it { is_expected.to be_nil }
+            context "when work is co-created" do
+              let(:creation) do
+                create(:work,
+                  authors: [creator, cocreator],
+                  title: "Work Title"
+                )
+              end
+
+              it { is_expected.to eq("#{app_nick} #{creator_byline} and #{cocreator_byline} posted #{creation.title}#{more}") }
             end
           end
         end
 
         context "when subscription is to a work" do
-          let(:work) { create(:work, authors: [creator]) }
-          let(:creation) { create(:chapter, work: work, authors: [creator]) }
+          let(:work) { create(:work, authors: [creator], title: "Work Title") }
+          let(:creation) { create(:chapter, authors: [creator], work: work) }
           let(:subscription) { create(:subscription, subscribable: work) }
 
-          it { is_expected.to eq("[#{ArchiveConfig.APP_SHORT_NAME}] #{first_creator_byline} posted #{chapter_header} of #{work.title}#{more}") }
+          it { is_expected.to eq("#{app_nick} #{creator_byline} posted #{chapter_header} of #{work.title}#{more}") }
 
           context "when work is anonymous" do
-            let(:work) { create(:work, collections: [create(:anonymous_collection)]) }
+            let(:work) do
+              create(:work, collections: [create(:anonymous_collection)])
+            end
 
-            it { is_expected.to eq("[#{ArchiveConfig.APP_SHORT_NAME}] Anonymous posted #{chapter_header} of #{work.title}#{more}") }
+            it { is_expected.to eq("#{app_nick} Anonymous posted #{chapter_header} of #{work.title}#{more}") }
           end
 
           context "when chapter is co-created" do
-            let(:creation) { create(:chapter, work: work, authors: [creator, cocreator]) }
+            let(:creation) do
+              create(:chapter, work: work, authors: [creator, cocreator])
+            end
 
-            it { is_expected.to eq("[#{ArchiveConfig.APP_SHORT_NAME}] #{first_creator_byline} and #{last_creator_byline} posted #{chapter_header} of #{work.title}#{more}") }
+            it { is_expected.to eq("#{app_nick} #{creator_byline} and #{cocreator_byline} posted #{chapter_header} of #{work.title}#{more}") }
           end
 
           context "when work is co-created but chapter is not" do
-            let(:work) { cocreated_work }
-            let(:creation) { create(:chapter, work: work, authors: [creator]) }
+            let(:work) do
+              create(:work,
+                authors: [creator, cocreator], title: "Work Title"
+              )
+            end
+            let(:creation) do
+              create(:chapter,
+                authors: [creator],
+                work: work
+              )
+            end
 
-            it { is_expected.to eq("[#{ArchiveConfig.APP_SHORT_NAME}] #{first_creator_byline} posted #{chapter_header} of #{work.title}#{more}") }
+            it { is_expected.to eq("#{app_nick} #{creator_byline} posted #{chapter_header} of #{work.title}#{more}") }
           end
         end
       end

--- a/spec/helpers/mailer_helper_spec.rb
+++ b/spec/helpers/mailer_helper_spec.rb
@@ -168,6 +168,7 @@ describe MailerHelper do
     subject do
       batch_subscription_subject(subscription, creation, additional_entries)
     end
+
     let(:creator) { create(:user, login: "creator").default_pseud }
     let(:cocreator) { create(:user, login: "cocreator").default_pseud }
     let(:creator_byline) { creation.pseuds.first.byline }

--- a/spec/helpers/mailer_helper_spec.rb
+++ b/spec/helpers/mailer_helper_spec.rb
@@ -362,4 +362,202 @@ describe MailerHelper do
       end
     end
   end
+
+  describe "#batch_subscription_text_preface" do
+    subject do
+      batch_subscription_text_preface(creation)
+    end
+
+    let(:anon_work) do
+      create(:work, collections: [create(:anonymous_collection)])
+    end
+    let(:cocreated_work) do
+      create(:work, authors: [create(:pseud), create(:pseud)])
+    end
+
+    context "when creation is a chapter" do
+      let(:work_title) { "\"#{creation.work.title}\"" }
+      let(:work_word_count) { creation.work.word_count }
+      let(:work_creators) { creator_text(creation.work) }
+
+      context "when work has one creator" do
+        let(:creation) { create(:chapter) }
+
+        it "includes the work creator and their URL, says \"new chapter\", and includes the work title and word count" do
+          expect(subject).to eq("#{work_creators} posted a new chapter of #{work_title} (#{work_word_count} words):")
+        end
+      end
+
+      context "when work has two creators" do
+        let(:creation) { create(:chapter, work: cocreated_work) }
+
+        it "includes the work creators and their URLs, says \"new chapter\", and includes the work title and word count" do
+          expect(subject).to eq("#{work_creators} posted a new chapter of #{work_title} (#{work_word_count} words):")
+        end
+      end
+
+      context "when work is anonymous" do
+        let(:creation) { create(:chapter, work: anon_work) }
+
+        it { is_expected.to eq("Anonymous posted a new chapter of #{work_title} (#{work_word_count} words):") }
+      end
+    end
+
+    context "when creation is a work" do
+      let(:work_creators) { creator_text(creation) }
+
+      context "when work is new" do
+        context "when work has one creator" do
+          let(:creation) { create(:work) }
+
+          it "includes the work creator and their URL and says \"new work\"" do
+            expect(subject).to eq("#{work_creators} posted a new work:")
+          end
+        end
+
+        context "when work has two creators" do
+          let(:creation) { cocreated_work }
+
+          it "includes the work creators and their URLs and says \"new work\"" do
+            expect(subject).to eq("#{work_creators} posted a new work:")
+          end
+        end
+
+        context "when work is anonymous" do
+          let(:creation) { anon_work }
+
+          it { is_expected.to eq("Anonymous posted a new work:") }
+        end
+      end
+
+      context "when work is backdated" do
+        context "when work has one creator" do
+          let(:creation) { create(:work, backdate: true) }
+
+          it "includes the work creator and their URL and says \"backdated work\"" do
+            expect(subject).to eq("#{work_creators} posted a backdated work:")
+          end
+        end
+
+        context "when work has two creators" do
+          let(:creation)  { cocreated_work }
+
+          before { creation.update(backdate: true) }
+
+          it "includes the work creators and their URLs and says \"backdated work\"" do
+            expect(subject).to eq("#{work_creators} posted a backdated work:")
+          end
+        end
+
+        context "when work is anonymous" do
+          let(:creation)  { anon_work }
+
+          before { creation.update(backdate: true) }
+
+          it { is_expected.to eq("Anonymous posted a backdated work:") }
+        end
+      end
+    end
+  end
+
+  describe "#batch_subscription_html_preface" do
+    subject do
+      batch_subscription_html_preface(creation)
+    end
+
+    let(:anon_work) do
+      create(:work, collections: [create(:anonymous_collection)])
+    end
+    let(:cocreated_work) do
+      create(:work, authors: [create(:pseud), create(:pseud)])
+    end
+
+    context "when creation is a chapter" do
+      let(:work_link) do
+        style_creation_link(creation.work.title, work_url(creation.work))
+      end
+      let(:work_word_count) { creation.work.word_count }
+      let(:work_creator_links) { creator_links(creation.work) }
+
+      context "when work has one creator" do
+        let(:creation) { create(:chapter) }
+
+        it "links to the work creator, says \"new chapter\", links to the work, and provides the work word count" do
+          expect(subject).to eq("#{work_creator_links} posted a new chapter of #{work_link} (#{work_word_count} words):")
+        end
+      end
+
+      context "when work has two creators" do
+        let(:creation) { create(:chapter, work: cocreated_work) }
+
+        it "links to the work creators, says \"new chapter\", links to the work, and provides the work word count" do
+          expect(subject).to eq("#{work_creator_links} posted a new chapter of #{work_link} (#{work_word_count} words):")
+        end
+      end
+
+      context "when work is anonymous" do
+        let(:creation) { create(:chapter, work: anon_work) }
+
+        it "says \"Anonymous posted a new chapter,\" links to the work, and provides the work word count" do
+          expect(subject).to eq("Anonymous posted a new chapter of #{work_link} (#{work_word_count} words):")
+        end
+      end
+    end
+
+    context "when creation is a work" do
+      let(:work_creator_links) { creator_links(creation) }
+
+      context "when work is new" do
+        context "when work has one creator" do
+          let(:creation) { create(:work) }
+
+          it "links to the work creator and says \"posted a new work\"" do
+            expect(subject).to eq("#{work_creator_links} posted a new work:")
+          end
+        end
+
+        context "when work has two creators" do
+          let(:creation) { cocreated_work }
+
+          it "links to the work creators and says \"posted a new work\"" do
+            expect(subject).to eq("#{work_creator_links} posted a new work:")
+          end
+        end
+
+        context "when work is anonymous" do
+          let(:creation) { anon_work }
+
+          it { is_expected.to eq("Anonymous posted a new work:") }
+        end
+      end
+
+      context "when work is backdated" do
+        context "when work has one creator" do
+          let(:creation) { create(:work, backdate: true) }
+
+          it "links to the work creator and says \"posted a backdated work\"" do
+            expect(subject).to eq("#{work_creator_links} posted a backdated work:")
+          end
+        end
+
+        context "when work has two creators" do
+          let(:creation)  { cocreated_work }
+
+          before { creation.update(backdate: true) }
+
+          it "links to the work creators and says \"posted a backdated work\"" do
+            expect(subject).to eq("#{work_creator_links} posted a backdated work:")
+          end
+        end
+
+        context "when work is anonymous" do
+          let(:creation) { anon_work }
+
+          before { creation.update(backdate: true) }
+
+          it { is_expected.to eq("Anonymous posted a backdated work:") }
+        end
+      end
+    end
+  end
 end

--- a/spec/helpers/mailer_helper_spec.rb
+++ b/spec/helpers/mailer_helper_spec.rb
@@ -184,7 +184,8 @@ describe MailerHelper do
 
         context "when subscription is to a series" do
           let(:work) do
-            create(:work,
+            create(
+              :work,
               authors: [creator],
               series: [create(:series, title: "Series Title")],
               title: "Work Title"
@@ -200,7 +201,8 @@ describe MailerHelper do
 
             context "when chapter is co-created" do
               let(:creation) do
-                create(:chapter,
+                create(
+                  :chapter,
                   authors: [creator, cocreator],
                   work: work
                 )
@@ -211,7 +213,8 @@ describe MailerHelper do
 
             context "when work is anonymous" do
               let(:work) do
-                create(:work,
+                create(
+                  :work,
                   authors: [creator],
                   collections: [create(:anonymous_collection)],
                   title: "Work Title",
@@ -225,7 +228,8 @@ describe MailerHelper do
 
           context "when main creation is a work" do
             let(:creation) do
-              create(:work,
+              create(
+                :work,
                 authors: [creator],
                 series: [series],
                 title: "Work Title"
@@ -236,7 +240,8 @@ describe MailerHelper do
 
             context "when work is co-created" do
               let(:creation) do
-                create(:work,
+                create(
+                  :work,
                   authors: [creator, cocreator],
                   series: [series],
                   title: "Work Title"
@@ -248,11 +253,12 @@ describe MailerHelper do
 
             context "when work is anonymous" do
               let(:creation) do
-                create(:work,
+                create(
+                  :work,
                   collections: [create(:anonymous_collection)],
                   series: [series],
                   title: "Work Title"
-                  )
+                )
               end
 
               it { is_expected.to eq("#{app_nick} Anonymous posted #{work.title} in the #{series.title} series#{more}") }
@@ -263,7 +269,8 @@ describe MailerHelper do
         context "when subscription is to a user" do
           let(:work) { create(:work, authors: [creator], title: "Work Title") }
           let(:anonymous_work) do
-            create(:work,
+            create(
+              :work,
               authors: [creator],
               collections: [create(:anonymous_collection)],
               title: "Work Title"
@@ -280,7 +287,7 @@ describe MailerHelper do
 
             context "when chapter is co-created" do
               let(:creation) do
-                create(:chapter, authors: [creator, cocreator], work: work )
+                create(:chapter, authors: [creator, cocreator], work: work)
               end
 
               it { is_expected.to eq("#{app_nick} #{creator_byline} and #{cocreator_byline} posted #{chapter_header} of #{work.title}#{more}") }
@@ -288,8 +295,8 @@ describe MailerHelper do
 
             context "when work is co-created but chapter is not" do
               let(:work) do
-                create(:work,
-                  authors: [creator, cocreator], title: "Work Title"
+                create(
+                  :work, authors: [creator, cocreator], title: "Work Title"
                 )
               end
               let(:creation) do
@@ -309,9 +316,8 @@ describe MailerHelper do
 
             context "when work is co-created" do
               let(:creation) do
-                create(:work,
-                  authors: [creator, cocreator],
-                  title: "Work Title"
+                create(
+                  :work, authors: [creator, cocreator], title: "Work Title"
                 )
               end
 
@@ -345,16 +351,9 @@ describe MailerHelper do
 
           context "when work is co-created but chapter is not" do
             let(:work) do
-              create(:work,
-                authors: [creator, cocreator], title: "Work Title"
-              )
+              create(:work, authors: [creator, cocreator], title: "Work Title")
             end
-            let(:creation) do
-              create(:chapter,
-                authors: [creator],
-                work: work
-              )
-            end
+            let(:creation) { create(:chapter, authors: [creator], work: work) }
 
             it { is_expected.to eq("#{app_nick} #{creator_byline} posted #{chapter_header} of #{work.title}#{more}") }
           end

--- a/spec/helpers/mailer_helper_spec.rb
+++ b/spec/helpers/mailer_helper_spec.rb
@@ -440,7 +440,7 @@ describe MailerHelper do
         end
 
         context "when work has two creators" do
-          let(:creation)  { cocreated_work }
+          let(:creation) { cocreated_work }
 
           before { creation.update(backdate: true) }
 
@@ -450,7 +450,7 @@ describe MailerHelper do
         end
 
         context "when work is anonymous" do
-          let(:creation)  { anon_work }
+          let(:creation) { anon_work }
 
           before { creation.update(backdate: true) }
 
@@ -541,7 +541,7 @@ describe MailerHelper do
         end
 
         context "when work has two creators" do
-          let(:creation)  { cocreated_work }
+          let(:creation) { cocreated_work }
 
           before { creation.update(backdate: true) }
 

--- a/spec/helpers/mailer_helper_spec.rb
+++ b/spec/helpers/mailer_helper_spec.rb
@@ -164,13 +164,13 @@ describe MailerHelper do
     end
   end
 
-  describe "#subscription_subject" do
-    subject { subscription_subject(subscription, creation, additional_entries) }
+  describe "#batch_subscription_subject" do
+    subject { batch_subscription_subject(subscription, creation, additional_entries) }
     let(:creator) { create(:user, login: "creator").default_pseud }
     let(:cocreator) { create(:user, login: "cocreator").default_pseud }
     let(:cocreated_work) { create(:work, authors: [creator, cocreator]) }
-    let(:creator_byline) { creation.pseuds.first.byline }
-    let(:cocreator_byline) { creation.pseuds.last.byline }
+    let(:first_creator_byline) { creation.pseuds.first.byline }
+    let(:last_creator_byline) { creation.pseuds.last.byline }
     let(:chapter_header) { creation.chapter_header }
 
     [0, 1, 2].each do |number|
@@ -186,7 +186,7 @@ describe MailerHelper do
             let(:work) { series.works.first }
             let(:creation) { create(:chapter, work: work) }
 
-            it { is_expected.to eq("#{creator_byline} posted #{chapter_header} of #{work.title} in the #{series.title} series#{more}") }
+            it { is_expected.to eq("[#{ArchiveConfig.APP_SHORT_NAME}] #{first_creator_byline} posted #{chapter_header} of #{work.title} in the #{series.title} series#{more}") }
 
             context "when work is anonymous" do
               before do
@@ -194,31 +194,31 @@ describe MailerHelper do
                 work.save
               end
 
-              it { is_expected.to eq("Anonymous posted #{chapter_header} of #{work.title} in the #{series.title} series#{more}") }
+              it { is_expected.to eq("[#{ArchiveConfig.APP_SHORT_NAME}] Anonymous posted #{chapter_header} of #{work.title} in the #{series.title} series#{more}") }
             end
 
             context "when chapter is co-created" do
               let(:creation) { create(:chapter, work: work, authors: [work.pseuds.first, cocreator]) }
 
-              it { is_expected.to eq("#{creator_byline} and #{cocreator_byline} posted #{chapter_header} of #{work.title} in the #{series.title} series#{more}") }
+              it { is_expected.to eq("[#{ArchiveConfig.APP_SHORT_NAME}] #{first_creator_byline} and #{last_creator_byline} posted #{chapter_header} of #{work.title} in the #{series.title} series#{more}") }
             end
           end
 
           context "when main creation is a work" do
             let(:creation) { create(:work, series: [series]) }
 
-            it { is_expected.to eq("#{creator_byline} posted #{creation.title} in the #{series.title} series#{more}") }
+            it { is_expected.to eq("[#{ArchiveConfig.APP_SHORT_NAME}] #{first_creator_byline} posted #{creation.title} in the #{series.title} series#{more}") }
 
             context "when work is anonymous" do
               let(:creation) { create(:work, collections: [create(:anonymous_collection)], series: [series]) }
 
-              it { is_expected.to eq("Anonymous posted #{work.title} in the #{series.title} series#{more}") }
+              it { is_expected.to eq("[#{ArchiveConfig.APP_SHORT_NAME}] Anonymous posted #{work.title} in the #{series.title} series#{more}") }
             end
 
             context "when work is co-created" do
               let(:creation) { create(:work, authors: [series.pseuds.first, cocreator], series: [series]) }
 
-              it { is_expected.to eq("#{creator_byline} and #{cocreator_byline} posted #{work.title} in the #{series.title} series#{more}") }
+              it { is_expected.to eq("[#{ArchiveConfig.APP_SHORT_NAME}] #{first_creator_byline} and #{last_creator_byline} posted #{work.title} in the #{series.title} series#{more}") }
             end
           end
         end
@@ -231,7 +231,7 @@ describe MailerHelper do
           context "when main creation is a chapter" do
             let(:creation) { create(:chapter, work: work, authors: [creator]) }
 
-            it { is_expected.to eq("#{creator_byline} posted #{chapter_header} of #{work.title}#{more}") }
+            it { is_expected.to eq("[#{ArchiveConfig.APP_SHORT_NAME}] #{first_creator_byline} posted #{chapter_header} of #{work.title}#{more}") }
 
             context "when work is anonymous" do
               let(:work) { anonymous_work }
@@ -242,25 +242,25 @@ describe MailerHelper do
             context "when chapter is co-created" do
               let(:creation) { create(:chapter, work: work, authors: [creator, cocreator]) }
 
-              it { is_expected.to eq("#{creator_byline} and #{cocreator_byline} posted #{chapter_header} of #{work.title}#{more}") }
+              it { is_expected.to eq("[#{ArchiveConfig.APP_SHORT_NAME}] #{first_creator_byline} and #{last_creator_byline} posted #{chapter_header} of #{work.title}#{more}") }
             end
 
             context "when work is co-created but chapter is not" do
               let(:creation) { create(:chapter, work: cocreated_work, authors: [creator]) }
 
-              it { is_expected.to eq("#{creator_byline} posted #{chapter_header} of #{work.title}#{more}") }
+              it { is_expected.to eq("[#{ArchiveConfig.APP_SHORT_NAME}] #{first_creator_byline} posted #{chapter_header} of #{work.title}#{more}") }
             end
           end
 
           context "when main creation is a work" do
             let(:creation) { work }
 
-            it { is_expected.to eq("#{creator_byline} posted #{creation.title}#{more}") }
+            it { is_expected.to eq("[#{ArchiveConfig.APP_SHORT_NAME}] #{first_creator_byline} posted #{creation.title}#{more}") }
 
             context "when work is co-created" do
               let(:creation) { cocreated_work }
 
-              it { is_expected.to eq("#{creator_byline} and #{cocreator_byline} posted #{creation.title}#{more}") }
+              it { is_expected.to eq("[#{ArchiveConfig.APP_SHORT_NAME}] #{first_creator_byline} and #{last_creator_byline} posted #{creation.title}#{more}") }
             end
 
             context "when work is anonymous" do
@@ -276,25 +276,25 @@ describe MailerHelper do
           let(:creation) { create(:chapter, work: work, authors: [creator]) }
           let(:subscription) { create(:subscription, subscribable: work) }
 
-          it { is_expected.to eq("#{creator_byline} posted #{chapter_header} of #{work.title}#{more}") }
+          it { is_expected.to eq("[#{ArchiveConfig.APP_SHORT_NAME}] #{first_creator_byline} posted #{chapter_header} of #{work.title}#{more}") }
 
           context "when work is anonymous" do
             let(:work) { create(:work, collections: [create(:anonymous_collection)]) }
 
-            it { is_expected.to eq("Anonymous posted #{chapter_header} of #{work.title}#{more}") }
+            it { is_expected.to eq("[#{ArchiveConfig.APP_SHORT_NAME}] Anonymous posted #{chapter_header} of #{work.title}#{more}") }
           end
 
           context "when chapter is co-created" do
             let(:creation) { create(:chapter, work: work, authors: [creator, cocreator]) }
 
-            it { is_expected.to eq("#{creator_byline} and #{cocreator_byline} posted #{chapter_header} of #{work.title}#{more}") }
+            it { is_expected.to eq("[#{ArchiveConfig.APP_SHORT_NAME}] #{first_creator_byline} and #{last_creator_byline} posted #{chapter_header} of #{work.title}#{more}") }
           end
 
           context "when work is co-created but chapter is not" do
             let(:work) { cocreated_work }
             let(:creation) { create(:chapter, work: work, authors: [creator]) }
 
-            it { is_expected.to eq("#{creator_byline} posted #{chapter_header} of #{work.title}#{more}") }
+            it { is_expected.to eq("[#{ArchiveConfig.APP_SHORT_NAME}] #{first_creator_byline} posted #{chapter_header} of #{work.title}#{more}") }
           end
         end
       end

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -607,68 +607,8 @@ describe UserMailer do
       end
     end
 
-    context "when creation is a backdated work" do
-      let(:work) { create(:work, backdate: true, authors: [creator]) }
-      let(:subscription) { create(:subscription, subscribable: work.pseuds.first.user) }
-      let(:entries) { ["Work_#{work.id}"].to_json }
-
-      context "when creator is not anonymous" do
-        it "has the correct subject line" do
-          subject = "[#{ArchiveConfig.APP_SHORT_NAME}] #{creator.byline} posted #{work.title}"
-          expect(email).to have_subject(subject)
-        end
-
-        it "has the correct preface in the HTML version" do
-          expect(email).to have_html_part_content("#{style_pseud_link(creator)} posted a backdated work:")
-        end
-
-        it "has the correct preface in the text version" do
-          expect(email).to have_text_part_content("#{text_pseud(creator)} posted a backdated work:")
-        end
-      end
-
-      context "when creator is anonymous" do
-        let(:series) { create(:series) }
-        let(:subscription) { create(:subscription, subscribable: series) }
-        let(:work) { create(:work, backdate: true, collections: [create(:anonymous_collection)], series: [series]) }
-
-        it "has the correct subject line" do
-          subject = "[#{ArchiveConfig.APP_SHORT_NAME}] Anonymous posted #{work.title} in the #{series.title} series"
-          expect(email).to have_subject(subject)
-        end
-
-        it "has the correct preface in the HTML version" do
-          expect(email).to have_html_part_content("Anonymous posted a backdated work:")
-        end
-
-        it "has the correct preface in the text version" do
-          expect(email).to have_text_part_content("Anonymous posted a backdated work:")
-        end
-      end
-    end
-
     context "when creation is a chapter" do
       let(:entries) { ["Chapter_#{chapter.id}"].to_json }
-
-      context "when work creator is anonymous" do
-        let(:work) { create(:work, collections: [create(:anonymous_collection)]) }
-        let(:subscription) { create(:subscription, subscribable: work) }
-        let(:chapter) { create(:chapter, work: work) }
-
-        it "has the correct subject line" do
-          subject = "[#{ArchiveConfig.APP_SHORT_NAME}] Anonymous posted #{chapter.chapter_header} of #{work.title}"
-          expect(email).to have_subject(subject)
-        end
-
-        it "has the correct preface in the HTML version" do
-          work_link = "<i><b>#{style_link(work.title, work_url(work))}</b></i>"
-          expect(email).to have_html_part_content("Anonymous posted a new chapter of #{work_link} (#{work.word_count} words):")
-        end
-
-        it "has the correct preface in the text version" do
-          expect(email).to have_text_part_content("Anonymous posted a new chapter of \"#{work.title}\" (#{work.word_count} words):\n#{work_chapter_url(work, chapter)}")
-        end
-      end
 
       context "with different creators than the work" do
         let(:creator1) { create(:user).default_pseud }

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -607,26 +607,76 @@ describe UserMailer do
     end
 
     context "when creation is a backdated work" do
-      let(:creator) { work.pseuds.first }
-      let(:work) { create(:work, backdate: true) }
       let(:entries) { ["Work_#{work.id}"].to_json }
 
-      it "has the correct preface in the HTML version" do
-        expect(email).to have_html_part_content("#{style_pseud_link(creator)} posted a backdated work:")
+      context "when creator is not anonymous" do
+        let(:creator) { work.pseuds.first }
+        let(:work) { create(:work, backdate: true) }
+
+        it "has the correct subject line" do
+          subject = "[#{ArchiveConfig.APP_SHORT_NAME}] #{creator.byline} posted #{work.title}"
+          expect(email).to have_subject(subject)
+        end
+
+        it "has the correct preface in the HTML version" do
+          expect(email).to have_html_part_content("#{style_pseud_link(creator)} posted a backdated work:")
+        end
+
+        it "has the correct preface in the text version" do
+          expect(email).to have_text_part_content("#{text_pseud(creator)} posted a backdated work:")
+        end
       end
 
-      it "has the correct preface in the text version" do
-        expect(email).to have_text_part_content("#{text_pseud(creator)} posted a backdated work:")
+      context "when creator is anonymous" do
+        let(:work) { create(:work, backdate: true, collections: [create(:anonymous_collection)]) }
+
+        it "has the correct subject line" do
+          subject = "[#{ArchiveConfig.APP_SHORT_NAME}] Anonymous posted #{work.title}"
+          expect(email).to have_subject(subject)
+        end
+
+        it "has the correct preface in the HTML version" do
+          expect(email).to have_html_part_content("Anonymous posted a backdated work:")
+        end
+
+        it "has the correct preface in the text version" do
+          expect(email).to have_text_part_content("Anonymous posted a backdated work:")
+        end
       end
     end
 
     context "when creation is a chapter" do
+      let(:entries) { ["Chapter_#{chapter.id}"].to_json }
+
+      context "when work creator is anonymous" do
+        let(:work) { create(:work, collections: [create(:anonymous_collection)]) }
+        let(:chapter) { create(:chapter, work: work) }
+
+        it "has the correct subject line" do
+          subject = "[#{ArchiveConfig.APP_SHORT_NAME}] Anonymous posted #{chapter.chapter_header} of #{work.title}"
+          expect(email).to have_subject(subject)
+        end
+
+        it "has the correct preface in the HTML version" do
+          work_link = "<i><b>#{style_link(work.title, work_url(work))}</b></i>"
+          expect(email).to have_html_part_content("Anonymous posted a new chapter of #{work_link} (#{work.word_count} words):")
+        end
+
+        it "has the correct preface in the text version" do
+          expect(email).to have_text_part_content("Anonymous posted a new chapter of \"#{work.title}\" (#{work.word_count} words):\n#{work_chapter_url(work, chapter)}")
+        end
+      end
+
       context "with different creators than the work" do
         let(:creator1) { create(:user).default_pseud }
         let(:creator2) { create(:user).default_pseud }
         let(:work) { create(:work, authors: [creator1, creator2]) }
         let(:chapter) { create(:chapter, work: work, authors: [creator1]) }
-        let(:entries) { ["Chapter_#{chapter.id}"].to_json }
+
+        it "has the correct subject line" do
+          subject = "[#{ArchiveConfig.APP_SHORT_NAME}] #{creator1.byline} posted #{chapter.chapter_header} of #{work.title}"
+          expect(email).to have_subject(subject)
+        end
 
         it "has the correct preface in the HTML version" do
           work_link = "<i><b>#{style_link(work.title, work_url(work))}</b></i>"

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -690,15 +690,22 @@ describe UserMailer do
           expect(email).to have_text_part_content("#{text_pseud(creator1)} and #{text_pseud(creator2)} posted a new chapter of \"#{work.title}\" (#{work.word_count} words):\n#{work_chapter_url(work, chapter)}")
         end
 
-        it "has the correct chapter link with work byline in the HTML version" do
+        it "has the correct chapter link with work attribution in the HTML version" do
           chapter_link = "<i><b>#{style_link(chapter.full_chapter_title.html_safe, work_chapter_url(work, chapter))}</b></i>"
-          # expect(email).to have_html_part_content("#{chapter_link} (#{chapter.word_count} words)<br>by #{style_pseud_link(creator1)}")
           expect(email).to have_html_part_content("#{chapter_link} (#{chapter.word_count} words)<br>by #{style_pseud_link(creator1)} and #{style_pseud_link(creator2)}")
         end
 
-        it "has the correct chapter title with work byline in the text version" do
-          # expect(email).to have_text_part_content("\"#{chapter.full_chapter_title.html_safe}\" (#{chapter.word_count} words)\nby #{text_pseud(creator1)}")
+        it "has the correct chapter title with work attribution in the text version" do
           expect(email).to have_text_part_content("\"#{chapter.full_chapter_title.html_safe}\" (#{chapter.word_count} words)\nby #{text_pseud(creator1)} and #{text_pseud(creator2)}")
+        end
+
+        xit "has the correct chapter link with chapter attribution in the HTML version", pending("AO3-5804: Fix chapter attribution when different from work") do
+          chapter_link = "<i><b>#{style_link(chapter.full_chapter_title.html_safe, work_chapter_url(work, chapter))}</b></i>"
+          expect(email).to have_html_part_content("#{chapter_link} (#{chapter.word_count} words)<br>by #{style_pseud_link(creator1)}")
+        end
+
+        xit "has the correct chapter title with chapter attribution in the text version", pending("AO3-5804: Fix chapter attribution when different from work") do
+          expect(email).to have_text_part_content("\"#{chapter.full_chapter_title.html_safe}\" (#{chapter.word_count} words)\nby #{text_pseud(creator1)}")
         end
       end
     end

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -565,7 +565,7 @@ describe UserMailer do
     it_behaves_like "an email with a valid sender"
 
     it "has the correct subject line" do
-      subject = "[#{ArchiveConfig.APP_SHORT_NAME}] #{subscription.subject_text(work)} and 1 more"
+      subject = "[#{ArchiveConfig.APP_SHORT_NAME}] #{creator.byline} posted #{work.title} and 1 more"
       expect(email).to have_subject(subject)
     end
 

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -699,12 +699,12 @@ describe UserMailer do
           expect(email).to have_text_part_content("\"#{chapter.full_chapter_title.html_safe}\" (#{chapter.word_count} words)\nby #{text_pseud(creator1)} and #{text_pseud(creator2)}")
         end
 
-        xit "has the correct chapter link with chapter attribution in the HTML version", pending("AO3-5804: Fix chapter attribution when different from work") do
+        xit "has the correct chapter link with chapter attribution in the HTML version", pending("AO3-5805: Fix chapter attribution when different from work") do
           chapter_link = "<i><b>#{style_link(chapter.full_chapter_title.html_safe, work_chapter_url(work, chapter))}</b></i>"
           expect(email).to have_html_part_content("#{chapter_link} (#{chapter.word_count} words)<br>by #{style_pseud_link(creator1)}")
         end
 
-        xit "has the correct chapter title with chapter attribution in the text version", pending("AO3-5804: Fix chapter attribution when different from work") do
+        xit "has the correct chapter title with chapter attribution in the text version", pending("AO3-5805: Fix chapter attribution when different from work") do
           expect(email).to have_text_part_content("\"#{chapter.full_chapter_title.html_safe}\" (#{chapter.word_count} words)\nby #{text_pseud(creator1)}")
         end
       end

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -88,4 +88,106 @@ describe Subscription do
       expect(subscription.valid?).to be_falsey
     end
   end
+
+  describe "#valid_notification_entry?" do
+    let(:subscription) { build(:subscription) }
+    let(:series) { build(:series) }
+    let(:work) { build(:work) }
+    let(:chapter) { build(:chapter) }
+    let(:anon_work) { build(:work, collections: [build(:anonymous_collection)]) }
+    let(:anon_series) { build(:series, works: [anon_work]) }
+    let(:anon_chapter) { build(:chapter, work: anon_work) }
+
+    it "returns false when creation is not a work or chapter" do
+      expect(subscription.valid_notification_entry?(series)).to be_falsey
+    end
+
+    context "when subscribable is a series" do
+      context "when series is not anonymous" do
+        let(:subscription) { build(:subscription, subscribable: series) }
+
+        it "returns true for a non-anonymous work" do
+          expect(subscription.valid_notification_entry?(work)).to be_truthy
+        end
+
+        it "returns true for a non-anonymous chapter" do
+          expect(subscription.valid_notification_entry?(chapter)).to be_truthy
+        end
+
+        it "returns false for an anonymous work" do
+          expect(subscription.valid_notification_entry?(anon_work)).to be_falsey
+        end
+
+        it "returns false for an anonymous chapter" do
+          expect(subscription.valid_notification_entry?(anon_chapter)).to be_falsey
+        end
+      end
+
+      context "when series is anonymous" do
+        let(:subscription) { build(:subscription, subscribable: anon_series) }
+
+        it "returns false for a non-anonymous work" do
+          expect(subscription.valid_notification_entry?(work)).to be_falsey
+        end
+
+        it "returns false for a non-anoymous chapter" do
+          expect(subscription.valid_notification_entry?(chapter)).to be_falsey
+        end
+
+        it "returns true for an anonymous work" do
+          expect(subscription.valid_notification_entry?(anon_work)).to be_truthy
+        end
+
+        it "returns true for an anonymous chapter" do
+          expect(subscription.valid_notification_entry?(anon_chapter)).to be_truthy
+        end
+      end
+    end
+
+    context "when subscribable is a user" do
+      let(:subscription) { build(:subscription, subscribable: create(:user)) }
+
+      it "returns true for a non-anonymous work" do
+        expect(subscription.valid_notification_entry?(work)).to be_truthy
+      end
+
+      it "returns true for a non-anonymous chapter" do
+        expect(subscription.valid_notification_entry?(chapter)).to be_truthy
+      end
+
+      it "returns false for an anonymous work" do
+        expect(subscription.valid_notification_entry?(anon_work)).to be_falsey
+      end
+
+      it "returns false for an anonymous chapter" do
+        expect(subscription.valid_notification_entry?(anon_chapter)).to be_falsey
+      end
+    end
+
+    context "when subscribable is a work" do
+      context "when work is not anonymous" do
+        let(:subscription) { build(:subscription, subscribable: work) }
+
+        it "returns true for a non-anonymous chapter" do
+          expect(subscription.valid_notification_entry?(chapter)).to be_truthy
+        end
+
+        it "returns false for an anonymous chapter" do
+          expect(subscription.valid_notification_entry?(anon_chapter)).to be_falsey
+        end
+      end
+
+      context "when work is anonymous" do
+        let(:subscription) { build(:subscription, subscribable: anon_work) }
+
+        it "returns false for a non-anonymous chapter" do
+          expect(subscription.valid_notification_entry?(chapter)).to be_falsey
+        end
+
+        it "returns true for an anonymous chapter" do
+          expect(subscription.valid_notification_entry?(anon_chapter)).to be_truthy
+        end
+      end
+    end
+  end
 end

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -93,13 +93,39 @@ describe Subscription do
     let(:subscription) { build(:subscription) }
     let(:series) { build(:series) }
     let(:work) { build(:work) }
+    let(:draft) { build(:draft) }
     let(:chapter) { build(:chapter) }
     let(:anon_work) { build(:work, collections: [build(:anonymous_collection)]) }
     let(:anon_series) { build(:series, works: [anon_work]) }
     let(:anon_chapter) { build(:chapter, work: anon_work) }
+    let(:orphan_pseud) { create(:user, login: "orphan_account").default_pseud }
+
+    it "returns false when creation is nil" do
+      expect(subscription.valid_notification_entry?(nil)).to be_falsey
+    end
 
     it "returns false when creation is not a work or chapter" do
       expect(subscription.valid_notification_entry?(series)).to be_falsey
+    end
+
+    it "returns false when creations is an unposted work" do
+      expect(subscription.valid_notification_entry?(draft)).to be_falsey
+    end
+
+    it "returns false when chapter is an unposted chapter" do
+      expect(subscription.valid_notification_entry?(build(:chapter, :draft))).to be_falsey
+    end
+
+    it "returns false when chapter is on an unposted work" do
+      expect(subscription.valid_notification_entry?(build(:chapter, work: draft))).to be_falsey
+    end
+
+    it "returns false when work is by orphan_account" do
+      expect(subscription.valid_notification_entry?(create(:work, authors: [orphan_pseud]))).to be_falsey
+    end
+
+    it "returns false when chapter is by orphan_account" do
+      expect(subscription.valid_notification_entry?(create(:chapter, authors: [orphan_pseud]))).to be_falsey
     end
 
     context "when subscribable is a series" do


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-4309

## Purpose

Make it so we can translate the subscription email. This includes

* Move the code for generating its subject line out of the subscription model and into the mailer helper, since it did not seem like code responsible for generating text should be there.
* Internationale the text generated by the `chapter_header` method, which remains in the chapter model.
* Allow `anonymous?` to be called on a chapter so we can remove the `anonymous_creation?(creation)` method from the subscription model and simply call `anonymous?` on any creation.
* Add `valid_entry_for_subscription?(creation)` method to the subscription model, so I could both mov the existing "should we skip this entry?" logic out of the mailer and extend it. Example: the mailer specs were including a work entry in a notification for a work subscription, which should never happen. Because this should never happen, there was no subject translation to cover a subject line simply reading "Anonymous posted Work Title," and thus the tests failed. 
This test has been updated.
** I initially added `return unless valid_entry_for_subscription?(creation)` to the new subject generation method as well, since it's still possible to pass that method an impossible combination of subscription and creation (i.e., again, work subscription and work creation) in tests or by calling it somewhere outside its intended use. However, I took it back out because it seemed silly to run the same check twice (once in the mailer, once in the subject line). I could put it back in if we think that's smart, though.
* Add two `creation_attribution_` helper methods for generating the text "by Anonymous" or "by [creator or creators]" for the mailers, since Translation needs to be able to translate "by Anonymous" as one word. I removed the anonymous logic from the existing `creator_` helper methods and updated the views for the mailer where they were being used to handle anonymous (the gift notification).
* Update the `work_info` partial so you can optionally suppress the summary, allowing the existing code to be reused in the subscription mailer.
* Move the logic for the preface of the email (the part that tells you who posted what) into the helpers. It doesn't result in fewer lines of code, but it's easier to test that it produces the desired results.

The tests for `batch_subscription_subject` are pretty verbose, but that is for a reason. I wanted the output to be more readable than "akghlkjalk (pohgalhga) and alkghalteiu (athwtwapjg) posted My title is long enough in the Awesome Series 16 series and 2 more" so I wouldn't need to write descriptions for each one (which I think would ultimately involve even more lines of code). However, when I tried making the works and chapters and such more reusable, it quickly turned into a tangled mess of overwriting the work variable to means something subtly different in one context than another, too many before blocks and reloads, etc etc. 

If someone has an idea for how to make them shorter and easier to read while still hitting every possible subject variation, please go right ahead! (Note that I did not test any scenarios that do not have translations. If we want to do that, it's probably best to add the `return unless valid_entry_for_subscription?(creation)` guard clause and then check that the method produces `nil`.)

## Testing Instructions

Refer to Jira. (Which tbh needs a lot more instructions if we want to test every possible combination of subject line and email content.)

