### PR TITLE
AO3-6973 Add email when user changes or resets password

### DIFF
--- a/app/mailers/archive_devise_mailer.rb
+++ b/app/mailers/archive_devise_mailer.rb
@@ -27,4 +27,10 @@ class ArchiveDeviseMailer < Devise::Mailer
     subject = t("users.mailer.confirmation_instructions.subject", app_name: ArchiveConfig.APP_SHORT_NAME)
     devise_mail(record, :confirmation_instructions, opts.merge(subject: subject))
   end
+
+  def password_change(record, opts = {})
+    @pac_footer = true
+    subject = t("users.mailer.password_change.subject", app_name: ArchiveConfig.APP_SHORT_NAME)
+    devise_mail(record, :password_change, opts.merge(subject: subject))
+  end
 end

--- a/app/mailers/archive_devise_mailer.rb
+++ b/app/mailers/archive_devise_mailer.rb
@@ -30,7 +30,13 @@ class ArchiveDeviseMailer < Devise::Mailer
 
   def password_change(record, opts = {})
     @pac_footer = true
-    subject = t("users.mailer.password_change.subject", app_name: ArchiveConfig.APP_SHORT_NAME)
+    subject = if record.is_a?(Admin)
+                t("admin.mailer.password_change.subject",
+                  app_name: ArchiveConfig.APP_SHORT_NAME)
+              else
+                t("users.mailer.password_change.subject",
+                  app_name: ArchiveConfig.APP_SHORT_NAME)
+              end
     devise_mail(record, :password_change, opts.merge(subject: subject))
   end
 end

--- a/app/views/admin/mailer/password_change.html.erb
+++ b/app/views/admin/mailer/password_change.html.erb
@@ -7,7 +7,7 @@
            login_link: style_link(t(".made_change.login"), new_admin_session_url),
            reset_password_link: style_link(t(".made_change.reset_password"), new_admin_password_url)) %></p>
 
-  <p><%= t(".did_not_make_change.html",
-           reset_password_link: style_link(t(".did_not_make_change.reset_password"), new_admin_password_url),
-           app_name: ArchiveConfig.APP_SHORT_NAME) %></p>
+  <p><%= t(".did_not_make_change", app_name: ArchiveConfig.APP_SHORT_NAME) %></p>
+
+  <p><%= t(".access_again.html", reset_password_link: style_link(t(".access_again.reset_password"), new_admin_password_url)) %></p>
 <% end %>

--- a/app/views/admin/mailer/password_change.html.erb
+++ b/app/views/admin/mailer/password_change.html.erb
@@ -1,7 +1,7 @@
 <% content_for :message do %>
   <p><%= t("mailer.general.greeting.formal.addressed_html", name: style_bold(@resource.login)) %></p>
 
