### PR TITLE
AO3-3945 List subtags in alphabetical order

### DIFF
--- a/app/helpers/tags_helper.rb
+++ b/app/helpers/tags_helper.rb
@@ -176,7 +176,7 @@ module TagsHelper
     sub_ul = ""
     unless tag.direct_sub_tags.empty?
       sub_ul << "<ul class='tags tree index'>"
-      tag.direct_sub_tags.each do |sub|
+      tag.direct_sub_tags.order(:name).each do |sub|
         sub_ul << "<li>" + link_to_tag(sub)
         unless sub.direct_sub_tags.empty?
           sub_ul << sub_tag_tree(sub)

--- a/app/views/tags/show.html.erb
+++ b/app/views/tags/show.html.erb
@@ -83,7 +83,7 @@
   <% unless @tag.direct_sub_tags.blank? %>
   <div class="sub listbox group">
     <h3 class="heading"><%= ts('Subtags') %>:</h3>
-    <% cache "tag-#{@tag.cache_key}-subtags-v2", expires_in: 24.hours, skip_digest: true do %>
+    <% cache "tag-#{@tag.cache_key}-subtags-v3", expires_in: 24.hours, skip_digest: true do %>
       <%= sub_tag_tree(@tag) %>
     <% end %>
   </div>

--- a/features/tags_and_wrangling/tag_wrangling.feature
+++ b/features/tags_and_wrangling/tag_wrangling.feature
@@ -365,3 +365,19 @@ Feature: Tag wrangling
       And I should see "Characters by fandom (2)"
     When I follow "Characters by fandom (2)"
     Then I should see "Mass Wrangle New/Unwrangled Tags"
+
+  Scenario: Subtags are listed in alphabetical order
+    Given a canonical freeform "Angst"
+      And a canonical freeform "Angstc"
+      And it is currently 1 second from now
+      And a canonical freeform "Angstb"
+      And it is currently 1 second from now
+      And a canonical freeform "Angsta"
+      And "Angst" is a metatag of the freeform "Angstc"
+      And it is currently 1 second from now
+      And "Angst" is a metatag of the freeform "Angstb"
+      And it is currently 1 second from now
+      And "Angst" is a metatag of the freeform "Angsta"
+    When I view the tag "Angst"
+    Then "Angsta" should appear before "Angstb"
+      And "Angstb" should appear before "Angstc"


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-3945

## Purpose

Order the subtag list on tag pages by name.

## References

PR Limit: 7 out of 5
Using reviewer bonus:
https://github.com/otwcode/otwarchive/pull/4264
https://github.com/otwcode/otwarchive/pull/4721

## Credit

Bilka
