### PR TITLE
AO3-5052 Delete cached series byline when updating pseud or username

### DIFF
--- a/app/models/pseud.rb
+++ b/app/models/pseud.rb
@@ -400,7 +400,7 @@ class Pseud < ApplicationRecord
   def expire_caches
     if saved_change_to_name?
       works.touch_all
-      series.touch_all
+      series.each(&:expire_byline_cache)
     end
   end
 

--- a/app/models/series.rb
+++ b/app/models/series.rb
@@ -150,6 +150,12 @@ class Series < ApplicationRecord
     self.works.each(&:touch) if saved_change_to_title?
   end
 
+  def expire_byline_cache
+    [true, false].each do |only_path|
+      Rails.cache.delete("#{cache_key}/byline-nonanon/#{only_path}")
+    end
+  end
+
   # Change the positions of the serial works in the series
   def reorder_list(positions)
     SortableList.new(self.serial_works.in_order).reorder_list(positions)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -158,7 +158,7 @@ class User < ApplicationRecord
 
   def expire_caches
     return unless saved_change_to_login?
-    series.touch_all
+    series.each(&:expire_byline_cache)
     self.works.each do |work|
       work.touch
       work.expire_caches

--- a/spec/models/pseud_spec.rb
+++ b/spec/models/pseud_spec.rb
@@ -66,20 +66,6 @@ describe Pseud do
     end
   end
 
-  describe "expire_caches" do
-    let(:pseud) { create(:pseud) }
-    let(:series) { create(:series, authors: [pseud]) }
-
-    it "modifies the updated_at of associated series" do
-      pseud.reload
-      series.reload
-      travel(1.day)
-      expect do
-        pseud.update(name: "New Name")
-      end.to change { series.reload.updated_at }
-    end
-  end
-
   describe ".default_alphabetical" do
     let(:user) { create(:user, login: "Zaphod") }
     let(:subject) { user.pseuds.default_alphabetical }


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [x] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [x] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [x] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-5052

## Purpose

- Delete the series byline cache when user/pseud name changes instead of touching series.
- Remove a spec as the series `updated_at` doesn't change anymore

## Testing Instructions

See Jira issue.

## References

https://github.com/otwcode/otwarchive/pull/4605 Automated tests were already added here. 

## Credit

weeklies (she/her)
