### PR TITLE
AO3-6903 Remove extra spaces after colons in mailers

### DIFF
--- a/app/helpers/mailer_helper.rb
+++ b/app/helpers/mailer_helper.rb
@@ -155,7 +155,7 @@ module MailerHelper
     end
   end
 
-  def work_metadata_label(text)
+  def metadata_label(text)
     text.html_safe + t("mailer.general.metadata_label_indicator")
   end
 
@@ -166,10 +166,8 @@ module MailerHelper
     "#{work_tag_metadata_label(tags)}#{work_tag_metadata_list(tags)}"
   end
 
-  # TODO: We're using this for labels in set_password_notification, too. Let's
-  # take the "work" out of the name.
-  def style_work_metadata_label(text)
-    style_bold(work_metadata_label(text))
+  def style_metadata_label(text)
+    style_bold(metadata_label(text))
   end
 
   # Spacing is dealt with in locale files, e.g. " : " for French.

--- a/app/views/admin_mailer/set_password_notification.html.erb
+++ b/app/views/admin_mailer/set_password_notification.html.erb
@@ -1,8 +1,8 @@
 <% content_for :message do %>
   <p><%= t("mailer.general.greeting.informal.addressed_html", name: style_bold(@admin.login)) %></p>
   <p><%= t(".created") %></p>
-  <p><%= style_work_metadata_label(t(".username")) %><%= @admin.login %></p>
-  <p><%= style_work_metadata_label(t(".url")) %><%= style_link(new_admin_session_url, new_admin_session_url) %></p>
+  <p><%= style_metadata_label(t(".username")) %><%= @admin.login %></p>
+  <p><%= style_metadata_label(t(".url")) %><%= style_link(new_admin_session_url, new_admin_session_url) %></p>
   <p><%= t(".finish_html", set_password_link: style_link(t(".set_password"), edit_admin_password_url(reset_password_token: @token))) %></p>
   <p><%= t(".expiration_html", count: ArchiveConfig.DAYS_UNTIL_ADMIN_RESET_PASSWORD_LINK_EXPIRES, request_reset_link: style_link(t(".request_reset"), new_admin_password_url)) %></p>
 <% end %>

--- a/app/views/admin_mailer/set_password_notification.text.erb
+++ b/app/views/admin_mailer/set_password_notification.text.erb
@@ -3,8 +3,8 @@
 
 <%= t(".created") %>
 
-<%= work_metadata_label(t(".username")) %><%= @admin.login %>
-<%= work_metadata_label(t(".url")) %><%= new_admin_session_url %>
+<%= metadata_label(t(".username")) %><%= @admin.login %>
+<%= metadata_label(t(".url")) %><%= new_admin_session_url %>
 
 <%= t(".finish", set_password_url: edit_admin_password_url(reset_password_token: @token)) %>
 

--- a/app/views/user_mailer/_work_info.html.erb
+++ b/app/views/user_mailer/_work_info.html.erb
@@ -1,6 +1,6 @@
 <% # expects work %>
 <p>
-  <%= style_work_metadata_label(Work.human_attribute_name("chapter_total_display")) %><%= chapter_total_display(work) %>
+  <%= style_metadata_label(Work.human_attribute_name("chapter_total_display")) %><%= chapter_total_display(work) %>
   <br /><%= style_work_tag_metadata(work.tag_groups["Fandom"]) %>
   <br /><%= style_work_tag_metadata(work.tag_groups["Rating"]) %>
   <br /><%= style_work_tag_metadata(work.tag_groups["ArchiveWarning"]) %>
@@ -14,11 +14,11 @@
     <br /><%= style_work_tag_metadata(work.tag_groups["Freeform"]) %>
   <% end %>
   <% unless work.series.count.zero? %>
-    <br /><%= style_work_metadata_label(Series.model_name.human(count: work.series.count)) %><%= series_list_for_feeds(work).html_safe %>
+    <br /><%= style_metadata_label(Series.model_name.human(count: work.series.count)) %><%= series_list_for_feeds(work).html_safe %>
   <% end %>
 </p>
 
 <% unless work.summary.blank? %>
