### PR TITLE
AO3-6719 Leave src URLs instead of emptiness for images stripped in AO3-6564

### DIFF
--- a/app/helpers/comments_helper.rb
+++ b/app/helpers/comments_helper.rb
@@ -47,6 +47,10 @@ module CommentsHelper
     end
   end
 
+  def image_safety_mode_cache_key(comment)
+    "image-safety-mode" if comment.use_image_safety_mode?
+  end
+
   ####
   ## Mar 4 2009 Enigel: the below shouldn't happen anymore, please test
   ####

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -495,7 +495,11 @@ class Comment < ApplicationRecord
   end
 
   def sanitized_content
-    sanitize_field(self, :comment_content, image_safety_mode: ultimate_parent.is_a?(AdminPost))
+    sanitize_field(self, :comment_content, image_safety_mode: use_image_safety_mode?)
+  end
+
+  def use_image_safety_mode?
+    parent_type.in?(ArchiveConfig.PARENTS_WITH_IMAGE_SAFETY_MODE)
   end
   include Responder
 end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -495,7 +495,7 @@ class Comment < ApplicationRecord
   end
 
   def sanitized_content
-    sanitize_field(self, :comment_content, strip_images: ultimate_parent.is_a?(AdminPost))
+    sanitize_field(self, :comment_content, image_saftey_mode: ultimate_parent.is_a?(AdminPost))
   end
   include Responder
 end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -495,7 +495,7 @@ class Comment < ApplicationRecord
   end
 
   def sanitized_content
-    sanitize_field(self, :comment_content, image_saftey_mode: ultimate_parent.is_a?(AdminPost))
+    sanitize_field(self, :comment_content, image_safety_mode: ultimate_parent.is_a?(AdminPost))
   end
   include Responder
 end

--- a/app/models/feedback_reporters/abuse_reporter.rb
+++ b/app/models/feedback_reporters/abuse_reporter.rb
@@ -32,6 +32,6 @@ class AbuseReporter < FeedbackReporter
   def ticket_description
     return "No comment submitted." if description.blank?
 
-    strip_images(description.html_safe)
+    strip_images(description.html_safe, keep_src: true)
   end
 end

--- a/app/models/feedback_reporters/support_reporter.rb
+++ b/app/models/feedback_reporters/support_reporter.rb
@@ -33,6 +33,6 @@ class SupportReporter < FeedbackReporter
   def ticket_description
     return "No description submitted." if description.blank?
 
-    strip_images(description.html_safe)
+    strip_images(description.html_safe, keep_src: true)
   end
 end

--- a/app/views/admin/banners/_banner.html.erb
+++ b/app/views/admin/banners/_banner.html.erb
@@ -2,6 +2,6 @@
 <% # don't forget to update layouts/banner! %>
 <div class="<%= admin_banner.banner_type %> announcement group">
   <blockquote class="userstuff">
-    <%= raw sanitize_field(admin_banner, :content, image_saftey_mode: true) %>
+    <%= raw sanitize_field(admin_banner, :content, image_safety_mode: true) %>
   </blockquote>
 </div>

--- a/app/views/admin/banners/_banner.html.erb
+++ b/app/views/admin/banners/_banner.html.erb
@@ -2,6 +2,6 @@
 <% # don't forget to update layouts/banner! %>
 <div class="<%= admin_banner.banner_type %> announcement group">
   <blockquote class="userstuff">
-    <%= raw sanitize_field(admin_banner, :content, strip_images: true) %>
+    <%= raw sanitize_field(admin_banner, :content, image_saftey_mode: true) %>
   </blockquote>
 </div>

--- a/app/views/bookmarks/_bookmark_blurb_short.html.erb
+++ b/app/views/bookmarks/_bookmark_blurb_short.html.erb
@@ -31,7 +31,7 @@
   <% if bookmark.bookmarker_notes.present? %>
     <h6 class="landmark heading"><%= ts("Bookmark Notes:") %></h6>
     <blockquote class="userstuff summary">
-      <%= raw sanitize_field(bookmark, :bookmarker_notes, strip_images: true) %>
+      <%= raw sanitize_field(bookmark, :bookmarker_notes, image_saftey_mode: true) %>
     </blockquote>
   <% end %>
   <!--actions-->

--- a/app/views/bookmarks/_bookmark_blurb_short.html.erb
+++ b/app/views/bookmarks/_bookmark_blurb_short.html.erb
@@ -31,7 +31,7 @@
   <% if bookmark.bookmarker_notes.present? %>
     <h6 class="landmark heading"><%= ts("Bookmark Notes:") %></h6>
     <blockquote class="userstuff summary">
-      <%= raw sanitize_field(bookmark, :bookmarker_notes, image_saftey_mode: true) %>
+      <%= raw sanitize_field(bookmark, :bookmarker_notes, image_safety_mode: true) %>
     </blockquote>
   <% end %>
   <!--actions-->

--- a/app/views/bookmarks/_bookmark_user_module.html.erb
+++ b/app/views/bookmarks/_bookmark_user_module.html.erb
@@ -48,7 +48,7 @@
     <% if bookmark.bookmarker_notes.present? %>
       <h6 class="landmark heading"><%= ts('Bookmarker\'s Notes') %></h6>
       <blockquote class="userstuff notes">
-        <%= raw sanitize_field(bookmark, :bookmarker_notes, image_saftey_mode: true) %>
+        <%= raw sanitize_field(bookmark, :bookmarker_notes, image_safety_mode: true) %>
       </blockquote>
     <% end %>
     <% # end of information added by the bookmark owner %>

--- a/app/views/bookmarks/_bookmark_user_module.html.erb
+++ b/app/views/bookmarks/_bookmark_user_module.html.erb
@@ -48,7 +48,7 @@
     <% if bookmark.bookmarker_notes.present? %>
       <h6 class="landmark heading"><%= ts('Bookmarker\'s Notes') %></h6>
       <blockquote class="userstuff notes">
-        <%= raw sanitize_field(bookmark, :bookmarker_notes, strip_images: true) %>
+        <%= raw sanitize_field(bookmark, :bookmarker_notes, image_saftey_mode: true) %>
       </blockquote>
     <% end %>
     <% # end of information added by the bookmark owner %>

--- a/app/views/comments/_single_comment.html.erb
+++ b/app/views/comments/_single_comment.html.erb
@@ -56,7 +56,7 @@
           <p class="notice"><%= ts("This comment has been hidden by an admin.") %></p>
         <% end %>
         <blockquote class="userstuff">
-          <%= raw sanitize_field(single_comment, :comment_content, strip_images: single_comment.ultimate_parent.is_a?(AdminPost)) %>
+          <%= raw sanitize_field(single_comment, :comment_content, image_saftey_mode: single_comment.ultimate_parent.is_a?(AdminPost)) %>
         </blockquote>
       <% end %>
       <% if single_comment.edited_at.present? %>

--- a/app/views/comments/_single_comment.html.erb
+++ b/app/views/comments/_single_comment.html.erb
@@ -56,7 +56,7 @@
           <p class="notice"><%= ts("This comment has been hidden by an admin.") %></p>
         <% end %>
         <blockquote class="userstuff">
-          <%= raw sanitize_field(single_comment, :comment_content, image_safety_mode: single_comment.ultimate_parent.is_a?(AdminPost)) %>
+          <%= raw sanitize_field(single_comment, :comment_content, image_safety_mode: single_comment.use_image_safety_mode?) %>
         </blockquote>
       <% end %>
       <% if single_comment.edited_at.present? %>

--- a/app/views/comments/_single_comment.html.erb
+++ b/app/views/comments/_single_comment.html.erb
@@ -56,7 +56,7 @@
           <p class="notice"><%= ts("This comment has been hidden by an admin.") %></p>
         <% end %>
         <blockquote class="userstuff">
-          <%= raw sanitize_field(single_comment, :comment_content, image_saftey_mode: single_comment.ultimate_parent.is_a?(AdminPost)) %>
+          <%= raw sanitize_field(single_comment, :comment_content, image_safety_mode: single_comment.ultimate_parent.is_a?(AdminPost)) %>
         </blockquote>
       <% end %>
       <% if single_comment.edited_at.present? %>

--- a/app/views/comments/_single_comment.html.erb
+++ b/app/views/comments/_single_comment.html.erb
@@ -37,8 +37,7 @@
           <%= time_in_zone(single_comment.created_at) %>
         </span>
       </h4>
-      <% image_safety_mode_key = single_comment.use_image_safety_mode? ? "-image-safety-mode" : "" %>
-      <% cache([single_comment, single_comment.comment_owner, "body", image_safety_mode_key], expires_in: 1.week) do %>
+      <% cache([single_comment, single_comment.comment_owner, "body", image_safety_mode_cache_key(single_comment)], expires_in: 1.week) do %>
         <div class="icon">
           <% if !single_comment.pseud.nil? %>
             <% if single_comment.by_anonymous_creator? %>

