### PR TITLE
AO3-6166 Fix two more pages showing unrevealed/hidden work title

### DIFF
--- a/app/controllers/collection_items_controller.rb
+++ b/app/controllers/collection_items_controller.rb
@@ -2,6 +2,7 @@ class CollectionItemsController < ApplicationController
   before_action :load_collection
   before_action :load_user, only: [:update_multiple]
   before_action :load_collectible_item, only: [:new, :create]
+  before_action :check_parent_visible, only: [:new]
 
   cache_sweeper :collection_sweeper
 
@@ -51,6 +52,10 @@ class CollectionItemsController < ApplicationController
     elsif params[:bookmark_id]
       @item = Bookmark.find(params[:bookmark_id])
     end
+  end
+
+  def check_parent_visible
+    check_visibility_for(@item)
   end
 
   def load_user

--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -13,6 +13,7 @@ class WorksController < ApplicationController
   # admins should have the ability to edit tags (:edit_tags, :update_tags) as per our ToS
   before_action :check_ownership_or_admin, only: [:edit_tags, :update_tags]
   before_action :log_admin_activity, only: [:update_tags]
+  before_action :check_parent_visible, only: [:navigate]
   before_action :check_visibility, only: [:show, :navigate, :share, :mark_for_later, :mark_as_read]
 
   before_action :load_first_chapter, only: [:show, :edit, :update, :preview]
@@ -788,6 +789,10 @@ class WorksController < ApplicationController
 
     @check_ownership_of = @work
     @check_visibility_of = @work
+  end
+
+  def check_parent_visible
+    check_visibility_for(@work)
   end
 
   def load_first_chapter

--- a/spec/controllers/collection_items_controller_spec.rb
+++ b/spec/controllers/collection_items_controller_spec.rb
@@ -270,23 +270,31 @@ describe CollectionItemsController do
     end
   end
 
-  describe "GET #create" do
-    context "creation" do
-      let(:collection) { FactoryBot.create(:collection) }
+  describe "GET #new" do
+    context "denies access for work that isn't visible to user" do
+      subject { get :new, params: { work_id: work.id } }
+      let(:success) { expect(response).to render_template("new") }
+      let(:success_admin) { success }
 
-      it "fails if collection names missing" do
-        get :create, params: { collection_id: collection.id }
-        it_redirects_to_with_error(root_path, "What collections did you want to add?")
-      end
-
-      it "fails if items missing" do
-        get :create, params: { collection_names: collection.name, collection_id: collection.id }
-        it_redirects_to_with_error(root_path, "What did you want to add to a collection?")
-      end
+      include_examples "denies access for work that isn't visible to user"
     end
   end
 
   describe "POST #create" do
+    context "creation" do
+      let(:collection) { FactoryBot.create(:collection) }
+
+      it "fails if collection names missing" do
+        post :create, params: { collection_id: collection.id }
+        it_redirects_to_with_error(root_path, "What collections did you want to add?")
+      end
+
+      it "fails if items missing" do
+        post :create, params: { collection_names: collection.name, collection_id: collection.id }
+        it_redirects_to_with_error(root_path, "What did you want to add to a collection?")
+      end
+    end
+
     context "when logged in as the collection maintainer" do
       before { fake_login_known_user(collection.owners.first.user) }
 

--- a/spec/controllers/works/works_controller_spec.rb
+++ b/spec/controllers/works/works_controller_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe WorksController do
+  include LoginMacros
+  include RedirectExpectationHelper
+
+  describe "GET #navigate" do
+    context "denies access for work that isn't visible to user" do
+      subject { get :navigate, params: { id: work.id } }
+      let(:success) { expect(response).to render_template("navigate") }
+      let(:success_admin) { success }
+
+      include_examples "denies access for work that isn't visible to user"
+    end
+  end
+end


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6166

## Purpose

Prevent access to the add to collection page and chapter navigation page for unrevealed/hidden works.

## Testing Instructions

Make unrevealed work. Log in as another user and try to access:
* the page for inviting the work to a collection (https://test.archiveofourown.org/works/###/collection_items/new)  
* the work’s chapter index (https://test.archiveofourown.org/works/###/navigate)

## Credit

Bilka