### PR TITLE
AO3-6515 Fix 500 error for work end notes without posted chapters

### DIFF
--- a/app/helpers/works_helper.rb
+++ b/app/helpers/works_helper.rb
@@ -91,14 +91,12 @@ module WorksHelper
   end
 
   def get_endnotes_link
-    if current_page?({ controller: "chapters", action: "show" })
-      if @work.posted?
-        chapter_path(@work.last_posted_chapter.id, anchor: 'work_endnotes')
-      else
-        chapter_path(@work.last_chapter.id, anchor: 'work_endnotes')
-      end
+    return "#work_endnotes" unless current_page?({ controller: "chapters", action: "show" })
+
+    if @work.posted? && @work.last_posted_chapter
+      chapter_path(@work.last_posted_chapter.id, anchor: "work_endnotes")
     else
-      "#work_endnotes"
+      chapter_path(@work.last_chapter.id, anchor: "work_endnotes")
     end
   end
 

--- a/app/helpers/works_helper.rb
+++ b/app/helpers/works_helper.rb
@@ -90,13 +90,13 @@ module WorksHelper
     link_to ts("Mark for Later"), mark_for_later_work_path(work)
   end
 
-  def get_endnotes_link
+  def get_endnotes_link(work)
     return "#work_endnotes" unless current_page?({ controller: "chapters", action: "show" })
 
-    if @work.posted? && @work.last_posted_chapter
-      chapter_path(@work.last_posted_chapter.id, anchor: "work_endnotes")
+    if work.posted? && work.last_posted_chapter
+      chapter_path(work.last_posted_chapter.id, anchor: "work_endnotes")
     else
-      chapter_path(@work.last_chapter.id, anchor: "work_endnotes")
+      chapter_path(work.last_chapter.id, anchor: "work_endnotes")
     end
   end
 

--- a/app/views/works/_work_header_notes.html.erb
+++ b/app/views/works/_work_header_notes.html.erb
@@ -20,7 +20,7 @@
           <%= related_work_note(related_work.work, "translated_to") %>
         </li>
       <% else %>
-        <% related_works_link ||= link_to ts("other works inspired by this one"), get_related_works_url %>
+        <% related_works_link ||= link_to t(".inspired_by.other_works_inspired_by_this_one"), get_related_works_url %>
       <% end %>
     <% end %>
 
@@ -64,12 +64,16 @@
     </blockquote>
   <% end %>
 
-  <% endnotes_link = link_to (@work.notes.blank? ? ts("notes") : ts("more notes")), get_endnotes_link %>
-  <% if !@work.endnotes.blank? && related_works_link %>
-    <p class="jump">(<%= ts("See the end of the work for ") %><%= endnotes_link %><%= ts(" and ") %><%= related_works_link %>.)</p>
-  <% elsif !@work.endnotes.blank? %>
-    <p class="jump">(<%= ts("See the end of the work for ") %><%= endnotes_link %>.)</p>
-  <% elsif related_works_link %>
-    <p class="jump">(<%= ts("See the end of the work for ") %><%= related_works_link %>.)</p>
+  <% if @work.endnotes.present? || related_works_link %>
+    <% endnotes_link = link_to (@work.notes.blank? ? t(".jump.notes") : t(".jump.more_notes")), get_endnotes_link(@work) %>
+    <p class="jump">
+      <% if @work.endnotes.present? && related_works_link %>
+        <%= t(".jump.endnotes_and_related_works_html", endnotes_link: endnotes_link, related_works_link: related_works_link) %>
+      <% elsif !@work.endnotes.blank? %>
+        <%= t(".jump.endnotes_html", endnotes_link: endnotes_link) %>
+      <% elsif related_works_link %>
+        <%= t(".jump.related_works_html", related_works_link: related_works_link) %>
+      <% end %>
+    </p>
   <% end %>
 </div>

