### PR TITLE
AO3-6681 Fix flaky orphaning account test

### DIFF
--- a/features/other_a/orphan_account.feature
+++ b/features/other_a/orphan_account.feature
@@ -23,7 +23,9 @@ Scenario: Orphan all works belonging to a user
   Then I should see "Orphan All Works"
     And I should see "Are you really sure you want to"
   When I choose "Take my pseud off as well"
-	And I press "Yes, I'm sure"
+    # Delay before orphaning to make sure the cache is expired
+    And it is currently 1 second from now
+    And I press "Yes, I'm sure"
   Then I should see "Orphaning was successful."
   When I view the work "Shenanigans"
   Then I should see "orphan_account"
@@ -54,7 +56,9 @@ Given I have an orphan account
   Then I should see "Orphan All Works"
     And I should see "Are you really sure you want to"
   When I choose "Leave a copy of my pseud on"
-	And I press "Yes, I'm sure"
+    # Delay before orphaning to make sure the cache is expired
+    And it is currently 1 second from now
+    And I press "Yes, I'm sure"
   Then I should see "Orphaning was successful."
   When I view the work "Shenanigans"
   Then I should see "orphaneer (orphan_account)"


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6681

Intermittent failures in cucumber features/other_a/orphan_account.feature: https://github.com/otwcode/otwarchive/actions/runs/7863503924/job/21454202626 https://github.com/otwcode/otwarchive/actions/runs/7434126817/job/20227944782

[features/other_a/orphan_account.feature:38](https://github.com/otwcode/otwarchive/blob/c6379417caea816c4abc272a650b985676435bbb/features/other_a/orphan_account.feature#L38) # Scenario: Orphan all works belonging to a user, add a copy of the pseud to the orphan_account
```
expected to find text "orphaneer (orphan_account)" in "Main Content While we've done our best to make the core functionality of this site accessible without javascript, it will work better with it enabled. Please consider turning it on! Example Archive beta User Navigation Hi, orphaneer! My Dashboard My History My Preferences Post New Work Import Work Log Out Site Navigation Fandoms All Fandoms Uncategorized Fandoms Browse Works Bookmarks Tags Collections Search Works Bookmarks Tags People About About Us News FAQ Wrangling Guidelines Donate or Volunteer Search Works Work Search: tip: katekyou \"alternate universe\" sort:>words Skip header Actions Bookmark Cancel Bookmark Mark for Later Comments Share Download AZW3 EPUB MOBI PDF HTML Work Header Rating: Not Rated Archive Warning: No Archive Warnings Apply Category: Other Fandom: Stargate SG-1 Additional Tags: Scary tag Language: English Stats: Published:2024-01-06Words:6Chapters:1/1Hits:0 Shenanigans - the early years orphaneer Work Text: That could be an amusing crossover. Actions ↑ Top Bookmark Kudos Comments Post Comment Comment as orphaneer (Plain text with limited HTML ?) Comment 10000 characters left Bookmark Bookmark × orphaneer, save a bookmark! Write Comments Notes The creator's summary is added automatically. Plain text with limited HTML ? 5000 characters left Your tags The creator's tags are added automatically. Comma separated, 100 characters per tag Add to collections Choose Type and Post Private bookmark Rec Footer About the Archive Site Map Diversity Statement Terms of Service DMCA Policy Contact Us Policy Questions & Abuse Reports Technical Support & Feedback Development Known Issues GPL by the OTW". (However, it was found 1 time including non-visible text.) (RSpec::Expectations::ExpectationNotMetError)
./features/step_definitions/web_steps.rb:123:in `block (2 levels) in <top (required)>'
./features/step_definitions/web_steps.rb:6:in `with_scope'
./features/step_definitions/web_steps.rb:122:in `/^(?:|I )should see "([^"]*)"(?: within "([^"]*)")?$/'
features/other_a/orphan_account.feature:66:in `Then I should see "orphaneer (orphan_account)"'
```

## Purpose

Fix flaky orphaning account tests by waiting for one second before orphaning so the cache is expired.

## Testing Instructions

No manual QA required. Before the fix, [50 test runs](https://github.com/Bilka2/otwarchive/actions/runs/7899879168) resulted in 1 failure. After the fixes [60 test runs](https://github.com/Bilka2/otwarchive/actions/runs/7900315212) result in no failures.

## Credit

Bilka (he/him)
