### PR TITLE
AO3-3764 Paginate tag set nominations review page

### DIFF
--- a/app/controllers/tag_set_nominations_controller.rb
+++ b/app/controllers/tag_set_nominations_controller.rb
@@ -133,27 +133,30 @@ class TagSetNominationsController < ApplicationController
 
   def base_nom_query(tag_type)
     TagNomination.where(type: (tag_type.is_a?(Array) ? tag_type.map {|t| "#{t.classify}Nomination"} : "#{tag_type.classify}Nomination")).
-      for_tag_set(@tag_set).unreviewed.limit(@nom_limit)
+      for_tag_set(@tag_set).unreviewed
+  end
+
+  # Paginate nominations by unique tagname, since the view groups duplicates.
+  def paginate_unique_noms(tag_type, page_param:)
+    query = base_nom_query(tag_type)
+    unique_ids = query.group(:tagname).select("MIN(tag_nominations.id)")
+    unique_query = TagNomination.where(id: unique_ids).order(:created_at, :id)
+    unique_count = query.distinct.count(:tagname)
+    pagy(unique_query, count: unique_count, page_param: page_param)
   end
 
   # set up various variables for reviewing nominations
   def setup_for_review
     set_limit
 
-    # Only this amount of tag nominations is shown on the review page.
-    # If there are more (more_noms == true), moderators have to approve/reject from the shown noms to see more noms.
-    # TODO: AO3-3764 Show all tag set nominations
-    @nom_limit = 30
     @nominations = HashWithIndifferentAccess.new
     @nominations_count = HashWithIndifferentAccess.new
-    more_noms = false
+    @paginations = HashWithIndifferentAccess.new
 
     if @tag_set.includes_fandoms?
       # all char and rel tags happen under fandom noms
       @nominations_count[:fandom] = @tag_set.fandom_nominations.unreviewed.count
-      more_noms = true if @nominations_count[:fandom] > @nom_limit
-      # Show a random selection of nominations if there are more noms than can be shown at once
-      @nominations[:fandom] = more_noms ? base_nom_query("fandom").random_order : base_nom_query("fandom").order(:tagname)
+      @paginations[:fandom], @nominations[:fandom] = paginate_unique_noms("fandom", page_param: :fandom_page)
       if (@limit[:character] > 0 || @limit[:relationship] > 0)
         @nominations[:cast] = base_nom_query(%w(character relationship)).
           join_fandom_nomination.
@@ -164,24 +167,17 @@ class TagSetNominationsController < ApplicationController
       # if there are no fandoms we're going to assume this is a one or few fandom tagset
       @nominations_count[:character] = @tag_set.character_nominations.unreviewed.count
       @nominations_count[:relationship] = @tag_set.relationship_nominations.unreviewed.count
-      more_noms = true if (@tag_set.character_nominations.unreviewed.count > @nom_limit || @tag_set.relationship_nominations.unreviewed.count > @nom_limit)
-      @nominations[:character] = base_nom_query("character") if @limit[:character] > 0
-      @nominations[:relationship] = base_nom_query("relationship") if @limit[:relationship] > 0
-      if more_noms # Show a random selection of nominations if there are more noms than can be shown at once
-        parent_tagnames = TagNomination.for_tag_set(@tag_set).unreviewed.random_order.limit(100).pluck(:parent_tagname).uniq.first(30)
-        @nominations[:character] = @nominations[:character].where(parent_tagname: parent_tagnames) if @limit[:character] > 0
-        @nominations[:relationship] = @nominations[:relationship].where(parent_tagname: parent_tagnames) if @limit[:relationship] > 0
+      if @limit[:character] > 0
+        @paginations[:character], @nominations[:character] = paginate_unique_noms("character", page_param: :character_page)
       end
-      @nominations[:character] = @nominations[:character].order(:parent_tagname, :tagname) if @limit[:character] > 0
-      @nominations[:relationship] = @nominations[:relationship].order(:parent_tagname, :tagname) if @limit[:relationship] > 0
+      if @limit[:relationship] > 0
+        @paginations[:relationship], @nominations[:relationship] = paginate_unique_noms("relationship", page_param: :relationship_page)
+      end
     end
-    @nominations_count[:freeform] =  @tag_set.freeform_nominations.unreviewed.count
-    more_noms = true if @nominations_count[:freeform] > @nom_limit
-    # Show a random selection of nominations if there are more noms than can be shown at once
-    @nominations[:freeform] = (more_noms ? base_nom_query("freeform").random_order : base_nom_query("freeform").order(:tagname)) unless @limit[:freeform].zero?
 
-    if more_noms
-      flash[:notice] = ts("There are too many nominations to show at once, so here's a randomized selection! Additional nominations will appear after you approve or reject some.")
+    unless @limit[:freeform].zero?
+      @nominations_count[:freeform] = @tag_set.freeform_nominations.unreviewed.count
+      @paginations[:freeform], @nominations[:freeform] = paginate_unique_noms("freeform", page_param: :freeform_page)
     end
 
     if @tag_set.tag_nominations.unreviewed.empty?

--- a/app/controllers/tag_set_nominations_controller.rb
+++ b/app/controllers/tag_set_nominations_controller.rb
@@ -168,14 +168,16 @@ class TagSetNominationsController < ApplicationController
       @nominations_count[:character] = @tag_set.character_nominations.unreviewed.count
       @nominations_count[:relationship] = @tag_set.relationship_nominations.unreviewed.count
       if @limit[:character] > 0
-        @paginations[:character], @nominations[:character] = paginate_unique_noms("character", page_param: :character_page)
+        @paginations[:character], @nominations[:character] =
+          paginate_unique_noms("character", page_param: :character_page)
       end
       if @limit[:relationship] > 0
-        @paginations[:relationship], @nominations[:relationship] = paginate_unique_noms("relationship", page_param: :relationship_page)
+        @paginations[:relationship], @nominations[:relationship] =
+          paginate_unique_noms("relationship", page_param: :relationship_page)
       end
     end
 
-    unless @limit[:freeform].zero?
+    if @limit[:freeform] > 0
       @nominations_count[:freeform] = @tag_set.freeform_nominations.unreviewed.count
       @paginations[:freeform], @nominations[:freeform] = paginate_unique_noms("freeform", page_param: :freeform_page)
     end

--- a/app/controllers/tag_set_nominations_controller.rb
+++ b/app/controllers/tag_set_nominations_controller.rb
@@ -167,17 +167,17 @@ class TagSetNominationsController < ApplicationController
       # if there are no fandoms we're going to assume this is a one or few fandom tagset
       @nominations_count[:character] = @tag_set.character_nominations.unreviewed.count
       @nominations_count[:relationship] = @tag_set.relationship_nominations.unreviewed.count
-      if @limit[:character] > 0
+      if @limit[:character].positive?
         @paginations[:character], @nominations[:character] =
           paginate_unique_noms("character", page_param: :character_page)
       end
-      if @limit[:relationship] > 0
+      if @limit[:relationship].positive?
         @paginations[:relationship], @nominations[:relationship] =
           paginate_unique_noms("relationship", page_param: :relationship_page)
       end
     end
 
