### PR TITLE
AO3-6312 Add preference to prevent guest replies to comments

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -142,7 +142,7 @@ class CommentsController < ApplicationController
   end
 
   def check_guest_replies_preference
-    return unless guest? && @commentable.respond_to?(:user) && @commentable.user&.disallow_guest_replies?(find_parent)
+    return unless guest? && @commentable.respond_to?(:guest_replies_disallowed?) && @commentable.guest_replies_disallowed?
 
     flash[:error] = t("comments.check_guest_replies_preference.error")
     redirect_back(fallback_location: root_path)

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -24,6 +24,7 @@ class CommentsController < ApplicationController
   before_action :check_frozen, only: [:new, :create, :add_comment_reply]
   before_action :check_hidden_by_admin, only: [:new, :create, :add_comment_reply]
   before_action :check_not_replying_to_spam, only: [:new, :create, :add_comment_reply]
+  before_action :check_guest_replies_preference, only: [:new, :create, :add_comment_reply]
   before_action :check_permission_to_review, only: [:unreviewed]
   before_action :check_permission_to_access_single_unreviewed, only: [:show]
   before_action :check_permission_to_moderate, only: [:approve, :reject]
@@ -138,6 +139,15 @@ class CommentsController < ApplicationController
     
     flash[:error] = t("comments.commentable.guest_comments_disabled")
     redirect_back(fallback_location: root_path)
+  end
+
+  def check_guest_replies_preference
+    return unless guest? && @commentable.respond_to?(:user)
+
+    if @commentable.user.disallow_guest_replies?(find_parent)
+      flash[:error] = t("comments.check_guest_replies_preference.error")
+      redirect_back(fallback_location: root_path)
+    end
   end
 
   def check_unreviewed

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -142,12 +142,10 @@ class CommentsController < ApplicationController
   end
 
   def check_guest_replies_preference
-    return unless guest? && @commentable.respond_to?(:user)
+    return unless guest? && @commentable.respond_to?(:user) && @commentable.user.disallow_guest_replies?(find_parent)
 
-    if @commentable.user.disallow_guest_replies?(find_parent)
-      flash[:error] = t("comments.check_guest_replies_preference.error")
-      redirect_back(fallback_location: root_path)
-    end
+    flash[:error] = t("comments.check_guest_replies_preference.error")
+    redirect_back(fallback_location: root_path)
   end
 
   def check_unreviewed

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -142,7 +142,7 @@ class CommentsController < ApplicationController
   end
 
   def check_guest_replies_preference
-    return unless guest? && @commentable.respond_to?(:user) && @commentable.user.disallow_guest_replies?(find_parent)
+    return unless guest? && @commentable.respond_to?(:user) && @commentable.user&.disallow_guest_replies?(find_parent)
 
     flash[:error] = t("comments.check_guest_replies_preference.error")
     redirect_back(fallback_location: root_path)

--- a/app/controllers/preferences_controller.rb
+++ b/app/controllers/preferences_controller.rb
@@ -67,7 +67,8 @@ class PreferencesController < ApplicationController
       :first_login,
       :banner_seen,
       :allow_cocreator,
-      :allow_gifts
+      :allow_gifts,
+      :guest_replies_off
     )
   end
 end

--- a/app/helpers/comments_helper.rb
+++ b/app/helpers/comments_helper.rb
@@ -108,8 +108,8 @@ module CommentsHelper
       comment_parent_hidden?(comment) ||
       blocked_by_comment?(comment) ||
       blocked_by?(comment.ultimate_parent) ||
-      guest? && admin_settings.guest_comments_off? ||
-      guest? && comment.user.disallow_guest_replies?(comment.ultimate_parent) )
+      (guest? && admin_settings.guest_comments_off?) ||
+      (guest? && comment.user&.disallow_guest_replies?(comment.ultimate_parent)))
   end
 
   def can_edit_comment?(comment)

--- a/app/helpers/comments_helper.rb
+++ b/app/helpers/comments_helper.rb
@@ -100,16 +100,18 @@ module CommentsHelper
 
   def can_reply_to_comment?(comment)
     admin_settings = AdminSetting.current
