### PR TITLE
AO3-5506 Don't include hidden works in Readings

### DIFF
--- a/app/controllers/readings_controller.rb
+++ b/app/controllers/readings_controller.rb
@@ -16,7 +16,7 @@ class ReadingsController < ApplicationController
       @readings = @readings.where(toread: true)
       @page_subtitle = ts("Marked For Later")
     end
-    @readings = @readings.order("last_viewed DESC").page(params[:page])
+    @readings = @readings.left_joins(:work).merge(Work.visible_to_registered_user).or(Work.where(id: nil)).order("last_viewed DESC").page(params[:page])
   end
 
   def destroy

--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -13,7 +13,7 @@ class WorksController < ApplicationController
   # admins should have the ability to edit tags (:edit_tags, :update_tags) as per our ToS
   before_action :check_ownership_or_admin, only: [:edit_tags, :update_tags]
   before_action :log_admin_activity, only: [:update_tags]
-  before_action :check_visibility, only: [:show, :navigate, :share]
+  before_action :check_visibility, only: [:show, :navigate, :share, :mark_for_later, :mark_as_read]
 
   before_action :load_first_chapter, only: [:show, :edit, :update, :preview]
 

--- a/features/other_a/reading.feature
+++ b/features/other_a/reading.feature
@@ -251,18 +251,15 @@ Feature: Reading count
   Given I am logged in as "writer"
   When I post the work "Testy"
   Then I should see "Work was successfully posted"
-  When I am logged out
-    And I am logged in as "reader"
+  When I am logged in as "reader"
     And I view the work "Testy"
   Then I should see "Mark for Later"
   When I follow "Mark for Later"
   Then I should see "This work was added to your Marked for Later list."
-  When I am logged out
-    And I am logged in as a "policy_and_abuse" admin
+  When I am logged in as a "policy_and_abuse" admin
     And I view the work "Testy"
     And I follow "Hide Work"
   Then I should see "Item has been hidden."
-  When I am logged out
-    And I am logged in as "reader"
+  When I am logged in as "reader"
     And I go to reader's reading page
   Then I should not see "Testy"

--- a/features/other_a/reading.feature
+++ b/features/other_a/reading.feature
@@ -245,3 +245,24 @@ Feature: Reading count
     And I go to the homepage
   Then I should see "Some Work V2"
     And I should not see "Some Work V1"
+
+  Scenario: A user cannot see hidden by admin works in their reading history
+
+  Given I am logged in as "writer"
+  When I post the work "Testy"
+  Then I should see "Work was successfully posted"
+  When I am logged out
+    And I am logged in as "reader"
+    And I view the work "Testy"
+  Then I should see "Mark for Later"
+  When I follow "Mark for Later"
+  Then I should see "This work was added to your Marked for Later list."
+  When I am logged out
+    And I am logged in as a "policy_and_abuse" admin
+    And I view the work "Testy"
+    And I follow "Hide Work"
+  Then I should see "Item has been hidden."
+  When I am logged out
+    And I am logged in as "reader"
+    And I go to reader's reading page
+  Then I should not see "Testy"


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [x] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [x] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [x] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-5506

## Purpose

Don't include hidden works in reading history

* Require works to be visible to mark for later

* Hide draft works and hidden by admin works from the reading history

* Test for visibility of hidden by admin works in reading history

## Testing Instructions

An automated test for hidden by admin works not being visible in the reading list is included. This may be tested manually by adding a work to a users reading list, an admin hiding it, and then viewing the users reading list and confirming it's absence.

Accessing a URL for a draft work like http://localhost:3000/works/110/mark_for_later (manually replace 110 with the id of a draft work owned by another user) should now return the error "Sorry, you don't have permission to access the page you were trying to reach." This URL was never linked in the UI for draft works, but could be guessed and draft works could previously be added to the reading list.

I don't know how to test the fact that the reading list no longer shows draft works if they somehow get added to the reading list (the above `.../mark_for_later` action is now blocked), but they should no longer be visible in the reading list now.

## Credit

@de3sw2aq1

Thanks @sarken for initial review of the security aspect of this issue and the pointer to `visible_to_registered_user` in Jira was helpful.