### PR TITLE
AO3-6112 Fix freeze/spam comment redirect

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -526,13 +526,13 @@ class CommentsController < ApplicationController
   def approve
     authorize @comment
     @comment.mark_as_ham!
-    redirect_to_all_comments(@comment.ultimate_parent, show_comments: true)
+    redirect_to_all_comments(@comment.parent, show_comments: true)
   end
 
   def reject
     authorize @comment if logged_in_as_admin?
     @comment.mark_as_spam!
-    redirect_to_all_comments(@comment.ultimate_parent, show_comments: true)
+    redirect_to_all_comments(@comment.parent, show_comments: true)
   end
 
   # PUT /comments/1/freeze
@@ -547,10 +547,10 @@ class CommentsController < ApplicationController
       flash[:comment_notice] = t(".success")
     end
 
-    redirect_to_all_comments(@comment.ultimate_parent, show_comments: true)
+    redirect_to_all_comments(@comment.parent, show_comments: true)
   rescue StandardError
     flash[:comment_error] = t(".error")
-    redirect_to_all_comments(@comment.ultimate_parent, show_comments: true)
+    redirect_to_all_comments(@comment.parent, show_comments: true)
   end
 
   # PUT /comments/1/unfreeze
@@ -565,10 +565,10 @@ class CommentsController < ApplicationController
       flash[:comment_error] = t(".error")
     end
 
-    redirect_to_all_comments(@comment.ultimate_parent, show_comments: true)
+    redirect_to_all_comments(@comment.parent, show_comments: true)
   rescue StandardError
     flash[:comment_error] = t(".error")
-    redirect_to_all_comments(@comment.ultimate_parent, show_comments: true)
+    redirect_to_all_comments(@comment.parent, show_comments: true)
   end
 
   # PUT /comments/1/hide

--- a/spec/controllers/comments/comment_moderation_spec.rb
+++ b/spec/controllers/comments/comment_moderation_spec.rb
@@ -335,7 +335,7 @@ describe CommentsController do
               it "marks the comment as spam" do
                 put :reject, params: { id: comment.id }
                 expect(flash[:error]).to be_nil
