### PR TITLE
AO3-6771 Fix that claim_notification didn't respect user's locale preference

### DIFF
--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -92,22 +92,14 @@ class UserMailer < ApplicationMailer
   end
 
   # Notifies a writer that their imported works have been claimed
-  def claim_notification(creator_id, claimed_work_ids, is_user=false)
-    if is_user
-      creator = User.find(creator_id)
-      locale = creator.preference.locale.iso
-    else
-      creator = ExternalAuthor.find(creator_id)
-      locale = I18n.default_locale
-    end
+  def claim_notification(creator_id, claimed_work_ids)
+    creator = User.find(creator_id)
     @external_email = creator.email
     @claimed_works = Work.where(id: claimed_work_ids)
-    I18n.with_locale(locale) do
-      mail(
-        to: creator.email,
-        subject: t("user_mailer.claim_notification.subject", app_name: ArchiveConfig.APP_SHORT_NAME)
-      )
-    end
+    mail(
+      to: creator.email,
+      subject: default_i18n_subject(app_name: ArchiveConfig.APP_SHORT_NAME)
+    )
   end
 
   # Sends a batched subscription notification

--- a/app/models/external_author.rb
+++ b/app/models/external_author.rb
@@ -131,7 +131,9 @@ class ExternalAuthor < ApplicationRecord
 
   def notify_user_of_claim(claimed_work_ids)
     # send announcement to user of the stories they have been given
-    UserMailer.claim_notification(self.id, claimed_work_ids).deliver_later
+    I18n.with_locale(self.user.preference.locale.iso) do
+      UserMailer.claim_notification(self.user_id, claimed_work_ids).deliver_later
+    end
   end
 
   def find_or_invite(archivist = nil)

--- a/features/importing/work_import.feature
+++ b/features/importing/work_import.feature
@@ -355,3 +355,20 @@ Feature: Import Works
       And I should not see "This chapter is a draft and hasn't been posted yet!"
     When I follow "Next Chapter"
     Then I should not see "This chapter is a draft and hasn't been posted yet!"
+
+  Scenario: Importing as an archivist for an existing Archive author should send translated claim email
+    Given a locale with translated emails
+      And the following activated users exist
+        | login    | email              |
+        | sam      | sam@example.com    |
+        | notsam   | notsam@example.com |
+      And the user "sam" enables translated emails
+      And all emails have been delivered
+    When I import the mock work "http://import-site-without-tags" by "sam" with email "sam@example.com" and by "notsam" with email "notsam@example.com"
+    Then I should see import confirmation
+      And 1 email should be delivered to "sam@example.com"
+      And the email should contain claim information
+      And the email to "sam" should be translated
+      And 1 email should be delivered to "notsam@example.com"
+      And the email should contain claim information
+      And the email to "notsam" should be non-translated

--- a/features/step_definitions/work_import_steps.rb
+++ b/features/step_definitions/work_import_steps.rb
@@ -72,6 +72,17 @@ When /^I start importing "(.*)"( with a mock website)?( as an archivist)?$/ do |
   step %{I select "English" from "Choose a language"}
 end
 
+When "I import the mock work {string} by {string} with email {string} and by {string} with email {string}" do |url, creator_name, creator_email, cocreator_name, cocreator_email|
+  step(%{I start importing "#{url}" with a mock website as an archivist})
+  step(%{I check "Import for others ONLY with permission"})
+  step(%{I fill in "external_author_name" with "#{creator_name}"})
+  step(%{I fill in "external_author_email" with "#{creator_email}"})
+  step(%{I fill in "external_coauthor_name" with "#{cocreator_name}"})
+  step(%{I fill in "external_coauthor_email" with "#{cocreator_email}"})
+  step(%{I check "Post without previewing"})
+  step(%{I press "Import"})
+end
+
 When /^I import "(.*)"( with a mock website)?$/ do |url, mock|
   step %{I start importing "#{url}"#{mock}}
   step %{I press "Import"}

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -149,7 +149,7 @@ describe UserMailer do
     title = "Façade"
     title2 = Faker::Book.title
 
-    subject(:email) { UserMailer.claim_notification(author.id, [work.id, work2.id], true) }
+    subject(:email) { UserMailer.claim_notification(author.id, [work.id, work2.id]) }
 
     let(:author) { create(:user) }
     let(:work) { create(:work, title: title, authors: [author.pseuds.first]) }

--- a/test/mailers/previews/user_mailer_preview.rb
+++ b/test/mailers/previews/user_mailer_preview.rb
@@ -34,10 +34,10 @@ class UserMailerPreview < ApplicationMailerPreview
     UserMailer.feedback(feedback.id)
   end
 
-  def claim_notification_registered
+  def claim_notification
     work = create(:work)
     creator_id = work.pseuds.first.user.id
-    UserMailer.claim_notification(creator_id, [work.id], true)
+    UserMailer.claim_notification(creator_id, [work.id])
   end
 
   private


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6771

## Purpose

Change the claim_notification mail sending to respect the locale preference of the user the email address belongs to. At the same time, fix the locale selector in the email preview.

## Testing Instructions

See Jira.

## Credit

Bilka (he/him)
