### PR TITLE
AO3-7035 Add Invitation Mailer Previews and Refactored I18n Keys

### DIFF
--- a/app/views/user_mailer/invitation.html.erb
+++ b/app/views/user_mailer/invitation.html.erb
@@ -8,7 +8,7 @@
   </p>
 
   <p>
-    <%= t(".about.html", otw_link: style_link(t(".html.otw_link_text"), "https://www.transformativeworks.org")) %>
+    <%= t(".about.html", otw_link: style_link(t(".about.otw_link_text"), "https://www.transformativeworks.org")) %>
   </p>
 
   <p>
@@ -16,14 +16,14 @@
   </p>
 
   <p>
-    <%= t(".join.html", invitation_link: style_link(t(".html.invitation_link_text"), signup_url(invitation_token: @invitation.token))) %>
+    <%= t(".join.html", invitation_link: style_link(t(".join.invitation_link_text"), signup_url(invitation_token: @invitation.token))) %>
   </p>
 
   <p>
-    <%= t(".activation_support.html", support_link: style_link(t(".html.support_link_text"), new_feedback_report_url)) %>
+    <%= t(".activation_support.html", support_link: style_link(t(".activation_support.support_link_text"), new_feedback_report_url)) %>
   </p>
 
   <p>
-    <%= t(".faq.html", faq_link: style_link(t(".html.faq_link_text"), archive_faqs_url)) %>
+    <%= t(".faq.html", faq_link: style_link(t(".faq.faq_link_text"), archive_faqs_url)) %>
   </p>
 <% end %>

--- a/app/views/user_mailer/invitation.html.erb
+++ b/app/views/user_mailer/invitation.html.erb
@@ -1,14 +1,14 @@
 <% content_for :message do %>
   <p>
     <% if !@user_name.blank? %>
-      <%= t(".has_invited", user_name: style_bold(@user_name)).html_safe %>
+      <%= t(".has_invited.html", user_name: style_bold(@user_name)) %>
     <% else %>
       <%= t ".been_invited" %>
     <% end %>
   </p>
 
   <p>
-    <%= t(".html.about", otw_link: style_link(t(".html.otw_link_text"), "https://www.transformativeworks.org")).html_safe %>
+    <%= t(".about.html", otw_link: style_link(t(".html.otw_link_text"), "https://www.transformativeworks.org")) %>
   </p>
 
   <p>
@@ -16,14 +16,14 @@
   </p>
 
   <p>
-    <%= t(".html.join", invitation_link: style_link(t(".html.invitation_link_text"), signup_url(invitation_token: @invitation.token))).html_safe %>
+    <%= t(".join.html", invitation_link: style_link(t(".html.invitation_link_text"), signup_url(invitation_token: @invitation.token))) %>
   </p>
 
   <p>
-    <%= t(".html.activation_support", support_link: style_link(t(".html.support_link_text"), new_feedback_report_url)).html_safe %>
+    <%= t(".activation_support.html", support_link: style_link(t(".html.support_link_text"), new_feedback_report_url)) %>
   </p>
 
   <p>
-    <%= t(".html.faq", faq_link: style_link(t(".html.faq_link_text"), archive_faqs_url)).html_safe %>
+    <%= t(".faq.html", faq_link: style_link(t(".html.faq_link_text"), archive_faqs_url)) %>
   </p>
 <% end %>

--- a/app/views/user_mailer/invitation.text.erb
+++ b/app/views/user_mailer/invitation.text.erb
@@ -1,17 +1,17 @@
 <% content_for :message do %>
 <% if !@user_name.blank? %>
-<%= t ".has_invited", user_name: @user_name %>
+<%= t ".has_invited.text", user_name: @user_name %>
 <% else %>
 <%= t ".been_invited" %>
 <% end %>
 
-<%= t ".text.about", otw_url: "https://www.transformativeworks.org" %>
+<%= t ".about.text", otw_url: "https://www.transformativeworks.org" %>
 
 <%= t ".features" %>
 
