### PR TITLE
AO3-6487 More attempts at fixing autocompletes after a fandom is made a synonym

### DIFF
--- a/app/models/common_tagging.rb
+++ b/app/models/common_tagging.rb
@@ -30,7 +30,7 @@ class CommonTagging < ApplicationRecord
   end
 
   def update_child_autocomplete
-    common_tag&.refresh_autocomplete
+    common_tag&.add_to_parent_fandoms_autocomplete
   end
 
   # A relationship should inherit its characters' fandoms

--- a/app/models/common_tagging.rb
+++ b/app/models/common_tagging.rb
@@ -36,7 +36,7 @@ class CommonTagging < ApplicationRecord
   end
 
   def remove_from_autocomplete
-    common_tag&.remove_from_fandom_autocomplete(filterable)
+    common_tag.remove_from_fandom_autocomplete(filterable)
   end
 
   # A relationship should inherit its characters' fandoms

--- a/app/models/common_tagging.rb
+++ b/app/models/common_tagging.rb
@@ -36,7 +36,7 @@ class CommonTagging < ApplicationRecord
   end
 
   def remove_from_autocomplete
-    common_tag.remove_from_fandom_autocomplete(filterable)
+    common_tag&.remove_from_fandom_autocomplete(filterable)
   end
 
   # A relationship should inherit its characters' fandoms

--- a/app/models/common_tagging.rb
+++ b/app/models/common_tagging.rb
@@ -30,7 +30,7 @@ class CommonTagging < ApplicationRecord
   end
 
   def update_child_autocomplete
-    common_tag.refresh_autocomplete
+    common_tag&.refresh_autocomplete
   end
 
   # A relationship should inherit its characters' fandoms

--- a/app/models/common_tagging.rb
+++ b/app/models/common_tagging.rb
@@ -21,9 +21,9 @@ class CommonTagging < ApplicationRecord
   after_create :remove_uncategorized_media
   after_create :add_to_autocomplete
 
-  after_commit :update_search
-
   before_destroy :remove_from_autocomplete
+
+  after_commit :update_search
 
   def update_wrangler
     unless User.current_user.nil?

--- a/app/models/common_tagging.rb
+++ b/app/models/common_tagging.rb
@@ -32,11 +32,15 @@ class CommonTagging < ApplicationRecord
   end
 
   def add_to_autocomplete
-    common_tag.add_to_fandom_autocomplete(filterable)
+    if filterable.is_a?(Fandom) && common_tag.eligible_for_fandom_autocomplete?
+      common_tag.add_to_fandom_autocomplete(filterable)
+    end
   end
 
   def remove_from_autocomplete
-    common_tag&.remove_from_fandom_autocomplete(filterable)
+    if filterable.is_a?(Fandom) && common_tag&.was_eligible_for_fandom_autocomplete?
+      common_tag.remove_from_fandom_autocomplete(filterable)
+    end
   end
 
   # A relationship should inherit its characters' fandoms

--- a/app/models/common_tagging.rb
+++ b/app/models/common_tagging.rb
@@ -32,15 +32,15 @@ class CommonTagging < ApplicationRecord
   end
 
   def add_to_autocomplete
-    if filterable.is_a?(Fandom) && common_tag.eligible_for_fandom_autocomplete?
-      common_tag.add_to_fandom_autocomplete(filterable)
-    end
+    return unless filterable.is_a?(Fandom) && common_tag.eligible_for_fandom_autocomplete?
+
+    common_tag.add_to_fandom_autocomplete(filterable)
   end
 
   def remove_from_autocomplete
-    if filterable.is_a?(Fandom) && common_tag&.was_eligible_for_fandom_autocomplete?
-      common_tag.remove_from_fandom_autocomplete(filterable)
-    end
+    return unless filterable.is_a?(Fandom) && common_tag&.was_eligible_for_fandom_autocomplete?
+
+    common_tag.remove_from_fandom_autocomplete(filterable)
   end
 
   # A relationship should inherit its characters' fandoms

