### PR TITLE
AO3-7355 Cache user roles for user menu in main nav

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -334,7 +334,7 @@ public
           current_user_offer_assignments: current_user.offer_assignments.undefaulted.count + current_user.pinch_hit_assignments.undefaulted.count,
           current_user_unposted_works_size: current_user.unposted_works.size,
           current_user_opendoors: permit?("opendoors"),
-          current_user_tag_wrangler: current_user.is_tag_wrangler? # also used in TagsHelper#show_wrangling_dashboard
+          current_user_tag_wrangler: current_user.is_tag_wrangler?
         }
       end
       user_menu_data.each do |variable, value|

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -334,7 +334,7 @@ public
           current_user_offer_assignments: current_user.offer_assignments.undefaulted.count + current_user.pinch_hit_assignments.undefaulted.count,
           current_user_unposted_works_size: current_user.unposted_works.size,
           current_user_opendoors: permit?("opendoors"),
-          current_user_tag_wrangler: current_user.is_tag_wrangler?, # also used in TagsHelper#show_wrangling_dashboard
+          current_user_tag_wrangler: current_user.is_tag_wrangler? # also used in TagsHelper#show_wrangling_dashboard
         }
       end
       user_menu_data.each do |variable, value|

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -324,10 +324,22 @@ public
     User.current_user = logged_in_as_admin? ? current_admin : current_user
     @current_user = current_user
     unless current_user.nil?
-      @current_user_subscriptions_count, @current_user_visible_work_count, @current_user_bookmarks_count, @current_user_owned_collections_count, @current_user_challenge_signups_count, @current_user_offer_assignments, @current_user_unposted_works_size=
-             Rails.cache.fetch("user_menu_counts_#{current_user.id}",
-                               expires_in: 2.hours,
-                               race_condition_ttl: 5) { "#{current_user.subscriptions.count}, #{current_user.visible_work_count}, #{current_user.bookmarks.count}, #{current_user.owned_collections.count}, #{current_user.challenge_signups.count}, #{current_user.offer_assignments.undefaulted.count + current_user.pinch_hit_assignments.undefaulted.count}, #{current_user.unposted_works.size}" }.split(",").map(&:to_i)
+      user_menu_data = Rails.cache.fetch([:user_menu_data, current_user.id], expires_in: 2.hours, race_condition_ttl: 5) do
+        {
+          current_user_subscriptions_count: current_user.subscriptions.count,
+          current_user_visible_work_count: current_user.visible_work_count,
+          current_user_bookmarks_count: current_user.bookmarks.count,
+          current_user_owned_collections_count: current_user.owned_collections.count,
+          current_user_challenge_signups_count: current_user.challenge_signups.count,
+          current_user_offer_assignments: current_user.offer_assignments.undefaulted.count + current_user.pinch_hit_assignments.undefaulted.count,
+          current_user_unposted_works_size: current_user.unposted_works.size,
+          current_user_opendoors: permit?("opendoors"),
+          current_user_tag_wrangler: current_user.is_tag_wrangler?, # also used in TagsHelper#show_wrangling_dashboard
+        }
+      end
+      user_menu_data.each do |variable, value|
+        instance_variable_set("@#{variable}", value)
+      end
     end
 
     yield

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -19,7 +19,7 @@ module ApplicationHelper
   def classes_for_main
     class_names = controller.controller_name + '-' + controller.action_name
 
-    show_sidebar = ((@user || @admin_posts || @collection || show_wrangling_dashboard) && !@hide_dashboard)
+    show_sidebar = (!@hide_dashboard && (@user || @admin_posts || @collection || show_wrangling_dashboard))
     class_names += " dashboard" if show_sidebar
 
     class_names += " filtered" if page_has_filters?

--- a/app/helpers/tags_helper.rb
+++ b/app/helpers/tags_helper.rb
@@ -152,10 +152,8 @@ module TagsHelper
   end
 
   def show_wrangling_dashboard