-  <p><%= style_work_metadata_label(Work.human_attribute_name("summary")) %></p>
+  <p><%= style_metadata_label(Work.human_attribute_name("summary")) %></p>
   <%= style_quote(raw sanitize_field(work, :summary)) %>
 <% end %>

--- a/app/views/user_mailer/_work_info.text.erb
+++ b/app/views/user_mailer/_work_info.text.erb
@@ -1,5 +1,5 @@
 <% # expects work %>
-<%= work_metadata_label(Work.human_attribute_name("chapter_total_display"))%><%= chapter_total_display(work) %>
+<%= metadata_label(Work.human_attribute_name("chapter_total_display"))%><%= chapter_total_display(work) %>
 <%= work_tag_metadata(work.tag_groups["Fandom"]) %>
 <%= work_tag_metadata(work.tag_groups["Rating"]) %>
 <%= work_tag_metadata(work.tag_groups["ArchiveWarning"]) %>
@@ -13,10 +13,10 @@
 <%= work_tag_metadata(work.tag_groups["Freeform"]) %>
 <% end %>
 <% unless work.series.count.zero? %>
-<%= work_metadata_label(Series.model_name.human(count: work.series.count)) %><%= raw to_plain_text(series_list_for_feeds(work)) %>
+<%= metadata_label(Series.model_name.human(count: work.series.count)) %><%= raw to_plain_text(series_list_for_feeds(work)) %>
 <% end %>
 <% unless work.summary.blank? %>
 
-<%= work_metadata_label(Work.human_attribute_name("summary")) %>
+<%= metadata_label(Work.human_attribute_name("summary")) %>
     <%= raw to_plain_text(sanitize_field(work, :summary)) %>
 <% end %>

--- a/app/views/user_mailer/abuse_report.html.erb
+++ b/app/views/user_mailer/abuse_report.html.erb
@@ -12,16 +12,14 @@
   <p><%= t(".resubmission") %></p>
 
   <p><%= t(".copy.intro") %></p>
-  
+
   <p>
-    <%= style_work_metadata_label(t(".copy.url")) %>
-    <%= style_link(@url, @url) %>
+    <%= style_work_metadata_label(t(".copy.url")) %><%= style_link(@url, @url) %>
   </p>
 
   <p>
-    <%= style_work_metadata_label(t(".copy.summary")) %>
     <%# TODO: Remove to_plain_text when AO3-6519 is fixed. %>
-    <%= to_plain_text(raw(@summary)) %>
+    <%= style_work_metadata_label(t(".copy.summary")) %><%= to_plain_text(raw(@summary)) %>
   </p>
 
   <p><%= style_work_metadata_label(t(".copy.comment")) %></p>
@@ -30,7 +28,7 @@
   <p><%= t(".thank_you") %></p>
 
   <p>
-    <%= t("mailer.general.closing.formal") %><br/>
+    <%= t("mailer.general.closing.formal") %><br />
     <%= style_bold(t("mailer.general.signature.abuse_team")) %>
   </p>
 <% end %>

--- a/app/views/user_mailer/abuse_report.html.erb
+++ b/app/views/user_mailer/abuse_report.html.erb
@@ -14,15 +14,15 @@
   <p><%= t(".copy.intro") %></p>
 
   <p>
-    <%= style_work_metadata_label(t(".copy.url")) %><%= style_link(@url, @url) %>
+    <%= style_metadata_label(t(".copy.url")) %><%= style_link(@url, @url) %>
   </p>
 
   <p>
     <%# TODO: Remove to_plain_text when AO3-6519 is fixed. %>
-    <%= style_work_metadata_label(t(".copy.summary")) %><%= to_plain_text(raw(@summary)) %>
+    <%= style_metadata_label(t(".copy.summary")) %><%= to_plain_text(raw(@summary)) %>
   </p>
 
