### PR TITLE
AO3-7219 persist work preference after comment

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -436,7 +436,7 @@ class CommentsController < ApplicationController
             elsif @comment.unreviewed?
               redirect_to_all_comments(@commentable)
             else
-              redirect_to_comment(@comment, { view_full_work: (params[:view_full_work] == "true"), page: params[:page] })
+              redirect_to_comment(@comment, {  page: params[:page] })
             end
           end
         end
@@ -733,6 +733,10 @@ class CommentsController < ApplicationController
   def redirect_to_all_comments(commentable, options = {})
     default_options = {anchor: "comments"}
     options = default_options.merge(options)
+    # If the user is coming from the chapter view (i.e. referrer is /chapters/:id)
+    # then stay in chapter view. Otherwise, go to user preference
+    is_coming_from_chapter_view = request.referer&.match(/chapter/).present?
+    view_full_work = !is_coming_from_chapter_view || current_user.try(:preference).try(:view_full_work)
 
     if commentable.is_a?(Tag)
       redirect_to comments_path(tag_id: commentable.to_param,
@@ -741,16 +745,16 @@ class CommentsController < ApplicationController
                   page: options[:page],
                   anchor: options[:anchor])
     else
-      if commentable.is_a?(Chapter) && (options[:view_full_work] || current_user.try(:preference).try(:view_full_works))
+      if commentable.is_a?(Chapter) && view_full_work
         commentable = commentable.work
       end
       redirect_to polymorphic_path(commentable,
                                    options.slice(:show_comments,
                                                  :add_comment_reply_id,
                                                  :delete_comment_id,
-                                                 :view_full_work,
                                                  :anchor,
-                                                 :page))
+                                                 :page)
+                                          .merge({view_full_work:}))
     end
   end
 

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -614,7 +614,6 @@ class CommentsController < ApplicationController
         # so we're being extra-nice and preserving any intention to comment along with the show comments option
         options = {show_comments: true}
         options[:add_comment_reply_id] = params[:add_comment_reply_id] if params[:add_comment_reply_id]
-        options[:view_full_work] = params[:view_full_work] if params[:view_full_work]
         options[:page] = params[:page]
         redirect_to_all_comments(@commentable, options)
       end
@@ -644,7 +643,6 @@ class CommentsController < ApplicationController
         options[:controller] = @commentable.class.to_s.underscore.pluralize
         options[:anchor] = "comment_#{params[:id]}"
         options[:page] = params[:page]
-        options[:view_full_work] = params[:view_full_work]
         if @thread_view
           options[:id] = @thread_root
           options[:add_comment_reply_id] = params[:id]

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -733,10 +733,6 @@ class CommentsController < ApplicationController
   def redirect_to_all_comments(commentable, options = {})
     default_options = {anchor: "comments"}
     options = default_options.merge(options)
-    # If the user is coming from the chapter view (i.e. referrer is /chapters/:id)
-    # then stay in chapter view. Otherwise, go to user preference
-    is_coming_from_chapter_view = request.referer&.match(/chapter/).present?
-    view_full_work = !is_coming_from_chapter_view || current_user.try(:preference).try(:view_full_work)
 
     if commentable.is_a?(Tag)
       redirect_to comments_path(tag_id: commentable.to_param,
@@ -745,6 +741,15 @@ class CommentsController < ApplicationController
                   page: options[:page],
                   anchor: options[:anchor])
     else
+      is_coming_from_chapter_view = request.referer&.match(/chapters/).present?
+      is_not_coming_from_work_view = request.referer&.match(/works/).nil?
+      view_full_work = if is_coming_from_chapter_view
+                         false
+                       elsif is_not_coming_from_work_view
+                         current_user.try(:preference).try(:view_full_works).present?
+                       else
+                         true
+                       end
       if commentable.is_a?(Chapter) && view_full_work
         commentable = commentable.work
       end
@@ -754,7 +759,10 @@ class CommentsController < ApplicationController
                                                  :delete_comment_id,
                                                  :anchor,
                                                  :page)
