### PR TITLE
AO3-6608 Delete Alt Text With Pseud Icon

### DIFF
--- a/app/models/pseud.rb
+++ b/app/models/pseud.rb
@@ -419,6 +419,7 @@ class Pseud < ApplicationRecord
 
   def clear_icon
     return unless delete_icon?
+    
     self.icon = nil if delete_icon?
     self.icon_alt_text = nil
   end

--- a/app/models/pseud.rb
+++ b/app/models/pseud.rb
@@ -419,6 +419,7 @@ class Pseud < ApplicationRecord
 
   def clear_icon
     self.icon = nil if delete_icon? && !icon.dirty?
+    self.icon_alt_text = nil if delete_icon?
   end
 
   #################################

--- a/app/models/pseud.rb
+++ b/app/models/pseud.rb
@@ -418,8 +418,9 @@ class Pseud < ApplicationRecord
   alias_method :delete_icon?, :delete_icon
 
   def clear_icon
-    self.icon = nil if delete_icon? && !icon.dirty?
-    self.icon_alt_text = nil if delete_icon?
+    return unless delete_icon?
+    self.icon = nil if delete_icon?
+    self.icon_alt_text = nil
   end
 
   #################################

--- a/app/models/pseud.rb
+++ b/app/models/pseud.rb
@@ -420,7 +420,7 @@ class Pseud < ApplicationRecord
   def clear_icon
     return unless delete_icon?
     
-    self.icon = nil if delete_icon?
+    self.icon = nil unless icon.dirty?
     self.icon_alt_text = nil
   end
 

--- a/features/collections/icon.feature
+++ b/features/collections/icon.feature
@@ -48,7 +48,7 @@ Feature: User icons
     And I fill in "pseud_icon_alt_text" with "Some test description"
     And I press "Update"
   Then I should see the image "alt" text "Some test description"
-  When I delete the icon from my psued
+  When I delete the icon from my pseud
   Then I should see "Pseud was successfully updated."
   When I follow "Edit Pseud"
   Then I should see the icon and alt text boxes are blank

--- a/features/collections/icon.feature
+++ b/features/collections/icon.feature
@@ -40,3 +40,15 @@ Feature: User icons
   When I delete the icon from the collection "Pretty"
   Then I should see "Collection was successfully updated."
     And the "Pretty" collection should not have an icon
+
+  Scenario: Users can delete icon and alt text
+
+  Given I have an icon uploaded
+  When I follow "Edit Pseud"
+    And I fill in "pseud_icon_alt_text" with "Some test description"
+    And I press "Update"
+  Then I should see the image "alt" text "Some test description"
+  When I delete the icon from my psued
+  Then I should see "Pseud was successfully updated."
+  When I follow "Edit Pseud"
+  Then I should see the icon and alt text boxes are blank

--- a/features/step_definitions/icon_steps.rb
+++ b/features/step_definitions/icon_steps.rb
@@ -34,6 +34,12 @@ When /^I delete the icon from the collection "([^"]*)"$/ do |title|
   step %{I press "Update"}
 end
 
+When /^I delete the icon from my psued$/ do
+  visit edit_user_pseud_path(User.current_user, User.current_user.default_pseud)
+  check('pseud_delete_icon')
+  step %{I press "Update"}
+end
+
 Then /^the "([^"]*)" collection should have an icon$/ do |title|
   collection = Collection.find_by(title: title)
   assert !collection.icon_file_name.blank?
@@ -45,3 +51,8 @@ Then /^the "([^"]*)" collection should not have an icon$/ do |title|
 end
 
 ### THEN
+
+Then /^I should see the icon and alt text boxes are blank$/ do
+  expect(find('#pseud_icon').value).to be_blank
+  expect(find('#pseud_icon_alt_text').value).to be_nil
+end

--- a/features/step_definitions/icon_steps.rb
+++ b/features/step_definitions/icon_steps.rb
@@ -36,7 +36,7 @@ end
 
 When /^I delete the icon from my psued$/ do
   visit edit_user_pseud_path(User.current_user, User.current_user.default_pseud)
-  check('pseud_delete_icon')
+  check("pseud_delete_icon")
   step %{I press "Update"}
 end
 
@@ -53,6 +53,6 @@ end
 ### THEN
 
 Then /^I should see the icon and alt text boxes are blank$/ do
-  expect(find('#pseud_icon').value).to be_blank
-  expect(find('#pseud_icon_alt_text').value).to be_nil
+  expect(find("#pseud_icon").value).to be_blank
+  expect(find("#pseud_icon_alt_text").value).to be_nil
 end

--- a/features/step_definitions/icon_steps.rb
+++ b/features/step_definitions/icon_steps.rb
@@ -52,7 +52,7 @@ end
 
 ### THEN
 
-Then  "I should see the icon and alt text boxes are blank" do
+Then "I should see the icon and alt text boxes are blank" do
   expect(find("#pseud_icon").value).to be_blank
   expect(find("#pseud_icon_alt_text").value).to be_nil
 end

--- a/features/step_definitions/icon_steps.rb
+++ b/features/step_definitions/icon_steps.rb
@@ -34,7 +34,7 @@ When /^I delete the icon from the collection "([^"]*)"$/ do |title|
   step %{I press "Update"}
 end
 
-When /^I delete the icon from my psued$/ do
+When "I delete the icon from my pseud" do
   visit edit_user_pseud_path(User.current_user, User.current_user.default_pseud)
   check("pseud_delete_icon")
   step %{I press "Update"}
@@ -52,7 +52,7 @@ end
 
 ### THEN
 
-Then /^I should see the icon and alt text boxes are blank$/ do
+Then  "I should see the icon and alt text boxes are blank" do
   expect(find("#pseud_icon").value).to be_blank
   expect(find("#pseud_icon_alt_text").value).to be_nil
 end


### PR DESCRIPTION
# Pull Request Checklist

* [X] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [X] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [X] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [X] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [X] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-6608 (Please fill in issue number and remove this comment.)

## Purpose

What does this PR do?

Delete alt text associated with a pseuds Icon when the icon is deleted.

## Testing Instructions

How can the Archive's QA team verify that this is working as you intended?

If you have a Jira account with access, please update or comment on the issue
with any new or missing testing instructions instead.

see Jira!

## References

Are there other relevant issues/pull requests/mailing list discussions?

## Credit

Claire C she/her


