### PR TITLE
AO3-6955 fix gif icons not animating

### DIFF
--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -3,7 +3,7 @@ class Collection < ApplicationRecord
   include WorksOwner
 
   has_one_attached :icon do |attachable|
-    attachable.variant(:standard, resize_to_limit: [100, 100])
+    attachable.variant(:standard, resize_to_limit: [100, 100], loader: { n: -1 })
   end
 
   # i18n-tasks-use t("errors.attributes.icon.invalid_format")

--- a/app/models/pseud.rb
+++ b/app/models/pseud.rb
@@ -4,7 +4,7 @@ class Pseud < ApplicationRecord
   include Justifiable
 
   has_one_attached :icon do |attachable|
-    attachable.variant(:standard, resize_to_limit: [100, 100])
+    attachable.variant(:standard, resize_to_limit: [100, 100], loader: { n: -1 })
   end
 
   # i18n-tasks-use t("errors.attributes.icon.invalid_format")

--- a/app/models/skin.rb
+++ b/app/models/skin.rb
@@ -49,7 +49,7 @@ class Skin < ApplicationRecord
   accepts_nested_attributes_for :skin_parents, allow_destroy: true, reject_if: proc { |attrs| attrs[:position].blank? || (attrs[:parent_skin_title].blank? && attrs[:parent_skin_id].blank?) }
 
   has_one_attached :icon do |attachable|
-    attachable.variant(:standard, resize_to_limit: [100, 100])
+    attachable.variant(:standard, resize_to_limit: [100, 100], loader: { n: -1 })
   end
 
   # i18n-tasks-use t("errors.attributes.icon.invalid_format")


### PR DESCRIPTION
Issue: https://otwarchive.atlassian.net/browse/AO3-6955

hi i'm melo, i run superlove. i contacted the address `otw-coders@transformativeworks.org` about a potential fix for GIF icons not animating after the active storage migration, because i did a similar migration on my own site and noticed the same problem, and managed to fix it last night. i got a response that recommended i do a pull request so i've done so.

i'm unable to test this on a personal developer instance because my own dev instance is an experimental dockerized production instance that's not up to date, so keep that in mind.