### PR TITLE
AO3-5712 Prevent non-fandom tags from another tagset association

### DIFF
--- a/app/models/prompt.rb
+++ b/app/models/prompt.rb
@@ -163,22 +163,29 @@ class Prompt < ApplicationRecord
   validate :restricted_tags
   def restricted_tags
     restriction = prompt_restriction
-    if restriction
-      TagSet::TAG_TYPES_RESTRICTED_TO_FANDOM.each do |tag_type|
-        if restriction.send("#{tag_type}_restrict_to_fandom")
-          # tag_type is one of a set set so we know it is safe for constantize
-          allowed_tags = tag_type.classify.constantize.with_parents(tag_set.fandom_taglist).canonical
-          disallowed_taglist = tag_set ? eval("tag_set.#{tag_type}_taglist") - allowed_tags : []
-          # check for tag set associations
-          disallowed_taglist.reject! {|tag| TagSetAssociation.where(tag_id: tag.id, parent_tag_id: tag_set.fandom_taglist).exists?}
-          unless disallowed_taglist.empty?
-            errors.add(:base, ts("^These %{tag_label} tags in your %{prompt_type} are not in the selected fandom(s), %{fandom}: %{taglist} (Your moderator may be able to fix this.)",
-                              prompt_type: self.class.name.downcase,
-                              tag_label: tag_type_label_name(tag_type).downcase, fandom: tag_set.fandom_taglist.collect(&:name).join(ArchiveConfig.DELIMITER_FOR_OUTPUT),
-                              taglist: disallowed_taglist.collect(&:name).join(ArchiveConfig.DELIMITER_FOR_OUTPUT)))
-          end
+    return unless restriction
+
+    TagSet::TAG_TYPES_RESTRICTED_TO_FANDOM.each do |tag_type|
+      next unless restriction.send("#{tag_type}_restrict_to_fandom")
+
+      # tag_type is one of a set set so we know it is safe for constantize
+      allowed_tags = tag_type.classify.constantize.with_parents(tag_set.fandom_taglist).canonical
+      disallowed_taglist = tag_set ? tag_set.send("#{tag_type}_taglist") - allowed_tags : []
+
+      # check for tag set associations
+      tag_set_associations = tag_set.owned_tag_set&.tag_set_associations
+      if tag_set_associations
+        disallowed_taglist.reject! do |tag|
+          tag_set_associations.exists?(tag_id: tag.id, parent_tag_id: tag_set.fandom_taglist)
         end
       end
+
+      next if disallowed_taglist.empty?
+
+      errors.add(:base, :tags_not_in_fandom,
+                 prompt_type: self.class.name.downcase,
+                 tag_label: tag_type_label_name(tag_type).downcase, fandom: tag_set.fandom_taglist.collect(&:name).join(ArchiveConfig.DELIMITER_FOR_OUTPUT),
+                 taglist: disallowed_taglist.collect(&:name).join(I18n.t("support.array.words_connector")))
     end
   end
 

--- a/config/locales/models/en.yml
+++ b/config/locales/models/en.yml
@@ -134,6 +134,8 @@ en:
             muted_id:
               taken: You have already muted that user.
           format: "%{message}"
+        prompt:
+          tags_not_in_fandom: "^These %{tag_label} tags in your %{prompt_type} are not in the selected fandom(s), %{fandom}: %{taglist} (Your moderator may be able to fix this.)"
         related_work:
           attributes:
             parent:

--- a/factories/tags.rb
+++ b/factories/tags.rb
@@ -49,6 +49,12 @@ FactoryBot.define do
     association :pseud
   end
 
+  factory :tag_set_association do
+    association :owned_tag_set
+    association :tag
+    association :parent_tag
+  end
+
   factory :tag_nomination do
     type { 'FandomNomination' }
 

--- a/spec/models/prompt_spec.rb
+++ b/spec/models/prompt_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Prompt do
+  describe "validations" do
+    context "when the prompt uses a non-fandom tag that is not in the challenge TagSet" do
+      let(:fandom) { create(:fandom, canonical: true) }
+      let(:non_fandom_character) { create(:character, canonical: true) }
+      let(:collection) { create(:collection, challenge: challenge) }
+
+      let!(:challenge) do
+        create(:gift_exchange,
+               offer_restriction: create(:prompt_restriction, character_restrict_to_fandom: true))
+      end
+
+      it "marks the prompt as invalid" do
+        create(:owned_tag_set, tags: [fandom, non_fandom_character])
+        create(:tag_set_association, tag: non_fandom_character, parent_tag: fandom)
+        prompt = build(:offer,
+                       tag_set: create(:tag_set, tags: [fandom, non_fandom_character]),
+                       collection_id: collection.id)
+        expect(prompt).not_to be_valid
+        expect(prompt.errors[:base][0]).to include("not in the selected fandom")
+      end
+    end
+  end
+end


### PR DESCRIPTION
# Pull Request Checklist

## Issue

https://otwarchive.atlassian.net/browse/AO3-5712

## Purpose

Fix the bug where tag set associations could mark a tag as being in a fandom, even when the tag set was not connected to the challenge being signed up for