### PR TITLE
AO3-7357 i18n SearchHelper#search_header

### DIFF
--- a/app/helpers/search_helper.rb
+++ b/app/helpers/search_helper.rb
@@ -1,43 +1,30 @@
 module SearchHelper
-
   # modified from mislav-will_paginate-2.3.2/lib/will_paginate/view_helpers.rb
-  def search_header(collection, search, item_name, parent=nil)
-    header = []
-    if !collection.respond_to?(:total_pages)
-      header << ts("Recent #{item_name.pluralize}")
-    elsif collection.total_pages < 2
-      header << pluralize(collection.total_entries, item_name)
+  def search_header(collection, item_type:, search: nil, parent: nil, fandom: nil, query_present: nil)
+    results = search_header_results(collection, item_type)
+    location = search_header_scope(parent, fandom)
+    has_query = search_query_present?(search, query_present)
+
+    if has_query && location.present?
+      t("search_helper.search_header.with_query_and_scope_html",
+        results: results,
+        location: location)
+    elsif has_query
+      t("search_helper.search_header.with_query_html",
+        results: results)
+    elsif location.present?
+      t("search_helper.search_header.with_scope_html",
+        results: results,
+        location: location)
     else
-      total_entries = collection.total_entries
-      total_entries = collection.unlimited_total_entries if collection.respond_to?(:unlimited_total_entries)
-      header << ts(" %{start_number} - %{end_number} of %{total} %{things}",
-                   start_number: number_with_delimiter(collection.offset + 1),
-                   end_number: number_with_delimiter(collection.offset + collection.length),
-                   total: number_with_delimiter(total_entries),
-                   things: item_name.pluralize)
+      t("search_helper.search_header.default_html",
+        results: results)
     end
-    header << ts("found") if search.present? && search.query.present?
-
-    case parent
-    when Collection
-      header << ts("in %{collection_link}", collection_link: link_to(parent.title, parent))
-    when Pseud
-      header << ts("by %{byline}", byline: parent.byline)
-    when User
-      header << ts("by %{username}", username: parent.login)
-    when Language
-      header << ts("in %{language}", language: parent.name)
-    end
-
-    header << ts("in %{tag_link}", tag_link: link_to_tag_with_text(parent, parent.name)) if parent.is_a?(Tag)
-    # The @fandom version is used when following a fandom link from a user's dashboard, which
-    # which will take you to a URL like /users/username/works?fandom_id=123.
-    header << ts("in %{fandom_link}", fandom_link: link_to_tag(@fandom)) if @fandom.present?
-    header.join(" ").html_safe
   end
 
   def search_results_found(results)
-    ts("%{count} Found", count: number_with_delimiter(results.unlimited_total_entries))
+    t("search_helper.search_results_found",
+      count: number_with_delimiter(results.unlimited_total_entries))
   end
 
   def random_search_tip
@@ -60,5 +47,148 @@ module SearchHelper
       only_path: true,
       **params.slice(:tag_id, :collection_id, :pseud_id, :user_id).permit!
     )
+  end
+
+  private
+
+  def search_header_results(collection, item_type)
+    if !collection.respond_to?(:total_pages)
+      search_header_recent(item_type, count: collection.size)
+    elsif collection.total_pages < 2
+      search_header_count(item_type, count: collection.total_entries)
+    else
+      total_entries = collection.respond_to?(:unlimited_total_entries) ? collection.unlimited_total_entries : collection.total_entries
+
+      search_header_range(
+        item_type,
+        count: total_entries,
+        start_number: number_with_delimiter(collection.offset + 1),
+        end_number: number_with_delimiter(collection.offset + collection.length),
+        total: number_with_delimiter(total_entries)
+      )
+    end
+  end
+
+  def search_header_recent(item_type, count:)
+    case item_type
+    when :bookmark
+      t("search_helper.search_header.items.bookmark.recent", count: count)
+    when :bookmarked_item
+      t("search_helper.search_header.items.bookmarked_item.recent", count: count)
+    when :challenge_signup
+      t("search_helper.search_header.items.challenge_signup.recent", count: count)
+    when :collection
+      t("search_helper.search_header.items.collection.recent", count: count)
+    when :comment
+      t("search_helper.search_header.items.comment.recent", count: count)
+    when :series
+      t("search_helper.search_header.items.series.recent", count: count)
+    when :tag_set
+      t("search_helper.search_header.items.tag_set.recent", count: count)
+    when :unposted_draft
+      t("search_helper.search_header.items.unposted_draft.recent", count: count)
+    when :user
+      t("search_helper.search_header.items.user.recent", count: count)
+    when :work
+      t("search_helper.search_header.items.work.recent", count: count)
+    else
+      raise ArgumentError, "Unknown search header item type: #{item_type.inspect}"
+    end
+  end
+
+  def search_header_count(item_type, count:)
+    case item_type
+    when :bookmark
+      t("search_helper.search_header.items.bookmark.count", count: count)
+    when :bookmarked_item
+      t("search_helper.search_header.items.bookmarked_item.count", count: count)
+    when :challenge_signup
+      t("search_helper.search_header.items.challenge_signup.count", count: count)
+    when :collection
+      t("search_helper.search_header.items.collection.count", count: count)
+    when :comment
+      t("search_helper.search_header.items.comment.count", count: count)
+    when :series
+      t("search_helper.search_header.items.series.count", count: count)
+    when :tag_set
+      t("search_helper.search_header.items.tag_set.count", count: count)
+    when :unposted_draft
+      t("search_helper.search_header.items.unposted_draft.count", count: count)
+    when :user
+      t("search_helper.search_header.items.user.count", count: count)
+    when :work
+      t("search_helper.search_header.items.work.count", count: count)
+    else
+      raise ArgumentError, "Unknown search header item type: #{item_type.inspect}"
+    end
+  end
+
+  def search_header_range(item_type, count:, start_number:, end_number:, total:)
+    case item_type
+    when :bookmark
+      t("search_helper.search_header.items.bookmark.range",
+        count: count, start_number: start_number, end_number: end_number, total: total)
+    when :bookmarked_item
+      t("search_helper.search_header.items.bookmarked_item.range",
+        count: count, start_number: start_number, end_number: end_number, total: total)
+    when :challenge_signup
+      t("search_helper.search_header.items.challenge_signup.range",
+        count: count, start_number: start_number, end_number: end_number, total: total)
+    when :collection
+      t("search_helper.search_header.items.collection.range",
+        count: count, start_number: start_number, end_number: end_number, total: total)
+    when :comment
+      t("search_helper.search_header.items.comment.range",
+        count: count, start_number: start_number, end_number: end_number, total: total)
+    when :series
+      t("search_helper.search_header.items.series.range",
+        count: count, start_number: start_number, end_number: end_number, total: total)
+    when :tag_set
+      t("search_helper.search_header.items.tag_set.range",
+        count: count, start_number: start_number, end_number: end_number, total: total)
+    when :unposted_draft
+      t("search_helper.search_header.items.unposted_draft.range",
+        count: count, start_number: start_number, end_number: end_number, total: total)
+    when :user
+      t("search_helper.search_header.items.user.range",
+        count: count, start_number: start_number, end_number: end_number, total: total)
+    when :work
+      t("search_helper.search_header.items.work.range",
+        count: count, start_number: start_number, end_number: end_number, total: total)
+    else
+      raise ArgumentError, "Unknown search header item type: #{item_type.inspect}"
+    end
+  end
+
+  def search_header_scope(parent, fandom)
+    scopes = []
+
+    case parent
+    when Collection
+      scopes << t("search_helper.search_header.scope.collection_html", collection_link: link_to(parent.title, parent))
+    when Pseud
+      scopes << t("search_helper.search_header.scope.pseud", byline: parent.byline)
+    when User
+      scopes << t("search_helper.search_header.scope.user", username: parent.login)
+    when Language
+      scopes << t("search_helper.search_header.scope.language", language: parent.name)
+    end
+
+    scopes << t("search_helper.search_header.scope.tag_html", tag_link: link_to_tag_with_text(parent, parent.name)) if parent.is_a?(Tag)
+    # The @fandom version is used when following a fandom link from a user's dashboard,
+    # which will take you to a URL like /users/username/works?fandom_id=123.
+    scopes << t("search_helper.search_header.scope.fandom_html", fandom_link: link_to_tag(fandom)) if fandom.present?
+
+    scopes.compact.reduce do |combined_scope, scope|
+      t("search_helper.search_header.scope.combined_html",
+        first_scope: combined_scope,
+        second_scope: scope)
+    end
+  end
+
+  def search_query_present?(search, query_present)
+    return query_present unless query_present.nil?
+
+    search.present? && search.respond_to?(:query) && search.query.present?
   end
 end

--- a/app/helpers/search_helper.rb
+++ b/app/helpers/search_helper.rb
@@ -1,24 +1,34 @@
 module SearchHelper
+  SEARCH_HEADER_ITEM_TYPES = %i[
+    bookmark
+    bookmarked_item
+    challenge_signup
+    collection
+    comment
+    series
+    tag_set
+    unposted_draft
+    user
+    work
+  ].freeze
+
+  SearchHeaderResult = Struct.new(:item_type, :kind, :translation_count, :variables, keyword_init: true)
+  SearchHeaderLocation = Struct.new(:key, :variables, keyword_init: true)
+
   # modified from mislav-will_paginate-2.3.2/lib/will_paginate/view_helpers.rb
   def search_header(collection, item_type:, search: nil, parent: nil, fandom: nil, query_present: nil)
-    results = search_header_results(collection, item_type)
-    location = search_header_scope(parent, fandom)
+    result = search_header_result(collection, item_type)
+    location = search_header_location(parent, fandom)
     has_query = search_query_present?(search, query_present)
 
     if has_query && location.present?
-      t("search_helper.search_header.with_query_and_scope_html",
-        results: results,
-        location: location)
+      search_header_text(result, "with_query_and_#{location.key}", location)
     elsif has_query
-      t("search_helper.search_header.with_query_html",
-        results: results)
+      search_header_text(result, "with_query")
     elsif location.present?
-      t("search_helper.search_header.with_scope_html",
-        results: results,
-        location: location)
+      search_header_text(result, "with_#{location.key}", location)
     else
-      t("search_helper.search_header.default_html",
-        results: results)
+      search_header_text(result)
     end
   end
 
@@ -51,139 +61,86 @@ module SearchHelper
 
   private
 
-  def search_header_results(collection, item_type)
+  def search_header_result(collection, item_type)
+    raise ArgumentError, "Unknown search header item type: #{item_type.inspect}" unless SEARCH_HEADER_ITEM_TYPES.include?(item_type)
+
     if !collection.respond_to?(:total_pages)
-      search_header_recent(item_type, count: collection.size)
+      SearchHeaderResult.new(item_type: item_type, kind: "recent", translation_count: collection.size, variables: {})
     elsif collection.total_pages < 2
-      search_header_count(item_type, count: collection.total_entries)
+      SearchHeaderResult.new(item_type: item_type, kind: "count", translation_count: collection.total_entries, variables: {})
     else
       total_entries = collection.respond_to?(:unlimited_total_entries) ? collection.unlimited_total_entries : collection.total_entries
 
-      search_header_range(
-        item_type,
-        count: total_entries,
-        start_number: number_with_delimiter(collection.offset + 1),
-        end_number: number_with_delimiter(collection.offset + collection.length),
-        total: number_with_delimiter(total_entries)
+      SearchHeaderResult.new(
+        item_type: item_type,
+        kind: "range",
+        translation_count: total_entries,
+        variables: {
+          start_number: number_with_delimiter(collection.offset + 1),
+          end_number: number_with_delimiter(collection.offset + collection.length),
+          total: number_with_delimiter(total_entries)
+        }
       )
     end
   end
 
-  def search_header_recent(item_type, count:)
-    case item_type
-    when :bookmark
-      t("search_helper.search_header.items.bookmark.recent", count: count)
-    when :bookmarked_item
-      t("search_helper.search_header.items.bookmarked_item.recent", count: count)
-    when :challenge_signup
-      t("search_helper.search_header.items.challenge_signup.recent", count: count)
-    when :collection
-      t("search_helper.search_header.items.collection.recent", count: count)
-    when :comment
-      t("search_helper.search_header.items.comment.recent", count: count)
-    when :series
-      t("search_helper.search_header.items.series.recent", count: count)
-    when :tag_set
-      t("search_helper.search_header.items.tag_set.recent", count: count)
-    when :unposted_draft
-      t("search_helper.search_header.items.unposted_draft.recent", count: count)
-    when :user
-      t("search_helper.search_header.items.user.recent", count: count)
-    when :work
-      t("search_helper.search_header.items.work.recent", count: count)
-    else
-      raise ArgumentError, "Unknown search header item type: #{item_type.inspect}"
-    end
+  def search_header_text(result, suffix = nil, location = nil)
+    translation_key = [result.kind, suffix].compact.join("_")
+    variables = result.variables.merge(count: result.translation_count)
+    variables.merge!(location.variables) if location.present?
+
+    t("search_helper.search_header.items.#{result.item_type}.#{translation_key}", **variables)
   end
 
-  def search_header_count(item_type, count:)
-    case item_type
-    when :bookmark
-      t("search_helper.search_header.items.bookmark.count", count: count)
-    when :bookmarked_item
-      t("search_helper.search_header.items.bookmarked_item.count", count: count)
-    when :challenge_signup
-      t("search_helper.search_header.items.challenge_signup.count", count: count)
-    when :collection
-      t("search_helper.search_header.items.collection.count", count: count)
-    when :comment
-      t("search_helper.search_header.items.comment.count", count: count)
-    when :series
-      t("search_helper.search_header.items.series.count", count: count)
-    when :tag_set
-      t("search_helper.search_header.items.tag_set.count", count: count)
-    when :unposted_draft
-      t("search_helper.search_header.items.unposted_draft.count", count: count)
-    when :user
-      t("search_helper.search_header.items.user.count", count: count)
-    when :work
-      t("search_helper.search_header.items.work.count", count: count)
-    else
-      raise ArgumentError, "Unknown search header item type: #{item_type.inspect}"
-    end
-  end
-
-  def search_header_range(item_type, count:, start_number:, end_number:, total:)
-    case item_type
-    when :bookmark
-      t("search_helper.search_header.items.bookmark.range",
-        count: count, start_number: start_number, end_number: end_number, total: total)
-    when :bookmarked_item
-      t("search_helper.search_header.items.bookmarked_item.range",
-        count: count, start_number: start_number, end_number: end_number, total: total)
-    when :challenge_signup
-      t("search_helper.search_header.items.challenge_signup.range",
-        count: count, start_number: start_number, end_number: end_number, total: total)
-    when :collection
-      t("search_helper.search_header.items.collection.range",
-        count: count, start_number: start_number, end_number: end_number, total: total)
-    when :comment
-      t("search_helper.search_header.items.comment.range",
-        count: count, start_number: start_number, end_number: end_number, total: total)
-    when :series
-      t("search_helper.search_header.items.series.range",
-        count: count, start_number: start_number, end_number: end_number, total: total)
-    when :tag_set
-      t("search_helper.search_header.items.tag_set.range",
-        count: count, start_number: start_number, end_number: end_number, total: total)
-    when :unposted_draft
-      t("search_helper.search_header.items.unposted_draft.range",
-        count: count, start_number: start_number, end_number: end_number, total: total)
-    when :user
-      t("search_helper.search_header.items.user.range",
-        count: count, start_number: start_number, end_number: end_number, total: total)
-    when :work
-      t("search_helper.search_header.items.work.range",
-        count: count, start_number: start_number, end_number: end_number, total: total)
-    else
-      raise ArgumentError, "Unknown search header item type: #{item_type.inspect}"
-    end
-  end
-
-  def search_header_scope(parent, fandom)
-    scopes = []
+  def search_header_location(parent, fandom)
+    locations = []
 
     case parent
     when Collection
-      scopes << t("search_helper.search_header.scope.collection_html", collection_link: link_to(parent.title, parent))
+      locations << SearchHeaderLocation.new(
+        key: "collection_html",
+        variables: { collection_link: link_to(parent.title, parent) }
+      )
     when Pseud
-      scopes << t("search_helper.search_header.scope.pseud", byline: parent.byline)
+      locations << SearchHeaderLocation.new(
+        key: "pseud",
+        variables: { byline: parent.byline }
+      )
     when User
-      scopes << t("search_helper.search_header.scope.user", username: parent.login)
+      locations << SearchHeaderLocation.new(
+        key: "user",
+        variables: { username: parent.login }
+      )
     when Language
-      scopes << t("search_helper.search_header.scope.language", language: parent.name)
+      locations << SearchHeaderLocation.new(
+        key: "language",
+        variables: { language: parent.name }
+      )
     end
 
-    scopes << t("search_helper.search_header.scope.tag_html", tag_link: link_to_tag_with_text(parent, parent.name)) if parent.is_a?(Tag)
+    if parent.is_a?(Tag)
+      locations << SearchHeaderLocation.new(
+        key: "tag_html",
+        variables: { tag_link: link_to_tag_with_text(parent, parent.name) }
+      )
+    end
+
     # The @fandom version is used when following a fandom link from a user's dashboard,
     # which will take you to a URL like /users/username/works?fandom_id=123.
-    scopes << t("search_helper.search_header.scope.fandom_html", fandom_link: link_to_tag(fandom)) if fandom.present?
-
-    scopes.compact.reduce do |combined_scope, scope|
-      t("search_helper.search_header.scope.combined_html",
-        first_scope: combined_scope,
-        second_scope: scope)
+    if fandom.present?
+      locations << SearchHeaderLocation.new(
+        key: "fandom_html",
+        variables: { fandom_link: link_to_tag(fandom) }
+      )
     end
+
+    return locations.first unless locations.size > 1
+
+    first_location, second_location = locations
+    SearchHeaderLocation.new(
+      key: "#{first_location.key.sub(/_html\z/, '')}_and_#{second_location.key}",
+      variables: first_location.variables.merge(second_location.variables)
+    )
   end
 
   def search_query_present?(search, query_present)

--- a/app/views/admin/admin_users/_user_creations_summary.html.erb
+++ b/app/views/admin/admin_users/_user_creations_summary.html.erb
@@ -3,7 +3,7 @@
 # an empty listbox with pagination if the admin manually enters the wrong URL.
 # This is consistent with pagination on other site pages. %>
   <div class="work listbox group" id="works-summary">
-    <h3 class="heading"><%= search_header(@works, nil, "Work") %></h3>
+    <h3 class="heading"><%= search_header(@works, item_type: :work) %></h3>
     <%= render "works/work_abbreviated_list", works: works %>
     <%= will_paginate(works, param_name: "works_page", params: { anchor: "works-summary" }) %>
   </div>
@@ -14,7 +14,7 @@
 # create a clear that causes wonky styling when there are only a few
 # comments. %>
   <div class="comments listbox group" id="comments-summary">
-    <h3 class="heading"><%= search_header(@comments, nil, "Comment") %></h3>
+    <h3 class="heading"><%= search_header(@comments, item_type: :comment) %></h3>
     <%= render "comments/comment_abbreviated_list", comments: comments %>
     <%= will_paginate(comments, param_name: "comments_page", params: { anchor: "comments-summary" }) %>
   </div>

--- a/app/views/bookmarks/index.html.erb
+++ b/app/views/bookmarks/index.html.erb
@@ -3,9 +3,9 @@
 
 <h2 class="heading">
   <% if @bookmarkable_items %>
-    <%= search_header @bookmarkable_items, @search, "Bookmarked Item", @owner %>
+    <%= search_header @bookmarkable_items, item_type: :bookmarked_item, search: @search, parent: @owner %>
   <% else %>
-    <%= search_header @bookmarks, @search, "Bookmark", @owner %>
+    <%= search_header @bookmarks, item_type: :bookmark, search: @search, parent: @owner %>
   <% end %>
 </h2>
 <!-- /descriptions-->

--- a/app/views/challenge/gift_exchange/_challenge_signups.html.erb
+++ b/app/views/challenge/gift_exchange/_challenge_signups.html.erb
@@ -1,7 +1,7 @@
 <!--descriptions-->
 <h2 class="heading">
   <% if @query %>
-    <%= search_header @challenge_signups, nil, t(".heading.for_search") %>
+    <%= search_header @challenge_signups, item_type: :challenge_signup, query_present: @query.present? %>
   <% else %>
     <%= t(".heading.for_collection", collection: @collection.title) %>
   <% end %>

--- a/app/views/collections/index.html.erb
+++ b/app/views/collections/index.html.erb
@@ -15,7 +15,7 @@
   <% if @collections.empty? %>
     <%= ts("Sorry, there were no collections found.") %>
   <% else %>
-    <%= search_header @collections, @query, ts("Collection") %>
+    <%= search_header @collections, item_type: :collection, search: @search %>
   <% end %>
 </h3>
 <!--/descriptions-->

--- a/app/views/kudos/index.html.erb
+++ b/app/views/kudos/index.html.erb
@@ -1,5 +1,7 @@
 <h2 class="heading">
-  <%= search_header(@kudos, nil, "User") %> Who Left Kudos on <%= link_to(@work.title, @work) %>
+  <%= t(".page_heading_html",
+        users: search_header(@kudos, item_type: :user),
+        work_link: link_to(@work.title, @work)) %>
 </h2>
 
 <% if @guest_kudos_count.positive? %>

--- a/app/views/owned_tag_sets/index.html.erb
+++ b/app/views/owned_tag_sets/index.html.erb
@@ -7,7 +7,7 @@
     <% elsif @restriction %>
       <%= ts('Tag Sets Used In This Challenge') %>
     <% elsif @query %>
-      <%= search_header @tag_sets, nil, ts('Tag Set') %> <%= link_to_help 'tagset-about' %>
+      <%= search_header @tag_sets, item_type: :tag_set, query_present: @query.present? %> <%= link_to_help "tagset-about" %>
     <% else %>
       <%= ts('Tag Sets') %> <%= link_to_help 'tagset-about' %> <%= ts('in the %{archive_name}', :archive_name => ArchiveConfig.APP_NAME) %>
     <% end %>

--- a/app/views/series/index.html.erb
+++ b/app/views/series/index.html.erb
@@ -3,7 +3,7 @@
 
 <h2 class="heading">
   <% if @user %>
-    <%= search_header @series, nil, "Series", @pseud ? @pseud : @user %>
+    <%= search_header @series, item_type: :series, parent: (@pseud || @user) %>
   <% else %>
     <%=h "View All Series" %>
   <% end %>

--- a/app/views/works/drafts.html.erb
+++ b/app/views/works/drafts.html.erb
@@ -1,5 +1,5 @@
 <!--Descriptive page names, messages and instructions-->
-<h2 class="heading"><%= search_header @works, nil, t(".page_heading") %></h2>
+<h2 class="heading"><%= search_header @works, item_type: :unposted_draft %></h2>
 
 <p class="caution notice">
   <strong><%= t(".please_note") %></strong>

--- a/app/views/works/index.html.erb
+++ b/app/views/works/index.html.erb
@@ -2,7 +2,7 @@
 <%= render "muted/muted_items_notice" %>
 
 <h2 class="heading">
-  <%= search_header @works, @search, "Work", @owner %>
+  <%= search_header @works, item_type: :work, search: @search, parent: @owner, fandom: @fandom %>
 </h2>
 <!-- /end descriptions-->
 

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -227,6 +227,8 @@ ignore_unused:
   - errors.messages.*
   - errors.attributes.ticket_number.{closed_ticket,invalid_department,required}
   - attributes.ticket_number
+  # Dynamically interpolated in app/helpers/search_helper.rb#search_header_text
+  - search_helper.search_header.items.*
 
 ## Exclude these keys from the `i18n-tasks eq-base' report:
 # ignore_eq_base:

--- a/config/locales/helpers/en.yml
+++ b/config/locales/helpers/en.yml
@@ -44,6 +44,122 @@ en:
   qr_code_helper:
     qr_code_as_svg:
       default_label: QR code
+  search_helper:
+    search_header:
+      default_html: "%{results}"
+      items:
+        bookmark:
+          count:
+            one: "%{count} Bookmark"
+            other: "%{count} Bookmarks"
+          range:
+            one: "%{start_number} - %{end_number} of %{total} Bookmark"
+            other: "%{start_number} - %{end_number} of %{total} Bookmarks"
+          recent:
+            one: Recent Bookmark
+            other: Recent Bookmarks
+        bookmarked_item:
+          count:
+            one: "%{count} Bookmarked Item"
+            other: "%{count} Bookmarked Items"
+          range:
+            one: "%{start_number} - %{end_number} of %{total} Bookmarked Item"
+            other: "%{start_number} - %{end_number} of %{total} Bookmarked Items"
+          recent:
+            one: Recent Bookmarked Item
+            other: Recent Bookmarked Items
+        challenge_signup:
+          count:
+            one: "%{count} Sign-up"
+            other: "%{count} Sign-ups"
+          range:
+            one: "%{start_number} - %{end_number} of %{total} Sign-up"
+            other: "%{start_number} - %{end_number} of %{total} Sign-ups"
+          recent:
+            one: Recent Sign-up
+            other: Recent Sign-ups
+        collection:
+          count:
+            one: "%{count} Collection"
+            other: "%{count} Collections"
+          range:
+            one: "%{start_number} - %{end_number} of %{total} Collection"
+            other: "%{start_number} - %{end_number} of %{total} Collections"
+          recent:
+            one: Recent Collection
+            other: Recent Collections
+        comment:
+          count:
+            one: "%{count} Comment"
+            other: "%{count} Comments"
+          range:
+            one: "%{start_number} - %{end_number} of %{total} Comment"
+            other: "%{start_number} - %{end_number} of %{total} Comments"
+          recent:
+            one: Recent Comment
+            other: Recent Comments
+        series:
+          count:
+            one: "%{count} Series"
+            other: "%{count} Series"
+          range:
+            one: "%{start_number} - %{end_number} of %{total} Series"
+            other: "%{start_number} - %{end_number} of %{total} Series"
+          recent:
+            one: Recent Series
+            other: Recent Series
+        tag_set:
+          count:
+            one: "%{count} Tag Set"
+            other: "%{count} Tag Sets"
+          range:
+            one: "%{start_number} - %{end_number} of %{total} Tag Set"
+            other: "%{start_number} - %{end_number} of %{total} Tag Sets"
+          recent:
+            one: Recent Tag Set
+            other: Recent Tag Sets
+        unposted_draft:
+          count:
+            one: "%{count} Unposted Draft"
+            other: "%{count} Unposted Drafts"
+          range:
+            one: "%{start_number} - %{end_number} of %{total} Unposted Draft"
+            other: "%{start_number} - %{end_number} of %{total} Unposted Drafts"
+          recent:
+            one: Recent Unposted Draft
+            other: Recent Unposted Drafts
+        user:
+          count:
+            one: "%{count} User"
+            other: "%{count} Users"
+          range:
+            one: "%{start_number} - %{end_number} of %{total} User"
+            other: "%{start_number} - %{end_number} of %{total} Users"
+          recent:
+            one: Recent User
+            other: Recent Users
+        work:
+          count:
+            one: "%{count} Work"
+            other: "%{count} Works"
+          range:
+            one: "%{start_number} - %{end_number} of %{total} Work"
+            other: "%{start_number} - %{end_number} of %{total} Works"
+          recent:
+            one: Recent Work
+            other: Recent Works
+      scope:
+        collection_html: in %{collection_link}
+        combined_html: "%{first_scope} %{second_scope}"
+        fandom_html: in %{fandom_link}
+        language: in %{language}
+        pseud: by %{byline}
+        tag_html: in %{tag_link}
+        user: by %{username}
+      with_query_and_scope_html: "%{results} found %{location}"
+      with_query_html: "%{results} found"
+      with_scope_html: "%{results} %{location}"
+    search_results_found: "%{count} Found"
   series_helper:
     series_description_html: Part %{index} of %{series_link}
   tags_helper:

--- a/config/locales/helpers/en.yml
+++ b/config/locales/helpers/en.yml
@@ -51,2172 +51,2172 @@ en:
           count:
             one: "%{count} Bookmark"
             other: "%{count} Bookmarks"
-          count_with_query:
-            one: "%{count} Bookmark found"
-            other: "%{count} Bookmarks found"
-          count_with_collection_html:
-            one: "%{count} Bookmark in %{collection_link}"
-            other: "%{count} Bookmarks in %{collection_link}"
-          count_with_query_and_collection_html:
-            one: "%{count} Bookmark found in %{collection_link}"
-            other: "%{count} Bookmarks found in %{collection_link}"
-          count_with_pseud:
-            one: "%{count} Bookmark by %{byline}"
-            other: "%{count} Bookmarks by %{byline}"
-          count_with_query_and_pseud:
-            one: "%{count} Bookmark found by %{byline}"
-            other: "%{count} Bookmarks found by %{byline}"
-          count_with_user:
-            one: "%{count} Bookmark by %{username}"
-            other: "%{count} Bookmarks by %{username}"
-          count_with_query_and_user:
-            one: "%{count} Bookmark found by %{username}"
-            other: "%{count} Bookmarks found by %{username}"
-          count_with_language:
-            one: "%{count} Bookmark in %{language}"
-            other: "%{count} Bookmarks in %{language}"
-          count_with_query_and_language:
-            one: "%{count} Bookmark found in %{language}"
-            other: "%{count} Bookmarks found in %{language}"
-          count_with_tag_html:
-            one: "%{count} Bookmark in %{tag_link}"
-            other: "%{count} Bookmarks in %{tag_link}"
-          count_with_query_and_tag_html:
-            one: "%{count} Bookmark found in %{tag_link}"
-            other: "%{count} Bookmarks found in %{tag_link}"
-          count_with_fandom_html:
-            one: "%{count} Bookmark in %{fandom_link}"
-            other: "%{count} Bookmarks in %{fandom_link}"
-          count_with_query_and_fandom_html:
-            one: "%{count} Bookmark found in %{fandom_link}"
-            other: "%{count} Bookmarks found in %{fandom_link}"
           count_with_collection_and_fandom_html:
             one: "%{count} Bookmark in %{collection_link} in %{fandom_link}"
             other: "%{count} Bookmarks in %{collection_link} in %{fandom_link}"
-          count_with_query_and_collection_and_fandom_html:
-            one: "%{count} Bookmark found in %{collection_link} in %{fandom_link}"
-            other: "%{count} Bookmarks found in %{collection_link} in %{fandom_link}"
-          count_with_pseud_and_fandom_html:
-            one: "%{count} Bookmark by %{byline} in %{fandom_link}"
-            other: "%{count} Bookmarks by %{byline} in %{fandom_link}"
-          count_with_query_and_pseud_and_fandom_html:
-            one: "%{count} Bookmark found by %{byline} in %{fandom_link}"
-            other: "%{count} Bookmarks found by %{byline} in %{fandom_link}"
-          count_with_user_and_fandom_html:
-            one: "%{count} Bookmark by %{username} in %{fandom_link}"
-            other: "%{count} Bookmarks by %{username} in %{fandom_link}"
-          count_with_query_and_user_and_fandom_html:
-            one: "%{count} Bookmark found by %{username} in %{fandom_link}"
-            other: "%{count} Bookmarks found by %{username} in %{fandom_link}"
+          count_with_collection_html:
+            one: "%{count} Bookmark in %{collection_link}"
+            other: "%{count} Bookmarks in %{collection_link}"
+          count_with_fandom_html:
+            one: "%{count} Bookmark in %{fandom_link}"
+            other: "%{count} Bookmarks in %{fandom_link}"
+          count_with_language:
+            one: "%{count} Bookmark in %{language}"
+            other: "%{count} Bookmarks in %{language}"
           count_with_language_and_fandom_html:
             one: "%{count} Bookmark in %{language} in %{fandom_link}"
             other: "%{count} Bookmarks in %{language} in %{fandom_link}"
+          count_with_pseud:
+            one: "%{count} Bookmark by %{byline}"
+            other: "%{count} Bookmarks by %{byline}"
+          count_with_pseud_and_fandom_html:
+            one: "%{count} Bookmark by %{byline} in %{fandom_link}"
+            other: "%{count} Bookmarks by %{byline} in %{fandom_link}"
+          count_with_query:
+            one: "%{count} Bookmark found"
+            other: "%{count} Bookmarks found"
+          count_with_query_and_collection_and_fandom_html:
+            one: "%{count} Bookmark found in %{collection_link} in %{fandom_link}"
+            other: "%{count} Bookmarks found in %{collection_link} in %{fandom_link}"
+          count_with_query_and_collection_html:
+            one: "%{count} Bookmark found in %{collection_link}"
+            other: "%{count} Bookmarks found in %{collection_link}"
+          count_with_query_and_fandom_html:
+            one: "%{count} Bookmark found in %{fandom_link}"
+            other: "%{count} Bookmarks found in %{fandom_link}"
+          count_with_query_and_language:
+            one: "%{count} Bookmark found in %{language}"
+            other: "%{count} Bookmarks found in %{language}"
           count_with_query_and_language_and_fandom_html:
             one: "%{count} Bookmark found in %{language} in %{fandom_link}"
             other: "%{count} Bookmarks found in %{language} in %{fandom_link}"
-          count_with_tag_and_fandom_html:
-            one: "%{count} Bookmark in %{tag_link} in %{fandom_link}"
-            other: "%{count} Bookmarks in %{tag_link} in %{fandom_link}"
+          count_with_query_and_pseud:
+            one: "%{count} Bookmark found by %{byline}"
+            other: "%{count} Bookmarks found by %{byline}"
+          count_with_query_and_pseud_and_fandom_html:
+            one: "%{count} Bookmark found by %{byline} in %{fandom_link}"
+            other: "%{count} Bookmarks found by %{byline} in %{fandom_link}"
           count_with_query_and_tag_and_fandom_html:
             one: "%{count} Bookmark found in %{tag_link} in %{fandom_link}"
             other: "%{count} Bookmarks found in %{tag_link} in %{fandom_link}"
+          count_with_query_and_tag_html:
+            one: "%{count} Bookmark found in %{tag_link}"
+            other: "%{count} Bookmarks found in %{tag_link}"
+          count_with_query_and_user:
+            one: "%{count} Bookmark found by %{username}"
+            other: "%{count} Bookmarks found by %{username}"
+          count_with_query_and_user_and_fandom_html:
+            one: "%{count} Bookmark found by %{username} in %{fandom_link}"
+            other: "%{count} Bookmarks found by %{username} in %{fandom_link}"
+          count_with_tag_and_fandom_html:
+            one: "%{count} Bookmark in %{tag_link} in %{fandom_link}"
+            other: "%{count} Bookmarks in %{tag_link} in %{fandom_link}"
+          count_with_tag_html:
+            one: "%{count} Bookmark in %{tag_link}"
+            other: "%{count} Bookmarks in %{tag_link}"
+          count_with_user:
+            one: "%{count} Bookmark by %{username}"
+            other: "%{count} Bookmarks by %{username}"
+          count_with_user_and_fandom_html:
+            one: "%{count} Bookmark by %{username} in %{fandom_link}"
+            other: "%{count} Bookmarks by %{username} in %{fandom_link}"
           range:
             one: "%{start_number} - %{end_number} of %{total} Bookmark"
             other: "%{start_number} - %{end_number} of %{total} Bookmarks"
-          range_with_query:
-            one: "%{start_number} - %{end_number} of %{total} Bookmark found"
-            other: "%{start_number} - %{end_number} of %{total} Bookmarks found"
-          range_with_collection_html:
-            one: "%{start_number} - %{end_number} of %{total} Bookmark in %{collection_link}"
-            other: "%{start_number} - %{end_number} of %{total} Bookmarks in %{collection_link}"
-          range_with_query_and_collection_html:
-            one: "%{start_number} - %{end_number} of %{total} Bookmark found in %{collection_link}"
-            other: "%{start_number} - %{end_number} of %{total} Bookmarks found in %{collection_link}"
-          range_with_pseud:
-            one: "%{start_number} - %{end_number} of %{total} Bookmark by %{byline}"
-            other: "%{start_number} - %{end_number} of %{total} Bookmarks by %{byline}"
-          range_with_query_and_pseud:
-            one: "%{start_number} - %{end_number} of %{total} Bookmark found by %{byline}"
-            other: "%{start_number} - %{end_number} of %{total} Bookmarks found by %{byline}"
-          range_with_user:
-            one: "%{start_number} - %{end_number} of %{total} Bookmark by %{username}"
-            other: "%{start_number} - %{end_number} of %{total} Bookmarks by %{username}"
-          range_with_query_and_user:
-            one: "%{start_number} - %{end_number} of %{total} Bookmark found by %{username}"
-            other: "%{start_number} - %{end_number} of %{total} Bookmarks found by %{username}"
-          range_with_language:
-            one: "%{start_number} - %{end_number} of %{total} Bookmark in %{language}"
-            other: "%{start_number} - %{end_number} of %{total} Bookmarks in %{language}"
-          range_with_query_and_language:
-            one: "%{start_number} - %{end_number} of %{total} Bookmark found in %{language}"
-            other: "%{start_number} - %{end_number} of %{total} Bookmarks found in %{language}"
-          range_with_tag_html:
-            one: "%{start_number} - %{end_number} of %{total} Bookmark in %{tag_link}"
-            other: "%{start_number} - %{end_number} of %{total} Bookmarks in %{tag_link}"
-          range_with_query_and_tag_html:
-            one: "%{start_number} - %{end_number} of %{total} Bookmark found in %{tag_link}"
-            other: "%{start_number} - %{end_number} of %{total} Bookmarks found in %{tag_link}"
-          range_with_fandom_html:
-            one: "%{start_number} - %{end_number} of %{total} Bookmark in %{fandom_link}"
-            other: "%{start_number} - %{end_number} of %{total} Bookmarks in %{fandom_link}"
-          range_with_query_and_fandom_html:
-            one: "%{start_number} - %{end_number} of %{total} Bookmark found in %{fandom_link}"
-            other: "%{start_number} - %{end_number} of %{total} Bookmarks found in %{fandom_link}"
           range_with_collection_and_fandom_html:
             one: "%{start_number} - %{end_number} of %{total} Bookmark in %{collection_link} in %{fandom_link}"
             other: "%{start_number} - %{end_number} of %{total} Bookmarks in %{collection_link} in %{fandom_link}"
-          range_with_query_and_collection_and_fandom_html:
-            one: "%{start_number} - %{end_number} of %{total} Bookmark found in %{collection_link} in %{fandom_link}"
-            other: "%{start_number} - %{end_number} of %{total} Bookmarks found in %{collection_link} in %{fandom_link}"
-          range_with_pseud_and_fandom_html:
-            one: "%{start_number} - %{end_number} of %{total} Bookmark by %{byline} in %{fandom_link}"
-            other: "%{start_number} - %{end_number} of %{total} Bookmarks by %{byline} in %{fandom_link}"
-          range_with_query_and_pseud_and_fandom_html:
-            one: "%{start_number} - %{end_number} of %{total} Bookmark found by %{byline} in %{fandom_link}"
-            other: "%{start_number} - %{end_number} of %{total} Bookmarks found by %{byline} in %{fandom_link}"
-          range_with_user_and_fandom_html:
-            one: "%{start_number} - %{end_number} of %{total} Bookmark by %{username} in %{fandom_link}"
-            other: "%{start_number} - %{end_number} of %{total} Bookmarks by %{username} in %{fandom_link}"
-          range_with_query_and_user_and_fandom_html:
-            one: "%{start_number} - %{end_number} of %{total} Bookmark found by %{username} in %{fandom_link}"
-            other: "%{start_number} - %{end_number} of %{total} Bookmarks found by %{username} in %{fandom_link}"
+          range_with_collection_html:
+            one: "%{start_number} - %{end_number} of %{total} Bookmark in %{collection_link}"
+            other: "%{start_number} - %{end_number} of %{total} Bookmarks in %{collection_link}"
+          range_with_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} Bookmark in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Bookmarks in %{fandom_link}"
+          range_with_language:
+            one: "%{start_number} - %{end_number} of %{total} Bookmark in %{language}"
+            other: "%{start_number} - %{end_number} of %{total} Bookmarks in %{language}"
           range_with_language_and_fandom_html:
             one: "%{start_number} - %{end_number} of %{total} Bookmark in %{language} in %{fandom_link}"
             other: "%{start_number} - %{end_number} of %{total} Bookmarks in %{language} in %{fandom_link}"
+          range_with_pseud:
+            one: "%{start_number} - %{end_number} of %{total} Bookmark by %{byline}"
+            other: "%{start_number} - %{end_number} of %{total} Bookmarks by %{byline}"
+          range_with_pseud_and_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} Bookmark by %{byline} in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Bookmarks by %{byline} in %{fandom_link}"
+          range_with_query:
+            one: "%{start_number} - %{end_number} of %{total} Bookmark found"
+            other: "%{start_number} - %{end_number} of %{total} Bookmarks found"
+          range_with_query_and_collection_and_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} Bookmark found in %{collection_link} in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Bookmarks found in %{collection_link} in %{fandom_link}"
+          range_with_query_and_collection_html:
+            one: "%{start_number} - %{end_number} of %{total} Bookmark found in %{collection_link}"
+            other: "%{start_number} - %{end_number} of %{total} Bookmarks found in %{collection_link}"
+          range_with_query_and_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} Bookmark found in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Bookmarks found in %{fandom_link}"
+          range_with_query_and_language:
+            one: "%{start_number} - %{end_number} of %{total} Bookmark found in %{language}"
+            other: "%{start_number} - %{end_number} of %{total} Bookmarks found in %{language}"
           range_with_query_and_language_and_fandom_html:
             one: "%{start_number} - %{end_number} of %{total} Bookmark found in %{language} in %{fandom_link}"
             other: "%{start_number} - %{end_number} of %{total} Bookmarks found in %{language} in %{fandom_link}"
-          range_with_tag_and_fandom_html:
-            one: "%{start_number} - %{end_number} of %{total} Bookmark in %{tag_link} in %{fandom_link}"
-            other: "%{start_number} - %{end_number} of %{total} Bookmarks in %{tag_link} in %{fandom_link}"
+          range_with_query_and_pseud:
+            one: "%{start_number} - %{end_number} of %{total} Bookmark found by %{byline}"
+            other: "%{start_number} - %{end_number} of %{total} Bookmarks found by %{byline}"
+          range_with_query_and_pseud_and_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} Bookmark found by %{byline} in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Bookmarks found by %{byline} in %{fandom_link}"
           range_with_query_and_tag_and_fandom_html:
             one: "%{start_number} - %{end_number} of %{total} Bookmark found in %{tag_link} in %{fandom_link}"
             other: "%{start_number} - %{end_number} of %{total} Bookmarks found in %{tag_link} in %{fandom_link}"
+          range_with_query_and_tag_html:
+            one: "%{start_number} - %{end_number} of %{total} Bookmark found in %{tag_link}"
+            other: "%{start_number} - %{end_number} of %{total} Bookmarks found in %{tag_link}"
+          range_with_query_and_user:
+            one: "%{start_number} - %{end_number} of %{total} Bookmark found by %{username}"
+            other: "%{start_number} - %{end_number} of %{total} Bookmarks found by %{username}"
+          range_with_query_and_user_and_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} Bookmark found by %{username} in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Bookmarks found by %{username} in %{fandom_link}"
+          range_with_tag_and_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} Bookmark in %{tag_link} in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Bookmarks in %{tag_link} in %{fandom_link}"
+          range_with_tag_html:
+            one: "%{start_number} - %{end_number} of %{total} Bookmark in %{tag_link}"
+            other: "%{start_number} - %{end_number} of %{total} Bookmarks in %{tag_link}"
+          range_with_user:
+            one: "%{start_number} - %{end_number} of %{total} Bookmark by %{username}"
+            other: "%{start_number} - %{end_number} of %{total} Bookmarks by %{username}"
+          range_with_user_and_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} Bookmark by %{username} in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Bookmarks by %{username} in %{fandom_link}"
           recent:
-            one: "Recent Bookmark"
-            other: "Recent Bookmarks"
-          recent_with_query:
-            one: "Recent Bookmark found"
-            other: "Recent Bookmarks found"
-          recent_with_collection_html:
-            one: "Recent Bookmark in %{collection_link}"
-            other: "Recent Bookmarks in %{collection_link}"
-          recent_with_query_and_collection_html:
-            one: "Recent Bookmark found in %{collection_link}"
-            other: "Recent Bookmarks found in %{collection_link}"
-          recent_with_pseud:
-            one: "Recent Bookmark by %{byline}"
-            other: "Recent Bookmarks by %{byline}"
-          recent_with_query_and_pseud:
-            one: "Recent Bookmark found by %{byline}"
-            other: "Recent Bookmarks found by %{byline}"
-          recent_with_user:
-            one: "Recent Bookmark by %{username}"
-            other: "Recent Bookmarks by %{username}"
-          recent_with_query_and_user:
-            one: "Recent Bookmark found by %{username}"
-            other: "Recent Bookmarks found by %{username}"
-          recent_with_language:
-            one: "Recent Bookmark in %{language}"
-            other: "Recent Bookmarks in %{language}"
-          recent_with_query_and_language:
-            one: "Recent Bookmark found in %{language}"
-            other: "Recent Bookmarks found in %{language}"
-          recent_with_tag_html:
-            one: "Recent Bookmark in %{tag_link}"
-            other: "Recent Bookmarks in %{tag_link}"
-          recent_with_query_and_tag_html:
-            one: "Recent Bookmark found in %{tag_link}"
-            other: "Recent Bookmarks found in %{tag_link}"
-          recent_with_fandom_html:
-            one: "Recent Bookmark in %{fandom_link}"
-            other: "Recent Bookmarks in %{fandom_link}"
-          recent_with_query_and_fandom_html:
-            one: "Recent Bookmark found in %{fandom_link}"
-            other: "Recent Bookmarks found in %{fandom_link}"
+            one: Recent Bookmark
+            other: Recent Bookmarks
           recent_with_collection_and_fandom_html:
-            one: "Recent Bookmark in %{collection_link} in %{fandom_link}"
-            other: "Recent Bookmarks in %{collection_link} in %{fandom_link}"
-          recent_with_query_and_collection_and_fandom_html:
-            one: "Recent Bookmark found in %{collection_link} in %{fandom_link}"
-            other: "Recent Bookmarks found in %{collection_link} in %{fandom_link}"
-          recent_with_pseud_and_fandom_html:
-            one: "Recent Bookmark by %{byline} in %{fandom_link}"
-            other: "Recent Bookmarks by %{byline} in %{fandom_link}"
-          recent_with_query_and_pseud_and_fandom_html:
-            one: "Recent Bookmark found by %{byline} in %{fandom_link}"
-            other: "Recent Bookmarks found by %{byline} in %{fandom_link}"
-          recent_with_user_and_fandom_html:
-            one: "Recent Bookmark by %{username} in %{fandom_link}"
-            other: "Recent Bookmarks by %{username} in %{fandom_link}"
-          recent_with_query_and_user_and_fandom_html:
-            one: "Recent Bookmark found by %{username} in %{fandom_link}"
-            other: "Recent Bookmarks found by %{username} in %{fandom_link}"
+            one: Recent Bookmark in %{collection_link} in %{fandom_link}
+            other: Recent Bookmarks in %{collection_link} in %{fandom_link}
+          recent_with_collection_html:
+            one: Recent Bookmark in %{collection_link}
+            other: Recent Bookmarks in %{collection_link}
+          recent_with_fandom_html:
+            one: Recent Bookmark in %{fandom_link}
+            other: Recent Bookmarks in %{fandom_link}
+          recent_with_language:
+            one: Recent Bookmark in %{language}
+            other: Recent Bookmarks in %{language}
           recent_with_language_and_fandom_html:
-            one: "Recent Bookmark in %{language} in %{fandom_link}"
-            other: "Recent Bookmarks in %{language} in %{fandom_link}"
+            one: Recent Bookmark in %{language} in %{fandom_link}
+            other: Recent Bookmarks in %{language} in %{fandom_link}
+          recent_with_pseud:
+            one: Recent Bookmark by %{byline}
+            other: Recent Bookmarks by %{byline}
+          recent_with_pseud_and_fandom_html:
+            one: Recent Bookmark by %{byline} in %{fandom_link}
+            other: Recent Bookmarks by %{byline} in %{fandom_link}
+          recent_with_query:
+            one: Recent Bookmark found
+            other: Recent Bookmarks found
+          recent_with_query_and_collection_and_fandom_html:
+            one: Recent Bookmark found in %{collection_link} in %{fandom_link}
+            other: Recent Bookmarks found in %{collection_link} in %{fandom_link}
+          recent_with_query_and_collection_html:
+            one: Recent Bookmark found in %{collection_link}
+            other: Recent Bookmarks found in %{collection_link}
+          recent_with_query_and_fandom_html:
+            one: Recent Bookmark found in %{fandom_link}
+            other: Recent Bookmarks found in %{fandom_link}
+          recent_with_query_and_language:
+            one: Recent Bookmark found in %{language}
+            other: Recent Bookmarks found in %{language}
           recent_with_query_and_language_and_fandom_html:
-            one: "Recent Bookmark found in %{language} in %{fandom_link}"
-            other: "Recent Bookmarks found in %{language} in %{fandom_link}"
-          recent_with_tag_and_fandom_html:
-            one: "Recent Bookmark in %{tag_link} in %{fandom_link}"
-            other: "Recent Bookmarks in %{tag_link} in %{fandom_link}"
+            one: Recent Bookmark found in %{language} in %{fandom_link}
+            other: Recent Bookmarks found in %{language} in %{fandom_link}
+          recent_with_query_and_pseud:
+            one: Recent Bookmark found by %{byline}
+            other: Recent Bookmarks found by %{byline}
+          recent_with_query_and_pseud_and_fandom_html:
+            one: Recent Bookmark found by %{byline} in %{fandom_link}
+            other: Recent Bookmarks found by %{byline} in %{fandom_link}
           recent_with_query_and_tag_and_fandom_html:
-            one: "Recent Bookmark found in %{tag_link} in %{fandom_link}"
-            other: "Recent Bookmarks found in %{tag_link} in %{fandom_link}"
+            one: Recent Bookmark found in %{tag_link} in %{fandom_link}
+            other: Recent Bookmarks found in %{tag_link} in %{fandom_link}
+          recent_with_query_and_tag_html:
+            one: Recent Bookmark found in %{tag_link}
+            other: Recent Bookmarks found in %{tag_link}
+          recent_with_query_and_user:
+            one: Recent Bookmark found by %{username}
+            other: Recent Bookmarks found by %{username}
+          recent_with_query_and_user_and_fandom_html:
+            one: Recent Bookmark found by %{username} in %{fandom_link}
+            other: Recent Bookmarks found by %{username} in %{fandom_link}
+          recent_with_tag_and_fandom_html:
+            one: Recent Bookmark in %{tag_link} in %{fandom_link}
+            other: Recent Bookmarks in %{tag_link} in %{fandom_link}
+          recent_with_tag_html:
+            one: Recent Bookmark in %{tag_link}
+            other: Recent Bookmarks in %{tag_link}
+          recent_with_user:
+            one: Recent Bookmark by %{username}
+            other: Recent Bookmarks by %{username}
+          recent_with_user_and_fandom_html:
+            one: Recent Bookmark by %{username} in %{fandom_link}
+            other: Recent Bookmarks by %{username} in %{fandom_link}
         bookmarked_item:
           count:
             one: "%{count} Bookmarked Item"
             other: "%{count} Bookmarked Items"
-          count_with_query:
-            one: "%{count} Bookmarked Item found"
-            other: "%{count} Bookmarked Items found"
-          count_with_collection_html:
-            one: "%{count} Bookmarked Item in %{collection_link}"
-            other: "%{count} Bookmarked Items in %{collection_link}"
-          count_with_query_and_collection_html:
-            one: "%{count} Bookmarked Item found in %{collection_link}"
-            other: "%{count} Bookmarked Items found in %{collection_link}"
-          count_with_pseud:
-            one: "%{count} Bookmarked Item by %{byline}"
-            other: "%{count} Bookmarked Items by %{byline}"
-          count_with_query_and_pseud:
-            one: "%{count} Bookmarked Item found by %{byline}"
-            other: "%{count} Bookmarked Items found by %{byline}"
-          count_with_user:
-            one: "%{count} Bookmarked Item by %{username}"
-            other: "%{count} Bookmarked Items by %{username}"
-          count_with_query_and_user:
-            one: "%{count} Bookmarked Item found by %{username}"
-            other: "%{count} Bookmarked Items found by %{username}"
-          count_with_language:
-            one: "%{count} Bookmarked Item in %{language}"
-            other: "%{count} Bookmarked Items in %{language}"
-          count_with_query_and_language:
-            one: "%{count} Bookmarked Item found in %{language}"
-            other: "%{count} Bookmarked Items found in %{language}"
-          count_with_tag_html:
-            one: "%{count} Bookmarked Item in %{tag_link}"
-            other: "%{count} Bookmarked Items in %{tag_link}"
-          count_with_query_and_tag_html:
-            one: "%{count} Bookmarked Item found in %{tag_link}"
-            other: "%{count} Bookmarked Items found in %{tag_link}"
-          count_with_fandom_html:
-            one: "%{count} Bookmarked Item in %{fandom_link}"
-            other: "%{count} Bookmarked Items in %{fandom_link}"
-          count_with_query_and_fandom_html:
-            one: "%{count} Bookmarked Item found in %{fandom_link}"
-            other: "%{count} Bookmarked Items found in %{fandom_link}"
           count_with_collection_and_fandom_html:
             one: "%{count} Bookmarked Item in %{collection_link} in %{fandom_link}"
             other: "%{count} Bookmarked Items in %{collection_link} in %{fandom_link}"
-          count_with_query_and_collection_and_fandom_html:
-            one: "%{count} Bookmarked Item found in %{collection_link} in %{fandom_link}"
-            other: "%{count} Bookmarked Items found in %{collection_link} in %{fandom_link}"
-          count_with_pseud_and_fandom_html:
-            one: "%{count} Bookmarked Item by %{byline} in %{fandom_link}"
-            other: "%{count} Bookmarked Items by %{byline} in %{fandom_link}"
-          count_with_query_and_pseud_and_fandom_html:
-            one: "%{count} Bookmarked Item found by %{byline} in %{fandom_link}"
-            other: "%{count} Bookmarked Items found by %{byline} in %{fandom_link}"
-          count_with_user_and_fandom_html:
-            one: "%{count} Bookmarked Item by %{username} in %{fandom_link}"
-            other: "%{count} Bookmarked Items by %{username} in %{fandom_link}"
-          count_with_query_and_user_and_fandom_html:
-            one: "%{count} Bookmarked Item found by %{username} in %{fandom_link}"
-            other: "%{count} Bookmarked Items found by %{username} in %{fandom_link}"
+          count_with_collection_html:
+            one: "%{count} Bookmarked Item in %{collection_link}"
+            other: "%{count} Bookmarked Items in %{collection_link}"
+          count_with_fandom_html:
+            one: "%{count} Bookmarked Item in %{fandom_link}"
+            other: "%{count} Bookmarked Items in %{fandom_link}"
+          count_with_language:
+            one: "%{count} Bookmarked Item in %{language}"
+            other: "%{count} Bookmarked Items in %{language}"
           count_with_language_and_fandom_html:
             one: "%{count} Bookmarked Item in %{language} in %{fandom_link}"
             other: "%{count} Bookmarked Items in %{language} in %{fandom_link}"
+          count_with_pseud:
+            one: "%{count} Bookmarked Item by %{byline}"
+            other: "%{count} Bookmarked Items by %{byline}"
+          count_with_pseud_and_fandom_html:
+            one: "%{count} Bookmarked Item by %{byline} in %{fandom_link}"
+            other: "%{count} Bookmarked Items by %{byline} in %{fandom_link}"
+          count_with_query:
+            one: "%{count} Bookmarked Item found"
+            other: "%{count} Bookmarked Items found"
+          count_with_query_and_collection_and_fandom_html:
+            one: "%{count} Bookmarked Item found in %{collection_link} in %{fandom_link}"
+            other: "%{count} Bookmarked Items found in %{collection_link} in %{fandom_link}"
+          count_with_query_and_collection_html:
+            one: "%{count} Bookmarked Item found in %{collection_link}"
+            other: "%{count} Bookmarked Items found in %{collection_link}"
+          count_with_query_and_fandom_html:
+            one: "%{count} Bookmarked Item found in %{fandom_link}"
+            other: "%{count} Bookmarked Items found in %{fandom_link}"
+          count_with_query_and_language:
+            one: "%{count} Bookmarked Item found in %{language}"
+            other: "%{count} Bookmarked Items found in %{language}"
           count_with_query_and_language_and_fandom_html:
             one: "%{count} Bookmarked Item found in %{language} in %{fandom_link}"
             other: "%{count} Bookmarked Items found in %{language} in %{fandom_link}"
-          count_with_tag_and_fandom_html:
-            one: "%{count} Bookmarked Item in %{tag_link} in %{fandom_link}"
-            other: "%{count} Bookmarked Items in %{tag_link} in %{fandom_link}"
+          count_with_query_and_pseud:
+            one: "%{count} Bookmarked Item found by %{byline}"
+            other: "%{count} Bookmarked Items found by %{byline}"
+          count_with_query_and_pseud_and_fandom_html:
+            one: "%{count} Bookmarked Item found by %{byline} in %{fandom_link}"
+            other: "%{count} Bookmarked Items found by %{byline} in %{fandom_link}"
           count_with_query_and_tag_and_fandom_html:
             one: "%{count} Bookmarked Item found in %{tag_link} in %{fandom_link}"
             other: "%{count} Bookmarked Items found in %{tag_link} in %{fandom_link}"
+          count_with_query_and_tag_html:
+            one: "%{count} Bookmarked Item found in %{tag_link}"
+            other: "%{count} Bookmarked Items found in %{tag_link}"
+          count_with_query_and_user:
+            one: "%{count} Bookmarked Item found by %{username}"
+            other: "%{count} Bookmarked Items found by %{username}"
+          count_with_query_and_user_and_fandom_html:
+            one: "%{count} Bookmarked Item found by %{username} in %{fandom_link}"
+            other: "%{count} Bookmarked Items found by %{username} in %{fandom_link}"
+          count_with_tag_and_fandom_html:
+            one: "%{count} Bookmarked Item in %{tag_link} in %{fandom_link}"
+            other: "%{count} Bookmarked Items in %{tag_link} in %{fandom_link}"
+          count_with_tag_html:
+            one: "%{count} Bookmarked Item in %{tag_link}"
+            other: "%{count} Bookmarked Items in %{tag_link}"
+          count_with_user:
+            one: "%{count} Bookmarked Item by %{username}"
+            other: "%{count} Bookmarked Items by %{username}"
+          count_with_user_and_fandom_html:
+            one: "%{count} Bookmarked Item by %{username} in %{fandom_link}"
+            other: "%{count} Bookmarked Items by %{username} in %{fandom_link}"
           range:
             one: "%{start_number} - %{end_number} of %{total} Bookmarked Item"
             other: "%{start_number} - %{end_number} of %{total} Bookmarked Items"
-          range_with_query:
-            one: "%{start_number} - %{end_number} of %{total} Bookmarked Item found"
-            other: "%{start_number} - %{end_number} of %{total} Bookmarked Items found"
-          range_with_collection_html:
-            one: "%{start_number} - %{end_number} of %{total} Bookmarked Item in %{collection_link}"
-            other: "%{start_number} - %{end_number} of %{total} Bookmarked Items in %{collection_link}"
-          range_with_query_and_collection_html:
-            one: "%{start_number} - %{end_number} of %{total} Bookmarked Item found in %{collection_link}"
-            other: "%{start_number} - %{end_number} of %{total} Bookmarked Items found in %{collection_link}"
-          range_with_pseud:
-            one: "%{start_number} - %{end_number} of %{total} Bookmarked Item by %{byline}"
-            other: "%{start_number} - %{end_number} of %{total} Bookmarked Items by %{byline}"
-          range_with_query_and_pseud:
-            one: "%{start_number} - %{end_number} of %{total} Bookmarked Item found by %{byline}"
-            other: "%{start_number} - %{end_number} of %{total} Bookmarked Items found by %{byline}"
-          range_with_user:
-            one: "%{start_number} - %{end_number} of %{total} Bookmarked Item by %{username}"
-            other: "%{start_number} - %{end_number} of %{total} Bookmarked Items by %{username}"
-          range_with_query_and_user:
-            one: "%{start_number} - %{end_number} of %{total} Bookmarked Item found by %{username}"
-            other: "%{start_number} - %{end_number} of %{total} Bookmarked Items found by %{username}"
-          range_with_language:
-            one: "%{start_number} - %{end_number} of %{total} Bookmarked Item in %{language}"
-            other: "%{start_number} - %{end_number} of %{total} Bookmarked Items in %{language}"
-          range_with_query_and_language:
-            one: "%{start_number} - %{end_number} of %{total} Bookmarked Item found in %{language}"
-            other: "%{start_number} - %{end_number} of %{total} Bookmarked Items found in %{language}"
-          range_with_tag_html:
-            one: "%{start_number} - %{end_number} of %{total} Bookmarked Item in %{tag_link}"
-            other: "%{start_number} - %{end_number} of %{total} Bookmarked Items in %{tag_link}"
-          range_with_query_and_tag_html:
-            one: "%{start_number} - %{end_number} of %{total} Bookmarked Item found in %{tag_link}"
-            other: "%{start_number} - %{end_number} of %{total} Bookmarked Items found in %{tag_link}"
-          range_with_fandom_html:
-            one: "%{start_number} - %{end_number} of %{total} Bookmarked Item in %{fandom_link}"
-            other: "%{start_number} - %{end_number} of %{total} Bookmarked Items in %{fandom_link}"
-          range_with_query_and_fandom_html:
-            one: "%{start_number} - %{end_number} of %{total} Bookmarked Item found in %{fandom_link}"
-            other: "%{start_number} - %{end_number} of %{total} Bookmarked Items found in %{fandom_link}"
           range_with_collection_and_fandom_html:
             one: "%{start_number} - %{end_number} of %{total} Bookmarked Item in %{collection_link} in %{fandom_link}"
             other: "%{start_number} - %{end_number} of %{total} Bookmarked Items in %{collection_link} in %{fandom_link}"
-          range_with_query_and_collection_and_fandom_html:
-            one: "%{start_number} - %{end_number} of %{total} Bookmarked Item found in %{collection_link} in %{fandom_link}"
-            other: "%{start_number} - %{end_number} of %{total} Bookmarked Items found in %{collection_link} in %{fandom_link}"
-          range_with_pseud_and_fandom_html:
-            one: "%{start_number} - %{end_number} of %{total} Bookmarked Item by %{byline} in %{fandom_link}"
-            other: "%{start_number} - %{end_number} of %{total} Bookmarked Items by %{byline} in %{fandom_link}"
-          range_with_query_and_pseud_and_fandom_html:
-            one: "%{start_number} - %{end_number} of %{total} Bookmarked Item found by %{byline} in %{fandom_link}"
-            other: "%{start_number} - %{end_number} of %{total} Bookmarked Items found by %{byline} in %{fandom_link}"
-          range_with_user_and_fandom_html:
-            one: "%{start_number} - %{end_number} of %{total} Bookmarked Item by %{username} in %{fandom_link}"
-            other: "%{start_number} - %{end_number} of %{total} Bookmarked Items by %{username} in %{fandom_link}"
-          range_with_query_and_user_and_fandom_html:
-            one: "%{start_number} - %{end_number} of %{total} Bookmarked Item found by %{username} in %{fandom_link}"
-            other: "%{start_number} - %{end_number} of %{total} Bookmarked Items found by %{username} in %{fandom_link}"
+          range_with_collection_html:
+            one: "%{start_number} - %{end_number} of %{total} Bookmarked Item in %{collection_link}"
+            other: "%{start_number} - %{end_number} of %{total} Bookmarked Items in %{collection_link}"
+          range_with_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} Bookmarked Item in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Bookmarked Items in %{fandom_link}"
+          range_with_language:
+            one: "%{start_number} - %{end_number} of %{total} Bookmarked Item in %{language}"
+            other: "%{start_number} - %{end_number} of %{total} Bookmarked Items in %{language}"
           range_with_language_and_fandom_html:
             one: "%{start_number} - %{end_number} of %{total} Bookmarked Item in %{language} in %{fandom_link}"
             other: "%{start_number} - %{end_number} of %{total} Bookmarked Items in %{language} in %{fandom_link}"
+          range_with_pseud:
+            one: "%{start_number} - %{end_number} of %{total} Bookmarked Item by %{byline}"
+            other: "%{start_number} - %{end_number} of %{total} Bookmarked Items by %{byline}"
+          range_with_pseud_and_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} Bookmarked Item by %{byline} in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Bookmarked Items by %{byline} in %{fandom_link}"
+          range_with_query:
+            one: "%{start_number} - %{end_number} of %{total} Bookmarked Item found"
+            other: "%{start_number} - %{end_number} of %{total} Bookmarked Items found"
+          range_with_query_and_collection_and_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} Bookmarked Item found in %{collection_link} in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Bookmarked Items found in %{collection_link} in %{fandom_link}"
+          range_with_query_and_collection_html:
+            one: "%{start_number} - %{end_number} of %{total} Bookmarked Item found in %{collection_link}"
+            other: "%{start_number} - %{end_number} of %{total} Bookmarked Items found in %{collection_link}"
+          range_with_query_and_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} Bookmarked Item found in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Bookmarked Items found in %{fandom_link}"
+          range_with_query_and_language:
+            one: "%{start_number} - %{end_number} of %{total} Bookmarked Item found in %{language}"
+            other: "%{start_number} - %{end_number} of %{total} Bookmarked Items found in %{language}"
           range_with_query_and_language_and_fandom_html:
             one: "%{start_number} - %{end_number} of %{total} Bookmarked Item found in %{language} in %{fandom_link}"
             other: "%{start_number} - %{end_number} of %{total} Bookmarked Items found in %{language} in %{fandom_link}"
-          range_with_tag_and_fandom_html:
-            one: "%{start_number} - %{end_number} of %{total} Bookmarked Item in %{tag_link} in %{fandom_link}"
-            other: "%{start_number} - %{end_number} of %{total} Bookmarked Items in %{tag_link} in %{fandom_link}"
+          range_with_query_and_pseud:
+            one: "%{start_number} - %{end_number} of %{total} Bookmarked Item found by %{byline}"
+            other: "%{start_number} - %{end_number} of %{total} Bookmarked Items found by %{byline}"
+          range_with_query_and_pseud_and_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} Bookmarked Item found by %{byline} in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Bookmarked Items found by %{byline} in %{fandom_link}"
           range_with_query_and_tag_and_fandom_html:
             one: "%{start_number} - %{end_number} of %{total} Bookmarked Item found in %{tag_link} in %{fandom_link}"
             other: "%{start_number} - %{end_number} of %{total} Bookmarked Items found in %{tag_link} in %{fandom_link}"
+          range_with_query_and_tag_html:
+            one: "%{start_number} - %{end_number} of %{total} Bookmarked Item found in %{tag_link}"
+            other: "%{start_number} - %{end_number} of %{total} Bookmarked Items found in %{tag_link}"
+          range_with_query_and_user:
+            one: "%{start_number} - %{end_number} of %{total} Bookmarked Item found by %{username}"
+            other: "%{start_number} - %{end_number} of %{total} Bookmarked Items found by %{username}"
+          range_with_query_and_user_and_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} Bookmarked Item found by %{username} in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Bookmarked Items found by %{username} in %{fandom_link}"
+          range_with_tag_and_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} Bookmarked Item in %{tag_link} in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Bookmarked Items in %{tag_link} in %{fandom_link}"
+          range_with_tag_html:
+            one: "%{start_number} - %{end_number} of %{total} Bookmarked Item in %{tag_link}"
+            other: "%{start_number} - %{end_number} of %{total} Bookmarked Items in %{tag_link}"
+          range_with_user:
+            one: "%{start_number} - %{end_number} of %{total} Bookmarked Item by %{username}"
+            other: "%{start_number} - %{end_number} of %{total} Bookmarked Items by %{username}"
+          range_with_user_and_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} Bookmarked Item by %{username} in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Bookmarked Items by %{username} in %{fandom_link}"
           recent:
-            one: "Recent Bookmarked Item"
-            other: "Recent Bookmarked Items"
-          recent_with_query:
-            one: "Recent Bookmarked Item found"
-            other: "Recent Bookmarked Items found"
-          recent_with_collection_html:
-            one: "Recent Bookmarked Item in %{collection_link}"
-            other: "Recent Bookmarked Items in %{collection_link}"
-          recent_with_query_and_collection_html:
-            one: "Recent Bookmarked Item found in %{collection_link}"
-            other: "Recent Bookmarked Items found in %{collection_link}"
-          recent_with_pseud:
-            one: "Recent Bookmarked Item by %{byline}"
-            other: "Recent Bookmarked Items by %{byline}"
-          recent_with_query_and_pseud:
-            one: "Recent Bookmarked Item found by %{byline}"
-            other: "Recent Bookmarked Items found by %{byline}"
-          recent_with_user:
-            one: "Recent Bookmarked Item by %{username}"
-            other: "Recent Bookmarked Items by %{username}"
-          recent_with_query_and_user:
-            one: "Recent Bookmarked Item found by %{username}"
-            other: "Recent Bookmarked Items found by %{username}"
-          recent_with_language:
-            one: "Recent Bookmarked Item in %{language}"
-            other: "Recent Bookmarked Items in %{language}"
-          recent_with_query_and_language:
-            one: "Recent Bookmarked Item found in %{language}"
-            other: "Recent Bookmarked Items found in %{language}"
-          recent_with_tag_html:
-            one: "Recent Bookmarked Item in %{tag_link}"
-            other: "Recent Bookmarked Items in %{tag_link}"
-          recent_with_query_and_tag_html:
-            one: "Recent Bookmarked Item found in %{tag_link}"
-            other: "Recent Bookmarked Items found in %{tag_link}"
-          recent_with_fandom_html:
-            one: "Recent Bookmarked Item in %{fandom_link}"
-            other: "Recent Bookmarked Items in %{fandom_link}"
-          recent_with_query_and_fandom_html:
-            one: "Recent Bookmarked Item found in %{fandom_link}"
-            other: "Recent Bookmarked Items found in %{fandom_link}"
+            one: Recent Bookmarked Item
+            other: Recent Bookmarked Items
           recent_with_collection_and_fandom_html:
-            one: "Recent Bookmarked Item in %{collection_link} in %{fandom_link}"
-            other: "Recent Bookmarked Items in %{collection_link} in %{fandom_link}"
-          recent_with_query_and_collection_and_fandom_html:
-            one: "Recent Bookmarked Item found in %{collection_link} in %{fandom_link}"
-            other: "Recent Bookmarked Items found in %{collection_link} in %{fandom_link}"
-          recent_with_pseud_and_fandom_html:
-            one: "Recent Bookmarked Item by %{byline} in %{fandom_link}"
-            other: "Recent Bookmarked Items by %{byline} in %{fandom_link}"
-          recent_with_query_and_pseud_and_fandom_html:
-            one: "Recent Bookmarked Item found by %{byline} in %{fandom_link}"
-            other: "Recent Bookmarked Items found by %{byline} in %{fandom_link}"
-          recent_with_user_and_fandom_html:
-            one: "Recent Bookmarked Item by %{username} in %{fandom_link}"
-            other: "Recent Bookmarked Items by %{username} in %{fandom_link}"
-          recent_with_query_and_user_and_fandom_html:
-            one: "Recent Bookmarked Item found by %{username} in %{fandom_link}"
-            other: "Recent Bookmarked Items found by %{username} in %{fandom_link}"
+            one: Recent Bookmarked Item in %{collection_link} in %{fandom_link}
+            other: Recent Bookmarked Items in %{collection_link} in %{fandom_link}
+          recent_with_collection_html:
+            one: Recent Bookmarked Item in %{collection_link}
+            other: Recent Bookmarked Items in %{collection_link}
+          recent_with_fandom_html:
+            one: Recent Bookmarked Item in %{fandom_link}
+            other: Recent Bookmarked Items in %{fandom_link}
+          recent_with_language:
+            one: Recent Bookmarked Item in %{language}
+            other: Recent Bookmarked Items in %{language}
           recent_with_language_and_fandom_html:
-            one: "Recent Bookmarked Item in %{language} in %{fandom_link}"
-            other: "Recent Bookmarked Items in %{language} in %{fandom_link}"
+            one: Recent Bookmarked Item in %{language} in %{fandom_link}
+            other: Recent Bookmarked Items in %{language} in %{fandom_link}
+          recent_with_pseud:
+            one: Recent Bookmarked Item by %{byline}
+            other: Recent Bookmarked Items by %{byline}
+          recent_with_pseud_and_fandom_html:
+            one: Recent Bookmarked Item by %{byline} in %{fandom_link}
+            other: Recent Bookmarked Items by %{byline} in %{fandom_link}
+          recent_with_query:
+            one: Recent Bookmarked Item found
+            other: Recent Bookmarked Items found
+          recent_with_query_and_collection_and_fandom_html:
+            one: Recent Bookmarked Item found in %{collection_link} in %{fandom_link}
+            other: Recent Bookmarked Items found in %{collection_link} in %{fandom_link}
+          recent_with_query_and_collection_html:
+            one: Recent Bookmarked Item found in %{collection_link}
+            other: Recent Bookmarked Items found in %{collection_link}
+          recent_with_query_and_fandom_html:
+            one: Recent Bookmarked Item found in %{fandom_link}
+            other: Recent Bookmarked Items found in %{fandom_link}
+          recent_with_query_and_language:
+            one: Recent Bookmarked Item found in %{language}
+            other: Recent Bookmarked Items found in %{language}
           recent_with_query_and_language_and_fandom_html:
-            one: "Recent Bookmarked Item found in %{language} in %{fandom_link}"
-            other: "Recent Bookmarked Items found in %{language} in %{fandom_link}"
-          recent_with_tag_and_fandom_html:
-            one: "Recent Bookmarked Item in %{tag_link} in %{fandom_link}"
-            other: "Recent Bookmarked Items in %{tag_link} in %{fandom_link}"
+            one: Recent Bookmarked Item found in %{language} in %{fandom_link}
+            other: Recent Bookmarked Items found in %{language} in %{fandom_link}
+          recent_with_query_and_pseud:
+            one: Recent Bookmarked Item found by %{byline}
+            other: Recent Bookmarked Items found by %{byline}
+          recent_with_query_and_pseud_and_fandom_html:
+            one: Recent Bookmarked Item found by %{byline} in %{fandom_link}
+            other: Recent Bookmarked Items found by %{byline} in %{fandom_link}
           recent_with_query_and_tag_and_fandom_html:
-            one: "Recent Bookmarked Item found in %{tag_link} in %{fandom_link}"
-            other: "Recent Bookmarked Items found in %{tag_link} in %{fandom_link}"
+            one: Recent Bookmarked Item found in %{tag_link} in %{fandom_link}
+            other: Recent Bookmarked Items found in %{tag_link} in %{fandom_link}
+          recent_with_query_and_tag_html:
+            one: Recent Bookmarked Item found in %{tag_link}
+            other: Recent Bookmarked Items found in %{tag_link}
+          recent_with_query_and_user:
+            one: Recent Bookmarked Item found by %{username}
+            other: Recent Bookmarked Items found by %{username}
+          recent_with_query_and_user_and_fandom_html:
+            one: Recent Bookmarked Item found by %{username} in %{fandom_link}
+            other: Recent Bookmarked Items found by %{username} in %{fandom_link}
+          recent_with_tag_and_fandom_html:
+            one: Recent Bookmarked Item in %{tag_link} in %{fandom_link}
+            other: Recent Bookmarked Items in %{tag_link} in %{fandom_link}
+          recent_with_tag_html:
+            one: Recent Bookmarked Item in %{tag_link}
+            other: Recent Bookmarked Items in %{tag_link}
+          recent_with_user:
+            one: Recent Bookmarked Item by %{username}
+            other: Recent Bookmarked Items by %{username}
+          recent_with_user_and_fandom_html:
+            one: Recent Bookmarked Item by %{username} in %{fandom_link}
+            other: Recent Bookmarked Items by %{username} in %{fandom_link}
         challenge_signup:
           count:
             one: "%{count} Sign-up"
             other: "%{count} Sign-ups"
-          count_with_query:
-            one: "%{count} Sign-up found"
-            other: "%{count} Sign-ups found"
-          count_with_collection_html:
-            one: "%{count} Sign-up in %{collection_link}"
-            other: "%{count} Sign-ups in %{collection_link}"
-          count_with_query_and_collection_html:
-            one: "%{count} Sign-up found in %{collection_link}"
-            other: "%{count} Sign-ups found in %{collection_link}"
-          count_with_pseud:
-            one: "%{count} Sign-up by %{byline}"
-            other: "%{count} Sign-ups by %{byline}"
-          count_with_query_and_pseud:
-            one: "%{count} Sign-up found by %{byline}"
-            other: "%{count} Sign-ups found by %{byline}"
-          count_with_user:
-            one: "%{count} Sign-up by %{username}"
-            other: "%{count} Sign-ups by %{username}"
-          count_with_query_and_user:
-            one: "%{count} Sign-up found by %{username}"
-            other: "%{count} Sign-ups found by %{username}"
-          count_with_language:
-            one: "%{count} Sign-up in %{language}"
-            other: "%{count} Sign-ups in %{language}"
-          count_with_query_and_language:
-            one: "%{count} Sign-up found in %{language}"
-            other: "%{count} Sign-ups found in %{language}"
-          count_with_tag_html:
-            one: "%{count} Sign-up in %{tag_link}"
-            other: "%{count} Sign-ups in %{tag_link}"
-          count_with_query_and_tag_html:
-            one: "%{count} Sign-up found in %{tag_link}"
-            other: "%{count} Sign-ups found in %{tag_link}"
-          count_with_fandom_html:
-            one: "%{count} Sign-up in %{fandom_link}"
-            other: "%{count} Sign-ups in %{fandom_link}"
-          count_with_query_and_fandom_html:
-            one: "%{count} Sign-up found in %{fandom_link}"
-            other: "%{count} Sign-ups found in %{fandom_link}"
           count_with_collection_and_fandom_html:
             one: "%{count} Sign-up in %{collection_link} in %{fandom_link}"
             other: "%{count} Sign-ups in %{collection_link} in %{fandom_link}"
-          count_with_query_and_collection_and_fandom_html:
-            one: "%{count} Sign-up found in %{collection_link} in %{fandom_link}"
-            other: "%{count} Sign-ups found in %{collection_link} in %{fandom_link}"
-          count_with_pseud_and_fandom_html:
-            one: "%{count} Sign-up by %{byline} in %{fandom_link}"
-            other: "%{count} Sign-ups by %{byline} in %{fandom_link}"
-          count_with_query_and_pseud_and_fandom_html:
-            one: "%{count} Sign-up found by %{byline} in %{fandom_link}"
-            other: "%{count} Sign-ups found by %{byline} in %{fandom_link}"
-          count_with_user_and_fandom_html:
-            one: "%{count} Sign-up by %{username} in %{fandom_link}"
-            other: "%{count} Sign-ups by %{username} in %{fandom_link}"
-          count_with_query_and_user_and_fandom_html:
-            one: "%{count} Sign-up found by %{username} in %{fandom_link}"
-            other: "%{count} Sign-ups found by %{username} in %{fandom_link}"
+          count_with_collection_html:
+            one: "%{count} Sign-up in %{collection_link}"
+            other: "%{count} Sign-ups in %{collection_link}"
+          count_with_fandom_html:
+            one: "%{count} Sign-up in %{fandom_link}"
+            other: "%{count} Sign-ups in %{fandom_link}"
+          count_with_language:
+            one: "%{count} Sign-up in %{language}"
+            other: "%{count} Sign-ups in %{language}"
           count_with_language_and_fandom_html:
             one: "%{count} Sign-up in %{language} in %{fandom_link}"
             other: "%{count} Sign-ups in %{language} in %{fandom_link}"
+          count_with_pseud:
+            one: "%{count} Sign-up by %{byline}"
+            other: "%{count} Sign-ups by %{byline}"
+          count_with_pseud_and_fandom_html:
+            one: "%{count} Sign-up by %{byline} in %{fandom_link}"
+            other: "%{count} Sign-ups by %{byline} in %{fandom_link}"
+          count_with_query:
+            one: "%{count} Sign-up found"
+            other: "%{count} Sign-ups found"
+          count_with_query_and_collection_and_fandom_html:
+            one: "%{count} Sign-up found in %{collection_link} in %{fandom_link}"
+            other: "%{count} Sign-ups found in %{collection_link} in %{fandom_link}"
+          count_with_query_and_collection_html:
+            one: "%{count} Sign-up found in %{collection_link}"
+            other: "%{count} Sign-ups found in %{collection_link}"
+          count_with_query_and_fandom_html:
+            one: "%{count} Sign-up found in %{fandom_link}"
+            other: "%{count} Sign-ups found in %{fandom_link}"
+          count_with_query_and_language:
+            one: "%{count} Sign-up found in %{language}"
+            other: "%{count} Sign-ups found in %{language}"
           count_with_query_and_language_and_fandom_html:
             one: "%{count} Sign-up found in %{language} in %{fandom_link}"
             other: "%{count} Sign-ups found in %{language} in %{fandom_link}"
-          count_with_tag_and_fandom_html:
-            one: "%{count} Sign-up in %{tag_link} in %{fandom_link}"
-            other: "%{count} Sign-ups in %{tag_link} in %{fandom_link}"
+          count_with_query_and_pseud:
+            one: "%{count} Sign-up found by %{byline}"
+            other: "%{count} Sign-ups found by %{byline}"
+          count_with_query_and_pseud_and_fandom_html:
+            one: "%{count} Sign-up found by %{byline} in %{fandom_link}"
+            other: "%{count} Sign-ups found by %{byline} in %{fandom_link}"
           count_with_query_and_tag_and_fandom_html:
             one: "%{count} Sign-up found in %{tag_link} in %{fandom_link}"
             other: "%{count} Sign-ups found in %{tag_link} in %{fandom_link}"
+          count_with_query_and_tag_html:
+            one: "%{count} Sign-up found in %{tag_link}"
+            other: "%{count} Sign-ups found in %{tag_link}"
+          count_with_query_and_user:
+            one: "%{count} Sign-up found by %{username}"
+            other: "%{count} Sign-ups found by %{username}"
+          count_with_query_and_user_and_fandom_html:
+            one: "%{count} Sign-up found by %{username} in %{fandom_link}"
+            other: "%{count} Sign-ups found by %{username} in %{fandom_link}"
+          count_with_tag_and_fandom_html:
+            one: "%{count} Sign-up in %{tag_link} in %{fandom_link}"
+            other: "%{count} Sign-ups in %{tag_link} in %{fandom_link}"
+          count_with_tag_html:
+            one: "%{count} Sign-up in %{tag_link}"
+            other: "%{count} Sign-ups in %{tag_link}"
+          count_with_user:
+            one: "%{count} Sign-up by %{username}"
+            other: "%{count} Sign-ups by %{username}"
+          count_with_user_and_fandom_html:
+            one: "%{count} Sign-up by %{username} in %{fandom_link}"
+            other: "%{count} Sign-ups by %{username} in %{fandom_link}"
           range:
             one: "%{start_number} - %{end_number} of %{total} Sign-up"
             other: "%{start_number} - %{end_number} of %{total} Sign-ups"
-          range_with_query:
-            one: "%{start_number} - %{end_number} of %{total} Sign-up found"
-            other: "%{start_number} - %{end_number} of %{total} Sign-ups found"
-          range_with_collection_html:
-            one: "%{start_number} - %{end_number} of %{total} Sign-up in %{collection_link}"
-            other: "%{start_number} - %{end_number} of %{total} Sign-ups in %{collection_link}"
-          range_with_query_and_collection_html:
-            one: "%{start_number} - %{end_number} of %{total} Sign-up found in %{collection_link}"
-            other: "%{start_number} - %{end_number} of %{total} Sign-ups found in %{collection_link}"
-          range_with_pseud:
-            one: "%{start_number} - %{end_number} of %{total} Sign-up by %{byline}"
-            other: "%{start_number} - %{end_number} of %{total} Sign-ups by %{byline}"
-          range_with_query_and_pseud:
-            one: "%{start_number} - %{end_number} of %{total} Sign-up found by %{byline}"
-            other: "%{start_number} - %{end_number} of %{total} Sign-ups found by %{byline}"
-          range_with_user:
-            one: "%{start_number} - %{end_number} of %{total} Sign-up by %{username}"
-            other: "%{start_number} - %{end_number} of %{total} Sign-ups by %{username}"
-          range_with_query_and_user:
-            one: "%{start_number} - %{end_number} of %{total} Sign-up found by %{username}"
-            other: "%{start_number} - %{end_number} of %{total} Sign-ups found by %{username}"
-          range_with_language:
-            one: "%{start_number} - %{end_number} of %{total} Sign-up in %{language}"
-            other: "%{start_number} - %{end_number} of %{total} Sign-ups in %{language}"
-          range_with_query_and_language:
-            one: "%{start_number} - %{end_number} of %{total} Sign-up found in %{language}"
-            other: "%{start_number} - %{end_number} of %{total} Sign-ups found in %{language}"
-          range_with_tag_html:
-            one: "%{start_number} - %{end_number} of %{total} Sign-up in %{tag_link}"
-            other: "%{start_number} - %{end_number} of %{total} Sign-ups in %{tag_link}"
-          range_with_query_and_tag_html:
-            one: "%{start_number} - %{end_number} of %{total} Sign-up found in %{tag_link}"
-            other: "%{start_number} - %{end_number} of %{total} Sign-ups found in %{tag_link}"
-          range_with_fandom_html:
-            one: "%{start_number} - %{end_number} of %{total} Sign-up in %{fandom_link}"
-            other: "%{start_number} - %{end_number} of %{total} Sign-ups in %{fandom_link}"
-          range_with_query_and_fandom_html:
-            one: "%{start_number} - %{end_number} of %{total} Sign-up found in %{fandom_link}"
-            other: "%{start_number} - %{end_number} of %{total} Sign-ups found in %{fandom_link}"
           range_with_collection_and_fandom_html:
             one: "%{start_number} - %{end_number} of %{total} Sign-up in %{collection_link} in %{fandom_link}"
             other: "%{start_number} - %{end_number} of %{total} Sign-ups in %{collection_link} in %{fandom_link}"
-          range_with_query_and_collection_and_fandom_html:
-            one: "%{start_number} - %{end_number} of %{total} Sign-up found in %{collection_link} in %{fandom_link}"
-            other: "%{start_number} - %{end_number} of %{total} Sign-ups found in %{collection_link} in %{fandom_link}"
-          range_with_pseud_and_fandom_html:
-            one: "%{start_number} - %{end_number} of %{total} Sign-up by %{byline} in %{fandom_link}"
-            other: "%{start_number} - %{end_number} of %{total} Sign-ups by %{byline} in %{fandom_link}"
-          range_with_query_and_pseud_and_fandom_html:
-            one: "%{start_number} - %{end_number} of %{total} Sign-up found by %{byline} in %{fandom_link}"
-            other: "%{start_number} - %{end_number} of %{total} Sign-ups found by %{byline} in %{fandom_link}"
-          range_with_user_and_fandom_html:
-            one: "%{start_number} - %{end_number} of %{total} Sign-up by %{username} in %{fandom_link}"
-            other: "%{start_number} - %{end_number} of %{total} Sign-ups by %{username} in %{fandom_link}"
-          range_with_query_and_user_and_fandom_html:
-            one: "%{start_number} - %{end_number} of %{total} Sign-up found by %{username} in %{fandom_link}"
-            other: "%{start_number} - %{end_number} of %{total} Sign-ups found by %{username} in %{fandom_link}"
+          range_with_collection_html:
+            one: "%{start_number} - %{end_number} of %{total} Sign-up in %{collection_link}"
+            other: "%{start_number} - %{end_number} of %{total} Sign-ups in %{collection_link}"
+          range_with_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} Sign-up in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Sign-ups in %{fandom_link}"
+          range_with_language:
+            one: "%{start_number} - %{end_number} of %{total} Sign-up in %{language}"
+            other: "%{start_number} - %{end_number} of %{total} Sign-ups in %{language}"
           range_with_language_and_fandom_html:
             one: "%{start_number} - %{end_number} of %{total} Sign-up in %{language} in %{fandom_link}"
             other: "%{start_number} - %{end_number} of %{total} Sign-ups in %{language} in %{fandom_link}"
+          range_with_pseud:
+            one: "%{start_number} - %{end_number} of %{total} Sign-up by %{byline}"
+            other: "%{start_number} - %{end_number} of %{total} Sign-ups by %{byline}"
+          range_with_pseud_and_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} Sign-up by %{byline} in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Sign-ups by %{byline} in %{fandom_link}"
+          range_with_query:
+            one: "%{start_number} - %{end_number} of %{total} Sign-up found"
+            other: "%{start_number} - %{end_number} of %{total} Sign-ups found"
+          range_with_query_and_collection_and_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} Sign-up found in %{collection_link} in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Sign-ups found in %{collection_link} in %{fandom_link}"
+          range_with_query_and_collection_html:
+            one: "%{start_number} - %{end_number} of %{total} Sign-up found in %{collection_link}"
+            other: "%{start_number} - %{end_number} of %{total} Sign-ups found in %{collection_link}"
+          range_with_query_and_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} Sign-up found in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Sign-ups found in %{fandom_link}"
+          range_with_query_and_language:
+            one: "%{start_number} - %{end_number} of %{total} Sign-up found in %{language}"
+            other: "%{start_number} - %{end_number} of %{total} Sign-ups found in %{language}"
           range_with_query_and_language_and_fandom_html:
             one: "%{start_number} - %{end_number} of %{total} Sign-up found in %{language} in %{fandom_link}"
             other: "%{start_number} - %{end_number} of %{total} Sign-ups found in %{language} in %{fandom_link}"
-          range_with_tag_and_fandom_html:
-            one: "%{start_number} - %{end_number} of %{total} Sign-up in %{tag_link} in %{fandom_link}"
-            other: "%{start_number} - %{end_number} of %{total} Sign-ups in %{tag_link} in %{fandom_link}"
+          range_with_query_and_pseud:
+            one: "%{start_number} - %{end_number} of %{total} Sign-up found by %{byline}"
+            other: "%{start_number} - %{end_number} of %{total} Sign-ups found by %{byline}"
+          range_with_query_and_pseud_and_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} Sign-up found by %{byline} in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Sign-ups found by %{byline} in %{fandom_link}"
           range_with_query_and_tag_and_fandom_html:
             one: "%{start_number} - %{end_number} of %{total} Sign-up found in %{tag_link} in %{fandom_link}"
             other: "%{start_number} - %{end_number} of %{total} Sign-ups found in %{tag_link} in %{fandom_link}"
+          range_with_query_and_tag_html:
+            one: "%{start_number} - %{end_number} of %{total} Sign-up found in %{tag_link}"
+            other: "%{start_number} - %{end_number} of %{total} Sign-ups found in %{tag_link}"
+          range_with_query_and_user:
+            one: "%{start_number} - %{end_number} of %{total} Sign-up found by %{username}"
+            other: "%{start_number} - %{end_number} of %{total} Sign-ups found by %{username}"
+          range_with_query_and_user_and_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} Sign-up found by %{username} in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Sign-ups found by %{username} in %{fandom_link}"
+          range_with_tag_and_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} Sign-up in %{tag_link} in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Sign-ups in %{tag_link} in %{fandom_link}"
+          range_with_tag_html:
+            one: "%{start_number} - %{end_number} of %{total} Sign-up in %{tag_link}"
+            other: "%{start_number} - %{end_number} of %{total} Sign-ups in %{tag_link}"
+          range_with_user:
+            one: "%{start_number} - %{end_number} of %{total} Sign-up by %{username}"
+            other: "%{start_number} - %{end_number} of %{total} Sign-ups by %{username}"
+          range_with_user_and_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} Sign-up by %{username} in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Sign-ups by %{username} in %{fandom_link}"
           recent:
-            one: "Recent Sign-up"
-            other: "Recent Sign-ups"
-          recent_with_query:
-            one: "Recent Sign-up found"
-            other: "Recent Sign-ups found"
-          recent_with_collection_html:
-            one: "Recent Sign-up in %{collection_link}"
-            other: "Recent Sign-ups in %{collection_link}"
-          recent_with_query_and_collection_html:
-            one: "Recent Sign-up found in %{collection_link}"
-            other: "Recent Sign-ups found in %{collection_link}"
-          recent_with_pseud:
-            one: "Recent Sign-up by %{byline}"
-            other: "Recent Sign-ups by %{byline}"
-          recent_with_query_and_pseud:
-            one: "Recent Sign-up found by %{byline}"
-            other: "Recent Sign-ups found by %{byline}"
-          recent_with_user:
-            one: "Recent Sign-up by %{username}"
-            other: "Recent Sign-ups by %{username}"
-          recent_with_query_and_user:
-            one: "Recent Sign-up found by %{username}"
-            other: "Recent Sign-ups found by %{username}"
-          recent_with_language:
-            one: "Recent Sign-up in %{language}"
-            other: "Recent Sign-ups in %{language}"
-          recent_with_query_and_language:
-            one: "Recent Sign-up found in %{language}"
-            other: "Recent Sign-ups found in %{language}"
-          recent_with_tag_html:
-            one: "Recent Sign-up in %{tag_link}"
-            other: "Recent Sign-ups in %{tag_link}"
-          recent_with_query_and_tag_html:
-            one: "Recent Sign-up found in %{tag_link}"
-            other: "Recent Sign-ups found in %{tag_link}"
-          recent_with_fandom_html:
-            one: "Recent Sign-up in %{fandom_link}"
-            other: "Recent Sign-ups in %{fandom_link}"
-          recent_with_query_and_fandom_html:
-            one: "Recent Sign-up found in %{fandom_link}"
-            other: "Recent Sign-ups found in %{fandom_link}"
+            one: Recent Sign-up
+            other: Recent Sign-ups
           recent_with_collection_and_fandom_html:
-            one: "Recent Sign-up in %{collection_link} in %{fandom_link}"
-            other: "Recent Sign-ups in %{collection_link} in %{fandom_link}"
-          recent_with_query_and_collection_and_fandom_html:
-            one: "Recent Sign-up found in %{collection_link} in %{fandom_link}"
-            other: "Recent Sign-ups found in %{collection_link} in %{fandom_link}"
-          recent_with_pseud_and_fandom_html:
-            one: "Recent Sign-up by %{byline} in %{fandom_link}"
-            other: "Recent Sign-ups by %{byline} in %{fandom_link}"
-          recent_with_query_and_pseud_and_fandom_html:
-            one: "Recent Sign-up found by %{byline} in %{fandom_link}"
-            other: "Recent Sign-ups found by %{byline} in %{fandom_link}"
-          recent_with_user_and_fandom_html:
-            one: "Recent Sign-up by %{username} in %{fandom_link}"
-            other: "Recent Sign-ups by %{username} in %{fandom_link}"
-          recent_with_query_and_user_and_fandom_html:
-            one: "Recent Sign-up found by %{username} in %{fandom_link}"
-            other: "Recent Sign-ups found by %{username} in %{fandom_link}"
+            one: Recent Sign-up in %{collection_link} in %{fandom_link}
+            other: Recent Sign-ups in %{collection_link} in %{fandom_link}
+          recent_with_collection_html:
+            one: Recent Sign-up in %{collection_link}
+            other: Recent Sign-ups in %{collection_link}
+          recent_with_fandom_html:
+            one: Recent Sign-up in %{fandom_link}
+            other: Recent Sign-ups in %{fandom_link}
+          recent_with_language:
+            one: Recent Sign-up in %{language}
+            other: Recent Sign-ups in %{language}
           recent_with_language_and_fandom_html:
-            one: "Recent Sign-up in %{language} in %{fandom_link}"
-            other: "Recent Sign-ups in %{language} in %{fandom_link}"
+            one: Recent Sign-up in %{language} in %{fandom_link}
+            other: Recent Sign-ups in %{language} in %{fandom_link}
+          recent_with_pseud:
+            one: Recent Sign-up by %{byline}
+            other: Recent Sign-ups by %{byline}
+          recent_with_pseud_and_fandom_html:
+            one: Recent Sign-up by %{byline} in %{fandom_link}
+            other: Recent Sign-ups by %{byline} in %{fandom_link}
+          recent_with_query:
+            one: Recent Sign-up found
+            other: Recent Sign-ups found
+          recent_with_query_and_collection_and_fandom_html:
+            one: Recent Sign-up found in %{collection_link} in %{fandom_link}
+            other: Recent Sign-ups found in %{collection_link} in %{fandom_link}
+          recent_with_query_and_collection_html:
+            one: Recent Sign-up found in %{collection_link}
+            other: Recent Sign-ups found in %{collection_link}
+          recent_with_query_and_fandom_html:
+            one: Recent Sign-up found in %{fandom_link}
+            other: Recent Sign-ups found in %{fandom_link}
+          recent_with_query_and_language:
+            one: Recent Sign-up found in %{language}
+            other: Recent Sign-ups found in %{language}
           recent_with_query_and_language_and_fandom_html:
-            one: "Recent Sign-up found in %{language} in %{fandom_link}"
-            other: "Recent Sign-ups found in %{language} in %{fandom_link}"
-          recent_with_tag_and_fandom_html:
-            one: "Recent Sign-up in %{tag_link} in %{fandom_link}"
-            other: "Recent Sign-ups in %{tag_link} in %{fandom_link}"
+            one: Recent Sign-up found in %{language} in %{fandom_link}
+            other: Recent Sign-ups found in %{language} in %{fandom_link}
+          recent_with_query_and_pseud:
+            one: Recent Sign-up found by %{byline}
+            other: Recent Sign-ups found by %{byline}
+          recent_with_query_and_pseud_and_fandom_html:
+            one: Recent Sign-up found by %{byline} in %{fandom_link}
+            other: Recent Sign-ups found by %{byline} in %{fandom_link}
           recent_with_query_and_tag_and_fandom_html:
-            one: "Recent Sign-up found in %{tag_link} in %{fandom_link}"
-            other: "Recent Sign-ups found in %{tag_link} in %{fandom_link}"
+            one: Recent Sign-up found in %{tag_link} in %{fandom_link}
+            other: Recent Sign-ups found in %{tag_link} in %{fandom_link}
+          recent_with_query_and_tag_html:
+            one: Recent Sign-up found in %{tag_link}
+            other: Recent Sign-ups found in %{tag_link}
+          recent_with_query_and_user:
+            one: Recent Sign-up found by %{username}
+            other: Recent Sign-ups found by %{username}
+          recent_with_query_and_user_and_fandom_html:
+            one: Recent Sign-up found by %{username} in %{fandom_link}
+            other: Recent Sign-ups found by %{username} in %{fandom_link}
+          recent_with_tag_and_fandom_html:
+            one: Recent Sign-up in %{tag_link} in %{fandom_link}
+            other: Recent Sign-ups in %{tag_link} in %{fandom_link}
+          recent_with_tag_html:
+            one: Recent Sign-up in %{tag_link}
+            other: Recent Sign-ups in %{tag_link}
+          recent_with_user:
+            one: Recent Sign-up by %{username}
+            other: Recent Sign-ups by %{username}
+          recent_with_user_and_fandom_html:
+            one: Recent Sign-up by %{username} in %{fandom_link}
+            other: Recent Sign-ups by %{username} in %{fandom_link}
         collection:
           count:
             one: "%{count} Collection"
             other: "%{count} Collections"
-          count_with_query:
-            one: "%{count} Collection found"
-            other: "%{count} Collections found"
-          count_with_collection_html:
-            one: "%{count} Collection in %{collection_link}"
-            other: "%{count} Collections in %{collection_link}"
-          count_with_query_and_collection_html:
-            one: "%{count} Collection found in %{collection_link}"
-            other: "%{count} Collections found in %{collection_link}"
-          count_with_pseud:
-            one: "%{count} Collection by %{byline}"
-            other: "%{count} Collections by %{byline}"
-          count_with_query_and_pseud:
-            one: "%{count} Collection found by %{byline}"
-            other: "%{count} Collections found by %{byline}"
-          count_with_user:
-            one: "%{count} Collection by %{username}"
-            other: "%{count} Collections by %{username}"
-          count_with_query_and_user:
-            one: "%{count} Collection found by %{username}"
-            other: "%{count} Collections found by %{username}"
-          count_with_language:
-            one: "%{count} Collection in %{language}"
-            other: "%{count} Collections in %{language}"
-          count_with_query_and_language:
-            one: "%{count} Collection found in %{language}"
-            other: "%{count} Collections found in %{language}"
-          count_with_tag_html:
-            one: "%{count} Collection in %{tag_link}"
-            other: "%{count} Collections in %{tag_link}"
-          count_with_query_and_tag_html:
-            one: "%{count} Collection found in %{tag_link}"
-            other: "%{count} Collections found in %{tag_link}"
-          count_with_fandom_html:
-            one: "%{count} Collection in %{fandom_link}"
-            other: "%{count} Collections in %{fandom_link}"
-          count_with_query_and_fandom_html:
-            one: "%{count} Collection found in %{fandom_link}"
-            other: "%{count} Collections found in %{fandom_link}"
           count_with_collection_and_fandom_html:
             one: "%{count} Collection in %{collection_link} in %{fandom_link}"
             other: "%{count} Collections in %{collection_link} in %{fandom_link}"
-          count_with_query_and_collection_and_fandom_html:
-            one: "%{count} Collection found in %{collection_link} in %{fandom_link}"
-            other: "%{count} Collections found in %{collection_link} in %{fandom_link}"
-          count_with_pseud_and_fandom_html:
-            one: "%{count} Collection by %{byline} in %{fandom_link}"
-            other: "%{count} Collections by %{byline} in %{fandom_link}"
-          count_with_query_and_pseud_and_fandom_html:
-            one: "%{count} Collection found by %{byline} in %{fandom_link}"
-            other: "%{count} Collections found by %{byline} in %{fandom_link}"
-          count_with_user_and_fandom_html:
-            one: "%{count} Collection by %{username} in %{fandom_link}"
-            other: "%{count} Collections by %{username} in %{fandom_link}"
-          count_with_query_and_user_and_fandom_html:
-            one: "%{count} Collection found by %{username} in %{fandom_link}"
-            other: "%{count} Collections found by %{username} in %{fandom_link}"
+          count_with_collection_html:
+            one: "%{count} Collection in %{collection_link}"
+            other: "%{count} Collections in %{collection_link}"
+          count_with_fandom_html:
+            one: "%{count} Collection in %{fandom_link}"
+            other: "%{count} Collections in %{fandom_link}"
+          count_with_language:
+            one: "%{count} Collection in %{language}"
+            other: "%{count} Collections in %{language}"
           count_with_language_and_fandom_html:
             one: "%{count} Collection in %{language} in %{fandom_link}"
             other: "%{count} Collections in %{language} in %{fandom_link}"
+          count_with_pseud:
+            one: "%{count} Collection by %{byline}"
+            other: "%{count} Collections by %{byline}"
+          count_with_pseud_and_fandom_html:
+            one: "%{count} Collection by %{byline} in %{fandom_link}"
+            other: "%{count} Collections by %{byline} in %{fandom_link}"
+          count_with_query:
+            one: "%{count} Collection found"
+            other: "%{count} Collections found"
+          count_with_query_and_collection_and_fandom_html:
+            one: "%{count} Collection found in %{collection_link} in %{fandom_link}"
+            other: "%{count} Collections found in %{collection_link} in %{fandom_link}"
+          count_with_query_and_collection_html:
+            one: "%{count} Collection found in %{collection_link}"
+            other: "%{count} Collections found in %{collection_link}"
+          count_with_query_and_fandom_html:
+            one: "%{count} Collection found in %{fandom_link}"
+            other: "%{count} Collections found in %{fandom_link}"
+          count_with_query_and_language:
+            one: "%{count} Collection found in %{language}"
+            other: "%{count} Collections found in %{language}"
           count_with_query_and_language_and_fandom_html:
             one: "%{count} Collection found in %{language} in %{fandom_link}"
             other: "%{count} Collections found in %{language} in %{fandom_link}"
-          count_with_tag_and_fandom_html:
-            one: "%{count} Collection in %{tag_link} in %{fandom_link}"
-            other: "%{count} Collections in %{tag_link} in %{fandom_link}"
+          count_with_query_and_pseud:
+            one: "%{count} Collection found by %{byline}"
+            other: "%{count} Collections found by %{byline}"
+          count_with_query_and_pseud_and_fandom_html:
+            one: "%{count} Collection found by %{byline} in %{fandom_link}"
+            other: "%{count} Collections found by %{byline} in %{fandom_link}"
           count_with_query_and_tag_and_fandom_html:
             one: "%{count} Collection found in %{tag_link} in %{fandom_link}"
             other: "%{count} Collections found in %{tag_link} in %{fandom_link}"
+          count_with_query_and_tag_html:
+            one: "%{count} Collection found in %{tag_link}"
+            other: "%{count} Collections found in %{tag_link}"
+          count_with_query_and_user:
+            one: "%{count} Collection found by %{username}"
+            other: "%{count} Collections found by %{username}"
+          count_with_query_and_user_and_fandom_html:
+            one: "%{count} Collection found by %{username} in %{fandom_link}"
+            other: "%{count} Collections found by %{username} in %{fandom_link}"
+          count_with_tag_and_fandom_html:
+            one: "%{count} Collection in %{tag_link} in %{fandom_link}"
+            other: "%{count} Collections in %{tag_link} in %{fandom_link}"
+          count_with_tag_html:
+            one: "%{count} Collection in %{tag_link}"
+            other: "%{count} Collections in %{tag_link}"
+          count_with_user:
+            one: "%{count} Collection by %{username}"
+            other: "%{count} Collections by %{username}"
+          count_with_user_and_fandom_html:
+            one: "%{count} Collection by %{username} in %{fandom_link}"
+            other: "%{count} Collections by %{username} in %{fandom_link}"
           range:
             one: "%{start_number} - %{end_number} of %{total} Collection"
             other: "%{start_number} - %{end_number} of %{total} Collections"
-          range_with_query:
-            one: "%{start_number} - %{end_number} of %{total} Collection found"
-            other: "%{start_number} - %{end_number} of %{total} Collections found"
-          range_with_collection_html:
-            one: "%{start_number} - %{end_number} of %{total} Collection in %{collection_link}"
-            other: "%{start_number} - %{end_number} of %{total} Collections in %{collection_link}"
-          range_with_query_and_collection_html:
-            one: "%{start_number} - %{end_number} of %{total} Collection found in %{collection_link}"
-            other: "%{start_number} - %{end_number} of %{total} Collections found in %{collection_link}"
-          range_with_pseud:
-            one: "%{start_number} - %{end_number} of %{total} Collection by %{byline}"
-            other: "%{start_number} - %{end_number} of %{total} Collections by %{byline}"
-          range_with_query_and_pseud:
-            one: "%{start_number} - %{end_number} of %{total} Collection found by %{byline}"
-            other: "%{start_number} - %{end_number} of %{total} Collections found by %{byline}"
-          range_with_user:
-            one: "%{start_number} - %{end_number} of %{total} Collection by %{username}"
-            other: "%{start_number} - %{end_number} of %{total} Collections by %{username}"
-          range_with_query_and_user:
-            one: "%{start_number} - %{end_number} of %{total} Collection found by %{username}"
-            other: "%{start_number} - %{end_number} of %{total} Collections found by %{username}"
-          range_with_language:
-            one: "%{start_number} - %{end_number} of %{total} Collection in %{language}"
-            other: "%{start_number} - %{end_number} of %{total} Collections in %{language}"
-          range_with_query_and_language:
-            one: "%{start_number} - %{end_number} of %{total} Collection found in %{language}"
-            other: "%{start_number} - %{end_number} of %{total} Collections found in %{language}"
-          range_with_tag_html:
-            one: "%{start_number} - %{end_number} of %{total} Collection in %{tag_link}"
-            other: "%{start_number} - %{end_number} of %{total} Collections in %{tag_link}"
-          range_with_query_and_tag_html:
-            one: "%{start_number} - %{end_number} of %{total} Collection found in %{tag_link}"
-            other: "%{start_number} - %{end_number} of %{total} Collections found in %{tag_link}"
-          range_with_fandom_html:
-            one: "%{start_number} - %{end_number} of %{total} Collection in %{fandom_link}"
-            other: "%{start_number} - %{end_number} of %{total} Collections in %{fandom_link}"
-          range_with_query_and_fandom_html:
-            one: "%{start_number} - %{end_number} of %{total} Collection found in %{fandom_link}"
-            other: "%{start_number} - %{end_number} of %{total} Collections found in %{fandom_link}"
           range_with_collection_and_fandom_html:
             one: "%{start_number} - %{end_number} of %{total} Collection in %{collection_link} in %{fandom_link}"
             other: "%{start_number} - %{end_number} of %{total} Collections in %{collection_link} in %{fandom_link}"
-          range_with_query_and_collection_and_fandom_html:
-            one: "%{start_number} - %{end_number} of %{total} Collection found in %{collection_link} in %{fandom_link}"
-            other: "%{start_number} - %{end_number} of %{total} Collections found in %{collection_link} in %{fandom_link}"
-          range_with_pseud_and_fandom_html:
-            one: "%{start_number} - %{end_number} of %{total} Collection by %{byline} in %{fandom_link}"
-            other: "%{start_number} - %{end_number} of %{total} Collections by %{byline} in %{fandom_link}"
-          range_with_query_and_pseud_and_fandom_html:
-            one: "%{start_number} - %{end_number} of %{total} Collection found by %{byline} in %{fandom_link}"
-            other: "%{start_number} - %{end_number} of %{total} Collections found by %{byline} in %{fandom_link}"
-          range_with_user_and_fandom_html:
-            one: "%{start_number} - %{end_number} of %{total} Collection by %{username} in %{fandom_link}"
-            other: "%{start_number} - %{end_number} of %{total} Collections by %{username} in %{fandom_link}"
-          range_with_query_and_user_and_fandom_html:
-            one: "%{start_number} - %{end_number} of %{total} Collection found by %{username} in %{fandom_link}"
-            other: "%{start_number} - %{end_number} of %{total} Collections found by %{username} in %{fandom_link}"
+          range_with_collection_html:
+            one: "%{start_number} - %{end_number} of %{total} Collection in %{collection_link}"
+            other: "%{start_number} - %{end_number} of %{total} Collections in %{collection_link}"
+          range_with_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} Collection in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Collections in %{fandom_link}"
+          range_with_language:
+            one: "%{start_number} - %{end_number} of %{total} Collection in %{language}"
+            other: "%{start_number} - %{end_number} of %{total} Collections in %{language}"
           range_with_language_and_fandom_html:
             one: "%{start_number} - %{end_number} of %{total} Collection in %{language} in %{fandom_link}"
             other: "%{start_number} - %{end_number} of %{total} Collections in %{language} in %{fandom_link}"
+          range_with_pseud:
+            one: "%{start_number} - %{end_number} of %{total} Collection by %{byline}"
+            other: "%{start_number} - %{end_number} of %{total} Collections by %{byline}"
+          range_with_pseud_and_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} Collection by %{byline} in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Collections by %{byline} in %{fandom_link}"
+          range_with_query:
+            one: "%{start_number} - %{end_number} of %{total} Collection found"
+            other: "%{start_number} - %{end_number} of %{total} Collections found"
+          range_with_query_and_collection_and_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} Collection found in %{collection_link} in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Collections found in %{collection_link} in %{fandom_link}"
+          range_with_query_and_collection_html:
+            one: "%{start_number} - %{end_number} of %{total} Collection found in %{collection_link}"
+            other: "%{start_number} - %{end_number} of %{total} Collections found in %{collection_link}"
+          range_with_query_and_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} Collection found in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Collections found in %{fandom_link}"
+          range_with_query_and_language:
+            one: "%{start_number} - %{end_number} of %{total} Collection found in %{language}"
+            other: "%{start_number} - %{end_number} of %{total} Collections found in %{language}"
           range_with_query_and_language_and_fandom_html:
             one: "%{start_number} - %{end_number} of %{total} Collection found in %{language} in %{fandom_link}"
             other: "%{start_number} - %{end_number} of %{total} Collections found in %{language} in %{fandom_link}"
-          range_with_tag_and_fandom_html:
-            one: "%{start_number} - %{end_number} of %{total} Collection in %{tag_link} in %{fandom_link}"
-            other: "%{start_number} - %{end_number} of %{total} Collections in %{tag_link} in %{fandom_link}"
+          range_with_query_and_pseud:
+            one: "%{start_number} - %{end_number} of %{total} Collection found by %{byline}"
+            other: "%{start_number} - %{end_number} of %{total} Collections found by %{byline}"
+          range_with_query_and_pseud_and_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} Collection found by %{byline} in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Collections found by %{byline} in %{fandom_link}"
           range_with_query_and_tag_and_fandom_html:
             one: "%{start_number} - %{end_number} of %{total} Collection found in %{tag_link} in %{fandom_link}"
             other: "%{start_number} - %{end_number} of %{total} Collections found in %{tag_link} in %{fandom_link}"
+          range_with_query_and_tag_html:
+            one: "%{start_number} - %{end_number} of %{total} Collection found in %{tag_link}"
+            other: "%{start_number} - %{end_number} of %{total} Collections found in %{tag_link}"
+          range_with_query_and_user:
+            one: "%{start_number} - %{end_number} of %{total} Collection found by %{username}"
+            other: "%{start_number} - %{end_number} of %{total} Collections found by %{username}"
+          range_with_query_and_user_and_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} Collection found by %{username} in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Collections found by %{username} in %{fandom_link}"
+          range_with_tag_and_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} Collection in %{tag_link} in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Collections in %{tag_link} in %{fandom_link}"
+          range_with_tag_html:
+            one: "%{start_number} - %{end_number} of %{total} Collection in %{tag_link}"
+            other: "%{start_number} - %{end_number} of %{total} Collections in %{tag_link}"
+          range_with_user:
+            one: "%{start_number} - %{end_number} of %{total} Collection by %{username}"
+            other: "%{start_number} - %{end_number} of %{total} Collections by %{username}"
+          range_with_user_and_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} Collection by %{username} in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Collections by %{username} in %{fandom_link}"
           recent:
-            one: "Recent Collection"
-            other: "Recent Collections"
-          recent_with_query:
-            one: "Recent Collection found"
-            other: "Recent Collections found"
-          recent_with_collection_html:
-            one: "Recent Collection in %{collection_link}"
-            other: "Recent Collections in %{collection_link}"
-          recent_with_query_and_collection_html:
-            one: "Recent Collection found in %{collection_link}"
-            other: "Recent Collections found in %{collection_link}"
-          recent_with_pseud:
-            one: "Recent Collection by %{byline}"
-            other: "Recent Collections by %{byline}"
-          recent_with_query_and_pseud:
-            one: "Recent Collection found by %{byline}"
-            other: "Recent Collections found by %{byline}"
-          recent_with_user:
-            one: "Recent Collection by %{username}"
-            other: "Recent Collections by %{username}"
-          recent_with_query_and_user:
-            one: "Recent Collection found by %{username}"
-            other: "Recent Collections found by %{username}"
-          recent_with_language:
-            one: "Recent Collection in %{language}"
-            other: "Recent Collections in %{language}"
-          recent_with_query_and_language:
-            one: "Recent Collection found in %{language}"
-            other: "Recent Collections found in %{language}"
-          recent_with_tag_html:
-            one: "Recent Collection in %{tag_link}"
-            other: "Recent Collections in %{tag_link}"
-          recent_with_query_and_tag_html:
-            one: "Recent Collection found in %{tag_link}"
-            other: "Recent Collections found in %{tag_link}"
-          recent_with_fandom_html:
-            one: "Recent Collection in %{fandom_link}"
-            other: "Recent Collections in %{fandom_link}"
-          recent_with_query_and_fandom_html:
-            one: "Recent Collection found in %{fandom_link}"
-            other: "Recent Collections found in %{fandom_link}"
+            one: Recent Collection
+            other: Recent Collections
           recent_with_collection_and_fandom_html:
-            one: "Recent Collection in %{collection_link} in %{fandom_link}"
-            other: "Recent Collections in %{collection_link} in %{fandom_link}"
-          recent_with_query_and_collection_and_fandom_html:
-            one: "Recent Collection found in %{collection_link} in %{fandom_link}"
-            other: "Recent Collections found in %{collection_link} in %{fandom_link}"
-          recent_with_pseud_and_fandom_html:
-            one: "Recent Collection by %{byline} in %{fandom_link}"
-            other: "Recent Collections by %{byline} in %{fandom_link}"
-          recent_with_query_and_pseud_and_fandom_html:
-            one: "Recent Collection found by %{byline} in %{fandom_link}"
-            other: "Recent Collections found by %{byline} in %{fandom_link}"
-          recent_with_user_and_fandom_html:
-            one: "Recent Collection by %{username} in %{fandom_link}"
-            other: "Recent Collections by %{username} in %{fandom_link}"
-          recent_with_query_and_user_and_fandom_html:
-            one: "Recent Collection found by %{username} in %{fandom_link}"
-            other: "Recent Collections found by %{username} in %{fandom_link}"
+            one: Recent Collection in %{collection_link} in %{fandom_link}
+            other: Recent Collections in %{collection_link} in %{fandom_link}
+          recent_with_collection_html:
+            one: Recent Collection in %{collection_link}
+            other: Recent Collections in %{collection_link}
+          recent_with_fandom_html:
+            one: Recent Collection in %{fandom_link}
+            other: Recent Collections in %{fandom_link}
+          recent_with_language:
+            one: Recent Collection in %{language}
+            other: Recent Collections in %{language}
           recent_with_language_and_fandom_html:
-            one: "Recent Collection in %{language} in %{fandom_link}"
-            other: "Recent Collections in %{language} in %{fandom_link}"
+            one: Recent Collection in %{language} in %{fandom_link}
+            other: Recent Collections in %{language} in %{fandom_link}
+          recent_with_pseud:
+            one: Recent Collection by %{byline}
+            other: Recent Collections by %{byline}
+          recent_with_pseud_and_fandom_html:
+            one: Recent Collection by %{byline} in %{fandom_link}
+            other: Recent Collections by %{byline} in %{fandom_link}
+          recent_with_query:
+            one: Recent Collection found
+            other: Recent Collections found
+          recent_with_query_and_collection_and_fandom_html:
+            one: Recent Collection found in %{collection_link} in %{fandom_link}
+            other: Recent Collections found in %{collection_link} in %{fandom_link}
+          recent_with_query_and_collection_html:
+            one: Recent Collection found in %{collection_link}
+            other: Recent Collections found in %{collection_link}
+          recent_with_query_and_fandom_html:
+            one: Recent Collection found in %{fandom_link}
+            other: Recent Collections found in %{fandom_link}
+          recent_with_query_and_language:
+            one: Recent Collection found in %{language}
+            other: Recent Collections found in %{language}
           recent_with_query_and_language_and_fandom_html:
-            one: "Recent Collection found in %{language} in %{fandom_link}"
-            other: "Recent Collections found in %{language} in %{fandom_link}"
-          recent_with_tag_and_fandom_html:
-            one: "Recent Collection in %{tag_link} in %{fandom_link}"
-            other: "Recent Collections in %{tag_link} in %{fandom_link}"
+            one: Recent Collection found in %{language} in %{fandom_link}
+            other: Recent Collections found in %{language} in %{fandom_link}
+          recent_with_query_and_pseud:
+            one: Recent Collection found by %{byline}
+            other: Recent Collections found by %{byline}
+          recent_with_query_and_pseud_and_fandom_html:
+            one: Recent Collection found by %{byline} in %{fandom_link}
+            other: Recent Collections found by %{byline} in %{fandom_link}
           recent_with_query_and_tag_and_fandom_html:
-            one: "Recent Collection found in %{tag_link} in %{fandom_link}"
-            other: "Recent Collections found in %{tag_link} in %{fandom_link}"
+            one: Recent Collection found in %{tag_link} in %{fandom_link}
+            other: Recent Collections found in %{tag_link} in %{fandom_link}
+          recent_with_query_and_tag_html:
+            one: Recent Collection found in %{tag_link}
+            other: Recent Collections found in %{tag_link}
+          recent_with_query_and_user:
+            one: Recent Collection found by %{username}
+            other: Recent Collections found by %{username}
+          recent_with_query_and_user_and_fandom_html:
+            one: Recent Collection found by %{username} in %{fandom_link}
+            other: Recent Collections found by %{username} in %{fandom_link}
+          recent_with_tag_and_fandom_html:
+            one: Recent Collection in %{tag_link} in %{fandom_link}
+            other: Recent Collections in %{tag_link} in %{fandom_link}
+          recent_with_tag_html:
+            one: Recent Collection in %{tag_link}
+            other: Recent Collections in %{tag_link}
+          recent_with_user:
+            one: Recent Collection by %{username}
+            other: Recent Collections by %{username}
+          recent_with_user_and_fandom_html:
+            one: Recent Collection by %{username} in %{fandom_link}
+            other: Recent Collections by %{username} in %{fandom_link}
         comment:
           count:
             one: "%{count} Comment"
             other: "%{count} Comments"
-          count_with_query:
-            one: "%{count} Comment found"
-            other: "%{count} Comments found"
-          count_with_collection_html:
-            one: "%{count} Comment in %{collection_link}"
-            other: "%{count} Comments in %{collection_link}"
-          count_with_query_and_collection_html:
-            one: "%{count} Comment found in %{collection_link}"
-            other: "%{count} Comments found in %{collection_link}"
-          count_with_pseud:
-            one: "%{count} Comment by %{byline}"
-            other: "%{count} Comments by %{byline}"
-          count_with_query_and_pseud:
-            one: "%{count} Comment found by %{byline}"
-            other: "%{count} Comments found by %{byline}"
-          count_with_user:
-            one: "%{count} Comment by %{username}"
-            other: "%{count} Comments by %{username}"
-          count_with_query_and_user:
-            one: "%{count} Comment found by %{username}"
-            other: "%{count} Comments found by %{username}"
-          count_with_language:
-            one: "%{count} Comment in %{language}"
-            other: "%{count} Comments in %{language}"
-          count_with_query_and_language:
-            one: "%{count} Comment found in %{language}"
-            other: "%{count} Comments found in %{language}"
-          count_with_tag_html:
-            one: "%{count} Comment in %{tag_link}"
-            other: "%{count} Comments in %{tag_link}"
-          count_with_query_and_tag_html:
-            one: "%{count} Comment found in %{tag_link}"
-            other: "%{count} Comments found in %{tag_link}"
-          count_with_fandom_html:
-            one: "%{count} Comment in %{fandom_link}"
-            other: "%{count} Comments in %{fandom_link}"
-          count_with_query_and_fandom_html:
-            one: "%{count} Comment found in %{fandom_link}"
-            other: "%{count} Comments found in %{fandom_link}"
           count_with_collection_and_fandom_html:
             one: "%{count} Comment in %{collection_link} in %{fandom_link}"
             other: "%{count} Comments in %{collection_link} in %{fandom_link}"
-          count_with_query_and_collection_and_fandom_html:
-            one: "%{count} Comment found in %{collection_link} in %{fandom_link}"
-            other: "%{count} Comments found in %{collection_link} in %{fandom_link}"
-          count_with_pseud_and_fandom_html:
-            one: "%{count} Comment by %{byline} in %{fandom_link}"
-            other: "%{count} Comments by %{byline} in %{fandom_link}"
-          count_with_query_and_pseud_and_fandom_html:
-            one: "%{count} Comment found by %{byline} in %{fandom_link}"
-            other: "%{count} Comments found by %{byline} in %{fandom_link}"
-          count_with_user_and_fandom_html:
-            one: "%{count} Comment by %{username} in %{fandom_link}"
-            other: "%{count} Comments by %{username} in %{fandom_link}"
-          count_with_query_and_user_and_fandom_html:
-            one: "%{count} Comment found by %{username} in %{fandom_link}"
-            other: "%{count} Comments found by %{username} in %{fandom_link}"
+          count_with_collection_html:
+            one: "%{count} Comment in %{collection_link}"
+            other: "%{count} Comments in %{collection_link}"
+          count_with_fandom_html:
+            one: "%{count} Comment in %{fandom_link}"
+            other: "%{count} Comments in %{fandom_link}"
+          count_with_language:
+            one: "%{count} Comment in %{language}"
+            other: "%{count} Comments in %{language}"
           count_with_language_and_fandom_html:
             one: "%{count} Comment in %{language} in %{fandom_link}"
             other: "%{count} Comments in %{language} in %{fandom_link}"
+          count_with_pseud:
+            one: "%{count} Comment by %{byline}"
+            other: "%{count} Comments by %{byline}"
+          count_with_pseud_and_fandom_html:
+            one: "%{count} Comment by %{byline} in %{fandom_link}"
+            other: "%{count} Comments by %{byline} in %{fandom_link}"
+          count_with_query:
+            one: "%{count} Comment found"
+            other: "%{count} Comments found"
+          count_with_query_and_collection_and_fandom_html:
+            one: "%{count} Comment found in %{collection_link} in %{fandom_link}"
+            other: "%{count} Comments found in %{collection_link} in %{fandom_link}"
+          count_with_query_and_collection_html:
+            one: "%{count} Comment found in %{collection_link}"
+            other: "%{count} Comments found in %{collection_link}"
+          count_with_query_and_fandom_html:
+            one: "%{count} Comment found in %{fandom_link}"
+            other: "%{count} Comments found in %{fandom_link}"
+          count_with_query_and_language:
+            one: "%{count} Comment found in %{language}"
+            other: "%{count} Comments found in %{language}"
           count_with_query_and_language_and_fandom_html:
             one: "%{count} Comment found in %{language} in %{fandom_link}"
             other: "%{count} Comments found in %{language} in %{fandom_link}"
-          count_with_tag_and_fandom_html:
-            one: "%{count} Comment in %{tag_link} in %{fandom_link}"
-            other: "%{count} Comments in %{tag_link} in %{fandom_link}"
+          count_with_query_and_pseud:
+            one: "%{count} Comment found by %{byline}"
+            other: "%{count} Comments found by %{byline}"
+          count_with_query_and_pseud_and_fandom_html:
+            one: "%{count} Comment found by %{byline} in %{fandom_link}"
+            other: "%{count} Comments found by %{byline} in %{fandom_link}"
           count_with_query_and_tag_and_fandom_html:
             one: "%{count} Comment found in %{tag_link} in %{fandom_link}"
             other: "%{count} Comments found in %{tag_link} in %{fandom_link}"
+          count_with_query_and_tag_html:
+            one: "%{count} Comment found in %{tag_link}"
+            other: "%{count} Comments found in %{tag_link}"
+          count_with_query_and_user:
+            one: "%{count} Comment found by %{username}"
+            other: "%{count} Comments found by %{username}"
+          count_with_query_and_user_and_fandom_html:
+            one: "%{count} Comment found by %{username} in %{fandom_link}"
+            other: "%{count} Comments found by %{username} in %{fandom_link}"
+          count_with_tag_and_fandom_html:
+            one: "%{count} Comment in %{tag_link} in %{fandom_link}"
+            other: "%{count} Comments in %{tag_link} in %{fandom_link}"
+          count_with_tag_html:
+            one: "%{count} Comment in %{tag_link}"
+            other: "%{count} Comments in %{tag_link}"
+          count_with_user:
+            one: "%{count} Comment by %{username}"
+            other: "%{count} Comments by %{username}"
+          count_with_user_and_fandom_html:
+            one: "%{count} Comment by %{username} in %{fandom_link}"
+            other: "%{count} Comments by %{username} in %{fandom_link}"
           range:
             one: "%{start_number} - %{end_number} of %{total} Comment"
             other: "%{start_number} - %{end_number} of %{total} Comments"
-          range_with_query:
-            one: "%{start_number} - %{end_number} of %{total} Comment found"
-            other: "%{start_number} - %{end_number} of %{total} Comments found"
-          range_with_collection_html:
-            one: "%{start_number} - %{end_number} of %{total} Comment in %{collection_link}"
-            other: "%{start_number} - %{end_number} of %{total} Comments in %{collection_link}"
-          range_with_query_and_collection_html:
-            one: "%{start_number} - %{end_number} of %{total} Comment found in %{collection_link}"
-            other: "%{start_number} - %{end_number} of %{total} Comments found in %{collection_link}"
-          range_with_pseud:
-            one: "%{start_number} - %{end_number} of %{total} Comment by %{byline}"
-            other: "%{start_number} - %{end_number} of %{total} Comments by %{byline}"
-          range_with_query_and_pseud:
-            one: "%{start_number} - %{end_number} of %{total} Comment found by %{byline}"
-            other: "%{start_number} - %{end_number} of %{total} Comments found by %{byline}"
-          range_with_user:
-            one: "%{start_number} - %{end_number} of %{total} Comment by %{username}"
-            other: "%{start_number} - %{end_number} of %{total} Comments by %{username}"
-          range_with_query_and_user:
-            one: "%{start_number} - %{end_number} of %{total} Comment found by %{username}"
-            other: "%{start_number} - %{end_number} of %{total} Comments found by %{username}"
-          range_with_language:
-            one: "%{start_number} - %{end_number} of %{total} Comment in %{language}"
-            other: "%{start_number} - %{end_number} of %{total} Comments in %{language}"
-          range_with_query_and_language:
-            one: "%{start_number} - %{end_number} of %{total} Comment found in %{language}"
-            other: "%{start_number} - %{end_number} of %{total} Comments found in %{language}"
-          range_with_tag_html:
-            one: "%{start_number} - %{end_number} of %{total} Comment in %{tag_link}"
-            other: "%{start_number} - %{end_number} of %{total} Comments in %{tag_link}"
-          range_with_query_and_tag_html:
-            one: "%{start_number} - %{end_number} of %{total} Comment found in %{tag_link}"
-            other: "%{start_number} - %{end_number} of %{total} Comments found in %{tag_link}"
-          range_with_fandom_html:
-            one: "%{start_number} - %{end_number} of %{total} Comment in %{fandom_link}"
-            other: "%{start_number} - %{end_number} of %{total} Comments in %{fandom_link}"
-          range_with_query_and_fandom_html:
-            one: "%{start_number} - %{end_number} of %{total} Comment found in %{fandom_link}"
-            other: "%{start_number} - %{end_number} of %{total} Comments found in %{fandom_link}"
           range_with_collection_and_fandom_html:
             one: "%{start_number} - %{end_number} of %{total} Comment in %{collection_link} in %{fandom_link}"
             other: "%{start_number} - %{end_number} of %{total} Comments in %{collection_link} in %{fandom_link}"
-          range_with_query_and_collection_and_fandom_html:
-            one: "%{start_number} - %{end_number} of %{total} Comment found in %{collection_link} in %{fandom_link}"
-            other: "%{start_number} - %{end_number} of %{total} Comments found in %{collection_link} in %{fandom_link}"
-          range_with_pseud_and_fandom_html:
-            one: "%{start_number} - %{end_number} of %{total} Comment by %{byline} in %{fandom_link}"
-            other: "%{start_number} - %{end_number} of %{total} Comments by %{byline} in %{fandom_link}"
-          range_with_query_and_pseud_and_fandom_html:
-            one: "%{start_number} - %{end_number} of %{total} Comment found by %{byline} in %{fandom_link}"
-            other: "%{start_number} - %{end_number} of %{total} Comments found by %{byline} in %{fandom_link}"
-          range_with_user_and_fandom_html:
-            one: "%{start_number} - %{end_number} of %{total} Comment by %{username} in %{fandom_link}"
-            other: "%{start_number} - %{end_number} of %{total} Comments by %{username} in %{fandom_link}"
-          range_with_query_and_user_and_fandom_html:
-            one: "%{start_number} - %{end_number} of %{total} Comment found by %{username} in %{fandom_link}"
-            other: "%{start_number} - %{end_number} of %{total} Comments found by %{username} in %{fandom_link}"
+          range_with_collection_html:
+            one: "%{start_number} - %{end_number} of %{total} Comment in %{collection_link}"
+            other: "%{start_number} - %{end_number} of %{total} Comments in %{collection_link}"
+          range_with_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} Comment in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Comments in %{fandom_link}"
+          range_with_language:
+            one: "%{start_number} - %{end_number} of %{total} Comment in %{language}"
+            other: "%{start_number} - %{end_number} of %{total} Comments in %{language}"
           range_with_language_and_fandom_html:
             one: "%{start_number} - %{end_number} of %{total} Comment in %{language} in %{fandom_link}"
             other: "%{start_number} - %{end_number} of %{total} Comments in %{language} in %{fandom_link}"
+          range_with_pseud:
+            one: "%{start_number} - %{end_number} of %{total} Comment by %{byline}"
+            other: "%{start_number} - %{end_number} of %{total} Comments by %{byline}"
+          range_with_pseud_and_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} Comment by %{byline} in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Comments by %{byline} in %{fandom_link}"
+          range_with_query:
+            one: "%{start_number} - %{end_number} of %{total} Comment found"
+            other: "%{start_number} - %{end_number} of %{total} Comments found"
+          range_with_query_and_collection_and_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} Comment found in %{collection_link} in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Comments found in %{collection_link} in %{fandom_link}"
+          range_with_query_and_collection_html:
+            one: "%{start_number} - %{end_number} of %{total} Comment found in %{collection_link}"
+            other: "%{start_number} - %{end_number} of %{total} Comments found in %{collection_link}"
+          range_with_query_and_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} Comment found in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Comments found in %{fandom_link}"
+          range_with_query_and_language:
+            one: "%{start_number} - %{end_number} of %{total} Comment found in %{language}"
+            other: "%{start_number} - %{end_number} of %{total} Comments found in %{language}"
           range_with_query_and_language_and_fandom_html:
             one: "%{start_number} - %{end_number} of %{total} Comment found in %{language} in %{fandom_link}"
             other: "%{start_number} - %{end_number} of %{total} Comments found in %{language} in %{fandom_link}"
-          range_with_tag_and_fandom_html:
-            one: "%{start_number} - %{end_number} of %{total} Comment in %{tag_link} in %{fandom_link}"
-            other: "%{start_number} - %{end_number} of %{total} Comments in %{tag_link} in %{fandom_link}"
+          range_with_query_and_pseud:
+            one: "%{start_number} - %{end_number} of %{total} Comment found by %{byline}"
+            other: "%{start_number} - %{end_number} of %{total} Comments found by %{byline}"
+          range_with_query_and_pseud_and_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} Comment found by %{byline} in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Comments found by %{byline} in %{fandom_link}"
           range_with_query_and_tag_and_fandom_html:
             one: "%{start_number} - %{end_number} of %{total} Comment found in %{tag_link} in %{fandom_link}"
             other: "%{start_number} - %{end_number} of %{total} Comments found in %{tag_link} in %{fandom_link}"
+          range_with_query_and_tag_html:
+            one: "%{start_number} - %{end_number} of %{total} Comment found in %{tag_link}"
+            other: "%{start_number} - %{end_number} of %{total} Comments found in %{tag_link}"
+          range_with_query_and_user:
+            one: "%{start_number} - %{end_number} of %{total} Comment found by %{username}"
+            other: "%{start_number} - %{end_number} of %{total} Comments found by %{username}"
+          range_with_query_and_user_and_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} Comment found by %{username} in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Comments found by %{username} in %{fandom_link}"
+          range_with_tag_and_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} Comment in %{tag_link} in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Comments in %{tag_link} in %{fandom_link}"
+          range_with_tag_html:
+            one: "%{start_number} - %{end_number} of %{total} Comment in %{tag_link}"
+            other: "%{start_number} - %{end_number} of %{total} Comments in %{tag_link}"
+          range_with_user:
+            one: "%{start_number} - %{end_number} of %{total} Comment by %{username}"
+            other: "%{start_number} - %{end_number} of %{total} Comments by %{username}"
+          range_with_user_and_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} Comment by %{username} in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Comments by %{username} in %{fandom_link}"
           recent:
-            one: "Recent Comment"
-            other: "Recent Comments"
-          recent_with_query:
-            one: "Recent Comment found"
-            other: "Recent Comments found"
-          recent_with_collection_html:
-            one: "Recent Comment in %{collection_link}"
-            other: "Recent Comments in %{collection_link}"
-          recent_with_query_and_collection_html:
-            one: "Recent Comment found in %{collection_link}"
-            other: "Recent Comments found in %{collection_link}"
-          recent_with_pseud:
-            one: "Recent Comment by %{byline}"
-            other: "Recent Comments by %{byline}"
-          recent_with_query_and_pseud:
-            one: "Recent Comment found by %{byline}"
-            other: "Recent Comments found by %{byline}"
-          recent_with_user:
-            one: "Recent Comment by %{username}"
-            other: "Recent Comments by %{username}"
-          recent_with_query_and_user:
-            one: "Recent Comment found by %{username}"
-            other: "Recent Comments found by %{username}"
-          recent_with_language:
-            one: "Recent Comment in %{language}"
-            other: "Recent Comments in %{language}"
-          recent_with_query_and_language:
-            one: "Recent Comment found in %{language}"
-            other: "Recent Comments found in %{language}"
-          recent_with_tag_html:
-            one: "Recent Comment in %{tag_link}"
-            other: "Recent Comments in %{tag_link}"
-          recent_with_query_and_tag_html:
-            one: "Recent Comment found in %{tag_link}"
-            other: "Recent Comments found in %{tag_link}"
-          recent_with_fandom_html:
-            one: "Recent Comment in %{fandom_link}"
-            other: "Recent Comments in %{fandom_link}"
-          recent_with_query_and_fandom_html:
-            one: "Recent Comment found in %{fandom_link}"
-            other: "Recent Comments found in %{fandom_link}"
+            one: Recent Comment
+            other: Recent Comments
           recent_with_collection_and_fandom_html:
-            one: "Recent Comment in %{collection_link} in %{fandom_link}"
-            other: "Recent Comments in %{collection_link} in %{fandom_link}"
-          recent_with_query_and_collection_and_fandom_html:
-            one: "Recent Comment found in %{collection_link} in %{fandom_link}"
-            other: "Recent Comments found in %{collection_link} in %{fandom_link}"
-          recent_with_pseud_and_fandom_html:
-            one: "Recent Comment by %{byline} in %{fandom_link}"
-            other: "Recent Comments by %{byline} in %{fandom_link}"
-          recent_with_query_and_pseud_and_fandom_html:
-            one: "Recent Comment found by %{byline} in %{fandom_link}"
-            other: "Recent Comments found by %{byline} in %{fandom_link}"
-          recent_with_user_and_fandom_html:
-            one: "Recent Comment by %{username} in %{fandom_link}"
-            other: "Recent Comments by %{username} in %{fandom_link}"
-          recent_with_query_and_user_and_fandom_html:
-            one: "Recent Comment found by %{username} in %{fandom_link}"
-            other: "Recent Comments found by %{username} in %{fandom_link}"
+            one: Recent Comment in %{collection_link} in %{fandom_link}
+            other: Recent Comments in %{collection_link} in %{fandom_link}
+          recent_with_collection_html:
+            one: Recent Comment in %{collection_link}
+            other: Recent Comments in %{collection_link}
+          recent_with_fandom_html:
+            one: Recent Comment in %{fandom_link}
+            other: Recent Comments in %{fandom_link}
+          recent_with_language:
+            one: Recent Comment in %{language}
+            other: Recent Comments in %{language}
           recent_with_language_and_fandom_html:
-            one: "Recent Comment in %{language} in %{fandom_link}"
-            other: "Recent Comments in %{language} in %{fandom_link}"
+            one: Recent Comment in %{language} in %{fandom_link}
+            other: Recent Comments in %{language} in %{fandom_link}
+          recent_with_pseud:
+            one: Recent Comment by %{byline}
+            other: Recent Comments by %{byline}
+          recent_with_pseud_and_fandom_html:
+            one: Recent Comment by %{byline} in %{fandom_link}
+            other: Recent Comments by %{byline} in %{fandom_link}
+          recent_with_query:
+            one: Recent Comment found
+            other: Recent Comments found
+          recent_with_query_and_collection_and_fandom_html:
+            one: Recent Comment found in %{collection_link} in %{fandom_link}
+            other: Recent Comments found in %{collection_link} in %{fandom_link}
+          recent_with_query_and_collection_html:
+            one: Recent Comment found in %{collection_link}
+            other: Recent Comments found in %{collection_link}
+          recent_with_query_and_fandom_html:
+            one: Recent Comment found in %{fandom_link}
+            other: Recent Comments found in %{fandom_link}
+          recent_with_query_and_language:
+            one: Recent Comment found in %{language}
+            other: Recent Comments found in %{language}
           recent_with_query_and_language_and_fandom_html:
-            one: "Recent Comment found in %{language} in %{fandom_link}"
-            other: "Recent Comments found in %{language} in %{fandom_link}"
-          recent_with_tag_and_fandom_html:
-            one: "Recent Comment in %{tag_link} in %{fandom_link}"
-            other: "Recent Comments in %{tag_link} in %{fandom_link}"
+            one: Recent Comment found in %{language} in %{fandom_link}
+            other: Recent Comments found in %{language} in %{fandom_link}
+          recent_with_query_and_pseud:
+            one: Recent Comment found by %{byline}
+            other: Recent Comments found by %{byline}
+          recent_with_query_and_pseud_and_fandom_html:
+            one: Recent Comment found by %{byline} in %{fandom_link}
+            other: Recent Comments found by %{byline} in %{fandom_link}
           recent_with_query_and_tag_and_fandom_html:
-            one: "Recent Comment found in %{tag_link} in %{fandom_link}"
-            other: "Recent Comments found in %{tag_link} in %{fandom_link}"
+            one: Recent Comment found in %{tag_link} in %{fandom_link}
+            other: Recent Comments found in %{tag_link} in %{fandom_link}
+          recent_with_query_and_tag_html:
+            one: Recent Comment found in %{tag_link}
+            other: Recent Comments found in %{tag_link}
+          recent_with_query_and_user:
+            one: Recent Comment found by %{username}
+            other: Recent Comments found by %{username}
+          recent_with_query_and_user_and_fandom_html:
+            one: Recent Comment found by %{username} in %{fandom_link}
+            other: Recent Comments found by %{username} in %{fandom_link}
+          recent_with_tag_and_fandom_html:
+            one: Recent Comment in %{tag_link} in %{fandom_link}
+            other: Recent Comments in %{tag_link} in %{fandom_link}
+          recent_with_tag_html:
+            one: Recent Comment in %{tag_link}
+            other: Recent Comments in %{tag_link}
+          recent_with_user:
+            one: Recent Comment by %{username}
+            other: Recent Comments by %{username}
+          recent_with_user_and_fandom_html:
+            one: Recent Comment by %{username} in %{fandom_link}
+            other: Recent Comments by %{username} in %{fandom_link}
         series:
           count:
             one: "%{count} Series"
             other: "%{count} Series"
-          count_with_query:
-            one: "%{count} Series found"
-            other: "%{count} Series found"
-          count_with_collection_html:
-            one: "%{count} Series in %{collection_link}"
-            other: "%{count} Series in %{collection_link}"
-          count_with_query_and_collection_html:
-            one: "%{count} Series found in %{collection_link}"
-            other: "%{count} Series found in %{collection_link}"
-          count_with_pseud:
-            one: "%{count} Series by %{byline}"
-            other: "%{count} Series by %{byline}"
-          count_with_query_and_pseud:
-            one: "%{count} Series found by %{byline}"
-            other: "%{count} Series found by %{byline}"
-          count_with_user:
-            one: "%{count} Series by %{username}"
-            other: "%{count} Series by %{username}"
-          count_with_query_and_user:
-            one: "%{count} Series found by %{username}"
-            other: "%{count} Series found by %{username}"
-          count_with_language:
-            one: "%{count} Series in %{language}"
-            other: "%{count} Series in %{language}"
-          count_with_query_and_language:
-            one: "%{count} Series found in %{language}"
-            other: "%{count} Series found in %{language}"
-          count_with_tag_html:
-            one: "%{count} Series in %{tag_link}"
-            other: "%{count} Series in %{tag_link}"
-          count_with_query_and_tag_html:
-            one: "%{count} Series found in %{tag_link}"
-            other: "%{count} Series found in %{tag_link}"
-          count_with_fandom_html:
-            one: "%{count} Series in %{fandom_link}"
-            other: "%{count} Series in %{fandom_link}"
-          count_with_query_and_fandom_html:
-            one: "%{count} Series found in %{fandom_link}"
-            other: "%{count} Series found in %{fandom_link}"
           count_with_collection_and_fandom_html:
             one: "%{count} Series in %{collection_link} in %{fandom_link}"
             other: "%{count} Series in %{collection_link} in %{fandom_link}"
-          count_with_query_and_collection_and_fandom_html:
-            one: "%{count} Series found in %{collection_link} in %{fandom_link}"
-            other: "%{count} Series found in %{collection_link} in %{fandom_link}"
-          count_with_pseud_and_fandom_html:
-            one: "%{count} Series by %{byline} in %{fandom_link}"
-            other: "%{count} Series by %{byline} in %{fandom_link}"
-          count_with_query_and_pseud_and_fandom_html:
-            one: "%{count} Series found by %{byline} in %{fandom_link}"
-            other: "%{count} Series found by %{byline} in %{fandom_link}"
-          count_with_user_and_fandom_html:
-            one: "%{count} Series by %{username} in %{fandom_link}"
-            other: "%{count} Series by %{username} in %{fandom_link}"
-          count_with_query_and_user_and_fandom_html:
-            one: "%{count} Series found by %{username} in %{fandom_link}"
-            other: "%{count} Series found by %{username} in %{fandom_link}"
+          count_with_collection_html:
+            one: "%{count} Series in %{collection_link}"
+            other: "%{count} Series in %{collection_link}"
+          count_with_fandom_html:
+            one: "%{count} Series in %{fandom_link}"
+            other: "%{count} Series in %{fandom_link}"
+          count_with_language:
+            one: "%{count} Series in %{language}"
+            other: "%{count} Series in %{language}"
           count_with_language_and_fandom_html:
             one: "%{count} Series in %{language} in %{fandom_link}"
             other: "%{count} Series in %{language} in %{fandom_link}"
+          count_with_pseud:
+            one: "%{count} Series by %{byline}"
+            other: "%{count} Series by %{byline}"
+          count_with_pseud_and_fandom_html:
+            one: "%{count} Series by %{byline} in %{fandom_link}"
+            other: "%{count} Series by %{byline} in %{fandom_link}"
+          count_with_query:
+            one: "%{count} Series found"
+            other: "%{count} Series found"
+          count_with_query_and_collection_and_fandom_html:
+            one: "%{count} Series found in %{collection_link} in %{fandom_link}"
+            other: "%{count} Series found in %{collection_link} in %{fandom_link}"
+          count_with_query_and_collection_html:
+            one: "%{count} Series found in %{collection_link}"
+            other: "%{count} Series found in %{collection_link}"
+          count_with_query_and_fandom_html:
+            one: "%{count} Series found in %{fandom_link}"
+            other: "%{count} Series found in %{fandom_link}"
+          count_with_query_and_language:
+            one: "%{count} Series found in %{language}"
+            other: "%{count} Series found in %{language}"
           count_with_query_and_language_and_fandom_html:
             one: "%{count} Series found in %{language} in %{fandom_link}"
             other: "%{count} Series found in %{language} in %{fandom_link}"
-          count_with_tag_and_fandom_html:
-            one: "%{count} Series in %{tag_link} in %{fandom_link}"
-            other: "%{count} Series in %{tag_link} in %{fandom_link}"
+          count_with_query_and_pseud:
+            one: "%{count} Series found by %{byline}"
+            other: "%{count} Series found by %{byline}"
+          count_with_query_and_pseud_and_fandom_html:
+            one: "%{count} Series found by %{byline} in %{fandom_link}"
+            other: "%{count} Series found by %{byline} in %{fandom_link}"
           count_with_query_and_tag_and_fandom_html:
             one: "%{count} Series found in %{tag_link} in %{fandom_link}"
             other: "%{count} Series found in %{tag_link} in %{fandom_link}"
+          count_with_query_and_tag_html:
+            one: "%{count} Series found in %{tag_link}"
+            other: "%{count} Series found in %{tag_link}"
+          count_with_query_and_user:
+            one: "%{count} Series found by %{username}"
+            other: "%{count} Series found by %{username}"
+          count_with_query_and_user_and_fandom_html:
+            one: "%{count} Series found by %{username} in %{fandom_link}"
+            other: "%{count} Series found by %{username} in %{fandom_link}"
+          count_with_tag_and_fandom_html:
+            one: "%{count} Series in %{tag_link} in %{fandom_link}"
+            other: "%{count} Series in %{tag_link} in %{fandom_link}"
+          count_with_tag_html:
+            one: "%{count} Series in %{tag_link}"
+            other: "%{count} Series in %{tag_link}"
+          count_with_user:
+            one: "%{count} Series by %{username}"
+            other: "%{count} Series by %{username}"
+          count_with_user_and_fandom_html:
+            one: "%{count} Series by %{username} in %{fandom_link}"
+            other: "%{count} Series by %{username} in %{fandom_link}"
           range:
             one: "%{start_number} - %{end_number} of %{total} Series"
             other: "%{start_number} - %{end_number} of %{total} Series"
-          range_with_query:
-            one: "%{start_number} - %{end_number} of %{total} Series found"
-            other: "%{start_number} - %{end_number} of %{total} Series found"
-          range_with_collection_html:
-            one: "%{start_number} - %{end_number} of %{total} Series in %{collection_link}"
-            other: "%{start_number} - %{end_number} of %{total} Series in %{collection_link}"
-          range_with_query_and_collection_html:
-            one: "%{start_number} - %{end_number} of %{total} Series found in %{collection_link}"
-            other: "%{start_number} - %{end_number} of %{total} Series found in %{collection_link}"
-          range_with_pseud:
-            one: "%{start_number} - %{end_number} of %{total} Series by %{byline}"
-            other: "%{start_number} - %{end_number} of %{total} Series by %{byline}"
-          range_with_query_and_pseud:
-            one: "%{start_number} - %{end_number} of %{total} Series found by %{byline}"
-            other: "%{start_number} - %{end_number} of %{total} Series found by %{byline}"
-          range_with_user:
-            one: "%{start_number} - %{end_number} of %{total} Series by %{username}"
-            other: "%{start_number} - %{end_number} of %{total} Series by %{username}"
-          range_with_query_and_user:
-            one: "%{start_number} - %{end_number} of %{total} Series found by %{username}"
-            other: "%{start_number} - %{end_number} of %{total} Series found by %{username}"
-          range_with_language:
-            one: "%{start_number} - %{end_number} of %{total} Series in %{language}"
-            other: "%{start_number} - %{end_number} of %{total} Series in %{language}"
-          range_with_query_and_language:
-            one: "%{start_number} - %{end_number} of %{total} Series found in %{language}"
-            other: "%{start_number} - %{end_number} of %{total} Series found in %{language}"
-          range_with_tag_html:
-            one: "%{start_number} - %{end_number} of %{total} Series in %{tag_link}"
-            other: "%{start_number} - %{end_number} of %{total} Series in %{tag_link}"
-          range_with_query_and_tag_html:
-            one: "%{start_number} - %{end_number} of %{total} Series found in %{tag_link}"
-            other: "%{start_number} - %{end_number} of %{total} Series found in %{tag_link}"
-          range_with_fandom_html:
-            one: "%{start_number} - %{end_number} of %{total} Series in %{fandom_link}"
-            other: "%{start_number} - %{end_number} of %{total} Series in %{fandom_link}"
-          range_with_query_and_fandom_html:
-            one: "%{start_number} - %{end_number} of %{total} Series found in %{fandom_link}"
-            other: "%{start_number} - %{end_number} of %{total} Series found in %{fandom_link}"
           range_with_collection_and_fandom_html:
             one: "%{start_number} - %{end_number} of %{total} Series in %{collection_link} in %{fandom_link}"
             other: "%{start_number} - %{end_number} of %{total} Series in %{collection_link} in %{fandom_link}"
-          range_with_query_and_collection_and_fandom_html:
-            one: "%{start_number} - %{end_number} of %{total} Series found in %{collection_link} in %{fandom_link}"
-            other: "%{start_number} - %{end_number} of %{total} Series found in %{collection_link} in %{fandom_link}"
-          range_with_pseud_and_fandom_html:
-            one: "%{start_number} - %{end_number} of %{total} Series by %{byline} in %{fandom_link}"
-            other: "%{start_number} - %{end_number} of %{total} Series by %{byline} in %{fandom_link}"
-          range_with_query_and_pseud_and_fandom_html:
-            one: "%{start_number} - %{end_number} of %{total} Series found by %{byline} in %{fandom_link}"
-            other: "%{start_number} - %{end_number} of %{total} Series found by %{byline} in %{fandom_link}"
-          range_with_user_and_fandom_html:
-            one: "%{start_number} - %{end_number} of %{total} Series by %{username} in %{fandom_link}"
-            other: "%{start_number} - %{end_number} of %{total} Series by %{username} in %{fandom_link}"
-          range_with_query_and_user_and_fandom_html:
-            one: "%{start_number} - %{end_number} of %{total} Series found by %{username} in %{fandom_link}"
-            other: "%{start_number} - %{end_number} of %{total} Series found by %{username} in %{fandom_link}"
+          range_with_collection_html:
+            one: "%{start_number} - %{end_number} of %{total} Series in %{collection_link}"
+            other: "%{start_number} - %{end_number} of %{total} Series in %{collection_link}"
+          range_with_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} Series in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Series in %{fandom_link}"
+          range_with_language:
+            one: "%{start_number} - %{end_number} of %{total} Series in %{language}"
+            other: "%{start_number} - %{end_number} of %{total} Series in %{language}"
           range_with_language_and_fandom_html:
             one: "%{start_number} - %{end_number} of %{total} Series in %{language} in %{fandom_link}"
             other: "%{start_number} - %{end_number} of %{total} Series in %{language} in %{fandom_link}"
+          range_with_pseud:
+            one: "%{start_number} - %{end_number} of %{total} Series by %{byline}"
+            other: "%{start_number} - %{end_number} of %{total} Series by %{byline}"
+          range_with_pseud_and_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} Series by %{byline} in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Series by %{byline} in %{fandom_link}"
+          range_with_query:
+            one: "%{start_number} - %{end_number} of %{total} Series found"
+            other: "%{start_number} - %{end_number} of %{total} Series found"
+          range_with_query_and_collection_and_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} Series found in %{collection_link} in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Series found in %{collection_link} in %{fandom_link}"
+          range_with_query_and_collection_html:
+            one: "%{start_number} - %{end_number} of %{total} Series found in %{collection_link}"
+            other: "%{start_number} - %{end_number} of %{total} Series found in %{collection_link}"
+          range_with_query_and_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} Series found in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Series found in %{fandom_link}"
+          range_with_query_and_language:
+            one: "%{start_number} - %{end_number} of %{total} Series found in %{language}"
+            other: "%{start_number} - %{end_number} of %{total} Series found in %{language}"
           range_with_query_and_language_and_fandom_html:
             one: "%{start_number} - %{end_number} of %{total} Series found in %{language} in %{fandom_link}"
             other: "%{start_number} - %{end_number} of %{total} Series found in %{language} in %{fandom_link}"
-          range_with_tag_and_fandom_html:
-            one: "%{start_number} - %{end_number} of %{total} Series in %{tag_link} in %{fandom_link}"
-            other: "%{start_number} - %{end_number} of %{total} Series in %{tag_link} in %{fandom_link}"
+          range_with_query_and_pseud:
+            one: "%{start_number} - %{end_number} of %{total} Series found by %{byline}"
+            other: "%{start_number} - %{end_number} of %{total} Series found by %{byline}"
+          range_with_query_and_pseud_and_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} Series found by %{byline} in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Series found by %{byline} in %{fandom_link}"
           range_with_query_and_tag_and_fandom_html:
             one: "%{start_number} - %{end_number} of %{total} Series found in %{tag_link} in %{fandom_link}"
             other: "%{start_number} - %{end_number} of %{total} Series found in %{tag_link} in %{fandom_link}"
+          range_with_query_and_tag_html:
+            one: "%{start_number} - %{end_number} of %{total} Series found in %{tag_link}"
+            other: "%{start_number} - %{end_number} of %{total} Series found in %{tag_link}"
+          range_with_query_and_user:
+            one: "%{start_number} - %{end_number} of %{total} Series found by %{username}"
+            other: "%{start_number} - %{end_number} of %{total} Series found by %{username}"
+          range_with_query_and_user_and_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} Series found by %{username} in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Series found by %{username} in %{fandom_link}"
+          range_with_tag_and_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} Series in %{tag_link} in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Series in %{tag_link} in %{fandom_link}"
+          range_with_tag_html:
+            one: "%{start_number} - %{end_number} of %{total} Series in %{tag_link}"
+            other: "%{start_number} - %{end_number} of %{total} Series in %{tag_link}"
+          range_with_user:
+            one: "%{start_number} - %{end_number} of %{total} Series by %{username}"
+            other: "%{start_number} - %{end_number} of %{total} Series by %{username}"
+          range_with_user_and_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} Series by %{username} in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Series by %{username} in %{fandom_link}"
           recent:
-            one: "Recent Series"
-            other: "Recent Series"
-          recent_with_query:
-            one: "Recent Series found"
-            other: "Recent Series found"
-          recent_with_collection_html:
-            one: "Recent Series in %{collection_link}"
-            other: "Recent Series in %{collection_link}"
-          recent_with_query_and_collection_html:
-            one: "Recent Series found in %{collection_link}"
-            other: "Recent Series found in %{collection_link}"
-          recent_with_pseud:
-            one: "Recent Series by %{byline}"
-            other: "Recent Series by %{byline}"
-          recent_with_query_and_pseud:
-            one: "Recent Series found by %{byline}"
-            other: "Recent Series found by %{byline}"
-          recent_with_user:
-            one: "Recent Series by %{username}"
-            other: "Recent Series by %{username}"
-          recent_with_query_and_user:
-            one: "Recent Series found by %{username}"
-            other: "Recent Series found by %{username}"
-          recent_with_language:
-            one: "Recent Series in %{language}"
-            other: "Recent Series in %{language}"
-          recent_with_query_and_language:
-            one: "Recent Series found in %{language}"
-            other: "Recent Series found in %{language}"
-          recent_with_tag_html:
-            one: "Recent Series in %{tag_link}"
-            other: "Recent Series in %{tag_link}"
-          recent_with_query_and_tag_html:
-            one: "Recent Series found in %{tag_link}"
-            other: "Recent Series found in %{tag_link}"
-          recent_with_fandom_html:
-            one: "Recent Series in %{fandom_link}"
-            other: "Recent Series in %{fandom_link}"
-          recent_with_query_and_fandom_html:
-            one: "Recent Series found in %{fandom_link}"
-            other: "Recent Series found in %{fandom_link}"
+            one: Recent Series
+            other: Recent Series
           recent_with_collection_and_fandom_html:
-            one: "Recent Series in %{collection_link} in %{fandom_link}"
-            other: "Recent Series in %{collection_link} in %{fandom_link}"
-          recent_with_query_and_collection_and_fandom_html:
-            one: "Recent Series found in %{collection_link} in %{fandom_link}"
-            other: "Recent Series found in %{collection_link} in %{fandom_link}"
-          recent_with_pseud_and_fandom_html:
-            one: "Recent Series by %{byline} in %{fandom_link}"
-            other: "Recent Series by %{byline} in %{fandom_link}"
-          recent_with_query_and_pseud_and_fandom_html:
-            one: "Recent Series found by %{byline} in %{fandom_link}"
-            other: "Recent Series found by %{byline} in %{fandom_link}"
-          recent_with_user_and_fandom_html:
-            one: "Recent Series by %{username} in %{fandom_link}"
-            other: "Recent Series by %{username} in %{fandom_link}"
-          recent_with_query_and_user_and_fandom_html:
-            one: "Recent Series found by %{username} in %{fandom_link}"
-            other: "Recent Series found by %{username} in %{fandom_link}"
+            one: Recent Series in %{collection_link} in %{fandom_link}
+            other: Recent Series in %{collection_link} in %{fandom_link}
+          recent_with_collection_html:
+            one: Recent Series in %{collection_link}
+            other: Recent Series in %{collection_link}
+          recent_with_fandom_html:
+            one: Recent Series in %{fandom_link}
+            other: Recent Series in %{fandom_link}
+          recent_with_language:
+            one: Recent Series in %{language}
+            other: Recent Series in %{language}
           recent_with_language_and_fandom_html:
-            one: "Recent Series in %{language} in %{fandom_link}"
-            other: "Recent Series in %{language} in %{fandom_link}"
+            one: Recent Series in %{language} in %{fandom_link}
+            other: Recent Series in %{language} in %{fandom_link}
+          recent_with_pseud:
+            one: Recent Series by %{byline}
+            other: Recent Series by %{byline}
+          recent_with_pseud_and_fandom_html:
+            one: Recent Series by %{byline} in %{fandom_link}
+            other: Recent Series by %{byline} in %{fandom_link}
+          recent_with_query:
+            one: Recent Series found
+            other: Recent Series found
+          recent_with_query_and_collection_and_fandom_html:
+            one: Recent Series found in %{collection_link} in %{fandom_link}
+            other: Recent Series found in %{collection_link} in %{fandom_link}
+          recent_with_query_and_collection_html:
+            one: Recent Series found in %{collection_link}
+            other: Recent Series found in %{collection_link}
+          recent_with_query_and_fandom_html:
+            one: Recent Series found in %{fandom_link}
+            other: Recent Series found in %{fandom_link}
+          recent_with_query_and_language:
+            one: Recent Series found in %{language}
+            other: Recent Series found in %{language}
           recent_with_query_and_language_and_fandom_html:
-            one: "Recent Series found in %{language} in %{fandom_link}"
-            other: "Recent Series found in %{language} in %{fandom_link}"
-          recent_with_tag_and_fandom_html:
-            one: "Recent Series in %{tag_link} in %{fandom_link}"
-            other: "Recent Series in %{tag_link} in %{fandom_link}"
+            one: Recent Series found in %{language} in %{fandom_link}
+            other: Recent Series found in %{language} in %{fandom_link}
+          recent_with_query_and_pseud:
+            one: Recent Series found by %{byline}
+            other: Recent Series found by %{byline}
+          recent_with_query_and_pseud_and_fandom_html:
+            one: Recent Series found by %{byline} in %{fandom_link}
+            other: Recent Series found by %{byline} in %{fandom_link}
           recent_with_query_and_tag_and_fandom_html:
-            one: "Recent Series found in %{tag_link} in %{fandom_link}"
-            other: "Recent Series found in %{tag_link} in %{fandom_link}"
+            one: Recent Series found in %{tag_link} in %{fandom_link}
+            other: Recent Series found in %{tag_link} in %{fandom_link}
+          recent_with_query_and_tag_html:
+            one: Recent Series found in %{tag_link}
+            other: Recent Series found in %{tag_link}
+          recent_with_query_and_user:
+            one: Recent Series found by %{username}
+            other: Recent Series found by %{username}
+          recent_with_query_and_user_and_fandom_html:
+            one: Recent Series found by %{username} in %{fandom_link}
+            other: Recent Series found by %{username} in %{fandom_link}
+          recent_with_tag_and_fandom_html:
+            one: Recent Series in %{tag_link} in %{fandom_link}
+            other: Recent Series in %{tag_link} in %{fandom_link}
+          recent_with_tag_html:
+            one: Recent Series in %{tag_link}
+            other: Recent Series in %{tag_link}
+          recent_with_user:
+            one: Recent Series by %{username}
+            other: Recent Series by %{username}
+          recent_with_user_and_fandom_html:
+            one: Recent Series by %{username} in %{fandom_link}
+            other: Recent Series by %{username} in %{fandom_link}
         tag_set:
           count:
             one: "%{count} Tag Set"
             other: "%{count} Tag Sets"
-          count_with_query:
-            one: "%{count} Tag Set found"
-            other: "%{count} Tag Sets found"
-          count_with_collection_html:
-            one: "%{count} Tag Set in %{collection_link}"
-            other: "%{count} Tag Sets in %{collection_link}"
-          count_with_query_and_collection_html:
-            one: "%{count} Tag Set found in %{collection_link}"
-            other: "%{count} Tag Sets found in %{collection_link}"
-          count_with_pseud:
-            one: "%{count} Tag Set by %{byline}"
-            other: "%{count} Tag Sets by %{byline}"
-          count_with_query_and_pseud:
-            one: "%{count} Tag Set found by %{byline}"
-            other: "%{count} Tag Sets found by %{byline}"
-          count_with_user:
-            one: "%{count} Tag Set by %{username}"
-            other: "%{count} Tag Sets by %{username}"
-          count_with_query_and_user:
-            one: "%{count} Tag Set found by %{username}"
-            other: "%{count} Tag Sets found by %{username}"
-          count_with_language:
-            one: "%{count} Tag Set in %{language}"
-            other: "%{count} Tag Sets in %{language}"
-          count_with_query_and_language:
-            one: "%{count} Tag Set found in %{language}"
-            other: "%{count} Tag Sets found in %{language}"
-          count_with_tag_html:
-            one: "%{count} Tag Set in %{tag_link}"
-            other: "%{count} Tag Sets in %{tag_link}"
-          count_with_query_and_tag_html:
-            one: "%{count} Tag Set found in %{tag_link}"
-            other: "%{count} Tag Sets found in %{tag_link}"
-          count_with_fandom_html:
-            one: "%{count} Tag Set in %{fandom_link}"
-            other: "%{count} Tag Sets in %{fandom_link}"
-          count_with_query_and_fandom_html:
-            one: "%{count} Tag Set found in %{fandom_link}"
-            other: "%{count} Tag Sets found in %{fandom_link}"
           count_with_collection_and_fandom_html:
             one: "%{count} Tag Set in %{collection_link} in %{fandom_link}"
             other: "%{count} Tag Sets in %{collection_link} in %{fandom_link}"
-          count_with_query_and_collection_and_fandom_html:
-            one: "%{count} Tag Set found in %{collection_link} in %{fandom_link}"
-            other: "%{count} Tag Sets found in %{collection_link} in %{fandom_link}"
-          count_with_pseud_and_fandom_html:
-            one: "%{count} Tag Set by %{byline} in %{fandom_link}"
-            other: "%{count} Tag Sets by %{byline} in %{fandom_link}"
-          count_with_query_and_pseud_and_fandom_html:
-            one: "%{count} Tag Set found by %{byline} in %{fandom_link}"
-            other: "%{count} Tag Sets found by %{byline} in %{fandom_link}"
-          count_with_user_and_fandom_html:
-            one: "%{count} Tag Set by %{username} in %{fandom_link}"
-            other: "%{count} Tag Sets by %{username} in %{fandom_link}"
-          count_with_query_and_user_and_fandom_html:
-            one: "%{count} Tag Set found by %{username} in %{fandom_link}"
-            other: "%{count} Tag Sets found by %{username} in %{fandom_link}"
+          count_with_collection_html:
+            one: "%{count} Tag Set in %{collection_link}"
+            other: "%{count} Tag Sets in %{collection_link}"
+          count_with_fandom_html:
+            one: "%{count} Tag Set in %{fandom_link}"
+            other: "%{count} Tag Sets in %{fandom_link}"
+          count_with_language:
+            one: "%{count} Tag Set in %{language}"
+            other: "%{count} Tag Sets in %{language}"
           count_with_language_and_fandom_html:
             one: "%{count} Tag Set in %{language} in %{fandom_link}"
             other: "%{count} Tag Sets in %{language} in %{fandom_link}"
+          count_with_pseud:
+            one: "%{count} Tag Set by %{byline}"
+            other: "%{count} Tag Sets by %{byline}"
+          count_with_pseud_and_fandom_html:
+            one: "%{count} Tag Set by %{byline} in %{fandom_link}"
+            other: "%{count} Tag Sets by %{byline} in %{fandom_link}"
+          count_with_query:
+            one: "%{count} Tag Set found"
+            other: "%{count} Tag Sets found"
+          count_with_query_and_collection_and_fandom_html:
+            one: "%{count} Tag Set found in %{collection_link} in %{fandom_link}"
+            other: "%{count} Tag Sets found in %{collection_link} in %{fandom_link}"
+          count_with_query_and_collection_html:
+            one: "%{count} Tag Set found in %{collection_link}"
+            other: "%{count} Tag Sets found in %{collection_link}"
+          count_with_query_and_fandom_html:
+            one: "%{count} Tag Set found in %{fandom_link}"
+            other: "%{count} Tag Sets found in %{fandom_link}"
+          count_with_query_and_language:
+            one: "%{count} Tag Set found in %{language}"
+            other: "%{count} Tag Sets found in %{language}"
           count_with_query_and_language_and_fandom_html:
             one: "%{count} Tag Set found in %{language} in %{fandom_link}"
             other: "%{count} Tag Sets found in %{language} in %{fandom_link}"
-          count_with_tag_and_fandom_html:
-            one: "%{count} Tag Set in %{tag_link} in %{fandom_link}"
-            other: "%{count} Tag Sets in %{tag_link} in %{fandom_link}"
+          count_with_query_and_pseud:
+            one: "%{count} Tag Set found by %{byline}"
+            other: "%{count} Tag Sets found by %{byline}"
+          count_with_query_and_pseud_and_fandom_html:
+            one: "%{count} Tag Set found by %{byline} in %{fandom_link}"
+            other: "%{count} Tag Sets found by %{byline} in %{fandom_link}"
           count_with_query_and_tag_and_fandom_html:
             one: "%{count} Tag Set found in %{tag_link} in %{fandom_link}"
             other: "%{count} Tag Sets found in %{tag_link} in %{fandom_link}"
+          count_with_query_and_tag_html:
+            one: "%{count} Tag Set found in %{tag_link}"
+            other: "%{count} Tag Sets found in %{tag_link}"
+          count_with_query_and_user:
+            one: "%{count} Tag Set found by %{username}"
+            other: "%{count} Tag Sets found by %{username}"
+          count_with_query_and_user_and_fandom_html:
+            one: "%{count} Tag Set found by %{username} in %{fandom_link}"
+            other: "%{count} Tag Sets found by %{username} in %{fandom_link}"
+          count_with_tag_and_fandom_html:
+            one: "%{count} Tag Set in %{tag_link} in %{fandom_link}"
+            other: "%{count} Tag Sets in %{tag_link} in %{fandom_link}"
+          count_with_tag_html:
+            one: "%{count} Tag Set in %{tag_link}"
+            other: "%{count} Tag Sets in %{tag_link}"
+          count_with_user:
+            one: "%{count} Tag Set by %{username}"
+            other: "%{count} Tag Sets by %{username}"
+          count_with_user_and_fandom_html:
+            one: "%{count} Tag Set by %{username} in %{fandom_link}"
+            other: "%{count} Tag Sets by %{username} in %{fandom_link}"
           range:
             one: "%{start_number} - %{end_number} of %{total} Tag Set"
             other: "%{start_number} - %{end_number} of %{total} Tag Sets"
-          range_with_query:
-            one: "%{start_number} - %{end_number} of %{total} Tag Set found"
-            other: "%{start_number} - %{end_number} of %{total} Tag Sets found"
-          range_with_collection_html:
-            one: "%{start_number} - %{end_number} of %{total} Tag Set in %{collection_link}"
-            other: "%{start_number} - %{end_number} of %{total} Tag Sets in %{collection_link}"
-          range_with_query_and_collection_html:
-            one: "%{start_number} - %{end_number} of %{total} Tag Set found in %{collection_link}"
-            other: "%{start_number} - %{end_number} of %{total} Tag Sets found in %{collection_link}"
-          range_with_pseud:
-            one: "%{start_number} - %{end_number} of %{total} Tag Set by %{byline}"
-            other: "%{start_number} - %{end_number} of %{total} Tag Sets by %{byline}"
-          range_with_query_and_pseud:
-            one: "%{start_number} - %{end_number} of %{total} Tag Set found by %{byline}"
-            other: "%{start_number} - %{end_number} of %{total} Tag Sets found by %{byline}"
-          range_with_user:
-            one: "%{start_number} - %{end_number} of %{total} Tag Set by %{username}"
-            other: "%{start_number} - %{end_number} of %{total} Tag Sets by %{username}"
-          range_with_query_and_user:
-            one: "%{start_number} - %{end_number} of %{total} Tag Set found by %{username}"
-            other: "%{start_number} - %{end_number} of %{total} Tag Sets found by %{username}"
-          range_with_language:
-            one: "%{start_number} - %{end_number} of %{total} Tag Set in %{language}"
-            other: "%{start_number} - %{end_number} of %{total} Tag Sets in %{language}"
-          range_with_query_and_language:
-            one: "%{start_number} - %{end_number} of %{total} Tag Set found in %{language}"
-            other: "%{start_number} - %{end_number} of %{total} Tag Sets found in %{language}"
-          range_with_tag_html:
-            one: "%{start_number} - %{end_number} of %{total} Tag Set in %{tag_link}"
-            other: "%{start_number} - %{end_number} of %{total} Tag Sets in %{tag_link}"
-          range_with_query_and_tag_html:
-            one: "%{start_number} - %{end_number} of %{total} Tag Set found in %{tag_link}"
-            other: "%{start_number} - %{end_number} of %{total} Tag Sets found in %{tag_link}"
-          range_with_fandom_html:
-            one: "%{start_number} - %{end_number} of %{total} Tag Set in %{fandom_link}"
-            other: "%{start_number} - %{end_number} of %{total} Tag Sets in %{fandom_link}"
-          range_with_query_and_fandom_html:
-            one: "%{start_number} - %{end_number} of %{total} Tag Set found in %{fandom_link}"
-            other: "%{start_number} - %{end_number} of %{total} Tag Sets found in %{fandom_link}"
           range_with_collection_and_fandom_html:
             one: "%{start_number} - %{end_number} of %{total} Tag Set in %{collection_link} in %{fandom_link}"
             other: "%{start_number} - %{end_number} of %{total} Tag Sets in %{collection_link} in %{fandom_link}"
-          range_with_query_and_collection_and_fandom_html:
-            one: "%{start_number} - %{end_number} of %{total} Tag Set found in %{collection_link} in %{fandom_link}"
-            other: "%{start_number} - %{end_number} of %{total} Tag Sets found in %{collection_link} in %{fandom_link}"
-          range_with_pseud_and_fandom_html:
-            one: "%{start_number} - %{end_number} of %{total} Tag Set by %{byline} in %{fandom_link}"
-            other: "%{start_number} - %{end_number} of %{total} Tag Sets by %{byline} in %{fandom_link}"
-          range_with_query_and_pseud_and_fandom_html:
-            one: "%{start_number} - %{end_number} of %{total} Tag Set found by %{byline} in %{fandom_link}"
-            other: "%{start_number} - %{end_number} of %{total} Tag Sets found by %{byline} in %{fandom_link}"
-          range_with_user_and_fandom_html:
-            one: "%{start_number} - %{end_number} of %{total} Tag Set by %{username} in %{fandom_link}"
-            other: "%{start_number} - %{end_number} of %{total} Tag Sets by %{username} in %{fandom_link}"
-          range_with_query_and_user_and_fandom_html:
-            one: "%{start_number} - %{end_number} of %{total} Tag Set found by %{username} in %{fandom_link}"
-            other: "%{start_number} - %{end_number} of %{total} Tag Sets found by %{username} in %{fandom_link}"
+          range_with_collection_html:
+            one: "%{start_number} - %{end_number} of %{total} Tag Set in %{collection_link}"
+            other: "%{start_number} - %{end_number} of %{total} Tag Sets in %{collection_link}"
+          range_with_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} Tag Set in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Tag Sets in %{fandom_link}"
+          range_with_language:
+            one: "%{start_number} - %{end_number} of %{total} Tag Set in %{language}"
+            other: "%{start_number} - %{end_number} of %{total} Tag Sets in %{language}"
           range_with_language_and_fandom_html:
             one: "%{start_number} - %{end_number} of %{total} Tag Set in %{language} in %{fandom_link}"
             other: "%{start_number} - %{end_number} of %{total} Tag Sets in %{language} in %{fandom_link}"
+          range_with_pseud:
+            one: "%{start_number} - %{end_number} of %{total} Tag Set by %{byline}"
+            other: "%{start_number} - %{end_number} of %{total} Tag Sets by %{byline}"
+          range_with_pseud_and_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} Tag Set by %{byline} in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Tag Sets by %{byline} in %{fandom_link}"
+          range_with_query:
+            one: "%{start_number} - %{end_number} of %{total} Tag Set found"
+            other: "%{start_number} - %{end_number} of %{total} Tag Sets found"
+          range_with_query_and_collection_and_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} Tag Set found in %{collection_link} in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Tag Sets found in %{collection_link} in %{fandom_link}"
+          range_with_query_and_collection_html:
+            one: "%{start_number} - %{end_number} of %{total} Tag Set found in %{collection_link}"
+            other: "%{start_number} - %{end_number} of %{total} Tag Sets found in %{collection_link}"
+          range_with_query_and_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} Tag Set found in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Tag Sets found in %{fandom_link}"
+          range_with_query_and_language:
+            one: "%{start_number} - %{end_number} of %{total} Tag Set found in %{language}"
+            other: "%{start_number} - %{end_number} of %{total} Tag Sets found in %{language}"
           range_with_query_and_language_and_fandom_html:
             one: "%{start_number} - %{end_number} of %{total} Tag Set found in %{language} in %{fandom_link}"
             other: "%{start_number} - %{end_number} of %{total} Tag Sets found in %{language} in %{fandom_link}"
-          range_with_tag_and_fandom_html:
-            one: "%{start_number} - %{end_number} of %{total} Tag Set in %{tag_link} in %{fandom_link}"
-            other: "%{start_number} - %{end_number} of %{total} Tag Sets in %{tag_link} in %{fandom_link}"
+          range_with_query_and_pseud:
+            one: "%{start_number} - %{end_number} of %{total} Tag Set found by %{byline}"
+            other: "%{start_number} - %{end_number} of %{total} Tag Sets found by %{byline}"
+          range_with_query_and_pseud_and_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} Tag Set found by %{byline} in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Tag Sets found by %{byline} in %{fandom_link}"
           range_with_query_and_tag_and_fandom_html:
             one: "%{start_number} - %{end_number} of %{total} Tag Set found in %{tag_link} in %{fandom_link}"
             other: "%{start_number} - %{end_number} of %{total} Tag Sets found in %{tag_link} in %{fandom_link}"
+          range_with_query_and_tag_html:
+            one: "%{start_number} - %{end_number} of %{total} Tag Set found in %{tag_link}"
+            other: "%{start_number} - %{end_number} of %{total} Tag Sets found in %{tag_link}"
+          range_with_query_and_user:
+            one: "%{start_number} - %{end_number} of %{total} Tag Set found by %{username}"
+            other: "%{start_number} - %{end_number} of %{total} Tag Sets found by %{username}"
+          range_with_query_and_user_and_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} Tag Set found by %{username} in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Tag Sets found by %{username} in %{fandom_link}"
+          range_with_tag_and_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} Tag Set in %{tag_link} in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Tag Sets in %{tag_link} in %{fandom_link}"
+          range_with_tag_html:
+            one: "%{start_number} - %{end_number} of %{total} Tag Set in %{tag_link}"
+            other: "%{start_number} - %{end_number} of %{total} Tag Sets in %{tag_link}"
+          range_with_user:
+            one: "%{start_number} - %{end_number} of %{total} Tag Set by %{username}"
+            other: "%{start_number} - %{end_number} of %{total} Tag Sets by %{username}"
+          range_with_user_and_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} Tag Set by %{username} in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Tag Sets by %{username} in %{fandom_link}"
           recent:
-            one: "Recent Tag Set"
-            other: "Recent Tag Sets"
-          recent_with_query:
-            one: "Recent Tag Set found"
-            other: "Recent Tag Sets found"
-          recent_with_collection_html:
-            one: "Recent Tag Set in %{collection_link}"
-            other: "Recent Tag Sets in %{collection_link}"
-          recent_with_query_and_collection_html:
-            one: "Recent Tag Set found in %{collection_link}"
-            other: "Recent Tag Sets found in %{collection_link}"
-          recent_with_pseud:
-            one: "Recent Tag Set by %{byline}"
-            other: "Recent Tag Sets by %{byline}"
-          recent_with_query_and_pseud:
-            one: "Recent Tag Set found by %{byline}"
-            other: "Recent Tag Sets found by %{byline}"
-          recent_with_user:
-            one: "Recent Tag Set by %{username}"
-            other: "Recent Tag Sets by %{username}"
-          recent_with_query_and_user:
-            one: "Recent Tag Set found by %{username}"
-            other: "Recent Tag Sets found by %{username}"
-          recent_with_language:
-            one: "Recent Tag Set in %{language}"
-            other: "Recent Tag Sets in %{language}"
-          recent_with_query_and_language:
-            one: "Recent Tag Set found in %{language}"
-            other: "Recent Tag Sets found in %{language}"
-          recent_with_tag_html:
-            one: "Recent Tag Set in %{tag_link}"
-            other: "Recent Tag Sets in %{tag_link}"
-          recent_with_query_and_tag_html:
-            one: "Recent Tag Set found in %{tag_link}"
-            other: "Recent Tag Sets found in %{tag_link}"
-          recent_with_fandom_html:
-            one: "Recent Tag Set in %{fandom_link}"
-            other: "Recent Tag Sets in %{fandom_link}"
-          recent_with_query_and_fandom_html:
-            one: "Recent Tag Set found in %{fandom_link}"
-            other: "Recent Tag Sets found in %{fandom_link}"
+            one: Recent Tag Set
+            other: Recent Tag Sets
           recent_with_collection_and_fandom_html:
-            one: "Recent Tag Set in %{collection_link} in %{fandom_link}"
-            other: "Recent Tag Sets in %{collection_link} in %{fandom_link}"
-          recent_with_query_and_collection_and_fandom_html:
-            one: "Recent Tag Set found in %{collection_link} in %{fandom_link}"
-            other: "Recent Tag Sets found in %{collection_link} in %{fandom_link}"
-          recent_with_pseud_and_fandom_html:
-            one: "Recent Tag Set by %{byline} in %{fandom_link}"
-            other: "Recent Tag Sets by %{byline} in %{fandom_link}"
-          recent_with_query_and_pseud_and_fandom_html:
-            one: "Recent Tag Set found by %{byline} in %{fandom_link}"
-            other: "Recent Tag Sets found by %{byline} in %{fandom_link}"
-          recent_with_user_and_fandom_html:
-            one: "Recent Tag Set by %{username} in %{fandom_link}"
-            other: "Recent Tag Sets by %{username} in %{fandom_link}"
-          recent_with_query_and_user_and_fandom_html:
-            one: "Recent Tag Set found by %{username} in %{fandom_link}"
-            other: "Recent Tag Sets found by %{username} in %{fandom_link}"
+            one: Recent Tag Set in %{collection_link} in %{fandom_link}
+            other: Recent Tag Sets in %{collection_link} in %{fandom_link}
+          recent_with_collection_html:
+            one: Recent Tag Set in %{collection_link}
+            other: Recent Tag Sets in %{collection_link}
+          recent_with_fandom_html:
+            one: Recent Tag Set in %{fandom_link}
+            other: Recent Tag Sets in %{fandom_link}
+          recent_with_language:
+            one: Recent Tag Set in %{language}
+            other: Recent Tag Sets in %{language}
           recent_with_language_and_fandom_html:
-            one: "Recent Tag Set in %{language} in %{fandom_link}"
-            other: "Recent Tag Sets in %{language} in %{fandom_link}"
+            one: Recent Tag Set in %{language} in %{fandom_link}
+            other: Recent Tag Sets in %{language} in %{fandom_link}
+          recent_with_pseud:
+            one: Recent Tag Set by %{byline}
+            other: Recent Tag Sets by %{byline}
+          recent_with_pseud_and_fandom_html:
+            one: Recent Tag Set by %{byline} in %{fandom_link}
+            other: Recent Tag Sets by %{byline} in %{fandom_link}
+          recent_with_query:
+            one: Recent Tag Set found
+            other: Recent Tag Sets found
+          recent_with_query_and_collection_and_fandom_html:
+            one: Recent Tag Set found in %{collection_link} in %{fandom_link}
+            other: Recent Tag Sets found in %{collection_link} in %{fandom_link}
+          recent_with_query_and_collection_html:
+            one: Recent Tag Set found in %{collection_link}
+            other: Recent Tag Sets found in %{collection_link}
+          recent_with_query_and_fandom_html:
+            one: Recent Tag Set found in %{fandom_link}
+            other: Recent Tag Sets found in %{fandom_link}
+          recent_with_query_and_language:
+            one: Recent Tag Set found in %{language}
+            other: Recent Tag Sets found in %{language}
           recent_with_query_and_language_and_fandom_html:
-            one: "Recent Tag Set found in %{language} in %{fandom_link}"
-            other: "Recent Tag Sets found in %{language} in %{fandom_link}"
-          recent_with_tag_and_fandom_html:
-            one: "Recent Tag Set in %{tag_link} in %{fandom_link}"
-            other: "Recent Tag Sets in %{tag_link} in %{fandom_link}"
+            one: Recent Tag Set found in %{language} in %{fandom_link}
+            other: Recent Tag Sets found in %{language} in %{fandom_link}
+          recent_with_query_and_pseud:
+            one: Recent Tag Set found by %{byline}
+            other: Recent Tag Sets found by %{byline}
+          recent_with_query_and_pseud_and_fandom_html:
+            one: Recent Tag Set found by %{byline} in %{fandom_link}
+            other: Recent Tag Sets found by %{byline} in %{fandom_link}
           recent_with_query_and_tag_and_fandom_html:
-            one: "Recent Tag Set found in %{tag_link} in %{fandom_link}"
-            other: "Recent Tag Sets found in %{tag_link} in %{fandom_link}"
+            one: Recent Tag Set found in %{tag_link} in %{fandom_link}
+            other: Recent Tag Sets found in %{tag_link} in %{fandom_link}
+          recent_with_query_and_tag_html:
+            one: Recent Tag Set found in %{tag_link}
+            other: Recent Tag Sets found in %{tag_link}
+          recent_with_query_and_user:
+            one: Recent Tag Set found by %{username}
+            other: Recent Tag Sets found by %{username}
+          recent_with_query_and_user_and_fandom_html:
+            one: Recent Tag Set found by %{username} in %{fandom_link}
+            other: Recent Tag Sets found by %{username} in %{fandom_link}
+          recent_with_tag_and_fandom_html:
+            one: Recent Tag Set in %{tag_link} in %{fandom_link}
+            other: Recent Tag Sets in %{tag_link} in %{fandom_link}
+          recent_with_tag_html:
+            one: Recent Tag Set in %{tag_link}
+            other: Recent Tag Sets in %{tag_link}
+          recent_with_user:
+            one: Recent Tag Set by %{username}
+            other: Recent Tag Sets by %{username}
+          recent_with_user_and_fandom_html:
+            one: Recent Tag Set by %{username} in %{fandom_link}
+            other: Recent Tag Sets by %{username} in %{fandom_link}
         unposted_draft:
           count:
             one: "%{count} Unposted Draft"
             other: "%{count} Unposted Drafts"
-          count_with_query:
-            one: "%{count} Unposted Draft found"
-            other: "%{count} Unposted Drafts found"
-          count_with_collection_html:
-            one: "%{count} Unposted Draft in %{collection_link}"
-            other: "%{count} Unposted Drafts in %{collection_link}"
-          count_with_query_and_collection_html:
-            one: "%{count} Unposted Draft found in %{collection_link}"
-            other: "%{count} Unposted Drafts found in %{collection_link}"
-          count_with_pseud:
-            one: "%{count} Unposted Draft by %{byline}"
-            other: "%{count} Unposted Drafts by %{byline}"
-          count_with_query_and_pseud:
-            one: "%{count} Unposted Draft found by %{byline}"
-            other: "%{count} Unposted Drafts found by %{byline}"
-          count_with_user:
-            one: "%{count} Unposted Draft by %{username}"
-            other: "%{count} Unposted Drafts by %{username}"
-          count_with_query_and_user:
-            one: "%{count} Unposted Draft found by %{username}"
-            other: "%{count} Unposted Drafts found by %{username}"
-          count_with_language:
-            one: "%{count} Unposted Draft in %{language}"
-            other: "%{count} Unposted Drafts in %{language}"
-          count_with_query_and_language:
-            one: "%{count} Unposted Draft found in %{language}"
-            other: "%{count} Unposted Drafts found in %{language}"
-          count_with_tag_html:
-            one: "%{count} Unposted Draft in %{tag_link}"
-            other: "%{count} Unposted Drafts in %{tag_link}"
-          count_with_query_and_tag_html:
-            one: "%{count} Unposted Draft found in %{tag_link}"
-            other: "%{count} Unposted Drafts found in %{tag_link}"
-          count_with_fandom_html:
-            one: "%{count} Unposted Draft in %{fandom_link}"
-            other: "%{count} Unposted Drafts in %{fandom_link}"
-          count_with_query_and_fandom_html:
-            one: "%{count} Unposted Draft found in %{fandom_link}"
-            other: "%{count} Unposted Drafts found in %{fandom_link}"
           count_with_collection_and_fandom_html:
             one: "%{count} Unposted Draft in %{collection_link} in %{fandom_link}"
             other: "%{count} Unposted Drafts in %{collection_link} in %{fandom_link}"
-          count_with_query_and_collection_and_fandom_html:
-            one: "%{count} Unposted Draft found in %{collection_link} in %{fandom_link}"
-            other: "%{count} Unposted Drafts found in %{collection_link} in %{fandom_link}"
-          count_with_pseud_and_fandom_html:
-            one: "%{count} Unposted Draft by %{byline} in %{fandom_link}"
-            other: "%{count} Unposted Drafts by %{byline} in %{fandom_link}"
-          count_with_query_and_pseud_and_fandom_html:
-            one: "%{count} Unposted Draft found by %{byline} in %{fandom_link}"
-            other: "%{count} Unposted Drafts found by %{byline} in %{fandom_link}"
-          count_with_user_and_fandom_html:
-            one: "%{count} Unposted Draft by %{username} in %{fandom_link}"
-            other: "%{count} Unposted Drafts by %{username} in %{fandom_link}"
-          count_with_query_and_user_and_fandom_html:
-            one: "%{count} Unposted Draft found by %{username} in %{fandom_link}"
-            other: "%{count} Unposted Drafts found by %{username} in %{fandom_link}"
+          count_with_collection_html:
+            one: "%{count} Unposted Draft in %{collection_link}"
+            other: "%{count} Unposted Drafts in %{collection_link}"
+          count_with_fandom_html:
+            one: "%{count} Unposted Draft in %{fandom_link}"
+            other: "%{count} Unposted Drafts in %{fandom_link}"
+          count_with_language:
+            one: "%{count} Unposted Draft in %{language}"
+            other: "%{count} Unposted Drafts in %{language}"
           count_with_language_and_fandom_html:
             one: "%{count} Unposted Draft in %{language} in %{fandom_link}"
             other: "%{count} Unposted Drafts in %{language} in %{fandom_link}"
+          count_with_pseud:
+            one: "%{count} Unposted Draft by %{byline}"
+            other: "%{count} Unposted Drafts by %{byline}"
+          count_with_pseud_and_fandom_html:
+            one: "%{count} Unposted Draft by %{byline} in %{fandom_link}"
+            other: "%{count} Unposted Drafts by %{byline} in %{fandom_link}"
+          count_with_query:
+            one: "%{count} Unposted Draft found"
+            other: "%{count} Unposted Drafts found"
+          count_with_query_and_collection_and_fandom_html:
+            one: "%{count} Unposted Draft found in %{collection_link} in %{fandom_link}"
+            other: "%{count} Unposted Drafts found in %{collection_link} in %{fandom_link}"
+          count_with_query_and_collection_html:
+            one: "%{count} Unposted Draft found in %{collection_link}"
+            other: "%{count} Unposted Drafts found in %{collection_link}"
+          count_with_query_and_fandom_html:
+            one: "%{count} Unposted Draft found in %{fandom_link}"
+            other: "%{count} Unposted Drafts found in %{fandom_link}"
+          count_with_query_and_language:
+            one: "%{count} Unposted Draft found in %{language}"
+            other: "%{count} Unposted Drafts found in %{language}"
           count_with_query_and_language_and_fandom_html:
             one: "%{count} Unposted Draft found in %{language} in %{fandom_link}"
             other: "%{count} Unposted Drafts found in %{language} in %{fandom_link}"
-          count_with_tag_and_fandom_html:
-            one: "%{count} Unposted Draft in %{tag_link} in %{fandom_link}"
-            other: "%{count} Unposted Drafts in %{tag_link} in %{fandom_link}"
+          count_with_query_and_pseud:
+            one: "%{count} Unposted Draft found by %{byline}"
+            other: "%{count} Unposted Drafts found by %{byline}"
+          count_with_query_and_pseud_and_fandom_html:
+            one: "%{count} Unposted Draft found by %{byline} in %{fandom_link}"
+            other: "%{count} Unposted Drafts found by %{byline} in %{fandom_link}"
           count_with_query_and_tag_and_fandom_html:
             one: "%{count} Unposted Draft found in %{tag_link} in %{fandom_link}"
             other: "%{count} Unposted Drafts found in %{tag_link} in %{fandom_link}"
+          count_with_query_and_tag_html:
+            one: "%{count} Unposted Draft found in %{tag_link}"
+            other: "%{count} Unposted Drafts found in %{tag_link}"
+          count_with_query_and_user:
+            one: "%{count} Unposted Draft found by %{username}"
+            other: "%{count} Unposted Drafts found by %{username}"
+          count_with_query_and_user_and_fandom_html:
+            one: "%{count} Unposted Draft found by %{username} in %{fandom_link}"
+            other: "%{count} Unposted Drafts found by %{username} in %{fandom_link}"
+          count_with_tag_and_fandom_html:
+            one: "%{count} Unposted Draft in %{tag_link} in %{fandom_link}"
+            other: "%{count} Unposted Drafts in %{tag_link} in %{fandom_link}"
+          count_with_tag_html:
+            one: "%{count} Unposted Draft in %{tag_link}"
+            other: "%{count} Unposted Drafts in %{tag_link}"
+          count_with_user:
+            one: "%{count} Unposted Draft by %{username}"
+            other: "%{count} Unposted Drafts by %{username}"
+          count_with_user_and_fandom_html:
+            one: "%{count} Unposted Draft by %{username} in %{fandom_link}"
+            other: "%{count} Unposted Drafts by %{username} in %{fandom_link}"
           range:
             one: "%{start_number} - %{end_number} of %{total} Unposted Draft"
             other: "%{start_number} - %{end_number} of %{total} Unposted Drafts"
-          range_with_query:
-            one: "%{start_number} - %{end_number} of %{total} Unposted Draft found"
-            other: "%{start_number} - %{end_number} of %{total} Unposted Drafts found"
-          range_with_collection_html:
-            one: "%{start_number} - %{end_number} of %{total} Unposted Draft in %{collection_link}"
-            other: "%{start_number} - %{end_number} of %{total} Unposted Drafts in %{collection_link}"
-          range_with_query_and_collection_html:
-            one: "%{start_number} - %{end_number} of %{total} Unposted Draft found in %{collection_link}"
-            other: "%{start_number} - %{end_number} of %{total} Unposted Drafts found in %{collection_link}"
-          range_with_pseud:
-            one: "%{start_number} - %{end_number} of %{total} Unposted Draft by %{byline}"
-            other: "%{start_number} - %{end_number} of %{total} Unposted Drafts by %{byline}"
-          range_with_query_and_pseud:
-            one: "%{start_number} - %{end_number} of %{total} Unposted Draft found by %{byline}"
-            other: "%{start_number} - %{end_number} of %{total} Unposted Drafts found by %{byline}"
-          range_with_user:
-            one: "%{start_number} - %{end_number} of %{total} Unposted Draft by %{username}"
-            other: "%{start_number} - %{end_number} of %{total} Unposted Drafts by %{username}"
-          range_with_query_and_user:
-            one: "%{start_number} - %{end_number} of %{total} Unposted Draft found by %{username}"
-            other: "%{start_number} - %{end_number} of %{total} Unposted Drafts found by %{username}"
-          range_with_language:
-            one: "%{start_number} - %{end_number} of %{total} Unposted Draft in %{language}"
-            other: "%{start_number} - %{end_number} of %{total} Unposted Drafts in %{language}"
-          range_with_query_and_language:
-            one: "%{start_number} - %{end_number} of %{total} Unposted Draft found in %{language}"
-            other: "%{start_number} - %{end_number} of %{total} Unposted Drafts found in %{language}"
-          range_with_tag_html:
-            one: "%{start_number} - %{end_number} of %{total} Unposted Draft in %{tag_link}"
-            other: "%{start_number} - %{end_number} of %{total} Unposted Drafts in %{tag_link}"
-          range_with_query_and_tag_html:
-            one: "%{start_number} - %{end_number} of %{total} Unposted Draft found in %{tag_link}"
-            other: "%{start_number} - %{end_number} of %{total} Unposted Drafts found in %{tag_link}"
-          range_with_fandom_html:
-            one: "%{start_number} - %{end_number} of %{total} Unposted Draft in %{fandom_link}"
-            other: "%{start_number} - %{end_number} of %{total} Unposted Drafts in %{fandom_link}"
-          range_with_query_and_fandom_html:
-            one: "%{start_number} - %{end_number} of %{total} Unposted Draft found in %{fandom_link}"
-            other: "%{start_number} - %{end_number} of %{total} Unposted Drafts found in %{fandom_link}"
           range_with_collection_and_fandom_html:
             one: "%{start_number} - %{end_number} of %{total} Unposted Draft in %{collection_link} in %{fandom_link}"
             other: "%{start_number} - %{end_number} of %{total} Unposted Drafts in %{collection_link} in %{fandom_link}"
-          range_with_query_and_collection_and_fandom_html:
-            one: "%{start_number} - %{end_number} of %{total} Unposted Draft found in %{collection_link} in %{fandom_link}"
-            other: "%{start_number} - %{end_number} of %{total} Unposted Drafts found in %{collection_link} in %{fandom_link}"
-          range_with_pseud_and_fandom_html:
-            one: "%{start_number} - %{end_number} of %{total} Unposted Draft by %{byline} in %{fandom_link}"
-            other: "%{start_number} - %{end_number} of %{total} Unposted Drafts by %{byline} in %{fandom_link}"
-          range_with_query_and_pseud_and_fandom_html:
-            one: "%{start_number} - %{end_number} of %{total} Unposted Draft found by %{byline} in %{fandom_link}"
-            other: "%{start_number} - %{end_number} of %{total} Unposted Drafts found by %{byline} in %{fandom_link}"
-          range_with_user_and_fandom_html:
-            one: "%{start_number} - %{end_number} of %{total} Unposted Draft by %{username} in %{fandom_link}"
-            other: "%{start_number} - %{end_number} of %{total} Unposted Drafts by %{username} in %{fandom_link}"
-          range_with_query_and_user_and_fandom_html:
-            one: "%{start_number} - %{end_number} of %{total} Unposted Draft found by %{username} in %{fandom_link}"
-            other: "%{start_number} - %{end_number} of %{total} Unposted Drafts found by %{username} in %{fandom_link}"
+          range_with_collection_html:
+            one: "%{start_number} - %{end_number} of %{total} Unposted Draft in %{collection_link}"
+            other: "%{start_number} - %{end_number} of %{total} Unposted Drafts in %{collection_link}"
+          range_with_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} Unposted Draft in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Unposted Drafts in %{fandom_link}"
+          range_with_language:
+            one: "%{start_number} - %{end_number} of %{total} Unposted Draft in %{language}"
+            other: "%{start_number} - %{end_number} of %{total} Unposted Drafts in %{language}"
           range_with_language_and_fandom_html:
             one: "%{start_number} - %{end_number} of %{total} Unposted Draft in %{language} in %{fandom_link}"
             other: "%{start_number} - %{end_number} of %{total} Unposted Drafts in %{language} in %{fandom_link}"
+          range_with_pseud:
+            one: "%{start_number} - %{end_number} of %{total} Unposted Draft by %{byline}"
+            other: "%{start_number} - %{end_number} of %{total} Unposted Drafts by %{byline}"
+          range_with_pseud_and_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} Unposted Draft by %{byline} in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Unposted Drafts by %{byline} in %{fandom_link}"
+          range_with_query:
+            one: "%{start_number} - %{end_number} of %{total} Unposted Draft found"
+            other: "%{start_number} - %{end_number} of %{total} Unposted Drafts found"
+          range_with_query_and_collection_and_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} Unposted Draft found in %{collection_link} in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Unposted Drafts found in %{collection_link} in %{fandom_link}"
+          range_with_query_and_collection_html:
+            one: "%{start_number} - %{end_number} of %{total} Unposted Draft found in %{collection_link}"
+            other: "%{start_number} - %{end_number} of %{total} Unposted Drafts found in %{collection_link}"
+          range_with_query_and_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} Unposted Draft found in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Unposted Drafts found in %{fandom_link}"
+          range_with_query_and_language:
+            one: "%{start_number} - %{end_number} of %{total} Unposted Draft found in %{language}"
+            other: "%{start_number} - %{end_number} of %{total} Unposted Drafts found in %{language}"
           range_with_query_and_language_and_fandom_html:
             one: "%{start_number} - %{end_number} of %{total} Unposted Draft found in %{language} in %{fandom_link}"
             other: "%{start_number} - %{end_number} of %{total} Unposted Drafts found in %{language} in %{fandom_link}"
-          range_with_tag_and_fandom_html:
-            one: "%{start_number} - %{end_number} of %{total} Unposted Draft in %{tag_link} in %{fandom_link}"
-            other: "%{start_number} - %{end_number} of %{total} Unposted Drafts in %{tag_link} in %{fandom_link}"
+          range_with_query_and_pseud:
+            one: "%{start_number} - %{end_number} of %{total} Unposted Draft found by %{byline}"
+            other: "%{start_number} - %{end_number} of %{total} Unposted Drafts found by %{byline}"
+          range_with_query_and_pseud_and_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} Unposted Draft found by %{byline} in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Unposted Drafts found by %{byline} in %{fandom_link}"
           range_with_query_and_tag_and_fandom_html:
             one: "%{start_number} - %{end_number} of %{total} Unposted Draft found in %{tag_link} in %{fandom_link}"
             other: "%{start_number} - %{end_number} of %{total} Unposted Drafts found in %{tag_link} in %{fandom_link}"
+          range_with_query_and_tag_html:
+            one: "%{start_number} - %{end_number} of %{total} Unposted Draft found in %{tag_link}"
+            other: "%{start_number} - %{end_number} of %{total} Unposted Drafts found in %{tag_link}"
+          range_with_query_and_user:
+            one: "%{start_number} - %{end_number} of %{total} Unposted Draft found by %{username}"
+            other: "%{start_number} - %{end_number} of %{total} Unposted Drafts found by %{username}"
+          range_with_query_and_user_and_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} Unposted Draft found by %{username} in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Unposted Drafts found by %{username} in %{fandom_link}"
+          range_with_tag_and_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} Unposted Draft in %{tag_link} in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Unposted Drafts in %{tag_link} in %{fandom_link}"
+          range_with_tag_html:
+            one: "%{start_number} - %{end_number} of %{total} Unposted Draft in %{tag_link}"
+            other: "%{start_number} - %{end_number} of %{total} Unposted Drafts in %{tag_link}"
+          range_with_user:
+            one: "%{start_number} - %{end_number} of %{total} Unposted Draft by %{username}"
+            other: "%{start_number} - %{end_number} of %{total} Unposted Drafts by %{username}"
+          range_with_user_and_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} Unposted Draft by %{username} in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Unposted Drafts by %{username} in %{fandom_link}"
           recent:
-            one: "Recent Unposted Draft"
-            other: "Recent Unposted Drafts"
-          recent_with_query:
-            one: "Recent Unposted Draft found"
-            other: "Recent Unposted Drafts found"
-          recent_with_collection_html:
-            one: "Recent Unposted Draft in %{collection_link}"
-            other: "Recent Unposted Drafts in %{collection_link}"
-          recent_with_query_and_collection_html:
-            one: "Recent Unposted Draft found in %{collection_link}"
-            other: "Recent Unposted Drafts found in %{collection_link}"
-          recent_with_pseud:
-            one: "Recent Unposted Draft by %{byline}"
-            other: "Recent Unposted Drafts by %{byline}"
-          recent_with_query_and_pseud:
-            one: "Recent Unposted Draft found by %{byline}"
-            other: "Recent Unposted Drafts found by %{byline}"
-          recent_with_user:
-            one: "Recent Unposted Draft by %{username}"
-            other: "Recent Unposted Drafts by %{username}"
-          recent_with_query_and_user:
-            one: "Recent Unposted Draft found by %{username}"
-            other: "Recent Unposted Drafts found by %{username}"
-          recent_with_language:
-            one: "Recent Unposted Draft in %{language}"
-            other: "Recent Unposted Drafts in %{language}"
-          recent_with_query_and_language:
-            one: "Recent Unposted Draft found in %{language}"
-            other: "Recent Unposted Drafts found in %{language}"
-          recent_with_tag_html:
-            one: "Recent Unposted Draft in %{tag_link}"
-            other: "Recent Unposted Drafts in %{tag_link}"
-          recent_with_query_and_tag_html:
-            one: "Recent Unposted Draft found in %{tag_link}"
-            other: "Recent Unposted Drafts found in %{tag_link}"
-          recent_with_fandom_html:
-            one: "Recent Unposted Draft in %{fandom_link}"
-            other: "Recent Unposted Drafts in %{fandom_link}"
-          recent_with_query_and_fandom_html:
-            one: "Recent Unposted Draft found in %{fandom_link}"
-            other: "Recent Unposted Drafts found in %{fandom_link}"
+            one: Recent Unposted Draft
+            other: Recent Unposted Drafts
           recent_with_collection_and_fandom_html:
-            one: "Recent Unposted Draft in %{collection_link} in %{fandom_link}"
-            other: "Recent Unposted Drafts in %{collection_link} in %{fandom_link}"
-          recent_with_query_and_collection_and_fandom_html:
-            one: "Recent Unposted Draft found in %{collection_link} in %{fandom_link}"
-            other: "Recent Unposted Drafts found in %{collection_link} in %{fandom_link}"
-          recent_with_pseud_and_fandom_html:
-            one: "Recent Unposted Draft by %{byline} in %{fandom_link}"
-            other: "Recent Unposted Drafts by %{byline} in %{fandom_link}"
-          recent_with_query_and_pseud_and_fandom_html:
-            one: "Recent Unposted Draft found by %{byline} in %{fandom_link}"
-            other: "Recent Unposted Drafts found by %{byline} in %{fandom_link}"
-          recent_with_user_and_fandom_html:
-            one: "Recent Unposted Draft by %{username} in %{fandom_link}"
-            other: "Recent Unposted Drafts by %{username} in %{fandom_link}"
-          recent_with_query_and_user_and_fandom_html:
-            one: "Recent Unposted Draft found by %{username} in %{fandom_link}"
-            other: "Recent Unposted Drafts found by %{username} in %{fandom_link}"
+            one: Recent Unposted Draft in %{collection_link} in %{fandom_link}
+            other: Recent Unposted Drafts in %{collection_link} in %{fandom_link}
+          recent_with_collection_html:
+            one: Recent Unposted Draft in %{collection_link}
+            other: Recent Unposted Drafts in %{collection_link}
+          recent_with_fandom_html:
+            one: Recent Unposted Draft in %{fandom_link}
+            other: Recent Unposted Drafts in %{fandom_link}
+          recent_with_language:
+            one: Recent Unposted Draft in %{language}
+            other: Recent Unposted Drafts in %{language}
           recent_with_language_and_fandom_html:
-            one: "Recent Unposted Draft in %{language} in %{fandom_link}"
-            other: "Recent Unposted Drafts in %{language} in %{fandom_link}"
+            one: Recent Unposted Draft in %{language} in %{fandom_link}
+            other: Recent Unposted Drafts in %{language} in %{fandom_link}
+          recent_with_pseud:
+            one: Recent Unposted Draft by %{byline}
+            other: Recent Unposted Drafts by %{byline}
+          recent_with_pseud_and_fandom_html:
+            one: Recent Unposted Draft by %{byline} in %{fandom_link}
+            other: Recent Unposted Drafts by %{byline} in %{fandom_link}
+          recent_with_query:
+            one: Recent Unposted Draft found
+            other: Recent Unposted Drafts found
+          recent_with_query_and_collection_and_fandom_html:
+            one: Recent Unposted Draft found in %{collection_link} in %{fandom_link}
+            other: Recent Unposted Drafts found in %{collection_link} in %{fandom_link}
+          recent_with_query_and_collection_html:
+            one: Recent Unposted Draft found in %{collection_link}
+            other: Recent Unposted Drafts found in %{collection_link}
+          recent_with_query_and_fandom_html:
+            one: Recent Unposted Draft found in %{fandom_link}
+            other: Recent Unposted Drafts found in %{fandom_link}
+          recent_with_query_and_language:
+            one: Recent Unposted Draft found in %{language}
+            other: Recent Unposted Drafts found in %{language}
           recent_with_query_and_language_and_fandom_html:
-            one: "Recent Unposted Draft found in %{language} in %{fandom_link}"
-            other: "Recent Unposted Drafts found in %{language} in %{fandom_link}"
-          recent_with_tag_and_fandom_html:
-            one: "Recent Unposted Draft in %{tag_link} in %{fandom_link}"
-            other: "Recent Unposted Drafts in %{tag_link} in %{fandom_link}"
+            one: Recent Unposted Draft found in %{language} in %{fandom_link}
+            other: Recent Unposted Drafts found in %{language} in %{fandom_link}
+          recent_with_query_and_pseud:
+            one: Recent Unposted Draft found by %{byline}
+            other: Recent Unposted Drafts found by %{byline}
+          recent_with_query_and_pseud_and_fandom_html:
+            one: Recent Unposted Draft found by %{byline} in %{fandom_link}
+            other: Recent Unposted Drafts found by %{byline} in %{fandom_link}
           recent_with_query_and_tag_and_fandom_html:
-            one: "Recent Unposted Draft found in %{tag_link} in %{fandom_link}"
-            other: "Recent Unposted Drafts found in %{tag_link} in %{fandom_link}"
+            one: Recent Unposted Draft found in %{tag_link} in %{fandom_link}
+            other: Recent Unposted Drafts found in %{tag_link} in %{fandom_link}
+          recent_with_query_and_tag_html:
+            one: Recent Unposted Draft found in %{tag_link}
+            other: Recent Unposted Drafts found in %{tag_link}
+          recent_with_query_and_user:
+            one: Recent Unposted Draft found by %{username}
+            other: Recent Unposted Drafts found by %{username}
+          recent_with_query_and_user_and_fandom_html:
+            one: Recent Unposted Draft found by %{username} in %{fandom_link}
+            other: Recent Unposted Drafts found by %{username} in %{fandom_link}
+          recent_with_tag_and_fandom_html:
+            one: Recent Unposted Draft in %{tag_link} in %{fandom_link}
+            other: Recent Unposted Drafts in %{tag_link} in %{fandom_link}
+          recent_with_tag_html:
+            one: Recent Unposted Draft in %{tag_link}
+            other: Recent Unposted Drafts in %{tag_link}
+          recent_with_user:
+            one: Recent Unposted Draft by %{username}
+            other: Recent Unposted Drafts by %{username}
+          recent_with_user_and_fandom_html:
+            one: Recent Unposted Draft by %{username} in %{fandom_link}
+            other: Recent Unposted Drafts by %{username} in %{fandom_link}
         user:
           count:
             one: "%{count} User"
             other: "%{count} Users"
-          count_with_query:
-            one: "%{count} User found"
-            other: "%{count} Users found"
-          count_with_collection_html:
-            one: "%{count} User in %{collection_link}"
-            other: "%{count} Users in %{collection_link}"
-          count_with_query_and_collection_html:
-            one: "%{count} User found in %{collection_link}"
-            other: "%{count} Users found in %{collection_link}"
-          count_with_pseud:
-            one: "%{count} User by %{byline}"
-            other: "%{count} Users by %{byline}"
-          count_with_query_and_pseud:
-            one: "%{count} User found by %{byline}"
-            other: "%{count} Users found by %{byline}"
-          count_with_user:
-            one: "%{count} User by %{username}"
-            other: "%{count} Users by %{username}"
-          count_with_query_and_user:
-            one: "%{count} User found by %{username}"
-            other: "%{count} Users found by %{username}"
-          count_with_language:
-            one: "%{count} User in %{language}"
-            other: "%{count} Users in %{language}"
-          count_with_query_and_language:
-            one: "%{count} User found in %{language}"
-            other: "%{count} Users found in %{language}"
-          count_with_tag_html:
-            one: "%{count} User in %{tag_link}"
-            other: "%{count} Users in %{tag_link}"
-          count_with_query_and_tag_html:
-            one: "%{count} User found in %{tag_link}"
-            other: "%{count} Users found in %{tag_link}"
-          count_with_fandom_html:
-            one: "%{count} User in %{fandom_link}"
-            other: "%{count} Users in %{fandom_link}"
-          count_with_query_and_fandom_html:
-            one: "%{count} User found in %{fandom_link}"
-            other: "%{count} Users found in %{fandom_link}"
           count_with_collection_and_fandom_html:
             one: "%{count} User in %{collection_link} in %{fandom_link}"
             other: "%{count} Users in %{collection_link} in %{fandom_link}"
-          count_with_query_and_collection_and_fandom_html:
-            one: "%{count} User found in %{collection_link} in %{fandom_link}"
-            other: "%{count} Users found in %{collection_link} in %{fandom_link}"
-          count_with_pseud_and_fandom_html:
-            one: "%{count} User by %{byline} in %{fandom_link}"
-            other: "%{count} Users by %{byline} in %{fandom_link}"
-          count_with_query_and_pseud_and_fandom_html:
-            one: "%{count} User found by %{byline} in %{fandom_link}"
-            other: "%{count} Users found by %{byline} in %{fandom_link}"
-          count_with_user_and_fandom_html:
-            one: "%{count} User by %{username} in %{fandom_link}"
-            other: "%{count} Users by %{username} in %{fandom_link}"
-          count_with_query_and_user_and_fandom_html:
-            one: "%{count} User found by %{username} in %{fandom_link}"
-            other: "%{count} Users found by %{username} in %{fandom_link}"
+          count_with_collection_html:
+            one: "%{count} User in %{collection_link}"
+            other: "%{count} Users in %{collection_link}"
+          count_with_fandom_html:
+            one: "%{count} User in %{fandom_link}"
+            other: "%{count} Users in %{fandom_link}"
+          count_with_language:
+            one: "%{count} User in %{language}"
+            other: "%{count} Users in %{language}"
           count_with_language_and_fandom_html:
             one: "%{count} User in %{language} in %{fandom_link}"
             other: "%{count} Users in %{language} in %{fandom_link}"
+          count_with_pseud:
+            one: "%{count} User by %{byline}"
+            other: "%{count} Users by %{byline}"
+          count_with_pseud_and_fandom_html:
+            one: "%{count} User by %{byline} in %{fandom_link}"
+            other: "%{count} Users by %{byline} in %{fandom_link}"
+          count_with_query:
+            one: "%{count} User found"
+            other: "%{count} Users found"
+          count_with_query_and_collection_and_fandom_html:
+            one: "%{count} User found in %{collection_link} in %{fandom_link}"
+            other: "%{count} Users found in %{collection_link} in %{fandom_link}"
+          count_with_query_and_collection_html:
+            one: "%{count} User found in %{collection_link}"
+            other: "%{count} Users found in %{collection_link}"
+          count_with_query_and_fandom_html:
+            one: "%{count} User found in %{fandom_link}"
+            other: "%{count} Users found in %{fandom_link}"
+          count_with_query_and_language:
+            one: "%{count} User found in %{language}"
+            other: "%{count} Users found in %{language}"
           count_with_query_and_language_and_fandom_html:
             one: "%{count} User found in %{language} in %{fandom_link}"
             other: "%{count} Users found in %{language} in %{fandom_link}"
-          count_with_tag_and_fandom_html:
-            one: "%{count} User in %{tag_link} in %{fandom_link}"
-            other: "%{count} Users in %{tag_link} in %{fandom_link}"
+          count_with_query_and_pseud:
+            one: "%{count} User found by %{byline}"
+            other: "%{count} Users found by %{byline}"
+          count_with_query_and_pseud_and_fandom_html:
+            one: "%{count} User found by %{byline} in %{fandom_link}"
+            other: "%{count} Users found by %{byline} in %{fandom_link}"
           count_with_query_and_tag_and_fandom_html:
             one: "%{count} User found in %{tag_link} in %{fandom_link}"
             other: "%{count} Users found in %{tag_link} in %{fandom_link}"
+          count_with_query_and_tag_html:
+            one: "%{count} User found in %{tag_link}"
+            other: "%{count} Users found in %{tag_link}"
+          count_with_query_and_user:
+            one: "%{count} User found by %{username}"
+            other: "%{count} Users found by %{username}"
+          count_with_query_and_user_and_fandom_html:
+            one: "%{count} User found by %{username} in %{fandom_link}"
+            other: "%{count} Users found by %{username} in %{fandom_link}"
+          count_with_tag_and_fandom_html:
+            one: "%{count} User in %{tag_link} in %{fandom_link}"
+            other: "%{count} Users in %{tag_link} in %{fandom_link}"
+          count_with_tag_html:
+            one: "%{count} User in %{tag_link}"
+            other: "%{count} Users in %{tag_link}"
+          count_with_user:
+            one: "%{count} User by %{username}"
+            other: "%{count} Users by %{username}"
+          count_with_user_and_fandom_html:
+            one: "%{count} User by %{username} in %{fandom_link}"
+            other: "%{count} Users by %{username} in %{fandom_link}"
           range:
             one: "%{start_number} - %{end_number} of %{total} User"
             other: "%{start_number} - %{end_number} of %{total} Users"
-          range_with_query:
-            one: "%{start_number} - %{end_number} of %{total} User found"
-            other: "%{start_number} - %{end_number} of %{total} Users found"
-          range_with_collection_html:
-            one: "%{start_number} - %{end_number} of %{total} User in %{collection_link}"
-            other: "%{start_number} - %{end_number} of %{total} Users in %{collection_link}"
-          range_with_query_and_collection_html:
-            one: "%{start_number} - %{end_number} of %{total} User found in %{collection_link}"
-            other: "%{start_number} - %{end_number} of %{total} Users found in %{collection_link}"
-          range_with_pseud:
-            one: "%{start_number} - %{end_number} of %{total} User by %{byline}"
-            other: "%{start_number} - %{end_number} of %{total} Users by %{byline}"
-          range_with_query_and_pseud:
-            one: "%{start_number} - %{end_number} of %{total} User found by %{byline}"
-            other: "%{start_number} - %{end_number} of %{total} Users found by %{byline}"
-          range_with_user:
-            one: "%{start_number} - %{end_number} of %{total} User by %{username}"
-            other: "%{start_number} - %{end_number} of %{total} Users by %{username}"
-          range_with_query_and_user:
-            one: "%{start_number} - %{end_number} of %{total} User found by %{username}"
-            other: "%{start_number} - %{end_number} of %{total} Users found by %{username}"
-          range_with_language:
-            one: "%{start_number} - %{end_number} of %{total} User in %{language}"
-            other: "%{start_number} - %{end_number} of %{total} Users in %{language}"
-          range_with_query_and_language:
-            one: "%{start_number} - %{end_number} of %{total} User found in %{language}"
-            other: "%{start_number} - %{end_number} of %{total} Users found in %{language}"
-          range_with_tag_html:
-            one: "%{start_number} - %{end_number} of %{total} User in %{tag_link}"
-            other: "%{start_number} - %{end_number} of %{total} Users in %{tag_link}"
-          range_with_query_and_tag_html:
-            one: "%{start_number} - %{end_number} of %{total} User found in %{tag_link}"
-            other: "%{start_number} - %{end_number} of %{total} Users found in %{tag_link}"
-          range_with_fandom_html:
-            one: "%{start_number} - %{end_number} of %{total} User in %{fandom_link}"
-            other: "%{start_number} - %{end_number} of %{total} Users in %{fandom_link}"
-          range_with_query_and_fandom_html:
-            one: "%{start_number} - %{end_number} of %{total} User found in %{fandom_link}"
-            other: "%{start_number} - %{end_number} of %{total} Users found in %{fandom_link}"
           range_with_collection_and_fandom_html:
             one: "%{start_number} - %{end_number} of %{total} User in %{collection_link} in %{fandom_link}"
             other: "%{start_number} - %{end_number} of %{total} Users in %{collection_link} in %{fandom_link}"
-          range_with_query_and_collection_and_fandom_html:
-            one: "%{start_number} - %{end_number} of %{total} User found in %{collection_link} in %{fandom_link}"
-            other: "%{start_number} - %{end_number} of %{total} Users found in %{collection_link} in %{fandom_link}"
-          range_with_pseud_and_fandom_html:
-            one: "%{start_number} - %{end_number} of %{total} User by %{byline} in %{fandom_link}"
-            other: "%{start_number} - %{end_number} of %{total} Users by %{byline} in %{fandom_link}"
-          range_with_query_and_pseud_and_fandom_html:
-            one: "%{start_number} - %{end_number} of %{total} User found by %{byline} in %{fandom_link}"
-            other: "%{start_number} - %{end_number} of %{total} Users found by %{byline} in %{fandom_link}"
-          range_with_user_and_fandom_html:
-            one: "%{start_number} - %{end_number} of %{total} User by %{username} in %{fandom_link}"
-            other: "%{start_number} - %{end_number} of %{total} Users by %{username} in %{fandom_link}"
-          range_with_query_and_user_and_fandom_html:
-            one: "%{start_number} - %{end_number} of %{total} User found by %{username} in %{fandom_link}"
-            other: "%{start_number} - %{end_number} of %{total} Users found by %{username} in %{fandom_link}"
+          range_with_collection_html:
+            one: "%{start_number} - %{end_number} of %{total} User in %{collection_link}"
+            other: "%{start_number} - %{end_number} of %{total} Users in %{collection_link}"
+          range_with_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} User in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Users in %{fandom_link}"
+          range_with_language:
+            one: "%{start_number} - %{end_number} of %{total} User in %{language}"
+            other: "%{start_number} - %{end_number} of %{total} Users in %{language}"
           range_with_language_and_fandom_html:
             one: "%{start_number} - %{end_number} of %{total} User in %{language} in %{fandom_link}"
             other: "%{start_number} - %{end_number} of %{total} Users in %{language} in %{fandom_link}"
+          range_with_pseud:
+            one: "%{start_number} - %{end_number} of %{total} User by %{byline}"
+            other: "%{start_number} - %{end_number} of %{total} Users by %{byline}"
+          range_with_pseud_and_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} User by %{byline} in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Users by %{byline} in %{fandom_link}"
+          range_with_query:
+            one: "%{start_number} - %{end_number} of %{total} User found"
+            other: "%{start_number} - %{end_number} of %{total} Users found"
+          range_with_query_and_collection_and_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} User found in %{collection_link} in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Users found in %{collection_link} in %{fandom_link}"
+          range_with_query_and_collection_html:
+            one: "%{start_number} - %{end_number} of %{total} User found in %{collection_link}"
+            other: "%{start_number} - %{end_number} of %{total} Users found in %{collection_link}"
+          range_with_query_and_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} User found in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Users found in %{fandom_link}"
+          range_with_query_and_language:
+            one: "%{start_number} - %{end_number} of %{total} User found in %{language}"
+            other: "%{start_number} - %{end_number} of %{total} Users found in %{language}"
           range_with_query_and_language_and_fandom_html:
             one: "%{start_number} - %{end_number} of %{total} User found in %{language} in %{fandom_link}"
             other: "%{start_number} - %{end_number} of %{total} Users found in %{language} in %{fandom_link}"
-          range_with_tag_and_fandom_html:
-            one: "%{start_number} - %{end_number} of %{total} User in %{tag_link} in %{fandom_link}"
-            other: "%{start_number} - %{end_number} of %{total} Users in %{tag_link} in %{fandom_link}"
+          range_with_query_and_pseud:
+            one: "%{start_number} - %{end_number} of %{total} User found by %{byline}"
+            other: "%{start_number} - %{end_number} of %{total} Users found by %{byline}"
+          range_with_query_and_pseud_and_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} User found by %{byline} in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Users found by %{byline} in %{fandom_link}"
           range_with_query_and_tag_and_fandom_html:
             one: "%{start_number} - %{end_number} of %{total} User found in %{tag_link} in %{fandom_link}"
             other: "%{start_number} - %{end_number} of %{total} Users found in %{tag_link} in %{fandom_link}"
+          range_with_query_and_tag_html:
+            one: "%{start_number} - %{end_number} of %{total} User found in %{tag_link}"
+            other: "%{start_number} - %{end_number} of %{total} Users found in %{tag_link}"
+          range_with_query_and_user:
+            one: "%{start_number} - %{end_number} of %{total} User found by %{username}"
+            other: "%{start_number} - %{end_number} of %{total} Users found by %{username}"
+          range_with_query_and_user_and_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} User found by %{username} in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Users found by %{username} in %{fandom_link}"
+          range_with_tag_and_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} User in %{tag_link} in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Users in %{tag_link} in %{fandom_link}"
+          range_with_tag_html:
+            one: "%{start_number} - %{end_number} of %{total} User in %{tag_link}"
+            other: "%{start_number} - %{end_number} of %{total} Users in %{tag_link}"
+          range_with_user:
+            one: "%{start_number} - %{end_number} of %{total} User by %{username}"
+            other: "%{start_number} - %{end_number} of %{total} Users by %{username}"
+          range_with_user_and_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} User by %{username} in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Users by %{username} in %{fandom_link}"
           recent:
-            one: "Recent User"
-            other: "Recent Users"
-          recent_with_query:
-            one: "Recent User found"
-            other: "Recent Users found"
-          recent_with_collection_html:
-            one: "Recent User in %{collection_link}"
-            other: "Recent Users in %{collection_link}"
-          recent_with_query_and_collection_html:
-            one: "Recent User found in %{collection_link}"
-            other: "Recent Users found in %{collection_link}"
-          recent_with_pseud:
-            one: "Recent User by %{byline}"
-            other: "Recent Users by %{byline}"
-          recent_with_query_and_pseud:
-            one: "Recent User found by %{byline}"
-            other: "Recent Users found by %{byline}"
-          recent_with_user:
-            one: "Recent User by %{username}"
-            other: "Recent Users by %{username}"
-          recent_with_query_and_user:
-            one: "Recent User found by %{username}"
-            other: "Recent Users found by %{username}"
-          recent_with_language:
-            one: "Recent User in %{language}"
-            other: "Recent Users in %{language}"
-          recent_with_query_and_language:
-            one: "Recent User found in %{language}"
-            other: "Recent Users found in %{language}"
-          recent_with_tag_html:
-            one: "Recent User in %{tag_link}"
-            other: "Recent Users in %{tag_link}"
-          recent_with_query_and_tag_html:
-            one: "Recent User found in %{tag_link}"
-            other: "Recent Users found in %{tag_link}"
-          recent_with_fandom_html:
-            one: "Recent User in %{fandom_link}"
-            other: "Recent Users in %{fandom_link}"
-          recent_with_query_and_fandom_html:
-            one: "Recent User found in %{fandom_link}"
-            other: "Recent Users found in %{fandom_link}"
+            one: Recent User
+            other: Recent Users
           recent_with_collection_and_fandom_html:
-            one: "Recent User in %{collection_link} in %{fandom_link}"
-            other: "Recent Users in %{collection_link} in %{fandom_link}"
-          recent_with_query_and_collection_and_fandom_html:
-            one: "Recent User found in %{collection_link} in %{fandom_link}"
-            other: "Recent Users found in %{collection_link} in %{fandom_link}"
-          recent_with_pseud_and_fandom_html:
-            one: "Recent User by %{byline} in %{fandom_link}"
-            other: "Recent Users by %{byline} in %{fandom_link}"
-          recent_with_query_and_pseud_and_fandom_html:
-            one: "Recent User found by %{byline} in %{fandom_link}"
-            other: "Recent Users found by %{byline} in %{fandom_link}"
-          recent_with_user_and_fandom_html:
-            one: "Recent User by %{username} in %{fandom_link}"
-            other: "Recent Users by %{username} in %{fandom_link}"
-          recent_with_query_and_user_and_fandom_html:
-            one: "Recent User found by %{username} in %{fandom_link}"
-            other: "Recent Users found by %{username} in %{fandom_link}"
+            one: Recent User in %{collection_link} in %{fandom_link}
+            other: Recent Users in %{collection_link} in %{fandom_link}
+          recent_with_collection_html:
+            one: Recent User in %{collection_link}
+            other: Recent Users in %{collection_link}
+          recent_with_fandom_html:
+            one: Recent User in %{fandom_link}
+            other: Recent Users in %{fandom_link}
+          recent_with_language:
+            one: Recent User in %{language}
+            other: Recent Users in %{language}
           recent_with_language_and_fandom_html:
-            one: "Recent User in %{language} in %{fandom_link}"
-            other: "Recent Users in %{language} in %{fandom_link}"
+            one: Recent User in %{language} in %{fandom_link}
+            other: Recent Users in %{language} in %{fandom_link}
+          recent_with_pseud:
+            one: Recent User by %{byline}
+            other: Recent Users by %{byline}
+          recent_with_pseud_and_fandom_html:
+            one: Recent User by %{byline} in %{fandom_link}
+            other: Recent Users by %{byline} in %{fandom_link}
+          recent_with_query:
+            one: Recent User found
+            other: Recent Users found
+          recent_with_query_and_collection_and_fandom_html:
+            one: Recent User found in %{collection_link} in %{fandom_link}
+            other: Recent Users found in %{collection_link} in %{fandom_link}
+          recent_with_query_and_collection_html:
+            one: Recent User found in %{collection_link}
+            other: Recent Users found in %{collection_link}
+          recent_with_query_and_fandom_html:
+            one: Recent User found in %{fandom_link}
+            other: Recent Users found in %{fandom_link}
+          recent_with_query_and_language:
+            one: Recent User found in %{language}
+            other: Recent Users found in %{language}
           recent_with_query_and_language_and_fandom_html:
-            one: "Recent User found in %{language} in %{fandom_link}"
-            other: "Recent Users found in %{language} in %{fandom_link}"
-          recent_with_tag_and_fandom_html:
-            one: "Recent User in %{tag_link} in %{fandom_link}"
-            other: "Recent Users in %{tag_link} in %{fandom_link}"
+            one: Recent User found in %{language} in %{fandom_link}
+            other: Recent Users found in %{language} in %{fandom_link}
+          recent_with_query_and_pseud:
+            one: Recent User found by %{byline}
+            other: Recent Users found by %{byline}
+          recent_with_query_and_pseud_and_fandom_html:
+            one: Recent User found by %{byline} in %{fandom_link}
+            other: Recent Users found by %{byline} in %{fandom_link}
           recent_with_query_and_tag_and_fandom_html:
-            one: "Recent User found in %{tag_link} in %{fandom_link}"
-            other: "Recent Users found in %{tag_link} in %{fandom_link}"
+            one: Recent User found in %{tag_link} in %{fandom_link}
+            other: Recent Users found in %{tag_link} in %{fandom_link}
+          recent_with_query_and_tag_html:
+            one: Recent User found in %{tag_link}
+            other: Recent Users found in %{tag_link}
+          recent_with_query_and_user:
+            one: Recent User found by %{username}
+            other: Recent Users found by %{username}
+          recent_with_query_and_user_and_fandom_html:
+            one: Recent User found by %{username} in %{fandom_link}
+            other: Recent Users found by %{username} in %{fandom_link}
+          recent_with_tag_and_fandom_html:
+            one: Recent User in %{tag_link} in %{fandom_link}
+            other: Recent Users in %{tag_link} in %{fandom_link}
+          recent_with_tag_html:
+            one: Recent User in %{tag_link}
+            other: Recent Users in %{tag_link}
+          recent_with_user:
+            one: Recent User by %{username}
+            other: Recent Users by %{username}
+          recent_with_user_and_fandom_html:
+            one: Recent User by %{username} in %{fandom_link}
+            other: Recent Users by %{username} in %{fandom_link}
         work:
           count:
             one: "%{count} Work"
             other: "%{count} Works"
-          count_with_query:
-            one: "%{count} Work found"
-            other: "%{count} Works found"
-          count_with_collection_html:
-            one: "%{count} Work in %{collection_link}"
-            other: "%{count} Works in %{collection_link}"
-          count_with_query_and_collection_html:
-            one: "%{count} Work found in %{collection_link}"
-            other: "%{count} Works found in %{collection_link}"
-          count_with_pseud:
-            one: "%{count} Work by %{byline}"
-            other: "%{count} Works by %{byline}"
-          count_with_query_and_pseud:
-            one: "%{count} Work found by %{byline}"
-            other: "%{count} Works found by %{byline}"
-          count_with_user:
-            one: "%{count} Work by %{username}"
-            other: "%{count} Works by %{username}"
-          count_with_query_and_user:
-            one: "%{count} Work found by %{username}"
-            other: "%{count} Works found by %{username}"
-          count_with_language:
-            one: "%{count} Work in %{language}"
-            other: "%{count} Works in %{language}"
-          count_with_query_and_language:
-            one: "%{count} Work found in %{language}"
-            other: "%{count} Works found in %{language}"
-          count_with_tag_html:
-            one: "%{count} Work in %{tag_link}"
-            other: "%{count} Works in %{tag_link}"
-          count_with_query_and_tag_html:
-            one: "%{count} Work found in %{tag_link}"
-            other: "%{count} Works found in %{tag_link}"
-          count_with_fandom_html:
-            one: "%{count} Work in %{fandom_link}"
-            other: "%{count} Works in %{fandom_link}"
-          count_with_query_and_fandom_html:
-            one: "%{count} Work found in %{fandom_link}"
-            other: "%{count} Works found in %{fandom_link}"
           count_with_collection_and_fandom_html:
             one: "%{count} Work in %{collection_link} in %{fandom_link}"
             other: "%{count} Works in %{collection_link} in %{fandom_link}"
-          count_with_query_and_collection_and_fandom_html:
-            one: "%{count} Work found in %{collection_link} in %{fandom_link}"
-            other: "%{count} Works found in %{collection_link} in %{fandom_link}"
-          count_with_pseud_and_fandom_html:
-            one: "%{count} Work by %{byline} in %{fandom_link}"
-            other: "%{count} Works by %{byline} in %{fandom_link}"
-          count_with_query_and_pseud_and_fandom_html:
-            one: "%{count} Work found by %{byline} in %{fandom_link}"
-            other: "%{count} Works found by %{byline} in %{fandom_link}"
-          count_with_user_and_fandom_html:
-            one: "%{count} Work by %{username} in %{fandom_link}"
-            other: "%{count} Works by %{username} in %{fandom_link}"
-          count_with_query_and_user_and_fandom_html:
-            one: "%{count} Work found by %{username} in %{fandom_link}"
-            other: "%{count} Works found by %{username} in %{fandom_link}"
+          count_with_collection_html:
+            one: "%{count} Work in %{collection_link}"
+            other: "%{count} Works in %{collection_link}"
+          count_with_fandom_html:
+            one: "%{count} Work in %{fandom_link}"
+            other: "%{count} Works in %{fandom_link}"
+          count_with_language:
+            one: "%{count} Work in %{language}"
+            other: "%{count} Works in %{language}"
           count_with_language_and_fandom_html:
             one: "%{count} Work in %{language} in %{fandom_link}"
             other: "%{count} Works in %{language} in %{fandom_link}"
+          count_with_pseud:
+            one: "%{count} Work by %{byline}"
+            other: "%{count} Works by %{byline}"
+          count_with_pseud_and_fandom_html:
+            one: "%{count} Work by %{byline} in %{fandom_link}"
+            other: "%{count} Works by %{byline} in %{fandom_link}"
+          count_with_query:
+            one: "%{count} Work found"
+            other: "%{count} Works found"
+          count_with_query_and_collection_and_fandom_html:
+            one: "%{count} Work found in %{collection_link} in %{fandom_link}"
+            other: "%{count} Works found in %{collection_link} in %{fandom_link}"
+          count_with_query_and_collection_html:
+            one: "%{count} Work found in %{collection_link}"
+            other: "%{count} Works found in %{collection_link}"
+          count_with_query_and_fandom_html:
+            one: "%{count} Work found in %{fandom_link}"
+            other: "%{count} Works found in %{fandom_link}"
+          count_with_query_and_language:
+            one: "%{count} Work found in %{language}"
+            other: "%{count} Works found in %{language}"
           count_with_query_and_language_and_fandom_html:
             one: "%{count} Work found in %{language} in %{fandom_link}"
             other: "%{count} Works found in %{language} in %{fandom_link}"
-          count_with_tag_and_fandom_html:
-            one: "%{count} Work in %{tag_link} in %{fandom_link}"
-            other: "%{count} Works in %{tag_link} in %{fandom_link}"
+          count_with_query_and_pseud:
+            one: "%{count} Work found by %{byline}"
+            other: "%{count} Works found by %{byline}"
+          count_with_query_and_pseud_and_fandom_html:
+            one: "%{count} Work found by %{byline} in %{fandom_link}"
+            other: "%{count} Works found by %{byline} in %{fandom_link}"
           count_with_query_and_tag_and_fandom_html:
             one: "%{count} Work found in %{tag_link} in %{fandom_link}"
             other: "%{count} Works found in %{tag_link} in %{fandom_link}"
+          count_with_query_and_tag_html:
+            one: "%{count} Work found in %{tag_link}"
+            other: "%{count} Works found in %{tag_link}"
+          count_with_query_and_user:
+            one: "%{count} Work found by %{username}"
+            other: "%{count} Works found by %{username}"
+          count_with_query_and_user_and_fandom_html:
+            one: "%{count} Work found by %{username} in %{fandom_link}"
+            other: "%{count} Works found by %{username} in %{fandom_link}"
+          count_with_tag_and_fandom_html:
+            one: "%{count} Work in %{tag_link} in %{fandom_link}"
+            other: "%{count} Works in %{tag_link} in %{fandom_link}"
+          count_with_tag_html:
+            one: "%{count} Work in %{tag_link}"
+            other: "%{count} Works in %{tag_link}"
+          count_with_user:
+            one: "%{count} Work by %{username}"
+            other: "%{count} Works by %{username}"
+          count_with_user_and_fandom_html:
+            one: "%{count} Work by %{username} in %{fandom_link}"
+            other: "%{count} Works by %{username} in %{fandom_link}"
           range:
             one: "%{start_number} - %{end_number} of %{total} Work"
             other: "%{start_number} - %{end_number} of %{total} Works"
-          range_with_query:
-            one: "%{start_number} - %{end_number} of %{total} Work found"
-            other: "%{start_number} - %{end_number} of %{total} Works found"
-          range_with_collection_html:
-            one: "%{start_number} - %{end_number} of %{total} Work in %{collection_link}"
-            other: "%{start_number} - %{end_number} of %{total} Works in %{collection_link}"
-          range_with_query_and_collection_html:
-            one: "%{start_number} - %{end_number} of %{total} Work found in %{collection_link}"
-            other: "%{start_number} - %{end_number} of %{total} Works found in %{collection_link}"
-          range_with_pseud:
-            one: "%{start_number} - %{end_number} of %{total} Work by %{byline}"
-            other: "%{start_number} - %{end_number} of %{total} Works by %{byline}"
-          range_with_query_and_pseud:
-            one: "%{start_number} - %{end_number} of %{total} Work found by %{byline}"
-            other: "%{start_number} - %{end_number} of %{total} Works found by %{byline}"
-          range_with_user:
-            one: "%{start_number} - %{end_number} of %{total} Work by %{username}"
-            other: "%{start_number} - %{end_number} of %{total} Works by %{username}"
-          range_with_query_and_user:
-            one: "%{start_number} - %{end_number} of %{total} Work found by %{username}"
-            other: "%{start_number} - %{end_number} of %{total} Works found by %{username}"
-          range_with_language:
-            one: "%{start_number} - %{end_number} of %{total} Work in %{language}"
-            other: "%{start_number} - %{end_number} of %{total} Works in %{language}"
-          range_with_query_and_language:
-            one: "%{start_number} - %{end_number} of %{total} Work found in %{language}"
-            other: "%{start_number} - %{end_number} of %{total} Works found in %{language}"
-          range_with_tag_html:
-            one: "%{start_number} - %{end_number} of %{total} Work in %{tag_link}"
-            other: "%{start_number} - %{end_number} of %{total} Works in %{tag_link}"
-          range_with_query_and_tag_html:
-            one: "%{start_number} - %{end_number} of %{total} Work found in %{tag_link}"
-            other: "%{start_number} - %{end_number} of %{total} Works found in %{tag_link}"
-          range_with_fandom_html:
-            one: "%{start_number} - %{end_number} of %{total} Work in %{fandom_link}"
-            other: "%{start_number} - %{end_number} of %{total} Works in %{fandom_link}"
-          range_with_query_and_fandom_html:
-            one: "%{start_number} - %{end_number} of %{total} Work found in %{fandom_link}"
-            other: "%{start_number} - %{end_number} of %{total} Works found in %{fandom_link}"
           range_with_collection_and_fandom_html:
             one: "%{start_number} - %{end_number} of %{total} Work in %{collection_link} in %{fandom_link}"
             other: "%{start_number} - %{end_number} of %{total} Works in %{collection_link} in %{fandom_link}"
-          range_with_query_and_collection_and_fandom_html:
-            one: "%{start_number} - %{end_number} of %{total} Work found in %{collection_link} in %{fandom_link}"
-            other: "%{start_number} - %{end_number} of %{total} Works found in %{collection_link} in %{fandom_link}"
-          range_with_pseud_and_fandom_html:
-            one: "%{start_number} - %{end_number} of %{total} Work by %{byline} in %{fandom_link}"
-            other: "%{start_number} - %{end_number} of %{total} Works by %{byline} in %{fandom_link}"
-          range_with_query_and_pseud_and_fandom_html:
-            one: "%{start_number} - %{end_number} of %{total} Work found by %{byline} in %{fandom_link}"
-            other: "%{start_number} - %{end_number} of %{total} Works found by %{byline} in %{fandom_link}"
-          range_with_user_and_fandom_html:
-            one: "%{start_number} - %{end_number} of %{total} Work by %{username} in %{fandom_link}"
-            other: "%{start_number} - %{end_number} of %{total} Works by %{username} in %{fandom_link}"
-          range_with_query_and_user_and_fandom_html:
-            one: "%{start_number} - %{end_number} of %{total} Work found by %{username} in %{fandom_link}"
-            other: "%{start_number} - %{end_number} of %{total} Works found by %{username} in %{fandom_link}"
+          range_with_collection_html:
+            one: "%{start_number} - %{end_number} of %{total} Work in %{collection_link}"
+            other: "%{start_number} - %{end_number} of %{total} Works in %{collection_link}"
+          range_with_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} Work in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Works in %{fandom_link}"
+          range_with_language:
+            one: "%{start_number} - %{end_number} of %{total} Work in %{language}"
+            other: "%{start_number} - %{end_number} of %{total} Works in %{language}"
           range_with_language_and_fandom_html:
             one: "%{start_number} - %{end_number} of %{total} Work in %{language} in %{fandom_link}"
             other: "%{start_number} - %{end_number} of %{total} Works in %{language} in %{fandom_link}"
+          range_with_pseud:
+            one: "%{start_number} - %{end_number} of %{total} Work by %{byline}"
+            other: "%{start_number} - %{end_number} of %{total} Works by %{byline}"
+          range_with_pseud_and_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} Work by %{byline} in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Works by %{byline} in %{fandom_link}"
+          range_with_query:
+            one: "%{start_number} - %{end_number} of %{total} Work found"
+            other: "%{start_number} - %{end_number} of %{total} Works found"
+          range_with_query_and_collection_and_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} Work found in %{collection_link} in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Works found in %{collection_link} in %{fandom_link}"
+          range_with_query_and_collection_html:
+            one: "%{start_number} - %{end_number} of %{total} Work found in %{collection_link}"
+            other: "%{start_number} - %{end_number} of %{total} Works found in %{collection_link}"
+          range_with_query_and_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} Work found in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Works found in %{fandom_link}"
+          range_with_query_and_language:
+            one: "%{start_number} - %{end_number} of %{total} Work found in %{language}"
+            other: "%{start_number} - %{end_number} of %{total} Works found in %{language}"
           range_with_query_and_language_and_fandom_html:
             one: "%{start_number} - %{end_number} of %{total} Work found in %{language} in %{fandom_link}"
             other: "%{start_number} - %{end_number} of %{total} Works found in %{language} in %{fandom_link}"
-          range_with_tag_and_fandom_html:
-            one: "%{start_number} - %{end_number} of %{total} Work in %{tag_link} in %{fandom_link}"
-            other: "%{start_number} - %{end_number} of %{total} Works in %{tag_link} in %{fandom_link}"
+          range_with_query_and_pseud:
+            one: "%{start_number} - %{end_number} of %{total} Work found by %{byline}"
+            other: "%{start_number} - %{end_number} of %{total} Works found by %{byline}"
+          range_with_query_and_pseud_and_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} Work found by %{byline} in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Works found by %{byline} in %{fandom_link}"
           range_with_query_and_tag_and_fandom_html:
             one: "%{start_number} - %{end_number} of %{total} Work found in %{tag_link} in %{fandom_link}"
             other: "%{start_number} - %{end_number} of %{total} Works found in %{tag_link} in %{fandom_link}"
+          range_with_query_and_tag_html:
+            one: "%{start_number} - %{end_number} of %{total} Work found in %{tag_link}"
+            other: "%{start_number} - %{end_number} of %{total} Works found in %{tag_link}"
+          range_with_query_and_user:
+            one: "%{start_number} - %{end_number} of %{total} Work found by %{username}"
+            other: "%{start_number} - %{end_number} of %{total} Works found by %{username}"
+          range_with_query_and_user_and_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} Work found by %{username} in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Works found by %{username} in %{fandom_link}"
+          range_with_tag_and_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} Work in %{tag_link} in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Works in %{tag_link} in %{fandom_link}"
+          range_with_tag_html:
+            one: "%{start_number} - %{end_number} of %{total} Work in %{tag_link}"
+            other: "%{start_number} - %{end_number} of %{total} Works in %{tag_link}"
+          range_with_user:
+            one: "%{start_number} - %{end_number} of %{total} Work by %{username}"
+            other: "%{start_number} - %{end_number} of %{total} Works by %{username}"
+          range_with_user_and_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} Work by %{username} in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Works by %{username} in %{fandom_link}"
           recent:
-            one: "Recent Work"
-            other: "Recent Works"
-          recent_with_query:
-            one: "Recent Work found"
-            other: "Recent Works found"
-          recent_with_collection_html:
-            one: "Recent Work in %{collection_link}"
-            other: "Recent Works in %{collection_link}"
-          recent_with_query_and_collection_html:
-            one: "Recent Work found in %{collection_link}"
-            other: "Recent Works found in %{collection_link}"
-          recent_with_pseud:
-            one: "Recent Work by %{byline}"
-            other: "Recent Works by %{byline}"
-          recent_with_query_and_pseud:
-            one: "Recent Work found by %{byline}"
-            other: "Recent Works found by %{byline}"
-          recent_with_user:
-            one: "Recent Work by %{username}"
-            other: "Recent Works by %{username}"
-          recent_with_query_and_user:
-            one: "Recent Work found by %{username}"
-            other: "Recent Works found by %{username}"
-          recent_with_language:
-            one: "Recent Work in %{language}"
-            other: "Recent Works in %{language}"
-          recent_with_query_and_language:
-            one: "Recent Work found in %{language}"
-            other: "Recent Works found in %{language}"
-          recent_with_tag_html:
-            one: "Recent Work in %{tag_link}"
-            other: "Recent Works in %{tag_link}"
-          recent_with_query_and_tag_html:
-            one: "Recent Work found in %{tag_link}"
-            other: "Recent Works found in %{tag_link}"
-          recent_with_fandom_html:
-            one: "Recent Work in %{fandom_link}"
-            other: "Recent Works in %{fandom_link}"
-          recent_with_query_and_fandom_html:
-            one: "Recent Work found in %{fandom_link}"
-            other: "Recent Works found in %{fandom_link}"
+            one: Recent Work
+            other: Recent Works
           recent_with_collection_and_fandom_html:
-            one: "Recent Work in %{collection_link} in %{fandom_link}"
-            other: "Recent Works in %{collection_link} in %{fandom_link}"
-          recent_with_query_and_collection_and_fandom_html:
-            one: "Recent Work found in %{collection_link} in %{fandom_link}"
-            other: "Recent Works found in %{collection_link} in %{fandom_link}"
-          recent_with_pseud_and_fandom_html:
-            one: "Recent Work by %{byline} in %{fandom_link}"
-            other: "Recent Works by %{byline} in %{fandom_link}"
-          recent_with_query_and_pseud_and_fandom_html:
-            one: "Recent Work found by %{byline} in %{fandom_link}"
-            other: "Recent Works found by %{byline} in %{fandom_link}"
-          recent_with_user_and_fandom_html:
-            one: "Recent Work by %{username} in %{fandom_link}"
-            other: "Recent Works by %{username} in %{fandom_link}"
-          recent_with_query_and_user_and_fandom_html:
-            one: "Recent Work found by %{username} in %{fandom_link}"
-            other: "Recent Works found by %{username} in %{fandom_link}"
+            one: Recent Work in %{collection_link} in %{fandom_link}
+            other: Recent Works in %{collection_link} in %{fandom_link}
+          recent_with_collection_html:
+            one: Recent Work in %{collection_link}
+            other: Recent Works in %{collection_link}
+          recent_with_fandom_html:
+            one: Recent Work in %{fandom_link}
+            other: Recent Works in %{fandom_link}
+          recent_with_language:
+            one: Recent Work in %{language}
+            other: Recent Works in %{language}
           recent_with_language_and_fandom_html:
-            one: "Recent Work in %{language} in %{fandom_link}"
-            other: "Recent Works in %{language} in %{fandom_link}"
+            one: Recent Work in %{language} in %{fandom_link}
+            other: Recent Works in %{language} in %{fandom_link}
+          recent_with_pseud:
+            one: Recent Work by %{byline}
+            other: Recent Works by %{byline}
+          recent_with_pseud_and_fandom_html:
+            one: Recent Work by %{byline} in %{fandom_link}
+            other: Recent Works by %{byline} in %{fandom_link}
+          recent_with_query:
+            one: Recent Work found
+            other: Recent Works found
+          recent_with_query_and_collection_and_fandom_html:
+            one: Recent Work found in %{collection_link} in %{fandom_link}
+            other: Recent Works found in %{collection_link} in %{fandom_link}
+          recent_with_query_and_collection_html:
+            one: Recent Work found in %{collection_link}
+            other: Recent Works found in %{collection_link}
+          recent_with_query_and_fandom_html:
+            one: Recent Work found in %{fandom_link}
+            other: Recent Works found in %{fandom_link}
+          recent_with_query_and_language:
+            one: Recent Work found in %{language}
+            other: Recent Works found in %{language}
           recent_with_query_and_language_and_fandom_html:
-            one: "Recent Work found in %{language} in %{fandom_link}"
-            other: "Recent Works found in %{language} in %{fandom_link}"
-          recent_with_tag_and_fandom_html:
-            one: "Recent Work in %{tag_link} in %{fandom_link}"
-            other: "Recent Works in %{tag_link} in %{fandom_link}"
+            one: Recent Work found in %{language} in %{fandom_link}
+            other: Recent Works found in %{language} in %{fandom_link}
+          recent_with_query_and_pseud:
+            one: Recent Work found by %{byline}
+            other: Recent Works found by %{byline}
+          recent_with_query_and_pseud_and_fandom_html:
+            one: Recent Work found by %{byline} in %{fandom_link}
+            other: Recent Works found by %{byline} in %{fandom_link}
           recent_with_query_and_tag_and_fandom_html:
-            one: "Recent Work found in %{tag_link} in %{fandom_link}"
-            other: "Recent Works found in %{tag_link} in %{fandom_link}"
+            one: Recent Work found in %{tag_link} in %{fandom_link}
+            other: Recent Works found in %{tag_link} in %{fandom_link}
+          recent_with_query_and_tag_html:
+            one: Recent Work found in %{tag_link}
+            other: Recent Works found in %{tag_link}
+          recent_with_query_and_user:
+            one: Recent Work found by %{username}
+            other: Recent Works found by %{username}
+          recent_with_query_and_user_and_fandom_html:
+            one: Recent Work found by %{username} in %{fandom_link}
+            other: Recent Works found by %{username} in %{fandom_link}
+          recent_with_tag_and_fandom_html:
+            one: Recent Work in %{tag_link} in %{fandom_link}
+            other: Recent Works in %{tag_link} in %{fandom_link}
+          recent_with_tag_html:
+            one: Recent Work in %{tag_link}
+            other: Recent Works in %{tag_link}
+          recent_with_user:
+            one: Recent Work by %{username}
+            other: Recent Works by %{username}
+          recent_with_user_and_fandom_html:
+            one: Recent Work by %{username} in %{fandom_link}
+            other: Recent Works by %{username} in %{fandom_link}
     search_results_found: "%{count} Found"
   series_helper:
     series_description_html: Part %{index} of %{series_link}

--- a/config/locales/helpers/en.yml
+++ b/config/locales/helpers/en.yml
@@ -46,119 +46,2177 @@ en:
       default_label: QR code
   search_helper:
     search_header:
-      default_html: "%{results}"
       items:
         bookmark:
           count:
             one: "%{count} Bookmark"
             other: "%{count} Bookmarks"
+          count_with_query:
+            one: "%{count} Bookmark found"
+            other: "%{count} Bookmarks found"
+          count_with_collection_html:
+            one: "%{count} Bookmark in %{collection_link}"
+            other: "%{count} Bookmarks in %{collection_link}"
+          count_with_query_and_collection_html:
+            one: "%{count} Bookmark found in %{collection_link}"
+            other: "%{count} Bookmarks found in %{collection_link}"
+          count_with_pseud:
+            one: "%{count} Bookmark by %{byline}"
+            other: "%{count} Bookmarks by %{byline}"
+          count_with_query_and_pseud:
+            one: "%{count} Bookmark found by %{byline}"
+            other: "%{count} Bookmarks found by %{byline}"
+          count_with_user:
+            one: "%{count} Bookmark by %{username}"
+            other: "%{count} Bookmarks by %{username}"
+          count_with_query_and_user:
+            one: "%{count} Bookmark found by %{username}"
+            other: "%{count} Bookmarks found by %{username}"
+          count_with_language:
+            one: "%{count} Bookmark in %{language}"
+            other: "%{count} Bookmarks in %{language}"
+          count_with_query_and_language:
+            one: "%{count} Bookmark found in %{language}"
+            other: "%{count} Bookmarks found in %{language}"
+          count_with_tag_html:
+            one: "%{count} Bookmark in %{tag_link}"
+            other: "%{count} Bookmarks in %{tag_link}"
+          count_with_query_and_tag_html:
+            one: "%{count} Bookmark found in %{tag_link}"
+            other: "%{count} Bookmarks found in %{tag_link}"
+          count_with_fandom_html:
+            one: "%{count} Bookmark in %{fandom_link}"
+            other: "%{count} Bookmarks in %{fandom_link}"
+          count_with_query_and_fandom_html:
+            one: "%{count} Bookmark found in %{fandom_link}"
+            other: "%{count} Bookmarks found in %{fandom_link}"
+          count_with_collection_and_fandom_html:
+            one: "%{count} Bookmark in %{collection_link} in %{fandom_link}"
+            other: "%{count} Bookmarks in %{collection_link} in %{fandom_link}"
+          count_with_query_and_collection_and_fandom_html:
+            one: "%{count} Bookmark found in %{collection_link} in %{fandom_link}"
+            other: "%{count} Bookmarks found in %{collection_link} in %{fandom_link}"
+          count_with_pseud_and_fandom_html:
+            one: "%{count} Bookmark by %{byline} in %{fandom_link}"
+            other: "%{count} Bookmarks by %{byline} in %{fandom_link}"
+          count_with_query_and_pseud_and_fandom_html:
+            one: "%{count} Bookmark found by %{byline} in %{fandom_link}"
+            other: "%{count} Bookmarks found by %{byline} in %{fandom_link}"
+          count_with_user_and_fandom_html:
+            one: "%{count} Bookmark by %{username} in %{fandom_link}"
+            other: "%{count} Bookmarks by %{username} in %{fandom_link}"
+          count_with_query_and_user_and_fandom_html:
+            one: "%{count} Bookmark found by %{username} in %{fandom_link}"
+            other: "%{count} Bookmarks found by %{username} in %{fandom_link}"
+          count_with_language_and_fandom_html:
+            one: "%{count} Bookmark in %{language} in %{fandom_link}"
+            other: "%{count} Bookmarks in %{language} in %{fandom_link}"
+          count_with_query_and_language_and_fandom_html:
+            one: "%{count} Bookmark found in %{language} in %{fandom_link}"
+            other: "%{count} Bookmarks found in %{language} in %{fandom_link}"
+          count_with_tag_and_fandom_html:
+            one: "%{count} Bookmark in %{tag_link} in %{fandom_link}"
+            other: "%{count} Bookmarks in %{tag_link} in %{fandom_link}"
+          count_with_query_and_tag_and_fandom_html:
+            one: "%{count} Bookmark found in %{tag_link} in %{fandom_link}"
+            other: "%{count} Bookmarks found in %{tag_link} in %{fandom_link}"
           range:
             one: "%{start_number} - %{end_number} of %{total} Bookmark"
             other: "%{start_number} - %{end_number} of %{total} Bookmarks"
+          range_with_query:
+            one: "%{start_number} - %{end_number} of %{total} Bookmark found"
+            other: "%{start_number} - %{end_number} of %{total} Bookmarks found"
+          range_with_collection_html:
+            one: "%{start_number} - %{end_number} of %{total} Bookmark in %{collection_link}"
+            other: "%{start_number} - %{end_number} of %{total} Bookmarks in %{collection_link}"
+          range_with_query_and_collection_html:
+            one: "%{start_number} - %{end_number} of %{total} Bookmark found in %{collection_link}"
+            other: "%{start_number} - %{end_number} of %{total} Bookmarks found in %{collection_link}"
+          range_with_pseud:
+            one: "%{start_number} - %{end_number} of %{total} Bookmark by %{byline}"
+            other: "%{start_number} - %{end_number} of %{total} Bookmarks by %{byline}"
+          range_with_query_and_pseud:
+            one: "%{start_number} - %{end_number} of %{total} Bookmark found by %{byline}"
+            other: "%{start_number} - %{end_number} of %{total} Bookmarks found by %{byline}"
+          range_with_user:
+            one: "%{start_number} - %{end_number} of %{total} Bookmark by %{username}"
+            other: "%{start_number} - %{end_number} of %{total} Bookmarks by %{username}"
+          range_with_query_and_user:
+            one: "%{start_number} - %{end_number} of %{total} Bookmark found by %{username}"
+            other: "%{start_number} - %{end_number} of %{total} Bookmarks found by %{username}"
+          range_with_language:
+            one: "%{start_number} - %{end_number} of %{total} Bookmark in %{language}"
+            other: "%{start_number} - %{end_number} of %{total} Bookmarks in %{language}"
+          range_with_query_and_language:
+            one: "%{start_number} - %{end_number} of %{total} Bookmark found in %{language}"
+            other: "%{start_number} - %{end_number} of %{total} Bookmarks found in %{language}"
+          range_with_tag_html:
+            one: "%{start_number} - %{end_number} of %{total} Bookmark in %{tag_link}"
+            other: "%{start_number} - %{end_number} of %{total} Bookmarks in %{tag_link}"
+          range_with_query_and_tag_html:
+            one: "%{start_number} - %{end_number} of %{total} Bookmark found in %{tag_link}"
+            other: "%{start_number} - %{end_number} of %{total} Bookmarks found in %{tag_link}"
+          range_with_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} Bookmark in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Bookmarks in %{fandom_link}"
+          range_with_query_and_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} Bookmark found in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Bookmarks found in %{fandom_link}"
+          range_with_collection_and_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} Bookmark in %{collection_link} in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Bookmarks in %{collection_link} in %{fandom_link}"
+          range_with_query_and_collection_and_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} Bookmark found in %{collection_link} in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Bookmarks found in %{collection_link} in %{fandom_link}"
+          range_with_pseud_and_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} Bookmark by %{byline} in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Bookmarks by %{byline} in %{fandom_link}"
+          range_with_query_and_pseud_and_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} Bookmark found by %{byline} in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Bookmarks found by %{byline} in %{fandom_link}"
+          range_with_user_and_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} Bookmark by %{username} in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Bookmarks by %{username} in %{fandom_link}"
+          range_with_query_and_user_and_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} Bookmark found by %{username} in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Bookmarks found by %{username} in %{fandom_link}"
+          range_with_language_and_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} Bookmark in %{language} in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Bookmarks in %{language} in %{fandom_link}"
+          range_with_query_and_language_and_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} Bookmark found in %{language} in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Bookmarks found in %{language} in %{fandom_link}"
+          range_with_tag_and_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} Bookmark in %{tag_link} in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Bookmarks in %{tag_link} in %{fandom_link}"
+          range_with_query_and_tag_and_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} Bookmark found in %{tag_link} in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Bookmarks found in %{tag_link} in %{fandom_link}"
           recent:
-            one: Recent Bookmark
-            other: Recent Bookmarks
+            one: "Recent Bookmark"
+            other: "Recent Bookmarks"
+          recent_with_query:
+            one: "Recent Bookmark found"
+            other: "Recent Bookmarks found"
+          recent_with_collection_html:
+            one: "Recent Bookmark in %{collection_link}"
+            other: "Recent Bookmarks in %{collection_link}"
+          recent_with_query_and_collection_html:
+            one: "Recent Bookmark found in %{collection_link}"
+            other: "Recent Bookmarks found in %{collection_link}"
+          recent_with_pseud:
+            one: "Recent Bookmark by %{byline}"
+            other: "Recent Bookmarks by %{byline}"
+          recent_with_query_and_pseud:
+            one: "Recent Bookmark found by %{byline}"
+            other: "Recent Bookmarks found by %{byline}"
+          recent_with_user:
+            one: "Recent Bookmark by %{username}"
+            other: "Recent Bookmarks by %{username}"
+          recent_with_query_and_user:
+            one: "Recent Bookmark found by %{username}"
+            other: "Recent Bookmarks found by %{username}"
+          recent_with_language:
+            one: "Recent Bookmark in %{language}"
+            other: "Recent Bookmarks in %{language}"
+          recent_with_query_and_language:
+            one: "Recent Bookmark found in %{language}"
+            other: "Recent Bookmarks found in %{language}"
+          recent_with_tag_html:
+            one: "Recent Bookmark in %{tag_link}"
+            other: "Recent Bookmarks in %{tag_link}"
+          recent_with_query_and_tag_html:
+            one: "Recent Bookmark found in %{tag_link}"
+            other: "Recent Bookmarks found in %{tag_link}"
+          recent_with_fandom_html:
+            one: "Recent Bookmark in %{fandom_link}"
+            other: "Recent Bookmarks in %{fandom_link}"
+          recent_with_query_and_fandom_html:
+            one: "Recent Bookmark found in %{fandom_link}"
+            other: "Recent Bookmarks found in %{fandom_link}"
+          recent_with_collection_and_fandom_html:
+            one: "Recent Bookmark in %{collection_link} in %{fandom_link}"
+            other: "Recent Bookmarks in %{collection_link} in %{fandom_link}"
+          recent_with_query_and_collection_and_fandom_html:
+            one: "Recent Bookmark found in %{collection_link} in %{fandom_link}"
+            other: "Recent Bookmarks found in %{collection_link} in %{fandom_link}"
+          recent_with_pseud_and_fandom_html:
+            one: "Recent Bookmark by %{byline} in %{fandom_link}"
+            other: "Recent Bookmarks by %{byline} in %{fandom_link}"
+          recent_with_query_and_pseud_and_fandom_html:
+            one: "Recent Bookmark found by %{byline} in %{fandom_link}"
+            other: "Recent Bookmarks found by %{byline} in %{fandom_link}"
+          recent_with_user_and_fandom_html:
+            one: "Recent Bookmark by %{username} in %{fandom_link}"
+            other: "Recent Bookmarks by %{username} in %{fandom_link}"
+          recent_with_query_and_user_and_fandom_html:
+            one: "Recent Bookmark found by %{username} in %{fandom_link}"
+            other: "Recent Bookmarks found by %{username} in %{fandom_link}"
+          recent_with_language_and_fandom_html:
+            one: "Recent Bookmark in %{language} in %{fandom_link}"
+            other: "Recent Bookmarks in %{language} in %{fandom_link}"
+          recent_with_query_and_language_and_fandom_html:
+            one: "Recent Bookmark found in %{language} in %{fandom_link}"
+            other: "Recent Bookmarks found in %{language} in %{fandom_link}"
+          recent_with_tag_and_fandom_html:
+            one: "Recent Bookmark in %{tag_link} in %{fandom_link}"
+            other: "Recent Bookmarks in %{tag_link} in %{fandom_link}"
+          recent_with_query_and_tag_and_fandom_html:
+            one: "Recent Bookmark found in %{tag_link} in %{fandom_link}"
+            other: "Recent Bookmarks found in %{tag_link} in %{fandom_link}"
         bookmarked_item:
           count:
             one: "%{count} Bookmarked Item"
             other: "%{count} Bookmarked Items"
+          count_with_query:
+            one: "%{count} Bookmarked Item found"
+            other: "%{count} Bookmarked Items found"
+          count_with_collection_html:
+            one: "%{count} Bookmarked Item in %{collection_link}"
+            other: "%{count} Bookmarked Items in %{collection_link}"
+          count_with_query_and_collection_html:
+            one: "%{count} Bookmarked Item found in %{collection_link}"
+            other: "%{count} Bookmarked Items found in %{collection_link}"
+          count_with_pseud:
+            one: "%{count} Bookmarked Item by %{byline}"
+            other: "%{count} Bookmarked Items by %{byline}"
+          count_with_query_and_pseud:
+            one: "%{count} Bookmarked Item found by %{byline}"
+            other: "%{count} Bookmarked Items found by %{byline}"
+          count_with_user:
+            one: "%{count} Bookmarked Item by %{username}"
+            other: "%{count} Bookmarked Items by %{username}"
+          count_with_query_and_user:
+            one: "%{count} Bookmarked Item found by %{username}"
+            other: "%{count} Bookmarked Items found by %{username}"
+          count_with_language:
+            one: "%{count} Bookmarked Item in %{language}"
+            other: "%{count} Bookmarked Items in %{language}"
+          count_with_query_and_language:
+            one: "%{count} Bookmarked Item found in %{language}"
+            other: "%{count} Bookmarked Items found in %{language}"
+          count_with_tag_html:
+            one: "%{count} Bookmarked Item in %{tag_link}"
+            other: "%{count} Bookmarked Items in %{tag_link}"
+          count_with_query_and_tag_html:
+            one: "%{count} Bookmarked Item found in %{tag_link}"
+            other: "%{count} Bookmarked Items found in %{tag_link}"
+          count_with_fandom_html:
+            one: "%{count} Bookmarked Item in %{fandom_link}"
+            other: "%{count} Bookmarked Items in %{fandom_link}"
+          count_with_query_and_fandom_html:
+            one: "%{count} Bookmarked Item found in %{fandom_link}"
+            other: "%{count} Bookmarked Items found in %{fandom_link}"
+          count_with_collection_and_fandom_html:
+            one: "%{count} Bookmarked Item in %{collection_link} in %{fandom_link}"
+            other: "%{count} Bookmarked Items in %{collection_link} in %{fandom_link}"
+          count_with_query_and_collection_and_fandom_html:
+            one: "%{count} Bookmarked Item found in %{collection_link} in %{fandom_link}"
+            other: "%{count} Bookmarked Items found in %{collection_link} in %{fandom_link}"
+          count_with_pseud_and_fandom_html:
+            one: "%{count} Bookmarked Item by %{byline} in %{fandom_link}"
+            other: "%{count} Bookmarked Items by %{byline} in %{fandom_link}"
+          count_with_query_and_pseud_and_fandom_html:
+            one: "%{count} Bookmarked Item found by %{byline} in %{fandom_link}"
+            other: "%{count} Bookmarked Items found by %{byline} in %{fandom_link}"
+          count_with_user_and_fandom_html:
+            one: "%{count} Bookmarked Item by %{username} in %{fandom_link}"
+            other: "%{count} Bookmarked Items by %{username} in %{fandom_link}"
+          count_with_query_and_user_and_fandom_html:
+            one: "%{count} Bookmarked Item found by %{username} in %{fandom_link}"
+            other: "%{count} Bookmarked Items found by %{username} in %{fandom_link}"
+          count_with_language_and_fandom_html:
+            one: "%{count} Bookmarked Item in %{language} in %{fandom_link}"
+            other: "%{count} Bookmarked Items in %{language} in %{fandom_link}"
+          count_with_query_and_language_and_fandom_html:
+            one: "%{count} Bookmarked Item found in %{language} in %{fandom_link}"
+            other: "%{count} Bookmarked Items found in %{language} in %{fandom_link}"
+          count_with_tag_and_fandom_html:
+            one: "%{count} Bookmarked Item in %{tag_link} in %{fandom_link}"
+            other: "%{count} Bookmarked Items in %{tag_link} in %{fandom_link}"
+          count_with_query_and_tag_and_fandom_html:
+            one: "%{count} Bookmarked Item found in %{tag_link} in %{fandom_link}"
+            other: "%{count} Bookmarked Items found in %{tag_link} in %{fandom_link}"
           range:
             one: "%{start_number} - %{end_number} of %{total} Bookmarked Item"
             other: "%{start_number} - %{end_number} of %{total} Bookmarked Items"
+          range_with_query:
+            one: "%{start_number} - %{end_number} of %{total} Bookmarked Item found"
+            other: "%{start_number} - %{end_number} of %{total} Bookmarked Items found"
+          range_with_collection_html:
+            one: "%{start_number} - %{end_number} of %{total} Bookmarked Item in %{collection_link}"
+            other: "%{start_number} - %{end_number} of %{total} Bookmarked Items in %{collection_link}"
+          range_with_query_and_collection_html:
+            one: "%{start_number} - %{end_number} of %{total} Bookmarked Item found in %{collection_link}"
+            other: "%{start_number} - %{end_number} of %{total} Bookmarked Items found in %{collection_link}"
+          range_with_pseud:
+            one: "%{start_number} - %{end_number} of %{total} Bookmarked Item by %{byline}"
+            other: "%{start_number} - %{end_number} of %{total} Bookmarked Items by %{byline}"
+          range_with_query_and_pseud:
+            one: "%{start_number} - %{end_number} of %{total} Bookmarked Item found by %{byline}"
+            other: "%{start_number} - %{end_number} of %{total} Bookmarked Items found by %{byline}"
+          range_with_user:
+            one: "%{start_number} - %{end_number} of %{total} Bookmarked Item by %{username}"
+            other: "%{start_number} - %{end_number} of %{total} Bookmarked Items by %{username}"
+          range_with_query_and_user:
+            one: "%{start_number} - %{end_number} of %{total} Bookmarked Item found by %{username}"
+            other: "%{start_number} - %{end_number} of %{total} Bookmarked Items found by %{username}"
+          range_with_language:
+            one: "%{start_number} - %{end_number} of %{total} Bookmarked Item in %{language}"
+            other: "%{start_number} - %{end_number} of %{total} Bookmarked Items in %{language}"
+          range_with_query_and_language:
+            one: "%{start_number} - %{end_number} of %{total} Bookmarked Item found in %{language}"
+            other: "%{start_number} - %{end_number} of %{total} Bookmarked Items found in %{language}"
+          range_with_tag_html:
+            one: "%{start_number} - %{end_number} of %{total} Bookmarked Item in %{tag_link}"
+            other: "%{start_number} - %{end_number} of %{total} Bookmarked Items in %{tag_link}"
+          range_with_query_and_tag_html:
+            one: "%{start_number} - %{end_number} of %{total} Bookmarked Item found in %{tag_link}"
+            other: "%{start_number} - %{end_number} of %{total} Bookmarked Items found in %{tag_link}"
+          range_with_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} Bookmarked Item in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Bookmarked Items in %{fandom_link}"
+          range_with_query_and_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} Bookmarked Item found in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Bookmarked Items found in %{fandom_link}"
+          range_with_collection_and_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} Bookmarked Item in %{collection_link} in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Bookmarked Items in %{collection_link} in %{fandom_link}"
+          range_with_query_and_collection_and_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} Bookmarked Item found in %{collection_link} in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Bookmarked Items found in %{collection_link} in %{fandom_link}"
+          range_with_pseud_and_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} Bookmarked Item by %{byline} in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Bookmarked Items by %{byline} in %{fandom_link}"
+          range_with_query_and_pseud_and_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} Bookmarked Item found by %{byline} in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Bookmarked Items found by %{byline} in %{fandom_link}"
+          range_with_user_and_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} Bookmarked Item by %{username} in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Bookmarked Items by %{username} in %{fandom_link}"
+          range_with_query_and_user_and_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} Bookmarked Item found by %{username} in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Bookmarked Items found by %{username} in %{fandom_link}"
+          range_with_language_and_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} Bookmarked Item in %{language} in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Bookmarked Items in %{language} in %{fandom_link}"
+          range_with_query_and_language_and_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} Bookmarked Item found in %{language} in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Bookmarked Items found in %{language} in %{fandom_link}"
+          range_with_tag_and_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} Bookmarked Item in %{tag_link} in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Bookmarked Items in %{tag_link} in %{fandom_link}"
+          range_with_query_and_tag_and_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} Bookmarked Item found in %{tag_link} in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Bookmarked Items found in %{tag_link} in %{fandom_link}"
           recent:
-            one: Recent Bookmarked Item
-            other: Recent Bookmarked Items
+            one: "Recent Bookmarked Item"
+            other: "Recent Bookmarked Items"
+          recent_with_query:
+            one: "Recent Bookmarked Item found"
+            other: "Recent Bookmarked Items found"
+          recent_with_collection_html:
+            one: "Recent Bookmarked Item in %{collection_link}"
+            other: "Recent Bookmarked Items in %{collection_link}"
+          recent_with_query_and_collection_html:
+            one: "Recent Bookmarked Item found in %{collection_link}"
+            other: "Recent Bookmarked Items found in %{collection_link}"
+          recent_with_pseud:
+            one: "Recent Bookmarked Item by %{byline}"
+            other: "Recent Bookmarked Items by %{byline}"
+          recent_with_query_and_pseud:
+            one: "Recent Bookmarked Item found by %{byline}"
+            other: "Recent Bookmarked Items found by %{byline}"
+          recent_with_user:
+            one: "Recent Bookmarked Item by %{username}"
+            other: "Recent Bookmarked Items by %{username}"
+          recent_with_query_and_user:
+            one: "Recent Bookmarked Item found by %{username}"
+            other: "Recent Bookmarked Items found by %{username}"
+          recent_with_language:
+            one: "Recent Bookmarked Item in %{language}"
+            other: "Recent Bookmarked Items in %{language}"
+          recent_with_query_and_language:
+            one: "Recent Bookmarked Item found in %{language}"
+            other: "Recent Bookmarked Items found in %{language}"
+          recent_with_tag_html:
+            one: "Recent Bookmarked Item in %{tag_link}"
+            other: "Recent Bookmarked Items in %{tag_link}"
+          recent_with_query_and_tag_html:
+            one: "Recent Bookmarked Item found in %{tag_link}"
+            other: "Recent Bookmarked Items found in %{tag_link}"
+          recent_with_fandom_html:
+            one: "Recent Bookmarked Item in %{fandom_link}"
+            other: "Recent Bookmarked Items in %{fandom_link}"
+          recent_with_query_and_fandom_html:
+            one: "Recent Bookmarked Item found in %{fandom_link}"
+            other: "Recent Bookmarked Items found in %{fandom_link}"
+          recent_with_collection_and_fandom_html:
+            one: "Recent Bookmarked Item in %{collection_link} in %{fandom_link}"
+            other: "Recent Bookmarked Items in %{collection_link} in %{fandom_link}"
+          recent_with_query_and_collection_and_fandom_html:
+            one: "Recent Bookmarked Item found in %{collection_link} in %{fandom_link}"
+            other: "Recent Bookmarked Items found in %{collection_link} in %{fandom_link}"
+          recent_with_pseud_and_fandom_html:
+            one: "Recent Bookmarked Item by %{byline} in %{fandom_link}"
+            other: "Recent Bookmarked Items by %{byline} in %{fandom_link}"
+          recent_with_query_and_pseud_and_fandom_html:
+            one: "Recent Bookmarked Item found by %{byline} in %{fandom_link}"
+            other: "Recent Bookmarked Items found by %{byline} in %{fandom_link}"
+          recent_with_user_and_fandom_html:
+            one: "Recent Bookmarked Item by %{username} in %{fandom_link}"
+            other: "Recent Bookmarked Items by %{username} in %{fandom_link}"
+          recent_with_query_and_user_and_fandom_html:
+            one: "Recent Bookmarked Item found by %{username} in %{fandom_link}"
+            other: "Recent Bookmarked Items found by %{username} in %{fandom_link}"
+          recent_with_language_and_fandom_html:
+            one: "Recent Bookmarked Item in %{language} in %{fandom_link}"
+            other: "Recent Bookmarked Items in %{language} in %{fandom_link}"
+          recent_with_query_and_language_and_fandom_html:
+            one: "Recent Bookmarked Item found in %{language} in %{fandom_link}"
+            other: "Recent Bookmarked Items found in %{language} in %{fandom_link}"
+          recent_with_tag_and_fandom_html:
+            one: "Recent Bookmarked Item in %{tag_link} in %{fandom_link}"
+            other: "Recent Bookmarked Items in %{tag_link} in %{fandom_link}"
+          recent_with_query_and_tag_and_fandom_html:
+            one: "Recent Bookmarked Item found in %{tag_link} in %{fandom_link}"
+            other: "Recent Bookmarked Items found in %{tag_link} in %{fandom_link}"
         challenge_signup:
           count:
             one: "%{count} Sign-up"
             other: "%{count} Sign-ups"
+          count_with_query:
+            one: "%{count} Sign-up found"
+            other: "%{count} Sign-ups found"
+          count_with_collection_html:
+            one: "%{count} Sign-up in %{collection_link}"
+            other: "%{count} Sign-ups in %{collection_link}"
+          count_with_query_and_collection_html:
+            one: "%{count} Sign-up found in %{collection_link}"
+            other: "%{count} Sign-ups found in %{collection_link}"
+          count_with_pseud:
+            one: "%{count} Sign-up by %{byline}"
+            other: "%{count} Sign-ups by %{byline}"
+          count_with_query_and_pseud:
+            one: "%{count} Sign-up found by %{byline}"
+            other: "%{count} Sign-ups found by %{byline}"
+          count_with_user:
+            one: "%{count} Sign-up by %{username}"
+            other: "%{count} Sign-ups by %{username}"
+          count_with_query_and_user:
+            one: "%{count} Sign-up found by %{username}"
+            other: "%{count} Sign-ups found by %{username}"
+          count_with_language:
+            one: "%{count} Sign-up in %{language}"
+            other: "%{count} Sign-ups in %{language}"
+          count_with_query_and_language:
+            one: "%{count} Sign-up found in %{language}"
+            other: "%{count} Sign-ups found in %{language}"
+          count_with_tag_html:
+            one: "%{count} Sign-up in %{tag_link}"
+            other: "%{count} Sign-ups in %{tag_link}"
+          count_with_query_and_tag_html:
+            one: "%{count} Sign-up found in %{tag_link}"
+            other: "%{count} Sign-ups found in %{tag_link}"
+          count_with_fandom_html:
+            one: "%{count} Sign-up in %{fandom_link}"
+            other: "%{count} Sign-ups in %{fandom_link}"
+          count_with_query_and_fandom_html:
+            one: "%{count} Sign-up found in %{fandom_link}"
+            other: "%{count} Sign-ups found in %{fandom_link}"
+          count_with_collection_and_fandom_html:
+            one: "%{count} Sign-up in %{collection_link} in %{fandom_link}"
+            other: "%{count} Sign-ups in %{collection_link} in %{fandom_link}"
+          count_with_query_and_collection_and_fandom_html:
+            one: "%{count} Sign-up found in %{collection_link} in %{fandom_link}"
+            other: "%{count} Sign-ups found in %{collection_link} in %{fandom_link}"
+          count_with_pseud_and_fandom_html:
+            one: "%{count} Sign-up by %{byline} in %{fandom_link}"
+            other: "%{count} Sign-ups by %{byline} in %{fandom_link}"
+          count_with_query_and_pseud_and_fandom_html:
+            one: "%{count} Sign-up found by %{byline} in %{fandom_link}"
+            other: "%{count} Sign-ups found by %{byline} in %{fandom_link}"
+          count_with_user_and_fandom_html:
+            one: "%{count} Sign-up by %{username} in %{fandom_link}"
+            other: "%{count} Sign-ups by %{username} in %{fandom_link}"
+          count_with_query_and_user_and_fandom_html:
+            one: "%{count} Sign-up found by %{username} in %{fandom_link}"
+            other: "%{count} Sign-ups found by %{username} in %{fandom_link}"
+          count_with_language_and_fandom_html:
+            one: "%{count} Sign-up in %{language} in %{fandom_link}"
+            other: "%{count} Sign-ups in %{language} in %{fandom_link}"
+          count_with_query_and_language_and_fandom_html:
+            one: "%{count} Sign-up found in %{language} in %{fandom_link}"
+            other: "%{count} Sign-ups found in %{language} in %{fandom_link}"
+          count_with_tag_and_fandom_html:
+            one: "%{count} Sign-up in %{tag_link} in %{fandom_link}"
+            other: "%{count} Sign-ups in %{tag_link} in %{fandom_link}"
+          count_with_query_and_tag_and_fandom_html:
+            one: "%{count} Sign-up found in %{tag_link} in %{fandom_link}"
+            other: "%{count} Sign-ups found in %{tag_link} in %{fandom_link}"
           range:
             one: "%{start_number} - %{end_number} of %{total} Sign-up"
             other: "%{start_number} - %{end_number} of %{total} Sign-ups"
+          range_with_query:
+            one: "%{start_number} - %{end_number} of %{total} Sign-up found"
+            other: "%{start_number} - %{end_number} of %{total} Sign-ups found"
+          range_with_collection_html:
+            one: "%{start_number} - %{end_number} of %{total} Sign-up in %{collection_link}"
+            other: "%{start_number} - %{end_number} of %{total} Sign-ups in %{collection_link}"
+          range_with_query_and_collection_html:
+            one: "%{start_number} - %{end_number} of %{total} Sign-up found in %{collection_link}"
+            other: "%{start_number} - %{end_number} of %{total} Sign-ups found in %{collection_link}"
+          range_with_pseud:
+            one: "%{start_number} - %{end_number} of %{total} Sign-up by %{byline}"
+            other: "%{start_number} - %{end_number} of %{total} Sign-ups by %{byline}"
+          range_with_query_and_pseud:
+            one: "%{start_number} - %{end_number} of %{total} Sign-up found by %{byline}"
+            other: "%{start_number} - %{end_number} of %{total} Sign-ups found by %{byline}"
+          range_with_user:
+            one: "%{start_number} - %{end_number} of %{total} Sign-up by %{username}"
+            other: "%{start_number} - %{end_number} of %{total} Sign-ups by %{username}"
+          range_with_query_and_user:
+            one: "%{start_number} - %{end_number} of %{total} Sign-up found by %{username}"
+            other: "%{start_number} - %{end_number} of %{total} Sign-ups found by %{username}"
+          range_with_language:
+            one: "%{start_number} - %{end_number} of %{total} Sign-up in %{language}"
+            other: "%{start_number} - %{end_number} of %{total} Sign-ups in %{language}"
+          range_with_query_and_language:
+            one: "%{start_number} - %{end_number} of %{total} Sign-up found in %{language}"
+            other: "%{start_number} - %{end_number} of %{total} Sign-ups found in %{language}"
+          range_with_tag_html:
+            one: "%{start_number} - %{end_number} of %{total} Sign-up in %{tag_link}"
+            other: "%{start_number} - %{end_number} of %{total} Sign-ups in %{tag_link}"
+          range_with_query_and_tag_html:
+            one: "%{start_number} - %{end_number} of %{total} Sign-up found in %{tag_link}"
+            other: "%{start_number} - %{end_number} of %{total} Sign-ups found in %{tag_link}"
+          range_with_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} Sign-up in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Sign-ups in %{fandom_link}"
+          range_with_query_and_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} Sign-up found in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Sign-ups found in %{fandom_link}"
+          range_with_collection_and_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} Sign-up in %{collection_link} in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Sign-ups in %{collection_link} in %{fandom_link}"
+          range_with_query_and_collection_and_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} Sign-up found in %{collection_link} in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Sign-ups found in %{collection_link} in %{fandom_link}"
+          range_with_pseud_and_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} Sign-up by %{byline} in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Sign-ups by %{byline} in %{fandom_link}"
+          range_with_query_and_pseud_and_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} Sign-up found by %{byline} in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Sign-ups found by %{byline} in %{fandom_link}"
+          range_with_user_and_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} Sign-up by %{username} in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Sign-ups by %{username} in %{fandom_link}"
+          range_with_query_and_user_and_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} Sign-up found by %{username} in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Sign-ups found by %{username} in %{fandom_link}"
+          range_with_language_and_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} Sign-up in %{language} in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Sign-ups in %{language} in %{fandom_link}"
+          range_with_query_and_language_and_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} Sign-up found in %{language} in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Sign-ups found in %{language} in %{fandom_link}"
+          range_with_tag_and_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} Sign-up in %{tag_link} in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Sign-ups in %{tag_link} in %{fandom_link}"
+          range_with_query_and_tag_and_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} Sign-up found in %{tag_link} in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Sign-ups found in %{tag_link} in %{fandom_link}"
           recent:
-            one: Recent Sign-up
-            other: Recent Sign-ups
+            one: "Recent Sign-up"
+            other: "Recent Sign-ups"
+          recent_with_query:
+            one: "Recent Sign-up found"
+            other: "Recent Sign-ups found"
+          recent_with_collection_html:
+            one: "Recent Sign-up in %{collection_link}"
+            other: "Recent Sign-ups in %{collection_link}"
+          recent_with_query_and_collection_html:
+            one: "Recent Sign-up found in %{collection_link}"
+            other: "Recent Sign-ups found in %{collection_link}"
+          recent_with_pseud:
+            one: "Recent Sign-up by %{byline}"
+            other: "Recent Sign-ups by %{byline}"
+          recent_with_query_and_pseud:
+            one: "Recent Sign-up found by %{byline}"
+            other: "Recent Sign-ups found by %{byline}"
+          recent_with_user:
+            one: "Recent Sign-up by %{username}"
+            other: "Recent Sign-ups by %{username}"
+          recent_with_query_and_user:
+            one: "Recent Sign-up found by %{username}"
+            other: "Recent Sign-ups found by %{username}"
+          recent_with_language:
+            one: "Recent Sign-up in %{language}"
+            other: "Recent Sign-ups in %{language}"
+          recent_with_query_and_language:
+            one: "Recent Sign-up found in %{language}"
+            other: "Recent Sign-ups found in %{language}"
+          recent_with_tag_html:
+            one: "Recent Sign-up in %{tag_link}"
+            other: "Recent Sign-ups in %{tag_link}"
+          recent_with_query_and_tag_html:
+            one: "Recent Sign-up found in %{tag_link}"
+            other: "Recent Sign-ups found in %{tag_link}"
+          recent_with_fandom_html:
+            one: "Recent Sign-up in %{fandom_link}"
+            other: "Recent Sign-ups in %{fandom_link}"
+          recent_with_query_and_fandom_html:
+            one: "Recent Sign-up found in %{fandom_link}"
+            other: "Recent Sign-ups found in %{fandom_link}"
+          recent_with_collection_and_fandom_html:
+            one: "Recent Sign-up in %{collection_link} in %{fandom_link}"
+            other: "Recent Sign-ups in %{collection_link} in %{fandom_link}"
+          recent_with_query_and_collection_and_fandom_html:
+            one: "Recent Sign-up found in %{collection_link} in %{fandom_link}"
+            other: "Recent Sign-ups found in %{collection_link} in %{fandom_link}"
+          recent_with_pseud_and_fandom_html:
+            one: "Recent Sign-up by %{byline} in %{fandom_link}"
+            other: "Recent Sign-ups by %{byline} in %{fandom_link}"
+          recent_with_query_and_pseud_and_fandom_html:
+            one: "Recent Sign-up found by %{byline} in %{fandom_link}"
+            other: "Recent Sign-ups found by %{byline} in %{fandom_link}"
+          recent_with_user_and_fandom_html:
+            one: "Recent Sign-up by %{username} in %{fandom_link}"
+            other: "Recent Sign-ups by %{username} in %{fandom_link}"
+          recent_with_query_and_user_and_fandom_html:
+            one: "Recent Sign-up found by %{username} in %{fandom_link}"
+            other: "Recent Sign-ups found by %{username} in %{fandom_link}"
+          recent_with_language_and_fandom_html:
+            one: "Recent Sign-up in %{language} in %{fandom_link}"
+            other: "Recent Sign-ups in %{language} in %{fandom_link}"
+          recent_with_query_and_language_and_fandom_html:
+            one: "Recent Sign-up found in %{language} in %{fandom_link}"
+            other: "Recent Sign-ups found in %{language} in %{fandom_link}"
+          recent_with_tag_and_fandom_html:
+            one: "Recent Sign-up in %{tag_link} in %{fandom_link}"
+            other: "Recent Sign-ups in %{tag_link} in %{fandom_link}"
+          recent_with_query_and_tag_and_fandom_html:
+            one: "Recent Sign-up found in %{tag_link} in %{fandom_link}"
+            other: "Recent Sign-ups found in %{tag_link} in %{fandom_link}"
         collection:
           count:
             one: "%{count} Collection"
             other: "%{count} Collections"
+          count_with_query:
+            one: "%{count} Collection found"
+            other: "%{count} Collections found"
+          count_with_collection_html:
+            one: "%{count} Collection in %{collection_link}"
+            other: "%{count} Collections in %{collection_link}"
+          count_with_query_and_collection_html:
+            one: "%{count} Collection found in %{collection_link}"
+            other: "%{count} Collections found in %{collection_link}"
+          count_with_pseud:
+            one: "%{count} Collection by %{byline}"
+            other: "%{count} Collections by %{byline}"
+          count_with_query_and_pseud:
+            one: "%{count} Collection found by %{byline}"
+            other: "%{count} Collections found by %{byline}"
+          count_with_user:
+            one: "%{count} Collection by %{username}"
+            other: "%{count} Collections by %{username}"
+          count_with_query_and_user:
+            one: "%{count} Collection found by %{username}"
+            other: "%{count} Collections found by %{username}"
+          count_with_language:
+            one: "%{count} Collection in %{language}"
+            other: "%{count} Collections in %{language}"
+          count_with_query_and_language:
+            one: "%{count} Collection found in %{language}"
+            other: "%{count} Collections found in %{language}"
+          count_with_tag_html:
+            one: "%{count} Collection in %{tag_link}"
+            other: "%{count} Collections in %{tag_link}"
+          count_with_query_and_tag_html:
+            one: "%{count} Collection found in %{tag_link}"
+            other: "%{count} Collections found in %{tag_link}"
+          count_with_fandom_html:
+            one: "%{count} Collection in %{fandom_link}"
+            other: "%{count} Collections in %{fandom_link}"
+          count_with_query_and_fandom_html:
+            one: "%{count} Collection found in %{fandom_link}"
+            other: "%{count} Collections found in %{fandom_link}"
+          count_with_collection_and_fandom_html:
+            one: "%{count} Collection in %{collection_link} in %{fandom_link}"
+            other: "%{count} Collections in %{collection_link} in %{fandom_link}"
+          count_with_query_and_collection_and_fandom_html:
+            one: "%{count} Collection found in %{collection_link} in %{fandom_link}"
+            other: "%{count} Collections found in %{collection_link} in %{fandom_link}"
+          count_with_pseud_and_fandom_html:
+            one: "%{count} Collection by %{byline} in %{fandom_link}"
+            other: "%{count} Collections by %{byline} in %{fandom_link}"
+          count_with_query_and_pseud_and_fandom_html:
+            one: "%{count} Collection found by %{byline} in %{fandom_link}"
+            other: "%{count} Collections found by %{byline} in %{fandom_link}"
+          count_with_user_and_fandom_html:
+            one: "%{count} Collection by %{username} in %{fandom_link}"
+            other: "%{count} Collections by %{username} in %{fandom_link}"
+          count_with_query_and_user_and_fandom_html:
+            one: "%{count} Collection found by %{username} in %{fandom_link}"
+            other: "%{count} Collections found by %{username} in %{fandom_link}"
+          count_with_language_and_fandom_html:
+            one: "%{count} Collection in %{language} in %{fandom_link}"
+            other: "%{count} Collections in %{language} in %{fandom_link}"
+          count_with_query_and_language_and_fandom_html:
+            one: "%{count} Collection found in %{language} in %{fandom_link}"
+            other: "%{count} Collections found in %{language} in %{fandom_link}"
+          count_with_tag_and_fandom_html:
+            one: "%{count} Collection in %{tag_link} in %{fandom_link}"
+            other: "%{count} Collections in %{tag_link} in %{fandom_link}"
+          count_with_query_and_tag_and_fandom_html:
+            one: "%{count} Collection found in %{tag_link} in %{fandom_link}"
+            other: "%{count} Collections found in %{tag_link} in %{fandom_link}"
           range:
             one: "%{start_number} - %{end_number} of %{total} Collection"
             other: "%{start_number} - %{end_number} of %{total} Collections"
+          range_with_query:
+            one: "%{start_number} - %{end_number} of %{total} Collection found"
+            other: "%{start_number} - %{end_number} of %{total} Collections found"
+          range_with_collection_html:
+            one: "%{start_number} - %{end_number} of %{total} Collection in %{collection_link}"
+            other: "%{start_number} - %{end_number} of %{total} Collections in %{collection_link}"
+          range_with_query_and_collection_html:
+            one: "%{start_number} - %{end_number} of %{total} Collection found in %{collection_link}"
+            other: "%{start_number} - %{end_number} of %{total} Collections found in %{collection_link}"
+          range_with_pseud:
+            one: "%{start_number} - %{end_number} of %{total} Collection by %{byline}"
+            other: "%{start_number} - %{end_number} of %{total} Collections by %{byline}"
+          range_with_query_and_pseud:
+            one: "%{start_number} - %{end_number} of %{total} Collection found by %{byline}"
+            other: "%{start_number} - %{end_number} of %{total} Collections found by %{byline}"
+          range_with_user:
+            one: "%{start_number} - %{end_number} of %{total} Collection by %{username}"
+            other: "%{start_number} - %{end_number} of %{total} Collections by %{username}"
+          range_with_query_and_user:
+            one: "%{start_number} - %{end_number} of %{total} Collection found by %{username}"
+            other: "%{start_number} - %{end_number} of %{total} Collections found by %{username}"
+          range_with_language:
+            one: "%{start_number} - %{end_number} of %{total} Collection in %{language}"
+            other: "%{start_number} - %{end_number} of %{total} Collections in %{language}"
+          range_with_query_and_language:
+            one: "%{start_number} - %{end_number} of %{total} Collection found in %{language}"
+            other: "%{start_number} - %{end_number} of %{total} Collections found in %{language}"
+          range_with_tag_html:
+            one: "%{start_number} - %{end_number} of %{total} Collection in %{tag_link}"
+            other: "%{start_number} - %{end_number} of %{total} Collections in %{tag_link}"
+          range_with_query_and_tag_html:
+            one: "%{start_number} - %{end_number} of %{total} Collection found in %{tag_link}"
+            other: "%{start_number} - %{end_number} of %{total} Collections found in %{tag_link}"
+          range_with_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} Collection in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Collections in %{fandom_link}"
+          range_with_query_and_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} Collection found in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Collections found in %{fandom_link}"
+          range_with_collection_and_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} Collection in %{collection_link} in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Collections in %{collection_link} in %{fandom_link}"
+          range_with_query_and_collection_and_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} Collection found in %{collection_link} in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Collections found in %{collection_link} in %{fandom_link}"
+          range_with_pseud_and_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} Collection by %{byline} in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Collections by %{byline} in %{fandom_link}"
+          range_with_query_and_pseud_and_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} Collection found by %{byline} in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Collections found by %{byline} in %{fandom_link}"
+          range_with_user_and_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} Collection by %{username} in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Collections by %{username} in %{fandom_link}"
+          range_with_query_and_user_and_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} Collection found by %{username} in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Collections found by %{username} in %{fandom_link}"
+          range_with_language_and_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} Collection in %{language} in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Collections in %{language} in %{fandom_link}"
+          range_with_query_and_language_and_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} Collection found in %{language} in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Collections found in %{language} in %{fandom_link}"
+          range_with_tag_and_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} Collection in %{tag_link} in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Collections in %{tag_link} in %{fandom_link}"
+          range_with_query_and_tag_and_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} Collection found in %{tag_link} in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Collections found in %{tag_link} in %{fandom_link}"
           recent:
-            one: Recent Collection
-            other: Recent Collections
+            one: "Recent Collection"
+            other: "Recent Collections"
+          recent_with_query:
+            one: "Recent Collection found"
+            other: "Recent Collections found"
+          recent_with_collection_html:
+            one: "Recent Collection in %{collection_link}"
+            other: "Recent Collections in %{collection_link}"
+          recent_with_query_and_collection_html:
+            one: "Recent Collection found in %{collection_link}"
+            other: "Recent Collections found in %{collection_link}"
+          recent_with_pseud:
+            one: "Recent Collection by %{byline}"
+            other: "Recent Collections by %{byline}"
+          recent_with_query_and_pseud:
+            one: "Recent Collection found by %{byline}"
+            other: "Recent Collections found by %{byline}"
+          recent_with_user:
+            one: "Recent Collection by %{username}"
+            other: "Recent Collections by %{username}"
+          recent_with_query_and_user:
+            one: "Recent Collection found by %{username}"
+            other: "Recent Collections found by %{username}"
+          recent_with_language:
+            one: "Recent Collection in %{language}"
+            other: "Recent Collections in %{language}"
+          recent_with_query_and_language:
+            one: "Recent Collection found in %{language}"
+            other: "Recent Collections found in %{language}"
+          recent_with_tag_html:
+            one: "Recent Collection in %{tag_link}"
+            other: "Recent Collections in %{tag_link}"
+          recent_with_query_and_tag_html:
+            one: "Recent Collection found in %{tag_link}"
+            other: "Recent Collections found in %{tag_link}"
+          recent_with_fandom_html:
+            one: "Recent Collection in %{fandom_link}"
+            other: "Recent Collections in %{fandom_link}"
+          recent_with_query_and_fandom_html:
+            one: "Recent Collection found in %{fandom_link}"
+            other: "Recent Collections found in %{fandom_link}"
+          recent_with_collection_and_fandom_html:
+            one: "Recent Collection in %{collection_link} in %{fandom_link}"
+            other: "Recent Collections in %{collection_link} in %{fandom_link}"
+          recent_with_query_and_collection_and_fandom_html:
+            one: "Recent Collection found in %{collection_link} in %{fandom_link}"
+            other: "Recent Collections found in %{collection_link} in %{fandom_link}"
+          recent_with_pseud_and_fandom_html:
+            one: "Recent Collection by %{byline} in %{fandom_link}"
+            other: "Recent Collections by %{byline} in %{fandom_link}"
+          recent_with_query_and_pseud_and_fandom_html:
+            one: "Recent Collection found by %{byline} in %{fandom_link}"
+            other: "Recent Collections found by %{byline} in %{fandom_link}"
+          recent_with_user_and_fandom_html:
+            one: "Recent Collection by %{username} in %{fandom_link}"
+            other: "Recent Collections by %{username} in %{fandom_link}"
+          recent_with_query_and_user_and_fandom_html:
+            one: "Recent Collection found by %{username} in %{fandom_link}"
+            other: "Recent Collections found by %{username} in %{fandom_link}"
+          recent_with_language_and_fandom_html:
+            one: "Recent Collection in %{language} in %{fandom_link}"
+            other: "Recent Collections in %{language} in %{fandom_link}"
+          recent_with_query_and_language_and_fandom_html:
+            one: "Recent Collection found in %{language} in %{fandom_link}"
+            other: "Recent Collections found in %{language} in %{fandom_link}"
+          recent_with_tag_and_fandom_html:
+            one: "Recent Collection in %{tag_link} in %{fandom_link}"
+            other: "Recent Collections in %{tag_link} in %{fandom_link}"
+          recent_with_query_and_tag_and_fandom_html:
+            one: "Recent Collection found in %{tag_link} in %{fandom_link}"
+            other: "Recent Collections found in %{tag_link} in %{fandom_link}"
         comment:
           count:
             one: "%{count} Comment"
             other: "%{count} Comments"
+          count_with_query:
+            one: "%{count} Comment found"
+            other: "%{count} Comments found"
+          count_with_collection_html:
+            one: "%{count} Comment in %{collection_link}"
+            other: "%{count} Comments in %{collection_link}"
+          count_with_query_and_collection_html:
+            one: "%{count} Comment found in %{collection_link}"
+            other: "%{count} Comments found in %{collection_link}"
+          count_with_pseud:
+            one: "%{count} Comment by %{byline}"
+            other: "%{count} Comments by %{byline}"
+          count_with_query_and_pseud:
+            one: "%{count} Comment found by %{byline}"
+            other: "%{count} Comments found by %{byline}"
+          count_with_user:
+            one: "%{count} Comment by %{username}"
+            other: "%{count} Comments by %{username}"
+          count_with_query_and_user:
+            one: "%{count} Comment found by %{username}"
+            other: "%{count} Comments found by %{username}"
+          count_with_language:
+            one: "%{count} Comment in %{language}"
+            other: "%{count} Comments in %{language}"
+          count_with_query_and_language:
+            one: "%{count} Comment found in %{language}"
+            other: "%{count} Comments found in %{language}"
+          count_with_tag_html:
+            one: "%{count} Comment in %{tag_link}"
+            other: "%{count} Comments in %{tag_link}"
+          count_with_query_and_tag_html:
+            one: "%{count} Comment found in %{tag_link}"
+            other: "%{count} Comments found in %{tag_link}"
+          count_with_fandom_html:
+            one: "%{count} Comment in %{fandom_link}"
+            other: "%{count} Comments in %{fandom_link}"
+          count_with_query_and_fandom_html:
+            one: "%{count} Comment found in %{fandom_link}"
+            other: "%{count} Comments found in %{fandom_link}"
+          count_with_collection_and_fandom_html:
+            one: "%{count} Comment in %{collection_link} in %{fandom_link}"
+            other: "%{count} Comments in %{collection_link} in %{fandom_link}"
+          count_with_query_and_collection_and_fandom_html:
+            one: "%{count} Comment found in %{collection_link} in %{fandom_link}"
+            other: "%{count} Comments found in %{collection_link} in %{fandom_link}"
+          count_with_pseud_and_fandom_html:
+            one: "%{count} Comment by %{byline} in %{fandom_link}"
+            other: "%{count} Comments by %{byline} in %{fandom_link}"
+          count_with_query_and_pseud_and_fandom_html:
+            one: "%{count} Comment found by %{byline} in %{fandom_link}"
+            other: "%{count} Comments found by %{byline} in %{fandom_link}"
+          count_with_user_and_fandom_html:
+            one: "%{count} Comment by %{username} in %{fandom_link}"
+            other: "%{count} Comments by %{username} in %{fandom_link}"
+          count_with_query_and_user_and_fandom_html:
+            one: "%{count} Comment found by %{username} in %{fandom_link}"
+            other: "%{count} Comments found by %{username} in %{fandom_link}"
+          count_with_language_and_fandom_html:
+            one: "%{count} Comment in %{language} in %{fandom_link}"
+            other: "%{count} Comments in %{language} in %{fandom_link}"
+          count_with_query_and_language_and_fandom_html:
+            one: "%{count} Comment found in %{language} in %{fandom_link}"
+            other: "%{count} Comments found in %{language} in %{fandom_link}"
+          count_with_tag_and_fandom_html:
+            one: "%{count} Comment in %{tag_link} in %{fandom_link}"
+            other: "%{count} Comments in %{tag_link} in %{fandom_link}"
+          count_with_query_and_tag_and_fandom_html:
+            one: "%{count} Comment found in %{tag_link} in %{fandom_link}"
+            other: "%{count} Comments found in %{tag_link} in %{fandom_link}"
           range:
             one: "%{start_number} - %{end_number} of %{total} Comment"
             other: "%{start_number} - %{end_number} of %{total} Comments"
+          range_with_query:
+            one: "%{start_number} - %{end_number} of %{total} Comment found"
+            other: "%{start_number} - %{end_number} of %{total} Comments found"
+          range_with_collection_html:
+            one: "%{start_number} - %{end_number} of %{total} Comment in %{collection_link}"
+            other: "%{start_number} - %{end_number} of %{total} Comments in %{collection_link}"
+          range_with_query_and_collection_html:
+            one: "%{start_number} - %{end_number} of %{total} Comment found in %{collection_link}"
+            other: "%{start_number} - %{end_number} of %{total} Comments found in %{collection_link}"
+          range_with_pseud:
+            one: "%{start_number} - %{end_number} of %{total} Comment by %{byline}"
+            other: "%{start_number} - %{end_number} of %{total} Comments by %{byline}"
+          range_with_query_and_pseud:
+            one: "%{start_number} - %{end_number} of %{total} Comment found by %{byline}"
+            other: "%{start_number} - %{end_number} of %{total} Comments found by %{byline}"
+          range_with_user:
+            one: "%{start_number} - %{end_number} of %{total} Comment by %{username}"
+            other: "%{start_number} - %{end_number} of %{total} Comments by %{username}"
+          range_with_query_and_user:
+            one: "%{start_number} - %{end_number} of %{total} Comment found by %{username}"
+            other: "%{start_number} - %{end_number} of %{total} Comments found by %{username}"
+          range_with_language:
+            one: "%{start_number} - %{end_number} of %{total} Comment in %{language}"
+            other: "%{start_number} - %{end_number} of %{total} Comments in %{language}"
+          range_with_query_and_language:
+            one: "%{start_number} - %{end_number} of %{total} Comment found in %{language}"
+            other: "%{start_number} - %{end_number} of %{total} Comments found in %{language}"
+          range_with_tag_html:
+            one: "%{start_number} - %{end_number} of %{total} Comment in %{tag_link}"
+            other: "%{start_number} - %{end_number} of %{total} Comments in %{tag_link}"
+          range_with_query_and_tag_html:
+            one: "%{start_number} - %{end_number} of %{total} Comment found in %{tag_link}"
+            other: "%{start_number} - %{end_number} of %{total} Comments found in %{tag_link}"
+          range_with_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} Comment in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Comments in %{fandom_link}"
+          range_with_query_and_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} Comment found in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Comments found in %{fandom_link}"
+          range_with_collection_and_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} Comment in %{collection_link} in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Comments in %{collection_link} in %{fandom_link}"
+          range_with_query_and_collection_and_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} Comment found in %{collection_link} in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Comments found in %{collection_link} in %{fandom_link}"
+          range_with_pseud_and_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} Comment by %{byline} in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Comments by %{byline} in %{fandom_link}"
+          range_with_query_and_pseud_and_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} Comment found by %{byline} in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Comments found by %{byline} in %{fandom_link}"
+          range_with_user_and_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} Comment by %{username} in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Comments by %{username} in %{fandom_link}"
+          range_with_query_and_user_and_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} Comment found by %{username} in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Comments found by %{username} in %{fandom_link}"
+          range_with_language_and_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} Comment in %{language} in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Comments in %{language} in %{fandom_link}"
+          range_with_query_and_language_and_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} Comment found in %{language} in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Comments found in %{language} in %{fandom_link}"
+          range_with_tag_and_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} Comment in %{tag_link} in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Comments in %{tag_link} in %{fandom_link}"
+          range_with_query_and_tag_and_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} Comment found in %{tag_link} in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Comments found in %{tag_link} in %{fandom_link}"
           recent:
-            one: Recent Comment
-            other: Recent Comments
+            one: "Recent Comment"
+            other: "Recent Comments"
+          recent_with_query:
+            one: "Recent Comment found"
+            other: "Recent Comments found"
+          recent_with_collection_html:
+            one: "Recent Comment in %{collection_link}"
+            other: "Recent Comments in %{collection_link}"
+          recent_with_query_and_collection_html:
+            one: "Recent Comment found in %{collection_link}"
+            other: "Recent Comments found in %{collection_link}"
+          recent_with_pseud:
+            one: "Recent Comment by %{byline}"
+            other: "Recent Comments by %{byline}"
+          recent_with_query_and_pseud:
+            one: "Recent Comment found by %{byline}"
+            other: "Recent Comments found by %{byline}"
+          recent_with_user:
+            one: "Recent Comment by %{username}"
+            other: "Recent Comments by %{username}"
+          recent_with_query_and_user:
+            one: "Recent Comment found by %{username}"
+            other: "Recent Comments found by %{username}"
+          recent_with_language:
+            one: "Recent Comment in %{language}"
+            other: "Recent Comments in %{language}"
+          recent_with_query_and_language:
+            one: "Recent Comment found in %{language}"
+            other: "Recent Comments found in %{language}"
+          recent_with_tag_html:
+            one: "Recent Comment in %{tag_link}"
+            other: "Recent Comments in %{tag_link}"
+          recent_with_query_and_tag_html:
+            one: "Recent Comment found in %{tag_link}"
+            other: "Recent Comments found in %{tag_link}"
+          recent_with_fandom_html:
+            one: "Recent Comment in %{fandom_link}"
+            other: "Recent Comments in %{fandom_link}"
+          recent_with_query_and_fandom_html:
+            one: "Recent Comment found in %{fandom_link}"
+            other: "Recent Comments found in %{fandom_link}"
+          recent_with_collection_and_fandom_html:
+            one: "Recent Comment in %{collection_link} in %{fandom_link}"
+            other: "Recent Comments in %{collection_link} in %{fandom_link}"
+          recent_with_query_and_collection_and_fandom_html:
+            one: "Recent Comment found in %{collection_link} in %{fandom_link}"
+            other: "Recent Comments found in %{collection_link} in %{fandom_link}"
+          recent_with_pseud_and_fandom_html:
+            one: "Recent Comment by %{byline} in %{fandom_link}"
+            other: "Recent Comments by %{byline} in %{fandom_link}"
+          recent_with_query_and_pseud_and_fandom_html:
+            one: "Recent Comment found by %{byline} in %{fandom_link}"
+            other: "Recent Comments found by %{byline} in %{fandom_link}"
+          recent_with_user_and_fandom_html:
+            one: "Recent Comment by %{username} in %{fandom_link}"
+            other: "Recent Comments by %{username} in %{fandom_link}"
+          recent_with_query_and_user_and_fandom_html:
+            one: "Recent Comment found by %{username} in %{fandom_link}"
+            other: "Recent Comments found by %{username} in %{fandom_link}"
+          recent_with_language_and_fandom_html:
+            one: "Recent Comment in %{language} in %{fandom_link}"
+            other: "Recent Comments in %{language} in %{fandom_link}"
+          recent_with_query_and_language_and_fandom_html:
+            one: "Recent Comment found in %{language} in %{fandom_link}"
+            other: "Recent Comments found in %{language} in %{fandom_link}"
+          recent_with_tag_and_fandom_html:
+            one: "Recent Comment in %{tag_link} in %{fandom_link}"
+            other: "Recent Comments in %{tag_link} in %{fandom_link}"
+          recent_with_query_and_tag_and_fandom_html:
+            one: "Recent Comment found in %{tag_link} in %{fandom_link}"
+            other: "Recent Comments found in %{tag_link} in %{fandom_link}"
         series:
           count:
             one: "%{count} Series"
             other: "%{count} Series"
+          count_with_query:
+            one: "%{count} Series found"
+            other: "%{count} Series found"
+          count_with_collection_html:
+            one: "%{count} Series in %{collection_link}"
+            other: "%{count} Series in %{collection_link}"
+          count_with_query_and_collection_html:
+            one: "%{count} Series found in %{collection_link}"
+            other: "%{count} Series found in %{collection_link}"
+          count_with_pseud:
+            one: "%{count} Series by %{byline}"
+            other: "%{count} Series by %{byline}"
+          count_with_query_and_pseud:
+            one: "%{count} Series found by %{byline}"
+            other: "%{count} Series found by %{byline}"
+          count_with_user:
+            one: "%{count} Series by %{username}"
+            other: "%{count} Series by %{username}"
+          count_with_query_and_user:
+            one: "%{count} Series found by %{username}"
+            other: "%{count} Series found by %{username}"
+          count_with_language:
+            one: "%{count} Series in %{language}"
+            other: "%{count} Series in %{language}"
+          count_with_query_and_language:
+            one: "%{count} Series found in %{language}"
+            other: "%{count} Series found in %{language}"
+          count_with_tag_html:
+            one: "%{count} Series in %{tag_link}"
+            other: "%{count} Series in %{tag_link}"
+          count_with_query_and_tag_html:
+            one: "%{count} Series found in %{tag_link}"
+            other: "%{count} Series found in %{tag_link}"
+          count_with_fandom_html:
+            one: "%{count} Series in %{fandom_link}"
+            other: "%{count} Series in %{fandom_link}"
+          count_with_query_and_fandom_html:
+            one: "%{count} Series found in %{fandom_link}"
+            other: "%{count} Series found in %{fandom_link}"
+          count_with_collection_and_fandom_html:
+            one: "%{count} Series in %{collection_link} in %{fandom_link}"
+            other: "%{count} Series in %{collection_link} in %{fandom_link}"
+          count_with_query_and_collection_and_fandom_html:
+            one: "%{count} Series found in %{collection_link} in %{fandom_link}"
+            other: "%{count} Series found in %{collection_link} in %{fandom_link}"
+          count_with_pseud_and_fandom_html:
+            one: "%{count} Series by %{byline} in %{fandom_link}"
+            other: "%{count} Series by %{byline} in %{fandom_link}"
+          count_with_query_and_pseud_and_fandom_html:
+            one: "%{count} Series found by %{byline} in %{fandom_link}"
+            other: "%{count} Series found by %{byline} in %{fandom_link}"
+          count_with_user_and_fandom_html:
+            one: "%{count} Series by %{username} in %{fandom_link}"
+            other: "%{count} Series by %{username} in %{fandom_link}"
+          count_with_query_and_user_and_fandom_html:
+            one: "%{count} Series found by %{username} in %{fandom_link}"
+            other: "%{count} Series found by %{username} in %{fandom_link}"
+          count_with_language_and_fandom_html:
+            one: "%{count} Series in %{language} in %{fandom_link}"
+            other: "%{count} Series in %{language} in %{fandom_link}"
+          count_with_query_and_language_and_fandom_html:
+            one: "%{count} Series found in %{language} in %{fandom_link}"
+            other: "%{count} Series found in %{language} in %{fandom_link}"
+          count_with_tag_and_fandom_html:
+            one: "%{count} Series in %{tag_link} in %{fandom_link}"
+            other: "%{count} Series in %{tag_link} in %{fandom_link}"
+          count_with_query_and_tag_and_fandom_html:
+            one: "%{count} Series found in %{tag_link} in %{fandom_link}"
+            other: "%{count} Series found in %{tag_link} in %{fandom_link}"
           range:
             one: "%{start_number} - %{end_number} of %{total} Series"
             other: "%{start_number} - %{end_number} of %{total} Series"
+          range_with_query:
+            one: "%{start_number} - %{end_number} of %{total} Series found"
+            other: "%{start_number} - %{end_number} of %{total} Series found"
+          range_with_collection_html:
+            one: "%{start_number} - %{end_number} of %{total} Series in %{collection_link}"
+            other: "%{start_number} - %{end_number} of %{total} Series in %{collection_link}"
+          range_with_query_and_collection_html:
+            one: "%{start_number} - %{end_number} of %{total} Series found in %{collection_link}"
+            other: "%{start_number} - %{end_number} of %{total} Series found in %{collection_link}"
+          range_with_pseud:
+            one: "%{start_number} - %{end_number} of %{total} Series by %{byline}"
+            other: "%{start_number} - %{end_number} of %{total} Series by %{byline}"
+          range_with_query_and_pseud:
+            one: "%{start_number} - %{end_number} of %{total} Series found by %{byline}"
+            other: "%{start_number} - %{end_number} of %{total} Series found by %{byline}"
+          range_with_user:
+            one: "%{start_number} - %{end_number} of %{total} Series by %{username}"
+            other: "%{start_number} - %{end_number} of %{total} Series by %{username}"
+          range_with_query_and_user:
+            one: "%{start_number} - %{end_number} of %{total} Series found by %{username}"
+            other: "%{start_number} - %{end_number} of %{total} Series found by %{username}"
+          range_with_language:
+            one: "%{start_number} - %{end_number} of %{total} Series in %{language}"
+            other: "%{start_number} - %{end_number} of %{total} Series in %{language}"
+          range_with_query_and_language:
+            one: "%{start_number} - %{end_number} of %{total} Series found in %{language}"
+            other: "%{start_number} - %{end_number} of %{total} Series found in %{language}"
+          range_with_tag_html:
+            one: "%{start_number} - %{end_number} of %{total} Series in %{tag_link}"
+            other: "%{start_number} - %{end_number} of %{total} Series in %{tag_link}"
+          range_with_query_and_tag_html:
+            one: "%{start_number} - %{end_number} of %{total} Series found in %{tag_link}"
+            other: "%{start_number} - %{end_number} of %{total} Series found in %{tag_link}"
+          range_with_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} Series in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Series in %{fandom_link}"
+          range_with_query_and_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} Series found in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Series found in %{fandom_link}"
+          range_with_collection_and_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} Series in %{collection_link} in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Series in %{collection_link} in %{fandom_link}"
+          range_with_query_and_collection_and_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} Series found in %{collection_link} in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Series found in %{collection_link} in %{fandom_link}"
+          range_with_pseud_and_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} Series by %{byline} in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Series by %{byline} in %{fandom_link}"
+          range_with_query_and_pseud_and_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} Series found by %{byline} in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Series found by %{byline} in %{fandom_link}"
+          range_with_user_and_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} Series by %{username} in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Series by %{username} in %{fandom_link}"
+          range_with_query_and_user_and_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} Series found by %{username} in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Series found by %{username} in %{fandom_link}"
+          range_with_language_and_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} Series in %{language} in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Series in %{language} in %{fandom_link}"
+          range_with_query_and_language_and_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} Series found in %{language} in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Series found in %{language} in %{fandom_link}"
+          range_with_tag_and_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} Series in %{tag_link} in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Series in %{tag_link} in %{fandom_link}"
+          range_with_query_and_tag_and_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} Series found in %{tag_link} in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Series found in %{tag_link} in %{fandom_link}"
           recent:
-            one: Recent Series
-            other: Recent Series
+            one: "Recent Series"
+            other: "Recent Series"
+          recent_with_query:
+            one: "Recent Series found"
+            other: "Recent Series found"
+          recent_with_collection_html:
+            one: "Recent Series in %{collection_link}"
+            other: "Recent Series in %{collection_link}"
+          recent_with_query_and_collection_html:
+            one: "Recent Series found in %{collection_link}"
+            other: "Recent Series found in %{collection_link}"
+          recent_with_pseud:
+            one: "Recent Series by %{byline}"
+            other: "Recent Series by %{byline}"
+          recent_with_query_and_pseud:
+            one: "Recent Series found by %{byline}"
+            other: "Recent Series found by %{byline}"
+          recent_with_user:
+            one: "Recent Series by %{username}"
+            other: "Recent Series by %{username}"
+          recent_with_query_and_user:
+            one: "Recent Series found by %{username}"
+            other: "Recent Series found by %{username}"
+          recent_with_language:
+            one: "Recent Series in %{language}"
+            other: "Recent Series in %{language}"
+          recent_with_query_and_language:
+            one: "Recent Series found in %{language}"
+            other: "Recent Series found in %{language}"
+          recent_with_tag_html:
+            one: "Recent Series in %{tag_link}"
+            other: "Recent Series in %{tag_link}"
+          recent_with_query_and_tag_html:
+            one: "Recent Series found in %{tag_link}"
+            other: "Recent Series found in %{tag_link}"
+          recent_with_fandom_html:
+            one: "Recent Series in %{fandom_link}"
+            other: "Recent Series in %{fandom_link}"
+          recent_with_query_and_fandom_html:
+            one: "Recent Series found in %{fandom_link}"
+            other: "Recent Series found in %{fandom_link}"
+          recent_with_collection_and_fandom_html:
+            one: "Recent Series in %{collection_link} in %{fandom_link}"
+            other: "Recent Series in %{collection_link} in %{fandom_link}"
+          recent_with_query_and_collection_and_fandom_html:
+            one: "Recent Series found in %{collection_link} in %{fandom_link}"
+            other: "Recent Series found in %{collection_link} in %{fandom_link}"
+          recent_with_pseud_and_fandom_html:
+            one: "Recent Series by %{byline} in %{fandom_link}"
+            other: "Recent Series by %{byline} in %{fandom_link}"
+          recent_with_query_and_pseud_and_fandom_html:
+            one: "Recent Series found by %{byline} in %{fandom_link}"
+            other: "Recent Series found by %{byline} in %{fandom_link}"
+          recent_with_user_and_fandom_html:
+            one: "Recent Series by %{username} in %{fandom_link}"
+            other: "Recent Series by %{username} in %{fandom_link}"
+          recent_with_query_and_user_and_fandom_html:
+            one: "Recent Series found by %{username} in %{fandom_link}"
+            other: "Recent Series found by %{username} in %{fandom_link}"
+          recent_with_language_and_fandom_html:
+            one: "Recent Series in %{language} in %{fandom_link}"
+            other: "Recent Series in %{language} in %{fandom_link}"
+          recent_with_query_and_language_and_fandom_html:
+            one: "Recent Series found in %{language} in %{fandom_link}"
+            other: "Recent Series found in %{language} in %{fandom_link}"
+          recent_with_tag_and_fandom_html:
+            one: "Recent Series in %{tag_link} in %{fandom_link}"
+            other: "Recent Series in %{tag_link} in %{fandom_link}"
+          recent_with_query_and_tag_and_fandom_html:
+            one: "Recent Series found in %{tag_link} in %{fandom_link}"
+            other: "Recent Series found in %{tag_link} in %{fandom_link}"
         tag_set:
           count:
             one: "%{count} Tag Set"
             other: "%{count} Tag Sets"
+          count_with_query:
+            one: "%{count} Tag Set found"
+            other: "%{count} Tag Sets found"
+          count_with_collection_html:
+            one: "%{count} Tag Set in %{collection_link}"
+            other: "%{count} Tag Sets in %{collection_link}"
+          count_with_query_and_collection_html:
+            one: "%{count} Tag Set found in %{collection_link}"
+            other: "%{count} Tag Sets found in %{collection_link}"
+          count_with_pseud:
+            one: "%{count} Tag Set by %{byline}"
+            other: "%{count} Tag Sets by %{byline}"
+          count_with_query_and_pseud:
+            one: "%{count} Tag Set found by %{byline}"
+            other: "%{count} Tag Sets found by %{byline}"
+          count_with_user:
+            one: "%{count} Tag Set by %{username}"
+            other: "%{count} Tag Sets by %{username}"
+          count_with_query_and_user:
+            one: "%{count} Tag Set found by %{username}"
+            other: "%{count} Tag Sets found by %{username}"
+          count_with_language:
+            one: "%{count} Tag Set in %{language}"
+            other: "%{count} Tag Sets in %{language}"
+          count_with_query_and_language:
+            one: "%{count} Tag Set found in %{language}"
+            other: "%{count} Tag Sets found in %{language}"
+          count_with_tag_html:
+            one: "%{count} Tag Set in %{tag_link}"
+            other: "%{count} Tag Sets in %{tag_link}"
+          count_with_query_and_tag_html:
+            one: "%{count} Tag Set found in %{tag_link}"
+            other: "%{count} Tag Sets found in %{tag_link}"
+          count_with_fandom_html:
+            one: "%{count} Tag Set in %{fandom_link}"
+            other: "%{count} Tag Sets in %{fandom_link}"
+          count_with_query_and_fandom_html:
+            one: "%{count} Tag Set found in %{fandom_link}"
+            other: "%{count} Tag Sets found in %{fandom_link}"
+          count_with_collection_and_fandom_html:
+            one: "%{count} Tag Set in %{collection_link} in %{fandom_link}"
+            other: "%{count} Tag Sets in %{collection_link} in %{fandom_link}"
+          count_with_query_and_collection_and_fandom_html:
+            one: "%{count} Tag Set found in %{collection_link} in %{fandom_link}"
+            other: "%{count} Tag Sets found in %{collection_link} in %{fandom_link}"
+          count_with_pseud_and_fandom_html:
+            one: "%{count} Tag Set by %{byline} in %{fandom_link}"
+            other: "%{count} Tag Sets by %{byline} in %{fandom_link}"
+          count_with_query_and_pseud_and_fandom_html:
+            one: "%{count} Tag Set found by %{byline} in %{fandom_link}"
+            other: "%{count} Tag Sets found by %{byline} in %{fandom_link}"
+          count_with_user_and_fandom_html:
+            one: "%{count} Tag Set by %{username} in %{fandom_link}"
+            other: "%{count} Tag Sets by %{username} in %{fandom_link}"
+          count_with_query_and_user_and_fandom_html:
+            one: "%{count} Tag Set found by %{username} in %{fandom_link}"
+            other: "%{count} Tag Sets found by %{username} in %{fandom_link}"
+          count_with_language_and_fandom_html:
+            one: "%{count} Tag Set in %{language} in %{fandom_link}"
+            other: "%{count} Tag Sets in %{language} in %{fandom_link}"
+          count_with_query_and_language_and_fandom_html:
+            one: "%{count} Tag Set found in %{language} in %{fandom_link}"
+            other: "%{count} Tag Sets found in %{language} in %{fandom_link}"
+          count_with_tag_and_fandom_html:
+            one: "%{count} Tag Set in %{tag_link} in %{fandom_link}"
+            other: "%{count} Tag Sets in %{tag_link} in %{fandom_link}"
+          count_with_query_and_tag_and_fandom_html:
+            one: "%{count} Tag Set found in %{tag_link} in %{fandom_link}"
+            other: "%{count} Tag Sets found in %{tag_link} in %{fandom_link}"
           range:
             one: "%{start_number} - %{end_number} of %{total} Tag Set"
             other: "%{start_number} - %{end_number} of %{total} Tag Sets"
+          range_with_query:
+            one: "%{start_number} - %{end_number} of %{total} Tag Set found"
+            other: "%{start_number} - %{end_number} of %{total} Tag Sets found"
+          range_with_collection_html:
+            one: "%{start_number} - %{end_number} of %{total} Tag Set in %{collection_link}"
+            other: "%{start_number} - %{end_number} of %{total} Tag Sets in %{collection_link}"
+          range_with_query_and_collection_html:
+            one: "%{start_number} - %{end_number} of %{total} Tag Set found in %{collection_link}"
+            other: "%{start_number} - %{end_number} of %{total} Tag Sets found in %{collection_link}"
+          range_with_pseud:
+            one: "%{start_number} - %{end_number} of %{total} Tag Set by %{byline}"
+            other: "%{start_number} - %{end_number} of %{total} Tag Sets by %{byline}"
+          range_with_query_and_pseud:
+            one: "%{start_number} - %{end_number} of %{total} Tag Set found by %{byline}"
+            other: "%{start_number} - %{end_number} of %{total} Tag Sets found by %{byline}"
+          range_with_user:
+            one: "%{start_number} - %{end_number} of %{total} Tag Set by %{username}"
+            other: "%{start_number} - %{end_number} of %{total} Tag Sets by %{username}"
+          range_with_query_and_user:
+            one: "%{start_number} - %{end_number} of %{total} Tag Set found by %{username}"
+            other: "%{start_number} - %{end_number} of %{total} Tag Sets found by %{username}"
+          range_with_language:
+            one: "%{start_number} - %{end_number} of %{total} Tag Set in %{language}"
+            other: "%{start_number} - %{end_number} of %{total} Tag Sets in %{language}"
+          range_with_query_and_language:
+            one: "%{start_number} - %{end_number} of %{total} Tag Set found in %{language}"
+            other: "%{start_number} - %{end_number} of %{total} Tag Sets found in %{language}"
+          range_with_tag_html:
+            one: "%{start_number} - %{end_number} of %{total} Tag Set in %{tag_link}"
+            other: "%{start_number} - %{end_number} of %{total} Tag Sets in %{tag_link}"
+          range_with_query_and_tag_html:
+            one: "%{start_number} - %{end_number} of %{total} Tag Set found in %{tag_link}"
+            other: "%{start_number} - %{end_number} of %{total} Tag Sets found in %{tag_link}"
+          range_with_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} Tag Set in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Tag Sets in %{fandom_link}"
+          range_with_query_and_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} Tag Set found in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Tag Sets found in %{fandom_link}"
+          range_with_collection_and_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} Tag Set in %{collection_link} in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Tag Sets in %{collection_link} in %{fandom_link}"
+          range_with_query_and_collection_and_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} Tag Set found in %{collection_link} in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Tag Sets found in %{collection_link} in %{fandom_link}"
+          range_with_pseud_and_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} Tag Set by %{byline} in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Tag Sets by %{byline} in %{fandom_link}"
+          range_with_query_and_pseud_and_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} Tag Set found by %{byline} in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Tag Sets found by %{byline} in %{fandom_link}"
+          range_with_user_and_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} Tag Set by %{username} in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Tag Sets by %{username} in %{fandom_link}"
+          range_with_query_and_user_and_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} Tag Set found by %{username} in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Tag Sets found by %{username} in %{fandom_link}"
+          range_with_language_and_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} Tag Set in %{language} in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Tag Sets in %{language} in %{fandom_link}"
+          range_with_query_and_language_and_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} Tag Set found in %{language} in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Tag Sets found in %{language} in %{fandom_link}"
+          range_with_tag_and_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} Tag Set in %{tag_link} in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Tag Sets in %{tag_link} in %{fandom_link}"
+          range_with_query_and_tag_and_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} Tag Set found in %{tag_link} in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Tag Sets found in %{tag_link} in %{fandom_link}"
           recent:
-            one: Recent Tag Set
-            other: Recent Tag Sets
+            one: "Recent Tag Set"
+            other: "Recent Tag Sets"
+          recent_with_query:
+            one: "Recent Tag Set found"
+            other: "Recent Tag Sets found"
+          recent_with_collection_html:
+            one: "Recent Tag Set in %{collection_link}"
+            other: "Recent Tag Sets in %{collection_link}"
+          recent_with_query_and_collection_html:
+            one: "Recent Tag Set found in %{collection_link}"
+            other: "Recent Tag Sets found in %{collection_link}"
+          recent_with_pseud:
+            one: "Recent Tag Set by %{byline}"
+            other: "Recent Tag Sets by %{byline}"
+          recent_with_query_and_pseud:
+            one: "Recent Tag Set found by %{byline}"
+            other: "Recent Tag Sets found by %{byline}"
+          recent_with_user:
+            one: "Recent Tag Set by %{username}"
+            other: "Recent Tag Sets by %{username}"
+          recent_with_query_and_user:
+            one: "Recent Tag Set found by %{username}"
+            other: "Recent Tag Sets found by %{username}"
+          recent_with_language:
+            one: "Recent Tag Set in %{language}"
+            other: "Recent Tag Sets in %{language}"
+          recent_with_query_and_language:
+            one: "Recent Tag Set found in %{language}"
+            other: "Recent Tag Sets found in %{language}"
+          recent_with_tag_html:
+            one: "Recent Tag Set in %{tag_link}"
+            other: "Recent Tag Sets in %{tag_link}"
+          recent_with_query_and_tag_html:
+            one: "Recent Tag Set found in %{tag_link}"
+            other: "Recent Tag Sets found in %{tag_link}"
+          recent_with_fandom_html:
+            one: "Recent Tag Set in %{fandom_link}"
+            other: "Recent Tag Sets in %{fandom_link}"
+          recent_with_query_and_fandom_html:
+            one: "Recent Tag Set found in %{fandom_link}"
+            other: "Recent Tag Sets found in %{fandom_link}"
+          recent_with_collection_and_fandom_html:
+            one: "Recent Tag Set in %{collection_link} in %{fandom_link}"
+            other: "Recent Tag Sets in %{collection_link} in %{fandom_link}"
+          recent_with_query_and_collection_and_fandom_html:
+            one: "Recent Tag Set found in %{collection_link} in %{fandom_link}"
+            other: "Recent Tag Sets found in %{collection_link} in %{fandom_link}"
+          recent_with_pseud_and_fandom_html:
+            one: "Recent Tag Set by %{byline} in %{fandom_link}"
+            other: "Recent Tag Sets by %{byline} in %{fandom_link}"
+          recent_with_query_and_pseud_and_fandom_html:
+            one: "Recent Tag Set found by %{byline} in %{fandom_link}"
+            other: "Recent Tag Sets found by %{byline} in %{fandom_link}"
+          recent_with_user_and_fandom_html:
+            one: "Recent Tag Set by %{username} in %{fandom_link}"
+            other: "Recent Tag Sets by %{username} in %{fandom_link}"
+          recent_with_query_and_user_and_fandom_html:
+            one: "Recent Tag Set found by %{username} in %{fandom_link}"
+            other: "Recent Tag Sets found by %{username} in %{fandom_link}"
+          recent_with_language_and_fandom_html:
+            one: "Recent Tag Set in %{language} in %{fandom_link}"
+            other: "Recent Tag Sets in %{language} in %{fandom_link}"
+          recent_with_query_and_language_and_fandom_html:
+            one: "Recent Tag Set found in %{language} in %{fandom_link}"
+            other: "Recent Tag Sets found in %{language} in %{fandom_link}"
+          recent_with_tag_and_fandom_html:
+            one: "Recent Tag Set in %{tag_link} in %{fandom_link}"
+            other: "Recent Tag Sets in %{tag_link} in %{fandom_link}"
+          recent_with_query_and_tag_and_fandom_html:
+            one: "Recent Tag Set found in %{tag_link} in %{fandom_link}"
+            other: "Recent Tag Sets found in %{tag_link} in %{fandom_link}"
         unposted_draft:
           count:
             one: "%{count} Unposted Draft"
             other: "%{count} Unposted Drafts"
+          count_with_query:
+            one: "%{count} Unposted Draft found"
+            other: "%{count} Unposted Drafts found"
+          count_with_collection_html:
+            one: "%{count} Unposted Draft in %{collection_link}"
+            other: "%{count} Unposted Drafts in %{collection_link}"
+          count_with_query_and_collection_html:
+            one: "%{count} Unposted Draft found in %{collection_link}"
+            other: "%{count} Unposted Drafts found in %{collection_link}"
+          count_with_pseud:
+            one: "%{count} Unposted Draft by %{byline}"
+            other: "%{count} Unposted Drafts by %{byline}"
+          count_with_query_and_pseud:
+            one: "%{count} Unposted Draft found by %{byline}"
+            other: "%{count} Unposted Drafts found by %{byline}"
+          count_with_user:
+            one: "%{count} Unposted Draft by %{username}"
+            other: "%{count} Unposted Drafts by %{username}"
+          count_with_query_and_user:
+            one: "%{count} Unposted Draft found by %{username}"
+            other: "%{count} Unposted Drafts found by %{username}"
+          count_with_language:
+            one: "%{count} Unposted Draft in %{language}"
+            other: "%{count} Unposted Drafts in %{language}"
+          count_with_query_and_language:
+            one: "%{count} Unposted Draft found in %{language}"
+            other: "%{count} Unposted Drafts found in %{language}"
+          count_with_tag_html:
+            one: "%{count} Unposted Draft in %{tag_link}"
+            other: "%{count} Unposted Drafts in %{tag_link}"
+          count_with_query_and_tag_html:
+            one: "%{count} Unposted Draft found in %{tag_link}"
+            other: "%{count} Unposted Drafts found in %{tag_link}"
+          count_with_fandom_html:
+            one: "%{count} Unposted Draft in %{fandom_link}"
+            other: "%{count} Unposted Drafts in %{fandom_link}"
+          count_with_query_and_fandom_html:
+            one: "%{count} Unposted Draft found in %{fandom_link}"
+            other: "%{count} Unposted Drafts found in %{fandom_link}"
+          count_with_collection_and_fandom_html:
+            one: "%{count} Unposted Draft in %{collection_link} in %{fandom_link}"
+            other: "%{count} Unposted Drafts in %{collection_link} in %{fandom_link}"
+          count_with_query_and_collection_and_fandom_html:
+            one: "%{count} Unposted Draft found in %{collection_link} in %{fandom_link}"
+            other: "%{count} Unposted Drafts found in %{collection_link} in %{fandom_link}"
+          count_with_pseud_and_fandom_html:
+            one: "%{count} Unposted Draft by %{byline} in %{fandom_link}"
+            other: "%{count} Unposted Drafts by %{byline} in %{fandom_link}"
+          count_with_query_and_pseud_and_fandom_html:
+            one: "%{count} Unposted Draft found by %{byline} in %{fandom_link}"
+            other: "%{count} Unposted Drafts found by %{byline} in %{fandom_link}"
+          count_with_user_and_fandom_html:
+            one: "%{count} Unposted Draft by %{username} in %{fandom_link}"
+            other: "%{count} Unposted Drafts by %{username} in %{fandom_link}"
+          count_with_query_and_user_and_fandom_html:
+            one: "%{count} Unposted Draft found by %{username} in %{fandom_link}"
+            other: "%{count} Unposted Drafts found by %{username} in %{fandom_link}"
+          count_with_language_and_fandom_html:
+            one: "%{count} Unposted Draft in %{language} in %{fandom_link}"
+            other: "%{count} Unposted Drafts in %{language} in %{fandom_link}"
+          count_with_query_and_language_and_fandom_html:
+            one: "%{count} Unposted Draft found in %{language} in %{fandom_link}"
+            other: "%{count} Unposted Drafts found in %{language} in %{fandom_link}"
+          count_with_tag_and_fandom_html:
+            one: "%{count} Unposted Draft in %{tag_link} in %{fandom_link}"
+            other: "%{count} Unposted Drafts in %{tag_link} in %{fandom_link}"
+          count_with_query_and_tag_and_fandom_html:
+            one: "%{count} Unposted Draft found in %{tag_link} in %{fandom_link}"
+            other: "%{count} Unposted Drafts found in %{tag_link} in %{fandom_link}"
           range:
             one: "%{start_number} - %{end_number} of %{total} Unposted Draft"
             other: "%{start_number} - %{end_number} of %{total} Unposted Drafts"
+          range_with_query:
+            one: "%{start_number} - %{end_number} of %{total} Unposted Draft found"
+            other: "%{start_number} - %{end_number} of %{total} Unposted Drafts found"
+          range_with_collection_html:
+            one: "%{start_number} - %{end_number} of %{total} Unposted Draft in %{collection_link}"
+            other: "%{start_number} - %{end_number} of %{total} Unposted Drafts in %{collection_link}"
+          range_with_query_and_collection_html:
+            one: "%{start_number} - %{end_number} of %{total} Unposted Draft found in %{collection_link}"
+            other: "%{start_number} - %{end_number} of %{total} Unposted Drafts found in %{collection_link}"
+          range_with_pseud:
+            one: "%{start_number} - %{end_number} of %{total} Unposted Draft by %{byline}"
+            other: "%{start_number} - %{end_number} of %{total} Unposted Drafts by %{byline}"
+          range_with_query_and_pseud:
+            one: "%{start_number} - %{end_number} of %{total} Unposted Draft found by %{byline}"
+            other: "%{start_number} - %{end_number} of %{total} Unposted Drafts found by %{byline}"
+          range_with_user:
+            one: "%{start_number} - %{end_number} of %{total} Unposted Draft by %{username}"
+            other: "%{start_number} - %{end_number} of %{total} Unposted Drafts by %{username}"
+          range_with_query_and_user:
+            one: "%{start_number} - %{end_number} of %{total} Unposted Draft found by %{username}"
+            other: "%{start_number} - %{end_number} of %{total} Unposted Drafts found by %{username}"
+          range_with_language:
+            one: "%{start_number} - %{end_number} of %{total} Unposted Draft in %{language}"
+            other: "%{start_number} - %{end_number} of %{total} Unposted Drafts in %{language}"
+          range_with_query_and_language:
+            one: "%{start_number} - %{end_number} of %{total} Unposted Draft found in %{language}"
+            other: "%{start_number} - %{end_number} of %{total} Unposted Drafts found in %{language}"
+          range_with_tag_html:
+            one: "%{start_number} - %{end_number} of %{total} Unposted Draft in %{tag_link}"
+            other: "%{start_number} - %{end_number} of %{total} Unposted Drafts in %{tag_link}"
+          range_with_query_and_tag_html:
+            one: "%{start_number} - %{end_number} of %{total} Unposted Draft found in %{tag_link}"
+            other: "%{start_number} - %{end_number} of %{total} Unposted Drafts found in %{tag_link}"
+          range_with_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} Unposted Draft in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Unposted Drafts in %{fandom_link}"
+          range_with_query_and_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} Unposted Draft found in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Unposted Drafts found in %{fandom_link}"
+          range_with_collection_and_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} Unposted Draft in %{collection_link} in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Unposted Drafts in %{collection_link} in %{fandom_link}"
+          range_with_query_and_collection_and_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} Unposted Draft found in %{collection_link} in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Unposted Drafts found in %{collection_link} in %{fandom_link}"
+          range_with_pseud_and_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} Unposted Draft by %{byline} in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Unposted Drafts by %{byline} in %{fandom_link}"
+          range_with_query_and_pseud_and_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} Unposted Draft found by %{byline} in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Unposted Drafts found by %{byline} in %{fandom_link}"
+          range_with_user_and_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} Unposted Draft by %{username} in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Unposted Drafts by %{username} in %{fandom_link}"
+          range_with_query_and_user_and_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} Unposted Draft found by %{username} in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Unposted Drafts found by %{username} in %{fandom_link}"
+          range_with_language_and_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} Unposted Draft in %{language} in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Unposted Drafts in %{language} in %{fandom_link}"
+          range_with_query_and_language_and_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} Unposted Draft found in %{language} in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Unposted Drafts found in %{language} in %{fandom_link}"
+          range_with_tag_and_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} Unposted Draft in %{tag_link} in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Unposted Drafts in %{tag_link} in %{fandom_link}"
+          range_with_query_and_tag_and_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} Unposted Draft found in %{tag_link} in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Unposted Drafts found in %{tag_link} in %{fandom_link}"
           recent:
-            one: Recent Unposted Draft
-            other: Recent Unposted Drafts
+            one: "Recent Unposted Draft"
+            other: "Recent Unposted Drafts"
+          recent_with_query:
+            one: "Recent Unposted Draft found"
+            other: "Recent Unposted Drafts found"
+          recent_with_collection_html:
+            one: "Recent Unposted Draft in %{collection_link}"
+            other: "Recent Unposted Drafts in %{collection_link}"
+          recent_with_query_and_collection_html:
+            one: "Recent Unposted Draft found in %{collection_link}"
+            other: "Recent Unposted Drafts found in %{collection_link}"
+          recent_with_pseud:
+            one: "Recent Unposted Draft by %{byline}"
+            other: "Recent Unposted Drafts by %{byline}"
+          recent_with_query_and_pseud:
+            one: "Recent Unposted Draft found by %{byline}"
+            other: "Recent Unposted Drafts found by %{byline}"
+          recent_with_user:
+            one: "Recent Unposted Draft by %{username}"
+            other: "Recent Unposted Drafts by %{username}"
+          recent_with_query_and_user:
+            one: "Recent Unposted Draft found by %{username}"
+            other: "Recent Unposted Drafts found by %{username}"
+          recent_with_language:
+            one: "Recent Unposted Draft in %{language}"
+            other: "Recent Unposted Drafts in %{language}"
+          recent_with_query_and_language:
+            one: "Recent Unposted Draft found in %{language}"
+            other: "Recent Unposted Drafts found in %{language}"
+          recent_with_tag_html:
+            one: "Recent Unposted Draft in %{tag_link}"
+            other: "Recent Unposted Drafts in %{tag_link}"
+          recent_with_query_and_tag_html:
+            one: "Recent Unposted Draft found in %{tag_link}"
+            other: "Recent Unposted Drafts found in %{tag_link}"
+          recent_with_fandom_html:
+            one: "Recent Unposted Draft in %{fandom_link}"
+            other: "Recent Unposted Drafts in %{fandom_link}"
+          recent_with_query_and_fandom_html:
+            one: "Recent Unposted Draft found in %{fandom_link}"
+            other: "Recent Unposted Drafts found in %{fandom_link}"
+          recent_with_collection_and_fandom_html:
+            one: "Recent Unposted Draft in %{collection_link} in %{fandom_link}"
+            other: "Recent Unposted Drafts in %{collection_link} in %{fandom_link}"
+          recent_with_query_and_collection_and_fandom_html:
+            one: "Recent Unposted Draft found in %{collection_link} in %{fandom_link}"
+            other: "Recent Unposted Drafts found in %{collection_link} in %{fandom_link}"
+          recent_with_pseud_and_fandom_html:
+            one: "Recent Unposted Draft by %{byline} in %{fandom_link}"
+            other: "Recent Unposted Drafts by %{byline} in %{fandom_link}"
+          recent_with_query_and_pseud_and_fandom_html:
+            one: "Recent Unposted Draft found by %{byline} in %{fandom_link}"
+            other: "Recent Unposted Drafts found by %{byline} in %{fandom_link}"
+          recent_with_user_and_fandom_html:
+            one: "Recent Unposted Draft by %{username} in %{fandom_link}"
+            other: "Recent Unposted Drafts by %{username} in %{fandom_link}"
+          recent_with_query_and_user_and_fandom_html:
+            one: "Recent Unposted Draft found by %{username} in %{fandom_link}"
+            other: "Recent Unposted Drafts found by %{username} in %{fandom_link}"
+          recent_with_language_and_fandom_html:
+            one: "Recent Unposted Draft in %{language} in %{fandom_link}"
+            other: "Recent Unposted Drafts in %{language} in %{fandom_link}"
+          recent_with_query_and_language_and_fandom_html:
+            one: "Recent Unposted Draft found in %{language} in %{fandom_link}"
+            other: "Recent Unposted Drafts found in %{language} in %{fandom_link}"
+          recent_with_tag_and_fandom_html:
+            one: "Recent Unposted Draft in %{tag_link} in %{fandom_link}"
+            other: "Recent Unposted Drafts in %{tag_link} in %{fandom_link}"
+          recent_with_query_and_tag_and_fandom_html:
+            one: "Recent Unposted Draft found in %{tag_link} in %{fandom_link}"
+            other: "Recent Unposted Drafts found in %{tag_link} in %{fandom_link}"
         user:
           count:
             one: "%{count} User"
             other: "%{count} Users"
+          count_with_query:
+            one: "%{count} User found"
+            other: "%{count} Users found"
+          count_with_collection_html:
+            one: "%{count} User in %{collection_link}"
+            other: "%{count} Users in %{collection_link}"
+          count_with_query_and_collection_html:
+            one: "%{count} User found in %{collection_link}"
+            other: "%{count} Users found in %{collection_link}"
+          count_with_pseud:
+            one: "%{count} User by %{byline}"
+            other: "%{count} Users by %{byline}"
+          count_with_query_and_pseud:
+            one: "%{count} User found by %{byline}"
+            other: "%{count} Users found by %{byline}"
+          count_with_user:
+            one: "%{count} User by %{username}"
+            other: "%{count} Users by %{username}"
+          count_with_query_and_user:
+            one: "%{count} User found by %{username}"
+            other: "%{count} Users found by %{username}"
+          count_with_language:
+            one: "%{count} User in %{language}"
+            other: "%{count} Users in %{language}"
+          count_with_query_and_language:
+            one: "%{count} User found in %{language}"
+            other: "%{count} Users found in %{language}"
+          count_with_tag_html:
+            one: "%{count} User in %{tag_link}"
+            other: "%{count} Users in %{tag_link}"
+          count_with_query_and_tag_html:
+            one: "%{count} User found in %{tag_link}"
+            other: "%{count} Users found in %{tag_link}"
+          count_with_fandom_html:
+            one: "%{count} User in %{fandom_link}"
+            other: "%{count} Users in %{fandom_link}"
+          count_with_query_and_fandom_html:
+            one: "%{count} User found in %{fandom_link}"
+            other: "%{count} Users found in %{fandom_link}"
+          count_with_collection_and_fandom_html:
+            one: "%{count} User in %{collection_link} in %{fandom_link}"
+            other: "%{count} Users in %{collection_link} in %{fandom_link}"
+          count_with_query_and_collection_and_fandom_html:
+            one: "%{count} User found in %{collection_link} in %{fandom_link}"
+            other: "%{count} Users found in %{collection_link} in %{fandom_link}"
+          count_with_pseud_and_fandom_html:
+            one: "%{count} User by %{byline} in %{fandom_link}"
+            other: "%{count} Users by %{byline} in %{fandom_link}"
+          count_with_query_and_pseud_and_fandom_html:
+            one: "%{count} User found by %{byline} in %{fandom_link}"
+            other: "%{count} Users found by %{byline} in %{fandom_link}"
+          count_with_user_and_fandom_html:
+            one: "%{count} User by %{username} in %{fandom_link}"
+            other: "%{count} Users by %{username} in %{fandom_link}"
+          count_with_query_and_user_and_fandom_html:
+            one: "%{count} User found by %{username} in %{fandom_link}"
+            other: "%{count} Users found by %{username} in %{fandom_link}"
+          count_with_language_and_fandom_html:
+            one: "%{count} User in %{language} in %{fandom_link}"
+            other: "%{count} Users in %{language} in %{fandom_link}"
+          count_with_query_and_language_and_fandom_html:
+            one: "%{count} User found in %{language} in %{fandom_link}"
+            other: "%{count} Users found in %{language} in %{fandom_link}"
+          count_with_tag_and_fandom_html:
+            one: "%{count} User in %{tag_link} in %{fandom_link}"
+            other: "%{count} Users in %{tag_link} in %{fandom_link}"
+          count_with_query_and_tag_and_fandom_html:
+            one: "%{count} User found in %{tag_link} in %{fandom_link}"
+            other: "%{count} Users found in %{tag_link} in %{fandom_link}"
           range:
             one: "%{start_number} - %{end_number} of %{total} User"
             other: "%{start_number} - %{end_number} of %{total} Users"
+          range_with_query:
+            one: "%{start_number} - %{end_number} of %{total} User found"
+            other: "%{start_number} - %{end_number} of %{total} Users found"
+          range_with_collection_html:
+            one: "%{start_number} - %{end_number} of %{total} User in %{collection_link}"
+            other: "%{start_number} - %{end_number} of %{total} Users in %{collection_link}"
+          range_with_query_and_collection_html:
+            one: "%{start_number} - %{end_number} of %{total} User found in %{collection_link}"
+            other: "%{start_number} - %{end_number} of %{total} Users found in %{collection_link}"
+          range_with_pseud:
+            one: "%{start_number} - %{end_number} of %{total} User by %{byline}"
+            other: "%{start_number} - %{end_number} of %{total} Users by %{byline}"
+          range_with_query_and_pseud:
+            one: "%{start_number} - %{end_number} of %{total} User found by %{byline}"
+            other: "%{start_number} - %{end_number} of %{total} Users found by %{byline}"
+          range_with_user:
+            one: "%{start_number} - %{end_number} of %{total} User by %{username}"
+            other: "%{start_number} - %{end_number} of %{total} Users by %{username}"
+          range_with_query_and_user:
+            one: "%{start_number} - %{end_number} of %{total} User found by %{username}"
+            other: "%{start_number} - %{end_number} of %{total} Users found by %{username}"
+          range_with_language:
+            one: "%{start_number} - %{end_number} of %{total} User in %{language}"
+            other: "%{start_number} - %{end_number} of %{total} Users in %{language}"
+          range_with_query_and_language:
+            one: "%{start_number} - %{end_number} of %{total} User found in %{language}"
+            other: "%{start_number} - %{end_number} of %{total} Users found in %{language}"
+          range_with_tag_html:
+            one: "%{start_number} - %{end_number} of %{total} User in %{tag_link}"
+            other: "%{start_number} - %{end_number} of %{total} Users in %{tag_link}"
+          range_with_query_and_tag_html:
+            one: "%{start_number} - %{end_number} of %{total} User found in %{tag_link}"
+            other: "%{start_number} - %{end_number} of %{total} Users found in %{tag_link}"
+          range_with_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} User in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Users in %{fandom_link}"
+          range_with_query_and_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} User found in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Users found in %{fandom_link}"
+          range_with_collection_and_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} User in %{collection_link} in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Users in %{collection_link} in %{fandom_link}"
+          range_with_query_and_collection_and_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} User found in %{collection_link} in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Users found in %{collection_link} in %{fandom_link}"
+          range_with_pseud_and_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} User by %{byline} in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Users by %{byline} in %{fandom_link}"
+          range_with_query_and_pseud_and_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} User found by %{byline} in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Users found by %{byline} in %{fandom_link}"
+          range_with_user_and_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} User by %{username} in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Users by %{username} in %{fandom_link}"
+          range_with_query_and_user_and_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} User found by %{username} in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Users found by %{username} in %{fandom_link}"
+          range_with_language_and_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} User in %{language} in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Users in %{language} in %{fandom_link}"
+          range_with_query_and_language_and_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} User found in %{language} in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Users found in %{language} in %{fandom_link}"
+          range_with_tag_and_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} User in %{tag_link} in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Users in %{tag_link} in %{fandom_link}"
+          range_with_query_and_tag_and_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} User found in %{tag_link} in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Users found in %{tag_link} in %{fandom_link}"
           recent:
-            one: Recent User
-            other: Recent Users
+            one: "Recent User"
+            other: "Recent Users"
+          recent_with_query:
+            one: "Recent User found"
+            other: "Recent Users found"
+          recent_with_collection_html:
+            one: "Recent User in %{collection_link}"
+            other: "Recent Users in %{collection_link}"
+          recent_with_query_and_collection_html:
+            one: "Recent User found in %{collection_link}"
+            other: "Recent Users found in %{collection_link}"
+          recent_with_pseud:
+            one: "Recent User by %{byline}"
+            other: "Recent Users by %{byline}"
+          recent_with_query_and_pseud:
+            one: "Recent User found by %{byline}"
+            other: "Recent Users found by %{byline}"
+          recent_with_user:
+            one: "Recent User by %{username}"
+            other: "Recent Users by %{username}"
+          recent_with_query_and_user:
+            one: "Recent User found by %{username}"
+            other: "Recent Users found by %{username}"
+          recent_with_language:
+            one: "Recent User in %{language}"
+            other: "Recent Users in %{language}"
+          recent_with_query_and_language:
+            one: "Recent User found in %{language}"
+            other: "Recent Users found in %{language}"
+          recent_with_tag_html:
+            one: "Recent User in %{tag_link}"
+            other: "Recent Users in %{tag_link}"
+          recent_with_query_and_tag_html:
+            one: "Recent User found in %{tag_link}"
+            other: "Recent Users found in %{tag_link}"
+          recent_with_fandom_html:
+            one: "Recent User in %{fandom_link}"
+            other: "Recent Users in %{fandom_link}"
+          recent_with_query_and_fandom_html:
+            one: "Recent User found in %{fandom_link}"
+            other: "Recent Users found in %{fandom_link}"
+          recent_with_collection_and_fandom_html:
+            one: "Recent User in %{collection_link} in %{fandom_link}"
+            other: "Recent Users in %{collection_link} in %{fandom_link}"
+          recent_with_query_and_collection_and_fandom_html:
+            one: "Recent User found in %{collection_link} in %{fandom_link}"
+            other: "Recent Users found in %{collection_link} in %{fandom_link}"
+          recent_with_pseud_and_fandom_html:
+            one: "Recent User by %{byline} in %{fandom_link}"
+            other: "Recent Users by %{byline} in %{fandom_link}"
+          recent_with_query_and_pseud_and_fandom_html:
+            one: "Recent User found by %{byline} in %{fandom_link}"
+            other: "Recent Users found by %{byline} in %{fandom_link}"
+          recent_with_user_and_fandom_html:
+            one: "Recent User by %{username} in %{fandom_link}"
+            other: "Recent Users by %{username} in %{fandom_link}"
+          recent_with_query_and_user_and_fandom_html:
+            one: "Recent User found by %{username} in %{fandom_link}"
+            other: "Recent Users found by %{username} in %{fandom_link}"
+          recent_with_language_and_fandom_html:
+            one: "Recent User in %{language} in %{fandom_link}"
+            other: "Recent Users in %{language} in %{fandom_link}"
+          recent_with_query_and_language_and_fandom_html:
+            one: "Recent User found in %{language} in %{fandom_link}"
+            other: "Recent Users found in %{language} in %{fandom_link}"
+          recent_with_tag_and_fandom_html:
+            one: "Recent User in %{tag_link} in %{fandom_link}"
+            other: "Recent Users in %{tag_link} in %{fandom_link}"
+          recent_with_query_and_tag_and_fandom_html:
+            one: "Recent User found in %{tag_link} in %{fandom_link}"
+            other: "Recent Users found in %{tag_link} in %{fandom_link}"
         work:
           count:
             one: "%{count} Work"
             other: "%{count} Works"
+          count_with_query:
+            one: "%{count} Work found"
+            other: "%{count} Works found"
+          count_with_collection_html:
+            one: "%{count} Work in %{collection_link}"
+            other: "%{count} Works in %{collection_link}"
+          count_with_query_and_collection_html:
+            one: "%{count} Work found in %{collection_link}"
+            other: "%{count} Works found in %{collection_link}"
+          count_with_pseud:
+            one: "%{count} Work by %{byline}"
+            other: "%{count} Works by %{byline}"
+          count_with_query_and_pseud:
+            one: "%{count} Work found by %{byline}"
+            other: "%{count} Works found by %{byline}"
+          count_with_user:
+            one: "%{count} Work by %{username}"
+            other: "%{count} Works by %{username}"
+          count_with_query_and_user:
+            one: "%{count} Work found by %{username}"
+            other: "%{count} Works found by %{username}"
+          count_with_language:
+            one: "%{count} Work in %{language}"
+            other: "%{count} Works in %{language}"
+          count_with_query_and_language:
+            one: "%{count} Work found in %{language}"
+            other: "%{count} Works found in %{language}"
+          count_with_tag_html:
+            one: "%{count} Work in %{tag_link}"
+            other: "%{count} Works in %{tag_link}"
+          count_with_query_and_tag_html:
+            one: "%{count} Work found in %{tag_link}"
+            other: "%{count} Works found in %{tag_link}"
+          count_with_fandom_html:
+            one: "%{count} Work in %{fandom_link}"
+            other: "%{count} Works in %{fandom_link}"
+          count_with_query_and_fandom_html:
+            one: "%{count} Work found in %{fandom_link}"
+            other: "%{count} Works found in %{fandom_link}"
+          count_with_collection_and_fandom_html:
+            one: "%{count} Work in %{collection_link} in %{fandom_link}"
+            other: "%{count} Works in %{collection_link} in %{fandom_link}"
+          count_with_query_and_collection_and_fandom_html:
+            one: "%{count} Work found in %{collection_link} in %{fandom_link}"
+            other: "%{count} Works found in %{collection_link} in %{fandom_link}"
+          count_with_pseud_and_fandom_html:
+            one: "%{count} Work by %{byline} in %{fandom_link}"
+            other: "%{count} Works by %{byline} in %{fandom_link}"
+          count_with_query_and_pseud_and_fandom_html:
+            one: "%{count} Work found by %{byline} in %{fandom_link}"
+            other: "%{count} Works found by %{byline} in %{fandom_link}"
+          count_with_user_and_fandom_html:
+            one: "%{count} Work by %{username} in %{fandom_link}"
+            other: "%{count} Works by %{username} in %{fandom_link}"
+          count_with_query_and_user_and_fandom_html:
+            one: "%{count} Work found by %{username} in %{fandom_link}"
+            other: "%{count} Works found by %{username} in %{fandom_link}"
+          count_with_language_and_fandom_html:
+            one: "%{count} Work in %{language} in %{fandom_link}"
+            other: "%{count} Works in %{language} in %{fandom_link}"
+          count_with_query_and_language_and_fandom_html:
+            one: "%{count} Work found in %{language} in %{fandom_link}"
+            other: "%{count} Works found in %{language} in %{fandom_link}"
+          count_with_tag_and_fandom_html:
+            one: "%{count} Work in %{tag_link} in %{fandom_link}"
+            other: "%{count} Works in %{tag_link} in %{fandom_link}"
+          count_with_query_and_tag_and_fandom_html:
+            one: "%{count} Work found in %{tag_link} in %{fandom_link}"
+            other: "%{count} Works found in %{tag_link} in %{fandom_link}"
           range:
             one: "%{start_number} - %{end_number} of %{total} Work"
             other: "%{start_number} - %{end_number} of %{total} Works"
+          range_with_query:
+            one: "%{start_number} - %{end_number} of %{total} Work found"
+            other: "%{start_number} - %{end_number} of %{total} Works found"
+          range_with_collection_html:
+            one: "%{start_number} - %{end_number} of %{total} Work in %{collection_link}"
+            other: "%{start_number} - %{end_number} of %{total} Works in %{collection_link}"
+          range_with_query_and_collection_html:
+            one: "%{start_number} - %{end_number} of %{total} Work found in %{collection_link}"
+            other: "%{start_number} - %{end_number} of %{total} Works found in %{collection_link}"
+          range_with_pseud:
+            one: "%{start_number} - %{end_number} of %{total} Work by %{byline}"
+            other: "%{start_number} - %{end_number} of %{total} Works by %{byline}"
+          range_with_query_and_pseud:
+            one: "%{start_number} - %{end_number} of %{total} Work found by %{byline}"
+            other: "%{start_number} - %{end_number} of %{total} Works found by %{byline}"
+          range_with_user:
+            one: "%{start_number} - %{end_number} of %{total} Work by %{username}"
+            other: "%{start_number} - %{end_number} of %{total} Works by %{username}"
+          range_with_query_and_user:
+            one: "%{start_number} - %{end_number} of %{total} Work found by %{username}"
+            other: "%{start_number} - %{end_number} of %{total} Works found by %{username}"
+          range_with_language:
+            one: "%{start_number} - %{end_number} of %{total} Work in %{language}"
+            other: "%{start_number} - %{end_number} of %{total} Works in %{language}"
+          range_with_query_and_language:
+            one: "%{start_number} - %{end_number} of %{total} Work found in %{language}"
+            other: "%{start_number} - %{end_number} of %{total} Works found in %{language}"
+          range_with_tag_html:
+            one: "%{start_number} - %{end_number} of %{total} Work in %{tag_link}"
+            other: "%{start_number} - %{end_number} of %{total} Works in %{tag_link}"
+          range_with_query_and_tag_html:
+            one: "%{start_number} - %{end_number} of %{total} Work found in %{tag_link}"
+            other: "%{start_number} - %{end_number} of %{total} Works found in %{tag_link}"
+          range_with_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} Work in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Works in %{fandom_link}"
+          range_with_query_and_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} Work found in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Works found in %{fandom_link}"
+          range_with_collection_and_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} Work in %{collection_link} in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Works in %{collection_link} in %{fandom_link}"
+          range_with_query_and_collection_and_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} Work found in %{collection_link} in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Works found in %{collection_link} in %{fandom_link}"
+          range_with_pseud_and_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} Work by %{byline} in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Works by %{byline} in %{fandom_link}"
+          range_with_query_and_pseud_and_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} Work found by %{byline} in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Works found by %{byline} in %{fandom_link}"
+          range_with_user_and_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} Work by %{username} in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Works by %{username} in %{fandom_link}"
+          range_with_query_and_user_and_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} Work found by %{username} in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Works found by %{username} in %{fandom_link}"
+          range_with_language_and_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} Work in %{language} in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Works in %{language} in %{fandom_link}"
+          range_with_query_and_language_and_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} Work found in %{language} in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Works found in %{language} in %{fandom_link}"
+          range_with_tag_and_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} Work in %{tag_link} in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Works in %{tag_link} in %{fandom_link}"
+          range_with_query_and_tag_and_fandom_html:
+            one: "%{start_number} - %{end_number} of %{total} Work found in %{tag_link} in %{fandom_link}"
+            other: "%{start_number} - %{end_number} of %{total} Works found in %{tag_link} in %{fandom_link}"
           recent:
-            one: Recent Work
-            other: Recent Works
-      scope:
-        collection_html: in %{collection_link}
-        combined_html: "%{first_scope} %{second_scope}"
-        fandom_html: in %{fandom_link}
-        language: in %{language}
-        pseud: by %{byline}
-        tag_html: in %{tag_link}
-        user: by %{username}
-      with_query_and_scope_html: "%{results} found %{location}"
-      with_query_html: "%{results} found"
-      with_scope_html: "%{results} %{location}"
+            one: "Recent Work"
+            other: "Recent Works"
+          recent_with_query:
+            one: "Recent Work found"
+            other: "Recent Works found"
+          recent_with_collection_html:
+            one: "Recent Work in %{collection_link}"
+            other: "Recent Works in %{collection_link}"
+          recent_with_query_and_collection_html:
+            one: "Recent Work found in %{collection_link}"
+            other: "Recent Works found in %{collection_link}"
+          recent_with_pseud:
+            one: "Recent Work by %{byline}"
+            other: "Recent Works by %{byline}"
+          recent_with_query_and_pseud:
+            one: "Recent Work found by %{byline}"
+            other: "Recent Works found by %{byline}"
+          recent_with_user:
+            one: "Recent Work by %{username}"
+            other: "Recent Works by %{username}"
+          recent_with_query_and_user:
+            one: "Recent Work found by %{username}"
+            other: "Recent Works found by %{username}"
+          recent_with_language:
+            one: "Recent Work in %{language}"
+            other: "Recent Works in %{language}"
+          recent_with_query_and_language:
+            one: "Recent Work found in %{language}"
+            other: "Recent Works found in %{language}"
+          recent_with_tag_html:
+            one: "Recent Work in %{tag_link}"
+            other: "Recent Works in %{tag_link}"
+          recent_with_query_and_tag_html:
+            one: "Recent Work found in %{tag_link}"
+            other: "Recent Works found in %{tag_link}"
+          recent_with_fandom_html:
+            one: "Recent Work in %{fandom_link}"
+            other: "Recent Works in %{fandom_link}"
+          recent_with_query_and_fandom_html:
+            one: "Recent Work found in %{fandom_link}"
+            other: "Recent Works found in %{fandom_link}"
+          recent_with_collection_and_fandom_html:
+            one: "Recent Work in %{collection_link} in %{fandom_link}"
+            other: "Recent Works in %{collection_link} in %{fandom_link}"
+          recent_with_query_and_collection_and_fandom_html:
+            one: "Recent Work found in %{collection_link} in %{fandom_link}"
+            other: "Recent Works found in %{collection_link} in %{fandom_link}"
+          recent_with_pseud_and_fandom_html:
+            one: "Recent Work by %{byline} in %{fandom_link}"
+            other: "Recent Works by %{byline} in %{fandom_link}"
+          recent_with_query_and_pseud_and_fandom_html:
+            one: "Recent Work found by %{byline} in %{fandom_link}"
+            other: "Recent Works found by %{byline} in %{fandom_link}"
+          recent_with_user_and_fandom_html:
+            one: "Recent Work by %{username} in %{fandom_link}"
+            other: "Recent Works by %{username} in %{fandom_link}"
+          recent_with_query_and_user_and_fandom_html:
+            one: "Recent Work found by %{username} in %{fandom_link}"
+            other: "Recent Works found by %{username} in %{fandom_link}"
+          recent_with_language_and_fandom_html:
+            one: "Recent Work in %{language} in %{fandom_link}"
+            other: "Recent Works in %{language} in %{fandom_link}"
+          recent_with_query_and_language_and_fandom_html:
+            one: "Recent Work found in %{language} in %{fandom_link}"
+            other: "Recent Works found in %{language} in %{fandom_link}"
+          recent_with_tag_and_fandom_html:
+            one: "Recent Work in %{tag_link} in %{fandom_link}"
+            other: "Recent Works in %{tag_link} in %{fandom_link}"
+          recent_with_query_and_tag_and_fandom_html:
+            one: "Recent Work found in %{tag_link} in %{fandom_link}"
+            other: "Recent Works found in %{tag_link} in %{fandom_link}"
     search_results_found: "%{count} Found"
   series_helper:
     series_description_html: Part %{index} of %{series_link}

--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -2356,6 +2356,8 @@ en:
     guest_header:
       one: "%{count} guest has also left kudos"
       other: "%{count} guests have also left kudos"
+    index:
+      page_heading_html: "%{users} who left kudos on %{work_link}"
     user_links:
       more_link:
         one: "%{count} more user"
@@ -3175,7 +3177,6 @@ en:
       add_co-creators: Add co-creators
       show_co-creator_options: Add co-creators?
     drafts:
-      page_heading: Unposted Draft
       please_note: 'Please note:'
       unposted_drafts_get_deleted: Unposted drafts are only saved for 30 days from the day they are first created, and then deleted from %{app_name}.
     edit_tags:

--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -667,7 +667,6 @@ en:
         close_requests_html: Close Requests &#8593;
         heading:
           for_collection: Sign-ups for %{collection}
-          for_search: Sign-up
         navigation:
           download_csv: Download (CSV)
           search: Search
@@ -2357,7 +2356,7 @@ en:
       one: "%{count} guest has also left kudos"
       other: "%{count} guests have also left kudos"
     index:
-      page_heading_html: "%{users} who left kudos on %{work_link}"
+      page_heading_html: "%{users} Who Left Kudos on %{work_link}"
     user_links:
       more_link:
         one: "%{count} more user"

--- a/spec/helpers/search_helper_spec.rb
+++ b/spec/helpers/search_helper_spec.rb
@@ -1,0 +1,51 @@
+require "spec_helper"
+
+describe SearchHelper do
+  describe "#search_header" do
+    let(:single_page_collection) do
+      instance_double("SearchResults", total_pages: 1, total_entries: 1)
+    end
+    let(:paginated_collection) do
+      instance_double(
+        "SearchResults",
+        total_pages: 3,
+        total_entries: 40,
+        unlimited_total_entries: 1_400,
+        offset: 20,
+        length: 20
+      )
+    end
+
+    it "uses item-specific recent translations for unpaginated results" do
+      expect(helper.search_header([:work], item_type: :work)).to eq("Recent Work")
+      expect(helper.search_header([:work, :work], item_type: :work)).to eq("Recent Works")
+    end
+
+    it "uses item-specific count translations instead of pluralize guesses" do
+      expect(helper.search_header(single_page_collection, item_type: :unposted_draft)).to eq("1 Unposted Draft")
+    end
+
+    it "uses the unlimited total for paginated range headers" do
+      expect(helper.search_header(paginated_collection, item_type: :work)).to eq("21 - 40 of 1,400 Works")
+    end
+
+    it "assembles query and scope text through translations" do
+      search = instance_double(WorkSearchForm, query: "coffee")
+      user = create(:user, login: "creator")
+
+      expect(helper.search_header(single_page_collection, item_type: :work, search: search, parent: user)).to eq("1 Work found by creator")
+    end
+
+    it "supports explicit query flags for non-search-form callers" do
+      expect(helper.search_header(single_page_collection, item_type: :challenge_signup, query_present: true)).to eq("1 Sign-up found")
+    end
+
+    it "combines multiple scope phrases without hard-coded concatenation" do
+      tag = create(:tag, name: "Alchemy")
+      fandom = create(:fandom, name: "Dragon Age")
+
+      expect(helper.search_header(single_page_collection, item_type: :bookmark, parent: tag, fandom: fandom))
+        .to include(%(1 Bookmark in <a class="tag" href="/tags/Alchemy">Alchemy</a> in <a class="tag" href="/tags/Dragon%20Age">Dragon Age</a>))
+    end
+  end
+end

--- a/spec/helpers/search_helper_spec.rb
+++ b/spec/helpers/search_helper_spec.rb
@@ -29,7 +29,7 @@ describe SearchHelper do
       expect(helper.search_header(paginated_collection, item_type: :work)).to eq("21 - 40 of 1,400 Works")
     end
 
-    it "assembles query and scope text through translations" do
+    it "uses item and location-specific translations when query text is present" do
       search = instance_double(WorkSearchForm, query: "coffee")
       user = create(:user, login: "creator")
 
@@ -40,7 +40,7 @@ describe SearchHelper do
       expect(helper.search_header(single_page_collection, item_type: :challenge_signup, query_present: true)).to eq("1 Sign-up found")
     end
 
-    it "combines multiple scope phrases without hard-coded concatenation" do
+    it "uses item-specific translations for combined locations" do
       tag = create(:tag, name: "Alchemy")
       fandom = create(:fandom, name: "Dragon Age")
 


### PR DESCRIPTION
# Pull Request Checklist

<!-- Mark steps in the checklist as complete by changing `[ ]` to `[X]` -->
* [X] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [X] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [X] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [X] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [X] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-7357

## Purpose
Rewrote `SearchHelper#search_header` to fix three i18n issues: pluralisation now uses explicit Rails `one`/`other` keys per item type, string concatenation isreplaced with full-phrase translation keys so locales can define their own word order, and each item type now has its own key tree instead of a word being inserted into a shared string.

  The method signature was updated to use keyword arguments; all call sites in views were updated accordingly.
  
## Testing Instructions
Automated coverage was added in `spec/helpers/search_helper_spec.rb`.

(Functional QA flow is documented in the Jira ticket.)


## Credit

varram (he/him)
