### PR TITLE
AO3-6580 Sets confirmation page title to "Account Created"

### DIFF
--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -3,7 +3,7 @@ class Users::RegistrationsController < Devise::RegistrationsController
   before_action :configure_permitted_parameters
 
   def new
-    @page_subtitle = t("registrations.page_title") # Displays "New Registration" otherwise
+    @page_subtitle = t(".page_title")
     super do |resource|
       if params[:invitation_token]
         @invitation = Invitation.find_by(token: params[:invitation_token])
@@ -16,7 +16,7 @@ class Users::RegistrationsController < Devise::RegistrationsController
   end
 
   def create
-    @page_subtitle = t("registrations.account_created_page_title")
+    @page_subtitle = t(".page_title")
     @hide_dashboard = true
     build_resource(sign_up_params)
 

--- a/config/locales/controllers/en.yml
+++ b/config/locales/controllers/en.yml
@@ -186,9 +186,6 @@ en:
     clear:
       error: There were problems deleting your history. Please try again later.
       success: Your history is now cleared.
-  registrations:
-    account_created_page_title: Account Created
-    page_title: Create Account
   related_works:
     index:
       page_title: "%{login} - Related Works"
@@ -249,6 +246,11 @@ en:
         logged_in: You are not logged in to the account whose email you are trying to change. Please log out and try again.
       invalid_token: This email confirmation link is invalid or expired. Please check your email for the correct link or submit the email change form again.
       success: Your email has been successfully updated.
+    registrations:
+      create:
+        page_title: Account Created
+      new:
+        page_title: Create Account
     status:
       ban_notice_html: Your account has been banned. You are not permitted to post or edit content on AO3. Please check your email or %{contact_abuse_link} for more information.
       suspension_notice_html: Your account has been suspended until %{suspended_until}. You cannot post, edit, or delete content until your suspension has ended. Please check your email or %{contact_abuse_link} for more information.

--- a/features/users/user_create.feature
+++ b/features/users/user_create.feature
@@ -77,10 +77,10 @@ Feature: Sign Up for a new account
 
   Scenario: The user should be able to create a new account with a valid email and password
     When I fill in the sign up form with valid data
-    Then I should see the page title "Create Account | Example Archive"
-      And all emails have been delivered
+    Then I should see the page title "Create Account"
+    When all emails have been delivered
       And I press "Create Account"
-    Then I should see the page title "Account Created | Example Archive"
-    Then I should see "Almost Done!"
+    Then I should see the page title "Account Created"
+      And I should see "Almost Done!"
       And I should get a new user activation email
       And a new user account should exist


### PR DESCRIPTION
# Pull Request Checklist

<!-- Mark steps in the checklist as complete by changing `[ ]` to `[X]` -->
* [X] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [X] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [X] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [X] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [X] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-6580

## Purpose

Sets confirmation page title to "Account Created" from "Create Registration"

## Testing Instructions

1. With signups open, create a new account
2. On the "Almost Done!" page, confirm tab title displays "Account Created"

## Credit

anna (she/her)
