### PR TITLE
AO3-6911 Add error page for Rack::Timeout::RequestTimeoutException

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -28,7 +28,7 @@ class ApplicationController < ActionController::Base
   rescue_from Rack::Timeout::RequestTimeoutException, with: :raise_timeout
   
   def raise_timeout
-    redirect_to '/timeout'
+    redirect_to "/timeout"
   end
 
   helper :all # include all helpers, all the time

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -25,6 +25,12 @@ class ApplicationController < ActionController::Base
     redirect_to '/404'
   end
 
+  rescue_from Rack::Timeout::RequestTimeoutException, with: :raise_timeout
+  
+  def raise_timeout
+    redirect_to '/timeout'
+  end
+
   helper :all # include all helpers, all the time
 
   include HtmlCleaner

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -28,7 +28,7 @@ class ApplicationController < ActionController::Base
   rescue_from Rack::Timeout::RequestTimeoutException, with: :raise_timeout
   
   def raise_timeout
-    redirect_to "/timeout"
+    redirect_to timeout_error_path
   end
 
   helper :all # include all helpers, all the time

--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -6,10 +6,11 @@ class ErrorsController < ApplicationController
   end
 
   def auth_error
-    @page_subtitle = "Auth Error"
+    @page_subtitle = t(".subtitle")
   end
 
   def timeout_error
-    @page_subtitle = "Timeout Error"
+    @page_subtitle = t(".subtitle")
+    render "timeout_error", status: 200, formats: :html
   end
 end

--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -8,4 +8,8 @@ class ErrorsController < ApplicationController
   def auth_error
     @page_subtitle = "Auth Error"
   end
+
+  def timeout_error
+    @page_subtitle = "Timeout Error"
+  end
 end

--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -6,11 +6,11 @@ class ErrorsController < ApplicationController
   end
 
   def auth_error
-    @page_subtitle = t(".subtitle")
+    @page_subtitle = t(".browser_title")
   end
 
   def timeout_error
-    @page_subtitle = t(".subtitle")
-    render "timeout_error", status: 504, formats: :html
+    @page_subtitle = t(".browser_title")
+    render "timeout_error", status: :gateway_timeout
   end
 end

--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -11,6 +11,6 @@ class ErrorsController < ApplicationController
 
   def timeout_error
     @page_subtitle = t(".subtitle")
-    render "timeout_error", status: 200, formats: :html
+    render "timeout_error", status: 504, formats: :html
   end
 end

--- a/app/views/errors/timeout.html.erb
+++ b/app/views/errors/timeout.html.erb
@@ -1,3 +1,0 @@
-<h2 class="heading"><%= t("errors.timeout.title") %></h2>
-<h3 class="heading"><%= t("errors.timeout.subtitle") %></h3>
-<p><%= t("errors.timeout.html", contact_support_link: link_to(ts("contact Support"), new_feedback_report_path)) %></p>

--- a/app/views/errors/timeout.html.erb
+++ b/app/views/errors/timeout.html.erb
@@ -1,2 +1,3 @@
-<h3 class="heading">The page was responding too slowly. Please try again after a few minutes.</h3>
-<p>If you still get this error after a few tries, you can  <%= link_to ts('contact Support'), new_feedback_report_path %>. In the form, please include a link to the page you're trying to reach and what action you are taking.</p>
+<h2 class="heading"><%= t("errors.timeout.title") %></h2>
+<h3 class="heading"><%= t("errors.timeout.subtitle") %></h3>
+<p><%= t("errors.timeout.html", contact_support_link: link_to(ts("contact Support"), new_feedback_report_path)) %></p>

--- a/app/views/errors/timeout.html.erb
+++ b/app/views/errors/timeout.html.erb
@@ -1,0 +1,2 @@
+<h3 class="heading">The page was responding too slowly. Please try again after a few minutes.</h3>
+<p>If you still get this error after a few tries, you can  <%= link_to ts('contact Support'), new_feedback_report_path %>. In the form, please include a link to the page you're trying to reach and what action you are taking.</p>

