### PR TITLE
AO3-6273 Word count blank when posting from draft

### DIFF
--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -637,7 +637,9 @@ class WorksController < ApplicationController
 
     # AO3-3498: since a work's word count is calculated in a before_save and the chapter is posted in an after_save,
     # work's word count needs to be updated with the chapter's word count after the chapter is posted
-    @work.set_word_count
+    # AO3-6273 Cannot rely on set_word_count here in a production environment, as it might query an older version of the database
+    # Instead, as the the work in this context is reduced its first chapter, we copy the value directly
+    @work.word_count = @work.first_chapter.word_count
     @work.save
 
     if !@collection.nil? && @collection.moderated?

--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -638,7 +638,7 @@ class WorksController < ApplicationController
     # AO3-3498: since a work's word count is calculated in a before_save and the chapter is posted in an after_save,
     # work's word count needs to be updated with the chapter's word count after the chapter is posted
     # AO3-6273 Cannot rely on set_word_count here in a production environment, as it might query an older version of the database
-    # Instead, as the the work in this context is reduced its first chapter, we copy the value directly
+    # Instead, as the work in this context is reduced its first chapter, we copy the value directly
     @work.word_count = @work.first_chapter.word_count
     @work.save
 

--- a/spec/controllers/works/drafts_spec.rb
+++ b/spec/controllers/works/drafts_spec.rb
@@ -129,15 +129,6 @@ describe WorksController do
       put :post_draft, params: { id: draft.id }
       it_redirects_to_with_notice(
         work_path(draft),
-        'Your work was successfully posted.'
-      )
-    end
-
-    it "should post the draft if there is none of the aforementioned issues" do
-      draft = create(:draft, authors: [drafts_user.default_pseud])
-      put :post_draft, params: { id: draft.id }
-      it_redirects_to_with_notice(
-        work_path(draft),
         "Your work was successfully posted."
       )
     end

--- a/spec/controllers/works/drafts_spec.rb
+++ b/spec/controllers/works/drafts_spec.rb
@@ -123,5 +123,40 @@ describe WorksController do
                                   "Work was submitted to a moderated collection."\
                                   " It will show up in the collection once approved.")
     end
+
+    it "should post the draft if there is none of the aforementioned issues" do
+      draft = create(:draft, authors: [drafts_user.default_pseud])
+      put :post_draft, params: { id: draft.id }
+      it_redirects_to_with_notice(
+        work_path(draft),
+        'Your work was successfully posted.'
+      )
+    end
+
+    it "should post the draft if there is none of the aforementioned issues" do
+      draft = create(:draft, authors: [drafts_user.default_pseud])
+      put :post_draft, params: { id: draft.id }
+      it_redirects_to_with_notice(
+        work_path(draft),
+        'Your work was successfully posted.'
+      )
+    end
+
+    it "should only count the words of the first, published, chapter after posting the draft" do
+      draft = create(:draft, authors: [drafts_user.default_pseud])
+      create(:chapter, :draft, work: draft)
+      draft.set_word_count
+
+      expect(draft.word_count).to eq(draft.chapters[0].word_count + draft.chapters[1].word_count)
+
+      put :post_draft, params: { id: draft.id }
+      it_redirects_to_with_notice(
+        work_path(draft),
+        'Your work was successfully posted.'
+      )
+
+      expect(draft.reload.first_chapter.posted).to be true
+      expect(draft.word_count).to eq(draft.first_chapter.word_count)
+    end
   end
 end

--- a/spec/controllers/works/drafts_spec.rb
+++ b/spec/controllers/works/drafts_spec.rb
@@ -138,7 +138,7 @@ describe WorksController do
       put :post_draft, params: { id: draft.id }
       it_redirects_to_with_notice(
         work_path(draft),
-        'Your work was successfully posted.'
+        "Your work was successfully posted."
       )
     end
 
@@ -152,7 +152,7 @@ describe WorksController do
       put :post_draft, params: { id: draft.id }
       it_redirects_to_with_notice(
         work_path(draft),
-        'Your work was successfully posted.'
+        "Your work was successfully posted."
       )
 
       expect(draft.reload.first_chapter.posted).to be true


### PR DESCRIPTION
# Pull Request Checklist

<!-- Mark steps in the checklist as complete by changing `[ ]` to `[X]` -->
* [x] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [x] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [x] Have you added the [Jira](https://otwarchive.atlassian.net) issue number as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [x] Do you have fewer than 5 pull requests already open? If not, please wait until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-6273

## Purpose

Tentative fix of the work word_count sometimes being nil when posting a draft through the post_draft route.

From my understanding, the issue is that `set_word_count`, when doing a read on the database [here](https://github.com/otwcode/otwarchive/blob/master/app/models/work.rb#L831), can sometimes query a version of the db where the first chapter hasn't been updated to `posted=TRUE`, thus counting nil.

My proposed solution is to get the data directly from the object, who I think should be up to date in all cases (all Ruby code is called synchronously). Might be a placebo however, as I'm not sure how to reproduce the issue locally or in tests.

## Testing Instructions

In theory, as per JIRA. However, I'm not sure how often the bug appears.

## Credit

Ceithir (he/him)