### PR TITLE
AO3-7095 Add user and admin accounts for more roles to fixtures

### DIFF
--- a/test/fixtures/admins.yml
+++ b/test/fixtures/admins.yml
@@ -1,10 +1,73 @@
 --- 
 admin_00001: 
   created_at: 2008-11-09 01:26:01 Z
-  encrypted_password: <%= Devise::Encryptor.digest(User, 'testadmin') %>
   updated_at: 2008-11-09 01:26:01 Z
+  encrypted_password: <%= Devise::Encryptor.digest(Admin, "testadmin") %>
   id: 1
   login: admin-testadmin
-  email: user1@example.com
+  email: testadmin@example.com
   roles:
     - superadmin
+communications:
+  created_at: 2025-04-12 17:00:00 Z
+  updated_at: 2025-04-12 17:00:00 Z
+  encrypted_password: <%= Devise::Encryptor.digest(Admin, "testadmin") %>
+  id: 2
+  login: admin-comms
+  email: admin-comms@example.com
+  roles:
+    - communications
+development_and_membership:
+  created_at: 2025-04-12 17:00:00 Z
+  updated_at: 2025-04-12 17:00:00 Z
+  encrypted_password: <%= Devise::Encryptor.digest(Admin, "testadmin") %>
+  id: 3
+  login: admin-devmem
+  email: admin-devmem@example.com
+  roles:
+    - development_and_membership
+docs:
+  created_at: 2025-04-12 17:00:00 Z
+  updated_at: 2025-04-12 17:00:00 Z
+  encrypted_password: <%= Devise::Encryptor.digest(Admin, "testadmin") %>
+  id: 4
+  login: admin-docs
+  email: admin-docs@example.com
+  roles:
+    - docs
+policy_and_abuse:
+  created_at: 2025-04-12 17:00:00 Z
+  updated_at: 2025-04-12 17:00:00 Z
+  encrypted_password: <%= Devise::Encryptor.digest(Admin, "testadmin") %>
+  id: 5
+  login: admin-pac
+  email: admin-pac@example.com
+  roles:
+    - policy_and_abuse
+support:
+  created_at: 2025-04-12 17:00:00 Z
+  updated_at: 2025-04-12 17:00:00 Z
+  encrypted_password: <%= Devise::Encryptor.digest(Admin, "testadmin") %>
+  id: 6
+  login: admin-support
+  email: admin-support@example.com
+  roles:
+    - support
+tag_wrangling:
+  created_at: 2025-04-12 17:00:00 Z
+  updated_at: 2025-04-12 17:00:00 Z
+  encrypted_password: <%= Devise::Encryptor.digest(Admin, "testadmin") %>
+  id: 7
+  login: admin-wrangling
+  email: admin-wrangling@example.com
+  roles:
+    - tag_wrangling
+translation:
+  created_at: 2025-04-12 17:00:00 Z
+  updated_at: 2025-04-12 17:00:00 Z
+  encrypted_password: <%= Devise::Encryptor.digest(Admin, "testadmin") %>
+  id: 8
+  login: admin-translation
+  email: admin-translation@example.com
+  roles:
+    - translation

--- a/test/fixtures/archive_faq_translations.yml
+++ b/test/fixtures/archive_faq_translations.yml
@@ -1,0 +1,8 @@
+---
+archive_faq_translation_00001:
+  created_at: 2025-04-12 17:00:00 Z
+  updated_at: 2025-04-12 17:00:00 Z
+  id: 1
+  archive_faq_id: 1
+  locale: en
+  title: Test FAQ category

--- a/test/fixtures/archive_faqs.yml
+++ b/test/fixtures/archive_faqs.yml
@@ -1,0 +1,8 @@
+---
+archive_faq_00001:
+  created_at: 2025-04-12 17:00:00 Z
+  updated_at: 2025-04-12 17:00:00 Z
+  id: 1
+  title: Test FAQ category
+  slug: test-faq-category
+  position: 1

