### PR TITLE
AO3-6632 Fix flaky collection anonymity tests

### DIFF
--- a/features/collections/collection_anonymity.feature
+++ b/features/collections/collection_anonymity.feature
@@ -60,6 +60,8 @@ Feature: Collection
       And all emails have been delivered
     When I am logged in as "first_user"
       And I post the work "First Snippet" to the collection "Hidden Treasury" as a gift for "third_user"
+      # Delay before posting to make sure first work is clearly older
+      And it is currently 1 second from now
       And I post the work "Second Snippet" to the collection "Hidden Treasury" as a gift for "fourth_user"
       And subscription notifications are sent
     Then 0 emails should be delivered
@@ -160,6 +162,8 @@ Feature: Collection
       And the user "third_user" allows gifts
       And I am logged in as "first_user"
       And I post the work "First Snippet" to the collection "Anonymous Hugs" as a gift for "third_user"
+      # Delay before posting to make sure first work is clearly older
+      And it is currently 1 second from now
       And I post the work "Second Snippet" to the collection "Anonymous Hugs" as a gift for "not a user"
     When subscription notifications are sent
     Then "second_user" should not be emailed
@@ -167,6 +171,8 @@ Feature: Collection
       And I view the approved collection items page for "Anonymous Hugs"
       # items listed in date order so checking the second will reveal the older work
       And I uncheck the 2nd checkbox with id matching "collection_items_\d+_anonymous"
+      # Delay before submitting to make sure the cache is expired
+      And it is currently 1 second from now
       And I submit
     Then the author of "First Snippet" should be publicly visible
     When subscription notifications are sent
@@ -388,6 +394,8 @@ Feature: Collection
     When I am logged in as the owner of "Anonymous Collection"
       And I go to "Anonymous Collection" collection edit page
       And I follow "Delete Collection"
+      # Delay before deleting to make sure the cache is expired
+      And it is currently 1 second from now
       And I press "Yes, Delete Collection"
       And I go to creator's works page
     Then I should see "Secret Work"
@@ -418,6 +426,8 @@ Feature: Collection
     When I am logged in as the owner of "Anonymous Collection"
       And I view the approved collection items page for "Anonymous Collection"
       And I check "Remove"
+      # Delay before submitting to make sure the cache is expired
+      And it is currently 1 second from now
       And I submit
       And I go to creator's works page
     Then I should see "Secret Work"
@@ -451,8 +461,9 @@ Feature: Collection
 
     When I edit the work "Secret Work"
       And I fill in "Collections" with "Holidays,Fluffy"
+      # Delay before posting to make sure the cache is expired
+      And it is currently 1 second from now
       And I press "Post"
-      And all indexing jobs have been run
       And I go to my works page
     Then I should see "Secret Work"
 


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6632

## Purpose

Fix flaky collection anonymity tests by adding simulated delays before certain actions to ensure cache expiry and correct ordering of works sorted by age.

## Testing Instructions

No manual QA required. I ran the test 50x [here](https://github.com/Bilka2/otwarchive/actions/runs/6847059993), with no failures. Before the fix, 50 runs resulted in a variety of [failures](https://github.com/Bilka2/otwarchive/actions/runs/6846844592), including in some tests in the same file that are not listed in the Jira issue. They are all fixed now.

## References

[sarken's WIP](https://github.com/otwcode/otwarchive/compare/master...sarken:otwarchive:AO3-6632_test_runs) with [email failure](https://github.com/sarken/otwarchive/actions/runs/6793417579/job/18468631211#step:12:49) related to work ordering.

## Credit

Bilka (he/him)