### PR TITLE
AO3-7075 Add padding around the grey blurb on the history page

### DIFF
--- a/public/stylesheets/site/2.0/13-group-blurb.css
+++ b/public/stylesheets/site/2.0/13-group-blurb.css
@@ -410,6 +410,7 @@ blurbs on the manage collection items pages, mostly reseting styles inherited fr
 
 .reading h4.viewed {
   background: #ddd;
+  padding: 0.25em;
 }
 
 .reading .deleted h4.viewed {


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-7075

## Purpose

This PR adds padding around the grey blurb on the history page.

Before change:
<img width="1685" height="412" alt="Screenshot 2025-08-09 at 12 14 06 PM" src="https://github.com/user-attachments/assets/0c162e2c-663d-4cad-94fb-c379c3ab58bf" />


After change:
<img width="1708" height="406" alt="Screenshot 2025-08-09 at 12 23 28 PM" src="https://github.com/user-attachments/assets/d5cdd848-0462-4dce-baa1-d0614c0e748f" />


## Credit
Connie Feng, she/her
([JIRA account](https://otwarchive.atlassian.net/jira/people/712020:17930fa1-d647-47bd-b334-8a84cbacfca7))
