### PR TITLE
AO3-6952 Skip submitting deleted comments to spam checker when spam-banning

### DIFF
--- a/app/controllers/admin/admin_users_controller.rb
+++ b/app/controllers/admin/admin_users_controller.rb
@@ -156,7 +156,7 @@ class Admin::AdminUsersController < Admin::BaseController
     end
 
     # comments are special and needs to be handled separately
-    @user.comments.each do |comment|
+    @user.comments.not_deleted.each do |comment|
       AdminActivity.log_action(current_admin, comment, action: "destroy spam", summary: comment.inspect)
       comment.submit_spam
       comment.destroy_or_mark_deleted # comments with replies cannot be destroyed, mark deleted instead

--- a/spec/controllers/admin/admin_users_controller_spec.rb
+++ b/spec/controllers/admin/admin_users_controller_spec.rb
@@ -483,6 +483,7 @@ describe Admin::AdminUsersController do
     let!(:collection1) { create(:collection) }
     let!(:collection2) { create(:collection) }
     let!(:comment) { create(:comment, pseud: user.default_pseud) }
+    let!(:deleted_comment) { create(:comment, pseud: user.default_pseud, is_deleted: true) }
 
     authorized_roles = %w[superadmin policy_and_abuse].freeze
 
@@ -536,6 +537,12 @@ describe Admin::AdminUsersController do
 
             it "sends all of the user's comments as spam reports to Akismet" do
               expect_any_instance_of(Comment).to receive(:submit_spam)
+
+              subject.call
+            end
+
+            it "does not send deleted comments to Akismet" do
+              expect(deleted_comment).to_not receive(:submit_spam)
 
               subject.call
             end


### PR DESCRIPTION
# Pull Request Checklist

<!-- Mark steps in the checklist as complete by changing `[ ]` to `[X]` -->
* [x] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [x] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [x] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [x] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-6952

## Purpose

Skip submitting marked-as-deleted comments to spam checker when banning a user for spam

## Credit

EchoEkhi
