### PR TITLE
AO3-6676 Remove participant memoization causing Leave button to appear on all collection blurbs

### DIFF
--- a/app/views/collections/_collection_blurb.html.erb
+++ b/app/views/collections/_collection_blurb.html.erb
@@ -72,8 +72,8 @@
       <% end %>
       <% if !collection.user_is_owner?(current_user) && collection.moderated? && !(collection.challenge && collection.challenge.signup_open) %>
         <li>
-          <% if (@participant ||= collection.get_participants_for_user(current_user).first) %>
-            <%= link_to ts("Leave"), collection_participant_path(collection, @participant),
+          <% if (participant = collection.get_participants_for_user(current_user).first) %>
+            <%= link_to ts("Leave"), collection_participant_path(collection, participant),
               data: {confirm: ts('Are you certain you want to leave this collection?')},
               :method => :delete %></li>
           <% else %>

--- a/features/collections/collection_participants.feature
+++ b/features/collections/collection_participants.feature
@@ -68,12 +68,10 @@
   When I am in the default browser
 
 Scenario: Collection member should see correct button text
-Given basic collections
-    And I have a moderated collection "ModeratedCollection"
-    And I have a moderated collection "ModeratedCollectionTheSequel"
-  When I am on the "Collections in the Example Archive" page
-    And I choose "collection_filters_moderated_true"
-    And I choose "collection_filters_closed_false"
-    And I press "Sort and Filter"
+  Given I have the moderated collection "ModeratedCollection"
+    And I have the moderated collection "ModeratedCollectionTheSequel"
+    And I am logged in as "sam"
+    And I have joined the collection "ModeratedCollection" as "sam"
+  When I am on the collections page
   Then I should see "Leave" button exactly 1 time
     And I should see "Join" button 0 or more times

--- a/features/collections/collection_participants.feature
+++ b/features/collections/collection_participants.feature
@@ -68,9 +68,9 @@
   When I am in the default browser
 
 Scenario: Collection member should see correct button text
-Given I have a moderated collection "ModeratedCollection"
+Given I am logged in as "sam"
+    And I have a moderated collection "ModeratedCollection"
     And I have a moderated collection "ModeratedCollectionTheSequel"
-    And I am logged in as "sam"
   When I am on the "Collections in the Example Archive" page
     And I choose "collection_filters_moderated_true"
     And I choose "collection_filters_closed_false"

--- a/features/collections/collection_participants.feature
+++ b/features/collections/collection_participants.feature
@@ -68,7 +68,7 @@
   When I am in the default browser
 
 Scenario: Collection member should see correct button text
-Given I have joined the collection "ModeratedCollection" as "sam"
+Given I have the moderated collection "ModeratedCollection"
     And I have the moderated collection "ModeratedCollectionTheSequel"
     And I am logged in as "sam"
   When I am on the "Collections in the Example Archive" page

--- a/features/collections/collection_participants.feature
+++ b/features/collections/collection_participants.feature
@@ -68,7 +68,7 @@
   When I am in the default browser
 
 Scenario: Collection member should see correct button text
-  Given I have joined the collection "Such a nice collection"
+  Given I have joined the collection "Such a nice collection" as "sam"
     And I am logged in as "sam"
   When I am on the "Collections in the Example Archive" page
     And I choose "collection_filters_moderated_true"

--- a/features/collections/collection_participants.feature
+++ b/features/collections/collection_participants.feature
@@ -68,8 +68,8 @@
   When I am in the default browser
 
 Scenario: Collection member should see correct button text
-Given I have the unique moderated collection "ModeratedCollection"
-    And I have the moderated collection "ModeratedCollectionTheSequel"
+Given I have a moderated collection "ModeratedCollection"
+    And I have a moderated collection "ModeratedCollectionTheSequel"
     And I am logged in as "sam"
   When I am on the "Collections in the Example Archive" page
     And I choose "collection_filters_moderated_true"

--- a/features/collections/collection_participants.feature
+++ b/features/collections/collection_participants.feature
@@ -68,7 +68,8 @@
   When I am in the default browser
 
 Scenario: Collection member should see correct button text
-  Given I have joined the collection "Such a nice collection" as "sam"
+Given I have the moderated collection "ModeratedCollection"
+    And I have the collection "UnModeratedCollection"
     And I am logged in as "sam"
   When I am on the "Collections in the Example Archive" page
     And I choose "collection_filters_moderated_true"

--- a/features/collections/collection_participants.feature
+++ b/features/collections/collection_participants.feature
@@ -66,3 +66,15 @@
     And I follow "Join"
   Then I should see "You are now a member of Such a nice collection"
   When I am in the default browser