--- a/app/views/comments/_single_comment.html.erb
+++ b/app/views/comments/_single_comment.html.erb
@@ -37,7 +37,8 @@
           <%= time_in_zone(single_comment.created_at) %>
         </span>
       </h4>
-      <% cache([single_comment, single_comment.comment_owner, "body"], expires_in: 1.week) do %>
+      <% image_safety_mode_key = single_comment.use_image_safety_mode? ? "-image-safety-mode" : "" %>
+      <% cache([single_comment, single_comment.comment_owner, "body", image_safety_mode_key], expires_in: 1.week) do %>
         <div class="icon">
           <% if !single_comment.pseud.nil? %>
             <% if single_comment.by_anonymous_creator? %>

--- a/app/views/inbox/_inbox_comment_contents.html.erb
+++ b/app/views/inbox/_inbox_comment_contents.html.erb
@@ -27,5 +27,5 @@
 </div>
 
 <blockquote class="userstuff">
-  <%= raw sanitize_field(feedback_comment, :comment_content, strip_images: feedback_comment.ultimate_parent.is_a?(AdminPost)) %>
+  <%= raw sanitize_field(feedback_comment, :comment_content, image_saftey_mode: feedback_comment.ultimate_parent.is_a?(AdminPost)) %>
 </blockquote>

--- a/app/views/inbox/_inbox_comment_contents.html.erb
+++ b/app/views/inbox/_inbox_comment_contents.html.erb
@@ -27,5 +27,5 @@
 </div>
 
 <blockquote class="userstuff">
-  <%= raw sanitize_field(feedback_comment, :comment_content, image_safety_mode: feedback_comment.ultimate_parent.is_a?(AdminPost)) %>
+  <%= raw sanitize_field(feedback_comment, :comment_content, image_safety_mode: feedback_comment.use_image_safety_mode?) %>
 </blockquote>

--- a/app/views/inbox/_inbox_comment_contents.html.erb
+++ b/app/views/inbox/_inbox_comment_contents.html.erb
@@ -27,5 +27,5 @@
 </div>
 
 <blockquote class="userstuff">
-  <%= raw sanitize_field(feedback_comment, :comment_content, image_saftey_mode: feedback_comment.ultimate_parent.is_a?(AdminPost)) %>
+  <%= raw sanitize_field(feedback_comment, :comment_content, image_safety_mode: feedback_comment.ultimate_parent.is_a?(AdminPost)) %>
 </blockquote>

--- a/app/views/layouts/_banner.html.erb
+++ b/app/views/layouts/_banner.html.erb
@@ -2,7 +2,7 @@
   <% unless session[:hide_banner] || current_user&.preference&.banner_seen %>
     <div class="<%= @admin_banner.banner_type %> announcement group" id="admin-banner">
       <blockquote class="userstuff">
-        <%= raw sanitize_field(@admin_banner, :content, image_saftey_mode: true) %>
+        <%= raw sanitize_field(@admin_banner, :content, image_safety_mode: true) %>
       </blockquote>
       <% if current_user.nil? %>
         <p class="submit">

--- a/app/views/layouts/_banner.html.erb
+++ b/app/views/layouts/_banner.html.erb
@@ -2,7 +2,7 @@
   <% unless session[:hide_banner] || current_user&.preference&.banner_seen %>
     <div class="<%= @admin_banner.banner_type %> announcement group" id="admin-banner">
       <blockquote class="userstuff">
-        <%= raw sanitize_field(@admin_banner, :content, strip_images: true) %>
+        <%= raw sanitize_field(@admin_banner, :content, image_saftey_mode: true) %>
       </blockquote>
       <% if current_user.nil? %>
         <p class="submit">

--- a/app/views/pseuds/_pseud_module.html.erb
+++ b/app/views/pseuds/_pseud_module.html.erb
@@ -17,6 +17,6 @@
 </div>
 <% if pseud.description.present? %>
   <blockquote class="userstuff">
-    <%= raw sanitize_field(pseud, :description, strip_images: true) %>
+    <%= raw sanitize_field(pseud, :description, image_saftey_mode: true) %>
   </blockquote>
 <% end %>

--- a/app/views/pseuds/_pseud_module.html.erb
+++ b/app/views/pseuds/_pseud_module.html.erb
@@ -17,6 +17,6 @@
 </div>
 <% if pseud.description.present? %>
   <blockquote class="userstuff">
-    <%= raw sanitize_field(pseud, :description, image_saftey_mode: true) %>
+    <%= raw sanitize_field(pseud, :description, image_safety_mode: true) %>
   </blockquote>
 <% end %>

--- a/app/views/share/_embed_meta_bookmark.erb
+++ b/app/views/share/_embed_meta_bookmark.erb
@@ -5,6 +5,6 @@
 <% end %>
 <% if bookmark.bookmarker_notes.present? %>
 <%= ts("Bookmarker's Notes: ").html_safe %>
-<%= raw sanitize_field(bookmark, :bookmarker_notes, image_saftey_mode: true) %>
+<%= raw sanitize_field(bookmark, :bookmarker_notes, image_safety_mode: true) %>
 <% end %>
 <% end %>

--- a/app/views/share/_embed_meta_bookmark.erb
+++ b/app/views/share/_embed_meta_bookmark.erb
@@ -5,6 +5,6 @@
 <% end %>
 <% if bookmark.bookmarker_notes.present? %>
 <%= ts("Bookmarker's Notes: ").html_safe %>
-<%= raw sanitize_field(bookmark, :bookmarker_notes, strip_images: true) %>
+<%= raw sanitize_field(bookmark, :bookmarker_notes, image_saftey_mode: true) %>
 <% end %>
 <% end %>

--- a/app/views/user_mailer/abuse_report.html.erb
+++ b/app/views/user_mailer/abuse_report.html.erb
@@ -26,7 +26,7 @@
   </p>
 
   <p><%= style_work_metadata_label(t(".copy.comment")) %></p>
-  <p><%= style_quote(raw(strip_images(@comment))) %></p>
+  <p><%= style_quote(raw(strip_images(@comment, keep_src: true))) %></p>
 
   <p><%= t(".thank_you") %></p>
 

--- a/app/views/user_mailer/abuse_report.text.erb
+++ b/app/views/user_mailer/abuse_report.text.erb
@@ -20,7 +20,7 @@
 <%= to_plain_text(raw @summary) %>
 
 <%= work_metadata_label(t(".copy.comment")) %>
-<%= to_plain_text(raw @comment) %>
+<%= to_plain_text(raw(strip_images(@comment, keep_src: true))) %>
 
 <%= text_divider %>
 

--- a/app/views/user_mailer/feedback.html.erb
+++ b/app/views/user_mailer/feedback.html.erb
@@ -16,7 +16,7 @@
     form:
   </p>
 
-  <%= style_quote("<b>#{raw(strip_images(@summary))}</b> #{raw(strip_images(@comment))}") %>
+  <%= style_quote("<b>#{raw(strip_images(@summary))}</b> #{raw(strip_images(@comment, keep_src: true))}") %>
 
   <p>
     If you have additional questions or information, do not hesitate to send in

--- a/app/views/user_mailer/feedback.text.erb
+++ b/app/views/user_mailer/feedback.text.erb
@@ -14,7 +14,7 @@ information you submitted through the Technical Support and Feedback form:
 <%= text_divider %>
 
 * <%= to_plain_text(raw @summary) %> *
-<%= to_plain_text(raw @comment) %>
+<%= to_plain_text(raw(strip_images(@comment, keep_src: true))) %>
 
 <%= text_divider %>
 

--- a/config/config.yml
+++ b/config/config.yml
@@ -292,6 +292,12 @@ NONZERO_INTEGER_PARAMETERS:
   page: 1
   per_page: 25
 
+# Enable image safety mode when sanitizing comments on the following parents for
+# display. This is the parent_type of the comment, not the ultimate_parent,
+# so if you want to add extra sanitization to work comments, use Chapter here.
+# Options: AdminPost, Chapter, Tag.
+PARENTS_WITH_IMAGE_SAFETY_MODE: []
+
 # These fields are encrypted and should not have characters escaped or be treated as HTML
 FIELDS_WITHOUT_SANITIZATION: ["password", "password_check", "password_confirmation"]
 

--- a/features/comments_and_kudos/add_comment.feature
+++ b/features/comments_and_kudos/add_comment.feature
@@ -180,17 +180,6 @@ Scenario: Set preference and receive comment notifications of your own comments
     And "commenter" should be emailed
     And 1 email should be delivered to "commenter"
 
-Scenario: Work comment displays images
-
-  Given the work "Generic Work"
-    And I am logged in as "commenter"
-    And I visit the new comment page for the work "Generic Work"
-  When I fill in "Comment" with "Fantastic!<img src='http://example.com/icon.svg'>"
-    And I press "Comment"
-  Then I should see "Comment created!"
-    And I should see "Fantastic!"
-    And I should see the image "src" text "http://example.com/icon.svg"
-
 Scenario: Try to post a comment with a < angle bracket before a linebreak, without a space before the bracket
 
     Given the work "Generic Work"

