### PR TITLE
AO3-5441 Allow filter functions for CSS filter

### DIFF
--- a/lib/css_cleaner.rb
+++ b/lib/css_cleaner.rb
@@ -22,6 +22,15 @@ module CssCleaner
   HSLA_REGEX = Regexp.new("hsla?" + PAREN_NUMBER_REGEX.to_s, Regexp::IGNORECASE)
   COLOR_REGEX = Regexp.new("#[0-9a-f]{3,6}|" + ALPHA_REGEX.to_s + "|" + RGBA_REGEX.to_s + "|" + HSLA_REGEX.to_s)
   COLOR_STOP_FUNCTION_REGEX = Regexp.new('color-stop\s*\(' + NUMBER_WITH_UNIT_REGEX.to_s + '\s*\,?\s*' + COLOR_REGEX.to_s + '\s*\)', Regexp::IGNORECASE)
+  
+  # list of filter functions can be found at https://developer.mozilla.org/en-US/docs/Web/CSS/filter#syntax
+  FILTER_NAME_REGEX = Regexp.new("blur|brightness|contrast|grayscale|hue-rotate|invert|opacity|saturate|sepia", Regexp::IGNORECASE)
+  FILTER_FUNCTION_REGEX = Regexp.new("#{FILTER_NAME_REGEX}#{PAREN_NUMBER_REGEX}")
+
+  # drop-shadow can take multiple values, which are a mix of numbers and colors
+  DROP_SHADOW_NAME_REGEX = Regexp.new("drop-shadow", Regexp::IGNORECASE)
+  DROP_SHADOW_VALUE_REGEX = Regexp.new('\(\s*(' + NUMBER_WITH_UNIT_REGEX.to_s + '|' + COLOR_REGEX.to_s + '\s*)+\s*\)')
+  DROP_SHADOW_FUNCTION_REGEX = Regexp.new("#{DROP_SHADOW_NAME_REGEX}#{DROP_SHADOW_VALUE_REGEX}")
 
   # from the ICANN list at http://www.icann.org/en/registries/top-level-domains.htm
   TOP_LEVEL_DOMAINS = %w(ac ad ae aero af ag ai al am an ao aq ar arpa as asia at au aw ax az ba bb bd be bf bg bh bi biz bj bm bn bo br bs bt bv bw by bz ca cat cc cd cf cg ch ci ck cl cm cn co com coop cr cu cv cx cy cz de dj dk dm do dz ec edu ee eg er es et eu fi fj fk fm fo fr ga gb gd ge gf gg gh gi gl gm gn gov gp gq gr gs gt gu gw gy hk hm hn hr ht hu id ie il im in info int io iq ir is it je jm jo jobs jp ke kg kh ki km kn kp kr kw ky kz la lb lc li lk lr ls lt lu lv ly ma mc md me mg mh mil mk ml mm mn mo mobi mp mq mr ms mt mu museum mv mw mx my mz na name nc ne net nf ng ni nl no np nr nu nz om org pa pe pf pg ph pk pl pm pn pr pro ps pt pw py qa re ro rs ru rw sa sb sc sd se sg sh si sj sk sl sm sn so sr st su sv sy sz tc td tel tf tg th tj tk tl tm tn to tp tr travel tt tv tw tz ua ug uk us uy uz va vc ve vg vi vn vu wf ws xn xxx ye yt za zm zw)
@@ -31,7 +40,7 @@ module CssCleaner
   URL_REGEX = Regexp.new(URI_REGEX.to_s + '|"' + URI_REGEX.to_s + '"|\'' + URI_REGEX.to_s + '\'')
   URL_FUNCTION_REGEX = Regexp.new('url\(\s*' + URL_REGEX.to_s + '\s*\)')
 
