### PR TITLE
AO3-5949 Remove cookie-based redirection to the last visited page

### DIFF
--- a/app/controllers/abuse_reports_controller.rb
+++ b/app/controllers/abuse_reports_controller.rb
@@ -1,5 +1,4 @@
 class AbuseReportsController < ApplicationController
-  skip_before_action :store_location
   before_action :load_abuse_languages
 
   def new

--- a/app/controllers/admin/passwords_controller.rb
+++ b/app/controllers/admin/passwords_controller.rb
@@ -2,6 +2,5 @@
 
 class Admin::PasswordsController < Devise::PasswordsController
   before_action :user_logout_required
-  skip_before_action :store_location
   layout "session"
 end

--- a/app/controllers/admin/sessions_controller.rb
+++ b/app/controllers/admin/sessions_controller.rb
@@ -3,7 +3,6 @@ class Admin
   # Handle admin session authentication
   class SessionsController < Devise::SessionsController
     before_action :user_logout_required, except: :destroy
-    skip_before_action :store_location, raise: false
 
     # GET /admin/logout
     def confirm_logout

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -239,15 +239,16 @@ public
     end
   end
 
-  def after_sign_in_path_for(resource)
-    if resource.is_a?(Admin)
-      admins_path
-    else
-      back = session[:return_to]
-      session.delete(:return_to)
+  def relative_uri(uri)
+    return uri if URI.parse(uri).relative? && uri.start_with?("/") && !uri.start_with?("//")
+  rescue URI::InvalidURIError
+    nil
+  end
 
-      back || user_path(current_user)
-    end
+  def after_sign_in_path_for(resource)
+    return admins_path if resource.is_a?(Admin)
+
+    relative_uri(params[:return_to]) || user_path(current_user)
   end
 
   def authenticate_admin!

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -255,17 +255,17 @@ public
   # behavior in case the user is not authorized
   # to access the requested action.  For example, a popup window might
   # simply close itself.
-  def access_denied(options ={})
+  def access_denied(options = {})
+    destination = options[:redirect]
     if logged_in?
-      destination = options[:redirect].blank? ? user_path(current_user) : options[:redirect]
+      destination ||= user_path(current_user)
       # i18n-tasks-use t('users.reconfirm_email.access_denied.logged_in')
       flash[:error] = t(".access_denied.logged_in", default: t("application.access_denied.access_denied.logged_in")) # rubocop:disable I18n/DefaultTranslation
-      redirect_to destination
     else
-      destination = options[:redirect].blank? ? new_user_session_path : options[:redirect]
+      destination ||= new_user_session_path(return_to: request.fullpath)
       flash[:error] = ts "Sorry, you don't have permission to access the page you were trying to reach. Please log in."
-      redirect_to destination
     end
+    redirect_to destination
     false
   end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -456,7 +456,7 @@ public
   # includes a special case for restricted works and series, since we want to encourage people to sign up to read them
   def check_visibility
     if @check_visibility_of.respond_to?(:restricted) && @check_visibility_of.restricted && User.current_user.nil?
-      redirect_to new_user_session_path(restricted: true)
+      redirect_to new_user_session_path(restricted: true, return_to: request.fullpath)
     elsif @check_visibility_of.is_a? Skin
       access_denied unless logged_in_as_admin? || current_user_owns?(@check_visibility_of) || @check_visibility_of.official?
     else

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -210,35 +210,6 @@ public
     @current_tos_version = 2024_11_19 # rubocop:disable Style/NumericLiterals
   end
 
-  # store previous page in session to make redirecting back possible
-  # if already redirected once, don't redirect again.
-  before_action :store_location
-  def store_location
-    if session[:return_to] == "redirected"
-      session.delete(:return_to)
-    elsif request.fullpath.length > 200
-      # Sessions are stored in cookies, which has a 4KB size limit.
-      # Don't store paths that are too long (e.g. filters with lots of exclusions).
-      # Also remove the previous stored path.
-      session.delete(:return_to)
-    else
-      session[:return_to] = request.fullpath
-    end
-  end
-
-  # Redirect to the URI stored by the most recent store_location call or
-  # to the passed default.
-  def redirect_back_or_default(default = root_path)
-    back = session[:return_to]
-    session.delete(:return_to)
-    if back
-      session[:return_to] = "redirected"
-      redirect_to(back) and return
-    else
-      redirect_to(default) and return
-    end
-  end
-
   def relative_uri(uri)
     return uri if URI.parse(uri).relative? && uri.start_with?("/") && !uri.start_with?("//")
   rescue URI::InvalidURIError
@@ -285,7 +256,6 @@ public
   # to access the requested action.  For example, a popup window might
   # simply close itself.
   def access_denied(options ={})
-    store_location
     if logged_in?
       destination = options[:redirect].blank? ? user_path(current_user) : options[:redirect]
       # i18n-tasks-use t('users.reconfirm_email.access_denied.logged_in')
@@ -560,7 +530,6 @@ public
   # Don't get unnecessary data for json requests
 
   skip_before_action  :load_admin_banner,
-                      :store_location,
                       if: proc { %w(js json).include?(request.format) }
 
 end

--- a/app/controllers/autocomplete_controller.rb
+++ b/app/controllers/autocomplete_controller.rb
@@ -1,7 +1,6 @@
 class AutocompleteController < ApplicationController
   respond_to :json
 
-  skip_before_action :store_location
   skip_around_action :set_current_user, except: [:collection_parent_name, :owned_tag_sets, :site_skins]
   skip_before_action :sanitize_ac_params # can we dare!
 

--- a/app/controllers/bookmarks_controller.rb
+++ b/app/controllers/bookmarks_controller.rb
@@ -11,8 +11,6 @@ class BookmarksController < ApplicationController
 
   before_action :check_pseud_ownership, only: [:create, :update]
 
-  skip_before_action :store_location, only: [:share]
-
   def check_pseud_ownership
     if params[:bookmark][:pseud_id]
       pseud = Pseud.find(bookmark_params[:pseud_id])

--- a/app/controllers/bookmarks_controller.rb
+++ b/app/controllers/bookmarks_controller.rb
@@ -274,7 +274,7 @@ class BookmarksController < ApplicationController
     else
       # Avoid getting an unstyled page if JavaScript is disabled
       flash[:error] = ts("Sorry, you need to have JavaScript enabled for this.")
-      redirect_to @bookmark
+      redirect_back(fallback_location: root_path)
     end
   end
 

--- a/app/controllers/bookmarks_controller.rb
+++ b/app/controllers/bookmarks_controller.rb
@@ -276,7 +276,7 @@ class BookmarksController < ApplicationController
     else
       # Avoid getting an unstyled page if JavaScript is disabled
       flash[:error] = ts("Sorry, you need to have JavaScript enabled for this.")
-      redirect_back(fallback_location: root_path)
+      redirect_to @bookmark
     end
   end
 

--- a/app/controllers/chapters_controller.rb
+++ b/app/controllers/chapters_controller.rb
@@ -144,8 +144,6 @@ class ChaptersController < ApplicationController
       case params[:from]
       when "edit-work"
         redirect_to edit_work_path(@work)
-      when "edit"
-        redirect_to edit_chapter_path(@chapter)
       when "manage"
         redirect_to manage_work_chapters_path(@work)
       else
@@ -166,7 +164,6 @@ class ChaptersController < ApplicationController
       else
         draft_flash_message(@work)
       end
-      params[:from] = "edit"
       render :preview
     else
       @chapter.posted = true if params[:post_button] || params[:post_without_preview_button]

--- a/app/controllers/chapters_controller.rb
+++ b/app/controllers/chapters_controller.rb
@@ -107,7 +107,11 @@ class ChaptersController < ApplicationController
   # POST /work/:work_id/chapters.xml
   def create
     if params[:cancel_button]
-      redirect_back_or_default(root_path)
+      if params[:from] == "edit-work"
+        redirect_to edit_work_path(@work)
+      else
+        redirect_to @work
+      end
       return
     end
 
@@ -137,8 +141,16 @@ class ChaptersController < ApplicationController
   # PUT /work/:work_id/chapters/1.xml
   def update
     if params[:cancel_button]
-      # Not quite working yet - should send the user back to wherever they were before they hit edit
-      redirect_back_or_default(root_path)
+      case params[:from]
+      when "edit-work"
+        redirect_to edit_work_path(@work)
+      when "edit"
+        redirect_to edit_chapter_path(@chapter)
+      when "manage"
+        redirect_to manage_work_chapters_path(@work)
+      else
+        redirect_to @chapter
+      end
       return
     end
 
@@ -154,6 +166,7 @@ class ChaptersController < ApplicationController
       else
         draft_flash_message(@work)
       end
+      params[:from] = "edit"
       render :preview
     else
       @chapter.posted = true if params[:post_button] || params[:post_without_preview_button]

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,5 +1,4 @@
 class CommentsController < ApplicationController
