### PR TITLE
AO3-6390 Remove the field for setting the default skin on the admin skins page

### DIFF
--- a/app/controllers/admin/skins_controller.rb
+++ b/app/controllers/admin/skins_controller.rb
@@ -75,23 +75,6 @@ class Admin::SkinsController < Admin::BaseController
 
     flash[:notice] << ts("The following skins were updated: %{titles}", titles: modified_skin_titles.join(', '))
 
-    # set default
-    if params[:set_default].present? && params[:set_default] != AdminSetting.default_skin&.title
-      authorize Skin, :set_default?
-
-      skin = Skin.find_by(title: params[:set_default], official: true)
-      @admin_setting = AdminSetting.first
-      if skin && @admin_setting
-        @admin_setting.default_skin = skin
-        @admin_setting.last_updated_by = params[:last_updated_by]
-        if @admin_setting.save
-          flash[:notice] << ts("Default skin changed to %{title}", title: skin.title)
-        else
-          flash[:error] = ts("We couldn't save the default skin change.")
-        end
-      end
-    end
-
     redirect_to admin_skins_path
   end
 

--- a/app/policies/skin_policy.rb
+++ b/app/policies/skin_policy.rb
@@ -12,10 +12,6 @@ class SkinPolicy < ApplicationPolicy
       user_has_roles?(MANAGE_WORK_SKINS) && @record.is_a?(WorkSkin)
   end
 
-  def set_default?
-    user_has_roles?(MANAGE_SITE_SKINS)
-  end
-
   alias index_approved? index?
   alias index_rejected? index?
 end

--- a/app/views/admin/skins/index_approved.html.erb
+++ b/app/views/admin/skins/index_approved.html.erb
@@ -81,19 +81,6 @@
     </table>
   </fieldset>
 
-  <% if policy(Skin).set_default? %>
-    <fieldset>
-      <legend><%= ts("Set Default Archive Skin") %></legend>
-      <h3 class="heading"><%= ts("Set Default Archive Skin") %></h3>
-      <p class="note"><%= ts("This will change the default skin FOR ALL USERS! Don't use unless you are REALLY SURE.") %></p>
-      <p>
-        <%= label_tag "set_default", ts("Default Skin Title: ") %>
-        <%= text_field_tag "set_default", AdminSetting.default_skin.try(:title), autocomplete_options("site_skins", data: { autocomplete_token_limit: 1 }) %>
-        <%= hidden_field_tag :last_updated_by, current_admin.id %>
-      </p>
-    </fieldset>
-  <% end %>
-
   <p class="submit"><%= submit_tag ts("Update") %></p>
 
 <% end %>

--- a/features/admins/admin_skins.feature
+++ b/features/admins/admin_skins.feature
@@ -115,29 +115,6 @@ Feature: Admin manage skins
     And I should not see "#title"
     And I should not see "text-decoration: blink;"
 
-  Scenario: Admin can change the default skin
-  Given basic skins
-    And the approved public skin "strange skin" with css "#title { text-decoration: underline;}"
-    And the approved public skin "public skin" with css "#title { text-decoration: blink;}"
-    And I am logged in as "skinner"
-    And the user "KnownUser" exists and is activated
-  When I am on skinner's preferences page
-    And I select "strange skin" from "preference_skin_id"
-    And I submit
-  Then I should see "{ text-decoration: underline; }" in the page style
-  When I am logged in as a "superadmin" admin
-  Then I should not see "{ text-decoration: blink; }" in the page style
-  When I follow "Approved Skins"
-    And I fill in "set_default" with "public skin"
-    And I press "Update"
-  Then I should see "Default skin changed to public skin"
-    And I should see "{ text-decoration: blink; }" in the page style
-  When I am logged in as "skinner"
-  Then I should see "{ text-decoration: underline; }" in the page style
-  # A user created before changing the default skin will still have the same skin
-  When I am logged in as "KnownUser"
-  Then I should not see "{ text-decoration: blink; }" in the page style
-
   Scenario: Admin can edit a skin with the word "archive" in the title
   Given the approved public skin "official archive skin" has reserved words in the title
     And I am logged in as a "superadmin" admin

