### PR TITLE
AO3-7342 Update embed sanitizer to new Allow syntax

### DIFF
--- a/lib/otw_sanitize/embed_sanitizer.rb
+++ b/lib/otw_sanitize/embed_sanitizer.rb
@@ -189,7 +189,7 @@ module OtwSanitize
     # Restrict the iframe "allow" attribute to only the "fullscreen" directive.
     # Removes the attribute entirely if "fullscreen" is not present.
     def restrict_iframe_allow_attribute
-      return unless node["allow"].present?
+      return if node["allow"].blank?
 
       if node["allow"].split(/[\s;,]+/).include?("fullscreen")
         node["allow"] = "fullscreen"

--- a/lib/otw_sanitize/embed_sanitizer.rb
+++ b/lib/otw_sanitize/embed_sanitizer.rb
@@ -161,7 +161,7 @@ module OtwSanitize
             allowfullscreen height src type width
           ] + optional_embed_attributes,
           "iframe" => %w[
-            allowfullscreen frameborder height src title
+            allow allowfullscreen frameborder height src title
             class type width
           ]
         }
@@ -171,6 +171,7 @@ module OtwSanitize
         disable_scripts(node)
         node["flashvars"] = "" unless allows_flashvars?
       end
+      restrict_iframe_allow_attribute if node_name == "iframe"
       { node_allowlist: [node] }
     end
 
@@ -182,6 +183,18 @@ module OtwSanitize
       embed_node.search("param").each do |param_node|
         param_node.unlink if param_node[:name].casecmp?("allowscriptaccess") ||
                              param_node[:name].casecmp?("allownetworking")
+      end
+    end
+
+    # Restrict the iframe "allow" attribute to only the "fullscreen" directive.
+    # Removes the attribute entirely if "fullscreen" is not present.
+    def restrict_iframe_allow_attribute
+      return unless node["allow"].present?
+
+      if node["allow"].split(/[\s;,]+/).include?("fullscreen")
+        node["allow"] = "fullscreen"
+      else
+        node.remove_attribute("allow")
       end
     end
 

--- a/spec/lib/html_cleaner_spec.rb
+++ b/spec/lib/html_cleaner_spec.rb
@@ -63,6 +63,31 @@ describe HtmlCleaner do
           expect(result).to be_empty
         end
 
+        it "keeps allow=\"fullscreen\" on iframes from allowed sources" do
+          html = '<iframe width="560" height="315" src="//vimeo.com/embed/123" allow="fullscreen" frameborder="0"></iframe>'
+          result = sanitize_value(field, html)
+          expect(result).to include('allow="fullscreen"')
+        end
+
+        it "restricts allow attribute to just fullscreen" do
+          html = '<iframe width="560" height="315" src="//vimeo.com/embed/123" allow="fullscreen; autoplay" frameborder="0"></iframe>'
+          result = sanitize_value(field, html)
+          expect(result).to include('allow="fullscreen"')
+          expect(result).not_to include("autoplay")
+        end
+
+        it "strips allow attribute if it does not include fullscreen" do
+          html = '<iframe width="560" height="315" src="//vimeo.com/embed/123" allow="autoplay" frameborder="0"></iframe>'
+          result = sanitize_value(field, html)
+          expect(result).not_to include("allow=")
+        end
+
+        it "keeps legacy allowfullscreen on iframes" do
+          html = '<iframe width="560" height="315" src="//vimeo.com/embed/123" allowfullscreen frameborder="0"></iframe>'
+          result = sanitize_value(field, html)
+          expect(result).to include("allowfullscreen")
+        end
+
         %w[criticalcommons.org].each do |source|
           it "doesn't convert src to https for #{source}" do
             html = '<iframe width="560" height="315" src="http://' + source + '/embed/123" frameborder="0"></iframe>'


### PR DESCRIPTION
# Pull Request Checklist

* [X] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [X] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [X] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [X] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [X] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-7342

## Purpose

Support the modern `allow="fullscreen"` attribute on iframe embeds alongside the legacy `allowfullscreen` boolean attribute. The `allow` attribute value is restricted to just `"fullscreen"` per ADT recommendation, stripping any other directives. This fixes fullscreen for embeds (e.g. Vimeo) that have switched to the new syntax.

## Testing Instructions

1. In a work or other field that allows media embeds, paste a Vimeo (or similar) iframe embed that uses `allow="fullscreen"` instead of `allowfullscreen`.
2. Verify fullscreen works on the embedded player.
3. Verify an iframe with `allow="fullscreen; autoplay"` is sanitized down to `allow="fullscreen"` only.
4. Verify an iframe with `allow="autoplay"` (no fullscreen) has the `allow` attribute stripped entirely.
5. Verify old embeds using the legacy `allowfullscreen` attribute still work.

## Credit

varram (he/him)