### PR TITLE
AO3-6633 Fix flaky series co-creator test

### DIFF
--- a/features/other_b/series.feature
+++ b/features/other_b/series.feature
@@ -207,6 +207,8 @@ Feature: Create and Edit Series
     Then I should see "Work was successfully updated."
       And "moon" should be a creator of the series "Ponies"
       And "son" should be a creator on the series "Ponies"
+      # Delay to make sure the cache is expired
+      And it is currently 1 second from now
     When I follow "Remove Me As Co-Creator"
     Then I should see "You have been removed as a creator from the series and its works."
       And "moon" should not be the creator of the series "Ponies"


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6633

## Purpose

Fix flaky series co-creator test by adding a simulated delay before removing the creator as a co-creator. This means the cache is expired and we don't get an intermittent failure.

## Testing Instructions

No manual QA required. I ran the test 50x [here](https://github.com/Bilka2/otwarchive/actions/runs/6834160438), with no failures. Before the fix, 50 runs resulted in [3 failures](https://github.com/Bilka2/otwarchive/actions/runs/6834091266).

## References

Fix and workflow to test the fix based on #4372.

## Credit

Bilka (he/him)
