### PR TITLE
AO3-4583 Fix redirect when creating top-level comment on work with multiple pages of comments

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -427,6 +427,7 @@ class CommentsController < ApplicationController
               # rubocop:disable Metrics/BlockNesting
               view_full_work = params[:view_full_work] == "true"
               parent = view_full_work || current_user&.preference&.view_full_works? ? @comment.ultimate_parent : @comment.parent
+              # if this comment starts a new top-level thread, it will always be on the last page of comments
               page = parent.comments.reviewed.count.ceildiv(Comment.per_page) if @comment.thread == @comment.id
               redirect_to_comment(@comment, { view_full_work: view_full_work, page: page || params[:page] })
               # rubocop:enable Metrics/BlockNesting

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -424,7 +424,12 @@ class CommentsController < ApplicationController
             elsif @comment.unreviewed?
               redirect_to_all_comments(@commentable)
             else
-              redirect_to_comment(@comment, { view_full_work: (params[:view_full_work] == "true"), page: params[:page] })
+              # rubocop:disable Metrics/BlockNesting
+              view_full_work = params[:view_full_work] == "true"
+              parent = view_full_work || current_user&.preference&.view_full_works? ? @comment.ultimate_parent : @comment.parent
+              page = parent.comments.reviewed.count.ceildiv(Comment.per_page) if @comment.thread == @comment.id
+              redirect_to_comment(@comment, { view_full_work: view_full_work, page: page || params[:page] })
+              # rubocop:enable Metrics/BlockNesting
             end
           end
         end

--- a/features/comments_and_kudos/comments_redirect.feature
+++ b/features/comments_and_kudos/comments_redirect.feature
@@ -117,3 +117,55 @@ Scenario: Posting top level comment on a middle chapter, while in temporary view
     And I should see "Chapter 2" within "div#chapters"
     # Once you've commented, it defaults back to your preference
     And I should see "Chapter 1" within "div#chapters"
+
+  Scenario: Posting a top level comment on a one-chapter work, when there is more than one page of comments
+    Given the work "The Collection" with 2 comments setup
+      And 2 comments displayed per page
+      And I am logged in as a random user
+    When I view the work "The Collection"
+      And I post a comment "wow, that's a lot of comments"
+    Then I should see "wow, that's a lot of comments"
+    When I view the work "The Collection"
+      And I post a comment "very over 1000 amazing"
+    Then I should see "very over 1000 amazing"
+    When I post a comment "have another comment"
+    Then I should see "have another comment"
+      And I should not see "wow, that's a lot of comments"
+
+  Scenario: Posting a top level comment on a multi-chapter work, when there is more than one page of comments,
+  with view full work in the preferences
+    Given the work "Welcome"
+      And 2 comments displayed per page
+      And a comment "hello." by "somebody" on the work "Welcome"
+      And a chapter is added to "Welcome"
+      And a comment "hi!" by "somebody" on the work "Welcome"
+      And a chapter is added to "Welcome"
+      And a comment "heyo" by "somebody" on the work "Welcome"
+      And I am logged in as a random user
+      And I set my preferences to View Full Work mode by default
+    When I view the work "Welcome"
+      And I post a comment "sup?"
+    Then I should see "sup?"
+      And I should see "heyo"
+      And I should not see "hi!"
+
+  Scenario: Posting a top level comment on the middle chapter of a work, when there is more than one page of comments,
+  with view full work in the preferences, and while in temporary view by chapter mode
+    Given the work "Welcome"
+      And 2 comments displayed per page
+      And a comment "hello." by "somebody" on the work "Welcome"
+      And a chapter is added to "Welcome"
+      And a comment "hi!" by "somebody" on the work "Welcome"
+      And a comment "hiya" by "somebody" on the work "Welcome"
+      And a chapter is added to "Welcome"
+      And a comment "heyo" by "somebody" on the work "Welcome"
+      And a comment "hey!" by "somebody" on the work "Welcome"
+      And I am logged in as a random user
+      And I set my preferences to View Full Work mode by default
+    When I view the work "Welcome" in chapter-by-chapter mode
+      And I view the 2nd chapter
+      And I post a comment "sup?"
+    # Once you've commented, it defaults back to your preference (full work)
+    Then I should see "sup?"
+      And I should see "hey!"
+      And I should not see "hiya"

--- a/features/step_definitions/comment_steps.rb
+++ b/features/step_definitions/comment_steps.rb
@@ -94,6 +94,10 @@ Given "the setup for testing image safety mode on the work {string}" do |title|
   step %{I am logged in as "commentrecip"}
 end
 
+Given "{int} comment(s) displayed per page" do |per_page|
+  allow(Comment).to receive(:per_page).and_return(per_page)
+end
+
 # THEN
 
 Then /^the comment's posted date should be nowish$/ do

