### PR TITLE
AO3-6729 Fix searching for otp: true

### DIFF
--- a/app/models/search/work_indexer.rb
+++ b/app/models/search/work_indexer.rb
@@ -13,10 +13,11 @@ class WorkIndexer < Indexer
       :stat_counter,
       :tags,
       :users,
+      :relationships,
       fandoms: { meta_tags: :meta_tags, merger: { meta_tags: :meta_tags } },
       pseuds: :user,
       serial_works: :series
-    ).includes(relationships: :merger)
+    )
   end
 
   def self.index_all(options = {})

--- a/app/models/search/work_indexer.rb
+++ b/app/models/search/work_indexer.rb
@@ -15,9 +15,8 @@ class WorkIndexer < Indexer
       :users,
       fandoms: { meta_tags: :meta_tags, merger: { meta_tags: :meta_tags } },
       pseuds: :user,
-      relationships: :merger,
       serial_works: :series
-    )
+    ).includes(relationships: :merger)
   end
 
   def self.index_all(options = {})

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -1248,7 +1248,8 @@ class Work < ApplicationRecord
   def otp
     return true if relationships.size == 1
 
-    all_without_syns = relationships.map { |r| r.merger_id ? r.merger_id : r.id }.uniq.compact
+    all_without_syns = relationships.map { |r| r.merger_id || r.id }
+      .uniq
     all_without_syns.count == 1
   end
 

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -1248,7 +1248,7 @@ class Work < ApplicationRecord
   def otp
     return true if relationships.size == 1
 
-    all_without_syns = relationships.map { |r| r.merger ? r.merger : r }.uniq.compact
+    all_without_syns = relationships.map { |r| r.merger_id ? r.merger_id : r.id }.uniq.compact
     all_without_syns.count == 1
   end
 

--- a/features/search/works_info.feature
+++ b/features/search/works_info.feature
@@ -82,23 +82,21 @@ Feature: Search works by work info
       And I should see "I am <strong>er Than Yesterday & Other Lies"
 
   Scenario: Search by crossovers
-    Given I have loaded the fixtures
+    Given a set of crossover works for searching
     When I am on the search works page
       And I choose "Exclude crossovers"
       And I press "Search" within "#new_work_search"
     Then I should see "You searched for: No Crossovers"
-      And I should see "6 Found"
-      And I should see "First work"
-      And I should see "second work"
-      And I should see "third work"
-      And I should see "fourth"
-      And I should see "fifth"
-      And I should see "I am <strong>er Than Yesterday & Other Lies"
+      And I should see "5 Found"
+      But I should not see "Work With Multiple Fandoms"
     When I am on the search works page
       And I choose "Only crossovers"
       And I press "Search" within "#new_work_search"
     Then I should see "You searched for: Only Crossovers"
-      And I should see "No results found"
+      And I should see "3 Found"
+      And I should see "First Work With Multiple Fandoms"
+      And I should see "Second Work With Multiple Fandoms"
+      And I should see "Third Work With Multiple Fandoms"
 
   Scenario: Search by single chapter
     Given I have the Battle set loaded

--- a/features/search/works_tags.feature
+++ b/features/search/works_tags.feature
@@ -217,6 +217,17 @@ Feature: Search works by tag
     When I follow "Edit Your Search"
     Then the field labeled "Relationships" should contain "James T. Kirk/Spock"
 
+  Scenario: Searching by otp: true returns works with one relationship tag or
+  multiple synonymous relationship tags.
+    Given a set of Ed/Stede works for searching
+    When I am on the search works page
+      And I fill in "Any Field" with "soulmates: true"
+      And I press "Search" within "#new_work_search"
+    Then I should see "You searched for: soulmates: true"
+      And I should see "3 Found"
+    When I follow "Edit Your Search"
+    Then the field labeled "Any Field" should contain "soulmates: true"
+
   Scenario: Searching by relationship and category returns only works using the
   category and the exact relationship tag or its synonyms
     Given a set of Kirk/Spock works for searching