-    if @limit[:freeform] > 0
+    if @limit[:freeform].positive?
       @nominations_count[:freeform] = @tag_set.freeform_nominations.unreviewed.count
       @paginations[:freeform], @nominations[:freeform] = paginate_unique_noms("freeform", page_param: :freeform_page)
     end

--- a/app/helpers/tag_sets_helper.rb
+++ b/app/helpers/tag_sets_helper.rb
@@ -40,6 +40,20 @@ module TagSetsHelper
     message
   end
 
+  def nomination_review_heading(tag_type, pagy)
+    return ts("Already Approved Fandoms") if tag_type == "cast"
+
+    type_name = tag_type_label_name(tag_type).pluralize
+    if pagy.pages > 1
+      ts("%{from} - %{to} of %{total} %{type}",
+         from: pagy.from, to: pagy.to,
+         total: pagy.count, type: type_name)
+    else
+      ts("%{type} (%{count} left to review)",
+         type: type_name, count: pagy.count)
+    end
+  end
+
   def nomination_status(nomination=nil)
     symbol = "?!"
     status = "unreviewed"

--- a/app/helpers/tag_sets_helper.rb
+++ b/app/helpers/tag_sets_helper.rb
@@ -41,16 +41,16 @@ module TagSetsHelper
   end
 
   def nomination_review_heading(tag_type, pagy)
-    return ts("Already Approved Fandoms") if tag_type == "cast"
+    return t("tag_sets.nomination_review_heading.already_approved_fandoms") if tag_type == "cast"
 
     type_name = tag_type_label_name(tag_type).pluralize
     if pagy.pages > 1
-      ts("%{from} - %{to} of %{total} %{type}",
-         from: pagy.from, to: pagy.to,
-         total: pagy.count, type: type_name)
+      t("tag_sets.nomination_review_heading.paginated",
+        from: pagy.from, to: pagy.to,
+        total: pagy.count, type: type_name)
     else
-      ts("%{type} (%{count} left to review)",
-         type: type_name, count: pagy.count)
+      t("tag_sets.nomination_review_heading.left_to_review",
+        type: type_name, count: pagy.count)
     end
   end
 

--- a/app/views/tag_set_nominations/_review.html.erb
+++ b/app/views/tag_set_nominations/_review.html.erb
@@ -38,7 +38,7 @@
           <%= check_all_none("Approve All", "Approve None", "approve") %>
           <% if @paginations&.dig(tag_type) %>
             <%== pagy_nav(@paginations[tag_type],
-                   anchor_string: "id=\"#{tag_type}_nominations\"") %>
+                   fragment: "##{tag_type}_nominations") %>
           <% end %>
           <ol class="tags index group">
             <% if tag_type == "fandom" %>
@@ -53,7 +53,7 @@
           </ol>
           <% if @paginations&.dig(tag_type) %>
             <%== pagy_nav(@paginations[tag_type],
-                   anchor_string: "id=\"#{tag_type}_nominations\"") %>
+                   fragment: "##{tag_type}_nominations") %>
           <% end %>
         </fieldset>
       <% end %>

--- a/app/views/tag_set_nominations/_review.html.erb
+++ b/app/views/tag_set_nominations/_review.html.erb
@@ -30,12 +30,22 @@
 
     <% %w(cast fandom character relationship freeform).each do |tag_type| %>
       <% if @nominations[tag_type] && @nominations[tag_type].count > 0 %>
-        <fieldset class="<%= tag_type %> listbox group">
-          <% heading = tag_type == "cast" ? ts("Already Approved Fandoms") : ts("#{tag_type_label_name(tag_type).pluralize} (%{count} left to review)", :count => @tag_set.send("#{tag_type}_nominations").unreviewed.count) %>
+        <fieldset class="<%= tag_type %> listbox group" id="<%= tag_type %>_nominations">
+          <% if tag_type == "cast" %>
+            <% heading = ts("Already Approved Fandoms") %>
+          <% else %>
+            <% pagy = @paginations[tag_type] %>
+            <% if pagy.pages > 1 %>
+              <% heading = ts("%{from} - %{to} of %{total} %{type}", from: pagy.from, to: pagy.to, total: pagy.count, type: tag_type_label_name(tag_type).pluralize) %>
+            <% else %>
+              <% heading = ts("%{type} (%{count} left to review)", type: tag_type_label_name(tag_type).pluralize, count: pagy.count) %>
+            <% end %>
+          <% end %>
           <legend><%= heading %></legend>
           <h3 class="heading"><%= heading %></h3>
           <%= check_all_none("Reject All", "Reject None", "reject") %>
           <%= check_all_none("Approve All", "Approve None", "approve") %>
+          <%== pagy_nav(@paginations[tag_type], anchor_string: "id=\"#{tag_type}_nominations\"") if @paginations&.dig(tag_type) %>
           <ol class="tags index group">
             <% if tag_type == "fandom" %>
               <%= render "review_fandoms", :fandoms => @nominations[:fandom] %>
@@ -47,6 +57,7 @@
               <% end %>
             <% end %>
           </ol>
+          <%== pagy_nav(@paginations[tag_type], anchor_string: "id=\"#{tag_type}_nominations\"") if @paginations&.dig(tag_type) %>
         </fieldset>
       <% end %>
     <% end %>

--- a/app/views/tag_set_nominations/_review.html.erb
+++ b/app/views/tag_set_nominations/_review.html.erb
@@ -35,17 +35,24 @@
             <% heading = ts("Already Approved Fandoms") %>
           <% else %>
             <% pagy = @paginations[tag_type] %>
+            <% type_name = tag_type_label_name(tag_type).pluralize %>
             <% if pagy.pages > 1 %>
-              <% heading = ts("%{from} - %{to} of %{total} %{type}", from: pagy.from, to: pagy.to, total: pagy.count, type: tag_type_label_name(tag_type).pluralize) %>
+              <% heading = ts("%{from} - %{to} of %{total} %{type}",
+                   from: pagy.from, to: pagy.to,
+                   total: pagy.count, type: type_name) %>
             <% else %>
-              <% heading = ts("%{type} (%{count} left to review)", type: tag_type_label_name(tag_type).pluralize, count: pagy.count) %>
+              <% heading = ts("%{type} (%{count} left to review)",
+                   type: type_name, count: pagy.count) %>
             <% end %>
           <% end %>
           <legend><%= heading %></legend>
           <h3 class="heading"><%= heading %></h3>
           <%= check_all_none("Reject All", "Reject None", "reject") %>
           <%= check_all_none("Approve All", "Approve None", "approve") %>
-          <%== pagy_nav(@paginations[tag_type], anchor_string: "id=\"#{tag_type}_nominations\"") if @paginations&.dig(tag_type) %>
+          <% if @paginations&.dig(tag_type) %>
+            <%== pagy_nav(@paginations[tag_type],
+                   anchor_string: "id=\"#{tag_type}_nominations\"") %>
+          <% end %>
           <ol class="tags index group">
             <% if tag_type == "fandom" %>
               <%= render "review_fandoms", :fandoms => @nominations[:fandom] %>
