### PR TITLE
Revert "AO3-6570 Import Work error message overflows for long URLs (#4716)"

### DIFF
--- a/public/stylesheets/site/2.0/22-system-messages.css
+++ b/public/stylesheets/site/2.0/22-system-messages.css
@@ -37,7 +37,6 @@ div.error {
   clear: right;
     box-shadow: inset 1px 1px 2px;
     border-radius: 0.25em;
-    word-wrap: break-word;
 }
 
 .caution {


### PR DESCRIPTION
This reverts commit 812d9663152c4860760dae299fc23b8db60f4f8b.

## Issue

https://otwarchive.atlassian.net/browse/AO3-6570 

## Purpose

What does this PR do?

## Testing Instructions

How can the Archive's QA team verify that this is working as you intended?

If you have a Jira account with access, please update or comment on the issue
with any new or missing testing instructions instead.

## References

Are there other relevant issues/pull requests/mailing list discussions?

## Credit

What name and pronouns should we use to credit you in the [Archive of Our Own's Release Notes](https://archiveofourown.org/admin_posts?tag=1)?

If you have a Jira account, please include the same name in the "Full name"
field on your Jira profile, so we can assign you the issues you're working on.

*Please note that if you do not fill in this section, we will use your GitHub account name and
they/them pronouns.*
