### PR TITLE
AO3-6622 Decrease margins on definition lists in FAQs

### DIFF
--- a/public/stylesheets/site/2.0/21-userstuff.css
+++ b/public/stylesheets/site/2.0/21-userstuff.css
@@ -1,10 +1,11 @@
 /* ==USERSTUFF: displaying content inputted by a user into a textarea.*/
 
 .userstuff {
-    word-wrap: break-word;
+  word-wrap: break-word;
 }
 
-.userstuff p, .userstuff details {
+.userstuff p,
+.userstuff details {
   margin: 1.286em auto;
   padding: 0;
   line-height: 1.5;
@@ -20,6 +21,10 @@
 .userstuff dl dl {
   width: 90%;
   margin: auto;
+}
+
+.faq .userstuff dl {
+  margin: 0.75em 0;
 }
 
 .userstuff dt {
@@ -40,12 +45,19 @@
   padding: 0;
 }
 
+.faq .userstuff dd {
+  margin-block-start: 0.75em;
+  margin-block-end: 0.75em;
+  margin-inline-start: 1.75em;
+}
+
 .userstuff ul {
   margin: 1.125em auto;
   padding: 0 1em;
 }
 
-.userstuff li, .userstuff ol ul li {
+.userstuff li,
+.userstuff ol ul li {
   font-weight: normal;
   display: list-item;
   list-style-type: disc;
@@ -108,7 +120,9 @@
   border-bottom: 1px solid;
 }
 
-.userstuff h3 a, .userstuff h3 a:link, .userstuff h3 a:visited {
+.userstuff h3 a,
+.userstuff h3 a:link,
+.userstuff h3 a:visited {
   font-weight: 500;
   border-bottom: 0;
   text-decoration: none;
@@ -119,11 +133,21 @@
 .userstuff caption {
   font-size: 1em;
   height: auto;
-  opacity: 1.0;
+  opacity: 1;
   width: auto;
 }
 
-.userstuff table, .userstuff td, .userstuff col, .userstuff tr, .userstuff thead, .userstuff tfoot, .userstuff tbody, .userstuff th, .userstuff thead td, .userstuff th a, .userstuff th a:link {
+.userstuff table,
+.userstuff td,
+.userstuff col,
+.userstuff tr,
+.userstuff thead,
+.userstuff tfoot,
+.userstuff tbody,
+.userstuff th,
+.userstuff thead td,
+.userstuff th a,
+.userstuff th a:link {
   background: transparent;
   border: none;
 }
@@ -179,11 +203,11 @@
 /* contexts */
 
 .bookmark .user .userstuff {
-	line-height: 1.5;
+  line-height: 1.5;
 }
 
 .bookmark .user .userstuff blockquote {
-	margin-bottom: 1.286em;
+  margin-bottom: 1.286em;
 }
 
 /*END== */

--- a/public/stylesheets/site/2.0/21-userstuff.css
+++ b/public/stylesheets/site/2.0/21-userstuff.css
@@ -45,8 +45,7 @@
     padding: 0 1em;
 }
 
-.userstuff li,
-.userstuff ol ul li {
+.userstuff li, .userstuff ol ul li {
     font-weight: normal;
     display: list-item;
     list-style-type: disc;
@@ -109,9 +108,7 @@
     border-bottom: 1px solid;
 }
 
-.userstuff h3 a,
-.userstuff h3 a:link,
-.userstuff h3 a:visited {
+.userstuff h3 a, .userstuff h3 a:link, .userstuff h3 a:visited {
     font-weight: 500;
     border-bottom: 0;
     text-decoration: none;

--- a/public/stylesheets/site/2.0/21-userstuff.css
+++ b/public/stylesheets/site/2.0/21-userstuff.css
@@ -1,139 +1,139 @@
 /* ==USERSTUFF: displaying content inputted by a user into a textarea.*/
 
 .userstuff {
-    word-wrap: break-word;
+  word-wrap: break-word;
 }
 
 .userstuff p, .userstuff details {
-    margin: 1.286em auto;
-    padding: 0;
-    line-height: 1.5;
+  margin: 1.286em auto;
+  padding: 0;
+  line-height: 1.5;
 }
 
 /*lists */
 
 .userstuff dl {
-    margin: 1.5em 0;
-    border: 0;
+  margin: 1.5em 0;
+  border: 0;
 }
 
 .userstuff dl dl {
-    width: 90%;
-    margin: auto;
+  width: 90%;
+  margin: auto;
 }
 
 .userstuff dt {
-    display: block;
-    font-weight: bold;
+  display: block;
+  font-weight: bold;
 }
 
 .userstuff dd {
-    display: block;
-    line-height: 1.5;
-    margin-block-start: 1.25em;
-    margin-block-end: 1.25em;
-    margin-inline-start: 3em;
+  display: block;
+  line-height: 1.5;
+  margin-block-start: 1.25em;
+  margin-block-end: 1.25em;
+  margin-inline-start: 3em;
 }
 
 .userstuff dd p {
-    margin: 0;
-    padding: 0;
+  margin: 0;
+  padding: 0;
 }
 
 .userstuff ul {
-    margin: 1.125em auto;
-    padding: 0 1em;
+  margin: 1.125em auto;
+  padding: 0 1em;
 }
 
 .userstuff li, .userstuff ol ul li {
-    font-weight: normal;
-    display: list-item;
-    list-style-type: disc;
-    margin-block-start: 0.75em;
-    margin-inline-end: 0;
-    margin-block-end: 0.75em;
-    margin-inline-start: 1.75em;
+  font-weight: normal;
+  display: list-item;
+  list-style-type: disc;
+  margin-block-start: 0.75em;
+  margin-inline-end: 0;
+  margin-block-end: 0.75em;
+  margin-inline-start: 1.75em;
 }
 
 .userstuff ol {
-    margin: 0.75em auto;
-    padding: 0 1.5em;
+  margin: 0.75em auto;
+  padding: 0 1.5em;
 }
 
 .userstuff ol li {
-    list-style-type: decimal;
-    margin-block-start: 0.75em;
-    margin-inline-end: 0;
-    margin-block-end: 0.75em;
-    margin-inline-start: 1.75em;
+  list-style-type: decimal;
+  margin-block-start: 0.75em;
+  margin-inline-end: 0;
+  margin-block-end: 0.75em;
+  margin-inline-start: 1.75em;
 }
 
 .userstuff ol li ol li {
-    list-style-type: lower-alpha;
+  list-style-type: lower-alpha;
 }
 
 .userstuff ol li ol li ol li {
-    list-style-type: lower-roman;
+  list-style-type: lower-roman;
 }
 
 /* headings */
 
 .userstuff h1 {
-    text-align: center;
+  text-align: center;
 }
 
 .userstuff h2 {
-    color: #333;
-    margin: 1.5em 0;
-    display: block;
+  color: #333;
+  margin: 1.5em 0;
+  display: block;
 }
 
 .userstuff h3 {
-    font-weight: 500;
-    padding: 0.125em;
-    border-bottom: 0.25em double #333;
+  font-weight: 500;
+  padding: 0.125em;
+  border-bottom: 0.25em double #333;
 }
 
 .userstuff h4 {
-    font-weight: 700;
+  font-weight: 700;
 }
 
 .userstuff h5 {
-    font-weight: 600;
-    font-size: 1em;
+  font-weight: 600;
+  font-size: 1em;
 }
 
 .userstuff h6 {
-    font-size: 0.975em;
-    border-bottom: 1px solid;
+  font-size: 0.975em;
+  border-bottom: 1px solid;
 }
 
 .userstuff h3 a, .userstuff h3 a:link, .userstuff h3 a:visited {
-    font-weight: 500;
-    border-bottom: 0;
-    text-decoration: none;
+  font-weight: 500;
+  border-bottom: 0;
+  text-decoration: none;
 }
 
 /*tables */
 
 .userstuff caption {
-    font-size: 1em;
-    height: auto;
-    opacity: 1;
-    width: auto;
+  font-size: 1em;
+  height: auto;
+  width: auto;
+      opacity: 1;
 }
 
 .userstuff table, .userstuff td, .userstuff col, .userstuff tr, .userstuff thead, .userstuff tfoot, .userstuff tbody, .userstuff th, .userstuff thead td, .userstuff th a, .userstuff th a:link {
-    background: transparent;
-    border: none;
+  background: transparent;
+  border: none;
 }
 
 /* quotes and stresses */
 
 .userstuff blockquote {
-    margin-inline-start: 1.5em;
-    padding: 0.75em;
-    border-inline-start: 2px solid #999;
+  margin-inline-start: 1.5em;
+  padding: 0.75em;
+  border-inline-start: 2px solid #999;
 }
 
 .userstuff blockquote blockquote {
@@ -142,16 +142,16 @@
 }
 
 .userstuff hr {
-    width: 33%;
-    margin: 0.875em auto 1.2525em auto;
-   border: 1px solid;
+  width: 33%;
+  margin: 0.875em auto 1.2525em auto;
+  border: 1px solid;
 }
 
 /* media */
 
 .userstuff img {
-    max-width: 100%;
-    height: auto;
+  max-width: 100%;
+  height: auto;
 }
 
 .userstuff video {
@@ -163,37 +163,37 @@
 /* WORK MARGINS */
 
 #workskin {
-    font-size: 1.08em;
-    margin: auto;
-    padding: 0 0.25em;
-    max-width: 72em;
-    overflow-x: auto;
-    overflow-y: hidden;
-    position: relative;
+  font-size: 1.08em;
+  margin: auto;
+  padding: 0 0.25em;
+  max-width: 72em;
+  overflow-x: auto;
+  overflow-y: hidden;
+  position: relative;
 }
 
 #workskin .module {
-    float: none;
+  float: none;
 }
 
 /* contexts */
 
 .bookmark .user .userstuff {
-    line-height: 1.5;
+  line-height: 1.5;
 }
 
 .bookmark .user .userstuff blockquote {
-    margin-bottom: 1.286em;
+  margin-bottom: 1.286em;
 }
 
 .faq .userstuff dd {
-    margin-block-start: 0.75em;
-    margin-block-end: 0.75em;
-    margin-inline-start: 1.75em;
+  margin-block-start: 0.75em;
+  margin-block-end: 0.75em;
+  margin-inline-start: 1.75em;
 }
 
 .faq .userstuff dl {
-    margin: 0.75em 0;
+  margin: 0.75em 0;
 }
 
 /*END== */

--- a/public/stylesheets/site/2.0/21-userstuff.css
+++ b/public/stylesheets/site/2.0/21-userstuff.css
@@ -1,7 +1,7 @@
 /* ==USERSTUFF: displaying content inputted by a user into a textarea.*/
 
 .userstuff {
-  word-wrap: break-word;
+    word-wrap: break-word;
 }
 
 .userstuff p, .userstuff details {
@@ -137,8 +137,8 @@
 }
 
 .userstuff blockquote blockquote {
-    padding: 0.25em;
-    border: 0;
+  padding: 0.25em;
+  border: 0;
 }
 
 .userstuff hr {

--- a/public/stylesheets/site/2.0/21-userstuff.css
+++ b/public/stylesheets/site/2.0/21-userstuff.css
@@ -1,181 +1,166 @@
 /* ==USERSTUFF: displaying content inputted by a user into a textarea.*/
 
 .userstuff {
-  word-wrap: break-word;
+    word-wrap: break-word;
 }
 
-.userstuff p,
-.userstuff details {
-  margin: 1.286em auto;
-  padding: 0;
-  line-height: 1.5;
+.userstuff p, .userstuff details {
+    margin: 1.286em auto;
+    padding: 0;
+    line-height: 1.5;
 }
 
 /*lists */
 
 .userstuff dl {
-  margin: 1.5em 0;
-  border: 0;
+    margin: 1.5em 0;
+    border: 0;
 }
 
 .userstuff dl dl {
-  width: 90%;
-  margin: auto;
-}
-
-.faq .userstuff dl {
-  margin: 0.75em 0;
+    width: 90%;
+    margin: auto;
 }
 
 .userstuff dt {
-  display: block;
-  font-weight: bold;
+    display: block;
+    font-weight: bold;
 }
 
 .userstuff dd {
-  display: block;
-  line-height: 1.5;
-  margin-block-start: 1.25em;
-  margin-block-end: 1.25em;
-  margin-inline-start: 3em;
+    display: block;
+    line-height: 1.5;
+    margin-block-start: 1.25em;
+    margin-block-end: 1.25em;
+    margin-inline-start: 3em;
 }
 
 .userstuff dd p {
-  margin: 0;
-  padding: 0;
+    margin: 0;
+    padding: 0;
 }
 
 .faq .userstuff dd {
-  margin-block-start: 0.75em;
-  margin-block-end: 0.75em;
-  margin-inline-start: 1.75em;
+    margin-block-start: 0.75em;
+    margin-block-end: 0.75em;
+    margin-inline-start: 1.75em;
 }
 
 .userstuff ul {
-  margin: 1.125em auto;
-  padding: 0 1em;
+    margin: 1.125em auto;
+    padding: 0 1em;
 }
 
 .userstuff li,
 .userstuff ol ul li {
-  font-weight: normal;
-  display: list-item;
-  list-style-type: disc;
-  margin-block-start: 0.75em;
-  margin-inline-end: 0;
-  margin-block-end: 0.75em;
-  margin-inline-start: 1.75em;
+    font-weight: normal;
+    display: list-item;
+    list-style-type: disc;
+    margin-block-start: 0.75em;
+    margin-inline-end: 0;
+    margin-block-end: 0.75em;
+    margin-inline-start: 1.75em;
 }
 
 .userstuff ol {
-  margin: 0.75em auto;
-  padding: 0 1.5em;
+    margin: 0.75em auto;
+    padding: 0 1.5em;
 }
 
 .userstuff ol li {
-  list-style-type: decimal;
-  margin-block-start: 0.75em;
-  margin-inline-end: 0;
-  margin-block-end: 0.75em;
-  margin-inline-start: 1.75em;
+    list-style-type: decimal;
+    margin-block-start: 0.75em;
+    margin-inline-end: 0;
+    margin-block-end: 0.75em;
+    margin-inline-start: 1.75em;
 }
 
 .userstuff ol li ol li {
-  list-style-type: lower-alpha;
+    list-style-type: lower-alpha;
 }
 
 .userstuff ol li ol li ol li {
-  list-style-type: lower-roman;
+    list-style-type: lower-roman;
 }
 
 /* headings */
 
 .userstuff h1 {
-  text-align: center;
+    text-align: center;
 }
 
 .userstuff h2 {
-  color: #333;
-  margin: 1.5em 0;
-  display: block;
+    color: #333;
+    margin: 1.5em 0;
+    display: block;
 }
 
 .userstuff h3 {
-  font-weight: 500;
-  padding: 0.125em;
-  border-bottom: 0.25em double #333;
+    font-weight: 500;
+    padding: 0.125em;
+    border-bottom: 0.25em double #333;
 }
 
 .userstuff h4 {
-  font-weight: 700;
+    font-weight: 700;
 }
 
 .userstuff h5 {
-  font-weight: 600;
-  font-size: 1em;
+    font-weight: 600;
+    font-size: 1em;
 }
 
 .userstuff h6 {
-  font-size: 0.975em;
-  border-bottom: 1px solid;
+    font-size: 0.975em;
+    border-bottom: 1px solid;
 }
 
 .userstuff h3 a,
 .userstuff h3 a:link,
 .userstuff h3 a:visited {
-  font-weight: 500;
-  border-bottom: 0;
-  text-decoration: none;
+    font-weight: 500;
+    border-bottom: 0;
+    text-decoration: none;
 }
 
 /*tables */
 
 .userstuff caption {
-  font-size: 1em;
-  height: auto;
-  opacity: 1;
-  width: auto;
+    font-size: 1em;
+    height: auto;
+    opacity: 1;
+    width: auto;
 }
 
-.userstuff table,
-.userstuff td,
-.userstuff col,
-.userstuff tr,
-.userstuff thead,
-.userstuff tfoot,
-.userstuff tbody,
-.userstuff th,
-.userstuff thead td,
-.userstuff th a,
-.userstuff th a:link {
-  background: transparent;
-  border: none;
+.userstuff table, .userstuff td, .userstuff col, .userstuff tr, .userstuff thead, .userstuff tfoot, .userstuff tbody, .userstuff th, .userstuff thead td, .userstuff th a, .userstuff th a:link {
+    background: transparent;
+    border: none;
 }
 
 /* quotes and stresses */
 
 .userstuff blockquote {
-  margin-inline-start: 1.5em;
-  padding: 0.75em;
-  border-inline-start: 2px solid #999;
+    margin-inline-start: 1.5em;
+    padding: 0.75em;
+    border-inline-start: 2px solid #999;
 }
 
 .userstuff blockquote blockquote {
-  padding: 0.25em;
-  border: 0;
+    padding: 0.25em;
+    border: 0;
 }
 
 .userstuff hr {
-  width: 33%;
-  margin: 0.875em auto 1.2525em auto;
-  border: 1px solid;
+    width: 33%;
+    margin: 0.875em auto 1.2525em auto;
+   border: 1px solid;
 }
 
 /* media */
 
 .userstuff img {
-  max-width: 100%;
-  height: auto;
+    max-width: 100%;
+    height: auto;
 }
 
 .userstuff video {
@@ -187,27 +172,31 @@
 /* WORK MARGINS */
 
 #workskin {
-  font-size: 1.08em;
-  margin: auto;
-  padding: 0 0.25em;
-  max-width: 72em;
-  overflow-x: auto;
-  overflow-y: hidden;
-  position: relative;
+    font-size: 1.08em;
+    margin: auto;
+    padding: 0 0.25em;
+    max-width: 72em;
+    overflow-x: auto;
+    overflow-y: hidden;
+    position: relative;
 }
 
 #workskin .module {
-  float: none;
+    float: none;
 }
 
 /* contexts */
 
 .bookmark .user .userstuff {
-  line-height: 1.5;
+    line-height: 1.5;
 }
 
 .bookmark .user .userstuff blockquote {
-  margin-bottom: 1.286em;
+    margin-bottom: 1.286em;
+}
+
+.faq .userstuff dl {
+    margin: 0.75em 0;
 }
 
 /*END== */

--- a/public/stylesheets/site/2.0/21-userstuff.css
+++ b/public/stylesheets/site/2.0/21-userstuff.css
@@ -40,12 +40,6 @@
     padding: 0;
 }
 
-.faq .userstuff dd {
-    margin-block-start: 0.75em;
-    margin-block-end: 0.75em;
-    margin-inline-start: 1.75em;
-}
-
 .userstuff ul {
     margin: 1.125em auto;
     padding: 0 1em;
@@ -193,6 +187,12 @@
 
 .bookmark .user .userstuff blockquote {
     margin-bottom: 1.286em;
+}
+
+.faq .userstuff dd {
+    margin-block-start: 0.75em;
+    margin-block-end: 0.75em;
+    margin-inline-start: 1.75em;
 }
 
 .faq .userstuff dl {

--- a/public/stylesheets/site/2.0/21-userstuff.css
+++ b/public/stylesheets/site/2.0/21-userstuff.css
@@ -120,7 +120,7 @@
   font-size: 1em;
   height: auto;
   width: auto;
-      opacity: 1;
+    opacity: 1;
 }
 
 .userstuff table, .userstuff td, .userstuff col, .userstuff tr, .userstuff thead, .userstuff tfoot, .userstuff tbody, .userstuff th, .userstuff thead td, .userstuff th a, .userstuff th a:link {

--- a/spec/models/abuse_report_spec.rb
+++ b/spec/models/abuse_report_spec.rb
@@ -340,6 +340,12 @@ describe AbuseReport do
       expect(spam_report.errors[:base]).to include("This report looks like spam to our system!")
     end
 
+    it "is valid even if the email casing is different" do
+      legit_user.email = legit_user.email.upcase
+      User.current_user = legit_user
+      expect(safe_report.save).to be_truthy
+    end
+
     it "is valid even with spam if logged in and providing correct email" do
       User.current_user = legit_user
       expect(safe_report.save).to be_truthy

--- a/spec/models/abuse_report_spec.rb
+++ b/spec/models/abuse_report_spec.rb
@@ -340,12 +340,6 @@ describe AbuseReport do
       expect(spam_report.errors[:base]).to include("This report looks like spam to our system!")
     end
 
-    it "is valid even if the email casing is different" do
-      legit_user.email = legit_user.email.upcase
-      User.current_user = legit_user
-      expect(safe_report.save).to be_truthy
-    end
-
     it "is valid even with spam if logged in and providing correct email" do
       User.current_user = legit_user
       expect(safe_report.save).to be_truthy


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [ ] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [x] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [x] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-6622

## Purpose

Adjusts the margins for `.userstuff` `dl` and `dd` elements within `.faq` containers to be smaller.

## Testing Instructions

These margins can be seen on the `/faq` path (although there does not seem to be any FAQ data on my local...)

## Credit

calm (they/them)