### PR TITLE
AO3-6467 Track deletion of previous fnok on update

### DIFF
--- a/app/controllers/admin/admin_users_controller.rb
+++ b/app/controllers/admin/admin_users_controller.rb
@@ -73,7 +73,8 @@ class Admin::AdminUsersController < Admin::BaseController
     kin = User.find_by(login: params[:next_of_kin_name])
     kin_email = params[:next_of_kin_email]
 
-    if fnok&.kin == kin && fnok&.kin_email == kin_email
+    noop = (fnok.blank? && kin.blank? && kin_email.blank?) || (fnok.present? && fnok.kin == kin && fnok.kin_email == kin_email)
+    if noop
       flash[:notice] = ts("No change to Fannish next of kin.")
       redirect_to admin_user_path(@user)
       return

--- a/app/controllers/admin/admin_users_controller.rb
+++ b/app/controllers/admin/admin_users_controller.rb
@@ -87,9 +87,18 @@ class Admin::AdminUsersController < Admin::BaseController
       return
     end
 
+    previous_fnok_user_id = fnok&.kin&.id
     fnok = @user.build_fannish_next_of_kin if fnok.blank?
     fnok.assign_attributes(kin: kin, kin_email: kin_email)
     if fnok.save
+      if previous_fnok_user_id
+        @user.create_log_item({
+                                action: ArchiveConfig.ACTION_REMOVE_FNOK,
+                                fnok_user_id: previous_fnok_user_id,
+                                admin_id: current_admin.id,
+                                note: "Change made by #{current_admin.login}"
+                              })
+      end
       @user.create_log_item({
                               action: ArchiveConfig.ACTION_ADD_FNOK,
                               fnok_user_id: fnok.kin.id,

--- a/app/controllers/admin/admin_users_controller.rb
+++ b/app/controllers/admin/admin_users_controller.rb
@@ -73,17 +73,21 @@ class Admin::AdminUsersController < Admin::BaseController
     kin = User.find_by(login: params[:next_of_kin_name])
     kin_email = params[:next_of_kin_email]
 
-    noop = (fnok.blank? && kin.blank? && kin_email.blank?) || (fnok.present? && fnok.kin == kin && fnok.kin_email == kin_email)
-    if noop
-      flash[:notice] = ts("No change to Fannish next of kin.")
+    if kin.blank? && kin_email.blank?
+      if fnok.blank?
+        flash[:notice] = ts("No change to Fannish next of kin.")
+      else
+        fnok.destroy
+        log_next_of_kin_removed(previous_fnok_user_id)
+        flash[:notice] = ts("Fannish next of kin was removed.")
+      end
+
       redirect_to admin_user_path(@user)
       return
     end
 
-    if kin.blank? && kin_email.blank?
-      fnok.destroy
-      log_next_of_kin_removed(previous_fnok_user_id)
-      flash[:notice] = ts("Fannish next of kin was removed.")
+    if fnok&.kin == kin && fnok&.kin_email == kin_email
+      flash[:notice] = ts("No change to Fannish next of kin.")
       redirect_to admin_user_path(@user)
       return
     end

--- a/app/controllers/admin/admin_users_controller.rb
+++ b/app/controllers/admin/admin_users_controller.rb
@@ -73,6 +73,12 @@ class Admin::AdminUsersController < Admin::BaseController
     kin = User.find_by(login: params[:next_of_kin_name])
     kin_email = params[:next_of_kin_email]
 
+    if fnok&.kin == kin && fnok&.kin_email == kin_email
+      flash[:notice] = ts("No change to Fannish next of kin.")
+      redirect_to admin_user_path(@user)
+      return
+    end
+
     if kin.blank? && kin_email.blank?
       if fnok.present?
         fnok.destroy

--- a/app/controllers/admin/admin_users_controller.rb
+++ b/app/controllers/admin/admin_users_controller.rb
@@ -191,6 +191,8 @@ class Admin::AdminUsersController < Admin::BaseController
     @log_items ||= (@user.log_items + LogItem.where(fnok_user_id: @user.id)).sort_by(&:created_at).reverse
   end
 
+  private
+
   def log_next_of_kin_removed(user_id)
     return if user_id.blank?
 

--- a/app/controllers/admin/admin_users_controller.rb
+++ b/app/controllers/admin/admin_users_controller.rb
@@ -80,11 +80,9 @@ class Admin::AdminUsersController < Admin::BaseController
     end
 
     if kin.blank? && kin_email.blank?
-      if fnok.present?
-        fnok.destroy
-        log_next_of_kin_removed(previous_fnok_user_id)
-        flash[:notice] = ts("Fannish next of kin was removed.")
-      end
+      fnok.destroy
+      log_next_of_kin_removed(previous_fnok_user_id)
+      flash[:notice] = ts("Fannish next of kin was removed.")
       redirect_to admin_user_path(@user)
       return
     end

--- a/app/controllers/admin/admin_users_controller.rb
+++ b/app/controllers/admin/admin_users_controller.rb
@@ -183,7 +183,7 @@ class Admin::AdminUsersController < Admin::BaseController
   end
 
   def log_next_of_kin_removed(user_id)
-    return unless user_id.present?
+    return if user_id.blank?
 
     @user.create_log_item({
                             action: ArchiveConfig.ACTION_REMOVE_FNOK,

--- a/app/controllers/admin/admin_users_controller.rb
+++ b/app/controllers/admin/admin_users_controller.rb
@@ -75,7 +75,7 @@ class Admin::AdminUsersController < Admin::BaseController
 
     if kin.blank? && kin_email.blank?
       if fnok.blank?
-        flash[:notice] = ts("No change to Fannish next of kin.")
+        flash[:notice] = ts("No change to fannish next of kin.")
       else
         fnok.destroy
         log_next_of_kin_removed(previous_fnok_user_id)
@@ -87,7 +87,7 @@ class Admin::AdminUsersController < Admin::BaseController
     end
 
     if fnok&.kin == kin && fnok&.kin_email == kin_email
-      flash[:notice] = ts("No change to Fannish next of kin.")
+      flash[:notice] = ts("No change to fannish next of kin.")
       redirect_to admin_user_path(@user)
       return
     end

--- a/spec/controllers/admin/admin_users_controller_spec.rb
+++ b/spec/controllers/admin/admin_users_controller_spec.rb
@@ -292,7 +292,7 @@ describe Admin::AdminUsersController do
       post :update_next_of_kin, params: {
         user_login: user.login, next_of_kin_name: previous_kin.kin.login, next_of_kin_email: previous_kin.kin_email
       }
-      it_redirects_to_with_notice(admin_user_path(user), "No change to Fannish next of kin.")
+      it_redirects_to_with_notice(admin_user_path(user), "No change to fannish next of kin.")
       expect(user.reload.log_items).to be_empty
     end
 
@@ -303,7 +303,7 @@ describe Admin::AdminUsersController do
       post :update_next_of_kin, params: {
         user_login: user.login, next_of_kin_email: ""
       }
-      it_redirects_to_with_notice(admin_user_path(user), "No change to Fannish next of kin.")
+      it_redirects_to_with_notice(admin_user_path(user), "No change to fannish next of kin.")
       expect(user.reload.log_items).to be_empty
     end
   end

--- a/spec/controllers/admin/admin_users_controller_spec.rb
+++ b/spec/controllers/admin/admin_users_controller_spec.rb
@@ -292,11 +292,15 @@ describe Admin::AdminUsersController do
         expect(user.reload.log_items).to be_empty
       end
 
-      it "does nothing if fnok is kept undefined" do
+      it "errors properly if trying to add an incomplete fnok" do
         post :update_next_of_kin, params: {
           user_login: user.login, next_of_kin_email: ""
         }
-        it_redirects_to_with_notice(admin_user_path(user), "No change to fannish next of kin.")
+
+        kin = assigns(:user).fannish_next_of_kin
+        expect(kin).not_to be_valid
+        expect(kin.errors[:kin_email]).to include("can't be blank")
+
         expect(user.reload.log_items).to be_empty
       end
     end

--- a/spec/controllers/admin/admin_users_controller_spec.rb
+++ b/spec/controllers/admin/admin_users_controller_spec.rb
@@ -301,7 +301,7 @@ describe Admin::AdminUsersController do
       fake_login_admin(admin)
 
       post :update_next_of_kin, params: {
-        user_login: user.login
+        user_login: user.login, next_of_kin_email: ""
       }
       it_redirects_to_with_notice(admin_user_path(user), "No change to Fannish next of kin.")
       expect(user.reload.log_items).to be_empty

--- a/spec/controllers/admin/admin_users_controller_spec.rb
+++ b/spec/controllers/admin/admin_users_controller_spec.rb
@@ -292,7 +292,7 @@ describe Admin::AdminUsersController do
         expect(user.reload.log_items).to be_empty
       end
 
-      it "errors properly if trying to add an incomplete fnok" do
+      it "errors if trying to add an incomplete fnok" do
         post :update_next_of_kin, params: {
           user_login: user.login, next_of_kin_email: ""
         }

--- a/spec/controllers/admin/admin_users_controller_spec.rb
+++ b/spec/controllers/admin/admin_users_controller_spec.rb
@@ -283,6 +283,29 @@ describe Admin::AdminUsersController do
       expect(add_log_item.admin_id).to eq(admin.id)
       expect(add_log_item.note).to eq("Change made by #{admin.login}")
     end
+
+    it "does nothing if changing the fnok to themselves" do
+      admin = create(:support_admin)
+      fake_login_admin(admin)
+      previous_kin = create(:fannish_next_of_kin, user: user)
+
+      post :update_next_of_kin, params: {
+        user_login: user.login, next_of_kin_name: previous_kin.kin.login, next_of_kin_email: previous_kin.kin_email
+      }
+      it_redirects_to_with_notice(admin_user_path(user), "No change to Fannish next of kin.")
+      expect(user.reload.log_items).to be_empty
+    end
+
+    it "does nothing if fnok is kept undefined" do
+      admin = create(:support_admin)
+      fake_login_admin(admin)
+
+      post :update_next_of_kin, params: {
+        user_login: user.login
+      }
+      it_redirects_to_with_notice(admin_user_path(user), "No change to Fannish next of kin.")
+      expect(user.reload.log_items).to be_empty
+    end
   end
 
   describe "POST #update_status" do

--- a/spec/controllers/admin/admin_users_controller_spec.rb
+++ b/spec/controllers/admin/admin_users_controller_spec.rb
@@ -259,6 +259,30 @@ describe Admin::AdminUsersController do
       expect(log_item.admin_id).to eq(admin.id)
       expect(log_item.note).to eq("Change made by #{admin.login}")
     end
+
+    it "logs updating a fannish next of kin" do
+      admin = create(:support_admin)
+      fake_login_admin(admin)
+      previous_kin_user_id = create(:fannish_next_of_kin, user: user).kin_id
+
+      post :update_next_of_kin, params: {
+        user_login: user.login, next_of_kin_name: kin.login, next_of_kin_email: kin.email
+      }
+      user.reload
+      expect(user.fannish_next_of_kin.kin).to eq(kin)
+
+      remove_log_item = user.log_items[-2]
+      expect(remove_log_item.action).to eq(ArchiveConfig.ACTION_REMOVE_FNOK)
+      expect(remove_log_item.fnok_user.id).to eq(previous_kin_user_id)
+      expect(remove_log_item.admin_id).to eq(admin.id)
+      expect(remove_log_item.note).to eq("Change made by #{admin.login}")
+
+      add_log_item = user.log_items.last
+      expect(add_log_item.action).to eq(ArchiveConfig.ACTION_ADD_FNOK)
+      expect(add_log_item.fnok_user.id).to eq(kin.id)
+      expect(add_log_item.admin_id).to eq(admin.id)
+      expect(add_log_item.note).to eq("Change made by #{admin.login}")
+    end
   end
 
   describe "POST #update_status" do


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [x] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [x] Have you added the [Jira](https://otwarchive.atlassian.net) issue number as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [x] Do you have fewer than 5 pull requests already open? If not, please wait until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-6467?focusedCommentId=360436

## Purpose

Add the missing log when a fnok is replaced (akin to one deletion and one addition) 

## Testing Instructions

1. Add AccountB as an FNOK for AccountA. Check it shows in both the logs of AccountA and AccountB
2. Update the FNOK for AccountA to be AccountC. Check the deletion of previous fnok shows in the logs of AccountA and AccountB, and the addition of the new fnok shows in the log of AccountA and AccountC.

## Credit

Ceithir (he/him)