### PR TITLE
AO3-5714 Do not treat non-canonical tags as fandom-associated in TagSets

### DIFF
--- a/app/controllers/owned_tag_sets_controller.rb
+++ b/app/controllers/owned_tag_sets_controller.rb
@@ -74,31 +74,31 @@ class OwnedTagSetsController < ApplicationController
       # we use this to store the tag name results
       @tag_hash = HashWithIndifferentAccess.new
 
-      %w(character relationship).each do |tag_type|
-        if @tag_set.has_type?(tag_type)
-          ## names_by_parent returns a hash of arrays like so:
-          ## hash[parent_name] => [child name, child name, child name]
+      %w[character relationship].each do |tag_type|
+        next unless @tag_set.has_type?(tag_type)
 
-          # get the manually associated fandoms
-          assoc_hash = TagSetAssociation.names_by_parent(TagSetAssociation.for_tag_set(@tag_set), tag_type)
+        ## names_by_parent returns a hash of arrays like so:
+        ## hash[parent_name] => [child name, child name, child name]
 
-          # get canonically associated fandoms
-          # Safe for constantize as tag_type restricted to character relationship
-          canonical_hash = Tag.names_by_parent(tag_type.classify.constantize.in_tag_set(@tag_set), "fandom")
+        # get the manually associated fandoms
+        assoc_hash = TagSetAssociation.names_by_parent(TagSetAssociation.for_tag_set(@tag_set), tag_type)
 
-          # merge the values of the two hashes (each value is an array) as a set (ie remove duplicates)
-          @tag_hash[tag_type] = assoc_hash.merge(canonical_hash) {|key, oldval, newval| (oldval | newval) }
+        # get canonically associated fandoms
+        # Safe for constantize as tag_type restricted to character relationship
+        canonical_hash = Tag.names_by_parent(tag_type.classify.constantize.in_tag_set(@tag_set).canonical, "fandom")
 
-          # get any tags without a fandom
-          remaining = @tag_set.with_type(tag_type).with_no_parents
-          if remaining.count > 0
-            @tag_hash[tag_type]["(No linked fandom - might need association)"] ||= []
-            @tag_hash[tag_type]["(No linked fandom - might need association)"] += remaining.pluck(:name)
-          end
+        # merge the values of the two hashes (each value is an array) as a set (ie remove duplicates)
+        @tag_hash[tag_type] = assoc_hash.merge(canonical_hash) { |_key, oldval, newval| (oldval | newval) }
 
-          # store the parents
-          @fandom_keys_from_other_tags += @tag_hash[tag_type].keys
+        # get any tags without a fandom
+        remaining = @tag_set.with_type(tag_type).where.not(name: @tag_hash[tag_type].values.flatten)
+        if remaining.any?
+          @tag_hash[tag_type]["(No linked fandom - might need association)"] ||= []
+          @tag_hash[tag_type]["(No linked fandom - might need association)"] += remaining.pluck(:name)
         end
+
+        # store the parents
+        @fandom_keys_from_other_tags += @tag_hash[tag_type].keys
       end
 
       # get rid of duplicates and sort

--- a/factories/tags.rb
+++ b/factories/tags.rb
@@ -49,6 +49,12 @@ FactoryBot.define do
     association :pseud
   end
 
+  factory :tag_set_association do
+    association :owned_tag_set
+    association :tag
+    association :parent_tag
+  end
+
   factory :tag_nomination do
     type { 'FandomNomination' }
 

--- a/lib/tasks/after_tasks.rake
+++ b/lib/tasks/after_tasks.rake
@@ -544,6 +544,7 @@ namespace :After do
     non_canonicals = SetTagging
       .joins("INNER JOIN `tag_sets` `tag_set` ON `tag_set`.`id` = `set_taggings`.`tag_set_id` INNER JOIN `owned_tag_sets` ON `owned_tag_sets`.`tag_set_id` = `tag_set`.`id` INNER JOIN `tags` `tag` ON `tag`.`id` = `set_taggings`.`tag_id` INNER JOIN `common_taggings` `common_tagging` ON  `common_tagging`.`common_tag_id` = `tag`.`id` INNER JOIN `tags` `parent_tag` ON `common_tagging`.`filterable_id` = `parent_tag`.`id`")
       .where("`tag`.`canonical` = FALSE AND `tag`.`type` IN ('Character', 'Relationship') AND `tag_set`.`id` IS NOT NULL AND `parent_tag`.`type` = 'Fandom' AND `parent_tag`.`canonical` = TRUE")
+      .distinct
 
     non_canonicals.find_in_batches.with_index do |batch, index|
       puts "Creating TagSetAssociations for batch #{index + 1}"

--- a/lib/tasks/after_tasks.rake
+++ b/lib/tasks/after_tasks.rake
@@ -552,7 +552,7 @@ namespace :After do
         owned_tag_set = set_tagging.tag_set.owned_tag_set
         tag = set_tagging.tag
 
-        fandoms = set_tagging.tag.fandoms.joins(:set_taggings).where(canonical: true, set_taggings: { tag_set_id: set_tagging.tag_set.id })
+        fandoms = tag.fandoms.joins(:set_taggings).where(canonical: true, set_taggings: { tag_set_id: set_tagging.tag_set.id })
         fandoms.find_each do |fandom|
           TagSetAssociation.create!(owned_tag_set: owned_tag_set, tag: tag, parent_tag: fandom)
         end

--- a/lib/tasks/after_tasks.rake
+++ b/lib/tasks/after_tasks.rake
@@ -542,8 +542,8 @@ namespace :After do
     # This might be possible with pure Ruby, but unfortunately the parent tag in common_taggings is polymorphic
     # (even though it doesn't need to be), which makes that trickier.
     non_canonicals = SetTagging
