### PR TITLE
AO3-6636 Add speculation rules next-chapter prefetch

### DIFF
--- a/.erb-lint.yml
+++ b/.erb-lint.yml
@@ -1,6 +1,10 @@
 ---
 EnableDefaultLinters: true
 linters:
+  AllowedScriptType:
+    allowed_types:
+      - "text/javascript"
+      - "speculationrules"
   DeprecatedClasses:
     enabled: true
     rule_set:

--- a/app/views/chapters/_chapter.html.erb
+++ b/app/views/chapters/_chapter.html.erb
@@ -81,15 +81,15 @@
 
   <% if @next_chapter %>
     <script type="speculationrules">
-    {
-      "prefetch": [
-        {
-          "source": "list",
-          "eagerness": "eager",
-          "urls": ["<%= work_chapter_path(@work, @next_chapter, anchor: "workskin") %>"]
-        }
-      ]
-    }
+      {
+        "prefetch": [
+          {
+            "source": "list",
+            "eagerness": "eager",
+            "urls": ["<%= work_chapter_path(@work, @next_chapter, anchor: "workskin") %>"]
+          }
+        ]
+      }
     </script>
   <% end %>
 

--- a/app/views/chapters/_chapter.html.erb
+++ b/app/views/chapters/_chapter.html.erb
@@ -79,6 +79,20 @@
     </div>
   <% end %>
 
+  <% if @next_chapter %>
+    <script type="speculationrules">
+    {
+      "prefetch": [
+        {
+          "source": "list",
+          "eagerness": "eager",
+          "urls": ["<%= work_chapter_path(@work, @next_chapter, anchor: "workskin") %>"]
+        }
+      ]
+    }
+    </script>
+  <% end %>
+
 </div>
 
 <% end %><!-- end of cache -->

--- a/app/views/chapters/_chapter.html.erb
+++ b/app/views/chapters/_chapter.html.erb
@@ -79,7 +79,7 @@
     </div>
   <% end %>
 
-  <% if @next_chapter %>
+  <% if @next_chapter && $rollout.active?(:prefetch_next_chapter) %>
     <script type="speculationrules">
       {
         "prefetch": [


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [ ] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?: per discussion [on the ticket](https://otwarchive.atlassian.net/browse/AO3-6636), this is probably fine without tests.
* [x] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [x] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-6636

## Purpose

Use the [speculation rules API](https://developer.mozilla.org/en-US/docs/Web/API/Speculation_Rules_API) to add prefetching of the next chapter in supported browsers. (Currently, Chromium-based browsers such as Chrome, Edge, Brave, etc.) This prefetching happens in idle time and at low priority, so should not disrupt the reading experience. The result should be faster page loads for chapters 2+.

## Testing Instructions

See https://otwarchive.atlassian.net/browse/AO3-6636

## References

The parent issue https://otwarchive.atlassian.net/browse/AO3-6635 is also relevant.

## Credit

Domenic Denicola, he/him