### PR TITLE
AO3-5538 Update tag set nominations with old tagname when renaming tags

### DIFF
--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -28,7 +28,7 @@ jobs:
           use_bundler: true
           reporter: github-pr-check
           skip_install: true
-          reviewdog_flags: "-fail-level=any"
+          fail_on_error: true
 
   erb-lint:
     name: ERB Lint runner

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -28,7 +28,7 @@ jobs:
           use_bundler: true
           reporter: github-pr-check
           skip_install: true
-          fail_on_error: true
+          reviewdog_flags: "-fail-level=any"
 
   erb-lint:
     name: ERB Lint runner

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1188,6 +1188,16 @@ class Tag < ApplicationRecord
     parent_names << "" if parent_names.present?
 
     TagNomination.where(tagname: name, parent_tagname: parent_names).update_all(parented: true)
+
+    if saved_change_to_name? && name_before_last_save.present?
+      # Act as if the tag with the previous name was deleted and mirror clear_tag_nominations
+      TagNomination.where(tagname: name_before_last_save).update_all(
+        canonical: false,
+        exists: false,
+        parented: false,
+        synonym: nil
+      )
+    end
   end
 
   before_destroy :clear_tag_nominations

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1189,15 +1189,15 @@ class Tag < ApplicationRecord
 
     TagNomination.where(tagname: name, parent_tagname: parent_names).update_all(parented: true)
 
-    if saved_change_to_name? && name_before_last_save.present?
-      # Act as if the tag with the previous name was deleted and mirror clear_tag_nominations
-      TagNomination.where(tagname: name_before_last_save).update_all(
-        canonical: false,
-        exists: false,
-        parented: false,
-        synonym: nil
-      )
-    end
+    return unless saved_change_to_name? && name_before_last_save.present?
+
+    # Act as if the tag with the previous name was deleted and mirror clear_tag_nominations
+    TagNomination.where(tagname: name_before_last_save).update_all(
+      canonical: false,
+      exists: false,
+      parented: false,
+      synonym: nil
+    )
   end
 
   before_destroy :clear_tag_nominations

--- a/features/tag_sets/tag_set_nominations.feature
+++ b/features/tag_sets/tag_set_nominations.feature
@@ -322,3 +322,19 @@ Feature: Nominating and reviewing nominations for a tag set
       And I should not see "Someone else has already nominated the tag for this set but in fandom First."
       And I should not see "Gold"
       And I should see "None nominated in this fandom."
+
+  Scenario: A nominated canonical tag can be renamed by a tag wrangling admin without affecting the nomination
+    Given a canonical character "Before" in fandom "Treasure Chest"
+      And I am logged in as "tagsetter"
+      And I set up the nominated tag set "Nominated Tags" with 1 fandom nom and 1 character nom
+      And I nominate fandom "Treasure Chest" and character "Before" in "Nominated Tags" as "tagsetter"
+    When I am logged in as an "tag_wrangling" admin
+      And I edit the tag "Before"
+      And I fill in "Name" with "After"
+      And I press "Save changes"
+    Then I should see "Tag was updated."
+    When I am logged in as "tagsetter"
+      And I go to the "Nominated Tags" tag set page
+      And I follow "My Nominations"
+    Then I should see "Treasure Chest"
+      And I should see "Before"


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5538

## Purpose

Changed `after_save :update_tag_nominations` on tags so that renaming a tag updates tag set nominations using the previous tag name, treating them as if the tag with the previous name was deleted. As per Jira, it does **not** rename the nomination.

## Testing Instructions

See Jira.

## References

I looked into the root cause of this issue while looking at the errors related to the blank tag in tag set nominations, see the [Jira comment](https://otwarchive.atlassian.net/browse/AO3-5538?focusedCommentId=361426).

## Credit

Bilka (he/him)
