### PR TITLE
AO3-4693 Fix collection deletion for collections with a challenge

### DIFF
--- a/app/models/challenge_models/gift_exchange.rb
+++ b/app/models/challenge_models/gift_exchange.rb
@@ -4,7 +4,7 @@ class GiftExchange < ApplicationRecord
 
   override_datetime_setters
 
-  has_one :collection, as: :challenge
+  has_one :collection, as: :challenge, dependent: :nullify
 
   # limits the kind of prompts users can submit
   belongs_to :request_restriction, class_name: "PromptRestriction", dependent: :destroy
@@ -43,9 +43,6 @@ class GiftExchange < ApplicationRecord
 
   # make sure that challenge sign-up / close / open dates aren't contradictory
   validate :validate_signup_dates
-
-  #  When Challenges are deleted, there are two references left behind that need to be reset to nil
-  before_destroy :clear_challenge_references
 
   after_save :copy_tag_set_from_offer_to_request
   def copy_tag_set_from_offer_to_request

--- a/app/models/challenge_models/prompt_meme.rb
+++ b/app/models/challenge_models/prompt_meme.rb
@@ -4,7 +4,7 @@ class PromptMeme < ApplicationRecord
 
   override_datetime_setters
 
-  has_one :collection, as: :challenge
+  has_one :collection, as: :challenge, dependent: :nullify
 
   # limits the kind of prompts users can submit
   belongs_to :request_restriction, class_name: "PromptRestriction", dependent: :destroy
@@ -34,9 +34,6 @@ class PromptMeme < ApplicationRecord
       self.requests_num_allowed = required
     end
   end
-
-  #  When Challenges are deleted, there are two references left behind that need to be reset to nil
-  before_destroy :clear_challenge_references
 
   def user_allowed_to_see_signups?(user)
     true

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -40,17 +40,6 @@ class Collection < ApplicationRecord
   has_many :assignments, class_name: "ChallengeAssignment", dependent: :destroy
   has_many :claims, class_name: "ChallengeClaim", dependent: :destroy
 
-  # We need to get rid of all of these if the challenge is destroyed
-  after_save :clean_up_challenge
-  def clean_up_challenge
-    return if self.challenge_id
-
-    assignments.each(&:destroy)
-    potential_matches.each(&:destroy)
-    signups.each(&:destroy)
-    prompts.each(&:destroy)
-  end
-
   has_many :collection_items, dependent: :destroy
   accepts_nested_attributes_for :collection_items, allow_destroy: true
   has_many :approved_collection_items, -> { approved_by_both }, class_name: "CollectionItem"

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -31,7 +31,13 @@ class Collection < ApplicationRecord
     self.collection_profile = CollectionProfile.new unless self.collection_profile
   end
 
-  belongs_to :challenge, dependent: :destroy, polymorphic: true
+  belongs_to :challenge, polymorphic: true
+
+  before_destroy :destroy_challenge
+  def destroy_challenge
+    challenge.destroy if challenge
+  end
+
   has_many :prompts, dependent: :destroy
 
   has_many :signups, class_name: "ChallengeSignup", dependent: :destroy

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -35,7 +35,7 @@ class Collection < ApplicationRecord
 
   before_destroy :destroy_challenge
   def destroy_challenge
-    challenge.destroy if challenge
+    challenge&.destroy
   end
 
   has_many :prompts, dependent: :destroy

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -31,12 +31,7 @@ class Collection < ApplicationRecord
     self.collection_profile = CollectionProfile.new unless self.collection_profile
   end
 
-  belongs_to :challenge, polymorphic: true
-
-  before_destroy :destroy_challenge
-  def destroy_challenge
-    challenge&.destroy
-  end
+  belongs_to :challenge, dependent: :destroy, polymorphic: true
 
   has_many :prompts, dependent: :destroy
 

--- a/lib/challenge_core.rb
+++ b/lib/challenge_core.rb
@@ -83,6 +83,15 @@ module ChallengeCore
     IndexQueue.enqueue_id(Collection, collection.id, :main)
   end
 
+  def clean_up_challenge
+    return unless collection
+
+    collection.assignments.each(&:destroy)
+    collection.potential_matches.each(&:destroy)
+    collection.signups.each(&:destroy)
+    collection.prompts.each(&:destroy)
+  end
+
   module ClassMethods
     # override datetime setters so we can take strings
     def override_datetime_setters
@@ -103,6 +112,7 @@ module ChallengeCore
   def self.included(base)
     base.class_eval do
       after_commit :update_collection_index, if: :should_update_collection_index?
+      before_destroy :clean_up_challenge
     end
     base.extend(ClassMethods)
   end

--- a/lib/challenge_core.rb
+++ b/lib/challenge_core.rb
@@ -34,14 +34,6 @@ module ChallengeCore
       end
     end
   end
-
-  # When Challenges are deleted, there are two references left behind that need to be reset to nil
-  def clear_challenge_references
-    collection.challenge_id = nil
-    collection.challenge_type = nil
-    collection.save!
-  end
-  
   # a couple of handy shorthand methods
   def required(type)
     self.send("#{type}_num_required")

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -694,17 +694,23 @@ describe Collection do
   end
 
   describe "#destroy" do
