### PR TITLE
AO3-5629 Switch from wkhtmltopdf to Calibre for PDF downloads

### DIFF
--- a/.github/workflows/automated-tests.yml
+++ b/.github/workflows/automated-tests.yml
@@ -104,13 +104,6 @@ jobs:
           sudo apt-get install -y redis-server
           ./script/gh-actions/multiple_redis.sh
 
-      - name: Cache wkhtmltopdf package
-        if: ${{ matrix.tests.ebook }}
-        uses: actions/cache@v3
-        with:
-          path: wkhtmltopdf
-          key: wkhtmltopdf-${{ hashFiles('script/gh-actions/ebook_converters.sh') }}
-
       - name: Install ebook converters
         if: ${{ matrix.tests.ebook }}
         run: ./script/gh-actions/ebook_converters.sh

--- a/app/models/download_writer.rb
+++ b/app/models/download_writer.rb
@@ -1,4 +1,4 @@
-require 'open3'
+require "open3"
 
 class DownloadWriter
   attr_reader :download, :work
@@ -125,7 +125,7 @@ class DownloadWriter
   # creating an empty stylesheets directory.
   def get_web2disk_command
     [
-      "web2disk',
+      "web2disk",
       "--base-dir", download.assets_path,
       "--max-recursions", "0",
       "--dont-download-stylesheets",

--- a/app/models/download_writer.rb
+++ b/app/models/download_writer.rb
@@ -82,7 +82,7 @@ class DownloadWriter
         "--pdf-page-margin-right", "36",
         "--pdf-page-margin-bottom", "36",
         "--pdf-page-margin-left", "36",
-        "--pdf-default-font-size", "17",
+        "--pdf-default-font-size", "17"
       ]
     end
 

