### PR TITLE
AO3-6872 Only notify creators when a work is added to a collection by an archivist

### DIFF
--- a/app/models/collection_item.rb
+++ b/app/models/collection_item.rb
@@ -101,7 +101,7 @@ class CollectionItem < ApplicationRecord
   # Sends emails to item creator(s) in the case that an archivist
   # has added them to the collection.
   def notify_archivist_added
-    return unless User.current_user&.archivist && collection.user_is_maintainer?(User.current_user)
+    return unless item.is_a?(Work) && User.current_user&.archivist && collection.user_is_maintainer?(User.current_user)
 
     item.users.each do |email_recipient|
       next if email_recipient.preference.collection_emails_off

--- a/features/bookmarks/bookmark_create.feature
+++ b/features/bookmarks/bookmark_create.feature
@@ -448,3 +448,13 @@ Scenario: A bookmark with duplicate tags other than capitalization has only firs
       And I fill in "Relationships" with "Relationship 1, Relationship 2"
       And I press "Create"
     Then I should see "Fandom, relationship, and character tags must not add up to more than 5. You have entered 6 of these tags, so you must remove 1 of them."
+
+  Scenario: Bookmark can be added to collection by Archivist without error (Issue 6872)
+    Given I have an archivist "archivist"
+      And I am logged in as "archivist"
+      And I create the collection "My Collection" with name "MyCollection"
+    When I open a bookmarkable work
+      And I follow "Bookmark"
+      And I fill in "bookmark_collection_names" with "MyCollection"
+      And I press "Create"
+    Then I should see "Bookmark was successfully created"

--- a/features/bookmarks/bookmark_create.feature
+++ b/features/bookmarks/bookmark_create.feature
@@ -449,7 +449,7 @@ Scenario: A bookmark with duplicate tags other than capitalization has only firs
       And I press "Create"
     Then I should see "Fandom, relationship, and character tags must not add up to more than 5. You have entered 6 of these tags, so you must remove 1 of them."
 
-  Scenario: Bookmark can be added to collection by Archivist without error (Issue 6872)
+  Scenario: Archivists can add bookmarks to collections
     Given I have an archivist "archivist"
       And I am logged in as "archivist"
       And I create the collection "My Collection" with name "MyCollection"

--- a/features/collections/collection_notification.feature
+++ b/features/collections/collection_notification.feature
@@ -47,18 +47,6 @@ Feature: Collectible items email
     And I should see "Antarctic Penguins"
     And 1 email should be delivered to test2@archiveofourown.org
 
-  Scenario: Work added to collection by Archivist sends notification email
-    Given I have a work "cool work"
-      And I have an archivist "archivist"
-      And all emails have been delivered
-    When I am logged in as "archivist"
-      And I create the collection "Cold Collection" with name "ColdCollection"
-      And I view the work "cool work"
-      And I follow "Add to Collections"
-      And I fill in "collection_names" with "ColdCollection"
-      And I press "Add"
-    Then 1 email should be delivered
-
   Scenario: Bookmark added to collection sends notification email
     Given all email have been delivered
     When I have the collection "Dont Bookmark Me Bro" with name "dont_bookmark_me_bro"

--- a/features/collections/collection_notification.feature
+++ b/features/collections/collection_notification.feature
@@ -47,6 +47,18 @@ Feature: Collectible items email
     And I should see "Antarctic Penguins"
     And 1 email should be delivered to test2@archiveofourown.org
 
+  Scenario: Work added to collection by Archivist sends notification email
+    Given I have a work "cool work"
+      And I have an archivist "archivist"
+      And all emails have been delivered
+    When I am logged in as "archivist"
+      And I create the collection "Cold Collection" with name "ColdCollection"
+      And I view the work "cool work"
+      And I follow "Add to Collections"
+      And I fill in "collection_names" with "ColdCollection"
+      And I press "Add"
+    Then 1 email should be delivered
+
   Scenario: Bookmark added to collection sends notification email
     Given all email have been delivered
     When I have the collection "Dont Bookmark Me Bro" with name "dont_bookmark_me_bro"


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [x] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [x] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [x] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-6872

## Purpose

Skips the attempt to notify creators when an archivist adds a non-work (a bookmark) to a collection.
Also adds a test to verify that a notification is still sent when a work is added to a collection by an archivist.

## Testing Instructions

See instructions on the Jira issue.

## References

N/A

## Credit

marcus8448 (he/him)