### PR TITLE
AO3-6807 Fix offer URL capitalisation in errors

### DIFF
--- a/config/locales/models/en.yml
+++ b/config/locales/models/en.yml
@@ -16,6 +16,8 @@ en:
         support: Support
         tag_wrangling: Tag Wrangling
         translation: Translation
+      challenge_signup/offers:
+        url: Offer URL
       challenge_signup/requests:
         url: Request URL
       chapters/creatorships:
@@ -37,6 +39,8 @@ en:
         meta_tag_id: Metatag
         sub_tag: Subtag
         sub_tag_id: Subtag
+      offer:
+        url: URL
       request:
         url: URL
       role:

--- a/features/gift_exchanges/challenge_giftexchange.feature
+++ b/features/gift_exchanges/challenge_giftexchange.feature
@@ -120,7 +120,7 @@ Feature: Gift Exchange Challenge
       And I submit
     Then I should see "URL: https://example.com/url_for_prompt"
 
-  Scenario: Invalid URL is disallowed when editing a signup
+  Scenario: Invalid URL is disallowed when editing a request in a signup
     Given the gift exchange "Awesome Gift Exchange" is ready for signups
       And I edit settings for "Awesome Gift Exchange" challenge
       And I check "gift_exchange[request_restriction_attributes][url_allowed]"
@@ -131,6 +131,18 @@ Feature: Gift Exchange Challenge
       And I fill in "Prompt URL:" with "i am broken."
       And I submit
     Then I should see "Request URL does not appear to be a valid URL."
+
+  Scenario: Invalid URL is disallowed when editing an offer in a signup
+    Given the gift exchange "Awesome Gift Exchange" is ready for signups
+      And I edit settings for "Awesome Gift Exchange" challenge
+      And I check "gift_exchange[offer_restriction_attributes][url_allowed]"
+      And I submit
+    When I am logged in as "myname1"
+      And I sign up for "Awesome Gift Exchange" with combination A
+      And I follow "Edit Sign-up"
+      And I fill in "Prompt URL:" with "i hereby offer you a bug."
+      And I submit
+    Then I should see "Offer URL does not appear to be a valid URL."
 
   Scenario: Sign-ups can be seen in the dashboard
     Given the gift exchange "Awesome Gift Exchange" is ready for signups


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6807

## Purpose

Add locale to fix the capitalization of offer URL in errors. Decided not to fix the double error thing in external work since it doesn't really harm anything and stopping generation of all future errors with `throw :abort` seems annoying especially on forms like the work form where you might have more than one error.

## Testing Instructions

Sign up for the gift exchange as in the original instructions, making sure to also enter an invalid URL for the offer, not just the request.

## Credit

Bilka
