### PR TITLE
AO3-5946 Allow lang attribute in user-generated HTML

### DIFF
--- a/app/views/help/html.html.erb
+++ b/app/views/help/html.html.erb
@@ -4,7 +4,7 @@
 <p>
   <code>a, abbr, acronym, address, [align], [alt], [axis], b, big, blockquote, br, caption, center, cite, [class], code,
     col, colgroup, dd, del, details, dfn, div, dl, dt, em, figcaption, figure, h1, h2, h3, h4, h5, h6, [height], hr, [href], i, img,
-    ins, kbd, li, [name], ol, p, pre, q, rp, rt, ruby, s, samp, small, span, [src], strike, strong, sub, summary, sup, table, tbody, td,
+    ins, kbd, [lang], li, [name], ol, p, pre, q, rp, rt, ruby, s, samp, small, span, [src], strike, strong, sub, summary, sup, table, tbody, td,
     tfoot, th, thead, [title], tr, tt, u, ul, var, [width]
   </code>
 </p>

--- a/config/initializers/gem-plugin_config/sanitizer_config.rb
+++ b/config/initializers/gem-plugin_config/sanitizer_config.rb
@@ -10,7 +10,7 @@ class Sanitize
         sub summary sup table tbody td tfoot th thead tr tt u ul var
       ],
       attributes: {
-        all: %w[align title dir],
+        all: %w[align dir lang title],
         "a" => %w[href name],
         "blockquote" => %w[cite],
         "col" => %w[span width],

--- a/features/other_a/parser.feature
+++ b/features/other_a/parser.feature
@@ -121,6 +121,6 @@ Feature: Parsing HTML
 Scenario: Can't use classes in a bookmark note
   Given the work "Really Good Thing"
     And I am logged in as "bookmarker"
-  When I bookmark the work "Really Good Thing" with the note "My <span='remove-me'>best yet</span>"
+  When I bookmark the work "Really Good Thing" with the note "My <span class='remove-me'>best yet</span>"
     And I edit the bookmark for "Really Good Thing"
   Then the "Notes" field should not contain "remove-me"

--- a/spec/lib/html_cleaner_spec.rb
+++ b/spec/lib/html_cleaner_spec.rb
@@ -517,6 +517,15 @@ describe HtmlCleaner do
 
         expect(doc.xpath("./details[@open]")).to be_empty
       end
+
+      it "preserves allowed global attributes in #{field}" do
+        html = '<p align="left" dir="ltr" lang="en" title="text title">some text</p>'
+
+        result = sanitize_value(field, html)
+        doc = Nokogiri::HTML.fragment(result)
+
+        expect(result).to include(html)
+      end
     end
   end
 

--- a/spec/lib/html_cleaner_spec.rb
+++ b/spec/lib/html_cleaner_spec.rb
@@ -520,10 +520,7 @@ describe HtmlCleaner do
 
       it "preserves allowed global attributes in #{field}" do
         html = '<p align="left" dir="ltr" lang="en" title="text title">some text</p>'
-
         result = sanitize_value(field, html)
-        doc = Nokogiri::HTML.fragment(result)
-
         expect(result).to include(html)
       end
     end


### PR DESCRIPTION
# Pull Request Checklist

<!-- Mark steps in the checklist as complete by changing `[ ]` to `[X]` -->
* [x] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [x] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [x] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [x] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

[AO3-5946](https://otwarchive.atlassian.net/browse/AO3-5946)

## Purpose

Allows the `lang` attribute in user-generated HTML content (allowing to mark text as being in a specific language, for better screen reader and font compatibility).

Also fixes a parser feature test so it actually tests that the class attribute gets stripped out as intended.

## Credit

slavalamp

[AO3-5946]: https://otwarchive.atlassian.net/browse/AO3-5946?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