### PR TITLE
AO3-5100  List all Open Challenges with pagination and filtering

### DIFF
--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -61,6 +61,7 @@ class CollectionsController < ApplicationController
     @page_subtitle = "Open Challenges"
     @hide_dashboard = true
     @sort_and_filter = true
+    @show_type_filter = true
     @search = CollectionSearchForm.new(challenge_filter_params.merge(signup_open: true, sort_column: "signups_close_at", page: params[:page]))
     @challenge_collections = @search.search_results
   end

--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -60,18 +60,23 @@ class CollectionsController < ApplicationController
   def list_challenges
     @page_subtitle = "Open Challenges"
     @hide_dashboard = true
-
-    @challenge_collections = CollectionSearchForm.new(signup_open: true, sort_column: "signups_close_at", page: params[:page]).search_results
+    @sort_and_filter = true
+    @search = CollectionSearchForm.new(challenge_filter_params.merge(signup_open: true, sort_column: "signups_close_at", page: params[:page]))
+    @challenge_collections = @search.search_results
   end
 
   def list_ge_challenges
     @page_subtitle = "Open Gift Exchange Challenges"
-    @challenge_collections = CollectionSearchForm.new(challenge_type: "GiftExchange", signup_open: true, sort_column: "signups_close_at", page: params[:page]).search_results
+    @sort_and_filter = true
+    @search = CollectionSearchForm.new(challenge_filter_params.merge(challenge_type: "GiftExchange", signup_open: true, sort_column: "signups_close_at", page: params[:page]))
+    @challenge_collections = @search.search_results
   end
 
   def list_pm_challenges
     @page_subtitle = "Open Prompt Meme Challenges"
-    @challenge_collections = CollectionSearchForm.new(challenge_type: "PromptMeme", signup_open: true, sort_column: "signups_close_at", page: params[:page]).search_results
+    @sort_and_filter = true
+    @search = CollectionSearchForm.new(challenge_filter_params.merge(challenge_type: "PromptMeme", signup_open: true, sort_column: "signups_close_at", page: params[:page]))
+    @challenge_collections = @search.search_results
   end
 
   def show
@@ -213,5 +218,11 @@ class CollectionsController < ApplicationController
         :gift_exchange, :show_random, :prompt_meme, :email_notify
       ]
     )
+  end
+
+  def challenge_filter_params
+    params.permit(:commit, collection_search: [
+      :title, :tag, :challenge_type, :moderated, :multifandom, :closed
+    ])[:collection_search] || {}
   end
 end

--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -61,18 +61,17 @@ class CollectionsController < ApplicationController
     @page_subtitle = "Open Challenges"
     @hide_dashboard = true
 
-    @challenge_collections = (CollectionSearchForm.new(challenge_type: "GiftExchange", signup_open: true, sort_column: "signups_close_at", page: 1, per_page: 15).search_results.to_a +
-                             CollectionSearchForm.new(challenge_type: "PromptMeme", signup_open: true, sort_column: "signups_close_at", page: 1, per_page: 15).search_results.to_a)
+    @challenge_collections = CollectionSearchForm.new(signup_open: true, sort_column: "signups_close_at", page: params[:page]).search_results
   end
 
   def list_ge_challenges
     @page_subtitle = "Open Gift Exchange Challenges"
-    @challenge_collections = CollectionSearchForm.new(challenge_type: "GiftExchange", signup_open: true, sort_column: "signups_close_at", page: 1, per_page: 15).search_results
+    @challenge_collections = CollectionSearchForm.new(challenge_type: "GiftExchange", signup_open: true, sort_column: "signups_close_at", page: params[:page]).search_results
   end
 
   def list_pm_challenges
     @page_subtitle = "Open Prompt Meme Challenges"
-    @challenge_collections = CollectionSearchForm.new(challenge_type: "PromptMeme", signup_open: true, sort_column: "signups_close_at", page: 1, per_page: 15).search_results
+    @challenge_collections = CollectionSearchForm.new(challenge_type: "PromptMeme", signup_open: true, sort_column: "signups_close_at", page: params[:page]).search_results
   end
 
   def show

--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -63,18 +63,23 @@ class CollectionsController < ApplicationController
   def list_challenges
     @page_subtitle = "Open Challenges"
     @hide_dashboard = true
-
-    @challenge_collections = CollectionSearchForm.new(signup_open: true, sort_column: "signups_close_at", page: params[:page]).search_results
+    @sort_and_filter = true
+    @search = CollectionSearchForm.new(challenge_filter_params.merge(signup_open: true, sort_column: "signups_close_at", page: params[:page]))
+    @challenge_collections = @search.search_results
   end
 
   def list_ge_challenges
     @page_subtitle = "Open Gift Exchange Challenges"
-    @challenge_collections = CollectionSearchForm.new(challenge_type: "GiftExchange", signup_open: true, sort_column: "signups_close_at", page: params[:page]).search_results
+    @sort_and_filter = true
+    @search = CollectionSearchForm.new(challenge_filter_params.merge(challenge_type: "GiftExchange", signup_open: true, sort_column: "signups_close_at", page: params[:page]))
+    @challenge_collections = @search.search_results
   end
 
   def list_pm_challenges
     @page_subtitle = "Open Prompt Meme Challenges"
-    @challenge_collections = CollectionSearchForm.new(challenge_type: "PromptMeme", signup_open: true, sort_column: "signups_close_at", page: params[:page]).search_results
+    @sort_and_filter = true
+    @search = CollectionSearchForm.new(challenge_filter_params.merge(challenge_type: "PromptMeme", signup_open: true, sort_column: "signups_close_at", page: params[:page]))
+    @challenge_collections = @search.search_results
   end
 
   def show
@@ -216,5 +221,11 @@ class CollectionsController < ApplicationController
         :gift_exchange, :show_random, :prompt_meme, :email_notify
       ]
     )
+  end
+
+  def challenge_filter_params
+    params.permit(:commit, collection_search: [
+      :title, :tag, :challenge_type, :moderated, :multifandom, :closed
+    ])[:collection_search] || {}
   end
 end

--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -64,6 +64,7 @@ class CollectionsController < ApplicationController
     @page_subtitle = "Open Challenges"
     @hide_dashboard = true
     @sort_and_filter = true
+    @show_type_filter = true
     @search = CollectionSearchForm.new(challenge_filter_params.merge(signup_open: true, sort_column: "signups_close_at", page: params[:page]))
     @challenge_collections = @search.search_results
   end