--- a/app/models/download_writer.rb
+++ b/app/models/download_writer.rb
@@ -19,8 +19,8 @@ class DownloadWriter
       http_host: ArchiveConfig.APP_HOST
     )
     renderer.render(
-      template: 'downloads/show',
-      layout: 'barebones',
+      template: "downloads/show",
+      layout: "barebones",
       assigns: {
         work: work,
         page_title: download.page_title,
@@ -40,7 +40,7 @@ class DownloadWriter
 
   # transform HTML version into ebook version
   def generate_ebook_download
-    return unless %w(azw3 epub mobi pdf).include?(download.file_type)
+    return unless %w[azw3 epub mobi pdf].include?(download.file_type)
     return if download.exists?
 
     cmds = get_commands
@@ -67,55 +67,55 @@ class DownloadWriter
     # Add info about first series if any
     series = []
     if meta[:series_title].present?
-      series = ['--series', meta[:series_title],
-                '--series-index', meta[:series_position]]
+      series = ["--series", meta[:series_title],
+                "--series-index", meta[:series_position]]
     end
 
     ### Format-specific options
     # epub: don't generate a cover image
-    epub = download.file_type == "epub" ? ['--no-default-epub-cover'] : []
+    epub = download.file_type == "epub" ? ["--no-default-epub-cover"] : []
     # pdf: decrease margins from 72pt default
     pdf = []
     if download.file_type == "pdf"
       pdf = [
-              '--pdf-page-margin-top', '36',
-              '--pdf-page-margin-right', '36',
-              '--pdf-page-margin-bottom', '36',
-              '--pdf-page-margin-left', '36',
-              '--pdf-default-font-size', '17',
-            ]
+        "--pdf-page-margin-top", "36",
+        "--pdf-page-margin-right", "36",
+        "--pdf-page-margin-bottom", "36",
+        "--pdf-page-margin-left", "36",
+        "--pdf-default-font-size", "17",
+      ]
     end
 
     ### CSS options
     # azw3, epub, and mobi get a special stylesheet
     css = []
-    if %w(azw3 epub mobi).include?(download.file_type)
-      css = ['--extra-css',
-             Rails.public_path.join('stylesheets/ebooks.css').to_s]
+    if %w[azw3 epub mobi].include?(download.file_type)
+      css = ["--extra-css",
+             Rails.public_path.join("stylesheets/ebooks.css").to_s]
     end
 
     [
-      'ebook-convert',
+      "ebook-convert",
       download.zip_path,
       download.file_path,
-      '--input-encoding', 'utf-8',
+      "--input-encoding", "utf-8",
       # Prevent it from turning links to endnotes into entries for the table of
       # contents on works with fewer than the specified number of chapters.
-      '--toc-threshold', '0',
-      '--use-auto-toc',
-      '--title', meta[:title],
-      '--title-sort', meta[:sortable_title],
-      '--authors', meta[:authors],
-      '--author-sort', meta[:sortable_authors],
-      '--comments', meta[:summary],
-      '--tags', meta[:tags],
-      '--pubdate', meta[:pubdate],
-      '--publisher', ArchiveConfig.APP_NAME,
-      '--language', meta[:language],
+      "--toc-threshold", "0",
+      "--use-auto-toc",
+      "--title", meta[:title],
+      "--title-sort", meta[:sortable_title],
+      "--authors", meta[:authors],
+      "--author-sort", meta[:sortable_authors],
+      "--comments", meta[:summary],
+      "--tags", meta[:tags],
+      "--pubdate", meta[:pubdate],
+      "--publisher", ArchiveConfig.APP_NAME,
+      "--language", meta[:language],
       # XPaths for detecting chapters are overly specific to make sure we don't grab
       # anything inputted by the user. First path is for single-chapter works,
       # second for multi-chapter, and third for the preface and afterword
-      '--chapter', "//h:body/h:div[@id='chapters']/h:h2[@class='toc-heading'] | //h:body/h:div[@id='chapters']/h:div[@class='meta group']/h:h2[@class='heading'] | //h:body/h:div[@id='preface' or @id='afterword']/h:h2[@class='toc-heading']"
+      "--chapter", "//h:body/h:div[@id='chapters']/h:h2[@class='toc-heading'] | //h:body/h:div[@id='chapters']/h:div[@class='meta group']/h:h2[@class='heading'] | //h:body/h:div[@id='preface' or @id='afterword']/h:h2[@class='toc-heading']"
     ] + series + css + epub + pdf
   end
 
@@ -125,10 +125,10 @@ class DownloadWriter
   # creating an empty stylesheets directory.
   def get_web2disk_command
     [
-      'web2disk',
-      '--base-dir', download.assets_path,
-      '--max-recursions', '0',
-      '--dont-download-stylesheets',
+      "web2disk',
+      "--base-dir", download.assets_path,
+      "--max-recursions", "0",
+      "--dont-download-stylesheets",
       "file://#{download.html_file_path}"
     ]
   end
@@ -136,8 +136,8 @@ class DownloadWriter
   # Zip the directory containing the HTML file and images.
   def get_zip_command
     [
-      'zip',
-      '-r',
+      "zip",
+      "-r",
       download.zip_path,
       download.assets_path
     ]

--- a/config/docker/Dockerfile
+++ b/config/docker/Dockerfile
@@ -6,7 +6,6 @@ RUN apt-get update             && \
         calibre                   \
         default-mysql-client      \
         shared-mime-info          \
-        wkhtmltopdf               \
         zip
 
 # Clean and mount repository at /otwa

--- a/script/gh-actions/ebook_converters.sh
+++ b/script/gh-actions/ebook_converters.sh
@@ -1,24 +1,5 @@
 #!/bin/bash
 
-# We can't use apt-get to install wkhtmltopdf because we use several options
-# (--log-level and --disable-smart-shrinking) that are not available on the
-# version currently available through apt-get. So we have to install
-# xfonts-75dpi and xfonts-base (which are dependencies for wkhtmltox) through
-# apt-get, but install wkhtmltox itself through a direct link to the package.
+sudo apt-get install -y calibre zip
 
-sudo apt-get install -y calibre zip xfonts-75dpi xfonts-base
-
-mkdir -p wkhtmltopdf
-pushd wkhtmltopdf
-
-FILE="wkhtmltox_0.12.5-1.bionic_amd64.deb"
-
-if [[ ! -e $FILE ]]; then
-  wget -N https://media.archiveofourown.org/systems/$FILE
-fi
-
-sudo dpkg -i $FILE
-
-popd
-
-ebook-convert --version && wkhtmltopdf --version
+ebook-convert --version


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5629

## Purpose

Switches from wkhtmltopdf to Calibre for generating our PDFs while attempting to maintain a similar appearance. (We can't update our operating system until we make this change.)

Once we've tested on staging, we should post beforehand to let users know PDFs will be changing in appearance (and explain that this change is necessary). Here are the difference I noticed:
* the title and work notes are on a separate page, not right below the meta
* there is slightly more space in the top/bottom margins
* the font on the meta, work title, and "summary" and "notes" headings is, at least on my system, a serif rather than a sans serif, _but_, based on past experience with our downloads, I think this might be due to different default system fonts on my computer and staging, so it may not be an issue 

## Testing Instructions

We'll want to download some PDF works and compare them to similar works on production:
* works with images
* works with embedded audio or video (using embeds from e.g., YouTube and Soundcloud as well as using the `video` and `audio` HTML tags)
* multi-chapter works, with work and chapter notes and chapter summaries 
* single chapter works, also ideally with notes and summaries 
* works that use a different alphabet than English, e.g. works in Chinese, Russian, and Hebrew

## References

Are there other relevant issues/pull requests/mailing list discussions?

## Credit

Sarken, she/her