### PR TITLE
AO3-7404 Enhancements to works New Comment page

### DIFF
--- a/app/helpers/comments_helper.rb
+++ b/app/helpers/comments_helper.rb
@@ -11,7 +11,7 @@ module CommentsHelper
     else
       title = link_to(commentable.commentable_name, commentable)
     end
-    t(".header_html", link: title)
+    t(".page_heading_html", link: title)
   end
 
   def link_to_comment_ultimate_parent(comment)

--- a/app/helpers/comments_helper.rb
+++ b/app/helpers/comments_helper.rb
@@ -11,7 +11,7 @@ module CommentsHelper
     else
       title = link_to(commentable.commentable_name, commentable)
     end
-    t("comments.index.page_heading_html", link: title)
+    t("comments.index.page_heading_html", commentable_link: title)
   end
 
   def title_for_new_comment_page(commentable)
@@ -22,7 +22,7 @@ module CommentsHelper
             else
               link_to(commentable.commentable_name, commentable)
             end
-    t("comments.new.page_heading_html", link: title)
+    t("comments.new.page_heading_html", commentable_link: title)
   end
 
   def link_to_comment_ultimate_parent(comment)

--- a/app/helpers/comments_helper.rb
+++ b/app/helpers/comments_helper.rb
@@ -11,7 +11,7 @@ module CommentsHelper
     else
       title = link_to(commentable.commentable_name, commentable)
     end
-    t("comments.index.page_heading_html", commentable_link: title)
+    t("comments_helper.page_heading.reading_comments_html", commentable_link: title)
   end
 
   def title_for_new_comment_page(commentable)
@@ -22,7 +22,7 @@ module CommentsHelper
             else
               link_to(commentable.commentable_name, commentable)
             end
-    t("comments.new.page_heading_html", commentable_link: title)
+    t("comments_helper.page_heading.new_comment_html", commentable_link: title)
   end
 
   def link_to_comment_ultimate_parent(comment)

--- a/app/helpers/comments_helper.rb
+++ b/app/helpers/comments_helper.rb
@@ -15,13 +15,13 @@ module CommentsHelper
   end
 
   def title_for_new_comment_page(commentable)
-    if commentable.commentable_name.blank?
-      title = ""
-    elsif commentable.is_a?(Tag)
-      title = link_to_tag(commentable)
-    else
-      title = link_to(commentable.commentable_name, commentable)
-    end
+    title = if commentable.commentable_name.blank?
+              ""
+            elsif commentable.is_a?(Tag)
+              link_to_tag(commentable)
+            else
+              link_to(commentable.commentable_name, commentable)
+            end
     t("comments.new.page_heading_html", link: title)
   end
 

--- a/app/helpers/comments_helper.rb
+++ b/app/helpers/comments_helper.rb
@@ -11,7 +11,7 @@ module CommentsHelper
     else
       title = link_to(commentable.commentable_name, commentable)
     end
-    (ts('Reading Comments on ') + title).html_safe
+    t(".header_html", link: title)
   end
 
   def link_to_comment_ultimate_parent(comment)

--- a/app/helpers/comments_helper.rb
+++ b/app/helpers/comments_helper.rb
@@ -11,7 +11,18 @@ module CommentsHelper
     else
       title = link_to(commentable.commentable_name, commentable)
     end
-    t(".page_heading_html", link: title)
+    t("comments.index.page_heading_html", link: title)
+  end
+
+  def title_for_new_comment_page(commentable)
+    if commentable.commentable_name.blank?
+      title = ""
+    elsif commentable.is_a?(Tag)
+      title = link_to_tag(commentable)
+    else
+      title = link_to(commentable.commentable_name, commentable)
+    end
+    t("comments.new.page_heading_html", link: title)
   end
 
   def link_to_comment_ultimate_parent(comment)

--- a/app/views/comments/new.html.erb
+++ b/app/views/comments/new.html.erb
@@ -4,10 +4,10 @@
 <!--/descriptions-->
 
 <!--main content-->
