### PR TITLE
AO3-3463 Fix comment cache keys to depend on record updated_at again

### DIFF
--- a/app/views/comments/_single_comment.html.erb
+++ b/app/views/comments/_single_comment.html.erb
@@ -16,7 +16,7 @@
     <% else %>
       <%# FRONT END, update this if a.user comes in %>
       <h4 class="heading byline">
-        <% cache("#{[single_comment, single_comment.comment_owner]}_heading", expires_in: 1.week) do %>
+        <% cache(["heading", single_comment, single_comment.comment_owner], expires_in: 1.week) do %>
           <% if single_comment.by_anonymous_creator? %>
             <%= ts("Anonymous Creator") %>
           <% else %>
@@ -37,7 +37,7 @@
           <%= time_in_zone(single_comment.created_at) %>
         </span>
       </h4>
-      <% cache("#{[single_comment, single_comment.comment_owner]}_body", expires_in: 1.week) do %>
+      <% cache(["body", single_comment, single_comment.comment_owner], expires_in: 1.week) do %>
         <div class="icon">
           <% if !single_comment.pseud.nil? %>
             <% if single_comment.by_anonymous_creator? %>

--- a/app/views/comments/_single_comment.html.erb
+++ b/app/views/comments/_single_comment.html.erb
@@ -16,7 +16,7 @@
     <% else %>
       <%# FRONT END, update this if a.user comes in %>
       <h4 class="heading byline">
-        <% cache(["heading", single_comment, single_comment.comment_owner], expires_in: 1.week) do %>
+        <% cache([single_comment, single_comment.comment_owner, "heading"], expires_in: 1.week) do %>
           <% if single_comment.by_anonymous_creator? %>
             <%= ts("Anonymous Creator") %>
           <% else %>
@@ -37,7 +37,7 @@
           <%= time_in_zone(single_comment.created_at) %>
         </span>
       </h4>
-      <% cache(["body", single_comment, single_comment.comment_owner], expires_in: 1.week) do %>
+      <% cache([single_comment, single_comment.comment_owner, "body"], expires_in: 1.week) do %>
         <div class="icon">
           <% if !single_comment.pseud.nil? %>
             <% if single_comment.by_anonymous_creator? %>


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-3463

## Purpose

I noticed an issue with the cache keys in the code of the [original PR](https://github.com/otwcode/otwarchive/pull/4610). The records are embedded in the key instead of using the [Rails cache dependency algorithm](https://api.rubyonrails.org/v6.1.7/classes/ActionView/Helpers/CacheHelper.html#method-i-cache) to generate the keys based on the records' updated_at timestamp as before.

On my local dev instance the cache keys look like this (for 1 user comment and 2 guest comments):
Before this PR:
```
memcached-tool 127.0.0.1:11211 dump | grep -a "add ao3-v2-dev:views/comments/"
Dumping memcache contents
add ao3-v2-dev:views/comments/_single_comment:d746d9d5ce8afaa44af98c5537a29737/[#<Comment%20id:%20228,%20pseud_id:%2025,%20comment_content:%20[FILTERED],%20depth:%200,%20threaded_left:%20nil,%20threaded_right:%20nil,%:md5:a23e58a2c0f593c27de78ad6fc4c2759 1 1708945180 151
add ao3-v2-dev:views/comments/_single_comment:d746d9d5ce8afaa44af98c5537a29737/[#<Comment%20id:%20279,%20pseud_id:%20nil,%20comment_content:%20[FILTERED],%20depth:%200,%20threaded_left:%20nil,%20threaded_right:%20nil,:md5:1b9ca25d6f0e7e2f87f5a69f4ac16630 1 1708945180 187
add ao3-v2-dev:views/comments/_single_comment:d746d9d5ce8afaa44af98c5537a29737/[#<Comment%20id:%20290,%20pseud_id:%20nil,%20comment_content:%20[FILTERED],%20depth:%200,%20threaded_left:%20nil,%20threaded_right:%20nil,:md5:48775bd0adf1f836d718418512dd20a9 1 1708945180 315
add ao3-v2-dev:views/comments/_single_comment:d746d9d5ce8afaa44af98c5537a29737/[#<Comment%20id:%20290,%20pseud_id:%20nil,%20comment_content:%20[FILTERED],%20depth:%200,%20threaded_left:%20nil,%20threaded_right:%20nil,:md5:4dd2a8ade876f80b3e5b67137fa52fd9 1 1708945180 196
add ao3-v2-dev:views/comments/_single_comment:d746d9d5ce8afaa44af98c5537a29737/[#<Comment%20id:%20228,%20pseud_id:%2025,%20comment_content:%20[FILTERED],%20depth:%200,%20threaded_left:%20nil,%20threaded_right:%20nil,%:md5:234a1dc6640d5a8f43d8579084ff0edb 1 1708945180 352
add ao3-v2-dev:views/comments/_single_comment:d746d9d5ce8afaa44af98c5537a29737/[#<Comment%20id:%20279,%20pseud_id:%20nil,%20comment_content:%20[FILTERED],%20depth:%200,%20threaded_left:%20nil,%20threaded_right:%20nil,:md5:9a7fd8d1b8ae70a7dd3c42082514bf36 1 1708945180 319
```
After this PR:
```
memcached-tool 127.0.0.1:11211 dump | grep -a "add ao3-v2-dev:views/comments/"
Dumping memcache contents
add ao3-v2-dev:views/comments/_single_comment:14612b2c65cb79fdb6d277d59bd6c7a3/body/comments/279-20231221072216000000/ 1 1708945243 319
add ao3-v2-dev:views/comments/_single_comment:14612b2c65cb79fdb6d277d59bd6c7a3/body/comments/228-20231204193742000000/users/1-20240218141746000000 1 1708945243 352
add ao3-v2-dev:views/comments/_single_comment:14612b2c65cb79fdb6d277d59bd6c7a3/heading/comments/279-20231221072216000000/ 1 1708945243 187
add ao3-v2-dev:views/comments/_single_comment:14612b2c65cb79fdb6d277d59bd6c7a3/heading/comments/228-20231204193742000000/users/1-20240218141746000000 1 1708945243 151
add ao3-v2-dev:views/comments/_single_comment:14612b2c65cb79fdb6d277d59bd6c7a3/body/comments/290-20240104112718000000/ 1 1708945243 315
add ao3-v2-dev:views/comments/_single_comment:14612b2c65cb79fdb6d277d59bd6c7a3/heading/comments/290-20240104112718000000/ 1 1708945243 196
```

As is visible above, the cache keys with the embedded records end up getting shortened with a hash. The string of the records includes the updated_at date (among other properties), so technically I think that means the behavior won't differ from doing it properly. However I think it is much better to create proper cache keys, just in case the reasoning of when the hash should change is not correct. I'm also not sure if the current cache keys are stable.

The formatting of the new `#cache` call is based on https://signalvnoise.com/posts/3113-how-key-based-cache-expiration-works which is linked from the [rails caching guide](https://guides.rubyonrails.org/caching_with_rails.html#references).

## Testing Instructions

As said above, I don't think the behavior is affected (in obvious ways), so no new testing instructions. I'd treat this as a delayed code review :sweat_smile: 

## Credit

Bilka (he/him)
