### PR TITLE
AO3-6304 Prevent searching series by restricted tags when logged out

### DIFF
--- a/app/models/external_work.rb
+++ b/app/models/external_work.rb
@@ -86,16 +86,21 @@ class ExternalWork < ApplicationRecord
   ######################
 
   def bookmarkable_json
+    methods = %i[creators posted restricted revised_at]
+    %w[restricted public].each do |visibility|
+      methods << :"tags_#{visibility}"
+
+      %w[archive_warning category character fandom filter freeform rating relationship].each do |tag_type|
+        methods << :"#{tag_type}_ids_#{visibility}"
+      end
+    end
+
     as_json(
       root: false,
       only: [
         :title, :summary, :hidden_by_admin, :created_at
       ],
-      methods: [
-        :posted, :restricted, :tag, :filter_ids, :rating_ids,
-        :archive_warning_ids, :category_ids, :fandom_ids, :character_ids,
-        :relationship_ids, :freeform_ids, :creators, :revised_at
-      ]
+      methods: methods
     ).merge(
       language_id: language&.short,
       bookmarkable_type: "ExternalWork",

--- a/app/models/series.rb
+++ b/app/models/series.rb
@@ -277,12 +277,12 @@ class Series < ApplicationRecord
   end
 
   # Index all the filters for pulling works
-  def filter_ids_public
-    (work_tags.pluck(:id) + filters_public.pluck(:id)).uniq
+  def filter_ids_restricted
+    (work_tags.pluck(:id) + filters_restricted.pluck(:id)).uniq
   end
 
-  def filter_ids_restricted
-    (work_tags.where(works: { restricted: false }).pluck(:id) + filters_restricted.pluck(:id)).uniq
+  def filter_ids_public
+    (work_tags.where(works: { restricted: false }).pluck(:id) + filters_public.pluck(:id)).uniq
   end
 
   %w[restricted public].each do |tag_visibility|

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -1182,24 +1182,29 @@ class Work < ApplicationRecord
   end
 
   def bookmarkable_json
+    methods = %i[collection_ids creators work_types]
+    %w[restricted public].each do |visibility|
+      methods << :"tags_#{visibility}"
+
+      %w[archive_warning category character fandom filter freeform rating relationship].each do |tag_type|
+        methods << :"#{tag_type}_ids_#{visibility}"
+      end
+    end
+
     as_json(
       root: false,
       only: [
         :title, :summary, :hidden_by_admin, :restricted, :posted,
         :created_at, :revised_at, :word_count, :complete
       ],
-      methods: [
-        :tag, :filter_ids, :rating_ids, :archive_warning_ids, :category_ids,
-        :fandom_ids, :character_ids, :relationship_ids, :freeform_ids,
-        :creators, :collection_ids, :work_types
-      ]
+      methods: methods
     ).merge(
       language_id: language&.short,
       anonymous: anonymous?,
       unrevealed: unrevealed?,
       pseud_ids: anonymous? || unrevealed? ? nil : pseud_ids,
       user_ids: anonymous? || unrevealed? ? nil : user_ids,
-      bookmarkable_type: 'Work',
+      bookmarkable_type: "Work",
       bookmarkable_join: { name: "bookmarkable" }
     )
   end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -88,6 +88,18 @@ services:
     # Make `docker compose attach web` work for debugging
     stdin_open: true
     tty: true
+  workers:
+    profiles:
+      - dev
+    build:
+      context: .
+      dockerfile: ./config/docker/Dockerfile
+    command: bundle exec rake environment resque:work
+    volumes:
+      - .:/otwa
+    environment:
+      - RAILS_ENV=development
+      - QUEUE=*
   chrome:
     profiles:
       - test


### PR DESCRIPTION
# Pull Request Checklist

## Issue

https://otwarchive.atlassian.net/browse/AO3-6304

## Purpose

Split the tag fields in Elasticsearch into _restricted and _public fields; the former is queried when a logged in user searches/filters, the latter when a guest does the same. The query also replaces `tags_<visibility>` with `tag`, which is then mapped to the correct `tags_<visibility>` to allow existing searches like "tag:Character" but prevent searches that directly reference the visibility-sensitive fields.

Due to the internal ES changes, bookmarkables will need to be reindexed.

Note: I have not added tests yet. A feature test is probably worthwhile, regardless of implementation details, but other tests depend on if we like this approach. Once folks have had a chance to offer feedback, I will go through and fix/add unit tests.
