### PR TITLE
AO3-4696 Adjust wording of description of canonical fandom tags

### DIFF
--- a/app/views/tags/show.html.erb
+++ b/app/views/tags/show.html.erb
@@ -24,12 +24,12 @@
   <!--main content-->
   <p><%= ts("This tag belongs to the %{tag_class} Category.", :tag_class => @tag.class::NAME) %>
   <% if @tag.canonical %>
-    <% if @tag.is_a?(Fandom) %>
-      <%= t(".list_fandom_tags_html", fandom_relationship_tags_link: link_to(t(".fandom_relationship_tags"), fandom_path(@tag.name))) %>
-    <% end %>
     <%= ts("It's a common tag. You can use it to ") %> 
     <%= link_to ts('filter works'), {:controller => :works, :action => :index, :tag_id => @tag} %> <%= ts('and to') %> 
     <%= link_to ts('filter bookmarks'), {:controller => :bookmarks, :action => :index, :tag_id => @tag} %>.
+    <% if @tag.is_a?(Fandom) %>
+      <%= t(".list_fandom_tags_html", fandom_relationship_tags_link: link_to(t(".fandom_relationship_tags"), fandom_path(@tag.name))) %>
+    <% end %>
   <% end %>
   </p>
   

--- a/app/views/tags/show.html.erb
+++ b/app/views/tags/show.html.erb
@@ -6,11 +6,11 @@
     <% if @tag.canonical || @tag.merger || can_wrangle? %>
       <ul class="navigation actions" role="navigation">
         <% if @tag.canonical || @tag.merger %>
-          <li><%= link_to ts('Works'), tag_works_path(@tag) %></li>
-          <li><%= link_to ts('Bookmarks'), tag_bookmarks_path(@tag) %></li>
+          <li><%= link_to ts("Works"), tag_works_path(@tag) %></li>
+          <li><%= link_to ts("Bookmarks"), tag_bookmarks_path(@tag) %></li>
         <% end %>
     	<% if can_wrangle? %>
-          <li><%= link_to ts('Edit'), edit_tag_path(@tag) %> </li>
+          <li><%= link_to ts("Edit"), edit_tag_path(@tag) %> </li>
           <li><%= tag_comment_link(@tag) %></li>
           <li class="reindex"><%= link_to ts("Troubleshoot"), tag_troubleshooting_path(@tag) %> </li>
         <% end %>

--- a/app/views/tags/show.html.erb
+++ b/app/views/tags/show.html.erb
@@ -25,9 +25,9 @@
   <p><%= ts("This tag belongs to the %{tag_class} Category.", :tag_class => @tag.class::NAME) %>
   <% if @tag.canonical %>
     <%= t(".canonical_html",
-          canonical_tag_faq_link: link_to(t(".canonical_tag_faq"), archive_faq_path("glossary", anchor: "canonicaldef")),
-          filter_works_link: link_to(t(".filter_works"), { controller: :works, action: :index, tag_id: @tag }),
-          filter_bookmarks_link: link_to(t(".filter_bookmarks"), { controller: :bookmarks, action: :index, tag_id: @tag })) %>
+          canonical_tag_link: link_to(t(".canonical_tag"), archive_faq_path("glossary", anchor: "canonicaldef")),
+          filter_works_link: link_to(t(".filter_works"), tag_works_path(@tag)),
+          filter_bookmarks_link: link_to(t(".filter_bookmarks"), tag_bookmarks_path(@tag))) %>
     <% if @tag.is_a?(Fandom) %>
       <%= t(".list_fandom_tags_html", fandom_relationship_tags_link: link_to(t(".fandom_relationship_tags"), fandom_path(@tag.name))) %>
     <% end %>

--- a/app/views/tags/show.html.erb
+++ b/app/views/tags/show.html.erb
@@ -6,12 +6,12 @@
     <% if @tag.canonical || @tag.merger || can_wrangle? %>
       <ul class="navigation actions" role="navigation">
         <% if @tag.canonical || @tag.merger %>
-          <li><%= link_to ts('Works'), {:controller => :works, :action => :index, :tag_id => @tag} %></li>
-          <li><%= link_to ts('Bookmarks'), {:controller => :bookmarks, :action => :index, :tag_id => @tag} %></li>
+          <li><%= link_to ts('Works'), tag_works_path(@tag) %></li>
+          <li><%= link_to ts('Bookmarks'), tag_bookmarks_path(@tag) %></li>
         <% end %>
     	<% if can_wrangle? %>
-      	  <li><%= link_to ts('Edit'), {:controller => :tags, :action => :edit, :id => @tag} %> </li>
-      	  <li><%= tag_comment_link(@tag) %></li>
+          <li><%= link_to ts('Edit'), edit_tag_path(@tag) %> </li>
+          <li><%= tag_comment_link(@tag) %></li>
           <li class="reindex"><%= link_to ts("Troubleshoot"), tag_troubleshooting_path(@tag) %> </li>
         <% end %>
       </ul>

--- a/app/views/tags/show.html.erb
+++ b/app/views/tags/show.html.erb
@@ -23,10 +23,11 @@
 
   <!--main content-->
   <p><%= ts("This tag belongs to the %{tag_class} Category.", :tag_class => @tag.class::NAME) %>