--- a/app/views/works/_work_header_notes.html.erb
+++ b/app/views/works/_work_header_notes.html.erb
@@ -69,7 +69,7 @@
     <p class="jump">
       <% if @work.endnotes.present? && related_works_link %>
         <%= t(".jump.endnotes_and_related_works_html", endnotes_link: endnotes_link, related_works_link: related_works_link) %>
-      <% elsif !@work.endnotes.blank? %>
+      <% elsif @work.endnotes.present? %>
         <%= t(".jump.endnotes_html", endnotes_link: endnotes_link) %>
       <% elsif related_works_link %>
         <%= t(".jump.related_works_html", related_works_link: related_works_link) %>

--- a/app/views/works/_work_header_notes.html.erb
+++ b/app/views/works/_work_header_notes.html.erb
@@ -1,16 +1,16 @@
 <div class="notes module">
   <h3 class="heading"><%= ts("Notes:") %></h3>
 
-  <% # We don't want the ul tag hanging around when it's empty (i.e. when there are no recipients, parent works, or claims) but we can't skip this entire section because line 25 generates the link to child works that appear under any notes. We repeat this logic on line 63 to close the ul. %>
+  <%# We don't want the ul tag hanging around when it's empty (i.e. when there are no recipients, parent works, or claims) but we can't skip this entire section because line 25 generates the link to child works that appear under any notes. We repeat this logic on line 63 to close the ul. %>
   <% if show_associations?(@work) %>
     <ul class="associations">
   <% end %>
-    <% # dedication %>
+    <%# dedication %>
     <% if @work.gifts.not_rejected.exists? %>
       <li><%= ts("For") %> <%= recipients_link(@work) %>.</li>
     <% end %>
 
-    <% # translations %>
+    <%# translations %>
     <%# i18n-tasks-use t("works.work_header_notes.translated_to.restricted_html") %>
     <%# i18n-tasks-use t("works.work_header_notes.translated_to.revealed_html") %>
     <%# i18n-tasks-use t("works.work_header_notes.translated_to.unrevealed_html") %>
@@ -24,7 +24,7 @@
       <% end %>
     <% end %>
 
-    <% # parent works %>
+    <%# parent works %>
     <%# i18n-tasks-use t("works.work_header_notes.translation_of.restricted_html") %>
     <%# i18n-tasks-use t("works.work_header_notes.translation_of.revealed_html") %>
     <%# i18n-tasks-use t("works.work_header_notes.translation_of.unrevealed") %>
@@ -40,7 +40,7 @@
       <% end %>
     <% end %>
 
-    <% # prompts %>
+    <%# prompts %>
     <% @work.challenge_claims.each do |claim| %>
       <% unless claim.request_prompt.nil? %>
         <li><%= ts("In response to a ") %><%= link_to("prompt", collection_prompt_path(claim.collection, claim.request_prompt)) %> <%= ts("by") %>
@@ -57,7 +57,7 @@
     </ul>
   <% end %>
 
-  <% # notes %>
+  <%# notes %>
   <% unless @work.notes.blank? %>
     <blockquote class="userstuff">
       <%=raw sanitize_field(@work, :notes) %>

--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -2455,9 +2455,16 @@ en:
         unrevealed: A work in an unrevealed collection
     work_header_notes:
       inspired_by:
+        other_works_inspired_by_this_one: other works inspired by this one
         restricted_html: Inspired by [Restricted Work] by %{creator_link} (Log in to access.)
         revealed_html: Inspired by %{work_link} by %{creator_link}
         unrevealed: Inspired by a work in an unrevealed collection
+      jump:
+        endnotes_and_related_works_html: "(See the end of the work for %{endnotes_link} and %{related_works_link}.)"
+        endnotes_html: "(See the end of the work for %{endnotes_link}.)"
+        more_notes: more notes
+        notes: notes
+        related_works_html: "(See the end of the work for %{related_works_link}.)"
       translated_to:
         restricted_html: 'Translation into %{language} available: [Restricted Work] by %{creator_link} (Log in to access.)'
         revealed_html: 'Translation into %{language} available: %{work_link} by %{creator_link}'

