### PR TITLE
AO3-6639 Output current DB schema

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -67,7 +67,7 @@ module Otwarchive
     config.filter_parameters += [:content, :password, :terms_of_service_non_production]
 
     # Disable dumping schemas after migrations.
-    config.active_record.dump_schema_after_migration = false
+    config.active_record.dump_schema_after_migration = true
 
     # Allows belongs_to associations to be optional
     config.active_record.belongs_to_required_by_default = false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -2,17 +2,17 @@
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
 #
-# Note that this schema.rb definition is the authoritative source for your
-# database schema. If you need to create the application database on another
-# system, you should be using db:schema:load, not running all the migrations
-# from scratch. The latter is a flawed and unsustainable approach (the more migrations
-# you'll amass, the slower it'll run and the greater likelihood for issues).
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20201214013251) do
+ActiveRecord::Schema.define(version: 2023_09_20_094945) do
 
-  create_table "abuse_reports", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC", force: :cascade do |t|
+  create_table "abuse_reports", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", options: "ENGINE=InnoDB ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.string "email"
     t.string "url", null: false
     t.text "comment", null: false
@@ -26,7 +26,7 @@ ActiveRecord::Schema.define(version: 20201214013251) do
     t.string "username"
   end
 
-  create_table "admin_activities", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC", force: :cascade do |t|
+  create_table "admin_activities", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", options: "ENGINE=InnoDB ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.integer "admin_id"
     t.integer "target_id"
     t.string "target_type"
@@ -37,21 +37,21 @@ ActiveRecord::Schema.define(version: 20201214013251) do
     t.datetime "updated_at"
   end
 
-  create_table "admin_banners", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC", force: :cascade do |t|
+  create_table "admin_banners", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", options: "ENGINE=InnoDB ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.text "content"
     t.integer "content_sanitizer_version", limit: 2, default: 0, null: false
     t.string "banner_type"
     t.boolean "active", default: false, null: false
   end
 
-  create_table "admin_blacklisted_emails", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC", force: :cascade do |t|
+  create_table "admin_blacklisted_emails", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", options: "ENGINE=InnoDB ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.string "email"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["email"], name: "index_admin_blacklisted_emails_on_email", unique: true
   end
 
-  create_table "admin_post_taggings", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC", force: :cascade do |t|
+  create_table "admin_post_taggings", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", options: "ENGINE=InnoDB ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.integer "admin_post_tag_id"
     t.integer "admin_post_id"
     t.datetime "created_at"
@@ -59,14 +59,14 @@ ActiveRecord::Schema.define(version: 20201214013251) do
     t.index ["admin_post_id"], name: "index_admin_post_taggings_on_admin_post_id"
   end
 
-  create_table "admin_post_tags", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC", force: :cascade do |t|
+  create_table "admin_post_tags", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", options: "ENGINE=InnoDB ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.string "name"
     t.integer "language_id"
     t.datetime "created_at"
     t.datetime "updated_at"
   end
 
-  create_table "admin_posts", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC", force: :cascade do |t|
+  create_table "admin_posts", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", options: "ENGINE=InnoDB ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.integer "admin_id"
     t.string "title"
     t.text "content"
@@ -80,7 +80,7 @@ ActiveRecord::Schema.define(version: 20201214013251) do
     t.index ["translated_post_id"], name: "index_admin_posts_on_post_id"
   end
 
-  create_table "admin_settings", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC", force: :cascade do |t|
+  create_table "admin_settings", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", options: "ENGINE=InnoDB ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.boolean "account_creation_enabled", default: true, null: false
     t.boolean "invite_from_queue_enabled", default: true, null: false
     t.bigint "invite_from_queue_number"
@@ -103,10 +103,11 @@ ActiveRecord::Schema.define(version: 20201214013251) do
     t.boolean "disable_support_form", default: false, null: false
     t.text "disabled_support_form_text"
     t.integer "disabled_support_form_text_sanitizer_version", limit: 2, default: 0, null: false
+    t.boolean "guest_comments_off", default: false, null: false
     t.index ["last_updated_by"], name: "index_admin_settings_on_last_updated_by"
   end
 
-  create_table "admins", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC", force: :cascade do |t|
+  create_table "admins", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", options: "ENGINE=InnoDB ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.datetime "created_at"
     t.datetime "updated_at"
     t.string "email"
@@ -114,11 +115,15 @@ ActiveRecord::Schema.define(version: 20201214013251) do
     t.string "encrypted_password"
     t.string "password_salt"
     t.text "roles"
+    t.string "reset_password_token"
+    t.datetime "reset_password_sent_at"
+    t.datetime "locked_at"
     t.index ["email"], name: "index_admins_on_email", unique: true
     t.index ["login"], name: "index_admins_on_login", unique: true
+    t.index ["reset_password_token"], name: "index_admins_on_reset_password_token", unique: true
   end
 
-  create_table "api_keys", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC", force: :cascade do |t|
+  create_table "api_keys", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", options: "ENGINE=InnoDB ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.string "name", null: false
     t.string "access_token", null: false
     t.boolean "banned", default: false, null: false
@@ -128,7 +133,7 @@ ActiveRecord::Schema.define(version: 20201214013251) do
     t.index ["name"], name: "index_api_keys_on_name", unique: true
   end
 