-  <p><%= style_work_metadata_label(t(".copy.comment")) %></p>
+  <p><%= style_metadata_label(t(".copy.comment")) %></p>
   <p><%= style_quote(raw(strip_images(@comment, keep_src: true))) %></p>
 
   <p><%= t(".thank_you") %></p>

--- a/app/views/user_mailer/abuse_report.text.erb
+++ b/app/views/user_mailer/abuse_report.text.erb
@@ -13,13 +13,13 @@
 
 <%= text_divider %>
 
-<%= work_metadata_label(t(".copy.url")) %>
+<%= metadata_label(t(".copy.url")) %>
 <%= to_plain_text(@url) %>
 
-<%= work_metadata_label(t(".copy.summary")) %>
+<%= metadata_label(t(".copy.summary")) %>
 <%= to_plain_text(raw @summary) %>
 
-<%= work_metadata_label(t(".copy.comment")) %>
+<%= metadata_label(t(".copy.comment")) %>
 <%= to_plain_text(raw(strip_images(@comment, keep_src: true))) %>
 
 <%= text_divider %>

--- a/app/views/user_mailer/challenge_assignment_notification.html.erb
+++ b/app/views/user_mailer/challenge_assignment_notification.html.erb
@@ -2,7 +2,7 @@
   <p><%= t(".assignment.html", link: style_link(@collection.title, collection_url(@collection))) %></p>
 
   <p>
-    <%= style_bold(t(".recipient")) %> <%= @request.nil? ? t(".recipient_missing") : style_link(@request.pseud.byline, user_pseud_url(@request.pseud.user, @request.pseud)) %>
+    <%= style_work_metadata_label(t(".recipient")) %><%= @request.nil? ? t(".recipient_missing") : style_link(@request.pseud.byline, user_pseud_url(@request.pseud.user, @request.pseud)) %>
   </p>
 
   <%= style_bold(t(".prompts")) %>
@@ -29,52 +29,43 @@
 
     <p>
       <% if fandoms %>
-        <%= style_bold(t("activerecord.models.fandom", count: prompt.any_fandom ? 1 : tag_groups["Fandom"].count) + t("mailer.general.metadata_label_indicator")) %>
-        <%= fandoms %>
+        <%= style_work_metadata_label(t("activerecord.models.fandom", count: prompt.any_fandom ? 1 : tag_groups["Fandom"].count)) %><%= fandoms %>
         <br />
       <% end %>
       <% if chars %>
-        <%= style_bold(t("activerecord.models.character", count: prompt.any_character ? 1 : tag_groups["Character"].count) + t("mailer.general.metadata_label_indicator")) %>
-        <%= chars %>
+        <%= style_work_metadata_label(t("activerecord.models.character", count: prompt.any_character ? 1 : tag_groups["Character"].count)) %><%= chars %>
         <br />
       <% end %>
       <% if ships %>
-        <%= style_bold(t("activerecord.models.relationship", count: prompt.any_relationship ? 1 : tag_groups["Relationship"].count) + t("mailer.general.metadata_label_indicator")) %>
-        <%= ships %>
+        <%= style_work_metadata_label(t("activerecord.models.relationship", count: prompt.any_relationship ? 1 : tag_groups["Relationship"].count)) %><%= ships %>
         <br />
       <% end %>
       <% if ratings %>
-        <%= style_bold(t("activerecord.models.rating", count: 1) + t("mailer.general.metadata_label_indicator")) %>
-        <%= ratings %>
+        <%= style_work_metadata_label(t("activerecord.models.rating", count: prompt.any_rating ? 1 : tag_groups["Rating"].count)) %><%= ratings %>
         <br />
       <% end %>
       <% if warnings %>
-        <%= style_bold(t("activerecord.models.archive_warning", count: prompt.any_archive_warning ? 1 : tag_groups["ArchiveWarning"].count) + t("mailer.general.metadata_label_indicator")) %>
-        <%= warnings %>
+        <%= style_work_metadata_label(t("activerecord.models.archive_warning", count: prompt.any_archive_warning ? 1 : tag_groups["ArchiveWarning"].count)) %><%= warnings %>
         <br />
       <% end %>
       <% if categories %>
