### PR TITLE
AO3-2520 Make comment deletion work on noscript

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -607,7 +607,7 @@ class CommentsController < ApplicationController
         options = {}
         options[:show_comments] = params[:show_comments] if params[:show_comments]
         options[:delete_comment_id] = params[:id] if params[:id]
-        redirect_to_comment(@comment, options) # TO DO: deleting without javascript doesn't work and it never has!
+        redirect_to_comment(@comment, options)
       end
       format.js
     end

--- a/app/helpers/comments_helper.rb
+++ b/app/helpers/comments_helper.rb
@@ -284,7 +284,7 @@ module CommentsHelper
   end
 
   def do_cancel_delete_comment_link(comment)
-    if params[:delete_comment_id] && params[:delete_comment_id] == comment.id.to_s
+    if params[:delete_comment_id] == comment.id.to_s
       cancel_delete_comment_link(comment)
     else
       delete_comment_link(comment)
@@ -315,7 +315,7 @@ module CommentsHelper
   # return html link to delete comments
   def delete_comment_link(comment)
     link_to(
-      ts("Delete"),
+      t("comments.confirm_delete.delete"),
       url_for(controller: :comments,
               action: :delete_comment,
               id: comment,
@@ -326,7 +326,7 @@ module CommentsHelper
   # return link to cancel new reply to a comment
   def cancel_delete_comment_link(comment)
     link_to(
-      ts("Cancel"),
+      t("comments.confirm_delete.cancel"),
       url_for(controller: :comments,
               action: :cancel_comment_delete,
               id: comment,

--- a/app/views/comments/_comment_actions.html.erb
+++ b/app/views/comments/_comment_actions.html.erb
@@ -1,10 +1,10 @@
 <h5 class="landmark heading"><%= ts("Comment Actions") %></h5>
 
 <ul class="actions" id="navigation_for_comment_<%= comment.id %>" <% if focused_on_comment(comment) %> style="display:none;"<% end %>>
-  <% # The effect is "Frozen" replaces "Reply." We can't do that in the helper
-     # method for the reply link because that would prevent "Frozen" from
-     # appearing on the Unreviewed Comments page for works with moderated
-     # comments. %>
+  <%# The effect is "Frozen" replaces "Reply." We can't do that in the helper
+    # method for the reply link because that would prevent "Frozen" from
+    # appearing on the Unreviewed Comments page for works with moderated
+    # comments. %>
   <% if comment.iced? %>
     <li><%= frozen_comment_indicator %></li>
   <% end %>
@@ -50,19 +50,19 @@
   <% end %>
 </ul>
 
-<!-- this is where the comment delete confirmation will be displayed if we have javascript -->
-<!-- if not, here is where we will render the delete-comment form -->
-<% if params[:delete_comment_id] && params[:delete_comment_id] == comment.id.to_s %>
+<%# If JavaScript is enabled, render comment delete confirmation %>
+<% if params[:delete_comment_id] == comment.id.to_s %>
   <div id="delete_comment_placeholder_<%= comment.id %>">
-    <%= render 'comments/confirm_delete', :comment => comment %>
+    <%= render "comments/confirm_delete", comment: comment %>
 <% else %>
+  <%# Render the delete-comment form %>
   <div id="delete_comment_placeholder_<%= comment.id %>" style="display:none;">
 <% end %>
   </div>
 
 <% if can_reply_to_comment?(comment) %>
-  <% # This is where the reply-to box will be added when "Reply" is hit, if the user has JavaScript. %>
-  <% # If not, we will render the comment form if this is the comment we are replying to. %>
+  <%# This is where the reply-to box will be added when "Reply" is hit, if the user has JavaScript. %>
+  <%# If not, we will render the comment form if this is the comment we are replying to. %>
   <% if focused_on_comment(comment) %>
     <div id="add_comment_reply_placeholder_<%= comment.id %>" title="<%= ts("reply to this comment") %>">
       <%= render 'comments/comment_form',

--- a/app/views/comments/_confirm_delete.html.erb
+++ b/app/views/comments/_confirm_delete.html.erb
@@ -1,5 +1,5 @@
-<h3 class="heading"><%= ts("Are you sure you want to delete this comment?") %></h3>
+<h3 class="heading"><%= t(".delete_confirmation") %></h3>
 <ul class="actions" role="menu">
-	<li><%= link_to ts('Yes, delete!'), comment, :method => :delete %></li>
+	<li><%= button_to t(".button"), comment, method: :delete %></li>
 	<li><%= cancel_delete_comment_link(comment) %></li>
 </ul>

--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -630,11 +630,6 @@ en:
       tags: Tags
       works: Works (%{count})
   comments:
-    confirm_delete:
-      button: Yes, delete!
-      cancel: Cancel
-      delete: Delete
-      delete_confirmation: Are you sure you want to delete this comment?
     comment_form:
       anonymous_creator: Anonymous Creator
       anonymous_forewarning: While this work is anonymous, comments you post will also be listed anonymously.
@@ -690,6 +685,11 @@ en:
           disable_anon: Sorry, this work doesn't allow non-Archive users to comment.
           hidden: Sorry, you can't add or edit comments on a hidden work.
           unrevealed: Sorry, you can't add or edit comments on an unrevealed work.
+    confirm_delete:
+      button: Yes, delete!
+      cancel: Cancel
+      delete: Delete
+      delete_confirmation: Are you sure you want to delete this comment?
     edit:
       back: Back
       page_heading: Editing comment

--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -630,6 +630,11 @@ en:
       tags: Tags
       works: Works (%{count})
   comments:
+    confirm_delete:
+      button: Yes, delete!
+      cancel: Cancel
+      delete: Delete
+      delete_confirmation: Are you sure you want to delete this comment?
     comment_form:
       anonymous_creator: Anonymous Creator
       anonymous_forewarning: While this work is anonymous, comments you post will also be listed anonymously.

--- a/features/comments_and_kudos/comment_blocking.feature
+++ b/features/comments_and_kudos/comment_blocking.feature
@@ -67,7 +67,7 @@ Feature: Comment Blocking
     When I am logged in as "pest"
       And I view the work "Aftermath" with comments
       And I follow "Delete"
-      And I follow "Yes, delete!"
+      And I press "Yes, delete!"
     Then I should see "Comment deleted."
 
   Scenario: Blocked users can comment on works shared with their blocker

--- a/features/comments_and_kudos/comments_delete.feature
+++ b/features/comments_and_kudos/comments_delete.feature
@@ -5,7 +5,7 @@ Feature: Delete a comment
   I want to be able to delete a comment I added
   As an author
   I want to be able to delete a comment a reader added to my work
-  
+
   Scenario: User deletes a comment they added to a work
     When I am logged in as "author"
       And I post the work "Awesome story"
@@ -28,7 +28,7 @@ Feature: Delete a comment
       And I should see "I didn't mean that"
       And I should see "Comments:1"
       And I should see a link "Hide Comments (1)"
-      
+
   Scenario: Author deletes a comment another user added to their work
     When I am logged in as "author"
       And I post the work "Awesome story"
@@ -40,7 +40,7 @@ Feature: Delete a comment
     Then I should see "Comment deleted."
       And I should not see "Comments:"
       And I should not see a link "Hide Comments (1)"
-    
+
   Scenario: Author deletes a parent comment that another user added to their work
     When I am logged in as "author"
       And I post the work "Awesome story"

--- a/features/step_definitions/comment_steps.rb
+++ b/features/step_definitions/comment_steps.rb
@@ -257,14 +257,14 @@ When /^I compose an invalid comment(?: within "([^"]*)")?$/ do |selector|
   end
 end
 
-When /^I delete the comment$/ do
+When "I delete the comment" do
   step %{I follow "Delete" within ".odd"}
-  step %{I follow "Yes, delete!"}
+  step %{I press "Yes, delete!"}
 end
 
-When /^I delete the reply comment$/ do
+When "I delete the reply comment" do
   step %{I follow "Delete" within ".even"}
-  step %{I follow "Yes, delete!"}
+  step %{I press "Yes, delete!"}
 end
 
 When /^I view the latest comment$/ do
@@ -377,7 +377,7 @@ When /^I delete all visible comments on "([^\"]*?)"$/ do |work|
     visit work_url(work, show_comments: true)
     break unless page.has_content? "Delete"
     click_link("Delete")
-    click_link("Yes, delete!") # TODO: Fix along with comment deletion.
+    click_button("Yes, delete!")
   end
 end
 

--- a/public/stylesheets/site/2.0/15-group-comments.css
+++ b/public/stylesheets/site/2.0/15-group-comments.css
@@ -92,6 +92,11 @@ fieldset.comments, .comment .userstuff {
   padding: 0.643em;
 }
 
+.comment .actions {
+  float: none;
+  text-align: right;
+}
+
 /* mods */
 
 .abbreviated .icon {


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-2520

## Purpose

- Use `button_to` for delete comment, which supports noscript.
- i18n and tidy up comments in affected views.
- Also, fix a visual bug for noscript comment deletion.

Before
<img width="735" height="70"  src="https://github.com/user-attachments/assets/5668f5a8-66ee-4377-a59f-32c1bceccd01" />
After 
<img width="650" height="90"  src="https://github.com/user-attachments/assets/374a7994-46bc-4eee-b8bb-8b3e8359f97d" />

As for automated tests, I wasn't sure why `comments_delete.feature` isn't failing before this fix and didn't know of a automated way to ensure the bug is fixed.
