### PR TITLE
AO3-6487 Fix autocomplete for synced fandoms

### DIFF
--- a/app/models/common_tagging.rb
+++ b/app/models/common_tagging.rb
@@ -19,6 +19,7 @@ class CommonTagging < ApplicationRecord
   after_create :update_wrangler
   after_create :inherit_parents
   after_create :remove_uncategorized_media
+  after_create :update_child_autocomplete
 
   after_commit :update_search
 
@@ -26,6 +27,10 @@ class CommonTagging < ApplicationRecord
     unless User.current_user.nil?
       common_tag.update!(last_wrangler: User.current_user)
     end
+  end
+
+  def update_child_autocomplete
+    common_tag.after_update
   end
 
   # A relationship should inherit its characters' fandoms

--- a/spec/models/tag_wrangling_spec.rb
+++ b/spec/models/tag_wrangling_spec.rb
@@ -185,6 +185,31 @@ describe Tag do
           expect(synonym.children.reload).to contain_exactly
         end
 
+        describe "with asynchronous jobs run asynchronously" do
+          include ActiveJob::TestHelper
+
+          it "transfers the subtags to the new parent autocomplete" do
+            child = create(:canonical_character)
+            synonym.add_association(child)
+            synonym.reload
+
+            fandom_redis_key = Tag.transliterate("autocomplete_fandom_#{fandom.name.downcase}_character")
+
+            expect(REDIS_AUTOCOMPLETE.exists(fandom_redis_key)).to be false
+
+            synonym.update!(syn_string: fandom.name)
+
+            User.current_user = nil # No current user in asynchronous context (?)
+            perform_enqueued_jobs
+
+            expect(fandom.children.reload).to contain_exactly(child)
+            expect(synonym.children.reload).to be_empty
+
+            expect(REDIS_AUTOCOMPLETE.exists(fandom_redis_key)).to be true
+            expect(REDIS_AUTOCOMPLETE.zrange(fandom_redis_key, 0, -1)).to eq(["#{child.id}: #{child.name}"])
+          end
+        end
+
         it "transfers favorite tags" do
           user = create(:user)
           user.favorite_tags.create(tag: synonym)


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [x] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [x] Have you added the [Jira](https://otwarchive.atlassian.net) issue number as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [x] Do you have fewer than 5 pull requests already open? If not, please wait until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-6487

## Purpose

Ensure all children tags (characters/relationships) of a synonym fandom show up in the autocomplete of their new canonical fandom.

## Testing Instructions

See ticket. However, I confess that, due to the complexity of all the callbacks, I'm not sure of the exact setup to repeat the original bug consistently.

## References

https://otwarchive.atlassian.net/browse/AO3-3632?focusedCommentId=355114

All the detective work was done in that comment. My job here was mostly just to write a realistic test reproducing the crime. Which should be the case, assuming my wild guess of `User.current_user` being `nil`in the case of an actual asynchronous job in staging/production to be correct.

## Credit

Ceithir (he/him)
