### PR TITLE
AO3-6565 Fix that find users page displayed results before searching

### DIFF
--- a/app/controllers/admin/admin_users_controller.rb
+++ b/app/controllers/admin/admin_users_controller.rb
@@ -32,6 +32,8 @@ class Admin::AdminUsersController < Admin::BaseController
     # Values for the role dropdown:
     @role_values = @roles.map { |role| [role.name.humanize.titlecase, role.id] }
 
+    return if search_params.empty?
+
     @query = UserQuery.new(search_params)
     @users = @query.search_results.scope(:with_includes_for_admin_index)
   end

--- a/app/models/search/user_query.rb
+++ b/app/models/search/user_query.rb
@@ -7,6 +7,10 @@ class UserQuery < Query
     UserIndexer.index_name
   end
 
+  def document_type
+    UserIndexer.document_type
+  end
+
   def filters
     @filters ||= [
       id_filter,

--- a/app/views/admin/admin_users/index.html.erb
+++ b/app/views/admin/admin_users/index.html.erb
@@ -69,9 +69,9 @@
               </tr>
             <% end %>
           </tbody>
-        <% end %>
-      </table>
-    </div>
+        </table>
+      </div>
+    <% end %>
     <%= will_paginate @users %>
   <% end %>
   <!--/content-->

--- a/features/admins/users/admin_find_users.feature
+++ b/features/admins/users/admin_find_users.feature
@@ -12,6 +12,16 @@ Feature: Admin Find Users page
       And all emails have been delivered
       And I go to the manage users page
 
+  Scenario: The Find Users page shows no results before searching and all results with blank search
+    Then I should not see "userA"
+      And I should not see "userB"
+      And I should not see "userCB"
+      And I should not see "found"
+    When I submit
+    Then I should see "userA"
+      And I should see "userB"
+      And I should see "userCB"
+
   Scenario: The Find Users page performs a partial match on name with * wildcard
     When I fill in "Name" with "u*er*"
       And I submit


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6565

## Purpose

Fix that find users page displayed results before searching and define `document_type` on the query because all other queries have it, despite it seemingly being unused. Mostly to avoid this biting us at some later point.

Also fix some invalid HTML when a search returns no results.

## Credit

Bilka