+    it "destroys the collection when it has no challenge" do
+      collection = create(:collection)
+      expect { collection.destroy! }
+        .not_to raise_error
+      expect(Collection.exists?(collection.id)).to be false
+    end
     it "destroys the collection and its gift exchange challenge" do
       challenge = create(:gift_exchange)
       collection = create(:collection, challenge: challenge)
-      collection.destroy
+      collection.destroy!
       expect(Collection.exists?(collection.id)).to be false
       expect(GiftExchange.exists?(challenge.id)).to be false
     end
     it "destroys the collection and its prompt meme challenge" do
       challenge = create(:prompt_meme)
       collection = create(:collection, challenge: challenge)
-      collection.destroy
+      collection.destroy!
       expect(Collection.exists?(collection.id)).to be false
       expect(PromptMeme.exists?(challenge.id)).to be false
     end

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -692,4 +692,21 @@ describe Collection do
       end
     end
   end
+
+  describe "#destroy" do
+    it "destroys the collection and its gift exchange challenge" do
+      challenge = create(:gift_exchange)
+      collection = create(:collection, challenge: challenge)
+      collection.destroy
+      expect(Collection.exists?(collection.id)).to be false
+      expect(GiftExchange.exists?(challenge.id)).to be false
+    end
+    it "destroys the collection and its prompt meme challenge" do
+      challenge = create(:prompt_meme)
+      collection = create(:collection, challenge: challenge)
+      collection.destroy
+      expect(Collection.exists?(collection.id)).to be false
+      expect(PromptMeme.exists?(challenge.id)).to be false
+    end
+  end
 end

--- a/spec/models/gift_exchange_spec.rb
+++ b/spec/models/gift_exchange_spec.rb
@@ -43,6 +43,23 @@ describe GiftExchange do
     end
   end
 
+  describe "#destroy" do
+    let!(:challenge) { create(:gift_exchange) }
+    let!(:collection) { create(:collection, challenge: challenge) }
+
+    it "does not destroy the collection" do
+      challenge.destroy!
+      expect(Collection.exists?(collection.id)).to be true
+    end
+
+    it "nullifies the collection's challenge reference" do
+      challenge.destroy!
+      collection.reload
+      expect(collection.challenge_id).to be_nil
+      expect(collection.challenge_type).to be_nil
+    end
+  end
+
   describe "reindexing" do
     let!(:collection) { create(:collection) }
 

--- a/spec/models/gift_exchange_spec.rb
+++ b/spec/models/gift_exchange_spec.rb
@@ -47,11 +47,6 @@ describe GiftExchange do
     let!(:challenge) { create(:gift_exchange) }
     let!(:collection) { create(:collection, challenge: challenge) }
 
-    it "does not destroy the collection" do
-      challenge.destroy!
-      expect(Collection.exists?(collection.id)).to be true
-    end
-
     it "nullifies the collection's challenge references" do
       challenge.destroy!
       collection.reload

--- a/spec/models/gift_exchange_spec.rb
+++ b/spec/models/gift_exchange_spec.rb
@@ -52,7 +52,7 @@ describe GiftExchange do
       expect(Collection.exists?(collection.id)).to be true
     end
 
-    it "nullifies the collection's challenge reference" do
+    it "nullifies the collection's challenge references" do
       challenge.destroy!
       collection.reload
       expect(collection.challenge_id).to be_nil

--- a/spec/models/prompt_meme_spec.rb
+++ b/spec/models/prompt_meme_spec.rb
@@ -5,11 +5,6 @@ describe PromptMeme do
     let!(:challenge) { create(:prompt_meme) }
     let!(:collection) { create(:collection, challenge: challenge) }
 
-    it "does not destroy the collection" do
-      challenge.destroy!
-      expect(Collection.exists?(collection.id)).to be true
-    end
-
     it "nullifies the collection's challenge references" do
       challenge.destroy!
       collection.reload

--- a/spec/models/prompt_meme_spec.rb
+++ b/spec/models/prompt_meme_spec.rb
@@ -10,7 +10,7 @@ describe PromptMeme do
       expect(Collection.exists?(collection.id)).to be true
     end
 
-    it "nullifies the collection's challenge reference" do
+    it "nullifies the collection's challenge references" do
       challenge.destroy!
       collection.reload
       expect(collection.challenge_id).to be_nil

--- a/spec/models/prompt_meme_spec.rb
+++ b/spec/models/prompt_meme_spec.rb
@@ -1,6 +1,23 @@
 require "spec_helper"
 
 describe PromptMeme do
+  describe "#destroy" do
+    let!(:challenge) { create(:prompt_meme) }
+    let!(:collection) { create(:collection, challenge: challenge) }
+
+    it "does not destroy the collection" do
+      challenge.destroy!
+      expect(Collection.exists?(collection.id)).to be true
+    end
+
+    it "nullifies the collection's challenge reference" do
+      challenge.destroy!
+      collection.reload
+      expect(collection.challenge_id).to be_nil
+      expect(collection.challenge_type).to be_nil
+    end
+  end
+
   describe "reindexing" do
     let!(:collection) { create(:collection) }
 


### PR DESCRIPTION
# Pull Request Checklist

<!-- Mark steps in the checklist as complete by changing `[ ]` to `[X]` -->
* [X] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [X] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [X] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [X] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [X] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-4693

## Purpose

This PR fixes deletion for collections with an associated challenge (gift exchange or prompt meme) by destroying the challenge first before the collection itself.

## Credit

Aya Sayadi