### PR TITLE
AO3-5744 Fix following relative redirects in work importing

### DIFF
--- a/app/models/story_parser.rb
+++ b/app/models/story_parser.rb
@@ -805,7 +805,9 @@ class StoryParser
           story = response.body
         when Net::HTTPRedirection
           if limit.positive?
-            story = download_with_timeout(response['location'], limit - 1)
+            new_uri = URI.parse(response["location"])
+            new_uri = URI.join(uri, new_uri) if new_uri.relative?
+            story = download_with_timeout(new_uri.to_s, limit - 1)
           end
         else
           Rails.logger.error("------- STORY PARSER: download_with_timeout: response is not success or redirection ------")

--- a/spec/models/story_parser_spec.rb
+++ b/spec/models/story_parser_spec.rb
@@ -155,6 +155,29 @@ describe StoryParser do
     end
   end
 
+  describe "#download_text" do
+    before do
+      WebMock.stub_request(:get, "http://example.org/foo")
+        .to_return(status: 200, body: "the response of the redirect target", headers: {})
+    end
+
+    it "follows relative redirects" do
+      input_url = "http://example.org/bar"
+      WebMock.stub_request(:get, input_url)
+        .to_return(status: 302, headers: { "Location" => "/foo" })
+
+      expect(@sp.send(:download_text, input_url)).to eq("the response of the redirect target")
+    end
+
+    it "follows absolute redirects" do
+      input_url = "http://foo.com/"
+      WebMock.stub_request(:get, input_url)
+        .to_return(status: 302, headers: { "Location" => "http://example.org/foo" })
+
+      expect(@sp.send(:download_text, input_url)).to eq("the response of the redirect target")
+    end
+  end
+
   describe "#parse_common" do
     it "converts relative to absolute links" do
       # This one doesn't work because the sanitizer is converting the & to &amp;


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5744

## Purpose

Handle relative redirects in work importing by using the original request host for relative redirect targets instead of trying to directly go to a target like `/856.html`. 

## Testing Instructions

More candidate URLs for testing are multichapter works on otwarchive sites because they do a relative redirect to the first chapter. E.g. https://squidgeworld.org/works/34491 redirects to /works/34491/chapters/76104

## Credit

Bilka (he/him)
