### PR TITLE
AO3-6689 Fix JavaScript for dropdowns on status index

### DIFF
--- a/public/status/index.html
+++ b/public/status/index.html
@@ -160,6 +160,7 @@
       }
     </script>
     <script type="text/javascript">$j = jQuery.noConflict();</script>
+    <script src="/javascripts/application.js" type="text/javascript"></script>
     <script src="/javascripts/bootstrap/bootstrap-dropdown.js" type="text/javascript"></script>
     <script src="/javascripts/jquery.timeago.min.js" type="text/javascript"></script>
     <script type="text/javascript">


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6689

## Purpose

Adds a missing JavaScript file to https://test.archiveofourown.org/status/index.html. Now clicking a menu like "About" won't take you somewhere; it'll just keep the menu open.

## Testing Instructions

Go to https://test.archiveofourown.org/status/index.html and make sure the page works, paying special attention to the behavior when clicking on the dropdown menus.

## References

Are there other relevant issues/pull requests/mailing list discussions?

## Credit

What name and pronouns should we use to credit you in the [Archive of Our Own's Release Notes](https://archiveofourown.org/admin_posts?tag=1)?

If you have a Jira account, please include the same name in the "Full name"
field on your Jira profile, so we can assign you the issues you're working on.

*Please note that if you do not fill in this section, we will use your GitHub account name and
they/them pronouns.*
