### PR TITLE
AO3-6937 Fix inbox page title to show username

### DIFF
--- a/app/controllers/inbox_controller.rb
+++ b/app/controllers/inbox_controller.rb
@@ -14,6 +14,7 @@ class InboxController < ApplicationController
 
   def show
     authorize InboxComment if logged_in_as_admin?
+    @page_title = "#{@user.login} - Inbox | #{ArchiveConfig.APP_NAME}"
     @inbox_total = @user.inbox_comments.with_bad_comments_removed.count
     @unread = @user.inbox_comments.with_bad_comments_removed.count_unread
     @filters = filter_params[:filters] || {}

--- a/app/controllers/inbox_controller.rb
+++ b/app/controllers/inbox_controller.rb
@@ -14,7 +14,7 @@ class InboxController < ApplicationController
 
   def show
     authorize InboxComment if logged_in_as_admin?
-    @page_title = "#{@user.login} - Inbox | #{ArchiveConfig.APP_NAME}"
+    @page_subtitle = t("inbox.page_title", user: @user.login)
     @inbox_total = @user.inbox_comments.with_bad_comments_removed.count
     @unread = @user.inbox_comments.with_bad_comments_removed.count_unread
     @filters = filter_params[:filters] || {}

--- a/config/locales/controllers/en.yml
+++ b/config/locales/controllers/en.yml
@@ -131,6 +131,8 @@ en:
       page_title: Terms of Service
     tos_faq:
       page_title: Terms of Service FAQ
+  inbox:
+    page_title: "%{user} - Inbox"
   invite_requests:
     create:
       queue_disabled:

--- a/features/other_a/page_title.feature
+++ b/features/other_a/page_title.feature
@@ -64,7 +64,7 @@ Scenario: Inbox has the expected browser page title
 
   When I am logged in as "boxer"
     And I go to boxer's inbox page
-  Then I should see the page title "Show Inbox | Example Archive"
+  Then I should see the page title "boxer - Inbox | Example Archive"
 
 Scenario: New tag set page has the expected browser page title
 


### PR DESCRIPTION
# Pull Request Checklist

<!-- Mark steps in the checklist as complete by changing `[ ]` to `[X]` -->
* [X] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [X] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [X] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [X] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [X] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-6937

## Purpose

Fix the browser tab title on the user's inbox page to: `user - Inbox | Archive of Our Own`

## Testing Instructions

1. Visit a user’s inbox page
2. Confirm the page title in the browser tab displays as `user - Inbox | Archive of Our Own`
3. Confirm that other page titles are not affected

## Credit

kitbur