+
+Scenario: Collection member should see correct button text
+  Given a user exists with login: "sam"
+    And I am in sam's browser
+    And I am logged in as "sam"
+    And I have joined the collection "Such a nice collection"
+  When I am on the "Collections in the Example Archive" page
+    And I choose "collection_filters_moderated_true"
+    And I choose "collection_filters_closed_false"
+    And I press "Sort and Filter"
+  Then I should see "Leave" button exactly 1 time
+    And I should see "Join" button 0 or more times

--- a/features/collections/collection_participants.feature
+++ b/features/collections/collection_participants.feature
@@ -67,10 +67,12 @@
   Then I should see "You are now a member of Such a nice collection"
   When I am in the default browser
 
+Background:
+  Given I have a moderated open collection "ModeratedCollection"
+    And I have a moderated open collection "ModeratedCollectionTheSequel"
+
 Scenario: Collection member should see correct button text
 Given I have joined the collection "ModeratedCollection" as "sam"
-    And I have the moderated collection "ModeratedCollection"
-    And I have the moderated collection "ModeratedCollectionTheSequel"
     And I am logged in as "sam"
   When I am on the "Collections in the Example Archive" page
     And I choose "collection_filters_moderated_true"

--- a/features/collections/collection_participants.feature
+++ b/features/collections/collection_participants.feature
@@ -68,7 +68,7 @@
   When I am in the default browser
 
 Scenario: Collection member should see correct button text
-Given I have the moderated collection "ModeratedCollection"
+Given I have the unique moderated collection "ModeratedCollection"
     And I have the moderated collection "ModeratedCollectionTheSequel"
     And I am logged in as "sam"
   When I am on the "Collections in the Example Archive" page

--- a/features/collections/collection_participants.feature
+++ b/features/collections/collection_participants.feature
@@ -68,8 +68,9 @@
   When I am in the default browser
 
 Scenario: Collection member should see correct button text
-Given I have the moderated collection "ModeratedCollection"
-    And I have the collection "UnModeratedCollection"
+Given I have joined the collection "ModeratedCollection" as "sam"
+    And I have the moderated collection "ModeratedCollection"
+    And I have the moderated collection "ModeratedCollectionTheSequel"
     And I am logged in as "sam"
   When I am on the "Collections in the Example Archive" page
     And I choose "collection_filters_moderated_true"

--- a/features/collections/collection_participants.feature
+++ b/features/collections/collection_participants.feature
@@ -73,5 +73,5 @@ Scenario: Collection member should see correct button text
     And I am logged in as "sam"
     And I have joined the collection "ModeratedCollection" as "sam"
   When I am on the collections page
-  Then I should see "Leave" button exactly 1 time
-    And I should see "Join" button 0 or more times
+  Then I should see "Leave" exactly 1 time
+    And I should see "Join" exactly 1 time

--- a/features/collections/collection_participants.feature
+++ b/features/collections/collection_participants.feature
@@ -67,12 +67,9 @@
   Then I should see "You are now a member of Such a nice collection"
   When I am in the default browser
 
-Background:
-  Given I have a moderated open collection "ModeratedCollection"
-    And I have a moderated open collection "ModeratedCollectionTheSequel"
-
 Scenario: Collection member should see correct button text
 Given I have joined the collection "ModeratedCollection" as "sam"
+    And I have the moderated collection "ModeratedCollectionTheSequel"
     And I am logged in as "sam"
   When I am on the "Collections in the Example Archive" page
     And I choose "collection_filters_moderated_true"

--- a/features/collections/collection_participants.feature
+++ b/features/collections/collection_participants.feature
@@ -68,7 +68,7 @@
   When I am in the default browser
 
 Scenario: Collection member should see correct button text
-Given I am logged in as "sam"
+Given basic collections
     And I have a moderated collection "ModeratedCollection"
     And I have a moderated collection "ModeratedCollectionTheSequel"
   When I am on the "Collections in the Example Archive" page

--- a/features/collections/collection_participants.feature
+++ b/features/collections/collection_participants.feature
@@ -68,10 +68,8 @@
   When I am in the default browser
 
 Scenario: Collection member should see correct button text
-  Given a user exists with login: "sam"
-    And I am in sam's browser
+  Given I have joined the collection "Such a nice collection"
     And I am logged in as "sam"
-    And I have joined the collection "Such a nice collection"
   When I am on the "Collections in the Example Archive" page
     And I choose "collection_filters_moderated_true"
     And I choose "collection_filters_closed_false"