-    
-    !(comment.unreviewed? ||
-      comment.iced? ||
-      comment.hidden_by_admin? ||
-      parent_disallows_comments?(comment) ||
-      comment_parent_hidden?(comment) ||
-      blocked_by_comment?(comment) ||
-      blocked_by?(comment.ultimate_parent) ||
-      (guest? && admin_settings.guest_comments_off?) ||
-      (guest? && comment.guest_replies_disallowed?))
+
+    return false if comment.unreviewed?
+    return false if comment.iced?
+    return false if comment.hidden_by_admin?
+    return false if parent_disallows_comments?(comment)
+    return false if comment_parent_hidden?(comment)
+    return false if blocked_by_comment?(comment)
+    return false if blocked_by?(comment.ultimate_parent)
+
+    return true unless guest?
+
+    !(admin_settings.guest_comments_off? || comment.guest_replies_disallowed?)
   end
 
   def can_edit_comment?(comment)

--- a/app/helpers/comments_helper.rb
+++ b/app/helpers/comments_helper.rb
@@ -109,7 +109,7 @@ module CommentsHelper
       blocked_by_comment?(comment) ||
       blocked_by?(comment.ultimate_parent) ||
       (guest? && admin_settings.guest_comments_off?) ||
-      (guest? && comment.user&.disallow_guest_replies?(comment.ultimate_parent)))
+      (guest? && comment.guest_replies_disallowed?))
   end
 
   def can_edit_comment?(comment)

--- a/app/helpers/comments_helper.rb
+++ b/app/helpers/comments_helper.rb
@@ -108,7 +108,8 @@ module CommentsHelper
       comment_parent_hidden?(comment) ||
       blocked_by_comment?(comment) ||
       blocked_by?(comment.ultimate_parent) ||
-      guest? && admin_settings.guest_comments_off?)
+      guest? && admin_settings.guest_comments_off? ||
+      guest? && comment.user.disallow_guest_replies?(comment.ultimate_parent) )
   end
 
   def can_edit_comment?(comment)

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -22,11 +22,12 @@ class Comment < ApplicationRecord
     maximum: ArchiveConfig.COMMENT_MAX,
     too_long: ts("must be less than %{count} characters long.", count: ArchiveConfig.COMMENT_MAX)
 
-  validates_each :commentable, if: :reply_comment?, unless: :pseud_id? do |record, attribute, value|
-    record.errors.add(attribute, :guest_replies_off) if value.user&.disallow_guest_replies?(value.ultimate_parent)
-  end
-
   delegate :user, to: :pseud, allow_nil: true
+
+  validate :reply_as_guest_allowed, if: :reply_comment?, unless: :pseud_id, on: :create
+  def reply_as_guest_allowed
+    errors.add(:commentable, :guest_replies_off) if commentable.user&.disallow_guest_replies?(ultimate_parent)
+  end
 
   # Check if the writer of this comment is blocked by the writer of the comment
   # they're replying to:

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -24,16 +24,16 @@ class Comment < ApplicationRecord
 
   delegate :user, to: :pseud, allow_nil: true
 
-  validate :can_be_guest_reply, if: :reply_comment?, unless: :pseud_id, on: :create
   # Whether the writer of the comment this is replying to allows guest replies
-  def can_be_guest_reply
+  validate :guest_can_reply, if: :reply_comment?, unless: :pseud_id, on: :create
+  def guest_can_reply
     errors.add(:commentable, :guest_replies_off) if commentable.guest_replies_disallowed?
   end
 
   # Whether the writer of this comment disallows guest replies
   def guest_replies_disallowed?
     return false unless user
-    
+
     user.preference.guest_replies_off && !user.is_author_of?(ultimate_parent)
   end
 

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -70,7 +70,7 @@ class Comment < ApplicationRecord
 
   scope :for_display, lambda {
     includes(
-      pseud: { user: [:roles, :block_of_current_user, :block_by_current_user] },
+      pseud: { user: [:roles, :block_of_current_user, :block_by_current_user, :preference] },
       parent: { work: [:pseuds, :users] }
     )
   }

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -22,6 +22,10 @@ class Comment < ApplicationRecord
     maximum: ArchiveConfig.COMMENT_MAX,
     too_long: ts("must be less than %{count} characters long.", count: ArchiveConfig.COMMENT_MAX)
 
