### PR TITLE
AO3-7388 Redirect to user skin page with error if trying to preview a skin you can't use

### DIFF
--- a/app/controllers/skins_controller.rb
+++ b/app/controllers/skins_controller.rb
@@ -3,7 +3,7 @@ class SkinsController < ApplicationController
   before_action :load_skin, except: [:index, :new, :create, :unset]
   before_action :check_ownership_or_admin, only: [:edit, :update]
   before_action :check_ownership, only: [:confirm_delete, :destroy]
-  before_action :check_visibility, only: [:show]
+  before_action :check_visibility, only: [:show, :preview]
   before_action :check_editability, only: [:edit, :update, :confirm_delete, :destroy]
 
   #### ACTIONS
@@ -129,9 +129,10 @@ class SkinsController < ApplicationController
 
   # Get /skins/1/preview
   def preview
-    if (@skin.is_a?(WorkSkin) || !@skin.approved_or_owned_by?(current_user) || @skin.unusable?)
+    if (@skin.is_a?(WorkSkin) || @skin.unusable?)
       flash[:error] = t("skins.preview.cannot_preview")
-      redirect_to user_skins_path(current_user) and return
+
+      redirect_to skin_path(@skin) and return
     end
 
     flash[:notice] = []

--- a/app/controllers/skins_controller.rb
+++ b/app/controllers/skins_controller.rb
@@ -129,6 +129,11 @@ class SkinsController < ApplicationController
 
   # Get /skins/1/preview
   def preview
+    if (@skin.is_a?(WorkSkin) || !@skin.approved_or_owned_by?(current_user) || @skin.unusable?)
+      flash[:error] = t("skins.preview.cannot_preview")
+      redirect_to user_skins_path(current_user) and return
+    end
+
     flash[:notice] = []
     flash[:notice] << ts("You are previewing the skin %{title}. This is a randomly chosen page.", title: @skin.title)
     flash[:notice] << ts("Go back or click any link to remove the skin.")

--- a/app/controllers/skins_controller.rb
+++ b/app/controllers/skins_controller.rb
@@ -129,7 +129,7 @@ class SkinsController < ApplicationController
 
   # Get /skins/1/preview
   def preview
-    if (@skin.is_a?(WorkSkin) || @skin.unusable?)
+    if @skin.is_a?(WorkSkin) || @skin.unusable?
       flash[:error] = t("skins.preview.cannot_preview")
 
       redirect_to skin_path(@skin) and return

--- a/app/controllers/skins_controller.rb
+++ b/app/controllers/skins_controller.rb
@@ -135,7 +135,6 @@ class SkinsController < ApplicationController
       redirect_to skins_path(skin_type: "Site") and return if current_user.nil?
 
       redirect_to user_skins_path(current_user) and return
-      end
     end
 
     flash[:notice] = []

--- a/app/controllers/skins_controller.rb
+++ b/app/controllers/skins_controller.rb
@@ -130,9 +130,13 @@ class SkinsController < ApplicationController
   # Get /skins/1/preview
   def preview
     if @skin.is_a?(WorkSkin) || @skin.unusable?
-      flash[:error] = t("skins.preview.cannot_preview")
+      flash[:error] = t(".cannot_preview")
 
-      redirect_to skin_path(@skin) and return
+      if current_user.nil?
+        redirect_to skins_path(skin_type: "Site") and return
+      else
+        redirect_to user_skins_path(current_user) and return
+      end
     end
 
     flash[:notice] = []

--- a/app/controllers/skins_controller.rb
+++ b/app/controllers/skins_controller.rb
@@ -1,5 +1,5 @@
 class SkinsController < ApplicationController
-  before_action :users_only, only: [:new, :create, :destroy]
+  before_action :users_only, only: [:new, :create, :destroy, :preview]
   before_action :load_skin, except: [:index, :new, :create, :unset]
   before_action :check_ownership_or_admin, only: [:edit, :update]
   before_action :check_ownership, only: [:confirm_delete, :destroy]
@@ -131,9 +131,6 @@ class SkinsController < ApplicationController
   def preview
     if @skin.is_a?(WorkSkin) || @skin.unusable?
       flash[:error] = t(".cannot_preview")
-
-      redirect_to skins_path(skin_type: "Site") and return if current_user.nil?
-
       redirect_to user_skins_path(current_user) and return
     end
 

--- a/app/controllers/skins_controller.rb
+++ b/app/controllers/skins_controller.rb
@@ -132,10 +132,9 @@ class SkinsController < ApplicationController
     if @skin.is_a?(WorkSkin) || @skin.unusable?
       flash[:error] = t(".cannot_preview")
 
