### PR TITLE
AO3-7076 Remove box-shadow on checkboxes and radio inputs

### DIFF
--- a/public/stylesheets/site/2.0/07-interactions.css
+++ b/public/stylesheets/site/2.0/07-interactions.css
@@ -102,7 +102,11 @@ select {
   width: 32.5%;
 }
 
-input[type="radio"], input[type="checkbox"], input[type="file"], input.number, p input, p select, .heading select, li select {
+input[type="checkbox"], input[type="radio"] {
+    box-shadow: none;
+}
+
+input[type="checkbox"], input[type="file"], input[type="radio"], input.number, p input, p select, .heading select, li select {
   width: auto;
   margin-right: 0.375em;
 }


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-7076

## Purpose

Remove a box-shadow that was doing weird things to checkboxes and radio buttons in Chrome. (The shadow did nothing in other browsers, so we're not losing anything.)