### PR TITLE
AO3-7426 Adjust page subtitle for showing a wrangling guideline

### DIFF
--- a/app/controllers/wrangling_guidelines_controller.rb
+++ b/app/controllers/wrangling_guidelines_controller.rb
@@ -9,6 +9,7 @@ class WranglingGuidelinesController < ApplicationController
   # GET /wrangling_guidelines/1
   def show
     @wrangling_guideline = WranglingGuideline.find(params[:id])
+    @page_subtitle = @wrangling_guideline.title
   end
 
   # GET /wrangling_guidelines/new

--- a/features/tags_and_wrangling/wrangling_guidelines.feature
+++ b/features/tags_and_wrangling/wrangling_guidelines.feature
@@ -16,6 +16,7 @@ Feature: Wrangling Guidelines
   When I go to the wrangling_guidelines page
     And I follow "Intro and General Concepts"
   Then I should see "This series of documents (Wrangling Guidelines) are intended to help tag wranglers remain consistent as they go about the business of wrangling tags by providing a set of formatting guidelines." within ".userstuff"
+    And the page title should include "Intro and General Concepts"
 
   Scenario: Edit Wrangling Guideline
 

--- a/spec/controllers/wrangling_guidelines_controller_spec.rb
+++ b/spec/controllers/wrangling_guidelines_controller_spec.rb
@@ -26,6 +26,11 @@ describe WranglingGuidelinesController do
       expect(response).to render_template("show")
       expect(assigns(:wrangling_guideline)).to eq(guideline)
     end
+
+    it "assigns page subtitle using guideline title" do
+      get :show, params: { id: guideline.id }
+      expect(assigns[:page_subtitle]).to eq(guideline.title)
+    end
   end
 
   describe "GET #new" do


### PR DESCRIPTION
# Pull Request Checklist

<!-- Mark steps in the checklist as complete by changing `[ ]` to `[X]` -->
* [X] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [X] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [X] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [X] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [X] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-7426

## Purpose

Adjust the browser title so it has the wrangling guideline name included.

## Credit
Jesse Malark he/him
