### PR TITLE
AO3-6975 Fix days_to_purge_unactivated admin setting and DAYS_TO_CONFIRM_EMAIL_CHANGE

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -109,7 +109,7 @@ class UsersController < ApplicationController
     @user = User.find_by(confirmation_token: params[:id])
 
     unless @user
-      flash[:error] = ts("Your activation key is invalid. If you didn't activate within 14 days, your account was deleted. Please sign up again, or contact support via the link in our footer for more help.").html_safe
+      flash[:error] = ts("Your activation key is invalid. If you didn't activate within #{AdminSetting.current.days_to_purge_unactivated} days, your account was deleted. Please sign up again, or contact support via the link in our footer for more help.").html_safe
       redirect_to root_path
 
       return

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -109,7 +109,7 @@ class UsersController < ApplicationController
     @user = User.find_by(confirmation_token: params[:id])
 
     unless @user
-      flash[:error] = ts("Your activation key is invalid. If you didn't activate within #{AdminSetting.current.days_to_purge_unactivated} days, your account was deleted. Please sign up again, or contact support via the link in our footer for more help.").html_safe
+      flash[:error] = ts("Your activation key is invalid. If you didn't activate within #{AdminSetting.current.days_to_purge_unactivated * 7} days, your account was deleted. Please sign up again, or contact support via the link in our footer for more help.").html_safe
       redirect_to root_path
 
       return

--- a/app/models/admin_setting.rb
+++ b/app/models/admin_setting.rb
@@ -18,7 +18,7 @@ class AdminSetting < ApplicationRecord
     invite_from_queue_number: ArchiveConfig.INVITE_FROM_QUEUE_NUMBER,
     invite_from_queue_frequency: ArchiveConfig.INVITE_FROM_QUEUE_FREQUENCY,
     account_creation_enabled?: ArchiveConfig.ACCOUNT_CREATION_ENABLED,
-    days_to_purge_unactivated: 14,
+    days_to_purge_unactivated: 2,
     suspend_filter_counts?: false,
     enable_test_caching?: false,
     cache_expiration: 10,
@@ -38,7 +38,7 @@ class AdminSetting < ApplicationRecord
       invite_from_queue_number: ArchiveConfig.INVITE_FROM_QUEUE_NUMBER,
       invite_from_queue_frequency: ArchiveConfig.INVITE_FROM_QUEUE_FREQUENCY,
       account_creation_enabled: ArchiveConfig.ACCOUNT_CREATION_ENABLED,
-      days_to_purge_unactivated: 14
+      days_to_purge_unactivated: 2
     )
     settings.save(validate: false)
     settings

--- a/app/models/admin_setting.rb
+++ b/app/models/admin_setting.rb
@@ -18,7 +18,7 @@ class AdminSetting < ApplicationRecord
     invite_from_queue_number: ArchiveConfig.INVITE_FROM_QUEUE_NUMBER,
     invite_from_queue_frequency: ArchiveConfig.INVITE_FROM_QUEUE_FREQUENCY,
     account_creation_enabled?: ArchiveConfig.ACCOUNT_CREATION_ENABLED,
-    days_to_purge_unactivated: ArchiveConfig.DAYS_TO_PURGE_UNACTIVATED,
+    days_to_purge_unactivated: 2.weeks,
     suspend_filter_counts?: false,
     enable_test_caching?: false,
     cache_expiration: 10,
@@ -38,7 +38,7 @@ class AdminSetting < ApplicationRecord
       invite_from_queue_number: ArchiveConfig.INVITE_FROM_QUEUE_NUMBER,
       invite_from_queue_frequency: ArchiveConfig.INVITE_FROM_QUEUE_FREQUENCY,
       account_creation_enabled: ArchiveConfig.ACCOUNT_CREATION_ENABLED,
-      days_to_purge_unactivated: ArchiveConfig.DAYS_TO_PURGE_UNACTIVATED
+      days_to_purge_unactivated: 2.weeks
     )
     settings.save(validate: false)
     settings

