### PR TITLE
AO3-6737 Make index clear nav in Low Vision Default when no landmark is present

### DIFF
--- a/public/stylesheets/masters/low_vision_default/low_vision_default_site_screen_.css
+++ b/public/stylesheets/masters/low_vision_default/low_vision_default_site_screen_.css
@@ -69,6 +69,10 @@ form blockquote.userstuff {
   border: 2px solid;
 }
 
+ul.navigation + .index {
+  clear: both;
+}
+
 li.blurb,
 .group {
   visibility: visible;


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6737

## Purpose

If there's no landmark heading between the floated subnavigation and the index of blurbs, the blurbs get a bit squished off to the left. This lets them extend to the right.

## Testing Instructions

1. Log in
2. Apply Low Vision Default skin 
3. Go to a work
4. Bookmark the work

On the page you see after bookmarking the work, the blurb should no longer have a gap on the right the approximate width of the “My Bookmarks” button

