### PR TITLE
AO3-6539 Update user creation summary h3s and pagination behavior

### DIFF
--- a/app/views/admin/admin_users/_user_creations_summary.html.erb
+++ b/app/views/admin/admin_users/_user_creations_summary.html.erb
@@ -1,17 +1,20 @@
-<% unless @works.empty? %>
+<% unless @user.works.empty? %>
+  <%# Checking @user.items.empty? rather than @items.empty? allows us to display
+# an empty listbox with pagination if the admin manually enters the wrong URL.
+# This is consistent with pagination on other site pages. %>
   <div class="work listbox group" id="works-summary">
-    <h3 class="heading"><%= t(".works", count: works.size) %></h3>
+    <h3 class="heading"><%= search_header(@works, nil, "Work") %></h3>
     <%= render "works/work_abbreviated_list", works: works %>
     <%= will_paginate(works, param_name: "works_page", params: { anchor: "works-summary" }) %>
   </div>
 <% end %>
 
-<% unless @comments.empty? %>
+<% unless @user.comments.empty? %>
   <%# We use comments rather than comment as the class because .comment:after
 # create a clear that causes wonky styling when there are only a few
 # comments. %>
   <div class="comments listbox group" id="comments-summary">
-    <h3 class="heading"><%= t(".comments", count: comments.size) %></h3>
+    <h3 class="heading"><%= search_header(@comments, nil, "Comment") %></h3>
     <%= render "comments/comment_abbreviated_list", comments: comments %>
     <%= will_paginate(comments, param_name: "comments_page", params: { anchor: "comments-summary" }) %>
   </div>

--- a/app/views/admin/admin_users/creations.html.erb
+++ b/app/views/admin/admin_users/creations.html.erb
@@ -4,15 +4,18 @@
   <!--/descriptions-->
 
   <!--subnav-->
-  <ul class="navigation actions" role="navigation">
+  <ul class="navigation actions">
     <li>
-      <%= link_to t(".admin_user"), admin_user_path(@user) %>
+      <%= span_if_current(t(".navigation.creations"), creations_admin_user_path(@user)) %>
+    </li>
+    <li>
+      <%= span_if_current(t(".navigation.admin_user"), admin_user_path(@user)) %>
     </li>
   </ul>
   <!--/subnav-->
 
   <!--main content-->
-  <% if @works.empty? && @comments.empty? %>
+  <% if @user.works.empty? && @user.comments.empty? %>
     <p class="notes"><%= t(".no_creations") %></p>
   <% else %>
     <%= render "user_creations_summary", works: @works, comments: @comments %>

--- a/app/views/admin/admin_users/show.html.erb
+++ b/app/views/admin/admin_users/show.html.erb
@@ -4,7 +4,7 @@
   <!--/descriptions-->
 
   <!--subnav-->
-  <ul class="navigation actions" role="navigation">
+  <ul class="navigation actions">
     <li>
       <%= link_to t(".navigation.invitations.manage"), manage_user_invitations_path(user_id: @user.login) %>
     </li>

--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -121,7 +121,9 @@ en:
         page_heading: Delete Spammer Creations
         submit: Yes, Delete All Spammer Creations
       creations:
-        admin_user: User Administration
+        navigation:
+          admin_user: User Administration
+          creations: Creations
         no_creations: This user has no works or comments.
         page_heading: Works and Comments by %{user}
         page_title: "%{login} - User Creations"
@@ -188,9 +190,6 @@ en:
               required: Required when adding or removing a warning or suspension to an account.
             submit: Update
           heading: Record Warnings, Suspensions, or Notes
-      user_creations_summary:
-        comments: Comments (%{count})
-        works: Works (%{count})
     api:
       edit:
         page_title: Edit API Token

--- a/features/admins/users/admin_manage_users.feature
+++ b/features/admins/users/admin_manage_users.feature
@@ -86,9 +86,11 @@ Feature: Admin Actions to manage users
     Then I should see the invitation id for the user "user2"
 
   Scenario: An admin can access a user's creations from their administration page
-    Given the user "lurker" exists and is activated
+    Given there is 1 user creation per page
+      And the user "lurker" exists and is activated
       And I am logged in as "troll"
       And I post the work "Creepy Gift"
+      And I post the work "NFW"
       And I post the comment "Neener" on the work "Creepy Gift"
     When I am logged in as a "support" admin
       And I go to the user administration page for "lurker"
@@ -103,8 +105,8 @@ Feature: Admin Actions to manage users
     When I go to the user administration page for "troll"
       And I follow "Creations"
     Then I should see "Works and Comments by troll"
-      And I should see "Works (1)" within "#works-summary"
+      And I should see "1 - 1 of 2 Works" within "#works-summary"
       And I should see "Creepy Gift" within "#works-summary"
-      And I should see "Comments (1)" within "#comments-summary"
+      And I should see "1 Comment" within "#comments-summary"
       And I should see "Comment on the work Creepy Gift" within "#comments-summary"
       And I should see "<p>Neener</p>" within "#comments-summary"

--- a/features/step_definitions/admin_steps.rb
+++ b/features/step_definitions/admin_steps.rb
@@ -218,6 +218,11 @@ Given "the admin {string} is unlocked" do |login|
   admin.unlock_access!
 end
 
+Given "there is/are {int} user creation(s) per page" do |amount|
+  allow(Work).to receive(:per_page).and_return(amount)
+  allow(Comment).to receive(:per_page).and_return(amount)
+end
+
 ### WHEN
 
 When /^I visit the last activities item$/ do


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6539

## Purpose

If an admin manually entered a URL with incorrect pagination params for user creations, they would see a page saying the user had no works or comments. Now it will not say that, but it will display empty list boxes with pagination links (if applicable) to be more consistent with other pages on the site.

I also:
* updated the heading on the user creation summary list boxes to say, "X - Y of Total Items"
* removed the `role="navigation"` from two lists, because that's not a valid way to use that attribute
* switched to `span_if_current` in the navigation, which is a little unnecessary, but never a bad idea for consistency
* added a "Creations" navigation item as a breadcrumb on the User Creations page

## Testing Instructions

[What needs testing](https://otwarchive.atlassian.net/browse/AO3-6539?focusedCommentId=361466)

