### PR TITLE
AO3-6565 Prevent iOS Chrome from automatically linkifying emails

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -16,6 +16,7 @@
       <meta name="googlebot" content="noindex" />
     <% end %>
   	<meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+    <meta name="chrome" content="nointentdetection" />
     <title><%= browser_page_title(@page_title, @page_subtitle) %></title>
 
     <%= render :partial => 'layouts/includes' %>


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6565 ([this comment](https://otwarchive.atlassian.net/browse/AO3-6565?focusedCommentId=368427))

## Purpose

Chrome has a very annoying little feature where it wraps things that look like email addresses or phone numbers in `chrome_annotation` tags to turn them into links. This also makes the text unbreakable, so it can overflow its box and become partially invisible.

This adds an undocumented meta tag that will disable that across the site.

## Testing Instructions

Use Chrome on iOS 18.3.2 or 18.5 and make sure the email addresses on a user's admin page aren't linked.

## References

https://stackoverflow.com/a/78839946