-  <p><%= t(".changed", date: l(Time.current)) %></p>
+  <p><%= t(".changed", date: l(Time.current), app_name: ArchiveConfig.APP_SHORT_NAME) %></p>
 
   <p><%= t(".made_change.html",
            login_link: style_link(t(".made_change.login"), new_admin_session_url),

--- a/app/views/admin/mailer/password_change.html.erb
+++ b/app/views/admin/mailer/password_change.html.erb
@@ -9,5 +9,5 @@
 
   <p><%= t(".did_not_make_change", app_name: ArchiveConfig.APP_SHORT_NAME) %></p>
 
-  <p><%= t(".access_again.html", reset_password_link: style_link(t(".access_again.reset_password"), new_admin_password_url)) %></p>
+  <p><%= t(".secure_again.html", reset_password_link: style_link(t(".secure_again.reset_password"), new_admin_password_url)) %></p>
 <% end %>

--- a/app/views/admin/mailer/password_change.html.erb
+++ b/app/views/admin/mailer/password_change.html.erb
@@ -1,0 +1,13 @@
+<% content_for :message do %>
+  <p><%= t("mailer.general.greeting.formal.addressed_html", name: style_bold(@resource.login)) %></p>
+
+  <p><%= t(".changed", date: l(Time.current)) %></p>
+
+  <p><%= t(".made_change.html",
+           login_link: style_link(t(".made_change.login"), new_admin_session_url),
+           reset_password_link: style_link(t(".made_change.reset_password"), new_admin_password_url)) %></p>
+
+  <p><%= t(".did_not_make_change.html",
+           reset_password_link: style_link(t(".did_not_make_change.reset_password"), new_admin_password_url),
+           app_name: ArchiveConfig.APP_SHORT_NAME) %></p>
+<% end %>

--- a/app/views/admin/mailer/password_change.text.erb
+++ b/app/views/admin/mailer/password_change.text.erb
@@ -1,7 +1,7 @@
 <% content_for :message do %>
 <%= t("mailer.general.greeting.formal.addressed_html", name: @resource.login) %>
 
-<%= t(".changed", date: l(Time.current)) %>
+<%= t(".changed", date: l(Time.current), app_name: ArchiveConfig.APP_SHORT_NAME) %>
 
 <%= t(".made_change.text",
       login_url: new_admin_session_url,

--- a/app/views/admin/mailer/password_change.text.erb
+++ b/app/views/admin/mailer/password_change.text.erb
@@ -9,5 +9,5 @@
 
 <%= t(".did_not_make_change", app_name: ArchiveConfig.APP_SHORT_NAME) %>
 
-<%= t(".access_again.text", reset_password_url: new_admin_password_url) %>
+<%= t(".secure_again.text", reset_password_url: new_admin_password_url) %>
 <% end %>

--- a/app/views/admin/mailer/password_change.text.erb
+++ b/app/views/admin/mailer/password_change.text.erb
@@ -7,7 +7,7 @@
       login_url: new_admin_session_url,
       reset_password_url: new_admin_password_url) %>
 
-<%= t(".did_not_make_change.text",
-      reset_password_url: new_admin_password_url,
-      app_name: ArchiveConfig.APP_SHORT_NAME) %>
+<%= t(".did_not_make_change", app_name: ArchiveConfig.APP_SHORT_NAME) %>
+
+<%= t(".access_again.text", reset_password_url: new_admin_password_url) %>
 <% end %>

--- a/app/views/admin/mailer/password_change.text.erb
+++ b/app/views/admin/mailer/password_change.text.erb
@@ -1,0 +1,13 @@
+<% content_for :message do %>
+<%= t("mailer.general.greeting.formal.addressed_html", name: @resource.login) %>
+
+<%= t(".changed", date: l(Time.current)) %>
+
+<%= t(".made_change.text",
+      login_url: new_admin_session_url,
+      reset_password_url: new_admin_password_url) %>
+
+<%= t(".did_not_make_change.text",
+      reset_password_url: new_admin_password_url,
+      app_name: ArchiveConfig.APP_SHORT_NAME) %>
+<% end %>

--- a/app/views/users/mailer/password_change.html.erb
+++ b/app/views/users/mailer/password_change.html.erb
@@ -1,7 +1,7 @@
 <% content_for :message do %>
   <p><%= t("mailer.general.greeting.formal.addressed_html", name: style_bold(@resource.login)) %></p>
 
-  <p><%= t(".changed", date: l(Time.current)) %></p>
+  <p><%= t(".changed", date: l(Time.current), app_name: ArchiveConfig.APP_SHORT_NAME) %></p>
 
   <p><%= t(".made_change.html",
            login_link: style_link(t(".made_change.login"), new_user_session_url),

--- a/app/views/users/mailer/password_change.html.erb
+++ b/app/views/users/mailer/password_change.html.erb
@@ -1,0 +1,15 @@
+<% content_for :message do %>
+  <p><%= t("mailer.general.greeting.formal.addressed_html", name: style_bold(@resource.login)) %></p>
+
+  <p><%= t(".changed", date: l(Time.current)) %></p>
+
+  <p><%= t(".made_change.html",
+           login_link: style_link(t(".made_change.login"), new_user_session_url),
+           reset_password_link: style_link(t(".made_change.reset_password"), new_user_password_url),
+           contact_support_link: support_link(t(".made_change.contact_support"))) %></p>
+
+  <p><%= t(".did_not_make_change.html",
+           reset_password_link: style_link(t(".did_not_make_change.reset_password"), new_user_password_url),
+           contact_policy_abuse_link: style_link(t(".did_not_make_change.contact_policy_abuse"), new_abuse_report_url),
+           app_name: ArchiveConfig.APP_SHORT_NAME) %></p>
+<% end %>

--- a/app/views/users/mailer/password_change.text.erb
+++ b/app/views/users/mailer/password_change.text.erb
@@ -1,7 +1,7 @@
 <% content_for :message do %>
 <%= t("mailer.general.greeting.formal.addressed_html", name: @resource.login) %>
 
-<%= t(".changed", date: l(Time.current)) %>
+<%= t(".changed", date: l(Time.current), app_name: ArchiveConfig.APP_SHORT_NAME) %>
 
 <%= t(".made_change.text",
       login_url: new_user_session_url,

--- a/app/views/users/mailer/password_change.text.erb
+++ b/app/views/users/mailer/password_change.text.erb
@@ -1,0 +1,15 @@
+<% content_for :message do %>
+<%= t("mailer.general.greeting.formal.addressed_html", name: @resource.login) %>
+
+<%= t(".changed", date: l(Time.current)) %>
+
+<%= t(".made_change.text",
+      login_url: new_user_session_url,
+      reset_password_url: new_user_password_url,
+      contact_support_url: new_feedback_report_url) %>
+
+<%= t(".did_not_make_change.text",
+      reset_password_url: new_user_password_url,
+      contact_policy_abuse_url: new_abuse_report_url,
+      app_name: ArchiveConfig.APP_SHORT_NAME) %>
+<% end %>

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -102,7 +102,7 @@ Devise.setup do |config|
   # config.pepper = '70ca884cc885f6ea790b81e61162e634afadc5121775443df4cb3d1e3d76d74b5c226af89d64b69c000ad9b42f1998c49ef2758ddbbab01483eded4723d7ef97'
 
   # Send a notification email when the user's password is changed
-  # config.send_password_change_notification = false
+  config.send_password_change_notification = true
 
   # ==> Configuration for :confirmable
   # A period that the user is allowed to access the website even without

--- a/config/locales/mailers/en.yml
+++ b/config/locales/mailers/en.yml
@@ -2,6 +2,18 @@
 en:
   admin:
     mailer:
+      password_change:
+        changed: The password for your AO3 admin account was changed on %{date}.
+        did_not_make_change:
+          html: If you did not make this change, someone else may have access to your %{app_name} admin account. Please %{reset_password_link}.
+          reset_password: reset your password now
+          text: 'If you did not make this change, someone else may have access to your %{app_name} admin account. Please reset your password now: %{reset_password_url}.'
+        made_change:
+          html: If you made this change, you can %{login_link} or %{reset_password_link} if you've forgotten it.
+          login: log in with your new password
+          reset_password: reset your password
+          text: If you made this change, you can log in with your new password (%{login_url}) or reset your password if you've forgotten it (%{reset_password_url}).
+        subject: "[%{app_name}] Your admin password has been changed"
       reset_password_instructions:
         expiration:
           one: If you do not use this link to reset your password within %{count} day, it will expire, and you will have to request a new one.

--- a/config/locales/mailers/en.yml
+++ b/config/locales/mailers/en.yml
@@ -3,10 +3,6 @@ en:
   admin:
     mailer:
       password_change:
-        access_again:
-          html: When your accounts are secure again, please %{reset_password_link}.
-          reset_password: reset your admin password
-          text: 'When your accounts are secure again, please reset your admin password: %{reset_password_url}.'
         changed: The password for your AO3 admin account was changed on %{date}.
         did_not_make_change: If you did not make this change, someone else may have access to your %{app_name} admin account or your OTW email. Please let AD&T and VolCom know immediately so they can take steps to secure your accounts.
         made_change:
@@ -14,6 +10,10 @@ en:
           login: log in with your new password
           reset_password: reset your password
           text: If you made this change, you can log in with your new password (%{login_url}) or reset your password if you've forgotten it (%{reset_password_url}).
+        secure_again:
+          html: When your accounts are secure again, please %{reset_password_link}.
+          reset_password: reset your admin password
+          text: 'When your accounts are secure again, please reset your admin password: %{reset_password_url}.'
         subject: "[%{app_name}] Your admin password has been changed"
       reset_password_instructions:
         expiration:

--- a/config/locales/mailers/en.yml
+++ b/config/locales/mailers/en.yml
@@ -3,11 +3,12 @@ en:
   admin:
     mailer:
       password_change:
+        access_again:
+          html: When your accounts are secure again, please %{reset_password_link}.
+          reset_password: reset your admin password
+          text: 'When your accounts are secure again, please reset your admin password: %{reset_password_url}.'
         changed: The password for your AO3 admin account was changed on %{date}.
-        did_not_make_change:
-          html: If you did not make this change, someone else may have access to your %{app_name} admin account. Please %{reset_password_link}.
-          reset_password: reset your password now
-          text: 'If you did not make this change, someone else may have access to your %{app_name} admin account. Please reset your password now: %{reset_password_url}.'
+        did_not_make_change: If you did not make this change, someone else may have access to your %{app_name} admin account or your OTW email. Please let AD&T and VolCom know immediately so they can take steps to secure your accounts.
         made_change:
           html: If you made this change, you can %{login_link} or %{reset_password_link} if you've forgotten it.
           login: log in with your new password

--- a/config/locales/mailers/en.yml
+++ b/config/locales/mailers/en.yml
@@ -467,6 +467,20 @@ en:
             other: 'If you made this request, please log in and confirm your email change within %{count} days: %{confirm_email_change_url}.'
         request_to_change_email_html: Someone has made a request to change the email address associated with the %{app_name} account %{username} to this email address.
         subject: "[%{app_name}] Confirm your email change"
+      password_change:
+        changed: The password for your AO3 account was changed on %{date}.
+        did_not_make_change:
+          contact_policy_abuse: contact Policy & Abuse
+          html: If you did not make this change, someone else may have access to your %{app_name} account. Please %{reset_password_link} or %{contact_policy_abuse_link}.
+          reset_password: reset your password now
+          text: 'If you did not make this change, someone else may have access to your %{app_name} account. Please reset your password now (%{reset_password_url}) or contact Policy & Abuse: %{contact_policy_abuse_url}.'
+        made_change:
+          contact_support: contact Support
+          html: If you made this change, you can %{login_link} or %{reset_password_link} if you've forgotten it. If you experience technical issues, please %{contact_support_link}.
+          login: log in with your new password
+          reset_password: reset your password
+          text: 'If you made this change, you can log in with your new password (%{login_url}) or reset your password if you''ve forgotten it (%{reset_password_url}). If you experience technical issues, please contact Support: %{contact_support_url}'
+        subject: "[%{app_name}] Your password has been changed"
       reset_password_instructions:
         expiration: If you do not use this link to reset your password within a week, it will expire, and you will have to request a new one.
         intro: 'Someone has requested a password reset for your account. You can change your account password by following the link below and entering your new password:'

--- a/config/locales/mailers/en.yml
+++ b/config/locales/mailers/en.yml
@@ -3,7 +3,7 @@ en:
   admin:
     mailer:
       password_change:
-        changed: The password for your AO3 admin account was changed on %{date}.
+        changed: The password for your %{app_name} admin account was changed on %{date}.
         did_not_make_change: If you did not make this change, someone else may have access to your %{app_name} admin account or your OTW email. Please let AD&T and VolCom know immediately so they can take steps to secure your accounts.
         made_change:
           html: If you made this change, you can %{login_link} or %{reset_password_link} if you've forgotten it.
@@ -481,7 +481,7 @@ en:
         request_to_change_email_html: Someone has made a request to change the email address associated with the %{app_name} account %{username} to this email address.
         subject: "[%{app_name}] Confirm your email change"
       password_change:
-        changed: The password for your AO3 account was changed on %{date}.
+        changed: The password for your %{app_name} account was changed on %{date}.
         did_not_make_change:
           contact_policy_abuse: contact Policy & Abuse
           html: If you did not make this change, someone else may have access to your %{app_name} account. Please %{reset_password_link} or %{contact_policy_abuse_link}.

--- a/features/admins/authenticate_admins.feature
+++ b/features/admins/authenticate_admins.feature
@@ -92,6 +92,7 @@ Feature: Authenticate Admin Users
     | login | password     | email             |
     | admin | testpassword | admin@example.com |
     And all emails have been delivered
+    And it is currently 2025-04-12 17:00 UTC
   When I go to the admin login page
     And I follow "Forgot admin password?"
   Then I should see "Forgotten your admin password?"
@@ -100,12 +101,16 @@ Feature: Authenticate Admin Users
   Then I should see "Check your email for instructions on how to reset your password."
     And 1 email should be delivered to "admin@example.com"
   When I follow "Change my password" in the email
+    And all emails have been delivered
   Then I should see "Set My Admin Password"
   When I fill in "New password" with "newpassword"
     And I fill in "Confirm new password" with "newpassword"
     And I press "Set Admin Password"
   Then I should see "Your password has been changed successfully. You are now signed in."
     And I should see "Hi, admin!"
+    And 1 emails should be delivered to "admin@example.com"
+    And the email should have "Your admin password has been changed" in the subject
+    And the email should contain "The password for your AO3 admin account was changed on Sat, 12 Apr 2025 17:00:.+ \+0000"
 
   Scenario: Reset password link expires.
   Given the following admin exists

--- a/features/admins/authenticate_admins.feature
+++ b/features/admins/authenticate_admins.feature
@@ -110,7 +110,7 @@ Feature: Authenticate Admin Users
     And I should see "Hi, admin!"
     And 1 emails should be delivered to "admin@example.com"
     And the email should have "Your admin password has been changed" in the subject
-    And the email should contain "The password for your AO3 admin account was changed on Sat, 12 Apr 2025 17:00:.+ \+0000"
+    And the email should contain "The password for your AO3 admin account was changed on Sat, 12 Apr 2025 17:00:\d+ \+0000"
 
   Scenario: Reset password link expires.
   Given the following admin exists

--- a/features/other_a/profile_edit.feature
+++ b/features/other_a/profile_edit.feature
@@ -238,7 +238,7 @@ Scenario: Change password
   Then I should see "Your password has been changed. To protect your account, you have been logged out of all active sessions. Please log in with your new password."
     And 1 email should be delivered to "editname"
     And the email should have "Your password has been changed" in the subject
-    And the email should contain "The password for your AO3 account was changed on Sat, 12 Apr 2025 17:00:.+ \+0000"
+    And the email should contain "The password for your AO3 account was changed on Sat, 12 Apr 2025 17:00:\d+ \+0000"
   When I am logged in as a super admin
     And I go to the user administration page for "editname"
   Then I should see "Password Changed" within "#user_history"

--- a/features/other_a/profile_edit.feature
+++ b/features/other_a/profile_edit.feature
@@ -233,9 +233,12 @@ Scenario: Change password - mistake in typing new password confirmation
 
 Scenario: Change password
 
-  When I change my password
+  When it is currently 2025-04-12 17:00 UTC
+    And I change my password
   Then I should see "Your password has been changed. To protect your account, you have been logged out of all active sessions. Please log in with your new password."
-    And 0 emails should be delivered
+    And 1 email should be delivered to "editname"
+    And the email should have "Your password has been changed" in the subject
+    And the email should contain "The password for your AO3 account was changed on Sat, 12 Apr 2025 17:00:.+ \+0000"
   When I am logged in as a super admin
     And I go to the user administration page for "editname"
   Then I should see "Password Changed" within "#user_history"

--- a/features/step_definitions/tag_steps.rb
+++ b/features/step_definitions/tag_steps.rb
@@ -138,6 +138,7 @@ Given /^the tag wrangler "([^\"]*)" with password "([^\"]*)" is wrangler of "([^
   if tw.blank?
     tw = FactoryBot.create(:user, login: user, password: password)
   else
+    tw.skip_password_change_notification!
     tw.password = password
     tw.password_confirmation = password
     tw.save

--- a/features/support/user.rb
+++ b/features/support/user.rb
@@ -9,6 +9,7 @@ module UserHelpers
       # triggering Sweeper hooks
       user.pseuds.first.add_to_autocomplete
     else
+      user.skip_password_change_notification!
       user.password = password
       user.password_confirmation = password
       user.save

--- a/features/users/authenticate_users.feature
+++ b/features/users/authenticate_users.feature
@@ -105,8 +105,8 @@ Feature: User Authentication
       And 1 email should be delivered to "notsam@example.com"
       And the email should have "Reset your password" in the subject
       And the email to "notsam" should be non-translated
-    When 1 email should be delivered to "sam@example.com"
-      And I follow "Change my password." in the email
+      And 1 email should be delivered to "sam@example.com"
+    When I follow "Change my password." in the email
       And all emails have been delivered
       And I fill in "New password" with "newpass"
       And I fill in "Confirm new password" with "newpass"

--- a/features/users/authenticate_users.feature
+++ b/features/users/authenticate_users.feature
@@ -86,7 +86,7 @@ Feature: User Authentication
       And I press "Log In"
     Then I should not see "Hi, sam"
 
-  Scenario: Translated reset password email
+  Scenario: Translated reset password email and password change email
     Given a locale with translated emails
       And the following activated users exist
         | login    | email              | password |
@@ -105,6 +105,16 @@ Feature: User Authentication
       And 1 email should be delivered to "notsam@example.com"
       And the email should have "Reset your password" in the subject
       And the email to "notsam" should be non-translated
+    When 1 email should be delivered to "sam@example.com"
+      And I follow "Change my password." in the email
+      And all emails have been delivered
+      And I fill in "New password" with "newpass"
+      And I fill in "Confirm new password" with "newpass"
+      And I press "Change Password"
+    Then I should see "Your password has been changed successfully."
+      And 1 email should be delivered to "sam"
+      And the email should have "Your password has been changed" in the subject
+      And the email to "sam" should be translated
 
   Scenario: Forgot password, logging in with email address
     Given I have no users

--- a/spec/mailers/archive_devise_mailer_spec.rb
+++ b/spec/mailers/archive_devise_mailer_spec.rb
@@ -106,34 +106,69 @@ describe ArchiveDeviseMailer do
   end
 
   describe "#password_change" do
-    let(:user) { create(:user) }
-    subject(:email) { ArchiveDeviseMailer.password_change(user) }
+    subject(:email) { ArchiveDeviseMailer.password_change(record) }
 
-    # Test the headers
-    it_behaves_like "an email with a valid sender"
+    context "when record is user" do
+      let(:record) { create(:user) }
 
-    it "has the correct subject line" do
-      subject = "[#{ArchiveConfig.APP_SHORT_NAME}] Your password has been changed"
-      expect(email.subject).to eq(subject)
-    end
+      # Test the headers
+      it_behaves_like "an email with a valid sender"
 
-    # Test both body contents
-    it_behaves_like "a multipart email"
+      it "has the correct subject line" do
+        subject = "[#{ArchiveConfig.APP_SHORT_NAME}] Your password has been changed"
+        expect(email.subject).to eq(subject)
+      end
 
-    it_behaves_like "a translated email"
+      # Test both body contents
+      it_behaves_like "a multipart email"
 
-    describe "HTML version" do
-      it "has the correct content" do
-        expect(email).to have_html_part_content("Hi <b")
-        expect(email).to have_html_part_content("#{user.login}</b>,")
-        expect(email).to have_html_part_content("The password for your AO3 account was changed")
+      it_behaves_like "a translated email"
+
+      describe "HTML version" do
+        it "has the correct content" do
+          expect(email).to have_html_part_content("Hi <b")
+          expect(email).to have_html_part_content("#{record.login}</b>,")
+          expect(email).to have_html_part_content("The password for your AO3 account was changed")
+        end
+      end
+
+      describe "text version" do
+        it "has the correct content" do
+          expect(email).to have_text_part_content("Hi #{record.login},")
+          expect(email).to have_text_part_content("The password for your AO3 account was changed")
+        end
       end
     end
 
-    describe "text version" do
-      it "has the correct content" do
-        expect(email).to have_text_part_content("Hi #{user.login},")
-        expect(email).to have_text_part_content("The password for your AO3 account was changed")
+    context "when record is admin" do
+      let(:record) { create(:admin) }
+
+      # Test the headers
+      it_behaves_like "an email with a valid sender"
+
+      it "has the correct subject line" do
+        subject = "[#{ArchiveConfig.APP_SHORT_NAME}] Your admin password has been changed"
+        expect(email.subject).to eq(subject)
+      end
+
+      # Test both body contents
+      it_behaves_like "a multipart email"
+
+      it_behaves_like "a translated email"
+
+      describe "HTML version" do
+        it "has the correct content" do
+          expect(email).to have_html_part_content("Hi <b")
+          expect(email).to have_html_part_content("#{record.login}</b>,")
+          expect(email).to have_html_part_content("The password for your AO3 admin account was changed")
+        end
+      end
+
+      describe "text version" do
+        it "has the correct content" do
+          expect(email).to have_text_part_content("Hi #{record.login},")
+          expect(email).to have_text_part_content("The password for your AO3 admin account was changed")
+        end
       end
     end
   end

--- a/spec/mailers/archive_devise_mailer_spec.rb
+++ b/spec/mailers/archive_devise_mailer_spec.rb
@@ -104,4 +104,37 @@ describe ArchiveDeviseMailer do
       end
     end
   end
+
+  describe "#password_change" do
+    let(:user) { create(:user) }
+    subject(:email) { ArchiveDeviseMailer.password_change(user) }
+
+    # Test the headers
+    it_behaves_like "an email with a valid sender"
+
+    it "has the correct subject line" do
+      subject = "[#{ArchiveConfig.APP_SHORT_NAME}] Your password has been changed"
+      expect(email.subject).to eq(subject)
+    end
+
+    # Test both body contents
+    it_behaves_like "a multipart email"
+
+    it_behaves_like "a translated email"
+
+    describe "HTML version" do
+      it "has the correct content" do
+        expect(email).to have_html_part_content("Hi <b")
+        expect(email).to have_html_part_content("#{user.login}</b>,")
+        expect(email).to have_html_part_content("The password for your AO3 account was changed")
+      end
+    end
+
+    describe "text version" do
+      it "has the correct content" do
+        expect(email).to have_text_part_content("Hi #{user.login},")
+        expect(email).to have_text_part_content("The password for your AO3 account was changed")
+      end
+    end
+  end
 end

--- a/spec/mailers/archive_devise_mailer_spec.rb
+++ b/spec/mailers/archive_devise_mailer_spec.rb
@@ -108,7 +108,7 @@ describe ArchiveDeviseMailer do
   describe "#password_change" do
     subject(:email) { ArchiveDeviseMailer.password_change(record) }
 
-    context "when record is user" do
+    context "when the record is a user" do
       let(:record) { create(:user) }
 
       # Test the headers
@@ -140,7 +140,7 @@ describe ArchiveDeviseMailer do
       end
     end
 
-    context "when record is admin" do
+    context "when the record is an admin" do
       let(:record) { create(:admin) }
 
       # Test the headers

--- a/test/mailers/previews/archive_devise_mailer_preview.rb
+++ b/test/mailers/previews/archive_devise_mailer_preview.rb
@@ -13,9 +13,15 @@ class ArchiveDeviseMailerPreview < ApplicationMailerPreview
     ArchiveDeviseMailer.confirmation_instructions(user, "fakeToken")
   end
 
-  # URL: /rails/mailers/archive_devise_mailer/password_change
-  def password_change
+  # URL: /rails/mailers/archive_devise_mailer/password_change_user
+  def password_change_user
     user = create(:user, :for_mailer_preview)
     ArchiveDeviseMailer.password_change(user)
+  end
+
+  # URL: /rails/mailers/archive_devise_mailer/password_change_admin
+  def password_change_admin
+    admin = create(:admin, login: "admin-#{Faker::Alphanumeric.alpha(number: 8)}")
+    ArchiveDeviseMailer.password_change(admin)
   end
 end

--- a/test/mailers/previews/archive_devise_mailer_preview.rb
+++ b/test/mailers/previews/archive_devise_mailer_preview.rb
@@ -12,4 +12,10 @@ class ArchiveDeviseMailerPreview < ApplicationMailerPreview
     user = create(:user, :for_mailer_preview, confirmation_sent_at: (params[:confirmation_sent_at] ? params[:confirmation_sent_at].to_time : Time.current))
     ArchiveDeviseMailer.confirmation_instructions(user, "fakeToken")
   end
+
+  # URL: /rails/mailers/archive_devise_mailer/password_change
+  def password_change
+    user = create(:user, :for_mailer_preview)
+    ArchiveDeviseMailer.password_change(user)
+  end
 end


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6973

## Purpose

When a user changes or resets their password they will be emailed.

Do the same for admin password resets.

## Credit

Bilka
