### PR TITLE
AO3-6026 Cover all Collection blurb count steps by automated tests

### DIFF
--- a/features/collections/collection_browse.feature
+++ b/features/collections/collection_browse.feature
@@ -237,7 +237,7 @@ Feature: Collection
       And I follow "Collection1"
     Then I should see an HTML comment containing the number 1744477200 within "li.work.blurb"
 
-  Scenario: Collection item counts show the correct amount for guests and registered users
+  Scenario: Collection item counts show the correct amount for guests, registered users and admins
 
   Given I have a collection "Item Counts"
   When I am logged in as the owner of "Item Counts"
@@ -253,6 +253,11 @@ Feature: Collection
   Then I should see the text with tags '<a href="/collections/Item_Counts/works">3</a>'
     And I should see the text with tags '<a href="/collections/Item_Counts/bookmarks">2</a>'
     And I should see the text with tags '<a href="/collections/Item_Counts/collections">1</a>'
+  When I am logged in as a super admin
+    And I go to the collections page
+  Then I should see the text with tags '<a href="/collections/Item_Counts/works">3</a>'
+    And I should see the text with tags '<a href="/collections/Item_Counts/bookmarks">2</a>'
+    And I should see the text with tags '<a href="/collections/Item_Counts/collections">1</a>'
   When I log out
     And I go to the collections page
   Then I should see the text with tags '<a href="/collections/Item_Counts/works">1</a>'
@@ -263,6 +268,11 @@ Feature: Collection
     And I bookmark the work "Public 2" to the collection "Item Counts"
     And the collection "Sub Count" is deleted
     And all indexing jobs have been run
+    And I go to the collections page
+  Then I should see the text with tags '<a href="/collections/Item_Counts/works">4</a>'
+    And I should see the text with tags '<a href="/collections/Item_Counts/bookmarks">3</a>'
+    And I should not see "Challenges/Subcollections:" within ".stats"
+  When I am logged in as a super admin
     And I go to the collections page
   Then I should see the text with tags '<a href="/collections/Item_Counts/works">4</a>'
     And I should see the text with tags '<a href="/collections/Item_Counts/bookmarks">3</a>'

--- a/spec/models/bookmark_spec.rb
+++ b/spec/models/bookmark_spec.rb
@@ -46,4 +46,58 @@ describe Bookmark do
     expect(activity.save).to be_truthy
     expect(activity.target_name).to eq("Bookmark #{bookmark.id}")
   end
+
+  context "reindexing" do
+    let!(:parent_collection) { create(:collection) }
+    let!(:collection) { create_invalid(:collection, parent: parent_collection) }
+
+    context "when bookmark is created in collection" do
+      it "enqueues the collection for reindex" do
+        expect do
+          create(:bookmark, collections: [collection])
+        end.to add_to_reindex_queue(collection, :background) &
+               add_to_reindex_queue(parent_collection, :background)
+      end
+    end
+
+    context "bookmark already exists in the collection" do
+      let!(:bookmark) { create(:bookmark, collections: [collection]) }
+
+      context "when bookmark is hidden by an admin" do
+        it "enqueues its collection for reindex" do
+          expect do
+            bookmark.update!(hidden_by_admin: true)
+          end.to add_to_reindex_queue(collection, :background) &
+                 add_to_reindex_queue(parent_collection, :background)
+        end
+      end
+
+      context "when bookmark is privated" do
+        it "enqueues its collection for reindex" do
+          expect do
+            bookmark.update!(private: true)
+          end.to add_to_reindex_queue(collection, :background) &
+                 add_to_reindex_queue(parent_collection, :background)
+        end
+      end
+
+      context "when bookmark is not significantly changed" do
+        it "doesn't enqueue its collection for reindex" do
+          expect do
+            bookmark.touch
+          end.to not_add_to_reindex_queue(collection, :background) &
+                 not_add_to_reindex_queue(parent_collection, :background)
+        end
+      end
+
+      context "when bookmark is destroyed" do
+        it "enqueues its collection for reindex" do
+          expect do
+            bookmark.destroy!
+          end.to add_to_reindex_queue(collection, :background) &
+                 add_to_reindex_queue(parent_collection, :background)
+        end
+      end
+    end
+  end
 end