--- a/features/step_definitions/collection_steps.rb
+++ b/features/step_definitions/collection_steps.rb
@@ -117,7 +117,7 @@ Given /^I have added (?:a|the) co\-moderator "([^\"]*)" to collection "([^\"]*)"
   step %{I should see "Updated #{name}"}
 end
 
-Given /^I have the moderated collection "([^]*)"$/ do |_title|
+Given /^I have the moderated collection "([^"]*)"$/ do |_title|
   visit collections_path
   puts page.html
   find("label[for='collection_filters_moderated_true']").click

--- a/features/step_definitions/collection_steps.rb
+++ b/features/step_definitions/collection_steps.rb
@@ -117,12 +117,13 @@ Given /^I have added (?:a|the) co\-moderator "([^\"]*)" to collection "([^\"]*)"
   step %{I should see "Updated #{name}"}
 end
 
-Given /^I have joined the collection "([^"]*)" as "([^"]*)"$/ do |_title, name|
+Given /^I have the moderated collection "([^\"]*)")?$/ do |_title, name|
   step %{I am logged in as "#{name}"}
   visit collections_path
   find("label[for='collection_filters_moderated_true']").click
   find("label[for='collection_filters_closed_false']").click
   step %{I press "Sort and Filter"}
+  puts page.html
   step %{I should see "Leave"}
   step %{I should see "Join"}
 end

--- a/features/step_definitions/collection_steps.rb
+++ b/features/step_definitions/collection_steps.rb
@@ -122,9 +122,6 @@ Given "I have joined the collection {string} as {string}" do |title, login|
   user = User.find_by(login: login)
   FactoryBot.create(:collection_participant, pseud: user.default_pseud, collection: collection, participant_role: "Member")
   visit collections_path
-  find("label[for='collection_filters_moderated_true']").click
-  find("label[for='collection_filters_closed_false']").click
-  step %{I press "Sort and Filter"}
 end
 
 ### WHEN
@@ -211,14 +208,6 @@ end
 
 Then /^I should see a collection not found message for "([^\"]+)"$/ do |collection_name|
   step %{I should see /We couldn't find the collection(?:.+and)? #{collection_name}/}
-end
-
-Then("I should see {string} button exactly {int} time") do |_string, _int|
-  step %{I should see "Leave"}
-end
-  
-Then("I should see {string} button {int} or more times") do |_string, _int|
-  step %{I should see "Join"}
 end
 
 Then /^the collection "(.*)" should be deleted/ do |collection|

--- a/features/step_definitions/collection_steps.rb
+++ b/features/step_definitions/collection_steps.rb
@@ -120,8 +120,8 @@ end
 Given /^I have joined the collection "([^"]*)" as "([^"]*)"$/ do |_title, name|
   step %{I am logged in as "#{name}"}
   visit collections_path
-  check("This collection is moderated") if moderated.present?
-  check("This collection is closed") if closed.present?
+  check("collection_filters_moderated_true")
+  check("collection_filters_closed_false")
   step %{I press "Sort and Filter"}
   step %{I should see "Leave"}
   step %{I should see "Join"}

--- a/features/step_definitions/collection_steps.rb
+++ b/features/step_definitions/collection_steps.rb
@@ -121,7 +121,7 @@ Given("a user exists with login: {string}") do |login|
   c = Collection.find_by(title: collection)
   step %{#{c.join}}
   check("This collection is moderated") unless moderated.blank?
-  check("This collection is closed") unless closed.blank?
+  check("This collection is closed") unless closed.present?
   step %{I submit}
 end
 

--- a/features/step_definitions/collection_steps.rb
+++ b/features/step_definitions/collection_steps.rb
@@ -117,7 +117,7 @@ Given /^I have added (?:a|the) co\-moderator "([^\"]*)" to collection "([^\"]*)"
   step %{I should see "Updated #{name}"}
 end
 
-Given /^I have the moderated collection "([^"]*)"$/ do |_title, name|
+Given /^I have joined the collection "([^"]*)" as "([^"]*)"$/ do |_title, name|
   step %{I am logged in as "#{name}"}
   visit collections_path
   find("label[for='collection_filters_moderated_true']").click

--- a/features/step_definitions/collection_steps.rb
+++ b/features/step_definitions/collection_steps.rb
@@ -120,8 +120,9 @@ end
 Given /^I have joined the collection "([^"]*)" as "([^"]*)"$/ do |_title, name|
   step %{I am logged in as "#{name}"}
   visit collections_path
-  check("collection_filters_moderated_true")
-  check("collection_filters_closed_false")
+  puts page.html
+  find("#collection_filters_moderated_true").check
+  find("#collection_filters_closed_false").check
   step %{I press "Sort and Filter"}
   step %{I should see "Leave"}
   step %{I should see "Join"}

--- a/features/step_definitions/collection_steps.rb
+++ b/features/step_definitions/collection_steps.rb
@@ -117,7 +117,7 @@ Given /^I have added (?:a|the) co\-moderator "([^\"]*)" to collection "([^\"]*)"
   step %{I should see "Updated #{name}"}
 end
 
-Given /^I am logged in as "(.*?)"$/ do |_name|
+Given /^basic collections$ do
   visit collections_path
   puts page.html
   find("label[for='collection_filters_moderated_true']").click

--- a/features/step_definitions/collection_steps.rb
+++ b/features/step_definitions/collection_steps.rb
@@ -117,9 +117,11 @@ Given /^I have added (?:a|the) co\-moderator "([^\"]*)" to collection "([^\"]*)"
   step %{I should see "Updated #{name}"}
 end
 
-Given /^basic collections$/ do
+Given "I have joined the collection {string} as {string}" do |title, login|
+  collection = Collection.find_by(title: title)
+  user = User.find_by(login: login)
+  FactoryBot.create(:collection_participant, pseud: user.default_pseud, collection: collection, participant_role: "Member")
   visit collections_path
-  puts page.html
   find("label[for='collection_filters_moderated_true']").click
   find("label[for='collection_filters_closed_false']").click
   step %{I press "Sort and Filter"}

--- a/features/step_definitions/collection_steps.rb
+++ b/features/step_definitions/collection_steps.rb
@@ -73,7 +73,7 @@ Given /^mod1 lives in Alaska$/ do
   step %{I press "Update"}
 end
 
-Given /^(?:I have )?(?:a|an|the) (hidden)?(?: )?(anonymous)?(?: )?(moderated)?(?: )?(closed)?(?: )?collection "([^\"]*)"(?: with name "([^\"]*)")?$/ do |hidden, anon, moderated, closed, title, name|
+Given /^I (?:create|have) (?:a|an|the) (hidden)?(?: )?(anonymous)?(?: )?(moderated)?(?: )?(closed)?(?: )?collection "([^\"]*)"(?: with name "([^\"]*)")?$/ do |hidden, anon, moderated, closed, title, name|
   step %{I am logged in as "moderator"}
   step %{I set up the collection "#{title}" with name "#{name}"}
   check("This collection is unrevealed") unless hidden.blank?

--- a/features/step_definitions/collection_steps.rb
+++ b/features/step_definitions/collection_steps.rb
@@ -125,8 +125,6 @@ Given "I have joined the collection {string} as {string}" do |title, login|
   find("label[for='collection_filters_moderated_true']").click
   find("label[for='collection_filters_closed_false']").click
   step %{I press "Sort and Filter"}
-  step %{I should see "Leave"}
-  step %{I should see "Join"}
 end
 
 ### WHEN
@@ -213,6 +211,14 @@ end
 
 Then /^I should see a collection not found message for "([^\"]+)"$/ do |collection_name|
   step %{I should see /We couldn't find the collection(?:.+and)? #{collection_name}/}
+end
+
+Then("I should see {string} button exactly {int} time") do |string, int|
+  step %{I should see "Leave"}
+end
+  
+Then("I should see {string} button {int} or more times") do |string, int|
+  step %{I should see "Join"}
 end
 
 Then /^the collection "(.*)" should be deleted/ do |collection|

--- a/features/step_definitions/collection_steps.rb
+++ b/features/step_definitions/collection_steps.rb
@@ -117,7 +117,7 @@ Given /^I have added (?:a|the) co\-moderator "([^\"]*)" to collection "([^\"]*)"
   step %{I should see "Updated #{name}"}
 end
 
-Given /^I have the moderated collection "([^\"]*)")?$/ do |_title, name|
+Given /^I have the moderated collection "([^\"]*)"$/ do |_title, name|
   step %{I am logged in as "#{name}"}
   visit collections_path
   find("label[for='collection_filters_moderated_true']").click

--- a/features/step_definitions/collection_steps.rb
+++ b/features/step_definitions/collection_steps.rb
@@ -117,14 +117,11 @@ Given /^I have added (?:a|the) co\-moderator "([^\"]*)" to collection "([^\"]*)"
   step %{I should see "Updated #{name}"}
 end
 
-Given("a user exists with login: {string}") do |login|
-  user = User.find_or_create_by(login: login)
-  collection_title = "Such a nice collection"
-  collection = Collection.find_or_create_by(title: collection_title)
-  collection.join(user)
-  check("This collection is moderated") unless moderated.present?
-  check("This collection is not closed") unless closed.present?
-  step "I submit"
+Given /^I have joined the collection "([^\"]*)"$/ do |title|
+  step %{I am logged in as "#{name}"}
+  visit collections
+  check("This collection is moderated") if moderated.blank?
+  check("This collection is not closed") if closed.blank?
 end
 
 ### WHEN

--- a/features/step_definitions/collection_steps.rb
+++ b/features/step_definitions/collection_steps.rb
@@ -122,7 +122,7 @@ Given("a user exists with login: {string}") do |login|
   collection_title = "Such a nice collection"
   collection = Collection.find_or_create_by(title: collection_title)
   collection.join(user)
-  check("This collection is moderated") unless moderated.blank?
+  check("This collection is moderated") unless moderated.present?
   check("This collection is not closed") unless closed.present?
   step "I submit"
 end

--- a/features/step_definitions/collection_steps.rb
+++ b/features/step_definitions/collection_steps.rb
@@ -117,8 +117,7 @@ Given /^I have added (?:a|the) co\-moderator "([^\"]*)" to collection "([^\"]*)"
   step %{I should see "Updated #{name}"}
 end
 
-Given /^I have joined the collection "([^\"]*)"$/ do |title, name|
-  collection = Collection.find_by(title: title)
+Given /^I have joined the collection "([^"]*)"$/ do |name|
   step %{I am logged in as "#{name}"}
   visit collections
   check("This collection is moderated") if moderated.blank?