@@ -57,7 +64,10 @@
               <% end %>
             <% end %>
           </ol>
-          <%== pagy_nav(@paginations[tag_type], anchor_string: "id=\"#{tag_type}_nominations\"") if @paginations&.dig(tag_type) %>
+          <% if @paginations&.dig(tag_type) %>
+            <%== pagy_nav(@paginations[tag_type],
+                   anchor_string: "id=\"#{tag_type}_nominations\"") %>
+          <% end %>
         </fieldset>
       <% end %>
     <% end %>

--- a/app/views/tag_set_nominations/_review.html.erb
+++ b/app/views/tag_set_nominations/_review.html.erb
@@ -31,20 +31,7 @@
     <% %w(cast fandom character relationship freeform).each do |tag_type| %>
       <% if @nominations[tag_type] && @nominations[tag_type].count > 0 %>
         <fieldset class="<%= tag_type %> listbox group" id="<%= tag_type %>_nominations">
-          <% if tag_type == "cast" %>
-            <% heading = ts("Already Approved Fandoms") %>
-          <% else %>
-            <% pagy = @paginations[tag_type] %>
-            <% type_name = tag_type_label_name(tag_type).pluralize %>
-            <% if pagy.pages > 1 %>
-              <% heading = ts("%{from} - %{to} of %{total} %{type}",
-                   from: pagy.from, to: pagy.to,
-                   total: pagy.count, type: type_name) %>
-            <% else %>
-              <% heading = ts("%{type} (%{count} left to review)",
-                   type: type_name, count: pagy.count) %>
-            <% end %>
-          <% end %>
+          <% heading = nomination_review_heading(tag_type, @paginations[tag_type]) %>
           <legend><%= heading %></legend>
           <h3 class="heading"><%= heading %></h3>
           <%= check_all_none("Reject All", "Reject None", "reject") %>

--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -2877,6 +2877,11 @@ en:
         works: My Work Subscriptions
       series: "(Series)"
       work: "(Work)"
+  tag_sets:
+    nomination_review_heading:
+      already_approved_fandoms: "Already Approved Fandoms"
+      paginated: "%{from} - %{to} of %{total} %{type}"
+      left_to_review: "%{type} (%{count} left to review)"
   tag_wranglers:
     index:
       filters:

--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -2879,9 +2879,9 @@ en:
       work: "(Work)"
   tag_sets:
     nomination_review_heading:
-      already_approved_fandoms: "Already Approved Fandoms"
-      paginated: "%{from} - %{to} of %{total} %{type}"
+      already_approved_fandoms: Already Approved Fandoms
       left_to_review: "%{type} (%{count} left to review)"
+      paginated: "%{from} - %{to} of %{total} %{type}"
   tag_wranglers:
     index:
       filters:

--- a/features/step_definitions/tag_set_steps.rb
+++ b/features/step_definitions/tag_set_steps.rb
@@ -155,11 +155,11 @@ Given "there are {int} nominations per page" do |amount|
   allow_any_instance_of(ApplicationController).to receive(:pagy_get_limit).and_return(amount)
 end
 
-Given /^the tag set "([^\"]*)" has (\d+) unreviewed freeform nominations$/ do |title, count|
+Given "the tag set {string} has {int} unreviewed freeform nominations" do |title, count|
   tag_set = OwnedTagSet.find_by!(title: title)
-  tag_set.update!(freeform_nomination_limit: count.to_i)
+  tag_set.update!(freeform_nomination_limit: count)
   nomination = tag_set.tag_set_nominations.first || FactoryBot.create(:tag_set_nomination, owned_tag_set: tag_set)
-  count.to_i.times do |i|
+  count.times do |i|
     FreeformNomination.create!(tag_set_nomination: nomination, tagname: "Freeform Tag #{i + 1}")
   end
 end

--- a/features/step_definitions/tag_set_steps.rb
+++ b/features/step_definitions/tag_set_steps.rb
@@ -151,6 +151,19 @@ When /^there are (\d+) unreviewed nominations$/ do |n|
   end
 end
 
+Given "there are {int} nominations per page" do |amount|
+  allow_any_instance_of(ApplicationController).to receive(:pagy_get_limit).and_return(amount)
+end
+
+Given /^the tag set "([^\"]*)" has (\d+) unreviewed freeform nominations$/ do |title, count|
+  tag_set = OwnedTagSet.find_by!(title: title)
+  tag_set.update!(freeform_nomination_limit: count.to_i)
+  nomination = tag_set.tag_set_nominations.first || FactoryBot.create(:tag_set_nomination, owned_tag_set: tag_set)
+  count.to_i.times do |i|
+    FreeformNomination.create!(tag_set_nomination: nomination, tagname: "Freeform Tag #{i + 1}")
+  end
+end
+
 When /^I review nominations for "([^\"]*)"/ do |title|
   step %{I am logged in as "tagsetter"}
   step %{I go to the "#{title}" tag set page}

--- a/features/tag_sets/tag_set_nominations.feature
+++ b/features/tag_sets/tag_set_nominations.feature
@@ -177,7 +177,7 @@ Feature: Nominating and reviewing nominations for a tag set
     And I am logged in as "tagsetter"
   When I go to the "Nominated Tags" tag set page
     And I follow "Review Nominations"
-  Then I should see "left to review"
+  Then I should see "Fandoms (3 left to review)"
 
   Scenario: If a moderator approves a nominated tag it should no longer appear on the review page and should appear on the tag set page
   Given I am logged in as "tagsetter"
@@ -215,7 +215,7 @@ Feature: Nominating and reviewing nominations for a tag set
     And I check "fandom_approve_Bar__LBRACKETFoo_RBRACKET"
     And I check "character_approve_Bat__LBRACKETBar_RBRACKET"
     And I submit
-  Then I should see "Successfully added to set: Bar [Foo], Foo [Bar]"
+  Then I should see "Successfully added to set: Foo [Bar], Bar [Foo]"
     And I should see "Successfully added to set: Bat [Bar]"
     And I should see "Successfully rejected: Yar [Bar]"
   When I go to the "Nominated Tags" tag set page

--- a/features/tag_sets/tag_set_nominations.feature
+++ b/features/tag_sets/tag_set_nominations.feature
@@ -164,14 +164,6 @@ Feature: Nominating and reviewing nominations for a tag set
   When I review nominations for "Nominated Tags"
   Then I should see "Next" within "fieldset.freeform .pagination"
 
-  Scenario: Owner of a tag set with over 30 nominations does not see the randomized selection message
-  Given I am logged in as "tagsetter"
-    And I set up the nominated tag set "Nominated Tags" with 6 fandom noms and 6 character noms
-  When there are 36 unreviewed nominations
-  Given I am logged in as "tagsetter"
-    And I review nominations for "Nominated Tags"
-  Then I should not see "There are too many nominations to show at once"
-
   Scenario: If a set has received nominations, a moderator should be able to review nominated tags
   Given I have the nominated tag set "Nominated Tags"
     And I am logged in as "tagsetter"

