### PR TITLE
AO3-7093 Add test for invalid records in otwseed fixtures

### DIFF
--- a/spec/lib/tasks/database_seed.rake_spec.rb
+++ b/spec/lib/tasks/database_seed.rake_spec.rb
@@ -1,0 +1,17 @@
+require "spec_helper"
+
+describe "rake db:fixtures:load" do
+  it "should result in valid records" do
+    subject.invoke
+
+    # Make sure all subclasses are present in ApplicationRecord.descendants
+    Rails.application.eager_load!
+
+    ApplicationRecord.descendants.each do |model|
+      model.all.each do |record|
+        expect(record).to be_valid
+      end
+    end
+  end
+end
+

--- a/test/fixtures/admin_settings.yml
+++ b/test/fixtures/admin_settings.yml
@@ -5,7 +5,7 @@ admin_setting_3:
   invite_from_queue_number: 10
   invite_from_queue_frequency: 7
   days_to_purge_unactivated: 7
-  last_updated_by:
+  last_updated_by: 1
   created_at: 2015-04-11 21:57:43.000000000 Z
   updated_at: 2015-04-11 21:57:43.000000000 Z
   invite_from_queue_at: 2015-04-18 21:57:43.000000000 Z

--- a/test/fixtures/chapters.yml
+++ b/test/fixtures/chapters.yml
@@ -13567,21 +13567,6 @@ chapter_00090:
   endnotes: 
   work_id: 81
   hidden_by_admin: false
-chapter_00063: 
-  posted: false
-  position: 1
-  created_at: 2009-06-07 17:24:44 Z
-  title: ""
-  updated_at: 2009-06-07 17:24:44 Z
-  notes: 
-  word_count: 7
-  id: 63
-  content: Uvc Z zbdpl rvao a dlipxiwws nxoia?
-  summary: 
-  published_at: 
-  endnotes: 
-  work_id: 55
-  hidden_by_admin: false
 chapter_00148: 
   posted: true
   position: 28

--- a/test/fixtures/common_taggings.yml
+++ b/test/fixtures/common_taggings.yml
@@ -62,13 +62,6 @@ common_tagging_00161:
   updated_at: 2008-12-07 21:06:54 Z
   id: 161
   filterable_id: 1063753758
-common_tagging_00190: 
-  filterable_type: Tag
-  common_tag_id: 1063753811
-  created_at: 2009-02-16 06:09:20 Z
-  updated_at: 2009-02-16 06:09:20 Z
-  id: 190
-  filterable_id: 1063753738
 common_tagging_00162: 
   filterable_type: Tag
   common_tag_id: 1063753762
@@ -216,13 +209,6 @@ common_tagging_02993:
   updated_at: 2009-03-20 20:06:52 Z
   id: 2993
   filterable_id: 1063753818
-common_tagging_00197: 
-  filterable_type: Tag
-  common_tag_id: 1063753747
-  created_at: 2009-02-16 06:11:18 Z
-  updated_at: 2009-02-16 06:11:18 Z
-  id: 197
-  filterable_id: 1063753738
 common_tagging_02938: 
   filterable_type: Tag
   common_tag_id: 1063753893
@@ -293,13 +279,6 @@ common_tagging_01652:
   updated_at: 2009-02-21 00:12:26 Z
   id: 1652
   filterable_id: 1063753818
-common_tagging_00085: 
-  filterable_type: Tag
-  common_tag_id: 0
-  created_at: 2008-11-21 07:59:52 Z
-  updated_at: 2008-11-21 07:59:52 Z
-  id: 85
-  filterable_id: 221905380
 common_tagging_00199: 
   filterable_type: Tag
   common_tag_id: 1063753750
@@ -349,13 +328,6 @@ common_tagging_01655:
   updated_at: 2009-02-21 00:12:45 Z
   id: 1655
   filterable_id: 1063753818
-common_tagging_00088: 
-  filterable_type: Tag
-  common_tag_id: 0
-  created_at: 2008-11-21 07:59:52 Z
-  updated_at: 2008-11-21 07:59:52 Z
-  id: 88
-  filterable_id: 26796919
 common_tagging_00001: 
   filterable_type: Tag
   common_tag_id: 26796919
@@ -391,13 +363,6 @@ common_tagging_00173:
   updated_at: 2009-02-16 05:57:47 Z
   id: 173
   filterable_id: 221905380
-common_tagging_00031: 
-  filterable_type: Tag
-  common_tag_id: 552317390
-  created_at: 2008-11-21 07:16:27 Z
-  updated_at: 2008-11-21 07:16:27 Z
-  id: 31
-  filterable_id: 713695255
 common_tagging_00003: 
   filterable_type: Tag
   common_tag_id: 545584597
@@ -405,13 +370,6 @@ common_tagging_00003:
   updated_at: 2008-11-21 06:11:27 Z
   id: 3
   filterable_id: 26796919
-common_tagging_00200: 
-  filterable_type: Tag
-  common_tag_id: 1063753750
-  created_at: 2009-02-16 06:11:18 Z
-  updated_at: 2009-02-16 06:11:18 Z
-  id: 200
-  filterable_id: 1063753738
 common_tagging_00174: 
   filterable_type: Tag
   common_tag_id: 1063753753
@@ -440,13 +398,6 @@ common_tagging_00175:
   updated_at: 2009-02-16 06:01:04 Z
   id: 175
   filterable_id: 1063753780
-common_tagging_00033: 
-  filterable_type: Tag
-  common_tag_id: 221905380
-  created_at: 2008-11-21 07:23:11 Z
-  updated_at: 2008-11-21 07:23:11 Z
-  id: 33
-  filterable_id: 713695255
 common_tagging_00230: 
   filterable_type: Tag
   common_tag_id: 1063753748
@@ -461,13 +412,6 @@ common_tagging_00202:
   updated_at: 2009-02-16 06:14:02 Z
   id: 202
   filterable_id: 1063753752
-common_tagging_00176: 
-  filterable_type: Tag
-  common_tag_id: 1063753808
-  created_at: 2009-02-16 06:01:04 Z
-  updated_at: 2009-02-16 06:01:04 Z
-  id: 176
-  filterable_id: 1063753738
 common_tagging_00034: 
   filterable_type: Tag
   common_tag_id: 545584597
@@ -552,13 +496,6 @@ common_tagging_00036:
   updated_at: 2008-11-21 07:33:32 Z
   id: 36
   filterable_id: 791950904
