### PR TITLE
AO3-6531 Fix create_placeholders_for_orphaned_comments task 500

### DIFF
--- a/lib/tasks/after_tasks.rake
+++ b/lib/tasks/after_tasks.rake
@@ -676,11 +676,13 @@ namespace :After do
     # This ensures that when multiple comments are deleted in the same branch,
     # we create the higher placeholders first so they exist as parents for the lower ones.
 
-    orphan_info = missing_commentable_ids.map do |missing_id|
+    orphan_info = missing_commentable_ids.filter_map do |missing_id|
       orphan = Comment.where(commentable_id: missing_id, commentable_type: "Comment").order(:id).first
+      next if orphan.nil?
+
       { missing_id: missing_id, orphan: orphan }
     end
-    orphan_info.sort_by! { |info| info[:orphan].threaded_left }
+    orphan_info.sort_by! { |info| info[:orphan].threaded_left || 0 }
 
     created_count = 0
 
@@ -698,7 +700,11 @@ namespace :After do
           orphan.threaded_right
         ).order(threaded_left: :desc).first
 
-        raise "Could not determine parent for missing comment #{missing_id} — possible data corruption" unless parent
+        unless parent
+          puts "  Skipping comment #{missing_id} — could not determine parent (possible data corruption)."
+          $stdout.flush
+          next
+        end
 
         placeholder = Comment.new(
           commentable: parent,

--- a/spec/lib/tasks/after_tasks.rake_spec.rb
+++ b/spec/lib/tasks/after_tasks.rake_spec.rb
@@ -924,6 +924,27 @@ describe "rake After:create_placeholders_for_orphaned_comments" do
       end.not_to raise_error
     end
   end
+
+  context "when an orphaned comment has nil threaded_left" do
+    let!(:work) { create(:work) }
+    let!(:chapter) { work.last_posted_chapter }
+    let!(:root_comment_a) { create(:comment, commentable: chapter) }
+    let!(:reply_a) { create(:comment, commentable: root_comment_a) }
+    let!(:root_comment_b) { create(:comment, commentable: chapter) }
+    let!(:reply_b) { create(:comment, commentable: root_comment_b) }
+
+    before do
+      reply_a.update_columns(threaded_left: nil, threaded_right: nil)
+      root_comment_a.delete
+      root_comment_b.delete
+    end
+
+    it "does not raise an error" do
+      expect do
+        subject.invoke
+      end.not_to raise_error
+    end
+  end
 end
 
 describe "rake After:sync_approved_to_spam" do


### PR DESCRIPTION
# Pull Request Checklist

* [X] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [X] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [X] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [X] Have you added the [Jira](https://otwarchive.atlassian.net) issue number as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [X] Do you have fewer than 5 pull requests already open? If not, please wait until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-6531

## Purpose

Fixes an `ArgumentError: comparison of NilClass with 2 failed` crash in the `After:create_placeholders_for_orphaned_comments` rake
  task when orphaned comments have `nil` values for `threaded_left`.

Changes:
- Use `filter_map` instead of `map` to skip entries where no orphan comment exists for a given `missing_id`.
- Add `|| 0` fallback in `sort_by!` so comments with `nil` `threaded_left` don't crash the comparison.
- Replace `raise` with `puts` + `next` when the parent comment cannot be determined, allowing the task to continue processing remaining comments instead of aborting.

## Testing Instructions

1. Run the rake task `After:create_placeholders_for_orphaned_comments` on a database that contains orphaned comments with `nil` `threaded_left` values.
2. Verify the task completes without raising an error.
3. Verify that comments with valid `threaded_left` values still get placeholders created correctly.
4. Run the new spec: `bundle exec rspec spec/lib/tasks/after_tasks.rake_spec.rb -e "when an orphaned comment has nil
threaded_left"`

## References

This fix addresses the error encountered when running the rake task on staging, reported by @brianjaustin.

## Credit

Pablo Monfort (he/him)