### PR TITLE
AO3-6596 Update first login help test to reflect stage/prod

### DIFF
--- a/features/other_a/help.feature
+++ b/features/other_a/help.feature
@@ -35,8 +35,7 @@ Feature: Help
   Scenario: Asked to log in if trying to access the first login page as guest
 
     When I go to the first login help page
-    Then I should see "Log in"
-      And I should not see "Here are some tips to help you get started"
+    Then I should be on the login page
 
     Given I am logged in
     When I go to the first login help page

--- a/features/other_a/help.feature
+++ b/features/other_a/help.feature
@@ -35,7 +35,8 @@ Feature: Help
   Scenario: Asked to log in if trying to access the first login page as guest
 
     When I go to the first login help page
-    Then I should see "Sorry, you don't have permission"
+    Then I should see "Log in"
+      And I should not see "Here are some tips to help you get started"
 
     Given I am logged in
     When I go to the first login help page


### PR DESCRIPTION
# Pull Request Checklist

* [X] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [X] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [X] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [X] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [X] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-6596

## Purpose

Update the first login help feature test to not check for flash messages. While these should show up (and do in local development), there's something more complex (caching? probably caching?) going on in staging/production that means it doesn't. A follow-up will be filed to fix that behavior, as it shows up in several places as listed in https://otwarchive.atlassian.net/browse/AO3-6596?focusedCommentId=361109.

## Credit

Brian Austin (they/he)