### PR TITLE
AO3-6831 Rename the Underage warning tag

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -226,7 +226,7 @@ WARNING_NONE_TAG_DISPLAY_NAME: 'No Archive Warnings Apply'
 WARNING_VIOLENCE_TAG_NAME: 'Graphic Depictions Of Violence'
 WARNING_DEATH_TAG_NAME: 'Major Character Death'
 WARNING_NONCON_TAG_NAME: 'Rape/Non-Con'
-WARNING_CHAN_TAG_NAME: 'Underage'
+WARNING_CHAN_TAG_NAME: 'Underage Sex'
 
 RATING_CATEGORY_NAME: 'Rating'
 RATING_DEFAULT_TAG_NAME: 'Not Rated'

--- a/factories/tags.rb
+++ b/factories/tags.rb
@@ -108,4 +108,9 @@ FactoryBot.define do
   factory :banned do |f|
     f.sequence(:name) { |n| "Banned #{n}" }
   end
+
+  factory :archive_warning do |f|
+    f.sequence(:name) { |n| "Archive Warning #{n}" }
+    canonical { true }
+  end
 end

--- a/features/importing/work_import.feature
+++ b/features/importing/work_import.feature
@@ -44,7 +44,7 @@ Feature: Import Works
       And I should see "Detected Title"
       And I should see "Language: Deutsch"
       And I should see "Explicit"
-      And I should see "Archive Warning: Underage"
+      And I should see "Archive Warning: Underage Sex"
       And I should see "Fandom: Detected Fandom"
       And I should see "Category: M/M"
       And I should see "Relationship: Detected 1/Detected 2"

--- a/features/search/works_tags.feature
+++ b/features/search/works_tags.feature
@@ -117,11 +117,11 @@ Feature: Search works by tag
 
   Scenario: Using the header search to exclude works with certain warnings using the warnings' filter_ids
     Given a set of works with various warnings for searching
-    When I search for works without the "Rape/Non-Con" and "Underage" filter_ids
+    When I search for works without the "Rape/Non-Con" and "Underage Sex" filter_ids
     Then the search summary should include the filter_id for "Rape/Non-Con"
-      And the search summary should include the filter_id for "Underage"
+      And the search summary should include the filter_id for "Underage Sex"
       And I should see "5 Found"
-      And the results should not contain the warning tag "Underage"
+      And the results should not contain the warning tag "Underage Sex"
       And the results should not contain the warning tag "Rape/Non-Con"
 
   Scenario: Searching by category returns all works using that category; search

