### PR TITLE
AO3-4190 Fix admin settings last updated date being modified by invitation sending

### DIFF
--- a/app/models/admin_setting.rb
+++ b/app/models/admin_setting.rb
@@ -58,7 +58,9 @@ class AdminSetting < ApplicationRecord
     return unless self.invite_from_queue_enabled? && InviteRequest.any? && Time.current >= self.invite_from_queue_at
 
     new_time = Time.current + self.invite_from_queue_frequency.hours
-    self.first.update_attribute(:invite_from_queue_at, new_time)
+    current_setting = self.first
+    current_setting.invite_from_queue_at = new_time
+    current_setting.save(validate: false, touch: false)
     InviteFromQueueJob.perform_now(count: invite_from_queue_number)
   end
 

--- a/app/views/admin/settings/index.html.erb
+++ b/app/views/admin/settings/index.html.erb
@@ -95,9 +95,8 @@
     <%= t(".queue_status",
           count: @admin_setting.invite_from_queue_number,
           time: l(@admin_setting.invite_from_queue_at, format: :long)) %>
+    <%= t(".queue_status_help") %>
   </p>
-
-  <p><%= t(".queue_status_help") %></p>
 <% end %>
 
 <p>

--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -392,7 +392,7 @@ en:
           suspend_filter_counts: Suspend some filter tracking due to high posting volume
           tag_wrangling_off: Turn off tag wrangling for non-admins
         heading: Archive Settings
-        last_updated_by_admin: Last updated on %{updated_at} by %{admin_name}.
+        last_updated_by_admin: Settings last updated on %{updated_at} by %{admin_name}.
         legend:
           account_and_invitations: Accounts and Invitations
           actions: Actions

--- a/features/admins/admin_settings.feature
+++ b/features/admins/admin_settings.feature
@@ -145,3 +145,25 @@ Feature: Admin Settings Page
     Then I should not see "Sorry, the Archive doesn't allow guests to comment right now."
     When I post the comment "Sent you a syn" on the tag "Stargate SG-1"
     Then I should see "Comment created!"
+
+  Scenario: Timestamp and admin for last update is not affected by invitation sending
+    Given time is frozen at 2025-04-12 17:00
+      And the invitation queue is enabled
+      And an invitation request for "invitee@example.org"
+      And an invitation request for "invitee2@example.org"
+      And an invitation request for "invitee3@example.org"
+      And I am logged in as a "superadmin" admin
+    When I go to the admin-settings page
+      And I fill in "Number of people to invite from the queue at once" with "2"
+      And I fill in "How often (in hours) should we invite people from the queue" with "1"
+      And I press "Update"
+    Then I should see "Settings last updated on 2025-04-12 17:00:00 UTC by testadmin-superadmin."
+      And I should see "2 people are scheduled to be sent invitations at April 12, 2025 18:00."
+    When time is frozen at 2025-04-14 03:00
+      And I go to the admin-settings page
+    Then I should see "Settings last updated on 2025-04-12 17:00:00 UTC by testadmin-superadmin."
+      And I should see "2 people are scheduled to be sent invitations at April 12, 2025 18:00."
+    When the scheduled check_invite_queue job is run
+      And I go to the admin-settings page
+    Then I should see "Settings last updated on 2025-04-12 17:00:00 UTC by testadmin-superadmin."
+      And I should see "2 people are scheduled to be sent invitations at April 14, 2025 04:00."


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-4190

## Purpose

Fix that sending invitations from the queue would update the "last updated" date for the admin settings.

The update being attributed to the wrong admin no longer appears to be an issue from what I could see, neither are the different timezones.

## Credit

Bilka
