### PR TITLE
AO3-6708 Add indices to owned set taggings

### DIFF
--- a/db/migrate/20240404183910_add_indices_to_owned_set_taggings.rb
+++ b/db/migrate/20240404183910_add_indices_to_owned_set_taggings.rb
@@ -1,0 +1,10 @@
+class AddIndicesToOwnedSetTaggings < ActiveRecord::Migration[6.1]
+  def change
+    change_table :owned_set_taggings do |t|
+      t.index :owned_tag_set_id
+      t.index [:set_taggable_id, :set_taggable_type, :owned_tag_set_id],
+              name: :index_owned_set_taggings_on_set_taggable_and_tag_set,
+              unique: true
+    end
+  end
+end


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6708

## Purpose

Add two indices to the `owned_set_taggings` table. One index on `owned_tag_set_id` and one unique index on `set_taggable_id`, `set_taggable_type`, `owned_tag_set_id`.

## Testing Instructions

See Jira.

## Credit
Bilka (he/him)
