### PR TITLE
AO3-6649 Add Departure arg to ignore replicas

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -546,3 +546,4 @@ PERCONA_ARGS: >
   --set-vars innodb_lock_wait_timeout=2
   --alter-foreign-keys-method=auto
   --no-check-unique-key-change
+  --recursion-method=none


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6649

## Purpose

I saw ptosc/departure error out when doing the migration for https://github.com/otwcode/otwarchive/pull/4648. More information on the ticket, but basically it seems that departure was interpreting replica disconnects as fatal errors (which regular ptosc does not do).

## Credit

Brian Austin (they/he)
