### PR TITLE
AO3-7211 Add a warning to the success message when directly adding existing bookmark to collection

### DIFF
--- a/app/controllers/collection_items_controller.rb
+++ b/app/controllers/collection_items_controller.rb
@@ -148,11 +148,12 @@ class CollectionItemsController < ApplicationController
                            collection_title: needs_user_approval.title)
       end
     end
+
     unless unapproved_collections.empty?
       flash[:notice] ||= ""
       flash[:notice] += ts(" You have submitted your work to #{unapproved_collections.size > 1 ? "moderated collections (%{all_collections}). It will not become a part of those collections" : "the moderated collection '%{all_collections}'. It will not become a part of the collection"} until it has been approved by a moderator.", all_collections: unapproved_collections.map { |f| f.title }.join(', '))
     end
-    flash[:notice] += t("collection_items.create.warnings.private_bookmark_added_to_collection") unless new_collections.empty? && unapproved_collections.empty?
+    flash[:notice] += t(".warnings.private_bookmark_added_to_collection") unless new_collections.empty? && unapproved_collections.empty?
     flash[:notice] = (flash[:notice]).html_safe unless flash[:notice].blank?
     flash[:error] = (flash[:error]).html_safe unless flash[:error].blank?
 

--- a/app/controllers/collection_items_controller.rb
+++ b/app/controllers/collection_items_controller.rb
@@ -138,7 +138,6 @@ class CollectionItemsController < ApplicationController
     unless new_collections.empty?
       flash[:notice] = ts("Added to collection(s): %{collections}.",
                             collections: new_collections.collect(&:title).join(", "))
-      flash[:notice] += t("bookmarks.create.warnings.private_bookmark_added_to_collection")
     end
     unless invited_collections.empty?
       invited_collections.each do |needs_user_approval|
@@ -153,7 +152,7 @@ class CollectionItemsController < ApplicationController
       flash[:notice] ||= ""
       flash[:notice] += ts(" You have submitted your work to #{unapproved_collections.size > 1 ? "moderated collections (%{all_collections}). It will not become a part of those collections" : "the moderated collection '%{all_collections}'. It will not become a part of the collection"} until it has been approved by a moderator.", all_collections: unapproved_collections.map { |f| f.title }.join(', '))
     end
-
+    flash[:notice] += t("collection_items.create.warnings.private_bookmark_added_to_collection") unless new_collections.empty? && unapproved_collections.empty?
     flash[:notice] = (flash[:notice]).html_safe unless flash[:notice].blank?
     flash[:error] = (flash[:error]).html_safe unless flash[:error].blank?
 

--- a/app/controllers/collection_items_controller.rb
+++ b/app/controllers/collection_items_controller.rb
@@ -138,6 +138,7 @@ class CollectionItemsController < ApplicationController
     unless new_collections.empty?
       flash[:notice] = ts("Added to collection(s): %{collections}.",
                             collections: new_collections.collect(&:title).join(", "))
+      flash[:notice] += t("bookmarks.create.warnings.private_bookmark_added_to_collection")
     end
     unless invited_collections.empty?
       invited_collections.each do |needs_user_approval|

--- a/config/locales/controllers/en.yml
+++ b/config/locales/controllers/en.yml
@@ -69,6 +69,8 @@ en:
     create:
       invited: invited
       invited_to_collections_html: This work has been %{invited_link} to your collection (%{collection_title}).
+      warnings:
+          private_bookmark_added_to_collection: " Please note: private bookmarks are not listed in collections."
   collection_participants:
     update:
       failure: Couldn't update %{participant}.

--- a/config/locales/controllers/en.yml
+++ b/config/locales/controllers/en.yml
@@ -69,6 +69,8 @@ en:
     create:
       invited: invited
       invited_to_collections_html: This work has been %{invited_link} to your collection (%{collection_title}).
+      warnings:
+        private_bookmark_added_to_collection: " Please note: private bookmarks are not listed in collections."
   collection_participants:
     update:
       failure: Couldn't update %{participant}.

--- a/spec/controllers/collection_items_controller_spec.rb
+++ b/spec/controllers/collection_items_controller_spec.rb
@@ -358,7 +358,7 @@ describe CollectionItemsController do
       context "when the item's creator does not allow collection invitations" do
         it "adds the item anyway" do
           post :create, params: params
-          it_redirects_to_with_notice(work, "Added to collection(s): #{collection.title}.")
+          it_redirects_to_with_notice(work, "Added to collection(s): #{collection.title}. Please note: private bookmarks are not listed in collections.")
           expect(work.reload.collections).to include(collection)
         end
       end
@@ -366,7 +366,7 @@ describe CollectionItemsController do
       context "when the item's creator allows collection invitations" do
         it "adds the item" do
           post :create, params: params
-          it_redirects_to_with_notice(work, "Added to collection(s): #{collection.title}.")
+          it_redirects_to_with_notice(work, "Added to collection(s): #{collection.title}. Please note: private bookmarks are not listed in collections.")
           expect(work.reload.collections).to include(collection)
         end
       end


### PR DESCRIPTION
# Pull Request Checklist

<!-- Mark steps in the checklist as complete by changing `[ ]` to `[X]` -->
* [X] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [X] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [X] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [X] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [X] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

[https://otwarchive.atlassian.net/browse/AO3-7211](https://otwarchive.atlassian.net/browse/AO3-7211)

## Purpose

What does this PR do?
Builds on [AO3-7205](https://github.com/otwcode/otwarchive/pull/5465), but adds the warning when directly adding existing bookmark to a collection with the **Add to Collection** button. This PR adds that warning to the success message when directly adding existing bookmark to collection.

## Testing Instructions

How can the Archive's QA team verify that this is working as you intended?
Build UI locally, follow repro steps in Jira ticket AO3-7211. Video of local testing included. 

https://github.com/user-attachments/assets/a865dfe8-f8f4-4ba3-a080-f96d5a76eb2b


## References

[AO3-7205 Add a warning to the bookmark success message](https://github.com/otwcode/otwarchive/pull/5465)

## Credit
Credit under "germpy" is fine, she/her. I dunno if this is a change that really requires credit tbhhhh


[AO3-7205]: https://otwarchive.atlassian.net/browse/AO3-7205?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