### PR TITLE
AO3-6026 Fix collection tag backfill issues

### DIFF
--- a/app/models/bookmark.rb
+++ b/app/models/bookmark.rb
@@ -83,7 +83,7 @@ class Bookmark < ApplicationRecord
   # users (regardless of the bookmark's hidden_by_admin/private status).
   scope :with_bookmarkable_visible_to_all, -> {
     join_bookmarkable.where(
-      "(works.posted = 1 AND works.restricted = 0 AND works.hidden_by_admin = 0) OR
+      "(works.posted = 1 AND works.restricted = 0 AND works.hidden_by_admin = 0 AND works.in_unrevealed_collection = 0) OR
       (series.restricted = 0 AND series.hidden_by_admin = 0) OR
       (external_works.hidden_by_admin = 0)"
     )

--- a/app/models/bookmark.rb
+++ b/app/models/bookmark.rb
@@ -83,7 +83,7 @@ class Bookmark < ApplicationRecord
   # users (regardless of the bookmark's hidden_by_admin/private status).
   scope :with_bookmarkable_visible_to_all, -> {
     join_bookmarkable.where(
-      "(works.posted = 1 AND works.restricted = 0 AND works.hidden_by_admin = 0 AND works.in_unrevealed_collection = 0) OR
+      "(works.posted = 1 AND works.restricted = 0 AND works.hidden_by_admin = 0) OR
       (series.restricted = 0 AND series.hidden_by_admin = 0) OR
       (external_works.hidden_by_admin = 0)"
     )

--- a/lib/tasks/after_tasks.rake
+++ b/lib/tasks/after_tasks.rake
@@ -586,7 +586,7 @@ namespace :After do
     total_batches = (collections.count + 999) / 1000
 
     def approved_taggables(collection)
-      bookmark_visible_revealed = Bookmark.join_bookmarkable.where(
+      bookmark_visible_revealed = Bookmark.is_public.join_bookmarkable.where(
         "(works.posted = 1 AND works.restricted = 0 AND works.hidden_by_admin = 0 AND works.in_unrevealed_collection = 0) OR
         (series.restricted = 0 AND series.hidden_by_admin = 0) OR
         (external_works.hidden_by_admin = 0)"

--- a/lib/tasks/after_tasks.rake
+++ b/lib/tasks/after_tasks.rake
@@ -586,16 +586,21 @@ namespace :After do
     total_batches = (collections.count + 999) / 1000
 
     def approved_taggables(collection)
+      bookmark_visible_revealed = Bookmark.join_bookmarkable.where(
+        "(works.posted = 1 AND works.restricted = 0 AND works.hidden_by_admin = 0 AND works.in_unrevealed_collection = 0) OR
+        (series.restricted = 0 AND series.hidden_by_admin = 0) OR
+        (external_works.hidden_by_admin = 0)"
+      )
       Work.visible_to_all.revealed.in_collection(collection).includes(:fandoms) + \
-        Bookmark.visible_to_all.in_collection(collection).includes(:fandoms) + \
-        Bookmark.visible_to_all.in_collection(collection).includes(bookmarkable: :fandoms).filter_map { |bookmark| bookmark.bookmarkable unless bookmark.bookmarkable.unrevealed? }
+        bookmark_visible_revealed.in_collection(collection).includes(:fandoms) + \
+        bookmark_visible_revealed.in_collection(collection).includes(bookmarkable: :fandoms).filter_map { |bookmark| bookmark.bookmarkable unless bookmark.bookmarkable.respond_to?(:unrevealed?) && bookmark.bookmarkable.unrevealed? }
     end
 
     Collection.no_touching do
       collections.find_in_batches.with_index do |batch, index|
         batch.each do |collection|
           tags = approved_taggables(collection)
-            .flat_map { |taggable| taggable.try(:fandoms) || taggable.try(&:work_tags)&.where(type: "Fandom") || [] }
+            .flat_map { |taggable| taggable.try(:fandoms) || taggable.try(:work_tags)&.where(type: "Fandom") || [] }
             .uniq
 
           next if tags.empty?

--- a/lib/tasks/after_tasks.rake
+++ b/lib/tasks/after_tasks.rake
@@ -595,7 +595,7 @@ namespace :After do
       collections.find_in_batches.with_index do |batch, index|
         batch.each do |collection|
           tags = approved_taggables(collection)
-            .flat_map { |taggable| taggable.try(:fandoms)&.where(canonical: true) || taggable.try(&:work_tags).where(canonical: true, type: "Fandom") || [] }
+            .flat_map { |taggable| taggable.try(:fandoms) || taggable.try(&:work_tags)&.where(type: "Fandom") || [] }
             .uniq
 
           next if tags.empty?

--- a/spec/lib/tasks/after_tasks.rake_spec.rb
+++ b/spec/lib/tasks/after_tasks.rake_spec.rb
@@ -743,7 +743,7 @@ describe "rake After:add_collection_tags" do
 
   context "when a collection has work bookmarks" do
     let(:fandom) { create(:canonical_fandom) }
-    let(:items) { [create(:bookmark, fandom_string: fandom.name)] }
+    let(:items) { [create(:bookmark, tag_string: fandom.name)] }
 
     it "tags the collection with the bookmark's AND bookmarked item's fandoms" do
       subject.invoke
@@ -795,7 +795,7 @@ describe "rake After:add_collection_tags" do
     let(:bookmark) { create(:series_bookmark, tag_string: fandom.name) }
     let(:items) { [bookmark] }
 
-    it "includes the bookmark's and serie's fandoms" do
+    it "includes the bookmark's and series's fandoms" do
       subject.invoke
       expect(collection.tags).to include(*bookmark.fandoms)
       expect(collection.tags).to include(*items.flat_map(&:bookmarkable).flat_map { |s| s.work_tags.where(type: "Fandom") })

--- a/spec/lib/tasks/after_tasks.rake_spec.rb
+++ b/spec/lib/tasks/after_tasks.rake_spec.rb
@@ -705,9 +705,6 @@ describe "rake After:add_collection_tags" do
     let(:items) { create_list(:work, 2) }
 
     it "tags the collection with the work's fandoms" do
-      items.each do |work|
-        work.fandoms.update_all(canonical: true)
-      end
       subject.invoke
       expect(collection.tags).to include(*items.flat_map(&:fandoms))
     end
@@ -722,23 +719,11 @@ describe "rake After:add_collection_tags" do
     context "when the work is hidden" do
       let(:items) { [create(:work, hidden_by_admin: true)] }
 
-      before do
-        items.each do |work|
-          work.fandoms.update_all(canonical: true)
-        end
-      end
-
       it_behaves_like "does not tag the collection"
     end
 
     context "when the work is restricted" do
       let(:items) { [create(:work, restricted: true)] }
-
-      before do
-        items.each do |work|
-          work.fandoms.update_all(canonical: true)
-        end
-      end
 
       it_behaves_like "does not tag the collection"
     end
@@ -748,17 +733,9 @@ describe "rake After:add_collection_tags" do
 
       before do
         items.each do |work|
-          work.fandoms.update_all(canonical: true)
           work.update!(in_unrevealed_collection: true)
         end
       end
-
-      it_behaves_like "does not tag the collection"
-    end
-
-    context "when the work is tagged with non-canonical fandoms" do
-      let(:fandom) { create(:fandom) }
-      let(:items) { [create(:work, fandom_string: fandom.name)] }
 
       it_behaves_like "does not tag the collection"
     end
@@ -767,12 +744,6 @@ describe "rake After:add_collection_tags" do
   context "when a collection has work bookmarks" do
     let(:fandom) { create(:canonical_fandom) }
     let(:items) { [create(:bookmark, fandom_string: fandom.name)] }
-
-    before do
-      items.each do |bookmark|
-        bookmark.bookmarkable.fandoms.update_all(canonical: true)
-      end
-    end
 
     it "tags the collection with the bookmark's AND bookmarked item's fandoms" do
       subject.invoke
@@ -811,7 +782,6 @@ describe "rake After:add_collection_tags" do
     context "when the bookmarked item is an unrevealed work" do
       before do
         items.each do |bookmark|
-          bookmark.bookmarkable.fandoms.update_all(canonical: true)
           bookmark.bookmarkable.update!(in_unrevealed_collection: true)
         end
       end
@@ -824,12 +794,6 @@ describe "rake After:add_collection_tags" do
     let(:fandom) { create(:canonical_fandom) }
     let(:bookmark) { create(:series_bookmark, tag_string: fandom.name) }
     let(:items) { [bookmark] }
-
-    before do
-      bookmark.bookmarkable.works.flat_map(&:fandoms).each do |fandom|
-        fandom.update!(canonical: true)
-      end
-    end
 
     it "includes the bookmark's and serie's fandoms" do
       subject.invoke


### PR DESCRIPTION
Fixes the following problems with backfilling collection tags:
* series tags are missing
* public bookmark of hidden work leads to the work tags being included
* public bookmark of restricted work leads to the work tags being included
* tags of unrevealed works are included