### PR TITLE
AO3-6676 Remove participant memoisation

### DIFF
--- a/app/views/collections/_collection_blurb.html.erb
+++ b/app/views/collections/_collection_blurb.html.erb
@@ -72,8 +72,8 @@
       <% end %>
       <% if !collection.user_is_owner?(current_user) && collection.moderated? && !(collection.challenge && collection.challenge.signup_open) %>
         <li>
-          <% if (@participant ||= collection.get_participants_for_user(current_user).first) %>
-            <%= link_to ts("Leave"), collection_participant_path(collection, @participant),
+          <% if (participant = collection.get_participants_for_user(current_user).first) %>
+            <%= link_to ts("Leave"), collection_participant_path(collection, participant),
               data: {confirm: ts('Are you certain you want to leave this collection?')},
               :method => :delete %></li>
           <% else %>


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [ ] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [x] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [x] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-6676

## Purpose

What does this PR do?

Removes the excessive persistence of the `@participant` from one collection blurb to all the following ones, so that it doesn't appear as if the current user has joined all the collections below the one that they're actually in.

## Testing Instructions

How can the Archive's QA team verify that this is working as you intended?

See Jira.

## References

Are there other relevant issues/pull requests/mailing list discussions?

## Credit

What name and pronouns should we use to credit you in the [Archive of Our Own's Release Notes](https://archiveofourown.org/admin_posts?tag=1)?

alien, they/them
