### PR TITLE
AO3-5351 Make remaining text in feedback response i18n-able

### DIFF
--- a/app/views/user_mailer/feedback.html.erb
+++ b/app/views/user_mailer/feedback.html.erb
@@ -8,20 +8,11 @@
     <% end %>
   </p>
 
-  <p>
-    We're working hard to reply to everyone, and we'll respond to you as soon as we can.
-    Your communication is greatly valued, and it will be reviewed and
-    answered by our volunteer Support team. In the meantime, here is a copy of
-    the information you submitted through the Technical Support and Feedback
-    form:
-  </p>
+  <p><%= t(".introduction") %></p>
 
   <%= style_quote("<b>#{raw(strip_images(@summary))}</b> #{raw(strip_images(@comment))}") %>
 
-  <p>
-    If you have additional questions or information, do not hesitate to send in
-    another ticket.
-  </p>
+  <p><%= t(".additional_ticket") %></p>
 
   <p>
     <%= t("mailer.general.closing.formal") %><br/>

--- a/app/views/user_mailer/feedback.text.erb
+++ b/app/views/user_mailer/feedback.text.erb
@@ -6,10 +6,7 @@
 <%= t("mailer.general.greeting.informal.unaddressed") %>
 <% end %>
 
-We're working hard to reply to everyone, and we'll respond to you as soon as we can.
-Your communication is greatly valued, and it will be reviewed and answered
-by our volunteer Support team. In the meantime, here is a copy of the
-information you submitted through the Technical Support and Feedback form:
+<%= t(".introduction") %>
 
 <%= text_divider %>
 
@@ -18,8 +15,7 @@ information you submitted through the Technical Support and Feedback form:
 
 <%= text_divider %>
 
-If you have additional questions or information, do not hesitate to send in
-another ticket.
+<%= t(".additional_ticket") %>
 
 <%= t("mailer.general.closing.formal") %>
 <%= t("mailer.general.signature.support") %>

--- a/config/locales/mailers/en.yml
+++ b/config/locales/mailers/en.yml
@@ -308,6 +308,9 @@ en:
         text: If you have questions, please %{support} (%{url}).
       subject: "[%{app_name}] Your work has been deleted"
       support: contact Support
+    feedback:
+      additional_ticket: If you have additional questions or information, do not hesitate to send in another ticket.
+      introduction: 'We''re working hard to reply to everyone, and we''ll respond to you as soon as we can. Your communication is greatly valued, and it will be reviewed and answered by our volunteer Support team. In the meantime, here is a copy of the information you submitted through the Technical Support and Feedback form:'
     invitation:
       been_invited: You've been invited to join the Archive of Our Own!
       features: With an account, you can post fanworks, use bookmarks to keep track of works you enjoyed, receive subscription emails when your favorite creators or works update, customize the way the site looks for you, and more!

--- a/features/other_b/support.feature
+++ b/features/other_b/support.feature
@@ -16,7 +16,8 @@ Feature: Filing a support request
     And I press "Send"
   Then I should see "Your message was sent to the Archive team - thank you!"
     And 1 email should be delivered
-    And the email should contain "We're working hard to reply to everyone, and we'll respond to you as soon as we can."
+    And the email should contain "working hard to reply to everyone"
+    And the email should contain "respond to you as soon as we can."
     And the email should contain "If you have additional questions or information"
     And the email should contain "Sent at Mon, 14 Mar 2022 12:00:00 \+0000"
   When I follow "Support & Feedback"

--- a/features/step_definitions/email_steps.rb
+++ b/features/step_definitions/email_steps.rb
@@ -64,7 +64,7 @@ end
 Then(/^#{capture_email} should contain "(.*)"$/) do |email_ref, text|
   if email(email_ref).multipart?
     email(email_ref).text_part.body.should =~ /#{text}/
-    email(email_ref).html_part.body.should =~ /#{CGI::escapeHTML(text)}/
+    email(email_ref).html_part.body.should =~ /#{text}/
   else
     email(email_ref).body.should =~ /#{text}/
   end

--- a/features/step_definitions/email_steps.rb
+++ b/features/step_definitions/email_steps.rb
@@ -64,7 +64,7 @@ end
 Then(/^#{capture_email} should contain "(.*)"$/) do |email_ref, text|
   if email(email_ref).multipart?
     email(email_ref).text_part.body.should =~ /#{text}/
-    email(email_ref).html_part.body.should =~ /#{text}/
+    email(email_ref).html_part.body.should =~ /#{CGI::escapeHTML(text)}/
   else
     email(email_ref).body.should =~ /#{text}/
   end

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -703,6 +703,7 @@ describe UserMailer do
 
       # Test both body contents
       it_behaves_like "a multipart email"
+      it_behaves_like "a translated email"
 
       describe "HTML version" do
         it "has the correct content" do
@@ -734,6 +735,7 @@ describe UserMailer do
 
       # Test both body contents
       it_behaves_like "a multipart email"
+      it_behaves_like "a translated email"
 
       describe "HTML version" do
         it "has the correct content" do

--- a/test/mailers/previews/user_mailer_preview.rb
+++ b/test/mailers/previews/user_mailer_preview.rb
@@ -24,7 +24,7 @@ class UserMailerPreview < ApplicationMailerPreview
   end
 
   # Sent to a user when the submit a support request (AKA feedback)
-  def feedback_response
+  def feedback
     feedback = create(:feedback)
     UserMailer.feedback(feedback.id)
   end


### PR DESCRIPTION
# Pull Request Checklist

* [X] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [X] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [X] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [X] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [X] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-5351

## Purpose

I18n-ising the remaining text in the feedback (support ticket) response emails. I didn't add a preview since I did that already in #4772.

## Credit

Brian Austin (they/he)