### PR TITLE
AO3-6486 Add development_and_membership admin role

### DIFF
--- a/app/models/admin.rb
+++ b/app/models/admin.rb
@@ -1,5 +1,5 @@
 class Admin < ApplicationRecord
-  VALID_ROLES = %w[superadmin board communications elections translation tag_wrangling docs support policy_and_abuse open_doors].freeze
+  VALID_ROLES = %w[superadmin board communications development_and_membership elections translation tag_wrangling docs support policy_and_abuse open_doors].freeze
 
   serialize :roles, Array
 

--- a/app/policies/admin_banner_policy.rb
+++ b/app/policies/admin_banner_policy.rb
@@ -12,6 +12,5 @@ class AdminBannerPolicy < ApplicationPolicy
 
   alias show? index?
   alias update? index?
-  alias create? create?
   alias destroy? create?
 end

--- a/app/policies/admin_banner_policy.rb
+++ b/app/policies/admin_banner_policy.rb
@@ -1,10 +1,17 @@
 class AdminBannerPolicy < ApplicationPolicy
+  ACCESS_AND_EDIT_ROLES = %w[superadmin board communications development_and_membership support].freeze
+  CREATE_AND_DESTROY_ROLES = %w[superadmin board communications support].freeze
+
   def index?
-    user_has_roles?(%w[superadmin board communications support])
+    user_has_roles?(ACCESS_AND_EDIT_ROLES)
+  end
+
+  def create?
+    user_has_roles?(CREATE_AND_DESTROY_ROLES)
   end
 
   alias show? index?
-  alias create? index?
   alias update? index?
-  alias destroy? index?
+  alias create? create?
+  alias destroy? create?
 end

--- a/app/views/admin/banners/_navigation.html.erb
+++ b/app/views/admin/banners/_navigation.html.erb
@@ -1,8 +1,12 @@
 <ul class="navigation actions">
-  <li><%= span_if_current ts('Banners'), admin_banners_path %></li>
-  <li><%= span_if_current ts('New Banner'), new_admin_banner_path %></li>
+  <li><%= span_if_current t(".index"), admin_banners_path %></li>
+  <% if policy(AdminBanner).new? %>
+    <li><%= span_if_current t(".new"), new_admin_banner_path %></li>
+  <% end %>
   <% if params[:id] %>
-    <li><%= span_if_current ts('Edit Banner'), edit_admin_banner_path(@admin_banner) %></li>
-    <li><%= link_to ts('Delete Banner'), confirm_delete_admin_banner_path(@admin_banner), data: {confirm: ts('Are you sure you want to delete this banner?')} %></li>
+    <li><%= span_if_current t(".edit"), edit_admin_banner_path(@admin_banner) %></li>
+    <% if policy(AdminBanner).destroy? %>
+      <li><%= link_to t(".delete"), confirm_delete_admin_banner_path(@admin_banner), data: { confirm: t(".confirm_delete") } %></li>
+    <% end %>
   <% end %>
 </ul>

--- a/app/views/admin/banners/index.html.erb
+++ b/app/views/admin/banners/index.html.erb
@@ -1,6 +1,6 @@
 <div class="admin">
   <!--Descriptive page name, messages and instructions-->
-  <h2 class="heading"><%= ts('Banners') %></h2>
+  <h2 class="heading"><%= t(".page_heading") %></h2>
   <!--/descriptions-->
 
   <!--subnav-->
@@ -13,20 +13,22 @@
   <ul class="banners index group">
     <% for admin_banner in @admin_banners %>
       <li class="blurb">
-        <%= render 'banner', admin_banner: admin_banner %>
+        <%= render "banner", admin_banner: admin_banner %>
         <ul class="actions">
           <% if admin_banner.active? %>
             <li>
-              <span class="active current"><%= ts('Active') %></span>
+              <span class="active current"><%= t(".actions.active") %></span>
             </li>
           <% end %>
           </li>
           <li>
-            <%= link_to ts('Edit'), edit_admin_banner_path(admin_banner) %>
+            <%= link_to t(".actions.edit"), edit_admin_banner_path(admin_banner) %>
           </li>
