### PR TITLE
AO3-6133 Fix action hash

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,7 +20,7 @@ jobs:
       COMMIT_ID: ${{ github.sha }}
 
     steps:
-      - uses: appleboy/ssh-action@v3ca8a7c5359ac6ad91aa47f1946ece1c3b025004
+      - uses: appleboy/ssh-action@3ca8a7c5359ac6ad91aa47f1946ece1c3b025004
         with:
           host: ${{ secrets.SSH_GATEWAY }}
           username: ${{ secrets.SSH_USER }}


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-XXXX (Please fill in issue number and remove this comment.)

## Purpose

Fix the hash, it had an extra v: `https://github.com/appleboy/ssh-action/commit/3ca8a7c5359ac6ad91aa47f1946ece1c3b025004`

## Credit

Bilka
