### PR TITLE
AO3-5937 "Save" button visible on bookmarks when logged out and on a tag's bookmarks page

### DIFF
--- a/app/views/bookmarks/_bookmarkable_blurb.html.erb
+++ b/app/views/bookmarks/_bookmarkable_blurb.html.erb
@@ -13,21 +13,23 @@
   <%= render "bookmarks/bookmark_item_module", bookmarkable: unwrapped %>
 
   <!--actions-->
-  <ul class="actions" role="navigation">
-    <li>
-      <% if current_user_bookmark ||= bookmark_if_exists(unwrapped) %>
-        <%= link_to ts("Saved"),
-                    edit_bookmark_path(current_user_bookmark),
-                    id: "bookmark_form_trigger_for_#{bookmarkable.id}",
-                    remote: true %>
-      <% else %>
-        <%= link_to ts("Save"),
-                    new_polymorphic_path([bookmarkable, Bookmark]),
-                    id: "bookmark_form_trigger_for_#{bookmarkable.id}",
-                    remote: true %>
-      <% end %>
-    </li>
-  </ul>
+  <% if logged_in? %>
+    <ul class="actions" role="navigation">
+      <li>
+          <% if current_user_bookmark ||= bookmark_if_exists(unwrapped) %>
+            <%= link_to ts("Saved"),
+                        edit_bookmark_path(current_user_bookmark),
+                        id: "bookmark_form_trigger_for_#{bookmarkable.id}",
+                        remote: true %>
+          <% else %>
+            <%= link_to ts("Save"),
+                        new_polymorphic_path([bookmarkable, Bookmark]),
+                        id: "bookmark_form_trigger_for_#{bookmarkable.id}",
+                        remote: true %>
+          <% end %>
+      </li>
+    </ul>
+  <% end %>
 
   <% if logged_in_as_admin? && bookmarkable.class == ExternalWork %>
     <%= render "admin/admin_options", item: bookmarkable %>


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [ ] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [x] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [x] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-5937 

## Purpose

Wraps the "save" and "saved" actions for bookmarks in a `logged_in?` check.

## Testing Instructions

I have left a comment for clarification on the JIRA ticket.

## Credit

calm (they/them)