--- a/spec/models/bookmark_spec.rb
+++ b/spec/models/bookmark_spec.rb
@@ -60,7 +60,7 @@ describe Bookmark do
       end
     end
 
-    context "bookmark already exists in the collection" do
+    context "when bookmark already exists in the collection" do
       let!(:bookmark) { create(:bookmark, collections: [collection]) }
 
       context "when bookmark is hidden by an admin" do

--- a/spec/models/bookmarkable_spec.rb
+++ b/spec/models/bookmarkable_spec.rb
@@ -19,6 +19,17 @@ describe Bookmarkable do
           end
         end
 
+        unless bookmarkable_type == :external_work
+          context "when #{bookmarkable_type} is restricted" do
+            it "enqueues its collection for reindex" do
+              expect do
+                bookmarkable.update!(restricted: !bookmarkable.restricted)
+              end.to add_to_reindex_queue(collection, :background) &
+                     add_to_reindex_queue(parent_collection, :background)
+            end
+          end
+        end
+
         context "when #{bookmarkable_type} is not significantly changed" do
           it "doesn't enqueue its collection for reindex" do
             expect do

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -407,7 +407,7 @@ describe Collection do
       end
     end
 
-    context "when the collection contains an invited public bookmark" do
+    context "when the collection contains a public bookmark awaiting collection approval" do
       let(:bookmark) { create(:bookmark) }
 
       before do
@@ -545,7 +545,7 @@ describe Collection do
       end
     end
 
-    context "when the collection contains an invited public bookmark" do
+    context "when the collection contains a public bookmark awaiting collection approval" do
       let(:bookmark) { create(:bookmark) }
 
       before do

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -165,6 +165,17 @@ describe Collection do
       it_behaves_like "does not count the work"
     end
 
+    context "when the collection includes a rejected public work" do
+      let(:work) { create(:work) }
+
+      before do
+        work.collections << collection
+        work.collection_items.update!(collection_approval_status: :rejected)
+      end
+
+      it_behaves_like "does not count the work"
+    end
+
     context "when the collection includes a public work" do
       let(:work) { create(:work) }
 
@@ -215,6 +226,17 @@ describe Collection do
 
       before do
         work.collections << collection
+      end
+
+      it_behaves_like "does not count the work"
+    end
+
+    context "when the collection includes a rejected public work" do
+      let(:work) { create(:work) }
+
+      before do
+        work.collections << collection
+        work.collection_items.update!(collection_approval_status: :rejected)
       end
 
       it_behaves_like "does not count the work"

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -337,6 +337,19 @@ describe Collection do
       end
     end
 
+    context "when the collection contains a rejected public bookmark" do
+      let(:bookmark) { create(:bookmark) }
+
+      before do
+        bookmark.collections << collection
+        bookmark.collection_items.update!(collection_approval_status: :rejected)
+      end
+
+      it "does not count the bookmark" do
+        expect(collection.general_bookmarked_items_count).to eq(0)
+      end
+    end
+
     context "when the collection contains a bookmark of a hidden work" do
       let(:bookmark) { create(:bookmark, bookmarkable: create(:work, hidden_by_admin: true)) }
 
@@ -417,6 +430,31 @@ describe Collection do
 
       before do
         bookmark.collections << collection
+      end
+
+      it "does not count the bookmark" do
+        expect(collection.public_bookmarked_items_count).to eq(0)
+      end
+    end
+
+    context "when the collection contains a hidden bookmark" do
+      let(:bookmark) { create(:bookmark, hidden_by_admin: true) }
+
+      before do
+        bookmark.collections << collection
+      end
+
+      it "does not count the bookmark" do
+        expect(collection.public_bookmarked_items_count).to eq(0)
+      end
+    end
+
+    context "when the collection contains a rejected public bookmark" do
+      let(:bookmark) { create(:bookmark) }
+
+      before do
+        bookmark.collections << collection
+        bookmark.collection_items.update!(collection_approval_status: :rejected)
       end
 
       it "does not count the bookmark" do

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -165,12 +165,34 @@ describe Collection do
       it_behaves_like "does not count the work"
     end
 