+  validates_each :commentable, if: :reply_comment?, unless: :pseud_id? do |record, attribute, value|
+    record.errors.add(attribute, :guest_replies_off) if value.user&.disallow_guest_replies?(value.ultimate_parent)
+  end
+
   delegate :user, to: :pseud, allow_nil: true
 
   # Check if the writer of this comment is blocked by the writer of the comment

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -33,6 +33,7 @@ class Comment < ApplicationRecord
   # Whether the writer of this comment disallows guest replies
   def guest_replies_disallowed?
     return false unless user
+    
     user.preference.guest_replies_off && !user.is_author_of?(ultimate_parent)
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -431,12 +431,6 @@ class User < ApplicationRecord
     has_role?(:no_resets)
   end
 
-  # Whether logged out users can reply to this user's comments with the given
-  # ultimate parent
-  def disallow_guest_replies?(ultimate_parent)
-    self.preference.guest_replies_off && !self.is_author_of?(ultimate_parent)
-  end
-
   # Creates log item tracking changes to user
   def create_log_item(options = {})
     options.reverse_merge! note: "System Generated", user_id: self.id

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -431,6 +431,12 @@ class User < ApplicationRecord
     has_role?(:no_resets)
   end
 
+  # Whether logged out users can reply to this user's comments with the given
+  # ultimate parent
+  def disallow_guest_replies?(ultimate_parent)
+    self.preference.guest_replies_off && !self.is_author_of?(ultimate_parent)
+  end
+
   # Creates log item tracking changes to user
   def create_log_item(options = {})
     options.reverse_merge! note: "System Generated", user_id: self.id

--- a/app/views/preferences/index.html.erb
+++ b/app/views/preferences/index.html.erb
@@ -110,7 +110,7 @@
       </li>
       <li>
         <%= f.check_box :guest_replies_off %>
-        <%= f.label :guest_replies_off, t(".guest_replies_off")  %>
+        <%= f.label :guest_replies_off, t(".guest_replies_off") %>
       </li>
     </ul>
   </fieldset>

--- a/app/views/preferences/index.html.erb
+++ b/app/views/preferences/index.html.erb
@@ -108,6 +108,10 @@
         <%= f.check_box :kudos_emails_off %>
         <%= f.label :kudos_emails_off, ts('Turn off emails about kudos.')  %>
       </li>
+      <li>
+        <%= f.check_box :guest_replies_off %>
+        <%= f.label :guest_replies_off, t(".guest_replies_off")  %>
+      </li>
     </ul>
   </fieldset>
   <fieldset>

--- a/config/locales/controllers/en.yml
+++ b/config/locales/controllers/en.yml
@@ -36,6 +36,8 @@ en:
       reply: Sorry, you have been blocked by that user.
     check_frozen:
       error: Sorry, you cannot reply to a frozen comment.
+    check_guest_replies_preference:
+      error: Sorry, this user doesn't allow non-Archive users to reply to their comments.
     check_hidden_by_admin:
       error: Sorry, you cannot reply to a hidden comment.
     check_not_replying_to_spam:

--- a/config/locales/models/en.yml
+++ b/config/locales/models/en.yml
@@ -100,6 +100,9 @@ en:
               blocked_comment: Sorry, you have been blocked by one or more of this work's creators.
               blocked_reply: Sorry, you have been blocked by that user.
               format: "%{message}"
+            commentable:
+              guest_replies_off: Sorry, this user doesn't allow non-Archive users to reply to their comments.
+              format: "%{message}"
         creatorship:
           attributes:
             pseud_id:

--- a/config/locales/models/en.yml
+++ b/config/locales/models/en.yml
@@ -96,12 +96,12 @@ en:
           format: "%{message}"
         comment:
           attributes:
