### PR TITLE
AO3-6589 Don't call ts() on user-generated text.

### DIFF
--- a/app/controllers/admin/blacklisted_emails_controller.rb
+++ b/app/controllers/admin/blacklisted_emails_controller.rb
@@ -15,7 +15,7 @@ class Admin::BlacklistedEmailsController < Admin::BaseController
     @page_subtitle = t(".browser_title")
 
     if @admin_blacklisted_email.save
-      flash[:notice] = ts("Email address #{@admin_blacklisted_email.email} banned.")
+      flash[:notice] = ts("Email address %{email} banned.", email: @admin_blacklisted_email.email)
       redirect_to admin_blacklisted_emails_path
     else
       render action: "index"
@@ -26,7 +26,7 @@ class Admin::BlacklistedEmailsController < Admin::BaseController
     @admin_blacklisted_email = authorize AdminBlacklistedEmail.find(params[:id])
     @admin_blacklisted_email.destroy
 
-    flash[:notice] = ts("Email address #{@admin_blacklisted_email.email} removed from banned emails list.")
+    flash[:notice] = ts("Email address %{email} removed from banned emails list.", email: @admin_blacklisted_email.email)
     redirect_to admin_blacklisted_emails_path
   end
 

--- a/app/controllers/bookmarks_controller.rb
+++ b/app/controllers/bookmarks_controller.rb
@@ -203,12 +203,12 @@ class BookmarksController < ApplicationController
     bookmark_params[:collection_names]&.split(",")&.map(&:strip)&.uniq&.each do |collection_name|
       collection = Collection.find_by(name: collection_name)
       if collection.nil?
-        errors << ts("#{collection_name} does not exist.")
+        errors << ts("%{name} does not exist.", name: collection_name)
       else
         if @bookmark.collections.include?(collection)
           next
         elsif collection.closed? && !collection.user_is_maintainer?(User.current_user)
-          errors << ts("#{collection.title} is closed to new submissions.")
+          errors << ts("%{title} is closed to new submissions.", title: collection.title)
         elsif @bookmark.add_to_collection(collection) && @bookmark.save
           if @bookmark.approved_collections.include?(collection)
             new_collections << collection
@@ -216,7 +216,7 @@ class BookmarksController < ApplicationController
             unapproved_collections << collection
           end
         else
-          errors << ts("Something went wrong trying to add collection #{collection.title}, sorry!")
+          errors << ts("Something went wrong trying to add collection %{title}, sorry!", title: collection.title)
         end
       end
     end

--- a/app/controllers/challenge_assignments_controller.rb
+++ b/app/controllers/challenge_assignments_controller.rb
@@ -181,11 +181,11 @@ class ChallengeAssignmentsController < ApplicationController
       case action
       when "default"
         # default_assignment_id = y/n
-        assignment.default || @errors << ts("We couldn't default the assignment for #{assignment.offer_byline}")
+        assignment.default || @errors << ts("We couldn't default the assignment for %{offer}", offer: assignment.offer_byline)
       when "undefault"
         # undefault_[assignment_id] = y/n - if set, undefault
         assignment.defaulted_at = nil
-        assignment.save || @errors << ts("We couldn't undefault the assignment covering #{assignment.request_byline}.")
+        assignment.save || @errors << ts("We couldn't undefault the assignment covering %{request}.", request: assignment.request_byline)
       when "approve"
         assignment.get_collection_item.approve_by_collection if assignment.get_collection_item
       when "cover"
@@ -193,9 +193,9 @@ class ChallengeAssignmentsController < ApplicationController
         next if val.blank? || assignment.pinch_hitter.try(:byline) == val
         pseud = Pseud.parse_byline(val)
         if pseud.nil?
-          @errors << ts("We couldn't find the user #{val} to assign that to.")
+          @errors << ts("We couldn't find the user %{val} to assign that to.", val: val)
         else
-          assignment.cover(pseud) || @errors << ts("We couldn't assign #{val} to cover #{assignment.request_byline}.")
+          assignment.cover(pseud) || @errors << ts("We couldn't assign %{val} to cover %{request}.", val: val, request: assignment.request_byline)
         end
       end
     end

--- a/app/controllers/challenge_assignments_controller.rb
+++ b/app/controllers/challenge_assignments_controller.rb
@@ -181,11 +181,11 @@ class ChallengeAssignmentsController < ApplicationController
       case action
       when "default"
         # default_assignment_id = y/n
-        assignment.default || @errors << ts("We couldn't default the assignment for %{offer}", offer: assignment.offer_byline)
+        assignment.default || (@errors << ts("We couldn't default the assignment for %{offer}", offer: assignment.offer_byline))
       when "undefault"
         # undefault_[assignment_id] = y/n - if set, undefault
         assignment.defaulted_at = nil
