### PR TITLE
AO3-6581 Update heading + page title for "Marked for Later" page

### DIFF
--- a/app/controllers/readings_controller.rb
+++ b/app/controllers/readings_controller.rb
@@ -11,10 +11,10 @@ class ReadingsController < ApplicationController
 
   def index
     @readings = @user.readings.visible
-    @page_subtitle = t(".history_page_title", username: @user.login)
+    @page_subtitle = t(".history_page_title")
     if params[:show] == 'to-read'
       @readings = @readings.where(toread: true)
-      @page_subtitle = t(".marked_for_later_page_title", username: @user.login)
+      @page_subtitle = t(".marked_for_later_page_title")
     end
     @readings = @readings.order("last_viewed DESC")
     @pagy, @readings = pagy(@readings)

--- a/app/controllers/readings_controller.rb
+++ b/app/controllers/readings_controller.rb
@@ -11,10 +11,10 @@ class ReadingsController < ApplicationController
 
   def index
     @readings = @user.readings.visible
-    @page_subtitle = ts("History")
+    @page_subtitle = t(".history")
     if params[:show] == 'to-read'
       @readings = @readings.where(toread: true)
-      @page_subtitle = ts("Marked For Later")
+      @page_subtitle = t(".marked_for_later")
     end
     @readings = @readings.order("last_viewed DESC")
     @pagy, @readings = pagy(@readings)

--- a/app/controllers/readings_controller.rb
+++ b/app/controllers/readings_controller.rb
@@ -11,10 +11,10 @@ class ReadingsController < ApplicationController
 
   def index
     @readings = @user.readings.visible
-    @page_subtitle = t(".history")
+    @page_subtitle = t(".history_page_title", username: @user.login)
     if params[:show] == 'to-read'
       @readings = @readings.where(toread: true)
-      @page_subtitle = t(".marked_for_later")
+      @page_subtitle = t(".marked_for_later_page_title", username: @user.login)
     end
     @readings = @readings.order("last_viewed DESC")
     @pagy, @readings = pagy(@readings)

--- a/app/views/readings/index.html.erb
+++ b/app/views/readings/index.html.erb
@@ -1,5 +1,11 @@
 <!--Descriptive page name, messages and instructions-->
-<h2 class="heading"><%= @page_subtitle %></h2>
+<h2 class="heading">
+  <% if params[:show] == "to-read" %>
+    <%= t(".marked_for_later") %>
+  <% else %>
+    <%= t(".history") %>
+  <% end %>
+</h2>
 <!--/descriptions-->
 
 <!--subnav-->
@@ -19,7 +25,13 @@
 <!--/subnav-->
 
 <!--main content-->
-<h3 class="landmark heading"><%= ts('List of History Items') %></h3>
+<h3 class="landmark heading">
+  <% if params[:show] == "to-read" %>
+    <%= t(".marked_for_later_landmark") %>
+  <% else %>
+    <%= t(".history_landmark") %>
+  <% end %>
+</h3>
 <% if logged_in? && @readings.present? %>
   <ol class="reading work index group">
     <% @readings.each do |reading| %>

--- a/app/views/readings/index.html.erb
+++ b/app/views/readings/index.html.erb
@@ -1,10 +1,8 @@
+<% mode = params[:show] == "to-read" ? "marked_for_later" : "history" %>
+
 <!--Descriptive page name, messages and instructions-->
 <h2 class="heading">
-  <% if params[:show] == "to-read" %>
-    <%= t(".marked_for_later") %>
-  <% else %>
-    <%= t(".history") %>
-  <% end %>
+  <%= t(".#{mode}.page_heading") %>
 </h2>
 <!--/descriptions-->
 
@@ -26,11 +24,7 @@
 
 <!--main content-->
 <h3 class="landmark heading">
-  <% if params[:show] == "to-read" %>
-    <%= t(".marked_for_later_landmark") %>
-  <% else %>
-    <%= t(".history_landmark") %>
-  <% end %>
+  <%= t(".#{mode}.landmark") %>
 </h3>
 <% if logged_in? && @readings.present? %>
   <ol class="reading work index group">

