### PR TITLE
AO3-7006 Move list markers in comments inwards

### DIFF
--- a/public/stylesheets/site/2.0/21-userstuff.css
+++ b/public/stylesheets/site/2.0/21-userstuff.css
@@ -182,6 +182,10 @@
 
 /* contexts */
 
+.comment .userstuff li {
+  list-style-position: inside;
+}
+
 .bookmark .user .userstuff {
   line-height: 1.5;
 }


### PR DESCRIPTION
# Pull Request Checklist

<!-- Mark steps in the checklist as complete by changing `[ ]` to `[X]` -->
* [X] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [X] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [X] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [X] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [X] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-7006

## Purpose

Updates `21-userstuff.css` stylesheet to move list items inwards such that markers do not overlap with profile photos.

## Testing Instructions

Leave a comment on a work with the content `<ul><li>item</li></ul><ol><li>item</li></ol>`

Here are locally-tested before and after screenshots:

Before:

<img width="312" height="477" alt="before mod" src="https://github.com/user-attachments/assets/544be8c3-e473-4ca3-a969-e3082b21f99f" />


After modifying `list-style-position`:
<img width="246" height="469" alt="Screenshot 2025-07-23 at 12 28 03 AM" src="https://github.com/user-attachments/assets/12f750c2-c411-4eb0-b6f5-72c3a1639290" />



## Credit

theamandawang (she/her)
