### PR TITLE
AO3-6636 Fixup speculation rules next-chapter prefetch

### DIFF
--- a/app/views/chapters/_chapter.html.erb
+++ b/app/views/chapters/_chapter.html.erb
@@ -85,7 +85,6 @@
         "prefetch": [
           {
             "source": "list",
-            "eagerness": "eager",
             "urls": ["<%= work_chapter_path(@work, @next_chapter, anchor: "workskin") %>"]
           }
         ]


### PR DESCRIPTION
942f4a3bd2d66e9212d25b7b7d2ffec7dd710ded accidentally used the "eagerness" field, which is only supported in Chrome 121+. It isn't necessary in our case (the value we used, "eager", is already the default) so we can just remove it to fix prefetching in earlier versions of Chrome.

# Pull Request Checklist

* [x] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [ ] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)? As discussed in [the ticket](https://otwarchive.atlassian.net/browse/AO3-6636), no automated tests are necessary for this. However, this time I tested manually using stable Chrome 119, and it works.
* [x] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [x] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-6636

## Purpose

Fixes the speculation rules prefetch feature to work on earlier Chrome versions.

## Testing Instructions

See [the Jira ticket](https://otwarchive.atlassian.net/browse/AO3-6636)

## References

- https://github.com/otwcode/otwarchive/pull/4661
- https://github.com/otwcode/otwarchive/pull/4665

## Credit

Domenic Denicola, he/him
