### PR TITLE
AO3-6704 Use URL from current host in abuse report response mailer preview

### DIFF
--- a/test/mailers/previews/user_mailer_preview.rb
+++ b/test/mailers/previews/user_mailer_preview.rb
@@ -1,6 +1,6 @@
 class UserMailerPreview < ApplicationMailerPreview
   # Sent to a user when they submit an abuse report
-  def abuse_report_response
+  def abuse_report
     abuse_report = create(:abuse_report, url: "https://#{ArchiveConfig.APP_HOST}/tags/1984%20-%20George%20Orwell")
     UserMailer.abuse_report(abuse_report.id)
   end

--- a/test/mailers/previews/user_mailer_preview.rb
+++ b/test/mailers/previews/user_mailer_preview.rb
@@ -1,7 +1,7 @@
 class UserMailerPreview < ApplicationMailerPreview
   # Sent to a user when they submit an abuse report
   def abuse_report_response
-    abuse_report = create(:abuse_report)
+    abuse_report = create(:abuse_report, url: "https://#{ArchiveConfig.APP_HOST}/tags/1984%20-%20George%20Orwell")
     UserMailer.abuse_report(abuse_report.id)
   end
 


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6704

## Purpose

Use `ArchiveConfig.APP_HOST` to create the URL for the abuse report in the abuse_report mailer preview. That way it uses a staging URL on staging.

## Testing Instructions

See Jira.

## Credit

Bilka (he/him)
