### PR TITLE
AO3-6328 Write tagging count to cache and Redis on tagging create and…

### DIFF
--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1133,9 +1133,6 @@ class Tag < ApplicationRecord
       end
     end
 
-    # Ensure tags with count cache can be reindexed.
-    Rails.cache.delete(taggings_count_cache_key) if tag.saved_change_to_taggings_count_cache?
-
     # Reindex immediately to update the unwrangled bin.
     if tag.saved_change_to_unwrangleable?
       tag.reindex_document

--- a/app/models/tagging.rb
+++ b/app/models/tagging.rb
@@ -22,15 +22,9 @@ class Tagging < ApplicationRecord
     Tagging.find_by(tagger_id: tag.id, taggable_id: taggable.id, tagger_type: 'Tag', taggable_type: taggable.class.name)
   end
 
-  # Most of the time, we don't need the taggings_count_cache stored in the
-  # database to be perfectly accurate. But because of the way Tag.in_use is
-  # defined and used, the difference between a value of 0 and a value of 1 is
-  # important. So we make sure to poke the taggings_count cache every time we
-  # create or destroy a tagging. If it's a large tag, it'll fall back on the
-  # cached value. If it's a small tag, it'll recompute -- and make sure that it
-  # handles the transition from 0 uses to 1 use properly.
   def update_taggings_count
-    tagger.update_tag_cache unless tagger.blank? || tagger.destroyed?
+    return if tagger.blank? || tagger.destroyed?
+    tagger.taggings_count = tagger.taggings.count
   end
 
   def update_search

--- a/app/models/tagging.rb
+++ b/app/models/tagging.rb
@@ -24,6 +24,7 @@ class Tagging < ApplicationRecord
 
   def update_taggings_count
     return if tagger.blank? || tagger.destroyed?
+
     tagger.taggings_count = tagger.taggings.count
   end
 

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -6,7 +6,7 @@ describe Tag do
     User.current_user = nil
   end
 
-  context 'checking count caching' do
+  context "checking count caching" do
     let(:fandom_tag) { create(:fandom) }
 
     before(:each) do
@@ -18,8 +18,8 @@ describe Tag do
       ArchiveConfig.TAGGINGS_COUNT_MIN_CACHE_COUNT = 3
     end
 
-    context 'without running TagCountUpdateJob to update taggings_count_cache' do
-      it 'does not cache tags which are not used much' do
+    context "without running TagCountUpdateJob to update taggings_count_cache" do
+      it "does not cache tags which are not used much" do
         create(:work, fandom_string: fandom_tag.name)
         fandom_tag.reload
         expect(fandom_tag.taggings_count_cache).to eq 0
@@ -27,7 +27,7 @@ describe Tag do
         expect(fandom_tag.taggings_count).to eq 1
       end
 
-      it 'starts caching when a tag is used significantly' do
+      it "starts caching when a tag is used significantly" do
         (1..ArchiveConfig.TAGGINGS_COUNT_MIN_CACHE_COUNT).each do |try|
           create(:work, fandom_string: fandom_tag.name)
           fandom_tag.reload
@@ -44,8 +44,8 @@ describe Tag do
       end
     end
 
-    context 'when running TagCountUpdateJob to update taggings_count_cache' do
-      it 'does not cache tags which are not used much' do
+    context "when running TagCountUpdateJob to update taggings_count_cache" do
+      it "does not cache tags which are not used much" do
         create(:work, fandom_string: fandom_tag.name)
         RedisJobSpawner.perform_now("TagCountUpdateJob")
         fandom_tag.reload
@@ -54,7 +54,7 @@ describe Tag do
         expect(fandom_tag.taggings_count).to eq 1
       end
 
-      it 'starts caching when a tag is used significantly' do
+      it "starts caching when a tag is used significantly" do
         (1..ArchiveConfig.TAGGINGS_COUNT_MIN_CACHE_COUNT).each do |try|
           create(:work, fandom_string: fandom_tag.name)
           RedisJobSpawner.perform_now("TagCountUpdateJob")


### PR DESCRIPTION
… destroy

## Issue

https://otwarchive.atlassian.net/browse/AO3-6328
https://otwarchive.atlassian.net/browse/AO3-6328?focusedCommentId=360558

## Purpose

Use `tagging_count=(value)` to update the tagging count in the cache and Redis when a new tagging is created or an existing one is destroyed. 

This is probably not a good idea -- it's quite likely posting is going to get slow as hell because it has to count, e.g., how many times the work's rating was used, and that number's going to be a Lot. But we can give it a shot.

## Testing Instructions

Refer to Jira