+            commentable:
+              format: "%{message}"
+              guest_replies_off: Sorry, this user doesn't allow non-Archive users to reply to their comments.
             user:
               blocked_comment: Sorry, you have been blocked by one or more of this work's creators.
               blocked_reply: Sorry, you have been blocked by that user.
-              format: "%{message}"
-            commentable:
-              guest_replies_off: Sorry, this user doesn't allow non-Archive users to reply to their comments.
               format: "%{message}"
         creatorship:
           attributes:

--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -525,6 +525,7 @@ en:
     index:
       allow_collection_invitation: Allow others to invite my works to collections.
       blocked_users: Blocked Users
+      guest_replies_off: Do not allow guests to reply to my comments on news posts or other users' works (you can still control the comment settings for your works separately).
       muted_users: Muted Users
   profile:
     pseud_list:

--- a/db/migrate/20230819074500_add_guest_replies_off_to_preference.rb
+++ b/db/migrate/20230819074500_add_guest_replies_off_to_preference.rb
@@ -1,0 +1,7 @@
+class AddGuestRepliesOffToPreference < ActiveRecord::Migration[6.1]
+  uses_departure! if Rails.env.staging? || Rails.env.production?
+
+  def change
+    add_column :preferences, :guest_replies_off, :boolean, default: false, null: false
+  end
+end

--- a/features/comments_and_kudos/guest_comment_replies.feature
+++ b/features/comments_and_kudos/guest_comment_replies.feature
@@ -55,3 +55,14 @@ Feature: Disallowing guest comment replies
       And I fill in "Comment" with "Ugh." within ".odd"
       And I press "Comment" within ".odd"
     Then I should see "Comment created!"
+
+  Scenario: Guests can reply to guests
+    Given the work "Aftermath"
+      And a guest comment on the work "Aftermath"
+    When I view the work "Aftermath" with comments
+    Then I should see a "Comment" button
+      And I should see a link "Reply"
+    When I am logged in as "reader"
+      And I view the work "Aftermath" with comments
+    Then I should see a "Comment" button
+      And I should see a link "Reply"

--- a/features/comments_and_kudos/guest_comment_replies.feature
+++ b/features/comments_and_kudos/guest_comment_replies.feature
@@ -1,0 +1,57 @@
+Feature: Disallowing guest comment replies
+
+  Scenario Outline: Guests cannot reply to a user who has guest comments off on news posts and other users' works
+    Given <commentable>
+      And the user "commenter" turns off guest comment replies
+      And a comment "OMG!" by "commenter" on <commentable>
+    When I view <commentable> with comments
+    Then I should see a "Comment" button
+      But I should not see a link "Reply"
+    When I am logged in as "reader"
+      And I view <commentable> with comments
+    Then I should see a "Comment" button
+      And I should see a link "Reply"
+
+    Examples:
+      | commentable                 |
+      | the work "Aftermath"        |
+      | the admin post "Change Log" |
+
+  Scenario: Guests can reply to a user who has guest comments off on their own work
+    Given the work "Aftermath" by "creator"
+      And the user "creator" turns off guest comment replies
+      And a comment "OMG!" by "creator" on the work "Aftermath"
+    When I view the work "Aftermath" with comments
+    Then I should see a "Comment" button
+      And I should see a link "Reply"
+    When I am logged in as "reader"
+      And I view the work "Aftermath" with comments
+    Then I should see a "Comment" button
+      And I should see a link "Reply"
+
+  Scenario: Guests can reply to a user who has guest comments off on works co-created by the user
+    Given the user "nemesis" turns off guest comment replies
+      And the work "Aftermath" by "creator" and "nemesis"
+      And a comment "OMG!" by "nemesis" on the work "Aftermath"
+    When I view the work "Aftermath" with comments
+    Then I should see a "Comment" button
+      And I should see a link "Reply"
+    When I am logged in as "reader"
+      And I view the work "Aftermath" with comments
+    Then I should see a "Comment" button
+      And I should see a link "Reply"
+
+  Scenario: Users can reply to a user who has guest comments off on tags
+    Given the following activated tag wranglers exist
+      | login     |
+      | commenter |
+      | wrangler  |
+      And a canonical fandom "Controversial"
+      And the user "commenter" turns off guest comment replies
+      And a comment "OMG!" by "commenter" on the tag "Controversial"
+    When I am logged in as "wrangler"
+      And I view the tag "Controversial" with comments
+      And I follow "Reply"
+      And I fill in "Comment" with "Ugh." within ".odd"
+      And I press "Comment" within ".odd"
+    Then I should see "Comment created!"

