### PR TITLE
AO3-7413 Unify new external bookmark page naming

### DIFF
--- a/app/controllers/external_works_controller.rb
+++ b/app/controllers/external_works_controller.rb
@@ -4,7 +4,7 @@ class ExternalWorksController < ApplicationController
   before_action :check_user_status, only: [:new]
 
   def new
-    @page_subtitle = ts("Bookmark External Work")
+    @page_subtitle = t(".page_title")
     @bookmarkable = ExternalWork.new
     @bookmark = Bookmark.new
   end

--- a/app/controllers/external_works_controller.rb
+++ b/app/controllers/external_works_controller.rb
@@ -4,6 +4,7 @@ class ExternalWorksController < ApplicationController
   before_action :check_user_status, only: [:new]
 
   def new
+    @page_subtitle = ts("Bookmark External Work")
     @bookmarkable = ExternalWork.new
     @bookmark = Bookmark.new
   end

--- a/app/views/external_works/new.html.erb
+++ b/app/views/external_works/new.html.erb
@@ -1,2 +1,2 @@
-<h2 class="heading"><%= ts("Bookmark an external work") %></h2>
+<h2 class="heading"><%= ts("Bookmark External Work") %></h2>
 <%= render 'bookmarks/bookmark_form', :bookmarkable => @bookmarkable, :bookmark => @bookmark, :button_name => ts("Create"), :action => 'create' %>

--- a/app/views/external_works/new.html.erb
+++ b/app/views/external_works/new.html.erb
@@ -1,2 +1,2 @@
-<h2 class="heading"><%= ts("Bookmark External Work") %></h2>
+<h2 class="heading"><%= t(".page_heading") %></h2>
 <%= render 'bookmarks/bookmark_form', :bookmarkable => @bookmarkable, :bookmark => @bookmark, :button_name => ts("Create"), :action => 'create' %>

--- a/config/locales/controllers/en.yml
+++ b/config/locales/controllers/en.yml
@@ -203,6 +203,8 @@ en:
     timeout_error:
       browser_title: Timeout Error
   external_works:
+    new:
+      page_title: Bookmark External Work
     update:
       successfully_updated: External work was successfully updated.
   fandoms:

--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -1078,7 +1078,6 @@ en:
       works_languages_help_title: Languages help
     new:
       page_heading: Bookmark External Work
-      page_title: Bookmark External Work
     notice: This work isn't hosted on the Archive so this blurb might not be complete or accurate.
   fandoms:
     index:

--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -1076,10 +1076,10 @@ en:
   external_works:
     edit:
       works_languages_help_title: Languages help
-    notice: This work isn't hosted on the Archive so this blurb might not be complete or accurate.
     new:
-      page_title: Bookmark External Work
       page_heading: Bookmark External Work
+      page_title: Bookmark External Work
+    notice: This work isn't hosted on the Archive so this blurb might not be complete or accurate.
   fandoms:
     index:
       page_heading: Fandoms

--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -1077,6 +1077,9 @@ en:
     edit:
       works_languages_help_title: Languages help
     notice: This work isn't hosted on the Archive so this blurb might not be complete or accurate.
+    new:
+      page_title: Bookmark External Work
+      page_heading: Bookmark External Work
   fandoms:
     index:
       page_heading: Fandoms

--- a/features/bookmarks/bookmark_external.feature
+++ b/features/bookmarks/bookmark_external.feature
@@ -210,3 +210,8 @@ Feature: Create bookmarks of external works
     When I follow "A Work Not Posted To The AO3"
     Then I should see "This work isn't hosted on the Archive"
       And I should see a link to "https://example.com/external_work" within "h4"
+
+  Scenario: A user should see the correct title on the external bookmark page
+    Given I am logged in as "bookmarker"
+    When I am on the new external work page
+    Then I should see the page title "Bookmark External Work"


### PR DESCRIPTION
# Pull Request Checklist

<!-- Mark steps in the checklist as complete by changing `[ ]` to `[X]` -->
* [x] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [x] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [x] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [x] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-7413

## Purpose

What does this PR do?

Unifies page title and header naming, when creating a new External Work Bookmark.

## Testing Instructions

Log in

Hi, username! > My Dashboard > Bookmarks > Bookmark External Work

The page tile on the browser tab should say: Bookmark External Work | Archive of Our Own.
The header (`h2`) should say: Bookmark External Work



## Credit
 gemmie she/her

