### PR TITLE
AO3-7150 Search by title or name in Autocomplete for Parent Collection

### DIFF
--- a/app/controllers/autocomplete_controller.rb
+++ b/app/controllers/autocomplete_controller.rb
@@ -138,7 +138,13 @@ class AutocompleteController < ApplicationController
 
   # For creating collections, autocomplete the name of a parent collection owned by the user only
   def collection_parent_name
-    render_output(current_user.maintained_collections.top_level.with_name_like(params[:term]).pluck(:name).sort)
+    results = current_user.maintained_collections.top_level
+      .with_name_or_title_like(params[:term])
+      .limit(10)
+      .order(:title)
+      .pluck(:name, :title)
+      .map { |name, title| { id: name, name: "#{title} (#{name})" } }
+    respond_with(results)
   end
 
   # for looking up existing urls for external works to avoid duplication

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -176,13 +176,8 @@ class Collection < ApplicationRecord
     end
   end
 
-  scope :with_name_like, lambda { |name|
-    where("collections.name LIKE ?", "%#{name}%")
-      .limit(10)
-  }
-
-  scope :with_title_like, lambda { |title|
-    where("collections.title LIKE ?", "%#{title}%")
+  scope :with_name_or_title_like, lambda { |term|
+    where("collections.name LIKE ? OR collections.title LIKE ?", "%#{term}%", "%#{term}%")
   }
 
   scope :with_item_count, lambda {

--- a/spec/controllers/autocomplete_controller_spec.rb
+++ b/spec/controllers/autocomplete_controller_spec.rb
@@ -51,7 +51,7 @@ describe AutocompleteController do
 
     before { fake_login_known_user(user) }
 
-    it "matches by name or title and formats results as 'Title (name)'" do
+    it "matches by name or title and formats suggestions as 'Title (name)'" do
       get :collection_parent_name, params: { term: "some", format: :json }
       expect(JSON.parse(response.body)).to contain_exactly(
         { "id" => "some_name", "name" => "Unrelated Title (some_name)" },

--- a/spec/controllers/autocomplete_controller_spec.rb
+++ b/spec/controllers/autocomplete_controller_spec.rb
@@ -1,6 +1,8 @@
 require "spec_helper"
 
 describe AutocompleteController do
+  include LoginMacros
+
   describe "tag" do
     let!(:tag1) { create(:canonical_fandom, name: "Match") }
     let!(:tag2) { create(:canonical_fandom, name: "Blargh") }
@@ -39,6 +41,22 @@ describe AutocompleteController do
         get :collection_title, params: { term: "here", format: :json }
         expect(JSON.parse(response.body)).to eq([{ "id" => "I am here", "name" => "not_here: I am here" }])
       end
+    end
+  end
+
+  describe "GET #collection_parent_name" do
+    let!(:user) { create(:user) }
+    let!(:collection1) { create(:collection, name: "some_name", title: "Unrelated Title", owner: user.default_pseud) }
+    let!(:collection2) { create(:collection, name: "unrelated_name", title: "Some Title", owner: user.default_pseud) }
+
+    before { fake_login_known_user(user) }
+
+    it "matches by name or title and formats results as 'Title (name)'" do
+      get :collection_parent_name, params: { term: "some", format: :json }
+      expect(JSON.parse(response.body)).to contain_exactly(
+        { "id" => "some_name", "name" => "Unrelated Title (some_name)" },
+        { "id" => "unrelated_name", "name" => "Some Title (unrelated_name)" }
+      )
     end
   end
 end


### PR DESCRIPTION
# Pull Request Checklist

<!-- Mark steps in the checklist as complete by changing `[ ]` to `[X]` -->
* [X] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [X] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [X] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [X] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [X] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-7150

## Purpose

This PR fixes parent collection autocomplete when creating a subcollection by:
- Searching both name and title (previously, typing a collection's title returned no results)
- Displaying the suggestions as "Title (name)" since collection titles are not unique

## Credit

Aya Sayadi