### PR TITLE
AO3-3471 Allow filtering on language specific /works page

### DIFF
--- a/app/views/works/_filters.html.erb
+++ b/app/views/works/_filters.html.erb
@@ -150,12 +150,14 @@
             <%= f.text_field :query %>
           </dd>
 
-          <dt class="language">
-            <%= f.label :language_id, ts("Language") %>
-          </dt>
-          <dd class="language">
-            <%= f.select(:language_id, language_options_for_select(Language.default_order, "short"), include_blank: true) %>
-          </dd>
+          <% unless @language %>
+            <dt class="language">
+              <%= f.label :language_id, ts("Language") %>
+            </dt>
+            <dd class="language">
+              <%= f.select(:language_id, language_options_for_select(Language.default_order, "short"), include_blank: true) %>
+            </dd>
+          <% end %>
         </dl>
       </dd>
       <dt class="landmark"><%= ts("Submit") %></dt>
@@ -174,6 +176,7 @@
       <%= hidden_field_tag("fandom_id", @fandom.id) if @fandom %>
       <%= hidden_field_tag("pseud_id", @pseud.name) if @pseud %>
       <%= hidden_field_tag("user_id", @user.login) if @user %>
+      <%= hidden_field_tag("language_id", @language.short) if @language %>
     </div>
 
   <% end %>

--- a/app/views/works/index.html.erb
+++ b/app/views/works/index.html.erb
@@ -12,30 +12,30 @@
     <h3 class="landmark heading"><%= ts("Navigation and Actions") %></h3>
     <!--gift search subnav-->
     <% if @collection && @collection.gift_exchange? %>
-      <%= render 'gifts/gift_search' %>
+      <%= render "gifts/gift_search" %>
     <% end %>
     <!--user role subnav-->
     <ul class="user navigation actions" role="navigation">
       <% if @user %>
         <% if @user == current_user %>
-          <li id="edit_multiple"><%= link_to ts('Edit Works'), show_multiple_user_works_path(@user) %></li>
+          <li id="edit_multiple"><%= link_to ts("Edit Works"), show_multiple_user_works_path(@user) %></li>
         <% end %>
-        <li><%= span_if_current ts('Works in Collections'), collected_user_works_path(@user) %></li>
-        <li><%= span_if_current ts('Works'), user_works_path(@user) %></li>
+        <li><%= span_if_current ts("Works in Collections"), collected_user_works_path(@user) %></li>
+        <li><%= span_if_current ts("Works"), user_works_path(@user) %></li>
       <% end %>
       <% if @tag && !@collection %>
-        <li><%= span_if_current ts('Works'), tag_works_path(@tag) %></li>
-        <li><%= span_if_current ts('Bookmarks'), tag_bookmarks_path(@tag) %></li>
+        <li><%= span_if_current ts("Works"), tag_works_path(@tag) %></li>
+        <li><%= span_if_current ts("Bookmarks"), tag_bookmarks_path(@tag) %></li>
       <% end %>
       <% if @facets.present? %>
-        <% # Filters button for narrow screens jumps to filters when JavaScript is disabled and opens filters when JavaScript is enabled %>
+        <%# Filters button for narrow screens jumps to filters when JavaScript is disabled and opens filters when JavaScript is enabled %>
         <li class="narrow-shown hidden"><a href="#work-filters" id="go_to_filters"><%= ts("Filters") %></a></li>
       <% end %>
       <% if @tag && logged_in? && !@collection %>
-        <li><%= render 'favorite_tags/form', current_user: @current_user, favorite_tag: @favorite_tag %></li>
+        <li><%= render "favorite_tags/form", current_user: @current_user, favorite_tag: @favorite_tag %></li>
       <% end %>
       <% if @tag && !@collection && (%w(Fandom Character Relationship).include?(@tag.type.to_s) || @tag.name == "F/F") %>
-        <li><%= link_to_rss feed_tag_path(:id => @tag.id, :format => :atom) %></li>
+        <li><%= link_to_rss feed_tag_path({ id: @tag.id, format: :atom }) %></li>
       <% end %>
     </ul>
   </div>
@@ -53,7 +53,7 @@
 <!--main content-->
 <h3 class="landmark heading"><%= ts("Listing Works") %></h3>
 <ol class="work index group">
-  <%= render partial: 'work_blurb', collection: @works, as: :work %>
+  <%= render partial: "work_blurb", collection: @works, as: :work %>
 </ol>
 
 <!--/content-->
@@ -67,4 +67,3 @@
 <% if @works.respond_to?(:total_pages) %>
   <%= will_paginate @works %>
 <% end %>
-

