### PR TITLE
AO3-7042 Change collections index to 404 for nonexistent objects

### DIFF
--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -31,7 +31,7 @@ class CollectionsController < ApplicationController
 
   def index
     if params[:work_id]
-      @work = Work.find_by!(id: params[:work_id])
+      @work = Work.find(params[:work_id])
       @collections = @work.approved_collections
         .by_title
         .for_blurb

--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -30,31 +30,27 @@ class CollectionsController < ApplicationController
   end
 
   def index
-    if params[:work_id] && (@work = Work.find_by(id: params[:work_id]))
+    if params[:work_id]
+      @work = Work.find_by!(id: params[:work_id])
       @collections = @work.approved_collections
         .by_title
         .for_blurb
         .paginate(page: params[:page])
-    elsif params[:collection_id] && (@collection = Collection.find_by(name: params[:collection_id]))
+    elsif params[:collection_id]
+      @collection = Collection.find_by!(name: params[:collection_id])
       @collections = @collection.children
         .by_title
         .for_blurb
         .paginate(page: params[:page])
       @page_subtitle = t(".subcollections_page_title", collection_title: @collection.title)
-    elsif params[:user_id] && (@user = User.find_by(login: params[:user_id]))
+    elsif params[:user_id]
+      @user = User.find_by!(login: params[:user_id])
       @collections = @user.maintained_collections
         .by_title
         .for_blurb
         .paginate(page: params[:page])
       @page_subtitle = ts("%{username} - Collections", username: @user.login)
     else
-      if params[:user_id]
-        flash.now[:error] = ts("We couldn't find a user by that name, sorry.")
-      elsif params[:collection_id]
-        flash.now[:error] = ts("We couldn't find a collection by that name.")
-      elsif params[:work_id]
-        flash.now[:error] = ts("We couldn't find that work.")
-      end
       @sort_and_filter = true
       params[:collection_filters] ||= {}
       params[:sort_column] = "collections.created_at" if !valid_sort_column(params[:sort_column], 'collection')

--- a/spec/controllers/collections_controller_spec.rb
+++ b/spec/controllers/collections_controller_spec.rb
@@ -28,6 +28,59 @@ describe CollectionsController do
         it_redirects_to_with_error(root_path, "Sorry, you don't have permission to access the page you were trying to reach. Please log in.")
       end
     end
+
+    context "when indexing collections for an object" do
+      context "when work does not exist" do
+        it "raises an error" do
+          expect do
+            get :index, params: { work_id: 0 }
+          end.to raise_error ActiveRecord::RecordNotFound
+        end
+      end
+
+      context "when work exists" do
+        let(:work) { create(:work) }
+
+        it "raises an error" do
+          get :index, params: { work_id: work.id }
+          expect(response).to render_template :index
+        end
+      end
+
+      context "when collection does not exist" do
+        it "raises an error" do
+          expect do
+            get :index, params: { collection_id: "not_here" }
+          end.to raise_error ActiveRecord::RecordNotFound
+        end
+      end
+
+      context "when collection exists" do
+        let(:collection) { create(:collection) }
+
+        it "raises an error" do
+          get :index, params: { collection_id: collection.name }
+          expect(response).to render_template :index
+        end
+      end
+
+      context "when user does not exist" do
+        it "raises an error" do
+          expect do
+            get :index, params: { user_id: "not_here" }
+          end.to raise_error ActiveRecord::RecordNotFound
+        end
+      end
+
+      context "when user exists" do
+        let(:user) { create(:user) }
+
+        it "raises an error" do
+          get :index, params: { user_id: user.login }
+          expect(response).to render_template :index
+        end
+      end
+    end
   end
 
   describe "GET #show" do

--- a/spec/controllers/collections_controller_spec.rb
+++ b/spec/controllers/collections_controller_spec.rb
@@ -41,7 +41,7 @@ describe CollectionsController do
       context "when work exists" do
         let(:work) { create(:work) }
 
-        it "raises an error" do
+        it "renders the index" do
           get :index, params: { work_id: work.id }
           expect(response).to render_template :index
         end
@@ -58,7 +58,7 @@ describe CollectionsController do
       context "when collection exists" do
         let(:collection) { create(:collection) }
 
-        it "raises an error" do
+        it "renders the index" do
           get :index, params: { collection_id: collection.name }
           expect(response).to render_template :index
         end
@@ -75,7 +75,7 @@ describe CollectionsController do
       context "when user exists" do
         let(:user) { create(:user) }
 
-        it "raises an error" do
+        it "renders the index" do
           get :index, params: { user_id: user.login }
           expect(response).to render_template :index
         end


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-7042

## Purpose

Change collections index to 404 if the object you're trying to view the collections of doesn't exist.

## Credit

Bilka
