### PR TITLE
AO3-6701 Fix flaky admin works and series tests

### DIFF
--- a/features/admins/admin_works.feature
+++ b/features/admins/admin_works.feature
@@ -227,6 +227,7 @@ Feature: Admin Actions for Works, Comments, Series, Bookmarks
     When I am logged in as a "policy_and_abuse" admin
       And I view the work "The One Where Neal is Awesome"
       And I follow "Comments (1)"
+      And it is currently 1 second from now
       And I follow "Not Spam"
     Then I should see "Hide Comments (2)"
       And I should not see "Not Spam"

--- a/features/other_b/series.feature
+++ b/features/other_b/series.feature
@@ -44,7 +44,9 @@ Feature: Create and Edit Series
   Scenario: Works in a series have series navigation
     Given I am logged in as "author"
       And I post the work "Sweetie Belle" as part of a series "Ponies"
+      And it is currently 1 second from now
       And I post the work "Starsong" as part of a series "Ponies"
+      And it is currently 1 second from now
       And I post the work "Rainbow Dash" as part of a series "Ponies"
     When I view the series "Ponies"
       And I follow "Rainbow Dash"


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6701

## Purpose

Fix flaky series test by adding a simulated delays before creating the works. This means the cache for the previous works is correctly expired when the new work is created, so the link is present in the meta and we don't get intermittent failures.

Fix flaky admin works test by adding a simulated delay before marking a comment as not spam. This means that marking the comment as not spam correctly expires the cache of the comment, so the comment text is shown and we don't get  intermittent failures.

## Testing Instructions

No manual QA required. I ran the admin work test 50x [here](https://github.com/Bilka2/otwarchive/actions/runs/8453192741) and the series test 50x [here](https://github.com/Bilka2/otwarchive/actions/runs/8452841603), with no failures. Before the fixes, 50 runs each resulted in [2 admin work test failures](https://github.com/Bilka2/otwarchive/actions/runs/8452869097) and [1 series test failure](https://github.com/Bilka2/otwarchive/actions/runs/8448415815). 

## Credit

Bilka (he/him)