### PR TITLE
AO3-7124 Fix chapter numbering in PDF downloads for chapters with custom titles

### DIFF
--- a/app/views/downloads/_download_chapter.html.erb
+++ b/app/views/downloads/_download_chapter.html.erb
@@ -1,7 +1,7 @@
 <% @chapter = chapter if defined?(chapter) %>
 
 <div class="meta group">
-  <h2 class="heading"><%= @chapter.chapter_title.html_safe %></h2>
+  <h2 class="heading"><%= @chapter.full_chapter_title.html_safe %></h2>
   <% if (!@chapter.pseuds.blank? && (@chapter.pseuds != @work.pseuds) && (!@work.anonymous?)) %>
     <%# only display byline if different from the main byline %>
     <p class="byline"><%= t(".chapter_byline_html", byline_names_link: byline(@chapter, only_path: false)) %></p>


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/jira/software/c/projects/AO3/issues/?jql=project%20%3D%20%22AO3%22%20ORDER%20BY%20created%20DESC&selectedIssue=AO3-7124

## Purpose

This PR fixes the issue where chapter titles in PDF downloads do not include the chapter number if the chapter has a custom title. Now, PDF downloads will match the site’s display of chapter titles.


## Credit

Yanpei Wang
