### PR TITLE
AO3-6522 Use standard analyzer for bookmarker and creators on bookmark search

### DIFF
--- a/app/models/search/bookmark_indexer.rb
+++ b/app/models/search/bookmark_indexer.rb
@@ -35,7 +35,7 @@ class BookmarkIndexer < Indexer
         },
         creators: {
           type: "text",
-          analyzer: "simple"
+          analyzer: "standard"
         },
         work_types: {
           type: "keyword"
@@ -45,7 +45,7 @@ class BookmarkIndexer < Indexer
         },
         bookmarker: {
           type: "text",
-          analyzer: "simple"
+          analyzer: "standard"
         },
         tag: {
           type: "text",

--- a/features/bookmarks/bookmark_search.feature
+++ b/features/bookmarks/bookmark_search.feature
@@ -238,6 +238,19 @@ Feature: Search Bookmarks
       And I should see "german work"
       And I should not see "english work"
 
+  Scenario: Search bookmarks by bookmarker
+    Given "testuser2" has a bookmark of a work titled "Test Title 2"
+    When I fill in "Bookmarker" with "testuser2"
+      And I press "Search Bookmarks"
+    Then I should see "You searched for: Bookmarker: testuser2"
+      And I should see "1 Found"
+      And I should see "Test Title 2"
+    When I follow "Edit Your Search"
+      And I fill in "Bookmarker" with "testuser"
+      And I press "Search Bookmarks"
+    Then I should see "You searched for: Bookmarker: testuser"
+      And I should see "No results found."
+
   Scenario: Inputting bad queries
     Given I have bookmarks to search
     When I fill in "Any field on work" with "bad~query~~!!!"

--- a/features/step_definitions/bookmark_steps.rb
+++ b/features/step_definitions/bookmark_steps.rb
@@ -310,6 +310,18 @@ Given /^"(.*?)" has bookmarks of works in various languages$/ do |user|
   step %{all indexing jobs have been run}
 end
 
+Given /^"(.*?)" has a bookmark of a work titled "(.*?)"$/ do |user, title|
+  step %{the user "#{user}" exists and is activated}
+
+  user_pseud = User.find_by(login: user).default_pseud
+  work1 = FactoryBot.create(:work, title: title)
+  FactoryBot.create(:bookmark,
+                     bookmarkable_id: work1.id,
+                     pseud_id: user_pseud.id)
+
+  step %{all indexing jobs have been run}
+end
+
 def submit_bookmark_form(pseud, note, tags)
   select(pseud, from: "bookmark_pseud_id") unless pseud.nil?
   fill_in("bookmark_notes", with: note) unless note.nil?

--- a/features/step_definitions/bookmark_steps.rb
+++ b/features/step_definitions/bookmark_steps.rb
@@ -316,8 +316,8 @@ Given "{string} has a bookmark of a work titled {string}" do |user, title|
   user_pseud = User.find_by(login: user).default_pseud
   work1 = FactoryBot.create(:work, title: title)
   FactoryBot.create(:bookmark,
-                    bookmarkable_id: work1.id,
-                    pseud_id: user_pseud.id)
+                    bookmarkable: work1,
+                    pseud: user_pseud)
 
   step %{all indexing jobs have been run}
 end

--- a/features/step_definitions/bookmark_steps.rb
+++ b/features/step_definitions/bookmark_steps.rb
@@ -310,14 +310,14 @@ Given /^"(.*?)" has bookmarks of works in various languages$/ do |user|
   step %{all indexing jobs have been run}
 end
 
-Given /^"(.*?)" has a bookmark of a work titled "(.*?)"$/ do |user, title|
+Given "{string} has a bookmark of a work titled {string}" do |user, title|
   step %{the user "#{user}" exists and is activated}
 
   user_pseud = User.find_by(login: user).default_pseud
   work1 = FactoryBot.create(:work, title: title)
   FactoryBot.create(:bookmark,
-                     bookmarkable_id: work1.id,
-                     pseud_id: user_pseud.id)
+                    bookmarkable_id: work1.id,
+                    pseud_id: user_pseud.id)
 
   step %{all indexing jobs have been run}
 end


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [x] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [x] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [x] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-6522

## Purpose

Change the Elasticsearch analyzer for boorkmarker and creators so that numbers in names (like "testy2") are not ignored when searching.

## Testing Instructions

I think the instructions given in the Jira issue will work. When testing in a local environment, you might need to (re)index new users and bookmarks you might have to create, and activate resque.

## References

n/a

## Credit

Potpotkettle (they/them)