### PR TITLE
AO3-6702 Prerender all links on hover

### DIFF
--- a/app/views/layouts/_javascripts.html.erb
+++ b/app/views/layouts/_javascripts.html.erb
@@ -120,4 +120,18 @@
   <% end %>
 <% end %>
 
+<script type="speculationrules">
+  {
+    "prerender": [
+      {
+        "source": "document",
+        "eagerness": "moderate",
+        "where": {
+          "href_matches": "/*"
+        }
+      }
+    ]
+  }
+</script>
+
 <%= yield :footer_js %>


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [ ] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)? Like previous speculative loading PRs, we think it's OK not to have tests for these
* [x] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [x] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-6702

## Purpose

Adds prerendering of any link on hover, in addition to the idle-time prerendering of the next chapter. This makes clicking around Ao3 pretty snappy in general!

## Testing Instructions

See https://otwarchive.atlassian.net/browse/AO3-6702

## References

https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script/type/speculationrules explains the new `"source": "document"` syntax we're using.

## Credit

Domenic Denicola, he/him