### PR TITLE
AO3-6703 Fix that some tests didn't run due to exit call in rake task

### DIFF
--- a/spec/lib/tasks/search_tasks.rake_spec.rb
+++ b/spec/lib/tasks/search_tasks.rake_spec.rb
@@ -76,8 +76,11 @@ describe "rake search:index_tags" do
     
     # Do not set up an expectation for TagIndexer.index_all
     allow($stdin).to receive(:gets).and_return("no")
-    expect { subject.invoke }
-      .to output("#{prompt}\nTask aborted.")
-      .to_stdout
+    begin
+      expect { subject.invoke }
+        .to output("#{prompt}\nTask aborted.")
+        .to_stdout
+    rescue SystemExit
+    end
   end
 end

--- a/spec/lib/tasks/search_tasks.rake_spec.rb
+++ b/spec/lib/tasks/search_tasks.rake_spec.rb
@@ -80,7 +80,7 @@ describe "rake search:index_tags" do
       expect { subject.invoke }
         .to output("#{prompt}\nTask aborted.")
         .to_stdout
-    rescue SystemExit
+    rescue SystemExit # rubocop:disable Lint/SuppressedException
     end
   end
 end


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6703

## Purpose

In the `search:index_tags` test, rescue the SystemExit exception raised by the `exit` call in the rake task, so that RSpec doesn't exit early.

## Testing Instructions

The issue is in automated testing, no manual QA needed.

The early exit caused a failed test on `master` in `spec/lib/i18n` to not get reported by GitHub Actions. It should get reported now, so **the RSpec test should fail on this PR**. No other test should fail. The i18n test itself is fixed in #4779.

## Credit

Bilka (he/him)
