### PR TITLE
AO3-6575 Turn News posts sidebar into navigation

### DIFF
--- a/app/views/admin_posts/_sidebar.html.erb
+++ b/app/views/admin_posts/_sidebar.html.erb
@@ -1,8 +1,8 @@
-<div id="dashboard" class="admin region" role="navigation region">
+<nav id="dashboard" class="admin region" role="navigation region">
 	<h3 class="landmark heading">Page Summary</h3>
-	<ul class="navigation actions" role="menu">
+	<ul class="navigation actions">
 	  <% @admin_posts.each do |admin_post| %>
   		<li><%= span_if_current admin_post.title.html_safe + " (#{admin_post.count_visible_comments})", admin_post %></li>
     <% end %>
   </ul>
-</div>
+</nav>


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [ ] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [x] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [x] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-6575

## Purpose

What does this PR do?

On the AO3 News page, the sidebar has the role `menu`, but its direct children do not have a relevant ARIA role (e.g. `menuitem`).

The list shouldn't be a menu in the first place, but a navigation. The preferred element to use is `nav` (rather than a `div` with the role navigation).

## Testing Instructions

How can the Archive's QA team verify that this is working as you intended?

If you have a Jira account with access, please update or comment on the issue
with any new or missing testing instructions instead.

## References

Are there other relevant issues/pull requests/mailing list discussions?

## Credit

What name and pronouns should we use to credit you in the [Archive of Our Own's Release Notes](https://archiveofourown.org/admin_posts?tag=1)?

alien, they/them

If you have a Jira account, please include the same name in the "Full name"
field on your Jira profile, so we can assign you the issues you're working on.

*Please note that if you do not fill in this section, we will use your GitHub account name and
they/them pronouns.*
