### PR TITLE
AO3-6749 Fix top-level menu item text color in Low Vision Default

### DIFF
--- a/public/stylesheets/masters/low_vision_default/low_vision_default_site_screen_.css
+++ b/public/stylesheets/masters/low_vision_default/low_vision_default_site_screen_.css
@@ -136,10 +136,9 @@ pre {
 }
 
 #header,
-#header ul.primary,
 #header .open a,
-#header .open a:focus,
-#header .user .open a:focus,
+#header .primary .dropdown a:focus,
+#header .user .dropdown a:focus,
 #footer,
 .actions a:hover,
 .actions a:focus {
@@ -147,7 +146,7 @@ pre {
   color: #eee;
 }
 
-#header h1.heading a {
+#header h1 a {
   color: #fff;
 }
 


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6749

## Purpose

* In Low Vision Default, the top-level menu items sometimes had dark text when open, making them hard to read. Now they'll have light text.
* Adjusted the selector used on the site name in the header because it was weightier than it needed to be.

## Testing Instructions

Make sure to follow the instructions in the Deploy Notes before setting to QA.

* To test the top-level menu items, refer to the second item in the Testing section of the Jira issue.
* To test the selector change, ensure the site name in the header remains white when you hover over it, give it keyboard focus, and click on it.

## Credit

Sarken, she/her