### PR TITLE
AO3-6864 Disallow URLs followed by something else in CSS

### DIFF
--- a/lib/css_cleaner.rb
+++ b/lib/css_cleaner.rb
@@ -227,7 +227,7 @@ module CssCleaner
     return value if value =~ /^\"([^\"]*)\"$/
 
     # or a valid img url
-    return value if value.match(URL_FUNCTION_REGEX)
+    return value if value.match(Regexp.new("^#{URL_FUNCTION_REGEX}$"))
 
     # or "none"
     return value if value == "none"

--- a/spec/models/skin_spec.rb
+++ b/spec/models/skin_spec.rb
@@ -177,7 +177,8 @@ describe Skin do
       "errors when saving gradient with xss" => "div {background: -webkit-linear-gradient(url(xss.htc))}",
       "errors when saving dsf images" => "body {background: url(http://foo.com/bar.dsf)}",
       "errors when saving urls with invalid domain" => "body {background: url(http://foo.htc/bar.png)}",
-      "errors when saving xss interrupted with comments" => "div {xss:expr/*XSS*/ession(alert('XSS'))}"
+      "errors when saving xss interrupted with comments" => "div {xss:expr/*XSS*/ession(alert('XSS'))}",
+      "errors when saving url followed by something else" => 'a {content: url(/images/fakeimage.png) " (" attr(href) ")"}'
     }.each_pair do |condition, css|
       it condition do
         @skin.css = css


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6864

## Purpose

Match the whole string when checking URL values in the CSS cleaner.

## Credit

Bilka
