### PR TITLE
AO3-6922 (BOT) fix link abuse form footnote

### DIFF
--- a/app/views/abuse_reports/new.html.erb
+++ b/app/views/abuse_reports/new.html.erb
@@ -129,7 +129,8 @@
       <dd class="required">
         <p id="comment-field-description">
           <%= t(".form.comment.description_html",
-                tos_link: link_to(t(".form.comment.tos"), tos_path(anchor: "content")),
+                content_policy_link: link_to(t(".form.comment.content_policy"), content_path),
+                tos_link: link_to(t(".form.comment.tos"), tos_path),
                 include_link: link_to(t(".form.comment.include"), anchor: "reporthow")) %>
         </p>
         <%= f.text_area :comment, "aria-describedby" => "comment-field-description" %>

--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -15,7 +15,7 @@ en:
           error: Please describe what you are reporting and why you are reporting it.
           include: include all relevant links and other information in your report
           label: Description of the content you are reporting (required)
-          tos: AO3 Terms of Service
+          tos: Terms of Service
         email:
           description: We cannot contact you if the email address you provide is invalid.
           label: Your email (required)

--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -10,7 +10,8 @@ en:
         split: Please only report one user at a time, and do not submit multiple reports about the same user.
       form:
         comment:
-          description_html: Explain what about this content violates the %{tos_link}. Please be as specific as possible and %{include_link}. All information provided will remain confidential.
+          content_policy: Content Policy
+          description_html: Explain how the content you are reporting violates the %{content_policy_link} or other parts of the %{tos_link}. Please be as specific as possible and %{include_link}. All information provided will remain confidential.
           error: Please describe what you are reporting and why you are reporting it.
           include: include all relevant links and other information in your report
           label: Description of the content you are reporting (required)


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6922

## Purpose

Updates the wording and links of the "Description of the content you are reporting" note

## References

per discussion in jira+slack

## Credit

lydia-theda
