### PR TITLE
AO3-5506 Don't include hidden works in Readings: fixed query

### DIFF
--- a/app/controllers/readings_controller.rb
+++ b/app/controllers/readings_controller.rb
@@ -10,13 +10,13 @@ class ReadingsController < ApplicationController
   end
 
   def index
-    @readings = @user.readings
+    @readings = @user.readings.visible
     @page_subtitle = ts("History")
     if params[:show] == 'to-read'
       @readings = @readings.where(toread: true)
       @page_subtitle = ts("Marked For Later")
     end
-    @readings = @readings.left_joins(:work).merge(Work.visible_to_registered_user).or(Work.where(id: nil)).order("last_viewed DESC").page(params[:page])
+    @readings = @readings.last_viewed.page(params[:page])
   end
 
   def destroy

--- a/app/controllers/readings_controller.rb
+++ b/app/controllers/readings_controller.rb
@@ -16,7 +16,7 @@ class ReadingsController < ApplicationController
       @readings = @readings.where(toread: true)
       @page_subtitle = ts("Marked For Later")
     end
-    @readings = @readings.last_viewed.page(params[:page])
+    @readings = @readings.order("last_viewed DESC").page(params[:page])
   end
 
   def destroy

--- a/app/decorators/homepage.rb
+++ b/app/decorators/homepage.rb
@@ -46,13 +46,13 @@ class Homepage
   def readings
     return unless logged_in? && @user.preference.try(:history_enabled?)
     if Rails.env.development?
-      @readings ||= @user.readings.random_order.
+      @readings ||= @user.readings.visible.random_order.
           limit(ArchiveConfig.NUMBER_OF_ITEMS_VISIBLE_ON_HOMEPAGE).
           where(toread: true).
           all
     else
       @readings ||= Rails.cache.fetch("home/index/#{@user.id}/home_marked_for_later") do
-        @user.readings.random_order.
+        @user.readings.visible.random_order.
           limit(ArchiveConfig.NUMBER_OF_ITEMS_VISIBLE_ON_HOMEPAGE).
           where(toread: true).
           to_a

--- a/app/decorators/homepage.rb
+++ b/app/decorators/homepage.rb
@@ -15,7 +15,7 @@ class Homepage
     @fandom_count = Rails.cache.fetch("/v1/home/counts/fandom", expires_in: 40.minutes) do
       estimate_number(Fandom.canonical.count)
     end
-    return @user_count, @work_count, @fandom_count
+    [@user_count, @work_count, @fandom_count]
   end
 
   def logged_in?
@@ -23,45 +23,48 @@ class Homepage
   end
 
   def admin_posts
-    if Rails.env.development?
-      @admin_posts = AdminPost.non_translated.for_homepage.all
-    else
-      @admin_posts = Rails.cache.fetch("home/index/home_admin_posts", expires_in: 20.minutes) do
-        AdminPost.non_translated.for_homepage.to_a
-      end
-    end
+    @admin_posts = if Rails.env.development?
+                     AdminPost.non_translated.for_homepage.all
+                   else
+                     Rails.cache.fetch("home/index/home_admin_posts", expires_in: 20.minutes) do
+                       AdminPost.non_translated.for_homepage.to_a
+                     end
+                   end
   end
 
   def favorite_tags
     return unless logged_in?
-    if Rails.env.development?
-      @favorite_tags ||= @user.favorite_tags.to_a.sort_by { |favorite_tag| favorite_tag.tag.sortable_name.downcase }
-    else
-      @favorite_tags ||= Rails.cache.fetch("home/index/#{@user.id}/home_favorite_tags") do
-        @user.favorite_tags.to_a.sort_by { |favorite_tag| favorite_tag.tag.sortable_name.downcase }
-      end
-    end
+
+    @favorite_tags ||= if Rails.env.development?
+                         @user.favorite_tags.to_a.sort_by { |favorite_tag| favorite_tag.tag.sortable_name.downcase }
+                       else
+                         Rails.cache.fetch("home/index/#{@user.id}/home_favorite_tags") do
+                           @user.favorite_tags.to_a.sort_by { |favorite_tag| favorite_tag.tag.sortable_name.downcase }
+                         end
+                       end
   end
 
   def readings
     return unless logged_in? && @user.preference.try(:history_enabled?)
