### PR TITLE
AO3-5748 Split off assignments with both offer and pinch hitter

### DIFF
--- a/app/controllers/challenge_assignments_controller.rb
+++ b/app/controllers/challenge_assignments_controller.rb
@@ -149,6 +149,7 @@ class ChallengeAssignmentsController < ApplicationController
     end
 
     ChallengeAssignment.update_placeholder_assignments!(@collection)
+    ChallengeAssignment.split_off_write_in_giver_assignments!(@collection)
     if @assignments.empty?
       flash[:notice] = "Assignments updated"
       redirect_to collection_potential_matches_path(@collection)

--- a/app/models/challenge_assignment.rb
+++ b/app/models/challenge_assignment.rb
@@ -496,4 +496,24 @@ class ChallengeAssignment < ApplicationRecord
       end
     end
   end
+
+  # create fresh new assignments for pinch hitters assigned alongside existing offer signups
+  def self.split_off_write_in_giver_assignments!(collection)
+    collection.assignments.each do |assignment|
+      assignment.split if assignment.double_assigned?
+    end
+  end
+
+  def double_assigned?
+    pinch_hitter && offer_signup && pinch_hitter.user != offering_user
+  end
+
+  def split
+    new_assignment = self.dup
+    new_assignment.offer_signup = nil
+    new_assignment.save!
+
+    self.pinch_hitter = nil
+    save!
+  end
 end


### PR DESCRIPTION
Split off assignments with both offer and pinch hitter


# Pull Request Checklist

<!-- Mark steps in the checklist as complete by changing `[ ]` to `[X]` -->
* [x] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [x] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [x] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [x] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-5748

## Purpose

What does this PR do?

Splits off assignments that have both an offer signup and a pinch hitter, into two separate assignments, one owned by the offering pseud, the other owned by the pinch hitter, neither leaking data about the other.

Usually, when a mod assigns a pinch-hitter through other means, a brand new ChallengeAssignment is created with a pinch_hitter_id (rather than adding a pinch_hitter_id to the existing ChallengeAssignment).

Let's do the same for the case of a pinch hitter being assigned at the same time as the offer signup.

We've chosen to do this at the point of saving the current configuration, so we can show the resulting assignments. We hope the maintainer won't double-assign again, thus causing a chain of splits.

The result, for a three-user challenge, will look something like this:

<img width="1089" height="628" alt="Screenshot 2026-01-22 at 03 03 16" src="https://github.com/user-attachments/assets/1c82626b-42fb-400d-9b35-0d564cfbd285" />

I've chosen to do this in a separate method, invoked after `update_placeholder_assignments!` has done its thing, because otherwise our freshly created assignment would have been deleted as being a "leftover placeholder" by the "# if this signup has at least one giver now, get rid of any leftover placeholders" check. I didn't want to mess with how leftover placeholders are defined, since we don't have any open issues about them. "If it ain't broke" etc.

## Testing Instructions

How can the Archive's QA team verify that this is working as you intended?

The JIRA issue has detailed instructions.

## References

Are there other relevant issues/pull requests/mailing list discussions? If not, you can remove this section.

Yes, this should also fix https://otwarchive.atlassian.net/browse/AO3-5752.

## Credit

What name and pronouns should we use to credit you in the [Archive of Our Own's Release Notes](https://archiveofourown.org/admin_posts?tag=1)?

alien, they/them