--- a/features/tag_sets/tag_set_nominations.feature
+++ b/features/tag_sets/tag_set_nominations.feature
@@ -145,13 +145,32 @@ Feature: Nominating and reviewing nominations for a tag set
     And I press "Yes, Clear Tag Set Nominations"
   Then I should see "All nominations for this Tag Set have been cleared"
 
-  Scenario: Owner of a tag set with over 30 nominations sees a message that they can't all be displayed on one page
+  Scenario: Fandom nominations are paginated on the review page
+  Given I am logged in as "tagsetter"
+    And I set up the nominated tag set "Nominated Tags" with 6 fandom noms and 6 character noms
+    And there are 2 nominations per page
+  When there are 36 unreviewed nominations
+  Given I am logged in as "tagsetter"
+    And I review nominations for "Nominated Tags"
+  Then I should see "Next" within "fieldset.fandom .pagination"
+  When I follow "Next" within "fieldset.fandom .pagination"
+  Then I should see "Fandoms" within "fieldset.fandom"
+
+  Scenario: Freeform nominations are paginated on the review page
+  Given I am logged in as "tagsetter"
+    And I set up the nominated tag set "Nominated Tags" with 0 fandom noms and 0 character noms
+    And the tag set "Nominated Tags" has 3 unreviewed freeform nominations
+    And there are 2 nominations per page
+  When I review nominations for "Nominated Tags"
+  Then I should see "Next" within "fieldset.freeform .pagination"
+
+  Scenario: Owner of a tag set with over 30 nominations does not see the randomized selection message
   Given I am logged in as "tagsetter"
     And I set up the nominated tag set "Nominated Tags" with 6 fandom noms and 6 character noms
   When there are 36 unreviewed nominations
   Given I am logged in as "tagsetter"
     And I review nominations for "Nominated Tags"
-  Then I should see "There are too many nominations to show at once, so here's a randomized selection! Additional nominations will appear after you approve or reject some"
+  Then I should not see "There are too many nominations to show at once"
 
   Scenario: If a set has received nominations, a moderator should be able to review nominated tags
   Given I have the nominated tag set "Nominated Tags"

--- a/spec/controllers/tag_set_nominations_controller_spec.rb
+++ b/spec/controllers/tag_set_nominations_controller_spec.rb
@@ -89,20 +89,17 @@ describe TagSetNominationsController do
                 context 'unreviewed freeform_nominations' do
                   context 'unreviewed freeform nominations <= 30' do
                     before do
-                      add_unreviewed_freeform_nominations(30)
+                      # Create with non-alphabetical names so ordering by tagname vs created_at differs
+                      FreeformNomination.create(tag_set_nomination: tag_set_nomination, tagname: "Zebra Freeform")
+                      FreeformNomination.create(tag_set_nomination: tag_set_nomination, tagname: "Apple Freeform")
+                      FreeformNomination.create(tag_set_nomination: tag_set_nomination, tagname: "Mango Freeform")
                       get :index, params: { tag_set_id: owned_tag_set.id }
                     end
 
-                    it 'returns all freeform nominations in order' do
-                      expect(assigns(:nominations_count)[:freeform]).to eq(30)
-                      expect(assigns(:nominations)[:freeform].count).to eq(30)
-                      expect(assigns(:nominations)[:freeform].first.tagname).to eq('New Freeform 0')
-                    end
-
-                    it 'does not return a flash notice about too many nominations' do
-                      expect(flash[:notice]).not_to eq("There are too many nominations to show at once, so here's a " \
-                                                         "randomized selection! Additional nominations will appear " \
-                                                         "after you approve or reject some.")
+                    it 'returns all freeform nominations ordered by creation date' do
+                      expect(assigns(:nominations)[:freeform].map(&:tagname)).to eq(
+                        ["Zebra Freeform", "Apple Freeform", "Mango Freeform"]
+                      )
                     end
                   end
 
@@ -112,15 +109,9 @@ describe TagSetNominationsController do
                       get :index, params: { tag_set_id: owned_tag_set.id }
                     end
 
-                    it 'returns 30 freeform nominations' do
+                    it 'returns 30 freeform nominations on the first page' do
                       expect(assigns(:nominations_count)[:freeform]).to eq(31)
                       expect(assigns(:nominations)[:freeform].count).to eq(30)
-                    end
-
-                    it 'returns a flash notice about too many nominations' do
-                      expect(flash[:notice]).to eq("There are too many nominations to show at once, so here's a " \
-                                                     "randomized selection! Additional nominations will appear " \
-                                                     "after you approve or reject some.")
                     end
                   end
 
@@ -177,35 +168,24 @@ describe TagSetNominationsController do
                   context 'unreviewed fandom nominations <= 30' do
                     let(:fandom_nom_num) { 30 }
 
-                    it 'returns all fandom nominations in order' do
+                    it 'returns all fandom nominations ordered by creation date' do
                       expect(assigns(:nominations_count)[:fandom]).to eq(30)
                       expect(assigns(:nominations)[:fandom].count).to eq(30)
-                      expect(assigns(:nominations)[:fandom].first.tagname).to eq('New Fandom 0')
+                      ids = assigns(:nominations)[:fandom].map(&:id)
+                      expect(ids).to eq(ids.sort)
                     end
 
                     it 'does not return associated character and relationship nominations' do
                       expect(assigns(:nominations)[:cast]).to be_empty
-                    end
-
-                    it 'does not return a flash notice about too many nominations' do
-                      expect(flash[:notice]).not_to eq("There are too many nominations to show at once, so here's a " \
-                                                         "randomized selection! Additional nominations will appear " \
-                                                         "after you approve or reject some.")
                     end
                   end
 
                   context 'unreviewed fandom nominations > 30' do
                     let(:fandom_nom_num) { 31 }
 
-                    it 'returns 30 fandom nominations' do
+                    it 'returns 30 fandom nominations on the first page' do
                       expect(assigns(:nominations_count)[:fandom]).to eq(31)
                       expect(assigns(:nominations)[:fandom].count).to eq(30)
-                    end
-
-                    it 'returns a flash notice about too many nominations' do
-                      expect(flash[:notice]).to eq("There are too many nominations to show at once, so here's a " \
-                                                     "randomized selection! Additional nominations will appear " \
-                                                     "after you approve or reject some.")
                     end
                   end
                 end
@@ -312,19 +292,15 @@ describe TagSetNominationsController do
                       get :index, params: { tag_set_id: owned_tag_set.id }
                     end
 
-                    it 'returns all ordered character and relationship nominations' do
+                    it 'returns all character and relationship nominations ordered by creation date' do
                       expect(assigns(:nominations_count)[:character]).to eq(30)
                       expect(assigns(:nominations)[:character].count).to eq(30)
-                      expect(assigns(:nominations)[:character].first.tagname).to eq('New Character 0')
+                      character_ids = assigns(:nominations)[:character].map(&:id)
+                      expect(character_ids).to eq(character_ids.sort)
                       expect(assigns(:nominations_count)[:relationship]).to eq(30)
                       expect(assigns(:nominations)[:relationship].count).to eq(30)
