### PR TITLE
AO3-7020 i18n creation bylines

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -87,13 +87,13 @@ module ApplicationHelper
     # Skip cache in preview mode
     return byline_text_uncached(creation, only_path) if @preview_mode
 
-    byline_text_cached(creation, only_path)
+    byline_text(creation, only_path)
   end
 
-  def byline_text_cached(creation, only_path)
+  def byline_text(creation, only_path, text_only: false)
     # Update Series#expire_byline_cache when changing cache key here
     creators = Rails.cache.fetch(["byline_data", creation.cache_key]) { byline_data(creation) }
-    byline_text_internal(creators, only_path)
+    byline_text_internal(creators, only_path, text_only: text_only)
   end
 
   def byline_text_uncached(creation, only_path, text_only: false)
@@ -154,7 +154,7 @@ module ApplicationHelper
       anon_byline
     else
       only_path = false
-      byline_text_uncached(creation, only_path, text_only: true)
+      byline_text(creation, only_path, text_only: true)
     end
   end
 

--- a/app/models/pseud.rb
+++ b/app/models/pseud.rb
@@ -153,8 +153,8 @@ class Pseud < ApplicationRecord
   end
 
   # Produces a byline that indicates the user's name if pseud is not unique
-  def byline
-    (name != user_name) ? "#{name} (#{user_name})" : name
+  def byline(username = user_login)
+    (name != username) ? "#{name} (#{username})" : name
   end
 
   # get the former byline

--- a/app/models/series.rb
+++ b/app/models/series.rb
@@ -152,9 +152,12 @@ class Series < ApplicationRecord
   end
 
   def expire_byline_cache
-    [true, false].each do |only_path|
-      Rails.cache.delete("#{cache_key}/byline-nonanon/#{only_path}")
-    end
+    Rails.cache.delete("byline_internal/#{cache_key}")
+    keys = I18n.available_locales.map do |locale|
+      ["byline_text/#{cache_key}_true_#{locale}", "byline_text/#{cache_key}_false_#{locale}"]
+    end.flatten
+
+    Rails.cache.delete_multi(keys)
   end
 
   # Change the positions of the serial works in the series

--- a/app/models/series.rb
+++ b/app/models/series.rb
@@ -152,7 +152,7 @@ class Series < ApplicationRecord
   end
 
   def expire_byline_cache
-    Rails.cache.delete(["byline_internal", cache_key])
+    Rails.cache.delete(["byline_data", cache_key])
   end
 
   # Change the positions of the serial works in the series

--- a/app/models/series.rb
+++ b/app/models/series.rb
@@ -152,12 +152,7 @@ class Series < ApplicationRecord
   end
 
   def expire_byline_cache
-    Rails.cache.delete("byline_internal/#{cache_key}")
-    keys = I18n.available_locales.map do |locale|
-      ["byline_text/#{cache_key}_true_#{locale}", "byline_text/#{cache_key}_false_#{locale}"]
-    end.flatten
-
-    Rails.cache.delete_multi(keys)
+    Rails.cache.delete(["byline_internal", cache_key])
   end
 
   # Change the positions of the serial works in the series

--- a/config/locales/helpers/en.yml
+++ b/config/locales/helpers/en.yml
@@ -1,6 +1,8 @@
 ---
 en:
   application_helper:
+    anonymous_byline: Anonymous
+    anonymous_with_name_byline: Anonymous [%{pseud_byline}]
     archivist_byline_html: "%{external_author} [archived by %{pseud_byline}]"
   collections_helper:
     collection_item_approval_options:

--- a/config/locales/helpers/en.yml
+++ b/config/locales/helpers/en.yml
@@ -1,5 +1,7 @@
 ---
 en:
+  application_helper:
+    archivist_byline_html: "%{external_author} [archived by %{pseud_byline}]"
   collections_helper:
     collection_item_approval_options:
       collection:

--- a/factories/works.rb
+++ b/factories/works.rb
@@ -58,6 +58,7 @@ FactoryBot.define do
 
   factory :external_author_name do |f|
     f.association :external_author
+    name { Faker::Name.first_name }
   end
 
   factory :external_creatorship do |f|

--- a/features/importing/archivist.feature
+++ b/features/importing/archivist.feature
@@ -52,58 +52,48 @@ Feature: Archivist bulk imports
       And 1 email should be delivered to "rebecca2525@livejournal.com"
       And the email should contain invitation warnings from "archivist" for work "Importing Test" in fandom "Lewis"
 
-  # TODO: Enable after AO3-6353.
-  @wip
   Scenario: Import a work for multiple authors without accounts should display all in the byline
-    When I go to the import page
-      And I import the work "http://ao3testing.dreamwidth.org/593.html" by "name1" with email "a@ao3.org" and by "name2" with email "b@ao3.org"
-    Then I should see "Story"
-      And I should see "name1 [archived by archivist]"
-      And I should see "name2 [archived by archivist]"
+    When I set up mock websites for importing
+      And I import the work "http://example.com/second-import-site-with-tags" by "name1" with email "a@ao3.org" and by "name2" with email "b@ao3.org"
+    Then I should see "Huddling"
+      And I should see "name1 [archived by archivist]" within ".byline"
+      And I should see "name2 [archived by archivist]" within ".byline"
 
-  # TODO: Enable after AO3-6353.
-  @wip
   Scenario: Import a work for multiple authors without accounts should send emails to all authors