--- a/features/search/works_tags.feature
+++ b/features/search/works_tags.feature
@@ -219,14 +219,14 @@ Feature: Search works by tag
 
   Scenario: Searching by otp: true returns works with one relationship tag or
   multiple synonymous relationship tags.
-    Given a set of Ed/Stede works for searching
+    Given a set of Ed Stede works for searching
     When I am on the search works page
-      And I fill in "Any Field" with "soulmates: true"
+      And I fill in "Any Field" with "otp: true"
       And I press "Search" within "#new_work_search"
-    Then I should see "You searched for: soulmates: true"
+    Then I should see "You searched for: otp: true"
       And I should see "3 Found"
     When I follow "Edit Your Search"
-    Then the field labeled "Any Field" should contain "soulmates: true"
+    Then the field labeled "Any Field" should contain "otp: true"
 
   Scenario: Searching by relationship and category returns only works using the
   category and the exact relationship tag or its synonyms

--- a/features/search/works_tags.feature
+++ b/features/search/works_tags.feature
@@ -225,6 +225,8 @@ Feature: Search works by tag
       And I press "Search" within "#new_work_search"
     Then I should see "You searched for: otp: true"
       And I should see "3 Found"
+      But I should not see "The Work Without a Relationship"
+      And I should not see "The Work With Multiple Ships"
     When I follow "Edit Your Search"
     Then the field labeled "Any Field" should contain "otp: true"
 

--- a/features/step_definitions/work_search_steps.rb
+++ b/features/step_definitions/work_search_steps.rb
@@ -117,7 +117,7 @@ Given /^a set of Spock\/Uhura works for searching$/ do
   step %{all indexing jobs have been run}
 end
 
-Given /^a set of Ed\/Stede works for searching$/ do
+Given "a set of Ed Stede works for searching" do
   step %{basic tags}
 
   # Create a relationship with a syn
@@ -136,8 +136,8 @@ Given /^a set of Ed\/Stede works for searching$/ do
 
   # Create a work with two unconnected relationship tags (an otp: false work)
   FactoryBot.create(:work,
-    title: "The Work With Multiple Ships",
-    relationship_string: "Ed/Stede, Ed/Izzy")
+                    title: "The Work With Multiple Ships",
+                    relationship_string: "Ed/Stede, Ed/Izzy")
 
   step %{all indexing jobs have been run}
 end

--- a/features/step_definitions/work_search_steps.rb
+++ b/features/step_definitions/work_search_steps.rb
@@ -117,6 +117,31 @@ Given /^a set of Spock\/Uhura works for searching$/ do
   step %{all indexing jobs have been run}
 end
 
+Given /^a set of Ed\/Stede works for searching$/ do
+  step %{basic tags}
+
+  # Create a relationship with a syn
+  step %{a canonical relationship "Blackbeard | Edward Teach/Stede Bonnet"}
+  step %{a synonym "Ed/Stede" of the tag "Blackbeard | Edward Teach/Stede Bonnet"}
+
+  # Create a work for each tag or set of tags (all are otp: true)
+  ["Ed/Stede",
+   "Blackbeard | Edward Teach/Stede Bonnet",
+   "Blackbeard | Edward Teach/Stede Bonnet, Ed/Stede"].each do |relationship|
+    FactoryBot.create(:work, relationship_string: relationship)
+  end
+
+  # Create a work with no relationship tag (an otp: false work)
+  FactoryBot.create(:work, title: "The Work Without a Relationship")
+
+  # Create a work with two unconnected relationship tags (an otp: false work)
+  FactoryBot.create(:work,
+    title: "The Work With Multiple Ships",
+    relationship_string: "Ed/Stede, Ed/Izzy")
+
+  step %{all indexing jobs have been run}
+end
+
 Given /^a set of works with various categories for searching$/ do
   step %{basic tags}
 

--- a/features/step_definitions/work_search_steps.rb
+++ b/features/step_definitions/work_search_steps.rb
@@ -142,6 +142,41 @@ Given "a set of Ed Stede works for searching" do
   step %{all indexing jobs have been run}
 end
 