-                      expect(assigns(:nominations)[:relationship].first.tagname).to eq('New Relationship 0')
-                    end
-
-                    it 'does not return a flash notice about too many nominations' do
-                      expect(flash[:notice]).not_to eq("There are too many nominations to show at once, so here's a " \
-                                                         "randomized selection! Additional nominations will appear " \
-                                                         "after you approve or reject some.")
+                      relationship_ids = assigns(:nominations)[:relationship].map(&:id)
+                      expect(relationship_ids).to eq(relationship_ids.sort)
                     end
                   end
 
@@ -335,17 +311,11 @@ describe TagSetNominationsController do
                       get :index, params: { tag_set_id: owned_tag_set.id }
                     end
 
-                    it 'returns 30 character and relationship nominations' do
+                    it 'returns 30 relationship nominations on the first page' do
                       expect(assigns(:nominations_count)[:character]).to eq(1)
                       expect(assigns(:nominations)[:character].count).to eq(1)
                       expect(assigns(:nominations_count)[:relationship]).to eq(31)
                       expect(assigns(:nominations)[:relationship].count).to eq(30)
-                    end
-
-                    it 'returns a flash notice about too many nominations' do
-                      expect(flash[:notice]).to eq("There are too many nominations to show at once, so here's a " \
-                                                     "randomized selection! Additional nominations will appear " \
-                                                     "after you approve or reject some.")
                     end
                   end
                 end

--- a/spec/controllers/tag_set_nominations_controller_spec.rb
+++ b/spec/controllers/tag_set_nominations_controller_spec.rb
@@ -90,9 +90,18 @@ describe TagSetNominationsController do
                   context 'unreviewed freeform nominations <= 30' do
                     before do
                       # Create with non-alphabetical names so ordering by tagname vs created_at differs
-                      FreeformNomination.create(tag_set_nomination: tag_set_nomination, tagname: "Zebra Freeform")
-                      FreeformNomination.create(tag_set_nomination: tag_set_nomination, tagname: "Apple Freeform")
-                      FreeformNomination.create(tag_set_nomination: tag_set_nomination, tagname: "Mango Freeform")
+                      create(:tag_nomination, type: "FreeformNomination",
+                                              tag_set_nomination: tag_set_nomination,
+                                              owned_tag_set: tag_set_nomination.owned_tag_set,
+                                              tagname: "Zebra Freeform")
+                      create(:tag_nomination, type: "FreeformNomination",
+                                              tag_set_nomination: tag_set_nomination,
+                                              owned_tag_set: tag_set_nomination.owned_tag_set,
+                                              tagname: "Apple Freeform")
+                      create(:tag_nomination, type: "FreeformNomination",
+                                              tag_set_nomination: tag_set_nomination,
+                                              owned_tag_set: tag_set_nomination.owned_tag_set,
+                                              tagname: "Mango Freeform")
                       get :index, params: { tag_set_id: owned_tag_set.id }
                     end
 
@@ -119,7 +128,10 @@ describe TagSetNominationsController do
 
                   def add_unreviewed_freeform_nominations(num)
                     num.times do |i|
-                      FreeformNomination.create(tag_set_nomination: tag_set_nomination, tagname: "New Freeform #{i}")
+                      create(:tag_nomination, type: "FreeformNomination",
+                                              tag_set_nomination: tag_set_nomination,
+                                              owned_tag_set: tag_set_nomination.owned_tag_set,
+                                              tagname: "New Freeform #{i}")
                     end
                   end
                 end
@@ -276,14 +288,19 @@ describe TagSetNominationsController do
                     unique_tagnames = noms_per_page * 3
                     unique_tagnames.times do |i|
                       nominator = create(:user)
-                      tsn = TagSetNomination.create!(owned_tag_set: owned_tag_set, pseud: nominator.default_pseud)
-                      FandomNomination.create!(tag_set_nomination: tsn, tagname: "Paginated Fandom #{i}")
+                      tsn = create(:tag_set_nomination, owned_tag_set: owned_tag_set, pseud: nominator.default_pseud)
+                      create(:tag_nomination, type: "FandomNomination",
+                                              tag_set_nomination: tsn,
+                                              owned_tag_set: owned_tag_set,
+                                              tagname: "Paginated Fandom #{i}")
                     end
-                    # Add duplicates of the first tagname from different nominators
                     2.times do
                       dup_user = create(:user)
-                      tsn = TagSetNomination.create!(owned_tag_set: owned_tag_set, pseud: dup_user.default_pseud)
-                      FandomNomination.create!(tag_set_nomination: tsn, tagname: "Paginated Fandom 0")
+                      tsn = create(:tag_set_nomination, owned_tag_set: owned_tag_set, pseud: dup_user.default_pseud)
+                      create(:tag_nomination, type: "FandomNomination",
+                                              tag_set_nomination: tsn,
+                                              owned_tag_set: owned_tag_set,
+                                              tagname: "Paginated Fandom 0")
                     end
                   end
 
@@ -325,14 +342,22 @@ describe TagSetNominationsController do
 
                 def add_fandom_nominations(num, status)
                   num.times do |i|
-                    fandom_nom = FandomNomination.create(tag_set_nomination: tag_set_nomination, tagname: "New Fandom #{i}")
+                    fandom_nom = create(:tag_nomination, type: "FandomNomination",
+                                                         tag_set_nomination: tag_set_nomination,
+                                                         owned_tag_set: tag_set_nomination.owned_tag_set,
+                                                         tagname: "New Fandom #{i}")
                     fandom_nom.update_column(status, true) if status != :unreviewed
                   end
                 end
               end
 
               context 'tag set fandom_nomination_limit is 0' do
-                let(:fandom_nom) { FandomNomination.create(tag_set_nomination: tag_set_nomination, tagname: 'New Fandom') }
+                let(:fandom_nom) do
+                  create(:tag_nomination, type: "FandomNomination",
+                                          tag_set_nomination: tag_set_nomination,
+                                          owned_tag_set: tag_set_nomination.owned_tag_set,
+                                          tagname: "New Fandom")
+                end
 
                 before do
                   owned_tag_set.update_column(:fandom_nomination_limit, 0)
@@ -401,15 +426,21 @@ describe TagSetNominationsController do
 
                 def add_unreviewed_character_nominations(num)
                   num.times do |i|
-                    CharacterNomination.create(tag_set_nomination: tag_set_nomination, fandom_nomination: fandom_nom,
-                                               tagname: "New Character #{i}")
+                    create(:tag_nomination, type: "CharacterNomination",
+                                            tag_set_nomination: tag_set_nomination,
+                                            owned_tag_set: tag_set_nomination.owned_tag_set,
+                                            fandom_nomination_id: fandom_nom.id,
+                                            tagname: "New Character #{i}")
                   end
                 end
 
                 def add_unreviewed_relationship_nominations(num)
                   num.times do |i|