--- a/test/fixtures/pseuds.yml
+++ b/test/fixtures/pseuds.yml
@@ -5,7 +5,7 @@ pseud_00027:
   created_at: 2009-12-12 21:07:09 Z
   delta: true
   updated_at: 2009-12-12 21:07:09 Z
-  is_default: false
+  is_default: true
   id: 27
   user_id: 21
   description: 
@@ -35,7 +35,7 @@ pseud_00038:
   created_at: 2009-12-12 22:39:41 Z
   delta: true
   updated_at: 2009-12-12 22:39:41 Z
-  is_default: false
+  is_default: true
   id: 38
   user_id: 31
   description: 
@@ -75,17 +75,17 @@ pseud_00028:
   created_at: 2009-12-12 21:07:24 Z
   delta: true
   updated_at: 2009-12-12 21:07:24 Z
-  is_default: false
+  is_default: true
   id: 28
   user_id: 22
   description: 
 pseud_00040: 
-  name: invitest
+  name: testsuspended
   icon_alt_text: ""
   created_at: 2009-12-17 11:37:58 Z
   delta: true
   updated_at: 2009-12-17 11:37:58 Z
-  is_default: false
+  is_default: true
   id: 40
   user_id: 33
   description: 
@@ -130,12 +130,12 @@ pseud_00007:
   user_id: 5
   description: Default pseud
 pseud_00030: 
-  name: moriann
+  name: testofficial
   icon_alt_text: ""
   created_at: 2009-12-12 21:07:42 Z
   delta: true
   updated_at: 2009-12-12 21:07:42 Z
-  is_default: false
+  is_default: true
   id: 30
   user_id: 24
   description: 
@@ -155,7 +155,7 @@ pseud_00019:
   created_at: 2009-07-17 22:44:23 Z
   delta: true
   updated_at: 2009-07-17 22:44:23 Z
-  is_default: false
+  is_default: true
   id: 19
   user_id: 15
   description: 
@@ -165,7 +165,7 @@ pseud_00031:
   created_at: 2009-12-12 21:07:52 Z
   delta: true
   updated_at: 2009-12-12 21:07:52 Z
-  is_default: false
+  is_default: true
   id: 31
   user_id: 25
   description: 
@@ -205,17 +205,17 @@ pseud_00021:
   created_at: 2009-07-17 23:18:52 Z
   delta: true
   updated_at: 2009-07-17 23:18:52 Z
-  is_default: false
+  is_default: true
   id: 21
   user_id: 16
   description: 
 pseud_00032: 
-  name: DawningStar
+  name: testbanned
   icon_alt_text: ""
   created_at: 2009-12-12 21:08:12 Z
   delta: true
   updated_at: 2009-12-12 21:08:12 Z
-  is_default: false
+  is_default: true
   id: 32
   user_id: 26
   description: 
@@ -225,7 +225,7 @@ pseud_00033:
   created_at: 2009-12-12 21:09:13 Z
   delta: true
   updated_at: 2009-12-12 21:09:13 Z
-  is_default: false
+  is_default: true
   id: 33
   user_id: 27
   description: 
@@ -235,7 +235,7 @@ pseud_00022:
   created_at: 2009-07-18 09:55:25 Z
   delta: true
   updated_at: 2009-07-18 09:55:25 Z
-  is_default: false
+  is_default: true
   id: 22
   user_id: 17
   description: 
@@ -275,7 +275,7 @@ pseud_00034:
   created_at: 2009-12-12 21:10:24 Z
   delta: true
   updated_at: 2009-12-12 21:10:24 Z
-  is_default: false
+  is_default: true
   id: 34
   user_id: 28
   description: 
@@ -315,7 +315,7 @@ pseud_00024:
   created_at: 2009-09-16 23:37:53 Z
   delta: true
   updated_at: 2009-09-16 23:37:53 Z
-  is_default: false
+  is_default: true
   id: 24
   user_id: 19
   description: 
