### PR TITLE
AO3-6807 Fix error 500 for invalid URLs in prompts and external works

### DIFF
--- a/app/models/external_work.rb
+++ b/app/models/external_work.rb
@@ -42,6 +42,8 @@ class ExternalWork < ApplicationRecord
   validates :url, presence: true, url_format: true, url_active: true
   def cleanup_url
     self.url = Addressable::URI.heuristic_parse(self.url) if self.url
+  rescue Addressable::URI::InvalidURIError
+    # url_format validation creates the error message
   end
 
   # Allow encoded characters to display correctly in titles

--- a/app/models/prompt.rb
+++ b/app/models/prompt.rb
@@ -65,6 +65,8 @@ class Prompt < ApplicationRecord
   before_validation :cleanup_url
   def cleanup_url
     self.url = Addressable::URI.heuristic_parse(self.url) if self.url
+  rescue Addressable::URI::InvalidURIError
+    # url_format validation creates the error message
   end
 
   validate :correct_number_of_tags

--- a/config/locales/models/en.yml
+++ b/config/locales/models/en.yml
@@ -16,6 +16,8 @@ en:
         support: Support
         tag_wrangling: Tag Wrangling
         translation: Translation
+      challenge_signup/requests:
+        url: Request URL
       chapters/creatorships:
         base: 'Invalid creator:'
         pseud_id: Pseud
@@ -35,6 +37,8 @@ en:
         meta_tag_id: Metatag
         sub_tag: Subtag
         sub_tag_id: Subtag
+      request:
+        url: URL
       role:
         archivist: Archivist
         no_resets: No Resets

--- a/features/gift_exchanges/challenge_giftexchange.feature
+++ b/features/gift_exchanges/challenge_giftexchange.feature
@@ -120,6 +120,18 @@ Feature: Gift Exchange Challenge
       And I submit
     Then I should see "URL: https://example.com/url_for_prompt"
 
+  Scenario: Invalid URL is disallowed when editing a signup
+    Given the gift exchange "Awesome Gift Exchange" is ready for signups
+      And I edit settings for "Awesome Gift Exchange" challenge
+      And I check "gift_exchange[request_restriction_attributes][url_allowed]"
+      And I submit
+    When I am logged in as "myname1"
+      And I sign up for "Awesome Gift Exchange" with combination A
+      And I follow "Edit Sign-up"
+      And I fill in "Prompt URL:" with "i am broken."
+      And I submit
+    Then I should see "Request URL does not appear to be a valid URL."
+
   Scenario: Sign-ups can be seen in the dashboard
     Given the gift exchange "Awesome Gift Exchange" is ready for signups
     When I am logged in as "myname1"

--- a/features/works/work_related.feature
+++ b/features/works/work_related.feature
@@ -389,6 +389,17 @@ Scenario: When a user is notified that a co-authored work has been inspired by a
     And the email should link to misterdeejay's user url
     And the email should not contain "&lt;a href=&quot;http://archiveofourown.org/users/misterdeejay/pseuds/misterdeejay&quot;"
 
+  Scenario: When using an invalid URL
+    Given I am logged in
+      And I set up a draft "Naughty"
+    When I check "parent-options-show"
+      And I fill in "URL" with "not valid."
+      And I fill in "Title" with "Breaking rules"
+      And I fill in "Author" with "human"
+      And I press "Post"
+    Then I should see a save error message
+      And I should see "Parent work URL does not appear to be a valid URL."
+
   Scenario: When using a URL on the site to cite a parent work, the URL can't be
   for something that isn't a work
   Given I am logged in


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6807

## Purpose

Fix that entering an invalid URL in the "inspired by" field when posting a work or in the prompt URL field when signing up to a challenge would result in an error 500.

I decided to fix the external work one as well because it has the most occurrences of `InvalidURIError` in Sentry: https://organization-for-transformativ.sentry.io/issues/6477975500 But I'd be happy to split this into a separate issue + PR instead. Collection header URLs and URLs in the external works controller likely have the same issue (all caused by #4600) but they don't really show up in Sentry so I didn't want to combine them into this as well.

## Testing Instructions

Inspired by instructions to be added to Jira based on the cucumber test if this is fine to combine.

## Credit

Bilka