### PR TITLE
AO3-6773 Fix url param pluralisation in invite_request_declined mailer preview

### DIFF
--- a/test/mailers/previews/user_mailer_preview.rb
+++ b/test/mailers/previews/user_mailer_preview.rb
@@ -42,7 +42,7 @@ class UserMailerPreview < ApplicationMailerPreview
   
   def invite_request_declined
     user = create(:user, :for_mailer_preview)
-    total = params[:total] || 1
+    total = params[:total].to_i || 1
     reason = "test reason"
     UserMailer.invite_request_declined(user.id, total, reason)
   end


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [x] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [x] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [x] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-6773

## Purpose

Convert URL parameters to a number (`to_i`) before passing them to the mailer preview.

## Testing Instructions

See Jira

## References

See discussion in the same ticket on Jira. `config/locales/phrase-exports/ru.yml` is missing the `other` pluralisation rule in multiple places. When a locale tries to use pluralisation, it errors.

## Credit

Amy Lee