-<%= render :partial => 'comments/comment_form', :locals => {
-    :comment => @comment, 
-    :commentable => @commentable,
-    :button_name => t(".actions.comment")
+<%= render partial: 'comments/comment_form', locals: {
+    comment: @comment, 
+    commentable: @commentable,
+    button_name: t(".actions.comment")
   } 
 %>
 <!--/content-->

--- a/app/views/comments/new.html.erb
+++ b/app/views/comments/new.html.erb
@@ -7,7 +7,7 @@
 <%= render :partial => 'comments/comment_form', :locals => {
     :comment => @comment, 
     :commentable => @commentable,
-    :button_name => ts("Comment")
+    :button_name => t(".actions.comment")
   } 
 %>
 <!--/content-->

--- a/app/views/comments/new.html.erb
+++ b/app/views/comments/new.html.erb
@@ -1,5 +1,5 @@
 <!--Descriptive page name, messages and instructions-->
-<h2 class="heading"><%= ts("New comment on %{name}", :name => @name) %></h2>
+<h2 class="heading"><%= title_for_comment_page(@commentable) %></h2>
 <%= error_messages_for :comment %>
 <!--/descriptions-->
 

--- a/app/views/comments/new.html.erb
+++ b/app/views/comments/new.html.erb
@@ -4,12 +4,11 @@
 <!--/descriptions-->
 
 <!--main content-->
-<%= render partial: 'comments/comment_form', locals: {
-    comment: @comment, 
-    commentable: @commentable,
-    button_name: t(".actions.comment")
-  } 
-%>
+<%= render partial: "comments/comment_form", locals: {
+  comment: @comment,
+  commentable: @commentable,
+  button_name: t(".actions.comment")
+} %>
 <!--/content-->
 
 <!--subnav-->

--- a/app/views/comments/new.html.erb
+++ b/app/views/comments/new.html.erb
@@ -1,5 +1,5 @@
 <!--Descriptive page name, messages and instructions-->
-<h2 class="heading"><%= title_for_comment_page(@commentable) %></h2>
+<h2 class="heading"><%= title_for_new_comment_page(@commentable) %></h2>
 <%= error_messages_for :comment %>
 <!--/descriptions-->
 

--- a/app/views/comments/new.html.erb
+++ b/app/views/comments/new.html.erb
@@ -13,5 +13,4 @@
 <!--/content-->
 
 <!--subnav-->
-<p class="navigation actions" role="navigation"><!--TODO: INVESTIGATE this baffling link--><%= link_to ts("Back"), @commentable.is_a?(Tag) ? tag_path(@commentable) : polymorphic_path(@commentable) %></p>
 <!--/subnav-->

--- a/app/views/comments/new.html.erb
+++ b/app/views/comments/new.html.erb
@@ -5,11 +5,8 @@
 
 <!--main content-->
 <%= render partial: "comments/comment_form", locals: {
-  comment: @comment,
-  commentable: @commentable,
-  button_name: t(".actions.comment")
-} %>
+      comment: @comment,
+      commentable: @commentable,
+      button_name: t(".actions.comment")
+    } %>
 <!--/content-->
-
-<!--subnav-->
-<!--/subnav-->

--- a/config/locales/helpers/en.yml
+++ b/config/locales/helpers/en.yml
@@ -44,6 +44,9 @@ en:
       on_tag_html: Comment on the tag %{name}
       on_unknown: Comment on unknown item
       on_work_html: Comment on the work %{title}
+    page_heading:
+      new_comment_html: New Comment on %{commentable_link}
+      reading_comments_html: Reading Comments on %{commentable_link}
   inbox_helper:
     comment_link_with_chapter_number: Chapter %{position} of %{title}
   qr_code_helper:

--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -914,12 +914,9 @@ en:
       page_heading: Editing comment
       show: Show
       update: Update
-    index:
-      page_heading_html: Reading Comments on %{commentable_link}
     new:
       actions:
         comment: Comment
-      page_heading_html: New Comment on %{commentable_link}
     show:
       comment_on_html: Comment on %{commentable_link}
     single_comment:

--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -915,11 +915,11 @@ en:
       show: Show
       update: Update
     index:
-      page_heading_html: Reading Comments on %{link}
+      page_heading_html: Reading Comments on %{commentable_link}
     new:
       actions:
         comment: Comment
-      page_heading_html: New Comment on %{link}
+      page_heading_html: New Comment on %{commentable_link}
     show:
       comment_on_html: Comment on %{commentable_link}
     single_comment:

--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -914,6 +914,10 @@ en:
       page_heading: Editing comment
       show: Show
       update: Update
+    index:
+      header_html: Reading Comments on %{link}
+    new:
+      header_html: New Comment on %{link}
     show:
       comment_on_html: Comment on %{commentable_link}
     single_comment:

--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -915,11 +915,11 @@ en:
       show: Show
       update: Update
     index:
-      header_html: Reading Comments on %{link}
+      page_heading_html: Reading Comments on %{link}
     new:
       actions:
         comment: Comment
-      header_html: New Comment on %{link}
+      page_heading_html: New Comment on %{link}
     show:
       comment_on_html: Comment on %{commentable_link}
     single_comment:

--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -917,6 +917,8 @@ en:
     index:
       header_html: Reading Comments on %{link}
     new:
