### PR TITLE
AO3-6591 Move imported_from_url to a new table

### DIFF
--- a/app/controllers/api/v2/works_controller.rb
+++ b/app/controllers/api/v2/works_controller.rb
@@ -127,6 +127,7 @@ class Api::V2::WorksController < Api::V2::BaseController
       message = "Please provide the original URL for the work."
     else
       # We know the url will be identical no need for a call to find_by_url
+      # TODO AO3-6591
       works = Work.where(imported_from_url: original_url)
       message = if works.empty?
                   "No work has been imported from \"" + original_url + "\"."

--- a/app/controllers/opendoors/tools_controller.rb
+++ b/app/controllers/opendoors/tools_controller.rb
@@ -51,7 +51,8 @@ class Opendoors::ToolsController < ApplicationController
         flash[:error] = ts("There is already a work imported from the url %{url}.", url: @imported_from_url)
       else
         # ok let's try to update
-        @work.update_attribute(:imported_from_url, @imported_from_url)
+        @work.update_attribute(:imported_from_url, @imported_from_url) # TODO AO3-6591
+        WorkUrl.prepare(@work, @imported_from_url).save(validate: false)
         flash[:notice] = "Updated imported-from url for #{@work.title} to #{@imported_from_url}"
       end
     end    

--- a/app/models/story_parser.rb
+++ b/app/models/story_parser.rb
@@ -301,6 +301,7 @@ class StoryParser
 
     @options = options
     work.imported_from_url = location
+    WorkUrl.prepare(work, location)
     work.ip_address = options[:ip_address]
     work.expected_number_of_chapters = work.chapters.length
     work.revised_at = work.chapters.last.published_at

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -65,6 +65,8 @@ class Work < ApplicationRecord
   # moderation
   has_one :moderated_work, dependent: :destroy
 
+  has_one :work_url, dependent: :destroy
+
   ########################################################################
   # VIRTUAL ATTRIBUTES
   ########################################################################
@@ -301,7 +303,7 @@ class Work < ApplicationRecord
     series.each(&:expire_caches)
 
     Work.expire_work_blurb_version(id)
-    Work.flush_find_by_url_cache unless imported_from_url.blank?
+    WorkUrl.flush_find_by_url_cache unless work_url.nil? && imported_from_url.blank? #TODO AO3-6591
   end
 
   def update_pseud_index
@@ -388,50 +390,12 @@ class Work < ApplicationRecord
   # IMPORTING
   ########################################################################
 
-  def self.find_by_url_generation_key
-    "/v1/find_by_url_generation_key"
-  end
-
-  def self.find_by_url_generation
-    Rails.cache.fetch(Work.find_by_url_generation_key, raw: true) { rand(1..1000) }
-  end
-
-  def self.flush_find_by_url_cache
-    Rails.cache.increment(Work.find_by_url_generation_key)
-  end
-
-  def self.find_by_url_cache_key(url)
-    url = UrlFormatter.new(url)
-    "/v1/find_by_url/#{Work.find_by_url_generation}/#{url.encoded}"
-  end
-
-  # Match `url` to a work's imported_from_url field using progressively fuzzier matching:
-  # 1. first exact match
-  # 2. first exact match with variants of the provided url
-  # 3. first match on variants of both the imported_from_url and the provided url if there is a partial match
-
-  def self.find_by_url_uncached(url)
-    url = UrlFormatter.new(url)
-    Work.where(imported_from_url: url.original).first ||
-      Work.where(imported_from_url: [url.minimal,
-                                     url.with_http, url.with_https,
-                                     url.no_www, url.with_www,
-                                     url.encoded, url.decoded,
-                                     url.minimal_no_protocol_no_www]).first ||
-      Work.where("imported_from_url LIKE ? or imported_from_url LIKE ?",
-                 "http://#{url.minimal_no_protocol_no_www}%",
-                 "https://#{url.minimal_no_protocol_no_www}%").select do |w|
-        work_url = UrlFormatter.new(w.imported_from_url)
-        %w[original minimal no_www with_www with_http with_https encoded decoded].any? do |method|
-          work_url.send(method) == url.send(method)
-        end
-      end.first
+  def import_url!(url)
+    WorkUrl.prepare(self, url).save!
   end
 
   def self.find_by_url(url)
