### PR TITLE
AO3-7007 Redirect to login when trying to add item to collection when…

### DIFF
--- a/app/controllers/collection_items_controller.rb
+++ b/app/controllers/collection_items_controller.rb
@@ -3,6 +3,7 @@ class CollectionItemsController < ApplicationController
   before_action :load_user, only: [:update_multiple]
   before_action :load_collectible_item, only: [:new, :create]
   before_action :check_parent_visible, only: [:new]
+  before_action :users_only, only: [:new]
 
   cache_sweeper :collection_sweeper
 


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [ ] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [x] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [x] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-7007

## Purpose

This PR fixes 500 error a user gets when they try to create a new collection item while logged out. Instead, they will be redirected to the login page. 

## Credit

Connie Feng, she/her
([JIRA account](https://otwarchive.atlassian.net/jira/people/712020:17930fa1-d647-47bd-b334-8a84cbacfca7))