### PR TITLE
AO3-5640 Empty flash message displays when an admin enters notes on a user account without selecting a warning or suspension option

### DIFF
--- a/app/models/user_manager.rb
+++ b/app/models/user_manager.rb
@@ -57,13 +57,16 @@ class UserManager
   end
 
   def validate_admin_note
-    return true if admin_note.present? || admin_action.blank?
-
     if admin_action == "spamban"
       @admin_note = "Banned for spam"
-    elsif admin_action.present?
+    elsif admin_action.blank?
+      errors << "You must choose an action to perform."
+      false
+    elsif admin_action.present? && admin_note.blank?
       errors << "You must include notes in order to perform this action."
       false
+    else
+      true
     end
   end
 

--- a/spec/models/user_manager_spec.rb
+++ b/spec/models/user_manager_spec.rb
@@ -18,14 +18,10 @@ describe UserManager do
       expect(manager.errors).to eq ["orphan_account cannot be warned, suspended, or banned."]
     end
     
-    it "does nothing without an admin action" do
+    it "returns error without an admin action" do
       manager = UserManager.new(admin, user, {})
-      expect do
-        manager.save
-      end.to avoid_changing { user.reload.updated_at }
-        .and avoid_changing { user.reload.log_items.count }
-      expect(manager.save).to be_truthy
-      expect(manager.successes).to be_empty
+      expect(manager.save).to be_falsey
+      expect(manager.errors).to eq ["You must choose an action to perform."]
     end
 
     it "returns error if notes are missing when suspending" do


### PR DESCRIPTION
# Pull Request Checklist

<!-- Mark steps in the checklist as complete by changing `[ ]` to `[X]` -->
* [X] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [X] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [X] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [X] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [X] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

[https://otwarchive.atlassian.net/browse/AO3-5640](https://otwarchive.atlassian.net/browse/AO3-5640)

## Purpose

This PR fixes a bug when logged in as admin. Currently, if an admin logs in, navigates to a user's admin detail page, enters text in the "Notes" field, does not select any of the Warnings and Suspensions options, and selects "Update", the notes field is cleared and a brief flash occurs with nothing added to the user's record. This PR makes it so that instead, an error appears with the message, "You must choose an action to perform." Tests have also been updated accordingly.

## Testing Instructions

Testing can be done by trying this behavior in the test environment (i.e. [http://localhost:3000/admin/login](http://localhost:3000/admin/login)). Additionally, the tests in `spec/models/user_manager_spec.rb` have been updated in this PR to test for this behavior, which can be found [here](https://github.com/Cubostar/otwarchive/blob/5f47515b6425f475743095f13884c19f133e51bd/spec/models/user_manager_spec.rb#L21).

## Credit

Cubostar, he/him
