### PR TITLE
AO3-5550 Don't expose restricted work titles to guests on related works pages

### DIFF
--- a/app/helpers/related_works_helper.rb
+++ b/app/helpers/related_works_helper.rb
@@ -1,20 +1,40 @@
 module RelatedWorksHelper
-  def related_work_title(related_work, with_byline: false, relation: "other_relations")
+  def related_work_title(related_work)
+    work_link = link_to related_work.title, polymorphic_url(related_work)
+
+    if related_work.respond_to?(:unrevealed?) && related_work.unrevealed?
+      t("related_works.index.unrevealed_work")
+    elsif related_work.restricted? && !logged_in?
+      t("related_works.index.restricted_work")
+    else
+      work_link
+    end
+  end
+
+  def related_work_title_with_byline(related_work)
     work_link = link_to related_work.title, polymorphic_url(related_work)
     creator_link = byline(related_work)
 
     if related_work.respond_to?(:unrevealed?) && related_work.unrevealed?
-      t("related_works.index.unrevealed")
+      t("related_works.index.unrevealed_work")
     elsif related_work.restricted? && !logged_in?
-      if with_byline
-        t(".#{relation}.restricted_by_html", creator_link: creator_link)
-      else
-        t(".#{relation}.restricted")
-      end
-    elsif with_byline
-      t(".#{relation}.revealed_html", work_link: work_link, creator_link: creator_link)
+      t("related_works.index.restricted_work_by_html", creator_link: creator_link)
     else
-      work_link
+      t("related_works.index.revealed_work_by_html",
+        work_link: work_link,
+        creator_link: creator_link)
+    end
+  end
+
+  def related_work_relation(related_work, relation)
+    work_link = link_to related_work.title, polymorphic_url(related_work)
+
+    if related_work.respond_to?(:unrevealed?) && related_work.unrevealed?
+      t(".#{relation}.unrevealed")
+    elsif related_work.restricted? && !logged_in?
+      t(".#{relation}.restricted")
+    else
+      t(".#{relation}.revealed_html", work_link: work_link)
     end
   end
 end

--- a/app/helpers/related_works_helper.rb
+++ b/app/helpers/related_works_helper.rb
@@ -1,0 +1,20 @@
+module RelatedWorksHelper
+  def related_work_title(related_work, with_byline: false, relation: "other_relations")
+    work_link = link_to related_work.title, polymorphic_url(related_work)
+    creator_link = byline(related_work)
+
+    if related_work.respond_to?(:unrevealed?) && related_work.unrevealed?
+      t("related_works.index.unrevealed")
+    elsif related_work.restricted? && !logged_in?
+      if with_byline
+        t(".#{relation}.restricted_by_html", creator_link: creator_link)
+      else
+        t(".#{relation}.restricted")
+      end
+    elsif with_byline
+      t(".#{relation}.revealed_html", work_link: work_link, creator_link: creator_link)
+    else
+      work_link
+    end
+  end
+end

--- a/app/views/related_works/index.html.erb
+++ b/app/views/related_works/index.html.erb
@@ -36,12 +36,9 @@
       <% if related_work.parent && related_work.work %>
       <tr>
         <% if related_work.work.unrevealed? %>
-          <td><%= t(".unrevealed") %></td>
+          <td><%= t(".unrevealed_work") %></td>
         <% else %>
-          <%# i18n-tasks-use t("related_works.index.other_relations.restricted_by_html") %>
-          <%# i18n-tasks-use t("related_works.index.other_relations.revealed_html") %>
-          <td scope="row"><%= related_work_title(related_work.work, with_byline: true) %></td>
-          <%# i18n-tasks-use t("related_works.index.other_relations.restricted") %>
+          <td scope="row"><%= related_work_title_with_byline(related_work.work) %></td>
           <td><%= related_work_title(related_work.parent) %></td>
           <td>
             <%= ts("From") %> <%= language_link(related_work.parent) %> <%= ts("to") %> <%= language_link(related_work.work) %>
@@ -81,10 +78,7 @@
     <% @translations_by_user.each do |related_work| %>
       <% if related_work.parent && related_work.work %>
         <tr>
