### PR TITLE
AO3-6579 Set @page_title to Create Account not New Registration

### DIFF
--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -3,6 +3,7 @@ class Users::RegistrationsController < Devise::RegistrationsController
   before_action :configure_permitted_parameters
 
   def new
+    @page_title = "Create Account" # Displays "New Registration" otherwise
     super do |resource|
       if params[:invitation_token]
         @invitation = Invitation.find_by(token: params[:invitation_token])


### PR DESCRIPTION
The heading in the New User Registrations page says "**Create Account**", however, the browser tab says "**New Registration**". In the controller's `:new` action, I added `@page_title = 'Create Account'` to make the browser tab match.

Note: This differs from setting `@title`, which would change the heading.

# Pull Request Checklist

* [X] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [X] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [ ] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)? 
* [X] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [X] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-6579

## Purpose

Match the browser tab `@page_title` with the Heading `@title`. 

## Testing Instructions

- Allow for new Account Creation in development 
  (I just temporarily removed `if !AdminSetting.current.account_creation_enabled?` in *users/registrations_controller.rb#66*. 
- Go to the `/signup` path (`127.0.0.1:3000/signup`, depending on your setup).
- Check your browser tab and ensure that it says "Create Account" instead of "New Registration" (or *(development) Create Account*).

## Credit 

Paul Lemus (he/him)