### PR TITLE
AO3-6763 Fix rubocop error by updating it

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,7 +11,7 @@ inherit_mode:
 
 AllCops:
   NewCops: enable
-  TargetRubyVersion: 3.0
+  TargetRubyVersion: 3.1
 
 Bundler/OrderedGems:
   Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -163,7 +163,7 @@ end
 
 group :linters do
   gem "erb_lint", "0.4.0"
-  gem "rubocop", "1.22.1"
+  gem "rubocop", "1.22.3"
   gem "rubocop-rails", "2.12.4"
   gem "rubocop-rspec", "2.6.0"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -402,7 +402,7 @@ GEM
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     orm_adapter (0.5.0)
-    parallel (1.24.0)
+    parallel (1.25.1)
     parser (3.3.0.5)
       ast (~> 2.4.1)
       racc
@@ -520,7 +520,7 @@ GEM
       rspec-mocks (~> 3.10)
       rspec-support (~> 3.10)
     rspec-support (3.13.1)
-    rubocop (1.22.1)
+    rubocop (1.22.3)
       parallel (~> 1.10)
       parser (>= 3.0.0.0)
       rainbow (>= 2.2.2, < 4.0)
@@ -529,7 +529,7 @@ GEM
       rubocop-ast (>= 1.12.0, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 3.0)
-    rubocop-ast (1.31.1)
+    rubocop-ast (1.31.2)
       parser (>= 3.3.0.4)
     rubocop-rails (2.12.4)
       activesupport (>= 4.2.0)
@@ -705,7 +705,7 @@ DEPENDENCIES
   rest-client (~> 2.1.0)
   rollout
   rspec-rails (~> 4.0.1)
-  rubocop (= 1.22.1)
+  rubocop (= 1.22.3)
   rubocop-rails (= 2.12.4)
   rubocop-rspec (= 2.6.0)
   rvm-capistrano


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6763

## Purpose

Due to the reviewdog changes, the rubocop error "An error occurred while Layout/BlockAlignment cop was inspecting ..." now makes the [action fail](https://github.com/otwcode/otwarchive/actions/runs/9941472849/job/27460594122). Previously this error also occurred but didn't affect the check status.

Updating rubocop gets rid of the error. This new version doesn't add any new cops, so we don't need to evaluate them.

I updated the TargetRubyVersion to 3.1 because according to https://docs.rubocop.org/rubocop/1.65/configuration.html#setting-the-target-ruby-version it should be the oldest Ruby version that we support. (This also means that the rubocop parser won't choke on Ruby 3.1 syntax.)

## Testing Instructions

The action should succeed on this PR.

## Credit

Bilka (he/him)