-        <%= style_bold(t("activerecord.models.category", count: prompt.any_category ? 1 : tag_groups["Category"].count) + t("mailer.general.metadata_label_indicator")) %>
-        <%= categories %>
+        <%= style_work_metadata_label(t("activerecord.models.category", count: prompt.any_category ? 1 : tag_groups["Category"].count)) %><%= categories %>
         <br />
       <% end %>
       <% if atags %>
-        <%= style_bold(t("activerecord.models.freeform", count: prompt.any_freeform ? 1 : tag_groups["Freeform"].count) + t("mailer.general.metadata_label_indicator")) %>
-        <%= atags %>
+        <%= style_work_metadata_label(t("activerecord.models.freeform", count: prompt.any_freeform ? 1 : tag_groups["Freeform"].count)) %><%= atags %>
         <br />
       <% end %>
       <% if otags %>
-        <%= style_bold(t(".optional_tags")) %>
-        <%= otags %>
+        <%= style_work_metadata_label(t(".optional_tags")) %><%= otags %>
         <br />
       <% end %>
       <% if prompt.url && !prompt.url.blank? %>
-        <%= style_bold(t(".prompt_url")) %>
-        <%= style_link(prompt.url, prompt.url) %>
+        <%= style_work_metadata_label(t(".prompt_url")) %><%= style_link(prompt.url, prompt.url) %>
         <br />
       <% end %>
       <% if prompt.description && !prompt.description.blank? %>
-        <%= style_bold(t(".description")) %>
+        <%= style_work_metadata_label(t(".description")) %>
         <%= style_quote(prompt.description) %>
       <% end %>
     </p>
@@ -83,7 +74,7 @@
   <%= styled_divider %>
 
   <p>
-    <%= style_bold(t(".due")) %> <%= time_in_zone(@collection.challenge.assignments_due_at, (@collection.challenge.time_zone || Time.zone.name), @assigned_user) %>.
+    <%= style_work_metadata_label(t(".due")) %><%= time_in_zone(@collection.challenge.assignments_due_at, (@collection.challenge.time_zone || Time.zone.name), @assigned_user) %>.
   </p>
 
   <p><%= t(".look_up.html", your_assignments_link: style_link(t(".look_up.your_assignments"), user_assignments_url(@assigned_user))) %></p>

--- a/app/views/user_mailer/challenge_assignment_notification.html.erb
+++ b/app/views/user_mailer/challenge_assignment_notification.html.erb
@@ -2,7 +2,7 @@
   <p><%= t(".assignment.html", link: style_link(@collection.title, collection_url(@collection))) %></p>
 
   <p>
-    <%= style_work_metadata_label(t(".recipient")) %><%= @request.nil? ? t(".recipient_missing") : style_link(@request.pseud.byline, user_pseud_url(@request.pseud.user, @request.pseud)) %>
+    <%= style_metadata_label(t(".recipient")) %><%= @request.nil? ? t(".recipient_missing") : style_link(@request.pseud.byline, user_pseud_url(@request.pseud.user, @request.pseud)) %>
   </p>
 
   <%= style_bold(t(".prompts")) %>
@@ -29,43 +29,43 @@
 
     <p>
       <% if fandoms %>
-        <%= style_work_metadata_label(t("activerecord.models.fandom", count: prompt.any_fandom ? 1 : tag_groups["Fandom"].count)) %><%= fandoms %>
+        <%= style_metadata_label(t("activerecord.models.fandom", count: prompt.any_fandom ? 1 : tag_groups["Fandom"].count)) %><%= fandoms %>
         <br />
       <% end %>
       <% if chars %>