-                       .joins("INNER JOIN `tag_sets` `tag_set` ON `tag_set`.`id` = `set_taggings`.`tag_set_id` INNER JOIN `owned_tag_sets` ON `owned_tag_sets`.`tag_set_id` = `tag_set`.`id` INNER JOIN `tags` `tag` ON `tag`.`id` = `set_taggings`.`tag_id` JOIN `common_taggings` `common_tagging` ON `tag`.`id` = `common_tagging`.`common_tag_id` JOIN `tags` `tag2` ON `common_tagging`.`filterable_id` = `tag2`.`id`")
-                       .where("`tag`.`canonical` = FALSE AND `tag`.`type` IN ('Character', 'Relationship') AND `tag_set`.`id` IS NOT NULL AND `tag2`.`type` = 'Fandom' AND `tag2`.`canonical` = TRUE")
+      .joins("INNER JOIN `tag_sets` `tag_set` ON `tag_set`.`id` = `set_taggings`.`tag_set_id` INNER JOIN `owned_tag_sets` ON `owned_tag_sets`.`tag_set_id` = `tag_set`.`id` INNER JOIN `tags` `tag` ON `tag`.`id` = `set_taggings`.`tag_id` JOIN `common_taggings` `common_tagging` ON `tag`.`id` = `common_tagging`.`common_tag_id` JOIN `tags` `tag2` ON `common_tagging`.`filterable_id` = `tag2`.`id`")
+      .where("`tag`.`canonical` = FALSE AND `tag`.`type` IN ('Character', 'Relationship') AND `tag_set`.`id` IS NOT NULL AND `tag2`.`type` = 'Fandom' AND `tag2`.`canonical` = TRUE")
 
     non_canonicals.find_in_batches.with_index do |batch, index|
       puts "Creating TagSetAssociations for batch #{index + 1}"

--- a/spec/lib/tasks/after_tasks.rake_spec.rb
+++ b/spec/lib/tasks/after_tasks.rake_spec.rb
@@ -567,16 +567,20 @@ describe "rake After:convert_official_kudos" do
 end
 
 describe "rake After:create_non_canonical_tagset_associations" do
-  context "when a tag is already canonical" do
-    let!(:character) { create(:canonical_character) }
-    let!(:relationship) { create(:canonical_relationship) }
-    let!(:owned_tag_set) { create(:owned_tag_set, tags: [character, relationship]) }
-
+  shared_examples "no TagSetAssociation is created" do
     it "does not create a TagSetAssociation" do
       expect do
         subject.invoke
       end.to avoid_changing { TagSetAssociation.count }
     end
+  end
+
+  context "when a tag is already canonical" do
+    let!(:character) { create(:canonical_character) }
+    let!(:relationship) { create(:canonical_relationship) }
+    let!(:owned_tag_set) { create(:owned_tag_set, tags: [character, relationship]) }
+
+    it_behaves_like "no TagSetAssociation is created"
   end
 
   context "when a canonical tag belongs to a canonical fandom" do
@@ -584,22 +588,29 @@ describe "rake After:create_non_canonical_tagset_associations" do
     let!(:relationship) { create(:common_tagging, common_tag: create(:canonical_relationship)).common_tag }
     let!(:owned_tag_set) { create(:owned_tag_set, tags: [character, relationship]) }
 
-    it "does not create a TagSetAssociation" do
-      expect do
-        subject.invoke
-      end.to avoid_changing { TagSetAssociation.count }
-    end
+    it_behaves_like "no TagSetAssociation is created"
   end
 
   context "when a non-canonical tag belongs to a canonical fandom" do
     let!(:character) { create(:common_tagging, common_tag: create(:character)).common_tag }
     let!(:relationship) { create(:common_tagging).common_tag }
-    let!(:owned_tag_set) { create(:owned_tag_set, tags: [character, relationship]) }
 
-    it "creates a TagSetAssociation for each tag" do
-      subject.invoke
-      expect(TagSetAssociation.where(tag: character, owned_tag_set: owned_tag_set)).to exist
-      expect(TagSetAssociation.where(tag: relationship, owned_tag_set: owned_tag_set)).to exist
+    context "when the fandom does not belong to the TagSet" do
+      let!(:owned_tag_set) { create(:owned_tag_set, tags: [character, relationship]) }
+
+      it_behaves_like "no TagSetAssociation is created"
+    end
+
+    context "when the fandom belongs to the TagSet" do
+      let!(:owned_tag_set) do
+        create(:owned_tag_set, tags: [character, character.fandoms, relationship, relationship.fandoms].flatten)
+      end
+
+      it "creates a TagSetAssociation for each tag" do
+        subject.invoke
+        expect(TagSetAssociation.where(tag: character, owned_tag_set: owned_tag_set)).to exist
+        expect(TagSetAssociation.where(tag: relationship, owned_tag_set: owned_tag_set)).to exist
+      end
     end
   end
 end


### PR DESCRIPTION
# Pull Request Checklist

## Issue

https://otwarchive.atlassian.net/browse/AO3-5714

## Purpose

Non-canonical characters associated with canonical fandoms _look_ like they're associated when added to a TagSet, but in prompts, they aren't treated that way (either for autocomplete or, after https://github.com/otwcode/otwarchive/pull/5140 is merged, for situations when fandom-only is selected). This PR updates the categorization to show these tags under the association-needed section instead to reduce confusion.

## Review Notes

I cleaned up a few Rubocop complaints as well, which changed indentation. I'd recommend using the "hide whitespace" option when reviewing, to make the diff a bit more comprehensible