### PR TITLE
AO3-7110 Fix flaky database seed spec

### DIFF
--- a/spec/lib/tasks/database_seed.rake_spec.rb
+++ b/spec/lib/tasks/database_seed.rake_spec.rb
@@ -1,6 +1,14 @@
 require "spec_helper"
 
 describe "rake db:fixtures:load" do
+  before do
+    WebMock.stub_request(:any, /example/)
+  end
+
+  after do
+    WebMock.reset!
+  end
+
   it "should result in valid records" do
     subject.invoke
 

--- a/spec/lib/tasks/database_seed.rake_spec.rb
+++ b/spec/lib/tasks/database_seed.rake_spec.rb
@@ -1,14 +1,6 @@
 require "spec_helper"
 
 describe "rake db:fixtures:load" do
-  before do
-    WebMock.stub_request(:any, /example/)
-  end
-
-  after do
-    WebMock.reset!
-  end
-
   it "should result in valid records" do
     subject.invoke
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -69,7 +69,7 @@ RSpec.configure do |config|
     allow(Akismetor).to receive(:spam?).and_return(false)
 
     # Stub all requests to example.org, the default external work URL:
-    WebMock.stub_request(:any, "www.example.org")
+    WebMock.stub_request(:any, /example/)
   end
 
   config.after :each do

--- a/test/fixtures/admin_settings.yml
+++ b/test/fixtures/admin_settings.yml
@@ -1,6 +1,6 @@
 admin_setting_3:
   id: 3
-  account_creation_enabled: false
+  account_creation_enabled: true
   invite_from_queue_enabled: true
   invite_from_queue_number: 10
   invite_from_queue_frequency: 7

--- a/test/fixtures/collections.yml
+++ b/test/fixtures/collections.yml
@@ -5,7 +5,7 @@ one:
   name: TheFirstCollection
   title: The First Collection!!!
   email: firstcollection@example.com
-  header_image_url: http://img.skitch.com/20091207-knxk8cpkhwg1dsrnig7dpp46dj.jpg
+  header_image_url: http://example.com/20091207-knxk8cpkhwg1dsrnig7dpp46dj.jpg
   description: This is the first collection yay.
 
 two:

--- a/test/fixtures/external_works.yml
+++ b/test/fixtures/external_works.yml
@@ -4,7 +4,7 @@ external_work_00001:
   title: Into the Garden
   author: architeuthis
   updated_at: 2009-07-17 23:56:42 Z
-  url: http://architeuthis.dreamwidth.org/954.html
+  url: http://example.org/954.html
   id: 1
   summary: Bathtime fun with Dean and Castiel, war between Heaven and Hell style.
   hidden_by_admin: false
@@ -13,7 +13,7 @@ external_work_00002:
   title: Just a fancy word for compromise
   author: Zooey Glass
   updated_at: 2009-07-18 00:33:05 Z
-  url: http://zooey-glass.dreamwidth.org/93177.html
+  url: http://example.org/93177.html
   id: 2
   summary: You've got to read between the years; you've got to write between the lines.
   hidden_by_admin: false
@@ -22,7 +22,7 @@ external_work_00003:
   title: Skies Grown Darker
   author: parenthetical
   updated_at: 2009-07-18 10:38:18 Z
-  url: http://parenthetical.livejournal.com/63702.html
+  url: http://example.com/63702.html
   id: 3
   summary: |-
     Set following 2.04 - Children Shouldn't Play With Dead Things. Dean and Sam try to find a way to move on, but some things can't be outrun. Gen.


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-7110

## Purpose

Use WebMock to stub out requests to livejournal/dreamwidth that keep failing, e.g. https://github.com/otwcode/otwarchive/actions/runs/17314839517/job/49155766858. Also flip the `account_creation_enabled` setting as discussed in Slack.

## Testing Instructions

Automated tests should pass.

## Credit

Bilka
