### PR TITLE
AO3-7286 Fix spamban page header to display username and ID

### DIFF
--- a/app/views/admin/admin_users/confirm_delete_user_creations.html.erb
+++ b/app/views/admin/admin_users/confirm_delete_user_creations.html.erb
@@ -1,5 +1,5 @@
 <!--Descriptive page name, messages and instructions-->
-<h2 class="heading"><%= t(".page_heading") %></h2>
+<h2 class="heading"><%= t(".page_heading", login: @user.login, id: @user.id) %></h2>
 
 <!--main content-->
 <%= form_tag destroy_user_creations_admin_user_path(@user), method: :post, class: "simple destroy" do %>

--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -177,7 +177,7 @@ en:
       confirm_delete_user_creations:
         caution_html: Are you sure you want to <strong><em>delete</em></strong> all the works and comments created by this user, along with their %{bookmarks} bookmarks, %{series} series, and %{collections} collections? This <strong>cannot be undone</strong>.
         confirm: Are you sure? Remember this will destroy ALL these objects!
-        page_heading: 'Delete Spammer Creations by %{login} (%{id})'
+        page_heading: Delete Spammer Creations by %{login} (%{id})
         submit: Yes, Delete All Spammer Creations
       creations:
         navigation:

--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -177,7 +177,7 @@ en:
       confirm_delete_user_creations:
         caution_html: Are you sure you want to <strong><em>delete</em></strong> all the works and comments created by this user, along with their %{bookmarks} bookmarks, %{series} series, and %{collections} collections? This <strong>cannot be undone</strong>.
         confirm: Are you sure? Remember this will destroy ALL these objects!
-        page_heading: Delete Spammer Creations
+        page_heading: 'Delete Spammer Creations by %{login} (%{id})'
         submit: Yes, Delete All Spammer Creations
       creations:
         navigation:


### PR DESCRIPTION
# Pull Request Checklist

* [X] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [X] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [ ] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)? 
* [X] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [X] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-7286

## Purpose

The spamban confirmation page now displays the username and user ID of the user to be banned.

## Credit

James Unsworth (he/him)
