### PR TITLE
AO3-7045 Migrate audits table to BIGINT

### DIFF
--- a/db/migrate/20251002104708_change_audits_id_to_bigint.rb
+++ b/db/migrate/20251002104708_change_audits_id_to_bigint.rb
@@ -1,0 +1,11 @@
+class ChangeAuditsIdToBigint < ActiveRecord::Migration[7.1]
+  uses_departure! if Rails.env.staging? || Rails.env.production?
+
+  def up
+    change_column :audits, :id, "bigint NOT NULL AUTO_INCREMENT"
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration, "This migration cannot be reverted because we can't safely migrate to a smaller id"
+  end
+end


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-7045

## Purpose

Migrates the audits table primary key from integer to BIGINT to prevent integer overflow as the audit log grows. This is a preventive infrastructure improvement to handle the increasing volume of audit records in the system.

## Testing Instructions

1. Run the migration in a development environment: `rails db:migrate`
2. Verify the schema change: Check that `audits.id` column is now BIGINT type
3. Test audit functionality: Ensure audit records are still created for tracked changes
4. Run existing test suite to verify no functionality breaks

## References

This follows the same pattern as recent similar migrations:
- `20250704060231_change_bookmark_foreign_keys_type.rb` 
- `20250718220533_change_subscriptions_id_to_bigint.rb`

## Credit

Alyssa Powell (she/her)