-                                          .merge({view_full_work:}))
+                                   # we don't actually use params[:view_full_work] within
+                                   # the comments controller anymore.
+                                   # still pass to the redirect since it is referred to elsewhere
+                                          .merge({view_full_work: params[:view_full_work]}))
     end
   end
 

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -436,7 +436,7 @@ class CommentsController < ApplicationController
             elsif @comment.unreviewed?
               redirect_to_all_comments(@commentable)
             else
-              redirect_to_comment(@comment, {  page: params[:page] })
+              redirect_to_comment(@comment, { page: params[:page] })
             end
           end
         end
@@ -704,40 +704,40 @@ class CommentsController < ApplicationController
   # if necessary to display it
   def redirect_to_comment(comment, options = {})
     if comment.depth > ArchiveConfig.COMMENT_THREAD_MAX_DEPTH
-      if comment.ultimate_parent.is_a?(Tag)
-        default_options = {
-           controller: :comments,
-           action: :show,
-           id: comment.commentable.id,
-           tag_id: comment.ultimate_parent.to_param,
-           anchor: "comment_#{comment.id}"
-        }
-      else
-        default_options = {
-           controller: comment.commentable.class.to_s.underscore.pluralize,
-           action: :show,
-           id: (comment.commentable.is_a?(Tag) ? comment.commentable.to_param : comment.commentable.id),
-           anchor: "comment_#{comment.id}"
-        }
-      end
+      default_options = if comment.ultimate_parent.is_a?(Tag)
+                          {
+                            controller: :comments,
+                            action: :show,
+                            id: comment.commentable.id,
+                            tag_id: comment.ultimate_parent.to_param,
+                            anchor: "comment_#{comment.id}"
+                          }
+                        else
+                          {
+                            controller: comment.commentable.class.to_s.underscore.pluralize,
+                            action: :show,
+                            id: (comment.commentable.is_a?(Tag) ? comment.commentable.to_param : comment.commentable.id),
+                            anchor: "comment_#{comment.id}"
+                          }
+                        end
       # display the comment's direct parent (and its associated thread)
       redirect_to(url_for(default_options.merge(options)))
     else
       # need to redirect to the specific chapter; redirect_to_all will then retrieve full work view if applicable
-      redirect_to_all_comments(comment.parent, options.merge({show_comments: true, anchor: "comment_#{comment.id}"}))
+      redirect_to_all_comments(comment.parent, options.merge({ show_comments: true, anchor: "comment_#{comment.id}" }))
     end
   end
 
   def redirect_to_all_comments(commentable, options = {})
-    default_options = {anchor: "comments"}
+    default_options = { anchor: "comments" }
     options = default_options.merge(options)
 
     if commentable.is_a?(Tag)
       redirect_to comments_path(tag_id: commentable.to_param,
-                  add_comment_reply_id: options[:add_comment_reply_id],
-                  delete_comment_id: options[:delete_comment_id],
-                  page: options[:page],
-                  anchor: options[:anchor])
+                                add_comment_reply_id: options[:add_comment_reply_id],
+                                delete_comment_id: options[:delete_comment_id],
+                                page: options[:page],
+                                anchor: options[:anchor])
     else
       is_coming_from_chapter_view = request.referer&.match(/chapters/).present?
       is_not_coming_from_work_view = request.referer&.match(/works/).nil?
@@ -748,19 +748,17 @@ class CommentsController < ApplicationController
                        else
                          true
                        end
-      if commentable.is_a?(Chapter) && view_full_work
-        commentable = commentable.work
-      end
+      commentable = commentable.work if commentable.is_a?(Chapter) && view_full_work
       redirect_to polymorphic_path(commentable,
                                    options.slice(:show_comments,
                                                  :add_comment_reply_id,
                                                  :delete_comment_id,
                                                  :anchor,
                                                  :page)
-                                   # we don't actually use params[:view_full_work] within
-                                   # the comments controller anymore.
-                                   # still pass to the redirect since it is referred to elsewhere
-                                          .merge({view_full_work: params[:view_full_work]}))
+                                          # we don't actually use params[:view_full_work] within
+                                          # the comments controller anymore.
+                                          # still pass to the redirect since it is referred to elsewhere
+                                          .merge({ view_full_work: params[:view_full_work] }))
     end
   end
 

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -752,9 +752,10 @@ class CommentsController < ApplicationController
       view_full_work = if is_coming_from_chapter_view
                          false
                        elsif is_not_coming_from_work_view
