### PR TITLE
AO3-6808 allow 'name' attribute on the details element

### DIFF
--- a/config/initializers/gem-plugin_config/sanitizer_config.rb
+++ b/config/initializers/gem-plugin_config/sanitizer_config.rb
@@ -15,7 +15,7 @@ class Sanitize
         "blockquote" => %w[cite],
         "col" => %w[span width],
         "colgroup" => %w[span width],
-        "details" => %w[open],
+        "details" => %w[open name],
         "hr" => %w[align width],
         "img" => %w[align alt border height src width],
         "ol" => %w[start type],

--- a/spec/lib/html_cleaner_spec.rb
+++ b/spec/lib/html_cleaner_spec.rb
@@ -657,7 +657,39 @@ describe HtmlCleaner do
       expect(doc.xpath("./details/p").size).to eq(2)
     end
 
-    ["ol", "ul"].each do |tag|
+    it "allows details to have a 'name' attribute" do
+      html = <<~HTML
+        <details name='test'>
+          <summary>Automated Status: Operational</summary>
+          <p>Velocity: 12m/s</p>
+          <p>Direction: North</p>
+        </details>
+      HTML
+      result = add_paragraphs_to_text(html)
+      doc = Nokogiri::HTML.fragment(result)
+      expect(doc.xpath("./details[@name]").size).to eq(1)
+    end
+
+    it "allows the value of the 'name' attribute to be repeated" do
+      html = <<~HTML
+        <details name='test'>
+          <summary>Automated Status: Operational</summary>
+          <p>Velocity: 12m/s</p>
+          <p>Direction: North</p>
+        </details>
+        <details name='test'>
+          <summary>Automated Status: Standby</summary>
+          <p>Velocity: 10m/s</p>
+          <p>Direction: South</p>
+        </details>
+      HTML
+      result = add_paragraphs_to_text(html)
+      doc = Nokogiri::HTML.fragment(result)
+      expect(doc.xpath("./details[@name]").size).to eq(2)
+    end
+      
+
+    %w[ol ul].each do |tag|
       it "should not convert linebreaks inside #{tag} lists" do
         html = """
         <#{tag}>

--- a/spec/lib/html_cleaner_spec.rb
+++ b/spec/lib/html_cleaner_spec.rb
@@ -685,7 +685,7 @@ describe HtmlCleaner do
       HTML
       result = add_paragraphs_to_text(html)
       doc = Nokogiri::HTML.fragment(result)
-      expect(doc.xpath("./details[@name]").size).to eq(2)
+      expect(doc.xpath("./details[@name='test']").size).to eq(2)
     end
       
 


### PR DESCRIPTION
# Pull Request Checklist

* [X] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [X] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [X] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [X] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [x] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-6808

## Purpose

Allow the details element to have the ['name' attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/details#name)

## Testing Instructions

Same as https://github.com/otwcode/otwarchive/pull/4448

## References

This is based on https://github.com/otwcode/otwarchive/pull/4457

## Credit

mystyrust, she/her
