### PR TITLE
AO3-6706 Fix Redis test config for non-docker

### DIFF
--- a/config/initializers/gem-plugin_config/redis.rb
+++ b/config/initializers/gem-plugin_config/redis.rb
@@ -5,7 +5,7 @@ rails_root = ENV["RAILS_ROOT"] || "#{File.dirname(__FILE__)}/../../.."
 rails_env = (ENV["RAILS_ENV"] || "development").to_sym
 
 # https://gist.github.com/441072
-start_redis!(rails_root, :cucumber) if rails_env == "test" && !(ENV["CI"] || ENV["DOCKER"])
+start_redis!(rails_root, :cucumber) if rails_env == :test && !(ENV["CI"] || ENV["DOCKER"])
 
 redis_configs = YAML.load_file("#{rails_root}/config/redis.yml", symbolize_names: true)
 redis_configs.each_pair do |name, redis_config|


### PR DESCRIPTION
# Pull Request Checklist

## Issue

https://otwarchive.atlassian.net/browse/AO3-6706

## Purpose

Fixes the redis initializer to properly launch during tests (when not using Docker or CI)

## References

Issue identified by @sarken in https://otwarchive.atlassian.net/browse/AO3-6706?focusedCommentId=361335
