### PR TITLE
Ao3 6971 tag page 500

### DIFF
--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -31,15 +31,19 @@ class TagsController < ApplicationController
       @tags = Freeform.canonical.for_collections_with_count([@collection] + @collection.children)
       @page_subtitle = t(".collection_page_title", collection_title: @collection.title)
     else
-      no_fandom = Fandom.find_by_name(ArchiveConfig.FANDOM_NO_TAG_NAME)
-      @tags = no_fandom.children.by_type('Freeform').first_class.limit(ArchiveConfig.TAGS_IN_CLOUD)
-      # have to put canonical at the end so that it doesn't overwrite sort order for random and popular
-      # and then sort again at the very end to make it alphabetic
-      @tags = if params[:show] == 'random'
-                @tags.random.canonical.sort
-              else
-                @tags.popular.canonical.sort
-              end
+      if no_fandom
+        no_fandom = Fandom.find_by_name(ArchiveConfig.FANDOM_NO_TAG_NAME)
+        @tags = no_fandom.children.by_type('Freeform').first_class.limit(ArchiveConfig.TAGS_IN_CLOUD)
+        # have to put canonical at the end so that it doesn't overwrite sort order for random and popular
+        # and then sort again at the very end to make it alphabetic
+        @tags = if params[:show] == 'random'
+                  @tags.random.canonical.sort
+                else
+                  @tags.popular.canonical.sort
+                end
+      else
+        @tags = []
+      end
     end
   end
 

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -31,8 +31,8 @@ class TagsController < ApplicationController
       @tags = Freeform.canonical.for_collections_with_count([@collection] + @collection.children)
       @page_subtitle = t(".collection_page_title", collection_title: @collection.title)
     else
+      no_fandom = Fandom.find_by_name(ArchiveConfig.FANDOM_NO_TAG_NAME)
       if no_fandom
-        no_fandom = Fandom.find_by_name(ArchiveConfig.FANDOM_NO_TAG_NAME)
         @tags = no_fandom.children.by_type('Freeform').first_class.limit(ArchiveConfig.TAGS_IN_CLOUD)
         # have to put canonical at the end so that it doesn't overwrite sort order for random and popular
         # and then sort again at the very end to make it alphabetic

--- a/spec/controllers/tags_controller_spec.rb
+++ b/spec/controllers/tags_controller_spec.rb
@@ -628,5 +628,25 @@ describe TagsController do
       get :index, params: { collection_id: collection.name }
       expect(assigns[:page_subtitle]).to eq("#{collection.title} - Tags")
     end
+
+    context "ArchiveConfig.FANDOM_NO_TAG_NAME doesn't exist" do
+      before do
+        allow(Fandom).to receive(:find_by_name).and_return(nil)
+      end
+
+      it "does not 500 error on /tags" do
+        get :index
+
+        expect(response).to have_http_status(:success)
+        expect(response).to render_template(:index)
+      end
+
+      it "does not 500 error on /tags?show=random" do
+        get :index, params: { show: :random }
+
+        expect(response).to have_http_status(:success)
+        expect(response).to render_template(:index)
+      end
+    end
   end
 end


### PR DESCRIPTION
# Pull Request Checklist

* [X] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [X] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [X] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [X] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [X] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-6971

## Purpose

Before this fix, attempting to access `/tags` or `/tags?show=random` when the tag `ArchiveConfig.FANDOM_NO_TAG_NAME` doesn't exist, there would be a 500 error. With this fix, the page loads but does not display any tags.

## Credit

Connie Feng, she/her
([JIRA account](https://otwarchive.atlassian.net/jira/people/712020:17930fa1-d647-47bd-b334-8a84cbacfca7))
