### PR TITLE
AO3-7033 Include skin title in browser page title for skin show page

### DIFF
--- a/app/controllers/skins_controller.rb
+++ b/app/controllers/skins_controller.rb
@@ -44,6 +44,7 @@ class SkinsController < ApplicationController
 
   # GET /skins/1
   def show
+    @page_subtitle = @skin.title.html_safe
   end
 
   # GET /skins/new

--- a/features/other_b/skin.feature
+++ b/features/other_b/skin.feature
@@ -3,12 +3,13 @@ Feature: Non-public site and work skins
 
   Scenario: A user should be able to create a skin with CSS
   Given I am logged in as "skinner"
+    And the app name is "Example Archive"
   When I am on the new skin page
-    And I fill in "Title" with "my blinking skin"
+    And I fill in "Title" with "my blinking & skin"
     And I fill in "CSS" with "#title { text-decoration: blink;}"
     And I submit
   Then I should see "Skin was successfully created"
-    And I should see "my blinking skin skin by skinner"
+    And I should see "my blinking & skin skin by skinner"
     And I should see "text-decoration: blink;"
     And I should see "(No Description Provided)"
     And I should see "by skinner"
@@ -18,6 +19,7 @@ Feature: Non-public site and work skins
     And I should not see "Stop Using"
     And I should not see "(Approved)"
     And I should not see "(Not yet reviewed)"
+    And I should see the page title "my blinking & skin | Example Archive"
 
   Scenario: A logged-out user should not be able to create skins.
   Given I am a visitor


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-7033

## Purpose

Add the skin title to the browser page title for the skin show page. We should at some future point move the `hmtl_safe` call to the title attribute on the model instead of sprinkling it into views, similar to how it's done with works. I suspect Brakeman will complain but it's fine because it's sanitized.

## Credit

Bilka
