### PR TITLE
AO3-7333 Add username to Challenge Claims page title

### DIFF
--- a/app/controllers/challenge_claims_controller.rb
+++ b/app/controllers/challenge_claims_controller.rb
@@ -71,7 +71,6 @@ class ChallengeClaimsController < ApplicationController
     if !(@collection = Collection.find_by(name: params[:collection_id])).nil? && @collection.closed? && !@collection.user_is_maintainer?(current_user)
       flash[:notice] = ts("This challenge is currently closed to new posts.")
     end
-    @page_subtitle = t(".page_title", username: @user.login)
     if params[:collection_id]
       return unless load_collection
 
@@ -90,6 +89,7 @@ class ChallengeClaimsController < ApplicationController
         @claims = @claims.order(@sort_order)
       end
     elsif params[:user_id] && (@user = User.find_by(login: params[:user_id]))
+      @page_subtitle = t(".page_title", username: @user.login)
       if current_user == @user
         @claims = @user.request_claims.order_by_date.unposted
 				if params[:posted]

--- a/app/controllers/challenge_claims_controller.rb
+++ b/app/controllers/challenge_claims_controller.rb
@@ -71,6 +71,7 @@ class ChallengeClaimsController < ApplicationController
     if !(@collection = Collection.find_by(name: params[:collection_id])).nil? && @collection.closed? && !@collection.user_is_maintainer?(current_user)
       flash[:notice] = ts("This challenge is currently closed to new posts.")
     end
+    @page_subtitle = t(".page_title", username: @user.login)
     if params[:collection_id]
       return unless load_collection
 

--- a/config/locales/controllers/en.yml
+++ b/config/locales/controllers/en.yml
@@ -99,7 +99,7 @@ en:
       not_owner: You aren't the owner of that assignment.
   challenge_claims:
     index:
-      page_title: "%username - Challenge Claims"
+      page_title: "%{username} - Challenge Claims"
   challenge_signups:
     new:
       page_title: New Challenge Sign-up

--- a/config/locales/controllers/en.yml
+++ b/config/locales/controllers/en.yml
@@ -92,14 +92,14 @@ en:
       success: Bookmark was successfully created. It should appear in bookmark listings within the next few minutes.
       warnings:
         private_bookmark_added_to_collection: " Please note: private bookmarks are not listed in collections."
-  challenge_claims:
-    index:
-      page_title: "%username - Challenge Claims"
   challenge_assignments:
     index:
       access_denied_user: You aren't allowed to see that user's assignments.
     validation:
       not_owner: You aren't the owner of that assignment.
+  challenge_claims:
+    index:
+      page_title: "%username - Challenge Claims"
   challenge_signups:
     new:
       page_title: New Challenge Sign-up

--- a/config/locales/controllers/en.yml
+++ b/config/locales/controllers/en.yml
@@ -92,6 +92,9 @@ en:
       success: Bookmark was successfully created. It should appear in bookmark listings within the next few minutes.
       warnings:
         private_bookmark_added_to_collection: " Please note: private bookmarks are not listed in collections."
+  challenge_claims:
+    index:
+      page_title: "%username - Challenge Claims"
   challenge_assignments:
     index:
       access_denied_user: You aren't allowed to see that user's assignments.

--- a/features/other_a/challenge_claims.feature
+++ b/features/other_a/challenge_claims.feature
@@ -1,0 +1,13 @@
+@users
+Feature: Examine challenge claims
+
+  Scenario: Check the title of the claims page
+
+  Given the following activated user exists
+  | login         | password   |
+  | scott         | password   |
+  
+  When I am logged in as scott with password "password"
+    And I go to scott's user page
+    And I follow "Claims"
+  Then I should see the page title "scott - Challenge Claims"

--- a/features/other_a/challenge_claims.feature
+++ b/features/other_a/challenge_claims.feature
@@ -2,12 +2,10 @@
 Feature: Examine challenge claims
 
   Scenario: Check the title of the claims page
-
-  Given the following activated user exists
-  | login         | password   |
-  | scott         | password   |
-  
-  When I am logged in as scott with password "password"
-    And I go to scott's user page
-    And I follow "Claims"
-  Then I should see the page title "scott - Challenge Claims"
+    Given the following activated user exists
+    | login         | password   |
+    | scott         | password   |
+    When I am logged in as "scott" with password "password"
+      And I go to scott's user page
+      And I follow "Claims ("
+    Then I should see the page title "scott - Challenge Claims"


### PR DESCRIPTION
# Pull Request Checklist

<!-- Mark steps in the checklist as complete by changing `[ ]` to `[X]` -->
* [X] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [X] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [X] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [X] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [X] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-7333

## Purpose

Changes the user's Challenge Claims page title from "Challenge Claims | Archive of Our Own" to "`username` - Challenge Claims | Archive of Our Own".

## Credit

Ling-Yi (any pronouns)