### PR TITLE
AO3-6609 Visual fixes for invitation status 

### DIFF
--- a/app/views/invite_requests/_invitation.html.erb
+++ b/app/views/invite_requests/_invitation.html.erb
@@ -5,14 +5,18 @@
 <!--/descriptions-->
 
 <!--main content-->
-<% status = invitation.resent_at ? "resent" : "not_resent" %>
 <p>
+  <% status = invitation.resent_at ? "resent" : "not_resent" %>
   <%= t(".info.#{status}",
         sent_at: l(invitation.sent_at.to_date),
         resent_at: invitation.resent_at ? l(invitation.resent_at.to_date) : nil) %>
+</p>
+
+<p>
   <% if invitation.can_resend? %>
   <%# i18n-tasks-use t("invite_requests.invitation.after_cooldown_period.not_resent")
-      i18n-tasks-use t("invite_requests.invitation.after_cooldown_period.resent")-%>
+      i18n-tasks-use t("invite_requests.invitation.after_cooldown_period.resent_html")-%>
+    <% status = invitation.resent_at ? "resent_html" : "not_resent" %>
     <%= t(".after_cooldown_period.#{status}",
           count: ArchiveConfig.HOURS_BEFORE_RESEND_INVITATION,
           contact_support_link: link_to(t(".contact_support"), new_feedback_report_path)) %>
@@ -21,15 +25,4 @@
     <%= t(".before_cooldown_period", count: ArchiveConfig.HOURS_BEFORE_RESEND_INVITATION) %>
   <% end %>
 </p>
-
-<%# Correct heading size for JavaScript display %>
-<%= content_for :footer_js do %>
-  <script>
-    $j(document).ready(function(){
-      $j('#invite-heading').replaceWith(function () {
-        return "<h3>" + $j(this).html() + "</h3>";
-      });
-    })
-  </script>
-<% end %>
 <!--/content-->

--- a/app/views/invite_requests/show.js.erb
+++ b/app/views/invite_requests/show.js.erb
@@ -2,6 +2,13 @@
   $j("#invite-status").html("<%= escape_javascript(render "invite_requests/invite_request", invite_request: @invite_request) %>");
 <% elsif @invitation %>
   $j("#invite-status").html("<%= escape_javascript(render "invitation", invitation: @invitation) %>");
+
+  <%# Correct heading size for JavaScript display %>
+  $j(document).ready(function(){
+    $j('#invite-heading').replaceWith(function () {
+      return '<h3 class="heading">' + $j(this).html() + "</h3>";
+    });
+  })
 <% else %>
   $j("#invite-status").html("<%= escape_javascript(render "no_invitation") %>");
 <% end %>

--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -521,7 +521,7 @@ en:
         not_resent:
           one: Because your invitation was sent more than an hour ago, you can have your invitation resent.
           other: Because your invitation was sent more than %{count} hours ago, you can have your invitation resent.
-        resent:
+        resent_html:
           one: Because your invitation was resent more than an hour ago, you can have your invitation resent again, or you may want to %{contact_support_link}.
           other: Because your invitation was resent more than %{count} hours ago, you can have your invitation resent again, or you may want to %{contact_support_link}.
       before_cooldown_period:


### PR DESCRIPTION
Second PR to fix some issues flagged by QA. 

## Issue

https://otwarchive.atlassian.net/browse/AO3-6609
## Purpose

* Fix headings for JS and no JS invitation status info
* Fix lack of paragraph separation for text 
* Fix unescaped HTML in contact support link in status info

## Testing Instructions
Check the status info with JS and no JS. 

## References
https://github.com/otwcode/otwarchive/pull/4648
