### PR TITLE
AO3-6531 Fix comment decorator 500 error for orphaned comments

### DIFF
--- a/app/decorators/comment_decorator.rb
+++ b/app/decorators/comment_decorator.rb
@@ -15,7 +15,8 @@ class CommentDecorator < SimpleDelegator
 
       next unless comment.reply_comment?
 
-      wrapped_by_id[comment.commentable_id].comments << wrapped
+      parent = wrapped_by_id[comment.commentable_id]
+      parent.comments << wrapped if parent
     end
 
     wrapped_by_id

--- a/lib/tasks/after_tasks.rake
+++ b/lib/tasks/after_tasks.rake
@@ -657,26 +657,26 @@ namespace :After do
 
   desc "Create placeholder comments for orphaned replies whose parent was physically deleted"
   task(create_placeholders_for_orphaned_comments: :environment) do
-    orphaned_commentable_ids = Comment
+    missing_commentable_ids = Comment
       .joins("LEFT JOIN comments AS commentable_comments ON comments.commentable_id = commentable_comments.id")
       .where(commentable_type: "Comment")
       .where(commentable_comments: { id: nil })
       .distinct
       .pluck(:commentable_id)
 
-    if orphaned_commentable_ids.empty?
+    if missing_commentable_ids.empty?
       puts "No orphaned comments found."
       next
     end
 
-    puts "Found #{orphaned_commentable_ids.size} missing parent comment(s). Creating placeholders..."
+    puts "Found #{missing_commentable_ids.size} missing parent comment(s). Creating placeholders..."
     $stdout.flush
 
     # Collect orphan info and sort by position in tree (top-down).
     # This ensures that when multiple comments are deleted in the same branch,
     # we create the higher placeholders first so they exist as parents for the lower ones.
 
-    orphan_info = orphaned_commentable_ids.map do |missing_id|
+    orphan_info = missing_commentable_ids.map do |missing_id|
       orphan = Comment.where(commentable_id: missing_id, commentable_type: "Comment").order(:id).first
       { missing_id: missing_id, orphan: orphan }
     end

--- a/lib/tasks/after_tasks.rake
+++ b/lib/tasks/after_tasks.rake
@@ -654,5 +654,70 @@ namespace :After do
     AuditsBackfillJob.spawn_jobs
     puts "Backfill started and running on resque in background"
   end
+
+  desc "Create placeholder comments for orphaned replies whose parent was physically deleted"
+  task(create_placeholders_for_orphaned_comments: :environment) do
+    orphaned_commentable_ids = Comment
+      .joins("LEFT JOIN comments AS commentable_comments ON comments.commentable_id = commentable_comments.id")
+      .where(commentable_type: "Comment")
+      .where(commentable_comments: { id: nil })
+      .distinct
+      .pluck(:commentable_id)
+
+    if orphaned_commentable_ids.empty?
+      puts "No orphaned comments found."
+      next
+    end
+
+    puts "Found #{orphaned_commentable_ids.size} missing parent comment(s). Creating placeholders..."
+    $stdout.flush
+
+    # Collect orphan info and sort by position in tree (top-down).
+    # This ensures that when multiple comments are deleted in the same branch,
+    # we create the higher placeholders first so they exist as parents for the lower ones.
+
+    orphan_info = orphaned_commentable_ids.map do |missing_id|
+      orphan = Comment.where(commentable_id: missing_id, commentable_type: "Comment").order(:id).first
+      { missing_id: missing_id, orphan: orphan }
+    end
+    orphan_info.sort_by! { |info| info[:orphan].threaded_left }
+
+    created_count = 0
+
+    Comment.transaction do
+      orphan_info.each do |info|
+        missing_id = info[:missing_id]
+        orphan = info[:orphan]
+
+        # Find the closest existing ancestor using the nested set.
+        # Using the orphan's threaded_left/right
+        parent = Comment.where(
+          "thread = ? AND threaded_left < ? AND threaded_right > ?",
+          orphan.thread,
+          orphan.threaded_left,
+          orphan.threaded_right
+        ).order(threaded_left: :desc).first
+
+        raise "Could not determine parent for missing comment #{missing_id} — possible data corruption" unless parent
+
+        placeholder = Comment.new(
+          commentable: parent,
+          thread: orphan.thread,
+          comment_content: "deleted comment",
+          is_deleted: true
+        )
+        placeholder.id = missing_id
+        placeholder.save(validate: false)
+        created_count += 1
+
+        puts "  Created placeholder for comment #{missing_id} in thread #{orphan.thread}."
+        $stdout.flush
+      end
+    end
+
+    puts "Done. Created #{created_count} placeholder(s)."
+    $stdout.flush
+  end
+
   # This is the end that you have to put new tasks above.
 end

