### PR TITLE
AO3-6862 Use official example domain

### DIFF
--- a/public/help/skins-creating.html
+++ b/public/help/skins-creating.html
@@ -112,7 +112,7 @@
   <dt>URLs</dt>
   <dd>
     <p>
-      We allow external image URLs (specified as <code>url('http://somesite.com/my_awesome_image.jpg')</code>) in JPG, GIF, and PNG formats.
+      We allow external image URLs (specified as <code>url('https://example.com/my_awesome_image.jpg')</code>) in JPG, GIF, and PNG formats.
       Please note, however, that skins using external images will not be approved for public use.
     </p>
   </dd>


### PR DESCRIPTION
# Pull Request Checklist

* [X] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [X] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [X] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [X] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [X] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-6862

## Purpose

Minor help document change: replace a "fake" domain with the official IANA example domain (and use https)

I also did a quick search for other incorrect example URLs. I didn't find any public ones, though I did find

https://github.com/otwcode/otwarchive/blob/6a471a1447cedbed74c9090c5d0f11669a599914/spec/controllers/api/v2/api_works_spec.rb#L21-L25

but since that's just a test, probably fine. Also, a good amount of http (not s) links, but those mostly get redirected to HTTPS by modern browsers anyhow.

https://github.com/otwcode/otwarchive/blob/6a471a1447cedbed74c9090c5d0f11669a599914/features/fixtures/external_works.yml

also references external domains, but since the point of the test is to make sure that external imports work...


## Testing Instructions

Look at the help page at https://test.archiveofourown.org/help/skins-creating.html (replace with localhost as appropriate) and see that it now uses example.com.

## References

Not that I know of.

## Credit

Sekoia, she/her. Jira account uses the same name.