### PR TITLE
AO3-6232 Fix referer for support tickets

### DIFF
--- a/app/controllers/feedbacks_controller.rb
+++ b/app/controllers/feedbacks_controller.rb
@@ -3,8 +3,9 @@ class FeedbacksController < ApplicationController
   before_action :load_support_languages
 
   def new
-    @feedback = Feedback.new
     @admin_setting = AdminSetting.current
+    @feedback = Feedback.new
+    @feedback.referer = request.referer
     if logged_in_as_admin?
       @feedback.email = current_admin.email
     elsif is_registered_user?
@@ -19,7 +20,7 @@ class FeedbacksController < ApplicationController
     @feedback.rollout = @feedback.rollout_string
     @feedback.user_agent = request.env["HTTP_USER_AGENT"]
     @feedback.ip_address = request.remote_ip
-    @feedback.referer = request.referer if request.referer && ArchiveConfig.PERMITTED_HOSTS.include?(URI(request.referer).host)
+    @feedback.referer = nil unless @feedback.referer && ArchiveConfig.PERMITTED_HOSTS.include?(URI(@feedback.referer).host)
     @feedback.site_skin = helpers.current_skin
     if @feedback.save
       @feedback.email_and_send
@@ -41,7 +42,7 @@ class FeedbacksController < ApplicationController
 
   def feedback_params
     params.require(:feedback).permit(
-      :comment, :email, :summary, :username, :language
+      :comment, :email, :summary, :username, :language, :referer
     )
   end
 end

--- a/app/views/feedbacks/new.html.erb
+++ b/app/views/feedbacks/new.html.erb
@@ -56,6 +56,7 @@
 
     <fieldset>
       <legend><%= t(".form.legend.feedback") %></legend>
+      <%= f.hidden_field :referer %>
       <dl>
         <dt class="required">
           <%= f.label :language, t(".form.language.label") %>

--- a/features/other_b/support.feature
+++ b/features/other_b/support.feature
@@ -74,7 +74,7 @@ Feature: Filing a support request
     And I press "Send"
   Then a Zoho ticket should be created with referer "http://www.example.com/works"
 
-  Scenario: Submit a request with an on-Archive referer
+  Scenario: Submit a request with a referer that is not on-Archive
 
   Given I am logged in as "puzzled"
     And basic languages
@@ -82,6 +82,6 @@ Feature: Filing a support request
   When I go to the works page
     And I follow "Support & Feedback"
     And I fill in "Brief summary" with "Just a brief note"
-    And I fill in "Your question or problem" with "Hi, I came from the Archive"
+    And I fill in "Your question or problem" with "Hi, I didn't come from the Archive"
     And I press "Send"
   Then a Zoho ticket should be created with referer "Unknown URL"

--- a/features/other_b/support.feature
+++ b/features/other_b/support.feature
@@ -60,3 +60,28 @@ Feature: Filing a support request
     # The sanitizer adds the domain in front of relative image URLs as of AO3-6571
     And the email should not contain "<img src="http://www.example.org/foo.jpg" />"
     But the email should contain "http://www.example.org/foo.jpgHi"
+
+  Scenario: Submit a request with an on-Archive referer
+
+  Given I am logged in as "puzzled"
+    And basic languages
+    And Zoho ticket creation is enabled
+    And "www.example.com" is a permitted Archive host
+  When I go to the works page
+    And I follow "Support & Feedback"
+    And I fill in "Brief summary" with "Just a brief note"
+    And I fill in "Your question or problem" with "Hi, I came from the Archive"
+    And I press "Send"
+  Then a Zoho ticket should be created with referer "http://www.example.com/works"
+
+  Scenario: Submit a request with an on-Archive referer
+
+  Given I am logged in as "puzzled"
+    And basic languages
+    And Zoho ticket creation is enabled
+  When I go to the works page
+    And I follow "Support & Feedback"
+    And I fill in "Brief summary" with "Just a brief note"
+    And I fill in "Your question or problem" with "Hi, I came from the Archive"
+    And I press "Send"
+  Then a Zoho ticket should be created with referer "Unknown URL"