-  create_table "archive_faq_translations", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC", force: :cascade do |t|
+  create_table "archive_faq_translations", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", options: "ENGINE=InnoDB ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.integer "archive_faq_id"
     t.string "locale", null: false
     t.datetime "created_at", null: false
@@ -138,7 +143,7 @@ ActiveRecord::Schema.define(version: 20201214013251) do
     t.index ["locale"], name: "index_archive_faq_translations_on_locale"
   end
 
-  create_table "archive_faqs", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC", force: :cascade do |t|
+  create_table "archive_faqs", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", options: "ENGINE=InnoDB ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.integer "admin_id"
     t.string "title"
     t.datetime "updated_at"
@@ -149,7 +154,7 @@ ActiveRecord::Schema.define(version: 20201214013251) do
     t.index ["slug"], name: "index_archive_faqs_on_slug", unique: true
   end
 
-  create_table "audits", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC", force: :cascade do |t|
+  create_table "audits", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", options: "ENGINE=InnoDB ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.integer "auditable_id"
     t.string "auditable_type"
     t.integer "associated_id"
@@ -167,11 +172,22 @@ ActiveRecord::Schema.define(version: 20201214013251) do
     t.index ["associated_id", "associated_type"], name: "associated_index"
     t.index ["auditable_id", "auditable_type"], name: "auditable_index"
     t.index ["created_at"], name: "index_audits_on_created_at"
+    t.index ["remote_address"], name: "index_audits_on_remote_address"
     t.index ["request_uuid"], name: "index_audits_on_request_uuid"
     t.index ["user_id", "user_type"], name: "user_index"
   end
 
-  create_table "bookmarks", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC", force: :cascade do |t|
+  create_table "blocks", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+    t.bigint "blocker_id"
+    t.bigint "blocked_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["blocked_id"], name: "index_blocks_on_blocked_id"
+    t.index ["blocker_id", "blocked_id"], name: "index_blocks_on_blocker_id_and_blocked_id", unique: true
+    t.index ["blocker_id"], name: "index_blocks_on_blocker_id"
+  end
+
+  create_table "bookmarks", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", options: "ENGINE=InnoDB ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.string "bookmarkable_type", limit: 15, null: false
     t.integer "bookmarkable_id", null: false
@@ -190,7 +206,7 @@ ActiveRecord::Schema.define(version: 20201214013251) do
     t.index ["user_id"], name: "fk_bookmarks_user"
   end
 
-  create_table "challenge_assignments", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC", force: :cascade do |t|
+  create_table "challenge_assignments", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", options: "ENGINE=InnoDB ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.integer "collection_id"
     t.integer "creation_id"
     t.string "creation_type"
@@ -213,7 +229,7 @@ ActiveRecord::Schema.define(version: 20201214013251) do
     t.index ["sent_at"], name: "assignments_on_offer_sent_at"
   end
 
-  create_table "challenge_claims", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC", force: :cascade do |t|
+  create_table "challenge_claims", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", options: "ENGINE=InnoDB ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.integer "collection_id"
     t.integer "creation_id"
     t.string "creation_type"
@@ -231,7 +247,7 @@ ActiveRecord::Schema.define(version: 20201214013251) do
     t.index ["request_signup_id"], name: "index_challenge_claims_on_request_signup_id"
   end
 
-  create_table "challenge_signups", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC", force: :cascade do |t|
+  create_table "challenge_signups", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", options: "ENGINE=InnoDB ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.integer "collection_id"
     t.integer "pseud_id"
     t.datetime "created_at"
@@ -242,8 +258,8 @@ ActiveRecord::Schema.define(version: 20201214013251) do
     t.index ["pseud_id"], name: "signups_on_pseud_id"
   end
 
-  create_table "chapters", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.text "content", limit: 4294967295, null: false, collation: "utf8mb4_unicode_ci"
+  create_table "chapters", id: :integer, charset: "utf8", force: :cascade do |t|
+    t.text "content", size: :long, null: false, collation: "utf8mb4_unicode_ci"
     t.integer "position", default: 1
     t.integer "work_id"
     t.datetime "created_at"
@@ -264,7 +280,7 @@ ActiveRecord::Schema.define(version: 20201214013251) do
     t.index ["work_id"], name: "works_chapter_index"
   end
 
-  create_table "collection_items", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC", force: :cascade do |t|
+  create_table "collection_items", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", options: "ENGINE=InnoDB ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.integer "collection_id"
     t.integer "item_id"
     t.string "item_type", default: "Work"
@@ -281,7 +297,7 @@ ActiveRecord::Schema.define(version: 20201214013251) do
     t.index ["unrevealed"], name: "collection_items_unrevealed"
   end
 
-  create_table "collection_participants", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC", force: :cascade do |t|
+  create_table "collection_participants", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", options: "ENGINE=InnoDB ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.integer "collection_id"
     t.integer "pseud_id"
     t.string "participant_role", default: "None", null: false
@@ -292,7 +308,7 @@ ActiveRecord::Schema.define(version: 20201214013251) do
     t.index ["pseud_id"], name: "participants_pseud_id"
   end
 
-  create_table "collection_preferences", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC", force: :cascade do |t|
+  create_table "collection_preferences", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", options: "ENGINE=InnoDB ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.integer "collection_id"
     t.datetime "created_at"
     t.datetime "updated_at"
@@ -307,11 +323,11 @@ ActiveRecord::Schema.define(version: 20201214013251) do
     t.index ["collection_id"], name: "index_collection_preferences_on_collection_id"
   end
 
