### PR TITLE
AO3-5578 Use rails_blob_url to allow ActiveStorage caching

### DIFF
--- a/app/helpers/collections_helper.rb
+++ b/app/helpers/collections_helper.rb
@@ -128,7 +128,7 @@ module CollectionsHelper
   def standard_icon_url(collection)
     return "/images/skins/iconsets/default/icon_collection.png" unless collection.icon.attached?
 
-    collection.icon.variant(:standard).processed.url
+    rails_blob_url(collection.icon.variant(:standard))
   end
 
   # Wraps the collection's standard_icon_url in an image tag

--- a/app/helpers/skins_helper.rb
+++ b/app/helpers/skins_helper.rb
@@ -11,11 +11,11 @@ module SkinsHelper
   def skin_preview_display(skin)
     return unless skin&.icon&.attached?
 
-    link_to image_tag(skin.icon.variant(:standard).processed.url,
+    link_to image_tag(rails_blob_url(skin.icon.variant(:standard)),
                       alt: skin.icon_alt_text,
                       class: "icon",
                       skip_pipeline: true),
-            skin.icon.url
+            rails_blob_url(skin.icon)
   end
 
   # Fetches the current skin. This is determined by the following

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -24,7 +24,7 @@ module UsersHelper
   def standard_icon(pseud = nil)
     return "/images/skins/iconsets/default/icon_user.png" unless pseud&.icon&.attached?
 
-    pseud.icon.variant(:standard).processed.url
+    rails_blob_url(pseud.icon.variant(:standard))
   end
 
   # no alt text if there isn't specific alt text


### PR DESCRIPTION
# Pull Request Checklist

## Issue

https://otwarchive.atlassian.net/browse/AO3-5578

## Purpose

Update the manual calls to `(.processed).url` to use the Rails URL helper instead. This will set a URL that CloudFlare can proxy, versus the current direct link to S3.