-    if Rails.env.development?
-      @readings ||= @user.readings.visible.random_order.
-          limit(ArchiveConfig.NUMBER_OF_ITEMS_VISIBLE_ON_HOMEPAGE).
-          where(toread: true).
-          all
-    else
-      @readings ||= Rails.cache.fetch("home/index/#{@user.id}/home_marked_for_later") do
-        @user.readings.visible.random_order.
-          limit(ArchiveConfig.NUMBER_OF_ITEMS_VISIBLE_ON_HOMEPAGE).
-          where(toread: true).
-          to_a
-      end
-    end
+
+    @readings ||= if Rails.env.development?
+                    @user.readings.visible.random_order
+                      .limit(ArchiveConfig.NUMBER_OF_ITEMS_VISIBLE_ON_HOMEPAGE)
+                      .where(toread: true)
+                      .all
+                  else
+                    Rails.cache.fetch("home/index/#{@user.id}/home_marked_for_later") do
+                      @user.readings.visible.random_order
+                        .limit(ArchiveConfig.NUMBER_OF_ITEMS_VISIBLE_ON_HOMEPAGE)
+                        .where(toread: true)
+                        .to_a
+                    end
+                  end
   end
 
   def inbox_comments
     return unless logged_in?
+
     @inbox_comments ||= @user.inbox_comments.with_bad_comments_removed.for_homepage
   end
 end

--- a/app/models/reading.rb
+++ b/app/models/reading.rb
@@ -5,6 +5,9 @@ class Reading < ApplicationRecord
   after_save :expire_cached_home_marked_for_later, if: :saved_change_to_toread?
   after_destroy :expire_cached_home_marked_for_later, if: :toread?
 
+  scope :visible, -> { left_joins(:work).merge(Work.visible_to_registered_user.or(Work.where(id: nil))) }
+  scope :last_viewed, -> { order("last_viewed DESC") }
+
   # called from show in work controller
   def self.update_or_create(work, user)
     if user && user.preference.try(:history_enabled) && !user.is_author_of?(work)

--- a/app/models/reading.rb
+++ b/app/models/reading.rb
@@ -6,7 +6,6 @@ class Reading < ApplicationRecord
   after_destroy :expire_cached_home_marked_for_later, if: :toread?
 
   scope :visible, -> { left_joins(:work).merge(Work.visible_to_registered_user.or(Work.where(id: nil))) }
-  scope :last_viewed, -> { order("last_viewed DESC") }
 
   # called from show in work controller
   def self.update_or_create(work, user)

--- a/factories/readings.rb
+++ b/factories/readings.rb
@@ -1,0 +1,14 @@
+require "faker"
+
+FactoryBot.define do
+  factory :reading do
+    user_id { FactoryBot.create(:user).id }
+    work_id { FactoryBot.create(:work).id }
+
+    # A reading with a deleted work means a reading with a work_id that
+    # doesn't exist. Here we use 0 because it will never be used as an id.
+    trait :deleted_work do
+      work_id { 0 }
+    end
+  end
+end

