### PR TITLE
AO3-6386 Fix that email addresses in mailer previews were localized

### DIFF
--- a/factories/admin.rb
+++ b/factories/admin.rb
@@ -5,7 +5,7 @@ FactoryBot.define do
     login { generate(:login) }
     password { "adminpassword" }
     password_confirmation { |u| u.password }
-    email { generate(:email) }
+    email { Faker::Internet.unique.email }
 
     factory :superadmin do
       roles { ["superadmin"] }

--- a/factories/admin_blacklisted_email.rb
+++ b/factories/admin_blacklisted_email.rb
@@ -2,6 +2,6 @@ require 'faker'
 
 FactoryBot.define do
   factory :admin_blacklisted_email do
-    email
+    email { Faker::Internet.unique.email }
   end
 end

--- a/factories/users.rb
+++ b/factories/users.rb
@@ -5,10 +5,6 @@ FactoryBot.define do
     "#{Faker::Lorem.characters(number: 8)}#{n}"
   end
 
-  sequence :email do |n|
-    Faker::Internet.email(name: "#{Faker::Name.first_name}_#{n}")
-  end
-
   factory :role do
     sequence(:name) { |n| "#{Faker::Company.profession}_#{n}" }
   end
@@ -19,7 +15,7 @@ FactoryBot.define do
     age_over_13 { "1" }
     terms_of_service { "1" }
     password_confirmation(&:password)
-    email { generate(:email) }
+    email { Faker::Internet.unique.email }
 
     # By default, create activated users who can log in, since we use
     # devise :confirmable.

--- a/spec/controllers/invite_requests_controller_spec.rb
+++ b/spec/controllers/invite_requests_controller_spec.rb
@@ -93,14 +93,14 @@ describe InviteRequestsController do
       end
 
       it "redirects to index with notice" do
-        email = generate(:email)
+        email = Faker::Internet.unique.email
         post :create, params: { invite_request: { email: email } }
         invite_request = InviteRequest.find_by!(email: email)
         it_redirects_to_with_notice(invite_requests_path, "You've been added to our queue! Yay! We estimate that you'll receive an invitation around #{invite_request.proposed_fill_date}. We strongly recommend that you add do-not-reply@archiveofourown.org to your address book to prevent the invitation email from getting blocked as spam by your email provider.")
       end
 
       it "assigns an IP address to the request" do
-        post :create, params: { invite_request: { email: generate(:email) } }
+        post :create, params: { invite_request: { email: Faker::Internet.unique.email } }
         expect(assigns(:invite_request).ip_address).to eq(ip)
       end
     end
@@ -111,7 +111,7 @@ describe InviteRequestsController do
       end
 
       it "redirects to index with error" do
-        post :create, params: { invite_request: { email: generate(:email) } }
+        post :create, params: { invite_request: { email: Faker::Internet.unique.email } }
         it_redirects_to_simple(invite_requests_path)
         expect(flash[:error]).to include("New invitation requests are currently closed.")
       end

--- a/test/mailers/previews/application_mailer_preview.rb
+++ b/test/mailers/previews/application_mailer_preview.rb
@@ -1,6 +1,7 @@
 require "factory_bot"
 
-FactoryBot.find_definitions
+# In test and dev this is automatically called by factory_bot_rails after initialize, don't call it again
+FactoryBot.find_definitions unless Rails.env.test? || Rails.env.development?
 
 class ApplicationMailerPreview < ActionMailer::Preview
   include FactoryBot::Syntax::Methods


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6386

## Purpose

This changes the generator for the emails of users and admins in tests and mailer previews to always produce valid email addresses.

This also fixes that the mailer previews [errored in local dev](https://github.com/otwcode/otwarchive/pull/4475#pullrequestreview-1329628736). The comment in the code is based on [the docs](https://thoughtbot.github.io/factory_bot/ref/find_definitions.html).

## Testing Instructions

The preview UI should be at https://test.archiveofourown.org/rails/mailers and the creatorship mailer previews should not error when selecting languages such as `ja`, `vi` or `zh-CN`.

## Credit

Bilka (he/him)
