### PR TITLE
AO3-7320 Don't submit deleted or spam comments to Akismet

### DIFF
--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -514,6 +514,8 @@ class Comment < ApplicationRecord
   end
 
   def submit_spam
+    return unless approved && !is_deleted
+    
     Rails.env.production? && Akismetor.submit_spam(akismet_attributes)
   end
 
@@ -522,9 +524,9 @@ class Comment < ApplicationRecord
   end
 
   def mark_as_spam!
+    submit_spam
     update_attribute(:approved, false)
     update_attribute(:spam, true)
-    submit_spam
   end
 
   def mark_as_ham!

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -922,7 +922,7 @@ describe Comment do
     context "when the comment is not marked as spam" do
       let(:comment) { create(:comment, approved: true, spam: false) }
 
-      it "flags the comment as spam." do
+      it "flags the comment as spam" do
         comment.mark_as_spam!
         comment.reload
         expect(comment.approved).to be_falsey
@@ -933,7 +933,7 @@ describe Comment do
     context "when the comment is already marked as spam" do
       let(:comment) { create(:comment, approved: false, spam: false) }
 
-      it "flags the comment as spam." do
+      it "flags the comment as spam" do
         comment.mark_as_spam!
         comment.reload
         expect(comment.approved).to be_falsey
@@ -945,7 +945,7 @@ describe Comment do
   describe "#mark_as_ham!" do
     let(:comment) { create(:comment, approved: false, spam: true) }
 
-    it "flags the comment as legitimate." do
+    it "flags the comment as legitimate" do
       comment.mark_as_ham!
       comment.reload
       expect(comment.approved).to be_truthy

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -919,13 +919,26 @@ describe Comment do
   end
 
   describe "#mark_as_spam!" do
-    let(:comment) { create(:comment, approved: true, spam: false) }
+    context "when the comment is not marked as spam" do
+      let(:comment) { create(:comment, approved: true, spam: false) }
 
-    it "flags the comment as spam." do
-      comment.mark_as_spam!
-      comment.reload
-      expect(comment.approved).to be_falsey
-      expect(comment.spam).to be_truthy
+      it "flags the comment as spam." do
+        comment.mark_as_spam!
+        comment.reload
+        expect(comment.approved).to be_falsey
+        expect(comment.spam).to be_truthy
+      end
+    end
+
+    context "when the comment is already marked as spam" do
+      let(:comment) { create(:comment, approved: false, spam: false) }
+
+      it "flags the comment as spam." do
+        comment.mark_as_spam!
+        comment.reload
+        expect(comment.approved).to be_falsey
+        expect(comment.spam).to be_truthy
+      end
     end
   end
 


### PR DESCRIPTION
…efore marking as spam

# Pull Request Checklist

<!-- Mark steps in the checklist as complete by changing `[ ]` to `[X]` -->
* [x] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [x] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [x] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [x] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-7320

## Purpose

This PR introduces a check before submitting a comment to Akismet as spam. If the comment is already marked as spam (not approved) or deleted the comment does not need to be submitted to Akismet again.

## Testing Instructions

Sorry if this is not the right spot for this.
I am aware that the RSpec test I added covers only part of the new logic.
I could not figure out how to verify that the Akismet.submit_spam method was not called. This is due to my inexperience with Ruby. 
I want to apologize in advance if this causes you undue work. I would appreciate a pointer as to how I could change my test to include said check.

## Credit

Julian Saxl 
He/Him