-  create_table "collection_profiles", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC", force: :cascade do |t|
+  create_table "collection_profiles", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", options: "ENGINE=InnoDB ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.integer "collection_id"
-    t.text "intro", limit: 16777215
-    t.text "faq", limit: 16777215
-    t.text "rules", limit: 16777215
+    t.text "intro", size: :medium
+    t.text "faq", size: :medium
+    t.text "rules", size: :medium
     t.datetime "created_at"
     t.datetime "updated_at"
     t.text "gift_notification"
@@ -322,7 +338,7 @@ ActiveRecord::Schema.define(version: 20201214013251) do
     t.index ["collection_id"], name: "index_collection_profiles_on_collection_id"
   end
 
-  create_table "collections", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC", force: :cascade do |t|
+  create_table "collections", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", options: "ENGINE=InnoDB ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.string "name"
     t.string "title"
     t.string "email"
@@ -346,7 +362,7 @@ ActiveRecord::Schema.define(version: 20201214013251) do
     t.index ["parent_id"], name: "index_collections_on_parent_id"
   end
 
-  create_table "comments", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC", force: :cascade do |t|
+  create_table "comments", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", options: "ENGINE=InnoDB ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.integer "pseud_id"
     t.text "comment_content", null: false
     t.integer "depth"
@@ -371,13 +387,14 @@ ActiveRecord::Schema.define(version: 20201214013251) do
     t.boolean "unreviewed", default: false, null: false
     t.boolean "iced", default: false, null: false
     t.index ["commentable_id", "commentable_type"], name: "index_comments_commentable"
+    t.index ["email"], name: "index_comments_on_email"
     t.index ["ip_address"], name: "index_comments_on_ip_address"
     t.index ["parent_id", "parent_type"], name: "index_comments_parent"
     t.index ["pseud_id"], name: "index_comments_on_pseud_id"
     t.index ["thread"], name: "comments_by_thread"
   end
 
-  create_table "common_taggings", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC", force: :cascade do |t|
+  create_table "common_taggings", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", options: "ENGINE=InnoDB ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.integer "common_tag_id", null: false
     t.integer "filterable_id", null: false
     t.string "filterable_type", limit: 100
@@ -387,7 +404,7 @@ ActiveRecord::Schema.define(version: 20201214013251) do
     t.index ["filterable_id"], name: "index_common_taggings_on_filterable_id"
   end
 
-  create_table "creatorships", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC", force: :cascade do |t|
+  create_table "creatorships", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", options: "ENGINE=InnoDB ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.integer "creation_id"
     t.string "creation_type", limit: 100
     t.integer "pseud_id"
@@ -398,7 +415,7 @@ ActiveRecord::Schema.define(version: 20201214013251) do
     t.index ["pseud_id"], name: "index_creatorships_pseud"
   end
 
-  create_table "delayed_jobs", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC", force: :cascade do |t|
+  create_table "delayed_jobs", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", options: "ENGINE=InnoDB ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.integer "priority", default: 0
     t.integer "attempts", default: 0
     t.text "handler"
@@ -415,7 +432,7 @@ ActiveRecord::Schema.define(version: 20201214013251) do
     t.index ["run_at"], name: "delayed_jobs_run_at"
   end
 
-  create_table "external_author_names", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC", force: :cascade do |t|
+  create_table "external_author_names", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", options: "ENGINE=InnoDB ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.integer "external_author_id", null: false
     t.string "name"
     t.datetime "created_at"
@@ -423,7 +440,7 @@ ActiveRecord::Schema.define(version: 20201214013251) do
     t.index ["external_author_id"], name: "index_external_author_names_on_external_author_id"
   end
 
-  create_table "external_authors", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC", force: :cascade do |t|
+  create_table "external_authors", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", options: "ENGINE=InnoDB ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.string "email"
     t.boolean "is_claimed", default: false, null: false
     t.integer "user_id"
@@ -435,7 +452,7 @@ ActiveRecord::Schema.define(version: 20201214013251) do
     t.index ["user_id"], name: "index_external_authors_on_user_id"
   end
 
-  create_table "external_creatorships", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC", force: :cascade do |t|
+  create_table "external_creatorships", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", options: "ENGINE=InnoDB ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.integer "creation_id"
     t.string "creation_type"
     t.datetime "created_at"
@@ -447,7 +464,7 @@ ActiveRecord::Schema.define(version: 20201214013251) do
     t.index ["external_author_name_id"], name: "index_external_creatorships_on_external_author_name_id"
   end
 
-  create_table "external_works", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC", force: :cascade do |t|
+  create_table "external_works", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", options: "ENGINE=InnoDB ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.string "url", null: false
     t.string "author", null: false
     t.boolean "dead", default: false, null: false
@@ -460,20 +477,20 @@ ActiveRecord::Schema.define(version: 20201214013251) do
     t.integer "language_id"
   end
 
-  create_table "fannish_next_of_kins", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC", force: :cascade do |t|
+  create_table "fannish_next_of_kins", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", options: "ENGINE=InnoDB ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.integer "user_id"
     t.integer "kin_id"
     t.string "kin_email"
     t.index ["user_id"], name: "index_fannish_next_of_kins_on_user_id"
   end
 