-  skip_before_action :store_location, except: [:show, :index, :new]
   before_action :load_commentable,
                 only: [:index, :new, :create, :edit, :update, :show_comments,
                        :hide_comments, :add_comment_reply,

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -449,7 +449,7 @@ class CommentsController < ApplicationController
     authorize @commentable, policy_class: CommentPolicy if logged_in_as_admin?
     unless (@commentable && current_user_owns?(@commentable)) || (@commentable && logged_in_as_admin? && @commentable.is_a?(AdminPost))
       flash[:error] = ts("What did you want to review comments on?")
-      redirect_back_or_to(root_path)
+      redirect_to(root_path)
       return
     end
 

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -100,7 +100,8 @@ class CommentsController < ApplicationController
     parent = find_parent
 
     return unless parent.respond_to?(:restricted) && parent.restricted? && !(logged_in? || logged_in_as_admin?)
-    redirect_to new_user_session_path(restricted_commenting: true)
+
+    redirect_to new_user_session_path(restricted_commenting: true, return_to: request.fullpath)
   end
 
   # Check to see if the ultimate_parent is a Work or AdminPost, and if so, if it allows

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -650,10 +650,10 @@ class CommentsController < ApplicationController
 
     if commentable.is_a?(Tag)
       redirect_to comments_path(tag_id: commentable.to_param,
-                                add_comment_reply_id: options[:add_comment_reply_id],
-                                delete_comment_id: options[:delete_comment_id],
-                                page: options[:page],
-                                anchor: options[:anchor])
+                  add_comment_reply_id: options[:add_comment_reply_id],
+                  delete_comment_id: options[:delete_comment_id],
+                  page: options[:page],
+                  anchor: options[:anchor])
     else
       if commentable.is_a?(Chapter) && (options[:view_full_work] || current_user.try(:preference).try(:view_full_works))
         commentable = commentable.work

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -129,7 +129,7 @@ class CommentsController < ApplicationController
     admin_settings = AdminSetting.current
 
     return unless admin_settings.guest_comments_off? && guest?
-    
+
     flash[:error] = t("comments.commentable.guest_comments_disabled")
     redirect_back(fallback_location: root_path)
   end
@@ -290,7 +290,7 @@ class CommentsController < ApplicationController
   def new
     if @commentable.nil?
       flash[:error] = ts("What did you want to comment on?")
-      redirect_back_or_default(root_path)
+      redirect_to root_path
     else
       @comment = Comment.new
       @controller_name = params[:controller_name] if params[:controller_name]
@@ -325,7 +325,7 @@ class CommentsController < ApplicationController
   def create
     if @commentable.nil?
       flash[:error] = ts("What did you want to comment on?")
-      redirect_back_or_default(root_path)
+      redirect_back_or_to root_path
     else
       @comment = Comment.new(comment_params)
       @comment.ip_address = request.remote_ip
@@ -405,7 +405,7 @@ class CommentsController < ApplicationController
     elsif unreviewed
       # go back to the rest of the unreviewed comments
       flash[:notice] = ts("Comment deleted.")
-      redirect_back(fallback_location: unreviewed_work_comments_path(@comment.commentable))
+      redirect_back_or_to(unreviewed_work_comments_path(@comment.commentable))
     elsif parent_comment
       flash[:comment_notice] = ts("Comment deleted.")
       redirect_to_comment(parent_comment)
@@ -449,7 +449,7 @@ class CommentsController < ApplicationController
     authorize @commentable, policy_class: CommentPolicy if logged_in_as_admin?
     unless (@commentable && current_user_owns?(@commentable)) || (@commentable && logged_in_as_admin? && @commentable.is_a?(AdminPost))
       flash[:error] = ts("What did you want to review comments on?")
-      redirect_back_or_default(root_path)
+      redirect_back_or_to(root_path)
       return
     end
 
@@ -650,10 +650,10 @@ class CommentsController < ApplicationController
 
     if commentable.is_a?(Tag)
       redirect_to comments_path(tag_id: commentable.to_param,
-                  add_comment_reply_id: options[:add_comment_reply_id],
-                  delete_comment_id: options[:delete_comment_id],
-                  page: options[:page],
-                  anchor: options[:anchor])
+                                add_comment_reply_id: options[:add_comment_reply_id],
+                                delete_comment_id: options[:delete_comment_id],
+                                page: options[:page],
+                                anchor: options[:anchor])
     else
       if commentable.is_a?(Chapter) && (options[:view_full_work] || current_user.try(:preference).try(:view_full_works))
         commentable = commentable.work

--- a/app/controllers/downloads_controller.rb
+++ b/app/controllers/downloads_controller.rb
@@ -1,6 +1,5 @@
 class DownloadsController < ApplicationController
 
-  skip_before_action :store_location, only: :show
   before_action :load_work, only: :show
   before_action :check_download_posted_status, only: :show
   before_action :check_download_visibility, only: :show

--- a/app/controllers/downloads_controller.rb
+++ b/app/controllers/downloads_controller.rb
@@ -36,7 +36,7 @@ protected
   def load_work
     unless AdminSetting.current.downloads_enabled?
       flash[:error] = ts("Sorry, downloads are currently disabled.")
-      redirect_back_or_default works_path
+      redirect_to work_path(params[:id])
       return
     end
 

--- a/app/controllers/favorite_tags_controller.rb
+++ b/app/controllers/favorite_tags_controller.rb
@@ -1,5 +1,4 @@
 class FavoriteTagsController < ApplicationController
-  skip_before_action :store_location, only: [:create, :destroy]
   before_action :users_only
   before_action :load_user
   before_action :check_ownership

--- a/app/controllers/feedbacks_controller.rb
+++ b/app/controllers/feedbacks_controller.rb
@@ -26,7 +26,7 @@ class FeedbacksController < ApplicationController
       @feedback.email_and_send
       flash[:notice] = t("successfully_sent",
         default: "Your message was sent to the Archive team - thank you!")
-      redirect_back_or_default(root_path)
+      redirect_to(@feedback.referer || root_path)
     else
       flash[:error] = t("failure_send",
         default: "Sorry, your message could not be saved - please try again!")

--- a/app/controllers/feedbacks_controller.rb
+++ b/app/controllers/feedbacks_controller.rb
@@ -1,5 +1,4 @@
 class FeedbacksController < ApplicationController
-  skip_before_action :store_location
   before_action :load_support_languages
 
   def new

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,7 +1,6 @@
 class HomeController < ApplicationController
 
   before_action :users_only, only: [:first_login_help]
-  skip_before_action :store_location, only: [:first_login_help, :token_dispenser]
 
   # unicorn_test
   def unicorn_test

--- a/app/controllers/inbox_controller.rb
+++ b/app/controllers/inbox_controller.rb
@@ -66,10 +66,10 @@ class InboxController < ApplicationController
   def check_blocked
     if blocked_by?(@commentable.ultimate_parent)
       flash[:error] = t("comments.check_blocked.parent")
-      redirect_back(fallback_location: user_inbox_path(@user))
+      redirect_to user_inbox_path(@user)
     elsif blocked_by_comment?(@commentable)
       flash[:error] = t("comments.check_blocked.reply")
-      redirect_back(fallback_location: user_inbox_path(@user))
+      redirect_to user_inbox_path(@user)
     end
   end
 end

--- a/app/controllers/kudos_controller.rb
+++ b/app/controllers/kudos_controller.rb
@@ -1,5 +1,4 @@
 class KudosController < ApplicationController
-  skip_before_action :store_location
   before_action :load_parent, only: [:index]
   before_action :check_parent_visible, only: [:index]
   before_action :admin_logout_required, only: [:create]

--- a/app/controllers/media_controller.rb
+++ b/app/controllers/media_controller.rb
@@ -1,6 +1,5 @@
 class MediaController < ApplicationController
   before_action :load_collection
-  skip_before_action :store_location, only: [:show]
 
   def index
     uncategorized = Media.uncategorized

--- a/app/controllers/orphans_controller.rb
+++ b/app/controllers/orphans_controller.rb
@@ -14,18 +14,23 @@ class OrphansController < ApplicationController
   def new
     if params[:work_id]
       @to_be_orphaned = Work.find(params[:work_id])
+      @return_to = edit_work_path(@to_be_orphaned)
       check_one_owned(@to_be_orphaned, current_user.works)
     elsif params[:work_ids]
       @to_be_orphaned = Work.where(id: params[:work_ids]).to_a
+      @return_to = show_multiple_user_works_path(current_user)
       check_all_owned(@to_be_orphaned, current_user.works)
     elsif params[:series_id]
       @to_be_orphaned = Series.find(params[:series_id])
+      @return_to = edit_series_path(@to_be_orphaned)
       check_one_owned(@to_be_orphaned, current_user.series)
     elsif params[:pseud_id]
       @to_be_orphaned = Pseud.find(params[:pseud_id])
+      @return_to = user_pseuds_path(@to_be_orphaned)
       check_one_owned(@to_be_orphaned, current_user.pseuds)
     else
       @to_be_orphaned = current_user
+      @return_to = user_path(@to_be_orphaned)
     end
   end
 

--- a/app/controllers/preferences_controller.rb
+++ b/app/controllers/preferences_controller.rb
@@ -1,7 +1,6 @@
 class PreferencesController < ApplicationController
   before_action :load_user
   before_action :check_ownership
-  skip_before_action :store_location
 
   # Ensure that the current user is authorized to view and change this information
   def load_user

--- a/app/controllers/related_works_controller.rb
+++ b/app/controllers/related_works_controller.rb
@@ -31,11 +31,11 @@ class RelatedWorksController < ApplicationController
     unless @user
       if current_user_owns?(@child)
         flash[:error] = ts("Sorry, but you don't have permission to do that. Try removing the link from your own work.")
-        redirect_back_or_to user_related_works_path(current_user)
       else
         flash[:error] = ts("Sorry, but you don't have permission to do that.")
-        redirect_back_or_to root_path
       end
