### PR TITLE
AO3-6792 Admins with the support and policy_and_abuse roles should be able to edit languages

### DIFF
--- a/app/controllers/languages_controller.rb
+++ b/app/controllers/languages_controller.rb
@@ -1,5 +1,4 @@
 class LanguagesController < ApplicationController
-
   def index
     @languages = Language.default_order
     @works_counts = Rails.cache.fetch("/v1/languages/work_counts/#{current_user.present?}", expires_in: 1.day) do
@@ -16,7 +15,7 @@ class LanguagesController < ApplicationController
     @language = Language.new(language_params)
     authorize @language
     if @language.save
-      flash[:notice] = t('successfully_added', default: 'Language was successfully added.')
+      flash[:notice] = t("languages.successfully_added")
       redirect_to languages_path
     else
       render action: "new"
@@ -31,8 +30,24 @@ class LanguagesController < ApplicationController
   def update
     @language = Language.find_by(short: params[:id])
     authorize @language
+    
+    unless User.current_user.roles.compact.flatten.include?("superadmin") || User.current_user.roles.compact.flatten.include?("translation")
+      
+      if User.current_user.roles.compact.flatten.include?("policy_and_abuse") && (@language.name != language_params[:name] || @language.short != language_params[:short] || @language.sortable_name != language_params[:sortable_name] || @language.support_available != (language_params[:support_available] == "1"))
+        flash[:error] = t("languages.update.policy_and_abuse_admin_error")
+        redirect_to languages_path
+        return
+      end
+
+      if User.current_user.roles.compact.flatten.include?("support") && (@language.abuse_support_available != (language_params[:abuse_support_available] == "1"))
+        flash[:error] = t("languages.update.support_admin_error")
+        redirect_to languages_path
+        return
+      end
+    end 
+
     if @language.update(language_params)
-      flash[:notice] = t('successfully_updated', default: 'Language was successfully updated.')
+      flash[:notice] = t("languages.successfully_updated")
       redirect_to languages_path
     else
       render action: "new"
@@ -40,6 +55,7 @@ class LanguagesController < ApplicationController
   end
 
   private