--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -65,21 +65,21 @@ class CollectionsController < ApplicationController
     @hide_dashboard = true
     @sort_and_filter = true
     @show_type_filter = true
-    @search = CollectionSearchForm.new(challenge_filter_params.merge(signup_open: true, sort_column: "signups_close_at", page: params[:page]))
+    @search = ChallengeSearchForm.new(challenge_filter_params.merge(signup_open: true, page: params[:page]))
     @challenge_collections = @search.search_results
   end
 
   def list_ge_challenges
     @page_subtitle = "Open Gift Exchange Challenges"
     @sort_and_filter = true
-    @search = CollectionSearchForm.new(challenge_filter_params.merge(challenge_type: "GiftExchange", signup_open: true, sort_column: "signups_close_at", page: params[:page]))
+    @search = ChallengeSearchForm.new(challenge_filter_params.merge(challenge_type: "GiftExchange", signup_open: true, page: params[:page]))
     @challenge_collections = @search.search_results
   end
 
   def list_pm_challenges
     @page_subtitle = "Open Prompt Meme Challenges"
     @sort_and_filter = true
-    @search = CollectionSearchForm.new(challenge_filter_params.merge(challenge_type: "PromptMeme", signup_open: true, sort_column: "signups_close_at", page: params[:page]))
+    @search = ChallengeSearchForm.new(challenge_filter_params.merge(challenge_type: "PromptMeme", signup_open: true, page: params[:page]))
     @challenge_collections = @search.search_results
   end
 
@@ -226,7 +226,8 @@ class CollectionsController < ApplicationController
 
   def challenge_filter_params
     params.permit(:commit, collection_search: [
-      :title, :tag, :challenge_type, :moderated, :multifandom, :closed
+      :title, :tag, :challenge_type, :moderated, :multifandom, :closed,
+      :sort_column, :sort_direction
     ])[:collection_search] || {}
   end
 end

--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -64,18 +64,17 @@ class CollectionsController < ApplicationController
     @page_subtitle = "Open Challenges"
     @hide_dashboard = true
 
-    @challenge_collections = (CollectionSearchForm.new(challenge_type: "GiftExchange", signup_open: true, sort_column: "signups_close_at", page: 1, per_page: 15).search_results.to_a +
-                             CollectionSearchForm.new(challenge_type: "PromptMeme", signup_open: true, sort_column: "signups_close_at", page: 1, per_page: 15).search_results.to_a)
+    @challenge_collections = CollectionSearchForm.new(signup_open: true, sort_column: "signups_close_at", page: params[:page]).search_results
   end
 
   def list_ge_challenges
     @page_subtitle = "Open Gift Exchange Challenges"
-    @challenge_collections = CollectionSearchForm.new(challenge_type: "GiftExchange", signup_open: true, sort_column: "signups_close_at", page: 1, per_page: 15).search_results
+    @challenge_collections = CollectionSearchForm.new(challenge_type: "GiftExchange", signup_open: true, sort_column: "signups_close_at", page: params[:page]).search_results
   end
 
   def list_pm_challenges
     @page_subtitle = "Open Prompt Meme Challenges"
-    @challenge_collections = CollectionSearchForm.new(challenge_type: "PromptMeme", signup_open: true, sort_column: "signups_close_at", page: 1, per_page: 15).search_results
+    @challenge_collections = CollectionSearchForm.new(challenge_type: "PromptMeme", signup_open: true, sort_column: "signups_close_at", page: params[:page]).search_results
   end
 
   def show

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -60,7 +60,9 @@ module ApplicationHelper
   COLLECTION_FILTER_ACTIONS = %w[index list_challenges list_ge_challenges list_pm_challenges].freeze
 
   def page_has_filters?
-    @facets.present? || (controller.controller_name == "collections" && COLLECTION_FILTER_ACTIONS.include?(controller.action_name)) || (controller.controller_name == "fandoms" && controller.action_name == "unassigned")
+    @facets.present? || # rubocop:disable Rails/HelperInstanceVariable
+      (controller.controller_name == "collections" && COLLECTION_FILTER_ACTIONS.include?(controller.action_name)) ||
+      (controller.controller_name == "fandoms" && controller.action_name == "unassigned")
   end
 
   # This is used to make the current page we're on (determined by the path or by the specified condition) a span with class "current" and it allows us to add a title attribute to the link or the span

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -60,9 +60,7 @@ module ApplicationHelper
   COLLECTION_FILTER_ACTIONS = %w[index list_challenges list_ge_challenges list_pm_challenges].freeze
 
   def page_has_filters?
-    @facets.present? ||
-      (controller.controller_name == 'collections' && COLLECTION_FILTER_ACTIONS.include?(controller.action_name)) ||
-      (controller.controller_name == 'fandoms' && controller.action_name == 'unassigned')
+    @facets.present? || (controller.controller_name == "collections" && COLLECTION_FILTER_ACTIONS.include?(controller.action_name)) || (controller.controller_name == "fandoms" && controller.action_name == "unassigned")
   end
 
   # This is used to make the current page we're on (determined by the path or by the specified condition) a span with class "current" and it allows us to add a title attribute to the link or the span

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -57,8 +57,12 @@ module ApplicationHelper
     class_names
   end
 
+  COLLECTION_FILTER_ACTIONS = %w[index list_challenges list_ge_challenges list_pm_challenges].freeze
+
   def page_has_filters?
-    @facets.present? || (controller.action_name == 'index' && controller.controller_name == 'collections') || (controller.action_name == 'unassigned' && controller.controller_name == 'fandoms')
+    @facets.present? ||
+      (controller.controller_name == 'collections' && COLLECTION_FILTER_ACTIONS.include?(controller.action_name)) ||
+      (controller.controller_name == 'fandoms' && controller.action_name == 'unassigned')
   end
 
   # This is used to make the current page we're on (determined by the path or by the specified condition) a span with class "current" and it allows us to add a title attribute to the link or the span

--- a/app/models/search/challenge_search_form.rb
+++ b/app/models/search/challenge_search_form.rb
@@ -1,0 +1,19 @@
+class ChallengeSearchForm < CollectionSearchForm
+  
+  def sort_options
+    [
+      ["Date Sign-ups Close", "signups_close_at"],
+      ["Date Created", "created_at"],
+      ["Title", "title.keyword"]
+    ].freeze
+  end
+
+  def default_sort_column
+    "signups_close_at"
+  end
+
+  def default_sort_direction
+    return "desc" if sort_column == "signups_close_at"
+    super
+  end
+end

