### PR TITLE
AO3-7048 Migrate inbox_comments table to BIGINT

### DIFF
--- a/db/migrate/20251002104852_change_inbox_comments_id_to_bigint.rb
+++ b/db/migrate/20251002104852_change_inbox_comments_id_to_bigint.rb
@@ -1,0 +1,11 @@
+class ChangeInboxCommentsIdToBigint < ActiveRecord::Migration[7.1]
+  uses_departure! if Rails.env.staging? || Rails.env.production?
+
+  def up
+    change_column :inbox_comments, :id, "bigint NOT NULL AUTO_INCREMENT"
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration, "This migration cannot be reverted because we can't safely migrate to a smaller id"
+  end
+end


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-7048

## Purpose

Migrates the inbox_comments table primary key from integer to BIGINT to prevent integer overflow as the inbox comments table grows. This is a preventive infrastructure improvement to handle the increasing volume of inbox comment notifications in the system.

## Testing Instructions

1. Run the migration in a development environment: `rails db:migrate`
2. Verify the schema change: Check that `inbox_comments.id` column is now BIGINT type
3. Test inbox comment functionality: Ensure comment notifications are still created and managed properly
4. Run existing test suite to verify no functionality breaks

## References

This follows the same pattern as recent similar migrations:
- `20250704060231_change_bookmark_foreign_keys_type.rb` 
- `20250718220533_change_subscriptions_id_to_bigint.rb`

## Credit

Alyssa Powell (she/her)