### PR TITLE
AO3-6925 Remove Open Challenges link from Subcollections page

### DIFF
--- a/.erb-lint.yml
+++ b/.erb-lint.yml
@@ -27,6 +27,8 @@ linters:
         Enabled: false
       Layout/TrailingWhitespace:
         Enabled: false
+      Layout/CommentIndentation:
+        Enabled: false
       Naming/FileName:
         Enabled: false
       Style/FrozenStringLiteralComment:

--- a/app/views/collections/index.html.erb
+++ b/app/views/collections/index.html.erb
@@ -31,22 +31,13 @@
   <% unless @user || @collection %>
     <li><%= link_to ts("Open Challenges"), list_challenges_collections_path %></li>
   <% end %>
-  <% if logged_in? %>
-    <%# Logged in user on own collections index gets links for user Collections and Manage Collection Items %>
-    <% if @user && @user == current_user %>
-      <li><%= span_if_current ts("Collections"), user_collections_path(@user) %></li>
+  <% if @user %>
+    <%# User collections index gets link for user Collections %>
+    <li><%= span_if_current ts("Collections"), user_collections_path(@user) %></li>
+    <%# Logged in user on own collections index gets link for Manage Collections Item %>
+    <% if logged_in? && @user && @user == current_user %>
       <li><%= link_to ts("Manage Collection Items"), user_collection_items_path(@user) %></li>
     <% end %>
-    <%# Logged in collection maintainer on own collection gets link for New Subcollection and all other logged in users get New Collection link %>
-    <% if @collection && !@collection.parent && @collection.user_is_maintainer?(current_user) %>
-      <li><%= link_to ts("New Subcollection"), new_collection_collection_path(@collection) %></li>
-    <% else %>
-      <li><%= link_to ts("New Collection"), new_collection_path %></li>
-    <% end %>
-  <% end %>
-  <% if @sort_and_filter %>
-    <%# Filters button for narrow screens jumps to filters when JavaScript is disabled and opens filters when JavaScript is enabled %>
-    <li class="narrow-shown hidden"><a href="#collection-filters" id="go_to_filters"><%= ts("Filters") %></a></li>
   <% end %>
 </ul>
 

--- a/app/views/collections/index.html.erb
+++ b/app/views/collections/index.html.erb
@@ -23,21 +23,21 @@
 <!--Subnavigation, sorting and actions-->
 <h3 class="landmark heading"><%= ts("Navigation") %></h3>
 <ul class="navigation actions">
-  <% # Collections and link unless a logged in user viewing own collections page %>
-  <% unless logged_in? && @user && @user == current_user  %>
+# Collections and link unless a logged in user viewing own collections page %>
+  <% unless logged_in? && @user && @user == current_user %>
     <li><%= span_if_current ts("Collections"), collections_path %></li>
   <% end %>
-  <% # Open Challenges link unless a logged in user viewing own collections page or on an individual collection page %>  
-  <% unless (logged_in? && @user && @user == current_user) || @collection  %>
-    <li><%= link_to ts("Open Challenges"), list_challenges_collections_path %></li>
+# Open Challenges link unless a logged in user viewing own collections page or on an individual collection page %>
+  <li><%= link_to ts("Open Challenges"), list_challenges_collections_path %></li>
+  <% unless (logged_in? && @user && @user == current_user) || @collection %>
   <% end %>
   <% if logged_in? %>
-    <% # Logged in user on own collections index gets links for user Collections and Manage Collection Items %>
+# Logged in user on own collections index gets links for user Collections and Manage Collection Items %>
     <% if @user && @user == current_user %>
       <li><%= span_if_current ts("Collections"), user_collections_path(@user) %></li>
       <li><%= link_to ts("Manage Collection Items"), user_collection_items_path(@user) %></li>
     <% end %>
-    <% # Logged in collection maintainer on own collection gets link for New Subcollection and all other logged in users get New Collection link %>
+# Logged in collection maintainer on own collection gets link for New Subcollection and all other logged in users get New Collection link %>
     <% if @collection && !@collection.parent && @collection.user_is_maintainer?(current_user) %>
       <li><%= link_to ts("New Subcollection"), new_collection_collection_path(@collection) %></li>
     <% else %>
@@ -45,7 +45,7 @@
     <% end %>
   <% end %>
   <% if @sort_and_filter %>
-    <% # Filters button for narrow screens jumps to filters when JavaScript is disabled and opens filters when JavaScript is enabled %>
+# Filters button for narrow screens jumps to filters when JavaScript is disabled and opens filters when JavaScript is enabled %>
     <li class="narrow-shown hidden"><a href="#collection-filters" id="go_to_filters"><%= ts("Filters") %></a></li>
   <% end %>
 </ul>
