### PR TITLE
AO3-6210 Use cached number of tags on mass wrangling

### DIFF
--- a/app/views/tag_wranglings/index.html.erb
+++ b/app/views/tag_wranglings/index.html.erb
@@ -120,7 +120,7 @@
                     <% end %>
                   </td>
 
-                  <td title="<%= ts('taggings') %>"><%= tag.taggings_count %></td>
+                  <td title="<%= ts('taggings') %>"><%= tag.taggings_count_cache %></td>
 
                   <td>
                     <ul class="actions" role="navigation">

--- a/app/views/tag_wranglings/index.html.erb
+++ b/app/views/tag_wranglings/index.html.erb
@@ -120,7 +120,7 @@
                     <% end %>
                   </td>
 
-                  <td title="<%= ts('taggings') %>"><%= tag.taggings_count_cache %></td>
+                  <td title="<%= ts("taggings") %>"><%= tag.taggings_count_cache %></td>
 
                   <td>
                     <ul class="actions" role="navigation">

--- a/features/step_definitions/tag_steps.rb
+++ b/features/step_definitions/tag_steps.rb
@@ -443,3 +443,7 @@ Then(/^show me what the tag "([^"]*)" is like$/) do |tagname|
   tag = Tag.find_by(name: tagname)
   puts tag.inspect
 end
+
+Then "no tag should scheduled for count update from now on" do
+  Tag.any_instance.should_not_receive(:write_taggings_to_redis)
+end

--- a/features/tags_and_wrangling/tag_wrangling.feature
+++ b/features/tags_and_wrangling/tag_wrangling.feature
@@ -353,3 +353,13 @@ Feature: Tag wrangling
     Then I should see "Youngest"
       But I should not see "Oldest"
       And I should not see "Middle"
+
+  Scenario: No call to Redis when no action is taken
+    Given the tag wrangling setup
+      And I am logged in as a tag wrangler
+    Then no tag should scheduled for count update from now on
+    When I go to my wrangling page
+    Then I should see "Wrangling Home"
+      And I should see "Characters by fandom (2)"
+    When I follow "Characters by fandom (2)"
+    Then I should see "Mass Wrangle New/Unwrangled Tags"


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [x] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [x] Have you added the [Jira](https://otwarchive.atlassian.net) issue number as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [x] Do you have fewer than 5 pull requests already open? If not, please wait until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-6210

## Purpose

Display the cached number of taggings on the Mass Wrangling page rather than triggering the whole logic to recompute the accurate one. This should improve performances as well as sort consistency as the [cached count is already used when sorting](https://github.com/otwcode/otwarchive/blob/53fc408f8590e585647f1b9d93a55c2a3c0f2164/app/controllers/tag_wranglings_controller.rb#L22).

Note sure this covers the whole issue, just did the quick and easy bit before the next release.

## Testing Instructions

Visible performance improvement on the Mass Wrangling page on staging/production?

## Credit

Ceithir (he/him)