@@ -360,7 +360,7 @@ pseud_00036:
   created_at: 2009-12-12 21:13:55 Z
   delta: true
   updated_at: 2009-12-12 21:13:55 Z
-  is_default: false
+  is_default: true
   id: 36
   user_id: 29
   description: 
@@ -370,7 +370,7 @@ pseud_00037:
   created_at: 2009-12-12 21:58:12 Z
   delta: true
   updated_at: 2009-12-12 21:58:12 Z
-  is_default: false
+  is_default: true
   id: 37
   user_id: 30
   description: 
@@ -400,7 +400,7 @@ pseud_00026:
   created_at: 2009-12-12 21:06:59 Z
   delta: true
   updated_at: 2009-12-12 21:06:59 Z
-  is_default: false
+  is_default: true
   id: 26
   user_id: 20
   description: 

--- a/test/fixtures/question_translations.yml
+++ b/test/fixtures/question_translations.yml
@@ -1,0 +1,17 @@
+---
+question_translation_00001:
+  created_at: 2025-04-12 17:00:00 Z
+  updated_at: 2025-04-12 17:00:00 Z
+  id: 1
+  question_id: 1
+  locale: en
+  question: First testing question
+  content: <p>Some testing faq answer</p>
+question_translation_00002:
+  created_at: 2025-04-12 17:00:00 Z
+  updated_at: 2025-04-12 17:00:00 Z
+  id: 2
+  question_id: 2
+  locale: en
+  question: Second testing question
+  content: <p>Another testing faq answer</p>

--- a/test/fixtures/questions.yml
+++ b/test/fixtures/questions.yml
@@ -1,0 +1,19 @@
+---
+question_00001:
+  created_at: 2025-04-12 17:00:00 Z
+  updated_at: 2025-04-12 17:00:00 Z
+  id: 1
+  archive_faq_id: 1
+  question: First testing question
+  content: <p>Some testing faq answer</p>
+  anchor: first-testing-anchor
+  position: 1
+question_00002:
+  created_at: 2025-04-12 17:00:00 Z
+  updated_at: 2025-04-12 17:00:00 Z
+  id: 2
+  archive_faq_id: 1
+  question: Second testing question
+  content: <p>Another testing faq answer</p>
+  anchor: second-testing-anchor
+  position: 2

--- a/test/fixtures/roles_users.yml
+++ b/test/fixtures/roles_users.yml
@@ -34,3 +34,6 @@ join_00001:
   updated_at: 2009-06-27 18:59:55
   role_id: "6"
   user_id: "1"
