### PR TITLE
AO3-6594 don't show location section if empty

### DIFF
--- a/app/views/profile/show.html.erb
+++ b/app/views/profile/show.html.erb
@@ -14,7 +14,7 @@
       <dd><%= l(@profile.created_at) %></dd>
       <dt><%= ts("My user ID is:") %></dt>
       <dd><%= @user.id %></dd>
-      <% if @profile.location and !@profile.location.empty? %>
+      <% if @profile.location.present? %>
         <dt class="location"><%=h ts("I live in:") %></dt>
         <dd><%=h @profile.location %></dd>
       <% end %>

--- a/app/views/profile/show.html.erb
+++ b/app/views/profile/show.html.erb
@@ -14,7 +14,7 @@
       <dd><%= l(@profile.created_at) %></dd>
       <dt><%= ts("My user ID is:") %></dt>
       <dd><%= @user.id %></dd>
-      <% if @profile.location %>
+      <% if @profile.location and !@profile.location.empty? %>
         <dt class="location"><%=h ts("I live in:") %></dt>
         <dd><%=h @profile.location %></dd>
       <% end %>

--- a/features/other_a/profile_edit.feature
+++ b/features/other_a/profile_edit.feature
@@ -16,18 +16,21 @@ Scenario: Add details
   When I fill in the details of my profile
   Then I should see "Your profile has been successfully updated"
     And 0 emails should be delivered
+    And I should see "I live in"
 
 Scenario: Change details
 
   When I change the details in my profile
   Then I should see "Your profile has been successfully updated"
     And 0 emails should be delivered
+    And I should see "I live in"
 
 Scenario: Remove details
 
   When I remove details from my profile
   Then I should see "Your profile has been successfully updated"
     And 0 emails should be delivered
+    And I should not see "I live in"
 
 Scenario: Change details as an admin
 


### PR DESCRIPTION
If the user's location is set to empty-string, omit the "I live in" section on their profile

## Issue

https://otwarchive.atlassian.net/browse/AO3-6594

## Purpose

Hides the "I live in" section on the profile if the location is set to empty-string

## Testing Instructions

Update your location to empty, make sure the corresponding section does not display on the profile view.

## Credit

Eliah Hecht, he/him
