### PR TITLE
AO3-7012 Show restricted works on gift pages to admins

### DIFF
--- a/app/controllers/gifts_controller.rb
+++ b/app/controllers/gifts_controller.rb
@@ -13,18 +13,18 @@ class GiftsController < ApplicationController
     end
 
     if @user
-      @works = if @can_access_refused_gifts && params[:refused]
-                 @user.rejected_gift_works.visible_to_registered_user
-               elsif current_user.nil?
-                 @user.gift_works.visible_to_all
-               else
-                 @user.gift_works.visible_to_registered_user
-               end
+      @works = @can_access_refused_gifts && params[:refused] ? @user.rejected_gift_works : @user.gift_works
     else
       pseud = Pseud.parse_byline(@recipient_name)
       @works = pseud ? pseud.gift_works : Work.giftworks_for_recipient_name(@recipient_name)
-      @works = current_user.nil? ? @works.visible_to_all : @works.visible_to_registered_user
     end
+    @works = if logged_in_as_admin?
+               @works.visible_to_admin
+             elsif logged_in?
+               @works.visible_to_registered_user
+             else
+               @works.visible_to_all
+             end
     @works = @works.in_collection(@collection) if @collection
     @works = @works.order("revised_at DESC").paginate(page: params[:page], per_page: ArchiveConfig.ITEMS_PER_PAGE)
   end

--- a/app/controllers/gifts_controller.rb
+++ b/app/controllers/gifts_controller.rb
@@ -18,12 +18,10 @@ class GiftsController < ApplicationController
       pseud = Pseud.parse_byline(@recipient_name)
       @works = pseud ? pseud.gift_works : Work.giftworks_for_recipient_name(@recipient_name)
     end
-    @works = if logged_in_as_admin?
-               @works.visible_to_admin
-             elsif logged_in?
-               @works.visible_to_registered_user
-             else
+    @works = if guest?
                @works.visible_to_all
+             else
+               @works.visible_to_registered_user
              end
     @works = @works.in_collection(@collection) if @collection
     @works = @works.order("revised_at DESC").paginate(page: params[:page], per_page: ArchiveConfig.ITEMS_PER_PAGE)

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -102,12 +102,10 @@ module UsersHelper
   end
 
   def gifts_link(user)
-    works = if logged_in_as_admin?
-              user.gift_works.visible_to_admin
-            elsif logged_in?
-              user.gift_works.visible_to_registered_user
-            else
+    works = if User.current_user.nil?
               user.gift_works.visible_to_all
+            else
+              user.gift_works.visible_to_registered_user
             end
     gift_number = works.distinct.count
     span_if_current t("users_helper.gifts_link", gift_number: gift_number), user_gifts_path(user)

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -102,12 +102,15 @@ module UsersHelper
   end
 
   def gifts_link(user)
-    if current_user.nil?
-      gift_number = user.gift_works.visible_to_all.distinct.count
-    else
-      gift_number = user.gift_works.visible_to_registered_user.distinct.count
-    end
-    span_if_current ts('Gifts (%{gift_number})', gift_number: gift_number.to_s), user_gifts_path(user)
+    works = if logged_in_as_admin?
+              user.gift_works.visible_to_admin
+            elsif logged_in?
+              user.gift_works.visible_to_registered_user
+            else
+              user.gift_works.visible_to_all
+            end
+    gift_number = works.distinct.count
+    span_if_current t("users_helper.gifts_link", gift_number: gift_number), user_gifts_path(user)
   end
 
   def authored_items(pseud, work_counts = {}, rec_counts = {})

--- a/config/locales/helpers/en.yml
+++ b/config/locales/helpers/en.yml
@@ -56,6 +56,7 @@ en:
       title: Symbols key
   users_helper:
     collections_link: Collections (%{coll_number})
+    gifts_link: Gifts (%{gift_number})
     log:
       ban: Suspended Permanently
       email_change: Email Changed

--- a/features/other_a/gift.feature
+++ b/features/other_a/gift.feature
@@ -39,10 +39,29 @@ Feature: Create Gifts
       And I set up the draft "GiftStory2" as a gift to "giftee1"
       And I lock the work
       And I press "Post"
+      And I post the work "Rude Gift" as a gift for "giftee1"
+      And I am logged in as a super admin
+      And I hide the work "Rude Gift"
       And I log out
-      And I go to the gifts page for the recipient giftee1
+      And I go to giftee1's gifts page
     Then I should see "GiftStory1 by gifter for giftee1"
       And I should not see "GiftStory2 by gifter for giftee1"
+      And I should see "Gifts (1)"
+
+  Scenario: When logged in as admin, gifts page for recipient should show locked and hidden gifts
+    When I give the work to "giftee1"
+      And I press "Post"
+      And I set up the draft "GiftStory2" as a gift to "giftee1"
+      And I lock the work
+      And I press "Post"
+      And I post the work "Rude Gift" as a gift for "giftee1"
+      And I am logged in as a super admin
+      And I hide the work "Rude Gift"
+    When I go to giftee1's gifts page
+    Then I should see "GiftStory1 by gifter for giftee1"
+      And I should see "GiftStory2 by gifter for giftee1"
+      And I should see "Rude Gift by gifter for giftee1"
+      And I should see "Gifts (3)"
 
   Scenario: Gifts page for user should show gifts given to their pseud
     Given I give the work to "g1 (giftee1)"
@@ -62,10 +81,27 @@ Feature: Create Gifts
       And I set up the draft "GiftStory2" as a gift to "g1"
       And I lock the work
       And I press "Post"