-    context "when the collection includes a rejected public work" do
+    context "when the collection includes a public work rejected by collection" do
       let(:work) { create(:work) }
 
       before do
         work.collections << collection
         work.collection_items.update!(collection_approval_status: :rejected)
+      end
+
+      it_behaves_like "does not count the work"
+    end
+
+    context "when the collection includes a public work rejected by user" do
+      let(:work) { create(:work) }
+
+      before do
+        work.collections << collection
+        work.collection_items.update!(user_approval_status: :rejected)
+      end
+
+      it_behaves_like "does not count the work"
+    end
+
+    context "when the collection includes an invited public work" do
+      let(:work) { create(:work) }
+
+      before do
+        work.collections << collection
+        work.collection_items.update!(collection_approval_status: :approved, user_approval_status: :unreviewed)
       end
 
       it_behaves_like "does not count the work"
@@ -231,12 +253,34 @@ describe Collection do
       it_behaves_like "does not count the work"
     end
 
-    context "when the collection includes a rejected public work" do
+    context "when the collection includes a public work rejected by collection" do
       let(:work) { create(:work) }
 
       before do
         work.collections << collection
         work.collection_items.update!(collection_approval_status: :rejected)
+      end
+
+      it_behaves_like "does not count the work"
+    end
+
+    context "when the collection includes a public work rejected by user" do
+      let(:work) { create(:work) }
+
+      before do
+        work.collections << collection
+        work.collection_items.update!(user_approval_status: :rejected)
+      end
+
+      it_behaves_like "does not count the work"
+    end
+
+    context "when the collection includes an invited public work" do
+      let(:work) { create(:work) }
+
+      before do
+        work.collections << collection
+        work.collection_items.update!(collection_approval_status: :approved, user_approval_status: :unreviewed)
       end
 
       it_behaves_like "does not count the work"
@@ -337,12 +381,38 @@ describe Collection do
       end
     end
 
-    context "when the collection contains a rejected public bookmark" do
+    context "when the collection contains a public bookmark rejected by collection" do
       let(:bookmark) { create(:bookmark) }
 
       before do
         bookmark.collections << collection
         bookmark.collection_items.update!(collection_approval_status: :rejected)
+      end
+
+      it "does not count the bookmark" do
+        expect(collection.general_bookmarked_items_count).to eq(0)
+      end
+    end
+
+    context "when the collection contains a public bookmark rejected by user" do
+      let(:bookmark) { create(:bookmark) }
+
+      before do
+        bookmark.collections << collection
+        bookmark.collection_items.update!(user_approval_status: :rejected)
+      end
+
+      it "does not count the bookmark" do
+        expect(collection.general_bookmarked_items_count).to eq(0)
+      end
+    end
+
+    context "when the collection contains an invited public bookmark" do
+      let(:bookmark) { create(:bookmark) }
+
+      before do
+        bookmark.collections << collection
+        bookmark.collection_items.update!(collection_approval_status: :approved, user_approval_status: :unreviewed)
       end
 
       it "does not count the bookmark" do
@@ -449,12 +519,38 @@ describe Collection do
       end
     end
 
-    context "when the collection contains a rejected public bookmark" do
+    context "when the collection contains a public bookmark rejected by collection" do
       let(:bookmark) { create(:bookmark) }
 
       before do
         bookmark.collections << collection
         bookmark.collection_items.update!(collection_approval_status: :rejected)
