### PR TITLE
AO3-6050 Fix sorting on wrangle child tags for character

### DIFF
--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -293,14 +293,14 @@ class TagsController < ApplicationController
       # this makes sure params[:status] is safe
       status = params[:status]
       if %w(unfilterable canonical synonymous unwrangleable).include?(status)
-        @tags = @tag.send(show).order(sort).send(status).paginate(page: params[:page], per_page: ArchiveConfig.ITEMS_PER_PAGE)
+        @tags = @tag.send(show).reorder(sort).send(status).paginate(page: params[:page], per_page: ArchiveConfig.ITEMS_PER_PAGE)
       elsif status == 'unwrangled'
         @tags = @tag.unwrangled_tags(
           params[:show].singularize.camelize,
           params.permit!.slice(:sort_column, :sort_direction, :page)
         )
       else
-        @tags = @tag.send(show).order(sort).paginate(page: params[:page], per_page: ArchiveConfig.ITEMS_PER_PAGE)
+        @tags = @tag.send(show).reorder(sort).paginate(page: params[:page], per_page: ArchiveConfig.ITEMS_PER_PAGE)
       end
     end
   end

--- a/spec/controllers/tags_controller_spec.rb
+++ b/spec/controllers/tags_controller_spec.rb
@@ -95,6 +95,36 @@ describe TagsController do
                                                    freeform2.name])
       end
     end
+
+    context "when showing canonical relationships for a character" do
+      let(:character1) { create(:canonical_character, name: "A") }
+      let(:relationship1) { create(:canonical_relationship, name: "A/B", taggings_count_cache: 1) }
+      let(:relationship2) { create(:canonical_relationship, name: "A/C", taggings_count_cache: 2) }
+      let(:relationship3) { create(:canonical_relationship, name: "A/D") }
+      let(:relationship4) { create(:canonical_relationship, name: "A/E") }
+
+      before do
+        relationship1.add_association(character1)
+        relationship2.add_association(character1)
+        relationship3.add_association(character1)
+        relationship4.add_association(character1)
+        run_all_indexing_jobs
+      end
+
+      it "sorts tags by taggings count" do
+        get :wrangle, params: { id: character1.name, show: "relationships", status: "canonical", sort_column: "taggings_count_cache", sort_direction: "DESC" }
+        expect(assigns(:tags).pluck(:name)).to eq([relationship2.name,
+                                                   relationship1.name,
+                                                   relationship3.name,
+                                                   relationship4.name])
+
+        get :wrangle, params: { id: character1.name, show: "relationships", status: "canonical", sort_column: "taggings_count_cache", sort_direction: "ASC" }
+        expect(assigns(:tags).pluck(:name)).to eq([relationship3.name,
+                                                   relationship4.name,
+                                                   relationship1.name,
+                                                   relationship2.name])
+      end
+    end
   
     context "when showing unwrangled relationships for a character" do
       let(:character1) { create(:character, canonical: true) }


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6050

## Purpose

Fix sorting on the wrangle tags page for child tags of other tags.

## Credit

Bilka