--- a/app/views/readings/index.html.erb
+++ b/app/views/readings/index.html.erb
@@ -1,5 +1,5 @@
 <!--Descriptive page name, messages and instructions-->
-<h2 class="heading"><%= ts('History') %></h2>
+<h2 class="heading"><%= @page_subtitle %></h2>
 <!--/descriptions-->
 
 <!--subnav-->

--- a/config/locales/controllers/en.yml
+++ b/config/locales/controllers/en.yml
@@ -194,8 +194,8 @@ en:
       error: There were problems deleting your history. Please try again later.
       success: Your history is now cleared.
     index:
-      history_page_title: "%{username} - History"
-      marked_for_later_page_title: "%{username} - Marked for Later"
+      history_page_title: "History"
+      marked_for_later_page_title: "Marked for Later"
   related_works:
     index:
       page_title: "%{login} - Related Works"

--- a/config/locales/controllers/en.yml
+++ b/config/locales/controllers/en.yml
@@ -193,6 +193,9 @@ en:
     clear:
       error: There were problems deleting your history. Please try again later.
       success: Your history is now cleared.
+    index:
+      history_page_title: "%{username} - History"
+      marked_for_later_page_title: "%{username} - Marked for Later"
   related_works:
     index:
       page_title: "%{login} - Related Works"

--- a/config/locales/controllers/en.yml
+++ b/config/locales/controllers/en.yml
@@ -194,8 +194,8 @@ en:
       error: There were problems deleting your history. Please try again later.
       success: Your history is now cleared.
     index:
-      history_page_title: "History"
-      marked_for_later_page_title: "Marked for Later"
+      history_page_title: History
+      marked_for_later_page_title: Marked for Later
   related_works:
     index:
       page_title: "%{login} - Related Works"

--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -2027,10 +2027,12 @@ en:
       submit: Submit
   readings:
     index:
-      history: History
-      history_landmark: List of History Items
-      marked_for_later: Marked for Later
-      marked_for_later_landmark: List of Marked for Later Items
+      history:
+        page_heading: History
+        landmark: List of History Items
+      marked_for_later:
+        page_heading: Marked for Later
+        landmark: List of Marked for Later Items
   related_works:
     index:
       page_heading: "%{login}'s Related Works"

--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -2028,7 +2028,9 @@ en:
   readings:
     index:
       history: History
+      history_landmark: List of History Items
       marked_for_later: Marked for Later
+      marked_for_later_landmark: List of Marked for Later Items
   related_works:
     index:
       page_heading: "%{login}'s Related Works"

--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -2025,6 +2025,10 @@ en:
       make_default: Make this name default
       name: Name
       submit: Submit
+  readings:
+    index:
+      history: History
+      marked_for_later: Marked for Later
   related_works:
     index:
       page_heading: "%{login}'s Related Works"

--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -2028,11 +2028,11 @@ en:
   readings:
     index:
       history:
-        page_heading: History
         landmark: List of History Items
+        page_heading: History
       marked_for_later:
-        page_heading: Marked for Later
         landmark: List of Marked for Later Items
+        page_heading: Marked for Later
   related_works:
     index:
       page_heading: "%{login}'s Related Works"

--- a/features/other_a/reading.feature
+++ b/features/other_a/reading.feature
@@ -297,13 +297,14 @@ Feature: Reading count
     When I go to ethel's reading page
     Then I should see an HTML comment containing the number 1744477200 within "li.work.blurb"
   
-  Scenario: History page contains the correct heading text
+  Scenario: History page contains the correct heading text and page title
 
     When I am logged in as "fandomer"
       And I go to fandomer's reading page
     Then I should see "History" within "h2.heading"
+    And I should see the page title "fandomer - History | Example Archive"
   
-  Scenario: Marked for Later page contains the correct heading text
+  Scenario: Marked for Later page contains the correct heading text and page title
 
     Given the work "Testy" by "writer"
     When I am logged in as "fandomer"