+      actions:
+        comment: Comment
       header_html: New Comment on %{link}
     show:
       comment_on_html: Comment on %{commentable_link}

--- a/features/comments_and_kudos/add_comment.feature
+++ b/features/comments_and_kudos/add_comment.feature
@@ -4,6 +4,14 @@ Feature: Comment on work
   As a reader
   I'd like to comment on a work
 
+Scenario: Reading comments page for a work displays correctly
+
+  Given the work "Generic Work"
+  When I am logged in as "commenter"
+    And I visit the comments page for the work "Generic Work"
+  Then I should see "Reading Comments on"
+    And I should see a page link to the work "Generic Work" within ".comments-index h2.heading"
+
 Scenario: New comment page for a work displays correctly
 
   Given the work "Generic Work"

--- a/features/comments_and_kudos/add_comment.feature
+++ b/features/comments_and_kudos/add_comment.feature
@@ -4,12 +4,13 @@ Feature: Comment on work
   As a reader
   I'd like to comment on a work
 
-Scenario: Comment links from downloads and static pages
+Scenario: New comment page for a work displays correctly
 
   Given the work "Generic Work"
   When I am logged in as "commenter"
     And I visit the new comment page for the work "Generic Work"
-  Then I should see the comment form
+  Then I should see "New Comment on"
+    And I should see a page link to the work "Generic Work" within ".comments-new h2.heading"
 
 Scenario: When logged in I can comment on a work
 

--- a/features/comments_and_kudos/add_comment.feature
+++ b/features/comments_and_kudos/add_comment.feature
@@ -5,7 +5,6 @@ Feature: Comment on work
   I'd like to comment on a work
 
 Scenario: Reading comments page for a work displays correctly
-
   Given the work "Generic Work"
   When I am logged in as "commenter"
     And I visit the comments page for the work "Generic Work"
@@ -13,7 +12,6 @@ Scenario: Reading comments page for a work displays correctly
     And I should see a page link to the work "Generic Work" within ".comments-index h2.heading"
 
 Scenario: New comment page for a work displays correctly
-
   Given the work "Generic Work"
   When I am logged in as "commenter"
     And I visit the new comment page for the work "Generic Work"

--- a/features/step_definitions/comment_steps.rb
+++ b/features/step_definitions/comment_steps.rb
@@ -195,6 +195,11 @@ When /^I reply to a comment with "([^"]*)"$/ do |comment_text|
   end
 end
 
+When /^I visit the comments page for the work "([^"]+)"$/ do |work|
+  work = Work.find_by(title: work)
+  visit work_comments_path(work, only_path: false)
+end
+
 When /^I visit the new comment page for the work "([^"]+)"$/ do |work|
   work = Work.find_by(title: work)
   visit new_work_comment_path(work, only_path: false)

--- a/features/step_definitions/comment_steps.rb
+++ b/features/step_definitions/comment_steps.rb
@@ -106,10 +106,6 @@ Then /^I should see Last Edited nowish$/ do
   step "I should see \"Last Edited #{nowish}\""
 end
 
-Then /^I should see the comment form$/ do
-  step %{I should see "New comment on"}
-end
-
 Then /^I should see the reply to comment form$/ do
   step %{I should see "Comment as" within ".odd"}
 end

--- a/features/step_definitions/comment_steps.rb
+++ b/features/step_definitions/comment_steps.rb
@@ -195,7 +195,7 @@ When /^I reply to a comment with "([^"]*)"$/ do |comment_text|
   end
 end
 
-When /^I visit the comments page for the work "([^"]+)"$/ do |work|
+When "I visit the comments page for the work {string}" do |work|
   work = Work.find_by(title: work)
   visit work_comments_path(work, only_path: false)
 end


### PR DESCRIPTION
# Pull Request Checklist

<!-- Mark steps in the checklist as complete by changing `[ ]` to `[X]` -->
* [x] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [x] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [x] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [x] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-7404

## Purpose

On the New Comment page of a work:
- Make the work title in the header a link to the work
- Title case the header i.e. "New Comment on [work title]"
- Remove the "Back" button

Also added some translations for the Comments page header, and the "Comment" button on the New Comment page.

## Testing Instructions

Below is an additional testing scenario to ensure the changes I've made on the Comments page haven't changed the functionality. I plan to comment this on the Jira ticket when/if this PR is merged.

### Steps to reproduce

1. (optionally) Log in
2. Find a work and go to its Comments page (`/works/xxx/comments`)

### What happens (and what should still happen)

The page header says "Reading Comments on [work title]" and the work title is a link to the work.

## Credit

bre-nana (she/they/he)
