### PR TITLE
AO3-7400 Fix browser title for gifts

### DIFF
--- a/config/locales/controllers/en.yml
+++ b/config/locales/controllers/en.yml
@@ -206,7 +206,7 @@ en:
       collection_page_title: "%{collection_title} - Fandoms"
   gifts:
     index:
-      page_subtitle: Gifts for %{name}
+      page_subtitle: "%{name} - Gifts"
       whose_gifts_error: Whose gifts did you want to see?
     toggle_rejected:
       now_hidden_notice: This work will no longer be listed among your gifts.

--- a/features/other_a/gift.feature
+++ b/features/other_a/gift.feature
@@ -49,6 +49,7 @@ Feature: Create Gifts
       And I press "Post"
     When I go to giftee1's gifts page
     Then I should see "GiftStory1 by gifter for g1 (giftee1)"
+      And the page title should include "giftee1 - Gifts"
 
   Scenario: Gifts page for recipient without account should show their gifts
     Given I give the work to "g1"


### PR DESCRIPTION
# Pull Request Checklist

* [X] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [X] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [X] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [X] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [X] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-7400

## Purpose

Updated the text in the en.yml file to change the title of the Gifts page as described in AO3-7400.

## Testing Instructions

To check the change is correct, please visit the gifts page for any account and verify the that the title has changed from  “Gifts for testy | Archive of Our Own” (or TEST ARCHIVE, etc). to “username - Gifts | Archive of Our Own”.

Note: I don't have Jira access, so I was unable to update the issue directly.

## Credit

Name: Pearl
Pronouns: She/Her