### PR TITLE
AO3-4283 make HTML and classes on the Marked for Later module consistent

### DIFF
--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -36,11 +36,11 @@
       </h3>
       <div class="flash"></div>
       <p class="note"><%= t(".readings.note") %></p>
-      <ul class="readings works index group">
+      <ol class="reading work index group">
         <% @homepage.readings.each do |reading| %>
           <%= render "readings/reading_blurb", work: reading.work, reading: reading %>
         <% end %>
-      </ul>
+      </ol>
     </div>
   <% end %>
 


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [x] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [x] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [x] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-4283

## Purpose

Makes HTML tag and classes of the Marked for Later module on the homepage consistent with the ones on the History and Marked for Later pages

## Testing Instructions

1. Have a work marked for later
2. Create and use a site skin that attempts to target history blurbs, e.g.: `ol.reading .blurb { background: pink; }`
3. The Marked for Later blurbs on the homepage should have pink backgrounds

## References

n/a

## Credit

slavalamp (they/them)

same name on Jira 