-  create_table "favorite_tags", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC", force: :cascade do |t|
+  create_table "favorite_tags", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", options: "ENGINE=InnoDB ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.integer "user_id"
     t.integer "tag_id"
     t.index ["user_id", "tag_id"], name: "index_favorite_tags_on_user_id_and_tag_id", unique: true
   end
 
-  create_table "feedbacks", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC", force: :cascade do |t|
+  create_table "feedbacks", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", options: "ENGINE=InnoDB ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.text "comment", null: false
     t.datetime "created_at"
     t.datetime "updated_at"
@@ -483,13 +500,12 @@ ActiveRecord::Schema.define(version: 20201214013251) do
     t.string "category"
     t.integer "comment_sanitizer_version", limit: 2, default: 0, null: false
     t.integer "summary_sanitizer_version", limit: 2, default: 0, null: false
-    t.string "ip_address"
     t.string "username"
     t.string "language"
     t.string "rollout"
   end
 
-  create_table "filter_counts", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC", force: :cascade do |t|
+  create_table "filter_counts", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", options: "ENGINE=InnoDB ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.bigint "filter_id", null: false
     t.bigint "public_works_count", default: 0
     t.bigint "unhidden_works_count", default: 0
@@ -500,7 +516,7 @@ ActiveRecord::Schema.define(version: 20201214013251) do
     t.index ["unhidden_works_count"], name: "index_unhidden_works_count"
   end
 
-  create_table "filter_taggings", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC", force: :cascade do |t|
+  create_table "filter_taggings", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", options: "ENGINE=InnoDB ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.bigint "filter_id", null: false
     t.bigint "filterable_id", null: false
     t.string "filterable_type", limit: 100
@@ -511,7 +527,7 @@ ActiveRecord::Schema.define(version: 20201214013251) do
     t.index ["filterable_id", "filterable_type"], name: "index_filter_taggings_filterable"
   end
 
-  create_table "gift_exchanges", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC", force: :cascade do |t|
+  create_table "gift_exchanges", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", options: "ENGINE=InnoDB ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.integer "request_restriction_id"
     t.integer "offer_restriction_id"
     t.integer "requests_num_required", default: 1, null: false
@@ -529,7 +545,6 @@ ActiveRecord::Schema.define(version: 20201214013251) do
     t.datetime "assignments_due_at"
     t.datetime "works_reveal_at"
     t.datetime "authors_reveal_at"
-    t.integer "prompt_restriction_id"
     t.string "request_url_label"
     t.string "request_description_label"
     t.string "offer_url_label"
@@ -543,7 +558,7 @@ ActiveRecord::Schema.define(version: 20201214013251) do
     t.boolean "requests_summary_visible", default: false, null: false
   end
 
-  create_table "gifts", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC", force: :cascade do |t|
+  create_table "gifts", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", options: "ENGINE=InnoDB ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.integer "work_id"
     t.string "recipient_name"
     t.datetime "created_at"
@@ -555,7 +570,7 @@ ActiveRecord::Schema.define(version: 20201214013251) do
     t.index ["work_id"], name: "index_gifts_on_work_id"
   end
 
-  create_table "inbox_comments", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC", force: :cascade do |t|
+  create_table "inbox_comments", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", options: "ENGINE=InnoDB ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.integer "user_id"
     t.integer "feedback_comment_id"
     t.datetime "created_at"
@@ -567,11 +582,7 @@ ActiveRecord::Schema.define(version: 20201214013251) do
     t.index ["user_id"], name: "index_inbox_comments_on_user_id"
   end
 
-  create_table "innodb_monitor", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.integer "a"
-  end
-
-  create_table "invitations", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC", force: :cascade do |t|
+  create_table "invitations", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", options: "ENGINE=InnoDB ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.integer "creator_id"
     t.string "invitee_email"
     t.string "token"
@@ -591,9 +602,8 @@ ActiveRecord::Schema.define(version: 20201214013251) do
     t.index ["token"], name: "index_invitations_on_token"
   end
 
-  create_table "invite_requests", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC", force: :cascade do |t|
+  create_table "invite_requests", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", options: "ENGINE=InnoDB ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.string "email"
-    t.integer "position"
     t.datetime "created_at"
     t.datetime "updated_at"
     t.string "simplified_email", default: "", null: false
@@ -602,7 +612,7 @@ ActiveRecord::Schema.define(version: 20201214013251) do
     t.index ["simplified_email"], name: "index_invite_requests_on_simplified_email", unique: true
   end
 
-  create_table "known_issues", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC", force: :cascade do |t|
+  create_table "known_issues", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", options: "ENGINE=InnoDB ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.integer "admin_id"
     t.string "title"
     t.text "content"
@@ -611,7 +621,7 @@ ActiveRecord::Schema.define(version: 20201214013251) do
     t.integer "content_sanitizer_version", limit: 2, default: 0, null: false
   end
 
-  create_table "kudos", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC", force: :cascade do |t|
+  create_table "kudos", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", options: "ENGINE=InnoDB ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.integer "commentable_id"
     t.string "commentable_type", collation: "utf8_general_ci"
     t.datetime "created_at"
@@ -624,7 +634,7 @@ ActiveRecord::Schema.define(version: 20201214013251) do
     t.index ["user_id"], name: "index_kudos_on_user_id"
   end
 