-<%= t ".text.join", invitation_url: signup_url(invitation_token: @invitation.token) %>
+<%= t ".join.text", invitation_url: signup_url(invitation_token: @invitation.token) %>
 
-<%= t ".text.activation_support", support_url: new_feedback_report_url %>
+<%= t ".activation_support.text", support_url: new_feedback_report_url %>
 
-<%= t ".text.faq", faq_url: archive_faqs_url %>
+<%= t ".faq.text", faq_url: archive_faqs_url %>
 <% end %>

--- a/config/locales/mailers/en.yml
+++ b/config/locales/mailers/en.yml
@@ -658,7 +658,7 @@ en:
         text: "%{user_name} has invited you to join the Archive of Our Own!"
       about:
         html: The Archive of Our Own (AO3) is a free, noncommercial archive built by and for fans. Our servers are owned by our parent nonprofit, the %{otw_link}, which works to protect fan rights and preserve fanworks. We welcome all kinds of fanworks, including fanfiction, fanart, fanvids, and podfic from any fandom.
-        text: The Archive of Our Own (AO3) is a free, noncommercial archive built by and for fans. Our servers are owned by our parent nonprofit, the %{otw_url}, which works to protect fan rights and preserve fanworks. We welcome all kinds of fanworks, including fanfiction, fanart, fanvids, and podfic from any fandom.
+        text: The Archive of Our Own (AO3) is a free, noncommercial archive built by and for fans. Our servers are owned by our parent nonprofit, the Organization for Transformative Works (%{otw_url}), which works to protect fan rights and preserve fanworks. We welcome all kinds of fanworks, including fanfiction, fanart, fanvids, and podfic from any fandom.
       activation_support: 
         html: After you sign up, you'll receive an account activation email. If you do not receive this email after 48 hours, please %{support_link}.
         text: After you sign up, you'll receive an account activation email. If you do not receive this email after 48 hours, please %{support_url}.

--- a/config/locales/mailers/en.yml
+++ b/config/locales/mailers/en.yml
@@ -651,28 +651,28 @@ en:
       signups_here: 'Here are the invalid sign-ups:'
       subject: "[%{app_name}][%{collection_title}] Invalid sign-ups found"
     invitation:
-      been_invited: You've been invited to join the Archive of Our Own!
-      features: With an account, you can post fanworks, use bookmarks to keep track of works you enjoyed, receive subscription emails when your favorite creators or works update, customize the way the site looks for you, and more!
-      has_invited: 
-        html: "%{user_name} has invited you to join the Archive of Our Own!"
-        text: "%{user_name} has invited you to join the Archive of Our Own!"
       about:
         html: The Archive of Our Own (AO3) is a free, noncommercial archive built by and for fans. Our servers are owned by our parent nonprofit, the %{otw_link}, which works to protect fan rights and preserve fanworks. We welcome all kinds of fanworks, including fanfiction, fanart, fanvids, and podfic from any fandom.
         text: The Archive of Our Own (AO3) is a free, noncommercial archive built by and for fans. Our servers are owned by our parent nonprofit, the %{otw_url}, which works to protect fan rights and preserve fanworks. We welcome all kinds of fanworks, including fanfiction, fanart, fanvids, and podfic from any fandom.
-      activation_support: 
+      activation_support:
         html: After you sign up, you'll receive an account activation email. If you do not receive this email after 48 hours, please %{support_link}.
         text: After you sign up, you'll receive an account activation email. If you do not receive this email after 48 hours, please %{support_url}.
+      been_invited: You've been invited to join the Archive of Our Own!
       faq:
         html: For more information, please check %{faq_link}.
         text: For more information, please check %{faq_url}.
-      join:
-        html: If you'd like to join us, please %{invitation_link}.
-        text: If you'd like to join us, please %{invitation_url}.
+      features: With an account, you can post fanworks, use bookmarks to keep track of works you enjoyed, receive subscription emails when your favorite creators or works update, customize the way the site looks for you, and more!
+      has_invited:
+        html: "%{user_name} has invited you to join the Archive of Our Own!"
+        text: "%{user_name} has invited you to join the Archive of Our Own!"
       html:
         faq_link_text: our FAQ
         invitation_link_text: follow this link to sign up
         otw_link_text: Organization for Transformative Works
         support_link_text: contact Support