-common_tagging_00206: 
-  filterable_type: Tag
-  common_tag_id: 1063753813
-  created_at: 2009-02-16 06:17:18 Z
-  updated_at: 2009-02-16 06:17:18 Z
-  id: 206
-  filterable_id: 1063753738
 common_tagging_02948: 
   filterable_type: Tag
   common_tag_id: 1063753840
@@ -601,13 +538,6 @@ common_tagging_00095:
   updated_at: 2008-11-21 07:59:52 Z
   id: 95
   filterable_id: 26796919
-common_tagging_00208: 
-  filterable_type: Tag
-  common_tag_id: 1063753812
-  created_at: 2009-02-16 06:17:18 Z
-  updated_at: 2009-02-16 06:17:18 Z
-  id: 208
-  filterable_id: 1063753738
 common_tagging_00150: 
   filterable_type: Tag
   common_tag_id: 1063753781
@@ -643,13 +573,6 @@ common_tagging_00152:
   updated_at: 2008-12-07 21:05:37 Z
   id: 152
   filterable_id: 741440589
-common_tagging_00098: 
-  filterable_type: Tag
-  common_tag_id: 26796919
-  created_at: 2008-11-21 08:02:42 Z
-  updated_at: 2008-11-21 08:02:42 Z
-  id: 98
-  filterable_id: 1063753746
 common_tagging_00153: 
   filterable_type: Tag
   common_tag_id: 1063753803
@@ -720,13 +643,6 @@ common_tagging_02952:
   updated_at: 2009-03-19 01:55:30 Z
   id: 2952
   filterable_id: 569823665
-common_tagging_00183: 
-  filterable_type: Tag
-  common_tag_id: 1063753779
-  created_at: 2009-02-16 06:03:48 Z
-  updated_at: 2009-02-16 06:03:48 Z
-  id: 183
-  filterable_id: 1063753738
 common_tagging_02924: 
   filterable_type: Tag
   common_tag_id: 1063753887

--- a/test/fixtures/creatorships.yml
+++ b/test/fixtures/creatorships.yml
@@ -367,14 +367,6 @@ creatorship_596033164:
   creation_type: Series
   approved: true
   id: 596033164
-creatorship_596033218: 
-  pseud_id: 17
-  created_at: 2009-03-09 16:33:16 Z
-  updated_at: 2009-03-09 16:33:16 Z
-  creation_id: 21
-  creation_type: Work
-  approved: true
-  id: 596033218
 creatorship_596033245: 
   pseud_id: 2
   created_at: 2009-03-11 21:54:50 Z
@@ -447,14 +439,6 @@ creatorship_596033165:
   creation_type: Series
   approved: true
   id: 596033165
-creatorship_596033219: 
-  pseud_id: 17
-  created_at: 2009-03-09 16:33:16 Z
-  updated_at: 2009-03-09 16:33:16 Z
-  creation_id: 23
-  creation_type: Chapter
-  approved: true
-  id: 596033219
 creatorship_596033326: 
   pseud_id: 3
   created_at: 2009-03-20 23:11:56 Z
@@ -1095,14 +1079,6 @@ creatorship_596033205:
   creation_type: Chapter
   approved: true
   id: 596033205
-creatorship_596033232: 
-  pseud_id: 17
-  created_at: 2009-03-09 21:56:37 Z
-  updated_at: 2009-03-09 21:56:37 Z
-  creation_id: 26
-  creation_type: Work
-  approved: true
-  id: 596033232
 creatorship_596033501: 
   pseud_id: 38
   created_at: 2009-12-12 23:28:00 Z
@@ -1127,14 +1103,6 @@ creatorship_596033206:
   creation_type: Work
   approved: true
   id: 596033206
-creatorship_596033233: 
-  pseud_id: 16
-  created_at: 2009-03-09 21:56:37 Z
-  updated_at: 2009-03-09 21:56:37 Z
-  creation_id: 26
-  creation_type: Work
-  approved: true
-  id: 596033233
 creatorship_596033313: 
   pseud_id: 16
   created_at: 2009-03-18 04:09:43 Z
@@ -1183,14 +1151,6 @@ creatorship_596033207:
   creation_type: Chapter
   approved: true
   id: 596033207
-creatorship_596033234: 
-  pseud_id: 17
-  created_at: 2009-03-09 21:56:37 Z
-  updated_at: 2009-03-09 21:56:37 Z
-  creation_id: 28
-  creation_type: Chapter
-  approved: true
-  id: 596033234
 creatorship_596033260: 
   pseud_id: 17
   created_at: 2009-03-12 00:28:57 Z
@@ -1231,22 +1191,6 @@ creatorship_596033154:
   creation_type: Work
   approved: true
   id: 596033154
-creatorship_596033208: 
-  pseud_id: 17
-  created_at: 2009-03-07 20:48:07 Z
-  updated_at: 2009-03-07 20:48:07 Z
-  creation_id: 18
-  creation_type: Work
-  approved: true
-  id: 596033208
-creatorship_596033235: 
-  pseud_id: 16
-  created_at: 2009-03-09 21:56:37 Z
-  updated_at: 2009-03-09 21:56:37 Z
-  creation_id: 28
-  creation_type: Chapter
-  approved: true
-  id: 596033235
 creatorship_596033261: 
   pseud_id: 17
   created_at: 2009-03-12 00:28:57 Z
@@ -1295,22 +1239,6 @@ creatorship_596033155:
   creation_type: Chapter
   approved: true
   id: 596033155
-creatorship_596033209: 
-  pseud_id: 17
-  created_at: 2009-03-07 20:48:07 Z
-  updated_at: 2009-03-07 20:48:07 Z
-  creation_id: 20
-  creation_type: Chapter
-  approved: true
-  id: 596033209
-creatorship_596033262: 
-  pseud_id: 17
-  created_at: 2009-03-12 00:33:29 Z
-  updated_at: 2009-03-12 00:33:29 Z
-  creation_id: 37
-  creation_type: Work
-  approved: true
-  id: 596033262
 creatorship_596033316: 
   pseud_id: 5
   created_at: 2009-03-18 04:10:19 Z
@@ -1367,22 +1295,6 @@ creatorship_596033156:
   creation_type: Work
   approved: true
   id: 596033156
-creatorship_596033236: 
-  pseud_id: 1
-  created_at: 2009-03-09 23:22:34 Z
-  updated_at: 2009-03-09 23:22:34 Z
-  creation_id: 27
-  creation_type: Work
-  approved: true
-  id: 596033236
-creatorship_596033263: 
-  pseud_id: 17
-  created_at: 2009-03-12 00:33:29 Z
-  updated_at: 2009-03-12 00:33:29 Z
-  creation_id: 39
-  creation_type: Chapter
-  approved: true
-  id: 596033263
 creatorship_596033317: 
   pseud_id: 5
   created_at: 2009-03-18 04:10:19 Z
