### PR TITLE
AO3-5843 change Invite Requests browser page title to Invitation Requests

### DIFF
--- a/app/controllers/invite_requests_controller.rb
+++ b/app/controllers/invite_requests_controller.rb
@@ -2,8 +2,10 @@ class InviteRequestsController < ApplicationController
   before_action :admin_only, only: [:manage, :destroy]
 
   # GET /invite_requests
+  # Set Browser Page Title to Invitation Requests | Archive Of Our Own
   def index
     @invite_request = InviteRequest.new
+    @page_title = ts("Invitation Requests | Archive Of Our Own")
   end
 
   # GET /invite_requests/1

--- a/app/controllers/invite_requests_controller.rb
+++ b/app/controllers/invite_requests_controller.rb
@@ -5,7 +5,7 @@ class InviteRequestsController < ApplicationController
   # Set Browser Page Title to Invitation Requests | Archive Of Our Own
   def index
     @invite_request = InviteRequest.new
-    @page_title = ts("Invitation Requests | Archive Of Our Own")
+    @page_title = t(".browser_page_title")
   end
 
   # GET /invite_requests/1

--- a/app/controllers/invite_requests_controller.rb
+++ b/app/controllers/invite_requests_controller.rb
@@ -2,10 +2,10 @@ class InviteRequestsController < ApplicationController
   before_action :admin_only, only: [:manage, :destroy]
 
   # GET /invite_requests
-  # Set Browser Page Title to Invitation Requests | Archive Of Our Own
+  # Set browser page title to Invitation Requests
   def index
     @invite_request = InviteRequest.new
-    @page_title = t(".browser_page_title")
+    @page_subtitle = t(".page_title")
   end
 
   # GET /invite_requests/1

--- a/config/locales/controllers/en.yml
+++ b/config/locales/controllers/en.yml
@@ -102,7 +102,8 @@ en:
     tos_faq:
       page_title: Terms of Service FAQ
   invite_requests:
-    browser_page_title: Invitation Requests | Archive Of Our Own
+    index:
+      browser_page_title: Invitation Requests | Archive Of Our Own
   kudos:
     create:
       success: Thank you for leaving kudos!

--- a/config/locales/controllers/en.yml
+++ b/config/locales/controllers/en.yml
@@ -101,6 +101,8 @@ en:
       page_title: Terms of Service
     tos_faq:
       page_title: Terms of Service FAQ
+  invite_requests:
+    browser_page_title: Invitation Requests | Archive Of Our Own
   kudos:
     create:
       success: Thank you for leaving kudos!

--- a/config/locales/controllers/en.yml
+++ b/config/locales/controllers/en.yml
@@ -103,7 +103,7 @@ en:
       page_title: Terms of Service FAQ
   invite_requests:
     index:
-      browser_page_title: Invitation Requests | Archive Of Our Own
+      page_title: Invitation Requests
   kudos:
     create:
       success: Thank you for leaving kudos!


### PR DESCRIPTION
… Requests

# Pull Request Checklist

* [x] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [ ] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [x] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [x] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-5843 

## Purpose

This changes and updates the browser page title from Invite Requests to Invitation Requests on the Invitation Requests page.

## Testing Instructions

How can the Archive's QA team verify that this is working as you intended?

If "Invitation Requests" page is rendered, browser title page should display "Invitation Requests | Archive Of Our Own" instead of "Invite Requests | Archive Of Our Own". 

If you have a Jira account with access, please update or comment on the issue
with any new or missing testing instructions instead.

## References

Are there other relevant issues/pull requests/mailing list discussions?

## Credit

What name and pronouns should we use to credit you in the [Archive of Our Own's Release Notes](https://archiveofourown.org/admin_posts?tag=1)?

Jeslyn See (she/her)

If you have a Jira account, please include the same name in the "Full name"
field on your Jira profile, so we can assign you the issues you're working on.

*Please note that if you do not fill in this section, we will use your GitHub account name and
they/them pronouns.*

