### PR TITLE
AO3-7334 Co-Creator Requests page missing username in browser page title

### DIFF
--- a/app/views/creatorships/show.html.erb
+++ b/app/views/creatorships/show.html.erb
@@ -1,5 +1,7 @@
 <!--Descriptive page name, messages and instructions-->
-<h2 class="heading"><%= ts("Co-Creator Requests") %></h2>
+<h2 class="heading">
+  <%= @user.login %> - <%= ts("Co-Creator Requests") %>
+</h2>
 <!--/descriptions-->
 
 <!--subnav-->


### PR DESCRIPTION
# Pull Request Checklist

<!-- Mark steps in the checklist as complete by changing `[ ]` to `[X]` -->
* [x] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [x] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [x] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [x] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-7334 

## Purpose

This PR adds in the username to the header of the Co-Creator Requests page. Previously was just "Co-Creator Requests" and is now "username - Co-Creator Requests"

## Credit

Nell Webber (she/her/hers)
