### PR TITLE
AO3-6520 Use higher contrast visited link hover color in Reversi

### DIFF
--- a/public/stylesheets/masters/reversi/reversi_site_screen_.css
+++ b/public/stylesheets/masters/reversi/reversi_site_screen_.css
@@ -162,20 +162,6 @@ fieldset fieldset.listbox,
   box-shadow: inset 1px 1px 3px #000;
 }
 
-#footer a:hover,
-#footer a:focus,
-#footer button:hover,
-#footer button:focus,
-.autocomplete .dropdown ul li:hover,
-.autocomplete .dropdown li.selected,
-a.tag:hover,
-.listbox .heading a.tag:visited:hover,
-.symbol .question,
-.qtip-content {
-  background: #5998D6;
-  color: #111;
-}
-
 .splash .favorite li:nth-of-type(odd) a:hover,
 .splash .favorite li:nth-of-type(odd) a:focus {
   background: #5998D6;
@@ -203,6 +189,8 @@ span.claimed,
 .droppable,
 span.requested,
 a.work,
+a:visited:hover,
+.splash .browse li a:visited:hover,
 .blurb h4 a:link,
 .blurb h4 img,
 .splash .module h3,
@@ -215,6 +203,20 @@ a.cloud7,
 a.cloud8,
 #tos_prompt .heading {
   color: #5998D6;
+}
+
+#footer a:hover,
+#footer a:focus,
+#footer button:hover,
+#footer button:focus,
+.autocomplete .dropdown ul li:hover,
+.autocomplete .dropdown li.selected,
+a.tag:hover,
+.listbox .heading a.tag:visited:hover,
+.symbol .question,
+.qtip-content {
+  background: #5998D6;
+  color: #111;
 }
 
 #greeting .icon,


### PR DESCRIPTION
# Pull Request Checklist

<!-- Mark steps in the checklist as complete by changing `[ ]` to `[X]` -->
* [X ] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [X ] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [ X] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [ X] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [ X] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-6520

## Purpose

Already visited links are dark gray on hover in the Reversi skin which is low contrast. The Jira issue was for work links but this affects most visited links on the site. I changed the hover color to be the same blue that unvisited links are. There are a few ways that this issue could be fixed but I figured this was the easiest and most straightforward. This does affect links in paragraphs like the about section (shown below), which were previously white. Further specificity can be added for these links if the hover to white is preferred.

Also moved the tag:hover and some footer styles below the a:visited:hover list. This is because the tag:hover needs to be below a:visited:hover in order to have the color for the text properly set. Otherwise the blue color takes priority in CSS stylesheet rules. These lists do not share style specificities so there should not be an issue in rearranging them.

## Testing Instructions

See instructions in Jira issue. This affects any previously visited links and the li for work categories on the home page.
<img width="917" height="432" alt="Screenshot 2026-03-09 at 2 44 23 PM" src="https://github.com/user-attachments/assets/cda0bd09-e641-4bae-b083-e3af4135698d" />
<img width="978" height="455" alt="Screenshot 2026-03-09 at 2 44 16 PM" src="https://github.com/user-attachments/assets/86284500-f4b6-41f2-9d4b-571761f7a6b2" />
<img width="1137" height="227" alt="Screenshot 2026-03-09 at 2 44 38 PM" src="https://github.com/user-attachments/assets/e8c70bd1-4956-4b11-a167-8816c0912393" />
<img width="1113" height="215" alt="Screenshot 2026-03-09 at 2 44 45 PM" src="https://github.com/user-attachments/assets/0278203a-5dc4-4b42-9a1f-49ba65993521" />


## Credit

Rhyme Dochtermann She/Her
