### PR TITLE
AO3-3396 Syns of fandom are now under fandom in stats page

### DIFF
--- a/app/controllers/stats_controller.rb
+++ b/app/controllers/stats_controller.rb
@@ -17,9 +17,18 @@ class StatsController < ApplicationController
     user_chapters = Chapter.joins(pseuds: :user).where(users: { id: @user.id }).where(posted: true)
     work_query = user_works
       .joins(:taggings)
-      .joins("inner join tags on ((taggings.tagger_id = tags.id AND tags.merger_id IS NULL) OR EXISTS (SELECT * FROM tags AS tags2 WHERE tags.id = tags2.merger_id AND tags2.id = taggings.tagger_id)) AND tags.type = 'Fandom'")
+      .joins(<<~SQL.squish)
+        INNER JOIN tags
+          ON ((taggings.tagger_id = tags.id AND tags.merger_id IS NULL)
+            OR EXISTS ( /* If the tag has a synonym, we take the synonym instead */
+              SELECT * FROM tags AS tags2
+              WHERE tags.id = tags2.merger_id
+                AND tags2.id = taggings.tagger_id
+            ))
+          AND tags.type = 'Fandom'
+      SQL
       .select("distinct tags.name as fandom, works.id as id, works.title as title")
-    
+
     # sort
 
     # NOTE: Because we are going to be eval'ing the @sort variable later we MUST make sure that its content is

--- a/app/controllers/stats_controller.rb
+++ b/app/controllers/stats_controller.rb
@@ -17,9 +17,9 @@ class StatsController < ApplicationController
     user_chapters = Chapter.joins(pseuds: :user).where(users: { id: @user.id }).where(posted: true)
     work_query = user_works
       .joins(:taggings)
-      .joins("inner join tags on taggings.tagger_id = tags.id AND tags.type = 'Fandom'")
+      .joins("inner join tags on ((taggings.tagger_id = tags.id AND tags.merger_id IS NULL) OR EXISTS (SELECT * FROM tags AS tags2 WHERE tags.id = tags2.merger_id AND tags2.id = taggings.tagger_id)) AND tags.type = 'Fandom'")
       .select("distinct tags.name as fandom, works.id as id, works.title as title")
-
+    
     # sort
 
     # NOTE: Because we are going to be eval'ing the @sort variable later we MUST make sure that its content is

--- a/app/controllers/stats_controller.rb
+++ b/app/controllers/stats_controller.rb
@@ -21,9 +21,9 @@ class StatsController < ApplicationController
         INNER JOIN tags
           ON ((taggings.tagger_id = tags.id AND tags.merger_id IS NULL)
             OR EXISTS ( /* If the tag has a synonym, we take the synonym instead */
-              SELECT * FROM tags AS tags2
-              WHERE tags.id = tags2.merger_id
-                AND tags2.id = taggings.tagger_id
+              SELECT * FROM tags AS synonyms
+              WHERE tags.id = synonyms.merger_id
+                AND synonyms.id = taggings.tagger_id
             ))
           AND tags.type = 'Fandom'
       SQL

--- a/features/other_b/stats.feature
+++ b/features/other_b/stats.feature
@@ -93,3 +93,15 @@ Feature: User statistics
   Given I am logged in as "NUMB3RSfan"
   When I go to NUMB3RSfan's stats page
   Then I should see the page title "NUMB3RSfan - Stats"
+
+  Scenario: Statistics page groups synonyms of a fandom with the fandom
+
+  Given I am logged in as "interestingIndividual"
+    And I post the work "Iced" with fandom "Raw"
+    And I post the work "Fire" with fandom "Shoot"
+    And a synonym "Raw" of the tag "Shoot"
+  When I go to interestingIndividual's stats page
+  Then I should see "Shoot"
+    And I should not see "Raw"
+    And I should see "Iced"
+    And I should see "Fire"


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-3396

## Purpose

This makes synonyms of fandom be grouped with the parent fandom in the stats page of an user (i.e work A in fandom 1, work B in fandom 2, 1 is a synonym of 2, we see A and B under 2 and we don't see 1)

## Credit

Danaël / Rever ( they / he )
Danaël Villeneuve on Jira