-          <li>
-            <%= link_to ts('Delete'), confirm_delete_admin_banner_path(admin_banner), data: {confirm: ts('Are you sure you want to delete this banner?')} %>
-          </li>
+          <% if policy(AdminBanner).destroy? %>
+            <li>
+              <%= link_to t(".actions.delete"), confirm_delete_admin_banner_path(admin_banner), data: { confirm: t(".actions.confirm_delete") } %>
+            </li>
+          <% end %>
         </ul>
       </li>
     <% end %>

--- a/config/locales/models/en.yml
+++ b/config/locales/models/en.yml
@@ -5,6 +5,7 @@ en:
       admin/role:
         board: Board
         communications: Communications
+        development_and_membership: Development & Membership
         docs: AO3 Docs
         elections: Elections
         open_doors: Open Doors

--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -178,6 +178,20 @@ en:
               required: Required when adding or removing a warning or suspension to an account.
             submit: Update
           heading: Record Warnings, Suspensions, or Notes
+    banners:
+      index:
+        actions:
+          active: Active
+          confirm_delete: Are you sure you want to delete this banner?
+          delete: Delete
+          edit: Edit
+        page_heading: Banners
+      navigation:
+        confirm_delete: Are you sure you want to delete this banner?
+        delete: Delete Banner
+        edit: Edit Banner
+        index: Banners
+        new: New Banner
     blacklist:
       emails_found:
         one: one email found

--- a/features/other_a/banner_general.feature
+++ b/features/other_a/banner_general.feature
@@ -118,3 +118,25 @@ Scenario: Admin can make minor changes to the text of an active banner without t
   Then I should see the banner with minor edits
   When I am logged in as "banner_tester_4"
   Then I should see the banner with minor edits
+
+Scenario: Development & Membership admin can see edit options but not delete or create
+  Given an admin creates a banner
+  When I am logged in as a "development_and_membership" admin
+    And I go to the admin_banners page
+  Then I should see "Banners" within "#header .admin.navigation"
+    And I should see "Banners" within "#main .navigation.actions"
+    And I should see "Edit" within "#main ul.banners.index.group"
+    But I should not see "Delete" within "#main ul.banners.index.group"
+    And I should not see "New Banner" within "#main .navigation.actions"
+  When I follow "Edit"
+  Then I should not see "New Banner" within "#main .navigation.actions"
+    And I should not see "Delete Banner" within "#main .navigation.actions"
+    But I should see "Edit Banner" within "#main h2"
+    And I should see "Edit Banner" within "#main .navigation.actions"
+  When I fill in "Banner text" with "Some fun new text"
+    And I press "Update Banner"
+  Then I should see "Banner successfully updated."
+    And I should see "Banners" within "#main .navigation.actions"
+    And I should see "Edit Banner" within "#main .navigation.actions"
+    But I should not see "Delete Banner" within "#main .navigation.actions"
+    And I should not see "New Banner" within "#main .navigation.actions"

--- a/spec/controllers/admin/banners_controller_spec.rb
+++ b/spec/controllers/admin/banners_controller_spec.rb
@@ -62,7 +62,7 @@ describe Admin::BannersController do
 
     it_behaves_like "only authorized admins are allowed",
                     authorized_roles: %w[superadmin board communications development_and_membership support]
-    end
+  end
 
   describe "GET #new" do
     subject { get :new }

--- a/spec/controllers/admin/banners_controller_spec.rb
+++ b/spec/controllers/admin/banners_controller_spec.rb
@@ -7,8 +7,8 @@ describe Admin::BannersController do
   let(:admin_banner) { create(:admin_banner) }
   let(:admin_banner_params) { attributes_for(:admin_banner) }
 
-  shared_examples "only authorized admins are allowed" do
-    %w[support communications superadmin board].each do |role|
+  shared_examples "only authorized admins are allowed" do |authorized_roles:|
+    authorized_roles.each do |role|
       it "succeeds for #{role} admins" do
         fake_login_admin(create(:admin, roles: [role]))
         subject
@@ -16,12 +16,29 @@ describe Admin::BannersController do
       end
     end
 
