### PR TITLE
AO3-6232 Include IP, referer, skin in support tickets

### DIFF
--- a/app/controllers/feedbacks_controller.rb
+++ b/app/controllers/feedbacks_controller.rb
@@ -20,7 +20,7 @@ class FeedbacksController < ApplicationController
     @feedback.user_agent = request.env["HTTP_USER_AGENT"]
     @feedback.ip_address = request.remote_ip
     @feedback.referer = request.referer if request.referer && ArchiveConfig.PERMITTED_HOSTS.include?(URI(request.referer).host)
-    @feedback.site_skin = current_skin
+    @feedback.site_skin = helpers.current_skin
     if @feedback.save
       @feedback.email_and_send
       flash[:notice] = t("successfully_sent",
@@ -37,13 +37,6 @@ class FeedbacksController < ApplicationController
 
   def load_support_languages
     @support_languages = Language.where(support_available: true).default_order
-  end
-
-  def current_skin
-    skin = Skin.approved_or_owned_by.usable.find_by(id: session[:site_skin]) if session[:site_skin]
-    skin ||= current_user&.preference&.skin
-    skin ||= Skin.default
-    skin
   end
 
   def feedback_params

--- a/app/helpers/skins_helper.rb
+++ b/app/helpers/skins_helper.rb
@@ -36,7 +36,7 @@ module SkinsHelper
     skin = current_skin
     return "" unless skin
 
-    # We include the version information for both the skin_id and the
+    # We include the version information for both the skin's id and the
     # AdminSetting.default_skin_id because the default skin is used in skins of
     # type "user", so we need to regenerate the cache block when it's modified.
     #

--- a/app/helpers/skins_helper.rb
+++ b/app/helpers/skins_helper.rb
@@ -14,30 +14,27 @@ module SkinsHelper
     end
   end
 
+  # Fetches the current skin. This is determined by the following
+  # 1. Skin ID set by request parameter
+  # 2. Skin ID set in the current session (if someone, a user or admin, is logged in)
+  # 3. Current user's skin preference
+  # 4. The default skin (as set by the active AdminSetting)
+  def current_skin
+    skin = Skin.approved_or_owned_by.usable.find_by(id: params[:site_skin]) if params[:site_skin]
+    skin ||= Skin.approved_or_owned_by.usable.find_by(id: session[:site_skin]) if (logged_in? || logged_in_as_admin?) && session[:site_skin]
+    skin ||= current_user&.preference&.skin
+    skin || AdminSetting.default_skin
+  end
+
   def skin_tag
-    skin = nil
-
-    if params[:site_skin]
-      skin ||= Skin.approved_or_owned_by.usable.find_by(id: params[:site_skin])
-    end
-
-    if (logged_in? || logged_in_as_admin?) && session[:site_skin]
-      skin ||= Skin.approved_or_owned_by.usable.find_by(id: session[:site_skin])
-    end
-
-    skin_id = if skin.nil?
-                current_user&.preference&.skin_id || AdminSetting.default_skin_id
-              else
-                skin.id
-              end
-
-    return "" if skin_id.nil?
-
     roles = if logged_in_as_admin?
               Skin::DEFAULT_ROLES_TO_INCLUDE + ["admin"]
             else
               Skin::DEFAULT_ROLES_TO_INCLUDE
             end
+
+    skin = current_skin
+    return "" unless skin
 
     # We include the version information for both the skin_id and the
     # AdminSetting.default_skin_id because the default skin is used in skins of
@@ -47,12 +44,11 @@ module SkinsHelper
     # regenerate the cache block when an admin updates the current default
     # skin.
     Rails.cache.fetch(
-      [:v1, :site_skin, skin_id, logged_in_as_admin?],
-      version: [skin_cache_version(skin_id),
+      [:v1, :site_skin, skin.id, logged_in_as_admin?],
+      version: [skin_cache_version(skin.id),
                 AdminSetting.default_skin_id,
                 skin_cache_version(AdminSetting.default_skin_id)]
     ) do
-      skin ||= Skin.find(skin_id)
       skin.get_style(roles)
     end
   end

--- a/app/models/feedback.rb
+++ b/app/models/feedback.rb
@@ -2,7 +2,7 @@
 class Feedback < ApplicationRecord
   attr_accessor :ip_address, :referer, :site_skin
 
-  # NOTE -- this has NOTHING to do with the Comment class!
+  # NOTE: this has NOTHING to do with the Comment class!
   # This is just the name of the text field in the Feedback
   # class which holds the user's comments.
   validates_presence_of :comment

--- a/app/models/feedback.rb
+++ b/app/models/feedback.rb
@@ -1,8 +1,8 @@
 # Class which holds feedback sent to the archive administrators about the archive as a whole
 class Feedback < ApplicationRecord
-  attr_accessor :ip_address
+  attr_accessor :ip_address, :referer, :site_skin
 
-  # note -- this has NOTHING to do with the Comment class!
+  # NOTE -- this has NOTHING to do with the Comment class!
   # This is just the name of the text field in the Feedback
   # class which holds the user's comments.
   validates_presence_of :comment
@@ -60,7 +60,8 @@ class Feedback < ApplicationRecord
   end
 
   def send_report
-    return unless %w(staging production).include?(Rails.env)
+    return unless zoho_enabled?
+
     reporter = SupportReporter.new(
       title: summary,
       description: comment,
@@ -69,8 +70,17 @@ class Feedback < ApplicationRecord
       username: username,
       user_agent: user_agent,
       site_revision: ArchiveConfig.REVISION.to_s,
-      rollout: rollout
+      rollout: rollout,
+      ip_address: ip_address,
+      referer: referer,
+      site_skin: site_skin
     )
     reporter.send_report!
+  end
+
+  private
+
+  def zoho_enabled?
+    %w[staging production].include?(Rails.env)
   end
 end

--- a/app/models/feedback_reporters/abuse_reporter.rb
+++ b/app/models/feedback_reporters/abuse_reporter.rb
@@ -1,6 +1,4 @@
 class AbuseReporter < FeedbackReporter
-  attr_accessor :ip_address
-
   def report_attributes
     super.deep_merge(
       "departmentId" => department_id,

--- a/app/models/feedback_reporters/feedback_reporter.rb
+++ b/app/models/feedback_reporters/feedback_reporter.rb
@@ -13,7 +13,8 @@ class FeedbackReporter
                 :language,
                 :category,
                 :username,
-                :url
+                :url,
+                :ip_address
 
   def initialize(attrs = {})
     attrs.each_pair do |key, val|

--- a/app/models/feedback_reporters/support_reporter.rb
+++ b/app/models/feedback_reporters/support_reporter.rb
@@ -1,5 +1,5 @@
 class SupportReporter < FeedbackReporter
-  attr_accessor :user_agent, :site_revision, :rollout
+  attr_accessor :user_agent, :referer, :rollout, :site_revision, :site_skin
 
   def report_attributes
     super.deep_merge(
@@ -16,7 +16,10 @@ class SupportReporter < FeedbackReporter
     {
       "cf_archive_version" => site_revision.presence || "Unknown site revision",
       "cf_rollout" => rollout.presence || "Unknown",
-      "cf_user_agent" => user_agent.presence || "Unknown user agent"
+      "cf_user_agent" => user_agent.presence || "Unknown user agent",
+      "cf_ip" => ip_address.presence || "Unknown",
+      "cf_referer" => referer.presence || "",
+      "cf_site_skin" => site_skin&.public ? site_skin.title : "Custom skin"
     }
   end
 

--- a/app/models/feedback_reporters/support_reporter.rb
+++ b/app/models/feedback_reporters/support_reporter.rb
@@ -13,16 +13,16 @@ class SupportReporter < FeedbackReporter
   private
 
   def custom_zoho_fields
-    # The Zoho field supports at most 255 characters. That _should_ be enough, but technically
-    # we support ludicrously long URLs because searches can do that. In those cases, just get the
-    # first 255 characters.
-    sanitized_url = referer.present? ? referer[0..254] : "Unknown URL"
+    # To avoid issues where Zoho ticket creation silently fails, only grab the first
+    # 255 characters of the referer URL. That may miss some complex search queries,
+    # but still keep enough to be useful most of the time.
+    truncated_referer = referer.present? ? referer[0..254] : "Unknown URL"
     {
       "cf_archive_version" => site_revision.presence || "Unknown site revision",
       "cf_rollout" => rollout.presence || "Unknown",
       "cf_user_agent" => user_agent.presence || "Unknown user agent",
       "cf_ip" => ip_address.presence || "Unknown IP",
-      "cf_url" => sanitized_url,
+      "cf_referer" => truncated_referer,
       "cf_site_skin" => site_skin&.public ? site_skin.title : "Custom skin"
     }
   end

--- a/app/models/feedback_reporters/support_reporter.rb
+++ b/app/models/feedback_reporters/support_reporter.rb
@@ -13,12 +13,16 @@ class SupportReporter < FeedbackReporter
   private
 
   def custom_zoho_fields
+    # The Zoho field supports at most 255 characters. That _should_ be enough, but technically
+    # we support ludicrously long URLs because searches can do that. In those cases, just get the
+    # first 255 characters.
+    sanitized_url = referer ? referer[0..254] : "Unknown URL"
     {
       "cf_archive_version" => site_revision.presence || "Unknown site revision",
       "cf_rollout" => rollout.presence || "Unknown",
       "cf_user_agent" => user_agent.presence || "Unknown user agent",
-      "cf_ip" => ip_address.presence || "Unknown",
-      "cf_referer" => referer.presence || "",
+      "cf_ip" => ip_address.presence || "Unknown IP",
+      "cf_url" => sanitized_url,
       "cf_site_skin" => site_skin&.public ? site_skin.title : "Custom skin"
     }
   end

--- a/app/models/feedback_reporters/support_reporter.rb
+++ b/app/models/feedback_reporters/support_reporter.rb
@@ -16,7 +16,7 @@ class SupportReporter < FeedbackReporter
     # The Zoho field supports at most 255 characters. That _should_ be enough, but technically
     # we support ludicrously long URLs because searches can do that. In those cases, just get the
     # first 255 characters.
-    sanitized_url = referer ? referer[0..254] : "Unknown URL"
+    sanitized_url = referer.present? ? referer[0..254] : "Unknown URL"
     {
       "cf_archive_version" => site_revision.presence || "Unknown site revision",
       "cf_rollout" => rollout.presence || "Unknown",

--- a/app/views/feedbacks/new.html.erb
+++ b/app/views/feedbacks/new.html.erb
@@ -42,9 +42,6 @@
   <%= form_for(@feedback, html: {class: "post feedback"}) do |f| %>
     <fieldset>
       <legend><%= t(".form.legend.contact_info") %></legend>
-      <p class="notice">
-        <%= t(".form.ip") %>
-      </p>
       <dl>
         <dt><%= f.label :username, t(".form.name.label") %></dt>
         <dd>

--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -525,7 +525,6 @@ en:
           label: Your question or problem (required)
         email:
           label: Your email (required)
-        ip: Our spam filter does collect IP addresses, but we never see them.
         language:
           label: Select language (required)
         legend:

--- a/spec/controllers/feedbacks_controller_spec.rb
+++ b/spec/controllers/feedbacks_controller_spec.rb
@@ -3,8 +3,6 @@
 require "spec_helper"
 
 describe FeedbacksController do
-  include LoginMacros
-
   describe "POST #create" do
     let(:mock_zoho) { instance_double(ZohoResourceClient) }
 

--- a/spec/controllers/feedbacks_controller_spec.rb
+++ b/spec/controllers/feedbacks_controller_spec.rb
@@ -1,0 +1,136 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe FeedbacksController do
+  include LoginMacros
+
+  describe "POST #create" do
+    let(:mock_zoho) { instance_double(ZohoResourceClient) }
+
+    let(:default_parameters) do
+      {
+        feedback: {
+          comment: "Hello",
+          email: "test@example.com",
+          summary: "Summary",
+          language: "en"
+        }
+      }
+    end
+
+    before do
+      allow_any_instance_of(Feedback).to receive(:zoho_enabled?).and_return(true)
+      allow(mock_zoho).to receive(:retrieve_contact_id)
+      allow_any_instance_of(FeedbackReporter).to receive(:zoho_resource_client).and_return(mock_zoho)
+    end
+
+    context "when accessed by a logged-in user" do
+      let(:user) { create(:user) }
+
+      before do
+        fake_login_known_user(user)
+      end
+
+      context "and the user has no skin set" do
+        before do
+          Skin.default
+        end
+
+        it "sets the skin title in the Zoho ticket" do
+          expect(mock_zoho).to receive(:create_ticket).with(ticket_attributes: include(
+            "cf" => include(
+              "cf_site_skin" => Skin.default.title
+            )
+          ))
+          post :create, params: default_parameters
+        end
+      end
+
+      context "and the user has a public non-default skin set" do
+        let(:skin) { create(:skin, :public) }
+
+        before do
+          user.preference.update!(skin: skin)
+        end
+
+        it "sets the skin title in the Zoho ticket" do
+          expect(mock_zoho).to receive(:create_ticket).with(ticket_attributes: include(
+            "cf" => include(
+              "cf_site_skin" => skin.title
+            )
+          ))
+          post :create, params: default_parameters
+        end
+      end
+
+      context "and the user has a private skin set" do
+        let(:skin) { create(:skin, author: user) }
+
+        before do
+          user.preference.update!(skin: skin)
+        end
+
+        it "sets the expected fields in the support ticket" do
+          expect(mock_zoho).to receive(:create_ticket).with(ticket_attributes: include(
+            "cf" => include(
+              "cf_site_skin" => "Custom skin"
+            )
+          ))
+          post :create, params: default_parameters
+        end
+      end
+    end
+
+    context "when accessed by a guest" do
+      context "and the guest has a skin set for the session" do
+        let(:skin) { create(:skin, :public) }
+
+        before do
+          session[:site_skin] = skin.id
+        end
+
+        it "sets the skin title in the Zoho ticket" do
+          expect(mock_zoho).to receive(:create_ticket).with(ticket_attributes: include(
+            "cf" => include(
+              "cf_site_skin" => skin.title
+            )
+          ))
+          post :create, params: default_parameters
+        end
+      end
+
+      context "and the referer is on the Archive" do
+        before do
+          request.env["HTTP_REFERER"] = "https://archiveofourown.org/works/1"
+        end
+
+        it "sets the referer in the Zoho ticket" do
+          expect(mock_zoho).to receive(:create_ticket).with(ticket_attributes: include(
+            "cf" => include(
+              "cf_referer" => "https://archiveofourown.org/works/1",
+              "cf_ip" => "0.0.0.0"
+            )
+          ))
+          post :create, params: default_parameters
+        end
+      end
+
+      context "and the referer is elsewhere" do
+        before do
+          request.env["HTTP_REFERER"] = "https://example.com/works/1"
+        end
+
+        it "does not set the referer in the Zoho ticket" do
+          expect(mock_zoho).to receive(:create_ticket).with(ticket_attributes: include(
+            "cf" => include(
+              "cf_referer" => "",
+              "cf_ip" => "0.0.0.0"
+            )
+          ))
+          post :create, params: default_parameters
+        end
+      end
+    end
+  end
+end

--- a/spec/controllers/feedbacks_controller_spec.rb
+++ b/spec/controllers/feedbacks_controller_spec.rb
@@ -3,6 +3,8 @@
 require "spec_helper"
 
 describe FeedbacksController do
+  include LoginMacros
+
   describe "POST #create" do
     let(:mock_zoho) { instance_double(ZohoResourceClient) }
 

--- a/spec/controllers/feedbacks_controller_spec.rb
+++ b/spec/controllers/feedbacks_controller_spec.rb
@@ -93,7 +93,7 @@ describe FeedbacksController do
         it "sets the referer in the Zoho ticket" do
           expect(mock_zoho).to receive(:create_ticket).with(ticket_attributes: include(
             "cf" => include(
-              "cf_referer" => "https://archiveofourown.org/works/1",
+              "cf_url" => "https://archiveofourown.org/works/1",
               "cf_ip" => "0.0.0.0"
             )
           ))
@@ -109,7 +109,7 @@ describe FeedbacksController do
         it "does not set the referer in the Zoho ticket" do
           expect(mock_zoho).to receive(:create_ticket).with(ticket_attributes: include(
             "cf" => include(
-              "cf_referer" => "",
+              "cf_url" => "Unknown URL",
               "cf_ip" => "0.0.0.0"
             )
           ))

--- a/spec/controllers/feedbacks_controller_spec.rb
+++ b/spec/controllers/feedbacks_controller_spec.rb
@@ -34,7 +34,9 @@ describe FeedbacksController do
 
       context "and the user has no skin set" do
         before do
-          Skin.default
+          admin_setting = AdminSetting.default
+          admin_setting.default_skin = Skin.default
+          admin_setting.save(validate: false)
         end
 
         it "sets the skin title in the Zoho ticket" do
@@ -83,23 +85,6 @@ describe FeedbacksController do
     end
 
     context "when accessed by a guest" do
-      context "and the guest has a skin set for the session" do
-        let(:skin) { create(:skin, :public) }
-
-        before do
-          session[:site_skin] = skin.id
-        end
-
-        it "sets the skin title in the Zoho ticket" do
-          expect(mock_zoho).to receive(:create_ticket).with(ticket_attributes: include(
-            "cf" => include(
-              "cf_site_skin" => skin.title
-            )
-          ))
-          post :create, params: default_parameters
-        end
-      end
-
       context "and the referer is on the Archive" do
         before do
           request.env["HTTP_REFERER"] = "https://archiveofourown.org/works/1"

--- a/spec/controllers/feedbacks_controller_spec.rb
+++ b/spec/controllers/feedbacks_controller_spec.rb
@@ -32,7 +32,7 @@ describe FeedbacksController do
         fake_login_known_user(user)
       end
 
-      context "and the user has no skin set" do
+      context "when the user has no skin set" do
         before do
           admin_setting = AdminSetting.default
           admin_setting.default_skin = Skin.default
@@ -49,7 +49,7 @@ describe FeedbacksController do
         end
       end
 
-      context "and the user has a public non-default skin set" do
+      context "when the user has a public non-default skin set" do
         let(:skin) { create(:skin, :public) }
 
         before do
@@ -66,7 +66,7 @@ describe FeedbacksController do
         end
       end
 
-      context "and the user has a private skin set" do
+      context "when the user has a private skin set" do
         let(:skin) { create(:skin, author: user) }
 
         before do
@@ -85,7 +85,7 @@ describe FeedbacksController do
     end
 
     context "when accessed by a guest" do
-      context "and the referer is on the Archive" do
+      context "when the referer is on the Archive" do
         before do
           request.env["HTTP_REFERER"] = "https://archiveofourown.org/works/1"
         end
@@ -101,7 +101,7 @@ describe FeedbacksController do
         end
       end
 
-      context "and the referer is elsewhere" do
+      context "when the referer is elsewhere" do
         before do
           request.env["HTTP_REFERER"] = "https://example.com/works/1"
         end

--- a/spec/controllers/feedbacks_controller_spec.rb
+++ b/spec/controllers/feedbacks_controller_spec.rb
@@ -93,7 +93,7 @@ describe FeedbacksController do
         it "sets the referer in the Zoho ticket" do
           expect(mock_zoho).to receive(:create_ticket).with(ticket_attributes: include(
             "cf" => include(
-              "cf_url" => "https://archiveofourown.org/works/1",
+              "cf_referer" => "https://archiveofourown.org/works/1",
               "cf_ip" => "0.0.0.0"
             )
           ))
@@ -109,7 +109,7 @@ describe FeedbacksController do
         it "does not set the referer in the Zoho ticket" do
           expect(mock_zoho).to receive(:create_ticket).with(ticket_attributes: include(
             "cf" => include(
-              "cf_url" => "Unknown URL",
+              "cf_referer" => "Unknown URL",
               "cf_ip" => "0.0.0.0"
             )
           ))

--- a/spec/helpers/skins_helper_spec.rb
+++ b/spec/helpers/skins_helper_spec.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe SkinsHelper do
+  describe "#current_skin" do
+    before do
+      allow(helper).to receive(:current_user)
+      allow(helper).to receive(:logged_in_as_admin?).and_return(false)
+      allow(helper).to receive(:logged_in?).and_return(false)
+      admin_setting = AdminSetting.default
+      admin_setting.default_skin = Skin.default
+      admin_setting.save(validate: false)
+    end
+
+    context "when the parameters include a skin id" do
+      before do
+        params[:site_skin] = skin.id
+      end
+
+      context "and the skin is usable" do
+        let(:skin) { create(:skin, :public) }
+
+        it "returns the skin matching the parameter" do
+          expect(helper.current_skin).to eq(skin)
+        end
+      end
+
+      context "and the skin is not usable" do
+        let(:skin) { create(:skin) }
+
+        it "falls back to other options" do
+          expect(helper.current_skin).to eq(Skin.default)
+        end
+      end
+    end
+
+    context "when the current user has a skin set for the session" do
+      before do
+        allow(helper).to receive(:current_user).and_return(create(:user))
+        allow(helper).to receive(:logged_in?).and_return(true)
+        session[:site_skin] = skin.id
+      end
+
+      context "and the skin is usable" do
+        let(:skin) { create(:skin, :public) }
+
+        it "returns the skin matching the session attribute" do
+          expect(helper.current_skin).to eq(skin)
+        end
+      end
+
+      context "and the skin is not usable" do
+        # Non-public skin with a different author
+        let(:skin) { create(:skin) }
+
+        it "falls back to other options" do
+          expect(helper.current_skin).to eq(Skin.default)
+        end
+      end
+    end
+
+    context "when the current user has a skin preference set" do
+      let(:skin) { create(:skin) }
+      let(:user) { skin.author }
+
+      before do
+        user.preference.update!(skin: skin)
+        allow(helper).to receive(:current_user).and_return(user)
+      end
+
+      it "returns the preferred skin" do
+        expect(helper.current_skin).to eq(skin)
+      end
+    end
+  end
+end

--- a/spec/helpers/skins_helper_spec.rb
+++ b/spec/helpers/skins_helper_spec.rb
@@ -18,7 +18,7 @@ describe SkinsHelper do
         params[:site_skin] = skin.id
       end
 
-      context "and the skin is usable" do
+      context "when the skin is applied" do
         let(:skin) { create(:skin, :public) }
 
         it "returns the skin matching the parameter" do
@@ -26,7 +26,7 @@ describe SkinsHelper do
         end
       end
 
-      context "and the skin is not usable" do
+      context "when the skin is not applied" do
         let(:skin) { create(:skin) }
 
         it "falls back to other options" do
@@ -42,7 +42,7 @@ describe SkinsHelper do
         session[:site_skin] = skin.id
       end
 
-      context "and the skin is usable" do
+      context "when the skin is applied" do
         let(:skin) { create(:skin, :public) }
 
         it "returns the skin matching the session attribute" do
@@ -50,7 +50,7 @@ describe SkinsHelper do
         end
       end
 
-      context "and the skin is not usable" do
+      context "when the skin is not applied" do
         # Non-public skin with a different author
         let(:skin) { create(:skin) }
 

--- a/spec/models/feedback_reporters/support_reporter_spec.rb
+++ b/spec/models/feedback_reporters/support_reporter_spec.rb
@@ -14,7 +14,10 @@ describe SupportReporter do
       username: "Walrus",
       user_agent: "HTTParty",
       site_revision: "eternal_beta",
-      rollout: "rollout_value"
+      rollout: "rollout_value",
+      ip_address: "127.0.0.1",
+      referrer: "https://example.com/works/1",
+      site_skin: build(:skin, title: "Reversi", public: true)
     }
   end
 
@@ -30,7 +33,10 @@ describe SupportReporter do
         "cf_name" => "Walrus",
         "cf_archive_version" => "eternal_beta",
         "cf_rollout" => "rollout_value",
-        "cf_user_agent" => "HTTParty"
+        "cf_user_agent" => "HTTParty",
+        "cf_ip" => "127.0.0.1",
+        "cf_referrer" => "https://example.com/works/1",
+        "cf_site_skin" => "Reversi"
       }
     }
   end
@@ -95,6 +101,46 @@ describe SupportReporter do
         allow(subject).to receive(:description).and_return('Hi!<img src="http://example.com/Camera-icon.svg">Bye!')
 
         expect(subject.report_attributes.fetch("description")).to eq("Hi!http://example.com/Camera-icon.svgBye!")
+      end
+    end
+
+    context "if the report has an empty ip address" do
+      before do
+        allow(subject).to receive(:ip_address).and_return("")
+      end
+
+      it "returns a hash containing 'Unknown' for IP address" do
+        expect(subject.report_attributes.dig("cf", "cf_ip")).to eq("Unknown")
+      end
+    end
+
+    context "if the report has an empty referrer" do
+      before do
+        allow(subject).to receive(:referrer).and_return("")
+      end
+
+      it "returns a hash containing a blank string for referrer" do
+        expect(subject.report_attributes.dig("cf", "cf_referrer")).to eq("")
+      end
+    end
+
+    context "if the report has an empty skin" do
+      before do
+        allow(subject).to receive(:site_skin).and_return(nil)
+      end
+
+      it "returns a hash containing the custom skin placeholder" do
+        expect(subject.report_attributes.dig("cf", "cf_site_skin")).to eq("Custom skin")
+      end
+    end
+
+    context "if the report has a private skin" do
+      before do
+        allow(subject).to receive(:site_skin).and_return(build(:skin, public: false))
+      end
+
+      it "returns a hash containing the custom skin placeholder" do
+        expect(subject.report_attributes.dig("cf", "cf_site_skin")).to eq("Custom skin")
       end
     end
   end

--- a/spec/models/feedback_reporters/support_reporter_spec.rb
+++ b/spec/models/feedback_reporters/support_reporter_spec.rb
@@ -35,7 +35,7 @@ describe SupportReporter do
         "cf_rollout" => "rollout_value",
         "cf_user_agent" => "HTTParty",
         "cf_ip" => "127.0.0.1",
-        "cf_url" => "https://example.com/works/1",
+        "cf_referer" => "https://example.com/works/1",
         "cf_site_skin" => "Reversi"
       }
     }
