### PR TITLE
AO3-5769 change name to display_name, wrong phrasing to correct constant

### DIFF
--- a/app/helpers/tags_helper.rb
+++ b/app/helpers/tags_helper.rb
@@ -242,9 +242,9 @@ module TagsHelper
     if tags && tags.size > 0
       # We don't use .to_sentence because these aren't links and we risk making any
       # connector word (e.g., "and") look like part of the final tag.
-      tags.pluck(:name).join(t("support.array.words_connector"))
+      tags.map(&:display_name).join(t("support.array.words_connector"))
     elsif tags.blank? && category_name.blank?
-     "Choose Not To Use Archive Warnings"
+      ArchiveConfig.WARNING_DEFAULT_TAG_DISPLAY_NAME
     else
       category_name.blank? ? "" : "No" + " " + category_name
     end


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5769

## Purpose

Makes "Choose Not To Use Archive Warnings", "Creator Chose Not ..." on blurbs' icon block. I know pluck would be more efficient but it doesn't take display_name. would performance impact be considerable?

## Testing Instructions

In addition to testing instructions on Jira, you can hover on warning's icon to see the title attribute.

## Credit

ömer faruk and he/him would be nice.