@@ -1391,14 +1303,6 @@ creatorship_596033317:
   creation_type: Chapter
   approved: true
   id: 596033317
-creatorship_596033370: 
-  pseud_id: 5
-  created_at: 2009-09-17 23:11:18 Z
-  updated_at: 2009-09-17 23:11:18 Z
-  creation_id: 66
-  creation_type: Work
-  approved: true
-  id: 596033370
 creatorship_596033424: 
   pseud_id: 37
   created_at: 2009-12-12 22:14:13 Z
@@ -1423,14 +1327,6 @@ creatorship_596033157:
   creation_type: Chapter
   approved: true
   id: 596033157
-creatorship_596033237: 
-  pseud_id: 1
-  created_at: 2009-03-09 23:22:34 Z
-  updated_at: 2009-03-09 23:22:34 Z
-  creation_id: 29
-  creation_type: Chapter
-  approved: true
-  id: 596033237
 creatorship_596033264: 
   pseud_id: 17
   created_at: 2009-03-12 00:50:20 Z
@@ -1455,14 +1351,6 @@ creatorship_596033318:
   creation_type: Series
   approved: true
   id: 596033318
-creatorship_596033371: 
-  pseud_id: 5
-  created_at: 2009-09-17 23:11:18 Z
-  updated_at: 2009-09-17 23:11:18 Z
-  creation_id: 75
-  creation_type: Chapter
-  approved: true
-  id: 596033371
 creatorship_596033425: 
   pseud_id: 37
   created_at: 2009-12-12 22:14:13 Z
@@ -1575,14 +1463,6 @@ creatorship_596033266:
   creation_type: Work
   approved: true
   id: 596033266
-creatorship_596033346: 
-  pseud_id: 5
-  created_at: 2009-06-07 17:24:45 Z
-  updated_at: 2009-06-07 17:24:45 Z
-  creation_id: 55
-  creation_type: Work
-  approved: true
-  id: 596033346
 creatorship_596033373: 
   pseud_id: 32
   created_at: 2009-12-12 21:10:09 Z
@@ -1911,14 +1791,6 @@ creatorship_596033301:
   creation_type: Chapter
   approved: true
   id: 596033301
-creatorship_596033220: 
-  pseud_id: 17
-  created_at: 2009-03-09 17:04:58 Z
-  updated_at: 2009-03-09 17:04:58 Z
-  creation_id: 22
-  creation_type: Work
-  approved: true
-  id: 596033220
 creatorship_596033140: 
   pseud_id: 8
   created_at: 2008-12-06 22:28:58 Z
@@ -1927,14 +1799,6 @@ creatorship_596033140:
   creation_type: Work
   approved: true
   id: 596033140
-creatorship_596033221: 
-  pseud_id: 17
-  created_at: 2009-03-09 17:04:58 Z
-  updated_at: 2009-03-09 17:04:58 Z
-  creation_id: 24
-  creation_type: Chapter
-  approved: true
-  id: 596033221
 creatorship_596033141: 
   pseud_id: 8
   created_at: 2008-12-06 22:28:58 Z
@@ -1943,14 +1807,6 @@ creatorship_596033141:
   creation_type: Chapter
   approved: true
   id: 596033141
-creatorship_596033222: 
-  pseud_id: 17
-  created_at: 2009-03-09 17:20:58 Z
-  updated_at: 2009-03-09 17:20:58 Z
-  creation_id: 23
-  creation_type: Work
-  approved: true
-  id: 596033222
 creatorship_596033302: 
   pseud_id: 4
   created_at: 2009-03-18 04:06:04 Z
@@ -1983,14 +1839,6 @@ creatorship_596033330:
   creation_type: Work
   approved: true
   id: 596033330
-creatorship_596033223: 
-  pseud_id: 17
-  created_at: 2009-03-09 17:20:58 Z
-  updated_at: 2009-03-09 17:20:58 Z
-  creation_id: 25
-  creation_type: Chapter
-  approved: true
-  id: 596033223
 creatorship_596033303: 
   pseud_id: 17
   created_at: 2009-03-18 04:06:50 Z
@@ -1999,22 +1847,6 @@ creatorship_596033303:
   creation_type: Chapter
   approved: true
   id: 596033303
-creatorship_596033142: 
-  pseud_id: 8
-  created_at: 2008-12-06 22:32:20 Z
-  updated_at: 2008-12-06 22:32:20 Z
-  creation_id: 9
-  creation_type: Chapter
-  approved: true
-  id: 596033142
-creatorship_596033224: 
-  pseud_id: 17
-  created_at: 2009-03-09 21:54:12 Z
-  updated_at: 2009-03-09 21:54:12 Z
-  creation_id: 24
-  creation_type: Work
-  approved: true
-  id: 596033224
 creatorship_596033304: 
   pseud_id: 2
   created_at: 2009-03-18 04:06:50 Z
@@ -2023,14 +1855,6 @@ creatorship_596033304:
   creation_type: Chapter
   approved: true
   id: 596033304
-creatorship_596033250: 
-  pseud_id: 17
-  created_at: 2009-03-11 22:18:40 Z
-  updated_at: 2009-03-11 22:18:40 Z
-  creation_id: 31
-  creation_type: Work
-  approved: true
-  id: 596033250
 creatorship_596033331: 
   pseud_id: 2
   created_at: 2009-03-20 23:17:44 Z
@@ -2063,14 +1887,6 @@ creatorship_596033332:
   creation_type: Series
   approved: true
   id: 596033332
-creatorship_596033251: 
-  pseud_id: 17
-  created_at: 2009-03-11 22:18:40 Z
-  updated_at: 2009-03-11 22:18:40 Z
-  creation_id: 33
-  creation_type: Chapter
-  approved: true
-  id: 596033251
 creatorship_596033305: 
   pseud_id: 4
   created_at: 2009-03-18 04:06:50 Z
@@ -2135,14 +1951,6 @@ creatorship_596033171:
   creation_type: Work
   approved: true
   id: 596033171
-creatorship_596033225: 
-  pseud_id: 17
-  created_at: 2009-03-09 21:54:12 Z
-  updated_at: 2009-03-09 21:54:12 Z
-  creation_id: 26
-  creation_type: Chapter
-  approved: true
-  id: 596033225
 creatorship_596033226: 
   pseud_id: 17
   created_at: 2009-03-09 21:54:33 Z
