### PR TITLE
AO3-6609 Fix status check of old invites without sent_at

### DIFF
--- a/app/models/invitation.rb
+++ b/app/models/invitation.rb
@@ -75,7 +75,8 @@ class Invitation < ApplicationRecord
   end
 
   def can_resend?
-    checked_date = self.resent_at || self.sent_at
+    # created_at fallback is a vestige of the already fixed AO3-6094.
+    checked_date = self.resent_at || self.sent_at || self.created_at
     checked_date < ArchiveConfig.HOURS_BEFORE_RESEND_INVITATION.hours.ago
   end
 

--- a/app/models/invitation.rb
+++ b/app/models/invitation.rb
@@ -71,7 +71,7 @@ class Invitation < ApplicationRecord
     if resend
       attrs = { resent_at: Time.current }
       # This applies to old invites when AO3-6094 wasn't fixed.
-      attrs[:sent_at] = self.updated_at if self.sent_at.nil?
+      attrs[:sent_at] = self.created_at if self.sent_at.nil?
       self.update_columns(attrs)
     else
       self.update_column(:sent_at, Time.current)
@@ -81,8 +81,8 @@ class Invitation < ApplicationRecord
   end
 
   def can_resend?
-    # updated_at fallback is a vestige of the already fixed AO3-6094.
-    checked_date = self.resent_at || self.sent_at || self.updated_at
+    # created_at fallback is a vestige of the already fixed AO3-6094.
+    checked_date = self.resent_at || self.sent_at || self.created_at
     checked_date < ArchiveConfig.HOURS_BEFORE_RESEND_INVITATION.hours.ago
   end
 

--- a/app/models/invitation.rb
+++ b/app/models/invitation.rb
@@ -69,9 +69,10 @@ class Invitation < ApplicationRecord
 
     # Skip callbacks within after_save by using update_column to avoid a callback loop
     if resend
-      self.update_column(:resent_at, Time.current)
+      attrs = { resent_at: Time.current }
       # This applies to old invites when AO3-6094 wasn't fixed.
-      self.update_column(:sent_at, self.updated_at) if self.sent_at.nil?
+      attrs[:sent_at] = self.updated_at if self.sent_at.nil?
+      self.update_columns(attrs)
     else
       self.update_column(:sent_at, Time.current)
     end

--- a/app/views/invite_requests/_invitation.html.erb
+++ b/app/views/invite_requests/_invitation.html.erb
@@ -7,9 +7,9 @@
 <!--main content-->
 <% status = invitation.resent_at ? "resent" : "not_resent" %>
 <p>
-  <%# created_at fallback is a vestige of the already fixed AO3-6094. %>
+  <%# updated_at fallback is a vestige of the already fixed AO3-6094. %>
   <%= t(".info.#{status}",
-        sent_at: l((invitation.sent_at || invitation.created_at).to_date),
+        sent_at: l((invitation.sent_at || invitation.updated_at).to_date),
         resent_at: invitation.resent_at ? l(invitation.resent_at.to_date) : nil) %>
   <% if invitation.can_resend? %>
   <%# i18n-tasks-use t("invite_requests.invitation.after_cooldown_period.not_resent")

--- a/app/views/invite_requests/_invitation.html.erb
+++ b/app/views/invite_requests/_invitation.html.erb
@@ -7,8 +7,9 @@
 <!--main content-->
 <% status = invitation.resent_at ? "resent" : "not_resent" %>
 <p>
+  <%# created_at fallback is a vestige of the already fixed AO3-6094. %>
   <%= t(".info.#{status}",
-        sent_at: l(invitation.sent_at.to_date),
+        sent_at: l((invitation.sent_at || invitation.created_at).to_date),
         resent_at: invitation.resent_at ? l(invitation.resent_at.to_date) : nil) %>
   <% if invitation.can_resend? %>
   <%# i18n-tasks-use t("invite_requests.invitation.after_cooldown_period.not_resent")

--- a/app/views/invite_requests/_invitation.html.erb
+++ b/app/views/invite_requests/_invitation.html.erb
@@ -8,7 +8,7 @@
 <p>
   <% status = invitation.resent_at ? "resent" : "not_resent" %>
   <%= t(".info.#{status}",
-        sent_at: l((invitation.sent_at || invitation.updated_at).to_date),
+        sent_at: l((invitation.sent_at || invitation.created_at).to_date),
         resent_at: invitation.resent_at ? l(invitation.resent_at.to_date) : nil) %>
 </p>
 

--- a/spec/models/invitation_spec.rb
+++ b/spec/models/invitation_spec.rb
@@ -78,7 +78,7 @@ describe Invitation, :ready do
 
   describe "can_resend?" do
     # Support old invites when AO3-6094 wasn't fixed.
-    context "old invites without sent_at" do
+    context "without sent_at" do
       let (:broken_invite) { create(:invitation) }
 
       before do
@@ -98,7 +98,7 @@ describe Invitation, :ready do
       end
     end
 
-    context "normal invites" do
+    context "with sent_at" do
       let! (:invite) { create(:invitation) }
 
       it "cannot be resent before set period" do

--- a/spec/models/invitation_spec.rb
+++ b/spec/models/invitation_spec.rb
@@ -79,7 +79,7 @@ describe Invitation, :ready do
   describe "can_resend?" do
     # Support old invites when AO3-6094 wasn't fixed.
     context "without sent_at" do
-      let (:broken_invite) { create(:invitation) }
+      let(:broken_invite) { create(:invitation) }
 
       before do
         broken_invite.sent_at = nil
@@ -99,7 +99,7 @@ describe Invitation, :ready do
     end
 
     context "with sent_at" do
-      let! (:invite) { create(:invitation) }
+      let!(:invite) { create(:invitation) }
 
       it "cannot be resent before set period" do
         travel(5.minutes)

--- a/spec/models/invitation_spec.rb
+++ b/spec/models/invitation_spec.rb
@@ -76,7 +76,7 @@ describe Invitation, :ready do
     end
   end
 
-  describe "can_resend?" do
+  describe "#can_resend?" do
     # Support old invites when AO3-6094 wasn't fixed.
     context "without sent_at" do
       let(:broken_invite) { create(:invitation) }


### PR DESCRIPTION
Third PR to fix issues raised in QA. PR may need further tweaks. Currently does set sent_at and relies on updated_at as fallback. 

## Issue

https://otwarchive.atlassian.net/browse/AO3-6609

## Purpose

Support resending and displaying status info of old invites without sent_at 

## Testing Instructions

Try to check and resend an old invite

## References

https://github.com/otwcode/otwarchive/pull/4685

## Credit

weeklies (she/her)
