### PR TITLE
AO3-6017 Use unique names for users in mailer previews

### DIFF
--- a/factories/users.rb
+++ b/factories/users.rb
@@ -25,6 +25,11 @@ FactoryBot.define do
       confirmed_at { nil }
     end
 
+    # User names used in mailer preview should be unique but recognizable as user names
+    trait :for_mailer_preview do
+      login { "User#{Faker::Alphanumeric.alpha(number: 8)}" }
+    end
+
     # Roles
 
     factory :archivist do

--- a/test/mailers/previews/admin_mailer_preview.rb
+++ b/test/mailers/previews/admin_mailer_preview.rb
@@ -1,7 +1,7 @@
 class AdminMailerPreview < ApplicationMailerPreview
   # Sent to an admin when they get a comment on an admin post
   def comment_notification
-    commenter = create(:user, login: "User#{Faker::Alphanumeric.alpha(number: 8)}")
+    commenter = create(:user, :for_mailer_preview)
     commenter_pseud = create(:pseud, user: commenter, name: "Custom pseud")
     comment = create(:comment, pseud: commenter_pseud)
     AdminMailer.comment_notification(comment.id)
@@ -9,7 +9,7 @@ class AdminMailerPreview < ApplicationMailerPreview
 
   # Sent to an admin when they get a comment on an admin post by an official user
   def comment_notification_official
-    commenter = create(:official_user, login: "User#{Faker::Alphanumeric.alpha(number: 8)}")
+    commenter = create(:official_user, :for_mailer_preview)
     comment = create(:comment, pseud: commenter.default_pseud)
     AdminMailer.comment_notification(comment.id)
   end
@@ -22,7 +22,7 @@ class AdminMailerPreview < ApplicationMailerPreview
 
   # Sent to an admin when a comment on an admin post is edited
   def edited_comment_notification
-    commenter = create(:user, login: "User#{Faker::Alphanumeric.alpha(number: 8)}")
+    commenter = create(:user, :for_mailer_preview)
     comment = create(:comment, pseud: commenter.default_pseud)
     AdminMailer.edited_comment_notification(comment.id)
   end

--- a/test/mailers/previews/admin_mailer_preview.rb
+++ b/test/mailers/previews/admin_mailer_preview.rb
@@ -1,15 +1,15 @@
 class AdminMailerPreview < ApplicationMailerPreview
   # Sent to an admin when they get a comment on an admin post
   def comment_notification
-    commenter = create(:user, login: "user#{Faker::Lorem.characters(number: 8)}")
-    commenter_pseud = create(:pseud, user: commenter, name: "custom pseud")
+    commenter = create(:user, login: "User#{Faker::Alphanumeric.alpha(number: 8)}")
+    commenter_pseud = create(:pseud, user: commenter, name: "Custom pseud")
     comment = create(:comment, pseud: commenter_pseud)
     AdminMailer.comment_notification(comment.id)
   end
 
   # Sent to an admin when they get a comment on an admin post by an official user
   def comment_notification_official
-    commenter = create(:official_user, login: "user#{Faker::Lorem.characters(number: 8)}")
+    commenter = create(:official_user, login: "User#{Faker::Alphanumeric.alpha(number: 8)}")
     comment = create(:comment, pseud: commenter.default_pseud)
     AdminMailer.comment_notification(comment.id)
   end
@@ -22,7 +22,7 @@ class AdminMailerPreview < ApplicationMailerPreview
 
   # Sent to an admin when a comment on an admin post is edited
   def edited_comment_notification
-    commenter = create(:user, login: "user#{Faker::Lorem.characters(number: 8)}")
+    commenter = create(:user, login: "User#{Faker::Alphanumeric.alpha(number: 8)}")
     comment = create(:comment, pseud: commenter.default_pseud)
     AdminMailer.edited_comment_notification(comment.id)
   end

--- a/test/mailers/previews/admin_mailer_preview.rb
+++ b/test/mailers/previews/admin_mailer_preview.rb
@@ -1,15 +1,15 @@
 class AdminMailerPreview < ApplicationMailerPreview
   # Sent to an admin when they get a comment on an admin post
   def comment_notification
-    commenter = create(:user, login: "Accumulator")
-    commenter_pseud = create(:pseud, user: commenter, name: "Blueprint")
+    commenter = create(:user, login: "user#{Faker::Lorem.characters(number: 8)}")
+    commenter_pseud = create(:pseud, user: commenter, name: "custom pseud")
     comment = create(:comment, pseud: commenter_pseud)
     AdminMailer.comment_notification(comment.id)
   end
 
   # Sent to an admin when they get a comment on an admin post by an official user
   def comment_notification_official
-    commenter = create(:official_user, login: "Centrifuge")
+    commenter = create(:official_user, login: "user#{Faker::Lorem.characters(number: 8)}")
     comment = create(:comment, pseud: commenter.default_pseud)
     AdminMailer.comment_notification(comment.id)
   end