+
   def language_params
     params.require(:language).permit(
       :name, :short, :support_available, :abuse_support_available, :sortable_name

--- a/app/controllers/languages_controller.rb
+++ b/app/controllers/languages_controller.rb
@@ -30,21 +30,18 @@ class LanguagesController < ApplicationController
   def update
     @language = Language.find_by(short: params[:id])
     authorize @language
-    
-    unless User.current_user.roles.compact.flatten.include?("superadmin") || User.current_user.roles.compact.flatten.include?("translation")
       
-      if !policy(@language).can_edit_other_fields? && (@language.name != language_params[:name] || @language.short != language_params[:short] || @language.sortable_name != language_params[:sortable_name] || @language.support_available != (language_params[:support_available] == "1"))
-        flash[:error] = t("languages.update.policy_and_abuse_admin_error")
-        redirect_to languages_path
-        return
-      end
+    if !policy(@language).can_edit_non_abuse_fields? && (@language.name != language_params[:name] || @language.short != language_params[:short] || @language.sortable_name != language_params[:sortable_name] || @language.support_available != (language_params[:support_available] == "1"))
+      flash[:error] = t("languages.update.non_abuse_field_error")
+      redirect_to languages_path
+      return
+    end
 
-      if !policy(@language).can_edit_abuse_support_available? && (@language.abuse_support_available != (language_params[:abuse_support_available] == "1"))
-        flash[:error] = t("languages.update.support_admin_error")
-        redirect_to languages_path
-        return
-      end
-    end 
+    if !policy(@language).can_edit_abuse_fields? && (@language.abuse_support_available != (language_params[:abuse_support_available] == "1"))
+      flash[:error] = t("languages.update.abuse_field_error")
+      redirect_to languages_path
+      return
+    end
 
     if @language.update(language_params)
       flash[:notice] = t("languages.successfully_updated")

--- a/app/controllers/languages_controller.rb
+++ b/app/controllers/languages_controller.rb
@@ -33,13 +33,13 @@ class LanguagesController < ApplicationController
     
     unless User.current_user.roles.compact.flatten.include?("superadmin") || User.current_user.roles.compact.flatten.include?("translation")
       
-      if User.current_user.roles.compact.flatten.include?("policy_and_abuse") && (@language.name != language_params[:name] || @language.short != language_params[:short] || @language.sortable_name != language_params[:sortable_name] || @language.support_available != (language_params[:support_available] == "1"))
+      if !policy(@language).can_edit_other_fields? && (@language.name != language_params[:name] || @language.short != language_params[:short] || @language.sortable_name != language_params[:sortable_name] || @language.support_available != (language_params[:support_available] == "1"))
         flash[:error] = t("languages.update.policy_and_abuse_admin_error")
         redirect_to languages_path
         return
       end
 
-      if User.current_user.roles.compact.flatten.include?("support") && (@language.abuse_support_available != (language_params[:abuse_support_available] == "1"))
+      if !policy(@language).can_edit_abuse_support_available? && (@language.abuse_support_available != (language_params[:abuse_support_available] == "1"))
         flash[:error] = t("languages.update.support_admin_error")
         redirect_to languages_path
         return

--- a/app/policies/language_policy.rb
+++ b/app/policies/language_policy.rb
@@ -14,7 +14,7 @@ class LanguagePolicy < ApplicationPolicy
     user_has_roles?(%w[superadmin translation policy_and_abuse])
   end
 
-  def can_edit_other_fields?
+  def can_edit_non_abuse_fields?
     user_has_roles?(%w[superadmin translation support])
   end
 

--- a/app/policies/language_policy.rb
+++ b/app/policies/language_policy.rb
@@ -1,11 +1,23 @@
 class LanguagePolicy < ApplicationPolicy
-  MANAGE_LANGUAGES = %w[superadmin translation].freeze
+  LANGUAGE_EDIT_ACCESS = %w[superadmin translation support policy_and_abuse].freeze
+  LANGUAGE_CREATE_ACCESS = %w[superadmin translation].freeze
 
   def new?
-    user_has_roles?(MANAGE_LANGUAGES)
+    user_has_roles?(LANGUAGE_CREATE_ACCESS)
+  end
+
+  def edit?
+    user_has_roles?(LANGUAGE_EDIT_ACCESS)
+  end
+
+  def can_edit_abuse_support_available?
+    user_has_roles?(%w[superadmin translation policy_and_abuse])
+  end
+
+  def can_edit_other_fields?
+    user_has_roles?(%w[superadmin translation support])
   end
 
   alias create? new?
-  alias edit? new?
-  alias update? new?
+  alias update? edit?
 end

--- a/app/policies/language_policy.rb
+++ b/app/policies/language_policy.rb
@@ -10,7 +10,7 @@ class LanguagePolicy < ApplicationPolicy
     user_has_roles?(LANGUAGE_EDIT_ACCESS)
   end
 
-  def can_edit_abuse_support_available?
+  def can_edit_abuse_fields?
     user_has_roles?(%w[superadmin translation policy_and_abuse])
   end
 

--- a/app/views/languages/_form.html.erb
+++ b/app/views/languages/_form.html.erb
@@ -2,26 +2,26 @@
 
 <%= form_for(@language, html: { class: "post" }) do |f| %>
 
-  <p class="required notice">* <%= t('.required_notice', default: "Required information") %></p>
+  <p class="required notice">* <%= t(".required_notice", default: "Required information") %></p>
 
   <fieldset>
     <dl>
       <dt class="required">
-        <%= f.label :name, t('.name', default: "Name") + " *" %>
+        <%= f.label :name, "#{t('.name', default: 'Name')} *" %>
       </dt>
       <dd class="required">
         <%= f.text_field :name, disabled: !policy(@language).can_edit_other_fields? %>
       </dd>
 
       <dt class="required">
-        <%= f.label :short, t('.short', default: "Abbreviation") + " *" %>
+        <%= f.label :short, "#{t('.short', default: 'Abbreviation')} *" %>
       </dt>
       <dd class="required">
         <%= f.text_field :short, disabled: !policy(@language).can_edit_other_fields? %>
       </dd>
 
       <dt>
-        <%= f.label :sortable_name, t('.sortable_name', default: "Name for alphabetical sorting") %>
+        <%= f.label :sortable_name, t(".sortable_name", default: "Name for alphabetical sorting") %>
       </dt>
       <dd>
         <%= f.text_field :sortable_name, disabled: !policy(@language).can_edit_other_fields? %>
@@ -31,22 +31,21 @@
         <%= f.check_box :support_available, disabled: !policy(@language).can_edit_other_fields? %>
       </dt>
       <dd>
-        <%= f.label :support_available, t('.support_available', default: "Support available") %>
+        <%= f.label :support_available, t(".support_available", default: "Support available") %>
       </dd>
       <dt>
-        <%= f.check_box :abuse_support_available, disabled: !policy(@language).can_edit_abuse_support_available?%>
+        <%= f.check_box :abuse_support_available, disabled: !policy(@language).can_edit_abuse_support_available? %>
       </dt>
       <dd>
-        <%= f.label :abuse_support_available, t('.abuse_support_available', default: "Abuse support available") %>
+        <%= f.label :abuse_support_available, t(".abuse_support_available", default: "Abuse support available") %>
       </dd>
     </dl>
     <p class="submit actions">
       <% if @language.new_record? %>
-        <%= f.submit t('.create', default: "Create Language") %>
+        <%= f.submit t(".create", default: "Create Language") %>
       <% else %>
-        <%= f.submit t('.update', default: "Update Language") %>
+        <%= f.submit t(".update", default: "Update Language") %>
       <% end %>
     </p>
   </fieldset>
 <% end %>
-

--- a/app/views/languages/_form.html.erb
+++ b/app/views/languages/_form.html.erb
@@ -7,14 +7,14 @@
   <fieldset>
     <dl>
       <dt class="required">
-        <%= f.label :name, "#{t(".name")} *" %>
+        <%= f.label :name, "#{t('.name')} *" %>
       </dt>
       <dd class="required">
         <%= f.text_field :name, disabled: !policy(@language).can_edit_non_abuse_fields? %>
       </dd>
 
       <dt class="required">
-        <%= f.label :short, "#{t(".short")} *" %>
+        <%= f.label :short, "#{t('.short')} *" %>
       </dt>
       <dd class="required">
         <%= f.text_field :short, disabled: !policy(@language).can_edit_non_abuse_fields? %>

--- a/app/views/languages/_form.html.erb
+++ b/app/views/languages/_form.html.erb
@@ -7,37 +7,37 @@
   <fieldset>
     <dl>
       <dt class="required">
-        <%= f.label :name, "#{t(".fieldset.name")} *" %>
+        <%= f.label :name, "#{t(".name")} *" %>
       </dt>
       <dd class="required">
-        <%= f.text_field :name, disabled: !policy(@language).can_edit_other_fields? %>
+        <%= f.text_field :name, disabled: !policy(@language).can_edit_non_abuse_fields? %>
       </dd>
 
       <dt class="required">
-        <%= f.label :short, "#{t(".fieldset.short")} *" %>
+        <%= f.label :short, "#{t(".short")} *" %>
       </dt>
       <dd class="required">
-        <%= f.text_field :short, disabled: !policy(@language).can_edit_other_fields? %>
+        <%= f.text_field :short, disabled: !policy(@language).can_edit_non_abuse_fields? %>
       </dd>
 
       <dt>
-        <%= f.label :sortable_name, t(".fieldset.sortable_name") %>
+        <%= f.label :sortable_name, t(".sortable_name") %>
       </dt>
       <dd>
-        <%= f.text_field :sortable_name, disabled: !policy(@language).can_edit_other_fields? %>
+        <%= f.text_field :sortable_name, disabled: !policy(@language).can_edit_non_abuse_fields? %>
       </dd>
 
       <dt>
-        <%= f.check_box :support_available, disabled: !policy(@language).can_edit_other_fields? %>
+        <%= f.check_box :support_available, disabled: !policy(@language).can_edit_non_abuse_fields? %>
       </dt>
       <dd>
-        <%= f.label :support_available, t(".fieldset.support_available") %>
+        <%= f.label :support_available, t(".support_available") %>
       </dd>
       <dt>
-        <%= f.check_box :abuse_support_available, disabled: !policy(@language).can_edit_abuse_support_available? %>
+        <%= f.check_box :abuse_support_available, disabled: !policy(@language).can_edit_abuse_fields? %>
       </dt>
       <dd>
-        <%= f.label :abuse_support_available, t(".fieldset.abuse_support_available") %>
+        <%= f.label :abuse_support_available, t(".abuse_support_available") %>
       </dd>
     </dl>
     <p class="submit actions">

--- a/app/views/languages/_form.html.erb
+++ b/app/views/languages/_form.html.erb
@@ -7,14 +7,14 @@
   <fieldset>
     <dl>
       <dt class="required">
-        <%= f.label :name, "#{t('.fieldset.name')} *" %>
+        <%= f.label :name, "#{t(".fieldset.name")} *" %>
       </dt>
       <dd class="required">
         <%= f.text_field :name, disabled: !policy(@language).can_edit_other_fields? %>
       </dd>
 
       <dt class="required">
-        <%= f.label :short, "#{t('.fieldset.short')} *" %>
+        <%= f.label :short, "#{t(".fieldset.short")} *" %>
       </dt>
       <dd class="required">
         <%= f.text_field :short, disabled: !policy(@language).can_edit_other_fields? %>

--- a/app/views/languages/_form.html.erb
+++ b/app/views/languages/_form.html.erb
@@ -10,31 +10,31 @@
         <%= f.label :name, t('.name', default: "Name") + " *" %>
       </dt>
       <dd class="required">
-        <%= f.text_field :name %>
+        <%= f.text_field :name, disabled: !policy(@language).can_edit_other_fields? %>
       </dd>
 
       <dt class="required">
         <%= f.label :short, t('.short', default: "Abbreviation") + " *" %>
       </dt>
       <dd class="required">
-        <%= f.text_field :short %>
+        <%= f.text_field :short, disabled: !policy(@language).can_edit_other_fields? %>
       </dd>
 
       <dt>
         <%= f.label :sortable_name, t('.sortable_name', default: "Name for alphabetical sorting") %>
       </dt>
       <dd>
-        <%= f.text_field :sortable_name %>
+        <%= f.text_field :sortable_name, disabled: !policy(@language).can_edit_other_fields? %>
       </dd>
 
       <dt>
-        <%= f.check_box :support_available %>
+        <%= f.check_box :support_available, disabled: !policy(@language).can_edit_other_fields? %>
       </dt>
       <dd>
         <%= f.label :support_available, t('.support_available', default: "Support available") %>
       </dd>
       <dt>
-        <%= f.check_box :abuse_support_available %>
+        <%= f.check_box :abuse_support_available, disabled: !policy(@language).can_edit_abuse_support_available?%>
       </dt>
       <dd>
         <%= f.label :abuse_support_available, t('.abuse_support_available', default: "Abuse support available") %>

--- a/app/views/languages/_form.html.erb
+++ b/app/views/languages/_form.html.erb
@@ -2,26 +2,26 @@
 
 <%= form_for(@language, html: { class: "post" }) do |f| %>
 
-  <p class="required notice">* <%= t(".required_notice", default: "Required information") %></p>
+  <p class="required notice">* <%= t(".required_notice") %></p>
 
   <fieldset>
     <dl>
       <dt class="required">
-        <%= f.label :name, "#{t('.name', default: 'Name')} *" %>
+        <%= f.label :name, "#{t('.fieldset.name')} *" %>
       </dt>
       <dd class="required">
         <%= f.text_field :name, disabled: !policy(@language).can_edit_other_fields? %>
       </dd>
 
       <dt class="required">
-        <%= f.label :short, "#{t('.short', default: 'Abbreviation')} *" %>
+        <%= f.label :short, "#{t('.fieldset.short')} *" %>
       </dt>
       <dd class="required">
         <%= f.text_field :short, disabled: !policy(@language).can_edit_other_fields? %>
       </dd>
 
       <dt>
-        <%= f.label :sortable_name, t(".sortable_name", default: "Name for alphabetical sorting") %>
+        <%= f.label :sortable_name, t(".fieldset.sortable_name") %>
       </dt>
       <dd>
         <%= f.text_field :sortable_name, disabled: !policy(@language).can_edit_other_fields? %>
@@ -31,20 +31,20 @@
         <%= f.check_box :support_available, disabled: !policy(@language).can_edit_other_fields? %>
       </dt>
       <dd>
-        <%= f.label :support_available, t(".support_available", default: "Support available") %>
+        <%= f.label :support_available, t(".fieldset.support_available") %>
       </dd>
       <dt>
         <%= f.check_box :abuse_support_available, disabled: !policy(@language).can_edit_abuse_support_available? %>
       </dt>
       <dd>
-        <%= f.label :abuse_support_available, t(".abuse_support_available", default: "Abuse support available") %>
+        <%= f.label :abuse_support_available, t(".fieldset.abuse_support_available") %>
       </dd>
     </dl>
     <p class="submit actions">
       <% if @language.new_record? %>
-        <%= f.submit t(".create", default: "Create Language") %>
+        <%= f.submit t(".submit.create") %>
       <% else %>
-        <%= f.submit t(".update", default: "Update Language") %>
+        <%= f.submit t(".submit.update") %>
       <% end %>
     </p>
   </fieldset>

--- a/config/locales/controllers/en.yml
+++ b/config/locales/controllers/en.yml
@@ -108,8 +108,8 @@ en:
     successfully_added: Language was successfully added.
     successfully_updated: Language was successfully updated.
     update:
-      policy_and_abuse_admin_error: Policy and abuse admin can only update the 'Abuse support available' field.
-      support_admin_error: Support Admin cannot update the 'Abuse support available' field.
+      abuse_field_error: Sorry, only an authorized admin can update the 'Abuse support available' field.
+      non_abuse_field_error: Sorry, only an authorized admin can update fields other than 'Abuse support available'.
   muted:
     users:
       create:

--- a/config/locales/controllers/en.yml
+++ b/config/locales/controllers/en.yml
@@ -104,6 +104,12 @@ en:
   kudos:
     create:
       success: Thank you for leaving kudos!
+  languages:
+    successfully_added: Language was successfully added.
+    successfully_updated: Language was successfully updated.
+    update:
+      policy_and_abuse_admin_error: Policy and abuse admin can only update the 'Abuse support available' field.
+      support_admin_error: Support Admin cannot update the 'Abuse support available' field.
   muted:
     users:
       create:

--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -1391,16 +1391,15 @@ en:
         other: "%{count} more users"
   languages:
     form:
-      fieldset:
-        abuse_support_available: Abuse support available
-        name: Name
-        short: Abbreviation
-        sortable_name: Name for alphabetical sorting
-        support_available: Support available
+      abuse_support_available: Abuse support available
+      name: Name
       required_notice: Required information
+      short: Abbreviation
+      sortable_name: Name for alphabetical sorting
       submit:
         create: Create Language
         update: Update Language
+      support_available: Support available
     index:
       navigation:
         add: Add a Language

--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -1390,6 +1390,17 @@ en:
         one: "%{count} more user"
         other: "%{count} more users"
   languages:
+    form:
+      fieldset:
+        abuse_support_available: Abuse support available
+        name: Name
+        short: Abbreviation
+        sortable_name: Name for alphabetical sorting
+        support_available: Support available
+      required_notice: Required information
+      submit:
+        create: Create Language
+        update: Update Language
     index:
       navigation:
         add: Add a Language

--- a/spec/controllers/languages_controller_spec.rb
+++ b/spec/controllers/languages_controller_spec.rb
@@ -59,7 +59,7 @@ describe LanguagesController do
   end
 
   describe "POST create" do
-    let(:language_params) { 
+    let(:language_params) do 
       {
         language: {
           name: "Suomi",
@@ -69,7 +69,7 @@ describe LanguagesController do
           sortable_name: "su"
         }
       }
-    }
+    end
 
     context "when not logged in" do
       it "redirects with error" do
@@ -154,7 +154,7 @@ describe LanguagesController do
 
   describe "PUT update" do
     let(:finnish) { Language.create(name: "Suomi", short: "fi", support_available: false, abuse_support_available: true) }
-    let(:language_params) { 
+    let(:language_params) do 
       {
         id: finnish.short,
         language: {
@@ -165,9 +165,9 @@ describe LanguagesController do
           sortable_name: "su"
         }
       }
-    }
+    end
 
-    let(:language_params_support) { 
+    let(:language_params_support) do 
       {
         id: finnish.short,
         language: {
@@ -178,9 +178,9 @@ describe LanguagesController do
           sortable_name: ""
         }
       }
-    }
+    end
 
-    let(:language_params_abuse) { 
+    let(:language_params_abuse) do 
       {
         id: finnish.short,
         language: {
@@ -191,7 +191,7 @@ describe LanguagesController do
           sortable_name: ""
         }
       }
-    }
+    end
     
     context "when not logged in" do
       it "redirects with error" do
@@ -280,7 +280,6 @@ describe LanguagesController do
       it "redirects with error" do
         it_redirects_to_with_error(languages_path, "Support Admin cannot update the 'Abuse support available' field.")
       end
-
     end 
 
     context "when logged in as an admin with support role and attempt to edit non-abuse fields" do

--- a/spec/controllers/languages_controller_spec.rb
+++ b/spec/controllers/languages_controller_spec.rb
@@ -153,15 +153,15 @@ describe LanguagesController do
   end
 
   describe "PUT update" do
-    let(:finnish) { Language.create(name: "Suomi", short: "fi", support_available: false, abuse_support_available: true) }
+    let(:finnish) { Language.create(name: "Suomi", short: "fi", support_available: "0", abuse_support_available: "1") }
     let(:language_params) do 
       {
         id: finnish.short,
         language: {
           name: "Suomi",
           short: "fi",
-          support_available: true,
-          abuse_support_available: false,
+          support_available: "1",
+          abuse_support_available: "0",
           sortable_name: "su"
         }
       }
@@ -173,8 +173,8 @@ describe LanguagesController do
         language: {
           name: "Suomi",
           short: "fi",
-          support_available: true,
-          abuse_support_available: true,
+          support_available: "1",
+          abuse_support_available: "1",
           sortable_name: ""
         }
       }
