### PR TITLE
AO3-6933 Add spam checking to user comments

### DIFF
--- a/app/controllers/admin/admin_users_controller.rb
+++ b/app/controllers/admin/admin_users_controller.rb
@@ -158,7 +158,7 @@ class Admin::AdminUsersController < Admin::BaseController
     # comments are special and needs to be handled separately
     @user.comments.each do |comment|
       AdminActivity.log_action(current_admin, comment, action: "destroy spam", summary: comment.inspect)
-      # Akismet spam procedures are skipped, since logged-in comments aren't spam-checked anyways
+      comment.mark_as_spam!
       comment.destroy_or_mark_deleted # comments with replies cannot be destroyed, mark deleted instead
     end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -429,6 +429,12 @@ class User < ApplicationRecord
     has_role?(:no_resets)
   end
 
+  # Should this user's comments be spam-checked?
+  def should_spam_check_comments?
+    # When account_age_threshold_for_comment_spam_check is 0, no users' comments should be spam-checked
+    (Time.zone.now.to_date - created_at.to_date).to_i < AdminSetting.current.account_age_threshold_for_comment_spam_check
+  end
+
   # Creates log item tracking changes to user
   def create_log_item(options = {})
     options.reverse_merge! note: "System Generated", user_id: self.id

--- a/app/policies/admin_setting_policy.rb
+++ b/app/policies/admin_setting_policy.rb
@@ -8,6 +8,7 @@ class AdminSettingPolicy < ApplicationPolicy
       hide_spam
       invite_from_queue_enabled
       invite_from_queue_number
+      account_age_threshold_for_comment_spam_check
     ],
     "superadmin" => %i[
       account_creation_enabled
@@ -20,6 +21,7 @@ class AdminSettingPolicy < ApplicationPolicy
       enable_test_caching
       hide_spam
       guest_comments_off
+      account_age_threshold_for_comment_spam_check
       invite_from_queue_enabled
       invite_from_queue_frequency
       invite_from_queue_number

--- a/app/views/admin/settings/index.html.erb
+++ b/app/views/admin/settings/index.html.erb
@@ -64,12 +64,23 @@
 
       <dt><%= f.label :cache_expiration, t(".fields.cache_expiration") %></dt>
       <dd><%= admin_setting_text_field(f, :cache_expiration, size: "3") %></dd>
+    </dl>
+  </fieldset>
 
+  <fieldset>
+    <legend><%= t(".legend.content") %></legend>
+    <dl>
       <dt><%= admin_setting_checkbox(f, :hide_spam) %></dt>
       <dd><%= f.label :hide_spam, t(".fields.hide_spam") %></dd>
 
       <dt><%= admin_setting_checkbox(f, :guest_comments_off) %></dt>
       <dd><%= f.label :guest_comments_off, t(".fields.guest_comments_off") %></dd>
+
+      <dt><%= f.label :account_age_threshold_for_comment_spam_check, t(".fields.account_age_threshold_for_comment_spam_check") %></dt>
+      <dd>
+        <%= admin_setting_text_field(f, :account_age_threshold_for_comment_spam_check, size: "3") %>
+        <p role="label" class="footnote"><%= t(".fields.account_age_threshold_for_comment_spam_check_note") %></p>
+      </dd>
     </dl>
   </fieldset>
 

--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -342,6 +342,8 @@ en:
     settings:
       index:
         fields:
+          account_age_threshold_for_comment_spam_check: How old (in days) accounts should be before we stop checking comments for spam
+          account_age_threshold_for_comment_spam_check_note: Enter 0 to turn off comment spam checks for all logged in users.
           account_creation_enabled: Account creation enabled
           cache_expiration: How often (in minutes) should we refresh caching
           creation_requires_invite: Account creation requires invitation
@@ -363,6 +365,7 @@ en:
         legend:
           account_and_invitations: Accounts and Invitations
           actions: Actions
+          content: Content
           disable_support_form: Turn Off Support Form
           performance_and_misc: Performance and Misc
         queue_status: "%{number} people are scheduled to be sent invitations on %{date}."

--- a/db/migrate/20250312233933_add_account_age_threshold_for_comment_spam_check_to_admin_settings.rb
+++ b/db/migrate/20250312233933_add_account_age_threshold_for_comment_spam_check_to_admin_settings.rb
@@ -1,0 +1,5 @@
+class AddAccountAgeThresholdForCommentSpamCheckToAdminSettings < ActiveRecord::Migration[7.1]
+  def change
+    add_column :admin_settings, :account_age_threshold_for_comment_spam_check, :integer, default: 0, null: false
+  end
+end

--- a/test/fixtures/admin_settings.yml
+++ b/test/fixtures/admin_settings.yml
@@ -20,3 +20,4 @@ admin_setting_3:
   downloads_enabled: true
   hide_spam: false
   guest_comments_off: false
+  account_age_threshold_for_comment_spam_check: 0


### PR DESCRIPTION
# Pull Request Checklist

<!-- Mark steps in the checklist as complete by changing `[ ]` to `[X]` -->
* [x] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [ ] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [x] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [x] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-6933

## Purpose

- Adds a new admin setting called account_age_threshold_for_comment_spam_check (self-explanatory)
- When an account is too new, its comments are spam-checked
- When an account gets spam-banned by an admin, all of its comments are marked as spam and sent to Akismet for training

## Testing Instructions

See JIRA ticket

## Credit
EchoEkhi