### PR TITLE
AO3-5259 Deduplicate and order admin post tags

### DIFF
--- a/app/controllers/admin_posts_controller.rb
+++ b/app/controllers/admin_posts_controller.rb
@@ -14,7 +14,7 @@ class AdminPostsController < Admin::BaseController
     @admin_posts ||= AdminPost
     if params[:language_id].present? && (@language = Language.find_by(short: params[:language_id]))
       @admin_posts = @admin_posts.where(language_id: @language.id)
-      @tags = AdminPostTag.joins(:admin_posts).where(admin_posts: { language_id: @language.id })
+      @tags = AdminPostTag.distinct.joins(:admin_posts).where(admin_posts: { language_id: @language.id }).order(:name)
     else
       @admin_posts = @admin_posts.non_translated
       @tags = AdminPostTag.order(:name)

--- a/spec/controllers/admin_posts_controller_spec.rb
+++ b/spec/controllers/admin_posts_controller_spec.rb
@@ -4,6 +4,22 @@ describe AdminPostsController do
   include LoginMacros
   include RedirectExpectationHelper
 
+  describe "GET #index" do
+    context "when filtering by language" do
+      let(:translated_post1) { create(:admin_post, tag_list: "xylophone,aardvark") }
+      let!(:translation_post1) { create(:admin_post, translated_post_id: translated_post1.id, language: create(:language, short: "fr")) }
+      let(:translated_post2) { create(:admin_post, tag_list: "xylophone,aardvark") }
+      let!(:translation_post2) { create(:admin_post, translated_post_id: translated_post2.id, language: translation_post1.language) }
+      let!(:untranslated_post) { create(:admin_post, tag_list: "uncommon tag") }
+
+      it "assigns the admin post tags for the language ordered by name" do
+        get :index, params: { language_id: "fr" }
+
+        expect(assigns[:tags].map(&:name).join(", ")).to eql("aardvark, xylophone")
+      end
+    end
+  end
+
   describe "POST #create" do
     before { fake_login_admin(create(:admin, roles: ["communications"])) }
 


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [ ] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [x] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [x] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-5259

## Purpose

What does this PR do?

Deduplicates and orders by name the admin post tags for admin posts filtered by language.

Note: I couldn't face writing a cucumber step for "and the tag is present exactly once". I welcome ideas on how to test, whether a whole integration test even adds more value than length to the testing suite, etc. I am trying to be really restrained and not rewrite the entire `index` action to use a presenter, façade, or some other kind of service object that is easier to test. >.>

## Testing Instructions

How can the Archive's QA team verify that this is working as you intended?

On Jira.

## References

Are there other relevant issues/pull requests/mailing list discussions?

## Credit

What name and pronouns should we use to credit you in the [Archive of Our Own's Release Notes](https://archiveofourown.org/admin_posts?tag=1)?

alien, they/them