@@ -120,7 +120,7 @@ describe SupportReporter do
       end
 
       it "returns a hash containing a blank string for referer" do
-        expect(subject.report_attributes.dig("cf", "cf_url")).to eq("Unknown URL")
+        expect(subject.report_attributes.dig("cf", "cf_referer")).to eq("Unknown URL")
       end
     end
 
@@ -130,7 +130,7 @@ describe SupportReporter do
       end
 
       it "truncates the referer to 255 characters" do
-        expect(subject.report_attributes.dig("cf", "cf_url").length).to eq(255)
+        expect(subject.report_attributes.dig("cf", "cf_referer").length).to eq(255)
       end
     end
 

--- a/spec/models/feedback_reporters/support_reporter_spec.rb
+++ b/spec/models/feedback_reporters/support_reporter_spec.rb
@@ -16,7 +16,7 @@ describe SupportReporter do
       site_revision: "eternal_beta",
       rollout: "rollout_value",
       ip_address: "127.0.0.1",
-      referrer: "https://example.com/works/1",
+      referer: "https://example.com/works/1",
       site_skin: build(:skin, title: "Reversi", public: true)
     }
   end
@@ -35,7 +35,7 @@ describe SupportReporter do
         "cf_rollout" => "rollout_value",
         "cf_user_agent" => "HTTParty",
         "cf_ip" => "127.0.0.1",
