### PR TITLE
Updated robots.txt to block chatGPT

### DIFF
--- a/public/robots.public.txt
+++ b/public/robots.public.txt
@@ -36,3 +36,7 @@ Disallow: /
 
 User-agent: Slurp
 Crawl-delay: 30
+
+#Disallow chatGPT access to any of the site to scrape.
+User-agent: GPTBot
+Disallow: /


### PR DESCRIPTION
# Pull Request Checklist

* [X] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [X] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [X] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [X] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [X] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

This is a general issue with chatGPT scraping the archive and trying to block it. 

## Purpose

This pull request adds the new code to the robots.txt that tells the GPTbot to ignore the entire website. more information can be found here at [https://platform.openai.com/docs/gptbot](https://platform.openai.com/docs/gptbot)

## Testing Instructions
the robots.txt just needs to be updated the way the site says to. 

## References

None at this time. 

## Credit

As ivedonestranger. 