--- a/features/other_a/preferences_edit.feature
+++ b/features/other_a/preferences_edit.feature
@@ -31,6 +31,7 @@ Feature: Edit preferences
     And I should see "Turn off messages to your inbox about comments."
     And I should see "Turn off copies of your own comments."
     And I should see "Turn off emails about kudos."
+    And I should see "Do not allow guests to reply to my comments on news posts or other users' works (you can still control the comment settings for your works separately)."
     And I should see "Allow others to invite my works to collections."
     And I should see "Turn off emails from collections."
     And I should see "Turn off inbox messages from collections."

--- a/features/step_definitions/preferences_steps.rb
+++ b/features/step_definitions/preferences_steps.rb
@@ -32,6 +32,12 @@ Given "the user {string} allows gifts" do |login|
   user.preference.save
 end
 
+When "the user {string} turns off guest comment replies" do |login|
+  user = User.where(login: login).first
+  user = find_or_create_new_user(login, DEFAULT_PASSWORD) if user.nil?
+  user.preference.update!(guest_replies_off: true)
+end
+
 Given "the user {string} is hidden from search engines" do |login|
   user = User.find_by(login: login)
   user.preference.update(minimize_search_engines: true)

--- a/public/help/comment-preferences.html
+++ b/public/help/comment-preferences.html
@@ -9,6 +9,6 @@
   <dd>Enable this option if you prefer not to receive emails for your own comments (for example, when you reply to comments on your own works).</dd>
   <dt>Turn off emails about kudos</dt>
   <dd>Enable this option if you would prefer not to receive email notifications when someone leaves kudos on your work.</dd>
-  <dt>Turn off admin emails</dt>
-  <dd>Occasionally, Archive staff may send out email notices to all users, for example to notify people of proposed changes to the Terms of Service or site downtime. If you would prefer not to receive such emails, please enable this option. Note that if you choose to disable this option, you may miss important information about site changes or events.</dd>
+  <dt>Do not allow guests to reply to my comments on news posts or other users' works</dt>
+  <dd>Enable this option if you would prefer not to receive replies from users who aren't logged in to an Archive account on comments you leave on news posts or other creators' works. This setting doesn't apply to comments on your own works; for more on controlling who can interact with you on your works check out the <a href="/faq/posting-and-editing#controlaccess">Posting and Editing FAQ</a>.</dd>
 </dl>

--- a/spec/controllers/comments_controller_spec.rb
+++ b/spec/controllers/comments_controller_spec.rb
@@ -233,6 +233,23 @@ describe CommentsController do
         it_behaves_like "guest can reply to a user with guest replies disabled on user's work"
       end
     end
+
+    context "when replying to guests" do
+      let (:comment) { create(:comment, :by_guest) }
+
+      it "redirects guest user without an error" do
+        get :add_comment_reply, params: { comment_id: comment.id }
+        expect(flash[:error]).to be_nil
+        expect(response).to redirect_to(chapter_path(comment.commentable, show_comments: true, anchor: "comment_#{comment.id}"))
+      end
+
+      it "redirects logged in user without an error" do
+        fake_login
+        get :add_comment_reply, params: { comment_id: comment.id }
+        expect(flash[:error]).to be_nil
+        expect(response).to redirect_to(chapter_path(comment.commentable, show_comments: true, anchor: "comment_#{comment.id}"))
+      end
+    end
   end
 
   describe "GET #unreviewed" do

--- a/spec/controllers/comments_controller_spec.rb
+++ b/spec/controllers/comments_controller_spec.rb
@@ -490,6 +490,7 @@ describe CommentsController do
 
         it_behaves_like "guest can reply to a user with guest replies disabled on user's work"
       end
