### PR TITLE
AO3-5047 Prevent duplicate AJAX flash messages

### DIFF
--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,6 +1,6 @@
 <% if @user == current_user && @user.preference.try(:first_login) %>
   <!-- pseudoflash because putting it in a real one was making for some ugly code -->
-  <div class="flash notice" id="first-login-help-banner">
+  <div class="notice" id="first-login-help-banner">
     <p>
       <%= t(".login_banner.welcome_html",
             new_user_tips_link: link_to_modal(t(".login_banner.new_user_tips"), for: help_first_login_path, title: t(".login_banner.help_title")),

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,5 +1,4 @@
 <% if @user == current_user && @user.preference.try(:first_login) %>
-  <!-- pseudoflash because putting it in a real one was making for some ugly code -->
   <div class="notice" id="first-login-help-banner">
     <p>
       <%= t(".login_banner.welcome_html",

--- a/features/tags_and_wrangling/favorite_tags.feature
+++ b/features/tags_and_wrangling/favorite_tags.feature
@@ -37,3 +37,18 @@ Feature: Favorite Tags
   When the tag "Rebecca Sutter" is decanonized
     And I go to the homepage
   Then I should not see "Rebecca Sutter"
+
+  @javascript
+  Scenario: Favoriting a tag only shows one AJAX notice when another flash is already present
+  Given a canonical fandom "Dallas (TV 2012)"
+    And the user "bourbon" exists and is activated
+    And I am a visitor
+  When I view the "Dallas (TV 2012)" works index
+    And I follow "Log In" within "#header"
+    And I fill in "user_session_login_small" with "bourbon" within "#login"
+    And I fill in "user_session_password_small" with "password" within "#login"
+    And I press "Log In" within "#login"
+  Then I should see "Successfully logged in"
+    And I should see a "Favorite Tag" button
+  When I press "Favorite Tag"
+  Then I should see "You have successfully added Dallas (TV 2012) to your favorite tags." exactly 1 time

--- a/features/tags_and_wrangling/favorite_tags.feature
+++ b/features/tags_and_wrangling/favorite_tags.feature
@@ -45,8 +45,8 @@ Feature: Favorite Tags
     And I am a visitor
   When I view the "Dallas (TV 2012)" works index
     And I follow "Log In" within "#header"
-    And I fill in "user_session_login_small" with "bourbon" within "#login"
-    And I fill in "user_session_password_small" with "password" within "#login"
+    And I fill in "Username or email:" with "bourbon" within "#login"
+    And I fill in "Password:" with "password" within "#login"
     And I press "Log In" within "#login"
   Then I should see "Successfully logged in"
     And I should see a "Favorite Tag" button

--- a/public/javascripts/application.js
+++ b/public/javascripts/application.js
@@ -461,6 +461,8 @@ $j(document).ready(function() {
 // data-destroy-value: text of button for destroying, e.g. Unfavorite, Unsubscribe
 // controller needs item_id and item_success_message for save success and
 // item_success_message for destroy success
+// Limit AJAX flash messages to #main > .flash so they don't get duplicated
+// when other flash-like banners are present
 $j(document).ready(function() {
   $j('form.ajax-create-destroy').on("click", function(event) {
     event.preventDefault();
@@ -470,7 +472,10 @@ $j(document).ready(function() {
     var formSubmit = form.find('[type="submit"]');
     var createValue = form.data('create-value');
     var destroyValue = form.data('destroy-value');
-    var flashContainer = $j('.flash');
+    var flashContainer = $j('#main > .flash').first();
+    if (flashContainer.length === 0) {
+      return;
+    }
 
     $j.ajax({
       type: 'POST',


### PR DESCRIPTION
# Pull Request Checklist

* [X] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [X] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [X] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [X] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [X] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-5047

## Purpose

Fixes duplicated flash messages for AJAX create/destroy actions (e.g. Favorite Tag) when another flash message/banner is already present on the page.

Root cause:
- The `ajax-create-destroy` handler used a broad selector (`.flash`), causing messages to be written into multiple flash containers.

Changes made:
- Scoped AJAX flash output to the main flash container only (`#main > .flash`) in `public/javascripts/application.js`.
- Added a guard clause to skip flash rendering if no main flash container is found.
- Updated the first-login help banner in `app/views/users/show.html.erb` from `class="flash notice"` to `class="notice"` so it is not treated as a flash target.

This keeps the fix minimal and aligned with the issue note about the first-login banner being a notice rather than a flash.

## Testing Instructions

Follow Example 1 from AO3-5047:
https://otwarchive.atlassian.net/browse/AO3-5047

Expected behavior:
- After logging in from a tag works index page and pressing Favorite Tag (or Unfavorite Tag), the success message appears only once.
- The AJAX message should not duplicate into multiple blue banners.

Automated tests:
- Added a new `@javascript` regression scenario in `features/tags_and_wrangling/favorite_tags.feature` covering:
  - logged-out user on tag works index
  - login from header form (existing "Successfully logged in" flash present)
  - Favorite Tag action
  - assertion that the success message appears exactly 1 time

Commands run:
- `docker compose run --rm test bundle exec cucumber features/tags_and_wrangling/favorite_tags.feature:42`
- `docker compose run --rm test bundle exec cucumber features/tags_and_wrangling/favorite_tags.feature`

Additional manual spot-check:
- Tag page deep pagination case from Jira notes (e.g. high page number) should also show the AJAX success message only once.

## Credit

Name: Noah Bravo  
Pronouns: they/them