@@ -312,3 +313,4 @@ Feature: Reading count
       And I go to fandomer's reading page
       And I follow "Marked for Later"
     Then I should see "Marked for Later" within "h2.heading"
+    And I should see the page title "fandomer - Marked for Later | Example Archive"

--- a/features/other_a/reading.feature
+++ b/features/other_a/reading.feature
@@ -11,7 +11,7 @@ Feature: Reading count
   Then I should see "Sorry, you don't have permission"
     And I should not see "History" within "div#dashboard"
   When I go to second_reader's reading page
-  Then I should see the page title "History | Example Archive"
+  Then I should see the page title "History"
     And I should see "History" within "h2.heading"
     And I should see "History" within "div#dashboard"
 

--- a/features/other_a/reading.feature
+++ b/features/other_a/reading.feature
@@ -11,7 +11,9 @@ Feature: Reading count
   Then I should see "Sorry, you don't have permission"
     And I should not see "History" within "div#dashboard"
   When I go to second_reader's reading page
-  Then I should see "History" within "div#dashboard"
+  Then I should see the page title "History | Example Archive"
+    And I should see "History" within "h2.heading"
+    And I should see "History" within "div#dashboard"
 
   Scenario: A user can read a work several times, updating the count and date in their history
 
@@ -112,8 +114,11 @@ Feature: Reading count
   Then I should see "Mark for Later"
   When I follow "Mark for Later"
   Then I should see "This work was added to your Marked for Later list."
-    And I go to reader's reading page
-  Then I should see "Testy"
+  When I go to reader's reading page
+    And I follow "Marked for Later"
+  Then I should see the page title "Marked for Later"
+    And I should see "Marked for Later" within "h2.heading"
+    And I should see "Testy"
     And I should see "(Marked for Later.)"
   When I view the work "Testy"
   Then I should see "Mark as Read"
@@ -296,21 +301,3 @@ Feature: Reading count
       And the readings are saved to the database
     When I go to ethel's reading page
     Then I should see an HTML comment containing the number 1744477200 within "li.work.blurb"
-  
-  Scenario: History page contains the correct heading text and page title
-
-    When I am logged in as "fandomer"
-      And I go to fandomer's reading page
-    Then I should see "History" within "h2.heading"
-    And I should see the page title "fandomer - History | Example Archive"
-  
-  Scenario: Marked for Later page contains the correct heading text and page title
-
-    Given the work "Testy" by "writer"
-    When I am logged in as "fandomer"
-      And I view the work "Testy"
-      And I follow "Mark for Later"
-      And I go to fandomer's reading page
-      And I follow "Marked for Later"
-    Then I should see "Marked for Later" within "h2.heading"
-    And I should see the page title "fandomer - Marked for Later | Example Archive"

--- a/features/other_a/reading.feature
+++ b/features/other_a/reading.feature
@@ -296,3 +296,19 @@ Feature: Reading count
       And the readings are saved to the database
     When I go to ethel's reading page
     Then I should see an HTML comment containing the number 1744477200 within "li.work.blurb"
+  
+  Scenario: History page contains the correct heading text
+
+    When I am logged in as "fandomer"
+      And I go to fandomer's reading page
+    Then I should see "History" within "h2.heading"
+  
+  Scenario: Marked for Later page contains the correct heading text
+
+    Given the work "Testy" by "writer"
+    When I am logged in as "fandomer"
+      And I view the work "Testy"
+      And I follow "Mark for Later"
+      And I go to fandomer's reading page
+      And I follow "Marked for Later"
+    Then I should see "Marked for Later" within "h2.heading"


### PR DESCRIPTION
# Pull Request Checklist

<!-- Mark steps in the checklist as complete by changing `[ ]` to `[X]` -->
* [X] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [X] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [X] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [X] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [X] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-6581

## Purpose

This PR updates the heading and page title for the "Marked for Later" page, as well as registers both the "History" and "Marked for Later" strings with the i18n system. 

## Credit

Jamis Gelvin (they/them)
