### PR TITLE
AO3-6218 Allow certain admins to access all collection and challenge pages usually reserved for owners

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -335,12 +335,28 @@ public
     @collection = Collection.find_by(name: params[:collection_id]) if params[:collection_id]
   end
 
+  def privileged_collection_admin?
+    logged_in_as_admin? && (current_admin.roles & %w[support policy_and_abuse superadmin]).present?
+  end
+
+  def users_or_privileged_collection_admin_only
+    logged_in? || privileged_collection_admin? || access_denied
+  end
+
   def collection_maintainers_only
     logged_in? && @collection && @collection.user_is_maintainer?(current_user) || access_denied
   end
 
+  def collection_maintainers_or_privileged_admins_only
+    (logged_in? && @collection && @collection.user_is_maintainer?(current_user)) || privileged_collection_admin? || access_denied
+  end
+
   def collection_owners_only
     logged_in? && @collection && @collection.user_is_owner?(current_user) || access_denied
+  end
+
+  def collection_owners_or_privileged_admins_only
+    (logged_in? && @collection && @collection.user_is_owner?(current_user)) || privileged_collection_admin? || access_denied
   end
 
   def not_allowed(fallback=nil)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -336,11 +336,13 @@ public
   end
 
   def privileged_collection_admin?
-    logged_in_as_admin? && (current_admin.roles & %w[support policy_and_abuse superadmin]).present?
+    policy(Collection).access?
   end
 
   def users_or_privileged_collection_admin_only
-    logged_in? || privileged_collection_admin? || access_denied
+    return if logged_in? || privileged_collection_admin?
+
+    logged_in_as_admin? ? admin_only_access_denied : access_denied
   end
 
   def collection_maintainers_only
@@ -348,7 +350,9 @@ public
   end
 
   def collection_maintainers_or_privileged_admins_only
-    (logged_in? && @collection && @collection.user_is_maintainer?(current_user)) || privileged_collection_admin? || access_denied
+    return if (logged_in? && @collection && @collection.user_is_maintainer?(current_user)) || privileged_collection_admin?
+
+    logged_in_as_admin? ? admin_only_access_denied : access_denied
   end
 
   def collection_owners_only
@@ -356,7 +360,9 @@ public
   end
 
   def collection_owners_or_privileged_admins_only
-    (logged_in? && @collection && @collection.user_is_owner?(current_user)) || privileged_collection_admin? || access_denied
+    return if (logged_in? && @collection && @collection.user_is_owner?(current_user)) || privileged_collection_admin?
+
+    logged_in_as_admin? ? admin_only_access_denied : access_denied
   end
 
   def not_allowed(fallback=nil)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -339,7 +339,7 @@ public
     policy(Collection).access?
   end
 
-  def users_or_privileged_collection_admin_only
+  def users_or_privileged_collection_admins_only
     return if logged_in? || privileged_collection_admin?
 
     logged_in_as_admin? ? admin_only_access_denied : access_denied

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -104,6 +104,7 @@ class ApplicationController < ActionController::Base
   helper_method :logged_in?
   helper_method :logged_in_as_admin?
   helper_method :guest?
+  helper_method :privileged_collection_admin?
 
   # Title helpers
   helper_method :process_title

--- a/app/controllers/challenge/gift_exchange_controller.rb
+++ b/app/controllers/challenge/gift_exchange_controller.rb
@@ -1,9 +1,11 @@
 class Challenge::GiftExchangeController < ChallengesController
 
-  before_action :users_only
+  before_action :users_only, except: [:edit]
+  before_action :users_or_privileged_collection_admin_only, only: [:edit]
   before_action :load_collection
   before_action :load_challenge, except: [:new, :create]
-  before_action :collection_owners_only, only: [:new, :create, :edit, :update, :destroy]
+  before_action :collection_owners_or_privileged_admins_only, only: [:edit]
+  before_action :collection_owners_only, only: [:new, :create, :update, :destroy]
 
   # ACTIONS
 

--- a/app/controllers/challenge/gift_exchange_controller.rb
+++ b/app/controllers/challenge/gift_exchange_controller.rb
@@ -1,5 +1,4 @@
 class Challenge::GiftExchangeController < ChallengesController
-
   before_action :users_only, except: [:edit]
   before_action :users_or_privileged_collection_admin_only, only: [:edit]
   before_action :load_collection
@@ -13,9 +12,9 @@ class Challenge::GiftExchangeController < ChallengesController
   end
 
   def new
-    if (@collection.challenge)
-      flash[:notice] = ts("There is already a challenge set up for this collection.")
-      # TODO this will break if the challenge isn't a gift exchange
+    if @collection.challenge
+      flash[:notice] = t("challenge.gift_exchange.already_set_up")
+      # TODO: this will break if the challenge isn't a gift exchange
       redirect_to edit_collection_gift_exchange_path(@collection)
     else
       @challenge = GiftExchange.new
@@ -30,7 +29,7 @@ class Challenge::GiftExchangeController < ChallengesController
     if @challenge.save
       @collection.challenge = @challenge
       @collection.save
-      flash[:notice] = ts('Challenge was successfully created.')
+      flash[:notice] = t("challenge.gift_exchange.create.success")
       redirect_to collection_profile_path(@collection)
     else
       render action: :new
@@ -39,10 +38,10 @@ class Challenge::GiftExchangeController < ChallengesController
 
   def update
     if @challenge.update(gift_exchange_params)
-      flash[:notice] = ts('Challenge was successfully updated.')
+      flash[:notice] = t("challenge.gift_exchange.update.success")
 
       # expire the cache on the signup form
-      ActionController::Base.new.expire_fragment('challenge_signups/new')
+      ActionController::Base.new.expire_fragment("challenge_signups/new")
 
       # see if we initialized the tag set
       redirect_to collection_profile_path(@collection)
@@ -53,7 +52,7 @@ class Challenge::GiftExchangeController < ChallengesController
 
   def destroy
     @challenge.destroy
-    flash[:notice] = 'Challenge settings were deleted.'
+    flash[:notice] = "Challenge settings were deleted."
     redirect_to @collection
   end
 
@@ -96,7 +95,7 @@ class Challenge::GiftExchangeController < ChallengesController
         :tag_sets_to_add, :character_restrict_to_fandom,
         :character_restrict_to_tag_set, :relationship_restrict_to_fandom,
         :relationship_restrict_to_tag_set,
-        tag_sets_to_remove: []
+        { tag_sets_to_remove: [] }
       ],
       potential_match_settings_attributes: [
         :id, :num_required_prompts, :num_required_fandoms, :num_required_characters,

--- a/app/controllers/challenge/gift_exchange_controller.rb
+++ b/app/controllers/challenge/gift_exchange_controller.rb
@@ -1,7 +1,6 @@
 class Challenge::GiftExchangeController < ChallengesController
 
   before_action :users_only, except: [:edit]
-  before_action :users_or_privileged_collection_admin_only, only: [:edit]
   before_action :load_collection
   before_action :load_challenge, except: [:new, :create]
   before_action :collection_owners_or_privileged_admins_only, only: [:edit]

--- a/app/controllers/challenge/gift_exchange_controller.rb
+++ b/app/controllers/challenge/gift_exchange_controller.rb
@@ -1,4 +1,5 @@
 class Challenge::GiftExchangeController < ChallengesController
+
   before_action :users_only, except: [:edit]
   before_action :users_or_privileged_collection_admin_only, only: [:edit]
   before_action :load_collection
@@ -12,9 +13,9 @@ class Challenge::GiftExchangeController < ChallengesController
   end
 
   def new
-    if @collection.challenge
-      flash[:notice] = t("challenge.gift_exchange.already_set_up")
-      # TODO: this will break if the challenge isn't a gift exchange
+    if (@collection.challenge)
+      flash[:notice] = ts("There is already a challenge set up for this collection.")
+      # TODO this will break if the challenge isn't a gift exchange
       redirect_to edit_collection_gift_exchange_path(@collection)
     else
       @challenge = GiftExchange.new
@@ -29,7 +30,7 @@ class Challenge::GiftExchangeController < ChallengesController
     if @challenge.save
       @collection.challenge = @challenge
       @collection.save
-      flash[:notice] = t("challenge.gift_exchange.create.success")
+      flash[:notice] = ts('Challenge was successfully created.')
       redirect_to collection_profile_path(@collection)
     else
       render action: :new
@@ -38,10 +39,10 @@ class Challenge::GiftExchangeController < ChallengesController
 
   def update
     if @challenge.update(gift_exchange_params)
-      flash[:notice] = t("challenge.gift_exchange.update.success")
+      flash[:notice] = ts('Challenge was successfully updated.')
 
       # expire the cache on the signup form
-      ActionController::Base.new.expire_fragment("challenge_signups/new")
+      ActionController::Base.new.expire_fragment('challenge_signups/new')
 
       # see if we initialized the tag set
       redirect_to collection_profile_path(@collection)
@@ -52,7 +53,7 @@ class Challenge::GiftExchangeController < ChallengesController
 
   def destroy
     @challenge.destroy
-    flash[:notice] = "Challenge settings were deleted."
+    flash[:notice] = 'Challenge settings were deleted.'
     redirect_to @collection
   end
 
@@ -95,7 +96,7 @@ class Challenge::GiftExchangeController < ChallengesController
         :tag_sets_to_add, :character_restrict_to_fandom,
         :character_restrict_to_tag_set, :relationship_restrict_to_fandom,
         :relationship_restrict_to_tag_set,
-        { tag_sets_to_remove: [] }
+        tag_sets_to_remove: []
       ],
       potential_match_settings_attributes: [
         :id, :num_required_prompts, :num_required_fandoms, :num_required_characters,

--- a/app/controllers/challenge/prompt_meme_controller.rb
+++ b/app/controllers/challenge/prompt_meme_controller.rb
@@ -1,5 +1,4 @@
 class Challenge::PromptMemeController < ChallengesController
-
   before_action :users_only, except: [:edit]
   before_action :users_or_privileged_collection_admin_only, only: [:edit]
   before_action :load_collection
@@ -15,7 +14,7 @@ class Challenge::PromptMemeController < ChallengesController
 
   # The new form for prompt memes is actually the challenge settings page because challenges are always created in the context of a collection.
   def new
-    if (@collection.challenge)
+    if @collection.challenge
       flash[:notice] = ts("There is already a challenge set up for this collection.")
       redirect_to edit_collection_prompt_meme_path(@collection)
     else
@@ -78,5 +77,4 @@ class Challenge::PromptMemeController < ChallengesController
       ]
     )
   end
-
 end

--- a/app/controllers/challenge/prompt_meme_controller.rb
+++ b/app/controllers/challenge/prompt_meme_controller.rb
@@ -1,9 +1,11 @@
 class Challenge::PromptMemeController < ChallengesController
 
-  before_action :users_only
+  before_action :users_only, except: [:edit]
+  before_action :users_or_privileged_collection_admin_only, only: [:edit]
   before_action :load_collection
   before_action :load_challenge, except: [:new, :create]
-  before_action :collection_owners_only, only: [:new, :create, :edit, :update, :destroy]
+  before_action :collection_owners_or_privileged_admins_only, only: [:edit]
+  before_action :collection_owners_only, only: [:new, :create, :update, :destroy]
 
   # ACTIONS
 

--- a/app/controllers/challenge/prompt_meme_controller.rb
+++ b/app/controllers/challenge/prompt_meme_controller.rb
@@ -1,7 +1,6 @@
 class Challenge::PromptMemeController < ChallengesController
 
   before_action :users_only, except: [:edit]
-  before_action :users_or_privileged_collection_admin_only, only: [:edit]
   before_action :load_collection
   before_action :load_challenge, except: [:new, :create]
   before_action :collection_owners_or_privileged_admins_only, only: [:edit]

--- a/app/controllers/challenge/prompt_meme_controller.rb
+++ b/app/controllers/challenge/prompt_meme_controller.rb
@@ -1,4 +1,5 @@
 class Challenge::PromptMemeController < ChallengesController
+
   before_action :users_only, except: [:edit]
   before_action :users_or_privileged_collection_admin_only, only: [:edit]
   before_action :load_collection
@@ -14,7 +15,7 @@ class Challenge::PromptMemeController < ChallengesController
 
   # The new form for prompt memes is actually the challenge settings page because challenges are always created in the context of a collection.
   def new
-    if @collection.challenge
+    if (@collection.challenge)
       flash[:notice] = ts("There is already a challenge set up for this collection.")
       redirect_to edit_collection_prompt_meme_path(@collection)
     else
@@ -77,4 +78,5 @@ class Challenge::PromptMemeController < ChallengesController
       ]
     )
   end
+
 end

--- a/app/controllers/challenge_assignments_controller.rb
+++ b/app/controllers/challenge_assignments_controller.rb
@@ -1,6 +1,6 @@
 class ChallengeAssignmentsController < ApplicationController
   before_action :users_only, except: [:index, :show]
-  before_action :users_or_privileged_collection_admin_only, only: [:index, :show]
+  before_action :users_or_privileged_collection_admins_only, only: [:index, :show]
 
   before_action :load_collection, except: [:index]
   before_action :load_challenge, except: [:index]

--- a/app/controllers/challenge_claims_controller.rb
+++ b/app/controllers/challenge_claims_controller.rb
@@ -9,7 +9,6 @@ class ChallengeClaimsController < ApplicationController
 
   before_action :allowed_to_destroy, only: [:destroy]
 
-
   # PERMISSIONS AND STATUS CHECKING
 
   def load_challenge
@@ -22,8 +21,12 @@ class ChallengeClaimsController < ApplicationController
   end
 
   def no_challenge
-    flash[:error] = ts("What challenge did you want to work with?")
-    redirect_to collection_path(@collection) rescue redirect_to '/'
+    flash[:error] = t("challenge_claims.no_challenge")
+    begin
+      redirect_to collection_path(@collection)
+    rescue StandardError
+      redirect_to "/"
+    end
     false
   end
 
@@ -33,11 +36,19 @@ class ChallengeClaimsController < ApplicationController
   end
 
   def no_claim
-    flash[:error] = ts("What claim did you want to work on?")
+    flash[:error] = t("challenge_claims.no_claim")
     if @collection
-      redirect_to collection_path(@collection) rescue redirect_to '/'
+      begin
+        redirect_to collection_path(@collection)
+      rescue StandardError
+        redirect_to "/"
+      end
     else
-      redirect_to user_path(@user) rescue redirect_to '/'
+      begin
+        redirect_to user_path(@user)
+      rescue StandardError
+        redirect_to "/"
+      end
     end
     false
   end
@@ -48,7 +59,7 @@ class ChallengeClaimsController < ApplicationController
   end
 
   def no_user
-    flash[:error] = ts("What user were you trying to work with?")
+    flash[:error] = t("challenge_claims.no_user")
     redirect_to "/" and return
     false
   end
@@ -56,7 +67,7 @@ class ChallengeClaimsController < ApplicationController
   def owner_only
     return if @user == @challenge_claim.claiming_user
 
-    flash[:error] = ts("You aren't the claimer of that prompt.")
+    flash[:error] = t("challenge_claims.owner_only")
     redirect_to "/" and return false
   end
 
@@ -64,11 +75,10 @@ class ChallengeClaimsController < ApplicationController
     @challenge_claim.user_allowed_to_destroy?(current_user) || not_allowed(@collection)
   end
 
-
   # ACTIONS
 
   def index
-    flash[:notice] = ts("This challenge is currently closed to new posts.") if !(@collection = Collection.find_by(name: params[:collection_id])).nil? && @collection.closed? && !@collection.user_is_maintainer?(current_user) && !privileged_collection_admin?
+    flash[:notice] = t("challenge_claims.index.challenge_closed") if !(@collection = Collection.find_by(name: params[:collection_id])).nil? && @collection.closed? && !@collection.user_is_maintainer?(current_user) && !privileged_collection_admin?
     if params[:collection_id]
       return unless load_collection
 
@@ -81,19 +91,19 @@ class ChallengeClaimsController < ApplicationController
       # sorting
       set_sort_order
 
