### PR TITLE
AO3-6521 Show titles of restricted related works to admins

### DIFF
--- a/app/helpers/works_helper.rb
+++ b/app/helpers/works_helper.rb
@@ -129,7 +129,7 @@ module WorksHelper
         t(".#{relation}.unrevealed",
           locale: default_locale)
       end
-    elsif related_work.restricted? && (download || !logged_in? && !logged_in_as_admin?)
+    elsif related_work.restricted? && (download || (!logged_in? && !logged_in_as_admin?))
       t(".#{relation}.restricted_html",
         language: language,
         locale: default_locale,


### PR DESCRIPTION
# Pull Request Checklist

<!-- Mark steps in the checklist as complete by changing `[ ]` to `[X]` -->
* [x] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [x] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [x] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [x] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-6521

## Purpose

Fixes a problem where the titles of restricted related works are not shown to admins.

## Credit

talvalin
he/him