### PR TITLE
AO3-5713 fix tag set fandom only validation

### DIFF
--- a/app/models/prompt.rb
+++ b/app/models/prompt.rb
@@ -175,6 +175,13 @@ class Prompt < ApplicationRecord
 
       # tag_type is one of a set set so we know it is safe for constantize
       allowed_tags = tag_type.classify.constantize.with_parents(tag_set.fandom_taglist).canonical
+
+      if restriction.send("#{tag_type}_restrict_to_tag_set")
+        allowed_tags = allowed_tags.where(
+          id: tag_set_associations.where(parent_tag_id: tag_set.fandom_taglist).select(:tag_id)
+        )
+      end
+
       disallowed_taglist = tag_set ? tag_set.send("#{tag_type}_taglist") - allowed_tags : []
 
       # check for tag set associations

--- a/spec/models/prompt_spec.rb
+++ b/spec/models/prompt_spec.rb
@@ -43,5 +43,65 @@ describe Prompt do
         expect(prompt.errors[:base][0]).to include("not in the selected fandom")
       end
     end
+
+    context "when restrict_to_fandom and restrict_to_tag_set are both enabled" do
+      let(:fandom_character) { create(:character, canonical: true) }
+
+      before do
+        create(:common_tagging, filterable: fandom, common_tag: fandom_character)
+        create(:common_tagging, filterable: fandom, common_tag: non_fandom_character)
+        create(:tag_set_association, tag: fandom_character, parent_tag: fandom, owned_tag_set: owned_tag_set)
+      end
+
+      let!(:challenge) do
+        create(:gift_exchange,
+               offer_restriction: create(:prompt_restriction,
+                                         character_restrict_to_fandom: true,
+                                         character_restrict_to_tag_set: true,
+                                         owned_tag_sets: [owned_tag_set]))
+      end
+
+      it "marks the prompt as valid when the character is in the tag set" do
+        prompt = build(:offer,
+                       tag_set: create(:tag_set, tags: [fandom, fandom_character]),
+                       collection_id: collection.id,
+                       challenge_signup: create(:challenge_signup))
+        expect(prompt).to be_valid
+      end
+
+      it "marks the prompt as invalid when the character is canonical in the fandom but not in the tag set" do
+        other_character = create(:character, canonical: true)
+        create(:common_tagging, filterable: fandom, common_tag: other_character)
+        prompt = build(:offer,
+                       tag_set: create(:tag_set, tags: [fandom, other_character]),
+                       collection_id: collection.id,
+                       challenge_signup: create(:challenge_signup))
+        expect(prompt).not_to be_valid
+      end
+    end
+
+    context "when only restrict_to_fandom is enabled (not restrict_to_tag_set)" do
+      let(:fandom_character) { create(:character, canonical: true) }
+
+      before do
+        create(:common_tagging, filterable: fandom, common_tag: fandom_character)
+      end
+
+      let!(:challenge) do
+        create(:gift_exchange,
+               offer_restriction: create(:prompt_restriction,
+                                         character_restrict_to_fandom: true,
+                                         character_restrict_to_tag_set: false,
+                                         owned_tag_sets: [owned_tag_set]))
+      end
+
+      it "marks the prompt as valid when the character is canonical in the fandom even if not in the tag set" do
+        prompt = build(:offer,
+                       tag_set: create(:tag_set, tags: [fandom, fandom_character]),
+                       collection_id: collection.id,
+                       challenge_signup: create(:challenge_signup))
+        expect(prompt).to be_valid
+      end
+    end
   end
 end

--- a/spec/models/prompt_spec.rb
+++ b/spec/models/prompt_spec.rb
@@ -46,19 +46,18 @@ describe Prompt do
 
     context "when restrict_to_fandom and restrict_to_tag_set are both enabled" do
       let(:fandom_character) { create(:character, canonical: true) }
-
-      before do
-        create(:common_tagging, filterable: fandom, common_tag: fandom_character)
-        create(:common_tagging, filterable: fandom, common_tag: non_fandom_character)
-        create(:tag_set_association, tag: fandom_character, parent_tag: fandom, owned_tag_set: owned_tag_set)
-      end
-
       let!(:challenge) do
         create(:gift_exchange,
                offer_restriction: create(:prompt_restriction,
                                          character_restrict_to_fandom: true,
                                          character_restrict_to_tag_set: true,
                                          owned_tag_sets: [owned_tag_set]))