-                    RelationshipNomination.create(tag_set_nomination: tag_set_nomination, fandom_nomination: fandom_nom,
-                                                  tagname: "New Relationship #{i}")
+                    create(:tag_nomination, type: "RelationshipNomination",
+                                            tag_set_nomination: tag_set_nomination,
+                                            owned_tag_set: tag_set_nomination.owned_tag_set,
+                                            fandom_nomination_id: fandom_nom.id,
+                                            tagname: "New Relationship #{i}")
                   end
                 end
               end

--- a/spec/controllers/tag_set_nominations_controller_spec.rb
+++ b/spec/controllers/tag_set_nominations_controller_spec.rb
@@ -96,14 +96,14 @@ describe TagSetNominationsController do
                       get :index, params: { tag_set_id: owned_tag_set.id }
                     end
 
-                    it 'returns all freeform nominations ordered by creation date' do
+                    it "returns all freeform nominations ordered by creation date" do
                       expect(assigns(:nominations)[:freeform].map(&:tagname)).to eq(
                         ["Zebra Freeform", "Apple Freeform", "Mango Freeform"]
                       )
                     end
                   end
 
-                  context 'unreviewed freeform nominations exceed per page limit' do
+                  context "unreviewed freeform nominations exceed per page limit" do
                     let(:per_page) { ArchiveConfig.ITEMS_PER_PAGE }
 
                     before do
@@ -111,7 +111,7 @@ describe TagSetNominationsController do
                       get :index, params: { tag_set_id: owned_tag_set.id }
                     end
 
-                    it 'returns one page of freeform nominations' do
+                    it "returns one page of freeform nominations" do
                       expect(assigns(:nominations_count)[:freeform]).to eq(per_page + 1)
                       expect(assigns(:nominations)[:freeform].count).to eq(per_page)
                     end
@@ -167,10 +167,10 @@ describe TagSetNominationsController do
                     get :index, params: { tag_set_id: owned_tag_set.id }
                   end
 
-                  context 'unreviewed fandom nominations within per page limit' do
+                  context "unreviewed fandom nominations within per page limit" do
                     let(:fandom_nom_num) { 20 }
 
-                    it 'returns all fandom nominations ordered by creation date' do
+                    it "returns all fandom nominations ordered by creation date" do
                       expect(assigns(:nominations_count)[:fandom]).to eq(20)
                       expect(assigns(:nominations)[:fandom].count).to eq(20)
                       ids = assigns(:nominations)[:fandom].map(&:id)
@@ -182,11 +182,11 @@ describe TagSetNominationsController do
                     end
                   end
 
-                  context 'unreviewed fandom nominations exceed per page limit' do
+                  context "unreviewed fandom nominations exceed per page limit" do
                     let(:per_page) { ArchiveConfig.ITEMS_PER_PAGE }
                     let(:fandom_nom_num) { per_page + 1 }
 
-                    it 'returns one page of fandom nominations' do
+                    it "returns one page of fandom nominations" do
                       expect(assigns(:nominations_count)[:fandom]).to eq(per_page + 1)
                       expect(assigns(:nominations)[:fandom].count).to eq(per_page)
                     end
@@ -267,7 +267,7 @@ describe TagSetNominationsController do
                   end
                 end
 
-                context 'duplicate tagnames across multiple nominators are paginated by unique tagname' do
+                context "duplicate tagnames across multiple nominators are paginated by unique tagname" do
                   let(:fandom_nom_num) { 0 }
                   let(:fandom_nom_status) { :unreviewed }
                   let(:noms_per_page) { ArchiveConfig.ITEMS_PER_PAGE }
@@ -287,14 +287,14 @@ describe TagSetNominationsController do
                     end
                   end
 
-                  it 'page 1 returns exactly one page of unique tagnames' do
+                  it "page 1 returns exactly one page of unique tagnames" do
                     get :index, params: { tag_set_id: owned_tag_set.id, fandom_page: 1 }
                     tagnames = assigns(:nominations)[:fandom].map(&:tagname)
                     expect(tagnames.length).to eq(noms_per_page)
                     expect(tagnames).to eq(tagnames.uniq)
                   end
 
-                  it 'page 2 returns the next page of unique tagnames without repeats from page 1' do
+                  it "page 2 returns the next page of unique tagnames without repeats from page 1" do
                     get :index, params: { tag_set_id: owned_tag_set.id, fandom_page: 1 }
                     page1_tagnames = assigns(:nominations)[:fandom].map(&:tagname)
 
@@ -306,7 +306,7 @@ describe TagSetNominationsController do
                     expect(page1_tagnames & page2_tagnames).to be_empty
                   end
 
-                  it 'page 3 returns the remaining unique tagnames' do
+                  it "page 3 returns the remaining unique tagnames" do
                     get :index, params: { tag_set_id: owned_tag_set.id, fandom_page: 3 }
                     page3_tagnames = assigns(:nominations)[:fandom].map(&:tagname)
 
@@ -314,7 +314,7 @@ describe TagSetNominationsController do
                     expect(page3_tagnames).to eq(page3_tagnames.uniq)
                   end
 
-                  it 'pagination count reflects unique tagnames not total nominations' do
+                  it "pagination count reflects unique tagnames not total nominations" do
                     get :index, params: { tag_set_id: owned_tag_set.id }
                     unique_count = noms_per_page * 3
                     total_count = unique_count + 2
@@ -344,14 +344,14 @@ describe TagSetNominationsController do
                     owned_tag_set.update_column(:relationship_nomination_limit, 1)
                   end
 
-                  context 'unreviewed character and relationship nominations within per page limit' do
+                  context "unreviewed character and relationship nominations within per page limit" do
                     before do
                       add_unreviewed_character_nominations(20)
                       add_unreviewed_relationship_nominations(20)
                       get :index, params: { tag_set_id: owned_tag_set.id }
                     end
 
-                    it 'returns all character and relationship nominations ordered by creation date' do
+                    it "returns all character and relationship nominations ordered by creation date" do
                       expect(assigns(:nominations_count)[:character]).to eq(20)
                       expect(assigns(:nominations)[:character].count).to eq(20)
                       character_ids = assigns(:nominations)[:character].map(&:id)
@@ -363,7 +363,7 @@ describe TagSetNominationsController do
                     end
                   end
 
-                  context 'unreviewed relationship nominations exceed per page limit' do
+                  context "unreviewed relationship nominations exceed per page limit" do
                     let(:per_page) { ArchiveConfig.ITEMS_PER_PAGE }
 
                     before do
@@ -372,7 +372,7 @@ describe TagSetNominationsController do
                       get :index, params: { tag_set_id: owned_tag_set.id }
                     end
 
-                    it 'returns one page of relationship nominations' do
+                    it "returns one page of relationship nominations" do
                       expect(assigns(:nominations_count)[:character]).to eq(1)
                       expect(assigns(:nominations)[:character].count).to eq(1)
                       expect(assigns(:nominations_count)[:relationship]).to eq(per_page + 1)

--- a/spec/controllers/tag_set_nominations_controller_spec.rb
+++ b/spec/controllers/tag_set_nominations_controller_spec.rb
@@ -180,11 +180,12 @@ describe TagSetNominationsController do
                   end
 
                   context "unreviewed fandom nominations within per page limit" do
