### PR TITLE
AO3-6395 Log Admin Banner Actions to Activities

### DIFF
--- a/app/controllers/admin/banners_controller.rb
+++ b/app/controllers/admin/banners_controller.rb
@@ -37,6 +37,8 @@ class Admin::BannersController < Admin::BaseController
     else
       render action: 'new'
     end
+
+    AdminActivity.log_action(current_admin, @admin_banner, action: "create_admin_banner", summary: "Content: #{@admin_banner.content}, Type: #{@admin_banner.banner_type.blank? ? "Default" : @admin_banner.banner_type}, Active: #{@admin_banner.active?}")
   end
 
   # PUT /admin/banners/1
@@ -57,6 +59,8 @@ class Admin::BannersController < Admin::BaseController
       end
       redirect_to @admin_banner
     end
+
+    AdminActivity.log_action(current_admin, @admin_banner, action: "update_admin_banner", summary: "Content: #{@admin_banner.content}, Type: #{@admin_banner.banner_type.blank? ? "Default" : @admin_banner.banner_type}, Active: #{@admin_banner.active?}")
   end
 
   # GET /admin/banners/1/confirm_delete
@@ -79,6 +83,8 @@ class Admin::BannersController < Admin::BaseController
       flash[:notice] = t(".success")
       redirect_to admin_banners_path
     end
+
+    AdminActivity.log_action(current_admin, @admin_banner, action: "destroy_admin_banner", summary: "Content: #{@admin_banner.content}, Type: #{@admin_banner.banner_type.blank? ? "Default" : @admin_banner.banner_type}")
   end
 
   private

--- a/app/controllers/admin/banners_controller.rb
+++ b/app/controllers/admin/banners_controller.rb
@@ -38,7 +38,7 @@ class Admin::BannersController < Admin::BaseController
       render action: 'new'
     end
 
-    AdminActivity.log_action(current_admin, @admin_banner, action: "create_admin_banner", summary: "Content: #{@admin_banner.content}, Type: #{@admin_banner.banner_type.blank? ? "Default" : @admin_banner.banner_type}, Active: #{@admin_banner.active?}")
+    AdminActivity.log_action(current_admin, @admin_banner, action: "create_admin_banner", summary: "Content: #{@admin_banner.content}, Type: #{@admin_banner.banner_type.presence || 'Default'}, Active: #{@admin_banner.active?}")
   end
 
   # PUT /admin/banners/1
@@ -60,7 +60,7 @@ class Admin::BannersController < Admin::BaseController
       redirect_to @admin_banner
     end
 
-    AdminActivity.log_action(current_admin, @admin_banner, action: "update_admin_banner", summary: "Content: #{@admin_banner.content}, Type: #{@admin_banner.banner_type.blank? ? "Default" : @admin_banner.banner_type}, Active: #{@admin_banner.active?}")
+    AdminActivity.log_action(current_admin, @admin_banner, action: "update_admin_banner", summary: "Content: #{@admin_banner.content}, Type: #{@admin_banner.banner_type.presence || 'Default'}, Active: #{@admin_banner.active?}")
   end
 
   # GET /admin/banners/1/confirm_delete
@@ -84,7 +84,7 @@ class Admin::BannersController < Admin::BaseController
       redirect_to admin_banners_path
     end
 
-    AdminActivity.log_action(current_admin, @admin_banner, action: "destroy_admin_banner", summary: "Content: #{@admin_banner.content}, Type: #{@admin_banner.banner_type.blank? ? "Default" : @admin_banner.banner_type}")
+    AdminActivity.log_action(current_admin, @admin_banner, action: "destroy_admin_banner", summary: "Content: #{@admin_banner.content}, Type: #{@admin_banner.banner_type.presence || 'Default'}")
   end
 
   private

--- a/app/controllers/admin/banners_controller.rb
+++ b/app/controllers/admin/banners_controller.rb
@@ -56,7 +56,7 @@ class Admin::BannersController < Admin::BaseController
       AdminActivity.log_action(current_admin, @admin_banner, action: "update admin banner", summary: "Content: #{@admin_banner.content}, Type: #{@admin_banner.banner_type.presence || 'Default'}, Active: #{@admin_banner.active?}")
       redirect_to @admin_banner
     else
-      render action: 'edit'
+      render action: "edit"
     end
   end
 

--- a/app/controllers/admin/banners_controller.rb
+++ b/app/controllers/admin/banners_controller.rb
@@ -44,19 +44,19 @@ class Admin::BannersController < Admin::BaseController
   def update
     @admin_banner = authorize AdminBanner.find(params[:id])
 
-    if !@admin_banner.update(admin_banner_params)
-      render action: 'edit'
-    else
+    if @admin_banner.update(admin_banner_params)
       if params[:admin_banner_minor_edit]
         flash[:notice] = t(".minor_edit")
       elsif @admin_banner.active?
