### PR TITLE
AO3-7094 Decrease case-sensitivity for custom properties/variables

### DIFF
--- a/app/models/work_skin.rb
+++ b/app/models/work_skin.rb
@@ -13,7 +13,7 @@ class WorkSkin < Skin
         errors.add(:base, :work_skin_custom_properties)
         return false
       end
-      if value.match(/\A(#{CssCleaner::VAR_FUNCTION_REGEX})\z/)
+      if value.match(/\bvar\b/i)
         errors.add(:base, :work_skin_var)
         return false
       end

--- a/config/locales/models/en.yml
+++ b/config/locales/models/en.yml
@@ -169,7 +169,7 @@ en:
           banned_property: We don't currently allow the CSS property %{property} -- please notify Support if you think this is an error.
           banned_value_for_property: "%{property} in %{selectors} cannot have the value %{value}, sorry!"
           font_face: We don't allow the @font-face feature.
-          invalid_custom_property_name: The %{property} custom property in %{selectors} has an invalid name. Names can contain letters in the English alphabet in both uppercase (A-Z) and lowercase (a-z), numerals zero to nine (0-9), and underscores (_).
+          invalid_custom_property_name: The %{property} custom property in %{selectors} has an invalid name. Names can contain lowercase letters (a-z) in the English alphabet, numerals zero to nine (0-9), dashes (-), and underscores (_).
           invalid_media: We don't currently support the media type %{media}, sorry! If we should, please let Support know.
           no_public_preview: You need to upload a screencap if you want to share your skin.
           no_rules_for_selectors: There don't seem to be any rules for %{selectors}.

--- a/public/help/skins-creating.html
+++ b/public/help/skins-creating.html
@@ -112,7 +112,7 @@
   <dt>Custom Properties (Variables)</dt>
   <dd>
     <p>
-      Custom property names can contain any combination of lowercase letters (a-z) in the English alphabet, numerals zero to nine (0-9), dashes (-), and underscores (_). They can't contain single (') or double (") quotation marks, or URLs.
+      Custom property names can contain any combination of lowercase letters (a-z) in the English alphabet, numerals zero to nine (0-9), dashes (-), and underscores (_). They can't contain single (') or double (") quotation marks, or URLs. Any uppercase letters (A-Z) will be converted to lowercase.
     </p>
     <p>
       All properties except <code>font-family</code> and <code>content</code> accept the <code>var()</code> function as a value. We don't allow fallbacks.

--- a/public/help/skins-creating.html
+++ b/public/help/skins-creating.html
@@ -112,7 +112,7 @@
   <dt>Custom Properties (Variables)</dt>
   <dd>
     <p>
-      Custom property names can contain any combination of letters in the English alphabet in both uppercase (A-Z) and lowercase (a-z), numerals zero to nine (0-9), and underscores (_). They can't contain single (') or double (") quotation marks, or URLs.
+      Custom property names can contain any combination of lowercase letters (a-z) in the English alphabet, numerals zero to nine (0-9), dashes (-), and underscores (_). They can't contain single (') or double (") quotation marks, or URLs.
     </p>
     <p>
       All properties except <code>font-family</code> and <code>content</code> accept the <code>var()</code> function as a value. We don't allow fallbacks.

--- a/spec/lib/css_cleaner_spec.rb
+++ b/spec/lib/css_cleaner_spec.rb
@@ -37,7 +37,7 @@ describe CssCleaner do
           expect(skin.reload.css).to eq(":root {\n  --rainbow: #fff;\n}\n\n")
         end
 
-        ["url", "URL"].each do |function_name|
+        %w[url URL].each do |function_name|
           it "strips custom property and returns error when value uses #{function_name}() function" do
             skin = build(:skin, css: ":root { --art: #{function_name}(\"https://example.com/img.png\"); }")
             expect(skin.save).to be_falsey
@@ -133,7 +133,7 @@ describe CssCleaner do
           expect(skin.css).to eq("div {\n  border: var(--thick);\n  margin: var(--thin);\n}\n\n")
         end
 
-        ["var", "VAR"].each do |function_name|
+        %w[var VAR].each do |function_name|
           it "strips #{function_name}() function from content property and returns error" do
             skin = build(:skin, css: "p:before { content: #{function_name}(--text) }")
             expect(skin.save).to be_falsey

--- a/spec/lib/css_cleaner_spec.rb
+++ b/spec/lib/css_cleaner_spec.rb
@@ -6,7 +6,7 @@ describe CssCleaner do
   describe ".clean_css_code" do
     context "when cleaning Skin CSS" do
       context "when defining custom property" do
-        it "allows custom property name with letters" do
+        it "allows custom property name with lowercase letters" do
           skin = build(:skin, css: ":root { --white: #fff; }")
           expect(skin.save).to be_truthy
           expect(skin.reload.css).to eq(":root {\n  --white: #fff;\n}\n\n")
@@ -30,24 +30,46 @@ describe CssCleaner do
           expect(skin.reload.css).to eq(":root {\n  --__: rgba(255, 255, 255, 0);\n}\n\n")
         end
 
-        it "strips custom property and returns error when value uses url() function" do
-          skin = build(:skin, css: ":root { --art: url(\"https://example.com/img.png\"); }")
-          expect(skin.save).to be_falsey
-          expect(skin.css).to eq("")
-          expect(skin.errors[:base]).to include("--art in :root cannot have the value url(\"https://example.com/img.png\"), sorry!")
+        # https://github.com/premailer/css_parser/blob/2ef7dcaaf9ceaba6652d67a875e4df5e76d8950f/lib/css_parser/rule_set.rb#L228-L232
+        it "downcases uppercase letters in custom property name" do
+          skin = build(:skin, css: ":root { --RAINBOW: #fff; }")
+          expect(skin.save).to be_truthy
+          expect(skin.reload.css).to eq(":root {\n  --rainbow: #fff;\n}\n\n")
         end
 
-        it "strips custom property and retruns error when value uses quotation marks" do
+        ["url", "URL"].each do |function_name|
+          it "strips custom property and returns error when value uses #{function_name}() function" do
+            skin = build(:skin, css: ":root { --art: #{function_name}(\"https://example.com/img.png\"); }")
+            expect(skin.save).to be_falsey
+            expect(skin.css).to eq("")
+            expect(skin.errors[:base]).to include("--art in :root cannot have the value #{function_name}(\"https://example.com/img.png\"), sorry!")
+          end
+        end
+
+        it "strips custom property and returns error when value uses double quotation marks" do
           skin = build(:skin, css: ":root { --serif: \"Times New Roman\" };")
           expect(skin.save).to be_falsey
           expect(skin.css).to eq("")
           expect(skin.errors[:base]).to include("--serif in :root cannot have the value \"Times New Roman\", sorry!")
         end
 
+        it "strips custom property and returns error when value uses single quotation marks" do
+          skin = build(:skin, css: ":root { --sans-serif: 'Lucida Sans' };")
+          expect(skin.save).to be_falsey
+          expect(skin.css).to eq("")
+          expect(skin.errors[:base]).to include("--sans-serif in :root cannot have the value 'Lucida Sans', sorry!")
+        end
+
         it "allows shorthand-style values" do
           skin = build(:skin, css: ":root { --heading: small-caps 1.125rem Georgia, Times New Roman, serif; }")
           expect(skin.save).to be_truthy
           expect(skin.reload.css).to eq(":root {\n  --heading: small-caps 1.125rem Georgia, Times New Roman, serif;\n}\n\n")
+        end
+
+        it "allows var() function as value" do
+          skin = build(:skin, css: "#header { --nav_color: var(--brand-color); }")
+          expect(skin.save).to be_truthy
+          expect(skin.reload.css).to eq("#header {\n  --nav_color: var(--brand-color);\n}\n\n")
         end
 
         it "strips custom property and returns error when shorthand-style value includes url() function" do
@@ -64,11 +86,11 @@ describe CssCleaner do
           expect(skin.errors[:base]).to include("--heading in :root cannot have the value small-caps 1.125rem Georgia, \"Times New Roman\", serif, sorry!")
         end
 
-        it "strips custom property with disallowed characters and returns error" do
+        it "strips custom property with disallowed characters in name and returns error" do
           skin = build(:skin, css: "#footer, #header { --#hash: absolute; }")
           expect(skin.save).to be_falsey
           expect(skin.css).to eq("")
-          expect(skin.errors[:base]).to include("The --#hash custom property in #footer, #header has an invalid name. Names can contain letters in the English alphabet in both uppercase (A-Z) and lowercase (a-z), numerals zero to nine (0-9), and underscores (_).")
+          expect(skin.errors[:base]).to include("The --#hash custom property in #footer, #header has an invalid name. Names can contain lowercase letters (a-z) in the English alphabet, numerals zero to nine (0-9), dashes (-), and underscores (_).")
         end
 
         it "strips invalid property and returns error when property contains text resembling custom property name" do
@@ -99,32 +121,46 @@ describe CssCleaner do
           expect(skin.css).to eq("div {\n  font: var(--black);\n}\n\n")
         end
 
-        it "strips var() function from content property and returns error" do
-          skin = build(:skin, css: "p:before { content: var(--text) }")
-          expect(skin.save).to be_falsey
-          expect(skin.css).to eq("")
-          expect(skin.errors[:base]).to include("content in p:before cannot have the value var(--text), sorry!")
+        it "allows multiple simple var() functions for shorthand property" do
+          skin = build(:skin, css: "blockquote { border: var(--border-width) var(--Border-Style) var(--color) }")
+          expect(skin.save).to be_truthy
+          expect(skin.css).to eq("blockquote {\n  border: var(--border-width) var(--border-style) var(--color);\n}\n\n")
         end
 
-        it "strips var() function from font-family property and returns error" do
-          skin = build(:skin, css: ".heading { font-family: var(--serif) }")
-          expect(skin.save).to be_falsey
-          expect(skin.css).to eq("")
-          expect(skin.errors[:base]).to include("font-family in .heading cannot have the value var(--serif), sorry!")
+        it "downcases var() functions" do
+          skin = build(:skin, css: "div { border: var(--THICK); margin: VAR(--Thin) }")
+          expect(skin.save).to be_truthy
+          expect(skin.css).to eq("div {\n  border: var(--thick);\n  margin: var(--thin);\n}\n\n")
         end
 
-        it "strips var() function with fallbacks and returns error" do
-          skin = build(:skin, css: "p { color: var(--blue, #fff) }")
-          expect(skin.save).to be_falsey
-          expect(skin.css).to eq("")
-          expect(skin.errors[:base]).to include("color in p cannot have the value var(--blue, #fff), sorry!")
-        end
+        ["var", "VAR"].each do |function_name|
+          it "strips #{function_name}() function from content property and returns error" do
+            skin = build(:skin, css: "p:before { content: #{function_name}(--text) }")
+            expect(skin.save).to be_falsey
+            expect(skin.css).to eq("")
+            expect(skin.errors[:base]).to include("content in p:before cannot have the value #{function_name}(--text), sorry!")
+          end
 
-        it "strips var() function with unclosed parentheses and returns error" do
-          skin = build(:skin, css: "p { color: var(--blue }")
-          expect(skin.save).to be_falsey
-          expect(skin.css).to eq("")
-          expect(skin.errors[:base]).to include("There don't seem to be any rules for p.")
+          it "strips #{function_name}() function from font-family property and returns error" do
+            skin = build(:skin, css: ".heading { font-family: #{function_name}(--serif) }")
+            expect(skin.save).to be_falsey
+            expect(skin.css).to eq("")
+            expect(skin.errors[:base]).to include("font-family in .heading cannot have the value #{function_name}(--serif), sorry!")
+          end
+
+          it "strips #{function_name}() function with fallbacks and returns error" do
+            skin = build(:skin, css: "p { color: #{function_name}(--blue, #fff) }")
+            expect(skin.save).to be_falsey
+            expect(skin.css).to eq("")
+            expect(skin.errors[:base]).to include("color in p cannot have the value #{function_name}(--blue, #fff), sorry!")
+          end
+
+          it "strips #{function_name}() function with unclosed parentheses and returns error" do
+            skin = build(:skin, css: "p { color: #{function_name}(--blue }")
+            expect(skin.save).to be_falsey
+            expect(skin.css).to eq("")
+            expect(skin.errors[:base]).to include("There don't seem to be any rules for p.")
+          end
         end
       end
     end
@@ -137,11 +173,19 @@ describe CssCleaner do
         expect(skin.errors[:base]).to include("Custom properties are not allowed in work skins.")
       end
 
-      it "strips variable functions and returns error" do
-        skin = build(:work_skin, css: "p { color: var(--yellow) }")
-        expect(skin.save).to be_falsey
-        expect(skin.css).to eq("")
-        expect(skin.errors[:base]).to include("The var() function is not allowed in work skins.")
+      context "with var() function as a value" do
+        {
+          "strips lowercase function and returns error" => "p { color: var(--puce) ; }",
+          "strips uppercase Vfunction and returns error" => ".class { width: var(--narrow) }",
+          "strips function with uppercase letters in variable and returns error" => "span { border-color:var(--SOMEcolor) }"
+        }.each_pair do |description, css|
+          it description do
+            skin = build(:work_skin, css: css)
+            expect(skin.save).to be_falsey
+            expect(skin.css).to eq("")
+            expect(skin.errors[:base]).to include("The var() function is not allowed in work skins.")
+          end
+        end
       end
 
       context "with position property" do

--- a/spec/lib/css_cleaner_spec.rb
+++ b/spec/lib/css_cleaner_spec.rb
@@ -108,7 +108,7 @@ describe CssCleaner do
         end
       end
 
-      context "when using var() function as value" do
+      context "with var() function as value" do
         it "allows simple var() functions for regular property" do
           skin = build(:skin, css: "div { color: var(--black) }")
           expect(skin.save).to be_truthy
@@ -128,9 +128,9 @@ describe CssCleaner do
         end
 
         it "downcases var() functions" do
-          skin = build(:skin, css: "div { border: var(--THICK); margin: VAR(--Thin) }")
+          skin = build(:skin, css: "div { border: var(--THICK); margin: 0 VAR(--wide) }")
           expect(skin.save).to be_truthy
-          expect(skin.css).to eq("div {\n  border: var(--thick);\n  margin: var(--thin);\n}\n\n")
+          expect(skin.css).to eq("div {\n  border: var(--thick);\n  margin: 0 var(--wide);\n}\n\n")
         end
 
         %w[var VAR].each do |function_name|
@@ -173,11 +173,13 @@ describe CssCleaner do
         expect(skin.errors[:base]).to include("Custom properties are not allowed in work skins.")
       end
 
-      context "with var() function as a value" do
+      context "with var() function as value" do
         {
-          "strips lowercase function and returns error" => "p { color: var(--puce) ; }",
-          "strips uppercase Vfunction and returns error" => ".class { width: var(--narrow) }",
-          "strips function with uppercase letters in variable and returns error" => "span { border-color:var(--SOMEcolor) }"
+          "strips var() function and returns error" => "p { color: var(--puce) ; }",
+          "strips var() function with uppercase letters in variable and returns error" => "span { border-color:var(--SOMEcolor) }",
+          "strips var() function in shorthand value and returns error" => "#id { border: var(--border-width) var(--Border-Style) #000; }",
+          "strips VAR() function and returns error" => ".class { width: VAR(--narrow) }",
+          "strips VAR() function in shorthand value and returns error" => "p:not(.class) { border: VAR(--border-width) VAR(--Border-Style) #000; }"
         }.each_pair do |description, css|
           it description do
             skin = build(:work_skin, css: css)


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-7094

## Purpose

**Please do review the code! This is a draft because I'm waiting on some additional text changes from Docs, not because the code is unfinished.**

- The text about dashes being allowed got eaten in some drafting back and forth with Docs; this restores it.
- The css_parser gem downcases all properties to normalize them. This was a problem because CSS variables are case-sensitive: if you entered `--RED: #900`, it would get converted to `--red: #900` and would no longer work when trying to access it with `var(--RED)`. To handle this, I've chosen to downcase the `var()` function and remove any reference to uppercase letters being allowed in variable names. (more info) 
  - Help text explaining this to come.
  - I removed a line of code downcasing properties on our side since it is not necessary (css_parser downcases as soon as we `add_block!`). 
  - I also added a test so we'll be aware if a css_parser update ever changes this behavior.
- It was possible to use the `var()` function in places we didn't want it (e.g., in work skins or as a value for `content`) by using uppercase letters (e.g., `VAR(--newcolor)` or `var(--NEWcolor)`), which would evade our regexes for giving errors when the `var()` function was found. I've made the regexes case-insensitive. (Downcasing the function as described in the previous point didn't fix this because the value gets downcased when we sanitize it, which happens after we check for its presence.)
  - We had the same problem when checking for the `url()` function, so I fixed that as well.
 
## Testing Instructions

1. Repeat the existing Step 1 and confirm the error message now mentions dashes and does not mention uppercase letters.
2. Check the help text and confirm it now mentions dashes and does not mention uppercase letters. It should also mention that variables will be downcased.
3. Use the `var()` function with uppercase letters, either in the function name itself or the name of the custom property. Confirm it is converted to lowercase, and that it gets stripped if you use it in work skins or with the `font-family` or `content` property. Make sure to test using it in shorthand values as well, e.g. `margin: var(--skinny) auto`.
4. Use the `url()` function with uppercase letters in the function name itself, i.e. `URL()`. Confirm it gets stripped if you use it with a property other than background, background-image, border, border-image, list-style, list-style-image. Confirm it's accepted as the value for at least one of those properties.
