### PR TITLE
AO3-5476 Remove unused code in works_controller

### DIFF
--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -656,8 +656,8 @@ class WorksController < ApplicationController
     @page_subtitle = ts("Edit Multiple Works")
     @user = current_user
 
-    @works = Work.joins(pseuds: :user).where('users.id = ?', @user.try(:id))
-    
+    @works = Work.joins(pseuds: :user).where(users: { id: @user.try(:id) })
+
     @works = @works.where(id: params[:work_ids]) if params[:work_ids]
 
     @works_by_fandom = @works.joins(:taggings)

--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -313,7 +313,6 @@ class WorksController < ApplicationController
     @work.set_challenge_claim_info
     set_work_form_fields
 
-    # If Cancel is pressed, bail out and display relevant form
     if work_cannot_be_saved?
       render :new
     else

--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -656,6 +656,8 @@ class WorksController < ApplicationController
     @page_subtitle = ts("Edit Multiple Works")
     @user = current_user
 
+    @works = Work.joins(pseuds: :user).where('users.id = ?', @user.try(:id))
+    
     @works = @works.where(id: params[:work_ids]) if params[:work_ids]
 
     @works_by_fandom = @works.joins(:taggings)

--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -655,7 +655,7 @@ class WorksController < ApplicationController
     @page_subtitle = ts("Edit Multiple Works")
     @user = current_user
 
-    @works = Work.joins(pseuds: :user).where(users: { id: @user.try(:id) })
+    @works = Work.joins(pseuds: :user).where(users: { id: @user.id })
 
     @works = @works.where(id: params[:work_ids]) if params[:work_ids]
 

--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -313,8 +313,8 @@ class WorksController < ApplicationController
     @work.set_challenge_claim_info
     set_work_form_fields
 
-    # If Edit or Cancel is pressed, bail out and display relevant form
-    if params[:edit_button] || work_cannot_be_saved?
+    # If Cancel is pressed, bail out and display relevant form
+    if work_cannot_be_saved?
       render :new
     else
       @work.posted = @chapter.posted = true if params[:post_button]
@@ -655,12 +655,6 @@ class WorksController < ApplicationController
   def show_multiple
     @page_subtitle = ts("Edit Multiple Works")
     @user = current_user
-
-    if params[:pseud_id]
-      @works = Work.joins(:pseuds).where(pseud_id: params[:pseud_id])
-    else
-      @works = Work.joins(pseuds: :user).where('users.id = ?', @user.id)
-    end
 
     @works = @works.where(id: params[:work_ids]) if params[:work_ids]
 


### PR DESCRIPTION
# Pull Request Checklist

* [X] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [X] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [X] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [X] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [X] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-5476

## Purpose

Removes references to the `pseud_id` parameter when editing multiple works, and removes reference to an edit button when creating a new work.

## Testing Instructions

1. Create two or more works
2. Navigate to the “Edit Multiple Works” page from the dashboard
3. Edit multiple works and confirm that your changes were successful
4. Verify that no edit button exists when posting a new work

## Credit

ktibur
