### PR TITLE
AO3-7001 Permanently strip image embeds from comment notification emails

### DIFF
--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -532,9 +532,14 @@ class Comment < ApplicationRecord
     update_attribute(:hidden_by_admin, false)
   end
 
-  def sanitized_content
+  def sanitized_content(is_mailer = "false")
     sanitize_field(self, :comment_content, image_safety_mode: use_image_safety_mode?)
   end
+
+  def sanitized_mailer_content
+    sanitize_field(self, :comment_content, image_safety_mode: true)
+  end
+
 
   def use_image_safety_mode?
     pseud_id.nil? || hidden_by_admin || parent_type.in?(ArchiveConfig.PARENTS_WITH_IMAGE_SAFETY_MODE)

--- a/app/views/comment_mailer/comment_notification.html.erb
+++ b/app/views/comment_mailer/comment_notification.html.erb
@@ -9,7 +9,7 @@
     <i><b><%= style_link(@comment.ultimate_parent.commentable_name.html_safe, polymorphic_url(@comment.ultimate_parent, :only_path => false)) %></b></i>:
   <% end %>
 
-  <%= style_quote(raw(@comment.sanitized_content)) %>
+  <%= style_quote(raw(@comment.sanitized_mailer_content)) %>
 
   <%= render 'comment_notification_footer' %>
 

--- a/app/views/comment_mailer/comment_notification.text.erb
+++ b/app/views/comment_mailer/comment_notification.text.erb
@@ -3,6 +3,6 @@
 <% if @comment.ultimate_parent.is_a?(Tag) then %>the tag "<%= @comment.ultimate_parent.commentable_name %>" (<%= url_for(:controller => :tags, :action => :show, :id => @comment.ultimate_parent, :only_path => false) %>) <% else %>"<%= @comment.ultimate_parent.commentable_name.html_safe %>" (<%= polymorphic_url(@comment.ultimate_parent, :only_path => false) %>)<% end %>:
 <%= text_divider %>
 
-<%= to_plain_text(raw @comment.sanitized_content) %>
+<%= to_plain_text(raw @comment.sanitized_mailer_content)%>
 
 <%= render 'comment_notification_footer', formats: [:text] %><% end %>

--- a/app/views/comment_mailer/comment_reply_notification.html.erb
+++ b/app/views/comment_mailer/comment_reply_notification.html.erb
@@ -11,12 +11,12 @@
 
   <p>
     You wrote:
-    <%= style_quote(raw @your_comment.sanitized_content) %>
+    <%= style_quote(raw @your_comment.sanitized_mailer_content) %>
   </p>
 
   <p>
     <%= commenter_pseud_or_name_link(@comment) %> responded:
-    <%= style_quote(raw(@comment.sanitized_content)) %>
+    <%= style_quote(raw(@comment.sanitized_mailer_content)) %>
   </p>
 
   <%= render 'comment_notification_footer' %>

--- a/app/views/comment_mailer/comment_reply_notification.text.erb
+++ b/app/views/comment_mailer/comment_reply_notification.text.erb
@@ -4,13 +4,13 @@
 You wrote:
 <%= text_divider %>
 
-<%= to_plain_text(raw @your_comment.sanitized_content) %>
+<%= to_plain_text(raw @your_comment.sanitized_mailer_content) %>
 
 <%= text_divider %>
     
 <%= commenter_pseud_or_name_text(@comment) %> responded:
 <%= text_divider %>
 
-<%= to_plain_text(raw @comment.sanitized_content) %>
+<%= to_plain_text(raw @comment.sanitized_mailer_content) %>
 
 <%= render 'comment_notification_footer', formats: [:text] %><% end %>

--- a/app/views/comment_mailer/comment_reply_sent_notification.html.erb
+++ b/app/views/comment_mailer/comment_reply_sent_notification.html.erb
@@ -10,12 +10,12 @@
 
   <p>
     <%= commenter_pseud_or_name_link(@parent_comment) %> wrote:
-    <%= style_quote(raw @parent_comment.sanitized_content) %>
+    <%= style_quote(raw @parent_comment.sanitized_mailer_content) %>
   </p>
 
   <p>
     You responded:
-    <%= style_quote(raw @comment.sanitized_content) %>
+    <%= style_quote(raw @comment.sanitized_mailer_content) %>
   </p>
 
   <%= render 'comment_notification_footer' %>

--- a/app/views/comment_mailer/comment_reply_sent_notification.text.erb
+++ b/app/views/comment_mailer/comment_reply_sent_notification.text.erb
@@ -4,13 +4,13 @@ You replied to a comment on <% if @comment.ultimate_parent.is_a?(Tag) then %>the
 <%= commenter_pseud_or_name_text(@parent_comment) %> wrote:
 <%= text_divider %>
 
