### PR TITLE
AO3-6714 Prevent tag sets becoming ownerless

### DIFF
--- a/features/step_definitions/tag_set_steps.rb
+++ b/features/step_definitions/tag_set_steps.rb
@@ -22,7 +22,8 @@ end
 # ...with a visible tag list
 # ...with the fandom tags "x, y, z" and the character tags "a, b, c"
 # ...with an invisible tag list and the freeform tags "m, n, o"
-When /^I set up the tag ?set "([^\"]*)" with(?: (?:an? )(visible|invisible) tag list and)? (.*)$/ do |title, visibility, tags|
+# ...with owners "a, b, c" and the freeform tags "x"
+When /^I set up the tag ?set "([^\"]*)" with(?: (?:an? )(visible|invisible) tag list and)?(:? owners "([^\"]*)" and)? (.*)$/ do |title, visibility, owners, tags|
   unless OwnedTagSet.find_by(title: title).present?
     visit new_tag_set_path
     fill_in("owned_tag_set_title", with: title)
@@ -31,6 +32,7 @@ When /^I set up the tag ?set "([^\"]*)" with(?: (?:an? )(visible|invisible) tag 
     check("owned_tag_set_visible") if visibility == "visible"
     uncheck("owned_tag_set_visible") if visibility == "invisible"
     step %{I add #{tags} to the tag set}
+    step %{I toggle the owners "#{owners}"}
     step %{I submit}
     step %{I should see a create confirmation message}
   end
@@ -60,6 +62,12 @@ When /^I remove (.*) from the tag ?set "([^\"]*)"$/ do |tags, title|
   end
   step %{I submit}
   step %{I should see an update confirmation message}
+end
+
+# Takes things like When I toggle the owners "tagsetter"
+# Don't forget the extra s, even if it's singular.
+When /^I toggle the owners "([^\"]*)"$/ do |owners|
+  fill_in("owned_tag_set_owner_changes", with: owners) if owners.present?
 end
 
 When /^I set up the nominated tag ?set "([^\"]*)" with (\d*) fandom noms? and (\d*) (character|relationship) noms?$/ do |title, fandom_count, nested_count, nested_type|
@@ -205,4 +213,8 @@ end
 
 Then /^"([^\"]*)" should be an unassociated tag$/ do |tag|
   step %{I should see "#{tag}" within "ol#list_for_unassociated_char_and_rel"}
+end
+
+Then /^Maintainers should be "([^\"]*)"$/ do |maintainers|
+  step %{I should see "#{maintainers}" within ".meta"}
 end

--- a/features/tag_sets/tag_set.feature
+++ b/features/tag_sets/tag_set.feature
@@ -10,7 +10,27 @@ Feature: Creating and editing tag sets
     And I submit
   Then I should see a create confirmation message
     And I should see "About Empty Tag Set"
-    And I should see "tagsetter" within ".meta"
+    And Maintainers should be "tagsetter"
+
+  Scenario: A user should be able to create a tag set with an additional owner
+  Given I am logged in as "tagsetter"
+    And the following activated users exist
+      | login         | password   |
+      | anotherowner  | password   |
+    And I set up the tag set "Additional Owner" with owners "anotherowner" and the freeform tags "Shared Responsibilities"
+  Then I should see a create confirmation message
+    And Maintainers should be "anotherowner tagsetter"
+
+  Scenario: A user should not be able to remove themselves as an owner (AO3-6714)
+  Given I am logged in as "tagsetter"
+    And I set up the tag set "Duplicate Ownership" with owners "tagsetter" and the freeform tags "Clones"
+  Then I should see a create confirmation message
+    And I should see "tagsetter tagsetter" within ".meta"
+  When I go to the "Duplicate Ownership" tag set edit page
+    And I toggle the owners "tagsetter"
+    And I submit
+  Then I should see an update confirmation message
+    And Maintainers should be "tagsetter"
 
   Scenario: A user should be able to create a tag set with noncanonical tags
   Given I am logged in as "tagsetter"


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [x] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [x] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [x] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-6714

## Purpose

This PR implements point 2. of the "What should happen" section of AO3-6714. For that specific case, if you:

- Are already an owner of a tagset more than once
- Edit the tagset
- Remove yourself as an owner

You are now only removed as a tagset owner once. You remain a tagset owner at least once. This means the tagset cannot be orphaned.

In more general terms, this PR enforces that when removing owners from a tagset:
- The number of `TagSetOwnership` records removed is at most one
- At least one `TagSetOwnership` records exist for an `OwnedTagSet`

## Testing Instructions

Follow the reproduction instructions in AO3-6714. You will still be able to create a tagset where a single user owns it twice, but you can no longer remove all owners from the tagset.

## References

N/A

## Credit

> What name and pronouns should we use to credit you in the [Archive of Our Own's Release Notes](https://archiveofourown.org/admin_posts?tag=1)?

Tom Milligan (they/them)
