### PR TITLE
AO3-6890 Remove unusable config

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -746,8 +746,3 @@ PERCONA_ARGS: >
 # Production has more than 5 for these
 BOOKMARKABLE_SHARDS: 5
 WORKS_SHARDS: 5
-
-# Puma killer config (automatically restart Puma when resource constrained);
-# both are measured in seconds.
-PUMA_ROLLING_RESTART_FREQUENCY: 172800 # 2 days
-PUMA_ROLLING_RESTART_SPLAY: 702


### PR DESCRIPTION
With my Systems hat on, I saw that we can't actually use these in `conf/puma.rb`. So no point in keeping them here and causing confusion.