-    Rails.cache.fetch(Work.find_by_url_cache_key(url)) do
-      find_by_url_uncached(url)
-    end
+    WorkUrl.find_by_url(url)
   end
 
   # Remove all pseuds associated with a particular user. Raises an exception if

--- a/app/models/work_url.rb
+++ b/app/models/work_url.rb
@@ -1,0 +1,73 @@
+class WorkUrl < ApplicationRecord
+  belongs_to :work
+
+  VARIANTS = %w[original minimal no_www with_www encoded decoded minimal_no_protocol_no_www].freeze
+
+  def self.build_url_attributes(url)
+    url = UrlFormatter.new(url)
+
+    VARIANTS.to_h { |s| [s.to_sym, url.send(s)] }
+  end
+
+  def self.prepare(work, url)
+    work_url = WorkUrl.find_or_initialize_by(work_id: work.id)
+
+    work_url.assign_attributes(self.build_url_attributes(url))
+
+    work.work_url = work_url
+
+    work_url
+  end
+
+  def self.find_by_url_generation_key
+    "/v1/find_by_url_generation_key"
+  end
+
+  def self.find_by_url_generation
+    Rails.cache.fetch(WorkUrl.find_by_url_generation_key, raw: true) { rand(1..1000) }
+  end
+
+  def self.flush_find_by_url_cache
+    Rails.cache.increment(WorkUrl.find_by_url_generation_key)
+  end
+
+  def self.find_by_url_cache_key(url)
+    url = UrlFormatter.new(url)
+    "/v1/find_by_url/#{WorkUrl.find_by_url_generation}/#{url.encoded}"
+  end
+
+  # Match `url` to a work's imported_from_url field using progressively fuzzier matching:
+  # 1. first exact match
+  # 2. first exact match with variants of the provided url
+  # 3. first match on variants of both the imported_from_url and the provided url if there is a partial match
+
+  def self.find_by_url_uncached(url)
+    url = UrlFormatter.new(url)
+
+    WorkUrl.where(
+      VARIANTS.map { |column| "#{column} = ?" } .join(' OR '),
+      *VARIANTS.map{ |method| url.send(method) }
+    ).first&.work ||
+      # TODO AO3-6591
+      Work.where(imported_from_url: url.original).first ||
+      Work.where(imported_from_url: [url.minimal,
+                                     url.with_http, url.with_https,
+                                     url.no_www, url.with_www,
+                                     url.encoded, url.decoded,
+                                     url.minimal_no_protocol_no_www]).first ||
+      Work.where("imported_from_url LIKE ? or imported_from_url LIKE ?",
+                 "http://#{url.minimal_no_protocol_no_www}%",
+                 "https://#{url.minimal_no_protocol_no_www}%").select do |w|
+        work_url = UrlFormatter.new(w.imported_from_url)
+        %w[original minimal no_www with_www with_http with_https encoded decoded].any? do |method|
+          work_url.send(method) == url.send(method)
+        end
+      end.first
+  end
+
+  def self.find_by_url(url)
+    Rails.cache.fetch(WorkUrl.find_by_url_cache_key(url)) do
+      find_by_url_uncached(url)
+    end
+  end
+end

