### PR TITLE
AO3-3620 Fix subscriptions to other creator(s) for works co-authored with orphan_account

### DIFF
--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -37,13 +37,23 @@ class Subscription < ApplicationRecord
     end
   end
 
+  def creator_no_longer_associated_with?(creation)
+    return false unless subscribable_type == "User"
+
+    # If any of the creation's pseud's users matches the subscribable, then the
+    # creator still matches, so we return "true"
+    return false if creation.pseuds.any? { |p| p.user == subscribable }
+
+    # We reach this case if e.g. someone is subscribed to a user, but they
+    # orphan the work before the subscription notification would be sent
+    return true
+
   # Guard against scenarios that may break anonymity or other things.
   # Emails should only contain works or chapters.
   # Emails should only contain posted works or chapters.
   # Emails should never contain chapters of draft works.
   # Emails should never contain hidden works or chapters of hidden works.
-  # Emails should never contain orphaned works or chapters.
-  # TODO: AO3-3620 & AO3-5696: Allow subscriptions to orphan_account to receive notifications.
+  # Emails should not contain orphaned works or chapters if the subscription is to a creator no longer associated with the work
   # Emails for user subs should never contain anon works or chapters.
   # Emails for work subs should never contain anything but chapters.
   # TODO: AO3-1250: Anon series subscription improvements
@@ -52,7 +62,7 @@ class Subscription < ApplicationRecord
     return false unless creation.try(:posted)
     return false if creation.is_a?(Chapter) && !creation.work.try(:posted)
     return false if creation.try(:hidden_by_admin) || (creation.is_a?(Chapter) && creation.work.try(:hidden_by_admin))
-    return false if creation.pseuds.any? { |p| p.user == User.orphan_account }
+    return false if creator_no_longer_associated_with?(creation)
     return false if subscribable_type == "User" && creation.anonymous?
     return false if subscribable_type == "Work" && !creation.is_a?(Chapter)
 

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -38,6 +38,7 @@ class Subscription < ApplicationRecord
   end
 
   def creator_no_longer_associated_with?(creation)
+    # If we're subscribed to a work or series, it doesn't matter who the creator is, we should send the notification
     return false unless subscribable_type == "User"
 
     # If any of the creation's pseud's users matches the subscribable, then the
@@ -46,7 +47,8 @@ class Subscription < ApplicationRecord
 
     # We reach this case if e.g. someone is subscribed to a user, but they
     # orphan the work before the subscription notification would be sent
-    return true
+    true
+  end
 
   # Guard against scenarios that may break anonymity or other things.
   # Emails should only contain works or chapters.

--- a/features/other_a/orphan_work.feature
+++ b/features/other_a/orphan_work.feature
@@ -8,9 +8,9 @@ Feature: Orphan work
   Background:
     Given I have an orphan account
       And the following activated users exists
-      | login             | password   | email                     |
-      | orphaneer         | password   | orphaneer@foo.com         |
-      | author_subscriber | password   | author_subscriber@foo.com |
+      | login             | password | email                     |
+      | orphaneer         | password | orphaneer@foo.com         |
+      | author_subscriber | password | author_subscriber@foo.com |
       And "author_subscriber" subscribes to author "orphaneer"
       And all emails have been delivered
       And I am logged in as "orphaneer"
@@ -53,7 +53,7 @@ Feature: Orphan work
     When I follow "Orphan Work"
     Then I should see "Read More About The Orphaning Process"
     When I choose "Leave a copy of my pseud on"
-    And I press "Yes, I'm sure"
+      And I press "Yes, I'm sure"
     Then I should see "Orphaning was successful."
     When I go to orphaneer's works page
     Then I should not see "Shenanigans2"
@@ -84,68 +84,76 @@ Feature: Orphan work
     Then 0 emails should be delivered
 
 
-  Scenario: Orphan a work (leave pseud) and don't notify subscribers to the work
+  Scenario: Orphan a work (leave pseud) but do notify subscribers to the work
 
     Given the following activated user exists
