### PR TITLE
AO3-2151 Redirect to work edit on related work deletion

### DIFF
--- a/app/controllers/related_works_controller.rb
+++ b/app/controllers/related_works_controller.rb
@@ -65,7 +65,7 @@ class RelatedWorksController < ApplicationController
       end
     end
     @related_work.destroy
-    redirect_back_or_default(user_related_works_path(current_user))
+    redirect_back(fallback_location: user_related_works_path(current_user))
   end
 
   private

--- a/spec/controllers/related_works_controller_spec.rb
+++ b/spec/controllers/related_works_controller_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require "spec_helper"
 
 describe RelatedWorksController do
   include RedirectExpectationHelper
@@ -87,45 +87,44 @@ describe RelatedWorksController do
   end
 
   describe "DELETE #destroy" do
+    let!(:related_work) { create(:related_work, parent: parent_work, work: child_work, reciprocal: true) }
+
     context "by the creator of the parent work" do
       before(:each) do
-        @related_work = FactoryBot.create(:related_work, parent_id: parent_work.id, reciprocal: true)
         fake_login_known_user(parent_creator)
-        delete :destroy, params: { id: @related_work }
+        delete :destroy, params: { id: related_work }
       end
 
       it "sets a flash message and redirects the requester" do
-        it_redirects_to_with_error(related_work_path(@related_work), "Sorry, but you don't have permission to do that. You can only approve or remove the link from your own work.")
+        it_redirects_to_with_error(related_work_path(related_work), "Sorry, but you don't have permission to do that. You can only approve or remove the link from your own work.")
       end
     end
 
     context "by a user who is not the creator of either work" do
       before(:each) do
-        @related_work = FactoryBot.create(:related_work)
         fake_login
-        delete :destroy, params: { id: @related_work }
+        delete :destroy, params: { id: related_work }
       end
 
       it "sets a flash message and redirects the requester" do
-        it_redirects_to_with_error(related_work_path(@related_work), "Sorry, but you don't have permission to do that.")
+        it_redirects_to_with_error(related_work_path(related_work), "Sorry, but you don't have permission to do that.")
       end
     end
 
     context "by the creator of the child work" do
       before(:each) do
-        @related_work = FactoryBot.create(:related_work, work_id: child_work.id)
         fake_login_known_user(child_creator)
       end
 
       it "deletes the related work" do
-        expect {
-          delete :destroy, params: { id: @related_work }
-        }.to change(RelatedWork, :count).by(-1)
+        expect { delete :destroy, params: { id: related_work } }
+          .to change(RelatedWork, :count).by(-1)
       end
 
-      it "redirects the requester" do
-        delete :destroy, params: { id: @related_work }
-        it_redirects_to(related_work_path(@related_work))
+      it "redirects the requester to referer" do
+        @request.set_header("HTTP_REFERER", "/works/#{related_work.id}/edit")
+        delete :destroy, params: { id: related_work }
+        it_redirects_to(edit_work_path(related_work))
       end
     end
   end


### PR DESCRIPTION
# Pull Request Checklist

* [X] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [X] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [X] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [X] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [X] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-2151

## Purpose

Update the redirect when destroying a `RelatedWork` to go back to the main work edit form instead of throwing a 404.
