### PR TITLE
AO3-7379 Add delimiters to collection blurb stats numbers

### DIFF
--- a/app/views/collections/_collection_blurb.html.erb
+++ b/app/views/collections/_collection_blurb.html.erb
@@ -42,17 +42,17 @@
     <!--stats-->
     <dl class="stats">
       <% if (@challenges_count = collection.children.count) > 0 %>
-        <dt class="collections"><%= ts("Challenges/Subcollections:") %></dt>
+        <dt class="collections"><%= t(".challenges_subcollections") %></dt>
         <dd class="collections"><%= link_to(@challenges_count, collection_collections_path(collection)) %></dd>
       <% end %>
       <% if collection.challenge? && collection.prompt_meme? %>
-        <dt class="prompts"><%= ts("Prompts:") %></dt>
+        <dt class="prompts"><%= t(".prompts") %></dt>
         <dd class="prompts"><%= link_to(collection.prompts.count.to_s, collection_requests_path(collection)) %></dd>
       <% end %>
-      <dt class="works"><%= ts("Works:") %></dt>
+      <dt class="works"><%= t(".works") %></dt>
       <dd class="works"><%= link_to(collection.approved_works_count, collection_works_path(collection)) %></dd>
       <% if (@bookmarks_count = collection.approved_bookmarked_items_count) > 0 %>
-        <dt class="bookmarks"><%= ts("Bookmarked Items:") %></dt>
+        <dt class="bookmarks"><%= t(".bookmarked_items") %></dt>
         <dd class="bookmarks"><%= link_to(@bookmarks_count, collection_bookmarks_path(collection)) %></dd>
       <% end %>
     </dl>

--- a/app/views/collections/_collection_blurb.html.erb
+++ b/app/views/collections/_collection_blurb.html.erb
@@ -43,17 +43,17 @@
     <dl class="stats">
       <% if (@challenges_count = collection.children.count) > 0 %>
         <dt class="collections"><%= t(".challenges_subcollections") %></dt>
-        <dd class="collections"><%= link_to(@challenges_count, collection_collections_path(collection)) %></dd>
+        <dd class="collections"><%= link_to(number_with_delimiter(@challenges_count), collection_collections_path(collection)) %></dd>
       <% end %>
       <% if collection.challenge? && collection.prompt_meme? %>
         <dt class="prompts"><%= t(".prompts") %></dt>
-        <dd class="prompts"><%= link_to(collection.prompts.count.to_s, collection_requests_path(collection)) %></dd>
+        <dd class="prompts"><%= link_to(number_with_delimiter(collection.prompts.count), collection_requests_path(collection)) %></dd>
       <% end %>
       <dt class="works"><%= t(".works") %></dt>
-      <dd class="works"><%= link_to(collection.approved_works_count, collection_works_path(collection)) %></dd>
+      <dd class="works"><%= link_to(number_with_delimiter(collection.approved_works_count), collection_works_path(collection)) %></dd>
       <% if (@bookmarks_count = collection.approved_bookmarked_items_count) > 0 %>
         <dt class="bookmarks"><%= t(".bookmarked_items") %></dt>
-        <dd class="bookmarks"><%= link_to(@bookmarks_count, collection_bookmarks_path(collection)) %></dd>
+        <dd class="bookmarks"><%= link_to(number_with_delimiter(@bookmarks_count), collection_bookmarks_path(collection)) %></dd>
       <% end %>
     </dl>
 

--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -771,9 +771,13 @@ en:
         collection_tags: 'Collection tags:'
   collections:
     collection_blurb:
+      bookmarked_items: 'Bookmarked Items:'
       collection_tags: 'Collection Tags:'
+      challenges_subcollections: 'Challenges/Subcollections:'
+      prompts: 'Prompts:'
       signups_close_at: 'Sign-ups close at:'
       summary: Summary
+      works: 'Works:'
     filters:
       clear_filters: Clear Filters
       closed:

--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -772,8 +772,8 @@ en:
   collections:
     collection_blurb:
       bookmarked_items: 'Bookmarked Items:'
-      collection_tags: 'Collection Tags:'
       challenges_subcollections: 'Challenges/Subcollections:'
+      collection_tags: 'Collection Tags:'
       prompts: 'Prompts:'
       signups_close_at: 'Sign-ups close at:'
       summary: Summary


### PR DESCRIPTION
# Pull Request Checklist

<!-- Mark steps in the checklist as complete by changing `[ ]` to `[X]` -->
* [x] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [x] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [x] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [x] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-7379

## Purpose

Add comma-delimiters to numbers in the collection blurbs (subcollections, prompts, works and/or bookmarked items).

Also converted some related text to use the `t()` method.

## Testing Instructions

Testing instructions on ticket.

Please note I was unsure how to test this myself in development (without manually creating thousands of works/prompts etc 😅). I have matched my changes to the use of the `number_with_delimiter` method elsewhere.

## Credit

bre-nana (she/they/he)