-          <%# i18n-tasks-use t("related_works.index.other_relations.restricted_by_html") %>
-          <%# i18n-tasks-use t("related_works.index.other_relations.revealed_html") %>
-          <td scope="row"><%= related_work_title(related_work.parent, with_byline: true) %></td>
-          <%# i18n-tasks-use t("related_works.index.other_relations.restricted") %>
+          <td scope="row"><%= related_work_title_with_byline(related_work.parent) %></td>
           <td><%= related_work_title(related_work.work) %></td>
           <td>
             <%= ts("From") %> <%= language_link(related_work.parent) %> <%= ts("to") %> <%= language_link(related_work.work) %>
@@ -106,16 +100,14 @@
       <% if related_work.parent && related_work.work %>
         <dt class="child">
           <% if related_work.work.unrevealed? %>
-            <%= t(".unrevealed") %>
+            <%= t(".unrevealed_work") %>
           <% else %>
-            <%# i18n-tasks-use t("related_works.index.other_relations.restricted_by_html") %>
-            <%# i18n-tasks-use t("related_works.index.other_relations.revealed_html") %>
-            <%= related_work_title(related_work.work, with_byline: true) %>
+            <%= related_work_title_with_byline(related_work.work) %>
           </dt>
           <%# i18n-tasks-use t("related_works.index.inspired_by.restricted") %>
           <%# i18n-tasks-use t("related_works.index.inspired_by.revealed_html") %>
           <%# i18n-tasks-use t("related_works.index.inspired_by.unrevealed") %>
-          <dd class="parent"><%= related_work_title(related_work.parent, relation: "inspired_by") %>
+          <dd class="parent"><%= related_work_relation(related_work.parent, "inspired_by") %>
             <% if current_user == @user %>
               <span class="submit actions">
                 <% if related_work.reciprocal? %>
@@ -139,15 +131,13 @@
       <% unless related_work.translation? %>
         <% if related_work.parent && related_work.work %>
           <dt class="parent">
-            <%# i18n-tasks-use t("related_works.index.other_relations.restricted_by_html") %>
-            <%# i18n-tasks-use t("related_works.index.other_relations.revealed_html") %>
-            <%= related_work_title(related_work.parent, with_byline: true) %>
+            <%= related_work_title_with_byline(related_work.parent) %>
           </dt>
           <dd class="child">
             <%# i18n-tasks-use t("related_works.index.inspired.restricted") %>
             <%# i18n-tasks-use t("related_works.index.inspired.revealed_html") %>
             <%# i18n-tasks-use t("related_works.index.inspired.unrevealed") %>
-            <%= related_work_title(related_work.work, relation: "inspired") %>
+            <%= related_work_relation(related_work.work, "inspired") %>
             <% if current_user == @user %>
               <span class="actions"><%= button_to ts("Remove"), related_work_path(related_work), data: { confirm: ts("Are you sure?") }, method: :delete %></span>
             <% end %>

--- a/app/views/related_works/index.html.erb
+++ b/app/views/related_works/index.html.erb
@@ -36,10 +36,13 @@
       <% if related_work.parent && related_work.work %>
       <tr>
         <% if related_work.work.unrevealed? %>
-          <td><%= ts("A work in an unrevealed collection") %></td>
+          <td><%= t(".unrevealed") %></td>
         <% else %>
-          <td scope="row"><%= link_to related_work.work.title, related_work.work %> <%= ts("by") %> <%= byline(related_work.work) %></td>
-          <td><%= link_to related_work.parent.title, related_work.parent %></td>
+          <%# i18n-tasks-use t("related_works.index.other_relations.restricted_by_html") %>
+          <%# i18n-tasks-use t("related_works.index.other_relations.revealed_html") %>
+          <td scope="row"><%= related_work_title(related_work.work, with_byline: true) %></td>
+          <%# i18n-tasks-use t("related_works.index.other_relations.restricted") %>
+          <td><%= related_work_title(related_work.parent) %></td>
           <td>
             <%= ts("From") %> <%= language_link(related_work.parent) %> <%= ts("to") %> <%= language_link(related_work.work) %>
           </td>
