### PR TITLE
AO3-5890 Add link to individual prompt and prompt user for prompt meme posts

### DIFF
--- a/app/views/prompts/_prompt_blurb.html.erb
+++ b/app/views/prompts/_prompt_blurb.html.erb
@@ -3,14 +3,15 @@
   <div class="header module">
     <h4 class="heading">
       <% if !prompt.title.blank? %>
-        <%= prompt.title %>
+        <%= link_to prompt.title, collection_prompt_path(prompt.collection, prompt) %>
       <% else %>
-        <%= ts("#{prompt.class.to_s}%{index}", :index => (index ||= false) ? " #{index+1}" : '') %>
+        <%= link_to ts("#{prompt.class.to_s}%{index}", :index => (index ||= false) ? " #{index+1}" : ''), collection_prompt_path(prompt.collection, prompt) %>
       <% end %>
       <% if prompt.anonymous? %>
         <%= ts("by Anonymous") %>
       <% else %>
-        <%= ts("by %{person}", :person => (prompt.pseud ? prompt.pseud.byline : prompt.challenge_signup.pseud.byline)) %>
+        <%= ts("by") %>
+        <%= pseud_link(prompt.pseud ? prompt.pseud : prompt.challenge_signup.pseud) %>
       <% end %>
       <% unless @collection %>
         <%= ts("in") %> <%= link_to prompt.collection.title, collection_path(prompt.collection) %>


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [x] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [x] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [x] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

This is a partial fix for [AO3-5890](https://otwarchive.atlassian.net/browse/AO3-5890).

I can see that the issue has been assigned to somebody, but it has not seen any updates since July 2021 — unsure what to do in this scenario, as this PR is looking to fix a specific problem that I would like to see resolved (namely, the inability to link to a specific prompt) but I also don't want to step on any toes in the process.

(Apologies about the discrepency between PR user and commit user — they're both me, but I accidentally pushed the commit with the incorrect Github user!)

## Purpose

Adds a permalink to a prompt inside of a prompt meme, allowing easier sharing of inidividual prompts, and also adds a link to a psued's page (if the prompt is not anonymous) in the same way a work blurb does.

## Testing Instructions

- Visit a prompt meme's list of requests (`/collections/collection/requests`)
- See that prompt titles are clickable links which take the user to the individual prompt page
- See that non-anonymous prompts show a link to the user's pseud dashboard

## References

No other relevant issues.

## Credit

spectralMachina (he/him)


[AO3-5890]: https://otwarchive.atlassian.net/browse/AO3-5890?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