### PR TITLE
AO3-6783 Fix that removing a tag nomination would result in a blank tag nomination

### DIFF
--- a/app/controllers/autocomplete_controller.rb
+++ b/app/controllers/autocomplete_controller.rb
@@ -92,9 +92,9 @@ class AutocompleteController < ApplicationController
     raise "Redshirt: Attempted to constantize invalid class initialize noncanonical_tag #{params[:type].classify}" unless Tag::TYPES.include?(params[:type].classify)
 
     tag_class = params[:type].classify.constantize
-    one_tag = tag_class.find_by(canonical: false, name: params[:term])
+    one_tag = tag_class.find_by(canonical: false, name: params[:term]) if params[:term].present?
     # If there is an exact match in the database, ensure it is the first thing suggested.
-    match = if one_tag && params[:term].present?
+    match = if one_tag
               [one_tag.name]
             else
               []

--- a/app/controllers/autocomplete_controller.rb
+++ b/app/controllers/autocomplete_controller.rb
@@ -94,7 +94,7 @@ class AutocompleteController < ApplicationController
     tag_class = params[:type].classify.constantize
     one_tag = tag_class.find_by(canonical: false, name: params[:term])
     # If there is an exact match in the database, ensure it is the first thing suggested.
-    match = if one_tag
+    match = if one_tag && params[:term].present?
               [one_tag.name]
             else
               []

--- a/app/models/tagset_models/cast_nomination.rb
+++ b/app/models/tagset_models/cast_nomination.rb
@@ -3,7 +3,7 @@ class CastNomination < TagNomination
   has_one :owned_tag_set, through: :tag_set_nomination
   belongs_to :fandom_nomination
   
-  validate :known_fandom
+  validate :known_fandom, unless: :blank_tagname?
   def known_fandom
     return true if (!parent_tagname.blank? || self.fandom_nomination || from_fandom_nomination)
     return true if (tag = Tag.find_by_name(self.tagname)) && tag.parents.any? {|p| p.is_a?(Fandom)}

--- a/app/models/tagset_models/tag_nomination.rb
+++ b/app/models/tagset_models/tag_nomination.rb
@@ -15,9 +15,9 @@ class TagNomination < ApplicationRecord
 
   validate :type_validity, unless: :blank_tagname?
   def type_validity
-    if (tag = Tag.find_by_name(tagname)) && "#{tag.type}Nomination" != self.type
-      errors.add(:base, ts("^The tag %{tagname} is already in the archive as a #{tag.type} tag. (All tags have to be unique.) Try being more specific, for instance tacking on the medium or the fandom.", tagname: self.tagname))
-    end
+    return unless (tag = Tag.find_by_name(tagname)) && "#{tag.type}Nomination" != self.type
+
+    errors.add(:base, ts("^The tag %{tagname} is already in the archive as a #{tag.type} tag. (All tags have to be unique.) Try being more specific, for instance tacking on the medium or the fandom.", tagname: self.tagname))
   end
 
   validate :not_already_reviewed, on: :update
@@ -45,11 +45,6 @@ class TagNomination < ApplicationRecord
 
   def get_owned_tag_set
     @tag_set || self.tag_set_nomination.owned_tag_set
-  end
-
-  after_save :destroy_if_blank
-  def destroy_if_blank
-    self.destroy if blank_tagname?
   end
 
   def blank_tagname?
@@ -105,6 +100,11 @@ class TagNomination < ApplicationRecord
       self.approved = set_noms.owned_tag_set.already_in_set?(tagname) || false
     end
     true
+  end
+
+  after_save :destroy_if_blank
+  def destroy_if_blank
+    self.destroy if blank_tagname?
   end
 
   def self.for_tag_set(tag_set)