-      if current_user.nil?
-        redirect_to skins_path(skin_type: "Site") and return
-      else
-        redirect_to user_skins_path(current_user) and return
+      redirect_to skins_path(skin_type: "Site") and return if current_user.nil?
+
+      redirect_to user_skins_path(current_user) and return
       end
     end
 

--- a/config/locales/controllers/en.yml
+++ b/config/locales/controllers/en.yml
@@ -310,6 +310,8 @@ en:
     index:
       public_site_page_title: Public Site Skins
       public_work_page_title: Public Work Skins
+    preview:
+      cannot_preview: Sorry, you can't preview that skin.
   stats:
     index:
       page_title: "%{username} - Stats"

--- a/spec/controllers/skins_controller_spec.rb
+++ b/spec/controllers/skins_controller_spec.rb
@@ -640,7 +640,7 @@ describe SkinsController do
         
       context "when logged in as a user who isn't the skin author" do
         it "errors and redirects to skin_path" do
-          fake_login()
+          fake_login
           subject
           success
         end

--- a/spec/controllers/skins_controller_spec.rb
+++ b/spec/controllers/skins_controller_spec.rb
@@ -622,4 +622,92 @@ describe SkinsController do
       end
     end
   end
+
+  describe "GET #preview" do
+    let(:skin_creator) { create(:user) }
+    subject { get :preview, params: { id: skin.id } }
+    let(:success) { it_redirects_to_with_error(skin_path(skin), "Sorry, you can't preview that skin.") }
+  
+    shared_examples "a public skin that cannot be previewed" do
+      
+      context "when logged in as the skin creator" do
+        it "errors and redirects to skin_path" do
+          fake_login_known_user(skin.author)
+          subject
+          success
+        end
+      end
+        
+      context "when logged in as a user who isn't the skin author" do
+        it "errors and redirects to skin_path" do
+          fake_login()
+          subject
+          success
+        end
+      end
+
+      context "when not logged in" do
+        it "errors and redirects to skin_path" do
+          subject
+          success
+        end
+      end
+    end
+
+    shared_examples "a non-public skin that cannot be previewed" do
+      
+      context "when logged in as the skin creator" do
+        it "errors and redirects to skin_path" do
+          fake_login_known_user(skin.author)
+          subject
+          success
+        end
+      end
+        
+      context "when logged in as a user who isn't the skin author" do
+        let(:other_user) { create(:user) }
+
+        it "errors and redirects to user_path" do
+          fake_login_known_user(other_user)
+          subject
+          it_redirects_to_with_error(user_path(other_user), "Sorry, you don't have permission to access the page you were trying to reach.")
+        end
+      end
+
+      context "when not logged in" do
+        it "errors and redirects to new_user_session_path" do
+          subject
+          it_redirects_to_with_error(new_user_session_path(return_to: request.fullpath), "Sorry, you don't have permission to access the page you were trying to reach. Please log in.")
+        end
+      end
+    end
+
+    context "with workskin" do
+      context "when workskin is public" do
+        let(:skin) { create(:work_skin, :public, title: "Work Skin", author: skin_creator) }   
+        
+        it_behaves_like "a public skin that cannot be previewed"
+      end
+
+      context "when workskin is not public" do
+        let(:skin) { create(:work_skin, title: "Work Skin", author: skin_creator) }   
+        
+        it_behaves_like "a non-public skin that cannot be previewed"
+      end
+    end
+
+    context "with unusable site skin" do
+      context "when site skin is public" do
+        let(:skin) { create(:skin, :public, title: "Unusable Site Skin", unusable: true, author: skin_creator) }
+          
+        it_behaves_like "a public skin that cannot be previewed"
+      end
+
+      context "when site skin is not public" do
+        let(:skin) { create(:skin, title: "Unusable Site Skin", unusable: true, author: skin_creator) }
+
+        it_behaves_like "a non-public skin that cannot be previewed"
+      end
+    end
+  end
 end

--- a/spec/controllers/skins_controller_spec.rb
+++ b/spec/controllers/skins_controller_spec.rb
@@ -625,51 +625,52 @@ describe SkinsController do
 
   describe "GET #preview" do
     let(:skin_creator) { create(:user) }
+    let(:other_user) { create(:user) }
     subject { get :preview, params: { id: skin.id } }
-    let(:success) { it_redirects_to_with_error(skin_path(skin), "Sorry, you can't preview that skin.") }
   
     shared_examples "a public skin that cannot be previewed" do
