### PR TITLE
AO3-6817 Prerender works links on hover

### DIFF
--- a/app/views/layouts/_javascripts.html.erb
+++ b/app/views/layouts/_javascripts.html.erb
@@ -111,4 +111,18 @@
   <% end %>
 <% end %>
 
+<script type="speculationrules">
+  {
+    "prerender": [
+      {
+        "source": "document",
+        "eagerness": "moderate",
+        "where": {
+          "href_matches": "/works/*"
+        }
+      }
+    ]
+  }
+</script>
+
 <%= yield :footer_js %>


### PR DESCRIPTION
# Pull Request Checklist

<!-- Mark steps in the checklist as complete by changing `[ ]` to `[X]` -->
* [x] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [ ] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)? Like [previous speculative loading PRs](https://github.com/otwcode/otwarchive/pulls?q=is%3Apr+author%3Adomenic+is%3Aclosed), we think it's OK not to have tests for these
* [x] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [x] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-6817

## Purpose

Adds prerendering of any link to a URL starting with `/works/`, which will trigger on hover. This is addition to (and does not conflict with) the idle-time prerendering of the next chapter. This makes clicking around Ao3 pretty snappy in general!

## Testing Instructions

See https://otwarchive.atlassian.net/browse/AO3-6817.

## References

See https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/script/type/speculationrules for more on the feature being used here.

## Credit

Domenic Denicola, he/him