### PR TITLE
AO3-6588 Allow Open Doors and Support admins to set no_resets role

### DIFF
--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -29,7 +29,7 @@ class UserPolicy < ApplicationPolicy
 
   # Define which admin roles can edit which user roles.
   ALLOWED_USER_ROLES_BY_ADMIN_ROLES = {
-    "open_doors" => %w[archivist opendoors],
+    "open_doors" => %w[archivist no_resets opendoors],
     "policy_and_abuse" => %w[no_resets protected_user],
     "superadmin" => %w[archivist no_resets official opendoors protected_user tag_wrangler],
     "tag_wrangling" => %w[tag_wrangler]

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -23,7 +23,7 @@ class UserPolicy < ApplicationPolicy
     "open_doors" => [roles: []],
     "policy_and_abuse" => [:email, { roles: [] }],
     "superadmin" => [:email, { roles: [] }],
-    "support" => %i[email],
+    "support" => [:email, { roles: [] }],
     "tag_wrangling" => [roles: []]
   }.freeze
 
@@ -32,6 +32,7 @@ class UserPolicy < ApplicationPolicy
     "open_doors" => %w[archivist no_resets opendoors],
     "policy_and_abuse" => %w[no_resets protected_user],
     "superadmin" => %w[archivist no_resets official opendoors protected_user tag_wrangler],
+    "support" => %w[no_resets],
     "tag_wrangling" => %w[tag_wrangler]
   }.freeze
 

--- a/spec/controllers/admin/admin_users_controller_spec.rb
+++ b/spec/controllers/admin/admin_users_controller_spec.rb
@@ -198,6 +198,30 @@ describe Admin::AdminUsersController do
         end
       end
 
+      context "with role support" do
+        before do
+          admin.update!(roles: ["support"])
+          user.update!(roles: [])
+          role.update!(name: "no_resets")
+        end
+
+        it "allows updating email" do
+          put :update, params: { id: user.login, user: { email: "updated@example.com" } }
+          expect(user.reload.email).to eq("updated@example.com")
+        end
+
+        it "allows updating roles" do
+          expect do
+            put :update, params: { id: user.login, user: { roles: [role.id.to_s] } }
+          end.to change { user.reload.roles.pluck(:name) }
+                   .from([])
+                   .to([role.name])
+                   .and avoid_changing { user.reload.email }
+
+          it_redirects_to_with_notice(root_path, "User was successfully updated.")
+        end
+      end
+
       context "with role tag_wrangling" do
         before do
           admin.update!(roles: ["tag_wrangling"])
@@ -221,31 +245,6 @@ describe Admin::AdminUsersController do
             .and avoid_changing { user.reload.email }
 
           it_redirects_to_with_notice(root_path, "User was successfully updated.")
-        end
-      end
-
-      # Keep the array in case we need to add another role like this.
-      %w[support].each do |admin_role|
-        context "with role #{admin_role}" do
-          before { admin.update!(roles: [admin_role]) }
-
-          it "does not allow updating roles" do
-            expect do
-              put :update, params: { id: user.login, user: { roles: [role.id.to_s] } }
-            end.to raise_exception(ActionController::UnpermittedParameters)
-            expect(user.reload.roles).not_to include(role)
-          end
-
-          it "allows updating email" do
-            expect do
-              put :update, params: { id: user.login, user: { email: "updated@example.com" } }
-            end.to change { user.reload.email }
-              .from("user@example.com")
-              .to("updated@example.com")
-              .and avoid_changing { user.reload.roles.pluck(:name) }
-
-            it_redirects_to_with_notice(root_path, "User was successfully updated.")
-          end
         end
       end
 

--- a/spec/controllers/admin/admin_users_controller_spec.rb
+++ b/spec/controllers/admin/admin_users_controller_spec.rb
@@ -214,9 +214,9 @@ describe Admin::AdminUsersController do
           expect do
             put :update, params: { id: user.login, user: { roles: [role.id.to_s] } }
           end.to change { user.reload.roles.pluck(:name) }
-                   .from([])
-                   .to([role.name])
-                   .and avoid_changing { user.reload.email }
+            .from([])
+            .to([role.name])
+            .and avoid_changing { user.reload.email }
 
           it_redirects_to_with_notice(root_path, "User was successfully updated.")
         end

--- a/spec/controllers/admin/admin_users_controller_spec.rb
+++ b/spec/controllers/admin/admin_users_controller_spec.rb
@@ -187,11 +187,12 @@ describe Admin::AdminUsersController do
         end
 
         it "allows updating roles" do
+          role_no_resets = create(:role, name: "no_resets")
           expect do
-            put :update, params: { id: user.login, user: { roles: [role.id.to_s] } }
+            put :update, params: { id: user.login, user: { roles: [role.id.to_s, role_no_resets.id.to_s] } }
           end.to change { user.reload.roles.pluck(:name) }
             .from([old_role.name])
-            .to([role.name])
+            .to([role.name, role_no_resets.name])
             .and avoid_changing { user.reload.email }
 
           it_redirects_to_with_notice(root_path, "User was successfully updated.")


### PR DESCRIPTION
# Pull Request Checklist

## Issue

https://otwarchive.atlassian.net/browse/AO3-6588

## Purpose

Allow Open Doors admins to give the no_resets role to user accounts.