### PR TITLE
AO3-6825 Update bookmark blurbs when bookmarker's tags are renamed

### DIFF
--- a/app/helpers/bookmarks_helper.rb
+++ b/app/helpers/bookmarks_helper.rb
@@ -24,11 +24,6 @@ module BookmarksHelper
     end
   end
 
-  # tag_bookmarks_path was behaving badly for tags with slashes
-  def link_to_tag_bookmarks(tag)
-    {controller: 'bookmarks', action: 'index', tag_id: tag}
-  end
-
   def link_to_bookmarkable_bookmarks(bookmarkable, link_text='')
     if link_text.blank?
       link_text = number_with_delimiter(Bookmark.count_visible_bookmarks(bookmarkable, current_user))

--- a/app/views/bookmarks/_bookmark_blurb_short.html.erb
+++ b/app/views/bookmarks/_bookmark_blurb_short.html.erb
@@ -15,14 +15,14 @@
     <h6 class="meta heading"><%= ts("Bookmark Tags:") %></h6>
     <ul class="meta tags commas">
       <% bookmark.tags.each do |tag| %>
-        <li><%= link_to tag.name, link_to_tag_bookmarks(tag), :class => 'tag' %></li>
+        <li><%= link_to tag.name, tag_bookmarks_path(tag), class: "tag" %></li>
       <% end %>
     </ul>
   <% end %>
   <% unless bookmark.collections.blank? %>
     <h6 class="meta heading"><%= ts("Bookmark Collections:") %></h6>
     <ul class="meta commas">
-      <% bookmark.collections.each do |coll|%>
+      <% bookmark.collections.each do |coll| %>
         <li><%= link_to coll.title, collection_path(coll) %></li>
       <% end %>
     </ul>
@@ -36,8 +36,8 @@
   <% end %>
   <!--actions-->
   <% if is_author_of?(bookmark) %>
-    <%= render :partial => 'bookmarks/bookmark_owner_navigation', :locals => {:bookmark => bookmark} %>
+    <%= render "bookmark_owner_navigation", bookmark: bookmark %>
   <% elsif logged_in_as_admin? %>
-    <%= render :partial => 'admin/admin_options', :locals => {:item => bookmark} %>
+    <%= render "admin/admin_options", item: bookmark %>
   <% end %>
 </li>

--- a/app/views/bookmarks/_bookmark_user_module.html.erb
+++ b/app/views/bookmarks/_bookmark_user_module.html.erb
@@ -1,5 +1,6 @@
 <% # expects "bookmark" %>
 <div class="<% if is_author_of?(bookmark) %>own <% end %>user module group">
+  <%# If you update the cache key, update flush_bookmark_cache in tag.rb %>
   <% blurb_cache_key = (is_author_of?(bookmark) ? "bookmark-owner-blurb-#{bookmark.cache_key}-v2" : "bookmark-blurb-#{bookmark.cache_key}-v2") %>
   <% cache(blurb_cache_key, skip_digest: true) do %>
     <!--bookmarker, time-->
@@ -14,7 +15,7 @@
       <h6 class="meta heading"><%= ts('Bookmarker\'s Tags:') %></h6>
       <ul class="meta tags commas">
         <% bookmark.tags.each do |tag| %>
-          <li><%= link_to(tag.name, link_to_tag_bookmarks(tag), :class => 'tag') %></li>
+          <li><%= link_to(tag.name, tag_bookmarks_path(tag), class: "tag") %></li>
         <% end %>
       </ul>
     <% end %>

--- a/features/tags_and_wrangling/tag_wrangling_admin.feature
+++ b/features/tags_and_wrangling/tag_wrangling_admin.feature
@@ -1,11 +1,18 @@
 @users @tag_wrangling @admin
 Feature: Tag wrangling
 
-  Scenario: Admin can rename a tag
+  Scenario: Admin can rename a tag and it updates works and bookmarks.
 
-    Given I am logged in as an admin
-      And a fandom exists with name: "Amelie", canonical: false
-    When I edit the tag "Amelie"
+    Given I am logged in as "audrey" with password "password"
+      And I post the work "Renoir's Boating Party"
+      And I bookmark the work "Renoir's Boating Party" with the tags "Amelie"
+      And I post the work "Luncheon" with fandom "Amelie"
+      # Visit the relevant pages to make sure the data gets cached.
+      And I go to my bookmarks page
+      And I go to my works page
+      And I go to the work "Luncheon"
+    When I am logged in as an admin
+      And I edit the tag "Amelie"
       And I fill in "Synonym of" with "Amélie"
       And I press "Save changes"
     Then I should see "Amélie is considered the same as Amelie by the database"
@@ -15,6 +22,15 @@ Feature: Tag wrangling
     Then I should see "Tag was updated"
       And I should see "Amélie"
       And I should not see "Amelie"
+    When I go to audrey's works page
+    Then I should not see "Amelie"
+      And I should see "Amélie"
+    When I go to the work "Luncheon"
+    Then I should not see "Amelie"
+      And I should see "Amélie"
+    When I go to audrey's bookmarks page
+    Then I should not see "Amelie"
+      And I should see "Amélie"
 
   Scenario: Admin can rename a tag using Eastern characters
 


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6825

## Purpose

When a wrangler or admin renames a tag, any bookmark blurbs using that tag should reflect the change. 

## Testing Instructions

Refer to Jira.

## Credit

Sarken