### PR TITLE
AO3-7251 Index past emails/usernames from purpose-specific tables

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -523,10 +523,13 @@ class User < ApplicationRecord
   # Looks up all past values of the given field, excluding the current value of
   # the field:
   def historic_values(field)
-    if field == "login"
+    case field
+    when "login"
       past_usernames.pluck(:username).distinct
-    elsif field == "email"
+    when "email"
       past_emails.pluck(:email_address).distinct
+    else
+      # should never get here
     end
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -518,6 +518,18 @@ class User < ApplicationRecord
     IndexQueue.enqueue(self, :users)
   end
 
+  # Function to make it easier to retrieve info from the audits table.
+  #
+  # Looks up all past values of the given field, excluding the current value of
+  # the field:
+  def historic_values(field)
+    if field == "login"
+      past_usernames.pluck(:username).distinct
+    elsif field == "email"
+      past_emails.pluck(:email_address).distinct
+    end
+  end
+
   private
 
   # Override the default Justifiable enabled check, because we only need to justify

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -525,7 +525,7 @@ class User < ApplicationRecord
   def historic_values(field)
     field = field.to_s
 
-    audits.order(id: :desc).limit(ArchiveConfig.USER_HISTORIC_VALUES_LIMIT).filter_map do |audit|
+    audits.filter_map do |audit|
       audit.audited_changes[field]
     end.flatten.uniq.without(self[field])
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -518,18 +518,6 @@ class User < ApplicationRecord
     IndexQueue.enqueue(self, :users)
   end
 
-  # Function to make it easier to retrieve info from the audits table.
-  #
-  # Looks up all past values of the given field, excluding the current value of
-  # the field:
-  def historic_values(field)
-    field = field.to_s
-
-    audits.filter_map do |audit|
-      audit.audited_changes[field]
-    end.flatten.uniq.without(self[field])
-  end
-
   private
 
   # Override the default Justifiable enabled check, because we only need to justify

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -525,9 +525,9 @@ class User < ApplicationRecord
   def historic_values(field)
     case field
     when "login"
-      past_usernames.pluck(:username).distinct
+      past_usernames.pluck(:username).uniq
     when "email"
-      past_emails.pluck(:email_address).distinct
+      past_emails.pluck(:email_address).uniq
     end
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -528,8 +528,6 @@ class User < ApplicationRecord
       past_usernames.pluck(:username).distinct
     when "email"
       past_emails.pluck(:email_address).distinct
-    else
-      # should never get here
     end
   end
 

--- a/app/views/admin/admin_users/show.html.erb
+++ b/app/views/admin/admin_users/show.html.erb
@@ -41,14 +41,14 @@
       <dt><%= t(".info.role", count: @user.roles.size) %></dt>
       <dd><%= @user.roles.any? ? @user.roles.map { |role| t("activerecord.attributes.role.#{role.name}") }.to_sentence : t(".info.no_role") %></dd>
       <% if policy(User).can_view_past? %>
-        <% past_logins = @user.historic_values("login").compact %>
+        <% past_logins = @user.historic_values("login") %>
         <% if past_logins.present? %>
           <dt><%= t(".info.past_logins", count: past_logins.size) %></dt>
           <dd>
             <%= past_logins.to_sentence %>
           </dd>
         <% end %>
-        <% past_emails = @user.historic_values("email").compact %>
+        <% past_emails = @user.historic_values("email") %>
         <% if past_emails.present? %>
           <dt><%= t(".info.past_emails", count: past_emails.size) %></dt>
           <dd>

--- a/config/config.yml
+++ b/config/config.yml
@@ -230,9 +230,6 @@ TAGGINGS_COUNT_MIN_CACHE_COUNT: 1000
 # For tagging changes, we only reindex tags used less than a certain number of times
 TAGGINGS_COUNT_REINDEX_LIMIT: 1000
 
-# How many rows we should get from audits for historic email and login values for users
-USER_HISTORIC_VALUES_LIMIT: 10_000
-
 # how many signups in a challenge before we move to static summaries generated hourly
 MAX_SIGNUPS_FOR_LIVE_SUMMARY: 20
 

--- a/config/config.yml
+++ b/config/config.yml
@@ -230,6 +230,9 @@ TAGGINGS_COUNT_MIN_CACHE_COUNT: 1000
 # For tagging changes, we only reindex tags used less than a certain number of times
 TAGGINGS_COUNT_REINDEX_LIMIT: 1000
 
+# How many rows we should get from audits for backfilling user history tables
+USER_HISTORIC_VALUES_LIMIT: 10_000
+
 # how many signups in a challenge before we move to static summaries generated hourly
 MAX_SIGNUPS_FOR_LIVE_SUMMARY: 20
 


### PR DESCRIPTION
# Pull Request Checklist

<!-- Mark steps in the checklist as complete by changing `[ ]` to `[X]` -->
* [X] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [X] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [X] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [X] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [X] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-7251

## Purpose

This PR changes the admin past-user and past-email searching feature to use the more efficient tables created in AO3-7249 instead of querying the audits table each time, since that table can get very large and can't easily be indexed

## Testing Instructions

See Jira issue

## References

Reverts AO3-7216, which was a hotfix this PR solves properly

Dependent on AO3-7249, branched off from that PR. Can't be merged before that PR is merged first. Also had a merge conflict with AO3-7060

## Credit

kiyazz (he/him)
