### PR TITLE
AO3-6731 Fix order of Recent Bookmarks in User and Pseud dashboards

### DIFF
--- a/app/controllers/pseuds_controller.rb
+++ b/app/controllers/pseuds_controller.rb
@@ -46,7 +46,7 @@ class PseudsController < ApplicationController
 
     @works = visible_works.order("revised_at DESC").limit(ArchiveConfig.NUMBER_OF_ITEMS_VISIBLE_IN_DASHBOARD)
     @series = visible_series.order("updated_at DESC").limit(ArchiveConfig.NUMBER_OF_ITEMS_VISIBLE_IN_DASHBOARD)
-    @bookmarks = visible_bookmarks.order("updated_at DESC").limit(ArchiveConfig.NUMBER_OF_ITEMS_VISIBLE_IN_DASHBOARD)
+    @bookmarks = visible_bookmarks.order("created_at DESC").limit(ArchiveConfig.NUMBER_OF_ITEMS_VISIBLE_IN_DASHBOARD)
 
     return unless current_user.respond_to?(:subscriptions)
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -22,7 +22,7 @@ class UsersController < ApplicationController
 
     @works = visible[:works].order('revised_at DESC').limit(ArchiveConfig.NUMBER_OF_ITEMS_VISIBLE_IN_DASHBOARD)
     @series = visible[:series].order('updated_at DESC').limit(ArchiveConfig.NUMBER_OF_ITEMS_VISIBLE_IN_DASHBOARD)
-    @bookmarks = visible[:bookmarks].order('updated_at DESC').limit(ArchiveConfig.NUMBER_OF_ITEMS_VISIBLE_IN_DASHBOARD)
+    @bookmarks = visible[:bookmarks].order('created_at DESC').limit(ArchiveConfig.NUMBER_OF_ITEMS_VISIBLE_IN_DASHBOARD)
     if current_user.respond_to?(:subscriptions)
       @subscription = current_user.subscriptions.where(subscribable_id: @user.id,
                                                        subscribable_type: 'User').first ||

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -22,7 +22,7 @@ class UsersController < ApplicationController
 
     @works = visible[:works].order('revised_at DESC').limit(ArchiveConfig.NUMBER_OF_ITEMS_VISIBLE_IN_DASHBOARD)
     @series = visible[:series].order('updated_at DESC').limit(ArchiveConfig.NUMBER_OF_ITEMS_VISIBLE_IN_DASHBOARD)
-    @bookmarks = visible[:bookmarks].order('created_at DESC').limit(ArchiveConfig.NUMBER_OF_ITEMS_VISIBLE_IN_DASHBOARD)
+    @bookmarks = visible[:bookmarks].order("created_at DESC").limit(ArchiveConfig.NUMBER_OF_ITEMS_VISIBLE_IN_DASHBOARD)
     if current_user.respond_to?(:subscriptions)
       @subscription = current_user.subscriptions.where(subscribable_id: @user.id,
                                                        subscribable_type: 'User').first ||

--- a/features/users/user_dashboard.feature
+++ b/features/users/user_dashboard.feature
@@ -304,3 +304,27 @@ Feature: User dashboard
   Then I should see "Here are some tips to help you get started" within "#modal"
     And I should see "First login help" within "#modal"
     And I should see "Close" within "#modal"
+
+  Scenario: The user dashboard should list the user's most recently created bookmarks
+  Given dashboard counts expire after 10 seconds
+    And I am logged in as "fruitpie"
+    And I post the works "Work One, Work Two, Work Three, Work Four, Work Five, Work Six"
+  When I am logged in as "meatloaf"
+    And I bookmark the works "Work One, Work Two, Work Three, Work Four, Work Five, Work Six"
+  When I go to meatloaf's user page
+  Then I should see "Recent bookmarks"
+    And I should not see "Work One" within "#user-bookmarks"
+    And I should see "Work Six" within "#user-bookmarks"
+  When I edit the bookmark for "Work One"
+    And I check "bookmark_rec"
+    And I press "Update"
+  When I go to meatloaf's user page
+  Then I should see "Recent bookmarks"
+    And I should not see "Work One" within "#user-bookmarks"
+    And I should see "Work Six" within "#user-bookmarks"
+  When I am on meatloaf's pseuds page
+    And I follow "meatloaf" within "ul.pseud.index"
+  Then I should be on the dashboard page for user "meatloaf" with pseud "meatloaf"
+    And I should see "Recent bookmarks"
+    And I should not see "Work One" within "#user-bookmarks"
+    And I should see "Work Six" within "#user-bookmarks"