-                         if params[:view_full_work] == "true"
+                         case params[:view_full_work]
+                         when "true"
                            true
-                         elsif params[:view_full_work] == "false"
+                         when "false"
                            false
                          else
                            current_user.try(:preference).try(:view_full_works).present?

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -93,8 +93,10 @@ class CommentsController < ApplicationController
 
   def check_pseud_ownership
     return unless params[:comment][:pseud_id]
+
     pseud = Pseud.find(params[:comment][:pseud_id])
     return if pseud && current_user && current_user.pseuds.include?(pseud)
+
     flash[:error] = ts("You can't comment with that pseud.")
     redirect_to root_path
   end
@@ -218,14 +220,17 @@ class CommentsController < ApplicationController
   def check_permission_to_review
     parent = find_parent
     return if logged_in_as_admin? || current_user_owns?(parent)
+
     flash[:error] = ts("Sorry, you don't have permission to see those unreviewed comments.")
     redirect_to logged_in? ? root_path : new_user_session_path(return_to: request.fullpath)
   end
 
   def check_permission_to_access_single_unreviewed
     return unless @comment.unreviewed?
+
     parent = find_parent
     return if logged_in_as_admin? || current_user_owns?(parent) || current_user_owns?(@comment)
+
     flash[:error] = ts("Sorry, that comment is currently in moderation.")
     redirect_to logged_in? ? root_path : new_user_session_path(return_to: request.fullpath)
   end
@@ -337,7 +342,7 @@ class CommentsController < ApplicationController
   def index
     return raise_not_found if @commentable.blank?
 
-    return unless @commentable.class == Comment
+    return unless @commentable.instance_of?(Comment)
 
     # we link to the parent object at the top
     @commentable = @commentable.ultimate_parent
@@ -436,7 +441,7 @@ class CommentsController < ApplicationController
             elsif @comment.unreviewed?
               redirect_to_all_comments(@commentable)
             else
-              redirect_to_comment(@comment, { page: params[:page] })
+              redirect_to_comment(@comment, { view_full_work: (params[:view_full_work] && params[:view_full_work] == "true"), page: params[:page] })
             end
           end
         end
@@ -452,10 +457,11 @@ class CommentsController < ApplicationController
   def update
     updated_comment_params = comment_params.merge(edited_at: Time.current)
     if @comment.update(updated_comment_params)
-      flash[:comment_notice] = ts('Comment was successfully updated.')
+      flash[:comment_notice] = ts("Comment was successfully updated.")
       respond_to do |format|
         format.html do
           redirect_to comment_path(@comment) and return if @comment.unreviewed?
+
           redirect_to_comment(@comment)
         end
         format.js # updating the comment in place
@@ -487,7 +493,7 @@ class CommentsController < ApplicationController
       redirect_to_comment(parent_comment)
     else
       flash[:comment_notice] = ts("Comment deleted.")
-      redirect_to_all_comments(parent, {show_comments: true})
+      redirect_to_all_comments(parent, { show_comments: true })
     end
   end
 
@@ -612,9 +618,10 @@ class CommentsController < ApplicationController
       format.html do
         # if non-ajax it could mean sudden javascript failure OR being redirected from login
         # so we're being extra-nice and preserving any intention to comment along with the show comments option
-        options = {show_comments: true}
+        options = { show_comments: true }
         options[:add_comment_reply_id] = params[:add_comment_reply_id] if params[:add_comment_reply_id]
         options[:page] = params[:page]
