### PR TITLE
AO3-6824 Install imagemagick in automated tests

### DIFF
--- a/.github/workflows/automated-tests.yml
+++ b/.github/workflows/automated-tests.yml
@@ -54,16 +54,22 @@ jobs:
             arguments: db:otwseed
           - command: rspec
             arguments: spec/controllers
+            imagemagick: true
           - command: rspec
             arguments: spec/models
+            imagemagick: true
           - command: rspec
             arguments: --exclude-pattern 'spec/{controllers,models}/**/*.rb'
+            imagemagick: true
           - command: cucumber
             arguments: features/admins
+            imagemagick: true
           - command: cucumber
             arguments: features/bookmarks
+            imagemagick: true
           - command: cucumber
             arguments: features/collections
+            imagemagick: true
           - command: cucumber
             arguments: features/comments_and_kudos
           - command: cucumber
@@ -73,8 +79,10 @@ jobs:
             vcr: true
           - command: cucumber
             arguments: features/other_a
+            imagemagick: true
           - command: cucumber
             arguments: features/other_b
+            imagemagick: true
           - command: cucumber
             arguments: features/prompt_memes_a
           - command: cucumber
@@ -92,6 +100,7 @@ jobs:
           - command: cucumber
             arguments: features/works
             ebook: true
+            imagemagick: true
 
     steps:
       - name: Check out code
@@ -128,6 +137,10 @@ jobs:
           key: cassette-library-${{ hashFiles(matrix.tests.arguments) }}-${{ github.run_id }}-${{ github.run_attempt }}
           restore-keys: |
             cassette-library-${{ hashFiles(matrix.tests.arguments) }}-
+
+      - name: Install imagemagick for image processing
+        if: ${{ matrix.tests.imagemagick }}
+        run: sudo apt-get install -y imagemagick
 
       - name: Set up Ruby and run bundle install
         uses: ruby/setup-ruby@v1


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6824

## Purpose

Fix automated tests after GitHub updated the the action runner to Ubuntu 24.04 by installing the ImageMagick package.

## Testing Instructions

Tests should pass on this PR.

You can also see the failing tests in [#4940](https://github.com/otwcode/otwarchive/pull/4940/commits/9e7f7bd02d4caf930efb1ee6f0d43b4c93851183) with the fixed tests visible with the [next commit](https://github.com/otwcode/otwarchive/pull/4940/commits/1ef675ee9602739fa98c987d77435883ff02d27a).

## Credit

Bilka (he/him)