+      # TODO(M): test - the spec dictates this
+      redirect_back_or_to related_work_path(@related_work)
       return
     end
     # the assumption here is that any update is a toggle from what was before
@@ -56,7 +56,7 @@ class RelatedWorksController < ApplicationController
     unless current_user_owns?(@child)
       if @user
         flash[:error] = ts("Sorry, but you don't have permission to do that. You can only approve or remove the link from your own work.")
-        redirect_back_or_to user_related_works_path(current_user)
+        redirect_back_or_to related_work_path(@related_work)
       else
         flash[:error] = ts("Sorry, but you don't have permission to do that.")
         redirect_back_or_to root_path

--- a/app/controllers/related_works_controller.rb
+++ b/app/controllers/related_works_controller.rb
@@ -27,17 +27,16 @@ class RelatedWorksController < ApplicationController
   end
 
   def update
-    # updates are done by the owner of the parent, to aprove or remove links on the parent work.
+    # updates are done by the owner of the parent, to approve or remove links on the parent work.
     unless @user
       if current_user_owns?(@child)
         flash[:error] = ts("Sorry, but you don't have permission to do that. Try removing the link from your own work.")
-        redirect_back_or_default(user_related_works_path(current_user))
-        return
+        redirect_back_or_to user_related_works_path(current_user)
       else
         flash[:error] = ts("Sorry, but you don't have permission to do that.")
-        redirect_back_or_default(root_path)
-        return
+        redirect_back_or_to root_path
       end
+      return
     end
     # the assumption here is that any update is a toggle from what was before
     @related_work.reciprocal = !@related_work.reciprocal?
@@ -57,16 +56,15 @@ class RelatedWorksController < ApplicationController
     unless current_user_owns?(@child)
       if @user
         flash[:error] = ts("Sorry, but you don't have permission to do that. You can only approve or remove the link from your own work.")
-        redirect_back_or_default(user_related_works_path(current_user))
-        return
+        redirect_back_or_to user_related_works_path(current_user)
       else
         flash[:error] = ts("Sorry, but you don't have permission to do that.")
-        redirect_back_or_default(root_path)
-        return
+        redirect_back_or_to root_path
       end
+      return
     end
     @related_work.destroy
-    redirect_back(fallback_location: user_related_works_path(current_user))
+    redirect_back_or_to user_related_works_path(current_user)
   end
 
   private
@@ -74,12 +72,12 @@ class RelatedWorksController < ApplicationController
   def load_user
     if params[:user_id].blank?
       flash[:error] = ts("Whose related works were you looking for?")
-      redirect_back_or_default(search_people_path)
+      redirect_to user_related_works_path
     else
       @user = User.find_by(login: params[:user_id])
       if @user.blank?
         flash[:error] = ts("Sorry, we couldn't find that user")
-        redirect_back_or_default(root_path)
+        redirect_to user_related_works_path
       end
     end
   end

--- a/app/controllers/related_works_controller.rb
+++ b/app/controllers/related_works_controller.rb
@@ -72,12 +72,12 @@ class RelatedWorksController < ApplicationController
   def load_user
     if params[:user_id].blank?
       flash[:error] = ts("Whose related works were you looking for?")
-      redirect_to user_related_works_path
+      redirect_to search_people_path
     else
       @user = User.find_by(login: params[:user_id])
       if @user.blank?
         flash[:error] = ts("Sorry, we couldn't find that user")
-        redirect_to user_related_works_path
+        redirect_to search_people_path
       end
     end
   end

--- a/app/controllers/skins_controller.rb
+++ b/app/controllers/skins_controller.rb
@@ -132,7 +132,8 @@ class SkinsController < ApplicationController
     else
       flash[:error] = ts("Sorry, but only certain skins can be used this way (for performance reasons). Please drop a support request if you'd like %{title} to be added!", title: @skin.title)
     end
-    redirect_back_or_default @skin
+    # TODO(M): check after AO3-5953 is merged - POST requests shouldn't be cached?
+    redirect_back_or_to @skin
   end
 
   def unset
@@ -142,7 +143,8 @@ class SkinsController < ApplicationController
       current_user.preference.save
     end
     flash[:notice] = ts("You are now using the default Archive skin again!")
-    redirect_back_or_default "/"
+    # TODO(M): check after AO3-5953 is merged - POST requests shouldn't be cached?
+    redirect_back_or_to root_path
   end
 
   # GET /skins/1/confirm_delete

--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -1,7 +1,5 @@
 class SubscriptionsController < ApplicationController
 
-  skip_before_action :store_location, only: [:create, :destroy]
-
   before_action :users_only
   before_action :load_user
   before_action :load_subscribable_type, only: [:index, :confirm_delete_all, :delete_all]

--- a/app/controllers/users/passwords_controller.rb
+++ b/app/controllers/users/passwords_controller.rb
@@ -3,7 +3,6 @@
 # Use for resetting lost passwords
 class Users::PasswordsController < Devise::PasswordsController
   before_action :admin_logout_required
-  skip_before_action :store_location
   layout "session"
 
   def create

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -2,7 +2,6 @@ class Users::SessionsController < Devise::SessionsController
 
   layout "session"
   before_action :admin_logout_required
-  skip_before_action :store_location
 
   # POST /users/login
   def create
@@ -23,13 +22,8 @@ class Users::SessionsController < Devise::SessionsController
 
   # DELETE /users/logout
   def destroy
-    # signed_out clears the session
-    return_to = session[:return_to]
-
     signed_out = (Devise.sign_out_all_scopes ? sign_out : sign_out(resource_name))
     set_flash_message! :notice, :signed_out if signed_out
-
-    session[:return_to] = return_to
 
     # TODO(M): redirect back? there's a decent chance that it will lead to an immediate access denied
     redirect_to root_path

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -25,7 +25,6 @@ class Users::SessionsController < Devise::SessionsController
     signed_out = (Devise.sign_out_all_scopes ? sign_out : sign_out(resource_name))
     set_flash_message! :notice, :signed_out if signed_out
 
-    # TODO(M): redirect back? there's a decent chance that it will lead to an immediate access denied
-    redirect_to root_path
+    redirect_back_or_to root_path
   end
 end

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -31,6 +31,7 @@ class Users::SessionsController < Devise::SessionsController
 
     session[:return_to] = return_to
 
-    redirect_back_or_default root_path
+    # TODO(M): redirect back? there's a decent chance that it will lead to an immediate access denied
+    redirect_to root_path
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -5,7 +5,6 @@ class UsersController < ApplicationController
   before_action :load_user, except: [:activate, :delete_confirmation, :index]
   before_action :check_ownership, except: [:activate, :change_username, :changed_username, :delete_confirmation, :edit, :index, :show, :update]
   before_action :check_ownership_or_admin, only: [:change_username, :changed_username, :edit, :update]
-  skip_before_action :store_location, only: [:end_first_login]
 
   def load_user
     @user = User.find_by!(login: params[:id])

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -238,6 +238,12 @@ class UsersController < ApplicationController
   # DELETE /users/1
   # DELETE /users/1.xml
   def destroy
+    if params[:cancel_button]
+      flash[:notice] = ts('Account deletion canceled.')
+      redirect_to user_profile_path(@user)
+      return
+    end
+
     @hide_dashboard = true
     @works = @user.works.where(posted: true)
     @sole_owned_collections = @user.sole_owned_collections
@@ -341,13 +347,6 @@ class UsersController < ApplicationController
   def destroy_author
     @sole_authored_works = @user.sole_authored_works
     @coauthored_works = @user.coauthored_works
-
-    if params[:cancel_button]
-      flash[:notice] = ts('Account deletion canceled.')
-      redirect_to user_profile_path(@user)
-
-      return
-    end
 
     if params[:coauthor] == 'keep_pseud' || params[:coauthor] == 'orphan_pseud'
       # Orphans co-authored works.

--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -20,8 +20,6 @@ class WorksController < ApplicationController
   cache_sweeper :collection_sweeper
   cache_sweeper :feed_sweeper
 
-  skip_before_action :store_location, only: [:share]
-
   # we want to extract the countable params from work_search and move them into their fields
   def clean_work_search_params
     QueryCleaner.new(work_search_params || {}).clean

--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -375,7 +375,6 @@ class WorksController < ApplicationController
     if params[:edit_button] || work_cannot_be_saved?
       render :edit
     elsif params[:preview_button]
-      params[:from] = "edit"
       unless @work.posted?
         flash[:notice] = ts("Your changes have not been saved. Please post your work or save as draft if you want to keep them.")
       end
@@ -826,7 +825,6 @@ class WorksController < ApplicationController
       if @work.posted
         flash[:notice] = ts('The work was not updated.')
         redirect_to user_works_path(current_user) and return if params[:from] == "blurb"
-        redirect_to edit_work_path(@work) and return if params[:from] == "edit"
         redirect_to edit_tags_work_path(@work) and return if params[:from] == "edit-tags"
       else
         flash[:notice] = ts('The work was not posted. It will be saved here in your drafts for one month, then deleted from the Archive.')

--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -296,11 +296,7 @@ class WorksController < ApplicationController
 
   # POST /works
   def create
-    if params[:cancel_button]
-      flash[:notice] = ts('New work posting canceled.')
-      redirect_to current_user
-      return
-    end
+    return cancel_posting_and_redirect if params[:cancel_button]
 
     @work = Work.new(work_params)
 