+        options[:view_full_work] = params[:view_full_work] if params[:view_full_work]
         redirect_to_all_comments(@commentable, options)
       end
 
@@ -639,10 +646,11 @@ class CommentsController < ApplicationController
     @comment = Comment.new
     respond_to do |format|
       format.html do
-        options = {show_comments: true}
+        options = { show_comments: true }
         options[:controller] = @commentable.class.to_s.underscore.pluralize
         options[:anchor] = "comment_#{params[:id]}"
         options[:page] = params[:page]
+        options[:view_full_work] = params[:view_full_work] if params[:view_full_work]
         if @thread_view
           options[:id] = @thread_root
           options[:add_comment_reply_id] = params[:id]
@@ -744,7 +752,13 @@ class CommentsController < ApplicationController
       view_full_work = if is_coming_from_chapter_view
                          false
                        elsif is_not_coming_from_work_view
-                         current_user.try(:preference).try(:view_full_works).present?
+                         if params[:view_full_work] == "true"
+                           true
+                         elsif params[:view_full_work] == "false"
+                           false
+                         else
+                           current_user.try(:preference).try(:view_full_works).present?
+                         end
                        else
                          true
                        end
@@ -753,12 +767,9 @@ class CommentsController < ApplicationController
                                    options.slice(:show_comments,
                                                  :add_comment_reply_id,
                                                  :delete_comment_id,
+                                                 :view_full_work,
                                                  :anchor,
-                                                 :page)
-                                          # we don't actually use params[:view_full_work] within
-                                          # the comments controller anymore.
-                                          # still pass to the redirect since it is referred to elsewhere
-                                          .merge({ view_full_work: params[:view_full_work] }))
+                                                 :page))
     end
   end
 

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -457,7 +457,7 @@ class CommentsController < ApplicationController
   def update
     updated_comment_params = comment_params.merge(edited_at: Time.current)
     if @comment.update(updated_comment_params)
-      flash[:comment_notice] = ts("Comment was successfully updated.")
+      flash[:comment_notice] = ts('Comment was successfully updated.')
       respond_to do |format|
         format.html do
           redirect_to comment_path(@comment) and return if @comment.unreviewed?

--- a/features/comments_and_kudos/comments_redirect.feature
+++ b/features/comments_and_kudos/comments_redirect.feature
@@ -49,8 +49,7 @@ Scenario: Posting top level comment on a chaptered work, with view full work in 
     And I post a comment "Woohoo"
   Then I should see "Woohoo"
     And I should see "Chapter 2" within "div#chapters"
-    # Once you've commented, it defaults back to your preference
-    And I should see "Chapter 1" within "div#chapters"
+    And I should not see "Chapter 1" within "div#chapters"
 
 # REPLY COMMENTS
 
@@ -115,5 +114,4 @@ Scenario: Posting top level comment on a middle chapter, while in temporary view
   When I reply to a comment with "Supercalifragelistic"
   Then I should see "Supercalifragelistic"
     And I should see "Chapter 2" within "div#chapters"
-    # Once you've commented, it defaults back to your preference
-    And I should see "Chapter 1" within "div#chapters"
+    And I should not see "Chapter 1" within "div#chapters"

--- a/spec/controllers/comments/comments_controller_spec.rb
+++ b/spec/controllers/comments/comments_controller_spec.rb
@@ -99,7 +99,7 @@ describe CommentsController do
       it "redirects to the comment on the work view without an error" do
         get :cancel_comment_delete, params: { id: comment.id }
         expect(flash[:error]).to be_nil
-        expect(response).to redirect_to(work_path(comment.commentable, show_comments: true, anchor: "comment_#{comment.id}"))
+        expect(response).to redirect_to(work_path(comment.commentable.work, show_comments: true, anchor: "comment_#{comment.id}"))
       end
     end
 
@@ -118,7 +118,7 @@ describe CommentsController do
         it "redirects to the comment on the work view without an error" do
           get :cancel_comment_delete, params: { id: comment.id }
           expect(flash[:error]).to be_nil
