### PR TITLE
AO3-6605 Add Reviewdog for Rubocop check

### DIFF
--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -25,8 +25,6 @@ jobs:
         with:
           use_bundler: true
           reporter: github-pr-check
-          rubocop_version: gemfile
-          rubocop_extensions: rubocop-rails:gemfile rubocop-rspec:gemfile
           skip_install: true
 
   erb-lint:

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -27,6 +27,7 @@ jobs:
           reporter: github-pr-check
           rubocop_version: gemfile
           rubocop_extensions: rubocop-rails:gemfile rubocop-rspec:gemfile
+          skip_install: true
 
   erb-lint:
     name: ERB Lint runner

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Ruby and run bundle install
         uses: ruby/setup-ruby@v1

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -8,6 +8,26 @@ permissions:
   checks: write
 
 jobs:
+  rubocop:
+    name: Rubocop
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+
+      - name: Set up Ruby and run bundle install
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+
+      - name: rubocop
+        uses: reviewdog/action-rubocop@e70b014b8062c447d6b515ee0209f834ea93e696
+        with:
+          use_bundler: true
+          reporter: github-pr-check
+          rubocop_version: gemfile
+          rubocop_extensions: rubocop-rails:gemfile rubocop-rspec:gemfile
+
   erb-lint:
     name: ERB Lint runner
     runs-on: ubuntu-latest

--- a/.hound.yml
+++ b/.hound.yml
@@ -4,3 +4,6 @@
 jshint:
   config_file: .jshintrc
   ignore_file: .jshintignore
+
+rubocop:
+  enabled: false

--- a/.hound.yml
+++ b/.hound.yml
@@ -4,7 +4,3 @@
 jshint:
   config_file: .jshintrc
   ignore_file: .jshintignore
-
-rubocop:
-  version: 1.22.1
-  config_file: .rubocop.yml


### PR DESCRIPTION
# Pull Request Checklist

* [X] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [X] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [X] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [X] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [X] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-6605

## Purpose

Add a Reviewdog action to run Rubocop. This will give us more flexibility to add custom cops and upgrade to the latest version of rubcop (and its plugins). Example of how Rubocop warnings will show up: https://github.com/brianjaustin/ao3-sandbox/pull/1/files (the specific message is from a custom cop).

Note: no changes in _what_ Rubocop flags are expected yet. Custom cops (and maybe other plugins?) will come in later PR(s)

## Follow-Up Instructions
1. Allow-list the action in this Github repository's settings (similar to #4604)
~2. Deactivate/remove this repository from our Hound account -- optional but recommended to avoid duplicate comments and errors when we upgrade or add custom cops~

## Credit

Brian Austin (they/he)