@@ -2439,7 +2247,7 @@ creatorship_596033176:
   creation_type: Series
   approved: true
   id: 596033176
-creatorship_596033418: 
+creatorship_596033418:
   pseud_id: 26
   created_at: 2009-12-12 21:20:47 Z
   updated_at: 2009-12-12 21:20:47 Z

--- a/test/fixtures/gifts.yml
+++ b/test/fixtures/gifts.yml
@@ -5,9 +5,5 @@ one:
   recipient_name: GiftRecipient1
 
 two:
-  work_id: 1
-  recipient_name: Recipient2
-  
-three:
   work_id: 14
   recipient_name: testuser 

--- a/test/fixtures/pseuds.yml
+++ b/test/fixtures/pseuds.yml
@@ -45,7 +45,7 @@ pseud_00039:
   created_at: 2009-12-12 23:45:44 Z
   delta: true
   updated_at: 2009-12-12 23:45:44 Z
-  is_default: false
+  is_default: true
   id: 39
   user_id: 32
   description: 

--- a/test/fixtures/series.yml
+++ b/test/fixtures/series.yml
@@ -54,16 +54,6 @@ series_00005:
   complete: false
   summary: Series including both public and restricted works, unregistered users should see no trace of the restricted ones!
   hidden_by_admin: false
-series_00006: 
-  restricted: true
-  created_at: 2009-12-12 22:43:13 Z
-  title: NCIS and the...
-  updated_at: 2009-12-12 22:43:13 Z
-  series_notes: 
-  id: 6
-  complete: false
-  summary: 
-  hidden_by_admin: false
 series_00007: 
   restricted: false
   created_at: 2009-12-12 22:48:20 Z

--- a/test/fixtures/taggings.yml
+++ b/test/fixtures/taggings.yml
@@ -255,14 +255,6 @@ tagging_1067725740:
   taggable_id: 107
   tagger_type: Tag
   taggable_type: Work
-tagging_1067725055: 
-  tagger_id: 1063753741
-  created_at: 2009-03-11 22:18:40 Z
-  updated_at: 2009-03-11 22:18:40 Z
-  id: 1067725055
-  taggable_id: 31
-  tagger_type: Tag
-  taggable_type: Work
 tagging_1067725187: 
   tagger_id: 1063753905
   created_at: 2009-03-20 23:14:14 Z
@@ -277,14 +269,6 @@ tagging_1067725741:
   updated_at: 2010-07-28 13:10:16 Z
   id: 1067725741
   taggable_id: 107
-  tagger_type: Tag
-  taggable_type: Work
-tagging_1067725056: 
-  tagger_id: 885489802
-  created_at: 2009-03-11 22:20:35 Z
-  updated_at: 2009-03-11 22:20:35 Z
-  id: 1067725056
-  taggable_id: 31
   tagger_type: Tag
   taggable_type: Work
 tagging_1067725188: 
@@ -311,14 +295,6 @@ tagging_1067725742:
   taggable_id: 107
   tagger_type: Tag
   taggable_type: Work
-tagging_1067725057: 
-  tagger_id: 569823665
-  created_at: 2009-03-11 22:20:36 Z
-  updated_at: 2009-03-11 22:20:36 Z
-  id: 1067725057
-  taggable_id: 31
-  tagger_type: Tag
-  taggable_type: Work
 tagging_1067725189: 
   tagger_id: 992891255
   created_at: 2009-03-20 23:17:43 Z
@@ -333,14 +309,6 @@ tagging_1067725743:
   updated_at: 2010-07-28 13:10:16 Z
   id: 1067725743
   taggable_id: 107
-  tagger_type: Tag
-  taggable_type: Work
-tagging_1067725058: 
-  tagger_id: 1063753732
-  created_at: 2009-03-11 22:21:05 Z
-  updated_at: 2009-03-11 22:21:05 Z
-  id: 1067725058
-  taggable_id: 31
   tagger_type: Tag
   taggable_type: Work
 tagging_1067725611: 
@@ -525,14 +493,6 @@ tagging_1067725195:
   updated_at: 2009-03-20 23:20:17 Z
   id: 1067725195
   taggable_id: 50
-  tagger_type: Tag
-  taggable_type: Work
-tagging_312493864: 
-  tagger_id: 714102448
-  created_at: 2008-11-09 01:26:02 Z
-  updated_at: 2008-11-09 01:26:02 Z
-  id: 312493864
-  taggable_id: 3
   tagger_type: Tag
   taggable_type: Work
 tagging_35934741: 
@@ -1191,28 +1151,12 @@ tagging_1067725519:
   taggable_id: 87
   tagger_type: Tag
   taggable_type: Work
-tagging_1067725097: 
-  tagger_id: 611729728
-  created_at: 2009-03-12 00:34:06 Z
-  updated_at: 2009-03-12 00:34:06 Z
-  id: 1067725097
-  taggable_id: 37
-  tagger_type: Tag
-  taggable_type: Work
 tagging_1067725650: 
   tagger_id: 1063753905
   created_at: 2009-12-12 23:52:01 Z
   updated_at: 2009-12-12 23:52:01 Z
   id: 1067725650
   taggable_id: 102
-  tagger_type: Tag
-  taggable_type: Work
-tagging_1067725098: 
-  tagger_id: 992891255
-  created_at: 2009-03-12 00:34:06 Z
-  updated_at: 2009-03-12 00:34:06 Z
-  id: 1067725098
-  taggable_id: 37
   tagger_type: Tag
   taggable_type: Work
 tagging_1067725651: 
@@ -1237,22 +1181,6 @@ tagging_1067725520:
   updated_at: 2009-12-12 21:28:21 Z
   id: 1067725520
   taggable_id: 87
-  tagger_type: Tag
-  taggable_type: Work
-tagging_1067725652: 
-  tagger_id: 1063754080
-  created_at: 2009-12-12 23:52:01 Z
-  updated_at: 2009-12-12 23:52:01 Z
-  id: 1067725652
-  taggable_id: 102
-  tagger_type: Tag
-  taggable_type: Work
-tagging_1067725099: 
-  tagger_id: 569823665
-  created_at: 2009-03-12 00:34:06 Z
-  updated_at: 2009-03-12 00:34:06 Z
-  id: 1067725099
-  taggable_id: 37
   tagger_type: Tag
   taggable_type: Work
 tagging_1067725521: 
