### PR TITLE
AO3-7089 Removed redundant shared example

### DIFF
--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -5,34 +5,32 @@ describe UsersController do
   include LoginMacros
 
   shared_examples "an action only authorized admins can access" do |authorized_roles:|
-    before do
-      fake_login_admin(admin)
-    end
-
-    context "when logged in as an admin with no role" do
-      let(:admin) { create(:admin) }
-
+    before { fake_login_admin(admin) }
+  
+    context "with no role" do
+      let(:admin) { create(:admin, roles: []) }
+  
       it "redirects with an error" do
         subject
         it_redirects_to_with_error(root_url, "Sorry, only an authorized admin can access the page you were trying to reach.")
       end
     end
-
-    (Admin::VALID_ROLES - authorized_roles).each do |admin_role|
-      context "when logged in as an admin with role #{admin_role}" do
-        let(:admin) { create(:admin, roles: [admin_role]) }
-
+  
+    (Admin::VALID_ROLES - authorized_roles).each do |role|
+      context "with role #{role}" do
+        let(:admin) { create(:admin, roles: [role]) }
+  
         it "redirects with an error" do
           subject
           it_redirects_to_with_error(root_url, "Sorry, only an authorized admin can access the page you were trying to reach.")
         end
       end
     end
-
-    authorized_roles.each do |admin_role|
-      context "when logged in as an admin with role #{admin_role}" do
-        let(:admin) { create(:admin, roles: [admin_role]) }
-
+  
+    authorized_roles.each do |role|
+      context "with role #{role}" do
+        let(:admin) { create(:admin, roles: [role]) }
+  
         it "succeeds" do
           subject
           success


### PR DESCRIPTION
# Pull Request Checklist

<!-- Mark steps in the checklist as complete by changing `[ ]` to `[X]` -->
* [X] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [X] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [X] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [X] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [X] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-7089

## Purpose

This PR replaces the "an action only authorized admins can access" shared example in [users_controller_spec.rb](https://github.com/otwcode/otwarchive/blob/2b802f97ff9a11ee22e9bc25e48971824bf731ae/spec/controllers/users_controller_spec.rb#L7-L42) with the shared example of the same name in [access_shared_examples.rb](https://github.com/otwcode/otwarchive/blob/2b802f97ff9a11ee22e9bc25e48971824bf731ae/spec/support/shared_examples/access_shared_examples.rb#L1) which is used by more tests. The shared example in users_controller_spec.rb has been removed.

## Credit

katieyang