### PR TITLE
AO3-6388 Fix email style and adjust error messages for changing email

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -172,6 +172,11 @@ class UsersController < ApplicationController
 
     @new_email = params[:new_email]
 
+    if @new_email.downcase == @user.email.downcase
+      flash[:error] = t("users.confirm_change_email.same_as_current")
+      render :change_email and return
+    end
+
     # Please note: This comparison is not technically correct. According to
     # RFC 5321, the local part of an email address is case sensitive, while the
     # domain is case insensitive. That said, all major email providers treat

--- a/app/views/user_mailer/change_email.html.erb
+++ b/app/views/user_mailer/change_email.html.erb
@@ -3,12 +3,12 @@
 
   <p><%= t(".made_request", app_name: ArchiveConfig.APP_SHORT_NAME) %></p>
 
-  <p><%= t(".confirm_change.html", unconfirmed_email: style_email(@new_email), count: User.confirm_within.in_days.to_i, contact_support_link: link_to(t(".contact_support"), new_feedback_report_url)) %></p>
+  <p><%= t(".confirm_change.html", unconfirmed_email: style_email(@new_email), count: User.confirm_within.in_days.to_i, contact_support_link: style_link(t(".contact_support"), new_feedback_report_url)) %></p>
 
-  <p><%= t(".wrong_email.html", email_change_form_link: link_to(t(".email_change_form"), change_email_user_url(@user))) %></p>
+  <p><%= t(".wrong_email.html", email_change_form_link: style_link(t(".email_change_form"), change_email_user_url(@user))) %></p>
 
   <p><%= t(".not_made_request.html",
-           reset_password_link: link_to(t(".reset_password"), new_user_password_url),
-           contact_policy_abuse_link: link_to(t(".contact_policy_abuse"), new_abuse_report_url),
+           reset_password_link: style_link(t(".reset_password"), new_user_password_url),
+           contact_policy_abuse_link: style_link(t(".contact_policy_abuse"), new_abuse_report_url),
            app_name: ArchiveConfig.APP_SHORT_NAME) %></p>
 <% end %>

--- a/app/views/users/mailer/confirmation_instructions.html.erb
+++ b/app/views/users/mailer/confirmation_instructions.html.erb
@@ -3,9 +3,9 @@
 
   <p><%= t(".request_to_change_email_html", username: style_bold(@resource.login), app_name: ArchiveConfig.APP_SHORT_NAME) %></p>
 
-  <p><%= t(".made_request.html", count: @resource.class.confirm_within.in_days.to_i, confirm_email_change_link: link_to(t(".confirm_email_change"), reconfirm_email_user_url(@resource, confirmation_token: @token))) %></p>
+  <p><%= t(".made_request.html", count: @resource.class.confirm_within.in_days.to_i, confirm_email_change_link: style_link(t(".confirm_email_change"), reconfirm_email_user_url(@resource, confirmation_token: @token))) %></p>
 
-  <p><%= t(".confirm_by.html", date: l(@resource.confirmation_sent_at + @resource.class.confirm_within), email_change_form_link: link_to(t(".email_change_form"), change_email_user_url(@user))) %></p>
+  <p><%= t(".confirm_by.html", date: l(@resource.confirmation_sent_at + @resource.class.confirm_within), email_change_form_link: style_link(t(".email_change_form"), change_email_user_url(@user))) %></p>
 
   <p><%= t(".did_not_make_request") %></p>
 <% end %>

--- a/config/locales/controllers/en.yml
+++ b/config/locales/controllers/en.yml
@@ -212,7 +212,8 @@ en:
       blank_password: You must enter your password.
       browser_title: Confirm New Email
       contact_support: contact Support
-      nonmatching_email: Email addresses don't match! Please retype and try again.
+      nonmatching_email: The email addresses you entered do not match. Please try again.
+      same_as_current: Your new email address must be different from your current email.
       wrong_password_html: Your password was incorrect. Please try again or log out and reset your password via the link on the login form. If you are still having trouble, %{contact_support_link} for help.
     contact_abuse: contact our Policy & Abuse team
     passwords:

--- a/config/locales/mailers/en.yml
+++ b/config/locales/mailers/en.yml
@@ -225,8 +225,8 @@ en:
       email_change_form: submit the email change form
       made_request: Someone has made a request to change the email address associated with your %{app_name} account.
       not_made_request:
-        html: If you did not make this request, someone else may have access to your %{app_name} account. Please %{reset_password_link}. If you are unable to reset your password, %{contact_policy_abuse_link}.
-        text: 'If you did not make this request, someone else may have access to your %{app_name} account. Please reset your password now: %{reset_password_url}. If you are unable to reset your password, contact Policy & Abuse: %{contact_policy_abuse_url}.'
+        html: If you did not make this request, someone else may have access to your %{app_name} account. Please %{reset_password_link} or %{contact_policy_abuse_link}.
+        text: 'If you did not make this request, someone else may have access to your %{app_name} account. Please reset your password now (%{reset_password_url}) or contact Policy & Abuse: %{contact_policy_abuse_url}.'
       reset_password: reset your password now
       subject: "[%{app_name}] Email change request"
       wrong_email:

--- a/config/locales/models/en.yml
+++ b/config/locales/models/en.yml
@@ -173,6 +173,8 @@ en:
             data_processing:
               accepted: Sorry, you need to consent to the processing of your personal data in order to sign up.
               format: "%{message}"
+            email:
+              taken: "^This email is already associated with another account. Please try again with a different email address."
             login:
               admin_must_use_default: must use the default. Please contact your chairs to use something else.
               changed_too_recently:

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -251,7 +251,7 @@ describe UsersController do
         put :confirm_change_email, params: { id: user, new_email: "new@example.com", email_confirmation: "new@example.com", password_check: "password" }
 
         expect(response).to render_template(:change_email)
-        expect(assigns[:user].errors.full_messages).to include("Email has already been taken")
+        expect(assigns[:user].errors.full_messages.first).to include("This email is already associated with another account. Please try again with a different email address.")
         expect(assigns[:user].email).to eq("old@example.com")
       end
     end

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -236,7 +236,7 @@ describe UsersController do
         put :confirm_change_email, params: { id: user, new_email: "new@example.com", email_confirmation: "different@example.com", password_check: "password" }
 
         expect(response).to render_template(:change_email)
-        expect(flash[:error]).to eq("Email addresses don't match! Please retype and try again.")
+        expect(flash[:error]).to eq("The email addresses you entered do not match. Please try again.")
       end
 
       it "allows case-insensitive email confirmation" do
@@ -253,6 +253,13 @@ describe UsersController do
         expect(response).to render_template(:change_email)
         expect(assigns[:user].errors.full_messages.first).to include("This email is already associated with another account. Please try again with a different email address.")
         expect(assigns[:user].email).to eq("old@example.com")
+      end
+
+      it "disallows using current email" do
+        put :confirm_change_email, params: { id: user, new_email: "old@example.com", email_confirmation: "old@example.com", password_check: "password" }
+
+        expect(response).to render_template(:change_email)
+        expect(flash[:error]).to eq("Your new email address must be different from your current email.")
       end
     end
   end


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6388

## Purpose

Fix link color in the emails and adjust error messages for requesting an email change.

## Testing Instructions

https://otwarchive.atlassian.net/browse/AO3-6388?focusedCommentId=365222

## References

Various conversations in various places, all summarized in the comment on Jira.

## Credit

Bilka