-        <%= style_work_metadata_label(t("activerecord.models.character", count: prompt.any_character ? 1 : tag_groups["Character"].count)) %><%= chars %>
+        <%= style_metadata_label(t("activerecord.models.character", count: prompt.any_character ? 1 : tag_groups["Character"].count)) %><%= chars %>
         <br />
       <% end %>
       <% if ships %>
-        <%= style_work_metadata_label(t("activerecord.models.relationship", count: prompt.any_relationship ? 1 : tag_groups["Relationship"].count)) %><%= ships %>
+        <%= style_metadata_label(t("activerecord.models.relationship", count: prompt.any_relationship ? 1 : tag_groups["Relationship"].count)) %><%= ships %>
         <br />
       <% end %>
       <% if ratings %>
-        <%= style_work_metadata_label(t("activerecord.models.rating", count: prompt.any_rating ? 1 : tag_groups["Rating"].count)) %><%= ratings %>
+        <%= style_metadata_label(t("activerecord.models.rating", count: prompt.any_rating ? 1 : tag_groups["Rating"].count)) %><%= ratings %>
         <br />
       <% end %>
       <% if warnings %>
-        <%= style_work_metadata_label(t("activerecord.models.archive_warning", count: prompt.any_archive_warning ? 1 : tag_groups["ArchiveWarning"].count)) %><%= warnings %>
+        <%= style_metadata_label(t("activerecord.models.archive_warning", count: prompt.any_archive_warning ? 1 : tag_groups["ArchiveWarning"].count)) %><%= warnings %>
         <br />
       <% end %>
       <% if categories %>
-        <%= style_work_metadata_label(t("activerecord.models.category", count: prompt.any_category ? 1 : tag_groups["Category"].count)) %><%= categories %>
+        <%= style_metadata_label(t("activerecord.models.category", count: prompt.any_category ? 1 : tag_groups["Category"].count)) %><%= categories %>
         <br />
       <% end %>
       <% if atags %>
-        <%= style_work_metadata_label(t("activerecord.models.freeform", count: prompt.any_freeform ? 1 : tag_groups["Freeform"].count)) %><%= atags %>
+        <%= style_metadata_label(t("activerecord.models.freeform", count: prompt.any_freeform ? 1 : tag_groups["Freeform"].count)) %><%= atags %>
         <br />
       <% end %>
       <% if otags %>
-        <%= style_work_metadata_label(t(".optional_tags")) %><%= otags %>
+        <%= style_metadata_label(t(".optional_tags")) %><%= otags %>
         <br />
       <% end %>
       <% if prompt.url && !prompt.url.blank? %>
-        <%= style_work_metadata_label(t(".prompt_url")) %><%= style_link(prompt.url, prompt.url) %>
+        <%= style_metadata_label(t(".prompt_url")) %><%= style_link(prompt.url, prompt.url) %>
         <br />
       <% end %>
       <% if prompt.description && !prompt.description.blank? %>
-        <%= style_work_metadata_label(t(".description")) %>
+        <%= style_metadata_label(t(".description")) %>
         <%= style_quote(prompt.description) %>
       <% end %>
     </p>
@@ -74,7 +74,7 @@
   <%= styled_divider %>
 
   <p>
-    <%= style_work_metadata_label(t(".due")) %><%= time_in_zone(@collection.challenge.assignments_due_at, (@collection.challenge.time_zone || Time.zone.name), @assigned_user) %>.
+    <%= style_metadata_label(t(".due")) %><%= time_in_zone(@collection.challenge.assignments_due_at, (@collection.challenge.time_zone || Time.zone.name), @assigned_user) %>.
   </p>
 
   <p><%= t(".look_up.html", your_assignments_link: style_link(t(".look_up.your_assignments"), user_assignments_url(@assigned_user))) %></p>

--- a/app/views/user_mailer/challenge_assignment_notification.text.erb
+++ b/app/views/user_mailer/challenge_assignment_notification.text.erb
@@ -1,7 +1,7 @@
 <% content_for :message do %>
 <%= t(".assignment.text", collection_title: @collection.title, collection_url: collection_url(@collection)) %>
 
