### PR TITLE
AO3-6893 Use rebuild_constraints to modify foreign keys

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -740,7 +740,7 @@ PERCONA_ARGS: >
   --max-load Threads_running=15
   --critical-load Threads_running=100
   --set-vars innodb_lock_wait_timeout=2
-  --alter-foreign-keys-method=drop_swap
+  --alter-foreign-keys-method=rebuild_constraints
   --no-check-unique-key-change
 
 # How many shards to have in elastic indexes.


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6893

## Purpose

@zz9pzza referenced [this blog post](https://www.percona.com/blog/dont-auto-pt-online-schema-change-for-tables-with-foreign-keys/). Our options:

- `rebuild_constraints` is safest but slow since it involves copying data from the old to the new table.
- `drop_swap` is fast but risky and not rollback friendly.
- `auto` is not a real third option, it picks between the first two by estimating how long it takes to copy data between the two tables.

Since we're using MariaDB, rebuilding constraints as an online operation can be fast (not requiring a full table copy) [as long as we disable `foreign_key_checks`](https://mariadb.com/kb/en/innodb-online-ddl-operations-with-the-inplace-alter-algorithm/#alter-table-add-foreign-key):

> InnoDB supports adding foreign key constraints to a table with [`ALGORITHM`](https://mariadb.com/kb/en/alter-table/#algorithm) set to `INPLACE`. In order to add a new foreign key constraint to a table with [`ALGORITHM`](https://mariadb.com/kb/en/alter-table/#algorithm) set to `INPLACE`, the [`foreign_key_checks`](https://mariadb.com/kb/en/server-system-variables/#foreign_key_checks) system variable needs to be set to `OFF`. If it is set to `ON`, then `ALGORITHM=COPY` is required.
>
> This operation only changes the table's metadata, so the table does not have to be rebuilt.

We would need to set:
```
--alter-foreign-keys-method=rebuild_constraints
--set-vars=foreign_key_checks=0
```
However, the version of pt-osc we use (3.5.4) has https://github.com/percona/percona-toolkit/pull/483, which set `foreign_key_checks=0` only briefly when running alter table. That means we can simply set:
```
--alter-foreign-keys-method=rebuild_constraints
```

## Testing Instructions

Retry the migrations in #5039.