--- a/app/models/search/challenge_search_form.rb
+++ b/app/models/search/challenge_search_form.rb
@@ -14,6 +14,7 @@ class ChallengeSearchForm < CollectionSearchForm
 
   def default_sort_direction
     return "desc" if sort_column == "signups_close_at"
+
     super
   end
 end

--- a/app/models/search/collection_query.rb
+++ b/app/models/search/collection_query.rb
@@ -57,10 +57,12 @@ class CollectionQuery < Query
   end
 
   def signup_closes_in_future_filter
+    return if options[:signup_open].blank?
+
     { bool: { should: [
       { range: { signups_close_at: { gt: "now" } } },
       { bool: { must_not: { exists: { field: "signups_close_at" } } } }
-    ] } } if options[:signup_open].present?
+    ] } }
   end
 
   def closed_filter

--- a/app/models/search/collection_query.rb
+++ b/app/models/search/collection_query.rb
@@ -57,7 +57,10 @@ class CollectionQuery < Query
   end
 
   def signup_closes_in_future_filter
-    { range: { signups_close_at: { gt: "now" } } } if options[:signup_open].present?
+    { bool: { should: [
+      { range: { signups_close_at: { gt: "now" } } },
+      { bool: { must_not: { exists: { field: "signups_close_at" } } } }
+    ] } } if options[:signup_open].present?
   end
 
   def closed_filter

--- a/app/models/search/collection_query.rb
+++ b/app/models/search/collection_query.rb
@@ -146,6 +146,10 @@ class CollectionQuery < Query
                   else
                     "desc"
                   end
-    [{ column => { order: direction } }, { "id" => { order: direction } }]
+
+    column_sort_options = { order: direction }
+    column_sort_options[:missing] = "_first" if column == "signups_close_at" && direction == "desc"
+
+    [{ column => column_sort_options }, { "id" => { order: direction } }]
   end
 end

--- a/app/views/collections/_challenge_collections.html.erb
+++ b/app/views/collections/_challenge_collections.html.erb
@@ -1,17 +1,17 @@
 <h3 class="heading">
   <% if @challenge_collections.blank? %>
-    <%= ts("There are no challenges currently open for sign-ups in the archive.") %>
+    <%= t("collections.challenge_collections.no_challenges") %>
   <% else %>
-    <%= search_header @challenge_collections, @query, ts("Challenge") %>
+    <%= search_header @challenge_collections, @query, t("collections.challenge_collections.search_header_label") %>
   <% end %>
 </h3>
 
 <% unless @challenge_collections.blank? %>
-  <p class="notes"><%= ts("The following challenges are currently open for sign-ups! Those closing soonest are at the top.") %></p>
+  <p class="notes"><%= t("collections.challenge_collections.open_description") %></p>
 
   <%= will_paginate @challenge_collections %>
 
-  <h3 class="landmark heading"><%= ts("List of Challenges") %></h3>
+  <h3 class="landmark heading"><%= t("collections.challenge_collections.list_heading") %></h3>
   <ul class="collection picture index group">
   <% @challenge_collections.each do |collection| %>
     <%= render :partial => "collection_blurb", :locals => {:collection => collection} %>

--- a/app/views/collections/_challenge_collections.html.erb
+++ b/app/views/collections/_challenge_collections.html.erb
@@ -1,23 +1,29 @@
-<% if @challenge_collections.blank? %>
-  <p class="notes"><%= ts("There are no challenges currently open for sign-ups in the archive.") %></p>
-<% else %>
+<h3 class="heading">
+  <% if @challenge_collections.blank? %>
+    <%= ts("There are no challenges currently open for sign-ups in the archive.") %>
+  <% else %>
+    <%= search_header @challenge_collections, @query, ts("Challenge") %>
+  <% end %>
+</h3>
 
-  <h3 class="heading">
-    <%= search_header @challenge_collections, nil, ts("Challenge") %>
-  </h3>
-
+<% unless @challenge_collections.blank? %>
   <p class="notes"><%= ts("The following challenges are currently open for sign-ups! Those closing soonest are at the top.") %></p>
 
   <%= will_paginate @challenge_collections %>
 
-  <h3 class="landmark heading"><%= ts("List of Collections") %></h3>
-  
+  <h3 class="landmark heading"><%= ts("List of Challenges") %></h3>
   <ul class="collection picture index group">
   <% @challenge_collections.each do |collection| %>
     <%= render :partial => "collection_blurb", :locals => {:collection => collection} %>
   <% end %>
   </ul>
 
-  <%= will_paginate @challenge_collections %>
+<% end %>
 
+<% if @sort_and_filter %>
+  <%= render 'challenge_filters' %>
+<% end %>
+
+<% unless @challenge_collections.blank? %>
+  <%= will_paginate @challenge_collections %>
 <% end %>

--- a/app/views/collections/_challenge_collections.html.erb
+++ b/app/views/collections/_challenge_collections.html.erb
@@ -21,7 +21,7 @@
 <% end %>
 
 <% if @sort_and_filter %>
-  <%= render 'challenge_filters' %>
+  <%= render "challenge_filters" %>
 <% end %>
 
 <% unless @challenge_collections.blank? %>

--- a/app/views/collections/_challenge_collections.html.erb
+++ b/app/views/collections/_challenge_collections.html.erb
@@ -1,12 +1,23 @@
 <% if @challenge_collections.blank? %>
   <p class="notes"><%= ts("There are no challenges currently open for sign-ups in the archive.") %></p>
 <% else %>
+
+  <h3 class="heading">
+    <%= search_header @challenge_collections, nil, ts("Challenge") %>
+  </h3>
+
   <p class="notes"><%= ts("The following challenges are currently open for sign-ups! Those closing soonest are at the top.") %></p>
 
+  <%= will_paginate @challenge_collections %>
+
   <h3 class="landmark heading"><%= ts("List of Collections") %></h3>
+  
   <ul class="collection picture index group">
   <% @challenge_collections.each do |collection| %>
     <%= render :partial => "collection_blurb", :locals => {:collection => collection} %>
   <% end %>
   </ul>
+
+  <%= will_paginate @challenge_collections %>
+
 <% end %>

