### PR TITLE
AO3-6026 Fix alignment of tags in collection blurb

### DIFF
--- a/public/stylesheets/site/2.0/13-group-blurb.css
+++ b/public/stylesheets/site/2.0/13-group-blurb.css
@@ -76,7 +76,7 @@ li.blurb:after, .blurb .blurb:after {
   line-height: 1.5;
 }
 
-.blurb .fandoms .landmark {
+.blurb h5 .landmark {
   position: absolute;
 }
 


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6026

## Purpose

The tags in collection blurbs are indented just a tiny bit due to the landmark. 

<img width="495" height="76" alt="Collection tags slightly indented from the title." src="https://github.com/user-attachments/assets/dd5d0c1d-c651-4cc8-9904-df367356a0c7" />

Fortunately, we already solved this issue for the fandom tags in work blurbs ([AO3-4153](https://otwarchive.atlassian.net/browse/AO3-4153)/#1919) many years ago, so we only need to tweak the CSS selector. 

## Testing Instructions

Look at a collection blurb with tags. The first tag should be aligned with the collection title.

<img width="491" height="80" alt="Collection tags aligned with the collection title." src="https://github.com/user-attachments/assets/8da3f773-0e7e-45e6-8fb8-05f4bd2cce00" />


[AO3-4153]: https://otwarchive.atlassian.net/browse/AO3-4153?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