### PR TITLE
AO3-5696 Disable orphan account user subscription emails

### DIFF
--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -46,6 +46,7 @@ class Subscription < ApplicationRecord
   # Emails should never contain hidden works or chapters of hidden works.
   # Emails should never contain orphaned works or chapters.
   # TODO: AO3-3620 & AO3-5696: Allow subscriptions to orphan_account to receive notifications.
+  #   When fixed, remove the two orphan_account checks below (lines with User.orphan_account).
   # Emails for user subs should never contain anon works or chapters.
   # Emails for work subs should never contain anything but chapters.
   # TODO: AO3-1250: Anon series subscription improvements
@@ -55,6 +56,7 @@ class Subscription < ApplicationRecord
     return false if creation.is_a?(Chapter) && !creation.work.try(:posted)
     return false if creation.try(:hidden_by_admin) || (creation.is_a?(Chapter) && creation.work.try(:hidden_by_admin))
     return false if creation.pseuds.any? { |p| p.user == User.orphan_account }
+    return false if subscribable_type == "User" && subscribable == User.orphan_account
     return false if subscribable_type == "User" && creation.anonymous?
     return false if subscribable_type == "Work" && !creation.is_a?(Chapter)
 

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -45,8 +45,6 @@ class Subscription < ApplicationRecord
   # Emails should never contain chapters of draft works.
   # Emails should never contain hidden works or chapters of hidden works.
   # Emails should never contain orphaned works or chapters.
-  # TODO: AO3-3620 & AO3-5696: Allow subscriptions to orphan_account to receive notifications.
-  #   When fixed, remove the two orphan_account checks below (lines with User.orphan_account).
   # Emails for user subs should never contain anon works or chapters.
   # Emails for work subs should never contain anything but chapters.
   # TODO: AO3-1250: Anon series subscription improvements

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -156,6 +156,14 @@ describe Subscription do
         expect(subscription.valid_notification_entry?(create(:chapter, authors: [orphan_pseud]))).to be_falsey
       end
 
+      it "returns false when subscribed to orphan_account and the chapter's work is co-created by orphan_account" do
+        other_pseud = create(:pseud)
+        orphan_work = create(:work, authors: [other_pseud, orphan_pseud])
+        chapter = create(:chapter, work: orphan_work, authors: [other_pseud])
+        orphan_subscription = build(:subscription, subscribable: orphan_pseud.user)
+        expect(orphan_subscription.valid_notification_entry?(chapter)).to be_falsey
+      end
+
       it "returns false when the chapter is on a hidden work" do
         expect(subscription.valid_notification_entry?(build(:chapter, work: build(:work, hidden_by_admin: true)))).to be_falsey
       end
@@ -213,6 +221,14 @@ describe Subscription do
 
       it "returns true for a non-anonymous chapter" do
         expect(subscription.valid_notification_entry?(chapter)).to be_truthy
+      end
+
+      it "returns true for a chapter on a work co-created with orphan_account" do
+        other_pseud = create(:pseud)
+        orphan_work = create(:work, authors: [other_pseud, orphan_pseud])
+        chapter = create(:chapter, work: orphan_work, authors: [other_pseud])
+        user_subscription = build(:subscription, subscribable: other_pseud.user)
+        expect(user_subscription.valid_notification_entry?(chapter)).to be_truthy
       end
 
       it "returns false for an anonymous work" do

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -132,7 +132,6 @@ describe Subscription do
         expect(subscription.valid_notification_entry?(draft)).to be_falsey
       end
 
-      # TODO: AO3-3620 & AO3-5696: Allow subscriptions to orphan_account to receive notifications
       it "returns false when the creation is by orphan_account" do
         expect(subscription.valid_notification_entry?(create(:work, authors: [orphan_pseud]))).to be_falsey
       end
@@ -151,7 +150,6 @@ describe Subscription do
         expect(subscription.valid_notification_entry?(build(:chapter, work: draft))).to be_falsey
       end
 
-      # TODO: AO3-3620 & AO3-5696: Allow subscriptions to orphan_account to receive notifications
       it "returns false when the creation is by orphan_account" do
         expect(subscription.valid_notification_entry?(create(:chapter, authors: [orphan_pseud]))).to be_falsey
       end
@@ -223,7 +221,7 @@ describe Subscription do
         expect(subscription.valid_notification_entry?(chapter)).to be_truthy
       end
 
-      it "returns true for a chapter on a work co-created with orphan_account" do
+      it "returns true for a chapter by only the user, on a work co-created with orphan_account" do
         other_pseud = create(:pseud)
         orphan_work = create(:work, authors: [other_pseud, orphan_pseud])
         chapter = create(:chapter, work: orphan_work, authors: [other_pseud])


### PR DESCRIPTION
* [X] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [X] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [X] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [X] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [X] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-5696

## Purpose

When `orphan_account` is a co-creator on a multi-chapter work and another co-creator posts a new chapter without listing `orphan_account`, users subscribed to `orphan_account` incorrectly receive subscription emails.

The existing check in `Subscription#valid_notification_entry?` only inspects the creation's (chapter's) pseuds, missing the case where `orphan_account` is a co-creator at the work level but not on the individual chapter.

Added a guard that skips notifications when the subscription is to `orphan_account` directly. Subscribers of other co-creators on the same work are not affected.

## Testing Instructions

1. Subscribe to `orphan_account`
2. Create a work with `orphan_account` as co-creator
3. Post a new chapter without adding `orphan_account` as chapter co-creator
4. Run `bundle exec rake notifications:deliver_subscriptions`
5. Verify no subscription email is sent to the subscriber of `orphan_account`
6. Verify that subscribers of the other co-creator still receive emails

## References

Related to AO3-3620 (Allow subscriptions to orphan_account to receive notifications). When AO3-3620 is fixed, the two
`User.orphan_account` guards in `valid_notification_entry?` should be removed.

## Credit

Pablo Monfort (he/him)