### PR TITLE
AO3-6806 Fix first comment layout on short admin posts

### DIFF
--- a/app/views/comments/hide_comments.js.erb
+++ b/app/views/comments/hide_comments.js.erb
@@ -2,6 +2,10 @@
 $j("#show_comments_link_top").html("<%= escape_javascript(show_hide_comments_link(@commentable)) %>");
 /* replace the "Hide Comments (#) link with "Comments (#)" */
 $j("#show_comments_link").html("<%= escape_javascript(show_hide_comments_link(@commentable, :show_count => true)) %>");
-/* roll up, then remove the comments */
+/* roll up, then remove the comments (skip animation on admin posts to avoid post-slideDown BFC reflow) */
+<% if @commentable.is_a?(AdminPost) %>
+$j("#comments_placeholder").hide();
+<% else %>
 $j("#comments_placeholder").slideUp();
+<% end %>
 $j("#comments_placeholder").html("");

--- a/app/views/comments/show_comments.js.erb
+++ b/app/views/comments/show_comments.js.erb
@@ -7,5 +7,9 @@ $j("#comments_placeholder").html("<%= escape_javascript(will_paginate(@comments,
 $j("#comments_placeholder").append("<%= escape_javascript(render "comments/comment_thread", {:comments => @comments, :depth => 0}) %>");
 $j("#comments_placeholder").append("</ol>");
 $j("#comments_placeholder").append("<%= escape_javascript(will_paginate(@comments, {:remote => true})) %>");
-/* roll down the comments */
+/* roll down the comments (skip animation on admin posts to avoid post-slideDown BFC reflow) */
+<% if @commentable.is_a?(AdminPost) %>
+$j("#comments_placeholder").show();
+<% else %>
 $j("#comments_placeholder").slideDown();
+<% end %>

--- a/public/stylesheets/site/2.0/15-group-comments.css
+++ b/public/stylesheets/site/2.0/15-group-comments.css
@@ -12,6 +12,12 @@ test note: have put clearfixes on listbox, blurb and comments here, to allow for
   margin: 0 0 auto;
 }
 
+/* Admin post comment bylines should not clear floated #dashboard nav */
+.news.admin.home .comment:after,
+.news.admin.home .comment h4.byline:after {
+  clear: none;
+}
+
 div.comment, li.comment {
   position: relative;
   border: 1px solid #ddd;


### PR DESCRIPTION
# Pull Request Checklist

* [X] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [X] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [ ] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [X] Have you added the [Jira](https://otwarchive.atlassian.net) issue number as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)?
* [X] Do you have fewer than 5 pull requests already open? If not, please wait until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-6806

## Purpose

Fixes a layout issue where the first comment on a short admin post had an oversized byline and a misplaced icon when the comment form was not present.

Root cause:
- The #dashboard sidebar has float: left at page level, and comment pseudo-elements have `clear: both`. When an admin post is shorter than the sidebar, the first comment's `clear: both` catches the active sidebar float and forces the comment to expand until the float clears.
- When the comment form is present, its height pushes the comments below the sidebar and the issue does not occur.

Changes made:
- Added a scoped `clear: none` rule under .`news.admin.home` in `15-group-comments.css` to prevent comment pseudo-elements from interacting with the sidebar float. Only affects admin post views. Works and chapters are unaffected.
- Replaced `slideDown()`/`slideUp()` with `show()`/`hide()` on admin posts in `show_comments.js.erb` and `hide_comments.js.erb`. The slide animation creates a temporary BFC that triggers a layout reflow on completion, which  was hidden before the CSS fix but became noticeable after. Works and chapters are unaffected.

## Testing Instructions

Follow the reproduction steps in AO3-6806:
https://otwarchive.atlassian.net/browse/AO3-6806

Expected behavior:
- The first comment on a short admin post should render normally, with the byline and icon displayed at the correct height.
- The rest of the comments should be unaffected.
- Comments on works and chapters should still animate with slideDown/slideUp as before.
- No visual difference on admin posts where the comment form is present.

Automated tests:

- No automated tests were added for this change, as the bug is a visual/layout issue dependent on relative content length.

## Credit

Name: Noah Bravo  
Pronouns: they/them