### PR TITLE
AO3-6570 Import Work error message overflows for long URLs

### DIFF
--- a/public/stylesheets/site/2.0/22-system-messages.css
+++ b/public/stylesheets/site/2.0/22-system-messages.css
@@ -37,6 +37,7 @@ div.error {
   clear: right;
     box-shadow: inset 1px 1px 2px;
     border-radius: 0.25em;
+  word-wrap: break-word;
 }
 
 .caution {
@@ -49,7 +50,6 @@ div.error {
   background: #efd1d1;
   border-color: #900;
     box-shadow: 1px 1px 2px;
-    word-wrap: break-word;
 }
 
 .notes {

--- a/public/stylesheets/site/2.0/22-system-messages.css
+++ b/public/stylesheets/site/2.0/22-system-messages.css
@@ -49,6 +49,7 @@ div.error {
   background: #efd1d1;
   border-color: #900;
     box-shadow: 1px 1px 2px;
+    word-wrap: break-word;
 }
 
 .notes {

--- a/public/stylesheets/site/2.0/22-system-messages.css
+++ b/public/stylesheets/site/2.0/22-system-messages.css
@@ -37,7 +37,7 @@ div.error {
   clear: right;
     box-shadow: inset 1px 1px 2px;
     border-radius: 0.25em;
-  word-wrap: break-word;
+    word-wrap: break-word;
 }
 
 .caution {


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6570

## Purpose

Set word-wrap to break-word on the error element so that the text wraps properly and does not overflow.

## Testing Instructions

How can the Archive's QA team verify that this is working as you intended?

Log in. 
Head to Import Work and enter a long external URL
Import it more than once and make sure the element doesn't spill out of the box - make your browser window small. 

If you have a Jira account with access, please update or comment on the issue
with any new or missing testing instructions instead.

## References

Are there other relevant issues/pull requests/mailing list discussions?

## Credit

What name and pronouns should we use to credit you in the [Archive of Our Own's Release Notes](https://archiveofourown.org/admin_posts?tag=1)?

Claire C
<img width="495" alt="Screen Shot 2024-01-12 at 8 30 38 PM" src="https://github.com/otwcode/otwarchive/assets/96350691/5e4d2647-3736-44bd-8ed8-22cd9b8c43ae">


If you have a Jira account, please include the same name in the "Full name"
field on your Jira profile, so we can assign you the issues you're working on.

*Please note that if you do not fill in this section, we will use your GitHub account name and
they/them pronouns.*
