### PR TITLE
AO3-7425 Set word count when posting draft from Edit Tag page

### DIFF
--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -401,7 +401,7 @@ class WorksController < ApplicationController
       @work.save
       flash[:notice] = ts('Tags were successfully updated.')
       redirect_to(@work)
-    else # Save Draft
+    else
       @work.posted = true
       @work.minor_version = @work.minor_version + 1
       @work.save

--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -405,6 +405,8 @@ class WorksController < ApplicationController
       @work.posted = true
       @work.minor_version = @work.minor_version + 1
       @work.save
+      @work.word_count = @work.first_chapter.word_count
+      @work.save
       flash[:notice] = ts('Work was successfully updated.')
       redirect_to(@work)
     end

--- a/features/works/work_edit_tags.feature
+++ b/features/works/work_edit_tags.feature
@@ -52,6 +52,21 @@ Feature: Edit tags on a work
     And I should see "Anthropomorphic"
     And I should see "The cooler version of tag"
 
+  Scenario: See correct word count when posting draft from Edit Tags
+  Given I am logged in as "imit" with password "tagyoure"
+    And the draft "Freeze Tag"
+  When I am on imit's works page
+  Then I should see "Drafts (1)"
+  When I follow "Drafts (1)"
+  Then I should see "Freeze Tag"
+    And I should see "Edit Tags" within "#main .own.work.blurb .actions"
+  When I follow "Edit Tags"
+  Then I should see "Post"
+  When I press "Post"
+  Then I should see "Work was successfully updated."
+    And I should not see "This work is a draft and has not been posted"
+    And I should see "Words:6"
+
   Scenario: Ampersands and angle brackets should display in work titles on Edit Tags page
   Given the work "I am &lt;strong&gt;er Than Yesterday &amp; Other Lies" by "testuser2"
     And I am logged in as "testuser2"

--- a/features/works/work_edit_tags.feature
+++ b/features/works/work_edit_tags.feature
@@ -55,14 +55,9 @@ Feature: Edit tags on a work
   Scenario: See correct word count when posting draft from Edit Tags
   Given I am logged in as "imit" with password "tagyoure"
     And the draft "Freeze Tag"
-  When I am on imit's works page
-  Then I should see "Drafts (1)"
-  When I follow "Drafts (1)"
-  Then I should see "Freeze Tag"
-    And I should see "Edit Tags" within "#main .own.work.blurb .actions"
+    And I view the work "Freeze Tag"
   When I follow "Edit Tags"
-  Then I should see "Post"
-  When I press "Post"
+    And I press "Post"
   Then I should see "Work was successfully updated."
     And I should not see "This work is a draft and has not been posted"
     And I should see "Words:6"


### PR DESCRIPTION
* [X] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [X] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [X] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [X] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [X] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue
https://otwarchive.atlassian.net/browse/AO3-7425

## Purpose
Fix word count when posting draft from Edit Tag page

## Credit
mellowmarsach
