### PR TITLE
AO3-6679 Remove session cookie migration logic

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -96,17 +96,6 @@ class ApplicationController < ActionController::Base
     end
   end
 
-  # Migrates session cookies from encrypted to signed format
-  before_action :migrate_session_cookie_20231230
-  def migrate_session_cookie_20231230
-    # If the request contains a valid encrypted session cookie, it means the
-    # session hasn't yet been migrated to a signed cookie, so we update the
-    # session with the contents of the encrypted cookie.
-    if cookies.encrypted[:_otwarchive_session].present?
-      session.update(cookies.encrypted[:_otwarchive_session])
-    end
-  end
-
   after_action :ensure_admin_credentials
   def ensure_admin_credentials
     if logged_in_as_admin?


### PR DESCRIPTION
# Pull Request Checklist

* [X] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [X] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [X] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [X] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [X] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-6679

## Purpose

This PR removes the session cookie migration logic introduced as part of https://otwarchive.atlassian.net/browse/AO3-6629. The migration logic was added to ensure users did not get logged out when the session cookie format was changed. More than two weeks (browser TTL of session cookie) have passed since the release, so the migration logic is no longer necessary.

## Testing Instructions

Users should stay signed in and no errors should be observed.

## Credit
Albert Pedersen (he/him)
