### PR TITLE
AO3-7356 Reduce N+1 queries on series show page

### DIFF
--- a/app/controllers/series_controller.rb
+++ b/app/controllers/series_controller.rb
@@ -42,14 +42,14 @@ class SeriesController < ApplicationController
   # GET /series/1
   # GET /series/1.xml
   def show
-    @works = @series.works_in_order.posted.select(&:visible?).paginate(page: params[:page])
+    @works = @series.works_in_order.posted.includes(:pseuds).select(&:visible?).paginate(page: params[:page])
 
     # sets the page title with the data for the series
     if @series.unrevealed?
       @page_subtitle = t(".unrevealed_series")
     else
       @page_title = get_page_title(@series.fandoms.pluck(:name).join(t("support.array.words_connector")),
-                                   @series.anonymous? ? t(".anonymous") : @series.allpseuds.collect(&:byline).join(t("support.array.words_connector")),
+                                   helpers.text_byline(@series),
                                    @series.title)
     end
 

--- a/app/models/series.rb
+++ b/app/models/series.rb
@@ -164,11 +164,6 @@ class Series < ApplicationRecord
     serial_works.where(work_id: work.id).pluck(:position).first
   end
 
-  # return list of pseuds on this series
-  def allpseuds
-    works.collect(&:pseuds).flatten.compact.uniq.sort
-  end
-
   # Remove a user (and all their pseuds) as an author of this series.
   #
   # We call Work#remove_author before destroying the series creatorships to

--- a/config/locales/controllers/en.yml
+++ b/config/locales/controllers/en.yml
@@ -282,7 +282,6 @@ en:
     index:
       page_title: "%{username} - Series"
     show:
-      anonymous: Anonymous
       unrevealed_series: Mystery Series
   subscriptions:
     delete_all:

--- a/spec/controllers/series_controller_spec.rb
+++ b/spec/controllers/series_controller_spec.rb
@@ -177,7 +177,7 @@ describe SeriesController do
 
     it "assigns page title for series" do
       work = create(:work, fandom_string: "Fandom", authors: [user.default_pseud])
-      series_with_work = create(:series, works: [work])
+      series_with_work = create(:series, works: [work], authors: [user.default_pseud])
       get :show, params: { id: series_with_work }
       expect(assigns[:page_title]).to eq("#{series_with_work.title} - #{user.default_pseud.name} - Fandom [#{ArchiveConfig.APP_NAME}]")
     end

--- a/spec/requests/series_n_plus_one_spec.rb
+++ b/spec/requests/series_n_plus_one_spec.rb
@@ -1,0 +1,54 @@
+require "spec_helper"
+
+describe "n+1 queries in the series controller" do
+  include LoginMacros
+
+  describe "#show", n_plus_one: true do
+    let!(:user) { create(:user) }
+
+    subject do
+      proc do
+        get series_path(Series.last)
+      end
+    end
+
+    before do
+      fake_login_known_user(user)
+    end
+
+    context "when all works are cached" do
+      populate do |n|
+        create(:series, works: create_list(:work, n))
+        subject.call # this caches the blurbs
+      end
+
+      it "performs around 1 query per work" do
+        # TODO: The last query is caused by Series#published_at and Series#revised_at and would be nice to eliminate as well
+        expect do
+          subject.call
+          expect(response.body.scan('<li id="work_').size).to eq(current_scale.to_i)
+        end.to perform_linear_number_of_queries(slope: 1)
+      end
+    end
+
+    context "when nothing is cached" do
+      populate do |n|
+        create(:series, works: create_list(:work, n))
+      end
+
+      warmup { get series_path(create(:series)) }
+
+      it "performs around 16 queries per work" do
+        # TODO: Ideally, we'd like the uncached serial work listings to also have a
+        # constant number of queries, instead of the linear number of queries
+        # we're checking for here. But we also don't want to put too much
+        # unnecessary load on the databases when we have a bunch of cache hits,
+        # so this requires some care & tuning.
+        expect do
+          subject.call
+          expect(response.body.scan('<li id="work_').size).to eq(current_scale.to_i)
+        end.to perform_linear_number_of_queries(slope: 16)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-7356

## Purpose

Remove N+1 queries related to pseuds and users on the series show page. There are still N+1 queries for chapters, but I couldn't figure out how to remove those (refer to code comment). And this already helps a lot.

Failing test pushed first to show it's testing the right thing.

## Credit

Bilka