-      | login             | password   | email                    |
-      | work_subscriber   | password   | work_subscriber@foo.com  |
+      | login           | password | email                   |
+      | work_subscriber | password | work_subscriber@foo.com |
       And I post the work "Torrid Idfic"
       And I am logged in as "work_subscriber"
       And I view the work "Torrid Idfic"
       And I press "Subscribe"
+      And I am logged in as "orphaneer"
       And a chapter is added to "Torrid Idfic"
       And I follow "Edit"
       And I follow "Orphan Work"
       And I choose "Leave a copy of my pseud on"
       And I press "Yes, I'm sure"
     When subscription notifications are sent
-    Then 0 emails should be delivered
+    Then 1 email should be delivered
 
 
-  Scenario: Orphan a work (leave pseud) and don't notify subscribers to the work's series
+  Scenario: Orphan a work (leave pseud) but do notify subscribers to the work's series
 
+    # Make the series exist, but make sure the initial work doesn't
+    # send an email for series_subscriber
     Given the following activated user exists
-      | login             | password   | email                     |
-      | series_subscriber | password   | series_subscriber@foo.com |
-      And I add the work "Lazy Purple Sausage" to series "Shame Series"
-      And I am logged in as "series_subscriber"
+      | login             | password | email                     |
+      | series_subscriber | password | series_subscriber@foo.com |
+      And I add the work "Work to create the series" to series "Shame Series"
+    When subscription notifications are sent
+    Then 0 emails should be delivered
+    # Subscribe
+    When I am logged in as "series_subscriber"
       And I view the series "Shame Series"
       And I press "Subscribe"
+      # Add a new work to the series, which we then immediately orphan
       And I am logged in as "orphaneer"
+      And I add the work "Lazy Purple Sausage" to series "Shame Series"
       And I view the work "Lazy Purple Sausage"
       And I follow "Edit"
       And I follow "Orphan Work"
       And I choose "Leave a copy of my pseud on"
       And I press "Yes, I'm sure"
     When subscription notifications are sent
-    Then 0 emails should be delivered
+    Then 1 email should be delivered
 
   Scenario: I can orphan multiple works at once
-  Given I am logged in as "author"
-    And I post the work "Glorious" with fandom "SGA"
-    And I post the work "Excellent" with fandom "Star Trek"
-    And I post the work "Lovely" with fandom "Steven Universe"
-    And I go to author's works page
-  When I follow "Edit Works"
-  Then I should see "Edit Multiple Works"
-  When I select "Glorious" for editing
-    And I select "Excellent" for editing
-    And I press "Delete"
-  Then I should see "Are you sure you want to delete these works PERMANENTLY?"
-    And I should see "Glorious"
-    And I should see "Excellent"
-    And I should not see "Lovely"
-    # Delay before orphaning to make sure the cache is expired
-    And it is currently 1 second from now
-  When I follow "Orphan Works Instead"
-  Then I should see "Orphaning a work removes it from your account and re-attaches it to the specially created orphan_account."
-  When I press "Yes, I'm sure"
-    And all indexing jobs have been run
-  Then I should see "Orphaning was successful."
-  When I go to author's works page
-  Then I should not see "Glorious"
-    And I should not see "Excellent"
-    And I should see "Lovely"
+    Given I am logged in as "author"
+      And I post the work "Glorious" with fandom "SGA"
+      And I post the work "Excellent" with fandom "Star Trek"
+      And I post the work "Lovely" with fandom "Steven Universe"
+      And I go to author's works page
+    When I follow "Edit Works"
+    Then I should see "Edit Multiple Works"
+    When I select "Glorious" for editing
+      And I select "Excellent" for editing
+      And I press "Delete"
+    Then I should see "Are you sure you want to delete these works PERMANENTLY?"
+      And I should see "Glorious"
+      And I should see "Excellent"
+      And I should not see "Lovely"
+      # Delay before orphaning to make sure the cache is expired
+      And it is currently 1 second from now
+    When I follow "Orphan Works Instead"
+    Then I should see "Orphaning a work removes it from your account and re-attaches it to the specially created orphan_account."
+    When I press "Yes, I'm sure"
+      And all indexing jobs have been run
+    Then I should see "Orphaning was successful."
+    When I go to author's works page
+    Then I should not see "Glorious"
+      And I should not see "Excellent"
+      And I should see "Lovely"
 
   Scenario: Orphaning a shared work should not affect chapters created solely by the other creator
 