-          expect(response).to redirect_to(work_path(comment.commentable, show_comments: true, anchor: "comment_#{comment.id}"))
+          expect(response).to redirect_to(work_path(comment.commentable.work, show_comments: true, anchor: "comment_#{comment.id}"))
         end
       end
 
@@ -157,7 +157,7 @@ describe CommentsController do
           it "redirects to the comment on the full work view without error" do
             get :cancel_comment_edit, params: { id: comment.id }
             expect(flash[:error]).to be_nil
-            expect(response).to redirect_to(work_path(comment.commentable, show_comments: true, anchor: "comment_#{comment.id}"))
+            expect(response).to redirect_to(work_path(comment.commentable.work, show_comments: true, anchor: "comment_#{comment.id}"))
           end
         end
 
@@ -174,7 +174,7 @@ describe CommentsController do
             it "redirects to the comment on the full work view without error" do
               get :cancel_comment_edit, params: { id: comment.id }
               expect(flash[:error]).to be_nil
-              expect(response).to redirect_to(work_path(comment.commentable, show_comments: true, anchor: "comment_#{comment.id}"))
+              expect(response).to redirect_to(work_path(comment.commentable.work, show_comments: true, anchor: "comment_#{comment.id}"))
             end
           end
 

--- a/spec/controllers/comments/comments_controller_spec.rb
+++ b/spec/controllers/comments/comments_controller_spec.rb
@@ -388,7 +388,8 @@ describe CommentsController do
         delete :destroy, params: { id: comment.id }
         expect(flash[:comment_notice]).to eq "Comment deleted."
         it_redirects_to_simple(work_path(work, show_comments: true, anchor: :comments))
-        expect { comment.reload }.to raise_exception(ActiveRecord::RecordNotFound)
+        expect { comment.reload }
+          .to raise_exception(ActiveRecord::RecordNotFound)
       end
 
       it "GET #add_comment_reply redirects to the work with an error" do
@@ -472,7 +473,8 @@ describe CommentsController do
             delete :destroy, params: { id: comment.id }
             expect(flash[:comment_notice]).to eq "Comment deleted."
             it_redirects_to_simple(work_path(work, show_comments: true, anchor: :comments))
-            expect { comment.reload }.to raise_exception(ActiveRecord::RecordNotFound)
+            expect { comment.reload }
+              .to raise_exception(ActiveRecord::RecordNotFound)
           end
         end
       end

--- a/spec/controllers/comments/comments_controller_spec.rb
+++ b/spec/controllers/comments/comments_controller_spec.rb
@@ -79,10 +79,56 @@ describe CommentsController do
   end
 
   describe "GET #cancel_comment_delete" do
-    it "redirects to the comment on the commentable without an error" do
-      get :cancel_comment_delete, params: { id: comment.id }
-      expect(flash[:error]).to be_nil
-      expect(response).to redirect_to(chapter_path(comment.commentable, show_comments: true, anchor: "comment_#{comment.id}"))
+    context "when cancelling from chapter by chapter view" do
+      before do
+        request.env["HTTP_REFERER"] = "/works/1/chapters/1"
+      end
+
+      it "redirects to the comment on the chapter view without an error" do
+        get :cancel_comment_delete, params: { id: comment.id }
+        expect(flash[:error]).to be_nil
+        expect(response).to redirect_to(chapter_path(comment.commentable, show_comments: true, anchor: "comment_#{comment.id}"))
+      end
+    end
+
+    context "when cancelling from the work view" do
+      before do
+        request.env["HTTP_REFERER"] = "/works/1"
+      end
+
+      it "redirects to the comment on the work view without an error" do
+        get :cancel_comment_delete, params: { id: comment.id }
+        expect(flash[:error]).to be_nil
+        expect(response).to redirect_to(work_path(comment.commentable, show_comments: true, anchor: "comment_#{comment.id}"))
+      end
+    end
+
+    context "when cancelling from comments view" do
+      before do
+        request.env["HTTP_REFERER"] = "/comments/1"
+      end
+
+      context "when user set preference to full work view" do
+        before do
+          known_user = create(:user)
+          known_user.preference.update!(view_full_works: true)
+          fake_login_known_user(known_user)
+        end
+
+        it "redirects to the comment on the work view without an error" do
+          get :cancel_comment_delete, params: { id: comment.id }
+          expect(flash[:error]).to be_nil
+          expect(response).to redirect_to(work_path(comment.commentable, show_comments: true, anchor: "comment_#{comment.id}"))
+        end
+      end
+
+      context "when user set preference to chapter by chapter view" do
+        it "redirects to the comment on the chapter view without an error" do
+          get :cancel_comment_delete, params: { id: comment.id }
+          expect(flash[:error]).to be_nil
+          expect(response).to redirect_to(chapter_path(comment.commentable, show_comments: true, anchor: "comment_#{comment.id}"))
+        end
+      end
     end
   end
 