--- a/app/views/collections/_challenge_filters.html.erb
+++ b/app/views/collections/_challenge_filters.html.erb
@@ -91,29 +91,31 @@
         </ul>
       </dd>
 
-      <dt><%= t("collections.filters.type.label") %></dt>
-      <dd>
-        <ul>
-          <li>
-            <%= f.label "challenge_type", value: "GiftExchange" do %>
-              <%= f.radio_button "challenge_type", "GiftExchange" %>
-              <%= label_indicator_and_text(t("collections.filters.type.gift_exchange")) %>
-            <% end %>
-          </li>
-          <li>
-            <%= f.label "challenge_type", value: "PromptMeme" do %>
-              <%= f.radio_button "challenge_type", "PromptMeme" %>
-              <%= label_indicator_and_text(t("collections.filters.type.prompt_meme")) %>
-            <% end %>
-          </li>
-          <li>
-            <%= f.label "challenge_type", value: "" do %>
-              <%= f.radio_button "challenge_type", "" %>
-              <%= label_indicator_and_text(t("collections.filters.type.any")) %>
-            <% end %>
-          </li>
-        </ul>
-      </dd>
+      <% if @show_type_filter %>
+        <dt><%= t("collections.filters.type.label") %></dt>
+        <dd>
+          <ul>
+            <li>
+              <%= f.label "challenge_type", value: "GiftExchange" do %>
+                <%= f.radio_button "challenge_type", "GiftExchange" %>
+                <%= label_indicator_and_text(t("collections.filters.type.gift_exchange")) %>
+              <% end %>
+            </li>
+            <li>
+              <%= f.label "challenge_type", value: "PromptMeme" do %>
+                <%= f.radio_button "challenge_type", "PromptMeme" %>
+                <%= label_indicator_and_text(t("collections.filters.type.prompt_meme")) %>
+              <% end %>
+            </li>
+            <li>
+              <%= f.label "challenge_type", value: "" do %>
+                <%= f.radio_button "challenge_type", "" %>
+                <%= label_indicator_and_text(t("collections.filters.type.any")) %>
+              <% end %>
+            </li>
+          </ul>
+        </dd>
+      <% end %>
 
       <dt class="landmark"><%= t("collections.filters.submit.landmark") %></dt>
       <dd class="submit actions"><%= submit_tag t("collections.filters.submit.button") %></dd>

--- a/app/views/collections/_challenge_filters.html.erb
+++ b/app/views/collections/_challenge_filters.html.erb
@@ -1,0 +1,130 @@
+<%= form_for @search, as: :collection_search, url: request.path, html: { method: :get, class: "narrow-hidden filters", id: "collection-filters" } do |f| %>
+  <h3 class="landmark heading"><%= t("collections.filters.landmark") %></h3>
+  <%= field_set_tag t("collections.filters.legend") do %>
+    <dl>
+      <dt class="landmark"><%= t("collections.filters.submit.landmark") %></dt>
+      <dd class="submit actions"><%= submit_tag t("collections.filters.submit.button") %></dd>
+
+      <dt class="autocomplete search">
+        <%= f.label "title", t("collections.filters.title") %>
+      </dt>
+      <dd class="autocomplete search">
+        <%= f.text_field "title", autocomplete_options("collection_title", data: { autocomplete_token_limit: 1 }) %>
+      </dd>
+
+      <dt class="autocomplete search">
+        <%= f.label "tag", t("collections.filters.tag") %>
+      </dt>
+      <dd class="autocomplete search">
+        <%= f.text_field "tag", autocomplete_options("tag", data: { autocomplete_token_limit: 5 }) %>
+      </dd>
+
+      <dt><%= t("collections.filters.multifandom.label") %></dt>
+      <dd>
+        <ul>
+          <li>
+            <%= f.label "multifandom", value: true do %>
+              <%= f.radio_button "multifandom", true %>
+              <%= label_indicator_and_text(t("collections.filters.multifandom.only")) %>
+            <% end %>
+          </li>
+          <li>
+            <%= f.label "multifandom", value: false do %>
+              <%= f.radio_button "multifandom", false %>
+              <%= label_indicator_and_text(t("collections.filters.multifandom.exclude")) %>
+            <% end %>
+          </li>
+          <li>
+            <%= f.label "multifandom", value: "" do %>
+              <%= f.radio_button "multifandom", "" %>
+              <%= label_indicator_and_text(t("collections.filters.multifandom.include")) %>
+            <% end %>
+          </li>
+        </ul>
+      </dd>
+
+      <dt><%= t("collections.filters.closed.label") %></dt>
+      <dd>
+        <ul>
+          <li>
+            <%= f.label "closed", value: true do %>
+              <%= f.radio_button "closed", true %>
+              <%= label_indicator_and_text(t("collections.filters.closed.only")) %>
+            <% end %>
+          </li>
+          <li>
+            <%= f.label "closed", value: false do %>
+              <%= f.radio_button "closed", false %>
+              <%= label_indicator_and_text(t("collections.filters.closed.exclude")) %>
+            <% end %>
+          </li>
+          <li>
+            <%= f.label "closed", value: "" do %>
+              <%= f.radio_button "closed", "" %>
+              <%= label_indicator_and_text(t("collections.filters.closed.include")) %>
+            <% end %>
+          </li>
+        </ul>
+      </dd>
+
+      <dt><%= t("collections.filters.moderated.label") %></dt>
+      <dd>
+        <ul>
+          <li>
+            <%= f.label "moderated", value: true do %>
+              <%= f.radio_button "moderated", true %>
+              <%= label_indicator_and_text(t("collections.filters.moderated.only")) %>
+            <% end %>
+          </li>
+          <li>
+            <%= f.label "moderated", value: false do %>
+              <%= f.radio_button "moderated", false %>
+              <%= label_indicator_and_text(t("collections.filters.moderated.exclude")) %>
+            <% end %>
+          </li>
+          <li>
+            <%= f.label "moderated", value: "" do %>
+              <%= f.radio_button "moderated", "" %>
+              <%= label_indicator_and_text(t("collections.filters.moderated.include")) %>
+            <% end %>
+          </li>
+        </ul>
+      </dd>
+
+      <dt><%= t("collections.filters.type.label") %></dt>
+      <dd>
+        <ul>
+          <li>
+            <%= f.label "challenge_type", value: "GiftExchange" do %>
+              <%= f.radio_button "challenge_type", "GiftExchange" %>
+              <%= label_indicator_and_text(t("collections.filters.type.gift_exchange")) %>
+            <% end %>
+          </li>
+          <li>
+            <%= f.label "challenge_type", value: "PromptMeme" do %>
+              <%= f.radio_button "challenge_type", "PromptMeme" %>
+              <%= label_indicator_and_text(t("collections.filters.type.prompt_meme")) %>
+            <% end %>
+          </li>
+          <li>
+            <%= f.label "challenge_type", value: "" do %>
+              <%= f.radio_button "challenge_type", "" %>
+              <%= label_indicator_and_text(t("collections.filters.type.any")) %>
+            <% end %>
+          </li>
+        </ul>
+      </dd>
+
+      <dt class="landmark"><%= t("collections.filters.submit.landmark") %></dt>
+      <dd class="submit actions"><%= submit_tag t("collections.filters.submit.button") %></dd>
+    </dl>
+    <p class="footnote">
+      <%= link_to t("collections.filters.clear_filters"), request.path %>
+    </p>
+  <% end %>
+  <p class="narrow-shown hidden">
+    <a href="#main" id="leave_filters" class="close">
+      <%= t("collections.filters.leave_filters") %>
+    </a>
+  </p>
+<% end %>

