### PR TITLE
AO3-6626 Add after task for removing invalid commas from tags

### DIFF
--- a/lib/tasks/after_tasks.rake
+++ b/lib/tasks/after_tasks.rake
@@ -269,7 +269,7 @@ namespace :After do
 
   desc "Remove full-width and ideographic commas from tags"
   task(remove_invalid_commas_from_tags: :environment) do
-    puts("Tags can only be renamed by an admin. Enter your admin login:")
+    puts("Tags can only be renamed by an admin, who will be listed as the tag's last wrangler. Enter the admin login we should use:")
     login = $stdin.gets.chomp.strip
     admin = Admin.find_by(login: login)
 

--- a/lib/tasks/after_tasks.rake
+++ b/lib/tasks/after_tasks.rake
@@ -270,7 +270,7 @@ namespace :After do
   desc "Remove full-width and ideographic commas from tags"
   task(remove_invalid_commas_from_tags: :environment) do
     puts("Tags can only be renamed by an admin. Enter your admin login:")
-    login = STDIN.gets.chomp.strip
+    login = $stdin.gets.chomp.strip
     admin = Admin.find_by(login: login)
 
     if admin.present?
@@ -280,14 +280,12 @@ namespace :After do
         tags = Tag.where("name LIKE ?", "%#{comma}%")
         tags.each do |tag|
           new_name = tag.name.gsub(/#{comma}/, "")
-          if tag.update(name: new_name)
-            puts(tag.reload.name)
-          elsif tag.update(name: "#{new_name} - AO3-6626")
+          if tag.update(name: new_name) || tag.update(name: "#{new_name} - AO3-6626")
             puts(tag.reload.name)
           else
             puts("Could not rename #{tag.reload.name}")
           end
-          STDOUT.flush
+          $stdout.flush
         end
       end
     else

--- a/lib/tasks/after_tasks.rake
+++ b/lib/tasks/after_tasks.rake
@@ -267,5 +267,32 @@ namespace :After do
     r&.destroy
   end
 
+  desc "Remove full-width and ideographic commas from tags"
+  task(remove_invalid_commas_from_tags: :environment) do
+    puts("Tags can only be renamed by an admin. Enter your admin login:")
+    login = STDIN.gets.chomp.strip
+    admin = Admin.find_by(login: login)
+
+    if admin.present?
+      User.current_user = admin
+
+      ["，", "、"].each do |comma|
+        tags = Tag.where("name LIKE ?", "%#{comma}%")
+        tags.each do |tag|
+          new_name = tag.name.gsub(/#{comma}/, "")
+          if tag.update(name: new_name)
+            puts(tag.reload.name)
+          elsif tag.update(name: "#{new_name} - AO3-6626")
+            puts(tag.reload.name)
+          else
+            puts("Could not rename #{tag.reload.name}")
+          end
+          STDOUT.flush
+        end
+      end
+    else
+      puts("Admin not found.")
+    end
+  end
   # This is the end that you have to put new tasks above.
 end

--- a/spec/lib/tasks/after_tasks.rake_spec.rb
+++ b/spec/lib/tasks/after_tasks.rake_spec.rb
@@ -393,7 +393,7 @@ describe "rake After:remove_invalid_commas_from_tags" do
   end
 
   it "puts an error and does not rename tags without a valid admin" do
-    allow(STDIN).to receive(:gets) { "typo" }
+    allow($stdin).to receive(:gets) { "typo" }
 
     expect do
       subject.invoke
@@ -406,24 +406,28 @@ describe "rake After:remove_invalid_commas_from_tags" do
     let!(:admin) { create(:admin, login: "admin") }
 
     before do
-      allow(STDIN).to receive(:gets) { "admin" }
+      allow($stdin).to receive(:gets) { "admin" }
     end
 
     it "removes full-width and ideographic commas when the name is otherwise unique" do
       expect do
         subject.invoke
-      end.to change { chinese_tag.reload.name }.from("Full-width，Comma").to("Full-widthComma")
+      end.to change { chinese_tag.reload.name }
+          .from("Full-width，Comma")
+          .to("Full-widthComma")
         .and change { japanese_tag.reload.name }.from("Ideographic、Comma").to("IdeographicComma")
         .and output("Tags can only be renamed by an admin. Enter your admin login:\nFull-widthComma\nIdeographicComma\n").to_stdout
     end
 
     it "removes full-width and ideographic commas and appends \" - AO3-6626\" when the name is not unique" do
-      duplicate_chinese_tag = create(:tag, name: "Full-widthComma")
-      duplicate_japanese_tag = create(:tag, name: "IdeographicComma")
+      create(:tag, name: "Full-widthComma")
+      create(:tag, name: "IdeographicComma")
 
       expect do
         subject.invoke
-      end.to change { chinese_tag.reload.name }.from("Full-width，Comma").to("Full-widthComma - AO3-6626")
+      end.to change { chinese_tag.reload.name }
+          .from("Full-width，Comma")
+          .to("Full-widthComma - AO3-6626")
         .and change { japanese_tag.reload.name }.from("Ideographic、Comma").to("IdeographicComma - AO3-6626")
         .and output("Tags can only be renamed by an admin. Enter your admin login:\nFull-widthComma - AO3-6626\nIdeographicComma - AO3-6626\n").to_stdout
     end

--- a/spec/lib/tasks/after_tasks.rake_spec.rb
+++ b/spec/lib/tasks/after_tasks.rake_spec.rb
@@ -381,6 +381,7 @@ describe "rake After:remove_translation_admin_role" do
 end
 
 describe "rake After:remove_invalid_commas_from_tags" do
+  let(:prompt) { "Tags can only be renamed by an admin, who will be listed as the tag's last wrangler. Enter the admin login we should use:\n" }
   let!(:chinese_tag) do
     tag = create(:tag)
     tag.update_column(:name, "Full-width，Comma")
@@ -399,7 +400,7 @@ describe "rake After:remove_invalid_commas_from_tags" do
       subject.invoke
     end.to avoid_changing { chinese_tag.reload.name }
       .and avoid_changing { japanese_tag.reload.name }
-      .and output("Tags can only be renamed by an admin. Enter your admin login:\nAdmin not found.\n").to_stdout
+      .and output("#{prompt}Admin not found.\n").to_stdout
   end
 
   context "with a valid admin" do
@@ -418,7 +419,7 @@ describe "rake After:remove_invalid_commas_from_tags" do
         .and change { japanese_tag.reload.name }
         .from("Ideographic、Comma")
         .to("IdeographicComma")
-        .and output("Tags can only be renamed by an admin. Enter your admin login:\nFull-widthComma\nIdeographicComma\n").to_stdout
+        .and output("#{prompt}Full-widthComma\nIdeographicComma\n").to_stdout
     end
 
     it "removes full-width and ideographic commas and appends \" - AO3-6626\" when the name is not unique" do
@@ -433,7 +434,7 @@ describe "rake After:remove_invalid_commas_from_tags" do
         .and change { japanese_tag.reload.name }
         .from("Ideographic、Comma")
         .to("IdeographicComma - AO3-6626")
-        .and output("Tags can only be renamed by an admin. Enter your admin login:\nFull-widthComma - AO3-6626\nIdeographicComma - AO3-6626\n").to_stdout
+        .and output("#{prompt}Full-widthComma - AO3-6626\nIdeographicComma - AO3-6626\n").to_stdout
     end
 
     it "puts an error when the tag cannot be renamed" do
@@ -443,7 +444,7 @@ describe "rake After:remove_invalid_commas_from_tags" do
         subject.invoke
       end.to avoid_changing { chinese_tag.reload.name }
         .and avoid_changing { japanese_tag.reload.name }
-        .and output("Tags can only be renamed by an admin. Enter your admin login:\nCould not rename Full-width，Comma\nCould not rename Ideographic、Comma\n").to_stdout
+        .and output("#{prompt}Could not rename Full-width，Comma\nCould not rename Ideographic、Comma\n").to_stdout
     end
   end
 end

--- a/spec/lib/tasks/after_tasks.rake_spec.rb
+++ b/spec/lib/tasks/after_tasks.rake_spec.rb
@@ -413,9 +413,11 @@ describe "rake After:remove_invalid_commas_from_tags" do
       expect do
         subject.invoke
       end.to change { chinese_tag.reload.name }
-          .from("Full-width，Comma")
-          .to("Full-widthComma")
-        .and change { japanese_tag.reload.name }.from("Ideographic、Comma").to("IdeographicComma")
+        .from("Full-width，Comma")
+        .to("Full-widthComma")
+        .and change { japanese_tag.reload.name }
+        .from("Ideographic、Comma")
+        .to("IdeographicComma")
         .and output("Tags can only be renamed by an admin. Enter your admin login:\nFull-widthComma\nIdeographicComma\n").to_stdout
     end
 
@@ -426,9 +428,11 @@ describe "rake After:remove_invalid_commas_from_tags" do
       expect do
         subject.invoke
       end.to change { chinese_tag.reload.name }
-          .from("Full-width，Comma")
-          .to("Full-widthComma - AO3-6626")
-        .and change { japanese_tag.reload.name }.from("Ideographic、Comma").to("IdeographicComma - AO3-6626")
+        .from("Full-width，Comma")
+        .to("Full-widthComma - AO3-6626")
+        .and change { japanese_tag.reload.name }
+        .from("Ideographic、Comma")
+        .to("IdeographicComma - AO3-6626")
         .and output("Tags can only be renamed by an admin. Enter your admin login:\nFull-widthComma - AO3-6626\nIdeographicComma - AO3-6626\n").to_stdout
     end
 


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6626

## Purpose

Spoke to wrangling chairs and what we’re going to do is

- remove the commas
- if the tag can’t be saved because the comma-less version already exists, remove the comma and append “ - AO3-6626” to the end of the tag name so it can be found and dealt with by a wrangling admin

I’ve written a task that will do that:

`bundle exec rake After:remove_invalid_commas_from_tags`

Because tags can only be renamed by admins, the task will prompt you for your admin login. This is the whole thing, e.g., `admin-sarken`. 

If the login you enter cannot be found, it will tell you and the task won’t run.

If the login is found, the task will run and give you the new tag names.

## Testing Instructions

Run the task, first trying an invalid admin login, and then trying a valid one.