-<%= to_plain_text(raw @parent_comment.sanitized_content) %>
+<%= to_plain_text(raw @parent_comment.sanitized_mailer_content) %>
 
 <%= text_divider %>
 
 You responded:
 <%= text_divider %>
 
-<%= to_plain_text(raw @comment.sanitized_content) %>
+<%= to_plain_text(raw @comment.sanitized_mailer_content) %>
 
 <%= render 'comment_notification_footer', formats: [:text] %><% end %>

--- a/app/views/comment_mailer/comment_sent_notification.html.erb
+++ b/app/views/comment_mailer/comment_sent_notification.html.erb
@@ -8,7 +8,7 @@
     <i><b><%= style_link(@comment.ultimate_parent.commentable_name.html_safe, polymorphic_url(@comment.ultimate_parent, :only_path => false)) %></b></i>:
   <% end %>
 
-  <%= style_quote(raw @comment.sanitized_content) %>  
+  <%= style_quote(raw @comment.sanitized_mailer_content) %>
 
   <%= render 'comment_notification_footer' %>
   

--- a/app/views/comment_mailer/comment_sent_notification.text.erb
+++ b/app/views/comment_mailer/comment_sent_notification.text.erb
@@ -3,6 +3,6 @@ You left the following comment on <% if @comment.ultimate_parent.is_a?(Tag) then
 
 <%= text_divider %>
 
-<%= to_plain_text(raw @comment.sanitized_content) %>
+<%= to_plain_text(raw @comment.sanitized_mailer_content) %>
 
 <%= render 'comment_notification_footer', formats: [:text] %><% end %>

--- a/app/views/comment_mailer/edited_comment_notification.html.erb
+++ b/app/views/comment_mailer/edited_comment_notification.html.erb
@@ -10,7 +10,7 @@
   <% end %>
 
   <p>
-    <%= style_quote(raw(@comment.sanitized_content)) %>
+    <%= style_quote(raw(@comment.sanitized_mailer_content)) %>
   </p>
 
   <%= render 'comment_notification_footer' %>

--- a/app/views/comment_mailer/edited_comment_notification.text.erb
+++ b/app/views/comment_mailer/edited_comment_notification.text.erb
@@ -3,6 +3,6 @@
 <% if @comment.ultimate_parent.is_a?(Tag) then %>the tag "<%= @comment.ultimate_parent.commentable_name %>" (<%= url_for(:controller => :tags, :action => :show, :id => @comment.ultimate_parent, :only_path => false) %>) <% else %>"<%= @comment.ultimate_parent.commentable_name.html_safe %>" (<%= polymorphic_url(@comment.ultimate_parent, :only_path => false) %>)<% end %>:
 <%= text_divider %>
 
-<%= to_plain_text(raw @comment.sanitized_content) %>
+<%= to_plain_text(raw @comment.sanitized_mailer_content) %>
 
 <%= render 'comment_notification_footer', formats: [:text] %><% end %>

--- a/app/views/comment_mailer/edited_comment_reply_notification.html.erb
+++ b/app/views/comment_mailer/edited_comment_reply_notification.html.erb
@@ -11,12 +11,12 @@
 
   <p>
     You wrote:
-    <%= style_quote(raw @your_comment.sanitized_content) %>
+    <%= style_quote(raw @your_comment.sanitized_mailer_content) %>
   </p>
 
   <p>
     <%= commenter_pseud_or_name_link(@comment) %> edited their response to:
-    <%= style_quote(raw(@comment.sanitized_content)) %>
+    <%= style_quote(raw(@comment.sanitized_mailer_content)) %>
   </p>
 
   <%= render 'comment_notification_footer' %>

--- a/app/views/comment_mailer/edited_comment_reply_notification.text.erb
+++ b/app/views/comment_mailer/edited_comment_reply_notification.text.erb
@@ -4,13 +4,13 @@
 You wrote:
 <%= text_divider %>
 
-<%= to_plain_text(raw @your_comment.sanitized_content) %>
+<%= to_plain_text(raw @your_comment.sanitized_mailer_content) %>
 
 <%= text_divider %>
 
 <%= commenter_pseud_or_name_text(@comment) %> edited their response to:
 <%= text_divider %>
 
-<%= to_plain_text(raw @comment.sanitized_content) %>
+<%= to_plain_text(raw @comment.sanitized_mailer_content) %>
 
 <%= render 'comment_notification_footer', formats: [:text] %><% end %>


### PR DESCRIPTION
# Pull Request Checklist

<!-- Mark steps in the checklist as complete by changing `[ ]` to `[X]` -->
* [X ] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [ X] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [ ] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [ X] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [X] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-7001

## Purpose

This will permanently strip image embeds from comment notification emails.

## Testing Instructions

Instructions on JIRA.


## Credit
Scott (he/him)
