### PR TITLE
AO3-3818 Increase user_agent limit for comments and feedback

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -337,7 +337,7 @@ class CommentsController < ApplicationController
     else
       @comment = Comment.new(comment_params)
       @comment.ip_address = request.remote_ip
-      @comment.user_agent = request.env["HTTP_USER_AGENT"]
+      @comment.user_agent = request.env["HTTP_USER_AGENT"]&.to(499)
       @comment.commentable = Comment.commentable_object(@commentable)
       @controller_name = params[:controller_name]
 

--- a/app/controllers/feedbacks_controller.rb
+++ b/app/controllers/feedbacks_controller.rb
@@ -18,7 +18,7 @@ class FeedbacksController < ApplicationController
     @admin_setting = AdminSetting.current
     @feedback = Feedback.new(feedback_params)
     @feedback.rollout = @feedback.rollout_string
-    @feedback.user_agent = request.env["HTTP_USER_AGENT"]
+    @feedback.user_agent = request.env["HTTP_USER_AGENT"]&.to(499)
     @feedback.ip_address = request.remote_ip
     @feedback.referer = nil unless @feedback.referer && ArchiveConfig.PERMITTED_HOSTS.include?(URI(@feedback.referer).host)
     @feedback.site_skin = helpers.current_skin

--- a/db/migrate/20250515095633_change_user_agent_limit.rb
+++ b/db/migrate/20250515095633_change_user_agent_limit.rb
@@ -1,0 +1,12 @@
+class ChangeUserAgentLimit < ActiveRecord::Migration[7.1]
+  uses_departure! if Rails.env.staging? || Rails.env.production?
+
+  def up
+    change_column :feedbacks, :user_agent, :string, limit: 500
+    change_column :comments, :user_agent, :string, limit: 500
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration, "This migration cannot be reverted because it would result in a shorter character limit"
+  end
+end

--- a/spec/controllers/comments/default_rails_actions_spec.rb
+++ b/spec/controllers/comments/default_rails_actions_spec.rb
@@ -633,7 +633,7 @@ describe CommentsController do
           fake_login_known_user(user)
           post :create, params: { work_id: work.id, comment: comment_attributes }
           comment = assigns[:comment]
-          it_redirects_to_with_comment_notice(chapter_path(work, show_comments: true, view_full_work: false, anchor: "comment_#{comment.id}"), "Comment created!")
+          it_redirects_to_with_comment_notice(chapter_path(comment.commentable, show_comments: true, view_full_work: false, anchor: "comment_#{comment.id}"), "Comment created!")
           expect(comment.user_agent.length).to eq(500)
         end
       end
@@ -651,7 +651,7 @@ describe CommentsController do
           fake_login_known_user(user)
           post :create, params: { work_id: work.id, comment: comment_attributes }
           comment = assigns[:comment]
-          it_redirects_to_with_comment_notice(chapter_path(work, show_comments: true, view_full_work: false, anchor: "comment_#{comment.id}"), "Comment created!")
+          it_redirects_to_with_comment_notice(chapter_path(comment.commentable, show_comments: true, view_full_work: false, anchor: "comment_#{comment.id}"), "Comment created!")
           expect(comment.user_agent).to be_nil
         end
       end

--- a/spec/controllers/comments/default_rails_actions_spec.rb
+++ b/spec/controllers/comments/default_rails_actions_spec.rb
@@ -615,6 +615,47 @@ describe CommentsController do
         it_behaves_like "guest can reply to a user with guest replies disabled on user's work"
       end
     end
+
+    context "with unusual user agents" do
+      let(:work) { create(:work) }
+      let(:user) { create(:user) }
+
+      context "when the user agent is very long" do
+        before do
+          request.env["HTTP_USER_AGENT"] = "Mozilla/5.0 (X11; Linux x86_64; rv:138.0) Gecko/20100101 Firefox/138.0" * 10
+        end
+
+        it "creates the comment with a truncated user agent" do
+          comment_attributes = {
+            pseud_id: user.default_pseud_id,
+            comment_content: "I love this!"
+          }
+          fake_login_known_user(user)
+          post :create, params: { work_id: work.id, comment: comment_attributes }
+          comment = assigns[:comment]
+          it_redirects_to_with_comment_notice(chapter_path(work, show_comments: true, view_full_work: false, anchor: "comment_#{comment.id}"), "Comment created!")
+          expect(comment.user_agent.length).to eq(500)
+        end
+      end
+
+      context "when no user agent is set" do
+        before do
+          request.env["HTTP_USER_AGENT"] = nil
+        end
+
+        it "creates the comment with no user agent" do
+          comment_attributes = {
+            pseud_id: user.default_pseud_id,
+            comment_content: "I love this!"
+          }
+          fake_login_known_user(user)
+          post :create, params: { work_id: work.id, comment: comment_attributes }
+          comment = assigns[:comment]
+          it_redirects_to_with_comment_notice(chapter_path(work, show_comments: true, view_full_work: false, anchor: "comment_#{comment.id}"), "Comment created!")
+          expect(comment.user_agent).to be_nil
+        end
+      end
+    end
   end
 
   describe "DELETE #destroy" do


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-3818

## Purpose

Increases the limit of the user_agent column for comments and feedback to 500. This is based on me going through the errors related to this column on Sentry for the last 3 days. The longest user agent was 443 characters, most were just slightly below 300. I picked 500 to play it safe.

If the user agent is longer, it will be truncated because per [MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/User-Agent), the end of the string is for extensions so truncating those shouldn't impact Akismet too much, as all the important info is still there. The one long string just had a baffling amount of extensions, like current font scale so I really don't think it matters if that gets truncated.

## Credit

Bilka
