### PR TITLE
AO3-6889 Add rack-timeout gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -110,8 +110,7 @@ gem "marcel", "1.0.2"
 # Library for helping run pt-online-schema-change commands:
 gem "departure", "~> 6.5"
 
-# Ruby 3.1 means we need to specify a version of mail until we get to rails 7.x
-gem "mail", ">= 2.8"
+gem "rack-timeout"
 
 group :test do
   gem "rspec-rails", "~> 6.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -437,6 +437,7 @@ GEM
       rack (~> 2.2, >= 2.2.4)
     rack-test (2.2.0)
       rack (>= 1.3)
+    rack-timeout (0.7.0)
     rails (7.0.8.7)
       actioncable (= 7.0.8.7)
       actionmailbox (= 7.0.8.7)
@@ -687,7 +688,6 @@ DEPENDENCIES
   kgio (= 2.10.0)
   launchy
   lograge
-  mail (>= 2.8)
   marcel (= 1.0.2)
   mechanize
   minitest
@@ -703,6 +703,7 @@ DEPENDENCIES
   rack (~> 2.2)
   rack-attack
   rack-dev-mark (>= 0.7.8)
+  rack-timeout
   rails (~> 7.0.8)
   rails-controller-testing
   rails-i18n


### PR DESCRIPTION
# Pull Request Checklist

* [X] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [X] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [X] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [X] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [X] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-6889

## Purpose

Add the rack-timeout gem so we can cut off long-running requests that are causing performance issues

## References

Caveats: https://github.com/zombocom/rack-timeout/blob/main/doc/risks.md

We should also be aware that this can negatively impact downloads. Those can already be a bit iffy performance-wise, and I've noticed longer works can be in the minutes range to complete requests. Perhaps we _want_ to cut those off earlier though 🤔 