### PR TITLE
AO3-7411 Display first two fandoms in work title

### DIFF
--- a/app/helpers/works_helper.rb
+++ b/app/helpers/works_helper.rb
@@ -34,10 +34,10 @@ module WorksHelper
     fandoms = work.fandoms
     title_fandom = if fandoms.empty?
                      t("works_helper.work_page_title.unspecified_fandom")
-                   elsif fandoms.size > 3
+                   elsif fandoms.size > 2
                      t("works_helper.work_page_title.multifandom")
                    else
-                     fandoms.first.name
+                     fandoms.pluck(:name).join(t("support.array.words_connector"))
                    end
     author = work.anonymous? ? t("works_helper.work_page_title.anonymous") : work.pseuds.sort.collect(&:byline).join(t("support.array.words_connector"))
 

--- a/spec/controllers/chapters_controller_spec.rb
+++ b/spec/controllers/chapters_controller_spec.rb
@@ -226,19 +226,19 @@ describe ChaptersController do
     end
 
     context "when work has two fandoms" do
-      it "assigns @page_title with the first fandom" do
+      it "assigns @page_title with the fandoms deliminated by commas" do
         first = create(:fandom, name: "The First")
         second = create(:fandom, name: "The Second")
         allow_any_instance_of(Work).to receive(:fandoms).and_return([first, second])
         get :show, params: { work_id: work.id, id: work.chapters.first.id }
         expect(response).to have_http_status(:ok)
-        expect(assigns[:page_title]).to start_with("#{work.title} - Chapter 1 - #{user.pseuds.first.name} - The First [")
+        expect(assigns[:page_title]).to start_with("#{work.title} - Chapter 1 - #{user.pseuds.first.name} - The First, The Second [")
       end
     end
 
     context "when work has many fandoms" do
       it "assigns @page_title with placeholder for the fandoms" do
-        fandoms = create_list(:fandom, 5)
+        fandoms = create_list(:fandom, 3)
         allow_any_instance_of(Work).to receive(:fandoms).and_return(fandoms)
         get :show, params: { work_id: work.id, id: work.chapters.first.id }
         expect(response).to have_http_status(:ok)


### PR DESCRIPTION
# Pull Request Checklist

<!-- Mark steps in the checklist as complete by changing `[ ]` to `[X]` -->
* [X] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [X] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [X] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [X] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [X] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-7411

## Purpose

Display the first two fandoms in the browser page title of a work.
For works with 3 or more fandoms, then they should be replaced with "Multifandom".

This is a slight change from the previous behaviour which would only list _the first_ fandom and would only display Multifandom when there were _4 or more_ fandoms instead of 3.

Examples:
`Work with one fandom - user_a - FandomOne [Example Archive]`
`Work with two fandoms - user_b - FandomOne, FandomTwo [Example Archive]`
`Work with three or more fandoms - user_c - Multifandom [Example Archive]`

## Credit

nicolacleary (she/her)