+      end
+
+      it "does not count the bookmark" do
+        expect(collection.public_bookmarked_items_count).to eq(0)
+      end
+    end
+
+    context "when the collection contains a public bookmark rejected by user" do
+      let(:bookmark) { create(:bookmark) }
+
+      before do
+        bookmark.collections << collection
+        bookmark.collection_items.update!(user_approval_status: :rejected)
+      end
+
+      it "does not count the bookmark" do
+        expect(collection.public_bookmarked_items_count).to eq(0)
+      end
+    end
+
+    context "when the collection contains an invited public bookmark" do
+      let(:bookmark) { create(:bookmark) }
+
+      before do
+        bookmark.collections << collection
+        bookmark.collection_items.update!(collection_approval_status: :approved, user_approval_status: :unreviewed)
       end
 
       it "does not count the bookmark" do

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -412,7 +412,7 @@ describe Collection do
 
       before do
         bookmark.collections << collection
-        bookmark.collection_items.update!(collection_approval_status: :approved, user_approval_status: :unreviewed)
+        bookmark.collection_items.update!(collection_approval_status: :unreviewed, user_approval_status: :approved)
       end
 
       it "does not count the bookmark" do
@@ -550,7 +550,7 @@ describe Collection do
 
       before do
         bookmark.collections << collection
-        bookmark.collection_items.update!(collection_approval_status: :approved, user_approval_status: :unreviewed)
+        bookmark.collection_items.update!(collection_approval_status: :unreviewed, user_approval_status: :approved)
       end
 
       it "does not count the bookmark" do

--- a/spec/models/search/collection_indexer_spec.rb
+++ b/spec/models/search/collection_indexer_spec.rb
@@ -84,6 +84,23 @@ describe CollectionIndexer do
         expect(document["public_bookmarked_items_count"]).to eq(1)
       end
     end
+
+    context "when the collection contains one private and one public bookmark of one item" do
+      let(:work) { create(:work) }
+      let(:bookmark) { create(:bookmark, bookmarkable: work) }
+      let(:bookmark2) { create(:bookmark, bookmarkable: work, private: true) }
+
+      before do
+        bookmark.collections << collection
+        bookmark2.collections << collection
+      end
+
+      it "is counts as one item" do
+        document = described_class.new([]).document(collection)
+        expect(document["general_bookmarked_items_count"]).to eq(1)
+        expect(document["public_bookmarked_items_count"]).to eq(1)
+      end
+    end
   end
 
   describe "#index_documents", collection_search: true do

--- a/spec/models/search/collection_indexer_spec.rb
+++ b/spec/models/search/collection_indexer_spec.rb
@@ -78,7 +78,7 @@ describe CollectionIndexer do
         bookmark2.collections << collection
       end
 
-      it "is counts as one item" do
+      it "counts as one item" do
         document = described_class.new([]).document(collection)
         expect(document["general_bookmarked_items_count"]).to eq(1)
         expect(document["public_bookmarked_items_count"]).to eq(1)
@@ -95,7 +95,7 @@ describe CollectionIndexer do
         bookmark2.collections << collection
       end
 
-      it "is counts as one item" do
+      it "counts as one item" do
         document = described_class.new([]).document(collection)
         expect(document["general_bookmarked_items_count"]).to eq(1)
         expect(document["public_bookmarked_items_count"]).to eq(1)

--- a/spec/models/work_spec.rb
+++ b/spec/models/work_spec.rb
@@ -164,7 +164,7 @@ describe Work do
         end
       end
 
-      context "work already exists in the collection" do
+      context "when work already exists in the collection" do
         let!(:work) { create(:work, collections: [collection]) }
 
         context "when work is hidden by an admin" do

--- a/spec/models/work_spec.rb
+++ b/spec/models/work_spec.rb
@@ -125,27 +125,83 @@ describe Work do
   describe "reindexing" do
     let!(:work) { create(:work) }
 
-    context "when draft status is changed" do
-      it "enqueues tags for reindex" do
-        expect do
-          work.update!(posted: false)
-        end.to add_to_reindex_queue(work.fandoms.last, :main)
+    context "tags" do
+      context "when draft status is changed" do
+        it "enqueues tags for reindex" do
+          expect do
+            work.update!(posted: false)
+          end.to add_to_reindex_queue(work.fandoms.last, :main)
+        end
+      end
+
+      context "when hidden by an admin" do
+        it "enqueues tags for reindex" do
+          expect do
+            work.update!(hidden_by_admin: true)
+          end.to add_to_reindex_queue(work.fandoms.last, :main)
+        end
+      end
+
+      context "when put in an unrevealed collection" do
+        it "enqueues tags for reindex" do
+          expect do
+            work.update!(in_unrevealed_collection: true)
+          end.to add_to_reindex_queue(work.fandoms.last, :main)
+        end
       end
     end
 
