### PR TITLE
AO3-6244 Fixed underline added to some links in preface on hover

### DIFF
--- a/public/stylesheets/site/2.0/14-group-preface.css
+++ b/public/stylesheets/site/2.0/14-group-preface.css
@@ -35,11 +35,6 @@ div.preface .module {
 div.preface .title, div.preface .byline, div.preface .byline a {
   border: 0;
   text-align: center;
-  text-decoration: none;
-}
-
-.preface a:hover {
-  text-decoration: underline;
 }
 
 .preface blockquote {


### PR DESCRIPTION
# Pull Request Checklist

* [X] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [X] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [X] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [X] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [X] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-6244

## Purpose

Fixed styling of links in preface on hover, in which underline was incorrectly added.

## Testing Instructions

Follow Jira's Steps to reproduce:
1. Log in
2. Post > New Work
3. Fill in required fields
4. For "Notes," check "at the beginning"
5. Include a link, e.g., <a href="#">Link</a>
6. Post
7. On a computer, hover over the link. 
8. Confirm underline is not added in addition to bottom border.

## References

N/A
## Credit
Paola Solari (she/her)