-  create_table "languages", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC", force: :cascade do |t|
+  create_table "languages", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", options: "ENGINE=InnoDB ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.string "short", limit: 4
     t.string "name"
     t.boolean "support_available", default: false, null: false
@@ -634,7 +644,14 @@ ActiveRecord::Schema.define(version: 20201214013251) do
     t.index ["sortable_name"], name: "index_languages_on_sortable_name"
   end
 
-  create_table "locales", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC", force: :cascade do |t|
+  create_table "last_wrangling_activities", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["user_id"], name: "index_last_wrangling_activities_on_user_id", unique: true
+  end
+
+  create_table "locales", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", options: "ENGINE=InnoDB ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.string "iso"
     t.string "short"
     t.string "name"
@@ -648,7 +665,7 @@ ActiveRecord::Schema.define(version: 20201214013251) do
     t.index ["short"], name: "index_locales_on_short"
   end
 
-  create_table "log_items", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC", force: :cascade do |t|
+  create_table "log_items", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", options: "ENGINE=InnoDB ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.integer "user_id", null: false
     t.integer "admin_id"
     t.integer "role_id"
@@ -658,12 +675,13 @@ ActiveRecord::Schema.define(version: 20201214013251) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.integer "note_sanitizer_version", limit: 2, default: 0, null: false
+    t.integer "fnok_user_id"
     t.index ["admin_id"], name: "index_log_items_on_admin_id"
     t.index ["role_id"], name: "index_log_items_on_role_id"
     t.index ["user_id"], name: "index_log_items_on_user_id"
   end
 
-  create_table "meta_taggings", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC", force: :cascade do |t|
+  create_table "meta_taggings", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", options: "ENGINE=InnoDB ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.bigint "meta_tag_id", null: false
     t.bigint "sub_tag_id", null: false
     t.boolean "direct", default: true
@@ -673,7 +691,7 @@ ActiveRecord::Schema.define(version: 20201214013251) do
     t.index ["sub_tag_id"], name: "index_meta_taggings_on_sub_tag_id"
   end
 
-  create_table "moderated_works", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC", force: :cascade do |t|
+  create_table "moderated_works", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", options: "ENGINE=InnoDB ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.bigint "work_id", null: false
     t.boolean "approved", default: false, null: false
     t.boolean "reviewed", default: false, null: false
@@ -682,22 +700,17 @@ ActiveRecord::Schema.define(version: 20201214013251) do
     t.index ["work_id"], name: "index_moderated_works_on_work_id"
   end
 
-  create_table "open_id_authentication_associations", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC", force: :cascade do |t|
-    t.integer "issued"
-    t.integer "lifetime"
-    t.string "handle"
-    t.string "assoc_type"
-    t.binary "server_url"
-    t.binary "secret"
+  create_table "mutes", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+    t.bigint "muter_id"
+    t.bigint "muted_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["muted_id"], name: "index_mutes_on_muted_id"
+    t.index ["muter_id", "muted_id"], name: "index_mutes_on_muter_id_and_muted_id", unique: true
+    t.index ["muter_id"], name: "index_mutes_on_muter_id"
   end
 
-  create_table "open_id_authentication_nonces", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC", force: :cascade do |t|
-    t.integer "timestamp", null: false
-    t.string "server_url"
-    t.string "salt", null: false
-  end
-
-  create_table "owned_set_taggings", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC", force: :cascade do |t|
+  create_table "owned_set_taggings", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", options: "ENGINE=InnoDB ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.integer "owned_tag_set_id"
     t.integer "set_taggable_id"
     t.string "set_taggable_type", limit: 100
@@ -705,7 +718,7 @@ ActiveRecord::Schema.define(version: 20201214013251) do
     t.datetime "updated_at"
   end
 
-  create_table "owned_tag_sets", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC", force: :cascade do |t|
+  create_table "owned_tag_sets", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", options: "ENGINE=InnoDB ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.integer "tag_set_id"
     t.boolean "visible", default: false, null: false
     t.boolean "nominated", default: false, null: false
@@ -722,7 +735,7 @@ ActiveRecord::Schema.define(version: 20201214013251) do
     t.boolean "usable", default: false, null: false
   end
 
-  create_table "potential_match_settings", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC", force: :cascade do |t|
+  create_table "potential_match_settings", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", options: "ENGINE=InnoDB ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.integer "num_required_prompts", default: 1, null: false
     t.integer "num_required_fandoms", default: 0, null: false
     t.integer "num_required_characters", default: 0, null: false
@@ -742,7 +755,7 @@ ActiveRecord::Schema.define(version: 20201214013251) do
     t.datetime "updated_at"
   end
 
-  create_table "potential_matches", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC", force: :cascade do |t|
+  create_table "potential_matches", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", options: "ENGINE=InnoDB ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.integer "collection_id"
     t.integer "offer_signup_id"
     t.integer "request_signup_id"
@@ -756,7 +769,7 @@ ActiveRecord::Schema.define(version: 20201214013251) do
     t.index ["request_signup_id"], name: "index_potential_matches_on_request_signup_id"
   end
 
-  create_table "preferences", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC", force: :cascade do |t|
+  create_table "preferences", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", options: "ENGINE=InnoDB ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.integer "user_id"
     t.boolean "history_enabled", default: true
     t.boolean "email_visible", default: false
