### PR TITLE
AO3-6563 Fix reporter for abuse download attachment

### DIFF
--- a/app/jobs/report_attachment_job.rb
+++ b/app/jobs/report_attachment_job.rb
@@ -2,6 +2,6 @@ class ReportAttachmentJob < ApplicationJob
   def perform(ticket_id, work)
     download = Download.new(work, mime_type: "text/html")
     html = DownloadWriter.new(download).generate_html
-    reporter.send_attachment!(ticket_id, html)
+    FeedbackReporter.new.send_attachment!(ticket_id, html)
   end
 end

--- a/spec/jobs/report_attachment_job_spec.rb
+++ b/spec/jobs/report_attachment_job_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe ReportAttachmentJob do
+  let(:work) { build(:work) }
+  let(:writer_mock) { instance_double(DownloadWriter) }
+  let(:reporter) { instance_double(FeedbackReporter) }
+
+  before do
+    download_mock = instance_double(Download)
+    allow(Download).to receive(:new).with(work, { mime_type: "text/html" }).and_return(download_mock)
+    allow(DownloadWriter).to receive(:new).with(download_mock).and_return(writer_mock)
+    allow(writer_mock).to receive(:generate_html)
+    allow(FeedbackReporter).to receive(:new).and_return(reporter)
+    allow(reporter).to receive(:send_attachment!)
+  end
+
+  it "attaches a download of the given work" do
+    ReportAttachmentJob.perform_now(0, work)
+    expect(writer_mock).to have_received(:generate_html)
+    expect(reporter).to have_received(:send_attachment!)
+  end
+end


### PR DESCRIPTION
# Pull Request Checklist

## Issue

https://otwarchive.atlassian.net/browse/AO3-6563

## Purpose

Fix the error identified by Sentry by passing a new `FeedbackReporter` to the `send_attachment!` call in the background job. I tried passing the `reporter` from the `AbuseReport`, but it's not serialisable so that didn't work.
