### PR TITLE
AO3-6084 Improve error behavior for Add Prompt form (prompt memes)

### DIFF
--- a/app/controllers/prompts_controller.rb
+++ b/app/controllers/prompts_controller.rb
@@ -125,8 +125,7 @@ class PromptsController < ApplicationController
       flash[:notice] = ts("Prompt was successfully added.")
       redirect_to collection_signup_path(@collection, @challenge_signup)
     else
-      flash[:error] = ts("That prompt would make your overall sign-up invalid, sorry.")
-      redirect_to edit_collection_signup_path(@collection, @challenge_signup)
+      render action: :new
     end
   end
 

--- a/app/views/prompts/new.html.erb
+++ b/app/views/prompts/new.html.erb
@@ -10,6 +10,7 @@
 
 <!--main content-->
 <%= form_for @prompt, :as => :prompt, :url => collection_prompts_path(@collection), :html => {:method => :post} do |form| %>
+  <%= error_messages_for @prompt %>
   <%= render "prompt_form", :form => form, :required => true, :index => @index %>
   <%= submit_fieldset form %>
 <% end %>

--- a/spec/controllers/prompts_controller_spec.rb
+++ b/spec/controllers/prompts_controller_spec.rb
@@ -24,7 +24,7 @@ describe PromptsController do
       it "displays the prompt" do
         get :show, params: { collection_id: collection.name, id: prompt.id }
         expect(flash[:error]).blank?
-        expect(response).to have_http_status(200)
+        expect(response).to have_http_status(:ok)
         expect(response).to render_template("prompts/show")
         expect(assigns(:prompt)).to eq(prompt)
       end
@@ -117,7 +117,7 @@ describe PromptsController do
       let(:user) { Pseud.find(ChallengeSignup.in_collection(open_signup.collection).first.pseud_id).user }
       it "should have no errors" do
         post :new, params: { collection_id: open_signup.collection.name, prompt_type: "offer" }
-        expect(response).to have_http_status(200)
+        expect(response).to have_http_status(:ok)
         expect(flash[:error]).blank?
         expect(assigns(:index)).to eq(open_signup.offers.count)
       end
@@ -175,7 +175,7 @@ describe PromptsController do
             }
           }
         }
-        expect(response).to have_http_status(200) # no redirect
+        expect(response).to have_http_status(:ok) # no redirect
         expect(assigns[:prompt].errors[:base]).to eq(
           ["^These character tags in your offer are not canonical and cannot be used in this challenge: Sakura Typomoto. To fix this, please ask your challenge moderator to set up a tag set for the challenge. New tags can be added to the tag set manually by the moderator or through open nominations."]
         )

--- a/spec/controllers/prompts_controller_spec.rb
+++ b/spec/controllers/prompts_controller_spec.rb
@@ -126,10 +126,18 @@ describe PromptsController do
 
   describe "create" do
     let(:user) { Pseud.find(ChallengeSignup.in_collection(open_signup.collection).first.pseud_id).user }
-    it "should have no errors and redirect to the edit page" do
-      post :create, params: { collection_id: open_signup.collection.name, prompt_type: "offer", prompt: { description: "This is a description." } }
-      it_redirects_to_simple("#{collection_signups_path(open_signup.collection)}/"\
-                      "#{open_signup.collection.prompts.first.challenge_signup_id}/edit")
+    it "should have no errors and redirect to the signup page" do
+      # Delete existing prompt of current user
+      open_signup.offers.first.destroy
+      post :create, params: {
+        collection_id: open_signup.collection.name,
+        prompt_type: "offer",
+        prompt: { description: "This is a description." }
+      }
+      it_redirects_to_with_notice(
+        collection_signup_path(open_signup.collection, open_signup),
+        "Prompt was successfully added."
+      )
     end
 
     context "prompt has tags" do
@@ -167,10 +175,7 @@ describe PromptsController do
             }
           }
         }
-        it_redirects_to_with_error(
-          edit_collection_signup_path(open_signup.collection, open_signup),
-          "That prompt would make your overall sign-up invalid, sorry."
-        )
+        expect(response).to have_http_status(200) # no redirect
         expect(assigns[:prompt].errors[:base]).to eq(
           ["^These character tags in your offer are not canonical and cannot be used in this challenge: Sakura Typomoto. To fix this, please ask your challenge moderator to set up a tag set for the challenge. New tags can be added to the tag set manually by the moderator or through open nominations."]
         )


### PR DESCRIPTION
# Pull Request Checklist

<!-- Mark steps in the checklist as complete by changing `[ ]` to `[X]` -->
* [X] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [X] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [X] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [X] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [X] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-6084

## Purpose

Add a potential error message section to the Add Prompt form. When the user uses the Add Prompt form to add a prompt with a noncanonical tag, instead of redirecting to the Edit Sign-up form, just re-render the Add Prompt form (preserving the user's input); the noncanonical tag error message (already set up for Edit Sign-up and Edit Prompt) automatically appears in the potential error message section.

(n.b. I didn't add any extra tests, just edited the ones that covered the original behavior)

## Credit

Ling-Yi (any pronouns)