-<%= work_metadata_label(t(".recipient")) %><%= @request.nil? ? t(".recipient_missing") : text_pseud(@request.pseud) %>
+<%= metadata_label(t(".recipient")) %><%= @request.nil? ? t(".recipient_missing") : text_pseud(@request.pseud) %>
 
 <%= t(".prompts") %>
 <% @request.requests.each_with_index do |prompt, index| %>
@@ -23,40 +23,40 @@
 <%= index + 1 %>. <%= prompt.title %>
 
 <% if fandoms %>
-<%= work_metadata_label(t("activerecord.models.fandom", count: prompt.any_fandom ? 1 : tag_groups["Fandom"].count)) %><%= fandoms %>
+<%= metadata_label(t("activerecord.models.fandom", count: prompt.any_fandom ? 1 : tag_groups["Fandom"].count)) %><%= fandoms %>
 <% end %>
 <% if chars %>
-<%= work_metadata_label(t("activerecord.models.character", count: prompt.any_character ? 1 : tag_groups["Character"].count)) %><%= chars %>
+<%= metadata_label(t("activerecord.models.character", count: prompt.any_character ? 1 : tag_groups["Character"].count)) %><%= chars %>
 <% end %>
 <% if ships %>
-<%= work_metadata_label(t("activerecord.models.relationship", count: prompt.any_relationship ? 1 : tag_groups["Relationship"].count)) %><%= ships %>
+<%= metadata_label(t("activerecord.models.relationship", count: prompt.any_relationship ? 1 : tag_groups["Relationship"].count)) %><%= ships %>
 <% end %>
 <% if ratings %>
-<%= work_metadata_label(t("activerecord.models.rating", count: prompt.any_rating ? 1 : tag_groups["Rating"].count)) %><%= ratings %>
+<%= metadata_label(t("activerecord.models.rating", count: prompt.any_rating ? 1 : tag_groups["Rating"].count)) %><%= ratings %>
 <% end %>
 <% if warnings %>
-<%= work_metadata_label(t("activerecord.models.archive_warning", count: prompt.any_archive_warning ? 1 : tag_groups["ArchiveWarning"].count)) %><%= warnings %>
+<%= metadata_label(t("activerecord.models.archive_warning", count: prompt.any_archive_warning ? 1 : tag_groups["ArchiveWarning"].count)) %><%= warnings %>
 <% end %>
 <% if categories %>
-<%= work_metadata_label(t("activerecord.models.category", count: prompt.any_category ? 1 : tag_groups["Category"].count)) %><%= categories %>
+<%= metadata_label(t("activerecord.models.category", count: prompt.any_category ? 1 : tag_groups["Category"].count)) %><%= categories %>
 <% end %>
 <% if atags %>
-<%= work_metadata_label(t("activerecord.models.freeform", count: prompt.any_freeform ? 1 : tag_groups["Freeform"].count)) %><%= atags %>
+<%= metadata_label(t("activerecord.models.freeform", count: prompt.any_freeform ? 1 : tag_groups["Freeform"].count)) %><%= atags %>
 <% end %>
 <% if otags %>
-<%= work_metadata_label(t(".optional_tags")) %><%= otags %>
+<%= metadata_label(t(".optional_tags")) %><%= otags %>
 <% end %>
 <% if prompt.url && !prompt.url.blank? %>
-<%= work_metadata_label(t(".prompt_url")) %><%= prompt.url %>
+<%= metadata_label(t(".prompt_url")) %><%= prompt.url %>
 <% end %>
 <% if prompt.description && !prompt.description.blank? %>
-<%= work_metadata_label(t(".description")) %>
+<%= metadata_label(t(".description")) %>
     <%= to_plain_text(prompt.description) %>
 <% end %>
 
 <% end %><%= text_divider %>
 