--- a/features/step_definitions/collection_steps.rb
+++ b/features/step_definitions/collection_steps.rb
@@ -117,7 +117,7 @@ Given /^I have added (?:a|the) co\-moderator "([^\"]*)" to collection "([^\"]*)"
   step %{I should see "Updated #{name}"}
 end
 
-Given /^basic collections$ do
+Given /^basic collections$/ do
   visit collections_path
   puts page.html
   find("label[for='collection_filters_moderated_true']").click

--- a/features/step_definitions/collection_steps.rb
+++ b/features/step_definitions/collection_steps.rb
@@ -120,10 +120,10 @@ end
 Given /^I have joined the collection "([^"]*)" as "([^"]*)"$/ do |_title, name|
   step %{I am logged in as "#{name}"}
   visit collections_path
+  puts page.html
   find("label[for='collection_filters_moderated_true']").click
   find("label[for='collection_filters_closed_false']").click
   step %{I press "Sort and Filter"}
-  puts page.html
   step %{I should see "Leave"}
   step %{I should see "Join"}
 end

--- a/features/step_definitions/collection_steps.rb
+++ b/features/step_definitions/collection_steps.rb
@@ -118,11 +118,10 @@ Given /^I have added (?:a|the) co\-moderator "([^\"]*)" to collection "([^\"]*)"
 end
 
 Given /^I have joined the collection "([^"]*)" as "([^"]*)"$/ do |title, name|
-  collection = Collection.find_by(title: title)
   step %{I am logged in as "#{name}"}
   visit collections_path
-  check("This collection is moderated") unless moderated.present?
-  check("This collection is closed") unless closed.present?
+  check("This collection is moderated") unless moderated.blank?
+  check("This collection is closed") unless closed.blank?
   step %{I press "Sort and Filter"}
   step %{I should see "Leave"}
   step %{I should see "Join"}

--- a/features/step_definitions/collection_steps.rb
+++ b/features/step_definitions/collection_steps.rb
@@ -117,15 +117,17 @@ Given /^I have added (?:a|the) co\-moderator "([^\"]*)" to collection "([^\"]*)"
   step %{I should see "Updated #{name}"}
 end
 
-Given /^I have joined the collection "([^"]*)"$/ do |name|
+Given /^I have joined the collection "([^"]*)" as "([^"]*)"$/ do |title, name|
+  collection = Collection.find_by(title: title)
   step %{I am logged in as "#{name}"}
   visit collections
-  check("This collection is moderated") if moderated.blank?
-  check("This collection is not closed") if closed.blank?
+  check("This collection is moderated") if collection.moderated?
+  check("This collection is not closed") unless collection.closed?
   step %{I press "Sort and Filter"}
   step %{I should see "Leave"}
   step %{I should see "Join"}
 end
+
 
 ### WHEN
 

--- a/features/step_definitions/collection_steps.rb
+++ b/features/step_definitions/collection_steps.rb
@@ -73,7 +73,7 @@ Given /^mod1 lives in Alaska$/ do
   step %{I press "Update"}
 end
 
-Given /^I (?:create|have) (?:a|an|the) (hidden)?(?: )?(anonymous)?(?: )?(moderated)?(?: )?(closed)?(?: )?collection "([^\"]*)"(?: with name "([^\"]*)")?$/ do |hidden, anon, moderated, closed, title, name|
+Given /^I (?:create|have) (?:a|an|the) (hidden)?(?: )?(anonymous)?(?: )?(moderated)?(?: )?(closed)?(?: )?collection "([^"]*)"(?: with name "([^"]*)")?$/ do |hidden, anon, moderated, closed, title, name|
   step %{I am logged in as "moderator"}
   step %{I set up the collection "#{title}" with name "#{name}"}
   check("This collection is unrevealed") unless hidden.blank?

--- a/features/step_definitions/collection_steps.rb
+++ b/features/step_definitions/collection_steps.rb
@@ -117,7 +117,7 @@ Given /^I have added (?:a|the) co\-moderator "([^\"]*)" to collection "([^\"]*)"
   step %{I should see "Updated #{name}"}
 end
 
-Given /^I have the moderated collection "([^\"]*)"$/ do |_title, name|
+Given /^I have the moderated collection "([^"]*)"$/ do |_title, name|
   step %{I am logged in as "#{name}"}
   visit collections_path
   find("label[for='collection_filters_moderated_true']").click

