### PR TITLE
AO3-7250 Remove Cancelled and Invalid Tag Edits From Activities Log

### DIFF
--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -14,7 +14,8 @@ class WorksController < ApplicationController
   before_action :check_ownership, except: [:index, :show, :navigate, :new, :create, :import, :show_multiple, :edit_multiple, :edit_tags, :update_tags, :update_multiple, :delete_multiple, :search, :mark_for_later, :mark_as_read, :drafts, :collected, :share]
   # admins should have the ability to edit tags (:edit_tags, :update_tags) as per our ToS
   before_action :check_ownership_or_admin, only: [:edit_tags, :update_tags]
-  before_action :log_admin_activity, only: [:update_tags]
+  before_action :save_old_tags, only: [:update_tags]
+  after_action :log_admin_activity, only: [:update_tags], if: [:tried_to_save?], unless: [:work_cannot_be_saved?]
   before_action :check_parent_visible, only: [:navigate]
   before_action :check_visibility, only: [:show, :navigate, :share, :mark_for_later, :mark_as_read]
 
@@ -780,6 +781,10 @@ class WorksController < ApplicationController
     !(@work.errors.empty? && @work.valid?)
   end
 
+  def tried_to_save?
+    params[:update_button].present?
+  end
+
   def set_work_form_fields
     @work.reset_published_at(@chapter)
     @series = current_user.series.distinct
@@ -825,12 +830,16 @@ class WorksController < ApplicationController
     end
   end
 
+  def save_old_tags
+    @old_tags = @work.tags.pluck(:name)
+  end
+
   def log_admin_activity
     if logged_in_as_admin?
       options = { action: params[:action] }
 
       if params[:action] == 'update_tags'
-        summary = "Old tags: #{@work.tags.pluck(:name).join(', ')}"
+        summary = "Old tags: #{@old_tags.join(', ')}"
       end
 
       AdminActivity.log_action(current_admin, @work, action: params[:action], summary: summary)

--- a/features/admins/admin_works.feature
+++ b/features/admins/admin_works.feature
@@ -202,13 +202,35 @@ Feature: Admin Actions for Works, Comments, Series, Bookmarks
       And I should see "Mature"
       And I should see "Admin-Added Relationship"
       And I should see "Admin-Added Character"
-     When I follow "Activities"
-     Then I should see "Admin Activities"
-     When I visit the last activities item
-     Then I should see "No Archive Warnings Apply"
+    When I follow "Activities"
+    Then I should see "Admin Activities"
+    When I visit the last activities item
+    Then I should see "No Archive Warnings Apply"
       And I should see "Old tags"
       And I should see "User-Added Fandom"
       And I should not see "Admin-Added Fandom"
+
+  Scenario: No activity log when tag edits are invalid
+    Given I am logged in as "regular_user"
+      And I post the work "Changes" with fandom "User-Added Fandom"
+    When I am logged in as a "policy_and_abuse" admin
+      And I view the work "Changes"
+      And I follow "Edit Tags and Language"
+      And I uncheck "No Archive Warnings Apply"
+    When I press "Update"
+      And I follow "Activities"
+    Then I should see 0 admin activity log entries
+
+  Scenario: No activity log when previewing without saving
+    Given I am logged in as "regular_user"
+      And I post the work "Changes" with fandom "User-Added Fandom"
+    When I am logged in as a "policy_and_abuse" admin
+      And I view the work "Changes"
+      And I follow "Edit Tags and Language"
+      And I fill in "Fandoms" with "Admin-Added Fandom"
+    When I press "Preview"
+      And I follow "Activities"
+    Then I should see 0 admin activity log entries
 
   Scenario: Can edit external works
     Given basic languages


### PR DESCRIPTION
# Pull Request Checklist

<!-- Mark steps in the checklist as complete by changing `[ ]` to `[X]` -->
* [x] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [x] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [x] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [x] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-7250

## Purpose

Restricts admin activities to being created only after checking if the edit is both:
1) Not just a preview without save
2) Valid 

## References

Admittedly, only after putting together these fixes did I realize that they overlap with work in review here: [AO3-6779](https://github.com/otwcode/otwarchive/pull/5532). I'm happy to work with @slavalamp to come to a resolution together if necessary!

## Credit

caitlin (she/her)


[AO3-6779]: https://otwarchive.atlassian.net/browse/AO3-6779?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