-      if params[:sort] == "claimer"
-        @claims = @claims.order_by_offering_pseud(@sort_direction)
-      else
-        @claims = @claims.order(@sort_order)
-      end
+      @claims = if params[:sort] == "claimer"
+                  @claims.order_by_offering_pseud(@sort_direction)
+                else
+                  @claims.order(@sort_order)
+                end
     elsif params[:user_id] && (@user = User.find_by(login: params[:user_id]))
       if current_user == @user
         @claims = @user.request_claims.order_by_date.unposted
         @claims = @user.request_claims.order_by_date.posted if params[:posted]
         @claims = @claims.in_collection(@collection) if params[:collection_id] && (@collection = Collection.find_by(name: params[:collection_id]))
       else
-        flash[:error] = ts("You aren't allowed to see that user's claims.")
-        redirect_to '/' and return
+        flash[:error] = t("challenge_claims.index.access_denied_user_claims")
+        redirect_to "/" and return
       end
     end
     @claims = @claims.paginate page: params[:page], per_page: ArchiveConfig.ITEMS_PER_PAGE
@@ -118,18 +128,18 @@ class ChallengeClaimsController < ApplicationController
 
   def destroy
     redirect_path = collection_claims_path(@collection)
-    flash[:notice] = ts("The claim was deleted.")
+    flash[:notice] = t("challenge_claims.destroy.claim_deleted")
 
     if @challenge_claim.claiming_user == current_user
       redirect_path = collection_claims_path(@collection, for_user: true)
-      flash[:notice] = ts("Your claim was deleted.")
+      flash[:notice] = t("challenge_claims.destroy.your_claim_deleted")
     end
 
     begin
       @challenge_claim.destroy
-    rescue
+    rescue StandardError
       flash.delete(:notice)
-      flash[:error] = ts("We couldn't delete that right now, sorry! Please try again later.")
+      flash[:error] = t("challenge_claims.destroy.delete_failed")
     end
     redirect_to redirect_path
   end

--- a/app/controllers/challenge_claims_controller.rb
+++ b/app/controllers/challenge_claims_controller.rb
@@ -1,4 +1,5 @@
 class ChallengeClaimsController < ApplicationController
+
   before_action :users_only, except: [:index]
   before_action :users_or_privileged_collection_admin_only, only: [:index]
   before_action :load_collection, except: [:index]
@@ -8,6 +9,7 @@ class ChallengeClaimsController < ApplicationController
   before_action :load_challenge, except: [:index]
 
   before_action :allowed_to_destroy, only: [:destroy]
+
 
   # PERMISSIONS AND STATUS CHECKING
 
@@ -21,12 +23,8 @@ class ChallengeClaimsController < ApplicationController
   end
 
   def no_challenge
-    flash[:error] = t("challenge_claims.no_challenge")
-    begin
-      redirect_to collection_path(@collection)
-    rescue StandardError
-      redirect_to "/"
-    end
+    flash[:error] = ts("What challenge did you want to work with?")
+    redirect_to collection_path(@collection) rescue redirect_to '/'
     false
   end
 
@@ -36,19 +34,11 @@ class ChallengeClaimsController < ApplicationController
   end
 
   def no_claim
-    flash[:error] = t("challenge_claims.no_claim")
+    flash[:error] = ts("What claim did you want to work on?")
     if @collection
-      begin
-        redirect_to collection_path(@collection)
-      rescue StandardError
-        redirect_to "/"
-      end
+      redirect_to collection_path(@collection) rescue redirect_to '/'
     else
-      begin
-        redirect_to user_path(@user)
-      rescue StandardError
-        redirect_to "/"
-      end
+      redirect_to user_path(@user) rescue redirect_to '/'
     end
     false
   end
@@ -59,26 +49,29 @@ class ChallengeClaimsController < ApplicationController
   end
 
   def no_user
-    flash[:error] = t("challenge_claims.no_user")
+    flash[:error] = ts("What user were you trying to work with?")
     redirect_to "/" and return
     false
   end
 
   def owner_only
-    return if @user == @challenge_claim.claiming_user
-
-    flash[:error] = t("challenge_claims.owner_only")
-    redirect_to "/" and return false
+    unless @user == @challenge_claim.claiming_user
+      flash[:error] = ts("You aren't the claimer of that prompt.")
+      redirect_to "/" and return false
+    end
   end
 
   def allowed_to_destroy
     @challenge_claim.user_allowed_to_destroy?(current_user) || not_allowed(@collection)
   end
 
+
   # ACTIONS
 
   def index
-    flash[:notice] = t("challenge_claims.index.challenge_closed") if !(@collection = Collection.find_by(name: params[:collection_id])).nil? && @collection.closed? && !@collection.user_is_maintainer?(current_user) && !privileged_collection_admin?
+    if !(@collection = Collection.find_by(name: params[:collection_id])).nil? && @collection.closed? && !@collection.user_is_maintainer?(current_user) && !privileged_collection_admin?
+      flash[:notice] = ts("This challenge is currently closed to new posts.")
+    end
     if params[:collection_id]
       return unless load_collection
 
@@ -91,19 +84,23 @@ class ChallengeClaimsController < ApplicationController
       # sorting
       set_sort_order
 
-      @claims = if params[:sort] == "claimer"
-                  @claims.order_by_offering_pseud(@sort_direction)
-                else
-                  @claims.order(@sort_order)
-                end
+      if params[:sort] == "claimer"
+        @claims = @claims.order_by_offering_pseud(@sort_direction)
+      else
+        @claims = @claims.order(@sort_order)
+      end
     elsif params[:user_id] && (@user = User.find_by(login: params[:user_id]))
       if current_user == @user
         @claims = @user.request_claims.order_by_date.unposted
-        @claims = @user.request_claims.order_by_date.posted if params[:posted]
-        @claims = @claims.in_collection(@collection) if params[:collection_id] && (@collection = Collection.find_by(name: params[:collection_id]))
+				if params[:posted]
+					@claims = @user.request_claims.order_by_date.posted
+				end
+        if params[:collection_id] && (@collection = Collection.find_by(name: params[:collection_id]))
+          @claims = @claims.in_collection(@collection)
+        end
       else
-        flash[:error] = t("challenge_claims.index.access_denied_user_claims")
-        redirect_to "/" and return
+        flash[:error] = ts("You aren't allowed to see that user's claims.")
+        redirect_to '/' and return
       end
     end
     @claims = @claims.paginate page: params[:page], per_page: ArchiveConfig.ITEMS_PER_PAGE
@@ -128,18 +125,18 @@ class ChallengeClaimsController < ApplicationController
 
   def destroy
     redirect_path = collection_claims_path(@collection)
-    flash[:notice] = t("challenge_claims.destroy.claim_deleted")
+    flash[:notice] = ts("The claim was deleted.")
 
     if @challenge_claim.claiming_user == current_user
       redirect_path = collection_claims_path(@collection, for_user: true)
-      flash[:notice] = t("challenge_claims.destroy.your_claim_deleted")
+      flash[:notice] = ts("Your claim was deleted.")
     end
 
     begin
       @challenge_claim.destroy
-    rescue StandardError
+    rescue
       flash.delete(:notice)
-      flash[:error] = t("challenge_claims.destroy.delete_failed")
+      flash[:error] = ts("We couldn't delete that right now, sorry! Please try again later.")
     end
     redirect_to redirect_path
   end

--- a/app/controllers/challenge_claims_controller.rb
+++ b/app/controllers/challenge_claims_controller.rb
@@ -1,7 +1,7 @@
 class ChallengeClaimsController < ApplicationController
 
   before_action :users_only, except: [:index]
-  before_action :users_or_privileged_collection_admin_only, only: [:index]
+  before_action :users_or_privileged_collection_admins_only, only: [:index]
   before_action :load_collection, except: [:index]
   before_action :collection_owners_only, except: [:index, :show, :create, :destroy]
   before_action :load_claim_from_id, only: [:show, :destroy]
@@ -79,7 +79,7 @@ class ChallengeClaimsController < ApplicationController
       not_allowed(@collection) unless user_scoped? || @challenge.user_allowed_to_see_assignments?(current_user) || privileged_collection_admin?
 
       @claims = ChallengeClaim.unposted_in_collection(@collection)
-      @claims = @claims.where(claiming_user_id: current_user.id) if user_scoped?
+      @claims = @claims.where(claiming_user_id: current_user.id) if user_scoped? && current_user
 
       # sorting
       set_sort_order

--- a/app/controllers/challenge_requests_controller.rb
+++ b/app/controllers/challenge_requests_controller.rb
@@ -7,10 +7,10 @@ class ChallengeRequestsController < ApplicationController
       flash.now[:notice] = ts("Collection could not be found")
       redirect_to "/" and return
     end
-    unless @collection.challenge_type == "PromptMeme" || privileged_collection_admin? || (@collection.challenge_type == "GiftExchange" && @collection.challenge.user_allowed_to_see_requests_summary?(current_user))
-      flash.now[:notice] = ts("You are not allowed to view the requests summary!")
-      redirect_to collection_path(@collection) and return
-    end
+    return if @collection.challenge_type == "PromptMeme" || privileged_collection_admin? || (@collection.challenge_type == "GiftExchange" && @collection.challenge.user_allowed_to_see_requests_summary?(current_user))
+
+    flash.now[:notice] = ts("You are not allowed to view the requests summary!")
+    redirect_to collection_path(@collection) and return
   end
 
   def index

--- a/app/controllers/challenge_requests_controller.rb
+++ b/app/controllers/challenge_requests_controller.rb
@@ -7,7 +7,7 @@ class ChallengeRequestsController < ApplicationController
       flash.now[:notice] = ts("Collection could not be found")
       redirect_to "/" and return
     end
-    unless @collection.challenge_type == "PromptMeme" || (@collection.challenge_type == "GiftExchange" && @collection.challenge.user_allowed_to_see_requests_summary?(current_user))
+    unless @collection.challenge_type == "PromptMeme" || privileged_collection_admin? || (@collection.challenge_type == "GiftExchange" && @collection.challenge.user_allowed_to_see_requests_summary?(current_user))
       flash.now[:notice] = ts("You are not allowed to view the requests summary!")
       redirect_to collection_path(@collection) and return
     end

--- a/app/controllers/challenge_requests_controller.rb
+++ b/app/controllers/challenge_requests_controller.rb
@@ -4,13 +4,15 @@ class ChallengeRequestsController < ApplicationController
 
   def check_visibility
     unless @collection
-      flash.now[:notice] = t("challenge_requests.check_visibility.collection_not_found")
+      flash.now[:notice] = ts("Collection could not be found")
       redirect_to "/" and return
     end
-    return if @collection.challenge_type == "PromptMeme" || privileged_collection_admin? || (@collection.challenge_type == "GiftExchange" && @collection.challenge.user_allowed_to_see_requests_summary?(current_user))
+    unless @collection.challenge_type == "PromptMeme" || privileged_collection_admin? || (@collection.challenge_type == "GiftExchange" && @collection.challenge.user_allowed_to_see_requests_summary?(current_user))
+      return admin_only_access_denied if logged_in_as_admin?
 
-    flash.now[:notice] = t("challenge_requests.check_visibility.access_denied")
-    redirect_to collection_path(@collection) and return
+      flash.now[:notice] = ts("You are not allowed to view the requests summary!")
+      redirect_to collection_path(@collection) and return
+    end
   end
 
   def index
@@ -23,10 +25,9 @@ class ChallengeRequestsController < ApplicationController
     # actual content, do the efficient method unless we need the full query
 
     if @sort_column == "fandom"
-      query = "SELECT prompts.*, GROUP_CONCAT(tags.name) AS tagnames FROM prompts INNER JOIN set_taggings ON prompts.tag_set_id = set_taggings.tag_set_id " \
-              "INNER JOIN tags ON tags.id = set_taggings.tag_id " \
-              "WHERE prompts.type = 'Request' AND tags.type = 'Fandom' AND prompts.collection_id = #{@collection.id} " \
-              "GROUP BY prompts.id ORDER BY tagnames #{@sort_direction}"
+      query = "SELECT prompts.*, GROUP_CONCAT(tags.name) AS tagnames FROM prompts INNER JOIN set_taggings ON prompts.tag_set_id = set_taggings.tag_set_id 
+      INNER JOIN tags ON tags.id = set_taggings.tag_id 
+      WHERE prompts.type = 'Request' AND tags.type = 'Fandom' AND prompts.collection_id = " + @collection.id.to_s + " GROUP BY prompts.id ORDER BY tagnames " + @sort_direction
       @requests = Prompt.paginate_by_sql(query, page: params[:page], per_page: ArchiveConfig.ITEMS_PER_PAGE)
     elsif @sort_column == "prompter" && !@collection.prompts.exists?(anonymous: true)
       @requests = @collection.prompts.where(type: "Request")

--- a/app/controllers/challenge_requests_controller.rb
+++ b/app/controllers/challenge_requests_controller.rb
@@ -7,12 +7,14 @@ class ChallengeRequestsController < ApplicationController
       flash.now[:notice] = ts("Collection could not be found")
       redirect_to "/" and return
     end
-    unless @collection.challenge_type == "PromptMeme" || privileged_collection_admin? || (@collection.challenge_type == "GiftExchange" && @collection.challenge.user_allowed_to_see_requests_summary?(current_user))
-      return admin_only_access_denied if logged_in_as_admin?
 
-      flash.now[:notice] = ts("You are not allowed to view the requests summary!")
-      redirect_to collection_path(@collection) and return
-    end
+    return if @collection.challenge_type == "PromptMeme" || privileged_collection_admin?
+    return if @collection.challenge_type == "GiftExchange" && @collection.challenge.user_allowed_to_see_requests_summary?(current_user)
+
+    return admin_only_access_denied if logged_in_as_admin?
+
+    flash.now[:notice] = ts("You are not allowed to view the requests summary!")
+    redirect_to collection_path(@collection) and return
   end
 
   def index

--- a/app/controllers/challenge_signups_controller.rb
+++ b/app/controllers/challenge_signups_controller.rb
@@ -5,7 +5,7 @@ class ChallengeSignupsController < ApplicationController
   include ExportsHelper
 
   before_action :users_only, except: [:summary, :index, :show]
-  before_action :users_or_privileged_collection_admin_only, only: [:index, :show]
+  before_action :users_or_privileged_collection_admins_only, only: [:index, :show]
   before_action :load_collection, except: [:index]
   before_action :load_challenge, except: [:index]
   before_action :load_signup_from_id, only: [:show, :edit, :update, :destroy, :confirm_delete]

--- a/app/controllers/challenge_signups_controller.rb
+++ b/app/controllers/challenge_signups_controller.rb
@@ -1,5 +1,5 @@
 # For exporting to Excel CSV format
-require "csv"
+require 'csv'
 
 class ChallengeSignupsController < ApplicationController
   include ExportsHelper
@@ -22,26 +22,18 @@ class ChallengeSignupsController < ApplicationController
   end
 
   def no_challenge
-    flash[:error] = t("challenge_signups.no_challenge")
-    begin
-      redirect_to collection_path(@collection)
-    rescue StandardError
-      redirect_to "/"
-    end
+    flash[:error] = ts("What challenge did you want to sign up for?")
+    redirect_to collection_path(@collection) rescue redirect_to '/'
     false
   end
 
   def check_signup_open
-    signup_closed and return unless @challenge.signup_open || @collection.user_is_maintainer?(current_user)
+    signup_closed and return unless (@challenge.signup_open || @collection.user_is_maintainer?(current_user))
   end
 
   def signup_closed
-    flash[:error] = t("challenge_signups.signup_closed")
-    begin
-      redirect_to @collection
-    rescue StandardError
-      redirect_to "/"
-    end
+    flash[:error] = ts("Sign-up is currently closed: please contact a moderator for help.")
+    redirect_to @collection rescue redirect_to '/'
     false
   end
 
@@ -54,11 +46,11 @@ class ChallengeSignupsController < ApplicationController
   end
 
   def maintainer_or_signup_owner_only
