### PR TITLE
AO3-5803 Make errors for challenge limits display inline

### DIFF
--- a/app/helpers/prompt_restrictions_helper.rb
+++ b/app/helpers/prompt_restrictions_helper.rb
@@ -58,7 +58,7 @@ module PromptRestrictionsHelper
         h(ts("Must Be Unique?")) + form.check_box("require_unique_#{tag_type}".to_sym, disabled: (hasprompts ? false : true))
       end
     end
-    content_tag(:dd, fields.html_safe, title: ts("#{tag_type_label_name(tag_type).pluralize.downcase}")) + "\n".html_safe
+    content_tag(:dd, fields.html_safe, class: "inline-error", title: ts("#{tag_type_label_name(tag_type).pluralize.downcase}")) + "\n".html_safe
   end
 
   # generate the string to use for the labels on sign-up forms

--- a/app/helpers/prompt_restrictions_helper.rb
+++ b/app/helpers/prompt_restrictions_helper.rb
@@ -58,7 +58,7 @@ module PromptRestrictionsHelper
         h(ts("Must Be Unique?")) + form.check_box("require_unique_#{tag_type}".to_sym, disabled: (hasprompts ? false : true))
       end
     end
-    content_tag(:dd, fields.html_safe, class: "inline-error", title: ts("#{tag_type_label_name(tag_type).pluralize.downcase}")) + "\n".html_safe
+    content_tag(:dd, fields.html_safe, class: "inline-error", title: ts(tag_type_label_name(tag_type).pluralize.downcase.to_s)) + "\n".html_safe
   end
 
   # generate the string to use for the labels on sign-up forms

--- a/app/helpers/prompt_restrictions_helper.rb
+++ b/app/helpers/prompt_restrictions_helper.rb
@@ -58,7 +58,7 @@ module PromptRestrictionsHelper
         h(ts("Must Be Unique?")) + form.check_box("require_unique_#{tag_type}".to_sym, disabled: (hasprompts ? false : true))
       end
     end
-    content_tag(:dd, fields.html_safe, class: "inline-error", title: ts(tag_type_label_name(tag_type).pluralize.downcase.to_s)) + "\n".html_safe
+    content_tag(:dd, fields.html_safe, class: "complex", title: ts(tag_type_label_name(tag_type).pluralize.downcase.to_s)) + "\n".html_safe
   end
 
   # generate the string to use for the labels on sign-up forms

--- a/public/stylesheets/site/2.0/22-system-messages.css
+++ b/public/stylesheets/site/2.0/22-system-messages.css
@@ -79,6 +79,10 @@ span.error {
   display: block;
 }
 
+.inline-error > span.error {
+  display: inline-block;
+}
+
 /* contexts */
 
 .actions + .footnote {

--- a/public/stylesheets/site/2.0/22-system-messages.css
+++ b/public/stylesheets/site/2.0/22-system-messages.css
@@ -75,11 +75,11 @@ ul.notes li, .error ul li, .notice ul li, .caution ul li, .alert.flash ul li {
   padding-left: 1.5em;
 }
 
-span.error {
+dt span.error, dd span.error {
   display: block;
 }
 
-.inline-error > span.error {
+dd.complex span.error {
   display: inline-block;
 }
 


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5803

## Purpose

When errors are displayed for fields like required requests per sign-up, the fields should be highlighted in red but not break the flow of the form. This fixes the issue where error highlighting takes up the whole line (refer to https://otwarchive.atlassian.net/browse/AO3-5803?focusedCommentId=360957).

New look:
![Challenge "Requests and Offers" section with number of requests and offers highlighted in red. The number required fields are also highlighted, but do not cause the allowed boxes to go to the next line.](https://github.com/otwcode/otwarchive/assets/13002992/86ba4906-9363-4df0-96b7-5520fec77375)

**NOTE:** This will require recaching skins to show up properly.

## Credit

Brian Austin (they/he)