### PR TITLE
AO3-6914 Update language short field to display as Abbreviation in error messages

### DIFF
--- a/config/locales/models/en.yml
+++ b/config/locales/models/en.yml
@@ -34,6 +34,8 @@ en:
         offers_num_required: Number of offers required per sign-up
         requests_num_allowed: Number of requests allowed per sign-up
         requests_num_required: Number of requests required per sign-up
+      language:
+        short: Abbreviation
       meta_tagging:
         meta_tag: Metatag
         meta_tag_id: Metatag

--- a/spec/models/language_spec.rb
+++ b/spec/models/language_spec.rb
@@ -25,6 +25,12 @@ describe Language do
         expect(korean).not_to be_valid
         expect(korean.errors[:short]).to include("is too long (maximum is 4 characters)")
       end
+
+      it "shows 'Abbreviation' in error messages" do
+        lang = Language.new(name: "Test Language", short: "toolong")
+        lang.validate
+        expect(lang.errors.full_messages).to include("Abbreviation is too long (maximum is 4 characters)")
+      end
     end
 
     context "for :name" do


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/issues/?filter=13119&selectedIssue=AO3-6914

## Purpose

This updates the UI to use "Abbreviation" instead of "short" in error messages for better consistency when adding a new language with an abbreviation longer than 5 characters.

