### PR TITLE
AO3-6644 Add jpeg support for collection header image URL

### DIFF
--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -147,7 +147,7 @@ class Collection < ApplicationRecord
                       too_long: ts("must be less than %{max} characters long.", max: ArchiveConfig.SUMMARY_MAX) }
 
   validates :header_image_url, format: { allow_blank: true, with: URI::DEFAULT_PARSER.make_regexp(%w[http https]), message: ts("is not a valid URL.") }
-  validates :header_image_url, format: { allow_blank: true, with: /\A\S+\.(png|gif|jpg)\z/, message: ts("can only point to a gif, jpg, or png file.") }
+  validates :header_image_url, format: { allow_blank: true, with: /\A\S+\.(png|gif|jpe?g)\z/, message: ts("can only point to a gif, jpg, jpeg, or png file.") }
 
   validates :tags_after_saving,
             length: { maximum: ArchiveConfig.COLLECTION_TAGS_MAX,

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -147,7 +147,7 @@ class Collection < ApplicationRecord
                       too_long: ts("must be less than %{max} characters long.", max: ArchiveConfig.SUMMARY_MAX) }
 
   validates :header_image_url, format: { allow_blank: true, with: URI::DEFAULT_PARSER.make_regexp(%w[http https]), message: ts("is not a valid URL.") }
-  validates :header_image_url, format: { allow_blank: true, with: /\A\S+\.(png|gif|jpe?g)\z/, message: ts("can only point to a gif, jpg, jpeg, or png file.") }
+  validates :header_image_url, format: { allow_blank: true, with: /\A\S+\.(png|gif|jpe?g)\z/, message: :file_format }
 
   validates :tags_after_saving,
             length: { maximum: ArchiveConfig.COLLECTION_TAGS_MAX,

--- a/config/locales/models/en.yml
+++ b/config/locales/models/en.yml
@@ -23,6 +23,8 @@ en:
       chapters/creatorships:
         base: 'Invalid creator:'
         pseud_id: Pseud
+      collection:
+        header_image_url: Header image URL
       creatorships:
         base: 'Invalid creator:'
         pseud_id: Pseud
@@ -96,6 +98,10 @@ en:
           attributes:
             pseud:
               required: can't be blank
+        collection:
+          attributes:
+            header_image_url:
+              file_format: can only point to a gif, jpg, jpeg, or png file.
         comment:
           attributes:
             comment_content:

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -82,6 +82,22 @@ describe Collection do
       expect(collection.errors.full_messages).to \
         include /Sorry, a collection can only have 10 tags./
     end
+
+    it "disallows invalid header image urls" do
+      collection.header_image_url = "https://example.com/image.webp"
+      expect(collection.save).to be_falsey
+      expect(collection.errors.full_messages).to include("Header image URL can only point to a gif, jpg, jpeg, or png file.")
+    end
+
+    it "allows jpeg header image urls" do
+      collection.header_image_url = "https://example.com/image.jpeg"
+      expect(collection.save).to be_truthy
+    end
+
+    it "allows jpg header image urls" do
+      collection.header_image_url = "https://example.com/image.jpg"
+      expect(collection.save).to be_truthy
+    end
   end
 
   describe "#clear_icon" do


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6644

## Purpose

Allow jpeg image links for the collection header URL.

## References

Adopted #4692

PR Limit: 6 out of 5
Using reviewer bonus:
https://github.com/otwcode/otwarchive/pull/4937
https://github.com/otwcode/otwarchive/pull/4903

## Credit

Ivedonestranger (code for previous PR)
Brian (code review for previous PR)
Bilka