-                    let(:fandom_nom_num) { 20 }
+                    let(:per_page) { ArchiveConfig.ITEMS_PER_PAGE }
+                    let(:fandom_nom_num) { per_page }
 
                     it "returns all fandom nominations ordered by creation date" do
-                      expect(assigns(:nominations_count)[:fandom]).to eq(20)
-                      expect(assigns(:nominations)[:fandom].count).to eq(20)
+                      expect(assigns(:nominations_count)[:fandom]).to eq(per_page)
+                      expect(assigns(:nominations)[:fandom].count).to eq(per_page)
                       ids = assigns(:nominations)[:fandom].map(&:id)
                       expect(ids).to eq(ids.sort)
                     end
@@ -370,19 +371,21 @@ describe TagSetNominationsController do
                   end
 
                   context "unreviewed character and relationship nominations within per page limit" do
+                    let(:per_page) { ArchiveConfig.ITEMS_PER_PAGE }
+
                     before do
-                      add_unreviewed_character_nominations(20)
-                      add_unreviewed_relationship_nominations(20)
+                      add_unreviewed_character_nominations(per_page)
+                      add_unreviewed_relationship_nominations(per_page)
                       get :index, params: { tag_set_id: owned_tag_set.id }
                     end
 
                     it "returns all character and relationship nominations ordered by creation date" do
-                      expect(assigns(:nominations_count)[:character]).to eq(20)
-                      expect(assigns(:nominations)[:character].count).to eq(20)
+                      expect(assigns(:nominations_count)[:character]).to eq(per_page)
+                      expect(assigns(:nominations)[:character].count).to eq(per_page)
                       character_ids = assigns(:nominations)[:character].map(&:id)
                       expect(character_ids).to eq(character_ids.sort)
-                      expect(assigns(:nominations_count)[:relationship]).to eq(20)
-                      expect(assigns(:nominations)[:relationship].count).to eq(20)
+                      expect(assigns(:nominations_count)[:relationship]).to eq(per_page)
+                      expect(assigns(:nominations)[:relationship].count).to eq(per_page)
                       relationship_ids = assigns(:nominations)[:relationship].map(&:id)
                       expect(relationship_ids).to eq(relationship_ids.sort)
                     end

--- a/spec/controllers/tag_set_nominations_controller_spec.rb
+++ b/spec/controllers/tag_set_nominations_controller_spec.rb
@@ -103,15 +103,17 @@ describe TagSetNominationsController do
                     end
                   end
 
-                  context 'unreviewed freeform nominations > 30' do
+                  context 'unreviewed freeform nominations exceed per page limit' do
+                    let(:per_page) { ArchiveConfig.ITEMS_PER_PAGE }
+
                     before do
-                      add_unreviewed_freeform_nominations(31)
+                      add_unreviewed_freeform_nominations(per_page + 1)
                       get :index, params: { tag_set_id: owned_tag_set.id }
                     end
 
-                    it 'returns 30 freeform nominations on the first page' do
-                      expect(assigns(:nominations_count)[:freeform]).to eq(31)
-                      expect(assigns(:nominations)[:freeform].count).to eq(30)
+                    it 'returns one page of freeform nominations' do
+                      expect(assigns(:nominations_count)[:freeform]).to eq(per_page + 1)
+                      expect(assigns(:nominations)[:freeform].count).to eq(per_page)
                     end
                   end
 
@@ -165,12 +167,12 @@ describe TagSetNominationsController do
                     get :index, params: { tag_set_id: owned_tag_set.id }
                   end
 
-                  context 'unreviewed fandom nominations <= 30' do
-                    let(:fandom_nom_num) { 30 }
+                  context 'unreviewed fandom nominations within per page limit' do
+                    let(:fandom_nom_num) { 20 }
 
                     it 'returns all fandom nominations ordered by creation date' do
-                      expect(assigns(:nominations_count)[:fandom]).to eq(30)
-                      expect(assigns(:nominations)[:fandom].count).to eq(30)
+                      expect(assigns(:nominations_count)[:fandom]).to eq(20)
+                      expect(assigns(:nominations)[:fandom].count).to eq(20)
                       ids = assigns(:nominations)[:fandom].map(&:id)
                       expect(ids).to eq(ids.sort)
                     end
@@ -180,12 +182,13 @@ describe TagSetNominationsController do
                     end
                   end
 
-                  context 'unreviewed fandom nominations > 30' do
-                    let(:fandom_nom_num) { 31 }
+                  context 'unreviewed fandom nominations exceed per page limit' do
+                    let(:per_page) { ArchiveConfig.ITEMS_PER_PAGE }
+                    let(:fandom_nom_num) { per_page + 1 }
 
-                    it 'returns 30 fandom nominations on the first page' do
-                      expect(assigns(:nominations_count)[:fandom]).to eq(31)
-                      expect(assigns(:nominations)[:fandom].count).to eq(30)
+                    it 'returns one page of fandom nominations' do
+                      expect(assigns(:nominations_count)[:fandom]).to eq(per_page + 1)
+                      expect(assigns(:nominations)[:fandom].count).to eq(per_page)
                     end
                   end
                 end
@@ -264,6 +267,62 @@ describe TagSetNominationsController do
                   end
                 end
 
+                context 'duplicate tagnames across multiple nominators are paginated by unique tagname' do
+                  let(:fandom_nom_num) { 0 }
+                  let(:fandom_nom_status) { :unreviewed }
+                  let(:noms_per_page) { ArchiveConfig.ITEMS_PER_PAGE }
+
+                  before do
+                    unique_tagnames = noms_per_page * 3
+                    unique_tagnames.times do |i|
+                      nominator = create(:user)
+                      tsn = TagSetNomination.create!(owned_tag_set: owned_tag_set, pseud: nominator.default_pseud)
+                      FandomNomination.create!(tag_set_nomination: tsn, tagname: "Paginated Fandom #{i}")
+                    end
+                    # Add duplicates of the first tagname from different nominators
+                    2.times do
+                      dup_user = create(:user)
+                      tsn = TagSetNomination.create!(owned_tag_set: owned_tag_set, pseud: dup_user.default_pseud)
+                      FandomNomination.create!(tag_set_nomination: tsn, tagname: "Paginated Fandom 0")
+                    end
+                  end
+
+                  it 'page 1 returns exactly one page of unique tagnames' do
+                    get :index, params: { tag_set_id: owned_tag_set.id, fandom_page: 1 }
+                    tagnames = assigns(:nominations)[:fandom].map(&:tagname)
+                    expect(tagnames.length).to eq(noms_per_page)
+                    expect(tagnames).to eq(tagnames.uniq)
+                  end
+
+                  it 'page 2 returns the next page of unique tagnames without repeats from page 1' do
+                    get :index, params: { tag_set_id: owned_tag_set.id, fandom_page: 1 }
+                    page1_tagnames = assigns(:nominations)[:fandom].map(&:tagname)
+
+                    get :index, params: { tag_set_id: owned_tag_set.id, fandom_page: 2 }
+                    page2_tagnames = assigns(:nominations)[:fandom].map(&:tagname)
+
+                    expect(page2_tagnames.length).to eq(noms_per_page)
+                    expect(page2_tagnames).to eq(page2_tagnames.uniq)
+                    expect(page1_tagnames & page2_tagnames).to be_empty
+                  end
+
+                  it 'page 3 returns the remaining unique tagnames' do
+                    get :index, params: { tag_set_id: owned_tag_set.id, fandom_page: 3 }
+                    page3_tagnames = assigns(:nominations)[:fandom].map(&:tagname)
+
+                    expect(page3_tagnames.length).to eq(noms_per_page)
+                    expect(page3_tagnames).to eq(page3_tagnames.uniq)
+                  end
+
+                  it 'pagination count reflects unique tagnames not total nominations' do
+                    get :index, params: { tag_set_id: owned_tag_set.id }
+                    unique_count = noms_per_page * 3
+                    total_count = unique_count + 2
+                    expect(assigns(:nominations_count)[:fandom]).to eq(total_count)
+                    expect(assigns(:paginations)[:fandom].count).to eq(unique_count)
+                  end
+                end
+
                 def add_fandom_nominations(num, status)
                   num.times do |i|
                     fandom_nom = FandomNomination.create(tag_set_nomination: tag_set_nomination, tagname: "New Fandom #{i}")
