### PR TITLE
AO3-6737 Add padding to bookmarker module

### DIFF
--- a/public/stylesheets/masters/low_vision_default/low_vision_default_site_screen_.css
+++ b/public/stylesheets/masters/low_vision_default/low_vision_default_site_screen_.css
@@ -78,7 +78,8 @@ li.blurb,
   visibility: visible;
 }
 
-li.blurb {
+li.blurb,
+.bookmark div.user {
   padding: 3%;
 }
 
@@ -174,6 +175,10 @@ pre {
 #header .dropdown .menu a:focus {
   background: #ccc;
   color: #111;
+}
+
+.bookmark div.user {
+  box-sizing: border-box;
 }
 
 .bookmark .recent,


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6737

## Purpose

Adds padding to the bookmarker module as long as we're examining its faults.

## Testing Instructions

Make a bookmark. Look at it. There should be white space around its content, keeping it far-ish from the border. It should look okay in a variety of window sizes.

## References

The box sizing and padding usually comes from the default blurb stylesheet, which we drop for Low Vision Default. 