-    not_allowed(@collection) and return unless @challenge_signup.pseud.user == current_user || @collection.user_is_maintainer?(current_user) || privileged_collection_admin?
+    not_allowed(@collection) and return unless (@challenge_signup.pseud.user == current_user || @collection.user_is_maintainer?(current_user) || privileged_collection_admin?)
   end
 
   def not_signup_owner
-    flash[:error] = t("challenge_signups.not_signup_owner")
+    flash[:error] = ts("You can't edit someone else's sign-up!")
     redirect_to @collection
     false
   end
@@ -72,20 +64,20 @@ class ChallengeSignupsController < ApplicationController
   end
 
   def check_pseud_ownership
-    return unless params[:challenge_signup][:pseud_id] && (pseud = Pseud.find(params[:challenge_signup][:pseud_id]))
-
-    # either you have to own the pseud, OR you have to be a mod editing after signups are closed and NOT changing the pseud
-    return if current_user.pseuds.include?(pseud) || (@challenge_signup && @challenge_signup.pseud == pseud && signup_closed_owner?)
-
-    flash[:error] = t("challenge_signups.check_pseud_ownership.invalid_pseud")
-    redirect_to root_path and return
+    if params[:challenge_signup][:pseud_id] && (pseud = Pseud.find(params[:challenge_signup][:pseud_id]))
+      # either you have to own the pseud, OR you have to be a mod editing after signups are closed and NOT changing the pseud
+      unless current_user.pseuds.include?(pseud) || (@challenge_signup && @challenge_signup.pseud == pseud && signup_closed_owner?)
+        flash[:error] = ts("You can't sign up with that pseud.")
+        redirect_to root_path and return
+      end
+    end
   end
 
   def check_signup_in_collection
-    return if @challenge_signup.collection_id == @collection.id
-
-    flash[:error] = t("challenge_signups.check_signup_in_collection.signup_not_in_collection")
-    redirect_to @collection
+    unless @challenge_signup.collection_id == @collection.id
+      flash[:error] = ts("Sorry, that sign-up isn't associated with that collection.")
+      redirect_to @collection
+    end
   end
 
   #### ACTIONS
@@ -96,8 +88,8 @@ class ChallengeSignupsController < ApplicationController
         @challenge_signups = @user.challenge_signups.order_by_date
         render action: :index and return
       else
-        flash[:error] = t("challenge_signups.index.access_denied_user_signups")
-        redirect_to "/" and return
+        flash[:error] = ts("You aren't allowed to see that user's sign-ups.")
+        redirect_to '/' and return
       end
     else
       load_collection
@@ -108,36 +100,32 @@ class ChallengeSignupsController < ApplicationController
     # using respond_to in order to provide Excel output
     # see ExportsHelper for export_csv method
     respond_to do |format|
-      format.html do
-        if @challenge.user_allowed_to_see_signups?(current_user) || privileged_collection_admin?
-          @challenge_signups = @collection.signups.joins(:pseud)
-          if params[:query]
-            @query = params[:query]
-            @challenge_signups = @challenge_signups.where("pseuds.name LIKE ?", "%#{params[:query]}%")
+      format.html {
+          if @challenge.user_allowed_to_see_signups?(current_user) || privileged_collection_admin?
+            @challenge_signups = @collection.signups.joins(:pseud)
+            if params[:query]
+              @query = params[:query]
+              @challenge_signups = @challenge_signups.where("pseuds.name LIKE ?", '%' + params[:query] + '%')
+            end
+            @challenge_signups = @challenge_signups.order("pseuds.name").paginate(page: params[:page], per_page: ArchiveConfig.ITEMS_PER_PAGE)
+          elsif params[:user_id] && (@user = User.find_by(login: params[:user_id]))
+            @challenge_signups = @collection.signups.by_user(current_user)
+          else
+            not_allowed(@collection)
           end
-          @challenge_signups = @challenge_signups.order("pseuds.name").paginate(page: params[:page], per_page: ArchiveConfig.ITEMS_PER_PAGE)
-        elsif params[:user_id] && (@user = User.find_by(login: params[:user_id]))
-          @challenge_signups = @collection.signups.by_user(current_user)
-        else
-          not_allowed(@collection)
-        end
-      end
-      format.csv do
+      }
+      format.csv {
         if privileged_collection_admin? ||
            (@collection.gift_exchange? && @challenge.user_allowed_to_see_signups?(current_user)) ||
-           (@collection.prompt_meme? && @collection.user_is_maintainer?(current_user))
+        (@collection.prompt_meme? && @collection.user_is_maintainer?(current_user))
           csv_data = self.send("#{@challenge.class.name.underscore}_to_csv")
-          filename = "#{@collection.name}_signups_#{Time.current.strftime('%Y-%m-%d-%H%M')}.csv"
+          filename = "#{@collection.name}_signups_#{Time.now.strftime('%Y-%m-%d-%H%M')}.csv"
           send_csv_data(csv_data, filename)
         else
-          flash[:error] = t("challenge_signups.index.access_denied_csv")
-          begin
-            redirect_to collection_path(@collection)
-          rescue StandardError
-            redirect_to "/" and return
-          end
+          flash[:error] = ts("You aren't allowed to see the CSV summary.")
+          redirect_to collection_path(@collection) rescue redirect_to '/' and return
         end
-      end
+      }
     end
   end
 
@@ -146,8 +134,8 @@ class ChallengeSignupsController < ApplicationController
 
     @summary = ChallengeSignupSummary.new(@collection)
 
-    if @collection.signups.count < (ArchiveConfig.ANONYMOUS_THRESHOLD_COUNT / 2)
-      flash.now[:notice] = t("challenge_signups.summary.minimum_signups", count: ((ArchiveConfig.ANONYMOUS_THRESHOLD_COUNT / 2)))
+    if @collection.signups.count < (ArchiveConfig.ANONYMOUS_THRESHOLD_COUNT/2)
+      flash.now[:notice] = ts("Summary does not appear until at least %{count} sign-ups have been made!", count: ((ArchiveConfig.ANONYMOUS_THRESHOLD_COUNT/2)))
     elsif @collection.signups.count > ArchiveConfig.MAX_SIGNUPS_FOR_LIVE_SUMMARY
       # too many signups in this collection to show the summary page "live"
       modification_time = @summary.cached_time
@@ -175,42 +163,40 @@ class ChallengeSignupsController < ApplicationController
   end
 
   def show
-    return if @challenge_signup.valid?
-
-    flash[:error] = t("challenge_signups.show.invalid_signup")
+    unless @challenge_signup.valid?
+      flash[:error] = ts("This sign-up is invalid. Please check your sign-ups for a duplicate or edit to fix any other problems.")
+    end
   end
 
   protected
-
   def build_prompts
     notice = ""
     @challenge.class::PROMPT_TYPES.each do |prompt_type|
       num_to_build = params["num_#{prompt_type}"] ? params["num_#{prompt_type}"].to_i : @challenge.required(prompt_type)
       if num_to_build < @challenge.required(prompt_type)
-        notice += t("challenge_signups.build_prompts.must_submit_at_least", required: @challenge.required(prompt_type), prompt_type: prompt_type)
+        notice += ts("You must submit at least %{required} #{prompt_type}. ", required: @challenge.required(prompt_type))
         num_to_build = @challenge.required(prompt_type)
       elsif num_to_build > @challenge.allowed(prompt_type)
-        notice += t("challenge_signups.build_prompts.can_only_submit_up_to", allowed: @challenge.allowed(prompt_type), prompt_type: prompt_type)
+        notice += ts("You can only submit up to %{allowed} #{prompt_type}. ", allowed: @challenge.allowed(prompt_type))
         num_to_build = @challenge.allowed(prompt_type)
       elsif params["num_#{prompt_type}"]
-        notice += t("challenge_signups.build_prompts.set_up_num", num: num_to_build, prompt_type: prompt_type.pluralize)
+        notice += ts("Set up %{num} #{prompt_type.pluralize}. ", num: num_to_build)
       end
       num_existing = @challenge_signup.send(prompt_type).count
-      num_existing.upto(num_to_build - 1) do
+      num_existing.upto(num_to_build-1) do
         @challenge_signup.send(prompt_type).build
       end
     end
-    return if notice.blank?
-
-    flash[:notice] = notice
+    unless notice.blank?
+      flash[:notice] = notice
+    end
   end
 
   public
-
   def new
     @page_subtitle = t(".page_title")
     if (@challenge_signup = ChallengeSignup.in_collection(@collection).by_user(current_user).first)
-      flash[:notice] = t("challenge_signups.new.already_signed_up")
+      flash[:notice] = ts("You are already signed up for this challenge. You can edit your sign-up below.")
       redirect_to edit_collection_signup_path(@collection, @challenge_signup)
     else
       @challenge_signup = ChallengeSignup.new
@@ -229,7 +215,7 @@ class ChallengeSignupsController < ApplicationController
     @challenge_signup.collection = @collection
     # we check validity first to prevent saving tag sets if invalid
     if @challenge_signup.valid? && @challenge_signup.save
-      flash[:notice] = t("challenge_signups.create.success")
+      flash[:notice] = ts('Sign-up was successfully created.')
       redirect_to collection_signup_path(@collection, @challenge_signup)
     else
       render action: :new
@@ -238,7 +224,7 @@ class ChallengeSignupsController < ApplicationController
 
   def update
     if @challenge_signup.update(challenge_signup_params)
-      flash[:notice] = t("challenge_signups.update.success")
+      flash[:notice] = ts('Sign-up was successfully updated.')
       redirect_to collection_signup_path(@collection, @challenge_signup)
     else
       render action: :edit
@@ -249,11 +235,11 @@ class ChallengeSignupsController < ApplicationController
   end
 
   def destroy
-    if @challenge.signup_open || @collection.user_is_maintainer?(current_user)
-      @challenge_signup.destroy
-      flash[:notice] = t("challenge_signups.destroy.success")
+    unless @challenge.signup_open || @collection.user_is_maintainer?(current_user)
+      flash[:error] = ts("You cannot delete your sign-up after sign-ups are closed. Please contact a moderator for help.")
     else
-      flash[:error] = t("challenge_signups.destroy.signups_closed")
+      @challenge_signup.destroy
+      flash[:notice] = ts("Challenge sign-up was deleted.")
     end
     if @collection.user_is_maintainer?(current_user) && !@collection.prompt_meme?
       redirect_to collection_signups_path(@collection)
@@ -264,21 +250,17 @@ class ChallengeSignupsController < ApplicationController
     end
   end
 
-  protected
+
+protected
 
   def request_to_array(type, request)
-    any_types = TagSet::TAG_TYPES.select { |tag_type| request&.send("any_#{tag_type}") }
-    any_types.map! { |tag_type| t("challenge_signups.request_to_array.any_type", type: tag_type.capitalize) }
-    tags = request.nil? ? [] : request.tag_set.tags.map(&:name)
+    any_types = TagSet::TAG_TYPES.select {|type| request && request.send("any_#{type}")}
+    any_types.map! { |type| ts("Any %{type}", type: type.capitalize) }
+    tags = request.nil? ? [] : request.tag_set.tags.map {|tag| tag.name}
     rarray = [(tags + any_types).join(", ")]
 
     if @challenge.send("#{type}_restriction").optional_tags_allowed
-      rarray << (if request.nil?
-                   ""
-                 else
-                   request.optional_tag_set.tags.map(&:name)
-                 .join(", ")
-                 end)
+      rarray << (request.nil? ? "" : request.optional_tag_set.tags.map {|tag| tag.name}.join(", "))
     end
 
     if @challenge.send("#{type}_restriction").title_allowed
@@ -298,22 +280,23 @@ class ChallengeSignupsController < ApplicationController
     rarray << (request.nil? ? "" : request.url) if
       @challenge.send("#{type}_restriction").url_allowed
 
-    rarray
+    return rarray
   end
+
 
   def gift_exchange_to_csv
     header = ["Pseud", "Email", "Sign-up URL"]
 
-    %w[request offer].each do |type|
+    %w(request offer).each do |type|
       @challenge.send("#{type.pluralize}_num_allowed").times do |i|
-        header << "#{type.capitalize} #{i + 1} Tags"
-        header << "#{type.capitalize} #{i + 1} Optional Tags" if
+        header << "#{type.capitalize} #{i+1} Tags"
+        header << "#{type.capitalize} #{i+1} Optional Tags" if
           @challenge.send("#{type}_restriction").optional_tags_allowed
-        header << "#{type.capitalize} #{i + 1} Title" if
+        header << "#{type.capitalize} #{i+1} Title" if
           @challenge.send("#{type}_restriction").title_allowed
-        header << "#{type.capitalize} #{i + 1} Description" if
+        header << "#{type.capitalize} #{i+1} Description" if
           @challenge.send("#{type}_restriction").description_allowed
-        header << "#{type.capitalize} #{i + 1} URL" if
+        header << "#{type.capitalize} #{i+1} URL" if
           @challenge.send("#{type}_restriction").url_allowed
       end
     end
@@ -325,7 +308,7 @@ class ChallengeSignupsController < ApplicationController
       row = [signup.pseud.name, signup.pseud.user.email,
              collection_signup_url(@collection, signup)]
 
-      %w[request offer].each do |type|
+      %w(request offer).each do |type|
         @challenge.send("#{type.pluralize}_num_allowed").times do |i|
           row += request_to_array(type, signup.send(type.pluralize)[i])
         end
@@ -335,6 +318,7 @@ class ChallengeSignupsController < ApplicationController
 
     csv_array
   end
+
 
   def prompt_meme_to_csv
     header = ["Pseud", "Sign-up URL", "Tags"]
@@ -384,7 +368,7 @@ class ChallengeSignupsController < ApplicationController
       :anonymous,
       :description,
       :_destroy,
-      { tag_set_attributes: [
+      tag_set_attributes: [
         :id,
         :updated_at,
         :character_tagnames,
@@ -394,17 +378,17 @@ class ChallengeSignupsController < ApplicationController
         :rating_tagnames,
         :archive_warning_tagnames,
         :fandom_tagnames,
-        { character_tagnames: [],
-          relationship_tagnames: [],
-          freeform_tagnames: [],
-          category_tagnames: [],
-          rating_tagnames: [],
-          archive_warning_tagnames: [],
-          fandom_tagnames: [] }
+        character_tagnames: [],
+        relationship_tagnames: [],
+        freeform_tagnames: [],
+        category_tagnames: [],
+        rating_tagnames: [],
+        archive_warning_tagnames: [],
+        fandom_tagnames: [],
       ],
-        optional_tag_set_attributes: [
-          :tagnames
-        ] }
+      optional_tag_set_attributes: [
+        :tagnames
+      ]
     ]
   end
 end

--- a/app/controllers/collection_items_controller.rb
+++ b/app/controllers/collection_items_controller.rb
@@ -10,7 +10,7 @@ class CollectionItemsController < ApplicationController
   def index
 
     # TODO: AO3-6507 Refactor to use send instead of case statements.
-    if @collection && @collection.user_is_maintainer?(current_user)
+    if @collection && (@collection.user_is_maintainer?(current_user) || privileged_collection_admin?)
       @collection_items = @collection.collection_items.include_for_works
       @collection_items = case params[:status]
                           when "approved"

--- a/app/controllers/collection_items_controller.rb
+++ b/app/controllers/collection_items_controller.rb
@@ -38,9 +38,9 @@ class CollectionItemsController < ApplicationController
                           else
                             @collection_items.unreviewed_by_user
                           end
-    elsif logged_in_as_admin?
-      admin_only_access_denied and return
     else
+      admin_only_access_denied and return if logged_in_as_admin?
+
       flash[:error] = ts("You don't have permission to see that, sorry!")
       redirect_to collections_path and return
     end

--- a/app/controllers/collection_items_controller.rb
+++ b/app/controllers/collection_items_controller.rb
@@ -38,6 +38,8 @@ class CollectionItemsController < ApplicationController
                           else
                             @collection_items.unreviewed_by_user
                           end
