### PR TITLE
AO3-6505 Preload approved_collections and stat_counter for work blurbs.

### DIFF
--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -1008,7 +1008,7 @@ class Work < ApplicationRecord
   }
 
   scope :with_includes_for_blurb, lambda {
-    includes(:pseuds)
+    includes(:pseuds, :approved_collections, :stat_counter)
   }
 
   scope :for_blurb, -> { with_columns_for_blurb.with_includes_for_blurb }

--- a/spec/requests/works_n_plus_one_spec.rb
+++ b/spec/requests/works_n_plus_one_spec.rb
@@ -29,7 +29,7 @@ describe "n+1 queries in the WorksController" do
         run_all_indexing_jobs
       end
 
-      it "performs around 13 queries per work" do
+      it "performs around 11 queries per work" do
         # TODO: Ideally, we'd like the uncached work listings to also have a
         # constant number of queries, instead of the linear number of queries
         # we're checking for here. But we also don't want to put too much
@@ -38,7 +38,7 @@ describe "n+1 queries in the WorksController" do
         expect do
           subject.call
           expect(response.body.scan('<li id="work_').size).to eq(current_scale.to_i)
-        end.to perform_linear_number_of_queries(slope: 13).with_warming_up
+        end.to perform_linear_number_of_queries(slope: 11).with_warming_up
       end
     end
   end


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6505

## Purpose

Adds `:approved_collections` and `:stat_counter` to the `includes` for the work blurb, reducing the number of database queries required on cache misses for the work blurb.