### PR TITLE
AO3-6637 Upgrade prefetch to prerender

### DIFF
--- a/app/views/chapters/show.html.erb
+++ b/app/views/chapters/show.html.erb
@@ -55,7 +55,7 @@
   <% if @next_chapter %>
     <script type="speculationrules">
       {
-        "prefetch": [
+        "prerender": [
           {
             "source": "list",
             "urls": ["<%= work_chapter_path(@work, @next_chapter, anchor: "workskin") %>"]

--- a/app/views/hit_count/_include.html.erb
+++ b/app/views/hit_count/_include.html.erb
@@ -2,7 +2,17 @@
   <% content_for :footer_js do %>
     <script>
       $j(document).on("loadedCSRF", function() {
-        $j.post("<%= work_hit_count_path(@work, format: :json) %>")
+        function send() {
+          $j.post("<%= work_hit_count_path(@work, format: :json) %>")
+        }
+
+        // If a browser doesn't support prerendering, then document.prerendering
+        // will be undefined, and we'll just send the hit count immediately.
+        if (document.prerendering) {
+          document.addEventListener("prerenderingchange", send);
+        } else {
+          send();
+        }
       })
     </script>
   <% end %>


### PR DESCRIPTION
This includes delaying the hit count logging while prerendering.

# Pull Request Checklist

* [x] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [ ] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)? I don't think any tests are necessary here; let me know if you think overwise!
* [x] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [x] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-6637

## Purpose

Per the discussion in https://otwarchive.atlassian.net/browse/AO3-6635, we've successfully completed a round of testing with prefetching the next chapter in idle time. This upgrades us to prerender them!

## Testing Instructions

How can the Archive's QA team verify that this is working as you intended?

See instructions in https://otwarchive.atlassian.net/browse/AO3-6637.

## References

(none besides the above)

## Credit

Domenic Denicola, he/him