### PR TITLE
AO3-5609 Fix that subscription notifications were sent for hidden works

### DIFF
--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -113,6 +113,7 @@ class UserMailer < ApplicationMailer
       creation = creation_type.constantize.where(id: creation_id).first
       next unless creation && creation.try(:posted)
       next if creation.is_a?(Chapter) && !creation.work.try(:posted)
+      next if creation.try(:hidden_by_admin) || creation.is_a?(Chapter) && creation.work.try(:hidden_by_admin)
       next if creation.pseuds.any? { |p| p.user == User.orphan_account } # no notifications for orphan works
 
       # TODO: allow subscriptions to orphan_account to receive notifications

--- a/features/other_b/subscriptions.feature
+++ b/features/other_b/subscriptions.feature
@@ -239,6 +239,52 @@
     And the email should contain "Anonymous"
     And the email should not contain "creator"
 
+    Scenario: When new chapter for a hidden work is posted, no subscription notifications are sent
+
+      Given the work "TOS Violation" by "violator"
+        And "author_subscriber" subscribes to author "violator"
+        And "work_subscriber" subscribes to work "TOS Violation"
+      When I am logged in as a "policy_and_abuse" admin
+        And I hide the work "TOS Violation"
+        And a chapter is added to "TOS Violation"
+        And subscription notifications are sent
+      Then "author_subscriber" should not be emailed
+        And "work_subscriber" should not be emailed
+      When I am logged in as a "policy_and_abuse" admin
+        And I unhide the work "TOS Violation"
+        And subscription notifications are sent
+      Then "author_subscriber" should not be emailed
+        And "work_subscriber" should not be emailed
+      When a chapter is added to "TOS Violation"
+        And subscription notifications are sent
+      Then "author_subscriber" should be emailed
+        And "work_subscriber" should be emailed
+
+    Scenario: When a hidden work is unrevealed, no subscription notifications are sent
+
+      Given I am logged in as "violator"
+        And I post the work "TOS Violation"
+        And "author_subscriber" subscribes to author "violator"
+        And "work_subscriber" subscribes to work "TOS Violation"
+        And I have the hidden collection "Secret"
+        And I am logged in as "violator"
+        And I edit the work "TOS Violation" to be in the collection "Secret"
+        And I am logged in as a "policy_and_abuse" admin
+        And I hide the work "TOS Violation"
+      When I am logged in as "moderator"
+        And I go to "Secret" collection's page
+        And I follow "Collection Settings"
+        And I uncheck "This collection is unrevealed"
+        And I press "Update"
+        And subscription notifications are sent
+      Then "author_subscriber" should not be emailed
+        And "work_subscriber" should not be emailed
+      When I am logged in as a "policy_and_abuse" admin
+        And I unhide the work "TOS Violation"
+        And subscription notifications are sent
+      Then "author_subscriber" should not be emailed
+        And "work_subscriber" should not be emailed
+
   Scenario: subscribe to an individual work with an the & and < and > characters in the title
 
   Given I have loaded the fixtures

--- a/features/step_definitions/admin_steps.rb
+++ b/features/step_definitions/admin_steps.rb
@@ -349,6 +349,24 @@ When /^I hide the work "(.*?)"$/ do |title|
   step %{I follow "Hide Work"}
 end
 
+When "I unhide the work {string}" do |title|
+  work = Work.find_by(title: title)
+  visit work_path(work)
+  step %{I follow "Make Work Visible"}
+end
+
+When "I hide the series {string}" do |title|
+  work = Series.find_by(title: title)
+  visit series_path(work)
+  step %{I follow "Hide Series"}
+end
+
+When "I unhide the series {string}" do |title|
+  work = Series.find_by(title: title)
+  visit series_path(work)
+  step %{I follow "Make Series Visible"}
+end
+
 When "the search criteria contains the ID for {string}" do |login|
   user_id = User.find_by(login: login).id
   fill_in("user_id", with: user_id)


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5609

## Purpose

Exclude works and chapters of works hidden by admin from sending subscription notifications.

## Credit

Bilka