### PR TITLE
AO3-6924 Move browser page title translations for users_controller to locale file for controllers

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -35,21 +35,21 @@ class UsersController < ApplicationController
 
   # GET /users/1/edit
   def edit
-    @page_subtitle = t(".browser_title") 
+    @page_subtitle = t(".browser_title")
     authorize @user.profile if logged_in_as_admin?
   end
 
   def change_email
-    @page_subtitle = t(".browser_title")
+    @page_subtitle = t(".page_title")
   end
 
   def change_password
-    @page_subtitle = t(".browser_title")
+    @page_subtitle = t(".page_title")
   end
 
   def change_username
     authorize @user if logged_in_as_admin?
-    @page_subtitle = t(".browser_title")
+    @page_subtitle = t(".page_title")
   end
 
   def changed_password
@@ -82,7 +82,7 @@ class UsersController < ApplicationController
     end
 
     if @new_login == @user.login
-      flash.now[:error] = t(".new_username_must_be_different") 
+      flash.now[:error] = t(".new_username_must_be_different")
       render :change_username and return
     end
 

--- a/config/locales/controllers/en.yml
+++ b/config/locales/controllers/en.yml
@@ -217,11 +217,11 @@ en:
       collection_page_title: "%{collection_title} - Tags"
   users:
     change_email:
-      browser_title: Change Email
+      page_title: Change Email
     change_password:
-      browser_title: Change Password
+      page_title: Change Password
     change_username:
-      browser_title: Change Username
+      page_title: Change Username
     changed_password:
       blank_password: You must enter your old password.
       wrong_password: Your old password was incorrect.

--- a/config/locales/controllers/en.yml
+++ b/config/locales/controllers/en.yml
@@ -216,6 +216,12 @@ en:
     index:
       collection_page_title: "%{collection_title} - Tags"
   users:
+    change_email:
+      browser_title: Change Email
+    change_password:
+      browser_title: Change Password
+    change_username:
+      browser_title: Change Username
     changed_password:
       blank_password: You must enter your old password.
       wrong_password: Your old password was incorrect.

--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -2177,7 +2177,6 @@ en:
       page_heading: Change Username
       ticket_id: Ticket ID
     change_email:
-      browser_title: Change Email
       caution:
         check_spam_html: "%{must_confirm_bold} Please check your spam folder or %{contact_support_link} if you do not receive the confirmation email."
         confirm_by: If you don't confirm your request by %{date}, your email address will not be changed.
@@ -2198,11 +2197,8 @@ en:
         other: You must use the link in the confirmation email in order to finish confirming your email change. If you don't confirm your request within %{count} days, the link will expire and your email address will not be changed.
       request_for_confirmation: Changing your email will send a request for confirmation to your new email address and a notification to your current email address.
       resubmission_html: Resubmitting this form with a new email address will %{invalidate_bold}.
-    change_password:
-      browser_title: Change Password
     change_username:
       account_faq: Account FAQ
-      browser_title: Change Username
       caution: Please use this feature with caution.
       change_window:
         one: You can change your username once per day.


### PR DESCRIPTION
# Pull Request Checklist

<!-- Mark steps in the checklist as complete by changing `[ ]` to `[X]` -->
* [X] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [X] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [X] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [X] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [X] Do you have fewer than 5 pull requests already open? If not, please wait until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-6924

## Purpose

This moves a few browser page title translations for users_controller from the views locale file to the controllers locale file. This was done because the browser page title is set in the controller, not the view. It also renames the key from `browser_title` to `page_title` as requested in the linked issue.

I wasn't sure if I should move all `browser_title` items or just the three mentioned in the issue. I also wasn't sure if I should refactor all the `browser_title` keys to `page_title`. So I played it safe and just edited what I moved. Please let me know if I should go back and move/refactor those other items!

## Credit

Kylia Miskell (they/them)