### PR TITLE
AO3-3464 HTML parser eats text after a missing quote upon preview or posting

### DIFF
--- a/lib/html_cleaner.rb
+++ b/lib/html_cleaner.rb
@@ -21,8 +21,7 @@ module HtmlCleaner
     sanitized_field
   end
 
-  # yank out bad end-of-line characters and evil msword curly quotes
-  def fix_bad_characters(text)
+  def clean_html_and_characters(text)
     return "" if text.nil?
 
     # get the text into UTF-8 and get rid of invalid characters
@@ -36,7 +35,14 @@ module HtmlCleaner
     # argh, get rid of ____spacer____ inserts
     text.gsub! "____spacer____", ""
 
-    return text
+    # fix unclosed attribute quotes
+    # find all HTML opening tags; then within those, searches for any unclosed quotes with look ahead; adds the closing quote before lookahead
+    # pattern: ="value without closing tag before another attribute= or >
+    text.gsub!(/<[a-zA-Z][^>]*>/i) do |tag|
+      tag.gsub(/="([^"]*?)(?=\s+[a-zA-Z]+=|>)/, '="\1"')
+    end
+
+    text
   end
 
   def sanitize_value(field, value)
@@ -70,10 +76,10 @@ module HtmlCleaner
       end
       # Now that we know what transformers we need, let's sanitize the unfrozen value
       if ArchiveConfig.FIELDS_ALLOWING_CSS.include?(field.to_s)