-        assignment.save || @errors << ts("We couldn't undefault the assignment covering %{request}.", request: assignment.request_byline)
+        assignment.save || (@errors << ts("We couldn't undefault the assignment covering %{request}.", request: assignment.request_byline))
       when "approve"
         assignment.get_collection_item.approve_by_collection if assignment.get_collection_item
       when "cover"
@@ -195,7 +195,7 @@ class ChallengeAssignmentsController < ApplicationController
         if pseud.nil?
           @errors << ts("We couldn't find the user %{val} to assign that to.", val: val)
         else
-          assignment.cover(pseud) || @errors << ts("We couldn't assign %{val} to cover %{request}.", val: val, request: assignment.request_byline)
+          assignment.cover(pseud) || (@errors << ts("We couldn't assign %{val} to cover %{request}.", val: val, request: assignment.request_byline))
         end
       end
     end

--- a/app/controllers/opendoors/external_authors_controller.rb
+++ b/app/controllers/opendoors/external_authors_controller.rb
@@ -33,7 +33,7 @@ class Opendoors::ExternalAuthorsController < ApplicationController
     unless @external_author.save
       flash[:error] = ts("We couldn't save that address.")
     else
-      flash[:notice] = ts("We have saved and blocked the email address #{@external_author.email}")
+      flash[:notice] = ts("We have saved and blocked the email address %{email}", email: @external_author.email)
     end
 
     redirect_to opendoors_tools_path
@@ -58,9 +58,9 @@ class Opendoors::ExternalAuthorsController < ApplicationController
     @invitation.invitee_email = @email
     @invitation.creator = User.find_by(login: "open_doors") || current_user
     if @invitation.save
-      flash[:notice] = ts("Claim invitation for #{@external_author.email} has been forwarded to #{@invitation.invitee_email}!")
+      flash[:notice] = ts("Claim invitation for %{author_email} has been forwarded to %{invitee_email}!", author_email: @external_author.email, invitee_email: @invitation.invitee_email)
     else
-      flash[:error] = ts("We couldn't forward the claim for #{@external_author.email} to that email address.") + @invitation.errors.full_messages.join(", ")
+      flash[:error] = ts("We couldn't forward the claim for %{author_email} to that email address.", author_email: @external_author.email) + @invitation.errors.full_messages.join(", ")
     end
 
     # redirect to external author listing for that user

--- a/app/controllers/opendoors/tools_controller.rb
+++ b/app/controllers/opendoors/tools_controller.rb
@@ -48,7 +48,7 @@ class Opendoors::ToolsController < ApplicationController
       # check for any other works 
       works = Work.where(imported_from_url: @imported_from_url)
       if works.count > 0 
-        flash[:error] = ts("There is already a work imported from the url #{@imported_from_url}.")
+        flash[:error] = ts("There is already a work imported from the url %{url}.", url: @imported_from_url)
       else
         # ok let's try to update
         @work.update_attribute(:imported_from_url, @imported_from_url)

--- a/app/controllers/redirect_controller.rb
+++ b/app/controllers/redirect_controller.rb
@@ -11,7 +11,7 @@ class RedirectController < ApplicationController
     else
       @work = Work.find_by_url(url)
       if @work
-        flash[:notice] = ts("You have been redirected here from #{url}. Please update the original link if possible!")
+        flash[:notice] = ts("You have been redirected here from %{url}. Please update the original link if possible!", url: url)
         redirect_to work_path(@work) and return
       else
         flash[:error] = ts("We could not find a work imported from that url in the Archive of Our Own, sorry! Try another url?")

--- a/app/controllers/tag_set_nominations_controller.rb
+++ b/app/controllers/tag_set_nominations_controller.rb
@@ -315,7 +315,7 @@ class TagSetNominationsController < ApplicationController
               @errors << ts("Couldn't find a #{type} nomination for %{name}", name: name)
               @force_expand[type] = true
             elsif !tagnom.change_tagname?(val)
-              @errors << ts("Invalid name change for %{name} to %{val}: %{msg}", name: name, val: val, msg: tagnom.errors.full_messages.join(', '))
+              @errors << ts("Invalid name change for %{name} to %{val}: %{msg}", name: name, val: val, msg: tagnom.errors.full_messages.join(", "))
               @force_expand[type] = true
             elsif action == "synonym"
               @synonym[type] << val

--- a/app/controllers/tag_set_nominations_controller.rb
+++ b/app/controllers/tag_set_nominations_controller.rb
@@ -312,10 +312,10 @@ class TagSetNominationsController < ApplicationController
             # this is the tricky one: make sure we can do this name change
             tagnom = TagNomination.for_tag_set(@tag_set).where(type: "#{type.classify}Nomination", tagname: name).first
             if !tagnom
