### PR TITLE
AO3-6650 Move speculation rules next chapter prefetch

### DIFF
--- a/app/views/chapters/_chapter.html.erb
+++ b/app/views/chapters/_chapter.html.erb
@@ -17,6 +17,7 @@
     <%= render "chapters/chapter_management", chapter: chapter, work: @work %>
   <% end %>
 
+<%# Both Entire Work and Chapter by Chapter mode write to and read from this cache. Only content needed for both modes should be included here. %>
 <% cache_if(!@preview_mode, "#{@work.cache_key}/#{chapter.cache_key}-show-v7", skip_digest: true) do %>
 
   <div class="chapter<%= ' preface' unless @preview_mode %> group">

--- a/app/views/chapters/_chapter.html.erb
+++ b/app/views/chapters/_chapter.html.erb
@@ -17,7 +17,7 @@
     <%= render "chapters/chapter_management", chapter: chapter, work: @work %>
   <% end %>
 
-<% cache_if(!@preview_mode, "#{@work.cache_key}/#{chapter.cache_key}-show-v6", skip_digest: true) do %>
+<% cache_if(!@preview_mode, "#{@work.cache_key}/#{chapter.cache_key}-show-v7", skip_digest: true) do %>
 
   <div class="chapter<%= ' preface' unless @preview_mode %> group">
     <h3 class="title">
@@ -77,19 +77,6 @@
         </blockquote>
       </div>
     </div>
-  <% end %>
-
-  <% if @next_chapter %>
-    <script type="speculationrules">
-      {
-        "prefetch": [
-          {
-            "source": "list",
-            "urls": ["<%= work_chapter_path(@work, @next_chapter, anchor: "workskin") %>"]
-          }
-        ]
-      }
-    </script>
   <% end %>
 
 </div>

--- a/app/views/chapters/show.html.erb
+++ b/app/views/chapters/show.html.erb
@@ -24,12 +24,12 @@
     <div id="chapters">
       <%= render :partial => 'chapters/chapter', :locals => { :chapter => @chapter } %>
     </div>
-  
+
     <% inspired_by = get_inspired_by(@work) %>
     <% last_chapter = @work.posted? ? @work.last_posted_chapter : @work.last_chapter %>
     <% if @chapter == last_chapter && (@work.endnotes.present? || @work.series.present? || inspired_by.present?) %>
       <!--afterword-->
-      <div class="afterword preface group">  
+      <div class="afterword preface group">
         <% if !@work.endnotes.blank? %>
           <%= render :partial => 'works/work_endnotes' %>
         <% end %>
@@ -42,7 +42,7 @@
       </div>
       <!--/afterword-->
     <% end %>
-  
+
     </div>
     <!-- END work skin -->
   </div>
@@ -51,6 +51,19 @@
   <!-- BEGIN comment section -->
   <%= render :partial => 'comments/commentable', :locals => {:commentable => @chapter} %>
   <!-- END comment section -->
+
+  <% if @next_chapter %>
+    <script type="speculationrules">
+      {
+        "prefetch": [
+          {
+            "source": "list",
+            "urls": ["<%= work_chapter_path(@work, @next_chapter, anchor: "workskin") %>"]
+          }
+        ]
+      }
+    </script>
+  <% end %>
 <% end %>
 
 <%= render "hit_count/include" %>


### PR DESCRIPTION
Previously, we were adding the `<script type=speculationrules>` block inside the `_chapter` include. However, this means it was included on the "Entire Work" page, which is undesirable. (On that page, there would be no `@next_chapter` variable, so nothing would be rendered... and then that lack of speculation rules would be cached.)

We only want to preload the next chapter when we're looking at a single chapter in isolation. For this, it's best to put the `<script type=speculationrules>` in the `chapters/show` template.

# Pull Request Checklist

* [x] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [ ] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?: per discussion [on the ticket](https://otwarchive.atlassian.net/browse/AO3-6636), this is probably fine without tests.
* [x] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [x] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-6650

## Purpose

To ensure speculation rules are included on all single-chapter pages with a next chapter, and not included on the Entire Work page, and cached correctly while we do it.

## Testing Instructions

See https://otwarchive.atlassian.net/browse/AO3-6650 for how to reproduce the bug; the idea is that it should no longer reproduce, after this change.

## References

- The parent issues https://otwarchive.atlassian.net/browse/AO3-6635 and https://otwarchive.atlassian.net/browse/AO3-6637 are also relevant.
- All credit to @sarken for understanding why this was broken.

## Credit

Domenic Denicola, he/him