--- a/features/comments_and_kudos/comments_adminposts.feature
+++ b/features/comments_and_kudos/comments_adminposts.feature
@@ -135,14 +135,3 @@ Feature: Commenting on admin posts
     When I follow "Edit Post"
     Then I should see "No one can comment"
     # TODO: Test that the other options aren't available/selected in a non-brittle way
-
-  Scenario: Admin post comment does not display images
-    Given I have posted an admin post
-      And I am logged in as "regular"
-      And I go to the admin-posts page
-      And I follow "Default Admin Post"
-    When I fill in "Comment" with "Hi!<img src='http://example.com/icon.svg'>"
-      And I press "Comment"
-    Then I should see "Comment created!"
-      And I should not see the image "src" text "http://example.com/icon.svg"
-      And I should see "Hi!"

--- a/features/comments_and_kudos/image_safety_mode.feature
+++ b/features/comments_and_kudos/image_safety_mode.feature
@@ -8,12 +8,20 @@ Feature: Image safety mode
       And image safety mode is disabled for comments
     When I view <commentable> with comments
     Then I should see the image "src" text "https://example.com/image.jpg"
+      And I should not see "OMG! https://example.com/image.jpg"
     When I go to the homepage
     Then I should see the image "src" text "https://example.com/image.jpg"
+      And I should not see "OMG! https://example.com/image.jpg"
     When I go to my inbox page
     Then I should see the image "src" text "https://example.com/image.jpg"
     When image safety mode is enabled for comments on a "<parent_type>"
       And I view <commentable> with comments
+    Then I should not see the image "src" text "https://example.com/image.jpg"
+      But I should see "OMG! https://example.com/image.jpg"
+    When I go to the homepage
+    Then I should not see the image "src" text "https://example.com/image.jpg"
+      But I should see "OMG! https://example.com/image.jpg"
+    When I go to my inbox page
     Then I should not see the image "src" text "https://example.com/image.jpg"
       But I should see "OMG! https://example.com/image.jpg"
 
@@ -38,7 +46,13 @@ Feature: Image safety mode
     When image safety mode is disabled for comments
       And I view <commentable> with comments
     Then I should see the image "src" text "https://example.com/image.jpg"
-      But I should not see "OMG! https://example.com/image.jpg"
+      And I should not see "OMG! https://example.com/image.jpg"
+    When I go to the homepage
+    Then I should see the image "src" text "https://example.com/image.jpg"
+      And I should not see "OMG! https://example.com/image.jpg"
+    When I go to my inbox page
+    Then I should see the image "src" text "https://example.com/image.jpg"
+      And I should not see "OMG! https://example.com/image.jpg"
 
     Examples:
       | parent_type | commentable                 |

--- a/features/comments_and_kudos/image_safety_mode.feature
+++ b/features/comments_and_kudos/image_safety_mode.feature
@@ -1,0 +1,48 @@
+Feature: Image safety mode
+  In order to protect users
+  As a site owner
+  I'd like to control which comments can include images
+
+  Scenario Outline: Images are embedded in comments when image safety mode is off.
+    Given the setup for testing image safety mode on <commentable>
+      And image safety mode is disabled for comments
+    When I view <commentable> with comments
+    Then I should see the image "src" text "https://example.com/image.jpg"
+    When I go to the homepage
+    Then I should see the image "src" text "https://example.com/image.jpg"
+    When I go to my inbox page
+    Then I should see the image "src" text "https://example.com/image.jpg"
+    When image safety mode is enabled for comments on a "<parent_type>"
+      And I view <commentable> with comments
+    Then I should not see the image "src" text "https://example.com/image.jpg"
+      But I should see "OMG! https://example.com/image.jpg"
+
+    Examples:
+      | commentable                 | parent_type |
+      | the admin post "Change Log" | AdminPost   |
+      | the work "My Opus"          | Chapter     |
+      | the tag "No Fandom"         | Tag         |
+
+  Scenario Outline: Embedded images in comments are replaced with their URLs when image safety mode is enabled.
+    Given the setup for testing image safety mode on <commentable>
+      And image safety mode is enabled for comments on a "<parent_type>"
+    When I view <commentable> with comments
+    Then I should not see the image "src" text "https://example.com/image.jpg"
+      But I should see "OMG! https://example.com/image.jpg"
+    When I go to the homepage
+    Then I should not see the image "src" text "https://example.com/image.jpg"
+      But I should see "OMG! https://example.com/image.jpg"
+    When I go to my inbox page
+    Then I should not see the image "src" text "https://example.com/image.jpg"
+      But I should see "OMG! https://example.com/image.jpg"
+    When image safety mode is disabled for comments
+      And I view <commentable> with comments
+    Then I should see the image "src" text "https://example.com/image.jpg"
+      But I should not see "OMG! https://example.com/image.jpg"
+
+    Examples:
+      | parent_type | commentable                 |
+      | AdminPost   | the admin post "Change Log" |
+      | Chapter     | the work "My Opus"          |
+      | Tag         | the tag "No Fandom"         |
+

--- a/features/comments_and_kudos/inbox.feature
+++ b/features/comments_and_kudos/inbox.feature
@@ -168,3 +168,4 @@ Feature: Get messages in the inbox
       And I go to the homepage
     Then I should see "My reply"
       And I should not see "<img src='foo.jpg' />"
+      But I should see "foo.jpg"

--- a/features/comments_and_kudos/inbox.feature
+++ b/features/comments_and_kudos/inbox.feature
@@ -163,9 +163,9 @@ Feature: Get messages in the inbox
   Scenario: Reply to a comment on an admin post that contains an image
     Given I have posted an admin post
       And a comment "My comment" by "sewwiththeflo" on the admin post "Default Admin Post"
-      And a reply "My reply <img src='foo.jpg' />" by "unbeatablesg" on the admin post "Default Admin Post"
+      And a reply "My reply <img src=\"foo.jpg\" />" by "unbeatablesg" on the admin post "Default Admin Post"
     When I am logged in as "sewwiththeflo"
       And I go to the homepage
     Then I should see "My reply"
-      And I should not see "<img src='foo.jpg' />"
-      But I should see "foo.jpg"
+      And I should not see the image "src" text "foo.jpg"
+      But I should see "My reply foo.jpg"

--- a/features/comments_and_kudos/inbox.feature
+++ b/features/comments_and_kudos/inbox.feature
@@ -159,13 +159,3 @@ Feature: Get messages in the inbox
       And I go to the homepage
     Then I should see "sewwiththeflo on Cat Thor's Bizarre Adventure"
       And I should see "Thank you! Please go to bed."
-
-  Scenario: Reply to a comment on an admin post that contains an image
-    Given I have posted an admin post
-      And a comment "My comment" by "sewwiththeflo" on the admin post "Default Admin Post"
-      And a reply "My reply <img src=\"foo.jpg\" />" by "unbeatablesg" on the admin post "Default Admin Post"
-    When I am logged in as "sewwiththeflo"
-      And I go to the homepage
-    Then I should see "My reply"
-      And I should not see the image "src" text "foo.jpg"
-      But I should see "My reply foo.jpg"

--- a/features/other_a/abuse_report.feature
+++ b/features/other_a/abuse_report.feature
@@ -65,10 +65,13 @@ Feature: Filing an abuse report
   Given I am logged in as "otheruser"
     And basic languages
   When I follow "Policy Questions & Abuse Reports"
-    And I fill in "Description of the content you are reporting (required)" with "This is wrong"
-    And I fill in "Brief summary of Terms of Service violation (required)" with '<img src="foo.jpg" />Hi'
+    And I fill in "Brief summary of Terms of Service violation (required)" with '<img src="foo.jpg" />Gross'
+    And I fill in "Description of the content you are reporting (required)" with "This is wrong <img src='bar.jpeg' />"
     And I fill in "Link to the page you are reporting (required)" with "http://www.archiveofourown.org/works"
     And I press "Submit"
   Then 1 email should be delivered
-    And the email should not contain "<img src="foo.jpg" />"
-    But the email should contain "foo.jpg"
+    # The sanitizer adds the domain in front of relative image URLs as of AO3-6571
+    And the email should not contain "<img src="http://www.example.org/foo.jpg" />"
+    And the email should not contain "<img src="http://www.example.org/bar.jpeg" />"
+    But the email should contain "Gross"
+    And the email should contain "This is wrong http://www.example.org/bar.jpeg"

--- a/features/other_a/abuse_report.feature
+++ b/features/other_a/abuse_report.feature
@@ -71,3 +71,4 @@ Feature: Filing an abuse report
     And I press "Submit"
   Then 1 email should be delivered
     And the email should not contain "<img src="foo.jpg" />"
+    But the email should contain "foo.jpg"

