### PR TITLE
AO3-6921 Commas used in series browser page title are not translatable

### DIFF
--- a/app/controllers/series_controller.rb
+++ b/app/controllers/series_controller.rb
@@ -48,7 +48,7 @@ class SeriesController < ApplicationController
     if @series.unrevealed?
       @page_subtitle = t(".unrevealed_series")
     else
-      @page_title = get_page_title(@series.allfandoms.collect(&:name).to_sentence, @series.anonymous? ? t(".anonymous") : @series.allpseuds.collect(&:byline).to_sentence, @series.title)
+      @page_title = get_page_title(@series.allfandoms.collect(&:name).join(t("support.array.words_connector")), @series.anonymous? ? t(".anonymous") : @series.allpseuds.collect(&:byline).join(t("support.array.words_connector")), @series.title)
     end
 
     if current_user.respond_to?(:subscriptions)


### PR DESCRIPTION
# Pull Request Checklist

<!-- Mark steps in the checklist as complete by changing `[ ]` to `[X]` -->
* [X] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [X] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [X] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [X] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [X] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-6921

## Purpose

Replaces the hard-coded comma in series_controller .join(",") with .join(t("support.array.words_connector")) so that the commas in the page title are translatable across languages.

## Testing Instructions

1. Switch the site to Mandarin (via URL parameter, user preference, or however AO3 handles locales).
2. Hard refresh the page to ensure the new locale is applied.
3. Inspect the <title> tag in the browser (hover or view source).
4. Verify that the list separators are the Mandarin comma (、) instead of the English comma ( , ).
5. For clarity, confirm that switching back to English restores the English comma ( , ).
6. (、)( , )