@@ -1477,14 +1405,6 @@ tagging_1067725665:
   updated_at: 2009-12-13 16:36:12 Z
   id: 1067725665
   taggable_id: 103
-  tagger_type: Tag
-  taggable_type: Work
-tagging_678331033: 
-  tagger_id: 404615116
-  created_at: 2008-11-09 01:26:02 Z
-  updated_at: 2008-11-09 01:26:02 Z
-  id: 678331033
-  taggable_id: 3
   tagger_type: Tag
   taggable_type: Work
 tagging_1067725402: 
@@ -3928,7 +3848,7 @@ tagging_1067725485:
   tagger_type: Tag
   taggable_type: Work
 tagging_1067725222: 
-  tagger_id: 1063753846
+  tagger_id: 1063754002
   created_at: 2009-04-20 01:09:58 Z
   updated_at: 2009-04-20 01:09:58 Z
   id: 1067725222
@@ -4271,14 +4191,6 @@ tagging_1067725496:
   taggable_id: 86
   tagger_type: Tag
   taggable_type: Work
-tagging_1067725100: 
-  tagger_id: 1063754002
-  created_at: 2009-03-12 00:34:06 Z
-  updated_at: 2009-03-12 00:34:06 Z
-  id: 1067725100
-  taggable_id: 37
-  tagger_type: Tag
-  taggable_type: Work
 tagging_1067725232: 
   tagger_id: 1063753774
   created_at: 2009-05-10 13:57:48 Z
@@ -4309,14 +4221,6 @@ tagging_1067724975:
   updated_at: 2008-12-07 20:52:14 Z
   id: 1067724975
   taggable_id: 14
-  tagger_type: Tag
-  taggable_type: Work
-tagging_1067725233: 
-  tagger_id: 112726825
-  created_at: 2009-06-07 17:24:44 Z
-  updated_at: 2009-06-07 17:24:44 Z
-  id: 1067725233
-  taggable_id: 55
   tagger_type: Tag
   taggable_type: Work
 tagging_1067725366: 
@@ -4351,14 +4255,6 @@ tagging_1067725102:
   taggable_id: 38
   tagger_type: Tag
   taggable_type: Work
-tagging_1067725234: 
-  tagger_id: 1063753737
-  created_at: 2009-06-07 17:24:45 Z
-  updated_at: 2009-06-07 17:24:45 Z
-  id: 1067725234
-  taggable_id: 55
-  tagger_type: Tag
-  taggable_type: Work
 tagging_1067725367: 
   tagger_id: 1063753979
   created_at: 2009-07-18 00:18:29 Z
@@ -4383,14 +4279,6 @@ tagging_1067725103:
   taggable_id: 38
   tagger_type: Tag
   taggable_type: Work
-tagging_1067725235: 
-  tagger_id: 1063753741
-  created_at: 2009-06-07 17:24:45 Z
-  updated_at: 2009-06-07 17:24:45 Z
-  id: 1067725235
-  taggable_id: 55
-  tagger_type: Tag
-  taggable_type: Work
 tagging_1067725368: 
   tagger_id: 1063753980
   created_at: 2009-07-18 00:21:37 Z
@@ -4405,22 +4293,6 @@ tagging_1067724978:
   updated_at: 2008-12-07 20:52:15 Z
   id: 1067724978
   taggable_id: 14
-  tagger_type: Tag
-  taggable_type: Work
-tagging_1067725104: 
-  tagger_id: 1063753868
-  created_at: 2009-03-12 00:50:20 Z
-  updated_at: 2009-03-12 00:50:20 Z
-  id: 1067725104
-  taggable_id: 38
-  tagger_type: Tag
-  taggable_type: Work
-tagging_1067725236: 
-  tagger_id: 741440589
-  created_at: 2009-06-07 17:24:45 Z
-  updated_at: 2009-06-07 17:24:45 Z
-  id: 1067725236
-  taggable_id: 55
   tagger_type: Tag
   taggable_type: Work
 tagging_1067725369: 
@@ -4863,14 +4735,6 @@ tagging_1067725383:
   taggable_id: 28
   tagger_type: Tag
   taggable_type: Bookmark
-tagging_1067724992: 
-  tagger_id: 992891255
-  created_at: 2009-03-07 20:48:06 Z
-  updated_at: 2009-03-07 20:48:06 Z
-  id: 1067724992
-  taggable_id: 18
-  tagger_type: Tag
-  taggable_type: Work
 tagging_1067725252: 
   tagger_id: 1063753736
   created_at: 2009-07-17 22:55:32 Z
@@ -4887,22 +4751,6 @@ tagging_1067725384:
   taggable_id: 29
   tagger_type: Tag
   taggable_type: Bookmark
-tagging_1067724993: 
-  tagger_id: 1063753735
-  created_at: 2009-03-07 20:48:07 Z
-  updated_at: 2009-03-07 20:48:07 Z
-  id: 1067724993
-  taggable_id: 18
-  tagger_type: Tag
-  taggable_type: Work
-tagging_1067724994: 
-  tagger_id: 1063754009
-  created_at: 2009-03-07 20:48:07 Z
-  updated_at: 2009-03-07 20:48:07 Z
-  id: 1067724994
-  taggable_id: 18
-  tagger_type: Tag
-  taggable_type: Work
 tagging_1067725121: 
   tagger_id: 1063753741
   created_at: 2009-03-12 01:43:37 Z
@@ -4927,14 +4775,6 @@ tagging_1067725385:
   taggable_id: 29
   tagger_type: Tag
   taggable_type: Bookmark
-tagging_1067724995: 
-  tagger_id: 1063753824
-  created_at: 2009-03-07 20:48:07 Z
-  updated_at: 2009-03-07 20:48:07 Z
-  id: 1067724995
-  taggable_id: 18
-  tagger_type: Tag
-  taggable_type: Work
 tagging_1067725122: 
   tagger_id: 569823665
   created_at: 2009-03-12 01:43:37 Z
@@ -4959,14 +4799,6 @@ tagging_1067725386:
   taggable_id: 30
   tagger_type: Tag
   taggable_type: Bookmark
-tagging_1067724996: 
-  tagger_id: 1063753826
-  created_at: 2009-03-07 20:48:07 Z
-  updated_at: 2009-03-07 20:48:07 Z
-  id: 1067724996
-  taggable_id: 18
-  tagger_type: Tag
-  taggable_type: Work
 tagging_1067725123: 
   tagger_id: 1063753877
   created_at: 2009-03-12 01:43:37 Z