--- a/features/step_definitions/support_steps.rb
+++ b/features/step_definitions/support_steps.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+Given "Zoho ticket creation is enabled" do
+  allow_any_instance_of(Feedback).to receive(:zoho_enabled?).and_return(true)
+  WebMock.stub_request(:get, %r{/contacts/search})
+    .to_return(headers: { content_type: "application/json" }, body: '{"data":[{"id":"1"}]}')
+  WebMock.stub_request(:post, %r{/tickets})
+    .to_return(headers: { content_type: "application/json" }, body: '{"id":"3"}')
+end
+
+Given "{string} is a permitted Archive host" do |host|
+  allow(ArchiveConfig).to receive(:PERMITTED_HOSTS).and_return([host])
+end
+
+Then "a Zoho ticket should be created with referer {string}" do |referer|
+  expect(WebMock).to have_requested(:post, "https://desk.zoho.com/api/v1/tickets")
+    .with { |req| JSON.parse(req.body)["cf"]["cf_url"] == referer }
+end

--- a/features/step_definitions/support_steps.rb
+++ b/features/step_definitions/support_steps.rb
@@ -13,6 +13,8 @@ Given "{string} is a permitted Archive host" do |host|
 end
 
 Then "a Zoho ticket should be created with referer {string}" do |referer|
+  # rubocop:disable Lint/AmbiguousBlockAssociation
   expect(WebMock).to have_requested(:post, "https://desk.zoho.com/api/v1/tickets")
     .with { |req| JSON.parse(req.body)["cf"]["cf_url"] == referer }
+  # rubocop:enable Lint/AmbiguousBlockAssociation
 end

--- a/spec/controllers/feedbacks_controller_spec.rb
+++ b/spec/controllers/feedbacks_controller_spec.rb
@@ -93,7 +93,7 @@ describe FeedbacksController do
         it "sets the referer in the Zoho ticket" do
           expect(mock_zoho).to receive(:create_ticket).with(ticket_attributes: include(
             "cf" => include(
-              "cf_referer" => "https://archiveofourown.org/works/1",
+              "cf_url" => "https://archiveofourown.org/works/1",
               "cf_ip" => "0.0.0.0"
             )
           ))
@@ -109,7 +109,7 @@ describe FeedbacksController do
         it "does not set the referer in the Zoho ticket" do
           expect(mock_zoho).to receive(:create_ticket).with(ticket_attributes: include(
             "cf" => include(
-              "cf_referer" => "Unknown URL",
+              "cf_url" => "Unknown URL",
               "cf_ip" => "0.0.0.0"
             )
           ))

--- a/spec/controllers/feedbacks_controller_spec.rb
+++ b/spec/controllers/feedbacks_controller_spec.rb
@@ -83,39 +83,5 @@ describe FeedbacksController do
         end
       end
     end
-
-    context "when accessed by a guest" do
-      context "when the referer is on the Archive" do
-        before do
-          request.env["HTTP_REFERER"] = "https://archiveofourown.org/works/1"
-        end
-
-        it "sets the referer in the Zoho ticket" do
-          expect(mock_zoho).to receive(:create_ticket).with(ticket_attributes: include(
-            "cf" => include(
-              "cf_url" => "https://archiveofourown.org/works/1",
-              "cf_ip" => "0.0.0.0"
-            )
-          ))
-          post :create, params: default_parameters
-        end
-      end
-
-      context "when the referer is elsewhere" do
-        before do
-          request.env["HTTP_REFERER"] = "https://example.com/works/1"
-        end
-
-        it "does not set the referer in the Zoho ticket" do
-          expect(mock_zoho).to receive(:create_ticket).with(ticket_attributes: include(
-            "cf" => include(
-              "cf_url" => "Unknown URL",
-              "cf_ip" => "0.0.0.0"
-            )
-          ))
-          post :create, params: default_parameters
-        end
-      end
-    end
   end
 end


### PR DESCRIPTION
Fixes an issue where referrer is always the support ticket form, plus a test I missed in #4989.