### PR TITLE
AO3-6888 Better align tags and stats in work meta

### DIFF
--- a/public/stylesheets/site/2.0/12-group-meta.css
+++ b/public/stylesheets/site/2.0/12-group-meta.css
@@ -29,14 +29,14 @@ dl.meta {
 }
 
 .meta .stats dl dd, .meta .stats dl dt {
-  margin: 0 0.375em auto 0;
+  margin: 0 0.625em auto 0;
   width: auto;
   min-width: 0;
   clear: none;
   float: left;
 }
 
-.meta .stats dl, .meta .stats dl dt:first-child, dl.meta dd ul li:first-child {
+.meta .stats dl, .meta .stats dl dd, .meta .stats dl dt, dl.meta dd ul li {
   padding-left: 0;
 }
 
@@ -48,6 +48,7 @@ dl.meta {
 .meta dd ul li {
   display: inline;
   margin: auto;
+  padding-right: 0.5em;
 }
 
 .meta dd blockquote {

--- a/public/stylesheets/site/2.0/12-group-meta.css
+++ b/public/stylesheets/site/2.0/12-group-meta.css
@@ -29,7 +29,9 @@ dl.meta {
 }
 
 .meta .stats dl dd, .meta .stats dl dt {
-  margin: 0 0.625em auto 0;
+  margin-block: 0 auto;
+  /* the 0.375em margin previously used here + 0.25em padding-left from .stats>* that is zeroed out in the ruleset below */
+  margin-inline: 0 0.625em;
   width: auto;
   min-width: 0;
   clear: none;
@@ -37,7 +39,7 @@ dl.meta {
 }
 
 .meta .stats dl, .meta .stats dl dd, .meta .stats dl dt, dl.meta dd ul li {
-  padding-left: 0;
+  padding-inline-start: 0;
 }
 
 .meta p {
@@ -48,7 +50,7 @@ dl.meta {
 .meta dd ul li {
   display: inline;
   margin: auto;
-  padding-right: 0.5em;
+  padding-inline-end: 0.5em;
 }
 
 .meta dd blockquote {

--- a/public/stylesheets/site/2.0/12-group-meta.css
+++ b/public/stylesheets/site/2.0/12-group-meta.css
@@ -28,7 +28,11 @@ dl.meta {
   margin-top: 0;
 }
 
-.meta .stats dl dd, .meta .stats dl dt {
+dl.meta dd ul li, .meta .stats dl, .meta .stats dl dt, .meta .stats dl dd {
+  padding-inline-start: 0;
+}
+
+.meta .stats dl dt, .meta .stats dl dd {
   margin-block: 0 auto;
   margin-inline: 0 0.375em;
   padding-inline-end: 0.25em;
@@ -38,8 +42,8 @@ dl.meta {
   float: left;
 }
 
-.meta .stats dl, .meta .stats dl dd, .meta .stats dl dt, dl.meta dd ul li {
-  padding-inline-start: 0;
+.meta .stats dl dd {
+  padding-inline-end: 0.75em;
 }
 
 .meta p {

--- a/public/stylesheets/site/2.0/12-group-meta.css
+++ b/public/stylesheets/site/2.0/12-group-meta.css
@@ -30,8 +30,8 @@ dl.meta {
 
 .meta .stats dl dd, .meta .stats dl dt {
   margin-block: 0 auto;
-  /* the 0.375em margin previously used here + 0.25em padding-left from .stats>* that is zeroed out in the ruleset below */
-  margin-inline: 0 0.625em;
+  margin-inline: 0 0.375em;
+  padding-inline-end: 0.25em;
   width: auto;
   min-width: 0;
   clear: none;


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6888

## Purpose

Fixes the alignment of tags and stats in work meta when the lines wrap.

I used `margin-block`, `margin-inline`, `padding-block`, and `padding-inline` because there's a slight improvement when
- a containing element (such as the `dd` or `ul`) has `dir="rtl"` applied, and
- the list of tags includes both English and a RTL language

The improvement? The comma was on the left of the English tag (i.e., it obeyed the direction rules of the container) instead of the right.

We won't ever actually encounter that scenario with the current code, but hey, let's do it anyway.

## Testing Instructions

Refer to Jira.

## References

#1919 and #1930 

## Credit

 Sarken, she/her