### PR TITLE
AO3-6691 Remove dot from link in custom cop

### DIFF
--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -753,7 +753,7 @@ en:
       fandom_relationship_tags: Relationship tags in this fandom
       filter_bookmarks: filter bookmarks
       filter_works: filter works
-      list_fandom_tags_html: You can also access a list of %{fandom_relationship_tags_link}. 
+      list_fandom_tags_html: You can also access a list of %{fandom_relationship_tags_link}.
   time:
     formats:
       date_short_html: <abbr class="day" title="%A">%a</abbr> <span class="date">%d</span> <abbr class="month" title="%B">%b</abbr> <span class="year">%Y</span>

--- a/rubocop/cop/i18n/deprecated_helper.rb
+++ b/rubocop/cop/i18n/deprecated_helper.rb
@@ -18,7 +18,7 @@ module RuboCop
       #  t(".relative.path.to.translation")
       #  t(".greeting", name: "world")
       class DeprecatedHelper < RuboCop::Cop::Base
-        MSG = "Prefer Rails built-in `t` helper over `ts`: the latter is not actually translatable. For more information, refer to https://github.com/otwcode/otwarchive/wiki/Internationalization-(i18n)-Standards."
+        MSG = "Prefer Rails built-in `t` helper over `ts`: the latter is not actually translatable. For more information, refer to https://github.com/otwcode/otwarchive/wiki/Internationalization-(i18n)-Standards"
 
         RESTRICT_ON_SEND = %i[ts].freeze
 

--- a/spec/rubocop/cop/i18n/deprecated_helper_spec.rb
+++ b/spec/rubocop/cop/i18n/deprecated_helper_spec.rb
@@ -7,14 +7,14 @@ describe RuboCop::Cop::I18n::DeprecatedHelper do
   it "registers an offense when `ts` is used" do
     expect_offense(<<~INVALID)
       ts("Some String")
-      ^^^^^^^^^^^^^^^^^ Prefer Rails built-in `t` helper over `ts`: the latter is not actually translatable. For more information, refer to https://github.com/otwcode/otwarchive/wiki/Internationalization-(i18n)-Standards.
+      ^^^^^^^^^^^^^^^^^ Prefer Rails built-in `t` helper over `ts`: the latter is not actually translatable. For more information, refer to https://github.com/otwcode/otwarchive/wiki/Internationalization-(i18n)-Standards
     INVALID
   end
 
   it "registers an offense when `ts` is used without parentheses" do
     expect_offense(<<~INVALID)
       ts "Another string"
-      ^^^^^^^^^^^^^^^^^^^ Prefer Rails built-in `t` helper over `ts`: the latter is not actually translatable. For more information, refer to https://github.com/otwcode/otwarchive/wiki/Internationalization-(i18n)-Standards.
+      ^^^^^^^^^^^^^^^^^^^ Prefer Rails built-in `t` helper over `ts`: the latter is not actually translatable. For more information, refer to https://github.com/otwcode/otwarchive/wiki/Internationalization-(i18n)-Standards
     INVALID
   end
 


### PR DESCRIPTION
## Issue

None, typo fix (for AO3-6691).

## Purpose

Remove the dot at the end of the sentence with the link to the I18n wiki page because by the GitHub Actions log viewer parses it as part of the link (which then goes nowhere): https://github.com/otwcode/otwarchive/actions/runs/8529536784/job/23365517628#step:4:161

Also, normalize en.yml because it's not normalized. The spec for it is failing on `master` but GitHub Actions isn't reporting the failure. I'm looking into that.

## Testing Instructions

None, this is an automated test and a typo fix.

## Credit

Bilka (he/him)
