### PR TITLE
AO3-6967 add save button to top of tag edit page

### DIFF
--- a/app/views/tags/edit.html.erb
+++ b/app/views/tags/edit.html.erb
@@ -17,9 +17,9 @@
 
 <%= form_for @tag, as: :tag, url: { action: "update", id: @tag}, html: { method: :put } do |f| %>
 <fieldset>
-    <legend><%= ts("Submit") %></legend>
+    <legend><%= t(".submit_legend") %></legend>
     <p class="submit actions">
-      <%= submit_tag ts("Save changes") %>
+      <%= submit_tag t(".save_changes") %>
     </p>
   </fieldset>
   <fieldset>
@@ -223,9 +223,9 @@
   <% end %>
 
   <fieldset>
-    <legend><%= ts("Submit") %></legend>
+    <legend><%= t(".submit_legend") %></legend>
     <p class="submit actions">
-      <%= submit_tag ts("Save changes") %>
+      <%= submit_tag t(".save_changes") %>
     </p>
   </fieldset>
 <% end %>

--- a/app/views/tags/edit.html.erb
+++ b/app/views/tags/edit.html.erb
@@ -16,7 +16,12 @@
 <% end %>
 
 <%= form_for @tag, as: :tag, url: { action: "update", id: @tag}, html: { method: :put } do |f| %>
-
+<fieldset>
+    <legend><%= ts("Submit") %></legend>
+    <p class="submit actions">
+      <%= submit_tag ts("Save changes") %>
+    </p>
+  </fieldset>
   <fieldset>
     <legend><%= ts("Tag Info") %></legend>
     <h3 class="landmark heading"><%= ts("Tag Info") %></h3>

--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -2048,6 +2048,9 @@ en:
       wrangling_home: Wrangling Home
       wrangling_tools: Wrangling Tools
   tags:
+    edit:
+      save_changes: Save changes
+      submit_legend: Submit
     index:
       about:
         popular: These are some of the most popular tags used on the Archive. To find more tags, %{search_tags_link}.


### PR DESCRIPTION
# Pull Request Checklist

<!-- Mark steps in the checklist as complete by changing `[ ]` to `[X]` -->
* [X] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [X] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [X] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [X] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [X] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-6967

## Purpose

Adding a save button to the top of the tag edit page for tag wranglers.

## Testing Instructions

Check Jira issue

## Credit

Grayson von Goetz (they/them)
