### PR TITLE
AO3-6943 Fix flaky search filtering tests

### DIFF
--- a/features/search/filters.feature
+++ b/features/search/filters.feature
@@ -12,6 +12,7 @@ Feature: Filters
       And I post the work "A Hobbit's Meandering" with fandom "The Hobbit"
       And I post the work "Bilbo Does the Thing" with fandom "The Hobbit, Legend of Korra"
       And I post the work "Roonal Woozlib and the Ferrets of Nimh" with fandom "Harry Potter"
+      And the dashboard counts have expired
 
   @javascript
   Scenario: You can filter through a user's works using inclusion filters
@@ -106,6 +107,7 @@ Feature: Filters
       And I bookmark the work "Bilbo Does the Thing"
       And I bookmark the work "A Hobbit's Meandering"
       And I bookmark the work "Roonal Woozlib and the Ferrets of Nimh"
+      And the dashboard counts have expired
     When I go to recengine's user page
       And I follow "Bookmarks (3)"
     Then I should see "Bilbo Does the Thing"
@@ -138,6 +140,7 @@ Feature: Filters
       And I bookmark the work "Bilbo Does the Thing"
       And I bookmark the work "A Hobbit's Meandering"
       And I bookmark the work "Roonal Woozlib and the Ferrets of Nimh"
+      And the dashboard counts have expired
     When I go to recengine's user page
       And I follow "Bookmarks (3)"
     When I press "Fandoms" within "dd.exclude"
@@ -287,6 +290,7 @@ Feature: Filters
       And I am logged in as "recengine"
       And I bookmark the work "A Hobbit's Meandering" with the tags "fun"
       And I bookmark the work "Bilbo Does the Thing" with the tags "fun little crossover"
+      And the dashboard counts have expired
 
     When I go to my bookmarks page
       And I fill in "Other work tags to include" with "legend korra"

--- a/features/step_definitions/search_steps.rb
+++ b/features/step_definitions/search_steps.rb
@@ -24,3 +24,8 @@ Given /^dashboard counts expire after (\d+) seconds?$/ do |seconds|
   stub_const("ArchiveConfig", OpenStruct.new(ArchiveConfig))
   ArchiveConfig.SECONDS_UNTIL_DASHBOARD_COUNTS_EXPIRE = seconds.to_i
 end
+
+When "the dashboard counts have expired" do
+  step "all indexing jobs have been run"
+  step "it is currently #{ArchiveConfig.SECONDS_UNTIL_DASHBOARD_COUNTS_EXPIRE} seconds from now"
+end


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6943

## Purpose

Add some indexing and waiting steps to the search filters features to make sure the dashboard count and its cache are up to date.

## Testing Instructions

No manual QA required. Without the fix, [20 test runs](https://github.com/Bilka2/otwarchive/actions/runs/13882003791) resulted in 12 failures. With the fixes [20 test runs](https://github.com/Bilka2/otwarchive/actions/runs/13882215668) result in no failures.

## References

PRs with failures:
#5096 https://github.com/otwcode/otwarchive/actions/runs/13869384770/job/38814060572
#5100 https://github.com/otwcode/otwarchive/actions/runs/13865383071/job/38803258894 (with partial fix)

## Credit

Bilka