@@ -91,10 +137,54 @@ describe CommentsController do
       before { fake_login_known_user(comment.pseud.user) }
 
       context "when the format is html" do
-        it "redirects to the comment on the commentable without an error" do
-          get :cancel_comment_edit, params: { id: comment.id }
-          expect(flash[:error]).to be_nil
-          expect(response).to redirect_to(chapter_path(comment.commentable, show_comments: true, anchor: "comment_#{comment.id}"))
+        context "when user is navigating from chapter view" do
+          before do
+            request.env["HTTP_REFERER"] = "/works/1/chapters/1"
+          end
+
+          it "redirects to the comment on the chapter view without an error" do
+            get :cancel_comment_edit, params: { id: comment.id }
+            expect(flash[:error]).to be_nil
+            expect(response).to redirect_to(chapter_path(comment.commentable, show_comments: true, anchor: "comment_#{comment.id}"))
+          end
+        end
+
+        context "when user is navigating from work view" do
+          before do
+            request.env["HTTP_REFERER"] = "/works/1"
+          end
+
+          it "redirects to the comment on the full work view without error" do
+            get :cancel_comment_edit, params: { id: comment.id }
+            expect(flash[:error]).to be_nil
+            expect(response).to redirect_to(work_path(comment.commentable, show_comments: true, anchor: "comment_#{comment.id}"))
+          end
+        end
+
+        context "when user is navigating from comment view" do
+          before do
+            request.env["HTTP_REFERER"] = "/comments/1"
+          end
+
+          context "when user preference is full work view" do
+            before do
+              comment.pseud.user.preference.update!(view_full_works: true)
+            end
+
+            it "redirects to the comment on the full work view without error" do
+              get :cancel_comment_edit, params: { id: comment.id }
+              expect(flash[:error]).to be_nil
+              expect(response).to redirect_to(work_path(comment.commentable, show_comments: true, anchor: "comment_#{comment.id}"))
+            end
+          end
+
+          context "when user preference is not full work view" do
+            it "redirects to the comment on the chapter view without error" do
+              get :cancel_comment_edit, params: { id: comment.id }
+              expect(flash[:error]).to be_nil
+              expect(response).to redirect_to(chapter_path(comment.commentable, show_comments: true, anchor: "comment_#{comment.id}"))
+            end
+          end
         end
       end
 

--- a/spec/controllers/comments/default_rails_actions_spec.rb
+++ b/spec/controllers/comments/default_rails_actions_spec.rb
@@ -325,6 +325,106 @@ describe CommentsController do
         end
       end
 