-    (Admin::VALID_ROLES - %w[support communications superadmin board]).each do |role|
+    (Admin::VALID_ROLES - authorized_roles).each do |role|
       it "displays an error to #{role} admins" do
         fake_login_admin(create(:admin, roles: [role]))
         subject
         it_redirects_to_with_error(root_path, "Sorry, only an authorized admin can access the page you were trying to reach.")
       end
+    end
+
+    it "displays an error to admins with no role" do
+      fake_login_admin(create(:admin, roles: []))
+      subject
+      it_redirects_to_with_error(root_path, "Sorry, only an authorized admin can access the page you were trying to reach.")
+    end
+
+    it "redirects logged out users to root with notice" do
+      subject
+      it_redirects_to_with_notice(root_path, "I'm sorry, only an admin can look at that area")
+    end
+
+    it "redirects logged in users to root with notice" do
+      fake_login
+      subject
+      it_redirects_to_with_notice(root_path, "I'm sorry, only an admin can look at that area")
     end
   end
 
@@ -32,7 +49,8 @@ describe Admin::BannersController do
       expect(response).to render_template(:index)
     end
 
-    it_behaves_like "only authorized admins are allowed"
+    it_behaves_like "only authorized admins are allowed",
+                    authorized_roles: %w[superadmin board communications development_and_membership support]
   end
 
   describe "GET #show" do
@@ -42,8 +60,9 @@ describe Admin::BannersController do
       expect(response).to render_template(:show)
     end
 
-    it_behaves_like "only authorized admins are allowed"
-  end
+    it_behaves_like "only authorized admins are allowed",
+                    authorized_roles: %w[superadmin board communications development_and_membership support]
+    end
 
   describe "GET #new" do
     subject { get :new }
@@ -52,7 +71,8 @@ describe Admin::BannersController do
       expect(response).to render_template(:new)
     end
 
-    it_behaves_like "only authorized admins are allowed"
+    it_behaves_like "only authorized admins are allowed",
+                    authorized_roles: %w[superadmin board communications support]
   end
 
   describe "POST #create" do
@@ -62,7 +82,8 @@ describe Admin::BannersController do
       it_redirects_to_with_notice(assigns[:admin_banner], "Banner successfully created.")
     end
 
-    it_behaves_like "only authorized admins are allowed"
+    it_behaves_like "only authorized admins are allowed",
+                    authorized_roles: %w[superadmin board communications support]
   end
 
   describe "GET #edit" do
@@ -72,7 +93,8 @@ describe Admin::BannersController do
       expect(response).to render_template(:edit)
     end
 
-    it_behaves_like "only authorized admins are allowed"
+    it_behaves_like "only authorized admins are allowed",
+                    authorized_roles: %w[superadmin board communications development_and_membership support]
   end
 
   describe "PUT #update" do
@@ -83,7 +105,8 @@ describe Admin::BannersController do
       it_redirects_to_with_notice(admin_banner, "Banner successfully updated.")
     end
 
-    it_behaves_like "only authorized admins are allowed"
+    it_behaves_like "only authorized admins are allowed",
+                    authorized_roles: %w[superadmin board communications development_and_membership support]
   end
 
   describe "GET #confirm_delete" do
@@ -93,7 +116,8 @@ describe Admin::BannersController do
       expect(response).to render_template(:confirm_delete)
     end
 
-    it_behaves_like "only authorized admins are allowed"
+    it_behaves_like "only authorized admins are allowed",
+                    authorized_roles: %w[superadmin board communications support]
   end
 
   describe "DELETE #destroy" do
@@ -104,6 +128,7 @@ describe Admin::BannersController do
       it_redirects_to_with_notice(admin_banners_path, "Banner successfully deleted.")
     end
 
-    it_behaves_like "only authorized admins are allowed"
+    it_behaves_like "only authorized admins are allowed",
+                    authorized_roles: %w[superadmin board communications support]
   end
 end


### PR DESCRIPTION

## Issue

https://otwarchive.atlassian.net/browse/AO3-6486

## Purpose

Create a `development_and_membership` admin role that allows DevMem to edit banners, but not create or delete them. 

## Testing Instructions

Refer to Jira.

## Credit

Sarken, she/her