### PR TITLE
AO3-3866 update revised_at when a work is revealed

### DIFF
--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -197,6 +197,11 @@ class Work < ApplicationRecord
 
   before_save :clean_and_validate_title, :validate_published_at, :ensure_revised_at
 
+  # If the work is becoming revealed, bump the revised-at date (AO3-3866)
+  before_save do
+    set_revised_at(Date.today) if will_save_change_to_in_unrevealed_collection?
+  end
+
   after_save :post_first_chapter
   before_save :set_word_count
 

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -199,7 +199,7 @@ class Work < ApplicationRecord
 
   # If the work is becoming revealed, bump the revised-at date (AO3-3866)
   before_save do
-    set_revised_at(Time.zone.today) if will_save_change_to_in_unrevealed_collection?
+    set_revised_at(Time.current) if will_save_change_to_in_unrevealed_collection?
   end
 
   after_save :post_first_chapter

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -199,7 +199,7 @@ class Work < ApplicationRecord
 
   # If the work is becoming revealed, bump the revised-at date (AO3-3866)
   before_save do
-    set_revised_at(Date.today) if will_save_change_to_in_unrevealed_collection?
+    set_revised_at(Time.zone.today) if will_save_change_to_in_unrevealed_collection?
   end
 
   after_save :post_first_chapter

--- a/spec/models/work_spec.rb
+++ b/spec/models/work_spec.rb
@@ -644,7 +644,11 @@ describe Work do
     reveal_date = Date.new(2000, 1, 2)
 
     let(:collection) { create(:collection) }
-    let(:work) { create(:work, collection_names: collection.name, chapters: [create(:chapter, published_at: publication_date)]) }
+    let(:work) do
+      create(:work, collection_names: collection.name, chapters: [
+        create(:chapter, published_at: publication_date)
+      ])
+    end
 
     context "when visibility is changed" do
       before do
@@ -666,23 +670,22 @@ describe Work do
     end
 
     context "when visibility is not changed" do
-        before do
-          collection.collection_preference.unrevealed = false
-          collection.collection_preference.save!
-        end
+      before do
+        collection.collection_preference.unrevealed = false
+        collection.collection_preference.save!
+      end
 
-        it "does not update the revised date" do
-          travel_to publication_date
-          work.save!
-          expect(work.reload.revised_at).to eq publication_date
+      it "does not update the revised date" do
+        travel_to publication_date
+        work.save!
+        expect(work.reload.revised_at).to eq publication_date
 
-          travel_to reveal_date
-          collection.collection_preference.unrevealed = false
-          collection.collection_preference.save!
+        travel_to reveal_date
+        collection.collection_preference.unrevealed = false
+        collection.collection_preference.save!
 
-          expect(work.reload.revised_at).to eq publication_date
-        end
+        expect(work.reload.revised_at).to eq publication_date
+      end
     end
   end
-
 end

--- a/spec/models/work_spec.rb
+++ b/spec/models/work_spec.rb
@@ -638,4 +638,51 @@ describe Work do
       end
     end
   end
+
+  describe "#save" do
+    publication_date = Date.new(2000, 1, 1)
+    reveal_date = Date.new(2000, 1, 2)
+
+    let(:collection) { create(:collection) }
+    let(:work) { create(:work, collection_names: collection.name, chapters: [create(:chapter, published_at: publication_date)]) }
+
+    context "when visibility is changed" do
+      before do
+        collection.collection_preference.unrevealed = true
+        collection.collection_preference.save!
+      end
+
+      it "updates the revised date" do
+        travel_to publication_date
+        work.save!
+        expect(work.reload.revised_at).to eq publication_date
+
+        travel_to reveal_date
+        collection.collection_preference.unrevealed = false
+        collection.collection_preference.save!
+
+        expect(work.reload.revised_at).to eq reveal_date
+      end
+    end
+
+    context "when visibility is not changed" do
+        before do
+          collection.collection_preference.unrevealed = false
+          collection.collection_preference.save!
+        end
+
+        it "does not update the revised date" do
+          travel_to publication_date
+          work.save!
+          expect(work.reload.revised_at).to eq publication_date
+
+          travel_to reveal_date
+          collection.collection_preference.unrevealed = false
+          collection.collection_preference.save!
+
+          expect(work.reload.revised_at).to eq publication_date
+        end
+    end
+  end
+
 end

--- a/spec/models/work_spec.rb
+++ b/spec/models/work_spec.rb
@@ -640,13 +640,13 @@ describe Work do
   end
 
   describe "#save" do
-    publication_date = Date.new(2000, 1, 1)
-    reveal_date = Date.new(2000, 1, 2)
+    publication_time = Time.zone.local(2000, 1, 1)
+    reveal_time = Time.zone.local(2000, 1, 2)
 
     let(:collection) { create(:collection) }
     let(:work) do
       create(:work, collection_names: collection.name, chapters: [
-        create(:chapter, published_at: publication_date)
+        create(:chapter, published_at: publication_time)
       ])
     end
 
@@ -657,15 +657,15 @@ describe Work do
       end
 
       it "updates the revised date" do
-        travel_to publication_date
+        travel_to publication_time
         work.save!
-        expect(work.reload.revised_at).to eq publication_date
+        expect(work.reload.revised_at).to eq publication_time
 
-        travel_to reveal_date
+        travel_to reveal_time
         collection.collection_preference.unrevealed = false
         collection.collection_preference.save!
 
-        expect(work.reload.revised_at).to eq reveal_date
+        expect(work.reload.revised_at).to eq reveal_time
       end
     end
 
@@ -676,15 +676,15 @@ describe Work do
       end
 
       it "does not update the revised date" do
-        travel_to publication_date
+        travel_to publication_time
         work.save!
-        expect(work.reload.revised_at).to eq publication_date
+        expect(work.reload.revised_at).to eq publication_time
 
-        travel_to reveal_date
+        travel_to reveal_time
         collection.collection_preference.unrevealed = false
         collection.collection_preference.save!
 
-        expect(work.reload.revised_at).to eq publication_date
+        expect(work.reload.revised_at).to eq publication_time
       end
     end
   end


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-3866 (Please fill in issue number and remove this comment.)

## Purpose

When a work changes from unrevealed to revealed, update its revised_at date, so that it sorts according to when it was revealed, rather than when it was originally posted.

## Testing Instructions

Testing instructions in the issue should confirm the fix.

## Credit

Eliah Hecht, he/him
