### PR TITLE
AO3-6769  Series browser page title for mystery series is missing site name

### DIFF
--- a/app/controllers/series_controller.rb
+++ b/app/controllers/series_controller.rb
@@ -45,7 +45,7 @@ class SeriesController < ApplicationController
     @works = @series.works_in_order.posted.select(&:visible?).paginate(page: params[:page])
 
     # sets the page title with the data for the series
-    @page_title = @series.unrevealed? ? ts("Mystery Series") : get_page_title(@series.allfandoms.collect(&:name).join(', '), @series.anonymous? ? ts("Anonymous") : @series.allpseuds.collect(&:byline).join(', '), @series.title)
+    @page_subtitle = @series.unrevealed? ? ts("Mystery Series") : get_page_title(@series.allfandoms.collect(&:name).join(', '), @series.anonymous? ? ts("Anonymous") : @series.allpseuds.collect(&:byline).join(', '), @series.title)
     if current_user.respond_to?(:subscriptions)
       @subscription = current_user.subscriptions.where(subscribable_id: @series.id,
                                                        subscribable_type: 'Series').first ||

--- a/app/controllers/series_controller.rb
+++ b/app/controllers/series_controller.rb
@@ -48,7 +48,7 @@ class SeriesController < ApplicationController
     if @series.unrevealed?
       @page_subtitle = t(".unrevealed_series")
     else
-      @page_subtitle = get_page_title(@series.allfandoms.collect(&:name).join(", "), @series.anonymous? ? t(".anonymous") : @series.allpseuds.collect(&:byline).join(", "), @series.title)
+      @page_title = get_page_title(@series.allfandoms.collect(&:name).join(", "), @series.anonymous? ? t(".anonymous") : @series.allpseuds.collect(&:byline).join(", "), @series.title)
     end
 
     if current_user.respond_to?(:subscriptions)

--- a/app/controllers/series_controller.rb
+++ b/app/controllers/series_controller.rb
@@ -45,7 +45,7 @@ class SeriesController < ApplicationController
     @works = @series.works_in_order.posted.select(&:visible?).paginate(page: params[:page])
 
     # sets the page title with the data for the series
-    @page_subtitle = @series.unrevealed? ? ts("Mystery Series") : get_page_title(@series.allfandoms.collect(&:name).join(', '), @series.anonymous? ? ts("Anonymous") : @series.allpseuds.collect(&:byline).join(', '), @series.title)
+    @page_subtitle = @series.unrevealed? ? ts("Mystery Series") : get_page_title(@series.allfandoms.collect(&:name).join(", "), @series.anonymous? ? ts("Anonymous") : @series.allpseuds.collect(&:byline).join(", "), @series.title)
     if current_user.respond_to?(:subscriptions)
       @subscription = current_user.subscriptions.where(subscribable_id: @series.id,
                                                        subscribable_type: 'Series').first ||

--- a/app/controllers/series_controller.rb
+++ b/app/controllers/series_controller.rb
@@ -45,7 +45,7 @@ class SeriesController < ApplicationController
     @works = @series.works_in_order.posted.select(&:visible?).paginate(page: params[:page])
 
     # sets the page title with the data for the series
-    @page_subtitle = @series.unrevealed? ? ts("Mystery Series") : get_page_title(@series.allfandoms.collect(&:name).join(", "), @series.anonymous? ? ts("Anonymous") : @series.allpseuds.collect(&:byline).join(", "), @series.title)
+    @page_subtitle = @series.unrevealed? ? t(".unrevealed_series") : get_page_title(@series.allfandoms.collect(&:name).join(", "), @series.anonymous? ? t(".anonymous") : @series.allpseuds.collect(&:byline).join(", "), @series.title)
     if current_user.respond_to?(:subscriptions)
       @subscription = current_user.subscriptions.where(subscribable_id: @series.id,
                                                        subscribable_type: 'Series').first ||

--- a/app/controllers/series_controller.rb
+++ b/app/controllers/series_controller.rb
@@ -45,7 +45,12 @@ class SeriesController < ApplicationController
     @works = @series.works_in_order.posted.select(&:visible?).paginate(page: params[:page])
 
     # sets the page title with the data for the series
-    @page_subtitle = @series.unrevealed? ? t(".unrevealed_series") : get_page_title(@series.allfandoms.collect(&:name).join(", "), @series.anonymous? ? t(".anonymous") : @series.allpseuds.collect(&:byline).join(", "), @series.title)
+    if @series.unrevealed?
+      @page_subtitle = t(".unrevealed_series")
+    else
+      @page_subtitle = get_page_title(@series.allfandoms.collect(&:name).join(", "), @series.anonymous? ? t(".anonymous") : @series.allpseuds.collect(&:byline).join(", "), @series.title)
+    end
+
     if current_user.respond_to?(:subscriptions)
       @subscription = current_user.subscriptions.where(subscribable_id: @series.id,
                                                        subscribable_type: 'Series').first ||

