### PR TITLE
AO3-7316 Change blockquote element in admin banners to be div instead

### DIFF
--- a/app/views/admin/banners/_banner.html.erb
+++ b/app/views/admin/banners/_banner.html.erb
@@ -1,7 +1,7 @@
 <% # expects admin_banner %>
 <% # don't forget to update layouts/banner! %>
 <div class="<%= admin_banner.banner_type %> announcement group">
-  <blockquote class="userstuff">
+  <div class="userstuff">
     <%= raw sanitize_field(admin_banner, :content, image_safety_mode: true) %>
-  </blockquote>
+  </div>
 </div>

--- a/app/views/layouts/_banner.html.erb
+++ b/app/views/layouts/_banner.html.erb
@@ -1,9 +1,9 @@
 <% if @admin_banner&.active? %>
   <% unless session[:hide_banner] || current_user&.preference&.banner_seen %>
     <div class="<%= @admin_banner.banner_type %> announcement group" id="admin-banner">
-      <blockquote class="userstuff">
+      <div class="userstuff">
         <%= raw sanitize_field(@admin_banner, :content, image_safety_mode: true) %>
-      </blockquote>
+      </div>
       <% if current_user.nil? %>
         <p class="submit">
           <%= link_to current_path_with(hide_banner: true), "aria-label": t(".hide"), class: "showme action" do


### PR DESCRIPTION
# Pull Request Checklist

<!-- Mark steps in the checklist as complete by changing `[ ]` to `[X]` -->
* [X] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [X] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [ ] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [X] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [X] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-7316 

## Purpose

 Changes banner wrapper form from blockquote to div, I did all of the testing from instruction in Jira issue


## Credit

'wAO3rker' He/him
