### PR TITLE
Update skin README files to provide information on media

### DIFF
--- a/public/stylesheets/masters/dark_mode/README.md
+++ b/public/stylesheets/masters/dark_mode/README.md
@@ -28,6 +28,7 @@ screen sizes.
 * Use the CSS from dark_mode_site_screen_.css.
 * Expand the "Advanced" section.
 * Check "Parent Only."
+* For "Media," check the "screen" option.
 
 ## Dark Mode - Midsize
 
@@ -46,6 +47,7 @@ placeholder CSS because the CSS field cannot be blank.
 
 * Include the placeholder CSS `#unused-selector { content: none; }`.
 * Expand the "Advanced" section.
+* For "Media," check the "screen" option.
 * Press the "Add parent skin" button.
 * For Parent #1, enter "Dark Mode - Screen".
 * Press the "Add parent skin" button again.

--- a/public/stylesheets/masters/reversi/README.md
+++ b/public/stylesheets/masters/reversi/README.md
@@ -2,3 +2,9 @@
 
 Reversi uses light text on a dark grey background and replaces the Archive's
 default red with blue.
+
+# Reversi Structure
+
+* Use the CSS from reversi_site_screen_.css.
+* Expand the "Advanced" section.
+* For "Media," check the "screen" option.

--- a/public/stylesheets/masters/reversi/README.md
+++ b/public/stylesheets/masters/reversi/README.md
@@ -3,7 +3,7 @@
 Reversi uses light text on a dark grey background and replaces the Archive's
 default red with blue.
 
-# Reversi Structure
+# Reversi Setup
 
 * Use the CSS from reversi_site_screen_.css.
 * Expand the "Advanced" section.

--- a/public/stylesheets/masters/snow/README.md
+++ b/public/stylesheets/masters/snow/README.md
@@ -6,3 +6,9 @@ other accents. Snow is a legacy skin created to turn those things pure white.
 Because some of the elements that Snow turns pure white were changed to pale
 grey in the default skin, it is necessary to keep using Snow as a parent for
 Snow Blue.
+
+# Snow Structure
+
+* Use the CSS from snow_site_screen_.css.
+* Expand the "Advanced" section.
+* For "Media," check the "screen" option.

--- a/public/stylesheets/masters/snow/README.md
+++ b/public/stylesheets/masters/snow/README.md
@@ -7,7 +7,7 @@ Because some of the elements that Snow turns pure white were changed to pale
 grey in the default skin, it is necessary to keep using Snow as a parent for
 Snow Blue.
 
-# Snow Structure
+# Snow Setup
 
 * Use the CSS from snow_site_screen_.css.
 * Expand the "Advanced" section.

--- a/public/stylesheets/masters/snow_blue/README.md
+++ b/public/stylesheets/masters/snow_blue/README.md
@@ -8,5 +8,6 @@ Snow Blue uses Snow as a parent to ensure certain elements are pure white.
 
 * Use the CSS from snow_blue_site_screen.css.
 * Expand the "Advanced" section.
+* For "Media," check the "screen" option.
 * Press the "Add parent skin" button.
 * For Parent #1, enter "Snow".


### PR DESCRIPTION
## Issue

N/A -- documentation update

## Purpose

Updates the README files for Snow, Snow Blue, Reversi, and Dark Mode to instruct you to set the `@media` to `screen` when setting up the skins. Doing so prevents them from being used when printing.

Low Vision Default specifies an `@media` already: `all`. This appears to be correct/desirable given its simplified layout.