--- a/app/models/common_tagging.rb
+++ b/app/models/common_tagging.rb
@@ -19,9 +19,9 @@ class CommonTagging < ApplicationRecord
   after_create :update_wrangler
   after_create :inherit_parents
   after_create :remove_uncategorized_media
-  after_create :update_child_autocomplete
 
   after_commit :update_search
+  after_commit :update_child_autocomplete
 
   def update_wrangler
     unless User.current_user.nil?

--- a/app/models/common_tagging.rb
+++ b/app/models/common_tagging.rb
@@ -23,6 +23,8 @@ class CommonTagging < ApplicationRecord
 
   after_commit :update_search
 
+  before_destroy :remove_from_autocomplete
+
   def update_wrangler
     unless User.current_user.nil?
       common_tag.update!(last_wrangler: User.current_user)
@@ -31,6 +33,10 @@ class CommonTagging < ApplicationRecord
 
   def add_to_autocomplete
     common_tag.add_to_fandom_autocomplete(filterable)
+  end
+
+  def remove_from_autocomplete
+    common_tag&.remove_from_fandom_autocomplete(filterable)
   end
 
   # A relationship should inherit its characters' fandoms

--- a/app/models/common_tagging.rb
+++ b/app/models/common_tagging.rb
@@ -19,9 +19,9 @@ class CommonTagging < ApplicationRecord
   after_create :update_wrangler
   after_create :inherit_parents
   after_create :remove_uncategorized_media
+  after_create :add_to_autocomplete
 
   after_commit :update_search
-  after_commit :update_child_autocomplete
 
   def update_wrangler
     unless User.current_user.nil?
@@ -29,8 +29,8 @@ class CommonTagging < ApplicationRecord
     end
   end
 
-  def update_child_autocomplete
-    common_tag&.add_to_parent_fandoms_autocomplete
+  def add_to_autocomplete
+    common_tag.add_to_fandom_autocomplete(filterable)
   end
 
   # A relationship should inherit its characters' fandoms

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -488,11 +488,16 @@ class Tag < ApplicationRecord
 
   def remove_from_autocomplete
     super
-    if self.is_a?(Character) || self.is_a?(Relationship)
-      parents.each do |parent|
-        REDIS_AUTOCOMPLETE.zrem(self.transliterate("autocomplete_fandom_#{parent.name.downcase}_#{type.downcase}"), autocomplete_value) if parent.is_a?(Fandom)
-      end
+    parents.each do |parent|
+      remove_from_fandom_autocomplete(parent)
     end
+  end
+
+  def remove_from_fandom_autocomplete(fandom)
+    return unless fandom.is_a?(Fandom)
+    return unless self.is_a?(Character) || self.is_a?(Relationship)
+
+    REDIS_AUTOCOMPLETE.zrem(self.transliterate("autocomplete_fandom_#{fandom.name.downcase}_#{type.downcase}"), autocomplete_value)
   end
 
   def remove_stale_from_autocomplete

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -498,11 +498,11 @@ class Tag < ApplicationRecord
   end
 
   def eligible_for_fandom_autocomplete?
-    return (self.is_a?(Character) || self.is_a?(Relationship)) && canonical
+    (self.is_a?(Character) || self.is_a?(Relationship)) && canonical
   end
 
   def was_eligible_for_fandom_autocomplete?
-    return (self.is_a?(Character) || self.is_a?(Relationship))
+    (self.is_a?(Character) || self.is_a?(Relationship))
   end
 
   def remove_stale_from_autocomplete

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -816,9 +816,11 @@ class Tag < ApplicationRecord
       self.child_taggings.destroy_all
       self.sub_taggings.destroy_all
       self.meta_taggings.destroy_all
-    end
 
-    refresh_autocomplete
+      if self.merger&.canonical? and self.merger&.is_a?(Fandom)
+        self.merger.async_after_commit(:refresh_all_children_autocomplete)
+      end
+    end
   end
 
   # When we make this tag a synonym of another canonical tag, we want to move