--- a/features/tags_and_wrangling/tag_comment.feature
+++ b/features/tags_and_wrangling/tag_comment.feature
@@ -168,9 +168,10 @@ I'd like to comment on a tag'
       And I am logged in as a tag wrangler
     When I post the comment "And now things should not break!" on the tag "hack/sign"
     Then I should see "Comment created"
+      And I should see "And now things should not break!"
     # all it checks is that the pagination links aren't broken
-    When I follow "Next" within ".pagination"
-    Then I should see "And now things should not break!"
+    When I follow "Previous" within ".pagination"
+      Then I should not see "And now things should not break!"
 
    Scenario: Comments pagination for a tag with periods in the name
 
@@ -178,9 +179,10 @@ I'd like to comment on a tag'
       And I am logged in as a tag wrangler
     When I post the comment "And now things should not break!" on the tag "sign.me"
     Then I should see "Comment created"
+      And I should see "And now things should not break!"
     # all it checks is that the pagination links aren't broken
-    When I follow "Next" within ".pagination"
-    Then I should see "And now things should not break!"
+    When I follow "Previous" within ".pagination"
+    Then I should not see "And now things should not break!"
 
   Scenario: Comments pagination for a tag with slashes and periods in the name
 
@@ -188,9 +190,10 @@ I'd like to comment on a tag'
       And I am logged in as a tag wrangler
     When I post the comment "And now things should not break!" on the tag "hack/sign.me"
     Then I should see "Comment created"
+      And I should see "And now things should not break!"
     # all it checks is that the pagination links aren't broken
-    When I follow "Next" within ".pagination"
-    Then I should see "And now things should not break!"
+    When I follow "Previous" within ".pagination"
+    Then I should not see "And now things should not break!"
 
   Scenario: Comments on a tag should not be visible to non-wranglers.
 

--- a/features/tags_and_wrangling/tag_comment.feature
+++ b/features/tags_and_wrangling/tag_comment.feature
@@ -171,7 +171,7 @@ I'd like to comment on a tag'
       And I should see "And now things should not break!"
     # all it checks is that the pagination links aren't broken
     When I follow "Previous" within ".pagination"
-      Then I should not see "And now things should not break!"
+    Then I should not see "And now things should not break!"
 
    Scenario: Comments pagination for a tag with periods in the name
 

--- a/spec/controllers/comments/default_rails_actions_spec.rb
+++ b/spec/controllers/comments/default_rails_actions_spec.rb
@@ -288,6 +288,7 @@ describe CommentsController do
           expect(comment.email).to eq anon_comment_attributes[:email]
           expect(comment.comment_content).to include anon_comment_attributes[:comment_content]
           path = comments_path(tag_id: fandom.to_param,
+                               page: 1,
                                anchor: "comment_#{comment.id}")
           expect(response).to redirect_to path
         end
@@ -520,7 +521,7 @@ describe CommentsController do
             post :create, params: { work_id: work.id, comment: comment_attributes }
             comment = Comment.last
             expect(flash[:error]).to be_nil
-            expect(response).to redirect_to(chapter_path(comment.commentable, show_comments: true, view_full_work: false, anchor: "comment_#{comment.id}"))
+            expect(response).to redirect_to(chapter_path(comment.commentable, show_comments: true, view_full_work: false, page: 1, anchor: "comment_#{comment.id}"))
           end
         end
       end
@@ -638,7 +639,7 @@ describe CommentsController do
           fake_login_known_user(user)
           post :create, params: { work_id: work.id, comment: comment_attributes }
           comment = assigns[:comment]
-          it_redirects_to_with_comment_notice(chapter_path(comment.commentable, show_comments: true, view_full_work: false, anchor: "comment_#{comment.id}"), "Comment created!")
+          it_redirects_to_with_comment_notice(chapter_path(comment.commentable, show_comments: true, view_full_work: false, page: 1, anchor: "comment_#{comment.id}"), "Comment created!")
           expect(comment.user_agent.length).to eq(500)
         end
       end
@@ -656,7 +657,7 @@ describe CommentsController do
           fake_login_known_user(user)
           post :create, params: { work_id: work.id, comment: comment_attributes }
           comment = assigns[:comment]
-          it_redirects_to_with_comment_notice(chapter_path(comment.commentable, show_comments: true, view_full_work: false, anchor: "comment_#{comment.id}"), "Comment created!")
+          it_redirects_to_with_comment_notice(chapter_path(comment.commentable, show_comments: true, view_full_work: false, page: 1, anchor: "comment_#{comment.id}"), "Comment created!")
           expect(comment.user_agent).to be_nil
         end
       end


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-4583

## Purpose

Fixes the comment creation redirect to point at the page of the comment you just created instead of the page of comments you were on.

## Credit

marcus8448 (he/him)