### PR TITLE
AO3-6961 Fix incorrect classes on caution text and update Reversi styling of caution text

### DIFF
--- a/app/views/orphans/_orphan_pseud.html.erb
+++ b/app/views/orphans/_orphan_pseud.html.erb
@@ -2,13 +2,13 @@
 <% works = pseud.works.to_a %>
 <h2 class="heading"><%= ts("Orphan All Works by %{name}", name: pseud.name) %></h2>
 
-<p class="caution">
+<p class="caution notice">
   <%= ts("Orphaning all works by %{name} will", name: pseud.name)%>
   <strong><%= ts("permanently")%></strong>
   <%= ts("remove the pseud %{name} from the following work(s), their chapters, associated series, and any feedback replies you may have left on them.", name: pseud.name) %>
 </p>
 
-<p class="caution">
+<p class="caution notice">
   <%= ts("Unless another one of your pseuds is listed as a creator on the work(s) below, orphaning them will remove them from your account and re-attach them to the specially created orphan_account. Please note that this is")%>
   <strong><%= ts("permanent and irreversible.")%></strong>
   <%= ts("You are giving up control over the work(s),")%>
@@ -17,7 +17,7 @@
 
 <%= render "works/work_abbreviated_list", works: works %>
 
-<p class="caution">
+<p class="caution notice">
   <%= ts("Are you")%>
   <strong><%= ts("really")%></strong>
   <%= ts("sure you want to do this?")%>

--- a/app/views/orphans/_orphan_series.html.erb
+++ b/app/views/orphans/_orphan_series.html.erb
@@ -1,7 +1,7 @@
 <!--Descriptive page name, messages and instructions-->
 <h2 class="heading"><%= ts("Orphan Series") %></h2>
 
-<p class="caution">
+<p class="caution notice">
   <%= ts('Are you sure you want to <strong>permanently</strong> remove all identifying data from your series "%{title}", its works and chapters, and any feedback replies you may have left on them?', 
 :title => series.title).html_safe %>
 </p>

--- a/app/views/orphans/_orphan_user.html.erb
+++ b/app/views/orphans/_orphan_user.html.erb
@@ -6,7 +6,7 @@
 
 <p class="caution"><%= t(".orphaning_bylines_only_message_html") %></p>
 
-<p class="caution">
+<p class="caution notice">
   <%= ts("Orphaning a work removes it from your account and re-attaches it to the specially created orphan_account. Please note that this is")%>
   <strong><%= ts("permanent and irreversible.")%></strong>
   <%= ts("You are giving up control over the work,")%>
@@ -15,7 +15,7 @@
 
 <%= render "works/work_abbreviated_list", works: works %>
 
-<p class="caution">
+<p class="caution notice">
   <%= ts("Are you")%>
   <strong><%= ts("really")%></strong>
   <%= ts("sure you want to do this?")%>

--- a/app/views/orphans/_orphan_user.html.erb
+++ b/app/views/orphans/_orphan_user.html.erb
@@ -2,9 +2,9 @@
 <% works = user.works.to_a %>
 <h2 class="heading"><%= ts("Orphan All Works") %></h2>
 
-<p class="caution"><%= t(".orphaning_works_message_html") %></p>
+<p class="caution notice"><%= t(".orphaning_works_message_html") %></p>
 
-<p class="caution"><%= t(".orphaning_bylines_only_message_html") %></p>
+<p class="caution notice"><%= t(".orphaning_bylines_only_message_html") %></p>
 
 <p class="caution notice">
   <%= ts("Orphaning a work removes it from your account and re-attaches it to the specially created orphan_account. Please note that this is")%>

--- a/app/views/orphans/_orphan_work.html.erb
+++ b/app/views/orphans/_orphan_work.html.erb
@@ -1,13 +1,13 @@
 <!--Descriptive page name, messages and instructions-->
 <h2 class="heading"><%= ts('Orphan Works') %></h2>
 
-<p class="caution">
+<p class="caution notice">
   <%= ts("Orphaning will")%>
   <strong><%= ts("permanently")%></strong>
   <%= ts("remove all identifying data from the following work(s), their chapters, associated series, and any feedback replies you may have left on them.") %>
 </p>
 
-<p class="caution">
+<p class="caution notice">
   <%= ts("Orphaning a work removes it from your account and re-attaches it to the specially created orphan_account. Please note that this is")%>
   <strong><%= ts("permanent and irreversible.")%></strong>
   <%= ts("You are giving up control over the work,")%>
@@ -16,7 +16,7 @@
 
 <%= render "works/work_abbreviated_list", :works => works %>
 
-<p class="caution">
+<p class="caution notice">
   <%= ts("Are you")%>
   <strong><%= ts("really")%></strong>
   <%= ts("sure you want to do this?")%>

--- a/app/views/users/change_username.html.erb
+++ b/app/views/users/change_username.html.erb
@@ -1,7 +1,7 @@
 <!--Descriptive page name, messages and instructions-->
 <h2 class="heading"><%= ts("Change My User Name") %></h2>
 <%= error_messages_for :user %>
-<div class="caution">
+<div class="caution notice">
   <p>
     <strong><%= t(".caution") %></strong>
     <%= t(".change_window", count: ArchiveConfig.USER_RENAME_LIMIT_DAYS) %>

--- a/app/views/works/_adult.html.erb
+++ b/app/views/works/_adult.html.erb
@@ -1,10 +1,10 @@
 <h2 class="landmark heading"><%= t(".page_title") %></h2>
 
-<p class="caution">
+<p class="caution notice">
   <%= t(".caution") %>
 </p>
 
-<ul class="actions" role="navigation">
+<ul class="actions">
   <li>
     <%= link_to t(".navigation.continue"), current_path_with(view_adult: true) %>
   </li>

--- a/app/views/works/confirm_delete_multiple.html.erb
+++ b/app/views/works/confirm_delete_multiple.html.erb
@@ -1,7 +1,7 @@
 <!--Descriptive page name, messages and instructions-->
 <h2 id="work-form-heading"><%= ts("Delete Works?") %></h2>
 
-<p class="caution">
+<p class="caution notice">
   You are about to delete <strong>all</strong> of the following works PERMANENTLY. This CANNOT BE UNDONE and all bookmarks, comments, and kudos will be lost. 
 </p>
 

--- a/public/stylesheets/masters/reversi/reversi_site_screen_.css
+++ b/public/stylesheets/masters/reversi/reversi_site_screen_.css
@@ -362,3 +362,8 @@ form dd.required {
 .filters .expander {
   color: #eee;
 }
+
+.caution {
+  border-color: #807640;
+  color: #dbbc54;
+}


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6961

## Purpose

Updates some HTML classes to ensure we have consistent styling of caution text, and updates Reversi so the caution text isn't the same color as regular text.

## Testing Instructions

Refer to Jira.