--- a/features/other_a/orphan_work.feature
+++ b/features/other_a/orphan_work.feature
@@ -90,7 +90,10 @@ Feature: Orphan work
       | login           | password | email                   |
       | work_subscriber | password | work_subscriber@foo.com |
       And I post the work "Torrid Idfic"
-      And I am logged in as "work_subscriber"
+    # FIXME: remove, I'm just trying to understand email logic
+    When subscription notifications are sent
+    Then 0 emails should be delivered to "series_subscriber@foo.com"
+    When I am logged in as "work_subscriber"
       And I view the work "Torrid Idfic"
       And I press "Subscribe"
       And I am logged in as "orphaneer"
@@ -102,6 +105,17 @@ Feature: Orphan work
     When subscription notifications are sent
     Then 1 email should be delivered
 
+  # FIXME: remove duplicate
+  Scenario: Test initial email is 0
+
+    # Make the series exist, but make sure the initial work doesn't
+    # send an email for series_subscriber
+    Given the following activated user exists
+      | login             | password | email                     |
+      | series_subscriber | password | series_subscriber@foo.com |
+      And I add the work "Work to create the series" to series "Shame Seriesss"
+    When subscription notifications are sent
+    Then 0 emails should be delivered to "series_subscriber@foo.com"
 
   Scenario: Orphan a work (leave pseud) but do notify subscribers to the work's series
 
@@ -112,7 +126,7 @@ Feature: Orphan work
       | series_subscriber | password | series_subscriber@foo.com |
       And I add the work "Work to create the series" to series "Shame Series"
     When subscription notifications are sent
-    Then 0 emails should be delivered
+    Then 0 emails should be delivered to "series_subscriber@foo.com"
     # Subscribe
     When I am logged in as "series_subscriber"
       And I view the series "Shame Series"
@@ -126,7 +140,7 @@ Feature: Orphan work
       And I choose "Leave a copy of my pseud on"
       And I press "Yes, I'm sure"
     When subscription notifications are sent
-    Then 1 email should be delivered
+    Then 1 email should be delivered to "series_subscriber@foo.com"
 
   Scenario: I can orphan multiple works at once
     Given I am logged in as "author"

--- a/features/other_a/orphan_work.feature
+++ b/features/other_a/orphan_work.feature
@@ -90,10 +90,7 @@ Feature: Orphan work
       | login           | password | email                   |
       | work_subscriber | password | work_subscriber@foo.com |
       And I post the work "Torrid Idfic"
-    # FIXME: remove, I'm just trying to understand email logic
-    When subscription notifications are sent
-    Then 0 emails should be delivered to "series_subscriber@foo.com"
-    When I am logged in as "work_subscriber"
+      And I am logged in as "work_subscriber"
       And I view the work "Torrid Idfic"
       And I press "Subscribe"
       And I am logged in as "orphaneer"
@@ -105,30 +102,15 @@ Feature: Orphan work
     When subscription notifications are sent
     Then 1 email should be delivered
 
-  # FIXME: remove duplicate
-  Scenario: Test initial email is 0
-
-    # Make the series exist, but make sure the initial work doesn't
-    # send an email for series_subscriber
-    Given the following activated user exists
-      | login             | password | email                     |
-      | series_subscriber | password | series_subscriber@foo.com |
-      And I add the work "Work to create the series" to series "Shame Seriesss"
-    When subscription notifications are sent
-    Then 0 emails should be delivered to "series_subscriber@foo.com"
-
   Scenario: Orphan a work (leave pseud) but do notify subscribers to the work's series
 
-    # Make the series exist, but make sure the initial work doesn't
-    # send an email for series_subscriber
     Given the following activated user exists
       | login             | password | email                     |
       | series_subscriber | password | series_subscriber@foo.com |
+      # Create the series, so we can subscribe to it before we add a work-to-be-orphaned
       And I add the work "Work to create the series" to series "Shame Series"