+    elsif logged_in_as_admin?
+      admin_only_access_denied and return
     else
       flash[:error] = ts("You don't have permission to see that, sorry!")
       redirect_to collections_path and return

--- a/app/controllers/collection_participants_controller.rb
+++ b/app/controllers/collection_participants_controller.rb
@@ -1,11 +1,13 @@
 class CollectionParticipantsController < ApplicationController
-  before_action :users_only
+  before_action :users_only, except: [:index]
+  before_action :users_or_privileged_collection_admin_only, only: [:index]
   before_action :load_collection
   before_action :load_participant, only: [:update, :destroy]
   before_action :allowed_to_promote, only: [:update]
   before_action :allowed_to_destroy, only: [:destroy]
   before_action :has_other_owners, only: [:update, :destroy]
-  before_action :collection_maintainers_only, only: [:index, :add, :update]
+  before_action :collection_maintainers_or_privileged_admins_only, only: [:index]
+  before_action :collection_maintainers_only, only: [:add, :update]
 
   cache_sweeper :collection_sweeper
 

--- a/app/controllers/collection_participants_controller.rb
+++ b/app/controllers/collection_participants_controller.rb
@@ -1,6 +1,5 @@
 class CollectionParticipantsController < ApplicationController
   before_action :users_only, except: [:index]
-  before_action :users_or_privileged_collection_admin_only, only: [:index]
   before_action :load_collection
   before_action :load_participant, only: [:update, :destroy]
   before_action :allowed_to_promote, only: [:update]

--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -1,7 +1,9 @@
 class CollectionsController < ApplicationController
-  before_action :users_only, only: [:new, :edit, :create, :update]
+  before_action :users_only, only: [:new, :create, :update]
+  before_action :users_or_privileged_collection_admin_only, only: [:edit]
   before_action :load_collection_from_id, only: [:show, :edit, :update, :destroy, :confirm_delete]
-  before_action :collection_owners_only, only: [:edit, :update, :destroy, :confirm_delete]
+  before_action :collection_owners_or_privileged_admins_only, only: [:edit]
+  before_action :collection_owners_only, only: [:update, :destroy, :confirm_delete]
   before_action :check_user_status, only: [:new, :create, :edit, :update, :destroy]
   before_action :validate_challenge_type
   before_action :check_parent_visible, only: [:index]

--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -1,6 +1,5 @@
 class CollectionsController < ApplicationController
-  before_action :users_only, only: [:new, :create, :update]
-  before_action :users_or_privileged_collection_admin_only, only: [:edit]
+  before_action :users_only, only: [:new, :create]
   before_action :load_collection_from_id, only: [:show, :edit, :update, :destroy, :confirm_delete]
   before_action :collection_owners_or_privileged_admins_only, only: [:edit]
   before_action :collection_owners_only, only: [:update, :destroy, :confirm_delete]

--- a/app/controllers/potential_matches_controller.rb
+++ b/app/controllers/potential_matches_controller.rb
@@ -9,15 +9,18 @@ class PotentialMatchesController < ApplicationController
   before_action :check_signup_closed, only: [:generate]
   before_action :load_potential_match_from_id, only: [:show]
 
-
   def load_challenge
     @challenge = @collection.challenge
     no_challenge and return unless @challenge
   end
 
   def no_challenge
-    flash[:error] = ts("What challenge did you want to sign up for?")
-    redirect_to collection_path(@collection) rescue redirect_to '/'
+    flash[:error] = t("potential_matches.no_challenge")
+    begin
+      redirect_to collection_path(@collection)
+    rescue StandardError
+      redirect_to "/"
+    end
     false
   end
 
@@ -27,18 +30,26 @@ class PotentialMatchesController < ApplicationController
   end
 
   def no_assignment
-    flash[:error] = ts("What potential match did you want to work on?")
-    redirect_to collection_path(@collection) rescue redirect_to '/'
+    flash[:error] = t("potential_matches.no_assignment")
+    begin
+      redirect_to collection_path(@collection)
+    rescue StandardError
+      redirect_to "/"
+    end
     false
   end
 
   def check_signup_closed
-    signup_open and return unless !@challenge.signup_open
+    signup_open and return if @challenge.signup_open
   end
 
   def signup_open
-    flash[:error] = ts("Sign-up is still open, you cannot determine potential matches now.")
-    redirect_to @collection rescue redirect_to '/'
+    flash[:error] = t("potential_matches.signup_open")
+    begin
+      redirect_to @collection
+    rescue StandardError
+      redirect_to "/"
+    end
     false
   end
 
@@ -47,8 +58,12 @@ class PotentialMatchesController < ApplicationController
   end
 
   def assignments_sent
-    flash[:error] = ts("Assignments have already been sent! If necessary, you can purge them.")
-    redirect_to collection_assignments_path(@collection) rescue redirect_to '/'
+    flash[:error] = t("potential_matches.assignments_sent")
+    begin
+      redirect_to collection_assignments_path(@collection)
+    rescue StandardError
+      redirect_to "/"
+    end
     false
   end
 
@@ -64,9 +79,9 @@ class PotentialMatchesController < ApplicationController
       @progress = PotentialMatch.progress(@collection)
     elsif ChallengeAssignment.in_progress?(@collection)
       @assignment_in_progress = true
-    elsif @collection.potential_matches.count > 0 && @collection.assignments.count == 0
-      flash[:error] = ts("There has been an error in the potential matching. Please first try regenerating assignments, and if that doesn't work, all potential matches. If the problem persists, please contact Support.")
-    elsif @collection.potential_matches.count > 0
+    elsif @collection.potential_matches.count.positive? && @collection.assignments.count.zero?
+      flash[:error] = t("potential_matches.index.matching_error")
+    elsif @collection.potential_matches.count.positive?
       # we have potential_matches and assignments
 
       ### find assignments with no potential recipients
@@ -80,19 +95,19 @@ class PotentialMatchesController < ApplicationController
       @assignments_with_no_potential_givers = @collection.assignments.where(request_signup_id: no_rpms)
 
       # list the assignments by requester
-      if params[:no_giver]
-        @assignments = @collection.assignments.with_request.with_no_offer.order_by_requesting_pseud
-      elsif params[:no_recipient]
-        # ordering causes this to hang on large challenge due to
-        # left join required to get offering pseuds
-        @assignments = @collection.assignments.with_offer.with_no_request # .order_by_offering_pseud
-      elsif params[:dup_giver]
-        @assignments = ChallengeAssignment.duplicate_givers(@collection).order_by_offering_pseud
-      elsif params[:dup_recipient]
-        @assignments = ChallengeAssignment.duplicate_recipients(@collection).order_by_requesting_pseud
-      else
-        @assignments = @collection.assignments.with_request.with_offer.order_by_requesting_pseud
-      end
+      @assignments = if params[:no_giver]
+                       @collection.assignments.with_request.with_no_offer.order_by_requesting_pseud
+                     elsif params[:no_recipient]
+                       # ordering causes this to hang on large challenge due to
+                       # left join required to get offering pseuds
+                       @collection.assignments.with_offer.with_no_request # .order_by_offering_pseud
+                     elsif params[:dup_giver]
+                       ChallengeAssignment.duplicate_givers(@collection).order_by_offering_pseud
+                     elsif params[:dup_recipient]
+                       ChallengeAssignment.duplicate_recipients(@collection).order_by_requesting_pseud
+                     else
+                       @collection.assignments.with_request.with_offer.order_by_requesting_pseud
+                     end
       @assignments = @assignments.paginate page: params[:page], per_page: ArchiveConfig.ITEMS_PER_PAGE
     end
   end
@@ -100,13 +115,13 @@ class PotentialMatchesController < ApplicationController
   # Generate potential matches
   def generate
     if PotentialMatch.in_progress?(@collection)
-      flash[:error] = ts("Potential matches are already being generated for this collection!")
+      flash[:error] = t("potential_matches.generate.already_in_progress")
     else
       # delete all existing assignments and potential matches for this collection
       ChallengeAssignment.clear!(@collection)
       PotentialMatch.clear!(@collection)
 
-      flash[:notice] = ts("Beginning generation of potential matches. This may take some time, especially if your challenge is large.")
+      flash[:notice] = t("potential_matches.generate.started")
       PotentialMatch.set_up_generating(@collection)
       PotentialMatch.generate(@collection)
     end
@@ -118,11 +133,10 @@ class PotentialMatchesController < ApplicationController
   # Regenerate matches for one signup
   def regenerate_for_signup
     if params[:signup_id].blank? || (@signup = ChallengeSignup.where(id: params[:signup_id]).first).nil?
-      flash[:error] = ts("What sign-up did you want to regenerate matches for?")
+      flash[:error] = t("potential_matches.regenerate_for_signup.no_signup")
     else
       PotentialMatch.regenerate_for_signup(@signup)
-      flash[:notice] = ts("Matches are being regenerated for ") + @signup.pseud.byline +
-                       ts(". Please allow at least 5 minutes for this process to complete before refreshing the page.")
+      flash[:notice] = t("potential_matches.regenerate_for_signup.started", pseud: @signup.pseud.byline)
     end
     # redirect to index
     redirect_to collection_potential_matches_path(@collection)
@@ -130,12 +144,12 @@ class PotentialMatchesController < ApplicationController
 
   def cancel_generate
     if !PotentialMatch.in_progress?(@collection)
-      flash[:error] = ts("Potential matches are not currently being generated for this challenge.")
+      flash[:error] = t("potential_matches.cancel_generate.not_in_progress")
     elsif PotentialMatch.canceled?(@collection)
-      flash[:error] = ts("Potential match generation has already been canceled, please refresh again shortly.")
+      flash[:error] = t("potential_matches.cancel_generate.already_canceled")
     else
       PotentialMatch.cancel_generation(@collection)
-      flash[:notice] = ts("Potential match generation cancellation requested. This may take a while, please refresh shortly.")
+      flash[:notice] = t("potential_matches.cancel_generate.requested")
     end
 
     redirect_to collection_potential_matches_path(@collection)

--- a/app/controllers/potential_matches_controller.rb
+++ b/app/controllers/potential_matches_controller.rb
@@ -1,5 +1,4 @@
 class PotentialMatchesController < ApplicationController
-
   before_action :users_only, except: [:index, :show]
   before_action :users_or_privileged_collection_admin_only, only: [:index, :show]
   before_action :load_collection
@@ -123,7 +122,7 @@ class PotentialMatchesController < ApplicationController
     else
       PotentialMatch.regenerate_for_signup(@signup)
       flash[:notice] = ts("Matches are being regenerated for ") + @signup.pseud.byline +
-        ts(". Please allow at least 5 minutes for this process to complete before refreshing the page.")
+                       ts(". Please allow at least 5 minutes for this process to complete before refreshing the page.")
     end
     # redirect to index
     redirect_to collection_potential_matches_path(@collection)
@@ -144,5 +143,4 @@ class PotentialMatchesController < ApplicationController
 
   def show
   end
-
 end

--- a/app/controllers/potential_matches_controller.rb
+++ b/app/controllers/potential_matches_controller.rb
@@ -1,8 +1,10 @@
 class PotentialMatchesController < ApplicationController
 
-  before_action :users_only
+  before_action :users_only, except: [:index, :show]
+  before_action :users_or_privileged_collection_admin_only, only: [:index, :show]
   before_action :load_collection
-  before_action :collection_maintainers_only
+  before_action :collection_maintainers_or_privileged_admins_only, only: [:index, :show]
+  before_action :collection_maintainers_only, except: [:index, :show]
   before_action :load_challenge
   before_action :check_assignments_not_sent
   before_action :check_signup_closed, only: [:generate]

--- a/app/controllers/potential_matches_controller.rb
+++ b/app/controllers/potential_matches_controller.rb
@@ -1,4 +1,5 @@
 class PotentialMatchesController < ApplicationController
+
   before_action :users_only, except: [:index, :show]
   before_action :users_or_privileged_collection_admin_only, only: [:index, :show]
   before_action :load_collection
@@ -9,18 +10,15 @@ class PotentialMatchesController < ApplicationController
   before_action :check_signup_closed, only: [:generate]
   before_action :load_potential_match_from_id, only: [:show]
 
+
   def load_challenge
     @challenge = @collection.challenge
     no_challenge and return unless @challenge
   end
 
   def no_challenge
-    flash[:error] = t("potential_matches.no_challenge")
-    begin
-      redirect_to collection_path(@collection)
-    rescue StandardError
-      redirect_to "/"
-    end
+    flash[:error] = ts("What challenge did you want to sign up for?")
+    redirect_to collection_path(@collection) rescue redirect_to '/'
     false
   end
 
@@ -30,26 +28,18 @@ class PotentialMatchesController < ApplicationController
   end
 
   def no_assignment
-    flash[:error] = t("potential_matches.no_assignment")
-    begin
-      redirect_to collection_path(@collection)
-    rescue StandardError
-      redirect_to "/"
-    end
+    flash[:error] = ts("What potential match did you want to work on?")
+    redirect_to collection_path(@collection) rescue redirect_to '/'
     false
   end
 
   def check_signup_closed
-    signup_open and return if @challenge.signup_open
+    signup_open and return unless !@challenge.signup_open
   end
 
   def signup_open
-    flash[:error] = t("potential_matches.signup_open")
-    begin
-      redirect_to @collection
-    rescue StandardError
-      redirect_to "/"
-    end
+    flash[:error] = ts("Sign-up is still open, you cannot determine potential matches now.")
+    redirect_to @collection rescue redirect_to '/'
     false
   end
 
@@ -58,12 +48,8 @@ class PotentialMatchesController < ApplicationController
   end
 
   def assignments_sent
-    flash[:error] = t("potential_matches.assignments_sent")
-    begin
-      redirect_to collection_assignments_path(@collection)
-    rescue StandardError
-      redirect_to "/"
-    end
+    flash[:error] = ts("Assignments have already been sent! If necessary, you can purge them.")
+    redirect_to collection_assignments_path(@collection) rescue redirect_to '/'
     false
   end
 
@@ -79,9 +65,9 @@ class PotentialMatchesController < ApplicationController
       @progress = PotentialMatch.progress(@collection)
     elsif ChallengeAssignment.in_progress?(@collection)
       @assignment_in_progress = true
-    elsif @collection.potential_matches.count.positive? && @collection.assignments.count.zero?
-      flash[:error] = t("potential_matches.index.matching_error")
-    elsif @collection.potential_matches.count.positive?
+    elsif @collection.potential_matches.count > 0 && @collection.assignments.count == 0
+      flash[:error] = ts("There has been an error in the potential matching. Please first try regenerating assignments, and if that doesn't work, all potential matches. If the problem persists, please contact Support.")
+    elsif @collection.potential_matches.count > 0
       # we have potential_matches and assignments
 
       ### find assignments with no potential recipients
@@ -95,19 +81,19 @@ class PotentialMatchesController < ApplicationController
       @assignments_with_no_potential_givers = @collection.assignments.where(request_signup_id: no_rpms)
 
       # list the assignments by requester
-      @assignments = if params[:no_giver]
-                       @collection.assignments.with_request.with_no_offer.order_by_requesting_pseud
-                     elsif params[:no_recipient]
-                       # ordering causes this to hang on large challenge due to
-                       # left join required to get offering pseuds
-                       @collection.assignments.with_offer.with_no_request # .order_by_offering_pseud
-                     elsif params[:dup_giver]
-                       ChallengeAssignment.duplicate_givers(@collection).order_by_offering_pseud
-                     elsif params[:dup_recipient]
-                       ChallengeAssignment.duplicate_recipients(@collection).order_by_requesting_pseud
-                     else
-                       @collection.assignments.with_request.with_offer.order_by_requesting_pseud
-                     end
+      if params[:no_giver]
+        @assignments = @collection.assignments.with_request.with_no_offer.order_by_requesting_pseud
+      elsif params[:no_recipient]
+        # ordering causes this to hang on large challenge due to
+        # left join required to get offering pseuds
+        @assignments = @collection.assignments.with_offer.with_no_request # .order_by_offering_pseud
+      elsif params[:dup_giver]
+        @assignments = ChallengeAssignment.duplicate_givers(@collection).order_by_offering_pseud
+      elsif params[:dup_recipient]
+        @assignments = ChallengeAssignment.duplicate_recipients(@collection).order_by_requesting_pseud
+      else
+        @assignments = @collection.assignments.with_request.with_offer.order_by_requesting_pseud
+      end
       @assignments = @assignments.paginate page: params[:page], per_page: ArchiveConfig.ITEMS_PER_PAGE
     end
   end
