### PR TITLE
AO3-6913 AO3-6597 Allow queue to send invitations every N hours

### DIFF
--- a/.erb-lint.yml
+++ b/.erb-lint.yml
@@ -10,6 +10,8 @@ linters:
     rule_set:
       - deprecated: ["bookmarks", "collections", "readings", "works"]
         suggestion: "Avoid the plural form of these classes."
+  RequireInputAutocomplete:
+    enabled: false
   Rubocop:
     enabled: true
     rubocop_config:

--- a/app/controllers/invite_requests_controller.rb
+++ b/app/controllers/invite_requests_controller.rb
@@ -48,8 +48,9 @@ class InviteRequestsController < ApplicationController
   # POST /invite_requests
   def create
     unless AdminSetting.current.invite_from_queue_enabled?
-      flash[:error] = ts("<strong>New invitation requests are currently closed.</strong> For more information, please check the %{news}.",
-                         news: view_context.link_to("\"Invitations\" tag on AO3 News", admin_posts_path(tag: 143))).html_safe
+      flash[:error] = t("invite_requests.create.queue_disabled.html",
+                        closed_bold: helpers.tag.strong(t("invite_requests.create.queue_disabled.closed")),
+                        news_link: helpers.link_to(t("invite_requests.create.queue_disabled.news"), admin_posts_path(tag: 143)))
       redirect_to invite_requests_path
       return
     end
@@ -57,7 +58,9 @@ class InviteRequestsController < ApplicationController
     @invite_request = InviteRequest.new(invite_request_params)
     @invite_request.ip_address = request.remote_ip
     if @invite_request.save
-      flash[:notice] = "You've been added to our queue! Yay! We estimate that you'll receive an invitation around #{@invite_request.proposed_fill_date}. We strongly recommend that you add do-not-reply@archiveofourown.org to your address book to prevent the invitation email from getting blocked as spam by your email provider."
+      flash[:notice] = t("invite_requests.create.success",
+                         date: l(@invite_request.proposed_fill_time.to_date, format: :long),
+                         return_address: ArchiveConfig.RETURN_ADDRESS)
       redirect_to invite_requests_path
     else
       render action: :index
@@ -108,7 +111,7 @@ class InviteRequestsController < ApplicationController
   end
 
   def status
-    @page_subtitle = ts("Invitation Request Status")
+    @page_subtitle = t(".browser_title")
   end
 
   private

--- a/app/controllers/invite_requests_controller.rb
+++ b/app/controllers/invite_requests_controller.rb
@@ -48,7 +48,7 @@ class InviteRequestsController < ApplicationController
   # POST /invite_requests
   def create
     unless AdminSetting.current.invite_from_queue_enabled?
