### PR TITLE
AO3-6948 Monitor InviteFromQueueJob with Sentry

### DIFF
--- a/app/jobs/invite_from_queue_job.rb
+++ b/app/jobs/invite_from_queue_job.rb
@@ -1,4 +1,10 @@
 class InviteFromQueueJob < ApplicationJob
+  if defined?(Sentry::Cron::MonitorCheckIns)
+    include Sentry::Cron::MonitorCheckIns
+
+    sentry_monitor_check_ins
+  end
+
   def perform(count:, creator: nil)
     InviteRequest.order(:id).limit(count).each do |request|
       request.invite_and_remove(creator)


### PR DESCRIPTION
# Pull Request Checklist

## Issue

https://otwarchive.atlassian.net/issues/AO3-6948

## Purpose

Report `InviteFromQueue` runs to Sentry. I deliberately didn't set the config required for upserts, since we want to be able to set the interval via the UI (because this runs based on the value set via the admin UI, not necessarily every hour)