### PR TITLE
AO3-7358 Fix 500 error when sending item_added_notification for bookmark of deleted work

### DIFF
--- a/app/views/collection_mailer/item_added_notification.html.erb
+++ b/app/views/collection_mailer/item_added_notification.html.erb
@@ -10,7 +10,11 @@
     <% if @creation.is_a?(Work) %>
       <i><b><%= style_link(@creation.title.html_safe, work_url(@creation)) %></b></i>
     <% else %>
+      <% if @creation.bookmarkable == nil %>
+      Bookmark of deleted item
+      <% else %>
       <i><b><%= style_link("A bookmark of: " + @creation.bookmarkable.title.html_safe, bookmark_url(@creation)) %></b></i>
+      <% end %>
     <% end %>
 
 

--- a/app/views/collection_mailer/item_added_notification.text.erb
+++ b/app/views/collection_mailer/item_added_notification.text.erb
@@ -2,14 +2,18 @@
 <% pseuds = @creation.is_a?(Work) ? @creation.pseuds.map{|p| text_pseud(p)}.to_sentence.html_safe : @creation.pseud.name %>
 
 
-<%= @creation.is_a?(Work) ? @creation.pseuds.length > 0 ? pseuds : @creation.authors_to_sort_on : pseuds %> posted a <%= @creation.is_a?(Work) ? @creation.backdate ? "backdated " : "new " : "new " %> <%= @creation.is_a?(Work) ? "work" : "bookmark" %> to your collection, "<%= @collection.name %>" (<%= collection_url(@collection) %>:
+<%= @creation.is_a?(Work) ? @creation.pseuds.length > 0 ? pseuds : @creation.authors_to_sort_on : pseuds %> posted a <%= @creation.is_a?(Work) ? @creation.backdate ? "backdated " : "new " : "new " %> <%= @creation.is_a?(Work) ? "work" : "bookmark" %> to your collection, "<%= @collection.name %>" (<%= collection_url(@collection) %>):
 
 <% if @creation.is_a?(Work) %>
 "<%= @creation.title.html_safe %>"
 <%= work_url(@creation) %>
 <% else %>
+<% if @creation.bookmarkable == nil %>
+Bookmark of deleted item
+<% else %>
 <%= "A bookmark of: " + @creation.bookmarkable.title.html_safe %>
 <%= bookmark_url(@creation) %>
+<% end %>
 <% end %>
 <% end %>
 


### PR DESCRIPTION
# Pull Request Checklist

<!-- Mark steps in the checklist as complete by changing `[ ]` to `[X]` -->
* [X] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [X] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [X] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [X] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [X] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-7358
## Purpose

Fix 500 error sending `item_added_notification` for bookmark of deleted work
The mail tries to reference `.title` of `@creation.bookmarkable` which errors out when `@creation.bookmarkable` is deleted. Updated the mail text to explicitly handle this case

## Credit

Smaran Jawalkar (he/him)
