### PR TITLE
AO3-6133 Deployment workflow to replace Codeship

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,28 @@
+name: Deploy AO3
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: "The environment to deploy to"
+        required: true
+        default: staging
+        options:
+          - staging
+
+concurrency: one-deploy-at-a-time
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.environment || 'staging' }}
+
+    env:
+      COMMIT_ID: ${{ github.sha }}
+
+    steps:
+      - uses: appleboy/ssh-action@v3ca8a7c5359ac6ad91aa47f1946ece1c3b025004
+        with:
+          host: ${{ secrets.SSH_GATEWAY }}
+          username: ${{ secrets.SSH_USER }}
+          key: ${{ secrets.SSH_KEY }}
+          script: ${{ env.DEPLOY_SCRIPT }}


### PR DESCRIPTION
# Pull Request Checklist

## Issue

https://otwarchive.atlassian.net/browse/AO3-6133

## Purpose

Add a manually-triggered workflow that we can use to deploy to staging, as a replacement for Cloudship (which is going EOL in 2026). I also parameterized a lot using GitHub environments in case we want to try with production (of course with an approver list) later.

**NOTE:** before merging, we should disable the cloudship deploy so we can test this properly