### PR TITLE
AO3-6572 Show admins when blocks and mutes were created

### DIFF
--- a/app/views/blocked/users/_blocked_user_blurb.html.erb
+++ b/app/views/blocked/users/_blocked_user_blurb.html.erb
@@ -1,6 +1,6 @@
 <% pseud = block.blocked.default_pseud %>
 <li class="user pseud picture blurb group" role="article">
-  <%= render "pseuds/pseud_module", pseud: pseud %>
+  <%= render "pseuds/pseud_module", pseud: pseud, date: block.created_at %>
 
   <h6 class="landmark heading">User Actions</h6>
   <ul class="actions" role="navigation">

--- a/app/views/muted/users/_muted_user_blurb.html.erb
+++ b/app/views/muted/users/_muted_user_blurb.html.erb
@@ -1,6 +1,6 @@
 <% pseud = mute.muted.default_pseud %>
 <li class="user pseud picture blurb group" role="article">
-  <%= render "pseuds/pseud_module", pseud: pseud %>
+  <%= render "pseuds/pseud_module", pseud: pseud, date: mute.created_at %>
 
   <h6 class="landmark heading">User Actions</h6>
   <ul class="actions" role="navigation">

--- a/app/views/pseuds/_pseud_module.html.erb
+++ b/app/views/pseuds/_pseud_module.html.erb
@@ -10,6 +10,10 @@
   <div class="icon">
     <%= icon_display(pseud.user, pseud) %>
   </div>
+  <%# created_at date to display to admins for mutes and blocks %>
+  <% if local_assigns[:date] && logged_in_as_admin? %>
+    <p class="datetime"><%= date %></p>
+  <% end %>
 </div>
 <% unless pseud.description.blank? %>
   <blockquote class="userstuff">

--- a/features/step_definitions/block_steps.rb
+++ b/features/step_definitions/block_steps.rb
@@ -23,3 +23,19 @@ Then "the user {string} should not have a block for {string}" do |blocker, block
   blocked = User.find_by(login: blocked)
   expect(Block.find_by(blocker: blocker, blocked: blocked)).to be_blank
 end
+
+Then "the blurb should say when {string} blocked {string}" do |blocker, blocked|
+  blocker = User.find_by(login: blocker)
+  blocked = User.find_by(login: blocked)
+  block = Block.where(blocker: blocker, blocked: blocked).first
+  # Find the blurb for the specified block using the h4 with the blocked user's name, navigate back up to div, and then down to the datetime p
+  expect(page).to have_xpath("//li/div/h4/a[text()[contains(., '#{blocked.login}')]]/parent::h4/parent::div/p[text()[contains(., '#{block.created_at}')]]")
+end
+
+Then "the blurb should not say when {string} blocked {string}" do |blocker, blocked|
+  blocker = User.find_by(login: blocker)
+  blocked = User.find_by(login: blocked)
+  block = Block.where(blocker: blocker, blocked: blocked).first
+  # Find the blurb for the specified block using the h4 with the blocked user's name, navigate back up to div, and then down to where the datetime p would be
+  expect(page).not_to have_xpath("//li/div/h4/a[text()[contains(., '#{blocked.login}')]]/parent::h4/parent::div/p[text()[contains(., '#{block.created_at}')]]")
+end

--- a/features/step_definitions/mute_steps.rb
+++ b/features/step_definitions/mute_steps.rb
@@ -23,3 +23,19 @@ Then "the user {string} should not have a mute for {string}" do |muter, muted|
   muted = User.find_by(login: muted)
   expect(Mute.find_by(muter: muter, muted: muted)).to be_blank
 end
+
+Then "the blurb should say when {string} muted {string}" do |muter, muted|
+  muter = User.find_by(login: muter)
+  muted = User.find_by(login: muted)
+  mute = Mute.where(muter: muter, muted: muted).first
+  # Find the blurb for the specified mute using the h4 with the muted user's name, navigate back up to div, and then down to the datetime p
+  expect(page).to have_xpath("//li/div/h4/a[text()[contains(., '#{muted.login}')]]/parent::h4/parent::div/p[text()[contains(., '#{mute.created_at}')]]")
+end
+
+Then "the blurb should not say when {string} muted {string}" do |muter, muted|
+  muter = User.find_by(login: muter)
+  muted = User.find_by(login: muted)
+  mute = Mute.where(muter: muter, muted: muted).first
+  # Find the blurb for the specified mute using the h4 with the muted user's name, navigate back up to div, and then down to where the datetime p would be
+  expect(page).not_to have_xpath("//li/div/h4/a[text()[contains(., '#{muted.login}')]]/parent::h4/parent::div/p[text()[contains(., '#{mute.created_at}')]]")
+end

--- a/features/users/blocking.feature
+++ b/features/users/blocking.feature
@@ -17,6 +17,7 @@ Feature: Blocking
       And I press "Yes, Block User"
     Then I should see "You have blocked the user pest."
       And the user "blocker" should have a block for "pest"
+      And the blurb should not say when "blocker" blocked "pest"
 
     Examples:
       | page                                                 |
@@ -109,6 +110,7 @@ Feature: Blocking
     When I am logged in as a "<role>" admin
       And I go to the blocked users page for "blocker"
     Then I should see "pest"
+      And the blurb should say when "blocker" blocked "pest"
       And I should see a link "Unblock"
     When I follow "Unblock"
     Then I should see "Sorry, you don't have permission to access the page you were trying to reach."

--- a/features/users/muting.feature
+++ b/features/users/muting.feature
@@ -8,6 +8,7 @@ Feature: Muting
       And I press "Yes, Mute User"
     Then I should see "You have muted the user pest."
       And the user "muter" should have a mute for "pest"
+      And the blurb should not say when "muter" muted "pest"
 
   Scenario Outline: Users can mute from various user-related pages
     Given the user "pest" exists and is activated
@@ -88,6 +89,7 @@ Feature: Muting
     When I am logged in as a "<role>" admin
       And I go to the muted users page for "muter"
     Then I should see "pest"
+      And the blurb should say when "muter" muted "pest"
       And I should see a link "Unmute"
     When I follow "Unmute"
     Then I should see "Sorry, you don't have permission to access the page you were trying to reach."


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6572

## Purpose

~Reduce database work.~

If you're logged in as an admin with access to users' Blocked Users and Muted Users pages, you'll now be able to see the date and time blocks and mutes were created. 

The format is just plain old `2023-04-26 03:23:09 UTC`, like the way we display creation dates for, e.g., admin posts and admin activities.

## Testing Instructions

1. Log in as a user and block and mute some users, noting the date/time you do it.
2. Make sure there are no dates/times displayed on the blurbs on your Blocked Users and Muted Users pages.
3. Log in as a superadmin, policy_and_abuse, or support admin and access the Blocked Users and Muted Users pages for the user from step one. Make sure the dates and times are there and they are correct.