@@ -78,14 +81,11 @@
     <% @translations_by_user.each do |related_work| %>
       <% if related_work.parent && related_work.work %>
         <tr>
-          <td scope="row">
-            <% if related_work.parent.is_a?(Work) && related_work.parent.unrevealed? %>
-              <%= ts("A work in an unrevealed collection") %>
-            <% else %>
-              <%= link_to related_work.parent.title, related_work.parent %> <%= ts("by") %> <%= byline(related_work.parent) %>
-            <% end %>
-          </td>
-          <td><%= link_to related_work.work.title, related_work.work %></td>
+          <%# i18n-tasks-use t("related_works.index.other_relations.restricted_by_html") %>
+          <%# i18n-tasks-use t("related_works.index.other_relations.revealed_html") %>
+          <td scope="row"><%= related_work_title(related_work.parent, with_byline: true) %></td>
+          <%# i18n-tasks-use t("related_works.index.other_relations.restricted") %>
+          <td><%= related_work_title(related_work.work) %></td>
           <td>
             <%= ts("From") %> <%= language_link(related_work.parent) %> <%= ts("to") %> <%= language_link(related_work.work) %>
           </td>
@@ -106,11 +106,16 @@
       <% if related_work.parent && related_work.work %>
         <dt class="child">
           <% if related_work.work.unrevealed? %>
-            <%= ts("A work in an unrevealed collection") %>
+            <%= t(".unrevealed") %>
           <% else %>
-            <%= link_to related_work.work.title, related_work.work %> <%= ts("by") %> <%= byline(related_work.work) %>
+            <%# i18n-tasks-use t("related_works.index.other_relations.restricted_by_html") %>
+            <%# i18n-tasks-use t("related_works.index.other_relations.revealed_html") %>
+            <%= related_work_title(related_work.work, with_byline: true) %>
           </dt>
-          <dd class="parent"><%= ts("was inspired by ") %><%= link_to related_work.parent.title, related_work.parent %>
+          <%# i18n-tasks-use t("related_works.index.inspired_by.restricted") %>
+          <%# i18n-tasks-use t("related_works.index.inspired_by.revealed_html") %>
+          <%# i18n-tasks-use t("related_works.index.inspired_by.unrevealed") %>
+          <dd class="parent"><%= related_work_title(related_work.parent, relation: "inspired_by") %>
             <% if current_user == @user %>
               <span class="submit actions">
                 <% if related_work.reciprocal? %>
@@ -134,15 +139,15 @@
       <% unless related_work.translation? %>
         <% if related_work.parent && related_work.work %>
           <dt class="parent">
-            <% if related_work.parent.is_a?(Work) && related_work.parent.unrevealed? %>
-              <%= ts("A work in an unrevealed collection") %>
-            <% else %>
-              <%= link_to related_work.parent.title, related_work.parent %> <%= ts("by") %> <%= byline(related_work.parent) %>
-            <% end %>
+            <%# i18n-tasks-use t("related_works.index.other_relations.restricted_by_html") %>
+            <%# i18n-tasks-use t("related_works.index.other_relations.revealed_html") %>
+            <%= related_work_title(related_work.parent, with_byline: true) %>
           </dt>
           <dd class="child">
-            <%= ts("inspired") %>
-            <%= link_to related_work.work.title, related_work.work %>
+            <%# i18n-tasks-use t("related_works.index.inspired.restricted") %>
+            <%# i18n-tasks-use t("related_works.index.inspired.revealed_html") %>
+            <%# i18n-tasks-use t("related_works.index.inspired.unrevealed") %>
+            <%= related_work_title(related_work.work, relation: "inspired") %>
             <% if current_user == @user %>
               <span class="actions"><%= button_to ts("Remove"), related_work_path(related_work), data: { confirm: ts("Are you sure?") }, method: :delete %></span>
             <% end %>

--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -2806,12 +2806,11 @@ en:
         restricted: was inspired by [Restricted Work] (Log in to access.)
         revealed_html: was inspired by %{work_link}
         unrevealed: was inspired by a work in an unrevealed collection
