### PR TITLE
AO3-6820 Update error message to "Pseud can't be blank"

### DIFF
--- a/config/locales/models/en.yml
+++ b/config/locales/models/en.yml
@@ -84,6 +84,10 @@ en:
             blocked_id:
               taken: You have already blocked that user.
           format: "%{message}"
+        bookmark:
+          attributes:
+            pseud:
+              required: can't be blank
         comment:
           attributes:
             commentable:

--- a/spec/models/bookmark_spec.rb
+++ b/spec/models/bookmark_spec.rb
@@ -18,6 +18,6 @@ describe Bookmark do
   it "is invalid without a pseud_id" do
     bookmark = build(:bookmark, pseud_id: nil)
     expect(bookmark).to_not be_valid
-    expect(bookmark.errors[:pseud].first).to include("must exist")
+    expect(bookmark.errors[:pseud].first).to eq("can't be blank")
   end
 end


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6820

## Purpose

Change the error message from "Pseud must exist" to "Pseud can't be blank".

## Testing Instructions

Refer to Jira.

## References

https://otwarchive.atlassian.net/browse/AO3-6820?focusedCommentId=362235


## Credit

Bilka
