### PR TITLE
AO3-7025 Fix typo in voice family property

### DIFF
--- a/public/help/skins-creating.html
+++ b/public/help/skins-creating.html
@@ -52,7 +52,7 @@
         speak-numeral, speak-punctuation, speech-rate, stress, string-set,
         tab-side, table-layout, target, target-name, target-new,
         target-position, top, unicode-bibi, unicode-bidi, user-select,
-        vertical-align, visibility, voice-balance, voice-duration, oice-family,
+        vertical-align, visibility, voice-balance, voice-duration, voice-family,
         voice-pitch, voice-pitch-range, voice-rate, voice-stress, voice-volume,
         volume, white-space, white-space-collapse, widows, width, word-break,
         word-spacing, word-wrap, writing-mode, z-index


### PR DESCRIPTION
Took 7 minutes

# Pull Request Checklist

<!-- Mark steps in the checklist as complete by changing `[ ]` to `[X]` -->
* [x] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [x] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [x] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [x] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-7025

## Purpose

What does this PR do?

Fixed the type in skin creation css style guide, changed the name of the property `oice-family` to `voice-family`

## Testing Instructions

How can the Archive's QA team verify that this is working as you intended?

As mentioned in the issue, go the `new skin creation form`, click on the `help section` and search for `voice-duration` the property after that should be named as `voice-family`.


## Credit

What name and pronouns should we use to credit you in the [Archive of Our Own's Release Notes](https://archiveofourown.org/admin_posts?tag=1)?

Abhinav Gupta, he/him