@@ -366,9 +362,7 @@ class WorksController < ApplicationController
 
   # PUT /works/1
   def update
-    if params[:cancel_button]
-      return cancel_posting_and_redirect
-    end
+    return cancel_posting_and_redirect if params[:cancel_button]
 
     @work.preview_mode = !!(params[:preview_button] || params[:edit_button])
     @work.attributes = work_params
@@ -383,6 +377,7 @@ class WorksController < ApplicationController
     if params[:edit_button] || work_cannot_be_saved?
       render :edit
     elsif params[:preview_button]
+      params[:from] = "edit"
       unless @work.posted?
         flash[:notice] = ts("Your changes have not been saved. Please post your work or save as draft if you want to keep them.")
       end
@@ -411,9 +406,7 @@ class WorksController < ApplicationController
 
   def update_tags
     authorize @work if logged_in_as_admin?
-    if params[:cancel_button]
-      return cancel_posting_and_redirect
-    end
+    return cancel_posting_and_redirect if params[:cancel_button]
 
     @work.preview_mode = !!(params[:preview_button] || params[:edit_button])
     @work.attributes = work_tag_params
@@ -421,6 +414,7 @@ class WorksController < ApplicationController
     if params[:edit_button] || work_cannot_be_saved?
       render :edit_tags
     elsif params[:preview_button]
+      params[:from] = "edit-tags"
       @preview_mode = true
       render :preview_tags
     elsif params[:save_button]
@@ -830,12 +824,20 @@ class WorksController < ApplicationController
   end
 
   def cancel_posting_and_redirect
-    if @work && @work.posted
-      flash[:notice] = ts('The work was not updated.')
-      redirect_to user_works_path(current_user)
+    if @work
+      if @work.posted
+        flash[:notice] = ts('The work was not updated.')
+        redirect_to user_works_path(current_user) and return if params[:from] == "blurb"
+        redirect_to edit_work_path(@work) and return if params[:from] == "edit"
+        redirect_to edit_tags_work_path(@work) and return if params[:from] == "edit-tags"
+      else
+        flash[:notice] = ts('The work was not posted. It will be saved here in your drafts for one month, then deleted from the Archive.')
+        redirect_to drafts_user_works_path(current_user) and return if params[:from] == "blurb"
+      end
+      redirect_to @work
     else
-      flash[:notice] = ts('The work was not posted. It will be saved here in your drafts for one month, then deleted from the Archive.')
-      redirect_to drafts_user_works_path(current_user)
+      flash[:notice] = ts('New work posting canceled.')
+      redirect_to current_user
     end
   end
 

--- a/app/views/chapters/_chapter_form.html.erb
+++ b/app/views/chapters/_chapter_form.html.erb
@@ -1,5 +1,6 @@
 <div id="chapter-form" class="verbose post work chapter">
   <%= form_for([@work, chapter]) do |f| %>
+    <%= f.hidden_field(:from, name: "from", value: params[:from]) if params[:from] %>
     <p class="required notice"><%= ts("* Required information") %></p>
     <fieldset id="chapter-ordering">
       <legend><%= ts("Name, Order and Date") %></legend>

--- a/app/views/chapters/manage.html.erb
+++ b/app/views/chapters/manage.html.erb
@@ -9,7 +9,7 @@
 <div id="manage-chapters">
 
   <p id="drag" class="showme"><%= ts("Drag chapters to change their order.") %><p>
-  <noscript><p><%= ts("Enter new chapter numbers.") %><p></noscript>
+  <noscript><p><%= ts("Enter new chapter numbers.") %></p></noscript>
 
   <%= form_tag url_for(action: 'update_positions') do %>
 

--- a/app/views/chapters/manage.html.erb
+++ b/app/views/chapters/manage.html.erb
@@ -27,7 +27,7 @@
         <% if !chapter.posted %>(Draft)<% end %>
 
         <ul class="chapter-control actions">
-          <li><%= link_to ts("Edit"), [:edit, @work, chapter] %></li>
+          <li><%= link_to ts("Edit"), edit_work_chapter_path(@work, chapter, from: "manage") %></li>
           <% if @work.chapters.count > 1 %>
             <li>
               <%= link_to ts("Delete"), [@work, chapter],
@@ -50,7 +50,7 @@
 
   <p class="submit actions">
     <%= submit_tag ts("Update Positions") %>
-    <%= link_to ts("Back"), url_for(@work) %>
+    <%= link_to ts("Back"), edit_work_path(@work) %>
   </p>
 
   <% end %>

--- a/app/views/chapters/preview.html.erb
+++ b/app/views/chapters/preview.html.erb
@@ -16,6 +16,7 @@
 </div>
 
 <%= form_for([@work, @chapter]) do |f| %>
+  <%= f.hidden_field(:from, name: "from", value: params[:from]) if params[:from] %>
 
   <%= render "hidden_fields", form: f %>
 

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -25,7 +25,7 @@
   <% else %>
     <div id="login" class="dropdown">
       <p class="user actions">
-        <%= link_to t(".login"), new_user_session_path, id: "login-dropdown" %>
+        <%= link_to t(".login"), new_user_session_path(return_to: request.fullpath), id: "login-dropdown" %>
       </p>
       <%= render "users/sessions/login" %>
     </div>

--- a/app/views/orphans/new.html.erb
+++ b/app/views/orphans/new.html.erb
@@ -2,5 +2,5 @@
 
 <ul class="actions" role="navigation">
   <li><%= link_to t('.orphans_about', default: "Read More About The Orphaning Process"), archive_faq_path("orphaning") %></li> 
-  <li><%= link_to t('.links.cancel', default: "Cancel"), :back %></li>
+  <li><%= link_to t('.links.cancel', default: "Cancel"), @return_to %></li>
 </ul>

--- a/app/views/users/sessions/_passwd.html.erb
+++ b/app/views/users/sessions/_passwd.html.erb
@@ -1,4 +1,4 @@
-<%= form_for(User.new, url: new_user_session_path) do |f| %>
+<%= form_for(User.new, url: new_user_session_path(return_to: params[:return_to])) do |f| %>
   <dl>
     <dt><%= f.label :login, t(".username_or_email") %></dt>
     <dd><%= f.text_field :login %></dd>

--- a/app/views/users/sessions/_passwd_small.html.erb
+++ b/app/views/users/sessions/_passwd_small.html.erb
@@ -1,6 +1,6 @@
 <%# We need to override the ids to avoid accessibility issues on the new user session page,
 which has a second user session form %>
-<%= form_for(User.new, url: user_session_path, html: { id: "new_user_session_small" }) do |f| %>
+<%= form_for(User.new, url: user_session_path(return_to: request.fullpath), html: { id: "new_user_session_small" }) do |f| %>
   <dl>
     <dt><%= f.label :login, t(".username_or_email"), for: "user_session_login_small" %></dt>
     <dd><%= f.text_field :login, autocomplete: "on", id: "user_session_login_small" %></dd>

--- a/app/views/users/sessions/_passwd_small.html.erb
+++ b/app/views/users/sessions/_passwd_small.html.erb
@@ -1,6 +1,6 @@
 <%# We need to override the ids to avoid accessibility issues on the new user session page,
 which has a second user session form %>
-<%= form_for(User.new, url: user_session_path(return_to: request.fullpath), html: { id: "new_user_session_small" }) do |f| %>
+<%= form_for(User.new, url: user_session_path(return_to: request.path == new_user_session_path ? root_path : request.fullpath), html: { id: "new_user_session_small" }) do |f| %>
   <dl>
     <dt><%= f.label :login, t(".username_or_email"), for: "user_session_login_small" %></dt>
     <dd><%= f.text_field :login, autocomplete: "on", id: "user_session_login_small" %></dd>

--- a/app/views/works/_standard_form.html.erb
+++ b/app/views/works/_standard_form.html.erb
@@ -1,5 +1,6 @@
 <!--REVIEW: trying out articles on these fieldsets to see if that's a better chunker, but may revert after testing. Have also tossed in landmark headings on top level groups-->
 <%= form_for(@work, html: { id: "work-form", class: "verbose post work" }) do |f| %>
+  <%= f.hidden_field(:from, name: "from", value: params[:from]) if params[:from] %>
 
   <p class="required notice">* <%= ts("Required information") %></p>
 

--- a/app/views/works/_work_blurb.html.erb
+++ b/app/views/works/_work_blurb.html.erb
@@ -4,8 +4,8 @@
   <% if is_author_of?(work) %>
     <h6 class="landmark heading"><%= ts("Author Actions") %></h6>
   	<ul class="actions" role="navigation">
-      <li><%= link_to ts("Edit"), edit_work_path(work) %></li>
-  	  <li><%= link_to ts("Edit Tags"), edit_tags_work_path(work) %></li>
+      <li><%= link_to ts("Edit"), edit_work_path(work, from: "blurb") %></li>
+  	  <li><%= link_to ts("Edit Tags"), edit_tags_work_path(work, from: "blurb") %></li>
       <% if work.is_wip %>
         <li><%= link_to ts("Add Chapter"), new_work_chapter_path(work) %></li>
       <% end %>

--- a/app/views/works/edit.html.erb
+++ b/app/views/works/edit.html.erb
@@ -6,14 +6,14 @@
 
 <!--subnav-->
 <ul class="navigation actions" role="menu">
