### PR TITLE
AO3-6996 Remove no longer needed ignored_columns from models

### DIFF
--- a/app/models/invite_request.rb
+++ b/app/models/invite_request.rb
@@ -1,6 +1,4 @@
 class InviteRequest < ApplicationRecord
-  self.ignored_columns = [:position]
-
   validates :email, presence: true, email_format: true
   validates :email, uniqueness: { message: "is already part of our queue." }
   before_validation :compare_with_users, on: :create

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,8 +5,6 @@ class User < ApplicationRecord
   include PasswordResetsLimitable
   include UserLoggable
 
-  self.ignored_columns = [:recently_reset]
-
   devise :database_authenticatable,
          :confirmable,
          :registerable,


### PR DESCRIPTION
# Pull Request Checklist

<!-- Mark steps in the checklist as complete by changing `[ ]` to `[X]` -->
* [X] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [X] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [X] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [X] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [X] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-6996

## Purpose

Removes unnecessary `ignored_columns` from `invite_request.rb` and `user.rb`.

## References

`ignored_columns` were from:
- [AO3-6995](https://otwarchive.atlassian.net/browse/AO3-6995)
- [AO3-5962](https://otwarchive.atlassian.net/browse/AO3-5962)

## Credit

kitbur


[AO3-6995]: https://otwarchive.atlassian.net/browse/AO3-6995?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