--- a/db/migrate/20250228135348_create_work_urls.rb
+++ b/db/migrate/20250228135348_create_work_urls.rb
@@ -1,0 +1,17 @@
+class CreateWorkUrls < ActiveRecord::Migration[7.1]
+  def change
+    create_table :work_urls do |t|
+      t.string :original, null: false, index: true
+      t.string :minimal, null: false, index: true
+      t.string :no_www, null: false, index: true
+      t.string :with_www, null: false, index: true
+      t.string :encoded, null: false, index: true
+      t.string :decoded, null: false, index: true
+      t.string :minimal_no_protocol_no_www, null: false, index: true
+
+      t.references :work, type: :integer, null: false, foreign_key: true, index: { unique: true }
+
+      t.timestamps
+    end
+  end
+end

--- a/lib/tasks/opendoors.rake
+++ b/lib/tasks/opendoors.rake
@@ -4,9 +4,11 @@ namespace :opendoors do
     def update_work(row)
       begin
         work = Work.find(row["AO3 id"])
+        # TODO AO3-6591
         if work&.imported_from_url.blank? || work&.imported_from_url == row["URL Imported From"]
           work.imported_from_url = row["Original URL"]
           work.save!
+          work.import_url!(row["Original URL"])
           "#{work.id}\twas updated: its import url is now #{work.imported_from_url}"
         else
           "#{work.id}\twas not changed: its import url is #{work.imported_from_url}"

--- a/lib/tasks/work_tasks.rake
+++ b/lib/tasks/work_tasks.rake
@@ -52,4 +52,16 @@ namespace :work do
     end
     puts && STDOUT.flush
   end
+
+  desc "Migrate imported_url into a dedicated table"
+  task(:migrate_imported_urls => :environment) do
+    Work
+      .left_joins(:work_url)
+      .where('imported_from_url IS NOT NULL AND work_urls.id IS NULL')
+      .find_in_batches do |batch|
+        batch.each do |work|
+          work.import_url!(work.imported_from_url)
+        end
+      end
+  end
 end

--- a/spec/controllers/opendoors/tools_controller_spec.rb
+++ b/spec/controllers/opendoors/tools_controller_spec.rb
@@ -91,6 +91,7 @@ describe Opendoors::ToolsController do
           it_redirects_to_with_notice(opendoors_tools_path(imported_from_url: url), "Updated imported-from url for #{work.title} to #{url}")
           work.reload
           expect(work.imported_from_url).to eq(url)
+          expect(work.work_url.original).to eq(url)
         end
 
         it "updates work if imported-from URL has non-ASCII characters" do
@@ -100,6 +101,7 @@ describe Opendoors::ToolsController do
           it_redirects_to_with_notice(opendoors_tools_path(imported_from_url: encoded_url), "Updated imported-from url for #{work.title} to #{encoded_url}")
           work.reload
           expect(work.imported_from_url).to eq(encoded_url)
+          expect(work.work_url.original).to eq(encoded_url)
         end
       end
     end

--- a/spec/lib/tasks/opendoors.rake_spec.rb
+++ b/spec/lib/tasks/opendoors.rake_spec.rb
@@ -15,8 +15,12 @@ describe 'rake opendoors:import_url_mapping' do
     it "takes a path to a CSV and updates works" do
       path = file_fixture("opendoors_import_url_mapping.csv")
       subject.invoke(path)
+      expect(Work.find(work_with_no_url.id).work_url.original).to eq(original_url2)
+      expect(Work.find(work_with_no_url.id).work_url.original).to eq(original_url2)
+
+      # TODO AO3-6591
       expect(Work.find(work_with_temp_url.id).imported_from_url).to eq(original_url)
-      expect(Work.find(work_with_no_url.id).imported_from_url).to eq(original_url2)
+      expect(Work.find(work_with_temp_url.id).imported_from_url).to eq(original_url)
     end
     it "fails if the CSV path is invalid" do
       expect { subject.invoke("not a path") }.to raise_error Errno::ENOENT

--- a/spec/lib/tasks/work_tasks.rake_spec.rb
+++ b/spec/lib/tasks/work_tasks.rake_spec.rb
@@ -164,3 +164,28 @@ describe "rake work:reset_word_counts" do
     end
   end
 end
