### PR TITLE
AO3-5977 Hide "Approve All Unreviewed Comments" button from admins on works

### DIFF
--- a/app/helpers/comments_helper.rb
+++ b/app/helpers/comments_helper.rb
@@ -210,6 +210,10 @@ module CommentsHelper
     is_author_of?(comment.ultimate_parent) || policy(comment).can_review_comment?
   end
 
+  def can_review_all_comments?(commentable)
+    commentable.is_a?(AdminPost) || is_author_of?(commentable)
+  end
+
   #### HELPERS FOR REPLYING TO COMMENTS #####
 
   # return link to add new reply to a comment

--- a/app/views/comments/unreviewed.html.erb
+++ b/app/views/comments/unreviewed.html.erb
@@ -3,7 +3,7 @@
 <!--/descriptions-->
 
 <!--Subnavigation, sorting and actions-->
-<% if @comments[0] && can_review_comment?(@comments[0]) %>
+<% if can_review_all_comments?(@commentable) %>
   <ul class="navigation actions">
     <% path = @commentable.is_a?(AdminPost) ? review_all_admin_post_comments_path(@commentable) : review_all_work_comments_path(@commentable) %>
     <li><%= button_to(t(".approve_all"), path, method: :put) %></li>

--- a/app/views/comments/unreviewed.html.erb
+++ b/app/views/comments/unreviewed.html.erb
@@ -3,10 +3,12 @@
 <!--/descriptions-->
 
 <!--Subnavigation, sorting and actions-->
-<ul class="navigation actions">
-  <% path = @commentable.is_a?(AdminPost) ? review_all_admin_post_comments_path(@commentable) : review_all_work_comments_path(@commentable) %>
-  <li><%= button_to(t(".approve_all"), path, method: :put) %></li>
-</ul>
+<% if @comments[0] && can_review_comment?(@comments[0]) %>
+  <ul class="navigation actions">
+    <% path = @commentable.is_a?(AdminPost) ? review_all_admin_post_comments_path(@commentable) : review_all_work_comments_path(@commentable) %>
+    <li><%= button_to(t(".approve_all"), path, method: :put) %></li>
+  </ul>
+<% end %>
 <!--/subnav-->
 
 <!--main content-->

--- a/features/admins/admin_works.feature
+++ b/features/admins/admin_works.feature
@@ -330,6 +330,19 @@ Feature: Admin Actions for Works, Comments, Series, Bookmarks
     Then I should see "rolex"
       And I should not see "This comment has been marked as spam."
 
+  Scenario: Moderated comments cannot be approved by admin
+    Given the moderated work "Moderation" by "author"
+      And I am logged in as "commenter"
+      And I post the comment "Test comment" on the work "Moderation"
+    When I am logged in as a "superadmin" admin
+      And I view the work "Moderation"
+    Then I should see "Unreviewed Comments (1)"
+      And the comment on "Moderation" should be marked as unreviewed
+    When I follow "Unreviewed Comments (1)"
+    Then I should see "Test comment"
+      And I should not see button "Approve All Unreviewed Comments"
+      And I should not see button "Approve"
+
   Scenario: Admin can edit language on works when posting without previewing
     Given basic languages
       And I am logged in as "regular_user"

--- a/features/admins/admin_works.feature
+++ b/features/admins/admin_works.feature
@@ -340,8 +340,8 @@ Feature: Admin Actions for Works, Comments, Series, Bookmarks
       And the comment on "Moderation" should be marked as unreviewed
     When I follow "Unreviewed Comments (1)"
     Then I should see "Test comment"
-      And I should not see button "Approve All Unreviewed Comments"
-      And I should not see button "Approve"
+      And I should not see an "Approve All Unreviewed Comments" button
+      And I should not see an "Approve" button
 
   Scenario: Admin can edit language on works when posting without previewing
     Given basic languages

--- a/features/step_definitions/web_steps.rb
+++ b/features/step_definitions/web_steps.rb
@@ -257,6 +257,12 @@ Then /^the "(.*?)" checkbox(?: within "(.*?)")? should not be checked$/ do |labe
   end
 end
 
+Then /^(?:|I )should not see button "([^"]*)"(?: within "([^"]*)")?$/ do |text, selector|
+  with_scope(selector) do
+    page.body.should_not have_button(text)
+  end
+end
+
 Then /^(?:|I )should be on (.+)$/ do |page_name|
   current_path = URI.parse(current_url).path
   if current_path.respond_to? :should

--- a/features/step_definitions/web_steps.rb
+++ b/features/step_definitions/web_steps.rb
@@ -257,12 +257,6 @@ Then /^the "(.*?)" checkbox(?: within "(.*?)")? should not be checked$/ do |labe
   end
 end
 
-Then /^(?:|I )should not see button "([^"]*)"(?: within "([^"]*)")?$/ do |text, selector|
-  with_scope(selector) do
-    page.body.should_not have_button(text)
-  end
-end
-
 Then /^(?:|I )should be on (.+)$/ do |page_name|
   current_path = URI.parse(current_url).path
   if current_path.respond_to? :should


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5977

## Purpose

Hides the "Approve All Unreviewed Comments" button if an admin is viewing a work with comment moderation turned on.

## Credit

Jake Faulkner