-      
       context "when logged in as the skin creator" do
-        it "errors and redirects to skin_path" do
+        it "errors and redirects to user_skins_path" do
           fake_login_known_user(skin.author)
           subject
-          success
+
+          it_redirects_to_with_error(user_skins_path(skin.author), "Sorry, you can't preview that skin.")
         end
       end
         
       context "when logged in as a user who isn't the skin author" do
-        it "errors and redirects to skin_path" do
-          fake_login
+        it "errors and redirects to user_skins_path" do
+          fake_login_known_user(other_user)
           subject
-          success
+
+          it_redirects_to_with_error(user_skins_path(other_user), "Sorry, you can't preview that skin.")
         end
       end
 
       context "when not logged in" do
-        it "errors and redirects to skin_path" do
+        it "errors and redirects to skins_path" do
           subject
-          success
+
+          it_redirects_to_with_error(skins_path(skin_type: "Site"), "Sorry, you can't preview that skin.")
         end
       end
     end
 
     shared_examples "a non-public skin that cannot be previewed" do
-      
       context "when logged in as the skin creator" do
-        it "errors and redirects to skin_path" do
+        it "errors and redirects to user_skins_path" do
           fake_login_known_user(skin.author)
           subject
-          success
+
+          it_redirects_to_with_error(user_skins_path(skin.author), "Sorry, you can't preview that skin.")
         end
       end
         
       context "when logged in as a user who isn't the skin author" do
-        let(:other_user) { create(:user) }
-
         it "errors and redirects to user_path" do
           fake_login_known_user(other_user)
           subject
+
           it_redirects_to_with_error(user_path(other_user), "Sorry, you don't have permission to access the page you were trying to reach.")
         end
       end
@@ -677,7 +678,8 @@ describe SkinsController do
       context "when not logged in" do
         it "errors and redirects to new_user_session_path" do
           subject
-          it_redirects_to_with_error(new_user_session_path(return_to: request.fullpath), "Sorry, you don't have permission to access the page you were trying to reach. Please log in.")
+
+          it_redirects_to_user_login_with_error
         end
       end
     end
@@ -685,7 +687,7 @@ describe SkinsController do
     context "with workskin" do
       context "when workskin is public" do
         let(:skin) { create(:work_skin, :public, title: "Work Skin", author: skin_creator) }   
-        
+
         it_behaves_like "a public skin that cannot be previewed"
       end
 
@@ -696,17 +698,87 @@ describe SkinsController do
       end
     end
 
-    context "with unusable site skin" do
+    context "with parent only site skin" do
       context "when site skin is public" do
-        let(:skin) { create(:skin, :public, title: "Unusable Site Skin", unusable: true, author: skin_creator) }
+        let(:skin) { create(:skin, :public, title: "Parent Only Site Skin", unusable: true, author: skin_creator) }
           
         it_behaves_like "a public skin that cannot be previewed"
       end
 
       context "when site skin is not public" do
-        let(:skin) { create(:skin, title: "Unusable Site Skin", unusable: true, author: skin_creator) }
+        let(:skin) { create(:skin, title: "Parent Only Site Skin", unusable: true, author: skin_creator) }
 
         it_behaves_like "a non-public skin that cannot be previewed"
+      end
+    end
+
+    context "with accessible site skin" do
+      let(:notice) { ["You are previewing the skin #{skin.title}. This is a randomly chosen page.", "Go back or click any link to remove the skin.", "Tip: You can preview any archive page you want by tacking on '?site_skin=[skin_id]' like you can see in the url above.", "<a href='#{skin_path(skin)}' class='action' role='button'>".html_safe + "Return To Skin To Use" + "</a>".html_safe] }
+      let(:success) { it_redirects_to_with_notice(tag_works_path(tag, site_skin: skin.id), notice) }
+      let(:tag) { create(:canonical_fandom) }
+
+      before do
+        FilterCount.create!(
+          filter: tag,
+          public_works_count: 10,
+          unhidden_works_count: 10
+        )
+      end
+
+      context "when site skin is public" do
+        let(:skin) { create(:skin, :public, title: "Accessible Site Skin", author: skin_creator)}
+
+        context "when logged in as the skin creator" do
+          it "succeeds" do
+            fake_login_known_user(skin.author)
+            subject
+            success
+          end
+        end
+        
+        context "when logged in as a user who isn't the skin author" do
+          it "succeeds" do
+            fake_login
+            subject
+            success
+          end
+        end
+
+        context "when not logged in" do
+          it "succeeds" do
+            subject
+            success
+          end
+        end
+      end
+
+      context "when site skin is not public" do
+        let(:skin) { create(:skin, title: "Accessible Site Skin", author: skin_creator)}
+        
+        context "when logged in as the skin author" do
+          it "succeeds" do
+            fake_login_known_user(skin.author)
+            subject
+            success
+          end
+        end
+
+        context "when logged in as a user who isn't the skin author" do
+          it "redirects with an error" do
+            fake_login_known_user(other_user)
+            subject
+
+            it_redirects_to_with_error(user_path(other_user), "Sorry, you don't have permission to access the page you were trying to reach.")
+          end
+        end
+
+        context "when logged out" do
+          it "redirects with an error" do
+            subject
+
+            it_redirects_to_user_login_with_error
+          end
+        end    
       end
     end
   end

