### PR TITLE
AO3-6267 Only update work version on posted chapters

### DIFF
--- a/app/controllers/chapters_controller.rb
+++ b/app/controllers/chapters_controller.rb
@@ -117,7 +117,6 @@ class ChaptersController < ApplicationController
     if params[:edit_button] || chapter_cannot_be_saved?
       render :new
     else # :post_without_preview or :preview
-      @work.major_version = @work.major_version + 1
       @chapter.posted = true if params[:post_without_preview_button]
       @work.set_revised_at_by_chapter(@chapter)
       if @chapter.save && @work.save
@@ -157,7 +156,6 @@ class ChaptersController < ApplicationController
       end
       render :preview
     else
-      @work.minor_version = @work.minor_version + 1
       @chapter.posted = true if params[:post_button] || params[:post_without_preview_button]
       posted_changed = @chapter.posted_changed?
       @work.set_revised_at_by_chapter(@chapter)
@@ -224,7 +222,7 @@ class ChaptersController < ApplicationController
 
     was_draft = !@chapter.posted?
     if @chapter.destroy
-      @work.minor_version = @work.minor_version + 1
+      @work.minor_version = @work.minor_version + 1 unless was_draft
       @work.set_revised_at
       @work.save
       flash[:notice] = ts("The chapter #{was_draft ? 'draft ' : ''}was successfully deleted.")

--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -395,7 +395,6 @@ class WorksController < ApplicationController
       @work.set_revised_at_by_chapter(@chapter)
       posted_changed = @work.posted_changed?
 
-      @work.minor_version = @work.minor_version + 1
       if @chapter.save && @work.save
         flash[:notice] = ts("Work was successfully #{posted_changed ? 'posted' : 'updated'}.")
         if posted_changed

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -611,6 +611,14 @@ class Work < ApplicationRecord
     self.invalidate_work_chapter_count(self)
     return if self.posted? && !chapter.posted?
 
+    unless self.posted_changed?
+      if chapter.posted_changed?
+        self.major_version = self.major_version + 1
+      else
+        self.minor_version = self.minor_version + 1
+      end
+    end
+
     if (self.new_record? || chapter.posted_changed?) && chapter.published_at == Date.current
       self.set_revised_at(Time.current) # a new chapter is being posted, so most recent update is now
     else

--- a/features/other_a/reading.feature
+++ b/features/other_a/reading.feature
@@ -263,3 +263,24 @@ Feature: Reading count
   When I am logged in as "reader"
     And I go to reader's reading page
   Then I should not see "Testy"
+
+  Scenario: When a chapter is added to a work, "update available" should not appear until it is posted
+
+    Given I am logged in as "writer"
+      And I post the work "Some Work"
+      And I am logged out
+    When I am logged in as "reader"
+      And I mark the work "Some Work" for later
+      And the readings are saved to the database
+      And I am logged out
+    When a draft chapter is added to "Some Work"
+      And I am logged in as "reader"
+      And I go to reader's reading page
+    Then I should not see "(Update available.)"
+    When I am logged in as "writer"
+      And I view the work "Some Work"
+      And I view the 2nd chapter
+      And I post the draft chapter
+    When I am logged in as "reader"
+      And I go to reader's reading page
+    Then I should see "(Update available.)"

--- a/features/other_a/reading.feature
+++ b/features/other_a/reading.feature
@@ -266,9 +266,7 @@ Feature: Reading count
 
   Scenario: When a chapter is added to a work, "update available" should not appear until it is posted
 
-    Given I am logged in as "writer"
-      And I post the work "Some Work"
-      And I am logged out
+    Given the work "Some Work" by "writer"
     When I am logged in as "reader"
       And I mark the work "Some Work" for later
       And the readings are saved to the database

--- a/spec/controllers/chapters_controller_spec.rb
+++ b/spec/controllers/chapters_controller_spec.rb
@@ -597,7 +597,7 @@ describe ChaptersController do
 
           it "does not update the work's major version" do
             expect(work.major_version).to eq(1)
-            post :create, params: { work_id: work.id, chapter: chapter_attributes, post_without_preview: true }
+            post :create, params: { work_id: work.id, chapter: chapter_attributes, preview_button: true }
             expect(assigns[:work].major_version).to eq(1)
           end
 

--- a/spec/controllers/chapters_controller_spec.rb
+++ b/spec/controllers/chapters_controller_spec.rb
@@ -516,10 +516,12 @@ describe ChaptersController do
         expect(response).to have_http_status :redirect
       end
 
-      it "does not update the work's major version" do
-        expect(work.major_version).to eq(1)
-        post :create, params: { work_id: work.id, chapter: chapter_attributes }
-        expect(assigns[:work].major_version).to eq(1)
+      context "when no button is clicked" do
+        it "does not update the work's major version" do
+          expect(work.major_version).to eq(1)
+          post :create, params: { work_id: work.id, chapter: chapter_attributes }
+          expect(assigns[:work].major_version).to eq(1)
+        end
       end
 
       context "when the post button is clicked" do

--- a/spec/controllers/chapters_controller_spec.rb
+++ b/spec/controllers/chapters_controller_spec.rb
@@ -516,10 +516,10 @@ describe ChaptersController do
         expect(response).to have_http_status :redirect
       end
 
-      it "updates the work's major version" do
+      it "does not update the work's major version" do
         expect(work.major_version).to eq(1)
         post :create, params: { work_id: work.id, chapter: chapter_attributes }
-        expect(assigns[:work].major_version).to eq(2)
+        expect(assigns[:work].major_version).to eq(1)
       end
 
       context "when the post button is clicked" do


### PR DESCRIPTION
# Pull Request Checklist

<!-- Mark steps in the checklist as complete by changing `[ ]` to `[X]` -->
* [x] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [x] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [x] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [x] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-6267

## Purpose

Prevents "update available" from appearing when a draft chapter added by only bumping the work version when a posted chapter is modified.

## Credit

marcus8448 (he/him)