### PR TITLE
AO3-4735 Don't treat "-" as NOT when it is alone

### DIFF
--- a/app/models/search/query.rb
+++ b/app/models/search/query.rb
@@ -237,7 +237,7 @@ class Query
     str = ""
     return str if text.blank?
     text.split(" ").each do |word|
-      if word[0] == "-"
+      if word.length >= 2 && word[0] == "-"
         str << " NOT"
         word.slice!(0)
       end

--- a/spec/models/search/query_spec.rb
+++ b/spec/models/search/query_spec.rb
@@ -27,5 +27,11 @@ describe Query do
       result = q.split_query_text_words(:hero, "superman -batman")
       expect(result).to eq(" hero:superman NOT hero:batman")
     end
+
+    it "should not touch stand-alone minuses" do
+      q = Query.new
+      result = q.split_query_text_words(:title, "foo - bar")
+      expect(result).to eq(" title:foo title:\\- title:bar")
+    end
   end
 end


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [x] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [x] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [x] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-4735

## Purpose

To make the title search not fail with an stand-alone "-" between words.

## Testing instructions

Queries like the one given in the Jira issue should work now when entered in "Title" under "Work info" in the search page.

Note that the system won't check whether a field has "-" or not anyway. `some - thing` will effectively the same as `some thing` in queries.

## Credit

Potpotkettle (they/them)
