### PR TITLE
AO3-7219 Keep users with 'show the whole work by default' enabled in chapter by chapter mode when commenting

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -384,7 +384,8 @@ class CommentsController < ApplicationController
             elsif @comment.unreviewed?
               redirect_to_all_comments(@commentable)
             else
-              redirect_to_comment(@comment, { view_full_work: (params[:view_full_work] == "true"), page: params[:page] })
+              user_chose_to_view_full_work = (current_user.try(:preference).try(:view_full_works) && params[:view_full_work] != "false")
+              redirect_to_comment(@comment, { view_full_work: (params[:view_full_work] == "true" || user_chose_to_view_full_work), page: params[:page] })
             end
           end
         end
@@ -689,7 +690,7 @@ class CommentsController < ApplicationController
                   page: options[:page],
                   anchor: options[:anchor])
     else
-      if commentable.is_a?(Chapter) && (options[:view_full_work] || current_user.try(:preference).try(:view_full_works))
+      if commentable.is_a?(Chapter) && (options[:view_full_work] || (current_user.try(:preference).try(:view_full_works) && options[:view_full_work] != false))
         commentable = commentable.work
       end
       redirect_to polymorphic_path(commentable,

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -55,8 +55,10 @@ class CommentsController < ApplicationController
 
   def check_pseud_ownership
     return unless params[:comment][:pseud_id]
+
     pseud = Pseud.find(params[:comment][:pseud_id])
     return if pseud && current_user && current_user.pseuds.include?(pseud)
+
     flash[:error] = ts("You can't comment with that pseud.")
     redirect_to root_path
   end
@@ -180,14 +182,17 @@ class CommentsController < ApplicationController
   def check_permission_to_review
     parent = find_parent
     return if logged_in_as_admin? || current_user_owns?(parent)
+
     flash[:error] = ts("Sorry, you don't have permission to see those unreviewed comments.")
     redirect_to logged_in? ? root_path : new_user_session_path(return_to: request.fullpath)
   end
 
   def check_permission_to_access_single_unreviewed
     return unless @comment.unreviewed?
+
     parent = find_parent
     return if logged_in_as_admin? || current_user_owns?(parent) || current_user_owns?(@comment)
+
     flash[:error] = ts("Sorry, that comment is currently in moderation.")
     redirect_to logged_in? ? root_path : new_user_session_path(return_to: request.fullpath)
   end
@@ -384,7 +389,9 @@ class CommentsController < ApplicationController
             elsif @comment.unreviewed?
               redirect_to_all_comments(@commentable)
             else
-              user_chose_to_view_full_work = (current_user.try(:preference).try(:view_full_works) && params[:view_full_work] != "false")
+              # keep the user in chapter by chapter view if that was the view they were in when they commented
+              # An entire work view url would look like works/:id
+              user_chose_to_view_full_work = (current_user.try(:preference).try(:view_full_works) && request.referer&.match(/chapters/).nil?)
               redirect_to_comment(@comment, { view_full_work: (params[:view_full_work] == "true" || user_chose_to_view_full_work), page: params[:page] })
             end
           end
@@ -690,8 +697,9 @@ class CommentsController < ApplicationController
                   page: options[:page],
                   anchor: options[:anchor])
     else
