### PR TITLE
AO3-5776 Remove mention of author from download afterword

### DIFF
--- a/app/views/downloads/_download_afterword.html.erb
+++ b/app/views/downloads/_download_afterword.html.erb
@@ -23,5 +23,5 @@
     </div>
   <% end %>
 
-  <p class="message"><%= t(".please_comment_html", work_comment_link: link_to(t(".work_comment"), new_work_comment_url(@work))) %></p>
+  <p class="message"><%= t(".please_comment_html", work_comment_link: link_to(t(".work_comment", locale: :en), new_work_comment_url(@work)), locale: :en) %></p>
 </div>

--- a/app/views/downloads/_download_afterword.html.erb
+++ b/app/views/downloads/_download_afterword.html.erb
@@ -23,5 +23,5 @@
     </div>
   <% end %>
 
-  <p class="message"><%= ts("Please") %> <%= link_to ts("drop by the archive and comment"), new_work_comment_url(@work) %> <%= ts("to let the author know if you enjoyed their work!") %></p>
+  <p class="message"><%= t(".please_comment_html", work_comment_link: link_to(t(".work_comment"), new_work_comment_url(@work))) %></p>
 </div>

--- a/app/views/downloads/show.html.erb
+++ b/app/views/downloads/show.html.erb
@@ -1,4 +1,4 @@
-<%= render 'downloads/download_preface.html' %>
+<%= render "downloads/download_preface" %>
 
 <div id="chapters" class="userstuff">
   <% if @chapters.size > 1 %>
@@ -14,4 +14,4 @@
   <% end %>
 </div>
 
-<%= render 'downloads/download_afterword.html' %>
+<%= render "downloads/download_afterword" %>

--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -378,7 +378,7 @@ en:
   downloads:
     download_afterword:
       please_comment_html: Please %{work_comment_link} to let the creator know if you enjoyed their work!
-      work_comment: drop by the archive and comment
+      work_comment: drop by the Archive and comment
   feedbacks:
     new:
       abuse:

--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -375,6 +375,10 @@ en:
           disable_anon: Sorry, this work doesn't allow non-Archive users to comment.
           hidden: Sorry, you can't add or edit comments on a hidden work.
           unrevealed: Sorry, you can't add or edit comments on an unrevealed work.
+  downloads:
+    download_afterword:
+      please_comment_html: Please %{work_comment_link} to let the creator know if you enjoyed their work!
+      work_comment: drop by the archive and comment
   feedbacks:
     new:
       abuse:

--- a/features/works/work_download.feature
+++ b/features/works/work_download.feature
@@ -114,6 +114,13 @@ Feature: Download a work
     And "Words:" should appear before "Chapters:"
     And "Chapters:" should appear before "Could be downloaded"
 
+  Scenario: Downloaded work afterword does not mention author
+
+  Given the work "Downloadable"
+  When I view the work "Downloadable"
+    And I follow "HTML"
+  Then I should not see "to let the author know if you enjoyed"
+    But I should see "to let the creator know if you enjoyed"
 
   Scenario: Download of chaptered works includes chapters
 


### PR DESCRIPTION
# Pull Request Checklist

* [X] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [X] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [X] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [X] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [X] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-5776

## Purpose

Replace "author" with "creator" in the download afterword that encourages commenting.

Did not do the bonus because counting the work creators looked quite complicated, at least when looking at the logic that bylines do. But maybe I missed some easy way to get all of a work's creators/external creators/anon status.

## Testing Instructions

See Jira.

## References

#4607 for the change to `downloads/show.html.erb`

## Credit

Bilka (he/him)