### PR TITLE
AO3-6739 Display moderated commenting notice on individual chapters

### DIFF
--- a/app/views/comments/_comment_form.html.erb
+++ b/app/views/comments/_comment_form.html.erb
@@ -28,10 +28,11 @@
 
       <% if comments_are_moderated(commentable) && !current_user_is_work_creator(commentable) %>
         <p class="notice">
-          <%# i18n-tasks-use
-              t("comments.commentable.permissions.moderated_commenting.notice.admin_post")
-              t("comments.commentable.permissions.moderated_commenting.notice.work") %>
-          <%= t("comments.commentable.permissions.moderated_commenting.notice.#{commentable.model_name.i18n_key}") %>
+          <% if commentable.is_a?(AdminPost) %>
+            <%= t("comments.commentable.permissions.moderated_commenting.notice.admin_post") %>
+          <% else %>
+            <%= t("comments.commentable.permissions.moderated_commenting.notice.work") %>
+          <% end %>
         </p>
       <% end %>
 

--- a/features/comments_and_kudos/comment_moderation.feature
+++ b/features/comments_and_kudos/comment_moderation.feature
@@ -37,10 +37,13 @@ Feature: Comment Moderation
       And I set up the draft "Moderation"
       And I check "Enable comment moderation"
       And I post the work without preview
+      And I post a chapter for the work "Moderation"
     Then comment moderation should be enabled on "Moderation"
     When I am logged in as "commenter"
-      And I view the work "Moderation"
-    Then I should see "has chosen to moderate comments"
+      And I go to the work "Moderation" in full mode
+    Then I should see "This work's creator has chosen to moderate comments on the work. Your comment will not appear until it has been approved by the creator."
+    When I go to the 2nd chapter of the work "Moderation"
+    Then I should see "This work's creator has chosen to moderate comments on the work. Your comment will not appear until it has been approved by the creator."
 
   Scenario: Post a moderated comment
     Given the moderated work "Moderation" by "author"


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6739

## Purpose

If you accessed at a work with moderated commenting enabled in chapter-by-chapter mode, it said "Chapter" (the i18n key, which was wrong -- there's not a dedicated notice for chapters) instead of "This work's creator has chosen to moderate comments on the work. Your comment will not appear until it has been approved by the creator." 

Now it uses the right key and says the big long thing.

## Testing Instructions

Refer to Jira.

## References

https://github.com/otwcode/otwarchive/pull/4790