@@ -4991,14 +4823,6 @@ tagging_1067725387:
   taggable_id: 30
   tagger_type: Tag
   taggable_type: Bookmark
-tagging_1067724997: 
-  tagger_id: 1063753827
-  created_at: 2009-03-07 20:48:07 Z
-  updated_at: 2009-03-07 20:48:07 Z
-  id: 1067724997
-  taggable_id: 18
-  tagger_type: Tag
-  taggable_type: Work
 tagging_1067725256: 
   tagger_id: 26796919
   created_at: 2009-07-17 22:55:33 Z
@@ -5015,14 +4839,6 @@ tagging_1067725388:
   taggable_id: 31
   tagger_type: Tag
   taggable_type: Bookmark
-tagging_1067724998: 
-  tagger_id: 1063753828
-  created_at: 2009-03-07 20:48:07 Z
-  updated_at: 2009-03-07 20:48:07 Z
-  id: 1067724998
-  taggable_id: 18
-  tagger_type: Tag
-  taggable_type: Work
 tagging_1067725125: 
   tagger_id: 1063753876
   created_at: 2009-03-12 01:43:37 Z
@@ -5431,14 +5247,6 @@ tagging_1067725270:
   taggable_id: 58
   tagger_type: Tag
   taggable_type: Work
-tagging_1067725007: 
-  tagger_id: 611729728
-  created_at: 2009-03-09 16:42:34 Z
-  updated_at: 2009-03-09 16:42:34 Z
-  id: 1067725007
-  taggable_id: 21
-  tagger_type: Tag
-  taggable_type: Work
 tagging_1067725139: 
   tagger_id: 992891255
   created_at: 2009-03-12 02:02:52 Z
@@ -5463,28 +5271,12 @@ tagging_1067724880:
   taggable_id: 5
   tagger_type: Tag
   taggable_type: Work
-tagging_1067725008: 
-  tagger_id: 112726825
-  created_at: 2009-03-09 16:42:34 Z
-  updated_at: 2009-03-09 16:42:34 Z
-  id: 1067725008
-  taggable_id: 21
-  tagger_type: Tag
-  taggable_type: Work
 tagging_1067725272: 
   tagger_id: 1063753737
   created_at: 2009-07-17 23:08:06 Z
   updated_at: 2009-07-17 23:08:06 Z
   id: 1067725272
   taggable_id: 59
-  tagger_type: Tag
-  taggable_type: Work
-tagging_1067725009: 
-  tagger_id: 1063753824
-  created_at: 2009-03-09 16:42:34 Z
-  updated_at: 2009-03-09 16:42:34 Z
-  id: 1067725009
-  taggable_id: 21
   tagger_type: Tag
   taggable_type: Work
 tagging_1067725141: 
@@ -5503,14 +5295,6 @@ tagging_1067725273:
   taggable_id: 59
   tagger_type: Tag
   taggable_type: Work
-tagging_1067725010: 
-  tagger_id: 1063754009
-  created_at: 2009-03-09 16:42:35 Z
-  updated_at: 2009-03-09 16:42:35 Z
-  id: 1067725010
-  taggable_id: 21
-  tagger_type: Tag
-  taggable_type: Work
 tagging_1067725274: 
   tagger_id: 1063753937
   created_at: 2009-07-17 23:08:06 Z
@@ -5527,14 +5311,6 @@ tagging_1067724883:
   taggable_id: 5
   tagger_type: Tag
   taggable_type: Work
-tagging_1067725011: 
-  tagger_id: 885489802
-  created_at: 2009-03-09 17:04:57 Z
-  updated_at: 2009-03-09 17:04:57 Z
-  id: 1067725011
-  taggable_id: 22
-  tagger_type: Tag
-  taggable_type: Work
 tagging_1067725275: 
   tagger_id: 1063753936
   created_at: 2009-07-17 23:08:06 Z
@@ -5549,14 +5325,6 @@ tagging_1067724885:
   updated_at: 2008-11-22 05:45:15 Z
   id: 1067724885
   taggable_id: 5
-  tagger_type: Tag
-  taggable_type: Work
-tagging_1067725012: 
-  tagger_id: 1063753736
-  created_at: 2009-03-09 17:04:57 Z
-  updated_at: 2009-03-09 17:04:57 Z
-  id: 1067725012
-  taggable_id: 22
   tagger_type: Tag
   taggable_type: Work
 tagging_1067725144: 
@@ -5613,14 +5381,6 @@ tagging_1067724887:
   updated_at: 2008-11-22 05:49:40 Z
   id: 1067724887
   taggable_id: 5
-  tagger_type: Tag
-  taggable_type: Work
-tagging_1067725014: 
-  tagger_id: 1063753829
-  created_at: 2009-03-09 17:04:57 Z
-  updated_at: 2009-03-09 17:04:57 Z
-  id: 1067725014
-  taggable_id: 22
   tagger_type: Tag
   taggable_type: Work
 tagging_1067725146: 
@@ -5687,14 +5447,6 @@ tagging_1067725700:
   taggable_id: 104
   tagger_type: Tag
   taggable_type: Work
-tagging_1067725016: 
-  tagger_id: 1063753741
-  created_at: 2009-03-09 17:15:29 Z
-  updated_at: 2009-03-09 17:15:29 Z
-  id: 1067725016
-  taggable_id: 22
-  tagger_type: Tag
-  taggable_type: Work
 tagging_1067725148: 
   tagger_id: 426547448
   created_at: 2009-03-18 04:08:37 Z
@@ -5709,14 +5461,6 @@ tagging_1067725701:
   updated_at: 2009-12-18 17:56:46 Z
   id: 1067725701
   taggable_id: 104
-  tagger_type: Tag
-  taggable_type: Work
-tagging_1067725017: 
-  tagger_id: 885489802
-  created_at: 2009-03-09 17:20:58 Z
-  updated_at: 2009-03-09 17:20:58 Z
-  id: 1067725017
-  taggable_id: 23
   tagger_type: Tag
   taggable_type: Work
 tagging_1067725149: 
@@ -5751,14 +5495,6 @@ tagging_1067724890:
   taggable_id: 6
   tagger_type: Tag
   taggable_type: Work
-tagging_1067725018: 
-  tagger_id: 1063753736
-  created_at: 2009-03-09 17:20:58 Z
-  updated_at: 2009-03-09 17:20:58 Z
-  id: 1067725018
-  taggable_id: 23
-  tagger_type: Tag
-  taggable_type: Work
 tagging_1067725703: 
   tagger_id: 1063753905
   created_at: 2009-12-18 18:25:31 Z
