### PR TITLE
AO3-7345 Update success message for setting a site skin for a session

### DIFF
--- a/app/controllers/skins_controller.rb
+++ b/app/controllers/skins_controller.rb
@@ -140,10 +140,10 @@ class SkinsController < ApplicationController
 
   def set
     if @skin.cached?
-      flash[:notice] = ts("The skin %{title} has been set. This will last for your current session.", title: @skin.title)
+      flash[:notice] = t(".success_html", skin_title: @skin.title, skin_page_link: helpers.link_to(t(".skin_page", skin_title: @skin.title), skin_path(@skin)))
       session[:site_skin] = @skin.id
     else
-      flash[:error] = ts("Sorry, but only certain skins can be used this way (for performance reasons). Please drop a support request if you'd like %{title} to be added!", title: @skin.title)
+      flash[:error] = t(".failure", skin_title: @skin.title)
     end
     redirect_back_or_to @skin
   end

--- a/config/locales/controllers/en.yml
+++ b/config/locales/controllers/en.yml
@@ -314,6 +314,12 @@ en:
     index:
       public_site_page_title: Public Site Skins
       public_work_page_title: Public Work Skins
+    preview:
+      cannot_preview: Sorry, you can't preview that skin.
+    set:
+      failure: Sorry, but only certain skins can be used this way (for performance reasons). Please drop a support request if you'd like %{skin_title} to be added!
+      skin_page: "%{skin_title} skin page"
+      success_html: You're now using the %{skin_title} skin. This will last for 2 weeks even if you close your browser. If you'd like to keep it longer, go to the %{skin_page_link} and select the "Use" button at the bottom of the page.
   stats:
     index:
       page_title: "%{username} - Stats"

--- a/config/locales/controllers/en.yml
+++ b/config/locales/controllers/en.yml
@@ -314,8 +314,6 @@ en:
     index:
       public_site_page_title: Public Site Skins
       public_work_page_title: Public Work Skins
-    preview:
-      cannot_preview: Sorry, you can't preview that skin.
     set:
       failure: Sorry, but only certain skins can be used this way (for performance reasons). Please drop a support request if you'd like %{skin_title} to be added!
       skin_page: "%{skin_title} skin page"

--- a/features/other_b/skin_public.feature
+++ b/features/other_b/skin_public.feature
@@ -14,7 +14,7 @@ Feature: Public skins
     And the skin "public skin" is in the chooser
   When I am logged in as "skinner"
     And I press "public skin"
-  Then I should see "The skin public skin has been set. This will last for your current session."
+  Then I should see "You're now using the public skin skin. This will last for 2 weeks"
     And the page should have the cached skin "public skin"
   When I press "Default"
   Then I should see "You are now using the default site skin again!"

--- a/spec/controllers/skins_controller_spec.rb
+++ b/spec/controllers/skins_controller_spec.rb
@@ -576,7 +576,7 @@ describe SkinsController do
     shared_examples "user can set it" do
       it "redirects with success notice" do
         post :set, params: { id: skin.id }
-        it_redirects_to_with_notice(skin_path(skin), "The skin Cached Public Skin has been set. This will last for your current session.")
+        it_redirects_to_with_notice(skin_path(skin), "You're now using the #{skin.title} skin. This will last for 2 weeks even if you close your browser. If you'd like to keep it longer, go to the <a href=\"#{skin_path(skin)}\">#{skin.title} skin page</a> and select the \"Use\" button at the bottom of the page.")
       end
     end
 


### PR DESCRIPTION
This reverts commit 9550af68eac2f69cc19eb8d17031851b547b0acf. It reintroduces https://github.com/otwcode/otwarchive/pull/5756.

# Pull Request Checklist

<!-- Mark steps in the checklist as complete by changing `[ ]` to `[X]` -->
* [X] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [X] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [X] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [X] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [X] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-7345

## Purpose

Context: When you successfully set a site skin for a session 

The success message has been expanded to add a link to the skin page and clarify how long the skin will stay/that it will survive closing the browser.

## Credit
Jesse Malark he/him