-          AdminBanner.banner_on
-          flash[:notice] = t(".banner_on")
+        AdminBanner.banner_on
+        flash[:notice] = t(".banner_on")
       else
         flash[:notice] = t(".success")
       end
       AdminActivity.log_action(current_admin, @admin_banner, action: "update admin banner", summary: "Content: #{@admin_banner.content}, Type: #{@admin_banner.banner_type.presence || 'Default'}, Active: #{@admin_banner.active?}")
       redirect_to @admin_banner
+    else
+      render action: 'edit'
     end
   end
 

--- a/app/controllers/admin/banners_controller.rb
+++ b/app/controllers/admin/banners_controller.rb
@@ -33,12 +33,11 @@ class Admin::BannersController < Admin::BaseController
       else
         flash[:notice] = t(".success")
       end
+      AdminActivity.log_action(current_admin, @admin_banner, action: "create admin banner", summary: "Content: #{@admin_banner.content}, Type: #{@admin_banner.banner_type.presence || 'Default'}, Active: #{@admin_banner.active?}")
       redirect_to @admin_banner
     else
       render action: 'new'
     end
-
-    AdminActivity.log_action(current_admin, @admin_banner, action: "create_admin_banner", summary: "Content: #{@admin_banner.content}, Type: #{@admin_banner.banner_type.presence || 'Default'}, Active: #{@admin_banner.active?}")
   end
 
   # PUT /admin/banners/1
@@ -49,6 +48,7 @@ class Admin::BannersController < Admin::BaseController
       render action: 'edit'
     elsif params[:admin_banner_minor_edit]
       flash[:notice] = t(".minor_edit")
+      AdminActivity.log_action(current_admin, @admin_banner, action: "update admin banner", summary: "Content: #{@admin_banner.content}, Type: #{@admin_banner.banner_type.presence || 'Default'}, Active: #{@admin_banner.active?}")
       redirect_to @admin_banner
     else
       if @admin_banner.active?
@@ -57,10 +57,9 @@ class Admin::BannersController < Admin::BaseController
       else
         flash[:notice] = t(".success")
       end
+      AdminActivity.log_action(current_admin, @admin_banner, action: "update admin banner", summary: "Content: #{@admin_banner.content}, Type: #{@admin_banner.banner_type.presence || 'Default'}, Active: #{@admin_banner.active?}")
       redirect_to @admin_banner
     end
-
-    AdminActivity.log_action(current_admin, @admin_banner, action: "update_admin_banner", summary: "Content: #{@admin_banner.content}, Type: #{@admin_banner.banner_type.presence || 'Default'}, Active: #{@admin_banner.active?}")
   end
 
   # GET /admin/banners/1/confirm_delete
@@ -81,10 +80,9 @@ class Admin::BannersController < Admin::BaseController
     else
       @admin_banner.destroy
       flash[:notice] = t(".success")
+      AdminActivity.log_action(current_admin, @admin_banner, action: "destroy admin banner", summary: "Content: #{@admin_banner.content}, Type: #{@admin_banner.banner_type.presence || 'Default'}")
       redirect_to admin_banners_path
     end
-
-    AdminActivity.log_action(current_admin, @admin_banner, action: "destroy_admin_banner", summary: "Content: #{@admin_banner.content}, Type: #{@admin_banner.banner_type.presence || 'Default'}")
   end
 
   private

--- a/app/controllers/admin/banners_controller.rb
+++ b/app/controllers/admin/banners_controller.rb
@@ -46,14 +46,12 @@ class Admin::BannersController < Admin::BaseController
 
     if !@admin_banner.update(admin_banner_params)
       render action: 'edit'
-    elsif params[:admin_banner_minor_edit]
-      flash[:notice] = t(".minor_edit")
-      AdminActivity.log_action(current_admin, @admin_banner, action: "update admin banner", summary: "Content: #{@admin_banner.content}, Type: #{@admin_banner.banner_type.presence || 'Default'}, Active: #{@admin_banner.active?}")
-      redirect_to @admin_banner
     else
-      if @admin_banner.active?
-        AdminBanner.banner_on
-        flash[:notice] = t(".banner_on")
+      if params[:admin_banner_minor_edit]
+        flash[:notice] = t(".minor_edit")
+      elsif @admin_banner.active?
+          AdminBanner.banner_on
+          flash[:notice] = t(".banner_on")
       else
         flash[:notice] = t(".success")
       end

--- a/spec/controllers/admin/banners_controller_spec.rb
+++ b/spec/controllers/admin/banners_controller_spec.rb
@@ -4,6 +4,7 @@ describe Admin::BannersController do
   include LoginMacros
   include RedirectExpectationHelper
 
+  let(:admin) { create(:admin, roles: ["superadmin"]) }
   let(:admin_banner) { create(:admin_banner) }
   let(:admin_banner_params) { attributes_for(:admin_banner) }
 
@@ -82,6 +83,17 @@ describe Admin::BannersController do
       it_redirects_to_with_notice(assigns[:admin_banner], "Banner successfully created.")
     end
 
