### PR TITLE
AO3-6686 Bring back polymorphic_path

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -666,16 +666,13 @@ class CommentsController < ApplicationController
       if commentable.is_a?(Chapter) && (options[:view_full_work] || current_user.try(:preference).try(:view_full_works))
         commentable = commentable.work
       end
-      redirect_to controller: commentable.class.to_s.underscore.pluralize,
-                  action: :show,
-                  id: commentable.id,
-                  show_comments: options[:show_comments],
-                  add_comment_reply_id: options[:add_comment_reply_id],
-                  delete_comment_id: options[:delete_comment_id],
-                  view_full_work: options[:view_full_work],
-                  anchor: options[:anchor],
-                  page: options[:page],
-                  only_path: true
+      redirect_to polymorphic_path(commentable,
+                                   options.slice(:show_comments,
+                                                 :add_comment_reply_id,
+                                                 :delete_comment_id,
+                                                 :view_full_work,
+                                                 :anchor,
+                                                 :page))
     end
   end
 

--- a/spec/controllers/comments_controller_spec.rb
+++ b/spec/controllers/comments_controller_spec.rb
@@ -824,7 +824,7 @@ describe CommentsController do
             post :create, params: { work_id: work.id, comment: comment_attributes }
             comment = Comment.last
             expect(flash[:error]).to be_nil
-            expect(response).to redirect_to(work_chapter_path(work, comment.commentable, show_comments: true, view_full_work: false, anchor: "comment_#{comment.id}"))
+            expect(response).to redirect_to(chapter_path(comment.commentable, show_comments: true, view_full_work: false, anchor: "comment_#{comment.id}"))
           end
         end
       end


### PR DESCRIPTION
# Pull Request Checklist

## Issue

https://otwarchive.atlassian.net/browse/AO3-6686

## Purpose

Switch back to polymorphic_path in the comments controller, since it's a bit more elegant than forcing `only_path`

## Testing Instructions

(automated testing is enough for this)