-    When I go to the import page
-      And I import the work "http://ao3testing.dreamwidth.org/593.html" by "name1" with email "a@ao3.org" and by "name2" with email "b@ao3.org"
+    When I set up mock websites for importing
+      And I import the work "http://example.com/second-import-site-with-tags" by "name1" with email "a@ao3.org" and by "name2" with email "b@ao3.org"
     Then 1 email should be delivered to "a@ao3.org"
       And 1 email should be delivered to "b@ao3.org"
 
-  # TODO: Enable after AO3-6353.
-  @wip
   Scenario: Import a work for multiple authors with and without accounts should display all in the byline
     Given the following activated users exist
       | login | email |
       | user1 | a@ao3.org |
-    When I go to the import page
-      And I import the work "http://ao3testing.dreamwidth.org/593.html" by "name1" with email "a@ao3.org" and by "name2" with email "b@ao3.org"
-    Then I should see "Story"
-      And I should see "user1"
-      And I should see "name2 [archived by archivist]"
+      And I set up mock websites for importing
+    When I import the work "http://example.com/second-import-site-with-tags" by "name1" with email "a@ao3.org" and by "name2" with email "b@ao3.org"
+    Then I should see "Huddling"
+      And I should see "user1" within ".byline"
+      And I should see "name2 [archived by archivist]" within ".byline"
 
-  # TODO: Enable after AO3-6353.
-  @wip
   Scenario: Import a work for multiple authors with and without accounts should send emails to all authors
     Given the following activated users exist
       | login | email |
       | user1 | a@ao3.org |
-    When I go to the import page
-      And I import the work "http://ao3testing.dreamwidth.org/593.html" by "name1" with email "a@ao3.org" and by "name2" with email "b@ao3.org"
+      And I set up mock websites for importing
+    When I import the work "http://example.com/second-import-site-with-tags" by "name1" with email "a@ao3.org" and by "name2" with email "b@ao3.org"
     Then 1 email should be delivered to "a@ao3.org"
       And 1 email should be delivered to "b@ao3.org"
 
-  # TODO: Enable after AO3-6353.
-  @wip
   Scenario: Import a work for multiple authors with accounts should not display the archivist
     Given the following activated users exist
       | login | email |
       | user1 | a@ao3.org |
       | user2 | b@ao3.org |
-    When I go to the import page
-    And I import the work "http://ao3testing.dreamwidth.org/593.html" by "name1" with email "a@ao3.org" and by "name2" with email "b@ao3.org"
-    Then I should see "Story"
-      And I should see "user1"
-      And I should see "user2"
+      And I set up mock websites for importing
+    When I import the work "http://example.com/second-import-site-with-tags" by "name1" with email "a@ao3.org" and by "name2" with email "b@ao3.org"
+    Then I should see "Huddling"
+      And I should see "user1" within ".byline"
+      And I should see "user2" within ".byline"
       But I should not see "archivist" within ".byline"
 
   # TODO: Enable after AO3-6353.

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -364,4 +364,25 @@ describe ApplicationHelper do
       end
     end
   end
+
+  describe "#byline" do
+    let(:user1) { create(:user, login: "Beetle") }
+    let(:user2) { create(:user, login: "Muppet") }
+    let(:work) { create(:work, authors: [user1.default_pseud, user2.default_pseud]) }
+
+    before do
+      create(:locale, iso: "new")
+      I18n.backend.store_translations(:new, { support: { array: { words_connector: "，" } } })
+    end
+
+    it "is locale independent" do
+      I18n.with_locale(I18n.default_locale) do
+        expect(helper.byline(work, visibility: "public")).to include("Beetle</a>, <a")
+      end
+
+      I18n.with_locale(:new) do
+        expect(helper.byline(work, visibility: "public")).to include("Beetle</a>，<a")
+      end
+    end
+  end
 end

--- a/spec/requests/works_n_plus_one_spec.rb
+++ b/spec/requests/works_n_plus_one_spec.rb
@@ -82,6 +82,26 @@ describe "n+1 queries in the WorksController" do
         it_behaves_like "displaying multiple works efficiently"
       end
     end
+
+    context "when viewing imported recent works" do
+      subject do
+        proc do
+          get works_path
+        end
+      end
+
+      let!(:work_attributes) { archivist = create(:archivist); { authors: [archivist.default_pseud], external_creatorships: [create(:external_creatorship, archivist: archivist)] } }
+
+      context "when logged in" do
+        before { fake_login }
+
+        it_behaves_like "displaying multiple works efficiently"
+      end
+
+      context "when logged out" do
+        it_behaves_like "displaying multiple works efficiently"
+      end
+    end
   end
 
   describe "#collected" do


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-7020

## Purpose

Prepare creation bylines for translation. This includes making the cache locale independent by not including the translations in the cache and instead caching the raw data.

The first commit in this PR shows a intermediate solution which had two layers of caching, one of which included the locale in the cache key. However, I found a way that avoided the extra db query for the user outside of `byline_data`, so there are no more db queries happening outside of the `byline_data`, as shown by the N+1 specs.

This does not make the format for `pseud#byline` translatable because it's used in untranslatable parts of the interface, such as the co-creator field on the work form where you can enter `pseud (user)`. If users got used to other formats (e.g. using different parens), these fields would become confusing.

This fixes that the text byline (used in RSS feeds and the share function) was not cached.

This PR has a conflict with #5225.

## Testing Instructions

TBD. I can't come up with anything good to test manually, since we don't have translations for this.

## Credit

Bilka