@@ -285,37 +344,39 @@ describe TagSetNominationsController do
                     owned_tag_set.update_column(:relationship_nomination_limit, 1)
                   end
 
-                  context 'unreviewed character and relationship nominations <= 30' do
+                  context 'unreviewed character and relationship nominations within per page limit' do
                     before do
-                      add_unreviewed_character_nominations(30)
-                      add_unreviewed_relationship_nominations(30)
+                      add_unreviewed_character_nominations(20)
+                      add_unreviewed_relationship_nominations(20)
                       get :index, params: { tag_set_id: owned_tag_set.id }
                     end
 
                     it 'returns all character and relationship nominations ordered by creation date' do
-                      expect(assigns(:nominations_count)[:character]).to eq(30)
-                      expect(assigns(:nominations)[:character].count).to eq(30)
+                      expect(assigns(:nominations_count)[:character]).to eq(20)
+                      expect(assigns(:nominations)[:character].count).to eq(20)
                       character_ids = assigns(:nominations)[:character].map(&:id)
                       expect(character_ids).to eq(character_ids.sort)
-                      expect(assigns(:nominations_count)[:relationship]).to eq(30)
-                      expect(assigns(:nominations)[:relationship].count).to eq(30)
+                      expect(assigns(:nominations_count)[:relationship]).to eq(20)
+                      expect(assigns(:nominations)[:relationship].count).to eq(20)
                       relationship_ids = assigns(:nominations)[:relationship].map(&:id)
                       expect(relationship_ids).to eq(relationship_ids.sort)
                     end
                   end
 
-                  context 'unreviewed character or relationship nominations > 30' do
+                  context 'unreviewed relationship nominations exceed per page limit' do
+                    let(:per_page) { ArchiveConfig.ITEMS_PER_PAGE }
+
                     before do
                       add_unreviewed_character_nominations(1)
-                      add_unreviewed_relationship_nominations(31)
+                      add_unreviewed_relationship_nominations(per_page + 1)
                       get :index, params: { tag_set_id: owned_tag_set.id }
                     end
 
-                    it 'returns 30 relationship nominations on the first page' do
+                    it 'returns one page of relationship nominations' do
                       expect(assigns(:nominations_count)[:character]).to eq(1)
                       expect(assigns(:nominations)[:character].count).to eq(1)
-                      expect(assigns(:nominations_count)[:relationship]).to eq(31)
-                      expect(assigns(:nominations)[:relationship].count).to eq(30)
+                      expect(assigns(:nominations_count)[:relationship]).to eq(per_page + 1)
+                      expect(assigns(:nominations)[:relationship].count).to eq(per_page)
                     end
                   end
                 end

--- a/spec/controllers/tag_set_nominations_controller_spec.rb
+++ b/spec/controllers/tag_set_nominations_controller_spec.rb
@@ -286,7 +286,7 @@ describe TagSetNominationsController do
                   let(:noms_per_page) { ArchiveConfig.ITEMS_PER_PAGE }
 
                   before do
-                    unique_tagnames = noms_per_page * 3
+                    unique_tagnames = noms_per_page * 2
                     unique_tagnames.times do |i|
                       nominator = create(:user)
                       tsn = create(:tag_set_nomination, owned_tag_set: owned_tag_set, pseud: nominator.default_pseud)
@@ -324,17 +324,9 @@ describe TagSetNominationsController do
                     expect(page1_tagnames & page2_tagnames).to be_empty
                   end
 
-                  it "page 3 returns the remaining unique tagnames" do
-                    get :index, params: { tag_set_id: owned_tag_set.id, fandom_page: 3 }
-                    page3_tagnames = assigns(:nominations)[:fandom].map(&:tagname)
-
-                    expect(page3_tagnames.length).to eq(noms_per_page)
-                    expect(page3_tagnames).to eq(page3_tagnames.uniq)
-                  end
-
                   it "pagination count reflects unique tagnames not total nominations" do
                     get :index, params: { tag_set_id: owned_tag_set.id }
-                    unique_count = noms_per_page * 3
+                    unique_count = noms_per_page * 2
                     total_count = unique_count + 2
                     expect(assigns(:nominations_count)[:fandom]).to eq(total_count)
                     expect(assigns(:paginations)[:fandom].count).to eq(unique_count)


### PR DESCRIPTION
# Pull Request Checklist

* [X] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [X] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [X] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [X] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [X] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-3764

## Purpose

When a tag set has more than 30 unreviewed nominations, moderators currently see a random subset with the message "There are too many nominations to show at once." This makes it impossible to systematically review all nominations.

This PR replaces the random selection with proper pagination using pagy:

- Paginate nominations by unique tagname, grouping duplicates (same tag nominated by multiple users) into a single entry
- Each tag type (fandom, character, relationship, freeform) paginates independently with its own page param
- Heading shows "X - Y of Z [Type]" when paginated, or "[Type] (N left to review)" when everything fits on one page
- Pagination links include anchors to scroll to the correct fieldset
- Order by `created_at` ascending for deterministic results
- Removed the random selection logic and the "too many nominations" flash message

## Testing Instructions

1. Log in as a moderator of a tag set with more than 25 unreviewed nominations
2. Go to Review Nominations
3. Verify pagination links appear and each tag type paginates independently
4. Verify that navigating pages does not affect other tag types (e.g. going to fandom page 2 keeps freeform on page 1)
5. Verify duplicate nominations (same tagname from different users) appear only once
6. Verify approving/rejecting tags updates counts correctly
7. Verify tag sets with fewer than 25 nominations show no pagination links and display the "(N left to review)" heading
8. Verify the old "There are too many nominations to show at once" message no longer appears

## Credit

Pablo Monfort (he/him)