### PR TITLE
AO3-6784 Fix error 500 on nominations show/index with tag in wrong category

### DIFF
--- a/app/helpers/tag_sets_helper.rb
+++ b/app/helpers/tag_sets_helper.rb
@@ -64,7 +64,7 @@ module TagSetsHelper
   end
 
   def nomination_tag_information(nominated_tag)
-    tag_object = nominated_tag.type.gsub(/Nomination/, '').constantize.find_by_name(nominated_tag.tagname)
+    tag_object = Tag.find_by(name: nominated_tag.tagname)
     status = "nonexistent"
     tooltip = ts("This tag has never been used before. Check the spelling!")
     title = ts("nonexistent tag")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -85,6 +85,9 @@ services:
       - redis
       - es
       - mc
+    # Make `docker compose attach web` work for debugging
+    stdin_open: true
+    tty: true
   chrome:
     profiles:
       - test

--- a/features/step_definitions/tag_set_steps.rb
+++ b/features/step_definitions/tag_set_steps.rb
@@ -1,4 +1,12 @@
-# encoding: utf-8
+Given "a nominated tag set {string} with a tag nomination in the wrong category" do |tag_set_name|
+  pseud = FactoryBot.create(:pseud, user: FactoryBot.create(:user, login: "tagsetter"))
+  owned_tag_set = FactoryBot.create(:owned_tag_set, title: tag_set_name, owner: pseud)
+  tag_set_nomination = FactoryBot.create(:tag_set_nomination, pseud: pseud, owned_tag_set: owned_tag_set)
+  FactoryBot.create(:relationship, name: "rel tag")
+  invalid_nom = tag_set_nomination.fandom_nominations.build(tagname: "rel tag") # intentional mismatch in tag category
+  invalid_nom.save(validate: false)
+end
+
 When /^I follow the add new tag ?set link$/ do
   step %{I follow "New Tag Set"}
 end

--- a/features/support/paths.rb
+++ b/features/support/paths.rb
@@ -263,6 +263,8 @@ module NavigationHelpers
       edit_tag_set_path(OwnedTagSet.find_by(title: $1))
     when /^the "(.*)" tag ?set page$/i
       tag_set_path(OwnedTagSet.find_by(title: $1))
+    when /^the "(.*)" tag ?set nominations page$/i
+      tag_set_nominations_path(OwnedTagSet.find_by(title: Regexp.last_match(1)))
     when /^the Open Doors tools page$/i
       opendoors_tools_path
     when /^the Open Doors external authors page$/i

--- a/features/tag_sets/tag_set_nominations.feature
+++ b/features/tag_sets/tag_set_nominations.feature
@@ -232,3 +232,34 @@ Feature: Nominating and reviewing nominations for a tag set
       And I submit
     Then I should see "The tag Veronica Mars is already in the archive as a Character tag. (All tags have to be unique.) Try being more specific, for instance tacking on the medium or the fandom."
 
+  Scenario: If a tag was nominated as another type of tag, "My Nominations" and "Review Nominations" can still be accessed
+    Given a nominated tag set "bad" with a tag nomination in the wrong category
+      And I am logged in as "tagsetter"
+      And I go to the "bad" tag set page
+    # preexisting non-canonical tag
+    When I follow "My Nominations"
+    Then I should see "My Nominations for bad"
+      And I should see "rel tag"
+    When I go to the "bad" tag set nominations page
+    Then I should see "Fandoms (1 left to review)"
+      And I should see "rel tag"
+    # canonical tag
+    When the tag "rel tag" is canonized
+      And I go to the "bad" tag set page
+    When I follow "My Nominations"
+    Then I should see "My Nominations for bad"
+      And I should see "rel tag"
+    When I go to the "bad" tag set nominations page
+    Then I should see "Fandoms (1 left to review)"
+      And I should see "rel tag"
+    # synonym tag
+    When the tag "rel tag" is decanonized
+      And a canonical relationship "canon tag"
+      And a synonym "rel tag" of the tag "canon tag"
+      And I go to the "bad" tag set page
+    When I follow "My Nominations"
+    Then I should see "My Nominations for bad"
+      And I should see "rel tag"
+    When I go to the "bad" tag set nominations page
+    Then I should see "Fandoms (1 left to review)"
+      And I should see "rel tag (canon tag)"


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6784

## Purpose

Fix error 500 when trying to view "My Nominations" or "Review Nominations" when a nominated tag was in the wrong category and that tag is a synonym or a canonical. This was discovered because AO3-6783 inserts the blank tag (a Fandom tag on staging) into other tag nomination categories, like character or relationship.

## Testing Instructions

See Jira.

## Credit

Bilka (he/him)
