### PR TITLE
AO3-6993 Show message instead of edit works form when user has no works

### DIFF
--- a/app/views/works/show_multiple.html.erb
+++ b/app/views/works/show_multiple.html.erb
@@ -38,10 +38,10 @@
               <ul class="index concise">
                 <% @works_by_fandom[fandom].each do |work| %>
                   <li>
-                    <label class="action" title="select <%= work.title + (work.posted? ? "" : ts(" (Draft)"))%>">
+                    <label class="action" title="select <%= work.title + (work.posted? ? "" : t(".draft")) %>">
                       <%= check_box_tag "work_ids[]", work.id, false, id: "work_ids_#{work.id}" %>
                     </label>
-                  <%= link_to work.title + (work.posted? ? "" : ts(" (Draft)")), work_path(id: work.id) %>
+                  <%= link_to work.title + (work.posted? ? "" : t(".draft")), work_path(id: work.id) %>
   		            </li>
                 <% end %>
               </ul>

--- a/app/views/works/show_multiple.html.erb
+++ b/app/views/works/show_multiple.html.erb
@@ -8,7 +8,7 @@
 
 <!--main content-->
 <% if @works.empty? %>
-  <p>
+  <p class="note">
     <%= t(".no_works") %>
   </p>
 <% else %>
@@ -38,10 +38,11 @@
               <ul class="index concise">
                 <% @works_by_fandom[fandom].each do |work| %>
                   <li>
-                    <label class="action" title="select <%= work.title + (work.posted? ? "" : t(".draft")) %>">
+                    <% work_title_with_status = work.title + (work.posted? ? "" : t(".draft")) %>
+                    <label class="action" title="select <%= work_title_with_status %>">
                       <%= check_box_tag "work_ids[]", work.id, false, id: "work_ids_#{work.id}" %>
                     </label>
-                  <%= link_to work.title + (work.posted? ? "" : t(".draft")), work_path(id: work.id) %>
+                  <%= link_to work_title_with_status, work_path(id: work.id) %>
                   </li>
                 <% end %>
               </ul>

--- a/app/views/works/show_multiple.html.erb
+++ b/app/views/works/show_multiple.html.erb
@@ -42,7 +42,7 @@
                       <%= check_box_tag "work_ids[]", work.id, false, id: "work_ids_#{work.id}" %>
                     </label>
                   <%= link_to work.title + (work.posted? ? "" : t(".draft")), work_path(id: work.id) %>
-  		            </li>
+                  </li>
                 <% end %>
               </ul>
             </fieldset>

--- a/app/views/works/show_multiple.html.erb
+++ b/app/views/works/show_multiple.html.erb
@@ -7,53 +7,59 @@
 <!--subnav-->
 
 <!--main content-->
-<%= form_tag edit_multiple_user_works_path(@user),  :id => 'edit-multiple-works' do %>
-
-  <fieldset>
-    <%= check_all_none %>
+<% if @works.empty? %>
+  <p>
+    <%= t(".no_works") %>
+  </p>
+<% else %>
+  <%= form_tag edit_multiple_user_works_path(@user),  :id => 'edit-multiple-works' do %>
 
     <fieldset>
-      <legend>Actions</legend>
-      <p class="submit">
-        <input type="submit" value="Edit" name="commit">
-        <input type="submit" value="Orphan" name="commit">
-        <input type="submit" value="Delete" name="commit">
-      </p>
+      <%= check_all_none %>
+
+      <fieldset>
+        <legend>Actions</legend>
+        <p class="submit">
+          <input type="submit" value="Edit" name="commit">
+          <input type="submit" value="Orphan" name="commit">
+          <input type="submit" value="Delete" name="commit">
+        </p>
+      </fieldset>
+
+      <ul class="index">
+        <% @works_by_fandom.keys.sort.each do |fandom| %>
+          <li>
+            <fieldset class="fandom listbox">
+              <legend>Select <%= fandom %> works</legend>
+              <h5 class="heading">
+                <%= fandom %>
+                <%= check_all_none %>
+              </h5>
+              <ul class="index concise">
+                <% @works_by_fandom[fandom].each do |work| %>
+                  <li>
+                    <label class="action" title="select <%= work.title + (work.posted? ? "" : ts(' (Draft)'))%>"><%= check_box_tag "work_ids[]", work.id, false, id: "work_ids_#{work.id}" %></label>
+                  <%= link_to work.title + (work.posted? ? "" : ts(' (Draft)')), work_path(:id => work.id) %>
+  		</li>
+                <% end %>
+              </ul>
+            </fieldset>
+          </li>
+        <% end %>
+      </ul>
+
+      <fieldset>
+        <legend>Actions</legend>
+        <p class="submit">
+          <input type="submit" value="Edit" name="commit">
+          <input type="submit" value="Orphan" name="commit">
+          <input type="submit" value="Delete" name="commit">
+        </p>
+      </fieldset>
+
     </fieldset>
 
