### PR TITLE
AO3-5481 Work search for words in different fields doesn't work

### DIFF
--- a/app/models/search/work_query.rb
+++ b/app/models/search/work_query.rb
@@ -252,7 +252,8 @@ class WorkQuery < Query
       query_string: {
         query: query,
         fields: ["creators^5", "title^7", "endnotes", "notes", "summary", "tag", "series.title"],
-        default_operator: "AND"
+        default_operator: "AND",
+        type: "cross_fields"
       }
     } unless query.blank?
   end


### PR DESCRIPTION
# Pull Request Checklist

<!-- Mark steps in the checklist as complete by changing `[ ]` to `[X]` -->
* [X] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [X] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [X] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [X] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [X] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-5481

## Purpose

What does this PR do?

Modifies the ElasticSearch work query to search across fields rather than looking for a match for all keywords in one field.

## Testing Instructions

How can the Archive's QA team verify that this is working as you intended?

As per the Jira, search "sarken closer" if a work by creator sarken in fandom closer exists and verify that it shows up in search. Try the advanced search as well with operators (e.g. harry || spock) and make sure that still works as expected as well.


## Credit

What name and pronouns should we use to credit you in the [Archive of Our Own's Release Notes](https://archiveofourown.org/admin_posts?tag=1)?

salt, they/them
