### PR TITLE
AO3-6154 Escaped HTML in link to original admin news post that appears on translations

### DIFF
--- a/app/views/admin_posts/_admin_post.html.erb
+++ b/app/views/admin_posts/_admin_post.html.erb
@@ -11,7 +11,7 @@
     <dd class="published"><%= admin_post.created_at %></dd>
     <% if admin_post.translated_post %>
       <dt class="original translations"><%= ts("Original:") %></dt>
-      <dd class="original translations"><%= link_to raw(admin_post.translated_post.title), admin_post.translated_post %></dd>
+      <dd class="original translations"><%= link_to admin_post.translated_post.title.html_safe, admin_post.translated_post %></dd>
     <% elsif !admin_post.translations.empty? %>
       <dt class="translations"><%= ts("Translations:") %></dt>
       <dd class="translations">

--- a/app/views/admin_posts/_admin_post.html.erb
+++ b/app/views/admin_posts/_admin_post.html.erb
@@ -11,7 +11,7 @@
     <dd class="published"><%= admin_post.created_at %></dd>
     <% if admin_post.translated_post %>
       <dt class="original translations"><%= ts("Original:") %></dt>
-      <dd class="original translations"><%= link_to admin_post.translated_post.title, admin_post.translated_post %></dd>
+      <dd class="original translations"><%= link_to raw(admin_post.translated_post.title), admin_post.translated_post %></dd>
     <% elsif !admin_post.translations.empty? %>
       <dt class="translations"><%= ts("Translations:") %></dt>
       <dd class="translations">

--- a/features/admins/admin_post_news.feature
+++ b/features/admins/admin_post_news.feature
@@ -168,6 +168,24 @@ Feature: Admin Actions to Post News
     Then I should see "App News & a <strong> Warning"
       And I should not see "App News &amp; a &lt;strong&gt; Warning"
 
+  Scenario: If a translated admin post has characters like & and < and > in the title, the escaped version will not show in the original post header
+  Given I have posted an admin post
+    And basic languages
+    And I am logged in as a "translation" admin
+  When I follow "Admin Posts"
+    And I follow "Post AO3 News"
+    And I fill in "admin_post_title" with "Deutsch News & a <strong> Warning"
+    And I fill in "content" with "Some translated content."
+    And I fill in "Translation of" with "1"
+    And I select "Deutsch" from "Choose a language"
+    And I press "Post"
+  Then I should see "Admin Post was successfully created."
+  When I am logged in as "ordinaryuser"
+    And I go to the admin-posts page
+    And I follow "Deutsch News & a <strong> Warning"
+  Then I should see "Deutsch News & a <strong> Warning" within "dd.original.translations"
+    And I should not see "Deutsch News &amp; a &lt;strong&gt; Warning"
+    
   Scenario: Admin post should be shown on the homepage
     Given I have posted an admin post
     When I am on the homepage

--- a/features/admins/admin_post_news.feature
+++ b/features/admins/admin_post_news.feature
@@ -169,16 +169,15 @@ Feature: Admin Actions to Post News
       And I should not see "App News &amp; a &lt;strong&gt; Warning"
 
   Scenario: If a translated admin post has characters like & and < and > in the title, the escaped version will not show in the original post header
-    Given I have posted an admin post
-      And basic languages
-      And I am logged in as a "translation" admin
-    When I make a translation of an admin post with title "Deutsch News & a <strong> Warning"
-    Then I should see "Admin Post was successfully created."
-    When I am logged in as "ordinaryuser"
-      And I go to the admin-posts page
-      And I go to the admin post with title "Deutsch News & a <strong> Warning"
-    Then I should see "Default Admin Post" within "dd.original.translations"
-      And I should not see "Default Admin Post &amp;"
+  Given I have posted an admin post
+    And basic languages
+    And I am logged in as a "translation" admin
+  When I make a translation of an admin post with title "Deutsch News & a <strong> Warning"
+  Then I should see "Admin Post was successfully created."
+  When I am logged in as "ordinaryuser"
+    And I visit the admin post with title "Deutsch News & a <strong> Warning"
+  Then I should see "Default Admin Post" within "dd.original.translations"
+    And I should not see "Default Admin Post &amp;"
     
   Scenario: Admin post should be shown on the homepage
     Given I have posted an admin post

--- a/features/admins/admin_post_news.feature
+++ b/features/admins/admin_post_news.feature
@@ -169,16 +169,16 @@ Feature: Admin Actions to Post News
       And I should not see "App News &amp; a &lt;strong&gt; Warning"
 
   Scenario: If a translated admin post has characters like & and < and > in the title, the escaped version will not show in the original post header