+      And I post the work "Rude Gift" as a gift for "g1"
+      And I am logged in as a super admin
+      And I hide the work "Rude Gift"
       And I log out
     When I go to the gifts page for the recipient g1
     Then I should see "GiftStory1 by gifter for g1"
       And I should not see "GiftStory2 by gifter for g1"
+
+  Scenario: When logged in as admin, gifts page for recipient without account should show locked and hidden gifts
+    When I give the work to "g1"
+      And I press "Post"
+      And I set up the draft "GiftStory2" as a gift to "g1"
+      And I lock the work
+      And I press "Post"
+      And I post the work "Rude Gift" as a gift for "g1"
+      And I am logged in as a super admin
+      And I hide the work "Rude Gift"
+    When I go to the gifts page for the recipient g1
+    Then I should see "GiftStory1 by gifter for g1"
+      And I should see "GiftStory2 by gifter for g1"
+      And I should see "Rude Gift by gifter for g1"
 
   Scenario: Giving a work as a gift when posting directly
     Given I give the work to "giftee1"

--- a/features/other_a/gift.feature
+++ b/features/other_a/gift.feature
@@ -22,8 +22,13 @@ Feature: Create Gifts
   Scenario: Gifts page for recipient should show recipient's gifts
     When I give the work to "giftee1"
       And I press "Post"
+      And I post the work "Rude Gift" as a gift for "giftee1"
+      And I am logged in as a super admin
+      And I hide the work "Rude Gift"
+      And I am logged in as "gifter"
       And I go to the gifts page for the recipient giftee1
     Then I should see "GiftStory1 by gifter for giftee1"
+      And I should not see "Rude Gift by gifter for giftee1"
 
   Scenario: Work blurb includes an HTML comment containing the unix epoch of the updated time
 
@@ -73,8 +78,13 @@ Feature: Create Gifts
   Scenario: Gifts page for recipient without account should show their gifts
     Given I give the work to "g1"
       And I press "Post"
+      And I post the work "Rude Gift" as a gift for "g1"
+      And I am logged in as a super admin
+      And I hide the work "Rude Gift"
+      And I am logged in as "gifter"
     When I go to the gifts page for the recipient g1
     Then I should see "GiftStory1 by gifter for g1"
+      And I should not see "Rude Gift by gifter for g1"
 
   Scenario: When logged out, gifts page for recipient without account should show gifts visible to all
     When I give the work to "g1"

--- a/features/other_a/gift.feature
+++ b/features/other_a/gift.feature
@@ -48,7 +48,7 @@ Feature: Create Gifts
       And I should not see "GiftStory2 by gifter for giftee1"
       And I should see "Gifts (1)"
 
-  Scenario: When logged in as admin, gifts page for recipient should show locked and hidden gifts
+  Scenario: When logged in as admin, gifts page for recipient should show locked but not hidden gifts
     When I give the work to "giftee1"
       And I press "Post"
       And I set up the draft "GiftStory2" as a gift to "giftee1"
@@ -60,8 +60,8 @@ Feature: Create Gifts
     When I go to giftee1's gifts page
     Then I should see "GiftStory1 by gifter for giftee1"
       And I should see "GiftStory2 by gifter for giftee1"
-      And I should see "Rude Gift by gifter for giftee1"
-      And I should see "Gifts (3)"
+      And I should not see "Rude Gift by gifter for giftee1"
+      And I should see "Gifts (2)"
 
   Scenario: Gifts page for user should show gifts given to their pseud
     Given I give the work to "g1 (giftee1)"
@@ -89,7 +89,7 @@ Feature: Create Gifts
     Then I should see "GiftStory1 by gifter for g1"
       And I should not see "GiftStory2 by gifter for g1"
 
-  Scenario: When logged in as admin, gifts page for recipient without account should show locked and hidden gifts
+  Scenario: When logged in as admin, gifts page for recipient without account should show locked but not hidden gifts
     When I give the work to "g1"
       And I press "Post"
       And I set up the draft "GiftStory2" as a gift to "g1"
@@ -101,7 +101,7 @@ Feature: Create Gifts
     When I go to the gifts page for the recipient g1
     Then I should see "GiftStory1 by gifter for g1"
       And I should see "GiftStory2 by gifter for g1"
-      And I should see "Rude Gift by gifter for g1"
+      And I should not see "Rude Gift by gifter for g1"
 
   Scenario: Giving a work as a gift when posting directly
     Given I give the work to "giftee1"

--- a/features/other_a/gift.feature
+++ b/features/other_a/gift.feature
@@ -46,6 +46,7 @@ Feature: Create Gifts
       And I go to giftee1's gifts page
     Then I should see "GiftStory1 by gifter for giftee1"
       And I should not see "GiftStory2 by gifter for giftee1"
+      And I should not see "Rude Gift by gifter for giftee1"
       And I should see "Gifts (1)"
 
   Scenario: When logged in as admin, gifts page for recipient should show locked but not hidden gifts
@@ -88,6 +89,7 @@ Feature: Create Gifts
     When I go to the gifts page for the recipient g1
     Then I should see "GiftStory1 by gifter for g1"
       And I should not see "GiftStory2 by gifter for g1"
+      And I should not see "Rude Gift by gifter for g1"
 
   Scenario: When logged in as admin, gifts page for recipient without account should show locked but not hidden gifts
     When I give the work to "g1"


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-7012

## Purpose

When logged in as admin restricted works are now listed on user's gift pages and gift searches.

## Credit

Bilka
