### PR TITLE
AO3-6857 Improve prompt meme anon tickbox behavior

### DIFF
--- a/app/views/prompts/_prompt_form.html.erb
+++ b/app/views/prompts/_prompt_form.html.erb
@@ -88,7 +88,8 @@
         %>
         <dt><%= form.label :anonymous, ts("Semi-anonymous Prompt?") %></dt>
         <dd>
-          <%= form.check_box :anonymous, :checked => @collection.challenge.anonymous? ? true : form.object.anonymous %>
+          <% # Default to the prompt's original anonymity value, unless we're making a new prompt and the challenge is anonymous. %>
+          <%= form.check_box :anonymous, :checked => form.object.anonymous? || (form.object.new_record? && @collection.challenge.anonymous?) %>
   	      <p class="footnote"><%= ts("(Note: This is not totally secure, and is still guessable in some places.)") %></p>
   	    </dd>
       <% end %>     

--- a/app/views/prompts/_prompt_form.html.erb
+++ b/app/views/prompts/_prompt_form.html.erb
@@ -88,8 +88,8 @@
         %>
         <dt><%= form.label :anonymous, ts("Semi-anonymous Prompt?") %></dt>
         <dd>
-          <% # Default to the prompt's original anonymity value, unless we're making a new prompt and the challenge is anonymous. %>
-          <%= form.check_box :anonymous, :checked => form.object.anonymous? || (form.object.new_record? && @collection.challenge.anonymous?) %>
+          <%# Default to the prompt's original anonymity value, unless we're making a new prompt and the challenge is anonymous. %>
+          <%= form.check_box :anonymous, checked: form.object.anonymous? || (form.object.new_record? && @collection.challenge.anonymous?) %>
   	      <p class="footnote"><%= ts("(Note: This is not totally secure, and is still guessable in some places.)") %></p>
   	    </dd>
       <% end %>     

--- a/features/prompt_memes_c/challenge_promptmeme_claims.feature
+++ b/features/prompt_memes_c/challenge_promptmeme_claims.feature
@@ -399,16 +399,41 @@ Feature: Prompt Meme Challenge
   When I go to the "Battle 12" requests page
   Then I should not see "Download (CSV)"
 
-  Scenario: Validation error doesn't cause semi-anon ticky to lose state (Issue 2617)
+  Scenario: Validation error doesn't cause semi-anon ticky to lose state (default non-anonymous) (Issue 2617)
   Given I set up an anon promptmeme "Scotts Prompt" with name "scotts_prompt"
     And I am logged in as "Scott" with password "password"
     And I go to "Scotts Prompt" collection's page
     And I follow "Prompt Form"
-    And I check "Semi-anonymous Prompt"
-    And I press "Submit"
+    And I check the 1st checkbox with id matching "anonymous"
+  When I press "Submit"
   Then I should see "There were some problems with this submission. Please correct the mistakes below."
     And I should see "Your Request must include between 1 and 2 fandom tags, but you have included 0 fandom tags in your current Request."
     And the "Semi-anonymous Prompt" checkbox should be checked
+
+  Scenario: Editing prompt form doesn't cause semi-anon ticky to lose state (default semi-anonymous)
+  Given I set up an anon promptmeme "Scotts Prompt" with name "scotts_prompt" that is semi-anon
+    And a canonical fandom "Stargate Atlantis"
+    And I am logged in as "Scott" with password "password"
+    And I go to "Scotts Prompt" collection's page
+    And I follow "Prompt Form"
+    And I fill in the 1st field with id matching "fandom_tagnames" with "Stargate Atlantis"
+    And I uncheck "challenge_signup_requests_attributes_0_anonymous"
+    And I press "Submit"
+  Then I should see "Sign-up was successfully created."
+    And I should see "Request 1 by Scott"
+  When I follow "Edit Sign-up"
+  Then the "challenge_signup_requests_attributes_0_anonymous" checkbox should not be checked
+  # note: if ArchiveConfig.PROMPT_MEME_PROMPTS_MAX is ever changed this must be too
+  When I follow "My Prompts"
+    And I follow "Add Prompt"
+    When I fill in the 1st field with id matching "fandom_tagnames" with "Stargate Atlantis"
+    And I press "Submit"
+  Then I should see "Prompt was successfully added."
+    And I should see "Request 1 by Scott"
+    And I should see "Request 2 by Anonymous"
+  When I follow "Edit Sign-up"
+  Then the "challenge_signup_requests_attributes_0_anonymous" checkbox should not be checked
+    And the "challenge_signup_requests_attributes_1_anonymous" checkbox should be checked
 
   Scenario: Dates should be correctly set on PromptMemes
     Given it is currently 2015-09-21 12:40 AM

--- a/features/prompt_memes_c/challenge_promptmeme_claims.feature
+++ b/features/prompt_memes_c/challenge_promptmeme_claims.feature
@@ -404,7 +404,7 @@ Feature: Prompt Meme Challenge
     And I am logged in as "Scott" with password "password"
     And I go to "Scotts Prompt" collection's page
     And I follow "Prompt Form"
-    And I check the 1st checkbox with id matching "anonymous"
+    And I check "Semi-anonymous Prompt"
   When I press "Submit"
   Then I should see "There were some problems with this submission. Please correct the mistakes below."
     And I should see "Your Request must include between 1 and 2 fandom tags, but you have included 0 fandom tags in your current Request."
@@ -423,7 +423,6 @@ Feature: Prompt Meme Challenge
     And I should see "Request 1 by Scott"
   When I follow "Edit Sign-up"
   Then the "challenge_signup_requests_attributes_0_anonymous" checkbox should not be checked
