### PR TITLE
AO3-7337 Update sign-up closing times to the correct timezone for collection blurbs

### DIFF
--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -409,8 +409,13 @@ class Collection < ApplicationRecord
   def self.expire_blurb_cache(id)
     # Expire both versions of the blurb, whether the user is logged in or not.
     %w[logged-in logged-out].each do |logged_in|
-      cache_key = "collection-blurb-#{logged_in}-#{id}-v5"
-      ActionController::Base.new.expire_fragment(cache_key)
+      [
+        "collection-blurb-#{logged_in}-#{id}-v5-header",
+        "collection-blurb-#{logged_in}-#{id}-v5-summary",
+        "collection-blurb-#{logged_in}-#{id}-v5-body"
+      ].each do |cache_key|
+        ActionController::Base.new.expire_fragment(cache_key)
+      end
     end
   end
 

--- a/app/views/collections/_collection_blurb.html.erb
+++ b/app/views/collections/_collection_blurb.html.erb
@@ -1,7 +1,7 @@
 <li class="<% if collection.user_is_owner?(current_user) %>own <% end %>collection picture blurb group" role="article">
   <% logged_in = (logged_in_as_admin? || logged_in?) ? "logged-in" : "logged-out" %>
-  <%# remember to update Collection.expire_blurb_cache if you change this key %>
-  <% cache("collection-blurb-#{logged_in}-#{collection.id}-v5", expires_in: ArchiveConfig.MINUTES_UNTIL_COLLECTION_BLURBS_EXPIRE.minutes, skip_digest: true) do %>
+  <%# remember to update Collection.expire_blurb_cache if you change this key (or the similar summary and body keys below) %>
+  <% cache("collection-blurb-#{logged_in}-#{collection.id}-v5-header", expires_in: ArchiveConfig.MINUTES_UNTIL_COLLECTION_BLURBS_EXPIRE.minutes, skip_digest: true) do %>
     <div class="header module group">
       <h4 class="heading">
         <%= link_to collection.title, collection_path(collection) %>
@@ -21,17 +21,20 @@
         </h5>
       <% end %>
     </div>
+  <% end %> <!-- end blurb header cache -->
 
-    <!--summary/descriptions-->
-    <h6 class="landmark heading"><%= ts("Summary") %></h6>
-    <blockquote class="userstuff summary">
+  <!--summary/descriptions-->
+  <h6 class="landmark heading"><%= t(".summary") %></h6>
+  <blockquote class="userstuff summary">
+    <% cache("collection-blurb-#{logged_in}-#{collection.id}-v5-summary", expires_in: ArchiveConfig.MINUTES_UNTIL_COLLECTION_BLURBS_EXPIRE.minutes, skip_digest: true) do %>
       <%=raw strip_images(sanitize_field(collection, :description)) || "&nbsp;".html_safe %>
+    <% end %><!-- end blurb summary cache -->
+    <% if collection.challenge && collection.challenge.signup_open %>
+      <p><%= t(".signups_close_at") %> <%= time_in_zone(collection.challenge.signups_close_at, (collection.challenge.time_zone || Time.zone.name)) %></p>
+    <% end %>
+  </blockquote>
 
-      <% if collection.challenge && collection.challenge.signup_open %>
-        <p><%= ts("Sign-ups close at:") %> <%= time_in_zone(collection.challenge.signups_close_at, (collection.challenge.time_zone || Time.zone.name)) %></p>
-      <% end %>
-    </blockquote>
-
+  <% cache("collection-blurb-#{logged_in}-#{collection.id}-v5-body", expires_in: ArchiveConfig.MINUTES_UNTIL_COLLECTION_BLURBS_EXPIRE.minutes, skip_digest: true) do %>
     <p class="type">
       (<%= collection.closed? ? ts("Closed") : ts("Open") %>, <%= collection.moderated? ? ts("Moderated") : ts("Unmoderated") %><%= collection.unrevealed? ? ts(", Unrevealed") : "" %><%= collection.anonymous? ? ts(", Anonymous") : "" %><%= collection.gift_exchange? ? ts(", Gift Exchange Challenge") : "" %><%= collection.prompt_meme? ? ts(", Prompt Meme Challenge") : "" %>)
     </p>
@@ -54,7 +57,7 @@
       <% end %>
     </dl>
 
-  <% end %><!-- end cache -->
+  <% end %><!-- end blurb body cache -->
 
   <% if collection.user_is_owner?(current_user) || (collection.challenge && collection.challenge.signup_open && logged_in?) || (collection.moderated? && logged_in?) %>
     <h6 class="landmark heading"><%= ts("User Actions") %></h6>

--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -755,6 +755,8 @@ en:
   collections:
     collection_blurb:
       collection_tags: 'Collection Tags:'
+      signups_close_at: 'Sign-ups close at:'
+      summary: Summary
     filters:
       clear_filters: Clear Filters
       closed:

--- a/features/prompt_memes_a/challenge_promptmeme_setup.feature
+++ b/features/prompt_memes_a/challenge_promptmeme_setup.feature
@@ -22,6 +22,17 @@ Feature: Prompt Meme Challenge
   When I create Battle 12 promptmeme
   Then Battle 12 prompt meme should be correctly created
 
+  Scenario: Prompt meme timezone updates without caching
+  
+  Given I have Battle 12 prompt meme fully set up
+    And I am logged in as "scott"
+  When the user "scott" sets the time zone to "Nairobi"
+    And I go to the Collections page
+  Then I should see "EAT" within ".collection.picture.index.group .userstuff.summary"
+  When the user "scott" sets the time zone to "Mumbai"
+    And I go to the Collections page
+  Then I should see "IST" within ".collection.picture.index.group .userstuff.summary"
+
   Scenario: User can see a prompt meme
   
   Given I have Battle 12 prompt meme fully set up


### PR DESCRIPTION
# Pull Request Checklist

<!-- Mark steps in the checklist as complete by changing `[ ]` to `[X]` -->
* [X] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [X] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [X] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [X] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [X] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-7337

## Purpose

Separates the collection blurb cache into 3 separate caches to exclude the sign-up closing time field so that it updates immediately upon the user changing their timezone in Preferences.

## References

(Identical to #5698 but with the commit history cleaned up.)

## Credit

Ling-Yi (any pronouns)
