### PR TITLE
AO3-6751 Fix "Relationships by Character" url for fandoms with periods

### DIFF
--- a/app/views/tags/show.html.erb
+++ b/app/views/tags/show.html.erb
@@ -29,7 +29,7 @@
           filter_works_link: link_to(t(".filter_works"), tag_works_path(@tag)),
           filter_bookmarks_link: link_to(t(".filter_bookmarks"), tag_bookmarks_path(@tag))) %>
     <% if @tag.is_a?(Fandom) %>
-      <%= t(".list_fandom_tags_html", fandom_relationship_tags_link: link_to(t(".fandom_relationship_tags"), fandom_path(@tag.name))) %>
+      <%= t(".list_fandom_tags_html", fandom_relationship_tags_link: link_to(t(".fandom_relationship_tags"), fandom_path(@tag))) %>
     <% end %>
   <% end %>
   </p>

--- a/features/other_b/fandoms.feature
+++ b/features/other_b/fandoms.feature
@@ -38,3 +38,10 @@ Feature: There is a list of unassigned Fandoms
       And I follow "Relationship tags in this fandom"
     Then I should see "Ruby (Steven Universe)"
       And I should see "Sapphire (Steven Universe)"
+
+  Scenario: Click on "Relationships by Character" on a fandom tag containing periods  
+    Given a canonical fandom "Harry Potter - J. K. Rowling"
+    When I view the tag "Harry Potter - J. K. Rowling"
+        And I follow "Relationship tags in this fandom" 
+    Then I should not see "The page you were looking for doesn't exist."
+        And I should see "Relationships by Character"

--- a/features/tags_and_wrangling/tag_fandom_relationships.feature
+++ b/features/tags_and_wrangling/tag_fandom_relationships.feature
@@ -1,8 +1,0 @@
-Feature: Fandom Relationship Tags Link
-
-  Scenario: Click on "Relationships by Character" on a fandom tag containing periods  
-    Given a canonical fandom "Harry Potter - J. K. Rowling"
-    When I view the tag "Harry Potter - J. K. Rowling"
-        And I follow "Relationship tags in this fandom" 
-    Then I should not see "The page you were looking for doesn't exist."
-        And I should see "Relationships by Character"

--- a/features/tags_and_wrangling/tag_fandom_relationships.feature
+++ b/features/tags_and_wrangling/tag_fandom_relationships.feature
@@ -1,0 +1,8 @@
+Feature: Fandom Relationship Tags Link
+
+  Scenario: Click on "Relationships by Character" on a fandom tag containing periods  
+    Given a canonical fandom "Harry Potter - J. K. Rowling"
+    When I view the tag "Harry Potter - J. K. Rowling"
+        And I follow "Relationship tags in this fandom" 
+    Then I should not see "The page you were looking for doesn't exist."
+        And I should see "Relationships by Character"


### PR DESCRIPTION
# Pull Request Checklist

<!-- Mark steps in the checklist as complete by changing `[ ]` to `[X]` -->
* [X] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [X] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [X] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [X] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [X] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-6751

## Purpose

Ensures period in the fandom tag page for fandoms with periods is properly escaped in the URL. Changed fandom_path(@tag.name) to fandom_path(@tag) in the app/views/tags/shot.html.erb file on line 32
## Testing Instructions
1) Go to https://archiveofourown.org/tags/Harry%20Potter%20-%20J*d*%20K*d*%20Rowling
2) Follow the 'Relationship tags in this fandom' link,
3) You should get a link that is properly escaped like this: https://archiveofourown.org/fandoms/Harry%20Potter%20-%20J*d*%20K*d*%20Rowling

## Credit

Emily Wiegand (she/her)