+      join:
+        html: If you'd like to join us, please %{invitation_link}.
+        text: If you'd like to join us, please follow this link to sign up: %{invitation_url}.
       subject: "[%{app_name}] Invitation"
     invitation_to_claim:
       access:

--- a/config/locales/mailers/en.yml
+++ b/config/locales/mailers/en.yml
@@ -667,7 +667,7 @@ en:
         text: For more information, please check %{faq_url}.
       join:
         html: If you'd like to join us, please %{invitation_link}.
-        text: If you'd like to join us, please %{invitation_url}.
+        text: If you'd like to join us, please follow this link to sign up: %{invitation_url}.
       html:
         faq_link_text: our FAQ
         invitation_link_text: follow this link to sign up

--- a/config/locales/mailers/en.yml
+++ b/config/locales/mailers/en.yml
@@ -651,28 +651,28 @@ en:
       signups_here: 'Here are the invalid sign-ups:'
       subject: "[%{app_name}][%{collection_title}] Invalid sign-ups found"
     invitation:
+      been_invited: You've been invited to join the Archive of Our Own!
+      features: With an account, you can post fanworks, use bookmarks to keep track of works you enjoyed, receive subscription emails when your favorite creators or works update, customize the way the site looks for you, and more!
+      has_invited: 
+        html: "%{user_name} has invited you to join the Archive of Our Own!"
+        text: "%{user_name} has invited you to join the Archive of Our Own!"
       about:
         html: The Archive of Our Own (AO3) is a free, noncommercial archive built by and for fans. Our servers are owned by our parent nonprofit, the %{otw_link}, which works to protect fan rights and preserve fanworks. We welcome all kinds of fanworks, including fanfiction, fanart, fanvids, and podfic from any fandom.
         text: The Archive of Our Own (AO3) is a free, noncommercial archive built by and for fans. Our servers are owned by our parent nonprofit, the %{otw_url}, which works to protect fan rights and preserve fanworks. We welcome all kinds of fanworks, including fanfiction, fanart, fanvids, and podfic from any fandom.
-      activation_support:
+      activation_support: 
         html: After you sign up, you'll receive an account activation email. If you do not receive this email after 48 hours, please %{support_link}.
         text: After you sign up, you'll receive an account activation email. If you do not receive this email after 48 hours, please %{support_url}.
-      been_invited: You've been invited to join the Archive of Our Own!
       faq:
         html: For more information, please check %{faq_link}.
         text: For more information, please check %{faq_url}.
-      features: With an account, you can post fanworks, use bookmarks to keep track of works you enjoyed, receive subscription emails when your favorite creators or works update, customize the way the site looks for you, and more!
-      has_invited:
-        html: "%{user_name} has invited you to join the Archive of Our Own!"
-        text: "%{user_name} has invited you to join the Archive of Our Own!"
+      join:
+        html: If you'd like to join us, please %{invitation_link}.
+        text: If you'd like to join us, please %{invitation_url}.
       html:
         faq_link_text: our FAQ
         invitation_link_text: follow this link to sign up
         otw_link_text: Organization for Transformative Works
         support_link_text: contact Support
-      join:
-        html: If you'd like to join us, please %{invitation_link}.
-        text: If you'd like to join us, please follow this link to sign up: %{invitation_url}.
       subject: "[%{app_name}] Invitation"
     invitation_to_claim:
       access:

--- a/config/locales/mailers/en.yml
+++ b/config/locales/mailers/en.yml
@@ -667,7 +667,7 @@ en:
         text: For more information, please check %{faq_url}.
       join:
         html: If you'd like to join us, please %{invitation_link}.
