### PR TITLE
AO3-7179 Collection participant messages should list both pseud and username

### DIFF
--- a/app/controllers/collection_participants_controller.rb
+++ b/app/controllers/collection_participants_controller.rb
@@ -73,16 +73,16 @@ class CollectionParticipantsController < ApplicationController
 
   def update
     if @participant.update(collection_participant_params)
-      flash[:notice] = t('collection_participants.update_success', default: "Updated %{participant}.", participant: @participant.pseud.name)
+      flash[:notice] = t(".success", participant: @participant.pseud.byline)
     else
-      flash[:error] = t(".failure", participant: @participant.pseud.name)
+      flash[:error] = t(".failure", participant: @participant.pseud.byline)
     end
     redirect_to collection_participants_path(@collection)
   end
 
   def destroy
     @participant.destroy
-    flash[:notice] = t('collection_participants.destroy', default: "Removed %{participant} from collection.", participant: @participant.pseud.name)
+    flash[:notice] = t(".success", participant: @participant.pseud.byline)
     redirect_back_or_to root_path
   end
 

--- a/app/views/collection_participants/_participant_form.html.erb
+++ b/app/views/collection_participants/_participant_form.html.erb
@@ -10,9 +10,8 @@
       <li><%= form.submit ts("Update"), id: participant.pseud.user.login + "_submit" %></li>
   <% end %>
       <li><%= button_to ts("Remove"), collection_participant_path(@collection, participant),
-                        data: { confirm: ts('Are you certain you want to remove %{participant}?',
-                                            participant: participant.pseud.name) },
-                        method: :delete %>
+                data: { confirm: t(".remove.confirm", participant: participant.pseud.byline) },
+                method: :delete %>
       </li>
   </ul>
 </li>

--- a/config/locales/controllers/en.yml
+++ b/config/locales/controllers/en.yml
@@ -128,8 +128,11 @@ en:
       invited: invited
       invited_to_collections_html: This work has been %{invited_link} to your collection (%{collection_title}).
   collection_participants:
+    destroy:
+      success: Removed %{participant} from collection.
     update:
       failure: Couldn't update %{participant}.
+      success: Updated %{participant}.
     validation:
       owners_required: You can't remove the only owner!
   collection_profile:

--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -761,6 +761,10 @@ en:
         notice:
           unreviewed_by_collection: Works and bookmarks listed here have been added to a collection but need approval from a collection moderator before they are listed in the collection.
         page_heading: Items by %{username} in Collections
+  collection_participants:
+    participant_form:
+      remove:
+        confirm: Are you sure you want to remove %{participant}?
   collection_profile:
     show:
       meta:

--- a/features/collections/collection_participants.feature
+++ b/features/collections/collection_participants.feature
@@ -38,7 +38,7 @@
     And I press "Submit"
   Then I should see "New members invited: moderator_pseud (moderator)"
   When I give "moderator_pseud (moderator)" the "Owner" role in the collection "Such a nice collection"
-  Then I should see "Updated moderator_pseud."
+  Then I should see "Updated moderator_pseud (moderator)."
     And "moderator_pseud (moderator)" should have the "Owner" role in the collection "Such a nice collection"
   When the dashboard counts have expired
     And I follow "My Dashboard"

--- a/features/other_a/pseud_delete.feature
+++ b/features/other_a/pseud_delete.feature
@@ -192,7 +192,7 @@ Feature: Delete pseud.
     Then I should see "New members invited: other_pseud (myself)"
     When I select "Moderator" from "myself_role"
       And I submit with the 4th button
-    Then I should see "Updated other_pseud."
+    Then I should see "Updated other_pseud (myself)."
     When I go to the collections page
     Then I should see "My Collection Thing"
       And I should see "other_pseud (myself)" within "#main"

--- a/features/other_a/pseuds.feature
+++ b/features/other_a/pseuds.feature
@@ -180,7 +180,7 @@ Scenario: Collections reflect pseud changes of moderators after the cache expire
   Then I should see "New members invited: before (myself)"
   When I select "Moderator" from "myself_role"
     And I submit with the 3rd button
-  Then I should see "Updated before."
+  Then I should see "Updated before (myself)."
   When I go to the collections page
   Then I should see "My Collection Thing"
     And I should see "before (myself)" within "#main"

