### PR TITLE
AO3-6010 Show admin post actions to the correct roles

### DIFF
--- a/app/views/admin_posts/show.html.erb
+++ b/app/views/admin_posts/show.html.erb
@@ -6,16 +6,20 @@
     <!--/descriptions-->
     <!--subnav-->
     <div class="navigation actions module" role="navigation">
-      <% if policy(@admin_post).can_post? %>
+      <% if logged_in_as_admin? %>
         <h4 class="landmark heading"><%= t(".navigation.admin.landmark") %></h4>
         <ul class="management actions">
-          <li><%= link_to t(".navigation.admin.edit"), edit_admin_post_path(@admin_post) %></li>
-          <li>
-            <%= link_to t(".navigation.admin.delete"),
-                  @admin_post,
-                  data: { confirm: t(".navigation.admin.confirm_delete") },
-                  method: :delete %>
-          </li>
+          <% if policy(@admin_post).edit? %>
+            <li><%= link_to t(".navigation.admin.edit"), edit_admin_post_path(@admin_post) %></li>
+          <% end %>
+          <% if policy(@admin_post).destroy? %>
+            <li>
+              <%= link_to t(".navigation.admin.delete"),
+                    @admin_post,
+                    data: { confirm: t(".navigation.admin.confirm_delete") },
+                    method: :delete %>
+            </li>
+          <% end %>
           <% if @admin_post.find_all_comments.unreviewed_only.exists? %>
             <li>
               <%= link_to t(".navigation.admin.unreviewed_comments", count: @admin_post.find_all_comments.unreviewed_only.count),

--- a/features/admins/admin_post_news.feature
+++ b/features/admins/admin_post_news.feature
@@ -272,7 +272,7 @@ Feature: Admin Actions to Post News
       And I should be on the show page for my latest comment
 
     # Access unreviewed comments
-    When I am logged in as a "communications" admin
+    When I am logged in as a "legal" admin
       And I go to the "Default Admin Post" admin post page
       And I follow "Unreviewed Comments (2)"
     Then I should see "Unreviewed Comments on Default Admin Post"


### PR DESCRIPTION
# Pull Request Checklist

## Issue

https://otwarchive.atlassian.net/browse/AO3-6010

## Purpose

Change the permissions check for admin nav on the show admin post (news post) page to make sure admins who can moderate comments actually see that button. (I also updated edit/delete to check the exact permissions, instead of the generic `can_post?` in case those become different in the future.)

## References

We discussed this in chat elsewhere, and while it's not really related to the issue at hand, it will reduce confusion in the long run so we can do it now.