-      flash[:error] = t("invite_requests.create.queue_disabled.html",
+      flash[:error] = t(".queue_disabled.html",
                         closed_bold: helpers.tag.strong(t("invite_requests.create.queue_disabled.closed")),
                         news_link: helpers.link_to(t("invite_requests.create.queue_disabled.news"), admin_posts_path(tag: 143)))
       redirect_to invite_requests_path
@@ -58,7 +58,7 @@ class InviteRequestsController < ApplicationController
     @invite_request = InviteRequest.new(invite_request_params)
     @invite_request.ip_address = request.remote_ip
     if @invite_request.save
-      flash[:notice] = t("invite_requests.create.success",
+      flash[:notice] = t(".success",
                          date: l(@invite_request.proposed_fill_time.to_date, format: :long),
                          return_address: ArchiveConfig.RETURN_ADDRESS)
       redirect_to invite_requests_path

--- a/app/models/admin_setting.rb
+++ b/app/models/admin_setting.rb
@@ -55,7 +55,7 @@ class AdminSetting < ApplicationRecord
 
   # run hourly with the resque scheduler
   def self.check_queue
-    return unless self.invite_from_queue_enabled? && InviteRequest.count.positive? && Time.current >= self.invite_from_queue_at
+    return unless self.invite_from_queue_enabled? && InviteRequest.any? && Time.current >= self.invite_from_queue_at
 
     new_time = Time.current + self.invite_from_queue_frequency.hours
     self.first.update_attribute(:invite_from_queue_at, new_time)

--- a/app/models/admin_setting.rb
+++ b/app/models/admin_setting.rb
@@ -55,12 +55,10 @@ class AdminSetting < ApplicationRecord
 
   # run hourly with the resque scheduler
   def self.check_queue
-    if self.invite_from_queue_enabled? && InviteRequest.count > 0
-      if Time.current >= self.invite_from_queue_at
-        new_time = Time.current + self.invite_from_queue_frequency.hours
-        self.first.update_attribute(:invite_from_queue_at, new_time)
-        InviteFromQueueJob.perform_now(count: invite_from_queue_number)
-      end
+    if self.invite_from_queue_enabled? && InviteRequest.count > 0 && Time.current >= self.invite_from_queue_at
+      new_time = Time.current + self.invite_from_queue_frequency.hours
+      self.first.update_attribute(:invite_from_queue_at, new_time)
+      InviteFromQueueJob.perform_now(count: invite_from_queue_number)
     end
   end
 

--- a/app/models/admin_setting.rb
+++ b/app/models/admin_setting.rb
@@ -53,12 +53,12 @@ class AdminSetting < ApplicationRecord
     delegate :default_skin, to: :current
   end
 
-  # run once a day from cron
+  # run hourly with the resque scheduler
   def self.check_queue
     if self.invite_from_queue_enabled? && InviteRequest.count > 0
-      if Date.today >= self.invite_from_queue_at.to_date
-        new_date = Time.now + self.invite_from_queue_frequency.days
-        self.first.update_attribute(:invite_from_queue_at, new_date)
+      if Time.current >= self.invite_from_queue_at
+        new_time = Time.current + self.invite_from_queue_frequency.hours
+        self.first.update_attribute(:invite_from_queue_at, new_time)
         InviteFromQueueJob.perform_now(count: invite_from_queue_number)
       end
     end
@@ -96,7 +96,7 @@ class AdminSetting < ApplicationRecord
 
   def update_invite_date
     if self.invite_from_queue_frequency_changed?
-      self.invite_from_queue_at = Time.now + self.invite_from_queue_frequency.days
+      self.invite_from_queue_at = Time.current + self.invite_from_queue_frequency.hours
     end
   end
 end

--- a/app/models/admin_setting.rb
+++ b/app/models/admin_setting.rb
@@ -55,11 +55,11 @@ class AdminSetting < ApplicationRecord
 
   # run hourly with the resque scheduler
   def self.check_queue
-    if self.invite_from_queue_enabled? && InviteRequest.count > 0 && Time.current >= self.invite_from_queue_at
-      new_time = Time.current + self.invite_from_queue_frequency.hours
-      self.first.update_attribute(:invite_from_queue_at, new_time)
-      InviteFromQueueJob.perform_now(count: invite_from_queue_number)
-    end
+    return unless self.invite_from_queue_enabled? && InviteRequest.count.positive? && Time.current >= self.invite_from_queue_at
+
+    new_time = Time.current + self.invite_from_queue_frequency.hours
+    self.first.update_attribute(:invite_from_queue_at, new_time)
+    InviteFromQueueJob.perform_now(count: invite_from_queue_number)
   end
 
   @queue = :admin

--- a/app/models/invite_request.rb
+++ b/app/models/invite_request.rb
@@ -21,11 +21,11 @@ class InviteRequest < ApplicationRecord
     end
   end
 
-  def proposed_fill_date
+  def proposed_fill_time
     admin_settings = AdminSetting.current
     number_of_rounds = (self.position.to_f/admin_settings.invite_from_queue_number.to_f).ceil - 1
-    proposed_date = admin_settings.invite_from_queue_at.to_date + (admin_settings.invite_from_queue_frequency * number_of_rounds).days
-    Date.today > proposed_date ? Date.today : proposed_date
+    proposed_time = admin_settings.invite_from_queue_at + (admin_settings.invite_from_queue_frequency * number_of_rounds).hours
+    Time.current > proposed_time ? Time.current : proposed_time
   end
 
   def position

--- a/app/views/admin/admin_invitations/index.html.erb
+++ b/app/views/admin/admin_invitations/index.html.erb
@@ -41,6 +41,7 @@
       <dd><%= select_tag "invitation[user_group]", "<option>All</option><option>With no unused invitations</option>".html_safe %></dd>
       <dt class="landmark"><%= t(".grant_to_users.submit_landmark") %></dt>
       <dd class="submit actions"><%= submit_tag t(".grant_to_users.submit") %></dd>
+    </dl>
   </fieldset>
 <% end %>
 

--- a/app/views/admin/admin_invitations/index.html.erb
+++ b/app/views/admin/admin_invitations/index.html.erb
@@ -10,52 +10,52 @@
 </ul>
 <!--/subnav-->
 <!--main content-->
-<%= form_tag  url_for(:controller => 'admin/admin_invitations', :action => :create) do |f| %>
+<%= form_tag url_for(controller: "admin/admin_invitations", action: :create) do %>
   <fieldset class="simple">
-    <h3 class="heading">Send to email</h3>
-    <p>Send an invite code to the following email address:
-      <%= text_field_tag "invitation[invitee_email]", (@invitation.try(:invitee_email) || ""), :title => ts("invite by email") %>
-      <span class="submit actions"><%= submit_tag ts('Invite user')  %></span>
+    <h3 class="heading"><%= t(".send_to_email.title") %></h3>
+    <p><%= t(".send_to_email.send_code_to_email") %>
+      <%= text_field_tag "invitation[invitee_email]", (@invitation.try(:invitee_email) || "") %>
+      <span class="submit actions"><%= submit_tag t(".send_to_email.submit") %></span>
     </p>
   </fieldset>
 <% end %>
 
-<%= form_tag url_for(:controller => 'admin/admin_invitations', :action => 'invite_from_queue') do %>
+<%= form_tag url_for(controller: "admin/admin_invitations", action: "invite_from_queue") do %>
   <fieldset class="simple">
-    <h3 class="heading">Send invite codes to people in our <%= link_to 'invitations queue', invite_requests_path %></h3>
-    <p>There are <%= InviteRequest.count %> requests in the queue.</p>
+    <h3 class="heading"><%= t(".send_to_queue.title_html", invitations_queue_link: link_to(t(".send_to_queue.invitations_queue"), invite_requests_path)) %></h3>
+    <p><%= t(".send_to_queue.current_request_count", count: InviteRequest.count) %></p>
     <p>
-      <%= label_tag "invitation[invite_from_queue]", ts('Number of people to invite') %>: <%= text_field_tag "invitation[invite_from_queue]" %>
-      <span class="submit actions"><%= submit_tag ts('Invite from queue')  %></span>
+      <%= label_tag "invitation[invite_from_queue]", t(".send_to_queue.invite_number") %> <%= text_field_tag "invitation[invite_from_queue]" %>
+      <span class="submit actions"><%= submit_tag t(".send_to_queue.submit") %></span>
     </p>
   </fieldset>
 <% end %>
 
-<%= form_tag  url_for(:controller => 'admin/admin_invitations', :action => 'grant_invites_to_users') do  %>
+<%= form_tag url_for(controller: "admin/admin_invitations", action: "grant_invites_to_users") do %>
   <fieldset>
-    <h3 class="heading"><%=h 'Give invite codes to current users' %></h3>
+    <h3 class="heading"><%= t(".grant_to_users.title") %></h3>
     <dl>
-      <dt><%= label_tag "invitation[number_of_invites]", ts('Number of invitations') %>:</dt>
+      <dt><%= label_tag "invitation[number_of_invites]", t(".grant_to_users.amount") %></dt>
       <dd><%= text_field_tag "invitation[number_of_invites]" %></dd>
-      <dt><%= label_tag "invitation[user_group]", ts('Users') %>:</dt>
-      <dd><%= select_tag "invitation[user_group]", "<option>All</option><option>With no unused invitations</option>".html_safe  %></dd>
-      <dt class="landmark">Submit</dt>
-      <dd class="submit actions"><%= submit_tag "Generate invitations" %></dd>
+      <dt><%= label_tag "invitation[user_group]", t(".grant_to_users.user_type") %></dt>
+      <dd><%= select_tag "invitation[user_group]", "<option>All</option><option>With no unused invitations</option>".html_safe %></dd>
+      <dt class="landmark"><%= t(".grant_to_users.submit_landmark") %></dt>
+      <dd class="submit actions"><%= submit_tag t(".grant_to_users.submit") %></dd>
   </fieldset>
 <% end %>
 
-<%= form_tag  url_for(:controller => 'admin/admin_invitations', :action => 'find'), :method => :get do  %>
+<%= form_tag url_for(controller: "admin/admin_invitations", action: "find"), method: :get do %>
   <fieldset>
-    <h3 class="heading"><%=h 'Track invitations' %></h3>
+    <h3 class="heading"><%= t(".track_invitations.title") %></h3>
     <dl>
-      <dt><%= label_tag "invitation[user_name]", ts('Enter a user name') %>:</dt>
-      <dd><%= text_field_tag "invitation[user_name]"  %></dd>
-      <dt><%= label_tag "invitation[token]", ts('Enter an invite token') %>:</dt>
-      <dd><%= text_field_tag "invitation[token]"  %></dd>
-      <dt><%= label_tag "track_invitation_invitee_email", t(".email") %>:</dt>
+      <dt><%= label_tag "invitation[user_name]", t(".track_invitations.user_name") %></dt>
+      <dd><%= text_field_tag "invitation[user_name]" %></dd>
+      <dt><%= label_tag "invitation[token]", t(".track_invitations.invite_token") %></dt>
+      <dd><%= text_field_tag "invitation[token]" %></dd>
+      <dt><%= label_tag "track_invitation_invitee_email", t(".track_invitations.email") %></dt>
       <dd><%= text_field_tag "invitation[invitee_email]", nil, id: "track_invitation_invitee_email" %></dd>
-      <dt class="landmark">Submit</dt>
-      <dd class="submit actions"><%= submit_tag "Go" %></dd>
+      <dt class="landmark"><%= t(".track_invitations.submit_landmark") %></dt>
+      <dd class="submit actions"><%= submit_tag t(".track_invitations.submit") %></dd>
     </dl>
   </fieldset>
 <% end %>

--- a/app/views/admin/admin_invitations/index.html.erb
+++ b/app/views/admin/admin_invitations/index.html.erb
@@ -16,8 +16,8 @@
     <p>
       <%= t(".send_to_email.description") %>
       <%= text_field_tag "invitation[invitee_email]",
-                         (@invitation.try(:invitee_email) || ""),
-                         title: t(".send_to_email.invite_by_email_title") %>
+            (@invitation.try(:invitee_email) || ""),
+            title: t(".send_to_email.invite_by_email_title") %>
       <span class="submit actions"><%= submit_tag t(".send_to_email.invite_user") %></span>
     </p>
   </fieldset>
@@ -47,8 +47,8 @@
       <dt><%= label_tag "invitation[user_group]", t(".grant_invites.users") %></dt>
       <dd>
         <%= select_tag "invitation[user_group]",
-                       options_for_select([t(".grant_invites.all"), t(".grant_invites.with_no_unused")],
-                                          t(".grant_invites.all")) %>
+              options_for_select([t(".grant_invites.all"), t(".grant_invites.with_no_unused")],
+                t(".grant_invites.all")) %>
       </dd>
       <dt class="landmark"><%= t(".grant_invites.landmark_submit") %></dt>
       <dd class="submit actions"><%= submit_tag t(".grant_invites.generate_invitations") %></dd>

--- a/app/views/admin/admin_invitations/index.html.erb
+++ b/app/views/admin/admin_invitations/index.html.erb
@@ -10,53 +10,64 @@
 </ul>
 <!--/subnav-->
 <!--main content-->
-<%= form_tag url_for(controller: "admin/admin_invitations", action: :create) do %>
+<%= form_tag url_for(controller: "admin/admin_invitations", action: :create), class: "invitation simple post", autocomplete: "off" do %>
   <fieldset class="simple">
-    <h3 class="heading"><%= t(".send_to_email.title") %></h3>
-    <p><%= t(".send_to_email.send_code_to_email") %>
-      <%= text_field_tag "invitation[invitee_email]", (@invitation.try(:invitee_email) || "") %>
-      <span class="submit actions"><%= submit_tag t(".send_to_email.submit") %></span>
-    </p>
-  </fieldset>
-<% end %>
-
-<%= form_tag url_for(controller: "admin/admin_invitations", action: "invite_from_queue") do %>
-  <fieldset class="simple">
-    <h3 class="heading"><%= t(".send_to_queue.title_html", invitations_queue_link: link_to(t(".send_to_queue.invitations_queue"), invite_requests_path)) %></h3>
-    <p><%= t(".send_to_queue.current_request_count", count: InviteRequest.count) %></p>
+    <h3 class="heading"><%= t(".send_to_email.heading") %></h3>
     <p>
-      <%= label_tag "invitation[invite_from_queue]", t(".send_to_queue.invite_number") %> <%= text_field_tag "invitation[invite_from_queue]" %>
-      <span class="submit actions"><%= submit_tag t(".send_to_queue.submit") %></span>
+      <%= t(".send_to_email.description") %>
+      <%= text_field_tag "invitation[invitee_email]",
+                         (@invitation.try(:invitee_email) || ""),
+                         title: t(".send_to_email.invite_by_email_title") %>
+      <span class="submit actions"><%= submit_tag t(".send_to_email.invite_user") %></span>
     </p>
   </fieldset>
 <% end %>
 
-<%= form_tag url_for(controller: "admin/admin_invitations", action: "grant_invites_to_users") do %>
+<%= form_tag url_for(controller: "admin/admin_invitations", action: :invite_from_queue), class: "queue invitation simple post", autocomplete: "off" do %>
+  <fieldset class="simple">
+    <h3 class="heading">
+      <%= t(".invite_from_queue.heading_html",
+            invitations_queue_link: link_to(t(".invite_from_queue.invitations_queue"), invite_requests_path)) %>
+    </h3>
+    <p><%= t(".invite_from_queue.requests_in_queue", count: InviteRequest.count) %></p>
+    <p>
+      <%= label_tag "invitation[invite_from_queue]", t(".invite_from_queue.number_to_invite") %>
+      <%= text_field_tag "invitation[invite_from_queue]" %>
+      <span class="submit actions"><%= submit_tag t(".invite_from_queue.invite_from_queue") %></span>
+    </p>
+  </fieldset>
+<% end %>
+
+<%= form_tag url_for(controller: "admin/admin_invitations", action: :grant_invites_to_users), class: "bulk invitation simple post", autocomplete: "off" do %>
   <fieldset>
-    <h3 class="heading"><%= t(".grant_to_users.title") %></h3>
+    <h3 class="heading"><%= t(".grant_invites.heading") %></h3>
     <dl>
-      <dt><%= label_tag "invitation[number_of_invites]", t(".grant_to_users.amount") %></dt>
+      <dt><%= label_tag "invitation[number_of_invites]", t(".grant_invites.number_of_invitations") %></dt>
       <dd><%= text_field_tag "invitation[number_of_invites]" %></dd>
-      <dt><%= label_tag "invitation[user_group]", t(".grant_to_users.user_type") %></dt>
-      <dd><%= select_tag "invitation[user_group]", "<option>All</option><option>With no unused invitations</option>".html_safe %></dd>
-      <dt class="landmark"><%= t(".grant_to_users.submit_landmark") %></dt>
-      <dd class="submit actions"><%= submit_tag t(".grant_to_users.submit") %></dd>
+      <dt><%= label_tag "invitation[user_group]", t(".grant_invites.users") %></dt>
+      <dd>
+        <%= select_tag "invitation[user_group]",
+                       options_for_select([t(".grant_invites.all"), t(".grant_invites.with_no_unused")],
+                                          t(".grant_invites.all")) %>
+      </dd>
+      <dt class="landmark"><%= t(".grant_invites.landmark_submit") %></dt>
+      <dd class="submit actions"><%= submit_tag t(".grant_invites.generate_invitations") %></dd>
     </dl>
   </fieldset>
 <% end %>
 
-<%= form_tag url_for(controller: "admin/admin_invitations", action: "find"), method: :get do %>
+<%= form_tag url_for(controller: "admin/admin_invitations", action: :find), class: "invitation simple search", autocomplete: "off", method: :get do %>
   <fieldset>
-    <h3 class="heading"><%= t(".track_invitations.title") %></h3>
+    <h3 class="heading"><%= t(".find.heading") %></h3>
     <dl>
-      <dt><%= label_tag "invitation[user_name]", t(".track_invitations.user_name") %></dt>
+      <dt><%= label_tag "invitation[user_name]", t(".find.username") %></dt>
       <dd><%= text_field_tag "invitation[user_name]" %></dd>
-      <dt><%= label_tag "invitation[token]", t(".track_invitations.invite_token") %></dt>
+      <dt><%= label_tag "invitation[token]", t(".find.invite_token") %></dt>
       <dd><%= text_field_tag "invitation[token]" %></dd>
-      <dt><%= label_tag "track_invitation_invitee_email", t(".track_invitations.email") %></dt>
+      <dt><%= label_tag "track_invitation_invitee_email", t(".find.email") %></dt>
       <dd><%= text_field_tag "invitation[invitee_email]", nil, id: "track_invitation_invitee_email" %></dd>
-      <dt class="landmark"><%= t(".track_invitations.submit_landmark") %></dt>
-      <dd class="submit actions"><%= submit_tag t(".track_invitations.submit") %></dd>
+      <dt class="landmark"><%= t(".find.landmark_submit") %></dt>
+      <dd class="submit actions"><%= submit_tag t(".find.search") %></dd>
     </dl>
   </fieldset>
 <% end %>

--- a/app/views/admin/settings/index.html.erb
+++ b/app/views/admin/settings/index.html.erb
@@ -83,7 +83,7 @@
   <p>
     <%= t(".queue_status",
           number: @admin_setting.invite_from_queue_number,
-          date: l(@admin_setting.invite_from_queue_at.to_date, format: :long)) %>
+          time: l(@admin_setting.invite_from_queue_at, format: :long)) %>
   </p>
 
   <p><%= t(".queue_status_help") %></p>

--- a/app/views/admin/settings/index.html.erb
+++ b/app/views/admin/settings/index.html.erb
@@ -82,7 +82,7 @@
 <% if @admin_setting.invite_from_queue_enabled? %>
   <p>
     <%= t(".queue_status",
-          number: @admin_setting.invite_from_queue_number,
+          count: @admin_setting.invite_from_queue_number,
           time: l(@admin_setting.invite_from_queue_at, format: :long)) %>
   </p>
 

--- a/app/views/invite_requests/_index_closed.html.erb
+++ b/app/views/invite_requests/_index_closed.html.erb
@@ -1,21 +1,16 @@
 <!--Descriptive page name, messages and instructions-->
 <h2 class="heading">
-  <%= ts("Invitation Requests") %>
+  <%= t(".page_heading") %>
 </h2>
 
 <p class="notice">
-  <%= ts("<strong>New invitation requests are currently closed.</strong> For     
-        more information, please check the %{news}.",
-      news: link_to("\"Invitations\" tag on AO3 News",
-                    admin_posts_path(tag: 143))
-      ).html_safe %>
+  <%= t(".queue_disabled.html",
+        closed_bold: tag.strong(t(".queue_disabled.closed")),
+        news_link: link_to(t(".queue_disabled.news"), admin_posts_path(tag: 143))) %>
 </p>
 <p>
-  <%= ts("If you have already requested an invitation, you can %{status}. There are %{count} people remaining on the waiting list.",
-      status: link_to("check your position on the waiting list",
-                      status_invite_requests_path),
-      count: InviteRequest.count
-  ).html_safe %>
+  <%= t(".already_requested_html", check_waitlist_position_link: link_to(t(".check_waitlist_position"), status_invite_requests_path)) %>
+  <%= t(".waiting_list_count", count: InviteRequest.count) %>
 <p>
 <!--/descriptions-->
 

--- a/app/views/invite_requests/_index_open.html.erb
+++ b/app/views/invite_requests/_index_open.html.erb
@@ -26,8 +26,10 @@
 <% end %>
 
 <p>
-  <%= t(".already_requested_html", check_status_link: link_to(t(".check_waitlist_position"), status_invite_requests_path)) %>
+  <%= t(".already_requested_html", check_waitlist_position_link: link_to(t(".check_waitlist_position"), status_invite_requests_path)) %>
   <%= t(".waiting_list_count", count: InviteRequest.count) %>
-  <%= t(".invitations_per_day", count: AdminSetting.current.invite_from_queue_number) %>
+  <%= t(".invitation_send_rate",
+        queue_invitation_number: t(".invitation_number", count: AdminSetting.current.invite_from_queue_number),
+        queue_frequency: t(".frequency", count: AdminSetting.current.invite_from_queue_frequency)) %>
 </p>
 <!--/content-->

--- a/app/views/invite_requests/_invite_request.html.erb
+++ b/app/views/invite_requests/_invite_request.html.erb
@@ -8,7 +8,7 @@
 <p>
   <%= t(".position_html", position: tag.strong(@position_in_queue)) %>
   <% if AdminSetting.current.invite_from_queue_enabled? %>
-    <%= t(".date", date: l(invite_request.proposed_fill_date, format: :long)) %>
+    <%= t(".date", date: l(invite_request.proposed_fill_time.to_date, format: :long)) %>
   <% end %>
 </p>
 <!--/content-->

--- a/app/views/invite_requests/status.html.erb
+++ b/app/views/invite_requests/status.html.erb
@@ -6,7 +6,9 @@
 <p>
   <%= t(".waiting_list", count: InviteRequest.count) %>
   <% if AdminSetting.current.invite_from_queue_enabled? %>
-    <%= t(".send_rate", invites: AdminSetting.current.invite_from_queue_number) %>
+    <%= t(".invitation_send_rate",
+          queue_invitation_number: t(".invitation_number", count: AdminSetting.current.invite_from_queue_number),
+          queue_frequency: t(".frequency", count: AdminSetting.current.invite_from_queue_frequency)) %>
   <% end %>
 </p>
 <!--/descriptions-->

--- a/config/config.yml
+++ b/config/config.yml
@@ -80,7 +80,8 @@ DELIMITER_FOR_OUTPUT: ', '
 # these can be overridden in the admin controller
 INVITE_FROM_QUEUE_ENABLED: true
 INVITE_FROM_QUEUE_NUMBER: 10
-INVITE_FROM_QUEUE_FREQUENCY: 7
+# How often INVITE_FROM_QUEUE_NUMBER of invites are sent from the queue, in hours
+INVITE_FROM_QUEUE_FREQUENCY: 12
 
 HOURS_BEFORE_RESEND_INVITATION: 24
 # this is whether or not people without invitations can create accounts

--- a/config/locales/controllers/en.yml
+++ b/config/locales/controllers/en.yml
@@ -103,12 +103,20 @@ en:
     tos_faq:
       page_title: Terms of Service FAQ
   invite_requests:
+    create:
+      queue_disabled:
+        closed: New invitation requests are currently closed.
+        html: "%{closed_bold} For more information, please check the %{news_link}."
+        news: '"Invitations" tag on AO3 News'
+      success: You've been added to our queue! Yay! We estimate that you'll receive an invitation around %{date}. We strongly recommend that you add %{return_address} to your address book to prevent the invitation email from getting blocked as spam by your email provider.
     index:
       page_title: Invitation Requests
     resend:
       not_found: Could not find an invitation associated with that email.
       not_yet: You cannot resend an invitation that was sent in the last %{count} hours.
       success: Invitation resent to %{email}.
+    status:
+      browser_title: Invitation Request Status
   kudos:
     create:
       success: Thank you for leaving kudos!

--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -1436,7 +1436,7 @@ en:
       invitation_number:
         one: "%{count} invitation"
         other: "%{count} invitations"
-      invitation_send_rate: We are sending out %{queue_invitation_number} per %{queue_frequency}.
+      invitation_send_rate: We are sending out %{queue_invitation_number} every %{queue_frequency}.
       page_heading: Invitation Requests
       privacy_policy: Privacy Policy
       request_invitation_header: Request an invitation
@@ -1477,7 +1477,7 @@ en:
       invitation_number:
         one: "%{count} invitation"
         other: "%{count} invitations"
-      invitation_send_rate: We are sending out %{queue_invitation_number} per %{queue_frequency}.
+      invitation_send_rate: We are sending out %{queue_invitation_number} every %{queue_frequency}.
       search: Look me up
       waiting_list:
         one: There is currently %{count} person on the waiting list.

--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -86,35 +86,38 @@ en:
         token: Enter an invite token
         user_name: Enter a user name
       index:
-        grant_to_users:
-          amount: 'Number of invitations:'
-          submit: Generate invitations
-          submit_landmark: Submit
-          title: Give invite codes to current users
-          user_type: 'Users:'
+        find:
+          email: All or part of an email address
+          heading: Track invitations
+          invite_token: Invite token
+          landmark_submit: Submit
+          search: Search
+          username: Username
+        grant_invites:
+          all: All
+          generate_invitations: Generate invitations
+          heading: Give invite codes to current users
+          landmark_submit: Submit
+          number_of_invitations: Number of invitations
+          users: Users
+          with_no_unused: With no unused invitations
+        invite_from_queue:
+          heading_html: Send invite codes to people in our %{invitations_queue_link}
+          invitations_queue: Invitations queue
+          invite_from_queue: Invite from queue
+          number_to_invite: Number of people to invite
+          requests_in_queue:
+            one: There is %{count} request in the queue.
+            other: There are %{count} requests in the queue.
         navigation:
           queue: Manage Queue
           requests: Manage Requests
         page_heading: Invite New Users
         send_to_email:
-          send_code_to_email: 'Send an invite code to the following email address:'
-          submit: Invite user
-          title: Send to email
-        send_to_queue:
-          current_request_count:
-            one: There is %{count} request in the queue.
-            other: There are %{count} requests in the queue.
-          invitations_queue: invitations queue
-          invite_number: 'Number of people to invite:'
-          submit: Invite from queue
-          title_html: Send invite codes to people in our %{invitations_queue_link}
-        track_invitations:
-          email: 'Enter all or part of an email address:'
-          invite_token: 'Enter an invite token:'
-          submit: Go
-          submit_landmark: Submit
-          title: Track invitations
-          user_name: 'Enter a user name:'
+          description: Email address
+          heading: Send to Email
+          invite_by_email_title: Invite by email
+          invite_user: Invite user
     admin_nav:
       ao3_news: AO3 News
       archive_faq: Archive FAQ

--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -86,11 +86,35 @@ en:
         token: Enter an invite token
         user_name: Enter a user name
       index:
-        email: Enter all or part of an email address
+        grant_to_users:
+          amount: 'Number of invitations:'
+          submit: Generate invitations
+          submit_landmark: Submit
+          title: Give invite codes to current users
+          user_type: 'Users:'
         navigation:
           queue: Manage Queue
           requests: Manage Requests
         page_heading: Invite New Users
+        send_to_email:
+          send_code_to_email: 'Send an invite code to the following email address:'
+          submit: Invite user
+          title: Send to email
+        send_to_queue:
+          current_request_count:
+            one: There is %{count} request in the queue.
+            other: There are %{count} requests in the queue.
+          invitations_queue: invitations queue
+          invite_number: 'Number of people to invite:'
+          submit: Invite from queue
+          title_html: Send invite codes to people in our %{invitations_queue_link}
+        track_invitations:
+          email: 'Enter all or part of an email address:'
+          invite_token: 'Enter an invite token:'
+          submit: Go
+          submit_landmark: Submit
+          title: Track invitations
+          user_name: 'Enter a user name:'
     admin_nav:
       ao3_news: AO3 News
       archive_faq: Archive FAQ
@@ -347,7 +371,9 @@ en:
           actions: Actions
           disable_support_form: Turn Off Support Form
           performance_and_misc: Performance and Misc
-        queue_status: "%{number} people are scheduled to be sent invitations at %{time}."
+        queue_status:
+          one: "%{count} person is scheduled to be sent an invitation at %{time}."
+          other: "%{count} people are scheduled to be sent invitations at %{time}."
         queue_status_help: "(The automatic task that invites people from the queue runs at most every hour. Don't be alarmed if the time you see is within the last hour. Do be alarmed if the time you see is more than one hour in the past and the queue is supposed to be active.)"
         update: Update
       update:
@@ -1384,6 +1410,17 @@ en:
     invitation:
       email_address_label: Enter an email address
   invite_requests:
+    index_closed:
+      already_requested_html: If you have already requested an invitation, you can %{check_waitlist_position_link}.
+      check_waitlist_position: check your position on the waiting list
+      page_heading: Invitation Requests
+      queue_disabled:
+        closed: New invitation requests are currently closed.
+        html: "%{closed_bold} For more information, please check the %{news_link}."
+        news: '"Invitations" tag on AO3 News'
+      waiting_list_count:
+        one: There is %{count} person remaining on the waiting list.
+        other: There are %{count} people remaining on the waiting list.
     index_open:
       add_to_list: Add me to the list
       already_requested_html: If you have already requested an invitation, you can %{check_waitlist_position_link}.

--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -335,7 +335,7 @@ en:
           guest_comments_off: Turn off guest comments across the site
           hide_spam: Automatically hide spam works
           invite_from_queue_enabled: Invite from queue enabled (People can add themselves to the queue and invitations are sent out automatically)
-          invite_from_queue_frequency: How often (in days) should we invite people from the queue
+          invite_from_queue_frequency: How often (in hours) should we invite people from the queue
           invite_from_queue_number: Number of people to invite from the queue at once
           request_invite_enabled: Users can request invitations
           suspend_filter_counts: Suspend some filter tracking due to high posting volume
@@ -347,8 +347,8 @@ en:
           actions: Actions
           disable_support_form: Turn Off Support Form
           performance_and_misc: Performance and Misc
-        queue_status: "%{number} people are scheduled to be sent invitations on %{date}."
-        queue_status_help: "(The automatic task that invites people from the queue only runs once a day. Don't be alarmed if the date you see is yesterday's. Do be alarmed if the date you see is more than one day in the past and the queue is supposed to be active.)"
+        queue_status: "%{number} people are scheduled to be sent invitations at %{time}."
+        queue_status_help: "(The automatic task that invites people from the queue runs at most every hour. Don't be alarmed if the time you see is within the last hour. Do be alarmed if the time you see is more than one hour in the past and the queue is supposed to be active.)"
         update: Update
       update:
         success: Archive settings were successfully updated.
@@ -1386,13 +1386,17 @@ en:
   invite_requests:
     index_open:
       add_to_list: Add me to the list
-      already_requested_html: If you have already requested an invitation, you can %{check_status_link}.
+      already_requested_html: If you have already requested an invitation, you can %{check_waitlist_position_link}.
       check_waitlist_position: check your position on the waiting list
       content_policy: Content Policy
       details_html: To get a free Archive of Our Own account, you need an Invitation. By submitting your email address to our invitation queue, you confirm that you are at least 13 years old, and if you're in a country whose residents/citizens have to be of an age older than 13 to consent, you are old enough to consent to the processing of your personal data without our obtaining written permission from a parent or legal guardian. We will use the email address you submit only to send you an Invitation and to process/manage your account activation. Please don't request an Invitation unless you've read our %{tos_link}, including the %{content_policy_link} and %{privacy_policy_link}, and agree to abide by those Terms.
-      invitations_per_day:
-        one: We are sending out %{count} invitation per day.
-        other: We are sending out %{count} invitations per day.
+      frequency:
+        one: hour
+        other: "%{count} hours"
+      invitation_number:
+        one: "%{count} invitation"
+        other: "%{count} invitations"
+      invitation_send_rate: We are sending out %{queue_invitation_number} per %{queue_frequency}.
       page_heading: Invitation Requests
       privacy_policy: Privacy Policy
       request_invitation_header: Request an invitation
@@ -1426,9 +1430,15 @@ en:
     show:
       instructions_html: To check on the status of your invitation, go to the %{status_link} and enter your email in the space provided.
     status:
+      frequency:
+        one: hour
+        other: "%{count} hours"
       heading: Invitation Request Status
+      invitation_number:
+        one: "%{count} invitation"
+        other: "%{count} invitations"
+      invitation_send_rate: We are sending out %{queue_invitation_number} per %{queue_frequency}.
       search: Look me up
-      send_rate: We are sending out %{invites} invitations per day.
       waiting_list:
         one: There is currently %{count} person on the waiting list.
         other: There are currently %{count} people on the waiting list.

--- a/config/resque_schedule.yml
+++ b/config/resque_schedule.yml
@@ -81,7 +81,7 @@ remove_old_hit_count_data:
   description: "Remove old hit count information from redis."
 
 check_invite_queue:
-  cron: "21 6 * * *"
+  every: 1h
   class: "AdminSetting"
   queue: utilities
   args: check_queue

--- a/features/admins/admin_invitations.feature
+++ b/features/admins/admin_invitations.feature
@@ -349,7 +349,7 @@ Feature: Admin Actions to Manage Invitations
     Then I should see "There are 2 requests in the queue."
     When I fill in "Number of people to invite" with "1"
       And press "Invite from queue"
-    Then I should see "There are 1 requests in the queue."
+    Then I should see "There is 1 request in the queue."
       And I should see "1 person from the invite queue is being invited"
       And 1 email should be delivered to "fred@bedrock.com"
 

--- a/features/admins/admin_invitations.feature
+++ b/features/admins/admin_invitations.feature
@@ -306,12 +306,12 @@ Feature: Admin Actions to Manage Invitations
       And "dax" has "2" invitations
       And I am logged in as an admin
     When I follow "Invite New Users"
-      And I fill in "Enter a user name" with "dax"
-      And I press "Go"
+      And I fill in "Username" with "dax"
+      And I press "Search" within "form.invitation.simple.search"
     Then I should see "copy and use"
     When I follow "Invite New Users"
-      And I fill in "Enter an invite token" with "dax's" invite code
-      And I press "Go"
+      And I fill in "Invite token" with "dax's" invite code
+      And I press "Search" within "form.invitation.simple.search"
     Then I should see "copy and use"
 
   Scenario: An admin can find all invitations via email partial match
@@ -324,16 +324,16 @@ Feature: Admin Actions to Manage Invitations
     When I fill in "Number of people to invite" with "2"
       And I press "Invite from queue"
     Then I should see "2 people from the invite queue are being invited"
-    When I fill in "Enter all or part of an email address" with "@"
-      And I press "Go"
+    When I fill in "All or part of an email address" with "@"
+      And I press "Search" within "form.invitation.simple.search"
     Then I should see "fred@bedrock.com"
       And I should see "barney@bedrock.com"
 
   Scenario: An admin can't find a invitation for a nonexistent user
     Given I am logged in as an admin
       And I follow "Invite New Users"
-    When I fill in "Enter a user name" with "dax"
-      And I press "Go"
+    When I fill in "Username" with "dax"
+      And I press "Search" within "form.invitation.simple.search"
     Then I should see "No results were found. Try another search"
     When I fill in "Enter a user name" with ""
       And I fill in "Enter all or part of an email address" with "nonexistent@domain.com"
@@ -360,7 +360,7 @@ Feature: Admin Actions to Manage Invitations
     When I fill in "Number of people to invite" with "1"
       And press "Invite from queue"
     Then I should see "1 person from the invite queue is being invited"
-    When I press "Go"
+    When I press "Search" within "form.invitation.simple.search"
       And I fill in "Enter all or part of an email address" with "test@example.com"
       And I press "Go"
     Then I should see "Sender testadmin-support"
@@ -370,12 +370,12 @@ Feature: Admin Actions to Manage Invitations
       And "dax" has "2" invitations
       And I am logged in as a "support" admin
     When I follow "Invite New Users"
-      And I fill in "Enter a user name" with "dax"
-      And I press "Go"
+      And I fill in "Username" with "dax"
+      And I press "Search" within "form.invitation.simple.search"
     Then I should see "copy and use"
     When I follow "Invite New Users"
-      And I fill in "Enter an invite token" with "dax's" invite code
-      And I press "Go"
+      And I fill in "Invite token" with "dax's" invite code
+      And I press "Search" within "form.invitation.simple.search"
     Then I should see "copy and use"
     When I fill in "Enter an email address" with "oldman@ds9.com"
       And I press "Update Invitation"

--- a/features/other_a/invite_queue.feature
+++ b/features/other_a/invite_queue.feature
@@ -49,7 +49,7 @@ Feature: Invite queue management
     When I am on the homepage
       And all emails have been delivered
       And I follow "Get an Invitation"
-    Then I should see "We are sending out 10 invitations per 12 hours."
+    Then I should see "We are sending out 10 invitations every 12 hours."
     When I fill in "invite_request_email" with "test@archiveofourown.org"
       And I press "Add me to the list"
     Then I should see "You've been added to our queue"

--- a/features/other_a/invite_queue.feature
+++ b/features/other_a/invite_queue.feature
@@ -49,7 +49,7 @@ Feature: Invite queue management
     When I am on the homepage
       And all emails have been delivered
       And I follow "Get an Invitation"
-    Then I should see "We are sending out 10 invitations per day."
+    Then I should see "We are sending out 10 invitations per 12 hours."
     When I fill in "invite_request_email" with "test@archiveofourown.org"
       And I press "Add me to the list"
     Then I should see "You've been added to our queue"
@@ -57,6 +57,7 @@ Feature: Invite queue management
     # check your place in the queue - invalid address
     When I check how long "testttt@archiveofourown.org" will have to wait in the invite request queue
     Then I should see "Invitation Request Status"
+      And I should see "We are sending out 10 invitations per 12 hours."
       And I should see "Sorry, we can't find the email address you entered."
       And I should not see "You are currently number"
 

--- a/features/other_a/invite_queue.feature
+++ b/features/other_a/invite_queue.feature
@@ -57,7 +57,6 @@ Feature: Invite queue management
     # check your place in the queue - invalid address
     When I check how long "testttt@archiveofourown.org" will have to wait in the invite request queue
     Then I should see "Invitation Request Status"
-      And I should see "We are sending out 10 invitations per 12 hours."
       And I should see "Sorry, we can't find the email address you entered."
       And I should not see "You are currently number"
 
@@ -73,6 +72,7 @@ Feature: Invite queue management
     Then I should not see "Request an invitation"
       And I should not see "invite_request_email"
       And I should see "New invitation requests are currently closed."
+      And I should see "There are 0 people remaining on the waiting list."
       And I should not see "Add me to the list"
 
   Scenario: Can still check status when queue is off

--- a/features/other_a/invite_queue.feature
+++ b/features/other_a/invite_queue.feature
@@ -105,7 +105,7 @@ Feature: Invite queue management
     When I am logged in as an admin
       And I follow "Invitations"
       And I fill in "track_invitation_invitee_email" with "test@archiveofourown.org"
-      And I press "Go"
+      And I press "Search" within "form.invitation.simple.search"
     Then I should see "Sender queue"
     When I follow "copy and use"
     Then I should see "You are already logged in!"

--- a/features/other_a/invite_request.feature
+++ b/features/other_a/invite_request.feature
@@ -151,7 +151,7 @@ Feature: Invite requests
       And I am logged in as a "support" admin
     When I follow "Invite New Users"
       And I fill in "invitation[user_name]" with "user1"
-      And I press "Go"
+      And I press "Search" within "form.invitation.simple.search"
     Then I should see "Token"
     When I follow "Delete"
     Then I should see "Invitation successfully destroyed"

--- a/features/step_definitions/admin_steps.rb
+++ b/features/step_definitions/admin_steps.rb
@@ -291,8 +291,8 @@ When "{int} Archive FAQ(s) with {int} question(s) exist(s)" do |faqs, questions|
   end
 end
 
-When /^the invite_from_queue_at is yesterday$/ do
-  AdminSetting.first.update_attribute(:invite_from_queue_at, Time.now - 1.day)
+When "the invite_from_queue_at is yesterday" do
+  AdminSetting.first.update_attribute(:invite_from_queue_at, Time.current - 1.day)
 end
 
 When "the scheduled check_invite_queue job is run" do

--- a/spec/controllers/invite_requests_controller_spec.rb
+++ b/spec/controllers/invite_requests_controller_spec.rb
@@ -96,7 +96,7 @@ describe InviteRequestsController do
         email = Faker::Internet.unique.email
         post :create, params: { invite_request: { email: email } }
         invite_request = InviteRequest.find_by!(email: email)
-        it_redirects_to_with_notice(invite_requests_path, "You've been added to our queue! Yay! We estimate that you'll receive an invitation around #{invite_request.proposed_fill_date}. We strongly recommend that you add do-not-reply@archiveofourown.org to your address book to prevent the invitation email from getting blocked as spam by your email provider.")
+        it_redirects_to_with_notice(invite_requests_path, "You've been added to our queue! Yay! We estimate that you'll receive an invitation around #{I18n.l(invite_request.proposed_fill_time.to_date, format: :long)}. We strongly recommend that you add #{ArchiveConfig.RETURN_ADDRESS} to your address book to prevent the invitation email from getting blocked as spam by your email provider.")
       end
 
       it "assigns an IP address to the request" do

--- a/spec/models/invite_request_spec.rb
+++ b/spec/models/invite_request_spec.rb
@@ -39,4 +39,27 @@ describe InviteRequest do
       end
     end
   end
+
+  describe "#proposed_fill_time" do
+    let(:invite_request) { create(:invite_request) }
+
+    before do
+      freeze_time
+
+      admin_setting = AdminSetting.default
+      admin_setting.invite_from_queue_number = 3
+      admin_setting.invite_from_queue_frequency = 11
+      admin_setting.save(validate: false)
+    end
+
+    it "returns time of next check for invite in next batch" do
+      expect(invite_request.proposed_fill_time).to eq(Time.current + 11.hours)
+    end
+
+    it "returns time with x3 check duration for invite in 3rd batch" do
+      allow(invite_request).to receive(:position).and_return(9)
+
+      expect(invite_request.proposed_fill_time).to eq(Time.current + 33.hours)
+    end
+  end
 end


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6913
https://otwarchive.atlassian.net/browse/AO3-6597

## Purpose

Change the invite queue check to run every hour so that it can be configured to send invitations every N hours.
Finish off the i18n of the pages because the strings had to be touched anyway.

## Testing Instructions

Refer to both Jira issues.

## References

PR Limit: 7 out of 5
Using reviewer bonus:
#4893
#4912

## Credit

Bilka
