### PR TITLE
AO3-6328 Try to fix large tags not updating in uses sort

### DIFF
--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1133,6 +1133,11 @@ class Tag < ApplicationRecord
       end
     end
 
+    # Ensure tags with count cache are updated.
+    if tag.saved_change_to_taggings_count_cache?
+      Rails.cache.delete(taggings_count_cache_key)
+    end
+
     # Reindex immediately to update the unwrangled bin.
     if tag.saved_change_to_unwrangleable?
       tag.reindex_document

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1133,7 +1133,7 @@ class Tag < ApplicationRecord
       end
     end
 
-    # Ensure tags with count cache are updated.
+    # Ensure tags with count cache can be reindexed.
     if tag.saved_change_to_taggings_count_cache?
       Rails.cache.delete(taggings_count_cache_key)
     end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1134,9 +1134,7 @@ class Tag < ApplicationRecord
     end
 
     # Ensure tags with count cache can be reindexed.
-    if tag.saved_change_to_taggings_count_cache?
-      Rails.cache.delete(taggings_count_cache_key)
-    end
+    Rails.cache.delete(taggings_count_cache_key) if tag.saved_change_to_taggings_count_cache?
 
     # Reindex immediately to update the unwrangled bin.
     if tag.saved_change_to_unwrangleable?

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -82,9 +82,7 @@ describe Tag do
       let(:tag) { create(:fandom) }
       let!(:work) { create(:work, fandom_string: tag.name) }
 
-      before do
-        run_update_tag_count_job
-      end
+      before { run_update_tag_count_job }
 
       def run_update_tag_count_job
         RedisJobSpawner.perform_now("TagCountUpdateJob")

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -137,8 +137,8 @@ describe Tag do
 
       it "triggers reindexing of tags which aren't used much" do
         create(:work, fandom_string: tag.name)
-        expect { run_update_tag_count_job }.to
-          add_to_reindex_queue(tag, :main)
+        expect { run_update_tag_count_job }
+          .to add_to_reindex_queue(tag, :main)
       end
 
       it "triggers reindexing of tags which are used significantly" do
@@ -146,8 +146,8 @@ describe Tag do
           create(:work, fandom_string: tag.name)
         end
 
-        expect { run_update_tag_count_job }.to
-          add_to_reindex_queue(tag, :main)
+        expect { run_update_tag_count_job }
+          .to add_to_reindex_queue(tag, :main)
         expect_tag_update_flag_in_redis_to_be(false)
 
         create(:work, fandom_string: tag.name)

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -137,7 +137,8 @@ describe Tag do
 
       it "triggers reindexing of tags which aren't used much" do
         create(:work, fandom_string: tag.name)
-        expect{ run_update_tag_count_job }.to add_to_reindex_queue(tag, :main)
+        expect { run_update_tag_count_job }.to
+          add_to_reindex_queue(tag, :main)
       end
 
       it "triggers reindexing of tags which are used significantly" do
@@ -145,7 +146,8 @@ describe Tag do
           create(:work, fandom_string: tag.name)
         end
 
-        expect{ run_update_tag_count_job }.to add_to_reindex_queue(tag, :main)
+        expect { run_update_tag_count_job }.to
+          add_to_reindex_queue(tag, :main)
         expect_tag_update_flag_in_redis_to_be(false)
 
         create(:work, fandom_string: tag.name)

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -83,6 +83,10 @@ describe Tag do
       let!(:work) { create(:work, fandom_string: tag.name) }
 
       before do
+        run_update_tag_count_job
+      end
+
+      def run_update_tag_count_job
         RedisJobSpawner.perform_now("TagCountUpdateJob")
         tag.reload
       end
@@ -105,8 +109,7 @@ describe Tag do
         tag.taggings_count = 2
         expect_tag_update_flag_in_redis_to_be(true)
 
-        RedisJobSpawner.perform_now("TagCountUpdateJob")
-        tag.reload
+        run_update_tag_count_job
 
         # Actual number of taggings has not changed though count cache has.
         expect(tag.taggings_count_cache).to eq 2
@@ -117,8 +120,7 @@ describe Tag do
         create(:work, fandom_string: tag.name)
         expect_tag_update_flag_in_redis_to_be(true)
 
-        RedisJobSpawner.perform_now("TagCountUpdateJob")
-        tag.reload
+        run_update_tag_count_job
 
         expect(tag.taggings_count_cache).to eq 2
         expect(tag.taggings_count).to eq 2
@@ -130,16 +132,14 @@ describe Tag do
         REDIS_GENERAL.set("tag_update_#{tag.id}_value", "")
         REDIS_GENERAL.sadd("tag_update", tag.id)
 
-        RedisJobSpawner.perform_now("TagCountUpdateJob")
+        run_update_tag_count_job
 
-        expect(tag.reload.taggings_count_cache).to eq 1
+        expect(tag.taggings_count_cache).to eq 1
       end
 
       it "triggers reindexing of tags which aren't used much" do
         create(:work, fandom_string: tag.name)
-
-        expect { RedisJobSpawner.perform_now("TagCountUpdateJob") }
-          .to add_to_reindex_queue(tag.reload, :main)
+        expect{ run_update_tag_count_job }.to add_to_reindex_queue(tag, :main)
       end
 
       it "triggers reindexing of tags which are used significantly" do
@@ -147,8 +147,11 @@ describe Tag do
           create(:work, fandom_string: tag.name)
         end
 
-        expect { RedisJobSpawner.perform_now("TagCountUpdateJob") }
-          .to add_to_reindex_queue(tag.reload, :main)
+        expect{ run_update_tag_count_job }.to add_to_reindex_queue(tag, :main)
+        expect_tag_update_flag_in_redis_to_be(false)
+
+        create(:work, fandom_string: tag.name)
+        expect_tag_update_flag_in_redis_to_be(true)
       end
     end
   end


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [x] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [x] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [x] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-6328 (Second PR)

## Purpose

Tries to ensure that when the number of uses of a large tag increases (e.g. when a work is posted), a reindex is triggered. After some investigation, it looks like the cached tag count prevents `write_taggings_to_redis` from being called when the tag has at least 1000 uses (`TAGGINGS_COUNT_MIN_CACHE_COUNT`). 

I am not 100% sure of this approach, which is to remove the old cached count in `after_update`. Another way I believe to be possible is setting the `taggings_count_cache` range in [ScheduledTagJob](https://github.com/otwcode/otwarchive/blob/660a67aae71f2e0dbfc0316727ce7ce160ed607a/app/models/scheduled_tag_job.rb#L5) to be a lower value like `TAGGINGS_COUNT_MIN_CACHE_COUNT`. Not sure of the broader implications of these methods.

## Testing Instructions

See Jira issue.

## References

https://github.com/otwcode/otwarchive/pull/4632

## Credit

weeklies (she/her)