+      context "when work is not restricted for a logged in user" do
+        let(:work) { create(:work) }
+        let(:user) { create(:user) }
+        let(:comment_attributes) do
+          {
+            pseud_id: user.default_pseud_id,
+            comment_content: "Hello fellow human!"
+          }
+        end
+        before { fake_login_known_user(user) }
+
+        context "when user is commenting from a work view" do
+          before do
+            request.env["HTTP_REFERER"] = "/works/1"
+          end
+
+          it "redirects to the work view" do
+            post :create, params: { work_id: work.id, comment: comment_attributes }
+            commentable_chapter = work.chapters.last
+            created_comment = user.comments.where(commentable: commentable_chapter).last
+            it_redirects_to_with_comment_notice(
+              work_path(work.id, show_comments: true, anchor: "comment_#{created_comment.id}"),
+              "Comment created!"
+            )
+          end
+        end
+
+        context "when user is commenting from a chapter view" do
+          before do
+            request.env["HTTP_REFERER"] = "/works/1/chapters/2"
+          end
+
+          it "redirects to the chapter view" do
+            post :create, params: { work_id: work.id, comment: comment_attributes }
+            commentable_chapter = work.chapters.last
+            created_comment = user.comments.where(commentable: commentable_chapter).last
+            it_redirects_to_with_comment_notice(
+              chapter_path(commentable_chapter.id, show_comments: true, anchor: "comment_#{created_comment.id}"),
+              "Comment created!"
+            )
+          end
+        end
+
+        context "when user is commenting from neither a work view nor chapter view" do
+          context "when param view_full_work == true" do
+            it "redirects to the work view" do
+              post :create, params: { work_id: work.id, comment: comment_attributes, view_full_work: true }
+              commentable_chapter = work.chapters.last
+              created_comment = user.comments.where(commentable: commentable_chapter).last
+              it_redirects_to_with_comment_notice(
+                work_path(work.id, show_comments: true, anchor: "comment_#{created_comment.id}", view_full_work: true),
+                "Comment created!"
+              )
+            end
+          end
+
+          context "when param view_full_work == false" do
+            it "redirects to the chapter view" do
+              post :create, params: { work_id: work.id, comment: comment_attributes, view_full_work: false }
+              commentable_chapter = work.chapters.last
+              created_comment = user.comments.where(commentable: commentable_chapter).last
+              it_redirects_to_with_comment_notice(
+                chapter_path(commentable_chapter.id, show_comments: true, anchor: "comment_#{created_comment.id}", view_full_work: false),
+                "Comment created!"
+              )
+            end
+          end
+
+          context "when param view_full_work is nil" do
+            context "when user preference is set to view full work" do
+              before do
+                user.preference.update!(view_full_works: true)
+              end
+
+              it "redirects to the full work view" do
+                post :create, params: { work_id: work.id, comment: comment_attributes }
+                commentable_chapter = work.chapters.last
+                created_comment = user.comments.where(commentable: commentable_chapter).last
+                it_redirects_to_with_comment_notice(
+                  work_path(work.id, show_comments: true, anchor: "comment_#{created_comment.id}"),
+                  "Comment created!"
+                )
+              end
+            end
+
+            context "when user preference is not set to view full work" do
+              it "redirects to the chapter view" do
+                post :create, params: { work_id: work.id, comment: comment_attributes }
+                commentable_chapter = work.chapters.last
+                created_comment = user.comments.where(commentable: commentable_chapter).last
+                it_redirects_to_with_comment_notice(
+                  chapter_path(commentable_chapter.id, show_comments: true, anchor: "comment_#{created_comment.id}"),
+                  "Comment created!"
+                )
+              end
+            end
+          end
+        end
+      end
+
       context "when the work has all comments disabled" do
         let(:work) { create(:work, comment_permissions: :disable_all) }
 
@@ -520,7 +620,7 @@ describe CommentsController do
             post :create, params: { work_id: work.id, comment: comment_attributes }
             comment = Comment.last
             expect(flash[:error]).to be_nil
-            expect(response).to redirect_to(chapter_path(comment.commentable, show_comments: true, view_full_work: false, anchor: "comment_#{comment.id}"))
+            expect(response).to redirect_to(chapter_path(comment.commentable, show_comments: true, anchor: "comment_#{comment.id}"))
           end
         end
       end
@@ -638,7 +738,7 @@ describe CommentsController do
           fake_login_known_user(user)
           post :create, params: { work_id: work.id, comment: comment_attributes }
           comment = assigns[:comment]
