### PR TITLE
Add workers to docker compose config

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -87,9 +87,22 @@ services:
       - redis
       - es
       - mc
+      - workers
     # Make `docker compose attach web` work for debugging
     stdin_open: true
     tty: true
+  workers:
+    profiles:
+      - dev
+    build:
+      context: .
+      dockerfile: ./config/docker/Dockerfile
+    command: bundle exec rake environment resque:work
+    volumes:
+      - .:/otwa
+    environment:
+      - RAILS_ENV=development
+      - QUEUE=*
   chrome:
     profiles:
       - test


### PR DESCRIPTION
# Pull Request Checklist

## Issue

Effectively a documentation change, so no Jira ticket

## Purpose

Add workers to the docker compose configuration so indexing (and other background/Resque tasks) work more easily.

## Testing Instructions

Does the init script still result in a working environment? Does `docker compose --profile dev up -d --build` still work as expected?

## References

https://github.com/otwcode/otwarchive/pull/5179#discussion_r2399866201
