### PR TITLE
AO3-6636 Remove rollout guard for speculation rules

### DIFF
--- a/app/views/chapters/_chapter.html.erb
+++ b/app/views/chapters/_chapter.html.erb
@@ -17,7 +17,7 @@
     <%= render "chapters/chapter_management", chapter: chapter, work: @work %>
   <% end %>
 
-<% cache_if(!@preview_mode, "#{@work.cache_key}/#{chapter.cache_key}-show-v5", skip_digest: true) do %>
+<% cache_if(!@preview_mode, "#{@work.cache_key}/#{chapter.cache_key}-show-v6", skip_digest: true) do %>
 
   <div class="chapter<%= ' preface' unless @preview_mode %> group">
     <h3 class="title">
@@ -79,7 +79,7 @@
     </div>
   <% end %>
 
-  <% if @next_chapter && $rollout.active?(:prefetch_next_chapter) %>
+  <% if @next_chapter %>
     <script type="speculationrules">
       {
         "prefetch": [


### PR DESCRIPTION
See https://otwarchive.atlassian.net/browse/AO3-6636?focusedCommentId=360670.

# Pull Request Checklist

* [x] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [ ] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)? No tests needed, per discussion on the issue
* [x] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [x] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-6636

## Purpose

Removes the rollout guard from the speculation rules next-chapter prefetch feature, since it interacts poorly with caching and was deemed unnecessary.

## Testing Instructions

See instructions in https://otwarchive.atlassian.net/browse/AO3-6636.

## References

The specific comment https://otwarchive.atlassian.net/browse/AO3-6636?focusedCommentId=360670.

## Credit

Domenic Denicola, he/him