--- a/config/locales/controllers/en.yml
+++ b/config/locales/controllers/en.yml
@@ -124,6 +124,9 @@ en:
   series:
     index:
       page_title: "%{username} - Series"
+    show:
+      unrevealed_series: Mystery Series
+      anonymous: Anonymous
   tag_wranglings:
     index:
       page_subtitle: fandoms

--- a/config/locales/controllers/en.yml
+++ b/config/locales/controllers/en.yml
@@ -125,8 +125,8 @@ en:
     index:
       page_title: "%{username} - Series"
     show:
-      unrevealed_series: Mystery Series
       anonymous: Anonymous
+      unrevealed_series: Mystery Series
   tag_wranglings:
     index:
       page_subtitle: fandoms

--- a/spec/controllers/series_controller_spec.rb
+++ b/spec/controllers/series_controller_spec.rb
@@ -151,7 +151,6 @@ describe SeriesController do
       create(:serial_work, work: unrevealed_work, series: series)
       get :show, params: { id: series }
       expect(assigns[:page_subtitle]).to eq("Mystery Series")
-
-   end
+    end
   end
 end

--- a/spec/controllers/series_controller_spec.rb
+++ b/spec/controllers/series_controller_spec.rb
@@ -145,7 +145,22 @@ describe SeriesController do
   end
 
   describe "show" do
-    it "assigns page_subtitle for unrevealed series" do
+    it "assigns page title for series" do
+      work = create(:work, fandom_string: "Fandom", authors: [user.default_pseud])
+      create(:serial_work, work: work, series: series)
+      get :show, params: { id: series }
+      expect(assigns[:page_title]).to eq("#{series.title} - #{user.default_pseud.name} - Fandom [#{ArchiveConfig.APP_NAME}]")
+    end
+
+    it "assigns page title for anonymous series" do
+      anonymous_collection = create(:anonymous_collection)
+      anonymous_work = create(:work, fandom_string: "Fandom", collections: [anonymous_collection])
+      create(:serial_work, work: anonymous_work, series: series)
+      get :show, params: { id: series }
+      expect(assigns[:page_title]).to eq("#{series.title} - Anonymous - Fandom [#{ArchiveConfig.APP_NAME}]")
+    end
+
+    it "assigns page subtitle for unrevealed series" do
       unrevealed_collection = create(:unrevealed_collection)
       unrevealed_work = create(:work, collections: [unrevealed_collection])
       create(:serial_work, work: unrevealed_work, series: series)

--- a/spec/controllers/series_controller_spec.rb
+++ b/spec/controllers/series_controller_spec.rb
@@ -143,4 +143,15 @@ describe SeriesController do
       end
     end
   end
+
+  describe "show" do
+    it "assigns page_subtitle for unrevealed series" do
+      unrevealed_collection = create(:unrevealed_collection)
+      unrevealed_work = create(:work, collections: [unrevealed_collection])
+      create(:serial_work, work: unrevealed_work, series: series)
+      get :show, params: { id: series }
+      expect(assigns[:page_subtitle]).to eq("Mystery Series")
+
+   end
+  end
 end


### PR DESCRIPTION
# Pull Request Checklist

<!-- Mark steps in the checklist as complete by changing `[ ]` to `[X]` -->
* [x] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [x] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [x] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [x] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/issues/AO3-6769

## Purpose

The browser page title for a mystery series says “Mystery Series | SITE NAME” instead of just "Mystery Series".

## Testing Instructions

1. Log in
2. Create an unrevealed collection
    a. Browse > Collections
    b. Press “New Collection”
    c. Fill in “Collection name” and “Display title”
    d. Tick the checkbox for “This collection is unrevealed”
    e. Press “Submit”
3. Create a series in the collection
    a. On the collection’s page, press “Post to Collection”
    b. Fill in the required fields in the work form
    c. Tick the checkbox for “This work is part of a series”
    d. Fill in “Or create and use a new one“
    e. Press “Post”
4. Go to the series page 
    a. On the work’s page, follow the link to the series in the work meta (Series: Part 1 of [series link]) 
    b. This will take you to a page with path `/series/{id}`
5. The browser page title says “Mystery Series | SITE NAME”.