--- a/spec/controllers/readings_controller_spec.rb
+++ b/spec/controllers/readings_controller_spec.rb
@@ -1,0 +1,150 @@
+require "spec_helper"
+
+describe ReadingsController do
+  include LoginMacros
+  include RedirectExpectationHelper
+
+  let(:user) { create(:user) }
+
+  describe "GET #index" do
+    context "with user params" do
+      context "when logged in as admin" do
+        it "redirects to login page with error" do
+          fake_login_admin(create(:admin))
+          get :index, params: { user_id: user }
+          it_redirects_to_with_error(new_user_session_path, "Sorry, you don't have permission to access the page you were trying to reach. Please log in.")
+        end
+      end
+
+      context "when logged out" do
+        it "redirects to login page with error" do
+          get :index, params: { user_id: user }
+          it_redirects_to_with_error(new_user_session_path, "Sorry, you don't have permission to access the page you were trying to reach. Please log in.")
+        end
+      end
+
+      context "when logged in as another user" do
+        it "redirects to requested user's dashboard with error" do
+          fake_login
+          get :index, params: { user_id: user }
+          it_redirects_to_with_error(user_path(user), "Sorry, you don't have permission to access the page you were trying to reach.")
+        end
+      end
+
+      context "when logged in as the user" do
+        it "includes user's readings sorted by last_viewed" do
+          reading1 = create(:reading, user: user, last_viewed: 2.days.ago)
+          reading2 = create(:reading, user: user, last_viewed: 1.hour.ago)
+          reading3 = create(:reading, user: user, last_viewed: 5.hours.ago)
+          reading4 = create(:reading)
+
+          fake_login_known_user(user)
+          get :index, params: { user_id: user }
+          expect(assigns(:readings)).to eq([reading2, reading3, reading1])
+          expect(assigns(:readings)).not_to include(reading4)
+        end
+
+        it "includes user's readings for restricted works" do
+          work = create(:work, restricted: true)
+          reading1 = create(:reading, user: user, work: work)
+          reading2 = create(:reading, work: work)
+
+          fake_login_known_user(user)
+          get :index, params: { user_id: user }
+          expect(assigns(:readings)).to include(reading1)
+          expect(assigns(:readings)).not_to include(reading2)
+        end
+
+        it "includes user's readings for deleted works" do
+          reading1 = create(:reading, :deleted_work, user: user)
+          reading2 = create(:reading, :deleted_work)
+
+          fake_login_known_user(user)
+          get :index, params: { user_id: user }
+          expect(assigns(:readings)).to include(reading1)
+          expect(assigns(:readings)).not_to include(reading2)
+        end
+
+        it "excludes user's readings for hidden works" do
+          work = create(:work, hidden_by_admin: true)
+          reading1 = create(:reading, user: user, work: work)
+          reading2 = create(:reading, work: work)
+
+          fake_login_known_user(user)
+          get :index, params: { user_id: user }
+          expect(assigns(:readings)).not_to include(reading1)
+          expect(assigns(:readings)).not_to include(reading2)
+        end
+
+        it "excludes user's readings for draft works" do
+          work = create(:draft)
+          reading1 = create(:reading, user: user, work: work)
+          reading2 = create(:reading, work: work)
+
+          fake_login_known_user(user)
+          get :index, params: { user_id: user }
+          expect(assigns(:readings)).not_to include(reading1)
+          expect(assigns(:readings)).not_to include(reading2)
+        end
+
+        context "with show=to-read params" do
+          it "includes user's toread readings sorted by last_viewed" do
+            reading1 = create(:reading, user: user, last_viewed: 2.days.ago, toread: true)
+            reading2 = create(:reading, user: user, last_viewed: 1.hour.ago, toread: true)
+            reading3 = create(:reading, user: user, last_viewed: 12.hours.ago)
+            reading4 = create(:reading, toread: true)
+
+            fake_login_known_user(user)
+            get :index, params: { user_id: user, show: "to-read" }
+            expect(assigns(:readings)).to eq([reading2, reading1])
+            expect(assigns(:readings)).not_to include(reading3)
+            expect(assigns(:readings)).not_to include(reading4)
+          end
+
+          it "includes user's toread readings for restricted works" do
+            work = create(:work, restricted: true)
+            reading1 = create(:reading, user: user, work: work, toread: true)
+            reading2 = create(:reading, work: work, toread: true)
+
+            fake_login_known_user(user)
+            get :index, params: { user_id: user, show: "to-read" }
+            expect(assigns(:readings)).to include(reading1)
+            expect(assigns(:readings)).not_to include(reading2)
+          end
+
+          it "includes user's toread readings for deleted works" do
+            reading1 = create(:reading, :deleted_work, user: user, toread: true)
+            reading2 = create(:reading, :deleted_work, toread: true)
+
+            fake_login_known_user(user)
+            get :index, params: { user_id: user, show: "to-read" }
+            expect(assigns(:readings)).to include(reading1)
+            expect(assigns(:readings)).not_to include(reading2)
+          end
+
+          it "excludes user's toread readings for hidden works" do
+            work = create(:work, hidden_by_admin: true)
+            reading1 = create(:reading, user: user, work: work, toread: true)
+            reading2 = create(:reading, work: work, toread: true)
+
+            fake_login_known_user(user)
+            get :index, params: { user_id: user, show: "to-read" }
+            expect(assigns(:readings)).not_to include(reading1)
+            expect(assigns(:readings)).not_to include(reading2)
+          end
+
+          it "excludes user's toread readings for draft works" do
+            work = create(:draft)
+            reading1 = create(:reading, user: user, work: work, toread: true)
+            reading2 = create(:reading, work: work, toread: true)
+
+            fake_login_known_user(user)
+            get :index, params: { user_id: user, show: "to-read" }
+            expect(assigns(:readings)).not_to include(reading1)
+            expect(assigns(:readings)).not_to include(reading2)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/models/reading_spec.rb
+++ b/spec/models/reading_spec.rb
@@ -1,0 +1,34 @@
+require "spec_helper"
+
+describe Reading do
+  it "has a valid factory" do
+    expect(create(:reading)).to be_valid
+  end
+
+  describe ".visible" do
+    it "excludes readings for unposted works" do
+      reading = create(:reading, work: create(:draft))
+      expect(Reading.visible).not_to include(reading)
+    end
+
+    it "excludes readings for works hidden by admin" do
+      reading = create(:reading, work: create(:work, hidden_by_admin: true))
+      expect(Reading.visible).not_to include(reading)
+    end
+
+    it "includes readings for deleted works" do
+      reading = create(:reading, :deleted_work)
+      expect(Reading.visible).to include(reading)
+    end
+
+    it "includes readings for restricted works" do
+      reading = create(:reading, work: create(:work, restricted: true))
+      expect(Reading.visible).to include(reading)
+    end
+
+    it "includes readings for regular works" do
+      reading = create(:reading)
+      expect(Reading.visible).to include(reading)
+    end
+  end
+end