@@ -115,13 +101,13 @@ class PotentialMatchesController < ApplicationController
   # Generate potential matches
   def generate
     if PotentialMatch.in_progress?(@collection)
-      flash[:error] = t("potential_matches.generate.already_in_progress")
+      flash[:error] = ts("Potential matches are already being generated for this collection!")
     else
       # delete all existing assignments and potential matches for this collection
       ChallengeAssignment.clear!(@collection)
       PotentialMatch.clear!(@collection)
 
-      flash[:notice] = t("potential_matches.generate.started")
+      flash[:notice] = ts("Beginning generation of potential matches. This may take some time, especially if your challenge is large.")
       PotentialMatch.set_up_generating(@collection)
       PotentialMatch.generate(@collection)
     end
@@ -133,10 +119,11 @@ class PotentialMatchesController < ApplicationController
   # Regenerate matches for one signup
   def regenerate_for_signup
     if params[:signup_id].blank? || (@signup = ChallengeSignup.where(id: params[:signup_id]).first).nil?
-      flash[:error] = t("potential_matches.regenerate_for_signup.no_signup")
+      flash[:error] = ts("What sign-up did you want to regenerate matches for?")
     else
       PotentialMatch.regenerate_for_signup(@signup)
-      flash[:notice] = t("potential_matches.regenerate_for_signup.started", pseud: @signup.pseud.byline)
+      flash[:notice] = ts("Matches are being regenerated for ") + @signup.pseud.byline +
+        ts(". Please allow at least 5 minutes for this process to complete before refreshing the page.")
     end
     # redirect to index
     redirect_to collection_potential_matches_path(@collection)
@@ -144,12 +131,12 @@ class PotentialMatchesController < ApplicationController
 
   def cancel_generate
     if !PotentialMatch.in_progress?(@collection)
-      flash[:error] = t("potential_matches.cancel_generate.not_in_progress")
+      flash[:error] = ts("Potential matches are not currently being generated for this challenge.")
     elsif PotentialMatch.canceled?(@collection)
-      flash[:error] = t("potential_matches.cancel_generate.already_canceled")
+      flash[:error] = ts("Potential match generation has already been canceled, please refresh again shortly.")
     else
       PotentialMatch.cancel_generation(@collection)
-      flash[:notice] = t("potential_matches.cancel_generate.requested")
+      flash[:notice] = ts("Potential match generation cancellation requested. This may take a while, please refresh shortly.")
     end
 
     redirect_to collection_potential_matches_path(@collection)
@@ -157,4 +144,5 @@ class PotentialMatchesController < ApplicationController
 
   def show
   end
+
 end

--- a/app/controllers/potential_matches_controller.rb
+++ b/app/controllers/potential_matches_controller.rb
@@ -1,10 +1,8 @@
 class PotentialMatchesController < ApplicationController
 
-  before_action :users_only, except: [:index, :show]
-  before_action :users_or_privileged_collection_admin_only, only: [:index, :show]
   before_action :load_collection
-  before_action :collection_maintainers_or_privileged_admins_only, only: [:index, :show]
-  before_action :collection_maintainers_only, except: [:index, :show]
+  before_action :collection_maintainers_or_privileged_admins_only, only: [:index]
+  before_action :collection_maintainers_only, except: [:index]
   before_action :load_challenge
   before_action :check_assignments_not_sent
   before_action :check_signup_closed, only: [:generate]

--- a/app/policies/collection_policy.rb
+++ b/app/policies/collection_policy.rb
@@ -1,0 +1,7 @@
+class CollectionPolicy < ApplicationPolicy
+  ACCESS_ROLES = %w[support policy_and_abuse superadmin].freeze
+
+  def access?
+    user_has_roles?(ACCESS_ROLES)
+  end
+end

--- a/app/views/challenge_assignments/index.html.erb
+++ b/app/views/challenge_assignments/index.html.erb
@@ -1,5 +1,5 @@
 <% if @user %>
   <%= render "user_index" %>
-<% elsif @challenge && @challenge.user_allowed_to_see_assignments?(current_user) %>
+<% elsif @challenge && (@challenge.user_allowed_to_see_assignments?(current_user) || privileged_collection_admin?) %>
   <%= render "maintainer_index" %>
 <% end %>

--- a/app/views/challenge_claims/index.html.erb
+++ b/app/views/challenge_claims/index.html.erb
@@ -1,5 +1,5 @@
-<% if @user || params[:for_user] || (@challenge && !@challenge.user_allowed_to_see_claims?(current_user)) %>
+<% if @user || params[:for_user] || (@challenge && !@challenge.user_allowed_to_see_claims?(current_user) && !privileged_collection_admin?) %>
   <%= render "user_index" %>
-<% elsif @challenge && @challenge.user_allowed_to_see_claims?(current_user) %>
-  <%= render "maintainer_index" %>  
+<% elsif @challenge && (@challenge.user_allowed_to_see_claims?(current_user) || privileged_collection_admin?) %>
+  <%= render "maintainer_index" %>
 <% end %>

--- a/app/views/collection_items/_collection_item_controls.html.erb
+++ b/app/views/collection_items/_collection_item_controls.html.erb
@@ -64,7 +64,7 @@
   <% end %>        
 
   <li>
-    <% disable_destroy = !collection_item.user_allowed_to_destroy?(@current_user) %>
+    <% disable_destroy = @current_user.nil? || !collection_item.user_allowed_to_destroy?(@current_user) %>
     <%= form.label(:remove,
       options = {},
       html_options = { class: disable_destroy ? "disabled" : nil }) do %>

--- a/app/views/collections/_form.html.erb
+++ b/app/views/collections/_form.html.erb
@@ -5,14 +5,14 @@
     <legend><%= ts("Header") %></legend>
     <dl>
 
-      <% if @collection.new_record? && current_user.pseuds.size > 1 %>
+      <% if @collection.new_record? && current_user&.pseuds&.size.to_i > 1 %>
         <dt>
           <%= label_tag "owner_pseuds[]", ts("Owner pseud(s)") %>
         </dt>
         <dd>
           <%= select_tag "owner_pseuds[]", options_from_collection_for_select(current_user.pseuds, :id, :name, current_user.default_pseud_id), multiple: true %>
         </dd>
-      <% else %>
+      <% elsif current_user %>
         <p><%= hidden_field_tag "owner_pseuds[]", [current_user.default_pseud.id] %></p>
       <% end %>
 

--- a/config/locales/controllers/en.yml
+++ b/config/locales/controllers/en.yml
@@ -113,7 +113,7 @@ en:
       access_denied: You are not allowed to view the requests summary!
   challenge_signups:
     no_challenge: What challenge did you want to sign up for?
-    signup_closed: Sign-up is currently closed: please contact a moderator for help.
+    signup_closed: "Sign-up is currently closed: please contact a moderator for help."
     not_signup_owner: You can't edit someone else's sign-up!
     check_pseud_ownership:
       invalid_pseud: You can't sign up with that pseud.

--- a/config/locales/controllers/en.yml
+++ b/config/locales/controllers/en.yml
@@ -90,58 +90,6 @@ en:
       success: Bookmark was successfully created. It should appear in bookmark listings within the next few minutes.
       warnings:
         private_bookmark_added_to_collection: " Please note: private bookmarks are not listed in collections."
-  challenge_assignments:
-    index:
-      access_denied_user: You aren't allowed to see that user's assignments.
-    validation:
-      not_owner: You aren't the owner of that assignment.
-  challenge_claims:
-    no_challenge: What challenge did you want to work with?
-    no_claim: What claim did you want to work on?
-    no_user: What user were you trying to work with?
-    owner_only: You aren't the claimer of that prompt.
-    index:
-      challenge_closed: This challenge is currently closed to new posts.
-      access_denied_user_claims: You aren't allowed to see that user's claims.
-    destroy:
-      claim_deleted: The claim was deleted.
-      your_claim_deleted: Your claim was deleted.
-      delete_failed: We couldn't delete that right now, sorry! Please try again later.
-  challenge_requests:
-    check_visibility:
-      collection_not_found: Collection could not be found
-      access_denied: You are not allowed to view the requests summary!
-  challenge_signups:
-    no_challenge: What challenge did you want to sign up for?
-    signup_closed: "Sign-up is currently closed: please contact a moderator for help."
-    not_signup_owner: You can't edit someone else's sign-up!
-    check_pseud_ownership:
-      invalid_pseud: You can't sign up with that pseud.
-    check_signup_in_collection:
-      signup_not_in_collection: Sorry, that sign-up isn't associated with that collection.
-    index:
-      access_denied_user_signups: You aren't allowed to see that user's sign-ups.
-      access_denied_csv: You aren't allowed to see the CSV summary.
-    summary:
-      minimum_signups: Summary does not appear until at least %{count} sign-ups have been made!
-    show:
-      invalid_signup: This sign-up is invalid. Please check your sign-ups for a duplicate or edit to fix any other problems.
-    build_prompts:
-      must_submit_at_least: You must submit at least %{required} %{prompt_type}.
-      can_only_submit_up_to: You can only submit up to %{allowed} %{prompt_type}.
-      set_up_num: Set up %{num} %{prompt_type}.
-    request_to_array:
-      any_type: Any %{type}
-    new:
-      page_title: New Challenge Sign-up
-      already_signed_up: You are already signed up for this challenge. You can edit your sign-up below.
-    create:
-      success: Sign-up was successfully created.
-    update:
-      success: Sign-up was successfully updated.
-    destroy:
-      success: Challenge sign-up was deleted.
-      signups_closed: You cannot delete your sign-up after sign-ups are closed. Please contact a moderator for help.
   challenge:
     gift_exchange:
       already_set_up: There is already a challenge set up for this collection.
@@ -149,23 +97,58 @@ en:
         success: Challenge was successfully created.
       update:
         success: Challenge was successfully updated.
-  potential_matches:
-    no_challenge: What challenge did you want to sign up for?
-    no_assignment: What potential match did you want to work on?
-    signup_open: Sign-up is still open, you cannot determine potential matches now.
-    assignments_sent: Assignments have already been sent! If necessary, you can purge them.
+  challenge_assignments:
     index:
-      matching_error: There has been an error in the potential matching. Please first try regenerating assignments, and if that doesn't work, all potential matches. If the problem persists, please contact Support.
-    generate:
-      already_in_progress: Potential matches are already being generated for this collection!
-      started: Beginning generation of potential matches. This may take some time, especially if your challenge is large.
-    regenerate_for_signup:
-      no_signup: What sign-up did you want to regenerate matches for?
-      started: "Matches are being regenerated for %{pseud}. Please allow at least 5 minutes for this process to complete before refreshing the page."
-    cancel_generate:
-      not_in_progress: Potential matches are not currently being generated for this challenge.
-      already_canceled: Potential match generation has already been canceled, please refresh again shortly.
-      requested: Potential match generation cancellation requested. This may take a while, please refresh shortly.
+      access_denied_user: You aren't allowed to see that user's assignments.
+    validation:
+      not_owner: You aren't the owner of that assignment.
+  challenge_claims:
+    destroy:
+      claim_deleted: The claim was deleted.
+      delete_failed: We couldn't delete that right now, sorry! Please try again later.
+      your_claim_deleted: Your claim was deleted.
+    index:
+      access_denied_user_claims: You aren't allowed to see that user's claims.
+      challenge_closed: This challenge is currently closed to new posts.
+    no_challenge: What challenge did you want to work with?
+    no_claim: What claim did you want to work on?
+    no_user: What user were you trying to work with?
+    owner_only: You aren't the claimer of that prompt.
+  challenge_requests:
+    check_visibility:
+      access_denied: You are not allowed to view the requests summary!
+      collection_not_found: Collection could not be found
+  challenge_signups:
+    build_prompts:
+      can_only_submit_up_to: You can only submit up to %{allowed} %{prompt_type}.
+      must_submit_at_least: You must submit at least %{required} %{prompt_type}.
+      set_up_num: Set up %{num} %{prompt_type}.
+    check_pseud_ownership:
+      invalid_pseud: You can't sign up with that pseud.
+    check_signup_in_collection:
+      signup_not_in_collection: Sorry, that sign-up isn't associated with that collection.
+    create:
+      success: Sign-up was successfully created.
+    destroy:
+      signups_closed: You cannot delete your sign-up after sign-ups are closed. Please contact a moderator for help.
+      success: Challenge sign-up was deleted.
+    index:
+      access_denied_csv: You aren't allowed to see the CSV summary.
+      access_denied_user_signups: You aren't allowed to see that user's sign-ups.
+    new:
+      already_signed_up: You are already signed up for this challenge. You can edit your sign-up below.
+      page_title: New Challenge Sign-up
+    no_challenge: What challenge did you want to sign up for?
+    not_signup_owner: You can't edit someone else's sign-up!
+    request_to_array:
+      any_type: Any %{type}
+    show:
+      invalid_signup: This sign-up is invalid. Please check your sign-ups for a duplicate or edit to fix any other problems.
+    signup_closed: 'Sign-up is currently closed: please contact a moderator for help.'
+    summary:
+      minimum_signups: Summary does not appear until at least %{count} sign-ups have been made!
+    update:
+      success: Sign-up was successfully updated.
   chapters:
     destroy:
       only_chapter: You can't delete the only chapter in your work. If you want to delete the work, choose "Delete Work".
@@ -303,6 +286,23 @@ en:
   people:
     index:
       collection_page_title: "%{collection_title} - People"
+  potential_matches:
+    assignments_sent: Assignments have already been sent! If necessary, you can purge them.
+    cancel_generate:
+      already_canceled: Potential match generation has already been canceled, please refresh again shortly.
+      not_in_progress: Potential matches are not currently being generated for this challenge.
+      requested: Potential match generation cancellation requested. This may take a while, please refresh shortly.
+    generate:
+      already_in_progress: Potential matches are already being generated for this collection!
+      started: Beginning generation of potential matches. This may take some time, especially if your challenge is large.
+    index:
+      matching_error: There has been an error in the potential matching. Please first try regenerating assignments, and if that doesn't work, all potential matches. If the problem persists, please contact Support.
+    no_assignment: What potential match did you want to work on?
+    no_challenge: What challenge did you want to sign up for?
+    regenerate_for_signup:
+      no_signup: What sign-up did you want to regenerate matches for?
+      started: Matches are being regenerated for %{pseud}. Please allow at least 5 minutes for this process to complete before refreshing the page.
+    signup_open: Sign-up is still open, you cannot determine potential matches now.
   preferences:
     update:
       error: Sorry, something went wrong. Please try that again.

--- a/config/locales/controllers/en.yml
+++ b/config/locales/controllers/en.yml
@@ -95,9 +95,77 @@ en:
       access_denied_user: You aren't allowed to see that user's assignments.
     validation:
       not_owner: You aren't the owner of that assignment.
+  challenge_claims:
+    no_challenge: What challenge did you want to work with?
+    no_claim: What claim did you want to work on?
+    no_user: What user were you trying to work with?
+    owner_only: You aren't the claimer of that prompt.
+    index:
+      challenge_closed: This challenge is currently closed to new posts.
+      access_denied_user_claims: You aren't allowed to see that user's claims.
+    destroy:
+      claim_deleted: The claim was deleted.
+      your_claim_deleted: Your claim was deleted.
+      delete_failed: We couldn't delete that right now, sorry! Please try again later.
+  challenge_requests:
+    check_visibility:
+      collection_not_found: Collection could not be found
+      access_denied: You are not allowed to view the requests summary!
   challenge_signups:
