### PR TITLE
AO3-6804 Fix flaky tag wrangling fandoms test

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,6 @@
 # Set the default behavior, in case people don't have core.autocrlf set.
 * text=auto
+# Bash scripts needs to have LF line endings, even on Windows
+*.sh text eol=lf
+# /usr/local/bin/ruby: warning: shebang line ending with \r may cause problems
+/bin/* text eol=lf

--- a/features/tags_and_wrangling/tag_wrangling_fandoms.feature
+++ b/features/tags_and_wrangling/tag_wrangling_fandoms.feature
@@ -112,7 +112,8 @@ Scenario: fandoms wrangling - syns, mergers, autocompletes, metatags
     And I press "Create Tag"
     And I fill in "MetaTags" with "Stargate SG-1"
     And I press "Save changes"
-    And I follow "Stargate SG-1"
+  Then I should see "Tag was updated"
+  When I edit the tag "Stargate SG-1"
   Then I should see "Stargate SG-1: Ark of Truth" within "div#child_SubTag_associations_to_remove_checkboxes"
     And I should see "Stargate Franchise" within "div#parent_MetaTag_associations_to_remove_checkboxes"
   When I am logged in as an admin


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6804

## Purpose

Fix flaky tag wrangling fandoms test by going directly to the tag edit page instead of following a link.

Also, make some changes to `.gitattributes` to fix the line endings of script files on Windows. This means that it is no longer necessary to manually set the line endings git configuration on Windows to get the scripts to run in Docker.

## Testing Instructions

No manual QA required. Without the fix, [20 test runs](https://github.com/Bilka2/otwarchive/actions/runs/10656468709) resulted in 12 failures. With the fixes [40 test runs](https://github.com/Bilka2/otwarchive/actions/runs/10656444471) result in no failures.

## Credit

Bilka (he/him)
