### PR TITLE
AO3-6777 Fix that tag names could be blank

### DIFF
--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -172,6 +172,9 @@ class Tag < ApplicationRecord
   validates :name,
             format: { with: /\A[^,，、*<>^{}=`\\%]+\z/,
                       message: "^Tag name '%{value}' cannot include the following restricted characters: , &#94; * < > { } = ` ， 、 \\ %" }
+  validates :name,
+            format: { without: /\A\p{Cf}+\z/,
+                      message: "^Tag name cannot be blank." }
   validates :sortable_name, presence: true
 
   validate :unwrangleable_status

--- a/features/step_definitions/tag_steps.rb
+++ b/features/step_definitions/tag_steps.rb
@@ -223,7 +223,7 @@ end
 
 Given "a zero width space tag exists" do
   blank_tag = FactoryBot.build(:character, name: ["200B".hex].pack("U"))
-  blank_tag.save!(validate: true) # TODO: Change to validate: false when AO3-6777 is fixed
+  blank_tag.save!(validate: false)
 end
 
 ### WHEN

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -174,7 +174,7 @@ describe Tag do
       ["200D".hex].pack("U"), # zero width joiner
       ["2060".hex].pack("U"), # word joiner
       (["200B".hex].pack("U") * 3),
-      (["200D".hex, "200D".hex, "2060".hex, "200B".hex].pack("U")),
+      ["200D".hex, "200D".hex, "2060".hex, "200B".hex].pack("U")
     ].each do |tag_name|
       tag = Tag.new
       tag.name = tag_name
@@ -186,11 +186,11 @@ describe Tag do
   end
 
   context "tags with names that contain some zero-width characters are valid" do
-    %w(
+    %w[
       👨‍👨‍👧‍👦
       ප්‍රදානය
       👩‍🔬
-    ).each do |tag_name|
+    ].each do |tag_name|
       tag = Tag.new
       tag.name = tag_name
       it "is saved" do

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -168,6 +168,39 @@ describe Tag do
     expect(tag.errors[:name].join).to match(/too long/)
   end
 
+  context "tags with blank names are invalid" do
+    [
+      ["200B".hex].pack("U"), # zero width space
+      ["200D".hex].pack("U"), # zero width joiner
+      ["2060".hex].pack("U"), # word joiner
+      (["200B".hex].pack("U") * 3),
+      (["200D".hex, "200D".hex, "2060".hex, "200B".hex].pack("U")),
+    ].each do |tag_name|
+      tag = Tag.new
+      tag.name = tag_name
+      it "is not saved with an error message about a blank tag" do
+        expect(tag.save).to be_falsey
+        expect(tag.errors[:name].join).to match(/cannot be blank/)
+      end
+    end
+  end
+
+  context "tags with names that contain some zero-width characters are valid" do
+    %w(
+      👨‍👨‍👧‍👦
+      ප්‍රදානය
+      👩‍🔬
+    ).each do |tag_name|
+      tag = Tag.new
+      tag.name = tag_name
+      it "is saved" do
+        expect(tag.save).to be_truthy
+        expect(tag.errors).to be_empty
+        expect(tag.name).to eq(tag_name)
+      end
+    end
+  end
+
   context "tags using restricted characters should not be saved" do
     [
       "bad, tag",


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6777

## Purpose

Forbid tag names that consist exclusively of Unicode characters from the [format category](https://www.compart.com/en/unicode/category/Cf) because they end up looking blank.

## Testing Instructions

See Jira.

## References

This validation is based on the fact that AO3-6087 created this bug by no longer stripping these characters from tag names.

## Credit

Bilka (he/him)