+    it "creates admin activity" do
+      fake_login_admin(admin)
+      expect {subject}
+        .to change { AdminActivity.count }
+        .by(1)
+      expect(AdminActivity.last.target).to eq(assigns(:admin_banner))
+      expect(AdminActivity.last.action).to eq("create_admin_banner")
+      expect(AdminActivity.last.admin).to eq(admin)
+      expect(AdminActivity.last.summary).to include(admin_banner_params[:content])
+    end
+
     it_behaves_like "only authorized admins are allowed",
                     authorized_roles: %w[superadmin board board_assistants_team communications support]
   end
@@ -103,6 +115,17 @@ describe Admin::BannersController do
     let(:success) do
       expect { admin_banner.reload }.to change { admin_banner.content }
       it_redirects_to_with_notice(admin_banner, "Banner successfully updated.")
+    end
+
+    it "creates admin activity" do
+      fake_login_admin(admin)
+      expect {subject}
+        .to change { AdminActivity.count }
+        .by(1)
+      expect(AdminActivity.last.target).to eq(assigns(:admin_banner))
+      expect(AdminActivity.last.action).to eq("update_admin_banner")
+      expect(AdminActivity.last.admin).to eq(admin)
+      expect(AdminActivity.last.summary).to include(admin_banner_params[:content])
     end
 
     it_behaves_like "only authorized admins are allowed",
@@ -128,11 +151,23 @@ describe Admin::BannersController do
   end
 
   describe "DELETE #destroy" do
+    let!(:admin_banner) { create(:admin_banner) }
     subject { delete :destroy, params: { id: admin_banner } }
 
     let(:success) do
       expect { admin_banner.reload }.to raise_exception(ActiveRecord::RecordNotFound)
       it_redirects_to_with_notice(admin_banners_path, "Banner successfully deleted.")
+    end
+
+    it "creates admin activity" do
+      fake_login_admin(admin)
+      expect {subject}
+        .to change { AdminActivity.count }
+        .by(1)
+      expect(AdminActivity.last.target).to eq(nil)
+      expect(AdminActivity.last.action).to eq("destroy_admin_banner")
+      expect(AdminActivity.last.admin).to eq(admin)
+      expect(AdminActivity.last.summary).to include(admin_banner.content)
     end
 
     it_behaves_like "only authorized admins are allowed",

--- a/spec/controllers/admin/banners_controller_spec.rb
+++ b/spec/controllers/admin/banners_controller_spec.rb
@@ -85,7 +85,7 @@ describe Admin::BannersController do
 
     it "creates admin activity" do
       fake_login_admin(admin)
-      expect {subject}
+      expect { subject }
         .to change { AdminActivity.count }
         .by(1)
       expect(AdminActivity.last.target).to eq(assigns(:admin_banner))
@@ -119,7 +119,7 @@ describe Admin::BannersController do
 
     it "creates admin activity" do
       fake_login_admin(admin)
-      expect {subject}
+      expect { subject }
         .to change { AdminActivity.count }
         .by(1)
       expect(AdminActivity.last.target).to eq(assigns(:admin_banner))
@@ -161,7 +161,7 @@ describe Admin::BannersController do
 
     it "creates admin activity" do
       fake_login_admin(admin)
-      expect {subject}
+      expect { subject }
         .to change { AdminActivity.count }
         .by(1)
       expect(AdminActivity.last.target).to eq(nil)

--- a/spec/controllers/admin/banners_controller_spec.rb
+++ b/spec/controllers/admin/banners_controller_spec.rb
@@ -89,7 +89,7 @@ describe Admin::BannersController do
         .to change { AdminActivity.count }
         .by(1)
       expect(AdminActivity.last.target).to eq(assigns(:admin_banner))
-      expect(AdminActivity.last.action).to eq("create_admin_banner")
+      expect(AdminActivity.last.action).to eq("create admin banner")
       expect(AdminActivity.last.admin).to eq(admin)
       expect(AdminActivity.last.summary).to include(admin_banner_params[:content])
     end
@@ -123,7 +123,7 @@ describe Admin::BannersController do
         .to change { AdminActivity.count }
         .by(1)
       expect(AdminActivity.last.target).to eq(assigns(:admin_banner))
-      expect(AdminActivity.last.action).to eq("update_admin_banner")
+      expect(AdminActivity.last.action).to eq("update admin banner")
       expect(AdminActivity.last.admin).to eq(admin)
       expect(AdminActivity.last.summary).to include(admin_banner_params[:content])
     end
@@ -165,7 +165,7 @@ describe Admin::BannersController do
         .to change { AdminActivity.count }
         .by(1)
       expect(AdminActivity.last.target).to eq(nil)
-      expect(AdminActivity.last.action).to eq("destroy_admin_banner")
+      expect(AdminActivity.last.action).to eq("destroy admin banner")
       expect(AdminActivity.last.admin).to eq(admin)
       expect(AdminActivity.last.summary).to include(admin_banner.content)
     end


### PR DESCRIPTION
# Pull Request Checklist

<!-- Mark steps in the checklist as complete by changing `[ ]` to `[X]` -->
* [x] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [x] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [x] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [x] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-6395

## Purpose

When an admin creates, updates, or deletes an admin banner, the action will be logged as an admin activity. The date, admin name, action, and target, and banner text is recorded.

## Credit

caitlin (she/her)
