### PR TITLE
AO3-6987 AO3-6991 Guest comment image safety with alt text

### DIFF
--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -537,7 +537,8 @@ class Comment < ApplicationRecord
   end
 
   def use_image_safety_mode?
-    parent_type.in?(ArchiveConfig.PARENTS_WITH_IMAGE_SAFETY_MODE) || hidden_by_admin
+    pseud_id.nil? || hidden_by_admin || parent_type.in?(ArchiveConfig.PARENTS_WITH_IMAGE_SAFETY_MODE)
   end
+
   include Responder
 end

--- a/app/views/comments/_single_comment.html.erb
+++ b/app/views/comments/_single_comment.html.erb
@@ -56,7 +56,7 @@
           <p class="notice"><%= ts("This comment has been hidden by an admin.") %></p>
         <% end %>
         <blockquote class="userstuff">
-          <%= raw sanitize_field(single_comment, :comment_content, image_safety_mode: single_comment.use_image_safety_mode?) %>
+          <%= raw single_comment.sanitized_content %>
         </blockquote>
       <% end %>
       <% if single_comment.edited_at.present? %>

--- a/app/views/inbox/_inbox_comment_contents.html.erb
+++ b/app/views/inbox/_inbox_comment_contents.html.erb
@@ -27,5 +27,5 @@
 </div>
 
 <blockquote class="userstuff">
-  <%= raw sanitize_field(feedback_comment, :comment_content, image_safety_mode: feedback_comment.use_image_safety_mode?) %>
+  <%= raw feedback_comment.sanitized_content %>
 </blockquote>

--- a/lib/html_cleaner.rb
+++ b/lib/html_cleaner.rb
@@ -141,13 +141,9 @@ module HtmlCleaner
   # These assume they are running on well-formed XHTML, which we can do
   # because they will only be used on already-cleaned fields.
 
-  # strip img tags, optionally leaving the src URL exposed
+  # strip img tags, optionally leaving the HTML attributes (e.g. src and alt) exposed
   def strip_images(value, keep_src: false)
-    value.gsub(/(<img .*?>)/) do |img_tag|
-      match_data = img_tag.match(/src="([^"]+)"/) if keep_src
-      src = match_data[1] if match_data
-      src || ""
-    end
+    value.gsub(%r{(?:<(img .*?) ?/?>)}, keep_src ? "\\1" : "")
   end
 
   def strip_html_breaks_simple(value)

--- a/spec/lib/html_cleaner_spec.rb
+++ b/spec/lib/html_cleaner_spec.rb
@@ -1,6 +1,5 @@
-# -*- coding: utf-8 -*-
-require 'spec_helper'
-require 'nokogiri'
+require "spec_helper"
+require "nokogiri"
 
 describe HtmlCleaner do
   include HtmlCleaner
@@ -1147,56 +1146,22 @@ describe HtmlCleaner do
     end
 
     context "with keep_src: false" do
-      it "removes the img tag entirely when the src uses double quotes" do
-        string = 'Hi! <img src="http://example.org/image.png" /> Bye'
-        expect(strip_images(string, keep_src: false)).to eq(result)
-      end
-
-      it "removes the img tag entirely when the src uses single quotes" do
-        string = "Hi! <img src='http://example.org/image.png'> Bye"
-        expect(strip_images(string, keep_src: false)).to eq(result)
-      end
-
-      it "removes the img tag entirely when the src uses mismatched quotes" do
-        string = "Hi! <img src=\"http://example.org/image.png'> Bye"
-        expect(strip_images(string, keep_src: false)).to eq(result)
-      end
-
-      it "removes the img tag entirely when the src is missing" do
-        string = 'Hi! <img alt="a11y"> Bye'
-        expect(strip_images(string, keep_src: false)).to eq(result)
-      end
-
-      it "removes the img tag entirely when the src is missing a closing quotation mark" do
-        string = 'Hi! <img src="http://example.org/image.png /> Bye'
+      it "removes the img tag entirely" do
+        string = 'Hi! <img src="http://example.org/image.png" alt=\'something\' /> Bye'
         expect(strip_images(string, keep_src: false)).to eq(result)
       end
     end
 
     context "with keep_src: true" do
-      it "keeps the img src URL when the src uses double quotes" do
-        string = 'Hi! <img src="http://example.org/image.png" /> Bye'
-        result = "Hi! http://example.org/image.png Bye"
+      it "keeps the img tag attributes" do
+        string = 'Hi! <img src="http://example.org/image.png" alt=\'something\'> Bye'
+        result = 'Hi! img src="http://example.org/image.png" alt=\'something\' Bye'
         expect(strip_images(string, keep_src: true)).to eq(result)
       end
 
-      it "removes the img tag entirely when the src uses single quotes" do
-        string = "Hi! <img src='http://example.org/image.png'> Bye"
-        expect(strip_images(string, keep_src: true)).to eq(result)
-      end
-
-      it "removes the img tag entirely when the src uses mismatched quotes" do
-        string = "Hi! <img src=\"http://example.org/image.png'> Bye"
-        expect(strip_images(string, keep_src: true)).to eq(result)
-      end
-
-      it "removes the img tag entirely when the src is missing" do
-        string = 'Hi! <img alt="a11y"> Bye'
-        expect(strip_images(string, keep_src: true)).to eq(result)
-      end
-
-      it "removes the img tag entirely when the src is missing a closing quotation mark" do
-        string = 'Hi! <img src="http://example.org/image.png /> Bye'
+      it "does not keep tag trailing slash" do
+        string = 'Hi! <img src="http://example.org/image.png" alt=\'something\' /> Bye'
+        result = 'Hi! img src="http://example.org/image.png" alt=\'something\' Bye'
         expect(strip_images(string, keep_src: true)).to eq(result)
       end
     end

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -664,5 +664,13 @@ describe Comment do
         expect(chapter_reply.use_image_safety_mode?).to be_falsey
       end
     end
+
+    context "when the comment is from a guest" do
+      let(:comment) { create(:comment, :by_guest) }
+
+      it "returns true" do
+        expect(comment.use_image_safety_mode?).to be_truthy
+      end
+    end
   end
 end


### PR DESCRIPTION
# Pull Request Checklist

## Issue

https://otwarchive.atlassian.net/browse/AO3-6987
https://otwarchive.atlassian.net/browse/AO3-6991

## Purpose

1. Update the image stripping function to include `img` tag attributes (e.g. src and alt)
2. Set guest comments to always use image safety mode