### PR TITLE
AO3-4728 Allow HTML in subscription byline

### DIFF
--- a/app/views/subscriptions/index.html.erb
+++ b/app/views/subscriptions/index.html.erb
@@ -46,10 +46,10 @@
         <% case subscription.subscribable_type %>
         <% when "Work" %>
           <%= t(".work") if @subscribable_type.blank? %>
-          <%= t(".byline", creators: byline(subscription.subscribable)) %>
+          <%= t(".byline_html", creators: byline(subscription.subscribable)) %>
         <% when "Series" %>
           <%= t(".series") if @subscribable_type.blank? %>
-          <%= t(".byline", creators: byline(subscription.subscribable)) %>
+          <%= t(".byline_html", creators: byline(subscription.subscribable)) %>
         <% end %>
       <% else %>
         <%= subscription.name %>

--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -855,7 +855,7 @@ en:
   subscriptions:
     index:
       button_html: Unsubscribe from %{name}
-      byline: by %{creators}
+      byline_html: by %{creators}
       heading:
         landmark:
           list: List of Subscriptions

--- a/features/other_b/subscriptions.feature
+++ b/features/other_b/subscriptions.feature
@@ -141,8 +141,10 @@
   When I am on my subscriptions page
   Then I should see "My Subscriptions"
     And I should see "Awesome Series (Series)"
+    And I should see a link "series_author"
     And I should see "third_user"
     And I should see "Awesome Story (Work)"
+    And I should see a link "wip_author"
   When I follow "Series Subscriptions"
   Then I should see "My Series Subscriptions"
     And I should see "Awesome Series"


### PR DESCRIPTION
# Pull Request Checklist

## Issue

https://otwarchive.atlassian.net/browse/AO3-4728

## Purpose

Update the I18n key for subscription bylines to make links render as links instead of `<a href="...`.

## References

https://otwarchive.atlassian.net/browse/AO3-4728?focusedCommentId=361551

## Credit

@Bilka2 for identifying where the bug was