### PR TITLE
AO3-6756 Add i18n-tasks workflow for Phrase export PRs

### DIFF
--- a/.github/workflows/phrase-export-checks.yml
+++ b/.github/workflows/phrase-export-checks.yml
@@ -1,0 +1,84 @@
+name: Check Phrase translations
+on:
+  pull_request:
+    branches:
+      - master
+      - main
+  workflow_dispatch:
+
+jobs:
+  en-keys-to-remove:
+    if: github.head_ref == 'phrase-translations'
+    runs-on: ubuntu-latest
+    name: Check for outdated English keys in Phrase
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+
+      - name: Set up Ruby and run bundle install
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+
+      - name: Run i18n-tasks
+        run: bundle exec i18n-tasks missing -t diff -f keys en | bundle exec i18n-tasks tree-mv -f keys "en.{*}" "\1" > en-keys-to-remove.txt
+
+      - name: Check that there are zero keys in other locales that don't exist in English
+        run: "! test -s en-keys-to-remove.txt"
+
+      - name: Upload list of English keys that should be removed from Phrase
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: en-keys-to-remove
+          path: en-keys-to-remove.txt
+
+  unused-keys:
+    if: github.head_ref == 'phrase-translations'
+    runs-on: ubuntu-latest
+    needs: en-keys-to-remove
+    name: Check unused keys for all locales
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+
+      - name: Set up Ruby and run bundle install
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+
+      - name: Run i18n-tasks unused
+        run: bundle exec i18n-tasks unused -f keys > unused-keys.txt
+
+      - name: Upload list of unused locale keys
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: unused-keys
+          path: unused-keys.txt
+
+  inconsistent-interpolations:
+    if: github.head_ref == 'phrase-translations'
+    runs-on: ubuntu-latest
+    name: Check consistent interpolations for all locales
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+
+      - name: Set up Ruby and run bundle install
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+
+      - name: Run i18n-tasks check-consistent-interpolations
+        run: bundle exec i18n-tasks check-consistent-interpolations -f yaml > inconsistent-interpolations.yml
+        continue-on-error: true
+
+      - name: Upload yaml of inconsistent interpolations
+        uses: actions/upload-artifact@v4
+        with:
+          name: inconsistent-interpolations
+          path: inconsistent-interpolations.yml

--- a/.github/workflows/phrase-export-checks.yml
+++ b/.github/workflows/phrase-export-checks.yml
@@ -1,4 +1,4 @@
-name: Check Phrase translations
+name: Check Phrase exports
 on:
   pull_request:
     branches:
@@ -21,10 +21,10 @@ jobs:
         with:
           bundler-cache: true
 
-      - name: Run i18n-tasks
+      - name: Run i18n-tasks missing (diff mode)
         run: bundle exec i18n-tasks missing -t diff -f keys en | bundle exec i18n-tasks tree-mv -f keys "en.{*}" "\1" > en-keys-to-remove.txt
 
-      - name: Check that there are zero keys in other locales that don't exist in English
+      - name: Check that all keys exported from Phrase exist in English
         run: "! test -s en-keys-to-remove.txt"
 
       - name: Upload list of English keys that should be removed from Phrase


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6756

## Purpose

Adds a GitHub Action workflow. The workflow lists all redundant English keys that should be removed from Phrase. The check will show as failed if there are any and the list will be available as workflow artifact. Furthermore, the workflow runs the consistent interpolations check for all locales and uploads its result. If there are no redundant keys on Phrase then it also runs the unused keys check for all locales. The check will show as failed and the unused keys will be available as workflow artifact if there are any unused keys.

The workflow runs automatically when making a pull request from a branch named `phrase-translations`. Phrase does this when exporting strings to GitHub, so it should be fully automatic.

[Demo PR](https://github.com/Bilka2/otwarchive/pull/10):
English keys that should removed from Phrase: https://github.com/Bilka2/otwarchive/actions/runs/9919350109

## Testing Instructions

See Jira.

## Credit

Bilka (he/him)
