### PR TITLE
AO3-6968 Add tag comment links to the wrangling bins

### DIFF
--- a/app/views/tag_wranglings/index.html.erb
+++ b/app/views/tag_wranglings/index.html.erb
@@ -124,10 +124,11 @@
                     <td title="<%= ts("taggings") %>"><%= tag.taggings_count_cache %></td>
 
                     <td>
-                      <ul class="actions" role="navigation">
-                        <li><%= link_to ts("Edit"), { controller: :tags, action: :edit, id: tag } %></li>
-                        <li><%= link_to ts("Wrangle"), { controller: :tags, action: :wrangle, id: tag } %></li>
-                        <li><%= link_to ts("Works"), { controller: :works, action: :index, tag_id: tag } %></li>
+                      <ul class="actions">
+                        <li><%= link_to t(".manage.edit"), edit_tag_path(tag) %></li>
+                        <li><%= link_to t(".manage.wrangle"), wrangle_tag_path(tag) %></li>
+                        <li><%= link_to t(".manage.works"), tag_works_path(tag) %></li>
+                        <li><%= link_to t(".manage.comments", count: tag.count_visible_comments), tag_comments_path(tag) %></li>
                       </ul>
                     </td>
                   </tr>

--- a/app/views/tags/wrangle.html.erb
+++ b/app/views/tags/wrangle.html.erb
@@ -145,9 +145,10 @@
                     </label>
                   </li>
                 <% end %>
-                <li><%= link_to ts('Edit'), {controller: :tags, action: :edit, id: tag} %></li>
-                <li><%= link_to ts('Wrangle'), {controller: :tags, action: :wrangle, id: tag} %></li>
-                <li><%= link_to ts('Works'), {controller: :works, action: :index, tag_id: tag} %></li>
+                <li><%= link_to t(".manage.edit"), edit_tag_path(tag) %></li>
+                <li><%= link_to t(".manage.wrangle"), wrangle_tag_path(tag) %></li>
+                <li><%= link_to t(".manage.works"), tag_works_path(tag) %></li>
+                <li><%= link_to t(".manage.comments", count: tag.count_visible_comments), tag_comments_path(tag) %></li>
               </ul>
             </td>
           </tr>

--- a/app/views/tags/wrangle.html.erb
+++ b/app/views/tags/wrangle.html.erb
@@ -136,7 +136,7 @@
             <td title="<%= ts("taggings") %>"><%= tag.taggings_count_cache %></td>
 
             <td>
-              <ul class="actions" role="menu">
+              <ul class="actions">
                 <% unless params[:status] == 'unwrangled' %>
                   <li>
                     <label for="remove_associated_<%= tag.id %>">

--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -2075,6 +2075,12 @@ en:
       last_wrangled_html: "%{wrangler_login} last wrangled at %{time}."
       tags_wrangled_csv: Tags Wrangled (CSV)
   tag_wranglings:
+    index:
+      manage:
+        comments: Comments (%{count})
+        edit: Edit
+        works: Works
+        wrangle: Wrangle
     wrangler_dashboard:
       characters_by_fandom: Characters by fandom (%{count})
       fandoms_by_media: Fandoms by media (%{count})
@@ -2136,6 +2142,12 @@ en:
       filter_bookmarks: filter bookmarks
       filter_works: filter works
       list_fandom_tags_html: You can also access a list of %{fandom_relationship_tags_link}.
+    wrangle:
+      manage:
+        comments: Comments (%{count})
+        edit: Edit
+        works: Works
+        wrangle: Wrangle
   time:
     formats:
       date_short_html: <abbr class="day" title="%A">%a</abbr> <span class="date">%d</span> <abbr class="month" title="%B">%b</abbr> <span class="year">%Y</span>

--- a/features/tags_and_wrangling/tag_wrangling.feature
+++ b/features/tags_and_wrangling/tag_wrangling.feature
@@ -381,3 +381,31 @@ Feature: Tag wrangling
     When I view the tag "Angst"
     Then "Angsta" should appear before "Angstb"
       And "Angstb" should appear before "Angstc"
+
+  Scenario: Tags in mass wrangling bins should have a link to the comment page with the comment count.
+
+    Given I am logged in as a random user
+      And I post the work "My Plan" with fandom "World Domination"
+      And all indexing jobs have been run
+      And I am logged in as a tag wrangler
+      And I go to the fandom mass bin
+    Then I should see "World Domination"
+      And I should see "Comments (0)"
+    When I post the comment "Anyone have a plan?" on the tag "World Domination"
+      And I go to the fandom mass bin
+    Then I should see "World Domination"
+      And I should see "Comments (1)"
+
+  Scenario: Tags in fandom bins should have a link to the comment page with the comment count.
+
+    Given I am logged in as a random user
+      And I post the work "My Plan" with fandom "World Domination" with character "New Person"
+      And all indexing jobs have been run
+      And I am logged in as a tag wrangler
+      And I view the unwrangled character bin for "World Domination"
+    Then I should see "New Person"
+      And I should see "Comments (0)"
+    When I post the comment "Who's this?" on the tag "New Person"
+      And I view the unwrangled character bin for "World Domination"
+    Then I should see "World Domination"
+      And I should see "Comments (1)"

--- a/features/tags_and_wrangling/tag_wrangling.feature
+++ b/features/tags_and_wrangling/tag_wrangling.feature
@@ -384,10 +384,9 @@ Feature: Tag wrangling
 
   Scenario: Tags in mass wrangling bins should have a link to the comment page with the comment count.
 
-    Given I am logged in as a random user
+    Given I am logged in as a tag wrangler
       And I post the work "My Plan" with fandom "World Domination"
       And all indexing jobs have been run
-      And I am logged in as a tag wrangler
       And I go to the fandom mass bin
     Then I should see "World Domination"
       And I should see "Comments (0)"
@@ -398,10 +397,9 @@ Feature: Tag wrangling
 
   Scenario: Tags in fandom bins should have a link to the comment page with the comment count.
 
-    Given I am logged in as a random user
+    Given I am logged in as a tag wrangler
       And I post the work "My Plan" with fandom "World Domination" with character "New Person"
       And all indexing jobs have been run
-      And I am logged in as a tag wrangler
       And I view the unwrangled character bin for "World Domination"
     Then I should see "New Person"
       And I should see "Comments (0)"


### PR DESCRIPTION
# Pull Request Checklist

<!-- Mark steps in the checklist as complete by changing `[ ]` to `[X]` -->
* [x] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [x] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [x] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [x] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-6968

## Purpose

This PR adds tag comment links to the fandom and mass wrangling bins for easier access to tag comment pages (and counts) when wrangling.

## Credit

marcus8448 (he/him)