-  VALUE_REGEX = Regexp.new("#{TRANSFORM_FUNCTION_REGEX}|#{URL_FUNCTION_REGEX}|#{COLOR_STOP_FUNCTION_REGEX}|#{COLOR_REGEX}|#{NUMBER_WITH_UNIT_REGEX}|#{ALPHA_REGEX}|#{SHAPE_FUNCTION_REGEX}")
+  VALUE_REGEX = Regexp.new("#{TRANSFORM_FUNCTION_REGEX}|#{URL_FUNCTION_REGEX}|#{COLOR_STOP_FUNCTION_REGEX}|#{COLOR_REGEX}|#{NUMBER_WITH_UNIT_REGEX}|#{ALPHA_REGEX}|#{SHAPE_FUNCTION_REGEX}|#{FILTER_FUNCTION_REGEX}|#{DROP_SHADOW_FUNCTION_REGEX}")
 
 
   # For use in ActiveRecord models

--- a/lib/css_cleaner.rb
+++ b/lib/css_cleaner.rb
@@ -29,7 +29,7 @@ module CssCleaner
 
   # drop-shadow can take multiple values, which are a mix of numbers and colors
   DROP_SHADOW_NAME_REGEX = Regexp.new("drop-shadow", Regexp::IGNORECASE)
-  DROP_SHADOW_VALUE_REGEX = Regexp.new('\(\s*(' + NUMBER_WITH_UNIT_REGEX.to_s + '|' + COLOR_REGEX.to_s + '\s*)+\s*\)')
+  DROP_SHADOW_VALUE_REGEX = Regexp.new("\\(\\s*(#{NUMBER_WITH_UNIT_REGEX}|#{COLOR_REGEX}\\s*)+\\s*\\)")
   DROP_SHADOW_FUNCTION_REGEX = Regexp.new("#{DROP_SHADOW_NAME_REGEX}#{DROP_SHADOW_VALUE_REGEX}")
 
   # from the ICANN list at http://www.icann.org/en/registries/top-level-domains.htm

--- a/spec/models/skin_spec.rb
+++ b/spec/models/skin_spec.rb
@@ -114,6 +114,21 @@ describe Skin do
         background:linear-gradient(top,#fafafa,#ddd);
         color:#555 }",
 
+      "allows filter properties" => 
+        ".filter_blur { filter: blur(5px); }
+        .filter_brightness { filter: brightness(0.4); }
+        .filter_contrast { filter: contrast(200%); }
+        .filter_drop { filter: drop-shadow(16px 16px 20px blue); }
+        .filter_grayscale { filter: grayscale(50%); }
+        .filter_hue { filter: hue-rotate(90deg); }
+        .filter_invert { filter: invert(75%); }
+        .filter_opacity { filter: opacity(25%); }
+        .filter_saturate { filter: saturate(30%); }
+        .filter_sepia { filter: sepia(60%); }",
+
+      "allows filter properties with multiple values" => 
+        ".filter_multi { filter: contrast(175%) brightness(3%) drop-shadow(3px 3px red) sepia(100%) drop-shadow(blue -3px -3px 5px); }",
+
       "allows display property with flex values" =>
         ".flex-container { display: flex; }
         .flex-container-inline { display: inline-flex; }",


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5441

## Purpose

Adds support for the possible CSS `filter` functions.  See the [MDN for CSS Filters](https://developer.mozilla.org/en-US/docs/Web/CSS/filter#syntax) for full details.

## Testing Instructions

Put the following into a skin and make sure that after saving, the output matches the input and you don't get any error messages. Note that this won't actually do anything useful; it's just to make sure all the values are accepted.

```css
/* <filter-function> values */

.a  { filter: blur(5px);}
.b { filter: brightness(0.4); }
.c { filter: contrast(200%); }
.e { filter: drop-shadow(16px 16px 20px blue); }
.f { filter: grayscale(50%); }
.g { filter: hue-rotate(90deg); }
.h { filter: invert(75%); }
.i { filter: opacity(25%); }
.j { filter: saturate(30%); }
.k { filter: sepia(60%); }

/* Multiple filters */
.l { filter: contrast(175%) brightness(3%); }
.m { filter: drop-shadow(3px 3px red) sepia(100%) drop-shadow(blue -3px -3px 5px); }

/* Use no filter */
.n { filter: none; }

/* Global values */
.o { filter: inherit; }
.p { filter: initial; }
.q { filter: revert; }
.r { filter: revert-layer; }
.s { filter: unset; }

```

## References

Are there other relevant issues/pull requests/mailing list discussions?

## Credit

David Bilsky/Ironskink (He/Him)