### PR TITLE
AO3-6556 Update text to refer to account activation rather than confirmation

### DIFF
--- a/app/views/users/confirmation.html.erb
+++ b/app/views/users/confirmation.html.erb
@@ -10,11 +10,11 @@
     <%= t(".no_email_html", contact_support_link: (link_to t(".contact_support"), new_feedback_report_path)) %>
   </p>
   <p>
-    <% # We do days_to_purge_unactivated * 7 because it's actually weeks %>
-    <%= t(".must_activate_html", days_before_purge: AdminSetting.current.days_to_purge_unactivated? ? (AdminSetting.current.days_to_purge_unactivated * 7) : ArchiveConfig.DAYS_TO_PURGE_UNACTIVATED) %>
+    <%# We do days_to_purge_unactivated * 7 because it's actually weeks %>
+    <%= t(".must_activate_html", count: AdminSetting.current.days_to_purge_unactivated? ? (AdminSetting.current.days_to_purge_unactivated * 7) : ArchiveConfig.DAYS_TO_PURGE_UNACTIVATED) %>
   </p>
   <p>
-    <%= link_to t('.go_back'), root_path %>
+    <%= link_to t(".go_back"), root_path %>
   </p>
 </div>
 <!--/content-->

--- a/app/views/users/confirmation.html.erb
+++ b/app/views/users/confirmation.html.erb
@@ -7,7 +7,7 @@
     <%= t(".receive_email_html", return_address: tag.strong(ArchiveConfig.RETURN_ADDRESS)) %>
   </p>
   <p>
-    <%= t(".no_email_html", contact_support_link: (link_to t(".contact_support"), new_feedback_report_path)) %>
+    <%= t(".no_email_html", contact_support_link: link_to(t(".contact_support"), new_feedback_report_path)) %>
   </p>
   <p>
     <%# We do days_to_purge_unactivated * 7 because it's actually weeks %>

--- a/app/views/users/confirmation.html.erb
+++ b/app/views/users/confirmation.html.erb
@@ -1,20 +1,20 @@
 <!--Descriptive page name, messages and instructions-->
-<h2 class="heading"><%= ts("Almost Done!") %></h2>
+<h2 class="heading"><%= t(".page_heading") %></h2>
 <!--/descriptions-->
 <!--main content-->
 <div class="userstuff">
   <p>
-    <%= ts("You should soon receive a confirmation email at the address you gave us. This will have the link you need to follow in order to activate your account and complete the account creation process. The confirmation email will come from <strong>%{return_address}</strong> -- you might want to add this to your address book to make sure you get the email.", return_address: ArchiveConfig.RETURN_ADDRESS).html_safe %>
+    <%= t(".receive_email_html", return_address: ArchiveConfig.RETURN_ADDRESS) %>
   </p>
   <p>
-    <%= ts("If you haven't received this email within 24 hours, and you don't find our email in your spam filter or Social folder, please <a href='%{support_path}'>contact Support</a> for help.", support_path: new_feedback_report_path).html_safe %>
+    <%= t(".no_email_html", contact_support_link: (link_to t(".contact_support"), new_feedback_report_path)) %>
   </p>
   <p>
     <% # We do days_to_purge_unactivated * 7 because it's actually weeks %>
-    <%= ts("<strong>Important!</strong> You must confirm your email address within %{days_before_purge} days, or your account will expire. If this happens, you can sign up again using the same invitation.", days_before_purge: AdminSetting.current.days_to_purge_unactivated? ? (AdminSetting.current.days_to_purge_unactivated * 7) : ArchiveConfig.DAYS_TO_PURGE_UNACTIVATED).html_safe %>
+    <%= t(".must_activate_html", days_before_purge: AdminSetting.current.days_to_purge_unactivated? ? (AdminSetting.current.days_to_purge_unactivated * 7) : ArchiveConfig.DAYS_TO_PURGE_UNACTIVATED) %>
   </p>
   <p>
-    <%= link_to ts('Return to Archive front page'), root_path %>
+    <%= link_to t('.go_back'), root_path %>
   </p>
 </div>
 <!--/content-->

--- a/app/views/users/confirmation.html.erb
+++ b/app/views/users/confirmation.html.erb
@@ -4,14 +4,15 @@
 <!--main content-->
 <div class="userstuff">
   <p>
-    <%= t(".receive_email_html", return_address: ArchiveConfig.RETURN_ADDRESS) %>
+    <%= t(".receive_email", return_address: "<strong>" + ArchiveConfig.RETURN_ADDRESS + "</strong>").html_safe %>
   </p>
   <p>
     <%= t(".no_email_html", contact_support_link: (link_to t(".contact_support"), new_feedback_report_path)) %>
   </p>
   <p>
     <%# We do days_to_purge_unactivated * 7 because it's actually weeks %>