+      end
+
+      before do
+        create(:common_tagging, filterable: fandom, common_tag: fandom_character)
+        create(:common_tagging, filterable: fandom, common_tag: non_fandom_character)
+        create(:tag_set_association, tag: fandom_character, parent_tag: fandom, owned_tag_set: owned_tag_set)
       end
 
       it "marks the prompt as valid when the character is in the tag set" do
@@ -84,17 +83,16 @@ describe Prompt do
 
     context "when only restrict_to_fandom is enabled (not restrict_to_tag_set)" do
       let(:fandom_character) { create(:character, canonical: true) }
-
-      before do
-        create(:common_tagging, filterable: fandom, common_tag: fandom_character)
-      end
-
       let!(:challenge) do
         create(:gift_exchange,
                offer_restriction: create(:prompt_restriction,
                                          character_restrict_to_fandom: true,
                                          character_restrict_to_tag_set: false,
                                          owned_tag_sets: [owned_tag_set]))
+      end
+
+      before do
+        create(:common_tagging, filterable: fandom, common_tag: fandom_character)
       end
 
       it "marks the prompt as valid when the character is canonical in the fandom even if not in the tag set" do

--- a/spec/models/prompt_spec.rb
+++ b/spec/models/prompt_spec.rb
@@ -62,20 +62,22 @@ describe Prompt do
       end
 
       it "marks the prompt as valid when the character is in the tag set" do
+        signup = build(:challenge_signup, collection: collection)
         prompt = build(:offer,
                        tag_set: create(:tag_set, tags: [fandom, fandom_character]),
                        collection_id: collection.id,
-                       challenge_signup: create(:challenge_signup))
+                       challenge_signup: signup)
         expect(prompt).to be_valid
       end
 
       it "marks the prompt as invalid when the character is canonical in the fandom but not in the tag set" do
         other_character = create(:character, canonical: true)
         create(:common_tagging, filterable: fandom, common_tag: other_character)
+        signup = build(:challenge_signup, collection: collection)
         prompt = build(:offer,
                        tag_set: create(:tag_set, tags: [fandom, other_character]),
                        collection_id: collection.id,
-                       challenge_signup: create(:challenge_signup))
+                       challenge_signup: signup)
         expect(prompt).not_to be_valid
       end
     end
@@ -96,10 +98,11 @@ describe Prompt do
       end
 
       it "marks the prompt as valid when the character is canonical in the fandom even if not in the tag set" do
+        signup = build(:challenge_signup, collection: collection)
         prompt = build(:offer,
                        tag_set: create(:tag_set, tags: [fandom, fandom_character]),
                        collection_id: collection.id,
-                       challenge_signup: create(:challenge_signup))
+                       challenge_signup: signup)
         expect(prompt).to be_valid
       end
     end


### PR DESCRIPTION
  # Pull Request Checklist

  * [X] Have you read ["How to write the perfect pull  request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
  * [X] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
  * [X] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
  * [X] Have you added the [Jira](https://otwarchive.atlassian.net) issue number as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
  * [X] Do you have fewer than 5 pull requests already open? If not, please wait until they are reviewed and merged before creating new pull requests.

  ## Issue

  https://otwarchive.atlassian.net/browse/AO3-5713

  ## Purpose

  The "Tag set fandom only?" option (`character_restrict_to_tag_set` / `relationship_restrict_to_tag_set`) on challenge prompt restrictions only controls the autocomplete suggestions in the signup form, but does not actually validate on the server side. Users can bypass the autocomplete by typing a tag name manually and submit characters or relationships that are canonical in the fandom but not in the tag set.

  This PR adds server-side validation in `Prompt#restricted_tags` so that when `restrict_to_tag_set` is enabled, allowed tags are further filtered to only those present in the tag set associations for the selected fandom. It reuses the `tag_set_associations` scope already set up by the AO3-5712 fix.

  ## Testing Instructions

  1. Create a gift exchange collection with a tag set that has a fandom and a few characters associated to that fandom.
  2. In the challenge settings, enable both "Restrict characters to fandom?" and "Tag set fandom only?" for offers.
  3. Sign up for the challenge. In the offer, select the fandom.
  4. Try to manually type a character that is canonical in the fandom but **not** in the tag set.
  5. **Expected**: The signup should fail validation with an error that the character is not in the selected fandom's tag set.
  6. Now type a character that **is** in the tag set for that fandom.
  7. **Expected**: The signup should be valid.
  8. Disable "Tag set fandom only?" and repeat — characters canonical in the fandom but not in the tag set should now be accepted.

  ## Credit

  Pablo Monfort (he/him)