### PR TITLE
AO3-5951 Fix lists displaying inline in userstuff blurb areas

### DIFF
--- a/public/stylesheets/site/2.0/21-userstuff.css
+++ b/public/stylesheets/site/2.0/21-userstuff.css
@@ -45,6 +45,10 @@
   padding: 0 1em;
 }
 
+.userstuff ul li { 
+  display: list-item; 
+}
+
 .userstuff li, .userstuff ol ul li {
   font-weight: normal;
   display: list-item;


### PR DESCRIPTION
# Pull Request Checklist

* [x ] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [ x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [ ] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [x ] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [ ] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-5951

## Purpose

This PR ensures that unordered lists in work summaries or bookmark notes appear with items listed horizontally in blurbs. With this change, they now stack vertically, each with a black circle in front of them, like they display in the summary on the work itself.

## Testing Instructions

Log in

Post > New Work

Fill in required fields and, in the "Summary" field, include an unordered list, e.g. <ul><li>list</li><li>item</li></ul>

Press "Post Without Preview" to post the work

Browse > Bookmarks

Press "Save" on one

In the "Notes" field, include an unordered list using the same HTML from step 3

Press "Create" to save your bookmark

Hi, username! > My Dashboard

The items in your work summary and bookmark notes should appear as normally now, instead of being side by side. 

## References

n/a

## Credit

MarleaM She/Her