-      other_relations:
-        restricted: "[Restricted Work] (Log in to access.)"
-        restricted_by_html: "[Restricted Work] by %{creator_link} (Log in to access.)"
-        revealed_html: "%{work_link} by %{creator_link}"
       page_heading: "%{login}'s Related Works"
-      unrevealed: A work in an unrevealed collection
+      restricted_work: "[Restricted Work] (Log in to access.)"
+      restricted_work_by_html: "[Restricted Work] by %{creator_link} (Log in to access.)"
+      revealed_work_by_html: "%{work_link} by %{creator_link}"
+      unrevealed_work: A work in an unrevealed collection
   series:
     series_module:
       hidden_by_admin_alt: "(Hidden by Admin)"

--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -2798,7 +2798,20 @@ en:
         page_heading: Marked for Later
   related_works:
     index:
+      inspired:
+        restricted: inspired [Restricted Work] (Log in to access.)
+        revealed_html: inspired %{work_link}
+        unrevealed: inspired a work in an unrevealed collection
+      inspired_by:
+        restricted: was inspired by [Restricted Work] (Log in to access.)
+        revealed_html: was inspired by %{work_link}
+        unrevealed: was inspired by a work in an unrevealed collection
+      other_relations:
+        restricted: "[Restricted Work] (Log in to access.)"
+        restricted_by_html: "[Restricted Work] by %{creator_link} (Log in to access.)"
+        revealed_html: "%{work_link} by %{creator_link}"
       page_heading: "%{login}'s Related Works"
+      unrevealed: A work in an unrevealed collection
   series:
     series_module:
       hidden_by_admin_alt: "(Hidden by Admin)"

--- a/features/works/work_related.feature
+++ b/features/works/work_related.feature
@@ -330,7 +330,7 @@ Scenario: External work language
 # especially during posting / editing / previewing a work
 # especially from the related_works page, which works but redirects to a non-existant page right now
 
-Scenario: Restricted works listed as Inspiration show up [Restricted] for guests
+Scenario: Restricted works listed as Inspiration show up [Restricted] for guests on work pages
   Given I have related works setup
     And a related work has been posted and approved
   When I am logged in as "remixer"
@@ -348,6 +348,34 @@ Scenario: Restricted works listed as Inspiration show up [Restricted] for guests
   When I am logged out
     And I view the work "Followup"
   Then I should see "Inspired by [Restricted Work] by inspiration"
+
+Scenario: Restricted works show up [Restricted] for guests on Related Works pages
+  Given I have related works setup
+    And a related work has been posted and approved
+    And a translation has been posted and approved
+  When I am logged in as "inspiration"
+    And I lock the work "Worldbuilding"
+  When I am logged in as "remixer"
+    And I lock the work "Followup"
+  When I am logged in as "translator"
+    And I lock the work "Worldbuilding Translated"
+  When I am logged out
+    And I go to inspiration's related works page
+  Then I should see "[Restricted Work] by remixer"
+    And I should see "[Restricted Work] by translator"
+    And I should see "[Restricted Work] (Log in to access.)" within "table#translationsofme"
+    And I should see "was inspired by [Restricted Work]"
+    And I should not see "Worldbuilding"
+    And I should not see "Followup"
+  When I go to remixer's related works page
+  Then I should see "[Restricted Work] by inspiration"
+    And I should see "inspired [Restricted Work]"
+    And I should not see "Worldbuilding"
+    And I should not see "Followup"
+  When I go to translator's related works page
+  Then I should see "[Restricted Work] by inspiration"
+    And I should see "[Restricted Work] (Log in to access.)" within "table#translationsbyme"
+    And I should not see "Worldbuilding"
 
 Scenario: Anonymous works listed as inspiration should have links to the authors,
   but only for the authors themselves and admins


### PR DESCRIPTION
## Pull Request Checklist

<!-- Mark steps in the checklist as complete by changing `[ ]` to `[X]` -->
* [x] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [x] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [x] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [x] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

[AO3-5550](https://otwarchive.atlassian.net/browse/AO3-5550)

## Purpose

Makes it so guests can't see titles and links of restricted works on related works pages

## Credit

slavalamp

[AO3-5550]: https://otwarchive.atlassian.net/browse/AO3-5550?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