### PR TITLE
AO3-6563 Fix Zoho attachment calls to force multipart upload

### DIFF
--- a/app/jobs/report_attachment_job.rb
+++ b/app/jobs/report_attachment_job.rb
@@ -2,6 +2,6 @@ class ReportAttachmentJob < ApplicationJob
   def perform(ticket_id, work)
     download = Download.new(work, mime_type: "text/html")
     html = DownloadWriter.new(download).generate_html
-    FeedbackReporter.new.send_attachment!(ticket_id, html)
+    FeedbackReporter.new.send_attachment!(ticket_id, "#{download.file_name}.html", html)
   end
 end

--- a/app/models/abuse_report.rb
+++ b/app/models/abuse_report.rb
@@ -117,7 +117,7 @@ class AbuseReport < ApplicationRecord
       url: url
     )
     response = reporter.send_report!
-    ticket_id = response.fetch("ticketNumber")
+    ticket_id = response["id"]
     return if ticket_id.blank?
 
     attach_work_download(ticket_id)

--- a/app/models/feedback_reporters/feedback_reporter.rb
+++ b/app/models/feedback_reporters/feedback_reporter.rb
@@ -33,10 +33,10 @@ class FeedbackReporter
     zoho_resource_client.create_ticket(ticket_attributes: report_attributes)
   end
 
-  def send_attachment!(id, download)
+  def send_attachment!(id, filename, download)
     zoho_resource_client.create_ticket_attachment(
       ticket_id: id,
-      attachment_attributes: attachment_attributes(download)
+      attachment_attributes: attachment_attributes(filename, download)
     )
   end
 
@@ -51,8 +51,15 @@ class FeedbackReporter
     }
   end
 
-  def attachment_attributes(download)
-    { file: download }
+  def attachment_attributes(filename, download)
+    attachment = StringIO.new(download)
+    # Workaround for HTTParty not recognizing StringIO as a file-like object:
+    # https://github.com/jnunemaker/httparty/issues/675#issuecomment-590757288
+    def attachment.path
+      filename
+    end
+
+    { file: ZohoStringAttachment.new(filename, download) }
   end
 
   private

--- a/app/models/feedback_reporters/feedback_reporter.rb
+++ b/app/models/feedback_reporters/feedback_reporter.rb
@@ -55,10 +55,7 @@ class FeedbackReporter
     attachment = StringIO.new(download)
     # Workaround for HTTParty not recognizing StringIO as a file-like object:
     # https://github.com/jnunemaker/httparty/issues/675#issuecomment-590757288
-    def attachment.path
-      filename
-    end
-
+    attachment.define_singleton_method(:path) { filename }
     { file: attachment }
   end
 

--- a/app/models/feedback_reporters/feedback_reporter.rb
+++ b/app/models/feedback_reporters/feedback_reporter.rb
@@ -59,7 +59,7 @@ class FeedbackReporter
       filename
     end
 
-    { file: ZohoStringAttachment.new(filename, download) }
+    { file: attachment }
   end
 
   private

--- a/lib/zoho_auth_client.rb
+++ b/lib/zoho_auth_client.rb
@@ -2,7 +2,7 @@
 
 class ZohoAuthClient
   ACCESS_TOKEN_REQUEST_ENDPOINT = "https://accounts.zoho.com/oauth/v2/token"
-  ACCESS_TOKEN_CACHE_KEY = "/v2/zoho_access_token"
+  ACCESS_TOKEN_CACHE_KEY = "/v3/zoho_access_token"
 
   SCOPE = [
     # - Find and create contacts before submitting tickets
@@ -12,7 +12,8 @@ class ZohoAuthClient
     "Desk.contacts.READ",
     "Desk.search.READ",
     "Desk.tickets.CREATE",
-    "Desk.tickets.READ"
+    "Desk.tickets.READ",
+    "Desk.tickets.UPDATE"
   ].join(",").freeze
 
   def access_token

--- a/lib/zoho_resource_client.rb
+++ b/lib/zoho_resource_client.rb
@@ -37,11 +37,14 @@ class ZohoResourceClient
   end
 
   def create_ticket_attachment(ticket_id:, attachment_attributes:)
-    HTTParty.post(
+    response = HTTParty.post(
       ticket_attachment_create_endpoint(ticket_id),
       headers: headers,
-      body: attachment_attributes.to_json
+      body: attachment_attributes
     ).parsed_response
+    raise response["message"] if response["errorCode"]
+
+    response
   end
 
   def find_contact

--- a/spec/jobs/report_attachment_job_spec.rb
+++ b/spec/jobs/report_attachment_job_spec.rb
@@ -10,6 +10,7 @@ describe ReportAttachmentJob do
   before do
     download_mock = instance_double(Download)
     allow(Download).to receive(:new).with(work, { mime_type: "text/html" }).and_return(download_mock)
+    allow(download_mock).to receive(:file_name).and_return("filename")
     allow(DownloadWriter).to receive(:new).with(download_mock).and_return(writer_mock)
     allow(writer_mock).to receive(:generate_html)
     allow(FeedbackReporter).to receive(:new).and_return(reporter)

--- a/spec/lib/zoho_auth_client_spec.rb
+++ b/spec/lib/zoho_auth_client_spec.rb
@@ -35,7 +35,7 @@ describe ZohoAuthClient do
           client_id: "111",
           client_secret: "a1b2c3",
           redirect_uri: "https://archiveofourown.org/support",
-          scope: "Desk.contacts.CREATE,Desk.contacts.READ,Desk.search.READ,Desk.tickets.CREATE,Desk.tickets.READ",
+          scope: "Desk.contacts.CREATE,Desk.contacts.READ,Desk.search.READ,Desk.tickets.CREATE,Desk.tickets.READ,Desk.tickets.UPDATE",
           grant_type: "refresh_token",
           refresh_token: "x1y2z3"
         }