--- a/app/views/collections/_challenge_filters.html.erb
+++ b/app/views/collections/_challenge_filters.html.erb
@@ -5,6 +5,19 @@
       <dt class="landmark"><%= t("collections.filters.submit.landmark") %></dt>
       <dd class="submit actions"><%= submit_tag t("collections.filters.submit.button") %></dd>
 
+      <dt class="sort">
+        <%= f.label :sort_column, t("collections.filters.sort.column") %>
+      </dt>
+      <dd class="sort">
+        <%= f.select :sort_column, options_for_select(@search.sort_options, @search.sort_column) %>
+      </dd>
+      <dt class="sort">
+        <%= f.label :sort_direction, t("collections.filters.sort.direction.label") %>
+      </dt>
+      <dd class="sort">
+        <%= f.select :sort_direction, options_for_select({ t("collections.filters.sort.direction.ascending") => "asc", t("collections.filters.sort.direction.descending") => "desc" }, @search.sort_direction) %>
+      </dd>
+
       <dt class="autocomplete search">
         <%= f.label "title", t("collections.filters.title") %>
       </dt>

--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -753,6 +753,11 @@ en:
       meta:
         collection_tags: 'Collection tags:'
   collections:
+    challenge_collections:
+      list_heading: List of Challenges
+      no_challenges: There are no challenges currently open for sign-ups in the archive.
+      open_description: The following challenges are currently open for sign-ups! Those closing soonest are at the top.
+      search_header_label: Challenge
     collection_blurb:
       collection_tags: 'Collection Tags:'
     filters:

--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -820,7 +820,7 @@ en:
     challenge_collections:
       list_heading: List of Challenges
       no_challenges: There are no challenges currently open for sign-ups in the archive.
-      open_description: The following challenges are currently open for sign-ups! Those closing soonest are at the top.
+      open_description: The following challenges are currently open for sign-ups!
       search_header_label: Challenge
     collection_blurb:
       bookmarked_items: 'Bookmarked Items:'

--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -817,6 +817,11 @@ en:
       meta:
         collection_tags: 'Collection tags:'
   collections:
+    challenge_collections:
+      list_heading: List of Challenges
+      no_challenges: There are no challenges currently open for sign-ups in the archive.
+      open_description: The following challenges are currently open for sign-ups! Those closing soonest are at the top.
+      search_header_label: Challenge
     collection_blurb:
       bookmarked_items: 'Bookmarked Items:'
       challenges_subcollections: 'Challenges/Subcollections:'

--- a/features/collections/open_challenges.feature
+++ b/features/collections/open_challenges.feature
@@ -1,0 +1,157 @@
+@collections
+Feature: Open Challenges
+  In order to find challenges currently accepting sign-ups
+  As a user
+  I want to browse and filter open challenges
+
+  # list_challenges
+
+  # merged GE + PM list
+
+  Scenario: Open challenges page shows both gift exchanges and prompt memes
+
+    Given a set of open challenges for searching
+    When I view open challenges
+    Then I should see "Open GE"
+    And I should see "Open PM"
+
+  Scenario: Open challenges page includes challenges with no closing date
+
+    Given a set of open challenges for searching
+    When I view open challenges
+    Then I should see "No Close PM"
+
+  # filter form
+
+  Scenario: Filter form appears on open challenges page
+
+    Given a set of open challenges for searching
+    When I view open challenges
+    Then I should see "Sort and Filter"
+
+  Scenario: Challenge type filter is shown on open challenges page
+
+    Given a set of open challenges for searching
+    When I view open challenges
+    Then I should see "Collection Type"
+
+  Scenario: No Challenge option is not available on open challenges filter
+
+    Given a set of open challenges for searching
+    When I view open challenges
+    Then I should not see "No Challenge"
+
+  Scenario: Sort options are not shown on open challenges filter
+
+    Given a set of open challenges for searching
+    When I view open challenges
+    Then I should not see "Sort by"
+
+  # filtering
+
+  Scenario: Filter open challenges by gift exchange type
+
+    Given a set of open challenges for searching
+    When I view open challenges
+      And I choose "Gift Exchange Challenge"
+      And I press "Sort and Filter"
+    Then I should see "Open GE"
+    And I should see "Moderated GE"
+    And I should not see "Open PM"
+    And I should not see "No Close PM"
+
+  Scenario: Filter open challenges by prompt meme type
+
+  Given a set of open challenges for searching
+    When I view open challenges
+      And I choose "Prompt Meme Challenge"
+      And I press "Sort and Filter"
+    Then I should see "Open PM"
+    And I should see "No Close PM"
+    And I should not see "Open GE"
+
+  Scenario: Filter open challenges by title
+
+    Given a set of open challenges for searching
+    When I view open challenges
+      And I fill in "collection_search_title" with "Open GE"
+      And I press "Sort and Filter"
+    Then I should see "Open GE"
+    And I should not see "Open PM"
+    And I should not see "No Close PM"
+
+  Scenario: Filter open challenges by tag
+
+    Given a set of open challenges for searching
+    When I view open challenges
+      And I fill in "collection_search_tag" with "Some cool tag"
+      And I press "Sort and Filter"
+    Then I should see "Open GE"
+      And I should not see "Open PM"
+      And I should not see "No Close PM"
+
+  Scenario: Filter open challenges by moderated
+
+    Given a set of open challenges for searching
+    When I view open challenges
+      And I choose "collection_search_moderated_true"
+      And I press "Sort and Filter"
+    Then I should see "Moderated GE"
+    And I should not see "Open GE"
+    And I should not see "Open PM"
+
+  Scenario: Filter open challenges by closed collection
+
+    Given a set of open challenges for searching
+    When I view open challenges
+      And I choose "collection_search_closed_true"
+      And I press "Sort and Filter"
+    Then I should see "Closed Collection GE"
+      And I should not see "Open GE"
+      And I should not see "Open PM"
+
+  Scenario: Filter open challenges by multifandom
+
+    Given a set of open challenges for searching
+    When I view open challenges
+      And I choose "collection_search_multifandom_true"
+      And I press "Sort and Filter"
+    Then I should see "Multifandom GE"
+      And I should not see "Open GE"
+      And I should not see "Open PM"
+
+  # list_ge_challenges
+
+  Scenario: Open gift exchange challenges page shows only gift exchanges
+
+    Given a set of open challenges for searching
+    When I view open challenges
+      And I follow "Gift Exchange Challenges"
+    Then I should see "Open GE"
+    And I should not see "Open PM"
+    And I should not see "No Close PM"
+
+  Scenario: Challenge type filter is not shown on gift exchange challenges page
+
+    Given a set of open challenges for searching
+    When I view open challenges
+      And I follow "Gift Exchange Challenges"
+    Then I should not see "Collection Type"
+
+  # list_pm_challenges
+
+  Scenario: Open prompt meme challenges page shows only prompt memes
+
+    Given a set of open challenges for searching
+    When I view open challenges
+      And I follow "Prompt Meme Challenges"
+    Then I should see "Open PM"
+    And I should see "No Close PM"
+    And I should not see "Open GE"
+
+  Scenario: Challenge type filter is not shown on prompt meme challenges page
+
+    Given a set of open challenges for searching
+    When I view open challenges
+      And I follow "Prompt Meme Challenges"
+    Then I should not see "Collection Type"

