### PR TITLE
AO3-6565 Make user indexer shards configurable

### DIFF
--- a/app/models/search/user_indexer.rb
+++ b/app/models/search/user_indexer.rb
@@ -7,6 +7,15 @@ class UserIndexer < Indexer
     User.includes(:pseuds, :roles, :audits)
   end
 
+  def self.index_all(options = {})
+    unless options[:skip_delete]
+      delete_index
+      create_index(shards: ArchiveConfig.USER_SHARDS)
+    end
+    options[:skip_delete] = true
+    super(options)
+  end
+
   def self.mapping
     {
       properties: {

--- a/config/config.yml
+++ b/config/config.yml
@@ -759,6 +759,7 @@ PERCONA_ARGS: >
   --no-check-unique-key-change
 
 # How many shards to have in elastic indexes.
-# Production has more than 5 for these
+# Production may have more than 5 for these
 BOOKMARKABLE_SHARDS: 5
 WORKS_SHARDS: 5
+USER_SHARDS: 5


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6565

## Purpose

Make the number of shards for the user indexer configurable.

## Credit

Bilka