-        unfrozen_value = Sanitize.clean(add_paragraphs_to_text(fix_bad_characters(unfrozen_value)),
+        unfrozen_value = Sanitize.clean(add_paragraphs_to_text(clean_html_and_characters(unfrozen_value)),
                                         Sanitize::Config::CSS_ALLOWED.merge(transformers: transformers))
       else
-        unfrozen_value = Sanitize.clean(add_paragraphs_to_text(fix_bad_characters(unfrozen_value)),
+        unfrozen_value = Sanitize.clean(add_paragraphs_to_text(clean_html_and_characters(unfrozen_value)),
                                         Sanitize::Config::ARCHIVE.merge(transformers: transformers))
       end
       doc = Nokogiri::HTML5::Document.new
@@ -81,7 +87,7 @@ module HtmlCleaner
       unfrozen_value = doc.fragment(unfrozen_value).to_html
     else
       # clean out all tags
-      unfrozen_value = Sanitize.clean(fix_bad_characters(unfrozen_value))
+      unfrozen_value = Sanitize.clean(clean_html_and_characters(unfrozen_value))
     end
 
     # Plain text fields can't contain &amp; entities:

--- a/lib/html_cleaner.rb
+++ b/lib/html_cleaner.rb
@@ -75,10 +75,7 @@ module HtmlCleaner
         transformers << OtwSanitize::UserClassSanitizer.transformer
       end
       # Now that we know what transformers we need, let's sanitize the unfrozen value
-      config = ArchiveConfig.FIELDS_ALLOWING_CSS.include?(field.to_s) ? 
-        Sanitize::Config::CSS_ALLOWED : 
-        Sanitize::Config::ARCHIVE
-
+      config = ArchiveConfig.FIELDS_ALLOWING_CSS.include?(field.to_s) ? Sanitize::Config::CSS_ALLOWED : Sanitize::Config::ARCHIVE
       unfrozen_value = Sanitize.clean(add_paragraphs_to_text(clean_html_and_characters(unfrozen_value)),
                                       config.merge(transformers: transformers))
       doc = Nokogiri::HTML5::Document.new

--- a/lib/html_cleaner.rb
+++ b/lib/html_cleaner.rb
@@ -75,13 +75,12 @@ module HtmlCleaner
         transformers << OtwSanitize::UserClassSanitizer.transformer
       end
       # Now that we know what transformers we need, let's sanitize the unfrozen value
-      if ArchiveConfig.FIELDS_ALLOWING_CSS.include?(field.to_s)
-        unfrozen_value = Sanitize.clean(add_paragraphs_to_text(clean_html_and_characters(unfrozen_value)),
-                                        Sanitize::Config::CSS_ALLOWED.merge(transformers: transformers))
-      else
-        unfrozen_value = Sanitize.clean(add_paragraphs_to_text(clean_html_and_characters(unfrozen_value)),
-                                        Sanitize::Config::ARCHIVE.merge(transformers: transformers))
-      end
+      config = ArchiveConfig.FIELDS_ALLOWING_CSS.include?(field.to_s) ? 
+        Sanitize::Config::CSS_ALLOWED : 
+        Sanitize::Config::ARCHIVE
+
+      unfrozen_value = Sanitize.clean(add_paragraphs_to_text(clean_html_and_characters(unfrozen_value)),
+                                      config.merge(transformers: transformers))
       doc = Nokogiri::HTML5::Document.new
       doc.encoding = "UTF-8"
       unfrozen_value = doc.fragment(unfrozen_value).to_html

--- a/spec/lib/html_cleaner_spec.rb
+++ b/spec/lib/html_cleaner_spec.rb
@@ -1339,15 +1339,6 @@ describe HtmlCleaner do
       end
     end
   end
-
-  describe "sanitize_value with unclosed quotes" do
-    ArchiveConfig.FIELDS_ALLOWING_CSS.each do |field|
-      context "#{field} field with unclosed quotes preserves user classes" do
-        it "preserves multi-class values in CSS-allowing fields" do
-          input = '<p class="col-6 text-center>Some content</p>'
-          result = sanitize_value(field, input)
-          expect(result).to include("Some content")
-        end
       end
     end
   end

--- a/spec/lib/html_cleaner_spec.rb
+++ b/spec/lib/html_cleaner_spec.rb
@@ -1359,39 +1359,6 @@ describe HtmlCleaner do
   end
 
   describe "sanitize_value with unclosed quotes" do
-    [:content, :endnotes, :notes].each do |field|
-      context "#{field} field with unclosed attribute quotes" do
-        it "preserves text after malformed tag with unclosed quote" do
-          input = '<p class="align-center>Text to be centered</p><p>More text</p>'
-          result = sanitize_value(field, input)
-          expect(result).to include("Text to be centered")
-          expect(result).to include("More text")
-        end
-
-        it "preserves complete work with missing quote in class attribute" do
-          input = '<p class="intro>This is the introduction.</p><p>This is the body.</p>'
-          result = sanitize_value(field, input)
-          expect(result).to include("This is the introduction.")
-          expect(result).to include("This is the body.")
-        end
-
-        it "handles unclosed quote with multiple malformed attributes" do
-          input = '<p class="bad id="main">Some text</p><p>More text</p>'
-          result = sanitize_value(field, input)
-          expect(result).to include("Some text")
-          expect(result).to include("More text")
-        end
-
-        it "preserves text with unclosed href in links" do
-          input = '<p>Check <a href="http://example.com>this</a> out.</p>'
-          result = sanitize_value(field, input)
-          expect(result).to include("Check")
-          expect(result).to include("this")
-          expect(result).to include("out.")
-        end
-      end
-    end
-
     ArchiveConfig.FIELDS_ALLOWING_CSS.each do |field|
       context "#{field} field with unclosed quotes preserves user classes" do
         it "preserves multi-class values in CSS-allowing fields" do

--- a/spec/lib/html_cleaner_spec.rb
+++ b/spec/lib/html_cleaner_spec.rb
@@ -1358,8 +1358,6 @@ describe HtmlCleaner do
     end
   end
 
-
-
   describe "sanitize_value with unclosed quotes" do
     [:content, :endnotes, :notes].each do |field|
       context "#{field} field with unclosed attribute quotes" do
@@ -1399,8 +1397,6 @@ describe HtmlCleaner do
         it "preserves multi-class values in CSS-allowing fields" do
           input = '<p class="col-6 text-center>Some content</p>'
           result = sanitize_value(field, input)
-          doc = Nokogiri::HTML5.fragment(result)
-          # Both classes should be present (or at least the text should be preserved)
           expect(result).to include("Some content")
         end
       end

--- a/spec/lib/html_cleaner_spec.rb
+++ b/spec/lib/html_cleaner_spec.rb
@@ -593,28 +593,10 @@ describe HtmlCleaner do
         expect(result).to eq('<a href="http://example.com">link</a>')
       end
 
-      it "handles original bug report example" do
-        input = '<p class="align-center>Text to be centered</p><p>More text</p>'
-        result = clean_html_and_characters(input)
-        expect(result).to eq('<p class="align-center">Text to be centered</p><p>More text</p>')
-      end
-
       it "fixes multiple malformed attributes in same tag" do
         input = '<p class="unclosed id="main" style="color>text</p>'
         result = clean_html_and_characters(input)
         expect(result).to eq('<p class="unclosed" id="main" style="color">text</p>')
-      end
-
-      it "preserves properly closed attributes alongside malformed ones" do
-        input = '<p id="good" class="bad>text</p>'
-        result = clean_html_and_characters(input)
-        expect(result).to eq('<p id="good" class="bad">text</p>')
-      end
-
-      it "handles multiple tags with unclosed quotes" do
-        input = '<p class="bad1>text</p><div id="bad2>more</div>'
-        result = clean_html_and_characters(input)
-        expect(result).to eq('<p class="bad1">text</p><div id="bad2">more</div>')
       end
 
       it "handles unclosed quote with special characters in value" do

--- a/spec/lib/html_cleaner_spec.rb
+++ b/spec/lib/html_cleaner_spec.rb
@@ -1339,7 +1339,4 @@ describe HtmlCleaner do
       end
     end
   end
-      end
-    end
-  end
 end

--- a/spec/lib/html_cleaner_spec.rb
+++ b/spec/lib/html_cleaner_spec.rb
@@ -512,45 +512,122 @@ describe HtmlCleaner do
     end
   end
 
-  describe "fix_bad_characters" do
+  describe "clean_html_and_characters" do
     it "should not touch normal text" do
-      expect(fix_bad_characters("normal text")).to eq("normal text")
+      expect(clean_html_and_characters("normal text")).to eq("normal text")
     end
 
     it "should not touch normal text with valid unicode chars" do
-      expect(fix_bad_characters("„‚nörmäl’—téxt‘“")).to eq("„‚nörmäl’—téxt‘“")
+      expect(clean_html_and_characters("„‚nörmäl’—téxt‘“")).to eq("„‚nörmäl’—téxt‘“")
     end
 
     it "does not touch zero-width non-joiner" do
       string = ["A".ord, 0x200C, "A".ord]  # "A[zwnj]A"
-      expect(fix_bad_characters(string.pack("U*")).unpack("U*")).to eq(string)
+      expect(clean_html_and_characters(string.pack("U*")).unpack("U*")).to eq(string)
     end
 
     it "does not touch zero-width joiner" do
       string = ["A".ord, 0x200D, "A".ord]  # "A[zwj]A"
-      expect(fix_bad_characters(string.pack("U*")).unpack("U*")).to eq(string)
+      expect(clean_html_and_characters(string.pack("U*")).unpack("U*")).to eq(string)
     end
 
     it "does not touch word joiner" do
       string = ["A".ord, 0x2060, "A".ord]  # "A[wj]A"
-      expect(fix_bad_characters(string.pack("U*")).unpack("U*")).to eq(string)
+      expect(clean_html_and_characters(string.pack("U*")).unpack("U*")).to eq(string)
     end
 
     it "should remove invalid unicode chars" do
       bad_string = [65, 150, 65].pack("C*")  # => "A\226A"
-      expect(fix_bad_characters(bad_string)).to eq("AA")
+      expect(clean_html_and_characters(bad_string)).to eq("AA")
     end
 
     it "should escape <3" do
-      expect(fix_bad_characters("normal <3 text")).to eq("normal &lt;3 text")
+      expect(clean_html_and_characters("normal <3 text")).to eq("normal &lt;3 text")
     end
 
     it "should convert \\r\\n to \\n" do
-      expect(fix_bad_characters("normal\r\ntext")).to eq("normal\ntext")
+      expect(clean_html_and_characters("normal\r\ntext")).to eq("normal\ntext")
     end
 
     it "should remove the spacer" do
-      expect(fix_bad_characters("A____spacer____A")).to eq("AA")
+      expect(clean_html_and_characters("A____spacer____A")).to eq("AA")
+    end
+
+    context "fixing unclosed quotes in tag attributes" do
+      it "should not touch normal text" do
+        expect(clean_html_and_characters("normal text")).to eq("normal text")
+      end
+
+      it "should not touch tags with properly closed quotes" do
+        html = '<p class="already-closed">text</p>'
+        expect(clean_html_and_characters(html)).to eq(html)
+      end
+
+      it "adds closing quote for missing quote before >" do
+        input = '<p class="unclosed>text</p>'
+        result = clean_html_and_characters(input)
+        expect(result).to eq('<p class="unclosed">text</p>')
+      end
+
+      it "adds closing quote when another attribute follows" do
+        input = '<p class="unclosed id="main">text</p>'
+        result = clean_html_and_characters(input)
+        expect(result).to eq('<p class="unclosed" id="main">text</p>')
+      end
+
+      it "preserves multi-word attribute values" do
+        input = '<p class="foo bar baz">text</p>'
+        result = clean_html_and_characters(input)
+        expect(result).to eq('<p class="foo bar baz">text</p>')
+      end
+
+      it "handles unclosed quote with multi-word value" do
+        input = '<p class="align center style>text</p>'
+        result = clean_html_and_characters(input)
+        expect(result).to eq('<p class="align center style">text</p>')
+      end
+
+      it "fixes unclosed href attribute" do
+        input = '<a href="http://example.com>link</a>'
+        result = clean_html_and_characters(input)
+        expect(result).to eq('<a href="http://example.com">link</a>')
+      end
+
+      it "handles original bug report example" do
+        input = '<p class="align-center>Text to be centered</p><p>More text</p>'
+        result = clean_html_and_characters(input)
+        expect(result).to eq('<p class="align-center">Text to be centered</p><p>More text</p>')
+      end
+
+      it "fixes multiple malformed attributes in same tag" do
+        input = '<p class="unclosed id="main" style="color>text</p>'
+        result = clean_html_and_characters(input)
+        expect(result).to eq('<p class="unclosed" id="main" style="color">text</p>')
+      end
+
+      it "preserves properly closed attributes alongside malformed ones" do
+        input = '<p id="good" class="bad>text</p>'
+        result = clean_html_and_characters(input)
+        expect(result).to eq('<p id="good" class="bad">text</p>')
+      end
+
+      it "handles multiple tags with unclosed quotes" do
+        input = '<p class="bad1>text</p><div id="bad2>more</div>'
+        result = clean_html_and_characters(input)
+        expect(result).to eq('<p class="bad1">text</p><div id="bad2">more</div>')
+      end
+
+      it "handles unclosed quote with special characters in value" do
+        input = '<p class="align-left bold>text</p>'
+        result = clean_html_and_characters(input)
+        expect(result).to eq('<p class="align-left bold">text</p>')
+      end
+
+      it "handles data attributes with unclosed quotes" do
+        input = '<div data-value="something>content</div>'
+        result = clean_html_and_characters(input)
+        expect(result).to eq('<div data-value="something">content</div>')
+      end
     end
   end
 
@@ -1278,11 +1355,54 @@ describe HtmlCleaner do
         result = 'Hi! img src="https://&lt;span&gt;" alt="&lt;script/src=\'http://ha.ckers.org/xss.js\'&gt;" Bye'
         expect(strip_images(string, keep_src: true)).to eq(result)
       end
+    end
+  end
 
-      it "escapes the value within the alt attribute when it contains an initial >" do
-        string = 'Hi! <img src="https://example.com" alt="><script src=\'http://ha.ckers.org/xss.js\'>"> Bye'
-        result = 'Hi! img src="https://example.com" alt="&gt;&lt;script src=\'http://ha.ckers.org/xss.js\'&gt;" Bye'
-        expect(strip_images(string, keep_src: true)).to eq(result)
+
+
+  describe "sanitize_value with unclosed quotes" do
+    [:content, :endnotes, :notes].each do |field|
+      context "#{field} field with unclosed attribute quotes" do
+        it "preserves text after malformed tag with unclosed quote" do
+          input = '<p class="align-center>Text to be centered</p><p>More text</p>'
+          result = sanitize_value(field, input)
+          expect(result).to include("Text to be centered")
+          expect(result).to include("More text")
+        end
+
+        it "preserves complete work with missing quote in class attribute" do
+          input = '<p class="intro>This is the introduction.</p><p>This is the body.</p>'
+          result = sanitize_value(field, input)
+          expect(result).to include("This is the introduction.")
+          expect(result).to include("This is the body.")
+        end
+
+        it "handles unclosed quote with multiple malformed attributes" do
+          input = '<p class="bad id="main">Some text</p><p>More text</p>'
+          result = sanitize_value(field, input)
+          expect(result).to include("Some text")
+          expect(result).to include("More text")
+        end
+
+        it "preserves text with unclosed href in links" do
+          input = '<p>Check <a href="http://example.com>this</a> out.</p>'
+          result = sanitize_value(field, input)
+          expect(result).to include("Check")
+          expect(result).to include("this")
+          expect(result).to include("out.")
+        end
+      end
+    end
+
+    ArchiveConfig.FIELDS_ALLOWING_CSS.each do |field|
+      context "#{field} field with unclosed quotes preserves user classes" do
+        it "preserves multi-class values in CSS-allowing fields" do
+          input = '<p class="col-6 text-center>Some content</p>'
+          result = sanitize_value(field, input)
+          doc = Nokogiri::HTML5.fragment(result)
+          # Both classes should be present (or at least the text should be preserved)
+          expect(result).to include("Some content")
+        end
       end
     end
   end


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [x] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [x] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [x] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-3464

## Purpose

Previously, an open quote in an HTML tag attribute would cause Nokogiri to "eat" the rest of the tag and its text until it found another quote or some other delimiter, sometimes resulting in a significant loss of user work. This change should sanitize any "loose" open quotes and intelligently find and add the closing quote to prevent this loss.

## Testing Instructions

I have added tests, but this should also be tested manually in new/edit/preview works and in comments.

## Credit

calm (they/them)