+
       context "when commentable is user's co-creation" do
         let(:work) { create(:work, authors: [create(:user).default_pseud, user.default_pseud]) }
         let(:comment) { create(:comment, pseud: user.default_pseud, commentable: work.first_chapter) }

--- a/spec/controllers/comments_controller_spec.rb
+++ b/spec/controllers/comments_controller_spec.rb
@@ -808,8 +808,12 @@ describe CommentsController do
       end
 
       it "redirects logged in user without an error" do
-        fake_login
-        post :create, params: { comment_id: comment.id, comment: anon_comment_attributes }
+        comment_attributes = {
+          pseud_id: user.default_pseud_id,
+          comment_content: "Hello fellow human!"
+        }
+        fake_login_known_user(user)
+        post :create, params: { comment_id: comment.id, comment: comment_attributes }
         expect(flash[:error]).to be_nil
       end
     end
@@ -821,8 +825,12 @@ describe CommentsController do
       end
 
       it "redirects logged in user without an error" do
-        fake_login
-        post :create, params: { comment_id: comment.id, comment: anon_comment_attributes }
+        comment_attributes = {
+          pseud_id: user.default_pseud_id,
+          comment_content: "Hello fellow human!"
+        }
+        fake_login_known_user(user)
+        post :create, params: { comment_id: comment.id, comment: comment_attributes }
         expect(flash[:error]).to be_nil
       end
     end

--- a/spec/controllers/comments_controller_spec.rb
+++ b/spec/controllers/comments_controller_spec.rb
@@ -235,7 +235,7 @@ describe CommentsController do
     end
 
     context "when replying to guests" do
-      let (:comment) { create(:comment, :by_guest) }
+      let(:comment) { create(:comment, :by_guest) }
 
       it "redirects guest user without an error" do
         get :add_comment_reply, params: { comment_id: comment.id }

--- a/spec/controllers/comments_controller_spec.rb
+++ b/spec/controllers/comments_controller_spec.rb
@@ -2950,7 +2950,9 @@ describe CommentsController do
 
       it "deletes the comment and redirects to referer with a notice" do
         delete :destroy, params: { id: unreviewed_comment.id }
-        expect { unreviewed_comment.reload }.to raise_exception(ActiveRecord::RecordNotFound)
+        expect do
+          unreviewed_comment.reload
+        end.to raise_exception(ActiveRecord::RecordNotFound)
         it_redirects_to_with_notice("/where_i_came_from", "Comment deleted.")
       end
 
@@ -2962,7 +2964,6 @@ describe CommentsController do
         expect(flash[:comment_error]).to eq "We couldn't delete that comment."
       end
     end
-
 
     context "when comment is a guest reply to user who turns off guest replies afterwards" do
       let(:comment) { create(:comment, :on_admin_post) }

--- a/spec/controllers/comments_controller_spec.rb
+++ b/spec/controllers/comments_controller_spec.rb
@@ -2983,7 +2983,9 @@ describe CommentsController do
           admin_post_path(reply.ultimate_parent, show_comments: true, anchor: "comment_#{comment.id}"),
           "Comment deleted."
         )
-        expect { reply.reload }.to raise_exception(ActiveRecord::RecordNotFound)
+        expect do
+          reply.reload
+        end.to raise_exception(ActiveRecord::RecordNotFound)
       end
     end
 

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -14,7 +14,7 @@ describe Comment do
 
     it "should be invalid if exactly duplicated" do
       expect(second_comment.valid?).to be_falsy
-      expect(second_comment.errors.keys).to include(:comment_content)
+      expect(second_comment.errors.attribute_names).to include(:comment_content)
     end
 
     it "should not be invalid if in the process of being deleted" do
@@ -164,6 +164,92 @@ describe Comment do
         it_behaves_like "creating and editing comments is allowed"
         it_behaves_like "deleting comments is allowed"
       end
