### PR TITLE
Add more instructions to pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,6 @@
 # Pull Request Checklist
 
+<!-- Mark steps in the checklist as complete by changing `[ ]` to `[X]` -->
 * [ ] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
 * [ ] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
 * [ ] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
@@ -23,9 +24,11 @@ How can the Archive's QA team verify that this is working as you intended?
 If you have a Jira account with access, please update or comment on the issue
 with any new or missing testing instructions instead.
 
+You can remove this section if there are already full testing instructions in the Jira issue.
+
 ## References
 
-Are there other relevant issues/pull requests/mailing list discussions?
+Are there other relevant issues/pull requests/mailing list discussions? If not, you can remove this section.
 
 ## Credit
 


### PR DESCRIPTION
## Issue

None, doc change.

## Purpose

Add some more instructions to the PR template based on common mistakes and some feedback from a contributor. The comment will show up in the template but not the final PR, so it's a great way to give "how to use this" instructions, I saw it in the rails repository.

## Credit

Bilka
