### PR TITLE
AO3-6988 Use cache-apt-pkgs-action in automated tests

### DIFF
--- a/.github/workflows/automated-tests.yml
+++ b/.github/workflows/automated-tests.yml
@@ -102,17 +102,21 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v4
 
-      - name: Run apt-get update
-        run: sudo apt-get update
+      - name: Install redis
+        uses: awalsh128/cache-apt-pkgs-action@7ca5f46d061ad9aa95863cd9b214dd48edef361d
+        with:
+          packages: redis-server
+          version: "1.0"
 
-      - name: Install and start up redis servers
-        run: |
-          sudo apt-get install -y redis-server
-          ./script/gh-actions/multiple_redis.sh
+      - name: Start up redis servers
+        run: ./script/gh-actions/multiple_redis.sh
 
       - name: Install ebook converters
         if: ${{ matrix.tests.ebook }}
-        run: ./script/gh-actions/ebook_converters.sh
+        uses: awalsh128/cache-apt-pkgs-action@7ca5f46d061ad9aa95863cd9b214dd48edef361d
+        with:
+          packages: calibre zip
+          version: "1.0"
 
       - name: Cache VCR cassettes
         if: ${{ matrix.tests.vcr }}
@@ -136,7 +140,10 @@ jobs:
 
       - name: Install libvips for image processing
         if: ${{ matrix.tests.libvips }}
-        run: sudo apt-get install -y libvips-dev
+        uses: awalsh128/cache-apt-pkgs-action@7ca5f46d061ad9aa95863cd9b214dd48edef361d
+        with:
+          packages: libvips-dev
+          version: "1.0"
 
       - name: Set up Ruby and run bundle install
         uses: ruby/setup-ruby@v1

--- a/script/gh-actions/ebook_converters.sh
+++ b/script/gh-actions/ebook_converters.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-
-sudo apt-get install -y calibre zip
-
-ebook-convert --version


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6988

## Purpose

Change our direct uses of `apt-get` to `cache-apt-pkgs-action` so that the result can be cached.

I also tried out caching all the apt packages in the same step, however that means that uncached runs have to install libvips and calibre even if they don't need it, which slows them down a lot. By keeping the caches separated by step nothing gets slowed down if there is a cache miss.

We have to add the action to the Allow specified actions and reusable workflows list (https://github.com/otwcode/otwarchive/settings/actions) to get it to run in this repo.

## Testing Instructions

Run without existing caches: https://github.com/Bilka2/otwarchive/actions/runs/14889581675

Run using caches, with massively reduced install times for ebooks/libvips: https://github.com/Bilka2/otwarchive/actions/runs/14889783962

## Credit

Bilka