+    end
+  end
+
+  context "when user has disabled guest replies" do
+    let(:no_reply_guy) do
+      user = create(:user)
+      user.preference.update!(guest_replies_off: true)
+      user
+    end
+
+    let(:guest_reply) do
+      Comment.new(commentable: comment,
+                  pseud: nil,
+                  name: "unwelcome guest",
+                  email: Faker::Internet.email,
+                  comment_content: "I'm a vampire.")
+    end
+
+    let(:user_reply) do
+      Comment.new(commentable: comment,
+                  pseud: create(:user).default_pseud,
+                  comment_content: "Hmm.")
+    end
+
+    shared_examples "creating guest reply is allowed" do
+      describe "save" do
+        it "allows guest replies" do
+          expect(guest_reply.save).to be_truthy
+          expect(guest_reply.errors.full_messages).to be_blank
+        end
+        it "allows user replies" do
+          expect(user_reply.save).to be_truthy
+          expect(user_reply.errors.full_messages).to be_blank
+        end
+      end
+    end
+
+    shared_examples "creating guest reply is not allowed" do
+      describe "save" do
+        it "doesn't allow guest replies" do
+          expect(guest_reply.save).to be_falsey
+          expect(guest_reply.errors.full_messages).to include("Sorry, this user doesn't allow non-Archive users to reply to their comments.")
+        end
+        it "allows user replies" do
+          expect(user_reply.save).to be_truthy
+          expect(user_reply.errors.full_messages).to be_blank
+        end
+      end
+    end
+
+    context "comment on a work" do
+      let(:comment) { create(:comment, pseud: no_reply_guy.default_pseud) }
+
+      include_examples "creating guest reply is not allowed"
+    end
+
+    context "comment on an admin post" do
+      let(:comment) { create(:comment, :on_admin_post, pseud: no_reply_guy.default_pseud) }
+
+      include_examples "creating guest reply is not allowed"
+    end
+
+    context "comment on a tag" do
+      let(:comment) { create(:comment, :on_tag, pseud: no_reply_guy.default_pseud) }
+
+      include_examples "creating guest reply is not allowed"
+    end
+
+    context "comment on the user's work" do
+      let(:work) { create(:work, authors: [no_reply_guy.default_pseud]) }
+      let(:comment) { create(:comment, pseud: no_reply_guy.default_pseud, commentable: work.first_chapter) }
+
+      include_examples "creating guest reply is allowed"
+    end
+
+    context "comment on the user's co-creation" do
+      let(:work) { create(:work, authors: [create(:user).default_pseud, no_reply_guy.default_pseud]) }
+      let(:comment) { create(:comment, pseud: no_reply_guy.default_pseud, commentable: work.first_chapter) }
+
+      include_examples "creating guest reply is allowed"
+    end
+
+    context "guest comment" do
+      let(:comment) { create(:comment, :by_guest) }
+
+      include_examples "creating guest reply is allowed"
     end
   end
 

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -194,6 +194,7 @@ describe Comment do
           expect(guest_reply.save).to be_truthy
           expect(guest_reply.errors.full_messages).to be_blank
         end
+
         it "allows user replies" do
           expect(user_reply.save).to be_truthy
           expect(user_reply.errors.full_messages).to be_blank
@@ -207,6 +208,7 @@ describe Comment do
           expect(guest_reply.save).to be_falsey
           expect(guest_reply.errors.full_messages).to include("Sorry, this user doesn't allow non-Archive users to reply to their comments.")
         end
+
         it "allows user replies" do
           expect(user_reply.save).to be_truthy
           expect(user_reply.errors.full_messages).to be_blank


### PR DESCRIPTION
# Pull Request Checklist

* [X] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [X] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [X] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [X] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [X] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-6312

## Purpose

Add a preference to prevent logged out users from replying to your comments on news posts and other users' works. Guests can still reply to you on works you created or co-created.

## Testing Instructions

See Jira.

## References

Partial implementation in #4243.
Migration with departure gem based on #4528.
Help text for the admin emails feature removed because of [AO3-5043](https://otwarchive.atlassian.net/browse/AO3-5043).

## Credit

Bilka (he/him)

[AO3-5043]: https://otwarchive.atlassian.net/browse/AO3-5043?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