--- a/features/step_definitions/work_import_steps.rb
+++ b/features/step_definitions/work_import_steps.rb
@@ -2,7 +2,7 @@ require 'webmock/cucumber'
 
 def content_fields
   {
-    title: "Detected Title", summary: "Detected summary", fandoms: "Detected Fandom", warnings: "Underage",
+    title: "Detected Title", summary: "Detected summary", fandoms: "Detected Fandom", warnings: "Underage Sex",
     characters: "Detected 1, Detected 2", rating: "Explicit", relationships: "Detected 1/Detected 2",
     categories: "F/F", freeform: "Detected tag 1, Detected tag 2", external_author_name: "Detected Author",
     external_author_email: "detected@foo.com", notes: "This is a <i>content note</i>.",

--- a/lib/tasks/after_tasks.rake
+++ b/lib/tasks/after_tasks.rake
@@ -302,5 +302,61 @@ namespace :After do
       puts("Admin not found.")
     end
   end
+
+  desc "Add suffix to existing Underage Sex tag in prepartion for Underage warning rename"
+  task(add_suffix_to_underage_sex_tag: :environment) do
+    puts("Tags can only be renamed by an admin, who will be listed as the tag's last wrangler. Enter the admin login we should use:")
+    login = $stdin.gets.chomp.strip
+    admin = Admin.find_by(login: login)
+
+    if admin.present?
+      User.current_user = admin
+
+      tag = Tag.find_by_name("Underage Sex")
+
+      if tag.blank?
+        puts("No Underage Sex tag found.")
+      elsif tag.is_a?(ArchiveWarning)
+        puts("Underage Sex is already an Archive Warning.")
+      else
+        suffixed_name = "Underage Sex - #{tag.class}"
+        if tag.update(name: suffixed_name)
+          puts("Renamed Underage Sex tag to #{tag.reload.name}.")
+        else
+          puts("Failed to rename Underage Sex tag to #{suffixed_name}.")
+        end
+        $stdout.flush
+      end
+    else
+      puts("Admin not found.")
+    end
+  end
+
+  desc "Rename Underage warning to Underage Sex"
+  task(rename_underage_warning: :environment) do
+    puts("Tags can only be renamed by an admin, who will be listed as the tag's last wrangler. Enter the admin login we should use:")
+    login = $stdin.gets.chomp.strip
+    admin = Admin.find_by(login: login)
+
+    if admin.present?
+      User.current_user = admin
+
+      tag = ArchiveWarning.find_by_name("Underage")
+
+      if tag.blank?
+        puts("No Underage warning tag found.")
+      else
+        new_name = "Underage Sex"
+        if tag.update(name: new_name)
+          puts("Renamed Underage warning tag to #{tag.reload.name}.")
+        else
+          puts("Failed to rename Underage warning tag to #{new_name}.")
+        end
+        $stdout.flush
+      end
+    else
+      puts("Admin not found.")
+    end
+  end
   # This is the end that you have to put new tasks above.
 end

--- a/public/help/warning-help.html
+++ b/public/help/warning-help.html
@@ -4,7 +4,7 @@
   The Archive of Our Own has chosen, for legal and other reasons, to mandate
   that users either warn for&mdash;or explicitly choose not to warn for&mdash;a
   short list of common warnings: Graphic Depictions of Violence, Major Character
-  Death, Rape/Non-Con, and Underage. We understand that creators may wish to not
+  Death, Rape/Non-Con, and Underage Sex. We understand that creators may wish to not
   warn for some of these things, or to warn for additional content, and have
   provided options for them to do so within this framework.
 </p>
@@ -50,7 +50,7 @@
     "Choose Not to Use Archive Warnings" instead.
   </dd>
   <dt>
-    Underage:
+    Underage Sex:
   </dt>
   <dd>
     This is for descriptions or depictions of sexual activity by characters

--- a/public/help/work-search-text-help.html
+++ b/public/help/work-search-text-help.html
@@ -31,6 +31,6 @@
   <dd>will return all works from Fandom X tagged as F/F, and exclude those tagged Explicit</dd>
 	<dt><kbd>"Character A" OR "Character B" -"Character Death"</kbd></dt>
   <dd>will return all works including Character A or Character B (or both), and no works tagged with "Character Death" in either the Warnings or the Additional tags</dd>
-  <dt><kbd>"Character A/Character B" Underage Mature OR Explicit</kbd></dt>
-  <dd>will return all works for this pairing that include an Underage warning and are either rated Mature or Explicit</dd>
+  <dt><kbd>"Character A/Character B" "Underage Sex" (Mature OR Explicit)</kbd></dt>
+  <dd>will return all works for this pairing that include an Underage Sex warning and are either rated Mature or Explicit</dd>
 </dl>

--- a/script/gift_exchange/tag_seed.json
+++ b/script/gift_exchange/tag_seed.json
@@ -76,6 +76,6 @@
     "Graphic Depictions Of Violence",
     "Major Character Death",
     "Rape/Non-Con",
-    "Underage"
+    "Underage Sex"
   ]
 }