--- a/features/other_b/support.feature
+++ b/features/other_b/support.feature
@@ -56,5 +56,6 @@ Feature: Filing a support request
     And I fill in "Your question or problem" with '<img src="foo.jpg" />Hi'
     And I press "Send"
   Then 1 email should be delivered
-    And the email should not contain "<img src="foo.jpg" />"
-    But the email should contain "foo.jpg"
+    # The sanitizer adds the domain in front of relative image URLs as of AO3-6571
+    And the email should not contain "<img src="http://www.example.org/foo.jpg" />"
+    But the email should contain "http://www.example.org/foo.jpgHi"

--- a/features/other_b/support.feature
+++ b/features/other_b/support.feature
@@ -57,3 +57,4 @@ Feature: Filing a support request
     And I press "Send"
   Then 1 email should be delivered
     And the email should not contain "<img src="foo.jpg" />"
+    But the email should contain "foo.jpg"

--- a/features/step_definitions/comment_steps.rb
+++ b/features/step_definitions/comment_steps.rb
@@ -73,7 +73,7 @@ Given "the setup for testing image safety mode on the admin post {string}" do |t
   visit comment_path(Comment.last)
   step %{I follow "Reply"}
   with_scope(".odd") do
-  # Use HTML that will get cleaned up by the sanitizer so we're sure it runs.
+    # Use HTML that will get cleaned up by the sanitizer so we're sure it runs.
     fill_in("comment[comment_content]", with: 'OMG! <img src= "https://example.com/image.jpg">')
     click_button("Comment")
   end
@@ -81,10 +81,10 @@ Given "the setup for testing image safety mode on the admin post {string}" do |t
 end
 
 Given "the setup for testing image safety mode on the tag {string}" do |name|
-  step %{the tag wrangler "commentrecip" with password "password" is wrangler of "No Fandom"}
+  step %{the tag wrangler "commentrecip" with password "password" is wrangler of "#{name}"}
   step %{the tag wrangler "commenter" with password "password" is wrangler of "Some Fandom"}
   step %{I am logged in as "commenter"}
-  visit tag_comments_path(Tag.find_by_name("No Fandom"))
+  visit tag_comments_path(Tag.find_by_name(name))
   # Use HTML that will get cleaned up by the sanitizer so we're sure it runs.
   fill_in("comment[comment_content]", with: 'OMG! <img src= "https://example.com/image.jpg">')
   click_button("Comment")

--- a/features/step_definitions/comment_steps.rb
+++ b/features/step_definitions/comment_steps.rb
@@ -58,6 +58,33 @@ Given "a reply {string} by {string} on {commentable}" do |text, user, commentabl
                     comment_content: text)
 end
 
+Given "image safety mode is enabled for comments on a {string}" do |parent_type|
+  allow(ArchiveConfig).to receive(:PARENTS_WITH_IMAGE_SAFETY_MODE).and_return(parent_type)
+end
+
+Given "image safety mode is disabled for comments" do
+  allow(ArchiveConfig).to receive(:PARENTS_WITH_IMAGE_SAFETY_MODE).and_return([])
+end
+
+Given "the setup for testing image safety mode on the admin post {string}" do |title|
+  step %{the admin post "#{title}"}
+  step %{a comment "plain text" by "commentrecip" on the admin post "#{title}"}
+  step %{a reply 'OMG! <img src="https://example.com/image.jpg">' by "commenter" on the admin post "#{title}"}
+  step %{I am logged in as "commentrecip"}
+end
+
+Given "the setup for testing image safety mode on the tag {string}" do |name|
+  step %{the tag wrangler "commentrecip" with password "password" is wrangler of "No Fandom"}
+  step %{a comment 'OMG! <img src="https://example.com/image.jpg">' by "commenter" on the tag "#{name}"}
+  step %{I am logged in as "commentrecip"}
+end
+
+Given "the setup for testing image safety mode on the work {string}" do |title|
+  step %{the work "#{title}" by "commentrecip"}
+  step %{a comment 'OMG! <img src="https://example.com/image.jpg">' by "commenter" on the work "#{title}"}
+  step %{I am logged in as "commentrecip"}
+end
+
 # THEN
 
 Then /^the comment's posted date should be nowish$/ do

--- a/features/step_definitions/comment_steps.rb
+++ b/features/step_definitions/comment_steps.rb
@@ -86,7 +86,7 @@ Given "the setup for testing image safety mode on the tag {string}" do |name|
   step %{I am logged in as "commenter"}
   visit tag_comments_path(Tag.find_by_name("No Fandom"))
   # Use HTML that will get cleaned up by the sanitizer so we're sure it runs.
-  fill_in("comment[comment_content]", with: 'OMG! <img src=\n"https://example.com/image.jpg">')
+  fill_in("comment[comment_content]", with: 'OMG! <img src= "https://example.com/image.jpg">')
   click_button("Comment")
   step %{I am logged in as "commentrecip"}
 end

--- a/features/step_definitions/comment_steps.rb
+++ b/features/step_definitions/comment_steps.rb
@@ -69,19 +69,35 @@ end
 Given "the setup for testing image safety mode on the admin post {string}" do |title|
   step %{the admin post "#{title}"}
   step %{a comment "plain text" by "commentrecip" on the admin post "#{title}"}
-  step %{a reply 'OMG! <img src="https://example.com/image.jpg">' by "commenter" on the admin post "#{title}"}
+  step %{I am logged in as "commenter"}
+  visit comment_path(Comment.last)
+  step %{I follow "Reply"}
+  with_scope(".odd") do
+  # Use HTML that will get cleaned up by the sanitizer so we're sure it runs.
+    fill_in("comment[comment_content]", with: 'OMG! <img src= "https://example.com/image.jpg">')
+    click_button("Comment")
+  end
   step %{I am logged in as "commentrecip"}
 end
 
 Given "the setup for testing image safety mode on the tag {string}" do |name|
   step %{the tag wrangler "commentrecip" with password "password" is wrangler of "No Fandom"}
-  step %{a comment 'OMG! <img src="https://example.com/image.jpg">' by "commenter" on the tag "#{name}"}
+  step %{the tag wrangler "commenter" with password "password" is wrangler of "Some Fandom"}
+  step %{I am logged in as "commenter"}
+  visit tag_comments_path(Tag.find_by_name("No Fandom"))
+  # Use HTML that will get cleaned up by the sanitizer so we're sure it runs.
+  fill_in("comment[comment_content]", with: 'OMG! <img src=\n"https://example.com/image.jpg">')
+  click_button("Comment")
   step %{I am logged in as "commentrecip"}
 end
 
 Given "the setup for testing image safety mode on the work {string}" do |title|
   step %{the work "#{title}" by "commentrecip"}
-  step %{a comment 'OMG! <img src="https://example.com/image.jpg">' by "commenter" on the work "#{title}"}
+  step %{I am logged in as "commenter"}
+  visit work_path(Work.find_by(title: title))
+  # Use HTML that will get cleaned up by the sanitizer so we're sure it runs.
+  fill_in("comment[comment_content]", with: 'OMG! <img src= "https://example.com/image.jpg">')
+  click_button("Comment")
   step %{I am logged in as "commentrecip"}
 end
 

--- a/lib/html_cleaner.rb
+++ b/lib/html_cleaner.rb
@@ -148,12 +148,12 @@ module HtmlCleaner
 
   # strip img tags, optionally leaving the src URL exposed
   def strip_images(value, keep_src: false)
-    value.gsub(%r{(<img .*?>)}) do |img_tag|
+    value.gsub(/(<img .*?>)/) do |img_tag|
       if keep_src
         # The cleaned field will always use double quotes (") but the fields
         # in tests aren't always cleaned, so we're allowing double or single
         # quotes here.