-    context "when hidden by an admin" do
-      it "enqueues tags for reindex" do
-        expect do
-          work.update!(hidden_by_admin: true)
-        end.to add_to_reindex_queue(work.fandoms.last, :main)
-      end
-    end
+    context "collections" do
+      let!(:parent_collection) { create(:collection) }
+      let!(:collection) { create_invalid(:collection, parent: parent_collection) }
 
-    context "when put in an unrevealed collection" do
-      it "enqueues tags for reindex" do
-        expect do
-          work.update!(in_unrevealed_collection: true)
-        end.to add_to_reindex_queue(work.fandoms.last, :main)
+      context "when work is created in collection" do
+        it "enqueues the collection for reindex" do
+          expect do
+            create(:work, collections: [collection])
+          end.to add_to_reindex_queue(collection, :background) &
+                 add_to_reindex_queue(parent_collection, :background)
+        end
+      end
+
+      context "work already exists in the collection" do
+        let!(:work) { create(:work, collections: [collection]) }
+
+        context "when work is hidden by an admin" do
+          it "enqueues its collection for reindex" do
+            expect do
+              work.update!(hidden_by_admin: true)
+            end.to add_to_reindex_queue(collection, :background) &
+                   add_to_reindex_queue(parent_collection, :background)
+          end
+        end
+
+        context "when work is restricted" do
+          it "enqueues its collection for reindex" do
+            expect do
+              work.update!(restricted: true)
+            end.to add_to_reindex_queue(collection, :background) &
+                   add_to_reindex_queue(parent_collection, :background)
+          end
+        end
+
+        context "when work is not significantly changed" do
+          it "doesn't enqueue its collection for reindex" do
+            expect do
+              work.touch
+            end.to not_add_to_reindex_queue(collection, :background) &
+                   not_add_to_reindex_queue(parent_collection, :background)
+          end
+        end
+
+        context "when work is destroyed" do
+          it "enqueues its collection for reindex" do
+            expect do
+              work.destroy!
+            end.to add_to_reindex_queue(collection, :background) &
+                   add_to_reindex_queue(parent_collection, :background)
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6026

## Purpose

Cover the testing steps for Collection blurb Works count and Collection blurb Bookmarked Items count with automatic tests instead because the blurb caching interacts so badly with updates that manual testing is not feasible. (Problem is that the blurb cache updates with info from ES before ES updates for the changes, so the stale data is cached for the whole blurb cache expiry time which is up to 2 hours).

Works:
Counts general vs public: public work, restricted work, hidden work, rejected work all in collection_spec.rb
Updating counts:
* adding work: created in collection_item_spec.rb and work_spec.rb
* restricting, hiding: work_spec.rb. unhiding code is same as hiding so no need to test
* approving, rejecting: collection_item_spec.rb
* removing work: destroyed collection item in collection_item_spec.rb
* destroying work: destroyed work in work_spec.rb

Count display for user/guest/admin: collection_browse.feature:240

Bookmarks:
Counts general vs public: public bookmark, private bookmark, hidden bookmark, rejected bookmark, bookmark of restricted work, bookmark of hidden work, bookmark of public work all in collection_spec.rb
Updating counts:
* adding bookmark: created in collection_item_spec.rb and bookmark_spec.rb
* privating, hiding: bookmark_spec.rb. unhiding code is same as hiding so no need to test
* approving, rejecting: collection_item_spec.rb
* hiding bookmarked work, restricting bookmarked work, deleting bookmarked work: bookmarkable.spec
* removing bookmark: destroyed collection item in collection_item_spec.rb
* destroying bookmark: destroyed work in bookmark_spec.rb

Count display for user/guest/admin: collection_browse.feature:240

## Credit

Bilka
