### PR TITLE
AO3-6957 Fix highlight for form fields outside dl's

### DIFF
--- a/public/stylesheets/site/2.0/22-system-messages.css
+++ b/public/stylesheets/site/2.0/22-system-messages.css
@@ -76,7 +76,7 @@ ul.notes li, .error ul li, .notice ul li, .caution ul li, .alert.flash ul li {
   padding-left: 1.5em;
 }
 
-dt span.error, dd span.error {
+p span.error, dt span.error, dd span.error {
   display: block;
 }
 


### PR DESCRIPTION
# Pull Request Checklist

<!-- Mark steps in the checklist as complete by changing `[ ]` to `[X]` -->
* [x] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [ ] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [x] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [x] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue
https://otwarchive.atlassian.net/browse/AO3-6957

## Purpose

Fix highlight error for form fields outside definition lists.

## Credit

Isabel Nunes (she/her)