--- a/app/views/errors/timeout_error.html.erb
+++ b/app/views/errors/timeout_error.html.erb
@@ -1,0 +1,3 @@
+<h2 class="heading"><%= t(".title") %></h2>
+<h3 class="heading"><%= t(".subtitle") %></h3>
+<p><%= t(".html", contact_support_link: link_to(t(".contact_support_link"), new_feedback_report_path)) %></p>

--- a/app/views/errors/timeout_error.html.erb
+++ b/app/views/errors/timeout_error.html.erb
@@ -1,3 +1,3 @@
-<h2 class="heading"><%= t(".title") %></h2>
+<h2 class="heading"><%= t(".page_heading") %></h2>
 <h3 class="heading"><%= t(".subtitle") %></h3>
-<p><%= t(".html", contact_support_link: link_to(t(".contact_support_link"), new_feedback_report_path)) %></p>
+<p><%= t(".html", contact_support_link: link_to(t(".contact_support"), new_feedback_report_path)) %></p>

--- a/config/locales/controllers/en.yml
+++ b/config/locales/controllers/en.yml
@@ -90,6 +90,11 @@ en:
       error: Sorry, that comment could not be unhidden.
       permission_denied: Sorry, you don't have permission to unhide that comment.
       success: Comment successfully unhidden!
+  errors:
+    timeout_error:
+      subtitle: "Timeout Error"
+    auth_error:
+      subtitle: "Authentication Error"
   external_works:
     update:
       successfully_updated: External work was successfully updated.

--- a/config/locales/controllers/en.yml
+++ b/config/locales/controllers/en.yml
@@ -92,9 +92,9 @@ en:
       success: Comment successfully unhidden!
   errors:
     timeout_error:
-      subtitle: "Timeout Error"
+      browser_title: "Timeout Error"
     auth_error:
-      subtitle: "Authentication Error"
+      browser_title: "Auth Error"
   external_works:
     update:
       successfully_updated: External work was successfully updated.

--- a/config/locales/controllers/en.yml
+++ b/config/locales/controllers/en.yml
@@ -91,10 +91,10 @@ en:
       permission_denied: Sorry, you don't have permission to unhide that comment.
       success: Comment successfully unhidden!
   errors:
-    timeout_error:
-      browser_title: "Timeout Error"
     auth_error:
-      browser_title: "Auth Error"
+      browser_title: Auth Error
+    timeout_error:
+      browser_title: Timeout Error
   external_works:
     update:
       successfully_updated: External work was successfully updated.

--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -613,10 +613,10 @@ en:
         unrevealed: A translation of a work in an unrevealed collection
   errors:
     timeout_error:
+      contact_support: contact Support
+      html: If you still get this error after a few tries, you can %{contact_support_link}.
       page_heading: Timeout Error
       subtitle: The page was responding too slowly. Please try again after a few minutes.
-      html: If you still get this error after a few tries, you can %{contact_support_link}.
-      contact_support: contact Support
   feedbacks:
     new:
       abuse:

--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -611,6 +611,11 @@ en:
         restricted_html: A translation of [Restricted Work] by %{creator_link}
         revealed_html: A translation of %{work_link} by %{creator_link}
         unrevealed: A translation of a work in an unrevealed collection
+  errors:
+    timeout:
+      title: Timeout
+      subtitle: The page was responding too slowly. Please try again after a few minutes.
+      html: If you still get this error after a few tries, please %{contact_support_link}.
   feedbacks:
     new:
       abuse:

--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -613,10 +613,10 @@ en:
         unrevealed: A translation of a work in an unrevealed collection
   errors:
     timeout_error:
-      title: Timeout
+      page_heading: Timeout Error
       subtitle: The page was responding too slowly. Please try again after a few minutes.
-      html: If you still get this error after a few tries, please %{contact_support_link}.
-      contact_support_link: contact Support
+      html: If you still get this error after a few tries, you can %{contact_support_link}.
+      contact_support: contact Support
   feedbacks:
     new:
       abuse:

--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -612,10 +612,11 @@ en:
         revealed_html: A translation of %{work_link} by %{creator_link}
         unrevealed: A translation of a work in an unrevealed collection
   errors:
-    timeout:
+    timeout_error:
       title: Timeout
       subtitle: The page was responding too slowly. Please try again after a few minutes.
       html: If you still get this error after a few tries, please %{contact_support_link}.
