### PR TITLE
AO3-7160 Fix clipped autocomplete dropdown when assigning a pinch hitter

### DIFF
--- a/public/stylesheets/site/2.0/10-types-groups.css
+++ b/public/stylesheets/site/2.0/10-types-groups.css
@@ -158,6 +158,12 @@ dl.index dd .userstuff p {
   display: block;
 }
 
+/* contexts */
+
+form dl.index {
+  position: initial;
+}
+
 /* TYPES */
 
 a.rss span {


### PR DESCRIPTION
This reverts commit 69d62687275c7af12440854bbcd717e716d33239. It reintroduces https://github.com/otwcode/otwarchive/pull/5699.

# Pull Request Checklist

* [X] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [X] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [ ] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [X] Have you added the [Jira](https://otwarchive.atlassian.net) issue number as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)?
* [X] Do you have fewer than 5 pull requests already open? If not, please wait until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-7160

## Purpose

Fixes the clipped autocomplete dropdown when assigning a pinch hitter on challenge maintainer assignments.

The dropdown was being clipped by ancestor elements using `overflow: hidden` (fieldset and form dl in 01-core.css).

Changes made:
- Added `maintainer-assignments` class to the maintainer assignments fieldset.
- Added scoped CSS override (`overflow: visible`) for that fieldset and its `dl.index` to allow the dropdown to render fully without affecting global styles.

## Testing Instructions

Follow the reproduction steps in Jira (AO3-7160):
https://otwarchive.atlassian.net/browse/AO3-7160

Expected result:
- The autocomplete dropdown is fully visible and not clipped.

Note: This is a visual/CSS fix and is not easily covered by existing automated tests.

## Screenshots

Before:
<img width="670" height="259" alt="ao3_7160_before" src="https://github.com/user-attachments/assets/ff4499a4-dceb-453c-83ae-96f01948fc8f" />

After:
<img width="668" height="313" alt="ao3_7160_after" src="https://github.com/user-attachments/assets/37b29e31-d0cf-4ad8-aa23-b8b98bc51bd7" />


## Credit

Name: Noah Bravo  
Pronouns: they/them
