### PR TITLE
AO3-7031 Add certainty in bookmark ID column data type in test cases

### DIFF
--- a/spec/models/bookmark_spec.rb
+++ b/spec/models/bookmark_spec.rb
@@ -21,24 +21,24 @@ describe Bookmark do
     expect(bookmark.errors[:pseud].first).to eq("can't be blank")
   end
 
-  it "can be tagged if has an id larger than int" do
-    bookmark = build(:bookmark, tag_string: "Huge", id: 2_247_740_375)
+  it "can be tagged if has an id larger than unsigned int" do
+    bookmark = build(:bookmark, tag_string: "Huge", id: 5_294_967_295)
     expect(bookmark).to be_valid
     expect(bookmark.save).to be_truthy
     expect(bookmark.reload.taggings.last.tagger.name).to eq("Huge")
   end
 
-  it "can be collected if has an id larger than int" do
+  it "can be collected if has an id larger than unsigned int" do
     collection = create(:collection)
-    bookmark = build(:bookmark, collection_names: collection.name, id: 2_247_740_375)
+    bookmark = build(:bookmark, collection_names: collection.name, id: 5_294_967_295)
     expect(bookmark).to be_valid
     expect(bookmark.save).to be_truthy
     expect(bookmark.collections).to include(collection)
     expect(collection.bookmarks).to include(bookmark)
   end
 
-  it "can be hidden if has an id larger than int" do
-    bookmark = create(:bookmark, id: 2_247_740_375)
+  it "can be hidden if has an id larger than unsigned int" do
+    bookmark = create(:bookmark, id: 5_294_967_295)
     admin = create(:admin)
     activity = build(:admin_activity, admin: admin, target: bookmark)
 


### PR DESCRIPTION
A value of 5_294_967_295 (greater than max 32 bit unsigned integer) will add confidence that bigint types are used for bookmark ID fields.

## Issue

https://otwarchive.atlassian.net/browse/AO3-7031

## Purpose
This change will increase certainty across code base and systems, e.g., redis, elasticsearch, that the Bookmarks ID field is of a size big int (64 bit int), and not merely unsigned int (32 bit int). 
Note: It would be a good idea to review the associated Bookmarks ID field data types inside any redis and elasticsearch systems across environments.

## Testing Instructions

Run the tests for the associated models spec file through automation.

## Credit

Credit however you feel like.