### PR TITLE
AO3-7031 Migrate foreign ids for bookmarks to bigint as well

### DIFF
--- a/db/migrate/20250704060231_change_bookmark_foreign_keys_type.rb
+++ b/db/migrate/20250704060231_change_bookmark_foreign_keys_type.rb
@@ -1,0 +1,12 @@
+class ChangeBookmarkForeignKeysType < ActiveRecord::Migration[7.1]
+  uses_departure! if Rails.env.staging? || Rails.env.production?
+
+  def up
+    change_column :collection_items, :item_id, "bigint"
+    change_column :taggings, :taggable_id, "bigint"
+    change_column :admin_activities, :target_id, "bigint"
+  end
+
+  def down
+  end
+end

--- a/spec/models/bookmark_spec.rb
+++ b/spec/models/bookmark_spec.rb
@@ -20,4 +20,30 @@ describe Bookmark do
     expect(bookmark).to_not be_valid
     expect(bookmark.errors[:pseud].first).to eq("can't be blank")
   end
+
+  it "can be tagged if has an id larger than int" do
+    bookmark = build(:bookmark, tag_string: "Huge", id: 2247740375)
+    expect(bookmark).to be_valid
+    expect(bookmark.save).to be_truthy
+    expect(bookmark.reload.taggings.last.tagger.name).to eq("Huge")
+  end
+
+  it "can be collected if has an id larger than int" do
+    collection = create(:collection)
+    bookmark = build(:bookmark, collection_names: collection.name, id: 2247740375)
+    expect(bookmark).to be_valid
+    expect(bookmark.save).to be_truthy
+    expect(bookmark.collections).to include(collection)
+    expect(collection.bookmarks).to include(bookmark)
+  end
+
+  it "can be hidden if has an id larger than int" do
+    bookmark = create(:bookmark, id: 2247740375)
+    admin = create(:admin)
+    activity = build(:admin_activity, admin: admin, target: bookmark)
+
+    expect(activity).to be_valid
+    expect(activity.save).to be_truthy
+    expect(activity.target_name).to eq("Bookmark #{bookmark.id}")
+  end
 end


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-7031

## Purpose

Update the type of columns containing bookmark ids to bigint.
 
## Credit

Bilka
