### PR TITLE
AO3-6844 Change padding on listbox notice to margin

### DIFF
--- a/public/stylesheets/site/2.0/11-group-listbox.css
+++ b/public/stylesheets/site/2.0/11-group-listbox.css
@@ -27,7 +27,7 @@ http://otwcode.github.com/docs/front_end_coding/patterns/listbox
 }
 
 .listbox > .notice {
-  padding: 0.25em;
+  margin: 0.25em;
 }
 
 .listbox .index {


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6844

## Purpose

What it says on the tin.

## Testing Instructions

Follow the steps on the issue to create a tag set with Unassociated Characters & Relationships and then confirm the blue banner is not pressed right up to the edges of the listbox.

