### PR TITLE
AO3-6795 fix 500 error when excluding search param is invalid

### DIFF
--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -117,7 +117,7 @@ class WorksController < ApplicationController
       flash_search_warnings(@works)
 
       @facets = @works.facets
-      if @search.options[:excluded_tag_ids].present?
+      if @search.options[:excluded_tag_ids].present? && @facets
         tags = Tag.where(id: @search.options[:excluded_tag_ids])
         tags.each do |tag|
           @facets[tag.class.to_s.underscore] ||= []

--- a/features/search/filters.feature
+++ b/features/search/filters.feature
@@ -79,6 +79,9 @@ Feature: Filters
     When I press "Fandoms" within "dd.exclude"
     Then the "Legend of Korra (1)" checkbox within "#exclude_fandom_tags" should not be checked
       And the "Harry Potter (1)" checkbox within "#exclude_fandom_tags" should not be checked
+    When I fill in "work_search_query" with "bad~query!!!"
+      And I press "Sort and Filter"
+    Then I should see "Your search failed because of a syntax error"
 
   @javascript
   Scenario: Filter through a user's works with non-existent tags


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [x] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [x] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [x] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-6795

## Purpose

This PR fixes a bug that displayed a 500 error when the search is invalid, because `@facets` is `nil` since `@works` is invalid (has an error).

```
NoMethodError: undefined method `[]' for nil:NilClass

          @facets[tag.class.to_s.underscore] ||= []
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  app/controllers/works_controller.rb:123:in `block in index'
    @facets[tag.class.to_s.underscore] ||= []
  app/controllers/works_controller.rb:122:in `index'
    tags.each do |tag|
```

## Testing Instructions

- Go to a tag, e.g. Alternate Universe: [https://test.archiveofourown.org/tags/Alternate Universe/works](https://test.archiveofourown.org/tags/Alternate%20Universe/works)
- In the filters, expand one of the sections for excluding a tag and choose something to exclude, e.g. the Not Rated rating
- Also in the filters, enter something invalid in “Search within results,” e.g. otp: true, sort: words (the comma makes it invalid)
- Press Sort and Filter
- Notice that instead of the 500 error we see an error flash with "Your search failed because of a syntax error" message

## Credit

AliceLsr (feminine pronouns)
