### PR TITLE
Update the list of large tables in rubocop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -84,14 +84,19 @@ Metrics/PerceivedComplexity:
 Migration/LargeTableSchemaUpdate:
   Tables:
     - abuse_reports
+    - active_storage_attachments
     - active_storage_blobs
+    - active_storage_variant_records
     - admin_activities
     - audits
+    - blocks
     - bookmarks
+    - chapters
     - comments
     - common_taggings
     - collection_items
     - collection_participants
+    - collection_preferences
     - collection_profiles
     - collections
     - creatorships
@@ -105,12 +110,14 @@ Migration/LargeTableSchemaUpdate:
     - invitations
     - kudos
     - log_items
+    - meta_taggings
     - mutes
     - preferences
     - profiles
     - prompts
     - pseuds
     - readings
+    - related_works
     - set_taggings
     - serial_works
     - series
@@ -119,8 +126,9 @@ Migration/LargeTableSchemaUpdate:
     - subscriptions
     - tag_nominations
     - tag_set_associations
-    - tags
+    - tag_sets
     - taggings
+    - tags
     - users
     - works
 


### PR DESCRIPTION
## Issue

Considering this a docs PR.

## Purpose

I recently used the list of large tables to find tables with high ids. In the process I noticed that a few large tables were missing, so this adds them. I added all tables that I checked and that have a current record count of over 400 thousand.


| Table name  | Max id | count |
| ------------- | ------------- | ------------- |
| chapters | 173_392_018  |  |
| invite_requests | 47_903_377 | 79_317 |
| potential_matches | 35_575_468 | 74_445 |
| active_storage_attachments | 21_749_020 |  |
| active_storage_variant_records | 13_161_289 |  |
| tag_sets | 8_184_766 | 2_650_269 |
| challenge_assignments | 3_333_973 | 194_908 |
| blocks | 2_725_009 | 802_264 |
| meta_taggings | 2_668_861 | 611_707 |
| collection_preferences | 2_083_342 | 450_268 |
| related_works | 1_669_462 | 416_082 |
| challenge_claims | 856_510 | 157_029 |
| challenge_signups | 670_684 | 202_085 |

## Credit

Bilka
