### PR TITLE
AO3-6859 Fix admins being disallowed from tags pages

### DIFF
--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -60,22 +60,22 @@ class TagsController < ApplicationController
     @page_subtitle = @tag.name
     if @tag.is_a?(Banned) 
       if !logged_in_as_admin?
-        flash[:error] = ts('Please log in as admin')
+        flash[:error] = t("admin.access.not_admin_denied")
         redirect_to(tag_wranglings_path) && return
       elsif !policy(:wrangling).read_access?
-        flash[:error] = ts('Sorry, only an authorized admin can access the page you were trying to reach.')
+        flash[:error] = t("admin.access.page_access_denied")
         redirect_to(root_path) && return
       end
     end
     # if tag is NOT wrangled, prepare to show works and bookmarks that are using it
     if !@tag.canonical && !@tag.merger
-      if logged_in? # current_user.is_a?User
-        @works = @tag.works.visible_to_registered_user.paginate(page: params[:page])
-      elsif logged_in_as_admin?
-        @works = @tag.works.visible_to_admin.paginate(page: params[:page])
-      else
-        @works = @tag.works.visible_to_all.paginate(page: params[:page])
-      end
+      @works = if logged_in? # current_user.is_a?User
+                 @tag.works.visible_to_registered_user.paginate(page: params[:page])
+               elsif logged_in_as_admin?
+                 @tag.works.visible_to_admin.paginate(page: params[:page])
+               else
+                 @tag.works.visible_to_all.paginate(page: params[:page])
+               end
       @bookmarks = @tag.bookmarks.visible.paginate(page: params[:page])
     end
     # cache the children, since it's a possibly massive query

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -60,11 +60,11 @@ class TagsController < ApplicationController
     @page_subtitle = @tag.name
     if @tag.is_a?(Banned) 
       if !logged_in_as_admin?
-      flash[:error] = ts('Please log in as admin')
-      redirect_to(tag_wranglings_path) && return
+        flash[:error] = ts('Please log in as admin')
+        redirect_to(tag_wranglings_path) && return
       elsif !policy(:wrangling).read_access?
-      flash[:error] = ts('Sorry, only an authorized admin can access the page you were trying to reach.')
-      redirect_to(root_path) && return
+        flash[:error] = ts('Sorry, only an authorized admin can access the page you were trying to reach.')
+        redirect_to(root_path) && return
       end
     end
     # if tag is NOT wrangled, prepare to show works and bookmarks that are using it

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -58,14 +58,9 @@ class TagsController < ApplicationController
 
   def show
     @page_subtitle = @tag.name
-    if @tag.is_a?(Banned) 
-      if !logged_in_as_admin?
-        flash[:error] = t("admin.access.not_admin_denied")
-        redirect_to(tag_wranglings_path) && return
-      elsif !policy(:wrangling).read_access?
-        flash[:error] = t("admin.access.page_access_denied")
-        redirect_to(root_path) && return
-      end
+    if @tag.is_a?(Banned) && !logged_in_as_admin?
+      flash[:error] = t("admin.access.not_admin_denied")
+      redirect_to(tag_wranglings_path) && return
     end
     # if tag is NOT wrangled, prepare to show works and bookmarks that are using it
     if !@tag.canonical && !@tag.merger

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -56,25 +56,23 @@ class TagsController < ApplicationController
     flash_search_warnings(@tags)
   end
 
-  # if user is admin with view access or Tag Wrangler, show them details about the tag
-  # if user is not logged in or a regular user, show them
-  #   1. the works, if the tag had been wrangled and we can redirect them to works using it or its canonical merger
-  #   2. the tag, the works and the bookmarks using it, if the tag is unwrangled (because we can't redirect them
-  #       to the works controller)
   def show
-    authorize :wrangling, :read_access? if logged_in_as_admin?
-
     @page_subtitle = @tag.name
-    if @tag.is_a?(Banned) && !logged_in_as_admin?
+    if @tag.is_a?(Banned) 
+      if !logged_in_as_admin?
       flash[:error] = ts('Please log in as admin')
       redirect_to(tag_wranglings_path) && return
