### PR TITLE
AO3-6618 Escape characters on bookmark fields fetched with JavaScript

### DIFF
--- a/app/views/external_works/fetch.js.erb
+++ b/app/views/external_works/fetch.js.erb
@@ -1,6 +1,6 @@
 <% unless @external_work.blank? %>
-  $j('#external_work_author').val("<%= @external_work.author %>").change();
-  $j('#external_work_title').val("<%= @external_work.title %>").change();
+  $j('#external_work_author').val("<%= escape_javascript(@external_work.author.html_safe) %>").change();
+  $j('#external_work_title').val("<%= escape_javascript(@external_work.title) %>").change();
   $j('#external_work_summary').val("<%= escape_javascript(@external_work.summary&.html_safe) %>").change();
   $j('#fetched').val("<%= @external_work.id %>");
   $j('#external_work_rating_string').val("<%= @external_work.rating_string %>");


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6618

## Purpose

Adds missing escaping to external work bookmark fields.