-        "cf_referrer" => "https://example.com/works/1",
+        "cf_referer" => "https://example.com/works/1",
         "cf_site_skin" => "Reversi"
       }
     }
@@ -114,13 +114,13 @@ describe SupportReporter do
       end
     end
 
-    context "if the report has an empty referrer" do
+    context "if the report has an empty referer" do
       before do
-        allow(subject).to receive(:referrer).and_return("")
+        allow(subject).to receive(:referer).and_return("")
       end
 
-      it "returns a hash containing a blank string for referrer" do
-        expect(subject.report_attributes.dig("cf", "cf_referrer")).to eq("")
+      it "returns a hash containing a blank string for referer" do
+        expect(subject.report_attributes.dig("cf", "cf_referer")).to eq("")
       end
     end
 

--- a/spec/models/feedback_reporters/support_reporter_spec.rb
+++ b/spec/models/feedback_reporters/support_reporter_spec.rb
@@ -35,7 +35,7 @@ describe SupportReporter do
         "cf_rollout" => "rollout_value",
         "cf_user_agent" => "HTTParty",
         "cf_ip" => "127.0.0.1",
-        "cf_referer" => "https://example.com/works/1",
+        "cf_url" => "https://example.com/works/1",
         "cf_site_skin" => "Reversi"
       }
     }
