### PR TITLE
AO3-7128 Collection maintainers listed twice in subcollection blurbs and profiles if they also have a different role in the parent collection

### DIFF
--- a/app/views/collection_profile/show.html.erb
+++ b/app/views/collection_profile/show.html.erb
@@ -27,7 +27,7 @@
       <dt class="maintainers"><%= ts('Maintainers:') %></dt>
       <dd class="maintainers">
         <ul class="commas">
-          <%= safe_join(@collection.maintainers.map { |maintainer| content_tag(:li, link_to(maintainer.byline, maintainer.user), class: @collection.user_is_owner?(maintainer.user) ? "owner" : "mod") }, "\n") %>
+          <%= safe_join(@collection.maintainers.uniq.map { |maintainer| content_tag(:li, link_to(maintainer.byline, maintainer.user), class: @collection.user_is_owner?(maintainer.user) ? "owner" : "mod") }, "\n") %>
         </ul>
       </dd>
       <% unless @collection.email.blank? %>

--- a/app/views/collections/_collection_blurb.html.erb
+++ b/app/views/collections/_collection_blurb.html.erb
@@ -8,7 +8,7 @@
         <span class="name">(<%= collection.name %>)</span>
         <%= ts('by') %>
         <%= safe_join(
-          collection.maintainers.map { |maintainer| link_to(maintainer.byline, maintainer.user, class: collection.user_is_owner?(maintainer.user) ? "owner" : "mod")}, t("support.array.words_connector")) %>
+          collection.maintainers.uniq.map { |maintainer| link_to(maintainer.byline, maintainer.user, class: collection.user_is_owner?(maintainer.user) ? "owner" : "mod")}, t("support.array.words_connector")) %>
       </h4>
       <!--collections header iconised header image-->
       <div class="icon">


### PR DESCRIPTION
# Pull Request Checklist

<!-- Mark steps in the checklist as complete by changing `[ ]` to `[X]` -->
* [X] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [X] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [X] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [X] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [X] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-7128

## Purpose

This PR removes duplicate maintainers listed in subcollection blurbs and profiles if they have a different role in the parent collection.

## Testing Instructions

Testing is explained in the Jira ticket under the section "Steps to reproduce". Following these steps and checking that there are no duplicates and the classes of the maintainers are correct as described in the section "What should happen" should suffice.

## Credit

Cubostar, he/him
