### PR TITLE
AO3-6842 Add Content Policy notice to all work forms

### DIFF
--- a/app/views/chapters/_chapter_form.html.erb
+++ b/app/views/chapters/_chapter_form.html.erb
@@ -69,6 +69,11 @@
 
     <fieldset>
       <legend><%= ts("Post Chapter") %></legend>
+      <p class="notice">
+        <%= t(".post_notice_html",
+              content_policy_link: link_to(t(".content_policy"), content_path),
+              tos_faq_link: link_to(t(".tos_faq"), tos_faq_path(anchor: "content_faq"))) %>
+      </p>
       <ul class="actions">
         <% unless @chapter.new_record? || @chapter.posted? %>
           <li><%= submit_tag ts("Save As Draft"), name: "save_button" %></li>

--- a/app/views/chapters/preview.html.erb
+++ b/app/views/chapters/preview.html.erb
@@ -21,6 +21,11 @@
 
   <fieldset>
     <legend><%= ts("Post Chapter") %></legend>
+    <p class="notice">
+      <%= t(".post_notice_html",
+            content_policy_link: link_to(t(".content_policy"), content_path),
+            tos_faq_link: link_to(t(".tos_faq"), tos_faq_path(anchor: "content_faq"))) %>
+    </p>
     <ul class="actions">
       <% if @chapter.posted? %>
         <li><%= submit_tag ts("Update"), name: "update_button" %></li>

--- a/app/views/works/edit_tags.html.erb
+++ b/app/views/works/edit_tags.html.erb
@@ -28,6 +28,11 @@
 
   <fieldset>
     <legend><%= ts('Post Work') %></legend>
+      <p class="notice">
+        <%= t(".post_notice_html",
+              content_policy_link: link_to(t(".content_policy"), content_path),
+              tos_faq_link: link_to(t(".tos_faq"), tos_faq_path(anchor: "content_faq"))) %>
+      </p>
     <ul class="actions">
       <% unless @work.posted? %>
         <li><%= submit_tag ts('Save As Draft'), name: 'save_button' %></li>

--- a/app/views/works/new_import.html.erb
+++ b/app/views/works/new_import.html.erb
@@ -182,6 +182,11 @@
 
   <fieldset>
     <legend><%= ts("Submit") %></legend>
+    <p class="notice">
+      <%= t(".post_notice_html",
+            content_policy_link: link_to(t(".content_policy"), content_path),
+            tos_faq_link: link_to(t(".tos_faq"), tos_faq_path(anchor: "content_faq"))) %>
+    </p>
     <p class="submit actions">
       <%= submit_tag ts("Import") %>
     </p>

--- a/app/views/works/preview.html.erb
+++ b/app/views/works/preview.html.erb
@@ -45,6 +45,11 @@
 
   <fieldset>
     <legend><%= ts("Post Work") %></legend>
+    <p class="notice">
+      <%= t(".post_notice_html",
+            content_policy_link: link_to(t(".content_policy"), content_path),
+            tos_faq_link: link_to(t(".tos_faq"), tos_faq_path(anchor: "content_faq"))) %>
+    </p>
     <ul class="actions">
       <% if @work.posted? %>
         <li><%= submit_tag ts("Update"), name: "update_button" %></li>

--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -441,6 +441,15 @@ en:
           preferences_link_text: update your preferences
           prompt_meme: Signing up for this challenge will allow any user who claims your prompt to gift you a work in response to your prompt regardless of your preference settings. If you wish to receive additional gifts from users who have not claimed your prompts, please %{preferences_link} to allow gifts from anyone. You can always %{refuse_link}.
           refuse_link_text: refuse a gift
+  chapters:
+    chapter_form:
+      content_policy: Content Policy
+      post_notice_html: All works you post on AO3 must comply with our %{content_policy_link}. For more information, please refer to our %{tos_faq_link}.
+      tos_faq: Terms of Service FAQ
+    preview:
+      content_policy: Content Policy
+      post_notice_html: All works you post on AO3 must comply with our %{content_policy_link}. For more information, please refer to our %{tos_faq_link}.
+      tos_faq: Terms of Service FAQ
   collection_items:
     collection_item_form:
       add: Add
@@ -1769,10 +1778,18 @@ en:
     byline:
       add_co-creators: Add co-creators
       show_co-creator_options: Add co-creators?
+    edit_tags:
+      content_policy: Content Policy
+      post_notice_html: All works you post on AO3 must comply with our %{content_policy_link}. For more information, please refer to our %{tos_faq_link}.
+      tos_faq: Terms of Service FAQ
     meta:
       original_creators:
         one: 'Original Creator ID:'
         other: 'Original Creator IDs:'
+    new_import:
+      content_policy: Content Policy
+      post_notice_html: All works you post on AO3 must comply with our %{content_policy_link}. For more information, please refer to our %{tos_faq_link}.
+      tos_faq: Terms of Service FAQ
     permissions:
       privacy: Privacy
       visibility:
@@ -1784,6 +1801,10 @@ en:
         unrestricted: Show to all
     preface:
       title: Preface
+    preview:
+      content_policy: Content Policy
+      post_notice_html: All works you post on AO3 must comply with our %{content_policy_link}. For more information, please refer to our %{tos_faq_link}.
+      tos_faq: Terms of Service FAQ
     search_box:
       a11y_label: Work
       label: Work Search


### PR DESCRIPTION
## Issue

[https://otwarchive.atlassian.net/browse/AO3-6842](https://otwarchive.atlassian.net/browse/AO3-6842)

## Purpose

Mirrors the Content Policy and TOS FAQ reminder notice from AO3-6838 onto the chapter form, chapter preview, edit work tags, import work, and work preview forms.

## Credit

lydia-theda
