### PR TITLE
AO3-6904 Set passwords of testuser and testadmin in fixtures to known values

### DIFF
--- a/test/fixtures/admins.yml
+++ b/test/fixtures/admins.yml
@@ -1,8 +1,7 @@
 --- 
 admin_00001: 
-  password_salt: 7e3041ebc2fc05a40c60028e2c4901a81035d3cd
   created_at: 2008-11-09 01:26:01 Z
-  encrypted_password: 00742970dc9e6319f8019fd54864d3ea740f04b1
+  encrypted_password: <%= Devise::Encryptor.digest(User, 'testadmin') %>
   updated_at: 2008-11-09 01:26:01 Z
   id: 1
   login: testadmin

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -420,10 +420,9 @@ user_00012:
   email: zooey@example.com
   banned: false
 user_00001: 
-  password_salt: 7e3041ebc2fc05a40c60028e2c4901a81035d3cd
+  encrypted_password: <%= Devise::Encryptor.digest(User, 'testuser') %>
   created_at: 2008-11-09 01:26:02 Z
   confirmed_at: 2008-11-09 01:26:02 Z
-  encrypted_password: 00742970dc9e6319f8019fd54864d3ea740f04b1
   updated_at: 2010-08-11 21:37:42 Z
   confirmation_token: 
   invitation_id: 


### PR DESCRIPTION
# Pull Request Checklist

<!-- Mark steps in the checklist as complete by changing `[ ]` to `[X]` -->
* [x] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [x] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [x] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [x] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-6904

## Purpose

This PR modifies two fixture entries: admins.yml and users.yml. In each, one of the users has their encrypted password changed from the hash to a function that allows the password to be read in plaintext.

## Credit

CJ G