-              @errors << ts("Couldn't find a #{type} nomination for #{name}")
+              @errors << ts("Couldn't find a #{type} nomination for %{name}", name: name)
               @force_expand[type] = true
             elsif !tagnom.change_tagname?(val)
-              @errors << ts("Invalid name change for #{name} to #{val}: %{msg}", msg: tagnom.errors.full_messages.join(', '))
+              @errors << ts("Invalid name change for %{name} to %{val}: %{msg}", name: name, val: val, msg: tagnom.errors.full_messages.join(', '))
               @force_expand[type] = true
             elsif action == "synonym"
               @synonym[type] << val

--- a/app/helpers/series_helper.rb
+++ b/app/helpers/series_helper.rb
@@ -55,7 +55,7 @@ module SeriesHelper
 
   def work_series_description(work, series)
     serial = SerialWork.where(work_id: work.id, series_id: series.id).first
-    ts("Part <strong>#{serial.position}</strong> of #{link_to(series.title, series)}").html_safe
+    ts("Part <strong>%{position}</strong> of %{title}".html_safe, position: serial.position, title: link_to(series.title, series))
   end
 
   def series_list_for_feeds(work)

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -179,7 +179,7 @@ class Work < ApplicationRecord
       next if self.challenge_assignments.map(&:requesting_pseud).include?(gift.pseud)
       next if self.challenge_claims.reject { |c| c.request_prompt.anonymous? }.map(&:requesting_pseud).include?(gift.pseud)
 
-      self.errors.add(:base, ts("#{gift.pseud.byline} does not accept gifts."))
+      self.errors.add(:base, ts("%{byline} does not accept gifts.", byline: gift.pseud.byline))
     end
   end
 