-	<li><%= link_to ts('Add Chapter'), new_work_chapter_path(@work) %></li>
+	<li><%= link_to ts('Add Chapter'), new_work_chapter_path(@work, from: "edit-work") %></li>
   <% if @chapters %>
     <li><%= ts('Edit Chapter:') %>
       <% for chapter in @chapters %>
         <% if chapter.posted? %>
-          <%= link_to h(chapter.position), [:edit, @work, chapter] %>
+          <%= link_to h(chapter.position), edit_work_chapter_path(@work, chapter, from: "edit-work") %>
         <% else %>
-            <%= link_to h(chapter.position) + ts(" (Draft)"), [:edit, @work, chapter] %>
+            <%= link_to h(chapter.position) + ts(" (Draft)"), edit_work_chapter_path(@work, chapter, from: "edit-work") %>
 	<% end %>
       <% end %></li>
     <li><%= link_to ts('Manage Chapters'), manage_work_chapters_path(@work) %></li>

--- a/app/views/works/edit_tags.html.erb
+++ b/app/views/works/edit_tags.html.erb
@@ -12,6 +12,7 @@
 
 <!--main content-->
 <%= form_for(@work, html: { id: "work-form", class: "verbose work post" }, url: { action: "update_tags" }) do |f| %>
+  <%= f.hidden_field(:from, name: "from", value: params[:from]) if params[:from] %>
   <p class="required notice">* <%= ts('Required information') %></p>
 
   <%= render 'work_form_tags', include_blank: false %>

--- a/app/views/works/preview.html.erb
+++ b/app/views/works/preview.html.erb
@@ -40,6 +40,7 @@
 <div class="clear"><!--presentational--></div>
 
 <%= form_for(@work) do |f| %>
+  <%= f.hidden_field(:from, name: "from", value: params[:from] || "blurb") %>
 
   <%= render "hidden_fields", form: f %>
 

--- a/features/works/work_edit.feature
+++ b/features/works/work_edit.feature
@@ -70,6 +70,8 @@ Feature: Edit Works
       And I fill in "content" with "second chapter new content"
       And I press "Preview"
       And I press "Cancel"
+      And I view the work "First Work"
+      And I view the 2nd chapter
     Then I should see "second chapter content"
       And I should see "Words:7"
     # Test changing pseuds on a work

--- a/spec/controllers/bookmarks_controller_spec.rb
+++ b/spec/controllers/bookmarks_controller_spec.rb
@@ -212,12 +212,12 @@ describe BookmarksController do
       expect(response.status).to eq(404)
     end
 
-    it "redirects to referer with an error for non-ajax warnings requests" do
+    it "redirects to bookmark with an error for non-ajax warnings requests" do
       bookmark = create(:bookmark)
 
       fake_login_known_user(bookmark.pseud.user)
       get :share, params: { id: bookmark.id }
-      it_redirects_to_with_error(root_path, "Sorry, you need to have JavaScript enabled for this.")
+      it_redirects_to_with_error(bookmark, "Sorry, you need to have JavaScript enabled for this.")
     end
   end
 

--- a/spec/controllers/bookmarks_controller_spec.rb
+++ b/spec/controllers/bookmarks_controller_spec.rb
@@ -4,10 +4,6 @@ describe BookmarksController do
   include LoginMacros
   include RedirectExpectationHelper
 
-  def it_redirects_to_user_login
-    it_redirects_to_simple new_user_session_path
-  end
-
   describe "new" do
     context "without javascript" do
       it "redirects logged out users" do
@@ -35,7 +31,7 @@ describe BookmarksController do
     context "denies access for work that isn't visible to user" do
       subject { get :new, params: { work_id: work } }
       let(:success) { expect(response).to render_template("new") }
-      let(:success_admin) { it_redirects_to_with_error(new_user_session_path, "Sorry, you don't have permission to access the page you were trying to reach. Please log in.") }
+      let(:success_admin) { it_redirects_to_user_login }
 
       include_examples "denies access for work that isn't visible to user"
     end

--- a/spec/controllers/bookmarks_controller_spec.rb
+++ b/spec/controllers/bookmarks_controller_spec.rb
@@ -212,12 +212,12 @@ describe BookmarksController do
       expect(response.status).to eq(404)
     end
 
-    it "redirects to bookmark with an error for non-ajax warnings requests" do
+    it "redirects to referer with an error for non-ajax warnings requests" do
       bookmark = create(:bookmark)
 
       fake_login_known_user(bookmark.pseud.user)
       get :share, params: { id: bookmark.id }
-      it_redirects_to_with_error(bookmark, "Sorry, you need to have JavaScript enabled for this.")
+      it_redirects_to_with_error(root_path, "Sorry, you need to have JavaScript enabled for this.")
     end
   end
 

--- a/spec/controllers/chapters_controller_spec.rb
+++ b/spec/controllers/chapters_controller_spec.rb
@@ -100,7 +100,7 @@ describe ChaptersController do
       it "errors and redirects to login when work is restricted" do
         restricted_work = create(:work, restricted: true)
         get :show, params: { work_id: restricted_work.id, id: restricted_work.chapters.first }
-        it_redirects_to(new_user_session_path(restricted: true))
+        it_redirects_to(new_user_session_path(restricted: true, return_to: request.fullpath))
       end
 
       it "assigns @chapters to only posted chapters" do

--- a/spec/controllers/chapters_controller_spec.rb
+++ b/spec/controllers/chapters_controller_spec.rb
@@ -49,7 +49,7 @@ describe ChaptersController do
     context "when user is logged out" do
       it "errors and redirects to login" do
         get :manage, params: { work_id: work.id }
-        it_redirects_to_with_error(new_user_session_path, "Sorry, you don't have permission to access the page you were trying to reach. Please log in.")
+        it_redirects_to_user_login
       end
     end
 
@@ -112,7 +112,7 @@ describe ChaptersController do
       it "errors and redirects to login when trying to view unposted chapter" do
         chapter = create(:chapter, :draft, work: work)
         get :show, params: { work_id: work.id, id: chapter.id }
-        it_redirects_to_with_error(new_user_session_path, "Sorry, you don't have permission to access the page you were trying to reach. Please log in.")
+        it_redirects_to_user_login
       end
     end
 
@@ -289,7 +289,7 @@ describe ChaptersController do
     context "when user is logged out" do
       it "errors and redirects to login" do
         get :new, params: { work_id: work.id }
-        it_redirects_to_with_error(new_user_session_path, "Sorry, you don't have permission to access the page you were trying to reach. Please log in.")
+        it_redirects_to_user_login
       end
     end
 
@@ -334,7 +334,7 @@ describe ChaptersController do
     context "when user is logged out" do
       it "errors and redirects to login" do
         get :edit, params: { work_id: work.id, id: work.chapters.first.id }
-        it_redirects_to_with_error(new_user_session_path, "Sorry, you don't have permission to access the page you were trying to reach. Please log in.")
+        it_redirects_to_user_login
       end
     end
 
@@ -443,7 +443,7 @@ describe ChaptersController do
     context "when user is logged out" do
       it "errors and redirects to login" do
         post :create, params: { work_id: work.id, chapter: chapter_attributes }
-        it_redirects_to_with_error(new_user_session_path, "Sorry, you don't have permission to access the page you were trying to reach. Please log in.")
+        it_redirects_to_user_login
       end
     end
 
@@ -654,7 +654,7 @@ describe ChaptersController do
     context "when user is logged out" do
       it "errors and redirects to login" do
         put :update, params: { work_id: work.id, id: work.chapters.first.id, chapter: chapter_attributes }
-        it_redirects_to_with_error(new_user_session_path, "Sorry, you don't have permission to access the page you were trying to reach. Please log in.")
+        it_redirects_to_user_login
       end
     end
 
@@ -850,7 +850,7 @@ describe ChaptersController do
     context "when user is logged out" do
       it "errors and redirects to login" do
         post :update_positions, params: { work_id: work.id, chapter: [chapter1, chapter3, chapter2, chapter4] }
-        it_redirects_to_with_error(new_user_session_path, "Sorry, you don't have permission to access the page you were trying to reach. Please log in.")
+        it_redirects_to_user_login
       end
     end
 
@@ -928,7 +928,7 @@ describe ChaptersController do
     context "when user is logged out" do
       it "errors and redirects to login" do
         get :preview, params: { work_id: work.id, id: work.chapters.first.id }
-        it_redirects_to_with_error(new_user_session_path, "Sorry, you don't have permission to access the page you were trying to reach. Please log in.")
+        it_redirects_to_user_login
       end
     end
 
@@ -970,7 +970,7 @@ describe ChaptersController do
     context "when user is logged out" do
       it "errors and redirects to login" do
         post :post, params: { work_id: work.id, id: @chapter_to_post.id }
-        it_redirects_to_with_error(new_user_session_path, "Sorry, you don't have permission to access the page you were trying to reach. Please log in.")
+        it_redirects_to_user_login
       end
     end
 
@@ -1092,7 +1092,7 @@ describe ChaptersController do
       it "errors and redirects to login" do
         pending "clean up chapter filters"
         delete :destroy, params: { work_id: work.id, id: work.chapters.first.id }
-        it_redirects_to_with_error(new_user_session_path, "Sorry, you don't have permission to access the page you were trying to reach. Please log in.")
+        it_redirects_to_user_login
       end
     end
 

--- a/spec/controllers/collection_participants_controller_spec.rb
+++ b/spec/controllers/collection_participants_controller_spec.rb
@@ -12,9 +12,7 @@ describe CollectionParticipantsController do
     context "where user isn't logged in" do
       it "redirects to new user session with error" do
         get :join, params: { collection_id: collection.name }
