### PR TITLE
AO3-6832 Don't attach work download to abuse report if provided comment URL

### DIFF
--- a/app/models/abuse_report.rb
+++ b/app/models/abuse_report.rb
@@ -124,9 +124,9 @@ class AbuseReport < ApplicationRecord
   end
 
   def attach_work_download(ticket_id)
-    comment_id = url[%r{/comments/(\d*)}, 1]
+    is_not_comments = url[%r{/comments/}, 0].nil?
     work_id = url[%r{/works/(\d+)}, 1]
-    return unless work_id and not comment_id
+    return unless work_id && is_not_comments
 
     work = Work.find_by(id: work_id)
     ReportAttachmentJob.perform_later(ticket_id, work) if work

--- a/app/models/abuse_report.rb
+++ b/app/models/abuse_report.rb
@@ -124,8 +124,9 @@ class AbuseReport < ApplicationRecord
   end
 
   def attach_work_download(ticket_id)
+    comment_id = url[%r{/comments/(\d*)}, 1]
     work_id = url[%r{/works/(\d+)}, 1]
-    return unless work_id
+    return unless work_id and not comment_id
 
     work = Work.find_by(id: work_id)
     ReportAttachmentJob.perform_later(ticket_id, work) if work

--- a/spec/models/abuse_report_spec.rb
+++ b/spec/models/abuse_report_spec.rb
@@ -359,6 +359,13 @@ describe AbuseReport do
         .not_to have_enqueued_job
     end
 
+    it "does not attach a download for comment sub-URLs asynchronously" do
+      allow(subject).to receive(:url).and_return("http://archiveofourown.org/works/#{work.id}/comments/")
+
+      expect { subject.attach_work_download(ticket_id) }
+        .not_to have_enqueued_job
+    end
+
     it "attaches a download for work URLs asynchronously" do
       allow(subject).to receive(:url).and_return("http://archiveofourown.org/works/#{work.id}/")
 


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6832

## Purpose

If the URI indicates a comment or a work's comment thread, don't attach an HTML download of the work to the ticket.

## Testing Instructions

Bypass/Comment out initial report send, fill in dummy `ticket_id`  ([link](https://github.com/otwcode/otwarchive/blob/dfaa140ed3b2d221d03d298040a94392fd6673b0/app/models/abuse_report.rb#L109C5-L120C31)), then verify `attach_work_download` returns early for non-work URLs

## Credit

Jake Faulkner
