### PR TITLE
AO3-6092 Add automated test to check chapter titles display in entire work view when work has only a single posted chapter

### DIFF
--- a/features/works/work_view.feature
+++ b/features/works/work_view.feature
@@ -70,12 +70,13 @@ Feature: View a work with various options
   Then I should see a link "Add to Collections"
     And I should see the "new_collection_item" form
 
-  Scenario: chapter title displays in View Full Work mode when work has one published chapter
+  Scenario: chapter title displays in View Full Work mode when chaptered work has one published chapter
   Given I am logged in as a random user
     And I set my preferences to View Full Work mode by default
   When I set up the draft "multiChap"
-    And I check the checkbox with id "chapters-options-show"
-    And I fill out the field with id "work-chapter-attributes-title" with "cool chapter title"
+    And I check "This work has multiple chapters"
+    And I fill in "Chapter Title" with "cool chapter title"
+    And I fill in "Chapter 1 of" with "?"
     And I press "Post"
   Then I should see "Chapter 1: "
     And I should see "cool chapter title"

--- a/features/works/work_view.feature
+++ b/features/works/work_view.feature
@@ -69,3 +69,13 @@ Feature: View a work with various options
     And I view the work "Imported Work"
   Then I should see a link "Add to Collections"
     And I should see the "new_collection_item" form
+
+  Scenario: chapter title displays in View Full Work mode when work has one published chapter
+  Given I am logged in as a random user
+    And I set my preferences to View Full Work mode by default
+  When I set up the draft "multiChap"
+    And I check the checkbox with id "chapters-options-show"
+    And I fill out the field with id "work-chapter-attributes-title" with "cool chapter title"
+    And I press "Post"
+  Then I should see "Chapter 1: "
+    And I should see "cool chapter title"


### PR DESCRIPTION
# Pull Request Checklist

<!-- Mark steps in the checklist as complete by changing `[ ]` to `[X]` -->
* [x] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [ ] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)? n/a only testing
* [x] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [x] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-6092

## Purpose

Add a automated test

## Credit

Hamham6, it/its