-        it_redirects_to_with_error(new_user_session_path,
-                                   "Sorry, you don't have permission to access the page"\
-                                   " you were trying to reach. Please log in.")
+        it_redirects_to_user_login
       end
     end
 
@@ -84,7 +82,7 @@ describe CollectionParticipantsController do
     context "user is not logged in" do
       it "redirects to the index and displays an access denied message" do
         get :index, params: { collection_id: collection.name }
-        it_redirects_to_with_error(new_user_session_path, "Sorry, you don't have permission to access the page you were trying to reach. Please log in.")
+        it_redirects_to_user_login
       end
     end
 

--- a/spec/controllers/comments/comment_moderation_spec.rb
+++ b/spec/controllers/comments/comment_moderation_spec.rb
@@ -18,13 +18,13 @@ describe CommentsController do
 
       it "redirects logged out users to login path with an error" do
         get :unreviewed, params: { work_id: work.id }
-        it_redirects_to_with_error(new_user_session_path, "Sorry, you don't have permission to see those unreviewed comments.")
+        it_redirects_to_user_login("Sorry, you don't have permission to see those unreviewed comments.")
       end
 
       it "redirects to root path with an error when logged in user does not own the commentable" do
         fake_login
         get :unreviewed, params: { work_id: work.id }
-        it_redirects_to_with_error(root_path, "Sorry, you don't have permission to see those unreviewed comments.")
+        it_redirects_to_user_login("Sorry, you don't have permission to see those unreviewed comments.")
       end
 
       it "renders the :unreviewed template for a user who owns the work" do

--- a/spec/controllers/comments/comment_moderation_spec.rb
+++ b/spec/controllers/comments/comment_moderation_spec.rb
@@ -18,13 +18,13 @@ describe CommentsController do
 
       it "redirects logged out users to login path with an error" do
         get :unreviewed, params: { work_id: work.id }
-        it_redirects_to_user_login("Sorry, you don't have permission to see those unreviewed comments.")
+        it_redirects_to_with_error(new_user_session_path, "Sorry, you don't have permission to see those unreviewed comments.")
       end
 
       it "redirects to root path with an error when logged in user does not own the commentable" do
         fake_login
         get :unreviewed, params: { work_id: work.id }
-        it_redirects_to_user_login("Sorry, you don't have permission to see those unreviewed comments.")
+        it_redirects_to_with_error(root_path, "Sorry, you don't have permission to see those unreviewed comments.")
       end
 
       it "renders the :unreviewed template for a user who owns the work" do

--- a/spec/controllers/comments/comments_controller_spec.rb
+++ b/spec/controllers/comments/comments_controller_spec.rb
@@ -64,10 +64,7 @@ describe CommentsController do
 
         it "shows an error and redirects" do
           get :show_comments, params: { tag_id: fandom.name }
-          it_redirects_to_with_error(new_user_session_path,
-                                     "Sorry, you don't have permission to " \
-                                     "access the page you were trying to " \
-                                     "reach. Please log in.")
+          it_redirects_to_user_login
         end
       end
     end

--- a/spec/controllers/comments/default_rails_actions_spec.rb
+++ b/spec/controllers/comments/default_rails_actions_spec.rb
@@ -63,10 +63,7 @@ describe CommentsController do
 
         it "shows an error and redirects" do
           get :new, params: { tag_id: fandom.name }
-          it_redirects_to_with_error(new_user_session_path,
-                                     "Sorry, you don't have permission to " \
-                                     "access the page you were trying to " \
-                                     "reach. Please log in.")
+          it_redirects_to_user_login
         end
       end
     end
@@ -305,10 +302,7 @@ describe CommentsController do
 
         it "shows an error and redirects" do
           post :create, params: { tag_id: fandom.name, comment: anon_comment_attributes }
-          it_redirects_to_with_error(new_user_session_path,
-                                     "Sorry, you don't have permission to " \
-                                     "access the page you were trying to " \
-                                     "reach. Please log in.")
+          it_redirects_to_user_login
         end
       end
     end
@@ -776,7 +770,7 @@ describe CommentsController do
           it "doesn't destroy comment and redirects with error" do
             delete :destroy, params: { id: comment.id }
 
-            it_redirects_to_with_error(new_user_session_path, "Sorry, you don't have permission to access the page you were trying to reach. Please log in.")
+            it_redirects_to_user_login
             expect { comment.reload }.not_to raise_exception
           end
         end

--- a/spec/controllers/comments/default_rails_actions_spec.rb
+++ b/spec/controllers/comments/default_rails_actions_spec.rb
@@ -313,7 +313,7 @@ describe CommentsController do
 
         it "redirects to the login page" do
           post :create, params: { work_id: work.id, comment: anon_comment_attributes }
-          it_redirects_to(new_user_session_path(restricted_commenting: true))
+          it_redirects_to(new_user_session_path(restricted_commenting: true, return_to: request.fullpath))
         end
       end
 
@@ -888,7 +888,7 @@ describe CommentsController do
 
               it "redirects to the login page" do
                 delete :destroy, params: { id: comment.id }
-                it_redirects_to(new_user_session_path(restricted_commenting: true))
+                it_redirects_to(new_user_session_path(restricted_commenting: true, return_to: request.fullpath))
               end
             end
           end

--- a/spec/controllers/comments/freeze_spec.rb
+++ b/spec/controllers/comments/freeze_spec.rb
@@ -78,7 +78,7 @@ describe CommentsController do
             put :freeze, params: { id: comment.id }
 
             expect(comment.reload.iced).to be_falsey
-            it_redirects_to_with_error(new_user_session_path, "Sorry, you don't have permission to access the page you were trying to reach. Please log in.")
+            it_redirects_to_user_login
           end
         end
 
@@ -349,7 +349,7 @@ describe CommentsController do
             put :freeze, params: { id: comment.id }
 
             expect(comment.reload.iced).to be_truthy
-            it_redirects_to_with_error(new_user_session_path, "Sorry, you don't have permission to access the page you were trying to reach. Please log in.")
+            it_redirects_to_user_login
           end
         end
 
@@ -602,7 +602,7 @@ describe CommentsController do
             put :unfreeze, params: { id: comment.id }
 
             expect(comment.reload.iced).to be_falsey
-            it_redirects_to_with_error(new_user_session_path, "Sorry, you don't have permission to access the page you were trying to reach. Please log in.")
+            it_redirects_to_user_login
           end
         end
 
@@ -853,7 +853,7 @@ describe CommentsController do
             put :unfreeze, params: { id: comment.id }
 
             expect(comment.reload.iced).to be_truthy
-            it_redirects_to_with_error(new_user_session_path, "Sorry, you don't have permission to access the page you were trying to reach. Please log in.")
+            it_redirects_to_user_login
           end
         end
 

--- a/spec/controllers/comments/hide_spec.rb
+++ b/spec/controllers/comments/hide_spec.rb
@@ -56,7 +56,7 @@ describe CommentsController do
             put :hide, params: { id: comment.id }
 
             expect(comment.reload.hidden_by_admin?).to be_falsey
-            it_redirects_to_with_error(new_user_session_path, "Sorry, you don't have permission to access the page you were trying to reach. Please log in.")
+            it_redirects_to_user_login
           end
         end
 
@@ -226,7 +226,7 @@ describe CommentsController do
             put :hide, params: { id: comment.id }
 
             expect(comment.reload.hidden_by_admin?).to be_truthy
-            it_redirects_to_with_error(new_user_session_path, "Sorry, you don't have permission to access the page you were trying to reach. Please log in.")
+            it_redirects_to_user_login
           end
         end
 
@@ -398,7 +398,7 @@ describe CommentsController do
             put :unhide, params: { id: comment.id }
 
             expect(comment.reload.hidden_by_admin?).to be_truthy
-            it_redirects_to_with_error(new_user_session_path, "Sorry, you don't have permission to access the page you were trying to reach. Please log in.")
+            it_redirects_to_user_login
           end
         end
 
@@ -568,7 +568,7 @@ describe CommentsController do
             put :unhide, params: { id: comment.id }
 
             expect(comment.reload.hidden_by_admin?).to be_falsey
-            it_redirects_to_with_error(new_user_session_path, "Sorry, you don't have permission to access the page you were trying to reach. Please log in.")
+            it_redirects_to_user_login
           end
         end
 

--- a/spec/controllers/comments/reply_spec.rb
+++ b/spec/controllers/comments/reply_spec.rb
@@ -21,13 +21,13 @@ describe CommentsController do
       context "when comment is unreviewed" do
         it "redirects logged out user to login path with an error" do
           get :add_comment_reply, params: { comment_id: unreviewed_comment.id }
-          it_redirects_to_user_login("Sorry, you cannot reply to an unapproved comment.")
+          it_redirects_to_with_error(new_user_session_path, "Sorry, you cannot reply to an unapproved comment.")
         end
 
         it "redirects logged in user to root path with an error" do
           fake_login
           get :add_comment_reply, params: { comment_id: unreviewed_comment.id }
-          it_redirects_to_user_login("Sorry, you cannot reply to an unapproved comment.")
+          it_redirects_to_with_error(root_path, "Sorry, you cannot reply to an unapproved comment.")
         end
       end
 

