### PR TITLE
AO3-6901 Use ActiveJob for asynchronous indexing

### DIFF
--- a/app/jobs/async_indexer_job.rb
+++ b/app/jobs/async_indexer_job.rb
@@ -1,0 +1,15 @@
+# A job to index the record IDs queued up by AsyncIndexer.
+class AsyncIndexerJob < ApplicationJob
+  REDIS = AsyncIndexer::REDIS
+
+  def perform(name)
+    indexer = name.split(":").first.constantize
+    ids = REDIS.smembers(name)
+
+    return if ids.empty?
+
+    batch = indexer.new(ids).index_documents
+    IndexSweeper.new(batch, indexer).process_batch
+    REDIS.del(name)
+  end
+end

--- a/app/models/search/async_indexer.rb
+++ b/app/models/search/async_indexer.rb
@@ -9,7 +9,7 @@ class AsyncIndexer
     # TODO: Keep the method so we can still run queued jobs from previous
     # versions. However, tests should no longer depend on it.
     #
-    # Remove in a future versions, once all old jobs have been retried or
+    # Remove in a future version, once all old jobs have been retried or
     # cleared.
     raise "Avoid using AsyncIndexer.perform in tests" if Rails.env.test?
 

--- a/app/models/search/async_indexer.rb
+++ b/app/models/search/async_indexer.rb
@@ -1,5 +1,4 @@
 class AsyncIndexer
-
   REDIS = REDIS_GENERAL
 
   ####################
@@ -7,6 +6,13 @@ class AsyncIndexer
   ####################
 
   def self.perform(name)
+    # TODO: Keep the method so we can still run queued jobs from previous
+    # versions. However, tests should no longer depend on it.
+    #
+    # Remove in a future versions, once all old jobs have been retried or
+    # cleared.
+    raise "Avoid using AsyncIndexer.perform in tests" if Rails.env.test?
+
     indexer = name.split(":").first.constantize
     ids = REDIS.smembers(name)
 
@@ -41,10 +47,10 @@ class AsyncIndexer
   def initialize(indexer, priority)
     @indexer = indexer
     @priority = case priority.to_s
-                when 'main'
-                  'high'
-                when 'background'
-                  'low'
+                when "main"
+                  "high"
+                when "background"
+                  "low"
                 else
                   priority
                 end
@@ -53,11 +59,10 @@ class AsyncIndexer
   def enqueue_ids(ids)
     name = "#{indexer}:#{ids.first}:#{Time.now.to_i}"
     REDIS.sadd(name, ids)
-    Resque::Job.create(queue, self.class, name)
+    AsyncIndexerJob.set(queue: queue).perform_later(name)
   end
 
   def queue
     "reindex_#{priority}"
   end
-
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -61,10 +61,6 @@ Rails.application.configure do
   # Use a different cache store in production.
   # config.cache_store = :mem_cache_store
 
-  # Use a real queuing backend for Active Job (and separate queues per environment).
-  # config.active_job.queue_adapter     = :resque
-  # config.active_job.queue_name_prefix = "otwarchive_production"
-
   config.action_mailer.perform_caching = false
 
   # Ignore bad email addresses and do not raise email delivery errors.

--- a/spec/lib/tasks/notifications.rake_spec.rb
+++ b/spec/lib/tasks/notifications.rake_spec.rb
@@ -1,13 +1,14 @@
 require "spec_helper"
 
 describe "rake notifications:send_tos_update" do
+  include ActiveJob::TestHelper
+
   let(:admin_post) { create(:admin_post) }
 
   context "with one user" do
     let!(:user) { create(:user) }
 
     it "enqueues one tos update notifications" do
-      ActiveJob::Base.queue_adapter = :test
       expect(User.all.size).to eq(1)
       expect { subject.invoke(admin_post.id) }
         .to have_enqueued_mail(TosUpdateMailer, :tos_update_notification).on_queue(:tos_update).with(user, admin_post.id)
@@ -18,7 +19,6 @@ describe "rake notifications:send_tos_update" do
     before { create_list(:user, 10) }
 
     it "enqueues multiple tos update notifications" do
-      ActiveJob::Base.queue_adapter = :test
       expect(User.all.size).to eq(10)
       expect { subject.invoke(admin_post.id) }
         .to have_enqueued_mail(TosUpdateMailer, :tos_update_notification).on_queue(:tos_update).with(instance_of(User), admin_post.id).exactly(10)

--- a/spec/models/search/index_sweeper_spec.rb
+++ b/spec/models/search/index_sweeper_spec.rb
@@ -127,7 +127,7 @@ describe IndexSweeper do
     expect(AsyncIndexer).to receive(:new).with(StatCounterIndexer, "failures").at_least(:once).and_return(indexer)
     expect(indexer).to receive(:enqueue_ids).with([work.stat_counter.id]).at_least(:once).and_call_original
 
-    expect(sweeper.process_batch).to be(true)
+    sweeper.process_batch
   end
 
   it "doesn't trigger an error if the batch results are empty" do


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6901

## Purpose

Move the asynchronous part of [AsyncIndexer](https://github.com/otwcode/otwarchive/blob/671cdb9273be76984a14957bfe7e44f0c7bfd841/app/models/search/async_indexer.rb#L56) to Active Job.

I thought about setting `config.active_job.queue_adapter = :test` for all of the test environment, but that broke too many things, including all Cucumber tests expecting emails sent with `deliver_later`. On top of that, pre-7.2 Rails does not consistently follow that setting which complicates things (https://github.com/rails/rails/pull/48585). I'm keeping test updates simple for now.

## Testing Instructions

See issue.