-<%= work_metadata_label(t(".due")) %><%= to_plain_text(time_in_zone(@collection.challenge.assignments_due_at, (@collection.challenge.time_zone || Time.zone.name), @assigned_user)).gsub(/\n\s*/, "") %>.
+<%= metadata_label(t(".due")) %><%= to_plain_text(time_in_zone(@collection.challenge.assignments_due_at, (@collection.challenge.time_zone || Time.zone.name), @assigned_user)).gsub(/\n\s*/, "") %>.
 
 <%= t(".look_up.text", your_assignments_url: user_assignments_url(@assigned_user)) %>
 <% if @collection && !@collection.assignment_notification.blank? %>

--- a/app/views/user_mailer/challenge_assignment_notification.text.erb
+++ b/app/views/user_mailer/challenge_assignment_notification.text.erb
@@ -1,9 +1,9 @@
 <% content_for :message do %>
-<%= t ".assignment.text", collection_title: @collection.title, collection_url: collection_url(@collection) %>
+<%= t(".assignment.text", collection_title: @collection.title, collection_url: collection_url(@collection)) %>
 
-<%= t ".recipient" %> <%= @request.nil? ? t(".recipient_missing") : text_pseud(@request.pseud) %>
+<%= work_metadata_label(t(".recipient")) %><%= @request.nil? ? t(".recipient_missing") : text_pseud(@request.pseud) %>
 
-<%= t ".prompts" %>
+<%= t(".prompts") %>
 <% @request.requests.each_with_index do |prompt, index| %>
 <% tag_groups = prompt.tag_groups %>
 <% def tag_list(tags) %>
@@ -23,40 +23,40 @@
 <%= index + 1 %>. <%= prompt.title %>
 
 <% if fandoms %>
-<%= t("activerecord.models.fandom", count: prompt.any_fandom ? 1 : tag_groups["Fandom"].count) + t("mailer.general.metadata_label_indicator") %><%= fandoms %>
+<%= work_metadata_label(t("activerecord.models.fandom", count: prompt.any_fandom ? 1 : tag_groups["Fandom"].count)) %><%= fandoms %>
 <% end %>
 <% if chars %>
-<%= t("activerecord.models.character", count: prompt.any_character ? 1 : tag_groups["Character"].count) + t("mailer.general.metadata_label_indicator") %><%= chars %>
+<%= work_metadata_label(t("activerecord.models.character", count: prompt.any_character ? 1 : tag_groups["Character"].count)) %><%= chars %>
 <% end %>
 <% if ships %>
-<%= t("activerecord.models.relationship", count: prompt.any_relationship ? 1 : tag_groups["Relationship"].count) + t("mailer.general.metadata_label_indicator") %><%= ships %>
+<%= work_metadata_label(t("activerecord.models.relationship", count: prompt.any_relationship ? 1 : tag_groups["Relationship"].count)) %><%= ships %>
 <% end %>
 <% if ratings %>
-<%= t("activerecord.models.rating", count: 1) + t("mailer.general.metadata_label_indicator") %><%= ratings %>
+<%= work_metadata_label(t("activerecord.models.rating", count: prompt.any_rating ? 1 : tag_groups["Rating"].count)) %><%= ratings %>
 <% end %>
 <% if warnings %>
-<%= t("activerecord.models.archive_warning", count: prompt.any_archive_warning ? 1 : tag_groups["ArchiveWarning"].count) + t("mailer.general.metadata_label_indicator") %><%= warnings %>
+<%= work_metadata_label(t("activerecord.models.archive_warning", count: prompt.any_archive_warning ? 1 : tag_groups["ArchiveWarning"].count)) %><%= warnings %>
 <% end %>
 <% if categories %>
-<%= t("activerecord.models.category", count: prompt.any_category ? 1 : tag_groups["Category"].count) + t("mailer.general.metadata_label_indicator") %><%= categories %>
+<%= work_metadata_label(t("activerecord.models.category", count: prompt.any_category ? 1 : tag_groups["Category"].count)) %><%= categories %>
 <% end %>
 <% if atags %>
