### PR TITLE
AO3-6706 Support Sentinel config for Redis clients

### DIFF
--- a/config/initializers/gem-plugin_config/redis.rb
+++ b/config/initializers/gem-plugin_config/redis.rb
@@ -1,22 +1,33 @@
-require 'redis_test_setup'
-include RedisTestSetup
+require "redis_test_setup"
+include RedisTestSetup # rubocop:disable Style/MixinUsage
 
-rails_root = ENV["RAILS_ROOT"] || File.dirname(__FILE__) + "/../../.."
-rails_env = ENV["RAILS_ENV"] || "development"
+rails_root = ENV["RAILS_ROOT"] || "#{File.dirname(__FILE__)}/../../.."
+rails_env = (ENV["RAILS_ENV"] || "development").to_sym
 
-unless ENV["CI"]
-  if rails_env == "test" && !ENV["DOCKER"]
-    # https://gist.github.com/441072
-    start_redis!(rails_root, :cucumber)
-  end
-end
+# https://gist.github.com/441072
+start_redis!(rails_root, :cucumber) if rails_env == "test" && !(ENV["CI"] || ENV["DOCKER"])
 
-redis_configs = YAML.load_file(rails_root + '/config/redis.yml')
+redis_configs = YAML.load_file("#{rails_root}/config/redis.yml", symbolize_names: true)
 redis_configs.each_pair do |name, redis_config|
-  redis_host, redis_port = redis_config[rails_env].split(":")
-  redis_connection = Redis.new(host: redis_host, port: redis_port)
-  if ENV['DEV_USER']
-    namespaced_redis = Redis::Namespace.new(ENV['DEV_USER'], redis: redis_connection)
+  redis_options = {}
+  if redis_config[rails_env].is_a?(Hash)
+    # example:
+    # redis_kudos:
+    #   development
+    #     sentinels:
+    #       - host: 127.0.0.1
+    #         port: 26379
+    #       - host: 127.0.0.1
+    #         port: 263780
+    redis_options = redis_config[rails_env]
+  else
+    redis_host, redis_port = redis_config[rails_env].split(":")
+    redis_options[:host] = redis_host
+    redis_options[:port] = redis_port
+  end
+  redis_connection = Redis.new(redis_options)
+  if ENV["DEV_USER"]
+    namespaced_redis = Redis::Namespace.new(ENV["DEV_USER"], redis: redis_connection)
     redis_connection = namespaced_redis
   end
   Object.const_set(name.upcase, redis_connection)

--- a/config/initializers/gem-plugin_config/redis.rb
+++ b/config/initializers/gem-plugin_config/redis.rb
@@ -14,11 +14,12 @@ redis_configs.each_pair do |name, redis_config|
     # example:
     # redis_kudos:
     #   development
+    #     name: redis_kudos
     #     sentinels:
     #       - host: 127.0.0.1
     #         port: 26379
     #       - host: 127.0.0.1
-    #         port: 263780
+    #         port: 26380
     redis_options = redis_config[rails_env]
   else
     redis_host, redis_port = redis_config[rails_env].split(":")

--- a/config/initializers/gem-plugin_config/resque.rb
+++ b/config/initializers/gem-plugin_config/resque.rb
@@ -1,14 +1,14 @@
-require 'resque'
+require "resque"
 
-rails_root = ENV["RAILS_ROOT"] || File.dirname(__FILE__) + "/../../.."
-rails_env = ENV["RAILS_ENV"] || "development"
+rails_root = ENV["RAILS_ROOT"] || "#{File.dirname(__FILE__)}/../../.."
+rails_env = (ENV["RAILS_ENV"] || "development").to_sym
 
- redis_configs = YAML.load_file(rails_root + '/config/redis.yml')
- Resque.redis = redis_configs['redis_resque'][rails_env]
+redis_configs = YAML.load_file("#{rails_root}/config/redis.yml", symbolize_names: true)
+Resque.redis = redis_configs[:redis_resque][rails_env]
 
- # in-process performing of jobs (for testing) doesn't require a redis server
- Resque.inline = ENV['RAILS_ENV'] == "test"
+# in-process performing of jobs (for testing) doesn't require a redis server
+Resque.inline = ENV["RAILS_ENV"] == "test"
 
- Resque.after_fork do
-   Resque.redis.client.reconnect
- end
+Resque.after_fork do
+  Resque.redis.client.reconnect
+end


### PR DESCRIPTION
# Pull Request Checklist

* [X] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [X] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [X] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [X] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [X] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-6706

## Purpose

With some work I've done (and will do after this is merged) on the systems side, this will let us use Redis Sentinel to support automatic failovers when one Redis server becomes unavailable. This is better for High Availability and situations where we need to upgrade software/hardware.

For reviewers: I'd recommend turning whitespace diff off, since I made changes there to satisfy Rubocop.

## Credit

Brian Austin (they/he)