### PR TITLE
AO3-6964 Correctly Display Reply Notice on Admin Posts

### DIFF
--- a/app/views/comments/_comment_form.html.erb
+++ b/app/views/comments/_comment_form.html.erb
@@ -30,7 +30,7 @@
         <p class="notice">
           <% if find_parent(commentable).is_a?(AdminPost) %>
             <%= t("comments.commentable.permissions.moderated_commenting.notice.admin_post") %>
-          <% else  %>
+          <% else %>
             <%= t("comments.commentable.permissions.moderated_commenting.notice.work") %>
           <% end %>
         </p>

--- a/app/views/comments/_comment_form.html.erb
+++ b/app/views/comments/_comment_form.html.erb
@@ -28,9 +28,9 @@
 
       <% if comments_are_moderated(commentable) && !current_user_is_work_creator(commentable) %>
         <p class="notice">
-          <% if commentable.is_a?(AdminPost) %>
+          <% if find_parent(commentable).is_a?(AdminPost) %>
             <%= t("comments.commentable.permissions.moderated_commenting.notice.admin_post") %>
-          <% else %>
+          <% else  %>
             <%= t("comments.commentable.permissions.moderated_commenting.notice.work") %>
           <% end %>
         </p>

--- a/features/comments_and_kudos/comments_adminposts.feature
+++ b/features/comments_and_kudos/comments_adminposts.feature
@@ -113,6 +113,27 @@ Feature: Commenting on admin posts
     Then I should see "Comment created!"
       And I should see "zug zug"
 
+  Scenario: Admin post with comment moderation
+    Given I have posted an admin post
+      And I am logged in as a "communications" admin
+    When I go to the admin-posts page
+      And I follow "Edit"
+      And I check "Enable comment moderation"
+    When I am logged out
+      And I go to the admin-posts page
+      And I follow "Default Admin Post"
+      And I fill in "comment[name]" with "tester"
+      And I fill in "comment[email]" with "tester@example.com"
+      And I fill in "comment[comment_content]" with "guz guz"
+      And I press "Comment"
+    When I follow "Reply"
+      And I fill in "comment[name]" with "tester"
+      And I fill in "comment[email]" with "tester@example.com"
+      And I fill in "comment[comment_content]" with "guz guz"
+      And I press "Comment"
+    Then I should see "Comments on this news post are moderated."
+
+
   Scenario: Modifying the comment permissions of an admin post with translations
     Given I have posted an admin post
       And basic languages

--- a/features/comments_and_kudos/comments_adminposts.feature
+++ b/features/comments_and_kudos/comments_adminposts.feature
@@ -129,7 +129,7 @@ Feature: Commenting on admin posts
     When I am logged in as a "communications" admin
       And I go to the admin-posts page
       And I follow "Default Admin Post"
-      And I follow "Unreviewed Comments"
+      And I follow "Unreviewed Comments (1)"
       And I press "Approve"
     When I am logged out
       And I go to the admin-posts page

--- a/features/comments_and_kudos/comments_adminposts.feature
+++ b/features/comments_and_kudos/comments_adminposts.feature
@@ -126,13 +126,20 @@ Feature: Commenting on admin posts
       And I fill in "comment[email]" with "tester@example.com"
       And I fill in "comment[comment_content]" with "guz guz"
       And I press "Comment"
+    When I am logged in as a "communications" admin
+      And I go to the admin-posts page
+      And I follow "Default Admin Post"
+      And I follow "Unreviewed Comments"
+      And I press "Approve"
+    When I am logged out
+      And I go to the admin-posts page
+      And I follow "Default Admin Post"
     When I follow "Reply"
       And I fill in "comment[name]" with "tester"
       And I fill in "comment[email]" with "tester@example.com"
       And I fill in "comment[comment_content]" with "guz"
       And I press "Comment"
     Then I should see "Comments on this news post are moderated."
-
 
   Scenario: Modifying the comment permissions of an admin post with translations
     Given I have posted an admin post

--- a/features/comments_and_kudos/comments_adminposts.feature
+++ b/features/comments_and_kudos/comments_adminposts.feature
@@ -129,7 +129,7 @@ Feature: Commenting on admin posts
     When I follow "Reply"
       And I fill in "comment[name]" with "tester"
       And I fill in "comment[email]" with "tester@example.com"
-      And I fill in "comment[comment_content]" with "guz guz"
+      And I fill in "comment[comment_content]" with "guz"
       And I press "Comment"
     Then I should see "Comments on this news post are moderated."
 


### PR DESCRIPTION
# Pull Request Checklist

<!-- Mark steps in the checklist as complete by changing `[ ]` to `[X]` -->
* [x] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [x] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [x] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [x] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-6964 

## Purpose

This pull request changes the way the notice for moderated comments is displayed by checking the parent of the commentable object rather than the object itself.

## References

Are there other relevant issues/pull requests/mailing list discussions? If not, you can remove this section.

## Credit

niic (he/him)