--- a/app/models/admin_setting.rb
+++ b/app/models/admin_setting.rb
@@ -18,7 +18,7 @@ class AdminSetting < ApplicationRecord
     invite_from_queue_number: ArchiveConfig.INVITE_FROM_QUEUE_NUMBER,
     invite_from_queue_frequency: ArchiveConfig.INVITE_FROM_QUEUE_FREQUENCY,
     account_creation_enabled?: ArchiveConfig.ACCOUNT_CREATION_ENABLED,
-    days_to_purge_unactivated: 2.weeks,
+    days_to_purge_unactivated: 14,
     suspend_filter_counts?: false,
     enable_test_caching?: false,
     cache_expiration: 10,
@@ -38,7 +38,7 @@ class AdminSetting < ApplicationRecord
       invite_from_queue_number: ArchiveConfig.INVITE_FROM_QUEUE_NUMBER,
       invite_from_queue_frequency: ArchiveConfig.INVITE_FROM_QUEUE_FREQUENCY,
       account_creation_enabled: ArchiveConfig.ACCOUNT_CREATION_ENABLED,
-      days_to_purge_unactivated: 2.weeks
+      days_to_purge_unactivated: 14
     )
     settings.save(validate: false)
     settings

--- a/app/views/users/confirmation.html.erb
+++ b/app/views/users/confirmation.html.erb
@@ -10,8 +10,9 @@
     <%= t(".no_email_html", contact_support_link: link_to(t(".contact_support"), new_feedback_report_path)) %>
   </p>
   <p>
+    <%# We do days_to_purge_unactivated * 7 because it's actually weeks %>
     <strong><%= t(".important")%></strong>
-    <%= t(".must_activate", count: AdminSetting.current.days_to_purge_unactivated) %>
+    <%= t(".must_activate", count: AdminSetting.current.days_to_purge_unactivated * 7) %>
   </p>
   <p>
     <%= link_to t(".go_back"), root_path %>

--- a/app/views/users/confirmation.html.erb
+++ b/app/views/users/confirmation.html.erb
@@ -10,9 +10,8 @@
     <%= t(".no_email_html", contact_support_link: link_to(t(".contact_support"), new_feedback_report_path)) %>
   </p>
   <p>
-    <%# We do days_to_purge_unactivated * 7 because it's actually weeks %>
     <strong><%= t(".important")%></strong>
-    <%= t(".must_activate", count: AdminSetting.current.days_to_purge_unactivated? ? (AdminSetting.current.days_to_purge_unactivated * 7) : ArchiveConfig.DAYS_TO_PURGE_UNACTIVATED) %>
+    <%= t(".must_activate", count: AdminSetting.current.days_to_purge_unactivated) %>
   </p>
   <p>
     <%= link_to t(".go_back"), root_path %>

--- a/config/config.yml
+++ b/config/config.yml
@@ -86,7 +86,7 @@ INVITE_FROM_QUEUE_FREQUENCY: 12
 HOURS_BEFORE_RESEND_INVITATION: 24
 # this is whether or not people without invitations can create accounts
 ACCOUNT_CREATION_ENABLED: false
-DAYS_TO_PURGE_UNACTIVATED: 7
+DAYS_TO_CONFIRM_EMAIL_CHANGE: 7
 # number of invites users can request
 MAX_USER_INVITE_REQUEST: 10
 # number of accounts users can block

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -118,7 +118,7 @@ Devise.setup do |config|
   # their account can't be confirmed with the token any more.
   # Default is nil, meaning there is no restriction on how long a user can take
   # before confirming their account.
-  config.confirm_within = ArchiveConfig.DAYS_TO_PURGE_UNACTIVATED.days
+  config.confirm_within = ArchiveConfig.DAYS_TO_CONFIRM_EMAIL_CHANGE.days
 
   # If true, requires any email changes to be confirmed (exactly the same way as
   # initial account confirmation) to be applied. Requires additional unconfirmed_email

--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -378,7 +378,7 @@ en:
           account_creation_enabled: Account creation enabled
           cache_expiration: How often (in minutes) should we refresh caching
           creation_requires_invite: Account creation requires invitation
-          days_to_purge_unactivated: How many days you have to activate your account before we purge it
+          days_to_purge_unactivated: How many weeks you have to activate your account before we purge it
           disable_support_form: Turn off support form
           disabled_support_form_text: Disabled support form text
           downloads_enabled: Allow downloads