-          it_redirects_to_with_comment_notice(chapter_path(comment.commentable, show_comments: true, view_full_work: false, anchor: "comment_#{comment.id}"), "Comment created!")
+          it_redirects_to_with_comment_notice(chapter_path(comment.commentable, show_comments: true, anchor: "comment_#{comment.id}"), "Comment created!")
           expect(comment.user_agent.length).to eq(500)
         end
       end
@@ -656,7 +756,7 @@ describe CommentsController do
           fake_login_known_user(user)
           post :create, params: { work_id: work.id, comment: comment_attributes }
           comment = assigns[:comment]
-          it_redirects_to_with_comment_notice(chapter_path(comment.commentable, show_comments: true, view_full_work: false, anchor: "comment_#{comment.id}"), "Comment created!")
+          it_redirects_to_with_comment_notice(chapter_path(comment.commentable, show_comments: true, anchor: "comment_#{comment.id}"), "Comment created!")
           expect(comment.user_agent).to be_nil
         end
       end


### PR DESCRIPTION
# Pull Request Checklist

<!-- Mark steps in the checklist as complete by changing `[ ]` to `[X]` -->
* [x] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [x] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [x] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [x] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-7219

## Purpose

Fix the bug where users who had "show the whole work by default" enabled were getting redirected to the full work view after commenting.

This was happening because of this line in the `redirect_to_all_comments` function

```
if commentable.is_a?(Chapter) && (options[:view_full_work] || current_user.try(:preference).try(:view_full_works))
   commentable = commentable.work
end
```
1. Commentable is always a chapter in multi-chapter works. 
2. Regardless of options[:view_full_work], if user's preference has view_full_works set to true, (options[:view_full_work] || current_user.try(:preference).try(:view_full_works)) is always true

We also had bugs earlier in the code when setting `options[:view_full_work]`

In `show_comments` and `add_comment_reply`, `options[:view_full_work]` always evaluates as truthy regardless of whether it's 'true', or 'false', since params get evaluated as string values.

I simplified the logic by basing redirects on the previous page (referer) rather than the view_full_work param.

Based on manual test + looking at the code, I'm assuming that there's 3 ways to create / edit / delete a comment
1. From work view (`/works/:id`)
2. From chapter view (`/works/:id/chapters/:id`)
3. From comment view (`/comments/:id`)

I was concerned that by updating the logic so we no longer rely on `params[:view_full_work]`, I'd break the flow from when a user deletes a comment from the comment view. 

But I confirmed that we never set the `view_full_work` param when a user is navigated to to the `comments` path in both of the below cases:
1. User clicks `Thread` on a comment box, which navigates to the `comments/:id` path
2. User creates a reply beyond maximum comment thread depth, which navigates to the `comments/:id` path

We also did not set the `view_full_work` param when a user switched from entire work view to chapter view.

Since the `view_full_work` param is set unpredictably, and inconsistently, I believe it would be more maintainable if we consolidate all the logic to the redirect function and go off of where the user last was instead.

## Testing Instructions
[Please see Jira ticket](https://otwarchive.atlassian.net/browse/AO3-7219) - [most recent test instructions are here](https://otwarchive.atlassian.net/browse/AO3-7219?focusedCommentId=381818) with screenshots
 
## References
This replaces an original PR: https://github.com/otwcode/otwarchive/pull/5524

@Bilka2 thank you for your careful review. I agreed with your comment that the routing logic in the original PR was too convoluted, and that the simplest solution is to take the user back to where they were to begin with.

I was going to work off of my old PR, but it was so old that just starting from a clean slate was easier.

## Credit

What name and pronouns should we use to credit you in the [Archive of Our Own's Release Notes](https://archiveofourown.org/admin_posts?tag=1)?

Zooms (any)

If you have a Jira account, please include the same name in the "Full name"
field on your Jira profile, so we can assign you the issues you're working on.

*Please note that if you do not fill in this section, we will use your GitHub account name and
they/them pronouns.*
