### PR TITLE
update the link to ao3's history on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Release Status
 ---------
 Development of the OTW-Archive software is an ongoing labor of love. You can see it in action on the [Archive of Our Own](https://archiveofourown.org/), aka AO3, a multifandom archive also run by the OTW.
 
-You can find more information about the [history and future of the AO3 project on the OTW website](https://www.transformativeworks.org/archive_of_our_own/).
+You can find more information about the [history and future of the AO3 project on the OTW website](https://www.transformativeworks.org/our-projects/archive-of-our-own/).
 
 If you wish to use this software, SquidgeWorld has generously provided [setup notes](https://squidgeworld.org/works/34491).
 


### PR DESCRIPTION
## Purpose

On README.md, change the outdated link to ao3's page on tw.org to the updated one. You can also consider changing "history and future" part, if you think that doesn't represent what that page is about anymore.

## Testing Instructions

Currently, the README links to a 404. This new link will show the correct page.

## Credit

ömer faruk he/him