### PR TITLE
AO3-6796 - fix QA returns for 500 error on fandom_id

### DIFF
--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -56,10 +56,8 @@ class WorksController < ApplicationController
 
     options = params[:work_search].present? ? clean_work_search_params : {}
 
-    if params[:fandom_id] || (@collection.present? && @tag.present?)
-      if params[:fandom_id].present?
-        @fandom = Fandom.find(params[:fandom_id])
-      end
+    if params[:fandom_id].present? || (@collection.present? && @tag.present?)
+      @fandom = Fandom.find(params[:fandom_id]) if params[:fandom_id]
 
       tag = @fandom || @tag
 

--- a/spec/controllers/works/default_rails_actions_spec.rb
+++ b/spec/controllers/works/default_rails_actions_spec.rb
@@ -358,6 +358,14 @@ describe WorksController, work_search: true do
       end
     end
 
+    describe "when the fandom id is empty" do
+      it "returns the work" do
+        params = { fandom_id: nil }
+        get :index, params: params
+        expect(assigns(:works)).to include(@work)
+      end
+    end
+
     describe "without caching" do
       before do
         AdminSetting.first.update_attribute(:enable_test_caching, false)


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [x] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [x] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [x] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-6796

## Purpose

This PR is a follow up of this previously merged PR, after QA analysis: https://github.com/otwcode/otwarchive/pull/4898

The scenario this PR fixes is the following: 
> Tried one more test, where I completely deleted all numbers from the fandom_id (https://test.archiveofourown.org/users/testy/works?fandom_id=), which resulted in an Error 500!

Now, `fandom_id` will be ignored if  null.

## Testing Instructions

Look at the test scenarios described in this issue: https://otwarchive.atlassian.net/browse/AO3-6796
And test again for "Tried one more test, where I completely deleted all numbers from the fandom_id". Expected behavior is "the behaviour should be to show the /works page as if the fandom_id wasn’t specified."

## References

This PR is a follow-up of: https://github.com/otwcode/otwarchive/pull/4898

## Credit

AliceLsr (feminine pronouns)