### PR TITLE
AO3-6757 Remove image embeds when hiding comments

### DIFF
--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -518,10 +518,12 @@ class Comment < ApplicationRecord
   end
 
   def mark_hidden!
+    update_attribute(:comment_content, sanitize_field(self, :comment_content, image_safety_mode: true))
     update_attribute(:hidden_by_admin, true)
   end
 
   def mark_unhidden!
+    # update_attribute(:comment_content, wrap_url_with_img(self.comment_content))
     update_attribute(:hidden_by_admin, false)
   end
 

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -518,7 +518,6 @@ class Comment < ApplicationRecord
   end
 
   def mark_hidden!
-    update_attribute(:comment_content, sanitize_field(self, :comment_content, image_safety_mode: true))
     update_attribute(:hidden_by_admin, true)
   end
 
@@ -531,7 +530,7 @@ class Comment < ApplicationRecord
   end
 
   def use_image_safety_mode?
-    parent_type.in?(ArchiveConfig.PARENTS_WITH_IMAGE_SAFETY_MODE)
+    parent_type.in?(ArchiveConfig.PARENTS_WITH_IMAGE_SAFETY_MODE) || self.hidden_by_admin
   end
   include Responder
 end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -530,7 +530,7 @@ class Comment < ApplicationRecord
   end
 
   def use_image_safety_mode?
-    parent_type.in?(ArchiveConfig.PARENTS_WITH_IMAGE_SAFETY_MODE) || self.hidden_by_admin
+    parent_type.in?(ArchiveConfig.PARENTS_WITH_IMAGE_SAFETY_MODE) || hidden_by_admin
   end
   include Responder
 end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -523,7 +523,6 @@ class Comment < ApplicationRecord
   end
 
   def mark_unhidden!
-    # update_attribute(:comment_content, wrap_url_with_img(self.comment_content))
     update_attribute(:hidden_by_admin, false)
   end
 

--- a/features/comments_and_kudos/hidden_comments.feature
+++ b/features/comments_and_kudos/hidden_comments.feature
@@ -66,13 +66,10 @@ Feature: Comment hiding
     Then I should see "A suspicious comment"
       And I should not see "This comment has been hidden by an admin."
 
-  Scenario Outline: Embedded images in hidden comments are replaced with their URLs.
-    Given I am logged in as "author"
-    And I post the work "Popular Fic"
-    And I am logged out
-    And I am logged in as "commenter"
-    And I post the comment "OMG! <img src= 'https://example.com/image.jpg'>" on the work "Popular Fic"
-    And I am logged out
+  Scenario: Embedded images in hidden comments are replaced with their URLs.
+    Given the work "Popular Fic"
+      And I am logged in as "commenter"
+      And I post the comment "OMG! <img src= 'https://example.com/image.jpg'>" on the work "Popular Fic"
 
     # Delay to make sure the cache is expired when the comment is hidden:
     When it is currently 1 second from now

--- a/features/comments_and_kudos/hidden_comments.feature
+++ b/features/comments_and_kudos/hidden_comments.feature
@@ -65,3 +65,26 @@ Feature: Comment hiding
       And I view the work "Popular Fic" with comments
     Then I should see "A suspicious comment"
       And I should not see "This comment has been hidden by an admin."
+
+  Scenario Outline: Embedded images in hidden comments are replaced with their URLs.
+    Given I am logged in as "author"
+    And I post the work "Popular Fic"
+    And I am logged out
+    And I am logged in as "commenter"
+    And I post the comment "OMG! <img src= 'https://example.com/image.jpg'>" on the work "Popular Fic"
+    And I am logged out
+
+    # Delay to make sure the cache is expired when the comment is hidden:
+    When it is currently 1 second from now
+      And I am logged in as a super admin
+      And I view the work "Popular Fic" with comments
+    Then I should see the image "src" text "https://example.com/image.jpg"
+      And I should not see "OMG! https://example.com/image.jpg"
+      And I press "Hide Comment"
+    Then I should see "Comment successfully hidden!"
+    Then I should not see the image "src" text "https://example.com/image.jpg"
+      And I should see "OMG! https://example.com/image.jpg"
+    Then I press "Make Comment Visible"
+      And I should see "Comment successfully unhidden!"
+    Then I should not see the image "src" text "https://example.com/image.jpg"
+      And I should see "OMG! https://example.com/image.jpg"

--- a/features/comments_and_kudos/hidden_comments.feature
+++ b/features/comments_and_kudos/hidden_comments.feature
@@ -86,5 +86,5 @@ Feature: Comment hiding
       And I should see "OMG! https://example.com/image.jpg"
     Then I press "Make Comment Visible"
       And I should see "Comment successfully unhidden!"
-    Then I should not see the image "src" text "https://example.com/image.jpg"
-      And I should see "OMG! https://example.com/image.jpg"
+    Then I should see the image "src" text "https://example.com/image.jpg"
+      And I should not see "OMG! https://example.com/image.jpg"


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6757

## Purpose

When a comment is hidden by an administrator, the contents are replaced with a placeholder and are no longer visible to users (other than the user who posted the comment, if it was by a registered user). However, they are still visible to admins. This PR will strip the IMG tag from comment content, and leave a plain URL in its place. 