### PR TITLE
AO3-6873 Upgrade Elasticsearch for dev and automated tests

### DIFF
--- a/.github/workflows/automated-tests.yml
+++ b/.github/workflows/automated-tests.yml
@@ -34,7 +34,7 @@ jobs:
           - 3306:3306
 
       elasticsearch:
-        image: docker.elastic.co/elasticsearch/elasticsearch:7.17.5
+        image: docker.elastic.co/elasticsearch/elasticsearch:7.17.26
         ports:
           - 9200:9200
         options: >-

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,7 +46,7 @@ services:
     volumes:
       - redis-data:/var/lib/redis:rw
   es:
-    image: docker.elastic.co/elasticsearch/elasticsearch:7.17.5
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.17.26
     ports:
       - "9200:9200"
       - "9300:9300"


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6873

## Purpose

Upgrade Elasticsearch for dev and automated tests so that I can use Linux Kernel version 6.12

## Testing Instructions

Automated tests should pass.

## Credit

Bilka