### PR TITLE
AO3-3524 Add 4shared.com to allowed embeds

### DIFF
--- a/lib/otw_sanitize/embed_sanitizer.rb
+++ b/lib/otw_sanitize/embed_sanitizer.rb
@@ -7,6 +7,7 @@ module OtwSanitize
   # Creates a Sanitize transformer to sanitize embedded media
   class EmbedSanitizer
     ALLOWLIST_REGEXES = {
+      "4shared":        %r{^(w\.)?4shared\.com\/web\/embed},
       archiveorg:       %r{^archive\.org\/embed/},
       bilibili:         %r{^(player\.)?bilibili\.com/},
       criticalcommons:  %r{^criticalcommons\.org/},
@@ -27,6 +28,7 @@ module OtwSanitize
     ].freeze
 
     SUPPORTS_HTTPS = %i[
+      4shared
       archiveorg bilibili eighttracks podfic
       soundcloud spotify viddersnet viddertube vimeo youtube
     ].freeze

--- a/lib/otw_sanitize/embed_sanitizer.rb
+++ b/lib/otw_sanitize/embed_sanitizer.rb
@@ -7,19 +7,19 @@ module OtwSanitize
   # Creates a Sanitize transformer to sanitize embedded media
   class EmbedSanitizer
     ALLOWLIST_REGEXES = {
-      "4shared":        %r{^(w\.)?4shared\.com\/web\/embed},
-      archiveorg:       %r{^archive\.org\/embed/},
-      bilibili:         %r{^(player\.)?bilibili\.com/},
-      criticalcommons:  %r{^criticalcommons\.org/},
-      eighttracks:      %r{^8tracks\.com/},
-      google:           %r{^google\.com/},
-      podfic:           %r{^podfic\.com/},
-      soundcloud:       %r{^(w\.)?soundcloud\.com/},
-      spotify:          %r{^(open\.)?spotify\.com/},
-      viddersnet:       %r{^vidders\.net/},
-      viddertube:       %r{^viddertube\.com/},
-      vimeo:            %r{^(player\.)?vimeo\.com/},
-      youtube:          %r{^youtube(-nocookie)?\.com/}
+      "4shared": %r{^(w\.)?4shared\.com/web/embed},
+      archiveorg: %r{^archive\.org/embed/},
+      bilibili: %r{^(player\.)?bilibili\.com/},
+      criticalcommons: %r{^criticalcommons\.org/},
+      eighttracks: %r{^8tracks\.com/},
+      google: %r{^google\.com/},
+      podfic: %r{^podfic\.com/},
+      soundcloud: %r{^(w\.)?soundcloud\.com/},
+      spotify: %r{^(open\.)?spotify\.com/},
+      viddersnet: %r{^vidders\.net/},
+      viddertube: %r{^viddertube\.com/},
+      vimeo: %r{^(player\.)?vimeo\.com/},
+      youtube: %r{^youtube(-nocookie)?\.com/}
     }.freeze
 
     ALLOWS_FLASHVARS = %i[
@@ -56,7 +56,7 @@ module OtwSanitize
 
       ensure_https
 
-      if parent_name == 'object'
+      if parent_name == "object"
         sanitize_object
       else
         sanitize_embed
@@ -67,9 +67,7 @@ module OtwSanitize
       node.name.to_s.downcase
     end
 
-    def parent
-      node.parent
-    end
+    delegate :parent, to: :node
 
     def parent_name
       parent.name.to_s.downcase if parent
@@ -78,14 +76,15 @@ module OtwSanitize
     # Since the transformer receives the deepest nodes first, we look for a
     # <param> element whose parent is an <object>, or an embed or iframe
     def embed_node?
-      (node_name == 'param' && parent_name == 'object') ||
-        %w(embed iframe).include?(node_name)
+      (node_name == "param" && parent_name == "object") ||
+        %w[embed iframe].include?(node_name)
     end
 
     # Compare the url to our list of allowlisted sources
     # and return the appropriate source symbol
     def source
       return @source if @source
+
       ALLOWLIST_REGEXES.each_pair do |name, reg|
         if source_url =~ reg
           @source = name
@@ -98,12 +97,14 @@ module OtwSanitize
     # Get the url of the thing we're embedding and standardize it
     def source_url
       return @source_url if @source_url
-      if node_name == 'param'
+
+      if node_name == "param"
         # Quick XPath search to find the <param> node that contains the video URL.
-        return unless movie_node = node.parent.search('param[@name="movie"]')[0]
-        url = movie_node['value']
+        return unless (movie_node = node.parent.search('param[@name="movie"]')[0])
+
+        url = movie_node["value"]
       else
-        url = node['src']
+        url = node["src"]
       end
       @source_url = standardize_url(url)
     end
@@ -113,17 +114,22 @@ module OtwSanitize
       protocol_regex = %r{^(?:https?:)?//(?:www\.)?}i
       # normalize the url
       url = url&.gsub(protocol_regex, "")
-      Addressable::URI.parse(url).normalize.to_s rescue nil
+      begin
+        Addressable::URI.parse(url).normalize.to_s
+      rescue StandardError
+        nil
+      end
     end
 
     # For sites that support https, ensure we use a secure embed
     def ensure_https
-      return unless supports_https? && node['src'].present?
-      node['src'] = node['src'].gsub("http:", "https:")
-      if allows_flashvars? && node['flashvars'].present?
-        node['flashvars'] = node['flashvars'].gsub("http:", "https:")
-        node['flashvars'] = node['flashvars'].gsub("http%3A", "https%3A")
-      end
+      return unless supports_https? && node["src"].present?
+
+      node["src"] = node["src"].gsub("http:", "https:")
+      return unless allows_flashvars? && node["flashvars"].present?
+
+      node["flashvars"] = node["flashvars"].gsub("http:", "https:")
+      node["flashvars"] = node["flashvars"].gsub("http%3A", "https%3A")
     end
 
     # We're now certain that this is an embed from a trusted source, but we
@@ -135,9 +141,9 @@ module OtwSanitize
         parent,
         elements: %w[embed object param],
         attributes: {
-          'embed'  => %w[allowfullscreen height src type width],
-          'object' => %w[height width],
-          'param'  => %w[name value]
+          "embed" => %w[allowfullscreen height src type width],
+          "object" => %w[height width],
+          "param" => %w[name value]
         }
       )
 
@@ -151,27 +157,27 @@ module OtwSanitize
         node,
         elements: %w[embed iframe],
         attributes: {
-          'embed' => %w[
+          "embed" => %w[
             allowfullscreen height src type width
           ] + optional_embed_attributes,
-          'iframe' => %w[
+          "iframe" => %w[
             allowfullscreen frameborder height src title
             class type width
           ]
         }
       )
 
-      if node_name == 'embed'
+      if node_name == "embed"
         disable_scripts(node)
-        node['flashvars'] = "" unless allows_flashvars?
+        node["flashvars"] = "" unless allows_flashvars?
       end
       { node_allowlist: [node] }
     end
 
     # disable script access and networking
     def disable_scripts(embed_node)
-      embed_node['allowscriptaccess'] = 'never'
-      embed_node['allownetworking'] = 'internal'
+      embed_node["allowscriptaccess"] = "never"
+      embed_node["allownetworking"] = "internal"
 
       embed_node.search("param").each do |param_node|
         param_node.unlink if param_node[:name].casecmp?("allowscriptaccess") ||

--- a/lib/otw_sanitize/embed_sanitizer.rb
+++ b/lib/otw_sanitize/embed_sanitizer.rb
@@ -7,7 +7,7 @@ module OtwSanitize
   # Creates a Sanitize transformer to sanitize embedded media
   class EmbedSanitizer
     ALLOWLIST_REGEXES = {
-      "4shared": %r{^(w\.)?4shared\.com/web/embed},
+      "4shared": %r{^4shared\.com/web/embed},
       archiveorg: %r{^archive\.org/embed/},
       bilibili: %r{^(player\.)?bilibili\.com/},
       criticalcommons: %r{^criticalcommons\.org/},

--- a/spec/lib/html_cleaner_spec.rb
+++ b/spec/lib/html_cleaner_spec.rb
@@ -11,7 +11,7 @@ describe HtmlCleaner do
         %w[youtube.com youtube-nocookie.com vimeo.com player.vimeo.com 
            vidders.net criticalcommons.org google.com podfic.com archive.org
            open.spotify.com spotify.com 8tracks.com w.soundcloud.com soundcloud.com viddertube.com
-           bilibili.com player.bilibili.com].each do |source|
+           bilibili.com player.bilibili.com 4shared.com/web/embed].each do |source|
 
           it "keeps embeds from #{source}" do
             html = '<iframe width="560" height="315" src="//' + source + '/embed/123" frameborder="0"></iframe>'
@@ -23,7 +23,7 @@ describe HtmlCleaner do
         %w[youtube.com youtube-nocookie.com vimeo.com player.vimeo.com
            archive.org 8tracks.com podfic.com
            open.spotify.com spotify.com w.soundcloud.com soundcloud.com vidders.net viddertube.com
-           bilibili.com player.bilibili.com].each do |source|
+           bilibili.com player.bilibili.com 4shared.com/web/embed].each do |source|
 
           it "converts src to https for #{source}" do
             html = '<iframe width="560" height="315" src="http://' + source + '/embed/123" frameborder="0"></iframe>'


### PR DESCRIPTION
# Pull Request Checklist

## Issue

https://otwarchive.atlassian.net/browse/AO3-3524

## Purpose

Add 4shared.com to the list of allowed embed sources (more information on the ticket, linked above). I also ran Rubocop, since the allowlisting was a very small change.