--- a/app/models/tagset_models/tag_nomination.rb
+++ b/app/models/tagset_models/tag_nomination.rb
@@ -13,9 +13,9 @@ class TagNomination < ApplicationRecord
     with: /\A[^,*<>^{}=`\\%]+\z/,
     message: ts("^Tag nominations cannot include the following restricted characters: , &#94; * < > { } = ` \\ %")
 
-  validate :type_validity
+  validate :type_validity, unless: :blank_tagname?
   def type_validity
-    if !tagname.blank? && (tag = Tag.find_by_name(tagname)) && "#{tag.type}Nomination" != self.type
+    if (tag = Tag.find_by_name(tagname)) && "#{tag.type}Nomination" != self.type
       errors.add(:base, ts("^The tag %{tagname} is already in the archive as a #{tag.type} tag. (All tags have to be unique.) Try being more specific, for instance tacking on the medium or the fandom.", tagname: self.tagname))
     end
   end
@@ -32,7 +32,7 @@ class TagNomination < ApplicationRecord
   end
 
   # This makes sure no tagnames are nominated for different parents in this tag set
-  validate :require_unique_tagname_with_parent
+  validate :require_unique_tagname_with_parent, unless: :blank_tagname?
   def require_unique_tagname_with_parent
     query = TagNomination.for_tag_set(get_owned_tag_set).where(tagname: self.tagname).where("parent_tagname != ?", (self.get_parent_tagname || ''))
     # let people change their own!
@@ -56,7 +56,7 @@ class TagNomination < ApplicationRecord
     tagname.blank?
   end
 
-  before_save :set_tag_status
+  before_save :set_tag_status, unless: :blank_tagname?
   def set_tag_status
     if (tag = Tag.find_by_name(tagname))
       self.exists = true
@@ -71,7 +71,7 @@ class TagNomination < ApplicationRecord
     true
   end
 
-  before_save :set_parented
+  before_save :set_parented, unless: :blank_tagname?
   def set_parented
     if type == "FreeformNomination"
       # skip freeforms
@@ -90,7 +90,7 @@ class TagNomination < ApplicationRecord
 
   # sneaky bit: if the tag set moderator has already rejected or approved this tag, don't
   # show it to them again.
-  before_save :set_approval_status
+  before_save :set_approval_status, unless: :blank_tagname?
   def set_approval_status
     set_noms = tag_set_nomination
     set_noms = fandom_nomination.tag_set_nomination if !set_noms && from_fandom_nomination

--- a/app/models/tagset_models/tag_nomination.rb
+++ b/app/models/tagset_models/tag_nomination.rb
@@ -43,15 +43,17 @@ class TagNomination < ApplicationRecord
     end
   end
 
-  after_save :destroy_if_blank
-  def destroy_if_blank
-    if tagname.blank?
-      self.destroy
-    end
-  end
-
   def get_owned_tag_set
     @tag_set || self.tag_set_nomination.owned_tag_set
+  end
+
+  after_save :destroy_if_blank
+  def destroy_if_blank
+    self.destroy if blank_tagname?
+  end
+
+  def blank_tagname?
+    tagname.blank?
   end
 
   before_save :set_tag_status

--- a/features/other_a/autocomplete.feature
+++ b/features/other_a/autocomplete.feature
@@ -222,7 +222,7 @@ Feature: Display autocomplete for tags
     Given a canonical character "Gold"
       And a zero width space tag exists
       And I am logged in as a tag wrangler
-    When I go to the "A/B" tag edit page
+    When I go to the "Gold" tag edit page
     Then I should see "This is the official name for the Character"
     When I enter " " in the "tag_merger_string_autocomplete" autocomplete field
     Then I should see "No suggestions found" in the autocomplete
@@ -232,7 +232,7 @@ Feature: Display autocomplete for tags
     Given a canonical character "Gold"
       And a zero width space tag exists
       And I am logged in as a tag wrangler
-    When I go to the "A/B" tag edit page
+    When I go to the "Gold" tag edit page
     Then I should see "This is the official name for the Character"
     # Zero width space tag
     When I enter "​" in the "tag_merger_string_autocomplete" autocomplete field

--- a/features/other_a/autocomplete.feature
+++ b/features/other_a/autocomplete.feature
@@ -217,3 +217,23 @@ Feature: Display autocomplete for tags
     Then I should see "日月" in the autocomplete
       But I should not see "大小" in the autocomplete
 
+  @javascript
+  Scenario: Zero width space tag doesn't appear in the autocomplete for space
+    Given a canonical character "Gold"
+      And a zero width space tag exists
+      And I am logged in as a tag wrangler
+    When I go to the "A/B" tag edit page
+    Then I should see "This is the official name for the Character"
+    When I enter " " in the "tag_merger_string_autocomplete" autocomplete field
+    Then I should see "No suggestions found" in the autocomplete
+
+  @javascript
+  Scenario: Zero width space tag appears in the autocomplete for zero width space
+    Given a canonical character "Gold"
+      And a zero width space tag exists
+      And I am logged in as a tag wrangler
+    When I go to the "A/B" tag edit page
+    Then I should see "This is the official name for the Character"
+    # Zero width space tag
+    When I enter "​" in the "tag_merger_string_autocomplete" autocomplete field
+    Then I should not see "No suggestions found" in the autocomplete

--- a/features/step_definitions/tag_steps.rb
+++ b/features/step_definitions/tag_steps.rb
@@ -221,6 +221,11 @@ Given /^the tag "([^"]*)" does not exist$/ do |tag_name|
   tag.destroy if tag.present?
 end
 