--- a/spec/controllers/api/api_helper.rb
+++ b/spec/controllers/api/api_helper.rb
@@ -15,7 +15,7 @@ module ApiHelper
   # Values in API fake content
   def content_fields
     {
-      title: "Detected Title", summary: "Detected summary", fandoms: "Detected Fandom", warnings: "Underage",
+      title: "Detected Title", summary: "Detected summary", fandoms: "Detected Fandom", warnings: "Underage Sex",
       characters: "Detected 1, Detected 2", rating: "Explicit", relationships: "Detected 1/Detected 2",
       categories: "F/F", freeform: "Detected tag 1, Detected tag 2", external_author_name: "Detected Author",
       external_author_email: "detected@foo.com", notes: "This is a <i>content note</i>.",

--- a/spec/lib/tasks/after_tasks.rake_spec.rb
+++ b/spec/lib/tasks/after_tasks.rake_spec.rb
@@ -392,3 +392,114 @@ describe "rake After:remove_invalid_commas_from_tags" do
     end
   end
 end
+
+describe "rake After:add_suffix_to_underage_sex_tag" do
+  let(:prompt) { "Tags can only be renamed by an admin, who will be listed as the tag's last wrangler. Enter the admin login we should use:\n" }
+
+  context "without a valid admin" do
+    it "puts an error without a valid admin" do
+      allow($stdin).to receive(:gets) { "no-admin" }
+
+      expect do
+        subject.invoke
+      end.to output("#{prompt}Admin not found.\n").to_stdout
+    end
+  end
+
+  context "with a valid admin" do
+    let!(:admin) { create(:admin, login: "admin") }
+
+    before do
+      allow($stdin).to receive(:gets) { "admin" }
+      tag = ArchiveWarning.find_by_name("Underage Sex")
+      tag.destroy!
+    end
+
+    it "puts an error if tag does not exist" do
+      expect do
+        subject.invoke
+      end.to output("#{prompt}No Underage Sex tag found.\n").to_stdout
+    end
+
+    it "puts an error if tag is an ArchiveWarning" do
+      tag = create(:archive_warning, name: "Underage Sex")
+
+      expect do
+        subject.invoke
+      end.to avoid_changing { tag.reload.name }
+        .and output("#{prompt}Underage Sex is already an Archive Warning.\n").to_stdout
+    end
+
+    it "puts a success message if tag exists and can be renamed" do
+      tag = create(:relationship, name: "Underage Sex")
+
+      expect do
+        subject.invoke
+      end.to change { tag.reload.name }
+        .from("Underage Sex")
+        .to("Underage Sex - Relationship")
+        .and output("#{prompt}Renamed Underage Sex tag to Underage Sex - Relationship.\n").to_stdout
+    end
+
+    it "puts an error if tag exists and cannot be renamed" do
+      tag = create(:freeform, name: "Underage Sex")
+      allow_any_instance_of(Tag).to receive(:save).and_return(false)
+
+      expect do
+        subject.invoke
+      end.to avoid_changing { tag.reload.name }
+        .and output("#{prompt}Failed to rename Underage Sex tag to Underage Sex - Freeform.\n").to_stdout
+    end
+  end
+end
+
+describe "rake After:rename_underage_warning" do
+  let(:prompt) { "Tags can only be renamed by an admin, who will be listed as the tag's last wrangler. Enter the admin login we should use:\n" }
+
+  context "without a valid admin" do
+    it "puts an error without a valid admin" do
+      allow($stdin).to receive(:gets) { "no-admin" }
+
+      expect do
+        subject.invoke
+      end.to output("#{prompt}Admin not found.\n").to_stdout
+    end
+  end
+
+  context "with a valid admin" do
+    let!(:admin) { create(:admin, login: "admin") }
+
+    before do
+      allow($stdin).to receive(:gets) { "admin" }
+      tag = ArchiveWarning.find_by_name("Underage Sex")
+      tag.destroy!
+    end
+
+    it "puts an error if tag does not exist" do
+      expect do
+        subject.invoke
+      end.to output("#{prompt}No Underage warning tag found.\n").to_stdout
+    end
+
+    it "puts a success message if tag exists and can be renamed" do
+      tag = create(:archive_warning, name: "Underage")
+
+      expect do
+        subject.invoke
+      end.to change { tag.reload.name }
+        .from("Underage")
+        .to("Underage Sex")
+        .and output("#{prompt}Renamed Underage warning tag to Underage Sex.\n").to_stdout
+    end
+
+    it "puts an error if tag exists and cannot be renamed" do
+      tag = create(:archive_warning, name: "Underage")
+      allow_any_instance_of(Tag).to receive(:save).and_return(false)
+
+      expect do
+        subject.invoke
+      end.to avoid_changing { tag.reload.name }
+        .and output("#{prompt}Failed to rename Underage warning tag to Underage Sex.\n").to_stdout
+    end
+  end
+end

--- a/test/fixtures/tags.yml
+++ b/test/fixtures/tags.yml
@@ -5629,7 +5629,7 @@ tag_1063754075:
   id: 1063754075
   type: Freeform
 tag_1063753743: 
-  name: Underage
+  name: Underage Sex
   merger_id: 
   last_wrangler_type: 
   canonical: true


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6831

## Purpose

* Adds two rake tasks: 
  * `bundle exec rake After:add_suffix_to_underage_sex_tag` to rename the Underage Sex freeform to Underage Sex - Freeform
  *  `bundle exec rake After:rename_underage_warning` to rename the existing Underage warning to Underage Sex
* Updates tests, configuration, and documentation to reflect the rename

## Testing Instructions

None needed, already tested.

## References

The TOS update itself will contain this change:

> 3. https://ao3.org/first_login_help   (https://github.com/otwcode/otwarchive/blob/1bdb4441e193ca269bb31f8c4a78ab5db7d1b663/app/views/home/first_login_help.html.erb#L125-L126) 
"and "Underage"" should be "and "Underage Sex"" 

This is because the TOS update internationalizes the text from that file, so there was no clean way to include the change here.

## Credit

Sarken, she/her