### PR TITLE
AO3-7182 Hide restricted works from guests on prompts page

### DIFF
--- a/app/models/challenge_claim.rb
+++ b/app/models/challenge_claim.rb
@@ -71,6 +71,9 @@ class ChallengeClaim < ApplicationRecord
              CollectionItem.user_approval_statuses[:approved], CollectionItem.collection_approval_statuses[:approved])
   }
 
+  scope :fulfilled_restricted, -> {
+    fulfilled.where("works.restricted = 1")
+  }
 
   scope :posted, -> { joins(WORKS_JOIN).where("challenge_claims.creation_id IS NOT NULL AND works.posted = 1") }
 

--- a/app/models/challenge_claim.rb
+++ b/app/models/challenge_claim.rb
@@ -71,9 +71,7 @@ class ChallengeClaim < ApplicationRecord
              CollectionItem.user_approval_statuses[:approved], CollectionItem.collection_approval_statuses[:approved])
   }
 
-  scope :fulfilled_restricted, -> {
-    fulfilled.where("works.restricted = 1")
-  }
+  scope :fulfilled_restricted, -> { fulfilled.where("works.restricted = 1") }
 
   scope :posted, -> { joins(WORKS_JOIN).where("challenge_claims.creation_id IS NOT NULL AND works.posted = 1") }
 

--- a/app/models/challenge_claim.rb
+++ b/app/models/challenge_claim.rb
@@ -71,7 +71,8 @@ class ChallengeClaim < ApplicationRecord
              CollectionItem.user_approval_statuses[:approved], CollectionItem.collection_approval_statuses[:approved])
   }
 
-  scope :fulfilled_unrestricted, -> { fulfilled.where("works.restricted = 0") }
+  # TODO: AO3-6024 for making sure we also exclude works hidden by admin
+  scope :work_visible_to_all, -> { where("works.restricted = 0") }
 
   scope :posted, -> { joins(WORKS_JOIN).where("challenge_claims.creation_id IS NOT NULL AND works.posted = 1") }
 

--- a/app/models/challenge_claim.rb
+++ b/app/models/challenge_claim.rb
@@ -71,7 +71,7 @@ class ChallengeClaim < ApplicationRecord
              CollectionItem.user_approval_statuses[:approved], CollectionItem.collection_approval_statuses[:approved])
   }
 
-  scope :fulfilled_restricted, -> { fulfilled.where("works.restricted = 1") }
+  scope :fulfilled_unrestricted, -> { fulfilled.where("works.restricted = 0") }
 
   scope :posted, -> { joins(WORKS_JOIN).where("challenge_claims.creation_id IS NOT NULL AND works.posted = 1") }
 

--- a/app/models/prompt.rb
+++ b/app/models/prompt.rb
@@ -209,6 +209,10 @@ class Prompt < ApplicationRecord
     self.request_claims.fulfilled
   end
 
+  def fulfilled_restricted_claims
+    self.request_claims.fulfilled_restricted
+  end
+
   # Computes the "full" tag set (tag_set + optional_tag_set), and stores the
   # result as an instance variable for speed. This is used by the matching
   # algorithm, which doesn't change any signup/prompt/tagset information, so

--- a/app/models/prompt.rb
+++ b/app/models/prompt.rb
@@ -209,10 +209,9 @@ class Prompt < ApplicationRecord
     self.request_claims.fulfilled
   end
 
-  def fulfilled_unrestricted_claims
-    self.request_claims.fulfilled_unrestricted
+  def fulfilled_claims_visible_to_all
+    self.request_claims.fulfilled.work_visible_to_all
   end
-
   # Computes the "full" tag set (tag_set + optional_tag_set), and stores the
   # result as an instance variable for speed. This is used by the matching
   # algorithm, which doesn't change any signup/prompt/tagset information, so

--- a/app/models/prompt.rb
+++ b/app/models/prompt.rb
@@ -209,8 +209,8 @@ class Prompt < ApplicationRecord
     self.request_claims.fulfilled
   end
 
-  def fulfilled_restricted_claims
-    self.request_claims.fulfilled_restricted
+  def fulfilled_unrestricted_claims
+    self.request_claims.fulfilled_unrestricted
   end
 
   # Computes the "full" tag set (tag_set + optional_tag_set), and stores the

--- a/app/views/prompts/_prompt_blurb.html.erb
+++ b/app/views/prompts/_prompt_blurb.html.erb
@@ -80,7 +80,7 @@
     <% end %>
 
     <% # if prompt has been fulfilled list works %>
