### PR TITLE
AO3-6058 Add 'translation into' to download preface

### DIFF
--- a/app/views/downloads/_download_preface.html.erb
+++ b/app/views/downloads/_download_preface.html.erb
@@ -65,15 +65,24 @@
       <% end %>
     <% end %>
 
+    <%# i18n-tasks-use t("downloads.download_preface.translated_to.restricted_html") %>
+    <%# i18n-tasks-use t("downloads.download_preface.translated_to.revealed_html") %>
+    <%# i18n-tasks-use t("downloads.download_preface.translated_to.unrevealed_html") %>
     <%# i18n-tasks-use t("downloads.download_preface.inspired_by.restricted_html") %>
     <%# i18n-tasks-use t("downloads.download_preface.inspired_by.revealed_html") %>
     <%# i18n-tasks-use t("downloads.download_preface.inspired_by.unrevealed") %>
     <%# i18n-tasks-use t("downloads.download_preface.translation_of.restricted_html") %>
     <%# i18n-tasks-use t("downloads.download_preface.translation_of.revealed_html") %>
     <%# i18n-tasks-use t("downloads.download_preface.translation_of.unrevealed") %>
+    <% translations = @work.approved_related_works.where(translation: true) %>
     <% related_works = @work.parent_work_relationships.reject { |wr| !wr.parent } %>
-    <% if related_works.length > 0 %>
+    <% if translations.any? || related_works.any? %>
       <ul>
+        <% translations.each do |related_work| %>
+          <li>
+            <%= related_work_note(related_work.work, "translated_to", download: true) %>
+          </li>
+        <% end %>
         <% related_works.each do |work| %>
           <li>
             <% relation = work.translation ? "translation_of" : "inspired_by" %>

--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -413,7 +413,7 @@ en:
       translated_to:
         restricted_html: 'Translation into %{language} available: [Restricted Work] by %{creator_link}'
         revealed_html: 'Translation into %{language} available: %{work_link} by %{creator_link}'
-        unrevealed_html: 'Translation into %{language} available: A work in an unrevealed collection.'
+        unrevealed_html: 'Translation into %{language} available: A work in an unrevealed collection'
       translation_of:
         restricted_html: A translation of [Restricted Work] by %{creator_link}
         revealed_html: A translation of %{work_link} by %{creator_link}

--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -410,6 +410,10 @@ en:
         restricted_html: Inspired by [Restricted Work] by %{creator_link}
         revealed_html: Inspired by %{work_link} by %{creator_link}
         unrevealed: Inspired by a work in an unrevealed collection
+      translated_to:
+        restricted_html: 'Translation into %{language} available: [Restricted Work] by %{creator_link}'
+        revealed_html: 'Translation into %{language} available: %{work_link} by %{creator_link}'
+        unrevealed_html: 'Translation into %{language} available: A work in an unrevealed collection.'
       translation_of:
         restricted_html: A translation of [Restricted Work] by %{creator_link}
         revealed_html: A translation of %{work_link} by %{creator_link}

--- a/features/works/work_download.feature
+++ b/features/works/work_download.feature
@@ -286,3 +286,38 @@ Feature: Download a work
     And I view the work "Followup"
     And I follow "HTML"
   Then I should see "Inspired by [Restricted Work] by inspiration"
+
+  Scenario: Downloads of translated work update when translation's revealed status changes.
+
+  Given a hidden collection "Hidden"
+    And I have related works setup
+    And a translation has been posted and approved
+    And I log out
+  When I view the work "Worldbuilding"
+    And I follow "HTML"
+  Then I should see "Worldbuilding Translated by translator"
+  # Going from revealed to unrevealed
+  When I am logged in as "translator"
+    And I edit the work "Worldbuilding Translated" to be in the collection "Hidden"
+    And I log out
+    And I view the work "Worldbuilding"
+    And I follow "HTML"
+  Then I should not see "Worldbuilding Translated by translator"
+    And I should see "A work in an unrevealed collection"
+  # Going from unrevealed to revealed
+  When I reveal works for "Hidden"
+    And I log out
+    And I view the work "Worldbuilding"
+    And I follow "HTML"
+  Then I should see "Worldbuilding Translated by translator"
+
+  Scenario: Downloads hide titles of restricted work translations
+
+  Given I have related works setup
+    And a translation has been posted and approved
+    And I am logged in as "translator"
+    And I lock the work "Worldbuilding Translated"
+  When I am logged out
+    And I view the work "Worldbuilding"
+    And I follow "HTML"
+  Then I should see "[Restricted Work] by translator"


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6058

## Purpose

Add the translation(s) of a work to the links displayed at the beginning of a download.

## Testing Instructions

Refer to Jira story

## References

Follow-up to #4608 

## Credit

@weeklies for the majority of the work in the linked PR
Brian Austin (they/he)