### PR TITLE
AO3-7394  Fix page header text, when updating tag name to invalid tag

### DIFF
--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -190,6 +190,7 @@ class Tag < ApplicationRecord
       # admins can change tags with no restriction
       unless User.current_user.is_a?(Admin) || only_case_changed?
         self.errors.add(:name, "can only be changed by an admin.")
+        self.name = self.name_was
       end
     end
     if self.merger_id

--- a/features/tags_and_wrangling/tag_wrangling_special.feature
+++ b/features/tags_and_wrangling/tag_wrangling_special.feature
@@ -39,6 +39,7 @@ Feature: Tag Wrangling - special cases
   When I fill in "Name" with "Amelia"
     And I press "Save changes"
   Then I should see "Name can only be changed by an admin."
+    And I should see "Edit Amelie Tag"
 
   Scenario: Change capitalisation of a tag
 


### PR DESCRIPTION
# Pull Request Checklist
* [X] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [X] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [X] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [X] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [X] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue
https://otwarchive.atlassian.net/browse/AO3-7394

## Purpose
In Edit Tag page header, when tag name is edited to be invalid, show the old & valid name, instead of the invalid one. 

## Credit
mellowmarsach