+
+describe "rake work:migrate_imported_urls" do
+  it "creates missing entries in the new table" do
+    work = create(:work, imported_from_url: "www.someplace.org")
+
+    expect(work.work_url).to be_nil
+
+    subject.invoke
+
+    work.reload
+
+    expect(work.work_url.original).to eq("www.someplace.org")
+  end
+
+  it "does nothing if an entry already exists (even if there's a mismatch)" do
+    work = create(:work, imported_from_url: "www.someplace.org")
+    work.import_url!("someotherplace.com")
+
+    subject.invoke
+
+    work.reload
+
+    expect(work.work_url.original).to eq("someotherplace.com")
+  end
+end

--- a/spec/models/story_parser_spec.rb
+++ b/spec/models/story_parser_spec.rb
@@ -320,5 +320,11 @@ describe StoryParser do
       story = @sp.download_and_parse_story("http://non-sgml-character-number-3", pseuds: [@user.default_pseud])
       expect(story.chapters[0].content).to include("When I get out of here")
     end
+
+    it "records source url" do
+      story = @sp.download_and_parse_story("http://non-sgml-character-number-3", pseuds: [@user.default_pseud])
+      expect(story.imported_from_url).to eq "http://non-sgml-character-number-3"
+      expect(story.work_url.original).to eq "http://non-sgml-character-number-3"
+    end
   end
 end

--- a/spec/models/work_spec.rb
+++ b/spec/models/work_spec.rb
@@ -447,11 +447,12 @@ describe Work do
   describe "#find_by_url" do
     it "should find imported works with various URL formats" do
       %w[http://foo.com/bar.html
-         http://foo.com/bar
-         http://lj-site.com/bar/foo?color=blue
-         https://www.lj-site.com/bar/foo?color=blue
-         http://www.foo.com/bar https://www.foo.com/bar].each do |url|
-        work = create(:work, imported_from_url: url)
+        http://foo.com/bar
+        http://lj-site.com/bar/foo?color=blue
+        https://www.lj-site.com/bar/foo?color=blue
+        http://www.foo.com/bar https://www.foo.com/bar].each do |url|
+        work = create(:work)
+        work.import_url!(url)
         expect(Work.find_by_url(url)).to eq(work)
         work.destroy
       end
@@ -463,37 +464,95 @@ describe Work do
         "http://efiction-site.com/viewstory.php?sid=123" => "http://efiction-site.com/viewstory.php?sid=456",
         "http://www.foo.com/i-am-something" => "http://foo.com/i-am-something/else"
       }.each do |import_url, find_url|
-        work = create(:work, imported_from_url: import_url)
+        work = create(:work)
+        work.import_url!(import_url)
         expect(Work.find_by_url(find_url)).to_not eq(work)
         work.destroy
       end
     end
 
     it "should find works imported with irrelevant query parameters" do
-      work = create(:work, imported_from_url: "http://lj-site.com/thing1?style=mine")
+      work = create(:work)
+      work.import_url!("http://lj-site.com/thing1?style=mine")
       expect(Work.find_by_url("http://lj-site.com/thing1?style=other")).to eq(work)
       work.destroy
     end
 
     it "finds works imported with HTTP protocol and irrelevant query parameters" do
-      work = create(:work, imported_from_url: "http://lj-site.com/thing1?style=mine")
+      work = create(:work)
+      work.import_url!("http://lj-site.com/thing1?style=mine")
       expect(Work.find_by_url("https://lj-site.com/thing1?style=other")).to eq(work)
       work.destroy
     end
 
     it "finds works imported with HTTPS protocol and irrelevant query parameters" do
-      work = create(:work, imported_from_url: "https://lj-site.com/thing1?style=mine")
+      work = create(:work)
+      work.import_url!("https://lj-site.com/thing1?style=mine")
       expect(Work.find_by_url("http://lj-site.com/thing1?style=other")).to eq(work)
       work.destroy
     end
 
     it "gets the work from cache when searching for an imported work by URL" do
       url = "http://lj-site.com/thing2"
