### PR TITLE
AO3-7267 Return 404 on the preferences page for nonexistent users

### DIFF
--- a/app/controllers/preferences_controller.rb
+++ b/app/controllers/preferences_controller.rb
@@ -4,7 +4,7 @@ class PreferencesController < ApplicationController
 
   # Ensure that the current user is authorized to view and change this information
   def load_user
-    @user = User.find_by(login: params[:user_id])
+    @user = User.find_by!(login: params[:user_id])
     @check_ownership_of = @user
   end
 

--- a/spec/controllers/preferences_controller_spec.rb
+++ b/spec/controllers/preferences_controller_spec.rb
@@ -50,7 +50,7 @@ describe PreferencesController do
       it_behaves_like "an action only authorized admins can access", authorized_roles: read_roles
     end
 
-    context "as nonexistent user" do
+    context "for a nonexistent user" do
       it "raises a 404 error" do
         expect do
           get :index, params: { user_id: "deleted_user" }

--- a/spec/controllers/preferences_controller_spec.rb
+++ b/spec/controllers/preferences_controller_spec.rb
@@ -49,6 +49,14 @@ describe PreferencesController do
 
       it_behaves_like "an action only authorized admins can access", authorized_roles: read_roles
     end
+
+    context "as nonexistent user" do
+      it "raises a 404 error" do
+        expect do
+          get :index, params: { user_id: "deleted_user" }
+        end.to raise_exception(ActiveRecord::RecordNotFound)
+      end
+    end
   end
 
   describe "PUT #update" do


### PR DESCRIPTION
# Pull Request Checklist

<!-- Mark steps in the checklist as complete by changing `[ ]` to `[X]` -->
* [X] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [X] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [X] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [X] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [X] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-7267

## Purpose

What does this PR do?
When a user or admin visits the preferences page of a nonexistent user, they are redirected to the "Not Found" page.
Users who are logged in can still access their own preferences page.

## Credit

What name and pronouns should we use to credit you in the [Archive of Our Own's Release Notes](https://archiveofourown.org/admin_posts?tag=1)?
Céline Bertaud she/her
