### PR TITLE
AO3-7391 Fix IE CSS selector

### DIFF
--- a/public/stylesheets/site/2.0/29-role-ie8_or_lower.css
+++ b/public/stylesheets/site/2.0/29-role-ie8_or_lower.css
@@ -10,7 +10,7 @@ test note: these files could certainly be reduced but I have no IE to test with
   background: #bbb;
 }
 
-span.replied. span.unreviewed, .actions a, .action {
+span.replied, span.unreviewed, .actions a, .action {
   font-family: "Arial Unicode MS", "Lucida Grande Unicode", Arial, sans-serif;
 }
 

--- a/public/stylesheets/site/2.0/30-role-ie5.css
+++ b/public/stylesheets/site/2.0/30-role-ie5.css
@@ -244,7 +244,7 @@ ul.media, li.medium .index, .alphabet .listbox li {
 
 /* font fallbacks for icons */
 
-span.replied. span.unreviewed, .actions a, .action, .symbol {
+span.replied, span.unreviewed, .actions a, .action, .symbol {
   font-family: 'Arial Unicode MS', 'Lucida Grande Unicode', Arial, sans-serif;
 }
 

--- a/public/stylesheets/site/2.0/31-role-ie6.css
+++ b/public/stylesheets/site/2.0/31-role-ie6.css
@@ -244,7 +244,7 @@ ul.media, li.medium .index, .alphabet .listbox li {
 
 /* font fallbacks for icons */
 
-span.replied. span.unreviewed, .actions a, .action, .symbol {
+span.replied, span.unreviewed, .actions a, .action, .symbol {
   font-family: 'Arial Unicode MS', 'Lucida Grande Unicode', Arial, sans-serif;
 }
 

--- a/public/stylesheets/site/2.0/32-role-ie7.css
+++ b/public/stylesheets/site/2.0/32-role-ie7.css
@@ -65,7 +65,7 @@ ul#skiplinks, .landmark, .landmark a, .index .heading.landmark {
 
 /* font fallbacks for icons */
 
-span.replied. span.unreviewed, .actions a, .action, .symbol {
+span.replied, span.unreviewed, .actions a, .action, .symbol {
   font-family: 'Arial Unicode MS', 'Lucida Grande Unicode', Arial, sans-serif;
 }
 


### PR DESCRIPTION
This reverts commit cf1922e241c6f3a9bd817557b6b0b82ad740d6e9. It reintroduces https://github.com/otwcode/otwarchive/pull/5789.

# Pull Request Checklist

<!-- Mark steps in the checklist as complete by changing `[ ]` to `[X]` -->
* [X] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [X] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [ ] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [X] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [X] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-7391

## Purpose

Fixes an incorrect CSS selector in the following CSS files: 
- 29-role-ie8_or_lower.css
- 30-role-ie5.css
- 31-role-ie6.css
-  32-role-ie7.css
The selector span.replied. has been corrected to span.replied,

## Credit
Mane Muradyan, she/her
