### PR TITLE
AO3-6401 Prevent official user accounts from leaving kudos

### DIFF
--- a/app/models/kudo.rb
+++ b/app/models/kudo.rb
@@ -46,6 +46,13 @@ class Kudo < ApplicationRecord
             uniqueness: { scope: [:commentable_id, :commentable_type] },
             if: proc { |kudo| kudo.user.present? }
 
+  validate :cannot_be_official_user, on: :create
+  def cannot_be_official_user
+    return unless user&.official
+
+    errors.add(:user, :official)
+  end
+
   scope :with_user, -> { where("user_id IS NOT NULL") }
   scope :by_guest, -> { where("user_id IS NULL") }
 

--- a/config/locales/models/en.yml
+++ b/config/locales/models/en.yml
@@ -122,6 +122,7 @@ en:
               inclusion: What did you want to leave kudos on?
             user:
               blocked: Sorry, you have been blocked by one or more of this work's creators.
+              official: Please log out of your official account!
           format: "%{message}"
           taken: You have already left kudos here. :)
         mute:

--- a/features/comments_and_kudos/kudos.feature
+++ b/features/comments_and_kudos/kudos.feature
@@ -222,8 +222,16 @@ Feature: Kudos
       And I view the work "Interesting beans"
     Then I should not see "newusername1 left kudos on this work!"
 
-  Scenario: Cannot leave kudos (no button) while logged as admin
+  Scenario: Cannot leave kudos (no button) while logged in as admin
     Given I am logged in as an admin
       And I view the work "Awesome Story"
     Then I should see "Awesome Story"
       And I should not see a "Kudos ♥" button
+
+  @javascript
+  Scenario: Cannot leave kudos while logged in as a user with the official role
+    Given the user "clicker" exists and has the role "official"
+      And I am logged in as "clicker"
+    When I view the work "Awesome Story"
+      And I press "Kudos ♥"
+    Then I should see "Please log out of your official account!"

--- a/lib/tasks/after_tasks.rake
+++ b/lib/tasks/after_tasks.rake
@@ -521,13 +521,14 @@ namespace :After do
   desc "Convert user kudos from users with the official role to guest kudos"
   task(convert_official_kudos: :environment) do
     official_role = Role.find_by(name: "official")
-    official_users = RolesUser.where(role_id: official_role.id).map(&:user) unless official_role.blank?
+    official_users = RolesUser.where(role_id: official_role.id).map(&:user) if official_role.present?
     if official_role.blank? || official_users.blank?
       puts "No official users found"
     else
       official_users.each do |user|
         kudos = user.kudos
-        next unless kudos.present?
+        next if kudos.blank?
+
         puts "Updating #{kudos.size} kudos from #{user.login}"
         user.kudos.each do |kudo|
           kudo.update_attribute(:user_id, nil)

--- a/lib/tasks/after_tasks.rake
+++ b/lib/tasks/after_tasks.rake
@@ -530,7 +530,6 @@ namespace :After do
 
         puts "Updating #{kudos.size} kudos from #{user.login}"
         user.remove_user_from_kudos
-        end
       end
 
       puts "Finished converting kudos from official users to guest kudos"

--- a/lib/tasks/after_tasks.rake
+++ b/lib/tasks/after_tasks.rake
@@ -520,9 +520,8 @@ namespace :After do
 
   desc "Convert user kudos from users with the official role to guest kudos"
   task(convert_official_kudos: :environment) do
-    official_role = Role.find_by(name: "official")
-    official_users = RolesUser.where(role_id: official_role.id).map(&:user) if official_role.present?
-    if official_role.blank? || official_users.blank?
+    official_users = Role.find_by(name: "official")&.users
+    if official_users.blank?
       puts "No official users found"
     else
       official_users.each do |user|
@@ -530,8 +529,7 @@ namespace :After do
         next if kudos.blank?
 
         puts "Updating #{kudos.size} kudos from #{user.login}"
-        user.kudos.each do |kudo|
-          kudo.update_attribute(:user_id, nil)
+        user.remove_user_from_kudos
         end
       end
 

--- a/lib/tasks/after_tasks.rake
+++ b/lib/tasks/after_tasks.rake
@@ -517,5 +517,25 @@ namespace :After do
 
     puts "Finished reindexing tags on hidden and unrevealed works"
   end
+
+  desc "Convert user kudos from users with the official role to guest kudos"
+  task(convert_official_kudos: :environment) do
+    official_role = Role.find_by(name: "official")
+    official_users = RolesUser.where(role_id: official_role.id).map(&:user) unless official_role.blank?
+    if official_role.blank? || official_users.blank?
+      puts "No official users found"
+    else
+      official_users.each do |user|
+        kudos = user.kudos
+        next unless kudos.present?
+        puts "Updating #{kudos.size} kudos from #{user.login}"
+        user.kudos.each do |kudo|
+          kudo.update_attribute(:user_id, nil)
+        end
+      end
+
+      puts "Finished converting kudos from official users to guest kudos"
+    end
+  end
   # This is the end that you have to put new tasks above.
 end

--- a/spec/models/kudo_spec.rb
+++ b/spec/models/kudo_spec.rb
@@ -26,6 +26,16 @@ describe Kudo do
           expect(new_kudo.errors).to be_empty
         end
       end
+
+      context "when user has official role" do
+        let(:user) { create(:official_user) }
+        let(:kudo) { build(:kudo, user: user) }
+
+        it "does not save" do
+          expect(kudo.save).to be_falsy
+          expect(kudo.errors[:user].first).to include("Please log out of your official account!")
+        end
+      end
     end
 
     context "for a guest kudos giver" do


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6401

## Purpose

Adds an error message if you're logged in with your official account and try to leave kudos. Also adds a task to clean up any kudos from existing official accounts.

Note: There are only 22 official accounts and I'm sure very few, if any, kudos from them, so I wasn't overly concerned with batching or performance for the task.

## Testing Instructions

Refer to Jira.

