### PR TITLE
AO3-6956 Corrected error message for duplicate comments

### DIFF
--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -71,7 +71,7 @@ class Comment < ApplicationRecord
   validates :comment_content, uniqueness: {
     scope: [:commentable_id, :commentable_type, :name, :email, :pseud_id],
     unless: :is_deleted?,
-    message: ts("^This comment has already been left on this work. (It may not appear right away for performance reasons.)")
+    message: ts("^You’ve already left this comment here. (It may not appear right away for performance reasons.")
   }
 
   scope :ordered_by_date, -> { order('created_at DESC') }

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -71,7 +71,7 @@ class Comment < ApplicationRecord
   validates :comment_content, uniqueness: {
     scope: [:commentable_id, :commentable_type, :name, :email, :pseud_id],
     unless: :is_deleted?,
-    message: ts("^You’ve already left this comment here. (It may not appear right away for performance reasons.")
+    message: :duplicate_comment
   }
 
   scope :ordered_by_date, -> { order('created_at DESC') }

--- a/config/locales/models/en.yml
+++ b/config/locales/models/en.yml
@@ -91,7 +91,7 @@ en:
         comment:
           attributes:
             comment_content:
-              duplicate_comment: ^You've already left this comment here. (It may not appear right away for performance reasons.)
+              duplicate_comment: "^You've already left this comment here. (It may not appear right away for performance reasons.)"
             commentable:
               format: "%{message}"
               guest_replies_off: Sorry, this user doesn't allow non-Archive users to reply to their comments.

--- a/config/locales/models/en.yml
+++ b/config/locales/models/en.yml
@@ -91,8 +91,7 @@ en:
         comment:
           attributes:
             comment_content:
-              duplicate_comment: You've already left this comment here. (It may not appear right away for performance reasons.)
-              format: "%{message}"
+              duplicate_comment: ^You've already left this comment here. (It may not appear right away for performance reasons.)
             commentable:
               format: "%{message}"
               guest_replies_off: Sorry, this user doesn't allow non-Archive users to reply to their comments.

--- a/config/locales/models/en.yml
+++ b/config/locales/models/en.yml
@@ -97,6 +97,9 @@ en:
               blocked_comment: Sorry, you have been blocked by one or more of this work's creators.
               blocked_reply: Sorry, you have been blocked by that user.
               format: "%{message}"
+            comment_content:
+              duplicate_comment: You've already left this comment here. (It may not appear right away for performance reasons.)
+              format: "%{message}"
         creatorship:
           attributes:
             pseud_id:

--- a/config/locales/models/en.yml
+++ b/config/locales/models/en.yml
@@ -90,15 +90,15 @@ en:
               required: can't be blank
         comment:
           attributes:
+            comment_content:
+              duplicate_comment: You've already left this comment here. (It may not appear right away for performance reasons.)
+              format: "%{message}"
             commentable:
               format: "%{message}"
               guest_replies_off: Sorry, this user doesn't allow non-Archive users to reply to their comments.
             user:
               blocked_comment: Sorry, you have been blocked by one or more of this work's creators.
               blocked_reply: Sorry, you have been blocked by that user.
-              format: "%{message}"
-            comment_content:
-              duplicate_comment: You've already left this comment here. (It may not appear right away for performance reasons.)
               format: "%{message}"
         creatorship:
           attributes:

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -94,7 +94,7 @@ describe Comment do
     end
   end
 
-  context "with an existing comment from the same user" do
+  context "with an existing comment from the same user" do 
     let(:first_comment) { create(:comment) }
 
     let(:second_comment) do
@@ -102,9 +102,10 @@ describe Comment do
       Comment.new(first_comment.attributes.slice(*attributes))
     end
 
-    it "should be invalid if exactly duplicated" do
+    it "should be invalid if exactly duplicated" do |message:|
       expect(second_comment.valid?).to be_falsy
       expect(second_comment.errors.attribute_names).to include(:comment_content)
+      expect(comment.errors.full_messages).to include(message)
     end
 
     it "should not be invalid if in the process of being deleted" do

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -105,7 +105,7 @@ describe Comment do
     it "should be invalid if exactly duplicated" do 
       expect(second_comment.valid?).to be_falsy
       expect(second_comment.errors.attribute_names).to include(:comment_content)
-      expect(second_comment.errors.full_messages).to include("You've already left this comment here")
+      expect(second_comment.errors.full_messages).to include("You've already left this comment here. (It may not appear right away for performance reasons.)")
     end
 
     it "should not be invalid if in the process of being deleted" do

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -105,7 +105,7 @@ describe Comment do
     it "should be invalid if exactly duplicated" do 
       expect(second_comment.valid?).to be_falsy
       expect(second_comment.errors.attribute_names).to include(:comment_content)
-      expect(second_comment.errors.full_messages).to include("You've already left this comment here. (It may not appear right away for performance reasons.)")
+      expect(second_comment.errors.full_messages.first).to include("You've already")
     end
 
     it "should not be invalid if in the process of being deleted" do

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -102,10 +102,10 @@ describe Comment do
       Comment.new(first_comment.attributes.slice(*attributes))
     end
 
-    it "should be invalid if exactly duplicated" do |message:|
+    it "should be invalid if exactly duplicated" do 
       expect(second_comment.valid?).to be_falsy
       expect(second_comment.errors.attribute_names).to include(:comment_content)
-      expect(comment.errors.full_messages).to include(message)
+      expect(second_comment.errors.full_messages).to include('You\'ve already left this comment here. (It may not appear right away for performance reasons.)')
     end
 
     it "should not be invalid if in the process of being deleted" do

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -105,7 +105,7 @@ describe Comment do
     it "should be invalid if exactly duplicated" do 
       expect(second_comment.valid?).to be_falsy
       expect(second_comment.errors.attribute_names).to include(:comment_content)
-      expect(second_comment.errors.full_messages).to include('You\'ve already left this comment here. (It may not appear right away for performance reasons.)')
+      expect(second_comment.errors.full_messages).to include("You've already left this comment here")
     end
 
     it "should not be invalid if in the process of being deleted" do


### PR DESCRIPTION
# Pull Request Checklist

<!-- Mark steps in the checklist as complete by changing `[ ]` to `[X]` -->
* [X] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [X] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [X] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [X] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [X] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-6956 

## Purpose

This pull request changes the error message upon posting a duplicate comment from "This comment has already been left on this work. (It may not appear right away for performance reasons." to the more descriptive (and accurate) "You’ve already left this comment here. (It may not appear right away for performance reasons.)"


## Credit

niic (he/him)
