### PR TITLE
AO3-6636 Update chapter cache key

### DIFF
--- a/app/views/chapters/_chapter.html.erb
+++ b/app/views/chapters/_chapter.html.erb
@@ -17,7 +17,7 @@
     <%= render "chapters/chapter_management", chapter: chapter, work: @work %>
   <% end %>
 
-<% cache_if(!@preview_mode, "#{@work.cache_key}/#{chapter.cache_key}-show-v4", skip_digest: true) do %>
+<% cache_if(!@preview_mode, "#{@work.cache_key}/#{chapter.cache_key}-show-v5", skip_digest: true) do %>
 
   <div class="chapter<%= ' preface' unless @preview_mode %> group">
     <h3 class="title">


### PR DESCRIPTION
This ensures that speculation rules prefetching is output, and cached, for all chapters.

This is an alternative to #4668.

# Pull Request Checklist

* [x] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [ ] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)? Per discussion on the ticket, no tests are needed for this feature
* [x] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [x] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-6636

## Purpose

Ensure the introduction of speculation rules next chapter prefetching causes the chapter to be evicted from cache, but then cached going forward under the new v5 cache key.

## Testing Instructions

General testing instructions for the feature are on the issue, but for this caching issue specifically, @sarken suggests testing on works which had previously been generated this change, maybe?

## References

- This comment https://otwarchive.atlassian.net/browse/AO3-6636?focusedCommentId=360659
- Discussions with @sarken and @zz9pzza

## Credit

Domenic Denicola, he/him