### PR TITLE
AO3-6737 Fix display of recent bookmarks module

### DIFF
--- a/public/stylesheets/masters/low_vision_default/low_vision_default_site_screen_.css
+++ b/public/stylesheets/masters/low_vision_default/low_vision_default_site_screen_.css
@@ -37,7 +37,8 @@ form blockquote.userstuff {
 #inner .filters,
 #footer,
 .filters dt,
-media .listbox {
+media .listbox,
+.bookmark .recent .index {
   width: 100%;
 }
 
@@ -163,4 +164,9 @@ pre {
 #header .dropdown .menu a:focus {
   background: #ccc;
   color: #111;
+}
+
+.bookmark .recent,
+.bookmark .recent .index {
+  border: none;
 }

--- a/public/stylesheets/site/2.0/13-group-blurb.css
+++ b/public/stylesheets/site/2.0/13-group-blurb.css
@@ -331,7 +331,7 @@ blurbs on the manage collection items pages, mostly reseting styles inherited fr
 	top: 28px;
 }
 
-.bookmark div.user {
+.bookmark div.user, .bookmark div.recent {
   clear: right;
   box-sizing: border-box;
 }
@@ -395,6 +395,11 @@ blurbs on the manage collection items pages, mostly reseting styles inherited fr
 
 .bookmark .dynamic {
 	position: static;
+}
+
+.bookmark .recent .index {
+  float: none;
+  width: 100%;
 }
 
 /* mod: READING */


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6737

## Purpose

I told james_ to remove some styles in #4808 ([AO3-6725](https://otwarchive.atlassian.net/browse/AO3-6725)) and I was wrong; when we removed them, the recent bookmarks on tag bookmark listings got too narrow and (in Low Vision Default) acquired all sorts of silly borders.

This puts that area back to the way it was.

## Testing Instructions

Refer to Jira.

## References

#4808 // [This comment ft. me being wrong](https://github.com/otwcode/otwarchive/pull/4808#issuecomment-2111323863)
#4825
#4846
[AO3-6725](https://otwarchive.atlassian.net/browse/AO3-6725)

## Credit

Sarken, she/her


[AO3-6725]: https://otwarchive.atlassian.net/browse/AO3-6725?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AO3-6725]: https://otwarchive.atlassian.net/browse/AO3-6725?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