@@ -772,7 +785,6 @@ ActiveRecord::Schema.define(version: 20201214013251) do
     t.string "work_title_format", default: "TITLE - AUTHOR - FANDOM"
     t.boolean "hide_freeform", default: false, null: false
     t.boolean "first_login", default: true
-    t.boolean "automatically_approve_collections", default: false, null: false
     t.boolean "collection_emails_off", default: false, null: false
     t.boolean "collection_inbox_off", default: false, null: false
     t.boolean "recipient_emails_off", default: false, null: false
@@ -787,11 +799,14 @@ ActiveRecord::Schema.define(version: 20201214013251) do
     t.boolean "banner_seen", default: false, null: false
     t.integer "preferred_locale", default: 1, null: false
     t.boolean "allow_cocreator", default: false
+    t.boolean "allow_gifts", default: false
+    t.boolean "allow_collection_invitation", default: false, null: false
+    t.boolean "guest_replies_off", default: false, null: false
     t.index ["skin_id"], name: "index_preferences_on_skin_id"
     t.index ["user_id"], name: "index_preferences_on_user_id"
   end
 
-  create_table "profiles", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC", force: :cascade do |t|
+  create_table "profiles", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", options: "ENGINE=InnoDB ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.integer "user_id"
     t.string "location"
     t.text "about_me"
@@ -803,8 +818,7 @@ ActiveRecord::Schema.define(version: 20201214013251) do
     t.index ["user_id"], name: "index_profiles_on_user_id"
   end
 
-  create_table "prompt_memes", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC", force: :cascade do |t|
-    t.integer "prompt_restriction_id"
+  create_table "prompt_memes", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", options: "ENGINE=InnoDB ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.integer "request_restriction_id"
     t.integer "requests_num_required", default: 1, null: false
     t.integer "requests_num_allowed", default: 5, null: false
@@ -826,7 +840,7 @@ ActiveRecord::Schema.define(version: 20201214013251) do
     t.boolean "anonymous", default: false, null: false
   end
 
-  create_table "prompt_restrictions", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC", force: :cascade do |t|
+  create_table "prompt_restrictions", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", options: "ENGINE=InnoDB ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.integer "tag_set_id"
     t.boolean "optional_tags_allowed", default: false, null: false
     t.boolean "description_allowed", default: true, null: false
@@ -871,7 +885,7 @@ ActiveRecord::Schema.define(version: 20201214013251) do
     t.boolean "title_allowed", default: false, null: false
   end
 
-  create_table "prompts", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC", force: :cascade do |t|
+  create_table "prompts", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", options: "ENGINE=InnoDB ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.integer "collection_id"
     t.integer "challenge_signup_id"
     t.integer "pseud_id"
@@ -900,7 +914,7 @@ ActiveRecord::Schema.define(version: 20201214013251) do
     t.index ["type"], name: "index_prompts_on_type"
   end
 
-  create_table "pseuds", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC", force: :cascade do |t|
+  create_table "pseuds", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", options: "ENGINE=InnoDB ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.integer "user_id"
     t.string "name", null: false
     t.text "description"
@@ -919,7 +933,7 @@ ActiveRecord::Schema.define(version: 20201214013251) do
     t.index ["user_id", "name"], name: "index_pseuds_on_user_id_and_name"
   end
 
-  create_table "question_translations", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC", force: :cascade do |t|
+  create_table "question_translations", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", options: "ENGINE=InnoDB ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.integer "question_id"
     t.string "locale", null: false
     t.datetime "created_at", null: false
@@ -933,7 +947,7 @@ ActiveRecord::Schema.define(version: 20201214013251) do
     t.index ["question_id"], name: "index_question_translations_on_question_id"
   end
 
-  create_table "questions", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC", force: :cascade do |t|
+  create_table "questions", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", options: "ENGINE=InnoDB ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.integer "archive_faq_id"
     t.string "question"
     t.text "content"
@@ -945,7 +959,7 @@ ActiveRecord::Schema.define(version: 20201214013251) do
     t.index ["archive_faq_id", "position"], name: "index_questions_on_archive_faq_id_and_position"
   end
 
-  create_table "readings", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC", force: :cascade do |t|
+  create_table "readings", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", options: "ENGINE=InnoDB ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.integer "major_version_read"
     t.integer "minor_version_read"
     t.integer "user_id"
@@ -959,7 +973,7 @@ ActiveRecord::Schema.define(version: 20201214013251) do
     t.index ["work_id"], name: "index_readings_on_work_id"
   end
 
-  create_table "related_works", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC", force: :cascade do |t|
+  create_table "related_works", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", options: "ENGINE=InnoDB ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.integer "parent_id"
     t.string "parent_type"
     t.integer "work_id"
@@ -971,7 +985,7 @@ ActiveRecord::Schema.define(version: 20201214013251) do
     t.index ["work_id"], name: "index_related_works_on_work_id"
   end
 
-  create_table "roles", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC", force: :cascade do |t|
+  create_table "roles", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", options: "ENGINE=InnoDB ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.string "name", limit: 40
     t.string "authorizable_type", limit: 40
     t.integer "authorizable_id"
@@ -982,7 +996,7 @@ ActiveRecord::Schema.define(version: 20201214013251) do
     t.index ["name"], name: "index_roles_on_name"
   end
 
-  create_table "roles_users", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+  create_table "roles_users", charset: "utf8", force: :cascade do |t|
     t.integer "user_id"
     t.integer "role_id"
     t.datetime "created_at"
