### PR TITLE
AO3-6616 Fix floating and displaced form elements in new webkit

### DIFF
--- a/public/stylesheets/site/2.0/07-interactions.css
+++ b/public/stylesheets/site/2.0/07-interactions.css
@@ -126,6 +126,10 @@ form dt {
   border-bottom: 1px solid #f3efec;
 }
 
+form dt.landmark, form dt.notes, .dashboard form dt.landmark {
+  clear: both;
+}
+
 form dd, form dd.any {
   float: left;
   width: 72.5%;
@@ -142,6 +146,10 @@ form dd + dd {
 
 form dd.required {
   color: #2a2a2a;
+}
+
+form dd.notes {
+  clear: none;
 }
 
 form .footnote code {
@@ -682,6 +690,7 @@ form.single .autocomplete + input + span.submit input[type="submit"] {
 .dashboard > form {
   float: left;
   width: 100%;
+  clear: none;
 }
 
 .dashboard fieldset {

--- a/public/stylesheets/site/2.0/07-interactions.css
+++ b/public/stylesheets/site/2.0/07-interactions.css
@@ -126,7 +126,7 @@ form dt {
   border-bottom: 1px solid #f3efec;
 }
 
-form dt.landmark, form dt.notes, .dashboard form dt.landmark {
+form dt.landmark, .dashboard form dt.landmark {
   clear: both;
 }
 
@@ -146,10 +146,6 @@ form dd + dd {
 
 form dd.required {
   color: #2a2a2a;
-}
-
-form dd.notes {
-  clear: none;
 }
 
 form .footnote code {

--- a/public/stylesheets/site/2.0/07-interactions.css
+++ b/public/stylesheets/site/2.0/07-interactions.css
@@ -126,10 +126,6 @@ form dt {
   border-bottom: 1px solid #f3efec;
 }
 
-form dt.landmark, .dashboard form dt.landmark {
-  clear: both;
-}
-
 form dd, form dd.any {
   float: left;
   width: 72.5%;
@@ -691,6 +687,10 @@ form.single .autocomplete + input + span.submit input[type="submit"] {
 
 .dashboard fieldset {
   clear: right;
+}
+
+.dashboard form dt.landmark {
+  clear: both;
 }
 
 /*END== */

--- a/public/stylesheets/site/2.0/13-group-blurb.css
+++ b/public/stylesheets/site/2.0/13-group-blurb.css
@@ -232,7 +232,6 @@ li.blurb:after, .blurb .blurb:after {
 }
 
 .blurb blockquote {
-  clear: none;
   margin: 0.643em auto;
   text-align: justify;
 }

--- a/public/stylesheets/site/2.0/22-system-messages.css
+++ b/public/stylesheets/site/2.0/22-system-messages.css
@@ -51,7 +51,7 @@ div.error {
     box-shadow: 1px 1px 2px;
 }
 
-.notes {
+p.notes {
   clear: right;
 }
 


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6616

## Purpose

webkit did something terrible that affected the position of various form elements, most notably:

- the bottom Sort and Filter button on the filters has relocated to the top
- the notes options on the posting form has migrated upward to interfere with other form options

Full details are in the issue.

## Testing Instructions

We'll want to test Safari 17 to make sure the issue is fixed _and_ at least one older version of Safari, plus Firefox and Chrome (any version), to make sure we didn't break anything new.

## References

I diagnose the issue in [this comment](https://otwarchive.atlassian.net/browse/AO3-6616?focusedCommentId=360502).

## Credit

Sarken, she/her