### PR TITLE
AO3-7038 Restrict ability to grant invitations to all current users

### DIFF
--- a/app/controllers/admin/admin_invitations_controller.rb
+++ b/app/controllers/admin/admin_invitations_controller.rb
@@ -26,6 +26,8 @@ class Admin::AdminInvitationsController < Admin::BaseController
   end
 
   def grant_invites_to_users
+    authorize :admin_invitation
+
     if invitation_params[:user_group] == "All"
       Invitation.grant_all(invitation_params[:number_of_invites].to_i)
     else

--- a/app/controllers/admin/admin_invitations_controller.rb
+++ b/app/controllers/admin/admin_invitations_controller.rb
@@ -26,7 +26,7 @@ class Admin::AdminInvitationsController < Admin::BaseController
   end
 
   def grant_invites_to_users
-    authorize :admin_invitation
+    authorize Invitation
 
     if invitation_params[:user_group] == "All"
       Invitation.grant_all(invitation_params[:number_of_invites].to_i)

--- a/app/policies/admin_invitation_policy.rb
+++ b/app/policies/admin_invitation_policy.rb
@@ -1,7 +1,0 @@
-class AdminInvitationPolicy < ApplicationPolicy
-  INVITE_ALL_ROLES = %w[superadmin].freeze
-
-  def grant_invites_to_users?
-    user_has_roles?(INVITE_ALL_ROLES)
-  end
-end

--- a/app/policies/admin_invitation_policy.rb
+++ b/app/policies/admin_invitation_policy.rb
@@ -1,0 +1,7 @@
+class AdminInvitationPolicy < ApplicationPolicy
+  INVITE_ALL_ROLES = %w[superadmin].freeze
+
+  def grant_invites_to_users?
+    user_has_roles?(INVITE_ALL_ROLES)
+  end
+end

--- a/app/policies/invitation_policy.rb
+++ b/app/policies/invitation_policy.rb
@@ -1,7 +1,12 @@
 class InvitationPolicy < ApplicationPolicy
   EXTRA_INFO_ROLES = %w[superadmin open_doors policy_and_abuse support tag_wrangling].freeze
+  INVITE_ALL_ROLES = %w[superadmin].freeze
 
   def access_invitee_details?
     user_has_roles?(EXTRA_INFO_ROLES)
+  end
+
+  def grant_invites_to_users?
+    user_has_roles?(INVITE_ALL_ROLES)
   end
 end

--- a/app/views/admin/admin_invitations/index.html.erb
+++ b/app/views/admin/admin_invitations/index.html.erb
@@ -39,23 +39,25 @@
   </fieldset>
 <% end %>
 
-<%= form_tag url_for(controller: "admin/admin_invitations", action: :grant_invites_to_users), class: "bulk invitation simple post", autocomplete: "off" do %>
-  <fieldset>
-    <h3 class="heading"><%= t(".grant_invites.heading") %></h3>
-    <dl>
-      <dt><%= label_tag "invitation[number_of_invites]", t(".grant_invites.number_of_invitations") %></dt>
-      <dd><%= text_field_tag "invitation[number_of_invites]" %></dd>
-      <dt><%= label_tag "invitation[user_group]", t(".grant_invites.users") %></dt>
-      <dd>
-        <%= select_tag "invitation[user_group]",
-              options_for_select([[t(".grant_invites.all"), "All"],
-                                  [t(".grant_invites.with_no_unused"), "With no unused invitations"]],
-                "All") %>
-      </dd>
-      <dt class="landmark"><%= t(".grant_invites.landmark_submit") %></dt>
-      <dd class="submit actions"><%= submit_tag t(".grant_invites.generate_invitations") %></dd>
-    </dl>
-  </fieldset>
+<% if policy(:admin_invitation).grant_invites_to_users? %>
+  <%= form_tag url_for(controller: "admin/admin_invitations", action: :grant_invites_to_users), class: "bulk invitation simple post", autocomplete: "off" do %>
+    <fieldset>
+      <h3 class="heading"><%= t(".grant_invites.heading") %></h3>
+      <dl>
+        <dt><%= label_tag "invitation[number_of_invites]", t(".grant_invites.number_of_invitations") %></dt>
+        <dd><%= text_field_tag "invitation[number_of_invites]" %></dd>
+        <dt><%= label_tag "invitation[user_group]", t(".grant_invites.users") %></dt>
+        <dd>
+          <%= select_tag "invitation[user_group]",
+                options_for_select([[t(".grant_invites.all"), "All"],
+                                    [t(".grant_invites.with_no_unused"), "With no unused invitations"]],
+                  "All") %>
+        </dd>
+        <dt class="landmark"><%= t(".grant_invites.landmark_submit") %></dt>
+        <dd class="submit actions"><%= submit_tag t(".grant_invites.generate_invitations") %></dd>
+      </dl>
+    </fieldset>
+  <% end %>
 <% end %>
 
 <%= form_tag url_for(controller: "admin/admin_invitations", action: :find), class: "invitation simple search", autocomplete: "off", method: :get do %>

