### PR TITLE
AO3-6235 Allow policy_and_abuse admins to toggle invite requests in settings

### DIFF
--- a/app/policies/admin_setting_policy.rb
+++ b/app/policies/admin_setting_policy.rb
@@ -8,6 +8,7 @@ class AdminSettingPolicy < ApplicationPolicy
       hide_spam
       invite_from_queue_enabled
       invite_from_queue_number
+      request_invite_enabled
       account_age_threshold_for_comment_spam_check
     ],
     "superadmin" => %i[

--- a/spec/controllers/admin/settings_controller_spec.rb
+++ b/spec/controllers/admin/settings_controller_spec.rb
@@ -94,6 +94,7 @@ describe Admin::SettingsController do
           hide_spam: true,
           invite_from_queue_enabled: false,
           invite_from_queue_number: 11,
+          request_invite_enabled: true,
           account_age_threshold_for_comment_spam_check: 10
         }.each_pair do |field, value|
           it "allows admins with policy_and_abuse role to update #{field}" do

--- a/spec/controllers/admin/settings_controller_spec.rb
+++ b/spec/controllers/admin/settings_controller_spec.rb
@@ -91,15 +91,15 @@ describe Admin::SettingsController do
         end
 
         {
-          hide_spam: true,
-          invite_from_queue_enabled: false,
+          account_age_threshold_for_comment_spam_check: 10,
+          hide_spam: 1,
+          invite_from_queue_enabled: 0,
           invite_from_queue_number: 11,
-          request_invite_enabled: true,
-          account_age_threshold_for_comment_spam_check: 10
+          request_invite_enabled: 1
         }.each_pair do |field, value|
           it "allows admins with policy_and_abuse role to update #{field}" do
             put :update, params: { id: setting.id, admin_setting: { field => value } }
-            expect(setting.reload.send(field)).to eq(value)
+            expect(setting.reload.read_attribute_before_type_cast(field)).to eq(value)
             it_redirects_to_with_notice(admin_settings_path, "Archive settings were successfully updated.")
           end
         end


### PR DESCRIPTION
# Pull Request Checklist

<!-- Mark steps in the checklist as complete by changing `[ ]` to `[X]` -->
* [X] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [X] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [X] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
  * ~~Tests were not added because a) this was a small change that was easily manually tested, and b) I couldn't find tests covering other permissions for `policy_and_abuse` archive settings. That being said, if I missed tests or if I should add tests, please let me know and I'll be happy to add them.~~
* [X] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [X] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-6235

## Purpose

This allows admins with the `policy_and_abuse` role to toggle invitation requests via Archive Settings.

## Testing Instructions

The JIRA ticket already has test instructions. However, additional testing can cover edge and negative cases:

* For an admin with additional roles including `policy_and_abuse`, test if you can toggle invitation requests (ex: an admin that has both the `policy_and_abuse` and `support` role).
* For an admin without `policy_and_abuse` role, check that you cannot toggle invitation requests.

## Credit

dismayonnaise (she/her)

💖 💖 Thank you!! 💖 💖 