### PR TITLE
AO3-7407 Add anonymous class to works and series blurbs and modules

### DIFF
--- a/app/views/gifts/_gift_blurb.html.erb
+++ b/app/views/gifts/_gift_blurb.html.erb
@@ -1,5 +1,5 @@
 <% # expects "work" and "gift" %>
-<li id="work_<%= work.id %>" class="<% if is_author_of?(work) %>own <% end %><% if work.unrevealed? %>mystery <% end %>gift work <%= css_classes_for_creation_blurb(work) %>" role="article">
+<li id="work_<%= work.id %>" class="<% if is_author_of?(work) %>own <% end %><% if work.anonymous? %>anonymous <% end %><% if work.unrevealed? %>mystery <% end %>gift work <%= css_classes_for_creation_blurb(work) %>" role="article">
   <%= render "works/work_module", work: work %>
   <% if @user && @user == current_user && (gift = work.gifts.where(:pseud_id => current_user.pseuds.pluck(:id)).first) %>
     <h6 class="landmark heading"><%= ts("Recipient Actions") %></h6>

--- a/app/views/series/_series_blurb.html.erb
+++ b/app/views/series/_series_blurb.html.erb
@@ -1,7 +1,7 @@
-<li id="series_<%= series.id %>" class="<% if is_author_of?(series) %>own <% end %>series <%= css_classes_for_creation_blurb(series) %>" role="article">
+<li id="series_<%= series.id %>" class="<% if is_author_of?(series) %>own <% end %><% if series.anonymous? %>anonymous <% end %>series <%= css_classes_for_creation_blurb(series) %>" role="article">
   <%= render 'series/series_module', :series => series %>
   <% if is_author_of?(series) %>
     <h6 class="landmark heading"><%= ts("Author Actions") %></h6>
-    <p class="actions" role="navigation"><%= link_to ts('Edit'), edit_series_path(series) %></p>
+    <p class="actions"><%= link_to ts('Edit'), edit_series_path(series) %></p>
   <% end %>
 </li>

--- a/app/views/series/_series_module.html.erb
+++ b/app/views/series/_series_module.html.erb
@@ -1,7 +1,7 @@
 <%# expects "series" %>
 
 <!--title etc-->
-<div class="header module">
+<div class="<% if series.anonymous? %>anonymous <% end %>header module">
   <h4 class="heading">
     <%= t(".series_by_html", series_title_link: link_to(series.title, series), byline: byline(series)) %>
     <% if series.restricted %>

--- a/app/views/works/_work_blurb.html.erb
+++ b/app/views/works/_work_blurb.html.erb
@@ -1,9 +1,9 @@
 <% # expects "work" %>
-<li id="work_<%= work.id %>" class="<% if is_author_of?(work) %>own <% end %><% if work.unrevealed? %>mystery <% end %>work <%= css_classes_for_creation_blurb(work) %>" role="article">
+<li id="work_<%= work.id %>" class="<% if is_author_of?(work) %>own <% end %><% if work.anonymous? %>anonymous <% end %><% if work.unrevealed? %>mystery <% end %>work <%= css_classes_for_creation_blurb(work) %>" role="article">
   <%= render "works/work_module", work: work %>
   <% if is_author_of?(work) %>
     <h6 class="landmark heading"><%= ts("Author Actions") %></h6>
-  	<ul class="actions" role="navigation">
+  	<ul class="actions">
       <li><%= link_to ts("Edit"), edit_work_path(work) %></li>
       <li><%= link_to ts("Edit Tags"), edit_tags_work_path(work) %></li>
       <% if work.is_wip %>
@@ -13,7 +13,7 @@
         <li>
           <%= link_to ts("Post Draft"), post_draft_work_path(work), method: :put %>
         </li>
-        <li role="button">
+        <li>
           <%= link_to ts("Delete Draft"), confirm_delete_work_path(work), data: { confirm: ts("Are you sure you want to delete this draft?") } %>
         </li>
       <% end %>

--- a/app/views/works/_work_module.html.erb
+++ b/app/views/works/_work_module.html.erb
@@ -3,7 +3,7 @@
   <%= render "works/mystery_blurb", item: work %>
 <% else %>
   <!--title, author, fandom-->
-  <div class="header module">
+  <div class="<% if work.anonymous? %>anonymous <% end %>header module">
     <!-- updated_at=<%= work.updated_at.to_i.to_s %> -->
     <h4 class="heading">
       <% if (work.unrevealed? || work.anonymous?) && (is_author_of?(work) || User.current_user.is_a?(Admin)) %>


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-7407

## Purpose

Adds an `anonymous` class for anon works and series to correspond with the `mystery` class. (Series can't be unrevealed, but they can be anon, so the `anonymous` class is in the same places for series as for works.)

## Testing Instructions

Refer to Jira.