--- a/spec/controllers/admin/skins_controller_spec.rb
+++ b/spec/controllers/admin/skins_controller_spec.rb
@@ -118,38 +118,6 @@ describe Admin::SkinsController do
     let(:site_skin) { create(:skin, :public) }
     let(:work_skin) { create(:work_skin, :public) }
 
-    shared_examples "unauthorized admin cannot update default skin" do
-      before { site_skin.update!(official: true) }
-
-      it "does not modify the default skin" do
-        expect do
-          put :update, params: { id: :update, set_default: site_skin.title, last_updated_by: admin.id }
-        end.not_to change { AdminSetting.first.default_skin }
-      end
-
-      it "redirects with error" do
-        put :update, params: { id: :update, set_default: site_skin.title, last_updated_by: admin.id }
-        it_redirects_to_simple(root_path)
-        expect(flash[:error]).to eq("Sorry, only an authorized admin can access the page you were trying to reach.")
-      end
-    end
-
-    shared_examples "authorized admin can update default skin" do
-      before { site_skin.update!(official: true) }
-
-      it "modifies the default skin" do
-        expect do
-          put :update, params: { id: :update, set_default: site_skin.title, last_updated_by: admin.id }
-        end.to change { AdminSetting.first.default_skin }.from(nil).to(site_skin)
-      end
-
-      it "redirects with notice" do
-        put :update, params: { id: :update, set_default: site_skin.title, last_updated_by: admin.id }
-        it_redirects_to_simple(admin_skins_path)
-        expect(flash[:notice]).to include("Default skin changed to #{site_skin.title}")
-      end
-    end
-
     shared_examples "unauthorized admin cannot update site skin" do
       it "does not modify site skin" do
         expect do
@@ -205,7 +173,6 @@ describe Admin::SkinsController do
     end
 
     context "when admin has no role" do
-      it_behaves_like "unauthorized admin cannot update default skin"
       it_behaves_like "unauthorized admin cannot update site skin"
       it_behaves_like "unauthorized admin cannot update work skin"
     end
@@ -214,7 +181,6 @@ describe Admin::SkinsController do
       context "when admin has #{role} role" do
         let(:admin) { create(:admin, roles: [role]) }
 
-        it_behaves_like "unauthorized admin cannot update default skin"
         it_behaves_like "unauthorized admin cannot update site skin"
         it_behaves_like "unauthorized admin cannot update work skin"
       end
@@ -223,7 +189,6 @@ describe Admin::SkinsController do
     context "when admin has superadmin role" do
       let(:admin) { create(:admin, roles: ["superadmin"]) }
 
-      it_behaves_like "authorized admin can update default skin"
       it_behaves_like "authorized admin can update site skin"
       it_behaves_like "authorized admin can update work skin"
 
@@ -250,7 +215,6 @@ describe Admin::SkinsController do
     context "when admin has support role" do
       let(:admin) { create(:admin, roles: ["support"]) }
 
-      it_behaves_like "unauthorized admin cannot update default skin"
       it_behaves_like "authorized admin can update work skin"
 
       context "when attempting to update a site skin" do


### PR DESCRIPTION
# Pull Request Checklist

<!-- Mark steps in the checklist as complete by changing `[ ]` to `[X]` -->
* [X] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [X] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [X] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [X] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [X] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue
https://otwarchive.atlassian.net/browse/AO3-6390

## Purpose
What does this PR do?
This PR removes the field for super admins to update the default skin from the /admin/skins/index_approved page. 
It removes the functionality to accept entering direct URL request to effect the same change. 
It updates tests to reflect these changes. 

## Testing Instructions
How can the Archive's QA team verify that this is working as you intended?
Follow Jira Ticket instruction for manual testing: https://otwarchive.atlassian.net/browse/AO3-6390

## Credit
Scott Venkataraman he/him (Svenkat on Jira)