-        text: If you'd like to join us, please follow this link to sign up: %{invitation_url}.
+        text: If you'd like to join us, please follow this link to sign up %{invitation_url}.
       html:
         faq_link_text: our FAQ
         invitation_link_text: follow this link to sign up

--- a/config/locales/mailers/en.yml
+++ b/config/locales/mailers/en.yml
@@ -651,28 +651,28 @@ en:
       signups_here: 'Here are the invalid sign-ups:'
       subject: "[%{app_name}][%{collection_title}] Invalid sign-ups found"
     invitation:
-      been_invited: You've been invited to join the Archive of Our Own!
-      features: With an account, you can post fanworks, use bookmarks to keep track of works you enjoyed, receive subscription emails when your favorite creators or works update, customize the way the site looks for you, and more!
-      has_invited: 
-        html: "%{user_name} has invited you to join the Archive of Our Own!"
-        text: "%{user_name} has invited you to join the Archive of Our Own!"
       about:
         html: The Archive of Our Own (AO3) is a free, noncommercial archive built by and for fans. Our servers are owned by our parent nonprofit, the %{otw_link}, which works to protect fan rights and preserve fanworks. We welcome all kinds of fanworks, including fanfiction, fanart, fanvids, and podfic from any fandom.
         text: The Archive of Our Own (AO3) is a free, noncommercial archive built by and for fans. Our servers are owned by our parent nonprofit, the Organization for Transformative Works (%{otw_url}), which works to protect fan rights and preserve fanworks. We welcome all kinds of fanworks, including fanfiction, fanart, fanvids, and podfic from any fandom.
-      activation_support: 
+      activation_support:
         html: After you sign up, you'll receive an account activation email. If you do not receive this email after 48 hours, please %{support_link}.
         text: After you sign up, you'll receive an account activation email. If you do not receive this email after 48 hours, please %{support_url}.
+      been_invited: You've been invited to join the Archive of Our Own!
       faq:
         html: For more information, please check %{faq_link}.
         text: For more information, please check %{faq_url}.
-      join:
-        html: If you'd like to join us, please %{invitation_link}.
-        text: If you'd like to join us, please follow this link to sign up %{invitation_url}.
+      features: With an account, you can post fanworks, use bookmarks to keep track of works you enjoyed, receive subscription emails when your favorite creators or works update, customize the way the site looks for you, and more!
+      has_invited:
+        html: "%{user_name} has invited you to join the Archive of Our Own!"
+        text: "%{user_name} has invited you to join the Archive of Our Own!"
       html:
         faq_link_text: our FAQ
         invitation_link_text: follow this link to sign up
         otw_link_text: Organization for Transformative Works
         support_link_text: contact Support
+      join:
+        html: If you'd like to join us, please %{invitation_link}.
+        text: If you'd like to join us, please follow this link to sign up %{invitation_url}.
       subject: "[%{app_name}] Invitation"
     invitation_to_claim:
       access:

--- a/config/locales/mailers/en.yml
+++ b/config/locales/mailers/en.yml
@@ -653,25 +653,25 @@ en:
     invitation:
       about:
         html: The Archive of Our Own (AO3) is a free, noncommercial archive built by and for fans. Our servers are owned by our parent nonprofit, the %{otw_link}, which works to protect fan rights and preserve fanworks. We welcome all kinds of fanworks, including fanfiction, fanart, fanvids, and podfic from any fandom.
-        text: The Archive of Our Own (AO3) is a free, noncommercial archive built by and for fans. Our servers are owned by our parent nonprofit, the Organization for Transformative Works (%{otw_url}), which works to protect fan rights and preserve fanworks. We welcome all kinds of fanworks, including fanfiction, fanart, fanvids, and podfic from any fandom.
         otw_link_text: Organization for Transformative Works
+        text: The Archive of Our Own (AO3) is a free, noncommercial archive built by and for fans. Our servers are owned by our parent nonprofit, the Organization for Transformative Works (%{otw_url}), which works to protect fan rights and preserve fanworks. We welcome all kinds of fanworks, including fanfiction, fanart, fanvids, and podfic from any fandom.
       activation_support:
         html: After you sign up, you'll receive an account activation email. If you do not receive this email after 48 hours, please %{support_link}.