-    <ul class="index">
-      <% @works_by_fandom.keys.sort.each do |fandom| %>
-        <li>
-          <fieldset class="fandom listbox">
-            <legend>Select <%= fandom %> works</legend>
-            <h5 class="heading">
-              <%= fandom %>
-              <%= check_all_none %>
-            </h5>
-            <ul class="index concise">
-              <% @works_by_fandom[fandom].each do |work| %>
-                <li>
-                  <label class="action" title="select <%= work.title + (work.posted? ? "" : ts(' (Draft)'))%>"><%= check_box_tag "work_ids[]", work.id, false, id: "work_ids_#{work.id}" %></label>
-                <%= link_to work.title + (work.posted? ? "" : ts(' (Draft)')), work_path(:id => work.id) %>
-		</li>
-              <% end %>
-            </ul>
-          </fieldset>
-        </li>
-      <% end %>
-    </ul>
-  
-    <fieldset>
-      <legend>Actions</legend>
-      <p class="submit">
-        <input type="submit" value="Edit" name="commit">
-        <input type="submit" value="Orphan" name="commit">
-        <input type="submit" value="Delete" name="commit">
-      </p>
-    </fieldset>
-
-  </fieldset>
-
+  <% end %>
 <% end %>
 <!--/content-->
 

--- a/app/views/works/show_multiple.html.erb
+++ b/app/views/works/show_multiple.html.erb
@@ -12,7 +12,7 @@
     <%= t(".no_works") %>
   </p>
 <% else %>
-  <%= form_tag edit_multiple_user_works_path(@user),  :id => 'edit-multiple-works' do %>
+  <%= form_tag edit_multiple_user_works_path(@user), id: "edit-multiple-works" do %>
 
     <fieldset>
       <%= check_all_none %>
@@ -20,9 +20,9 @@
       <fieldset>
         <legend>Actions</legend>
         <p class="submit">
-          <input type="submit" value="Edit" name="commit">
-          <input type="submit" value="Orphan" name="commit">
-          <input type="submit" value="Delete" name="commit">
+          <input type="submit" value="Edit" name="commit" />
+          <input type="submit" value="Orphan" name="commit" />
+          <input type="submit" value="Delete" name="commit" />
         </p>
       </fieldset>
 
@@ -38,9 +38,11 @@
               <ul class="index concise">
                 <% @works_by_fandom[fandom].each do |work| %>
                   <li>
-                    <label class="action" title="select <%= work.title + (work.posted? ? "" : ts(' (Draft)'))%>"><%= check_box_tag "work_ids[]", work.id, false, id: "work_ids_#{work.id}" %></label>
-                  <%= link_to work.title + (work.posted? ? "" : ts(' (Draft)')), work_path(:id => work.id) %>
-  		</li>
+                    <label class="action" title="select <%= work.title + (work.posted? ? "" : ts(" (Draft)"))%>">
+                      <%= check_box_tag "work_ids[]", work.id, false, id: "work_ids_#{work.id}" %>
+                    </label>
+                  <%= link_to work.title + (work.posted? ? "" : ts(" (Draft)")), work_path(id: work.id) %>
+  		            </li>
                 <% end %>
               </ul>
             </fieldset>
@@ -51,9 +53,9 @@
       <fieldset>
         <legend>Actions</legend>
         <p class="submit">
-          <input type="submit" value="Edit" name="commit">
-          <input type="submit" value="Orphan" name="commit">
-          <input type="submit" value="Delete" name="commit">
+          <input type="submit" value="Edit" name="commit" />
+          <input type="submit" value="Orphan" name="commit" />
+          <input type="submit" value="Delete" name="commit" />
         </p>
       </fieldset>
 
@@ -62,4 +64,3 @@
   <% end %>
 <% end %>
 <!--/content-->
-

--- a/config/locales/controllers/en.yml
+++ b/config/locales/controllers/en.yml
@@ -240,6 +240,8 @@ en:
   works:
     drafts:
       page_title: "%{username} - Drafts"
+    show_multiple:
+      no_works: You have no works or drafts to edit.
   wrangling_guidelines:
     create: Wrangling Guideline was successfully created.
     delete: Wrangling Guideline was successfully deleted.

--- a/config/locales/controllers/en.yml
+++ b/config/locales/controllers/en.yml
@@ -241,6 +241,7 @@ en:
     drafts:
       page_title: "%{username} - Drafts"
     show_multiple:
+      draft: " (Draft)"
       no_works: You have no works or drafts to edit.
   wrangling_guidelines:
     create: Wrangling Guideline was successfully created.

--- a/config/locales/controllers/en.yml
+++ b/config/locales/controllers/en.yml
@@ -240,9 +240,6 @@ en:
   works:
     drafts:
       page_title: "%{username} - Drafts"
-    show_multiple:
-      draft: " (Draft)"
-      no_works: You have no works or drafts to edit.
   wrangling_guidelines:
     create: Wrangling Guideline was successfully created.
     delete: Wrangling Guideline was successfully deleted.

--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -2398,6 +2398,9 @@ en:
       tooltip_label: 'tip:'
     show:
       unposted_deletion_notice_html: This work is a draft and has not been posted. The draft will be <strong>scheduled for deletion</strong> on %{deletion_date}.
+    show_multiple:
+      draft: " (Draft)"
+      no_works: You have no works or drafts to edit.
     skin:
       select: Select work skin
     standard_form:


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [ ] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [x] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [x] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-6993

## Purpose

This PR changes the code to not show the "edit multiple works" form if the user does not have any works.

Before change:
![Screenshot 2025-05-11 at 2 48 35 PM](https://github.com/user-attachments/assets/fd774022-e222-4913-9c33-328065ec1db9)


After change:
![Screenshot 2025-05-11 at 2 48 11 PM](https://github.com/user-attachments/assets/ee68e89c-5aee-42ee-a55c-e6bcab12be62)




## Credit

Connie Feng, she/her
([JIRA account](https://otwarchive.atlassian.net/jira/people/712020:17930fa1-d647-47bd-b334-8a84cbacfca7))
