### PR TITLE
AO3-4250 Made gift recipients update on blurbs on pseud / username changes

### DIFF
--- a/app/models/pseud.rb
+++ b/app/models/pseud.rb
@@ -392,6 +392,7 @@ class Pseud < ApplicationRecord
 
   def expire_caches
     return unless saved_change_to_name? || (destroyed? && !user.nil? && !user.default_pseud.nil?)
+
     pseud = destroyed? ? user.default_pseud : self
     pseud.series.each(&:expire_byline_cache)
     pseud.works.each do |work|

--- a/app/models/pseud.rb
+++ b/app/models/pseud.rb
@@ -391,9 +391,11 @@ class Pseud < ApplicationRecord
   end
 
   def expire_caches
-    return unless saved_change_to_name? || (destroyed? && !user.nil? && !user.default_pseud.nil?)
+    return unless saved_change_to_name? || (destroyed? && !user.nil?)
 
     pseud = destroyed? ? user.default_pseud : self
+    return unless !pseud.nil?
+
     pseud.series.each(&:expire_byline_cache)
     pseud.works.each do |work|
       work.touch

--- a/app/models/pseud.rb
+++ b/app/models/pseud.rb
@@ -394,7 +394,7 @@ class Pseud < ApplicationRecord
     return unless saved_change_to_name? || (destroyed? && !user.nil?)
 
     pseud = destroyed? ? user.default_pseud : self
-    return unless !pseud.nil?
+    return if pseud.nil?
 
     pseud.series.each(&:expire_byline_cache)
     pseud.works.each do |work|

--- a/app/models/pseud.rb
+++ b/app/models/pseud.rb
@@ -75,8 +75,8 @@ class Pseud < ApplicationRecord
 
   after_update :check_default_pseud
   after_update :expire_caches
-  after_commit :reindex_creations, :touch_comments
   after_destroy :expire_caches
+  after_commit :reindex_creations, :touch_comments
 
   scope :alphabetical, -> { order(:name) }
   scope :default_alphabetical, -> { order(is_default: :desc).alphabetical }
@@ -391,8 +391,8 @@ class Pseud < ApplicationRecord
   end
 
   def expire_caches
-    return unless saved_change_to_name? || (destroyed? && user != nil && user.default_pseud != nil)
-    pseud = if destroyed? then user.default_pseud else self end
+    return unless saved_change_to_name? || (destroyed? && !user.nil? && !user.default_pseud.nil?)
+    pseud = destroyed? ? user.default_pseud : self
     pseud.series.each(&:expire_byline_cache)
     pseud.works.each do |work|
       work.touch

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -166,6 +166,10 @@ class User < ApplicationRecord
       work.touch
       work.expire_caches
     end
+    self.gift_works.each do |work|
+      work.touch
+      work.expire_caches
+    end
   end
 
   def remove_user_from_kudos

--- a/features/other_a/pseud_delete.feature
+++ b/features/other_a/pseud_delete.feature
@@ -202,3 +202,34 @@ Feature: Delete pseud.
     Then I should see "My Collection Thing"
       And I should not see "other_pseud (myself)" within "#main"
       And I should see "myself" within "#main"
+
+  Scenario: Deleting a pseud updates series blurbs
+
+    Given I am logged in as "Myself"
+      And I add the work "Great Work" to series "Best Series" as "Me2"
+    When I go to the dashboard page for user "Myself" with pseud "Me2"
+      And I follow "Series"
+    Then I should see "Best Series by Me2 (Myself)"
+
+    When I delete the pseud "Me2"
+      And I follow "Series"
+    Then I should see "Best Series by Myself"
+
+  Scenario: Deleting a pseud updates gift blurbs
+    Given I have no users
+      And the following activated users exist
+        | login      | password    | email                | id |
+        | gifter     | something   | gifter@example.com   | 1  |
+        | giftee1    | something   | giftee1@example.com  | 2  |
+      And a pseud exists with name: "Me2", user_id: 2
+      And the user "giftee1" allows gifts
+      And I am logged in as "gifter" with password "something"
+      And I set up the draft "GiftStory1"
+      And I give the work to "Me2 (giftee1)"
+      And I press "Post"
+      And I am logged in as "giftee1" with password "something"
+    When I go to my gifts page
+    Then I should see "GiftStory1 by gifter for Me2 (giftee1)"
+    When I delete the pseud "Me2"
+      And I go to my gifts page
+    Then I should see "GiftStory1 by gifter for giftee1"