--- a/spec/decorators/comment_decorator_spec.rb
+++ b/spec/decorators/comment_decorator_spec.rb
@@ -1,0 +1,38 @@
+require "spec_helper"
+
+describe CommentDecorator do
+  describe ".from_thread_ids" do
+    context "when a parent comment has been physically deleted from the database" do
+      let!(:work) { create(:work) }
+      let!(:chapter) { work.last_posted_chapter }
+      let!(:root_comment) { create(:comment, commentable: chapter) }
+      let!(:reply) { create(:comment, commentable: root_comment) }
+      let!(:nested_reply) { create(:comment, commentable: reply) }
+
+      before do
+        reply.delete
+      end
+
+      it "does not raise an error" do
+        expect do
+          CommentDecorator.from_thread_ids([root_comment.thread])
+        end.not_to raise_error
+      end
+
+      it "still returns the root comment" do
+        result = CommentDecorator.from_thread_ids([root_comment.thread])
+        expect(result[root_comment.id]).to be_present
+      end
+
+      it "does not include the deleted comment" do
+        result = CommentDecorator.from_thread_ids([root_comment.thread])
+        expect(result[reply.id]).to be_nil
+      end
+
+      it "still includes the orphaned nested reply" do
+        result = CommentDecorator.from_thread_ids([root_comment.thread])
+        expect(result[nested_reply.id]).to be_present
+      end
+    end
+  end
+end

--- a/spec/decorators/comment_decorator_spec.rb
+++ b/spec/decorators/comment_decorator_spec.rb
@@ -1,38 +1,28 @@
 require "spec_helper"
 
 describe CommentDecorator do
-  describe ".from_thread_ids" do
-    context "when a parent comment has been physically deleted from the database" do
-      let!(:work) { create(:work) }
-      let!(:chapter) { work.last_posted_chapter }
-      let!(:root_comment) { create(:comment, commentable: chapter) }
-      let!(:reply) { create(:comment, commentable: root_comment) }
-      let!(:nested_reply) { create(:comment, commentable: reply) }
+  context "when a parent comment has been physically deleted from the database" do
+    let!(:work) { create(:work) }
+    let!(:chapter) { work.last_posted_chapter }
+    let!(:root_comment) { create(:comment, commentable: chapter) }
+    let!(:reply) { create(:comment, commentable: root_comment) }
+    let!(:nested_reply) { create(:comment, commentable: reply) }
 
-      before do
-        reply.delete
-      end
+    before do
+      reply.delete
+    end
 
-      it "does not raise an error" do
-        expect do
-          CommentDecorator.from_thread_ids([root_comment.thread])
-        end.not_to raise_error
-      end
+    it "does not raise an error" do
+      expect do
+        CommentDecorator.from_thread_ids([root_comment.thread])
+      end.not_to raise_error
+    end
 
-      it "still returns the root comment" do
-        result = CommentDecorator.from_thread_ids([root_comment.thread])
-        expect(result[root_comment.id]).to be_present
-      end
-
-      it "does not include the deleted comment" do
-        result = CommentDecorator.from_thread_ids([root_comment.thread])
-        expect(result[reply.id]).to be_nil
-      end
-
-      it "still includes the orphaned nested reply" do
-        result = CommentDecorator.from_thread_ids([root_comment.thread])
-        expect(result[nested_reply.id]).to be_present
-      end
+    it "returns the root comment and orphaned nested reply but not the deleted comment" do
+      result = CommentDecorator.from_thread_ids([root_comment.thread])
+      expect(result[root_comment.id]).to be_present
+      expect(result[reply.id]).to be_nil
+      expect(result[nested_reply.id]).to be_present
     end
   end
 end

--- a/spec/lib/tasks/after_tasks.rake_spec.rb
+++ b/spec/lib/tasks/after_tasks.rake_spec.rb
@@ -805,6 +805,127 @@ describe "rake After:add_collection_tags" do
   end
 end
 
