### PR TITLE
AO3-5552 Remove unreachable no_signup code and update tests

### DIFF
--- a/app/controllers/challenge_signups_controller.rb
+++ b/app/controllers/challenge_signups_controller.rb
@@ -60,13 +60,6 @@ class ChallengeSignupsController < ApplicationController
 
   def load_signup_from_id
     @challenge_signup = ChallengeSignup.find(params[:id])
-    no_signup and return unless @challenge_signup
-  end
-
-  def no_signup
-    flash[:error] = ts("What sign-up did you want to work on?")
-    redirect_to collection_path(@collection) rescue redirect_to '/'
-    false
   end
 
   def check_pseud_ownership

--- a/spec/controllers/challenge_signups_controller_spec.rb
+++ b/spec/controllers/challenge_signups_controller_spec.rb
@@ -49,14 +49,6 @@ describe ChallengeSignupsController do
   end
 
   describe "show" do
-    # TODO: AO3-5552
-    xit "redirects and errors if there is no sign-up with that id" do
-      fake_login
-      get :show, params: { id: 0, collection_id: closed_collection.name }
-      it_redirects_to_with_error(collection_path(closed_collection),
-                                 "What sign-up did you want to work on?")
-    end
-
     it "redirects and errors if the user does not own the sign-up or the collection" do
       fake_login
       get :show, params: { id: closed_signup, collection_id: closed_collection.name }


### PR DESCRIPTION
# Pull Request Checklist

<!-- Mark steps in the checklist as complete by changing `[ ]` to `[X]` -->
* [X] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [X] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [X] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [X] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [X] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-5552

## Purpose

Removes the unused no_signup code path and the corresponding test.

## Testing Instructions

How can the Archive's QA team verify that this is working as you intended?

Refer to Jira.

## Credit

Samridhi
