### PR TITLE
AO3-6995 Add recently_reset to ignored_columns

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,6 +5,8 @@ class User < ApplicationRecord
   include PasswordResetsLimitable
   include UserLoggable
 
+  self.ignored_columns = [:recently_reset]
+
   devise :database_authenticatable,
          :confirmable,
          :registerable,


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6995

## Purpose

Try to prevent errors when dropping the column by adding it to ignore_columns.

The migration should be run in the next deploy after the one that this PR is included in, and then it should be run shortly before that deploy.

## Testing Instructions

None.

## Credit

Bilka
