### PR TITLE
AO3-6812 Modify cookie rotator to accept SHA256 cookies

### DIFF
--- a/config/initializers/cookie_rotator.rb
+++ b/config/initializers/cookie_rotator.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-# As part of the Rails 7 upgrade, we need to convert legacy (SHA1) cookies to SHA256.
-# This can be removed after it has been in production for a little bit.
+# Due to the rolled back deploy, some users have SHA256 cookies.
+# Read them, but write back SHA1 cookies (writing is based on current setting of config.active_support.key_generator_hash_digest_class)
 # Ref: https://guides.rubyonrails.org/upgrading_ruby_on_rails.html#key-generator-digest-class-change-requires-a-cookie-rotator
 Rails.application.config.after_initialize do
   Rails.application.config.action_dispatch.cookies_rotations.tap do |cookies|
@@ -11,7 +11,7 @@ Rails.application.config.after_initialize do
     secret_key_base = Rails.application.secret_key_base
 
     key_generator = ActiveSupport::KeyGenerator.new(
-      secret_key_base, iterations: 1000, hash_digest_class: OpenSSL::Digest::SHA1
+      secret_key_base, iterations: 1000, hash_digest_class: OpenSSL::Digest::SHA256
     )
     key_len = ActiveSupport::MessageEncryptor.key_len
 

--- a/config/initializers/cookie_rotator.rb
+++ b/config/initializers/cookie_rotator.rb
@@ -1,7 +1,13 @@
 # frozen_string_literal: true
 
-# Due to the rolled back deploy, some users have SHA256 cookies.
-# Read them, but write back SHA1 cookies (writing is based on current setting of config.active_support.key_generator_hash_digest_class)
+# To support a rolling deploy of SHA256 cookies:
+# 1. Current: Read SHA256 cookies, but write back SHA1 cookies (writing is based on current setting of config.active_support.key_generator_hash_digest_class).
+# 2. Next step: Switch this rotator to read SHA1 and change key_generator_hash_digest_class to write SHA256.
+#   Explanation:
+#     During rolling deploy, rotator from step 1 will still be present on some servers. It will read the new SHA256 cookies and write cookies as SHA1.
+#     While new rotator from step 2 on updated servers converts old SHA1 cookies to new SHA256 cookies.
+#     After rolling deploy is finished, only new rotator will be present on all servers and will convert all SHA1 cookies to SHA256.
+# 3. Step after that: After the rotator from step 2 has been deployed for a while and all cookies should be converted to SHA256, remove the rotator.
 # Ref: https://guides.rubyonrails.org/upgrading_ruby_on_rails.html#key-generator-digest-class-change-requires-a-cookie-rotator
 Rails.application.config.after_initialize do
   Rails.application.config.action_dispatch.cookies_rotations.tap do |cookies|


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6812

## Purpose

Change the cookie rotator to force everyone to be backwards compatible (when before it didn't actually do anything :sob:)

## Testing Instructions

How can the Archive's QA team verify that this is working as you intended?

If you have a Jira account with access, please update or comment on the issue
with any new or missing testing instructions instead.

## Credit

Bilka (he/him)