### PR TITLE
AO3-6667 Avoid counting non-visible works for languages page

### DIFF
--- a/app/controllers/languages_controller.rb
+++ b/app/controllers/languages_controller.rb
@@ -2,7 +2,7 @@ class LanguagesController < ApplicationController
 
   def index
     @languages = Language.default_order
-    @works_counts = Rails.cache.fetch("/v1/languages/work_counts", expires_in: 1.day) do
+    @works_counts = Rails.cache.fetch("/v1/languages/work_counts/#{current_user.present?}", expires_in: 1.day) do
       WorkQuery.new.works_per_language(@languages.count)
     end
   end

--- a/app/models/search/work_query.rb
+++ b/app/models/search/work_query.rb
@@ -308,6 +308,7 @@ class WorkQuery < Query
   def works_per_language(languages_count)
     response = $elasticsearch.search(index: index_name, body: {
                                        size: 0,
+                                       query: filtered_query,
                                        aggregations: {
                                          languages: {
                                            terms: { field: "language_id.keyword", size: languages_count }

--- a/spec/models/search/work_query_spec.rb
+++ b/spec/models/search/work_query_spec.rb
@@ -214,9 +214,9 @@ describe WorkQuery do
                         { term: { posted: "true" } },
                         { term: { hidden_by_admin: "false" } },
                         { term: { restricted: "false" } },
-                        { term: { in_unrevealed_collection: "false" } },
-                      ],
-                    },
+                        { term: { in_unrevealed_collection: "false" } }
+                      ]
+                    }
                   },
                   aggregations: {
                     languages: {
@@ -264,24 +264,24 @@ describe WorkQuery do
           }
         }
         allow($elasticsearch).to receive(:search)
-                                   .with(index: "ao3_test_works", body: {
-                                     size: 0,
-                                     query: {
-                                       bool: {
-                                         filter: [
-                                           { term: { posted: "true" } },
-                                           { term: { hidden_by_admin: "false" } },
-                                           { term: { in_unrevealed_collection: "false" } },
-                                         ],
-                                       },
-                                     },
-                                     aggregations: {
-                                       languages: {
-                                         terms: { field: "language_id.keyword", size: 100 }
-                                       }
-                                     }
-                                   })
-                                   .and_return(es_response)
+          .with(index: "ao3_test_works", body: {
+                  size: 0,
+                  query: {
+                    bool: {
+                      filter: [
+                        { term: { posted: "true" } },
+                        { term: { hidden_by_admin: "false" } },
+                        { term: { in_unrevealed_collection: "false" } }
+                      ]
+                    }
+                  },
+                  aggregations: {
+                    languages: {
+                      terms: { field: "language_id.keyword", size: 100 }
+                    }
+                  }
+                })
+          .and_return(es_response)
 
         result = WorkQuery.new.works_per_language(100)
         expect(result).to eq({ "en" => 863_269, "ru" => 11_476, "zh" => 1622 })

--- a/spec/models/search/work_query_spec.rb
+++ b/spec/models/search/work_query_spec.rb
@@ -178,7 +178,7 @@ describe WorkQuery do
 
   describe "#works_per_language" do
     context "when invoked by a guest" do
-      it "returns the count of works per language code" do
+      it "returns the count of public, revealed, and unhidden works per language code" do
         es_response = {
           "took" => 16,
           "timed_out" => false,
@@ -236,7 +236,7 @@ describe WorkQuery do
         User.current_user = build(:user)
       end
 
-      it "returns the count of works per language code" do
+      it "returns the count of public, restricted, revealed, and unhidden works works per language code" do
         es_response = {
           "took" => 16,
           "timed_out" => false,


### PR DESCRIPTION
# Pull Request Checklist

* [X] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [X] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [X] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [X] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [X] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-6667

## Purpose

Avoid counting
* Admin hidden
* Unrevealed
* Non-posted
* (if browsing as a guest) restricted

works in the languages count page. Previously, the code (that was inefficient and hit the database) didn't include this, but it's weird that searching does, so we might as well fix it while we're here.

## References

This is a follow-up to https://github.com/otwcode/otwarchive/pull/4714.

## Credit

Brian Austin (they/he)