--- a/spec/controllers/comments/reply_spec.rb
+++ b/spec/controllers/comments/reply_spec.rb
@@ -21,13 +21,13 @@ describe CommentsController do
       context "when comment is unreviewed" do
         it "redirects logged out user to login path with an error" do
           get :add_comment_reply, params: { comment_id: unreviewed_comment.id }
-          it_redirects_to_with_error(new_user_session_path, "Sorry, you cannot reply to an unapproved comment.")
+          it_redirects_to_user_login("Sorry, you cannot reply to an unapproved comment.")
         end
 
         it "redirects logged in user to root path with an error" do
           fake_login
           get :add_comment_reply, params: { comment_id: unreviewed_comment.id }
-          it_redirects_to_with_error(root_path, "Sorry, you cannot reply to an unapproved comment.")
+          it_redirects_to_user_login("Sorry, you cannot reply to an unapproved comment.")
         end
       end
 

--- a/spec/controllers/gifts_controller_spec.rb
+++ b/spec/controllers/gifts_controller_spec.rb
@@ -11,7 +11,7 @@ describe GiftsController do
 
     it "errors and redirects to login page if no user is logged on" do
       post :toggle_rejected, params: { id: gift.id }
-      it_redirects_to_with_error(new_user_session_path, "Sorry, you don't have permission to access the page you were trying to reach. Please log in.")
+      it_redirects_to_user_login
     end
 
     it "errors and redirects to homepage if the gift's recipient is not logged on" do

--- a/spec/controllers/invitations_controller_spec.rb
+++ b/spec/controllers/invitations_controller_spec.rb
@@ -14,7 +14,7 @@ describe InvitationsController do
         fake_login_admin(admin)
         get :index, params: { user_id: user.login }
 
-        it_redirects_to_with_error(new_user_session_path, "Sorry, you don't have permission to access the page you were trying to reach. Please log in.")
+        it_redirects_to_user_login
       end
     end
 
@@ -36,7 +36,7 @@ describe InvitationsController do
         fake_login_admin(admin)
         get :manage, params: { user_id: user.login }
 
-        it_redirects_to_with_error(new_user_session_path, "Sorry, you don't have permission to access the page you were trying to reach. Please log in.")
+        it_redirects_to_user_login
       end
     end
 
@@ -60,7 +60,7 @@ describe InvitationsController do
         it "redirects with error" do
           get :show, params: { user_id: user.login, id: invitation.id }
 
-          it_redirects_to_with_error(new_user_session_path, "Sorry, you don't have permission to access the page you were trying to reach. Please log in.")
+          it_redirects_to_user_login
         end
       end
 
@@ -87,7 +87,7 @@ describe InvitationsController do
           fake_login_admin(admin)
           get :show, params: { user_id: user.login, id: invitation.id }
 
-          it_redirects_to_with_error(new_user_session_path, "Sorry, you don't have permission to access the page you were trying to reach. Please log in.")
+          it_redirects_to_user_login
         end
       end
 
@@ -107,7 +107,7 @@ describe InvitationsController do
         it "redirects with error" do
           get :show, params: { id: invitation.id }
 
-          it_redirects_to_with_error(new_user_session_path, "Sorry, you don't have permission to access the page you were trying to reach. Please log in.")
+          it_redirects_to_user_login
         end
       end
 
@@ -134,7 +134,7 @@ describe InvitationsController do
           fake_login_admin(admin)
           get :show, params: { id: invitation.id }
 
-          it_redirects_to_with_error(new_user_session_path, "Sorry, you don't have permission to access the page you were trying to reach. Please log in.")
+          it_redirects_to_user_login
         end
       end
 

--- a/spec/controllers/opendoors/tools_controller_spec.rb
+++ b/spec/controllers/opendoors/tools_controller_spec.rb
@@ -11,7 +11,7 @@ describe Opendoors::ToolsController do
     it "denies access if not logged in with Open Doors privileges" do
       fake_logout
       get :index
-      it_redirects_to_with_error(new_user_session_path, "Sorry, you don't have permission to access the page you were trying to reach. Please log in.")
+      it_redirects_to_user_login
 
       fake_login_known_user(user)
       get :index
@@ -40,7 +40,7 @@ describe Opendoors::ToolsController do
     it "denies access if not logged in with Open Doors privileges" do
       fake_logout
       post :url_update
-      it_redirects_to_with_error(new_user_session_path, "Sorry, you don't have permission to access the page you were trying to reach. Please log in.")
+      it_redirects_to_user_login
 
       fake_login_known_user(user)
       post :url_update

--- a/spec/controllers/owned_tag_sets_controller_spec.rb
+++ b/spec/controllers/owned_tag_sets_controller_spec.rb
@@ -183,7 +183,7 @@ describe OwnedTagSetsController do
     context "where user is not logged in" do
       it "shows the access denied path" do
         post :create
-        it_redirects_to_with_error(new_user_session_path, "Sorry, you don't have permission to access the page you were trying to reach. Please log in.")
+        it_redirects_to_user_login
       end
     end
 

--- a/spec/controllers/readings_controller_spec.rb
+++ b/spec/controllers/readings_controller_spec.rb
@@ -12,14 +12,14 @@ describe ReadingsController do
         it "redirects to login page with error" do
           fake_login_admin(create(:admin))
           get :index, params: { user_id: user }
-          it_redirects_to_with_error(new_user_session_path, "Sorry, you don't have permission to access the page you were trying to reach. Please log in.")
+          it_redirects_to_user_login
         end
       end
 
       context "when logged out" do
         it "redirects to login page with error" do
           get :index, params: { user_id: user }
-          it_redirects_to_with_error(new_user_session_path, "Sorry, you don't have permission to access the page you were trying to reach. Please log in.")
+          it_redirects_to_user_login
         end
       end
 
@@ -190,7 +190,7 @@ describe ReadingsController do
       it "redirects to login page with error" do
         post :clear, params: { user_id: user }
 
-        it_redirects_to_with_error(new_user_session_path, "Sorry, you don't have permission to access the page you were trying to reach. Please log in.")
+        it_redirects_to_user_login
       end
     end
 

--- a/spec/controllers/related_works_controller_spec.rb
+++ b/spec/controllers/related_works_controller_spec.rb
@@ -117,7 +117,7 @@ describe RelatedWorksController do
       end
 
       it "sets a flash message and redirects the requester" do
-        it_redirects_to_with_error(related_work_path(related_work), "Sorry, but you don't have permission to do that.")
+        it_redirects_to_with_error(root_path, "Sorry, but you don't have permission to do that.")
       end
     end
 

--- a/spec/controllers/related_works_controller_spec.rb
+++ b/spec/controllers/related_works_controller_spec.rb
@@ -15,7 +15,7 @@ describe RelatedWorksController do
       end
 
       it "sets a flash message and redirects the requester" do
-        it_redirects_to_with_error(user_related_works_path, "Whose related works were you looking for?") 
+        it_redirects_to_with_error(search_people_path, "Whose related works were you looking for?")
       end
     end
 
@@ -25,7 +25,7 @@ describe RelatedWorksController do
       end
 
       it "sets a flash message and redirects the requester" do
-        it_redirects_to_with_error(user_related_works_path, "Sorry, we couldn't find that user")
+        it_redirects_to_with_error(search_people_path, "Sorry, we couldn't find that user")
       end
     end
 

--- a/spec/controllers/subscriptions_controller_spec.rb
+++ b/spec/controllers/subscriptions_controller_spec.rb
@@ -16,8 +16,7 @@ describe SubscriptionsController do
 
     it "redirects to login when not logged in" do
       get :index, params: { user_id: user.login }
-      it_redirects_to_with_error(new_user_session_path,
-                                 "Sorry, you don't have permission to access the page you were trying to reach. Please log in.")
+      it_redirects_to_user_login
     end
 
     context "when logged in" do

--- a/spec/controllers/tag_set_associations_controller_spec.rb
+++ b/spec/controllers/tag_set_associations_controller_spec.rb
@@ -17,8 +17,7 @@ describe TagSetAssociationsController do
     context "when user is not logged in" do
       it "redirects and returns an error message" do
         put :update_multiple, params: { tag_set_id: owned_tag_set.id }
-        it_redirects_to_with_error(new_user_session_path, "Sorry, you don't have permission to access the page you " \
-          "were trying to reach. Please log in.")
+        it_redirects_to_user_login
       end
     end
 

--- a/spec/controllers/tag_set_nominations_controller_spec.rb
+++ b/spec/controllers/tag_set_nominations_controller_spec.rb
@@ -23,8 +23,7 @@ describe TagSetNominationsController do
     context 'user is not logged in' do
       it 'redirects and returns an error message' do
         get :index, params: { user_id: moderator.login, tag_set_id: owned_tag_set.id }
-        it_redirects_to_with_error(new_user_session_path, "Sorry, you don't have permission to access the page you " \
-          "were trying to reach. Please log in.")
+        it_redirects_to_user_login
       end
     end
 
@@ -412,8 +411,7 @@ describe TagSetNominationsController do
     context 'user is not logged in' do
       it 'redirects and returns an error message' do
         get :show, params: { id: tag_set_nomination.id, tag_set_id: owned_tag_set.id }
-        it_redirects_to_with_error(new_user_session_path, "Sorry, you don't have permission to access the page you " \
-          "were trying to reach. Please log in.")
+        it_redirects_to_user_login
       end
     end
 
@@ -490,8 +488,7 @@ describe TagSetNominationsController do
     context 'user is not logged in' do
       it 'redirects and returns an error message' do
         get :new, params: { tag_set_id: owned_tag_set.id }