-        text: After you sign up, you'll receive an account activation email. If you do not receive this email after 48 hours, please %{support_url}.
         support_link_text: contact Support
+        text: After you sign up, you'll receive an account activation email. If you do not receive this email after 48 hours, please %{support_url}.
       been_invited: You've been invited to join the Archive of Our Own!
       faq:
+        faq_link_text: our FAQ
         html: For more information, please check %{faq_link}.
         text: For more information, please check %{faq_url}.
-        faq_link_text: our FAQ 
       features: With an account, you can post fanworks, use bookmarks to keep track of works you enjoyed, receive subscription emails when your favorite creators or works update, customize the way the site looks for you, and more!
       has_invited:
         html: "%{user_name} has invited you to join the Archive of Our Own!"
-        text: "%{user_name} has invited you to join the Archive of Our Own!" 
+        text: "%{user_name} has invited you to join the Archive of Our Own!"
       join:
         html: If you'd like to join us, please %{invitation_link}.
-        text: If you'd like to join us, please follow this link to sign up %{invitation_url}.
         invitation_link_text: follow this link to sign up
+        text: If you'd like to join us, please follow this link to sign up %{invitation_url}.
       subject: "[%{app_name}] Invitation"
     invitation_to_claim:
       access:

--- a/config/locales/mailers/en.yml
+++ b/config/locales/mailers/en.yml
@@ -653,22 +653,27 @@ en:
     invitation:
       been_invited: You've been invited to join the Archive of Our Own!
       features: With an account, you can post fanworks, use bookmarks to keep track of works you enjoyed, receive subscription emails when your favorite creators or works update, customize the way the site looks for you, and more!
-      has_invited: "%{user_name} has invited you to join the Archive of Our Own!"
+      has_invited: 
+        html: "%{user_name} has invited you to join the Archive of Our Own!"
+        text: "%{user_name} has invited you to join the Archive of Our Own!"
+      about:
+        html: The Archive of Our Own (AO3) is a free, noncommercial archive built by and for fans. Our servers are owned by our parent nonprofit, the %{otw_link}, which works to protect fan rights and preserve fanworks. We welcome all kinds of fanworks, including fanfiction, fanart, fanvids, and podfic from any fandom.
+        text: The Archive of Our Own (AO3) is a free, noncommercial archive built by and for fans. Our servers are owned by our parent nonprofit, the %{otw_url}, which works to protect fan rights and preserve fanworks. We welcome all kinds of fanworks, including fanfiction, fanart, fanvids, and podfic from any fandom.
+      activation_support: 
+        html: After you sign up, you'll receive an account activation email. If you do not receive this email after 48 hours, please %{support_link}.
+        text: After you sign up, you'll receive an account activation email. If you do not receive this email after 48 hours, please %{support_url}.
+      faq:
+        html: For more information, please check %{faq_link}.
+        text: For more information, please check %{faq_url}.
+      join:
+        html: If you'd like to join us, please %{invitation_link}.
+        text: If you'd like to join us, please %{invitation_url}.
       html:
-        about: The Archive of Our Own (AO3) is a free, noncommercial archive built by and for fans. Our servers are owned by our parent nonprofit, the %{otw_link}, which works to protect fan rights and preserve fanworks. We welcome all kinds of fanworks, including fanfiction, fanart, fanvids, and podfic from any fandom.
-        activation_support: After you sign up, you'll receive an account activation email. If you do not receive this email after 48 hours, please %{support_link}.
-        faq: For more information, please check %{faq_link}.
         faq_link_text: our FAQ
         invitation_link_text: follow this link to sign up
-        join: If you'd like to join us, please %{invitation_link}.
         otw_link_text: Organization for Transformative Works
         support_link_text: contact Support
       subject: "[%{app_name}] Invitation"
