### PR TITLE
AO3-6893 Patch departure to prevent DB locking error

### DIFF
--- a/config/initializers/monkeypatches/departure.rb
+++ b/config/initializers/monkeypatches/departure.rb
@@ -1,0 +1,11 @@
+module Departure
+  module Migration
+    # Make all connections in the connection pool to use PerconaAdapter
+    # instead of the current adapter.
+    def reconnect_with_percona
+      ActiveRecord::Base.establish_connection(connection_config.merge(adapter: "percona"))
+    end
+  end
+end
+
+puts "WARNING: The monkeypatch #{__FILE__} was written for version 6.7.0 of the departure gem, but you are running #{PhraseApp::VERSION}. Please update or remove the monkeypatch." unless Departure::VERSION == "6.7.0"

--- a/config/initializers/monkeypatches/departure.rb
+++ b/config/initializers/monkeypatches/departure.rb
@@ -1,11 +1,11 @@
 module Departure
   module Migration
-    # Make all connections in the connection pool to use PerconaAdapter
-    # instead of the current adapter.
+    # Make all connections in the connection pool NOT use PerconaAdapter instead of the current adapter.
+    # Ref https://github.com/departurerb/departure/issues/110.
     def reconnect_with_percona
       ActiveRecord::Base.establish_connection(connection_config.merge(adapter: "percona"))
     end
   end
 end
 
-puts "WARNING: The monkeypatch #{__FILE__} was written for version 6.7.0 of the departure gem, but you are running #{PhraseApp::VERSION}. Please update or remove the monkeypatch." unless Departure::VERSION == "6.7.0"
+puts "WARNING: The monkeypatch #{__FILE__} was written for version 6.7.0 of the departure gem, but you are running #{Departure::VERSION}. Please update or remove the monkeypatch." unless Departure::VERSION == "6.7.0"


### PR DESCRIPTION
# Pull Request Checklist

## Issue

https://otwarchive.atlassian.net/browse/AO3-6893

## Purpose

Add a monkeypatch to avoid not unlocking the lock Rails migrations acquire via `GET_LOCK()`. Workaround for https://github.com/departurerb/departure/issues/110 until I (or someone else) can PR a fix.

Thanks to @scottsds for helping test this!