### PR TITLE
AO3-6167 Fixed that restricted series on user's series page weren't visible to admins

### DIFF
--- a/app/controllers/series_controller.rb
+++ b/app/controllers/series_controller.rb
@@ -23,7 +23,7 @@ class SeriesController < ApplicationController
     @user = User.find_by!(login: params[:user_id])
     @page_subtitle = t(".page_title", username: @user.login)
 
-    @series = if current_user.nil?
+    @series = if User.current_user.nil?
                 Series.visible_to_all
               else
                 Series.visible_to_registered_user

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -78,7 +78,7 @@ module UsersHelper
   def series_link(user, pseud = nil)
     return pseud_series_link(pseud) if pseud.present? && !pseud.new_record?
 
-    total = if current_user.nil?
+    total = if User.current_user.nil?
               Series.visible_to_all.exclude_anonymous.for_user(user).count.size
             else
               Series.visible_to_registered_user.exclude_anonymous.for_user(user).count.size

--- a/features/other_b/series_lock.feature
+++ b/features/other_b/series_lock.feature
@@ -65,3 +65,22 @@ Feature: Locked and partially locked series
       And I should see "Part 1 of Antiholidays"
     When I press "Update"
     Then I should see "Work was successfully updated"
+
+  Scenario: Admins can see locked series on user's series page
+    Given I am logged in as "Accumulator"
+      And I post the work "Restricted work" as part of a series "So Restrictive"
+      And I lock the work "Restricted work"
+    When I go to Accumulator's user page
+    Then I should see "Series (1)" within "#dashboard"
+    When I am logged in as a super admin
+      And I go to Accumulator's user page
+    Then I should see "Series (1)" within "#dashboard"
+      And I follow "Series (1)"
+    Then I should see "1 Series by Accumulator"
+      And I should see "So Restrictive"
+    When I log out
+      And I go to Accumulator's user page
+    Then I should see "Series (0)" within "#dashboard"
+      And I follow "Series (0)"
+    Then I should see "0 Series by Accumulator"
+      And I should not see "So Restrictive"


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6167

## Purpose

Change user dashboard sidebar series count and user series page to include restricted series when logged in as admin. 

## Testing Instructions

Refer to Jira.

## Credit

Bilka
