### PR TITLE
AO3-6265 Use text-align start in comments

### DIFF
--- a/public/stylesheets/site/2.0/15-group-comments.css
+++ b/public/stylesheets/site/2.0/15-group-comments.css
@@ -15,6 +15,7 @@ div.comment, li.comment {
   position: relative;
   border: 1px solid #ddd;
   overflow: visible;
+  text-align: start;
 }
 
 .comment:after,


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6265

## Purpose

Fixes the issue where RTL text within comments is incorrectly left-aligned.

I was unable to think of a good way to automatically test this -- open to suggestions. Here's a screenshot from my dev environment though:

![46bb8e187da1e021351e5c371eb5fbed](https://github.com/otwcode/otwarchive/assets/532174/b81d77b6-3909-40c8-98cc-49169094c30c)

## Testing Instructions

Write a comment on work with text like `<p dir="rtl">Some text goes here</p>`, and make sure it appears right-aligned within the comment box.

## Credit

Eliah Hecht, he/him
