### PR TITLE
AO3-3463 Move time_in_zone out of comment cache blocks

### DIFF
--- a/app/views/comments/_single_comment.html.erb
+++ b/app/views/comments/_single_comment.html.erb
@@ -14,9 +14,9 @@
     <% elsif !can_see_hidden_comment?(single_comment) %>
       <p class="message"><%= ts("(This comment is under review by an admin and is currently unavailable.)") %></p>
     <% else %>
-      <% cache([single_comment, single_comment.comment_owner], expires_in: 1.week) do %>
-        <% # FRONT END, update this if a.user comes in %>
-        <h4 class="heading byline">
+      <% # FRONT END, update this if a.user comes in %>
+      <h4 class="heading byline">
+        <% cache("#{[single_comment, single_comment.comment_owner]}_heading", expires_in: 1.week) do %>
           <% if single_comment.by_anonymous_creator? %>
             <%= ts("Anonymous Creator") %>
           <% else %>
@@ -32,10 +32,12 @@
               <%= ts("(Unreviewed)") %>
             </span>
           <% end %>
-          <span class="posted datetime">
-            <%= time_in_zone(single_comment.created_at) %>
-          </span>
-        </h4>
+        <% end %>
+        <span class="posted datetime">
+          <%= time_in_zone(single_comment.created_at) %>
+        </span>
+      </h4>
+      <% cache("#{[single_comment, single_comment.comment_owner]}_body", expires_in: 1.week) do %>
         <div class="icon">
           <% if !single_comment.pseud.nil? %>
             <% if single_comment.by_anonymous_creator? %>
@@ -54,12 +56,12 @@
           <p class="notice"><%= ts("This comment has been hidden by an admin.") %></p>
         <% end %>
         <blockquote class="userstuff"><%=raw sanitize_field(single_comment, :comment_content) %></blockquote>
-        <% unless single_comment.edited_at.blank? %>
-          <p class="edited datetime">
-            <%= ts("Last Edited") %> <%= time_in_zone(single_comment.edited_at) %>
-          </p>
-        <% end %>
-      <% end %><!-- end caching -->
+      <% end %>
+      <% unless single_comment.edited_at.blank? %>
+        <p class="edited datetime">
+          <%= ts("Last Edited") %> <%= time_in_zone(single_comment.edited_at) %>
+        </p>
+      <% end %>
 
       <% if policy(single_comment).show_email? && single_comment.email.present? %>
         <p class="email"><%= ts("Email: %{email}", email: single_comment.email) %></p>

--- a/app/views/comments/_single_comment.html.erb
+++ b/app/views/comments/_single_comment.html.erb
@@ -14,7 +14,7 @@
     <% elsif !can_see_hidden_comment?(single_comment) %>
       <p class="message"><%= ts("(This comment is under review by an admin and is currently unavailable.)") %></p>
     <% else %>
-      <% # FRONT END, update this if a.user comes in %>
+      <%# FRONT END, update this if a.user comes in %>
       <h4 class="heading byline">
         <% cache("#{[single_comment, single_comment.comment_owner]}_heading", expires_in: 1.week) do %>
           <% if single_comment.by_anonymous_creator? %>

--- a/app/views/comments/_single_comment.html.erb
+++ b/app/views/comments/_single_comment.html.erb
@@ -57,7 +57,7 @@
         <% end %>
         <blockquote class="userstuff"><%=raw sanitize_field(single_comment, :comment_content) %></blockquote>
       <% end %>
-      <% unless single_comment.edited_at.blank? %>
+      <% if single_comment.edited_at.present? %>
         <p class="edited datetime">
           <%= ts("Last Edited") %> <%= time_in_zone(single_comment.edited_at) %>
         </p>

--- a/features/comments_and_kudos/add_comment.feature
+++ b/features/comments_and_kudos/add_comment.feature
@@ -207,3 +207,20 @@ Scenario: Try to post a comment with a < angle bracket before a linebreak, with 
       """
       And I press "Comment"
     Then I should see "Comment created!"
+
+Scenario: Users with different time zone preferences should see the time in their own timezone
+  Given the work "Generic Work"
+    And I am logged in as "commenter"
+    And I set my time zone to "UTC"
+    And I post the comment "Something" on the work "Generic Work"
+    And it is currently 1 second from now
+    And I follow "Edit"
+    And I fill in "Comment" with "Something else"
+    And I press "Update"
+  Then I should see "UTC" within ".posted.datetime"
+    And I should see "UTC" within ".edited.datetime"
+  When I am logged in as "reader"
+    And I set my time zone to "Eastern Time (US & Canada)"
+    And I view the work "Generic Work" with comments
+  Then I should see "EDT" within ".posted.datetime"
+    And I should see "EDT" within ".edited.datetime"


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [x] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [x] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [x] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-3463

## Purpose

Fix inconsistent time zones in comments.

## Testing Instructions

See JIRA ticket.

## Credit

EchoEkhi (He/him)