### PR TITLE
AO3-7394 If tag name is in error state, display old name instead

### DIFF
--- a/app/helpers/tags_helper.rb
+++ b/app/helpers/tags_helper.rb
@@ -55,7 +55,7 @@ module TagsHelper
     display_name = tag.errors.has_key?(:name) ? tag.name_was : tag.display_name
     link_to_tag_with_text(tag, display_name, options)
   end
-  
+
   def link_to_tag_works(tag, options = {})
     link_to_tag_works_with_text(tag, tag.display_name, options)
   end

--- a/app/helpers/tags_helper.rb
+++ b/app/helpers/tags_helper.rb
@@ -52,9 +52,10 @@ module TagsHelper
   end
 
   def link_to_tag(tag, options = {})
-    link_to_tag_with_text(tag, tag.display_name, options)
+    display_name = tag.errors.has_key?(:name) ? tag.name_was : tag.display_name
+    link_to_tag_with_text(tag, display_name, options)
   end
-
+  
   def link_to_tag_works(tag, options = {})
     link_to_tag_works_with_text(tag, tag.display_name, options)
   end

--- a/app/helpers/tags_helper.rb
+++ b/app/helpers/tags_helper.rb
@@ -52,7 +52,7 @@ module TagsHelper
   end
 
   def link_to_tag(tag, options = {})
-    display_name = tag.errors.has_key?(:name) ? tag.name_was : tag.display_name
+    display_name = tag.errors.key?(:name) ? tag.name_was : tag.display_name
     link_to_tag_with_text(tag, display_name, options)
   end
 

--- a/features/tags_and_wrangling/tag_wrangling_special.feature
+++ b/features/tags_and_wrangling/tag_wrangling_special.feature
@@ -39,6 +39,7 @@ Feature: Tag Wrangling - special cases
   When I fill in "Name" with "Amelia"
     And I press "Save changes"
   Then I should see "Name can only be changed by an admin."
+    And I should see "Edit Amelie Tag"
 
   Scenario: Change capitalisation of a tag
 


### PR DESCRIPTION
# Pull Request Checklist

<!-- Mark steps in the checklist as complete by changing `[ ]` to `[X]` -->
* [x] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [x] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [x] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [x] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-7394

## Purpose

When editing tag, if tag name is invalid, display old, valid name instead.

## Credit
mellowmarsach