--- a/features/collections/open_challenges.feature
+++ b/features/collections/open_challenges.feature
@@ -41,11 +41,12 @@ Feature: Open Challenges
     When I view open challenges
     Then I should not see "No Challenge"
 
-  Scenario: Sort options are not shown on open challenges filter
+  Scenario: Sort options are shown on open challenges filter
 
     Given a set of open challenges for searching
     When I view open challenges
-    Then I should not see "Sort by"
+    Then I should see "Sort by"
+    And I should see "Date Sign-ups Close"
 
   # filtering
 

--- a/features/step_definitions/collection_steps.rb
+++ b/features/step_definitions/collection_steps.rb
@@ -342,3 +342,56 @@ Then "{string} should have the {string} role in the collection {string}" do |byl
     expect(page).to have_select("#{pseud.user.login}_role", selected: role)
   end
 end
+
+Given "a set of open challenges for searching" do
+  FactoryBot.create(:collection,
+                    name: "open_ge",
+                    title: "Open GE",
+                    tag_string: "Some cool tag",
+                    challenge: FactoryBot.create(:gift_exchange,
+                                                 signup_open: true,
+                                                 signups_open_at: Time.zone.now - 2.days,
+                                                 signups_close_at: Time.zone.now + 1.week),
+                    challenge_type: "GiftExchange")
+  FactoryBot.create(:collection,
+                    name: "multifandom_ge",
+                    title: "Multifandom GE",
+                    multifandom: true,
+                    challenge: FactoryBot.create(:gift_exchange,
+                                                 signup_open: true,
+                                                 signups_open_at: Time.zone.now - 1.day,
+                                                 signups_close_at: Time.zone.now + 1.week),
+                    challenge_type: "GiftExchange")
+  FactoryBot.create(:collection,
+                    name: "open_pm",
+                    title: "Open PM",
+                    challenge: FactoryBot.create(:prompt_meme,
+                                                 signup_open: true,
+                                                 signups_open_at: Time.zone.now - 2.days,
+                                                 signups_close_at: Time.zone.now + 1.week),
+                    challenge_type: "PromptMeme")
+  FactoryBot.create(:collection,
+                    name: "no_close_pm",
+                    title: "No Close PM",
+                    challenge: FactoryBot.create(:prompt_meme, signup_open: true, signups_open_at: Time.zone.now - 1.day),
+                    challenge_type: "PromptMeme")
+  FactoryBot.create(:collection,
+                    :moderated,
+                    name: "moderated_ge",
+                    title: "Moderated GE",
+                    challenge: FactoryBot.create(:gift_exchange,
+                                                 signup_open: true,
+                                                 signups_open_at: Time.zone.now - 1.day,
+                                                 signups_close_at: Time.zone.now + 1.week),
+                    challenge_type: "GiftExchange")
+  FactoryBot.create(:collection,
+                    :closed,
+                    name: "closed_ge",
+                    title: "Closed Collection GE",
+                    challenge: FactoryBot.create(:gift_exchange,
+                                                 signup_open: true,
+                                                 signups_open_at: Time.zone.now - 1.day,
+                                                 signups_close_at: Time.zone.now + 1.week),
+                    challenge_type: "GiftExchange")
+  step %{all indexing jobs have been run}
+end

--- a/features/step_definitions/collection_steps.rb
+++ b/features/step_definitions/collection_steps.rb
@@ -359,3 +359,56 @@ Then /^the (\d+)(?:st|nd|rd|th) collection result should not contain "([^"]*)"$/
     expect(page).not_to have_content(text)
   end
 end
