### PR TITLE
AO3-6796 fix 500 error when trying to access user's works for invalid fandom_id

### DIFF
--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -62,6 +62,9 @@ class WorksController < ApplicationController
       end
 
       tag = @fandom || @tag
+
+      return raise_not_found unless tag
+
       options[:filter_ids] ||= []
       options[:filter_ids] << tag.id
     end

--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -58,12 +58,10 @@ class WorksController < ApplicationController
 
     if params[:fandom_id] || (@collection.present? && @tag.present?)
       if params[:fandom_id].present?
-        @fandom = Fandom.find_by(id: params[:fandom_id])
+        @fandom = Fandom.find(params[:fandom_id])
       end
 
       tag = @fandom || @tag
-
-      return raise_not_found unless tag
 
       options[:filter_ids] ||= []
       options[:filter_ids] << tag.id

--- a/spec/controllers/works/default_rails_actions_spec.rb
+++ b/spec/controllers/works/default_rails_actions_spec.rb
@@ -353,7 +353,8 @@ describe WorksController, work_search: true do
     describe "when the fandom id is invalid" do
       it "raises a 404 for an invalid id" do
         params = { fandom_id: 0 }
-        expect { get :index, params: params }.to raise_error ActiveRecord::RecordNotFound
+        expect { get :index, params: params }
+          .to raise_error ActiveRecord::RecordNotFound
       end
     end
 

--- a/spec/controllers/works/default_rails_actions_spec.rb
+++ b/spec/controllers/works/default_rails_actions_spec.rb
@@ -337,7 +337,6 @@ describe WorksController, work_search: true do
     before do
       @fandom = create(:canonical_fandom)
       @work = create(:work, fandom_string: @fandom.name)
-      @invalid_fandom_id = Fandom.last.id + 1
     end
 
     it "returns the work" do
@@ -352,10 +351,9 @@ describe WorksController, work_search: true do
     end
 
     describe "when the fandom id is invalid" do
-      it "causes a 404 error" do
-        params = { fandom_id: @invalid_fandom_id }
-        get :index, params: params
-        it_redirects_to_simple("/404")
+      it "raises a 404 for an invalid id" do
+        params = { fandom_id: 0 }
+        expect { get :index, params: params }.to raise_error ActiveRecord::RecordNotFound
       end
     end
 

--- a/spec/controllers/works/default_rails_actions_spec.rb
+++ b/spec/controllers/works/default_rails_actions_spec.rb
@@ -337,6 +337,7 @@ describe WorksController, work_search: true do
     before do
       @fandom = create(:canonical_fandom)
       @work = create(:work, fandom_string: @fandom.name)
+      @invalid_fandom_id = Fandom.last.id + 1
     end
 
     it "returns the work" do
@@ -348,6 +349,14 @@ describe WorksController, work_search: true do
       params = { fandom_id: @fandom.id }
       get :index, params: params
       expect(assigns(:fandom)).to eq(@fandom)
+    end
+
+    describe "when the fandom id is invalid" do
+      it "causes a 404 error" do
+        params = { fandom_id: @invalid_fandom_id }
+        get :index, params: params
+        it_redirects_to_simple("/404")
+      end
     end
 
     describe "without caching" do


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [x] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [x] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [x] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-6796

## Purpose

This PR fixes a 500 error when `@fandom` variable in `WorksController#index` was `nil`. 
Now the `@fandom` is retrieved using `find` which will raise an `ActiveRecord::ErrorNotFound` and redirect to 404 if the id is invalid.

## Testing Instructions

Access the following URL: `users/testuser/works?fandom_id=29292929`
It will raise an `ActiveRecord:: RecordNotFound` and be displayed as a 404 in production.

## Credit

What name and pronouns should we use to credit you in the [Archive of Our Own's Release Notes](https://archiveofourown.org/admin_posts?tag=1)? 

AliceLsr (feminine pronouns)
You can find me on Jira and assign it to AliceLsr.