@@ -5781,14 +5517,6 @@ tagging_1067724891:
   updated_at: 2008-12-05 13:59:14 Z
   id: 1067724891
   taggable_id: 6
-  tagger_type: Tag
-  taggable_type: Work
-tagging_1067725019: 
-  tagger_id: 1063753741
-  created_at: 2009-03-09 17:20:58 Z
-  updated_at: 2009-03-09 17:20:58 Z
-  id: 1067725019
-  taggable_id: 23
   tagger_type: Tag
   taggable_type: Work
 tagging_1067725704: 
@@ -6015,14 +5743,6 @@ tagging_59736118:
   taggable_id: 1
   tagger_type: Tag
   taggable_type: Work
-tagging_1067725024: 
-  tagger_id: 885489802
-  created_at: 2009-03-09 23:22:34 Z
-  updated_at: 2009-03-09 23:22:34 Z
-  id: 1067725024
-  taggable_id: 27
-  tagger_type: Tag
-  taggable_type: Work
 tagging_1067725156: 
   tagger_id: 1063753886
   created_at: 2009-03-18 20:15:26 Z
@@ -6053,14 +5773,6 @@ tagging_1067725710:
   updated_at: 2010-07-28 09:36:25 Z
   id: 1067725710
   taggable_id: 105
-  tagger_type: Tag
-  taggable_type: Work
-tagging_1067725025: 
-  tagger_id: 611729728
-  created_at: 2009-03-09 23:22:34 Z
-  updated_at: 2009-03-09 23:22:34 Z
-  id: 1067725025
-  taggable_id: 27
   tagger_type: Tag
   taggable_type: Work
 tagging_1067725157: 
@@ -6095,14 +5807,6 @@ tagging_1067725711:
   taggable_id: 105
   tagger_type: Tag
   taggable_type: Work
-tagging_1067725026: 
-  tagger_id: 1063753741
-  created_at: 2009-03-09 23:22:34 Z
-  updated_at: 2009-03-09 23:22:34 Z
-  id: 1067725026
-  taggable_id: 27
-  tagger_type: Tag
-  taggable_type: Work
 tagging_1067725158: 
   tagger_id: 1063753888
   created_at: 2009-03-18 20:15:26 Z
@@ -6125,14 +5829,6 @@ tagging_1067725290:
   updated_at: 2009-07-17 23:21:53 Z
   id: 1067725290
   taggable_id: 61
-  tagger_type: Tag
-  taggable_type: Work
-tagging_1067725027: 
-  tagger_id: 1063753824
-  created_at: 2009-03-09 23:22:34 Z
-  updated_at: 2009-03-09 23:22:34 Z
-  id: 1067725027
-  taggable_id: 27
   tagger_type: Tag
   taggable_type: Work
 tagging_1067725159: 
@@ -6405,14 +6101,6 @@ tagging_1067725723:
   updated_at: 2010-07-28 13:10:04 Z
   id: 1067725723
   taggable_id: 106
-  tagger_type: Tag
-  taggable_type: Work
-tagging_1067725038: 
-  tagger_id: 1063753831
-  created_at: 2009-03-10 00:28:25 Z
-  updated_at: 2009-03-10 00:28:25 Z
-  id: 1067725038
-  taggable_id: 29
   tagger_type: Tag
   taggable_type: Work
 tagging_1067725724: 

--- a/test/fixtures/tags.yml
+++ b/test/fixtures/tags.yml
@@ -4016,19 +4016,6 @@ tag_1063753893:
   adult: false
   id: 1063753893
   type: Relationship
-tag_1063753846: 
-  name: "#"
-  merger_id: 
-  last_wrangler_type: 
-  canonical: false
-  created_at: 2009-03-11 23:55:35 Z
-  delta: false
-  updated_at: 2009-03-11 23:55:35 Z
-  taggings_count_cache: 1
-  last_wrangler_id: 
-  adult: false
-  id: 1063753846
-  type: ArchiveWarning
 tag_1063753894: 
   name: Gwen Cooper/Toshiko Sato
   merger_id: 

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -12,7 +12,7 @@ user_00025:
   suspended_until: 
   login: badjuju
   out_of_invites: true
-  email: mjsunbound@gmail.com
+  email: badjuju@example.com
   banned: false
 user_00014: 
   password_salt: 9a5dd70dd81851f215947e1bd1ec3f37e2ecec6b
@@ -72,7 +72,7 @@ user_00015:
   suspended_until: 
   login: parenthetical
   out_of_invites: true
-  email: sarkymoocow@example.com
+  email: parenthetical@example.com
   banned: false
 user_00026: 
   password_salt: 631dcaa51dd023f4cdcdf2747a6322fc2e108ceb
@@ -87,7 +87,7 @@ user_00026:
   suspended_until: 
   login: DawningStar
   out_of_invites: true
-  email: dawn@ccaonline.com
+  email: dawn@example.com
   banned: false
 user_00027: 
   password_salt: 5a432a7543be536b62f1f51fee2255d0483c3b9d
@@ -102,7 +102,7 @@ user_00027:
   suspended_until: 
   login: yulechatismadeofawesome
   out_of_invites: true
-  email: attempt-unique@yahoo.com
+  email: attempt-unique@example.com
   banned: false
 user_00016: 
   password_salt: 47bfebbcd173627903284aced46fc6efea0c9eb4
@@ -147,7 +147,7 @@ user_00006:
   suspended_until: 
   login: orphan_account
   out_of_invites: true
-  email: 
+  email: orphan_account@example.com
   banned: false
 user_00017: 
   password_salt: 97730ef8bcd524fd18e4b9237fc05130a177c413
@@ -177,7 +177,7 @@ user_00028:
   suspended_until: 
   login: Shusu
   out_of_invites: true
-  email: boo@moog.com
+  email: shusu@example.com
   banned: false
 user_00029: 
   password_salt: 73c1309f8eafb8a949355857d46f682a36854cc3
@@ -192,7 +192,7 @@ user_00029:
   suspended_until: 
   login: whetherwoman
   out_of_invites: true
-  email: marina@nbtsc.org
+  email: whetherwoman@example.com
   banned: false
 user_00007: 
   password_salt: 2239939fc04c4d2a0d2b5ceedfc1727c3e527b63
@@ -222,7 +222,7 @@ user_00030:
   suspended_until: 
   login: Lizifer
   out_of_invites: true
-  email: elmiller00@gmail.com
+  email: lizifer@example.com
   banned: false
 user_00031: 
   password_salt: 570b4a55a931c7a1c5be1f5608ee825a88b51e37