+
+Given "a set of open challenges for searching" do
+  FactoryBot.create(:collection,
+                    name: "open_ge",
+                    title: "Open GE",
+                    tag_string: "Some cool tag",
+                    challenge: FactoryBot.create(:gift_exchange,
+                                                 signup_open: true,
+                                                 signups_open_at: Time.zone.now - 2.days,
+                                                 signups_close_at: Time.zone.now + 1.week),
+                    challenge_type: "GiftExchange")
+  FactoryBot.create(:collection,
+                    name: "multifandom_ge",
+                    title: "Multifandom GE",
+                    multifandom: true,
+                    challenge: FactoryBot.create(:gift_exchange,
+                                                 signup_open: true,
+                                                 signups_open_at: Time.zone.now - 1.day,
+                                                 signups_close_at: Time.zone.now + 1.week),
+                    challenge_type: "GiftExchange")
+  FactoryBot.create(:collection,
+                    name: "open_pm",
+                    title: "Open PM",
+                    challenge: FactoryBot.create(:prompt_meme,
+                                                 signup_open: true,
+                                                 signups_open_at: Time.zone.now - 2.days,
+                                                 signups_close_at: Time.zone.now + 1.week),
+                    challenge_type: "PromptMeme")
+  FactoryBot.create(:collection,
+                    name: "no_close_pm",
+                    title: "No Close PM",
+                    challenge: FactoryBot.create(:prompt_meme, signup_open: true, signups_open_at: Time.zone.now - 1.day),
+                    challenge_type: "PromptMeme")
+  FactoryBot.create(:collection,
+                    :moderated,
+                    name: "moderated_ge",
+                    title: "Moderated GE",
+                    challenge: FactoryBot.create(:gift_exchange,
+                                                 signup_open: true,
+                                                 signups_open_at: Time.zone.now - 1.day,
+                                                 signups_close_at: Time.zone.now + 1.week),
+                    challenge_type: "GiftExchange")
+  FactoryBot.create(:collection,
+                    :closed,
+                    name: "closed_ge",
+                    title: "Closed Collection GE",
+                    challenge: FactoryBot.create(:gift_exchange,
+                                                 signup_open: true,
+                                                 signups_open_at: Time.zone.now - 1.day,
+                                                 signups_close_at: Time.zone.now + 1.week),
+                    challenge_type: "GiftExchange")
+  step %{all indexing jobs have been run}
+end

--- a/spec/controllers/collections_controller_spec.rb
+++ b/spec/controllers/collections_controller_spec.rb
@@ -259,6 +259,21 @@ describe CollectionsController, collection_search: true do
         expect(assigns(:challenge_collections)).to include prompt_meme_collection
         expect(assigns(:challenge_collections)).to include gift_exchange_collection
       end
+
+      context "pagination" do
+        before { allow(ArchiveConfig).to receive(:ITEMS_PER_PAGE).and_return(1) }
+
+        let!(:second_pm) { create(:prompt_meme, signup_open: true, signups_open_at: Time.zone.now - 1.day, signups_close_at: Time.zone.now + 2.weeks) }
+        let!(:second_pm_collection) { create(:collection, challenge: second_pm, challenge_type: "PromptMeme") }
+
+        before { run_all_indexing_jobs }
+
+        it "paginates results" do
+          get :list_challenges
+          expect(assigns(:challenge_collections).total_entries).to be > 1
+          expect(assigns(:challenge_collections).size).to eq(1)
+        end
+      end
     end
 
     context "displays all open gift exchange challenges on list_ge_challenges index" do

--- a/spec/controllers/collections_controller_spec.rb
+++ b/spec/controllers/collections_controller_spec.rb
@@ -291,6 +291,21 @@ describe CollectionsController, collection_search: true do
         expect(assigns(:challenge_collections)).to include prompt_meme_collection
         expect(assigns(:challenge_collections)).to include gift_exchange_collection
       end
+
+      context "pagination" do
+        before { allow(ArchiveConfig).to receive(:ITEMS_PER_PAGE).and_return(1) }
+
+        let!(:second_pm) { create(:prompt_meme, signup_open: true, signups_open_at: Time.zone.now - 1.day, signups_close_at: Time.zone.now + 2.weeks) }
+        let!(:second_pm_collection) { create(:collection, challenge: second_pm, challenge_type: "PromptMeme") }
+
+        before { run_all_indexing_jobs }
+
+        it "paginates results" do
+          get :list_challenges
+          expect(assigns(:challenge_collections).total_entries).to be > 1
+          expect(assigns(:challenge_collections).size).to eq(1)
+        end
+      end
     end
 
     context "displays all open gift exchange challenges on list_ge_challenges index" do

--- a/spec/controllers/collections_controller_spec.rb
+++ b/spec/controllers/collections_controller_spec.rb
@@ -325,6 +325,24 @@ describe CollectionsController, collection_search: true do
         expect(assigns(:challenge_collections)).not_to include gift_exchange_collection
       end
     end
+
+    context "sorting" do
+      it "sorts by signups_close_at descending by default" do
+        get :list_challenges
+        expect(assigns(:search).sort_column).to eq("signups_close_at")
+        expect(assigns(:search).sort_direction).to eq("desc")
+      end
+
+      it "respects an explicit sort_column param" do
+        get :list_challenges, params: { collection_search: { sort_column: "title.keyword" } }
+        expect(assigns(:search).sort_column).to eq("title.keyword")
+      end
+
+      it "respects an explicit sort_direction param" do
+        get :list_challenges, params: { collection_search: { sort_direction: "asc" } }
+        expect(assigns(:search).sort_direction).to eq("asc")
+      end
+    end
   end
 
   describe "GET #show" do

