### PR TITLE
AO3-7377 Bump Addressable from 2.8.7 to 2.9.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -116,8 +116,8 @@ GEM
       uri (>= 0.13.1)
     acts_as_list (0.9.19)
       activerecord (>= 3.0)
-    addressable (2.8.7)
-      public_suffix (>= 2.0.2, < 7.0)
+    addressable (2.9.0)
+      public_suffix (>= 2.0.2, < 8.0)
     after_commit_everywhere (1.6.0)
       activerecord (>= 4.2)
       activesupport


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-7377

## Purpose

Bump a gem to resolve an advisory that doesn't affect us, but it's nice to be up-to-date anyway.

## Credit

Bilka