+    no_challenge: What challenge did you want to sign up for?
+    signup_closed: Sign-up is currently closed: please contact a moderator for help.
+    not_signup_owner: You can't edit someone else's sign-up!
+    check_pseud_ownership:
+      invalid_pseud: You can't sign up with that pseud.
+    check_signup_in_collection:
+      signup_not_in_collection: Sorry, that sign-up isn't associated with that collection.
+    index:
+      access_denied_user_signups: You aren't allowed to see that user's sign-ups.
+      access_denied_csv: You aren't allowed to see the CSV summary.
+    summary:
+      minimum_signups: Summary does not appear until at least %{count} sign-ups have been made!
+    show:
+      invalid_signup: This sign-up is invalid. Please check your sign-ups for a duplicate or edit to fix any other problems.
+    build_prompts:
+      must_submit_at_least: You must submit at least %{required} %{prompt_type}.
+      can_only_submit_up_to: You can only submit up to %{allowed} %{prompt_type}.
+      set_up_num: Set up %{num} %{prompt_type}.
+    request_to_array:
+      any_type: Any %{type}
     new:
       page_title: New Challenge Sign-up
+      already_signed_up: You are already signed up for this challenge. You can edit your sign-up below.
+    create:
+      success: Sign-up was successfully created.
+    update:
+      success: Sign-up was successfully updated.
+    destroy:
+      success: Challenge sign-up was deleted.
+      signups_closed: You cannot delete your sign-up after sign-ups are closed. Please contact a moderator for help.
+  challenge:
+    gift_exchange:
+      already_set_up: There is already a challenge set up for this collection.
+      create:
+        success: Challenge was successfully created.
+      update:
+        success: Challenge was successfully updated.
+  potential_matches:
+    no_challenge: What challenge did you want to sign up for?
+    no_assignment: What potential match did you want to work on?
+    signup_open: Sign-up is still open, you cannot determine potential matches now.
+    assignments_sent: Assignments have already been sent! If necessary, you can purge them.
+    index:
+      matching_error: There has been an error in the potential matching. Please first try regenerating assignments, and if that doesn't work, all potential matches. If the problem persists, please contact Support.
+    generate:
+      already_in_progress: Potential matches are already being generated for this collection!
+      started: Beginning generation of potential matches. This may take some time, especially if your challenge is large.
+    regenerate_for_signup:
+      no_signup: What sign-up did you want to regenerate matches for?
+      started: "Matches are being regenerated for %{pseud}. Please allow at least 5 minutes for this process to complete before refreshing the page."
+    cancel_generate:
+      not_in_progress: Potential matches are not currently being generated for this challenge.
+      already_canceled: Potential match generation has already been canceled, please refresh again shortly.
+      requested: Potential match generation cancellation requested. This may take a while, please refresh shortly.
   chapters:
     destroy:
       only_chapter: You can't delete the only chapter in your work. If you want to delete the work, choose "Delete Work".

--- a/config/locales/controllers/en.yml
+++ b/config/locales/controllers/en.yml
@@ -90,65 +90,14 @@ en:
       success: Bookmark was successfully created. It should appear in bookmark listings within the next few minutes.
       warnings:
         private_bookmark_added_to_collection: " Please note: private bookmarks are not listed in collections."
-  challenge:
-    gift_exchange:
-      already_set_up: There is already a challenge set up for this collection.
-      create:
-        success: Challenge was successfully created.
-      update:
-        success: Challenge was successfully updated.
   challenge_assignments:
     index:
       access_denied_user: You aren't allowed to see that user's assignments.
     validation:
       not_owner: You aren't the owner of that assignment.
-  challenge_claims:
-    destroy:
-      claim_deleted: The claim was deleted.
-      delete_failed: We couldn't delete that right now, sorry! Please try again later.
-      your_claim_deleted: Your claim was deleted.
-    index:
-      access_denied_user_claims: You aren't allowed to see that user's claims.
-      challenge_closed: This challenge is currently closed to new posts.
-    no_challenge: What challenge did you want to work with?
-    no_claim: What claim did you want to work on?
-    no_user: What user were you trying to work with?
-    owner_only: You aren't the claimer of that prompt.
-  challenge_requests:
-    check_visibility:
-      access_denied: You are not allowed to view the requests summary!
-      collection_not_found: Collection could not be found
   challenge_signups:
-    build_prompts:
-      can_only_submit_up_to: You can only submit up to %{allowed} %{prompt_type}.
-      must_submit_at_least: You must submit at least %{required} %{prompt_type}.
-      set_up_num: Set up %{num} %{prompt_type}.
-    check_pseud_ownership:
-      invalid_pseud: You can't sign up with that pseud.
-    check_signup_in_collection:
-      signup_not_in_collection: Sorry, that sign-up isn't associated with that collection.
-    create:
-      success: Sign-up was successfully created.
-    destroy:
-      signups_closed: You cannot delete your sign-up after sign-ups are closed. Please contact a moderator for help.
-      success: Challenge sign-up was deleted.
-    index:
-      access_denied_csv: You aren't allowed to see the CSV summary.
-      access_denied_user_signups: You aren't allowed to see that user's sign-ups.
     new:
-      already_signed_up: You are already signed up for this challenge. You can edit your sign-up below.
       page_title: New Challenge Sign-up
-    no_challenge: What challenge did you want to sign up for?
-    not_signup_owner: You can't edit someone else's sign-up!
-    request_to_array:
-      any_type: Any %{type}
-    show:
-      invalid_signup: This sign-up is invalid. Please check your sign-ups for a duplicate or edit to fix any other problems.
-    signup_closed: 'Sign-up is currently closed: please contact a moderator for help.'
-    summary:
-      minimum_signups: Summary does not appear until at least %{count} sign-ups have been made!
-    update:
-      success: Sign-up was successfully updated.
   chapters:
     destroy:
       only_chapter: You can't delete the only chapter in your work. If you want to delete the work, choose "Delete Work".
@@ -286,23 +235,6 @@ en:
   people:
     index:
       collection_page_title: "%{collection_title} - People"
-  potential_matches:
-    assignments_sent: Assignments have already been sent! If necessary, you can purge them.
-    cancel_generate:
-      already_canceled: Potential match generation has already been canceled, please refresh again shortly.
-      not_in_progress: Potential matches are not currently being generated for this challenge.
-      requested: Potential match generation cancellation requested. This may take a while, please refresh shortly.
-    generate:
-      already_in_progress: Potential matches are already being generated for this collection!
-      started: Beginning generation of potential matches. This may take some time, especially if your challenge is large.
-    index:
-      matching_error: There has been an error in the potential matching. Please first try regenerating assignments, and if that doesn't work, all potential matches. If the problem persists, please contact Support.
-    no_assignment: What potential match did you want to work on?
-    no_challenge: What challenge did you want to sign up for?
-    regenerate_for_signup:
-      no_signup: What sign-up did you want to regenerate matches for?
-      started: Matches are being regenerated for %{pseud}. Please allow at least 5 minutes for this process to complete before refreshing the page.
-    signup_open: Sign-up is still open, you cannot determine potential matches now.
   preferences:
     update:
       error: Sorry, something went wrong. Please try that again.

--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -648,9 +648,7 @@ en:
         close_requests_html: Close Requests &#8593;
         heading:
           for_collection: Sign-ups for %{collection}
-          for_search:
-            one: Sign-up
-            other: Sign-ups
+          for_search: Sign-up
         navigation:
           download_csv: Download (CSV)
           search: Search

--- a/features/collections/collection_admin_access.feature
+++ b/features/collections/collection_admin_access.feature
@@ -1,0 +1,236 @@
+@collection
+
+Feature: Admin access to collection pages
+  Admins with support, policy_and_abuse, or superadmin roles should be
+  able to view all collection and challenge pages that owners can access,
+  but should not be able to make changes.
+
+  # ============================================================
+  # General Collection Pages
+  # ============================================================
+
+  Scenario: Support admin can access the Manage Items page with no items
+    Given I have a collection "Owned Collection"
+      And I am logged in as a "support" admin
+    When I view the awaiting collection approval collection items page for "Owned Collection"
+    Then I should see "Items in"
+      And I should not see "You don't have permission"
+
+  Scenario: Support admin can access the Manage Items page with items
+    Given I am logged in as "author"
+      And I set my preferences to allow collection invitations
+      And I post the work "Admin Viewable Work"
+      And I have a collection "Items Collection"
+      And I am logged in as "moderator"
+      And I invite the work "Admin Viewable Work" to the collection "Items Collection"
+      And I am logged in as "author"
+      And "author" accepts the invitation for their work in the collection "Items Collection"
+      And I press "Submit"
+    When I am logged in as a "support" admin
+      And I view the approved collection items page for "Items Collection"
+    Then I should see "Admin Viewable Work"
+
+  Scenario: Support admin can access all Manage Items status pages
+    Given I am logged in as "author"
+      And I set my preferences to allow collection invitations
+      And I post the work "Test Work"
+      And I have a moderated collection "Moderated Collection"
+      And I am logged in as "moderator"
+      And I invite the work "Test Work" to the collection "Moderated Collection"
+    When I am logged in as a "support" admin
+      And I view the awaiting collection approval collection items page for "Moderated Collection"
+    Then I should not see "You don't have permission"
+    When I view the awaiting user approval collection items page for "Moderated Collection"
+    Then I should not see "You don't have permission"
+    When I view the rejected by collection collection items page for "Moderated Collection"
+    Then I should not see "You don't have permission"
+    When I view the rejected by user collection items page for "Moderated Collection"
+    Then I should not see "You don't have permission"
+
+  Scenario: Support admin can access Collection Settings page
+    Given I have a collection "Settings Collection"
+      And I am logged in as a "support" admin
+    When I go to "Settings Collection" collection edit page
+    Then I should see "Edit Collection"
+
+  Scenario: Support admin cannot update collection settings
+    Given I have a collection "No Edit Collection"
+      And I am logged in as a "support" admin
+    When I go to "No Edit Collection" collection edit page
+      And I press "Update"
+    Then I should see "Please log out of your admin account first!"
+
+  Scenario: Support admin can access Membership page
+    Given I have a collection "Members Collection"
+      And I am logged in as a "support" admin
+    When I go to the "Members Collection" participants page
+    Then I should see "Members of"
+
+  Scenario: Support admin cannot add members
+    Given I have a collection "No Add Member Collection"
+      And I am logged in as a "support" admin
+    When I go to the "No Add Member Collection" participants page
+      And I fill in "participants_to_invite" with "someone"
+      And I press "Submit"
+    Then I should see "Please log out of your admin account first!"
+
+  Scenario: Policy and abuse admin can access collection pages
+    Given I have a collection "PAB Collection"
+      And I am logged in as a "policy_and_abuse" admin
+    When I go to "PAB Collection" collection edit page
+    Then I should see "Edit Collection"
+    When I go to the "PAB Collection" participants page
+    Then I should see "Members of"
+
+  Scenario: Superadmin can access collection pages
+    Given I have a collection "Super Collection"
+      And I am logged in as a super admin
+    When I go to "Super Collection" collection edit page
+    Then I should see "Edit Collection"
+    When I go to the "Super Collection" participants page
+    Then I should see "Members of"
+
+  Scenario: Unauthorized admin roles cannot access collection management pages
+    Given I have a collection "Restricted Collection"
+      And I am logged in as a "tag_wrangling" admin
+    When I go to "Restricted Collection" collection edit page
+    Then I should see "Sorry, only an authorized admin can access the page you were trying to reach."
+
+  # ============================================================
+  # Gift Exchange Pages
+  # ============================================================
+
+  Scenario: Support admin can access gift exchange sign-ups
+    Given I have created the gift exchange "GE Admin Test"
+      And I open signups for "GE Admin Test"
+      And I am logged in as "signer1"
+      And I sign up for "GE Admin Test" with combination A
+    When I am logged in as a "support" admin
+      And I go to the "GE Admin Test" signups page
+    Then I should see "Sign-ups"
+      And I should see "signer1"
+
+  Scenario: Support admin can access an individual sign-up
+    Given I have created the gift exchange "GE Signup View"
+      And I open signups for "GE Signup View"
+      And I am logged in as "signer1"
+      And I sign up for "GE Signup View" with combination A
+    When I am logged in as a "support" admin
+      And I go to the "GE Signup View" signups page
+      And I follow "signer1"
+    Then I should see "Sign-up for"
+      And I should see "signer1"
+
+  Scenario: Support admin can access the Requests Summary
+    Given I have created the gift exchange "GE Requests"
+      And I open signups for "GE Requests"
+      And I am logged in as "signer1"
+      And I sign up for "GE Requests" with combination A
+    When I am logged in as a "support" admin
+      And I go to the "GE Requests" requests page
+    Then I should not see "You are not allowed to view the requests summary!"
+
+  Scenario: Support admin can access the Matching page
+    Given I have created the gift exchange "GE Matching"
+      And I open signups for "GE Matching"
+    When I am logged in as a "support" admin
+      And I go to "GE Matching" gift exchange matching page
+    Then I should not see "Sorry, you don't have permission"
+
+  Scenario: Support admin cannot generate potential matches
+    Given I have created the gift exchange "GE No Match"
+      And I open signups for "GE No Match"
+      And I am logged in as "signer1"
+      And I sign up for "GE No Match" with combination A
+      And I am logged in as "signer2"
+      And I sign up for "GE No Match" with combination B
+      And I close signups for "GE No Match"
+    When I am logged in as a "support" admin
+      And I go to "GE No Match" gift exchange matching page
+      And I press "Generate Potential Matches"
+    Then I should see "Please log out of your admin account first!"
+
+  Scenario: Support admin can access Assignments page
+    Given everyone has their assignments for "GE Assignments"
+    When I am logged in as a "support" admin
+      And I go to the "GE Assignments" assignments page
+    Then I should see "Assignments"
+
+  Scenario: Support admin can access gift exchange Challenge Settings
+    Given I have created the gift exchange "GE Settings"
+    When I am logged in as a "support" admin
+      And I go to "GE Settings" gift exchange edit page
+    Then I should see "Setting Up the"
+
+  Scenario: Support admin cannot update gift exchange settings
+    Given I have created the gift exchange "GE No Edit"
+    When I am logged in as a "support" admin
+      And I go to "GE No Edit" gift exchange edit page
+      And I press "Update"
+    Then I should see "Please log out of your admin account first!"
+
+  Scenario: Support admin cannot delete a gift exchange challenge
+    Given I have created the gift exchange "GE No Delete"
+    When I am logged in as a "support" admin
+      And I go to "GE No Delete" gift exchange edit page
+      And I follow "Delete Challenge"
+    Then I should see "Please log out of your admin account first!"
+
+  Scenario: Support admin cannot default assignments
+    Given everyone has their assignments for "GE No Default"
+    When I am logged in as a "support" admin
+      And I go to the "GE No Default" assignments page
+      And I press "Default All Incomplete"
+    Then I should see "Please log out of your admin account first!"
+
+  Scenario: Support admin cannot purge assignments
+    Given everyone has their assignments for "GE No Purge"
+    When I am logged in as a "support" admin
+      And I go to the "GE No Purge" assignments page
+      And I follow "Purge Assignments"
+    Then I should see "Please log out of your admin account first!"
+
+  Scenario: Unauthorized admin cannot access gift exchange sign-ups
+    Given I have created the gift exchange "GE Restricted"
+      And I open signups for "GE Restricted"
+    When I am logged in as a "tag_wrangling" admin
+      And I go to the "GE Restricted" signups page
+    Then I should see "Sorry, only an authorized admin can access the page you were trying to reach."
+
+  # ============================================================
+  # Prompt Meme Pages
+  # ============================================================
+
+  Scenario: Support admin can access prompt meme Unposted Claims
+    Given I have Battle 12 prompt meme fully set up
+      And I open signups for "Battle 12"
+      And I am logged in as "signer1"
+      And I sign up for Battle 12 with combination A
+    When I am logged in as a "support" admin
+      And I go to the "Battle 12" claims page
+    Then I should not see "Sorry, you don't have permission"
+
+  Scenario: Support admin can access prompt meme Challenge Settings
+    Given I have Battle 12 prompt meme fully set up
+    When I am logged in as a "support" admin
+      And I go to "Battle 12" prompt meme edit page
+    Then I should see "Setting Up the"
+
+  Scenario: Support admin cannot update prompt meme settings
+    Given I have Battle 12 prompt meme fully set up
+    When I am logged in as a "support" admin
+      And I go to "Battle 12" prompt meme edit page
+      And I press "Update"
+    Then I should see "Please log out of your admin account first!"
+
+  Scenario: Unauthorized admin cannot access prompt meme claims
+    Given I have Battle 12 prompt meme fully set up
+    When I am logged in as a "tag_wrangling" admin
+      And I go to the "Battle 12" claims page
+    Then I should see "Sorry, only an authorized admin can access the page you were trying to reach."
+
+  Scenario: Unauthorized admin cannot access prompt meme Challenge Settings
+    Given I have Battle 12 prompt meme fully set up
+    When I am logged in as a "tag_wrangling" admin
+      And I go to "Battle 12" prompt meme edit page
+    Then I should see "Sorry, only an authorized admin can access the page you were trying to reach."

