### PR TITLE
AO3-3748 Fix collection title filter autocomplete

### DIFF
--- a/app/controllers/autocomplete_controller.rb
+++ b/app/controllers/autocomplete_controller.rb
@@ -120,9 +120,11 @@ class AutocompleteController < ApplicationController
 
   # look up collections ranked by number of items they contain
 
-  def collection_fullname
-    results = Collection.autocomplete_lookup(search_param: params[:term], autocomplete_prefix: "autocomplete_collection_all").map {|res| Collection.fullname_from_autocomplete(res)}
-    render_output(results)
+  def collection_title
+    results = Collection.autocomplete_lookup(search_param: params[:term], autocomplete_prefix: "autocomplete_collection_all").map do |res|
+      { id: Collection.title_from_autocomplete(res), name: Collection.fullname_from_autocomplete(res) }
+    end
+    respond_with(results)
   end
 
   # return collection names

--- a/app/views/collections/_filters.html.erb
+++ b/app/views/collections/_filters.html.erb
@@ -21,7 +21,7 @@
         <%= f.label "title", ts("Filter by title") %>
       </dt>
       <dd class="autocomplete search">
-        <%= f.text_field "title", autocomplete_options("collection_fullname", data: { autocomplete_token_limit: 1 }) %>
+        <%= f.text_field "title", autocomplete_options("collection_title", data: { autocomplete_token_limit: 1 }) %>
       </dd>
 
       <dt class="autocomplete search">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -694,7 +694,7 @@ Rails.application.routes.draw do
     tags_in_sets
     associated_tags
     noncanonical_tag
-    collection_fullname
+    collection_title
     open_collection_names
     collection_parent_name
     external_work

--- a/features/collections/collection_browse.feature
+++ b/features/collections/collection_browse.feature
@@ -134,6 +134,51 @@ Feature: Collection
     And I should not see "Surprise Presents"
     And I should not see "On Demand"
 
+  Scenario: Can't filter collections index by collection name
+
+    Given a set of collections for searching
+    When I go to the collections page
+      And I fill in "collection_search_title" with "demandtest"
+      And I press "Sort and Filter"
+    Then I should not see "Another Plain Collection"
+      And I should not see "Another Gift Swap"
+      And I should not see "Some Test Collection"
+      And I should not see "Some Other Collection"
+      And I should not see "Surprise Presents"
+      And I should not see "On Demand"
+
+  @javascript
+  Scenario: Filter collections index by collection name using autocomplete
+
+    Given a set of collections for searching
+    When I go to the collections page
+      And I enter "demandte" in the "Filter by title" autocomplete field
+    Then I should see "demandtest: On Demand" in the autocomplete
+    When I choose "demandtest: On Demand" from the "Filter by title" autocomplete
+      And I press "Sort and Filter"
+    Then I should see "On Demand"
+      But I should not see "Another Gift Swap"
+      And I should not see "Another Plain Collection"
+      And I should not see "Some Test Collection"
+      And I should not see "Some Other Collection"
+      And I should not see "Surprise Presents"
+
+  @javascript
+  Scenario: Filter collections index by collection title using autocomplete
+
+    Given a set of collections for searching
+    When I go to the collections page
+      And I enter "Gift" in the "Filter by title" autocomplete field
+    Then I should see "swaptest: Another Gift Swap" in the autocomplete
+    When I choose "swaptest: Another Gift Swap" from the "Filter by title" autocomplete
+    And I press "Sort and Filter"
+    Then I should see "Another Gift Swap"
+      But I should not see "On Demand"
+      And I should not see "Another Plain Collection"
+      And I should not see "Some Test Collection"
+      And I should not see "Some Other Collection"
+      And I should not see "Surprise Presents"
+
   Scenario: Filter collections by non-canonical and non-existent collection tags
 
   Given a set of collections for searching

--- a/spec/controllers/autocomplete_controller_spec.rb
+++ b/spec/controllers/autocomplete_controller_spec.rb
@@ -10,4 +10,35 @@ describe AutocompleteController do
       expect(JSON.parse(response.body)).to eq([{ "id" => "Match", "name" => "Match" }])
     end
   end
+
+  describe "GET #collection_title" do
+    let!(:collection_to_find) { create(:collection, title: "I am here", name: "not_here") }
+    let!(:collection_not_to_find) { create(:collection, title: "Foo foo", name: "foo") }
+
+    before do
+      collection_to_find.add_to_autocomplete
+      collection_not_to_find.add_to_autocomplete
+    end
+
+    context "when searching by collection name" do
+      it "returns the fullname for display but only the title for the field" do
+        get :collection_title, params: { term: "not", format: :json }
+        expect(JSON.parse(response.body)).to eq([{ "id" => "I am here", "name" => "not_here: I am here" }])
+      end
+    end
+
+    context "when searching by collection title" do
+      it "returns the fullname for display but only the title for the field" do
+        get :collection_title, params: { term: "am", format: :json }
+        expect(JSON.parse(response.body)).to eq([{ "id" => "I am here", "name" => "not_here: I am here" }])
+      end
+    end
+
+    context "when searching for name and title" do
+      it "returns the fullname for display but only the title for the field" do
+        get :collection_title, params: { term: "here", format: :json }
+        expect(JSON.parse(response.body)).to eq([{ "id" => "I am here", "name" => "not_here: I am here" }])
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-3748

## Purpose

The autocomplete was returning the result as "name: title" which no longer works because we don't search Elasticsearch by name. Change it to still show the same "name: title" result but input only the title into the search field.

Because this is not the only place the collection autocomplete is used it doesn't look viable to me to change it to not search by name. I figured this was less confusing than showing only the title in the dropdown when it can still match by name.

## Testing Instructions

Same as original issue.

## Credit

Bilka