### PR TITLE
AO3-6087 Stop removing non-printable Unicode characters

### DIFF
--- a/lib/html_cleaner.rb
+++ b/lib/html_cleaner.rb
@@ -34,11 +34,6 @@ module HtmlCleaner
     # argh, get rid of ____spacer____ inserts
     text.gsub! "____spacer____", ""
 
-    # trash a whole bunch of crappy non-printing format characters stuck
-    # in most commonly by MS Word
-    # \p{Cf} matches all unicode char in the "other, format" category
-    text.gsub!(/\p{Cf}/u, '')
-
     return text
   end
 

--- a/spec/lib/html_cleaner_spec.rb
+++ b/spec/lib/html_cleaner_spec.rb
@@ -524,6 +524,21 @@ describe HtmlCleaner do
       expect(fix_bad_characters("„‚nörmäl’—téxt‘“")).to eq("„‚nörmäl’—téxt‘“")
     end
 
+    it "should not touch zero-width non-joiner" do
+      string = ["A".ord, 0x200C, "A".ord]  # "A[zwnj]A"
+      expect(fix_bad_characters(string.pack("U*")).unpack("U*")).to eq(string)
+    end
+
+    it "should not touch zero-width joiner" do
+      string = ["A".ord, 0x200D, "A".ord]  # "A[zwj]A"
+      expect(fix_bad_characters(string.pack("U*")).unpack("U*")).to eq(string)
+    end
+
+    it "should not touch word joiner" do
+      string = ["A".ord, 0x2060, "A".ord]  # "A[wj]A"
+      expect(fix_bad_characters(string.pack("U*")).unpack("U*")).to eq(string)
+    end
+
     it "should remove invalid unicode chars" do
       bad_string = [65, 150, 65].pack("C*")  # => "A\226A"
       expect(fix_bad_characters(bad_string)).to eq("AA")
@@ -539,10 +554,6 @@ describe HtmlCleaner do
 
     it "should remove the spacer" do
       expect(fix_bad_characters("A____spacer____A")).to eq("AA")
-    end
-
-    it "should remove unicode chars in the 'other, format' category" do
-      expect(fix_bad_characters("A\xE2\x81\xA0A")).to eq("AA")
     end
   end
 

--- a/spec/lib/html_cleaner_spec.rb
+++ b/spec/lib/html_cleaner_spec.rb
@@ -524,17 +524,17 @@ describe HtmlCleaner do
       expect(fix_bad_characters("„‚nörmäl’—téxt‘“")).to eq("„‚nörmäl’—téxt‘“")
     end
 
-    it "should not touch zero-width non-joiner" do
+    it "does not touch zero-width non-joiner" do
       string = ["A".ord, 0x200C, "A".ord]  # "A[zwnj]A"
       expect(fix_bad_characters(string.pack("U*")).unpack("U*")).to eq(string)
     end
 
-    it "should not touch zero-width joiner" do
+    it "does not touch zero-width joiner" do
       string = ["A".ord, 0x200D, "A".ord]  # "A[zwj]A"
       expect(fix_bad_characters(string.pack("U*")).unpack("U*")).to eq(string)
     end
 
-    it "should not touch word joiner" do
+    it "does not touch word joiner" do
       string = ["A".ord, 0x2060, "A".ord]  # "A[wj]A"
       expect(fix_bad_characters(string.pack("U*")).unpack("U*")).to eq(string)
     end


### PR DESCRIPTION
* [x] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [x] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [x] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [x] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-6087

## Purpose

This will retain non-printable characters entered by the user in various places including the chapter text, comment, etc. They are necessary for representing characters in some languages.

Apparently the special characters caused problems to the parser in the past. While the details are unclear, we tentatively believe that is not the case any more.

## Testing Instructions

Try entering text with zero-width joiner, zero-width non-joiner, and word joiner into the main text of a work, or into a comment. They should remain.

## References

I believe this will also affect emojis with gender variants (and maybe other variants), as reported in https://old.reddit.com/r/AO3/comments/1cbpoh8/commenting_issue/ .

## Credit

Potpotkettle (they/them)
