### PR TITLE
AO3-7018 Added rescue to avoid error 500 when entering invalid URL in collection custom header field

### DIFF
--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -169,6 +169,7 @@ class Collection < ApplicationRecord
 
   def cleanup_url
     self.header_image_url = Addressable::URI.heuristic_parse(self.header_image_url) if self.header_image_url
+  rescue Addressable::URI::InvalidURIError
   end
 
   # Get only collections with running challenges

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -82,6 +82,12 @@ describe Collection do
       expect(collection.errors.full_messages).to \
         include /Sorry, a collection can only have 10 tags./
     end
+
+    it "does not raise an 500 error when header_image_url is not a valid URL" do
+      collection.header_image_url = "This will error."
+      expect { collection.save }.not_to raise_error
+    end
+    
   end
 
   describe "#clear_icon" do


### PR DESCRIPTION
# Pull Request Checklist

<!-- Mark steps in the checklist as complete by changing `[ ]` to `[X]` -->
* [X] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [X] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [X] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [X] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [X] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-7018

## Purpose

It makes it so that Error 500 gets rescued and it goes straight to the next step, so for example if something like "This will error." is entered, it would pass it to validation, where it would be caught and an error would be displayed to the user on the collections page.

## Testing Instructions

I added this test in collection_spec.rb:

`it "does not raise an 500 error when header_image_url is not a valid URL" do`
`collection.header_image_url = "This will error."`
`expect { collection.save }.not_to raise_error`
`end`

## Credit

katieyang
