### PR TITLE
AO3-951 Add hide_chapter_numbering option to works

### DIFF
--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -875,7 +875,7 @@ class WorksController < ApplicationController
       :archive_warning_string, :category_string,
       :freeform_string, :summary, :notes, :endnotes, :collection_names, :recipients, :wip_length,
       :backdate, :language_id, :work_skin_id, :restricted, :comment_permissions,
-      :moderated_commenting_enabled, :title, :pseuds_to_add, :collections_to_add,
+      :moderated_commenting_enabled, :hide_chapter_numbering, :title, :pseuds_to_add, :collections_to_add,
       current_user_pseud_ids: [],
       collections_to_remove: [],
       challenge_assignment_ids: [],

--- a/app/models/chapter.rb
+++ b/app/models/chapter.rb
@@ -131,17 +131,23 @@ class Chapter < ApplicationRecord
     self.title.blank? ? self.chapter_header : self.title
   end
 
-  # Header plus title, used in subscriptions
+  # Header plus title, used in subscriptions and downloads
   def full_chapter_title
-    str = chapter_header
-    if title.present?
-      str += ": #{title}"
+    if work.hide_chapter_numbering && title.present?
+      title
+    else
+      str = chapter_header
+      str += ": #{title}" if title.present?
+      str
     end
-    str
   end
 
   def display_title
-    self.position.to_s + '. ' + self.chapter_title
+    if work.hide_chapter_numbering
+      title.presence || chapter_header
+    else
+      "#{position}. #{chapter_title}"
+    end
   end
 
   def abbreviated_display_title

--- a/app/views/chapters/_chapter.html.erb
+++ b/app/views/chapters/_chapter.html.erb
@@ -22,7 +22,11 @@
 
   <div class="chapter<%= ' preface' unless @preview_mode %> group">
     <h3 class="title">
-      <%= link_to chapter.chapter_header, [chapter.work, chapter] %><% unless chapter.title.blank? %>: <%= chapter.title.html_safe %><% end %>
+      <% if chapter.work.hide_chapter_numbering && chapter.title.present? %>
+        <%= link_to chapter.title.html_safe, [chapter.work, chapter] %>
+      <% else %>
+        <%= link_to chapter.chapter_header, [chapter.work, chapter] %><% unless chapter.title.blank? %>: <%= chapter.title.html_safe %><% end %>
+      <% end %>
     </h3>
 
     <!-- only display byline if different from the main byline -->

--- a/app/views/downloads/_download_chapter.html.erb
+++ b/app/views/downloads/_download_chapter.html.erb
@@ -2,13 +2,12 @@
 
 <div class="meta group">
   <h2 class="heading">
-    <% if @chapter.title.present? %>
-      <%= t(".full_chapter_title_with_title",
-            chapter_number: @chapter.position,
-            title: @chapter.title) %>
+    <% if @work.hide_chapter_numbering && @chapter.title.present? %>
+      <%= @chapter.title %>
+    <% elsif @chapter.title.present? %>
+      <%= t(".full_chapter_title_with_title", chapter_number: @chapter.position, title: @chapter.title) %>
     <% else %>
-      <%= t(".full_chapter_title_without_title",
-            chapter_number: @chapter.position) %>
+      <%= t(".full_chapter_title_without_title", chapter_number: @chapter.position) %>
     <% end %>
   </h2>
   <% if (!@chapter.pseuds.blank? && (@chapter.pseuds != @work.pseuds) && (!@work.anonymous?)) %>

--- a/app/views/works/_standard_form.html.erb
+++ b/app/views/works/_standard_form.html.erb
@@ -220,6 +220,13 @@
           </fieldset>
         </dd>
 
+        <dt class="hide-chapter-numbering">
+          <%= f.check_box :hide_chapter_numbering %>
+        </dt>
+        <dd class="hide-chapter-numbering">
+          <%= f.label :hide_chapter_numbering, t("works.permissions.hide_chapter_numbering") %>
+        </dd>
+
         <!--backdate-->
         <dt class="backdate">
           <%= f.check_box :backdate, { id: "backdate-options-show", class: "toggle_formfield" } %>

--- a/app/views/works/navigate.html.erb
+++ b/app/views/works/navigate.html.erb
@@ -5,4 +5,3 @@
   <li><%= link_to chapter.display_title.html_safe, [chapter.work, chapter] %> <span class="datetime">(<%= chapter.published_at.to_date %>)</span></li>
 <% end %>
 </ol>
-

--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -3335,6 +3335,7 @@ en:
       post_notice_html: All works you post on AO3 must comply with our %{content_policy_link}. For more information, please refer to our %{tos_faq_link}.
       tos_faq: Terms of Service FAQ
     permissions:
+      hide_chapter_numbering: Hide chapter numbers (show only chapter titles)
       privacy: Privacy
       visibility:
         import_works_restricted: Only show imported works to registered users

--- a/db/migrate/20260423000000_add_hide_chapter_numbering_to_works.rb
+++ b/db/migrate/20260423000000_add_hide_chapter_numbering_to_works.rb
@@ -1,0 +1,7 @@
+class AddHideChapterNumberingToWorks < ActiveRecord::Migration[7.0]
+  uses_departure! if Rails.env.staging? || Rails.env.production?
+
+  def change
+    add_column :works, :hide_chapter_numbering, :boolean, default: false, null: false
+  end
+end

--- a/features/works/work_view.feature
+++ b/features/works/work_view.feature
@@ -81,6 +81,28 @@ Feature: View a work with various options
   Then I should see "Chapter 1: "
     And I should see "cool chapter title"
 
