### PR TITLE
AO3-6953 clear reading history error

### DIFF
--- a/app/controllers/readings_controller.rb
+++ b/app/controllers/readings_controller.rb
@@ -40,14 +40,22 @@ class ReadingsController < ApplicationController
   end
 
   def clear
+    @errors = []
+
     @user.readings.each do |reading|
-       begin
-         reading.destroy
-       rescue
-         @errors << ts("There were problems deleting your history.")
-       end
-     end
-    flash[:notice] = ts("Your history is now cleared.")
+      begin
+        reading.destroy!
+      rescue => e
+        @errors << t(".error", message: e.message)
+      end
+    end
+
+    if @errors.any?
+      flash[:error] = @errors
+    else
+      flash[:notice] = t(".success")
+    end
+
     redirect_to user_readings_path(current_user)
   end
 

--- a/config/locales/controllers/en.yml
+++ b/config/locales/controllers/en.yml
@@ -178,6 +178,10 @@ en:
     not_found: Sorry, we couldn't find the FAQ you were looking for.
     update_positions:
       success: Question order has been successfully updated.
+  readings:
+    clear:
+      error: "There were problems deleting your history: %{message}"
+      success: Your history is now cleared.
   related_works:
     index:
       page_title: "%{login} - Related Works"


### PR DESCRIPTION
# Pull Request Checklist

<!-- Mark steps in the checklist as complete by changing `[ ]` to `[X]` -->
* [X] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [X] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [X] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [X] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [X] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-6953 (Please fill in issue number and remove this comment.)

## Purpose

Currently, if there is an error when clearing reading history, the action silently fails. This PR fixes that and makes sure the error message is shown.

## Credit
Connie Feng, she/her
([JIRA account](https://otwarchive.atlassian.net/jira/people/712020:17930fa1-d647-47bd-b334-8a84cbacfca7))
