### PR TITLE
AO3-7376 Redirect to user psueds page when deleting an already deleted pseud

### DIFF
--- a/app/controllers/pseuds_controller.rb
+++ b/app/controllers/pseuds_controller.rb
@@ -122,7 +122,9 @@ class PseudsController < ApplicationController
     end
 
     @pseud = @user.pseuds.find_by(name: params[:id])
-    if @pseud.is_default
+    if @pseud.nil?
+      flash[:error] = t(".cannot_delete_nonexisting")
+    elsif @pseud.is_default
       flash[:error] = t(".cannot_delete_default")
     elsif @pseud.name == @user.login
       flash[:error] = t(".cannot_delete_matching_username")

--- a/config/locales/controllers/en.yml
+++ b/config/locales/controllers/en.yml
@@ -280,6 +280,7 @@ en:
     destroy:
       cannot_delete_default: You cannot delete your default pseudonym, sorry!
       cannot_delete_matching_username: You cannot delete the pseud matching your username, sorry!
+      cannot_delete_nonexisting: What pseud did you want to delete?
       not_deleted: The pseud was not deleted.
       successfully_deleted: The pseud was successfully deleted.
     update:

--- a/spec/controllers/pseuds_controller_spec.rb
+++ b/spec/controllers/pseuds_controller_spec.rb
@@ -247,6 +247,13 @@ describe PseudsController do
           it_redirects_to_with_error(user_pseuds_path(user), "You cannot delete the pseud matching your username, sorry!")
         end
       end
+
+      context "when deleting a pseud that does not exist" do
+        it "errors and redirects to user_pseuds_path" do
+          post :destroy, params: { user_id: user, id: "nonexistent_pseud" }
+          it_redirects_to_with_error(user_pseuds_path(user), "What pseud did you want to delete?")
+        end
+      end
     end
   end
 


### PR DESCRIPTION
# Pull Request Checklist

<!-- Mark steps in the checklist as complete by changing `[ ]` to `[X]` -->
* [X] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [X] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [X] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [X] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [X] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-7376

## Purpose

Redirects to the user pseuds page with flash error “What pseud did you want to delete?” when trying to delete a pseud that has already been deleted.

## Credit

zrei (she/they)