### PR TITLE
AO3-6737 Bookmark blurbs should be full width on Low Vision Default

### DIFF
--- a/public/stylesheets/masters/low_vision_default/low_vision_default_site_screen_.css
+++ b/public/stylesheets/masters/low_vision_default/low_vision_default_site_screen_.css
@@ -28,7 +28,8 @@ form blockquote.userstuff {
 .alphabet .listbox li,
 .media .listbox,
 .works-index .index,
-.collections-index .index {
+.collections-index .index,
+.bookmarks-index .index {
   float: none;
   width: auto;
   max-width: 100%;


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6737

## Purpose

Fixes the display of bookmark blurbs on filterable index pages, so they are 100% rather than 75%.

## Testing Instructions

Note that a superadmin needs to copy this CSS into Low Vision Default and Systems needs to recache the skins.

1. Log in
2. Choose "Low Vision Default" from the list of skins in the footer
3. Go to a page that would usually show bookmarks with filters, like https://test.archiveofourown.org/users/USERNAME/bookmarks
4. Verify the blurbs take up about 100% of their allotted width rather than 75%

## References

- [Comment with screenshot of the issue](https://otwarchive.atlassian.net/browse/AO3-6737?focusedCommentId=362781) 
- [Comment with explanation of the issue](https://otwarchive.atlassian.net/browse/AO3-6737?focusedCommentId=362785)