+Given "a zero width space tag exists" do
+  blank_tag = FactoryBot.build(:character, name: ["200B".hex].pack("U"))
+  blank_tag.save!(validate: true) # TODO: Change to validate: false when AO3-6777 is fixed
+end
+
 ### WHEN
 
 When /^the periodic tag count task is run$/i do

--- a/features/support/paths.rb
+++ b/features/support/paths.rb
@@ -263,8 +263,6 @@ module NavigationHelpers
       edit_tag_set_path(OwnedTagSet.find_by(title: $1))
     when /^the "(.*)" tag ?set page$/i
       tag_set_path(OwnedTagSet.find_by(title: $1))
-    when /^the "(.*)" tag ?set nominations page$/i
-      tag_set_nominations_path(OwnedTagSet.find_by(title: Regexp.last_match(1)))
     when /^the Open Doors tools page$/i
       opendoors_tools_path
     when /^the Open Doors external authors page$/i

--- a/features/tag_sets/tag_set_nominations.feature
+++ b/features/tag_sets/tag_set_nominations.feature
@@ -114,6 +114,25 @@ Feature: Nominating and reviewing nominations for a tag set
     And I should see "My Favorite Character/Their Worst Enemy"
     But I should not see "Their Best Friend"
 
+  Scenario: You should be able to delete a nominated character and its fandom at once
+  when the tagset doesn't allow fandom nominations
+    Given a canonical character "Common Character" in fandom "Canon"
+    And I am logged in as "tagsetter"
+    And I set up the nominated tag set "Nominated Tags" with 0 fandom noms and 3 character noms
+    When I follow "Nominate"
+    And I fill in "Character 1" with "Obscure Character"
+    And I fill in "Fandom?" with "Canon"
+    And I press "Submit"
+    Then I should see "Your nominations were successfully submitted."
+    And I should see "Obscure Character"
+    When I follow "Edit"
+    And I fill in "Character 1" with ""
+    And I fill in "Fandom?" with ""
+    And I press "Submit"
+    Then I should see "Your nominations were successfully updated."
+    And I should see "None nominated in this category."
+    But I should not see "We need to know what fandom belongs in."
+
   Scenario: Owner of a tag set can clear all nominations
   Given I am logged in as "tagsetter"
     And I set up the nominated tag set "Nominated Tags" with 3 fandom noms and 3 character noms

