### PR TITLE
AO3-7199 Added creations button to user view when logged in as admin

### DIFF
--- a/app/views/users/_header_navigation.html.erb
+++ b/app/views/users/_header_navigation.html.erb
@@ -20,4 +20,9 @@
   <% if policy(User).can_manage_users? %>
     <li><%= link_to t(".admin_user"), admin_user_path(@user) %></li>
   <% end %>
+  <% if policy(User).can_access_creation_summary? %>
+    <li>
+      <%= link_to t("admin.admin_users.show.navigation.creations"), creations_admin_user_path(@user) %>
+    </li>
+  <% end %>
 </ul>

--- a/app/views/users/_header_navigation.html.erb
+++ b/app/views/users/_header_navigation.html.erb
@@ -22,7 +22,7 @@
   <% end %>
   <% if policy(User).can_access_creation_summary? %>
     <li>
-      <%= link_to t("admin.admin_users.show.navigation.creations"), creations_admin_user_path(@user) %>
+      <%= link_to t(".admin_creations"), creations_admin_user_path(@user) %>
     </li>
   <% end %>
 </ul>

--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -2544,6 +2544,7 @@ en:
       edit_multiple: Edit Works
       invitations: Invitations
       new_work: Post New
+      admin_creations: Creations
     passwords:
       edit:
         change_password: Change Password

--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -2540,11 +2540,11 @@ en:
       edit_my_profile: Edit My Profile
       edit_profile: Edit Profile
     header_navigation:
+      admin_creations: Creations
       admin_user: User Administration
       edit_multiple: Edit Works
       invitations: Invitations
       new_work: Post New
-      admin_creations: Creations
     passwords:
       edit:
         change_password: Change Password

--- a/features/admins/users/admin_manage_users.feature
+++ b/features/admins/users/admin_manage_users.feature
@@ -114,8 +114,16 @@ Feature: Admin Actions to manage users
       And I go to the user administration page for "lurker"
     Then the page should have a dashboard sidebar
       And I should not see "Creations"
+    When I go to lurker's user page
+    Then the page should have a dashboard sidebar
+      And I should not see "Creations"
     When I am logged in as a "policy_and_abuse" admin
       And I go to the user administration page for "lurker"
+      And I follow "Creations"
+    Then I should see "Works and Comments by lurker"
+      And I should see "This user has no works or comments."
+      And the page should have a dashboard sidebar
+    When I go to lurker's user page
       And I follow "Creations"
     Then I should see "Works and Comments by lurker"
       And I should see "This user has no works or comments."
@@ -128,3 +136,4 @@ Feature: Admin Actions to manage users
       And I should see "1 Comment" within "#comments-summary"
       And I should see "Comment on the work Creepy Gift" within "#comments-summary"
       And I should see "<p>Neener</p>" within "#comments-summary"
+

--- a/features/admins/users/admin_manage_users.feature
+++ b/features/admins/users/admin_manage_users.feature
@@ -136,4 +136,3 @@ Feature: Admin Actions to manage users
       And I should see "1 Comment" within "#comments-summary"
       And I should see "Comment on the work Creepy Gift" within "#comments-summary"
       And I should see "<p>Neener</p>" within "#comments-summary"
-


### PR DESCRIPTION
# Pull Request Checklist

<!-- Mark steps in the checklist as complete by changing `[ ]` to `[X]` -->
* [X] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [X] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [X] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [X] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [x] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-7199

## Purpose

This PR adds an extra button for admins to access the creations page a bit faster. Instead of needing to go into user administration, the link is directly visible from user profile. 

## Credit

Kiyazz (he/him)
