### PR TITLE
AO3-6590 Add reviewdog for linting ERB files

### DIFF
--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -1,0 +1,27 @@
+# Based on https://github.com/tk0miya/action-erblint/blob/main/README.md#example-usage
+
+name: Reviewdog ERB Lint
+
+on: [pull_request]
+
+permissions:
+  checks: write
+
+jobs:
+  erb-lint:
+    name: ERB Lint runner
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+
+      - name: Set up Ruby and run bundle install
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+
+      - name: erb-lint
+        uses: tk0miya/action-erblint@667687e73b44e7b7a710a1204b180f49f80ebb5e
+        with:
+          use_bundler: true
+          reporter: github-pr-check # default

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -1,6 +1,6 @@
 # Based on https://github.com/tk0miya/action-erblint/blob/main/README.md#example-usage
 
-name: Reviewdog ERB Lint
+name: Reviewdog
 
 on: [pull_request]
 

--- a/.hound.yml
+++ b/.hound.yml
@@ -1,10 +1,6 @@
 # Available linter versions:
 # http://help.houndci.com/en/articles/2461415-supported-linters
 
-erblint:
-  enabled: true
-  config_file: .erb-lint.yml
-
 jshint:
   config_file: .jshintrc
   ignore_file: .jshintignore


### PR DESCRIPTION
# Pull Request Checklist

* [X] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [X] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [ ] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [X] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [X] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-6590

## Purpose

Use reviewdog to run ERB lint on pull requests because Hound does not run it (despite being configured for it).

Demo PR from same repo: https://github.com/Bilka2/otwarchive/pull/1
Demo PR from forked repo: https://github.com/Bilka2/otwarchive/pull/2 (see reviewdog's docs on [Graceful degradation for PRs from forks](https://github.com/reviewdog/reviewdog#graceful-degradation-for-pull-requests-from-forked-repositories))

## Testing Instructions

See Jira.

## Credit

Bilka (he/him)