+      contact_support_link: contact Support
   feedbacks:
     new:
       abuse:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -53,6 +53,7 @@ Rails.application.routes.draw do
   get '/422', to: 'errors#422'
   get '/500', to: 'errors#500'
   get '/auth_error', to: 'errors#auth_error'
+  get '/timeout', to: 'errors#timeout'
 
   #### DOWNLOADS ####
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -53,7 +53,7 @@ Rails.application.routes.draw do
   get '/422', to: 'errors#422'
   get '/500', to: 'errors#500'
   get '/auth_error', to: 'errors#auth_error'
-  get '/timeout', to: 'errors#timeout'
+  get "/timeout", to: "errors#timeout"
 
   #### DOWNLOADS ####
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -53,7 +53,7 @@ Rails.application.routes.draw do
   get '/422', to: 'errors#422'
   get '/500', to: 'errors#500'
   get '/auth_error', to: 'errors#auth_error'
-  get "/timeout", to: "errors#timeout"
+  get "/timeout_error", to: "errors#timeout_error"
 
   #### DOWNLOADS ####
 

--- a/spec/controllers/errors_controller_spec.rb
+++ b/spec/controllers/errors_controller_spec.rb
@@ -40,7 +40,7 @@ describe ErrorsController do
   describe "GET #timeout_error" do
     it "returns an HTML timeout error page" do
       get :timeout_error
-      expect(response.status).to eq(200)
+      expect(response.status).to eq(504)
       expect(response.header["Content-Type"]).to eq("text/html; charset=utf-8")
     end
   end

--- a/spec/controllers/errors_controller_spec.rb
+++ b/spec/controllers/errors_controller_spec.rb
@@ -29,7 +29,7 @@ describe ErrorsController do
     end
   end
 
-  describe "auth_error" do
+  describe "GET #auth_error" do
     it "returns an HTML auth error page" do
       get :auth_error
       expect(response.status).to eq(200)

--- a/spec/controllers/errors_controller_spec.rb
+++ b/spec/controllers/errors_controller_spec.rb
@@ -28,4 +28,20 @@ describe ErrorsController do
       expect(response.header["Content-Type"]).to eq("text/html; charset=utf-8")
     end
   end
+
+  describe "auth_error" do
+    it "returns an HTML auth error page" do
+      get :auth_error
+      expect(response.status).to eq(200)
+      expect(response.header["Content-Type"]).to eq("text/html; charset=utf-8")
+    end
+  end
+
+  describe "timeout" do
+    it "returns an HTML timeout error page" do
+      get :timeout
+      expect(response.status).to eq(200)
+      expect(response.header["Content-Type"]).to eq("text/html; charset=utf-8")
+    end
+  end
 end

--- a/spec/controllers/errors_controller_spec.rb
+++ b/spec/controllers/errors_controller_spec.rb
@@ -37,9 +37,9 @@ describe ErrorsController do
     end
   end
 
-  describe "timeout" do
+  describe "GET #timeout_error" do
     it "returns an HTML timeout error page" do
-      get :timeout
+      get :timeout_error
       expect(response.status).to eq(200)
       expect(response.header["Content-Type"]).to eq("text/html; charset=utf-8")
     end


### PR DESCRIPTION


# Pull Request Checklist

<!-- Mark steps in the checklist as complete by changing `[ ]` to `[X]` -->
* [x] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [x] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [x] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [x] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-6911 

## Purpose

1. Add a page under `/timeout` that is returned should the app controller encounter `Rack::Timeout::RequestTimeoutException`. 
2. Added a test that the page is rendered on that route.
3. Added a test that the `auth_error` page is rendered on its route to `errors_controller_spec.rb`

## Testing Instructions
*Needs Systems change*, see story for details

I added a unit test that this page can be routed too, but I do not think there is a way to test the actual timeout rescue except from an integration test. [See the docs here.](https://github.com/zombocom/rack-timeout/blob/main/doc/exceptions.md) If I'm missing something or if we have a method for setting up such tests already that someone could point me too it would be much appreciated.

## Credit

unsafe-deref, he/him