-      work = create(:work, imported_from_url: url)
-      expect(Rails.cache.read(Work.find_by_url_cache_key(url))).to be_nil
+      work = create(:work)
+      work.import_url!(url)
+      expect(Rails.cache.read(WorkUrl.find_by_url_cache_key(url))).to be_nil
       expect(Work.find_by_url(url)).to eq(work)
-      expect(Rails.cache.read(Work.find_by_url_cache_key(url))).to eq(work)
+      expect(Rails.cache.read(WorkUrl.find_by_url_cache_key(url))).to eq(work)
       work.destroy
+    end
+
+    describe "legacy – to be removed eventually – cf AO3-6591" do
+      it "should find imported works with various URL formats" do
+        %w[http://foo.com/bar.html
+          http://foo.com/bar
+          http://lj-site.com/bar/foo?color=blue
+          https://www.lj-site.com/bar/foo?color=blue
+          http://www.foo.com/bar https://www.foo.com/bar].each do |url|
+          work = create(:work, imported_from_url: url)
+          expect(Work.find_by_url(url)).to eq(work)
+          work.destroy
+        end
+      end
+
+      it "should not mix up imported works with similar URLs or significant query parameters" do
+        {
+          "http://foo.com/12345" => "http://foo.com/123",
+          "http://efiction-site.com/viewstory.php?sid=123" => "http://efiction-site.com/viewstory.php?sid=456",
+          "http://www.foo.com/i-am-something" => "http://foo.com/i-am-something/else"
+        }.each do |import_url, find_url|
+          work = create(:work, imported_from_url: import_url)
+          expect(Work.find_by_url(find_url)).to_not eq(work)
+          work.destroy
+        end
+      end
+
+      it "should find works imported with irrelevant query parameters" do
+        work = create(:work, imported_from_url: "http://lj-site.com/thing1?style=mine")
+        expect(Work.find_by_url("http://lj-site.com/thing1?style=other")).to eq(work)
+        work.destroy
+      end
+
+      it "finds works imported with HTTP protocol and irrelevant query parameters" do
+        work = create(:work, imported_from_url: "http://lj-site.com/thing1?style=mine")
+        expect(Work.find_by_url("https://lj-site.com/thing1?style=other")).to eq(work)
+        work.destroy
+      end
+
+      it "finds works imported with HTTPS protocol and irrelevant query parameters" do
+        work = create(:work, imported_from_url: "https://lj-site.com/thing1?style=mine")
+        expect(Work.find_by_url("http://lj-site.com/thing1?style=other")).to eq(work)
+        work.destroy
+      end
+
+      it "gets the work from cache when searching for an imported work by URL" do
+        url = "http://lj-site.com/thing2"
+        work = create(:work, imported_from_url: url)
+        expect(Rails.cache.read(WorkUrl.find_by_url_cache_key(url))).to be_nil
+        expect(Work.find_by_url(url)).to eq(work)
+        expect(Rails.cache.read(WorkUrl.find_by_url_cache_key(url))).to eq(work)
+        work.destroy
+      end
     end
   end
 


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [x] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [x] Have you added the [Jira](https://otwarchive.atlassian.net) issue number as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [x] Do you have fewer than 5 pull requests already open? If not, please wait until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-6591

## Purpose

First step of migrating `imported_from_url` into its own table:
- Create new table
- Update existing place where the url is imported to fill it properly
- Update search to use it
- Provide a task to migrate existing import urls

What this PR does not do and that will have to be done in a second time, after the new task is successfully run, is deleting all the code still using imported_from_url (albeit now as a fallback) and dropping the column from the table.

## Testing Instructions

No visible change to any behavior related to importing urls/searching by import urls. Lines should be created/updated in the new table however.

## Credit

Ceithir (he/him)