--- a/app/views/works/index.html.erb
+++ b/app/views/works/index.html.erb
@@ -7,7 +7,7 @@
 <!-- /end descriptions-->
 
 <!--Subnavigation, sorting and actions.-->
-<% if @collection || @tag || @user %>
+<% if @collection || @tag || @user || @language %>
   <div class="navigation actions module">
     <h3 class="landmark heading"><%= ts("Navigation and Actions") %></h3>
     <!--gift search subnav-->
@@ -15,31 +15,29 @@
       <%= render 'gifts/gift_search' %>
     <% end %>
     <!--user role subnav-->
-    <% if @tag || @user || @collection %>
-      <ul class="user navigation actions" role="navigation">
-        <% if @user %>
-          <% if @user == current_user %>
-            <li id="edit_multiple"><%= link_to ts('Edit Works'), show_multiple_user_works_path(@user) %></li>
-          <% end %>
-          <li><%= span_if_current ts('Works in Collections'), collected_user_works_path(@user) %></li>
-          <li><%= span_if_current ts('Works'), user_works_path(@user) %></li>
+    <ul class="user navigation actions" role="navigation">
+      <% if @user %>
+        <% if @user == current_user %>
+          <li id="edit_multiple"><%= link_to ts('Edit Works'), show_multiple_user_works_path(@user) %></li>
         <% end %>
-        <% if @tag && !@collection %>
-          <li><%= span_if_current ts('Works'), tag_works_path(@tag) %></li>
-          <li><%= span_if_current ts('Bookmarks'), tag_bookmarks_path(@tag) %></li>
-        <% end %>
-        <% if @facets.present? %>
-          <% # Filters button for narrow screens jumps to filters when JavaScript is disabled and opens filters when JavaScript is enabled %>
-          <li class="narrow-shown hidden"><a href="#work-filters" id="go_to_filters"><%= ts("Filters") %></a></li>
-        <% end %>
-        <% if @tag && logged_in? && !@collection %>
-          <li><%= render 'favorite_tags/form', current_user: @current_user, favorite_tag: @favorite_tag %></li>
-        <% end %>
-        <% if @tag && !@collection && (%w(Fandom Character Relationship).include?(@tag.type.to_s) || @tag.name == "F/F") %>
-          <li><%= link_to_rss feed_tag_path(:id => @tag.id, :format => :atom) %></li>
-        <% end %>
-      </ul>
-    <% end %>
+        <li><%= span_if_current ts('Works in Collections'), collected_user_works_path(@user) %></li>
+        <li><%= span_if_current ts('Works'), user_works_path(@user) %></li>
+      <% end %>
+      <% if @tag && !@collection %>
+        <li><%= span_if_current ts('Works'), tag_works_path(@tag) %></li>
+        <li><%= span_if_current ts('Bookmarks'), tag_bookmarks_path(@tag) %></li>
+      <% end %>
+      <% if @facets.present? %>
+        <% # Filters button for narrow screens jumps to filters when JavaScript is disabled and opens filters when JavaScript is enabled %>
+        <li class="narrow-shown hidden"><a href="#work-filters" id="go_to_filters"><%= ts("Filters") %></a></li>
+      <% end %>
+      <% if @tag && logged_in? && !@collection %>
+        <li><%= render 'favorite_tags/form', current_user: @current_user, favorite_tag: @favorite_tag %></li>
+      <% end %>
+      <% if @tag && !@collection && (%w(Fandom Character Relationship).include?(@tag.type.to_s) || @tag.name == "F/F") %>
+        <li><%= link_to_rss feed_tag_path(:id => @tag.id, :format => :atom) %></li>
+      <% end %>
+    </ul>
   </div>
 <% end %>
 <!---/subnav-->

--- a/features/works/work_browse.feature
+++ b/features/works/work_browse.feature
@@ -172,6 +172,8 @@ Scenario: Can also browse work indexed by language
       And I should see "Deutsch" within "dd.language"
     When I browse works in language "English"
       Then I should see "2 Works in English"
+    When I press "Sort and Filter"
+      Then I should see "2 Works in English"
     When I browse works in language "Deutsch"
       Then I should see "1 Work in Deutsch"
     When I browse works in language "Persian"


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [x] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [x] Have you added the [Jira](https://otwarchive.atlassian.net) issue number as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [x] Do you have fewer than 5 pull requests already open? If not, please wait until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-3471

## Purpose
Fix the two bugs reported [here](https://otwarchive.atlassian.net/browse/AO3-3471?focusedCommentId=360724), namely:
- Conserve "owner" language_id when using filters
- Show "Filters" button on mobile

## Testing Instructions

1. On a page like `/languages/en/works`, `/languages/de/works`, etc.
2. Try using the filters on both desktop and mobile versions

## Credit

Ceithir (he/him)