@@ -237,7 +237,7 @@ user_00031:
   suspended_until: 
   login: tassos
   out_of_invites: true
-  email: savyln7@gmail.com
+  email: tassos@example.com
   banned: false
 user_00019: 
   password_salt: 
@@ -252,7 +252,7 @@ user_00019:
   suspended_until: 
   login: Zee
   out_of_invites: true
-  email: zooey.glass04@gmail.com
+  email: zee@example.com
   banned: false
 user_00008: 
   password_salt: 6e2ee018720464deaa10520d4b3f059710eb2b8d
@@ -282,7 +282,7 @@ user_00020:
   suspended_until: 
   login: hh_ook
   out_of_invites: true
-  email: hh-ook@gmail.com
+  email: hh@example.com
   banned: false
 user_00021: 
   password_salt: 56e1aeae2f94163b784b694f4d22f6452241d543
@@ -342,7 +342,7 @@ user_00032:
   suspended_until: 
   login: Enigel
   out_of_invites: true
-  email: enigel@gmail.com
+  email: enigel@example.com
   banned: false
 user_00033: 
   password_salt: feef278f6c8d201c0cb4c37253833f60f2090f8e
@@ -357,7 +357,7 @@ user_00033:
   suspended_until: 
   login: invitest
   out_of_invites: true
-  email: liminimail@googlemail.com
+  email: invitest@example.com
   banned: false
 user_00011: 
   password_salt: 21f8f1eb19a6dd5b649b451bb4386841506a387d
@@ -387,7 +387,7 @@ user_00022:
   suspended_until: 
   login: Jenn_Calaelen
   out_of_invites: true
-  email: jenn.calaelen@googlemail.com
+  email: jenn@example.com
   banned: false
 user_00023: 
   password_salt: b510f1f2ac546e9b85d0d17dec60f590992715ca
@@ -402,7 +402,7 @@ user_00023:
   suspended_until: 
   login: Llwyden
   out_of_invites: true
-  email: llwyden@trickster.org
+  email: llwyden@example.com
   banned: false
 user_00012: 
   password_salt: c5e416e746f06c3c68b542ed3223d89ce9be52cf

--- a/test/fixtures/works.yml
+++ b/test/fixtures/works.yml
@@ -14,7 +14,7 @@ work_00082:
   word_count: 683
   title_to_sort_on: all it's cracked up to be
   id: 82
-  language_id: 
+  language_id: 1
   minor_version: 0
   complete: false
   summary: 
@@ -212,7 +212,7 @@ work_00083:
   word_count: 218
   title_to_sort_on: best of men, the
   id: 83
-  language_id: 
+  language_id: 1
   minor_version: 0
   complete: false
   summary: 
@@ -300,7 +300,7 @@ work_00084:
   word_count: 5807
   title_to_sort_on: better man, the
   id: 84
-  language_id: 
+  language_id: 1
   minor_version: 0
   complete: false
   summary: 
@@ -344,7 +344,7 @@ work_00085:
   word_count: 862
   title_to_sort_on: mazes and monsters
   id: 85
-  language_id: 
+  language_id: 1
   minor_version: 0
   complete: false
   summary: 
@@ -542,7 +542,7 @@ work_00086:
   word_count: 209
   title_to_sort_on: not just a pretty face
   id: 86
-  language_id: 
+  language_id: 1
   minor_version: 0
   complete: false
   summary: 
@@ -801,7 +801,7 @@ work_00088:
   word_count: 2329
   title_to_sort_on: tapped out
   id: 88
-  language_id: 
+  language_id: 1
   minor_version: 0
   complete: false
   summary: 
@@ -1016,7 +1016,7 @@ work_00071:
   word_count: 501
   title_to_sort_on: sometimes
   id: 71
-  language_id: 
+  language_id: 1
   minor_version: 0
   complete: false
   summary: 
@@ -1266,7 +1266,7 @@ work_00072:
   word_count: 1774
   title_to_sort_on: gk christmas story
   id: 72
-  language_id: 
+  language_id: 1
   minor_version: 0
   complete: false
   summary: 
@@ -1398,7 +1398,7 @@ work_00073:
   word_count: 2028
   title_to_sort_on: celebrations
   id: 73
-  language_id: 
+  language_id: 1
   minor_version: 0
   complete: false
   summary: 
@@ -1489,7 +1489,7 @@ work_00074:
   word_count: 1131
   title_to_sort_on: light
   id: 74
-  language_id: 
+  language_id: 1
   minor_version: 0
   complete: false
   summary: 
@@ -1627,7 +1627,7 @@ work_00075:
   word_count: 5875
   title_to_sort_on: found again
   id: 75
-  language_id: 
+  language_id: 1
   minor_version: 0
   complete: false
   summary: 
@@ -1815,7 +1815,7 @@ work_00076:
   word_count: 1251
   title_to_sort_on: dreams of reality
   id: 76
-  language_id: 
+  language_id: 1
   minor_version: 0
   complete: false
   summary: 
@@ -1903,7 +1903,7 @@ work_00077:
   word_count: 625
   title_to_sort_on: bugged
   id: 77
-  language_id: 
+  language_id: 1
   minor_version: 0
   complete: false
   summary: 
@@ -1975,7 +1975,7 @@ work_00078:
   word_count: 1156
   title_to_sort_on: once more, with feeling
   id: 78
-  language_id: 
+  language_id: 1
   minor_version: 0
   complete: false
   summary: 
@@ -2063,7 +2063,7 @@ work_00080:
   word_count: 547
   title_to_sort_on: as it didn't happen
   id: 80
-  language_id: 
+  language_id: 1
   minor_version: 0
   complete: false
   summary: 
@@ -2085,7 +2085,7 @@ work_00079:
   word_count: 3909
   title_to_sort_on: murphy's law
   id: 79
-  language_id: 
+  language_id: 1
   minor_version: 0
   complete: false
   summary: 
@@ -2107,7 +2107,7 @@ work_00081:
   word_count: 3980
   title_to_sort_on: friends
   id: 81
-  language_id: 
+  language_id: 1
   minor_version: 0
   complete: false
   summary: 


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-7093

## Purpose

Make sure the fixtures used to seed the database during development are valid records. Remove the invalid ones so the test passes. Also, replace some user emails that looked suspiciously valid.

Note: This is a different set of fixtures than the ones removed in #5295. These are in test/fixtures, the other ones were in features/fixtures.

## Credit

Bilka