--- a/spec/lib/zoho_resource_client_spec.rb
+++ b/spec/lib/zoho_resource_client_spec.rb
@@ -145,11 +145,6 @@ describe ZohoResourceClient do
 
   describe "#create_ticket_attachment" do
     let(:attachment_attributes) do
-      attachment = StringIO.new("the_file")
-      def attachment.path
-        "the_file.html"
-      end
-
       { file: "the_file" }
     end
 

--- a/spec/lib/zoho_resource_client_spec.rb
+++ b/spec/lib/zoho_resource_client_spec.rb
@@ -145,6 +145,11 @@ describe ZohoResourceClient do
 
   describe "#create_ticket_attachment" do
     let(:attachment_attributes) do
+      attachment = StringIO.new("the_file")
+      def attachment.path
+        "the_file.html"
+      end
+
       { file: "the_file" }
     end
 
@@ -162,7 +167,7 @@ describe ZohoResourceClient do
       expect(WebMock).to have_requested(:post, "https://desk.zoho.com/api/v1/tickets/3/attachments")
         .with(
           headers: expected_request_headers,
-          body: attachment_attributes.to_json
+          body: "file=the_file"
         )
     end
   end

--- a/spec/models/feedback_reporters/feedback_reporter_spec.rb
+++ b/spec/models/feedback_reporters/feedback_reporter_spec.rb
@@ -73,10 +73,6 @@ describe FeedbackReporter do
   describe "#send_attachment!" do
     let(:download) { "the_file" }
 
-    let(:expected_attachment_attributes) do
-      { file: StringIO.new(download) }
-    end
-
     it "calls the Zoho ticket attachment creator with the expected arguments" do
       expect(ZohoResourceClient).to receive_message_chain(
         :new,

--- a/spec/models/feedback_reporters/feedback_reporter_spec.rb
+++ b/spec/models/feedback_reporters/feedback_reporter_spec.rb
@@ -56,15 +56,15 @@ describe FeedbackReporter do
     end
 
     it "calls the ZohoResourceClient with the expected arguments" do
-      expect(ZohoResourceClient).to receive(:new).
-        with(access_token: "x7y8z9", email: "walrus@example.org")
+      expect(ZohoResourceClient).to receive(:new)
+        .with(access_token: "x7y8z9", email: "walrus@example.org")
 
       subject.send_report!
     end
 
     it "calls the Zoho ticket creator with the expected arguments" do
-      expect(ZohoResourceClient).to receive_message_chain(:new, :create_ticket).
-        with(ticket_attributes: expected_ticket_attributes)
+      expect(ZohoResourceClient).to receive_message_chain(:new, :create_ticket)
+        .with(ticket_attributes: expected_ticket_attributes)
 
       subject.send_report!
     end
@@ -84,6 +84,7 @@ describe FeedbackReporter do
       ) do |ticket_id:, attachment_attributes:|
         expect(ticket_id).to eq("123")
         expect(attachment_attributes[:file].gets).to eq(download)
+        expect(attachment_attributes[:file].path).to eq("#{download}.html")
       end
 
       subject.send_attachment!("123", "#{download}.html", download)

--- a/spec/models/feedback_reporters/feedback_reporter_spec.rb
+++ b/spec/models/feedback_reporters/feedback_reporter_spec.rb
@@ -71,23 +71,22 @@ describe FeedbackReporter do
   end
 
   describe "#send_attachment!" do
-    let(:work_id) { "123" }
     let(:download) { "the_file" }
 
     let(:expected_attachment_attributes) do
-      { file: download }
+      { file: StringIO.new(download) }
     end
 
     it "calls the Zoho ticket attachment creator with the expected arguments" do
       expect(ZohoResourceClient).to receive_message_chain(
         :new,
         :create_ticket_attachment
-      ).with(
-        ticket_id: work_id,
-        attachment_attributes: expected_attachment_attributes
-      )
+      ) do |ticket_id:, attachment_attributes:|
+        expect(ticket_id).to eq("123")
+        expect(attachment_attributes[:file].gets).to eq(download)
+      end
 
-      subject.send_attachment!(work_id, download)
+      subject.send_attachment!("123", "#{download}.html", download)
     end
   end
 


### PR DESCRIPTION
# Pull Request Checklist

## Issue

https://otwarchive.atlassian.net/browse/AO3-6563

## Purpose

* Fix scopes for Zoho to get the required UPDATE permissions for attaching a file
* Force HTTParty to treat the HTML string as a file by using `StringIO` with a workaround