--- a/features/collections/collection_admin_access.feature
+++ b/features/collections/collection_admin_access.feature
@@ -39,13 +39,13 @@ Feature: Admin access to collection pages
       And I invite the work "Test Work" to the collection "Moderated Collection"
     When I am logged in as a "support" admin
       And I view the awaiting collection approval collection items page for "Moderated Collection"
-    Then I should not see "You don't have permission"
+    Then I should see "Items in"
     When I view the awaiting user approval collection items page for "Moderated Collection"
-    Then I should not see "You don't have permission"
+    Then I should see "Items in"
     When I view the rejected by collection collection items page for "Moderated Collection"
-    Then I should not see "You don't have permission"
+    Then I should see "Items in"
     When I view the rejected by user collection items page for "Moderated Collection"
-    Then I should not see "You don't have permission"
+    Then I should see "Items in"
 
   Scenario: Support admin can access Collection Settings page
     Given I have a collection "Settings Collection"
@@ -100,7 +100,7 @@ Feature: Admin access to collection pages
   # Gift Exchange Pages
   # ============================================================
 
-  Scenario: Support admin can access gift exchange sign-ups
+  Scenario: Support admin can access gift exchange sign-ups and view an individual sign-up
     Given I have created the gift exchange "GE Admin Test"
       And I open signups for "GE Admin Test"
       And I am logged in as "signer1"
@@ -109,15 +109,7 @@ Feature: Admin access to collection pages
       And I go to the "GE Admin Test" signups page
     Then I should see "Sign-ups"
       And I should see "signer1"
-
-  Scenario: Support admin can access an individual sign-up
-    Given I have created the gift exchange "GE Signup View"
-      And I open signups for "GE Signup View"
-      And I am logged in as "signer1"
-      And I sign up for "GE Signup View" with combination A
-    When I am logged in as a "support" admin
-      And I go to the "GE Signup View" signups page
-      And I follow "signer1"
+    When I follow "signer1"
     Then I should see "Sign-up for"
       And I should see "signer1"
 
@@ -128,14 +120,14 @@ Feature: Admin access to collection pages
       And I sign up for "GE Requests" with combination A
     When I am logged in as a "support" admin
       And I go to the "GE Requests" requests page
-    Then I should not see "You are not allowed to view the requests summary!"
+    Then I should see "Prompts for"
 
   Scenario: Support admin can access the Matching page
     Given I have created the gift exchange "GE Matching"
       And I open signups for "GE Matching"
     When I am logged in as a "support" admin
       And I go to "GE Matching" gift exchange matching page
-    Then I should not see "Sorry, you don't have permission"
+    Then I should see "Matching for"
 
   Scenario: Support admin cannot generate potential matches
     Given I have created the gift exchange "GE No Match"
@@ -155,6 +147,12 @@ Feature: Admin access to collection pages
     When I am logged in as a "support" admin
       And I go to the "GE Assignments" assignments page
     Then I should see "Assignments"
+
+  Scenario: Support admin can access an individual assignment
+    Given everyone has their assignments for "GE Individual Assignment"
+    When I am logged in as a "support" admin
+      And I go to the first assignment page for "GE Individual Assignment"
+    Then I should see "Assignment for"
 
   Scenario: Support admin can access gift exchange Challenge Settings
     Given I have created the gift exchange "GE Settings"
@@ -208,7 +206,7 @@ Feature: Admin access to collection pages
       And I sign up for Battle 12 with combination A
     When I am logged in as a "support" admin
       And I go to the "Battle 12" claims page
-    Then I should not see "Sorry, you don't have permission"
+    Then I should see "Unposted Claims for"
 
   Scenario: Support admin can access prompt meme Challenge Settings
     Given I have Battle 12 prompt meme fully set up

--- a/features/support/paths.rb
+++ b/features/support/paths.rb
@@ -186,6 +186,10 @@ module NavigationHelpers
       edit_collection_gift_exchange_path(Collection.find_by(title: $1))
     when /^"(.*)" gift exchange matching page$/i
       collection_potential_matches_path(Collection.find_by(title: $1))
+    when /^"(.*)" prompt meme edit page$/i
+      edit_collection_prompt_meme_path(Collection.find_by(title: $1))
+    when /^the "(.*)" claims page$/i
+      collection_claims_path(Collection.find_by(title: $1))
     when /^the works tagged "(.*?)" in collection "(.*?)"$/i
       step %{all indexing jobs have been run}
       collection_tag_works_path(Collection.find_by(title: $2), Tag.find_by_name($1))

--- a/features/support/paths.rb
+++ b/features/support/paths.rb
@@ -178,6 +178,9 @@ module NavigationHelpers
       collection_requests_path(Collection.find_by(title: $1))
     when /^the "(.*)" assignments page$/i                      # e.g. when I go to the "Collection name" assignments page
       collection_assignments_path(Collection.find_by(title: $1))
+    when /^the first assignment page for "(.*?)"$/i
+      collection = Collection.find_by(title: Regexp.last_match(1))
+      collection_assignment_path(collection, collection.assignments.first)
     when /^the "(.*)" participants page$/i                      # e.g. when I go to the "Collection name" participants page
       collection_participants_path(Collection.find_by(title: $1))
     when /^"(.*)" collection's url$/i                          # e.g. when I go to "Collection name" collection's url

--- a/spec/controllers/challenge_assignments_controller_spec.rb
+++ b/spec/controllers/challenge_assignments_controller_spec.rb
@@ -452,4 +452,31 @@ describe ChallengeAssignmentsController do
       end
     end
   end
+
+  describe "admin access to assignments pages" do
+    let(:gift_exchange) { create(:gift_exchange, assignments_sent_at: Faker::Time.backward) }
+    let(:user) { other_user }
+
+    it "allows support admins to view assignments index and individual assignment pages" do
+      fake_logout
+      fake_login_admin(create(:support_admin))
+
+      get :index, params: { collection_id: collection.name }
+      expect(response).to have_http_status(:success)
+      expect(response).to render_template(:index)
+
+      get :show, params: { id: assignment.id, collection_id: collection.name }
+      expect(response).to have_http_status(:success)
+      expect(response).to render_template(:show)
+    end
+
+    it "does not allow admins with other roles to view assignments index" do
+      fake_logout
+      fake_login_admin(create(:tag_wrangling_admin))
+
+      get :index, params: { collection_id: collection.name }
+
+      it_redirects_to_user_login_with_error
+    end
+  end
 end

--- a/spec/controllers/challenge_assignments_controller_spec.rb
+++ b/spec/controllers/challenge_assignments_controller_spec.rb
@@ -454,29 +454,32 @@ describe ChallengeAssignmentsController do
   end
 
   describe "admin access to assignments pages" do
+    authorized_roles = %w[support policy_and_abuse superadmin].freeze
     let(:gift_exchange) { create(:gift_exchange, assignments_sent_at: Faker::Time.backward) }
     let(:user) { other_user }
 
-    it "allows support admins to view assignments index and individual assignment pages" do
-      fake_logout
-      fake_login_admin(create(:support_admin))
+    before { fake_logout }
 
-      get :index, params: { collection_id: collection.name }
-      expect(response).to have_http_status(:success)
-      expect(response).to render_template(:index)
+    describe "GET #index" do
+      subject { get :index, params: { collection_id: collection.name } }
 
-      get :show, params: { id: assignment.id, collection_id: collection.name }
-      expect(response).to have_http_status(:success)
-      expect(response).to render_template(:show)
+      let(:success) do
+        expect(response).to have_http_status(:success)
+        expect(response).to render_template(:index)
+      end
+
+      it_behaves_like "an action only authorized admins can access", authorized_roles: authorized_roles
     end
 
-    it "does not allow admins with other roles to view assignments index" do
-      fake_logout
-      fake_login_admin(create(:tag_wrangling_admin))
+    describe "GET #show" do
+      subject { get :show, params: { id: assignment.id, collection_id: collection.name } }
 
-      get :index, params: { collection_id: collection.name }
+      let(:success) do
+        expect(response).to have_http_status(:success)
+        expect(response).to render_template(:show)
+      end
 
-      it_redirects_to_user_login_with_error
+      it_behaves_like "an action only authorized admins can access", authorized_roles: authorized_roles
     end
   end
 end

--- a/spec/controllers/challenge_claims_controller_spec.rb
+++ b/spec/controllers/challenge_claims_controller_spec.rb
@@ -154,4 +154,27 @@ describe ChallengeClaimsController do
       end
     end
   end
+
+  describe "admin access to claims index" do
+    let(:claiming_user) { create(:user) }
+    let!(:claim_one) { create(:challenge_claim, collection: collection, claiming_user: claiming_user) }
+    let!(:claim_two) { create(:challenge_claim, collection: collection, claiming_user: create(:user)) }
+
+    it "allows support admins to view all claims in a collection" do
+      fake_login_admin(create(:support_admin))
+
+      get :index, params: { collection_id: collection.name }
+
+      expect(response).to have_http_status(:success)
+      expect(assigns(:claims)).to include(claim_one, claim_two)
+    end
+
+    it "does not allow admins with other roles to view claims index" do
+      fake_login_admin(create(:tag_wrangling_admin))
+
+      get :index, params: { collection_id: collection.name }
+
+      it_redirects_to_user_login_with_error
+    end
+  end
 end

--- a/spec/controllers/challenge_claims_controller_spec.rb
+++ b/spec/controllers/challenge_claims_controller_spec.rb
@@ -156,25 +156,17 @@ describe ChallengeClaimsController do
   end
 
   describe "admin access to claims index" do
-    let(:claiming_user) { create(:user) }
-    let!(:claim_one) { create(:challenge_claim, collection: collection, claiming_user: claiming_user) }
+    authorized_roles = %w[support policy_and_abuse superadmin].freeze
+    let!(:claim_one) { create(:challenge_claim, collection: collection, claiming_user: create(:user)) }
     let!(:claim_two) { create(:challenge_claim, collection: collection, claiming_user: create(:user)) }
 
-    it "allows support admins to view all claims in a collection" do
-      fake_login_admin(create(:support_admin))
+    subject { get :index, params: { collection_id: collection.name } }
 
-      get :index, params: { collection_id: collection.name }
-
+    let(:success) do
       expect(response).to have_http_status(:success)
       expect(assigns(:claims)).to include(claim_one, claim_two)
     end
 
-    it "does not allow admins with other roles to view claims index" do
-      fake_login_admin(create(:tag_wrangling_admin))
-
-      get :index, params: { collection_id: collection.name }
-
-      it_redirects_to_user_login_with_error
-    end
+    it_behaves_like "an action only authorized admins can access", authorized_roles: authorized_roles
   end
 end

--- a/spec/controllers/challenge_requests_controller_spec.rb
+++ b/spec/controllers/challenge_requests_controller_spec.rb
@@ -16,5 +16,27 @@ describe ChallengeRequestsController, bookmark_search: true, collection_search: 
         expect(response.status).not_to eq(500)
       end
     end
+
+    context "with gift exchanges where request summary is private" do
+      let(:challenge) { create(:gift_exchange, requests_summary_visible: false) }
+      let(:collection) { create(:collection, challenge: challenge) }
+
+      it "allows support admins to view the requests summary" do
+        fake_login_admin(create(:support_admin))
+
+        get :index, params: { collection_id: collection.name }
+
+        expect(response).to have_http_status(:success)
+        expect(response).to render_template(:index)
+      end
+
+      it "does not allow admins with other roles to view the requests summary" do
+        fake_login_admin(create(:tag_wrangling_admin))
+
+        get :index, params: { collection_id: collection.name }
+
+        it_redirects_to_with_notice(collection_path(collection), "You are not allowed to view the requests summary!")
+      end
+    end
   end
 end

--- a/spec/controllers/challenge_requests_controller_spec.rb
+++ b/spec/controllers/challenge_requests_controller_spec.rb
@@ -1,11 +1,11 @@
 require "spec_helper"
 
-describe ChallengeRequestsController, bookmark_search: true, collection_search: true, work_search: true do 
+describe ChallengeRequestsController do
   include LoginMacros
   include RedirectExpectationHelper
 
   describe "index" do
-    context "when there are anonymous prompts" do
+    context "when there are anonymous prompts", bookmark_search: true, collection_search: true, work_search: true do
       render_views
 
       it "does not throw a 500 error if sorting by prompter with an anonymous prompt" do

--- a/spec/controllers/challenge_requests_controller_spec.rb
+++ b/spec/controllers/challenge_requests_controller_spec.rb
@@ -18,25 +18,18 @@ describe ChallengeRequestsController, bookmark_search: true, collection_search: 
     end
 
     context "with gift exchanges where request summary is private" do
+      authorized_roles = %w[support policy_and_abuse superadmin].freeze
       let(:challenge) { create(:gift_exchange, requests_summary_visible: false) }
       let(:collection) { create(:collection, challenge: challenge) }
 
-      it "allows support admins to view the requests summary" do
-        fake_login_admin(create(:support_admin))
+      subject { get :index, params: { collection_id: collection.name } }
 
-        get :index, params: { collection_id: collection.name }
-
+      let(:success) do
         expect(response).to have_http_status(:success)
         expect(response).to render_template(:index)
       end
 
-      it "does not allow admins with other roles to view the requests summary" do
-        fake_login_admin(create(:tag_wrangling_admin))
-
-        get :index, params: { collection_id: collection.name }
-
-        it_redirects_to_with_notice(collection_path(collection), "You are not allowed to view the requests summary!")
-      end
+      it_behaves_like "an action only authorized admins can access", authorized_roles: authorized_roles
     end
   end
 end

--- a/spec/controllers/challenge_signups_controller_spec.rb
+++ b/spec/controllers/challenge_signups_controller_spec.rb
@@ -272,4 +272,35 @@ describe ChallengeSignupsController do
       end
     end
   end
+
+  describe "admin access to signups pages" do
+    it "allows support admins to view signups index and download CSV" do
+      fake_login_admin(create(:support_admin))
+
+      get :index, params: { collection_id: closed_collection.name }
+      expect(response).to have_http_status(:success)
+      expect(response).to render_template(:index)
+
+      get :index, params: { collection_id: closed_collection.name, format: :csv }
+      expect(response).to have_http_status(:success)
+      expect(response.content_type).to include("text/csv")
+    end
+
+    it "allows support admins to view individual signups" do
+      fake_login_admin(create(:support_admin))
+
+      get :show, params: { id: closed_signup.id, collection_id: closed_collection.name }
+
+      expect(response).to have_http_status(:success)
+      expect(response).to render_template(:show)
+    end
+
+    it "does not allow admins with other roles to view signups index" do
+      fake_login_admin(create(:tag_wrangling_admin))
+
+      get :index, params: { collection_id: closed_collection.name }
+
+      it_redirects_to_user_login_with_error
+    end
+  end
 end

