### PR TITLE
AO3-5668 Change fandom tag check logic

### DIFF
--- a/app/views/challenge/shared/_challenge_requests.html.erb
+++ b/app/views/challenge/shared/_challenge_requests.html.erb
@@ -12,7 +12,7 @@
   <% end %>
   <li><%= ts("Sort By") %></li>
   <% if @show_request_fandom_tags && @collection.prompts.joins(:tags).where(tags: { type: "Fandom" }).exists? %>
-    <li><%= sort_link t(".fandom"), :fandom %></li>
+    <li><%= sort_link t(".fandom", allowed_fandom_count: @collection.challenge.request_restriction.allowed("fandom")), :fandom %></li>
   <% end %>
   <% unless @collection.prompts.where(:anonymous => true).exists? %>
     <li><%= sort_link ts("Prompter"), :prompter %></li>

--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -561,7 +561,7 @@ en:
         requests_html: Requests &#8595;
     shared:
       challenge_requests:
-        fandom: Fandom
+        fandom: Fandom %{allowed_fandom_count}
   challenge_assignments:
     to_default:
       button: Default


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5668

## Purpose

Query the db instead of loading all prompts as to whether to show the fandom sort button or not.

## Credit

anna