### PR TITLE
AO3-6742 Fix sentry initializer for Resque workers

### DIFF
--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -9,7 +9,7 @@ if Rails.env.production? || Rails.env.staging?
     config.traces_sampler = lambda do |sampling_context|
       next sampling_context[:parent_sampled] unless sampling_context[:parent_sampled].nil?
 
-      rack_env = sampling_context[:env]
+      rack_env = sampling_context[:env] || {}
       rate_from_nginx = Float(rack_env["HTTP_X_SENTRY_RATE"], exception: false)
       return rate_from_nginx if rate_from_nginx
       return 0.01 if Rails.env.production?


### PR DESCRIPTION
# Pull Request Checklist

## Issue

https://otwarchive.atlassian.net/browse/AO3-6742

## Purpose

Make the Sentry initializer work on Resque workers by not expecting the rack environment to always exist

## Testing Instructions

Refer to Sarken's comment on the Jira ticket