-    When subscription notifications are sent
-    Then 0 emails should be delivered to "series_subscriber@foo.com"
-    # Subscribe
-    When I am logged in as "series_subscriber"
+      # Subscribe
+      And I am logged in as "series_subscriber"
       And I view the series "Shame Series"
       And I press "Subscribe"
       # Add a new work to the series, which we then immediately orphan

--- a/features/other_a/orphan_work.feature
+++ b/features/other_a/orphan_work.feature
@@ -122,7 +122,7 @@ Feature: Orphan work
       And I choose "Leave a copy of my pseud on"
       And I press "Yes, I'm sure"
     When subscription notifications are sent
-    Then 1 email should be delivered to "series_subscriber@foo.com"
+    Then 1 email should be delivered
 
   Scenario: I can orphan multiple works at once
     Given I am logged in as "author"

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -740,6 +740,7 @@ describe UserMailer do
         let(:creator2) { create(:user).default_pseud }
         let(:work) { create(:work, authors: [creator1, creator2]) }
         let(:chapter) { create(:chapter, work: work, authors: [creator1]) }
+        let(:subscription) { create(:subscription, subscribable: creator1.user) }
 
         it "has the correct subject line" do
           subject = "[#{ArchiveConfig.APP_SHORT_NAME}] #{creator1.byline} posted #{chapter.chapter_header} of #{work.title}"

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require "spec_helper"
 
 describe Subscription do
   let(:subscription) { build(:subscription) }
@@ -22,7 +22,8 @@ describe Subscription do
       end
 
       it "should be destroyed" do
-        expect { subscription.reload }.to raise_error ActiveRecord::RecordNotFound
+        expect { subscription.reload }
+          .to raise_error ActiveRecord::RecordNotFound
       end
     end
   end
@@ -43,7 +44,8 @@ describe Subscription do
       end
 
       it "should be destroyed" do
-        expect { subscription.reload }.to raise_error ActiveRecord::RecordNotFound
+        expect { subscription.reload }
+          .to raise_error ActiveRecord::RecordNotFound
       end
     end
   end
@@ -64,7 +66,8 @@ describe Subscription do
       end
 
       it "should be destroyed" do
-        expect { subscription.reload }.to raise_error ActiveRecord::RecordNotFound
+        expect { subscription.reload }
+          .to raise_error ActiveRecord::RecordNotFound
       end
     end
   end
@@ -117,7 +120,7 @@ describe Subscription do
     let(:chapter) { create(:chapter, authors: [author_pseud]) }
     let(:anon_work) { create(:work, authors: [author_pseud], collections: [build(:anonymous_collection)]) }
     let(:anon_series) { create(:series, works: [anon_work]) }
-    let(:anon_chapter) { create(:chapter, authors:[author_pseud], work: anon_work) }
+    let(:anon_chapter) { create(:chapter, authors: [author_pseud], work: anon_work) }
     let(:orphan_pseud) { create(:user, login: "orphan_account").default_pseud }
 
     it "returns false when the creation is nil" do
@@ -134,7 +137,7 @@ describe Subscription do
       end
 
       it "returns false when the creation is hidden_by_admin" do
-        expect(subscription.valid_notification_entry?(build(:work, hidden_by_admin: true))).to be_falsey
+        expect(subscription.valid_notification_entry?(build(:work, hidden_by_admin: true))).to be_truthy
       end
     end
 
@@ -203,7 +206,6 @@ describe Subscription do
       end
 
       it "returns true for a non-anonymous chapter" do
-        expect(chapter.pseuds).to contain(author_pseud)
         expect(subscription.valid_notification_entry?(chapter)).to be_truthy
       end
 

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -200,7 +200,7 @@ describe Subscription do
 
       it "returns true for a non-anonymous work" do
         # FIXME: make sure subscription is being set up properly
-        expect(subscribable.subscribable_type).to be("User")
+        expect(subscription.subscribable_type).to be("User")
         expect(subscription.valid_notification_entry?(work)).to be_truthy
       end
 

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -114,10 +114,10 @@ describe Subscription do
     let(:author_pseud) { create(:user).default_pseud }
     let(:work) { create(:work, authors: [author_pseud]) }
     let(:draft) { build(:draft) }
