### PR TITLE
AO3-3217 Remove aria attributes from char counts

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -243,8 +243,8 @@ module ApplicationHelper
   # see: http://www.w3.org/TR/wai-aria/states_and_properties#aria-valuenow
   def generate_countdown_html(field_id, max)
     max = max.to_s
-    span = content_tag(:span, max, id: "#{field_id}_counter", class: "value", "data-maxlength" => max, "aria-live" => "polite", "aria-valuemax" => max, "aria-valuenow" => field_id)
-    content_tag(:p, span + ts(' characters left'), class: "character_counter")
+    span = content_tag(:span, max, id: "#{field_id}_counter", class: "value", "data-maxlength" => max)
+    content_tag(:p, span + ts(' characters left'), class: "character_counter", "tabindex" => 0)
   end
 
   # expand/contracts all expand/contract targets inside its nearest parent with the target class (usually index or listbox etc)


### PR DESCRIPTION
Remove chatty ARIA attributes from char count elements, make those elements tab-focusable instead.

## Issue

https://otwarchive.atlassian.net/browse/AO3-3217

## Purpose

Updates screenreader attributes on character count elements to prevent them from announcing the character count every time the user types. Instead, makes those elements tab-focusable.

## Testing Instructions

Using a screenreader, try editing fields like such at "Title" on the user profile page.

## Credit

Eliah Hecht, he/him
