### PR TITLE
AO3-7011 Make hidden inputs hidden and unfocusable

### DIFF
--- a/public/stylesheets/site/2.0/07-interactions.css
+++ b/public/stylesheets/site/2.0/07-interactions.css
@@ -52,13 +52,17 @@ fieldset dd dl, form .meta dd, fieldset dl fieldset dl, dd fieldset {
 
 /*end nesting */
 
-legend, input[type="hidden"] {
+legend {
   height: 0;
   width: 0;
   font-size: 0;
   opacity: 0;
   padding: 0;
   margin: 0;
+}
+
+input[type="hidden"] {
+  display: none !important;
 }
 
 label {


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-7011

## Purpose

Returns the default `display: none` to hidden inputs so they don't get focus when browsing via keyboard navigation.

While it may have been possible to update the troublesome selector in `08-actions.css` to something like `.actions input:not([type="hidden"])`, using `input[type="hidden"] { display: none !important; }` provides a fix that is compatible even with truly ancient browsers that don't support `:not()`. It also provides protection against us reintroducing a similar issue in the future.

## Testing Instructions

Refer to Jira.