+Given "a set of crossover works for searching" do
+  step %{basic tags}
+
+  # Create two unrelated fandoms, one with a syn
+  step %{a canonical fandom "Unrelated Fandom"}
+  step %{a canonical fandom "Hermitcraft SMP"}
+  step %{a synonym "Hermitcraft" of the tag "Hermitcraft SMP"}
+
+  # Create a fandom and make it the metatag of one of the fandoms
+  step %{a canonical fandom "Video Blogging RPF"}
+  step %{"Video Blogging RPF" is a metatag of the fandom "Hermitcraft SMP"}
+
+  # Create a work for each tag or set of tags (none are crossovers)
+  ["Video Blogging RPF",
+   "Hermitcraft SMP",
+   "Hermitcraft SMP, Hermitcraft",
+   "Hermitcraft SMP, Video Blogging RPF",
+   "Hermitcraft, Video Blogging RPF"].each do |fandom|
+    FactoryBot.create(:work, fandom_string: fandom)
+  end
+
+  # Create three works with two unconnected fandom tags (crossover works)
+  FactoryBot.create(:work,
+                    title: "First Work With Multiple Fandoms",
+                    fandom_string: "Hermitcraft SMP, Unrelated Fandom")
+  FactoryBot.create(:work,
+                    title: "Second Work With Multiple Fandoms",
+                    fandom_string: "Hermitcraft, Unrelated Fandom")
+  FactoryBot.create(:work,
+                    title: "Third Work With Multiple Fandoms",
+                    fandom_string: "Video Blogging RPF, Unrelated Fandom")
+
+  step %{all indexing jobs have been run}
+end
+
 Given /^a set of works with various categories for searching$/ do
   step %{basic tags}
 

--- a/spec/models/search/work_indexer_spec.rb
+++ b/spec/models/search/work_indexer_spec.rb
@@ -23,7 +23,7 @@ describe WorkIndexer, work_search: true do
     end
 
     context "with multiple works in a batch", :n_plus_one do
-      populate { |n| create_list(:work, n) }
+      populate { |n| create_list(:work, n, relationship_string: "a/b,c/d") }
 
       it "generates a constant number of database queries" do
         expect do

--- a/spec/models/search/work_indexer_spec.rb
+++ b/spec/models/search/work_indexer_spec.rb
@@ -23,7 +23,13 @@ describe WorkIndexer, work_search: true do
     end
 
     context "with multiple works in a batch", :n_plus_one do
-      populate { |n| create_list(:work, n, relationship_string: "a/b,c/d") }
+      let(:relationships) do
+        rel1 = create(:canonical_relationship, name: "aa/bb")
+        syn = create(:relationship, name: "a/b", merger: rel1)
+        rel2 = create(:relationship, name: "test")
+        [syn, rel2] # so that Work#otp doesn't take an early return
+      end
+      populate { |n| create_list(:work, n, relationships: relationships) }
 
       it "generates a constant number of database queries" do
         expect do


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6729

## Purpose

Separate the fandoms and relationships `includes` in the WorkIndexer into two separate method calls. If they are combined, the second set of tags ends up with tags of the first type in their return value. So, in this case the Fandom tags ended up in `relationships`. `relationships` is used in `#otp` to determine OTP status, so that gets messed up by the extra Fandom tag(s). 

I adjusted the existing N+1 spec that was added together with the `includes` in #4291 to make sure `#otp` hits the line that queries the [merger](https://github.com/otwcode/otwarchive/blob/47cc03880769f4256456598e94eed99a8d6e0faf/app/models/work.rb#L1251).

This preload going wrong is most likely a Rails bug, I found a few Rails 7.0+ issues related to preloading leading to wrongly returned records. However, I have not yet checked if this particular case was reported and/or fixed for a newer version of Rails. That would likely need a more isolated reproduction case. If anyone wants to have a go at it, the different tag types are accessed via the scoped `has_many` in [taggable.rb](https://github.com/otwcode/otwarchive/blob/47cc03880769f4256456598e94eed99a8d6e0faf/app/models/concerns/taggable.rb#L8-L15).

There are no other spots where `:merger` is preloaded.

## Testing Instructions

See Jira.

## Credit

Bilka
Sarken (for the otp search feature test) 