@@ -58,14 +58,14 @@
   <h3 class="landmark heading"><%= ts("List of Collections") %></h3>
   <ul class="collection picture index group">
     <% @collections.each do |collection| %>
-      <%= render :partial => "collection_blurb", :locals => {:collection => collection} %>
+      <%= render partial: "collection_blurb", locals: { collection: collection } %>
     <% end %>
   </ul>
 <% end %>
 
 <% if @sort_and_filter %>
   <!--filters subnav-->
-  <%= render 'collections/filters' %>
+  <%= render "collections/filters" %>
   <!---/subnav-->
 <% end %>
 

--- a/app/views/collections/index.html.erb
+++ b/app/views/collections/index.html.erb
@@ -22,10 +22,13 @@
 
 <!--Subnavigation, sorting and actions-->
 <h3 class="landmark heading"><%= ts("Navigation") %></h3>
-<ul class="navigation actions" role="navigation">
-  <% # Collections and Open Challenges links unless a logged in user viewing own collections page %>
-  <% unless logged_in? && @user && @user == current_user %>
+<ul class="navigation actions">
+  <% # Collections and link unless a logged in user viewing own collections page %>
+  <% unless logged_in? && @user && @user == current_user  %>
     <li><%= span_if_current ts("Collections"), collections_path %></li>
+  <% end %>
+  <% # Open Challenges link unless a logged in user viewing own collections page or on an individual collection page %>  
+  <% unless (logged_in? && @user && @user == current_user) || @collection  %>
     <li><%= link_to ts("Open Challenges"), list_challenges_collections_path %></li>
   <% end %>
   <% if logged_in? %>

--- a/app/views/collections/index.html.erb
+++ b/app/views/collections/index.html.erb
@@ -23,21 +23,21 @@
 <!--Subnavigation, sorting and actions-->
 <h3 class="landmark heading"><%= ts("Navigation") %></h3>
 <ul class="navigation actions">
-# Collections and link unless a logged in user viewing own collections page %>
+<% # Collections link unless a logged in user viewing own collections page %>
   <% unless logged_in? && @user && @user == current_user %>
     <li><%= span_if_current ts("Collections"), collections_path %></li>
   <% end %>
-# Open Challenges link unless a logged in user viewing own collections page or on an individual collection page %>
+<% # Open Challenges link unless a logged in user viewing own collections page or on an individual collection page %>
   <li><%= link_to ts("Open Challenges"), list_challenges_collections_path %></li>
   <% unless (logged_in? && @user && @user == current_user) || @collection %>
   <% end %>
   <% if logged_in? %>
-# Logged in user on own collections index gets links for user Collections and Manage Collection Items %>
+<% # Logged in user on own collections index gets links for user Collections and Manage Collection Items %>
     <% if @user && @user == current_user %>
       <li><%= span_if_current ts("Collections"), user_collections_path(@user) %></li>
       <li><%= link_to ts("Manage Collection Items"), user_collection_items_path(@user) %></li>
     <% end %>
-# Logged in collection maintainer on own collection gets link for New Subcollection and all other logged in users get New Collection link %>
+<% # Logged in collection maintainer on own collection gets link for New Subcollection and all other logged in users get New Collection link %>
     <% if @collection && !@collection.parent && @collection.user_is_maintainer?(current_user) %>
       <li><%= link_to ts("New Subcollection"), new_collection_collection_path(@collection) %></li>
     <% else %>
@@ -45,7 +45,7 @@
     <% end %>
   <% end %>
   <% if @sort_and_filter %>
-# Filters button for narrow screens jumps to filters when JavaScript is disabled and opens filters when JavaScript is enabled %>
+<% # Filters button for narrow screens jumps to filters when JavaScript is disabled and opens filters when JavaScript is enabled %>
     <li class="narrow-shown hidden"><a href="#collection-filters" id="go_to_filters"><%= ts("Filters") %></a></li>
   <% end %>
 </ul>
@@ -58,7 +58,7 @@
   <h3 class="landmark heading"><%= ts("List of Collections") %></h3>
   <ul class="collection picture index group">
     <% @collections.each do |collection| %>
-      <%= render partial: "collection_blurb", locals: { collection: collection } %>
+      <%= render "collection_blurb", collection: collection %>
     <% end %>
   </ul>
 <% end %>

--- a/app/views/collections/index.html.erb
+++ b/app/views/collections/index.html.erb
@@ -23,21 +23,21 @@
 <!--Subnavigation, sorting and actions-->
 <h3 class="landmark heading"><%= ts("Navigation") %></h3>
 <ul class="navigation actions">
-<% # Collections link unless a logged in user viewing own collections page %>
-  <% unless logged_in? && @user && @user == current_user %>
+  <%# Collections link unless a logged in user viewing own collections page %>
+  <% unless @user %>
     <li><%= span_if_current ts("Collections"), collections_path %></li>
   <% end %>
