### PR TITLE
AO3-6639 Revert schema dump setting

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -66,6 +66,11 @@ module Otwarchive
     # Configure sensitive parameters which will be filtered from the log file.
     config.filter_parameters += [:content, :password, :terms_of_service_non_production]
 
+    # Disable dumping schemas after migrations.
+    # This can cause problems since we don't always update versions on merge.
+    # Ideally this would be enabled in dev, but we're not quite ready for that.
+    config.active_record.dump_schema_after_migration = false
+
     # Allows belongs_to associations to be optional
     config.active_record.belongs_to_required_by_default = false
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1057,7 +1057,7 @@ ActiveRecord::Schema.define(version: 2023_09_20_094945) do
   create_table "skins", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", options: "ENGINE=InnoDB ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.string "title"
     t.integer "author_id"
-    t.text "css"
+    t.text "css", size: :long
     t.boolean "public", default: false
     t.boolean "official", default: false
     t.datetime "created_at"


### PR DESCRIPTION
## Issue 

https://otwarchive.atlassian.net/browse/AO3-6639

Reverses the change in https://github.com/otwcode/otwarchive/pull/4669 that has the schema dump updated on any changes to dev. It ended up being problematic for tests, and since we don't always merge things fast, the potential for merge conflicts is... not great. I can work on some improvements, but for now let's just do what worked.