### PR TITLE
AO3-4820 AO3-3810 Validate skins with "archive" in title

### DIFF
--- a/app/controllers/skins_controller.rb
+++ b/app/controllers/skins_controller.rb
@@ -2,7 +2,6 @@ class SkinsController < ApplicationController
 
   before_action :users_only, only: [:new, :create, :destroy]
   before_action :load_skin, except: [:index, :new, :create, :unset]
-  before_action :check_title, only: [:create, :update]
   before_action :check_ownership_or_admin, only: [:edit, :update]
   before_action :check_ownership, only: [:confirm_delete, :destroy]
   before_action :check_visibility, only: [:show]
@@ -196,13 +195,6 @@ class SkinsController < ApplicationController
     unless @skin.editable?
       flash[:error] = ts("Sorry, you don't have permission to edit this skin")
       redirect_to @skin
-    end
-  end
-
-  def check_title
-    if params[:skin][:title].match(/archive/i)
-      flash[:error] = ts("You can't use the word 'archive' in your skin title, sorry! (We have to reserve it for official skins.)")
-      render @skin ? :edit : :new
     end
   end
 

--- a/app/models/skin.rb
+++ b/app/models/skin.rb
@@ -108,8 +108,13 @@ class Skin < ApplicationRecord
     errors.add(:base, ts("You need to upload a screencap if you want to share your skin."))
   end
 
-  validates_presence_of :title
-  validates :title, uniqueness: { message: ts("must be unique"), case_sensitive: true }
+  validates :title, presence: true, uniqueness: { message: ts("must be unique"), case_sensitive: true }
+  validate :allowed_title
+  def allowed_title
+    return true if (!self.title.match(/archive/i) || User.current_user.is_a?(Admin))
+
+    errors.add(:base, ts("You can't use the word 'Archive' in your skin title, sorry! (We have to reserve it for official skins.)"))
+  end
 
   validates_numericality_of :margin, :base_em, allow_nil: true
   validate :valid_font
@@ -479,7 +484,7 @@ class Skin < ApplicationRecord
           skin.unusable = true
           skin.official = true
           File.open(version_dir + 'preview.png', 'rb') {|preview_file| skin.icon = preview_file}
-          skin.save!
+          skin.save!(validate: false)
           skins << skin
         end
 
@@ -494,7 +499,7 @@ class Skin < ApplicationRecord
         end
         File.open(version_dir + 'preview.png', 'rb') {|preview_file| top_skin.icon = preview_file}
         top_skin.official = true
-        top_skin.save!
+        top_skin.save!(validate: false)
         skins.each_with_index do |skin, index|
           skin_parent = top_skin.skin_parents.build(child_skin: top_skin, parent_skin: skin, position: index+1)
           skin_parent.save!

--- a/features/admins/admin_skins.feature
+++ b/features/admins/admin_skins.feature
@@ -137,3 +137,15 @@ Feature: Admin manage skins
   # A user created before changing the default skin will still have the same skin
   When I am logged in as "KnownUser"
   Then I should not see "{ text-decoration: blink; }" in the page style
+
+  Scenario: Admin can edit a skin with the word "archive" in the title
+  Given the approved public skin "official archive skin" that has reserved words in the title
+    And I am logged in as a "superadmin" admin
+  When I go to "official archive skin" skin page
+    And I follow "Edit"
+    And I fill in "CSS" with "#greeting.logged-in { text-decoration: blink;}"
+    And I fill in "Description" with "all your skin are belong to us"
+    And I submit
+  Then I should see an update confirmation message
+    And I should see "all your skin are belong to us"
+    And I should see "#greeting.logged-in"

--- a/features/other_b/skin.feature
+++ b/features/other_b/skin.feature
@@ -183,18 +183,14 @@ Feature: Non-public site and work skins
   Scenario: The cache should be flushed with a parent and not when unrelated
   Given I have loaded site skins
     And I am logged in as "skinner"
-  When I set up the skin "Complex"
-    And I select "replace archive skin entirely" from "What it does:"
-    And I check "Load Archive Skin Components"
-    And I submit
-  Then I should see a create confirmation message
+    And I have a skin "Child" with a parent "Parent"
    When I am on the new skin page
-    And I fill in "Title" with "my blinking skin"
+    And I fill in "Title" with "Unrelated"
     And I fill in "CSS" with "#title { text-decoration: blink;}"
     And I submit
   Then I should see "Skin was successfully created"
-    And the cache of the skin on "my blinking skin" should not expire after I save "Complex"
-    And the cache of the skin on "Complex" should expire after I save a parent skin
+    And the cache of the skin on "Unrelated" should not expire after I save "Child"
+    And the cache of the skin on "Child" should expire after I save a parent skin
 
   Scenario: Users should be able to create skins using @media queries
   Given I am logged in as "skinner"
@@ -232,9 +228,8 @@ Feature: Non-public site and work skins
   Scenario: A user can't make a skin with "Archive" in the title
   Given I am logged in as "skinner"
     And I set up the skin "My Archive Skin" with some css
-  When "AO3-4820" is fixed
-    # And I press "Submit"
-  # Then I should see "You can't use the word 'archive' in your skin title, sorry! (We have to reserve it for official skins.)"
+    And I press "Submit"
+  Then I should see "You can't use the word 'Archive' in your skin title, sorry! (We have to reserve it for official skins.)"
 
   Scenario: A user can't look at another user's skins
   Given the user "scully" exists and is activated
@@ -278,7 +273,7 @@ Feature: Non-public site and work skins
   Then I should see "My Site Skins"
     And I should see "My Work Skins"
 
-  Scenario: User should be able to revert to the default skin from an individual 
+  Scenario: User should be able to revert to the default skin from an individual
   skin's edit page
   Given basic skins
     And I am logged in as "skinner"

--- a/features/step_definitions/skin_steps.rb
+++ b/features/step_definitions/skin_steps.rb
@@ -82,13 +82,20 @@ end
 
 Given /^the approved public skin "([^"]*)" with css "([^"]*)"$/ do |skin_name, css|
   step "the unapproved public skin \"#{skin_name}\" with css \"#{css}\""
-  step "I am logged in as an admin"
   step "I approve the skin \"#{skin_name}\""
   step "I am logged out"
 end
 
 Given /^the approved public skin "([^"]*)"$/ do |skin_name|
   step "the approved public skin \"#{skin_name}\" with css #{DEFAULT_CSS}"
+end
+
+Given /^the approved public skin "(.*?)" that has reserved words in the title$/ do |skin_name|
+  # Admins can't create skins, so we have to create it this way.
+  FactoryBot.build(:skin, title: skin_name, public: true).save!(validate: false)
+
+  step "I approve the skin \"#{skin_name}\""
+  step "I am logged out"
 end
 
 Given /^"([^"]*)" is using the approved public skin "([^"]*)" with css "([^"]*)"$/ do |login, skin_name, css|


### PR DESCRIPTION

## Issue

https://otwarchive.atlassian.net/browse/AO3-4820 

https://otwarchive.atlassian.net/browse/AO3-3810 
## Purpose

* Resolve AO3-3810 and AO3-4820 
* Remove an unnecessary step in skin_steps
* Fix failing tests
 
Note: I am not sure which admins should be allowed to edit a skin with “Archive”.

## Testing Instructions

See both issues.