### PR TITLE
AO3-6962 Fix color issues on tag set nomination review pages in Reversi and Snow Blue

### DIFF
--- a/public/stylesheets/masters/reversi/reversi_site_screen_.css
+++ b/public/stylesheets/masters/reversi/reversi_site_screen_.css
@@ -80,7 +80,8 @@ th,
 .javascript,
 .statistics .index li:nth-of-type(even),
 #tos_prompt,
-.announcement input[type="submit"] {
+.announcement input[type="submit"],
+.nomination dt {
   background: #333;
 }
 
@@ -275,6 +276,8 @@ button,
 .actions button:hover,
 .actions input:hover,
 #dashboard a:hover,
+label.action:hover,
+.action:hover,
 .actions a:focus,
 .actions button:focus,
 .actions input:focus,

--- a/public/stylesheets/masters/snow_blue/snow_blue_site_screen_.css
+++ b/public/stylesheets/masters/snow_blue/snow_blue_site_screen_.css
@@ -18,6 +18,8 @@ a.tag:hover {
 .actions a:hover,
 .actions button:hover,
 .actions input:hover,
+label.action:hover,
+.action:hover,
 .delete a,
 span.delete,
 span.unread,


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6962

## Purpose

* Fixes the background color of tag set nominations in Reversi.
* Fixes the hover styling of certain types of actions on the tag set review pages in Reversi and Snow Blue.

## Testing Instructions

Refer to Jira. 
