### PR TITLE
AO3-6653 Update labeler configuration syntax

### DIFF
--- a/.github/labeler/awaiting.yml
+++ b/.github/labeler/awaiting.yml
@@ -1,4 +1,3 @@
 "Awaiting Review":
-  - "**/*"
-  - ".*"
-  - ".*/**/*"
+- changed-files:
+  - any-glob-to-any-file: ["**/*", ".*", ".*/**/*"]

--- a/.github/labeler/awaiting.yml
+++ b/.github/labeler/awaiting.yml
@@ -1,3 +1,3 @@
 "Awaiting Review":
 - changed-files:
-  - any-glob-to-any-file: ["**/*", ".*", ".*/**/*"]
+  - any-glob-to-any-file: "**/*"

--- a/.github/labeler/contents.yml
+++ b/.github/labeler/contents.yml
@@ -1,14 +1,15 @@
 "Gem Updates":
-  - "Gemfile"
-  - "Gemfile.lock"
+- changed-files:
+  - any-glob-to-any-file: ["Gemfile", "Gemfile.lock"]
 
 "Has Migrations":
-  - "db/migrate/**/*"
+- changed-files:
+  - any-glob-to-any-file: "db/migrate/**/*"
 
 "Scope: i18n Only":
-  - all:
-    - "config/locales/**/*"
+-changed-files:
+  - any-glob-to-all-files: "config/locales/**/*"
 
 "Scope: Tests Only":
-  - all:
-    - "{factories,features,spec,test,.github}/**/*"
+- changed-files:
+  - any-glob-to-all-files: "{factories,features,spec,test,.github}/**/*"

--- a/.github/labeler/review.yml
+++ b/.github/labeler/review.yml
@@ -1,8 +1,7 @@
 # Label to be added when the PR is updated:
 "Coder Has Actioned Review":
-  - "**/*"
-  - ".*"
-  - ".*/**/*"
+- changed-files:
+  - any-glob-to-any-file: ["**/*", ".*", ".*/**/*"]
 
 # Label to be removed when the PR is updated:
 "Reviewed: Action Needed": []

--- a/.github/labeler/review.yml
+++ b/.github/labeler/review.yml
@@ -1,7 +1,7 @@
 # Label to be added when the PR is updated:
 "Coder Has Actioned Review":
 - changed-files:
-  - any-glob-to-any-file: ["**/*", ".*", ".*/**/*"]
+  - any-glob-to-any-file: "**/*"
 
 # Label to be removed when the PR is updated:
 "Reviewed: Action Needed": []


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6653

## Purpose

Hi, I'm the dumbass who saw the PR was passing and thought it meant we weren't using the config file they mentioned. (In my defense, we weren't. We had multiple ones with different names instead. 😆) Ergo, I am the dumbass who is hopefully fixing our config.

- I am not sure how it's going to feel about the rule for "Reviewed: Action Needed" -- it might still want `changed_files` in there.
- It checks paths starting with dot (e.g., `.github/`) by default now, so I took those out in a separate, easily reversible commit.

## Testing Instructions

Merge and make sure the action works.

(Note: It'll fail on this because it's using the config from master, not the PR, which is where I went wrong with my life.)

## References

[actions/labeler docs](https://github.com/actions/labeler/tree/main#breaking-changes-in-v5)