### PR TITLE
AO3-3601 Reindex bookmarks on pseud deletion

### DIFF
--- a/app/models/pseud.rb
+++ b/app/models/pseud.rb
@@ -399,9 +399,13 @@ class Pseud < ApplicationRecord
   end
 
   def change_bookmarks_ownership
-    bookmark_ids = Bookmark.where(pseud_id: id).ids
-    Bookmark.where(pseud_id: id).update_all(pseud_id: user.default_pseud.id)
-    IndexQueue.enqueue_ids(Bookmark, bookmark_ids, :main) if bookmark_ids.present?
+    default_pseud_id = user.default_pseud.id
+    bookmarks = Bookmark.where(pseud_id: id)
+    bookmark_ids = bookmarks.ids
+    return if bookmark_ids.empty?
+
+    bookmarks.update_all(pseud_id: default_pseud_id)
+    IndexQueue.enqueue_ids(Bookmark, bookmark_ids, :main)
   end
 
   def change_collections_membership

--- a/app/models/pseud.rb
+++ b/app/models/pseud.rb
@@ -399,7 +399,9 @@ class Pseud < ApplicationRecord
   end
 
   def change_bookmarks_ownership
-    Bookmark.where("pseud_id = #{self.id}").update_all("pseud_id = #{self.user.default_pseud.id}")
+    bookmark_ids = Bookmark.where(pseud_id: id).ids
+    Bookmark.where(pseud_id: id).update_all(pseud_id: user.default_pseud.id)
+    IndexQueue.enqueue_ids(Bookmark, bookmark_ids, :main) if bookmark_ids.present?
   end
 
   def change_collections_membership

--- a/spec/models/pseud_spec.rb
+++ b/spec/models/pseud_spec.rb
@@ -94,6 +94,31 @@ describe Pseud do
     end
   end
 
+  describe "#change_bookmarks_ownership" do
+    let(:user) { create(:user) }
+    let(:pseud) { create(:pseud, user: user) }
+    let(:default_pseud) { user.default_pseud }
+
+    let!(:bookmarks) { Array.new(2) { create(:bookmark, pseud: pseud) } }
+
+    before do
+      IndexQueue.new("index:bookmark:main").run
+    end
+
+    it "enqueues transferred bookmarks for indexing" do
+      pseud.change_bookmarks_ownership
+
+      bookmarks.each do |bookmark|
+        expect(bookmark.reload.pseud_id).to eq(default_pseud.id)
+      end
+
+      indexed_ids = IndexQueue.new("index:bookmark:main").ids
+      bookmarks.each do |bookmark|
+        expect(indexed_ids).to include(bookmark.id.to_s)
+      end
+    end
+  end
+
   describe "#clear_icon" do
     subject { create(:pseud, icon_alt_text: "icon alt", icon_comment_text: "icon comment") }
 

--- a/spec/models/pseud_spec.rb
+++ b/spec/models/pseud_spec.rb
@@ -99,7 +99,7 @@ describe Pseud do
     let(:pseud) { create(:pseud, user: user) }
     let(:default_pseud) { user.default_pseud }
 
-    let!(:bookmarks) { Array.new(2) { create(:bookmark, pseud: pseud) } }
+    let!(:bookmarks) { create_list(:bookmark, 2, pseud: pseud) }
 
     before do
       IndexQueue.new("index:bookmark:main").run


### PR DESCRIPTION
# Pull Request Checklist

* [X] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [X] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [X] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [X] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [X] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-3601

## Purpose

When a pseud is deleted and its bookmarks are transferred to the default pseud, `Pseud#change_bookmarks_ownership` uses `update_all` to reassign the bookmarks.
Since `update_all` skips ActiveRecord callbacks, the bookmarks are never reindexed in Elasticsearch, so they don't appear on the default pseud's bookmark page.

This PR enqueues the transferred bookmark IDs for reindexing after the `update_all`, and modernizes the raw SQL strings to use hash conditions.

## Testing Instructions

1. Create a pseud and use it to bookmark several works
2. Delete the pseud and choose "Transfer these bookmarks to the default pseud"
3. Verify that the bookmarks appear on the default pseud's bookmark page

## Credit

Pablo Monfort (he/him)