### PR TITLE
AO3-6763 Set github action check to fail if reviewdog finds an error

### DIFF
--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -45,7 +45,8 @@ jobs:
           bundler-cache: true
 
       - name: erb-lint
-        uses: tk0miya/action-erblint@667687e73b44e7b7a710a1204b180f49f80ebb5e
+        uses: tk0miya/action-erblint@eda368e7a0d8a0e71c475bb7cc65d0d612e5148c
         with:
           use_bundler: true
-          reporter: github-pr-check # default
+          reporter: github-pr-check
+          fail_on_error: true

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -28,6 +28,7 @@ jobs:
           use_bundler: true
           reporter: github-pr-check
           skip_install: true
+          fail_on_error: true
 
   erb-lint:
     name: ERB Lint runner


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6763, broken on test II

## Purpose

Sets fail_on_error for the reviewdog action so that the check is shown as failed when rubocop or erb-lint find an error. Currently the check shows as passed, see e.g. #4875.

## Testing Instructions

Merge this into a PR with rubocop or erb-lint warnings and make sure that the reviewdog check on the PR fails.

## References

Example PR: https://github.com/brianjaustin/otwarchive/pull/1

## Credit

Bilka (he/him)