-  # note: if ArchiveConfig.PROMPT_MEME_PROMPTS_MAX is ever changed this must be too
   When I follow "My Prompts"
     And I follow "Add Prompt"
     When I fill in the 1st field with id matching "fandom_tagnames" with "Stargate Atlantis"

--- a/features/step_definitions/challenge_promptmeme_steps.rb
+++ b/features/step_definitions/challenge_promptmeme_steps.rb
@@ -76,7 +76,7 @@ Given /^"([^\"]*)" has claimed a prompt from Battle 12$/ do |username|
   step %{I claim a prompt from "Battle 12"}
 end
 
-When /^I set up an?(?: ([^"]*)) promptmeme "([^\"]*)"(?: with name "([^"]*)")?$/ do |type, title, name|
+When /^I set up an?(?: ([^"]*)) promptmeme "([^\"]*)"(?: with name "([^"]*)")?(?: that is ([^\"]*))?$/ do |type, title, name, semianon|
   step %{I am logged in as "mod1"}
   visit new_collection_path
   if name.nil?
@@ -100,6 +100,9 @@ When /^I set up an?(?: ([^"]*)) promptmeme "([^\"]*)"(?: with name "([^"]*)")?$/
   fill_in("prompt_meme_request_restriction_attributes_fandom_num_allowed", with: 2)
   fill_in("Sign-up opens:", with: Date.yesterday)
   fill_in("Sign-up closes:", with: Date.tomorrow)
+  if semianon == "semi-anon"
+    check("Prompts anonymous by default?")
+  end
   step %{I submit}
   step "I should see \"Challenge was successfully created\""
 end

--- a/features/step_definitions/challenge_promptmeme_steps.rb
+++ b/features/step_definitions/challenge_promptmeme_steps.rb
@@ -76,7 +76,7 @@ Given /^"([^\"]*)" has claimed a prompt from Battle 12$/ do |username|
   step %{I claim a prompt from "Battle 12"}
 end
 
-When /^I set up an?(?: ([^"]*)) promptmeme "([^\"]*)"(?: with name "([^"]*)")?(?: that is ([^\"]*))?$/ do |type, title, name, semianon|
+When /^I set up an?(?: ([^"]*)) promptmeme "([^"]*)"(?: with name "([^"]*)")?(?: that is ([^"]*))?$/ do |type, title, name, semianon| # rubocop:disable Cucumber/RegexStepName
   step %{I am logged in as "mod1"}
   visit new_collection_path
   if name.nil?
@@ -100,9 +100,7 @@ When /^I set up an?(?: ([^"]*)) promptmeme "([^\"]*)"(?: with name "([^"]*)")?(?
   fill_in("prompt_meme_request_restriction_attributes_fandom_num_allowed", with: 2)
   fill_in("Sign-up opens:", with: Date.yesterday)
   fill_in("Sign-up closes:", with: Date.tomorrow)
-  if semianon == "semi-anon"
-    check("Prompts anonymous by default?")
-  end
+  check("Prompts anonymous by default?") if semianon == "semi-anon"
   step %{I submit}
   step "I should see \"Challenge was successfully created\""
 end


### PR DESCRIPTION
# Pull Request Checklist

<!-- Mark steps in the checklist as complete by changing `[ ]` to `[X]` -->
* [X] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [X] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [X] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [X] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [X] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-6857

## Purpose

Previously, for a prompt meme with default-anonymous prompts, all your previously added prompts would default back to a checked anonymous tickbox when you edited your signup, even if you unchecked the tickbox when first creating them. This PR makes it so previously added prompts have their original anonymity status preserved.

## Testing Instructions

Anonymous by Default:
1. Create or find a Prompt Meme with "Prompts Anonymous by Default" checked (https://test.archiveofourown.org/collections/testing_assignments_edited is available on Staging)
2. Create a prompt sign-up - deselect "Semi-anonymous prompt?", which should be selected by default - and save
5. Press "Edit Sign-up"
6. Verify that the first prompt still has the "Semi-anonymous prompt?" unchecked
7. Add another prompt, this time leaving "Semi-anonymous prompt?" still selected, and save
8. Press "Edit Sign-up"
9. Verify the first prompt's tickbox is unchecked and the second prompt's tickbox is checked
11. Add a third prompt and deselect "Semi-anonymous prompt?", and enter some noncanonical tag before saving
12. The prompt form should error out
13. Verify that the first prompt's tickbox is still unchecked, the second is still checked, and the third is also checked (unfortunately) (a sacrifice for the sake of not overcomplicating it)

Not Anonymous by Default:
1. Create or find a Prompt Meme with "Prompts Anonymous by Default" not checked
2. Create a prompt sign-up - leave "Semi-anonymous prompt?" unchecked, which it should be by default - and save
5. Press "Edit Sign-up"
6. Verify that the first prompt still has the "Semi-anonymous prompt?" unchecked
7. Add another prompt, this time selecting "Semi-anonymous prompt?", and save
8. Press "Edit Sign-up"
9. Verify the first prompt's tickbox is unchecked and the second prompt's tickbox is checked
11. Add a third prompt and select "Semi-anonymous prompt?", and enter some noncanonical tag before saving
12. The prompt form should error out
13. Verify that the first prompt's tickbox is still unchecked, the second is still checked, and the third is also checked (yay!)

## References

Undoing some stuff from https://otwarchive.atlassian.net/browse/AO3-2614, corresponding to some of the most recent commits on [the prompt form view](https://github.com/otwcode/otwarchive/commits/f9c47c2fdaec901252cc1c1a2fe6c4c82914691c/app/views/prompts/_prompt_form.html.erb)

## Credit

Ling-Yi (any pronouns)