-        it_redirects_to_with_error(new_user_session_path, "Sorry, you don't have permission to access the page you " \
-          "were trying to reach. Please log in.")
+        it_redirects_to_user_login
       end
     end
 
@@ -600,8 +597,7 @@ describe TagSetNominationsController do
     context 'user is not logged in' do
       it 'redirects and returns an error message' do
         get :edit, params: { id: tag_set_nomination.id, tag_set_id: owned_tag_set.id }
-        it_redirects_to_with_error(new_user_session_path, "Sorry, you don't have permission to access the page you " \
-          "were trying to reach. Please log in.")
+        it_redirects_to_user_login
       end
     end
 
@@ -763,8 +759,7 @@ describe TagSetNominationsController do
     context 'user is not logged in' do
       it 'redirects and returns an error message' do
         post :create, params: { tag_set_id: owned_tag_set.id }
-        it_redirects_to_with_error(new_user_session_path, "Sorry, you don't have permission to access the page you " \
-          "were trying to reach. Please log in.")
+        it_redirects_to_user_login
       end
     end
 
@@ -938,8 +933,7 @@ describe TagSetNominationsController do
     context 'user is not logged in' do
       it 'redirects and returns an error message' do
         put :update, params: { tag_set_id: owned_tag_set.id, id: tag_set_nomination.id }
-        it_redirects_to_with_error(new_user_session_path, "Sorry, you don't have permission to access the page you " \
-          "were trying to reach. Please log in.")
+        it_redirects_to_user_login
       end
     end
 
@@ -1191,8 +1185,7 @@ describe TagSetNominationsController do
     context 'user is not logged in' do
       it 'redirects and returns an error message' do
         delete :destroy, params: { id: tag_set_nomination.id, tag_set_id: owned_tag_set.id }
-        it_redirects_to_with_error(new_user_session_path, "Sorry, you don't have permission to access the page you " \
-          "were trying to reach. Please log in.")
+        it_redirects_to_user_login
       end
     end
 
@@ -1296,8 +1289,7 @@ describe TagSetNominationsController do
     context 'user is not logged in' do
       it 'redirects and returns an error message' do
         get :confirm_destroy_multiple, params: { tag_set_id: owned_tag_set.id }
-        it_redirects_to_with_error(new_user_session_path, "Sorry, you don't have permission to access the page you " \
-          "were trying to reach. Please log in.")
+        it_redirects_to_user_login
       end
     end
 
@@ -1333,8 +1325,7 @@ describe TagSetNominationsController do
     context 'user is not logged in' do
       it 'redirects and returns an error message' do
         delete :destroy_multiple, params: { tag_set_id: owned_tag_set.id }
-        it_redirects_to_with_error(new_user_session_path, "Sorry, you don't have permission to access the page you " \
-          "were trying to reach. Please log in.")
+        it_redirects_to_user_login
       end
     end
 
@@ -1373,8 +1364,7 @@ describe TagSetNominationsController do
     context 'user is not logged in' do
       it 'redirects and returns an error message' do
         put :update_multiple, params: { tag_set_id: owned_tag_set.id }
-        it_redirects_to_with_error(new_user_session_path, "Sorry, you don't have permission to access the page you " \
-          "were trying to reach. Please log in.")
+        it_redirects_to_user_login
       end
     end
 

--- a/spec/controllers/troubleshooting_controller_spec.rb
+++ b/spec/controllers/troubleshooting_controller_spec.rb
@@ -15,7 +15,7 @@ describe TroubleshootingController do
     context "when logged out" do
       it "errors and redirects to the login page" do
         get :show, params: { tag_id: tag.to_param }
-        it_redirects_to_with_error(new_user_session_path, "Sorry, you don't have permission to access the page you were trying to reach. Please log in.")
+        it_redirects_to_user_login
       end
     end
 
@@ -69,7 +69,7 @@ describe TroubleshootingController do
     context "when logged out" do
       it "errors and redirects to the login page" do
         put :update, params: { tag_id: tag.to_param, actions: ["fix_counts"] }
-        it_redirects_to_with_error(new_user_session_path, "Sorry, you don't have permission to access the page you were trying to reach. Please log in.")
+        it_redirects_to_user_login
       end
     end
 

--- a/spec/controllers/unsorted_tags_controller_spec.rb
+++ b/spec/controllers/unsorted_tags_controller_spec.rb
@@ -13,10 +13,7 @@ describe UnsortedTagsController do
       end
 
       it "redirects with an error" do
-        it_redirects_to_with_error(
-          new_user_session_path,
-          "Sorry, you don't have permission to access the page you were trying to reach. Please log in."
-        )
+        it_redirects_to_user_login
       end
     end
 

--- a/spec/controllers/works/default_rails_actions_spec.rb
+++ b/spec/controllers/works/default_rails_actions_spec.rb
@@ -180,8 +180,7 @@ describe WorksController, work_search: true do
   describe "new" do
     it "doesn't return the form for anyone not logged in" do
       get :new
-      it_redirects_to_with_error(new_user_session_path,
-                                 "Sorry, you don't have permission to access the page you were trying to reach. Please log in.")
+      it_redirects_to_user_login
     end
 
     it "renders the form if logged in" do

--- a/spec/controllers/works/default_rails_actions_spec.rb
+++ b/spec/controllers/works/default_rails_actions_spec.rb
@@ -32,8 +32,7 @@ describe WorksController, work_search: true do
     context "when no work search parameters are given" do
       it "redirects to the login screen when no user is logged in" do
         get :clean_work_search_params, params: params
-        it_redirects_to_with_error(new_user_session_path,
-                                   "Sorry, you don't have permission to access the page you were trying to reach. Please log in.")
+        it_redirects_to_user_login
       end
     end
 

--- a/spec/controllers/works/drafts_spec.rb
+++ b/spec/controllers/works/drafts_spec.rb
@@ -31,7 +31,7 @@ describe WorksController do
 
       it "redirects to the login page and displays a error message" do
         get :drafts, params: { user_id: drafts_user.login }
-        it_redirects_to_user_login("You can only see your own drafts, sorry!")
+        it_redirects_to_with_error(new_user_session_path, "You can only see your own drafts, sorry!")
       end
     end
 

--- a/spec/controllers/works/drafts_spec.rb
+++ b/spec/controllers/works/drafts_spec.rb
@@ -31,8 +31,7 @@ describe WorksController do
 
       it "redirects to the login page and displays a error message" do
         get :drafts, params: { user_id: drafts_user.login }
-        it_redirects_to_with_error(new_user_session_path,
-                                   "You can only see your own drafts, sorry!")
+        it_redirects_to_user_login("You can only see your own drafts, sorry!")
       end
     end
 

--- a/spec/support/redirect_expectation_helper.rb
+++ b/spec/support/redirect_expectation_helper.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
 module RedirectExpectationHelper
+  def it_redirects_to_user_login(notice = "Sorry, you don't have permission to access the page you were trying to reach. Please log in.")
+    it_redirects_to_with_error(new_user_session_path(return_to: request.fullpath), notice)
+  end
+
   def it_redirects_to_with_notice(path, notice)
     it_redirects_to_simple(path)
     expect(flash[:notice]).to eq notice


### PR DESCRIPTION
(Blocked by #5171)

# Pull Request Checklist

<!-- Mark steps in the checklist as complete by changing `[ ]` to `[X]` -->
* [x] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [ ] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [x] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [x] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-5949

## Purpose

Replaces cookie-based redirection (`store_location` & `redirect_back_or_default`) with other forms of redirects.

Most redirects have been updated to either point to specific paths or redirect to the referrer (if its a non-GET request).

The user login form now takes a `redirect_to` parameter (e.g. `?return_to=/works/12345`).
To ensure that it doesn't redirect anywhere outside the archive the path is checked to start with exactly one `/` and be recognized as a relative URI.

Chapter and work edit/preview/manage cancel buttons are special as there are many ways to navigate to them. It feels bad to press cancel and go to some page you weren’t on before, so these pages keep track of where they generally came from via either a hidden form tag or a url parameter (and redirect appropriately). I’ve hardcoded the sources (e.g. `manage` or `edit-tags`) rather than storing the full paths, but that can be changed if needed.

### Notable redirect changes

**Viewing draft work > Edit > Cancel | Viewing draft work > Edit > Preview > Cancel**
Redirects back to the draft work, instead of user drafts. Creating a draft and cancelling the preview is unchanged.

**Edit Work Page > Edit Chapter X > Cancel**
Redirects back to the edit work page, rather than the work page.

**Manage Chapters Page > Edit > Cancel**
Redirects back to the manage chapters page, rather than the edited chapter's page.

**Edit Work Page > Add Chapter > Cancel**
Redirects back to the edit work page, rather than the work page.

**? > New Orphan > Cancel**
When orphaning…
* One work → Edit work page
* Multiple works → Show multiple works (user page)
* Series → Edit series page
* Pseud → User pseuds page
* User → User page

### Miscellaneous other changes
These can be reverted or split off if necessary.

* The cancel button on the delete user confirmation page did not work previously (it would lead to a 204).
  * Now it redirects to the user page (unchanged from intended functionality).
* Closed an unclosed \<p\> tag in app/views/chapters/manage.html.erb

## Testing Instructions

TBD. Will be posted on JIRA.

## Credit

marcus8448 (he/him)