@@ -991,7 +1005,7 @@ ActiveRecord::Schema.define(version: 20201214013251) do
     t.index ["user_id", "role_id"], name: "index_roles_users_on_user_id_and_role_id"
   end
 
-  create_table "searches", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC", force: :cascade do |t|
+  create_table "searches", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", options: "ENGINE=InnoDB ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.integer "user_id"
     t.string "name"
     t.text "options"
@@ -1000,7 +1014,7 @@ ActiveRecord::Schema.define(version: 20201214013251) do
     t.datetime "updated_at"
   end
 
-  create_table "serial_works", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC", force: :cascade do |t|
+  create_table "serial_works", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", options: "ENGINE=InnoDB ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.integer "series_id"
     t.integer "work_id"
     t.integer "position", default: 1
@@ -1010,7 +1024,7 @@ ActiveRecord::Schema.define(version: 20201214013251) do
     t.index ["work_id"], name: "index_serial_works_on_work_id"
   end
 
-  create_table "series", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC", force: :cascade do |t|
+  create_table "series", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", options: "ENGINE=InnoDB ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.datetime "created_at"
     t.datetime "updated_at"
     t.string "title", null: false
@@ -1023,7 +1037,7 @@ ActiveRecord::Schema.define(version: 20201214013251) do
     t.integer "series_notes_sanitizer_version", limit: 2, default: 0, null: false
   end
 
-  create_table "set_taggings", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC", force: :cascade do |t|
+  create_table "set_taggings", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", options: "ENGINE=InnoDB ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.integer "tag_id"
     t.integer "tag_set_id"
     t.datetime "created_at"
@@ -1032,7 +1046,7 @@ ActiveRecord::Schema.define(version: 20201214013251) do
     t.index ["tag_set_id"], name: "index_set_taggings_on_tag_set_id"
   end
 
-  create_table "skin_parents", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC", force: :cascade do |t|
+  create_table "skin_parents", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", options: "ENGINE=InnoDB ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.integer "child_skin_id"
     t.integer "parent_skin_id"
     t.integer "position"
@@ -1040,7 +1054,7 @@ ActiveRecord::Schema.define(version: 20201214013251) do
     t.datetime "updated_at"
   end
 
-  create_table "skins", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC", force: :cascade do |t|
+  create_table "skins", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", options: "ENGINE=InnoDB ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.string "title"
     t.integer "author_id"
     t.text "css"
@@ -1083,7 +1097,7 @@ ActiveRecord::Schema.define(version: 20201214013251) do
     t.index ["type"], name: "index_skins_on_type"
   end
 
-  create_table "stat_counters", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC", force: :cascade do |t|
+  create_table "stat_counters", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", options: "ENGINE=InnoDB ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.integer "work_id"
     t.integer "hit_count", default: 0, null: false
     t.integer "download_count", default: 0, null: false
@@ -1094,7 +1108,7 @@ ActiveRecord::Schema.define(version: 20201214013251) do
     t.index ["work_id"], name: "index_hit_counters_on_work_id", unique: true
   end
 
-  create_table "subscriptions", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC", force: :cascade do |t|
+  create_table "subscriptions", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", options: "ENGINE=InnoDB ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.integer "user_id"
     t.integer "subscribable_id"
     t.string "subscribable_type"
@@ -1104,7 +1118,7 @@ ActiveRecord::Schema.define(version: 20201214013251) do
     t.index ["user_id"], name: "user_id"
   end
 
-  create_table "tag_nominations", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC", force: :cascade do |t|
+  create_table "tag_nominations", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", options: "ENGINE=InnoDB ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.string "type"
     t.integer "tag_set_nomination_id"
     t.integer "fandom_nomination_id"
@@ -1118,6 +1132,7 @@ ActiveRecord::Schema.define(version: 20201214013251) do
     t.boolean "exists", default: false, null: false
     t.boolean "parented", default: false, null: false
     t.string "synonym"
+    t.index ["tag_set_nomination_id", "type"], name: "index_tag_nominations_on_tag_set_nomination_id_and_type"
     t.index ["tagname"], name: "index_tag_nominations_on_tagname"
     t.index ["type", "fandom_nomination_id"], name: "index_tag_nominations_on_type_and_fandom_nomination_id"
     t.index ["type", "synonym"], name: "index_tag_nominations_on_type_and_synonym"
@@ -1125,22 +1140,27 @@ ActiveRecord::Schema.define(version: 20201214013251) do
     t.index ["type", "tagname"], name: "index_tag_nominations_on_type_and_tagname"
   end
 
-  create_table "tag_set_associations", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC", force: :cascade do |t|
+  create_table "tag_set_associations", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", options: "ENGINE=InnoDB ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.integer "owned_tag_set_id"
     t.integer "tag_id"
     t.integer "parent_tag_id"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.index ["owned_tag_set_id", "parent_tag_id", "tag_id"], name: "index_tag_set_associations_on_tag_set_and_parent_and_tag", unique: true
+    t.index ["parent_tag_id"], name: "index_tag_set_associations_on_parent_tag_id"
+    t.index ["tag_id"], name: "index_tag_set_associations_on_tag_id"
   end
 
-  create_table "tag_set_nominations", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC", force: :cascade do |t|
+  create_table "tag_set_nominations", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", options: "ENGINE=InnoDB ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.integer "pseud_id"
     t.integer "owned_tag_set_id"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.index ["owned_tag_set_id"], name: "index_tag_set_nominations_on_owned_tag_set_id"
