### PR TITLE
AO3-3934 Footer not sitting at bottom of page

### DIFF
--- a/public/stylesheets/site/2.0/10-types-groups.css
+++ b/public/stylesheets/site/2.0/10-types-groups.css
@@ -103,11 +103,9 @@ https://otwcode.github.io/docs/classes-taxonomy.html#grouping-and-spacing
 #outer.wrapper {
   float: left;
   width: 100%;
-
     display: flex;
     display: -webkit-flex;
     flex-direction: column;
-    -webkit-flex-direction: column;
     min-height: 100vh;
 }
 
@@ -116,7 +114,6 @@ https://otwcode.github.io/docs/classes-taxonomy.html#grouping-and-spacing
 }
 
 #inner.wrapper {
-    -webkit-flex: 1;
     flex: 1;
 }
 

--- a/public/stylesheets/site/2.0/10-types-groups.css
+++ b/public/stylesheets/site/2.0/10-types-groups.css
@@ -104,7 +104,6 @@ https://otwcode.github.io/docs/classes-taxonomy.html#grouping-and-spacing
   float: left;
   width: 100%;
     display: flex;
-    display: -webkit-flex;
     flex-direction: column;
     min-height: 100vh;
 }

--- a/public/stylesheets/site/2.0/10-types-groups.css
+++ b/public/stylesheets/site/2.0/10-types-groups.css
@@ -103,10 +103,21 @@ https://otwcode.github.io/docs/classes-taxonomy.html#grouping-and-spacing
 #outer.wrapper {
   float: left;
   width: 100%;
+
+    display: flex;
+    display: -webkit-flex;
+    flex-direction: column;
+    -webkit-flex-direction: column;
+    min-height: 100vh;
 }
 
 #outer.wrapper, #inner.wrapper {
     box-shadow: none;
+}
+
+#inner.wrapper {
+    -webkit-flex: 1;
+    flex: 1;
 }
 
 .module, .index, .index .index {


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [ ] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [x] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [x] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-3934

## Purpose

The footer does not sit at the bottom of the page on pages where the site content does not fill the full height. This is especially obvious on larger screens and pages with short content like /about.

Fixing this was not easily, if at all, possible with only CSS2. To remedy this, we use minimal CSS3 flexbox rules that should not affect the current views in older browsers without CSS3, while fixing the issue in all browsers that do support CSS3. Unfortunately, because this is entirely a cosmetic change and due to the limitations in CSS2, this may be the best solution we have, though I am open to any and all suggestions.

This change also supports other device layouts and is mobile-responsive.

## Testing Instructions

I've tested this change as thoroughly as I could for regressions, but there may be pages or edge cases I am unaware of that could be affected. If this CSS3 approach is accepted, I can update the Jira ticket.

## Credit

calm (they/them)