-                expect(response).to redirect_to(work_path(comment.ultimate_parent,
+                expect(response).to redirect_to(chapter_path(comment.parent,
                                                           show_comments: true,
                                                           anchor: "comments"))
                 comment.reload
@@ -366,7 +366,7 @@ describe CommentsController do
           it "marks the comment as spam" do
             put :reject, params: { id: comment.id }
             expect(flash[:error]).to be_nil
-            expect(response).to redirect_to(work_path(comment.ultimate_parent,
+            expect(response).to redirect_to(chapter_path(comment.parent,
                                                       show_comments: true,
                                                       anchor: "comments"))
             comment.reload
@@ -479,7 +479,7 @@ describe CommentsController do
           it "marks the comment as not spam" do
             put :approve, params: { id: comment.id }
             expect(flash[:error]).to be_nil
-            expect(response).to redirect_to(work_path(comment.ultimate_parent,
+            expect(response).to redirect_to(chapter_path(comment.parent,
                                                       show_comments: true,
                                                       anchor: "comments"))
             comment.reload

--- a/spec/controllers/comments/comments_controller_spec.rb
+++ b/spec/controllers/comments/comments_controller_spec.rb
@@ -345,7 +345,7 @@ describe CommentsController do
       it "PUT #freeze successfully freezes the comment" do
         put :freeze, params: { id: comment.id }
         it_redirects_to_with_comment_notice(
-          work_path(comment.ultimate_parent, show_comments: true, anchor: :comments),
+          chapter_path(comment.parent, show_comments: true, anchor: :comments),
           "Comment thread successfully frozen!"
         )
         expect(comment.reload.iced).to be_truthy
@@ -355,7 +355,7 @@ describe CommentsController do
         comment.update!(iced: true)
         put :unfreeze, params: { id: comment.id }
         it_redirects_to_with_comment_notice(
-          work_path(comment.ultimate_parent, show_comments: true, anchor: :comments),
+          chapter_path(comment.parent, show_comments: true, anchor: :comments),
           "Comment thread successfully unfrozen!"
         )
         expect(comment.reload.iced).to be_falsey
@@ -442,7 +442,7 @@ describe CommentsController do
             fake_login_admin(admin)
             put :freeze, params: { id: comment.id }
             it_redirects_to_with_comment_notice(
-              work_path(comment.ultimate_parent, show_comments: true, anchor: :comments),
+              chapter_path(comment.parent, show_comments: true, anchor: :comments),
               "Comment thread successfully frozen!"
             )
             expect(comment.reload.iced).to be_truthy
@@ -466,7 +466,7 @@ describe CommentsController do
             fake_login_admin(admin)
             put :unfreeze, params: { id: comment.id }
             it_redirects_to_with_comment_notice(
-              work_path(comment.ultimate_parent, show_comments: true, anchor: :comments),
+              chapter_path(comment.parent, show_comments: true, anchor: :comments),
               "Comment thread successfully unfrozen!"
             )
             expect(comment.reload.iced).to be_falsey

--- a/spec/controllers/comments/freeze_spec.rb
+++ b/spec/controllers/comments/freeze_spec.rb
@@ -145,7 +145,7 @@ describe CommentsController do
 
             expect(comment.reload.iced).to be true
             it_redirects_to_with_comment_notice(
-              work_path(comment.ultimate_parent, show_comments: true, anchor: :comments),
+              chapter_path(comment.parent, show_comments: true, anchor: :comments),
               "Comment thread successfully frozen!"
             )
           end
@@ -300,7 +300,7 @@ describe CommentsController do
 
               expect(comment.reload.iced).to be false
               it_redirects_to_with_comment_error(
-                work_path(comment.ultimate_parent, show_comments: true, anchor: :comments),
+                chapter_path(comment.parent, show_comments: true, anchor: :comments),
                 "Sorry, that comment thread could not be frozen."
               )
             end
@@ -449,7 +449,7 @@ describe CommentsController do
 
                 expect(comment.reload.iced).to be_truthy
                 it_redirects_to_with_comment_error(
-                  work_path(comment.ultimate_parent, show_comments: true, anchor: :comments),
+                  chapter_path(comment.parent, show_comments: true, anchor: :comments),
                   "Sorry, that comment thread could not be frozen."
                 )
               end
@@ -474,7 +474,7 @@ describe CommentsController do
 
             expect(comment.reload.iced).to be_truthy
             it_redirects_to_with_comment_error(
-              work_path(comment.ultimate_parent, show_comments: true, anchor: :comments),
+              chapter_path(comment.parent, show_comments: true, anchor: :comments),
               "Sorry, that comment thread could not be frozen."
             )
           end
@@ -495,7 +495,7 @@ describe CommentsController do
             expect(comment.reload.iced).to be_truthy
           end
           it_redirects_to_with_comment_error(
-            work_path(comment.ultimate_parent, show_comments: true, anchor: :comments),
+            chapter_path(comment.parent, show_comments: true, anchor: :comments),
             "Sorry, that comment thread could not be frozen."
           )
         end
@@ -515,7 +515,7 @@ describe CommentsController do
             expect(comment.reload.iced).to be_truthy
           end
           it_redirects_to_with_comment_error(
-            work_path(comment.ultimate_parent, show_comments: true, anchor: :comments),
+            chapter_path(comment.parent, show_comments: true, anchor: :comments),
             "Sorry, that comment thread could not be frozen."
           )
         end
@@ -535,7 +535,7 @@ describe CommentsController do
             expect(comment.reload.iced).to be_truthy
           end
           it_redirects_to_with_comment_error(
-            work_path(comment.ultimate_parent, show_comments: true, anchor: :comments),
+            chapter_path(comment.parent, show_comments: true, anchor: :comments),
             "Sorry, that comment thread could not be frozen."
           )
         end
@@ -554,7 +554,7 @@ describe CommentsController do
 
           expect(comment.reload.iced).to be true
           it_redirects_to_with_comment_error(
-            work_path(comment.ultimate_parent, show_comments: true, anchor: :comments),
+            chapter_path(comment.parent, show_comments: true, anchor: :comments),
             "Sorry, that comment thread could not be frozen."
           )
         end
@@ -703,7 +703,7 @@ describe CommentsController do
 
                 expect(comment.reload.iced).to be_falsey
                 it_redirects_to_with_comment_error(
-                  work_path(comment.ultimate_parent, show_comments: true, anchor: :comments),
+                  chapter_path(comment.parent, show_comments: true, anchor: :comments),
                   "Sorry, that comment thread could not be unfrozen."
                 )
               end
@@ -728,7 +728,7 @@ describe CommentsController do
 
             expect(comment.reload.iced).to be_falsey
             it_redirects_to_with_comment_error(
-              work_path(comment.ultimate_parent, show_comments: true, anchor: :comments),
+              chapter_path(comment.parent, show_comments: true, anchor: :comments),
               "Sorry, that comment thread could not be unfrozen."
             )
           end
@@ -749,7 +749,7 @@ describe CommentsController do
             expect(comment.reload.iced).to be_falsey
           end
           it_redirects_to_with_comment_error(
-            work_path(comment.ultimate_parent, show_comments: true, anchor: :comments),
+            chapter_path(comment.parent, show_comments: true, anchor: :comments),
             "Sorry, that comment thread could not be unfrozen."
           )
         end
@@ -769,7 +769,7 @@ describe CommentsController do
             expect(comment.reload.iced).to be_falsey
           end
           it_redirects_to_with_comment_error(
-            work_path(comment.ultimate_parent, show_comments: true, anchor: :comments),
+            chapter_path(comment.parent, show_comments: true, anchor: :comments),
             "Sorry, that comment thread could not be unfrozen."
           )
         end
@@ -789,7 +789,7 @@ describe CommentsController do
             expect(comment.reload.iced).to be_falsey
           end
           it_redirects_to_with_comment_error(
-            work_path(comment.ultimate_parent, show_comments: true, anchor: :comments),
+            chapter_path(comment.parent, show_comments: true, anchor: :comments),
             "Sorry, that comment thread could not be unfrozen."
           )
         end
@@ -808,7 +808,7 @@ describe CommentsController do
 
           expect(comment.reload.iced).to be false
           it_redirects_to_with_comment_error(
-            work_path(comment.ultimate_parent, show_comments: true, anchor: :comments),
+            chapter_path(comment.parent, show_comments: true, anchor: :comments),
             "Sorry, that comment thread could not be unfrozen."
           )
         end
@@ -929,7 +929,7 @@ describe CommentsController do
 
             expect(comment.reload.iced).to be false
             it_redirects_to_with_comment_notice(
-              work_path(comment.ultimate_parent, show_comments: true, anchor: :comments),
+              chapter_path(comment.parent, show_comments: true, anchor: :comments),
               "Comment thread successfully unfrozen!"
             )
           end
@@ -1065,7 +1065,7 @@ describe CommentsController do
 
               expect(comment.reload.iced).to be true
               it_redirects_to_with_comment_error(
-                work_path(comment.ultimate_parent, show_comments: true, anchor: :comments),
+                chapter_path(comment.parent, show_comments: true, anchor: :comments),
                 "Sorry, that comment thread could not be unfrozen."
               )
             end


### PR DESCRIPTION
# Pull Request Checklist

<!-- Mark steps in the checklist as complete by changing `[ ]` to `[X]` -->
* [x] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [x] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [x] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [x] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-6112

## Purpose

Fix the redirect path when a user marks a comment as spam/not spam or freeze/unfreeze when their preference is set to not show the whole work

## Credit

EchoEkhi (He/Him)
