### PR TITLE
AO3-7325 Don't attach HTML of work to Abuse ticket when reporting bookmarks

### DIFF
--- a/app/models/abuse_report.rb
+++ b/app/models/abuse_report.rb
@@ -182,10 +182,11 @@ class AbuseReport < ApplicationRecord
     end
   end
 
-  # ID of the reported work, unless the report is about comment(s) on the work
+  # ID of the reported work, unless the report is about comment(s) or bookmark(s) on the work
   def reported_work_id
     comments = url[%r{/comments/}, 0]
-    url[%r{/works/(\d+)}, 1] if comments.nil?
+    bookmarks = url[%r{/bookmarks}, 0]
+    url[%r{/works/(\d+)}, 1] if comments.nil? && bookmarks.nil?
   end
 
   # ID of the reported comment

--- a/app/models/abuse_report.rb
+++ b/app/models/abuse_report.rb
@@ -185,7 +185,7 @@ class AbuseReport < ApplicationRecord
   # ID of the reported work, unless the report is about comment(s) or bookmark(s) on the work
   def reported_work_id
     comments = url[%r{/comments/}, 0]
-    bookmarks = url[%r{/bookmarks}, 0]
+    bookmarks = url[%r{/bookmarks/}, 0]
     url[%r{/works/(\d+)}, 1] if comments.nil? && bookmarks.nil?
   end
 

--- a/spec/models/abuse_report_spec.rb
+++ b/spec/models/abuse_report_spec.rb
@@ -693,7 +693,7 @@ describe AbuseReport do
 
     context "for a work URL with bookmarks" do
       it "returns nil" do
-        allow(subject).to receive(:url).and_return("http://archiveofourown.org/works/123/bookmarks")
+        allow(subject).to receive(:url).and_return("http://archiveofourown.org/works/123/bookmarks/")
         expect(subject.reported_work_id).to be_nil
       end
     end

--- a/spec/models/abuse_report_spec.rb
+++ b/spec/models/abuse_report_spec.rb
@@ -669,6 +669,43 @@ describe AbuseReport do
     end
   end
 
+  describe "#reported_work_id" do
+    context "for a plain work URL" do
+      it "returns the work id" do
+        allow(subject).to receive(:url).and_return("http://archiveofourown.org/works/123/")
+        expect(subject.reported_work_id).to eq("123")
+      end
+    end
+
+    context "for a work URL with bookmark-form anchor" do
+      it "returns the work id" do
+        allow(subject).to receive(:url).and_return("http://archiveofourown.org/works/123#bookmark-form")
+        expect(subject.reported_work_id).to eq("123")
+      end
+    end
+
+    context "for a work URL with comments" do
+      it "returns nil" do
+        allow(subject).to receive(:url).and_return("http://archiveofourown.org/works/123/comments/")
+        expect(subject.reported_work_id).to be_nil
+      end
+    end
+
+    context "for a work URL with bookmarks" do
+      it "returns nil" do
+        allow(subject).to receive(:url).and_return("http://archiveofourown.org/works/123/bookmarks")
+        expect(subject.reported_work_id).to be_nil
+      end
+    end
+
+    context "for a work URL with a specific bookmark" do
+      it "returns nil" do
+        allow(subject).to receive(:url).and_return("http://archiveofourown.org/works/123/bookmarks/456/")
+        expect(subject.reported_work_id).to be_nil
+      end
+    end
+  end
+
   describe "#creator_ids" do
     it "returns no creator ids for non-work URLs" do
       allow(subject).to receive(:url).and_return("http://archiveofourown.org/users/someone/")

--- a/spec/models/abuse_report_spec.rb
+++ b/spec/models/abuse_report_spec.rb
@@ -693,7 +693,7 @@ describe AbuseReport do
 
     context "for a work URL with bookmarks" do
       it "returns nil" do
