### PR TITLE
AO3-6696 Change reviewdog workflows to install only linter gems

### DIFF
--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -11,6 +11,8 @@ jobs:
   rubocop:
     name: Rubocop
     runs-on: ubuntu-latest
+    env:
+      BUNDLE_ONLY: linters
     steps:
       - name: Check out code
         uses: actions/checkout@v4
@@ -30,6 +32,8 @@ jobs:
   erb-lint:
     name: ERB Lint runner
     runs-on: ubuntu-latest
+    env:
+      BUNDLE_ONLY: linters
     steps:
       - name: Check out code
         uses: actions/checkout@v4


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6696

## Purpose

Use the `BUNDLE_ONLY` environment variable to install only the linter gems in the reviewdog linter github action workflows. Installing less gems should hopefully speed up the workflows.

## Testing Instructions

No manual testing needed, simply see if it runs correctly on new PRs/pushes for PRs (including this PR). I tested it on my fork and the workflow was fine and reported the added errors: https://github.com/Bilka2/otwarchive/pull/9

## References

Based on the [updated readme](https://github.com/reviewdog/action-rubocop/commit/53401726feff8cfe2342d0d85f3c1406bbf5ba93) of action-rubocop which I found when reviewing #4766. However, this change is independent of the update of the action.

## Credit

Bilka (he/him)