--- a/features/other_a/pseuds.feature
+++ b/features/other_a/pseuds.feature
@@ -253,6 +253,30 @@ Scenario: Edit pseud updates series blurbs
   When I follow "Series"
   Then I should see "Best Series by Me3 (Myself)"
 
+Scenario: Edit pseud updates gift blurbs
+  Given I have no users
+    And the following activated users exist
+      | login      | password    | email                | id |
+      | gifter     | something   | gifter@example.com   | 1  |
+      | giftee1    | something   | giftee1@example.com  | 2  |
+    And a pseud exists with name: "Me2", user_id: 2
+    And the user "giftee1" allows gifts
+    And I am logged in as "gifter" with password "something"
+    And I set up the draft "GiftStory1"
+    And I give the work to "Me2 (giftee1)"
+    And I press "Post"
+    And I am logged in as "giftee1" with password "something"
+  When I go to my gifts page
+  Then I should see "GiftStory1 by gifter for Me2 (giftee1)"
+  When I go to my profile page
+    And I follow "Manage My Pseuds"
+    And I follow "Edit Me2"
+    And I fill in "Name" with "Me3"
+    And I press "Update"
+  Then I should see "Pseud was successfully updated."
+  When I go to my gifts page
+  Then I should see "GiftStory1 by gifter for Me3 (giftee1)"
+
 Scenario: Change details as an admin
 
   Given "someone" has the pseud "alt"

--- a/features/step_definitions/pseud_steps.rb
+++ b/features/step_definitions/pseud_steps.rb
@@ -29,7 +29,7 @@ end
 
 When(/^I delete the pseud "([^\"]*)"$/) do |pseud|
   visit user_pseuds_path(User.current_user)
-  click_link("delete_#{pseud}")
+  click_link("delete_#{pseud.downcase}")
 end
 
 When /^"([^\"]*)" creates the default pseud "([^"]*)"$/ do |username, newpseud|

--- a/features/users/user_delete.feature
+++ b/features/users/user_delete.feature
@@ -117,3 +117,26 @@ Scenario: Delete a user who has coauthored a work
       And a user account should not exist for "testuser"
     When I go to orphan_account's series page
     Then I should see "Epic"
+
+  Scenario: Deleting a user updates gift blurbs
+    Given I have no users
+      And I have no works or comments
+      And the following activated users exist
+        | login      | password    | email                | id |
+        | gifter     | something   | gifter@example.com   | 1  |
+        | giftee1    | something   | giftee1@example.com  | 2  |
+      And the user "giftee1" allows gifts
+      And I am logged in as "gifter" with password "something"
+      And I set up the draft "GiftStory1"
+      And I give the work to "giftee1"
+      And I press "Post"
+      And I am logged in as "giftee1" with password "something"
+    When I am on gifter's works page
+    Then I should see "GiftStory1 by gifter for giftee1"
+    When I try to delete my account as giftee1
+    Then I should see "You have successfully deleted your account."
+      And a user account should not exist for "giftee1"
+      And I should be logged out
+    When I am on gifter's works page
+    Then I should see "GiftStory1 by gifter"
+      And I should not see "GiftStory1 by gifter for giftee1"

--- a/features/users/user_rename.feature
+++ b/features/users/user_rename.feature
@@ -182,35 +182,104 @@ Feature:
       And I should see "after" within "#main"
       And I should not see "before" within "#main"
 
-  Scenario: Changing username updates series blurbs
+  Scenario: Changing only username updates series blurbs
     Given I have no users
-      And I am logged in as "oldusername" with password "password"
+      And the following activated user exists
+      | login         | password | id |
+      | oldusername   | secret   | 1  |
+      And a pseud exists with name: "newusername", user_id: 1
+      And I am logged in as "oldusername" with password "secret"
       And I add the work "Great Work" to series "Best Series"
     When I go to the dashboard page for user "oldusername" with pseud "oldusername"
       And I follow "Series"
     Then I should see "Best Series by oldusername"
     When I visit the change username page for oldusername
       And I fill in "New user name" with "newusername"
-      And I fill in "Password" with "password"
+      And I fill in "Password" with "secret"
+      And I press "Change User Name"
+    Then I should get confirmation that I changed my username
+      And I should see "Hi, newusername"
+    When I follow "Series"
+    Then I should see "Best Series by oldusername (newusername)"
+
+  Scenario: Changing username and pseud updates series blurbs
+    Given I have no users
+      And I am logged in as "oldusername" with password "secret"
+      And I add the work "Great Work" to series "Best Series"
+    When I go to the dashboard page for user "oldusername" with pseud "oldusername"
+      And I follow "Series"
+    Then I should see "Best Series by oldusername"
+    When I visit the change username page for oldusername
+      And I fill in "New user name" with "newusername"
+      And I fill in "Password" with "secret"
       And I press "Change User Name"
     Then I should get confirmation that I changed my username
       And I should see "Hi, newusername"
     When I follow "Series"
     Then I should see "Best Series by newusername"