-        subject.url = "http://archiveofourown.org/works/123/bookmarks"
+        subject.url = "http://archiveofourown.org/works/123/bookmarks/"
         expect(subject.reported_work_id).to be_nil
       end
     end

--- a/spec/models/abuse_report_spec.rb
+++ b/spec/models/abuse_report_spec.rb
@@ -672,35 +672,36 @@ describe AbuseReport do
   describe "#reported_work_id" do
     context "for a plain work URL" do
       it "returns the work id" do
-        allow(subject).to receive(:url).and_return("http://archiveofourown.org/works/123/")
+        # allow(subject).to receive(:url).and_return("http://archiveofourown.org/works/123/")
+        subject.url = "http://archiveofourown.org/works/123/"
         expect(subject.reported_work_id).to eq("123")
       end
     end
 
     context "for a work URL with bookmark-form anchor" do
       it "returns the work id" do
-        allow(subject).to receive(:url).and_return("http://archiveofourown.org/works/123#bookmark-form")
+        subject.url = "http://archiveofourown.org/works/123#bookmark-form"
         expect(subject.reported_work_id).to eq("123")
       end
     end
 
     context "for a work URL with comments" do
       it "returns nil" do
-        allow(subject).to receive(:url).and_return("http://archiveofourown.org/works/123/comments/")
+        subject.url = "http://archiveofourown.org/works/123/comments/"
         expect(subject.reported_work_id).to be_nil
       end
     end
 
     context "for a work URL with bookmarks" do
       it "returns nil" do
-        allow(subject).to receive(:url).and_return("http://archiveofourown.org/works/123/bookmarks/")
+        subject.url = "http://archiveofourown.org/works/123/comments/"
         expect(subject.reported_work_id).to be_nil
       end
     end
 
     context "for a work URL with a specific bookmark" do
       it "returns nil" do
-        allow(subject).to receive(:url).and_return("http://archiveofourown.org/works/123/bookmarks/456/")
+        subject.url = "http://archiveofourown.org/works/123/comments/"
         expect(subject.reported_work_id).to be_nil
       end
     end

--- a/spec/models/abuse_report_spec.rb
+++ b/spec/models/abuse_report_spec.rb
@@ -672,7 +672,6 @@ describe AbuseReport do
   describe "#reported_work_id" do
     context "for a plain work URL" do
       it "returns the work id" do
-        # allow(subject).to receive(:url).and_return("http://archiveofourown.org/works/123/")
         subject.url = "http://archiveofourown.org/works/123/"
         expect(subject.reported_work_id).to eq("123")
       end
@@ -694,14 +693,14 @@ describe AbuseReport do
 
     context "for a work URL with bookmarks" do
       it "returns nil" do
-        subject.url = "http://archiveofourown.org/works/123/comments/"
+        subject.url = "http://archiveofourown.org/works/123/bookmarks"
         expect(subject.reported_work_id).to be_nil
       end
     end
 
     context "for a work URL with a specific bookmark" do
       it "returns nil" do
-        subject.url = "http://archiveofourown.org/works/123/comments/"
+        subject.url = "http://archiveofourown.org/works/123/bookmarks/456/"
         expect(subject.reported_work_id).to be_nil
       end
     end


### PR DESCRIPTION
# Pull Request Checklist
<!-- Mark steps in the checklist as complete by changing `[ ]` to `[X]` -->
* [X] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [X] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [X] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [X] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [X] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue
https://otwarchive.atlassian.net/browse/AO3-7325

## Purpose
What does this PR do?
This PR adds exclusion criteria, to prevent attaching HTML of the work to an abuse ticket when reporting a bookmark. 

## Testing Instructions

How can the Archive's QA team verify that this is working as you intended?
I'm not sure how to test in development with Zoho ticket, open to guidance on how to test that functionality. 

## Credit

What name and pronouns should we use to credit you in the [Archive of Our Own's Release Notes](https://archiveofourown.org/admin_posts?tag=1)?

Scott Venkataraman he/him