### PR TITLE
AO3-6643 Fix error when sorting by columns without a pretty name

### DIFF
--- a/app/models/search/work_search_form.rb
+++ b/app/models/search/work_search_form.rb
@@ -162,9 +162,12 @@ class WorkSearchForm
     if @options[:sort_column].present?
       # Use pretty name if available, otherwise fall back to plain column name
       pretty_sort_name = name_for_sort_column(@options[:sort_column])
-      summary << ("sort by: #{pretty_sort_name&.downcase || @options[:sort_column]}" +
-        (@options[:sort_direction].present? ?
-          (@options[:sort_direction] == "asc" ? " ascending" : " descending") : ""))
+      direction = if @options[:sort_direction].present?
+                    @options[:sort_direction] == "asc" ? " ascending" : " descending"
+                  else
+                    ""
+                  end
+      summary << ("sort by: #{pretty_sort_name&.downcase || @options[:sort_column]}" + direction)
     end
     summary.join(" ")
   end

--- a/app/models/search/work_search_form.rb
+++ b/app/models/search/work_search_form.rb
@@ -160,7 +160,9 @@ class WorkSearchForm
       end
     end
     if @options[:sort_column].present?
-      summary << "sort by: #{name_for_sort_column(@options[:sort_column]).downcase}" +
+      # Use pretty name if available, otherwise fall back to plain column name
+      pretty_sort_name = name_for_sort_column(@options[:sort_column])
+      summary << "sort by: #{pretty_sort_name.nil? ? @options[:sort_column] : pretty_sort_name.downcase}" +
         (@options[:sort_direction].present? ?
           (@options[:sort_direction] == "asc" ? " ascending" : " descending") : "")
     end

--- a/app/models/search/work_search_form.rb
+++ b/app/models/search/work_search_form.rb
@@ -162,7 +162,7 @@ class WorkSearchForm
     if @options[:sort_column].present?
       # Use pretty name if available, otherwise fall back to plain column name
       pretty_sort_name = name_for_sort_column(@options[:sort_column])
-      summary << "sort by: #{pretty_sort_name.nil? ? @options[:sort_column] : pretty_sort_name.downcase}" +
+      summary << "sort by: #{pretty_sort_name&.downcase || @options[:sort_column]}" +
         (@options[:sort_direction].present? ?
           (@options[:sort_direction] == "asc" ? " ascending" : " descending") : "")
     end

--- a/app/models/search/work_search_form.rb
+++ b/app/models/search/work_search_form.rb
@@ -162,9 +162,9 @@ class WorkSearchForm
     if @options[:sort_column].present?
       # Use pretty name if available, otherwise fall back to plain column name
       pretty_sort_name = name_for_sort_column(@options[:sort_column])
-      summary << "sort by: #{pretty_sort_name&.downcase || @options[:sort_column]}" +
+      summary << ("sort by: #{pretty_sort_name&.downcase || @options[:sort_column]}" +
         (@options[:sort_direction].present? ?
-          (@options[:sort_direction] == "asc" ? " ascending" : " descending") : "")
+          (@options[:sort_direction] == "asc" ? " ascending" : " descending") : ""))
     end
     summary.join(" ")
   end

--- a/spec/models/search/work_search_form_spec.rb
+++ b/spec/models/search/work_search_form_spec.rb
@@ -108,6 +108,14 @@ describe WorkSearchForm, work_search: true do
         expect(searcher.options[:sort_direction]).to eq("desc")
       end
     end
+
+    context "when sorting by field without pretty name" do
+      it "displays the field name in search summary" do
+        options = { sort_column: "expected_number_of_chapters", sort_direction: "desc" }
+        searcher = WorkSearchForm.new(options)
+        expect(searcher.summary).to eq("sort by: expected_number_of_chapters descending")
+      end
+    end
   end
 
   describe "searching" do


### PR DESCRIPTION
# Pull Request Checklist

* [X] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [X] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [X] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [X] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [X] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

[AO3-6643](https://otwarchive.atlassian.net/browse/AO3-6643)

## Purpose

This PR fixes an error that occurs when attempting to sort by a column without a pretty name in a work search (e.g. the `id` or `expected_number_of_chapters` column).

## Testing Instructions

Refer to the Jira issue.

## Credit

Albert Pedersen (he/him)


[AO3-6643]: https://otwarchive.atlassian.net/browse/AO3-6643?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