--- a/spec/helpers/works_helper_spec.rb
+++ b/spec/helpers/works_helper_spec.rb
@@ -71,34 +71,28 @@ describe WorksHelper do
       before { allow(helper).to receive(:current_page?).and_return(false) }
 
       it "returns #work_endnotes" do
-        expect(helper.get_endnotes_link).to eq("#work_endnotes")
+        expect(helper.get_endnotes_link(work)).to eq("#work_endnotes")
       end
     end
 
     context "chapters#show for a posted work" do
-      before do
-        @work = work
-        allow(helper).to receive(:current_page?).and_return(true)
-      end
+      before { allow(helper).to receive(:current_page?).and_return(true) }
 
       it "returns path to last posted chapter's endnotes" do
-        expect(helper.get_endnotes_link).to eq(chapter_path(work.last_posted_chapter, anchor: "work_endnotes"))
+        expect(helper.get_endnotes_link(work)).to eq(chapter_path(work.last_posted_chapter, anchor: "work_endnotes"))
       end
 
       it "returns path to last chapter's endnotes if no posted chapters" do
         chapter.destroy!
-        expect(helper.get_endnotes_link).to eq(chapter_path(work.last_chapter, anchor: "work_endnotes"))
+        expect(helper.get_endnotes_link(work)).to eq(chapter_path(work.last_chapter, anchor: "work_endnotes"))
       end
     end
 
     context "chapters#show for a draft work" do
-      before do
-        @work = unposted_work
-        allow(helper).to receive(:current_page?).and_return(true)
-      end
+      before { allow(helper).to receive(:current_page?).and_return(true) }
 
       it "returns path to last chapter's endnotes" do
-        expect(helper.get_endnotes_link).to eq(chapter_path(unposted_work.last_chapter, anchor: "work_endnotes"))
+        expect(helper.get_endnotes_link(unposted_work)).to eq(chapter_path(unposted_work.last_chapter, anchor: "work_endnotes"))
       end
     end
   end

--- a/spec/helpers/works_helper_spec.rb
+++ b/spec/helpers/works_helper_spec.rb
@@ -61,4 +61,45 @@ describe WorksHelper do
       expect(sorted_languages).to eq([indonesian, german, english, finnish])
     end
   end
+
+  describe "#get_endnotes_link" do
+    let(:work) { create(:work) }
+    let(:chapter) { create(:chapter, work: work) }
+    let(:unposted_work) { create(:draft) }
+
+    context "not on chapters#show" do
+      before { allow(helper).to receive(:current_page?).and_return(false) }
+
+      it "returns #work_endnotes" do
+        expect(helper.get_endnotes_link).to eq("#work_endnotes")
+      end
+    end
+
+    context "chapters#show for a posted work" do
+      before do
+        @work = work
+        allow(helper).to receive(:current_page?).and_return(true)
+      end
+
+      it "returns path to last posted chapter's endnotes" do
+        expect(helper.get_endnotes_link).to eq(chapter_path(work.last_posted_chapter, anchor: "work_endnotes"))
+      end
+
+      it "returns path to last chapter's endnotes if no posted chapters" do
+        chapter.destroy!
+        expect(helper.get_endnotes_link).to eq(chapter_path(work.last_chapter, anchor: "work_endnotes"))
+      end
+    end
+
+    context "chapters#show for a draft work" do
+      before do
+        @work = unposted_work
+        allow(helper).to receive(:current_page?).and_return(true)
+      end
+
+      it "returns path to last chapter's endnotes" do
+        expect(helper.get_endnotes_link).to eq(chapter_path(unposted_work.last_chapter, anchor: "work_endnotes"))
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6515

## Purpose

- Fix 500 error for work end notes without posted chapters. 
- Do not use instance variable `@work` for helper function. 
- Fix issue in view not having right syntax highlighting in GitHub.
- i18n

## Testing Instructions

See issue.