### PR TITLE
AO3-5714 Skip association creation when a TagSetAssociation exists

### DIFF
--- a/lib/tasks/after_tasks.rake
+++ b/lib/tasks/after_tasks.rake
@@ -555,6 +555,8 @@ namespace :After do
         fandoms = tag.fandoms.joins(:set_taggings).where(canonical: true, set_taggings: { tag_set_id: set_tagging.tag_set.id })
         fandoms.find_each do |fandom|
           TagSetAssociation.create!(owned_tag_set: owned_tag_set, tag: tag, parent_tag: fandom)
+        rescue ActiveRecord::RecordInvalid
+          puts "Association already exists for fandom '#{fandom.name}' and tag '#{tag.name}'"
         end
       end
     end

--- a/spec/lib/tasks/after_tasks.rake_spec.rb
+++ b/spec/lib/tasks/after_tasks.rake_spec.rb
@@ -612,5 +612,20 @@ describe "rake After:create_non_canonical_tagset_associations" do
         expect(TagSetAssociation.where(tag: relationship, owned_tag_set: owned_tag_set)).to exist
       end
     end
+
+    context "when a TagSetAssociation already exists for the fandom and tag" do
+      let!(:owned_tag_set) do
+        create(:owned_tag_set, tags: [character, character.fandoms, relationship, relationship.fandoms].flatten)
+      end
+
+      before do
+        create(:tag_set_association,
+               owned_tag_set: owned_tag_set, tag: character, parent_tag: character.fandoms.first)
+        create(:tag_set_association,
+               owned_tag_set: owned_tag_set, tag: relationship, parent_tag: relationship.fandoms.first)
+      end
+
+      it_behaves_like "no TagSetAssociation is created"
+    end
   end
 end


### PR DESCRIPTION
# Pull Request Checklist

## Issue

https://otwarchive.atlassian.net/browse/AO3-5714

## Purpose

Fix the rake task so it ignores validation errors (raised when the `TagSetAssociation` for the set, fandom, and child tag already exists)