### PR TITLE
AO3-6314 Use Departure for external works migration

### DIFF
--- a/db/migrate/20230430160300_remove_dead_column.rb
+++ b/db/migrate/20230430160300_remove_dead_column.rb
@@ -1,4 +1,6 @@
 class RemoveDeadColumn < ActiveRecord::Migration[6.0]
+  uses_departure! if Rails.env.staging? || Rails.env.production?
+
   def change
     remove_column :external_works, :dead, :boolean
   end


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6314

## Purpose

Use Departure / `pt-online-schema-change` for an external works migration. This table had ~450k rows when we ran the migration on 2023-01-06, so @zz9pzza hot fixed the migration to be on the safe side. We're adding the change to the repo as well.

## Testing Instructions

N/A, this was already ran in production.