### PR TITLE
AO3-7065 Fix flaky bookmarks v2 API tests

### DIFF
--- a/config/initializers/gem-plugin_config/webmock.rb
+++ b/config/initializers/gem-plugin_config/webmock.rb
@@ -1,5 +1,6 @@
 if Rails.env.test?
-  # https://stackoverflow.com/questions/59632283/chromedriver-capybara-too-many-open-files-socket2-for-127-0-0-1-port-951
-  WebMock.allow_net_connect!(net_http_connect_on_start: true)
+  # net_http_connect_on_start: https://stackoverflow.com/questions/59632283/chromedriver-capybara-too-many-open-files-socket2-for-127-0-0-1-port-951
+  # limited to localhost: https://github.com/bblimke/webmock/issues/955#issuecomment-1373962511
+  WebMock.allow_net_connect!(net_http_connect_on_start: %w[127.0.0.1 localhost])
   WebMock.enable!
 end

--- a/spec/controllers/api/v2/api_bookmarks_spec.rb
+++ b/spec/controllers/api/v2/api_bookmarks_spec.rb
@@ -106,7 +106,7 @@ describe "API v2 BookmarksController", type: :request, bookmark_search: true do
                    "This bookmark does not contain a URL to an external site. Please specify a valid, non-AO3 URL."
     end
 
-    it "returns an error message if the URL is on AO3" do
+    xit "returns an error message if the URL is on AO3" do
       work = create(:work)
       post "/api/v2/bookmarks",
            params: { archivist: archivist.login,


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-7065

## Purpose

Change webmock to only connect to Capybara requests on start, not all of them, which could result in unexpected connection failures for normally stubbed requests.

Five runs without problems after the change: https://github.com/Bilka2/otwarchive/actions/runs/16387864713

This breaks the "returns an error message if the URL is on AO3" test, which was previously hitting a 404 on example.com. External works can generally be created for AO3 URLs, there is no check for this in the external work model, despite what https://github.com/otwcode/otwarchive/blob/c1d52a8b76b1b76da4879f009d1e5f703e13d97a/app/controllers/api/v2/bookmarks_controller.rb#L164 implies. The creation usually fails on production/staging because it's always using a HTTP URL and AO3 appears to mostly be returning 520 errors for those on the first request. Refer to [AO3-5981](https://otwarchive.atlassian.net/browse/AO3-5981).

## References

Mailing list: Pointer from Marcus that webmock is the problem and that solving this breaks the "returns an error message if the URL is on AO3" test

https://github.com/bblimke/webmock/issues/955 and https://github.com/bblimke/webmock/pull/975 for more info on the underlying issue and solution

## Credit

marcus8448
Bilka


[AO3-5981]: https://otwarchive.atlassian.net/browse/AO3-5981?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