@@ -104,13 +104,13 @@ describe SupportReporter do
       end
     end
 
-    context "if the report has an empty ip address" do
+    context "if the report has an empty IP address" do
       before do
         allow(subject).to receive(:ip_address).and_return("")
       end
 
       it "returns a hash containing 'Unknown' for IP address" do
-        expect(subject.report_attributes.dig("cf", "cf_ip")).to eq("Unknown")
+        expect(subject.report_attributes.dig("cf", "cf_ip")).to eq("Unknown IP")
       end
     end
 
@@ -120,7 +120,17 @@ describe SupportReporter do
       end
 
       it "returns a hash containing a blank string for referer" do
-        expect(subject.report_attributes.dig("cf", "cf_referer")).to eq("")
+        expect(subject.report_attributes.dig("cf", "cf_url")).to eq("")
+      end
+    end
+
+    context "if the reporter has a very long referer" do
+      before do
+        allow(subject).to receive(:referer).and_return("a" * 256)
+      end
+
+      it "truncates the referer to 255 characters" do
+        expect(subject.report_attributes.dig("cf", "cf_url").length).to eq(255)
       end
     end
 

--- a/spec/models/feedback_reporters/support_reporter_spec.rb
+++ b/spec/models/feedback_reporters/support_reporter_spec.rb
@@ -120,7 +120,7 @@ describe SupportReporter do
       end
 
       it "returns a hash containing a blank string for referer" do
-        expect(subject.report_attributes.dig("cf", "cf_url")).to eq("")
+        expect(subject.report_attributes.dig("cf", "cf_url")).to eq("Unknown URL")
       end
     end
 


### PR DESCRIPTION
# Pull Request Checklist

* [X] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [X] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [X] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [X] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [X] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-6232

## Purpose

Adds custom field to Zoho tickets for the submitter's IP address, referer, and the skin they're using at the time of submitting a support ticket

## References

The names in this PR will need a final approval from support before merging, to make sure they've created the fields in Zoho as required

## Credit

Brian Austin (they/he)