+    t.index ["pseud_id", "owned_tag_set_id"], name: "index_tag_set_nominations_on_pseud_id_and_owned_tag_set_id"
   end
 
-  create_table "tag_set_ownerships", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC", force: :cascade do |t|
+  create_table "tag_set_ownerships", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", options: "ENGINE=InnoDB ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.integer "pseud_id"
     t.integer "owned_tag_set_id"
     t.boolean "owner", default: false, null: false
@@ -1148,12 +1168,12 @@ ActiveRecord::Schema.define(version: 20201214013251) do
     t.datetime "updated_at"
   end
 
-  create_table "tag_sets", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC", force: :cascade do |t|
+  create_table "tag_sets", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", options: "ENGINE=InnoDB ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.datetime "created_at"
     t.datetime "updated_at"
   end
 
-  create_table "taggings", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC", force: :cascade do |t|
+  create_table "taggings", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", options: "ENGINE=InnoDB ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.integer "tagger_id"
     t.integer "taggable_id", null: false
     t.string "taggable_type", limit: 100, default: ""
@@ -1164,7 +1184,7 @@ ActiveRecord::Schema.define(version: 20201214013251) do
     t.index ["tagger_id", "tagger_type", "taggable_id", "taggable_type"], name: "index_taggings_polymorphic", unique: true
   end
 
-  create_table "tags", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC", force: :cascade do |t|
+  create_table "tags", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", options: "ENGINE=InnoDB ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.string "name", limit: 100, default: ""
     t.boolean "canonical", default: false, null: false
     t.datetime "created_at"
@@ -1188,7 +1208,7 @@ ActiveRecord::Schema.define(version: 20201214013251) do
     t.index ["type"], name: "index_tags_on_type"
   end
 
-  create_table "user_invite_requests", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC", force: :cascade do |t|
+  create_table "user_invite_requests", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", options: "ENGINE=InnoDB ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.integer "user_id"
     t.integer "quantity"
     t.text "reason"
@@ -1199,7 +1219,7 @@ ActiveRecord::Schema.define(version: 20201214013251) do
     t.index ["user_id"], name: "index_user_invite_requests_on_user_id"
   end
 
-  create_table "users", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC", force: :cascade do |t|
+  create_table "users", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", options: "ENGINE=InnoDB ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.datetime "created_at"
     t.datetime "updated_at"
     t.string "email"
@@ -1227,14 +1247,17 @@ ActiveRecord::Schema.define(version: 20201214013251) do
     t.string "unlock_token"
     t.datetime "locked_at"
     t.boolean "recently_reset"
+    t.datetime "renamed_at"
+    t.integer "resets_requested", default: 0, null: false
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["login"], name: "index_users_on_login", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
+    t.index ["resets_requested"], name: "index_users_on_resets_requested"
     t.index ["unlock_token"], name: "index_users_on_unlock_token", unique: true
   end
 
-  create_table "work_links", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC", force: :cascade do |t|
+  create_table "work_links", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", options: "ENGINE=InnoDB ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.integer "work_id"
     t.string "url"
     t.integer "count"
@@ -1243,7 +1266,17 @@ ActiveRecord::Schema.define(version: 20201214013251) do
     t.index ["work_id", "url"], name: "work_links_work_id_url", unique: true
   end
 
-  create_table "works", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC", force: :cascade do |t|
+  create_table "work_original_creators", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+    t.bigint "work_id", null: false
+    t.bigint "user_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["user_id"], name: "index_work_original_creators_on_user_id"
+    t.index ["work_id", "user_id"], name: "index_work_original_creators_on_work_id_and_user_id", unique: true
+    t.index ["work_id"], name: "index_work_original_creators_on_work_id"
+  end
+
+  create_table "works", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", options: "ENGINE=InnoDB ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.integer "expected_number_of_chapters", default: 1
     t.datetime "created_at"
     t.datetime "updated_at"
@@ -1285,14 +1318,14 @@ ActiveRecord::Schema.define(version: 20201214013251) do
     t.index ["spam"], name: "index_works_on_spam"
   end
 
-  create_table "wrangling_assignments", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC", force: :cascade do |t|
+  create_table "wrangling_assignments", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", options: "ENGINE=InnoDB ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.integer "user_id"
     t.integer "fandom_id"
     t.index ["fandom_id"], name: "wrangling_assignments_by_fandom_id"
     t.index ["user_id"], name: "wrangling_assignments_by_user_id"
   end
 
-  create_table "wrangling_guidelines", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC", force: :cascade do |t|
+  create_table "wrangling_guidelines", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", options: "ENGINE=InnoDB ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.integer "admin_id"
     t.string "title"
     t.text "content"


### PR DESCRIPTION
# Pull Request Checklist

* [X] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [X] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [X] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [X] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [X] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-6639

## Purpose

* Output the latest DB schema (based on a Docker setup)
  * This should make new environment bootstrapping a bit quicker
  * Since Rails upgrades change schema formats, we will have a record of things now _before_ Rails 7
* Change the schema output process to update `schema.rb` when a new migration runs; this will make it so PRs with migrations update by default, saving us work later (we update the structure SQL separately, and that will stay manual as MySQL formats may change to not match real prod)

## Credit

Brian Austin (they/he)