-<% # Open Challenges link unless a logged in user viewing own collections page or on an individual collection page %>
-  <li><%= link_to ts("Open Challenges"), list_challenges_collections_path %></li>
-  <% unless (logged_in? && @user && @user == current_user) || @collection %>
+  <%# Open Challenges link unless viewing a user collections page or on an individual collection page %>
+  <% unless @user || @collection %>
+    <li><%= link_to ts("Open Challenges"), list_challenges_collections_path %></li>
   <% end %>
   <% if logged_in? %>
-<% # Logged in user on own collections index gets links for user Collections and Manage Collection Items %>
+    <%# Logged in user on own collections index gets links for user Collections and Manage Collection Items %>
     <% if @user && @user == current_user %>
       <li><%= span_if_current ts("Collections"), user_collections_path(@user) %></li>
       <li><%= link_to ts("Manage Collection Items"), user_collection_items_path(@user) %></li>
     <% end %>
-<% # Logged in collection maintainer on own collection gets link for New Subcollection and all other logged in users get New Collection link %>
+    <%# Logged in collection maintainer on own collection gets link for New Subcollection and all other logged in users get New Collection link %>
     <% if @collection && !@collection.parent && @collection.user_is_maintainer?(current_user) %>
       <li><%= link_to ts("New Subcollection"), new_collection_collection_path(@collection) %></li>
     <% else %>
@@ -45,7 +45,7 @@
     <% end %>
   <% end %>
   <% if @sort_and_filter %>
-<% # Filters button for narrow screens jumps to filters when JavaScript is disabled and opens filters when JavaScript is enabled %>
+    <%# Filters button for narrow screens jumps to filters when JavaScript is disabled and opens filters when JavaScript is enabled %>
     <li class="narrow-shown hidden"><a href="#collection-filters" id="go_to_filters"><%= ts("Filters") %></a></li>
   <% end %>
 </ul>

--- a/app/views/collections/index.html.erb
+++ b/app/views/collections/index.html.erb
@@ -39,6 +39,18 @@
       <li><%= link_to ts("Manage Collection Items"), user_collection_items_path(@user) %></li>
     <% end %>
   <% end %>
+  <%# New Collection/Subcollection links for logged in users %>
+  <% if logged_in? %>
+    <% if @collection && !@collection.parent && @collection.user_is_maintainer?(current_user) %>
+      <li><%= link_to ts("New Subcollection"), new_collection_collection_path(@collection) %></li>
+    <% else %>
+      <li><%= link_to ts("New Collection"), new_collection_path %></li>
+    <% end %>
+  <% end %>
+  <% if @sort_and_filter %>
+    <%# Filters button for narrow screens jumps to filters when JavaScript is disabled and opens filters when JavaScript is enabled %>
+    <li class="narrow-shown hidden"><a href="#collection-filters" id="go_to_filters"><%= ts("Filters") %></a></li>
+  <% end %>
 </ul>
 
 <% unless @collections.blank? %>

--- a/features/collections/collection_browse.feature
+++ b/features/collections/collection_browse.feature
@@ -167,3 +167,9 @@ Feature: Collection
     And I should see "It's a test collection" within "#faq"
     And I should see "Be nice to testers" within "#rules"
     And I should see "About Some Test Collection (sometest)"
+
+  Scenario: Open Challenges link should not appear on subcollections page
+  Given I have loaded the fixtures
+    And "Some Test Collection" has subcollections
+  When I go to "Some Test Collection" subcollections page
+  Then I should not see "Open Challenges"

--- a/features/collections/collection_browse.feature
+++ b/features/collections/collection_browse.feature
@@ -169,6 +169,7 @@ Feature: Collection
     And I should see "About Some Test Collection (sometest)"
 
   Scenario: Open Challenges link should not appear on subcollections page
+  
   Given I have loaded the fixtures
     And "Some Test Collection" has subcollections
   When I go to "Some Test Collection" subcollections page


### PR DESCRIPTION
# Pull Request Checklist

<!-- Mark steps in the checklist as complete by changing `[ ]` to `[X]` -->
* [X] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [X] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [x] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [X] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [X] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-6925

## Purpose

- Remove the Open Challenges link from Subcollections page. (It still appears in the main collections index.)
- Have also removed the `role="navigation"` attribute from the ul

**Before:**
<img width="511" alt="image" src="https://github.com/user-attachments/assets/dee5839a-30fd-4405-8ff5-5d92fb7958dd" />

**After:**
<img width="510" alt="image" src="https://github.com/user-attachments/assets/3ef1d0cb-461f-450f-85ea-0841a814dc98" />

## Credit

gelphcore, they/them
Same on [Jira](https://otwarchive.atlassian.net/jira/people/712020:c09d3147-f70f-47f7-acf8-0943e01197c4)
