### PR TITLE
AO3-6626: stop tags from being added with Chinese or Japanese commas

### DIFF
--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -168,7 +168,7 @@ class Tag < ApplicationRecord
     maximum: ArchiveConfig.TAG_MAX,
     message: "^Tag name '%{value}' is too long -- try using less than %{count} characters or using commas to separate your tags."
   validates_format_of :name,
-    with: /\A[^,，、*<>^{}=`\\%]+\z/,
+    with:    /\A[^,，、*<>^{}=`\\%]+\z/,
     message: "^Tag name '%{value}' cannot include the following restricted characters: , &#94; * < > { } = ` ， 、 \\ %"
 
   validates_presence_of :sortable_name

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -168,8 +168,8 @@ class Tag < ApplicationRecord
     maximum: ArchiveConfig.TAG_MAX,
     message: "^Tag name '%{value}' is too long -- try using less than %{count} characters or using commas to separate your tags."
   validates_format_of :name,
-    with: /\A[^,*<>^{}=`\\%]+\z/,
-    message: "^Tag name '%{value}' cannot include the following restricted characters: , &#94; * < > { } = ` \\ %"
+    with: /\A[^,，、*<>^{}=`\\%]+\z/,
+    message: "^Tag name '%{value}' cannot include the following restricted characters: , &#94; * < > { } = ` ， 、 \\ %"
 
   validates_presence_of :sortable_name
 

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -110,7 +110,7 @@ class Tag < ApplicationRecord
   end
 
   has_many :mergers, foreign_key: 'merger_id', class_name: 'Tag'
-  belongs_to :merger, class_name: 'Tag'
+  belongs_to :merger, class_name: "Tag"
   belongs_to :fandom
   belongs_to :media
   belongs_to :last_wrangler, polymorphic: true
@@ -161,17 +161,18 @@ class Tag < ApplicationRecord
   has_many :tag_set_associations, dependent: :destroy
   has_many :parent_tag_set_associations, class_name: 'TagSetAssociation', foreign_key: 'parent_tag_id', dependent: :destroy
 
-  validates_presence_of :name
+  validates :name, presence: true
   validates :name, uniqueness: true
-  validates_length_of :name, minimum: 1, message: "cannot be blank."
-  validates_length_of :name,
-    maximum: ArchiveConfig.TAG_MAX,
-    message: "^Tag name '%{value}' is too long -- try using less than %{count} characters or using commas to separate your tags."
-  validates_format_of :name,
-    with:    /\A[^,，、*<>^{}=`\\%]+\z/,
-    message: "^Tag name '%{value}' cannot include the following restricted characters: , &#94; * < > { } = ` ， 、 \\ %"
-
-  validates_presence_of :sortable_name
+  validates :name,
+            length: { minimum: 1,
+                      message: "cannot be blank." }
+  validates :name,
+            length: { maximum: ArchiveConfig.TAG_MAX,
+                      message: "^Tag name '%{value}' is too long -- try using less than %{count} characters or using commas to separate your tags." }
+  validates :name,
+            format: { with: /\A[^,，、*<>^{}=`\\%]+\z/,
+                      message: "^Tag name '%{value}' cannot include the following restricted characters: , &#94; * < > { } = ` ， 、 \\ %" }
+  validates :sortable_name, presence: true
 
   validate :unwrangleable_status
   def unwrangleable_status

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -49,7 +49,7 @@ describe Tag do
         expect(@fandom_tag.taggings_count).to eq 1
       end
 
-      it 'will start caching a when tag when that tag is used significantly' do
+      it 'will start caching a tag when that tag is used significantly' do
         (1..ArchiveConfig.TAGGINGS_COUNT_MIN_CACHE_COUNT).each do |try|
           FactoryBot.create(:work, fandom_string: @fandom_tag.name)
           RedisJobSpawner.perform_now("TagCountUpdateJob")
@@ -168,11 +168,15 @@ describe Tag do
     expect(tag.errors[:name].join).to match(/too long/)
   end
 
-  it "should not be valid with disallowed characters" do
-    tag = Tag.new
-    tag.name = "bad<tag"
-    expect(tag.save).to be_falsey
-    expect(tag.errors[:name].join).to match(/restricted characters/)
+  context "tags using restricted characters should not be saved" do
+    BAD_TAGS.each do |tag|
+      forbidden_tag = Tag.new
+      forbidden_tag.name = tag 
+      it "is not saved and receives an error message about restricted characters" do
+        expect(forbidden_tag.save).to be_falsey
+        expect(forbidden_tag.errors[:name].join).to match(/restricted characters/)
+      end
+    end
   end
 
   context "unwrangleable" do

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -6,7 +6,7 @@ describe Tag do
     User.current_user = nil
   end
 
-  context 'checking count caching' do
+  context "checking count caching" do
     before(:each) do
       # Set the minimal amount of time a tag can be cached for.
       ArchiveConfig.TAGGINGS_COUNT_MIN_TIME = 1
@@ -17,15 +17,15 @@ describe Tag do
       @fandom_tag = FactoryBot.create(:fandom)
     end
 
-    context 'without updating taggings_count_cache' do
-      it 'should not cache tags which are not used much' do
+    context "without updating taggings_count_cache" do
+      it "should not cache tags which are not used much" do
         FactoryBot.create(:work, fandom_string: @fandom_tag.name)
         @fandom_tag.reload
         expect(@fandom_tag.taggings_count_cache).to eq 0
         expect(@fandom_tag.taggings_count).to eq 1
       end
 
-      it 'will start caching a when tag when that tag is used significantly' do
+      it "will start caching a when tag when that tag is used significantly" do
         (1..ArchiveConfig.TAGGINGS_COUNT_MIN_CACHE_COUNT).each do |try|
           FactoryBot.create(:work, fandom_string: @fandom_tag.name)
           @fandom_tag.reload
@@ -40,8 +40,8 @@ describe Tag do
       end
     end
 
-    context 'updating taggings_count_cache' do
-      it 'should not cache tags which are not used much' do
+    context "updating taggings_count_cache" do
+      it "should not cache tags which are not used much" do
         FactoryBot.create(:work, fandom_string: @fandom_tag.name)
         RedisJobSpawner.perform_now("TagCountUpdateJob")
         @fandom_tag.reload
@@ -49,7 +49,7 @@ describe Tag do
         expect(@fandom_tag.taggings_count).to eq 1
       end
 
-      it 'will start caching a tag when that tag is used significantly' do
+      it "will start caching a tag when that tag is used significantly" do
         (1..ArchiveConfig.TAGGINGS_COUNT_MIN_CACHE_COUNT).each do |try|
           FactoryBot.create(:work, fandom_string: @fandom_tag.name)
           RedisJobSpawner.perform_now("TagCountUpdateJob")
@@ -65,7 +65,7 @@ describe Tag do
         expect(@fandom_tag.taggings_count).to eq ArchiveConfig.TAGGINGS_COUNT_MIN_CACHE_COUNT
       end
 
-      it "Writes to the database do not happen immeadiately" do
+      it "Writes to the database do not happen immediately" do
         (1..40 * ArchiveConfig.TAGGINGS_COUNT_CACHE_DIVISOR - 1).each do |try|
           @fandom_tag.taggings_count = try
           @fandom_tag.reload
@@ -254,20 +254,20 @@ describe Tag do
         expect(tag.save).to be_falsey
       end
 
-      it 'autocomplete should work' do
-        tag_character = FactoryBot.create(:character, canonical: true, name: 'kirk')
-        tag_fandom = FactoryBot.create(:fandom, name: 'Star Trek', canonical: true)
+      it "autocomplete should work" do
+        tag_character = FactoryBot.create(:character, canonical: true, name: "kirk")
+        tag_fandom = FactoryBot.create(:fandom, name: "Star Trek", canonical: true)
         tag_fandom.add_to_autocomplete
-        results = Tag.autocomplete_fandom_lookup(term: 'ki', fandom: 'Star Trek')
+        results = Tag.autocomplete_fandom_lookup(term: "ki", fandom: "Star Trek")
         expect(results.include?("#{tag_character.id}: #{tag_character.name}")).to be_truthy
         expect(results.include?("brave_sire_robin")).to be_falsey
       end
 
-      it 'old tag maker still works' do
-        tag_adult = Rating.create_canonical('adult', true)
-        tag_normal = ArchiveWarning.create_canonical('other')
-        expect(tag_adult.name).to eq('adult')
-        expect(tag_normal.name).to eq('other')
+      it "old tag maker still works" do
+        tag_adult = Rating.create_canonical("adult", true)
+        tag_normal = ArchiveWarning.create_canonical("other")
+        expect(tag_adult.name).to eq("adult")
+        expect(tag_normal.name).to eq("other")
         expect(tag_adult.adult).to be_truthy
         expect(tag_normal.adult).to be_falsey
       end

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -169,7 +169,21 @@ describe Tag do
   end
 
   context "tags using restricted characters should not be saved" do
-    BAD_TAGS.each do |tag|
+    [
+      "bad, tag",
+      "also， bad",
+      "no、good",
+      "wild*card",
+      "back\\slash",
+      "lesser<tag",
+      "greater>tag",
+      "^tag",
+      "{open",
+      "close}",
+      "not=allowed",
+      "suspicious`character",
+      "no%maths"
+    ].each do |tag|
       forbidden_tag = Tag.new
       forbidden_tag.name = tag 
       it "is not saved and receives an error message about restricted characters" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -137,7 +137,6 @@ RSpec.configure do |config|
   config.use_transactional_fixtures = true
 
   BAD_EMAILS = ["Abc.example.com", "A@b@c@example.com", 'a\"b(c)d,e:f;g<h>i[j\k]l@example.com', 'this is"not\allowed@example.com', 'this\ still\"not/\/\allowed@example.com', "nodomain", "foo@oops", "ast*risk@example.com", "asterisk@ex*ample.com"].freeze
-  BAD_TAGS = ["bad, tag", "also， bad", "no、good", "wild*card", "lesser<tag", "greater>tag", "^tag", "{open", "close}", "not=allowed", "suspicious`character", "no%maths"].freeze
   INVALID_URLS = %w[no_scheme.com ftp://ftp.address.com http://www.b@d!35.com https://www.b@d!35.com http://b@d!35.com https://www.b@d!35.com].freeze
   VALID_URLS = %w[http://rocksalt-recs.livejournal.com/196316.html https://rocksalt-recs.livejournal.com/196316.html].freeze
   INACTIVE_URLS = %w[https://www.iaminactive.com http://www.iaminactive.com https://iaminactive.com http://iaminactive.com].freeze

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -137,6 +137,7 @@ RSpec.configure do |config|
   config.use_transactional_fixtures = true
 
   BAD_EMAILS = ["Abc.example.com", "A@b@c@example.com", 'a\"b(c)d,e:f;g<h>i[j\k]l@example.com', 'this is"not\allowed@example.com', 'this\ still\"not/\/\allowed@example.com', "nodomain", "foo@oops", "ast*risk@example.com", "asterisk@ex*ample.com"].freeze
+  BAD_TAGS = ["bad, tag", "also， bad", "no、good", "wild*card", "lesser<tag", "greater>tag", "^tag", "{open", "close}", "not=allowed", "suspicious`character", "no%maths"].freeze
   INVALID_URLS = %w[no_scheme.com ftp://ftp.address.com http://www.b@d!35.com https://www.b@d!35.com http://b@d!35.com https://www.b@d!35.com].freeze
   VALID_URLS = %w[http://rocksalt-recs.livejournal.com/196316.html https://rocksalt-recs.livejournal.com/196316.html].freeze
   INACTIVE_URLS = %w[https://www.iaminactive.com http://www.iaminactive.com https://iaminactive.com http://iaminactive.com].freeze


### PR DESCRIPTION
Hi! First time looking at the AO3 codebase - I wanted to learn a bit about Ruby and I'm a happy AO3 user so I set up an AO3 dev env and rummaged around Jira a little. Here is a very simple change for an existing ticket, please let me know if I'm missing anything.

# Pull Request Checklist

* [x] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [x] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [x] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [x] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

(https://otwarchive.atlassian.net/jira/software/c/projects/AO3/issues/AO3-6626)

## Purpose

This pull request adds two additional characters to the regex of forbidden characters

## Testing Instructions

The Archive's QA team can verify that this is working as intended by following the test steps set out in the Jira ticket, copy/pasted here:

>     Log in as a tag wrangler (e.g., testy)
> 
>     Create a new tag with a Chinese ( ， ) or Japanese (、) comma
> 
>         Browse > Tags > New Tag
> 
>         In the Name field, enter a tag name that contains one of the commas 
> 
>             Both Tag With 、Japanese Comma and Tag With ，Chinese Comma have been created on staging
> 
>         Select a Category, e.g., Additional Tag
> 
>         Check the Canonical checkbox
> 
>         Press Create Tag
> 
>     Try to use the tag in an autocomplete field
> 
>         Post > New Work
> 
>         Fill in required fields
> 
>         In the appropriate tag field, enter the name of the tag you created in Step 2, or choose it from the autocomplete
> 
>         Press Post

I have tested this on a local Docker environment. I did not add a unit test because there's already an appropriate-looking unit test for the forbidden character filter, which currently passes:

```
  it "should not be valid with disallowed characters" do
    tag = Tag.new
    tag.name = "bad<tag"
    expect(tag.save).to be_falsey
    expect(tag.errors[:name].join).to match(/restricted characters/)
  end
```

Which currently passes:

```
Run options: include {:locations=>{"./spec/models/tag_spec.rb"=>[171]}}

Tag
  should not be valid with disallowed characters

Finished in 5.17 seconds (files took 5.43 seconds to load)
1 example, 0 failures
```

## References

No other relevant issues/pull requests/mailing list discussions.

## Credit

What name and pronouns should we use to credit you in the [Archive of Our Own's Release Notes](https://archiveofourown.org/admin_posts?tag=1)?

username: kwerey
pronouns: they/them

I do not currently have a public Jira account.