-      if commentable.is_a?(Chapter) && (options[:view_full_work] || (current_user.try(:preference).try(:view_full_works) && options[:view_full_work] != false))
-        commentable = commentable.work
+      if commentable.is_a?(Chapter)
+        user_chose_to_view_full_work = current_user.try(:preference).try(:view_full_works) && options[:view_full_work] != false 
+        commentable = commentable.work if options[:view_full_work] || user_chose_to_view_full_work
       end
       redirect_to polymorphic_path(commentable,
                                    options.slice(:show_comments,

--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -191,7 +191,7 @@ class WorksController < ApplicationController
 
     # Users must explicitly okay viewing of entire work
     if @work.chaptered?
-      if params[:view_full_work] || (logged_in? && current_user.preference.try(:view_full_works))
+      if params[:view_full_work] == "true" || (logged_in? && current_user.preference.try(:view_full_works) && params[:view_full_works] != "false")
         @chapters = @work.chapters_in_order(
           include_drafts: (logged_in_as_admin? ||
                            @work.user_is_owner_or_invited?(current_user))

--- a/features/comments_and_kudos/comments_redirect.feature
+++ b/features/comments_and_kudos/comments_redirect.feature
@@ -49,8 +49,7 @@ Scenario: Posting top level comment on a chaptered work, with view full work in 
     And I post a comment "Woohoo"
   Then I should see "Woohoo"
     And I should see "Chapter 2" within "div#chapters"
-    # Once you've commented, it defaults back to your preference
-    And I should see "Chapter 1" within "div#chapters"
+    And I should not see "Chapter 1" within "div#chapters"
 
 # REPLY COMMENTS
 


### PR DESCRIPTION
# Pull Request Checklist

<!-- Mark steps in the checklist as complete by changing `[ ]` to `[X]` -->
* [x] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [ ] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [x] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [x] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.


Note on tests:

I decided not to add tests since comments_controller_spec did not have any tests for the create endpoint, nor tests that would verify redirect_to_all_comments behaviors. works_controller_spec likewise only had tests for #navigate.

I'm assuming this was a conscious decision to avoid bogging down CI since there's a robust QA team. 

I'm happy to put in some extra work to add net new tests for these endpoints if the testing gap was due to lack of resources, but that would increase the scope of this PR.

## Issue

https://otwarchive.atlassian.net/browse/AO3-7219

## Purpose

Fix the bug where users who had "show the whole work by default" enabled were getting redirected to the full work view after commenting.

This was happening because we were showing the whole work

`if params[:view_full_work] || (logged_in? && current_user.preference.try(:view_full_works))`

Since `params[:view_full_work]` is either `"true"` or `"false"` this always evaluates to `true` if it is set.
But even if `params[:view_full_work] == "false"`, if the user had their preference set to `view_full_works`, we would have shown the full work view and not the chapter by chapter view.

There was also a routing error in the comments_controller where
`if commentable.is_a?(Chapter) && (options[:view_full_work] || current_user.try(:preference).try(:view_full_works))` we set the chapter commentable to a work commentable, which also routed to the entire work view.

I added the same logic here that I added in the works controller


## Testing Instructions
Reported bug
1. Log in
2. Have the "Show the whole work by default" preference enabled
3. Open a work in chapter by chapter mode
4. Leave a comment or reply to a comment on a chapter
5. Confirm users stays in chapter by chapter mode

Ensure other behavior did not change
1. Log in
2. Have the "Show the whole work by default" preference enabled
3. Open a work in entire work mode
4. Leave a comment or reply to a comment on a chapter
5. Confirm user stays in entire work mode, and that the new comment is tied to the last chapter


**Testing Notes**
While testing, I found that when the new comment would be in page 2+, the user does not get redirected to the comment section. This is an unrelated issue, and potentially a bug. To test

1. Log in
2. Open work in whatever mode
3. Leave a comment that would show in page 2 of the comments view
4. User is redirected to the work view upon submitting a comment, but the stays at the top of the page and does not get navigated to the comments box


How can the Archive's QA team verify that this is working as you intended?

If you have a Jira account with access, please update or comment on the issue
with any new or missing testing instructions instead.

You can remove this section if there are already full testing instructions in the Jira issue.

## Credit

What name and pronouns should we use to credit you in the [Archive of Our Own's Release Notes](https://archiveofourown.org/admin_posts?tag=1)?
Zooms, any pronoun

If you have a Jira account, please include the same name in the "Full name"
field on your Jira profile, so we can assign you the issues you're working on.

*Please note that if you do not fill in this section, we will use your GitHub account name and
they/them pronouns.*
