### PR TITLE
AO3-7415 Exclude parent-only skins from user preferences dropdown

### DIFF
--- a/app/controllers/preferences_controller.rb
+++ b/app/controllers/preferences_controller.rb
@@ -8,18 +8,23 @@ class PreferencesController < ApplicationController
     @check_ownership_of = @user
   end
 
+  def available_skins
+    (@user.skins.site_skins.usable +
+    Skin.approved_skins.site_skins.usable).uniq
+  end
+
   def index
     @page_subtitle = t(".page_title", username: @user.login)
     @preference = @user.preference
     authorize @preference if logged_in_as_admin?
-    @available_skins = (@user.skins.site_skins + Skin.approved_skins.site_skins).uniq
+    @available_skins = available_skins
     @available_locales = Locale.where(email_enabled: true)
   end
 
   def update
     @preference = @user.preference
     authorize @preference if logged_in_as_admin?
-    @available_skins = (@user.skins.site_skins + Skin.approved_skins.site_skins).uniq
+    @available_skins = available_skins
     @available_locales = Locale.where(email_enabled: true)
 
     @user.preference.attributes = preference_params

--- a/app/controllers/preferences_controller.rb
+++ b/app/controllers/preferences_controller.rb
@@ -8,11 +8,6 @@ class PreferencesController < ApplicationController
     @check_ownership_of = @user
   end
 
-  def available_skins
-    (@user.skins.site_skins.usable +
-    Skin.approved_skins.site_skins.usable).uniq
-  end
-
   def index
     @page_subtitle = t(".page_title", username: @user.login)
     @preference = @user.preference
@@ -44,6 +39,11 @@ class PreferencesController < ApplicationController
   end
 
   private
+
+  def available_skins
+    (@user.skins.site_skins.usable +
+    Skin.approved_skins.site_skins.usable).uniq
+  end
 
   def preference_params
     params.require(:preference).permit(

--- a/spec/controllers/preferences_controller_spec.rb
+++ b/spec/controllers/preferences_controller_spec.rb
@@ -25,6 +25,16 @@ describe PreferencesController do
 
         it_redirects_to_with_error(user_path(other_user), "Sorry, you don't have permission to access the page you were trying to reach.")
       end
+
+      it "does not include parent-only skins in available site skins" do
+        usable_skin = create(:skin, author: user, unusable: false)
+        parent_only_skin = create(:skin, author: user, unusable: true)
+
+        get :index, params: { user_id: user.login }
+
+        expect(assigns(:available_skins)).to include(usable_skin)
+        expect(assigns(:available_skins)).not_to include(parent_only_skin)
+      end
     end
 
     context "as a guest" do


### PR DESCRIPTION
# Pull Request Checklist

* [X] Have you read "How to write the perfect pull request"?
* [X] Have you read the contributing guidelines?
* [X] Have you added tests for any changed functionality?
* [X] Have you added the Jira issue number as the first thing in your pull request title?
* [X] Do you have fewer than 5 pull requests already open?

## Issue

https://otwarchive.atlassian.net/browse/AO3-7415

## Purpose

Fixes an issue where parent-only site skins (including default archive components like "(1) core") appear in the "Your site skin" dropdown in user preferences, when they should not be user selectable.  

This change updates the available skins query in PreferencesController to only include skins that are `.usable`, which excludes parent-only skins (those marked as `unusable`).

## Testing Instructions

1. Log in as a user
2. Create a new site skin
3. In Advanced options, enable the "Parent only" condition
4. Save the skin
5. Go to Preferences → "Your site skin" dropdown

**Before fix:**  
- Parent-only skin appears in the dropdown  
- Default parent-only components (e.g. "(1) core") also appear  

**After fix:**  
- Parent-only skins are not included in the dropdown  
- Only usable (selectable) site skins are listed  

## References

N/A

## Credit

Please credit as: cayugalyn (they/them)