-<%= t("activerecord.models.freeform", count: prompt.any_freeform ? 1 : tag_groups["Freeform"].count) + t("mailer.general.metadata_label_indicator") %><%= atags %>
+<%= work_metadata_label(t("activerecord.models.freeform", count: prompt.any_freeform ? 1 : tag_groups["Freeform"].count)) %><%= atags %>
 <% end %>
 <% if otags %>
-<%= t(".optional_tags") %> <%= otags %>
+<%= work_metadata_label(t(".optional_tags")) %><%= otags %>
 <% end %>
 <% if prompt.url && !prompt.url.blank? %>
-<%= t(".prompt_url") %> <%= prompt.url %>
+<%= work_metadata_label(t(".prompt_url")) %><%= prompt.url %>
 <% end %>
 <% if prompt.description && !prompt.description.blank? %>
-<%= t(".description") %>
+<%= work_metadata_label(t(".description")) %>
     <%= to_plain_text(prompt.description) %>
 <% end %>
 
 <% end %><%= text_divider %>
 
-<%= t(".due") %> <%= to_plain_text(time_in_zone(@collection.challenge.assignments_due_at, (@collection.challenge.time_zone || Time.zone.name), @assigned_user)).gsub(/\n\s*/, "") %>.
+<%= work_metadata_label(t(".due")) %><%= to_plain_text(time_in_zone(@collection.challenge.assignments_due_at, (@collection.challenge.time_zone || Time.zone.name), @assigned_user)).gsub(/\n\s*/, "") %>.
 
 <%= t(".look_up.text", your_assignments_url: user_assignments_url(@assigned_user)) %>
 <% if @collection && !@collection.assignment_notification.blank? %>

--- a/config/locales/mailers/en.yml
+++ b/config/locales/mailers/en.yml
@@ -182,8 +182,8 @@ en:
       assignment:
         html: You have been assigned the following request in the %{link} challenge at the Archive of Our Own!
         text: You have been assigned the following request in the "%{collection_title}" challenge (%{collection_url}) at the Archive of Our Own!
-      description: 'Description:'
-      due: 'This assignment is due at:'
+      description: Description
+      due: This assignment is due at
       footer:
         challenge_profile: the challenge profile page
         html: You're receiving this email because you signed up for the %{title} challenge. For more information about this challenge and contact information for the moderators, please visit %{challenge_profile_link}.
@@ -192,10 +192,10 @@ en:
         html: You can look up this assignment from %{your_assignments_link}.
         text: You can look up this assignment from your Assignments page at %{your_assignments_url}.
         your_assignments: your Assignments page
-      optional_tags: 'Optional Tags:'
-      prompt_url: 'Prompt URL:'
+      optional_tags: Optional Tags
+      prompt_url: Prompt URL
       prompts: 'Prompts:'
-      recipient: 'Recipient:'
+      recipient: Recipient
       recipient_missing: 'None: contact a moderator for help!'
       subject: "[%{app_name}][%{collection_title}] Your assignment!"
     change_email:

--- a/spec/helpers/mailer_helper_spec.rb
+++ b/spec/helpers/mailer_helper_spec.rb
@@ -71,9 +71,9 @@ describe MailerHelper do
     end
   end
 
-  describe "#work_metadata_label" do
+  describe "#metadata_label" do
     it "appends the metadata indicator to a string" do
-      expect(work_metadata_label("Text")).to eq("Text: ")
+      expect(metadata_label("Text")).to eq("Text: ")
     end
   end
 


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6903

## Purpose

Remove the extra spaces after the labels in the `challenge_assignment_notification` and `abuse_report` mailers. Convert the `challenge_assignment_notification` to use the existing methods for adding the `metadata_label_indicator`. Address a todo to remove the word "work" from those methods, separated into an extra commit for easier reviewing.

Also, make the rating label in challenge_assignment_notification pluralize because I realized that I forgot that in the initial preview changes.

## Testing Instructions

Refer to Jira.

## Credit

Bilka
