### PR TITLE
AO3-6584 Fix Duplicate Inbox Notifications for Moderated Comments

### DIFF
--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -400,6 +400,9 @@ class Comment < ApplicationRecord
       end
     end
 
+    # Avoid duplicate inbox notifications when parent comment owner is a work creator who has already received the same notification with the approval request
+    return if self.saved_change_to_unreviewed? && !self.unreviewed? && self.ultimate_parent.commentable_owners.include?(parent_comment_owner)
+
     if parent_comment_owner && notify_user_by_inbox?(parent_comment_owner)
       if self.saved_change_to_edited_at?
         update_feedback_in_inbox(parent_comment_owner)

--- a/features/comments_and_kudos/comment_moderation.feature
+++ b/features/comments_and_kudos/comment_moderation.feature
@@ -137,6 +137,22 @@ Feature: Comment Moderation
       And I should see "Comments (1)"
       And I should not see "Unreviewed Comments (1)"
 
+  Scenario: Authors with moderated comments should not see duplicate inbox notifications for approved replies to their comments
+    Given the moderated work "Moderation" by "author"
+      And I am logged in as "author"
+      And I post the comment "Author comment" on the work "Moderation"
+    When I am logged in as "commenter"
+      And I view the work "Moderation"
+      And I follow "Comments (1)"
+      And I follow "Reply" within ".odd"
+      And I fill in "Comment" with "A moderated reply" within ".odd"
+      And I press "Comment" within ".odd"
+    When I am logged in as "author"
+      And I view the unreviewed comments page for "Moderation"
+      And I press "Approve"
+      And I go to author's inbox page
+    Then I should see "(1 comments, 0 unread)"
+
   Scenario: Comments can be approved from the home page inbox
     Given the moderated work "Moderation" by "author"
       And I am logged in as "commenter"


### PR DESCRIPTION
# Pull Request Checklist

<!-- Mark steps in the checklist as complete by changing `[ ]` to `[X]` -->
* [x] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [x] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [x] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [x] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-6584

## Purpose

Fixed bug where a work creator was receiving duplicate inbox notifications for replies to their comments, on works that had comment moderation enabled. 

## Credit

caitlin (she/her)
