### PR TITLE
AO3-7398 Add username to Challenge Sign-Ups browser page title

### DIFF
--- a/app/controllers/challenge_signups_controller.rb
+++ b/app/controllers/challenge_signups_controller.rb
@@ -85,6 +85,7 @@ class ChallengeSignupsController < ApplicationController
     if params[:user_id] && (@user = User.find_by(login: params[:user_id]))
       if current_user == @user
         @challenge_signups = @user.challenge_signups.order_by_date
+        @page_subtitle = t(".page_title", username: @user.login)
         render action: :index and return
       else
         flash[:error] = ts("You aren't allowed to see that user's sign-ups.")

--- a/config/locales/controllers/en.yml
+++ b/config/locales/controllers/en.yml
@@ -114,10 +114,10 @@ en:
     index:
       page_title: "%{username} - Challenge Claims"
   challenge_signups:
-    new:
-      page_title: New Challenge Sign-up
     index:
       page_title: "%{username} - Challenge Sign-ups"
+    new:
+      page_title: New Challenge Sign-up
   chapters:
     destroy:
       only_chapter: You can't delete the only chapter in your work. If you want to delete the work, choose "Delete Work".

--- a/config/locales/controllers/en.yml
+++ b/config/locales/controllers/en.yml
@@ -116,6 +116,8 @@ en:
   challenge_signups:
     new:
       page_title: New Challenge Sign-up
+    index:
+      page_title: "%{username} - Challenge Sign-ups"
   chapters:
     destroy:
       only_chapter: You can't delete the only chapter in your work. If you want to delete the work, choose "Delete Work".

--- a/spec/controllers/challenge_signups_controller_spec.rb
+++ b/spec/controllers/challenge_signups_controller_spec.rb
@@ -81,6 +81,14 @@ describe ChallengeSignupsController do
       it_redirects_to_with_error(closed_collection,
                                  "You aren't allowed to see the CSV summary.")
     end
+
+    context "when user visits their own sign-ups" do
+      it "sets the page subtitle correctly" do
+        fake_login_known_user(user)
+        get :index, params: { user_id: user.login }
+        expect(assigns(:page_subtitle)).to eq("#{user.login} - Challenge Sign-ups")
+      end
+    end
   end
 
   describe "destroy" do


### PR DESCRIPTION
# Pull Request Checklist

<!-- Mark steps in the checklist as complete by changing `[ ]` to `[X]` -->
* [x] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [x] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [x] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [x] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-7398

## Purpose

This PR fixes the browser page title for "Challenge Sign-Ups" to include the username of the logged in user if the user is looking at their own sign-up page (based on my understanding of the existing code a user should only be able to look at their own sign-ups page, but let me know if I've misinterpreted this.)

<img width="1920" height="967" alt="Screenshot 2026-05-04 at 3 26 42 PM" src="https://github.com/user-attachments/assets/c6c47a2c-da76-41ee-b88c-18db2e6302e4" />



## Credit

lynn (she/her) - but my username is also fine! thanks :-)