+      elsif !policy(:wrangling).read_access?
+      flash[:error] = ts('Sorry, only an authorized admin can access the page you were trying to reach.')
+      redirect_to(root_path) && return
+      end
     end
     # if tag is NOT wrangled, prepare to show works and bookmarks that are using it
     if !@tag.canonical && !@tag.merger
       if logged_in? # current_user.is_a?User
         @works = @tag.works.visible_to_registered_user.paginate(page: params[:page])
       elsif logged_in_as_admin?
-        @works = @tag.works.visible_to_owner.paginate(page: params[:page])
+        @works = @tag.works.visible_to_admin.paginate(page: params[:page])
       else
         @works = @tag.works.visible_to_all.paginate(page: params[:page])
       end

--- a/app/helpers/tags_helper.rb
+++ b/app/helpers/tags_helper.rb
@@ -99,7 +99,7 @@ module TagsHelper
 
   # Should the current user be able to access tag wrangling pages?
   def can_wrangle?
-    logged_in_as_admin? || (current_user.is_a?(User) && current_user.is_tag_wrangler?)
+    policy(:wrangling).read_access? || (current_user.is_a?(User) && current_user.is_tag_wrangler?)
   end
 
   # Determines whether or not to display warnings for a creation

--- a/app/helpers/tags_helper.rb
+++ b/app/helpers/tags_helper.rb
@@ -99,7 +99,7 @@ module TagsHelper
 
   # Should the current user be able to access tag wrangling pages?
   def can_wrangle?
-    policy(:wrangling).read_access? || (current_user.is_a?(User) && current_user.is_tag_wrangler?)
+    logged_in_as_admin? || (current_user.is_a?(User) && current_user.is_tag_wrangler?)
   end
 
   # Determines whether or not to display warnings for a creation

--- a/config/locales/controllers/en.yml
+++ b/config/locales/controllers/en.yml
@@ -3,6 +3,7 @@ en:
   admin:
     access:
       action_access_denied: Sorry, only an authorized admin can do that.
+      not_admin_denied: Please log in as admin
       page_access_denied: Sorry, only an authorized admin can access the page you were trying to reach.
     admin_invitations:
       find:

--- a/spec/controllers/tags_controller_spec.rb
+++ b/spec/controllers/tags_controller_spec.rb
@@ -321,7 +321,11 @@ describe TagsController do
         expect(response).to have_http_status(:success)
       end
 
-      it_behaves_like "an action only authorized admins can access", authorized_roles: wrangling_read_access_roles
+      it "displays the tag information page for admins" do
+        fake_login_admin(create(:admin))
+        subject
+        success
+      end
 
       it "redirects with an error when not an admin" do
         get :show, params: { id: tag.name }

--- a/spec/controllers/tags_controller_spec.rb
+++ b/spec/controllers/tags_controller_spec.rb
@@ -288,10 +288,35 @@ describe TagsController do
   end
 
   describe "show" do   
+    context "displays the tag information page" do
+      let(:tag) { create(:tag) }
+      
+      subject { get :show, params: { id: tag.name } }
+      let(:success) do
+        expect(response).to have_http_status(:success)
+      end
+
+      it "for guests" do
+        subject
+        success
+      end
+
+      it "for users" do
+        fake_login
+        subject
+        success
+      end
+      
+      it "for admins" do
+        fake_login_admin(create(:admin))
+        subject
+        success
+      end
+    end
     context "when showing a banned tag" do
       let(:tag) { create(:banned) } 
 
-      subject { get :edit, params: { id: tag.name } }
+      subject { get :show, params: { id: tag.name } }
       let(:success) do
         expect(response).to have_http_status(:success)
       end


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6859

## Purpose

Only check auth if the tag is banned, so non-wrangler admin roles can view normal tags.
Drop comment that doesn't describe the action anymore.
Tweak check so wrangler tools are fully hidden for non-wrangler admins.
Fix test that was calling the wrong (?) action.

I'm not fully certain why the auth check was added to #show, so I'm assuming that it was meant to only apply to Banned tags.

## Credit

Jake Faulkner