--- a/spec/models/search/homepage_decorator_spec.rb
+++ b/spec/models/search/homepage_decorator_spec.rb
@@ -1,0 +1,64 @@
+require "spec_helper"
+
+describe Homepage do
+  let(:user) { create(:user) }
+
+  describe "#readings" do
+    it "includes user's toread readings" do
+      reading1 = create(:reading, user: user, toread: true)
+      reading2 = create(:reading, toread: true)
+
+      homepage = Homepage.new(user)
+      expect(homepage.readings).to include(reading1)
+      expect(homepage.readings).not_to include(reading2)
+    end
+
+    it "excludes user's readings that are not toread" do
+      reading1 = create(:reading, user: user)
+      reading2 = create(:reading)
+
+      homepage = Homepage.new(user)
+      expect(homepage.readings).not_to include(reading1)
+      expect(homepage.readings).not_to include(reading2)
+    end
+
+    it "includes user's toread readings for restricted works" do
+      work = create(:work, restricted: true)
+      reading1 = create(:reading, user: user, toread: true, work: work)
+      reading2 = create(:reading, toread: true, work: work)
+
+      homepage = Homepage.new(user)
+      expect(homepage.readings).to include(reading1)
+      expect(homepage.readings).not_to include(reading2)
+    end
+
+    it "includes user's toread readings for deleted works" do
+      reading1 = create(:reading, :deleted_work, user: user, toread: true)
+      reading2 = create(:reading, :deleted_work, toread: true)
+
+      homepage = Homepage.new(user)
+      expect(homepage.readings).to include(reading1)
+      expect(homepage.readings).not_to include(reading2)
+    end
+
+    it "excludes user's toread readings for hidden works" do
+      work = create(:work, hidden_by_admin: true)
+      reading1 = create(:reading, user: user, toread: true, work: work)
+      reading2 = create(:reading, toread: true, work: work)
+
+      homepage = Homepage.new(user)
+      expect(homepage.readings).not_to include(reading1)
+      expect(homepage.readings).not_to include(reading2)
+    end
+
+    it "excludes user's toread readings for draft works" do
+      work = create(:draft)
+      reading1 = create(:reading, user: user, toread: true, work: work)
+      reading2 = create(:reading, toread: true, work: work)
+
+      homepage = Homepage.new(user)
+      expect(homepage.readings).not_to include(reading1)
+      expect(homepage.readings).not_to include(reading2)
+    end
+  end
+end


### PR DESCRIPTION
Move `.or()` inside `.merge()` to prevent showing deleted works from other user's reading lists showing on all users' reading lists.

# Pull Request Checklist

* [x] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [ ] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [x] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [x] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

Fix for bug in AO3-5506 implementation: https://otwarchive.atlassian.net/browse/AO3-5506?focusedCommentId=361327

## Purpose

https://github.com/otwcode/otwarchive/pull/4781/ excluded admin works and never published works from the reading list. 

However there was a bug. `.or()` needs to be moved inside `.merge()` to ensure the generated SQL is correct. Previously deleted works from other users' reading lists were being shown for all users.

Bad SQL:

```
SELECT `readings`.* FROM `readings` LEFT OUTER JOIN `works` ON `works`.`id` = `readings`.`work_id` WHERE (`readings`.`user_id` = 1 AND `works`.`posted` = TRUE AND `works`.`hidden_by_admin` = FALSE OR `works`.`id` IS NULL) ORDER BY last_viewed DESC LIMIT 25 OFFSET 0
```

Fixed SQL:

```
SELECT `readings`.* FROM `readings` LEFT OUTER JOIN `works` ON `works`.`id` = `readings`.`work_id` WHERE `readings`.`user_id` = 37 AND (`works`.`posted` = TRUE AND `works`.`hidden_by_admin` = FALSE OR `works`.`id` IS NULL) ORDER BY last_viewed DESC LIMIT 25 OFFSET 0
```

## Testing Instructions

1. Add a work to the reading list for user 1
2. Check that it shows "Deleted work" on the reading list for user 1
3. Log into a second new user 2, the reading list should be empty (no "Deleted work" should show)

## References

https://github.com/otwcode/otwarchive/pull/4781/

## Credit

@de3sw2aq1