@@ -22,7 +22,7 @@ class AdminMailerPreview < ApplicationMailerPreview
 
   # Sent to an admin when a comment on an admin post is edited
   def edited_comment_notification
-    commenter = create(:user, login: "Defender")
+    commenter = create(:user, login: "user#{Faker::Lorem.characters(number: 8)}")
     comment = create(:comment, pseud: commenter.default_pseud)
     AdminMailer.edited_comment_notification(comment.id)
   end

--- a/test/mailers/previews/comment_mailer_preview.rb
+++ b/test/mailers/previews/comment_mailer_preview.rb
@@ -3,7 +3,7 @@ class CommentMailerPreview < ApplicationMailerPreview
   def comment_notification
     user = create(:user)
 
-    commenter = create(:user, login: "User#{Faker::Alphanumeric.alpha(number: 8)}")
+    commenter = create(:user, :for_mailer_preview)
     commenter_pseud = create(:pseud, user: commenter, name: "Custom pseud")
     comment = create(:comment, pseud: commenter_pseud)
     CommentMailer.comment_notification(user, comment)
@@ -13,7 +13,7 @@ class CommentMailerPreview < ApplicationMailerPreview
   def comment_notification_official
     user = create(:user)
 
-    commenter = create(:official_user, login: "User#{Faker::Alphanumeric.alpha(number: 8)}")
+    commenter = create(:official_user, :for_mailer_preview)
     comment = create(:comment, pseud: commenter.default_pseud)
     CommentMailer.comment_notification(user, comment)
   end
@@ -29,7 +29,7 @@ class CommentMailerPreview < ApplicationMailerPreview
   def comment_reply_notification
     comment = create(:comment)
 
-    replier = create(:user, login: "User#{Faker::Alphanumeric.alpha(number: 8)}")
+    replier = create(:user, :for_mailer_preview)
     reply = create(:comment, commentable: comment, pseud: replier.default_pseud)
     CommentMailer.comment_reply_notification(comment, reply)
   end
@@ -46,7 +46,7 @@ class CommentMailerPreview < ApplicationMailerPreview
 
   # Sent to a user when they make a reply to a comment and they want to be notified of their own comments
   def comment_reply_sent_notification
-    commenter = create(:user, login: "User#{Faker::Alphanumeric.alpha(number: 8)}")
+    commenter = create(:user, :for_mailer_preview)
 
     comment = create(:comment, pseud: commenter.default_pseud)
     reply = create(:comment, commentable: comment)

--- a/test/mailers/previews/comment_mailer_preview.rb
+++ b/test/mailers/previews/comment_mailer_preview.rb
@@ -3,8 +3,8 @@ class CommentMailerPreview < ApplicationMailerPreview
   def comment_notification
     user = create(:user)
 
-    commenter = create(:user, login: "Accumulator")
-    commenter_pseud = create(:pseud, user: commenter, name: "Blueprint")
+    commenter = create(:user, login: "user#{Faker::Lorem.characters(number: 8)}")
+    commenter_pseud = create(:pseud, user: commenter, name: "custom pseud")
     comment = create(:comment, pseud: commenter_pseud)
     CommentMailer.comment_notification(user, comment)
   end
@@ -13,7 +13,7 @@ class CommentMailerPreview < ApplicationMailerPreview
   def comment_notification_official
     user = create(:user)
 
-    commenter = create(:official_user, login: "Centrifuge")
+    commenter = create(:official_user, login: "user#{Faker::Lorem.characters(number: 8)}")
     comment = create(:comment, pseud: commenter.default_pseud)
     CommentMailer.comment_notification(user, comment)
   end
@@ -29,7 +29,7 @@ class CommentMailerPreview < ApplicationMailerPreview
   def comment_reply_notification
     comment = create(:comment)
 
-    replier = create(:user, login: "Defender")
+    replier = create(:user, login: "user#{Faker::Lorem.characters(number: 8)}")
     reply = create(:comment, commentable: comment, pseud: replier.default_pseud)
     CommentMailer.comment_reply_notification(comment, reply)
   end
@@ -46,7 +46,7 @@ class CommentMailerPreview < ApplicationMailerPreview
 
   # Sent to a user when they make a reply to a comment and they want to be notified of their own comments
   def comment_reply_sent_notification
-    commenter = create(:user, login: "Exoskeleton")
+    commenter = create(:user, login: "user#{Faker::Lorem.characters(number: 8)}")
 
     comment = create(:comment, pseud: commenter.default_pseud)
     reply = create(:comment, commentable: comment)

--- a/test/mailers/previews/comment_mailer_preview.rb
+++ b/test/mailers/previews/comment_mailer_preview.rb
@@ -3,8 +3,8 @@ class CommentMailerPreview < ApplicationMailerPreview
   def comment_notification
     user = create(:user)
 
