### PR TITLE
AO3-5596 Make boxes on All Fandoms page clear properly

### DIFF
--- a/public/stylesheets/site/2.0/18-zone-searchbrowse.css
+++ b/public/stylesheets/site/2.0/18-zone-searchbrowse.css
@@ -18,6 +18,10 @@ Arguably filter and search could be styled in interactions but I've put them her
   min-height: 17.5em;
 }
 
+.media-index .listbox:nth-of-type(odd) {
+  clear: left;
+}
+
 /* INTERACTION: SEARCH */
 
 form.search input[type="text"] {


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [x] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [x] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [x] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-5596

## Purpose

Makes fandom boxes in All Fandoms have no big gaps when they're displayed in two columns and have unequal height

## Testing Instructions

1. Open the All Fandoms page
2. The browser window width needs to be such that the fandoms are displayed in two columns and a box on the left needs to be taller than the box to its right, you might need to resize the window to achieve that. (For reference, for me this happens with all window widths between 880-1572px right now, but it might vary based on fandom sizes/fonts/etc)
3. There should not be a big empty space below the left box

## References

n/a

## Credit

slavalamp (they/them)
