### PR TITLE
AO3-7447 Update wording of Content Policy notice

### DIFF
--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -734,7 +734,7 @@ en:
         update: Update
       content_policy: Content Policy
       legend: Post Chapter
-      post_notice_html: All works you post on AO3 must comply with our %{content_policy_link}. For more information, please refer to our %{tos_faq_link}.
+      post_notice_html: All works on AO3 must comply with our %{content_policy_link}. For more information, please refer to our %{tos_faq_link}.
       tos_faq: Terms of Service FAQ
     preview:
       page_heading: Preview
@@ -3272,7 +3272,7 @@ en:
       page_heading_html: Chapter Index for %{work_link} by %{creators}
     new_import:
       content_policy: Content Policy
-      post_notice_html: All works you post on AO3 must comply with our %{content_policy_link}. For more information, please refer to our %{tos_faq_link}.
+      post_notice_html: All works on AO3 must comply with our %{content_policy_link}. For more information, please refer to our %{tos_faq_link}.
       tos_faq: Terms of Service FAQ
       works_languages_help_title: Languages help
     permissions:
@@ -3295,7 +3295,7 @@ en:
         update: Update
       content_policy: Content Policy
       legend: Post Work
-      post_notice_html: All works you post on AO3 must comply with our %{content_policy_link}. For more information, please refer to our %{tos_faq_link}.
+      post_notice_html: All works on AO3 must comply with our %{content_policy_link}. For more information, please refer to our %{tos_faq_link}.
       tos_faq: Terms of Service FAQ
     preface:
       title: Preface


### PR DESCRIPTION
# Pull Request Checklist

<!-- Mark steps in the checklist as complete by changing `[ ]` to `[X]` -->
* [x] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [x] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [x] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [x] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-7447

## Purpose

Update Content Policy notice to remove "you post" from the wordings. 

e.g.
`All works you post on AO3 must comply with our %{content_policy_link}. For more information, please refer to our %{tos_faq_link}.`
to 
``All works on AO3 must comply with our %{content_policy_link}. For more information, please refer to our %{tos_faq_link}.``

## Testing Instructions

Automated Tests: none
Manual Test: verify on Post, Import, and chapter's Post that the notice has been updated. Eg.
<img width="995" height="175" alt="image" src="https://github.com/user-attachments/assets/9a6374eb-cfb6-4169-9320-879cf1f358bc" />

## Credit

Soaphbar (she/her)
