### PR TITLE
AO3-7096 Track when a collection's anonymous/unrevealed settings were…

### DIFF
--- a/app/models/collection_preference.rb
+++ b/app/models/collection_preference.rb
@@ -1,15 +1,31 @@
 class CollectionPreference < ApplicationRecord
   belongs_to :collection
+
+  after_create :set_initial_audit_timestamps
+  after_update :set_audit_timestamps
   after_update :after_update
 
+  private
+
+  def set_initial_audit_timestamps
+    update_columns(
+      unrevealed_updated_at: created_at,
+      anonymous_updated_at: created_at
+    )
+  end
+
+  def set_audit_timestamps
+    updates = {}
+    updates[:unrevealed_updated_at] = updated_at if saved_change_to_unrevealed?
+    updates[:anonymous_updated_at]  = updated_at if saved_change_to_anonymous?
+
+    update_columns(updates) if updates.any?
+  end
+
   def after_update
-    if self.collection.valid? && self.valid?
-      if self.saved_change_to_unrevealed? && !self.unrevealed?
-        self.collection.reveal!
-      end
-      if self.saved_change_to_anonymous? && !self.anonymous?
-        collection.reveal_authors!
-      end
-    end
+    return unless collection.valid? && valid?
+
+    collection.reveal! if saved_change_to_unrevealed? && !unrevealed?
+    collection.reveal_authors! if saved_change_to_anonymous? && !anonymous?
   end
 end

--- a/db/migrate/20250816213210_add_audit_timestamps_to_collection_preferences.rb
+++ b/db/migrate/20250816213210_add_audit_timestamps_to_collection_preferences.rb
@@ -1,0 +1,20 @@
+class AddAuditTimestampsToCollectionPreferences < ActiveRecord::Migration[7.1]
+  uses_departure! if Rails.env.staging? || Rails.env.production?
+
+  def change
+    change_table :collection_preferences, bulk: true do |t|
+      t.datetime :unrevealed_updated_at
+      t.datetime :anonymous_updated_at
+    end
+
+    reversible do |dir|
+      dir.up do
+        execute <<~SQL.squish
+          UPDATE collection_preferences
+          SET unrevealed_updated_at = created_at,
+              anonymous_updated_at  = created_at
+        SQL
+      end
+    end
+  end
+end

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -1,14 +1,13 @@
-require 'spec_helper'
+require "spec_helper"
 
 describe Collection do
-
   before do
     @collection = FactoryBot.create(:collection)
   end
 
   describe "collections with challenges" do
     [GiftExchange, PromptMeme].each do |challenge_klass|
-      ["true","false"].each do |moderated_status|
+      %w[true false].each do |moderated_status|
         describe "of type #{challenge_klass.name}" do
           before do
             @collection.challenge = challenge_klass.new
@@ -54,7 +53,6 @@ describe Collection do
               it "should not be listed as open" do
                 expect(Collection.signup_open(@challenge.class.name)).not_to include(@collection)
               end
-
             end
           end
 
@@ -71,6 +69,77 @@ describe Collection do
         end
       end # moderated_status loop
     end # challenges type loop
+  end
+
+  describe "audit timestamps for collection preferences" do
+    let(:preference) { create(:collection_preference, collection: @collection, unrevealed: true, anonymous: true) }
+
+    it "sets unrevealed_updated_at and anonymous_updated_at to created_at on creation" do
+      expect(preference.unrevealed_updated_at).to eq(preference.created_at)
+      expect(preference.anonymous_updated_at).to eq(preference.created_at)
+    end
+
+    it "updates unrevealed_updated_at when unrevealed changes" do
+      old_time = preference.unrevealed_updated_at
+
+      preference.update!(unrevealed: !preference.unrevealed)
+
+      preference.reload
+
+      expect(preference.unrevealed_updated_at).to be >= old_time
+      expect(preference.unrevealed_updated_at).to eq(preference.updated_at)
+    end
+
+    it "updates anonymous_updated_at when anonymous changes" do
+      old_time = preference.anonymous_updated_at
+
+      preference.update!(anonymous: !preference.anonymous)
+
+      preference.reload
+
+      expect(preference.anonymous_updated_at).to be >= old_time
+      expect(preference.anonymous_updated_at).to eq(preference.updated_at)
+    end
+
+    it "does not update timestamps when other attributes change" do
+      old_unrevealed = preference.unrevealed_updated_at
+      old_anonymous  = preference.anonymous_updated_at
+
+      preference.update!(moderated: !preference.moderated)
+
+      preference.reload
+
+      expect(preference.unrevealed_updated_at).to eq(old_unrevealed)
+      expect(preference.anonymous_updated_at).to eq(old_anonymous)
+    end
+
+    it "calls reveal! when unrevealed is changed to false" do
+      collection_spy = preference.collection
+      allow(collection_spy).to receive(:reveal!)
+
+      preference.update!(unrevealed: false)
+
+      expect(collection_spy).to have_received(:reveal!)
+    end
+
+    it "calls reveal_authors! when anonymous is changed to false" do
+      collection_spy = preference.collection
+      allow(collection_spy).to receive(:reveal_authors!)
+
+      preference.update!(anonymous: false)
+
+      expect(collection_spy).to have_received(:reveal_authors!)
+    end
+
+    it "does not call reveal methods when flags are unchanged" do
+      allow(preference.collection).to receive(:reveal!)
+      allow(preference.collection).to receive(:reveal_authors!)
+
+      preference.update!(moderated: true)
+
+      expect(preference.collection).not_to have_received(:reveal!)
+      expect(preference.collection).not_to have_received(:reveal_authors!)
+    end
   end
 
   describe "save" do


### PR DESCRIPTION

## Issue

https://otwarchive.atlassian.net/browse/AO3-7096

## Purpose
This PR adds audit tracking for a collection’s anonymous and unrevealed settings, recording when they were last updated to aid database administration and troubleshooting.

- Adds a migration to add `unrevealed_updated_at` and `anonymous_updated_at` columns to the CollectionPreferenceTable
- New columns are always initialized to the same timestamp as `created_at`
- When the anonymous or unrevealed setting is changed, the corresponding timestamps are updated to match the `updated_at` timestamp

## Credit

Connie Feng, she/her
([JIRA account](https://otwarchive.atlassian.net/jira/people/712020:17930fa1-d647-47bd-b334-8a84cbacfca7))