+testofficial_official:
+  role_id: 8
+  user_id: 24

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -1,4 +1,95 @@
---- 
+---
+user_00001:
+  encrypted_password: <%= Devise::Encryptor.digest(User, "testuser") %>
+  created_at: 2008-11-09 01:26:02 Z
+  confirmed_at: 2008-11-09 01:26:02 Z
+  updated_at: 2010-08-11 21:37:42 Z
+  confirmation_token:
+  invitation_id:
+  id: 1
+  suspended: false
+  suspended_until:
+  login: testuser
+  out_of_invites: true
+  email: user1@example.com
+  banned: false
+user_00002:
+  encrypted_password: <%= Devise::Encryptor.digest(User, "testuser") %>
+  created_at: 2008-11-09 01:26:02 Z
+  confirmed_at: 2008-11-09 01:26:02 Z
+  updated_at: 2010-01-09 13:55:01 Z
+  confirmation_token:
+  invitation_id:
+  id: 2
+  suspended: false
+  suspended_until:
+  login: testuser2
+  out_of_invites: true
+  email: user2@example.com
+  banned: false
+user_00003:
+  encrypted_password: <%= Devise::Encryptor.digest(User, "testuser") %>
+  created_at: 2008-11-09 01:26:02 Z
+  confirmed_at: 2008-11-09 01:26:02 Z
+  updated_at: 2009-03-02 20:16:34 Z
+  confirmation_token:
+  invitation_id:
+  id: 3
+  suspended: false
+  suspended_until:
+  login: testuser3
+  out_of_invites: true
+  email: user3@example.com
+  banned: false
+user_00004:
+  encrypted_password: <%= Devise::Encryptor.digest(User, "testuser") %>
+  created_at: 2008-11-09 01:26:02 Z
+  confirmed_at: 2008-11-09 01:26:02 Z
+  updated_at: 2008-11-09 01:26:02 Z
+  confirmation_token:
+  invitation_id:
+  id: 4
+  suspended: false
+  suspended_until:
+  login: testuser4
+  out_of_invites: true
+  email: user4@example.com
+  banned: false
+user_00024:
+  encrypted_password: <%= Devise::Encryptor.digest(User, "testuser") %>
+  created_at: 2009-12-12 21:07:42 Z
+  confirmed_at: 2009-12-12 21:07:47 Z
+  updated_at: 2009-12-12 21:07:47 Z
+  id: 24
+  suspended: false
+  banned: false
+  login: testofficial
+  email: official@example.com
+user_00026:
+  encrypted_password: <%= Devise::Encryptor.digest(User, "testuser") %>
+  created_at: 2009-12-12 21:08:12 Z
+  confirmed_at: 2009-12-12 21:08:19 Z
+  updated_at: 2009-12-12 21:08:19 Z
+  confirmation_token:
+  invitation_id:
+  id: 26
+  suspended: false
+  banned: true
+  login: testbanned
+  email: banned@example.com
+user_00033:
+  encrypted_password: <%= Devise::Encryptor.digest(User, "testuser") %>
+  created_at: 2009-12-17 11:37:58 Z
+  confirmed_at: 2009-12-17 22:03:16 Z
+  updated_at: 2009-12-17 22:03:17 Z
+  confirmation_token:
+  invitation_id:
+  id: 33
+  suspended: true
+  suspended_until: 2125-04-12 17:00:00 Z
+  banned: false
+  login: testsuspended
+  email: suspended@example.com
 user_00025: 
   password_salt: 2aa64c10d3ea67188845a59d3d9d411d52301838
   created_at: 2009-12-12 21:07:52 Z
@@ -29,36 +120,6 @@ user_00014:
   out_of_invites: true
   email: Uriel@example.com
   banned: false
-user_00003: 
-  password_salt: 7e3041ebc2fc05a40c60028e2c4901a81035d3cd
-  created_at: 2008-11-09 01:26:02 Z
-  confirmed_at: 2008-11-09 01:26:02 Z
-  encrypted_password: 00742970dc9e6319f8019fd54864d3ea740f04b1
-  updated_at: 2009-03-02 20:16:34 Z
-  confirmation_token: 
-  invitation_id: 
-  id: 3
-  suspended: false
-  suspended_until: 
-  login: testuser3
-  out_of_invites: true
-  email: user3@example.com
-  banned: false
-user_00004: 
-  password_salt: 7e3041ebc2fc05a40c60028e2c4901a81035d3cd
-  created_at: 2008-11-09 01:26:02 Z
-  confirmed_at: 2008-11-09 01:26:02 Z
-  encrypted_password: 00742970dc9e6319f8019fd54864d3ea740f04b1
-  updated_at: 2008-11-09 01:26:02 Z
-  confirmation_token: 
-  invitation_id: 
-  id: 4
-  suspended: false
-  suspended_until: 
-  login: testuser4
-  out_of_invites: true
-  email: user4@example.com
-  banned: false
 user_00015: 
   password_salt: 787e39d8cc37646fb25274a444a48abbafeebd7a
   created_at: 2009-07-17 22:44:23 Z
@@ -73,21 +134,6 @@ user_00015:
   login: parenthetical
   out_of_invites: true
   email: parenthetical@example.com