@@ -1006,6 +1008,10 @@ class Tag < ApplicationRecord
         syn.update(merger_id: self.id)
       end
     end
+  end
+
+  def refresh_all_children_autocomplete
+    child_taggings&.each(&:update_child_autocomplete)
   end
 
   #################################

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -486,10 +486,11 @@ class Tag < ApplicationRecord
 
   def remove_from_autocomplete
     super
-    if was_eligible_for_fandom_autocomplete?
-      parents.each do |parent|
-        remove_from_fandom_autocomplete(parent) if parent.is_a?(Fandom)
-      end
+
+    return unless was_eligible_for_fandom_autocomplete?
+
+    parents.each do |parent|
+      remove_from_fandom_autocomplete(parent) if parent.is_a?(Fandom)
     end
   end
 

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -817,9 +817,7 @@ class Tag < ApplicationRecord
       self.sub_taggings.destroy_all
       self.meta_taggings.destroy_all
 
-      if self.merger&.canonical? and self.merger&.is_a?(Fandom)
-        self.merger.async_after_commit(:refresh_all_children_autocomplete)
-      end
+      self.merger.async_after_commit(:refresh_all_children_autocomplete) if self.merger&.canonical? && self.merger.is_a?(Fandom)
     end
   end
 

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -822,8 +822,6 @@ class Tag < ApplicationRecord
       self.child_taggings.destroy_all
       self.sub_taggings.destroy_all
       self.meta_taggings.destroy_all
-
-      self.merger.async_after_commit(:refresh_all_children_autocomplete) if self.merger&.canonical? && self.merger.is_a?(Fandom)
     end
   end
 
@@ -1012,10 +1010,6 @@ class Tag < ApplicationRecord
         syn.update(merger_id: self.id)
       end
     end
-  end
-
-  def refresh_all_children_autocomplete
-    child_taggings&.each(&:add_to_autocomplete)
   end
 
   #################################

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -503,7 +503,7 @@ class Tag < ApplicationRecord
   end
 
   def was_eligible_for_fandom_autocomplete?
-    (self.is_a?(Character) || self.is_a?(Relationship)) && canonical_before_last_save
+    (self.is_a?(Character) || self.is_a?(Relationship)) && (canonical || canonical_before_last_save)
   end
 
   def remove_stale_from_autocomplete

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -817,6 +817,8 @@ class Tag < ApplicationRecord
       self.sub_taggings.destroy_all
       self.meta_taggings.destroy_all
     end
+
+    refresh_autocomplete
   end
 
   # When we make this tag a synonym of another canonical tag, we want to move

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -471,13 +471,18 @@ class Tag < ApplicationRecord
   end
 
   def add_to_autocomplete(score = nil)
-    score ||= autocomplete_score
-    if self.is_a?(Character) || self.is_a?(Relationship)
-      parents.each do |parent|
-        REDIS_AUTOCOMPLETE.zadd(self.transliterate("autocomplete_fandom_#{parent.name.downcase}_#{type.downcase}"), score, autocomplete_value) if parent.is_a?(Fandom)
-      end
-    end
+    add_to_parent_fandoms_autocomplete(score)
     super
+  end
+
+  def add_to_parent_fandoms_autocomplete(score = nil)
+    return unless canonical
+    return unless self.is_a?(Character) || self.is_a?(Relationship)
+
+    score ||= autocomplete_score
+    parents.each do |parent|
+      REDIS_AUTOCOMPLETE.zadd(self.transliterate("autocomplete_fandom_#{parent.name.downcase}_#{type.downcase}"), score, autocomplete_value) if parent.is_a?(Fandom)
+    end
   end
 
   def remove_from_autocomplete

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -503,16 +503,16 @@ class Tag < ApplicationRecord
   end
 
   def was_eligible_for_fandom_autocomplete?
-    self.is_a?(Character) || self.is_a?(Relationship) && canonical_before_last_save
+    (self.is_a?(Character) || self.is_a?(Relationship)) && canonical_before_last_save
   end
 
   def remove_stale_from_autocomplete
     super
 