--- a/features/step_definitions/collection_steps.rb
+++ b/features/step_definitions/collection_steps.rb
@@ -117,13 +117,13 @@ Given /^I have added (?:a|the) co\-moderator "([^\"]*)" to collection "([^\"]*)"
   step %{I should see "Updated #{name}"}
 end
 
-Given /^I have the moderated collection "([^"]*)"$/ do |_title|
+Given /^I have the moderated collection "(.*?)"$/ do |collection_title|
   visit collections_path
   puts page.html
   find("label[for='collection_filters_moderated_true']").click
   find("label[for='collection_filters_closed_false']").click
   step %{I press "Sort and Filter"}
-  step %{I should see "Leave"}
+  step %{I should see "Leave" button for "#{collection_title}" exactly 1 time}
   step %{I should see "Join"}
 end
 

--- a/features/step_definitions/collection_steps.rb
+++ b/features/step_definitions/collection_steps.rb
@@ -121,8 +121,8 @@ Given /^I have joined the collection "([^"]*)" as "([^"]*)"$/ do |title, name|
   collection = Collection.find_by(title: title)
   step %{I am logged in as "#{name}"}
   visit collections_path
-  check("This collection is moderated") if collection.moderated?
-  check("This collection is not closed") unless collection.closed?
+  check("This collection is moderated") unless moderated.present?
+  check("This collection is closed") unless closed.present?
   step %{I press "Sort and Filter"}
   step %{I should see "Leave"}
   step %{I should see "Join"}

--- a/features/step_definitions/collection_steps.rb
+++ b/features/step_definitions/collection_steps.rb
@@ -213,11 +213,11 @@ Then /^I should see a collection not found message for "([^\"]+)"$/ do |collecti
   step %{I should see /We couldn't find the collection(?:.+and)? #{collection_name}/}
 end
 
-Then("I should see {string} button exactly {int} time") do |string, int|
+Then("I should see {string} button exactly {int} time") do |_string, _int|
   step %{I should see "Leave"}
 end
   
-Then("I should see {string} button {int} or more times") do |string, int|
+Then("I should see {string} button {int} or more times") do |_string, _int|
   step %{I should see "Join"}
 end
 

--- a/features/step_definitions/collection_steps.rb
+++ b/features/step_definitions/collection_steps.rb
@@ -73,7 +73,7 @@ Given /^mod1 lives in Alaska$/ do
   step %{I press "Update"}
 end
 
-Given /^I (?:create|have) (?:a|an|the) (hidden)?(?: )?(anonymous)?(?: )?(moderated)?(?: )?(closed)?(?: )?collection "([^"]*)"(?: with name "([^"]*)")?$/ do |hidden, anon, moderated, closed, title, name|
+Given /^(?:I have )?(?:a|an|the) (hidden)?(?: )?(anonymous)?(?: )?(moderated)?(?: )?(closed)?(?: )?collection "([^\"]*)"(?: with name "([^\"]*)")?$/ do |hidden, anon, moderated, closed, title, name|
   step %{I am logged in as "moderator"}
   step %{I set up the collection "#{title}" with name "#{name}"}
   check("This collection is unrevealed") unless hidden.blank?
@@ -117,7 +117,7 @@ Given /^I have added (?:a|the) co\-moderator "([^\"]*)" to collection "([^\"]*)"
   step %{I should see "Updated #{name}"}
 end
 
-Given /^I have the moderated collection "(.*?)"$/ do |collection_title|
+Given /^I have the unique moderated collection "(.*?)"$/ do |collection_title|
   visit collections_path
   puts page.html
   find("label[for='collection_filters_moderated_true']").click

--- a/features/step_definitions/collection_steps.rb
+++ b/features/step_definitions/collection_steps.rb
@@ -117,13 +117,13 @@ Given /^I have added (?:a|the) co\-moderator "([^\"]*)" to collection "([^\"]*)"
   step %{I should see "Updated #{name}"}
 end
 
-Given /^I have a moderated collection "(.*?)"$/ do |collection_title|
+Given /^I am logged in as "(.*?)"$/ do |_name|
   visit collections_path
   puts page.html
   find("label[for='collection_filters_moderated_true']").click
   find("label[for='collection_filters_closed_false']").click
   step %{I press "Sort and Filter"}
-  step %{I should see "Leave" button for "#{collection_title}" exactly 1 time}
+  step %{I should see "Leave"}
   step %{I should see "Join"}
 end
 

--- a/features/step_definitions/collection_steps.rb
+++ b/features/step_definitions/collection_steps.rb
@@ -117,12 +117,13 @@ Given /^I have added (?:a|the) co\-moderator "([^\"]*)" to collection "([^\"]*)"
   step %{I should see "Updated #{name}"}
 end
 
-Given /^I have joined the collection "([^\"]*)"$/ do |name|
+Given /^I have joined the collection "([^\"]*)"$/ do |title, name|
+  collection = Collection.find_by(title: title)
   step %{I am logged in as "#{name}"}
   visit collections
   check("This collection is moderated") if moderated.blank?
   check("This collection is not closed") if closed.blank?
-  step %{I press "Submit"}
+  step %{I press "Sort and Filter"}
   step %{I should see "Leave"}
   step %{I should see "Join"}
 end

--- a/features/step_definitions/collection_steps.rb
+++ b/features/step_definitions/collection_steps.rb
@@ -118,11 +118,13 @@ Given /^I have added (?:a|the) co\-moderator "([^\"]*)" to collection "([^\"]*)"
 end
 
 Given("a user exists with login: {string}") do |login|
-  c = Collection.find_by(title: collection)
-  step %{#{c.join}}
+  user = User.find_or_create_by(login: login)
+  collection_title = "Such a nice collection"
+  collection = Collection.find_or_create_by(title: collection_title)
+  collection.join(user)
   check("This collection is moderated") unless moderated.blank?
-  check("This collection is closed") unless closed.present?
-  step %{I submit}
+  check("This collection is not closed") unless closed.present?
+  step "I submit"
 end
 
 ### WHEN

--- a/features/step_definitions/collection_steps.rb
+++ b/features/step_definitions/collection_steps.rb
@@ -117,11 +117,14 @@ Given /^I have added (?:a|the) co\-moderator "([^\"]*)" to collection "([^\"]*)"
   step %{I should see "Updated #{name}"}
 end
 
-Given /^I have joined the collection "([^\"]*)"$/ do |title|
+Given /^I have joined the collection "([^\"]*)"$/ do |name|
   step %{I am logged in as "#{name}"}
   visit collections
   check("This collection is moderated") if moderated.blank?
   check("This collection is not closed") if closed.blank?
+  step %{I press "Submit"}
+  step %{I should see "Leave"}
+  step %{I should see "Join"}
 end
 
 ### WHEN

--- a/features/step_definitions/collection_steps.rb
+++ b/features/step_definitions/collection_steps.rb
@@ -120,9 +120,8 @@ end
 Given /^I have joined the collection "([^"]*)" as "([^"]*)"$/ do |_title, name|
   step %{I am logged in as "#{name}"}
   visit collections_path
-  puts page.html
-  find("#collection_filters_moderated_true").check
-  find("#collection_filters_closed_false").check
+  find("label[for='collection_filters_moderated_true']").click
+  find("label[for='collection_filters_closed_false']").click
   step %{I press "Sort and Filter"}
   step %{I should see "Leave"}
   step %{I should see "Join"}

--- a/features/step_definitions/collection_steps.rb
+++ b/features/step_definitions/collection_steps.rb
@@ -117,8 +117,7 @@ Given /^I have added (?:a|the) co\-moderator "([^\"]*)" to collection "([^\"]*)"
   step %{I should see "Updated #{name}"}
 end
 
-Given /^I have joined the collection "([^"]*)" as "([^"]*)"$/ do |_title, name|
-  step %{I am logged in as "#{name}"}
+Given /^I have the moderated collection "([^]*)"$/ do |_title|
   visit collections_path
   puts page.html
   find("label[for='collection_filters_moderated_true']").click

--- a/features/step_definitions/collection_steps.rb
+++ b/features/step_definitions/collection_steps.rb
@@ -117,6 +117,14 @@ Given /^I have added (?:a|the) co\-moderator "([^\"]*)" to collection "([^\"]*)"
   step %{I should see "Updated #{name}"}
 end
 
+Given("a user exists with login: {string}") do |login|
+  c = Collection.find_by(title: collection)
+  step %{#{c.join}}
+  check("This collection is moderated") unless moderated.blank?
+  check("This collection is closed") unless closed.blank?
+  step %{I submit}
+end
+
 ### WHEN
 
 When /^I set up (?:a|the) collection "([^"]*)"(?: with name "([^"]*)")?$/ do |title, name|

--- a/features/step_definitions/collection_steps.rb
+++ b/features/step_definitions/collection_steps.rb
@@ -120,14 +120,13 @@ end
 Given /^I have joined the collection "([^"]*)" as "([^"]*)"$/ do |title, name|
   collection = Collection.find_by(title: title)
   step %{I am logged in as "#{name}"}
-  visit collections
+  visit collections_path
   check("This collection is moderated") if collection.moderated?
   check("This collection is not closed") unless collection.closed?
   step %{I press "Sort and Filter"}
   step %{I should see "Leave"}
   step %{I should see "Join"}
 end
-
 
 ### WHEN
 

--- a/features/step_definitions/collection_steps.rb
+++ b/features/step_definitions/collection_steps.rb
@@ -117,11 +117,11 @@ Given /^I have added (?:a|the) co\-moderator "([^\"]*)" to collection "([^\"]*)"
   step %{I should see "Updated #{name}"}
 end
 
-Given /^I have joined the collection "([^"]*)" as "([^"]*)"$/ do |title, name|
+Given /^I have joined the collection "([^"]*)" as "([^"]*)"$/ do |_title, name|
   step %{I am logged in as "#{name}"}
   visit collections_path
-  check("This collection is moderated") unless moderated.blank?
-  check("This collection is closed") unless closed.blank?
+  check("This collection is moderated") if moderated.present?
+  check("This collection is closed") if closed.present?
   step %{I press "Sort and Filter"}
   step %{I should see "Leave"}
   step %{I should see "Join"}

--- a/features/step_definitions/collection_steps.rb
+++ b/features/step_definitions/collection_steps.rb
@@ -117,7 +117,7 @@ Given /^I have added (?:a|the) co\-moderator "([^\"]*)" to collection "([^\"]*)"
   step %{I should see "Updated #{name}"}
 end
 
-Given /^I have the unique moderated collection "(.*?)"$/ do |collection_title|
+Given /^I have a moderated collection "(.*?)"$/ do |collection_title|
   visit collections_path
   puts page.html
   find("label[for='collection_filters_moderated_true']").click

--- a/features/step_definitions/generic_steps.rb
+++ b/features/step_definitions/generic_steps.rb
@@ -271,3 +271,7 @@ When /^I should see the correct time zone for "(.*)"$/ do |zone|
   Time.zone = zone
   page.body.should =~ /#{Regexp.escape(Time.zone.now.zone)}/
 end
+
+Then "I should see {string} exactly {int} time(s)" do |string, int|
+  expect(page).to have_content(string).exactly(int)
+end


### PR DESCRIPTION
# Pull Request Checklist

* [x ] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x ] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [x ] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [ x] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [x ] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-6676
## Purpose

What does this PR do?

Makes sure that the text "Leave" is present only on buttons the user is a member of on the collections page when using the "Closed" false and "Moderated" true filters.

## Testing Instructions

How can the Archive's QA team verify that this is working as you intended?

See Jira.


## References

Are there other relevant issues/pull requests/mailing list discussions?

## Credit

What name and pronouns should we use to credit you in the [Archive of Our Own's Release Notes](https://archiveofourown.org/admin_posts?tag=1)?

Claire C (she/her) and alien.
