### PR TITLE
AO3-7316 Change admin banner wrapper from blockquote to div

### DIFF
--- a/app/views/admin/banners/_banner.html.erb
+++ b/app/views/admin/banners/_banner.html.erb
@@ -1,7 +1,7 @@
 <% # expects admin_banner %>
 <% # don't forget to update layouts/banner! %>
 <div class="<%= admin_banner.banner_type %> announcement group">
-  <blockquote class="userstuff">
+  <div class="userstuff">
     <%= raw sanitize_field(admin_banner, :content, image_safety_mode: true) %>
-  </blockquote>
+  </div>
 </div>

--- a/app/views/layouts/_banner.html.erb
+++ b/app/views/layouts/_banner.html.erb
@@ -1,9 +1,9 @@
 <% if @admin_banner&.active? %>
   <% unless session[:hide_banner] || current_user&.preference&.banner_seen %>
     <div class="<%= @admin_banner.banner_type %> announcement group" id="admin-banner">
-      <blockquote class="userstuff">
+      <div class="userstuff">
         <%= raw sanitize_field(@admin_banner, :content, image_safety_mode: true) %>
-      </blockquote>
+      </div>
       <% if current_user.nil? %>
         <p class="submit">
           <%= link_to current_path_with(hide_banner: true), "aria-label": t(".hide"), class: "showme action" do


### PR DESCRIPTION
# Pull Request Checklist

* [X] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [X] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [ ] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [X] Have you added the [Jira](https://otwarchive.atlassian.net) issue number as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)?
* [X] Do you have fewer than 5 pull requests already open? If not, please wait until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-7316

## Purpose

Changes the banner content wrapper from `blockquote.userstuff` to `div.userstuff` in:

- `app/views/layouts/_banner.html.erb`
- `app/views/admin/banners/_banner.html.erb`

This matches the structure used for support notices.

## Testing Instructions

Follow the Jira testing instructions for AO3-7316:
https://otwarchive.atlassian.net/browse/AO3-7316

Note: I did not add a new automated test for this change, as it is primarily a visual/markup update. I validated it manually using the Jira steps and also ran the existing banner feature tests.

## Screenshots

Before:
<img width="1363" height="744" alt="before" src="https://github.com/user-attachments/assets/65962c23-4b75-4e69-bf6c-8cb018818199" />

After:
<img width="1365" height="698" alt="after" src="https://github.com/user-attachments/assets/37d46590-a8a9-44c4-984b-9c28dc78481b" />

## Credit

Name: Noah Bravo  
Pronouns: they/them