### PR TITLE
AO3-6636 Move next chapter prefetch outside cache block

### DIFF
--- a/app/views/chapters/_chapter.html.erb
+++ b/app/views/chapters/_chapter.html.erb
@@ -78,20 +78,19 @@
       </div>
     </div>
   <% end %>
-
-  <% if @next_chapter && $rollout.active?(:prefetch_next_chapter) %>
-    <script type="speculationrules">
-      {
-        "prefetch": [
-          {
-            "source": "list",
-            "urls": ["<%= work_chapter_path(@work, @next_chapter, anchor: "workskin") %>"]
-          }
-        ]
-      }
-    </script>
-  <% end %>
-
 </div>
 
 <% end %><!-- end of cache -->
+
+<% if @next_chapter && $rollout.active?(:prefetch_next_chapter) %>
+  <script type="speculationrules">
+    {
+      "prefetch": [
+        {
+          "source": "list",
+          "urls": ["<%= work_chapter_path(@work, @next_chapter, anchor: "workskin") %>"]
+        }
+      ]
+    }
+  </script>
+<% end %>


### PR DESCRIPTION
This should ensure it shows up on all chapters, including ones that have been cached recently.

**This is a speculative fix and should be reviewed by someone who understands the caching mechanisms better than me, before merging. I creating this PR to make it easy to merge, in case this _is_ the right fix.**

# Pull Request Checklist

* [x] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [ ] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)? Per discussion on the ticket, no tests are needed for this feature
* [x] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [x] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-6636

## Purpose

Ensure speculation rules next chapter prefetching is not part of the cached content for a work, and thus shows up on all chapters.

## Testing Instructions

General testing instructions for the feature are on the issue, but for this caching issue specifically, @sarken suggests testing on works which had previously been generated this change, maybe?

## References

This comment https://otwarchive.atlassian.net/browse/AO3-6636?focusedCommentId=360659

## Credit

Domenic Denicola, he/him