-  banned: false
-user_00026: 
-  password_salt: 631dcaa51dd023f4cdcdf2747a6322fc2e108ceb
-  created_at: 2009-12-12 21:08:12 Z
-  confirmed_at: 2009-12-12 21:08:19 Z
-  encrypted_password: c6d89e7b1d2ea8db07513f7c6cb1db4e9ad395c9
-  updated_at: 2009-12-12 21:08:19 Z
-  confirmation_token: 
-  invitation_id: 
-  id: 26
-  suspended: false
-  suspended_until: 
-  login: DawningStar
-  out_of_invites: true
-  email: dawn@example.com
   banned: false
 user_00027: 
   password_salt: 5a432a7543be536b62f1f51fee2255d0483c3b9d
@@ -344,21 +390,6 @@ user_00032:
   out_of_invites: true
   email: enigel@example.com
   banned: false
-user_00033: 
-  password_salt: feef278f6c8d201c0cb4c37253833f60f2090f8e
-  created_at: 2009-12-17 11:37:58 Z
-  confirmed_at: 2009-12-17 22:03:16 Z
-  encrypted_password: 1b719cd8460f4819cdf86576edccf8579b5efda7
-  updated_at: 2009-12-17 22:03:17 Z
-  confirmation_token: 
-  invitation_id: 
-  id: 33
-  suspended: false
-  suspended_until: 
-  login: invitest
-  out_of_invites: true
-  email: invitest@example.com
-  banned: false
 user_00011: 
   password_salt: 21f8f1eb19a6dd5b649b451bb4386841506a387d
   created_at: 2008-12-06 23:05:24 Z
@@ -419,35 +450,6 @@ user_00012:
   out_of_invites: true
   email: zooey@example.com
   banned: false
-user_00001: 
-  encrypted_password: <%= Devise::Encryptor.digest(User, 'testuser') %>
-  created_at: 2008-11-09 01:26:02 Z
-  confirmed_at: 2008-11-09 01:26:02 Z
-  updated_at: 2010-08-11 21:37:42 Z
-  confirmation_token: 
-  invitation_id: 
-  id: 1
-  suspended: false
-  suspended_until: 
-  login: testuser
-  out_of_invites: true
-  email: user1@example.com
-  banned: false
-user_00002: 
-  password_salt: 7e3041ebc2fc05a40c60028e2c4901a81035d3cd
-  created_at: 2008-11-09 01:26:02 Z
-  confirmed_at: 2008-11-09 01:26:02 Z
-  encrypted_password: 00742970dc9e6319f8019fd54864d3ea740f04b1
-  updated_at: 2010-01-09 13:55:01 Z
-  confirmation_token: 
-  invitation_id: 
-  id: 2
-  suspended: false
-  suspended_until: 
-  login: testuser2
-  out_of_invites: true
-  email: user2@example.com
-  banned: false
 user_00013: 
   password_salt: 5860eac2a470dbee25aa5a4ba8a4e6b841c38c37
   created_at: 2008-12-06 23:29:42 Z
@@ -462,19 +464,4 @@ user_00013:
   login: Jessica
   out_of_invites: true
   email: Jessica@example.com
-  banned: false
-user_00024: 
-  password_salt: 943292d06d1761ac3c7e8585a5b728db1f82a930
-  created_at: 2009-12-12 21:07:42 Z
-  confirmed_at: 2009-12-12 21:07:47 Z
-  encrypted_password: 4cb86274abca59515b0060f727e57ec32ac2a878
-  updated_at: 2009-12-12 21:07:47 Z
-  confirmation_token: 
-  invitation_id: 
-  id: 24
-  suspended: false
-  suspended_until: 
-  login: moriann
-  out_of_invites: true
-  email: aaa@bbb.com
   banned: false


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-7095

## Purpose

Add more admin and users accounts in the initial seed data to make development with gitpod easier. 

## References

Internal discussion regarding what data to add, reflected in the Jira issue,

## Credit

Bilka