-    <% unless prompt.unfulfilled? || (guest? && prompt.fulfilled_claims_visible_to_all.count < 1) %>
+    <% unless prompt.unfulfilled? || (guest? && prompt.fulfilled_claims_visible_to_all.empty?) %>
       <div class="work listbox group">
         <h5 class="heading"><%= ts("Fulfilled By")%></h5>
         <ul class="index group">

--- a/app/views/prompts/_prompt_blurb.html.erb
+++ b/app/views/prompts/_prompt_blurb.html.erb
@@ -80,7 +80,7 @@
     <% end %>
 
     <% # if prompt has been fulfilled list works %>
-    <% unless prompt.unfulfilled? || (guest? && prompt.fulfilled_unrestricted_claims.count < 1) %>
+    <% unless prompt.unfulfilled? || (guest? && prompt.fulfilled_claims_visible_to_all.count < 1) %>
       <div class="work listbox group">
         <h5 class="heading"><%= ts("Fulfilled By")%></h5>
         <ul class="index group">

--- a/app/views/prompts/_prompt_blurb.html.erb
+++ b/app/views/prompts/_prompt_blurb.html.erb
@@ -84,16 +84,19 @@
       <div class="work listbox group">
         <h5 class="heading"><%= ts("Fulfilled By")%></h5>
         <ul class="index group">
-          <% prompt.fulfilled_claims.map(&:creation).each do |creation| %>
-            <% if creation.is_a?(Work) %>
-              <% if guest? && creation.restricted %>
+          <% if guest? && prompt.fulfilled_restricted_claims.count > 0 %>
+          <li>
                 <%= image_tag("lockblue.png", size: "15x15",
                                    alt: ts("(Restricted)"),
                                    title: ts("Restricted"),
                                    skip_pipeline: true) %>
                                    
                 <%= t(".restricted.work_unavailable") %>
-              <% else%>
+          </li>
+          <% end %>
+          <% prompt.fulfilled_claims.map(&:creation).each do |creation| %>
+            <% if creation.is_a?(Work) %>
+              <% unless guest? && creation.restricted %>
                 <%= render "works/work_blurb", :work => creation %>
               <% end %>
             <% end %>

--- a/app/views/prompts/_prompt_blurb.html.erb
+++ b/app/views/prompts/_prompt_blurb.html.erb
@@ -86,12 +86,8 @@
         <ul class="index group">
           <% if guest? && prompt.fulfilled_restricted_claims.count > 0 %>
           <li>
-                <%= image_tag("lockblue.png", size: "15x15",
-                                   alt: ts("(Restricted)"),
-                                   title: ts("Restricted"),
-                                   skip_pipeline: true) %>
-                                   
-                <%= t(".restricted.work_unavailable") %>
+            <%= image_tag("lockblue.png", size: "15x15", alt: "(Restricted)", title: "Restricted", skip_pipeline: true) %>
+            <%= t(".restricted.work_unavailable") %>
           </li>
           <% end %>
           <% prompt.fulfilled_claims.map(&:creation).each do |creation| %>

--- a/app/views/prompts/_prompt_blurb.html.erb
+++ b/app/views/prompts/_prompt_blurb.html.erb
@@ -80,16 +80,10 @@
     <% end %>
 
     <% # if prompt has been fulfilled list works %>
-    <% unless prompt.unfulfilled? %>
+    <% unless prompt.unfulfilled? || (guest? && prompt.fulfilled_unrestricted_claims.count < 1) %>
       <div class="work listbox group">
         <h5 class="heading"><%= ts("Fulfilled By")%></h5>
         <ul class="index group">
-          <% if guest? && prompt.fulfilled_restricted_claims.count > 0 %>
-          <li>
-            <%= image_tag("lockblue.png", size: "15x15", alt: "(Restricted)", title: "Restricted", skip_pipeline: true) %>
-            <%= t(".restricted.work_unavailable") %>
-          </li>
-          <% end %>
           <% prompt.fulfilled_claims.map(&:creation).each do |creation| %>
             <% if creation.is_a?(Work) %>
               <% unless guest? && creation.restricted %>

--- a/app/views/prompts/_prompt_blurb.html.erb
+++ b/app/views/prompts/_prompt_blurb.html.erb
@@ -93,7 +93,7 @@
           <% prompt.fulfilled_claims.map(&:creation).each do |creation| %>
             <% if creation.is_a?(Work) %>
               <% unless guest? && creation.restricted %>
