### PR TITLE
AO3-6909 Bump tk0miya/action-erblint to 44c5fe3

### DIFF
--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -45,8 +45,8 @@ jobs:
           bundler-cache: true
 
       - name: erb-lint
-        uses: tk0miya/action-erblint@b6e537f4616e4fa7a9eef209ca34ca944e1440dd
+        uses: tk0miya/action-erblint@44c5fe3552356fe8bff23f30d534aa4258aa3f7b
         with:
           use_bundler: true
           reporter: github-pr-check
-          fail_on_error: true
+          fail_level: any


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6909

## Purpose

It gets ahead of the dependabot PR to update the action so that we can bundle the input change in the same PR. This is the same change as #4975 but for erblint instead of rubocop, now that the erblint action also supports the new flag.

## Credit

Bilka