-      text:
-        about: The Archive of Our Own (AO3) is a free, noncommercial archive built by and for fans. Our servers are owned by our parent nonprofit, the Organization for Transformative Works (%{otw_url}), which works to protect fan rights and preserve fanworks. We welcome all kinds of fanworks, including fanfiction, fanart, fanvids, and podfic from any fandom.
-        activation_support: 'After you sign up, you''ll receive an account activation email. If you do not receive this email after 48 hours, please contact Support: %{support_url}.'
-        faq: 'For more information, please check our FAQ: %{faq_url}.'
-        join: 'If you''d like to join us, please follow this link to sign up: %{invitation_url}.'
     invitation_to_claim:
       access:
         html: Depending on the archive, your works may have been imported as restricted to registered users only (to keep them out of Google searches). If this is the case, the works will only be accessible by logged-in users unless you choose to make them fully visible. For help unlocking, orphaning, or deleting your works, please %{contact_support_link}.

--- a/config/locales/mailers/en.yml
+++ b/config/locales/mailers/en.yml
@@ -654,25 +654,24 @@ en:
       about:
         html: The Archive of Our Own (AO3) is a free, noncommercial archive built by and for fans. Our servers are owned by our parent nonprofit, the %{otw_link}, which works to protect fan rights and preserve fanworks. We welcome all kinds of fanworks, including fanfiction, fanart, fanvids, and podfic from any fandom.
         text: The Archive of Our Own (AO3) is a free, noncommercial archive built by and for fans. Our servers are owned by our parent nonprofit, the Organization for Transformative Works (%{otw_url}), which works to protect fan rights and preserve fanworks. We welcome all kinds of fanworks, including fanfiction, fanart, fanvids, and podfic from any fandom.
+        otw_link_text: Organization for Transformative Works
       activation_support:
         html: After you sign up, you'll receive an account activation email. If you do not receive this email after 48 hours, please %{support_link}.
         text: After you sign up, you'll receive an account activation email. If you do not receive this email after 48 hours, please %{support_url}.
+        support_link_text: contact Support
       been_invited: You've been invited to join the Archive of Our Own!
       faq:
         html: For more information, please check %{faq_link}.
         text: For more information, please check %{faq_url}.
+        faq_link_text: our FAQ 
       features: With an account, you can post fanworks, use bookmarks to keep track of works you enjoyed, receive subscription emails when your favorite creators or works update, customize the way the site looks for you, and more!
       has_invited:
         html: "%{user_name} has invited you to join the Archive of Our Own!"
-        text: "%{user_name} has invited you to join the Archive of Our Own!"
-      html:
-        faq_link_text: our FAQ
-        invitation_link_text: follow this link to sign up
-        otw_link_text: Organization for Transformative Works
-        support_link_text: contact Support
+        text: "%{user_name} has invited you to join the Archive of Our Own!" 
       join:
         html: If you'd like to join us, please %{invitation_link}.
         text: If you'd like to join us, please follow this link to sign up %{invitation_url}.
+        invitation_link_text: follow this link to sign up
       subject: "[%{app_name}] Invitation"
     invitation_to_claim:
       access:

--- a/test/mailers/previews/user_mailer_preview.rb
+++ b/test/mailers/previews/user_mailer_preview.rb
@@ -153,6 +153,22 @@ class UserMailerPreview < ApplicationMailerPreview
     UserMailer.invitation_to_claim(invitation.id, archivist.login)
   end
 
+
+  # URL: /rails/mailers/user_mailer/invitation
+  def invitation_by_other_user
+    inviting_user = create(:user)
+    invitation = create(:invitation, creator: inviting_user)
+    user = create(:user, :for_mailer_preview)
+    UserMailer.invitation(invitation.id)
+  end
+
+  # URL: /rails/mailers/user_mailer/invitation
+  def invitation_by_queue
+    invitation = create(:invitation)
+    user = create(:user, :for_mailer_preview)
+    UserMailer.invitation(invitation.id)
+  end
+
   # URL: /rails/mailers/user_mailer/invite_request_declined?total=3
   def invite_request_declined
     user = create(:user, :for_mailer_preview)

