### PR TITLE
AO3-6553 Use div with a role rather than nav element

### DIFF
--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -15,13 +15,13 @@
       </ul>
     </div>
   <% else %>
-    <nav aria-label="<%= t(".media_navigation_label") %>" class="browse module">
+    <div role="navigation" aria-label="<%= t(".media_navigation_label") %>" class="browse module">
       <h3 class="heading"><%= t(".find_your_favorites") %></h3>
       <% if logged_in? %>
         <p class="note"><%= t(".browse_or_favorite", count: ArchiveConfig.MAX_FAVORITE_TAGS) %></p>
       <% end %>
       <%= render 'fandoms' %>
-    </nav>
+    </div>
   <% end %>
 
   <% if @homepage.admin_posts.present? %>

--- a/public/stylesheets/site/2.0/26-media-narrow.css
+++ b/public/stylesheets/site/2.0/26-media-narrow.css
@@ -182,7 +182,7 @@ body .narrow-shown {
   padding: 0;
 }
 
-.splash div.module, .splash nav.module, .logged-in .splash div.module, .logged-in .splash nav.module {
+.splash div.module, .logged-in .splash div.module {
   clear: both;
   margin-left: 0;
   margin-right: 0;


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6553

## Purpose

The two column layout breaks when we switch to `nav` because it relies on `nth-of-type` to apply styling to the odd-numbered modules. You can't do `.class:nth-of-type` without specifying an element (`div`), so things get complicated if we switch from `div` to `nav`.

## Testing Instructions

In addition to the original testing instructions, log in to an account with no favorite tags and ensure the layout on the homepage is normal.

## References

#4581 

alien originally asked if we could revert this because they have a lot on their plate, but when I realized what the issue was and asked if they'd mind me fixing it instead of reverting, they said it was fine.
