### PR TITLE
Ao3-6303 Hide restricted work tags on series blurbs

### DIFF
--- a/app/controllers/series_controller.rb
+++ b/app/controllers/series_controller.rb
@@ -48,14 +48,15 @@ class SeriesController < ApplicationController
     if @series.unrevealed?
       @page_subtitle = t(".unrevealed_series")
     else
-      @page_title = get_page_title(@series.allfandoms.collect(&:name).join(", "), @series.anonymous? ? t(".anonymous") : @series.allpseuds.collect(&:byline).join(", "), @series.title)
+      @page_title = get_page_title(@series.fandoms.pluck(:name).join(t("support.array.words_connector")),
+                                   @series.anonymous? ? t(".anonymous") : @series.allpseuds.collect(&:byline).join(t("support.array.words_connector")),
+                                   @series.title)
     end
 
-    if current_user.respond_to?(:subscriptions)
-      @subscription = current_user.subscriptions.where(subscribable_id: @series.id,
-                                                       subscribable_type: 'Series').first ||
-                      current_user.subscriptions.build(subscribable: @series)
-    end
+    return unless current_user.respond_to?(:subscriptions)
+
+    @subscription = current_user.subscriptions.where(subscribable: @series).first ||
+                    current_user.subscriptions.build(subscribable: @series)
   end
 
   # GET /series/new

--- a/app/models/series.rb
+++ b/app/models/series.rb
@@ -190,8 +190,8 @@ class Series < ApplicationRecord
   end
 
   # returns list of fandoms on this series
-  def allfandoms
-    works.collect(&:fandoms).flatten.compact.uniq.sort
+  def fandoms
+    tag_groups["Fandom"].sort
   end
 
   def author_tags
@@ -199,7 +199,11 @@ class Series < ApplicationRecord
   end
 
   def tag_groups
-    self.work_tags.group_by { |t| t.type.to_s }
+    @tag_groups ||= if User.current_user.present?
+                      self.work_tags.group_by { |t| t.type.to_s }
+                    else
+                      self.work_tags.where(works: { restricted: false }).group_by { |t| t.type.to_s }
+                    end
   end
 
   # Grabs the earliest published_at date of the visible works in the series

--- a/app/views/series/_series_module.html.erb
+++ b/app/views/series/_series_module.html.erb
@@ -1,27 +1,23 @@
-<% # expects "series" %>
+<%# expects "series" %>
 
 <!--title etc-->
 <div class="header module">
   <h4 class="heading">
-    <%= link_to series.title, series %>
-    <%= ts('by') %>
-    <%= byline(series) %>
+    <%= t(".series_by_html", series_title_link: link_to(series.title, series), byline: byline(series)) %>
     <% if series.restricted %>
-      <%= image_tag("lockblue.png", size: "15x15", alt: ts("(Restricted)"),
-                    title: ts("Restricted"),
+      <%= image_tag("lockblue.png", size: "15x15", alt: t(".restricted_alt"),
+                    title: t(".restricted"),
                     skip_pipeline: true) %>
     <% end %>
     <% if series.hidden_by_admin %>
-      <%= image_tag("lockred.png", size: "15x15", alt: ts("(Hidden by Admin)"),
-                    title: ts("Hidden by Administrator"),
+      <%= image_tag("lockred.png", size: "15x15", alt: t(".hidden_by_admin_alt"),
+                    title: t(".hidden_by_administrator"),
                     skip_pipeline: true) %>
     <% end %>
   </h4>
   <h5 class="fandoms heading">
-    <span class="landmark"><%= ts('Fandom') %>:</span>
-    <%= series.work_tags.select{ |tag| tag.type == "Fandom" }.
-                         sort.collect{ |tag| link_to_tag_works(tag) }.
-                         join(', ').html_safe %>
+    <span class="landmark"><%= t(".landmark.fandom") %></span>
+    <%= series.fandoms.map { |tag| link_to_tag_works(tag) }.join(t("support.array.words_connector")).html_safe %>
   </h5>
   <%= get_symbols_for(series) %>
   <p class="datetime"><%= set_format_for_date(series.revised_at) %></p>
@@ -34,7 +30,7 @@
 
 <!--summary-->
 <% unless series.summary.blank? %>
-  <h6 class="landmark heading"><%= ts("Summary") %></h6>
+  <h6 class="landmark heading"><%= t(".landmark.summary") %></h6>
   <blockquote class="userstuff summary">
     <%=raw strip_images(sanitize_field(series, :summary)) %>
   </blockquote>

--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -1976,6 +1976,16 @@ en:
   related_works:
     index:
       page_heading: "%{login}'s Related Works"
+  series:
+    series_module:
+      hidden_by_admin_alt: "(Hidden by Admin)"
+      hidden_by_administrator: Hidden by Administrator
+      landmark:
+        fandom: Fandom
+        summary: Summary
+      restricted: Restricted
+      restricted_alt: "(Restricted)"
+      series_by_html: "%{series_title_link} by %{byline}"
   skins:
     confirm_delete:
       confirm_html: Are you sure you want to <strong><em>delete</em></strong> the skin "%{skin_title}"?

--- a/features/bookmarks/bookmark_browse.feature
+++ b/features/bookmarks/bookmark_browse.feature
@@ -16,3 +16,17 @@ Feature: Browse Bookmarks
     When I go to the bookmarks page for user "ethel" with pseud "aka"
     Then I should see "Bookmarked with Other Pseud"
       And I should not see "Bookmarked with Default Pseud"
+
+  Scenario: Bookmarked series' blurbs show tags on restricted works only to logged in users
+    Given I am logged in as "bookmarker"
+      And I post the work "Public Work" with fandom "FandomP" as part of a series "Mixed Access"
+      And I post the work "Restricted Work" with fandom "FandomR" as part of a series "Mixed Access"
+      And I lock the work "Restricted Work"
+      And I bookmark the series "Mixed Access"
+    When I go to the first bookmark for the series "Mixed Access"
+    Then I should see "FandomP"
+      And I should see "FandomR"
+    When I am logged out
+      And I go to the first bookmark for the series "Mixed Access"
+    Then I should see "FandomP"
+      But I should not see "FandomR"

--- a/features/support/paths.rb
+++ b/features/support/paths.rb
@@ -196,6 +196,9 @@ module NavigationHelpers
     when /^the first bookmark for the work "(.*?)"$/i
       work = Work.find_by(title: Regexp.last_match(1))
       bookmark_path(work.bookmarks.first)
+    when /^the first bookmark for the series "(.*?)"$/i
+      series = Series.find_by(title: Regexp.last_match(1))
+      bookmark_path(series.bookmarks.first)
     when /^the new bookmark page for work "(.*?)"$/i
       new_work_bookmark_path(Work.find_by(title: Regexp.last_match(1)))
     when /^the tag comments? page for "(.*)"$/i


### PR DESCRIPTION
# Pull Request Checklist

## Issue

https://otwarchive.atlassian.net/browse/AO3-6303

## Purpose

Updates series' blurbs (e.g. when viewing a bookmark) to hide tags that are only on restricted works when the blurb is viewed as a guest.

## References

This doesn't _have_ to be merged at the same time as https://github.com/otwcode/otwarchive/pull/5179, although there is potential for confusion if not (either bookmarks are returned in search where the blurb doesn't have a tag, or bookmarks with a tag in their blurb aren't returned in search)