-    if was_eligible_for_fandom_autocomplete?
-      parents.each do |parent|
-        REDIS_AUTOCOMPLETE.zrem(self.transliterate("autocomplete_fandom_#{parent.name.downcase}_#{type.downcase}"), autocomplete_value_before_last_save) if parent.is_a?(Fandom)
-      end
+    return unless was_eligible_for_fandom_autocomplete?
+
+    parents.each do |parent|
+      REDIS_AUTOCOMPLETE.zrem(self.transliterate("autocomplete_fandom_#{parent.name.downcase}_#{type.downcase}"), autocomplete_value_before_last_save) if parent.is_a?(Fandom)
     end
   end
 

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -503,12 +503,13 @@ class Tag < ApplicationRecord
   end
 
   def was_eligible_for_fandom_autocomplete?
-    (self.is_a?(Character) || self.is_a?(Relationship))
+    self.is_a?(Character) || self.is_a?(Relationship) && canonical_before_last_save
   end
 
   def remove_stale_from_autocomplete
     super
-    if self.is_a?(Character) || self.is_a?(Relationship)
+
+    if was_eligible_for_fandom_autocomplete?
       parents.each do |parent|
         REDIS_AUTOCOMPLETE.zrem(self.transliterate("autocomplete_fandom_#{parent.name.downcase}_#{type.downcase}"), autocomplete_value_before_last_save) if parent.is_a?(Fandom)
       end

--- a/spec/models/tag_wrangling_spec.rb
+++ b/spec/models/tag_wrangling_spec.rb
@@ -586,7 +586,7 @@ describe Tag do
       expect_autocomplete_to_return(fandom, [character])
     end
 
-    it "updates Redis autocomplete when removing a canon character from a fandom" do
+    it "updates Redis autocomplete when removing a character from a fandom" do
       fandom = create(:canonical_fandom)
       character = create(:canonical_character)
 

--- a/spec/models/tag_wrangling_spec.rb
+++ b/spec/models/tag_wrangling_spec.rb
@@ -201,6 +201,7 @@ describe Tag do
 
             User.current_user = nil # No current user in asynchronous context (?)
             perform_enqueued_jobs
+            perform_enqueued_jobs # Some async jobs trigger other async jobs
 
             expect(fandom.children.reload).to contain_exactly(child)
             expect(synonym.children.reload).to be_empty

--- a/spec/models/tag_wrangling_spec.rb
+++ b/spec/models/tag_wrangling_spec.rb
@@ -596,6 +596,17 @@ describe Tag do
       fandom.child_taggings.destroy_all
       expect_autocomplete_to_return(fandom, [])
     end
+
+    it "updates Redis autocomplete when a character is deleted" do
+      fandom = create(:canonical_fandom)
+      character = create(:canonical_character)
+
+      fandom.add_association(character)
+      expect_autocomplete_to_return(fandom, [character])
+
+      character.destroy
+      expect_autocomplete_to_return(fandom, [])
+    end
   end
 
   def redis_autocomplete_key(fandom)

--- a/spec/models/tag_wrangling_spec.rb
+++ b/spec/models/tag_wrangling_spec.rb
@@ -609,15 +609,9 @@ describe Tag do
     end
   end
 
-  def redis_autocomplete_key(fandom)
-    Tag.transliterate("autocomplete_fandom_#{fandom.name.downcase}_character")
-  end
-
-  def redis_autocomplete_store(fandom)
-    REDIS_AUTOCOMPLETE.zrange(redis_autocomplete_key(fandom), 0, -1)
-  end
-
   def expect_autocomplete_to_return(fandom, characters)
-    expect(redis_autocomplete_store(fandom)).to eq characters.map { |character| "#{character.id}: #{character.name}" }
+    redis_key = Tag.transliterate("autocomplete_fandom_#{fandom.name.downcase}_character")
+    redis_store = REDIS_AUTOCOMPLETE.zrange(redis_key, 0, -1)
+    expect(redis_store).to eq characters.map { |character| "#{character.id}: #{character.name}" }
   end
 end

