### PR TITLE
AO3-5701 AO3-6331 Reindex works and bookmarks when a collection's parent changes

### DIFF
--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -471,19 +471,8 @@ class Collection < ApplicationRecord
                if: :saved_change_to_parent_id?
 
   def reindex_associated_works_and_bookmarks
-    items = all_items.pluck(:item_type, :item_id)
-
-    work_ids = []
-    bookmark_ids = []
-
-    items.each do |item_type, item_id|
-      case item_type
-      when "Work"
-        work_ids << item_id
-      when "Bookmark"
-        bookmark_ids << item_id
-      end
-    end
+    work_ids = all_items.where(item_type: "Work").pluck(:item_id).uniq
+    bookmark_ids = all_items.where(item_type: "Bookmark").pluck(:item_id).uniq
 
     IndexQueue.enqueue_ids(Work, work_ids.uniq, :background) if work_ids.present?
     IndexQueue.enqueue_ids(Bookmark, bookmark_ids.uniq, :background) if bookmark_ids.present?

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -464,4 +464,29 @@ class Collection < ApplicationRecord
   def approved_bookmarked_items_count
     SearchCounts.bookmarkable_count_for_collection(self)
   end
+
+  # Reindex associated works and bookmarks when a collection's parent changes
+  # because works and bookmarks index parent collection ids in Elasticsearch.
+  after_commit :reindex_associated_works_and_bookmarks,
+               if: :saved_change_to_parent_id?
+
+  def reindex_associated_works_and_bookmarks
+    items = all_items.pluck(:item_type, :item_id)
+
+    work_ids = []
+    bookmark_ids = []
+
+    items.each do |item_type, item_id|
+      case item_type
+      when "Work"
+        work_ids << item_id
+      when "Bookmark"
+        bookmark_ids << item_id
+      end
+    end
+
+    IndexQueue.enqueue_ids(Work, work_ids.uniq, :background) if work_ids.present?
+    IndexQueue.enqueue_ids(Bookmark, bookmark_ids.uniq, :background) if bookmark_ids.present?
+  end
+
 end

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -474,7 +474,7 @@ class Collection < ApplicationRecord
     work_ids = all_items.where(item_type: "Work").pluck(:item_id).uniq
     bookmark_ids = all_items.where(item_type: "Bookmark").pluck(:item_id).uniq
 
-    IndexQueue.enqueue_ids(Work, work_ids.uniq, :background) if work_ids.present?
-    IndexQueue.enqueue_ids(Bookmark, bookmark_ids.uniq, :background) if bookmark_ids.present?
+    IndexQueue.enqueue_ids(Work, work_ids, :background) if work_ids.present?
+    IndexQueue.enqueue_ids(Bookmark, bookmark_ids, :background) if bookmark_ids.present?
   end
 end

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -488,5 +488,4 @@ class Collection < ApplicationRecord
     IndexQueue.enqueue_ids(Work, work_ids.uniq, :background) if work_ids.present?
     IndexQueue.enqueue_ids(Bookmark, bookmark_ids.uniq, :background) if bookmark_ids.present?
   end
-
 end

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -107,8 +107,9 @@ describe Collection do
     end
 
     context "when subcollection is added or removed" do
-      let(:parent_collection) { create(:collection) }
-      let(:child) { create(:collection) }
+      let(:user) { create(:user) }
+      let(:parent_collection) { create(:collection, user: user ) }
+      let(:child) { create(:collection, user: user) }
       let(:work) { create(:work) }
 
       before do

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -105,6 +105,28 @@ describe Collection do
       expect { create(:collection, open_doors: nil) }
         .to raise_error(ActiveRecord::NotNullViolation)
     end
+
+    context "when subcollection is added or removed" do
+      let(:parent_collection) { create(:collection) }
+      let(:child) { create(:collection) }
+      let(:work) { create(:work) }
+
+      before do
+        child.collection_items.create(item: work)
+      end
+
+      it "enqueues reindexing of works when subcolelction is added" do
+        child.update!(parent_id: parent_collection.id)
+        expect(IndexQueue).to receive(:enqueue_ids).with(Work, [work.id], :background)
+        allow(IndexQueue).to receive(:enqueue_ids).with(Bookmark, anything, :background)
+      end
+
+      it "enqueues reindexing of works when subcollection is removed" do
+        child.update!(parent_id: nil)
+        expect(IndexQueue).to receive(:enqueue_ids).with(Work, [work.id], :background)
+        allow(IndexQueue).to receive(:enqueue_ids).with(Bookmark, anything, :background)
+      end
+    end
   end
 
   describe "#clear_icon" do


### PR DESCRIPTION
# Pull Request Checklist

<!-- Mark steps in the checklist as complete by changing `[ ]` to `[X]` -->
* [X] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [X] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [X] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [X] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [X] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-5701
https://otwarchive.atlassian.net/browse/AO3-6331

## Purpose

Reindex works and bookmarks when collection parent changes

Works and bookmarks index parent collection IDs in Elasticsearch. When a collection is added to or removed from a parent collection, associated Elasticsearch documents are not updated, causing stale collection search results.

This change reindexes affected works and bookmarks whenever a collection's parent_id changes.

## Credit

Smaran Jawalkar (he/him)
