### PR TITLE
AO3-5052 Update series byline on username or pseud update

### DIFF
--- a/app/models/pseud.rb
+++ b/app/models/pseud.rb
@@ -399,7 +399,8 @@ class Pseud < ApplicationRecord
 
   def expire_caches
     if saved_change_to_name?
-      self.works.each{ |work| work.touch }
+      works.touch_all
+      series.touch_all
     end
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -158,6 +158,7 @@ class User < ApplicationRecord
 
   def expire_caches
     return unless saved_change_to_login?
+    series.touch_all
     self.works.each do |work|
       work.touch
       work.expire_caches

--- a/features/other_a/pseuds.feature
+++ b/features/other_a/pseuds.feature
@@ -173,3 +173,21 @@ Scenario: Many pseuds
   When there are 10 pseuds per page
     And I view my profile
   Then I should see "Zaphod, Agrajag, Betelgeuse, and Slartibartfast" within "dl.meta"
+
+Scenario: Edit pseud updates series blurbs
+
+  Given I am logged in as "Myself"
+    And I add the work "Great Work" to series "Best Series" as "Me2"
+  When I go to the dashboard page for user "Myself" with pseud "Me2"
+    And I follow "Series"
+  Then I should see "Best Series by Me2 (Myself)"
+
+  When I go to my profile page
+    And I follow "Manage My Pseuds"
+    And I follow "Edit Me2"
+    And I fill in "Name" with "Me3"
+    And I press "Update"
+  Then I should see "Pseud was successfully updated."
+
+  When I follow "Series"
+  Then I should see "Best Series by Me3 (Myself)"

--- a/features/users/user_rename.feature
+++ b/features/users/user_rename.feature
@@ -147,3 +147,19 @@ Feature:
       And I view the work "Interesting" with comments
     Then I should see "after" within ".comment h4.byline"
       And I should not see "mine (before)"
+
+  Scenario: Changing username updates series blurbs
+    Given I have no users
+      And I am logged in as "oldusername" with password "password"
+      And I add the work "Great Work" to series "Best Series"
+    When I go to the dashboard page for user "oldusername" with pseud "oldusername"
+      And I follow "Series"
+    Then I should see "Best Series by oldusername"
+    When I visit the change username page for oldusername
+      And I fill in "New user name" with "newusername"
+      And I fill in "Password" with "password"
+      And I press "Change User Name"
+    Then I should get confirmation that I changed my username
+      And I should see "Hi, newusername"
+    When I follow "Series"
+    Then I should see "Best Series by newusername"

--- a/spec/models/pseud_spec.rb
+++ b/spec/models/pseud_spec.rb
@@ -66,6 +66,20 @@ describe Pseud do
     end
   end
 
+  describe "expire_caches" do
+    let(:pseud) { create(:pseud) }
+    let(:series) { create(:series, authors: [pseud]) }
+
+    it "modifies the updated_at of associated series" do
+      pseud.reload
+      series.reload
+      travel(1.day)
+      expect do
+        pseud.update(name: "New Name")
+      end.to change { series.reload.updated_at }
+    end
+  end
+
   describe ".default_alphabetical" do
     let(:user) { create(:user, login: "Zaphod") }
     let(:subject) { user.pseuds.default_alphabetical }


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [x] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [x] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [x] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests. **(This updates a stale PR, hopefully this doesn't count towards my limit —but I can close one of mine if necessary.)**

## Issue
https://otwarchive.atlassian.net/browse/AO3-5052

## Purpose

> Touches the all the series for a user or pseud when either of those are changed. This will bust the cache on the byline so that series blurb will show the updated pseud or username right away regardless of caching status.

This PR adds a spec on top of tlee911's changes.

## Testing Instructions
See Jira issue

## References

[tlee911’s PR.](https://github.com/otwcode/otwarchive/pull/4217)

## Credit
tlee911
weeklies (she/her)