### PR TITLE
AO3-6567 Use % for translate_string instead of I18n.translate.

### DIFF
--- a/app/views/tag_set_nominations/_tag_nominations_by_fandom.html.erb
+++ b/app/views/tag_set_nominations/_tag_nominations_by_fandom.html.erb
@@ -1,14 +1,14 @@
 <% @tag_set_nomination.fandom_nominations.each_with_index do |nom, index| %>
   <%= f.fields_for :fandom_nominations, nom do |nom_form| %>
     <fieldset class="tagset">
-      <legend><%= ts("Fandom %{index}", :index => index+1) %></legend>
+      <legend><%= ts("Fandom %{index}", index: index + 1) %></legend>
       <dl>
         <dt><%= nom_form.label :tagname, ts("Fandom %{index}", :index => index+1) %></dt>
         <dd>
           <% if nom.approved || nom.rejected %>
             <%= nom.tagname %>  <%= nomination_status(nom) %>
           <% else %>
-            <div title="<%= ts("Fandom %{index}") %>"><%= nom_form.text_field :tagname, autocomplete_options("fandom", data: { autocomplete_token_limit: 1 }, class: "autocomplete") %></div>
+            <div title="<%= ts("Fandom %{index}", index: index + 1) %>"><%= nom_form.text_field :tagname, autocomplete_options("fandom", data: { autocomplete_token_limit: 1 }, class: "autocomplete") %></div>
           <% end %>
         </dd>
 

--- a/app/views/tag_set_nominations/_tag_nominations_by_fandom.html.erb
+++ b/app/views/tag_set_nominations/_tag_nominations_by_fandom.html.erb
@@ -3,7 +3,7 @@
     <fieldset class="tagset">
       <legend><%= ts("Fandom %{index}", index: index + 1) %></legend>
       <dl>
-        <dt><%= nom_form.label :tagname, ts("Fandom %{index}", :index => index+1) %></dt>
+        <dt><%= nom_form.label :tagname, ts("Fandom %{index}", index: index + 1) %></dt>
         <dd>
           <% if nom.approved || nom.rejected %>
             <%= nom.tagname %>  <%= nomination_status(nom) %>

--- a/config/initializers/monkeypatches/translate_string.rb
+++ b/config/initializers/monkeypatches/translate_string.rb
@@ -1,11 +1,11 @@
 module I18n
   class << self
-    # A shorthand for translation that takes a string as its first argument, which
-    # will be the default string.
+    # Formats a string. Used to mark strings that should eventually be
+    # translated with I18n, but aren't at the moment.
     #
     # Deprecated.
     def translate_string(str, **options)
-      translate(str, **options.merge(default: str))
+      str % options
     end
 
     alias :ts :translate_string
@@ -65,13 +65,11 @@ module ActionMailer #:nodoc:
   end
 end
 
-# Note: we define this separately for ActionView so that we get the controller/action name
-# in the key, and use the added scoping for translate in TranslationHelper.
 module ActionView
   module Helpers
     module TranslationHelper
       def translate_string(str, **options)
-        translate(str, **options.merge(default: str))
+        str % options
       end
 
       alias :ts :translate_string


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6567

## Purpose

Tries to improve the `translate_string`/`ts` function by making it use `%` instead of `I18n.translate`.