--- a/spec/controllers/challenge_signups_controller_spec.rb
+++ b/spec/controllers/challenge_signups_controller_spec.rb
@@ -274,33 +274,37 @@ describe ChallengeSignupsController do
   end
 
   describe "admin access to signups pages" do
-    it "allows support admins to view signups index and download CSV" do
-      fake_login_admin(create(:support_admin))
+    authorized_roles = %w[support policy_and_abuse superadmin].freeze
 
-      get :index, params: { collection_id: closed_collection.name }
-      expect(response).to have_http_status(:success)
-      expect(response).to render_template(:index)
+    describe "GET #index" do
+      subject { get :index, params: { collection_id: closed_collection.name } }
+
+      let(:success) do
+        expect(response).to have_http_status(:success)
+        expect(response).to render_template(:index)
+      end
+
+      it_behaves_like "an action only authorized admins can access", authorized_roles: authorized_roles
+    end
+
+    describe "GET #show" do
+      subject { get :show, params: { id: closed_signup.id, collection_id: closed_collection.name } }
+
+      let(:success) do
+        expect(response).to have_http_status(:success)
+        expect(response).to render_template(:show)
+      end
+
+      it_behaves_like "an action only authorized admins can access", authorized_roles: authorized_roles
+    end
+
+    it "allows support admins to download CSV" do
+      fake_login_admin(create(:support_admin))
 
       get :index, params: { collection_id: closed_collection.name, format: :csv }
+
       expect(response).to have_http_status(:success)
       expect(response.content_type).to include("text/csv")
-    end
-
-    it "allows support admins to view individual signups" do
-      fake_login_admin(create(:support_admin))
-
-      get :show, params: { id: closed_signup.id, collection_id: closed_collection.name }
-
-      expect(response).to have_http_status(:success)
-      expect(response).to render_template(:show)
-    end
-
-    it "does not allow admins with other roles to view signups index" do
-      fake_login_admin(create(:tag_wrangling_admin))
-
-      get :index, params: { collection_id: closed_collection.name }
-
-      it_redirects_to_user_login_with_error
     end
   end
 end

--- a/spec/controllers/collection_items_controller_spec.rb
+++ b/spec/controllers/collection_items_controller_spec.rb
@@ -626,4 +626,23 @@ describe CollectionItemsController do
       end
     end
   end
+
+  describe "admin access to manage items" do
+    it "allows support admins to view the collection items index" do
+      fake_login_admin(create(:support_admin))
+
+      get :index, params: { collection_id: collection.name }
+
+      expect(response).to have_http_status(:success)
+      expect(response).to render_template(:index)
+    end
+
+    it "does not allow admins with other roles to view the collection items index" do
+      fake_login_admin(create(:tag_wrangling_admin))
+
+      get :index, params: { collection_id: collection.name }
+
+      it_redirects_to_with_error(collections_path, "You don't have permission to see that, sorry!")
+    end
+  end
 end

--- a/spec/controllers/collection_items_controller_spec.rb
+++ b/spec/controllers/collection_items_controller_spec.rb
@@ -628,21 +628,15 @@ describe CollectionItemsController do
   end
 
   describe "admin access to manage items" do
-    it "allows support admins to view the collection items index" do
-      fake_login_admin(create(:support_admin))
+    authorized_roles = %w[support policy_and_abuse superadmin].freeze
 
-      get :index, params: { collection_id: collection.name }
+    subject { get :index, params: { collection_id: collection.name } }
 
+    let(:success) do
       expect(response).to have_http_status(:success)
       expect(response).to render_template(:index)
     end
 
-    it "does not allow admins with other roles to view the collection items index" do
-      fake_login_admin(create(:tag_wrangling_admin))
-
-      get :index, params: { collection_id: collection.name }
-
-      it_redirects_to_with_error(collections_path, "You don't have permission to see that, sorry!")
-    end
+    it_behaves_like "an action only authorized admins can access", authorized_roles: authorized_roles
   end
 end

--- a/spec/controllers/collection_participants_controller_spec.rb
+++ b/spec/controllers/collection_participants_controller_spec.rb
@@ -444,4 +444,23 @@ describe CollectionParticipantsController do
       end
     end
   end
+
+  describe "admin access to membership index" do
+    it "allows support admins to view membership" do
+      fake_login_admin(create(:support_admin))
+
+      get :index, params: { collection_id: collection.name }
+
+      expect(response).to have_http_status(:success)
+      expect(response).to render_template(:index)
+    end
+
+    it "does not allow admins with other roles to view membership" do
+      fake_login_admin(create(:tag_wrangling_admin))
+
+      get :index, params: { collection_id: collection.name }
+
+      it_redirects_to_user_login_with_error
+    end
+  end
 end

--- a/spec/controllers/collection_participants_controller_spec.rb
+++ b/spec/controllers/collection_participants_controller_spec.rb
@@ -446,21 +446,15 @@ describe CollectionParticipantsController do
   end
 
   describe "admin access to membership index" do
-    it "allows support admins to view membership" do
-      fake_login_admin(create(:support_admin))
+    authorized_roles = %w[support policy_and_abuse superadmin].freeze
 
-      get :index, params: { collection_id: collection.name }
+    subject { get :index, params: { collection_id: collection.name } }
 
+    let(:success) do
       expect(response).to have_http_status(:success)
       expect(response).to render_template(:index)
     end
 
-    it "does not allow admins with other roles to view membership" do
-      fake_login_admin(create(:tag_wrangling_admin))
-
-      get :index, params: { collection_id: collection.name }
-
-      it_redirects_to_user_login_with_error
-    end
+    it_behaves_like "an action only authorized admins can access", authorized_roles: authorized_roles
   end
 end

--- a/spec/controllers/collections_controller_spec.rb
+++ b/spec/controllers/collections_controller_spec.rb
@@ -289,4 +289,33 @@ describe CollectionsController, collection_search: true do
       end
     end
   end
+
+  describe "admin access to owner pages" do
+    let(:collection) { create(:collection) }
+
+    it "allows support admins to view edit" do
+      fake_login_admin(create(:support_admin))
+
+      get :edit, params: { id: collection.name }
+
+      expect(response).to have_http_status(:success)
+      expect(response).to render_template(:edit)
+    end
+
+    it "does not allow admins with other roles to view edit" do
+      fake_login_admin(create(:tag_wrangling_admin))
+
+      get :edit, params: { id: collection.name }
+
+      it_redirects_to_user_login_with_error
+    end
+
+    it "does not allow support admins to update" do
+      fake_login_admin(create(:support_admin))
+
+      put :update, params: { id: collection.name, collection: { title: "Changed title" } }
+
+      it_redirects_to_user_login_with_error
+    end
+  end
 end

--- a/spec/controllers/collections_controller_spec.rb
+++ b/spec/controllers/collections_controller_spec.rb
@@ -291,23 +291,18 @@ describe CollectionsController, collection_search: true do
   end
 
   describe "admin access to owner pages" do
+    authorized_roles = %w[support policy_and_abuse superadmin].freeze
     let(:collection) { create(:collection) }
 
-    it "allows support admins to view edit" do
-      fake_login_admin(create(:support_admin))
+    describe "GET #edit" do
+      subject { get :edit, params: { id: collection.name } }
 
-      get :edit, params: { id: collection.name }
+      let(:success) do
+        expect(response).to have_http_status(:success)
+        expect(response).to render_template(:edit)
+      end
 
-      expect(response).to have_http_status(:success)
-      expect(response).to render_template(:edit)
-    end
-
-    it "does not allow admins with other roles to view edit" do
-      fake_login_admin(create(:tag_wrangling_admin))
-
-      get :edit, params: { id: collection.name }
-
-      it_redirects_to_user_login_with_error
+      it_behaves_like "an action only authorized admins can access", authorized_roles: authorized_roles
     end
 
     it "does not allow support admins to update" do

--- a/spec/controllers/gift_exchange_controller_spec.rb
+++ b/spec/controllers/gift_exchange_controller_spec.rb
@@ -120,4 +120,34 @@ describe Challenge::GiftExchangeController do
       it_redirects_to_with_notice(collection, "Challenge settings were deleted.")
     end
   end
+
+  describe "admin access to challenge settings" do
+    it "allows support admins to view edit" do
+      fake_logout
+      fake_login_admin(create(:support_admin))
+
+      get :edit, params: { collection_id: collection.name }
+
+      expect(response).to have_http_status(:success)
+      expect(response).to render_template(:edit)
+    end
+
+    it "does not allow support admins to update settings" do
+      fake_logout
+      fake_login_admin(create(:support_admin))
+
+      put :update, params: { collection_id: collection.name, gift_exchange: { requests_num_required: 3 } }
+
+      it_redirects_to_user_login_with_error
+    end
+
+    it "does not allow admins with other roles to view edit" do
+      fake_logout
+      fake_login_admin(create(:tag_wrangling_admin))
+
+      get :edit, params: { collection_id: collection.name }
+
+      it_redirects_to_user_login_with_error
+    end
+  end
 end

--- a/spec/controllers/gift_exchange_controller_spec.rb
+++ b/spec/controllers/gift_exchange_controller_spec.rb
@@ -122,32 +122,16 @@ describe Challenge::GiftExchangeController do
   end
 
   describe "admin access to challenge settings" do
-    it "allows support admins to view edit" do
-      fake_logout
-      fake_login_admin(create(:support_admin))
+    authorized_roles = %w[support policy_and_abuse superadmin].freeze
+    before { fake_logout }
 
-      get :edit, params: { collection_id: collection.name }
+    subject { get :edit, params: { collection_id: collection.name } }
 
+    let(:success) do
       expect(response).to have_http_status(:success)
       expect(response).to render_template(:edit)
     end
 
-    it "does not allow support admins to update settings" do
-      fake_logout
-      fake_login_admin(create(:support_admin))
-
-      put :update, params: { collection_id: collection.name, gift_exchange: { requests_num_required: 3 } }
-
-      it_redirects_to_user_login_with_error
-    end
-
-    it "does not allow admins with other roles to view edit" do
-      fake_logout
-      fake_login_admin(create(:tag_wrangling_admin))
-
-      get :edit, params: { collection_id: collection.name }
-
-      it_redirects_to_user_login_with_error
-    end
+    it_behaves_like "an action only authorized admins can access", authorized_roles: authorized_roles
   end
 end

--- a/spec/controllers/potential_matches_controller_spec.rb
+++ b/spec/controllers/potential_matches_controller_spec.rb
@@ -1,0 +1,29 @@
+require "spec_helper"
+
+describe PotentialMatchesController do
+  include LoginMacros
+  include RedirectExpectationHelper
+
+  let(:collection) { create(:collection, challenge: create(:gift_exchange)) }
+
+  describe "index" do
+    %i[support_admin policy_and_abuse_admin superadmin].each do |admin_factory|
+      it "allows #{admin_factory} to view potential matches" do
+        fake_login_admin(create(admin_factory))
+
+        get :index, params: { collection_id: collection.name }
+
+        expect(response).to have_http_status(:success)
+        expect(response).to render_template(:index)
+      end
+    end
+
+    it "does not allow admins with other roles to view potential matches" do
+      fake_login_admin(create(:tag_wrangling_admin))
+
+      get :index, params: { collection_id: collection.name }
+
+      it_redirects_to_user_login_with_error
+    end
+  end
+end

--- a/spec/controllers/potential_matches_controller_spec.rb
+++ b/spec/controllers/potential_matches_controller_spec.rb
@@ -7,23 +7,15 @@ describe PotentialMatchesController do
   let(:collection) { create(:collection, challenge: create(:gift_exchange)) }
 
   describe "index" do
-    %i[support_admin policy_and_abuse_admin superadmin].each do |admin_factory|
-      it "allows #{admin_factory} to view potential matches" do
-        fake_login_admin(create(admin_factory))
+    authorized_roles = %w[support policy_and_abuse superadmin].freeze
 
-        get :index, params: { collection_id: collection.name }
+    subject { get :index, params: { collection_id: collection.name } }
 
-        expect(response).to have_http_status(:success)
-        expect(response).to render_template(:index)
-      end
+    let(:success) do
+      expect(response).to have_http_status(:success)
+      expect(response).to render_template(:index)
     end
 
-    it "does not allow admins with other roles to view potential matches" do
-      fake_login_admin(create(:tag_wrangling_admin))
-
-      get :index, params: { collection_id: collection.name }
-
-      it_redirects_to_user_login_with_error
-    end
+    it_behaves_like "an action only authorized admins can access", authorized_roles: authorized_roles
   end
 end

--- a/spec/controllers/prompt_meme_controller_spec.rb
+++ b/spec/controllers/prompt_meme_controller_spec.rb
@@ -114,4 +114,34 @@ describe Challenge::PromptMemeController do
       expect(response).to redirect_to(collection)
     end
   end
+
+  describe "admin access to challenge settings" do
+    it "allows support admins to view edit" do
+      fake_logout
+      fake_login_admin(create(:support_admin))
+
+      get :edit, params: { collection_id: collection.name }
+
+      expect(response).to have_http_status(:success)
+      expect(response).to render_template(:edit)
+    end
+
+    it "does not allow support admins to update settings" do
+      fake_logout
+      fake_login_admin(create(:support_admin))
+
+      put :update, params: { collection_id: collection.name, prompt_meme: { requests_num_required: 3 } }
+
+      it_redirects_to_user_login_with_error
+    end
+
+    it "does not allow admins with other roles to view edit" do
+      fake_logout
+      fake_login_admin(create(:tag_wrangling_admin))
+
+      get :edit, params: { collection_id: collection.name }
+
+      it_redirects_to_user_login_with_error
+    end
+  end
 end

--- a/spec/controllers/prompt_meme_controller_spec.rb
+++ b/spec/controllers/prompt_meme_controller_spec.rb
@@ -116,32 +116,16 @@ describe Challenge::PromptMemeController do
   end
 
   describe "admin access to challenge settings" do
-    it "allows support admins to view edit" do
-      fake_logout
-      fake_login_admin(create(:support_admin))
+    authorized_roles = %w[support policy_and_abuse superadmin].freeze
+    before { fake_logout }
 
-      get :edit, params: { collection_id: collection.name }
+    subject { get :edit, params: { collection_id: collection.name } }
 
+    let(:success) do
       expect(response).to have_http_status(:success)
       expect(response).to render_template(:edit)
     end
 
-    it "does not allow support admins to update settings" do
-      fake_logout
-      fake_login_admin(create(:support_admin))
-
-      put :update, params: { collection_id: collection.name, prompt_meme: { requests_num_required: 3 } }
-
-      it_redirects_to_user_login_with_error
-    end
-
-    it "does not allow admins with other roles to view edit" do
-      fake_logout
-      fake_login_admin(create(:tag_wrangling_admin))
-
-      get :edit, params: { collection_id: collection.name }
-
-      it_redirects_to_user_login_with_error
-    end
+    it_behaves_like "an action only authorized admins can access", authorized_roles: authorized_roles
   end
 end


### PR DESCRIPTION
# Pull Request Checklist

<!-- Mark steps in the checklist as complete by changing `[ ]` to `[X]` -->
* [X] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [X] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [X] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [X] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [X] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.
  
## Issue
  https://otwarchive.atlassian.net/browse/AO3-6218

## Additional Notes
Failed on QA. Made necessary changes as per comments on jira.

## Purpose
Allow admins with `support`, `policy_and_abuse`, or `superadmin` roles to access owner/maintainer collection and challenge pages for viewing/troubleshooting, without granting write permissions.

Implemented via shared controller helpers and action-level filter changes so read routes are opened for those roles while create/update/destroy paths remain owner/maintainer-only.

## Testing Instructions
Automated coverage was added/updated for the affected controllers to verify:
- allowed admin roles can access read pages
- other admin roles cannot
- privileged admins still cannot perform protected updates

(Functional QA flow is already documented in the Jira ticket.)

## Credit
varram (he/him)