### PR TITLE
AO3-6544 Send comment_type and user_role to spam checker for tickets and comments

### DIFF
--- a/app/models/abuse_report.rb
+++ b/app/models/abuse_report.rb
@@ -26,11 +26,15 @@ class AbuseReport < ApplicationRecord
 
   def akismet_attributes
     name = username ? username : ""
+    # If the user is logged in and we're sending info to Akismet, we can assume
+    # the email does not match.
+    role = User.current_user.present? ? "user-with-nonmatching-email" : "guest"
     {
       comment_type: "contact-form",
       key: ArchiveConfig.AKISMET_KEY,
       blog: ArchiveConfig.AKISMET_NAME,
       user_ip: ip_address,
+      user_role: role,
       comment_author: name,
       comment_author_email: email,
       comment_content: comment

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -93,7 +93,12 @@ class Comment < ApplicationRecord
   has_comment_methods
 
   def akismet_attributes
+    # While we do have tag comments, those are from logged-in users with special
+    # access granted by admins, so we never spam check them, unlike comments on
+    # works or admin posts.
+    comment_type = ultimate_parent.is_a?(Work) ? "fanwork-comment" : "comment"
     {
+      comment_type: comment_type,
       key: ArchiveConfig.AKISMET_KEY,
       blog: ArchiveConfig.AKISMET_NAME,
       user_ip: ip_address,

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -98,6 +98,7 @@ class Comment < ApplicationRecord
       blog: ArchiveConfig.AKISMET_NAME,
       user_ip: ip_address,
       user_agent: user_agent,
+      user_role: "guest",
       comment_author: name,
       comment_author_email: email,
       comment_content: comment_content

--- a/app/models/feedback.rb
+++ b/app/models/feedback.rb
@@ -23,11 +23,16 @@ class Feedback < ApplicationRecord
   end
 
   def akismet_attributes
+    # If the user is logged in and we're sending info to Akismet, we can assume
+    # the email does not match.
+    role = User.current_user.present? ? "user-with-nonmatching-email" : "guest"
     {
+      comment_type: "contact-form",
       key: ArchiveConfig.AKISMET_KEY,
       blog: ArchiveConfig.AKISMET_NAME,
       user_ip: ip_address,
       user_agent: user_agent,
+      user_role: role,
       comment_author_email: email,
       comment_content: comment
     }

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -1098,6 +1098,7 @@ class Work < ApplicationRecord
       key: ArchiveConfig.AKISMET_KEY,
       blog: ArchiveConfig.AKISMET_NAME,
       user_ip: ip_address,
+      user_role: "user",
       comment_date_gmt: created_at.to_time.iso8601,
       blog_lang: language.short,
       comment_author: user.login,

--- a/spec/models/abuse_report_spec.rb
+++ b/spec/models/abuse_report_spec.rb
@@ -353,6 +353,23 @@ describe AbuseReport do
     end
   end
 
+  context "when report is submitted to Akismet" do
+    let(:report) { build(:abuse_report) }
+
+    it "has comment_type \"contact-form\"" do
+      expect(report.akismet_attributes[:comment_type]).to eq("contact-form")
+    end
+
+    it "has user_role \"user-with-nonmatching-email\" when reporter is logged in" do
+      User.current_user = create(:user)
+      expect(report.akismet_attributes[:user_role]).to eq("user-with-nonmatching-email")
+    end
+
+    it "has user_role \"guest\" when reporter is logged out" do
+      expect(report.akismet_attributes[:user_role]).to eq("guest")
+    end
+  end
+
   describe "#attach_work_download" do
     include ActiveJob::TestHelper
 

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -28,6 +28,14 @@ describe Comment do
           .to raise_error(ActiveRecord::RecordNotFound)
       end
     end
+
+    context "when submitting comment to Akismet" do
+      subject { build(:comment) }
+
+      it "has user_role \"guest\"" do
+        expect(subject.akismet_attributes[:user_role]).to eq("guest")
+      end
+    end
   end
 
   context "with an existing comment from the same user" do

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -30,10 +30,42 @@ describe Comment do
     end
 
     context "when submitting comment to Akismet" do
-      subject { build(:comment) }
+      subject { create(:comment) }
 
       it "has user_role \"guest\"" do
         expect(subject.akismet_attributes[:user_role]).to eq("guest")
+      end
+
+      context "when the commentable is a chapter" do
+        it "has comment_type \"fanwork-comment\"" do
+          expect(subject.akismet_attributes[:comment_type]).to eq("fanwork-comment")
+        end
+      end
+
+      context "when the commentable is an admin post" do
+        subject { create(:comment, :on_admin_post) }
+
+        it "has comment_type \"comment\"" do
+          expect(subject.akismet_attributes[:comment_type]).to eq("comment")
+        end
+      end
+
+      context "when the commentable is a comment" do
+        context "when the comment is on a chapter" do
+          subject { create(:comment, commentable: create(:comment)) }
+
+          it "has comment_type \"fanwork-comment\"" do
+            expect(subject.akismet_attributes[:comment_type]).to eq("fanwork-comment")
+          end
+        end
+
+        context "when the comment is on an admin post" do
+          subject { create(:comment, commentable: create(:comment, :on_admin_post)) }
+
+          it "has comment_type \"comment\"" do
+            expect(subject.akismet_attributes[:comment_type]).to eq("comment")
+          end
+        end
       end
     end
   end

--- a/spec/models/feedback_spec.rb
+++ b/spec/models/feedback_spec.rb
@@ -83,4 +83,21 @@ describe Feedback do
       expect(safe_report.save).to be_truthy
     end
   end
+
+  context "when report is submitted to Akismet" do
+    let(:report) { build(:feedback) }
+
+    it "has comment_type \"contact-form\"" do
+      expect(report.akismet_attributes[:comment_type]).to eq("contact-form")
+    end
+
+    it "has user_role \"user-with-nonmatching-email\" when reporter is logged in" do
+      User.current_user = create(:user)
+      expect(report.akismet_attributes[:user_role]).to eq("user-with-nonmatching-email")
+    end
+
+    it "has user_role \"guest\" when reporter is logged out" do
+      expect(report.akismet_attributes[:user_role]).to eq("guest")
+    end
+  end
 end


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6544

## Purpose

Lets the spam checker know if it's checking 
- content from a guest or (on the Suport and PAC contact forms) someone who is logged in but has entered an email address that isn't the one on their account
- content from a contact form, blog (admin post) comment, or fanwork comment (as opposed to a fanwork)

## Testing Instructions

Refer to Jira

## References

* [Akismet comment check docs](https://akismet.com/developers/detailed-docs/comment-check/)
* A June 21, 2023 email discussion with the Akismet devs saying this would be nice to eventually have

