### PR TITLE
AO3-6938 Fix Related Works page missing username in browser page title

### DIFF
--- a/app/controllers/related_works_controller.rb
+++ b/app/controllers/related_works_controller.rb
@@ -5,6 +5,7 @@ class RelatedWorksController < ApplicationController
   before_action :get_instance_variables, except: [:index]
 
   def index
+    @page_subtitle = ts("%{username} - Related Works", username: @user.login)
     @translations_of_user = @user.related_works.posted.where(translation: true)
     @remixes_of_user = @user.related_works.posted.where(translation: false)
     @translations_by_user = @user.parent_work_relationships.posted.where(translation: true)

--- a/app/controllers/related_works_controller.rb
+++ b/app/controllers/related_works_controller.rb
@@ -5,7 +5,7 @@ class RelatedWorksController < ApplicationController
   before_action :get_instance_variables, except: [:index]
 
   def index
-    @page_subtitle = ts("%{username} - Related Works", username: @user.login)
+    @page_subtitle = t(".page_title", login: @user.login)
     @translations_of_user = @user.related_works.posted.where(translation: true)
     @remixes_of_user = @user.related_works.posted.where(translation: false)
     @translations_by_user = @user.parent_work_relationships.posted.where(translation: true)

--- a/app/views/related_works/index.html.erb
+++ b/app/views/related_works/index.html.erb
@@ -1,6 +1,6 @@
 <!--Descriptive page name, messages and instructions-->
 <% if @user %>
-<h2 class="heading"><%= ts("%{user_login}'s Related Works", :user_login => @user.login) %></h2>
+<h2 class="heading"><%= t(".page_heading", login: @user.login) %></h2>
 <% end %>
 <!--/descriptions-->
 

--- a/config/locales/controllers/en.yml
+++ b/config/locales/controllers/en.yml
@@ -150,7 +150,7 @@ en:
       success: Question order has been successfully updated.
   related_works:
     index:
-      page_title: '%{login} - Related Works'
+      page_title: "%{login} - Related Works"
   series:
     index:
       page_title: "%{username} - Series"

--- a/config/locales/controllers/en.yml
+++ b/config/locales/controllers/en.yml
@@ -148,6 +148,9 @@ en:
     not_found: Sorry, we couldn't find the FAQ you were looking for.
     update_positions:
       success: Question order has been successfully updated.
+  related_works:
+    index:
+      page_title: '%{login} - Related Works'
   series:
     index:
       page_title: "%{username} - Series"

--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -1812,6 +1812,9 @@ en:
       make_default: Make this name default
       name: Name
       submit: Submit
+  related_works:
+    index:
+      page_heading: "%{login}'s Related Works"
   skins:
     confirm_delete:
       confirm_html: Are you sure you want to <strong><em>delete</em></strong> the skin "%{skin_title}"?

--- a/spec/controllers/related_works_controller_spec.rb
+++ b/spec/controllers/related_works_controller_spec.rb
@@ -28,6 +28,16 @@ describe RelatedWorksController do
         it_redirects_to_with_error(user_related_works_path, "Sorry, we couldn't find that user")
       end
     end
+
+    context 'for a valid user' do
+      before(:each) do
+        get :index, params: { user_id: parent_creator.login }
+      end
+
+      it 'sets the page subtitle correctly' do
+        expect(assigns(:page_subtitle)).to eq("#{parent_creator.login} - Related Works")
+      end
+    end
   end
 
   describe "PUT #update" do

--- a/spec/controllers/related_works_controller_spec.rb
+++ b/spec/controllers/related_works_controller_spec.rb
@@ -29,12 +29,12 @@ describe RelatedWorksController do
       end
     end
 
-    context 'for a valid user' do
+    context "for a valid user" do
       before(:each) do
         get :index, params: { user_id: parent_creator.login }
       end
 
-      it 'sets the page subtitle correctly' do
+      it "sets the page subtitle correctly" do
         expect(assigns(:page_subtitle)).to eq("#{parent_creator.login} - Related Works")
       end
     end


### PR DESCRIPTION
# Pull Request Checklist

<!-- Mark steps in the checklist as complete by changing `[ ]` to `[X]` -->
* [X] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [X] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [X] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [X] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [X] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/issues/AO3-6938

## Purpose

- Fix Related Work's index view title not showing the username on Related Works page
- Fix Related Work's index view heading to use i18n instead.

## Testing Instructions

1. Go to https://archiveofourown.org/users/[user]/related_works
2. Check the page title and the heading of the page

## Credit

Michelle Tanoto

**Note:** I would like to be invited to the Jira as this is my first pull request :) 