### PR TITLE
AO3-6935 Change skin title uniqueness validation to case insensitive

### DIFF
--- a/app/models/skin.rb
+++ b/app/models/skin.rb
@@ -111,7 +111,7 @@ class Skin < ApplicationRecord
     errors.add(:base, :no_public_preview)
   end
 
-  validates :title, presence: true, uniqueness: { case_sensitive: true }
+  validates :title, presence: true, uniqueness: { case_sensitive: false }
   validate :allowed_title
   def allowed_title
     return true unless self.title.match(/archive/i)

--- a/spec/models/skin_spec.rb
+++ b/spec/models/skin_spec.rb
@@ -204,6 +204,13 @@ describe Skin do
       expect(skin2.errors[:title]).not_to be_empty
     end
 
+    it "has a unique title ignoring case" do
+      expect(@skin.save).to be_truthy
+      skin2 = Skin.new(title: "test skin")
+      expect(skin2.save).not_to be_truthy
+      expect(skin2.errors[:title]).not_to be_empty
+    end
+
     it "requires a preview image if public" do
       @skin.css = "body {background: #fff;}"
       @skin.public = true


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6935

## Purpose

Change the validation so you no longer get a confusing error 500 when your skin title matches another one except for capitalisation.

## Credit

Bilka
