### PR TITLE
AO3-7029 Show links to skip to and from filters in Low Vision Default

### DIFF
--- a/public/stylesheets/masters/low_vision_default/low_vision_default_site_screen_.css
+++ b/public/stylesheets/masters/low_vision_default/low_vision_default_site_screen_.css
@@ -186,11 +186,10 @@ pre {
   border: none;
 }
 
-html.no-js form#work-filters {
-  display: block !important;
+body .narrow-shown {
+  display: block;
 }
 
-html.no-js p.narrow-hidden,
-html.no-js p.narrow-shown {
-  display: block !important;
+.actions li.narrow-shown {
+  display: inline;
 }


### PR DESCRIPTION
Took 36 minutes

# Pull Request Checklist

<!-- Mark steps in the checklist as complete by changing `[ ]` to `[X]` -->
* [x] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [x] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [x] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [x] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-7029

## Purpose

It fixes the bug that just enables buttons to be displayed when JS is disabled. HTML buttons were already present just need to change the CSS for this.

## Testing Instructions

As mentioned in the PR, go the filters page, disable JS in your browser click on Filters Button it should take you down on the page to the filters and then below the filters there is button to take you to the top, it should take you at the top. 