-    # Warning: @current_user_tag_wrangler is cached and not a 1:1 replacement for checking whether the current user is a wrangler
-    (logged_in_as_admin? || @current_user_tag_wrangler) && # rubocop:disable Rails/HelperInstanceVariable
     (%w(tags tag_wranglings tag_wranglers tag_wrangling_requests unsorted_tags).include?(controller.controller_name) ||
-    (@tag && controller.controller_name == 'comments'))
+    (@tag && controller.controller_name == 'comments')) && can_wrangle?
   end
 
   # Returns a nested list of meta tags

--- a/app/helpers/tags_helper.rb
+++ b/app/helpers/tags_helper.rb
@@ -152,7 +152,8 @@ module TagsHelper
   end
 
   def show_wrangling_dashboard
-    can_wrangle? &&
+    # Warning: @current_user_tag_wrangler is cached and not a 1:1 replacement for checking whether the current user is a wrangler
+    (logged_in_as_admin? || @current_user_tag_wrangler) && # rubocop:disable Rails/HelperInstanceVariable
     (%w(tags tag_wranglings tag_wranglers tag_wrangling_requests unsorted_tags).include?(controller.controller_name) ||
     (@tag && controller.controller_name == 'comments'))
   end

--- a/app/models/roles_user.rb
+++ b/app/models/roles_user.rb
@@ -9,6 +9,7 @@ class RolesUser < ApplicationRecord
   after_destroy :log_role_removal
   after_destroy :destroy_last_wrangling_activity
   after_destroy :enqueue_to_index
+  after_commit :expire_user_menu_data_cache
 
   def log_role_addition
     admin = User.current_user
@@ -34,5 +35,9 @@ class RolesUser < ApplicationRecord
     return unless role.name == "tag_wrangler"
 
     user.last_wrangling_activity&.destroy
+  end
+
+  def expire_user_menu_data_cache
+    Rails.cache.delete([:user_menu_data, user.id])
   end
 end

--- a/app/views/users/sessions/_greeting.html.erb
+++ b/app/views/users/sessions/_greeting.html.erb
@@ -27,10 +27,10 @@
             <li><%= link_to t(".nav.history"), user_readings_path(current_user) %></li>
           <% end %>
           <li><%= link_to t(".nav.preferences"), user_preferences_path(current_user) %></li>
-          <% if permit?("opendoors") %>
+          <% if @current_user_opendoors %>
             <li><%= link_to t(".nav.open_doors"), opendoors_tools_path %></li>
           <% end %>
-          <% if current_user.is_tag_wrangler? %>
+          <% if @current_user_tag_wrangler %>
             <li><%= link_to t(".nav.tag_wrangling"), tag_wrangler_path(current_user) %></li>
           <% end %>
         </ul>

--- a/features/tags_and_wrangling/tag_wrangling.feature
+++ b/features/tags_and_wrangling/tag_wrangling.feature
@@ -5,7 +5,7 @@ Feature: Tag wrangling
 
     Given the role "tag_wrangler"
     When I am logged in as "dizmo"
-    Then I should not see "Tag Wrangling" within "#header"
+    Then I should not see "Tag Wrangling" within "#greeting"
     When I am logged in as a "tag_wrangling" admin
       And I go to the manage users page
       And I fill in "Name" with "dizmo"
@@ -17,7 +17,7 @@ Feature: Tag wrangling
     Then I should see "User was successfully updated"
     # accessing wrangling pages
     When I am logged in as "dizmo"
-      And I follow "Tag Wrangling" within "#header"
+      And I follow "Tag Wrangling" within "#greeting"
     Then I should see "Wrangling Home"
     # no access otherwise
     When I log out


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-7355

## Purpose

Cache the user's relevant roles together with their dashboard counts for the dropdown in the main nav, to massively reduce how often we query the role related tables. 

## Credit

Bilka