+describe "rake After:create_placeholders_for_orphaned_comments" do
+  context "when there are no orphaned comments" do
+    let!(:comment) { create(:comment) }
+
+    it "does not create any comments" do
+      expect do
+        subject.invoke
+      end.to avoid_changing { Comment.count }
+        .and output("No orphaned comments found.\n").to_stdout
+    end
+  end
+
+  context "when a parent comment has been physically deleted" do
+    let!(:work) { create(:work) }
+    let!(:chapter) { work.last_posted_chapter }
+    let!(:root_comment) { create(:comment, commentable: chapter) }
+    let!(:reply) { create(:comment, commentable: root_comment) }
+    let!(:nested_reply) { create(:comment, commentable: reply) }
+
+    before do
+      reply.delete
+    end
+
+    it "creates a placeholder with the correct attributes" do
+      subject.invoke
+      placeholder = Comment.find_by(id: reply.id)
+
+      expect(placeholder).to be_present
+      expect(placeholder.is_deleted).to be true
+      expect(placeholder.comment_content).to eq("deleted comment")
+      expect(placeholder.thread).to eq(root_comment.thread)
+      expect(placeholder.commentable).to eq(root_comment)
+    end
+
+    it "creates a placeholder with valid nested set positioning" do
+      subject.invoke
+      placeholder = Comment.find_by(id: reply.id)
+      root_comment.reload
+
+      expect(placeholder.threaded_left).to be > root_comment.threaded_left
+      expect(placeholder.threaded_right).to be < root_comment.threaded_right
+    end
+
+    it "outputs progress messages" do
+      expect do
+        subject.invoke
+      end.to output(
+        /Found 1 missing parent comment.*Creating placeholders.*Created placeholder for comment #{reply.id}.*Done/m
+      ).to_stdout
+    end
+
+    it "allows CommentDecorator to build the tree without error" do
+      subject.invoke
+      expect do
+        CommentDecorator.from_thread_ids([root_comment.thread])
+      end.not_to raise_error
+    end
+  end
+
+  context "when multiple comments are deleted in the same branch" do
+    # Tree structure before deletion:
+    #   root_comment
+    #     reply_a (deleted)
+    #       reply_b (deleted)
+    #         reply_c
+    #           reply_d (deleted)
+    #             reply_e
+    let!(:work) { create(:work) }
+    let!(:chapter) { work.last_posted_chapter }
+    let!(:root_comment) { create(:comment, commentable: chapter) }
+    let!(:reply_a) { create(:comment, commentable: root_comment) }
+    let!(:reply_b) { create(:comment, commentable: reply_a) }
+    let!(:reply_c) { create(:comment, commentable: reply_b) }
+    let!(:reply_d) { create(:comment, commentable: reply_c) }
+    let!(:reply_e) { create(:comment, commentable: reply_d) }
+
+    before do
+      reply_a.delete
+      reply_b.delete
+      reply_d.delete
+    end
+
+    it "creates placeholders with the correct commentable for each missing comment" do
+      subject.invoke
+
+      # reply_b is detected as missing because reply_c (exists) points to it.
+      # Its closest existing ancestor is root_comment (reply_a is also deleted).
+      placeholder_b = Comment.find_by(id: reply_b.id)
+      expect(placeholder_b).to be_present
+      expect(placeholder_b.commentable).to eq(root_comment)
+
+      # reply_d is detected as missing because reply_e (exists) points to it.
+      # Its closest existing ancestor is reply_c.
+      placeholder_d = Comment.find_by(id: reply_d.id)
+      expect(placeholder_d).to be_present
+      expect(placeholder_d.commentable).to eq(reply_c)
+    end
+
+    it "creates placeholders with valid nested set positioning" do
+      subject.invoke
+      root_comment.reload
+      reply_c.reload
+
+      placeholder_b = Comment.find_by(id: reply_b.id)
+      expect(placeholder_b.threaded_left).to be > root_comment.threaded_left
+      expect(placeholder_b.threaded_right).to be < root_comment.threaded_right
+
+      placeholder_d = Comment.find_by(id: reply_d.id)
+      expect(placeholder_d.threaded_left).to be > reply_c.threaded_left
+      expect(placeholder_d.threaded_right).to be < reply_c.threaded_right
+    end
+
+    it "allows CommentDecorator to build the tree without error" do
+      subject.invoke
+      expect do
+        CommentDecorator.from_thread_ids([root_comment.thread])
+      end.not_to raise_error
+    end
+  end
+end
+
 describe "rake After:sync_approved_to_spam" do
   let(:synced_ham_comment) { create(:comment) }
   let(:synced_spam_comment) { create(:comment) }


### PR DESCRIPTION
# Pull Request Checklist

* [X] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [X] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [X] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [X] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [X] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-6531

## Purpose

Fixes a 500 error in `CommentDecorator.from_thread_ids` caused by orphaned comments — replies whose parent comment was physically removed from
the database (via `.delete`) rather than soft-deleted.

When building the comment tree, the decorator looks up each reply's parent in a hash by `commentable_id`. If the parent was physically deleted,
the lookup returns `nil`, causing a `NoMethodError`. The fix adds a nil check so that orphaned replies are silently skipped when building the
tree, rather than crashing the page.

Additionally, this PR includes a rake task `After:create_placeholders_for_orphaned_comments` that finds all orphaned comments in the
database and creates soft-deleted placeholder comments in their place. The task:
- Uses a LEFT JOIN to efficiently find comments whose parent no longer exists
- Processes orphans top-down using the nested set (`threaded_left`) to handle cases where multiple comments were deleted in the same branch
- Creates each placeholder as a child of the closest existing ancestor, preserving the tree structure

## Testing Instructions

1. Create a comment thread with at least 3 levels (root → reply → nested reply)
2. Physically delete the middle comment from the database (e.g., `Comment.find(id).delete`)
3. Visit the page that displays the thread
4. Verify no 500 error occurs and the root comment still displays
5. Run the rake task: `bundle exec rake After:create_placeholders_for_orphaned_comments`
6. Verify a soft-deleted placeholder was created for the deleted comment
7. Visit the thread again and verify the placeholder appears as "[deleted comment]"

## Credit

Pablo Monfort (he/him)