--- a/spec/models/search/challenge_search_form_spec.rb
+++ b/spec/models/search/challenge_search_form_spec.rb
@@ -1,0 +1,65 @@
+require "spec_helper"
+
+describe ChallengeSearchForm, collection_search: true do
+  describe "#sort_options" do
+    it "includes signups_close_at" do
+      searcher = ChallengeSearchForm.new({})
+      expect(searcher.sort_options).to include(["Date Sign-ups Close", "signups_close_at"])
+    end
+  end
+
+  describe "#set_sorting" do
+    it "sorts by signups_close_at by default" do
+      searcher = ChallengeSearchForm.new({})
+      expect(searcher.options[:sort_column]).to eq("signups_close_at")
+    end
+
+    it "sorts by signups_close_at descending by default" do
+      searcher = ChallengeSearchForm.new({})
+      expect(searcher.options[:sort_direction]).to eq("desc")
+    end
+
+    it "does not override provided sort column" do
+      searcher = ChallengeSearchForm.new(sort_column: "title.keyword")
+      expect(searcher.options[:sort_column]).to eq("title.keyword")
+    end
+
+    it "does not override provided sort direction" do
+      searcher = ChallengeSearchForm.new(sort_column: "signups_close_at", sort_direction: "asc")
+      expect(searcher.options[:sort_direction]).to eq("asc")
+    end
+  end
+
+  describe "#default_sort_direction" do
+    it "defaults to ascending for title" do
+      searcher = ChallengeSearchForm.new(sort_column: "title.keyword")
+      expect(searcher.default_sort_direction).to eq("asc")
+    end
+
+    it "defaults to descending for created_at" do
+      searcher = ChallengeSearchForm.new(sort_column: "created_at")
+      expect(searcher.default_sort_direction).to eq("desc")
+    end
+
+    it "defaults to descending for signups_close_at" do
+      searcher = ChallengeSearchForm.new(sort_column: "signups_close_at")
+      expect(searcher.default_sort_direction).to eq("desc")
+    end
+  end
+
+  describe "sorting results" do
+    let!(:first_gift_exchange) { create(:gift_exchange, signup_open: true, signups_open_at: Time.zone.now - 2.days, signups_close_at: Time.zone.now + 1.week) }
+    let!(:first_collection) { create(:collection, title: "first", challenge: first_gift_exchange, challenge_type: "GiftExchange") }
+    let!(:second_gift_exchange) { create(:gift_exchange, signup_open: true, signups_open_at: Time.zone.now - 2.days, signups_close_at: Time.zone.now + 2.weeks) }
+    let!(:second_collection) { create(:collection, title: "second", challenge: second_gift_exchange, challenge_type: "GiftExchange") }
+
+    before do
+      run_all_indexing_jobs
+    end
+
+    it "sorts collections by signups_close_at descending by default" do
+      searcher = ChallengeSearchForm.new(signup_open: true)
+      expect(searcher.search_results.map(&:title)).to eq %w[second first]
+    end
+  end
+end

--- a/spec/models/search/collection_query_spec.rb
+++ b/spec/models/search/collection_query_spec.rb
@@ -82,6 +82,15 @@ describe CollectionQuery do
       expect(query.search_results).not_to include signup_past_open_collection
     end
 
+    it "includes collections with no closing date when signup_open is true" do
+      no_close_pm = create(:prompt_meme, signup_open: true, signups_open_at: Time.current - 1.day)
+      no_close_collection = create(:collection, challenge: no_close_pm, challenge_type: "PromptMeme")
+      run_all_indexing_jobs
+
+      query = CollectionQuery.new(signup_open: true)
+      expect(query.search_results).to include no_close_collection
+    end
+
     it "filters collections by multifandom filter" do
       query = CollectionQuery.new(multifandom: true)
       expect(query.search_results).not_to include prompt_meme_collection

--- a/spec/models/search/collection_query_spec.rb
+++ b/spec/models/search/collection_query_spec.rb
@@ -104,6 +104,15 @@ describe CollectionQuery do
       expect(query.search_results).not_to include signup_past_open_collection
     end
 
+    it "includes collections with no closing date when signup_open is true" do
+      no_close_pm = create(:prompt_meme, signup_open: true, signups_open_at: Time.current - 1.day)
+      no_close_collection = create(:collection, challenge: no_close_pm, challenge_type: "PromptMeme")
+      run_all_indexing_jobs
+
+      query = CollectionQuery.new(signup_open: true)
+      expect(query.search_results).to include no_close_collection
+    end
+
     it "filters collections by multifandom filter" do
       query = CollectionQuery.new(multifandom: true)
       expect(query.search_results).not_to include prompt_meme_collection

--- a/spec/models/search/collection_query_spec.rb
+++ b/spec/models/search/collection_query_spec.rb
@@ -183,11 +183,35 @@ describe CollectionQuery do
         %w[created_at title.keyword signups_close_at].each do |column|
           context "when the sort column is set to #{column}" do
             it "returns #{sort_direction}" do
+              expected_column_sort_options = { order: sort_direction }
+              expected_column_sort_options[:missing] = "_first" if column == "signups_close_at" && sort_direction == "desc"
+
               expect(CollectionQuery.new(sort_column: column, sort_direction: sort_direction).sort)
-                .to eq([{ column => { order: sort_direction } }, { "id" => { order: sort_direction } }])
+                .to eq([{ column => expected_column_sort_options }, { "id" => { order: sort_direction } }])
             end
           end
         end
+      end
+    end
+
+    context "when sorting by signups_close_at", collection_search: true do
+      let!(:dated_pm) { create(:prompt_meme, signup_open: true, signups_open_at: Time.current - 1.day, signups_close_at: Time.current + 1.week) }
+      let!(:dated_collection) { create(:collection, title: "dated", challenge: dated_pm, challenge_type: "PromptMeme") }
+      let!(:no_close_pm) { create(:prompt_meme, signup_open: true, signups_open_at: Time.current - 1.day) }
+      let!(:no_close_collection) { create(:collection, title: "no close", challenge: no_close_pm, challenge_type: "PromptMeme") }
+
+      before do
+        run_all_indexing_jobs
+      end
+
+      it "sorts collections with no closing date last when ascending" do
+        query = CollectionQuery.new(signup_open: true, sort_column: "signups_close_at", sort_direction: "asc")
+        expect(query.search_results.map(&:title)).to eq ["dated", "no close"]
+      end
+
+      it "sorts collections with no closing date first when descending" do
+        query = CollectionQuery.new(signup_open: true, sort_column: "signups_close_at", sort_direction: "desc")
+        expect(query.search_results.map(&:title)).to eq ["no close", "dated"]
       end
     end
   end


### PR DESCRIPTION
# Pull Request Checklist

<!-- Mark steps in the checklist as complete by changing `[ ]` to `[X]` -->
* [X] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [X] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [X] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [X] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [X] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-5100

## Purpose

**Merge Gift Exchange and Prompt Meme lists**

`list_challenges` runs two separate queries (one for Gift Exchanges and one for Prompt Memes), concatenates and caps the results at 15. It now runs a single query across both challenge types, paginated and sorted by closing date.

**Include challenges with no closing date**

The open challenges query filters by `signups_close_at > now`, which silently excludes challenges with no closing date. The filter now matches challenges closing in the future or challenges with no closing date set.

**Filter Open Challenges**

Open Challenges can now be filtered by _title_, _tag_, _multifandom_, _closed_, _moderated_, and _collection type_ (the "_No Challenge_" option is hidden since it's all challenges)

Gift Exchange Challenges and Prompt Meme Challenges support the same filters, except _collection type_.

## Credit

Aya Sayadi