@@ -186,8 +186,8 @@ describe LanguagesController do
         language: {
           name: "Suomi",
           short: "fi",
-          support_available: false,
-          abuse_support_available: false,
+          support_available: "0",
+          abuse_support_available: "0",
           sortable_name: ""
         }
       }
@@ -246,7 +246,7 @@ describe LanguagesController do
         put :update, params: language_params
       end
       it "redirects with error" do
-        it_redirects_to_with_error(languages_path, "Policy and abuse admin can only update the 'Abuse support available' field.")
+        it_redirects_to_with_error(languages_path, "Sorry, only an authorized admin can update fields other than 'Abuse support available'.")
       end
     end 
 
@@ -278,7 +278,7 @@ describe LanguagesController do
         put :update, params: language_params
       end
       it "redirects with error" do
-        it_redirects_to_with_error(languages_path, "Support Admin cannot update the 'Abuse support available' field.")
+        it_redirects_to_with_error(languages_path, "Sorry, only an authorized admin can update the 'Abuse support available' field.")
       end
     end 
 

--- a/spec/controllers/languages_controller_spec.rb
+++ b/spec/controllers/languages_controller_spec.rb
@@ -126,7 +126,7 @@ describe LanguagesController do
       end
     end
     
-    (Admin::VALID_ROLES - %w[superadmin translation]).each do |role|
+    (Admin::VALID_ROLES - %w[superadmin translation support policy_and_abuse]).each do |role|
       context "when logged in as an admin with #{role} role" do
         let(:admin) { create(:admin, roles: [role]) }
         
