### PR TITLE
AO3-6439 Fix pseud autocomplete on people search page when searching for a space

### DIFF
--- a/app/controllers/autocomplete_controller.rb
+++ b/app/controllers/autocomplete_controller.rb
@@ -23,8 +23,7 @@ class AutocompleteController < ApplicationController
   def pseud
     if params[:term].blank?
       # get the user's own pseuds
-      set_current_user
-      render_output(current_user.pseuds.collect(&:byline))
+      set_current_user { render_output(current_user.pseuds.collect(&:byline)) }
     else
       render_output(Pseud.autocomplete_lookup(search_param: params[:term], autocomplete_prefix: "autocomplete_pseud").map {|res| Pseud.fullname_from_autocomplete(res)})
     end

--- a/features/other_a/autocomplete.feature
+++ b/features/other_a/autocomplete.feature
@@ -106,6 +106,17 @@ Feature: Display autocomplete for tags
       And the pseud autocomplete should not contain "different_user (funny)"
 
   @javascript
+  Scenario: People search autocomplete shows current users pseuds when searching for space
+    Given I am logged in as "basic"
+      And "basic" creates the pseud "one"
+      And "basic" creates the pseud "two"
+      And I go to the search people page
+    When I enter " " in the "Name" autocomplete field
+    Then I should see "basic" in the autocomplete
+      And I should see "one (basic)" in the autocomplete
+      And I should see "two (basic)" in the autocomplete
+
+  @javascript
   Scenario: Characters in a fandom with non-ASCII uppercase letters should appear in the autocomplete.
 
     Given basic tags


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6439

## Purpose

Fix the pseud autocomplete on the people search page when typing a space into the field

## Credit

Bilka
