### PR TITLE
AO3-6576 Published date in news post blurb is unnecessarily complex to screen readers 

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -257,7 +257,7 @@ module ApplicationHelper
     unabbreviated_zone_name = TZInfo::Timezone.get(zone).friendly_identifier(true) rescue zone
     
     time_parts = [
-      localized_time.strftime('<abbr class="day" title="%A">%a</abbr> %d <abbr class="month" title="%B">%b</abbr> %Y %I:%M%p'),
+      localized_time.strftime('<abbr class="day" title="%A">%a</abbr> %d <abbr class="month" title="%B">%b</abbr> %Y %I:%M%p').html_safe,
       " ",
       content_tag(:abbr, localized_time.zone, class: "timezone", title: unabbreviated_zone_name)
     ]

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -254,7 +254,11 @@ module ApplicationHelper
 
     zone ||= (user&.is_a?(User) && user.preference.time_zone) ? user.preference.time_zone : Time.zone.name
     localized_time = time.in_time_zone(zone)
-    unabbreviated_zone_name = TZInfo::Timezone.get(zone).friendly_identifier(true) rescue zone
+    unabbreviated_zone_name = begin
+      TZInfo::Timezone.get(zone).friendly_identifier(true)
+    rescue TZInfo::InvalidTimezoneIdentifier
+      zone
+    end
     
     time_parts = [
       localized_time.strftime('<abbr class="day" title="%A">%a</abbr> %d <abbr class="month" title="%B">%b</abbr> %Y %I:%M%p').html_safe,
@@ -264,10 +268,14 @@ module ApplicationHelper
 
     user_time_parts = if user.is_a?(User) && user.preference.time_zone && user.preference.time_zone != zone
       user_localized_time = time.in_time_zone(user.preference.time_zone)
-      unabbreviated_user_zone_name = TZInfo::Timezone.get(user.preference.time_zone).friendly_identifier(true) rescue user.preference.time_zone
+      unabbreviated_user_zone_name = begin
+        TZInfo::Timezone.get(user.preference.time_zone).friendly_identifier(true)
+      rescue TZInfo::InvalidTimezoneIdentifier
+        user.preference.time_zone
+      end
       [
         " (",
-        user_localized_time.strftime('%I:%M%p'),
+        user_localized_time.strftime("%I:%M%p"),
         " ",
         content_tag(:abbr, user_localized_time.zone, class: "timezone", title: unabbreviated_user_zone_name),
         ")"

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -256,7 +256,7 @@ module ApplicationHelper
     localized_time = time.in_time_zone(zone)
     unabbreviated_zone_name = TZInfo::Timezone.get(zone).friendly_identifier(true) rescue zone
     
-    time_pieces = [
+    time_parts = [
       localized_time.strftime('<abbr class="day" title="%A">%a</abbr> %d <abbr class="month" title="%B">%b</abbr> %Y %I:%M%p'),
       " ",
       content_tag(:abbr, localized_time.zone, class: "timezone", title: unabbreviated_zone_name)
@@ -274,7 +274,7 @@ module ApplicationHelper
       ]
     end
 
-    safe_join(time_pieces + (user_time_parts || [])).strip.html_safe
+    safe_join(time_parts + (user_time_parts || [])).strip.html_safe
   end
 
   def mailto_link(user, options={})

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -266,14 +266,15 @@ module ApplicationHelper
       content_tag(:abbr, localized_time.zone, class: "timezone", title: unabbreviated_zone_name)
     ]
 
-    user_time_parts = if user.is_a?(User) && user.preference.time_zone && user.preference.time_zone != zone
+    if user.is_a?(User) && user.preference.time_zone && user.preference.time_zone != zone
       user_localized_time = time.in_time_zone(user.preference.time_zone)
       unabbreviated_user_zone_name = begin
         TZInfo::Timezone.get(user.preference.time_zone).friendly_identifier(true)
       rescue TZInfo::InvalidTimezoneIdentifier
         user.preference.time_zone
       end
-      [
+      
+      user_time_parts = [
         " (",
         user_localized_time.strftime("%I:%M%p"),
         " ",

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -253,24 +253,28 @@ module ApplicationHelper
     return ts("(no time specified)") if time.blank?
 
     zone ||= (user&.is_a?(User) && user.preference.time_zone) ? user.preference.time_zone : Time.zone.name
-    time_in_zone = time.in_time_zone(zone)
-    time_in_zone_string = time_in_zone.strftime('<abbr class="day" title="%A">%a</abbr> <span class="date">%d</span>
-                                                 <abbr class="month" title="%B">%b</abbr> <span class="year">%Y</span>
-                                                 <span class="time">%I:%M%p</span>') +
-                          " <abbr class=\"timezone\" title=\"#{zone}\">#{time_in_zone.zone}</abbr> "
+    localized_time = time.in_time_zone(zone)
+    unabbreviated_zone_name = TZInfo::Timezone.get(zone).friendly_identifier(true) rescue zone
+    
+    time_pieces = [
+      localized_time.strftime('<abbr class="day" title="%A">%a</abbr> %d <abbr class="month" title="%B">%b</abbr> %Y %I:%M%p'),
+      " ",
+      content_tag(:abbr, localized_time.zone, class: "timezone", title: unabbreviated_zone_name)
+    ]
 
-    user_time_string = ""
-    if user.is_a?(User) && user.preference.time_zone
-      if user.preference.time_zone != zone
-        user_time = time.in_time_zone(user.preference.time_zone)
-        user_time_string = "(" + user_time.strftime('<span class="time">%I:%M%p</span>') +
-                           " <abbr class=\"timezone\" title=\"#{user.preference.time_zone}\">#{user_time.zone}</abbr>)"
-      elsif !user.preference.time_zone
-        user_time_string = link_to ts("(set timezone)"), user_preferences_path(user)
-      end
+    user_time_parts = if user.is_a?(User) && user.preference.time_zone && user.preference.time_zone != zone
+      user_localized_time = time.in_time_zone(user.preference.time_zone)
+      unabbreviated_user_zone_name = TZInfo::Timezone.get(user.preference.time_zone).friendly_identifier(true) rescue user.preference.time_zone
+      [
+        " (",
+        user_localized_time.strftime('%I:%M%p'),
+        " ",
+        content_tag(:abbr, user_localized_time.zone, class: "timezone", title: unabbreviated_user_zone_name),
+        ")"
+      ]
     end
 
-    (time_in_zone_string + user_time_string).strip.html_safe
+    safe_join(time_pieces + (user_time_parts || [])).strip.html_safe
   end
 
   def mailto_link(user, options={})

--- a/app/helpers/date_helper.rb
+++ b/app/helpers/date_helper.rb
@@ -6,7 +6,7 @@ module DateHelper
     if datetime > 30.days.ago && !AdminSetting.enable_test_caching?
       time_ago_in_words(datetime)
     else
-      date_in_zone(date_in_user_time_zone(datetime), format: :date_html)
+      date_in_zone(date_in_user_time_zone(datetime), format: :date_blurb_html)
     end
   end
 
@@ -32,6 +32,6 @@ module DateHelper
     time_in_zone = time.in_time_zone(zone)
     I18n.l(time_in_zone, format: format).html_safe
     # i18n-tasks-use t('time.formats.date_short_html')
-    # i18n-tasks-use t('time.formats.date_html')
+    # i18n-tasks-use t('time.formats.date_blurb_html')
   end
 end

--- a/app/helpers/date_helper.rb
+++ b/app/helpers/date_helper.rb
@@ -6,7 +6,7 @@ module DateHelper
     if datetime > 30.days.ago && !AdminSetting.enable_test_caching?
       time_ago_in_words(datetime)
     else
-      date_in_user_time_zone(datetime).strftime('%d <abbr class="month" title="%B">%b</abbr> %Y').html_safe
+      date_in_zone(date_in_user_time_zone(datetime), format: :date_html)
     end
   end
 
@@ -25,12 +25,13 @@ module DateHelper
 
   # show date in the time zone specified
   # note: this does *not* append timezone and does *not* reflect user preferences
-  def date_in_zone(time, zone = nil)
+  def date_in_zone(time, zone = nil, format: :date_short_html)
     zone ||= Time.zone.name
     return nil if time.blank?
 
     time_in_zone = time.in_time_zone(zone)
-    I18n.l(time_in_zone, format: :date_short_html).html_safe
+    I18n.l(time_in_zone, format: format).html_safe
     # i18n-tasks-use t('time.formats.date_short_html')
+    # i18n-tasks-use t('time.formats.date_html')
   end
 end

--- a/app/helpers/date_helper.rb
+++ b/app/helpers/date_helper.rb
@@ -6,7 +6,7 @@ module DateHelper
     if datetime > 30.days.ago && !AdminSetting.enable_test_caching?
       time_ago_in_words(datetime)
     else
-      date_in_user_time_zone(datetime).to_date.to_formatted_s(:rfc822)
+      date_in_user_time_zone(datetime).strftime('%d <abbr class="month" title="%B">%b</abbr> %Y').html_safe
     end
   end
 

--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -2951,7 +2951,7 @@ en:
         wrangle: Wrangle
   time:
     formats:
-      date_short_html: <abbr class="day" title="%A">%a</abbr> <span class="date">%d</span> <abbr class="month" title="%B">%b</abbr> <span class="year">%Y</span>
+      date_short_html: <abbr class="day" title="%A">%a</abbr> %d <abbr class="month" title="%B">%b</abbr> %Y
   troubleshooting:
     show:
       fix_associations:

--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -2951,8 +2951,8 @@ en:
         wrangle: Wrangle
   time:
     formats:
-      date_short_html: <abbr class="day" title="%A">%a</abbr> %d <abbr class="month" title="%B">%b</abbr> %Y
       date_blurb_html: '%d <abbr class="month" title="%B">%b</abbr> %Y'
+      date_short_html: <abbr class="day" title="%A">%a</abbr> %d <abbr class="month" title="%B">%b</abbr> %Y
   troubleshooting:
     show:
       fix_associations:

--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -6,7 +6,7 @@ en:
     new:
       do_not_spam:
         delay: it may take several months for us to get to your report
-        paragraph_html: '%{split_bold} Our volunteer team is small, so %{delay_link}.'
+        paragraph_html: "%{split_bold} Our volunteer team is small, so %{delay_link}."
         split: Please only report one user at a time, and do not submit multiple reports about the same user.
       form:
         comment:
@@ -185,7 +185,7 @@ en:
           creations: Creations
         no_creations: This user has no works or comments.
         page_heading: Works and Comments by %{user} (%{id})
-        page_title: '%{login} - User Creations'
+        page_title: "%{login} - User Creations"
       history:
         heading: User History
         table:
@@ -244,7 +244,7 @@ en:
           troubleshoot: Troubleshoot
         note: To fix common errors with this user's Subscriptions and Stats pages, and to reindex the user and their works and bookmarks, choose "Troubleshoot."
         page_heading: 'User: %{login} (%{id})'
-        page_title: '%{login} - User Administration'
+        page_title: "%{login} - User Administration"
         status:
           form:
             admin_action:
@@ -303,7 +303,7 @@ en:
     blacklist:
       emails_found:
         one: one email found
-        other: '%{count} emails found'
+        other: "%{count} emails found"
     blacklisted_emails:
       create:
         browser_title: Create Banned Email
@@ -360,7 +360,7 @@ en:
     passwords:
       edit:
         describedby:
-          password_length: '%{minimum} to %{maximum} characters'
+          password_length: "%{minimum} to %{maximum} characters"
         label:
           confirmation: Confirm new password
           password: New password
@@ -418,8 +418,8 @@ en:
           disable_support_form: Turn Off Support Form
           performance_and_misc: Performance and Misc
         queue_status:
-          one: '%{count} person is scheduled to be sent an invitation at %{time}.'
-          other: '%{count} people are scheduled to be sent invitations at %{time}.'
+          one: "%{count} person is scheduled to be sent an invitation at %{time}."
+          other: "%{count} people are scheduled to be sent invitations at %{time}."
         queue_status_help: "(The automatic task that invites people from the queue runs at most every hour. Don't be alarmed if the time you see is within the last hour. Do be alarmed if the time you see is more than one hour in the past and the queue is supposed to be active.)"
         update: Update
       update:
@@ -682,7 +682,7 @@ en:
         fandom: Fandom %{allowed_fandom_count}
   challenge_assignments:
     assignment_blurb:
-      header_draft_html: '%{title_link} (Draft)'
+      header_draft_html: "%{title_link} (Draft)"
       stats:
         creation:
           posted: 'Posted:'
@@ -911,7 +911,7 @@ en:
           draft: Sorry, you can't comment on a draft.
           hidden: Sorry, you can't add or edit comments on a hidden work.
           unrevealed: Sorry, you can't add or edit comments on an unrevealed work.
-      previous_chapter_html: '%{back_arrow_html} Previous Chapter'
+      previous_chapter_html: "%{back_arrow_html} Previous Chapter"
     confirm_delete:
       confirm_button: Yes, delete!
       delete_confirmation: Are you sure you want to delete this comment?
@@ -937,8 +937,8 @@ en:
       comment: drop by the Archive and comment
       end_notes: End Notes
       inspired_by:
-        restricted_html: '[Restricted Work] by %{creator_link}'
-        revealed_html: '%{work_link} by %{creator_link}'
+        restricted_html: "[Restricted Work] by %{creator_link}"
+        revealed_html: "%{work_link} by %{creator_link}"
         title: Works inspired by this one
         unrevealed: A work in an unrevealed collection
       please_comment_html: Please %{comment_link} to let the creator know if you enjoyed their work!
@@ -973,7 +973,7 @@ en:
       series_list_html: Part %{position} of %{series_link}
       stats: 'Stats:'
       summary: Summary
-      tag_type: '%{tag_type}:'
+      tag_type: "%{tag_type}:"
       translated_to:
         restricted_html: 'Translation into %{language} available: [Restricted Work] by %{creator_link}'
         revealed_html: 'Translation into %{language} available: %{work_link} by %{creator_link}'
@@ -1085,7 +1085,7 @@ en:
       abuse:
         contact: contact our Policy and Abuse team
         reports_html: For reports of violations of the Terms of Service such as harassment, spam, or plagiarism, or if you believe your account has been hacked, please %{contact_link} instead. We cannot act on these reports or provide information about Policy and Abuse cases.
-      do_not_spam_html: '<strong>We respond to every report we receive, but we are a small volunteer team.</strong> For this reason, we ask you to not submit multiple reports regarding any one issue, or encourage other people to report the same issue, unless there is additional information to offer.'
+      do_not_spam_html: "<strong>We respond to every report we receive, but we are a small volunteer team.</strong> For this reason, we ask you to not submit multiple reports regarding any one issue, or encourage other people to report the same issue, unless there is additional information to offer."
       form:
         comment:
           description: Please be as specific as possible, including error messages and/or links
@@ -1112,7 +1112,7 @@ en:
         landmark:
           reference: Reference Links
         page_title: Support and Feedback
-      languages_html: '<strong>We can answer Support inquiries in %{list_html}.</strong> Please allow for additional delay for responses in any language other than English.'
+      languages_html: "<strong>We can answer Support inquiries in %{list_html}.</strong> Please allow for additional delay for responses in any language other than English."
       navigation:
         faqs: FAQs & Tutorials
         known_issues: Known Issues
@@ -1132,7 +1132,7 @@ en:
         tag_changes: Requests to canonize or change tags
         work_problems: Works labeled with the wrong language or duplicate works
       status:
-        bluesky: '@status.archiveofourown.org'
+        bluesky: "@status.archiveofourown.org"
         current_html: For current updates on AO3 performance or downtime, please check our %{status_page_link} and follow %{bluesky_link} on Bluesky or %{tumblr_link} on Tumblr.
         status_page: status page
         tumblr: ao3org
@@ -1233,26 +1233,26 @@ en:
         description: 'When you enter HTML into the archive, we do some cleanup on it to make sure that it is safe (so spammers and hackers cannot upload badness) and try and do some basic formatting both for your convenience and for accessibility reasons. Here are the formatting steps we take:'
         example:
           blockquote:
-            description_html: '&lt;blockquote&gt;%{text_blockquote}&lt;/blockquote&gt;'
+            description_html: "&lt;blockquote&gt;%{text_blockquote}&lt;/blockquote&gt;"
             text: To quote a block of text
-          chapter_title: '<h3>Chapter title<h3>'
+          chapter_title: "<h3>Chapter title<h3>"
           cite:
             description_html: Try cite to cite &lt;cite&gt;%{phrase_or_title_cite}&lt;/cite&gt;
             phrase_or_title: a phrase or title
           em:
-            description_html: '&lt;em&gt;%{rodney_italic}&lt;/em&gt; McKay'
+            description_html: "&lt;em&gt;%{rodney_italic}&lt;/em&gt; McKay"
             rodney: Rodney
-          footnote_title: '<h6>Footnote title<h6>'
+          footnote_title: "<h6>Footnote title<h6>"
           inline_quote:
             description_html: Use q to &lt;q&gt;%{phrase_inline_quote}&lt;/q&gt;
             phrase: To quote a phrase
-          scene_title: '<h4>Scene title<h4>'
+          scene_title: "<h4>Scene title<h4>"
           strong:
             description_html: I will &lt;strong&gt;%{never_bold}&lt;/strong&gt; understand you!
             never: never
-          subtitle_h2: '<h2>Subtitle<h2>'
-          subtitle_h5: '<h5>Subtitle<h5>'
-          title: '<h1>Title<h1>'
+          subtitle_h2: "<h2>Subtitle<h2>"
+          subtitle_h5: "<h5>Subtitle<h5>"
+          title: "<h1>Title<h1>"
         forgotten_open_tags: If you have forgotten to close a formatting tag, it will be closed at the end of the paragraph for you.
         good_html_note_html: Good HTML means HTML that labels what the text is supposed to be -- so if you have paragraphs, they should be inside paragraph tags, not just separated with break tags. If you have emphasized text, it should be inside em tags. If you have a list of items, each item should be inside list tags. If you %{negation_italic} have a list of items, you shouldn't have list tags. :) (We are putting together a set of more detailed helpful references about this, but this is the basic idea.)
         header: How Do We Format Your HTML?
@@ -1370,9 +1370,9 @@ en:
         reverse_underscore: Start with fandom, then with author, then title, with underscores instead of dashes.
       page_heading: Work Title Format
     rte:
-      description_html: "The exact behavior of the Rich Text Editor (%{rte_abbreviation}) depends on your device, browser, and operating system as well as the source you're pasting from. However, starting with a well-formatted document will help you get the most out of the %{rte_abbreviation_no_title}. Here are some general tips to ensure that as much of your formatting as possible will be retained:"
+      description_html: 'The exact behavior of the Rich Text Editor (%{rte_abbreviation}) depends on your device, browser, and operating system as well as the source you''re pasting from. However, starting with a well-formatted document will help you get the most out of the %{rte_abbreviation_no_title}. Here are some general tips to ensure that as much of your formatting as possible will be retained:'
       enter_once:
-        description_html: '%{intro_sentence_bold_html} Pressing %{enter_for_twice_key} twice will insert a blank paragraph, creating additional, and likely unwanted, space between paragraphs when you paste into the %{rte_abbreviation}. The Archive uses top and bottom margins to create the appearance of a blank line between paragraphs; you can use the paragraph formatting options in your text editor to create a similar effect without adding extra %{p_tag_code} tags.'
+        description_html: "%{intro_sentence_bold_html} Pressing %{enter_for_twice_key} twice will insert a blank paragraph, creating additional, and likely unwanted, space between paragraphs when you paste into the %{rte_abbreviation}. The Archive uses top and bottom margins to create the appearance of a blank line between paragraphs; you can use the paragraph formatting options in your text editor to create a similar effect without adding extra %{p_tag_code} tags."
         enter_for_once: Enter
         enter_for_twice: Enter
         intro_sentence_html: Press %{enter_for_once_key} %{once_italic} between paragraphs.
@@ -1487,7 +1487,7 @@ en:
         header: You can create new skins for the Archive using our wizard, or by writing your own CSS (cascading style sheets) code
       numeric_values:
         description:
-          em_unit_html: "PS: we highly encourage learning about and using %{em_code}, which lets you set things relative to the viewer's current font size! It will make your layouts much more flexible and responsive to different browser/font settings."
+          em_unit_html: 'PS: we highly encourage learning about and using %{em_code}, which lets you set things relative to the viewer''s current font size! It will make your layouts much more flexible and responsive to different browser/font settings.'
           precision_html: 'You can specify numeric values up to two decimal places, either as percentages or in %{various_units_link}: %{units_list_code}'
           units_list: cm, em, ex, in, mm, pc, pt, px
           various_units: various units
@@ -1500,7 +1500,7 @@ en:
         header: Scale
         numeric_value: numeric value
       skin_examples:
-        description_html: '%{public_skins_link} are visible and you can read their code and copy them to edit for your own use.'
+        description_html: "%{public_skins_link} are visible and you can read their code and copy them to edit for your own use."
         header: Look at other public skins for examples
         public_skins: All approved public skins
     skins_parents:
@@ -1601,7 +1601,7 @@ en:
         description: This is for content with adult themes (sex, violence, etc.) that isn't as graphic as explicit-rated content.
         header: Mature (Adult!)
       more_info:
-        html: '(For more information, see the %{ratings_and_warnings_tos_section_link}.)'
+        html: "(For more information, see the %{ratings_and_warnings_tos_section_link}.)"
         ratings_and_warnings_tos_section: Ratings and Warnings section of the %{app_name} Terms of Service
       not_rated:
         description: For searching, screening, and other Archive functions, this may get treated the same way as explicit-rated content.  In reality, it could be anything from porn to completely family-friendly stuff.  Choose this rating if you prefer not to rate your content (because you don't like ratings, because you're trying to avoid spoilers, etc.).
@@ -1670,14 +1670,14 @@ en:
         otw_long: Organization for Transformative Works
       major_projects:
         fanlore: Fanlore
-        fanlore_details_html: '%{fanlore_link}, a fandom wiki devoted to preserving the history of transformative fanworks and the fandoms from which they have arisen.'
+        fanlore_details_html: "%{fanlore_link}, a fandom wiki devoted to preserving the history of transformative fanworks and the fandoms from which they have arisen."
         legal_advocacy: Legal Advocacy
-        legal_details_html: '%{legal_advocacy_link} committed to protecting and defending fanworks from commercial exploitation and legal challenge.'
+        legal_details_html: "%{legal_advocacy_link} committed to protecting and defending fanworks from commercial exploitation and legal challenge."
         open_doors: Open Doors
-        open_doors_details_html: '%{open_doors_link}, which offers shelter to at-risk fannish projects.'
+        open_doors_details_html: "%{open_doors_link}, which offers shelter to at-risk fannish projects."
         title: 'Our other major projects include:'
         twc: Transformative Works and Cultures
-        twc_details_html: '%{twc_link}, a peer-reviewed academic journal that seeks to promote scholarship on fanworks and practices.'
+        twc_details_html: "%{twc_link}, a peer-reviewed academic journal that seeks to promote scholarship on fanworks and practices."
       more_info:
         communications_team: Communications team
         faq_page: FAQ page
@@ -1690,7 +1690,7 @@ en:
         heading: II.C. Commercial Promotion
         not_allowed: Promotion, solicitation, and advertisement of commercial products or activities are not allowed.
         tos_faq: FAQ for Section II.C
-        tos_faq_in_parens_html: '(%{tos_faq_link})'
+        tos_faq_in_parens_html: "(%{tos_faq_link})"
         tos_faq_link_label: Commercial Promotion FAQ
       content_policy: Content Policy
       content_policy_heading: II. Content Policy
@@ -1699,20 +1699,20 @@ en:
         heading: II.D. Copyright Infringement
         not_allowed: Reproductions of large excerpts of copyrighted works are not allowed without the consent of the copyright owner. This includes stories, artwork, songs, poems, transcripts, and other copyrighted material. Crediting the original creator does not give you the right to upload, podfic, or translate someone else's work without permission, regardless of whether the source is a fanwork or a professionally published work.
         tos_faq: FAQ for Section II.D
-        tos_faq_in_parens_html: '(%{tos_faq_link})'
+        tos_faq_in_parens_html: "(%{tos_faq_link})"
         tos_faq_link_label: Copyright Infringement and Plagiarism FAQ
         transformative_fanworks: transformative fanworks
         transformative_works_legal_html: We believe that %{transformative_fanworks_link} are legal. Complaints about the mere existence of fanworks that mention trademarks or are based on copyrighted material will not be pursued.
       effective: 'Effective: November 19, 2024'
       fanworks:
         bookmarks: Bookmarks
-        bookmarks_only_fanworks_html: '%{bookmarks_link} must only be created for fanworks. You may create %{external_bookmarks_link} for fanworks hosted on third-party sites.'
+        bookmarks_only_fanworks_html: "%{bookmarks_link} must only be created for fanworks. You may create %{external_bookmarks_link} for fanworks hosted on third-party sites."
         external_bookmarks: external bookmarks
         heading: II.B. Fanworks
         must_be_fanworks_html: Works must be fanworks. Posting a Work that primarily consists of %{non_fanwork_content_link} is not allowed.
         non_fanwork_content: non-fanwork Content
         tos_faq: FAQ for Section II.B
-        tos_faq_in_parens_html: '(%{tos_faq_link})'
+        tos_faq_in_parens_html: "(%{tos_faq_link})"
         tos_faq_link_label: Fanworks and Non-Fanwork Content FAQ
       harassment:
         advocating_harm:
@@ -1734,7 +1734,7 @@ en:
           text: Creating RPF never constitutes harassment in and of itself. Posting works where someone dies, is subjected to slurs, or is otherwise harmed as part of the plot is usually not a violation of the Harassment Policy. However, deliberately posting such Content in a manner designed to be seen by the subject of the work, such as by gifting them the work, may result in a judgment of harassment.
         threatening_versus_annoying_html: In general, threatening Content will be considered harassment, while Content that is merely rude or annoying will be allowed. Not everyone agrees about what is offensive and unacceptable. Users are encouraged to use tools such as %{blocking_link}, %{muting_link}, and %{filtering_link} to control their own environment on AO3.
         tos_faq: FAQ for Section II.H
-        tos_faq_in_parens_html: '(%{tos_faq_link})'
+        tos_faq_in_parens_html: "(%{tos_faq_link})"
         tos_faq_link_label: Harassment FAQ
       illegal_inappropriate_content:
         automated_spam_check_html: We may use automated means to filter out spam. If you submit Content that is erroneously caught in a spam filter, please %{contact_ao3_administrators_link}.
@@ -1747,7 +1747,7 @@ en:
         spamming_behavior: Spamming behavior is prohibited. Repeated identical or nearly identical posts in multiple places may be considered spam regardless of commercial content.
         technical_integrity: technical integrity
         tos_faq: FAQ for Section II.K
-        tos_faq_in_parens_html: '(%{tos_faq_link})'
+        tos_faq_in_parens_html: "(%{tos_faq_link})"
         tos_faq_link_label: Offensive Content vs Illegal Content FAQ
         violates_us_law_html: If you encounter Content that you believe violates a specific law of the United States, you can %{report_it_to_us_link}.
       impersonation:
@@ -1755,7 +1755,7 @@ en:
         heading: II.G. Impersonation
         html: You may not impersonate or misrepresent your affiliation with any person, entity, or %{function_link}. Fiction clearly marked as such is not considered impersonation.
         tos_faq: FAQ for Section II.G
-        tos_faq_in_parens_html: '(%{tos_faq_link})'
+        tos_faq_in_parens_html: "(%{tos_faq_link})"
         tos_faq_link_label: Fannish Identities and Impersonation FAQ
       intro:
         all_content_must_comply_html: All %{content_link} on AO3 must comply with our Content Policy.
@@ -1764,7 +1764,7 @@ en:
         maximum_inclusiveness: maximum inclusiveness of fanwork content
         our_goal_html: Our goal is %{maximum_inclusiveness_link}. We want to provide a safe and permanent home for fanworks, including works that might be at risk on other sites due to being deemed immoral, explicit, or otherwise objectionable. Users should always observe and heed the ratings and warnings provided before accessing works on AO3.
         report_it_to_us: report it to us
-        review_before_posting_html: '%{all_content_must_comply_bold} Please review this page carefully before you begin posting. Answers to common questions about the Content Policy can be found in the %{tos_faq_link}.'
+        review_before_posting_html: "%{all_content_must_comply_bold} Please review this page carefully before you begin posting. Answers to common questions about the Content Policy can be found in the %{tos_faq_link}."
         tos_faq: TOS FAQ
         we_do_not_prescreen: We do not prescreen content on AO3.
         you_can_report_html: If you encounter content that you believe violates our Content Policy, you can %{report_it_to_us_link}. %{we_do_not_prescreen_bold}
@@ -1783,13 +1783,13 @@ en:
         tags_applied_automatically_html: Some tags may be automatically applied to Works. In addition, AO3 administrators may determine that tags in a mandatory tag field on a Work are inaccurate or insufficient. In such cases, AO3 administrators may remove inaccurate tags; add non-specific tags to the Work; add specific tags to the Work in fields where non-specific tags are %{not_available_link}; require the creator to appropriately adjust the Work's tags; hide the Work; or take other appropriate action to address the matter. Refer to the %{tos_faq_link} for details about when AO3 administrators may enforce the presence or removal of tags in mandatory fields.
         tos_faq: TOS FAQ
         tos_faq_endnote: FAQ for Section II.J
-        tos_faq_in_parens_html: '(%{tos_faq_link})'
+        tos_faq_in_parens_html: "(%{tos_faq_link})"
         tos_faq_link_label: Ratings and Archive Warnings FAQ
       offensive_content:
         heading: II.A. Offensive Content
         removal_not_just_offensiveness: Unless it violates some other policy, we will not remove Content for offensiveness.
         tos_faq: FAQ for Section II.A
-        tos_faq_in_parens_html: '(%{tos_faq_link})'
+        tos_faq_in_parens_html: "(%{tos_faq_link})"
         tos_faq_link_label: Offensive Content vs Illegal Content FAQ
       page_content_landmark: Main Text
       page_heading: Content Policy
@@ -1805,14 +1805,14 @@ en:
         sharing_sufficient_information: sharing information sufficient to identify someone else's legal or professional identity or their physical location (e.g. phone numbers, email addresses, residential addresses, or hotel room numbers); and
         special_categories_of_personal_data: Special Categories of Personal Data
         tos_faq: FAQ for Section II.F
-        tos_faq_in_parens_html: '(%{tos_faq_link})'
+        tos_faq_in_parens_html: "(%{tos_faq_link})"
         tos_faq_link_label: Fannish Identities and Impersonation FAQ
       plagiarism:
         heading: II.E. Plagiarism
         html: Plagiarism is the use of someone else's words, or %{their_expressions_of_their_ideas_link}, without attribution. Minor alterations (such as replacing names, substituting synonyms, or rearranging a few words) are insufficient to make a work your own. Plagiarism is not allowed. Deliberately creating a work using the same general idea as another work is not plagiarism, but citation may be appropriate.
         their_expressions_of_their_ideas: their expressions of their ideas
         tos_faq: FAQ for Section II.E
-        tos_faq_in_parens_html: '(%{tos_faq_link})'
+        tos_faq_in_parens_html: "(%{tos_faq_link})"
         tos_faq_link_label: Copyright Infringement and Plagiarism FAQ
       privacy_policy: Privacy Policy
       terms_of_service: Terms of Service
@@ -1823,7 +1823,7 @@ en:
         heading: II.I. User Icons
         text: User icons must be appropriate for general audiences. They must not depict genital nudity, explicit sexual activity, hate symbols, or imagery that promotes, advocates, or causes harm.
         tos_faq: FAQ for Section II.I
-        tos_faq_in_parens_html: '(%{tos_faq_link})'
+        tos_faq_in_parens_html: "(%{tos_faq_link})"
         tos_faq_link_label: Usernames, Icons, and Profiles FAQ
     diversity_statement:
       archive_description_html: This archive is a permanent, panfandom place for fanworks, built by fans for fans. Whichever way you use the Archive, you're part of this, powering it, shaping it through your use and %{your_feedback_link}.
@@ -1838,7 +1838,7 @@ en:
         html: This work is licensed under a %{creative_commons_by_sa_link}.
         image_alt: Creative Commons License
       some_essential_parts: some essential parts
-      still_missing_html: "We know that there are %{some_essential_parts_link} that are still missing to make the Archive truly panfandom: the ability to host fanworks other than text, an interface in languages other than English, and more ways for you to connect with each other, to name just a few. But with your support, we'll get there."
+      still_missing_html: 'We know that there are %{some_essential_parts_link} that are still missing to make the Archive truly panfandom: the ability to host fanworks other than text, an interface in languages other than English, and more ways for you to connect with each other, to name just a few. But with your support, we''ll get there.'
       terms_of_service: Terms of Service
       we_build_for: We are building this archive for you. Come be a part of it.
       welcome_header: You are welcome at the Archive of Our Own.
@@ -1879,7 +1879,7 @@ en:
           title: Is it later already?
         note: Some works you've marked for later.
       social:
-        bluesky: '@status.archiveofourown.org on Bluesky'
+        bluesky: "@status.archiveofourown.org on Bluesky"
         heading: Follow us
         note_html: Follow AO3 on Bluesky or Tumblr for status updates, and don't forget to check out the %{other_outlets_link} for updates on our other projects!
         other_outlets: Organization for Transformative Works' news outlets
@@ -2142,17 +2142,17 @@ en:
           privacy_policy: Privacy Policy
         entirety_of_agreement:
           entirety_of_agreement: 'Entirety of agreement:'
-          html: '%{entirety_of_agreement} These Terms of Service constitute the entire agreement between you and the Organization for Transformative Works (OTW) and govern your use of AO3. They replace all prior agreements between you and the OTW concerning your use of AO3. They do not govern your use of any other OTW sites and/or projects, all of which are covered under separate agreements.'
+          html: "%{entirety_of_agreement} These Terms of Service constitute the entire agreement between you and the Organization for Transformative Works (OTW) and govern your use of AO3. They replace all prior agreements between you and the OTW concerning your use of AO3. They do not govern your use of any other OTW sites and/or projects, all of which are covered under separate agreements."
         heading: I.A. General terms
         jurisdiction:
-          html: '%{jurisdiction} The AO3 TOS, the relationship between you and the OTW, and all disputes arising out of or related to them shall be governed by the laws of the United States and specifically %{the_state_of_new_york_link}, without regard to any conflict-of-law provisions. You and the OTW agree to submit to the personal and exclusive jurisdiction of the courts located within New York County (Manhattan), New York, and to waive any objection to the laying of venue there.'
+          html: "%{jurisdiction} The AO3 TOS, the relationship between you and the OTW, and all disputes arising out of or related to them shall be governed by the laws of the United States and specifically %{the_state_of_new_york_link}, without regard to any conflict-of-law provisions. You and the OTW agree to submit to the personal and exclusive jurisdiction of the courts located within New York County (Manhattan), New York, and to waive any objection to the laying of venue there."
           jurisdiction: 'Jurisdiction:'
           the_state_of_new_york: the State of New York
         limitation_on_claims:
-          html: '%{limitation_on_claims} You agree that, regardless of any statute or law to the contrary, any claim or cause of action arising out of or related to any use of AO3 or its TOS must be filed within one (1) year after such claim or cause of action arose or be forever barred.'
+          html: "%{limitation_on_claims} You agree that, regardless of any statute or law to the contrary, any claim or cause of action arising out of or related to any use of AO3 or its TOS must be filed within one (1) year after such claim or cause of action arose or be forever barred."
           limitation_on_claims: 'Limitation on claims:'
         no_assignment:
-          html: '%{no_assignment} These TOS are personal to you. You may not assign or transfer your rights or obligations under these TOS to any other person or entity, and any attempted assignment or transfer is void.'
+          html: "%{no_assignment} These TOS are personal to you. You may not assign or transfer your rights or obligations under these TOS to any other person or entity, and any attempted assignment or transfer is void."
           no_assignment: 'No assignment:'
         non_severability:
           html: "%{non_severability} The OTW's failure to enforce any part of the TOS will not waive the OTW's ability to enforce it. Any waiver with regard to a specific instance shall not constitute a waiver of any other breaches of the TOS, even with regard to the same user. If any provision of the TOS is found by a court of competent jurisdiction to be invalid, you agree that the court should give effect to the party's intentions as reflected in the provision, and that all other provisions of the TOS remain in full force and effect."
@@ -2245,7 +2245,7 @@ en:
     tos_navigation:
       content: Content Policy
       privacy: Privacy Policy
-      top: '%{arrow} Top'
+      top: "%{arrow} Top"
       tos: Terms of Service
       tos_faq: TOS FAQ
     tos_toc:
@@ -2327,7 +2327,7 @@ en:
       page_heading: Invitation Requests
       queue_disabled:
         closed: New invitation requests are currently closed.
-        html: '%{closed_bold} For more information, please check the %{news_link}.'
+        html: "%{closed_bold} For more information, please check the %{news_link}."
         news: '"Invitations" tag on AO3 News'
       waiting_list_count:
         one: There is %{count} person remaining on the waiting list.
@@ -2340,10 +2340,10 @@ en:
       details_html: To get a free Archive of Our Own account, you need an Invitation. By submitting your email address to our invitation queue, you confirm that you are at least 13 years old, and if you're in a country whose residents/citizens have to be of an age older than 13 to consent, you are old enough to consent to the processing of your personal data without our obtaining written permission from a parent or legal guardian. We will use the email address you submit only to send you an Invitation and to process/manage your account activation. Please don't request an Invitation unless you've read our %{tos_link}, including the %{content_policy_link} and %{privacy_policy_link}, and agree to abide by those Terms.
       frequency:
         one: hour
-        other: '%{count} hours'
+        other: "%{count} hours"
       invitation_number:
-        one: '%{count} invitation'
-        other: '%{count} invitations'
+        one: "%{count} invitation"
+        other: "%{count} invitations"
       invitation_send_rate: We are sending out %{queue_invitation_number} every %{queue_frequency}.
       page_heading: Invitation Requests
       privacy_policy: Privacy Policy
@@ -2380,11 +2380,11 @@ en:
     status:
       frequency:
         one: hour
-        other: '%{count} hours'
+        other: "%{count} hours"
       heading: Invitation Request Status
       invitation_number:
-        one: '%{count} invitation'
-        other: '%{count} invitations'
+        one: "%{count} invitation"
+        other: "%{count} invitations"
       invitation_send_rate: We are sending out %{queue_invitation_number} every %{queue_frequency}.
       search: Look me up
       waiting_list:
@@ -2392,12 +2392,12 @@ en:
         other: There are currently %{count} people on the waiting list.
   kudos:
     guest_header:
-      one: '%{count} guest has also left kudos'
-      other: '%{count} guests have also left kudos'
+      one: "%{count} guest has also left kudos"
+      other: "%{count} guests have also left kudos"
     user_links:
       more_link:
-        one: '%{count} more user'
-        other: '%{count} more users'
+        one: "%{count} more user"
+        other: "%{count} more users"
   languages:
     form:
       abuse_support_available: Abuse support available
@@ -2410,15 +2410,15 @@ en:
         update: Update Language
       support_available: Support available
     index:
-      language_code_format_html: '(%{code})'
+      language_code_format_html: "(%{code})"
       navigation:
         add: Add a Language
         edit: Edit
         suggest: Suggest a Language
       page_heading: Work Languages
       works_count:
-        one: '%{formatted_count} work'
-        other: '%{formatted_count} works'
+        one: "%{formatted_count} work"
+        other: "%{formatted_count} works"
   layouts:
     banner:
       hide: hide banner
@@ -2444,7 +2444,7 @@ en:
         gpl_2_0_or_later: GPL-2.0-or-later
         header: Development
         known_issues: Known Issues
-        license_details_html: '%{license_link} by the %{otw_link}'
+        license_details_html: "%{license_link} by the %{otw_link}"
         view_license: View License
       landmark: Footer
       otw:
@@ -2563,7 +2563,7 @@ en:
     aria_label:
       nav: Pagination
     next: Next →
-    prev: '← Previous'
+    prev: "← Previous"
   potential_matches:
     in_progress:
       cancel: Cancel Potential Match Generation
@@ -2658,8 +2658,8 @@ en:
       update: Update
     pseud_list:
       more_pseuds:
-        one: '%{count} more pseud'
-        other: '%{count} more pseuds'
+        one: "%{count} more pseud"
+        other: "%{count} more pseuds"
     show:
       delete_account_confirmation: This will permanently delete your account and cannot be undone. Are you sure?
       delete_my_account: Delete My Account
@@ -2691,11 +2691,11 @@ en:
       confirm_delete: Are you sure?
       default_pseud: Default Pseud
       delete_html: Delete%{landmark_span}
-      delete_landmark_text: ' %{pseud}'
+      delete_landmark_text: " %{pseud}"
       edit_html: Edit%{landmark_span}
-      edit_landmark_text: ' %{pseud}'
+      edit_landmark_text: " %{pseud}"
       orphan_html: Orphan Works%{landmark_span}
-      orphan_landmark_text: ' by %{pseud}'
+      orphan_landmark_text: " by %{pseud}"
       user_actions: User Actions
     pseuds_form:
       cannot_change_matching_pseud_html: You cannot change the pseud that matches your username. However, you can %{change_username_link} instead.
@@ -2734,16 +2734,16 @@ en:
       page_heading: "%{login}'s Related Works"
   series:
     series_module:
-      hidden_by_admin_alt: '(Hidden by Admin)'
+      hidden_by_admin_alt: "(Hidden by Admin)"
       hidden_by_administrator: Hidden by Administrator
       landmark:
         fandom: Fandom
         summary: Summary
       restricted: Restricted
-      restricted_alt: '(Restricted)'
-      series_by_html: '%{series_title_link} by %{byline}'
+      restricted_alt: "(Restricted)"
+      series_by_html: "%{series_title_link} by %{byline}"
     series_order:
-      draft_work_title: '%{title} (DRAFT)'
+      draft_work_title: "%{title} (DRAFT)"
   skins:
     confirm_delete:
       confirm_html: Are you sure you want to <strong><em>delete</em></strong> the skin "%{skin_title}"?
@@ -2808,13 +2808,13 @@ en:
         series: My Series Subscriptions
         users: My User Subscriptions
         works: My Work Subscriptions
-      series: '(Series)'
-      work: '(Work)'
+      series: "(Series)"
+      work: "(Work)"
   tag_sets:
     nomination_review_heading:
       already_approved_fandoms: Already Approved Fandoms
-      left_to_review: '%{type} (%{count} left to review)'
-      paginated: '%{from} - %{to} of %{total} %{type}'
+      left_to_review: "%{type} (%{count} left to review)"
+      paginated: "%{from} - %{to} of %{total} %{type}"
   tag_wranglers:
     index:
       filters:
@@ -2823,42 +2823,42 @@ en:
         only_media: Only media
         only_wrangler: Only wrangler
     show:
-      last_wrangled_html: '%{wrangler_login} last wrangled at %{time}.'
+      last_wrangled_html: "%{wrangler_login} last wrangled at %{time}."
       tags_wrangled_csv: Tags Wrangled (CSV)
   tag_wranglings:
     index:
       general_resources:
         ao3_catch_and_release: AO3_Catch_and_Release
-        ao3_catch_and_release_html: '%{ao3_catch_and_release_link} - For more information, please see the %{ao3_wrangling_project_faq_link}'
+        ao3_catch_and_release_html: "%{ao3_catch_and_release_link} - For more information, please see the %{ao3_wrangling_project_faq_link}"
         ao3_wrangling_project_faq: Tag Wrangling AO3 Project FAQ
         current_wrangling_limitations: Current Wrangling Limitations
-        current_wrangling_limitations_html: '%{current_wrangling_limitations_link} - Details about current wrangling limitations and policies'
+        current_wrangling_limitations_html: "%{current_wrangling_limitations_link} - Details about current wrangling limitations and policies"
         fandom_and_megafandom_directory: Directory of Fandom & Megafandom Wiki Pages
-        fandom_and_megafandom_directory_html: '%{fandom_and_megafandom_directory_link} - All currently available fandom & megafandom wiki pages'
+        fandom_and_megafandom_directory_html: "%{fandom_and_megafandom_directory_link} - All currently available fandom & megafandom wiki pages"
         fandoms_in_need_of_cowranglers: Fandoms in need of Cowranglers
-        fandoms_in_need_of_cowranglers_html: '%{fandoms_in_need_of_cowranglers_link} - Interested in helping out a fandom in need?'
+        fandoms_in_need_of_cowranglers_html: "%{fandoms_in_need_of_cowranglers_link} - Interested in helping out a fandom in need?"
         heading: 'General Wrangling Resources:'
         otw_slack_chat: OTW Slack Chat
-        otw_slack_chat_html: '%{otw_slack_chat_link} - For more information please see the %{tag_wrangling_slack_tutorial_link}'
+        otw_slack_chat_html: "%{otw_slack_chat_link} - For more information please see the %{tag_wrangling_slack_tutorial_link}"
         tag_wranglers_mailing_list: Tag Wranglers Mailing List Conversations
-        tag_wranglers_mailing_list_html: '%{tag_wranglers_mailing_list_link} - Message Archive for the Tagwranglers Mailing List'
+        tag_wranglers_mailing_list_html: "%{tag_wranglers_mailing_list_link} - Message Archive for the Tagwranglers Mailing List"
         tag_wrangling_bugs: Tag Wrangling Bugs & Troubleshooting
-        tag_wrangling_bugs_html: '%{tag_wrangling_bugs_link} - Having technical issues while wrangling? Check here for solutions!'
+        tag_wrangling_bugs_html: "%{tag_wrangling_bugs_link} - Having technical issues while wrangling? Check here for solutions!"
         tag_wrangling_committee: Tag Wrangling Committee
-        tag_wrangling_committee_html: '%{tag_wrangling_committee_link} - Full collection of wiki links & policies'
+        tag_wrangling_committee_html: "%{tag_wrangling_committee_link} - Full collection of wiki links & policies"
         tag_wrangling_communication_policy: Tag Wrangling Communication Policy
-        tag_wrangling_communication_policy_html: '%{tag_wrangling_communication_policy_link} - Includes instructions for leaving tag comments and chat rules'
+        tag_wrangling_communication_policy_html: "%{tag_wrangling_communication_policy_link} - Includes instructions for leaving tag comments and chat rules"
         tag_wrangling_faq: Tag Wrangling FAQ
-        tag_wrangling_faq_html: '%{tag_wrangling_faq_link} - Check here to find answers to frequently asked questions'
+        tag_wrangling_faq_html: "%{tag_wrangling_faq_link} - Check here to find answers to frequently asked questions"
         tag_wrangling_moodle: Tag Wrangling Moodle
-        tag_wrangling_moodle_html: '%{tag_wrangling_moodle_link} - Additional modular training and support for all wranglers'
+        tag_wrangling_moodle_html: "%{tag_wrangling_moodle_link} - Additional modular training and support for all wranglers"
         tag_wrangling_slack_tutorial: Tag Wrangling Slack Tutorial
         tag_wrangling_training: Tag Wrangling Training
-        tag_wrangling_training_html: '%{tag_wrangling_training_link} - New wranglers, start here!'
+        tag_wrangling_training_html: "%{tag_wrangling_training_link} - New wranglers, start here!"
         unassigned_fandoms: Unassigned Fandoms
-        unassigned_fandoms_html: '%{unassigned_fandoms_link} - A list of all current unassigned fandoms'
+        unassigned_fandoms_html: "%{unassigned_fandoms_link} - A list of all current unassigned fandoms"
         vacations_and_retiring: Vacation and Retiring from Wrangling
-        vacations_and_retiring_html: '%{vacations_and_retiring_link} - Unable to wrangle for more than 2 weeks? Read about options for taking a break from wrangling!'
+        vacations_and_retiring_html: "%{vacations_and_retiring_link} - Unable to wrangle for more than 2 weeks? Read about options for taking a break from wrangling!"
       manage:
         comments: Comments (%{count})
         edit: Edit
@@ -2870,8 +2870,8 @@ en:
         landmark: Notes
         question_for_chair: Question for a Chair!
         question_for_supervisor: Question for a Supervisor!
-        tw_wranglers_quietroom_slack: '#tw-wranglers-quietroom'
-        tw_wranglers_slack: '#tw-wranglers'
+        tw_wranglers_quietroom_slack: "#tw-wranglers-quietroom"
+        tw_wranglers_slack: "#tw-wranglers"
         wrangle_to_guidelines_html: Wrangle tags in accordance with the %{wrangling_guidelines_link}.
         wrangling_guidelines: wrangling guidelines
       page_heading: Tag Wrangling
@@ -2889,7 +2889,7 @@ en:
         merger: Mergers
         relationship: Relationships
         subtag: SubTags
-      tag_type_and_count: '%{tag_type} (%{count})'
+      tag_type_and_count: "%{tag_type} (%{count})"
       unsorted_tags: Unsorted Tags (%{count})
       use_type:
         bookmarks: Bookmarks
@@ -2899,7 +2899,7 @@ en:
         private_bookmarks: Private Bookmarks
         taggings_count: Taggings Count
         works: Works
-      use_type_and_count: '%{use_type} (%{count})'
+      use_type_and_count: "%{use_type} (%{count})"
       wranglers: Wranglers
       wrangling_home: Wrangling Home
       wrangling_tools: Wrangling Tools
@@ -2952,7 +2952,7 @@ en:
   time:
     formats:
       date_short_html: <abbr class="day" title="%A">%a</abbr> %d <abbr class="month" title="%B">%b</abbr> %Y
-      date_html: '%d <abbr class="month" title="%B">%b</abbr> %Y'
+      date_blurb_html: '%d <abbr class="month" title="%B">%b</abbr> %Y'
   troubleshooting:
     show:
       fix_associations:
@@ -2992,7 +2992,7 @@ en:
       ticket_id: Ticket ID
     change_email:
       caution:
-        check_spam_html: '%{must_confirm_bold} Please check your spam folder or %{contact_support_link} if you do not receive the confirmation email.'
+        check_spam_html: "%{must_confirm_bold} Please check your spam folder or %{contact_support_link} if you do not receive the confirmation email."
         confirm_by: If you don't confirm your request by %{date}, your email address will not be changed.
         contact_support: contact Support
         must_confirm: You must use the link in the confirmation email in order to finish confirming your email change.
@@ -3018,8 +3018,8 @@ en:
       old_password: Old password
       page_heading: Change Password
       password_length:
-        one: '%{minimum} to %{count} character'
-        other: '%{minimum} to %{count} characters'
+        one: "%{minimum} to %{count} character"
+        other: "%{minimum} to %{count} characters"
       submit: Submit
     change_username:
       account_faq: Account FAQ
@@ -3041,7 +3041,7 @@ en:
       password: Password
       submit: Change Username
       submit_landmark: Submit
-      username_requirements: '%{minimum} to %{maximum} characters (A-Z, a-z, _, 0-9 only), no spaces, cannot begin or end with underscore (_)'
+      username_requirements: "%{minimum} to %{maximum} characters (A-Z, a-z, _, 0-9 only), no spaces, cannot begin or end with underscore (_)"
     confirm_change_email:
       are_you_sure_html: Are you sure you want to change your email address to %{unconfirmed_email}? A confirmation email will be sent to this address.
       cancel: Cancel
@@ -3102,8 +3102,8 @@ en:
         new_password: New password
         page_heading: Change Password
         password_length:
-          one: '%{minimum} to %{count} character'
-          other: '%{minimum} to %{count} characters'
+          one: "%{minimum} to %{count} character"
+          other: "%{minimum} to %{count} characters"
         submit: Submit
       new:
         email_html: Email address
@@ -3133,10 +3133,10 @@ en:
         confirm_password: Confirm password
         confirm_password_validation: Please enter the same password in both fields.
         password: Password
-        password_requirements: '%{minimum} to %{maximum} characters'
+        password_requirements: "%{minimum} to %{maximum} characters"
         password_validation: Please enter a password! (At least %{minimum} characters long, please.)
         username: Username
-        username_requirements: '%{minimum} to %{maximum} characters (A-Z, a-z, _, 0-9 only), no spaces, cannot begin or end with underscore (_)'
+        username_requirements: "%{minimum} to %{maximum} characters (A-Z, a-z, _, 0-9 only), no spaces, cannot begin or end with underscore (_)"
         username_validation: You need a username! (At least %{minimum} letters long, please.)
         valid_email: Valid email
     sessions:
@@ -3258,7 +3258,7 @@ en:
         edit_tags_and_language_html: Edit Work Tags and Language for %{title}
         edit_tags_html: Edit Work Tags for %{title}
     import:
-      draft_work_title_html: '%{work_link} (Draft)'
+      draft_work_title_html: "%{work_link} (Draft)"
       page_heading: Imported Works
       success: We were able to successfully upload the following works.
     index:
@@ -3316,7 +3316,7 @@ en:
     show:
       unposted_deletion_notice_html: This work is a draft and has not been posted. The draft will be <strong>scheduled for deletion</strong> on %{deletion_date}.
     show_multiple:
-      draft: ' (Draft)'
+      draft: " (Draft)"
       no_works: You have no works or drafts to edit.
     skin:
       select: Select work skin
@@ -3328,8 +3328,8 @@ en:
       works_translation_link_help_title: Translation link
     work_approved_children:
       inspired_by:
-        restricted_html: '[Restricted Work] by %{creator_link} (Log in to access.)'
-        revealed_html: '%{work_link} by %{creator_link}'
+        restricted_html: "[Restricted Work] by %{creator_link} (Log in to access.)"
+        revealed_html: "%{work_link} by %{creator_link}"
         title: Works inspired by this one
         unrevealed: A work in an unrevealed collection
     work_form_associations_language:
@@ -3354,11 +3354,11 @@ en:
         revealed_html: Inspired by %{work_link} by %{creator_link}
         unrevealed: Inspired by a work in an unrevealed collection
       jump:
-        endnotes_and_related_works_html: '(See the end of the work for %{endnotes_link} and %{related_works_link}.)'
-        endnotes_html: '(See the end of the work for %{endnotes_link}.)'
+        endnotes_and_related_works_html: "(See the end of the work for %{endnotes_link} and %{related_works_link}.)"
+        endnotes_html: "(See the end of the work for %{endnotes_link}.)"
         more_notes: more notes
         notes: notes
-        related_works_html: '(See the end of the work for %{related_works_link}.)'
+        related_works_html: "(See the end of the work for %{related_works_link}.)"
       translated_to:
         restricted_html: 'Translation into %{language} available: [Restricted Work] by %{creator_link} (Log in to access.)'
         revealed_html: 'Translation into %{language} available: %{work_link} by %{creator_link}'

--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -6,7 +6,7 @@ en:
     new:
       do_not_spam:
         delay: it may take several months for us to get to your report
-        paragraph_html: "%{split_bold} Our volunteer team is small, so %{delay_link}."
+        paragraph_html: '%{split_bold} Our volunteer team is small, so %{delay_link}.'
         split: Please only report one user at a time, and do not submit multiple reports about the same user.
       form:
         comment:
@@ -185,7 +185,7 @@ en:
           creations: Creations
         no_creations: This user has no works or comments.
         page_heading: Works and Comments by %{user} (%{id})
-        page_title: "%{login} - User Creations"
+        page_title: '%{login} - User Creations'
       history:
         heading: User History
         table:
@@ -244,7 +244,7 @@ en:
           troubleshoot: Troubleshoot
         note: To fix common errors with this user's Subscriptions and Stats pages, and to reindex the user and their works and bookmarks, choose "Troubleshoot."
         page_heading: 'User: %{login} (%{id})'
-        page_title: "%{login} - User Administration"
+        page_title: '%{login} - User Administration'
         status:
           form:
             admin_action:
@@ -303,7 +303,7 @@ en:
     blacklist:
       emails_found:
         one: one email found
-        other: "%{count} emails found"
+        other: '%{count} emails found'
     blacklisted_emails:
       create:
         browser_title: Create Banned Email
@@ -360,7 +360,7 @@ en:
     passwords:
       edit:
         describedby:
-          password_length: "%{minimum} to %{maximum} characters"
+          password_length: '%{minimum} to %{maximum} characters'
         label:
           confirmation: Confirm new password
           password: New password
@@ -418,8 +418,8 @@ en:
           disable_support_form: Turn Off Support Form
           performance_and_misc: Performance and Misc
         queue_status:
-          one: "%{count} person is scheduled to be sent an invitation at %{time}."
-          other: "%{count} people are scheduled to be sent invitations at %{time}."
+          one: '%{count} person is scheduled to be sent an invitation at %{time}.'
+          other: '%{count} people are scheduled to be sent invitations at %{time}.'
         queue_status_help: "(The automatic task that invites people from the queue runs at most every hour. Don't be alarmed if the time you see is within the last hour. Do be alarmed if the time you see is more than one hour in the past and the queue is supposed to be active.)"
         update: Update
       update:
@@ -682,7 +682,7 @@ en:
         fandom: Fandom %{allowed_fandom_count}
   challenge_assignments:
     assignment_blurb:
-      header_draft_html: "%{title_link} (Draft)"
+      header_draft_html: '%{title_link} (Draft)'
       stats:
         creation:
           posted: 'Posted:'
@@ -911,7 +911,7 @@ en:
           draft: Sorry, you can't comment on a draft.
           hidden: Sorry, you can't add or edit comments on a hidden work.
           unrevealed: Sorry, you can't add or edit comments on an unrevealed work.
-      previous_chapter_html: "%{back_arrow_html} Previous Chapter"
+      previous_chapter_html: '%{back_arrow_html} Previous Chapter'
     confirm_delete:
       confirm_button: Yes, delete!
       delete_confirmation: Are you sure you want to delete this comment?
@@ -937,8 +937,8 @@ en:
       comment: drop by the Archive and comment
       end_notes: End Notes
       inspired_by:
-        restricted_html: "[Restricted Work] by %{creator_link}"
-        revealed_html: "%{work_link} by %{creator_link}"
+        restricted_html: '[Restricted Work] by %{creator_link}'
+        revealed_html: '%{work_link} by %{creator_link}'
         title: Works inspired by this one
         unrevealed: A work in an unrevealed collection
       please_comment_html: Please %{comment_link} to let the creator know if you enjoyed their work!
@@ -973,7 +973,7 @@ en:
       series_list_html: Part %{position} of %{series_link}
       stats: 'Stats:'
       summary: Summary
-      tag_type: "%{tag_type}:"
+      tag_type: '%{tag_type}:'
       translated_to:
         restricted_html: 'Translation into %{language} available: [Restricted Work] by %{creator_link}'
         revealed_html: 'Translation into %{language} available: %{work_link} by %{creator_link}'
@@ -1085,7 +1085,7 @@ en:
       abuse:
         contact: contact our Policy and Abuse team
         reports_html: For reports of violations of the Terms of Service such as harassment, spam, or plagiarism, or if you believe your account has been hacked, please %{contact_link} instead. We cannot act on these reports or provide information about Policy and Abuse cases.
-      do_not_spam_html: "<strong>We respond to every report we receive, but we are a small volunteer team.</strong> For this reason, we ask you to not submit multiple reports regarding any one issue, or encourage other people to report the same issue, unless there is additional information to offer."
+      do_not_spam_html: '<strong>We respond to every report we receive, but we are a small volunteer team.</strong> For this reason, we ask you to not submit multiple reports regarding any one issue, or encourage other people to report the same issue, unless there is additional information to offer.'
       form:
         comment:
           description: Please be as specific as possible, including error messages and/or links
@@ -1112,7 +1112,7 @@ en:
         landmark:
           reference: Reference Links
         page_title: Support and Feedback
-      languages_html: "<strong>We can answer Support inquiries in %{list_html}.</strong> Please allow for additional delay for responses in any language other than English."
+      languages_html: '<strong>We can answer Support inquiries in %{list_html}.</strong> Please allow for additional delay for responses in any language other than English.'
       navigation:
         faqs: FAQs & Tutorials
         known_issues: Known Issues
@@ -1132,7 +1132,7 @@ en:
         tag_changes: Requests to canonize or change tags
         work_problems: Works labeled with the wrong language or duplicate works
       status:
-        bluesky: "@status.archiveofourown.org"
+        bluesky: '@status.archiveofourown.org'
         current_html: For current updates on AO3 performance or downtime, please check our %{status_page_link} and follow %{bluesky_link} on Bluesky or %{tumblr_link} on Tumblr.
         status_page: status page
         tumblr: ao3org
@@ -1233,26 +1233,26 @@ en:
         description: 'When you enter HTML into the archive, we do some cleanup on it to make sure that it is safe (so spammers and hackers cannot upload badness) and try and do some basic formatting both for your convenience and for accessibility reasons. Here are the formatting steps we take:'
         example:
           blockquote:
-            description_html: "&lt;blockquote&gt;%{text_blockquote}&lt;/blockquote&gt;"
+            description_html: '&lt;blockquote&gt;%{text_blockquote}&lt;/blockquote&gt;'
             text: To quote a block of text
-          chapter_title: "<h3>Chapter title<h3>"
+          chapter_title: '<h3>Chapter title<h3>'
           cite:
             description_html: Try cite to cite &lt;cite&gt;%{phrase_or_title_cite}&lt;/cite&gt;
             phrase_or_title: a phrase or title
           em:
-            description_html: "&lt;em&gt;%{rodney_italic}&lt;/em&gt; McKay"
+            description_html: '&lt;em&gt;%{rodney_italic}&lt;/em&gt; McKay'
             rodney: Rodney
-          footnote_title: "<h6>Footnote title<h6>"
+          footnote_title: '<h6>Footnote title<h6>'
           inline_quote:
             description_html: Use q to &lt;q&gt;%{phrase_inline_quote}&lt;/q&gt;
             phrase: To quote a phrase
-          scene_title: "<h4>Scene title<h4>"
+          scene_title: '<h4>Scene title<h4>'
           strong:
             description_html: I will &lt;strong&gt;%{never_bold}&lt;/strong&gt; understand you!
             never: never
-          subtitle_h2: "<h2>Subtitle<h2>"
-          subtitle_h5: "<h5>Subtitle<h5>"
-          title: "<h1>Title<h1>"
+          subtitle_h2: '<h2>Subtitle<h2>'
+          subtitle_h5: '<h5>Subtitle<h5>'
+          title: '<h1>Title<h1>'
         forgotten_open_tags: If you have forgotten to close a formatting tag, it will be closed at the end of the paragraph for you.
         good_html_note_html: Good HTML means HTML that labels what the text is supposed to be -- so if you have paragraphs, they should be inside paragraph tags, not just separated with break tags. If you have emphasized text, it should be inside em tags. If you have a list of items, each item should be inside list tags. If you %{negation_italic} have a list of items, you shouldn't have list tags. :) (We are putting together a set of more detailed helpful references about this, but this is the basic idea.)
         header: How Do We Format Your HTML?
@@ -1370,9 +1370,9 @@ en:
         reverse_underscore: Start with fandom, then with author, then title, with underscores instead of dashes.
       page_heading: Work Title Format
     rte:
-      description_html: 'The exact behavior of the Rich Text Editor (%{rte_abbreviation}) depends on your device, browser, and operating system as well as the source you''re pasting from. However, starting with a well-formatted document will help you get the most out of the %{rte_abbreviation_no_title}. Here are some general tips to ensure that as much of your formatting as possible will be retained:'
+      description_html: "The exact behavior of the Rich Text Editor (%{rte_abbreviation}) depends on your device, browser, and operating system as well as the source you're pasting from. However, starting with a well-formatted document will help you get the most out of the %{rte_abbreviation_no_title}. Here are some general tips to ensure that as much of your formatting as possible will be retained:"
       enter_once:
-        description_html: "%{intro_sentence_bold_html} Pressing %{enter_for_twice_key} twice will insert a blank paragraph, creating additional, and likely unwanted, space between paragraphs when you paste into the %{rte_abbreviation}. The Archive uses top and bottom margins to create the appearance of a blank line between paragraphs; you can use the paragraph formatting options in your text editor to create a similar effect without adding extra %{p_tag_code} tags."
+        description_html: '%{intro_sentence_bold_html} Pressing %{enter_for_twice_key} twice will insert a blank paragraph, creating additional, and likely unwanted, space between paragraphs when you paste into the %{rte_abbreviation}. The Archive uses top and bottom margins to create the appearance of a blank line between paragraphs; you can use the paragraph formatting options in your text editor to create a similar effect without adding extra %{p_tag_code} tags.'
         enter_for_once: Enter
         enter_for_twice: Enter
         intro_sentence_html: Press %{enter_for_once_key} %{once_italic} between paragraphs.
@@ -1487,7 +1487,7 @@ en:
         header: You can create new skins for the Archive using our wizard, or by writing your own CSS (cascading style sheets) code
       numeric_values:
         description:
-          em_unit_html: 'PS: we highly encourage learning about and using %{em_code}, which lets you set things relative to the viewer''s current font size! It will make your layouts much more flexible and responsive to different browser/font settings.'
+          em_unit_html: "PS: we highly encourage learning about and using %{em_code}, which lets you set things relative to the viewer's current font size! It will make your layouts much more flexible and responsive to different browser/font settings."
           precision_html: 'You can specify numeric values up to two decimal places, either as percentages or in %{various_units_link}: %{units_list_code}'
           units_list: cm, em, ex, in, mm, pc, pt, px
           various_units: various units
@@ -1500,7 +1500,7 @@ en:
         header: Scale
         numeric_value: numeric value
       skin_examples:
-        description_html: "%{public_skins_link} are visible and you can read their code and copy them to edit for your own use."
+        description_html: '%{public_skins_link} are visible and you can read their code and copy them to edit for your own use.'
         header: Look at other public skins for examples
         public_skins: All approved public skins
     skins_parents:
@@ -1601,7 +1601,7 @@ en:
         description: This is for content with adult themes (sex, violence, etc.) that isn't as graphic as explicit-rated content.
         header: Mature (Adult!)
       more_info:
-        html: "(For more information, see the %{ratings_and_warnings_tos_section_link}.)"
+        html: '(For more information, see the %{ratings_and_warnings_tos_section_link}.)'
         ratings_and_warnings_tos_section: Ratings and Warnings section of the %{app_name} Terms of Service
       not_rated:
         description: For searching, screening, and other Archive functions, this may get treated the same way as explicit-rated content.  In reality, it could be anything from porn to completely family-friendly stuff.  Choose this rating if you prefer not to rate your content (because you don't like ratings, because you're trying to avoid spoilers, etc.).
@@ -1670,14 +1670,14 @@ en:
         otw_long: Organization for Transformative Works
       major_projects:
         fanlore: Fanlore
-        fanlore_details_html: "%{fanlore_link}, a fandom wiki devoted to preserving the history of transformative fanworks and the fandoms from which they have arisen."
+        fanlore_details_html: '%{fanlore_link}, a fandom wiki devoted to preserving the history of transformative fanworks and the fandoms from which they have arisen.'
         legal_advocacy: Legal Advocacy
-        legal_details_html: "%{legal_advocacy_link} committed to protecting and defending fanworks from commercial exploitation and legal challenge."
+        legal_details_html: '%{legal_advocacy_link} committed to protecting and defending fanworks from commercial exploitation and legal challenge.'
         open_doors: Open Doors
-        open_doors_details_html: "%{open_doors_link}, which offers shelter to at-risk fannish projects."
+        open_doors_details_html: '%{open_doors_link}, which offers shelter to at-risk fannish projects.'
         title: 'Our other major projects include:'
         twc: Transformative Works and Cultures
-        twc_details_html: "%{twc_link}, a peer-reviewed academic journal that seeks to promote scholarship on fanworks and practices."
+        twc_details_html: '%{twc_link}, a peer-reviewed academic journal that seeks to promote scholarship on fanworks and practices.'
       more_info:
         communications_team: Communications team
         faq_page: FAQ page
@@ -1690,7 +1690,7 @@ en:
         heading: II.C. Commercial Promotion
         not_allowed: Promotion, solicitation, and advertisement of commercial products or activities are not allowed.
         tos_faq: FAQ for Section II.C
-        tos_faq_in_parens_html: "(%{tos_faq_link})"
+        tos_faq_in_parens_html: '(%{tos_faq_link})'
         tos_faq_link_label: Commercial Promotion FAQ
       content_policy: Content Policy
       content_policy_heading: II. Content Policy
@@ -1699,20 +1699,20 @@ en:
         heading: II.D. Copyright Infringement
         not_allowed: Reproductions of large excerpts of copyrighted works are not allowed without the consent of the copyright owner. This includes stories, artwork, songs, poems, transcripts, and other copyrighted material. Crediting the original creator does not give you the right to upload, podfic, or translate someone else's work without permission, regardless of whether the source is a fanwork or a professionally published work.
         tos_faq: FAQ for Section II.D
-        tos_faq_in_parens_html: "(%{tos_faq_link})"
+        tos_faq_in_parens_html: '(%{tos_faq_link})'
         tos_faq_link_label: Copyright Infringement and Plagiarism FAQ
         transformative_fanworks: transformative fanworks
         transformative_works_legal_html: We believe that %{transformative_fanworks_link} are legal. Complaints about the mere existence of fanworks that mention trademarks or are based on copyrighted material will not be pursued.
       effective: 'Effective: November 19, 2024'
       fanworks:
         bookmarks: Bookmarks
-        bookmarks_only_fanworks_html: "%{bookmarks_link} must only be created for fanworks. You may create %{external_bookmarks_link} for fanworks hosted on third-party sites."
+        bookmarks_only_fanworks_html: '%{bookmarks_link} must only be created for fanworks. You may create %{external_bookmarks_link} for fanworks hosted on third-party sites.'
         external_bookmarks: external bookmarks
         heading: II.B. Fanworks
         must_be_fanworks_html: Works must be fanworks. Posting a Work that primarily consists of %{non_fanwork_content_link} is not allowed.
         non_fanwork_content: non-fanwork Content
         tos_faq: FAQ for Section II.B
-        tos_faq_in_parens_html: "(%{tos_faq_link})"
+        tos_faq_in_parens_html: '(%{tos_faq_link})'
         tos_faq_link_label: Fanworks and Non-Fanwork Content FAQ
       harassment:
         advocating_harm:
@@ -1734,7 +1734,7 @@ en:
           text: Creating RPF never constitutes harassment in and of itself. Posting works where someone dies, is subjected to slurs, or is otherwise harmed as part of the plot is usually not a violation of the Harassment Policy. However, deliberately posting such Content in a manner designed to be seen by the subject of the work, such as by gifting them the work, may result in a judgment of harassment.
         threatening_versus_annoying_html: In general, threatening Content will be considered harassment, while Content that is merely rude or annoying will be allowed. Not everyone agrees about what is offensive and unacceptable. Users are encouraged to use tools such as %{blocking_link}, %{muting_link}, and %{filtering_link} to control their own environment on AO3.
         tos_faq: FAQ for Section II.H
-        tos_faq_in_parens_html: "(%{tos_faq_link})"
+        tos_faq_in_parens_html: '(%{tos_faq_link})'
         tos_faq_link_label: Harassment FAQ
       illegal_inappropriate_content:
         automated_spam_check_html: We may use automated means to filter out spam. If you submit Content that is erroneously caught in a spam filter, please %{contact_ao3_administrators_link}.
@@ -1747,7 +1747,7 @@ en:
         spamming_behavior: Spamming behavior is prohibited. Repeated identical or nearly identical posts in multiple places may be considered spam regardless of commercial content.
         technical_integrity: technical integrity
         tos_faq: FAQ for Section II.K
-        tos_faq_in_parens_html: "(%{tos_faq_link})"
+        tos_faq_in_parens_html: '(%{tos_faq_link})'
         tos_faq_link_label: Offensive Content vs Illegal Content FAQ
         violates_us_law_html: If you encounter Content that you believe violates a specific law of the United States, you can %{report_it_to_us_link}.
       impersonation:
@@ -1755,7 +1755,7 @@ en:
         heading: II.G. Impersonation
         html: You may not impersonate or misrepresent your affiliation with any person, entity, or %{function_link}. Fiction clearly marked as such is not considered impersonation.
         tos_faq: FAQ for Section II.G
-        tos_faq_in_parens_html: "(%{tos_faq_link})"
+        tos_faq_in_parens_html: '(%{tos_faq_link})'
         tos_faq_link_label: Fannish Identities and Impersonation FAQ
       intro:
         all_content_must_comply_html: All %{content_link} on AO3 must comply with our Content Policy.
@@ -1764,7 +1764,7 @@ en:
         maximum_inclusiveness: maximum inclusiveness of fanwork content
         our_goal_html: Our goal is %{maximum_inclusiveness_link}. We want to provide a safe and permanent home for fanworks, including works that might be at risk on other sites due to being deemed immoral, explicit, or otherwise objectionable. Users should always observe and heed the ratings and warnings provided before accessing works on AO3.
         report_it_to_us: report it to us
-        review_before_posting_html: "%{all_content_must_comply_bold} Please review this page carefully before you begin posting. Answers to common questions about the Content Policy can be found in the %{tos_faq_link}."
+        review_before_posting_html: '%{all_content_must_comply_bold} Please review this page carefully before you begin posting. Answers to common questions about the Content Policy can be found in the %{tos_faq_link}.'
         tos_faq: TOS FAQ
         we_do_not_prescreen: We do not prescreen content on AO3.
         you_can_report_html: If you encounter content that you believe violates our Content Policy, you can %{report_it_to_us_link}. %{we_do_not_prescreen_bold}
@@ -1783,13 +1783,13 @@ en:
         tags_applied_automatically_html: Some tags may be automatically applied to Works. In addition, AO3 administrators may determine that tags in a mandatory tag field on a Work are inaccurate or insufficient. In such cases, AO3 administrators may remove inaccurate tags; add non-specific tags to the Work; add specific tags to the Work in fields where non-specific tags are %{not_available_link}; require the creator to appropriately adjust the Work's tags; hide the Work; or take other appropriate action to address the matter. Refer to the %{tos_faq_link} for details about when AO3 administrators may enforce the presence or removal of tags in mandatory fields.
         tos_faq: TOS FAQ
         tos_faq_endnote: FAQ for Section II.J
-        tos_faq_in_parens_html: "(%{tos_faq_link})"
+        tos_faq_in_parens_html: '(%{tos_faq_link})'
         tos_faq_link_label: Ratings and Archive Warnings FAQ
       offensive_content:
         heading: II.A. Offensive Content
         removal_not_just_offensiveness: Unless it violates some other policy, we will not remove Content for offensiveness.
         tos_faq: FAQ for Section II.A
-        tos_faq_in_parens_html: "(%{tos_faq_link})"
+        tos_faq_in_parens_html: '(%{tos_faq_link})'
         tos_faq_link_label: Offensive Content vs Illegal Content FAQ
       page_content_landmark: Main Text
       page_heading: Content Policy
@@ -1805,14 +1805,14 @@ en:
         sharing_sufficient_information: sharing information sufficient to identify someone else's legal or professional identity or their physical location (e.g. phone numbers, email addresses, residential addresses, or hotel room numbers); and
         special_categories_of_personal_data: Special Categories of Personal Data
         tos_faq: FAQ for Section II.F
-        tos_faq_in_parens_html: "(%{tos_faq_link})"
+        tos_faq_in_parens_html: '(%{tos_faq_link})'
         tos_faq_link_label: Fannish Identities and Impersonation FAQ
       plagiarism:
         heading: II.E. Plagiarism
         html: Plagiarism is the use of someone else's words, or %{their_expressions_of_their_ideas_link}, without attribution. Minor alterations (such as replacing names, substituting synonyms, or rearranging a few words) are insufficient to make a work your own. Plagiarism is not allowed. Deliberately creating a work using the same general idea as another work is not plagiarism, but citation may be appropriate.
         their_expressions_of_their_ideas: their expressions of their ideas
         tos_faq: FAQ for Section II.E
-        tos_faq_in_parens_html: "(%{tos_faq_link})"
+        tos_faq_in_parens_html: '(%{tos_faq_link})'
         tos_faq_link_label: Copyright Infringement and Plagiarism FAQ
       privacy_policy: Privacy Policy
       terms_of_service: Terms of Service
@@ -1823,7 +1823,7 @@ en:
         heading: II.I. User Icons
         text: User icons must be appropriate for general audiences. They must not depict genital nudity, explicit sexual activity, hate symbols, or imagery that promotes, advocates, or causes harm.
         tos_faq: FAQ for Section II.I
-        tos_faq_in_parens_html: "(%{tos_faq_link})"
+        tos_faq_in_parens_html: '(%{tos_faq_link})'
         tos_faq_link_label: Usernames, Icons, and Profiles FAQ
     diversity_statement:
       archive_description_html: This archive is a permanent, panfandom place for fanworks, built by fans for fans. Whichever way you use the Archive, you're part of this, powering it, shaping it through your use and %{your_feedback_link}.
@@ -1838,7 +1838,7 @@ en:
         html: This work is licensed under a %{creative_commons_by_sa_link}.
         image_alt: Creative Commons License
       some_essential_parts: some essential parts
-      still_missing_html: 'We know that there are %{some_essential_parts_link} that are still missing to make the Archive truly panfandom: the ability to host fanworks other than text, an interface in languages other than English, and more ways for you to connect with each other, to name just a few. But with your support, we''ll get there.'
+      still_missing_html: "We know that there are %{some_essential_parts_link} that are still missing to make the Archive truly panfandom: the ability to host fanworks other than text, an interface in languages other than English, and more ways for you to connect with each other, to name just a few. But with your support, we'll get there."
       terms_of_service: Terms of Service
       we_build_for: We are building this archive for you. Come be a part of it.
       welcome_header: You are welcome at the Archive of Our Own.
@@ -1879,7 +1879,7 @@ en:
           title: Is it later already?
         note: Some works you've marked for later.
       social:
-        bluesky: "@status.archiveofourown.org on Bluesky"
+        bluesky: '@status.archiveofourown.org on Bluesky'
         heading: Follow us
         note_html: Follow AO3 on Bluesky or Tumblr for status updates, and don't forget to check out the %{other_outlets_link} for updates on our other projects!
         other_outlets: Organization for Transformative Works' news outlets
@@ -2142,17 +2142,17 @@ en:
           privacy_policy: Privacy Policy
         entirety_of_agreement:
           entirety_of_agreement: 'Entirety of agreement:'
-          html: "%{entirety_of_agreement} These Terms of Service constitute the entire agreement between you and the Organization for Transformative Works (OTW) and govern your use of AO3. They replace all prior agreements between you and the OTW concerning your use of AO3. They do not govern your use of any other OTW sites and/or projects, all of which are covered under separate agreements."
+          html: '%{entirety_of_agreement} These Terms of Service constitute the entire agreement between you and the Organization for Transformative Works (OTW) and govern your use of AO3. They replace all prior agreements between you and the OTW concerning your use of AO3. They do not govern your use of any other OTW sites and/or projects, all of which are covered under separate agreements.'
         heading: I.A. General terms
         jurisdiction:
-          html: "%{jurisdiction} The AO3 TOS, the relationship between you and the OTW, and all disputes arising out of or related to them shall be governed by the laws of the United States and specifically %{the_state_of_new_york_link}, without regard to any conflict-of-law provisions. You and the OTW agree to submit to the personal and exclusive jurisdiction of the courts located within New York County (Manhattan), New York, and to waive any objection to the laying of venue there."
+          html: '%{jurisdiction} The AO3 TOS, the relationship between you and the OTW, and all disputes arising out of or related to them shall be governed by the laws of the United States and specifically %{the_state_of_new_york_link}, without regard to any conflict-of-law provisions. You and the OTW agree to submit to the personal and exclusive jurisdiction of the courts located within New York County (Manhattan), New York, and to waive any objection to the laying of venue there.'
           jurisdiction: 'Jurisdiction:'
           the_state_of_new_york: the State of New York
         limitation_on_claims:
-          html: "%{limitation_on_claims} You agree that, regardless of any statute or law to the contrary, any claim or cause of action arising out of or related to any use of AO3 or its TOS must be filed within one (1) year after such claim or cause of action arose or be forever barred."
+          html: '%{limitation_on_claims} You agree that, regardless of any statute or law to the contrary, any claim or cause of action arising out of or related to any use of AO3 or its TOS must be filed within one (1) year after such claim or cause of action arose or be forever barred.'
           limitation_on_claims: 'Limitation on claims:'
         no_assignment:
-          html: "%{no_assignment} These TOS are personal to you. You may not assign or transfer your rights or obligations under these TOS to any other person or entity, and any attempted assignment or transfer is void."
+          html: '%{no_assignment} These TOS are personal to you. You may not assign or transfer your rights or obligations under these TOS to any other person or entity, and any attempted assignment or transfer is void.'
           no_assignment: 'No assignment:'
         non_severability:
           html: "%{non_severability} The OTW's failure to enforce any part of the TOS will not waive the OTW's ability to enforce it. Any waiver with regard to a specific instance shall not constitute a waiver of any other breaches of the TOS, even with regard to the same user. If any provision of the TOS is found by a court of competent jurisdiction to be invalid, you agree that the court should give effect to the party's intentions as reflected in the provision, and that all other provisions of the TOS remain in full force and effect."
@@ -2245,7 +2245,7 @@ en:
     tos_navigation:
       content: Content Policy
       privacy: Privacy Policy
-      top: "%{arrow} Top"
+      top: '%{arrow} Top'
       tos: Terms of Service
       tos_faq: TOS FAQ
     tos_toc:
@@ -2327,7 +2327,7 @@ en:
       page_heading: Invitation Requests
       queue_disabled:
         closed: New invitation requests are currently closed.
-        html: "%{closed_bold} For more information, please check the %{news_link}."
+        html: '%{closed_bold} For more information, please check the %{news_link}.'
         news: '"Invitations" tag on AO3 News'
       waiting_list_count:
         one: There is %{count} person remaining on the waiting list.
@@ -2340,10 +2340,10 @@ en:
       details_html: To get a free Archive of Our Own account, you need an Invitation. By submitting your email address to our invitation queue, you confirm that you are at least 13 years old, and if you're in a country whose residents/citizens have to be of an age older than 13 to consent, you are old enough to consent to the processing of your personal data without our obtaining written permission from a parent or legal guardian. We will use the email address you submit only to send you an Invitation and to process/manage your account activation. Please don't request an Invitation unless you've read our %{tos_link}, including the %{content_policy_link} and %{privacy_policy_link}, and agree to abide by those Terms.
       frequency:
         one: hour
-        other: "%{count} hours"
+        other: '%{count} hours'
       invitation_number:
-        one: "%{count} invitation"
-        other: "%{count} invitations"
+        one: '%{count} invitation'
+        other: '%{count} invitations'
       invitation_send_rate: We are sending out %{queue_invitation_number} every %{queue_frequency}.
       page_heading: Invitation Requests
       privacy_policy: Privacy Policy
@@ -2380,11 +2380,11 @@ en:
     status:
       frequency:
         one: hour
-        other: "%{count} hours"
+        other: '%{count} hours'
       heading: Invitation Request Status
       invitation_number:
-        one: "%{count} invitation"
-        other: "%{count} invitations"
+        one: '%{count} invitation'
+        other: '%{count} invitations'
       invitation_send_rate: We are sending out %{queue_invitation_number} every %{queue_frequency}.
       search: Look me up
       waiting_list:
@@ -2392,12 +2392,12 @@ en:
         other: There are currently %{count} people on the waiting list.
   kudos:
     guest_header:
-      one: "%{count} guest has also left kudos"
-      other: "%{count} guests have also left kudos"
+      one: '%{count} guest has also left kudos'
+      other: '%{count} guests have also left kudos'
     user_links:
       more_link:
-        one: "%{count} more user"
-        other: "%{count} more users"
+        one: '%{count} more user'
+        other: '%{count} more users'
   languages:
     form:
       abuse_support_available: Abuse support available
@@ -2410,15 +2410,15 @@ en:
         update: Update Language
       support_available: Support available
     index:
-      language_code_format_html: "(%{code})"
+      language_code_format_html: '(%{code})'
       navigation:
         add: Add a Language
         edit: Edit
         suggest: Suggest a Language
       page_heading: Work Languages
       works_count:
-        one: "%{formatted_count} work"
-        other: "%{formatted_count} works"
+        one: '%{formatted_count} work'
+        other: '%{formatted_count} works'
   layouts:
     banner:
       hide: hide banner
@@ -2444,7 +2444,7 @@ en:
         gpl_2_0_or_later: GPL-2.0-or-later
         header: Development
         known_issues: Known Issues
-        license_details_html: "%{license_link} by the %{otw_link}"
+        license_details_html: '%{license_link} by the %{otw_link}'
         view_license: View License
       landmark: Footer
       otw:
@@ -2563,7 +2563,7 @@ en:
     aria_label:
       nav: Pagination
     next: Next →
-    prev: "← Previous"
+    prev: '← Previous'
   potential_matches:
     in_progress:
       cancel: Cancel Potential Match Generation
@@ -2658,8 +2658,8 @@ en:
       update: Update
     pseud_list:
       more_pseuds:
-        one: "%{count} more pseud"
-        other: "%{count} more pseuds"
+        one: '%{count} more pseud'
+        other: '%{count} more pseuds'
     show:
       delete_account_confirmation: This will permanently delete your account and cannot be undone. Are you sure?
       delete_my_account: Delete My Account
@@ -2691,11 +2691,11 @@ en:
       confirm_delete: Are you sure?
       default_pseud: Default Pseud
       delete_html: Delete%{landmark_span}
-      delete_landmark_text: " %{pseud}"
+      delete_landmark_text: ' %{pseud}'
       edit_html: Edit%{landmark_span}
-      edit_landmark_text: " %{pseud}"
+      edit_landmark_text: ' %{pseud}'
       orphan_html: Orphan Works%{landmark_span}
-      orphan_landmark_text: " by %{pseud}"
+      orphan_landmark_text: ' by %{pseud}'
       user_actions: User Actions
     pseuds_form:
       cannot_change_matching_pseud_html: You cannot change the pseud that matches your username. However, you can %{change_username_link} instead.
@@ -2734,16 +2734,16 @@ en:
       page_heading: "%{login}'s Related Works"
   series:
     series_module:
-      hidden_by_admin_alt: "(Hidden by Admin)"
+      hidden_by_admin_alt: '(Hidden by Admin)'
       hidden_by_administrator: Hidden by Administrator
       landmark:
         fandom: Fandom
         summary: Summary
       restricted: Restricted
-      restricted_alt: "(Restricted)"
-      series_by_html: "%{series_title_link} by %{byline}"
+      restricted_alt: '(Restricted)'
+      series_by_html: '%{series_title_link} by %{byline}'
     series_order:
-      draft_work_title: "%{title} (DRAFT)"
+      draft_work_title: '%{title} (DRAFT)'
   skins:
     confirm_delete:
       confirm_html: Are you sure you want to <strong><em>delete</em></strong> the skin "%{skin_title}"?
@@ -2808,13 +2808,13 @@ en:
         series: My Series Subscriptions
         users: My User Subscriptions
         works: My Work Subscriptions
-      series: "(Series)"
-      work: "(Work)"
+      series: '(Series)'
+      work: '(Work)'
   tag_sets:
     nomination_review_heading:
       already_approved_fandoms: Already Approved Fandoms
-      left_to_review: "%{type} (%{count} left to review)"
-      paginated: "%{from} - %{to} of %{total} %{type}"
+      left_to_review: '%{type} (%{count} left to review)'
+      paginated: '%{from} - %{to} of %{total} %{type}'
   tag_wranglers:
     index:
       filters:
@@ -2823,42 +2823,42 @@ en:
         only_media: Only media
         only_wrangler: Only wrangler
     show:
-      last_wrangled_html: "%{wrangler_login} last wrangled at %{time}."
+      last_wrangled_html: '%{wrangler_login} last wrangled at %{time}.'
       tags_wrangled_csv: Tags Wrangled (CSV)
   tag_wranglings:
     index:
       general_resources:
         ao3_catch_and_release: AO3_Catch_and_Release
-        ao3_catch_and_release_html: "%{ao3_catch_and_release_link} - For more information, please see the %{ao3_wrangling_project_faq_link}"
+        ao3_catch_and_release_html: '%{ao3_catch_and_release_link} - For more information, please see the %{ao3_wrangling_project_faq_link}'
         ao3_wrangling_project_faq: Tag Wrangling AO3 Project FAQ
         current_wrangling_limitations: Current Wrangling Limitations
-        current_wrangling_limitations_html: "%{current_wrangling_limitations_link} - Details about current wrangling limitations and policies"
+        current_wrangling_limitations_html: '%{current_wrangling_limitations_link} - Details about current wrangling limitations and policies'
         fandom_and_megafandom_directory: Directory of Fandom & Megafandom Wiki Pages
-        fandom_and_megafandom_directory_html: "%{fandom_and_megafandom_directory_link} - All currently available fandom & megafandom wiki pages"
+        fandom_and_megafandom_directory_html: '%{fandom_and_megafandom_directory_link} - All currently available fandom & megafandom wiki pages'
         fandoms_in_need_of_cowranglers: Fandoms in need of Cowranglers
-        fandoms_in_need_of_cowranglers_html: "%{fandoms_in_need_of_cowranglers_link} - Interested in helping out a fandom in need?"
+        fandoms_in_need_of_cowranglers_html: '%{fandoms_in_need_of_cowranglers_link} - Interested in helping out a fandom in need?'
         heading: 'General Wrangling Resources:'
         otw_slack_chat: OTW Slack Chat
-        otw_slack_chat_html: "%{otw_slack_chat_link} - For more information please see the %{tag_wrangling_slack_tutorial_link}"
+        otw_slack_chat_html: '%{otw_slack_chat_link} - For more information please see the %{tag_wrangling_slack_tutorial_link}'
         tag_wranglers_mailing_list: Tag Wranglers Mailing List Conversations
-        tag_wranglers_mailing_list_html: "%{tag_wranglers_mailing_list_link} - Message Archive for the Tagwranglers Mailing List"
+        tag_wranglers_mailing_list_html: '%{tag_wranglers_mailing_list_link} - Message Archive for the Tagwranglers Mailing List'
         tag_wrangling_bugs: Tag Wrangling Bugs & Troubleshooting
-        tag_wrangling_bugs_html: "%{tag_wrangling_bugs_link} - Having technical issues while wrangling? Check here for solutions!"
+        tag_wrangling_bugs_html: '%{tag_wrangling_bugs_link} - Having technical issues while wrangling? Check here for solutions!'
         tag_wrangling_committee: Tag Wrangling Committee
-        tag_wrangling_committee_html: "%{tag_wrangling_committee_link} - Full collection of wiki links & policies"
+        tag_wrangling_committee_html: '%{tag_wrangling_committee_link} - Full collection of wiki links & policies'
         tag_wrangling_communication_policy: Tag Wrangling Communication Policy
-        tag_wrangling_communication_policy_html: "%{tag_wrangling_communication_policy_link} - Includes instructions for leaving tag comments and chat rules"
+        tag_wrangling_communication_policy_html: '%{tag_wrangling_communication_policy_link} - Includes instructions for leaving tag comments and chat rules'
         tag_wrangling_faq: Tag Wrangling FAQ
-        tag_wrangling_faq_html: "%{tag_wrangling_faq_link} - Check here to find answers to frequently asked questions"
+        tag_wrangling_faq_html: '%{tag_wrangling_faq_link} - Check here to find answers to frequently asked questions'
         tag_wrangling_moodle: Tag Wrangling Moodle
-        tag_wrangling_moodle_html: "%{tag_wrangling_moodle_link} - Additional modular training and support for all wranglers"
+        tag_wrangling_moodle_html: '%{tag_wrangling_moodle_link} - Additional modular training and support for all wranglers'
         tag_wrangling_slack_tutorial: Tag Wrangling Slack Tutorial
         tag_wrangling_training: Tag Wrangling Training
-        tag_wrangling_training_html: "%{tag_wrangling_training_link} - New wranglers, start here!"
+        tag_wrangling_training_html: '%{tag_wrangling_training_link} - New wranglers, start here!'
         unassigned_fandoms: Unassigned Fandoms
-        unassigned_fandoms_html: "%{unassigned_fandoms_link} - A list of all current unassigned fandoms"
+        unassigned_fandoms_html: '%{unassigned_fandoms_link} - A list of all current unassigned fandoms'
         vacations_and_retiring: Vacation and Retiring from Wrangling
-        vacations_and_retiring_html: "%{vacations_and_retiring_link} - Unable to wrangle for more than 2 weeks? Read about options for taking a break from wrangling!"
+        vacations_and_retiring_html: '%{vacations_and_retiring_link} - Unable to wrangle for more than 2 weeks? Read about options for taking a break from wrangling!'
       manage:
         comments: Comments (%{count})
         edit: Edit
@@ -2870,8 +2870,8 @@ en:
         landmark: Notes
         question_for_chair: Question for a Chair!
         question_for_supervisor: Question for a Supervisor!
-        tw_wranglers_quietroom_slack: "#tw-wranglers-quietroom"
-        tw_wranglers_slack: "#tw-wranglers"
+        tw_wranglers_quietroom_slack: '#tw-wranglers-quietroom'
+        tw_wranglers_slack: '#tw-wranglers'
         wrangle_to_guidelines_html: Wrangle tags in accordance with the %{wrangling_guidelines_link}.
         wrangling_guidelines: wrangling guidelines
       page_heading: Tag Wrangling
@@ -2889,7 +2889,7 @@ en:
         merger: Mergers
         relationship: Relationships
         subtag: SubTags
-      tag_type_and_count: "%{tag_type} (%{count})"
+      tag_type_and_count: '%{tag_type} (%{count})'
       unsorted_tags: Unsorted Tags (%{count})
       use_type:
         bookmarks: Bookmarks
@@ -2899,7 +2899,7 @@ en:
         private_bookmarks: Private Bookmarks
         taggings_count: Taggings Count
         works: Works
-      use_type_and_count: "%{use_type} (%{count})"
+      use_type_and_count: '%{use_type} (%{count})'
       wranglers: Wranglers
       wrangling_home: Wrangling Home
       wrangling_tools: Wrangling Tools
@@ -2952,6 +2952,7 @@ en:
   time:
     formats:
       date_short_html: <abbr class="day" title="%A">%a</abbr> %d <abbr class="month" title="%B">%b</abbr> %Y
+      date_html: '%d <abbr class="month" title="%B">%b</abbr> %Y'
   troubleshooting:
     show:
       fix_associations:
@@ -2991,7 +2992,7 @@ en:
       ticket_id: Ticket ID
     change_email:
       caution:
-        check_spam_html: "%{must_confirm_bold} Please check your spam folder or %{contact_support_link} if you do not receive the confirmation email."
+        check_spam_html: '%{must_confirm_bold} Please check your spam folder or %{contact_support_link} if you do not receive the confirmation email.'
         confirm_by: If you don't confirm your request by %{date}, your email address will not be changed.
         contact_support: contact Support
         must_confirm: You must use the link in the confirmation email in order to finish confirming your email change.
@@ -3017,8 +3018,8 @@ en:
       old_password: Old password
       page_heading: Change Password
       password_length:
-        one: "%{minimum} to %{count} character"
-        other: "%{minimum} to %{count} characters"
+        one: '%{minimum} to %{count} character'
+        other: '%{minimum} to %{count} characters'
       submit: Submit
     change_username:
       account_faq: Account FAQ
@@ -3040,7 +3041,7 @@ en:
       password: Password
       submit: Change Username
       submit_landmark: Submit
-      username_requirements: "%{minimum} to %{maximum} characters (A-Z, a-z, _, 0-9 only), no spaces, cannot begin or end with underscore (_)"
+      username_requirements: '%{minimum} to %{maximum} characters (A-Z, a-z, _, 0-9 only), no spaces, cannot begin or end with underscore (_)'
     confirm_change_email:
       are_you_sure_html: Are you sure you want to change your email address to %{unconfirmed_email}? A confirmation email will be sent to this address.
       cancel: Cancel
@@ -3101,8 +3102,8 @@ en:
         new_password: New password
         page_heading: Change Password
         password_length:
-          one: "%{minimum} to %{count} character"
-          other: "%{minimum} to %{count} characters"
+          one: '%{minimum} to %{count} character'
+          other: '%{minimum} to %{count} characters'
         submit: Submit
       new:
         email_html: Email address
@@ -3132,10 +3133,10 @@ en:
         confirm_password: Confirm password
         confirm_password_validation: Please enter the same password in both fields.
         password: Password
-        password_requirements: "%{minimum} to %{maximum} characters"
+        password_requirements: '%{minimum} to %{maximum} characters'
         password_validation: Please enter a password! (At least %{minimum} characters long, please.)
         username: Username
-        username_requirements: "%{minimum} to %{maximum} characters (A-Z, a-z, _, 0-9 only), no spaces, cannot begin or end with underscore (_)"
+        username_requirements: '%{minimum} to %{maximum} characters (A-Z, a-z, _, 0-9 only), no spaces, cannot begin or end with underscore (_)'
         username_validation: You need a username! (At least %{minimum} letters long, please.)
         valid_email: Valid email
     sessions:
@@ -3257,7 +3258,7 @@ en:
         edit_tags_and_language_html: Edit Work Tags and Language for %{title}
         edit_tags_html: Edit Work Tags for %{title}
     import:
-      draft_work_title_html: "%{work_link} (Draft)"
+      draft_work_title_html: '%{work_link} (Draft)'
       page_heading: Imported Works
       success: We were able to successfully upload the following works.
     index:
@@ -3315,7 +3316,7 @@ en:
     show:
       unposted_deletion_notice_html: This work is a draft and has not been posted. The draft will be <strong>scheduled for deletion</strong> on %{deletion_date}.
     show_multiple:
-      draft: " (Draft)"
+      draft: ' (Draft)'
       no_works: You have no works or drafts to edit.
     skin:
       select: Select work skin
@@ -3327,8 +3328,8 @@ en:
       works_translation_link_help_title: Translation link
     work_approved_children:
       inspired_by:
-        restricted_html: "[Restricted Work] by %{creator_link} (Log in to access.)"
-        revealed_html: "%{work_link} by %{creator_link}"
+        restricted_html: '[Restricted Work] by %{creator_link} (Log in to access.)'
+        revealed_html: '%{work_link} by %{creator_link}'
         title: Works inspired by this one
         unrevealed: A work in an unrevealed collection
     work_form_associations_language:
@@ -3353,11 +3354,11 @@ en:
         revealed_html: Inspired by %{work_link} by %{creator_link}
         unrevealed: Inspired by a work in an unrevealed collection
       jump:
-        endnotes_and_related_works_html: "(See the end of the work for %{endnotes_link} and %{related_works_link}.)"
-        endnotes_html: "(See the end of the work for %{endnotes_link}.)"
+        endnotes_and_related_works_html: '(See the end of the work for %{endnotes_link} and %{related_works_link}.)'
+        endnotes_html: '(See the end of the work for %{endnotes_link}.)'
         more_notes: more notes
         notes: notes
-        related_works_html: "(See the end of the work for %{related_works_link}.)"
+        related_works_html: '(See the end of the work for %{related_works_link}.)'
       translated_to:
         restricted_html: 'Translation into %{language} available: [Restricted Work] by %{creator_link} (Log in to access.)'
         revealed_html: 'Translation into %{language} available: %{work_link} by %{creator_link}'


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [ ] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [x] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [x] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-6576

## Purpose

This removes the extraneous `<span>`s wrapped around the date/time elements on news posts, work blurbs, and anything else that uses `date_in_zone` to improve screenreader accessibility. A comment on the Jira ticket also noted that the time zone's `title` seemed strange, so it has been updated to use the unabbreviated time zone name instead of the Country/City it previously used.

## Credit

calm (they/them)
