### PR TITLE
AO3-7015 Add data-updated-at attribute to work blurb HTML for crawlers

### DIFF
--- a/app/views/works/_work_blurb.html.erb
+++ b/app/views/works/_work_blurb.html.erb
@@ -1,5 +1,5 @@
 <% # expects "work" %>
-<li id="work_<%= work.id %>" class="<% if is_author_of?(work) %>own <% end %><% if work.unrevealed? %>mystery <% end %>work <%= css_classes_for_creation_blurb(work) %>" role="article">
+<li id="work_<%= work.id %>" class="<% if is_author_of?(work) %>own <% end %><% if work.unrevealed? %>mystery <% end %>work <%= css_classes_for_creation_blurb(work) %>" role="article" data-updated-at="<%= work.updated_at.to_i %>">
   <%= render "works/work_module", work: work %>
   <% if is_author_of?(work) %>
     <h6 class="landmark heading"><%= ts("Author Actions") %></h6>

--- a/features/step_definitions/work_steps.rb
+++ b/features/step_definitions/work_steps.rb
@@ -813,3 +813,8 @@ Then "I should not see {string} within the work blurb of {string}" do |content, 
   work = Work.find_by(title: work)
   step %{I should not see "#{content}" within "li#work_#{work.id}"}
 end
+
+Then "I should see the data-updated-at attribute to be around {int}" do |expected_updated_at|
+  data_updated_at = page.find("li.work.blurb")["data-updated-at"].to_i
+  expect(data_updated_at).to be_within(5).of(expected_updated_at)
+end

--- a/features/works/work_browse.feature
+++ b/features/works/work_browse.feature
@@ -178,3 +178,9 @@ Scenario: Can also browse work indexed by language
       Then I should see "1 Work in Deutsch"
     When I browse works in language "Persian"
       Then I should see "0 Works in Persian"
+
+Scenario: Work blurb includes correct data-updated-at attribute
+  Given it is currently 2025-04-12 17:00 UTC
+    And the work "Test"
+  When I go to the works page
+  Then I should see the data-updated-at attribute to be around 1744477200


### PR DESCRIPTION
# Pull Request Checklist

<!-- Mark steps in the checklist as complete by changing `[ ]` to `[X]` -->
* [x] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [x] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [x] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [x] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/issues/AO3-7015

## Purpose

Add data-updated-at attribute to work blurb HTML for crawlers.

## Testing Instructions

Open a page with work blurbs, inspect the blurb's element, and see  if the data-updated-at attribute is correct.

## Credit

EchoEkhi