-  Given I have posted an admin post
-    And basic languages
-    And I am logged in as a "translation" admin
-  When I make a translation of an admin post with title "Deutsch News & a <strong> Warning"
-  Then I should see "Admin Post was successfully created."
-  When I am logged in as "ordinaryuser"
-    And I go to the admin-posts page
-    And I follow "Deutsch News & a <strong> Warning"
-  Then I should see "Default Admin Post" within "dd.original.translations"
-    And I should not see "Default Admin Post &amp;"
+    Given I have posted an admin post
+      And basic languages
+      And I am logged in as a "translation" admin
+    When I make a translation of an admin post with title "Deutsch News & a <strong> Warning"
+    Then I should see "Admin Post was successfully created."
+    When I am logged in as "ordinaryuser"
+      And I go to the admin-posts page
+      And I go to the admin post with title "Deutsch News & a <strong> Warning"
+    Then I should see "Default Admin Post" within "dd.original.translations"
+      And I should not see "Default Admin Post &amp;"
     
   Scenario: Admin post should be shown on the homepage
     Given I have posted an admin post

--- a/features/admins/admin_post_news.feature
+++ b/features/admins/admin_post_news.feature
@@ -172,19 +172,13 @@ Feature: Admin Actions to Post News
   Given I have posted an admin post
     And basic languages
     And I am logged in as a "translation" admin
-  When I follow "Admin Posts"
-    And I follow "Post AO3 News"
-    And I fill in "admin_post_title" with "Deutsch News & a <strong> Warning"
-    And I fill in "content" with "Some translated content."
-    And I fill in "Translation of" with "1"
-    And I select "Deutsch" from "Choose a language"
-    And I press "Post"
+  When I make a translation of an admin post with title "Deutsch News & a <strong> Warning"
   Then I should see "Admin Post was successfully created."
   When I am logged in as "ordinaryuser"
     And I go to the admin-posts page
     And I follow "Deutsch News & a <strong> Warning"
-  Then I should see "Deutsch News & a <strong> Warning" within "dd.original.translations"
-    And I should not see "Deutsch News &amp; a &lt;strong&gt; Warning"
+  Then I should see "Default Admin Post" within "dd.original.translations"
+    And I should not see "Default Admin Post &amp;"
     
   Scenario: Admin post should be shown on the homepage
     Given I have posted an admin post

--- a/features/step_definitions/admin_steps.rb
+++ b/features/step_definitions/admin_steps.rb
@@ -362,9 +362,9 @@ When /^I make a translation of an admin post( with tags "(.*?)")?$/ do |tags|
   click_button("Post")
 end
 
-When /^I make a translation of an admin post with title "([^"]*)"$/ do |title|
+When "I make a translation of an admin post with title {string}" do |title|
   admin_post = AdminPost.find_by(title: "Default Admin Post")
-  admin_post_id = !admin_post.nil? ? admin_post.id : 0
+  admin_post_id = admin_post.nil? ? 0 : admin_post.id
   visit new_admin_post_path
   fill_in("admin_post_title", with: title)
   fill_in("content", with: "Some translated content.")

--- a/features/step_definitions/admin_steps.rb
+++ b/features/step_definitions/admin_steps.rb
@@ -373,6 +373,11 @@ When "I make a translation of an admin post with title {string}" do |title|
   click_button("Post")
 end
 
+When "I visit the admin post with title {string}" do |title|
+  admin_post = AdminPost.order(created_at: :desc).first
+  visit admin_post_path(admin_post)
+end
+
 When /^I hide the work "(.*?)"$/ do |title|
   work = Work.find_by(title: title)
   visit work_path(work)

--- a/features/step_definitions/admin_steps.rb
+++ b/features/step_definitions/admin_steps.rb
@@ -362,6 +362,17 @@ When /^I make a translation of an admin post( with tags "(.*?)")?$/ do |tags|
   click_button("Post")
 end
 
+When /^I make a translation of an admin post with title "([^"]*)"$/ do |title|
+  admin_post = AdminPost.find_by(title: "Default Admin Post")
+  admin_post_id = !admin_post.nil? ? admin_post.id : 0
+  visit new_admin_post_path
+  fill_in("admin_post_title", with: title)
+  fill_in("content", with: "Some translated content.")
+  step %{I select "Deutsch" from "Choose a language"}
+  fill_in("admin_post_translated_post_id", with: admin_post_id)
+  click_button("Post")
+end
+
 When /^I hide the work "(.*?)"$/ do |title|
   work = Work.find_by(title: title)
   visit work_path(work)

--- a/features/step_definitions/admin_steps.rb
+++ b/features/step_definitions/admin_steps.rb
@@ -373,7 +373,7 @@ When "I make a translation of an admin post with title {string}" do |title|
   click_button("Post")
 end
 
-When "I visit the admin post with title {string}" do |title|
+When "I visit the admin post with title {string}" do |_title|
   admin_post = AdminPost.order(created_at: :desc).first
   visit admin_post_path(admin_post)
 end


### PR DESCRIPTION
# Pull Request Checklist

<!-- Mark steps in the checklist as complete by changing `[ ]` to `[X]` -->
* [X] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [X] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [X] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [X] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [X] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue
https://otwarchive.atlassian.net/browse/AO3-6154

## Purpose
What does this PR do?
This PR prevents escaping of HTML in AO3 news admin posting translations

## Testing Instructions
See Jira ticket https://otwarchive.atlassian.net/browse/AO3-6154

## Credit
Scott Venkataraman he/him