### PR TITLE
AO3-6848 Create unique tags for mailer preview

### DIFF
--- a/factories/tags.rb
+++ b/factories/tags.rb
@@ -71,6 +71,11 @@ FactoryBot.define do
   factory :fandom do
     sequence(:name) { |n| "The #{n} Fandom" }
 
+    # Tags names used in mailer preview should be unique but recognizable as tag names
+    trait :for_mailer_preview do
+      name { "Fandom#{Faker::Alphanumeric.alpha(number: 8)}" }
+    end
+
     factory :canonical_fandom do
       canonical { true }
     end
@@ -78,6 +83,11 @@ FactoryBot.define do
 
   factory :character do
     sequence(:name) { |n| "Character #{n}" }
+
+    # Tags names used in mailer preview should be unique but recognizable as tag names
+    trait :for_mailer_preview do
+      name { "Character#{Faker::Alphanumeric.alpha(number: 8)}" }
+    end
 
     factory :canonical_character do
       canonical { true }
@@ -87,6 +97,11 @@ FactoryBot.define do
   factory :relationship do
     sequence(:name) { |n| "Jane#{n}/John#{n}" }
 
+    # Tags names used in mailer preview should be unique but recognizable as tag names
+    trait :for_mailer_preview do
+      name { "Relationship#{Faker::Alphanumeric.alpha(number: 8)}" }
+    end
+
     factory :canonical_relationship do
       canonical { true }
     end
@@ -94,6 +109,11 @@ FactoryBot.define do
 
   factory :freeform do
     sequence(:name) { |n| "Freeform #{n}" }
+
+    # Tags names used in mailer preview should be unique but recognizable as tag names
+    trait :for_mailer_preview do
+      name { "Freeform#{Faker::Alphanumeric.alpha(number: 8)}" }
+    end
 
     factory :canonical_freeform do
       canonical { true }

--- a/test/mailers/previews/user_mailer_preview.rb
+++ b/test/mailers/previews/user_mailer_preview.rb
@@ -79,7 +79,7 @@ class UserMailerPreview < ApplicationMailerPreview
     tag_set.rating_tagnames = [ArchiveConfig.RATING_EXPLICIT_TAG_NAME, ArchiveConfig.RATING_MATURE_TAG_NAME, ArchiveConfig.RATING_TEEN_TAG_NAME].join(ArchiveConfig.DELIMITER_FOR_OUTPUT)
     tag_set.category_tagnames = [ArchiveConfig.CATEGORY_GEN_TAG_NAME, ArchiveConfig.CATEGORY_HET_TAG_NAME, ArchiveConfig.CATEGORY_SLASH_TAG_NAME].join(ArchiveConfig.DELIMITER_FOR_OUTPUT)
     %w[fandom character relationship freeform].each do |type|
-      tag_set.tags += [create(:"canonical_#{type}"), create(:"canonical_#{type}"), create(:"canonical_#{type}")]
+      tag_set.tags += [create(:"canonical_#{type}",  :for_mailer_preview), create(:"canonical_#{type}",  :for_mailer_preview), create(:"canonical_#{type}",  :for_mailer_preview)]
     end
     tag_set.save!
 
@@ -87,7 +87,7 @@ class UserMailerPreview < ApplicationMailerPreview
     prompt.tag_set = tag_set
     prompt.title = "This is a title"
     prompt.url = "https://example.com/"
-    prompt.optional_tag_set = create(:tag_set, tags: [create(:freeform), create(:freeform), create(:freeform)])
+    prompt.optional_tag_set = create(:tag_set, tags: [create(:freeform,  :for_mailer_preview), create(:freeform,  :for_mailer_preview), create(:freeform, :for_mailer_preview)])
     prompt.save!
 
     UserMailer.challenge_assignment_notification(assignment.collection.id, assignment.offering_user.id, assignment.id)

--- a/test/mailers/previews/user_mailer_preview.rb
+++ b/test/mailers/previews/user_mailer_preview.rb
@@ -79,7 +79,7 @@ class UserMailerPreview < ApplicationMailerPreview
     tag_set.rating_tagnames = [ArchiveConfig.RATING_EXPLICIT_TAG_NAME, ArchiveConfig.RATING_MATURE_TAG_NAME, ArchiveConfig.RATING_TEEN_TAG_NAME].join(ArchiveConfig.DELIMITER_FOR_OUTPUT)
     tag_set.category_tagnames = [ArchiveConfig.CATEGORY_GEN_TAG_NAME, ArchiveConfig.CATEGORY_HET_TAG_NAME, ArchiveConfig.CATEGORY_SLASH_TAG_NAME].join(ArchiveConfig.DELIMITER_FOR_OUTPUT)
     %w[fandom character relationship freeform].each do |type|
-      tag_set.tags += [create(:"canonical_#{type}",  :for_mailer_preview), create(:"canonical_#{type}",  :for_mailer_preview), create(:"canonical_#{type}",  :for_mailer_preview)]
+      tag_set.tags += [create(:"canonical_#{type}", :for_mailer_preview), create(:"canonical_#{type}", :for_mailer_preview), create(:"canonical_#{type}", :for_mailer_preview)]
     end
     tag_set.save!
 
@@ -87,7 +87,7 @@ class UserMailerPreview < ApplicationMailerPreview
     prompt.tag_set = tag_set
     prompt.title = "This is a title"
     prompt.url = "https://example.com/"
-    prompt.optional_tag_set = create(:tag_set, tags: [create(:freeform,  :for_mailer_preview), create(:freeform,  :for_mailer_preview), create(:freeform, :for_mailer_preview)])
+    prompt.optional_tag_set = create(:tag_set, tags: [create(:freeform, :for_mailer_preview), create(:freeform, :for_mailer_preview), create(:freeform, :for_mailer_preview)])
     prompt.save!
 
     UserMailer.challenge_assignment_notification(assignment.collection.id, assignment.offering_user.id, assignment.id)


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6848

## Purpose

Solves that the first few visits of https://test.archiveofourown.org/rails/mailers/user_mailer/user_mailer/challenge_assignment_notification_filled would result in an error 422 because the preview would try to create tags that already exist in the archive by generating more unique tag names.

## Testing Instructions

Step 3 and 4 from the original issue.

## Credit

Bilka