--- a/features/users/user_dashboard.feature
+++ b/features/users/user_dashboard.feature
@@ -307,11 +307,10 @@ Feature: User dashboard
 
   Scenario: The user dashboard should list the user's most recently created bookmarks
   Given dashboard counts expire after 10 seconds
-    And I am logged in as "fruitpie"
+    And I am logged in as "meatloaf"
     And I post the works "Work One, Work Two, Work Three, Work Four, Work Five, Work Six"
-  When I am logged in as "meatloaf"
     And I bookmark the works "Work One, Work Two, Work Three, Work Four, Work Five, Work Six"
-  When I go to meatloaf's user page
+    And I go to meatloaf's user page
   Then I should see "Recent bookmarks"
     And I should not see "Work One" within "#user-bookmarks"
     And I should see "Work Six" within "#user-bookmarks"
@@ -322,9 +321,7 @@ Feature: User dashboard
   Then I should see "Recent bookmarks"
     And I should not see "Work One" within "#user-bookmarks"
     And I should see "Work Six" within "#user-bookmarks"
-  When I am on meatloaf's pseuds page
-    And I follow "meatloaf" within "ul.pseud.index"
-  Then I should be on the dashboard page for user "meatloaf" with pseud "meatloaf"
+  When I go to the dashboard page for user "meatloaf" with pseud "meatloaf"
     And I should see "Recent bookmarks"
     And I should not see "Work One" within "#user-bookmarks"
     And I should see "Work Six" within "#user-bookmarks"

--- a/features/users/user_dashboard.feature
+++ b/features/users/user_dashboard.feature
@@ -316,7 +316,7 @@ Feature: User dashboard
   When I edit the bookmark for "Work One"
     And I check "Rec"
     And I press "Update"
-  When I go to meatloaf's user page
+    And I go to meatloaf's user page
   Then I should see "Recent bookmarks"
     And I should not see "Work One" within "#user-bookmarks"
     And I should see "Work Six" within "#user-bookmarks"

--- a/features/users/user_dashboard.feature
+++ b/features/users/user_dashboard.feature
@@ -315,7 +315,7 @@ Feature: User dashboard
     And I should not see "Work One" within "#user-bookmarks"
     And I should see "Work Six" within "#user-bookmarks"
   When I edit the bookmark for "Work One"
-    And I check "bookmark_rec"
+    And I check "Rec"
     And I press "Update"
   When I go to meatloaf's user page
   Then I should see "Recent bookmarks"

--- a/features/users/user_dashboard.feature
+++ b/features/users/user_dashboard.feature
@@ -306,8 +306,7 @@ Feature: User dashboard
     And I should see "Close" within "#modal"
 
   Scenario: The user dashboard should list the user's most recently created bookmarks
-  Given dashboard counts expire after 10 seconds
-    And I am logged in as "meatloaf"
+  Given I am logged in as "meatloaf"
     And I post the works "Work One, Work Two, Work Three, Work Four, Work Five, Work Six"
     And I bookmark the works "Work One, Work Two, Work Three, Work Four, Work Five, Work Six"
     And I go to meatloaf's user page

--- a/features/users/user_dashboard.feature
+++ b/features/users/user_dashboard.feature
@@ -321,6 +321,6 @@ Feature: User dashboard
     And I should not see "Work One" within "#user-bookmarks"
     And I should see "Work Six" within "#user-bookmarks"
   When I go to the dashboard page for user "meatloaf" with pseud "meatloaf"
-    And I should see "Recent bookmarks"
+  Then I should see "Recent bookmarks"
     And I should not see "Work One" within "#user-bookmarks"
     And I should see "Work Six" within "#user-bookmarks"


### PR DESCRIPTION
# Pull Request Checklist

<!-- Mark steps in the checklist as complete by changing `[ ]` to `[X]` -->
* [X] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [X] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [X] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [X] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [X] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-6731

## Purpose

Updates the sorting on the query that loads bookmarks on the User and Pseud controllers so that they sort by `created_at`, which is the expected behavior.

## Credit

Luis Pabon (they/he)