-        img_tag.match(%r{src=['"]([^"]+)['"]})[1]
+        img_tag.match(/src=['"]([^"]+)['"]/)[1]
       else
         ""
       end

--- a/lib/html_cleaner.rb
+++ b/lib/html_cleaner.rb
@@ -148,14 +148,16 @@ module HtmlCleaner
 
   # strip img tags, optionally leaving the src URL exposed
   def strip_images(value, keep_src: false)
-    value.gsub(/<img .*?>/, '')
-    #value.gsub(%r{(<img .*?>)}) do |img_tag|
-    #  if keep_src
-    #    img_tag.match(%r{src="([^"]+)"})[1]
-    #  else
-    #    ""
-    #  end
-    # end
+    value.gsub(%r{(<img .*?>)}) do |img_tag|
+      if keep_src
+        # The cleaned field will always use double quotes (") but the fields
+        # in tests aren't always cleaned, so we're allowing double or single
+        # quotes here.
+        img_tag.match(%r{src=['"]([^"]+)['"]})[1]
+      else
+        ""
+      end
+    end
   end
 
   def strip_html_breaks_simple(value)

--- a/lib/html_cleaner.rb
+++ b/lib/html_cleaner.rb
@@ -2,7 +2,9 @@
 module HtmlCleaner
   # If we aren't sure that this field hasn't been sanitized since the last sanitizer version,
   # we sanitize it before we allow it to pass through (and save it if possible).
-  def sanitize_field(object, fieldname, strip_images: false)
+  # For certain highly visible fields, we might want to be cautious about
+  # images. Use image_safety_mode: true to prevent images from embedding as-is.
+  def sanitize_field(object, fieldname, image_safety_mode: false)
     return "" if object.send(fieldname).nil?
 
     sanitizer_version = object.try("#{fieldname}_sanitizer_version")
@@ -15,7 +17,7 @@ module HtmlCleaner
         sanitize_value(fieldname, object.send(fieldname))
       end
 
-    sanitized_field = strip_images(sanitized_field) if strip_images
+    sanitized_field = strip_images(sanitized_field, keep_src: true) if image_safety_mode
     sanitized_field
   end
 
@@ -144,9 +146,13 @@ module HtmlCleaner
   # These assume they are running on well-formed XHTML, which we can do
   # because they will only be used on already-cleaned fields.
 
-  # strip img tags
-  def strip_images(value)
-    value.gsub(/<img .*?>/, '')
+  # strip img tags, optionally leaving the src URL exposed
+  def strip_images(value, keep_src: false)
+    if keep_src
+      value.gsub(%r{<img .*?src="(.*?)" .*?\/>}, '\1')
+    else
+      value.gsub(%r{<img .*?}, "")
+    end
   end
 
   def strip_html_breaks_simple(value)

--- a/lib/html_cleaner.rb
+++ b/lib/html_cleaner.rb
@@ -149,14 +149,13 @@ module HtmlCleaner
   # strip img tags, optionally leaving the src URL exposed
   def strip_images(value, keep_src: false)
     value.gsub(/(<img .*?>)/) do |img_tag|
-      if keep_src
-        # The cleaned field will always use double quotes (") but the fields
-        # in tests aren't always cleaned, so we're allowing double or single
-        # quotes here.
-        img_tag.match(/src=['"]([^"]+)['"]/)[1]
-      else
-        ""
-      end
+      return "" unless keep_src
+      # The cleaned field will always use double quotes (") but the fields
+      # in tests aren't always cleaned, so we're allowing double or single
+      # quotes here.
+      match_data = img_tag.match(/src="([^"]+)"/)
+      src = match_data[1] if match_data
+      src || ""
     end
   end
 

--- a/lib/html_cleaner.rb
+++ b/lib/html_cleaner.rb
@@ -148,13 +148,14 @@ module HtmlCleaner
 
   # strip img tags, optionally leaving the src URL exposed
   def strip_images(value, keep_src: false)
-    value.gsub(%r{(<img .*?>)}) do |img_tag|
-      if keep_src
-        img_tag.match(%r{src="([^"]+)"})[1]
-      else
-        ""
-      end
-    end
+    value.gsub(/<img .*?>/, '')
+    #value.gsub(%r{(<img .*?>)}) do |img_tag|
+    #  if keep_src
+    #    img_tag.match(%r{src="([^"]+)"})[1]
+    #  else
+    #    ""
+    #  end
+    # end
   end
 
   def strip_html_breaks_simple(value)

--- a/lib/html_cleaner.rb
+++ b/lib/html_cleaner.rb
@@ -148,10 +148,12 @@ module HtmlCleaner
 
   # strip img tags, optionally leaving the src URL exposed
   def strip_images(value, keep_src: false)
-    if keep_src
-      value.gsub(%r{<img .*?src="(.*?)" .*?\/>}, '\1')
-    else
-      value.gsub(%r{<img .*?}, "")
+    value.gsub(%r{(<img .*?>)}) do |img_tag|
+      if keep_src
+        img_tag.match(%r{src="([^"]+)"})[1]
+      else
+        ""
+      end
     end
   end
 

--- a/lib/html_cleaner.rb
+++ b/lib/html_cleaner.rb
@@ -149,11 +149,7 @@ module HtmlCleaner
   # strip img tags, optionally leaving the src URL exposed
   def strip_images(value, keep_src: false)
     value.gsub(/(<img .*?>)/) do |img_tag|
-      return "" unless keep_src
-      # The cleaned field will always use double quotes (") but the fields
-      # in tests aren't always cleaned, so we're allowing double or single
-      # quotes here.
-      match_data = img_tag.match(/src="([^"]+)"/)
+      match_data = img_tag.match(/src="([^"]+)"/) if keep_src
       src = match_data[1] if match_data
       src || ""
     end

--- a/spec/lib/html_cleaner_spec.rb
+++ b/spec/lib/html_cleaner_spec.rb
@@ -1104,4 +1104,90 @@ describe HtmlCleaner do
       expect(add_break_between_paragraphs(original)).to eq(result)
     end
   end
+
+  describe "strip_images" do
+    let(:result) { "Hi!  Bye" }
+
+    context "without keep_src" do
+      it "removes the img tag entirely when the src uses double quotes" do
+        string = 'Hi! <img src="http://example.org/image.png" /> Bye'
+        expect(strip_images(string)).to eq(result)
+      end
+
+      it "removes the img tag entirely when the src uses single quotes" do
+        string = "Hi! <img src='http://example.org/image.png'> Bye"
+        expect(strip_images(string)).to eq(result)
+      end
+
+      it "removes the img tag entirely when the src uses mismatched quotes" do
+        string = "Hi! <img src=\"http://example.org/image.png'> Bye"
+        expect(strip_images(string)).to eq(result)
+      end
+
+      it "removes the img tag entirely when the src is missing" do
+        string = 'Hi! <img alt="a11y"> Bye'
+        expect(strip_images(string)).to eq(result)
+      end
+
+      it "removes the img tag entirely when the src is missing a closing quotation mark" do
+        string = 'Hi! <img src="http://example.org/image.png /> Bye'
+        expect(strip_images(string)).to eq(result)
+      end
+    end
+
+    context "with keep_src: false" do
+      it "removes the img tag entirely when the src uses double quotes" do
+        string = 'Hi! <img src="http://example.org/image.png" /> Bye'
+        expect(strip_images(string, keep_src: false)).to eq(result)
+      end
+
+      it "removes the img tag entirely when the src uses single quotes" do
+        string = "Hi! <img src='http://example.org/image.png'> Bye"
+        expect(strip_images(string, keep_src: false)).to eq(result)
+      end
+
+      it "removes the img tag entirely when the src uses mismatched quotes" do
+        string = "Hi! <img src=\"http://example.org/image.png'> Bye"
+        expect(strip_images(string, keep_src: false)).to eq(result)
+      end
+
+      it "removes the img tag entirely when the src is missing" do
+        string = 'Hi! <img alt="a11y"> Bye'
+        expect(strip_images(string, keep_src: false)).to eq(result)
+      end
+
+      it "removes the img tag entirely when the src is missing a closing quotation mark" do
+        string = 'Hi! <img src="http://example.org/image.png /> Bye'
+        expect(strip_images(string, keep_src: false)).to eq(result)
+      end
+    end
+
+    context "with keep_src: true" do
+      it "keeps the img src URL when the src uses double quotes" do
+        string = 'Hi! <img src="http://example.org/image.png" /> Bye'
+        result = "Hi! http://example.org/image.png Bye"
+        expect(strip_images(string, keep_src: true)).to eq(result)
+      end
+
+      it "removes the img tag entirely when the src uses single quotes" do
+        string = "Hi! <img src='http://example.org/image.png'> Bye"
+        expect(strip_images(string, keep_src: true)).to eq(result)
+      end
+
+      it "removes the img tag entirely when the src uses mismatched quotes" do
+        string = "Hi! <img src=\"http://example.org/image.png'> Bye"
+        expect(strip_images(string, keep_src: true)).to eq(result)
+      end
+
+      it "removes the img tag entirely when the src is missing" do
+        string = 'Hi! <img alt="a11y"> Bye'
+        expect(strip_images(string, keep_src: true)).to eq(result)
+      end
+
+      it "removes the img tag entirely when the src is missing a closing quotation mark" do
+        string = 'Hi! <img src="http://example.org/image.png /> Bye'
+        expect(strip_images(string, keep_src: true)).to eq(result)
+      end
+    end
+  end
 end

--- a/spec/mailers/admin_mailer_spec.rb
+++ b/spec/mailers/admin_mailer_spec.rb
@@ -23,7 +23,9 @@ describe AdminMailer do
 
           it "strips the image from the email message but leaves its URL" do
             expect(email).not_to have_html_part_content(image_tag)
+            expect(email).not_to have_text_part_content(image_tag)
             expect(email).to have_html_part_content(image_url)
+            expect(email).to have_text_part_content(image_url)
           end
         end
 
@@ -31,11 +33,13 @@ describe AdminMailer do
           it "embeds the image when image safety mode is completely disabled" do
             allow(ArchiveConfig).to receive(:PARENTS_WITH_IMAGE_SAFETY_MODE).and_return([])
             expect(email).to have_html_part_content(image_tag)
+            expect(email).not_to have_text_part_content(image_url)
           end
 
           it "embeds the image when image safety mode is enabled for other types of comments" do
             allow(ArchiveConfig).to receive(:PARENTS_WITH_IMAGE_SAFETY_MODE).and_return(%w[Chapter Tag])
             expect(email).to have_html_part_content(image_tag)
+            expect(email).not_to have_text_part_content(image_url)
           end
         end
       end

--- a/spec/mailers/admin_mailer_spec.rb
+++ b/spec/mailers/admin_mailer_spec.rb
@@ -10,15 +10,17 @@ describe AdminMailer do
       let(:comment) { create(:comment, :on_admin_post) }
 
       context "and the comment's contents contain an image" do
-        let(:image_tag) { "<img src=\"an_image.png\" />" }
+        let(:image_url) { "an_image.png" }
+        let(:image_tag) { "<img src=\"#{image_url}\" />" }
 
         before do
           comment.comment_content += image_tag
           comment.save!
         end
 
-        it "strips the image from the email message" do
+        it "strips the image from the email message but leaves its URL" do
           expect(email).not_to have_html_part_content(image_tag)
+          expect(email).to have_html_part_content(image_url)
         end
       end
     end
@@ -31,15 +33,17 @@ describe AdminMailer do
       let(:comment) { create(:comment, :on_admin_post) }
 
       context "and the comment's contents contain an image" do
-        let(:image_tag) { "<img src=\"an_image.png\" />" }
+        let(:image_url) { "an_image.png" }
+        let(:image_tag) { "<img src=\"#{image_url}\" />" }
 
         before do
           comment.comment_content += image_tag
           comment.save!
         end
 
-        it "strips the image from the email message" do
+        it "strips the image from the email message but leaves its URL" do
           expect(email).not_to have_html_part_content(image_tag)
+          expect(email).to have_html_part_content(image_url)
         end
       end
     end

--- a/spec/mailers/admin_mailer_spec.rb
+++ b/spec/mailers/admin_mailer_spec.rb
@@ -34,7 +34,7 @@ describe AdminMailer do
           end
 
           it "embeds the image when image safety mode is enabled for other types of comments" do
-            allow(ArchiveConfig).to receive(:PARENTS_WITH_IMAGE_SAFETY_MODE).and_return(["Chapter", "Tag"])
+            allow(ArchiveConfig).to receive(:PARENTS_WITH_IMAGE_SAFETY_MODE).and_return(%w[Chapter Tag])
             expect(email).to have_html_part_content(image_tag)
           end
         end
@@ -76,7 +76,7 @@ describe AdminMailer do
           end
 
           it "embeds the image in the HTML email when image safety mode is enabled for other types of comments" do
-            allow(ArchiveConfig).to receive(:PARENTS_WITH_IMAGE_SAFETY_MODE).and_return(["Chapter", "Tag"])
+            allow(ArchiveConfig).to receive(:PARENTS_WITH_IMAGE_SAFETY_MODE).and_return(%w[Chapter Tag])
             expect(email).to have_html_part_content(image_tag)
             expect(email).not_to have_text_part_content(image_url)
           end

--- a/spec/mailers/admin_mailer_spec.rb
+++ b/spec/mailers/admin_mailer_spec.rb
@@ -18,9 +18,25 @@ describe AdminMailer do
           comment.save!
         end
 
-        it "strips the image from the email message but leaves its URL" do
-          expect(email).not_to have_html_part_content(image_tag)
-          expect(email).to have_html_part_content(image_url)
+        context "when image safety mode is enabled for admin post comments" do
+          before { allow(ArchiveConfig).to receive(:PARENTS_WITH_IMAGE_SAFETY_MODE).and_return(["AdminPost"]) }
+
+          it "strips the image from the email message but leaves its URL" do
+            expect(email).not_to have_html_part_content(image_tag)
+            expect(email).to have_html_part_content(image_url)
+          end
+        end
+
+        context "when image safety mode is not enabled for admin post comments" do
+          it "embeds the image when image safety mode is completely disabled" do
+            allow(ArchiveConfig).to receive(:PARENTS_WITH_IMAGE_SAFETY_MODE).and_return([])
+            expect(email).to have_html_part_content(image_tag)
+          end
+
+          it "embeds the image when image safety mode is enabled for other types of comments" do
+            allow(ArchiveConfig).to receive(:PARENTS_WITH_IMAGE_SAFETY_MODE).and_return(["Chapter", "Tag"])
+            expect(email).to have_html_part_content(image_tag)
+          end
         end
       end
     end
@@ -32,7 +48,7 @@ describe AdminMailer do
     context "when the comment is on an admin post" do
       let(:comment) { create(:comment, :on_admin_post) }
 
-      context "and the comment's contents contain an image" do
+      context "with an image in the comment content" do
         let(:image_url) { "an_image.png" }
         let(:image_tag) { "<img src=\"#{image_url}\" />" }
 
@@ -41,9 +57,29 @@ describe AdminMailer do
           comment.save!
         end
 
-        it "strips the image from the email message but leaves its URL" do
-          expect(email).not_to have_html_part_content(image_tag)
-          expect(email).to have_html_part_content(image_url)
+        context "when image safety mode is enabled for admin post comments" do
+          before { allow(ArchiveConfig).to receive(:PARENTS_WITH_IMAGE_SAFETY_MODE).and_return(["AdminPost"]) }
+
+          it "strips the image from the email message but leaves its URL" do
+            expect(email).not_to have_html_part_content(image_tag)
+            expect(email).not_to have_text_part_content(image_tag)
+            expect(email).to have_html_part_content(image_url)
+            expect(email).to have_text_part_content(image_url)
+          end
+        end
+
+        context "when image safety mode is not enabled for admin post comments" do
+          it "embeds the image in the HTML email when image safety mode is completely disabled" do
+            allow(ArchiveConfig).to receive(:PARENTS_WITH_IMAGE_SAFETY_MODE).and_return([])
+            expect(email).to have_html_part_content(image_tag)
+            expect(email).not_to have_text_part_content(image_url)
+          end
+
+          it "embeds the image in the HTML email when image safety mode is enabled for other types of comments" do
+            allow(ArchiveConfig).to receive(:PARENTS_WITH_IMAGE_SAFETY_MODE).and_return(["Chapter", "Tag"])
+            expect(email).to have_html_part_content(image_tag)
+            expect(email).not_to have_text_part_content(image_url)
+          end
         end
       end
     end

--- a/spec/mailers/comment_mailer_spec.rb
+++ b/spec/mailers/comment_mailer_spec.rb
@@ -71,20 +71,40 @@ describe CommentMailer do
     end
   end
 
-  shared_examples "strips image tags" do
+  shared_examples "a comment subject to image safety mode settings" do
     let(:image_url) { "an_image.png" }
     let(:image_tag) { "<img src=\"#{image_url}\" />" }
+    let(:all_parent_types) { %w[AdminPost Chapter Tag] }
+    let(:comment_parent_type) { [comment.parent_type] }
 
     before do
       comment.comment_content += image_tag
       comment.save!
     end
 
-    it "strips the image from the email message but leaves its URL" do
-      expect(email).not_to have_html_part_content(image_tag)
-      expect(email).not_to have_text_part_content(image_tag)
-      expect(email).to have_html_part_content(image_url)
-      expect(email).to have_text_part_content(image_url)
+    context "when image safety mode is enabled for the parent type" do
+      before { allow(ArchiveConfig).to receive(:PARENTS_WITH_IMAGE_SAFETY_MODE).and_return(comment_parent_type) }
+
+      it "strips the image from the email message but leaves its URL" do
+        expect(email).not_to have_html_part_content(image_tag)
+        expect(email).not_to have_text_part_content(image_tag)
+        expect(email).to have_html_part_content(image_url)
+        expect(email).to have_text_part_content(image_url)
+      end
+    end
+
+    context "when image safety mode is not enabled for the parent type" do
+      it "embeds the image in the HTML email when image safety mode is completely disabled" do
+        allow(ArchiveConfig).to receive(:PARENTS_WITH_IMAGE_SAFETY_MODE).and_return([])
+        expect(email).to have_html_part_content(image_tag)
+        expect(email).not_to have_text_part_content(image_url)
+      end
+
+      it "embeds the image in the HTML email when image safety mode is enabled for other parent types" do
+        allow(ArchiveConfig).to receive(:PARENTS_WITH_IMAGE_SAFETY_MODE).and_return(all_parent_types - comment_parent_type)
+        expect(email).to have_html_part_content(image_tag)
+        expect(email).not_to have_text_part_content(image_url)
+      end
     end
   end
 
@@ -95,11 +115,12 @@ describe CommentMailer do
     it_behaves_like "it retries when the comment doesn't exist"
     it_behaves_like "a notification email with a link to the comment"
     it_behaves_like "a notification email with a link to reply to the comment"
+    it_behaves_like "a comment subject to image safety mode settings"
 
     context "when the comment is on an admin post" do
       let(:comment) { create(:comment, :on_admin_post) }
 
-      it_behaves_like "strips image tags"
+      it_behaves_like "a comment subject to image safety mode settings"
     end
 
     context "when the comment is a reply to another comment" do
@@ -108,6 +129,7 @@ describe CommentMailer do
       it_behaves_like "a notification email with a link to the comment"
       it_behaves_like "a notification email with a link to reply to the comment"
       it_behaves_like "a notification email with a link to the comment's thread"
+      it_behaves_like "a comment subject to image safety mode settings"
     end
 
     context "when the comment is on a tag" do
@@ -115,6 +137,7 @@ describe CommentMailer do
 
       it_behaves_like "a notification email with a link to the comment"
       it_behaves_like "a notification email with a link to reply to the comment"
+      it_behaves_like "a comment subject to image safety mode settings"
 
       context "when the comment is a reply to another comment" do
         let(:comment) { create(:comment, commentable: create(:comment, :on_tag)) }
@@ -133,11 +156,12 @@ describe CommentMailer do
     it_behaves_like "it retries when the comment doesn't exist"
     it_behaves_like "a notification email with a link to the comment"
     it_behaves_like "a notification email with a link to reply to the comment"
+    it_behaves_like "a comment subject to image safety mode settings"
 
     context "when the comment is on an admin post" do
       let(:comment) { create(:comment, :on_admin_post) }
 
-      it_behaves_like "strips image tags"
+      it_behaves_like "a comment subject to image safety mode settings"
     end
 
     context "when the comment is a reply to another comment" do
@@ -146,6 +170,7 @@ describe CommentMailer do
       it_behaves_like "a notification email with a link to the comment"
       it_behaves_like "a notification email with a link to reply to the comment"
       it_behaves_like "a notification email with a link to the comment's thread"
+      it_behaves_like "a comment subject to image safety mode settings"
     end
 
     context "when the comment is on a tag" do
@@ -153,6 +178,7 @@ describe CommentMailer do
 
       it_behaves_like "a notification email with a link to the comment"
       it_behaves_like "a notification email with a link to reply to the comment"
+      it_behaves_like "a comment subject to image safety mode settings"
 
       context "when the comment is a reply to another comment" do
         let(:comment) { create(:comment, commentable: create(:comment, :on_tag)) }
@@ -160,6 +186,7 @@ describe CommentMailer do
         it_behaves_like "a notification email with a link to the comment"
         it_behaves_like "a notification email with a link to reply to the comment"
         it_behaves_like "a notification email with a link to the comment's thread"
+        it_behaves_like "a comment subject to image safety mode settings"
       end
     end
   end
@@ -175,11 +202,12 @@ describe CommentMailer do
     it_behaves_like "a notification email with a link to the comment"
     it_behaves_like "a notification email with a link to reply to the comment"
     it_behaves_like "a notification email with a link to the comment's thread"
+    it_behaves_like "a comment subject to image safety mode settings"
 
     context "when the comment is on an admin post" do
       let(:comment) { create(:comment, :on_admin_post) }
 
-      it_behaves_like "strips image tags"
+      it_behaves_like "a comment subject to image safety mode settings"
     end
 
     context "when the comment is on a tag" do
@@ -188,6 +216,7 @@ describe CommentMailer do
       it_behaves_like "a notification email with a link to the comment"
       it_behaves_like "a notification email with a link to reply to the comment"
       it_behaves_like "a notification email with a link to the comment's thread"
+      it_behaves_like "a comment subject to image safety mode settings"
     end
 
     context "when the comment is from a user using a banned email" do
@@ -217,11 +246,12 @@ describe CommentMailer do
     it_behaves_like "a notification email with a link to the comment"
     it_behaves_like "a notification email with a link to reply to the comment"
     it_behaves_like "a notification email with a link to the comment's thread"
+    it_behaves_like "a comment subject to image safety mode settings"
 
     context "when the comment is on an admin post" do
       let(:comment) { create(:comment, :on_admin_post) }
 
-      it_behaves_like "strips image tags"
+      it_behaves_like "a comment subject to image safety mode settings"
     end
 
     context "when the comment is on a tag" do
@@ -230,6 +260,7 @@ describe CommentMailer do
       it_behaves_like "a notification email with a link to the comment"
       it_behaves_like "a notification email with a link to reply to the comment"
       it_behaves_like "a notification email with a link to the comment's thread"
+      it_behaves_like "a comment subject to image safety mode settings"
     end
 
     context "when the comment is from a user using a banned email" do
@@ -254,11 +285,19 @@ describe CommentMailer do
     it_behaves_like "an email with a valid sender"
     it_behaves_like "it retries when the comment doesn't exist"
     it_behaves_like "a notification email with a link to the comment"
+    it_behaves_like "a comment subject to image safety mode settings"
+
+    context "when the comment is on an admin post" do
+      let(:comment) { create(:comment, :on_admin_post) }
+
+      it_behaves_like "a comment subject to image safety mode settings"
+    end
 
     context "when the comment is on a tag" do
       let(:parent_comment) { create(:comment, :on_tag) }
 
       it_behaves_like "a notification email with a link to the comment"
+      it_behaves_like "a comment subject to image safety mode settings"
     end
   end
 
@@ -272,12 +311,20 @@ describe CommentMailer do
     it_behaves_like "it retries when the comment doesn't exist"
     it_behaves_like "a notification email with a link to the comment"
     it_behaves_like "a notification email with a link to the comment's thread"
+    it_behaves_like "a comment subject to image safety mode settings"
+
+    context "when the comment is on an admin post" do
+      let(:parent_comment) { create(:comment, :on_admin_post) }
+
+      it_behaves_like "a comment subject to image safety mode settings"
+    end
 
     context "when the parent comment is on a tag" do
       let(:parent_comment) { create(:comment, :on_tag) }
 
       it_behaves_like "a notification email with a link to the comment"
       it_behaves_like "a notification email with a link to the comment's thread"
+      it_behaves_like "a comment subject to image safety mode settings"
     end
   end
 end

--- a/spec/mailers/comment_mailer_spec.rb
+++ b/spec/mailers/comment_mailer_spec.rb
@@ -145,6 +145,7 @@ describe CommentMailer do
         it_behaves_like "a notification email with a link to the comment"
         it_behaves_like "a notification email with a link to reply to the comment"
         it_behaves_like "a notification email with a link to the comment's thread"
+        it_behaves_like "a comment subject to image safety mode settings"
       end
     end
   end

--- a/spec/mailers/comment_mailer_spec.rb
+++ b/spec/mailers/comment_mailer_spec.rb
@@ -72,16 +72,19 @@ describe CommentMailer do
   end
 
   shared_examples "strips image tags" do
-    let(:image_tag) { "<img src=\"an_image.png\" />" }
+    let(:image_url) { "an_image.png" }
+    let(:image_tag) { "<img src=\"#{image_url}\" />" }
 
     before do
       comment.comment_content += image_tag
       comment.save!
     end
 
-    it "strips the image from the email message" do
+    it "strips the image from the email message but leaves its URL" do
       expect(email).not_to have_html_part_content(image_tag)
       expect(email).not_to have_text_part_content(image_tag)
+      expect(email).to have_html_part_content(image_url)
+      expect(email).to have_text_part_content(image_url)
     end
   end
 

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -379,4 +379,93 @@ describe Comment do
       end
     end
   end
+
+  describe "#use_image_safety_mode?" do
+    let(:admin_post_comment) { create(:comment, :on_admin_post) }
+    let(:chapter_comment) { create(:comment) }
+    let(:tag_comment) { create(:comment, :on_tag) }
+    let(:admin_post_reply) { create(:comment, commentable: admin_post_comment) }
+    let(:chapter_reply) { create(:comment, commentable: chapter_comment) }
+    let(:tag_reply) { create(:comment, commentable: tag_comment) }
+
+    context "when ArchiveConfig.PARENTS_WITH_IMAGE_SAFETY_MODE is empty" do
+      it "returns false for comments and replies for all parent types" do
+        expect(admin_post_comment.use_image_safety_mode?).to be_falsey
+        expect(chapter_comment.use_image_safety_mode?).to be_falsey
+        expect(tag_comment.use_image_safety_mode?).to be_falsey
+        expect(admin_post_reply.use_image_safety_mode?).to be_falsey
+        expect(chapter_reply.use_image_safety_mode?).to be_falsey
+        expect(tag_reply.use_image_safety_mode?).to be_falsey
+      end
+    end
+
+    context "when ArchiveConfig.PARENTS_WITH_IMAGE_SAFETY_MODE is set to something that doesn't match an existing parent type" do
+      before { allow(ArchiveConfig).to receive(:PARENTS_WITH_IMAGE_SAFETY_MODE).and_return(["Work"]) }
+
+      it "returns false for comments and replies for all parent types" do
+        expect(admin_post_comment.use_image_safety_mode?).to be_falsey
+        expect(chapter_comment.use_image_safety_mode?).to be_falsey
+        expect(tag_comment.use_image_safety_mode?).to be_falsey
+        expect(admin_post_reply.use_image_safety_mode?).to be_falsey
+        expect(chapter_reply.use_image_safety_mode?).to be_falsey
+        expect(tag_reply.use_image_safety_mode?).to be_falsey
+      end
+    end
+
+    context "when ArchiveConfig.PARENTS_WITH_IMAGE_SAFETY_MODE is set to AdminPost" do
+      before { allow(ArchiveConfig).to receive(:PARENTS_WITH_IMAGE_SAFETY_MODE).and_return(["AdminPost"]) }
+
+      it "returns true for AdminPost comments and replies and false for Chapter and Tag comments and replies" do
+        expect(admin_post_comment.use_image_safety_mode?).to be_truthy
+        expect(admin_post_reply.use_image_safety_mode?).to be_truthy
+
+        expect(chapter_comment.use_image_safety_mode?).to be_falsey
+        expect(tag_comment.use_image_safety_mode?).to be_falsey
+        expect(chapter_reply.use_image_safety_mode?).to be_falsey
+        expect(tag_reply.use_image_safety_mode?).to be_falsey
+      end
+    end
+
+    context "when ArchiveConfig.PARENTS_WITH_IMAGE_SAFETY_MODE is set to Chapter" do
+      before { allow(ArchiveConfig).to receive(:PARENTS_WITH_IMAGE_SAFETY_MODE).and_return(["Chapter"]) }
+
+      it "returns true for Chapter comments and false for AdminPost and Tag comments and replies" do
+        expect(chapter_comment.use_image_safety_mode?).to be_truthy
+        expect(chapter_reply.use_image_safety_mode?).to be_truthy
+
+        expect(admin_post_comment.use_image_safety_mode?).to be_falsey
+        expect(tag_comment.use_image_safety_mode?).to be_falsey
+        expect(admin_post_reply.use_image_safety_mode?).to be_falsey
+        expect(tag_reply.use_image_safety_mode?).to be_falsey
+      end
+    end
+
+    context "when ArchiveConfig.PARENTS_WITH_IMAGE_SAFETY_MODE is set to Tag" do
+      before { allow(ArchiveConfig).to receive(:PARENTS_WITH_IMAGE_SAFETY_MODE).and_return(["Tag"]) }
+
+      it "returns true for Tag comments and replies and false for AdminPost and Chapter comments and replies" do
+        expect(tag_comment.use_image_safety_mode?).to be_truthy
+        expect(tag_reply.use_image_safety_mode?).to be_truthy
+
+        expect(admin_post_comment.use_image_safety_mode?).to be_falsey
+        expect(chapter_comment.use_image_safety_mode?).to be_falsey
+        expect(admin_post_reply.use_image_safety_mode?).to be_falsey
+        expect(chapter_reply.use_image_safety_mode?).to be_falsey
+      end
+    end
+
+    context "when ArchiveConfig.PARENTS_WITH_IMAGE_SAFETY_MODE includes multiple parent types" do
+      before { allow(ArchiveConfig).to receive(:PARENTS_WITH_IMAGE_SAFETY_MODE).and_return(["AdminPost", "Tag"]) }
+
+      it "returns true for comments and replies on the listed parent types and false for the other" do
+        expect(admin_post_comment.use_image_safety_mode?).to be_truthy
+        expect(tag_comment.use_image_safety_mode?).to be_truthy
+        expect(admin_post_reply.use_image_safety_mode?).to be_truthy
+        expect(tag_reply.use_image_safety_mode?).to be_truthy
+
+        expect(chapter_comment.use_image_safety_mode?).to be_falsey
+        expect(chapter_reply.use_image_safety_mode?).to be_falsey
+      end
+    end
+  end
 end

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -455,7 +455,7 @@ describe Comment do
     end
 
     context "when ArchiveConfig.PARENTS_WITH_IMAGE_SAFETY_MODE includes multiple parent types" do
-      before { allow(ArchiveConfig).to receive(:PARENTS_WITH_IMAGE_SAFETY_MODE).and_return(["AdminPost", "Tag"]) }
+      before { allow(ArchiveConfig).to receive(:PARENTS_WITH_IMAGE_SAFETY_MODE).and_return(%w[AdminPost Tag]) }
 
       it "returns true for comments and replies on the listed parent types and false for the other" do
         expect(admin_post_comment.use_image_safety_mode?).to be_truthy

--- a/spec/models/feedback_reporters/abuse_reporter_spec.rb
+++ b/spec/models/feedback_reporters/abuse_reporter_spec.rb
@@ -82,7 +82,7 @@ describe AbuseReporter do
 
     context "if the report has an image in description" do
       it "strips all img tags but leaves the src URLs" do
-        allow(subject).to receive(:description).and_return("Hi!<img src='http://example.com/Camera-icon.svg'>Bye!")
+        allow(subject).to receive(:description).and_return('Hi!<img src="http://example.com/Camera-icon.svg">Bye!')
 
         expect(subject.report_attributes.fetch("description")).to eq("Hi!http://example.com/Camera-icon.svgBye!")
       end

--- a/spec/models/feedback_reporters/abuse_reporter_spec.rb
+++ b/spec/models/feedback_reporters/abuse_reporter_spec.rb
@@ -81,10 +81,10 @@ describe AbuseReporter do
     end
 
     context "if the report has an image in description" do
-      it "strips all img tags" do
+      it "strips all img tags but leaves the src URLs" do
         allow(subject).to receive(:description).and_return("Hi!<img src='http://example.com/Camera-icon.svg'>Bye!")
 
-        expect(subject.report_attributes.fetch("description")).to eq("Hi!Bye!")
+        expect(subject.report_attributes.fetch("description")).to eq("Hi!http://example.com/Camera-icon.svgBye!")
       end
     end
   end

--- a/spec/models/feedback_reporters/support_reporter_spec.rb
+++ b/spec/models/feedback_reporters/support_reporter_spec.rb
@@ -91,10 +91,10 @@ describe SupportReporter do
     end
 
     context "if the report has an image in description" do
-      it "strips all img tags" do
+      it "strips all img tags but leaves the src URLs" do
         allow(subject).to receive(:description).and_return("Hi!<img src='http://example.com/Camera-icon.svg'>Bye!")
 
-        expect(subject.report_attributes.fetch("description")).to eq("Hi!Bye!")
+        expect(subject.report_attributes.fetch("description")).to eq("Hi!http://example.com/Camera-icon.svgBye!")
       end
     end
   end

--- a/spec/models/feedback_reporters/support_reporter_spec.rb
+++ b/spec/models/feedback_reporters/support_reporter_spec.rb
@@ -92,7 +92,7 @@ describe SupportReporter do
 
     context "if the report has an image in description" do
       it "strips all img tags but leaves the src URLs" do
-        allow(subject).to receive(:description).and_return("Hi!<img src='http://example.com/Camera-icon.svg'>Bye!")
+        allow(subject).to receive(:description).and_return('Hi!<img src="http://example.com/Camera-icon.svg">Bye!')
 
         expect(subject.report_attributes.fetch("description")).to eq("Hi!http://example.com/Camera-icon.svgBye!")
       end


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6719

## Purpose

Adds a `keep_src` keyword argument to the `strip_images` method that lets us have the option of replacing the stripped `img` tag with its `src` URL instead of empty space. I'm happy to give it a different name or make it a separate method. I very much hate the hack to make it work with tests, but I also felt like I'd get side-eyed for changing the tests. 😆 I can do that instead, though!

Replaces the `strip_images` keyword argument on `sanitize_field` with a new argument called `image_safety_mode`. We use it in the same places we were using `strip_images`, but it's a more flexible name in case we decide to switch to placeholders or go back to nothingness or something else entirely -- right now it uses `strip_images` with `keep_src: true` on the sanitized content. Again, delighted to give it a different name if you have one. 

I assumed that we wouldn't mind including the image URL in the main content of support tickets and abuse reports, as well as the emailed copies of same. They were kind of a weird hybrid of "affected by AO3-6564" and "not affected by AO3-6564." Happy to go back to no images at all, though.

ETA: And the big one, make it so we can use the config to temporarily strip images in work comments without a deploy. (You can do tags, too, but that seems unlikely to be an issue.) We'll need to set `PARENTS_WITH_IMAGE_SAFETY_MODE: ["AdminPost"]` when this is deployed to keep the current behavior of stripping images from news post comments.

## Testing Instructions

How can the Archive's QA team verify that this is working as you intended?

If you have a Jira account with access, please update or comment on the issue
with any new or missing testing instructions instead.

## References

* [AO3-6564](https://otwarchive.atlassian.net/browse/AO3-6564)
* #4729 
* #4772



[AO3-6564]: https://otwarchive.atlassian.net/browse/AO3-6564?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