+  Scenario: chapter title displays without "Chapter N:" prefix when hide chapter numbering is enabled
+  Given I am logged in as a random user
+    And I set my preferences to View Full Work mode by default
+  When I set up the draft "PrologueWork"
+    And I check "This work has multiple chapters"
+    And I fill in "Chapter Title" with "Prologue: The Beginning"
+    And I fill in "Chapter 1 of" with "?"
+    And I check "Hide chapter numbers (show only chapter titles)"
+    And I press "Post"
+  Then I should see "Prologue: The Beginning"
+    And I should not see "Chapter 1: Prologue: The Beginning"
+
+  Scenario: chapter title falls back to "Chapter N" when hide chapter numbering is enabled but no title is set
+  Given I am logged in as a random user
+    And I set my preferences to View Full Work mode by default
+  When I set up the draft "NoTitleWork"
+    And I check "This work has multiple chapters"
+    And I fill in "Chapter 1 of" with "?"
+    And I check "Hide chapter numbers (show only chapter titles)"
+    And I press "Post"
+  Then I should see "Chapter 1"
+
   Scenario: Works and chapters include the navigation, meta, work skin CSS, and
   preface, except in preview mode, which contains more limited information.
     Given the work skin "Flair" by "carbon"

--- a/spec/helpers/mailer_helper_spec.rb
+++ b/spec/helpers/mailer_helper_spec.rb
@@ -38,6 +38,20 @@ describe MailerHelper do
       end
     end
 
+    context "when the creation is a chapter and hide_chapter_numbering is enabled" do
+      let(:work_hidden) { create(:work, hide_chapter_numbering: true) }
+
+      it "returns hyperlinked chapter title without chapter number and parenthetical word count" do
+        chapter = create(:chapter, title: "My Title", work: work_hidden)
+        expect(creation_link_with_word_count(chapter, chapter_url(chapter))).to eq("<i><b><a style=\"color:#990000\" href=\"#{chapter_url(chapter)}\">My Title</a></b></i> (#{chapter.word_count} words)")
+      end
+
+      it "falls back to 'Chapter N' when the chapter has no title" do
+        chapter = create(:chapter, title: "", work: work_hidden)
+        expect(creation_link_with_word_count(chapter, chapter_url(chapter))).to eq("<i><b><a style=\"color:#990000\" href=\"#{chapter_url(chapter)}\">Chapter #{chapter.position}</a></b></i> (#{chapter.word_count} words)")
+      end
+    end
+
     context "when the creation is a series" do
       it "returns hyperlinked series title and parenthetical word count" do
         expect(creation_link_with_word_count(series, series_url(series))).to eq("<i><b><a style=\"color:#990000\" href=\"#{series_url(series)}\">#{series.title}</a></b></i> (#{series.word_count} words)")

--- a/spec/models/chapter_spec.rb
+++ b/spec/models/chapter_spec.rb
@@ -27,6 +27,63 @@ describe Chapter do
     end
   end
 
+  describe "title display methods" do
+    let(:work) { create(:work) }
+    let(:work_hidden) { create(:work, hide_chapter_numbering: true) }
+
+    describe "#full_chapter_title" do
+      context "when hide_chapter_numbering is false" do
+        it "returns 'Chapter N' when the chapter has no title" do
+          chapter = create(:chapter, work: work, title: "")
+          expect(chapter.full_chapter_title).to eq("Chapter #{chapter.position}")
+        end
+
+        it "returns 'Chapter N: Title' when the chapter has a title" do
+          chapter = create(:chapter, work: work, title: "My Title")
+          expect(chapter.full_chapter_title).to eq("Chapter #{chapter.position}: My Title")
+        end
+      end
+
+      context "when hide_chapter_numbering is true" do
+        it "falls back to 'Chapter N' when the chapter has no title" do
+          chapter = create(:chapter, work: work_hidden, title: "")
+          expect(chapter.full_chapter_title).to eq("Chapter #{chapter.position}")
+        end
+
+        it "returns just the title when the chapter has a title" do
+          chapter = create(:chapter, work: work_hidden, title: "My Title")
+          expect(chapter.full_chapter_title).to eq("My Title")
+        end
+      end
+    end
+
+    describe "#display_title" do
+      context "when hide_chapter_numbering is false" do
+        it "returns 'N. Chapter N' when the chapter has no title" do
+          chapter = create(:chapter, work: work, title: "")
+          expect(chapter.display_title).to eq("#{chapter.position}. Chapter #{chapter.position}")
+        end
+
+        it "returns 'N. Title' when the chapter has a title" do
+          chapter = create(:chapter, work: work, title: "My Title")
+          expect(chapter.display_title).to eq("#{chapter.position}. My Title")
+        end
+      end
+
+      context "when hide_chapter_numbering is true" do
+        it "falls back to 'Chapter N' when the chapter has no title" do
+          chapter = create(:chapter, work: work_hidden, title: "")
+          expect(chapter.display_title).to eq("Chapter #{chapter.position}")
+        end
+
+        it "returns just the title when the chapter has a title" do
+          chapter = create(:chapter, work: work_hidden, title: "My Title")
+          expect(chapter.display_title).to eq("My Title")
+        end
+      end
+    end
+  end
+
   describe "co-creator permissions" do
     let(:creator) { create(:user) }
     let(:co_creator) { create(:user) }


### PR DESCRIPTION
# Pull Request Checklist

<!-- Mark steps in the checklist as complete by changing `[ ]` to `[X]` -->
* [X] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [X] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [X] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [X] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [X] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-951

## Purpose

Lets authors hide chapter numbers from display, allowing for front-matter and interstitial non-chapter content (notes, interludes, etc) that don't lead to spurious chapter numbers being displayed.

## Testing Instructions

My local testing involved creating a new work with the option turned on, then posting two chapters. I checked the Chapter Index dropdown, the full page navigation menu, and chapter titles. Didn't test subscription e-mails.

## Credit

selberhad he/him