### PR TITLE
AO3-6645 Fix flaky bookmarks test

### DIFF
--- a/features/bookmarks/bookmark_create.feature
+++ b/features/bookmarks/bookmark_create.feature
@@ -130,6 +130,8 @@ Scenario: bookmark added to moderated collection has flash notice only when not 
     Then I should see "The collection Five Pillars is currently moderated."
   When I log out
     And I am logged in as "moderator" with password "password"
+    # Delay before approving to make sure the cache is expired
+    And it is currently 1 second from now
     And I approve the first item in the collection "Five Pillars"
     And all indexing jobs have been run
     And I am logged in as "bookmarker" with password "password"

--- a/features/bookmarks/bookmark_search.feature
+++ b/features/bookmarks/bookmark_search.feature
@@ -177,9 +177,8 @@ Feature: Search Bookmarks
       And I press "Search Bookmarks"
     Then I should see the page title "Search Bookmarks"
       And I should see "You searched for: Notes: broken heart, With Notes"
-    When "AO3-3943" is fixed
-      # And I should see "1 Found"
-      # And I should see "fifth"
+      And I should see "1 Found"
+      And I should see "fifth"
     When I follow "Edit Your Search"
     Then the field labeled "Notes" should contain "broken heart"
       And the "With notes" checkbox should be checked


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6645

[features/bookmarks/bookmark_create.feature:111](https://github.com/otwcode/otwarchive/blob/4ec559fb011ce2eba4b164a6b799f71eac9b2eec/features/bookmarks/bookmark_create.feature#L111) # Scenario: bookmark added to moderated collection has flash notice only when not approved
```
expected not to find text "The collection Five Pillars is currently moderated." in "Main Content While we've done our best to make the core functionality of this site accessible without javascript, it will work better with it enabled. Please consider turning it on! Example Archive beta User Navigation Hi, bookmarker! My Dashboard My History My Preferences Post New Work Import Work Log Out Site Navigation Fandoms All Fandoms Uncategorized Fandoms Browse Works Bookmarks Tags Collections Search Works Bookmarks Tags People About About Us News FAQ Wrangling Guidelines Donate or Volunteer Search Works Work Search: tip: lex m/m (mature OR explicit) Choices Dashboard Profile Preferences Skins Pitch Works (0) Drafts (0) Series (0) Bookmarks (1) Collections (0) Catch Inbox (0) Statistics History Subscriptions Switch Sign-ups (0) Assignments (0) Claims (0) Related Works (0) Gifts (0) 1 Bookmark by bookmarker Bookmark External Work Filters List of Bookmarks Public Bookmark 1 Fire Burn, Cauldron Bubble by workauthor Fandoms: Stargate SG-1 Not Rated No Archive Warnings Apply Other Complete Work 25 Nov 2023 Tags No Archive Warnings ApplyScary tag Language: English Words: 6 Chapters: 1/1 Bookmarks: 1 Hits: 0 Bookmarked by bookmarker 25 Nov 2023 The collection Five Pillars is currently moderated. Your bookmark must be approved by the collection maintainers before being listed there. Bookmarker's Collections: Five Pillars Edit Delete Add To Collection Share Filters Filter results: Submit Sort by Date Bookmarked Date Updated Include ? Include Ratings Not Rated (1) Include Warnings No Archive Warnings Apply (1) Include Categories Other (1) Include Fandoms Include Characters Include Relationships Include Additional Tags Include Bookmarker's Tags Other work tags to include Other bookmarker's tags to include Exclude ? Exclude Ratings Not Rated (1) Exclude Warnings No Archive Warnings Apply (1) Exclude Categories Other (1) Exclude Fandoms Exclude Characters Exclude Relationships Exclude Additional Tags Exclude Bookmarker's Tags Other work tags to exclude Other bookmarker's tags to exclude More Options Search within results ? Search bookmarker's tags and notes ? Work language English Bookmark types Recs only Only bookmarks with notes Submit Clear Filters Top of Bookmark Index Footer About the Archive Site Map Diversity Statement Terms of Service DMCA Policy Contact Us Policy Questions & Abuse Reports Technical Support & Feedback Development Known Issues GPL by the OTW" (RSpec::Expectations::ExpectationNotMetError)
./features/step_definitions/web_steps.rb:182:in `block (2 levels) in <top (required)>'
./features/step_definitions/web_steps.rb:6:in `with_scope'
./features/step_definitions/web_steps.rb:180:in `/^(?:|I )should not see "([^"]*)"(?: within "([^"]*)")?$/'
features/bookmarks/bookmark_create.feature:137:in `Then I should not see "The collection Five Pillars is currently moderated."'
```

## Purpose

Fix flaky bookmarks test by waiting for one second before approving a moderated bookmark so the cache is expired.

Also, enable a test for a Jira issue that was fixed some years ago: https://otwarchive.atlassian.net/browse/AO3-3943 

## Testing Instructions

No manual testing needed. Before the fix, [50 test runs](https://github.com/Bilka2/otwarchive/actions/runs/6991099412) resulted in 5 failures. After the fix [50 test runs](https://github.com/Bilka2/otwarchive/actions/runs/6991194455) result in no failures.

## Credit

Bilka (he/him)
