### PR TITLE
AO3-7375 Fix TypeError by adding localStorage feature check for accepted_tos check

### DIFF
--- a/app/views/layouts/_javascripts.html.erb
+++ b/app/views/layouts/_javascripts.html.erb
@@ -89,7 +89,7 @@
             cookie need the popup.
             We have to use JavaScript to remember their choice or risk issues
             when full page caching is enabled. %>
-        if (localStorage.getItem("accepted_tos") !== "<%= @current_tos_version %>" && Cookies.get("accepted_tos") !== "<%= @current_tos_version %>") {
+        if ((!isSupported() || localStorage.getItem("accepted_tos") !== "<%= @current_tos_version %>") && Cookies.get("accepted_tos") !== "<%= @current_tos_version %>") {
           $j("body").prepend("<%= escape_javascript(render "layouts/tos_prompt") %>");
         }
       <% end %>


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [ ] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [x] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [x] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-7375

## Purpose

Check that `localStorage` is supported before using it to look for an `accepted_tos` entry. This prevents an error like `Uncaught TypeError: can't access property "getItem", localStorage is null` which breaks subsequent JS on the page, including further jquery `$j(document).ready()` callbacks.

## Testing Instructions

In Firefox, set `dom.storage.enabled` to `false` in `about:config`. Load any page and open the JS console, observe no `Uncaught TypeError`.

Compare to the same on `master`, which does result in the `TypeError`.

## References

Discovered and discussed in #5641, specifically under the last details block in the [comment attaching screenshots](https://github.com/otwcode/otwarchive/pull/5641#issuecomment-4187675439).

## Credit

mjec (they/them)