--- a/app/models/work_skin.rb
+++ b/app/models/work_skin.rb
@@ -9,7 +9,7 @@ class WorkSkin < Skin
     return if self.css.blank?
     check = lambda {|ruleset, property, value|
       if property == "position" && value == "fixed"
-        errors.add(:base, ts("The #{property} property in #{ruleset.selectors.join(', ')} cannot have the value #{value} in Work skins, sorry!"))
+        errors.add(:base, ts("The %{property} property in %{selectors} cannot have the value %{value} in Work skins, sorry!", property: property, selectors: ruleset.selectors.join(', '), value: value))
         return false
       end
       return true

--- a/app/models/work_skin.rb
+++ b/app/models/work_skin.rb
@@ -9,7 +9,7 @@ class WorkSkin < Skin
     return if self.css.blank?
     check = lambda {|ruleset, property, value|
       if property == "position" && value == "fixed"
-        errors.add(:base, ts("The %{property} property in %{selectors} cannot have the value %{value} in Work skins, sorry!", property: property, selectors: ruleset.selectors.join(', '), value: value))
+        errors.add(:base, ts("The %{property} property in %{selectors} cannot have the value %{value} in Work skins, sorry!", property: property, selectors: ruleset.selectors.join(", "), value: value))
         return false
       end
       return true

--- a/app/views/archive_faqs/show.html.erb
+++ b/app/views/archive_faqs/show.html.erb
@@ -28,7 +28,7 @@
       <div id="toc" class="toc" role="navigation">
         <h3 class="heading">
           <% #TODO: Change this back to 'Questions in the NAME Category' once Translation system in place %>
-          <%= ts("#{@archive_faq.title}") %>
+          <%= @archive_faq.title %>
         </h3>
         <ul role="navigation">
           <% for q in @questions %>

--- a/app/views/bookmarks/_bookmark_user_module.html.erb
+++ b/app/views/bookmarks/_bookmark_user_module.html.erb
@@ -23,7 +23,7 @@
     <% unless bookmark.collections.blank? %>
       <% bookmark.collections.each do |modded| %>
         <% if modded.moderated? && !bookmark.approved_collections.include?(modded) && is_author_of?(bookmark)  %>
-          <p class="notice"><%= ts("The collection #{modded.title} is currently moderated. Your bookmark must be approved by the collection maintainers before being listed there.") %></p>
+          <p class="notice"><%= ts("The collection %{title} is currently moderated. Your bookmark must be approved by the collection maintainers before being listed there.", title: modded.title) %></p>
         <% end %>
       <% end %>
       <% unless bookmark.approved_collections.empty? && !is_author_of?(bookmark) %>

--- a/app/views/menu/_menu_fandoms.html.erb
+++ b/app/views/menu/_menu_fandoms.html.erb
@@ -3,7 +3,7 @@
   <% cache "menu-fandoms-version4", skip_digest: true do %>
     <% Media.for_menu.each do |medium| %>
       <% unless medium.id.nil? %>
-        <li id="medium_<%= medium.id %>"><%= link_to ts("#{medium.name}", key: 'header.fandom'), medium_fandoms_path(medium) %></li>
+        <li id="medium_<%= medium.id %>"><%= link_to medium.name, medium_fandoms_path(medium) %></li>
       <% end %>
     <% end %>
   <% end %>

--- a/app/views/works/_search_box.html.erb
+++ b/app/views/works/_search_box.html.erb
@@ -4,7 +4,7 @@
     <p>
       <%= label_tag :site_search, ts('Work Search:', key: 'header'), :class => 'landmark' %>
       <%= f.text_field :query, :class => 'text', :id => 'site_search', :"aria-describedby" => 'site_search_tooltip' %>
-      <span class="tip" role="tooltip" id="site_search_tooltip"><%= ts('tip:', key: 'header') %> <%= ts("#{random_search_tip}", key: 'searchtip') %></span>
+      <span class="tip" role="tooltip" id="site_search_tooltip"><%= ts('tip:', key: 'header') %> <%= random_search_tip %></span>
       <span class="submit actions"><%= submit_tag ts('Search', key: 'header'), :class => 'button', :name => nil %></span>
     </p>
   </fieldset>

--- a/lib/css_cleaner.rb
+++ b/lib/css_cleaner.rb
@@ -63,17 +63,17 @@ module CssCleaner
         clean_declarations = ""
         rs.each_declaration do |property, value, is_important|
           if property.blank? || value.blank?
-            errors.add(:base, ts("The code for #{rs.selectors.join(',')} doesn't seem to be a valid CSS rule."))
+            errors.add(:base, ts("The code for %{selectors} doesn't seem to be a valid CSS rule.", selectors: rs.selectors.join(',')))
           elsif sanitize_css_property(property).blank?
-            errors.add(:base, ts("We don't currently allow the CSS property #{property} -- please notify support if you think this is an error."))
+            errors.add(:base, ts("We don't currently allow the CSS property %{property} -- please notify support if you think this is an error.", property: property))
           elsif (cleanval = sanitize_css_declaration_value(property, value)).blank?
-            errors.add(:base, ts("The #{property} property in #{rs.selectors.join(', ')} cannot have the value #{value}, sorry!"))
+            errors.add(:base, ts("The %{property} property in %{selectors} cannot have the value %{value}, sorry!", property: property, selectors: rs.selectors.join(', '), value: value))
           elsif (!caller_check || caller_check.call(rs, property, value))
             clean_declarations += "  #{property}: #{cleanval}#{is_important ? ' !important' : ''};\n"
           end
         end
         if clean_declarations.blank?
-          errors.add(:base, ts("There don't seem to be any rules for #{rs.selectors.join(',')}"))
+          errors.add(:base, ts("There don't seem to be any rules for %{selectors}", selectors: rs.selectors.join(',')))
         else
           # everything looks ok, add it to the css
           clean_css += "#{selectors.join(",\n")} {\n"

--- a/lib/css_cleaner.rb
+++ b/lib/css_cleaner.rb
@@ -63,17 +63,17 @@ module CssCleaner
         clean_declarations = ""
         rs.each_declaration do |property, value, is_important|
           if property.blank? || value.blank?
-            errors.add(:base, ts("The code for %{selectors} doesn't seem to be a valid CSS rule.", selectors: rs.selectors.join(',')))
+            errors.add(:base, ts("The code for %{selectors} doesn't seem to be a valid CSS rule.", selectors: rs.selectors.join(",")))
           elsif sanitize_css_property(property).blank?
             errors.add(:base, ts("We don't currently allow the CSS property %{property} -- please notify support if you think this is an error.", property: property))
           elsif (cleanval = sanitize_css_declaration_value(property, value)).blank?
-            errors.add(:base, ts("The %{property} property in %{selectors} cannot have the value %{value}, sorry!", property: property, selectors: rs.selectors.join(', '), value: value))
+            errors.add(:base, ts("The %{property} property in %{selectors} cannot have the value %{value}, sorry!", property: property, selectors: rs.selectors.join(", "), value: value))
           elsif (!caller_check || caller_check.call(rs, property, value))
             clean_declarations += "  #{property}: #{cleanval}#{is_important ? ' !important' : ''};\n"
           end
         end
         if clean_declarations.blank?
-          errors.add(:base, ts("There don't seem to be any rules for %{selectors}", selectors: rs.selectors.join(',')))
+          errors.add(:base, ts("There don't seem to be any rules for %{selectors}", selectors: rs.selectors.join(",")))
         else
           # everything looks ok, add it to the css
           clean_css += "#{selectors.join(",\n")} {\n"


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6589

## Purpose

Rewrites some calls to `ts()` that used to pass user-generated text as part of the format string, potentially causing errors if that user-generated text contains a `%` sign.