@@ -139,7 +139,7 @@ describe LanguagesController do
       end
     end
 
-    %w[translation superadmin].each do |role|
+    %w[translation superadmin support policy_and_abuse].each do |role|
       context "when logged in as an admin with #{role} role" do
         let(:admin) { create(:admin, roles: [role]) }
 
@@ -175,7 +175,7 @@ describe LanguagesController do
       end
     end
 
-    (Admin::VALID_ROLES - %w[superadmin translation]).each do |role|
+    (Admin::VALID_ROLES - %w[superadmin translation support policy_and_abuse]).each do |role|
       context "when logged in as an admin with #{role} role" do
         let(:admin) { create(:admin, roles: [role]) }
         
@@ -188,7 +188,7 @@ describe LanguagesController do
       end
     end
 
-    %w[translation superadmin].each do |role|
+    %w[translation superadmin support policy_and_abuse].each do |role|
       context "when logged in as an admin with #{role} role" do
         let(:admin) { create(:admin, roles: [role]) }
 


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [x] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [x] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [x] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-6792 

## Purpose

Adds support and policy_and_abuse roles to language policy + validation to disallow support and policy_and_abuse roles to edit certain fields in the form


## Testing Instructions

How can the Archive's QA team verify that this is working as you intended?

If you have a Jira account with access, please update or comment on the issue
with any new or missing testing instructions instead.

## References

Are there other relevant issues/pull requests/mailing list discussions?

## Credit

What name and pronouns should we use to credit you in the [Archive of Our Own's Release Notes](https://archiveofourown.org/admin_posts?tag=1)?

If you have a Jira account, please include the same name in the "Full name"
field on your Jira profile, so we can assign you the issues you're working on.

*Please note that if you do not fill in this section, we will use your GitHub account name and
they/them pronouns.*
