### PR TITLE
AO3-6537 Use standard analyzer for work title search

### DIFF
--- a/app/models/search/work_indexer.rb
+++ b/app/models/search/work_indexer.rb
@@ -38,7 +38,7 @@ class WorkIndexer < Indexer
         },
         title: {
           type: "text",
-          analyzer: "simple"
+          analyzer: "standard"
         },
         creators: {
           type: "text"

--- a/features/fixtures/works.yml
+++ b/features/fixtures/works.yml
@@ -11,7 +11,7 @@ first:
 second:
   id: 2
   posted: true
-  title: second work
+  title: second work (2 of 6)
   word_count: 1000
   title_to_sort_on: second work
   language: english

--- a/features/search/works_info.feature
+++ b/features/search/works_info.feature
@@ -139,3 +139,17 @@ Feature: Search works by work info
     Then the field labeled "Title" should contain "work"
       And "Title" should be selected within "Sort by"
       And "Ascending" should be selected within "Sort direction"
+
+  Scenario: Search by number in title
+    Given I have loaded the fixtures
+    When I am on the search works page
+      And I fill in "Title" with "work 2 6"
+      And I press "Search" within "#new_work_search"
+    Then I should see "You searched for: Title: work 2 6"
+      And I should see "1 Found"
+      And the 1st result should contain "second work (2 of 6)"
+    When I am on the search works page
+      And I fill in "Title" with "work 1"
+      And I press "Search" within "#new_work_search"
+    Then I should see "You searched for: Title: work 1"
+      And I should see "No results found"


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [x] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [x] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [x] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-6537

## Purpose

Titles may contain numbers and users expect to be able to search by them. I would like to change the analyzer from simple to standard, because [simple](https://www.elastic.co/guide/en/elasticsearch/reference/current/analysis-simple-analyzer.html) ignores numbers.

## Testing Instructions

See the Jira ticket.

## References

I have a similar pull request at https://github.com/otwcode/otwarchive/pull/4647 (not yet merged). The other one is for bookmark search.

## Credit

Potpotkettle (they/them)