--- a/features/tag_sets/tag_set_nominations.feature
+++ b/features/tag_sets/tag_set_nominations.feature
@@ -300,7 +300,7 @@ Feature: Nominating and reviewing nominations for a tag set
       But I should not see "Gold"
       And I should see "None nominated in this fandom."
 
-  Scenario: A tag nomination with for the zero width space tag doesn't prevent removing other tag nominations
+  Scenario: A tag nomination with the zero width space tag doesn't prevent removing other tag nominations
     Given a canonical fandom "First"
       And a canonical fandom "Treasure Chest"
       And a zero width space tag exists

--- a/features/tag_sets/tag_set_nominations.feature
+++ b/features/tag_sets/tag_set_nominations.feature
@@ -259,7 +259,7 @@ Feature: Nominating and reviewing nominations for a tag set
     When I follow "My Nominations"
     Then I should see "My Nominations for bad"
       And I should see "rel tag"
-    When I go to the "bad" tag set nominations page
+    When I review nominations for "bad"
     Then I should see "Fandoms (1 left to review)"
       And I should see "rel tag"
     # canonical tag
@@ -268,7 +268,7 @@ Feature: Nominating and reviewing nominations for a tag set
     When I follow "My Nominations"
     Then I should see "My Nominations for bad"
       And I should see "rel tag"
-    When I go to the "bad" tag set nominations page
+    When I review nominations for "bad"
     Then I should see "Fandoms (1 left to review)"
       And I should see "rel tag"
     # synonym tag
@@ -279,6 +279,46 @@ Feature: Nominating and reviewing nominations for a tag set
     When I follow "My Nominations"
     Then I should see "My Nominations for bad"
       And I should see "rel tag"
-    When I go to the "bad" tag set nominations page
+    When I review nominations for "bad"
     Then I should see "Fandoms (1 left to review)"
       And I should see "rel tag (canon tag)"
+
+  Scenario: The zero width space tag doesn't replace deleted tag nominations
+    Given a canonical fandom "Treasure Chest"
+      And a zero width space tag exists
+      And I am logged in as "tagsetter"
+      And I set up the nominated tag set "Nominated Tags" with 2 fandom noms and 3 character noms
+      And I nominate fandom "Treasure Chest" and character "Gold" in "Nominated Tags"
+      And I go to the "Nominated Tags" tag set page
+      And I follow "My Nominations"
+    Then I should see "Not Yet Reviewed (may be edited or deleted)"
+    When I follow "Edit"
+      And I fill in "Character" with ""
+      And I press "Submit"
+    Then I should see "Your nominations were successfully updated."
+      And I should see "Treasure Chest"
+      But I should not see "Gold"
+      And I should see "None nominated in this fandom."
+
+  Scenario: A tag nomination with for the zero width space tag doesn't prevent removing other tag nominations
+    Given a canonical fandom "First"
+      And a canonical fandom "Treasure Chest"
+      And a zero width space tag exists
+      And I am logged in as "tagsetter"
+      And I set up the nominated tag set "Nominated Tags" with 2 fandom noms and 1 character noms
+      # Zero width space character tag in first fandom
+      And I nominate fandom "First,Treasure Chest" and character "​,Gold" in "Nominated Tags"
+      And I go to the "Nominated Tags" tag set page
+      And I follow "My Nominations"
+    Then I should see "First"
+      And I should not see "None nominated in this fandom."
+      And I should see "Treasure Chest"
+      And I should see "Gold"
+    When I follow "Edit"
+      # Empty second fandom character field
+      And I fill in "tag_set_nomination_fandom_nominations_attributes_1_character_nominations_attributes_0_tagname" with ""
+      And I press "Submit"
+    Then I should see "Your nominations were successfully updated."
+      And I should not see "Someone else has already nominated the tag for this set but in fandom First."
+      And I should not see "Gold"
+      And I should see "None nominated in this fandom."

