### PR TITLE
AO3-7414 Display error messages for multi-URL import

### DIFF
--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -539,7 +539,8 @@ class WorksController < ApplicationController
     unless failed_urls.empty?
       error_msgs = (0...failed_urls.length).map do |index|
         # each failed url may have multiple errors, so show them in a bulleted list underneath the url
-        errors_per_url = errors[index].map { |error| "<li>#{error}</li>" }.join("\n")
+        errors_per_url = errors[index].map { |error| "<li>#{error}</li>" }
+                                      .join("\n")
         "<dt>#{failed_urls[index]}</dt><ul>#{errors_per_url}</ul>"
       end.join("\n")
       flash.now[:error] = "<h3>#{ts('Failed Imports')}</h3><dl>#{error_msgs}</dl>".html_safe

--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -540,7 +540,7 @@ class WorksController < ApplicationController
       error_msgs = (0...failed_urls.length).map do |index|
         # each failed url may have multiple errors, so show them in a bulleted list underneath the url
         errors_per_url = errors[index].map { |error| "<li>#{error}</li>" }
-                                      .join("\n")
+          .join("\n")
         "<dt>#{failed_urls[index]}</dt><ul>#{errors_per_url}</ul>"
       end.join("\n")
       flash.now[:error] = "<h3>#{ts('Failed Imports')}</h3><dl>#{error_msgs}</dl>".html_safe

--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -537,7 +537,11 @@ class WorksController < ApplicationController
 
     # collect the errors neatly, matching each error to the failed url
     unless failed_urls.empty?
-      error_msgs = 0.upto(failed_urls.length).map { |index| "<dt>#{failed_urls[index]}</dt><dd>#{errors[index]}</dd>" }.join("\n")
+      error_msgs = (0...failed_urls.length).map do |index|
+        # each failed url may have multiple errors, so show them in a bulleted list underneath the url
+        errors_per_url = errors[index].map { |error| "<li>#{error}</li>" }.join("\n")
+        "<dt>#{failed_urls[index]}</dt><ul>#{errors_per_url}</ul>"
+      end.join("\n")
       flash.now[:error] = "<h3>#{ts('Failed Imports')}</h3><dl>#{error_msgs}</dl>".html_safe
     end
 

--- a/app/models/story_parser.rb
+++ b/app/models/story_parser.rb
@@ -178,7 +178,7 @@ class StoryParser
           works << work
         else
           failed_urls << url
-          errors << work.errors.values.join(", ")
+          errors << work.errors.full_messages
           work.delete if work
         end
       rescue Timeout::Error

--- a/spec/controllers/works/works_controller_spec.rb
+++ b/spec/controllers/works/works_controller_spec.rb
@@ -41,17 +41,17 @@ describe WorksController do
         expect(controller).to receive(:render).with(:new_import)
         controller.send(:import_multiple, urls, {})
         expect(flash[:error]).to eq(
-          "<h3>Failed Imports</h3>" +
-          "<dl>" +
-          "<dt>https://www.failedurl1.com</dt>" +
-          "<ul>" +
-          "<li>failedurl1 first error</li>\n" +
-          "<li>failedurl1 second error</li>" +
-          "</ul>\n" +
-          "<dt>https://www.failedurl2.com</dt>" +
-          "<ul>" +
-          "<li>failedurl2 first error</li>" +
-          "</ul>" +
+          "<h3>Failed Imports</h3>" \
+          "<dl>" \
+          "<dt>https://www.failedurl1.com</dt>" \
+          "<ul>" \
+          "<li>failedurl1 first error</li>\n" \
+          "<li>failedurl1 second error</li>" \
+          "</ul>\n" \
+          "<dt>https://www.failedurl2.com</dt>" \
+          "<ul>" \
+          "<li>failedurl2 first error</li>" \
+          "</ul>" \
           "</dl>"
        )
       end

--- a/spec/controllers/works/works_controller_spec.rb
+++ b/spec/controllers/works/works_controller_spec.rb
@@ -37,7 +37,7 @@ describe WorksController do
       end
       let(:urls) { ["https://www.failedurl1.com", "https://www.failedurl2.com"] }
 
-      it 'returns a well-formatted error message' do
+      it "returns a well-formatted error message" do
         expect(controller).to receive(:render).with(:new_import)
         controller.send(:import_multiple, urls, {})
         expect(flash[:error]).to eq(
@@ -53,7 +53,7 @@ describe WorksController do
           "<li>failedurl2 first error</li>" \
           "</ul>" \
           "</dl>"
-       )
+        )
       end
     end
   end

--- a/spec/controllers/works/works_controller_spec.rb
+++ b/spec/controllers/works/works_controller_spec.rb
@@ -24,4 +24,37 @@ describe WorksController do
       end
     end
   end
+
+  describe ".import_multiple" do
+    context "when the import has a failure from at least one URL" do
+      before do
+        allow_any_instance_of(StoryParser).to receive(:import_from_urls).and_return([
+          [],
+          urls,
+          [["failedurl1 first error", "failedurl1 second error"], ["failedurl2 first error"]]
+        ])
+        allow(controller).to receive(:render).with(:new_import)
+      end
+      let(:urls) { ["https://www.failedurl1.com", "https://www.failedurl2.com"] }
+
+      it 'returns a well-formatted error message' do
+        expect(controller).to receive(:render).with(:new_import)
+        controller.send(:import_multiple, urls, {})
+        expect(flash[:error]).to eq(
+          "<h3>Failed Imports</h3>" +
+          "<dl>" +
+          "<dt>https://www.failedurl1.com</dt>" +
+          "<ul>" +
+          "<li>failedurl1 first error</li>\n" +
+          "<li>failedurl1 second error</li>" +
+          "</ul>\n" +
+          "<dt>https://www.failedurl2.com</dt>" +
+          "<ul>" +
+          "<li>failedurl2 first error</li>" +
+          "</ul>" +
+          "</dl>"
+       )
+      end
+    end
+  end
 end


### PR DESCRIPTION
# Pull Request Checklist

<!-- Mark steps in the checklist as complete by changing `[ ]` to `[X]` -->
* [x] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [x] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [x] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [x] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-7414

## Purpose

This PR fixes an issue on the import page where if any URL in the list of URLs has an error, clicking 'Import' would return a 500. Now a red pop-up will appear indicating the errors that occurred for each URL that was imported. Some formatting changes were made as well so that an array of errors for a single URL is formatted as a list, similar to `ValidationHelper.error_messages_formatted`.

Before: 500

After (all URLs had errors):
<img width="1899" height="663" alt="Screenshot 2026-05-07 at 4 11 47 PM" src="https://github.com/user-attachments/assets/410cea78-c590-4d2b-a08f-e1441addfa3e" />

After (some URLs had errors):
<img width="1874" height="338" alt="Screenshot 2026-05-07 at 2 05 04 PM" src="https://github.com/user-attachments/assets/649010ba-686b-44e8-9a98-e0aca984105d" />

After (a URL doesn't have corresponding error messages):
<img width="1871" height="110" alt="Screenshot 2026-05-07 at 2 02 11 PM" src="https://github.com/user-attachments/assets/46934984-893a-4426-8aa7-7772597480a0" />

## Credit

lynn (she/her)