--- a/spec/controllers/skins_controller_spec.rb
+++ b/spec/controllers/skins_controller_spec.rb
@@ -713,7 +713,7 @@ describe SkinsController do
     end
 
     context "with accessible site skin" do
-      let(:notice) { ["You are previewing the skin #{skin.title}. This is a randomly chosen page.", "Go back or click any link to remove the skin.", "Tip: You can preview any archive page you want by tacking on '?site_skin=[skin_id]' like you can see in the url above.", "#{"<a href='#{skin_path(skin)}' class='action' role='button'>".html_safe}Return To Skin To Use#{"</a>".html_safe}"] }
+      let(:notice) { ["You are previewing the skin #{skin.title}. This is a randomly chosen page.", "Go back or click any link to remove the skin.", "Tip: You can preview any archive page you want by tacking on '?site_skin=[skin_id]' like you can see in the url above.", "<a href='#{skin_path(skin)}' class='action' role='button'>Return To Skin To Use</a>"] }
       let(:success) { it_redirects_to_with_notice(tag_works_path(tag, site_skin: skin.id), notice) }
       let(:tag) { create(:canonical_fandom) }
 

--- a/spec/controllers/skins_controller_spec.rb
+++ b/spec/controllers/skins_controller_spec.rb
@@ -627,6 +627,43 @@ describe SkinsController do
     let(:skin_creator) { create(:user) }
     let(:other_user) { create(:user) }
     subject { get :preview, params: { id: skin.id } }
+
+    shared_examples "a skin admins cannot preview" do
+      before do
+        fake_login_admin(admin)
+      end
+
+      context "when logged in as an admin with no role" do
+        let(:admin) { create(:admin, roles: []) }
+
+        it "redirects with an error" do
+          subject
+          # This actually redirects to the root path
+          it_redirects_to_user_login_with_error
+        end
+      end
+
+      Admin::VALID_ROLES.each do |role|
+        context "when logged in as an admin with role #{role}" do
+          let(:admin) { create(:admin, roles: [role]) }
+
+          it "redirects with an error" do
+            subject
+            # This actually redirects to the root path
+            it_redirects_to_user_login_with_error
+          end
+        end
+      end
+    end
+  
+    shared_examples "a skin guests cannot preview" do
+      context "when not logged in" do
+        it "errors and redirects to user_login" do
+          subject
+          it_redirects_to_user_login_with_error
+        end
+      end
+    end
   
     shared_examples "a public skin that cannot be previewed" do
       context "when logged in as the skin creator" do
@@ -647,12 +684,12 @@ describe SkinsController do
         end
       end
 
-      context "when not logged in" do
-        it "errors and redirects to skins_path" do
-          subject
+      context "when logged in as an admin" do
+        it_behaves_like "a skin admins cannot preview"
+      end
 
-          it_redirects_to_with_error(skins_path(skin_type: "Site"), "Sorry, you can't preview that skin.")
-        end
+      context "when not logged in" do
+        it_behaves_like "a skin guests cannot preview"
       end
     end
 
@@ -675,12 +712,12 @@ describe SkinsController do
         end
       end
 
-      context "when not logged in" do
-        it "errors and redirects to new_user_session_path" do
-          subject
+      context "when logged in as an admin" do
+        it_behaves_like "a skin admins cannot preview"
+      end
 
-          it_redirects_to_user_login_with_error
-        end
+      context "when not logged in" do
+        it_behaves_like "a skin guests cannot preview"
       end
     end
 
@@ -713,8 +750,7 @@ describe SkinsController do
     end
 
     context "with accessible site skin" do