--- a/spec/controllers/collection_participants_controller_spec.rb
+++ b/spec/controllers/collection_participants_controller_spec.rb
@@ -202,7 +202,7 @@ describe CollectionParticipantsController do
         context "where the participant is updated successfully" do
           it "successfully updates and redirects to collection participants" do
             put :update, params: params
-            it_redirects_to_with_notice(collection_participants_path(collection), "Updated #{participant.pseud.name}.")
+            it_redirects_to_with_notice(collection_participants_path(collection), "Updated #{participant.pseud.byline}.")
           end
         end
 
@@ -213,7 +213,7 @@ describe CollectionParticipantsController do
 
           it "displays an error notice and and redirects to collection participants" do
             put :update, params: params
-            it_redirects_to_with_error(collection_participants_path(collection), "Couldn't update #{participant.pseud.name}.")
+            it_redirects_to_with_error(collection_participants_path(collection), "Couldn't update #{participant.pseud.byline}.")
           end
         end
       end
@@ -221,7 +221,7 @@ describe CollectionParticipantsController do
   end
 
   describe "destroy" do
-    let(:pseud_name) { user.default_pseud.name }
+    let(:pseud_byline) { user.default_pseud.byline }
     let(:user_participant_role) { CollectionParticipant::MEMBER }
     let!(:user_participant) do
       create(
@@ -254,7 +254,7 @@ describe CollectionParticipantsController do
         context "where the user is destroying their own participant" do
           it "destroys the participant successfully and redirects to index" do
             delete :destroy, params: params
-            it_redirects_to_with_notice(root_path, "Removed #{pseud_name} from collection.")
+            it_redirects_to_with_notice(root_path, "Removed #{pseud_byline} from collection.")
             expect(CollectionParticipant.find_by(pseud_id: user.default_pseud.id)).to_not be_present
           end
         end
@@ -275,7 +275,7 @@ describe CollectionParticipantsController do
               participant_role: CollectionParticipant::MEMBER
             )
           end
-          let(:pseud_name) { other_participant.pseud.name }
+          let(:pseud_byline) { other_participant.pseud.byline }
           let(:params) { { id: other_participant.id, collection_id: collection.name } }
 
           it "doesn't allow the destroy and redirects to the collection page" do
@@ -295,7 +295,7 @@ describe CollectionParticipantsController do
             participant_role: CollectionParticipant::MEMBER
           )
         end
-        let(:pseud_name) { other_participant.pseud.name }
+        let(:pseud_byline) { other_participant.pseud.byline }
         let(:params) do
           { id: other_participant.id, collection_id: collection.name }
         end
@@ -303,7 +303,7 @@ describe CollectionParticipantsController do
         context "where participant to be destroyed is not an owner" do
           it "destroys the participant successfully and redirects to index" do
             delete :destroy, params: params
-            it_redirects_to_with_notice(root_path, "Removed #{pseud_name} from collection.")
+            it_redirects_to_with_notice(root_path, "Removed #{pseud_byline} from collection.")
             expect(CollectionParticipant.find_by(pseud_id: other_participant.pseud_id)).to_not be_present
           end
         end
@@ -321,7 +321,7 @@ describe CollectionParticipantsController do
           end
 
           context "where there are other owners" do
-            let!(:pseud_name) { CollectionParticipant.find(delete_participant_id.id).pseud.name }
+            let!(:pseud_byline) { CollectionParticipant.find(delete_participant_id.id).pseud.byline }
             let!(:other_owner) do
               create(
                 :collection_participant,
@@ -332,7 +332,7 @@ describe CollectionParticipantsController do
 
             it "destroys the participant successfully and redirects to index" do
               delete :destroy, params: params
-              it_redirects_to_with_notice(root_path, "Removed #{pseud_name} from collection.")
+              it_redirects_to_with_notice(root_path, "Removed #{pseud_byline} from collection.")
               expect(CollectionParticipant.where(id: delete_participant_id)).to be_empty
             end
           end


### PR DESCRIPTION
# Pull Request Checklist

<!-- Mark steps in the checklist as complete by changing `[ ]` to `[X]` -->
* [X] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [X] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [X] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [X] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [X] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-7179

## Purpose
I updated collection_participants_controller to use byline so that message alerts put both pseud name and username in the messages (instead of just the pseud)

## Credit
Jesse Malark he/him
