### PR TITLE
AO3-6637 Avoid recording prerendered chapter in history

### DIFF
--- a/app/controllers/chapters_controller.rb
+++ b/app/controllers/chapters_controller.rb
@@ -69,7 +69,7 @@ class ChaptersController < ApplicationController
                         current_user.subscriptions.build(subscribable: @work)
       end
       # update the history.
-      Reading.update_or_create(@work, current_user) if current_user
+      Reading.update_or_create(@work, current_user) if current_user && !speculative_loading?
 
       respond_to do |format|
         format.html
@@ -285,5 +285,12 @@ class ChaptersController < ApplicationController
                                     :notes, :endnotes, :content, :published_at,
                                     author_attributes: [:byline, ids: [], coauthors: []])
 
+  end
+
+  def speculative_loading?
+    sec_purpose = request.headers["HTTP_SPEC_PURPOSE"]
+    return false unless sec_purpose
+
+    sec_purpose.include?("prefetch") || sec_purpose.include?("prerender")
   end
 end

--- a/app/controllers/chapters_controller.rb
+++ b/app/controllers/chapters_controller.rb
@@ -288,7 +288,7 @@ class ChaptersController < ApplicationController
   end
 
   def speculative_loading?
-    sec_purpose = request.headers["HTTP_SPEC_PURPOSE"]
+    sec_purpose = request.headers["HTTP_SEC_PURPOSE"]
     return false unless sec_purpose
 
     sec_purpose.include?("prefetch") || sec_purpose.include?("prerender")

--- a/spec/controllers/chapters_controller_spec.rb
+++ b/spec/controllers/chapters_controller_spec.rb
@@ -114,6 +114,22 @@ describe ChaptersController do
         get :show, params: { work_id: work.id, id: chapter.id }
         it_redirects_to_with_error(new_user_session_path, "Sorry, you don't have permission to access the page you were trying to reach. Please log in.")
       end
+
+      context "when viewing as a logged-in user" do
+        before do
+          fake_login
+        end
+
+        context "when speculative loading is enabled" do
+          it "does not record history" do
+            create(:chapter, work: work)
+            chapter1 = work.chapters.first
+            @request.headers["Spec-Purpose"] = "prerender"
+            get :show, params: { work_id: work.id, id: chapter1.id }
+            expect(Reading).not_to receive(:update_or_create)
+          end
+        end
+      end
     end
 
     context "when work is adult" do

--- a/spec/controllers/chapters_controller_spec.rb
+++ b/spec/controllers/chapters_controller_spec.rb
@@ -124,7 +124,7 @@ describe ChaptersController do
           it "does not record history" do
             create(:chapter, work: work)
             chapter1 = work.chapters.first
-            @request.headers["Spec-Purpose"] = "prerender"
+            @request.headers["Sec-Purpose"] = "prerender"
             get :show, params: { work_id: work.id, id: chapter1.id }
             expect(Reading).not_to receive(:update_or_create)
           end


### PR DESCRIPTION
Ideally the test would be in Cucumber, but Selenium with Chrome doesn't seem to do speculative loading (either yet or as how it's currently configured).

## Issue

https://otwarchive.atlassian.net/browse/AO3-6637

## Purpose

Avoid recording a reading history for when a browser opens a multi-chapter work in Chrome. Otherwise, with prefetch/prerender, we record 2 entries (1 for the actual view, 1 for the speculative loading).

## References

Follow up to #4724 based on discussion elsewhere

## Credit

Brian Austin (they/he)
Domenic Denicola (he/him)