### PR TITLE
AO3-4698 add @page_subtitle with correct spelling

### DIFF
--- a/app/controllers/challenge_signups_controller.rb
+++ b/app/controllers/challenge_signups_controller.rb
@@ -197,7 +197,7 @@ class ChallengeSignupsController < ApplicationController
 
   public
   def new
-    @page_subtitle = ts("New Challenge Sign-up")
+    @page_subtitle = t(".page_title")
     if (@challenge_signup = ChallengeSignup.in_collection(@collection).by_user(current_user).first)
       flash[:notice] = ts("You are already signed up for this challenge. You can edit your sign-up below.")
       redirect_to edit_collection_signup_path(@collection, @challenge_signup)

--- a/config/locales/controllers/en.yml
+++ b/config/locales/controllers/en.yml
@@ -46,6 +46,9 @@ en:
   challenge_assignments:
     validation:
       not_owner: You aren't the owner of that assignment.
+  challenge_signups:
+    new:
+      page_title: New Challenge Sign-up
   chapters:
     destroy:
       only_chapter: You can't delete the only chapter in your work. If you want to delete the work, choose "Delete Work".


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-4698

## Purpose

app/helpers/application_helper.rb says browser page title will be taken simply action_name + controller_name if page title isn't specified, in this case it wasn't. 

## Testing Instructions
1. From the homepage, Browse Collections
2. From open challenges, find a Gift Exchange to sign up
3. On the Sign-up Form, hover the tab or view page source to see page's title  

You can also create your own challenge and observe it's Sign-up Form

## Credit
ömer faruk, he/him