### PR TITLE
AO3-7057 Add error message display to admin invitation page

### DIFF
--- a/app/views/admin/admin_invitations/index.html.erb
+++ b/app/views/admin/admin_invitations/index.html.erb
@@ -1,5 +1,6 @@
 <!--Descriptive page name, messages and instructions-->
 <h2 class="heading"><%= t(".page_heading") %></h2>
+<%= error_messages_for @invitation %>
 <!--/descriptions-->
 <!--subnav-->
 <ul class="navigation actions" role="navigation">
@@ -53,6 +54,7 @@
       </dd>
       <dt class="landmark"><%= t(".grant_invites.landmark_submit") %></dt>
       <dd class="submit actions"><%= submit_tag t(".grant_invites.generate_invitations") %></dd>
+    </dl>
   </fieldset>
 <% end %>
 

--- a/features/admins/admin_invitations.feature
+++ b/features/admins/admin_invitations.feature
@@ -263,6 +263,15 @@ Feature: Admin Actions to Manage Invitations
     Then I should see "An invitation was sent to fred@bedrock.com"
       And 1 email should be delivered
 
+  Scenario: An admin can't create an invite with invalid email
+    Given I am logged in as an admin
+      And all emails have been delivered
+    When I follow "Invite New Users"
+      And I fill in "invitation[invitee_email]" with "abcdefgh"
+      And I press "Invite user"
+    Then I should see "Invitee email should look like an email address. Please use a different address or leave blank."
+      And 0 email should be delivered
+
   Scenario: An admin can't create an invite without an email address.
     Given I am logged in as an admin
       And all emails have been delivered


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-7057

## Purpose

Show validation errors when sending invitations directly to an email as admin.

## Credit

Bilka
