### PR TITLE
AO3-6599 Apply local config on schedulers

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -86,7 +86,7 @@ namespace :deploy do
   end
 
   desc "Get the config files"
-  task :update_configs, roles: [:app, :web, :workers] do
+  task :update_configs, roles: [:app, :web, :workers, :schedulers] do
     run "/home/ao3app/bin/create_links_on_install"
   end
 


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [x] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [x] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [x] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-6599 

## Purpose

Currently the local config is not applied to machines which only run the scheduler.

## Testing Instructions

Someone with accounts on the systems will have to log in to a machine which only has the scheduler running and check that database.yml for example is populated.

## References

Are there other relevant issues/pull requests/mailing list discussions?

## Credit

james_ (him)
