### PR TITLE
AO3-6026 Reduce N+1 queries in fandom crossover method

### DIFF
--- a/lib/fandom_crossover.rb
+++ b/lib/fandom_crossover.rb
@@ -10,12 +10,11 @@ class FandomCrossover
 
     # Replace fandoms with their mergers if possible,
     # as synonyms should have no meta tags themselves
-    all_without_syns = fandoms.map { |f| f.merger || f }
-      .uniq
+    all_without_syns = Fandom.select("IFNULL(merger_id, id) as id").where(id: fandoms).distinct
 
     # For each fandom, find the set of all meta tags for that fandom (including
     # the fandom itself).
-    meta_tag_groups = all_without_syns.map do |f|
+    meta_tag_groups = all_without_syns.includes(:meta_tags).map do |f|
       # TODO: This is more complicated than it has to be. Once the
       # meta_taggings table is fixed so that the inherited meta-tags are
       # correctly calculated, this can be simplified. Refer to AO3-5667.


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6026

## Purpose

This reduces the amount of N+1 queries in the fandom crossover check. I spotted two more N+1 queries in the logs:

1. When loading the mergers for `all_without_syns`
2. When loading the metatags for `meta_tag_groups`

The first can be mostly be avoided by getting only the merger_ids and continuing to do the conditional in Ruby, but doing that [in the database](https://mariadb.com/docs/server/reference/sql-functions/control-flow-functions/ifnull) instead has an additional benefit: I can make it return an `ActiveRecord::Relation` instead of a plain array.

And that `ActiveRecord::Relation` allows the `includes` in spot two, and that one should be pretty obvious for why it helps. It doesn't help for the `until` loop lower in the method that gets even more metatag layers, though. But my hope is that won't be a large N, compared to the N of all non-syn tags of the `all_without_syns` loop.

Potentially we could avoid those further metatagging N+1 queries by getting rid of the loop and relying on inherited metataggings being set up correctly. However, that is a riskier change since it may affect behaviour so I didn't do it for now.

## Testing Instructions

I don't think we can easily test this on Staging, so I did benchmarking of `bundle exec rails After:add_collection_tags` on dev:

Setup: 4 works with independent fandoms, 4 works with syns, 4 works with subtags per collection. 200 collections:
Time needed to run rake task: 1m41.967s -> 1m37.928s

Setup: 5 works with independent fandoms, 5 works with syns, 5 works with subtags per collection. 1000 collections, **not** saving the result to the db:
Time needed to run rake task: 1m29.861s -> 0m54.345s

Also, more query log staring with 4 canonicals, 3 syns, 3 subtags:
Before
<img width="1868" height="666" alt="Screenshot_20250917_134053" src="https://github.com/user-attachments/assets/bb36b586-f577-4ec6-8230-d0b64f5d58ff" />

After
<img width="1860" height="520" alt="Screenshot_20250917_150207" src="https://github.com/user-attachments/assets/5b01f53c-7652-400b-a70c-e04debd7d7d0" />

## Credit
Bilka