--- a/spec/models/tag_wrangling_spec.rb
+++ b/spec/models/tag_wrangling_spec.rb
@@ -607,6 +607,40 @@ describe Tag do
       character.destroy
       expect_autocomplete_to_return(fandom, [])
     end
+
+    it "adds to autocomplete when a character becomes canonical" do
+      fandom = create(:canonical_fandom)
+      character = create(:character)
+
+      fandom.add_association(character)
+      expect_autocomplete_to_return(fandom, [])
+
+      character.reload.update! canonical: true
+      expect_autocomplete_to_return(fandom, [character])
+    end
+
+    it "removes from autocomplete when a character loses its canonicity" do
+      fandom = create(:canonical_fandom)
+      character = create(:canonical_character)
+
+      fandom.add_association(character)
+      expect_autocomplete_to_return(fandom, [character])
+
+      character.reload.update! canonical: false
+      expect_autocomplete_to_return(fandom, [])
+    end
+
+    it "updates autocomplete when a character name changes" do
+      fandom = create(:canonical_fandom)
+      character = create(:canonical_character)
+
+      fandom.add_association(character)
+      expect_autocomplete_to_return(fandom, [character])
+
+      User.current_user = create(:admin)
+      character.reload.update! name: "Toto"
+      expect_autocomplete_to_return(fandom, [character])
+    end
   end
 
   def expect_autocomplete_to_return(fandom, characters)

--- a/spec/models/tag_wrangling_spec.rb
+++ b/spec/models/tag_wrangling_spec.rb
@@ -201,7 +201,6 @@ describe Tag do
 
             User.current_user = nil # No current user in asynchronous context
             perform_enqueued_jobs
-            perform_enqueued_jobs # Some async jobs trigger other async jobs
 
             expect(fandom.children.reload).to contain_exactly(child)
             expect(synonym.children.reload).to be_empty

--- a/spec/models/tag_wrangling_spec.rb
+++ b/spec/models/tag_wrangling_spec.rb
@@ -199,7 +199,7 @@ describe Tag do
 
             synonym.update!(syn_string: fandom.name)
 
-            User.current_user = nil # No current user in asynchronous context (?)
+            User.current_user = nil # No current user in asynchronous context
             perform_enqueued_jobs
             perform_enqueued_jobs # Some async jobs trigger other async jobs
 


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [x] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [x] Have you added the [Jira](https://otwarchive.atlassian.net) issue number as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [x] Do you have fewer than 5 pull requests already open? If not, please wait until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-6487

## Purpose

Shots in the dark at fixing the issue described in the ticket.

Because, while it's not issue reproducing it on staging:

Manually fixed tag:
```
curl -u "LOGIN:PASSWORD" "https://test.archiveofourown.org/autocomplete/character_in_fandom?term=bob&fandom[]=Your%20Organic%20Love" -H "Accept: application/json"
```

Tag left as is after synonymizing:
```
curl -u "LOGIN:PASSWORD" "https://test.archiveofourown.org/autocomplete/character_in_fandom?term=lindsey&fandom[]=Your%20Organic%20Love" -H "Accept: application/json"
```

~~I haven't been able to recreate the conditions for it in tests.~~

~~So trying to:~~
~~- Force the autocomplete refresh each time the association is updated, not only on create. It makes sense and is consistent with how the reindex works.~~
~~- Add an explicit autocomplete refresh at the end of the merging operation ("belts and suspenders")~~

-> Change of approach, by going granular instead, with unit tests checking if the autocomplete is updated properly when creating/deleting an association. Did find and fix some bugs at that level, though still unsure that's the cause of what's happening in staging/production.

## Testing Instructions

1. Rename a fandom by making it a synonym of a new (canonical) fandom
2. When creating a work for that fandom, check the autocomplete is only limited to that fandom tags

## Credit

Ceithir (he/him)