### PR TITLE
AO3-7189 Allow admins to change user skin via the Preferences page

### DIFF
--- a/app/controllers/preferences_controller.rb
+++ b/app/controllers/preferences_controller.rb
@@ -22,7 +22,7 @@ class PreferencesController < ApplicationController
     @available_skins = available_skins
     @available_locales = Locale.where(email_enabled: true)
 
-    @user.preference.attributes = preference_params
+    @user.preference.attributes = permitted_attributes(@preference)
     
     if params[:preference][:skin_id].present?
       # unset session skin if user changed their skin
@@ -43,36 +43,5 @@ class PreferencesController < ApplicationController
   def available_skins
     (@user.skins.site_skins.usable +
     Skin.approved_skins.site_skins.usable).uniq
-  end
-
-  def preference_params
-    params.require(:preference).permit(
-      :minimize_search_engines,
-      :disable_share_links,
-      :adult,
-      :view_full_works,
-      :hide_warnings,
-      :hide_freeform,
-      :disable_work_skins,
-      :skin_id,
-      :time_zone,
-      :preferred_locale,
-      :work_title_format,
-      :comment_emails_off,
-      :comment_inbox_off,
-      :comment_copy_to_self_off,
-      :kudos_emails_off,
-      :admin_emails_off,
-      :allow_collection_invitation,
-      :collection_emails_off,
-      :collection_inbox_off,
-      :recipient_emails_off,
-      :history_enabled,
-      :first_login,
-      :banner_seen,
-      :allow_cocreator,
-      :allow_gifts,
-      :guest_replies_off
-    )
   end
 end

--- a/app/policies/preference_policy.rb
+++ b/app/policies/preference_policy.rb
@@ -1,9 +1,54 @@
 class PreferencePolicy < ApplicationPolicy
   READ_ACCESS_ROLES = %w[superadmin policy_and_abuse support].freeze
+  EDIT_ROLES = %w[superadmin support].freeze
 
   def read_access?
     user_has_roles?(READ_ACCESS_ROLES)
   end
 
+  def edit_access?
+    user_has_roles?(EDIT_ROLES)
+  end
+
+  # Define which roles can update which attributes
+  ALLOWED_ATTRIBUTES_BY_ROLES = {
+    "superadmin" => %i[skin_id],
+    "support" => %i[skin_id]
+  }.freeze
+
+  def permitted_attributes
+    if user.is_a?(Admin)
+      ALLOWED_ATTRIBUTES_BY_ROLES.values_at(*user.roles).compact.flatten
+    else
+      [:minimize_search_engines,
+       :disable_share_links,
+       :adult,
+       :view_full_works,
+       :hide_warnings,
+       :hide_freeform,
+       :disable_work_skins,
+       :skin_id,
+       :time_zone,
+       :preferred_locale,
+       :work_title_format,
+       :comment_emails_off,
+       :comment_inbox_off,
+       :comment_copy_to_self_off,
+       :kudos_emails_off,
+       :admin_emails_off,
+       :allow_collection_invitation,
+       :collection_emails_off,
+       :collection_inbox_off,
+       :recipient_emails_off,
+       :history_enabled,
+       :first_login,
+       :banner_seen,
+       :allow_cocreator,
+       :allow_gifts,
+       :guest_replies_off]
+    end
+  end
+
   alias index? read_access?
+  alias update? edit_access?
 end

--- a/spec/controllers/preferences_controller_spec.rb
+++ b/spec/controllers/preferences_controller_spec.rb
@@ -147,9 +147,34 @@ describe PreferencesController do
     end
 
     context "as admin" do
-      subject { put :update, params: { user_id: user.login, id: user.preference.id, preference: preference_params } }
-      
-      it_behaves_like "an action only authorized admins can access", authorized_roles: []
+      subject { put :update, params: { user_id: user.login, id: user.preference.id, preference: { skin_id: new_skin.id } } }
+      let(:new_skin) { create(:skin, author_id: user.id) }
+      let(:success) do
+        expect(user.preference.reload.skin_id).to eq(new_skin.id)
+        it_redirects_to_with_notice(user_path(user), "Your preferences were successfully updated.")
+      end
+
+      before do
+        expect(user.preference.skin_id).not_to eq(new_skin.id)
+      end
+
+      it_behaves_like "an action only authorized admins can access", authorized_roles: %w[superadmin support]
+
+      context "attempting to edit a non-permitted field" do
+        let(:admin) { create(:admin, roles: ["support"]) }
+
+        before do
+          fake_login_admin(admin)
+        end
+
+        it "throws error and doesn't save changes to non-permitted field" do
+          expect(user.preference.history_enabled).to be_truthy
+          expect do
+            put :update, params: { user_id: user.login, id: user.preference.id, preference: { history_enabled: "0" } }
+          end.to raise_exception(ActionController::UnpermittedParameters)
+          expect(user.preference.reload.history_enabled).to be_truthy
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
This reverts commit ddf67664f5896743d6c51c3efba5c78b44836af9. It is a reintroduction of https://github.com/otwcode/otwarchive/pull/5771.

## Issue

https://otwarchive.atlassian.net/browse/AO3-7189

## Purpose

Allow support and superadmins to edit a user's skin via their preferences.

## Credit

Bilka