-  <% if @tag.canonical %>
-    <%= ts("It's a common tag. You can use it to ") %> 
-    <%= link_to ts('filter works'), {:controller => :works, :action => :index, :tag_id => @tag} %> <%= ts('and to') %> 
-    <%= link_to ts('filter bookmarks'), {:controller => :bookmarks, :action => :index, :tag_id => @tag} %>.
+  <% if @tag.canonical %>   
+    <%= t(".canonical_html",
+          canonical_tag_faq_link: link_to(t(".canonical_tag_faq"), archive_faq_path("glossary", anchor: "canonicaldef")),
+          filter_works_link: link_to(t(".filter_works"), {:controller => :works, :action => :index, :tag_id => @tag}),
+          filter_bookmarks_link: link_to(t(".filter_bookmarks"), {:controller => :bookmarks, :action => :index, :tag_id => @tag})) %>
     <% if @tag.is_a?(Fandom) %>
       <%= t(".list_fandom_tags_html", fandom_relationship_tags_link: link_to(t(".fandom_relationship_tags"), fandom_path(@tag.name))) %>
     <% end %>

--- a/app/views/tags/show.html.erb
+++ b/app/views/tags/show.html.erb
@@ -23,7 +23,7 @@
 
   <!--main content-->
   <p><%= ts("This tag belongs to the %{tag_class} Category.", :tag_class => @tag.class::NAME) %>
-  <% if @tag.canonical %>   
+  <% if @tag.canonical %>
     <%= t(".canonical_html",
           canonical_tag_faq_link: link_to(t(".canonical_tag_faq"), archive_faq_path("glossary", anchor: "canonicaldef")),
           filter_works_link: link_to(t(".filter_works"), { controller: :works, action: :index, tag_id: @tag }),

--- a/app/views/tags/show.html.erb
+++ b/app/views/tags/show.html.erb
@@ -26,8 +26,8 @@
   <% if @tag.canonical %>   
     <%= t(".canonical_html",
           canonical_tag_faq_link: link_to(t(".canonical_tag_faq"), archive_faq_path("glossary", anchor: "canonicaldef")),
-          filter_works_link: link_to(t(".filter_works"), {:controller => :works, :action => :index, :tag_id => @tag}),
-          filter_bookmarks_link: link_to(t(".filter_bookmarks"), {:controller => :bookmarks, :action => :index, :tag_id => @tag})) %>
+          filter_works_link: link_to(t(".filter_works"), { controller: :works, action: :index, tag_id: @tag }),
+          filter_bookmarks_link: link_to(t(".filter_bookmarks"), { controller: :bookmarks, action: :index, tag_id: @tag })) %>
     <% if @tag.is_a?(Fandom) %>
       <%= t(".list_fandom_tags_html", fandom_relationship_tags_link: link_to(t(".fandom_relationship_tags"), fandom_path(@tag.name))) %>
     <% end %>

--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -735,7 +735,7 @@ en:
       search_tags: try our tag search
     show:
       fandom_relationship_tags: Relationship tags in this fandom
-      list_fandom_tags_html: A list of all the %{fandom_relationship_tags_link} is available.
+      list_fandom_tags_html: You can also access a list of %{fandom_relationship_tags_link}.
   time:
     formats:
       date_short_html: <abbr class="day" title="%A">%a</abbr> <span class="date">%d</span> <abbr class="month" title="%B">%b</abbr> <span class="year">%Y</span>

--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -734,8 +734,12 @@ en:
         random_in_collection: These are some random tags used in the collection.
       search_tags: try our tag search
     show:
+      canonical_html: It's a %{canonical_tag_faq_link}. You can use it to %{filter_works_link} and to %{filter_bookmarks_link}.
+      canonical_tag_faq: canonical tag
       fandom_relationship_tags: Relationship tags in this fandom
-      list_fandom_tags_html: You can also access a list of %{fandom_relationship_tags_link}.
+      filter_bookmarks: filter bookmarks
+      filter_works: filter works
+      list_fandom_tags_html: You can also access a list of %{fandom_relationship_tags_link}. 
   time:
     formats:
       date_short_html: <abbr class="day" title="%A">%a</abbr> <span class="date">%d</span> <abbr class="month" title="%B">%b</abbr> <span class="year">%Y</span>

--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -734,8 +734,8 @@ en:
         random_in_collection: These are some random tags used in the collection.
       search_tags: try our tag search
     show:
-      canonical_html: It's a %{canonical_tag_faq_link}. You can use it to %{filter_works_link} and to %{filter_bookmarks_link}.
-      canonical_tag_faq: canonical tag
+      canonical_html: It's a %{canonical_tag_link}. You can use it to %{filter_works_link} and to %{filter_bookmarks_link}.
+      canonical_tag: canonical tag
       fandom_relationship_tags: Relationship tags in this fandom
       filter_bookmarks: filter bookmarks
       filter_works: filter works


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-4696

## Purpose

Adjust the wording of the description of canonical tags and move the link to the relationship tags of the fandom after the description.

## Testing Instructions

See Jira.

## Credit

Bilka (he/him)