### PR TITLE
AO3-6877 Change collection name to title for notes on works that fill prompts

### DIFF
--- a/app/views/works/_work_header_notes.html.erb
+++ b/app/views/works/_work_header_notes.html.erb
@@ -45,9 +45,9 @@
       <% unless claim.request_prompt.nil? %>
         <li><%= ts("In response to a ") %><%= link_to("prompt", collection_prompt_path(claim.collection, claim.request_prompt)) %> <%= ts("by") %>
           <% if claim.request_prompt.anonymous? %>
-            <%= ts("Anonymous in the ") %><%= link_to(claim.collection.name, collection_path(claim.collection)) %>
+            <%= ts("Anonymous in the ") %><%= link_to(claim.collection.title, collection_path(claim.collection)) %>
           <% else %>
-            <%= link_to(claim.request_signup.pseud.byline, user_pseud_path(claim.request_signup.user, claim.request_signup.pseud)) %> <%= ts(" in the ") %> <%= link_to(claim.collection.name, collection_path(claim.collection)) %>
+            <%= link_to(claim.request_signup.pseud.byline, user_pseud_path(claim.request_signup.user, claim.request_signup.pseud)) %> <%= ts(" in the ") %> <%= link_to(claim.collection.title, collection_path(claim.collection)) %>
           <% end %>
           <%= ts("collection.") %>
         </li>

--- a/features/prompt_memes_b/challenge_promptmeme_posting_fills.feature
+++ b/features/prompt_memes_b/challenge_promptmeme_posting_fills.feature
@@ -41,7 +41,7 @@ Feature: Prompt Meme Challenge
     And I press "Post"
   Then I should see "Kinky Story"
     And I should find a list for associations
-    And I should see "In response to a prompt by Anonymous in the promptcollection collection"
+    And I should see "In response to a prompt by Anonymous in the The Kissing Game collection"
     And I should see a link "prompt"
     And 1 email should be delivered to "my1@e.org"
 # TODO: when work_anonymous is implemented, test that the prompt filler can be anon too

--- a/features/prompt_memes_c/challenge_promptmeme_claims.feature
+++ b/features/prompt_memes_c/challenge_promptmeme_claims.feature
@@ -446,3 +446,11 @@ Feature: Prompt Meme Challenge
       And I go to "Battle 12" collection's page
       And I follow "Prompt Form"
     Then I should not see "any user who claims your prompt to gift you a work in response to your prompt regardless of your preference settings"
+
+  Scenario: When a work is posted to fulfill a prompt, the notes should contain the collection title
+  Given I have Battle 12 prompt meme fully set up
+    And everyone has signed up for Battle 12
+  When I am logged in as "myname1"
+    And I claim a prompt from "Battle 12"
+    And I fulfill my claim
+  Then I should see "In response to a prompt by myname4 in the Battle 12 collection"


### PR DESCRIPTION


# Pull Request Checklist

<!-- Mark steps in the checklist as complete by changing `[ ]` to `[X]` -->
* [X] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [X] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [X] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [X] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [X] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-6877 

## Purpose

A work that fulfills a prompt is posted with a note: “In response to a prompt by whoever in the Collection Title collection.” The collection title is used in this note now instead of the collection name. 

## Credit

Emily Wiegand (she/her)