-    commenter = create(:user, login: "user#{Faker::Lorem.characters(number: 8)}")
-    commenter_pseud = create(:pseud, user: commenter, name: "custom pseud")
+    commenter = create(:user, login: "User#{Faker::Alphanumeric.alpha(number: 8)}")
+    commenter_pseud = create(:pseud, user: commenter, name: "Custom pseud")
     comment = create(:comment, pseud: commenter_pseud)
     CommentMailer.comment_notification(user, comment)
   end
@@ -13,7 +13,7 @@ class CommentMailerPreview < ApplicationMailerPreview
   def comment_notification_official
     user = create(:user)
 
-    commenter = create(:official_user, login: "user#{Faker::Lorem.characters(number: 8)}")
+    commenter = create(:official_user, login: "User#{Faker::Alphanumeric.alpha(number: 8)}")
     comment = create(:comment, pseud: commenter.default_pseud)
     CommentMailer.comment_notification(user, comment)
   end
@@ -29,7 +29,7 @@ class CommentMailerPreview < ApplicationMailerPreview
   def comment_reply_notification
     comment = create(:comment)
 
-    replier = create(:user, login: "user#{Faker::Lorem.characters(number: 8)}")
+    replier = create(:user, login: "User#{Faker::Alphanumeric.alpha(number: 8)}")
     reply = create(:comment, commentable: comment, pseud: replier.default_pseud)
     CommentMailer.comment_reply_notification(comment, reply)
   end
@@ -46,7 +46,7 @@ class CommentMailerPreview < ApplicationMailerPreview
 
   # Sent to a user when they make a reply to a comment and they want to be notified of their own comments
   def comment_reply_sent_notification
-    commenter = create(:user, login: "user#{Faker::Lorem.characters(number: 8)}")
+    commenter = create(:user, login: "User#{Faker::Alphanumeric.alpha(number: 8)}")
 
     comment = create(:comment, pseud: commenter.default_pseud)
     reply = create(:comment, commentable: comment)

--- a/test/mailers/previews/user_mailer_preview.rb
+++ b/test/mailers/previews/user_mailer_preview.rb
@@ -38,8 +38,8 @@ class UserMailerPreview < ApplicationMailerPreview
   private
 
   def creatorship_notification_data
-    first_creator = create(:user, login: "user1#{Faker::Lorem.characters(number: 8)}")
-    second_creator = create(:user, login: "user2#{Faker::Lorem.characters(number: 8)}")
+    first_creator = create(:user, login: "User1#{Faker::Alphanumeric.alpha(number: 8)}")
+    second_creator = create(:user, login: "User2#{Faker::Alphanumeric.alpha(number: 8)}")
     work = create(:work, authors: [first_creator.default_pseud, second_creator.default_pseud])
     second_creatorship = Creatorship.find_by(creation: work, pseud: second_creator.default_pseud)
     [second_creatorship, first_creator]

--- a/test/mailers/previews/user_mailer_preview.rb
+++ b/test/mailers/previews/user_mailer_preview.rb
@@ -38,8 +38,8 @@ class UserMailerPreview < ApplicationMailerPreview
   private
 
   def creatorship_notification_data
-    first_creator = create(:user, login: "User1#{Faker::Alphanumeric.alpha(number: 8)}")
-    second_creator = create(:user, login: "User2#{Faker::Alphanumeric.alpha(number: 8)}")
+    first_creator = create(:user, :for_mailer_preview)
+    second_creator = create(:user, :for_mailer_preview)
     work = create(:work, authors: [first_creator.default_pseud, second_creator.default_pseud])
     second_creatorship = Creatorship.find_by(creation: work, pseud: second_creator.default_pseud)
     [second_creatorship, first_creator]

--- a/test/mailers/previews/user_mailer_preview.rb
+++ b/test/mailers/previews/user_mailer_preview.rb
@@ -38,8 +38,8 @@ class UserMailerPreview < ApplicationMailerPreview
   private
 
   def creatorship_notification_data
-    first_creator = create(:user, login: "JayceHexmaster")
-    second_creator = create(:user, login: "viktor_the_machine")
+    first_creator = create(:user, login: "user1#{Faker::Lorem.characters(number: 8)}")
+    second_creator = create(:user, login: "user2#{Faker::Lorem.characters(number: 8)}")
     work = create(:work, authors: [first_creator.default_pseud, second_creator.default_pseud])
     second_creatorship = Creatorship.find_by(creation: work, pseud: second_creator.default_pseud)
     [second_creatorship, first_creator]


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6017

## Purpose

Fix Error 422 "Validation failed: User name has already been taken" in some mailer previews on staging. This is done by using generated and thus hopefully unique user names when creating users for the previews.

## Testing Instructions

Visit https://test.archiveofourown.org/rails/mailers/admin_mailer/comment_notification_official and https://test.archiveofourown.org/rails/mailers/comment_mailer/comment_reply_sent_notification and make sure they display working emails, not "Error 422".

## Credit

Bilka (he/him)
