### PR TITLE
AO3-7026 Add recheck_reason to Akismet attributes for comment edits

### DIFF
--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -116,6 +116,8 @@ class Comment < ApplicationRecord
       comment_author = user.login
     end
 
+    recheck_reason = comment_content_changed? ? "edit" : nil
+
     {
       comment_type: comment_type,
       key: ArchiveConfig.AKISMET_KEY,
@@ -125,7 +127,8 @@ class Comment < ApplicationRecord
       user_role: user_role,
       comment_author: comment_author,
       comment_author_email: comment_owner_email,
-      comment_content: comment_content
+      comment_content: comment_content,
+      recheck_reason: recheck_reason
     }
   end
 

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -186,6 +186,21 @@ describe Comment do
         expect(subject.akismet_attributes[:comment_author_email]).to eq(subject.pseud.user.email)
       end
 
+      context "when the comment is being created" do
+        it "does not set recheck_reason" do
+          expect(subject.akismet_attributes[:recheck_reason]).to be_nil
+        end
+      end
+
+      context "when the comment is being edited" do
+        it "sets recheck_reason to 'edit'" do
+          subject.comment_content += " updated"
+          subject.save!
+          
+          expect(subject.akismet_attributes[:recheck_reason]).to eq("edit")
+        end
+      end
+
       context "when the comment is from a guest" do
         subject { create(:comment, :by_guest) }
 


### PR DESCRIPTION
# Pull Request Checklist

<!-- Mark steps in the checklist as complete by changing `[ ]` to `[X]` -->
* [x] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [x] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [x] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [x] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/issues/AO3-7026

## Purpose

Add recheck_reason to Akismet attributes for comment edits

## Credit

EchoEkhi