-    let(:chapter) { build(:chapter, authors: [author_pseud]) }
-    let(:anon_work) { build(:work, authors: [author_pseud], collections: [build(:anonymous_collection)]) }
-    let(:anon_series) { build(:series, works: [anon_work]) }
-    let(:anon_chapter) { build(:chapter, authors:[author_pseud], work: anon_work) }
+    let(:chapter) { create(:chapter, authors: [author_pseud]) }
+    let(:anon_work) { create(:work, authors: [author_pseud], collections: [build(:anonymous_collection)]) }
+    let(:anon_series) { create(:series, works: [anon_work]) }
+    let(:anon_chapter) { create(:chapter, authors:[author_pseud], work: anon_work) }
     let(:orphan_pseud) { create(:user, login: "orphan_account").default_pseud }
 
     it "returns false when the creation is nil" do

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -199,8 +199,6 @@ describe Subscription do
       let(:subscription) { build(:subscription, subscribable: author_pseud.user) }
 
       it "returns true for a non-anonymous work" do
-        # FIXME: make sure subscription is being set up properly
-        expect(subscription.subscribable_type).to be("User")
         expect(subscription.valid_notification_entry?(work)).to be_truthy
       end
 

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -137,7 +137,7 @@ describe Subscription do
       end
 
       it "returns false when the creation is hidden_by_admin" do
-        expect(subscription.valid_notification_entry?(build(:work, hidden_by_admin: true))).to be_truthy
+        expect(subscription.valid_notification_entry?(build(:work, hidden_by_admin: true))).to be_falsey
       end
     end
 

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -111,8 +111,7 @@ describe Subscription do
   describe "#valid_notification_entry?" do
     let(:subscription) { build(:subscription) }
     let(:series) { build(:series) }
-    let(:author) { create(:user) }
-    let(:author_pseud) { author.default_pseud }
+    let(:author_pseud) { create(:user).default_pseud }
     let(:work) { create(:work, authors: [author_pseud]) }
     let(:draft) { build(:draft) }
     let(:chapter) { build(:chapter, authors: [author_pseud]) }
@@ -197,9 +196,11 @@ describe Subscription do
     end
 
     context "when subscribable is a user" do
-      let(:subscription) { build(:subscription, subscribable_type: "User", subscribable: author) }
+      let(:subscription) { build(:subscription, subscribable: author_pseud.user) }
 
       it "returns true for a non-anonymous work" do
+        # FIXME: make sure subscription is being set up properly
+        expect(subscribable.subscribable_type).to be("User")
         expect(subscription.valid_notification_entry?(work)).to be_truthy
       end
 

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -203,6 +203,7 @@ describe Subscription do
       end
 
       it "returns true for a non-anonymous chapter" do
+        expect(chapter.pseuds).to contain(author_pseud)
         expect(subscription.valid_notification_entry?(chapter)).to be_truthy
       end
 


### PR DESCRIPTION
# Pull Request Checklist

<!-- Mark steps in the checklist as complete by changing `[ ]` to `[X]` -->
* [x] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [X] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [X] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [x] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-3620

## Purpose

Instead of checking whether orphan account is one of the creators to block notifications for newly-orphaned works, checks whether the creator associated with the subscription is still associated with the creation

> [!NOTE]
> A lot of the issue instructions talk about removing the ability to subscribe to orphan account, which ~~appears to already be the case~~ (edit: I fully goofed here, I was logged out when I was looking at the orphan account page :joy::upside_down_face:), so I figured this issue was still open because of it breaking subscriptions to other creators, and named this PR after what it actually fixes

> [!NOTE]
> With this PR, if someone is subscribed to author A but not author B, where A and B are co-creators of a work, the user will NOT get a notification if author B adds a new chapter without author A

## Testing Instructions

How can the Archive's QA team verify that this is working as you intended?

1. Post a work with a co-creator
2. Have one of the co-creators orphan the work
3. Subscribe to the second creator
4. Have the second creator add a chapter to the work
5. Have a database admin send subscription notifications (bundle exec rake notifications:deliver_subscriptions) or wait for them to send
6. Verify that you received a notification for the new chapter

## References

Related issue: https://otwarchive.atlassian.net/browse/AO3-5696

## Credit

irrationalpie (they/them)
