### PR TITLE
AO3-6914 Update language short field error message to display as "Abbreviation"

### DIFF
--- a/config/locales/models/en.yml
+++ b/config/locales/models/en.yml
@@ -30,6 +30,8 @@ en:
         offers_num_required: Number of offers required per sign-up
         requests_num_allowed: Number of requests allowed per sign-up
         requests_num_required: Number of requests required per sign-up
+      language:
+        short: Abbreviation
       meta_tagging:
         meta_tag: Metatag
         meta_tag_id: Metatag


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [ ] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [x] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [x] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-6914

## Purpose

When editing a language short code, if the short code is too long, the validation error message says "Short is too long". However, the form UI refers to the short code as "Abbreviation", so this PR changes the error message to match the form.

## Testing Instructions

1. Log in as an admin
2. Go to `/languages`
3. Click `Edit` on any of the languages
4. Change the abbreviation to something with more than 4 characters
5. Click `Update Language` and form validations should appear, saying "Abbreviation is too long" rather than "Short is too long"

![Screenshot 2025-04-20 at 1 19 10 PM](https://github.com/user-attachments/assets/9a1f305c-c200-4df8-9af4-f228f08f0fe2)

## Credit

Connie Feng, she/her
([JIRA account](https://otwarchive.atlassian.net/jira/people/712020:17930fa1-d647-47bd-b334-8a84cbacfca7))
