### PR TITLE
AO3-5862 Use Departure to really delete users.recently_reset

### DIFF
--- a/db/migrate/20181222022628_remove_recently_reset_from_users.rb
+++ b/db/migrate/20181222022628_remove_recently_reset_from_users.rb
@@ -1,5 +1,0 @@
-class RemoveRecentlyResetFromUsers < ActiveRecord::Migration[5.1]
-  def change
-    remove_column :users, :recently_reset, :boolean
-  end
-end

--- a/db/migrate/20250421192808_remove_recently_reset_from_users.rb
+++ b/db/migrate/20250421192808_remove_recently_reset_from_users.rb
@@ -1,0 +1,7 @@
+class RemoveRecentlyResetFromUsers < ActiveRecord::Migration[7.1]
+  uses_departure! if Rails.env.staging? || Rails.env.production?
+
+  def change
+    remove_column :users, :recently_reset, :boolean
+  end
+end


### PR DESCRIPTION
# Pull Request Checklist

## Issue

https://otwarchive.atlassian.net/browse/AO3-5862

## Purpose

Update the old migration (that was never actually applied per the ticket above) to use Departure and have a more recent timestamp.