### PR TITLE
AO3-7108 Load default skin with correct attributes

### DIFF
--- a/app/models/skin.rb
+++ b/app/models/skin.rb
@@ -554,7 +554,7 @@ class Skin < ApplicationRecord
   end
 
   def self.default
-    Skin.find_by(title: "Default", official: true) || Skin.create_default
+    Skin.find_by(title: "Default", official: true, public: true, role: "site") || Skin.create_default
   end
 
   def self.create_default

--- a/spec/models/skin_spec.rb
+++ b/spec/models/skin_spec.rb
@@ -396,5 +396,68 @@ describe Skin do
       end
     end
   end
+
+  describe ".default" do
+    context "when there is a skin with the title Default" do
+      let!(:skin) { create(:skin, title: "Default") }
+
+      context "with official: true, public: true, role: \"site\"," do
+        before do
+          skin.update!(official: true, public: true, role: "site", css: ".test { display: none; }")
+        end
+
+        it "returns the skin without changes" do
+          expect do
+            Skin.default
+          end.to avoid_changing { skin.reload.official }
+            .and avoid_changing { skin.reload.public }
+            .and avoid_changing { skin.reload.role }
+            .and avoid_changing { skin.reload.css }
+          expect(Skin.default).to eq(skin)
+        end
+      end
+
+      context "with a role other than \"site\"" do
+        it "updates the role to \"site\" and returns the skin" do
+          expect do
+            Skin.default
+          end.to change { skin.reload.role }
+            .from(nil).to("site")
+          expect(Skin.default).to eq(skin)
+        end
+      end
+
+      context "with official: false" do
+        it "updates official to true and returns the skin" do
+          expect do
+            Skin.default
+          end.to change { skin.reload.official }
+            .from(false).to(true)
+          expect(Skin.default).to eq(skin)
+        end
+      end
+
+      context "with public: false" do
+        it "updates public to true and returns the skin" do
+          expect do
+            Skin.default
+          end.to change { skin.reload.public }
+            .from(false).to(true)
+          expect(Skin.default).to eq(skin)
+        end
+      end
+    end
+
+    context "when there is no skin with the title Default" do
+      before { Skin.where(title: "Default").delete_all }
+
+      it "creates a skin and returns it" do
+        expect do
+          Skin.default
+        end.to change(Skin, :count).by(1)
+        expect(Skin.default).to have_attributes(title: "Default", public: true, official: true, role: "site", css: "")
+      end
+    end
+  end
 end
 

--- a/spec/models/skin_spec.rb
+++ b/spec/models/skin_spec.rb
@@ -401,7 +401,7 @@ describe Skin do
     context "when there is a skin with the title Default" do
       let!(:skin) { create(:skin, title: "Default") }
 
-      context "with official: true, public: true, role: \"site\"," do
+      context "with official: true, public: true, role: \"site\"" do
         before do
           skin.update!(official: true, public: true, role: "site", css: ".test { display: none; }")
         end
@@ -417,8 +417,8 @@ describe Skin do
         end
       end
 
-      context "with a role other than \"site\"" do
-        it "updates the role to \"site\" and returns the skin" do
+      context "without a role" do
+        it "adds the \"site\" role and returns the skin" do
           expect do
             Skin.default
           end.to change { skin.reload.role }
@@ -427,7 +427,19 @@ describe Skin do
         end
       end
 
-      context "with official: false" do
+      context "with a role other than \"site\"" do
+        before { skin.update!(role: "user") }
+
+        it "updates the role to \"site\" and returns the skin" do
+          expect do
+            Skin.default
+          end.to change { skin.reload.role }
+            .from("user").to("site")
+          expect(Skin.default).to eq(skin)
+        end
+      end
+
+      context "with official set to false" do
         it "updates official to true and returns the skin" do
           expect do
             Skin.default
@@ -437,7 +449,7 @@ describe Skin do
         end
       end
 
-      context "with public: false" do
+      context "with public set to false" do
         it "updates public to true and returns the skin" do
           expect do
             Skin.default


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-7108

## Purpose

Makes sure the default skin is public, official, and has the "site" role.