### PR TITLE
AO3-7024 - Fixed inbox success message being incorrectly displayed

### DIFF
--- a/app/controllers/inbox_controller.rb
+++ b/app/controllers/inbox_controller.rb
@@ -42,10 +42,10 @@ class InboxController < ApplicationController
       elsif params[:delete]
         @inbox_comments.each { |i| i.destroy }
       end
+      success_message = ts('Inbox successfully updated.')
     rescue
-      flash[:caution] = ts("Please select something first")
+      flash[:caution] = ts("Please select something first.")
     end
-    success_message = ts('Inbox successfully updated.')
     respond_to do |format|
       format.html { redirect_to request.referer || user_inbox_path(@user, page: params[:page], filters: params[:filters]), notice: success_message }
       format.json { render json: { item_success_message: success_message }, status: :ok }

--- a/spec/controllers/inbox_controller_spec.rb
+++ b/spec/controllers/inbox_controller_spec.rb
@@ -271,19 +271,15 @@ describe InboxController do
       before { fake_login_known_user(user) }
 
       context "with no comments selected" do
-        it "redirects to inbox with caution and a notice" do
+        it "redirects to the user's inbox with a caution" do
           put :update, params: { user_id: user.login, read: "yeah" }
-          it_redirects_to_with_caution_and_notice(user_inbox_path(user),
-                                                  "Please select something first",
-                                                  "Inbox successfully updated.")
+          it_redirects_to_with_caution(user_inbox_path(user), "Please select something first.")
         end
 
-        it "redirects to the previously viewed page if HTTP_REFERER is set, with a caution and a notice" do
+        it "redirects to the previously viewed page if HTTP_REFERER is set, with a caution" do
           @request.env["HTTP_REFERER"] = root_path
           put :update, params: { user_id: user.login, read: "yeah" }
-          it_redirects_to_with_caution_and_notice(root_path,
-                                                  "Please select something first",
-                                                  "Inbox successfully updated.")
+          it_redirects_to_with_caution(root_path, "Please select something first.")
         end
       end
 


### PR DESCRIPTION
# Pull Request Checklist

<!-- Mark steps in the checklist as complete by changing `[ ]` to `[X]` -->
* [x] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [x] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [x] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [x] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-7024

## Purpose

Fixes a display issue where the success message "Inbox successfully updated.” is displayed when Mark Read/Mark Unread/Delete is used without any inbox items being selected.

## Credit

talvalin
he/him