### PR TITLE
AO3-7124 Fix chapter numbering in PDF downloads for chapters with custom titles

### DIFF
--- a/app/views/downloads/_download_chapter.html.erb
+++ b/app/views/downloads/_download_chapter.html.erb
@@ -1,7 +1,16 @@
 <% @chapter = chapter if defined?(chapter) %>
 
 <div class="meta group">
-  <h2 class="heading"><%= @chapter.chapter_title.html_safe %></h2>
+<h2 class="heading">
+  <% if @chapter.title.present? %>
+    <%= t(".full_chapter_title_with_title",
+          chapter_number: @chapter.position,
+          title: @chapter.title) %>
+  <% else %>
+    <%= t(".full_chapter_title_without_title",
+          chapter_number: @chapter.position) %>
+  <% end %>
+</h2>
   <% if (!@chapter.pseuds.blank? && (@chapter.pseuds != @work.pseuds) && (!@work.anonymous?)) %>
     <%# only display byline if different from the main byline %>
     <p class="byline"><%= t(".chapter_byline_html", byline_names_link: byline(@chapter, only_path: false)) %></p>

--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -773,6 +773,8 @@ en:
       chapter_end_notes_without_chapter_notes: notes
       chapter_notes: Chapter Notes
       chapter_summary: Chapter Summary
+      full_chapter_title_with_title: 'Chapter %{chapter_number}: %{title}'
+      full_chapter_title_without_title: Chapter %{chapter_number}
       section_chapter_end_notes: Chapter End Notes
       see_chapter_end_notes_html: See the end of the chapter for %{chapter_end_notes_link}
     download_preface:

--- a/features/works/work_download.feature
+++ b/features/works/work_download.feature
@@ -420,3 +420,22 @@ Feature: Download a work
     And I view the work "Worldbuilding"
     And I follow "HTML"
   Then I should see "[Restricted Work] by translator"
+
+
+  Scenario: Download multi-chapter work with mixed chapter titles (one without, one with)
+  
+    Given I am logged in as "myname"
+    And I set up the draft "Multi-Chapter Download"
+    And I fill in "Work Title" with "Multi-Chapter Download"
+    And I fill in "content" with "Content for chapter one."
+    And I press "Post"
+    And I follow "Add Chapter"
+    And I fill in "content" with "Content for chapter two."
+    And I fill in "Chapter Title" with "Chapter Two Title"
+    And I press "Post"
+  When I view the work "Multi-Chapter Download"
+    And I follow "HTML"
+  Then I should receive a file of type "html"
+    And I should see "Chapter 1"
+    And I should see "Chapter 2: Chapter Two Title"
+


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-7124

## Purpose

This PR fixes the issue where chapter titles in PDF downloads do not include the chapter number if the chapter has a custom title. Now, PDF downloads will match the site’s display of chapter titles.

## Credit

Yanpei Wang
