### PR TITLE
AO3-7324 List user creations by date, not by pseud

### DIFF
--- a/app/controllers/admin/admin_users_controller.rb
+++ b/app/controllers/admin/admin_users_controller.rb
@@ -22,8 +22,8 @@ class Admin::AdminUsersController < Admin::BaseController
   end
 
   def load_user_creations
-    @works = @user.works.paginate(page: params[:works_page])
-    @comments = @user.comments.paginate(page: params[:comments_page])
+    @works = @user.works.reorder(created_at: :asc, id: :asc).paginate(page: params[:works_page])
+    @comments = @user.comments.reorder(created_at: :asc, id: :asc).paginate(page: params[:comments_page])
   end
 
   def index

--- a/spec/controllers/admin/admin_users_controller_spec.rb
+++ b/spec/controllers/admin/admin_users_controller_spec.rb
@@ -770,8 +770,6 @@ describe Admin::AdminUsersController do
           let!(:newer_comment) { create(:comment, pseud: user.default_pseud) }
           let!(:older_work) { create(:work, authors: [other_pseud]) }
           let!(:newer_work) { create(:work, authors: [user.default_pseud]) }
-          let!(:other_comment) { create(:comment) }
-          let!(:other_work) { create(:work) }
 
           before do
             fake_login_admin(admin)

--- a/spec/controllers/admin/admin_users_controller_spec.rb
+++ b/spec/controllers/admin/admin_users_controller_spec.rb
@@ -765,18 +765,28 @@ describe Admin::AdminUsersController do
       authorized_roles.each do |role|
         context "with #{role} role" do
           let(:admin) { create(:admin, roles: [role]) }
-          let!(:user_comment) { create(:comment, pseud: user.default_pseud) }
+          let!(:other_pseud) { create(:pseud, user:user) }
+          let!(:older_comment) { create(:comment, pseud: other_pseud) }
+          let!(:newer_comment) { create(:comment, pseud: user.default_pseud) }
+          let!(:older_work) { create(:work, authors: [other_pseud]) }
+          let!(:newer_work) { create(:work, authors: [user.default_pseud]) }
           let!(:other_comment) { create(:comment) }
-          let!(:user_work) { create(:work, authors: [user.default_pseud]) }
           let!(:other_work) { create(:work) }
 
-          before { fake_login_admin(admin) }
+          before do
+            fake_login_admin(admin)
 
-          it "renders creations template and assigns comments and works" do
+            older_comment.update_columns(created_at: 2.days.ago)
+            newer_comment.update_columns(created_at: 1.day.ago)
+            older_work.update_columns(created_at: 2.days.ago)
+            newer_work.update_columns(created_at: 1.day.ago)
+          end
+
+          it "renders creations template and assigns comments and works in order by oldest first" do
             subject.call
             expect(response).to render_template(:creations)
-            expect(assigns[:comments]).to contain_exactly(user_comment)
-            expect(assigns[:works]).to contain_exactly(user_work)
+            expect(assigns(:comments).map(&:id)).to eq([older_comment.id, newer_comment.id])
+            expect(assigns(:works).map(&:id)).to eq([older_work.id, newer_work.id])
           end
 
           it "raises ActiveRecord::RecordNotFound when user does not exist" do

--- a/spec/controllers/admin/admin_users_controller_spec.rb
+++ b/spec/controllers/admin/admin_users_controller_spec.rb
@@ -765,7 +765,7 @@ describe Admin::AdminUsersController do
       authorized_roles.each do |role|
         context "with #{role} role" do
           let(:admin) { create(:admin, roles: [role]) }
-          let!(:other_pseud) { create(:pseud, user:user) }
+          let!(:other_pseud) { create(:pseud, user: user) }
           let!(:older_comment) { create(:comment, pseud: other_pseud) }
           let!(:newer_comment) { create(:comment, pseud: user.default_pseud) }
           let!(:older_work) { create(:work, authors: [other_pseud]) }


### PR DESCRIPTION
# Pull Request Checklist

* [X] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [X] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [X] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [X] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [X] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-7324

## Purpose

List user creations on the spamban page in order from oldest to newest by creation date and then ID, rather than by pseud. 

## Credit

kekley (they/them)