--- a/test/mailers/previews/user_mailer_preview.rb
+++ b/test/mailers/previews/user_mailer_preview.rb
@@ -153,19 +153,16 @@ class UserMailerPreview < ApplicationMailerPreview
     UserMailer.invitation_to_claim(invitation.id, archivist.login)
   end
 
-
   # URL: /rails/mailers/user_mailer/invitation
   def invitation_by_other_user
     inviting_user = create(:user)
     invitation = create(:invitation, creator: inviting_user)
-    user = create(:user, :for_mailer_preview)
     UserMailer.invitation(invitation.id)
   end
 
   # URL: /rails/mailers/user_mailer/invitation
   def invitation_by_queue
     invitation = create(:invitation)
-    user = create(:user, :for_mailer_preview)
     UserMailer.invitation(invitation.id)
   end
 

--- a/test/mailers/previews/user_mailer_preview.rb
+++ b/test/mailers/previews/user_mailer_preview.rb
@@ -157,12 +157,14 @@ class UserMailerPreview < ApplicationMailerPreview
   def invitation_by_other_user
     inviting_user = create(:user)
     invitation = create(:invitation, creator: inviting_user)
+    user = create(:user, :for_mailer_preview)
     UserMailer.invitation(invitation.id)
   end
 
   # URL: /rails/mailers/user_mailer/invitation
   def invitation_by_queue
     invitation = create(:invitation)
+    user = create(:user, :for_mailer_preview)
     UserMailer.invitation(invitation.id)
   end
 

--- a/test/mailers/previews/user_mailer_preview.rb
+++ b/test/mailers/previews/user_mailer_preview.rb
@@ -157,14 +157,12 @@ class UserMailerPreview < ApplicationMailerPreview
   def invitation_by_other_user
     inviting_user = create(:user)
     invitation = create(:invitation, creator: inviting_user)
-    user = create(:user, :for_mailer_preview)
     UserMailer.invitation(invitation.id)
   end
 
   # URL: /rails/mailers/user_mailer/invitation
   def invitation_by_queue
     invitation = create(:invitation)
-    user = create(:user, :for_mailer_preview)
     UserMailer.invitation(invitation.id)
   end
 


### PR DESCRIPTION
# Pull Request Checklist

<!-- Mark steps in the checklist as complete by changing `[ ]` to `[X]` -->
* [X] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [X] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [X ] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [X] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [X] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.
  

## Issue

[https://otwarchive.atlassian.net/browse/AO3-7035](https://otwarchive.atlassian.net/browse/AO3-7035)

## Purpose

This PR introduces the Invitation Mailer Preview functionality and conducts a required I18n refactoring of the invitation email. The refactoring eliminates unsafe practices (like html_safe and view helpers for formatting) to improve code maintainability, rendering safety, and compliance with current I18n standards.

## Changes Included

- **Added Mailer Preview** (`invitation_mailer_preview.rb`): A new preview class was added, featuring two necessary variants:
   - `invitation_by_other_user`: Previews the mailer when an inviter's username is present in the greeting.
   - ` invitation_by_queue`: Previews the generic mailer greeting when the invitation is system-generated.
- **Refactored I18n Keys** (`config/locales/*.en.yml`) and Templates(`app/views/user_mailer/invitation.*.erb`):
   - Eliminated the use of `html_safe` from all calls in `app/views/user_mailer/invitation.*.erb`.
   - Refactored Locale Keys (`config/locales/*.en.yml`): Separated nested keys (e.g., `.html.about`) into the standard structure (`.about.html` and `.about.text`). This ensures the I18n system correctly prevents raw HTML from showing in the final message while allowing helpers to be used in the HTML view.
   - Resolved Issue: This refactoring inherently fixed the issues with exposed HTML tags and eliminated the variable mismatch errors encountered during development.


## Credit
Dcano-png (She/Her)