--- a/app/views/admin/admin_invitations/index.html.erb
+++ b/app/views/admin/admin_invitations/index.html.erb
@@ -39,7 +39,7 @@
   </fieldset>
 <% end %>
 
-<% if policy(:admin_invitation).grant_invites_to_users? %>
+<% if policy(Invitation).grant_invites_to_users? %>
   <%= form_tag url_for(controller: "admin/admin_invitations", action: :grant_invites_to_users), class: "bulk invitation simple post", autocomplete: "off" do %>
     <fieldset>
       <h3 class="heading"><%= t(".grant_invites.heading") %></h3>

--- a/features/admins/admin_invitations.feature
+++ b/features/admins/admin_invitations.feature
@@ -287,7 +287,7 @@ Feature: Admin Actions to Manage Invitations
       | odo   | mybucket9  |
       And "dax" has "0" invitations
       And "odo" has "3" invitations
-      And I am logged in as an admin
+      And I am logged in as a super admin
     When I follow "Invite New Users"
       And I fill in "Number of invitations" with "2"
       And I select "All" from "Users"
@@ -302,7 +302,7 @@ Feature: Admin Actions to Manage Invitations
       | bashir | heytheredoc |
       And "dax" has "5" invitations
       And "bashir" has "0" invitations
-      And I am logged in as an admin
+      And I am logged in as a super admin
     When I follow "Invite New Users"
       And I fill in "Number of invitations" with "2"
       And I select "With no unused invitations" from "Users"

--- a/spec/controllers/admin/admin_invitations_controller_spec.rb
+++ b/spec/controllers/admin/admin_invitations_controller_spec.rb
@@ -61,22 +61,21 @@ describe Admin::AdminInvitationsController do
     end
   end
 
+  grant_to_all_roles = %w[superadmin].freeze
+
   describe "POST #grant_invites_to_users" do
-    let(:admin) { create(:admin) }
-    let(:invite_request) { create(:invite_request) }
+    subject { post :grant_invites_to_users, params: { invitation: { user_group: "ALL", number_of_invites: "2" } } }
+    let(:success) do
+      it_redirects_to_with_notice(admin_invitations_path, "Invitations successfully created.")
+    end
+
+    it_behaves_like "an action only authorized admins can access", authorized_roles: grant_to_all_roles
 
     it "does not allow non-admins to grant invites to all users" do
       fake_login
-      post :grant_invites_to_users, params: { invitation: { user_group: "ALL" } }
+      subject
 
       it_redirects_to_with_notice(root_path, "I'm sorry, only an admin can look at that area")
-    end
-
-    it "allows admins to grant invites to all users" do
-      fake_login_admin(admin)
-      post :grant_invites_to_users, params: { invitation: { user_group: "ALL", number_of_invites: "2" } }
-
-      it_redirects_to_with_notice(admin_invitations_path, "Invitations successfully created.")
     end
   end
 


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-7038

## Purpose

Add an AdminInvitationPolicy and restrict access to `grant_invites_to_users` to superadmins.

## Credit

Bilka