-    <%= t(".must_activate_html", count: AdminSetting.current.days_to_purge_unactivated? ? (AdminSetting.current.days_to_purge_unactivated * 7) : ArchiveConfig.DAYS_TO_PURGE_UNACTIVATED) %>
+    <strong><%= t(".important")%></strong>
+    <%= t(".must_activate", count: AdminSetting.current.days_to_purge_unactivated? ? (AdminSetting.current.days_to_purge_unactivated * 7) : ArchiveConfig.DAYS_TO_PURGE_UNACTIVATED) %>
   </p>
   <p>
     <%= link_to t(".go_back"), root_path %>

--- a/app/views/users/confirmation.html.erb
+++ b/app/views/users/confirmation.html.erb
@@ -4,7 +4,7 @@
 <!--main content-->
 <div class="userstuff">
   <p>
-    <%= t(".receive_email", return_address: "<strong>" + ArchiveConfig.RETURN_ADDRESS + "</strong>").html_safe %>
+    <%= t(".receive_email_html", return_address: tag.strong(ArchiveConfig.RETURN_ADDRESS)) %>
   </p>
   <p>
     <%= t(".no_email_html", contact_support_link: (link_to t(".contact_support"), new_feedback_report_path)) %>

--- a/config/locales/devise/en.yml
+++ b/config/locales/devise/en.yml
@@ -25,7 +25,7 @@ en:
         not_found_in_database: The password or user name you entered doesn't match our records. Please try again or <a href="%{reset_path}">reset your password</a>. If you still can't log in, please visit <a href="%{problems_path}">Problems When Logging In</a> for help.
         timeout: Your session expired. Please sign in again to continue.
         unauthenticated: You need to sign in or sign up before continuing.
-        unconfirmed: You have to confirm your email before continuing. Please check your email for the confirmation link.
+        unconfirmed: You have to activate your account before continuing. Please check your email for the activation link.
     mailer:
       confirmation_instructions:
         subject: Confirmation instructions

--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -588,12 +588,13 @@ en:
     confirmation:
       contact_support: contact Support
       go_back: Return to Archive front page
-      must_activate_html:
-        one: "<strong>Important!</strong> You must activate your account within %{count} day, or your account will expire. If this happens, you can sign up again using the same invitation."
-        other: "<strong>Important!</strong> You must activate your account within %{count} days, or your account will expire. If this happens, you can sign up again using the same invitation."
+      important: Important!
+      must_activate:
+        one: You must activate your account within %{count} day, or your account will expire. If this happens, you can sign up again using the same invitation.
+        other: You must activate your account within %{count} days, or your account will expire. If this happens, you can sign up again using the same invitation.
       no_email_html: If you haven't received this email within 24 hours, and you don't find our email in your spam filter or Social folder, please %{contact_support_link} for help.
       page_heading: Almost Done!
-      receive_email_html: You should soon receive an activation email at the address you gave us. This will have the link you need to follow in order to activate your account and complete the account creation process. The activation email will come from <strong>%{return_address}</strong> -- you might want to add this to your address book to make sure you get the email.
+      receive_email: You should soon receive an activation email at the address you gave us. This will have the link you need to follow in order to activate your account and complete the account creation process. The activation email will come from %{return_address} -- you might want to add this to your address book to make sure you get the email.
     delete_preview:
       cancel: Cancel
       co_creations:

--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -586,12 +586,12 @@ en:
       last_renamed: You last changed your user name on %{renamed_at}.
       more_info: For information on how changing your user name will affect your account, please check out the %{account_faq_link}. Note that changes to your user name may take several days or longer to appear. If you are still seeing your old user name on your works, bookmarks, series, or collections after a week, please %{contact_support_link}.
     confirmation:
+      contact_support: contact Support
+      go_back: Return to Archive front page
+      must_activate_html: "<strong>Important!</strong> You must activate your account within %{days_before_purge} days, or your account will expire. If this happens, you can sign up again using the same invitation."
+      no_email_html: If you haven't received this email within 24 hours, and you don't find our email in your spam filter or Social folder, please %{contact_support_link} for help.
       page_heading: Almost Done!
       receive_email_html: You should soon receive an activation email at the address you gave us. This will have the link you need to follow in order to activate your account and complete the account creation process. The activation email will come from <strong>%{return_address}</strong> -- you might want to add this to your address book to make sure you get the email.
-      no_email_html: If you haven't received this email within 24 hours, and you don't find our email in your spam filter or Social folder, please %{contact_support_link} for help.
-      contact_support: contact Support
-      must_activate_html: <strong>Important!</strong> You must activate your account within %{days_before_purge} days, or your account will expire. If this happens, you can sign up again using the same invitation.
-      go_back: Return to Archive front page
     delete_preview:
       cancel: Cancel
       co_creations:

--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -594,7 +594,7 @@ en:
         other: You must activate your account within %{count} days, or your account will expire. If this happens, you can sign up again using the same invitation.
       no_email_html: If you haven't received this email within 24 hours, and you don't find our email in your spam filter or Social folder, please %{contact_support_link} for help.
       page_heading: Almost Done!
-      receive_email: You should soon receive an activation email at the address you gave us. This will have the link you need to follow in order to activate your account and complete the account creation process. The activation email will come from %{return_address} -- you might want to add this to your address book to make sure you get the email.
+      receive_email_html: You should soon receive an activation email at the address you gave us. This will have the link you need to follow in order to activate your account and complete the account creation process. The activation email will come from %{return_address} -- you might want to add this to your address book to make sure you get the email.
     delete_preview:
       cancel: Cancel
       co_creations:

--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -585,6 +585,13 @@ en:
       contact_support: contact Support
       last_renamed: You last changed your user name on %{renamed_at}.
       more_info: For information on how changing your user name will affect your account, please check out the %{account_faq_link}. Note that changes to your user name may take several days or longer to appear. If you are still seeing your old user name on your works, bookmarks, series, or collections after a week, please %{contact_support_link}.
+    confirmation:
+      page_heading: Almost Done!
+      receive_email_html: You should soon receive an activation email at the address you gave us. This will have the link you need to follow in order to activate your account and complete the account creation process. The activation email will come from <strong>%{return_address}</strong> -- you might want to add this to your address book to make sure you get the email.
+      no_email_html: If you haven't received this email within 24 hours, and you don't find our email in your spam filter or Social folder, please %{contact_support_link} for help.
+      contact_support: contact Support
+      must_activate_html: <strong>Important!</strong> You must activate your account within %{days_before_purge} days, or your account will expire. If this happens, you can sign up again using the same invitation.
+      go_back: Return to Archive front page
     delete_preview:
       cancel: Cancel
       co_creations:

--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -588,7 +588,9 @@ en:
     confirmation:
       contact_support: contact Support
       go_back: Return to Archive front page
-      must_activate_html: "<strong>Important!</strong> You must activate your account within %{days_before_purge} days, or your account will expire. If this happens, you can sign up again using the same invitation."
+      must_activate_html:
+        one: "<strong>Important!</strong> You must activate your account within %{count} day, or your account will expire. If this happens, you can sign up again using the same invitation."
+        other: "<strong>Important!</strong> You must activate your account within %{count} days, or your account will expire. If this happens, you can sign up again using the same invitation."
       no_email_html: If you haven't received this email within 24 hours, and you don't find our email in your spam filter or Social folder, please %{contact_support_link} for help.
       page_heading: Almost Done!
       receive_email_html: You should soon receive an activation email at the address you gave us. This will have the link you need to follow in order to activate your account and complete the account creation process. The activation email will come from <strong>%{return_address}</strong> -- you might want to add this to your address book to make sure you get the email.

--- a/features/other_a/invite_request.feature
+++ b/features/other_a/invite_request.feature
@@ -95,7 +95,7 @@ Feature: Invite requests
         | user_registration_password               | password1 |
         | user_registration_password_confirmation  | password1 |
       And I press "Create Account"
-    Then I should see "You should soon receive a confirmation email at the address you gave us"
+    Then I should see "You should soon receive an activation email at the address you gave us"
       And I should see how long I have to activate my account
       And I should see "If you haven't received this email within 24 hours"
 

--- a/features/step_definitions/invite_steps.rb
+++ b/features/step_definitions/invite_steps.rb
@@ -150,7 +150,7 @@ end
 
 Then /^I should see how long I have to activate my account$/ do
   days_to_activate = AdminSetting.first.days_to_purge_unactivated? ? (AdminSetting.first.days_to_purge_unactivated * 7) : ArchiveConfig.DAYS_TO_PURGE_UNACTIVATED
-  step %{I should see "You must confirm your email address within #{days_to_activate} days"}
+  step %{I should see "You must activate your account within #{days_to_activate} days"}
 end
 
 Then /^"([^"]*)" should have "([^"]*)" invitations$/ do |login, invitation_count|


### PR DESCRIPTION
# Pull Request Checklist

* [X] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [X] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [X] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [X] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [X] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-6556

## Purpose

Update text that refers to account confirmation to refer to activation instead. Also, i18n the page. No test added, but there is a test that already covers the page that I modified.

## Testing Instructions

See Jira.

## Credit

Bilka (he/him)
