### PR TITLE
AO3-6765 Improve Skin Preview Message

### DIFF
--- a/features/other_b/skin_public.feature
+++ b/features/other_b/skin_public.feature
@@ -120,7 +120,8 @@ Feature: Public skins
     And I follow "Preview"
   Then I should be on the works tagged "Major Crimes"
     And I should see "You are previewing the skin Usable Skin. This is a randomly chosen page."
-    And I should see "Go back or click any link to remove the skin"
-    And I should see "Tip: You can preview any archive page you want by tacking on '?site_skin=[skin_id]' like you can see in the url above."
-  When I follow "Return To Skin To Use"
+    And I should see "Go back or follow any link to remove the skin"
+    And I should see "Tip: You can preview any archive page you want by adding '?site_skin="
+    And I should see "' to the end of the URL."
+  When I follow "Return to Skin to Use"
   Then I should be on "Usable Skin" skin page


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6765
## Purpose

* Adds the skin ID to the preview tip (rather than making the user copy-paste it themselves)
* Wraps the "Return" button in a paragraph tag so that it is not a bulleted list item
* Adjusts wording in message


## Testing Instructions

Updated preview message following the changes in the ticket should look like this:
<img width="788" alt="image" src="https://github.com/user-attachments/assets/5ca59673-e8a8-441a-a3e6-9c98488cd49e">


## References

Are there other relevant issues/pull requests/mailing list discussions?

## Credit

David Bilsky/Ironskink (He/Him)