--- a/features/tag_sets/tag_set_nominations.feature
+++ b/features/tag_sets/tag_set_nominations.feature
@@ -117,21 +117,21 @@ Feature: Nominating and reviewing nominations for a tag set
   Scenario: You should be able to delete a nominated character and its fandom at once
   when the tagset doesn't allow fandom nominations
     Given a canonical character "Common Character" in fandom "Canon"
-    And I am logged in as "tagsetter"
-    And I set up the nominated tag set "Nominated Tags" with 0 fandom noms and 3 character noms
+      And I am logged in as "tagsetter"
+      And I set up the nominated tag set "Nominated Tags" with 0 fandom noms and 3 character noms
     When I follow "Nominate"
-    And I fill in "Character 1" with "Obscure Character"
-    And I fill in "Fandom?" with "Canon"
-    And I press "Submit"
+      And I fill in "Character 1" with "Obscure Character"
+      And I fill in "Fandom?" with "Canon"
+      And I press "Submit"
     Then I should see "Your nominations were successfully submitted."
-    And I should see "Obscure Character"
+      And I should see "Obscure Character"
     When I follow "Edit"
-    And I fill in "Character 1" with ""
-    And I fill in "Fandom?" with ""
-    And I press "Submit"
+      And I fill in "Character 1" with ""
+      And I fill in "Fandom?" with ""
+      And I press "Submit"
     Then I should see "Your nominations were successfully updated."
-    And I should see "None nominated in this category."
-    But I should not see "We need to know what fandom belongs in."
+      And I should see "None nominated in this category."
+      But I should not see "We need to know what fandom belongs in."
 
   Scenario: Owner of a tag set can clear all nominations
   Given I am logged in as "tagsetter"


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6783

## Purpose

If a tag nomination is blank (empty string for tagname) because it is meant to be destroyed, don't modify it in `before_save` and exclude it from certain validations.

`Tag.find_by(name: "")` where name is an empty string returns the broken blank tag. Tag nominations that are meant to be removed have an empty string for the tag name. So,  `Tag.find_by_name(tagname)` in TagNomination's `before_save :set_tag_status` returns the broken blank tag and its name is used to set the `TagNomination.tagname`. This means the nomination that was meant to be destroyed by  `after_save :destroy_if_blank` is no longer blank, instead it contains all the information from the broken blank tag so it doesn't get destroyed. There is no way to get rid of this tag nomination, since any attempt to clear the tagname field will repeat this process. The only way to escape the broken blank tag is by renaming the nomination to a completely different tag name, but that still keeps the unwanted tag nomination around.

The problem of the DB returning the broken tag also affects the autocomplete, so I've also added the bypass there.

While investigating which callbacks to skip, I noticed that `validate :known_fandom` on CastNomination would run for nominations about to be destroyed, so you needed to keep Fandom? filled out if you wanted to remove a character or relationship nomination in a tag set that doesn't allow fandom nominations. That's also fixed by skipping it for blank tagnames, so I went ahead and changed it.

## Testing Instructions

See Jira.

## References

The database returning the zero width space tag when querying for an empty string is potentially caused by the database collation. However, the comments on [AO3-6366](https://otwarchive.atlassian.net/issues/AO3-6366) indicates that changing this collation would be a complicated endeavor. So this PR can serve as a workaround to get rid of the incredibly annoying behaviour currently happening on production until it's clear whether changing the collation fixes the underlying issue.

Note that all tests I added here (with the exception of `Scenario: Zero width space tag appears in the autocomplete for zero width space`) fail before the changes in this PR. So users on production are likely hitting the confusing "Someone else has already nominated the tag for this set but in fandom ...." error in `Scenario: A tag nomination with for the zero width space tag doesn't prevent removing other tag nominations`.

## Credit

Bilka (he/him)

[AO3-6366]: https://otwarchive.atlassian.net/browse/AO3-6366?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