### PR TITLE
AO3-6533 Validates provided rating string must be one of the allowed strings

### DIFF
--- a/app/models/rating.rb
+++ b/app/models/rating.rb
@@ -7,13 +7,17 @@ class Rating < Tag
     to_s
   end
 
+  def self.rating_tags
+    Set[ArchiveConfig.RATING_DEFAULT_TAG_NAME,
+      ArchiveConfig.RATING_GENERAL_TAG_NAME,
+      ArchiveConfig.RATING_TEEN_TAG_NAME,
+      ArchiveConfig.RATING_MATURE_TAG_NAME,
+      ArchiveConfig.RATING_EXPLICIT_TAG_NAME]
+  end
+
   # Gives us the default ratings as Not Rated + low to high
   def self.defaults_by_severity
-    ratings = [ArchiveConfig.RATING_DEFAULT_TAG_NAME,
-               ArchiveConfig.RATING_GENERAL_TAG_NAME,
-               ArchiveConfig.RATING_TEEN_TAG_NAME,
-               ArchiveConfig.RATING_MATURE_TAG_NAME,
-               ArchiveConfig.RATING_EXPLICIT_TAG_NAME]
+    ratings = self.rating_tags
     ratings_by_id = Rating.where(name: ratings).inject({}) do |result, rating|
       result[rating.name] = rating
       result

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -144,7 +144,9 @@ class Work < ApplicationRecord
   validates :archive_warning_string,
             presence: { message: "^Please select at least one warning." }
   validates :rating_string,
-            presence: { message: "^Please choose a rating." }
+            presence: { message: "^Please choose a rating." }, 
+            inclusion: { in: Rating.rating_tags,
+                         message: "^Only canonical rating tags are allowed." }
 
   # rephrases the "chapters is invalid" message
   after_validation :check_for_invalid_chapters


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [ ] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [x] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [x] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-6533

## Purpose

Prevent users from adding more than one ratings. 

## Testing Instructions

Same as in issue:
1. Log in
1. Post > New Work
1. With your browser’s web developer tools enabled, right click on the Rating select menu and choose Inspect Element or equivalent
1. Locate the selected option, which will look something like <option selected="selected" value="Not Rated">Not Rated</option>
1. Edit its value attribute to contain two ratings separated by a comma, e.g., value="Not Rated, General Audiences"
1. Fill in remaining required information in the form
1. Post

Now, it gives an error:
```
Sorry! We couldn't save this work because:
- Only canonical rating tags are allowed.
```

## References

N/A

## Credit

ellieyhc (she/her)
