### PR TITLE
AO3-6297 Revert accidental gem downgrades in MimeMagic removal

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -352,7 +352,7 @@ GEM
       mime-types-data (~> 3.2015)
     mime-types-data (3.2022.0105)
     mini_mime (1.1.2)
-    mini_portile2 (2.8.2)
+    mini_portile2 (2.8.5)
     minitest (5.17.0)
     mono_logger (1.1.2)
     multi_json (1.15.0)
@@ -383,15 +383,16 @@ GEM
     net-ssh-gateway (2.0.0)
       net-ssh (>= 4.0.0)
     netrc (0.11.0)
-    newrelic_rpm (8.16.0)
+    newrelic_rpm (9.7.1)
     nio4r (2.5.8)
-    nokogiri (1.14.3)
-      mini_portile2 (~> 2.8.0)
+    nokogiri (1.16.3)
+      mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     orm_adapter (0.5.0)
     parallel (1.23.0)
-    parser (3.1.0.0)
+    parser (3.3.0.5)
       ast (~> 2.4.1)
+      racc
     permit_yo (2.1.3)
     phraseapp-in-context-editor-ruby (1.4.0)
       i18n (>= 0.6)
@@ -413,7 +414,7 @@ GEM
     pundit (2.1.1)
       activesupport (>= 3.0.0)
     raabro (1.4.0)
-    racc (1.7.1)
+    racc (1.7.3)
     rack (2.2.6.4)
     rack-attack (6.6.0)
       rack (>= 1.0, < 3)
@@ -723,4 +724,4 @@ RUBY VERSION
    ruby 3.1.4p223
 
 BUNDLED WITH
-   2.2.33
+   2.5.6


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6297

## Purpose

The MimeMagic removal commit d40d751 had some extra changes in the Gemfile.lock that led to various gems getting downgraded. Most likely this was caused by a merge conflict. This commit reverts the extra changes.

## Testing Instructions

No extra testing.

## References

I noticed this because nokogiri got downgraded to a vulnerable version and dependabot opened #4784 to upgrade it again.

Comparison between this branch and master before d40d751: https://github.com/otwcode/otwarchive/compare/test-0.9.367.5...Bilka2:AO3-6297-bot. Shows that after this PR, only following things are changed in the Gemfile.lock:
* The originally intended removal of MimeMagic.
* Update of net-smtp from 0.4.0 to 0.5.0. This was also introduced with d40d751. I decided not to revert it because it's a version upgrade and based on [the changelog](https://github.com/ruby/net-smtp/blob/master/NEWS.md#version-050-2024-03-27) there are no changes that affect us.
* Minor nokogiri version bump (1.16.2 -> 1.16.3). Shouldn't matter and it was easier than forcing bundler to pick 1.16.2.
* Update of bundler to 2.5.6, which is the version used in the [Dockerfile](https://github.com/otwcode/otwarchive/blob/9894e31f32da7f61240f4489d8454aa06334fd79/config/docker/Dockerfile#L19).

## Credit

Bilka (he/him)
