### PR TITLE
AO3-6540 Suspended and banned users should not be able to update chapter positions 

### DIFF
--- a/app/controllers/chapters_controller.rb
+++ b/app/controllers/chapters_controller.rb
@@ -1,7 +1,7 @@
 class ChaptersController < ApplicationController
   # only registered users and NOT admin should be able to create new chapters
   before_action :users_only, except: [ :index, :show, :destroy, :confirm_delete ]
-  before_action :check_user_status, only: [:new, :create, :update]
+  before_action :check_user_status, only: [:new, :create, :update, :update_positions]
   before_action :check_user_not_suspended, only: [:edit, :confirm_delete, :destroy]
   before_action :load_work
   # only authors of a work should be able to edit its chapters

--- a/spec/controllers/chapters_controller_spec.rb
+++ b/spec/controllers/chapters_controller_spec.rb
@@ -862,6 +862,28 @@ describe ChaptersController do
           expect(chapter4.reload.position).to eq(4)
         end
       end
+
+      context "when the logged in user is suspended" do
+        before do
+          fake_login_known_user(suspended_user)
+        end
+        
+        it "errors and redirects to user page" do
+          post :update_positions, params: { work_id: suspended_users_work.id, chapter: [suspended_users_work_chapter2, suspended_users_work.chapters.first] }
+          expect(flash[:error]).to include("Your account has been suspended")
+        end
+      end
+  
+      context "when the logged in user is banned" do
+        before do
+          fake_login_known_user(banned_user)
+        end
+        
+        it "errors and redirects to user page" do
+          post :update_positions, params: { work_id: banned_users_work.id, chapter: [banned_users_work_chapter2, banned_users_work.chapters.first] }
+          expect(flash[:error]).to include("Your account has been banned")
+        end
+      end
     end
   end
 


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [x] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [x] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [x] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-6540

## Purpose

Fix the slip-up QA spotted.

Not technically my fault, it looks like update_positions was always allowed for suspended and banned users even before I started working on this ¯\_(ツ)_/¯ good job on wick for catching this!

## Testing Instructions

See JIRA ticket.

## References

https://github.com/otwcode/otwarchive/pull/4552

## Credit

EchoEkhi