+      And I should not see "Best Series by oldusername"
 
-    Scenario: Changing the username from a forbidden name to non-forbidden
-      Given I have no users
-        And the following activated user exists
-          | login     | password |
-          | forbidden | secret   |
-        And the user name "forbidden" is on the forbidden list
-      When I am logged in as "forbidden" with password "secret"
-        And I visit the change username page for forbidden
-        And I fill in "New user name" with "notforbidden"
-        And I fill in "Password" with "secret"
-        And I press "Change User Name"
-      Then I should get confirmation that I changed my username
-        And I should see "Hi, notforbidden"
+  Scenario: Changing only username updates gift blurbs
+    Given I have no users
+      And the following activated users exist
+        | login      | password    | email                | id |
+        | gifter     | something   | gifter@example.com   | 1  |
+        | giftee1    | something   | giftee1@example.com  | 2  |
+      And a pseud exists with name: "newusername", user_id: 2
+      And the user "giftee1" allows gifts
+      And I am logged in as "gifter" with password "something"
+      And I set up the draft "GiftStory1"
+      And I give the work to "giftee1"
+      And I press "Post"
+      And I am logged in as "giftee1" with password "something"
+    When I go to my gifts page
+    Then I should see "GiftStory1 by gifter for giftee1"
+    When I visit the change username page for giftee1
+      And I fill in "New user name" with "newusername"
+      And I fill in "Password" with "something"
+      And I press "Change User Name"
+    Then I should get confirmation that I changed my username
+      And I should see "Hi, newusername"
+    When I go to my gifts page
+    Then I should see "GiftStory1 by gifter for giftee1 (newusername)"
+
+  Scenario: Changing username and pseud updates gift blurbs
+    Given I have no users
+      And the following activated users exist
+        | login      | password    | email                | id |
+        | gifter     | something   | gifter@example.com   | 1  |
+        | giftee1    | something   | giftee1@example.com  | 2  |
+      And the user "giftee1" allows gifts
+      And I am logged in as "gifter" with password "something"
+      And I set up the draft "GiftStory1"
+      And I give the work to "giftee1"
+      And I press "Post"
+      And I am logged in as "giftee1" with password "something"
+    When I go to my gifts page
+    Then I should see "GiftStory1 by gifter for giftee1"
+    When I visit the change username page for giftee1
+      And I fill in "New user name" with "newusername"
+      And I fill in "Password" with "something"
+      And I press "Change User Name"
+    Then I should get confirmation that I changed my username
+      And I should see "Hi, newusername"
+    When I go to my gifts page
+    Then I should see "GiftStory1 by gifter for newusername"
+      And I should not see "GiftStory1 by gifter for giftee1"
+
+  Scenario: Changing the username from a forbidden name to non-forbidden
+    Given I have no users
+      And the following activated user exists
+        | login     | password |
+        | forbidden | secret   |
+      And the user name "forbidden" is on the forbidden list
+    When I am logged in as "forbidden" with password "secret"
+      And I visit the change username page for forbidden
+      And I fill in "New user name" with "notforbidden"
+      And I fill in "Password" with "secret"
+      And I press "Change User Name"
+    Then I should get confirmation that I changed my username
+      And I should see "Hi, notforbidden"
 
   Scenario: Tag wrangling supervisors are emailed about tag wrangler username changes
     Given the user "before" exists and is activated


### PR DESCRIPTION
# Pull Request Checklist

<!-- Mark steps in the checklist as complete by changing `[ ]` to `[X]` -->
* [X] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [X] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [X] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [X] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [X] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-4250

## Purpose

Made it so that changing a pseud or username, deleting a pseud, or deleting a user account will expire the cache for all gift works (so that the byline will no longer display the old pseud or username.)

For deleting a pseud, this is done by expiring the cache on all gifts for the default pseud (since gifts are reassigned to the default pseud.) This will clear more caches than necessary - technically we only need to expire the cache for the gifts that were previously assigned to pseud being deleted. I did it this way for now because it's easier & keeps all the code in one place, which I think is easier to understand / less likely to break; however, I can definitely go back and change this if desired.

I also tweaked some of the tests related to series blurb updates (to ensure that they behave properly if only the username is updated and no pseuds) and fixed some minor whitespace issues on adjacent tests.

## Credit

Stephen Lewis, he/him