### PR TITLE
AO3-7392 Allow pluralisation in mailer creation_attribution

### DIFF
--- a/app/helpers/mailer_helper.rb
+++ b/app/helpers/mailer_helper.rb
@@ -158,7 +158,7 @@ module MailerHelper
     if creation.anonymous?
       t("mailer.general.creation.attribution.anon")
     else
-      t("mailer.general.creation.attribution.named.html", creator_links: creator_links(creation))
+      t("mailer.general.creation.attribution.named.html", creator_links: creator_links(creation), count: creation.pseuds.size)
     end
   end
 
@@ -166,7 +166,7 @@ module MailerHelper
     if creation.anonymous?
       t("mailer.general.creation.attribution.anon")
     else
-      t("mailer.general.creation.attribution.named.text", creators: creator_text(creation))
+      t("mailer.general.creation.attribution.named.text", creators: creator_text(creation), count: creation.pseuds.size)
     end
   end
 

--- a/config/locales/mailers/en.yml
+++ b/config/locales/mailers/en.yml
@@ -232,8 +232,12 @@ en:
         attribution:
           anon: by Anonymous
           named:
-            html: by %{creator_links}
-            text: by %{creators}
+            html:
+              one: by %{creator_links}
+              other: by %{creator_links}
+            text:
+              one: by %{creators}
+              other: by %{creators}
         link_with_word_count: "%{creation_link} (%{word_count})"
         title_with_chapter_number: Chapter %{position} of %{title}
         title_with_word_count: '"%{creation_title}" (%{word_count})'


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-7392

## Purpose

Allow pluralisation in mailer creation_attribution by number of creators, similar how it's done in the subscription email preface.

## Credit

Bilka