-      let(:notice) { ["You are previewing the skin #{skin.title}. This is a randomly chosen page.", "Go back or click any link to remove the skin.", "Tip: You can preview any archive page you want by tacking on '?site_skin=[skin_id]' like you can see in the url above.", "<a href='#{skin_path(skin)}' class='action' role='button'>Return To Skin To Use</a>"] }
-      let(:success) { it_redirects_to_with_notice(tag_works_path(tag, site_skin: skin.id), notice) }
+      let(:success) { it_redirects_to_simple(tag_works_path(tag, site_skin: skin.id)) }
       let(:tag) { create(:canonical_fandom) }
 
       before do
@@ -744,11 +780,12 @@ describe SkinsController do
           end
         end
 
+        context "when logged in as an admin" do
+          it_behaves_like "a skin admins cannot preview"
+        end
+
         context "when not logged in" do
-          it "succeeds" do
-            subject
-            success
-          end
+          it_behaves_like "a skin guests cannot preview"
         end
       end
 
@@ -772,13 +809,13 @@ describe SkinsController do
           end
         end
 
-        context "when logged out" do
-          it "redirects with an error" do
-            subject
+        context "when logged in as an admin" do
+          it_behaves_like "a skin admins cannot preview"
+        end
 
-            it_redirects_to_user_login_with_error
-          end
-        end    
+        context "when not logged in" do
+          it_behaves_like "a skin guests cannot preview"
+        end
       end
     end
   end

--- a/spec/controllers/skins_controller_spec.rb
+++ b/spec/controllers/skins_controller_spec.rb
@@ -726,7 +726,7 @@ describe SkinsController do
       end
 
       context "when site skin is public" do
-        let(:skin) { create(:skin, :public, title: "Accessible Site Skin", author: skin_creator)}
+        let(:skin) { create(:skin, :public, title: "Accessible Site Skin", author: skin_creator) }
 
         context "when logged in as the skin creator" do
           it "succeeds" do
@@ -753,7 +753,7 @@ describe SkinsController do
       end
 
       context "when site skin is not public" do
-        let(:skin) { create(:skin, title: "Accessible Site Skin", author: skin_creator)}
+        let(:skin) { create(:skin, title: "Accessible Site Skin", author: skin_creator) }
         
         context "when logged in as the skin author" do
           it "succeeds" do

--- a/spec/controllers/skins_controller_spec.rb
+++ b/spec/controllers/skins_controller_spec.rb
@@ -713,7 +713,7 @@ describe SkinsController do
     end
 
     context "with accessible site skin" do
-      let(:notice) { ["You are previewing the skin #{skin.title}. This is a randomly chosen page.", "Go back or click any link to remove the skin.", "Tip: You can preview any archive page you want by tacking on '?site_skin=[skin_id]' like you can see in the url above.", "<a href='#{skin_path(skin)}' class='action' role='button'>".html_safe + "Return To Skin To Use" + "</a>".html_safe] }
+      let(:notice) { ["You are previewing the skin #{skin.title}. This is a randomly chosen page.", "Go back or click any link to remove the skin.", "Tip: You can preview any archive page you want by tacking on '?site_skin=[skin_id]' like you can see in the url above.", "#{"<a href='#{skin_path(skin)}' class='action' role='button'>".html_safe}Return To Skin To Use#{"</a>".html_safe}"] }
       let(:success) { it_redirects_to_with_notice(tag_works_path(tag, site_skin: skin.id), notice) }
       let(:tag) { create(:canonical_fandom) }
 


### PR DESCRIPTION
# Pull Request Checklist
<!-- Mark steps in the checklist as complete by changing `[ ]` to `[X]` -->
* [X] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [X] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [X] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [X] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [X] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-7388

## Purpose

Redirects to the user skins page when trying to preview a skin that can't be used but can be viewed while logged in as a user. This includes parent-only site skins and work skins. For skins that a logged-in user cannot view (not owned and not public), they are redirected to their dashboard with an error.

Changed preview to a user-only action. Redirects to the login page with an error when trying to preview any skin while logged out. Redirects to the root page with an error when trying to preview any skin while logged in as an admin.

## Testing Instructions
For site skins, refer to Jira.

For work skins:
1. Log in
2. Make a work skin
    a. Hi, username! > My Dashboard > Skins > Create Work Skin
    b. Fill in required information
    c. Press “Submit” to save
3. In your browser address bar, add /preview to the end of the skin URL and press Return

For not owned, not public skins:
1. Log in
2. Make a site skin
    a. Hi, username! > My Dashboard > Skins > Create Site Skin
    b. Fill in required information
    c. Press “Submit” to save
3. Copy the site skin URL
4. Log into another account and paste the site skin URL into the browser address bar. Add /preview to the end of the URL and press Return

## Credit

zrei (she/they)