-                <%= render "works/work_blurb", :work => creation %>
+                <%= render "works/work_blurb", work: creation %>
               <% end %>
             <% end %>
           <% end %>

--- a/app/views/prompts/_prompt_blurb.html.erb
+++ b/app/views/prompts/_prompt_blurb.html.erb
@@ -86,7 +86,16 @@
         <ul class="index group">
           <% prompt.fulfilled_claims.map(&:creation).each do |creation| %>
             <% if creation.is_a?(Work) %>
-              <%= render "works/work_blurb", :work => creation %>
+              <% if guest? && creation.restricted %>
+                <%= image_tag("lockblue.png", size: "15x15",
+                                   alt: ts("(Restricted)"),
+                                   title: ts("Restricted"),
+                                   skip_pipeline: true) %>
+                                   
+                <%= t(".restricted.work_unavailable") %>
+              <% else%>
+                <%= render "works/work_blurb", :work => creation %>
+              <% end %>
             <% end %>
           <% end %>
         </ul>

--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -2515,10 +2515,6 @@ en:
       edit_my_pseuds: Manage My Pseuds
       edit_my_works: Edit My Works
       edit_profile: Edit Profile
-  prompts:
-    prompt_blurb:
-      restricted:
-        work_unavailable: Some of these prompts are only available to registered users of the Archive.
   pseuds:
     delete_preview:
       cancel: Cancel

--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -2515,6 +2515,10 @@ en:
       edit_my_pseuds: Manage My Pseuds
       edit_my_works: Edit My Works
       edit_profile: Edit Profile
+  prompts:
+    prompt_blurb:
+      restricted:
+        work_unavailable: This work is only available to registered users of the Archive.
   pseuds:
     delete_preview:
       cancel: Cancel

--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -2518,7 +2518,7 @@ en:
   prompts:
     prompt_blurb:
       restricted:
-        work_unavailable: This work is only available to registered users of the Archive.
+        work_unavailable: Some of these prompts are only available to registered users of the Archive.
   pseuds:
     delete_preview:
       cancel: Cancel

--- a/features/prompt_memes_b/challenge_promptmeme_posting_fills.feature
+++ b/features/prompt_memes_b/challenge_promptmeme_posting_fills.feature
@@ -593,3 +593,21 @@ Feature: Prompt Meme Challenge
     And I uncheck "Battle 12 (prompter)"
     And I press "Update"
   Then I should see "For prompter."
+
+  Scenario: When a prompt is filled with a restricted work, the work should only be visible to logged-in users
+
+  Given I have Battle 12 prompt meme fully set up
+  When I am logged in as "myname1"
+  When I sign up for Battle 12
+  When I am logged in as "myname2"
+    And I claim a prompt from "Battle 12"
+    And I start to fulfill my claim with "Restricted Fill"
+    And I lock the work
+    And I press "Post"
+    And I go to "Battle 12" collection's page
+    And I follow "Prompts ("
+  Then I should see "Fulfilled By"
+  When I log out
+    And I go to "Battle 12" collection's page
+    And I follow "Prompts ("
+  Then I should not see "Fulfilled By"

--- a/features/prompt_memes_b/challenge_promptmeme_posting_fills.feature
+++ b/features/prompt_memes_b/challenge_promptmeme_posting_fills.feature
@@ -597,17 +597,18 @@ Feature: Prompt Meme Challenge
   Scenario: When a prompt is filled with a restricted work, the work should only be visible to logged-in users
 
   Given I have Battle 12 prompt meme fully set up
-  When I am logged in as "myname1"
-  When I sign up for Battle 12
-  When I am logged in as "myname2"
+    And I am logged in as "myname1"
+    And I sign up for Battle 12
+    And I am logged in as "myname2"
     And I claim a prompt from "Battle 12"
     And I start to fulfill my claim with "Restricted Fill"
     And I lock the work
     And I press "Post"
-    And I go to "Battle 12" collection's page
-    And I follow "Prompts ("
+  When I view prompts for "Battle 12"
   Then I should see "Fulfilled By"
+    And I should see "Restricted Fill"
   When I log out
     And I go to "Battle 12" collection's page
     And I follow "Prompts ("
   Then I should not see "Fulfilled By"
+    And I should not see "Restricted Fill"


### PR DESCRIPTION
# Pull Request Checklist

<!-- Mark steps in the checklist as complete by changing `[ ]` to `[X]` -->
* [x] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [x] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [x] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [x] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-7182

## Purpose

Fixes a visibility bug on the meme prompt page. 

## Credit
Luis Pabon (they/he)
