### PR TITLE
AO3-6945 Treat vertical bar (pipe, |) as a word delimiter in autocomplete

### DIFF
--- a/features/other_a/autocomplete.feature
+++ b/features/other_a/autocomplete.feature
@@ -237,3 +237,13 @@ Feature: Display autocomplete for tags
     # Zero width space tag
     When I enter "​" in the "tag_merger_string_autocomplete" autocomplete field
     Then I should not see "No suggestions found" in the autocomplete
+
+  @javascript
+  Scenario: Vertical bar is treated as a word separator
+    Given I am logged in
+      And a canonical character "Taylor Hebert | Skitter | Weaver"
+      And I go to the new work page
+    When I enter "|" in the "Characters" autocomplete field
+    Then I should see "No suggestions found" in the autocomplete
+    When I enter "Taylor|Skitter" in the "Characters" autocomplete field
+    Then I should see "Taylor Hebert | Skitter | Weaver" in the autocomplete

--- a/lib/autocomplete_source.rb
+++ b/lib/autocomplete_source.rb
@@ -246,9 +246,9 @@ module AutocompleteSource
       # letters with accents or other diacritics.
       normalized = self.transliterate(string).downcase.to_s
 
-      # Split on one or more spaces, ampersand, slash, double quotation mark,
-      # opening parenthesis, closing parenthesis (just in case), tilde, hyphen
-      normalized.split(/(?:\s+|\&|\/|"|\(|\)|\~|-)/).reject(&:blank?)
+      # Split on one or more spaces, ampersands, slashes, double quotation marks,
+      # opening parentheses, closing parentheses (just in case), tildes, hyphens, vertical bars
+      normalized.split(%r{(?:\s|&|/|"|\(|\)|~|-|\|)+})
     end
 
     def autocomplete_pieces(string)


### PR DESCRIPTION
## Pull Request Checklist

<!-- Mark steps in the checklist as complete by changing `[ ]` to `[X]` -->
* [x] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [x] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [x] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [x] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-6945

## Purpose

Makes autocomplete treat | as a word delimiter, which should make it parse queries like "taylor|skitter" correctly and not take 3-50 times longer to search when the query has " | "

## Credit

slavalamp (they/them)