### PR TITLE
AO3-6749 Fix main navigation position and color in Low Vision Default

### DIFF
--- a/public/stylesheets/masters/low_vision_default/low_vision_default_site_screen_.css
+++ b/public/stylesheets/masters/low_vision_default/low_vision_default_site_screen_.css
@@ -134,6 +134,7 @@ pre {
 
 #header,
 #header ul.primary,
+#header .open a,
 #footer,
 .actions a:hover,
 .actions a:focus {

--- a/public/stylesheets/masters/low_vision_default/low_vision_default_site_screen_.css
+++ b/public/stylesheets/masters/low_vision_default/low_vision_default_site_screen_.css
@@ -135,6 +135,8 @@ pre {
 #header,
 #header ul.primary,
 #header .open a,
+#header .open a:focus,
+#header .user .open a:focus,
 #footer,
 .actions a:hover,
 .actions a:focus {
@@ -150,13 +152,13 @@ pre {
   background: transparent;
 }
 
-#header .menu a {
+#header .dropdown .menu a {
   background: #111;
   color: #fff;
 }
 
-#header .menu a:hover,
-#header .menu a:focus {
+#header .dropdown .menu a:hover,
+#header .dropdown .menu a:focus {
   background: #ccc;
   color: #111;
 }

--- a/public/stylesheets/masters/low_vision_default/low_vision_default_site_screen_.css
+++ b/public/stylesheets/masters/low_vision_default/low_vision_default_site_screen_.css
@@ -124,6 +124,7 @@ pre {
 
 #header .menu {
   display: none;
+  position: static;
 }
 
 #footer {


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6749

## Purpose

In Low Vision Default:
* Brings the dropdown menus out from behind the top-level menu items in mobile.
* Ensures the background of the open top-level menu item is red on all screen sizes.

## Testing Instructions

An admin with the superadmin role will need to copy the updated CSS into Low Vision Default *before* merging (to ensure it gets recached on deploying):
1. Log in as admin
2. Skins > Approved Skins
3. Locate Low Vision Default in the table and click the title to open the skin show page
4. Follow the Edit link at the bottom to access the skin edit page
5. Copy the entire contents of public/stylesheets/masters/low_vision_default/low_vision_default_site_screen_.css from this pull request
6. Paste into the CSS field on the skin edit page
7. Press Update to save
8. Merge this pull request

Then testers should check the behavior of Low Vision Default on multiple screen sizes and browsers. The correct colors for the navigation:
1. Top-level items should be button-style with black border and dark text by default.
2. Top-level items that are being hovered over with the mouse, have keyboard focus, or are the parent of an open dropdown menu, should have red backgrounds with light grey text and border.
3. Dropdown menu items should have black background with light grey text and border.
4. Dropdown menu items that are being hovered over with the mouse or that have keyboard focus should have light grey backgrounds with dark grey/black text.

