### PR TITLE
AO3-7476 Fix that text-only bylines for anon creations could contain HTML

### DIFF
--- a/app/helpers/byline_helper.rb
+++ b/app/helpers/byline_helper.rb
@@ -10,12 +10,13 @@ module BylineHelper
 
   # A plain text version of the byline, for when we don't want to deliver a linkified version.
   def text_byline(creation, options = {})
+    only_path = false
+
     if creation.respond_to?(:anonymous?) && creation.anonymous?
       anon_byline = t("byline_helper.anonymous_byline")
-      anon_byline = t("byline_helper.anonymous_with_name_byline_html", pseud_byline: non_anonymous_byline(creation)) if anonymous_with_name?(options, creation)
+      anon_byline = t("byline_helper.anonymous_with_name_byline_html", pseud_byline: byline_text(creation, only_path, text_only: true)) if anonymous_with_name?(options, creation)
       anon_byline
     else
-      only_path = false
       byline_text(creation, only_path, text_only: true)
     end
   end

--- a/spec/helpers/byline_helper_spec.rb
+++ b/spec/helpers/byline_helper_spec.rb
@@ -21,4 +21,18 @@ describe BylineHelper do
       end
     end
   end
+
+  describe "#text_byline" do
+    let(:user) { create(:user, login: "Joe") }
+    let(:work) { create(:work, authors: [user.default_pseud], collections: [create(:anonymous_collection)]) }
+
+    before do
+      allow(helper).to receive(:logged_in_as_admin?).and_return(true)
+    end
+
+    it "includes no links for partially anonymous byline shown to admins" do
+      expect(helper.text_byline(work)).to_not include("href")
+      expect(helper.text_byline(work)).to eq("Anonymous [Joe]")
+    end
+  end
 end


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-7476

## Purpose

Fix that text only bylines, like they are currently used in the series browser title, could contain HTML for admins viewing anon series or creators viewing their own anon series.

This bug did not get found earlier because all other spots using text-only bylines deal with logged-out scenarios (share modal).

## Credit

Bilka
