### PR TITLE
AO3-6388 Fix flash error sticking around on change_email

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -166,7 +166,7 @@ class UsersController < ApplicationController
     render :change_email and return unless reauthenticate
 
     if params[:new_email].blank?
-      flash[:error] = t("users.confirm_change_email.blank_email")
+      flash.now[:error] = t("users.confirm_change_email.blank_email")
       render :change_email and return
     end
 
@@ -181,12 +181,12 @@ class UsersController < ApplicationController
     # Also, email addresses are validated on the client, and will only contain
     # a limited subset of ASCII, so we don't need to do a unicode casefolding pass.
     if @new_email.downcase == @user.email.downcase
-      flash[:error] = t("users.confirm_change_email.same_as_current")
+      flash.now[:error] = t("users.confirm_change_email.same_as_current")
       render :change_email and return
     end
 
     if @new_email.downcase != params[:email_confirmation].downcase
-      flash[:error] = t("users.confirm_change_email.nonmatching_email")
+      flash.now[:error] = t("users.confirm_change_email.nonmatching_email")
       render :change_email and return
     end
 

--- a/app/views/users/change_email.html.erb
+++ b/app/views/users/change_email.html.erb
@@ -29,10 +29,10 @@
     <dd><%= @user.email %></dd>
 
     <dt><%= label_tag :new_email, t(".form.new_email") %></dt>
-    <dd><%= email_field_tag :new_email %></dd>
+    <dd><%= email_field_tag :new_email, nil, autocomplete: "off" %></dd>
 
     <dt><%= label_tag :email_confirmation, t(".form.email_again") %></dt>
-    <dd><%= email_field_tag :email_confirmation %></dd>
+    <dd><%= email_field_tag :email_confirmation, nil, autocomplete: "off" %></dd>
 
     <dt><%= label_tag :password_check, t(".form.password") %></dt>
     <dd><%= password_field_tag :password_check %></dd>

--- a/config/locales/mailers/en.yml
+++ b/config/locales/mailers/en.yml
@@ -460,11 +460,11 @@ en:
         email_change_form: submit the email change form
         made_request:
           html:
-            one: If you made this request, please %{confirm_email_change_link} within %{count} day.
-            other: If you made this request, please %{confirm_email_change_link} within %{count} days.
+            one: If you made this request, please log in and %{confirm_email_change_link} within %{count} day.
+            other: If you made this request, please log in and %{confirm_email_change_link} within %{count} days.
           text:
-            one: 'If you made this request, please confirm your email change within %{count} day: %{confirm_email_change_url}.'
-            other: 'If you made this request, please confirm your email change within %{count} days: %{confirm_email_change_url}.'
+            one: 'If you made this request, please log in and confirm your email change within %{count} day: %{confirm_email_change_url}.'
+            other: 'If you made this request, please log in and confirm your email change within %{count} days: %{confirm_email_change_url}.'
         request_to_change_email_html: Someone has made a request to change the email address associated with the %{app_name} account %{username} to this email address.
         subject: "[%{app_name}] Confirm your email change"
       reset_password_instructions:

--- a/spec/mailers/archive_devise_mailer_spec.rb
+++ b/spec/mailers/archive_devise_mailer_spec.rb
@@ -98,7 +98,7 @@ describe ArchiveDeviseMailer do
     describe "text version" do
       it "has the correct content" do
         expect(email).to have_text_part_content("Hi,")
-        expect(email).to have_text_part_content("please confirm your email change within #{ArchiveConfig.DAYS_UNTIL_RESET_PASSWORD_LINK_EXPIRES} days")
+        expect(email).to have_text_part_content("confirm your email change within #{ArchiveConfig.DAYS_UNTIL_RESET_PASSWORD_LINK_EXPIRES} days")
         expect(email).to have_html_part_content("If you don't confirm your request by")
         expect(email).to have_html_part_content(", #{ArchiveConfig.DAYS_UNTIL_RESET_PASSWORD_LINK_EXPIRES + 10} Apr 2020 10:51:00 +0000, the link in")
       end


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6388

## Purpose

Use [flash.now](https://api.rubyonrails.org/classes/ActionDispatch/Flash/FlashHash.html#method-i-now) for errors on change_email so that they don't stick around too long. (It renders, instead of redirects, so they should only stay for the current action).

## Testing Instructions

This can't be reliably reproduced. One person should test the instructions from the previous BOT PR to make sure the errors still show up in general (https://otwarchive.atlassian.net/browse/AO3-6388?focusedCommentId=365222)

## References

Second commit per Lydia's request.

## Credit

Bilka