--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -378,7 +378,7 @@ en:
           account_creation_enabled: Account creation enabled
           cache_expiration: How often (in minutes) should we refresh caching
           creation_requires_invite: Account creation requires invitation
-          days_to_purge_unactivated: How many weeks you have to activate your account before we purge it
+          days_to_purge_unactivated: How many days you have to activate your account before we purge it
           disable_support_form: Turn off support form
           disabled_support_form_text: Disabled support form text
           downloads_enabled: Allow downloads

--- a/features/step_definitions/invite_steps.rb
+++ b/features/step_definitions/invite_steps.rb
@@ -171,7 +171,7 @@ end
 ### Then
 
 Then /^I should see how long I have to activate my account$/ do
-  days_to_activate = AdminSetting.first.days_to_purge_unactivated? ? (AdminSetting.first.days_to_purge_unactivated * 7) : ArchiveConfig.DAYS_TO_PURGE_UNACTIVATED
+  days_to_activate = AdminSetting.first.days_to_purge_unactivated
   step %{I should see "You must activate your account within #{days_to_activate} days"}
 end
 

--- a/features/step_definitions/invite_steps.rb
+++ b/features/step_definitions/invite_steps.rb
@@ -171,7 +171,7 @@ end
 ### Then
 
 Then /^I should see how long I have to activate my account$/ do
-  days_to_activate = AdminSetting.first.days_to_purge_unactivated
+  days_to_activate = AdminSetting.first.days_to_purge_unactivated * 7
   step %{I should see "You must activate your account within #{days_to_activate} days"}
 end
 

--- a/lib/tasks/admin_tasks.rake
+++ b/lib/tasks/admin_tasks.rake
@@ -16,7 +16,7 @@ namespace :admin do
 
   desc "Purge unvalidated accounts created more than 2 weeks ago"
   task(:purge_unvalidated_users => :environment) do
-    users = User.where("confirmed_at IS NULL AND created_at < ?", AdminSetting.current.days_to_purge_unactivated.days.ago)
+    users = User.where("confirmed_at IS NULL AND created_at < ?", AdminSetting.current.days_to_purge_unactivated.weeks.ago)
     puts users.map(&:login).join(", ")
     users.map(&:destroy)
     puts "Unvalidated accounts created more than two weeks ago have been purged"

--- a/lib/tasks/admin_tasks.rake
+++ b/lib/tasks/admin_tasks.rake
@@ -16,7 +16,7 @@ namespace :admin do
 
   desc "Purge unvalidated accounts created more than 2 weeks ago"
   task(:purge_unvalidated_users => :environment) do
-    users = User.where("confirmed_at IS NULL AND created_at < ?", 2.weeks.ago)
+    users = User.where("confirmed_at IS NULL AND created_at < ?", AdminSetting.current.days_to_purge_unactivated.ago)
     puts users.map(&:login).join(", ")
     users.map(&:destroy)
     puts "Unvalidated accounts created more than two weeks ago have been purged"

--- a/lib/tasks/admin_tasks.rake
+++ b/lib/tasks/admin_tasks.rake
@@ -16,7 +16,7 @@ namespace :admin do
 
   desc "Purge unvalidated accounts created more than 2 weeks ago"
   task(:purge_unvalidated_users => :environment) do
-    users = User.where("confirmed_at IS NULL AND created_at < ?", AdminSetting.current.days_to_purge_unactivated.ago)
+    users = User.where("confirmed_at IS NULL AND created_at < ?", AdminSetting.current.days_to_purge_unactivated.days.ago)
     puts users.map(&:login).join(", ")
     users.map(&:destroy)
     puts "Unvalidated accounts created more than two weeks ago have been purged"


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [ ] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [x] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [x] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-6975

## Purpose

This PR updates the `purge_unvalidated_users` rake task to use the admin setting `days_to_purge_unactivated`. It also adds a `DAYS_TO_CONFIRM_EMAIL_CHANGE` to config.yml and updates all the spots that `ArchiveConfig.DAYS_TO_PURGE_UNACTIVATED` was used.

## Credit
Connie Feng, she/her
([JIRA account](https://otwarchive.atlassian.net/jira/people/712020:17930fa1-d647-47bd-b334-8a84cbacfca7))
