### PR TITLE
AO3-7023 Fix ExternalWorkscontroller#fetch when the URL is invalid

### DIFF
--- a/app/controllers/external_works_controller.rb
+++ b/app/controllers/external_works_controller.rb
@@ -11,8 +11,12 @@ class ExternalWorksController < ApplicationController
   # Used with bookmark form to get an existing external work and return it via ajax
   def fetch
     if params[:external_work_url]
-      url = Addressable::URI.heuristic_parse(params[:external_work_url]).to_str
-      @external_work = ExternalWork.where(url: url).first
+      begin
+        url = Addressable::URI.heuristic_parse(params[:external_work_url]).to_str
+        @external_work = ExternalWork.where(url: url).first
+      rescue Addressable::URI::InvalidURIError => e
+        Rails.logger.info("Invalid external_work_url: #{e.message}")
+      end
     end
     respond_to do |format|
       format.js

--- a/app/controllers/external_works_controller.rb
+++ b/app/controllers/external_works_controller.rb
@@ -11,11 +11,12 @@ class ExternalWorksController < ApplicationController
   # Used with bookmark form to get an existing external work and return it via ajax
   def fetch
     if params[:external_work_url]
-      begin
-        url = Addressable::URI.heuristic_parse(params[:external_work_url]).to_str
-        @external_work = ExternalWork.where(url: url).first
+      url = begin
+        Addressable::URI.heuristic_parse(params[:external_work_url]).to_str
       rescue Addressable::URI::InvalidURIError
+        nil
       end
+      @external_work = ExternalWork.where(url: url).first if url
     end
     respond_to do |format|
       format.js

--- a/app/controllers/external_works_controller.rb
+++ b/app/controllers/external_works_controller.rb
@@ -14,8 +14,7 @@ class ExternalWorksController < ApplicationController
       begin
         url = Addressable::URI.heuristic_parse(params[:external_work_url]).to_str
         @external_work = ExternalWork.where(url: url).first
-      rescue Addressable::URI::InvalidURIError => e
-        Rails.logger.info("Invalid external_work_url: #{e.message}")
+      rescue Addressable::URI::InvalidURIError
       end
     end
     respond_to do |format|

--- a/spec/controllers/external_works_controller_spec.rb
+++ b/spec/controllers/external_works_controller_spec.rb
@@ -44,6 +44,13 @@ describe ExternalWorksController do
         expect(assigns(:external_work)).to be_nil
       end
     end
+
+    context "when the URL is invalid" do
+      it "does not set an external work" do
+        get :fetch, params: { external_work_url: "Invalid URL.", format: :json }
+        expect(assigns(:external_work)).to be_nil
+      end
+    end
   end
 
   describe "POST #update" do

--- a/spec/controllers/external_works_controller_spec.rb
+++ b/spec/controllers/external_works_controller_spec.rb
@@ -47,9 +47,9 @@ describe ExternalWorksController do
 
     context "when the URL is invalid" do
       it "does not error and does not set an external work" do
-        get :fetch, params: { external_work_url: "Invalid URL.", format: :json }
+        get :fetch, xhr: true, params: { external_work_url: "Invalid URL.", format: :js }
 
-        expect(response).to have_http_status(:found)
+        expect(response).to have_http_status(:ok)
         expect(assigns(:external_work)).to be_nil
       end
     end

--- a/spec/controllers/external_works_controller_spec.rb
+++ b/spec/controllers/external_works_controller_spec.rb
@@ -46,8 +46,10 @@ describe ExternalWorksController do
     end
 
     context "when the URL is invalid" do
-      it "does not set an external work" do
+      it "does not error and does not set an external work" do
         get :fetch, params: { external_work_url: "Invalid URL.", format: :json }
+
+        expect(response).to have_http_status(:found)
         expect(assigns(:external_work)).to be_nil
       end
     end


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-7023

## Purpose

This PR fixes the 500 error when ExternalWorksController#fetch gets an invalid URL for `external_work_url`. 

## Credit

Connie Feng, she/her
([JIRA account](https://otwarchive.atlassian.net/jira/people/712020:17930fa1-d647-47bd-b334-8a84cbacfca7))
